### PR TITLE
[Epic/wallet] transaction details

### DIFF
--- a/src/status_im/translations/en.cljs
+++ b/src/status_im/translations/en.cljs
@@ -2,7 +2,7 @@
 
 (def translations
   {
-   ;common
+   ;;common
    :members-title                         "Members"
    :not-implemented                       "!not implemented"
    :chat-name                             "Chat name"
@@ -20,7 +20,7 @@
    :camera-access-error                   "To grant the required camera permission, please, go to your system settings and make sure that Status > Camera is selected."
    :photos-access-error                   "To grant the required photos permission, please, go to your system settings and make sure that Status > Photos is selected."
 
-   ;drawer
+   ;;drawer
    :invite-friends                        "Invite friends"
    :faq                                   "FAQ"
    :switch-users                          "Switch users"
@@ -28,7 +28,7 @@
    :view-all                              "View all"
    :current-network                       "Current network"
 
-   ;chat
+   ;;chat
    :is-typing                             "is typing"
    :and-you                               "and you"
    :search-chat                           "Search chat"
@@ -48,11 +48,11 @@
    :faucet-success                        "Faucet request has been received"
    :faucet-error                          "Faucet request error"
 
-   ;sync
+   ;;sync
    :sync-in-progress                      "Syncing..."
    :sync-synced                           "In sync"
 
-   ;messages
+   ;;messages
    :status-sending                        "Sending"
    :status-pending                        "Pending"
    :status-sent                           "Sent"
@@ -61,7 +61,7 @@
    :status-delivered                      "Delivered"
    :status-failed                         "Failed"
 
-   ;datetime
+   ;;datetime
    :datetime-ago-format                   "{{number}} {{time-intervals}} {{ago}}"
    :datetime-second                       {:one   "second"
                                            :other "seconds"}
@@ -76,7 +76,7 @@
    :datetime-yesterday                    "yesterday"
    :datetime-today                        "today"
 
-   ;profile
+   ;;profile
    :profile                               "Profile"
    :edit-profile                          "Edit profile"
    :report-user                           "REPORT USER"
@@ -116,7 +116,7 @@
    :browsing-open-in-web-browser          "Open in web browser"
    :browsing-cancel                       "Cancel"
 
-   ;sign-up
+   ;;sign-up
    :contacts-syncronized                  "Your contacts have been synchronized"
    :confirmation-code                     (str "Thanks! We've sent you a text message with a confirmation "
                                                "code. Please provide that code to confirm your phone number")
@@ -135,13 +135,13 @@
    :move-to-internal-failure-message      "We need to move some important files from external to internal storage. To do this, we need your permission. We won't be using external storage in future versions."
    :debug-enabled                         "Debug server has been launched! You can now execute *status-dev-cli scan* to find the server from your computer on the same network."
 
-   ;phone types
+   ;;phone types
    :phone-e164                            "International 1"
    :phone-international                   "International 2"
    :phone-national                        "National"
    :phone-significant                     "Significant"
 
-   ;chats
+   ;;chats
    :chats                                 "Chats"
    :new-chat                              "New chat"
    :delete-chat                           "Delete chat"
@@ -153,7 +153,7 @@
    :topic-format                          "Wrong format [a-z0-9\\-]+"
    :public-group-topic                    "Topic"
 
-   ;discover
+   ;;discover
    :discover                              "Discover"
    :none                                  "None"
    :search-tags                           "Type your search tags here"
@@ -162,10 +162,10 @@
    :no-statuses-discovered                "No statuses discovered"
    :no-statuses-found                     "No statuses found"
 
-   ;settings
+   ;;settings
    :settings                              "Settings"
 
-   ;contacts
+   ;;contacts
    :contacts                              "Contacts"
    :new-contact                           "New contact"
    :delete-contact                        "Delete contact"
@@ -183,7 +183,7 @@
    :enter-address                         "Enter address"
    :more                                  "more"
 
-   ;group-settings
+   ;;group-settings
    :remove                                "Remove"
    :save                                  "Save"
    :delete                                "Delete"
@@ -200,7 +200,7 @@
    :green                                 "Green"
    :red                                   "Red"
 
-   ;commands
+   ;;commands
    :money-command-description             "Send money"
    :location-command-description          "Send location"
    :phone-command-description             "Send phone number"
@@ -216,7 +216,7 @@
    :chat-send-eth-to                      "{{amount}} ETH to {{chat-name}}"
    :chat-send-eth-from                    "{{amount}} ETH from {{chat-name}}"
 
-   ;location command
+   ;;location command
    :your-current-location                 "Your current location"
    :places-nearby                         "Places nearby"
    :search-results                        "Search results"
@@ -226,7 +226,7 @@
    :sharing-copy-to-clipboard-address     "Copy the Address"
    :sharing-copy-to-clipboard-coordinates "Copy coordinates"
 
-   ;new-group
+   ;;new-group
    :group-chat-name                       "Chat name"
    :empty-group-chat-name                 "Please enter a name"
    :illegal-group-chat-name               "Please select another name"
@@ -241,11 +241,11 @@
    :contact-s                             {:one   "contact"
                                            :other "contacts"}
 
-   ;participants
+   ;;participants
    :add-participants                      "Add Participants"
    :remove-participants                   "Remove Participants"
 
-   ;protocol
+   ;;protocol
    :received-invitation                   "received chat invitation"
    :removed-from-chat                     "removed you from group chat"
    :left                                  "left"
@@ -253,7 +253,7 @@
    :removed                               "removed"
    :You                                   "You"
 
-   ;new-contact
+   ;;new-contact
    :add-new-contact                       "Add new contact"
    :import-qr                             "Import"
    :scan-qr                               "Scan QR"
@@ -267,7 +267,7 @@
    :can-not-add-yourself                  "You can't add yourself"
    :unknown-address                       "Unknown address"
 
-   ;login
+   ;;login
    :connect                               "Connect"
    :address                               "Address"
    :password                              "Password"
@@ -276,7 +276,7 @@
    :sign-in                               "Sign in"
    :wrong-password                        "Wrong password"
 
-   ;recover
+   ;;recover
    :recover-from-passphrase               "Recover from passphrase"
    :recover-explain                       "Please enter the passphrase for your password to recover access"
    :passphrase                            "Passphrase"
@@ -285,21 +285,21 @@
    :enter-valid-password                  "Please enter a password"
    :twelve-words-in-correct-order         "12 words in correct order"
 
-   ;accounts
+   ;;accounts
    :recover-access                        "Recover access"
    :add-account                           "Add account"
    :create-new-account                    "Create new account"
 
-   ;wallet-qr-code
+   ;;wallet-qr-code
    :done                                  "Done"
 
-   ;validation
+   ;;validation
    :invalid-phone                         "Invalid phone number"
    :amount                                "Amount"
    :not-enough-eth                        (str "Not enough ETH on balance "
                                                "({{balance}} ETH)")
 
-   ;transactions
+   ;;transactions
    :confirm                               "Confirm"
    :confirm-transactions                  {:one   "Confirm transaction"
                                            :other "Confirm {{count}} transactions"
@@ -324,8 +324,19 @@
    :data                                  "Data"
    :got-it                                "Got it"
    :contract-creation                     "Contract Creation"
+   :block                                 "Block"
+   :hash                                  "Hash"
+   :gas-limit                             "Gas limit"
+   :gas-price                             "Gas price"
+   :gas-used                              "Gas Used"
+   :cost-fee                              "Cost/Fee"
+   :nonce                                 "Nonce"
+   :confirmations                         "confirmations"
+   :confirmations-helper-text             "If you want to be sure your transaction will not be compromise wait until it gets at least 10 blocks confirmations"
+   :copy-transaction-hash                 "Copy transaction hash"
+   :open-on-etherscan                     "Open on Etherscan"
 
-   ;:webview
+   ;;webview
    :web-view-error                        "oops, error"
 
    ;;testfairy warning
@@ -350,6 +361,7 @@
    :share                                 "Share"
    :currency                              "Currency"
    :transactions                          "Transactions"
+   :transaction-details                   "Transaction details"
    :transactions-sign                     "Sign"
    :transactions-sign-all                 "Sign all"
    :transactions-sign-all-text            "Sign the transaction by entering your password.\nMake sure that the words above match your secret signing phrase"

--- a/src/status_im/ui/screens/subs.cljs
+++ b/src/status_im/ui/screens/subs.cljs
@@ -42,3 +42,7 @@
     (or search-mode?
         (and (= view-id :chat-list) chats-edit-mode?)
         (and (= view-id :contact-list) contacts-edit-mode?))))
+
+(reg-sub :network
+  (fn [db]
+    (:network db)))

--- a/src/status_im/ui/screens/views.cljs
+++ b/src/status_im/ui/screens/views.cljs
@@ -66,6 +66,8 @@
                           :wallet-list wallet-list-screen
                           :wallet-send-transaction send-transaction
                           :wallet-request-transaction request-transaction
+                          :wallet-transactions wallet-transactions/transactions
+                          :wallet-transaction-details wallet-transactions/transaction-details
                           :discover-search-results discover-search-results
                           :new-chat new-chat
                           :new-group new-group
@@ -106,7 +108,6 @@
                                   :transaction-details transaction-details
                                   :confirmation-success confirmation-success
                                   :contact-list-modal contact-list-modal
-                                  :wallet-transactions wallet-transactions/transactions
                                   :wallet-transactions-filter wallet-transactions/filter-history
                                   :wallet-transactions-sign-all wallet-transactions/sign-all
                                   (throw (str "Unknown modal view: " modal-view)))]

--- a/src/status_im/ui/screens/wallet/events.cljs
+++ b/src/status_im/ui/screens/wallet/events.cljs
@@ -130,3 +130,9 @@
     (-> db
         (assoc-error-message :prices-update err)
         (assoc :prices-loading? false))))
+
+(handlers/register-handler-fx
+  :show-transaction-details
+  (fn [{:keys [db]} [_ hash]]
+    {:db (assoc-in db [:wallet :current-transaction] hash)
+     :dispatch [:navigate-to :wallet-transaction-details]}))

--- a/src/status_im/ui/screens/wallet/main/views.cljs
+++ b/src/status_im/ui/screens/wallet/main/views.cljs
@@ -33,7 +33,7 @@
 (def transaction-history-action
   {:icon      :icons/transaction-history
    :icon-opts (merge {:color :white :style {:viewBox "-108 65.9 24 24"}} wallet.styles/toolbar-icon)
-   :handler   #(rf/dispatch [:navigate-to-modal :wallet-transactions])})
+   :handler   #(rf/dispatch [:navigate-to :wallet-transactions])})
 
 (defn toolbar-view []
   [toolbar/toolbar2 {:style wallet.styles/toolbar}

--- a/src/status_im/ui/screens/wallet/subs.cljs
+++ b/src/status_im/ui/screens/wallet/subs.cljs
@@ -2,9 +2,14 @@
   (:require [re-frame.core :refer [reg-sub subscribe]]
             [status-im.utils.money :as money]))
 
-(reg-sub :balance
+(reg-sub :wallet
   (fn [db]
-    (get-in db [:wallet :balance])))
+    (:wallet db)))
+
+(reg-sub :balance
+  :<- [:wallet]
+  (fn [wallet]
+    (:balance wallet)))
 
 (reg-sub :price
   (fn [db]
@@ -15,9 +20,10 @@
     (get-in db [:prices :last-day])))
 
 (reg-sub :wallet/error-message?
-  (fn [db]
-    (or (get-in db [:wallet :errors :balance-update])
-        (get-in db [:wallet :errors :prices-update]))))
+  :<- [:wallet]
+  (fn [wallet]
+    (or (get-in wallet [:errors :balance-update])
+        (get-in wallet [:errors :prices-update]))))
 
 (reg-sub :eth-balance
   :<- [:balance]
@@ -51,5 +57,6 @@
     (:prices-loading? db)))
 
 (reg-sub :wallet/balance-loading?
-  (fn [db]
-    (get-in db [:wallet :balance-loading?])))
+  :<- [:wallet]
+  (fn [wallet]
+    (:balance-loading? wallet)))

--- a/src/status_im/ui/screens/wallet/transactions/styles.cljs
+++ b/src/status_im/ui/screens/wallet/transactions/styles.cljs
@@ -15,7 +15,9 @@
    :padding-right 10
    :font-size     13})
 
-(def main-section styles/flex)
+(def main-section
+  {:flex             1
+   :background-color styles/color-white})
 
 (def tabs
   {:border-bottom-width 1
@@ -29,7 +31,7 @@
   {:color styles/color-gray7})
 
 (def empty-text
-  {:text-align       :center
+  {:text-align        :center
    :margin-top        22
    :margin-horizontal 92})
 
@@ -88,3 +90,80 @@
    :height           40
    :border-radius    32
    :background-color color})
+
+;; transaction details
+
+(def transaction-details-row
+  {:flex-direction  :row
+   :margin-vertical 5})
+
+(def transaction-details-item-label
+  {:flex         1
+   :margin-right 10
+   :color        styles/color-gray4
+   :font-size    14})
+
+(def transaction-details-item-value-wrapper
+  {:flex 5})
+
+(def transaction-details-item-value
+  {:font-size 14
+   :color     styles/color-black})
+
+(def transaction-details-item-extra-value
+  {:font-size 14
+   :color     styles/color-gray4})
+
+(def transaction-details-header
+  {:margin-horizontal 16
+   :margin-top        10
+   :flex-direction    :row})
+
+(def transaction-details-header-icon
+  {:margin-vertical 7})
+
+(def transaction-details-header-infos
+  {:flex            1
+   :flex-direction  :column
+   :margin-left     12
+   :margin-vertical 7})
+
+(def transaction-details-header-value
+  {:font-size 16
+   :color     styles/color-black})
+
+(def transaction-details-header-date
+  {:font-size 14
+   :color     styles/color-gray4})
+
+(def transaction-details-block
+  {:margin-horizontal 16})
+
+(def progress-bar
+  {:flex-direction  :row
+   :margin-vertical 10
+   :height          2})
+
+(defn progress-bar-done [done]
+  {:flex             done
+   :background-color styles/color-blue2})
+
+(defn progress-bar-todo [todo]
+  {:flex             todo
+   :background-color styles/color-blue2
+   :opacity          0.30})
+
+(def transaction-details-confirmations-count
+  {:color           styles/color-black
+   :font-size       15
+   :margin-vertical 2})
+
+(def transaction-details-confirmations-helper-text
+  {:color           styles/color-gray4
+   :font-size       14
+   :margin-vertical 2})
+
+(def transaction-details-separator
+  {:background-color styles/color-light-gray3
+   :height           1
+   :margin-vertical  10})

--- a/src/status_im/ui/screens/wallet/transactions/subs.cljs
+++ b/src/status_im/ui/screens/wallet/transactions/subs.cljs
@@ -24,11 +24,6 @@
   (fn [transactions]
     (group-by :type (vals transactions))))
 
-(reg-sub :wallet.transactions/unsigned-transactions
-  :<- [:wallet.transactions/grouped-transactions]
-  (fn [transactions]
-    (:unsigned transactions)))
-
 (reg-sub :wallet.transactions/postponed-transactions-list
   :<- [:wallet.transactions/grouped-transactions]
   (fn [{:keys [postponed]}]

--- a/src/status_im/ui/screens/wallet/transactions/subs.cljs
+++ b/src/status_im/ui/screens/wallet/transactions/subs.cljs
@@ -1,26 +1,36 @@
 (ns status-im.ui.screens.wallet.transactions.subs
   (:require [re-frame.core :refer [reg-sub subscribe]]
-            [status-im.utils.datetime :as datetime]))
+            [status-im.utils.datetime :as datetime]
+            [status-im.utils.money :as money]
+            [status-im.utils.transactions :as transactions]))
 
 (reg-sub :wallet.transactions/transactions-loading?
-  (fn [db]
-    (get-in db [:wallet :transactions-loading?])))
+  :<- [:wallet]
+  (fn [wallet]
+    (:transactions-loading? wallet)))
 
 (reg-sub :wallet.transactions/error-message?
-  (fn [db]
-    (get-in db [:wallet :errors :transactions-update])))
+  :<- [:wallet]
+  (fn [wallet]
+    (get-in wallet [:errors :transactions-update])))
 
 (reg-sub :wallet.transactions/transactions
-  (fn [db]
-    (group-by :type (get-in db [:wallet :transactions]))))
+  :<- [:wallet]
+  (fn [wallet]
+    (:transactions wallet)))
+
+(reg-sub :wallet.transactions/grouped-transactions
+  :<- [:wallet.transactions/transactions]
+  (fn [transactions]
+    (group-by :type (vals transactions))))
 
 (reg-sub :wallet.transactions/unsigned-transactions
-  :<- [:wallet.transactions/transactions]
+  :<- [:wallet.transactions/grouped-transactions]
   (fn [transactions]
     (:unsigned transactions)))
 
 (reg-sub :wallet.transactions/postponed-transactions-list
-  :<- [:wallet.transactions/transactions]
+  :<- [:wallet.transactions/grouped-transactions]
   (fn [{:keys [postponed]}]
     (when postponed
       {:title "Postponed"
@@ -28,7 +38,7 @@
        :data postponed})))
 
 (reg-sub :wallet.transactions/pending-transactions-list
-  :<- [:wallet.transactions/transactions]
+  :<- [:wallet.transactions/grouped-transactions]
   (fn [{:keys [pending]}]
     (when pending
       {:title "Pending"
@@ -36,7 +46,7 @@
        :data pending})))
 
 (reg-sub :wallet.transactions/completed-transactions-list
-  :<- [:wallet.transactions/transactions]
+  :<- [:wallet.transactions/grouped-transactions]
   (fn [{:keys [inbound outbound]}]
     (->> (into inbound outbound)
          (group-by #(datetime/timestamp->date-key (:timestamp %)))
@@ -57,3 +67,38 @@
       postponed (into postponed)
       pending   (into pending)
       completed (into completed))))
+
+(reg-sub :wallet.transactions/current-transaction
+  :<- [:wallet]
+  (fn [wallet]
+    (:current-transaction wallet)))
+
+(reg-sub :wallet.transactions/transaction-details
+  :<- [:wallet.transactions/transactions]
+  :<- [:wallet.transactions/current-transaction]
+  :<- [:network]
+  (fn [[transactions current-transaction network]]
+    (let [{:keys [gas-used gas-price hash timestamp type] :as transaction} (get transactions current-transaction)]
+      (merge transaction
+             {:cost (money/wei->ether (money/fee-value gas-used gas-price))
+              :gas-price-eth  (str (.toFixed (money/wei->ether gas-price)) " ETH")
+              :date (datetime/timestamp->long-date timestamp)
+              :url (transactions/get-transaction-details-url network hash)}
+             ;; TODO (yenda) proper wallet logic when wallet switching is impletmented
+             (if (= type :inbound)
+               {:to-wallet "Main wallet"}
+               {:from-wallet "Main wallet"})))))
+
+(reg-sub :wallet.transactions.details/confirmations
+  :<- [:wallet.transactions/transaction-details]
+  (fn [transaction-details]
+    ;;TODO (yenda) this field should be calculated based on the current-block and the block of the transaction
+    (:confirmations transaction-details)))
+
+(reg-sub :wallet.transactions.details/confirmations-progress
+  :<- [:wallet.transactions.details/confirmations]
+  (fn [confirmations]
+    (let [max-confirmations 10]
+      (if (>= confirmations max-confirmations)
+        100
+        (* 100 (/ confirmations max-confirmations))))))

--- a/src/status_im/ui/screens/wallet/transactions/views.cljs
+++ b/src/status_im/ui/screens/wallet/transactions/views.cljs
@@ -93,7 +93,7 @@
   (letsubs [transactions-history-list [:wallet.transactions/transactions-history-list]
             transactions-loading?     [:wallet.transactions/transactions-loading?]
             error-message             [:wallet.transactions/error-message?]]
-    [react/scroll-view {:style styles/flex}
+    [react/view {:style styles/flex}
      (when error-message
        [wallet.views/error-message-view transactions.styles/error-container transactions.styles/error-message])
      [list/section-list {:sections        transactions-history-list
@@ -105,7 +105,7 @@
 (defview unsigned-list []
   []
   (let [transactions nil] ;; TODO replace by letsubs later
-    [react/scroll-view {:style styles/flex}
+    [react/view {:style styles/flex}
      [list/flat-list {:data            transactions
                       :render-fn       render-transaction
                       :empty-component (empty-text (i18n/label :t/transactions-unsigned-empty))}]]))
@@ -180,7 +180,7 @@
     [toolbar/content-title (i18n/label :t/transactions-filter-title)]
     [toolbar/text-action {:handler #(utils/show-popup "TODO" "Select All")}
      (i18n/label :t/transactions-filter-select-all)]]
-   [react/scroll-view
+   [react/view {:style styles/flex}
     [list/section-list {:sections filter-data}]]])
 
 (defn- main-section [view-id tabs]

--- a/src/status_im/ui/screens/wallet/transactions/views.cljs
+++ b/src/status_im/ui/screens/wallet/transactions/views.cljs
@@ -117,12 +117,12 @@
          (if (pos? count) (str " " count)))))
 
 (defn- tab-list []
-  [{:view-id :wallet-transactions-unsigned
-    :title   (unsigned-transactions-title)
-    :screen  [unsigned-list]}
-   {:view-id :wallet-transactions-history
+  [{:view-id :wallet-transactions-history
     :title   (i18n/label :t/transactions-history)
-    :screen  [history-list]}])
+    :screen  [history-list]}
+   {:view-id :wallet-transactions-unsigned
+    :title   (unsigned-transactions-title)
+    :screen  [unsigned-list]}])
 
 ;; Sign all
 

--- a/src/status_im/ui/screens/wallet/transactions/views.cljs
+++ b/src/status_im/ui/screens/wallet/transactions/views.cljs
@@ -29,21 +29,22 @@
   ;; TODO(yenda) implement
   (utils/show-popup "TODO" "Delete Transaction"))
 
-(defn unsigned-action [unsigned-transactions]
-  [toolbar/text-action {:disabled? (zero? (count unsigned-transactions)) :handler #(re-frame/dispatch [:navigate-to-modal :wallet-transactions-sign-all])}
+(defn unsigned-action []
+  ;; TODO subscribe to unsigned-transactions-count or pass it as parameter ?
+  [toolbar/text-action {:disabled? (zero? 0 #_(count unsigned-transactions)) :handler #(re-frame/dispatch [:navigate-to-modal :wallet-transactions-sign-all])}
    (i18n/label :t/transactions-sign-all)])
 
 (def history-action
   {:icon      :icons/filter
    :handler   #(utils/show-popup "TODO" "Not implemented") #_(re-frame/dispatch [:navigate-to-modal :wallet-transactions-sign-all])})
 
-(defn toolbar-view [view-id unsigned-transactions]
+(defn toolbar-view [view-id]
   [toolbar/toolbar2 {:flat? true}
    toolbar/default-nav-back
    [toolbar/content-title (i18n/label :t/transactions)]
    (case @view-id
      :wallet-transactions-unsigned
-     [unsigned-action unsigned-transactions]
+     [unsigned-action]
 
      :wallet-transactions-history
      [toolbar/actions
@@ -101,22 +102,24 @@
                          :on-refresh      #(re-frame/dispatch [:update-transactions])
                          :refreshing      transactions-loading?}]]))
 
-(defview unsigned-list [transactions]
+(defview unsigned-list []
   []
-  [react/scroll-view {:style styles/flex}
-   [list/flat-list {:data            transactions
-                    :render-fn       render-transaction
-                    :empty-component (empty-text (i18n/label :t/transactions-unsigned-empty))}]])
+  (let [transactions nil] ;; TODO replace by letsubs later
+    [react/scroll-view {:style styles/flex}
+     [list/flat-list {:data            transactions
+                      :render-fn       render-transaction
+                      :empty-component (empty-text (i18n/label :t/transactions-unsigned-empty))}]]))
 
-(defn- unsigned-transactions-title [transactions]
-  (let [count (count transactions)]
+(defn- unsigned-transactions-title []
+  ;; TODO subscribe to unsigned-transactions-count or pass it as parameter ?
+  (let [count 0 #_(count transactions)]
     (str (i18n/label :t/transactions-unsigned)
          (if (pos? count) (str " " count)))))
 
-(defn- tab-list [unsigned-transactions]
+(defn- tab-list []
   [{:view-id :wallet-transactions-unsigned
-    :title   (unsigned-transactions-title unsigned-transactions)
-    :screen  [unsigned-list unsigned-transactions]}
+    :title   (unsigned-transactions-title)
+    :screen  [unsigned-list]}
    {:view-id :wallet-transactions-history
     :title   (i18n/label :t/transactions-history)
     :screen  [history-list]}])
@@ -192,13 +195,12 @@
 ;; TODO(yenda) must reflect selected wallet
 
 (defview transactions []
-  [unsigned-transactions [:wallet.transactions/unsigned-transactions]]
-  (let [tabs         (tab-list unsigned-transactions)
+  (let [tabs         (tab-list)
         default-view (get-in tabs [0 :view-id])
         view-id      (reagent/atom default-view)]
     [react/view {:style styles/flex}
      [status-bar/status-bar]
-     [toolbar-view view-id unsigned-transactions]
+     [toolbar-view view-id]
      [main-section view-id tabs]]))
 
 (defn transaction-details-header [{:keys [value date type]}]

--- a/src/status_im/utils/datetime.cljs
+++ b/src/status_im/utils/datetime.cljs
@@ -44,6 +44,12 @@
                                                from-long
                                                (plus time-zone-offset)))))
 
+(defn timestamp->long-date [ms]
+  (keyword (unparse (formatter "MMM DD YYYY HH:mm:ss")
+                    (-> ms
+                        from-long
+                        (plus time-zone-offset)))))
+
 (defn day-relative [ms]
   (when (pos? ms)
     (to-short-str ms #(label :t/datetime-today))))


### PR DESCRIPTION
This PR includes the following commits/PR:

should also [FIX #1824] 

- add transaction details screen [FIX #1775]
- [FIX #1854] Fixed broken pull-to-refresh behavior
- remove unsigned transactions before they are implemented

The last one should have no visible effects.
Transaction details screen should now be accessible in transaction history when pressing the arrow icon on a transaction
Pull to refresh transaction history should work ?

The main change to existing transaction history screen is that now it is a screen and not a modal anymore