### PR TITLE
fix #1501 wallet: display right fee amount

### DIFF
--- a/bots/wallet/bot.js
+++ b/bots/wallet/bot.js
@@ -6,7 +6,10 @@ function calculateFee(n, tx) {
 
     var gasMultiplicator = Math.pow(1.4, n).toFixed(3);
     var weiFee = web3.eth.gasPrice * gasMultiplicator * estimatedGas;
-    return parseFloat(web3.fromWei(weiFee, "ether")).toFixed(7);
+    // force fee in eth to be of BigNumber type
+    var ethFee = web3.toBigNumber(web3.fromWei(weiFee, "ether"));
+    // always display 7 decimal places
+    return ethFee.toFixed(7);
 }
 
 function calculateGasPrice(n) {


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)
fixes #1501 

### Summary:
[comment]: # (Summarise the problem and how the pull request solves it)
Previously, to be able to format fractional number to fixed amount of decimal places, string returned from `web3.fromWei` call was parsed into native js float type with `parseFloat` function. Unfortunately for some amounts (not immediately obvious during developer testing), this is not enough, as native js float has problems with precision, so slightly different sum was displayed between fee/amount edits.
This PR solves it by parsing `web3.fromWei` result directly into BigNumber type (this type should be returned from `web3.fromWei` call anyway, but it depends on call arguments) and calling `toFixed(n)` method in it.

### Steps to test:
- Open Status
- Open 1-1 Chat
- Start typing `/send` command and select amount 10
- Push the fee slider to the right (max), remember the fee shown
- Edit the amount to 1
- Edit the amount back to 10
- Compare the fee with the fee shown for amount 10 for the first time (before amount edit), they should be the same

[comment]: # (PRs will only be accepted if squashed into single commit.)
status: ready

