### PR TITLE
[bug] fix order of transactions in sections of transactions history

### DIFF
--- a/test/cljs/status_im/test/runner.cljs
+++ b/test/cljs/status_im/test/runner.cljs
@@ -4,6 +4,7 @@
             [status-im.test.contacts.events]
             [status-im.test.accounts.events]
             [status-im.test.wallet.events]
+            [status-im.test.wallet.transactions.subs]
             [status-im.test.profile.events]
             [status-im.test.chat.models.input]
             [status-im.test.components.main-tabs]
@@ -30,6 +31,7 @@
  'status-im.test.contacts.events
  'status-im.test.profile.events
  'status-im.test.wallet.events
+ 'status-im.test.wallet.transactions.subs
  'status-im.test.chat.models.input
  'status-im.test.components.main-tabs
  'status-im.test.handlers

--- a/test/cljs/status_im/test/wallet/transactions/subs.cljs
+++ b/test/cljs/status_im/test/wallet/transactions/subs.cljs
@@ -1,0 +1,29 @@
+(ns status-im.test.wallet.transactions.subs
+  (:require [cljs.test :refer [deftest is testing]]
+            reagent.core
+            [re-frame.core :as re-frame]
+            [day8.re-frame.test :refer [run-test-sync]]
+            status-im.ui.screens.db
+            status-im.ui.screens.subs
+            [status-im.ui.screens.events :as events]
+            [status-im.ui.screens.wallet.transactions.subs :as transactions-subs]))
+
+(def transactions [{:timestamp "1505912551000"}
+                   {:timestamp "1505764322000"}
+                   {:timestamp "1505750000000"}])
+
+(def grouped-transactions '({:title "20 Sep"
+                             :key :20170920
+                             :data
+                             ({:timestamp "1505912551000"})}
+                            {:title "18 Sep"
+                             :key :20170918
+                             :data
+                             ({:timestamp "1505764322000"}
+                              {:timestamp "1505750000000"})}))
+
+
+(deftest group-transactions-by-date
+  "Check if transactions are sorted by date"
+  (is (= (transactions-subs/group-transactions-by-date transactions)
+         grouped-transactions)))


### PR DESCRIPTION
order should be latest transaction first

### Summary:

Given those 2 transactions:

![screenshot_1507161608](https://user-images.githubusercontent.com/1181225/31205476-ef22e612-a971-11e7-8cf2-862c023c9ea6.png)
![screenshot_1507161619](https://user-images.githubusercontent.com/1181225/31205477-ef28483c-a971-11e7-98b2-a03c86ab62ad.png)

Before:

![screenshot_1507161229](https://user-images.githubusercontent.com/1181225/31205474-ef1f593e-a971-11e7-8c4e-f51adf16226d.png)

After:

![screenshot_1507161597](https://user-images.githubusercontent.com/1181225/31205475-ef202c92-a971-11e7-9fa0-11b6ee292e48.png)


### Steps to test:
- Open Status
- Open account with at least 2 transactions that occurred the same day (or send/receive two transactions)
- Check that the latest is first

[comment]: # (PRs will only be accepted if squashed into single commit.)
status: ready

