### PR TITLE
Bug/bad suggestion #1207

### DIFF
--- a/bots/console/bot.js
+++ b/bots/console/bot.js
@@ -141,7 +141,10 @@ function getLastLevel(code) {
         var char = code[index];
         if (char == ')') {
             level--;
-            nested = true;
+            // A single unbalanced ')' shouldn't set nested to true.
+            if (level > 0) {
+                nested = true;
+            }
         }
         if (char == '(') {
             level++;
@@ -343,6 +346,8 @@ function jsSuggestions(params, context) {
             sugestionsMarkup
         );
         return {markup: view};
+    } else {
+        return {markup: null};
     }
 }
 

--- a/bots/console/test.js
+++ b/bots/console/test.js
@@ -1,0 +1,42 @@
+// Run this in a node REPL
+// .load test.js
+
+// Load dependencies
+.load web3_metadata.js
+.load bot.js
+
+// A map from current input text to suggestion titles
+var suggestionTests = {
+    ",": [],
+    ")": [],
+    "(": [],
+    "a)": [],
+// Expected?
+//    "a,": [],
+//    "a(": [],
+    "c": ["console"],
+    "console.": ["log(text)"]
+};
+
+// Mock localStorage, necessary for suggestions functions in bot.js
+var STORE = {};
+var localStorage = function() {};
+localStorage.getItem = function(k) { return STORE[k]; };
+localStorage.setItem = function(k, v) { STORE[k] = v; };
+
+var checkSuggestion = function(input) {
+    var suggestions = getJsSuggestions(input, {});
+    var titles = suggestions.map(function(suggestion) {
+        return suggestion.title;
+    });
+    var expectedTitles = suggestionTests[input];
+    var iseq = JSON.stringify(titles) == JSON.stringify(expectedTitles);
+    console.log("CHECK", input, "   ", iseq);
+    if (!iseq) {
+        console.log("EXPECTED", expectedTitles);
+        console.log("ACTUAL", titles);
+    }
+};
+
+// Run tests
+Object.keys(suggestionTests).forEach(checkSuggestion);

--- a/src/status_im/chat/subs.cljs
+++ b/src/status_im/chat/subs.cljs
@@ -113,7 +113,7 @@
   :<- [:chat :input-text]
   :<- [:chat-ui-props :validation-messages]
   (fn [[chat-parameter-box show-suggestions? input-text validation-messages]]
-    (and chat-parameter-box
+    (and (get chat-parameter-box :markup)
          (not validation-messages)
          (not show-suggestions?))))
 


### PR DESCRIPTION
fixes #1207 (partially)

### Summary:
Typing ')' and 'a)' in Console autocompletes wrongly to "console" and "web3". This is due to a parsing bug where a single unbalanced ')' is counted as nesting, resulting in a wrongly parsed code form ('').

Additionally, another problem was surfaced while working on this issue and in the #1207 thread. It isn't currently clear what suggestions should be allowed, and this seems like an open problem. I included an ad hoc test script that lets us define inputs and their expected suggestions. Let me know if you want me to squash this or get rid of it / change it.

For example, is 'a(' in invalid suggestion? If we want to allow Javascript, the following code is valid:

```
var a = console.log;
a("foo");
```

So the behavior would be expected. To me that seems like a separate issue from #1207, and perhaps we should open an issue for defining a suggestion grammar for console, since this is the first port of call for new users.

(I also started a refactor of the parsing code based on my current understanding of the basic suggestions we are supporting, but decided to leave it out to keep this PR minimal.)

### Steps to test:
- Open Status
- Chat with console
- Type "a," or "a)" and check that it doesn't suggest anything

[comment]: # (PRs will only be accepted if squashed into single commit.)
status: wip

@rasom What are your thoughts?

https://github.com/status-im/status-react/pull/1494
