### PR TITLE
[FIX #1731] Prepare configuration allowing to fail build

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -42,7 +42,8 @@
                                      :compiler     {:output-to     "target/android/app.js"
                                                     :main          "env.android.main"
                                                     :output-dir    "target/android"
-                                                    :optimizations :none}}}}
+                                                    :optimizations :none}
+                                     :warning-handlers [status-im.utils.build/warning-handler]}}}
                     :repl-options {:nrepl-middleware [cemerick.piggieback/wrap-cljs-repl]
                                    :timeout          240000}}
              :test {:dependencies [[day8.re-frame/test "0.1.5"]]
@@ -73,7 +74,8 @@
                                                  :optimizations      :simple
                                                  :closure-defines    {"goog.DEBUG" false}
                                                  :parallel-build     true
-                                                 :language-in        :ecmascript5}}
+                                                 :language-in        :ecmascript5}
+                                  :warning-handlers [status-im.utils.build/warning-handler]}
                                  :android
                                  {:source-paths ["react-native/src" "src" "env/prod"]
                                   :compiler     {:output-to          "index.android.js"
@@ -84,4 +86,5 @@
                                                  :optimizations      :simple
                                                  :closure-defines    {"goog.DEBUG" false}
                                                  :parallel-build     true
-                                                 :language-in        :ecmascript5}}}}}})
+                                                 :language-in        :ecmascript5}
+                                  :warning-handlers [status-im.utils.build/warning-handler]}}}}})

--- a/src/status_im/utils/build.clj
+++ b/src/status_im/utils/build.clj
@@ -1,0 +1,10 @@
+(ns status-im.utils.build
+  (:require [cljs.analyzer :as analyzer]))
+
+(defn warning-handler [warning-type env extra]
+  (when (warning-type analyzer/*cljs-warnings*)
+    (when-let [s (analyzer/error-message warning-type extra)]
+      (binding [*out* *err*]
+        (println (analyzer/message env (str "\u001B[31mWARNING\u001B[0m: " s))))
+      ;; TODO Do not enable yet as our current reagent version generates warnings
+      #_(System/exit 1))))


### PR DESCRIPTION
### Summary:

Improve `warnings` visibility (red color).
Prepare configuration for failing build on warnings. This is not enabled yet due to one of our dependency generating warnings.

### Steps to test:
- Execute production build
- See wrnings being printed in red

status: ready

