### PR TITLE
Order of messages fix (#550)

### DIFF
--- a/src/status_im/chat/subs.cljs
+++ b/src/status_im/chat/subs.cljs
@@ -31,11 +31,6 @@
         (get-in [:chats (:current-chat-id @db) k])
         (reaction))))
 
-(register-sub :get-chat-messages
-  (fn [db _]
-    (let [chat-id (:current-chat-id @db)]
-      (reaction (get-in @db [:chats chat-id :messages])))))
-
 (register-sub :get-current-chat-id
   (fn [db _]
     (reaction (:current-chat-id @db))))

--- a/src/status_im/data_store/chats.cljs
+++ b/src/status_im/data_store/chats.cljs
@@ -64,6 +64,10 @@
   [chat-id]
   (get-property chat-id :removed-at))
 
+(defn get-message-overhead
+  [chat-id]
+  (get-property chat-id :message-overhead))
+
 (defn get-active-group-chats
   []
   (data-store/get-active-group-chats))
@@ -71,6 +75,14 @@
 (defn set-active
   [chat-id active?]
   (save-property chat-id :is-active active?))
+
+(defn inc-message-overhead
+  [chat-id]
+  (save-property chat-id :message-overhead (inc (get-message-overhead chat-id))))
+
+(defn reset-message-overhead
+  [chat-id]
+  (save-property chat-id :message-overhead 0))
 
 (defn new-update?
   [timestamp chat-id]

--- a/src/status_im/data_store/messages.cljs
+++ b/src/status_im/data_store/messages.cljs
@@ -63,6 +63,10 @@
                               (generate-hiccup (read-string preview)))))
                  message)))))
 
+(defn get-count-by-chat-id
+  [chat-id]
+  (data-store/get-count-by-chat-id chat-id))
+
 (defn get-by-chat-id
   ([chat-id]
    (get-by-chat-id chat-id 0))
@@ -81,13 +85,24 @@
                   message))))))
 
 (defn get-last-message
-  [{:keys [chats] :as db} chat-id]
-  (if-let [message (first (get-in db [:chats chat-id :messages]))]
-    message
-    (if-let [{:keys [content-type] :as message} (data-store/get-last-message chat-id)]
-      (if (command-type? content-type)
-        (clojure.core/update message :content str-to-map)
-        message))))
+  [db chat-id]
+  (if-let [{:keys [content-type] :as message} (data-store/get-last-message chat-id)]
+    (if (command-type? content-type)
+      (clojure.core/update message :content str-to-map)
+      message)))
+
+(defn get-last-outgoing
+  [chat-id number-of-messages]
+  (data-store/get-by-fields {:chat-id  chat-id
+                             :outgoing true}
+                            0
+                            number-of-messages))
+
+(defn get-last-clock-value
+  [chat-id]
+  (if-let [message (data-store/get-last-message chat-id)]
+    (:clock-value message)
+    0))
 
 (defn get-unviewed
   []

--- a/src/status_im/data_store/realm/messages.cljs
+++ b/src/status_im/data_store/realm/messages.cljs
@@ -27,6 +27,11 @@
        (realm/page from (+ from number-of-messages))
        (realm/realm-collection->list))))
 
+(defn get-count-by-chat-id
+  [chat-id]
+  (-> (get-by-chat-id chat-id)
+      (realm/get-count)))
+
 (defn get-by-fields
   [fields from number-of-messages]
   (-> (realm/get-by-fields @realm/account-realm :message :and fields)

--- a/src/status_im/data_store/realm/schemas/account/v1/chat.cljs
+++ b/src/status_im/data_store/realm/schemas/account/v1/chat.cljs
@@ -29,12 +29,12 @@
                           :updated-at       {:type     :int
                                              :optional true}
                           :last-message-id  :string
+                          :message-overhead {:type    :int
+                                             :default 0}
                           :public-key       {:type     :string
                                              :optional true}
                           :private-key      {:type     :string
                                              :optional true}
-                          :clock-value      {:type    :int
-                                             :default 0}
                           :pending-contact? {:type    :bool
                                              :default false}
                           :contact-info     {:type     :string

--- a/src/status_im/data_store/realm/schemas/account/v1/message.cljs
+++ b/src/status_im/data_store/realm/schemas/account/v1/message.cljs
@@ -28,7 +28,9 @@
                           :user-statuses  {:type       :list
                                            :objectType "user-status"}
                           :clock-value    {:type    :int
-                                           :default 0}}})
+                                           :default 0}
+                          :show?          {:type    :bool
+                                           :default true}}})
 
 (defn migration [old-realm new-realm]
   (log/debug "migrating message schema"))

--- a/src/status_im/protocol/chat.cljs
+++ b/src/status_im/protocol/chat.cljs
@@ -41,3 +41,25 @@
                  :requires-ack? false)
                (assoc-in [:payload :group-id] (:group-id message))
                (dissoc :group-id)))))
+
+(defn send-clock-value-request!
+  [{:keys [web3 message]}]
+  (debug :send-clock-value-request message)
+  (d/add-pending-message!
+   web3
+   (merge message-defaults
+          (-> message
+              (assoc
+               :type :clock-value-request
+               :requires-ack? false)))))
+
+(defn send-clock-value!
+  [{:keys [web3 message]}]
+  (debug :send-clock-value message)
+  (d/add-pending-message!
+   web3
+   (merge message-defaults
+          (-> message
+              (assoc
+               :type :clock-value
+               :requires-ack? false)))))

--- a/src/status_im/protocol/core.cljs
+++ b/src/status_im/protocol/core.cljs
@@ -17,6 +17,8 @@
 ;; user
 (def send-message! chat/send!)
 (def send-seen! chat/send-seen!)
+(def send-clock-value-request! chat/send-clock-value-request!)
+(def send-clock-value! chat/send-clock-value!)
 (def reset-pending-messages! d/reset-pending-messages!)
 
 ;; group

--- a/src/status_im/protocol/handlers.cljs
+++ b/src/status_im/protocol/handlers.cljs
@@ -97,6 +97,8 @@
                    (dispatch [:message-delivered message])
                    (dispatch [:pending-message-remove message]))
             :seen (dispatch [:message-seen message])
+            :clock-value-request (dispatch [:message-clock-value-request message])
+            :clock-value (dispatch [:message-clock-value message])
             :group-invitation (dispatch [:group-chat-invite-received message])
             :update-group (dispatch [:update-group-message message])
             :add-group-identity (dispatch [:participant-invited-to-group message])
@@ -275,6 +277,15 @@
                           (assoc message :message-status status))]
             (messages/update message)))))))
 
+(defn save-message-clock-value!
+  [{:keys [message-extras] :as db}
+   [_ {:keys [from]
+       {:keys [message-id clock-value]} :payload}]]
+  (when-let [{old-clock-value :clock-value
+              :as             message} (merge (messages/get-by-id message-id)
+                                              (get message-extras message-id))]
+    (if (>= clock-value old-clock-value)
+      (messages/update (assoc message :clock-value clock-value :show? true)))))
 
 (defn update-message-status [status]
   (fn [db
@@ -313,6 +324,35 @@
 (register-handler :message-seen
   [(after (save-message-status! :seen))]
   (update-message-status :seen))
+
+(register-handler :message-clock-value-request
+  (u/side-effect!
+   (fn [db [_ {:keys [from] {:keys [message-id]} :payload}]]
+     (let [{:keys [chat-id]} (messages/get-by-id message-id)
+           message-overhead (chats/get-message-overhead chat-id)
+           last-clock-value (messages/get-last-clock-value chat-id)]
+       (if (> message-overhead 0)
+         (let [last-outgoing (->> (messages/get-last-outgoing chat-id message-overhead)
+                                  (reverse)
+                                  (map-indexed vector))]
+           (chats/reset-message-overhead chat-id)
+           (doseq [[i message] last-outgoing]
+             (dispatch [:update-clock-value! from i message (+ last-clock-value 100)])))
+         (dispatch [:send-clock-value! from message-id]))))))
+
+(register-handler :message-clock-value
+  (after save-message-clock-value!)
+  (fn [{:keys [message-extras] :as db}
+       [_ {:keys [from]
+           {:keys [message-id clock-value]} :payload}]]
+    (if-let [{old-clock-value :clock-value
+              :as             message} (merge (messages/get-by-id message-id)
+                                              (get message-extras message-id))]
+      (if (> clock-value old-clock-value)
+        (assoc-in db [:message-extras message-id] {:clock-value clock-value
+                                                   :show?       true})
+        db)
+      db)))
 
 (register-handler :pending-message-upsert
   (after


### PR DESCRIPTION
Fixes #550.

:clock-value now works better and there should be no problems with message order. I've checked it — everything works fine.