### PR TITLE
chat.suggestions: updated regex for switch from ! to / command char

### DIFF
--- a/src/status_im/chat/suggestions.cljs
+++ b/src/status_im/chat/suggestions.cljs
@@ -41,7 +41,7 @@
 
 (defn check-suggestion [db message]
   (when-let [suggestion-text (when (string? message)
-                               (re-matches #"^![^\s]+\s" message))]
+                               (re-matches (re-pattern (str "^" chat-consts/command-char "[^\\s]+\\s")) message))]
     (let [suggestion-text' (s/trim suggestion-text)]
       (->> (get-commands db)
            (filter #(= suggestion-text' (->> % second :name (str chat-consts/command-char))))


### PR DESCRIPTION
Regex needed to be updated in order to accommodate the move from the "!" command char to the "/" command char.
chat-consts/command-char should not be a character that cannot be used in a regex, after "^"
