### PR TITLE
Enable treating warnings as errors and list acceptable warnings

### DIFF
--- a/src/status_im/utils/build.clj
+++ b/src/status_im/utils/build.clj
@@ -1,10 +1,21 @@
 (ns status-im.utils.build
   (:require [cljs.analyzer :as analyzer]))
 
+;; Some warnings are unavoidable due to dependencies. For example, reagent 0.6.0
+;; has a warning in its util.cljs namespace. Adjust this as is necessary and
+;; unavoidable warnings arise.
+(def acceptable-warning?
+  #{
+    "Protocol IFn implements method -invoke with variadic signature (&)" ;; reagent 0.6.0 reagent/impl/util.cljs:61
+    })
+
+(defn nil-acceptable-warning [s]
+  (when-not (acceptable-warning? s)
+    s))
+
 (defn warning-handler [warning-type env extra]
   (when (warning-type analyzer/*cljs-warnings*)
-    (when-let [s (analyzer/error-message warning-type extra)]
+    (when-let [s (nil-acceptable-warning (analyzer/error-message warning-type extra))]
       (binding [*out* *err*]
         (println (analyzer/message env (str "\u001B[31mWARNING\u001B[0m: " s))))
-      ;; TODO Do not enable yet as our current reagent version generates warnings
-      #_(System/exit 1))))
+      (System/exit 1))))


### PR DESCRIPTION
Addresses https://github.com/status-im/status-react/issues/1797

Enable warning as errors on build to catch bugs like #1796 in automated way.

Defines a whitelist of warnings that we currently can't do anything about.

status: ready