### PR TITLE
Fixes #1212

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -20,7 +20,8 @@
                          ["do" "clean"
                           ["with-profile" "prod" "cljsbuild" "once" "ios"]
                           ["with-profile" "prod" "cljsbuild" "once" "android"]]
-            "generate-externs" ["with-profile" "prod" "externs" "android" "externs/externs.js"]}
+            "generate-externs" ["with-profile" "prod" "externs" "android" "externs/externs.js"]
+            "test" ["doo" "phantom" "test" "once"]}
   :test-paths ["test/clj"]
   :figwheel {:nrepl-port 7888}
   :profiles {:dev  {:dependencies [[figwheel-sidecar "0.5.8"]
@@ -29,7 +30,7 @@
                                    [com.cemerick/piggieback "0.2.1"]
                                    [io.appium/java-client "3.4.1"]
                                    [hawk "0.2.10"]]
-                    :plugins      [[lein-doo "0.1.6"]]
+                    :plugins      [[lein-doo "0.1.7"]]
                     :source-paths ["src" "env/dev"]
                     :cljsbuild    {:builds [{:id           :ios
                                              :source-paths ["src" "env/dev"]
@@ -45,13 +46,13 @@
                                                             :main          "env.android.main"
                                                             :output-dir    "target/android"
                                                             :optimizations :none}}
-                                            {:id           :test
+                                            {:id           "test"
                                              :source-paths ["src" "test/cljs"]
                                              :compiler
                                                            {:main          status-im.test.runner
                                                             :output-to     "target/test/test.js"
-                                                            :optimizations :none
-                                                            :target        :nodejs}}]}
+                                                            :output-dir    "target"
+                                                            :optimizations :none}}]}
                     :repl-options {:nrepl-middleware [cemerick.piggieback/wrap-cljs-repl]
                                    :timeout          240000}}
              :prod {:cljsbuild {:builds [{:id           "ios"

--- a/src/status_im/chat/handlers/input.cljs
+++ b/src/status_im/chat/handlers/input.cljs
@@ -96,7 +96,7 @@
   :update-suggestions
   (fn [{:keys [current-chat-id] :as db} [_ chat-id text]]
     (let [chat-id         (or chat-id current-chat-id)
-          chat-text       (or text (get-in db [:chats chat-id :input-text]) "")
+          chat-text       (str/trim (or text (get-in db [:chats chat-id :input-text]) ""))
           requests        (->> (suggestions/get-request-suggestions db chat-text)
                                (remove (fn [{:keys [type]}]
                                          (= type :grant-permissions))))

--- a/src/status_im/chat/models/input.cljs
+++ b/src/status_im/chat/models/input.cljs
@@ -29,7 +29,8 @@
         command-text (if space?
                        (str command-text ".")
                        command-text)
-        splitted     (cond-> (str/split command-text const/spacing-char)
+        command-text-normalized (if command-text (str/replace (str/trim command-text) #" +" " ") command-text)
+        splitted     (cond-> (str/split command-text-normalized const/spacing-char)
                              space? (drop-last))]
     (->> splitted
          (reduce (fn [[list command-started?] arg]

--- a/src/status_im/chat/subs.cljs
+++ b/src/status_im/chat/subs.cljs
@@ -141,7 +141,7 @@
           requests          (subscribe [:chat :request-suggestions chat-id])
           commands          (subscribe [:chat :command-suggestions chat-id])]
       (reaction
-        (and (or @show-suggestions? (chat-utils/starts-as-command? @input-text))
+        (and (or @show-suggestions? (chat-utils/starts-as-command? (str/trim (or @input-text ""))))
              (not (:command @selected-command))
              (or (not-empty @requests)
                  (not-empty @commands)))))))

--- a/src/status_im/chat/views/input/input.cljs
+++ b/src/status_im/chat/views/input/input.cljs
@@ -128,9 +128,10 @@
   (let [input-text (subscribe [:chat :input-text])]
     (fn [{:keys [command width]}]
       (when-not (get-in command [:command :sequential-params])
-        (let [real-args (remove str/blank? (:args command))]
+        (let [input (str/trim (or @input-text ""))
+              real-args (remove str/blank? (:args command))]
           (when-let [placeholder (cond
-                                   (#{const/command-char const/bot-char} @input-text)
+                                   (#{const/command-char const/bot-char} input)
                                    (i18n/label :t/type-a-command)
 
                                    (and command (empty? real-args))
@@ -138,7 +139,7 @@
 
                                    (and command
                                         (= (count real-args) 1)
-                                        (input-model/text-ends-with-space? @input-text))
+                                        (input-model/text-ends-with-space? input))
                                    (get-in command [:command :params 1 :placeholder]))]
             [text {:style (style/input-helper-text width)}
              placeholder]))))))

--- a/test/cljs/status_im/test/chat/models/input.cljs
+++ b/test/cljs/status_im/test/chat/models/input.cljs
@@ -1,0 +1,8 @@
+(ns status-im.test.chat.models.input
+  (:require [cljs.test :refer-macros [deftest is]]
+            [status-im.chat.models.input :as in]))
+
+(deftest test-split-command-args
+  (is (= [""] (in/split-command-args nil)))
+  (is (= ["@browse" "google.com"] (in/split-command-args "@browse google.com")))
+  (is (= ["@browse" "google.com"] (in/split-command-args "  @browse   google.com  "))))

--- a/test/cljs/status_im/test/runner.cljs
+++ b/test/cljs/status_im/test/runner.cljs
@@ -1,7 +1,17 @@
 (ns status-im.test.runner
-  (:require #_[doo.runner :refer-macros [doo-tests]]
+  (:require [doo.runner :refer-macros [doo-tests]]
+            [status-im.test.chat.models.input]
             [status-im.test.handlers]
             [status-im.test.commands.handlers]))
 
-#_(doo-tests 'status-im.test.handlers
+(enable-console-print!)
+
+;; Or doo will exit with an error, see:
+;; https://github.com/bensu/doo/issues/83#issuecomment-165498172
+(set! (.-error js/console) (fn [x] (.log js/console x)))
+
+(set! goog.DEBUG false)
+
+(doo-tests 'status-im.test.chat.models.input
+           'status-im.test.handlers
            'status-im.test.commands.handlers)


### PR DESCRIPTION
Fixes #1212

### Summary:
Can't send @browse command if space is typed before url

### Steps to test:
- Open Status
- Open console
- Type " @browse google.com" (spaces can be added before or after browse)
- URL should be correctly browsed

Also allow command to be recognized if a space is added before `@`. Some unit tests validate various extra spaces pattern.

status: ready

