### PR TITLE
Discover: Display toolbar on a blank list

### DIFF
--- a/src/status_im/ui/screens/discover/components/views.cljs
+++ b/src/status_im/ui/screens/discover/components/views.cljs
@@ -3,35 +3,35 @@
   (:require [re-frame.core :as re-frame]
             [clojure.string :as str]
             [status-im.components.react :as react]
-            [status-im.ui.screens.discover.styles :as st]
+            [status-im.ui.screens.discover.styles :as styles]
             [status-im.components.status-view.view :as view]
             [status-im.utils.gfycat.core :as gfycat]
             [status-im.utils.identicon :as identicon]
-            [status-im.components.chat-icon.screen :as ci]
+            [status-im.components.chat-icon.screen :as chat-icon]
             [status-im.utils.platform :as platform]
-            [status-im.components.icons.vector-icons :as vi]
+            [status-im.components.icons.vector-icons :as vector-icons]
             [status-im.i18n :as i18n]))
 
 (defn title [label-kw action-kw action-fn active?]
-  [react/view st/title
+  [react/view styles/title
    [react/text {:style      (get-in platform/platform-specific [:component-styles :discover :subtitle])
                 :uppercase? (get-in platform/platform-specific [:discover :uppercase-subtitles?])
                 :font       :medium}
     (i18n/label label-kw)]
    [react/touchable-highlight {:on-press action-fn}
     [react/view {}
-     [react/text {:style (st/title-action-text active?)}
+     [react/text {:style (styles/title-action-text active?)}
       (i18n/label action-kw)]]]])
 
 (defn tags-menu [tags]
-  [react/view st/tag-title-container
+  [react/view styles/tag-title-container
    (for [tag (take 3 tags)]
      ^{:key (str "tag-" tag)}
      [react/touchable-highlight {:on-press #(do (re-frame/dispatch [:set :discover-search-tags [tag]])
                                                 (re-frame/dispatch [:navigate-to :discover-search-results]))}
       [react/view (merge (get-in platform/platform-specific [:component-styles :discover :tag])
                          {:margin-left 2 :margin-right 2})
-       [react/text {:style st/tag-title
+       [react/text {:style styles/tag-title
                     :font  :default}
         (str " #" tag)]]])])
 
@@ -55,29 +55,31 @@
     (let [{:keys [name photo-path whisper-id message-id status]} message
           {account-photo-path :photo-path
            account-address    :public-key
-           account-name       :name} current-account
-          me?        (= account-address whisper-id)
-          item-style (get-in platform/platform-specific [:component-styles :discover :item])]
+           account-name       :name}                             current-account
+          me?                                                    (= account-address whisper-id)
+          item-style                                             (get-in platform/platform-specific [:component-styles :discover :item])]
       [react/view
-       [react/view st/popular-list-item
+       [react/view styles/popular-list-item
         [view/status-view {:id     message-id
                            :style  (:status-text item-style)
                            :status status}]
-        [react/view st/popular-list-item-second-row
-         [react/view st/popular-list-item-name-container
-          [react/view (merge st/popular-list-item-avatar-container
+        [react/view styles/popular-list-item-second-row
+         [react/view styles/popular-list-item-name-container
+          [react/view (merge styles/popular-list-item-avatar-container
                              (:icon item-style))
-           [ci/chat-icon
+           [chat-icon/chat-icon
             (display-image me? account-photo-path contact-photo-path photo-path whisper-id)
             {:size 20}]]
-          [react/text {:style           st/popular-list-item-name
+          [react/text {:style           styles/popular-list-item-name
                        :font            :medium
                        :number-of-lines 1}
            (display-name me? account-name contact-name name whisper-id)]]
          (when-not me?
            [react/touchable-highlight {:on-press #(re-frame/dispatch [:start-chat whisper-id])}
-            [react/view st/popular-list-chat-action
-             [vi/icon :icons/chats {:color "rgb(110, 0, 228)"}]
-             [react/text {:style st/popular-list-chat-action-text} (i18n/label :t/chat)]]])]
-        (when show-separator?
-          [react/view st/separator])]])))
+            [react/view styles/popular-list-chat-action
+             [vector-icons/icon :icons/chats {:color "#4360df"}]
+             [react/text {:style      styles/popular-list-chat-action-text
+                          :font       :medium
+                          :uppercase? (get platform/platform-specific :uppercase?)} (i18n/label :t/chat)]]])]]
+       (when show-separator?
+         [react/view styles/separator])])))

--- a/src/status_im/ui/screens/discover/recent_statuses/views.cljs
+++ b/src/status_im/ui/screens/discover/recent_statuses/views.cljs
@@ -1,27 +1,26 @@
 (ns status-im.ui.screens.discover.recent-statuses.views
   (:require-macros [status-im.utils.views :refer [defview letsubs]])
-  (:require
-    [status-im.components.react :as react]
-    [status-im.ui.screens.discover.styles :as st]
-    [status-im.utils.listview :refer [to-datasource]]
-    [status-im.ui.screens.discover.components.views :as components]
-    [status-im.components.toolbar-new.view :as toolbar]))
+  (:require [re-frame.core :as re-frame]
+            [status-im.components.react :as react]
+            [status-im.i18n :as i18n]
+            [status-im.ui.screens.discover.styles :as styles]
+            [status-im.utils.listview :refer [to-datasource]]
+            [status-im.ui.screens.discover.components.views :as components]
+            [status-im.components.toolbar-new.view :as toolbar]))
 
 (defview discover-all-recent []
   (letsubs [discoveries     [:get-recent-discoveries]
             tabs-hidden?    [:tabs-hidden?]
             current-account [:get-current-account]]
-    (when (seq discoveries)
-      [react/view st/discover-container
-       [toolbar/toolbar2 {}
-        toolbar/default-nav-back
-        [react/view {} [react/text {} "All recent"]]]
-       [react/scroll-view (st/list-container tabs-hidden?)
-        [react/view st/recent-container
-         [react/view st/recent-list
+    [react/view styles/discover-container
+     [toolbar/toolbar2 (i18n/label :t/recent)]
+     (when (seq discoveries)
+       [react/scroll-view styles/list-container
+        [react/view styles/recent-container
+         [react/view styles/recent-list
           (let [discoveries (map-indexed vector discoveries)]
             (for [[i {:keys [message-id] :as message}] discoveries]
               ^{:key (str "message-recent-" message-id)}
               [components/discover-list-item {:message         message
                                               :show-separator? (not= (inc i) (count discoveries))
-                                              :current-account current-account}]))]]]])))
+                                              :current-account current-account}]))]]])]))

--- a/src/status_im/ui/screens/discover/styles.cljs
+++ b/src/status_im/ui/screens/discover/styles.cljs
@@ -68,10 +68,8 @@
    :padding-right  9})
 
 (def separator
-  {:background-color "rgb(238, 241, 245)"
-   :height           2
-   :margin-top       2
-   :margin-bottom    2})
+  {:background-color "#eef2f5"
+   :height           3})
 
 ;; Popular list item
 
@@ -79,19 +77,19 @@
   {:flex             1
    :background-color :white
    :padding-top      18
-   :padding-left     16
-   })
+   :padding-left     16})
 
 (def popular-list-item
   {:flex-direction "column"
+   :padding-left 16
+   :padding-vertical 10
    :padding-bottom 16
-   :margin-right   10
+   :padding-right 16
    :top            1})
 
 (def popular-list-item-second-row
   {:flex            1
    :flex-direction  :row
-   :align-items     :center
    :justify-content :space-between
    :margin-bottom   5
    :padding-top     25})
@@ -99,6 +97,7 @@
 (def popular-list-item-name-container
   {:flex            0.3
    :flex-direction  :row
+   :align-items :center
    :justify-content :flex-start})
 
 (def popular-list-item-name
@@ -110,13 +109,15 @@
   {:flex-direction "column"})
 
 (def popular-list-chat-action
-  {:background-color "rgb(220, 214, 251)"
+  {:background-color "rgba(67, 96, 223, 0.2)"
    :flex-direction   :row
-   :border-radius    5
+   :align-items      :center
+   :border-radius    4
    :padding          4})
 
 (def popular-list-chat-action-text
-  {:color "rgb(110, 0, 228)"})
+  {:color "#4360df"
+   :margin-right 8})
 
 ;; discover_recent
 
@@ -124,8 +125,7 @@
   {:background-color toolbar-background2})
 
 (def recent-list
-  {:background-color :white
-   :padding-left     16})
+  {:background-color :white})
 
 ;; All dapps
 
@@ -223,10 +223,12 @@
 
 (def discover-container
   {:flex             1
-   :background-color styles/color-white})
+   :background-color "#eef2f5"})
 
 (def list-container
-  {:flex 1})
+  {:flex 1
+   :padding-top 3
+   :background-color "#eef2f5"})
 
 (def search-icon
   {:width  17


### PR DESCRIPTION
fixes #2079 

### Summary:
- [x] Grey background
- [x] Display toolbar on the empty screen
- [x] Fix toolbar font
- [x] Fix colors for chat action button
- [x] Capitalize chat action button
- [x] Fix divider between individual statuses
- [x] Center username with relation to avatar picture
- [x] Expand some namespace aliases

<img width=320 src=https://user-images.githubusercontent.com/640347/31415407-b5bc1b96-adf9-11e7-8f89-bd300a71f283.png />

<img width=320 src=https://user-images.githubusercontent.com/640347/31415596-bdba6266-adfa-11e7-95cb-a21c73129a98.png />

status: ready

