### PR TITLE
chat, protocol: Introduce Lamport clock semantics for message order

### DIFF
--- a/src/status_im/chat/handlers/send_message.cljs
+++ b/src/status_im/chat/handlers/send_message.cljs
@@ -19,7 +19,8 @@
             [status-im.protocol.core :as protocol]
             [taoensso.timbre :refer-macros [debug] :as log]
             [status-im.chat.handlers.console :as console]
-            [status-im.utils.types :as types]))
+            [status-im.utils.types :as types]
+            [status-im.utils.clocks :as clocks]))
 
 (defn prepare-command
   [identity chat-id clock-value
@@ -52,7 +53,7 @@
      :to-message   to-message
      :type         (:type command)
      :has-handler  (:has-handler command)
-     :clock-value  (inc clock-value)
+     :clock-value  (clocks/send clock-value)
      :show?        true}))
 
 (defn console-command? [chat-id command-name]
@@ -178,7 +179,7 @@
                            :content-type text-content-type
                            :outgoing     true
                            :timestamp    (time/now-ms)
-                           :clock-value  (inc clock-value)
+                           :clock-value  (clocks/send clock-value)
                            :show?        true})
             message''   (cond-> message'
                                 (and group-chat public?)

--- a/src/status_im/protocol/chat.cljs
+++ b/src/status_im/protocol/chat.cljs
@@ -40,23 +40,3 @@
                  :requires-ack? false)
                (assoc-in [:payload :group-id] (:group-id message))
                (dissoc :group-id)))))
-
-(defn send-clock-value-request!
-  [{:keys [web3 message]}]
-  (debug :send-clock-value-request message)
-  (d/add-pending-message!
-    web3
-    (merge message-defaults
-           (assoc message
-             :type :clock-value-request
-             :requires-ack? false))))
-
-(defn send-clock-value!
-  [{:keys [web3 message]}]
-  (debug :send-clock-value message)
-  (d/add-pending-message!
-    web3
-    (merge message-defaults
-           (assoc message
-             :type :clock-value
-             :requires-ack? false))))

--- a/src/status_im/protocol/core.cljs
+++ b/src/status_im/protocol/core.cljs
@@ -18,8 +18,6 @@
 ;; user
 (def send-message! chat/send!)
 (def send-seen! chat/send-seen!)
-(def send-clock-value-request! chat/send-clock-value-request!)
-(def send-clock-value! chat/send-clock-value!)
 (def reset-pending-messages! d/reset-pending-messages!)
 
 ;; group

--- a/src/status_im/utils/clocks.cljs
+++ b/src/status_im/utils/clocks.cljs
@@ -1,0 +1,32 @@
+(ns status-im.utils.clocks)
+
+;; We use Lamport clocks to ensure correct ordering of events in chats. This is
+;; necessary because we operate in a distributed system and there is no central
+;; coordinator for what happened before what.
+;;
+;; For example, the last received message in a group chat will appear last,
+;; regardless if that person has seen all the previous group chat messages. The
+;; principal invariant to maintain is that clock-values should be monotonically
+;; increasing.
+;;
+;; All clock updates happens as part of sending or receiving a message. Here's
+;; the basic algorithm:
+;;
+;; Sending messages:
+;; time = time+1;
+;; time_stamp = time;
+;; send(message, time_stamp);
+;;
+;; Receiving messages:
+;; (message, time_stamp) = receive();
+;; time = max(time_stamp, time)+1;
+;;
+;; Details:
+;; https://en.wikipedia.org/wiki/Lamport_timestamps
+;; http://amturing.acm.org/p558-lamport.pdf
+
+(defn send [local-clock]
+  (inc local-clock))
+
+(defn receive [message-clock local-clock]
+  (inc (max message-clock local-clock)))

--- a/test/cljs/status_im/test/runner.cljs
+++ b/test/cljs/status_im/test/runner.cljs
@@ -3,7 +3,8 @@
             [status-im.test.contacts.handlers]
             [status-im.test.chat.models.input]
             [status-im.test.handlers]
-            [status-im.test.utils.utils]))
+            [status-im.test.utils.utils]
+            [status-im.test.utils.clocks]))
 
 (enable-console-print!)
 
@@ -16,4 +17,5 @@
 (doo-tests 'status-im.test.contacts.handlers
            'status-im.test.chat.models.input
            'status-im.test.handlers
-           'status-im.test.utils.utils)
+           'status-im.test.utils.utils
+           'status-im.test.utils.clocks)

--- a/test/cljs/status_im/test/utils/clocks.cljs
+++ b/test/cljs/status_im/test/utils/clocks.cljs
@@ -1,0 +1,93 @@
+(ns status-im.test.utils.clocks
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [status-im.utils.clocks :as clocks]))
+
+;; Messages are shown on a per-chat basis, ordered by the message clock-value.
+;; See status-im-utils.clocks namespace for details.
+
+;; We are not a monolith.
+(def a (atom {:identity "a"}))
+(def b (atom {:identity "b"}))
+(def c (atom {:identity "c"}))
+
+;; The network is unreliable.
+(defn random-broadcast! [chat-id message]
+  (when (> (rand-int 10) 5) (recv! a chat-id message))
+  (when (> (rand-int 10) 5) (recv! b chat-id message))
+  (when (> (rand-int 10) 5) (recv! c chat-id message)))
+
+(defn get-last-clock-value
+  [db chat-id]
+  (if-let [messages (-> @db :chats chat-id :messages)]
+    (-> (sort-by :clock-value > messages)
+        first
+        :clock-value)
+    0))
+
+(defn save! [db chat-id message]
+  (swap! db
+         (fn [state]
+           (let [messages (-> state :chats chat-id :messages)]
+             (assoc-in state [:chats chat-id :messages]
+                       (conj messages message))))))
+
+(defn send! [db chat-id message]
+  (let [clock-value (get-last-clock-value db chat-id)
+        prepared-message (assoc message :clock-value (clocks/send clock-value))]
+    (save! db chat-id prepared-message)
+    (random-broadcast! chat-id prepared-message)))
+
+(defn recv! [db chat-id {:keys [clock-value] :as message}]
+  (let [local-clock (get-last-clock-value db chat-id)
+        new-clock   (clocks/receive clock-value local-clock)]
+    (when-not (= (:from message) (:identity @db))
+      (save! db chat-id (assoc message :clock-value new-clock)))))
+
+(defn thread [db chat-id]
+  (let [messages (-> @db :chats chat-id :messages)]
+    (sort-by :clock-value < messages)))
+
+(defn format-message [{:keys [from text]}]
+  (str from ": " text ", "))
+
+(defn format-thread [thread]
+    (apply str (map format-message thread)))
+
+;; Invariant we want to maintain.
+(defn ordered-increasing-text? [thread]
+  (let [xs (map :text thread)]
+    (or (empty? xs) (apply < xs))))
+
+(defn simulate! []
+  (send! a :foo {:from "a" :text "1"})
+  (send! a :foo {:from "a" :text "2"})
+
+  (send! a :bar {:from "a" :text "1"})
+
+  (send! b :foo {:from "b" :text "3"})
+  (send! c :foo {:from "c" :text "4"})
+  (send! a :foo {:from "a" :text "5"})
+
+  (send! c :bar {:from "c" :text "7"}))
+
+(deftest clocks
+  (testing "Message order preserved"
+    (simulate!)
+    (is (ordered-increasing-text? (thread a :foo)))
+    (is (ordered-increasing-text? (thread b :foo)))
+    (is (ordered-increasing-text? (thread c :foo)))
+    (is (ordered-increasing-text? (thread a :bar))))
+
+  (testing "Bad thread recognized as such"
+    (let [bad-thread '({:from "a", :text "1", :clock-value 1}
+                       {:from "c", :text "4", :clock-value 1}
+                       {:from "a", :text "2", :clock-value 2}
+                       {:from "a", :text "5", :clock-value 8})]
+      (is (not (ordered-increasing-text? bad-thread))))))
+
+  ;; Debugging
+;;(println "******************************************")
+;;(println "A's POV :foo" (format-thread (thread a :foo)))
+;;(println "B's POV :foo" (format-thread (thread b :foo)))
+;;(println "C's POV :foo" (format-thread (thread c :foo)))
+;;(println "******************************************")


### PR DESCRIPTION
fixes #1015, #1195 and #1051 

### Summary:
This commit ensures messages are ordered correctly when participants join and leave a group chat. Specifically, the last received message will appear last. Previously the user and chat clock was queried and updated in an ad hoc manner. With this change there are only two clock changes to keep track of. Here's the basic algorithm:

Sending messages:
time = time+1;
time_stamp = time;
send(message, time_stamp);

Receiving messages:
(message, time_stamp) = receive();
time = max(time_stamp, time)+1;

(See https://en.wikipedia.org/wiki/Lamport_timestamps)

Note that this means we can get rid of all the non-message clock queries and updates.

### Steps to test:

For #1015:
-  A sends message to public chat
-  B joins public chat, sees no message from A, sends message
- A sees message, sends message back which B sees
- (A leaves chat), C joins chat, sees no messages, sends message, B receives this
- Notice that all the messages are in the correct order

Plus any additional tests that puts the message ordering to the test. See comments below in PR or #1195 and #1051.

### Review note:

Please note this commit removes quite a lot of code, and it is more than likely that I missed one or many things in how the previous clock-value worked. Looking over the code I simply didn't see the use of the out-of-band/out-of-message clock synchronizations from a Lamport clock ordering perspective, so I decided to remove it all and see if it still works.

Status: ready