### PR TITLE
contacts: create "State of the Dapps" group

### DIFF
--- a/resources/default_contacts.json
+++ b/resources/default_contacts.json
@@ -24,34 +24,6 @@
         "dapp?": false
     },
 
-    "auction-house":
-    {
-        "name":
-        {
-            "en": "Auction House"
-        },
-        "photo-path": "contacts://auction-house",
-        "dapp?": true,
-        "dapp-url":
-        {
-            "en": "http://auctionhouse.dappbench.com"
-        }
-    },
-
-    "flight-delays-suck":
-    {
-        "name":
-        {
-            "en": "Flight Delays Suck"
-        },
-        "photo-path": "contacts://flight-delays-suck",
-        "dapp?": true,
-        "dapp-url":
-        {
-            "en": "https://fdd.etherisc.com"
-        }
-    },
-
     "mkr-market":
     {
         "name":
@@ -63,20 +35,6 @@
         "dapp-url":
         {
             "en": "https://mkr.market"
-        }
-    },
-
-    "FirstBlood":
-    {
-        "name":
-        {
-            "en": "FirstBlood"
-        },
-        "photo-path": "contacts://firstblood",
-        "dapp?": true,
-        "dapp-url":
-        {
-            "en": "https://app.firstblood.io"
         }
     },
 

--- a/resources/state_of_the_dapps.json
+++ b/resources/state_of_the_dapps.json
@@ -6,7 +6,6 @@
             "en": "Auction House"
         },
         "photo-path": "contacts://auction-house",
-        "state-of-the-dapp?": true,
         "dapp-url":
         {
             "en": "http://auctionhouse.dappbench.com"
@@ -20,7 +19,6 @@
             "en": "Flight Delays Suck"
         },
         "photo-path": "contacts://flight-delays-suck",
-        "state-of-the-dapp?": true,
         "dapp-url":
         {
             "en": "https://fdd.etherisc.com"
@@ -34,7 +32,6 @@
             "en": "FirstBlood"
         },
         "photo-path": "contacts://firstblood",
-        "state-of-the-dapp?": true,
         "dapp-url":
         {
             "en": "https://app.firstblood.io"

--- a/resources/state_of_the_dapps.json
+++ b/resources/state_of_the_dapps.json
@@ -1,0 +1,43 @@
+{
+    "auction-house":
+    {
+        "name":
+        {
+            "en": "Auction House"
+        },
+        "photo-path": "contacts://auction-house",
+        "state-of-the-dapp?": true,
+        "dapp-url":
+        {
+            "en": "http://auctionhouse.dappbench.com"
+        }
+    },
+
+    "flight-delays-suck":
+    {
+        "name":
+        {
+            "en": "Flight Delays Suck"
+        },
+        "photo-path": "contacts://flight-delays-suck",
+        "state-of-the-dapp?": true,
+        "dapp-url":
+        {
+            "en": "https://fdd.etherisc.com"
+        }
+    },
+
+    "FirstBlood":
+    {
+        "name":
+        {
+            "en": "FirstBlood"
+        },
+        "photo-path": "contacts://firstblood",
+        "state-of-the-dapp?": true,
+        "dapp-url":
+        {
+            "en": "https://app.firstblood.io"
+        }
+    }
+}

--- a/src/status_im/commands/handlers/loading.cljs
+++ b/src/status_im/commands/handlers/loading.cljs
@@ -168,16 +168,18 @@
   (u/side-effect!
     (fn [{:keys [chats]}]
       (doseq [[id {:keys [name photo-path public-key add-chat?
-                          dapp? state-of-the-dapp? dapp-url dapp-hash] :or {dapp? false state-of-the-dapp? false add-chat? false} :as data}] (concat js-res/default-contacts js-res/state-of-the-dapps)]
+                          dapp? state-of-the-dapp? dapp-url dapp-hash]
+                   :or {dapp? false state-of-the-dapp? false add-chat? false}}]
+              (concat js-res/default-contacts js-res/state-of-the-dapps)]
         (let [id' (clojure.core/name id)]
           (when-not (chats id')
             (when add-chat?
               (dispatch [:add-chat id' {:name (:en name)}]))
             (dispatch [:add-contacts [{:whisper-identity id'
-                                       :name             (:en name)
-                                       :photo-path       photo-path
-                                       :public-key       public-key
-                                       :dapp?            dapp?
+                                       :name               (:en name)
+                                       :photo-path         photo-path
+                                       :public-key         public-key
+                                       :dapp?              dapp?
                                        :state-of-the-dapp? state-of-the-dapp?
-                                       :dapp-url         (:en dapp-url)
-                                       :dapp-hash        dapp-hash}]])))))))
+                                       :dapp-url           (:en dapp-url)
+                                       :dapp-hash          dapp-hash}]])))))))

--- a/src/status_im/commands/handlers/loading.cljs
+++ b/src/status_im/commands/handlers/loading.cljs
@@ -168,7 +168,7 @@
   (u/side-effect!
     (fn [{:keys [chats]}]
       (doseq [[id {:keys [name photo-path public-key add-chat?
-                          dapp? dapp-url dapp-hash]}] js-res/default-contacts]
+                          dapp? state-of-the-dapp? dapp-url dapp-hash] :or {dapp? false state-of-the-dapp? false add-chat? false} :as data}] (concat js-res/default-contacts js-res/state-of-the-dapps)]
         (let [id' (clojure.core/name id)]
           (when-not (chats id')
             (when add-chat?
@@ -178,5 +178,6 @@
                                        :photo-path       photo-path
                                        :public-key       public-key
                                        :dapp?            dapp?
+                                       :state-of-the-dapp? state-of-the-dapp?
                                        :dapp-url         (:en dapp-url)
                                        :dapp-hash        dapp-hash}]])))))))

--- a/src/status_im/contacts/screen.cljs
+++ b/src/status_im/contacts/screen.cljs
@@ -116,15 +116,15 @@
                 :style create-icon}]]]])
 
 (defn contact-list [_]
-  (let [peoples              (subscribe [:get-added-people-with-limit contacts-limit])
-        dapps                (subscribe [:get-added-dapps-with-limit contacts-limit])
-        state-of-the-dapps   (subscribe [:get-added-state-of-the-dapps-with-limit contacts-limit])
-        people-count         (subscribe [:added-people-count])
-        dapps-count          (subscribe [:added-dapps-count])
+  (let [peoples                  (subscribe [:get-added-people-with-limit contacts-limit])
+        dapps                    (subscribe [:get-added-dapps-with-limit contacts-limit])
+        state-of-the-dapps       (subscribe [:get-added-state-of-the-dapps-with-limit contacts-limit])
+        people-count             (subscribe [:added-people-count])
+        dapps-count              (subscribe [:added-dapps-count])
         state-of-the-dapps-count (subscribe [:added-state-of-the-dapps-count])
-        click-handler        (subscribe [:get :contacts-click-handler])
-        show-search          (subscribe [:get-in [:toolbar-search :show]])
-        show-toolbar-shadow? (r/atom false)]
+        click-handler            (subscribe [:get :contacts-click-handler])
+        show-search              (subscribe [:get-in [:toolbar-search :show]])
+        show-toolbar-shadow?     (r/atom false)]
     (fn [current-view?]
       [view st/contacts-list-container
        [toolbar-view (and current-view?

--- a/src/status_im/contacts/screen.cljs
+++ b/src/status_im/contacts/screen.cljs
@@ -118,8 +118,10 @@
 (defn contact-list [_]
   (let [peoples              (subscribe [:get-added-people-with-limit contacts-limit])
         dapps                (subscribe [:get-added-dapps-with-limit contacts-limit])
+        state-of-the-dapps   (subscribe [:get-added-state-of-the-dapps-with-limit contacts-limit])
         people-count         (subscribe [:added-people-count])
         dapps-count          (subscribe [:added-dapps-count])
+        state-of-the-dapps-count (subscribe [:added-state-of-the-dapps-count])
         click-handler        (subscribe [:get :contacts-click-handler])
         show-search          (subscribe [:get-in [:toolbar-search :show]])
         show-toolbar-shadow? (r/atom false)]
@@ -131,7 +133,7 @@
         (when @show-toolbar-shadow?
           [linear-gradient {:style  st/contact-group-header-gradient-bottom
                             :colors st/contact-group-header-gradient-bottom-colors}])]
-       (if (pos? (+ @dapps-count @people-count))
+       (if (pos? (+ @dapps-count @state-of-the-dapps-count @people-count))
          [scroll-view {:style    st/contact-groups
                        :onScroll (fn [e]
                                    (let [offset (.. e -nativeEvent -contentOffset -y)]
@@ -143,6 +145,13 @@
              @dapps-count
              (label :t/contacts-group-dapps)
              :dapps
+             @click-handler])
+          (when (pos? @state-of-the-dapps-count)
+            [contact-group-view
+             @state-of-the-dapps
+             @state-of-the-dapps-count
+             (label :t/contacts-group-state-of-the-dapps)
+             :state-of-the-dapps
              @click-handler])
           (when (pos? @people-count)
             [contact-group-view

--- a/src/status_im/contacts/subs.cljs
+++ b/src/status_im/contacts/subs.cljs
@@ -32,12 +32,12 @@
 (register-sub :all-added-people
   (fn []
     (let [contacts (subscribe [:all-added-contacts])]
-      (reaction (remove #(some % [:dapp? :state-of-the-dapp?]) @contacts)))))
+      (reaction (remove :dapp? @contacts)))))
 
 (register-sub :all-added-dapps
   (fn []
     (let [contacts (subscribe [:all-added-contacts])]
-      (reaction (filter :dapp? @contacts)))))
+      (reaction (filter #(and (:dapp? %) (not (:state-of-the-dapp? %))) @contacts)))))
 
 (register-sub :all-added-state-of-the-dapps
   (fn []

--- a/src/status_im/contacts/subs.cljs
+++ b/src/status_im/contacts/subs.cljs
@@ -32,12 +32,17 @@
 (register-sub :all-added-people
   (fn []
     (let [contacts (subscribe [:all-added-contacts])]
-      (reaction (remove :dapp? @contacts)))))
+      (reaction (remove #(some % [:dapp? :state-of-the-dapp?]) @contacts)))))
 
 (register-sub :all-added-dapps
   (fn []
     (let [contacts (subscribe [:all-added-contacts])]
       (reaction (filter :dapp? @contacts)))))
+
+(register-sub :all-added-state-of-the-dapps
+  (fn []
+    (let [contacts (subscribe [:all-added-contacts])]
+      (reaction (filter :state-of-the-dapp? @contacts)))))
 
 (register-sub :get-added-people-with-limit
   (fn [_ [_ limit]]
@@ -49,6 +54,11 @@
     (let [contacts (subscribe [:all-added-dapps])]
       (reaction (take limit @contacts)))))
 
+(register-sub :get-added-state-of-the-dapps-with-limit
+  (fn [_ [_ limit]]
+    (let [contacts (subscribe [:all-added-state-of-the-dapps])]
+      (reaction (take limit @contacts)))))
+
 (register-sub :added-people-count
   (fn [_ _]
     (let [contacts (subscribe [:all-added-people])]
@@ -57,6 +67,11 @@
 (register-sub :added-dapps-count
   (fn [_ _]
     (let [contacts (subscribe [:all-added-dapps])]
+      (reaction (count @contacts)))))
+
+(register-sub :added-state-of-the-dapps-count
+  (fn [_ _]
+    (let [contacts (subscribe [:all-added-state-of-the-dapps])]
       (reaction (count @contacts)))))
 
 (defn get-contact-letter [contact]

--- a/src/status_im/translations/en.cljs
+++ b/src/status_im/translations/en.cljs
@@ -133,6 +133,7 @@
    :remove-contact                        "Remove contact"
    :show-all                              "SHOW ALL"
    :contacts-group-dapps                  "ÐApps"
+   :contacts-group-state-of-the-dapps     "State of the ÐApps"
    :contacts-group-people                 "People"
    :contacts-group-new-chat               "Start new chat"
    :no-contacts                           "No contacts yet"

--- a/src/status_im/utils/js_resources.cljs
+++ b/src/status_im/utils/js_resources.cljs
@@ -4,8 +4,10 @@
 
 (def default-contacts (-> (slurp "resources/default_contacts.json")
                           (json->clj)))
-(def state-of-the-dapps (-> (slurp "resources/state_of_the_dapps.json")
-                          (json->clj)))
+(def state-of-the-dapps (->> (slurp "resources/state_of_the_dapps.json")
+                             (json->clj)
+                             (map (fn [[k v]] [k (assoc v :dapp? true :state-of-the-dapp? true)]))
+                             (into {})))
 (def commands-js (slurp "resources/commands.js"))
 (def console-js (slurp "resources/console.js"))
 (def status-js (slurp "resources/status.js"))

--- a/src/status_im/utils/js_resources.cljs
+++ b/src/status_im/utils/js_resources.cljs
@@ -4,7 +4,8 @@
 
 (def default-contacts (-> (slurp "resources/default_contacts.json")
                           (json->clj)))
-
+(def state-of-the-dapps (-> (slurp "resources/state_of_the_dapps.json")
+                          (json->clj)))
 (def commands-js (slurp "resources/commands.js"))
 (def console-js (slurp "resources/console.js"))
 (def status-js (slurp "resources/status.js"))


### PR DESCRIPTION
This PR solves #599 
Changes:
1. Moved the 3 state-of-the-dapps  from `default_contact.json` to `state_of_the_dapps.json` and added `utils/js-resources`
2. `commands/handlers/loading.cljs`: in `:load-default-contacts!` handler - load both `js-res/default-contacts` and  `js-res/state-of-the-dapps`
3. `contacts/screen.cljs`: Create a new "State of the Dapps" group in the contacts screen
4. `contacts/subs.cljs`: `register-sub` for state-of-the-dapps data + fix the filter for `:all-added-people` to exclude also `state-of-the-dapp?`
5. `translations/en.cljs`: added a string for `:contacts-group-state-of-the-dapps`



Questions:
A. Some names and urls returned by state-of-the-dapps are a bit different that the ones we had in `default_contact.json`:

1. "Flight Delay Insurance" instead of "Flight Delays Suck"
2. "https://firstblood.io/" instead "https://app.firstblood.io"

Which ones should we use?

B. What translations should we use for "State of the Dapps" in the contacts screen?
C. Do we want to have the data format in `state_of_the_dapps.json` to be as it is now or to have the same format as it is returned by state-of-the-dapps JSON endpoint? (Maybe we can leave it as it is now and where there are more dapps we will decide what is the correct format?)
D. Should I add unit tests for my changes?
