### PR TITLE
Add progress-spinner to sign-transaction

### DIFF
--- a/src/status_im/ui/screens/wallet/send/db.cljs
+++ b/src/status_im/ui/screens/wallet/send/db.cljs
@@ -16,7 +16,10 @@
 (spec/def ::width double?)
 (spec/def ::camera-dimensions (spec/keys :req-un [::height ::width]))
 (spec/def ::camera-flashlight #{:on :off})
+(spec/def ::in-progress? boolean?)
 
 (spec/def :wallet/send-transaction (allowed-keys
-                                     :opt-un [::amount ::to-address ::to-name ::amount-error ::password ::wrong-password?
-                                              ::waiting-signal? ::signing? ::transaction-id ::later? ::camera-dimensions ::camera-flashlight]))
+                                     :opt-un [::amount ::to-address ::to-name ::amount-error ::password
+                                              ::waiting-signal? ::signing? ::transaction-id ::later?
+                                              ::camera-dimensions ::camera-flashlight ::in-progress?
+                                              ::wrong-password?]))

--- a/src/status_im/ui/screens/wallet/send/styles.cljs
+++ b/src/status_im/ui/screens/wallet/send/styles.cljs
@@ -61,3 +61,13 @@
    :font-size      15
    :letter-spacing -0.2
    :height         20})
+
+(def processing-view
+  {:position         :absolute
+   :top              0
+   :bottom           0
+   :right            0
+   :left             0
+   :align-items      :center
+   :justify-content  :center
+   :background-color (str styles/color-black "1A")})


### PR DESCRIPTION
### Summary:
As a user, when signing a transaction, I want feedback that signing is in progress.

### Steps to test:
- Open status
- Navigate to send a transaction
- Fill out the transaction and sign it
- An activity spinner should appear next to the signing button.
![screenshot_1507054730](https://user-images.githubusercontent.com/640347/31141617-46a87a3e-a84e-11e7-9cd7-e9256020f6b2.png)


status: ready

