### PR TITLE
wallet: always displays fee with fixed precision

### DIFF
--- a/bots/wallet/bot.js
+++ b/bots/wallet/bot.js
@@ -5,7 +5,8 @@ function calculateFee(n, tx) {
     }
 
     var gasMultiplicator = Math.pow(1.4, n).toFixed(3);
-    return web3.fromWei(web3.eth.gasPrice * gasMultiplicator * estimatedGas, "ether");
+    var weiFee = web3.eth.gasPrice * gasMultiplicator * estimatedGas;
+    return parseFloat(web3.fromWei(weiFee, "ether")).toFixed(7);
 }
 
 function calculateGasPrice(n) {


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)
fixes #1489 

### Summary:
[comment]: # (Summarise the problem and how the pull request solves it)
Previously, we displayed transaction fee as result of the `web3.fromWei` call without any further formatting, which sometimes caused inconsistent fee values even for the same tx amount and slider position, because they differed in precision.
This PR introduces change where transaction fee is always formatted to 7 decimal places, so it stays consistent.

### Steps to test:
- Open Status
- Open 1-1 chat
- Enter `/send` command, choose contact and enter tx value '10'
- Move tx fee slider to the right (maximal fee)
- Change the tx value to '1'
- Change the tx value to '10' again
- Observe that the fee value for tx value of '10' is always the same

[comment]: # (PRs will only be accepted if squashed into single commit.)
status: ready

