### PR TITLE
Extended defview macro

### DIFF
--- a/src/status_im/utils/views.clj
+++ b/src/status_im/utils/views.clj
@@ -1,27 +1,58 @@
-(ns status-im.utils.views)
+(ns status-im.utils.views
+  (:require [clojure.walk :as w]))
+
+(defn atom? [sub]
+  (or (vector? sub)
+      (and (seq sub)
+           (#{'atom `reagent.core/atom} (first sub)))))
+
+(defn walk-sub [sub form->sym]
+  (if (coll? sub)
+    (w/postwalk (fn [f]
+                  (or (form->sym f) f)) sub)
+    (or (form->sym sub) sub)))
 
 (defn prepare-subs [subs]
-  (let [pairs (map (fn [[form sub]]
-                     {:form form
-                      :sub  sub
-                      :sym  (gensym)})
-                   (partition 2 subs))]
-    [(mapcat (fn [{:keys [sym sub]}]
-               [sym `(re-frame.core/subscribe ~sub)])
+  (let [pairs     (map (fn [[form sub]]
+                         {:form form
+                          :sub  sub
+                          :sym  (if (atom? sub)
+                                  (gensym (str (if (map? form) "keys" form)))
+                                  form)})
+                       (partition 2 subs))
+        form->sym (->> pairs
+                       (map (fn [{:keys [form sym]}]
+                              [form sym]))
+                       (into {}))]
+    [(mapcat (fn [{:keys [form sym sub]}]
+               (if (vector? sub)
+                 [sym `(re-frame.core/subscribe ~(walk-sub sub form->sym))]
+                 [form (walk-sub sub form->sym)]))
              pairs)
-     (mapcat (fn [{:keys [sym form]}]
-               [form `(deref ~sym)])
-             pairs)]))
+     (apply concat (keep (fn [{:keys [sym form sub]}]
+                           (when (atom? sub)
+                             [form `(deref ~sym)]))
+                         pairs))]))
 
 (defmacro defview
   [n params & rest]
-  (let [[subs body] (if (= 1 (count rest))
-                      [nil (first rest)]
-                      rest)
+  (let [[subs component-map body] (case (count rest)
+                                    1 [nil {} (first rest)]
+                                    2 [(first rest) {} (second rest)]
+                                    3 rest)
         [subs-bindings vars-bindings] (prepare-subs subs)]
     `(defn ~n ~params
        (let [~@subs-bindings]
-         (fn ~params
-           (let [~@vars-bindings]
-             ~body))))))
+         (reagent.core/create-class
+           (merge ~(->> component-map
+                        (map (fn [[k f]]
+                               (let [args (gensym "args")]
+                                 [k `(fn [& ~args]
+                                       (let [~@vars-bindings]
+                                         (apply ~f ~args)))])))
+                        (into {}))
+                  {:reagent-render
+                   (fn ~params
+                     (let [~@vars-bindings]
+                       ~body))}))))))
 


### PR DESCRIPTION
```clojure
;; before
(defn v [params]
  (let [s "some_string"
        a (subscribe [:a])
        b (subscribe [:b s])
        c (atom nil)
        d (reagent.core/atom nil)]
    (reagent.core/create-class
      {:component-did-mount (fn [] (+ @a @c))
       :reagent-render      (fn [params]
                              @b
                              [view [text (str s @d)]])})))

;; after
(defview v [params]
  [s "some_string"
   a [:a] 
   ;; bindings above can be used
   b [:b s]
   ;; clojure.core/atom and reagent.core/atom will be automatically
   ;; dereferenced by defview
   c (atom nil)
   d (reagent.core/atom nil)]
  ;; component's map can be passed as third parameter
  {:component-did-mount (fn [] (+ a c))}
  [view [text (str s d)]])
```