### PR TITLE
Bugfix: resolve undeclared var for status/notify

### DIFF
--- a/src/status_im/native_module/core.cljs
+++ b/src/status_im/native_module/core.cljs
@@ -91,3 +91,6 @@
 
 (defn should-move-to-internal-storage? [callback]
   (module-interface/-should-move-to-internal-storage? rns-module callback))
+
+(defn notify [token callback]
+  (module-interface/-notify rns-module token callback))

--- a/src/status_im/native_module/impl/module.cljs
+++ b/src/status_im/native_module/impl/module.cljs
@@ -216,6 +216,8 @@
     (call-function! params))
   (-call-web3 [this host payload callback]
     (call-web3 host payload callback))
+  (-notify [this token callback]
+    (notify token callback))
 
   ;; other calls
   (-move-to-internal-storage [this callback]

--- a/src/status_im/native_module/impl/non_status_go_module.cljs
+++ b/src/status_im/native_module/impl/non_status_go_module.cljs
@@ -59,4 +59,5 @@
   (-module-initialized! [this]
     (impl/module-initialized!))
   (-should-move-to-internal-storage? [this callback]
-    (impl/should-move-to-internal-storage? callback)))
+    (impl/should-move-to-internal-storage? callback))
+  (-notify [this token callback]))

--- a/src/status_im/native_module/module.cljs
+++ b/src/status_im/native_module/module.cljs
@@ -19,5 +19,6 @@
   (-clear-web-data [this])
   (-call-web3 [this host payload callback])
   (-module-initialized! [this])
-  (-should-move-to-internal-storage? [this callback]))
+  (-should-move-to-internal-storage? [this callback])
+  (-notify [this token callback]))
 


### PR DESCRIPTION
Rebasing introduced regression due to refactoring of how native modules are called. Call implementation when available, noop when stubbing status-go.

status: ready