### PR TITLE
Fix spelling issues in labels

### DIFF
--- a/src/status_im/translations/en.cljs
+++ b/src/status_im/translations/en.cljs
@@ -389,7 +389,7 @@
    :transaction-moved-text                "The transaction has been successfully moved to “Unsigned”"
    :transaction-moved-title               "Transaction Moved"
    :sign-later-title                      "Sign Transaction Later?"
-   :sign-later-text                       "You will be able to sign in in the transaction history"
+   :sign-later-text                       "You will be able to sign in the transaction history"
    :not-applicable                        "Not applicable for unsigned transactions"
 
    ;; Wallet Send


### PR DESCRIPTION
Noticed some small spelling issues in call, quick fixes

status: ready

