### PR TITLE
chat, data, utils: add implementation of simple preview caching

### DIFF
--- a/src/status_im/data_store/messages.cljs
+++ b/src/status_im/data_store/messages.cljs
@@ -2,6 +2,7 @@
   (:require [status-im.data-store.realm.messages :as data-store]
             [clojure.string :refer [join split]]
             [status-im.utils.random :refer [timestamp]]
+            [status-im.utils.utils :refer [update-if-present]]
             [clojure.walk :refer [stringify-keys keywordize-keys]]
             [cljs.reader :refer [read-string]]
             [status-im.constants :as c])
@@ -111,10 +112,10 @@
                            :timestamp (timestamp)})]
       (data-store/save message'))))
 
-(defn update
+(defn update 
   [{:keys [message-id] :as message}]
   (when (data-store/exists? message-id)
-    (let [message (clojure.core/update message :user-statuses vals)]
+    (let [message (update-if-present message :user-statuses vals)]
       (data-store/save message))))
 
 (defn delete-by-chat-id [chat-id]

--- a/src/status_im/utils/utils.cljs
+++ b/src/status_im/utils/utils.cljs
@@ -20,11 +20,11 @@
    (.alert (.-Alert rn-dependencies/react-native)
            title
            content
-           ; Styles are only relevant on iOS. On Android first button is 'neutral' and second is 'positive'
+           ;; Styles are only relevant on iOS. On Android first button is 'neutral' and second is 'positive'
            (clj->js
-             (vector (merge {:text (label :t/cancel) :style "cancel"}
-                            (when on-cancel {:onPress on-cancel}))
-                     {:text (or s "OK") :onPress on-accept :style "destructive"})))))
+            (vector (merge {:text (label :t/cancel) :style "cancel"}
+                           (when on-cancel {:onPress on-cancel}))
+                    {:text (or s "OK") :onPress on-accept :style "destructive"})))))
 
 (defn http-post
   ([action data on-success]
@@ -49,7 +49,7 @@
 
 (defn http-get
   ([url on-success on-error]
-    (http-get url nil on-success on-error))
+   (http-get url nil on-success on-error))
   ([url valid-response? on-success on-error]
    (-> (.fetch js/window url (clj->js {:method  "GET"
                                        :headers {"Cache-Control" "no-cache"}}))
@@ -72,9 +72,13 @@
                    (fn [error]
                      (show-popup "Error" (str error))))))))
 
-(defn truncate-str [s max]
-  (if (and (< max (count s)) s)
-    (str (subs s 0 (- max 3)) "...")
+(defn truncate-str
+  "Given string and max threshold, trims the string to threshold length with `...`
+  appended to end if length of the string exceeds max threshold, returns the same
+  string if threshold is not exceeded"
+  [s threshold]
+  (if (and s (< threshold (count s)))
+    (str (subs s 0 (- threshold 3)) "...")
     s))
 
 (defn clean-text [s]
@@ -84,14 +88,13 @@
       (str/trim)))
 
 (defn first-index
-  [cond coll]
-  (loop [index 0
-         cond cond
-         coll coll]
-    (when (seq coll)
-      (if (cond (first coll))
-        index
-        (recur (inc index) cond (next coll))))))
+  "Returns first index in coll where predicate on coll element is truthy"
+  [pred coll]
+  (->> coll
+       (keep-indexed (fn [idx e]
+                       (when (pred e)
+                         idx)))
+       first))
 
 (defn hash-tag? [s]
   (= \# (first s)))
@@ -105,3 +108,11 @@
         (vreset! called? true)
         (apply f args)
         nil))))
+
+(defn update-if-present
+  "Like regular `clojure.core/update` but returns original map if update key is not present"
+  [m k f & args]
+  (if (contains? m k)
+    (apply update m k f args)
+    m))
+

--- a/test/cljs/status_im/test/utils/utils.cljs
+++ b/test/cljs/status_im/test/utils/utils.cljs
@@ -1,6 +1,6 @@
 (ns status-im.test.utils.utils
-    (:require [cljs.test :refer-macros [deftest is]]
-              [status-im.utils.utils :as u]))
+  (:require [cljs.test :refer-macros [deftest is]]
+            [status-im.utils.utils :as u]))
 
 (deftest wrap-as-call-once-test
   (let [count (atom 0)]
@@ -10,3 +10,29 @@
         (is (= 1 @count))
         (is (nil? (f)))
         (is (= 1 @count))))))
+
+(deftest truncate-str-test
+  (is (= (u/truncate-str "Long string" 7) "Long...")) ; threshold is less then string length
+  (is (= (u/truncate-str "Long string" 11) "Long string")) ; threshold is the same as string length
+  (is (= (u/truncate-str "Long string" 20) "Long string"))) ; threshold is more then string length
+
+(deftest clean-text-test
+  (is (= (u/clean-text "Hello! \n\r") "Hello!")
+      (= (u/clean-text "Hello!") "Hello!")))
+
+(deftest first-index-test
+  (is (= 2 (u/first-index (partial = :test)
+                          '(:a :b :test :c :test))))
+  (is (= nil (u/first-index (partial = :test)
+                            '(:a :b :c)))))
+
+(deftest hash-tag?-test
+  (is (u/hash-tag? "#clojure"))
+  (is (not (u/hash-tag? "clojure")))
+  (is (not (u/hash-tag? "clo#jure")))
+  (is (not (u/hash-tag? "clojure#"))))
+
+(deftest update-if-present-test
+  (is (= {:a 1} (u/update-if-present {:a 0} :a inc)))
+  (is (= {:a 2} (u/update-if-present {:a 0} :a + 2)))
+  (is (= {:a 0} (u/update-if-present {:a 0} :b inc))))


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

### Summary:
[comment]: # (Summarise the problem and how the pull request solves it)
Implement simple preview caching for command messages in realm-db, so if preview was already loaded and displayed, no `:request-command-preview` with jail call is made. 

Next steps are to implement default `preview/shortPreview` functionality of command messages on top of this caching, however, there are some issues I would like to discuss first with @rasom @alwx and @jeluard -
* I think it would be wise to change semantics of how command previews registered from javascript API (see for example [here)](https://github.com/status-im/status-react/blob/develop/bots/console/bot.js#L545) are evaluated in OttoVM jail - instead of calling the function with the message params to construct preview ready for particular message, it would be great to compile preview function ready to be used from cljs environment. With that in place, we could reduce data redundancy, save space in realm-db/app-db and simplify preview saving/loading logic.
* There are still data living under `[:message-data message-id]` path which can't be moved under `[:command-data command-name]` path as recommended above (user-statuses). 
However, we should strive to have no redundancy in our data model - see [this].(https://github.com/omcljs/om/wiki/Components,-Identity-&-Normalization) 
We should rather have table with all messages indexed by their primary key and in `[:chats chat-id :messages]` path, we will just have (ordered) sequence of message-ids.
Transformation of this model into tree suitable for rendering should be responsibility of reagent subscriptions.
With that in place, `[:message-data message-id]` will become completely unnecessary and we can hold everything related to messages in one place.

[comment]: # (PRs will only be accepted if squashed into single commit.)
status: ready

