### PR TITLE
Missing hints for @browse and /location (#1210)

### DIFF
--- a/src/status_im/contacts/handlers.cljs
+++ b/src/status_im/contacts/handlers.cljs
@@ -110,7 +110,7 @@
                              (filter (fn [[_ c]] (:global-command c)))
                              (map (fn [[id {:keys [global-command]}]]
                                     [(keyword id) (-> global-command
-                                                      (update :params vals)
+                                                      (update :params (comp vec vals))
                                                       (assoc :bot id
                                                              :type :command))]))
                              (into {}))

--- a/src/status_im/data_store/realm/schemas/account/core.cljs
+++ b/src/status_im/data_store/realm/schemas/account/core.cljs
@@ -6,7 +6,8 @@
             [status-im.data-store.realm.schemas.account.v5.core :as v5]
             [status-im.data-store.realm.schemas.account.v6.core :as v6]
             [status-im.data-store.realm.schemas.account.v7.core :as v7]
-            [status-im.data-store.realm.schemas.account.v8.core :as v8]))
+            [status-im.data-store.realm.schemas.account.v8.core :as v8]
+            [status-im.data-store.realm.schemas.account.v9.core :as v9]))
 
 ; put schemas ordered by version
 (def schemas [{:schema        v1/schema
@@ -32,4 +33,7 @@
                :migration     v7/migration}
               {:schema        v8/schema
                :schemaVersion 8
-               :migration     v8/migration}])
+               :migration     v8/migration}
+              {:schema        v9/schema
+               :schemaVersion 9
+               :migration     v9/migration}])

--- a/src/status_im/data_store/realm/schemas/account/v9/command_parameter.cljs
+++ b/src/status_im/data_store/realm/schemas/account/v9/command_parameter.cljs
@@ -1,0 +1,8 @@
+(ns status-im.data-store.realm.schemas.account.v9.command-parameter
+  (:require [taoensso.timbre :as log]))
+
+(def schema {:name       :command-parameter
+             :properties {:name        {:type :string}
+                          :type        {:type :string}
+                          :placeholder {:type     :string
+                                        :optional true}}})

--- a/src/status_im/data_store/realm/schemas/account/v9/core.cljs
+++ b/src/status_im/data_store/realm/schemas/account/v9/core.cljs
@@ -1,0 +1,49 @@
+(ns status-im.data-store.realm.schemas.account.v9.core
+  (:require [status-im.data-store.realm.schemas.account.v4.chat :as chat]
+            [status-im.data-store.realm.schemas.account.v1.chat-contact :as chat-contact]
+            [status-im.data-store.realm.schemas.account.v6.command :as command]
+            [status-im.data-store.realm.schemas.account.v9.command-parameter :as command-parameter]
+            [status-im.data-store.realm.schemas.account.v7.contact :as contact]
+            [status-im.data-store.realm.schemas.account.v1.discover :as discover]
+            [status-im.data-store.realm.schemas.account.v1.kv-store :as kv-store]
+            [status-im.data-store.realm.schemas.account.v4.message :as message]
+            [status-im.data-store.realm.schemas.account.v7.pending-message :as pending-message]
+            [status-im.data-store.realm.schemas.account.v1.processed-message :as processed-message]
+            [status-im.data-store.realm.schemas.account.v1.request :as request]
+            [status-im.data-store.realm.schemas.account.v1.tag :as tag]
+            [status-im.data-store.realm.schemas.account.v1.user-status :as user-status]
+            [status-im.data-store.realm.schemas.account.v5.contact-group :as contact-group]
+            [status-im.data-store.realm.schemas.account.v5.group-contact :as group-contact]
+            [status-im.data-store.realm.schemas.account.v8.local-storage :as local-storage]
+            [taoensso.timbre :as log]))
+
+(def schema [chat/schema
+             chat-contact/schema
+             command/schema
+             command-parameter/schema
+             contact/schema
+             discover/schema
+             kv-store/schema
+             message/schema
+             pending-message/schema
+             processed-message/schema
+             request/schema
+             tag/schema
+             user-status/schema
+             contact-group/schema
+             group-contact/schema
+             local-storage/schema])
+
+(defn migration [old-realm new-realm]
+  (log/debug "migrating v8 account database: " old-realm new-realm)
+  (let [new-commands (.objects new-realm "command")]
+    (dotimes [i (.-length new-commands)]
+      (let [command (aget new-commands i)
+            command-name (aget command "name")
+            command-title (aget command "title")]
+        (cond
+          (and (= command-name "global") (= command-title "Browser"))
+          (aset command "params" 0 "placeholder" "URL")
+
+          (= command-name "location")
+          (aset command "params" 0 "placeholder" "Address"))))))


### PR DESCRIPTION
fixes #1210 

### Summary:

There was no text hint for the `@browse` and `/location` commands after the first run of the application. This was caused by the fact that the schema for `command-parameter` didn't include a `:placeholder` attribute so when the browse contact is saved the placeholder text is lost.

I added a migration to add placeholder as an optional attributes (not all commands seem to have it). In addition the migration function will also add back the missing placeholder attribute so that users already affected by the bug will get the placeholder back automatically.

### Steps to test:
- Open Status not 1st time
- Open console
- type @browse or select it from commands. check if URL is shown after it
- delete browse command
- type /location or select it from commands. check if URL is shown after it Address

If you want to test the migration function:
- comment out the v8 migration from `src/status_im/data_store/realm/schemas/account/core.cljs`
- run the above steps, the placeholders should be missing
- close the app and uncomment the v8 migration
- follow the above steps, the placeholders should be correct

status: ready