### PR TITLE
#2078 - alignment in discover main - empty states

### DIFF
--- a/src/status_im/translations/en.cljs
+++ b/src/status_im/translations/en.cljs
@@ -174,9 +174,9 @@
    :dapps                                 "DApps"
    :dapp-profile                          "DApp Profile"
    :no-statuses-discovered                "No statuses discovered"
-   :no-statuses-discovered-body           "When somebody posts a status\nyou will see it here."
+   :no-statuses-discovered-body           "When somebody posts\na status you will see it here."
    :no-hashtags-discovered-title          "No hashtags discovered"
-   :no-hashtags-discovered-body           "When a hashtag becomes popular\nyou will see it here."
+   :no-hashtags-discovered-body           "When a hashtag becomes\npopular you will see it here."
 
    ;;settings
    :settings                              "Settings"

--- a/src/status_im/ui/screens/discover/styles.cljs
+++ b/src/status_im/ui/screens/discover/styles.cljs
@@ -422,8 +422,10 @@
 
 (def empty-section-container
   {:flex-direction   :row
-   :margin-left      32
-   :padding-vertical 50})
+   :justify-content  :center
+   :align-items      :center
+   :padding-vertical 50
+   :margin-right     6})
 
 (def empty-section-image
   {:height 70
@@ -431,7 +433,7 @@
 
 (def empty-section-description
   {:flex-direction :column
-   :margin-left    12})
+   :margin-left    6})
 
 (def empty-section-title-text
   {:font-size 15})


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

addresses #2078 specifically the alignment "must have".

status: ready

5s:

![simulator screen shot oct 17 2017 3 28 14 pm](https://user-images.githubusercontent.com/711764/31667886-fb9ef546-b350-11e7-86a7-c424ec25ebde.png)

6s:

![simulator screen shot oct 17 2017 3 25 46 pm](https://user-images.githubusercontent.com/711764/31667910-0ac95408-b351-11e7-8e4e-5b34a0cb888e.png)
