### PR TITLE
Cursor is moved to command box instead of parameter box if edit phone from profile [ui-refresh] (#998)

### DIFF
--- a/src/status_im/chat/styles/input/input.cljs
+++ b/src/status_im/chat/styles/input/input.cljs
@@ -84,7 +84,7 @@
    :text-align-vertical :center
    :height              min-input-height
    :align-items         :center
-   :android             {:left (+ 15 left)
+   :android             {:left (+ 10 left)
                          :top  0.5}
    :ios                 {:line-height min-input-height
                          :left        (+ 9 left)}})

--- a/src/status_im/chat/views/input/input.cljs
+++ b/src/status_im/chat/views/input/input.cljs
@@ -79,8 +79,8 @@
                                    (set-layout-height h))
         :on-selection-change    #(let [s (-> (.-nativeEvent %)
                                              (.-selection))]
-                                   (when (and (= (.-end s) 10)
-                                              (get command [:command :sequential-params]))
+                                   (when (and (= (.-end s) (+ 2 (count (get-in @command [:command :name]))))
+                                              (get-in @command [:command :sequential-params]))
                                      (dispatch [:chat-input-focus :seq-input-ref])))
         :on-submit-editing      #(dispatch [:send-current-message])
         :on-focus               #(do (dispatch [:set-chat-ui-props :input-focused? true])


### PR DESCRIPTION
Fixes #998 