### PR TITLE
Patch files to workaround iOS device crash

### DIFF
--- a/bin/fix-ios-device-crash.sh
+++ b/bin/fix-ios-device-crash.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+
+echo "Patching RCT Bundle URL provider to timeout if bundle update takes too long"
+patch -p0 < rct-bundle-url-provider.patch
+echo "Patching React Native Xcode script to not use xip.io"
+patch -p0 < react-native-xcode.patch
+echo "Ready to build and run for iOS device."

--- a/rct-bundle-url-provider.patch
+++ b/rct-bundle-url-provider.patch
@@ -1,0 +1,28 @@
+--- node_modules/react-native/React/Base/RCTBundleURLProvider.m	2017-08-30 17:59:11.000000000 +0200
++++ node_modules/react-native/React/Base/RCTBundleURLProvider.m.new	2017-08-30 18:00:12.000000000 +0200
+@@ -71,11 +71,21 @@
+ - (BOOL)isPackagerRunning:(NSString *)host
+ {
+   NSURL *url = [serverRootWithHost(host) URLByAppendingPathComponent:@"status"];
+-  NSURLRequest *request = [NSURLRequest requestWithURL:url];
+-  NSURLResponse *response;
++  // HACK: Sync network request sometimes takes too long, causing main thread to hang with an 0x8badf00d error.
++  // https://github.com/facebook/react-native/issues/10187
++  NSURLRequest *request = [NSMutableURLRequest requestWithURL:url cachePolicy:NSURLRequestReloadIgnoringCacheData timeoutInterval:5];
++  NSHTTPURLResponse *response = nil;
+   NSData *data = [NSURLConnection sendSynchronousRequest:request returningResponse:&response error:NULL];
+-  NSString *status = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+-  return [status isEqualToString:@"packager-status:running"];
++  if (response == nil) {
++    // timed out or failed
++    NSLog(@"sync request timed out.");
++    return false;
++  } else {
++    // all good
++    NSString *status = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
++    return [status isEqualToString:@"packager-status:running"];
++  }
++  return false;
+ }
+ 
+ - (NSString *)guessPackagerHost

--- a/react-native-xcode.patch
+++ b/react-native-xcode.patch
@@ -1,0 +1,13 @@
+--- node_modules/react-native/packager/react-native-xcode.sh	2017-08-30 18:07:25.000000000 +0200
++++ node_modules/react-native/packager/react-native-xcode.sh.new	2017-08-30 18:07:43.000000000 +0200
+@@ -79,8 +79,8 @@
+     IP=$(ifconfig | grep 'inet ' | grep -v 127.0.0.1 | cut -d\   -f2  | awk 'NR==1{print $1}')
+   fi
+   $PLISTBUDDY -c "Add NSAppTransportSecurity:NSExceptionDomains:localhost:NSTemporaryExceptionAllowsInsecureHTTPLoads bool true" "$PLIST"
+-  $PLISTBUDDY -c "Add NSAppTransportSecurity:NSExceptionDomains:$IP.xip.io:NSTemporaryExceptionAllowsInsecureHTTPLoads bool true" "$PLIST"
+-  echo "$IP.xip.io" > "$DEST/ip.txt"
++  $PLISTBUDDY -c "Add NSAppTransportSecurity:NSExceptionDomains:$IP:NSTemporaryExceptionAllowsInsecureHTTPLoads bool true" "$PLIST"
++  echo "$IP" > "$DEST/ip.txt"
+ fi
+ 
+ BUNDLE_FILE="$DEST/main.jsbundle"


### PR DESCRIPTION
Timeout sync network request to RN bundle if it takes too long. Sync network requests is the primary suspect for for 0x8badf00d errors according to Apple docs. Addresses https://github.com/status-im/status-react/issues/1687

Test requirement:
- dev who currently can't run iOS on device but has one

How to test:
- Install deps like normal
- Run `./bin/fix-ios-device-crash.sh`
- Build and run for iOS device

status: ready