### PR TITLE
fix Use of undeclared Var status-im.utils.platform/platform warning

### DIFF
--- a/src/status_im/utils/styles.clj
+++ b/src/status_im/utils/styles.clj
@@ -1,5 +1,20 @@
 (ns status-im.utils.styles)
 
+(def first-time (atom true))
+
+(defn wrap-first-time
+  "Allows to avoid
+  \"Use of undeclared Var status-im.utils.platform/platform\"
+  warning. When defstyle or defnstyle is called first time status-im.utils.platform
+  namespace will be explicitly required so that clojurescript compiler will compile
+  it before using status-im.utils.platform/platform in macro"
+  [body]
+  `(do
+     ~@[(when @first-time
+          (reset! first-time false)
+          `(require 'status-im.utils.platform))]
+     ~body))
+
 (defn body [style]
   `(let [style#            ~style
          common#            (dissoc style# :android :ios)
@@ -26,8 +41,9 @@
     {:width  100
      :height 20}"
   [style-name style]
-  `(def ~style-name
-     ~(body style)))
+  (wrap-first-time
+    `(def ~style-name
+       ~(body style))))
 
 (defmacro defnstyle
   "Defines style function.
@@ -46,6 +62,7 @@
     {:width  100
      :height 5}"
   [style-name params style]
-  `(defn ~style-name
-     [~@params]
-     ~(body style)))
+  (wrap-first-time
+    `(defn ~style-name
+       [~@params]
+       ~(body style))))


### PR DESCRIPTION
When `defstyle` or `defnstyle` is called first time `status-im.utils.platform` namespace will be explicitly required so that clojurescript compiler will compile it before using `status-im.utils.platform/platform` in macro.

status: ready

