### PR TITLE
Move message send until after configuration should be loaded

### DIFF
--- a/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusModule.java
+++ b/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusModule.java
@@ -65,7 +65,6 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
         if (status == null) {
             status = new ServiceConnector(currentActivity, StatusService.class);
             status.registerHandler(this);
-
         }
 
         status.bindService();
@@ -220,6 +219,7 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
         String res = Statusgo.StartNode(config);
         Log.d(TAG, "StartNode result: " + res);
         Log.d(TAG, "Geth node started");
+	status.sendMessage();
     }
 
     private String getOldExternalDir() {
@@ -305,7 +305,6 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
     @ReactMethod
     public void startNode(final String config) {
         Log.d(TAG, "startNode");
-        status.sendMessage();
         if (!checkAvailability()) {
             return;
         }


### PR DESCRIPTION
One possible solution for #1130 

### Summary:
One of the things that prevents end-to-end tests from running is a race condition between the `StatusService` handler and the Geth node. If the handler is started before the Geth node is configured, `StatusService` doesn't have a reference to send status messages to, and the app never receives the message that the Geth node is up. This should address the race condition, I'd like to run some end-to-end tests against this to determine whether it solves one of the two problems.

### Steps to test:
- Run end-to-end tests
- Look specifically for
```
3678 E StatusService: java.lang.NullPointerException: Attempt to invoke virtual method 'void android.os.Messenger.send(android.os.Message)' on a null object reference
10-05 00:34:59.420  3562  3678 E StatusService: 	at im.status.ethereum.module.StatusService.sendReply(StatusService.java:92)
10-05 00:34:59.420  3562  3678 E StatusService: 	at im.status.ethereum.module.StatusService.signalEvent(StatusService.java:59)
```

In the logcat for the CI run if the test fails and the console doesn't send a password prompt.


status: ready

