### PR TITLE
Upgraded figwheel/cljsbuild.

### DIFF
--- a/env/dev/user.clj
+++ b/env/dev/user.clj
@@ -24,9 +24,6 @@
 (def cljs-builds
   (get-in profiles [:dev :cljsbuild :builds]))
 
-(def buids-by-id
-  (into {} (map (fn [{:keys [id] :as build}] [id build]) cljs-builds)))
-
 (defn start-figwheel
   "Start figwheel for one or more builds"
   [build-ids cljs-builds]
@@ -62,16 +59,18 @@
 (defn get-builds [ids all-builds]
   (keep
     (fn [id]
-      (let [build (get all-builds (get-id id))]
-        (if (test-id? id)
-          (get-test-build build)
-          build)))
+      (assoc
+        (let [build (get all-builds (get-id id))]
+          (if (test-id? id)
+            (get-test-build build)
+            build))
+        :id id))
     ids))
 
 (let [env-build-ids (System/getenv "BUILD_IDS")
       build-ids     (if env-build-ids
                       (map keyword (s/split env-build-ids #","))
                       [:android])
-      builds        (get-builds build-ids buids-by-id)]
+      builds        (get-builds build-ids cljs-builds)]
   (start-figwheel build-ids builds)
   (rfs/-main))

--- a/figwheel-bridge.js
+++ b/figwheel-bridge.js
@@ -220,7 +220,7 @@ function loadApp(platform, devHost, onLoadCb) {
                 // seriously React packager? why.
                 var googreq = goog.require;
 
-                googreq('figwheel.connect.' + platform);
+                googreq('figwheel.connect.build_' + platform);
             });
         });
     }

--- a/project.clj
+++ b/project.clj
@@ -12,8 +12,8 @@
                  [tailrecursion/cljs-priority-map "1.2.0"]
                  [com.taoensso/timbre "4.7.4"]
                  [com.google.guava/guava "21.0"]]
-  :plugins [[lein-cljsbuild "1.1.4"]
-            [lein-figwheel "0.5.8"]
+  :plugins [[lein-cljsbuild "1.1.6"]
+            [lein-figwheel "0.5.11"]
             [lein-re-frisk "0.4.7"]
             [rasom/lein-externs "0.1.7"]]
   :clean-targets ["target/" "index.ios.js" "index.android.js"]
@@ -25,7 +25,7 @@
             "test" ["doo" "phantom" "test" "once"]}
   :test-paths ["test/clj"]
   :figwheel {:nrepl-port 7888}
-  :profiles {:dev  {:dependencies [[figwheel-sidecar "0.5.8"]
+  :profiles {:dev  {:dependencies [[figwheel-sidecar "0.5.11"]
                                    [re-frisk-remote "0.4.2"]
                                    [re-frisk-sidecar "0.4.5"]
                                    [com.cemerick/piggieback "0.2.1"]
@@ -33,48 +33,49 @@
                                    [hawk "0.2.10"]]
                     :plugins      [[lein-doo "0.1.7"]]
                     :source-paths ["src" "env/dev"]
-                    :cljsbuild    {:builds [{:id           :ios
-                                             :source-paths ["src" "env/dev"]
-                                             :figwheel     true
-                                             :compiler     {:output-to     "target/ios/app.js"
-                                                            :main          "env.ios.main"
-                                                            :output-dir    "target/ios"
-                                                            :optimizations :none}}
-                                            {:id           :android
-                                             :source-paths ["src" "env/dev"]
-                                             :figwheel     true
-                                             :compiler     {:output-to     "target/android/app.js"
-                                                            :main          "env.android.main"
-                                                            :output-dir    "target/android"
-                                                            :optimizations :none}}
-                                            {:id           "test"
-                                             :source-paths ["src" "test/cljs"]
-                                             :compiler
-                                                           {:main          status-im.test.runner
-                                                            :output-to     "target/test/test.js"
-                                                            :output-dir    "target"
-                                                            :optimizations :none}}]}
+                    :cljsbuild    {:builds
+                                   {:ios
+                                    {:source-paths ["src" "env/dev"]
+                                     :figwheel     true
+                                     :compiler     {:output-to     "target/ios/app.js"
+                                                    :main          "env.ios.main"
+                                                    :output-dir    "target/ios"
+                                                    :optimizations :none}}
+                                    :android
+                                    {:source-paths ["src" "env/dev"]
+                                     :figwheel     true
+                                     :compiler     {:output-to     "target/android/app.js"
+                                                    :main          "env.android.main"
+                                                    :output-dir    "target/android"
+                                                    :optimizations :none}}
+                                    :test
+                                    {:source-paths ["src" "test/cljs"]
+                                     :compiler     {:main          status-im.test.runner
+                                                    :output-to     "target/test/test.js"
+                                                    :output-dir    "target"
+                                                    :optimizations :none}}}}
                     :repl-options {:nrepl-middleware [cemerick.piggieback/wrap-cljs-repl]
                                    :timeout          240000}}
-             :prod {:cljsbuild {:builds [{:id           "ios"
-                                          :source-paths ["src" "env/prod"]
-                                          :compiler     {:output-to          "index.ios.js"
-                                                         :main               "env.ios.main"
-                                                         :output-dir         "target/ios-prod"
-                                                         :static-fns         true
-                                                         :optimize-constants true
-                                                         :optimizations      :advanced
-                                                         :externs            ["externs/externs.js"]
-                                                         :closure-defines    {"goog.DEBUG" false}
-                                                         :parallel-build true}}
-                                         {:id           "android"
-                                          :source-paths ["src" "env/prod"]
-                                          :compiler     {:output-to          "index.android.js"
-                                                         :main               "env.android.main"
-                                                         :output-dir         "target/android-prod"
-                                                         :static-fns         true
-                                                         :optimize-constants true
-                                                         :optimizations      :advanced
-                                                         :externs            ["externs/externs.js"]
-                                                         :closure-defines    {"goog.DEBUG" false}
-                                                         :parallel-build true}}]}}})
+             :prod {:cljsbuild {:builds
+                                {:ios
+                                 {:source-paths ["src" "env/prod"]
+                                  :compiler     {:output-to          "index.ios.js"
+                                                 :main               "env.ios.main"
+                                                 :output-dir         "target/ios-prod"
+                                                 :static-fns         true
+                                                 :optimize-constants true
+                                                 :optimizations      :advanced
+                                                 :externs            ["externs/externs.js"]
+                                                 :closure-defines    {"goog.DEBUG" false}
+                                                 :parallel-build true}}
+                                 :android
+                                 {:source-paths ["src" "env/prod"]
+                                  :compiler     {:output-to          "index.android.js"
+                                                 :main               "env.android.main"
+                                                 :output-dir         "target/android-prod"
+                                                 :static-fns         true
+                                                 :optimize-constants true
+                                                 :optimizations      :advanced
+                                                 :externs            ["externs/externs.js"]
+                                                 :closure-defines    {"goog.DEBUG" false}
+                                                 :parallel-build true}}}}}})


### PR DESCRIPTION
### Summary:
Upgraded to latest figwheel/cljsbuild. Adapted `builds` syntax so that we can perform the following:

* lein doo phantom test once
* lein cljsbuild once android

Note `figwheel` offers new features we might want to leverage (e.g. it would be nice to be able to execute test w/o starting figwheel /re-frisk..)
To be addressed in a subsequent PR.

status: ready
