### PR TITLE
Assert flat-list sequential data

### DIFF
--- a/src/status_im/components/list/views.cljs
+++ b/src/status_im/components/list/views.cljs
@@ -86,6 +86,7 @@
   "A wrapper for FlatList.
    See https://facebook.github.io/react-native/docs/flatlist.html"
   [{:keys [data render-fn empty-component] :as props}]
+  {:pre [(sequential? data)]}
   (if (and (empty? data) empty-component)
     ;; TODO(jeluard) remove when native :ListEmptyComponent is supported
     empty-component


### PR DESCRIPTION
Deals with vector-of-maps vs map-of-maps issues, e.g. map-of-maps hangs with bad errors from React Native side

I got bit by this bug for a while, and IIRC I've seen this bug happen once or twice to other people. Ideally this PR would solve this class of bug for more root components but I figured this was a good start.

Testing:
- Check that some common lists (chat lists, contacts) still show as expected
- No UX changes, just assertions for developers

Can probably merge straight away though, as something is likely to be wrong if we aren't rendering `sequential` data in lists.

status: ready