### PR TITLE
Fix precondition for flat-list

### DIFF
--- a/src/status_im/components/list/views.cljs
+++ b/src/status_im/components/list/views.cljs
@@ -86,7 +86,8 @@
   "A wrapper for FlatList.
    See https://facebook.github.io/react-native/docs/flatlist.html"
   [{:keys [data render-fn empty-component] :as props}]
-  {:pre [(sequential? data)]}
+  {:pre [(or (nil? data)
+             (sequential? data))]}
   (if (and (empty? data) empty-component)
     ;; TODO(jeluard) remove when native :ListEmptyComponent is supported
     empty-component


### PR DESCRIPTION
The flat-list component handles the nil case but the precondition does
not.

This is currently causing transaction list failures when the list of
unsigned transactions is empty.

### Summary:
When the unsigned transaction list is empty, an assert fails, breaking operations on unsigned transactions.

- Navigate to wallet
- List transactions with no unsigned transactions
- Assert fails

![screenshot_1507556604](https://user-images.githubusercontent.com/640347/31341281-6b5d6f5c-acdf-11e7-9549-08a74f07bbbc.png)


### Steps to test:
- Navigate to wallet
- List transactions with no unsigned transactions
- Empty list element displays correctly, signing and deletion of transactions works.


status: ready

