### PR TITLE
resources, commands.js, replace() comma to period

### DIFF
--- a/resources/commands.js
+++ b/resources/commands.js
@@ -918,7 +918,7 @@ status.command({
     },
     validator: function(params) {
         try {
-            var val = web3.toWei(params.amount, "ether");
+            var val = web3.toWei(params.amount.replace(",", "."), "ether");
             if (val <= 0) { throw new Error(); }
         } catch (err) {
             return {


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)
fixes #874 

### Summary:
[comment]: # (Summarise the problem and how the pull request solves it)

The error appeared on iOS and Android, Status 0.9.3.

`resources/command.js` defines JavaScript `send` and `receive` functions, which are loaded up into the re-frame database by `commands/handlers/loading.cljs`. `send()`'s validator calls `replace()` on the amount, but `receive()` did not. The fix simply calls `replace()` on `receive()` as well, so its validator acts like `send`'s validator.

Note that this now applies to all languages, not just German: any language-user can type in "0,5" without error, just like any language-user could send "0,5".


### Steps to test:
- Open Status
- Log in
- Request "0,5" Eth.
- In English language, should show you have requested "0.5". In German, "0,5".

[comment]: # (PRs will only be accepted if squashed into single commit.)
status: <ready>
