### PR TITLE
add gas price in gwei in transaction details

### DIFF
--- a/src/status_im/ui/screens/wallet/transactions/subs.cljs
+++ b/src/status_im/ui/screens/wallet/transactions/subs.cljs
@@ -75,10 +75,11 @@
   (fn [[transactions current-transaction network]]
     (let [{:keys [gas-used gas-price hash timestamp type] :as transaction} (get transactions current-transaction)]
       (merge transaction
-             {:cost (money/wei->ether (money/fee-value gas-used gas-price))
-              :gas-price-eth  (str (.toFixed (money/wei->ether gas-price)) " ETH")
-              :date (datetime/timestamp->long-date timestamp)
-              :url (transactions/get-transaction-details-url network hash)}
+             {:cost           (money/wei->ether (money/fee-value gas-used gas-price))
+              :gas-price-eth  (money/wei->str :eth gas-price)
+              :gas-price-gwei (money/wei->str :gwei gas-price)
+              :date           (datetime/timestamp->long-date timestamp)
+              :url            (transactions/get-transaction-details-url network hash)}
              ;; TODO (yenda) proper wallet logic when wallet switching is impletmented
              (if (= type :inbound)
                {:to-wallet "Main wallet"}

--- a/src/status_im/ui/screens/wallet/transactions/views.cljs
+++ b/src/status_im/ui/screens/wallet/transactions/views.cljs
@@ -234,14 +234,14 @@
      [react/text {:style transactions.styles/transaction-details-item-value} (str value)]
      [react/text {:style transactions.styles/transaction-details-item-extra-value} (str extra-value)]]]))
 
-(defn transaction-details-list [{:keys [block hash from from-wallet to to-wallet gas-limit gas-price-eth gas-used cost nonce data]}]
+(defn transaction-details-list [{:keys [block hash from from-wallet to to-wallet gas-limit gas-price-gwei gas-price-eth gas-used cost nonce data]}]
   [react/view {:style transactions.styles/transaction-details-block}
    [transaction-details-list-row :t/block block]
    [transaction-details-list-row :t/hash hash]
    [transaction-details-list-row :t/from (or from-wallet from) (when from-wallet from)]
    [transaction-details-list-row :t/to (or to-wallet to) (when to-wallet to)]
    [transaction-details-list-row :t/gas-limit gas-limit]
-   [transaction-details-list-row :t/gas-price gas-price-eth]
+   [transaction-details-list-row :t/gas-price gas-price-gwei gas-price-eth]
    [transaction-details-list-row :t/gas-used gas-used]
    [transaction-details-list-row :t/cost-fee (str cost " ETH")]
    [transaction-details-list-row :t/nonce nonce]

--- a/src/status_im/utils/money.cljs
+++ b/src/status_im/utils/money.cljs
@@ -1,5 +1,6 @@
 (ns status-im.utils.money
-  (:require [status-im.js-dependencies :as dependencies]))
+  (:require [status-im.js-dependencies :as dependencies]
+            [clojure.string :as string]))
 
 ;; The BigNumber version included in web3 sometimes hangs when dividing large
 ;; numbers Hence we want to use these functions instead of fromWei etc, which
@@ -22,10 +23,27 @@
 (defn bignumber [n]
   (dependencies/Web3.prototype.toBigNumber (str n)))
 
-(def ether-unit-value (bignumber "1000000000000000000"))
+(def eth-units
+  {:wei    (bignumber "1")
+   :kwei   (bignumber "1000")
+   :mwei   (bignumber "1000000")
+   :gwei   (bignumber "1000000000")
+   :szabo  (bignumber "1000000000000")
+   :finney (bignumber "1000000000000000")
+   :eth    (bignumber "1000000000000000000")
+   :keth   (bignumber "1000000000000000000000")
+   :meth   (bignumber "1000000000000000000000000")
+   :geth   (bignumber "1000000000000000000000000000")
+   :teth   (bignumber "1000000000000000000000000000000")})
+
+(defn wei-> [unit n]
+  (.dividedBy (bignumber n) (eth-units unit)))
+
+(defn wei->str [unit n]
+  (str (.toFixed (wei-> unit n)) " " (string/upper-case (name unit))))
 
 (defn wei->ether [n]
-  (.dividedBy (bignumber n) ether-unit-value))
+  (wei-> :eth n))
 
 (defn fee-value [gas gas-price]
   (.times (bignumber gas) (bignumber gas-price)))


### PR DESCRIPTION
### Summary:

fixes what was discussed during design meeting on 2017/09/22:

- [x] show the gas price in GWEI in the transaction details screen

What implementation looks like:

![screenshot_1506293227](https://user-images.githubusercontent.com/1181225/30787584-61dba9c0-a18c-11e7-83c6-b4663289a755.png)

What zeplin looks like:

![screenshot from 2017-09-25 00-48-39](https://user-images.githubusercontent.com/1181225/30787585-64441058-a18c-11e7-8c37-05c690bf8a8a.png)

### Steps to test:
- Open Status
- Log in to an account with transactions
- Go to wallet->transaction-history->press arrow on one of the transactions

[comment]: # (PRs will only be accepted if squashed into single commit.)
status: ready

