### PR TITLE
Alternate Currency Formats breaks ability to send ETH (#665)

### DIFF
--- a/resources/commands.js
+++ b/resources/commands.js
@@ -751,7 +751,7 @@ function validateSend(params, context) {
     }
 
     try {
-        var val = web3.toWei(params.amount, "ether");
+        var val = web3.toWei(params.amount.replace(",", "."), "ether");
         if (val <= 0) { throw new Error(); }
     } catch (err) {
         return {
@@ -788,7 +788,7 @@ function sendTransaction(params, context) {
     var data = {
         from: context.from,
         to: context.to,
-        value: web3.toWei(params.amount, "ether")
+        value: web3.toWei(params.amount.replace(",", "."), "ether")
     };
 
     try {


### PR DESCRIPTION
#665

Since all countries use either comma or point as a decimal mark (https://en.wikipedia.org/wiki/Decimal_mark), simple `replace` works great here.