### PR TITLE
Bot API improvements

### DIFF
--- a/bots/demo_bot/bot.js
+++ b/bots/demo_bot/bot.js
@@ -71,13 +71,12 @@ function demoSuggestions(params, context) {
     });
 
     return {markup: view};
-};
+}
 
 status.addListener("on-message-input-change", demoSuggestions);
-status.addListener("init", demoSuggestions);
 status.addListener("on-message-send", function (params, context) {
     var cnt = localStorage.getItem("cnt");
-    if(!cnt) {
+    if (!cnt) {
         cnt = 0;
     }
 
@@ -106,4 +105,42 @@ status.addListener("on-message-send", function (params, context) {
             status.sendMessage("You are the hero, you sent " + value + " ETH to yourself!")
         }
     });
+});
+
+status.command({
+    name: "init-request",
+    description: "send-request",
+    color: "#a187d5",
+    sequentialParams: true,
+    params: [{
+        name: "address",
+        type: status.types.TEXT,
+        placeholder: "address"
+    }],
+    handler: function (params) {
+        return {
+            "text-message": {
+                type: "request",
+                content: {
+                    command: "response",
+                    params: {first: "123"},
+                    text: "That's request's content! It works!"
+                }
+            }
+        };
+    }
+});
+
+status.response({
+    name: "response",
+    color: "#a187d5",
+    sequentialParams: true,
+    params: [{
+        name: "first",
+        type: status.types.TEXT,
+        placeholder: "first"
+    }],
+    handler: function (params) {
+        return {"text-message": "ok"};
+    }
 });

--- a/resources/status.js
+++ b/resources/status.js
@@ -218,8 +218,11 @@ var status = {
     updateDb: function (db) {
         addContext("update-db", db)
     },
-    sendMessage: function (text) {
-        statusSignals.sendMessage(text);
+    sendMessage: function (message) {
+        if(typeof message !== "string") {
+            message = JSON.stringify(message);
+        }
+        statusSignals.sendMessage(message);
     },
     addLogMessage: function (type, message) {
         var message = {

--- a/src/status_im/chat/handlers/input.cljs
+++ b/src/status_im/chat/handlers/input.cljs
@@ -115,7 +115,8 @@
 (handlers/register-handler
   :load-chat-parameter-box
   (handlers/side-effect!
-    (fn [{:keys [current-chat-id] :as db} [_ {:keys [name type bot] :as command}]]
+    (fn [{:keys [current-chat-id current-account-id] :as db}
+         [_ {:keys [name type bot] :as command}]]
       (let [parameter-index (input-model/argument-position db current-chat-id)]
         (when (and command (> parameter-index -1))
           (let [jail-id (or bot current-chat-id)
@@ -128,8 +129,12 @@
                 args    (-> (get-in db [:chats current-chat-id :input-text])
                             (input-model/split-command-args)
                             (rest))
+                to       (get-in db [:contacts current-chat-id :address])
+                from (get-in db [])
                 params  {:parameters {:args args}
-                         :context    (merge {:data data}
+                         :context    (merge {:data data
+                                             :from       current-account-id
+                                             :to         to}
                                             (input-model/command-dependent-context-params command))}]
             (status/call-jail
               {:jail-id  jail-id

--- a/src/status_im/chat/handlers/input.cljs
+++ b/src/status_im/chat/handlers/input.cljs
@@ -129,12 +129,11 @@
                 args    (-> (get-in db [:chats current-chat-id :input-text])
                             (input-model/split-command-args)
                             (rest))
-                to       (get-in db [:contacts current-chat-id :address])
-                from (get-in db [])
+                to      (get-in db [:contacts current-chat-id :address])
                 params  {:parameters {:args args}
                          :context    (merge {:data data
-                                             :from       current-account-id
-                                             :to         to}
+                                             :from current-account-id
+                                             :to   to}
                                             (input-model/command-dependent-context-params command))}]
             (status/call-jail
               {:jail-id  jail-id

--- a/src/status_im/chat/handlers/send_message.cljs
+++ b/src/status_im/chat/handlers/send_message.cljs
@@ -80,7 +80,7 @@
             command'      (->> (assoc command-message :handler-data handler-data)
                                (prepare-command current-public-key chat-id clock-value request)
                                (cu/check-author-direction db chat-id))]
-        (log/debug "Handler data: " request (:handler-data command) (dissoc params :commands :command-message))
+        (log/debug "Handler data: " request handler-data (dissoc params :commands :command-message))
         (dispatch [:update-message-overhead! chat-id network-status])
         (dispatch [:set-chat-ui-props {:sending-in-progress? false}])
         (dispatch [::send-command! add-to-chat-id (assoc params :command command') hidden-params])

--- a/src/status_im/chat/views/message/request_message.cljs
+++ b/src/status_im/chat/views/message/request_message.cljs
@@ -76,12 +76,13 @@
         status-initialized? (subscribe [:get :status-module-initialized?])
         markup              (subscribe [:get-in [:message-data :preview message-id :markup]])]
     (fn [{:keys [message-id content from incoming-group]}]
-      (let [commands @commands-atom
-            params   (:params content)
+      (let [commands     @commands-atom
+            params       (:params content)
+            text-content (:text content)
             {:keys [command content]} (parse-command-request commands content)
-            command  (if (and params command)
-                       (merge command {:prefill (vals params)})
-                       command)]
+            command      (if (and params command)
+                           (merge command {:prefill (vals params)})
+                           command)]
         [view st/comand-request-view
          [touchable-highlight
           {:on-press (when (and (not @answered?) @status-initialized?)
@@ -90,9 +91,9 @@
            (if (and @markup
                     (not (string? @markup)))
              [view @markup]
-             [text {:style     st/style-message-text
-                    :font      :default}
-              (or @markup content)])]]
+             [text {:style st/style-message-text
+                    :font  :default}
+              (or text-content @markup content)])]]
          (when (:request-text command)
            [view st/command-request-text-view
             [text {:style st/style-sub-text

--- a/src/status_im/utils/types.cljs
+++ b/src/status_im/utils/types.cljs
@@ -13,4 +13,6 @@
 
 (defn json->clj [json]
   (when-not (= json "undefined")
-    (js->clj (.parse js/JSON json) :keywordize-keys true)))
+    (try
+      (js->clj (.parse js/JSON json) :keywordize-keys true)
+      (catch js/Error _ (when (string? json) json)))))


### PR DESCRIPTION
Some changes that were done during hackathon and were included only in hackathon's version of app.

1. `text-message` can be used fro sending message from bot after command (if status.sendMessage is used, message will appear before command)
2. `from`/`to` props in context args for suggestions functions
3. `text-message` property and `status.sendMessage` method allows to send request from bot
4. ability to add some plain text to request message (instead of rendering command's preview )