### PR TITLE
Transactions back button doesn't cancel transactions

### DIFF
--- a/src/status_im/transactions/screens/unsigned_transactions.cljs
+++ b/src/status_im/transactions/screens/unsigned_transactions.cljs
@@ -17,8 +17,7 @@
 (defn toolbar-view [transactions]
   [toolbar/toolbar
    {:background-color st/transactions-toolbar-background
-    :nav-action       (act/close-white #(do (rf/dispatch [:deny-transactions])
-                                            (rf/dispatch [:navigate-back])))
+    :nav-action       (act/close-white #(rf/dispatch [:navigate-back]))
     :border-style     st/toolbar-border
     :custom-content   [rn/view {:style st/toolbar-title-container}
                        [rn/text {:style st/toolbar-title-text


### PR DESCRIPTION
### Summary:
In the "Unsigned transactions" screen, the X button in the toolbar no longer cancels all pending transactions. Now it just closes the screen.

status: ready

