### PR TITLE
re-frame post migration bugs (part 2)

### DIFF
--- a/src/status_im/utils/handlers.clj
+++ b/src/status_im/utils/handlers.clj
@@ -5,8 +5,14 @@
    All functions are expected to accept [db event] as parameters.
    If one handler returns a modified db it will be used as parameters for subsequent handlers."
   [& forms]
-  (let [db (gensym "db")
-        event (gensym "event")]
+  (let [db     (gensym "db")
+        event  (gensym "event")
+        new-db (gensym "new-db")]
     `(fn [~db ~event]
-       (let [~@(interleave (repeat db) (map #(list 'or (list % db event) db) forms))]
+       (let [~@(interleave (repeat db)
+                           (map (fn [form]
+                                  `(let [~new-db (~form ~db ~event)]
+                                     (if (map? ~new-db)
+                                       ~new-db
+                                       ~db))) forms))]
          ~db))))


### PR DESCRIPTION
Before this commit 
```clojure
(handlers->
    (fn [db [_ data]]
      (account-update db data))
    save-account!
    broadcast-account-update)
```
was expanded as 
```clojure
(fn*
    ([db# event#]
     (let [db# (or ((fn [db [_ data]] (account-update db data)) db# event#) db#)
           db# (or (save-account! db# event#) db#)
           db# (or (broadcast-account-update db# event#) db#)]
       db#)))
```
which means that if `save-account!` returns not nil value but not db the flow will be broken.

This fix doesn't guaranty that problem will not appear anymore, but `handlers->` is a temporary solution before refactoring and it should work fine for now.

```clojure
(fn*
  ([db# event#]
   (let [db# (let [new-db# ((fn [db [_ data]] (account-update db data))
                             db#
                             event#)]
               (if (map? new-db#)
                 new-db#
                 db#))
         db# (let [new-db# (save-account! db# event#)]
               (if (map? new-db#)
                 new-db#
                 db#))
         db# (let [new-db# (broadcast-account-update db# event#)]
               (if (map? new-db#)
                 new-db#
                 db#))]
     db#)))
```
status: ready

