### PR TITLE
Prevent !send with null "to" address

### DIFF
--- a/resources/commands.js
+++ b/resources/commands.js
@@ -65,7 +65,17 @@ status.command({
     }]
 });
 
-function validateBalance(params, context) {
+function validateSend(params, context) {
+    if (!context.to) {
+        return {
+            errors: [
+                status.components.validationMessage(
+                    "Wrong address",
+                    "Recipient address must be specified"
+                )
+            ]
+        };
+    }
     if (!params.amount) {
         return {
             errors: [
@@ -136,7 +146,7 @@ var send = {
         );
     },
     handler: sendTransaction,
-    validator: validateBalance
+    validator: validateSend
 };
 
 status.command(send);

--- a/src/status_im/accounts/login/handlers.cljs
+++ b/src/status_im/accounts/login/handlers.cljs
@@ -24,7 +24,7 @@
       (dispatch [:navigate-to-clean :chat-list])
       (dispatch [:navigate-to :chat console-chat-id]))
     (do
-      (dispatch [:navigate-to-clean :accounts])
+      (dispatch [:navigate-to-clean :chat-list])
       (dispatch [:navigate-to :chat-list]))))
 
 (register-handler

--- a/src/status_im/chat/handlers/commands.cljs
+++ b/src/status_im/chat/handlers/commands.cljs
@@ -243,8 +243,10 @@
                                   :params
                                   (get parameter-idx)
                                   :name)
+            to                (get-in db [:contacts chat-id :address])
             context           {:current-parameter current-parameter
-                               :from              address}
+                               :from              address
+                               :to                to}
             path              [(if (= :command type) :commands :responses)
                                name
                                :validator]

--- a/src/status_im/contacts/handlers.cljs
+++ b/src/status_im/contacts/handlers.cljs
@@ -16,9 +16,11 @@
 
 (defmethod nav/preload-data! :group-contacts
   [db [_ _ group]]
-  (if group
-    (assoc db :contacts-group group)
-    db))
+  (dissoc
+    (if group
+      (assoc db :contacts-group group)
+      db)
+    :contacts-filter))
 
 (defmethod nav/preload-data! :new-group
   [db _]
@@ -28,7 +30,8 @@
 
 (defmethod nav/preload-data! :contact-list
   [db [_ _ click-handler]]
-  (assoc db :contacts-click-handler click-handler))
+  (assoc db :contacts-click-handler click-handler
+            :contacts-filter nil))
 
 
 (register-handler :remove-contacts-click-handler
@@ -132,7 +135,7 @@
 
 (defn request-stored-contacts [contacts]
   (let [contacts-by-hash (get-contacts-by-hash contacts)
-        data (or (keys contacts-by-hash) ())]
+        data             (or (keys contacts-by-hash) ())]
     (http-post "get-contacts" {:phone-number-hashes data}
                (fn [{:keys [contacts]}]
                  (let [contacts' (add-identity contacts-by-hash contacts)]
@@ -156,7 +159,7 @@
 
 (defn add-new-contacts
   [{:keys [contacts] :as db} [_ new-contacts]]
-  (let [identities (set (map :whisper-identity contacts))
+  (let [identities    (set (map :whisper-identity contacts))
         new-contacts' (->> new-contacts
                            (map #(update-pending-status contacts %))
                            (remove #(identities (:whisper-identity %)))

--- a/src/status_im/contacts/subs.cljs
+++ b/src/status_im/contacts/subs.cljs
@@ -60,9 +60,11 @@
 
 (register-sub :contacts-with-letters
   (fn [db _]
-    (let [contacts (reaction (:contacts @db))]
+    (let [contacts (reaction (:contacts @db))
+          pred     (subscribe [:get :contacts-filter])]
       (reaction
-        (let [ordered (sort-contacts @contacts)]
+        (let [ordered (sort-contacts @contacts)
+              ordered (if pred (filter @pred ordered) ordered)]
           (reduce (fn [prev cur]
                     (let [prev-letter (get-contact-letter (last prev))
                           cur-letter  (get-contact-letter cur)]

--- a/src/status_im/transactions/handlers.cljs
+++ b/src/status_im/transactions/handlers.cljs
@@ -123,6 +123,13 @@
     (remove-pending-message db message-id)))
 
 (register-handler :transaction-queued
+  (u/side-effect!
+    (fn [_ [_ {:keys [id args] :as transaction}]]
+      (if (:to args)
+        (dispatch [::transaction-queued transaction])
+        (status/discard-transaction id)))))
+
+(register-handler ::transaction-queued
   (after #(dispatch [:navigate-to-modal :confirm]))
   (fn [db [_ {:keys [id message_id args]}]]
     (let [{:keys [from to value]} args


### PR DESCRIPTION
fixes #430

1. Validation of `to` address was added to `!send` command:

 <img width="425" alt="screen shot 2016-11-10 at 12 03 40" src="https://cloud.githubusercontent.com/assets/2364994/20179758/4b51d642-a760-11e6-85d6-3ae5b85f0349.png">

2. If there is no address in contact entry it is not shown in the list when user select contact to send ETH (this will not have too much sense when we will derive address from public key, but it has some sense now)

 <img width="429" alt="screen shot 2016-11-10 at 15 58 06" src="https://cloud.githubusercontent.com/assets/2364994/20179843/a0ba506e-a760-11e6-9935-a6383758cb0d.png">

