### PR TITLE
#2084 - proper sizes of open icon and button

### DIFF
--- a/src/status_im/ui/screens/discover/dapp_details/views.cljs
+++ b/src/status_im/ui/screens/discover/dapp_details/views.cljs
@@ -27,7 +27,7 @@
      [react/view styles/dapp-details-container
       [react/view styles/dapp-details-header
        [react/view styles/dapp-details-icon
-        [chat-icon.screen/chat-icon photo-path {:size 50}]]
+        [chat-icon.screen/chat-icon photo-path {:size 56}]]
        [react/view styles/dapp-details-name-container
         [react/text {:font  :medium
                      :style styles/dapp-details-name-text} name]]]

--- a/src/status_im/ui/screens/discover/styles.cljs
+++ b/src/status_im/ui/screens/discover/styles.cljs
@@ -376,7 +376,9 @@
 (def dapp-details-action-container
   {:flex-direction :row
    :margin-top     15
-   :margin-bottom  15})
+   :margin-bottom  15
+   :android        {:height 64}
+   :ios            {:height 72}})
 
 (def dapp-details-action-icon-container
   {:height           80
@@ -386,11 +388,9 @@
    :background-color styles/color-white})
 
 (defstyle dapp-details-open-icon
-  {:margin-left      10
-   :android {:width  72
-             :height 72}
-   :ios     {:width  64
-             :height 64}})
+  {:margin-left 10
+   :width       24
+   :height      24})
 
 (def dapp-details-action-name-container
   {:height           80
@@ -400,9 +400,11 @@
    :justify-content  :flex-start
    :align-items      :center})
 
-(def dapp-details-action-name-text
+(defstyle dapp-details-action-name-text
   {:margin-left 10
-   :color       styles/color-blue4})
+   :color       styles/color-blue4
+   :android     {:font-size 16}
+   :ios         {:font-size 17}})
 
 (def dapp-details-section-container
   {:background-color styles/color-white})


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

addresses #2084 

Properly fixes the must haves, specifically size of Open icon vs Open "button"

<img width=320 src=https://user-images.githubusercontent.com/711764/31670234-700dcd0c-b357-11e7-8cb9-a2e9c75c9bde.png />


status: ready

