### PR TITLE
Removal of wallet bot and its leftovers

### DIFF
--- a/resources/default_contacts.json
+++ b/resources/default_contacts.json
@@ -24,22 +24,6 @@
         "unremovable?": true
     },
 
-    "wallet":
-    {
-        "name":
-        {
-            "en": "Wallet",
-            "es": "Monedero",
-            "es-ar": "Monedero",
-            "ru": "Кошелек"
-        },
-        "photo-path": "icon_wallet_avatar",
-        "dapp?": true,
-        "pending?": true,
-        "bot-url": "local://wallet-bot",
-        "unremovable?": true
-    },
-
     "mailman":
     {
         "name":

--- a/src/status_im/chat/events.cljs
+++ b/src/status_im/chat/events.cljs
@@ -82,7 +82,7 @@
 
 (defn init-console-chat
   [{:keys [chats] :accounts/keys [current-account-id] :as db} existing-account?]
-  (if (chats const/console-chat-id)
+  (if (get chats const/console-chat-id)
     {:db db}
     (cond-> {:db (-> db
                      (assoc :new-chat sign-up/console-chat)
@@ -177,12 +177,10 @@
       (if account-creation?
         {:db new-db
          :dispatch-n [event]}
-        (let [chats            (->> all-stored-chats
-                                    (map (fn [{:keys [chat-id] :as chat}]
-                                           [chat-id (assoc chat :last-message (get-last-stored-message chat-id))]))
-                                    (into {}))
-              ;;TODO temporary hide wallet chat, this code should be deleted after wallet contact will be deleted
-              chats' (dissoc chats "wallet")]
+        (let [chats (->> all-stored-chats
+                         (map (fn [{:keys [chat-id] :as chat}]
+                                [chat-id (assoc chat :last-message (get-last-stored-message chat-id))]))
+                         (into {}))]
           (-> new-db
               (assoc-in [:message-data :preview] message-previews)
               (assoc :handler-data (handler-data/get-all))

--- a/src/status_im/chat/events.cljs
+++ b/src/status_im/chat/events.cljs
@@ -184,7 +184,7 @@
           (-> new-db
               (assoc-in [:message-data :preview] message-previews)
               (assoc :handler-data (handler-data/get-all))
-              (assoc :chats chats')
+              (assoc :chats chats)
               (init-console-chat true)
               (update :dispatch-n conj event)))))))
 

--- a/src/status_im/chat/events/receive_message.cljs
+++ b/src/status_im/chat/events/receive_message.cljs
@@ -32,18 +32,6 @@
   [{:accounts/keys [accounts current-account-id]}]
   (get-in accounts [current-account-id :public-key]))
 
-(defn- wallet-message
-  [{:keys [content-type] :as message}]
-  (log/debug "Wallet msg")
-  (let [wallet-ct (if (= content-type const/content-type-command)
-                    const/content-type-wallet-command
-                    const/content-type-wallet-request)]
-    (-> message
-        (assoc :clock-value 0
-               :chat-id const/wallet-chat-id
-               :content-type wallet-ct)
-        (dissoc :group-id))))
-
 (defn add-message
   [{:keys [db get-stored-message get-last-stored-message pop-up-chat?
            get-last-clock-value current-timestamp random-id]}

--- a/src/status_im/chat/handlers.cljs
+++ b/src/status_im/chat/handlers.cljs
@@ -12,8 +12,7 @@
             [status-im.constants :refer [text-content-type
                                          content-type-command
                                          content-type-command-request
-                                         console-chat-id
-                                         wallet-chat-id]]
+                                         console-chat-id]]
             [status-im.utils.random :as random]
             [status-im.chat.sign-up :as sign-up-service]
             [status-im.ui.screens.navigation :as nav]

--- a/src/status_im/chat/handlers/send_message.cljs
+++ b/src/status_im/chat/handlers/send_message.cljs
@@ -5,7 +5,6 @@
             [status-im.chat.events.console :as console]
             [status-im.chat.utils :as cu]
             [status-im.constants :refer [console-chat-id
-                                         wallet-chat-id
                                          text-content-type
                                          content-type-log-message
                                          content-type-command
@@ -103,9 +102,8 @@
     (fn [_ [_ add-to-chat-id params hidden-params]]
       (dispatch [::add-command add-to-chat-id params])
       (dispatch [::save-command! add-to-chat-id params hidden-params])
-      (when (not= add-to-chat-id wallet-chat-id)
-        (dispatch [::dispatch-responded-requests! params])
-        (dispatch [::send-command-protocol! params])))))
+      (dispatch [::dispatch-responded-requests! params])
+      (dispatch [::send-command-protocol! params]))))
 
 (register-handler ::add-command
   (after (fn [_ [_ _ {:keys [handler]}]]

--- a/src/status_im/chat/handlers/webview_bridge.cljs
+++ b/src/status_im/chat/handlers/webview_bridge.cljs
@@ -100,7 +100,6 @@
                       :action  :request
                       :params  params}])
           :webview-scan-qr (dispatch [:show-scan-qr :webview-address-from-qr])
-          :webview-send-eth (dispatch [:webview-send-eth! params])
           :nfc (dispatch [:webview-nfc params])
           (log/error (str "Unknown event: " event')))))))
 
@@ -122,21 +121,6 @@
     (fn [{:keys [webview-bridge]} [_ data]]
       (when webview-bridge
         (.sendToBridge webview-bridge (t/clj->json data))))))
-
-(register-handler :webview-send-eth!
-  (u/side-effect!
-    (fn [{:accounts/keys [current-account-id]} [_ {:keys [amount address]}]]
-      (let [context    {:from current-account-id}
-            path       [:functions :send]
-            parameters {:context    context
-                        :parameters {:amount  amount
-                                     :address address}}]
-        (s/call-jail
-          {:jail-id  c/wallet-chat-id
-           :path     path
-           :params   parameters
-           :callback (fn [data]
-                       (log/debug :webview-send-eth-callback data))})))))
 
 (register-handler :webview-nfc
   (u/side-effect!

--- a/src/status_im/chat/new_public_chat/db.cljs
+++ b/src/status_im/chat/new_public_chat/db.cljs
@@ -1,14 +1,13 @@
 (ns status-im.chat.new-public-chat.db
   (:require [cljs.spec.alpha :as spec]
             status-im.utils.db
-            [status-im.constants :refer [console-chat-id wallet-chat-id]]
+            [status-im.constants :refer [console-chat-id]]
             [clojure.string :as string]
             [status-im.utils.homoglyph :as utils]))
 
 (defn legal-name? [username]
   (let [username (some-> username string/trim)]
-    (and (not (utils/matches username console-chat-id))
-         (not (utils/matches username wallet-chat-id)))))
+    (not (utils/matches username console-chat-id))))
 
 (spec/def ::legal-name legal-name?)
 

--- a/src/status_im/chat/utils.cljs
+++ b/src/status_im/chat/utils.cljs
@@ -9,9 +9,6 @@
 (def not-console?
   (complement console?))
 
-(defn wallet? [s]
-  (= consts/wallet-chat-id s))
-
 (defn safe-trim [s]
   (when (string? s)
     (str/trim s)))

--- a/src/status_im/chat/views/message/message.cljs
+++ b/src/status_im/chat/views/message/message.cljs
@@ -24,7 +24,6 @@
             [status-im.chat.views.message.datemark :refer [chat-datemark]]
             [status-im.react-native.resources :as res]
             [status-im.constants :refer [console-chat-id
-                                         wallet-chat-id
                                          text-content-type
                                          content-type-log-message
                                          content-type-status
@@ -100,11 +99,7 @@
   (let [{:keys [recipient amount]} (walk/keywordize-keys params)]
     [text {:style st/command-text
            :font  :default}
-     (if (= current-chat-id wallet-chat-id)
-       (let [label-val (if outgoing? :t/chat-send-eth-to :t/chat-send-eth-from)]
-         (label label-val {:amount    amount
-                           :chat-name (or name contact-address recipient)}))
-       (label :t/chat-send-eth {:amount amount}))]))
+     (label :t/chat-send-eth {:amount amount})]))
 
 (defn wallet-command? [content-type]
   (#{c/content-type-wallet-command c/content-type-wallet-request} content-type))
@@ -294,9 +289,6 @@
         status          (cond (and (not (console/commands-with-delivery-status (:command content)))
                                    (cu/console? chat-id))
                               :seen
-
-                              (cu/wallet? chat-id)
-                              :sent
 
                               :else
                               (or delivery-status message-status app-db-message-status-value :sending))]

--- a/src/status_im/chat/views/toolbar_content.cljs
+++ b/src/status_im/chat/views/toolbar_content.cljs
@@ -13,11 +13,11 @@
             [status-im.utils.datetime :as time]
             [status-im.utils.platform :refer [platform-specific]]
             [status-im.utils.gfycat.core :refer [generate-gfy]]
-            [status-im.constants :refer [console-chat-id wallet-chat-id]]))
+            [status-im.constants :refer [console-chat-id]]))
 
 (defn online-text [contact chat-id]
   (cond
-    (#{console-chat-id wallet-chat-id} chat-id) (label :t/available)
+    (= console-chat-id chat-id) (label :t/available)
     contact (let [last-online      (get contact :last-online)
                   last-online-date (time/to-date last-online)
                   now-date         (t/now)]

--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -16,17 +16,11 @@
 (def content-type-status "status")
 
 (def max-chat-name-length 20)
-
-(def response-input-hiding-duration 100)
 (def response-suggesstion-resize-duration 100)
-
 (def default-number-of-messages 20)
 (def blocks-per-hour 120)
 
-(def default-number-of-discover-search-results 20)
-
 (def console-chat-id "console")
-(def wallet-chat-id "wallet")
 
 (def default-network "testnet_rpc")
 

--- a/src/status_im/data_store/realm/schemas/account/core.cljs
+++ b/src/status_im/data_store/realm/schemas/account/core.cljs
@@ -14,7 +14,7 @@
             [status-im.data-store.realm.schemas.account.v13.core :as v13]
             [status-im.data-store.realm.schemas.account.v14.core :as v14]
             [status-im.data-store.realm.schemas.account.v15.core :as v15]
-            ))
+            [status-im.data-store.realm.schemas.account.v16.core :as v16]))
 
 ;; TODO(oskarth): Add failing test if directory vXX exists but isn't in schemas.
 
@@ -64,4 +64,7 @@
               {:schema        v15/schema
                :schemaVersion 15
                :migration     v15/migration}
+              {:schema        v16/schema
+               :schemaVersion 16
+               :migration     v16/migration}
               ])

--- a/src/status_im/data_store/realm/schemas/account/v16/core.cljs
+++ b/src/status_im/data_store/realm/schemas/account/v16/core.cljs
@@ -1,0 +1,50 @@
+(ns status-im.data-store.realm.schemas.account.v16.core
+  (:require [status-im.data-store.realm.schemas.account.v11.chat :as chat]
+            [status-im.data-store.realm.schemas.account.v1.chat-contact :as chat-contact]
+            [status-im.data-store.realm.schemas.account.v6.command :as command]
+            [status-im.data-store.realm.schemas.account.v9.command-parameter :as command-parameter]
+            [status-im.data-store.realm.schemas.account.v15.contact :as contact]
+            [status-im.data-store.realm.schemas.account.v1.discover :as discover]
+            [status-im.data-store.realm.schemas.account.v1.kv-store :as kv-store]
+            [status-im.data-store.realm.schemas.account.v10.message :as message]
+            [status-im.data-store.realm.schemas.account.v12.pending-message :as pending-message]
+            [status-im.data-store.realm.schemas.account.v1.processed-message :as processed-message]
+            [status-im.data-store.realm.schemas.account.v15.request :as request]
+            [status-im.data-store.realm.schemas.account.v1.tag :as tag]
+            [status-im.data-store.realm.schemas.account.v1.user-status :as user-status]
+            [status-im.data-store.realm.schemas.account.v5.contact-group :as contact-group]
+            [status-im.data-store.realm.schemas.account.v5.group-contact :as group-contact]
+            [status-im.data-store.realm.schemas.account.v8.local-storage :as local-storage]
+            [status-im.data-store.realm.schemas.account.v13.handler-data :as handler-data]
+            [taoensso.timbre :as log]))
+
+(def schema [chat/schema
+             chat-contact/schema
+             command/schema
+             command-parameter/schema
+             contact/schema
+             discover/schema
+             kv-store/schema
+             message/schema
+             pending-message/schema
+             processed-message/schema
+             request/schema
+             tag/schema
+             user-status/schema
+             contact-group/schema
+             group-contact/schema
+             local-storage/schema
+             handler-data/schema])
+
+(defn migration [old-realm new-realm]
+  (log/debug "migrating v16 account database: " old-realm new-realm)
+  (when-let [wallet-chat (some-> new-realm
+                                 (.objects "chat")
+                                 (.filtered "chat-id = \"wallet\"")
+                                 (aget 0))]
+    (.delete new-realm wallet-chat))
+  (when-let [wallet-contact (some-> new-realm
+                                    (.objects "contact")
+                                    (.filtered "whisper-identity = \"wallet\"")
+                                    (aget 0))]
+    (.delete new-realm wallet-contact)))

--- a/src/status_im/ui/screens/contacts/events.cljs
+++ b/src/status_im/ui/screens/contacts/events.cljs
@@ -271,10 +271,7 @@
   [(inject-cofx ::get-all-contacts)]
   (fn [{:keys [db all-contacts]} _]
     (let [contacts-list (map #(vector (:whisper-identity %) %) all-contacts)
-          contacts (into {} contacts-list)
-          contacts' (if (get contacts "wallet")
-                      (assoc-in contacts ["wallet" :pending?] true)
-                      contacts)]
+          contacts (into {} contacts-list)]
       {:db         (assoc db :contacts/contacts contacts)
        :dispatch-n (mapv (fn [_ contact] [:watch-contact contact]) contacts)})))
 

--- a/src/status_im/ui/screens/group/db.cljs
+++ b/src/status_im/ui/screens/group/db.cljs
@@ -2,7 +2,7 @@
   (:require-macros [status-im.utils.db :refer [allowed-keys]])
   (:require [cljs.spec.alpha :as spec]
             status-im.utils.db
-            [status-im.constants :refer [console-chat-id wallet-chat-id]]
+            [status-im.constants :refer [console-chat-id]]
             [clojure.string :as string]
             [status-im.utils.homoglyph :as utils]))
 

--- a/src/status_im/ui/screens/profile/db.cljs
+++ b/src/status_im/ui/screens/profile/db.cljs
@@ -13,7 +13,6 @@
     (every? false?
             [(string/blank? username)
              (homoglyph/matches username constants/console-chat-id)
-             (homoglyph/matches username constants/wallet-chat-id)
              (string/includes? username chat.constants/command-char)
              (string/includes? username chat.constants/bot-char)])))
 

--- a/src/status_im/utils/js_resources.cljs
+++ b/src/status_im/utils/js_resources.cljs
@@ -23,16 +23,13 @@
 
 (def demo-bot-js (slurp-bot :demo_bot))
 
-(def wallet-js (slurp-bot :wallet))
-
 (def resources
   {:transactor-group-bot    transactor-group-js
    :transactor-personal-bot transactor-personal-js
    :console-bot             console-js
    :browse-bot              browse-js
    :mailman-bot             mailman-js
-   :demo-bot                demo-bot-js
-   :wallet-bot              wallet-js})
+   :demo-bot                demo-bot-js})
 
 (defn get-resource [url]
   (let [resource-name (keyword (subs url (count local-protocol)))]


### PR DESCRIPTION
There is no need in `wallet` dapp/bot, because both `/send` and `/request` were moved to `transactor-group`/`transactor-personal`, and internal Wallet has been created. 

This PR removes wallet and its leftovers.