### PR TITLE
Bugfix: correct realm schema for release

### DIFF
--- a/src/status_im/data_store/realm/schemas/account/core.cljs
+++ b/src/status_im/data_store/realm/schemas/account/core.cljs
@@ -11,7 +11,9 @@
             [status-im.data-store.realm.schemas.account.v10.core :as v10]
             [status-im.data-store.realm.schemas.account.v11.core :as v11]
             [status-im.data-store.realm.schemas.account.v12.core :as v12]
-            [status-im.data-store.realm.schemas.account.v13.core :as v13]))
+            [status-im.data-store.realm.schemas.account.v13.core :as v13]
+            [status-im.data-store.realm.schemas.account.v14.core :as v14]
+            ))
 
 ;; TODO(oskarth): Add failing test if directory vXX exists but isn't in schemas.
 
@@ -54,4 +56,8 @@
                :migration     v12/migration}
               {:schema        v13/schema
                :schemaVersion 13
-               :migration     v13/migration}])
+               :migration     v13/migration}
+              {:schema        v14/schema
+               :schemaVersion 14
+               :migration     v14/migration}
+              ])

--- a/src/status_im/data_store/realm/schemas/account/v14/contact.cljs
+++ b/src/status_im/data_store/realm/schemas/account/v14/contact.cljs
@@ -1,4 +1,4 @@
-(ns status-im.data-store.realm.schemas.account.v13.contact
+(ns status-im.data-store.realm.schemas.account.v14.contact
   (:require [taoensso.timbre :as log]))
 
 (def schema {:name       :contact

--- a/src/status_im/data_store/realm/schemas/account/v14/core.cljs
+++ b/src/status_im/data_store/realm/schemas/account/v14/core.cljs
@@ -1,9 +1,9 @@
-(ns status-im.data-store.realm.schemas.account.v13.core
+(ns status-im.data-store.realm.schemas.account.v14.core
   (:require [status-im.data-store.realm.schemas.account.v11.chat :as chat]
             [status-im.data-store.realm.schemas.account.v1.chat-contact :as chat-contact]
             [status-im.data-store.realm.schemas.account.v6.command :as command]
             [status-im.data-store.realm.schemas.account.v9.command-parameter :as command-parameter]
-            [status-im.data-store.realm.schemas.account.v7.contact :as contact]
+            [status-im.data-store.realm.schemas.account.v14.contact :as contact]
             [status-im.data-store.realm.schemas.account.v1.discover :as discover]
             [status-im.data-store.realm.schemas.account.v1.kv-store :as kv-store]
             [status-im.data-store.realm.schemas.account.v10.message :as message]
@@ -37,4 +37,4 @@
              handler-data/schema])
 
 (defn migration [old-realm new-realm]
-  (log/debug "migrating v13 account database: " old-realm new-realm))
+  (log/debug "migrating v14 account database: " old-realm new-realm))


### PR DESCRIPTION
In release 0.9.11 we'll have v13, so we don't want to modify this in develop.
This moves Push notification related changes into a new migration as opposed to
merging them into one.

status: ready