### PR TITLE
Show connectivity issues & displaying errors in console chat (#226)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.WRITE_CONTACTS"/>
     <uses-permission android:name="android.permission.READ_PROFILE"/>
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
     <application
             android:allowBackup="true"

--- a/resources/console.js
+++ b/resources/console.js
@@ -101,24 +101,12 @@ var phoneConfig = {
     name: "phone",
     description: "Send phone number",
     color: "#5fc48d",
-    validator: function (params) {
-        return {
-            validationHandler: "phone",
-            parameters: [params.phone]
-        };
-    },
     params: [{
         name: "phone",
         type: status.types.PHONE,
         suggestions: phoneSuggestions,
         placeholder: "Phone number"
-    }],
-    handler: function (params) {
-        return {
-            event: "sign-up",
-            params: [params.phone, params]
-        };
-    }
+    }]
 };
 status.response(phoneConfig);
 status.command(phoneConfig);
@@ -128,16 +116,6 @@ status.command({
     name: "help",
     description: "Help",
     color: "#7099e6",
-    /* Validator example
-     validator: function (params) {
-     if (params.value != "3") {
-     var error = status.components.view(
-     {backgroundColor: "red"},
-     [status.components.text({}, "ooops :(")]
-     );
-     return {errors: [error]}
-     }
-     },*/
     params: [{
         name: "query",
         type: status.types.TEXT
@@ -152,12 +130,6 @@ status.response({
         name: "code",
         type: status.types.NUMBER
     }],
-    handler: function (params) {
-        return {
-            event: "confirm-sign-up",
-            params: [params.code]
-        };
-    },
     validator: function (params) {
         if (!/^[\d]{4}$/.test(params.code)) {
             var error = status.components.validationMessage(
@@ -184,12 +156,6 @@ status.response({
         type: status.types.PASSWORD,
         placeholder: "Please re-enter password to confirm"
     }],
-    handler: function (params) {
-        return {
-            event: "save-password",
-            params: [params.password]
-        };
-    },
     validator: function (params, context) {
         var errorMessages = [];
         var currentParameter = context["current-parameter"];

--- a/src/status_im/android/core.cljs
+++ b/src/status_im/android/core.cljs
@@ -105,6 +105,7 @@
 
 (defn init [& [env]]
   (dispatch-sync [:reset-app])
+  (dispatch [:listen-to-network-status!])
   (dispatch [:initialize-crypt])
   (dispatch [:initialize-geth])
   (status/set-soft-input-mode status/adjust-resize)

--- a/src/status_im/chat/handlers/console.cljs
+++ b/src/status_im/chat/handlers/console.cljs
@@ -1,0 +1,39 @@
+(ns status-im.chat.handlers.console
+  (:require [re-frame.core :refer [dispatch dispatch-sync after]]
+            [status-im.utils.handlers :refer [register-handler] :as u]
+            [status-im.constants :refer [console-chat-id]]
+            [status-im.data-store.messages :as messages]))
+
+(def console-commands
+  {:password
+   (fn [params _]
+     (dispatch [:create-account (params "password")]))
+
+   :phone
+   (fn [params id]
+     (dispatch [:sign-up (params "phone") id]))
+
+   :confirmation-code
+   (fn [params id]
+     (dispatch [:sign-up-confirm (params "code") id]))})
+
+(def commands-names (set (keys console-commands)))
+
+(def commands-with-delivery-status
+  (disj commands-names :password))
+
+(register-handler :invoke-console-command-handler!
+  (u/side-effect!
+    (fn [_ [_ {:keys [staged-command] :as parameters}]]
+      (let [{:keys [id command params]} staged-command
+            {:keys [name]} command]
+        (dispatch [:prepare-command! parameters])
+        ((console-commands (keyword name)) params id)))))
+
+(register-handler :set-message-status
+  (after
+    (fn [_ [_ message-id status]]
+      (messages/update {:message-id     message-id
+                        :message-status status})))
+  (fn [db [_ message-id status]]
+    (assoc-in db [:message-statuses message-id] {:status status})))

--- a/src/status_im/chat/views/message.cljs
+++ b/src/status_im/chat/views/message.cljs
@@ -29,7 +29,8 @@
             [status-im.utils.gfycat.core :refer [generate-gfy]]
             [status-im.i18n :refer [label]]
             [status-im.chat.utils :as cu]
-            [clojure.string :as str]))
+            [clojure.string :as str]
+            [status-im.chat.handlers.console :as console]))
 
 (defn message-content-status [_]
   (let [{:keys [chat-id group-chat name color]} (subscribe [:chat-properties [:chat-id :group-chat :name :color]])
@@ -200,10 +201,13 @@
                  :font  :default}
            (str "+ " (- (count user-statuses) 3))])]])))
 
-(defview message-delivery-status [{:keys [message-id chat-id message-status user-statuses]}]
+(defview message-delivery-status
+  [{:keys [message-id chat-id message-status user-statuses content]}]
   [app-db-message-status-value [:get-in [:message-statuses message-id :status]]]
   (let [delivery-status (get-in user-statuses [chat-id :status])
-        status          (if (cu/console? chat-id)
+        command-name    (keyword (:command content))
+        status          (if (and (not (console/commands-with-delivery-status command-name))
+                                 (cu/console? chat-id))
                           :seen
                           (or delivery-status message-status app-db-message-status-value :sending))]
     [view st/delivery-view

--- a/src/status_im/components/react.cljs
+++ b/src/status_im/components/react.cljs
@@ -1,31 +1,18 @@
 (ns status-im.components.react
   (:require [reagent.core :as r]
             [status-im.components.styles :as st]
-            [status-im.utils.utils :as u]
+            [status-im.utils.utils :as u
+             :refer [get-react-property get-class adapt-class]]
             [status-im.utils.platform :refer [platform-specific]]))
 
 (def react-native (u/require "react-native"))
 (def native-modules (.-NativeModules react-native))
 (def device-event-emitter (.-DeviceEventEmitter react-native))
-(def geth (.-Geth native-modules))
 
 (def linear-gradient-module (u/require "react-native-linear-gradient"))
 (def dismiss-keyboard! (u/require "dismissKeyboard"))
 (def orientation (u/require "react-native-orientation"))
 (def drawer (u/require "react-native-drawer-layout"))
-
-;; Getters
-
-(defn- get-react-property [name]
-  (aget react-native name))
-
-(defn- adapt-class [class]
-  (when class
-    (r/adapt-react-class class)))
-
-(defn- get-class [name]
-  (adapt-class (get-react-property name)))
-
 
 ;; React Components
 

--- a/src/status_im/components/sync_state/offline.cljs
+++ b/src/status_im/components/sync_state/offline.cljs
@@ -18,12 +18,13 @@
                                   :duration 250})))
 
 (defn offline-view [_]
-  (let [sync-state          (subscribe [:get :sync-state])
-        offline-opacity     (anim/create-value 0.0)
-        on-update           (fn [_ _]
-                              (anim/set-value offline-opacity 0)
-                              (when (= @sync-state :offline)
-                                (start-offline-animation offline-opacity)))]
+  (let [sync-state      (subscribe [:get :sync-state])
+        network-status  (subscribe [:get :network-status])
+        offline-opacity (anim/create-value 0.0)
+        on-update       (fn [_ _]
+                          (anim/set-value offline-opacity 0)
+                          (when (or (= @network-status :offline) (= @sync-state :offline))
+                            (start-offline-animation offline-opacity)))]
     (r/create-class
       {:component-did-mount
        on-update
@@ -31,7 +32,7 @@
        on-update
        :reagent-render
        (fn [{:keys [top]}]
-         (when (= @sync-state :offline)
+         (when (or (= @network-status :offline) (= @sync-state :offline))
            [animated-view {:style (st/offline-wrapper top offline-opacity window-width)}
             [view
              [text {:style st/offline-text}

--- a/src/status_im/handlers.cljs
+++ b/src/status_im/handlers.cljs
@@ -22,6 +22,7 @@
     status-im.accounts.handlers
     status-im.protocol.handlers
     status-im.transactions.handlers
+    status-im.network.handlers
     [status-im.utils.types :as t]
     [status-im.constants :refer [console-chat-id]]))
 

--- a/src/status_im/handlers/server.cljs
+++ b/src/status_im/handlers/server.cljs
@@ -1,10 +1,12 @@
 (ns status-im.handlers.server
   (:require [re-frame.core :refer [subscribe dispatch dispatch-sync]]
             [status-im.utils.utils :refer [http-post]]
-            [taoensso.timbre :as log]))
+            [taoensso.timbre :as log]
+            [status-im.utils.scheduler :as sch]
+            [status-im.data-store.messages :as messages]))
 
 (defn sign-up
-  [db phone-number handler]
+  [db phone-number message-id handler]
   (let [current-account-id (get db :current-account-id)
         {:keys [public-key address]} (get-in db [:accounts current-account-id])]
     ;(user-data/save-phone-number phone-number)
@@ -14,11 +16,22 @@
                           :address          address}
                (fn [body]
                  (log/debug body)
-                 (handler)))
+                 (dispatch [:set-message-status message-id :seen])
+                 (handler))
+               (fn [_]
+                 (sch/execute-later
+                   #(dispatch [:sign-up phone-number message-id])
+                   (sch/s->ms 1))))
     db))
 
 (defn sign-up-confirm
-  [confirmation-code handler]
+  [confirmation-code message-id handler]
   (http-post "sign-up-confirm"
              {:code confirmation-code}
-             handler))
+             (fn [body]
+               (dispatch [:set-message-status message-id :seen])
+               (handler body))
+             (fn [_]
+               (sch/execute-later
+                 #(dispatch [:sign-up-confirm confirmation-code message-id])
+                 (sch/s->ms 1)))))

--- a/src/status_im/network/handlers.cljs
+++ b/src/status_im/network/handlers.cljs
@@ -1,0 +1,18 @@
+(ns status-im.network.handlers
+  (:require [re-frame.core :refer [dispatch debug enrich after]]
+            [status-im.utils.handlers :refer [register-handler]]
+            [status-im.utils.handlers :as u]
+            [status-im.network.net-info :as ni]
+            [clojure.string :as s]))
+
+(register-handler :listen-to-network-status!
+  (u/side-effect!
+    (fn []
+      (let [handler #(dispatch [:update-network-status %])]
+        (ni/init handler)
+        (ni/add-listener handler)))))
+
+(register-handler :update-network-status
+  (fn [db [_ is-connected?]]
+    (let [status (if is-connected? :online :offline)]
+      (assoc db :network-status status))))

--- a/src/status_im/network/net_info.cljs
+++ b/src/status_im/network/net_info.cljs
@@ -1,0 +1,16 @@
+(ns status-im.network.net-info
+  (:require [status-im.utils.utils :as u]
+            [taoensso.timbre :as log]))
+
+(def net-info (u/get-react-property "NetInfo"))
+
+(defn init [callback]
+  (when net-info
+    (.then (.fetch (.-isConnected net-info))
+           (fn [is-connected?]
+             (log/debug "Is connected?" is-connected?)
+             (callback is-connected?)))))
+
+(defn add-listener [listener]
+  (when net-info
+    (.addEventListener (.-isConnected net-info) "change" listener)))

--- a/src/status_im/protocol/handlers.cljs
+++ b/src/status_im/protocol/handlers.cljs
@@ -184,7 +184,7 @@
 (register-handler :participant-invited-to-group
   (u/side-effect!
     (fn [{:keys [current-public-key]}
-         [_ {:keys                                   [from]
+         [_ {:keys                                  [from]
              {:keys [group-id identity message-id]} :payload}]]
       (participant-invited-to-group-message group-id current-public-key identity from message-id)
       (when-not (= current-public-key identity)
@@ -232,11 +232,11 @@
        [_ {:keys                                        [from]
            {:keys [message-id ack-of-message group-id]} :payload}]]
     (if (chats/is-active? (or group-id from))
-      (let [message-id'    (or ack-of-message message-id)
-            group?         (boolean group-id)
-            status-path    (if (and group? (not= status :sent))
-                             [:message-user-statuses message-id' from]
-                             [:message-statuses message-id'])
+      (let [message-id' (or ack-of-message message-id)
+            group?      (boolean group-id)
+            status-path (if (and group? (not= status :sent))
+                          [:message-user-statuses message-id' from]
+                          [:message-statuses message-id'])
             {current-status :status} (get-in db status-path)]
         (if-not (= :seen current-status)
           (assoc-in db status-path {:whisper-identity from

--- a/src/status_im/utils/scheduler.cljs
+++ b/src/status_im/utils/scheduler.cljs
@@ -1,0 +1,10 @@
+(ns status-im.utils.scheduler
+  (:require-macros [cljs.core.async.macros :refer [go]])
+  (:require [cljs.core.async :refer [<! timeout]]))
+
+(defn s->ms [s] (* 1000 s))
+
+(defn execute-later
+  [function timeout-ms]
+  (go (<! (timeout timeout-ms))
+      (function)))

--- a/src/status_im/utils/utils.cljs
+++ b/src/status_im/utils/utils.cljs
@@ -1,7 +1,8 @@
 (ns status-im.utils.utils
   (:require-macros
    [natal-shell.async-storage :refer [get-item set-item]])
-  (:require [status-im.constants :as const]))
+  (:require [status-im.constants :as const]
+            [reagent.core :as r]))
 
 (defn require [module]
   (if (exists? js/window)
@@ -64,3 +65,13 @@
       (if (cond (first coll))
         index
         (recur (inc index) cond (next coll))))))
+
+(defn get-react-property [name]
+  (aget react-native name))
+
+(defn adapt-class [class]
+  (when class
+    (r/adapt-react-class class)))
+
+(defn get-class [name]
+  (adapt-class (get-react-property name)))

--- a/test/cljs/status_im/test/handlers_stubs.cljs
+++ b/test/cljs/status_im/test/handlers_stubs.cljs
@@ -8,7 +8,6 @@
 (defn init-stubs []
   (register-handler :sign-up
     (fn []
-      (println :ohh)
       ;; todo save phone number to db
       (sign-up-service/on-sign-up-response)))
 


### PR DESCRIPTION
fixes #226

When user is not connected to wifi/mobile network/etc he will see `offline` bage (the same as when there are errors at syncing):
<img width="427" alt="screen shot 2016-10-19 at 15 25 59" src="https://cloud.githubusercontent.com/assets/2364994/19518530/63161a4c-9610-11e6-89a1-67f0eadfb8ea.png">

When some troubles appear at sending phone number or confirmation code to the server user will see toast with error and the message will be not sent, so the user will be able to try again. 


![ni](https://cloud.githubusercontent.com/assets/2364994/19518775/8d3869e6-9611-11e6-8d5a-55a231a018be.gif)

Maybe there is a better way to show errors there but I'm not sure how.

