### PR TITLE
status.sendMessage/showSuggestions methods in jail

### DIFF
--- a/bots/demo_bot/bot.js
+++ b/bots/demo_bot/bot.js
@@ -28,7 +28,7 @@ status.defineSubscription(
     }
 );
 
-function superSuggestion(params, context) {
+function demoSuggestions(params, context) {
     var balance = parseFloat(web3.fromWei(web3.eth.getBalance(context.from), "ether"));
     var defaultSliderValue = balance / 2;
 
@@ -73,10 +73,10 @@ function superSuggestion(params, context) {
     return {markup: view};
 };
 
-status.addListener("on-message-input-change", superSuggestion);
-status.addListener("init", superSuggestion);
+status.addListener("on-message-input-change", demoSuggestions);
+status.addListener("init", demoSuggestions);
 status.addListener("on-message-send", function (params, context) {
-    cnt = localStorage.getItem("cnt");
+    var cnt = localStorage.getItem("cnt");
     if(!cnt) {
         cnt = 0;
     }
@@ -85,7 +85,6 @@ status.addListener("on-message-send", function (params, context) {
 
     localStorage.setItem("cnt", cnt);
     if (isNaN(params.message)) {
-
         return {"text-message": "Seems that you don't want to send money :(. cnt = " + cnt};
     }
 
@@ -95,14 +94,16 @@ status.addListener("on-message-send", function (params, context) {
     if (bn(weiValue).greaterThan(bn(balance))) {
         return {"text-message": "No way man, you don't have enough money! :)"};
     }
-    try {
-        web3.eth.sendTransaction({
-            from: context.from,
-            to: context.from,
-            value: weiValue
-        });
-        return {"text-message": "You are the hero, you sent " + value + " ETH to yourself!"};
-    } catch (err) {
-        return {"text-message": "Something went wrong :("};
-    }
+    web3.eth.sendTransaction({
+        from: context.from,
+        to: context.from,
+        value: weiValue
+    }, function (error, hash) {
+        if (error) {
+            status.sendMessage("Something went wrong, try again :(");
+            status.showSuggestions(demoSuggestions(params, context).markup);
+        } else {
+            status.sendMessage("You are the hero, you sent " + value + " ETH to yourself!")
+        }
+    });
 });

--- a/resources/status.js
+++ b/resources/status.js
@@ -209,8 +209,8 @@ var status = {
         subscribe: subscribe,
         dispatch: dispatch
     },
-    setSuggestions: function (view) {
-        addContext("suggestions", view);
+    showSuggestions: function (view) {
+        statusSignals.showSuggestions(JSON.stringify(view));
     },
     setDefaultDb: function (db) {
         addContext("default-db", db);
@@ -219,7 +219,7 @@ var status = {
         addContext("update-db", db)
     },
     sendMessage: function (text) {
-        addContext("text-message", text);
+        statusSignals.sendMessage(text);
     },
     addLogMessage: function (type, message) {
         var message = {
@@ -278,10 +278,18 @@ console = (function (old) {
 }(console));
 
 localStorage.setItem = function(key, value) {
-    localStorageData[key] = value;
+    if(value === null) {
+        delete localStorageData[key];
+    } else {
+        localStorageData[key] = value;
+    }
+
     localStorage.set(JSON.stringify(localStorageData));
 };
 
-localStorage.getItem = function(key) {
+localStorage.getItem = function (key) {
+    if (typeof localStorageData[key] === "undefined") {
+        return null;
+    }
     return localStorageData[key];
 };

--- a/src/status_im/chat/handlers/send_message.cljs
+++ b/src/status_im/chat/handlers/send_message.cljs
@@ -18,7 +18,8 @@
             [status-im.utils.datetime :as datetime]
             [status-im.protocol.core :as protocol]
             [taoensso.timbre :refer-macros [debug] :as log]
-            [status-im.chat.handlers.console :as console]))
+            [status-im.chat.handlers.console :as console]
+            [status-im.utils.types :as types]))
 
 (defn prepare-command
   [identity chat-id clock-value request
@@ -236,6 +237,27 @@
                       :chat-id      chat-id
                       :from         chat-id
                       :to           "me"}]))))))
+
+(register-handler :send-message-from-jail
+  (u/side-effect!
+    (fn [_ [_ {:keys [chat_id message]}]]
+      (dispatch [:received-message
+                 {:message-id   (random/id)
+                  :content      (str message)
+                  :content-type text-content-type
+                  :outgoing     false
+                  :chat-id      chat_id
+                  :from         chat_id
+                  :to           "me"}]))))
+
+(register-handler :show-suggestions-from-jail
+  (u/side-effect!
+    (fn [_ [_ {:keys [chat_id markup]}]]
+      (let [markup' (types/json->clj markup)
+            result  (assoc-in {} [:result :returned :markup] markup')]
+        (dispatch [:suggestions-handler
+                   {:result  result
+                    :chat-id chat_id}])))))
 
 (register-handler ::send-message!
   (u/side-effect!

--- a/src/status_im/handlers.cljs
+++ b/src/status_im/handlers.cljs
@@ -161,6 +161,8 @@
           "local_storage.set" (dispatch [:set-local-storage event])
           "request_geo_permissions" (dispatch [:request-permissions [:geolocation]
                                                #(dispatch [:webview-geo-permissions-granted])])
+          "jail.send_message" (dispatch [:send-message-from-jail event])
+          "jail.show_suggestions" (dispatch [:show-suggestions-from-jail event])
           (log/debug "Event " type " not handled"))))))
 
 (register-handler :status-module-initialized!

--- a/src/status_im/utils/js_resources.cljs
+++ b/src/status_im/utils/js_resources.cljs
@@ -50,8 +50,4 @@
        (slurp "resources/web3_init.js")))
 
 (defn local-storage-data [data]
-  (str "var localStorageData = "
-       (if data
-         data
-         "{}")
-       ";"))
+  (str "var localStorageData = " (or data "{}") ";"))


### PR DESCRIPTION
`status.sendMessage(text)` - will send message in 1-to-1 chat with bot
`status.showSuggestions(markup)` - allows to add markup to suggestion area

`status.sendMessage/showSuggestions` are signal based so can be called from callbacks (and will be useful when event loop will be added to jail).

Example: https://github.com/status-im/status-react/blob/feature/signal-based-messages-suggestions-in-jail/bots/demo_bot/bot.js#L103

status: ready

