### PR TITLE
Exit iOS RN parent script when failing

### DIFF
--- a/ios/StatusIm.xcodeproj/project.pbxproj
+++ b/ios/StatusIm.xcodeproj/project.pbxproj
@@ -1720,7 +1720,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "export NODE_BINARY=\"node --max-old-space-size=4096\" \n../node_modules/react-native/packager/react-native-xcode.sh";
+			shellScript = "set -o errexit\nexport NODE_BINARY=\"node --max-old-space-size=4096\"\n../node_modules/react-native/packager/react-native-xcode.sh";
 		};
 		1986C962445001A2631E6AB0 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
### Summary:
Addresses https://github.com/status-im/status-react/issues/1790

[comment]: # (Summarise the problem and how the pull request solves it)

Script exits on error:
```
set -o errexit # <- new
export NODE_BINARY="node --max-old-space-size=4096"
../node_modules/react-native/packager/react-native-xcode.sh
```

`react-native-xcode.sh` sometimes exits with an error but Xcode keeps building. With this shell safeguard the build should fail instead.

Tested by adding `exit 1` and noticing the resulting build failing. Leaving it alone (usually, since it is an intermittent issue) causes a successful build.

Nothing to test really as this is an intermittent build issue at Jenkins. Can be merged straight away.

status: ready