### PR TITLE
Fix for "Add to contacts" request (#570)

### DIFF
--- a/src/status_im/chat/handlers.cljs
+++ b/src/status_im/chat/handlers.cljs
@@ -456,11 +456,6 @@
           (dispatch [::start-chat! contact-id options navigation-type]))))))
 
 (register-handler :add-chat
-  (u/side-effect!
-    (fn [_ [_ chat-id chat]]
-      (dispatch [::add-chat chat-id chat]))))
-
-(register-handler ::add-chat
   (-> add-new-chat
       ((enrich add-chat))
       ((after save-new-chat!))))

--- a/src/status_im/protocol/handlers.cljs
+++ b/src/status_im/protocol/handlers.cljs
@@ -385,19 +385,19 @@
         (let [{{:keys [name profile-image address status]} :contact
                {:keys [public private]}                    :keypair} payload
 
-              contact        {:whisper-identity from
-                              :public-key       public
-                              :private-key      private
-                              :address          address
-                              :status           status
-                              :photo-path       profile-image
-                              :name             name}
-              contact-exist? (get contacts from)
-              chat           {:name             name
-                              :chat-id          from
-                              :contact-info     (prn-str contact)
-                              :pending-contact? true}]
-          (if contact-exist?
+              contact         {:whisper-identity from
+                               :public-key       public
+                               :private-key      private
+                               :address          address
+                               :status           status
+                               :photo-path       profile-image
+                               :name             name}
+              contact-exists? (get contacts from)
+              chat            {:name             name
+                               :chat-id          from
+                               :contact-info     (prn-str contact)
+                               :pending-contact? true}]
+          (if contact-exists?
             (do
               (dispatch [:update-contact! contact])
               (dispatch [:watch-contact contact]))


### PR DESCRIPTION
Fixes #570.

This problem reproduces because of the unnecessary double `dispatch`. The message simply arrived before we saved the new chat to the database. By removing the `dispatch` we guarantee that the incoming message will always use the updated value of chat object.

It was harder to find this bug than to fix it.