### PR TITLE
Ensure that `:initialCenterCoordinate` attribute gets the correct data

### DIFF
--- a/src/status_im/chat/views/api/geolocation/views.cljs
+++ b/src/status_im/chat/views/api/geolocation/views.cljs
@@ -24,6 +24,10 @@
                 #(reset! cur-loc-geocoded nil))
       true)))
 
+(defn get-coord [{:keys [latitude longitude]}]
+  {:latitude (or latitude 0)
+   :longitude (or longitude 0)})
+
 (defn place-item [{:keys [title address pin-style] [latitude longitude] :center}]
   [touchable-highlight {:on-press #(do
                                      (dispatch [:set-command-argument [0
@@ -58,7 +62,7 @@
                               (dispatch [:set-chat-seq-arg-input-text "Dropped pin"])
                               (dispatch [:chat-input-blur :seq-input-ref])
                               (dispatch [:load-chat-parameter-box (:command command)]))
-                    :initialCenterCoordinate coord
+                    :initialCenterCoordinate (get-coord coord)
                     :showsUserLocation true
                     :initialZoomLevel 10
                     :logoIsHidden true
@@ -140,10 +144,11 @@
         result          (reaction (when @pin-location (get-places @pin-location pin-geolocation)))
         result2         (reaction (when @pin-location (get-places @pin-location pin-nearby true)))]
     (fn []
-      (let [_ @result _ @result2]
+      (let [_ @result _ @result2
+            coord (select-keys (:coords geolocation) [:latitude :longitude])]
         [view
          [view
-          [mapview {:initial-center-coordinate (select-keys (:coords geolocation) [:latitude :longitude])
+          [mapview {:initial-center-coordinate (get-coord coord) 
                     :initialZoomLevel 10
                     :onRegionDidChange #(reset! pin-location (js->clj % :keywordize-keys true))
                     :logoIsHidden true


### PR DESCRIPTION
Mapview component accepts the `:initialCenterCoordinate` which always must have
longitude and latitude attributes. This ensures that they will always be present
even when they are missing from the map passed retreived from the app state.

[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)
fixes #1435

### Summary:
[comment]: # (Summarise the problem and how the pull request solves it)
The problem was:

> Use location command 3-4 times to send some address by selecting it on the map and app crashes

This pull request solves it by ensuring that the initialCenterCoordinate always gets the correct data

### Steps to test:
- Open Status
- Open 1-1 chat with Jarrad
- tap on /location
- in the map shown move pin to some location to get an address
- tap on the address shown and send it in 1-1 chat
- repeat same actions 2-3 times to send other addresses


[comment]: # (PRs will only be accepted if squashed into single commit.)
status:  ready

