### PR TITLE
components, profile: better username validation #685

### DIFF
--- a/src/status_im/components/drawer/view.cljs
+++ b/src/status_im/components/drawer/view.cljs
@@ -71,9 +71,9 @@
               :editable         true
               :input-style      (st/name-input-text (s/valid? ::v/name (or new-name name)))
               :wrapper-style    st/name-input-wrapper
-              :value            name
+              :value            (or new-name name)
               :on-change-text   #(dispatch [:set-in [:profile-edit :name] %])
-              :on-end-editing   #(when (and new-name (not (str/blank? new-name)))
+              :on-end-editing   #(when (s/valid? ::v/name new-name)
                                   (dispatch [:account-update {:name (clean-text new-name)}]))}]]
            [view st/status-container
             (if @status-edit?

--- a/src/status_im/profile/validations.cljs
+++ b/src/status_im/profile/validations.cljs
@@ -1,13 +1,17 @@
 (ns status-im.profile.validations
   (:require [cljs.spec :as s]
             [status-im.constants :refer [console-chat-id wallet-chat-id]]
+            [status-im.chat.constants :as chat-consts]
             [clojure.string :as str]
             [status-im.utils.homoglyph :as h]))
 
 (defn correct-name? [username]
   (let [username (some-> username (str/trim))]
-    (and (not (h/matches username console-chat-id))
-         (not (h/matches username wallet-chat-id)))))
+    (every? false?
+      [(str/blank? username)
+       (h/matches username console-chat-id)
+       (h/matches username wallet-chat-id)
+       (str/includes? username chat-consts/command-char)])))
 
 (defn correct-email? [email]
   (let [pattern #"[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?"]


### PR DESCRIPTION
Fixes #685 

I mainly added a couple of rules to the profile name spec, and made sure that the drawer input was using that for validation as well. 
The UI still remains a bit strange, as the user can input an invalid name, and it will show in a red color (or empty), but it won't save, without warning.