### PR TITLE
Update navigation for QR scan

### DIFF
--- a/src/status_im/ui/screens/wallet/choose_recipient/views.cljs
+++ b/src/status_im/ui/screens/wallet/choose_recipient/views.cljs
@@ -45,7 +45,7 @@
    [react/touchable-highlight {:style    (styles/recipient-touchable true)
                                :on-press #(react/get-from-clipboard
                                             (fn [clipboard]
-                                              (re-frame/dispatch [:choose-recipient clipboard])))}
+                                              (re-frame/dispatch [:choose-recipient clipboard nil])))}
     [react/view {:style styles/recipient-button}
      [react/text {:style styles/recipient-button-text}
       (i18n/label :t/wallet-address-from-clipboard)]
@@ -93,6 +93,6 @@
                                        (let [data (-> code
                                                       .-data
                                                       (string/replace #"ethereum:" ""))]
-                                         (re-frame/dispatch [:choose-recipient data])))}]
+                                         (re-frame/dispatch [:choose-recipient data nil])))}]
       [viewfinder camera-dimensions]]
      [recipient-buttons]]))

--- a/src/status_im/ui/screens/wallet/send/events.cljs
+++ b/src/status_im/ui/screens/wallet/send/events.cljs
@@ -37,17 +37,20 @@
 
 ;;;; Handlers
 
-(handlers/register-handler-db
+(defn choose-address-and-name [db address name]
+  (update db :wallet/send-transaction assoc :to-address address :to-name name))
+
+(handlers/register-handler-fx
   :choose-recipient
-  (fn [db [_ recipient]]
-    (assoc-in db [:wallet :send :recipient] recipient)))
+  (fn [{:keys [db]} [_ address name]]
+    (let [{:keys [view-id]} db]
+      (cond-> {:db (choose-address-and-name db address name)}
+        (= :choose-recipient view-id) (assoc :dispatch [:navigate-back])))))
 
 (handlers/register-handler-fx
   :wallet-open-send-transaction
   (fn [{db :db} [_ address name]]
-    {:db         (update db :wallet/send-transaction
-                         #(assoc % :to-address address
-                                   :to-name name))
+    {:db         (choose-address-and-name db address name)
      :dispatch-n [[:navigate-back]
                   [:navigate-back]]}))
 


### PR DESCRIPTION
fixes #1983 

### Summary:
Event handlers on choose-recipient weren't in line with the rest of the screens.

### Steps to test:
- Open status
- Navigate to Send Transaction
- Navigate to Choose Recipient
- Scan QR or paste from clipboard
- Observe navigation back to choose recipient

status: ready

