### PR TITLE
Be more defensive when checking user balance

### DIFF
--- a/resources/js/bots/wallet/bot.js
+++ b/resources/js/bots/wallet/bot.js
@@ -321,7 +321,20 @@ function validateSend(params, context) {
         };
     }
 
-    var balance = web3.eth.getBalance(context.from);
+    try {
+        var balance = web3.eth.getBalance(context.from);
+        if (isNaN(balance)) {
+            throw new Error();
+        }
+    } catch (err) {
+        return {
+            markup: status.components.validationMessage(
+                I18n.t('validation_internal_title'),
+                I18n.t('validation_balance')
+            )
+        };
+    }
+    
     var fee = calculateFee(
         params["bot-db"]["sliderValue"],
         {

--- a/resources/js/bots/wallet/translations.js
+++ b/resources/js/bots/wallet/translations.js
@@ -22,6 +22,8 @@ I18n.translations = {
         request_requesting: 'Requesting ',
         request_requesting_from: 'from ',
 
+        validation_internal_title: 'Internal error',
+        validation_balance: 'Could not fetch current balance',
         validation_title: 'Amount',
         validation_tx_title: 'Transaction',
         validation_tx_failed: 'Transaction failed',


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)
(partially) fixes #1913

### Summary:
[comment]: # (Summarise the problem and how the pull request solves it)
Previously, we used unguarded call to get current user balance, which sometimes led to errors (RPC calls in `ethereum-go`) which were unhandled on RN side, resulting in transactions "proceeding" from UI POW, making it confusing for the end user. 
This PR should fix it, when it's not possible to get balance for whatever reason, error is displayed and user can't proceed with normal transaction workflow.

### Steps to test:
- Open Status
- Notice that it's not possible to send tx if you don't have enough funds

[comment]: # (PRs will only be accepted if squashed into single commit.)
status: ready

