### PR TITLE
Bigger tap area for buttons (#1072)

### DIFF
--- a/src/status_im/chats_list/styles.cljs
+++ b/src/status_im/chats_list/styles.cljs
@@ -46,19 +46,18 @@
    :ios             {:margin-top 14}})
 
 (defstyle chat-options-container
-  {:margin-right 16
-   :padding-top  10
-   :android      {:margin-top 16}
-   :ios          {:margin-top 14}})
+  {:padding-top 10})
 
-(def item-upper-container
-  {:flex            1
-   :flex-direction  :row})
+(defstyle item-upper-container
+  {:flex           1
+   :flex-direction :row
+   :padding-right  16})
 
 (defstyle item-lower-container
   {:flex            1
    :flex-direction  :row
    :justify-content :space-between
+   :padding-right   16
    :android         {:margin-top 4}
    :ios             {:margin-top 6}})
 
@@ -152,11 +151,12 @@
   {:flex-direction :row
    :padding-right  14})
 
-(def opts-btn
-  {:width           24
-   :height          24
-   :align-items     :center
+(def opts-btn-container
+  {:align-items     :center
    :justify-content :center})
+
+(def opts-btn
+  {:padding 16})
 
 (def create-icon
   {:fontSize 20

--- a/src/status_im/chats_list/views/inner_item.cljs
+++ b/src/status_im/chats_list/views/inner_item.cljs
@@ -90,10 +90,12 @@
   (let [options [{:value        #(dispatch [:remove-chat chat-id])
                   :text         (label :t/delete-chat)
                   :destructive? true}]]
-    [view st/opts-btn
+    [view st/opts-btn-container
      [context-menu
       [icon :options_gray]
-      options]]))
+      options
+      nil
+      st/opts-btn]]))
 
 (defn chat-list-item-name [name group-chat? public?]
   (let [private-group? (and group-chat? (not public?))

--- a/src/status_im/components/common/common.cljs
+++ b/src/status_im/components/common/common.cljs
@@ -53,5 +53,7 @@
       [view st/form-title-extend-container
        [context-menu
         [icon :options_gray]
-        options]])]
+        options
+        nil
+        st/form-title-extend-button]])]
    [top-shadow]])

--- a/src/status_im/components/common/styles.cljs
+++ b/src/status_im/components/common/styles.cljs
@@ -55,12 +55,13 @@
                     :margin-top       8}})
 
 (defstyle form-title-extend-container
-  {:padding-right 16
-   :ios          {:margin-top 16
-                  :padding-top 16
+  {:ios          {:margin-top 16
                   :background-color color-white}
-   :android      {:margin-top 24
+   :android      {:margin-top 8
                   :background-color color-light-gray}})
+
+(def form-title-extend-button
+  {:padding 16})
 
 (defstyle form-title
   {:flex-shrink 1

--- a/src/status_im/components/contact/contact.cljs
+++ b/src/status_im/components/contact/contact.cljs
@@ -33,10 +33,12 @@
     [view st/contact-container
      [contact-inner-view {:contact contact :info info}]
      (when extended?
-       [view st/more-btn
+       [view st/more-btn-container
         [context-menu
          [icon :options_gray]
-         extend-options]])]]])
+         extend-options
+         nil
+         st/more-btn]])]]])
 
 (defview toogle-contact-view [{:keys [whisper-identity] :as contact} selected-key on-toggle-handler]
   [checked [selected-key whisper-identity]]

--- a/src/status_im/components/contact/styles.cljs
+++ b/src/status_im/components/contact/styles.cljs
@@ -33,14 +33,14 @@
 (def contact-container
   {:flex-direction   :row
    :align-items      :center
-   :background-color common/color-white
-   :padding-right    16})
+   :background-color common/color-white})
+
+(def more-btn-container
+  {:alignItems     :center
+   :justifyContent :center})
 
 (def more-btn
-  {:width          24
-   :height         24
-   :alignItems     :center
-   :justifyContent :center})
+  {:padding 16})
 
 (def selected-contact
   {:background-color common/selected-contact-color})

--- a/src/status_im/components/context_menu.cljs
+++ b/src/status_im/components/context_menu.cljs
@@ -27,7 +27,7 @@
 (defn context-menu-options [custom-styles]
   {:customStyles {:optionsContainer
                   (merge {:elevation      2
-                          :margin-top     30
+                          :margin-top     0
                           :padding-top    8
                           :width          164
                           :padding-bottom 8}

--- a/src/status_im/profile/screen.cljs
+++ b/src/status_im/profile/screen.cljs
@@ -98,7 +98,9 @@
    (when options
      [context-menu
       [icon :options_gray]
-      options])])
+      options
+      nil
+      st/profile-info-item-button])])
 
 (defn show-qr [contact qr-source]
   #(dispatch [:navigate-to-modal :qr-code-view {:contact   contact

--- a/src/status_im/profile/styles.cljs
+++ b/src/status_im/profile/styles.cljs
@@ -26,6 +26,9 @@
 (defstyle profile-info-container
   {:background-color color-white})
 
+(def profile-info-item-button
+  {:padding 16})
+
 (def status-prompt
   {:padding-left  16
    :padding-right 16
@@ -95,7 +98,6 @@
   {:flex-direction :row
    :align-items    :center
    :padding-left   16
-   :padding-right  16
    :ios            {:height 73}
    :android        {:height 72}})
 


### PR DESCRIPTION
fixes #1072 

### Summary:
Expanded the tap area for the buttons in the chats list, contacts list and profile screen

status: ready

