### PR TITLE
fix #2160 - status author name no longer overlaps with chat button on…

### DIFF
--- a/src/status_im/ui/screens/discover/styles.cljs
+++ b/src/status_im/ui/screens/discover/styles.cljs
@@ -48,6 +48,7 @@
 
 (def discover-list-item-name-container
   {:flex            0.3
+   :padding-right   30
    :flex-direction  :row
    :justify-content :flex-start
    :align-items     :center})


### PR DESCRIPTION
Fixes #2160 

Fixes overlap between status author's name and Chat button in rendered statuses in all Discover screens on devices with smaller screens (tested on iphone 5s)

Before:

<img width=300 src=https://user-images.githubusercontent.com/711764/31613287-ef212ad8-b282-11e7-9c98-cd0279ec89ec.png />

After:


<img width=300 src=https://user-images.githubusercontent.com/711764/31613276-e66ea5dc-b282-11e7-981c-661c9bfb2686.png />

status: ready