### PR TITLE
Prevent non-positive-number amounts for send / request commands (#668)

### DIFF
--- a/resources/commands.js
+++ b/resources/commands.js
@@ -752,6 +752,7 @@ function validateSend(params, context) {
 
     try {
         var val = web3.toWei(params.amount, "ether");
+        if (val <= 0) { throw new Error(); }
     } catch (err) {
         return {
             errors: [
@@ -895,4 +896,19 @@ status.command({
             }
         };
     },
+    validator: function(params) {
+        try {
+            var val = web3.toWei(params.amount, "ether");
+            if (val <= 0) { throw new Error(); }
+        } catch (err) {
+            return {
+                errors: [
+                    status.components.validationMessage(
+                        I18n.t('validation_title'),
+                        I18n.t('validation_invalid_number')
+                    )
+                ]
+            };
+        }
+    }
 });


### PR DESCRIPTION
Quick fix to prevent non-numbers in request command. Used the same check as the send command (web3.toWei).

Also preventing 0 or negative amount, as I believe makes no sense (I was able to "send -3 ether", but the app crashed when it tried to confirm the transaction).

fixes #668