### PR TITLE
text-field component renamed to text-input-with-label

### DIFF
--- a/src/status_im/accounts/login/screen.cljs
+++ b/src/status_im/accounts/login/screen.cljs
@@ -12,7 +12,7 @@
             [status-im.components.toolbar.actions :as act]
             [status-im.components.toolbar.styles :refer [toolbar-title-container
                                                          toolbar-title-text]]
-            [status-im.components.text-field.view :refer [text-field]]
+            [status-im.components.text-input-with-label.view :refer [text-input-with-label]]
             [status-im.components.styles :refer [color-white
                                                  icon-search
                                                  button-input]]
@@ -27,7 +27,7 @@
 
 (defview address-input [address]
   [view
-   [text-field
+   [text-input-with-label
     {:value          address
      :editable       false
      :label          (label :t/address)
@@ -39,7 +39,7 @@
 
 (defview password-input [error]
   [view
-   [text-field
+   [text-input-with-label
     {:editable          true
      :error             (when (pos? (count error)) (label :t/wrong-password))
      :error-color       :white

--- a/src/status_im/accounts/recover/screen.cljs
+++ b/src/status_im/accounts/recover/screen.cljs
@@ -7,7 +7,7 @@
                                                 linear-gradient
                                                 touchable-highlight]]
             [status-im.components.status-bar :refer [status-bar]]
-            [status-im.components.text-field.view :refer [text-field]]
+            [status-im.components.text-input-with-label.view :refer [text-input-with-label]]
             [status-im.components.toolbar.view :refer [toolbar]]
             [status-im.components.toolbar.actions :as act]
             [status-im.components.toolbar.styles :refer [toolbar-gradient
@@ -38,7 +38,7 @@
                 error
                 (label :t/enter-valid-passphrase))]
     [view
-     [text-field
+     [text-input-with-label
       {:value          passphrase
        :error          error
        :error-color    color-blue
@@ -56,7 +56,7 @@
                 error
                 (label :t/enter-valid-password))]
     [view
-     [text-field
+     [text-input-with-label
       {:value             password
        :secure-text-entry true
        :error             error

--- a/src/status_im/components/drawer/view.cljs
+++ b/src/status_im/components/drawer/view.cljs
@@ -11,7 +11,7 @@
                                                 drawer-layout
                                                 touchable-without-feedback
                                                 touchable-opacity]]
-            [status-im.components.text-field.view :refer [text-field]]
+            [status-im.components.text-input-with-label.view :refer [text-input-with-label]]
             [status-im.components.status-view.view :refer [status-view]]
             [status-im.components.drawer.styles :as st]
             [status-im.profile.validations :as v]
@@ -64,7 +64,7 @@
             [view st/user-photo-container
              [ci/chat-icon photo-path {:size 64}]]]
            [view st/name-container
-            [text-field
+            [text-input-with-label
              {:line-color       :white
               :focus-line-color :white
               :placeholder      placeholder

--- a/src/status_im/components/text_input_with_label/styles.cljs
+++ b/src/status_im/components/text_input_with_label/styles.cljs
@@ -1,0 +1,45 @@
+(ns status-im.components.text-input-with-label.styles
+  (:require [status-im.utils.platform :refer [platform-specific]]))
+
+
+(def text-input-with-label-container
+  {:position       :relative
+   :height         72
+   :padding-top    30
+   :padding-bottom 34})
+
+(def text-input
+  {:font-size           16
+   :height              34
+   :line-height         34
+   :padding-bottom      5
+   :text-align-vertical :top})
+
+(defn label [top font-size color]
+  (let [input-label-style (get-in platform-specific [:component-styles :input-label])]
+    (merge input-label-style
+           {:position         :absolute
+            :top              top
+            :color            color
+            :font-size        font-size
+            :background-color :transparent})))
+
+(def label-float
+  {})
+
+(defn underline-container [background-color]
+  {:background-color background-color
+   :height           1
+   :align-items      :center})
+
+(defn underline [background-color width]
+  {:background-color background-color
+   :height           1
+   :width            width})
+
+(defn error-text [color]
+  (let [input-error-text-style (get-in platform-specific [:component-styles :input-error-text])]
+    (merge input-error-text-style
+           {:color            color
+            :background-color :transparent
+            :font-size        12})))

--- a/src/status_im/components/text_input_with_label/styles.cljs~
+++ b/src/status_im/components/text_input_with_label/styles.cljs~
@@ -1,4 +1,4 @@
-(ns status-im.components.text-field.styles
+(ns status-im.components.text-input-with-label.styles
   (:require [status-im.utils.platform :refer [platform-specific]]))
 
 

--- a/src/status_im/components/text_input_with_label/view.cljs
+++ b/src/status_im/components/text_input_with_label/view.cljs
@@ -1,0 +1,154 @@
+(ns status-im.components.text-input-with-label.view
+  (:require [clojure.string :as s]
+            [re-frame.core :refer [subscribe dispatch dispatch-sync]]
+            [reagent.core :as r]
+            [status-im.components.react :refer [react-native
+                                                view
+                                                text
+                                                animated-text
+                                                animated-view
+                                                text-input
+                                                touchable-opacity]]
+            [status-im.components.text-input-with-label.styles :as st]
+            [status-im.i18n :refer [label]]
+            [status-im.components.animation :as anim]
+            [taoensso.timbre :as log]
+            [status-im.components.styles :refer [separator-color]]))
+
+
+(def config {:label-top                16
+             :label-bottom             37
+             :label-font-large         16
+             :label-font-small         13
+             :label-animation-duration 200})
+
+(def default-props {:wrapper-style     {}
+                    :input-style       {}
+                    :line-style        {}
+                    :editable          true
+                    :label-color       "#838c93"
+                    :line-color        separator-color
+                    :focus-line-color  separator-color
+                    :error-color       "#d50000"
+                    :secure-text-entry false
+                    :on-focus          #()
+                    :on-blur           #()
+                    :on-change-text    #()
+                    :on-change         #()})
+
+(defn field-animation [{:keys [top to-top font-size to-font-size
+                               line-width to-line-width]}]
+  (let [duration (:label-animation-duration config)
+        animation (anim/parallel [(anim/timing top {:toValue  to-top
+                                                    :duration duration})
+                                  (anim/timing font-size {:toValue  to-font-size
+                                                          :duration duration})
+                                  (anim/timing line-width {:toValue  to-line-width
+                                                           :duration duration})])]
+    (anim/start animation (fn [arg]
+                            (when (.-finished arg)
+                              (log/debug "Field animation finished"))))))
+
+; Invoked once before the component is mounted. The return value will be used
+; as the initial value of this.state.
+(defn get-initial-state [_]
+  {:has-focus       false
+   :float-label?    false
+   :label-top       0
+   :label-font-size 0
+   :line-width      (anim/create-value 0)
+   :max-line-width  100})
+
+; Invoked once, both on the client and server, immediately before the initial
+; rendering occurs. If you call setState within this method, render() will see
+; the updated state and will be executed only once despite the state change.
+(defn component-will-mount [component]
+  (let [{:keys [value]} (r/props component)
+        data {:label-top       (anim/create-value (if (s/blank? value)
+                                                    (:label-bottom config)
+                                                    (:label-top config)))
+              :label-font-size (anim/create-value (if (s/blank? value)
+                                                    (:label-font-large config)
+                                                    (:label-font-small config)))
+              :float-label?    (if (s/blank? value) false true)}]
+    ;(log/debug "component-will-mount")
+    (r/set-state component data)))
+
+(defn on-input-focus [{:keys [component animation onFocus]}]
+  (do
+    (log/debug "input focused")
+    (r/set-state component {:has-focus    true
+                            :float-label? true})
+    (field-animation animation)
+    (when onFocus (onFocus))))
+
+(defn on-input-blur [{:keys [component value animation onBlur]}]
+  (log/debug "Input blurred")
+  (r/set-state component {:has-focus    false
+                          :float-label? (if (s/blank? value) false true)})
+  (when (s/blank? value)
+    (field-animation animation))
+  (when onBlur (onBlur)))
+
+(defn get-width [event]
+  (.-width (.-layout (.-nativeEvent event))))
+
+(defn reagent-render [_ _]
+  (let [component        (r/current-component)
+        {:keys [float-label?
+                label-top
+                label-font-size
+                line-width
+                current-value
+                max-line-width]} (r/state component)
+        {:keys [wrapper-style input-style label-hidden? line-color focus-line-color secure-text-entry
+                label-color error-color error label value on-focus on-blur
+                on-change-text on-change on-end-editing editable placeholder]} (merge default-props (r/props component))
+        line-color       (if error error-color line-color)
+        focus-line-color (if error error-color focus-line-color)
+        label-color      (if (and error (not float-label?)) error-color label-color)
+        label            (when-not label-hidden?
+                           (if error (str label " *") label))]
+    [view (merge st/text-input-with-label-container wrapper-style)
+     (when-not label-hidden?
+       [animated-text {:style (st/label label-top label-font-size label-color)} label])
+     [text-input {:style             (merge st/text-input input-style)
+                  :placeholder       (or placeholder "")
+                  :editable          editable
+                  :secure-text-entry secure-text-entry
+                  :on-focus          #(on-input-focus {:component component
+                                                       :animation {:top           label-top
+                                                                   :to-top        (:label-top config)
+                                                                   :font-size     label-font-size
+                                                                   :to-font-size  (:label-font-small config)
+                                                                   :line-width    line-width
+                                                                   :to-line-width max-line-width}
+                                                       :onFocus   on-focus})
+                  :on-blur           #(on-input-blur {:component component
+                                                      :value     (or current-value value)
+                                                      :animation {:top           label-top
+                                                                  :to-top        (:label-bottom config)
+                                                                  :font-size     label-font-size
+                                                                  :to-font-size  (:label-font-large config)
+                                                                  :line-width    line-width
+                                                                  :to-line-width 0}
+                                                      :onBlur    on-blur})
+                  :on-change-text    (fn [text]
+                                       (r/set-state component {:current-value text})
+                                       (on-change-text text))
+                  :on-change         #(on-change %)
+                  :default-value     value
+                  :on-end-editing    (when on-end-editing
+                                       on-end-editing)}]
+     [view {:style    (st/underline-container line-color)
+            :onLayout #(r/set-state component {:max-line-width (get-width %)})}
+      [animated-view {:style (st/underline focus-line-color line-width)}]]
+     [text {:style (st/error-text error-color)} error]]))
+
+(defn text-input-with-label [_ _]
+  (let [component-data {:get-initial-state            get-initial-state
+                        :component-will-mount         component-will-mount
+                        :display-name                 "text-input-with-label"
+                        :reagent-render               reagent-render}]
+    ;(log/debug "Creating text-input-with-label component: " data)
+    (r/create-class component-data)))

--- a/src/status_im/components/text_input_with_label/view.cljs~
+++ b/src/status_im/components/text_input_with_label/view.cljs~
@@ -1,4 +1,4 @@
-(ns status-im.components.text-field.view
+(ns status-im.components.text-input-with-label.view
   (:require [clojure.string :as s]
             [re-frame.core :refer [subscribe dispatch dispatch-sync]]
             [reagent.core :as r]

--- a/src/status_im/contacts/views/contact_list.cljs
+++ b/src/status_im/contacts/views/contact_list.cljs
@@ -7,7 +7,7 @@
                                                 list-view
                                                 list-item]]
             [status-im.contacts.views.contact :refer [contact-view]]
-            [status-im.components.text-field.view :refer [text-field]]
+            [status-im.components.text-input-with-label.view :refer [text-input-with-label]]
             [status-im.components.status-bar :refer [status-bar]]
             [status-im.components.toolbar.view :refer [toolbar]]
             [status-im.components.toolbar.actions :as act]

--- a/src/status_im/contacts/views/new_contact.cljs
+++ b/src/status_im/contacts/views/new_contact.cljs
@@ -7,7 +7,7 @@
                                                 image
                                                 linear-gradient
                                                 touchable-highlight]]
-            [status-im.components.text-field.view :refer [text-field]]
+            [status-im.components.text-input-with-label.view :refer [text-input-with-label]]
             [status-im.utils.identicon :refer [identicon]]
             [status-im.components.status-bar :refer [status-bar]]
             [status-im.components.toolbar.view :refer [toolbar]]
@@ -85,7 +85,7 @@
   (let [error (when-not (str/blank? whisper-identity)
                 (validation-error-message whisper-identity current-account error))]
     [view button-input-container
-     [text-field
+     [text-input-with-label
       {:error          error
        :error-color    color-blue
        :input-style    st/qr-input

--- a/src/status_im/new_group/screen.cljs
+++ b/src/status_im/new_group/screen.cljs
@@ -9,7 +9,7 @@
                                                 touchable-highlight
                                                 list-view
                                                 list-item]]
-            [status-im.components.text-field.view :refer [text-field]]
+            [status-im.components.text-input-with-label.view :refer [text-input-with-label]]
             [status-im.components.styles :refer [color-blue
                                                  separator-color]]
             [status-im.components.status-bar :refer [status-bar]]
@@ -36,7 +36,7 @@
 (defview group-name-input []
   [new-chat-name [:get :new-chat-name]]
   [view
-   [text-field
+   [text-input-with-label
     {:error          (cond
                        (not (s/valid? ::v/not-empty-string new-chat-name))
                        (label :t/empty-group-chat-name)

--- a/src/status_im/profile/screen.cljs
+++ b/src/status_im/profile/screen.cljs
@@ -19,7 +19,7 @@
             [status-im.components.icons.custom-icons :refer [oct-icon]]
             [status-im.components.chat-icon.screen :refer [my-profile-icon]]
             [status-im.components.status-bar :refer [status-bar]]
-            [status-im.components.text-field.view :refer [text-field]]
+            [status-im.components.text-input-with-label.view :refer [text-input-with-label]]
             [status-im.components.selectable-field.view :refer [selectable-field]]
             [status-im.components.status-view.view :refer [status-view]]
             [status-im.components.list-selection :refer [share]]
@@ -89,7 +89,7 @@
              [my-profile-icon {:account {:photo-path photo-path
                                          :name       name}
                                :edit?   edit?}])]
-          [text-field
+          [text-input-with-label
            {:line-color       :white
             :focus-line-color :white
             :editable         edit?

--- a/src/status_im/transactions/screen.cljs
+++ b/src/status_im/transactions/screen.cljs
@@ -14,7 +14,7 @@
             [status-im.components.status-bar :refer [status-bar]]
             [status-im.components.toolbar.view :refer [toolbar]]
             [status-im.components.toolbar.styles :refer [toolbar-title-container]]
-            [status-im.components.text-field.view :refer [text-field]]
+            [status-im.components.text-input-with-label.view :refer [text-input-with-label]]
             [status-im.transactions.views.transaction-page :refer [transaction-page]]
             [status-im.transactions.styles :as st]
             [status-im.i18n :refer [label label-pluralize]]
@@ -49,7 +49,7 @@
        (for [transaction transactions]
          [transaction-page transaction]))]]
    [view st/form-container
-    [text-field
+    [text-input-with-label
      {:editable          true
       :error             (when wrong-password? (label :t/wrong-password))
       :error-color       :#ffffff80 #_:#7099e6


### PR DESCRIPTION
Refactoring: `text-field` component renamed to `text-input-with-label` regarding issue #793