### PR TITLE
Fix profile and drawer input inconsistencies (#774)

### DIFF
--- a/src/status_im/components/drawer/view.cljs
+++ b/src/status_im/components/drawer/view.cljs
@@ -73,8 +73,10 @@
               :wrapper-style    st/name-input-wrapper
               :value            (or new-name name)
               :on-change-text   #(dispatch [:set-in [:profile-edit :name] %])
-              :on-end-editing   #(when (s/valid? ::v/name new-name)
-                                  (dispatch [:account-update {:name (clean-text new-name)}]))}]]
+              :on-end-editing   #(do
+                                   (dispatch [:set-in [:profile-edit :name] nil])
+                                   (when (s/valid? ::v/name new-name)
+                                     (dispatch [:account-update {:name (clean-text new-name)}])))}]]
            [view st/status-container
             (if @status-edit?
               [text-input {:style               st/status-input
@@ -118,6 +120,7 @@
              [view st/switch-users-container
               [touchable-opacity {:onPress (fn []
                                              (close-drawer)
+                                             (dispatch [:set-in [:profile-edit :name] nil])
                                              (dispatch [:navigate-to :accounts]))}
                [text {:style st/switch-users-text
                       :font  :default}

--- a/src/status_im/components/text_field/view.cljs
+++ b/src/status_im/components/text_field/view.cljs
@@ -95,6 +95,7 @@
 
 (defn reagent-render [_ _]
   (let [component        (r/current-component)
+        input-ref        (r/atom nil)
         {:keys [float-label?
                 label-top
                 label-font-size
@@ -112,7 +113,8 @@
     [view (merge st/text-field-container wrapper-style)
      (when-not label-hidden?
        [animated-text {:style (st/label label-top label-font-size label-color)} label])
-     [text-input {:style             (merge st/text-input input-style)
+     [text-input {:ref               #(reset! input-ref %)
+                  :style             (merge st/text-input input-style)
                   :placeholder       (or placeholder "")
                   :editable          editable
                   :secure-text-entry secure-text-entry
@@ -138,6 +140,7 @@
                                        (on-change-text text))
                   :on-change         #(on-change %)
                   :default-value     value
+                  :on-submit-editing #(.blur @input-ref)
                   :on-end-editing    (when on-end-editing
                                        on-end-editing)}]
      [view {:style    (st/underline-container line-color)

--- a/src/status_im/profile/screen.cljs
+++ b/src/status_im/profile/screen.cljs
@@ -191,6 +191,7 @@
    qr [:get-in [:profile-edit :qr-code]]
    current-account [:get-current-account]
    changed-account [:get :profile-edit]]
+  {:component-will-unmount #(dispatch [:set-in [:profile-edit :name] nil])}
   (let [{:keys [phone
                 address
                 public-key]

--- a/src/status_im/profile/validations.cljs
+++ b/src/status_im/profile/validations.cljs
@@ -6,7 +6,7 @@
             [status-im.utils.homoglyph :as h]))
 
 (defn correct-name? [username]
-  (let [username (some-> username (str/trim))]
+  (when-let [username (some-> username (str/trim))]
     (every? false?
       [(str/blank? username)
        (h/matches username console-chat-id)


### PR DESCRIPTION
Fixes #774 

The cause and solution used can be found in this RN issue: https://github.com/facebook/react-native/issues/7047
Besides fixing the issues explicit in #774, the following issues are also solved in this PR:

- Editing the username (on drawer or profile screen) and switching account showed the first account's username in the drawer.
- Editing the username (on drawer or profile screen) and leaving it in a invalid state didn't save the invalid username (which is correct), but didn't reverse it either (so you could navigate around and even switch accounts but the invalid username would persist on the drawer). Now:
  - On the drawer, when the user finishes editing the username, the input reverses to the previous saved one if the new one is invalid.
  - On the profile screen, if the user leaves the screen without saving, this unsaved username will be discarded, invalid or not.