### PR TITLE
Added Status identifier when calling cryptocompare API

### DIFF
--- a/src/status_im/utils/prices.cljs
+++ b/src/status_im/utils/prices.cljs
@@ -11,9 +11,10 @@
 ;; (get-prices "ETH" "USD" println print)
 
 (def api-url "https://min-api.cryptocompare.com/data")
+(def status-identifier "extraParams=Status.im")
 
 (defn- gen-price-url [fsyms tsyms]
-  (str api-url "/pricemultifull?fsyms=" fsyms "&tsyms=" tsyms))
+  (str api-url "/pricemultifull?fsyms=" fsyms "&tsyms=" tsyms "&" status-identifier))
 
 (defn- format-price-resp [from to resp]
   (let [raw (:RAW (types/json->clj resp))


### PR DESCRIPTION
fixes #2123

### Summary:

Added Status identifier when calling cryptocompare API

### Steps to test:
- Open Status
- Navigate wallet
- Ensure prices are displayed

status: ready

