### PR TITLE
Increase timeout interval so Jenkins fails less often

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ node {
       sh 'rm -rf node_modules'
       sh 'cp .env.jenkins .env'
       sh 'lein deps && npm install && ./re-natal deps'
-      sh 'sed -i "" "s/301000/601000/g" node_modules/react-native/packager/src/JSTransformer/index.js'
+      sh 'sed -i "" "s/301000/1201000/g" node_modules/react-native/packager/src/JSTransformer/index.js'
       sh 'mvn -f modules/react-native-status/ios/RCTStatus dependency:unpack'
       sh 'cd ios && pod install && cd ..'
     }


### PR DESCRIPTION
Jenkins often times out. Like this https://github.com/status-im/status-react/pull/1167 we bump timeout x2 (again) until we can beef up Jenkins instance.