### PR TITLE
[Wallet] remove syncing animation

### DIFF
--- a/src/status_im/chat/screen.cljs
+++ b/src/status_im/chat/screen.cljs
@@ -114,7 +114,7 @@
   [view
    [status-bar]
    (let [hide-nav? (or (empty? accounts) show-actions? creating?)]
-     [toolbar/toolbar2 {}
+     [toolbar/toolbar2 {:show-sync-bar? true}
       (when-not hide-nav? toolbar/default-nav-back)
       [toolbar-content-view]
       [toolbar-action]])

--- a/src/status_im/chat/views/toolbar_content.cljs
+++ b/src/status_im/chat/views/toolbar_content.cljs
@@ -71,7 +71,7 @@
             show-actions? [:chat-ui-props :show-actions?]
             accounts      [:get-accounts]
             contact       [:get-in [:contacts/contacts @chat-id]]
-            sync-state    [:get :sync-state]
+            sync-state    [:sync-state]
             creating?     [:get :accounts/creating-account?]]
     [view (st/chat-name-view (or (empty? accounts)
                                  show-actions?

--- a/src/status_im/components/sync_state/gradient.cljs
+++ b/src/status_im/components/sync_state/gradient.cljs
@@ -74,7 +74,7 @@
 
 
 (defn sync-state-gradient-view []
-  (let [sync-state          (subscribe [:get :sync-state])
+  (let [sync-state          (subscribe [:sync-state])
         gradient-position   (anim/create-value 0)
         sync-state-opacity  (anim/create-value 0.0)
         in-progress-opacity (anim/create-value 0.0)

--- a/src/status_im/components/sync_state/offline.cljs
+++ b/src/status_im/components/sync_state/offline.cljs
@@ -17,7 +17,7 @@
                                   :duration 250})))
 
 (defn offline-view [_]
-  (let [sync-state       (subscribe [:get :sync-state])
+  (let [sync-state       (subscribe [:sync-state])
         network-status   (subscribe [:get :network-status])
         offline-opacity  (anim/create-value 0.0)
         on-update        (fn [_ _]

--- a/src/status_im/components/toolbar_new/view.cljs
+++ b/src/status_im/components/toolbar_new/view.cljs
@@ -98,7 +98,7 @@
   ([title] (toolbar2 nil title))
   ([props title] (toolbar2 props default-nav-back [content-title title]))
   ([props nav-item content-item] (toolbar2 props nav-item content-item [actions [{:image :blank}]]))
-  ([{:keys [background-color style flat? no-sync-bar?]}
+  ([{:keys [background-color style flat? show-sync-bar?]}
     nav-item
     content-item
     action-items]
@@ -114,7 +114,7 @@
        [rn/view st/flex]
        content-item)
      action-items]
-    (when-not no-sync-bar? [sync-state-gradient-view/sync-state-gradient-view])]))
+    (when show-sync-bar? [sync-state-gradient-view/sync-state-gradient-view])]))
 
 (defn toolbar
   "DEPRECATED

--- a/src/status_im/transactions/screens/transaction_details.cljs
+++ b/src/status_im/transactions/screens/transaction_details.cljs
@@ -54,7 +54,7 @@
   [{:keys [id] :as transaction} [:get :selected-transaction]
    {:keys [password]}           [:get :confirm-transactions]
    confirmed?                   [:get-in [:transaction-details-ui-props :confirmed?]]
-   sync-state                   [:get :sync-state]
+   sync-state                   [:sync-state]
    network-status               [:get :network-status]]
   {:component-did-update   #(when-not transaction (rf/dispatch [:navigate-to-modal :unsigned-transactions]))
    :component-will-unmount #(rf/dispatch [:set-in [:transaction-details-ui-props :confirmed?] false])}

--- a/src/status_im/transactions/screens/unsigned_transactions.cljs
+++ b/src/status_im/transactions/screens/unsigned_transactions.cljs
@@ -45,7 +45,7 @@
   [transactions       [:transactions]
    {:keys [password]} [:get :confirm-transactions]
    confirmed?         [:get-in [:transactions-list-ui-props :confirmed?]]
-   sync-state         [:get :sync-state]
+   sync-state         [:sync-state]
    network-status     [:get :network-status]]
   {:component-did-update   #(when-not (seq transactions) (rf/dispatch [:navigate-back]))
    :component-will-unmount #(rf/dispatch [:set-in [:transactions-list-ui-props :confirmed?] false])}

--- a/src/status_im/ui/screens/chats_list/views.cljs
+++ b/src/status_im/ui/screens/chats_list/views.cljs
@@ -38,7 +38,7 @@
    (act/add #(re-frame/dispatch [:navigate-to :new-chat]))])
 
 (defn toolbar-view []
-  [toolbar/toolbar2 {}
+  [toolbar/toolbar2 {:show-sync-bar? true}
    [toolbar/nav-button (act/hamburger drawer/open-drawer!)]
    [toolbar/content-title (i18n/label :t/chats)]
    [toolbar/actions
@@ -47,7 +47,7 @@
       (android-toolbar-actions))]])
 
 (defn toolbar-edit []
-  [toolbar/toolbar2 {}
+  [toolbar/toolbar2 {:show-sync-bar? true}
    [toolbar/nav-button (act/back #(re-frame/dispatch [:set-in [:chat-list-ui-props :edit?] false]))]
    [toolbar/content-title (i18n/label :t/edit-chats)]])
 

--- a/src/status_im/ui/screens/db.cljs
+++ b/src/status_im/ui/screens/db.cljs
@@ -63,7 +63,7 @@
 ;;;;NODE
 
 (spec/def ::sync-listening-started (spec/nilable boolean?))
-(spec/def ::sync-state (spec/nilable keyword?))
+(spec/def ::sync-state (spec/nilable #{:pending :in-progress :synced :done :offline}))
 (spec/def ::sync-data (spec/nilable map?))
 
 ;;;;NAVIGATION

--- a/src/status_im/ui/screens/subs.cljs
+++ b/src/status_im/ui/screens/subs.cljs
@@ -49,3 +49,7 @@
 (reg-sub :network
   (fn [db]
     (:network db)))
+
+(reg-sub :sync-state
+  (fn [db]
+    (:sync-state db)))

--- a/src/status_im/ui/screens/wallet/choose_recipient/views.cljs
+++ b/src/status_im/ui/screens/wallet/choose_recipient/views.cljs
@@ -24,8 +24,7 @@
                        :params  {:hide-actions? true}}]))
 
 (defn toolbar-view [camera-flashlight]
-  [toolbar/toolbar2 {:style        wallet.styles/toolbar
-                     :no-sync-bar? true}
+  [toolbar/toolbar2 {:style wallet.styles/toolbar}
    [toolbar/nav-button (act/back-white act/default-handler)]
    [toolbar/content-title {:color :white} (i18n/label :t/wallet-choose-recipient)]
    [toolbar/actions [{:icon      (if (= :on camera-flashlight) :icons/flash-active


### PR DESCRIPTION
### Summary:

Removes the syncing animation from the toolbar except in chat screens:
- only show the bar when show-sync-bar? param is true
- add subscription for sync-state to make testing easier
- add spec for sync-state

![screenshot_1507158936](https://user-images.githubusercontent.com/1181225/31204345-c43dadca-a96b-11e7-99f6-9c93444919f1.png)
![screenshot_1507158991](https://user-images.githubusercontent.com/1181225/31204346-c453bf0c-a96b-11e7-9182-f879183af621.png)
![screenshot_1507159038](https://user-images.githubusercontent.com/1181225/31204347-c45fa8a8-a96b-11e7-8e02-a7172e40e580.png)


### Steps to test:
- use :in-progress value in the :sync-state subscription to pretend sync is in progress (there is no sync on develop because it uses upstream RPC now?)
- build and run status
- check that the syncing line is only visible on chat screens

[comment]: # (PRs will only be accepted if squashed into single commit.)
status: ready (need squashing if subscription is accepted in PR)

