### PR TITLE
[BUG #2023] Improved QR code readability

### DIFF
--- a/src/status_im/ui/screens/wallet/request/styles.cljs
+++ b/src/status_im/ui/screens/wallet/request/styles.cljs
@@ -1,4 +1,5 @@
 (ns status-im.ui.screens.wallet.request.styles
+  (:require-macros [status-im.utils.styles :refer [defstyle]])
   (:require [status-im.components.styles :as styles]))
 
 (def network-label
@@ -8,8 +9,12 @@
   {:flex        1
    :align-items :center})
 
-(def qr-container
-  {:margin-top 16})
+(defstyle qr-container
+  {:margin-top       16
+   :padding          16
+   :background-color styles/color-white
+   :ios              {:border-radius 8}
+   :android          {:border-radius 4}})
 
 (def share-icon-container
   {:margin-right 8})

--- a/src/status_im/ui/screens/wallet/request/views.cljs
+++ b/src/status_im/ui/screens/wallet/request/views.cljs
@@ -32,8 +32,6 @@
     [components.qr-code/qr-code
      {:value   (.stringify js/JSON (clj->js {:address (:address account)
                                              :amount  0}))
-      :bgColor :white
-      :fgColor "#4360df"
       :size    256}]))
 
 (views/defview request-transaction []


### PR DESCRIPTION
fixes #2023

### Summary:

White QR code cannot be read by all apps

### Steps to test:
- Open Status
- Initiate a request from wallet
- Make sure generated QR code can be read on android/iOS and by other apps

status: ready

