### PR TITLE
letsubs macro

### DIFF
--- a/src/status_im/chat/views/input/input.cljs
+++ b/src/status_im/chat/views/input/input.cljs
@@ -1,5 +1,5 @@
 (ns status-im.chat.views.input.input
-  (:require-macros [status-im.utils.views :refer [defview]])
+  (:require-macros [status-im.utils.views :refer [defview letsubs]])
   (:require [clojure.string :as str]
             [reagent.core :as r]
             [re-frame.core :refer [subscribe dispatch]]
@@ -213,30 +213,30 @@
                   [icon :close_gray style/input-clear-icon]]]))]))})))
 
 (defview input-container [{:keys [anim-margin]}]
-  [command-completion [:command-completion]
-   selected-command [:selected-chat-command]
-   input-text [:chat :input-text]
-   seq-arg-input-text [:chat :seq-argument-input-text]
-   result-box [:chat-ui-props :result-box]]
-  (let [single-line-input? (:singleLineInput result-box)]
-    [view style/input-container
-     [input-view {:anim-margin        anim-margin
-                  :single-line-input? single-line-input?}]
-     (if (:actions result-box)
-       [input-actions/input-actions-view]
-       (when (and (not (str/blank? input-text))
-                  (or (not selected-command)
-                      (some #{:complete :less-than-needed} [command-completion])))
-         [touchable-highlight {:on-press #(if (get-in selected-command [:command :sequential-params])
-                                            (do
-                                              (when-not (str/blank? seq-arg-input-text)
-                                                (dispatch [:send-seq-argument]))
-                                              (js/setTimeout
-                                                (fn [] (dispatch [:chat-input-focus :seq-input-ref]))
-                                                100))
-                                            (dispatch [:send-current-message]))}
-          [view style/send-message-container
-           [icon :arrow_top style/send-message-icon]]]))]))
+  (letsubs [command-completion [:command-completion]
+            selected-command   [:selected-chat-command]
+            input-text         [:chat :input-text]
+            seq-arg-input-text [:chat :seq-argument-input-text]
+            result-box         [:chat-ui-props :result-box]]
+    (let [single-line-input? (:singleLineInput result-box)]
+      [view style/input-container
+       [input-view {:anim-margin        anim-margin
+                    :single-line-input? single-line-input?}]
+       (if (:actions result-box)
+         [input-actions/input-actions-view]
+         (when (and (not (str/blank? input-text))
+                    (or (not selected-command)
+                        (some #{:complete :less-than-needed} [command-completion])))
+           [touchable-highlight {:on-press #(if (get-in selected-command [:command :sequential-params])
+                                              (do
+                                                (when-not (str/blank? seq-arg-input-text)
+                                                  (dispatch [:send-seq-argument]))
+                                                (js/setTimeout
+                                                  (fn [] (dispatch [:chat-input-focus :seq-input-ref]))
+                                                  100))
+                                              (dispatch [:send-current-message]))}
+            [view style/send-message-container
+             [icon :arrow_top style/send-message-icon]]]))])))
 
 (defn container []
   (let [margin                (subscribe [:chat-input-margin])

--- a/src/status_im/utils/views.clj
+++ b/src/status_im/utils/views.clj
@@ -34,12 +34,17 @@
                              [form `(deref ~sym)]))
                          pairs))]))
 
+(defmacro letsubs [args body])
+
 (defmacro defview
-  [n params & rest]
-  (let [[subs component-map body] (case (count rest)
-                                    1 [nil {} (first rest)]
-                                    2 [(first rest) {} (second rest)]
-                                    3 rest)
+  [n params & rest-body]
+  (let [rest-body' (if (= (ffirst rest-body) 'letsubs)
+                     (rest (first rest-body))
+                     rest-body)
+        [subs component-map body] (case (count rest-body')
+                                    1 [nil {} (first rest-body')]
+                                    2 [(first rest-body') {} (second rest-body')]
+                                    3 rest-body')
         [subs-bindings vars-bindings] (prepare-subs subs)]
     `(defn ~n ~params
        (let [~@subs-bindings]

--- a/src/status_im/utils/views.clj
+++ b/src/status_im/utils/views.clj
@@ -38,9 +38,11 @@
 
 (defmacro defview
   [n params & rest-body]
-  (let [rest-body' (if (= (ffirst rest-body) 'letsubs)
-                     (rest (first rest-body))
-                     rest-body)
+  (let [first-symbol (ffirst rest-body)
+        rest-body'   (if (and (symbol? first-symbol)
+                              (= (name first-symbol) "letsubs"))
+                       (rest (first rest-body))
+                       rest-body)
         [subs component-map body] (case (count rest-body')
                                     1 [nil {} (first rest-body')]
                                     2 [(first rest-body') {} (second rest-body')]


### PR DESCRIPTION
```clojure
;; Allows to write
(defview v [arg]
  (letsubs [sub [:sub]]
    [text (str sub arg)]))

;; instead of
(defview v [arg]
  [sub [:sub]]
  [text (str sub arg)])
```
In result `letsubs` can be resolved as let macro in Cursive and symbols defined in `letsubs` will be resolved too. `defview` is compatible with previous version.

