### PR TITLE
Multiline chat input

### DIFF
--- a/src/status_im/components/drawer/view.cljs
+++ b/src/status_im/components/drawer/view.cljs
@@ -55,7 +55,8 @@
      keyboard-height (subscribe [:get :keyboard-height])
      placeholder     (generate-gfy)
      status-edit?    (r/atom false)
-     status-text     (r/atom nil)]
+     status-text     (r/atom nil)
+     input-ref       (r/atom nil)]
     (fn []
       (let [{:keys [name photo-path status]} @account
             {new-name   :name
@@ -81,6 +82,7 @@
            [view st/status-container
             (if @status-edit?
               [text-input {:style               st/status-input
+                           :ref                 #(reset! input-ref %)
                            :editable            true
                            :multiline           true
                            :auto-focus          true
@@ -96,6 +98,7 @@
                                                    (reset! status-text status)
                                                    (if (str/includes? % "\n")
                                                      (do
+                                                       (.clear @input-ref)
                                                        (reset! status-edit? false)
                                                        (update-status status))
                                                      (dispatch [:set-in [:profile-edit :status] status])))}]


### PR DESCRIPTION
I've copied some code from drawer to chat to allow users to send messages by tapping Enter on the keyboard (previously it didn't work well on iOS)