### PR TITLE
chat: fix broken chat delete logic

### DIFF
--- a/src/status_im/chat/handlers.cljs
+++ b/src/status_im/chat/handlers.cljs
@@ -392,7 +392,7 @@
 (defn delete-chat!
   [_ [_ chat-id]]
   (let [{:keys [debug? group-chat]} (chats/get-by-id chat-id)]
-    (when (and (not debug?) group-chat)
+    (if (and (not debug?) group-chat)
       (chats/set-inactive chat-id)
       (chats/delete chat-id))))
 

--- a/src/status_im/chat/handlers.cljs
+++ b/src/status_im/chat/handlers.cljs
@@ -392,10 +392,9 @@
 (defn delete-chat!
   [_ [_ chat-id]]
   (let [{:keys [debug? group-chat]} (chats/get-by-id chat-id)]
-    (when group-chat
-      (if debug?
-        (chats/delete chat-id)
-        (chats/set-inactive chat-id)))))
+    (when (and (not debug?) group-chat)
+      (chats/set-inactive chat-id)
+      (chats/delete chat-id))))
 
 (defn remove-pending-messages!
   [_ [_ chat-id]]


### PR DESCRIPTION
fixes #1291 

### Summary:
Chat is deleted in Chats but after app relaunch it's shown again in Chats...

### Steps to test:
* Open Status
* Open Chats
* Delete some chat (e.g with Auction House)
* Close app
* Open app
* Check if Auction House is shown in Chats

status: ready

