### PR TITLE
Delivery status issues #248

### DIFF
--- a/src/status_im/models/pending_messages.cljs
+++ b/src/status_im/models/pending_messages.cljs
@@ -46,10 +46,12 @@
                (r/create :account :pending-message message' true)))))
 
 (defn remove-pending-message!
-  [{{:keys [message-id]} :payload}]
+  [{{:keys [message-id ack-of-message]} :payload}]
   (r/write :account
            (fn []
-             (r/delete :account (r/get-by-field :account :pending-message :message-id message-id)))))
+             (r/delete :account
+                       (r/get-by-field :account :pending-message
+                                       :message-id (or ack-of-message message-id))))))
 
 (defn remove-all-by-chat [chat-id]
   (r/write

--- a/src/status_im/protocol/ack.cljs
+++ b/src/status_im/protocol/ack.cljs
@@ -1,22 +1,24 @@
 (ns status-im.protocol.ack
   (:require [status-im.protocol.web3.delivery :as d]
-            [status-im.protocol.web3.filtering :as f]))
+            [status-im.protocol.web3.filtering :as f]
+            [status-im.utils.random :as random]))
 
 (defn check-ack!
   [web3
    from
-   {:keys [type requires-ack? message-id ack? group-id]}
+   {:keys [type requires-ack? message-id ack? group-id ack-of-message]}
    identity]
   (when (and requires-ack? (not ack?))
     (let [message {:from       identity
                    :to         from
-                   :message-id message-id
+                   :message-id (random/id)
                    :topics     [f/status-topic]
                    :type       type
                    :ack?       true
-                   :payload    {:type     type
-                                :ack?     true
-                                :group-id group-id}}]
+                   :payload    {:type           type
+                                :ack?           true
+                                :ack-of-message message-id
+                                :group-id       group-id}}]
       (d/add-pending-message! web3 message)))
   (when ack?
-    (d/remove-pending-message! web3 message-id from)))
+    (d/remove-pending-message! web3 ack-of-message from)))


### PR DESCRIPTION
1) Usage of :ack-of-message instead of :message-id 
2) Prevent update of message's status if it was already set to `:seen`.
fixes #248