### PR TITLE
console: add preview for phone command

### DIFF
--- a/bots/console/bot.js
+++ b/bots/console/bot.js
@@ -467,7 +467,23 @@ var phoneConfig = {
         type: status.types.PHONE,
         suggestions: phoneSuggestions,
         placeholder: I18n.t('phone_placeholder')
-    }]
+    }],
+    preview: function (params) {
+        return {
+            markup: status.components.text(
+                {},
+                params.phone
+            )
+        };
+    },
+    shortPreview: function (params) {
+        return {
+            markup: status.components.text(
+                {},
+                params.phone
+            )
+        };
+    }
 };
 status.response(phoneConfig);
 status.command(phoneConfig);


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)
fixes #1438 

### Summary:
[comment]: # (Summarise the problem and how the pull request solves it)
Preview for phone command was missing, as a result, internal piece of app-db was displayed whenever `/phone` command was entered in the console, this PR fixes it by correct preview/shortPreview functions which pull just relevant data (phone number) in right markup for display.

### Steps to test:
- Open Status
- Open console from contacts
- Isse an `/phone` command
- Check if the `/phone` command message is displayed in a correct way (only command prefix + phone number)

[comment]: # (PRs will only be accepted if squashed into single commit.)
status: ready

