### PR TITLE
Do not prevent input if first character is invalid

### DIFF
--- a/src/status_im/components/text_field/view.cljs
+++ b/src/status_im/components/text_field/view.cljs
@@ -118,6 +118,7 @@
                 auto-focus on-change-text on-change on-end-editing editable placeholder
                 placeholder-text-color auto-capitalize multiline number-of-lines]}
         (merge default-props (r/props component))
+        valid-value      (or valid-value "")
         line-color       (if error error-color line-color)
         focus-line-color (if error error-color focus-line-color)
         label-color      (if (and error (not float-label?)) error-color label-color)
@@ -164,7 +165,7 @@
                                                 (on-change-text text))
                                               (r/set-state component {:temp-value valid-value
                                                                       :max-length (count valid-value)})))
-                  :on-change              #(on-change %)
+                  :on-change              on-change
                   :default-value          value
                   :value                  temp-value
                   :max-length             max-length


### PR DESCRIPTION
fixes #1297

### Summary:
In _Join public chat_ screen user types "A" in topic. After this

all other typed characters are not shown at all (on iOS)
next typed character "deletes" the first one so field is empty (on Android)

### Steps to test:
- Open Status
- Open Chats
- tap on +
- tap Join public chat
- set keyboard to uppercase and type "A"
- type "m". check that topic field contains "m".

status: ready

