### PR TITLE
test #1574 updating cljs test support 

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -24,7 +24,7 @@
             "generate-externs" ["with-profile" "prod" "externs" "android" "externs/externs.js"]
             "test-cljs"        ["with-profile" "test" "doo" "node" "test" "once"]
             "test-protocol"    ["with-profile" "test" "doo" "node" "protocol" "once"]}
-  :test-paths ["test/clj"]
+  :test-paths ["test/clj" "test/cljs"]
   :figwheel {:nrepl-port 7888}
   :profiles {:dev  {:dependencies [[figwheel-sidecar "0.5.11"]
                                    [re-frisk-remote "0.4.2"]

--- a/test/cljs/status_im/test/loader.clj
+++ b/test/cljs/status_im/test/loader.clj
@@ -1,0 +1,31 @@
+(ns ^{:doc "todo"
+      :author "Goran Jovic"}
+  status-im.test.loader
+  (:require [clojure.java.io :as io]
+            [clojure.string :as string]))
+
+(defn path->ns [path]
+  (-> path
+      (string/split #"/test/cljs/")
+      second
+      (string/replace "_" "-")
+      (string/replace "/" ".")
+      (string/replace ".cljs" "")))
+
+(defn ns->req [ns-str]
+  `(quote ~(symbol ns-str)))
+
+(defmacro require-test-namespaces [root]
+  (cons 'require
+        (->> root
+             io/file
+             file-seq
+             (filter #(and (.exists %)(.isFile %)))
+             (map #(.getPath %))
+             (filter #(not (string/includes? % "protocol"))) ; a temporary hack
+             (filter #(not (string/includes? % "contacts"))) ; a temporary hack
+             (filter #(not (string/includes? % "runner")))
+             (filter #(string/ends-with? % "cljs"))
+             (map path->ns)
+             (map ns->req))))
+

--- a/test/cljs/status_im/test/runner.cljs
+++ b/test/cljs/status_im/test/runner.cljs
@@ -1,11 +1,6 @@
 (ns status-im.test.runner
-  (:require [doo.runner :refer-macros [doo-tests]]
-            [status-im.test.contacts.handlers]
-            [status-im.test.chat.models.input]
-            [status-im.test.handlers]
-            [status-im.test.utils.utils]
-            [status-im.test.utils.money]
-            [status-im.test.utils.clocks]))
+  (:require-macros [status-im.test.loader :refer [require-test-namespaces]])
+  (:require [doo.runner :refer-macros [doo-tests doo-all-tests]]))
 
 (enable-console-print!)
 
@@ -13,11 +8,12 @@
 ;; https://github.com/bensu/doo/issues/83#issuecomment-165498172
 (set! (.-error js/console) (fn [x] (.log js/console x)))
 
+
+
 (set! goog.DEBUG false)
 
-(doo-tests 'status-im.test.contacts.handlers
-           'status-im.test.chat.models.input
-           'status-im.test.handlers
-           'status-im.test.utils.utils
-           'status-im.test.utils.money
-           'status-im.test.utils.clocks)
+(require-test-namespaces "./test/cljs/status_im/test")
+
+(println (macroexpand '(require-test-namespaces "./test/cljs/status_im/test")))
+
+(doo-all-tests #"status\-im\.test.*")


### PR DESCRIPTION
ClojureScript tests are executed as long as they exist under the root test package. There is no longer a reason for them to be explicitly included in the test suite.

At the moment, previously disabled tests (`contacts`) and tests with a separate runner (`protocol`) are excluded from the loader using a hardcoded rule. The exact way we can generalize this remains an open brainstorming topic.

status: wip

