### PR TITLE
Bug: Can't set status with #\ (#1245)

### DIFF
--- a/src/status_im/data_store/realm/core.cljs
+++ b/src/status_im/data_store/realm/core.cljs
@@ -197,11 +197,6 @@
           (js->clj res :keywordize-keys true))
       res)))
 
-(defn get-by-filter [realm schema-name filter]
-  (-> realm
-      (.objects (name schema-name))
-      (.filtered filter)))
-
 (defn- get-schema-by-name [opts]
   (->> opts
        (mapv (fn [{:keys [name] :as schema}]

--- a/src/status_im/data_store/realm/core.cljs
+++ b/src/status_im/data_store/realm/core.cljs
@@ -4,7 +4,8 @@
             [status-im.data-store.realm.schemas.base.core :as base]
             [taoensso.timbre :as log]
             [status-im.utils.fs :as fs]
-            [clojure.string :as str])
+            [clojure.string :as str]
+            [goog.string :as gstr])
   (:refer-clojure :exclude [exists?]))
 
 (def realm-class (js/require "realm"))
@@ -219,7 +220,7 @@
 (defmethod to-query :eq [schema schema-name _ field value]
   (let [value         (to-string value)
         field-type    (field-type schema schema-name field)
-        escaped-value (when value (str/replace (str value) #"\"" "\\\""))
+        escaped-value (when value (gstr/escapeString (str value)))
         query         (str (name field) "=" (if (= "string" (name field-type))
                                               (str "\"" escaped-value "\"")
                                               value))]


### PR DESCRIPTION
fixes #1245 

### Summary:
Updating your profile status with a hashtag and a character that needs to be escaped causes the app to crash. This was caused by the string not being escaped in some cases when sent to realmjs as a query.

This pull request updates the escaped query value via `goog.string.escapedString` instead of the currently used `string/replace`.

I also removed a dead function `get-by-filter` as it's not used anywhere and could also lead to a similar error if the user forgets to escape the filter.

### Steps to test:
Open Status
Open profile
Edit profile
in Status type #\ and tap Save

status: ready

