### PR TITLE
[WIP] fix #1386 increased gas price multiplier in order to prevent the app …

### DIFF
--- a/resources/js/bots/wallet/bot.js
+++ b/resources/js/bots/wallet/bot.js
@@ -6,7 +6,7 @@ function calculateFee(n, tx) {
 
     var gasMultiplicator = Math.pow(1.4, n).toFixed(3);
     var weiFee = web3.eth.gasPrice * gasMultiplicator * estimatedGas;
-    // force fee in eth to be of BigNumber type
+    // force fee in ETH to be of BigNumber type
     var ethFee = web3.toBigNumber(web3.fromWei(weiFee, "ether"));
     // always display 7 decimal places
     return ethFee.toFixed(7);

--- a/resources/js/bots/wallet/bot.js
+++ b/resources/js/bots/wallet/bot.js
@@ -26,7 +26,7 @@ status.defineSubscription(
 );
 
 function getFeeExplanation(n) {
-    return I18n.t('send_explanation') + I18n.t('send_explanation_' + (n + 2));
+    return I18n.t('send_explanation') + I18n.t('send_explanation_' + n);
 }
 
 status.defineSubscription(
@@ -182,8 +182,8 @@ function amountParameterBox(params, context) {
                     ),
                     status.components.slider(
                         {
-                            maximumValue: 2,
-                            minimumValue: -2,
+                            maximumValue: 4,
+                            minimumValue: 0,
                             onSlidingComplete: status.components.dispatch(
                                 [status.events.UPDATE_DB, "sliderValue"]
                             ),


### PR DESCRIPTION
#1386 

If a transaction is sent with the lowest fee (or even second to lowest) it will not be sent and no subsequent transaction will be sent from the same account either until the app is restarted.

### Context

Ivan T:
>When you send a transaction, it gets assigned a nonce (just an incrementing number).
If you send a transaction with a low fee which is never mined, all subsequent transactions won't be mined as well.
Just because they have a higher nonce and miners won't even process them.
All that, as I know, is happening on the local memory queue. If you restart the application, that memory pool is gone and you can start sending transactions again.
As I can see, we just need to increase the minimum possible fee to the amount miners accept.

Originally, the code was built based on Ethereum Wallet: https://github.com/ethereum/meteor-package-elements/blob/master/selectGasPrice.js
Their code did change in the mean time, but in a way that allows transactions with even lower fees to be submitted. Specifically, their formula was changed from:

```gasPrice * estimatedGas * 1.4^n  | for n in range [-2, 2] default 0```

to this:

```gasPrice * estimatedGas * 2.0^n  | for n in range [-4, 1] default 0``` 

I'm yet to test a few transactions with Ethereum Wallet, just to see if perhaps their cheaper settings also get stuck and, if so, how do they handle it.

### Current fix

Meanwhile, here's a workaround that solves the immediate problem at hand. I changed the fee formula to remove the two previous cheapest options and added two more expensive ones. Basically, just shifted all fee options to right.

```gasPrice * estimatedGas * 1.4^n  | for n in range [-2, 2] default 0```

The new minimum fee is what was previously the default fee (i.e. middle or `n=0`) All other options may only be more expensive and as such will not fail to be included in the blockchain. 

Obviously all alternative (or incremental) suggestions are welcome.

### Steps to test:

1. Open Status
2. Send some eth to any account with the lowest fee
3. Check the account balance on ropsten.etherscan.io 
4. Note: double check if the transaction has at least 12 confirmations
5. Repeat the process a couple of times with a different fee

### Expected outcome

All transactions went through 

[comment]: # (PRs will only be accepted if squashed into single commit.)
status: wip

