### PR TITLE
[WIP] Wallet token data screen

### DIFF
--- a/src/status_im/ui/screens/views.cljs
+++ b/src/status_im/ui/screens/views.cljs
@@ -43,6 +43,7 @@
             [status-im.ui.screens.profile.qr-code.views :refer [qr-code-view]]
 
             [status-im.ui.screens.wallet.send.views :refer [send-transaction]]
+            [status-im.ui.screens.wallet.token-data.views :as token-data-views]
             [status-im.ui.screens.wallet.wallet-list.views :refer [wallet-list-screen]]
             [status-im.ui.screens.wallet.history.views :as wallet-history]))
 
@@ -63,6 +64,7 @@
                           :wallet main-tabs
                           :wallet-list wallet-list-screen
                           :wallet-send-transaction send-transaction
+                          :wallet-token-details token-data-views/screen
                           :discover main-tabs
                           :discover-search-results discover-search-results
                           :chat-list main-tabs

--- a/src/status_im/ui/screens/wallet/main/views.cljs
+++ b/src/status_im/ui/screens/wallet/main/views.cljs
@@ -78,16 +78,18 @@
        :disabled? true}]]]])
 
 (defn render-asset-fn [{:keys [id currency amount]}]
-  [list/touchable-item show-not-implemented!
-   [rn/view
-    [list/item
-     [list/item-image {:uri :launch_logo}]
-     [rn/view {:style st/asset-item-value-container}
-      [rn/text {:style st/asset-item-value} (str amount)]
-      [rn/text {:style      st/asset-item-currency
-                :uppercase? true}
-       id]]
-     [list/item-icon :icons/forward]]]])
+  (let [token? (not (= "eth" id))]
+    [list/touchable-item (if token? #(rf/dispatch [:navigate-to :wallet-token-details]))
+     [rn/view
+      [list/item
+       [list/item-image {:uri :launch_logo}]
+       [rn/view {:style st/asset-item-value-container}
+        [rn/text {:style st/asset-item-value} (str amount)]
+        [rn/text {:style      st/asset-item-currency
+                  :uppercase? true}
+         id]]
+       (if token?
+         [list/item-icon :icons/forward])]]]))
 
 (defn asset-section [eth]
   (let [assets [{:id "eth" :currency :eth :amount eth}]]

--- a/src/status_im/ui/screens/wallet/token-data/styles.cljs
+++ b/src/status_im/ui/screens/wallet/token-data/styles.cljs
@@ -1,0 +1,178 @@
+(ns status-im.ui.screens.wallet.token-data.styles
+  (:require-macros [status-im.utils.styles :refer [defnstyle]])
+  (:require [status-im.components.styles :as common]
+            [status-im.utils.platform :as platform]))
+
+(def screen-container
+  {:flex             1
+   :background-color common/color-white})
+
+(def tabs-container
+  {:padding 16})
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Token balance section ;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(def total-balance-container
+  {:margin-top 10
+   :align-items :center
+   :justify-content :center})
+
+(def total-balance
+  {:flex-direction :row})
+
+(def total-balance-value
+  {:font-size 36
+   :color common/color-black})
+
+(def total-balance-currency
+  {:font-size 36
+   :margin-left 6
+   :color common/color-gray7})
+
+(def value-variation
+  {:flex-direction :row
+   :align-items :center})
+
+(def fiat-value
+  {:font-size 14
+   :color common/color-gray7})
+
+(def today-variation-container
+  {:border-radius 10
+   :margin-left 5
+   :padding-horizontal 8
+   :padding-vertical 2
+   :background-color common/color-green-1})
+
+(def today-variation
+  {:font-size 14
+   :color common/color-green-2})
+
+;;;;;;;;;;;;;;;;;;;;
+;; Action buttons ;;
+;;;;;;;;;;;;;;;;;;;;
+
+(def action-buttons-container
+  {:flex-direction :row
+   :background-color common/color-light-blue2
+   :margin-top   24
+   :border-radius 7})
+
+(def action-button
+  {:padding-horizontal 26
+   :padding-vertical   12})
+
+(def action-button-left
+  (merge action-button
+         {:border-right-width 1
+          :border-color common/color-separator}))
+
+(def action-button-text
+  {:font-size 16
+   :color common/color-blue4})
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Transactions section ;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(def transaction-section
+  {:background-color common/color-white
+   :margin-top 25})
+
+(def transaction-section-title
+  {:font-size 14
+   :color common/color-gray4})
+
+(def transaction-list {})
+
+(def transaction-item-container
+  {:flex-direction :row
+   :align-items      :center
+   :padding-vertical 10})
+
+(def transaction-item-icon-container
+  {:border-radius 30
+   :width 40
+   :height 40
+   :background-color common/color-light-blue4
+   :align-items :center
+   :justify-content :center
+   :margin-right 16})
+
+(def transaction-item-icon
+  {:height 26
+   :width 26})
+
+(def transaction-item-info-container
+  {:flex 1})
+
+(def transaction-item-value
+  {:font-size 18
+   :color common/color-black})
+
+(def transaction-item-recipient-container
+  {:flex 1
+   :flex-direction :row})
+
+(def transaction-item-recipient-label
+  {:font-size 14
+   :color common/color-black})
+
+(def transaction-item-recipient
+  {:font-size 14
+   :color common/color-gray4
+   :margin-left 4})
+
+(def transaction-item-details-icon
+  {:flex-shrink 1
+   :height 20
+   :width 20})
+
+(def transaction-list-separator
+  {:margin-left 70
+   :border-bottom-width 1
+   :border-color common/color-separator})
+
+;;;;;;;;;;;;;;;;;
+;; Market data ;;
+;;;;;;;;;;;;;;;;;
+
+(def market-data-row
+  {:flex-direction :row
+   :justify-content :space-between})
+
+(def market-data-item-container
+  {:margin-top 8
+   :margin-bottom 8})
+
+(def market-data-item-title
+  {:font-size 16
+   :color common/color-gray4
+   :margin-bottom 6})
+
+(defn market-data-item-text [large?]
+  {:font-size (if large? 18 16)
+   :color common/color-black})
+
+(def market-data-links-container
+  {:flex-direction :row})
+
+(def market-data-link
+  {:border-radius 6
+   :background-color common/color-light-blue4
+   :padding-vertical 4
+   :padding-horizontal 6
+   :margin-right 12
+   :flex-direction :row
+   :align-items :center})
+
+(def market-data-link-title
+  {:font-size 16
+   :color common/color-blue4})
+
+(def market-data-link-icon
+  {:margin-left 5
+   :width 26
+   :height 26})

--- a/src/status_im/ui/screens/wallet/token-data/views.cljs
+++ b/src/status_im/ui/screens/wallet/token-data/views.cljs
@@ -1,0 +1,117 @@
+(ns status-im.ui.screens.wallet.token-data.views
+  (:require-macros [status-im.utils.views :refer [defview]])
+  (:require [clojure.string :as string]
+            [re-frame.core :as rf]
+            [status-im.components.common.common :as common]
+            [status-im.components.react :as rn]
+            [status-im.components.toolbar-new.view :as toolbar]
+            [status-im.components.toolbar-new.actions :as act]
+            [status-im.i18n :as i18n]
+            [status-im.utils.listview :as lw]
+            [status-im.ui.screens.wallet.token-data.styles :as st]))
+
+(defn toolbar-view [transactions]
+  [toolbar/toolbar {:nav-action act/default-back}])
+
+(defn token-balance []
+  [rn/view {:style st/total-balance-container}
+   [rn/view {:style st/total-balance}
+    [rn/text {:style st/total-balance-value} "123.4"]
+    [rn/text {:style st/total-balance-currency} "GNO"]]
+   [rn/view {:style st/value-variation}
+    [rn/text {:style st/fiat-value} "2562.56 USD"]
+    [rn/view {:style st/today-variation-container}
+     [rn/text {:style st/today-variation} "+5.433%"]]]
+   [rn/view {:style st/action-buttons-container}
+    [rn/view {:style st/action-button-left}
+     [rn/text {:style st/action-button-text} "Send GNO"]]
+    [rn/view {:style st/action-button}
+     [rn/text {:style st/action-button-text} "Exchange GNO"]]]])
+
+(defn transaction-list-item [[id {:keys [to currency amount] :as row}]]
+  (let [amount-string (str amount " " (string/upper-case (name currency)))]
+    [rn/view {:style st/transaction-item-container}
+     [rn/view {:style st/transaction-item-icon-container}
+      [rn/image {:style st/transaction-item-icon
+                :source {:uri :icon_arrow_right_gray}}]]
+     [rn/view {:style st/transaction-item-info-container}
+      [rn/text {:style st/transaction-item-value} amount-string]
+      [rn/view {:style st/transaction-item-recipient-container}
+       [rn/text {:style st/transaction-item-recipient-label} "To"]
+       [rn/text {:style st/transaction-item-recipient} to]]]
+     [rn/image {:source {:uri :icon_back_gray}
+                :style st/transaction-item-details-icon}]]))
+
+(defn render-separator-fn [transactions-count]
+  (fn [_ row-id _]
+    (rn/list-item
+     ^{:key row-id}
+     [common/separator {} st/transaction-list-separator])))
+
+(defn render-row-fn [row _ _]
+  (rn/list-item
+   [rn/touchable-highlight {:on-press #()}
+    [rn/view
+     [transaction-list-item row]]]))
+
+(defn transactions-section []
+  (let [transactions {"1" {:currency :gno :amount 1.3 :to "0xea78969082nfaslkj81hblasf9jh"}
+                      "2" {:currency :gno :amount 0.03 :to "0xbi998asjh00987fsnjksuyfa9087"}}]
+    [rn/view {:style st/transaction-section}
+     [rn/text {:style st/transaction-section-title} "Transactions"]
+     [rn/list-view {:style           st/transaction-list
+                    :dataSource      (lw/to-datasource transactions)
+                    :renderSeparator (render-separator-fn (count transactions))
+                    :renderRow       render-row-fn}]]))
+
+(defn market-data-item [title content & large? custom-content?]
+  [rn/view {:style st/market-data-item-container}
+   [rn/text {:style st/market-data-item-title} title]
+   (if custom-content?
+     [content]
+     [rn/text {:style (st/market-data-item-text large?)} content])])
+
+(defn market-data-link [title]
+  [rn/view {:style st/market-data-link}
+   [rn/text {:style st/market-data-link-title} title]
+   [rn/image {:style st/market-data-link-icon
+              :source {:uri :icon_arrow_right_gray}}]])
+
+(defn market-data-links []
+  [rn/view {:style st/market-data-links-container}
+   [market-data-link "Website"]
+   [market-data-link "Facebook"]
+   [market-data-link "Reddit"]])
+
+(defn market-value-tab []
+  [rn/view
+   [rn/view {:style st/market-data-row}
+    [rn/view
+     [market-data-item "Market Cap" "230,019,822 USD" true]
+     [market-data-item "Circulating Supply" "1,104,590 GNO" true]]
+    [rn/view
+     [market-data-item "Volume 24h" "3,567,910 USD" true]
+     [market-data-item "Total Supply" "10,000,000 GNO" true]]]
+   [market-data-item "Concept" "Status is a free (libre) and open source mobile client targeting Android & iOS, built entirely on Ethereum technologies."]
+   [market-data-item "Crowdsale opening date" "20. Jun 2017"]
+   [market-data-item "Crowdsale closing date" "22. Jun 2017"]
+   [market-data-item "Links" market-data-links false true]])
+
+(defn my-token-tab []
+  [rn/view
+   [token-balance]
+   [transactions-section]])
+
+(defn screen []
+  [rn/scroll-view {:style st/screen-container}
+   [toolbar-view]
+   [rn/view {:style st/tabs-container}
+    [market-value-tab]
+    [my-token-tab]]])
+
+;; (defn header []
+;;   [rn/view {:style st/header-container}
+;;    [rn/image {:style st/token-image
+;;               :src }]
+;;    [rn/text {:style st/token-name} "Gnosis"]
+;;    [rn/text {:style st/token-abbreviation} "GNO"]])


### PR DESCRIPTION
Fixes #1528 

### Summary:
This PR adds the token data screen to the wallet.

## TODO

This PR implements mockups raw 6.

* decide which token will be supported
* add graphs
* add tab switching (currently both tabs are merged in a single tab)

### Steps to test:
- Open Status
- Navigate to the "Discover" tab (for now, until the main tabs are reworked).

status: wip

