### PR TITLE
fix #1888 ether amount not updated in /send suggestion if it was init…

### DIFF
--- a/resources/js/bots/wallet/bot.js
+++ b/resources/js/bots/wallet/bot.js
@@ -51,8 +51,11 @@ function amountParameterBox(params, context) {
 
     var txData;
     var amount;
+
+
+
     try {
-        amount = params.args[1];
+        amount = params.args[1] || "0";
         txData = {
             to: contactAddress,
             value: web3.toWei(amount) || 0

--- a/resources/js/bots/wallet/bot.js
+++ b/resources/js/bots/wallet/bot.js
@@ -52,8 +52,6 @@ function amountParameterBox(params, context) {
     var txData;
     var amount;
 
-    //ether amount
-
     try {
         amount = params.args[1] || "0";
         txData = {

--- a/resources/js/bots/wallet/bot.js
+++ b/resources/js/bots/wallet/bot.js
@@ -52,7 +52,7 @@ function amountParameterBox(params, context) {
     var txData;
     var amount;
 
-
+    //ether amount
 
     try {
         amount = params.args[1] || "0";


### PR DESCRIPTION
fixes #1888 

### Summary:

The amount in /send suggestion never updates if the suggestion box is initialized as `undefined` which is the normal workflow of that command. This PR removes the immediate blocker by making sure the `amount` is never `undefined` to start with.

### Steps to test:
see #1888 

[comment]: # (PRs will only be accepted if squashed into single commit.)
status: ready

