### PR TITLE
Simplification and comments for `input` model

### DIFF
--- a/src/status_im/chat/subs.cljs
+++ b/src/status_im/chat/subs.cljs
@@ -73,13 +73,6 @@
                      (merge responses commands))))
            (apply merge)))))
 
-(reg-sub :possible-chat-actions
-  (fn [db [_ chat-id]]
-    "Returns a vector of [command message-id] values. `message-id` can be `:any`.
-     Example: [[browse-command :any] [debug-command :any] [phone-command '1489161286111-58a2cd...']]"
-    (let [chat-id (or chat-id (db :current-chat-id))]
-      (input-model/possible-chat-actions db chat-id))))
-
 (reg-sub
   :selected-chat-command
   (fn [db [_ chat-id]]
@@ -138,7 +131,7 @@
           selected-command  (subscribe [:selected-chat-command chat-id])
           requests          (subscribe [:chat :request-suggestions chat-id])
           commands          (subscribe [:chat :command-suggestions chat-id])]
-      (and (or @show-suggestions? (chat-utils/starts-as-command? (str/trim (or @input-text ""))))
+      (and (or @show-suggestions? (input-model/starts-as-command? (str/trim (or @input-text ""))))
            (not (:command @selected-command))
            (or (not-empty @requests)
                (not-empty @commands))))))

--- a/src/status_im/chat/utils.cljs
+++ b/src/status_im/chat/utils.cljs
@@ -56,8 +56,3 @@
     bot (str const/bot-char bot)
 
     :else (str const/command-char name)))
-
-(defn starts-as-command? [text]
-  (and (not (nil? text))
-       (or (str/starts-with? text const/bot-char)
-           (str/starts-with? text const/command-char))))

--- a/src/status_im/chat/views/api/choose_contact.cljs
+++ b/src/status_im/chat/views/api/choose_contact.cljs
@@ -1,4 +1,4 @@
-(ns status-im.chat.views.choosers.choose-contact
+(ns status-im.chat.views.api.choose-contact
   (:require-macros [status-im.utils.views :refer [defview]])
   (:require [reagent.core :as r]
             [re-frame.core :refer [dispatch subscribe]]

--- a/src/status_im/chat/views/api/geolocation/styles.cljs
+++ b/src/status_im/chat/views/api/geolocation/styles.cljs
@@ -1,4 +1,4 @@
-(ns status-im.chat.views.geolocation.styles
+(ns status-im.chat.views.api.geolocation.styles
   (:require [status-im.components.styles :as common]))
 
 (defn place-item-container [address]

--- a/src/status_im/chat/views/api/geolocation/views.cljs
+++ b/src/status_im/chat/views/api/geolocation/views.cljs
@@ -1,4 +1,4 @@
-(ns status-im.chat.views.geolocation.views
+(ns status-im.chat.views.api.geolocation.views
   (:require-macros [status-im.utils.views :refer [defview letsubs]]
                    [reagent.ratom :refer [reaction]])
   (:require [status-im.components.react :refer [view image text touchable-highlight]]
@@ -6,7 +6,7 @@
             [goog.string :as gstr]
             [status-im.utils.utils :refer [http-get]]
             [status-im.utils.types :refer [json->clj]]
-            [status-im.chat.views.geolocation.styles :as st]
+            [status-im.chat.views.api.geolocation.styles :as st]
             [status-im.components.mapbox :refer [mapview]]
             [re-frame.core :refer [dispatch subscribe]]
             [status-im.i18n :refer [label]]

--- a/src/status_im/commands/utils.cljs
+++ b/src/status_im/commands/utils.cljs
@@ -5,9 +5,9 @@
             [status-im.components.react :as components]
             [status-im.chat.views.input.web-view :as chat-web-view]
             [status-im.chat.views.input.validation-messages :as chat-validation-messages]
-            [status-im.chat.views.choosers.choose-contact :as choose-contact]
+            [status-im.chat.views.api.choose-contact :as choose-contact]
             [status-im.components.qr-code :as qr]
-            [status-im.chat.views.geolocation.views :as geolocation]
+            [status-im.chat.views.api.geolocation.views :as geolocation]
             [status-im.utils.handlers :refer [register-handler]]
             [taoensso.timbre :as log]))
 

--- a/src/status_im/components/react.cljs
+++ b/src/status_im/components/react.cljs
@@ -170,3 +170,7 @@
                        [keyboard-avoiding-view-class (merge {:behavior :padding} props)]
                        [view props])]
     (vec (concat view-element children))))
+
+;; Emoji
+
+(def emojilib (js/require "emojilib"))


### PR DESCRIPTION
This PR aims to solve two problems:
1) The `input` model's code is too complex and cannot be understood by everyone;
2) There is some logic in `input` view, and this logic should be moved to `input` model or subscriptions/handlers.

I've also moved `geolocation` views to `status.chat.views.api`, and reduced the number of dispatch calls for input (i.e. created a separate handler `:update-input-data` which is now called instead of 3 handlers in a row).