### PR TITLE
Input fixes (#1067, #676), #1110

### DIFF
--- a/.re-natal
+++ b/.re-natal
@@ -41,7 +41,8 @@
     "instabug-reactnative",
     "nfc-react-native",
     "react-native-http-bridge",
-    "react-native-network-info"
+    "react-native-network-info",
+    "react-native-autogrow-textinput"
   ],
   "imageDirs": [
     "images"

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "react-native": "^0.43.4",
     "react-native-action-button": "^2.0.13",
     "react-native-android-sms-listener": "github:adrian-tiberius/react-native-android-sms-listener#listener-bugfix",
+    "react-native-autogrow-textinput": "^3.0.2",
     "react-native-autolink": "^0.10.0",
     "react-native-camera": "^0.7.0",
     "react-native-circle-checkbox": "github:paramoshkinandrew/ReactNativeCircleCheckbox",

--- a/src/status_im/chat/styles/input/input.cljs
+++ b/src/status_im/chat/styles/input/input.cljs
@@ -13,8 +13,8 @@
 
 (def max-input-height 66)
 (def min-input-height 38)
-(def input-spacing-top 5)
-(def input-spacing-bottom 8)
+(def input-spacing-top 3)
+(def input-spacing-bottom 5)
 
 (defnstyle root [margin-bottom]
   {:flex-direction   :column
@@ -47,12 +47,17 @@
    :android          {:border-radius 4}
    :ios              {:border-radius 8}})
 
+(defnstyle input-touch-handler-view [container-width]
+  {:position :absolute
+   :width    container-width
+   :height   min-input-height})
+
 (defnstyle input-view [content-height]
   {:flex           1
    :font-size      14
    :padding-top    input-spacing-top
    :padding-bottom input-spacing-bottom
-   :height         (min (max min-input-height content-height) max-input-height)})
+   :height (+ (min (max min-input-height content-height) max-input-height))})
 
 (def invisible-input-text
   {:font-size        14

--- a/src/status_im/components/react.cljs
+++ b/src/status_im/components/react.cljs
@@ -127,6 +127,12 @@
 
 (def swiper (adapt-class (js/require "react-native-swiper")))
 
+;; Autogrow text input
+
+(def autogrow-class (js/require "react-native-autogrow-textinput"))
+
+(def autogrow-text-input (r/adapt-react-class (.-AutoGrowingTextInput autogrow-class)))
+
 ;; Clipboard
 
 (def sharing

--- a/src/status_im/data_store/chats.cljs
+++ b/src/status_im/data_store/chats.cljs
@@ -43,9 +43,7 @@
 (defn add-contacts
   [chat-id identities]
   (data-store/add-contacts chat-id identities)
-  ; TODO: move this somewhere else
-  ; TODO: temp. Update chat in db atom
-  (dispatch [:initialize-chats]))
+  (dispatch [:reload-chats]))
 
 (defn remove-contacts
   [chat-id identities]


### PR DESCRIPTION
React Native 0.40+ gave us an ability to fix #676 because the blocking issue (https://github.com/facebook/react-native/issues/6552) has been resolved.

This PR also fixes #1067 by adding an `input-touch-handler` and #1110 by cleaning data on re-login.

All these issues are related to input text, so I decided to create one single PR instead of several ones.