### PR TITLE
Fix for red screen on login (#381)

### DIFF
--- a/src/status_im/protocol/web3/delivery.cljs
+++ b/src/status_im/protocol/web3/delivery.cljs
@@ -207,12 +207,10 @@
 
 (defn reset-pending-messages! [to]
   (doseq [key (@recipient->pending-message to)]
-    (swap! messages
-           (fn [messages]
-             (when (get-in messages key)
-               (update-in messages key assoc
-                          :last-attempt 0
-                          :attempts 0))))))
+    (when (get-in @messages key)
+      (swap! messages #(update-in % key assoc
+                                  :last-attempt 0
+                                  :attempts 0)))))
 
 (defn reset-all-pending-messages! []
   (reset! messages {}))


### PR DESCRIPTION
Fixes #381

The problem happens because of one small bug in `reset-pending-messages!` function — when there is no key, it resets `messages` map to `nil` value