### PR TITLE
Semicolon in password works fine now (#684); fix for crash #25

### DIFF
--- a/resources/console.js
+++ b/resources/console.js
@@ -1832,11 +1832,13 @@ status.response({
     params: [{
         name: "password",
         type: status.types.PASSWORD,
-        placeholder: I18n.t('password_placeholder')
+        placeholder: I18n.t('password_placeholder'),
+        hidden: true
     }, {
         name: "password-confirmation",
         type: status.types.PASSWORD,
-        placeholder: I18n.t('password_placeholder2')
+        placeholder: I18n.t('password_placeholder2'),
+        hidden: true
     }],
     validator: function (params, context) {
         var errorMessages = [];


### PR DESCRIPTION
This PR fixes #684 and the scariest Instabug crash (https://instabug.com/applications/status-10bb8cbc-15f6-44f0-8c7a-db478dc34d7d/beta/crashes/25).

This bug happens because of our `str-to-map` and `map-to-str` functions (https://github.com/status-im/status-react/blob/develop/src/status_im/data_store/messages.cljs#L11). Since we split the char sequence by semicolon (;) and equals sign (=), we can't use these chars in the input. The easiest solution is to use other characters in this sequence, but
1) it will ruin the existing messages, and users will see crap instead of previews;
2) all characters can be used inside a password, so by replacing ";" and "=" with something else, we postpone the problem instead of solving it.

In this PR I simply remove `password` and `password-confirmation` data from the `content`. It also improves a security a bit — by not storing a password in the database we're also making it impossible to steal this information.