### PR TITLE
chat: fix #1390, selection OOB

### DIFF
--- a/src/status_im/chat/handlers/input.cljs
+++ b/src/status_im/chat/handlers/input.cljs
@@ -388,7 +388,8 @@
               new-sel      (->> command-args
                                 (take (+ 3 arg-pos))
                                 (input-model/join-command-args)
-                                (count))
+                                count
+                                (min (count input-text)))
               ref          (get-in chat-ui-props [current-chat-id :input-ref])]
           (.setNativeProps ref (clj->js {:selection {:start new-sel :end new-sel}}))
           (dispatch [:update-text-selection new-sel]))))))


### PR DESCRIPTION
fixes #1390 

### Summary:
[comment]: # (Summarise the problem and how the pull request solves it)
When the input field includes an unmatched " in the input-text, there's a mismatch between the parsed command-args and the length of the text field, causing text selection to be out of bounds. By bounding the new selection to a maximum of the input text length, this is avoided.

#### Example 1 (bad case):

command-args: ["/request" "Abandoned Worried Wolf"]
input-text: "/request \"Abandoned Worried Wolf"]
new-sel: (before PR): 33 
**new-sel: (after PR): 32**

#### Example 2 (good case):
command-args: ["/request" "Abandoned Worried Wolf"]
input-text "/request \"Abandoned Worried Wolf\""
new-sel: (before PR): 33 
new-sel: (after PR): 33

### Steps to test:
- Open Status
- Chat with a user that has many parts in their name (e.g. "Abandoned Worried Wolf")
- Type `/request` and select the user in the suggestions area
- Delete part of the name include the ending `"`
- Click suggestion area
- Notice that it no longer crashes on Android

[comment]: # (PRs will only be accepted if squashed into single commit.)
status: <ready>