### PR TITLE
Fix compilation warnings

### DIFF
--- a/src/status_im/chat/views/input/validation_messages.cljs
+++ b/src/status_im/chat/views/input/validation_messages.cljs
@@ -1,6 +1,7 @@
 (ns status-im.chat.views.input.validation-messages
-  (:require-macros [status-im.utils.views :refer [defview]])
-  (:require [status-im.components.react :as c]
+  (:require-macros [status-im.utils.views :refer [defview letsubs]])
+  (:require [re-frame.core :as re-frame]
+            [status-im.components.react :as c]
             [status-im.chat.styles.input.validation-message :as style]
             [status-im.utils.listview :as lw]
             [status-im.i18n :as i18n]))
@@ -17,12 +18,12 @@
    markup])
 
 (defview validation-messages-view []
-  [chat-input-margin [:chat-input-margin]
-   input-height [:chat-ui-props :input-height]
-   messages [:chat-ui-props :validation-messages]]
-  (when messages
-    [c/view (style/root (+ input-height chat-input-margin))
-     (if (string? messages)
-       [messages-list [validation-message {:title       (i18n/label :t/error)
-                                           :description messages}]]
-       [messages-list messages])]))
+  (letsubs [chat-input-margin [:chat-input-margin]
+            input-height [:chat-ui-props :input-height]
+            messages [:chat-ui-props :validation-messages]]
+    (when messages
+      [c/view (style/root (+ input-height chat-input-margin))
+       (if (string? messages)
+         [messages-list [validation-message {:title       (i18n/label :t/error)
+                                             :description messages}]]
+         [messages-list messages])])))

--- a/src/status_im/ui/screens/wallet/events.cljs
+++ b/src/status_im/ui/screens/wallet/events.cljs
@@ -62,9 +62,9 @@
   (assoc-in db [:wallet :wallet/error] err))
 
 (handlers/register-handler-db
- :wallet/clear-error-message
- (fn [db [_]]
-   (update db :wallet dissoc :wallet/error)))
+  :wallet/clear-error-message
+  (fn [db [_]]
+    (update db :wallet dissoc :wallet/error)))
 
 (handlers/register-handler-db
   :update-balance
@@ -84,6 +84,6 @@
 
 (handlers/register-handler-db
   :update-prices-fail
-  (fn [_ [_ err]]
+  (fn [db [_ err]]
     (log/debug "Unable to get prices: " err)
     (set-error-message db :error)))


### PR DESCRIPTION
### Summary:
Small PR that simply fixes compilation warning by adding missing imports and function parameter names

status: ready

