### PR TITLE
Track commands that have requested the preview

### DIFF
--- a/src/status_im/chat/specs.cljs
+++ b/src/status_im/chat/specs.cljs
@@ -30,3 +30,4 @@
 (s/def :chat/raw-unviewed-messages (s/nilable vector?))
 (s/def :chat/bot-db (s/nilable map?))
 (s/def :chat/geolocation (s/nilable map?))
+(s/def :chat/message-preview-waiting (s/nilable map?))

--- a/src/status_im/chat/subs.cljs
+++ b/src/status_im/chat/subs.cljs
@@ -236,3 +236,7 @@
     (let [preview (subscribe [:get-message-preview-markup message-id])]
       (when-let [markup @preview]
         (commands-utils/generate-hiccup markup)))))
+
+(reg-sub :get-message-preview-waiting?
+  (fn [db [_ message-id]]
+    (get-in db [:message-preview-waiting message-id])))

--- a/src/status_im/chat/views/message/message.cljs
+++ b/src/status_im/chat/views/message/message.cljs
@@ -111,12 +111,14 @@
   (#{c/content-type-wallet-command c/content-type-wallet-request} content-type))
 
 (defn command-preview
-  [{:keys [params preview content-type] :as message}]
+  [{:keys [params preview content-type preview-waiting?] :as message}]
   (cond
     (wallet-command? content-type)
     (wallet-command-preview message)
 
     preview preview
+
+    (and (nil? preview) preview-waiting?) nil
 
     :else
     [text {:style st/command-text
@@ -137,7 +139,8 @@
    global-commands [:get :global-commands]
    current-chat-id [:get-current-chat-id]
    contact-chat [:get-in [:chats (if outgoing to from)]]
-   preview [:get-message-preview message-id]]
+   preview [:get-message-preview message-id]
+   message-preview-waiting? [:get-message-preview-waiting? message-id]]
   (let [commands (merge commands from-commands)
         {:keys [command params]} (parse-command-message-content commands global-commands content)
         {:keys     [name type]
@@ -157,6 +160,7 @@
                        :params          params
                        :outgoing?       outgoing
                        :preview         preview
+                       :preview-waiting? message-preview-waiting?
                        :contact-chat    contact-chat
                        :contact-address (if outgoing to from)
                        :current-chat-id current-chat-id}]]))

--- a/src/status_im/ui/screens/db.cljs
+++ b/src/status_im/ui/screens/db.cljs
@@ -160,6 +160,8 @@
                   :chat/raw-unviewed-messages
                   :chat/bot-db
                   :chat/geolocation
+                  :chat/message-preview-waiting
+                  :profile/profile-edit
                   :transactions/transactions
                   :transactions/transactions-queue
                   :transactions/selected-transaction


### PR DESCRIPTION
This prevents the rendering of the command source before the preview is ready

[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)
#1441 

### Summary:
[comment]: # (Summarise the problem and how the pull request solves it)
Send and location messages are shown as long text messages for several seconds after app is launched and chat is opened for the first time. After several seconds they are transformed into expected form.

This commit ensures that we track commands that have it's preview requested. Currently nothing will be rendered while waiting on preview, but we could add a loading icon (spinner)

### Steps to test:
- Open Status
- Open a chat with someone
- Add location
- Close Status
- Open Status
- Open the chat where you've added the location

[comment]: # (PRs will only be accepted if squashed into single commit.)
status: ready

