### PR TITLE
chat: implement emoji replace

### DIFF
--- a/.re-natal
+++ b/.re-natal
@@ -40,7 +40,8 @@
     "react-native-autolink",
     "instabug-reactnative",
     "nfc-react-native",
-    "react-native-http-bridge"
+    "react-native-http-bridge",
+    "emojilib"
   ],
   "imageDirs": [
     "images"

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "dns.js": "^1.0.1",
     "domain-browser": "^1.1.7",
     "eccjs": "0.3.1",
+    "emojilib": "^2.2.1",
     "events": "^1.1.1",
     "homoglyph-finder": "^1.1.1",
     "https-browserify": "0.0.1",

--- a/src/status_im/chat/handlers/input.cljs
+++ b/src/status_im/chat/handlers/input.cljs
@@ -14,10 +14,10 @@
             [clojure.string :as str]))
 
 (handlers/register-handler
-  :set-chat-input-text
-  (fn [{:keys [current-chat-id chats chat-ui-props] :as db} [_ text chat-id]]
-    (let [chat-id          (or chat-id current-chat-id)
-          ends-with-space? (input-model/text-ends-with-space? text)]
+ :set-chat-input-text
+ (fn [{:keys [current-chat-id chats chat-ui-props] :as db} [_ text chat-id]]
+   (let [chat-id          (or chat-id current-chat-id)
+         ends-with-space? (input-model/text-ends-with-space? text)]
       (dispatch [:update-suggestions chat-id text])
 
       (if-let [{command :command} (input-model/selected-chat-command db chat-id text)]
@@ -26,7 +26,9 @@
               new-args       (rest text-splitted)
               new-input-text (input-model/make-input-text text-splitted old-args)]
           (assoc-in db [:chats chat-id :input-text] new-input-text))
-        (assoc-in db [:chats chat-id :input-text] text)))))
+        (->> text
+             (input-model/text->emoji)
+             (assoc-in db [:chats chat-id :input-text]))))))
 
 (handlers/register-handler
   :add-to-chat-input-text

--- a/src/status_im/chat/models/input.cljs
+++ b/src/status_im/chat/models/input.cljs
@@ -9,6 +9,17 @@
             [status-im.chat.utils :as chat-utils]
             [status-im.bots.constants :as bots-constants]))
 
+(def emojis (js/require "emojilib"))
+
+(defn text->emoji [text]
+  (when text
+    (str/replace text
+                 #":([a-z_\-+0-9]*):"
+                 (fn [[original emoji-id]]
+                   (if-let [emoji-map (aget emojis "lib" emoji-id)]
+                     (aget emoji-map "char")
+                     original)))))
+
 (defn text-ends-with-space? [text]
   (when text
     (= (str/last-index-of text const/spacing-char)


### PR DESCRIPTION
fixes #840 

### Summary:
- This will replace text-based emoticons with emojis in the chat. 
- This PR uses this very simple emoji package that provides a json containing all the emojis indexed by their names: https://github.com/muan/emojilib 

### Steps to test:
- Open Status
- Go to the chat and type one of the emoji name between `:` (ex:  `:smile:` `:+1:`  `:123:` `:cactus:` )
(all the keys of the following json are supported: https://github.com/muan/emojilib/blob/master/emojis.json )

status: ready
