### PR TITLE
Wallet data bindings #1652

### DIFF
--- a/src/status_im/ui/screens/subs.cljs
+++ b/src/status_im/ui/screens/subs.cljs
@@ -7,6 +7,7 @@
             status-im.ui.screens.discover.subs
             status-im.ui.screens.contacts.subs
             status-im.ui.screens.group.subs
+            status-im.ui.screens.wallet.subs
             status-im.transactions.subs
             status-im.bots.subs))
 

--- a/src/status_im/ui/screens/wallet/db.cljs
+++ b/src/status_im/ui/screens/wallet/db.cljs
@@ -5,3 +5,15 @@
 
 ;; TODO(oskarth): spec for balance as BigNumber
 ;; TODO(oskarth): Spec for prices as as: {:from ETH, :to USD, :price 290.11, :last-day 304.17}
+
+(def dummy-transaction-data
+  [{:to "0x829bd824b016326a401d083b33d092293333a830" :content {:value "0,4908" :symbol "ETH"} :state :unsigned}
+   {:to "0x829bd824b016326a401d083b33d092293333a830" :content {:value "10000" :symbol "SGT"} :state :unsigned}
+   {:to "0x829bd824b016326a401d083b33d092293333a830" :content {:value "10000" :symbol "SGT"} :state :unsigned}
+   {:to "0x829bd824b016326a401d083b33d092293333a830" :content {:value "0,4908" :symbol "ETH"} :state :pending}
+   {:to "0x829bd824b016326a401d083b33d092293333a830" :content {:value "10000" :symbol "SGT"} :state :pending}
+   {:to "0x829bd824b016326a401d083b33d092293333a830" :content {:value "10000" :symbol "SGT"} :state :sent}
+   {:to "0x829bd824b016326a401d083b33d092293333a830" :content {:value "10000" :symbol "SGT"} :state :postponed}
+   {:to "0x829bd824b016326a401d083b33d092293333a830" :content {:value "0,4908" :symbol "ETH"} :state :pending}
+   {:to "0x829bd824b016326a401d083b33d092293333a830" :content {:value "10000" :symbol "SGT"} :state :pending}
+   {:to "0x829bd824b016326a401d083b33d092293333a830" :content {:value "10000" :symbol "SGT"} :state :sent}])

--- a/src/status_im/ui/screens/wallet/events.cljs
+++ b/src/status_im/ui/screens/wallet/events.cljs
@@ -1,7 +1,9 @@
 (ns status-im.ui.screens.wallet.events
   (:require [re-frame.core :as re-frame :refer [dispatch reg-fx]]
             [status-im.utils.handlers :as handlers]
-            [status-im.utils.prices :as prices]))
+            [status-im.utils.prices :as prices]
+            [status-im.ui.screens.wallet.db :as wallet.db]
+            [status-im.components.status :as status]))
 
 (defn get-balance [{:keys [web3 account-id on-success on-error]}]
   (if (and web3 account-id)
@@ -17,20 +19,20 @@
 ;; FX
 
 (reg-fx
- :get-balance
- (fn [{:keys [web3 account-id success-event error-event]}]
-   (get-balance
-    {:web3           web3
-     :account-id     account-id
-     :on-success     #(dispatch [success-event %])
-     :on-error       #(dispatch [error-event %])})))
+  :get-balance
+  (fn [{:keys [web3 account-id success-event error-event]}]
+    (get-balance
+     {:web3           web3
+      :account-id     account-id
+      :on-success     #(dispatch [success-event %])
+      :on-error       #(dispatch [error-event %])})))
 
 (reg-fx
- :get-prices
- (fn [{:keys [from to success-event error-event]}]
-   (prices/get-prices
-    from
-    to
+  :get-prices
+  (fn [{:keys [from to success-event error-event]}]
+    (prices/get-prices
+     from
+     to
      #(dispatch [success-event %])
      #(dispatch [error-event %]))))
 
@@ -38,38 +40,39 @@
 
 ;; TODO(oskarth): At some point we want to get list of relevant assets to get prices for
 (handlers/register-handler-fx
- :load-prices
- (fn [{{:keys [wallet] :as db} :db} [_ a]]
-   {:get-prices  {:from          "ETH"
-                  :to            "USD"
-                  :success-event :update-prices
-                  :error-event   :update-prices-fail}}))
+  :load-prices
+  (fn [{{:keys [wallet] :as db} :db} [_ a]]
+    {:get-prices  {:from          "ETH"
+                   :to            "USD"
+                   :success-event :update-prices
+                   :error-event   :update-prices-fail}}))
 
 (handlers/register-handler-fx
- :init-wallet
- (fn [{{:keys [web3 accounts/current-account-id] :as db} :db} [_ a]]
-   {:get-balance {:web3          web3
-                  :account-id    current-account-id
-                  :success-event :update-balance
-                  :error-event   :update-balance-fail}
-    :dispatch    [:load-prices]}))
+  :init-wallet
+  (fn [{{:keys [web3 accounts/current-account-id] :as db} :db} [_ a]]
+    {:get-balance {:web3          web3
+                   :account-id    current-account-id
+                   :success-event :update-balance
+                   :error-event   :update-balance-fail}
+     :dispatch    [:load-prices]
+     :db (assoc-in db [:wallet :transactions] wallet.db/dummy-transaction-data)}))
 
 (handlers/register-handler-db
- :update-balance
- (fn [db [_ balance]]
-   (assoc db :wallet {:balance balance})))
+  :update-balance
+  (fn [db [_ balance]]
+    (assoc-in db [:wallet :balance] balance)))
 
 (handlers/register-handler-db
- :update-prices
- (fn [db [_ prices]]
-   (assoc db :prices prices)))
+  :update-prices
+  (fn [db [_ prices]]
+    (assoc db :prices prices)))
 
 (handlers/register-handler-fx
- :update-balance-fail
- (fn [_ [_ err]]
-   (.log js/console "Unable to get balance: " err)))
+  :update-balance-fail
+  (fn [_ [_ err]]
+    (.log js/console "Unable to get balance: " err)))
 
 (handlers/register-handler-fx
- :update-prices-fail
- (fn [_ [_ err]]
-   (.log js/console "Unable to get prices: " err)))
+  :update-prices-fail
+  (fn [_ [_ err]]
+    (.log js/console "Unable to get prices: " err)))

--- a/src/status_im/ui/screens/wallet/history/views.cljs
+++ b/src/status_im/ui/screens/wallet/history/views.cljs
@@ -59,37 +59,32 @@
       [action-buttons m])]
    [list/item-icon :icons/forward]])
 
-(def dummy-transaction-data
-  [{:to "0x829bd824b016326a401d083b33d092293333a830" :content {:value "0,4909" :symbol "ETH"} :state :unsigned}
-   {:to "0x829bd824b016326a401d083b33d092293333a830" :content {:value "10000" :symbol "SGT"} :state :unsigned}
-   {:to "0x829bd824b016326a401d083b33d092293333a830" :content {:value "10000" :symbol "SGT"} :state :unsigned}])
-
-(def dummy-transaction-data-sorted
-  [{:title "Postponed"
-    :key :postponed
-    :data [{:to "0x829bd824b016326a401d083b33d092293333a830" :content {:value "0,4909" :symbol "ETH"} :state :pending}
-           {:to "0x829bd824b016326a401d083b33d092293333a830" :content {:value "10000" :symbol "SGT"} :state :pending}
-           {:to "0x829bd824b016326a401d083b33d092293333a830" :content {:value "10000" :symbol "SGT"} :state :sent}]}
-   {:title "Pending"
-    :key :pending
-    :data [{:to "0x829bd824b016326a401d083b33d092293333a830" :content {:value "0,4909" :symbol "ETH"} :state :pending}
-           {:to "0x829bd824b016326a401d083b33d092293333a830" :content {:value "10000" :symbol "SGT"} :state :pending}
-           {:to "0x829bd824b016326a401d083b33d092293333a830" :content {:value "10000" :symbol "SGT"} :state :sent}]}])
-
 ;; TODO(yenda) hook with re-frame
 
 (defn empty-text [s]
   [rn/text {:style st/empty-text} s])
 
 (defview history-list []
-  [list/section-list {:sections        dummy-transaction-data-sorted
-                      :render-fn       render-transaction
-                      :empty-component (empty-text (i18n/label :t/transactions-history-empty))}])
+  (letsubs [pending-transactions   [:wallet/pending-transactions]
+            postponed-transactions [:wallet/postponed-transactions]
+            sent-transactions      [:wallet/sent-transactions]]
+    [list/section-list {:sections        [{:title "Postponed"
+                                           :key :postponed
+                                           :data postponed-transactions}
+                                          {:title "Pending"
+                                           :key :pending
+                                           :data pending-transactions}
+                                          {:title "Sent"
+                                           :key :sent
+                                           :data sent-transactions}]
+                        :render-fn       render-transaction
+                        :empty-component (empty-text (i18n/label :t/transactions-history-empty))}]))
 
 (defview unsigned-list []
-  [list/flat-list {:data            dummy-transaction-data
-                   :render-fn       render-transaction
-                   :empty-component (empty-text (i18n/label :t/transactions-unsigned-empty))}])
+  (letsubs [transactions [:wallet/unsigned-transactions]]
+    [list/flat-list {:data            transactions
+                     :render-fn       render-transaction
+                     :empty-component (empty-text (i18n/label :t/transactions-unsigned-empty))}]))
 
 (def tab-list
   [{:view-id :wallet-transactions-unsigned

--- a/src/status_im/ui/screens/wallet/main/views.cljs
+++ b/src/status_im/ui/screens/wallet/main/views.cljs
@@ -88,31 +88,12 @@
      [list/flat-list {:data      assets
                       :render-fn render-asset-fn}]]))
 
-(defn eth-balance [{:keys [balance]}]
-  (when balance
-    (money/wei->ether balance)))
-
-(defn portfolio-value [{:keys [balance]} {:keys [price]}]
-  (when (and balance price)
-    (-> (money/wei->ether balance)
-        (money/eth->usd price)
-        (money/with-precision 2)
-        str)))
-
-(defn portfolio-change [{:keys [price last-day]}]
-  (when (and price last-day)
-    (-> (money/percent-change price last-day)
-        (money/with-precision 2)
-        (str "%"))))
-
 (defview wallet []
-  (letsubs [wallet [:get :wallet]
-            prices [:get :prices]]
-    (let [eth    (or (eth-balance wallet) "...")
-          usd    (or (portfolio-value wallet prices) "...")
-          change (or (portfolio-change prices) "-%")]
-      [rn/view {:style st/wallet-container}
-       [toolbar-view]
-       [rn/scroll-view
-        [main-section usd change]
-        [asset-section eth]]])))
+  (letsubs [eth-balance [:eth-balance]
+            portfolio-value [:portfolio-value]
+            portfolio-change [:portfolio-change]]
+    [rn/view {:style st/wallet-container}
+     [toolbar-view]
+     [rn/scroll-view
+      [main-section portfolio-value portfolio-change]
+      [asset-section eth-balance]]]))

--- a/src/status_im/ui/screens/wallet/subs.cljs
+++ b/src/status_im/ui/screens/wallet/subs.cljs
@@ -1,0 +1,67 @@
+(ns status-im.ui.screens.wallet.subs
+  (:require [re-frame.core :refer [reg-sub subscribe]]
+            [status-im.utils.money :as money]))
+
+(reg-sub :balance
+  (fn [db]
+    (get-in db [:wallet :balance])))
+
+(reg-sub :price
+  (fn [db]
+    (get-in db [:prices :price])))
+
+(reg-sub :last-day
+  (fn [db]
+    (get-in db [:prices :last-day])))
+
+(reg-sub :eth-balance
+  :<- [:balance]
+  (fn [balance]
+    (if balance
+      (money/wei->ether balance)
+      "...")))
+
+(reg-sub :portfolio-value
+  :<- [:balance]
+  :<- [:price]
+  (fn [[balance price]]
+    (if (and balance price)
+      (-> (money/wei->ether balance)
+          (money/eth->usd price)
+          (money/with-precision 2)
+          str)
+      "...")))
+
+(reg-sub :portfolio-change
+  :<- [:price]
+  :<- [:last-day]
+  (fn [[price last-day]]
+    (if (and price last-day)
+      (-> (money/percent-change price last-day)
+          (money/with-precision 2)
+          (str "%"))
+      "-%")))
+
+(reg-sub :wallet/transactions
+  (fn [db]
+    (get-in db [:wallet :transactions])))
+
+(reg-sub :wallet/unsigned-transactions
+  :<- [:wallet/transactions]
+  (fn [transactions]
+    (filter #(= (:state %) :unsigned) transactions)))
+
+(reg-sub :wallet/pending-transactions
+  :<- [:wallet/transactions]
+  (fn [transactions]
+    (filter #(= (:state %) :pending) transactions)))
+
+(reg-sub :wallet/postponed-transactions
+  :<- [:wallet/transactions]
+  (fn [transactions]
+    (filter #(= (:state %) :postponed) transactions)))
+
+(reg-sub :wallet/sent-transactions
+  :<- [:wallet/transactions]
+  (fn [transactions]
+    (filter #(= (:state %) :sent) transactions)))


### PR DESCRIPTION
The goal of this first PR is to replace dummy data by subscriptions to hook the views with re-frame infrastructure.

What is left for future PRs:
- define the datastructures for the wallet
- use real data

## User Story

As a user, I want to have access to real data in my wallet transactions screens.

## Description

Type: Feature

## Expected behavior

Data displayed in Transactions screens is not hardcoded but reflect a user wallet. User can trigger sign / delete / show details operations.

[comment]: # (PRs will only be accepted if squashed into single commit.)
status: ready

