### PR TITLE
Hide opened keyboard when user taps on chat (#1057)

### DIFF
--- a/src/status_im/chat/screen.cljs
+++ b/src/status_im/chat/screen.cljs
@@ -166,7 +166,6 @@
                 :renderScrollComponent     #(invertible-scroll-view (js->clj %))
                 :onEndReached              (when-not loaded? #(dispatch [:load-more-messages]))
                 :enableEmptySections       true
-                :keyboardShouldPersistTaps true
                 :dataSource                (to-datasource-inverted messages)}]))
 
 (defview chat []


### PR DESCRIPTION
One-line fix for #1057 