### PR TITLE
Bugfix/upgrade status go two gba963cc

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,6 +20,8 @@ node {
       sh 'cp .env.jenkins .env'
       sh 'lein deps && npm install && ./re-natal deps'
       sh 'sed -i "" "s/301000/1201000/g" node_modules/react-native/packager/src/JSTransformer/index.js'
+      sh 'ls ~/.m2/repository/status-im/status-go-ios-simulator/'
+      sh 'ls ~/.m2/repository/status-im/status-go-ios-simulator/develop-gba963cc'
       sh 'mvn -f modules/react-native-status/ios/RCTStatus dependency:unpack'
       sh 'cd ios && pod install && cd ..'
     }

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ If this interests you, **help us make Status a reality** - anyone can contribute
 
 Go straight to the [wiki](https://wiki.status.im) or [join our Slack](http://slack.status.im) or choose what interests you:
 
-- **Developer**  
+- **Developer**
 Developers are the heart of software and to keep Status beating we need all the help we can get! If you're looking to code in ClojureScript or Golang then Status is the project for you! We use React Native and there is even some Java/Objective-C too!  
 Want to learn more about it? Start by reading our [Developer Introduction](http://wiki.status.im/contributing/development/introduction/) which guides you through the technology stack and and start browsing [beginner issues](https://github.com/status-im/status-react/issues?q=is%3Aopen+is%3Aissue+label%3Abeginner). Then you can read how to [Build Status](http://wiki.status.im/contributing/development/building-status/), which talks about managing project dependencies, coding guidelines and testing procedures.  
 

--- a/modules/react-native-status/android/build.gradle
+++ b/modules/react-native-status/android/build.gradle
@@ -15,5 +15,5 @@ android {
 dependencies {
     compile 'com.facebook.react:react-native:+'
     compile 'com.instabug.library:instabug:3+'
-    compile(group: 'status-im', name: 'status-go', version: 'bugfix-upstream-routing-g676a77b', ext: 'aar')
+    compile(group: 'status-im', name: 'status-go', version: 'develop-gba963cc', ext: 'aar')
 }

--- a/modules/react-native-status/ios/RCTStatus/pom.xml
+++ b/modules/react-native-status/ios/RCTStatus/pom.xml
@@ -25,7 +25,7 @@
                         <artifactItem>
                             <groupId>status-im</groupId>
                             <artifactId>status-go-ios-simulator</artifactId>
-                            <version>bugfix-upstream-routing-g676a77b</version>
+                            <version>develop-gba963cc</version>
                             <type>zip</type>
                             <overWrite>true</overWrite>
                             <outputDirectory>./</outputDirectory>

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "react-native-tcp": "^3.2.1",
     "react-native-udp": "^2.0.0",
     "react-native-vector-icons": "^4.0.1",
-    "react-native-webview-bridge": "git+https://github.com/status-im/react-native-webview-bridge.git#bugfix-upstream-routing",
+    "react-native-webview-bridge": "git+https://github.com/status-im/react-native-webview-bridge.git#status-go-develop-gba963cc",
     "readable-stream": "1.0.33",
     "realm": "^0.14.3",
     "stream-browserify": "^1.0.0",


### PR DESCRIPTION
Upgrade status-go to incorporate gas fix

Second branch to get a new Jenkins environment.

Addresses #1885

status-go/develop also includes status-im/status-go@676a77b which was previous status-go version used.

Reproduced 'intrinsinc gas too low' issue on release/0.9.11 branch. Locally compiling with latest status-go develop (gba963cc) transaction goes through. Tested on iOS simulator.

Also includes updated react-native-webview-bridge: status-im/react-native-webview-bridge@015957e

@rasom let me know if this is the correct way of patching webview-bridge.

Also note build might fail because of lack of artifacts, then just retrigger.

status: ready