### PR TITLE
Improved ios styles

### DIFF
--- a/src/status_im/components/button/styles.cljs
+++ b/src/status_im/components/button/styles.cljs
@@ -51,8 +51,11 @@
                          (when disabled? {:opacity 0.6}))})
 
 (defstyle button-borders
-  {:android           {:border-radius 4}
-   :ios               {:border-radius 8}})
+  {:android {:border-radius 4}
+   :ios     {:border-radius 8
+             ;; Border radius is ignored with transparent background unless overflow "hidden" is used
+             ;; See https://github.com/facebook/react-native/issues/13760
+             :overflow      :hidden}})
 
 (def primary-button
   (merge

--- a/src/status_im/components/list/styles.cljs
+++ b/src/status_im/components/list/styles.cljs
@@ -38,8 +38,12 @@
 (def left-item-wrapper
   {:margin 14})
 
+(def content-item-wrapper
+  {:flex         1
+   :margin-right 16})
+
 (def right-item-wrapper
-  {:margin 16})
+  {:margin-right 16})
 
 (def base-separator
   {:height           1

--- a/src/status_im/components/list/views.cljs
+++ b/src/status_im/components/list/views.cljs
@@ -32,9 +32,11 @@
    [rn/view {:style lst/item}
     [rn/view {:style lst/left-item-wrapper}
      left-action]
-    content
-    [rn/view {:style lst/right-item-wrapper}
-     right-action]]))
+    [rn/view {:style lst/content-item-wrapper}
+     content]
+    (when right-action
+      [rn/view {:style lst/right-item-wrapper}
+       right-action])]))
 
 (defn touchable-item [handler item]
   [rn/touchable-highlight {:on-press handler}

--- a/src/status_im/ui/screens/wallet/components/styles.cljs
+++ b/src/status_im/ui/screens/wallet/components/styles.cljs
@@ -105,12 +105,18 @@
    :font-size      15
    :letter-spacing -0.2})
 
+(def wallet-value-container
+  {:flex           1
+   :flex-direction :row})
+
 (def wallet-value
   {:padding-left   6
-   :flex-shrink    1
    :color          styles/color-white-transparent-5
    :font-size      15
    :letter-spacing -0.2})
+
+(def wallet-value-amount
+  {:flex -1})
 
 (def separator
   {:height            1

--- a/src/status_im/ui/screens/wallet/components/views.cljs
+++ b/src/status_im/ui/screens/wallet/components/views.cljs
@@ -107,12 +107,16 @@
      [react/view (merge styles/wallet-container
                         style)
       [react/text {:style styles/wallet-name} (i18n/label :t/main-wallet)]
-      [react/text {:style           styles/wallet-value
-                   :number-of-lines 1
-                   :ellipsizeMode   :middle}
-       (if balance
-         (money/wei->str :eth balance)
-         "...")]]]))
+      (if balance
+        [react/view {:style styles/wallet-value-container}
+         [react/text {:style           (merge styles/wallet-value styles/wallet-value-amount)
+                      :number-of-lines 1
+                      :ellipsize-mode  :tail}
+          (str (money/wei->ether balance))]
+         [react/text {:style styles/wallet-value}
+          (i18n/label :t/eth)]]
+        [react/text {:style styles/wallet-value}
+         "..."])]]))
 
 (defn network-label
   ([n] (network-label [{} n]))

--- a/src/status_im/ui/screens/wallet/main/styles.cljs
+++ b/src/status_im/ui/screens/wallet/main/styles.cljs
@@ -129,7 +129,8 @@
    :align-items    :center})
 
 (def asset-item-value
-  {:font-size 16
+  {:flex      -1
+   :font-size 16
    :color     styles/color-black})
 
 (defstyle add-asset-icon

--- a/src/status_im/ui/screens/wallet/main/views.cljs
+++ b/src/status_im/ui/screens/wallet/main/views.cljs
@@ -116,9 +116,13 @@
       (let [{:keys [source style]} (token->image id)]
         [list/item-image source style])
       [react/view {:style styles/asset-item-value-container}
-       [react/text {:style styles/asset-item-value} (str (money/wei->ether amount))]
-       [react/text {:style      styles/asset-item-currency
-                    :uppercase? true}
+       [react/text {:style           styles/asset-item-value
+                    :number-of-lines 1
+                    :ellipsize-mode  :tail}
+        (str (money/wei->ether amount))]
+       [react/text {:style           styles/asset-item-currency
+                    :uppercase?      true
+                    :number-of-lines 1}
         id]]]]
     [add-asset]))
 


### PR DESCRIPTION
fixes #2087 
fixes #2088 

Fixes squared `sign` button

### Summary:
[comment]: # (Summarise the problem and how the pull request solves it)
...

### Steps to test:
- Open Status
- Navigate wallet
- Make sure long amount do not break UI
- Make sure unsigned transactions `sign` button has proper style

status: ready

