### PR TITLE
chat: fix input length styling after commands

### DIFF
--- a/src/status_im/chat/styles/input/input.cljs
+++ b/src/status_im/chat/styles/input/input.cljs
@@ -82,8 +82,8 @@
    :ios                 {:line-height min-input-height
                          :left        (+ 10 left)}})
 
-(defnstyle seq-input-text [left]
-  {:min-width           200
+(defnstyle seq-input-text [left container-width]
+  {:min-width           (- container-width left)
    :font-size           14
    :position            :absolute
    :text-align-vertical :center

--- a/src/status_im/chat/views/input/input.cljs
+++ b/src/status_im/chat/views/input/input.cljs
@@ -155,11 +155,11 @@
         arg-pos              (subscribe [:current-chat-argument-position])
         seq-arg-input-text   (subscribe [:chat :seq-argument-input-text])
         sending-in-progress? (subscribe [:chat-ui-props :sending-in-progress?])]
-    (fn [{:keys [command-width]}]
+    (fn [{:keys [command-width container-width]}]
       (when (get-in @command [:command :sequential-params])
         (let [{:keys [placeholder hidden type]} (get-in @command [:command :params @arg-pos])]
           [text-input (merge {:ref               #(dispatch [:set-chat-ui-props {:seq-input-ref %}])
-                              :style             (style/seq-input-text command-width)
+                              :style             (style/seq-input-text command-width container-width)
                               :default-value     (or @seq-arg-input-text "")
                               :on-change-text    #(do (dispatch [:set-chat-seq-arg-input-text %])
                                                       (dispatch [:set-chat-ui-props {:validation-messages nil}]))
@@ -194,7 +194,8 @@
                                :single-line-input?  single-line-input?}]
             [input-helper {:command command
                            :width   width}]
-            [seq-input {:command-width width}]
+            [seq-input {:command-width width
+                        :container-width container-width}]
             (if-not command
               [touchable-highlight
                {:on-press #(do (dispatch [:toggle-chat-ui-props :show-emoji?])


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)
fixes #1354 

### Summary:
[comment]: # (Summarise the problem and how the pull request solves it)
This PR fixes overflowing characters after  any `/command` input if the text is too long and doesn't fit on one line together with `/command` prefix. 
The reason why it was happening was that minimal width of the input element for commands was set to 200, which together with `/command` width was often more then width of the wrapping container element.
Now the minimal width for the input element is computed by subtracting `/command` width from enclosing container-width.

### Steps to test:
- Open Status
- Open console
- Select `/confirmation-code` command and write some long number there, notice that it doesn't overflow over right edge (over `x` button) as before.

[comment]: # (PRs will only be accepted if squashed into single commit.)
status: ready
