### PR TITLE
upgrade react-native-webview-bridge to 0.33.17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6072,7 +6072,7 @@
       }
     },
     "react-native-webview-bridge": {
-      "version": "git+https://github.com/status-im/react-native-webview-bridge.git#354ec944d5f611bc41db5aee94dc795d4b635b0e",
+      "version": "git+https://github.com/status-im/react-native-webview-bridge.git#a52580df1a069c95f4254a5a3f8bf47253625e68",
       "requires": {
         "invariant": "2.2.0",
         "keymirror": "0.1.1"

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "react-native-tcp": "^3.2.1",
     "react-native-udp": "^2.0.0",
     "react-native-vector-icons": "^4.0.1",
-    "react-native-webview-bridge": "git+https://github.com/status-im/react-native-webview-bridge.git#status-go-develop-g283ae3e",
+    "react-native-webview-bridge": "git+https://github.com/status-im/react-native-webview-bridge.git#0.33.17",
     "readable-stream": "1.0.33",
     "realm": "^0.14.3",
     "stream-browserify": "^1.0.0",


### PR DESCRIPTION
[fix](https://github.com/status-im/react-native-webview-bridge/commit/a52580df1a069c95f4254a5a3f8bf47253625e68#diff-7ae5a9093507568eabbf35c3b0665732R34) for #1917, no need to update `status-go` version in `react-native-webview-bridge` each time anymore 

status: ready

