### PR TITLE
Fixes #1180 Cleanup navigation stack when creating public group

### DIFF
--- a/src/status_im/new_group/handlers.cljs
+++ b/src/status_im/new_group/handlers.cljs
@@ -116,7 +116,8 @@
 
 (register-handler :create-new-public-group
   (after (fn [_ [_ topic]]
-           (dispatch [:navigation-replace :chat topic])))
+           (dispatch [:navigate-to-clean :chat-list])
+           (dispatch [:navigate-to :chat topic])))
   (u/side-effect!
     (fn [db [_ topic]]
       (let [exists? (boolean (get-in db [:chats topic]))


### PR DESCRIPTION
### Steps to test:
- Open Status
- Click + (start a new chat)
- Create a new public chat
- Navigate back
- user is now redirected to chats list

status: ready

