### PR TITLE
Emoji and numeric keyboards are shown when tap on /send while emojis are opened (#1056)

### DIFF
--- a/src/status_im/chat/views/input/input.cljs
+++ b/src/status_im/chat/views/input/input.cljs
@@ -150,6 +150,7 @@
                               :placeholder       placeholder
                               :blur-on-submit    false
                               :editable          (not @sending-in-progress?)
+                              :on-focus          #(dispatch [:set-chat-ui-props :show-emoji? false])
                               :on-submit-editing (fn []
                                                    (when-not (str/blank? @seq-arg-input-text)
                                                      (dispatch [:send-seq-argument]))


### PR DESCRIPTION
Fixes #1056 