### PR TITLE
IP address is not shown for /debug On (#1101)

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "react-native-invertible-scroll-view": "^1.0.0",
     "react-native-level-fs": "^2.0.1",
     "react-native-linear-gradient": "2.0.0",
-    "react-native-network-info": "github:alwx/react-native-network-info",
+    "react-native-network-info": "2.0.0",
     "react-native-orientation": "github:youennPennarun/react-native-orientation",
     "react-native-popup-menu": "^0.7.1",
     "react-native-qrcode": "^0.2.2",

--- a/src/status_im/chat/handlers/console.cljs
+++ b/src/status_im/chat/handlers/console.cljs
@@ -36,7 +36,9 @@
            (get-ip (fn [ip]
                      (dispatch [:received-message
                                 {:message-id   (random/id)
-                                 :content      (label :t/debug-enabled {:ip ip})
+                                 :content      (if ip
+                                                 (label :t/debug-enabled {:ip ip})
+                                                 (label :t/debug-enabled-no-ip))
                                  :content-type text-content-type
                                  :outgoing     false
                                  :chat-id      console-chat-id

--- a/src/status_im/components/network_info.cljs
+++ b/src/status_im/components/network_info.cljs
@@ -1,7 +1,7 @@
 (ns status-im.components.network-info
   (:require [taoensso.timbre :as log]))
 
-(def network-info-class (js/require "react-native-network-info"))
+(def network-info-class (.-NetworkInfo (js/require "react-native-network-info")))
 
 (defn get-ip [callback]
   (.getIPAddress network-info-class

--- a/src/status_im/translations/en.cljs
+++ b/src/status_im/translations/en.cljs
@@ -123,6 +123,7 @@
    :intro-message1                        "Welcome to Status\nTap this message to set your password & get started!"
    :account-generation-message            "Gimmie a sec, I gotta do some crazy math to generate your account!"
    :debug-enabled                         "Debug server has been launched! Your IP address is {{ip}}. You can now add your DApp by running *status-dev-cli add-dapp --ip {{ip}}* from your computer"
+   :debug-enabled-no-ip                   "Debug server has been launched! You can now add your DApp by running *status-dev-cli add-dapp --ip [your ip]* from your computer"
 
    ;phone types
    :phone-e164                            "International 1"


### PR DESCRIPTION
Fixes #1101 
I've updated `react-native-network-info` library because the developer of this lib has changed the code that determines the IP. Now everything should be okay in 99.9% of cases.

I've also added a fallback message for the remaining 0.01%. Probably nobody will see this message, but since IP can be `null`, we should handle it.