### PR TITLE
migrate to Geth/1.6.1-unstable

### DIFF
--- a/modules/react-native-status/android/build.gradle
+++ b/modules/react-native-status/android/build.gradle
@@ -14,5 +14,5 @@ android {
 
 dependencies {
     compile 'com.facebook.react:react-native:+'
-    compile(group: 'status-im', name: 'status-go', version: '0.9.6-unstable-59-g1b31a5c', ext: 'aar')
+    compile(group: 'status-im', name: 'status-go', version: '0.9.8-g311f2b8', ext: 'aar')
 }

--- a/modules/react-native-status/ios/RCTStatus/pom.xml
+++ b/modules/react-native-status/ios/RCTStatus/pom.xml
@@ -25,7 +25,7 @@
                         <artifactItem>
                             <groupId>status-im</groupId>
                             <artifactId>status-go-ios-simulator</artifactId>
-                            <version>0.9.6-unstable-59-g1b31a5c</version>
+                            <version>0.9.8-g311f2b8</version>
                             <type>zip</type>
                             <overWrite>true</overWrite>
                             <outputDirectory>./</outputDirectory>

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "tty-browserify": "0.0.0",
     "url": "^0.10.3",
     "vm-browserify": "0.0.4",
-    "web3": "github:status-im/web3.js#status-0.18.4"
+    "web3": "github:farazdagi/web3.js#geth/1.6.1-unstable"
   },
   "browser": {
     "crypto": "react-native-crypto",

--- a/src/status_im/data_store/pending_messages.cljs
+++ b/src/status_im/data_store/pending_messages.cljs
@@ -4,11 +4,11 @@
 
 (defn- get-id
   [message-id to]
-  (let [to' (i/normalize-hex to)
+  (let [to'  (i/normalize-hex to)
         to'' (when to' (subs to' 0 7))
-        id' (if to''
-              (str message-id "-" (subs to'' 0 7))
-              message-id)]
+        id'  (if to''
+               (str message-id "-" (subs to'' 0 7))
+               message-id)]
     id'))
 
 (defn get-all
@@ -25,16 +25,18 @@
 
 (defn save
   [{:keys [id to group-id message] :as pending-message}]
-  (let [{:keys [from topics payload]} message
-        id' (get-id id to)
-        chat-id (or group-id to)
+  (let [{:keys [sig key type topic payload]} message
+        id'      (get-id id to)
+        chat-id  (or group-id to)
         message' (-> pending-message
                      (assoc :id id'
-                            :from from
+                            :sig sig
+                            :key key
+                            :key-type type
                             :message-id id
                             :chat-id chat-id
                             :payload payload
-                            :topics (prn-str topics))
+                            :topic topic)
                      (dissoc :message))]
     (data-store/save message')))
 

--- a/src/status_im/data_store/realm/pending_messages.cljs
+++ b/src/status_im/data_store/realm/pending_messages.cljs
@@ -9,9 +9,7 @@
 (defn get-all-as-list
   []
   (->> (get-all)
-       realm/realm-collection->list
-       (map (fn [message]
-              (update message :topics read-string)))))
+       realm/realm-collection->list))
 
 (defn get-by-message-id
   [message-id]

--- a/src/status_im/data_store/realm/schemas/account/v7/contact.cljs
+++ b/src/status_im/data_store/realm/schemas/account/v7/contact.cljs
@@ -16,7 +16,7 @@
                           :private-key      {:type     :string
                                              :optional true}
                           :unremovable?     {:type    :bool
-                                             :default :false}
+                                             :default false}
                           :dapp?            {:type    :bool
                                              :default false}
                           :dapp-url         {:type     :string

--- a/src/status_im/data_store/realm/schemas/account/v7/core.cljs
+++ b/src/status_im/data_store/realm/schemas/account/v7/core.cljs
@@ -7,7 +7,7 @@
             [status-im.data-store.realm.schemas.account.v1.discover :as discover]
             [status-im.data-store.realm.schemas.account.v1.kv-store :as kv-store]
             [status-im.data-store.realm.schemas.account.v4.message :as message]
-            [status-im.data-store.realm.schemas.account.v1.pending-message :as pending-message]
+            [status-im.data-store.realm.schemas.account.v7.pending-message :as pending-message]
             [status-im.data-store.realm.schemas.account.v1.processed-message :as processed-message]
             [status-im.data-store.realm.schemas.account.v1.request :as request]
             [status-im.data-store.realm.schemas.account.v1.tag :as tag]

--- a/src/status_im/data_store/realm/schemas/account/v7/pending_message.cljs
+++ b/src/status_im/data_store/realm/schemas/account/v7/pending_message.cljs
@@ -1,0 +1,27 @@
+(ns status-im.data-store.realm.schemas.account.v7.pending-message
+  (:require [taoensso.timbre :as log]))
+
+(def schema {:name       :pending-message
+             :primaryKey :id
+             :properties {:id            :string
+                          :message-id    :string
+                          :chat-id       {:type     :string
+                                          :optional true}
+                          :ack?          :bool
+                          :requires-ack? :bool
+                          :sig           :string
+                          :key           :string
+                          :key-type      :string
+                          :to            {:type     :string
+                                          :optional true}
+                          :payload       :string
+                          :type          :string
+                          :topic         :string
+                          :attempts      :int
+                          :was-sent?     :bool}})
+
+(defn migration [_ new-realm]
+  (log/debug "migrating pending-message schema v7")
+  (let [new-contacts (.objects new-realm "contact")]
+    (dotimes [i (.-length new-contacts)]
+      (.delete new-realm (aget new-contacts i)))))

--- a/src/status_im/protocol/core.cljs
+++ b/src/status_im/protocol/core.cljs
@@ -6,9 +6,9 @@
             [taoensso.timbre :refer-macros [debug]]
             [status-im.protocol.validation :refer-macros [valid?]]
             [status-im.protocol.web3.utils :as u]
+            [status-im.protocol.web3.keys :as shh-keys]
             [status-im.protocol.chat :as chat]
             [status-im.protocol.group :as group]
-            [status-im.protocol.web3.public-group :as public-group]
             [status-im.protocol.listeners :as l]
             [status-im.protocol.encryption :as e]
             [status-im.protocol.discoveries :as discoveries]
@@ -91,7 +91,7 @@
     ;; start listening to user's inbox
     (f/add-filter!
       web3
-      {:to     identity
+      {:key    identity
        :topics [f/status-topic]}
       (l/message-listener listener-options))
     ;; start listening to profiles

--- a/src/status_im/protocol/message.cljs
+++ b/src/status_im/protocol/message.cljs
@@ -3,6 +3,10 @@
 
 (s/def :message/ttl (s/and int? pos?))
 (s/def :message/from string?)
+(s/def :message/sig :message/from)
+(s/def :message/key string?)
+(s/def :message/topic string?)
+(s/def :message-key/type #{:sym :asym "sym" "asym"})
 (s/def :message/to (s/nilable string?))
 (s/def :message/message-id string?)
 (s/def :message/requires-ack? boolean?)

--- a/src/status_im/protocol/web3/delivery.cljs
+++ b/src/status_im/protocol/web3/delivery.cljs
@@ -7,17 +7,19 @@
             [cljs.spec :as s]
             [taoensso.timbre :refer-macros [debug] :as log]
             [status-im.protocol.validation :refer-macros [valid?]]
-            [clojure.set :as set]))
+            [clojure.set :as set]
+            [status-im.protocol.web3.keys :as shh-keys]))
 
 (defonce loop-state (atom nil))
 (defonce messages (atom {}))
 
 (defn prepare-message
-  [{:keys [payload keypair to] :as message}]
-  (debug :prepare-message!)
+  [web3 {:keys [payload keypair to from topics ttl key-password]
+         :as message}
+   callback]
   (let [{:keys [public]} keypair
 
-        content (:content payload)
+        content  (:content payload)
         content' (if (and (not to) public content)
                    (e/encrypt public (prn-str content))
                    content)
@@ -28,13 +30,22 @@
                      (assoc :content content')
                      prn-str
                      u/from-utf8)]
-    (-> message
-        (select-keys [:from :to :topics :ttl])
-        (assoc :payload payload'))))
+    (shh-keys/get-sym-key
+      web3
+      (or key-password shh-keys/status-key-password)
+      (fn [status-key-id]
+        (callback
+          (merge
+            (select-keys message [:ttl])
+            {:type    (if to :asym :sym)
+             :sig     from
+             :key     (or to status-key-id)
+             :topic   (first topics)
+             :payload payload'}))))))
 
 (s/def :shh/pending-message
-  (s/keys :req-un [:message/from :shh/payload :message/topics]
-          :opt-un [:message/ttl :message/to]))
+  (s/keys :req-un [:message/sig :message-key/type :shh/payload :message/topic]
+          :opt-un [:message/ttl :message/key]))
 
 (defonce pending-mesage-callback (atom nil))
 (defonce recipient->pending-message (atom {}))
@@ -47,37 +58,41 @@
   [web3 {:keys [type message-id requires-ack? to ack?] :as message}]
   {:pre [(valid? :protocol/message message)]}
   (go
-    (debug :add-pending-message!)
+    (debug :add-pending-message! message)
     ;; encryption can take some time, better to run asynchronously
-    (let [message' (prepare-message message)]
-      (when (valid? :shh/pending-message message')
-        (let [group-id (get-in message [:payload :group-id])
-              pending-message {:id            message-id
-                               :ack?          (boolean ack?)
-                               :message       message'
-                               :to            to
-                               :type          type
-                               :group-id      group-id
-                               :requires-ack? (boolean requires-ack?)
-                               :attempts      0
-                               :was-sent?     false}]
-          (when (and @pending-mesage-callback requires-ack?)
-            (@pending-mesage-callback :pending pending-message))
-          (swap! messages assoc-in [web3 message-id to] pending-message)
-          (when to
-            (swap! recipient->pending-message
-                   update to set/union #{[web3 message-id to]})))))))
+    (prepare-message
+      web3 message
+      (fn [message']
+        (when (valid? :shh/pending-message message')
+          (let [group-id        (get-in message [:payload :group-id])
+                pending-message {:id            message-id
+                                 :ack?          (boolean ack?)
+                                 :message       message'
+                                 :to            to
+                                 :type          type
+                                 :group-id      group-id
+                                 :requires-ack? (boolean requires-ack?)
+                                 :attempts      0
+                                 :was-sent?     false}]
+            (when (and @pending-mesage-callback requires-ack?)
+              (@pending-mesage-callback :pending pending-message))
+            (swap! messages assoc-in [web3 message-id to] pending-message)
+            (when to
+              (swap! recipient->pending-message
+                     update to set/union #{[web3 message-id to]}))))))))
 
 (s/def :delivery/pending-message
-  (s/keys :req-un [:message/from :message/to :shh/payload
-                   :message/requires-ack? :payload/ack? ::id :message/topics
+  (s/keys :req-un [:message/sig :message/key :message/to :shh/payload
+                   :message/requires-ack? :payload/ack? ::id :message/topic
                    ::attempts ::was-sent?]))
 
 (defn add-prepeared-pending-message!
-  [web3 {:keys [message-id to] :as pending-message}]
+  [web3 {:keys [message-id to key-type] :as pending-message}]
   {:pre [(valid? :delivery/pending-message pending-message)]}
   (debug :add-prepeared-pending-message!)
-  (let [message          (select-keys pending-message [:from :to :topics :payload])
+  (let [message          (-> pending-message
+                             (select-keys [:sig :key :topics :payload])
+                             (assoc :type key-type))
         pending-message' (assoc pending-message :message message
                                                 :id message-id)]
     (swap! messages assoc-in [web3 message-id to] pending-message')
@@ -89,7 +104,7 @@
   (swap! messages update web3
          (fn [messages]
            (when messages
-             (let [message (messages id)
+             (let [message  (messages id)
                    ;; Message that is send without specified "from" option
                    ;; is stored in pending "messages" map as
                    ;; {message-id {nil message}}.
@@ -108,7 +123,7 @@
 (defn message-was-sent! [web3 id to]
   (let [messages' (swap! messages update web3
                          (fn [messages]
-                           (let [message (get-in messages [id to])
+                           (let [message  (get-in messages [id to])
                                  message' (when message
                                             (assoc message :was-sent? true
                                                            :attempts 1))]
@@ -191,7 +206,7 @@
   {:pre [(valid? ::delivery-options options)]}
   (debug :run-delivery-loop!)
   (let [previous-stop-flag @loop-state
-        stop? (atom false)]
+        stop?              (atom false)]
     ;; stop previous delivery loop if it exists
     (when previous-stop-flag
       (reset! previous-stop-flag true))

--- a/src/status_im/protocol/web3/keys.cljs
+++ b/src/status_im/protocol/web3/keys.cljs
@@ -1,0 +1,27 @@
+(ns status-im.protocol.web3.keys)
+
+(defonce status-sym-key-id (atom nil))
+(def status-key-password "status-key-password")
+(def status-group-key-password "status-public-group-key-password")
+
+(defonce password->keys (atom {}))
+
+(defn- add-sym-key-from-password
+  [web3 password callback]
+  (.. web3
+      -shh
+      (addSymmetricKeyFromPassword password callback)))
+
+(defn get-sym-key [web3 password callback]
+  (if-let [key-id (get @password->keys password)]
+    (callback key-id)
+    (add-sym-key-from-password
+      web3 password
+      (fn [err res]
+        (swap! password->keys assoc password res)
+        (callback res)))))
+
+
+(defn get-status-sym-key
+  [web3 callback]
+  (get-sym-key web3 status-key-password callback))

--- a/src/status_im/protocol/web3/public_group.cljs
+++ b/src/status_im/protocol/web3/public_group.cljs
@@ -1,7 +1,0 @@
-(ns status-im.protocol.web3.public-group
-  (:require [status-im.protocol.web3.filtering :as f]
-            [status-im.protocol.listeners :as l]
-            [status-im.protocol.validation :refer-macros [valid?]]
-            [status-im.protocol.web3.delivery :as d]
-            [cljs.spec :as s]))
-

--- a/src/status_im/protocol/web3/transport.cljs
+++ b/src/status_im/protocol/web3/transport.cljs
@@ -7,28 +7,12 @@
 (s/def :shh/payload string?)
 (s/def :shh/message
   (s/keys
-    :req-un [:shh/payload :message/ttl :message/from :message/topics]
-    :opt-un [:message/to]))
+    :req-un [:shh/payload :message/ttl :message/key :message/sig
+             :message/topic :message-key/type]))
 
 (defn post-message!
-  [web3 {:keys [topics from to] :as message} callback]
+  [web3 message callback]
   {:pre [(valid? :shh/message message)]}
   (debug :post-message message)
-  (let [topic      (first topics)
-        shh        (u/shh web3)
-        encrypted? (boolean to)
-        message'   (if encrypted?
-                     message
-                     (assoc message :keyname topic))
-        do-post    (fn [] (.post shh (clj->js message') callback))]
-    (if encrypted?
-      (do-post)
-      (.hasSymKey
-        shh topic
-        (fn [_ res]
-          (if-not res
-            (.addSymKey
-              shh topic u/status-key-data
-              (fn [error _]
-                (when-not error (do-post))))
-            (do-post)))))))
+  (let [shh (u/shh web3)]
+    (.post shh (clj->js message) callback)))

--- a/src/status_im/protocol/web3/utils.cljs
+++ b/src/status_im/protocol/web3/utils.cljs
@@ -24,6 +24,3 @@
 
 (defn timestamp []
   (to-long (now)))
-
-(def status-key-data (.toHex web3.prototype "status-key-data"))
-


### PR DESCRIPTION
related to https://github.com/status-im/status-go/pull/153

Messaging should work the same way as it worked in `develop`
Older versions of app will not able to communicate with this version