### PR TITLE
Search input on Discover can leave header in indeterminate state (#695)

### DIFF
--- a/src/status_im/components/toolbar/view.cljs
+++ b/src/status_im/components/toolbar/view.cljs
@@ -67,6 +67,8 @@
       {:style             st/toolbar-search-input
        :auto-focus        true
        :placeholder       search-placeholder
+       :return-key-type   "search"
+       :on-blur           #(dispatch [:set-in [:toolbar-search :show] nil])
        :on-change-text    #(dispatch [:set-in [:toolbar-search :text] %])
        :on-submit-editing #(toolbar-search-submit on-search-submit)}]
      [view
@@ -82,8 +84,7 @@
                                    on-search-submit]
                             :as   opts}]
   (let [toggle-search-fn #(dispatch [:set-in [:toolbar-search :show] %])
-        actions          (if show-search?
-                           [(act/search #(toolbar-search-submit on-search-submit))]
+        actions          (if-not show-search?
                            (into actions [(act/search #(toggle-search-fn search-key))]))]
     [toolbar {:style          (merge st/toolbar-with-search style)
               :nav-action     (if show-search?


### PR DESCRIPTION
Fixes #695