### PR TITLE
Prevent touch events from reaching camera.

### DIFF
--- a/src/status_im/ui/screens/wallet/choose_recipient/styles.cljs
+++ b/src/status_im/ui/screens/wallet/choose_recipient/styles.cljs
@@ -62,7 +62,7 @@
    :border-color               "rgba(255, 255, 255, 0.3)"})
 
 (def qr-container
-  {:flex              1})
+  {:flex           1})
 
 (def preview
   {:flex            1

--- a/src/status_im/ui/screens/wallet/choose_recipient/views.cljs
+++ b/src/status_im/ui/screens/wallet/choose_recipient/views.cljs
@@ -81,11 +81,12 @@
     [react/view {:style styles/wallet-container}
      [status-bar/status-bar {:type :wallet}]
      [toolbar-view camera-flashlight]
-     [react/view {:style     styles/qr-container
-                  :on-layout #(let [layout (.. % -nativeEvent -layout)]
-                                (re-frame/dispatch [:set-in [:wallet/send-transaction :camera-dimensions]
-                                                    {:width  (.-width layout)
-                                                     :height (.-height layout)}]))}
+            [react/view {:style         styles/qr-container
+                         :pointerEvents :none
+                         :on-layout     #(let [layout (.. % -nativeEvent -layout)]
+                                           (re-frame/dispatch [:set-in [:wallet/send-transaction :camera-dimensions]
+                                                               {:width  (.-width layout)
+                                                                :height (.-height layout)}]))}
       (when (or platform/android?
                 camera-permitted?)
         [camera/camera {:style         styles/preview


### PR DESCRIPTION
### Summary:
QR scanner can crash if tapped on before starting. Since the choose-recipient QR scanner doesn't have any touch elements, we can prevent the crash by stopping touch events.

### Steps to test:
- Open Status
- Navigate to choose-recipient in wallet.
- Tap on the camera before it's fully started.
@asemiankevich has reproduced the issue here: https://github.com/status-im/status-react/issues/1774#issuecomment-334164096

status: ready

