### PR TITLE
Bug/chat list ui issues

### DIFF
--- a/src/status_im/chats_list/screen.cljs
+++ b/src/status_im/chats_list/screen.cljs
@@ -53,9 +53,11 @@
   [toolbar {:nav-action (act/back #(dispatch [:set-in [:chat-list-ui-props :edit?] false]))
             :title      (label :t/edit-chats)}])
 
-(defn toolbar-search []
+(defview toolbar-search []
+  [search-text [:get-in [:toolbar-search :text]]]
   [toolbar-with-search
    {:show-search?       true
+    :search-text        search-text
     :search-key         :chat-list
     :title              (label :t/chats)
     :search-placeholder (label :t/search-for)}])

--- a/src/status_im/ios/platform.cljs
+++ b/src/status_im/ios/platform.cljs
@@ -205,7 +205,7 @@
 (defn action-sheet-options [options]
   (let [destructive-opt-index (utils/first-index :destructive? options)]
     (clj->js (merge {:options           (mapv :text options)
-                     :cancelButtonIndex (count options)}
+                     :cancelButtonIndex (dec (count options))}
                     (when destructive-opt-index {:destructiveButtonIndex destructive-opt-index})))))
 
 (defn show-action-sheet [{:keys [options callback]}]


### PR DESCRIPTION
fixes #900

### Summary:
* Chats list search now shows a "clear" button
* The iOS menu (ActionSheet) now closes when user taps outside, and the cancel button is styled properly.

status: ready