### PR TITLE
Bugfix/discover pixel perfect main two #2076

### DIFF
--- a/src/status_im/ui/screens/discover/all_dapps/views.cljs
+++ b/src/status_im/ui/screens/discover/all_dapps/views.cljs
@@ -20,14 +20,11 @@
       [react/view styles/dapps-list-item-second-row
        [react/view styles/dapps-list-item-name-container
         [react/view styles/dapps-list-item-avatar-container
-         [react/view (chat-icon/contact-icon-contacts-tab dapp)]]
+         [react/view [chat-icon/contact-icon-view dapp {:size 80}]]]
         [react/text {:style           styles/dapps-list-item-name
                      :font            :medium
                      :number-of-lines 1}
          name]]]]])
-
-;; TODO(oskarth): Carousel task, possibly different subcomponent
-(def dapp-item render-dapp)
 
 ;; TODO(oskarth): Move this to top level discover ns
 (defn preview [dapps]
@@ -38,11 +35,12 @@
     :t/all
     #(re-frame/dispatch [:navigate-to :discover-all-dapps])]
    (if (seq dapps)
-     ;; TODO(oskarth): Too wide margins bug
-     [list/flat-list {:data                    (vals dapps)
-                      :render-fn               render-dapp
-                      :horizontal              true
-                      :content-container-style styles/all-dapps-flat-list}]
+     [list/flat-list {:data                              (vals dapps)
+                      :render-fn                         render-dapp
+                      :horizontal                        true
+                      :separator?                        false
+                      :shows-horizontal-scroll-indicator false
+                      :content-container-style           styles/dapp-preview-flat-list}]
      [react/text (i18n/label :t/none)])])
 
 (defview main []

--- a/src/status_im/ui/screens/discover/styles.cljs
+++ b/src/status_im/ui/screens/discover/styles.cljs
@@ -165,9 +165,11 @@
    :background-color styles/color-white})
 
 (def all-dapps-flat-list-item
-  {:margin 10
-   :width  100
-   :height 100})
+  {:margin          10
+   :width           100
+   :height          140
+   :justify-content :center
+   :align-items     :center})
 
 (def dapps-list-item-second-row
   {:flex    1
@@ -200,15 +202,13 @@
    :margin-top       16
    :margin-bottom    4})
 
-(def dapp-preview-content
-  {:border-radius    4
-   :padding-top      4
-   :padding-left     4
-   :margin-top       2
-   :margin-bottom    4
-   :margin-right     2
-   :background-color styles/color-white
-   :size             10})
+(def dapp-preview-flat-list
+  {:justify-content  :center
+   :flex-direction   :row
+   :flex-wrap        :wrap
+   :margin-left      8
+   :margin-vertical  0
+   :background-color styles/color-white})
 
 ;; Discover tag
 
@@ -287,7 +287,7 @@
 
 (def public-chats-item-container
   {:flex-direction :row
-   :padding        3})
+   :padding        16})
 
 (def public-chats-icon-width-ratio
   0.15)


### PR DESCRIPTION
Progress towards pixel perfection main discover screen

- Fix icon size and remove badge numbers
- Preview: tighten up margins
- Hide horizontal scrollbar
- Padding for public chats

https://github.com/status-im/status-react/issues/2076

![image](https://user-images.githubusercontent.com/1552237/31546232-b35cee68-b022-11e7-91cf-ad41967803b6.png)
![image](https://user-images.githubusercontent.com/1552237/31546241-b997efda-b022-11e7-9691-76a4f5b7fef8.png)


status: ready