### PR TITLE
Bug: share dialog crash #920

### DIFF
--- a/src/status_im/android/platform.cljs
+++ b/src/status_im/android/platform.cljs
@@ -172,7 +172,7 @@
 (defn show-dialog [{:keys [title options callback]}]
   (let [dialog (new react-native-dialogs)]
     (.set dialog (clj->js {:title         title
-                           :items         options
+                           :items         (mapv :text options)
                            :itemsCallback callback}))
     (.show dialog)))
 

--- a/src/status_im/components/context_menu.cljs
+++ b/src/status_im/components/context_menu.cljs
@@ -27,13 +27,11 @@
 (def list-selection-fn (:list-selection-fn platform-specific))
 
 (defn open-ios-menu [options]
-  (let [cancel-option {:text (label :t/cancel)}
-        options       (conj options cancel-option)]
-    (list-selection-fn {:options  options
-                        :callback (fn [index]
-                                    (when (< index (count options))
-                                      (when-let [handler (:value (nth options index))]
-                                        (handler))))}))
+  (list-selection-fn {:options  options
+                      :callback (fn [index]
+                                  (when (< index (count options))
+                                    (when-let [handler (:value (nth options index))]
+                                      (handler))))})
   nil)
 
 (defn context-menu [trigger options]

--- a/src/status_im/components/list_selection.cljs
+++ b/src/status_im/components/list_selection.cljs
@@ -17,7 +17,7 @@
 (defn share [text dialog-title]
   (let [list-selection-fn (:list-selection-fn platform-specific)]
     (list-selection-fn {:title       dialog-title
-                        :options     [(label :t/sharing-copy-to-clipboard) (label :t/sharing-share)]
+                        :options     (share-options text)
                         :callback    (fn [index]
                                        (case index
                                          0 (copy-to-clipboard text)

--- a/src/status_im/ios/platform.cljs
+++ b/src/status_im/ios/platform.cljs
@@ -1,5 +1,6 @@
 (ns status-im.ios.platform
   (:require [status-im.components.styles :as styles]
+            [status-im.i18n :refer [label]]
             [status-im.utils.utils :as utils]))
 
 (def component-styles
@@ -203,9 +204,11 @@
 (def react-native (js/require "react-native"))
 
 (defn action-sheet-options [options]
-  (let [destructive-opt-index (utils/first-index :destructive? options)]
+  (let [destructive-opt-index (utils/first-index :destructive? options)
+        cancel-option         {:text (label :t/cancel)}
+        options               (conj options cancel-option)]
     (clj->js (merge {:options           (mapv :text options)
-                     :cancelButtonIndex (count options)}
+                     :cancelButtonIndex (dec (count options))}
                     (when destructive-opt-index {:destructiveButtonIndex destructive-opt-index})))))
 
 (defn show-action-sheet [{:keys [options callback]}]


### PR DESCRIPTION
fixes #920 

### Summary:
The share dialog was broken everywhere in iOS, not just in chat messages. It is fixed now.

#### Note:
I moved back the cancel button code from `context-menu` to iOS `show-action-sheet`, so that all iOS menus have the cancel button automatically.

[comment]: # (PRs will only be accepted if squashed into single commit.)
status: ready

