### PR TITLE
Bigger result-box/parameter-box top margin

### DIFF
--- a/src/status_im/android/platform.cljs
+++ b/src/status_im/android/platform.cljs
@@ -15,6 +15,10 @@
                                          :bar-style    "light-content"
                                          :translucent? true
                                          :color        styles/color-transparent}
+                           :overlay     {:height       25
+                                         :bar-style    "dark-content"
+                                         :translucent? true
+                                         :color        styles/color-transparent}
                            :modal       {:height    0
                                          :bar-style "light-content"
                                          :color     styles/color-black}}

--- a/src/status_im/chat/screen.cljs
+++ b/src/status_im/chat/screen.cljs
@@ -110,10 +110,11 @@
 
 (defview chat-toolbar []
   [show-actions? [:chat-ui-props :show-actions?]
+   show-chat-overlay? [:show-chat-overlay?]
    accounts [:get :accounts]
    creating? [:get :creating-account?]]
-  [view
-   [status-bar]
+  [view (when show-chat-overlay? {:style {:zIndex 0}})
+   [status-bar {:type (if show-chat-overlay? :overlay :default)}]
    [toolbar {:hide-nav?      (or (empty? accounts) show-actions? creating?)
              :custom-content [toolbar-content-view]
              :custom-action  [toolbar-action]}]
@@ -175,6 +176,7 @@
    show-actions? [:chat-ui-props :show-actions?]
    show-bottom-info? [:chat-ui-props :show-bottom-info?]
    show-emoji? [:chat-ui-props :show-emoji?]
+   show-chat-overlay? [:show-chat-overlay?]
    layout-height [:get :layout-height]
    input-text [:chat :input-text]]
   {:component-did-mount    #(dispatch [:check-autorun])
@@ -186,6 +188,8 @@
                           (dispatch [:set-layout-height height]))))}
    [chat-toolbar]
    [messages-view group-chat]
+   (when show-chat-overlay?
+     [view {:style st/result-box-overlay}])
    [input/container {:text-empty? (str/blank? input-text)}]
    (when show-actions?
      [actions-view])

--- a/src/status_im/chat/styles/animations.cljs
+++ b/src/status_im/chat/styles/animations.cljs
@@ -16,13 +16,14 @@
    :position         :absolute})
 
 (def header-container
-  {:height           17
+  {:min-height       19
    :background-color common/color-white
-   :alignItems       :center
-   :justifyContent   :center})
+   :alignItems       :center})
 
 (def header-icon
   {:background-color header-draggable-icon
+   :margin-top       8
+   :margin-bottom    6
    :width            24
    :border-radius    1.5
    :height           3})

--- a/src/status_im/chat/styles/input/input.cljs
+++ b/src/status_im/chat/styles/input/input.cljs
@@ -4,8 +4,7 @@
             [status-im.utils.platform :as platform]
             [taoensso.timbre :as log]))
 
-(def color-root-border "rgba(192, 198, 202, 0.28)")
-(def color-root-border-android "#e8eaeb")
+(def color-root-border "#e8eaeb")
 (def color-input "#edf1f3")
 (def color-input-helper-text "rgb(182, 189, 194)")
 (def color-input-helper-placeholder "rgb(182, 189, 194)")
@@ -22,8 +21,7 @@
    :elevation        2
    :margin-bottom    margin-bottom
    :border-top-width 1
-   :ios              {:border-top-color color-root-border}
-   :android          {:border-top-color color-root-border-android}})
+   :border-top-color color-root-border})
 
 (defn container [container-anim-margin bottom-anim-margin]
   {:background-color common/color-white

--- a/src/status_im/chat/styles/screen.cljs
+++ b/src/status_im/chat/styles/screen.cljs
@@ -6,6 +6,7 @@
                                                  text1-color
                                                  text2-color
                                                  text4-color
+                                                 color-black
                                                  color-gray6]]
             [status-im.components.toolbar.styles :refer [toolbar-background1]]))
 
@@ -215,3 +216,12 @@
   {:text-align          :center
    :text-align-vertical :center
    :color               :#7099e6})
+
+(def result-box-overlay
+  {:background-color color-black
+   :opacity          0.6
+   :position         :absolute
+   :top              0
+   :bottom           0
+   :left             0
+   :right            0})

--- a/src/status_im/chat/subs.cljs
+++ b/src/status_im/chat/subs.cljs
@@ -112,6 +112,26 @@
           nil)))))
 
 (register-sub
+ :show-parameter-box?
+ (fn [db _]
+   (let [chat-parameter-box  (subscribe [:chat-parameter-box])
+         show-suggestions?   (subscribe [:show-suggestions?])
+         input-text          (subscribe [:chat :input-text])
+         validation-messages (subscribe [:chat-ui-props :validation-messages])]
+     (reaction (and @chat-parameter-box
+                    (not (str/blank? @input-text))
+                    (not @validation-messages)
+                    (not @show-suggestions?))))))
+
+(register-sub
+ :show-chat-overlay?
+ (fn [db _]
+   (let [show-parameter-box? (subscribe [:show-parameter-box?])
+         result-box          (subscribe [:chat-ui-props :result-box])]
+     (reaction (or @show-parameter-box?
+                   @result-box)))))
+
+(register-sub
   :command-completion
   (fn [db [_ chat-id]]
     (reaction

--- a/src/status_im/chat/views/input/parameter_box.cljs
+++ b/src/status_im/chat/views/input/parameter_box.cljs
@@ -18,14 +18,8 @@
     (:hiccup parameter-box)))
 
 (defview parameter-box-view []
-  [chat-parameter-box [:chat-parameter-box]
-   show-suggestions? [:show-suggestions?]
-   input-text [:chat :input-text]
-   validation-messages [:chat-ui-props :validation-messages]]
-  (when (and chat-parameter-box
-             (not (str/blank? input-text))
-             (not validation-messages)
-             (not show-suggestions?))
+  [show-parameter-box? [:show-parameter-box?]]
+  (when show-parameter-box?
     [expandable-view {:key        :parameter-box
                       :draggable? true}
      [parameter-box-container]]))

--- a/src/status_im/chat/views/input/result_box.cljs
+++ b/src/status_im/chat/views/input/result_box.cljs
@@ -12,7 +12,8 @@
             [status-im.i18n :refer [label]]
             [taoensso.timbre :as log]))
 
-(defn header [title]
+(defview header []
+  [{:keys [title]} [:chat-ui-props :result-box]]
   [view {:style style/header-container}
    [view style/header-title-container
     [text {:style style/header-title-text
@@ -28,10 +29,9 @@
    markup])
 
 (defview result-box-view []
-  [{:keys [markup title] :as result-box} [:chat-ui-props :result-box]]
+  [{:keys [markup] :as result-box} [:chat-ui-props :result-box]]
   (when result-box
-    [expandable-view {:key        :result-box
-                      :draggable? true}
-     [view {:flex 1}
-      [header title]
-      [result-box-container markup]]]))
+    [expandable-view {:key           :result-box
+                      :draggable?    true
+                      :custom-header header}
+     [result-box-container markup]]))

--- a/src/status_im/chat/views/input/utils.cljs
+++ b/src/status_im/chat/views/input/utils.cljs
@@ -1,16 +1,19 @@
 (ns status-im.chat.views.input.utils
   (:require [taoensso.timbre :as log]
-            [status-im.utils.platform :refer [platform-specific]]))
+            [status-im.components.toolbar-new.styles :as toolbar-st]
+            [status-im.utils.platform :as p]))
 
 (def min-height     17)
 (def default-height 300)
 
 (defn default-container-area-height [bottom screen-height]
-  (let [status-bar-height (get-in platform-specific [:component-styles :status-bar :default :height])]
+  (let [status-bar-height (get-in p/platform-specific [:component-styles :status-bar :overlay :height])]
     (if (> (+ bottom default-height status-bar-height) screen-height)
       (- screen-height bottom status-bar-height)
       default-height)))
 
 (defn max-container-area-height [bottom screen-height]
-  (let [status-bar-height (get-in platform-specific [:component-styles :status-bar :default :height])]
-    (- screen-height bottom status-bar-height)))
+  (let [status-bar-height (get-in p/platform-specific [:component-styles :status-bar :overlay :height])
+        toolbar-height (:height toolbar-st/toolbar)
+        margin-top (+ status-bar-height (/ toolbar-height 2))]
+    (- screen-height bottom margin-top)))

--- a/src/status_im/chat/views/input/utils.cljs
+++ b/src/status_im/chat/views/input/utils.cljs
@@ -3,7 +3,7 @@
             [status-im.components.toolbar-new.styles :as toolbar-st]
             [status-im.utils.platform :as p]))
 
-(def min-height     17)
+(def min-height     19)
 (def default-height 300)
 
 (defn default-container-area-height [bottom screen-height]

--- a/src/status_im/ios/platform.cljs
+++ b/src/status_im/ios/platform.cljs
@@ -13,6 +13,9 @@
                            :transparent {:height    20
                                          :bar-style "light-content"
                                          :color     styles/color-transparent}
+                           :overlay     {:height       20
+                                         :bar-style    "dark-content"
+                                         :color        styles/color-white}
                            :modal       {:height    20
                                          :bar-style "light-content"
                                          :color     "#2f3031"}}


### PR DESCRIPTION
fixes item 5 in #994 

### Summary:
- Expanded the top margin of the draggable box, to be able to drag it down without sliding the OS top bar down. The limit now (max height) is at the middle of the toolbar, which should be always a "safe" tapping area.
- Added a dark overlay beneath the box, over the chat screen below.
- The whole header can now be used to drag the box down.

### Steps to test:
- Open some Dapps to activate the browse command.
- Try some commands in Console, like /faucet and /debug

### Not implemented / other issues:
The following are not blocking and can be addressed later:
- The overlay should hide when the box is dragged beneath 50%. Also, this should be animated.
- In Android, with the overlay, the status bar color is a bit off. Not straightforward to fix, RN Android status bar has some wierd issues.

status: ready

