### PR TITLE
Make sure validation-messages are nil when navigating to a chat

### DIFF
--- a/src/status_im/chat/handlers.cljs
+++ b/src/status_im/chat/handlers.cljs
@@ -274,6 +274,8 @@
                                {:chat-id  chat-id
                                 :function :init
                                 :context  {:from current-account-id}}))]
+       ; Reset validation messages, if any
+       (dispatch [:set-chat-ui-props {:validation-messages nil}])
        (dispatch [:load-requests! chat-id])
         ;; todo rewrite this. temporary fix for https://github.com/status-im/status-react/issues/607
        #_(dispatch [:load-commands! chat-id])


### PR DESCRIPTION

fixes #1421 

### Summary:
The error message remains on Chat switching 

### Steps to test:

Log in to the app
Go to the Contact -> Jarrad
Use send command to send 1000 amount (e.g."Send Jarrad 1000") As a result, error message is shown.
Go to the wallet or another chat
Go to chat Jarrad
There is no error

status: ready

