### PR TITLE
react-native-network-info update

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "react-native-invertible-scroll-view": "^1.0.0",
     "react-native-level-fs": "^2.0.1",
     "react-native-linear-gradient": "2.0.0",
-    "react-native-network-info": "2.0.0",
+    "react-native-network-info": "github:alwx/react-native-network-info",
     "react-native-orientation": "github:youennPennarun/react-native-orientation",
     "react-native-popup-menu": "^0.7.1",
     "react-native-qrcode": "^0.2.2",


### PR DESCRIPTION
I've updated react-native-network-info because it was a bit buggy, for instance, IP addresses may have looked this way: `fe80::4680:ebff:fea9:95d2%wlan0`.