### PR TITLE
feature #1969 - public chats teaser in discover

### DIFF
--- a/src/status_im/translations/en.cljs
+++ b/src/status_im/translations/en.cljs
@@ -165,6 +165,9 @@
    :no-statuses-found                     "No statuses found"
    :chat                                  "Chat"
    :all                                   "All"
+   :public-chats                          "Public chats"
+   :soon                                  "Soon"
+   :public-chat-user-count                "{{count}} people"
 
    ;;settings
    :settings                              "Settings"

--- a/src/status_im/ui/screens/discover/components/views.cljs
+++ b/src/status_im/ui/screens/discover/components/views.cljs
@@ -12,14 +12,16 @@
             [status-im.components.icons.vector-icons :as vi]
             [status-im.i18n :as i18n]))
 
-(defn title [label-kw action-kw action-fn]
+(defn title [label-kw action-kw action-fn active?]
   [react/view st/title
    [react/text {:style      (get-in platform/platform-specific [:component-styles :discover :subtitle])
                 :uppercase? (get-in platform/platform-specific [:discover :uppercase-subtitles?])
                 :font       :medium}
     (i18n/label label-kw)]
    [react/touchable-highlight {:on-press action-fn}
-    [react/view {} [react/text {:style st/title-action-text} (i18n/label action-kw)]]]])
+    [react/view {}
+     [react/text {:style (st/title-action-text active?)}
+      (i18n/label action-kw)]]]])
 
 (defn tags-menu [tags]
   [react/view st/tag-title-container

--- a/src/status_im/ui/screens/discover/styles.cljs
+++ b/src/status_im/ui/screens/discover/styles.cljs
@@ -1,8 +1,6 @@
 (ns status-im.ui.screens.discover.styles
   (:require-macros [status-im.utils.styles :refer [defnstyle]])
-  (:require [status-im.components.styles :refer [color-white
-                                                 color-light-gray
-                                                 color-blue]]
+  (:require [status-im.components.styles :as styles]
             [status-im.components.toolbar.styles :refer [toolbar-background2]]
             [status-im.components.tabs.styles :as tabs-st]
             [status-im.utils.platform :as p]))
@@ -22,7 +20,7 @@
 
 (def empty-view
   {:flex             1
-   :background-color color-white
+   :background-color styles/color-white
    :align-items      :center
    :justify-content  :center})
 
@@ -40,7 +38,7 @@
   {})
 
 (def tag-button
-  {:color           color-blue
+  {:color           styles/color-blue
    :font-size       14
    :padding-right   5
    :padding-bottom  2
@@ -48,7 +46,7 @@
    :justify-content :center})
 
 (def tag-name
-  {:color            color-blue
+  {:color            styles/color-blue
    :background-color :white
    :font-size        14
    :align-items      :center
@@ -137,7 +135,7 @@
 
 (def discover-tag-container
   {:flex            1
-   :backgroundColor color-light-gray})
+   :backgroundColor styles/color-light-gray})
 
 (def tag-title-scroll
   {:flex           1
@@ -151,7 +149,7 @@
    :flex-direction "row"})
 
 (def tag-title
-  {:color          color-blue
+  {:color          styles/color-blue
    :font-size      14
    :padding-right  5
    :padding-bottom 2})
@@ -166,7 +164,7 @@
 
 (def discover-container
   {:flex            1
-   :backgroundColor color-white})
+   :backgroundColor styles/color-white})
 
 (def list-container
   {:flex 1})
@@ -175,8 +173,10 @@
   {:width  17
    :height 17})
 
-(def title-action-text
-  {:color "rgb(110, 0, 228)"})
+(defn title-action-text  [active?]
+  {:color (if active?
+            styles/color-blue
+            styles/color-gray-transparent)})
 
 (def recent-statuses-preview-container
   {:background-color toolbar-background2})
@@ -189,3 +189,40 @@
    :margin-bottom    4
    :margin-right     2
    :background-color :white})
+
+(def public-chats-item-container
+  {:flex-direction :row
+   :padding        3})
+
+(def public-chats-icon-width-ratio
+  0.15)
+
+(def public-chats-icon-container
+  {:flex public-chats-icon-width-ratio})
+
+(defn public-chats-icon [color]
+  {:width            50
+   :height           50
+   :border-radius    25
+   :background-color color
+   :flex-direction   :row
+   :justify-content  :center
+   :align-items      :center})
+
+(def public-chats-icon-text
+  {:font-size 25
+   :color     styles/color-gray-transparent-light})
+
+(def public-chats-item-inner
+  {:flex           (- 1 public-chats-icon-width-ratio)
+   :margin-left    10
+   :flex-direction :column})
+
+(def public-chats-item-name-container
+  {:flex-direction :row})
+
+(def public-chats-item-name-text
+  {:color       styles/color-gray-transparent
+   :font-weight :bold
+   :font-size   16
+   :margin-left 5})


### PR DESCRIPTION
fixes #1969

### Summary:
A hardcoded teaser preview for Public chats is now added to the main Discover screen. It's placed at the bottom of the screen (see attached image).

### Steps to test:
- Open Status
- Open Discover screen and scroll down to see Public chats section
- It's intentionally disabled, so other than seeing it sit there, you can't really do anything with it at the moment.

Designs: https://app.zeplin.io/project/5863cdcee68455850f1929f2/screen/59ca26fd3db52a686d640e98 
(first screen, bottom)

Note: the screen should look reasonably like on the design, but we will do design once over anyway when all Discover pieces are in place.


[comment]: # (PRs will only be accepted if squashed into single commit.)
status: ready

