### PR TITLE
Generating message preview on the fly (#645, #754)

### DIFF
--- a/resources/commands.js
+++ b/resources/commands.js
@@ -825,7 +825,7 @@ var send = {
                     style: amountStyle,
                     font: "light"
                 },
-                params.amount
+                status.localizeNumber(params.amount, context.delimiter, context.separator)
             )]);
 
         var currency = status.components.view(
@@ -877,12 +877,6 @@ status.command({
         name: "amount",
         type: status.types.NUMBER
     }],
-    preview: function (params) {
-        return status.components.text(
-            {},
-            params.amount + " ETH"
-        );
-    },
     handler: function (params) {
         return {
             event: "request",
@@ -891,10 +885,14 @@ status.command({
                 command: "send",
                 params: {
                     amount: params.amount
-                },
-                content: I18n.t('request_requesting') + params.amount + "ETH"
+                }
             }
         };
+    },
+    preview: function (params, context) {
+        return I18n.t('request_requesting')
+            + status.localizeNumber(params.amount, context.delimiter, context.separator)
+            + " ETH";
     },
     validator: function(params) {
         try {

--- a/resources/status.js
+++ b/resources/status.js
@@ -167,6 +167,11 @@ var status = {
     autorun: function (commandName) {
         _status_catalog.autorun = commandName;
     },
+    localizeNumber: function (num, del, sep) {
+        return I18n.toNumber(
+            num.replace(",", "."),
+            {precision: 10, strip_insignificant_zeros: true, delimiter: del, separator: sep});
+    },
     types: {
         TEXT: 'text',
         NUMBER: 'number',

--- a/resources/wallet.js
+++ b/resources/wallet.js
@@ -1,11 +1,3 @@
-
-I18n.translations = {
-  en: {
-    browse_title: 'Browser',
-    browse_description: 'Launch the browser'
-  }
-};
-
 function wallet(params, context) {
     var url = 'https://status.im/dapps/wallet';
 

--- a/src/status_im/chat/handlers.cljs
+++ b/src/status_im/chat/handlers.cljs
@@ -297,7 +297,12 @@
 (defn load-messages!
   ([db] (load-messages! db nil))
   ([{:keys [current-chat-id] :as db} _]
-   (assoc db :messages (messages/get-by-chat-id current-chat-id))))
+   (let [messages (messages/get-by-chat-id current-chat-id)]
+     (doseq [{:keys [content] :as message} messages]
+       (when (and (:command content)
+                  (not (:content content)))
+         (dispatch [:request-command-preview (assoc message :chat-id current-chat-id)])))
+     (assoc db :messages messages))))
 
 (defn init-chat
   ([db] (init-chat db nil))

--- a/src/status_im/chat/handlers/console.cljs
+++ b/src/status_im/chat/handlers/console.cljs
@@ -43,7 +43,7 @@
       (messages/update {:message-id     message-id
                         :message-status status})))
   (fn [db [_ message-id status]]
-    (assoc-in db [:message-statuses message-id] {:status status})))
+    (assoc-in db [:message-data :statuses message-id] {:status status})))
 
 (register-handler :console-respond-command
   (u/side-effect!

--- a/src/status_im/chat/handlers/send_message.cljs
+++ b/src/status_im/chat/handlers/send_message.cljs
@@ -29,16 +29,14 @@
      :from             identity
      :to               chat-id
      :timestamp        (time/now-ms)
-     :content          (assoc content :preview preview-string
-                                      :handler-data handler-data
-                                      :type (name (:type command)))
+     :content          (assoc content :handler-data handler-data
+                                      :type (name (:type command))
+                                      :content-command (:name command))
      :content-type     (or content-type
                            (if request
                              content-type-command-request
                              content-type-command))
      :outgoing         true
-     :preview          preview-string
-     :rendered-preview preview
      :to-message       to-message
      :type             (:type command)
      :has-handler      (:has-handler command)
@@ -142,7 +140,7 @@
     (fn [_ [_ chat-id {:keys [command]} hidden-params]]
       (let [command (-> command
                         (update-in [:content :params] #(apply dissoc % hidden-params))
-                        (dissoc :rendered-preview :to-message :has-handler))]
+                        (dissoc :to-message :has-handler))]
         (messages/save chat-id command)))))
 
 (register-handler ::dispatch-responded-requests!
@@ -288,7 +286,7 @@
 (register-handler ::send-command-protocol!
   (u/side-effect!
     (fn [{:keys [web3 current-public-key chats network-status] :as db}
-         [_ {:keys [chat-id command]}]]
+         [_ {:keys [chat-id command command-message]}]]
       (log/debug "sending command: " command)
       (when (cu/not-console? chat-id)
         (let [{:keys [public-key private-key]} (chats chat-id)

--- a/src/status_im/chat/views/request_message.cljs
+++ b/src/status_im/chat/views/request_message.cljs
@@ -76,7 +76,8 @@
   (let [top-offset          (r/atom {:specified? false})
         commands-atom       (subscribe [:get-responses])
         answered?           (subscribe [:is-request-answered? message-id])
-        status-initialized? (subscribe [:get :status-module-initialized?])]
+        status-initialized? (subscribe [:get :status-module-initialized?])
+        preview             (subscribe [:get-in [:message-data :preview message-id]])]
     (fn [{:keys [message-id content from incoming-group]}]
       (let [commands @commands-atom
             params   (:params content)
@@ -93,14 +94,17 @@
              [text {:style st/command-request-from-text
                     :font  :default}
               from])
-           [text {:style     st/style-message-text
-                  :on-layout #(reset! top-offset {:specified? true
-                                                  :value      (-> (.-nativeEvent %)
-                                                                  (.-layout)
-                                                                  (.-height)  
-                                                                  (> 25))})
-                  :font      :default}
-            content]]]
+           (if (and @preview
+                    (not (string? @preview)))
+             [view @preview]
+             [text {:style     st/style-message-text
+                    :on-layout #(reset! top-offset {:specified? true
+                                                    :value      (-> (.-nativeEvent %)
+                                                                    (.-layout)
+                                                                    (.-height)  
+                                                                    (> 25))})
+                    :font      :default}
+              (or @preview content)])]]
          (when (:request-text command)
            [view st/command-request-text-view
             [text {:style st/style-sub-text

--- a/src/status_im/commands/handlers/jail.cljs
+++ b/src/status_im/commands/handlers/jail.cljs
@@ -67,16 +67,6 @@
     ;; todo show error?
     nil)))
 
-(defn command-preview
-  [_ [command-message {:keys [result]}]]
-  (let [result' (:returned result)]
-    (dispatch [:send-chat-message
-               (if result'
-                 (assoc command-message
-                   :preview (generate-hiccup result')
-                   :preview-string (str result'))
-                 command-message)])))
-
 (defn print-error-message! [message]
   (fn [_ params]
     (when (:error (last params))
@@ -99,10 +89,6 @@
               (r/dismiss-keyboard!))))]
   suggestions-handler!)
 (reg-handler :suggestions-event! (u/side-effect! suggestions-events-handler!))
-
-(reg-handler :command-preview
-  (after (print-error-message! "Error on command preview"))
-  (u/side-effect! command-preview))
 
 (reg-handler :set-local-storage
   (fn [{:keys [current-chat-id] :as db} [{:keys [data] :as event}]]

--- a/src/status_im/components/status.cljs
+++ b/src/status_im/components/status.cljs
@@ -131,9 +131,9 @@
   (when status
     (call-module
       #(do
-         (log/debug :chat-id chat-id)
-         (log/debug :path path)
-         (log/debug :params params)
+         (log/debug :call-jail :chat-id chat-id)
+         (log/debug :call-jail :path path)
+         (log/debug :call-jail :params params)
          (let [params' (update params :context assoc
                                :debug js/goog.DEBUG
                                :locale i/i18n.locale)

--- a/src/status_im/data_store/messages.cljs
+++ b/src/status_im/data_store/messages.cljs
@@ -53,13 +53,9 @@
        (mapv #(clojure.core/update % :user-statuses user-statuses-to-map))
        (into '())
        reverse
-       (keep (fn [{:keys [content-type preview] :as message}]
+       (keep (fn [{:keys [content-type] :as message}]
                (if (command-type? content-type)
-                 (-> message
-                     (clojure.core/update :content str-to-map)
-                     (assoc :rendered-preview
-                            (when preview
-                              (generate-hiccup (read-string preview)))))
+                 (clojure.core/update message :content str-to-map)
                  message)))))
 
 (defn get-count-by-chat-id
@@ -76,11 +72,7 @@
         reverse
         (keep (fn [{:keys [content-type preview] :as message}]
                 (if (command-type? content-type)
-                  (-> message
-                      (clojure.core/update :content str-to-map)
-                      (assoc :rendered-preview
-                             (when preview
-                               (generate-hiccup (read-string preview)))))
+                  (clojure.core/update message :content str-to-map)
                   message))))))
 
 (defn get-last-message

--- a/src/status_im/protocol/handlers.cljs
+++ b/src/status_im/protocol/handlers.cljs
@@ -310,8 +310,8 @@
       (let [message-id' (or ack-of-message message-id)
             group?      (boolean group-id)
             status-path (if (and group? (not= status :sent))
-                          [:message-user-statuses message-id' from]
-                          [:message-statuses message-id'])
+                          [:message-data :user-statuses message-id' from]
+                          [:message-data :statuses message-id'])
             {current-status :status} (get-in db status-path)]
         (if-not (= :seen current-status)
           (assoc-in db status-path {:whisper-identity from

--- a/src/status_im/transactions/screen.cljs
+++ b/src/status_im/transactions/screen.cljs
@@ -20,7 +20,6 @@
             [status-im.i18n :refer [label label-pluralize]]
             [clojure.string :as s]))
 
-
 (defview confirm []
   [transactions [:transactions]
    {:keys [password]} [:get :confirm-transactions]

--- a/src/status_im/transactions/views/transaction_page.cljs
+++ b/src/status_im/transactions/views/transaction_page.cljs
@@ -10,7 +10,7 @@
                                                 touchable-opacity]]
             [status-im.components.styles :refer [icon-close]]
             [status-im.transactions.styles :as st]
-            [status-im.i18n :refer [label label-pluralize]]))
+            [status-im.i18n :refer [label label-pluralize label-number]]))
 
 (defn title-bar [title id]
   [view st/title-bar
@@ -35,10 +35,10 @@
 (defview transaction-page [{:keys [id from to value] :as transaction}]
   [{:keys [name] :as contact} [:contact-by-address to]]
   (let [eth-value         (.fromWei js/Web3.prototype value "ether")
-        title             (str eth-value " ETH to " (or name to))
+        title             (str (label-number eth-value) " ETH to " (or name to))
         transactions-info [[(label :t/status) (label :t/pending-confirmation)]
                            [(label :t/recipient) (or name to)]
-                           [(label :t/value) (str eth-value " ETH")]]]
+                           [(label :t/value) (str (label-number eth-value) " ETH")]]]
     [view {:style st/transaction-page
            :key   id}
      [title-bar title id]

--- a/src/status_im/translations/en.cljs
+++ b/src/status_im/translations/en.cljs
@@ -178,6 +178,7 @@
    :command-text-send                     "Transaction: {{amount}} ETH"
    :command-text-help                     "Help"
    :command-text-faucet                   "Faucet: {{url}}"
+   :command-text-request                  "Request: {{amount}} ETH"
 
    ;new-group
    :group-chat-name                       "Chat name"


### PR DESCRIPTION
In order to fix #645 we needed to change the way we do rendering, because it is almost impossible to translate the content that was pre-rendered before and saved to database. 
This PR introduces the new way of rendering — I've removed `:preview` and `:rendered-preview` from the message model and made the process dynamic. And since the rendering became dynamic, we can easily translate almost everything every time we need.

Fixes #645, #754