### PR TITLE
Discover pixel perfect: Main screen and empty main screen

### DIFF
--- a/src/status_im/ui/screens/discover/all_dapps/views.cljs
+++ b/src/status_im/ui/screens/discover/all_dapps/views.cljs
@@ -33,7 +33,8 @@
    [discover-components/title
     :t/dapps
     :t/all
-    #(re-frame/dispatch [:navigate-to :discover-all-dapps])]
+    #(re-frame/dispatch [:navigate-to :discover-all-dapps])
+    true]
    (if (seq dapps)
      [list/flat-list {:data                              (vals dapps)
                       :render-fn                         render-dapp

--- a/src/status_im/ui/screens/discover/components/views.cljs
+++ b/src/status_im/ui/screens/discover/components/views.cljs
@@ -11,6 +11,7 @@
             [status-im.components.icons.vector-icons :as vector-icons]
             [status-im.i18n :as i18n]))
 
+;; TODO(oskarth): Too many positional args, refactor to map
 (defn title [label-kw action-kw action-fn active?]
   [react/view styles/title
    [react/text {:style      styles/title-text

--- a/src/status_im/ui/screens/discover/styles.cljs
+++ b/src/status_im/ui/screens/discover/styles.cljs
@@ -56,7 +56,7 @@
 (def discover-list-item-name
   {:margin-left 7
    :color       styles/color-black
-   :font-size   12})
+   :font-size   14})
 
 (def discover-list-item
   {:flex-direction :column
@@ -127,7 +127,7 @@
    :padding-left     16
    :ios              {:border-radius 3
                       :border-width  1
-                      :border-color  styles/color-light-gray5}
+                      :border-color  styles/color-white}
    :android          {:border-radius 4
                       :margin-top    2
                       :margin-bottom 4
@@ -204,7 +204,7 @@
    :padding     4
    :margin      4
    :color       styles/text1-color
-   :font-size   12})
+   :font-size   14})
 
 (defstyle dapps-list-item-avatar-container
   {:flex-direction :column
@@ -274,7 +274,6 @@
 
 (def discover-container
   {:flex             1
-   :margin-top       16
    :background-color styles/color-light-gray})
 
 (def list-container

--- a/src/status_im/ui/screens/discover/views.cljs
+++ b/src/status_im/ui/screens/discover/views.cljs
@@ -62,7 +62,7 @@
       [react/view styles/tag-count-container
        [react/text {:style styles/tag-count
                     :font  :default}
-        (:total discoveries)]]]
+        (str (:total discoveries))]]]
      [components/discover-list-item {:message         (first (:discoveries discoveries))
                                      :show-separator? false
                                      :current-account current-account}]]))


### PR DESCRIPTION
Addresses all non-test must haves except "All content hidden behind right edge on smaller screen (check 5s)"

https://github.com/status-im/status-react/issues/2076 and https://github.com/status-im/status-react/issues/2078

- Main screen (empty): fix topbar margin
- Main screen: Font size name (and dapp list item)
- Main screen: Get rid of popular hashtag border
- Main screen: All for DApps should be blue
- Main screen: tap on number of popular hashtag -> error (RN Android specific bug)

status: ready