### PR TITLE
[WIP] Prevent double tap when capturing profile picture

### DIFF
--- a/src/status_im/profile/photo_capture/screen.cljs
+++ b/src/status_im/profile/photo_capture/screen.cljs
@@ -40,6 +40,7 @@
                :background-color toolbar-background1}]
      [camera {:style         {:flex 1}
               :aspect        (:fill aspects)
+              :captureQuality "480p"
               :captureTarget (:disk capture-targets)
               :type          "front"
               :ref           #(reset! camera-ref %)}]


### PR DESCRIPTION
fixes #1363

### Summary:
The user picture doesn't change if tapping on the "Camera" button twice

Reduce captured photo size.
_TODO_ Disable button after first tap

### Steps to test:
- Launch app "Status"
- Login with valid credentials
- Go to Profile
- Click on the button with three points and tap on the "Edit" button
- Tap on the user picture
- Select "Capture"
- Tap on the "Camera" button twice or more

status: wip

