### PR TITLE
fix #1499 chat: don't persist null properties

### DIFF
--- a/src/status_im/chat/handlers/commands.cljs
+++ b/src/status_im/chat/handlers/commands.cljs
@@ -44,7 +44,7 @@
                                          (update result :markup cu/generate-hiccup)
                                          result)] 
                             (dispatch [:set-in [:message-data data-type message-id] result'])
-                            (when (= :preview data-type)
+                            (when (and result (= :preview data-type))
                               ;; update message in realm with serialized preview
                               (messages/update {:message-id message-id
                                                 :preview (prn-str result)}))


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)
fixes #1499

### Summary:
[comment]: # (Summarise the problem and how the pull request solves it)
Don't put nil (null) values into realm store where schema doesn't allow it

### Steps to test:
- Clean phone settings and install Status app from scratch
- Open Status
- Set password
- Confirm password
- App doesn't crash as before this bugfix

[comment]: # (PRs will only be accepted if squashed into single commit.)
status: ready

