### PR TITLE
fix #701: Redirect user to the console when he tries to edit phone number on profile page

### DIFF
--- a/src/status_im/profile/handlers.cljs
+++ b/src/status_im/profile/handlers.cljs
@@ -5,7 +5,8 @@
             [status-im.utils.image-processing :refer [img->base64]]
             [status-im.i18n :refer [label]]
             [status-im.utils.handlers :as u :refer [get-hashtags]]
-            [taoensso.timbre :as log]))
+            [taoensso.timbre :as log]
+            [status-im.constants :refer [console-chat-id]]))
 
 (defn message-user [identity]
   (when identity
@@ -35,3 +36,11 @@
                                            1 (dispatch [:open-image-picker])
                                            :default))
                           :cancel-text (label :t/image-source-cancel)}))))
+
+(register-handler :phone-number-change-requested
+  ;; Switch user to the console issuing the !phone command automatically to let him change his phone number.
+  ;; We allow to change phone number only from console because this requires entering SMS verification code.
+  (u/side-effect!
+    (fn [db _]
+      (dispatch [:navigate-to :chat console-chat-id])
+      (dispatch [:set-chat-command :phone]))))

--- a/src/status_im/profile/screen.cljs
+++ b/src/status_im/profile/screen.cljs
@@ -33,7 +33,8 @@
             [status-im.utils.utils :refer [clean-text]]
             [status-im.components.image-button.view :refer [show-qr-button]]
             [status-im.i18n :refer [label
-                                    get-contact-translated]]))
+                                    get-contact-translated]]
+            [status-im.constants :refer [console-chat-id wallet-chat-id]]))
 
 (defn toolbar [{:keys [account edit?]}]
   (let [profile-edit-data-valid? (s/valid? ::v/profile account)]
@@ -113,6 +114,13 @@
             [status-view {:style  (st/status-text (:height (r/state component)))
                           :status status}])])})))
 
+(defn- navigate-to-phone-change
+  "Switch user to the console issuing the !phone command automatically to let him change his phone number."
+  []
+  (dispatch [:navigate-to :chat console-chat-id])
+  (dispatch [:set-chat-command :phone])
+  )
+
 (defview profile []
   [{whisper-identity :whisper-identity
     address          :address
@@ -155,10 +163,13 @@
 
     [view st/profile-property-with-top-spacing
      [selectable-field {:label     (label :t/phone-number)
+
                         :editable? false
                         :value     (if (and phone (not (str/blank? phone)))
                                      (format-phone-number phone)
-                                     (label :t/not-specified))}]
+                                     (label :t/not-specified))
+                        ;; TODO: should this be changed?
+                        :on-press  navigate-to-phone-change}]
      [view st/underline-container]]
 
     (when address
@@ -211,7 +222,8 @@
                           :editable? edit?
                           :value     (if (and phone (not (str/blank? phone)))
                                        (format-phone-number phone)
-                                       (label :t/not-specified))}]
+                                       (label :t/not-specified))
+                          :on-press  navigate-to-phone-change}]
        [view st/underline-container]]
 
       [view st/profile-property

--- a/src/status_im/profile/screen.cljs
+++ b/src/status_im/profile/screen.cljs
@@ -114,13 +114,6 @@
             [status-view {:style  (st/status-text (:height (r/state component)))
                           :status status}])])})))
 
-(defn- navigate-to-phone-change
-  "Switch user to the console issuing the !phone command automatically to let him change his phone number."
-  []
-  (dispatch [:navigate-to :chat console-chat-id])
-  (dispatch [:set-chat-command :phone])
-  )
-
 (defview profile []
   [{whisper-identity :whisper-identity
     address          :address
@@ -163,13 +156,10 @@
 
     [view st/profile-property-with-top-spacing
      [selectable-field {:label     (label :t/phone-number)
-
                         :editable? false
                         :value     (if (and phone (not (str/blank? phone)))
                                      (format-phone-number phone)
-                                     (label :t/not-specified))
-                        ;; TODO: should this be changed?
-                        :on-press  navigate-to-phone-change}]
+                                     (label :t/not-specified))}]
      [view st/underline-container]]
 
     (when address
@@ -223,7 +213,7 @@
                           :value     (if (and phone (not (str/blank? phone)))
                                        (format-phone-number phone)
                                        (label :t/not-specified))
-                          :on-press  navigate-to-phone-change}]
+                          :on-press  #(dispatch [:phone-number-change-requested])}]
        [view st/underline-container]]
 
       [view st/profile-property


### PR DESCRIPTION
Since phone change requires sms verification, we don't want user let to edit it directly on profile page.
Instead, we redirect him to the Console automatically issuing :phone command.