### PR TITLE
[WIP] chats-list: toolbar styles, search and edit functions

### DIFF
--- a/src/status_im/android/platform.cljs
+++ b/src/status_im/android/platform.cljs
@@ -85,7 +85,8 @@
    :list-selection-fn            show-dialog
    :tabs                         {:tab-shadows? true}
    :chats                        {:action-button?       true
-                                  :new-chat-in-toolbar? false}
+                                  :new-chat-in-toolbar? true
+                                  :render-separator?    false}
    :contacts                     {:action-button?          true
                                   :new-contact-in-toolbar? false
                                   :uppercase-subtitles?    false

--- a/src/status_im/chats_list/screen.cljs
+++ b/src/status_im/chats_list/screen.cljs
@@ -14,54 +14,78 @@
             [status-im.components.drawer.view :refer [open-drawer]]
             [status-im.components.styles :refer [color-blue]]
             [status-im.components.status-bar :refer [status-bar]]
-            [status-im.components.toolbar.view :refer [toolbar-with-search]]
+            [status-im.components.toolbar.view :refer [toolbar toolbar-with-search]]
             [status-im.components.toolbar.actions :as act]
             [status-im.components.icons.custom-icons :refer [ion-icon]]
             [status-im.components.react :refer [linear-gradient]]
             [status-im.components.sync-state.offline :refer [offline-view]]
+            [status-im.components.context-menu :refer [context-menu]]
             [status-im.utils.listview :refer [to-datasource]]
             [status-im.chats-list.views.chat-list-item :refer [chat-list-item]]
             [status-im.i18n :refer [label]]
-            [status-im.utils.platform :refer [platform-specific]]
+            [status-im.utils.platform :refer [platform-specific
+                                              ios?]]
             [status-im.chats-list.styles :as st]
+            [status-im.components.toolbar.styles :as tst]
             [status-im.components.tabs.styles :refer [tabs-height]]))
 
-(defview toolbar-view []
-  [chats-scrolled? [:get :chats-scrolled?]]
-  (let [new-chat? (get-in platform-specific [:chats :new-chat-in-toolbar?])
-        actions   (if new-chat?
-                    [(act/add #(dispatch [:navigate-to :group-contacts :people]))])]
-    [toolbar-with-search
-     {:show-search?       false
-      :search-key         :chat-list
-      :title              (label :t/chats)
-      :search-placeholder (label :t/search-for)
-      :nav-action         (act/hamburger open-drawer)
-      :actions            actions
-      :style              (st/toolbar chats-scrolled?)}]))
+(def android-toolbar-popup-options
+  [{:text (label :t/edit) :value #(dispatch [:set-in [:chat-list-ui-props :edit?] true])}])
+
+(defn android-toolbar-actions []
+  [view st/toolbar-actions
+   [touchable-highlight
+    {:on-press #(dispatch [:set-in [:toolbar-search :show] true])}
+    [view st/toolbar-btn
+     [icon :search_dark]]]
+   [view st/toolbar-btn
+    [context-menu
+     [icon :options_dark]
+     android-toolbar-popup-options]]])
+
+(def ios-toolbar-popup-options
+  [{:text (label :t/edit-chats) :value #(dispatch [:set-in [:chat-list-ui-props :edit?] true])}
+   {:text (label :t/search-chats) :value #(dispatch [:set-in [:toolbar-search :show] true])}])
+
+(defn ios-toolbar-actions []
+  [view st/toolbar-actions
+   [view st/toolbar-btn
+    [context-menu
+     [icon :options_dark]
+     ios-toolbar-popup-options]]
+   [touchable-highlight
+    {:on-press #(dispatch [:navigate-to :group-contacts :people])}
+    [view st/toolbar-btn
+     [icon :add]]]])
+
+(defn toolbar-view []
+  [toolbar {:style         tst/toolbar-with-search
+            :title          (label :t/chats)
+            :nav-action     (act/hamburger open-drawer)
+            :custom-action  (if ios?
+                              (ios-toolbar-actions)
+                              (android-toolbar-actions))}])
+
+(defn toolbar-edit []
+  [toolbar {:style          tst/toolbar-with-search
+            :nav-action     (act/back #(dispatch [:set-in [:chat-list-ui-props :edit?] false]))
+            :title          (label :t/edit-chats)}])
+
+(defn toolbar-search []
+  [toolbar-with-search
+   {:show-search?       true
+    :search-key         :chat-list
+    :title              (label :t/chats)
+    :search-placeholder (label :t/search-for)
+    :style              (st/toolbar)}])
 
 (defn chats-action-button []
   [action-button {:button-color color-blue
                   :offset-x     16
                   :offset-y     22
                   :hide-shadow  true
-                  :spacing      13}
-   [action-button-item
-    {:title       (label :t/new-chat)
-     :buttonColor :#9b59b6
-     :onPress     #(dispatch [:navigate-to :group-contacts :people])}
-    [ion-icon {:name  :md-create
-               :style st/create-icon}]]
-   [action-button-item
-    {:title       (label :t/new-group-chat)
-     :buttonColor :#1abc9c
-     :onPress     #(dispatch [:navigate-to :new-group])}
-    [icon :private_group_big st/group-icon]]
-   [action-button-item
-    {:title       (label :t/new-public-group-chat)
-     :buttonColor :#1abc9c
-     :onPress     #(dispatch [:navigate-to :new-public-group])}
-    [icon :public_group_big st/group-icon]]])
+                  :spacing      13
+                  :on-press     #(dispatch [:navigate-to :group-contacts :people])}])
 
 (defn chat-shadow-item []
   [view {:height 3}
@@ -69,12 +93,17 @@
                      :colors st/gradient-top-bottom-shadow}]])
 
 (defview chats-list []
-  [chats [:get :chats]]
+  [chats   [:filtered-chats]
+   edit?   [:get-in [:chat-list-ui-props :edit?]]
+   search? [:get-in [:toolbar-search :show]]]
   [view st/chats-container
-   [toolbar-view]
+   (cond
+     edit?   [toolbar-edit]
+     search? [toolbar-search]
+     :else   [toolbar-view])
    [list-view {:dataSource      (to-datasource chats)
                :renderRow       (fn [[id :as row] _ _]
-                                  (list-item ^{:key id} [chat-list-item row]))
+                                  (list-item ^{:key id} [chat-list-item row edit?]))
                :renderFooter    #(list-item [chat-shadow-item])
                :renderSeparator #(list-item
                                    (when (< %2 (- (count chats) 1))
@@ -82,6 +111,8 @@
                                      [view st/chat-separator-wrapper
                                       [view st/chat-separator-item]]))
                :style           st/list-container}]
-   (when (get-in platform-specific [:chats :action-button?])
+   (when (and (not edit?)
+              (not search?)
+              (get-in platform-specific [:chats :action-button?]))
      [chats-action-button])
    [offline-view]])

--- a/src/status_im/chats_list/styles.cljs
+++ b/src/status_im/chats_list/styles.cljs
@@ -11,10 +11,8 @@
                                                          toolbar-background2]]
             [status-im.utils.platform :as p]))
 
-(defn toolbar [chats-scrolled?]
-  (merge {:background-color (if chats-scrolled?
-                              toolbar-background1
-                              toolbar-background2)}
+(defn toolbar []
+  (merge {:background-color toolbar-background1}
          (get-in p/platform-specific [:component-styles :toolbar])))
 
 (def gradient-top-bottom-shadow
@@ -135,6 +133,16 @@
   (merge (get-in p/platform-specific [:component-styles :main-tab-list])
          {:background-color color-light-gray}))
 
+(def toolbar-actions
+  {:flex-direction :row
+   :padding-right  14})
+
+(def toolbar-btn
+  {:width          24
+   :height         56
+   :margin-left    24
+   :alignItems     :center
+   :justifyContent :center})
 
 (def create-icon
   {:fontSize 20

--- a/src/status_im/chats_list/subs.cljs
+++ b/src/status_im/chats_list/subs.cljs
@@ -1,0 +1,19 @@
+(ns status-im.chats-list.subs
+  (:require-macros [reagent.ratom :refer [reaction]])
+  (:require [re-frame.core :refer [register-sub subscribe]]
+            [clojure.string :as str]))
+
+(defn search-filter [text item]
+  (let [name (-> (or (:name item) "")
+                 (str/lower-case))
+        text (str/lower-case text)]
+    (not= (str/index-of name text) nil)))
+
+(register-sub :filtered-chats
+  (fn [_ _]
+    (let [chats       (subscribe [:get :chats])
+          search-text (subscribe [:get-in [:toolbar-search :text]])]
+      (reaction
+       (if @search-text
+         (filter #(search-filter @search-text (second %)) @chats)
+         @chats)))))

--- a/src/status_im/chats_list/views/chat_list_item.cljs
+++ b/src/status_im/chats_list/views/chat_list_item.cljs
@@ -6,7 +6,7 @@
                                                 touchable-highlight]]
             [status-im.chats-list.views.inner-item :refer [chat-list-item-inner-view]]))
 
-(defn chat-list-item [[chat-id chat]]
+(defn chat-list-item [[chat-id chat] edit?]
   [touchable-highlight {:on-press #(dispatch [:navigate-to :chat chat-id])}
    [view
-    [chat-list-item-inner-view (assoc chat :chat-id chat-id)]]])
+    [chat-list-item-inner-view (assoc chat :chat-id chat-id) edit?]]])

--- a/src/status_im/chats_list/views/inner_item.cljs
+++ b/src/status_im/chats_list/views/inner_item.cljs
@@ -4,6 +4,7 @@
             [clojure.string :as str]
             [status-im.components.react :refer [view image icon text]]
             [status-im.components.chat-icon.screen :refer [chat-icon-view-chat-list]]
+            [status-im.components.context-menu :refer [context-menu]]
             [status-im.models.commands :refer [parse-command-message-content]]
             [status-im.chats-list.styles :as st]
             [status-im.utils.utils :refer [truncate-str]]
@@ -76,9 +77,16 @@
             :font  :medium}
       unviewed-messages]]))
 
+(defn options-btn [chat-id]
+  (let [options [{:value #(dispatch [:remove-chat chat-id]) :text (label :t/delete-chat)}]]
+    [view st/more-btn
+     [context-menu
+      [icon :options_gray]
+      options]]))
+
 (defn chat-list-item-inner-view [{:keys [chat-id name color last-message
-                                         online group-chat contacts public?]
-                                  :as chat}]
+                                         online group-chat contacts public?] :as chat}
+                                 edit?]
   (let [last-message (or (first (sort-by :clock-value > (:messages chat)))
                          last-message)
         name         (or (get-contact-translated chat-id :name name)
@@ -108,9 +116,12 @@
          [text {:style st/memebers-text}
           (label-pluralize (inc (count contacts)) :t/members)])]
       [message-content-text last-message]]
-     [view
-      (when last-message
-        [view st/status-container
-         [message-status chat last-message]
-         [message-timestamp last-message]])
-      [unviewed-indicator chat-id]]]))
+     (if edit?
+       [view st/status-container
+        [options-btn chat-id]]
+       [view
+        (when last-message
+          [view st/status-container
+           [message-status chat last-message]
+           [message-timestamp last-message]])
+        [unviewed-indicator chat-id]])]))

--- a/src/status_im/subs.cljs
+++ b/src/status_im/subs.cljs
@@ -2,6 +2,7 @@
   (:require-macros [reagent.ratom :refer [reaction]])
   (:require [re-frame.core :refer [register-sub subscribe]]
             status-im.chat.subs
+            status-im.chats-list.subs
             status-im.group-settings.subs
             status-im.discover.subs
             status-im.contacts.subs

--- a/src/status_im/translations/en.cljs
+++ b/src/status_im/translations/en.cljs
@@ -120,8 +120,11 @@
    ;chats
    :chats                                 "Chats"
    :new-chat                              "New chat"
+   :delete-chat                           "Delete chat"
    :new-group-chat                        "New group chat"
-   :new-public-group-chat                 "Join public group chat"
+   :new-public-group-chat                 "Join public chat"
+   :edit-chats                            "Edit chats"
+   :search-chats                          "Search chats"
    :empty-topic                           "Empty topic"
    :topic-format                          "Wrong format [a-z0-9\\-]+"
    :public-group-topic                    "Topic"


### PR DESCRIPTION
### Summary:

What this contains:
- Chats list toolbar background color
- Search is now functioning (only by name)
- Action button now goes straight to "Start new group" screen.
- Can delete chats, using Edit function in the toolbar.

What isn't covered:
- Toolbar title positioning (@flexsurfer is doing that globally)
- Popups styling: smaller edit popup, red "Delete chat" text (to avoid duplicating @flexsurfer work).

#### Notes
- Edit button in each list item: it is still in old style, will fix when #824 is merged.

status: wip

