### PR TITLE
Upgrade status-go to bugfix-no-messaging-rinkeby-gd04e667-12 (geth 1.7 rebase)

### DIFF
--- a/modules/react-native-status/android/build.gradle
+++ b/modules/react-native-status/android/build.gradle
@@ -16,5 +16,5 @@ dependencies {
     compile 'com.facebook.react:react-native:+'
     compile 'com.instabug.library:instabug:3+'
     compile 'status-im:function:0.0.1'
-    compile(group: 'status-im', name: 'status-go', version: 'bugfix-fix-loop-memory-alignment-g6d1096c-2', ext: 'aar')
+    compile(group: 'status-im', name: 'status-go', version: 'bugfix-network-switch-panic-gab8d1f1-11', ext: 'aar')
 }

--- a/modules/react-native-status/android/build.gradle
+++ b/modules/react-native-status/android/build.gradle
@@ -16,5 +16,5 @@ dependencies {
     compile 'com.facebook.react:react-native:+'
     compile 'com.instabug.library:instabug:3+'
     compile 'status-im:function:0.0.1'
-    compile(group: 'status-im', name: 'status-go', version: 'develop-ge61c39b', ext: 'aar')
+    compile(group: 'status-im', name: 'status-go', version: 'develop-g90acfed', ext: 'aar')
 }

--- a/modules/react-native-status/android/build.gradle
+++ b/modules/react-native-status/android/build.gradle
@@ -16,5 +16,5 @@ dependencies {
     compile 'com.facebook.react:react-native:+'
     compile 'com.instabug.library:instabug:3+'
     compile 'status-im:function:0.0.1'
-    compile(group: 'status-im', name: 'status-go', version: 'develop-g281b304e', ext: 'aar')
+    compile(group: 'status-im', name: 'status-go', version: 'bugfix-fix-loop-memory-alignment-g6d1096c-2', ext: 'aar')
 }

--- a/modules/react-native-status/android/build.gradle
+++ b/modules/react-native-status/android/build.gradle
@@ -16,5 +16,5 @@ dependencies {
     compile 'com.facebook.react:react-native:+'
     compile 'com.instabug.library:instabug:3+'
     compile 'status-im:function:0.0.1'
-    compile(group: 'status-im', name: 'status-go', version: 'develop-g90acfed', ext: 'aar')
+    compile(group: 'status-im', name: 'status-go', version: 'develop-g281b304e', ext: 'aar')
 }

--- a/modules/react-native-status/android/build.gradle
+++ b/modules/react-native-status/android/build.gradle
@@ -16,5 +16,5 @@ dependencies {
     compile 'com.facebook.react:react-native:+'
     compile 'com.instabug.library:instabug:3+'
     compile 'status-im:function:0.0.1'
-    compile(group: 'status-im', name: 'status-go', version: 'bugfix-network-switch-panic-gab8d1f1-11', ext: 'aar')
+    compile(group: 'status-im', name: 'status-go', version: 'bugfix-no-messaging-rinkeby-gd04e667-12', ext: 'aar')
 }

--- a/modules/react-native-status/ios/RCTStatus/pom.xml
+++ b/modules/react-native-status/ios/RCTStatus/pom.xml
@@ -25,7 +25,7 @@
                         <artifactItem>
                             <groupId>status-im</groupId>
                             <artifactId>status-go-ios-simulator</artifactId>
-                            <version>develop-ge61c39b</version>
+                            <version>develop-g90acfed</version>
                             <type>zip</type>
                             <overWrite>true</overWrite>
                             <outputDirectory>./</outputDirectory>

--- a/modules/react-native-status/ios/RCTStatus/pom.xml
+++ b/modules/react-native-status/ios/RCTStatus/pom.xml
@@ -25,7 +25,7 @@
                         <artifactItem>
                             <groupId>status-im</groupId>
                             <artifactId>status-go-ios-simulator</artifactId>
-                            <version>develop-g90acfed</version>
+                            <version>develop-g281b304e</version>
                             <type>zip</type>
                             <overWrite>true</overWrite>
                             <outputDirectory>./</outputDirectory>

--- a/modules/react-native-status/ios/RCTStatus/pom.xml
+++ b/modules/react-native-status/ios/RCTStatus/pom.xml
@@ -25,7 +25,7 @@
                         <artifactItem>
                             <groupId>status-im</groupId>
                             <artifactId>status-go-ios-simulator</artifactId>
-                            <version>bugfix-network-switch-panic-gab8d1f1-11</version>
+                            <version>bugfix-no-messaging-rinkeby-gd04e667-12</version>
                             <type>zip</type>
                             <overWrite>true</overWrite>
                             <outputDirectory>./</outputDirectory>

--- a/modules/react-native-status/ios/RCTStatus/pom.xml
+++ b/modules/react-native-status/ios/RCTStatus/pom.xml
@@ -25,7 +25,7 @@
                         <artifactItem>
                             <groupId>status-im</groupId>
                             <artifactId>status-go-ios-simulator</artifactId>
-                            <version>develop-g281b304e</version>
+                            <version>bugfix-fix-loop-memory-alignment-g6d1096c-2</version>
                             <type>zip</type>
                             <overWrite>true</overWrite>
                             <outputDirectory>./</outputDirectory>

--- a/modules/react-native-status/ios/RCTStatus/pom.xml
+++ b/modules/react-native-status/ios/RCTStatus/pom.xml
@@ -25,7 +25,7 @@
                         <artifactItem>
                             <groupId>status-im</groupId>
                             <artifactId>status-go-ios-simulator</artifactId>
-                            <version>bugfix-fix-loop-memory-alignment-g6d1096c-2</version>
+                            <version>bugfix-network-switch-panic-gab8d1f1-11</version>
                             <type>zip</type>
                             <overWrite>true</overWrite>
                             <outputDirectory>./</outputDirectory>

--- a/src/status_im/ui/screens/accounts/events.cljs
+++ b/src/status_im/ui/screens/accounts/events.cljs
@@ -109,7 +109,7 @@
   (fn [{{:keys          [network]
          :networks/keys [networks]
          :as            db} :db} [_ {:keys [address] :as account} password]]
-    (let [address (utils/normalize-hex address)
+    (let [address (utils.hex/normalize-hex address)
           account' (assoc account
                           :network network
                           :networks networks

--- a/src/status_im/ui/screens/accounts/events.cljs
+++ b/src/status_im/ui/screens/accounts/events.cljs
@@ -16,7 +16,8 @@
    [status-im.utils.handlers :as handlers]
    [status-im.ui.screens.accounts.statuses :as statuses]
    [status-im.utils.signing-phrase.core :as signing-phrase]
-   [status-im.utils.gfycat.core :refer [generate-gfy]]))
+   [status-im.utils.gfycat.core :refer [generate-gfy]]
+   [status-im.utils.hex :as utils.hex]))
 
 ;;;; Helper fns
 
@@ -108,13 +109,16 @@
   (fn [{{:keys          [network]
          :networks/keys [networks]
          :as            db} :db} [_ {:keys [address] :as account} password]]
-    (let [account' (assoc account :network network
-                                  :networks networks)]
+    (let [address (utils/normalize-hex address)
+          account' (assoc account
+                          :network network
+                          :networks networks
+                          :address address)]
       (merge
-        {:db            (assoc-in db [:accounts/accounts address] account')
-         ::save-account account'}
-        (when password
-          {:dispatch-later [{:ms 400 :dispatch [:login-account address password true]}]})))))
+       {:db            (assoc-in db [:accounts/accounts address] account')
+        ::save-account account'}
+       (when password
+         {:dispatch-later [{:ms 400 :dispatch [:login-account address password true]}]})))))
 
 (handlers/register-handler-fx
   :create-new-account-handler

--- a/src/status_im/utils/hex.cljs
+++ b/src/status_im/utils/hex.cljs
@@ -1,10 +1,11 @@
 (ns status-im.utils.hex
-  (:require [clojure.string :as s]))
+  (:require [clojure.string :as string]))
 
 (defn normalize-hex [hex]
-  (if (and hex (s/starts-with? hex "0x"))
-    (subs hex 2)
-    hex))
+  (when hex
+    (string/lower-case (if (string/starts-with? hex "0x")
+                         (subs hex 2)
+                         hex))))
 
 (defn valid-hex? [hex]
   (let [hex (normalize-hex hex)]


### PR DESCRIPTION
Includes latest status-go develop that uses geth 1.7. Here be dragons.