### PR TITLE
fix #1605 protocol message parser catches all invalid payload as errors

### DIFF
--- a/src/status_im/protocol/listeners.cljs
+++ b/src/status_im/protocol/listeners.cljs
@@ -3,28 +3,37 @@
             [status-im.protocol.ack :as ack]
             [status-im.protocol.web3.utils :as u]
             [status-im.protocol.encryption :as e]
-            [taoensso.timbre :refer-macros [debug]]
+            [taoensso.timbre :as log]
             [status-im.utils.hex :as i]))
 
+(defn create-error [description]
+  (log/debug :parse-payload-error description)
+  {:error description})
+
 (defn- parse-payload [payload]
-  (debug :parse-payload)
+  (log/debug :parse-payload)
   (try
     ;; todo figure why we have to call to-utf8 twice
-    (let [read (comp r/read-string u/to-utf8 u/to-utf8)]
-      {:payload (read payload)})
+    (let [payload'   (u/to-utf8 payload)
+          payload''  (r/read-string payload')
+          payload''' (if (map? payload'')
+                       payload''
+                       (r/read-string (u/to-utf8 payload')))]
+      (if (map? payload''')
+        {:payload payload'''}
+        (create-error (str "Invalid payload type " (type payload''')))))
     (catch :default err
-      (debug :parse-payload-error err)
-      {:error err})))
+      (create-error err))))
 
 (defn- decrypt [key content]
   (try
     {:content (r/read-string (e/decrypt key content))}
     (catch :default err
-      (debug :decrypt-error err)
+      (log/debug :decrypt-error err)
       {:error err})))
 
 (defn- parse-content [key {:keys [content]} was-encrypted?]
-  (debug :parse-content
+  (log/debug :parse-content
          "Key exists:" (not (nil? key))
          "Content exists:" (not (nil? content)))
   (if (and (not was-encrypted?) key content)
@@ -36,9 +45,9 @@
   (fn [error js-message]
     ;; todo handle error
     (when error
-      (debug :listener-error error))
+      (log/debug :listener-error error))
     (when-not error
-      (debug :message-received (js->clj js-message))
+      (log/debug :message-received (js->clj js-message))
       (let [{:keys [sig payload recipientPublicKey] :as message}
             (js->clj js-message :keywordize-keys true)
 
@@ -56,7 +65,7 @@
                                                             (not= "" recipientPublicKey)
                                                             (not (nil? recipientPublicKey))))]
             (if error
-              (debug :failed-to-handle-message error)
+              (log/debug :failed-to-handle-message error)
               (let [payload'' (assoc payload' :content content)
                     message'  (assoc message :payload payload''
                                              :to recipientPublicKey


### PR DESCRIPTION
#1605 

### Summary:
[comment]: # (Summarise the problem and how the pull request solves it)

The main issue here was that there was a case where code that parses protocol messages could parse malformed messages incorrectly instead of detecting the error.

Specifically, EDN parser (`u/read-string`) could parse payload that's valid ClojureScript but invalid message, e.g. a symbol or a number. Subsequent code assumes that parsed message is a map or at least associative and that leads to the uncaught runtime error. 

This PR adds an extra check to see if the parsed payload is a ClojureScript map and if not treats the case as an error, which it is. 

This only removes the embarrassing popup from the users' eyes and properly logs it in logcat. To fix the root cause of the issue we need to find the code that creates, sends or encodes the malformed protocol messages. With that in mind, I recommend continuing with these follow up issues: #1805, #1806 

### Steps to test:

See #1605 

[comment]: # (PRs will only be accepted if squashed into single commit.)
status: ready

