### PR TITLE
Allow SD Card Installation

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           xmlns:tools="http://schemas.android.com/tools"
+          android:installLocation="auto"
           package="im.status.ethereum">
 
     <!-- non-dangerous permissions -->


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)
fixes #1236 

### Summary:
[comment]: # (Summarise the problem and how the pull request solves it)
By adding android:installLocation="auto" to the manifest (https://developer.android.com/guide/topics/manifest/manifest-element.html) , the location the app is installed to is allowed to be changed, so that it can be put on the SD card to conserve space, as noted in the relevant issue.

[comment]: # (PRs will only be accepted if squashed into single commit.)
status: ready

