### PR TITLE
Cleaning WebView sessions (#688)

### DIFF
--- a/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusModule.java
+++ b/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusModule.java
@@ -2,12 +2,17 @@ package im.status.ethereum.module;
 
 import android.app.Activity;
 import android.view.WindowManager;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Message;
 import android.os.RemoteException;
+import android.util.Log;
+import android.webkit.CookieManager;
+import android.webkit.CookieSyncManager;
+import android.webkit.WebStorage;
+
 import com.facebook.react.bridge.*;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
-import android.util.Log;
 
 import java.util.HashMap;
 import java.util.UUID;
@@ -329,5 +334,42 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
                 activity.getWindow().setSoftInputMode(mode);
             }
         });
+    }
+
+    @SuppressWarnings("deprecation")
+    @ReactMethod
+    public void clearCookies() {
+        Log.d(TAG, "clearCookies");
+        final Activity activity = getCurrentActivity();
+        if (activity == null) {
+            return;
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1) {
+            CookieManager.getInstance().removeAllCookies(null);
+            CookieManager.getInstance().flush();
+        } else {
+            CookieSyncManager cookieSyncManager = CookieSyncManager.createInstance(activity);
+            cookieSyncManager.startSync();
+            CookieManager cookieManager = CookieManager.getInstance();
+            cookieManager.removeAllCookie();
+            cookieManager.removeSessionCookie();
+            cookieSyncManager.stopSync();
+            cookieSyncManager.sync();
+        }
+    }
+
+    @ReactMethod
+    public void clearStorageAPIs() {
+        Log.d(TAG, "clearStorageAPIs");
+        final Activity activity = getCurrentActivity();
+        if (activity == null) {
+            return;
+        }
+
+        WebStorage storage = WebStorage.getInstance();
+        if (storage != null) {
+            storage.deleteAllData();
+        }
     }
 }

--- a/modules/react-native-status/ios/RCTStatus/RCTStatus.m
+++ b/modules/react-native-status/ios/RCTStatus/RCTStatus.m
@@ -283,6 +283,26 @@ RCT_EXPORT_METHOD(setSoftInputMode: (NSInteger) i) {
 #endif
 }
 
+RCT_EXPORT_METHOD(clearCookies) {
+    NSHTTPCookie *cookie;
+    NSHTTPCookieStorage *storage = [NSHTTPCookieStorage sharedHTTPCookieStorage];
+    for (cookie in [storage cookies]) {
+        [storage deleteCookie:cookie];
+    }
+}
+
+RCT_EXPORT_METHOD(clearStorageAPIs) {
+    [[NSURLCache sharedURLCache] removeAllCachedResponses];
+
+    NSString *path = [NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES) lastObject];
+    NSArray *array = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:path error:nil];
+    for (NSString *string in array) {
+        NSLog(@"Removing %@", [path stringByAppendingPathComponent:string]);
+    if ([[string pathExtension] isEqualToString:@"localstorage"])
+        [[NSFileManager defaultManager] removeItemAtPath:[path stringByAppendingPathComponent:string] error:nil];
+    }
+}
+
 + (void)signalEvent:(const char *) signal
 {
     if(!signal){

--- a/src/status_im/accounts/login/handlers.cljs
+++ b/src/status_im/accounts/login/handlers.cljs
@@ -35,6 +35,7 @@
   :change-account
   (u/side-effect!
     (fn [_ [_ address new-account? callback]]
+      (status/clear-web-data)
       (data-store/change-account address new-account?
                                  #(callback % address new-account?)))))
 

--- a/src/status_im/components/status.cljs
+++ b/src/status_im/components/status.cljs
@@ -151,5 +151,10 @@
   (when status
     (call-module #(.setSoftInputMode status mode))))
 
+(defn clear-web-data []
+  (when status
+    (call-module #(.clearCookies status))
+    (call-module #(.clearStorageAPIs status))))
+
 (def adjust-resize 16)
 (def adjust-pan 32)


### PR DESCRIPTION
Fixes #688

Works on Android (devices + emulator) and real iOS devices.
It doesn't work in iOS Simulator, and seems like I've found the reason why:

_WebView cookies are stored by the device's operating system.  The location will vary by OS and I'm pretty sure it's opaque to apps._
 
_... webView:deleteCookies() not working on OS X.  Unfortunately, OS X shares cookies between all webview instances (including Safari) so enabling CoronaSDK apps to delete all of them would have surprising side-effects._

(from here: https://forums.coronalabs.com/topic/9540-delete-cookies-from-webview/)
