### PR TITLE
translations: Fix french translation

### DIFF
--- a/src/status_im/translations/fr.cljs
+++ b/src/status_im/translations/fr.cljs
@@ -175,7 +175,7 @@
    :choose-from-contacts                  "Ajouter depuis mes contacts"
    :no-contacts                           "Pas encore de contacts"
    :show-qr                               "Afficher le QR"
-   :enter-address                         "Entrez Addresse"
+   :enter-address                         "Entrer Adresse"
    :more                                  "plus"
 
    ;group-settings


### PR DESCRIPTION
"Address" in english is "Adresse" in French + Everything in the page is in Zero infinitive excect this "Entrez Addresse", which sounded weird.