### PR TITLE
Back button doesn't work on recover screen Bug/#675

### DIFF
--- a/src/status_im/accounts/handlers.cljs
+++ b/src/status_im/accounts/handlers.cljs
@@ -155,11 +155,13 @@
   (let [accounts (->> (accounts-store/get-all)
                       (map (fn [{:keys [address] :as account}]
                              [address account]))
-                      (into {}))]
+                      (into {}))
+        view (if (empty? accounts)
+               :chat
+               :accounts)]
     (assoc db :accounts accounts
-              :view-id (if (empty? accounts)
-                         :chat
-                         :accounts))))
+              :view-id view
+              :navigation-stack (list view))))
 
 (register-handler :load-accounts load-accounts!)
 

--- a/src/status_im/accounts/screen.cljs
+++ b/src/status_im/accounts/screen.cljs
@@ -39,8 +39,6 @@
 
 (defn create-account [_]
   (dispatch-sync [:reset-app])
-  ; add accounts screen to history ( maybe there is a better way ? )
-  (dispatch [:navigate-to-clean :accounts])
   (dispatch [:navigate-to :chat console-chat-id]))
 
 (defview accounts []

--- a/src/status_im/accounts/views/account.cljs
+++ b/src/status_im/accounts/views/account.cljs
@@ -11,7 +11,6 @@
             [status-im.accounts.styles :as st]))
 
 (defn on-press [address]
-  (dispatch [:navigate-to-clean :accounts])
   (dispatch [:navigate-to :login address])
   (dispatch [:set-in [:login :address] address]))
 


### PR DESCRIPTION
The reason of this bug
```
; add accounts screen to history ( maybe there is a better way ? )
  (dispatch [:navigate-to-clean :accounts])
```

should be a better way, I think better to add :accounts key into the :navigation-stack at the app initialization, but i don't know app's structure well, so, it needs to be refactored i think

fixes #675
