### PR TITLE
Upgraded ClojureScript dependencies

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,7 +20,6 @@ node {
       sh 'cp .env.jenkins .env'
       sh 'lein deps && npm install && ./re-natal deps'
       sh 'sed -i "" "s/301000/601000/g" node_modules/react-native/packager/src/JSTransformer/index.js'
-      sh 'lein generate-externs'
       sh 'mvn -f modules/react-native-status/ios/RCTStatus dependency:unpack'
       sh 'cd ios && pod install && cd ..'
     }

--- a/project.clj
+++ b/project.clj
@@ -3,35 +3,33 @@
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"
             :url  "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.9.0-alpha13"]
-                 [org.clojure/clojurescript "1.9.671"]
+  :dependencies [[org.clojure/clojure "1.9.0-alpha17"]
+                 [org.clojure/clojurescript "1.9.671"] ;; Can't update to more recent releases waiting for https://github.com/tailrecursion/cljs-priority-map/issues/10
                  [org.clojure/core.async "0.3.443"]
                  [reagent "0.6.0" :exclusions [cljsjs/react cljsjs/react-dom cljsjs/react-dom-server]]
-                 [re-frame "0.9.4"]
+                 [re-frame "0.10.1"]
                  [com.andrewmcveigh/cljs-time "0.5.0"]
                  [tailrecursion/cljs-priority-map "1.2.0"]
-                 [com.taoensso/timbre "4.7.4"]
+                 [com.taoensso/timbre "4.10.0"]
                  [com.google.guava/guava "21.0"]]
-  :plugins [[lein-cljsbuild "1.1.6"]
-            [lein-figwheel "0.5.11"]
-            [lein-re-frisk "0.4.7"]
-            [rasom/lein-externs "0.1.7"]]
+  :plugins [[lein-cljsbuild "1.1.7"]
+            [lein-figwheel "0.5.13"]
+            [lein-re-frisk "0.4.8"]]
   :clean-targets ["target/" "index.ios.js" "index.android.js"]
   :aliases {"prod-build"       ^{:doc "Recompile code with prod profile."}
                                ["do" "clean"
                                 ["with-profile" "prod" "cljsbuild" "once" "ios"]
                                 ["with-profile" "prod" "cljsbuild" "once" "android"]]
-            "generate-externs" ["with-profile" "prod" "externs" "android" "externs/externs.js"]
             "test-cljs"        ["with-profile" "test" "doo" "node" "test" "once"]
             "test-protocol"    ["with-profile" "test" "doo" "node" "protocol" "once"]}
   :test-paths ["test/clj"]
   :figwheel {:nrepl-port 7888}
-  :profiles {:dev  {:dependencies [[figwheel-sidecar "0.5.11"]
+  :profiles {:dev  {:dependencies [[figwheel-sidecar "0.5.13"]
                                    [re-frisk-remote "0.4.2"]
                                    [re-frisk-sidecar "0.4.5"]
-                                   [com.cemerick/piggieback "0.2.1"]
+                                   [com.cemerick/piggieback "0.2.2"]
                                    [io.appium/java-client "3.4.1"]
-                                   [hawk "0.2.10"]]
+                                   [hawk "0.2.11"]]
                     :source-paths ["src" "env/dev"]
                     :cljsbuild    {:builds
                                    {:ios
@@ -78,7 +76,6 @@
                                                  :static-fns         true
                                                  :optimize-constants true
                                                  :optimizations      :simple
-                                                 :externs            ["externs/externs.js"]
                                                  :closure-defines    {"goog.DEBUG" false}
                                                  :parallel-build     true}}
                                  :android
@@ -89,6 +86,5 @@
                                                  :static-fns         true
                                                  :optimize-constants true
                                                  :optimizations      :simple
-                                                 :externs            ["externs/externs.js"]
                                                  :closure-defines    {"goog.DEBUG" false}
                                                  :parallel-build     true}}}}}})


### PR DESCRIPTION
Upgrade ClojureScript dependencies when possible.
Reagent has not been updated yet (some challenges).
ClojureScript has not been updated to latest version due to an incompatibility with one of our libraries.

status: ready

