### PR TITLE
fix #1488 new_group: once-only handler for save

### DIFF
--- a/src/status_im/new_group/screen_private.cljs
+++ b/src/status_im/new_group/screen_private.cljs
@@ -96,4 +96,7 @@
        [sticky-button (label :t/save)
         (if (= group-type :contact-group)
           #(dispatch [:create-new-group group-name])
-          #(dispatch [:create-new-group-chat group-name]))])]))
+          #(dispatch [:create-new-group-chat group-name]))
+        ;; once? set to true, so once component is mounted, on-press handler
+        ;; will be executed only once
+        true])]))

--- a/src/status_im/new_group/views/chat_group_settings.cljs
+++ b/src/status_im/new_group/views/chat_group_settings.cljs
@@ -72,4 +72,7 @@
        [view st/separator]
        [group-chat-settings-btns]]]
      (when save-btn-enabled?
-       [sticky-button (label :t/save) #(dispatch [:set-chat-name])])]))
+       [sticky-button (label :t/save) #(dispatch [:set-chat-name])
+        ;; once? set to true, so once component is mounted, on-press handler
+        ;; will be executed only once
+        true])]))


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)
fixes #1488 

### Summary:
[comment]: # (Summarise the problem and how the pull request solves it)
@jeluard did all the hard work of implementing once-only option for `:on-press` handlers, this PR just uses the option when creating new group chat :)

Additional issue which is probably not in scope of this PR - it's still totally possible to create duplicate group chats with same set of participants and same name - should this be actually allowed, or do we wan't to enforce some rules like at least set of participants or name must be different ? What do you think @rasom @jarradh ?

### Steps to test:
- Open Status
- Create new group chat
- Try to tap on save button multiple times
- Only one group chat should be created

[comment]: # (PRs will only be accepted if squashed into single commit.)
status: ready

