### PR TITLE
console: fix bad suggestion (#1207)

### DIFF
--- a/bots/console/bot.js
+++ b/bots/console/bot.js
@@ -116,7 +116,7 @@ function getLastForm(code) {
     var index = codeLength - 1;
     while (index >= 0) {
         var char = code[index];
-        if (level == 0 && (char == '(' || char == ',')) {
+        if (level == 0 && index != 0 && (char == '(' || char == ',')) {
             break;
         }
         if (char == ')') {
@@ -162,7 +162,7 @@ function getLastLevel(code) {
         }
         index--;
     }
-    if (form.indexOf("(") < 0) {
+    if (form.indexOf("(") < 0 && form != ",") {
         var parts = form.split(',');
         form = parts[parts.length - 1];
     }


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)
fixes #1207 

### Summary:
[comment]: # (Summarise the problem and how the pull request solves it)
When you type "," to Console it autocomplete to "console" and "web3". This is due to a bug in the Console parsing code where "," is treated differently from characters like ".",  resulting in an empty form which matches the top level in DOC_MAP. The pull request checks if we are the very beginning of parsing a form and makes sure "," stays intact, like it's done with other special characters.

### Steps to test:
- Open Status
- Chat with console
- Type "," and check that it doesn't suggest anything

- Unknown: What is the grammar of a suggestion? Under what circumstances do we use characters like "," and "(" for suggestions? I'd like to test these to avoid regressions.

[comment]: # (PRs will only be accepted if squashed into single commit.)
status: <ready|wip>
