### PR TITLE
Upgrade status-go to develop-g283ae3e to incorporate gas fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ If this interests you, **help us make Status a reality** - anyone can contribute
 
 Go straight to the [wiki](https://wiki.status.im) or [join our Slack](http://slack.status.im) or choose what interests you:
 
-- **Developer**  
+- **Developer**
 Developers are the heart of software and to keep Status beating we need all the help we can get! If you're looking to code in ClojureScript or Golang then Status is the project for you! We use React Native and there is even some Java/Objective-C too!  
 Want to learn more about it? Start by reading our [Developer Introduction](http://wiki.status.im/contributing/development/introduction/) which guides you through the technology stack and and start browsing [beginner issues](https://github.com/status-im/status-react/issues?q=is%3Aopen+is%3Aissue+label%3Abeginner). Then you can read how to [Build Status](http://wiki.status.im/contributing/development/building-status/), which talks about managing project dependencies, coding guidelines and testing procedures.  
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6072,7 +6072,7 @@
       }
     },
     "react-native-webview-bridge": {
-      "version": "git+https://github.com/status-im/react-native-webview-bridge.git#fddeb7b1dd7c6966d3df6a67cc29ee9d174b9ca4",
+      "version": "git+https://github.com/status-im/react-native-webview-bridge.git#354ec944d5f611bc41db5aee94dc795d4b635b0e",
       "requires": {
         "invariant": "2.2.0",
         "keymirror": "0.1.1"

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "react-native-tcp": "^3.2.1",
     "react-native-udp": "^2.0.0",
     "react-native-vector-icons": "^4.0.1",
-    "react-native-webview-bridge": "git+https://github.com/status-im/react-native-webview-bridge.git#fix-for-push-notifications",
+    "react-native-webview-bridge": "git+https://github.com/status-im/react-native-webview-bridge.git#status-go-develop-g283ae3e",
     "readable-stream": "1.0.33",
     "realm": "^0.14.3",
     "stream-browserify": "^1.0.0",


### PR DESCRIPTION
Gas fix: https://github.com/status-im/status-go/commit/ba963cc1bddbcf450e0665519baaa759d975e31f

develop also includes https://github.com/status-im/status-go/commit/676a77b89299193924177b146aebf16fdc81d4bd which was previous version

Include react-native-webview-bridge upgrade

status: ready

