### PR TITLE
Improved message delivery

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,8 +9,8 @@
                  [re-frame "0.7.0"]
                  [prismatic/schema "1.0.4"]
                  ^{:voom {:repo   "git@github.com:status-im/status-lib.git"
-                          :branch "master"}}
-                 [status-im/protocol "0.1.3-20160818_172519-g2f734a6"]
+                          :branch "message-delivery"}}
+                 [status-im/protocol "0.2.0-20160829_094621-g83381b2"]
                  [natal-shell "0.3.0"]
                  [com.andrewmcveigh/cljs-time "0.4.0"]
                  [tailrecursion/cljs-priority-map "1.2.0"]

--- a/src/status_im/accounts/handlers.cljs
+++ b/src/status_im/accounts/handlers.cljs
@@ -104,9 +104,9 @@
 (register-handler :load-accounts load-accounts!)
 
 (defn console-create-account [db _]
-  (let [msg-id (random/id)]
+  (let [message-id (random/id)]
     (dispatch [:received-message
-               {:msg-id       msg-id
+               {:message-id   message-id
                 :content      {:command (name :keypair)
                                :content (label :t/keypair-generated)}
                 :content-type content-type-command-request

--- a/src/status_im/chat/handlers/commands.cljs
+++ b/src/status_im/chat/handlers/commands.cljs
@@ -128,11 +128,11 @@
    (after invoke-command-preview!)]
   (fn [db [_ chat-id]]
     (let [db (assoc-in db [:chats chat-id :input-text] nil)
-          {:keys [command content to-msg-id]} (command-input db)
+          {:keys [command content to-message-id]} (command-input db)
           content' (content-by-command command content)
           command-info {:command    command
                         :content    content'
-                        :to-message to-msg-id
+                        :to-message to-message-id
                         :created-at (time/now-ms)
                         :id         (random/id)}]
       (-> db
@@ -157,9 +157,9 @@
    (after #(dispatch [:command-edit-mode]))]
   set-chat-command)
 
-(defn set-response-command [db [_ to-msg-id command-key]]
+(defn set-response-command [db [_ to-message-id command-key]]
   (-> db
-      (commands/set-command-input :responses to-msg-id command-key)
+      (commands/set-command-input :responses to-message-id command-key)
       (assoc :canceled-command false)))
 
 (register-handler :set-response-chat-command

--- a/src/status_im/chat/handlers/unviewed_messages.cljs
+++ b/src/status_im/chat/handlers/unviewed_messages.cljs
@@ -4,17 +4,15 @@
             [status-im.persistence.realm.core :as realm]))
 
 (defn delivered-messages []
-  (-> (realm/get-by-fields
-        :account :message
-        {:delivery-status :delivered
-         :outgoing        false})
+  (-> (realm/get-by-fields :account :message :and [[:delivery-status :delivered]
+                                                   [:outgoing false]])
       (realm/collection->map)))
 
 (defn set-unviewed-messages [db]
   (let [messages (->> (::raw-unviewed-messages db)
                       (group-by :chat-id)
                       (map (fn [[id messages]]
-                             [id {:messages-ids (map :msg-id messages)
+                             [id {:messages-ids (map :message-id messages)
                                   :count        (count messages)}]))
                       (into {}))]
     (-> db

--- a/src/status_im/chat/screen.cljs
+++ b/src/status_im/chat/screen.cljs
@@ -34,13 +34,13 @@
               [identity contact]))
        (into {})))
 
-(defn add-msg-color [{:keys [from] :as msg} contact-by-identity]
+(defn add-message-color [{:keys [from] :as message} contact-by-identity]
   (if (= "system" from)
-    (assoc msg :text-color :#4A5258
-               :background-color :#D3EEEF)
+    (assoc message :text-color :#4A5258
+                   :background-color :#D3EEEF)
     (let [{:keys [text-color background-color]} (get contact-by-identity from)]
-      (assoc msg :text-color text-color
-                 :background-color background-color))))
+      (assoc message :text-color text-color
+                     :background-color background-color))))
 
 (defview chat-icon []
   [chat-id [:chat :chat-id]
@@ -66,11 +66,11 @@
 
 (defn message-row [{:keys [contact-by-identity platform-specific group-chat messages-count]}]
   (fn [row _ idx]
-    (let [msg (-> row
-                  (add-msg-color contact-by-identity)
-                  (assoc :group-chat group-chat)
-                  (assoc :last-msg (= (js/parseInt idx) (dec messages-count))))]
-      (list-item [chat-message msg platform-specific]))))
+    (let [message (-> row
+                      (add-message-color contact-by-identity)
+                      (assoc :group-chat group-chat)
+                      (assoc :last-message (= (js/parseInt idx) (dec messages-count))))]
+      (list-item [chat-message message platform-specific]))))
 
 (defn on-action-selected [position]
   (case position

--- a/src/status_im/chat/sign_up.cljs
+++ b/src/status_im/chat/sign_up.cljs
@@ -16,8 +16,8 @@
                                          content-type-status]]
             [status-im.i18n :refer [label]]))
 
-(defn send-console-msg [text]
-  {:msg-id       (random/id)
+(defn send-console-message [text]
+  {:message-id   (random/id)
    :from         "me"
    :to           "console"
    :content      text
@@ -36,9 +36,9 @@
 
 ;; -- Send phone number ----------------------------------------
 (defn on-sign-up-response [& [message]]
-  (let [msg-id (random/id)]
+  (let [message-id (random/id)]
     (dispatch [:received-message
-               {:msg-id       msg-id
+               {:message-id   message-id
                 :content      (command-content
                                 :confirmation-code
                                 (or message (label :t/confirmation-code)))
@@ -64,7 +64,7 @@
 ;; -- Send confirmation code and synchronize contacts---------------------------
 (defn on-sync-contacts []
   (dispatch [:received-message
-             {:msg-id       (random/id)
+             {:message-id   (random/id)
               :content      (label :t/contacts-syncronized)
               :content-type text-content-type
               :outgoing     false
@@ -78,7 +78,7 @@
 
 (defn on-send-code-response [body]
   (dispatch [:received-message
-             {:msg-id       (random/id)
+             {:message-id   (random/id)
               :content      (:message body)
               :content-type text-content-type
               :outgoing     false
@@ -95,9 +95,9 @@
       (on-sign-up-response (label :t/incorrect-code)))))
 
 (defn start-signup []
-  (let [msg-id (random/id)]
+  (let [message-id (random/id)]
     (dispatch [:received-message
-               {:msg-id       msg-id
+               {:message-id   message-id
                 :content      (command-content
                                 :phone
                                 (label :t/phone-number-required))
@@ -110,7 +110,7 @@
 (defn save-password [password mnemonic]
   ;; TODO validate and save password
   (dispatch [:received-message
-             {:msg-id       (random/id)
+             {:message-id   (random/id)
               :content      (label :t/password-saved)
               :content-type text-content-type
               :outgoing     false
@@ -118,7 +118,7 @@
               :to           "me"
               :new?         false}])
   (dispatch [:received-message
-             {:msg-id       (random/id)
+             {:message-id   (random/id)
               :content      (label :t/generate-passphrase)
               :content-type text-content-type
               :outgoing     false
@@ -126,7 +126,7 @@
               :to           "me"
               :new?         false}])
   (dispatch [:received-message
-             {:msg-id       (random/id)
+             {:message-id   (random/id)
               :content      (label :t/here-is-your-passphrase)
               :content-type text-content-type
               :outgoing     false
@@ -134,7 +134,7 @@
               :to           "me"
               :new?         false}])
   (dispatch [:received-message
-             {:msg-id       (random/id)
+             {:message-id   (random/id)
               :content      mnemonic
               :content-type text-content-type
               :outgoing     false
@@ -142,7 +142,7 @@
               :to           "me"
               :new?         false}])
   (dispatch [:received-message
-             {:msg-id       "8"
+             {:message-id   "8"
               :content      (label :t/written-down)
               :content-type text-content-type
               :outgoing     false
@@ -155,7 +155,7 @@
 
 
 (def intro-status
-  {:msg-id          "intro-status"
+  {:message-id      "intro-status"
    :content         (label :t/intro-status)
    :delivery-status "seen"
    :from            "console"
@@ -167,7 +167,7 @@
 (defn intro [logged-in?]
   (dispatch [:received-message intro-status])
   (dispatch [:received-message
-             {:msg-id       "intro-message1"
+             {:message-id   "intro-message1"
               :content      (label :t/intro-message1)
               :content-type text-content-type
               :outgoing     false
@@ -175,7 +175,7 @@
               :to           "me"}])
   (when-not logged-in?
     (dispatch [:received-message
-               {:msg-id       "intro-message2"
+               {:message-id   "intro-message2"
                 :content      (label :t/intro-message2)
                 :content-type text-content-type
                 :outgoing     false
@@ -183,7 +183,7 @@
                 :to           "me"}])
 
     (dispatch [:received-message
-               {:msg-id       "intro-message3"
+               {:message-id   "intro-message3"
                 :content      (command-content
                                 :keypair
                                 (label :t/keypair-generated))

--- a/src/status_im/chat/styles/message.cljs
+++ b/src/status_im/chat/styles/message.cljs
@@ -31,8 +31,8 @@
     :else 10))
 
 (defn last-message-padding
-  [{:keys [last-msg typing]}]
-  (when (and last-msg (not typing))
+  [{:keys [last-message typing]}]
+  (when (and last-message (not typing))
     {:paddingBottom 20}))
 
 (def message-body-base

--- a/src/status_im/chat/subs.cljs
+++ b/src/status_im/chat/subs.cljs
@@ -102,9 +102,9 @@
   (fn [db _]
     (reaction (commands/get-chat-command-content @db))))
 
-(register-sub :get-chat-command-to-msg-id
+(register-sub :get-chat-command-to-message-id
   (fn [db _]
-    (reaction (commands/get-chat-command-to-msg-id @db))))
+    (reaction (commands/get-chat-command-to-message-id @db))))
 
 (register-sub :chat-command-request
   (fn [db _]

--- a/src/status_im/chat/suggestions.cljs
+++ b/src/status_im/chat/suggestions.cljs
@@ -3,7 +3,7 @@
             [status-im.db :as db]
             [status-im.models.commands :refer [get-commands
                                                get-chat-command-request
-                                               get-chat-command-to-msg-id]]
+                                               get-chat-command-to-message-id]]
             [status-im.utils.utils :refer [log on-error http-get]]
             [clojure.string :as s]))
 
@@ -28,15 +28,15 @@
 
 (defn handle-command [db command-key content]
   (when-let [command-handler (get-chat-command-request db)]
-    (let [to-msg-id (get-chat-command-to-msg-id db)]
-      (command-handler to-msg-id command-key content)))
+    (let [to-message-id (get-chat-command-to-message-id db)]
+      (command-handler to-message-id command-key content)))
   db)
 
 (defn get-command-handler [db command-key content]
   (when-let [command-handler (get-chat-command-request db)]
-    (let [to-msg-id (get-chat-command-to-msg-id db)]
+    (let [to-message-id (get-chat-command-to-message-id db)]
       (fn []
-        (command-handler to-msg-id command-key content)))))
+        (command-handler to-message-id command-key content)))))
 
 (defn check-suggestion [db message]
   (when-let [suggestion-text (when (string? message)

--- a/src/status_im/chat/views/plain_message.cljs
+++ b/src/status_im/chat/views/plain_message.cljs
@@ -15,7 +15,7 @@
   (dispatch [:set-chat-input-text message]))
 
 (defn send []
-  (dispatch [:send-chat-msg]))
+  (dispatch [:send-chat-message]))
 
 (defn message-valid? [staged-commands message]
   (or (and (pos? (count message))

--- a/src/status_im/chat/views/request_message.cljs
+++ b/src/status_im/chat/views/request_message.cljs
@@ -12,8 +12,8 @@
 
 (def request-message-icon-scale-delay 600)
 
-(defn set-chat-command [msg-id command]
-  (dispatch [:set-response-chat-command msg-id (keyword (:name command))]))
+(defn set-chat-command [message-id command]
+  (dispatch [:set-response-chat-command message-id (keyword (:name command))]))
 
 (defn label [command]
   (when command
@@ -42,9 +42,9 @@
       (anim/start
         (button-animation val min-scale loop? answered?)))))
 
-(defn request-button [msg-id command]
+(defn request-button [message-id command]
   (let [scale-anim-val (anim/create-value min-scale)
-        answered? (subscribe [:is-request-answered? msg-id])
+        answered? (subscribe [:is-request-answered? message-id])
         loop? (r/atom true)
         context {:to-value  max-scale
                  :val       scale-anim-val
@@ -56,11 +56,11 @@
        :component-will-unmount
        #(reset! loop? false)
        :reagent-render
-       (fn [msg-id command]
+       (fn [message-id command]
          (if command
            [touchable-highlight
             {:on-press            (when-not @answered?
-                                    #(set-chat-command msg-id command))
+                                    #(set-chat-command message-id command))
              :style               st/command-request-image-touchable
              :accessibility-label (label command)}
             [animated-view {:style (st/command-request-image-view command scale-anim-val)}
@@ -68,9 +68,9 @@
                      :style  st/command-request-image}]]]))})))
 
 (defn message-content-command-request
-  [{:keys [msg-id content from incoming-group]} platform-specific]
+  [{:keys [message-id content from incoming-group]} platform-specific]
   (let [commands-atom (subscribe [:get-responses])]
-    (fn [{:keys [msg-id content from incoming-group]}]
+    (fn [{:keys [message-id content from incoming-group]}]
       (let [commands @commands-atom
             {:keys [command content]} (parse-command-request commands content)]
         [view st/comand-request-view
@@ -84,7 +84,7 @@
                  :platform-specific platform-specific
                  :font              :default}
            content]]
-         [request-button msg-id command]
+         [request-button message-id command]
          (when (:request-text command)
            [view st/command-request-text-view
             [text {:style             st/style-sub-text

--- a/src/status_im/db.cljs
+++ b/src/status_im/db.cljs
@@ -27,12 +27,13 @@
              :discovery-search-tags  []
              :tags                   {}
 
-             :contacts-ids           #{}
-             :selected-contacts      #{}
-             :current-chat-id        "console"
+             :chats                  {}
              :chat                   {:command      nil
                                       :last-message nil}
-             :chats                  {}
+             :current-chat-id        "console"
+
+             :contacts-ids           #{}
+             :selected-contacts      #{}
              :chats-updated-signal   0
              :show-actions           false
              :selected-participants  #{}
@@ -52,11 +53,11 @@
   [:chats chat-id :staged-commands])
 (defn chat-command-path [chat-id]
   [:chats chat-id :command-input :command])
-(defn chat-command-to-msg-id-path [chat-id]
-  [:chats chat-id :command-input :to-msg-id])
+(defn chat-command-to-message-id-path [chat-id]
+  [:chats chat-id :command-input :to-message-id])
 (defn chat-command-content-path [chat-id]
   [:chats chat-id :command-input :content])
 (defn chat-command-requests-path [chat-id]
   [:chats chat-id :command-requests])
-(defn chat-command-request-path [chat-id msg-id]
-  [:chats chat-id :command-requests msg-id])
+(defn chat-command-request-path [chat-id message-id]
+  [:chats chat-id :command-requests message-id])

--- a/src/status_im/discovery/handlers.cljs
+++ b/src/status_im/discovery/handlers.cljs
@@ -36,8 +36,8 @@
 (register-handler :discovery-response-received
   (u/side-effect!
     (fn [db [_ from payload]]
-      (let [{:keys [msg-id name photo-path status hashtags]} payload
-            discovery {:msg-id       msg-id
+      (let [{:keys [message-id name photo-path status hashtags]} payload
+            discovery {:message-id   message-id
                        :name         name
                        :photo-path   photo-path
                        :status       status
@@ -60,8 +60,8 @@
 
 (defn add-discovery
   [{db-discoveries :discoveries
-    :as            db} [_ {:keys [msg-id] :as discovery}]]
-  (let [updated-discoveries (if-let [i (first-index #(= (:msg-id %) msg-id) db-discoveries)]
+    :as            db} [_ {:keys [message-id] :as discovery}]]
+  (let [updated-discoveries (if-let [i (first-index #(= (:message-id %) message-id) db-discoveries)]
                               (assoc db-discoveries i discovery)
                               (conj db-discoveries discovery))]
     (-> db

--- a/src/status_im/discovery/model.cljs
+++ b/src/status_im/discovery/model.cljs
@@ -22,15 +22,15 @@
   (doseq [tag (distinct tags)]
     (update-tag-counter func tag)))
 
-(defn get-tags [msg-id]
-  (-> (r/get-by-field :account :discovery :msg-id msg-id)
+(defn get-tags [message-id]
+  (-> (r/get-by-field :account :discovery :message-id message-id)
       (r/single-cljs)
       (:tags)
       (vals)))
 
-(defn- upsert-discovery [{:keys [msg-id tags] :as discovery}]
+(defn- upsert-discovery [{:keys [message-id tags] :as discovery}]
   (log/debug "Creating/updating discovery with tags: " tags)
-  (let [prev-tags (get-tags msg-id)]
+  (let [prev-tags (get-tags message-id)]
     (if prev-tags
       (update-tags-counter dec prev-tags))
     (r/create :account :discovery discovery true)

--- a/src/status_im/discovery/views/popular_list.cljs
+++ b/src/status_im/discovery/views/popular_list.cljs
@@ -31,6 +31,6 @@
             :platform-specific platform-specific
             :font              :default}
       count]]]
-   (for [{:keys [msg-id] :as discovery} discoveries]
-     ^{:key (str "message-" msg-id)}
+   (for [{:keys [message-id] :as discovery} discoveries]
+     ^{:key (str "message-" message-id)}
      [discovery-list-item discovery platform-specific])])

--- a/src/status_im/discovery/views/recent.cljs
+++ b/src/status_im/discovery/views/recent.cljs
@@ -14,6 +14,6 @@
 (defview discovery-recent [{platform-specific :platform-specific}]
   [discoveries [:get :discoveries]]
   [view st/recent-list
-   (for [{:keys [msg-id] :as discovery} discoveries]
-     ^{:key (str "message-" msg-id)}
+   (for [{:keys [message-id] :as discovery} discoveries]
+     ^{:key (str "message-" message-id)}
      [discovery-list-item discovery platform-specific])])

--- a/src/status_im/group_settings/handlers.cljs
+++ b/src/status_im/group_settings/handlers.cljs
@@ -89,13 +89,13 @@
   (doseq [participant selected-participants]
     (api/group-remove-participant current-chat-id participant)))
 
-(defn system-message [msg-id content]
+(defn system-message [message-id content]
   {:from         "system"
-   :msg-id       msg-id
+   :message-id   message-id
    :content      content
    :content-type text-content-type})
 
-(defn removed-participant-msg [chat-id identity]
+(defn removed-participant-message [chat-id identity]
   (let [contact-name (:name (contacts/contact-by-identity identity))]
     (->> (str "You've removed " (or contact-name identity))
          (system-message (random/id))
@@ -104,7 +104,7 @@
 (defn create-removing-messages!
   [{:keys [current-chat-id selected-participants]} _]
   (doseq [participant selected-participants]
-    (removed-participant-msg current-chat-id participant)))
+    (removed-participant-message current-chat-id participant)))
 
 (defn deselect-members [db _]
   (assoc db :selected-participants #{}))

--- a/src/status_im/handlers.cljs
+++ b/src/status_im/handlers.cljs
@@ -74,6 +74,7 @@
       (dispatch [:initialize-protocol address])
       (dispatch [:initialize-account-db])
       (dispatch [:initialize-chats])
+      (dispatch [:initialize-pending-messages])
       (dispatch [:load-contacts])
       (dispatch [:init-chat])
       (dispatch [:init-discoveries])

--- a/src/status_im/i18n.cljs
+++ b/src/status_im/i18n.cljs
@@ -16,8 +16,14 @@
      (.t i18n (name path) (clj->js options))
      (name path))))
 
-
 (defn label-pluralize [count path & options]
   (if (exists? i18n.t)
     (.p i18n count (name path) (clj->js options))
     (name path)))
+
+(defn message-status-label [status]
+  (->> status
+       (name)
+       (str "t/status-")
+       (keyword)
+       (label)))

--- a/src/status_im/models/chats.cljs
+++ b/src/status_im/models/chats.cljs
@@ -32,7 +32,7 @@
   (save-message chat-id
                 {:from         "Status"
                  :to           nil
-                 :msg-id       (random/id)
+                 :message-id   (random/id)
                  :content      (str "The brash businessman’s braggadocio "
                                     "and public exchange with candidates "
                                     "in the US presidential election")
@@ -40,8 +40,8 @@
                  :outgoing     false}))
 
 (defn create-chat
-  ([{:keys [last-msg-id] :as chat}]
-   (let [chat (assoc chat :last-msg-id (or last-msg-id ""))]
+  ([{:keys [last-message-id] :as chat}]
+   (let [chat (assoc chat :last-message-id (or last-message-id ""))]
      (r/write :account #(r/create :account :chat chat))))
   ([db chat-id identities group-chat? chat-name]
    (when-not (chat-exists? chat-id)
@@ -59,7 +59,7 @@
                         :group-chat  group-chat?
                         :timestamp   (timestamp)
                         :contacts    contacts
-                        :last-msg-id ""}))))
+                        :last-message-id ""}))))
        (add-status-message chat-id)))))
 
 (defn chat-contacts [chat-id]

--- a/src/status_im/models/commands.cljs
+++ b/src/status_im/models/commands.cljs
@@ -27,16 +27,16 @@
 (defn set-command-input
   ([db type command-key]
     (set-command-input db type nil command-key))
-  ([{:keys [current-chat-id] :as db} type msg-id command-key]
+  ([{:keys [current-chat-id] :as db} type message-id command-key]
    (update-in db [:chats current-chat-id :command-input] merge
               {:content       nil
                :command       (get-response-or-command type db command-key)
                :parameter-idx 0
-               :to-msg-id     msg-id})))
+               :to-message-id message-id})))
 
-(defn get-chat-command-to-msg-id
+(defn get-chat-command-to-message-id
   [{:keys [current-chat-id] :as db}]
-  (get-in db (db/chat-command-to-msg-id-path current-chat-id)))
+  (get-in db (db/chat-command-to-message-id-path current-chat-id)))
 
 (defn compare-commands
   [{created-at-1 :created-at} {created-at-2 :created-at}]
@@ -58,14 +58,14 @@
 (defn get-chat-command-request
   [{:keys [current-chat-id] :as db}]
   (get-in db (db/chat-command-request-path current-chat-id
-                                           (get-chat-command-to-msg-id db))))
+                                           (get-chat-command-to-message-id db))))
 
 (defn set-chat-command-request
-  [{:keys [current-chat-id] :as db} msg-id handler]
+  [{:keys [current-chat-id] :as db} message-id handler]
   (update-in db (db/chat-command-requests-path current-chat-id)
-             #(assoc % msg-id handler)))
+             #(assoc % message-id handler)))
 
-(defn parse-command-msg-content [commands content]
+(defn parse-command-message-content [commands content]
   (update content :command #((keyword %) commands)))
 
 (defn parse-command-request [commands content]

--- a/src/status_im/models/messages.cljs
+++ b/src/status_im/models/messages.cljs
@@ -26,10 +26,10 @@
 
 (defn save-message
   ;; todo remove chat-id parameter
-  [chat-id {:keys [delivery-status msg-id content]
-            :or   {delivery-status :pending}
+  [chat-id {:keys [delivery-status message-id content]
+            :or   {delivery-status :sending}
             :as   message}]
-  (when-not (r/exists? :account :message :msg-id msg-id)
+  (when-not (r/exists? :account :message :message-id message-id)
     (r/write :account
       (fn []
         (let [content' (if (string? content)
@@ -66,15 +66,14 @@
                                (generate-hiccup (read-string preview)))))
                   message))))))
 
-(defn update-message! [{:keys [msg-id] :as msg}]
-  (log/debug "update-message!" msg)
+(defn update-message! [{:keys [message-id] :as message}]
   (r/write :account
     (fn []
-      (when (r/exists? :account :message :msg-id msg-id)
-        (r/create :account :message msg true)))))
+      (when (r/exists? :account :message :message-id message-id)
+        (r/create :account :message message true)))))
 
 (defn get-message [id]
-  (r/get-one-by-field :account :message :msg-id id))
+  (r/get-one-by-field :account :message :message-id id))
 
 (defn get-last-message [chat-id]
   (-> (r/get-by-field :account :message :chat-id chat-id)

--- a/src/status_im/models/pending_messages.cljs
+++ b/src/status_im/models/pending_messages.cljs
@@ -1,0 +1,37 @@
+(ns status-im.models.pending-messages
+  (:require [status-im.persistence.realm.core :as r]
+            [re-frame.core :refer [dispatch]]
+            [cljs.reader :refer [read-string]]
+            [status-im.utils.random :refer [timestamp]]
+            [clojure.string :refer [join split]]
+            [clojure.walk :refer [stringify-keys keywordize-keys]]
+            [status-im.constants :as c]
+            [status-im.utils.types :refer [clj->json json->clj]]
+            [status-im.commands.utils :refer [generate-hiccup]]))
+
+(defn get-pending-messages []
+  (let [collection (-> (r/get-by-fields :account :pending-message :or [[:status :sending]
+                                                                       [:status :sent]])
+                       (r/sorted :timestamp :desc)
+                       (r/collection->map))]
+    (->> collection
+         (map (fn [{:keys [message-id] :as message}]
+                (let [message (-> message
+                                  (update :message json->clj)
+                                  (update :identities json->clj))]
+                  [message-id message])))
+         (into {}))))
+
+(defn upsert-pending-message!
+  [message]
+  (r/write :account
+           (fn []
+             (let [message (-> message
+                               (update :message clj->json)
+                               (update :identities clj->json))]
+               (r/create :account :pending-message message true)))))
+
+(defn remove-pending-message! [message-id]
+  (r/write :account
+           (fn []
+             (r/delete :account (r/get-by-field :account :pending-message :message-id message-id)))))

--- a/src/status_im/persistence/realm/core.cljs
+++ b/src/status_im/persistence/realm/core.cljs
@@ -100,8 +100,11 @@
   [schema schema-name obj]
   (write schema (fn [] (create schema schema-name obj true))))
 
-(defn and-q [queries]
+(defn and-query [queries]
   (str/join " and " queries))
+
+(defn or-query [queries]
+  (str/join " or " queries))
 
 (defmulti to-query (fn [schema schema-name operator field value]
                      operator))
@@ -122,11 +125,14 @@
   (let [q (to-query schema schema-name :eq field value)]
     (.filtered (.objects (realm schema) (name schema-name)) q)))
 
-(defn get-by-fields [schema schema-name fields]
+(defn get-by-fields [schema schema-name op fields]
   (let [queries (map (fn [[k v]]
                        (to-query schema schema-name :eq k v))
                      fields)]
-    (.filtered (.objects (realm schema) (name schema-name)) (and-q queries))))
+    (.filtered (.objects (realm schema) (name schema-name))
+               (case op
+                 :and (and-query queries)
+                 :or (or-query queries)))))
 
 (defn get-all [schema schema-name]
   (.objects (realm schema) (to-string schema-name)))

--- a/src/status_im/persistence/realm/schemas.cljs
+++ b/src/status_im/persistence/realm/schemas.cljs
@@ -37,8 +37,8 @@
                                :properties {:name  "string"
                                             :count {:type "int" :optional true :default 0}}}
                               {:name       :discovery
-                               :primaryKey :msg-id
-                               :properties {:msg-id       "string"
+                               :primaryKey :message-id
+                               :properties {:message-id   "string"
                                             :name         {:type "string" :optional true}
                                             :status       "string"
                                             :whisper-id   "string"
@@ -52,10 +52,12 @@
                                :properties {:key   "string"
                                             :value "string"}}
                               {:name       :message
-                               :primaryKey :msg-id
-                               :properties {:msg-id          "string"
+                               :primaryKey :message-id
+                               :properties {:message-id      "string"
                                             :from            "string"
                                             :to              {:type     "string"
+                                                              :optional true}
+                                            :group-id        {:type     "string"
                                                               :optional true}
                                             :content         "string" ;; TODO make it ArrayBuffer
                                             :content-type    "string"
@@ -65,31 +67,49 @@
                                             :outgoing        "bool"
                                             :delivery-status {:type     "string"
                                                               :optional true}
+                                            :retry-count     {:type    :int
+                                                              :default 0}
                                             :same-author     "bool"
                                             :same-direction  "bool"
                                             :preview         {:type     :string
+                                                              :optional true}
+                                            :message-type    {:type     :string
                                                               :optional true}}}
+                              {:name       :pending-message
+                               :primaryKey :message-id
+                               :properties {:message-id  "string"
+                                            :chat-id     {:type     "string"
+                                                          :optional true}
+                                            :message     "string"
+                                            :timestamp   "int"
+                                            :status      "string"
+                                            :retry-count "int"
+                                            :send-once   "bool"
+                                            :identities  {:type     "string"
+                                                          :optional true}
+                                            :internal?   {:type     "bool"
+                                                          :optional true}}}
                               {:name       :chat-contact
                                :properties {:identity   "string"
                                             :is-in-chat {:type    "bool"
                                                          :default true}}}
                               {:name       :chat
                                :primaryKey :chat-id
-                               :properties {:chat-id     "string"
-                                            :name        "string"
-                                            :color       {:type    "string"
-                                                          :default default-chat-color}
-                                            :group-chat  {:type    "bool"
-                                                          :indexed true}
-                                            :is-active   "bool"
-                                            :timestamp   "int"
-                                            :contacts    {:type       "list"
-                                                          :objectType "chat-contact"}
-                                            :dapp-url    {:type     :string
-                                                          :optional true}
-                                            :dapp-hash   {:type     :int
-                                                          :optional true}
-                                            :last-msg-id "string"}}
+                               :properties {:chat-id         "string"
+                                            :name            "string"
+                                            :color           {:type    "string"
+                                                              :default default-chat-color}
+                                            :group-chat      {:type    "bool"
+                                                              :indexed true}
+                                            :is-active       "bool"
+                                            :timestamp       "int"
+                                            :contacts        {:type       "list"
+                                                              :objectType "chat-contact"}
+                                            :dapp-url        {:type     :string
+                                                              :optional true}
+                                            :dapp-hash       {:type     :int
+                                                              :optional true}
+                                            :last-message-id "string"}}
                               {:name       :command
                                :primaryKey :chat-id
                                :properties {:chat-id "string"

--- a/src/status_im/protocol/handlers.cljs
+++ b/src/status_im/protocol/handlers.cljs
@@ -7,13 +7,14 @@
             [re-frame.core :refer [dispatch after]]
             [status-im.utils.handlers :refer [register-handler]]
             [status-im.models.contacts :as contacts]
+            [status-im.models.messages :as messages]
+            [status-im.models.pending-messages :as pending-messages]
+            [status-im.models.chats :as chats]
             [status-im.protocol.api :refer [init-protocol]]
             [status-im.protocol.protocol-handler :refer [make-handler]]
             [status-im.models.protocol :refer [update-identity
                                                set-initialized]]
             [status-im.constants :refer [text-content-type]]
-            [status-im.models.messages :as messages]
-            [status-im.models.chats :as chats]
             [status-im.i18n :refer [label]]))
 
 (register-handler :initialize-protocol
@@ -28,106 +29,129 @@
         (update-identity identity)
         (set-initialized true))))
 
-(defn system-message [msg-id content]
+(defn system-message [message-id content]
   {:from         "system"
-   :msg-id       msg-id
+   :message-id   message-id
    :content      content
    :content-type text-content-type})
 
-(defn joined-chat-msg [chat-id from msg-id]
+(defn joined-chat-message [chat-id from message-id]
   (let [contact-name (:name (contacts/contact-by-identity from))]
     (messages/save-message chat-id {:from         "system"
-                                    :msg-id       (str msg-id "_" from)
+                                    :message-id   (str message-id "_" from)
                                     :content      (str (or contact-name from) " " (label :t/received-invitation))
                                     :content-type text-content-type})))
 
-(defn participant-invited-to-group-msg [chat-id identity from msg-id]
+(defn participant-invited-to-group-message [chat-id identity from message-id]
   (let [inviter-name (:name (contacts/contact-by-identity from))
         invitee-name (if (= identity (api/my-identity))
                        (label :t/You)
                        (:name (contacts/contact-by-identity identity)))]
     (messages/save-message chat-id {:from         "system"
-                                    :msg-id       msg-id
+                                    :message-id   message-id
                                     :content      (str (or inviter-name from) " " (label :t/invited) " " (or invitee-name identity))
                                     :content-type text-content-type})))
 
-(defn participant-removed-from-group-msg [chat-id identity from msg-id]
+(defn participant-removed-from-group-message [chat-id identity from message-id]
   (let [remover-name (:name (contacts/contact-by-identity from))
         removed-name (:name (contacts/contact-by-identity identity))]
     (->> (str (or remover-name from) " " (label :t/removed) " " (or removed-name identity))
-         (system-message msg-id)
+         (system-message message-id)
          (messages/save-message chat-id))))
 
-(defn you-removed-from-group-msg [chat-id from msg-id]
+(defn you-removed-from-group-message [chat-id from message-id]
   (let [remover-name (:name (contacts/contact-by-identity from))]
     (->> (str (or remover-name from) " " (label :t/removed-from-chat))
-         (system-message msg-id)
+         (system-message message-id)
          (messages/save-message chat-id))))
 
-(defn participant-left-group-msg [chat-id from msg-id]
+(defn participant-left-group-message [chat-id from message-id]
   (let [left-name (:name (contacts/contact-by-identity from))]
     (->> (str (or left-name from) " " (label :t/left))
-         (system-message msg-id)
+         (system-message message-id)
          (messages/save-message chat-id))))
 
 (register-handler :group-chat-invite-acked
   (u/side-effect!
-    (fn [_ [action from group-id ack-msg-id]]
-      (log/debug action from group-id ack-msg-id)
-      #_(joined-chat-msg group-id from ack-msg-id))))
+    (fn [_ [action from group-id ack-message-id]]
+      (log/debug action from group-id ack-message-id)
+      #_(joined-chat-message group-id from ack-message-id))))
 
 (register-handler :participant-removed-from-group
   (u/side-effect!
-    (fn [_ [action from group-id identity msg-id]]
-      (log/debug action msg-id from group-id identity)
+    (fn [_ [action from group-id identity message-id]]
+      (log/debug action message-id from group-id identity)
       (chats/chat-remove-participants group-id [identity])
-      (participant-removed-from-group-msg group-id identity from msg-id))))
+      (participant-removed-from-group-message group-id identity from message-id))))
 
 (register-handler :you-removed-from-group
   (u/side-effect!
-    (fn [_ [action from group-id msg-id]]
-      (log/debug action msg-id from group-id)
-      (you-removed-from-group-msg group-id from msg-id)
+    (fn [_ [action from group-id message-id]]
+      (log/debug action message-id from group-id)
+      (you-removed-from-group-message group-id from message-id)
       (chats/set-chat-active group-id false))))
 
 (register-handler :participant-left-group
   (u/side-effect!
-    (fn [_ [action from group-id msg-id]]
-      (log/debug action msg-id from group-id)
+    (fn [_ [action from group-id message-id]]
+      (log/debug action message-id from group-id)
       (when-not (= (api/my-identity) from)
-        (participant-left-group-msg group-id from msg-id)))))
+        (participant-left-group-message group-id from message-id)))))
 
 (register-handler :participant-invited-to-group
   (u/side-effect!
-    (fn [_ [action from group-id identity msg-id]]
-      (log/debug action msg-id from group-id identity)
-      (participant-invited-to-group-msg group-id identity from msg-id))))
+    (fn [_ [action from group-id identity message-id]]
+      (log/debug action message-id from group-id identity)
+      (participant-invited-to-group-message group-id identity from message-id))))
 
 (defn update-message! [status]
-  (fn [_ [_ _ msg-id]]
-    (messages/update-message! {:msg-id          msg-id
+  (fn [_ [_ _ message-id]]
+    (messages/update-message! {:message-id      message-id
                                :delivery-status status})))
 
 (defn update-message-status [status]
-  (fn [db [_ from msg-id]]
-    (let [current-status (get-in db [:message-status from msg-id])]
+  (fn [db [_ chat-id message-id]]
+    (let [current-status (get-in db [:message-status chat-id message-id])]
       (if-not (= :seen current-status)
-        (assoc-in db [:message-status from msg-id] status)
+        (assoc-in db [:message-status chat-id message-id] status)
         db))))
 
-(register-handler :acked-msg
+(register-handler :message-delivered
   (after (update-message! :delivered))
   (update-message-status :delivered))
 
-(register-handler :msg-delivery-failed
+(register-handler :message-failed
   (after (update-message! :failed))
   (update-message-status :failed))
 
-(register-handler :msg-seen
+(register-handler :message-sent
+  (after (update-message! :sent))
+  (update-message-status :sent))
+
+(register-handler :message-seen
   [(after (update-message! :seen))
    (after (fn [_ [_ chat-id]]
             (dispatch [:remove-unviewed-messages chat-id])))]
   (update-message-status :seen))
+
+(register-handler :pending-message-upsert
+  (after
+    (fn [_ [_ {:keys [message-id status] :as pending-message}]]
+      (pending-messages/upsert-pending-message! pending-message)
+      (messages/update-message! {:message-id message-id
+                                 :delivery-status status})))
+  (fn [db [_ {:keys [message-id chat-id status] :as pending-message}]]
+    (if chat-id
+      (let [current-status (get-in db [:message-status chat-id message-id])]
+        (if-not (= :seen current-status)
+          (assoc-in db [:message-status chat-id message-id] status)
+          db))
+      db)))
+
+(register-handler :pending-message-remove
+  (u/side-effect!
+    (fn [_ [_ message-id]]
+      (pending-messages/remove-pending-message! message-id))))
 
 (register-handler :send-transaction!
   (u/side-effect!

--- a/src/status_im/protocol/protocol_handler.cljs
+++ b/src/status_im/protocol/protocol_handler.cljs
@@ -17,35 +17,40 @@
                        (case event-type
                          :initialized (let [{:keys [identity]} event]
                                         (dispatch [:protocol-initialized identity]))
-                         :new-msg (let [{:keys [from to payload]} event]
-                                    (dispatch [:received-message (assoc payload
-                                                                   :chat-id from
-                                                                   :from from
-                                                                   :to to)]))
-                         :msg-acked (let [{:keys [msg-id from]} event]
-                                      (dispatch [:acked-msg from msg-id]))
-                         :msg-seen (let [{:keys [msg-id from]} event]
-                                     (dispatch [:msg-seen from msg-id]))
-                         :delivery-failed (let [{:keys [msg-id from]} event]
-                                            (dispatch [:msg-delivery-failed from msg-id]))
+                         :message-received (let [{:keys [from to payload]} event]
+                                             (dispatch [:received-message (assoc payload :chat-id from
+                                                                                         :from from
+                                                                                         :to to)]))
+                         :message-delivered (let [{:keys [message-id from]} event]
+                                              (dispatch [:message-delivered from message-id]))
+                         :message-seen (let [{:keys [message-id from]} event]
+                                         (dispatch [:message-seen from message-id]))
+                         :message-failed (let [{:keys [message-id chat-id] :as event} event]
+                                           (dispatch [:message-failed chat-id message-id]))
+                         :message-sent (let [{:keys [message-id chat-id]} event]
+                                         (dispatch [:message-sent chat-id message-id]))
+                         :pending-message-upsert (let [{message :message} event]
+                                                   (dispatch [:pending-message-upsert message]))
+                         :pending-message-remove (let [{:keys [message-id]} event]
+                                                   (dispatch [:pending-message-remove message-id]))
                          :new-group-chat (let [{:keys [from group-id identities group-name]} event]
                                            (dispatch [:group-chat-invite-received from group-id identities group-name]))
-                         :new-group-msg (let [{from     :from
-                                               group-id :group-id
-                                               payload  :payload} event]
-                                          (dispatch [:received-message (assoc payload
-                                                                               :chat-id group-id
-                                                                               :from from)]))
-                         :group-chat-invite-acked (let [{:keys [from group-id ack-msg-id]} event]
-                                                    (dispatch [:group-chat-invite-acked from group-id ack-msg-id]))
-                         :group-new-participant (let [{:keys [group-id identity from msg-id]} event]
-                                                  (dispatch [:participant-invited-to-group from group-id identity msg-id]))
-                         :group-removed-participant (let [{:keys [group-id identity from msg-id]} event]
-                                                      (dispatch [:participant-removed-from-group from group-id identity msg-id]))
-                         :removed-from-group (let [{:keys [group-id from msg-id]} event]
-                                               (dispatch [:you-removed-from-group from group-id msg-id]))
-                         :participant-left-group (let [{:keys [group-id from msg-id]} event]
-                                                   (dispatch [:participant-left-group from group-id msg-id]))
+                         :new-group-message (let [{from     :from
+                                                   group-id :group-id
+                                                   payload  :payload} event]
+                                              (dispatch [:received-message (assoc payload
+                                                                             :chat-id group-id
+                                                                             :from from)]))
+                         :group-chat-invite-acked (let [{:keys [from group-id ack-message-id]} event]
+                                                    (dispatch [:group-chat-invite-acked from group-id ack-message-id]))
+                         :group-new-participant (let [{:keys [group-id identity from message-id]} event]
+                                                  (dispatch [:participant-invited-to-group from group-id identity message-id]))
+                         :group-removed-participant (let [{:keys [group-id identity from message-id]} event]
+                                                      (dispatch [:participant-removed-from-group from group-id identity message-id]))
+                         :removed-from-group (let [{:keys [group-id from message-id]} event]
+                                               (dispatch [:you-removed-from-group from group-id message-id]))
+                         :participant-left-group (let [{:keys [group-id from message-id]} event]
+                                                   (dispatch [:participant-left-group from group-id message-id]))
                          :discover-response (let [{:keys [from payload]} event]
                                               (dispatch [:discovery-response-received from payload]))
                          :contact-update (let [{:keys [from payload]} event]

--- a/src/status_im/translations/en.cljs
+++ b/src/status_im/translations/en.cljs
@@ -23,6 +23,14 @@
    :active-online                         "online"
    :active-unknown                        "unknown"
 
+   ;messages
+   :status-sending                        "Sending"
+   :status-sent                           "Sent"
+   :status-seen-by-everyone               "Seen by everyone"
+   :status-seen                           "Seen"
+   :status-delivered                      "Delivered"
+   :status-failed                         "Failed"
+
    ;datetime
    :datetime-second                       {:one   "second"
                                            :other "seconds"}

--- a/src/status_im/utils/event.cljs
+++ b/src/status_im/utils/event.cljs
@@ -3,7 +3,7 @@
   (:require-macros [cljs.core.async.macros :refer [go]]))
 
 (defn handle-channel-events [chan handler]
-  (go (loop [[msg args] (<! chan)]
-        (when msg
-          (handler msg args)
+  (go (loop [[message args] (<! chan)]
+        (when message
+          (handler message args)
           (recur (<! chan))))))


### PR DESCRIPTION
This PR includes lots of fixes and improvements in the way message delivery works.
It fixes #191
1. Now we save pending messages to the database and restore them from the database on the next login. It allows not to lost pending messages.
2. Both users don't need to be online to chat together — users can receive messages later, and we will send the message again if there is now confirmation that the message was received;
3. `:sending` and `:sent` statuses — it allows us to handle the situation when we can't send the message because of internet connection problem. Since now we will keep trying sending the message in this situation and all these attempts won't change `retry-count` value;
4. Refactoring (lots of small changes).

Also includes changes to `status-lib`: https://github.com/status-im/status-lib/pull/9
