### PR TITLE
Wallet UX: fix sticking errors and enable more frequent refreshes

### DIFF
--- a/src/status_im/components/styles.cljs
+++ b/src/status_im/components/styles.cljs
@@ -20,6 +20,7 @@
 (def color-gray6 "#212121")
 (def color-gray7 "#9fa3b4")
 (def color-gray8 "#6E777E")
+(def color-gray9 "#E9EBEC")
 (def color-dark "#49545d")
 (def color-steel "#838b91")
 (def color-white "white")

--- a/src/status_im/ui/screens/events.cljs
+++ b/src/status_im/ui/screens/events.cljs
@@ -165,8 +165,8 @@
                   [:start-requesting-discoveries]
                   [:remove-old-discoveries!]
                   [:set :accounts/creating-account? false]
-                  [:refresh-wallet]
-                  [:refresh-transactions]
+                  [:update-wallet]
+                  [:update-transactions]
                   [:get-fcm-token]]}))
 
 (register-handler-fx
@@ -270,7 +270,7 @@
 
 ;; TODO(oskarth): Put this token in DB
 (register-handler-fx
- :get-fcm-token
- (fn [_ _]
-   (notifications/get-fcm-token)
-   {}))
+  :get-fcm-token
+  (fn [_ _]
+    (notifications/get-fcm-token)
+    {}))

--- a/src/status_im/ui/screens/wallet/history/styles.cljs
+++ b/src/status_im/ui/screens/wallet/history/styles.cljs
@@ -1,14 +1,29 @@
 (ns status-im.ui.screens.wallet.history.styles
-  (:require [status-im.components.styles :as st]))
+  (:require [status-im.components.styles :as styles]))
+
+(def error-container
+  {:align-self       :center
+   :justify-content  :center
+   :border-radius    4
+   :padding-vertical 4
+   :flex-direction   :row
+   :background-color styles/color-gray9})
+
+(def error-message
+  {:color         styles/color-black
+   :padding-top   3
+   :padding-right 10
+   :font-size     13})
+
 
 (def wallet-transactions-container
   {:flex             1
-   :background-color st/color-white})
+   :background-color styles/color-white})
 
 (def main-section
   {:flex             1
    :position         :relative
-   :background-color st/color-white})
+   :background-color styles/color-white})
 
 (def empty-text
   {:text-align       :center
@@ -24,11 +39,11 @@
   {:flex              1
    :flex-direction    :column
    :justify-content   :center
-   :background-color  st/color-gray-transparent})
+   :background-color  styles/color-gray-transparent})
 
 (def sign-all-popup
   {:align-self        :flex-start
-   :background-color  st/color-white
+   :background-color  styles/color-white
    :margin-horizontal 12
    :border-radius     8})
 
@@ -38,7 +53,7 @@
    :margin-horizontal 12
    :text-align        :center
    :padding-vertical  9
-   :background-color  st/color-light-gray})
+   :background-color  styles/color-light-gray})
 
 (def sign-all-popup-text
   {:margin-top        8
@@ -64,4 +79,4 @@
 
 (defn transaction-icon-background [color]
   {:border-radius    32
-   :background-color st/color-blue4-transparent})
+   :background-color styles/color-blue4-transparent})

--- a/src/status_im/ui/screens/wallet/main/styles.cljs
+++ b/src/status_im/ui/screens/wallet/main/styles.cljs
@@ -1,39 +1,26 @@
 (ns status-im.ui.screens.wallet.main.styles
-  (:require [status-im.components.styles :as st]
+  (:require [status-im.components.styles :as styles]
             [status-im.utils.platform :as platform]))
 
 (def wallet-container
   {:flex             1
-   :background-color st/color-white})
+   :background-color styles/color-white})
 
-(def wallet-error-container
+(def error-container
   {:align-self       :center
    :justify-content  :center
    :border-radius    20
    :flex-direction   :row
-   :background-color st/color-blue5})
+   :background-color styles/color-blue5})
 
-(def wallet-exclamation-container
-  {:background-color st/color-red-2
-   :justify-content  :center
-   :margin-top       5
-   :margin-left      10
-   :margin-right     7
-   :margin-bottom    5
-   :border-radius    100})
-
-(def wallet-error-exclamation
-  {:width  16
-   :height 16})
-
-(def wallet-error-message
-  {:color         st/color-white
+(def error-message
+  {:color         styles/color-white
    :padding-top   3
    :padding-right 10
    :font-size     13})
 
 (def toolbar
-  {:background-color st/color-blue5
+  {:background-color styles/color-blue5
    :elevation        0})
 
 (def toolbar-title-container
@@ -45,7 +32,7 @@
   {:flex-direction :row})
 
 (def toolbar-title-text
-  {:color        st/color-white
+  {:color        styles/color-white
    :font-size    17
    :margin-right 4})
 
@@ -69,7 +56,7 @@
 
 (def main-section
   {:padding          16
-   :background-color st/color-blue4})
+   :background-color styles/color-blue4})
 
 (def total-balance-container
   {:margin-top      18
@@ -81,12 +68,12 @@
 
 (def total-balance-value
   {:font-size 37
-   :color     st/color-white})
+   :color     styles/color-white})
 
 (def total-balance-currency
   {:font-size   37
    :margin-left 9
-   :color       st/color-white
+   :color       styles/color-white
    :opacity     0.4})
 
 (def value-variation
@@ -95,7 +82,7 @@
 
 (def value-variation-title
   {:font-size 14
-   :color     st/color-white
+   :color     styles/color-white
    :opacity   0.6})
 
 (def today-variation-container
@@ -106,22 +93,22 @@
 
 (def today-variation-container-positive
   (merge today-variation-container
-         {:background-color st/color-green-1}))
+         {:background-color styles/color-green-1}))
 
 (def today-variation-container-negative
   (merge today-variation-container
-         {:background-color st/color-red-3}))
+         {:background-color styles/color-red-3}))
 
 (def today-variation
   {:font-size 12})
 
 (def today-variation-positive
   (merge today-variation
-         {:color st/color-green-2}))
+         {:color styles/color-green-2}))
 
 (def today-variation-negative
   (merge today-variation
-         {:color st/color-red-4}))
+         {:color styles/color-red-4}))
 
 (def buttons
   {:margin-top 34})
@@ -131,13 +118,13 @@
 ;;;;;;;;;;;;;;;;;;;;
 
 (def asset-section
-  {:background-color st/color-white
+  {:background-color styles/color-white
    :padding-vertical 16})
 
 (def asset-section-title
   {:font-size   14
    :margin-left 16
-   :color       st/color-gray4})
+   :color       styles/color-gray4})
 
 (def asset-item-value-container
   {:flex           1
@@ -146,19 +133,19 @@
 
 (def asset-item-value
   {:font-size 16
-   :color     st/color-black})
+   :color     styles/color-black})
 
 (def add-asset-icon
   {:border-radius    32
-   :background-color st/color-blue4-transparent})
+   :background-color styles/color-blue4-transparent})
 
 (def add-asset-text
   {:font-size 16
-   :color     st/color-blue4})
+   :color     styles/color-blue4})
 
 (def asset-item-currency
   {:font-size   16
-   :color       st/color-gray4
+   :color       styles/color-gray4
    :margin-left 6})
 
 (defn asset-border [color]

--- a/src/status_im/ui/screens/wallet/main/views.cljs
+++ b/src/status_im/ui/screens/wallet/main/views.cljs
@@ -17,6 +17,7 @@
             [status-im.utils.platform :as platform]
             [status-im.utils.utils :as utils]
             [status-im.ui.screens.wallet.main.styles :as wallet-styles]
+            [status-im.ui.screens.wallet.views :as wallet.views]
             [status-im.utils.money :as money]))
 
 (defn- show-not-implemented! []
@@ -46,16 +47,9 @@
    [toolbar-title]
    [toolbar-buttons]])
 
-(defn error-message-view [error-message]
-  [rn/view {:style wallet-styles/wallet-error-container}
-   [rn/view {:style wallet-styles/wallet-exclamation-container}
-    [vi/icon :icons/exclamation_mark {:color           :white
-                                      :container-style wallet-styles/wallet-error-exclamation}]]
-   [rn/text {:style wallet-styles/wallet-error-message} (i18n/label :t/wallet-error)]])
-
 (defn main-section [usd-value change error-message]
   [rn/view {:style wallet-styles/main-section}
-   (when error-message [error-message-view error-message])
+   (when error-message [wallet.views/error-message-view wallet-styles/error-container wallet-styles/error-message])
    [rn/view {:style wallet-styles/total-balance-container}
     [rn/view {:style wallet-styles/total-balance}
      [rn/text {:style wallet-styles/total-balance-value} usd-value]
@@ -124,7 +118,7 @@
                                    :data       [{}]
                                    :renderItem (list/wrap-render-fn render-add-asset-fn)}]
        :render-section-header-fn #()
-       :on-refresh               #(rf/dispatch [:refresh-wallet])
+       :on-refresh               #(rf/dispatch [:update-wallet])
        :refreshing               (or prices-loading? balance-loading?)}]]))
 
 (defview wallet []
@@ -133,7 +127,7 @@
             portfolio-change [:portfolio-change]
             prices-loading?  [:prices-loading?]
             balance-loading? [:wallet/balance-loading?]
-            error-message    [:wallet/error-message]]
+            error-message    [:wallet/error-message?]]
     [rn/view {:style wallet-styles/wallet-container}
      [toolbar-view]
      [rn/scroll-view

--- a/src/status_im/ui/screens/wallet/navigation.cljs
+++ b/src/status_im/ui/screens/wallet/navigation.cljs
@@ -1,0 +1,13 @@
+(ns status-im.ui.screens.wallet.navigation
+  (:require [re-frame.core :as re-frame]
+            [status-im.ui.screens.navigation :as navigation]))
+
+(defmethod navigation/preload-data! :wallet
+  [db _]
+  (re-frame/dispatch [:update-wallet])
+  db)
+
+(defmethod navigation/preload-data! :wallet-transactions
+  [db _]
+  (re-frame/dispatch [:update-transactions])
+  db)

--- a/src/status_im/ui/screens/wallet/styles.cljs
+++ b/src/status_im/ui/screens/wallet/styles.cljs
@@ -1,0 +1,15 @@
+(ns status-im.ui.screens.wallet.styles
+  (:require [status-im.components.styles :as st]))
+
+(def wallet-exclamation-container
+  {:background-color st/color-red-2
+   :justify-content  :center
+   :margin-top       5
+   :margin-left      10
+   :margin-right     7
+   :margin-bottom    5
+   :border-radius    100})
+
+(def wallet-error-exclamation
+  {:width  16
+   :height 16})

--- a/src/status_im/ui/screens/wallet/subs.cljs
+++ b/src/status_im/ui/screens/wallet/subs.cljs
@@ -16,9 +16,14 @@
   (fn [db]
     (get-in db [:prices :last-day])))
 
-(reg-sub :wallet/error-message
+(reg-sub :wallet/error-message?
   (fn [db]
-    (get-in db [:wallet :wallet/error])))
+    (or (get-in db [:wallet :errors :balance-update])
+        (get-in db [:wallet :errors :prices-update]))))
+
+(reg-sub :wallet.transactions/error-message?
+  (fn [db]
+    (get-in db [:wallet :errors :transactions-update])))
 
 (reg-sub :eth-balance
   :<- [:balance]

--- a/src/status_im/ui/screens/wallet/views.cljs
+++ b/src/status_im/ui/screens/wallet/views.cljs
@@ -1,0 +1,12 @@
+(ns status-im.ui.screens.wallet.views
+  (:require [status-im.components.react :as react]
+            [status-im.ui.screens.wallet.styles :as styles]
+            [status-im.components.icons.vector-icons :as vector-icons]
+            [status-im.i18n :as i18n]))
+
+(defn error-message-view [error-container-style error-message-style]
+  [react/view {:style error-container-style}
+   [react/view {:style styles/wallet-exclamation-container}
+    [vector-icons/icon :icons/exclamation_mark {:color           :white
+                                                :container-style styles/wallet-error-exclamation}]]
+   [react/text {:style error-message-style} (i18n/label :t/wallet-error)]])

--- a/test/cljs/status_im/test/wallet/events.cljs
+++ b/test/cljs/status_im/test/wallet/events.cljs
@@ -14,15 +14,20 @@
    clear-error"
   (run-test-sync
    (re-frame/reg-fx ::events/init-store #())
+   (re-frame/reg-fx :get-prices #())
+   (re-frame/reg-fx :get-balance #())
    (re-frame/dispatch [:initialize-db])
-   (let [error (re-frame/subscribe [:wallet/error-message])
-         message :error]
+   (let [error (re-frame/subscribe [:wallet/error-message?])
+         message "failed balance update"]
      (re-frame/dispatch [:update-balance-fail message])
      (is (= message @error)))
-   (let [error (re-frame/subscribe [:wallet/error-message])
-         message :error]
+   (let [error (re-frame/subscribe [:wallet/error-message?])]
+     (re-frame/dispatch [:update-wallet])
+     (is (nil? @error)))
+   (let [error (re-frame/subscribe [:wallet/error-message?])
+         message "failed price update"]
      (re-frame/dispatch [:update-prices-fail message])
-     (is (= message @error)))
-   (let [error (re-frame/subscribe [:wallet/error-message])]
-     (re-frame/dispatch [:wallet/clear-error-message])
-     (is (nil? @error)))))
+     (is (= message @error))))
+  (let [error (re-frame/subscribe [:wallet/error-message?])]
+    (re-frame/dispatch [:update-wallet])
+    (is (nil? @error))))


### PR DESCRIPTION

[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)
fixes #1777

### Summary:
- fix wallet errors that were sticking when refresh occurred
- add separate errors for transaction history fetching with visual feedback
- update wallet when going on wallet tab
- update transaction list when opening transaction modal

### Steps to test:
- Open Status
- go to wallet tab
- kill network
- refresh wallet assets
- check error is shown
- go to transaction history
- check error is shown
- restart network
- refresh transaction history
- check error is gone
- go back to wallet tab
- refresh
- check error is gone
[comment]: # (PRs will only be accepted if squashed into single commit.)
status: ready

### Relevant issues for this PR
- #1786 A general mechanism to feed errors back to user
- #1785 Handle timeout for network failure in utils.utils/http-get and http-post
