### PR TITLE
Interactive suggestions

### DIFF
--- a/bots/console/bot.js
+++ b/bots/console/bot.js
@@ -332,7 +332,7 @@ function jsSuggestions(params, context) {
                 ])]);
         if (suggestion.pressValue) {
             suggestionMarkup = status.components.touchable({
-                    onPress: [status.events.SET_VALUE, suggestion.pressValue]},
+                    onPress: status.components.dispatch([status.events.SET_VALUE, suggestion.pressValue])},
                 suggestionMarkup);
         }
         sugestionsMarkup.push(suggestionMarkup);
@@ -444,7 +444,7 @@ function phoneSuggestions(params, context) {
 
     suggestions = ph.map(function (phone) {
         return status.components.touchable(
-            {onPress: [status.events.SET_VALUE, phone.number]},
+            {onPress: status.components.dispatch([status.events.SET_VALUE, phone.number])},
             status.components.view(suggestionContainerStyle,
                 [status.components.view(suggestionSubContainerStyle,
                     [
@@ -512,7 +512,7 @@ var faucets = [
 function faucetSuggestions(params) {
     var suggestions = faucets.map(function(entry) {
         return status.components.touchable(
-            {onPress: [status.events.SET_VALUE, entry.url]},
+            {onPress: status.components.dispatch([status.events.SET_VALUE, entry.url])},
             status.components.view(
                 suggestionContainerStyle,
                 [status.components.view(
@@ -583,7 +583,7 @@ status.command({
 function debugSuggestions(params) {
     var suggestions = ["On", "Off"].map(function(entry) {
         return status.components.touchable(
-            {onPress: [status.events.SET_VALUE, entry]},
+            {onPress: status.components.dispatch([status.events.SET_VALUE, entry])},
             status.components.view(
                 suggestionContainerStyle,
                 [status.components.view(

--- a/bots/demo_bot/bot.js
+++ b/bots/demo_bot/bot.js
@@ -1,0 +1,99 @@
+function round(n) {
+    return Math.round(n * 100) / 100;
+}
+
+function doubledValueLabel(params) {
+    var value = round(params.value);
+    return "sliderValue = " + value +
+        "; (2 * sliderValue) = " + (2 * value);
+}
+
+status.defineSubscription(
+    // the name of subscription and the name of the value in bot-db
+    // associated with this subscription
+    "doubledValue",
+    // the map of values on which subscription depends: keys are arbitrary names
+    // and values are db paths to another value
+    {value: ["sliderValue"]},
+    // the function which will be called as reaction on changes of values above,
+    // should be pure. Returned result will be associated with subscription in bot-db
+    doubledValueLabel
+);
+
+status.defineSubscription(
+    "roundedValue",
+    {value: ["sliderValue"]},
+    function (params) {
+        return round(params.value);
+    }
+)
+
+function superSuggestion(params, context) {
+    var balance = parseFloat(web3.fromWei(web3.eth.getBalance(context.from), "ether"));
+    var defaultSliderValue = balance / 2;
+
+    var view = ["view", {},
+        ["text", {}, "Balance " + balance + " ETH"],
+        ["text", {}, ["subscribe", ["doubledValue"]]],
+        ["slider", {
+            maximumValue: ["subscribe", ["balance"]],
+            value: defaultSliderValue,
+            minimumValue: 0,
+            onSlidingComplete: ["dispatch", ["set", "sliderValue"]],
+            step: 0.05
+        }],
+        ['touchable',
+            {onPress: ['dispatch', ["set-value-from-db", "roundedValue"]]},
+            ["view", {}, ["text", {}, "Set value"]]
+        ],
+        ["text", {style: {color: "red"}}, ["subscribe", ["validationText"]]]
+    ];
+
+    status.setDefaultDb({
+        sliderValue: defaultSliderValue,
+        doubledValue: doubledValueLabel({value: defaultSliderValue})
+    });
+
+    var validationText = "";
+
+    if (isNaN(params.message)) {
+        validationText = "That's not a float number!";
+    } else if (parseFloat(params.message) > balance) {
+        validationText =
+            "Input value is too big!" +
+            " You have only " + balance + " ETH on your balance!";
+    }
+
+    status.updateDb({
+        balance: balance,
+        validationText: validationText
+    });
+
+    status.setSuggestions(view);
+};
+
+status.on("text-change", superSuggestion);
+status.on("message", function (params, context) {
+    if (isNaN(params.message)) {
+        status.sendMessage("Seems that you don't want to send money :(");
+        return;
+    }
+
+    var balance = web3.eth.getBalance(context.from);
+    var value = parseFloat(params.message);
+    var weiValue = web3.toWei(value, "ether");
+    if (bn(weiValue).greaterThan(bn(balance))) {
+        status.sendMessage("No way man, you don't have enough money! :)");
+        return;
+    }
+    try {
+        web3.eth.sendTransaction({
+            from: context.from,
+            to: context.from,
+            value: weiValue
+        });
+        status.sendMessage("You are the hero, you sent " + value + " ETH to yourself!");
+    } catch (err) {
+        status.sendMessage("Something went wrong :(")
+    }
+});

--- a/bots/mailman/bot.js
+++ b/bots/mailman/bot.js
@@ -38,7 +38,3 @@ status.command({
     type: status.types.TEXT,
     placeholder: I18n.t('location_address')
 });
-
-status.on("init", function(params, context) {
-    status.sendMessage("Hello, man!");
-});

--- a/resources/default_contacts.json
+++ b/resources/default_contacts.json
@@ -31,6 +31,16 @@
         "bot-url": "local://mailman-bot"
     },
 
+    "demo-bot":
+    {
+        "name":
+        {
+            "en": "Demo bot"
+        },
+        "dapp?": true,
+        "bot-url": "local://demo-bot"
+    },
+
     "browse":
     {
         "name":

--- a/resources/status.js
+++ b/resources/status.js
@@ -1,7 +1,8 @@
 var _status_catalog = {
         commands: {},
         responses: {},
-        functions: {}
+        functions: {},
+        subscriptions: {}
     },
     status = {};
 
@@ -107,6 +108,10 @@ function view(options, elements) {
     return ['view', options].concat(elements);
 }
 
+function slider(options) {
+    return ['slider', options];
+}
+
 function image(options) {
     return ['image', options];
 }
@@ -117,6 +122,14 @@ function touchable(options, element) {
 
 function scrollView(options, elements) {
     return ['scroll-view', options].concat(elements);
+}
+
+function subscribe(path) {
+    return ['subscribe', path];
+}
+
+function dispatch(path) {
+    return ['dispatch', path];
 }
 
 function validationMessage(titleText, descriptionText) {
@@ -182,16 +195,25 @@ var status = {
     components: {
         view: view,
         text: text,
+        slider: slider,
         image: image,
         touchable: touchable,
         scrollView: scrollView,
-        validationMessage: validationMessage
+        validationMessage: validationMessage,
+        subscribe: subscribe,
+        dispatch: dispatch
     },
     browse: function (url) {
         addContext("web-view-url", url);
     },
     setSuggestions: function (view) {
         addContext("suggestions", view);
+    },
+    setDefaultDb: function (db) {
+        addContext("default-db", db);
+    },
+    updateDb: function (db) {
+        addContext("update-db", db)
     },
     sendMessage: function (text) {
         addContext("text-message", text);
@@ -207,9 +229,25 @@ var status = {
         }
         logMessages.push(message);
         addContext("log-messages", logMessages);
+    },
+    defineSubscription: function (name, subscriptions, handler) {
+        _status_catalog.subscriptions[name] = {
+            subscriptions: subscriptions,
+            handler: handler
+        };
     }
 };
 
+function calculateSubscription(parameters, context) {
+    var subscriptionConfig = _status_catalog.subscriptions[parameters.name];
+    if (!subscriptionConfig) {
+        return;
+    }
+
+    return subscriptionConfig.handler(parameters.subscriptions);
+}
+
+status.on("subscription", calculateSubscription);
 
 console = (function (old) {
     return {

--- a/src/status_im/bots/handlers.cljs
+++ b/src/status_im/bots/handlers.cljs
@@ -1,0 +1,65 @@
+(ns status-im.bots.handlers
+  (:require [re-frame.core :as re-frame]
+            [status-im.components.status :as status]
+            [status-im.utils.handlers :as u]))
+
+(defn check-subscriptions
+  [{:keys [bot-db] :as db} [handler {:keys [path key bot]}]]
+  (let [path'          (or path [key])
+        subscriptions  (get-in db [:bot-subscriptions path'])
+        current-bot-db (get bot-db bot)]
+    (doseq [{:keys [bot subscriptions name]} subscriptions]
+      (let [subs-values (reduce (fn [res [sub-name sub-path]]
+                                  (assoc res sub-name (get-in current-bot-db sub-path)))
+                                {} subscriptions)]
+        (status/call-function!
+          {:chat-id    bot
+           :function   :subscription
+           :parameters {:name          name
+                        :subscriptions subs-values}
+           :callback   #(re-frame/dispatch
+                          [::calculated-subscription {:bot    bot
+                                                      :path   [name]
+                                                      :result %}])})))))
+
+(u/register-handler
+  :set-bot-db
+  (re-frame/after check-subscriptions)
+  (fn [db [_ {:keys [bot key value]}]]
+    (assoc-in db [:bot-db bot key] value)))
+
+(u/register-handler
+  :set-in-bot-db
+  (re-frame/after check-subscriptions)
+  (fn [db [_ {:keys [bot path value]}]]
+    (assoc-in db (concat [:bot-db bot] path) value)))
+
+(u/register-handler
+  :register-bot-subscription
+  (fn [db [_ {:keys [bot subscriptions] :as opts}]]
+    (reduce
+      (fn [db [sub-name sub-path]]
+        (let [sub-path'  (if (coll? sub-path) sub-path [sub-path])
+              sub-path'' (mapv keyword sub-path')]
+          (update-in db [:bot-subscriptions sub-path''] conj
+                     (assoc-in opts [:subscriptions sub-name] sub-path''))))
+      db
+      subscriptions)))
+
+(u/register-handler
+  ::calculated-subscription
+  (u/side-effect!
+    (fn [_ [_ {:keys                  [bot path]
+               {:keys [error result]} :result
+               :as                    data}]]
+      (when-not error
+        (let [returned (:returned result)
+              opts {:bot   bot
+                    :path  path
+                    :value returned}]
+          (re-frame/dispatch [:set-in-bot-db opts]))))))
+
+(u/register-handler
+  :update-bot-db
+  (fn [app-db [_ {:keys [bot db]}]]
+    (update-in app-db [:bot-db bot] merge db)))

--- a/src/status_im/bots/subs.cljs
+++ b/src/status_im/bots/subs.cljs
@@ -1,0 +1,9 @@
+(ns status-im.bots.subs
+  (:require-macros [reagent.ratom :refer [reaction]])
+  (:require [re-frame.core :as re-frame]))
+
+(re-frame/register-sub
+  :bot-subscription
+  (fn [db [_ path]]
+    (let [chat-id (re-frame/subscribe [:get-current-chat-id])]
+      (reaction (get-in @db (concat [:bot-db @chat-id] path))))))

--- a/src/status_im/bots/subs.cljs
+++ b/src/status_im/bots/subs.cljs
@@ -7,3 +7,9 @@
   (fn [db [_ path]]
     (let [chat-id (re-frame/subscribe [:get-current-chat-id])]
       (reaction (get-in @db (concat [:bot-db @chat-id] path))))))
+
+(re-frame/register-sub
+  :current-bot-db
+  (fn [db]
+    (let [chat-id (re-frame/subscribe [:get-current-chat-id])]
+      (reaction (get-in @db [:bot-db @chat-id])))))

--- a/src/status_im/chat/handlers.cljs
+++ b/src/status_im/chat/handlers.cljs
@@ -150,7 +150,7 @@
 
 (register-handler ::check-bot-suggestions
   (u/side-effect!
-    (fn [db [_ chat-id text]]
+    (fn [{:keys [current-account-id] :as db} [_ chat-id text]]
       (let [data   (get-in db [:local-storage chat-id])
             params {:parameters {:message text}
                     :context    {:data data}}]
@@ -158,7 +158,8 @@
           {:chat-id    chat-id
            :function   :text-change
            :parameters {:message text}
-           :context    {:data data}})))))
+           :context    {:data data
+                        :from current-account-id}})))))
 
 (register-handler :set-chat-input-text
   (u/side-effect!

--- a/src/status_im/chat/handlers/receive_message.cljs
+++ b/src/status_im/chat/handlers/receive_message.cljs
@@ -3,7 +3,6 @@
             [re-frame.core :refer [enrich after debug dispatch path]]
             [status-im.data-store.messages :as messages]
             [status-im.chat.utils :as cu]
-            [status-im.commands.utils :refer [generate-hiccup]]
             [status-im.utils.random :as random]
             [status-im.constants :refer [wallet-chat-id
                                          content-type-command

--- a/src/status_im/chat/subs.cljs
+++ b/src/status_im/chat/subs.cljs
@@ -124,6 +124,10 @@
   (fn [db _]
     (reaction (get-in @db [:suggestions (:current-chat-id @db)]))))
 
+(register-sub :get-raw-suggestions
+  (fn [db _]
+    (reaction (get-in @db [:raw-suggestions (:current-chat-id @db)]))))
+
 (register-sub :command?
   (fn [db]
     (->> (get-in @db [:edit-mode (:current-chat-id @db)])
@@ -139,7 +143,7 @@
   (fn []
     (let [command?            (subscribe [:command?])
           type                (subscribe [:command-type])
-          command-suggestions (subscribe [:get-content-suggestions])]
+          command-suggestions (subscribe [:get-raw-suggestions])]
       (reaction
         (cond (and @command? (= @type :response))
               c/request-info-height

--- a/src/status_im/chat/views/response.cljs
+++ b/src/status_im/chat/views/response.cljs
@@ -152,14 +152,15 @@
   [view st/input-placeholder])
 
 (defview response-suggestions-view []
-  [suggestions [:get-content-suggestions]]
-  (when (seq suggestions) suggestions))
+  [bot-db [:current-bot-db]
+   suggestions [:get-raw-suggestions]]
+  (cu/generate-hiccup suggestions bot-db))
 
 (defn response-view []
   (let [response-height (anim/create-value c/input-height)
         command         (subscribe [:get-chat-command])
         text            (subscribe [:get-chat-input-text])
-        suggestions     (subscribe [:get-content-suggestions])
+        suggestions     (subscribe [:get-raw-suggestions])
         errors          (subscribe [:validation-errors])
         custom-errors   (subscribe [:custom-validation-errors])]
     (fn []

--- a/src/status_im/commands/utils.cljs
+++ b/src/status_im/commands/utils.cljs
@@ -1,10 +1,11 @@
 (ns status-im.commands.utils
   (:require [clojure.set :as set]
             [clojure.walk :as w]
-            [status-im.components.react :refer [text scroll-view view web-view
-                                                image touchable-highlight]]
-            [re-frame.core :refer [dispatch trim-v debug]]
-            [status-im.utils.handlers :refer [register-handler]]))
+            [status-im.components.react :as react-components]
+            [re-frame.core :refer [dispatch trim-v debug subscribe]]
+            [status-im.utils.handlers :refer [register-handler]]
+            [cljs.js :as cljs]
+            [clojure.string :as s]))
 
 (def command-prefix "c ")
 
@@ -13,36 +14,85 @@
     (js->clj (.parse js/JSON json) :keywordize-keys true)))
 
 (def elements
-  {:text        text
-   :view        view
-   :scroll-view scroll-view
-   :web-view    web-view
-   :image       image
-   :touchable   touchable-highlight})
+  {:text        `react-components/text
+   :view        `react-components/view
+   :slider      `react-components/slider
+   :scroll-view `react-components/scroll-view
+   :web-view    `react-components/web-view
+   :image       `react-components/image
+   :touchable   `react-components/touchable-highlight})
 
 (defn get-element [n]
   (elements (keyword (.toLowerCase n))))
 
-(def events #{:onPress})
+(def events #{:onPress :onValueChange :onSlidingComplete})
 
 (defn wrap-event [event]
-  #(dispatch [:suggestions-event! event]))
+  (let [data (gensym)]
+    `(cljs.core/fn [~data] (dispatch [:suggestions-event! ~event ~data]))))
 
 (defn check-events [m]
   (let [ks  (set (keys m))
         evs (set/intersection ks events)]
     (reduce #(update %1 %2 wrap-event) m evs)))
 
-(defn generate-hiccup [markup]
-  ;; todo implement validation
-  (w/prewalk
-    (fn [el]
-      (if (and (vector? el) (string? (first el)))
-        (-> el
-            (update 0 get-element)
-            (update 1 check-events))
-        el))
-    markup))
+(def components-state
+  {:name 'status-im.components.react
+   :defs (reduce (fn [res el] (assoc res (symbol (name el)) {})) {} (vals elements))})
+(defn empty-state []
+  (cljs/empty-state
+    (fn [state]
+      (-> state
+          (assoc-in [::cljs.analyzer/namespaces 're-frame.core]
+                    {:name 're-frame.core
+                     :defs {'dispatch  {}
+                            'subscribe {}}})
+          (assoc-in [::cljs.analyzer/namespaces 'status-im.components.react]
+                    components-state)))))
+
+(defn eval [code cb]
+  (cljs/eval (empty-state) code {:eval cljs/js-eval} cb))
+
+(defn parse-markup [markup]
+  (let [subs (atom {})]
+    [(w/prewalk
+       (fn [el]
+         (cond
+
+           (and (vector? el) (= "subscribe" (first el)))
+           (let [sub-name (gensym "sub")]
+             (swap! subs assoc sub-name (second el))
+             sub-name)
+
+           (and (vector? el) (= "dispatch" (first el)))
+           (-> el
+               second
+               (update 0 keyword))
+
+           (and (vector? el) (string? (first el)))
+           (-> el
+               (update 0 get-element)
+               (update 1 check-events))
+
+           :esle el))
+       markup)
+     @subs]))
+
+(defn generate-view-form [parsed-markup subs]
+  `(defn ~(gensym) []
+     (let [~@(mapcat (fn [[sym sub]]
+                       [sym `(subscribe [:bot-subscription ~(mapv keyword sub)])])
+                     subs)]
+       ~(w/postwalk
+          (fn [el]
+            (if (and (symbol? el) (s/starts-with? (str el) "sub"))
+              `(deref ~el)
+              el))
+          parsed-markup))))
+
+(defn generate-hiccup [markup callback]
+  (let [form (apply generate-view-form (parse-markup markup))]
+    (eval form (fn [{:keys [value]}] (callback [value])))))
 
 (defn reg-handler
   ([name handler] (reg-handler name nil handler))

--- a/src/status_im/commands/utils.cljs
+++ b/src/status_im/commands/utils.cljs
@@ -4,7 +4,6 @@
             [status-im.components.react :as react-components]
             [re-frame.core :refer [dispatch trim-v debug subscribe]]
             [status-im.utils.handlers :refer [register-handler]]
-            [cljs.js :as cljs]
             [clojure.string :as s]))
 
 (def command-prefix "c ")
@@ -14,85 +13,47 @@
     (js->clj (.parse js/JSON json) :keywordize-keys true)))
 
 (def elements
-  {:text        `react-components/text
-   :view        `react-components/view
-   :slider      `react-components/slider
-   :scroll-view `react-components/scroll-view
-   :web-view    `react-components/web-view
-   :image       `react-components/image
-   :touchable   `react-components/touchable-highlight})
+  {:text        react-components/text
+   :view        react-components/view
+   :slider      react-components/slider
+   :scroll-view react-components/scroll-view
+   :web-view    react-components/web-view
+   :image       react-components/image
+   :touchable   react-components/touchable-highlight})
 
 (defn get-element [n]
   (elements (keyword (.toLowerCase n))))
 
 (def events #{:onPress :onValueChange :onSlidingComplete})
 
-(defn wrap-event [event]
+(defn wrap-event [[_ event]]
   (let [data (gensym)]
-    `(cljs.core/fn [~data] (dispatch [:suggestions-event! ~event ~data]))))
+    #(dispatch [:suggestions-event! (update event 0 keyword) %])))
 
 (defn check-events [m]
   (let [ks  (set (keys m))
         evs (set/intersection ks events)]
     (reduce #(update %1 %2 wrap-event) m evs)))
 
-(def components-state
-  {:name 'status-im.components.react
-   :defs (reduce (fn [res el] (assoc res (symbol (name el)) {})) {} (vals elements))})
-(defn empty-state []
-  (cljs/empty-state
-    (fn [state]
-      (-> state
-          (assoc-in [::cljs.analyzer/namespaces 're-frame.core]
-                    {:name 're-frame.core
-                     :defs {'dispatch  {}
-                            'subscribe {}}})
-          (assoc-in [::cljs.analyzer/namespaces 'status-im.components.react]
-                    components-state)))))
+(defn generate-hiccup
+  ([markup]
+    (generate-hiccup markup {}))
+  ([markup data]
+   (w/prewalk
+     (fn [el]
+       (cond
 
-(defn eval [code cb]
-  (cljs/eval (empty-state) code {:eval cljs/js-eval} cb))
+         (and (vector? el) (= "subscribe" (first el)))
+         (let [path (mapv keyword (second el))]
+           (get-in data path))
 
-(defn parse-markup [markup]
-  (let [subs (atom {})]
-    [(w/prewalk
-       (fn [el]
-         (cond
+         (and (vector? el) (string? (first el)))
+         (-> el
+             (update 0 get-element)
+             (update 1 check-events))
 
-           (and (vector? el) (= "subscribe" (first el)))
-           (let [sub-name (gensym "sub")]
-             (swap! subs assoc sub-name (second el))
-             sub-name)
-
-           (and (vector? el) (= "dispatch" (first el)))
-           (-> el
-               second
-               (update 0 keyword))
-
-           (and (vector? el) (string? (first el)))
-           (-> el
-               (update 0 get-element)
-               (update 1 check-events))
-
-           :esle el))
-       markup)
-     @subs]))
-
-(defn generate-view-form [parsed-markup subs]
-  `(defn ~(gensym) []
-     (let [~@(mapcat (fn [[sym sub]]
-                       [sym `(subscribe [:bot-subscription ~(mapv keyword sub)])])
-                     subs)]
-       ~(w/postwalk
-          (fn [el]
-            (if (and (symbol? el) (s/starts-with? (str el) "sub"))
-              `(deref ~el)
-              el))
-          parsed-markup))))
-
-(defn generate-hiccup [markup callback]
-  (let [form (apply generate-view-form (parse-markup markup))]
-    (eval form (fn [{:keys [value]}] (callback [value])))))
+         :esle el))
+     markup)))
 
 (defn reg-handler
   ([name handler] (reg-handler name nil handler))

--- a/src/status_im/components/react.cljs
+++ b/src/status_im/components/react.cljs
@@ -51,6 +51,7 @@
 (def keyboard (.-Keyboard react-native))
 (def linking (.-Linking js/ReactNative))
 
+(def slider (get-class "Slider"))
 ;; Accessor methods for React Components
 
 (defn add-font-style [style-key {:keys [font] :as opts :or {font :default}}]

--- a/src/status_im/components/status.cljs
+++ b/src/status_im/components/status.cljs
@@ -147,14 +147,14 @@
            (.callJail status chat-id (cljs->json path) (cljs->json params') cb))))))
 
 (defn call-function!
-  [{:keys [chat-id function] :as opts}]
+  [{:keys [chat-id function callback] :as opts}]
   (let [path   [:functions function]
         params (select-keys opts [:parameters :context])]
     (call-jail
       chat-id
       path
       params
-      #(dispatch [:received-bot-response {:chat-id chat-id} %]))))
+      (or callback #(dispatch [:received-bot-response {:chat-id chat-id} %])))))
 
 (defn set-soft-input-mode [mode]
   (when status

--- a/src/status_im/data_store/messages.cljs
+++ b/src/status_im/data_store/messages.cljs
@@ -3,7 +3,6 @@
             [clojure.string :refer [join split]]
             [status-im.utils.random :refer [timestamp]]
             [clojure.walk :refer [stringify-keys keywordize-keys]]
-            [status-im.commands.utils :refer [generate-hiccup]]
             [cljs.reader :refer [read-string]]
             [status-im.constants :as c])
   (:refer-clojure :exclude [update]))

--- a/src/status_im/handlers.cljs
+++ b/src/status_im/handlers.cljs
@@ -23,6 +23,7 @@
     status-im.transactions.handlers
     status-im.network.handlers
     status-im.debug.handlers
+    status-im.bots.handlers
     [status-im.utils.types :as t]
     [status-im.i18n :refer [label]]
     [status-im.constants :refer [console-chat-id]]

--- a/src/status_im/subs.cljs
+++ b/src/status_im/subs.cljs
@@ -7,7 +7,8 @@
             status-im.contacts.subs
             status-im.new-group.subs
             status-im.participants.subs
-            status-im.transactions.subs))
+            status-im.transactions.subs
+            status-im.bots.subs))
 
 (register-sub :get
   (fn [db [_ k]]

--- a/src/status_im/transactions/handlers.cljs
+++ b/src/status_im/transactions/handlers.cljs
@@ -172,8 +172,9 @@
             {:keys [hash]} (get transactions id)
             pending-message (get transaction-subscribers message-id)]
         (when (and pending-message id hash)
-          (dispatch [::send-pending-message message-id hash])
-          (dispatch [::remove-transaction id]))))))
+          (dispatch [::send-pending-message message-id hash]))
+        ;; todo revisit this
+        (dispatch [::remove-transaction id])))))
 
 (def wrong-password-code "2")
 (def discard-code "4")

--- a/src/status_im/utils/js_resources.cljs
+++ b/src/status_im/utils/js_resources.cljs
@@ -16,15 +16,18 @@
 
 (def browse-js (slurp-bot :browse))
 
-(def mailman-js (slurp-bot :mailman ))
+(def mailman-js (slurp-bot :mailman))
+
+(def demo-bot-js (slurp-bot :demo_bot))
 
 (def commands-js wallet-js)
 
 (def resources
-  {:wallet-bot wallet-js
+  {:wallet-bot  wallet-js
    :console-bot console-js
-   :browse-bot browse-js
-   :mailman-bot mailman-js})
+   :browse-bot  browse-js
+   :mailman-bot mailman-js
+   :demo-bot    demo-bot-js})
 
 (defn get-resource [url]
   (let [resource-name (keyword (subs url (count local-protocol)))]

--- a/src/status_im/utils/slurp.clj
+++ b/src/status_im/utils/slurp.clj
@@ -7,5 +7,9 @@
 
 (defmacro slurp-bot [bot-name & files]
   (->> (concat files ["translations.js" "bot.js"])
-       (map #(clojure.core/slurp (s/join "/" ["bots" (name bot-name) %])))
+       (map (fn [file-name]
+              (try
+                (clojure.core/slurp
+                  (s/join "/" ["bots" (name bot-name) file-name]))
+                (catch Exception _ ""))))
        (apply str)))


### PR DESCRIPTION
PR contains the next features/changes:
1. `status.defineSubscription` method was added to allow a bot to react on changes in `bot-db` and add another calculated value to `bot-db` in the result. Maybe better to call it `defineReaction`

      ```js
     status.defineSubscription(
    // the name of subscription and the name of the value in bot-db
    // associated with this subscription
    "doubledValue",
    // the map of values on which subscription depends: keys are arbitrary names
    // and values are db paths to another value
    {value: ["sliderValue"]},
    // the function which will be called as reaction on changes of values above,
    // should be pure. Returned result will be associated with subscription in bot-db
    doubledValueLabel
     );
     ```
2. `status.component.subscribe(path)` (alternatively just `["subscribe", ["doubledValue"]]`) allows to add subscription in markup. This subscription will get the value from the `bit-db` using specifiied `path`
3. `status.component.dispatch(event)` (or `["dispatch", ["set", ...]]`) allows to evevnt that will be dispatched on some event inside markup (like pressing button, text change etc...)
4. `status.setDefaultDb(map)` method can be used to add default values to `bot-db`. These values will be applied to app db only when markup is rendered the first time. For instance, on each change in command input `suggestions` handler for particular command's parameter is called, and this handler returns some markup. If markup wasn't changed between calls values passed to `setDefaultDb` will not be applied to `bot-db`.
5. `status.updateDb(map)` updates `bot-db` even if markup doesn't contain any changes
6. As was mentioned before markup will not be rerendered if it doesn't contain changes, it means that the state of suggestions area will persist between calls to suggestion handler.
7. Markup is transformed to function that returns hiccup: 
   ```js
   ['view', {}, ['text', {}, ['subscribe', ['balance']]]]
   ```
   will be transformed to
   ```clojure
   (fn []
     (let [balance (subscribe [:bots-subscription [:balance]])]
       [view {} [text {} @balance]]))
   ```

