### PR TITLE
Update package-lock with new react-native-svg dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1361,6 +1361,37 @@
       "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
       "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw=="
     },
+    "color": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
+      "integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
+      "requires": {
+        "clone": "1.0.2",
+        "color-convert": "1.9.0",
+        "color-string": "0.3.0"
+      }
+    },
+    "color-convert": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
+      "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "color-string": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
+      "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
     "combined-stream": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
@@ -4961,6 +4992,15 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/react-native-splash-screen/-/react-native-splash-screen-1.0.9.tgz",
       "integrity": "sha1-TQhH5DyrKX1vjD6YkJ8AoVkpyyc="
+    },
+    "react-native-svg": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/react-native-svg/-/react-native-svg-4.6.1.tgz",
+      "integrity": "sha1-CPvFcTfo1XCnPC01xriauyOc1As=",
+      "requires": {
+        "color": "0.11.4",
+        "lodash": "4.17.4"
+      }
     },
     "react-native-swiper": {
       "version": "1.5.3",


### PR DESCRIPTION
Update package.lock with latest react-native-svg dependencies. Nothing to test, dev convenience thing.