### PR TITLE
Bug: save button behind keyboard in iOS #924

### DIFF
--- a/src/status_im/components/react.cljs
+++ b/src/status_im/components/react.cljs
@@ -30,6 +30,7 @@
 (def list-view-class (get-class "ListView"))
 (def scroll-view (get-class "ScrollView"))
 (def web-view (get-class "WebView"))
+(def keyboard-avoiding-view (get-class "KeyboardAvoidingView"))
 
 (def text-class (get-class "Text"))
 (def text-input-class (get-class "TextInput"))

--- a/src/status_im/new_group/screen_private.cljs
+++ b/src/status_im/new_group/screen_private.cljs
@@ -4,6 +4,7 @@
             [status-im.contacts.views.contact :refer [contact-view]]
             [status-im.components.react :refer [view
                                                 scroll-view
+                                                keyboard-avoiding-view
                                                 list-view
                                                 list-item]]
             [status-im.components.confirm-button :refer [confirm-button]]
@@ -18,6 +19,7 @@
                                                      separator]]
             [status-im.new-group.validations :as v]
             [status-im.i18n :refer [label]]
+            [status-im.utils.platform :refer [ios?]]
             [cljs.spec :as s]))
 
 (def contacts-limit 3)
@@ -55,16 +57,17 @@
    type [:get :group-type]]
   (let [save-btn-enabled? (and (s/valid? ::v/name group-name)
                                (not= group-name (:name group)))]
-    [view st/group-container
+    [(if ios? keyboard-avoiding-view view) (merge {:behavior :padding}
+                                                  st/group-container)
      [group-toolbar type true]
      [group-name-view]
-     [add-btn #(dispatch [:navigate-to :add-contacts-toggle-list])]
-     [group-contacts-view group]
-     [view st/separator]
-     [delete-btn #(do
-                    (dispatch [:delete-group])
-                    (dispatch [:navigate-to-clean :contact-list]))]
-     [view {:flex 1}]
+     [view {:flex 1}
+      [add-btn #(dispatch [:navigate-to :add-contacts-toggle-list])]
+      [group-contacts-view group]
+      [view st/separator]
+      [delete-btn #(do
+                     (dispatch [:delete-group])
+                     (dispatch [:navigate-to-clean :contact-list]))]]
      (when save-btn-enabled?
        [confirm-button (label :t/save) save])]))
 
@@ -83,7 +86,8 @@
    group-name [:get :new-chat-name]
    group-type [:get :group-type]]
   (let [save-btn-enabled? (and (s/valid? ::v/name group-name) (pos? (count contacts)))]
-    [view st/group-container
+    [(if ios? keyboard-avoiding-view view) (merge {:behavior :padding}
+                                                  st/group-container)
      [group-toolbar group-type false]
      [group-name-view]
      [view {:flex 1}

--- a/src/status_im/new_group/views/chat_group_settings.cljs
+++ b/src/status_im/new_group/views/chat_group_settings.cljs
@@ -4,6 +4,7 @@
     [status-im.contacts.views.contact :refer [contact-view]]
     [status-im.components.react :refer [view
                                         scroll-view
+                                        keyboard-avoiding-view
                                         icon
                                         touchable-highlight]]
     [status-im.components.confirm-button :refer [confirm-button]]
@@ -17,6 +18,7 @@
                                              separator]]
     [status-im.new-group.validations :as v]
     [status-im.i18n :refer [label]]
+    [status-im.utils.platform :refer [ios?]]
     [cljs.spec :as s]))
 
 (def contacts-limit 3)
@@ -65,7 +67,8 @@
    type [:get :group-type]]
   (let [save-btn-enabled? (and (s/valid? ::v/name new-chat-name)
                                (not= new-chat-name chat-name))]
-    [view st/group-container
+    [(if ios? keyboard-avoiding-view view) (merge {:behavior :padding}
+                                                  st/group-container)
      [view {:flex 1}
       [group-toolbar type true]
       [scroll-view

--- a/src/status_im/new_group/views/contact_toggle_list.cljs
+++ b/src/status_im/new_group/views/contact_toggle_list.cljs
@@ -3,6 +3,7 @@
   (:require [re-frame.core :refer [dispatch]]
     [status-im.contacts.views.contact :refer [contact-view]]
     [status-im.components.react :refer [view
+                                        keyboard-avoiding-view
                                         text
                                         list-view
                                         list-item]]
@@ -10,6 +11,7 @@
     [status-im.components.status-bar :refer [status-bar]]
     [status-im.components.toolbar-new.view :refer [toolbar-with-search]]
     [status-im.utils.listview :refer [to-datasource]]
+    [status-im.utils.platform :refer [ios?]]
     [status-im.new-group.views.toggle-contact :refer [group-toggle-contact
                                                       group-toggle-participant]]
     [status-im.components.common.common :refer [separator]]
@@ -50,7 +52,8 @@
   [contacts [:all-added-group-contacts-filtered]
    selected-contacts-count [:selected-contacts-count]
    group-type [:get :group-type]]
-  [view st/group-container
+  [(if ios? keyboard-avoiding-view view) (merge {:behavior :padding}
+                                                st/group-container)
    [status-bar]
    [toggle-list-toolbar
     (label (if (= group-type :contact-group)
@@ -74,7 +77,8 @@
   [contacts [:all-group-not-added-contacts-filtered]
    group [:get-contact-group]
    selected-contacts-count [:selected-contacts-count]]
-  [view st/group-container
+  [(if ios? keyboard-avoiding-view view) (merge {:behavior :padding}
+                                                st/group-container)
    [status-bar]
    [toggle-list-toolbar (:name group) selected-contacts-count]
    [view {:flex 1}
@@ -96,7 +100,8 @@
   [contacts [:contacts-filtered :all-new-contacts]
    chat-name [:chat :name]
    selected-contacts-count [:selected-participants-count]]
-  [view st/group-container
+  [(if ios? keyboard-avoiding-view view) (merge {:behavior :padding}
+                                                st/group-container)
    [status-bar]
    [toggle-list-toolbar chat-name selected-contacts-count]
    [view {:flex 1}

--- a/src/status_im/profile/edit/screen.cljs
+++ b/src/status_im/profile/edit/screen.cljs
@@ -14,9 +14,11 @@
             [status-im.profile.validations :as v]
             [status-im.components.react :refer [view
                                                 scroll-view
+                                                keyboard-avoiding-view
                                                 text
                                                 touchable-highlight
                                                 text-input]]
+            [status-im.utils.platform :refer [ios?]]
             [cljs.spec :as s]))
 
 (defn edit-my-profile-toolbartoolbar []
@@ -77,7 +79,8 @@
         profile-edit-data-changed? (or (not= (:name current-account) (:name changed-account))
                                        (not= (:status current-account) (:status changed-account))
                                        (not= (:photo-path current-account) (:photo-path changed-account)))]
-    [view st/profile
+    [(if ios? keyboard-avoiding-view view) (merge {:behavior :padding}
+                                                  st/profile)
      [status-bar]
      [edit-my-profile-toolbartoolbar]
      [view {:flex 1}


### PR DESCRIPTION
fixes #924 

### Summary:
Save button now shows correctly above the virtual keyboard when it pops up, in all screens containing it:
- Create group chat
- Group chat settings
- Add contact to group chat
- Create contact group
- Edit contact group
- Edit profile

status: ready