### PR TITLE
chat: auto capitalize first letter of each sentence

### DIFF
--- a/src/status_im/chat/views/message_input.cljs
+++ b/src/status_im/chat/views/message_input.cljs
@@ -47,6 +47,7 @@
                  :auto-focus             false
                  :blur-on-submit         true
                  :multiline              true
+                 :auto-capitalize        "sentences"
                  :on-content-size-change #(let [size (-> (.-nativeEvent %)
                                                          (.-contentSize)
                                                          (.-height))]


### PR DESCRIPTION
As a user, I would expect the keyboard to automatically switch to uppercase for the first letter of a sentence.
This change enables that, using the _autoCapitalize_ property for [TextInput](https://facebook.github.io/react-native/docs/textinput.html).