### PR TITLE
added a datetime-ago-format 

### DIFF
--- a/src/status_im/translations/de.cljs
+++ b/src/status_im/translations/de.cljs
@@ -45,6 +45,7 @@
    :status-failed                         "Fehlgeschlagen"
 
    ;datetime
+   :datetime-ago-format                   "{{ago}} {{number}} {{time-intervals}}"
    :datetime-second                       {:one   "Sekunde"
                                            :other "Sekunden"}
    :datetime-minute                       {:one   "Minute"
@@ -53,7 +54,7 @@
                                            :other "Stunden"}
    :datetime-day                          {:one   "Tag"
                                            :other "Tage"}
-   :datetime-multiple                     "s"     
+   :datetime-multiple                     "s"
    :datetime-ago                          "vor"
    :datetime-yesterday                    "Gestern"
    :datetime-today                        "Heute"
@@ -217,6 +218,6 @@
    :one-more-item                         "Noch ein Objekt"
    :fee                                   "Gebühr"
    :value                                 "Wert"
-                                          
-   ;:webview                              
+
+   ;:webview
    :web-view-error                        "Ups, Fehler"})

--- a/src/status_im/translations/en.cljs
+++ b/src/status_im/translations/en.cljs
@@ -51,6 +51,7 @@
    :status-failed                         "Failed"
 
    ;datetime
+   :datetime-ago-format                   "{{number}} {{time-intervals}} {{ago}}"
    :datetime-second                       {:one   "second"
                                            :other "seconds"}
    :datetime-minute                       {:one   "minute"

--- a/src/status_im/translations/es.cljs
+++ b/src/status_im/translations/es.cljs
@@ -45,6 +45,7 @@
    :status-failed                         "Fallido"
 
    ;datetime
+   :datetime-ago-format                   "{{ago}} {{number}} {{time-intervals}}"
    :datetime-second                       {:one   "segundo"
                                            :other "segundos"}
    :datetime-minute                       {:one   "minuto"

--- a/src/status_im/utils/datetime.cljs
+++ b/src/status_im/utils/datetime.cljs
@@ -40,7 +40,9 @@
 
 (defn format-time-ago [diff unit]
   (let [name (label-pluralize diff (:name unit))]
-    (gstring/format "%s %s %s" diff name (label :t/datetime-ago))))
+    (label :t/datetime-ago-format {:ago (label :t/datetime-ago)
+                                   :number diff
+                                   :time-intervals name})))
 
 (defn time-ago [time]
   (let [diff (t/in-seconds (t/interval time (t/now)))]


### PR DESCRIPTION
Added a datetime-ago-format in translations to support different sentence order.

[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)
fixes #621 

### Summary:
[comment]: # (Summarise the problem and how the pull request solves it)
Default format is "{{number}} {{time-intervals}} {{ago}}" (i.e. "1 minute ago"), but for some locales you can choose different order, for example "{{ago}} {{number}} {{time-intervals}}" for de and es ( "vor 1 Minute", "hace 1 minuto")


### Steps to test:
- change phone locale to "de"
- Open Status
- check if someone's toolbar status says something like "vor 1 Minute"
- change locale to "en"
- Open Status
- check if someone's toolbar status says something like  "1 minute ago"
- change locale to "ua"
- Open Status
- check if someone's toolbar status says something like  "1 хвилина тому" (falls back to en locale by defauls)


[comment]: # (PRs will only be accepted if squashed into single commit.)
status: ready

