### PR TITLE
fix warnings related to outdated shh keys

### DIFF
--- a/src/status_im/components/drawer/view.cljs
+++ b/src/status_im/components/drawer/view.cljs
@@ -27,7 +27,8 @@
             [status-im.utils.listview :as lw]
             [status-im.utils.platform :as platform]
             [status-im.utils.utils :as utils]
-            [status-im.utils.money :as money]))
+            [status-im.utils.money :as money]
+            [status-im.protocol.core :as protocol]))
 
 (defonce drawer-atom (atom nil))
 (defn open-drawer! [] (.openDrawer @drawer-atom))
@@ -49,6 +50,8 @@
 (defn navigate-to-accounts []
   (close-drawer!)
   (save-profile!)
+  ;; TODO(rasom): probably not the best place for this call
+  (protocol/stop-whisper!)
   (rf/dispatch [:navigate-to :accounts]))
 
 (defview profile-picture []

--- a/src/status_im/protocol/core.cljs
+++ b/src/status_im/protocol/core.cljs
@@ -68,6 +68,12 @@
 
 (def stop-watching-all! f/remove-all-filters!)
 (def reset-all-pending-messages! d/reset-all-pending-messages!)
+(def reset-keys! shh-keys/reset-keys!)
+
+(defn stop-whisper! []
+  (stop-watching-all!)
+  (reset-all-pending-messages!)
+  (reset-keys!))
 
 (defn init-whisper!
   [{:keys [identity groups callback web3
@@ -75,8 +81,7 @@
     :as   options}]
   {:pre [(valid? ::options options)]}
   (debug :init-whisper)
-  (stop-watching-all!)
-  (d/reset-all-pending-messages!)
+  (stop-whisper!)
   (let [listener-options {:web3     web3
                           :identity identity
                           :callback callback}]

--- a/src/status_im/protocol/handlers.cljs
+++ b/src/status_im/protocol/handlers.cljs
@@ -1,6 +1,6 @@
 (ns status-im.protocol.handlers
   (:require [status-im.utils.handlers :as u]
-            [re-frame.core :refer [dispatch after]]
+            [re-frame.core :refer [dispatch after] :as re-frame]
             [status-im.utils.handlers :refer [register-handler]]
             [status-im.data-store.contacts :as contacts]
             [status-im.data-store.messages :as messages]
@@ -21,6 +21,10 @@
             [status-im.utils.scheduler :as s]
             [status-im.utils.web3-provider :as w3]
             [status-im.utils.datetime :as time]))
+
+(re-frame/reg-fx
+  :stop-whisper
+  (fn [] (protocol/stop-whisper!)))
 
 (register-handler :initialize-protocol
   (fn [db [_ current-account-id ethereum-rpc-url]]

--- a/src/status_im/protocol/web3/keys.cljs
+++ b/src/status_im/protocol/web3/keys.cljs
@@ -19,3 +19,6 @@
       (fn [err res]
         (swap! password->keys assoc password res)
         (callback res)))))
+
+(defn reset-keys! []
+  (reset! password->keys {}))

--- a/src/status_im/ui/screens/network_settings/events.cljs
+++ b/src/status_im/ui/screens/network_settings/events.cljs
@@ -31,4 +31,5 @@
   :connect-network
   (fn [cofx [_ network]]
     (merge (accounts-events/account-update cofx {:network network})
-           {:dispatch [:navigate-to-clean :accounts]})))
+           {:dispatch [:navigate-to-clean :accounts]
+            :stop-whisper nil})))


### PR DESCRIPTION
Symmetric keys generated via [`generateSymKeyFromPassword`](https://github.com/status-im/status-react/blob/6b66d3c4994748c0510b842d777ba6e7a65ed06d/src/status_im/protocol/web3/keys.cljs#L12) gets outdated after restarting node. Keys should be removed and generated again. 
Also applies to switching accounts, because accounts may be using different networks.

bug caused warnings like this
<img width="375" alt="screen shot 2017-10-03 at 16 36 52" src="https://user-images.githubusercontent.com/2364994/31134061-73bdbddc-a861-11e7-8fba-a62974619f0c.png">

status: ready

