### PR TITLE
Fix Ethlance DApp URL

### DIFF
--- a/resources/default_contacts.json
+++ b/resources/default_contacts.json
@@ -238,7 +238,7 @@
         "dapp?": true,
         "dapp-url":
         {
-          "en": "https://madvas.github.io/ethlance/resources/public/"
+          "en": "https://ethlance.com"
         },
         "groups": ["dapps"]
     },


### PR DESCRIPTION
### Summary:
Fix Ethlance DApp URL #1302

### Steps to test:
- Open Status
- Open Contact
- Tap on Ethlance

status: ready

