### PR TITLE
Persist keyboard when typing command and moving to parameters (#776)

### DIFF
--- a/src/status_im/chat/handlers/commands.cljs
+++ b/src/status_im/chat/handlers/commands.cljs
@@ -1,6 +1,7 @@
 (ns status-im.chat.handlers.commands
   (:require [re-frame.core :refer [enrich after dispatch]]
             [status-im.utils.handlers :refer [register-handler] :as u]
+            [status-im.components.react :as react-comp]
             [status-im.components.status :as status]
             [status-im.models.commands :as commands]
             [status-im.chat.utils :refer [console? not-console?]]
@@ -295,7 +296,9 @@
     (fn [_ [_ {:keys [command]}]]
       (let [suggestions-trigger (keyword (:suggestions-trigger command))]
         (if (= :on-send suggestions-trigger)
-          (dispatch [:invoke-commands-suggestions!])
+          (do
+            (dispatch [:invoke-commands-suggestions!])
+            (react-comp/dismiss-keyboard!))
           (do
             (dispatch [:set-chat-ui-props :sending-disabled? true])
             (dispatch [:validate-command])))))))

--- a/src/status_im/chat/views/new_message.cljs
+++ b/src/status_im/chat/views/new_message.cljs
@@ -12,25 +12,10 @@
 (defn get-height [event]
   (.-height (.-layout (.-nativeEvent event))))
 
-(defn get-options [{:keys [type placeholder]} command-type]
-  (let [options (case (keyword type)
-                  :phone {:input-options {:keyboard-type "phone-pad"}}
-                  :password {:input-options {:secure-text-entry true}}
-                  :number {:input-options {:keyboard-type "numeric"}}
-                  ;; todo maybe nil is fine for now :)
-                  nil #_(throw (js/Error. "Unknown command type")))]
-    (if (= :response command-type)
-      (if placeholder
-        (assoc-in options [:input-options :placeholder] placeholder)
-        options)
-      (assoc-in options [:input-options :placeholder] ""))))
-
 (defview chat-message-input-view []
   [margin [:input-margin]
    command? [:command?]
    response-height [:response-height]
-   parameter [:get-command-parameter]
-   type [:command-type]
    suggestions [:get-suggestions]
    message-input-height [:get-message-input-view-height]]
   (let [on-top? (or (and (seq suggestions) (not command?))
@@ -41,5 +26,4 @@
                         (let [height (get-height event)]
                           (when (not= height message-input-height)
                             (dispatch [:set-message-input-view-height height]))))}
-     [plain-message-input-view
-      (when command? (get-options parameter type))]]))
+     [plain-message-input-view]]))

--- a/src/status_im/chat/views/response.cljs
+++ b/src/status_im/chat/views/response.cljs
@@ -25,7 +25,8 @@
             [status-im.utils.datetime :as dt]
             [status-im.utils.name :refer [shortened-name]]
             [status-im.utils.js-resources :as js-res]
-            [status-im.commands.utils :as cu]))
+            [status-im.commands.utils :as cu]
+            [taoensso.timbre :as log]))
 
 (defn drag-icon []
   [view st/drag-container

--- a/src/status_im/commands/handlers/jail.cljs
+++ b/src/status_im/commands/handlers/jail.cljs
@@ -81,12 +81,7 @@
 
 (reg-handler :suggestions-handler
   [(after #(dispatch [:animate-show-response]))
-   (after (print-error-message! "Error on param suggestions"))
-   (after (fn [_ [{:keys [command]}]]
-            (when (= :on-send (keyword (:suggestions-trigger command)))
-              #_(when (:webViewUrl (:returned result))
-                (dispatch [:set-soft-input-mode :pan]))
-              (r/dismiss-keyboard!))))]
+   (after (print-error-message! "Error on param suggestions"))]
   suggestions-handler!)
 (reg-handler :suggestions-event! (u/side-effect! suggestions-events-handler!))
 


### PR DESCRIPTION
Fixes #776
Also fixes bugs with /browse command on Android