### PR TITLE
typo prevented error on prices-update from clearing

### DIFF
--- a/src/status_im/ui/screens/wallet/events.cljs
+++ b/src/status_im/ui/screens/wallet/events.cljs
@@ -70,7 +70,7 @@
                    :success-event :update-prices-success
                    :error-event   :update-prices-fail}
      :db          (-> db
-                      (clear-error-message :price-update)
+                      (clear-error-message :prices-update)
                       (clear-error-message :balance-update)
                       (assoc-in [:wallet :balance-loading?] true)
                       (assoc :prices-loading? true))}))


### PR DESCRIPTION
When an error occured on prices-update event the error was sticking forever because of a typo in the clearing code

[comment]: # (PRs will only be accepted if squashed into single commit.)
status: ready

