### PR TITLE
remove statusgo from webview bridge#1917

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -103,17 +103,24 @@ def getVersionName = { ->
 
 android {
     compileSdkVersion 24
-    buildToolsVersion "23.0.1"
+    buildToolsVersion "24.0.2"
 
     defaultConfig {
         applicationId "im.status.ethereum"
         minSdkVersion 18
-        targetSdkVersion 23
+        targetSdkVersion 24
         multiDexEnabled true
         versionCode getVersionCode()
         versionName getVersionName()
         ndk {
             abiFilters "armeabi-v7a", "x86"
+        }
+        jackOptions {
+            enabled true
+        }
+        compileOptions {
+            sourceCompatibility JavaVersion.VERSION_1_8
+            targetCompatibility JavaVersion.VERSION_1_8
         }
     }
     dexOptions {

--- a/android/app/src/main/java/im/status/ethereum/MainApplication.java
+++ b/android/app/src/main/java/im/status/ethereum/MainApplication.java
@@ -32,6 +32,7 @@ import me.alwx.HttpServer.HttpServerReactPackage;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Function;
 
 public class MainApplication extends MultiDexApplication implements ReactApplication {
 
@@ -43,6 +44,8 @@ public class MainApplication extends MultiDexApplication implements ReactApplica
 
         @Override
         protected List<ReactPackage> getPackages() {
+            StatusPackage statusPackage = new StatusPackage(BuildConfig.DEBUG);
+            Function<String, String> callRPC = statusPackage.getCallRPC();
             List<ReactPackage> packages = new ArrayList<ReactPackage>(Arrays.asList(
                     new MainReactPackage(),
                     new SvgPackage(),
@@ -51,7 +54,7 @@ public class MainApplication extends MultiDexApplication implements ReactApplica
                     new HttpServerReactPackage(),
                     new NfcReactNativePackage(),
                     new SplashScreenReactPackage(),
-                    new StatusPackage(BuildConfig.DEBUG),
+                    statusPackage,
                     new RealmReactPackage(),
                     new VectorIconsPackage(),
                     new ReactNativeContacts(),
@@ -65,7 +68,7 @@ public class MainApplication extends MultiDexApplication implements ReactApplica
                     new ReactNativeDialogsPackage(),
                     new ImageResizerPackage(),
                     new PickerPackage(),
-                    new WebViewBridgePackage(BuildConfig.DEBUG),
+                    new WebViewBridgePackage(BuildConfig.DEBUG, callRPC),
                     new ReactNativeConfigPackage()
                                                                                     ));
 

--- a/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusPackage.java
+++ b/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusPackage.java
@@ -5,10 +5,12 @@ import com.facebook.react.bridge.JavaScriptModule;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.uimanager.ViewManager;
+import com.github.status_im.status_go.cmd.Statusgo;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Function;
 
 public class StatusPackage implements ReactPackage {
 
@@ -36,5 +38,14 @@ public class StatusPackage implements ReactPackage {
     @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         return Collections.emptyList();
+    }
+
+    public Function<String, String> getCallRPC() {
+        return new Function<String, String>() {
+            @Override
+            public String apply(String payload) {
+                return Statusgo.CallRPC(payload);
+            }
+        };
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5954,7 +5954,7 @@
       }
     },
     "react-native-webview-bridge": {
-      "version": "git+https://github.com/status-im/react-native-webview-bridge.git#a52580df1a069c95f4254a5a3f8bf47253625e68",
+      "version": "git+https://github.com/status-im/react-native-webview-bridge.git#3fc01ceeffaaffc6b86f7bc74edac7999530ffb1",
       "requires": {
         "invariant": "2.2.0",
         "keymirror": "0.1.1"

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "react-native-tcp": "^3.2.1",
     "react-native-udp": "^2.0.0",
     "react-native-vector-icons": "^4.0.1",
-    "react-native-webview-bridge": "git+https://github.com/status-im/react-native-webview-bridge.git#0.33.17",
+    "react-native-webview-bridge": "git+https://github.com/status-im/react-native-webview-bridge.git#remove-status-go",
     "readable-stream": "1.0.33",
     "realm": "^0.14.3",
     "stream-browserify": "^1.0.0",


### PR DESCRIPTION
fix for #1917 
Statusgo.CallRPC is wrapped with with Function<> interface and passed to webview-bridge, so that webview-bridge doesn't need to have status-go dependency. 

status: ready

