### PR TITLE
fix #2081 - fixed toolbar title for smaller ios screens

### DIFF
--- a/src/status_im/components/toolbar_new/styles.cljs
+++ b/src/status_im/components/toolbar_new/styles.cljs
@@ -120,4 +120,6 @@
 
 (def item-text-white-background {:color styles/color-blue4})
 
-(def ios-content-item {:position :absolute :right 90 :left 90})
+;;TODO(goranjovic) - Breaks the toolbar title into new line on smaller screens
+;;e.g. see Discover > Popular hashtags on iPhone 5s
+(def ios-content-item {:position :absolute :right 40 :left 40})

--- a/src/status_im/ui/screens/discover/styles.cljs
+++ b/src/status_im/ui/screens/discover/styles.cljs
@@ -256,6 +256,7 @@
 
 (def discover-container
   {:flex             1
+   :margin-top       16
    :background-color styles/color-light-gray})
 
 (def list-container


### PR DESCRIPTION
Fixed style issues for heading of Popular hashtags screen in Discover

- Title "Popular hashtags" is no longer broken in two lines on iphones with smaller screens (e.g. 5s)
- Fixed vertical margin for toolbar

Partially addresses #2081 for ios only and not including style fixes for rendered statuses which affect all Discover screens (addressed separately in #2119)

status: ready
