### PR TITLE
'Property must be of type: string' popup after providing confirmation code [feature/command-scopes]

### DIFF
--- a/src/status_im/chat/events/sign_up.cljs
+++ b/src/status_im/chat/events/sign_up.cljs
@@ -107,11 +107,11 @@
   ::contacts-synced
   [re-frame/trim-v (re-frame/inject-cofx :random-id)]
   (fn [{:keys [db random-id] :as cofx} [contacts]]
-    (-> db
+    (-> {:db db}
         (as-> fx
-            (merge fx
-                   (accounts-events/account-update (assoc cofx :db (:db fx)) {:signed-up? true})
-                   {:dispatch (sign-up/contacts-synchronised-event random-id)})))))
+              (merge fx
+                     (accounts-events/account-update (assoc cofx :db (:db fx)) {:signed-up? true})
+                     {:dispatch (sign-up/contacts-synchronised-event random-id)})))))
 
 (handlers/register-handler-fx
   ::http-request-failure


### PR DESCRIPTION
Fixes #2060 