### PR TITLE
status hashtags, android: fix #1247

### DIFF
--- a/src/status_im/android/platform.cljs
+++ b/src/status_im/android/platform.cljs
@@ -37,8 +37,7 @@
                                       :background-color "#7099e619"
                                       :border-radius    5
                                       :padding          4}
-                           :item     {:status-text {:color       styles/color-black
-                                                    :line-height 22
+                           :item     {:status-text {:line-height 22
                                                     :font-size   14}}}
    :contacts              {:show-all-text-font :medium}
    :bottom-gradient       {:height 3}

--- a/src/status_im/components/drawer/styles.cljs
+++ b/src/status_im/components/drawer/styles.cljs
@@ -52,10 +52,12 @@
    :color               common/color-black})
 
 (defnstyle status-view [placeholder?]
-  (merge status-input-view
-         {:color      (if placeholder? common/color-gray common/color-black)
-          :min-height 0
-          :ios        {:padding-top 10}}))
+  (-> (dissoc status-input-view :color)
+      (cond-> placeholder?
+        (assoc :color common/color-gray))
+      (merge
+       {:min-height 0
+        :ios        {:padding-top 10}})))
 
 (def options-button
   {:position :absolute

--- a/src/status_im/components/status_view/view.cljs
+++ b/src/status_im/components/status_view/view.cljs
@@ -4,7 +4,8 @@
             [clojure.string :as str]
             [status-im.components.react :refer [view text]]
             [status-im.utils.platform :refer [platform-specific]]
-            [status-im.components.styles :refer [color-blue]]))
+            [status-im.components.styles :refer [color-blue color-black]]
+            [status-im.utils.utils :refer [hash-tag?]]))
 
 (defn tag-view [tag]
   [text {:style {:color color-blue}
@@ -12,18 +13,21 @@
    (str tag " ")])
 
 (defn status-view [{:keys [style
+                           non-tag-color
                            message-id
                            status
                            on-press
                            number-of-lines]
-                    :or {message-id "msg"}}]
+                    :or {message-id "msg"
+                         non-tag-color color-black}}]
   [text {:style           style
          :on-press        on-press
          :number-of-lines number-of-lines
          :font            :default}
    (for [[i status] (map-indexed vector (str/split status #" "))]
-     (if (.startsWith status "#")
+     (if (hash-tag? status)
        ^{:key (str "item-" message-id "-" i)}
        [tag-view status]
        ^{:key (str "item-" message-id "-" i)}
-       (str status " ")))])
+       [text {:style {:color non-tag-color}}
+        (str status " ")]))])

--- a/src/status_im/profile/screen.cljs
+++ b/src/status_im/profile/screen.cljs
@@ -30,7 +30,8 @@
             [status-im.profile.handlers :refer [message-user]]
             [status-im.profile.styles :as st]
             [status-im.i18n :refer [label]]
-            [status-im.utils.datetime :as time]))
+            [status-im.utils.datetime :as time]
+            [status-im.utils.utils :refer [hash-tag?]]))
 
 
 (defn my-profile-toolbar []
@@ -137,7 +138,7 @@
 
 (defn colorize-status-hashtags [status]
   (for [[i status] (map-indexed vector (str/split status #" "))]
-    (if (.startsWith status "#")
+    (if (hash-tag? status)
       ^{:key (str "item-" i)}
       [tag-view status]
       ^{:key (str "item-" i)}

--- a/src/status_im/utils/utils.cljs
+++ b/src/status_im/utils/utils.cljs
@@ -110,3 +110,6 @@
 
 (defn get-class [name]
   (adapt-class (get-react-property name)))
+
+(defn hash-tag? [s]
+  (= \# (first s)))


### PR DESCRIPTION
fix #1247

### Summary:

`(.startsWith "#你好" "#")` not works, but both
`(.startsWith "#你好" "#你")` and `(.startsWith "#abc" "#")` works.