### PR TITLE
Fixes #919 Confirmation dialog for the delete actions

### DIFF
--- a/src/status_im/contacts/screen.cljs
+++ b/src/status_im/contacts/screen.cljs
@@ -20,6 +20,7 @@
             [status-im.components.context-menu :refer [context-menu]]
             [status-im.components.contact.contact :refer [contact-view]]
             [status-im.utils.platform :refer [platform-specific ios? android?]]
+            [status-im.utils.utils :as u]
             [status-im.i18n :refer [label]]
             [status-im.contacts.styles :as st]
             [status-im.components.styles :refer [color-blue
@@ -48,7 +49,10 @@
             :title          (label :t/edit-contacts)}])
 
 (defn contact-options [{:keys [unremovable?] :as contact} group]
-  (let [delete-contact-opt {:value        #(dispatch [:hide-contact contact])
+  (let [delete-contact-opt {:value        #(u/show-confirmation
+                                             (str (label :t/delete-contact) "?") (label :t/delete-contact-confirmation)
+                                             (label :t/delete)
+                                             (fn[] (dispatch [:hide-contact contact])))
                             :text         (label :t/delete-contact)
                             :destructive? true}
         options            (if unremovable? [] [delete-contact-opt])]

--- a/src/status_im/new_group/screen_private.cljs
+++ b/src/status_im/new_group/screen_private.cljs
@@ -10,6 +10,7 @@
                                                 list-item]]
             [status-im.components.renderers.renderers :as renderers]
             [status-im.components.sticky-button :refer [sticky-button]]
+            [status-im.utils.utils :as u]
             [status-im.utils.listview :refer [to-datasource]]
             [status-im.new-group.styles :as st]
             [status-im.new-group.views.group :refer [group-toolbar
@@ -62,9 +63,11 @@
       [add-btn #(dispatch [:navigate-to :add-contacts-toggle-list])]
       [group-contacts-view group]
       [view st/separator]
-      [delete-btn #(do
-                     (dispatch [:delete-group])
-                     (dispatch [:navigate-to-clean :contact-list]))]]
+      [delete-btn #(u/show-confirmation
+                     (str (label :t/delete-group) "?") (label :t/delete-group-confirmation) (label :t/delete)
+                     (fn[]
+                       (dispatch [:delete-group])
+                       (dispatch [:navigate-to-clean :contact-list])))]]
      (when save-btn-enabled?
        [sticky-button (label :t/save) #(dispatch [:set-group-name])])]))
 

--- a/src/status_im/translations/en.cljs
+++ b/src/status_im/translations/en.cljs
@@ -162,6 +162,7 @@
    :contacts                              "Contacts"
    :new-contact                           "New contact"
    :delete-contact                        "Delete contact"
+   :delete-contact-confirmation           "This contact will be removed from your contacts"
    :remove-from-group                     "Remove from group"
    :edit-contacts                         "Edit contacts"
    :search-contacts                       "Search contacts"
@@ -178,6 +179,7 @@
    ;group-settings
    :remove                                "Remove"
    :save                                  "Save"
+   :delete                                "Delete"
    :change-color                          "Change color"
    :clear-history                         "Clear history"
    :mute-notifications                    "Mute notifications"
@@ -216,6 +218,7 @@
    :group-name                            "Group name"
    :edit-group                            "Edit group"
    :delete-group                          "Delete group"
+   :delete-group-confirmation             "This group will be removed from your groups. This will not affect contacts"
    :delete-group-prompt                   "This will not affect contacts"
    :group-members                         "Group members"
    :contact-s                             {:one   "contact"

--- a/src/status_im/utils/utils.cljs
+++ b/src/status_im/utils/utils.cljs
@@ -1,5 +1,6 @@
 (ns status-im.utils.utils
   (:require [status-im.constants :as const]
+            [status-im.i18n :refer [label]]
             [reagent.core :as r]
             [clojure.string :as str]))
 
@@ -17,6 +18,21 @@
   (.alert (.-Alert react-native)
           title
           content))
+
+(defn show-confirmation
+  ([title content on-accept]
+   (show-confirmation title content nil on-accept))
+  ([title content s on-accept]
+   (show-confirmation title content s on-accept nil))
+  ([title content s on-accept on-cancel]
+   (.alert (.-Alert react-native)
+           title
+           content
+           ; Styles are only relevant on iOS. On Android first button is 'neutral' and second is 'positive'
+           (clj->js
+             (vector (merge {:text (label :t/cancel) :style "cancel"}
+                            (when on-cancel {:onPress on-cancel}))
+                     {:text (or s "OK") :onPress on-accept :style "destructive"})))))
 
 (defn http-post
   ([action data on-success]


### PR DESCRIPTION
### Summary:
Added confirmation dialog for the delete actions

### Steps to test:
- Open Status
- Open contacts
- Edit group
- Delete group
- A confirmation alert will popup

status: ready

NOTE: `:delete-contact-confirmation` and `:delete-group-confirmation` texts should be confirmed
