### PR TITLE
Upgraded react-native-camera. Fixes #1359

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "react-native-android-sms-listener": "github:adrian-tiberius/react-native-android-sms-listener#listener-bugfix",
     "react-native-autogrow-textinput": "^3.0.2",
     "react-native-autolink": "^0.10.0",
-    "react-native-camera": "^0.7.0",
+    "react-native-camera": "^0.9.4",
     "react-native-circle-checkbox": "github:paramoshkinandrew/ReactNativeCircleCheckbox",
     "react-native-contacts": "^0.2.4",
     "react-native-crypto": "^2.0.1",


### PR DESCRIPTION
fixes #1359

### Summary:
App stopped on edit Capture in profile
Fixed by upgrading `react-native-camera`

### Steps to test:
* Launch the app
* Sign into account 
* Edit profile (left top menu)
* Tap Edit (right top menu)
* Tap on profile image and select Capture
* Take a photo

status: ready

