### PR TITLE
Fix chat long tap not working with input focused (#1143)

### DIFF
--- a/src/status_im/chat/screen.cljs
+++ b/src/status_im/chat/screen.cljs
@@ -167,7 +167,7 @@
                 :renderScrollComponent     #(invertible-scroll-view (js->clj %))
                 :onEndReached              (when-not loaded? #(dispatch [:load-more-messages]))
                 :enableEmptySections       true
-                :keyboardShouldPersistTaps (if platform/android? :always :never)
+                :keyboardShouldPersistTaps (if platform/android? :always :handled)
                 :dataSource                (to-datasource-inverted messages)}]))
 
 (defview chat []

--- a/src/status_im/chat/views/message/message.cljs
+++ b/src/status_im/chat/views/message/message.cljs
@@ -11,7 +11,8 @@
                                                 touchable-without-feedback
                                                 touchable-highlight
                                                 autolink
-                                                get-dimensions]]
+                                                get-dimensions
+                                                dismiss-keyboard!]]
             [status-im.components.animation :as anim]
             [status-im.chat.constants :as chat-consts]
             [status-im.components.list-selection :refer [share browse]]
@@ -31,6 +32,7 @@
             [status-im.components.chat-icon.screen :refer [chat-icon-message-status]]
             [status-im.utils.identicon :refer [identicon]]
             [status-im.utils.gfycat.core :refer [generate-gfy]]
+            [status-im.utils.platform :as platform]
             [status-im.i18n :refer [label
                                     get-contact-translated]]
             [status-im.chat.utils :as cu]
@@ -389,7 +391,8 @@
        :reagent-render
        (fn [{:keys [outgoing group-chat content-type content] :as message}]
          [message-container message
-          [touchable-highlight {:on-long-press (when (= content-type text-content-type)
+          [touchable-highlight {:on-press #(when platform/ios? (dismiss-keyboard!))
+                                :on-long-press (when (= content-type text-content-type)
                                                  #(share content (label :t/message)))}
            [view
             (let [incoming-group (and group-chat (not outgoing))]


### PR DESCRIPTION
fixes #1143, #1142 

### Summary:
Now long tap in message works with input focused, in both platforms, opening the menu.
Normal tap still works as planned: hide the keyboard in iOS but not in Android.

status: ready

