### PR TITLE
NFC access for DApps (#670)

### DIFF
--- a/.re-natal
+++ b/.re-natal
@@ -1,7 +1,7 @@
 {
   "name": "StatusIm",
   "interface": "reagent",
-  "androidHost": "localhost",
+  "androidHost": "10.0.3.2",
   "modules": [
     "react-native-contacts",
     "react-native-invertible-scroll-view",
@@ -37,7 +37,8 @@
     "react-native-share",
     "react-native-emoji-picker",
     "react-native-autolink",
-    "instabug-reactnative"
+    "instabug-reactnative",
+    "nfc-react-native"
   ],
   "imageDirs": [
     "images"

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -158,6 +158,7 @@ android {
 }
 
 dependencies {
+    compile project(':nfc-react-native')
     compile project(':instabug-reactnative')
     compile project(':react-native-splash-screen')
     compile project(':react-native-image-resizer')

--- a/android/app/src/main/java/im/status/ethereum/MainApplication.java
+++ b/android/app/src/main/java/im/status/ethereum/MainApplication.java
@@ -3,6 +3,7 @@ package im.status.ethereum;
 import android.app.Application;
 
 import com.facebook.react.ReactApplication;
+import es.tiarg.nfcreactnative.NfcReactNativePackage;
 import com.instabug.reactlibrary.RNInstabugReactnativePackage;
 import com.cboy.rn.splashscreen.SplashScreenReactPackage;
 import com.facebook.react.ReactNativeHost;
@@ -41,6 +42,7 @@ public class MainApplication extends Application implements ReactApplication {
     protected List<ReactPackage> getPackages() {
       return Arrays.asList(
               new MainReactPackage(),
+              new NfcReactNativePackage(),
               new RNInstabugReactnativePackage("b239f82a9cb00464e4c72cc703e6821e",MainApplication.this,"shake"),
               new SplashScreenReactPackage(),
               new StatusPackage(),

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,6 +1,8 @@
 rootProject.name = 'StatusIm'
 
 include ':app'
+include ':nfc-react-native'
+project(':nfc-react-native').projectDir = new File(rootProject.projectDir, '../node_modules/nfc-react-native/android')
 include ':instabug-reactnative'
 project(':instabug-reactnative').projectDir = new File(rootProject.projectDir, '../node_modules/instabug-reactnative/android')
 include ':react-native-splash-screen'

--- a/externs/externs.js
+++ b/externs/externs.js
@@ -198,5 +198,8 @@ var TopLevel = {
 "_value" : function () {},
 "ListView": function() {},
 "DataSource": function() {},
-"IBGLog": function() {}
+"IBGLog": function() {},
+"getCardId": function() {},
+"readTag": function() {},
+"writeTag": function() {}
 };

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "https-browserify": "0.0.1",
     "identicon.js": "github:status-im/identicon.js",
     "instabug-reactnative": "git+https://github.com/status-im/instabug-reactnative.git",
+    "nfc-react-native": "^0.3.9",
     "os-browserify": "^0.1.2",
     "path-browserify": "0.0.0",
     "process": "^0.11.5",

--- a/src/status_im/components/drawer/view.cljs
+++ b/src/status_im/components/drawer/view.cljs
@@ -20,7 +20,6 @@
             [status-im.i18n :refer [label]]
             [status-im.components.react :refer [dismiss-keyboard!]]
             [clojure.string :as str]
-            [cljs.spec :as s]
             [status-im.components.chat-icon.screen :as ci]))
 
 (defonce drawer-atom (atom))

--- a/src/status_im/components/nfc.cljs
+++ b/src/status_im/components/nfc.cljs
@@ -1,0 +1,30 @@
+(ns status-im.components.nfc
+  (:require [cljs.spec :as s]
+            [status-im.utils.platform :as platform]))
+
+(def class
+  (when platform/android?
+    (js/require "nfc-react-native")))
+
+(def android-only-error "NFC API is available only on Android")
+
+(defn get-card-id [on-success on-error]
+  (if platform/android?
+    (-> (.getCardId class)
+        (.then on-success)
+        (.catch on-error))
+    (on-error android-only-error)))
+
+(defn read-tag [sectors on-success on-error]
+  (if platform/android?
+    (-> (.readTag class (clj->js sectors))
+        (.then on-success)
+        (.catch on-error))
+    (on-error android-only-error)))
+
+(defn write-tag [sectors card-id on-success on-error]
+  (if platform/android?
+    (-> (.writeTag class (clj->js sectors) card-id)
+        (.then on-success)
+        (.catch on-error))
+    (on-error android-only-error)))


### PR DESCRIPTION
There are 3 methods in `nfc-react-native` package. This PR allows to use any of them in DApps.

**JS API**

```javascript

// getCardId

statusAPI.dispatch(
    "nfc", 
    {
        data: {
            event: "get-card-id"
        }, 
        callback: function (params) {
            // params.card, params.error
        }
    }
);

// readTag

statusAPI.dispatch(
    "nfc", 
    {
        data: {
            event: "read-tag",
            params: {
                sectors: [{ sector: 5, bloques: [1,2], clave: 'FFFFFFFFFFFF', tipoClave: 'A' }]
            }
        }, 
        callback: function (params) {
            // params.card, params.error
        }
    }
);

// writeTag

statusAPI.dispatch(
    "nfc", 
    {
        data: {
            event: "write-tag",
            params: {
                sectors: [{ sector: 5, bloques: [ ... ] }],
                id: "CARD_ID_GOES_HERE"
            }
        }, 
        callback: function (params) {
            // params.card, params.error
        }
    }
);
```

Fixes #670 