### PR TITLE
Prevent js warnings when running lein prod-build

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -77,7 +77,8 @@
                                                  :optimize-constants true
                                                  :optimizations      :simple
                                                  :closure-defines    {"goog.DEBUG" false}
-                                                 :parallel-build     true}}
+                                                 :parallel-build     true
+                                                 :language-in        :ecmascript5}}
                                  :android
                                  {:source-paths ["react-native/src" "src" "env/prod"]
                                   :compiler     {:output-to          "index.android.js"
@@ -87,4 +88,5 @@
                                                  :optimize-constants true
                                                  :optimizations      :simple
                                                  :closure-defines    {"goog.DEBUG" false}
-                                                 :parallel-build     true}}}}}})
+                                                 :parallel-build     true
+                                                 :language-in        :ecmascript5}}}}}})


### PR DESCRIPTION
# Prevent js warnings when running lein prod-build

### Summary:

The closure compiler seems to emit lots of warnings when running `lein prod-build`. For example...

```
WARNING: /Users/achambers/Projects/status-react/target/ios-prod/status_im/components/camera.js:9: WARNING - Keywords and reserved words are not allowed as unquoted property names in older versions of JavaScript. If you are targeting newer versions of JavaScript, set the appropriate language_in option.
status_im.components.camera.default_camera = status_im.react_native.js_dependencies.camera.default;
                                                                                           ^

Aug 17, 2017 8:27:56 PM com.google.javascript.jscomp.LoggerErrorManager println
WARNING: /Users/achambers/Projects/status-react/target/ios-prod/status_im/components/camera.js:21: WARNING - Keywords and reserved words are not allowed as unquoted property names in older versions of JavaScript. If you are targeting newer versions of JavaScript, set the appropriate language_in option.
})).catch((function (){
    ^

Aug 17, 2017 8:27:56 PM com.google.javascript.jscomp.LoggerErrorManager println
WARNING: /Users/achambers/Projects/status-react/target/ios-prod/status_im/components/icons/custom_icons.js:7: WARNING - Keywords and reserved words are not allowed as unquoted property names in older versions of JavaScript. If you are targeting newer versions of JavaScript, set the appropriate language_in option.
status_im.components.icons.custom_icons.ion_icon = reagent.core.adapt_react_class(status_im.react_native.js_dependencies.vector_icons.default);
                                                                                                                                      ^
```

This PR heeds the suggestion of setting the `:language-in` option in project.clj

### Steps to test:

1. git pull $this-pr
2. lein prod-build

The only remaining warning is the one about IFn implementing `-invoke` with variadic signature.

```
$ lein prod-build
Compiling ClojureScript...
Compiling "index.ios.js" from ["react-native/src" "src" "env/prod"]...
WARNING: Protocol IFn implements method -invoke with variadic signature (&) at line 61 target/ios-prod/reagent/impl/util.cljs
Successfully compiled "index.ios.js" in 54.524 seconds.
Compiling ClojureScript...
Compiling "index.android.js" from ["react-native/src" "src" "env/prod"]...
WARNING: Protocol IFn implements method -invoke with variadic signature (&) at line 61 target/android-prod/reagent/impl/util.cljs
Successfully compiled "index.android.js" in 57.728 seconds.
```

status: ready

