### PR TITLE
Extend tap area for sign buttons

### DIFF
--- a/src/status_im/ui/screens/wallet/request/views.cljs
+++ b/src/status_im/ui/screens/wallet/request/views.cljs
@@ -62,12 +62,12 @@
           [components/choose-currency wallet.styles/choose-currency]]]]]
      [components/separator]
      [react/view wallet.styles/buttons-container
-      [react/touchable-highlight {:on-press #()}
+      [react/touchable-highlight {:style wallet.styles/button :disabled true}
        [react/view (wallet.styles/button-container false)
         [vi/icon :icons/share {:color :white :container-style styles/share-icon-container}]
         [components/button-text (i18n/label :t/share)]]]
       [react/view components.styles/flex]
-      [react/touchable-highlight {:on-press (when request-enabled? send-request)}
+      [react/touchable-highlight {:style wallet.styles/button :disabled (not request-enabled?) :on-press  send-request}
        [react/view (wallet.styles/button-container request-enabled?)
         [components/button-text (i18n/label :t/send-request)]
         [vi/icon :icons/forward {:color :white :container-style wallet.styles/forward-icon-container}]]]]]))

--- a/src/status_im/ui/screens/wallet/send/views.cljs
+++ b/src/status_im/ui/screens/wallet/send/views.cljs
@@ -60,11 +60,11 @@
 (defview signing-buttons [cancel-handler sign-handler in-progress?]
   (letsubs [sign-enabled? [:wallet.send/sign-password-enabled?]]
     [react/view wallet.styles/buttons-container
-     [react/touchable-highlight {:on-press cancel-handler}
+     [react/touchable-highlight {:style wallet.styles/button :on-press cancel-handler}
       [react/view (wallet.styles/button-container true)
        [components/button-text (i18n/label :t/cancel)]]]
      [react/view components.styles/flex]
-     [react/touchable-highlight {:on-press sign-handler}
+     [react/touchable-highlight {:style wallet.styles/button :on-press sign-handler}
       [react/view (wallet.styles/button-container sign-enabled?)
        (when in-progress? [react/activity-indicator {:animating? true}])
        [components/button-text (i18n/label :t/transactions-sign-transaction)]
@@ -82,11 +82,12 @@
         immediate-sign-enabled? (and sign-enabled? sufficient-funds?)]
     [react/view wallet.styles/buttons-container
      (when sign-enabled?
-       [react/touchable-highlight {:on-press sign-later-handler}
+       [react/touchable-highlight {:style wallet.styles/button :on-press sign-later-handler}
         [react/view (wallet.styles/button-container sign-enabled?)
          [components/button-text (i18n/label :t/transactions-sign-later)]]])
      [react/view components.styles/flex]
-     [react/touchable-highlight {:on-press (when immediate-sign-enabled? #(re-frame/dispatch [:set-in [:wallet/send-transaction :signing?] true]))}
+     [react/touchable-highlight {:style wallet.styles/button
+                                 :on-press (when immediate-sign-enabled? #(re-frame/dispatch [:set-in [:wallet/send-transaction :signing?] true]))}
       [react/view (wallet.styles/button-container immediate-sign-enabled?)
        [components/button-text (i18n/label :t/transactions-sign-transaction)]
        [vector-icons/icon :icons/forward {:color :white :container-style wallet.styles/forward-icon-container}]]]]))

--- a/src/status_im/ui/screens/wallet/styles.cljs
+++ b/src/status_im/ui/screens/wallet/styles.cljs
@@ -33,10 +33,12 @@
              :elevation        0}})
 
 (def buttons-container
-  {:margin-vertical    15
-   :padding-horizontal 12
-   :flex-direction     :row
-   :align-items        :center})
+  {:flex-direction :row
+   :align-items    :center})
+
+(def button
+  {:padding-vertical   15
+   :padding-horizontal 12})
 
 (def forward-icon-container
   {:margin-left 8})


### PR DESCRIPTION

### Summary:

Extend tap area button so that it's easier to sign a transaction.

### Steps to test:
- Open Status
- Navigate wallet / send
- Make sure sign tap area are big enough

status: ready

