### PR TITLE
Fix #1648

### DIFF
--- a/src/status_im/components/drawer/view.cljs
+++ b/src/status_im/components/drawer/view.cljs
@@ -44,16 +44,18 @@
 (defview name-input []
   [account [:get-current-account]
    name-text  (r/atom nil)]
-  (let [previous-name (:name account)]
+  (let [previous-name (:name account)
+        public-key (:public-key account)
+        placeholder (gfycat/generate-gfy public-key)]
     [view st/name-input-wrapper
      [text-input
-      {:placeholder    (gfycat/generate-gfy public-key)
+      {:placeholder    placeholder
        :style          (st/name-input-text (s/valid? ::profile.db/name @name-text))
        :font           :medium
        :default-value  (or @name-text previous-name)
        :on-change-text #(reset! name-text %)
        :on-end-editing #(if (s/valid? ::profile.db/name @name-text)
-                          (rf/dispatch [:account-update {:name (utils/clean-text @name-text)}])
+                          (rf/dispatch [:account-update {:name (utils/clean-text (or @name-text placeholder))}])
                           (reset! name-text previous-name))}]]))
 
 (defview status-input []


### PR DESCRIPTION
Fixes #1648 `Popup null is not an object (evaluating 'e.replace') if tap on
status -> username -> status in drawer`

### Summary:
[comment]: # (Summarise the problem and how the pull request solves it)
The problem was that the profile name could be nil and then the `clean-text` function in utils would
throw an exception

### Steps to test:
- Open Status
- In a newly created account open the drawer
- Tap on the username then tap on the status
- No error should occur

[comment]: # (PRs will only be accepted if squashed into single commit.)
status: wip

