### PR TITLE
Fixes #1220 Do not let catch escape

### DIFF
--- a/src/status_im/components/camera.cljs
+++ b/src/status_im/components/camera.cljs
@@ -17,9 +17,9 @@
 (defn request-access [callback]
   (if platform/android?
       (callback true)
-      (let [result (.checkVideoAuthorizationStatus camera-default)
-            result (.then result #(callback %))
-            result (.catch result #(callback false))])))
+      (-> (.checkVideoAuthorizationStatus camera-default)
+          (.then #(callback %))
+          (.catch #(callback false)))))
 
 (defn camera [props]
   (r/create-element camera-default (clj->js (merge {:inverted true} props))))

--- a/src/status_im/components/react.cljs
+++ b/src/status_im/components/react.cljs
@@ -120,11 +120,17 @@
 
 (def image-picker-class (js/require "react-native-image-crop-picker"))
 
+(defn show-access-error [o]
+  (when (= "ERROR_PICKER_UNAUTHORIZED_KEY" (aget o "code")) ; Do not show error when user cancel selection
+    (u/show-popup (i18n/label :t/error)
+                  (i18n/label :t/photos-access-error))))
+
 (defn show-image-picker [images-fn]
   (let [image-picker (.-default image-picker-class)]
     (-> image-picker
         (.openPicker (clj->js {:multiple false}))
-        (.then images-fn))))
+        (.then images-fn)
+        (.catch show-access-error))))
 
 (def swiper (adapt-class (js/require "react-native-swiper")))
 

--- a/src/status_im/translations/en.cljs
+++ b/src/status_im/translations/en.cljs
@@ -16,6 +16,7 @@
    :error                                 "Error"
 
    :camera-access-error                   "To grant the required camera permission, please, go to your system settings and make sure that Status > Camera is selected."
+   :photos-access-error                   "To grant the required photos permission, please, go to your system settings and make sure that Status > Photos is selected."
 
    ;drawer
    :invite-friends                        "Invite friends"

--- a/src/status_im/utils/fs.cljs
+++ b/src/status_im/utils/fs.cljs
@@ -3,10 +3,9 @@
 (def fs (js/require "react-native-fs"))
 
 (defn move-file [src dst handler]
-  (let [result (.moveFile fs src dst)
-        result (.then result #(handler nil %))
-        result (.catch result #(handler % nil))]
-    result))
+  (-> (.moveFile fs src dst)
+      (.then #(handler nil %))
+      (.catch #(handler % nil))))
 
 (defn read-file [path encoding on-read on-error]
   (-> (.readFile fs path encoding)


### PR DESCRIPTION
fix #1220 No response if use 'Select from gallery' after access to photos was denied
 
### Steps to test:
- Open Status first time
- Open Profile
- Edit Profile
- Edit profile picture
- tap on Select from Gallery. As a result, popup is shown "Deny/Allow" access to photos
- Deny access to photos
- Tap on Select from Gallery again.
- An error message is  shown

status: ready

