### PR TITLE
accounts, login, screen: Android keyboard for Login Password lowercas…

### DIFF
--- a/src/status_im/accounts/login/screen.cljs
+++ b/src/status_im/accounts/login/screen.cljs
@@ -48,6 +48,7 @@
      :label-color       "#ffffff80"
      :line-color        :white
      :input-style       st/input-style
+     :auto-capitalize   :none
      :on-change-text    #(do
                           (dispatch [:set-in [:login :password] %])
                           (dispatch [:set-in [:login :error] ""]))}]])


### PR DESCRIPTION
…e (#878)

[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)
fixes #878 

### Summary:
The default prop for `TextInput` in `components.text-field.view` is `:auto-capitalize :sentences`, a fine default for most non-password areas. In `accounts.login.screen` we can just pass in `:auto-capitalize :none`. iOS was lowercase anyway.

https://facebook.github.io/react-native/docs/textinput.html#autocapitalize

### Steps to test:
- Open Status in Android
- Tap on name 
- Tap on password field.
- Keyboard should be lowercase

[comment]: # (PRs will only be accepted if squashed into single commit.)
status: <ready>
