### PR TITLE
No more react-native-network-info, updated /debug command response

### DIFF
--- a/.re-natal
+++ b/.re-natal
@@ -41,7 +41,6 @@
     "instabug-reactnative",
     "nfc-react-native",
     "react-native-http-bridge",
-    "react-native-network-info",
     "react-native-autogrow-textinput"
   ],
   "imageDirs": [

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -158,7 +158,6 @@ android {
 }
 
 dependencies {
-    compile project(':react-native-network-info')
     compile project(':react-native-http-bridge')
     compile project(':nfc-react-native')
     compile project(':instabug-reactnative')

--- a/android/app/src/main/java/im/status/ethereum/MainApplication.java
+++ b/android/app/src/main/java/im/status/ethereum/MainApplication.java
@@ -16,7 +16,6 @@ import com.i18n.reactnativei18n.ReactNativeI18n;
 import com.instabug.reactlibrary.RNInstabugReactnativePackage;
 import com.lwansbrough.RCTCamera.RCTCameraPackage;
 import com.oblador.vectoricons.VectorIconsPackage;
-import com.pusherman.networkinfo.RNNetworkInfoPackage;
 import com.reactnative.ivpusic.imagepicker.PickerPackage;
 import com.rnfs.RNFSPackage;
 import com.rt2zz.reactnativecontacts.ReactNativeContacts;
@@ -42,7 +41,6 @@ public class MainApplication extends Application implements ReactApplication {
         protected List<ReactPackage> getPackages() {
             List<ReactPackage> packages = new ArrayList<ReactPackage>(Arrays.asList(
                     new MainReactPackage(),
-                    new RNNetworkInfoPackage(),
                     new HttpServerReactPackage(),
                     new NfcReactNativePackage(),
                     new SplashScreenReactPackage(),

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,8 +1,6 @@
 rootProject.name = 'StatusIm'
 
 include ':app'
-include ':react-native-network-info'
-project(':react-native-network-info').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-network-info/android')
 include ':react-native-http-bridge'
 project(':react-native-http-bridge').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-http-bridge/android')
 include ':nfc-react-native'

--- a/ios/StatusIm.xcodeproj/project.pbxproj
+++ b/ios/StatusIm.xcodeproj/project.pbxproj
@@ -65,7 +65,6 @@
 		CE4E31B31D8695250033ED64 /* Statusgo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE4E31B21D8695250033ED64 /* Statusgo.framework */; };
 		D28AEFB4C39548EB80416889 /* Entypo.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 52E205D210BC48B7A553BB62 /* Entypo.ttf */; };
 		E0AD9E8F495A4907B65104BF /* libRCTImageResizer.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2BEE3436791D42248F853999 /* libRCTImageResizer.a */; };
-		EC8998BFE2C04023A860C065 /* libRNNetworkInfo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 74B7BDFF464F43D3BA8EA040 /* libRNNetworkInfo.a */; };
 		EF2B5857B4A34E0C9707FB3F /* Octicons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = B3B19223008342D096AA356E /* Octicons.ttf */; };
 		F9238D6C1E5F055900C047B9 /* SF-UI-Text-Semibold.otf in Resources */ = {isa = PBXBuildFile; fileRef = F9238D6B1E5F055900C047B9 /* SF-UI-Text-Semibold.otf */; };
 		FD4F213C3873473CB703B1D2 /* libRNFS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 674B3D9595A047AB8D518F4E /* libRNFS.a */; };
@@ -373,13 +372,6 @@
 			remoteGlobalIDString = 3D3CD9181DE5FBD800167DC4;
 			remoteInfo = "jschelpers-tvOS";
 		};
-		B2D090C71E6839D7005BD157 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = F93B6663A59F4B26BD4DA525 /* RNNetworkInfo.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 045BEB3C1B52EA6A0013C1B9;
-			remoteInfo = RNNetworkInfo;
-		};
 		B2DEA0B01E49E32000FA28D6 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = B2DEA0A41E49E32000FA28D6 /* RCTHttpServer.xcodeproj */;
@@ -461,7 +453,6 @@
 		5535217F57E44D77AA9CF083 /* libRCTOrientation.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libRCTOrientation.a; sourceTree = "<group>"; };
 		5E5A7625B76441D984EA8C0D /* RCTImageResizer.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RCTImageResizer.xcodeproj; path = "../node_modules/react-native-image-resizer/ios/RCTImageResizer.xcodeproj"; sourceTree = "<group>"; };
 		674B3D9595A047AB8D518F4E /* libRNFS.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libRNFS.a; sourceTree = "<group>"; };
-		74B7BDFF464F43D3BA8EA040 /* libRNNetworkInfo.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libRNNetworkInfo.a; sourceTree = "<group>"; };
 		78C398B01ACF4ADC00677621 /* RCTLinking.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTLinking.xcodeproj; path = "../node_modules/react-native/Libraries/LinkingIOS/RCTLinking.xcodeproj"; sourceTree = "<group>"; };
 		78C55F15EB4D4DAF9202A662 /* libRNRandomBytes.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libRNRandomBytes.a; sourceTree = "<group>"; };
 		7B5870D9ED504F32B6A09C35 /* FontAwesome.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = FontAwesome.ttf; path = "../node_modules/react-native-vector-icons/Fonts/FontAwesome.ttf"; sourceTree = "<group>"; };
@@ -494,7 +485,6 @@
 		F090E261B9854867A728CE4F /* RealmReact.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RealmReact.xcodeproj; path = "../node_modules/realm/react-native/ios/RealmReact.xcodeproj"; sourceTree = "<group>"; };
 		F3548417D8DA4362B6796A54 /* RNInstabug.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNInstabug.xcodeproj; path = "../node_modules/instabug-reactnative/ios/RNInstabug.xcodeproj"; sourceTree = "<group>"; };
 		F9238D6B1E5F055900C047B9 /* SF-UI-Text-Semibold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SF-UI-Text-Semibold.otf"; sourceTree = "<group>"; };
-		F93B6663A59F4B26BD4DA525 /* RNNetworkInfo.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNNetworkInfo.xcodeproj; path = "../node_modules/react-native-network-info/ios/RNNetworkInfo.xcodeproj"; sourceTree = "<group>"; };
 		FC1CBCFE6C906043D6CCEEE1 /* libPods-StatusImTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-StatusImTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -547,7 +537,6 @@
 				E0AD9E8F495A4907B65104BF /* libRCTImageResizer.a in Frameworks */,
 				5F8585D411844E5981B94F40 /* libRNInstabug.a in Frameworks */,
 				8E55E6877F950B81C8D711C5 /* libPods-StatusIm.a in Frameworks */,
-				EC8998BFE2C04023A860C065 /* libRNNetworkInfo.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -841,7 +830,6 @@
 				439B6B4B407A4E2AACAFE5BE /* RCTStatus.xcodeproj */,
 				5E5A7625B76441D984EA8C0D /* RCTImageResizer.xcodeproj */,
 				F3548417D8DA4362B6796A54 /* RNInstabug.xcodeproj */,
-				F93B6663A59F4B26BD4DA525 /* RNNetworkInfo.xcodeproj */,
 			);
 			name = Libraries;
 			sourceTree = "<group>";
@@ -934,14 +922,6 @@
 			children = (
 				B2A5F4381DEC36B200174F4D /* libRCTAnimation.a */,
 				B2A5F43A1DEC36B200174F4D /* libRCTAnimation-tvOS.a */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		B2D090A31E6839D7005BD157 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				B2D090C81E6839D7005BD157 /* libRNNetworkInfo.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1140,10 +1120,6 @@
 				{
 					ProductGroup = 9E3F1BE31DDAE781005E4779 /* Products */;
 					ProjectRef = F3548417D8DA4362B6796A54 /* RNInstabug.xcodeproj */;
-				},
-				{
-					ProductGroup = B2D090A31E6839D7005BD157 /* Products */;
-					ProjectRef = F93B6663A59F4B26BD4DA525 /* RNNetworkInfo.xcodeproj */;
 				},
 				{
 					ProductGroup = 20B7D0F01D3F74CC00B70F14 /* Products */;
@@ -1465,13 +1441,6 @@
 			remoteRef = B2BC5D921EADD18B00A140D0 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		B2D090C81E6839D7005BD157 /* libRNNetworkInfo.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libRNNetworkInfo.a;
-			remoteRef = B2D090C71E6839D7005BD157 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
 		B2DEA0B11E49E32000FA28D6 /* libRCTHttpServer.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
@@ -1786,7 +1755,6 @@
 					"$(SRCROOT)/../node_modules/react-native-image-resizer/ios/RCTImageResizer",
 					"$(SRCROOT)/../node_modules/instabug-reactnative/ios/RNInstabug",
 					"$(SRCROOT)/../node_modules/react-native-splash-screen/ios",
-					"$(SRCROOT)/../node_modules/react-native-network-info/ios",
 				);
 				INFOPLIST_FILE = StatusIm/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
@@ -1835,7 +1803,6 @@
 					"$(SRCROOT)/../node_modules/react-native-image-resizer/ios/RCTImageResizer",
 					"$(SRCROOT)/../node_modules/instabug-reactnative/ios/RNInstabug",
 					"$(SRCROOT)/../node_modules/react-native-splash-screen/ios",
-					"$(SRCROOT)/../node_modules/react-native-network-info/ios",
 				);
 				INFOPLIST_FILE = StatusIm/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
@@ -1906,7 +1873,6 @@
 					"$(SRCROOT)/../node_modules/react-native-image-resizer/ios/RCTImageResizer",
 					"$(SRCROOT)/../node_modules/instabug-reactnative/ios/RNInstabug",
 					"$(SRCROOT)/../node_modules/react-native-splash-screen/ios",
-					"$(SRCROOT)/../node_modules/react-native-network-info/ios",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
@@ -1964,7 +1930,6 @@
 					"$(SRCROOT)/../node_modules/react-native-image-resizer/ios/RCTImageResizer",
 					"$(SRCROOT)/../node_modules/instabug-reactnative/ios/RNInstabug",
 					"$(SRCROOT)/../node_modules/react-native-splash-screen/ios",
-					"$(SRCROOT)/../node_modules/react-native-network-info/ios",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				MTL_ENABLE_DEBUG_INFO = NO;

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "react-native-invertible-scroll-view": "^1.0.0",
     "react-native-level-fs": "^2.0.1",
     "react-native-linear-gradient": "2.0.0",
-    "react-native-network-info": "github:alwx/react-native-network-info",
     "react-native-orientation": "github:youennPennarun/react-native-orientation",
     "react-native-popup-menu": "^0.7.1",
     "react-native-qrcode": "^0.2.2",

--- a/src/status_im/chat/handlers/console.cljs
+++ b/src/status_im/chat/handlers/console.cljs
@@ -3,7 +3,6 @@
             [status-im.utils.handlers :refer [register-handler] :as u]
             [status-im.constants :refer [console-chat-id
                                          text-content-type]]
-            [status-im.components.network-info :refer [get-ip]]
             [status-im.data-store.messages :as messages]
             [status-im.i18n :refer [label]]
             [status-im.utils.random :as random]
@@ -33,17 +32,14 @@
        (if debug-on?
          (do
            (dispatch [:debug-server-start])
-           (get-ip (fn [ip]
-                     (dispatch [:received-message
-                                {:message-id   (random/id)
-                                 :content      (if ip
-                                                 (label :t/debug-enabled {:ip ip})
-                                                 (label :t/debug-enabled-no-ip))
-                                 :content-type text-content-type
-                                 :outgoing     false
-                                 :chat-id      console-chat-id
-                                 :from         console-chat-id
-                                 :to           "me"}]))))
+           (dispatch [:received-message
+                      {:message-id   (random/id)
+                       :content      (label :t/debug-enabled)
+                       :content-type text-content-type
+                       :outgoing     false
+                       :chat-id      console-chat-id
+                       :from         console-chat-id
+                       :to           "me"}]))
          (dispatch [:debug-server-stop]))))})
 
 (def commands-names (set (keys console-commands)))

--- a/src/status_im/components/network_info.cljs
+++ b/src/status_im/components/network_info.cljs
@@ -1,8 +1,0 @@
-(ns status-im.components.network-info
-  (:require [taoensso.timbre :as log]))
-
-(def network-info-class (.-NetworkInfo (js/require "react-native-network-info")))
-
-(defn get-ip [callback]
-  (.getIPAddress network-info-class
-                 callback))

--- a/src/status_im/translations/en.cljs
+++ b/src/status_im/translations/en.cljs
@@ -128,8 +128,7 @@
    :intro-message1                        "Welcome to Status\nTap this message to set your password & get started!"
    :account-generation-message            "Gimmie a sec, I gotta do some crazy math to generate your account!"
    :move-to-internal-failure-message      "We need to move some important files from external to internal storage. To do this, we need your permission. We won't be using external storage in future versions."
-   :debug-enabled                         "Debug server has been launched! Your IP address is {{ip}}. You can now add your DApp by running *status-dev-cli add-dapp --ip {{ip}}* from your computer"
-   :debug-enabled-no-ip                   "Debug server has been launched! You can now add your DApp by running *status-dev-cli add-dapp --ip [your ip]* from your computer"
+   :debug-enabled                         "Debug server has been launched! You can now execute *status-dev-cli scan* to find the server from your computer on the same network."
 
    ;phone types
    :phone-e164                            "International 1"


### PR DESCRIPTION
This PR removes `react-native-network-info` and changes the response to `/debug On` command.