### PR TITLE
Add ability to copy/paste messages #639

### DIFF
--- a/src/status_im/chat/views/message.cljs
+++ b/src/status_im/chat/views/message.cljs
@@ -13,6 +13,7 @@
                                                 get-dimensions]]
             [status-im.components.animation :as anim]
             [status-im.chat.constants :as chat-consts]
+            [status-im.components.share :refer [share]]
             [status-im.chat.views.request-message :refer [message-content-command-request]]
             [status-im.chat.styles.message :as st]
             [status-im.chat.styles.command-pill :as pill-st]
@@ -198,7 +199,8 @@
   [{:keys [content] :as message}]
   [message-view message
    [text {:style (st/text-message message)
-          :font  :default}
+          :font  :default
+          :on-long-press  #(share content (label :t/message))}
     (parse-text content)]])
 
 (defmethod message-content text-content-type

--- a/src/status_im/components/share.cljs
+++ b/src/status_im/components/share.cljs
@@ -1,6 +1,12 @@
-(ns status-im.components.share)
+(ns status-im.components.share
+  (:require [re-frame.core :refer [dispatch]]
+            [status-im.utils.platform :refer [platform-specific]]))
 
 (def class (js/require "react-native-share"))
 
 (defn open [opts]
   (.open class (clj->js opts)))
+
+(defn share [text dialog-title]
+  (let [list-selection-fn (:list-selection-fn platform-specific)]
+    (dispatch [:open-sharing list-selection-fn text dialog-title])))

--- a/src/status_im/handlers.cljs
+++ b/src/status_im/handlers.cljs
@@ -6,6 +6,8 @@
     [taoensso.timbre :as log]
     [status-im.utils.crypt :refer [gen-random-bytes]]
     [status-im.components.status :as status]
+    [status-im.components.share :refer [open]]
+    [status-im.components.react :refer [copy-to-clipboard]]
     [status-im.utils.handlers :refer [register-handler] :as u]
     status-im.chat.handlers
     status-im.group-settings.handlers
@@ -23,6 +25,7 @@
     status-im.transactions.handlers
     status-im.network.handlers
     [status-im.utils.types :as t]
+    [status-im.i18n :refer [label]]
     [status-im.constants :refer [console-chat-id]]
     [status-im.utils.ethereum-network :as enet]))
 
@@ -41,6 +44,18 @@
 (register-handler :set-animation
   (fn [db [_ k v]]
     (assoc-in db [:animations k] v)))
+
+(register-handler :open-sharing
+  (u/side-effect!
+    (fn [_ [_ list-selection-fn text dialog-title]]
+      (list-selection-fn {:title       dialog-title
+                          :options     [(label :t/sharing-copy-to-clipboard) (label :t/sharing-share)]
+                          :callback    (fn [index]
+                                         (case index
+                                           0 (copy-to-clipboard text)
+                                           1 (open {:message text})
+                                           :default))
+                          :cancel-text (label :t/sharing-cancel)}))))
 
 (register-handler :initialize-db
   (fn [{:keys [status-module-initialized? network-status network]} _]

--- a/src/status_im/profile/handlers.cljs
+++ b/src/status_im/profile/handlers.cljs
@@ -1,9 +1,7 @@
 (ns status-im.profile.handlers
   (:require [re-frame.core :refer [subscribe dispatch]]
             [status-im.utils.handlers :refer [register-handler]]
-            [status-im.components.react :refer [show-image-picker
-                                                copy-to-clipboard]]
-            [status-im.components.share :refer [open]]
+            [status-im.components.react :refer [show-image-picker]]
             [status-im.utils.image-processing :refer [img->base64]]
             [status-im.i18n :refer [label]]
             [status-im.utils.handlers :as u :refer [get-hashtags]]
@@ -37,15 +35,3 @@
                                            1 (dispatch [:open-image-picker])
                                            :default))
                           :cancel-text (label :t/image-source-cancel)}))))
-
-(register-handler :open-sharing
-  (u/side-effect!
-    (fn [_ [_ list-selection-fn text dialog-title]]
-      (list-selection-fn {:title       dialog-title
-                          :options     [(label :t/sharing-copy-to-clipboard) (label :t/sharing-share)]
-                          :callback    (fn [index]
-                                         (case index
-                                           0 (copy-to-clipboard text)
-                                           1 (open {:message text})
-                                           :default))
-                          :cancel-text (label :t/sharing-cancel)}))))

--- a/src/status_im/profile/screen.cljs
+++ b/src/status_im/profile/screen.cljs
@@ -22,6 +22,7 @@
             [status-im.components.text-field.view :refer [text-field]]
             [status-im.components.selectable-field.view :refer [selectable-field]]
             [status-im.components.status-view.view :refer [status-view]]
+            [status-im.components.share :refer [share]]
             [status-im.utils.phone-number :refer [format-phone-number]]
             [status-im.utils.image-processing :refer [img->base64]]
             [status-im.utils.platform :refer [platform-specific]]
@@ -33,10 +34,6 @@
             [status-im.components.image-button.view :refer [show-qr-button]]
             [status-im.i18n :refer [label
                                     get-contact-translated]]))
-
-(defn share [text dialog-title]
-  (let [list-selection-fn (:list-selection-fn platform-specific)]
-    (dispatch [:open-sharing list-selection-fn text dialog-title])))
 
 (defn toolbar [{:keys [account edit?]}]
   (let [profile-edit-data-valid? (s/valid? ::v/profile account)]


### PR DESCRIPTION
Overview: reused the same function from the profile screen (which copies the public key)

- I've made it work only on the text messages, not command ones
- It's copying the raw content, so text decoration is preserved. Maybe for the future, another option could be added to copy just the text?

**Implementation:**
Both the share function and the event handler were in the _profile_ namespace, although they seemed more general to me.
- Moved the share function to the existent component/share namespace.
- Moved the share event handler to the root handlers file (couldn't figure out a better place)
- Added the share action to the message component (not sure if I choose the best place) and cleared namespace declarations everywhere.

fixes #639