### PR TITLE
Tested new utils/utils/http-get with DApp commands and faucet.

### DIFF
--- a/src/status_im/chat/suggestions.cljs
+++ b/src/status_im/chat/suggestions.cljs
@@ -4,7 +4,7 @@
             [status-im.models.commands :refer [get-commands
                                                get-chat-command-request
                                                get-chat-command-to-message-id]]
-            [status-im.utils.utils :refer [log http-get]]
+            [status-im.utils.utils :refer [log]]
             [clojure.string :as s]))
 
 (defn suggestion? [text]

--- a/src/status_im/commands/handlers/jail.cljs
+++ b/src/status_im/commands/handlers/jail.cljs
@@ -1,7 +1,7 @@
 (ns status-im.commands.handlers.jail
   (:require [re-frame.core :refer [after dispatch subscribe trim-v debug]]
             [status-im.utils.handlers :as u]
-            [status-im.utils.utils :refer [http-get show-popup]]
+            [status-im.utils.utils :refer [show-popup]]
             [status-im.utils.types :refer [json->clj]]
             [status-im.commands.utils :refer [generate-hiccup reg-handler]]
             [clojure.string :as s]

--- a/src/status_im/commands/handlers/loading.cljs
+++ b/src/status_im/commands/handlers/loading.cljs
@@ -38,10 +38,8 @@
     (and dapp? dapp-url)
     (http-get (s/join "/" [dapp-url commands-js])
               (fn [response]
-                (and
-                  (string? (.text response))
                   (when-let [content-type (.. response -headers (get "Content-Type"))]
-                    (s/includes? "application/javascript" content-type))))
+                    (s/includes? "application/javascript" content-type)))
               #(dispatch [::validate-hash whisper-identity %])
               #(dispatch [::validate-hash whisper-identity js-res/dapp-js]))
 

--- a/src/status_im/utils/utils.cljs
+++ b/src/status_im/utils/utils.cljs
@@ -45,23 +45,21 @@
   ([url valid-response? on-success on-error]
    (-> (.fetch js/window url (clj->js {:method "GET"}))
        (.then (fn [response]
-                (log response)
                 (let [ok?  (.-ok response)
                       ok?' (if valid-response?
                              (and ok? (valid-response? response))
                              ok?)]
-                  [(.text response) ok?'])))
-       (.then (fn [[response ok?]]
-                (cond
-                  ok? (on-success response)
-
-                  (and on-error (not ok?))
-                  (on-error response)
-
-                  :else false)))
+                  (if-not ok?'
+                    (on-error response)
+                    (.text response)))))
+       (.then (fn [text]
+                (if (string? text)
+                  (on-success text)
+                  (on-error text))))
        (.catch (or on-error
                    (fn [error]
                      (show-popup "Error" (str error))))))))
+
 
 (defn truncate-str [s max]
   (if (and (< max (count s)) s)


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)
fixes #987 

### Summary:
[comment]: # (Summarise the problem and how the pull request solves it)
When a DApp with `commands.js` is added to Status, the commands do not get added. This is because `utils/utils/http-get` uses `(.text response)` to read the text of the JS file. However, `.text()` returns a promise, and you cannot use in synchronous code the value which a promise will return. 

This PR changes the tests so that they don't use `(.text response)` as a value, passes the `.text()` to a `.then`, and inside the `then` sends the text off to the right place.

### Steps to test:
- Open Status
- Add a truffle-status-box with `commands.js`. Command should show.
- Test `faucet`, the only other command that uses `http-get`

[comment]: # (PRs will only be accepted if squashed into single commit.)
status: ready
