### PR TITLE
Names for send/request messages in group chat (#1396); refactoring of command sending

### DIFF
--- a/bots/wallet/bot.js
+++ b/bots/wallet/bot.js
@@ -424,7 +424,7 @@ function previewSend(params, context) {
                     lineHeight: 18
                 }
             },
-            "to " + params["bot-db"]["public"]["recipient"]["name"]
+            I18n.t('send_sending_to') + " " + params["bot-db"]["public"]["recipient"]["name"]
         );
         markup = [firstRow, secondRow];
     } else {
@@ -506,18 +506,51 @@ status.command({
                 },
                 prefill: [context["current-account"]["name"], val],
                 prefillBotDb: {
-                    contact: context["current-account"]
+                    public: {
+                        recipient: context["current-account"]
+                    }
                 }
             }
         };
     },
     preview: function (params, context) {
+        var firstRow = status.components.text(
+            {},
+            I18n.t('request_requesting') + " "
+            + status.localizeNumber(params.amount, context.delimiter, context.separator)
+            + " ETH"
+        );
+
+        var markup;
+
+        if (params["bot-db"]
+            && params["bot-db"]["public"]
+            && params["bot-db"]["public"]["recipient"]
+            && context["chat"]["group-chat"] === true) {
+
+            var secondRow = status.components.text(
+                {
+                    style: {
+                        color: "#9199a0",
+                        fontSize: 14,
+                        lineHeight: 18
+                    }
+                },
+                I18n.t('request_requesting_from') + " " + params["bot-db"]["public"]["recipient"]["name"]
+            );
+            markup = [firstRow, secondRow];
+        } else {
+            markup = [firstRow];
+        }
+
         return {
-            markup: status.components.text(
-                {},
-                I18n.t('request_requesting') + " "
-                + status.localizeNumber(params.amount, context.delimiter, context.separator)
-                + " ETH"
+            markup: status.components.view(
+                {
+                    style: {
+                        flexDirection: "column"
+                    }
+                },
+                markup
             )
         };
     },

--- a/bots/wallet/translations.js
+++ b/bots/wallet/translations.js
@@ -13,12 +13,14 @@ I18n.translations = {
         send_explanation_2: 'usually within a minute.',
         send_explanation_3: 'probably within 30 seconds.',
         send_explanation_4: 'probably within a few seconds.',
+        send_sending_to: 'to ',
 
         eth: 'ETH',
 
         request_title: 'Request ETH',
         request_description: 'Request a payment',
         request_requesting: 'Requesting ',
+        request_requesting_from: 'from ',
 
         validation_title: 'Amount',
         validation_amount_specified: 'Amount must be specified',

--- a/src/status_im/chat/handlers/commands.cljs
+++ b/src/status_im/chat/handlers/commands.cljs
@@ -21,7 +21,7 @@
   (handlers/side-effect!
     (fn [{:keys [contacts current-account-id chats] :as db}
          [_ {{:keys [command params content-command type]} :content
-             :keys [message-id from chat-id on-requested jail-id] :as message} data-type]]
+             :keys [message-id chat-id jail-id on-requested from] :as message} data-type]]
       (let [jail-id  (or jail-id chat-id)
             jail-id' (if (get-in chats [jail-id :group-chat])
                        (get-in chats [jail-id :command-suggestions (keyword command) :owner-id])

--- a/src/status_im/chat/handlers/console.cljs
+++ b/src/status_im/chat/handlers/console.cljs
@@ -10,24 +10,24 @@
 
 (def console-commands
   {:password
-   (fn [params _]
-     (dispatch [:create-account (params "password")]))
+   (fn [{:keys [password]} _]
+     (dispatch [:create-account password]))
 
    :phone
-   (fn [params id]
-     (dispatch [:sign-up (params "phone") id]))
+   (fn [{:keys [phone]} id]
+     (dispatch [:sign-up phone id]))
 
    :confirmation-code
-   (fn [params id]
-     (dispatch [:sign-up-confirm (params "code") id]))
+   (fn [{:keys [code]} id]
+     (dispatch [:sign-up-confirm code id]))
 
    :faucet
-   (fn [params id]
-     (dispatch [:open-faucet (params "url") id]))
+   (fn [{:keys [url]} id]
+     (dispatch [:open-faucet url id]))
 
    :debug
-   (fn [params id]
-     (let [debug-on? (= (params "mode") "On")]
+   (fn [{:keys [mode]} id]
+     (let [debug-on? (= mode "On")]
        (dispatch [:account-update {:debug? debug-on?}])
        (if debug-on?
          (do
@@ -49,10 +49,14 @@
 
 (register-handler :invoke-console-command-handler!
   (u/side-effect!
-    (fn [_ [_ {:keys [chat-id command-message] :as parameters}]]
-      (let [{:keys [id command params]} command-message
-            {:keys [name]} command]
-        (dispatch [:prepare-command! chat-id parameters])
+    (fn [_ [_ {{:keys [command
+                       params
+                       id]
+                :as   content} :command
+               chat-id         :chat-id
+               :as             all-params}]]
+      (let [{:keys [name]} command]
+        (dispatch [:prepare-command! chat-id all-params])
         ((console-commands (keyword name)) params id)))))
 
 (register-handler :set-message-status

--- a/src/status_im/chat/handlers/input.cljs
+++ b/src/status_im/chat/handlers/input.cljs
@@ -168,10 +168,10 @@
 
 (handlers/register-handler ::send-message
   (handlers/side-effect!
-    (fn [{:keys [current-public-key current-account-id] :as db} [_ command-message chat-id]]
+    (fn [{:keys [current-public-key current-account-id] :as db} [_ command chat-id]]
       (let [text (get-in db [:chats chat-id :input-text])
             data {:message  text
-                  :command  command-message
+                  :command  command
                   :chat-id  chat-id
                   :identity current-public-key
                   :address  current-account-id}]
@@ -179,41 +179,30 @@
         (dispatch [:set-chat-input-metadata nil chat-id])
         (dispatch [:set-chat-ui-props {:sending-in-progress? false}])
         (cond
-          command-message
+          command
           (dispatch [:check-commands-handlers! data])
           (not (str/blank? text))
           (dispatch [:prepare-message data]))))))
 
 (handlers/register-handler :proceed-command
   (handlers/side-effect!
-    (fn [db [_ command chat-id]]
-      (let [jail-id (or (get-in command [:command :bot]) chat-id)]
-        ;:check-and-load-commands!
-        (let [params
-              {:command command
-               :chat-id chat-id
-               :jail-id jail-id}
+    (fn [db [_ {{:keys [bot]} :command :as content} chat-id]]
+      (let [params            {:content content
+                               :chat-id chat-id
+                               :jail-id (or bot chat-id)}
+            on-send-params    (merge params
+                                     {:data-type :on-send
+                                      :after     #(dispatch [::send-command %2 content chat-id])})
+            after-validation  #(dispatch [::request-command-data on-send-params])
+            validation-params (merge params
+                                     {:data-type :validator
+                                      :after     #(dispatch [::proceed-validation %2 after-validation])})]
 
-              on-send-params
-              (merge params
-                     {:data-type :on-send
-                      :after     (fn [_ res]
-                                   (dispatch [::send-command res command chat-id]))})
+        (dispatch [::request-command-data validation-params])))))
 
-              after-validation
-              #(dispatch [::request-command-data on-send-params])
-
-              validation-params
-              (merge params
-                     {:data-type :validator
-                      :after     #(dispatch [::proceed-validation-messages
-                                             command chat-id %2 after-validation])})]
-
-          (dispatch [::request-command-data validation-params]))))))
-
-(handlers/register-handler ::proceed-validation-messages
+(handlers/register-handler ::proceed-validation
   (handlers/side-effect!
-    (fn [db [_ command chat-id {:keys [markup validationHandler parameters]} proceed-fn]]
+    (fn [db [_ {:keys [markup validationHandler parameters]} proceed-fn]]
       (let [set-errors #(do (dispatch [:set-chat-ui-props {:validation-messages  %
                                                            :sending-in-progress? false}]))]
         (cond
@@ -235,7 +224,7 @@
 
 (handlers/register-handler ::send-command
   (handlers/side-effect!
-    (fn [db [_ on-send {{:keys [fullscreen]} :command :as command} chat-id]]
+    (fn [db [_ on-send {{:keys [fullscreen bot]} :command :as content} chat-id]]
       (if on-send
         (do
           (when fullscreen
@@ -244,9 +233,9 @@
                                          :sending-in-progress? false}])
           (react-comp/dismiss-keyboard!))
         (dispatch [::request-command-data
-                   {:command   command
+                   {:content   content
                     :chat-id   chat-id
-                    :jail-id   (get-in command [:command :bot])
+                    :jail-id   (or bot chat-id)
                     :data-type :preview
                     :after     #(dispatch [::send-message % chat-id])}])))))
 
@@ -256,8 +245,8 @@
          [_ {{:keys [command
                      metadata
                      args]
-              :as   c} :command
-             :keys     [message-id chat-id jail-id data-type after]}]]
+              :as   content} :content
+             :keys     [chat-id jail-id data-type after]}]]
       (let [{:keys [dapp? dapp-url name]} (get contacts chat-id)
             message-id      (random/id)
             metadata        (merge metadata
@@ -266,7 +255,10 @@
                                       :name (i18n/get-contact-translated chat-id :name name)}))
             owner-id        (:owner-id command)
             bot-db          (get bot-db chat-id)
-            params          (assoc (input-model/args->params c) :bot-db bot-db)
+            params          (merge (input-model/args->params content)
+                                   {:bot-db   bot-db
+                                    :metadata metadata})
+
             command-message {:command    command
                              :params     params
                              :to-message (:to-message-id metadata)
@@ -274,11 +266,12 @@
                              :id         message-id
                              :chat-id    chat-id
                              :jail-id    (or owner-id jail-id)}
+
             request-data    {:message-id   message-id
                              :chat-id      chat-id
                              :jail-id      (or owner-id jail-id)
                              :content      {:command (:name command)
-                                            :params  (assoc params :metadata metadata :bot-db bot-db)
+                                            :params  params
                                             :type    (:type command)}
                              :on-requested #(after command-message %)}]
         (dispatch [:request-command-data request-data data-type])))))
@@ -344,11 +337,11 @@
                                 (dispatch [:update-seq-arguments chat-id])
                                 (dispatch [:send-current-message]))]
         (dispatch [::request-command-data
-                   {:command   command
+                   {:content   command
                     :chat-id   chat-id
+                    ;;TODO(alwx): jail-id ?
                     :data-type :validator
-                    :after     #(dispatch [::proceed-validation-messages
-                                           command chat-id %2 after-validation])}])))))
+                    :after     #(dispatch [::proceed-validation %2 after-validation])}])))))
 
 (handlers/register-handler :set-chat-seq-arg-input-text
   (fn [{:keys [current-chat-id] :as db} [_ text chat-id]]

--- a/src/status_im/chat/models/input.cljs
+++ b/src/status_im/chat/models/input.cljs
@@ -158,7 +158,7 @@
   (let [params (:params command)]
     (->> args
          (map-indexed (fn [i value]
-                        (vector (get-in params [i :name]) value)))
+                        [(keyword (get-in params [i :name])) value]))
          (into {}))))
 
 (defn command-dependent-context-params

--- a/src/status_im/chat/views/message/request_message.cljs
+++ b/src/status_im/chat/views/message/request_message.cljs
@@ -77,12 +77,12 @@
         markup              (subscribe [:get-in [:message-data :preview message-id :markup]])]
     (fn [{:keys [message-id content from incoming-group]}]
       (let [commands @commands-atom
-            {:keys        [prefill prefillBotDb params]
+            {:keys        [prefill prefill-bot-db prefillBotDb params]
              text-content :text} content
             {:keys [command content]} (parse-command-request commands content)
             command  (if (and params command)
                        (merge command {:prefill        prefill
-                                       :prefill-bot-db prefillBotDb})
+                                       :prefill-bot-db (or prefill-bot-db prefillBotDb)})
                        command)]
         [view st/comand-request-view
          [touchable-highlight

--- a/src/status_im/commands/handlers/jail.cljs
+++ b/src/status_im/commands/handlers/jail.cljs
@@ -15,7 +15,7 @@
 
 (defn command-handler!
   [_ [chat-id
-      {:keys [command-message] :as parameters}
+      {:keys [command] :as params}
       {:keys [result error]}]]
   (let [{:keys [context returned]} result
         {handler-error :error} returned]
@@ -25,14 +25,14 @@
         (dispatch [:set-chat-ui-props {:validation-messages (cu/generate-hiccup markup)}]))
 
       result
-      (let [command'    (assoc command-message :handler-data returned)
-            parameters' (assoc parameters :command command')]
+      (let [command' (assoc command :handler-data returned)
+            params'  (assoc params :command command')]
         (if (:eth_sendTransaction context)
-          (dispatch [:wait-for-transaction (:id command-message) parameters'])
-          (dispatch [:prepare-command! chat-id parameters'])))
+          (dispatch [:wait-for-transaction (:id command) params'])
+          (dispatch [:prepare-command! chat-id params'])))
 
       (not (or error handler-error))
-      (dispatch [:prepare-command! chat-id parameters])
+      (dispatch [:prepare-command! chat-id params])
 
       :else nil)))
 


### PR DESCRIPTION
I've changed the way command's structure look like (for instance, there is no more `:command-message`) and fixes #1396
Probably it also solves other issues.