### PR TITLE
add unsigned transactions bindings in new wallet

### DIFF
--- a/src/status_im/translations/en.cljs
+++ b/src/status_im/translations/en.cljs
@@ -33,11 +33,11 @@
    :and-you              "and you"
    :search-chat          "Search chat"
    :members              {:one   "1 member"
-                                           :other "{{count}} members"
-                                           :zero  "no members"}
+                          :other "{{count}} members"
+                          :zero  "no members"}
    :members-active       {:one   "1 member"
-                                           :other "{{count}} members"
-                                           :zero  "no members"}
+                          :other "{{count}} members"
+                          :zero  "no members"}
    :public-group-status  "Public"
    :active-online        "Online"
    :active-unknown       "Unknown"
@@ -365,7 +365,7 @@
    :transactions-sign                     "Sign"
    :transactions-sign-all                 "Sign all"
    :transactions-sign-all-text            "Sign the transaction by entering your password.\nMake sure that the words above match your secret signing phrase"
-   :transactions-sign-input-placeholder   "Enter your passphrase"
+   :transactions-sign-input-placeholder   "Enter your password"
    :transactions-history                  "History"
    :transactions-unsigned                 "Unsigned"
    :transactions-history-empty            "You don't have a history transactions"
@@ -374,12 +374,12 @@
    :transactions-filter-tokens            "Tokens"
    :transactions-filter-type              "Type"
    :transactions-filter-select-all        "Select all"
+   :not-applicable                        "Not applicable for unsigned transactions"
+
    ;; Wallet Send
    :wallet-send-transaction               "Send a Transaction"
    :wallet-send-step-one                  "Step 1 of 3"
    :wallet-choose-recipient               "Choose Recipient"
    :wallet-choose-from-contacts           "Choose From Contacts"
    :wallet-address-from-clipboard         "Use Address From Clipboard"
-   :wallet-browse-photos                  "Browse Photos"
-
-   })
+   :wallet-browse-photos                  "Browse Photos"})

--- a/src/status_im/ui/screens/wallet/transactions/views.cljs
+++ b/src/status_im/ui/screens/wallet/transactions/views.cljs
@@ -20,39 +20,60 @@
   (utils/show-popup "TODO" "Not implemented yet!"))
 
 (defn on-sign-transaction
-  [m]
+  [password]
   ;; TODO(yenda) implement
-  (utils/show-popup "TODO" "Sign Transaction"))
+  (re-frame/dispatch [:accept-transactions password]))
 
 (defn on-delete-transaction
   [m]
   ;; TODO(yenda) implement
   (utils/show-popup "TODO" "Delete Transaction"))
 
-(defn unsigned-action []
-  ;; TODO subscribe to unsigned-transactions-count or pass it as parameter ?
-  [toolbar/text-action {:disabled? (zero? 0 #_(count unsigned-transactions)) :handler #(re-frame/dispatch [:navigate-to-modal :wallet-transactions-sign-all])}
+(defn unsigned-action [unsigned-transactions-count]
+  [toolbar/text-action {:disabled? (zero? unsigned-transactions-count)
+                        :handler #(re-frame/dispatch [:navigate-to-modal :wallet-transactions-sign-all])}
    (i18n/label :t/transactions-sign-all)])
 
 (def history-action
   {:icon      :icons/filter
    :handler   #(utils/show-popup "TODO" "Not implemented") #_(re-frame/dispatch [:navigate-to-modal :wallet-transactions-sign-all])})
 
-(defn toolbar-view [view-id]
+(defn toolbar-view [view-id unsigned-transactions-count]
   [toolbar/toolbar2 {:flat? true}
    toolbar/default-nav-back
    [toolbar/content-title (i18n/label :t/transactions)]
    (case @view-id
      :wallet-transactions-unsigned
-     [unsigned-action]
+     [unsigned-action unsigned-transactions-count]
 
      :wallet-transactions-history
      [toolbar/actions
       [history-action]])])
 
+;; Sign all
+
+(defview sign-all []
+  []
+  [react/keyboard-avoiding-view {:style transactions.styles/sign-all-view}
+   [react/view {:style transactions.styles/sign-all-done}
+    [button/primary-button {:style    transactions.styles/sign-all-done-button
+                            :text     (i18n/label :t/done)
+                            :on-press #(re-frame/dispatch [:navigate-back])}]]
+   [react/view {:style transactions.styles/sign-all-popup}
+    [react/text {:style transactions.styles/sign-all-popup-sign-phrase} "one two three"] ;; TODO hook
+    [react/text {:style transactions.styles/sign-all-popup-text} (i18n/label :t/transactions-sign-all-text)]
+    [react/view {:style transactions.styles/sign-all-actions}
+     [react/text-input {:style             transactions.styles/sign-all-input
+                        :secure-text-entry true
+                        :placeholder       (i18n/label :t/transactions-sign-input-placeholder)}]
+     [button/primary-button {:text (i18n/label :t/transactions-sign-all) :on-press #(println %)}]]]])
+
+
 (defn action-buttons [m]
   [react/view {:style transactions.styles/action-buttons}
-   [button/primary-button {:text (i18n/label :t/transactions-sign) :on-press #(on-sign-transaction m)}]
+   [button/primary-button {:text (i18n/label :t/transactions-sign)
+
+                           :on-press #(re-frame/dispatch [:navigate-to-modal :wallet-transactions-sign-all])}]
    [button/secondary-button {:text (i18n/label :t/delete) :on-press #(on-delete-transaction m)}]])
 
 (defn- inbound? [type] (= "inbound" type))
@@ -103,44 +124,23 @@
                          :refreshing      transactions-loading?}]]))
 
 (defview unsigned-list []
-  []
-  (let [transactions nil] ;; TODO replace by letsubs later
+  (letsubs [transactions [:wallet.transactions/unsigned-transactions-list]]
     [react/view {:style styles/flex}
      [list/flat-list {:data            transactions
                       :render-fn       render-transaction
                       :empty-component (empty-text (i18n/label :t/transactions-unsigned-empty))}]]))
 
-(defn- unsigned-transactions-title []
-  ;; TODO subscribe to unsigned-transactions-count or pass it as parameter ?
-  (let [count 0 #_(count transactions)]
-    (str (i18n/label :t/transactions-unsigned)
-         (if (pos? count) (str " " count)))))
+(defn- unsigned-transactions-title [unsigned-transactions-count]
+  (str (i18n/label :t/transactions-unsigned)
+       (if (pos? unsigned-transactions-count) (str " " unsigned-transactions-count))))
 
-(defn- tab-list []
+(defn- tab-list [unsigned-transactions-count]
   [{:view-id :wallet-transactions-history
     :title   (i18n/label :t/transactions-history)
     :screen  [history-list]}
    {:view-id :wallet-transactions-unsigned
-    :title   (unsigned-transactions-title)
+    :title   (unsigned-transactions-title unsigned-transactions-count)
     :screen  [unsigned-list]}])
-
-;; Sign all
-
-(defview sign-all []
-  []
-  [react/keyboard-avoiding-view {:style transactions.styles/sign-all-view}
-   [react/view {:style transactions.styles/sign-all-done}
-    [button/primary-button {:style    transactions.styles/sign-all-done-button
-                            :text     (i18n/label :t/done)
-                            :on-press #(re-frame/dispatch [:navigate-back])}]]
-   [react/view {:style transactions.styles/sign-all-popup}
-    [react/text {:style transactions.styles/sign-all-popup-sign-phrase} "one two three"] ;; TODO hook
-    [react/text {:style transactions.styles/sign-all-popup-text} (i18n/label :t/transactions-sign-all-text)]
-    [react/view {:style transactions.styles/sign-all-actions}
-     [react/text-input {:style             transactions.styles/sign-all-input
-                        :secure-text-entry true
-                        :placeholder       (i18n/label :t/transactions-sign-input-placeholder)}]
-     [button/primary-button {:text (i18n/label :t/transactions-sign-all) :on-press #(on-sign-transaction %)}]]]])
 
 ;; Filter history
 
@@ -195,13 +195,14 @@
 ;; TODO(yenda) must reflect selected wallet
 
 (defview transactions []
-  (let [tabs         (tab-list)
-        default-view (get-in tabs [0 :view-id])
-        view-id      (reagent/atom default-view)]
-    [react/view {:style styles/flex}
-     [status-bar/status-bar]
-     [toolbar-view view-id]
-     [main-section view-id tabs]]))
+  (letsubs [unsigned-transactions-count [:wallet.transactions/unsigned-transactions-count]]
+    (let [tabs         (tab-list unsigned-transactions-count)
+          default-view (get-in tabs [0 :view-id])
+          view-id      (reagent/atom default-view)]
+      [react/view {:style styles/flex}
+       [status-bar/status-bar]
+       [toolbar-view view-id unsigned-transactions-count]
+       [main-section view-id tabs]])))
 
 (defn transaction-details-header [{:keys [value date type]}]
   [react/view {:style transactions.styles/transaction-details-header}
@@ -243,7 +244,7 @@
    [transaction-details-list-row :t/gas-limit gas-limit]
    [transaction-details-list-row :t/gas-price gas-price-gwei gas-price-eth]
    [transaction-details-list-row :t/gas-used gas-used]
-   [transaction-details-list-row :t/cost-fee (str cost " ETH")]
+   [transaction-details-list-row :t/cost-fee cost]
    [transaction-details-list-row :t/nonce nonce]
    [transaction-details-list-row :t/data data]])
 
@@ -252,9 +253,9 @@
                   {:text (i18n/label :t/open-on-etherscan) :value #(.openURL react/linking url)}])])
 
 (defview transaction-details []
-  (letsubs [{:keys [hash url] :as transaction-details} [:wallet.transactions/transaction-details]
-            confirmations                              [:wallet.transactions.details/confirmations]
-            confirmations-progress                     [:wallet.transactions.details/confirmations-progress]]
+  (letsubs [{:keys [hash url type] :as transaction-details} [:wallet.transactions/transaction-details]
+            confirmations                                   [:wallet.transactions.details/confirmations]
+            confirmations-progress                          [:wallet.transactions.details/confirmations-progress]]
     [react/view {:style styles/flex}
      [status-bar/status-bar]
      [toolbar/toolbar2 {}


### PR DESCRIPTION
### Summary:
Adds bindings to the new wallet to be able to list unsigned transactions in the transactions list of the new wallet.

![screenshot_1506499207](https://user-images.githubusercontent.com/1181225/30907871-388f8a4a-a37c-11e7-8405-ec203615a1aa.png)

![screenshot_1506506671](https://user-images.githubusercontent.com/1181225/30907878-3d17e1ca-a37c-11e7-8439-941194cf7b73.png)

### Steps to test:
- Open Status
- Start sending a transaction and click on the top right cross on this screen:

![screenshot_1506506661](https://user-images.githubusercontent.com/1181225/30907843-1d44401e-a37c-11e7-943d-e40c2297d2ee.png)

- Go to new wallet, transactions, unsigned transactions tab, transaction should be there

### TODOS

- [ ] unsigned transactions count should be in grey in the tab title (requires changing tab component)
- [ ] styling of buttons and icon
- [ ] bindings to sign transactions
- [ ] bindings to delete transactions
- [ ] handle the fact that unsigned transactions time out and disappears after some time, so the transaction details screen can turn into a red screen after a while

[comment]: # (PRs will only be accepted if squashed into single commit.)

status: wip

