### PR TITLE
Push notifications: Print notif and data payload when resuming app

### DIFF
--- a/src/status_im/android/core.cljs
+++ b/src/status_im/android/core.cljs
@@ -68,7 +68,9 @@
        :component-did-mount
        (fn []
          (when config/notifications-wip-enabled?
-           (notifications/on-refresh-fcm-token)))
+           (notifications/on-refresh-fcm-token)
+           ;; TODO(oskarth): Background click_action handler
+           (notifications/on-notification)))
        :component-will-unmount
        (fn []
          (.stop react/http-bridge)

--- a/src/status_im/ios/core.cljs
+++ b/src/status_im/ios/core.cljs
@@ -44,7 +44,8 @@
        (fn []
          (when config/notifications-wip-enabled?
            (notifications/request-permissions)
-           (notifications/on-refresh-fcm-token)))
+           (notifications/on-refresh-fcm-token)
+           (notifications/on-notification)))
        :component-will-unmount
        (fn []
          (.stop react/http-bridge))

--- a/src/status_im/utils/notifications.cljs
+++ b/src/status_im/utils/notifications.cljs
@@ -32,3 +32,16 @@
        (fn [x]
          (log/debug "on-refresh-fcm-token: " x)
          (dispatch [:update-fcm-token x]))))
+
+;; TODO(oskarth): Only called in background on iOS right now.
+;; NOTE(oskarth): Hardcoded data keys :sum and :msg in status-go right now.
+(defn on-notification []
+  (.on (.-default rn/react-native-fcm)
+       (.-Notification (.-FCMEvent rn/react-native-fcm))
+       (fn [event-js]
+         (let [event (js->clj event-js :keywordize-keys true)
+               data  (select-keys event [:sum :msg])
+               aps   (:aps event)]
+           (log/debug "on-notification event: " (pr-str event))
+           (log/debug "on-notification aps: "   (pr-str aps))
+           (log/debug "on-notification data: "  (pr-str data))))))


### PR DESCRIPTION
Push notifications: Print notif and data payload when resuming app

- on-notification listener registered in root component
- print data (hardcoded keys) and notif payload to debug

Addresses https://github.com/status-im/status-react/issues/1906

status: ready