### PR TITLE
Feature/reworked send command #2033

### DIFF
--- a/resources/js/status.js
+++ b/resources/js/status.js
@@ -26,8 +26,7 @@ Command.prototype.create = function (com) {
     this.title = com.title;
     this.description = com.description;
     this.handler = com.handler;
-    this["has-handler"] = com.handler != null;
-    this["async-handler"] = (com.handler != null) && com.asyncHandler
+    this["has-handler"] = com.handler != null; 
     this["registered-only"] = com.registeredOnly;
     this.validator = com.validator;
     this.color = com.color;

--- a/src/status_im/chat/events/commands.cljs
+++ b/src/status_im/chat/events/commands.cljs
@@ -55,12 +55,12 @@
 (handlers/register-handler-fx
   ::jail-command-data-response
   [re-frame/trim-v]
-  (fn [{:keys [db]} [{{:keys [returned]} :result} {:keys [message-id on-requested]} data-type]]
+  (fn [{:keys [db]} [{{:keys [returned]} :result} {:keys [message-id on-requested]} data-type]] 
     (cond-> {}
       returned
       (assoc :db (assoc-in db [:message-data data-type message-id] returned))
-      (and returned
-           (= :preview data-type))
+      (and (= :preview data-type)
+           returned)
       (assoc :update-message {:message-id message-id
                               :preview (prn-str returned)})
       on-requested

--- a/src/status_im/chat/events/console.cljs
+++ b/src/status_im/chat/events/console.cljs
@@ -115,10 +115,9 @@
   :invoke-console-command-handler!
   [re-frame/trim-v (re-frame/inject-cofx :random-id)]
   (fn [cofx [{:keys [chat-id command] :as command-params}]]
-    (let [fx-fn (get console-commands->fx (-> command :command :name))]
-      (-> cofx
-          (fx-fn command)
-          (update :dispatch-n (fnil conj []) [:prepare-command! chat-id command-params])))))
+    (let [fx-fn (get console-commands->fx (-> command :command :name))
+          command-fx (fx-fn cofx command)]
+      {:dispatch [:prepare-command! chat-id (assoc command-params :command-fx command-fx)]})))
 
 ;; TODO(janherich) remove this once send-message events are refactored
 (handlers/register-handler-fx

--- a/src/status_im/ui/screens/events.cljs
+++ b/src/status_im/ui/screens/events.cljs
@@ -314,8 +314,10 @@
                                                          :message data}])
       "handler-result" (let [orig-params (:origParams data)]
                          ;; TODO(janherich): figure out and fix chat_id from event
-                         (dispatch [:command-handler! (:chat-id orig-params) orig-params
-                                    {:result {:returned (dissoc data :origParams)}}])) 
+                         (dispatch [:command-handler!
+                                    (:chat-id orig-params)
+                                    orig-params
+                                    (dissoc data :origParams)])) 
       (log/debug "Unknown jail signal " event))))
 
 (register-handler-fx

--- a/src/status_im/ui/screens/wallet/send/db.cljs
+++ b/src/status_im/ui/screens/wallet/send/db.cljs
@@ -10,7 +10,7 @@
 (spec/def ::wrong-password? (spec/nilable boolean?))
 (spec/def ::transaction-id (spec/nilable string?))
 (spec/def ::waiting-signal? (spec/nilable boolean?))
-(spec/def ::signing? (spec/nilable boolean?))
+(spec/def ::signing? (spec/nilable boolean?)) 
 (spec/def ::later? (spec/nilable boolean?))
 (spec/def ::height double?)
 (spec/def ::width double?)
@@ -18,9 +18,10 @@
 (spec/def ::camera-flashlight #{:on :off})
 (spec/def ::camera-permitted? boolean?)
 (spec/def ::in-progress? boolean?)
+(spec/def ::from-chat? (spec/nilable boolean?))
 
 (spec/def :wallet/send-transaction (allowed-keys
                                      :opt-un [::amount ::to-address ::to-name ::amount-error ::password
                                               ::waiting-signal? ::signing? ::transaction-id ::later?
                                               ::camera-dimensions ::camera-flashlight ::in-progress?
-                                              ::wrong-password? ::camera-permitted?]))
+                                              ::wrong-password? ::camera-permitted? ::from-chat?]))

--- a/src/status_im/ui/screens/wallet/send/views.cljs
+++ b/src/status_im/ui/screens/wallet/send/views.cljs
@@ -22,8 +22,7 @@
 (defn toolbar-view [signing?]
   [toolbar/toolbar2 {:style wallet.styles/toolbar}
    [toolbar/nav-button (act/back-white (if signing?
-                                         #(do (re-frame/dispatch [:wallet/discard-transaction])
-                                              (act/default-handler))
+                                         #(re-frame/dispatch [:wallet/discard-transaction-navigate-back])
                                          act/default-handler))]
    [toolbar/content-title {:color :white} (i18n/label :t/send-transaction)]])
 
@@ -144,9 +143,11 @@
           [sign-panel])]
        (when in-progress? [react/view send.styles/processing-view])])))
 
-(defn toolbar-modal []
+(defn toolbar-modal [from-chat?]
   [toolbar/toolbar2 {:style wallet.styles/toolbar}
-   [toolbar/nav-button (act/close-white act/default-handler)]
+   [toolbar/nav-button (act/close-white (if from-chat?
+                                          #(re-frame/dispatch [:wallet/discard-transaction-navigate-back])
+                                          act/default-handler))]
    [toolbar/content-title {:color :white} (i18n/label :t/send-transaction)]])
 
 (defview send-transaction-modal []
@@ -156,11 +157,12 @@
             to-address   [:get-in [:wallet/send-transaction :to-address]]
             to-name      [:get-in [:wallet/send-transaction :to-name]]
             recipient    [:contact-by-address @to-name]
-            in-progress? [:get-in [:wallet/send-transaction :in-progress?]]]
+            in-progress? [:get-in [:wallet/send-transaction :in-progress?]]
+            from-chat?   [:get-in [:wallet/send-transaction :from-chat?]]]
     [react/keyboard-avoiding-view wallet.styles/wallet-modal-container
      [react/view components.styles/flex
       [status-bar/status-bar {:type :wallet}]
-      [toolbar-modal]
+      [toolbar-modal from-chat?]
       [react/scroll-view {:keyboardShouldPersistTaps :always}
        [react/view components.styles/flex
         [react/view wallet.styles/choose-participant-container

--- a/src/status_im/ui/screens/wallet/transactions/events.cljs
+++ b/src/status_im/ui/screens/wallet/transactions/events.cljs
@@ -49,7 +49,8 @@
               {:dispatch [:navigate-to-modal :wallet-send-transaction-modal {:amount (str (money/wei->ether value))
                                                                              :transaction-id id
                                                                              :to-address to
-                                                                             :to-name to}]}))))
+                                                                             :to-name to
+                                                                             :from-chat? true}]}))))
       {:discard-transaction id})))
 
 ;TRANSACTION FAILED signal from status-go


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)
Partially implements #2033 and fixes #2031 

### Summary:
[comment]: # (Summarise the problem and how the pull request solves it)
This PR fixes the most urgent things for the `/send` command to integrate seamlessly into the new wallet.
I started implementing it as a complete move of the sending logic to the new wallet, where `/send` command itself would not be doing the actual adding of the transaction to the tx-queue on the ethereum-node, but just provide necessary arguments for the wallet screen/events to do so. 
All plumbing for that is ready on the command handling side, unfortunately, wallet (screens and transitions between them) is currently coded in such a way, that it expects the present `/send` code behaviour, eq the send modal window is only displayed when transaction is already in tx-queue, therefore I decided to retain that behaviour because of the time constraints. 
I still think we should revisit it after devcon, as the "dumb" `/send` command would make it possible to simplify the wallet code a lot, not even talking about the actual bot js code where the command is defined. 

So what's done:
* When `/send` is issued from the chat and you are taken to the send transaction modal window, upon clicking on "x" icon in the upper left corner, transaction is discarded.
* Fetching the command preview is moved to the later point where command-handler result is ready (tx hash in the case of `/send`), so it provides important prerequisite for implementation of the number of confirmations in the preview + link to the transaction detail from preview
* It removes some obsolete code which is creating by duplicating `/send` command messages for the old wallet. 

What's left to be done:
* Better `/send` command message preview with number of tx confirmations and link to transaction detail

### Steps to test:
- exercise `/send` command behaviour 

[comment]: # (PRs will only be accepted if squashed into single commit.)
status: WIP

