### PR TITLE
Discover: Fix toolbar title styling

### DIFF
--- a/src/status_im/ui/screens/discover/all_dapps/views.cljs
+++ b/src/status_im/ui/screens/discover/all_dapps/views.cljs
@@ -57,8 +57,7 @@
       [react/view styles/all-dapps-container
        [toolbar/toolbar2 {}
         toolbar/default-nav-back
-        ;; TODO(oskarth): Lowercase and wrong style for some reason
-        [react/view [react/text :t/dapps]]]
+        [toolbar/content-title (i18n/label :t/dapps)]]
        [list/flat-list {:data                    (vals all-dapps)
                         :render-fn               render-dapp
                         :num-columns             3

--- a/src/status_im/ui/screens/discover/styles.cljs
+++ b/src/status_im/ui/screens/discover/styles.cljs
@@ -131,6 +131,7 @@
 
 (def all-dapps-container
   {:flex             1
+   :margin-top       16
    :background-color toolbar-background2})
 
 (def all-dapps-flat-list


### PR DESCRIPTION
Center, margin, font

Now:
<img width=320 src=https://user-images.githubusercontent.com/1552237/31347543-f92aa86c-ad1c-11e7-868b-e56d6982887e.png />

status: ready