### PR TITLE
[BUG #1991] Make sure provided eth address is valid

### DIFF
--- a/src/status_im/translations/en.cljs
+++ b/src/status_im/translations/en.cljs
@@ -401,6 +401,7 @@
    :wallet-choose-recipient               "Choose Recipient"
    :wallet-choose-from-contacts           "Choose From Contacts"
    :wallet-address-from-clipboard         "Use Address From Clipboard"
+   :wallet-invalid-address                "Address is invalid"
    :wallet-browse-photos                  "Browse Photos"
    :validation-amount-invalid             "Amount is not valid"
    :validation-amount-invalid-number      "Amount is not a valid number"

--- a/src/status_im/ui/screens/events.cljs
+++ b/src/status_im/ui/screens/events.cljs
@@ -177,6 +177,11 @@
   (fn []
     (notifications/get-fcm-token)))
 
+(reg-fx
+  :show-error
+  (fn [content]
+    (utils/show-popup "Error" content)))
+
 (re-frame/reg-fx
   :show-confirmation
   (fn [{:keys [title content confirm-button-text on-accept on-cancel]}]


### PR DESCRIPTION
fix for #1991

### Summary:
Properly handle incorrect recipient address

### Steps to test:
- Open Status
- Navigate wallet / send screen
- Provide an incorrect recipient either from clipboard or qr-code
- Validtae a popup appears and no recipient is set

status: ready

