### PR TITLE
Checking pending messages when user appears online (#210)

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,8 +8,9 @@
                  [reagent "0.5.1" :exclusions [cljsjs/react]]
                  [re-frame "0.7.0"]
                  [prismatic/schema "1.0.4"]
-                 ^{:voom {:repo "git@github.com:status-im/status-lib.git" :branch "master"}}
-                 [status-im/protocol "0.2.1-20160908_061908-geefb360"]
+                 ^{:voom {:repo "git@github.com:status-im/status-lib.git"
+                          :branch "master"}}
+                 [status-im/protocol "0.2.2-20160909_082306-gcfbb92b"]
                  [natal-shell "0.3.0"]
                  [com.andrewmcveigh/cljs-time "0.4.0"]
                  [tailrecursion/cljs-priority-map "1.2.0"]

--- a/src/status_im/contacts/handlers.cljs
+++ b/src/status_im/contacts/handlers.cljs
@@ -179,7 +179,8 @@
   (u/side-effect!
     (fn [db [_ from {last-online :at :as payload}]]
       (let [prev-last-online (get-in db [:contacts from :last-online])]
-        (if (< prev-last-online last-online)
+        (when (< prev-last-online last-online)
+          (api/resend-pending-messages from)
           (dispatch [:update-contact! {:whisper-identity from
                                        :last-online      last-online}]))))))
 

--- a/src/status_im/models/pending_messages.cljs
+++ b/src/status_im/models/pending_messages.cljs
@@ -12,7 +12,8 @@
 
 (defn get-pending-messages []
   (let [collection (-> (r/get-by-fields :account :pending-message :or [[:status :sending]
-                                                                       [:status :sent]])
+                                                                       [:status :sent]
+                                                                       [:status :failed]])
                        (r/sorted :timestamp :desc)
                        (r/collection->map))]
     (->> collection


### PR DESCRIPTION
When we receive online status from a user we now also try to resend pending messages. This feature allows us to decrease message ttl and make delivery process more stable and predictable. 

This feature also requires changes to status-lib. The related PR is https://github.com/status-im/status-lib/pull/14
