### PR TITLE
Remove cljs-priority-map

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,12 +3,11 @@
   :license {:name "Eclipse Public License"
             :url  "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.9.0-alpha17"]
-                 [org.clojure/clojurescript "1.9.671"] ;; Can't update to more recent releases waiting for https://github.com/tailrecursion/cljs-priority-map/issues/10
+                 [org.clojure/clojurescript "1.9.671"] ;; TODO: Update, cljs-priority-map blocker issue is gone.
                  [org.clojure/core.async "0.3.443"]
                  [reagent "0.6.0" :exclusions [cljsjs/react cljsjs/react-dom cljsjs/react-dom-server]]
                  [re-frame "0.10.1"]
                  [com.andrewmcveigh/cljs-time "0.5.0"]
-                 [tailrecursion/cljs-priority-map "1.2.0"]
                  [com.taoensso/timbre "4.10.0"]
                  [hickory "0.7.1"]]
   :plugins [[lein-cljsbuild "1.1.7"]

--- a/src/status_im/chat/handlers.cljs
+++ b/src/status_im/chat/handlers.cljs
@@ -39,8 +39,7 @@
             [cljs.core.async :as a]
             status-im.chat.handlers.webview-bridge
             status-im.chat.handlers.console
-            [taoensso.timbre :as log]
-            [tailrecursion.priority-map :refer [priority-map-by]]))
+            [taoensso.timbre :as log]))
 
 (register-handler :set-layout-height
   (fn [db [_ height]]
@@ -208,10 +207,6 @@
     init-chat
     load-commands!))
 
-(defn compare-chats
-  [{timesatmp1 :timestamp} {timestamp2 :timestamp}]
-  (compare timestamp2 timesatmp1))
-
 (defn initialize-chats
   [{:keys [loaded-chats chats] :accounts/keys [account-creation?] :as db} _]
   (let [chats' (if account-creation?
@@ -220,7 +215,7 @@
                       (map (fn [{:keys [chat-id] :as chat}]
                              (let [last-message (messages/get-last-message chat-id)]
                                [chat-id (assoc chat :last-message last-message)])))
-                      (into (priority-map-by compare-chats))))]
+                      (into {})))]
 
     (-> db
         (assoc :chats chats')
@@ -248,7 +243,7 @@
                                    prev-chat    (get chats chat-id)
                                    new-chat     (assoc chat :last-message last-message)]
                                [chat-id (merge prev-chat new-chat)])))
-                      (into (priority-map-by compare-chats)))]
+                      (into {}))]
       (-> (assoc db :chats chats')
           (init-console-chat true)))))
 

--- a/src/status_im/ui/screens/chats_list/subs.cljs
+++ b/src/status_im/ui/screens/chats_list/subs.cljs
@@ -12,6 +12,8 @@
   :<- [:get :chats]
   :<- [:get-in [:toolbar-search :text]]
   (fn [[chats search-text]]
-    (if search-text
-      (filter #(search-filter search-text (second %)) chats)
-      chats)))
+    (let [unordered-chats (if search-text
+                            (filter #(search-filter search-text (second %))
+                                    chats)
+                            chats)]
+      (sort-by #(-> % second :timestamp) > unordered-chats))))


### PR DESCRIPTION
cljs-priority-map provides a special purpose data structure that needlessly
complicated things and doesn't appear to provide much value for what it gives
us.

Instead, keep :chats an ordinary map and sort vector on final subscription, as
our ListView destructures data-source items correctly.

This means we can upgrade Clojurescript.

Addresses https://github.com/status-im/status-react/issues/1818

### Steps to test:
Open a few chats, make sure chats appear ordered by time and there's no crazy difference in render speed.

status: ready