### PR TITLE
fix #1171: hide remove option from profile menu for unremovable contacts

### DIFF
--- a/src/status_im/profile/screen.cljs
+++ b/src/status_im/profile/screen.cljs
@@ -40,7 +40,8 @@
 
 (defn profile-toolbar [contact]
   [toolbar
-   (when-not (:pending? contact)
+   (when (and (not (:pending? contact))
+              (not (:unremovable? contact)))
      {:actions [(act/opts [{:value #(dispatch [:hide-contact contact])
                             :text  (label :t/remove-from-contacts)}])]})])
 


### PR DESCRIPTION
fixes #1171 

### Summary:
Before this patch there was one menu remaining that allowed removing "unremovable" contacts.

### Steps to test:
- Open Status
- Open Console Profile
- Edit Profile
- Delete Contact option should not be visible

status: ready
