### PR TITLE
Command and argument are misaligned [iOS only] (#1151)

### DIFF
--- a/src/status_im/chat/styles/input/input.cljs
+++ b/src/status_im/chat/styles/input/input.cljs
@@ -13,8 +13,6 @@
 
 (def max-input-height 66)
 (def min-input-height 38)
-(def input-spacing-top 3)
-(def input-spacing-bottom 5)
 
 (defnstyle root [margin-bottom]
   {:flex-direction   :column
@@ -58,9 +56,10 @@
 (defnstyle input-view [content-height]
   {:flex           1
    :font-size      14
-   :padding-top    input-spacing-top
-   :padding-bottom input-spacing-bottom
-   :height (+ (min (max min-input-height content-height) max-input-height))})
+   :padding-top    5
+   :padding-bottom 5
+   :height         (+ (min (max min-input-height content-height) max-input-height))
+   :android        {:padding-top 3}})
 
 (def invisible-input-text
   {:font-size        14

--- a/src/status_im/chat/views/input/input.cljs
+++ b/src/status_im/chat/views/input/input.cljs
@@ -156,7 +156,6 @@
                               :default-value     (or @seq-arg-input-text "")
                               :on-change-text    #(do (dispatch [:set-chat-seq-arg-input-text %])
                                                       (dispatch [:set-chat-ui-props {:validation-messages nil}]))
-                              :secure-text-entry hidden
                               :placeholder       placeholder
                               :blur-on-submit    false
                               :editable          (not @sending-in-progress?)


### PR DESCRIPTION
Fixes #1151  
Also removes redundant `:secure-text-entry` from `seq-input`