### PR TITLE
[FIX #1604] Chat is cleared after command is completed

### DIFF
--- a/src/status_im/chat/handlers/input.cljs
+++ b/src/status_im/chat/handlers/input.cljs
@@ -288,7 +288,10 @@
           (if (= :complete (input-model/command-completion chat-command))
             (do
               (dispatch [:proceed-command chat-command chat-id])
-              (dispatch [:clear-seq-arguments chat-id]))
+              (dispatch [:clear-seq-arguments chat-id])
+              (dispatch [:set-chat-input-text nil chat-id])
+              (dispatch [:set-chat-input-metadata nil chat-id])
+              (dispatch [:set-chat-ui-props {:sending-in-progress? false}]))
             (let [text (get-in db [:chats chat-id :input-text])]
               (dispatch [:set-chat-ui-props {:sending-in-progress? false}])
               (when-not (input-model/text-ends-with-space? text)


### PR DESCRIPTION
Fixes #1604 

Clear command and chat after command completion. This prevents double submit.

### Summary:
Same command send (or request, location) is sent several times if quickly tap on the send button. This does not happen for text or emoji. Expected: consistent behaviour for everything that is sent - anything in the input field is sent once even if user taps on send button several times.


### Steps to test:
video: https://drive.google.com/open?id=0Bz3t9zSg1wb7MGZhbGNJWkNoMGc

Open Status
Open 1-1 chat
Construct a request to the contact in the input field, e.g. /request X 0.1
quickly tap on send button several times
check that messages area for new request messages (expected only 1)
Construct send command in the input field, e.g. /send X 0.3333
quickly tap on send button several times
Tap on /location command
On the suggestions shown, quickly tap several times on the address
