### PR TITLE
Clear Seq arguments before navigating back to chat. Fixes #1355

### DIFF
--- a/src/status_im/profile/handlers.cljs
+++ b/src/status_im/profile/handlers.cljs
@@ -37,6 +37,7 @@
 (register-handler :open-chat-with-the-send-transaction
   (u/side-effect!
     (fn [db [_ chat-id]]
+      (dispatch [:clear-seq-arguments])
       (dispatch [:navigate-to :chat chat-id])
       (js/setTimeout #(dispatch [:select-chat-input-command {:name "send"}]) 500))))
 


### PR DESCRIPTION
Fixes #1355 

### Summary:
Parameter of the previous command is shown if use Send Transaction from a user profile
`fix`: make sure seq arguments are cleared before navigating back to chat 

### Steps to test:
- Launch app "Status"
- Login with valid credentials
- Go to 1-1 Chats
- Select any command (ex. Location) and type smth in the field
- Tap on the "Profile" icon
- Select "Send"

status: ready

