### PR TITLE
Bug: contact group's long title style #923

### DIFF
--- a/src/status_im/android/platform.cljs
+++ b/src/status_im/android/platform.cljs
@@ -66,8 +66,9 @@
                                                           :margin-top       0}
                            :contact-list-title           {:color     styles/text4-color
                                                           :font-size 14}}
-   :contacts              {:subtitle     {:color     styles/color-gray4
-                                          :font-size 14}
+   :contacts              {:subtitle     {:color       styles/color-gray4
+                                          :font-size   14
+                                          :flex-shrink 1}
                            :subtitle-count {:color     styles/color-gray4
                                             :font-size 14}
                            :info-container {:margin-left 16}
@@ -79,8 +80,8 @@
                                           :height        17}
                            :group-header {:flexDirection   :row
                                           :alignItems      :center
-                                          :height          56
-                                          :padding-top     10
+                                          :padding-top     28
+                                          :padding-bottom  20
                                           :padding-left    16
                                           :padding-right   14
                                           :backgroundColor styles/color-light-gray}
@@ -125,14 +126,7 @@
                                                  :flex-direction :row
                                                  :align-items    :center}
                            :settings-group-container {:margin-top    23}}
-   :reorder-groups        {:order-item-container     {:height           56
-                                                      :background-color styles/color-white}
-                           :order-item-icon          {:padding-right 16}
-                           :order-item-label         {:padding-left   16
-                                                      :font-size      16
-                                                      :color          styles/color-black
-                                                      :line-height    24}
-                           :reorder-list-container   {:padding-top 16}
+   :reorder-groups        {:reorder-list-container   {:padding-top 16}
                            :order-item-contacts      {:font-size   16
                                                       :line-height 24}
                            :add-to-contacts-text     {:font-size      14

--- a/src/status_im/contacts/styles.cljs
+++ b/src/status_im/contacts/styles.cljs
@@ -130,6 +130,7 @@
 (def more-btn
   {:width          24
    :height         24
+   :margin-left    16
    :alignItems     :center
    :justifyContent :center})
 

--- a/src/status_im/ios/platform.cljs
+++ b/src/status_im/ios/platform.cljs
@@ -73,7 +73,8 @@
                                                           :font-size 16}}
    :contacts              {:subtitle     {:color          styles/text1-color
                                           :font-size      16
-                                          :letter-spacing -0.2}
+                                          :letter-spacing -0.2
+                                          :flex-shrink    1}
                            :subtitle-count {:color          styles/color-gray4
                                             :font-size      16
                                             :letter-spacing -0.2}
@@ -85,9 +86,10 @@
                            :group-header {:flexDirection   :row
                                           :alignItems      :center
                                           :margin-top      24
+                                          :padding-top     19
+                                          :padding-bottom  15
                                           :padding-left    16
                                           :padding-right   16
-                                          :height          53
                                           :backgroundColor styles/color-white}
                            :show-all     {:padding-left    72
                                           :height          64}
@@ -150,12 +152,6 @@
                                                    :border-radius    50}}
    :reorder-groups        {:order-item-separator     {:margin-left      16
                                                       :opacity          0.5}
-                           :order-item-container     {:height 63}
-                           :order-item-icon          {:padding-right 20}
-                           :order-item-label         {:padding-left   16
-                                                      :font-size      17
-                                                      :line-height    20
-                                                      :letter-spacing -0.2}
                            :order-item-contacts      {:font-size      17
                                                       :line-height    20
                                                       :letter-spacing -0.2}}

--- a/src/status_im/new_group/styles.cljs
+++ b/src/status_im/new_group/styles.cljs
@@ -1,6 +1,8 @@
 (ns status-im.new-group.styles
+  (:require-macros [status-im.utils.styles :refer [defstyle]])
   (:require [status-im.components.styles :refer [color-white
                                                  color-blue
+                                                 color-black
                                                  text1-color
                                                  text2-color
                                                  color-light-blue
@@ -165,21 +167,34 @@
 (def order-item-container
   {:background-color color-white})
 
-(def order-item-inner-container
-  (merge {:flex-direction :row
-          :align-items    :center}
-         (ps-reorder :order-item-container)))
+(defstyle order-item-inner-container
+  {:flex-direction :row
+   :align-items    :center
+   :android        {:padding-top      17
+                    :padding-bottom   15
+                    :min-height       56
+                    :background-color color-white}
+   :ios            {:padding-vertical 22
+                    :min-height       63}})
 
-(def order-item-label
-  (ps-reorder :order-item-label))
+(defstyle order-item-label
+  {:padding-left 16
+   :flex-shrink  1
+   :android      {:font-size   16
+                  :color       color-black
+                  :line-height 24}
+   :ios          {:font-size      17
+                  :line-height    20
+                  :letter-spacing -0.2}})
 
 (def order-item-contacts
   (merge (ps-reorder :order-item-contacts)
          {:padding-left 8
           :color color-gray4}))
 
-(def order-item-icon
-  (ps-reorder :order-item-icon))
+(defstyle order-item-icon
+  {:android {:padding-horizontal 16}
+   :ios     {:padding-horizontal 20}})
 
 (def order-item-separator-wrapper
   {:background-color color-white})


### PR DESCRIPTION
fixes #923 

### Summary:
- Fixes styles when the contact group name is too long.
- Edit button now appears correctly.
- Also fixed same issues in Reorder Groups screen.

Fixed and tested in Android and iOS

status: ready

