### PR TITLE
fix #1050 transaction view: app crash

### DIFF
--- a/src/status_im/transactions/views/list_item.cljs
+++ b/src/status_im/transactions/views/list_item.cljs
@@ -30,10 +30,11 @@
 
 (defview view [{:keys [to value id] :as transaction} on-deny]
   [recipient [:contact-by-address to]]
-  (let [eth-value      (.fromWei js/Web3.prototype value "ether")
-        value          (str (i18n/label-number eth-value) " ETH")
+  (let [bignumber      (.toBigNumber js/Web3.prototype value)
+        eth-value      (str (.fromWei js/Web3.prototype bignumber "ether"))
+        value-str      (str (i18n/label-number eth-value) " ETH")
         recipient-name (or (:name recipient) to (i18n/label :t/contract-creation))]
     [rn/view {:style st/item}
      [item-image recipient]
-     [item-info recipient-name value]
+     [item-info recipient-name value-str]
      [deny-btn id on-deny]]))


### PR DESCRIPTION
### Summary:
Transactions with 15 significant digits crashes the app due to something weird going on in the Clojurescript -> web3 -> BigNumber call chain. This fix rounds transactions to a maximum 14 significants digits which ensures the app doesn't crash.

### Steps to test:
- Open Status (iOS)
- Ensure you Ether on your account
- /send PERSON 0.111122223333444
- Notice that app no longer crashes

status: wip