### PR TITLE
Add ios-specific permissions checking

### DIFF
--- a/src/status_im/ui/screens/wallet/main/views.cljs
+++ b/src/status_im/ui/screens/wallet/main/views.cljs
@@ -61,11 +61,6 @@
         (str (when pos-change? "+") change "%")
         "-%")]]))
 
-(defn- wallet-send []
-  (rf/dispatch [:navigate-to :wallet-send-transaction])
-  (when platform/android?
-    (rf/dispatch [:request-permissions [:camera]])))
-
 (defn main-section [usd-value change error-message]
   [react/view {:style styles/main-section}
    (when error-message
@@ -79,7 +74,8 @@
       (i18n/label :t/wallet-total-value)]
      [change-display change]]
     [react/view {:style (merge button.styles/buttons-container styles/buttons) :button-text-style styles/main-button-text}
-     [btn/button {:on-press wallet-send :style (button.styles/button-bar :first)}
+     [btn/button {:on-press #(rf/dispatch [:navigate-to :wallet-send-transaction])
+                  :style    (button.styles/button-bar :first)}
       (i18n/label :t/wallet-send)]
      [btn/button {:on-press #(rf/dispatch [:navigate-to :wallet-request-transaction]) :style (button.styles/button-bar :other)}
       (i18n/label :t/wallet-request)]

--- a/src/status_im/ui/screens/wallet/send/db.cljs
+++ b/src/status_im/ui/screens/wallet/send/db.cljs
@@ -16,10 +16,11 @@
 (spec/def ::width double?)
 (spec/def ::camera-dimensions (spec/keys :req-un [::height ::width]))
 (spec/def ::camera-flashlight #{:on :off})
+(spec/def ::camera-permitted? boolean?)
 (spec/def ::in-progress? boolean?)
 
 (spec/def :wallet/send-transaction (allowed-keys
                                      :opt-un [::amount ::to-address ::to-name ::amount-error ::password
                                               ::waiting-signal? ::signing? ::transaction-id ::later?
                                               ::camera-dimensions ::camera-flashlight ::in-progress?
-                                              ::wrong-password?]))
+                                              ::wrong-password? ::camera-permitted?]))

--- a/src/status_im/ui/screens/wallet/send/views.cljs
+++ b/src/status_im/ui/screens/wallet/send/views.cljs
@@ -96,6 +96,14 @@
 (defn- sufficient-funds? [amount balance]
   (<= amount (money/wei->ether balance)))
 
+(defn request-camera-permissions []
+  (when platform/android?
+    (re-frame/dispatch [:request-permissions [:camera]]))
+  (camera/request-access
+   (fn [permitted?]
+     (re-frame/dispatch [:set-in [:wallet/send-transaction :camera-permitted?] permitted?])
+     (re-frame/dispatch [:navigate-to :choose-recipient]))))
+
 (defview send-transaction []
   (letsubs [balance      [:balance]
             amount       [:get-in [:wallet/send-transaction :amount]]
@@ -114,7 +122,7 @@
           [react/view wallet.styles/choose-participant-container
            [components/choose-recipient {:address  to-address
                                          :name     to-name
-                                         :on-press #(re-frame/dispatch [:navigate-to :choose-recipient])}]]
+                                         :on-press request-camera-permissions}]]
           [react/view wallet.styles/choose-wallet-container
            [components/choose-wallet]]
           [react/view wallet.styles/amount-container


### PR DESCRIPTION
fixes #2057 

### Summary:
- Move permission check from main screen (no longer makes sense given
  choose recipient is reached from send)
- Add ios-specific display and permission checks

### Steps to test:
- Open Status first time
- Create password
- Open wallet
- Tap Send
- Tap on Recipient field
- Deny access to camera on Choose Recipient screen
- close Choose Recipient screen
- Tap on Recipient field again, app should not crash

status: ready

