### PR TITLE
Add loading spinner logic to transaction-modal

### DIFF
--- a/src/status_im/ui/screens/wallet/send/views.cljs
+++ b/src/status_im/ui/screens/wallet/send/views.cljs
@@ -182,4 +182,5 @@
          in-progress?]
         [sign-buttons amount-error to-address amount true #(re-frame/dispatch [:navigate-back])])
       (when signing?
-        [sign-panel])]]))
+        [sign-panel])]
+     (when in-progress? [react/view send.styles/processing-view])]))


### PR DESCRIPTION
fixes #2046 

### Summary:
Signing progress spinner logic was not applied to signing from a modal, so when signing from unsigned transactions, we had no spinner.

### Steps to test:
- Open status
- Navigate to send transaction
- Sign Later and confirm.
- Navigate to transaction list
- Navigate to unsigned
- Click "Sign" on transaction
- Upon signing, loading spinner should now appear.

[comment]: # (PRs will only be accepted if squashed into single commit.)
status: ready

