### PR TITLE
sort completed-transactions by timestamp

### DIFF
--- a/src/status_im/ui/screens/wallet/history/views.cljs
+++ b/src/status_im/ui/screens/wallet/history/views.cljs
@@ -78,8 +78,8 @@
 (defn- empty-text [s] [react/text {:style history.styles/empty-text} s])
 
 (defview history-list []
-  (letsubs [transactions-history-list [:wallet/transactions-history-list]
-            transactions-loading?     [:wallet/transactions-loading?]
+  (letsubs [transactions-history-list [:wallet.transactions/transactions-history-list]
+            transactions-loading?     [:wallet.transactions/transactions-loading?]
             error-message             [:wallet.transactions/error-message?]]
     [react/scroll-view {:style styles/flex}
      (when error-message [wallet.views/error-message-view history.styles/error-container history.styles/error-message])
@@ -180,7 +180,7 @@
 ;; TODO(yenda) must reflect selected wallet
 
 (defview transactions []
-  [unsigned-transactions [:wallet/unsigned-transactions]]
+  [unsigned-transactions [:wallet.transactions/unsigned-transactions]]
   (let [tabs         (tab-list unsigned-transactions)
         default-view (get-in tabs [0 :view-id])
         view-id      (reagent/atom default-view)]

--- a/src/status_im/ui/screens/wallet/subs.cljs
+++ b/src/status_im/ui/screens/wallet/subs.cljs
@@ -60,40 +60,54 @@
   (fn [db]
     (get-in db [:wallet :balance-loading?])))
 
-(reg-sub :wallet/transactions-loading?
+(reg-sub :wallet.transactions/transactions-loading?
   (fn [db]
     (get-in db [:wallet :transactions-loading?])))
 
-(reg-sub :wallet/transactions
+(reg-sub :wallet.transactions/transactions
   (fn [db]
-    (get-in db [:wallet :transactions])))
+    (group-by :type (get-in db [:wallet :transactions]))))
 
-(defn filter-transactions [type transactions]
-  (filter #(= (:type %) type) transactions))
-
-(reg-sub :wallet/unsigned-transactions
-  :<- [:wallet/transactions]
+(reg-sub :wallet.transactions/unsigned-transactions
+  :<- [:wallet.transactions/transactions]
   (fn [transactions]
-    (filter-transactions :unsigned transactions)))
+    (:unsigned transactions)))
 
-(defn mini-str-date->keyword [mini-str-date]
-  (keyword (str "sent-" (string/replace mini-str-date #" " "-"))))
+(reg-sub :wallet.transactions/postponed-transactions-list
+  :<- [:wallet.transactions/transactions]
+  (fn [{:keys [postponed]}]
+    (when postponed
+      {:title "Postponed"
+       :key :postponed
+       :data postponed})))
 
-(reg-sub :wallet/transactions-history-list
-  :<- [:wallet/transactions]
-  (fn [transactions]
-    (let [{:keys [postponed pending inbound outbound]} (group-by :type transactions)
-          transaction-history-list                     [(if postponed
-                                                          {:title "Postponed"
-                                                           :key   :postponed
-                                                           :data  postponed})
-                                                        (if pending
-                                                          {:title "Pending"
-                                                           :key   :pending
-                                                           :data  pending})]
-          completed-transactions                       (->> (into inbound outbound)
-                                                            (group-by #(datetime/date->mini-str-date (:timestamp %)))
-                                                            (map (fn [[k v]] {:title k
-                                                                              :key   (mini-str-date->keyword k)
-                                                                              :data  v})))]
-      (into (filterv (complement nil?) transaction-history-list) (or completed-transactions [])))))
+(reg-sub :wallet.transactions/pending-transactions-list
+  :<- [:wallet.transactions/transactions]
+  (fn [{:keys [pending]}]
+    (when pending
+      {:title "Pending"
+       :key :pending
+       :data pending})))
+
+(reg-sub :wallet.transactions/completed-transactions-list
+  :<- [:wallet.transactions/transactions]
+  (fn [{:keys [inbound outbound]}]
+    (->> (into inbound outbound)
+         (group-by #(datetime/timestamp->date-key (:timestamp %)))
+         (sort-by key)
+         reverse
+         (map (fn [[k v]]
+                {:title (datetime/timestamp->mini-date (:timestamp (first v)))
+                 :key   k
+                 ;; TODO (yenda investigate wether this sort-by is necessary or not)
+                 :data  (sort-by :timestamp v)})))))
+
+(reg-sub :wallet.transactions/transactions-history-list
+  :<- [:wallet.transactions/postponed-transactions-list]
+  :<- [:wallet.transactions/pending-transactions-list]
+  :<- [:wallet.transactions/completed-transactions-list]
+  (fn [[postponed pending completed]]
+    (cond-> []
+      postponed (into postponed)
+      pending   (into pending)
+      completed (into completed))))

--- a/src/status_im/utils/datetime.cljs
+++ b/src/status_im/utils/datetime.cljs
@@ -34,10 +34,15 @@
        (before? date today) (label :t/datetime-yesterday)
        :else (today-format-fn local)))))
 
-(defn date->mini-str-date [ms]
+(defn timestamp->mini-date [ms]
   (unparse (formatter "dd MMM") (-> ms
                                     from-long
                                     (plus time-zone-offset))))
+
+(defn timestamp->date-key [ms]
+  (keyword (unparse (formatter "YYYYMMDD") (-> ms
+                                               from-long
+                                               (plus time-zone-offset)))))
 
 (defn day-relative [ms]
   (when (pos? ms)


### PR DESCRIPTION
fixes #1813 

### Summary:
`On History tab dates are not sorted (at least on iOS) - have Aug, Jul and Jun dates mixed. Check with recovered account that had transactions in the past 3 months`

Transactions should be sorted now with this PR

[comment]: # (PRs will only be accepted if squashed into single commit.)
status: ready

