### PR TITLE
Improve error message when status-go throw an error

### DIFF
--- a/src/status_im/translations/en.cljs
+++ b/src/status_im/translations/en.cljs
@@ -14,6 +14,8 @@
    :type-a-message                        "Type a message..."
    :type-a-command                        "Start typing a command..."
    :error                                 "Error"
+   :unknown-status-go-error               "Unknown status-go error"
+   :node-unavailable                      "No ethereum node running"
 
    :camera-access-error                   "To grant the required camera permission, please, go to your system settings and make sure that Status > Camera is selected."
    :photos-access-error                   "To grant the required photos permission, please, go to your system settings and make sure that Status > Photos is selected."

--- a/src/status_im/ui/screens/accounts/login/views.cljs
+++ b/src/status_im/ui/screens/accounts/login/views.cljs
@@ -1,6 +1,7 @@
 (ns status-im.ui.screens.accounts.login.views
   (:require-macros [status-im.utils.views :refer [defview letsubs]])
-  (:require [re-frame.core :refer [dispatch dispatch-sync]]
+  (:require [clojure.string :as string]
+            [re-frame.core :refer [dispatch dispatch-sync]]
             [status-im.ui.screens.accounts.styles :as ast]
             [status-im.ui.screens.accounts.views :refer [account-badge]]
             [status-im.components.text-input-with-label.view :refer [text-input-with-label]]
@@ -28,6 +29,19 @@
   (.blur @password-text-input)
   (dispatch [:login-account address password]))
 
+(defn- error-key [error]
+  ;; TODO Improved selection logic when status-go provide an error code
+  ;; see https://github.com/status-im/status-go/issues/278
+  (cond
+    (string/starts-with? error "there is no running node")
+    :t/node-unavailable
+
+    (string/starts-with? error "cannot retrieve a valid key")
+    :t/wrong-password
+
+    :else
+    :t/unknown-status-go-error))
+
 (defview login []
   (letsubs [{:keys [address photo-path name password error processing]} [:get :accounts/login]]
     [view ast/accounts-container
@@ -47,7 +61,7 @@
                                :on-submit-editing #(login-account password-text-input address password)
                                :auto-focus        true
                                :secure-text-entry true
-                               :error             (when (pos? (count error)) (i18n/label :t/wrong-password))}]]
+                               :error             (when (pos? (count error)) (i18n/label (error-key error)))}]]
       [view {:margin-top 16}
        [touchable-highlight {:on-press #(login-account password-text-input address password)}
         [view st/sign-in-button


### PR DESCRIPTION
### Summary:

Properly map `status-go` error messages and do not always show `Wrong password` message.

### Steps to test:
- Open Status
- Enter an incorrect password
- Check that the usual message is printed

New error messages can only be checked when `status-go` fails to initialize. Unfortunately we can't control that.

status: ready

