### PR TITLE
Tooling: Jenkins configuration for nightly build in source control

### DIFF
--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -1,0 +1,78 @@
+// We need nightly builds for users who want to test apps, diawi removes old builds and limits downloads, hence the need for Artifactory.
+// To see env: echo sh(returnStdout: true, script: 'env')
+
+env.LANG="en_US.UTF-8"
+env.LANGUAGE="en_US.UTF-8"
+env.LC_ALL="en_US.UTF-8"
+node {
+  def apkUrl = ''
+  def ipaUrl = ''
+  def testPassed = true
+
+  sh 'source /etc/profile'
+
+  try {
+
+    stage('Git & Dependencies') {
+      git([url: 'https://github.com/status-im/status-react.git', branch: 'develop'])
+      // Checkout master because used for iOS Plist version information
+      sh 'git checkout -- .'
+      sh 'git fetch --tags'
+      sh 'git checkout master' 
+      sh 'git checkout ' + 'develop'
+      sh 'rm -rf node_modules'
+      sh 'cp .env.jenkins .env'
+      sh 'lein deps && npm install && ./re-natal deps'
+      sh 'sed -i "" "s/301000/1201000/g" node_modules/react-native/packager/src/JSTransformer/index.js'
+      sh 'mvn -f modules/react-native-status/ios/RCTStatus dependency:unpack'
+      sh 'cd ios && pod install && cd ..'
+    }
+
+    stage('Tests') {
+      sh 'lein test-cljs'
+    }
+
+    stage('Build') {
+      sh 'lein prod-build'
+    }
+
+    stage('Build (Android)') {
+      sh 'cd android && ./gradlew assembleRelease'
+    }
+
+    stage('Build (iOS)') {
+      sh 'export RCT_NO_LAUNCH_PACKAGER=true && xcodebuild -workspace ios/StatusIm.xcworkspace -scheme StatusIm -configuration release -archivePath status clean archive'
+      sh 'xcodebuild -exportArchive -exportPath status -archivePath status.xcarchive -exportOptionsPlist /Users/Xcloud/archive.plist'
+    }
+
+    stage('Deploy (Android)') {
+      def artifact_dir = pwd() + '/android/app/build/outputs/apk/'
+      def artifact = new File(artifact_dir + 'app-release.apk')
+      assert artifact.exists()
+      def server = Artifactory.server('artifacts')
+      def shortCommit = sh(returnStdout: true, script: 'git rev-parse HEAD').trim().take(6)
+      def filename = 'im.status.ethereum-' + shortCommit + '.apk'
+      artifact.renameTo artifact_dir + filename
+      def uploadSpec = '{ "files": [ { "pattern": "*apk/' + filename + '", "target": "nightlies-local" }]}'
+      def buildInfo = server.upload(uploadSpec)
+      slackSend color: 'good', message: 'develop' + ' (Android) http://artifacts.status.im:8081/artifactory/nightlies-local/' + filename
+    }
+
+    stage('Deploy (iOS)') {
+      withCredentials([string(credentialsId: 'diawi-token', variable: 'token')]) {
+        def job = sh(returnStdout: true, script: 'curl https://upload.diawi.com/ -F token='+token+' -F file=@status/StatusIm.ipa -F find_by_udid=0 -F wall_of_apps=0 | jq -r ".job"').trim()
+        sh 'sleep 10'
+        def hash = sh(returnStdout: true, script: "curl -vvv 'https://upload.diawi.com/status?token="+token+"&job="+job+"'|jq -r '.hash'").trim()  
+        slackSend color: 'good', message: 'develop' + ' (iOS) https://i.diawi.com/' + hash
+      }
+    }
+  } catch (e) {
+    slackSend color: 'bad', message: 'Nightly build (develop) failed to build. ' + env.BUILD_URL
+    throw e
+  }
+
+  stage('Slack Notification') {
+    def c = (testPassed ? 'good' : 'warning' )
+    slackSend color: c, message: 'Nightly build (develop) \nTests: ' + (testPassed ? ':+1:' : ':-1:') + ')\nAndroid: ' + apkUrl + '\n iOS: ' + ipaUrl
+  }
+}


### PR DESCRIPTION
### Summary:
Previously this was inline at Jenkins which lead to configuration drift. This commit introduces Slack notifications for failed builds.

Addresses https://github.com/status-im/status-react/issues/1822

### Steps to test:
- Open Status
- ...
- Step 3, etc.

status: ready

### Env for status-nightly

Notice the lack of `BRANCH_NAME` compared with Jenkinsfile, because we are using Jenkins "pipelines", hence the need for hardcoded branch name:

```
[Pipeline] echo
BUILD_URL=http://185.90.37.243:8080/job/status-react-nightly/297/
ANDROID_HOME=/usr/local/opt/android-sdk
SHELL=/bin/bash
HUDSON_SERVER_COOKIE=XXXXXXXXXXXXXX
TMPDIR=/var/folders/3b/szyhrsjx64qg_72m240zzycm0000gn/T/
GRADLE_HOME=/usr/local/opt/gradle
BUILD_TAG=jenkins-status-react-nightly-297
Apple_PubSub_Socket_Render=/private/tmp/com.apple.launchd.An6ixXc1ww/Render
JOB_URL=http://185.90.37.243:8080/job/status-react-nightly/
ANT_HOME=/usr/local/opt/ant
WORKSPACE=/Users/Xcloud/.jenkins/workspace/status-react-nightly
LC_ALL=en_US.UTF-8
RUN_CHANGES_DISPLAY_URL=http://185.90.37.243:8080/job/status-react-nightly/297/display/redirect?page=changes
USER=Xcloud
com.apple.java.jvmTask=CommandLine
SSH_AUTH_SOCK=/private/tmp/com.apple.launchd.A7QKpgp2dq/Listeners
__CF_USER_TEXT_ENCODING=0x1F5:0x0:0x0
JENKINS_HOME=/Users/Xcloud/.jenkins
PATH=/usr/local/bin:/usr/local/opt/android-sdk/build-tools/$(ls /usr/local/opt/android-sdk/build-tools | sort | tail -1):/usr/local/opt/android-sdk/platform-tools:/usr/local/opt/android-sdk/tools:/usr/local/opt/gradle/bin:/usr/local/opt/maven/bin:/usr/local/opt/ant/bin:/usr/bin:/bin:/usr/sbin:/sbin
MAVEN_HOME=/usr/local/opt/maven
RUN_DISPLAY_URL=http://185.90.37.243:8080/job/status-react-nightly/297/display/redirect
_=/usr/bin/env
JAVA_MAIN_CLASS_677=Main
PWD=/Users/Xcloud/.jenkins/workspace/status-react-nightly
HUDSON_URL=http://185.90.37.243:8080/
LANG=en_US.UTF-8
JOB_NAME=status-react-nightly
XPC_FLAGS=0x0
BUILD_DISPLAY_NAME=#297
BUILD_ID=297
JENKINS_URL=http://185.90.37.243:8080/
XPC_SERVICE_NAME=0
JOB_BASE_NAME=status-react-nightly
HOME=/Users/Xcloud
SHLVL=2
LANGUAGE=en_US.UTF-8
EXECUTOR_NUMBER=1
JENKINS_SERVER_COOKIE=durable-XXXXXXXXXXXXXXXXX
NODE_LABELS=master osx
LOGNAME=Xcloud
HUDSON_HOME=/Users/Xcloud/.jenkins
NODE_NAME=master
BUILD_NUMBER=297
JOB_DISPLAY_URL=http://185.90.37.243:8080/job/status-react-nightly/display/redirect
ANDROID_NDK_HOME=/usr/local/opt/android-ndk
HUDSON_COOKIE=XXXXXXXXXXXXXXX
```
