### PR TITLE
Fixed incorrect message keys

### DIFF
--- a/src/status_im/translations/it.cljs
+++ b/src/status_im/translations/it.cljs
@@ -229,7 +229,7 @@
    :public-group-topic                    "Argomento"
    :debug-enabled                         "Il server di debug è stato avviato! Il tuo indirizzo IP è {{ip}}. Ora puoi aggiungere la tua DApp avviando *status-dev-cli add-dapp --ip {{ip}}* dal tuo computer"
    :new-public-group-chat                 "Entra nella chat pubblica"
-   :datetime-ago-format                   "{{number}} {{time-intervals}} {{fa}}"
+   :datetime-ago-format                   "{{number}} {{time-intervals}} {{ago}}"
    :sharing-cancel                        "Annulla"
    :share-qr                              "Condividi QR"
    :feedback                              "Hai suggerimenti?\nScuoti il tuo telefono!"

--- a/src/status_im/translations/ru.cljs
+++ b/src/status_im/translations/ru.cljs
@@ -244,7 +244,7 @@
    :public-group-topic                    "Тема"
    :debug-enabled                         "Запущен сервер отладки! Ваш IP-адрес: {{ip}}. Теперь вы можете добавить DApp, выполнив со своего компьютера *status-dev-cli add-dapp -ip {{ip}}*"
    :new-public-group-chat                 "Присоединиться к общему чату"
-   :datetime-ago-format                   "{{Number}} {{time-interval}} {{ago}}"
+   :datetime-ago-format                   "{{number}} {{time-intervals}} {{ago}}"
    :share-qr                              "Поделиться QR"
    :feedback                              "Есть отзыв?\nВстряхните телефон!"
    :twelve-words-in-correct-order         "12 слов в нужном порядке"

--- a/src/status_im/translations/vi.cljs
+++ b/src/status_im/translations/vi.cljs
@@ -229,7 +229,7 @@
    :public-group-topic                    "Chủ đề"
    :debug-enabled                         "Máy chủ gỡ lỗi đã được khởi chạy! Địa chỉ IP của bạn là {{ip}}. Bạn có thể thêm DApp bằng cách chạy * status-dev-cli add-dapp -ip {{ip}} * từ máy tính của mình"
    :new-public-group-chat                 "Tham gia cuộc trò chuyện công khai"
-   :datetime-ago-format                   "{{Number}} {{time-intervals}} {{ago}}"
+   :datetime-ago-format                   "{{number}} {{time-intervals}} {{ago}}"
    :sharing-cancel                        "Hủy"
    :share-qr                              "Chia sẻ mã QR"
    :feedback                              "Nhận phản hồi?\nLắc điện thoại của bạn!"


### PR DESCRIPTION
fixes #1481 

### Summary:
For 1-1 chats that were created before changing device language (and Status UI language): chat toolbar status contains [missing {{Number}} value] ... instead of "4 hours ago", "Online" etc

### Steps to test:
* Open Status when device language is in English
* Create some 1-1 chat
* change device language to Russian
* launch Status
* Open created 1-1 chat and check the bar above message area

status: ready

