### PR TITLE
fix #1469 chat: location is shown as plaintext

### DIFF
--- a/src/status_im/chat/handlers/commands.cljs
+++ b/src/status_im/chat/handlers/commands.cljs
@@ -43,8 +43,10 @@
                 callback #(let [result (get-in % [:result :returned])
                                 result' (if (:markup result)
                                          (update result :markup cu/generate-hiccup)
-                                         result)] 
-                            (dispatch [:set-in [:message-data data-type message-id] result'])
+                                         result)]
+                            ;; don't fill message data with nil results
+                            (when result'
+                              (dispatch [:set-in [:message-data data-type message-id] result']))
                             (when (and result (= :preview data-type))
                               ;; update message in realm with serialized preview
                               (messages/update {:message-id message-id


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

### Summary:
[comment]: # (Summarise the problem and how the pull request solves it)
Previously, we were not checking if the `:request-command-data` call (calling jail) was actually returning something meaningful and just blindly updated the `:message-data` in db with call result, unfortunately this resulted in lot of `:message-data` entries where value under particular message-id was nil (mainly for previews/shortPreviews).
As we check the map under `[:message-data :preview]` path with `contains?` for particular message-id before deciding if we want to fetch/re-fetch message preview/shortPreview, sometimes we erroneously decided not to fetch, even if no usable preview/shortPreview was ready.

The reason why some message preview/shortPreview calls to jail actually return null/nil results remains open and is not really clear to me, as I still don't 100% understand the interaction between RN, Go and Whisper. 

I will try to refactor the command handlers to use cofx/fx pattern and add unit-tests when it's ready, currently, it's very hard to write some tests executing the command loading logic.

### Steps to test:
- Open Status for User A
- Open Status for User B
- As a User A, add user B to contacts
- As a User A, open chat with user B
- As a User A, write `/location` message to user B
- As a User B, check the incoming chat with user A
- As a User B, notice that `/location` message from user A is rendered correctly

[comment]: # (PRs will only be accepted if squashed into single commit.)
status: ready

