### PR TITLE
Bug/Keyboard is hidden on hit Enter instead of moving to new line in input field (#1111)

### DIFF
--- a/src/status_im/chat/views/input/input.cljs
+++ b/src/status_im/chat/views/input/input.cljs
@@ -64,16 +64,19 @@
   (let [input-text           (subscribe [:chat :input-text])
         command              (subscribe [:selected-chat-command])
         sending-in-progress? (subscribe [:chat-ui-props :sending-in-progress?])
-        input-focused?       (subscribe [:chat-ui-props :input-focused?])]
+        input-focused?       (subscribe [:chat-ui-props :input-focused?])
+        input-ref            (atom nil)]
     (fn [{:keys [set-layout-height set-container-width height]}]
       [text-input
        {:ref                    #(when %
-                                   (dispatch [:set-chat-ui-props {:input-ref %}]))
+                                   (dispatch [:set-chat-ui-props {:input-ref %}])
+                                   (reset! input-ref %))
         :accessibility-label    id/chat-message-input
         :multiline              true
         :default-value          (or @input-text "")
         :editable               true
         :blur-on-submit         false
+        :on-submit-editing      #(.setNativeProps @input-ref (clj->js {:text (str @input-text "\n")})) ;because of bug on Android, next line is not inserted
         :on-focus               #(dispatch [:set-chat-ui-props {:input-focused? true
                                                                 :show-emoji?    false}])
         :on-blur                #(do (dispatch [:set-chat-ui-props {:input-focused? false}]))


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)
fixes #1111

### Summary:
[comment]: # (Summarise the problem and how the pull request solves it)
There is a bug in RN on Android when using multiline text input https://github.com/facebook/react-native/issues/7047 

@annadanchenko I've fixed this issue using most painless way, but text input size doesn't recalculate after press enter, only after input next symbol

@alwx I don't know why but genymotion works different from real device, and you should press "Enter" on your computer's keyboard and in this case, it works same way as on real device


[comment]: # (PRs will only be accepted if squashed into single commit.)
status: ready

