### PR TITLE
Bug #2132 clear unsigned transactions when switching accounts

### DIFF
--- a/src/status_im/ui/screens/events.cljs
+++ b/src/status_im/ui/screens/events.cljs
@@ -238,6 +238,7 @@
         (assoc :current-chat-id console-chat-id)
         (dissoc :transactions
                 :transactions-queue
+                :wallet
                 :contacts/new-identity))))
 
 (register-handler-fx
@@ -268,14 +269,14 @@
                  :chat
                  :accounts)]
       (merge
-        {:db (assoc db :view-id view
-                       :navigation-stack (list view))}
-        (when (or (empty? accounts) open-console?)
-          {:dispatch-n (concat
-                         [[:init-console-chat]
-                          [:load-commands!]]
-                         (when open-console?
-                           [[:navigate-to :chat console-chat-id]]))})))))
+       {:db (assoc db
+                   :view-id view
+                   :navigation-stack (list view))}
+       (when (or (empty? accounts) open-console?)
+         {:dispatch-n (concat [[:init-console-chat]
+                               [:load-commands!]]
+                              (when open-console?
+                                [[:navigate-to :chat console-chat-id]]))})))))
 
 (register-handler-fx
   :initialize-crypt
@@ -315,7 +316,7 @@
       "handler-result" (let [orig-params (:origParams data)]
                          ;; TODO(janherich): figure out and fix chat_id from event
                          (dispatch [:command-handler! (:chat-id orig-params) orig-params
-                                    {:result {:returned (dissoc data :origParams)}}])) 
+                                    {:result {:returned (dissoc data :origParams)}}]))
       (log/debug "Unknown jail signal " event))))
 
 (register-handler-fx


### PR DESCRIPTION
fix for #2132 

### Summary:
Clear the wallet map when switching account so that there is no shared state between accounts

related to #1784

