### PR TITLE
Ask for confirmation before unsigned transaction deletion

### DIFF
--- a/src/status_im/translations/en.cljs
+++ b/src/status_im/translations/en.cljs
@@ -387,6 +387,8 @@
    :transactions-sign-later               "Sign Later"
    :transactions-sign-all-text            "Sign the transaction by entering your password.\nMake sure that the words above match your secret signing phrase"
    :transactions-sign-input-placeholder   "Enter your password"
+   :transactions-delete                   "Delete transaction"
+   :transactions-delete-content           "Transaction will be removed from unsigned list"
    :transactions-history                  "History"
    :transactions-unsigned                 "Unsigned"
    :transactions-history-empty            "You don't have a history transactions"

--- a/src/status_im/ui/screens/wallet/events.cljs
+++ b/src/status_im/ui/screens/wallet/events.cljs
@@ -1,13 +1,13 @@
 (ns status-im.ui.screens.wallet.events
   (:require [re-frame.core :as re-frame :refer [dispatch reg-fx]]
+            [status-im.i18n :as i18n]
+            [status-im.native-module.core :as status]
+            [status-im.ui.screens.wallet.db :as wallet.db]
+            [status-im.ui.screens.wallet.navigation]
             [status-im.utils.handlers :as handlers]
             [status-im.utils.prices :as prices]
             [status-im.utils.transactions :as transactions]
             [status-im.utils.utils :as utils]
-            [status-im.ui.screens.wallet.db :as wallet.db]
-
-            [status-im.native-module.core :as status]
-            [status-im.ui.screens.wallet.navigation]
             [taoensso.timbre :as log]
             status-im.ui.screens.wallet.request.events))
 
@@ -141,3 +141,11 @@
   :wallet/discard-unsigned-transaction
   (fn [_ [_ transaction-id]]
     {:discard-transaction transaction-id}))
+
+(handlers/register-handler-fx
+  :wallet/discard-unsigned-transaction-with-confirmation
+  (fn [cofx [_ transaction-id]]
+    {:show-confirmation {:title               (i18n/label :t/transactions-delete)
+                         :content             (i18n/label :t/transactions-delete-content)
+                         :confirm-button-text (i18n/label :t/confirm)
+                         :on-accept           #(re-frame/dispatch [:wallet/discard-unsigned-transaction transaction-id])}}))

--- a/src/status_im/ui/screens/wallet/transactions/views.cljs
+++ b/src/status_im/ui/screens/wallet/transactions/views.cljs
@@ -26,8 +26,7 @@
 
 (defn on-delete-transaction
   [{:keys [id]}]
-  ;; TODO(andrey) implement alert
-  (re-frame/dispatch [:wallet/discard-unsigned-transaction id]))
+  (re-frame/dispatch [:wallet/discard-unsigned-transaction-with-confirmation id]))
 
 ;; TODO (andrey) implement
 (defn unsigned-action [unsigned-transactions-count]


### PR DESCRIPTION
### Summary:

Ask for confirmation before unsigned transaction deletion

### Steps to test:
- Open Status
- Navigate wallet/send
- Create a transaction and hit sign later
- Try to delete it: there should be an alert asking for confirmation

status: ready

