### PR TITLE
[proposal] Rename history -> transactions

### DIFF
--- a/src/status_im/ui/screens/subs.cljs
+++ b/src/status_im/ui/screens/subs.cljs
@@ -9,6 +9,7 @@
             status-im.ui.screens.group.subs
             status-im.ui.screens.profile.subs
             status-im.ui.screens.wallet.subs
+            status-im.ui.screens.wallet.transactions.subs
             status-im.transactions.subs
             status-im.bots.subs))
 

--- a/src/status_im/ui/screens/views.cljs
+++ b/src/status_im/ui/screens/views.cljs
@@ -44,7 +44,7 @@
 
             [status-im.ui.screens.wallet.send.views :refer [send-transaction]]
             [status-im.ui.screens.wallet.wallet-list.views :refer [wallet-list-screen]]
-            [status-im.ui.screens.wallet.history.views :as wallet-history]))
+            [status-im.ui.screens.wallet.transactions.views :as wallet-transactions]))
 
 (defn validate-current-view
   [current-view signed-up?]
@@ -103,8 +103,8 @@
                                   :transaction-details transaction-details
                                   :confirmation-success confirmation-success
                                   :contact-list-modal contact-list-modal
-                                  :wallet-transactions wallet-history/transactions
-                                  :wallet-transactions-filter wallet-history/filter-history
-                                  :wallet-transactions-sign-all wallet-history/sign-all
+                                  :wallet-transactions wallet-transactions/transactions
+                                  :wallet-transactions-filter wallet-transactions/filter-history
+                                  :wallet-transactions-sign-all wallet-transactions/sign-all
                                   (throw (str "Unknown modal view: " modal-view)))]
                   [component])]])]])))))

--- a/src/status_im/ui/screens/wallet/subs.cljs
+++ b/src/status_im/ui/screens/wallet/subs.cljs
@@ -1,8 +1,6 @@
 (ns status-im.ui.screens.wallet.subs
   (:require [re-frame.core :refer [reg-sub subscribe]]
-            [clojure.string :as string]
-            [status-im.utils.money :as money]
-            [status-im.utils.datetime :as datetime]))
+            [status-im.utils.money :as money]))
 
 (reg-sub :balance
   (fn [db]
@@ -20,10 +18,6 @@
   (fn [db]
     (or (get-in db [:wallet :errors :balance-update])
         (get-in db [:wallet :errors :prices-update]))))
-
-(reg-sub :wallet.transactions/error-message?
-  (fn [db]
-    (get-in db [:wallet :errors :transactions-update])))
 
 (reg-sub :eth-balance
   :<- [:balance]
@@ -59,55 +53,3 @@
 (reg-sub :wallet/balance-loading?
   (fn [db]
     (get-in db [:wallet :balance-loading?])))
-
-(reg-sub :wallet.transactions/transactions-loading?
-  (fn [db]
-    (get-in db [:wallet :transactions-loading?])))
-
-(reg-sub :wallet.transactions/transactions
-  (fn [db]
-    (group-by :type (get-in db [:wallet :transactions]))))
-
-(reg-sub :wallet.transactions/unsigned-transactions
-  :<- [:wallet.transactions/transactions]
-  (fn [transactions]
-    (:unsigned transactions)))
-
-(reg-sub :wallet.transactions/postponed-transactions-list
-  :<- [:wallet.transactions/transactions]
-  (fn [{:keys [postponed]}]
-    (when postponed
-      {:title "Postponed"
-       :key :postponed
-       :data postponed})))
-
-(reg-sub :wallet.transactions/pending-transactions-list
-  :<- [:wallet.transactions/transactions]
-  (fn [{:keys [pending]}]
-    (when pending
-      {:title "Pending"
-       :key :pending
-       :data pending})))
-
-(reg-sub :wallet.transactions/completed-transactions-list
-  :<- [:wallet.transactions/transactions]
-  (fn [{:keys [inbound outbound]}]
-    (->> (into inbound outbound)
-         (group-by #(datetime/timestamp->date-key (:timestamp %)))
-         (sort-by key)
-         reverse
-         (map (fn [[k v]]
-                {:title (datetime/timestamp->mini-date (:timestamp (first v)))
-                 :key   k
-                 ;; TODO (yenda investigate wether this sort-by is necessary or not)
-                 :data  (sort-by :timestamp v)})))))
-
-(reg-sub :wallet.transactions/transactions-history-list
-  :<- [:wallet.transactions/postponed-transactions-list]
-  :<- [:wallet.transactions/pending-transactions-list]
-  :<- [:wallet.transactions/completed-transactions-list]
-  (fn [[postponed pending completed]]
-    (cond-> []
-      postponed (into postponed)
-      pending   (into pending)
-      completed (into completed))))

--- a/src/status_im/ui/screens/wallet/transactions/styles.cljs
+++ b/src/status_im/ui/screens/wallet/transactions/styles.cljs
@@ -1,4 +1,4 @@
-(ns status-im.ui.screens.wallet.history.styles
+(ns status-im.ui.screens.wallet.transactions.styles
   (:require [status-im.components.styles :as styles]))
 
 (def error-container

--- a/src/status_im/ui/screens/wallet/transactions/subs.cljs
+++ b/src/status_im/ui/screens/wallet/transactions/subs.cljs
@@ -1,0 +1,59 @@
+(ns status-im.ui.screens.wallet.transactions.subs
+  (:require [re-frame.core :refer [reg-sub subscribe]]
+            [status-im.utils.datetime :as datetime]))
+
+(reg-sub :wallet.transactions/transactions-loading?
+  (fn [db]
+    (get-in db [:wallet :transactions-loading?])))
+
+(reg-sub :wallet.transactions/error-message?
+  (fn [db]
+    (get-in db [:wallet :errors :transactions-update])))
+
+(reg-sub :wallet.transactions/transactions
+  (fn [db]
+    (group-by :type (get-in db [:wallet :transactions]))))
+
+(reg-sub :wallet.transactions/unsigned-transactions
+  :<- [:wallet.transactions/transactions]
+  (fn [transactions]
+    (:unsigned transactions)))
+
+(reg-sub :wallet.transactions/postponed-transactions-list
+  :<- [:wallet.transactions/transactions]
+  (fn [{:keys [postponed]}]
+    (when postponed
+      {:title "Postponed"
+       :key :postponed
+       :data postponed})))
+
+(reg-sub :wallet.transactions/pending-transactions-list
+  :<- [:wallet.transactions/transactions]
+  (fn [{:keys [pending]}]
+    (when pending
+      {:title "Pending"
+       :key :pending
+       :data pending})))
+
+(reg-sub :wallet.transactions/completed-transactions-list
+  :<- [:wallet.transactions/transactions]
+  (fn [{:keys [inbound outbound]}]
+    (->> (into inbound outbound)
+         (group-by #(datetime/timestamp->date-key (:timestamp %)))
+         (sort-by key)
+         reverse
+         (map (fn [[k v]]
+                {:title (datetime/timestamp->mini-date (:timestamp (first v)))
+                 :key   k
+                 ;; TODO (yenda investigate wether this sort-by is necessary or not)
+                 :data  (sort-by :timestamp v)})))))
+
+(reg-sub :wallet.transactions/transactions-history-list
+  :<- [:wallet.transactions/postponed-transactions-list]
+  :<- [:wallet.transactions/pending-transactions-list]
+  :<- [:wallet.transactions/completed-transactions-list]
+  (fn [[postponed pending completed]]
+    (cond-> []
+      postponed (into postponed)
+      pending   (into pending)
+      completed (into completed))))

--- a/src/status_im/ui/screens/wallet/transactions/views.cljs
+++ b/src/status_im/ui/screens/wallet/transactions/views.cljs
@@ -1,4 +1,4 @@
-(ns status-im.ui.screens.wallet.history.views
+(ns status-im.ui.screens.wallet.transactions.views
   (:require [re-frame.core :as re-frame]
             [reagent.core :as reagent]
             [status-im.components.button.view :as button]
@@ -10,7 +10,7 @@
             [status-im.components.tabs.views :as tabs]
             [status-im.components.toolbar-new.view :as toolbar]
             [status-im.i18n :as i18n]
-            [status-im.ui.screens.wallet.history.styles :as history.styles]
+            [status-im.ui.screens.wallet.transactions.styles :as transactions.styles]
             [status-im.ui.screens.wallet.views :as wallet.views]
             [status-im.utils.utils :as utils])
   (:require-macros [status-im.utils.views :refer [defview letsubs]]))
@@ -46,13 +46,16 @@
       [history-action]])])
 
 (defn action-buttons [m]
-  [react/view {:style history.styles/action-buttons}
+  [react/view {:style transactions.styles/action-buttons}
    [button/primary-button {:text (i18n/label :t/transactions-sign) :on-press #(on-sign-transaction m)}]
    [button/secondary-button {:text (i18n/label :t/delete) :on-press #(on-delete-transaction m)}]])
 
 (defn- unsigned? [type] (= "unsigned" type))
 
-(defn- transaction-icon [k background-color color] {:icon k :icon-opts {:color color} :style (history.styles/transaction-icon-background background-color)})
+(defn- transaction-icon [k background-color color]
+  {:icon      k
+   :icon-opts {:color color}
+   :style     (transactions.styles/transaction-icon-background background-color)})
 
 (defn- transaction-type->icon [s]
   (case s
@@ -72,17 +75,18 @@
       (str (i18n/label :t/from) " " from))
     (when (unsigned? type)
       [action-buttons m])]
-   [list/item-icon {:icon :icons/forward :icon-opts history.styles/forward}]])
+   [list/item-icon {:icon :icons/forward :icon-opts transactions.styles/forward}]])
 
 ;; TODO(yenda) hook with re-frame
-(defn- empty-text [s] [react/text {:style history.styles/empty-text} s])
+(defn- empty-text [s] [react/text {:style transactions.styles/empty-text} s])
 
 (defview history-list []
   (letsubs [transactions-history-list [:wallet.transactions/transactions-history-list]
             transactions-loading?     [:wallet.transactions/transactions-loading?]
             error-message             [:wallet.transactions/error-message?]]
     [react/scroll-view {:style styles/flex}
-     (when error-message [wallet.views/error-message-view history.styles/error-container history.styles/error-message])
+     (when error-message
+       [wallet.views/error-message-view transactions.styles/error-container transactions.styles/error-message])
      [list/section-list {:sections        transactions-history-list
                          :render-fn       render-transaction
                          :empty-component (empty-text (i18n/label :t/transactions-history-empty))
@@ -113,16 +117,16 @@
 
 (defview sign-all []
   []
-  [react/keyboard-avoiding-view {:style history.styles/sign-all-view}
-   [react/view {:style history.styles/sign-all-done}
-    [button/primary-button {:style    history.styles/sign-all-done-button
+  [react/keyboard-avoiding-view {:style transactions.styles/sign-all-view}
+   [react/view {:style transactions.styles/sign-all-done}
+    [button/primary-button {:style    transactions.styles/sign-all-done-button
                             :text     (i18n/label :t/done)
                             :on-press #(re-frame/dispatch [:navigate-back])}]]
-   [react/view {:style history.styles/sign-all-popup}
-    [react/text {:style history.styles/sign-all-popup-sign-phrase} "one two three"] ;; TODO hook
-    [react/text {:style history.styles/sign-all-popup-text} (i18n/label :t/transactions-sign-all-text)]
-    [react/view {:style history.styles/sign-all-actions}
-     [react/text-input {:style             history.styles/sign-all-input
+   [react/view {:style transactions.styles/sign-all-popup}
+    [react/text {:style transactions.styles/sign-all-popup-sign-phrase} "one two three"] ;; TODO hook
+    [react/text {:style transactions.styles/sign-all-popup-text} (i18n/label :t/transactions-sign-all-text)]
+    [react/view {:style transactions.styles/sign-all-actions}
+     [react/text-input {:style             transactions.styles/sign-all-input
                         :secure-text-entry true
                         :placeholder       (i18n/label :t/transactions-sign-input-placeholder)}]
      [button/primary-button {:text (i18n/label :t/transactions-sign-all) :on-press #(on-sign-transaction %)}]]]])
@@ -170,12 +174,12 @@
 
 (defn- main-section [view-id tabs]
   (let [prev-view-id (reagent/atom @view-id)]
-    [tabs/swipable-tabs {:style            history.styles/main-section
-                         :style-tabs       history.styles/tabs
-                         :style-tab-active history.styles/tab-active
+    [tabs/swipable-tabs {:style            transactions.styles/main-section
+                         :style-tabs       transactions.styles/tabs
+                         :style-tab-active transactions.styles/tab-active
                          :on-view-change   #(do (reset! prev-view-id @view-id)
                                                 (reset! view-id %))}
-      tabs prev-view-id view-id]))
+     tabs prev-view-id view-id]))
 
 ;; TODO(yenda) must reflect selected wallet
 


### PR DESCRIPTION
I found the current naming of the wallet.history namespace a bit weird because it is not just the history but also the unsigned transactions. I propose to rename it wallet.transactions to clarify things.
 
I propose to move the wallet.transactions related subscriptions in a dedicated namespace to unclog the main wallet subs a bit.

[comment]: # (PRs will only be accepted if squashed into single commit.)
status: ready

