### PR TITLE
Multiple hit on save should not create multiple groups

### DIFF
--- a/src/status_im/components/sticky_button.cljs
+++ b/src/status_im/components/sticky_button.cljs
@@ -2,6 +2,7 @@
   (:require-macros [status-im.utils.styles :refer [defstyle defnstyle]])
   (:require [status-im.components.styles :as common]
             [status-im.utils.platform :refer [platform-specific]]
+            [status-im.utils.utils :as u]
             [status-im.components.react :refer [view
                                                 text
                                                 touchable-highlight]]))
@@ -21,9 +22,11 @@
    :android {:font-size      14
              :letter-spacing 0.5}})
 
-(defn sticky-button [label on-press]
-  [touchable-highlight {:on-press on-press}
-   [view sticky-button-style
-    [text {:style sticky-button-label-style
-           :uppercase? (get-in platform-specific [:uppercase?])}
-          label]]])
+(defn sticky-button
+  ([label on-press] (sticky-button label on-press false))
+  ([label on-press once?]
+   [touchable-highlight {:on-press (if once? (u/wrap-call-once! on-press) on-press)}
+    [view sticky-button-style
+     [text {:style sticky-button-label-style
+            :uppercase? (get-in platform-specific [:uppercase?])}
+           label]]]))

--- a/src/status_im/utils/utils.cljs
+++ b/src/status_im/utils/utils.cljs
@@ -95,3 +95,13 @@
 
 (defn hash-tag? [s]
   (= \# (first s)))
+
+(defn wrap-call-once!
+  "Returns a version of provided function that will be called only the first time wrapping function is called. Returns nil."
+  [f]
+  (let [called? (volatile! false)]
+    (fn [& args]
+      (when-not @called?
+        (vreset! called? true)
+        (apply f args)
+        nil))))

--- a/test/cljs/status_im/test/runner.cljs
+++ b/test/cljs/status_im/test/runner.cljs
@@ -1,7 +1,8 @@
 (ns status-im.test.runner
   (:require [doo.runner :refer-macros [doo-tests]]
             [status-im.test.chat.models.input]
-            [status-im.test.handlers]))
+            [status-im.test.handlers]
+            [status-im.test.utils.utils]))
 
 (enable-console-print!)
 
@@ -12,4 +13,5 @@
 (set! goog.DEBUG false)
 
 (doo-tests 'status-im.test.chat.models.input
-           'status-im.test.handlers)
+           'status-im.test.handlers
+           'status-im.test.utils.utils)

--- a/test/cljs/status_im/test/utils/utils.cljs
+++ b/test/cljs/status_im/test/utils/utils.cljs
@@ -1,0 +1,12 @@
+(ns status-im.test.utils.utils
+    (:require [cljs.test :refer-macros [deftest is]]
+              [status-im.utils.utils :as u]))
+
+(deftest wrap-as-call-once-test
+  (let [count (atom 0)]
+    (letfn [(inc-count [] (swap! count inc))]
+      (let [f (u/wrap-call-once! inc-count)]
+        (is (nil? (f)))
+        (is (= 1 @count))
+        (is (nil? (f)))
+        (is (= 1 @count))))))


### PR DESCRIPTION
fixes #1488 

### Summary:
Can tap several times on Save button that causes multiple group chats been created with same name 

### Steps to test:
* Open Status
* Go to Chats
* Create new group chat
* Tap several times on Save button

status: ready

