### PR TITLE
Feature/profile refactoring: PR #2 Functional changes

### DIFF
--- a/src/status_im/ui/screens/db.cljs
+++ b/src/status_im/ui/screens/db.cljs
@@ -27,7 +27,7 @@
              :current-chat-id            console-chat-id
              :loading-allowed            true
              :selected-participants      #{}
-             :profile-edit               {:edit?      false
+             :my-profile/edit            {:edit?      false
                                           :name       nil
                                           :email      nil
                                           :status     nil
@@ -97,7 +97,8 @@
                   :group/contact-group-id
                   :group/group-type
                   :group/selected-contacts
-                  :group/groups-order]
+                  :group/groups-order
+                  :my-profile/edit]
                  :opt-un
                  [::current-public-key
                   ::modal
@@ -158,7 +159,6 @@
                   :chat/raw-unviewed-messages
                   :chat/bot-db
                   :chat/geolocation
-                  :profile/profile-edit
                   :transactions/transactions
                   :transactions/transactions-queue
                   :transactions/selected-transaction

--- a/src/status_im/ui/screens/profile/db.cljs
+++ b/src/status_im/ui/screens/profile/db.cljs
@@ -1,4 +1,5 @@
 (ns status-im.ui.screens.profile.db
+  (:require-macros [status-im.utils.db :refer [allowed-keys]])
   (:require [cljs.spec.alpha :as spec]
             [clojure.string :as string]
             [status-im.chat.constants :as chat.constants]
@@ -19,10 +20,26 @@
     (or (string/blank? email)
         (and (string? email) (re-matches pattern email)))))
 
-(spec/def ::name correct-name?)
-(spec/def ::email correct-email?)
+(defn base64-encoded-image-path? [photo-path]
+  (or (string/starts-with? photo-path "data:image/jpeg;base64,")
+      (string/starts-with? photo-path "data:image/png;base64,")))
 
-(spec/def ::profile (spec/keys :req-un [::name]))
+
+(spec/def :profile/name (spec/nilable correct-name?))
+
+(spec/def ::profile (spec/keys :req-un [:profile/name]))
+
+
+(spec/def ::name (spec/or :name correct-name?
+                          :empty-string string/blank?))
+(spec/def ::email (spec/nilable correct-email?))
+(spec/def ::edit? boolean?)
+(spec/def ::status (spec/nilable string?))
+(spec/def ::photo-path (spec/nilable base64-encoded-image-path?))
+(spec/def ::edit-status? boolean?)
+
 
 ;; EDIT PROFILE
-(spec/def :profile/profile-edit (spec/nilable map?))
+(spec/def :my-profile/edit (allowed-keys
+                             :req-un [::email ::edit? ::name ::status ::photo-path]
+                             :opt-un [::edit-status?]))

--- a/src/status_im/ui/screens/profile/edit/views.cljs
+++ b/src/status_im/ui/screens/profile/edit/views.cljs
@@ -24,15 +24,15 @@
             :actions [{:image :blank}]}])
 
 (defview profile-name-input []
-  (letsubs [new-profile-name [:get-in [:profile-edit :name]]]
+  (letsubs [new-profile-name [:get-in [:my-profile/edit :name]]]
     [react/view
      [text-input-with-label {:label          (label :t/name)
                              :default-value  new-profile-name
-                             :on-change-text #(dispatch [:set-in [:profile-edit :name] %])}]]))
+                             :on-change-text #(dispatch [:set-in [:my-profile/edit :name] %])}]]))
 
 (def profile-icon-options
   [{:text  (label :t/image-source-gallery)
-    :value #(dispatch [:open-image-picker])}
+    :value #(dispatch [:my-profile/update-picture])}
    {:text  (label :t/image-source-make-photo)
     :value (fn []
              (dispatch [:request-permissions
@@ -43,8 +43,8 @@
                                 (utils/show-popup (label :t/error)
                                                   (label :t/camera-access-error)))))]))}])
 
-(defn edit-profile-bage [contact]
-  [react/view styles/edit-profile-bage
+(defn edit-profile-badge [contact]
+  [react/view styles/edit-profile-badge
    [react/view styles/edit-profile-icon-container
     [context-menu
      [my-profile-icon {:account contact
@@ -66,12 +66,12 @@
           :max-length        140
           :placeholder       (label :t/status)
           :style             styles/profile-status-input
-          :on-change-text    #(dispatch [:set-in [:profile-edit :status] (clean-text %)])
-          :on-blur           #(dispatch [:set-in [:profile-edit :edit-status?] false])
+          :on-change-text    #(dispatch [:set-in [:my-profile/edit :status] (clean-text %)])
+          :on-blur           #(dispatch [:set-in [:my-profile/edit :edit-status?] false])
           :blur-on-submit    true
           :on-submit-editing #(.blur @input-ref)
           :default-value     status}]
-        [react/touchable-highlight {:on-press #(dispatch [:set-in [:profile-edit :edit-status?] true])}
+        [react/touchable-highlight {:on-press #(dispatch [:set-in [:my-profile/edit :edit-status?] true])}
          [react/view
           (if (string/blank? status)
             [react/text {:style styles/add-a-status}
@@ -87,8 +87,8 @@
 
 (defview edit-my-profile []
   (letsubs [current-account [:get-current-account]
-            changed-account [:get :profile-edit]]
-    {:component-will-unmount #(dispatch [:set-in [:profile-edit :edit-status?] false])}
+            changed-account [:get :my-profile/edit]]
+    {:component-will-unmount #(dispatch [:set-in [:my-profile/edit :edit-status?] false])}
     (let [profile-edit-data-valid? (spec/valid? ::db/profile changed-account)
           profile-edit-data-changed? (or (not= (:name current-account) (:name changed-account))
                                          (not= (:status current-account) (:status changed-account))
@@ -97,10 +97,8 @@
        [status-bar]
        [edit-my-profile-toolbar]
        [react/view styles/edit-my-profile-form
-        [edit-profile-bage changed-account]
+        [edit-profile-badge changed-account]
         [edit-profile-status changed-account]
         [status-prompt changed-account]]
        (when (and profile-edit-data-changed? profile-edit-data-valid?)
-         [sticky-button (label :t/save) #(do
-                                           (dispatch [:check-status-change (:status changed-account)])
-                                           (dispatch [:account-update changed-account]))])])))
+         [sticky-button (label :t/save) #(dispatch [:my-profile/save-changes])])])))

--- a/src/status_im/ui/screens/profile/photo_capture/views.cljs
+++ b/src/status_im/ui/screens/profile/photo_capture/views.cljs
@@ -18,7 +18,7 @@
         _          (log/debug "Captured image: " path)
         on-success (fn [base64]
                      (log/debug "Captured success: " base64)
-                     (dispatch [:set-in [:profile-edit :photo-path] (str "data:image/jpeg;base64," base64)])
+                     (dispatch [:set-in [:my-profile/edit :photo-path] (str "data:image/jpeg;base64," base64)])
                      (dispatch [:navigate-back]))
         on-error   (fn [type error]
                      (log/debug type error))]

--- a/src/status_im/ui/screens/profile/styles.cljs
+++ b/src/status_im/ui/screens/profile/styles.cljs
@@ -50,10 +50,10 @@
    :padding          16
    :max-height       114})
 
-(def profile-bage
+(def profile-badge
   {:flex-direction :row})
 
-(def edit-profile-bage
+(def edit-profile-badge
   {:flex-direction :row
    :padding-left   24})
 

--- a/src/status_im/ui/screens/profile/views.cljs
+++ b/src/status_im/ui/screens/profile/views.cljs
@@ -17,14 +17,13 @@
             [status-im.components.toolbar-new.actions :as actions]
             [status-im.components.toolbar-new.view :refer [toolbar]]
             [status-im.i18n :refer [label]]
-            [status-im.ui.screens.profile.events :as profile.event :refer [message-user]]
             [status-im.ui.screens.profile.styles :as styles]
             [status-im.utils.datetime :as time]
             [status-im.utils.utils :refer [hash-tag?]])
   (:require-macros [status-im.utils.views :refer [defview]]))
 
 (defn my-profile-toolbar []
-  [toolbar {:actions [(actions/opts [{:value #(dispatch [:open-edit-my-profile])
+  [toolbar {:actions [(actions/opts [{:value #(dispatch [:my-profile/edit])
                                       :text (label :t/edit)}])]}])
 
 (defn profile-toolbar [contact]
@@ -43,7 +42,7 @@
       (label :t/active-unknown))))
 
 (defn profile-badge [{:keys [name last-online] :as contact}]
-  [react/view styles/profile-bage
+  [react/view styles/profile-badge
    [my-profile-icon {:account contact
                      :edit?   false}]
    [react/view styles/profile-badge-name-container
@@ -66,13 +65,13 @@
    [action-separator]
    [action-button (label :t/start-conversation)
     :chats_blue
-    #(message-user whisper-identity)]
+    #(dispatch [:profile/send-message whisper-identity])]
    (when-not dapp?
      [react/view
       [action-separator]
       [action-button (label :t/send-transaction)
        :arrow_right_blue
-       #(dispatch [:open-chat-with-the-send-transaction chat-id])]])])
+       #(dispatch [:profile/send-transaction chat-id])]])])
 
 (defn profile-info-item [{:keys [label value options text-mode empty-value?]}]
   [react/view styles/profile-setting-item
@@ -160,22 +159,18 @@
    [info-item-separator]
    [profile-info-phone-item
     phone
-    [{:value #(dispatch [:phone-number-change-requested])
+    [{:value #(dispatch [:my-profile/change-phone-number])
       :text (label :t/edit)}]]])
-
-(defn- profile-status-on-press []
-  (dispatch [:set-in [:profile-edit :edit-status?] true])
-  (dispatch [:open-edit-my-profile]))
 
 (defn profile-status [status & [edit?]]
   [react/view styles/profile-status-container
    (if (or (nil? status) (string/blank? status))
-     [react/touchable-highlight {:on-press profile-status-on-press}
+     [react/touchable-highlight {:on-press #(dispatch [:my-profile/edit :status])}
       [react/view
        [react/text {:style styles/add-a-status}
         (label :t/add-a-status)]]]
      [react/scroll-view
-      [react/touchable-highlight {:on-press (when edit? profile-status-on-press)}
+      [react/touchable-highlight {:on-press (when edit? #(dispatch [:my-profile/edit :status]))}
        [react/view
         [react/text {:style styles/profile-status-text}
          (colorize-status-hashtags status)]]]])])


### PR DESCRIPTION
## Second step of refactoring guidelines (for #1571) 
 - use fx and cofx
 - use ns keys for events
 - moved some event logic that was in the view into the events
 - keep state locally in the drawer
 - no subscriptions
 - specs

## Steps to test:

play around with profile editing and contact profile to see if anything broke
- change status from drawer
- change name from drawer
- edit profile
- try username "wallet" (should be in red and if saved go back to previous name)
- change image profile
