### PR TITLE
Fixes #1243 Adding some dapps to state of the dapps group

### DIFF
--- a/resources/default_contact_groups.json
+++ b/resources/default_contact_groups.json
@@ -7,14 +7,15 @@
         },
         "contacts":
         [
-            "wallet",
-            "oaken-water-meter",
-            "melonport",
-            "bchat",
-            "Dentacoin",
             "Augur",
+            "bchat",
+            "Commiteth",
+            "Dentacoin",
+            "Etherplay",
             "Ethlance",
-            "Commiteth"
+            "melonport",
+            "oaken-water-meter",
+            "wallet"
         ]
     },
     "state-of-dapps":
@@ -25,11 +26,18 @@
         },
         "contacts":
         [
-            "flight-delays-suck",
-            "FirstBlood",
             "auction-house",
+            "Augur",
+            "Commiteth",
+            "Dentacoin",
+            "Etherplay",
+            "Ethlance",
+            "FirstBlood",
+            "flight-delays-suck",
             "gnosis",
-            "mkr-market"
+            "melonport",
+            "mkr-market",
+            "oaken-water-meter"
         ]
     }
 }

--- a/resources/default_contacts.json
+++ b/resources/default_contacts.json
@@ -150,7 +150,7 @@
         {
             "en": "http://waterflowdapp.projectoaken.com"
         },
-        "groups": ["dapps"]
+        "groups": ["dapps", "state-of-dapps"]
     },
 
     "gnosis":
@@ -180,7 +180,7 @@
         {
             "en": "https://portal.melonport.com/"
         },
-        "groups": ["dapps"]
+        "groups": ["dapps", "state-of-dapps"]
     },
 
     "bchat":
@@ -210,7 +210,7 @@
         {
             "en": "http://dentacoin.com/testnet/"
         },
-        "groups": ["dapps"]
+        "groups": ["dapps", "state-of-dapps"]
     },
 
     "Augur":
@@ -225,7 +225,7 @@
         {
           "en": "https://app.augur.net"
         },
-        "groups": ["dapps"]
+        "groups": ["dapps", "state-of-dapps"]
     },
 
     "Ethlance":
@@ -240,7 +240,7 @@
         {
           "en": "https://madvas.github.io/ethlance/resources/public/"
         },
-        "groups": ["dapps"]
+        "groups": ["dapps", "state-of-dapps"]
     },
     
     "Commiteth":
@@ -255,7 +255,7 @@
         {
             "en": "https://commiteth.com"
         },
-        "groups": ["dapps"]
+        "groups": ["dapps", "state-of-dapps"]
     },
 
     "Etherplay":
@@ -270,6 +270,6 @@
         {
             "en": "http://test.etherplay.io"
         },
-        "groups": ["dapps"]
+        "groups": ["dapps", "state-of-dapps"]
     }
 }


### PR DESCRIPTION
Description

Type: Bug

Summary: Add DApps below to group State of the DApps (as they can be found on https://dapps.ethercasts.com/ ):
Augur, Commiteth, Dentacoin, Etherplay, Ethlance, Melonport and Oaken Water Meter

Expected behavior

State of the DApps group in Contacts contains
Augur, Commiteth, Dentacoin, Etherplay, Ethlance, Melonport and Oaken Water Meter in addition to the current members

Actual behavior

Augur, Commiteth, Dentacoin, Etherplay, Ethlance, Melonport and Oaken Water Meter are not in the group State of DApps

Reproduction

Open Status
Open Contacts
Check members of State of the DApps
Additional Information

Status version: 0.9.8
Operating System: Android and iOS
status: ready

