### PR TITLE
Fix Android action button position (#1097)

### DIFF
--- a/src/status_im/chats_list/screen.cljs
+++ b/src/status_im/chats_list/screen.cljs
@@ -67,7 +67,7 @@
 (defn chats-action-button []
   [native-action-button {:button-color color-blue
                          :offset-x     16
-                         :offset-y     22
+                         :offset-y     40
                          :spacing      13
                          :hide-shadow  true
                          :on-press     #(dispatch [:navigate-to :new-chat])}])

--- a/src/status_im/contacts/screen.cljs
+++ b/src/status_im/contacts/screen.cljs
@@ -106,7 +106,7 @@
 (defn contacts-action-button []
   [native-action-button {:button-color color-blue
                          :offset-x     16
-                         :offset-y     22
+                         :offset-y     40
                          :hide-shadow  true
                          :spacing      13}
    [native-action-button-item


### PR DESCRIPTION
fixes #1097 

### Summary:
The button is now back to its correct position, in the Chat List and Contact List.

status: ready

