### PR TITLE
status-dev-cli removed

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
     "react-native-webview-bridge": "github:status-im/react-native-webview-bridge#0.33.7",
     "readable-stream": "^1.0.33",
     "realm": "^0.14.3",
-    "status-dev-cli": "^1.1.3",
     "stream-browserify": "^1.0.0",
     "timers-browserify": "^1.4.2",
     "tty-browserify": "0.0.0",

--- a/postinstall.sh
+++ b/postinstall.sh
@@ -12,10 +12,3 @@ if ! [ -f re-natal ]; then
 else
   echo "re-natal exists"
 fi
-
-# symlink for status-dev-cli
-if ! [ -f status-dev-cli ]; then
-  ln -s ./node_modules/status-dev-cli/index.js status-dev-cli;
-else
-  echo "status-dev-cli exists"
-fi


### PR DESCRIPTION
The newest version of `status-dev-cli` should be installed globally, so there is no need to include it to the main application.