### PR TITLE
[FIX #1602] Trim whitespace from passphrase during account recovery

### DIFF
--- a/src/status_im/ui/screens/accounts/recover/events.cljs
+++ b/src/status_im/ui/screens/accounts/recover/events.cljs
@@ -16,7 +16,10 @@
 (reg-fx
   ::recover-account-fx
   (fn [[passphrase password]]
-    (status/recover-account passphrase password #(dispatch [:account-recovered %]))))
+    (status/recover-account
+     (str/trim passphrase)
+     password
+     #(dispatch [:account-recovered %]))))
 
 ;;;; Handlers
 
@@ -45,4 +48,3 @@
   :recover-account
   (fn [_ [_ passphrase password]]
     {::recover-account-fx [passphrase password]}))
-


### PR DESCRIPTION
Currently account recovery includes whitespace on either side of the
passphrase, preventing recovery of the desired account.

We trim that whitespace in the account-recovery-fx

Fixes #1602 

### Summary:
Passphrase whitespace is taken at face value, leading to incorrect account recovery. This patch trims the passphrase to prevent this issue.

### Steps to test:
- Open Status
- Copy the passphrase from an account
- Switch accounts
- Recover account
- Paste passphrase, pad with carriage returns or spaces
- Recover
- Should recover an existing account rather than creating a new account.

status: ready

