### PR TITLE
Fixes #1222 Do not crash when sharing null address.

### DIFF
--- a/src/status_im/components/list_selection.cljs
+++ b/src/status_im/components/list_selection.cljs
@@ -6,14 +6,16 @@
             [status-im.utils.platform :refer [platform-specific]]
             [status-im.i18n :refer [label]]))
 
-(defn open [opts]
-  (.share sharing (clj->js opts)))
+(defn open-share [content]
+  (when (or (:message content)
+            (:url content))
+    (.share sharing (clj->js content))))
 
 (defn share-options [text]
   [{:text  (label :t/sharing-copy-to-clipboard)
     :value #(copy-to-clipboard text)}
    {:text  (label :t/sharing-share)
-    :value #(open {:message text})}])
+    :value #(open-share {:message text})}])
 
 (defn share [text dialog-title]
   (let [list-selection-fn (:list-selection-fn platform-specific)]
@@ -22,7 +24,7 @@
                         :callback    (fn [index]
                                        (case index
                                          0 (copy-to-clipboard text)
-                                         1 (open {:message text})
+                                         1 (open-share {:message text})
                                          :default))
                         :cancel-text (label :t/sharing-cancel)})))
 

--- a/src/status_im/profile/screen.cljs
+++ b/src/status_im/profile/screen.cljs
@@ -106,24 +106,25 @@
   #(dispatch [:navigate-to-modal :qr-code-view {:contact   contact
                                                 :qr-source qr-source}]))
 
+(defn profile-options [contact k text]
+  (into []
+        (concat [{:value (show-qr contact k)
+                  :text (label :t/show-qr)}]
+                (when text
+                  (share-options text)))))
+
 (defn profile-info-address-item [{:keys [address] :as contact}]
   [profile-info-item
    {:label     (label :t/address)
     :value     address
-    :options   (into []
-                 (concat [{:value (show-qr contact :address)
-                           :text (label :t/show-qr)}]
-                         (share-options address)))
+    :options   (profile-options contact :address address)
     :text-mode :middle}])
 
 (defn profile-info-public-key-item [public-key contact]
   [profile-info-item
    {:label     (label :t/public-key)
     :value     public-key
-    :options   (into []
-                 (concat [{:value (show-qr contact :public-key)
-                           :text (label :t/show-qr)}]
-                         (share-options public-key)))
+    :options   (profile-options contact :public-key public-key)
     :text-mode :middle}])
 
 (defn info-item-separator []


### PR DESCRIPTION
Fixes #1222 

### Summary:

Do not crash when sharing empty text. Hide sharing options when nothing can be shared

### Steps to test:
- Open Status
- Go to console
- Select profile
- Address should be blank
- Click on '...': no sharing options should be available (Only 'Show QR')

Note I also fixed the original issue (sharing null won't fail anymore).

[comment]: # (PRs will only be accepted if squashed into single commit.)
status: ready

