### PR TITLE
[bug] fix #2003 unsigned transaction count upon expiration

### DIFF
--- a/src/status_im/components/styles.cljs
+++ b/src/status_im/components/styles.cljs
@@ -25,6 +25,7 @@
 (def color-gray7 "#9fa3b4")
 (def color-gray8 "#6E777E")
 (def color-gray9 "#E9EBEC")
+(def color-gray10 "#9BA3A8")
 (def color-dark "#49545d")
 (def color-steel "#838b91")
 (def color-white "white")

--- a/src/status_im/components/tabs/styles.cljs
+++ b/src/status_im/components/tabs/styles.cljs
@@ -35,11 +35,13 @@
    :border-bottom-width 2
    :border-bottom-color styles/color-white})
 
+(def tab-title-wrapper
+  {:min-width  60
+   :margin-top 3})
+
 (defnstyle tab-title [active? text-only?]
   {:ios        {:font-size (if text-only? 15 11)}
    :android    {:font-size (if text-only? 14 12)}
-   :margin-top 3
-   :min-width  60
    :text-align :center
    :color      (cond
                  active? styles/color-blue4

--- a/src/status_im/components/tabs/styles.cljs
+++ b/src/status_im/components/tabs/styles.cljs
@@ -35,10 +35,6 @@
    :border-bottom-width 2
    :border-bottom-color styles/color-white})
 
-(def tab-title-wrapper
-  {:min-width  60
-   :margin-top 3})
-
 (defnstyle tab-title [active? text-only?]
   {:ios        {:font-size (if text-only? 15 11)}
    :android    {:font-size (if text-only? 14 12)}
@@ -62,9 +58,9 @@
 
 (defn main-swiper [tabs-hidden?]
   (merge
-    swiper
-    {:position :absolute
-     :top      0
-     :left     0
-     :right    0
-     :bottom   (if tabs-hidden? 0 tabs-height)}))
+   swiper
+   {:position :absolute
+    :top      0
+    :left     0
+    :right    0
+    :bottom   (if tabs-hidden? 0 tabs-height)}))

--- a/src/status_im/components/tabs/views.cljs
+++ b/src/status_im/components/tabs/views.cljs
@@ -9,20 +9,25 @@
             [status-im.components.tabs.styles :as tabs.styles]
             [status-im.utils.platform :as platform]))
 
-(defn- tab [{:keys [view-id title icon-active icon-inactive style-active selected-view-id on-press]}]
+(defn- tab [{:keys [view-id title title-fn icon-active icon-inactive style-active selected-view-id on-press]
+             :or {title-fn react/text}}]
   (let [active? (= view-id selected-view-id)
         text-only? (nil? icon-active)]
-    [react/touchable-highlight {:style    (merge tabs.styles/tab (if (and active? style-active) style-active))
+    [react/touchable-highlight {:style    (merge tabs.styles/tab
+                                                 (when (and active? style-active)
+                                                   style-active))
                                 :disabled active?
-                                :on-press  #(if on-press (on-press view-id) (dispatch [:navigate-to-tab view-id]))}
+                                :on-press #(if on-press
+                                             (on-press view-id)
+                                             (dispatch [:navigate-to-tab view-id]))}
      [react/view {:style tabs.styles/tab-container}
       (when-let [icon (if active? icon-active icon-inactive)]
         [react/view
          [vi/icon icon (tabs.styles/tab-icon active?)]])
-      [react/view
-       [react/text (merge (if text-only? {:uppercase? (get-in platform/platform-specific [:uppercase?])})
-                          {:style (tabs.styles/tab-title active? text-only?)})
-        title]]]]))
+      [react/view {:style tabs.styles/tab-title-wrapper}
+       (title-fn {:uppercase? (and text-only? (get-in platform/platform-specific [:uppercase?]))
+                  :style      (tabs.styles/tab-title active? text-only?)}
+                 title)]]]))
 
 (defn- create-tab [index data selected-view-id on-press style-active]
   (let [data (merge data {:key              index
@@ -90,28 +95,29 @@
         scroll-ended      (async/chan 10)]
     (r/create-class
       {:component-did-mount
-                     #(start-scrolling-loop scroll-start scroll-ended)
+       #(start-scrolling-loop scroll-start scroll-ended)
        :component-will-update
-                     (fn []
-                       (if @swiped?
-                         (reset! swiped? false)
-                         (when @main-swiper
-                           (let [to (scroll-to tab-list @prev-view-id @view-id)]
-                             (async/put! scroll-start [@main-swiper to])))))
+       (fn []
+         (if @swiped?
+           (reset! swiped? false)
+           (when @main-swiper
+             (let [to (scroll-to tab-list @prev-view-id @view-id)]
+               (async/put! scroll-start [@main-swiper to])))))
        :display-name "swipable-tabs"
        :reagent-render
-                     (fn []
-                       [react/view {:style style}
-                        [tabs {:selected-view-id @view-id
-                               :tab-list         tab-list
-                               :style            style-tabs
-                               :style-tab-active style-tab-active
-                               :on-press         on-view-change}]
-                        [react/swiper (merge tabs.styles/swiper
-                                             {:index                  (get-tab-index tab-list @view-id)
-                                              :ref                    #(reset! main-swiper %)
-                                              :loop                   false
-                                              :on-momentum-scroll-end (on-scroll-end on-view-change tab-list swiped? scroll-ended view-id)})
-                         (doall
-                           (map-indexed (fn [index {screen :screen}]
-                                          (with-meta screen {:key index})) tab-list))]])})))
+       (fn []
+         [react/view {:style style}
+          [tabs {:selected-view-id @view-id
+                 :tab-list         tab-list
+                 :style            style-tabs
+                 :style-tab-active style-tab-active
+                 :on-press         on-view-change}]
+          [react/swiper (merge tabs.styles/swiper
+                               {:index                  (get-tab-index tab-list @view-id)
+                                :ref                    #(reset! main-swiper %)
+                                :loop                   false
+                                :on-momentum-scroll-end (on-scroll-end on-view-change tab-list swiped? scroll-ended view-id)})
+           (doall
+            (map-indexed (fn [index {screen :screen}]
+                           (with-meta screen {:key index}))
+                         tab-list))]])})))

--- a/src/status_im/components/tabs/views.cljs
+++ b/src/status_im/components/tabs/views.cljs
@@ -1,33 +1,25 @@
 (ns status-im.components.tabs.views
-  (:require-macros [status-im.utils.views :refer [defview]]
-                   [cljs.core.async.macros :as am])
-  (:require [cljs.core.async :as async]
-            [reagent.core :as r]
-            [re-frame.core :refer [subscribe dispatch]]
-            [status-im.components.react :as react]
+  (:require [re-frame.core :refer [dispatch]]
             [status-im.components.icons.vector-icons :as vi]
+            [status-im.components.react :as react]
             [status-im.components.tabs.styles :as tabs.styles]
-            [status-im.utils.platform :as platform]))
+            [status-im.utils.platform :as platform])
+  (:require-macros [status-im.utils.views :refer [defview]]))
 
-(defn- tab [{:keys [view-id title title-fn icon-active icon-inactive style-active selected-view-id on-press]
-             :or {title-fn react/text}}]
+(defn- tab [{:keys [view-id title icon-active icon-inactive style-active selected-view-id on-press]}]
   (let [active? (= view-id selected-view-id)
         text-only? (nil? icon-active)]
-    [react/touchable-highlight {:style    (merge tabs.styles/tab
-                                                 (when (and active? style-active)
-                                                   style-active))
+    [react/touchable-highlight {:style    (merge tabs.styles/tab (if (and active? style-active) style-active))
                                 :disabled active?
-                                :on-press #(if on-press
-                                             (on-press view-id)
-                                             (dispatch [:navigate-to-tab view-id]))}
+                                :on-press  #(if on-press (on-press view-id) (dispatch [:navigate-to-tab view-id]))}
      [react/view {:style tabs.styles/tab-container}
       (when-let [icon (if active? icon-active icon-inactive)]
         [react/view
          [vi/icon icon (tabs.styles/tab-icon active?)]])
-      [react/view {:style tabs.styles/tab-title-wrapper}
-       (title-fn {:uppercase? (and text-only? (get-in platform/platform-specific [:uppercase?]))
-                  :style      (tabs.styles/tab-title active? text-only?)}
-                 title)]]]))
+      [react/view
+       [react/text (merge (if text-only? {:uppercase? (get-in platform/platform-specific [:uppercase?])})
+                          {:style (tabs.styles/tab-title active? text-only?)})
+        title]]]]))
 
 (defn- create-tab [index data selected-view-id on-press style-active]
   (let [data (merge data {:key              index
@@ -46,78 +38,5 @@
 (defn tabs [{:keys [style style-tab-active tab-list selected-view-id on-press]}]
   [tabs-container style
    (into
-     [react/view tabs.styles/tabs-inner-container]
-     (map-indexed #(create-tab %1 %2 selected-view-id on-press style-tab-active) tab-list))])
-
-;; Swipable tabs
-
-(defn- tab->index [tabs] (reduce #(assoc %1 (:view-id %2) (count %1)) {} tabs))
-
-(defn get-tab-index [tabs view-id]
-  (get (tab->index tabs) view-id 0))
-
-(defn index->tab [tabs] (clojure.set/map-invert (tab->index tabs)))
-
-(defn scroll-to [tab-list prev-view-id view-id]
-  (let [p (get-tab-index tab-list prev-view-id)
-        n (get-tab-index tab-list view-id)]
-    (- n p)))
-
-(defonce scrolling? (atom false))
-
-(defn on-scroll-end [on-view-change tabs swiped? scroll-ended view-id]
-  (fn [_ state]
-    (when @scrolling?
-      (async/put! scroll-ended true))
-    (let [{:strs [index]} (js->clj state)
-          new-view-id ((index->tab tabs) index)]
-      (if new-view-id
-        (when-not (= @view-id new-view-id)
-          (reset! swiped? true)
-          (on-view-change new-view-id))))))
-
-(defn start-scrolling-loop
-  "Loop that synchronizes tabs scrolling to avoid an inconsistent state."
-  [scroll-start scroll-ended]
-  (am/go-loop [[swiper to] (async/<! scroll-start)]
-              ;; start scrolling
-              (reset! scrolling? true)
-              (.scrollBy swiper to)
-              ;; lock loop until scroll ends
-              (async/alts! [scroll-ended (async/timeout 2000)])
-              (reset! scrolling? false)
-              (recur (async/<! scroll-start))))
-
-(defn swipable-tabs [{:keys [style style-tabs style-tab-active on-view-change]} tab-list prev-view-id view-id]
-  (let [swiped?           (r/atom false)
-        main-swiper       (r/atom nil)
-        scroll-start      (async/chan 10)
-        scroll-ended      (async/chan 10)]
-    (r/create-class
-      {:component-did-mount
-       #(start-scrolling-loop scroll-start scroll-ended)
-       :component-will-update
-       (fn []
-         (if @swiped?
-           (reset! swiped? false)
-           (when @main-swiper
-             (let [to (scroll-to tab-list @prev-view-id @view-id)]
-               (async/put! scroll-start [@main-swiper to])))))
-       :display-name "swipable-tabs"
-       :reagent-render
-       (fn []
-         [react/view {:style style}
-          [tabs {:selected-view-id @view-id
-                 :tab-list         tab-list
-                 :style            style-tabs
-                 :style-tab-active style-tab-active
-                 :on-press         on-view-change}]
-          [react/swiper (merge tabs.styles/swiper
-                               {:index                  (get-tab-index tab-list @view-id)
-                                :ref                    #(reset! main-swiper %)
-                                :loop                   false
-                                :on-momentum-scroll-end (on-scroll-end on-view-change tab-list swiped? scroll-ended view-id)})
-           (doall
-            (map-indexed (fn [index {screen :screen}]
-                           (with-meta screen {:key index}))
-                         tab-list))]])})))
+    [react/view tabs.styles/tabs-inner-container]
+    (map-indexed #(create-tab %1 %2 selected-view-id on-press style-tab-active) tab-list))])

--- a/src/status_im/ui/screens/wallet/events.cljs
+++ b/src/status_im/ui/screens/wallet/events.cljs
@@ -141,3 +141,8 @@
   :wallet/discard-unsigned-transaction
   (fn [_ [_ transaction-id]]
     {:discard-transaction transaction-id}))
+
+(handlers/register-handler-db
+  :change-tab
+  (fn [db [_ current-tab]]
+    (assoc-in db [:wallet :current-tab] current-tab)))

--- a/src/status_im/ui/screens/wallet/navigation.cljs
+++ b/src/status_im/ui/screens/wallet/navigation.cljs
@@ -5,7 +5,7 @@
 (defmethod navigation/preload-data! :wallet
   [db _]
   (re-frame/dispatch [:update-wallet])
-  db)
+  (assoc-in db [:wallet :current-tab] 0))
 
 (defmethod navigation/preload-data! :wallet-transactions
   [db _]

--- a/src/status_im/ui/screens/wallet/transactions/styles.cljs
+++ b/src/status_im/ui/screens/wallet/transactions/styles.cljs
@@ -1,5 +1,7 @@
 (ns status-im.ui.screens.wallet.transactions.styles
-  (:require [status-im.components.styles :as styles]))
+  (:require-macros [status-im.utils.styles :refer [defnstyle defstyle]])
+  (:require [status-im.components.styles :as styles]
+            [status-im.utils.platform :as platform]))
 
 (def error-container
   {:align-self       :center
@@ -19,13 +21,32 @@
   {:flex             1
    :background-color styles/color-white})
 
-(def tabs
-  {:border-bottom-width 1
-   :border-bottom-color styles/color-gray10-transparent})
+(def tab-height (if platform/ios? 51 55))
 
-(def tab-active
-  {:border-bottom-width 2
-   :border-bottom-color styles/color-blue4})
+(def tabs-container
+  {:flexDirection :row})
+
+(defnstyle tab [active?]
+  {:flex                1
+   :height              tab-height
+   :justify-content     :center
+   :align-items         :center
+   :border-bottom-width (if active? 2 1)
+   :border-bottom-color (if active?
+                          styles/color-blue4
+                          styles/color-gray10-transparent)})
+
+(defnstyle tab-title [active?]
+  {:ios        {:font-size 15}
+   :android    {:font-size 14}
+   :text-align :center
+   :color      (if active?
+                 styles/color-blue4
+                 styles/color-black)})
+
+(def tab-unsigned-transactions-count
+  (merge (tab-title false)
+         {:color styles/color-gray10}))
 
 (def forward
   {:color styles/color-gray7})

--- a/src/status_im/ui/screens/wallet/transactions/subs.cljs
+++ b/src/status_im/ui/screens/wallet/transactions/subs.cljs
@@ -16,6 +16,11 @@
   (fn [wallet]
     (get-in wallet [:errors :transactions-update])))
 
+(reg-sub :wallet.transactions/current-tab
+  :<- [:wallet]
+  (fn [wallet]
+    (get wallet :current-tab 0)))
+
 (reg-sub :wallet.transactions/transactions
   :<- [:wallet]
   (fn [wallet]

--- a/src/status_im/ui/screens/wallet/transactions/views.cljs
+++ b/src/status_im/ui/screens/wallet/transactions/views.cljs
@@ -120,17 +120,25 @@
                       :render-fn       render-transaction
                       :empty-component (empty-text (i18n/label :t/transactions-unsigned-empty))}]]))
 
-(defn- unsigned-transactions-title [unsigned-transactions-count]
-  (str (i18n/label :t/transactions-unsigned)
-       (if (pos? unsigned-transactions-count) (str " " unsigned-transactions-count))))
+(defn unsigned-transactions-title [{:keys [uppercase? style]} title]
+  (let [unsigned-transactions-count (re-frame/subscribe [:wallet.transactions/unsigned-transactions-count])]
+    [react/view {:flex-direction :row}
+     [react/text {:style style
+                  :uppercase? uppercase?}
+      (i18n/label :t/transactions-unsigned)]
+     (when (pos? @unsigned-transactions-count)
+       [react/text {:style (merge
+                            style
+                            {:color styles/color-gray10})}
+        (str " " @unsigned-transactions-count)])]))
 
 (defn- tab-list [unsigned-transactions-count]
   [{:view-id :wallet-transactions-history
     :title   (i18n/label :t/transactions-history)
     :screen  [history-list]}
-   {:view-id :wallet-transactions-unsigned
-    :title   (unsigned-transactions-title unsigned-transactions-count)
-    :screen  [unsigned-list]}])
+   {:view-id  :wallet-transactions-unsigned
+    :title-fn unsigned-transactions-title
+    :screen   [unsigned-list]}])
 
 ;; Filter history
 


### PR DESCRIPTION
fixing #2003

Before:
![screenshot_1507207147](https://user-images.githubusercontent.com/1181225/31227711-28bc3ba8-a9db-11e7-89d0-7eb76f422621.png)
After:
![screenshot_1507263339](https://user-images.githubusercontent.com/1181225/31262801-de18223c-aa5d-11e7-8fa9-c926a13f3867.png)
![screenshot_1507263366](https://user-images.githubusercontent.com/1181225/31262802-de347644-aa5d-11e7-8dbb-2303b6c535a4.png)


### Summary:


Fix color of transaction count and refresh when transactions expire

this fixed involved changing the swiper so that a function can be passed as title instead of a string.
this allows developpers to pass custom elements as titles and still use style and variables that are computed when tab is built

edit: completely reworked the swiper

### Steps to test:
- Open Status
- Send a transaction but sign later
- Go to unsigned tab and wait 5 min for the transaction to expire
- Count and transaction should have disappeared

[comment]: # (PRs will only be accepted if squashed into single commit.)
status: ready
