### PR TITLE
Clear :last-message when clearing chat history. Fixes #212

### DIFF
--- a/src/status_im/group_settings/handlers.cljs
+++ b/src/status_im/group_settings/handlers.cljs
@@ -56,7 +56,9 @@
 
 (defn clear-messages
   [{:keys [current-chat-id] :as db} _]
-  (assoc-in db [:chats current-chat-id :messages] '()))
+  (-> db
+      (assoc-in [:chats current-chat-id :messages] '())
+      (assoc-in [:chats current-chat-id :last-message] nil)))
 
 (register-handler :clear-history
   (after delete-messages!)


### PR DESCRIPTION
fixes #212

### Summary:
Clearing the chat history when line is still shown in Chats

### Steps to test:
-Open Status
-Click Chats Tab
-Chat with someone
-Clean the current chat history
-Back to Chats Tab
-Make sure `No messages` is displayed

status: ready

