### PR TITLE
Send multiple transactions fix (#1029)

### DIFF
--- a/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusModule.java
+++ b/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusModule.java
@@ -277,8 +277,8 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
     }
 
     @ReactMethod
-    public void completeTransaction(final String hash, final String password, final Callback callback) {
-        Log.d(TAG, "completeTransaction");
+    public void completeTransactions(final String hashes, final String password, final Callback callback) {
+        Log.d(TAG, "completeTransactions");
         if (!checkAvailability()) {
             callback.invoke(false);
             return;
@@ -287,8 +287,7 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
         Thread thread = new Thread() {
             @Override
             public void run() {
-                String res = Statusgo.CompleteTransaction(hash, password);
-
+                String res = Statusgo.CompleteTransactions(hashes, password);
                 callback.invoke(res);
             }
         };

--- a/modules/react-native-status/ios/RCTStatus/RCTStatus.m
+++ b/modules/react-native-status/ios/RCTStatus/RCTStatus.m
@@ -249,21 +249,21 @@ RCT_EXPORT_METHOD(login:(NSString *)address
 }
 
 ////////////////////////////////////////////////////////////////////
-#pragma mark - Complete Transaction
-//////////////////////////////////////////////////////////////////// completeTransaction
-RCT_EXPORT_METHOD(completeTransaction:(NSString *)hash
+#pragma mark - Complete Transactions
+//////////////////////////////////////////////////////////////////// completeTransactions
+RCT_EXPORT_METHOD(completeTransactions:(NSString *)hashes
                   password:(NSString *)password
                   callback:(RCTResponseSenderBlock)callback) {
 #if DEBUG
-    NSLog(@"CompleteTransaction() method called");
+    NSLog(@"CompleteTransactions() method called");
 #endif
-    char * result = CompleteTransaction((char *) [hash UTF8String], (char *) [password UTF8String]);
+    char * result = CompleteTransactions((char *) [hashes UTF8String], (char *) [password UTF8String]);
     callback(@[[NSString stringWithUTF8String: result]]);
 }
 
 ////////////////////////////////////////////////////////////////////
 #pragma mark - Discard Transaction
-//////////////////////////////////////////////////////////////////// completeTransaction
+//////////////////////////////////////////////////////////////////// discardTransaction
 RCT_EXPORT_METHOD(discardTransaction:(NSString *)id) {
 #if DEBUG
     NSLog(@"DiscardTransaction() method called");

--- a/src/status_im/components/status.cljs
+++ b/src/status_im/components/status.cljs
@@ -10,6 +10,9 @@
             [status-im.i18n :as i]
             [status-im.utils.platform :as p]))
 
+(defn cljs->json [data]
+  (.stringify js/JSON (clj->js data)))
+
 ;; if StatusModule is not initialized better to store
 ;; calls and make them only when StatusModule is ready
 ;; this flag helps to handle this
@@ -108,11 +111,11 @@
   (when status
     (call-module #(.login status address password on-result))))
 
-(defn complete-transaction
-  [hash password callback]
-  (log/debug :complete-transaction (boolean status) hash password)
+(defn complete-transactions
+  [hashes password callback]
+  (log/debug :complete-transactions (boolean status) hashes password)
   (when status
-    (call-module #(.completeTransaction status (str hash) password callback))))
+    (call-module #(.completeTransactions status (cljs->json hashes) password callback))))
 
 (defn discard-transaction
   [id]
@@ -123,9 +126,6 @@
 (defn parse-jail [chat-id file callback]
   (when status
     (call-module #(.parseJail status chat-id file callback))))
-
-(defn cljs->json [data]
-  (.stringify js/JSON (clj->js data)))
 
 (defn call-jail [chat-id path params callback]
   (when status


### PR DESCRIPTION
fixes #1029 

### Summary:
Now `status-go` `completeTransactions` method (which wasn't being used before) is used instead of `completeTransaction`.

I decided to not keep the interface to `completeTransaction`, as it was not used anymore. Nor can I see any reason to use it in the future.

[Here is the address](https://ropsten.etherscan.io/address/0x323a7fd769a0f106d6b41232b10c44064bb4be88) used in the tests, you can now see sets of 2 or more transactions sent in the same time. Tested in Android and iOS.

status: ready

