### PR TITLE
[FIX #1474] Fix copy/paste of coordinates, address, and map viewing

### DIFF
--- a/src/status_im/chat/views/message/message.cljs
+++ b/src/status_im/chat/views/message/message.cljs
@@ -412,9 +412,9 @@
                                 :on-long-press #(cond (= content-type text-content-type)
                                                       (share content (label :t/message))
                                                       (and (= content-type content-type-command) (= "location" (:content-command content)))
-                                                      (let [params (str/split (get-in content [:params "address"]) #"&amp;")
-                                                            latlong (rest params)]
-                                                        (share-or-open-map (first params) (first latlong) (second latlong))))}
+                                                      (let [address (get-in content [:params :address])
+                                                            [location lat long] (str/split address #"&amp;")]
+                                                        (share-or-open-map location lat long)))}
            [view
             (let [incoming-group (and group-chat (not outgoing))]
               [message-content message-body (merge message


### PR DESCRIPTION
#1474 

### Summary:
The messages view assumed a message structure that looks like this:

```clojure
{:params 
  {"address" "This is a Place#amp;lat#amp;long"}}
```
But ```:address``` is a keyword and not a string.

### Steps to test:
- Open Status
- Send a location
- Long press on the resulting map
- Copy the address, paste it into chat (you should see the place name)
- Copy the lat/long, paste them into chat (you should see ```lat```,```long```)

status: ready