### PR TITLE
fix #1467 console: confirmation code preview

### DIFF
--- a/bots/console/bot.js
+++ b/bots/console/bot.js
@@ -665,6 +665,22 @@ status.response({
 
             return {markup: error};
         }
+    },
+    preview: function (params) {
+        return {
+            markup: status.components.text(
+                {},
+                params.code
+            )
+        };
+    },
+    shortPreview: function (params) {
+        return {
+            markup: status.components.text(
+                {},
+                params.code
+            )
+        };
     }
 });
 


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)
fixes #1467 

### Summary:
[comment]: # (Summarise the problem and how the pull request solves it)
Preview/shortPreview console bot option for confirmation command response was not defined, this simple fix just adds it.
In the very near future, we will provide some meaningful default preview/shortPreview function for commands/command-responses so it's not necessary to define it if nothing more then simple param display is required

### Steps to test:
- Open Status
- Open Console
- Send `/confirmation-code` command with some number
- Observe that confirmation code is rendered correctly

[comment]: # (PRs will only be accepted if squashed into single commit.)
status: ready

