### PR TITLE
Ethereum transactions history data bindings

### DIFF
--- a/src/status_im/ui/screens/events.cljs
+++ b/src/status_im/ui/screens/events.cljs
@@ -166,6 +166,7 @@
                   [:remove-old-discoveries!]
                   [:set :accounts/creating-account? false]
                   [:refresh-wallet]
+                  [:refresh-transactions]
                   [:get-fcm-token]]}))
 
 (register-handler-fx
@@ -273,4 +274,3 @@
  (fn [_ _]
    (notifications/get-fcm-token)
    {}))
-

--- a/src/status_im/ui/screens/wallet/main/views.cljs
+++ b/src/status_im/ui/screens/wallet/main/views.cljs
@@ -128,12 +128,12 @@
        :refreshing               (or prices-loading? balance-loading?)}]]))
 
 (defview wallet []
-  (letsubs [eth-balance [:eth-balance]
-            portfolio-value [:portfolio-value]
+  (letsubs [eth-balance      [:eth-balance]
+            portfolio-value  [:portfolio-value]
             portfolio-change [:portfolio-change]
-            prices-loading?    [:prices-loading?]
-            balance-loading?   [:wallet/balance-loading?]
-            error-message [:wallet/error-message]]
+            prices-loading?  [:prices-loading?]
+            balance-loading? [:wallet/balance-loading?]
+            error-message    [:wallet/error-message]]
     [rn/view {:style wallet-styles/wallet-container}
      [toolbar-view]
      [rn/scroll-view

--- a/src/status_im/utils/datetime.cljs
+++ b/src/status_im/utils/datetime.cljs
@@ -34,6 +34,11 @@
        (before? date today) (label :t/datetime-yesterday)
        :else (today-format-fn local)))))
 
+(defn date->mini-str-date [ms]
+  (unparse (formatter "dd MMM") (-> ms
+                                    from-long
+                                    (plus time-zone-offset))))
+
 (defn day-relative [ms]
   (when (pos? ms)
     (to-short-str ms #(label :t/datetime-today))))

--- a/src/status_im/utils/transactions.cljs
+++ b/src/status_im/utils/transactions.cljs
@@ -1,0 +1,37 @@
+(ns status-im.utils.transactions
+  (:require [status-im.utils.utils :as utils]
+            [status-im.utils.types :as types]
+            [status-im.utils.money :as money]))
+
+(defn get-transaction-url [network account]
+  (let [network (case network
+                  "testnet" "ropsten"
+                  "mainnet" "api")]
+    (str "https://" network ".etherscan.io/api?module=account&action=txlist&address=0x"
+         account "&startblock=0&endblock=99999999&sort=desc&apikey=YourApiKeyToken?q=json")))
+
+(defn format-transaction [account {:keys [value to from timeStamp]}]
+  (let [transaction {:value (money/wei->ether value)
+                     ;; timestamp is in seconds, we convert it in ms
+                     :timestamp (str timeStamp "000")
+                     :symbol "ETH"}
+        inbound?    (= (str "0x" account) to)]
+    (if inbound?
+      (assoc transaction
+             :from from
+             :type :inbound)
+      (assoc transaction
+             :to to
+             :type :outbound))))
+
+(defn format-transactions-response [response account]
+  (->> response
+       types/json->clj
+       :result
+       (map (partial format-transaction account))
+       (sort-by :timestamp)))
+
+(defn get-transactions [network account on-success on-error]
+  (utils/http-get (get-transaction-url network account)
+                  #(on-success (format-transactions-response % account))
+                  on-error))


### PR DESCRIPTION

- [x] use etherscan to fetch the transaction history of the new wallet 
- [x] show real transaction data in the History tab of the new wallet

### Summary:
The data-binding for the pending and postponed transaction will be done in a separate PR to merge faster.

### Steps to test:
- Open Status
- Go to the new wallet screen
- Press the top right double arrow icon to go to transaction screen
- Check if the data you see is your real Ethereum transaction

status: ready

