### PR TITLE
[BUG #2189] Do not clear user set amount when scanning QR code

### DIFF
--- a/src/status_im/ui/screens/wallet/choose_recipient/events.cljs
+++ b/src/status_im/ui/screens/wallet/choose_recipient/events.cljs
@@ -11,7 +11,10 @@
       (assoc-in db [:wallet :send-transaction :camera-flashlight] toggled-state))))
 
 (defn choose-address-and-name [db address name amount]
-  (update-in db [:wallet :send-transaction] assoc :to-address address :to-name name :amount amount))
+  (update-in
+    db [:wallet :send-transaction]
+    #(cond-> (assoc % :to-address address :to-name name)
+             amount (assoc :amount amount))))
 
 (defn- extract-details
   "First try to parse as EIP67 URI, if not assume this is an address directly.

--- a/src/status_im/ui/screens/wallet/request/views.cljs
+++ b/src/status_im/ui/screens/wallet/request/views.cljs
@@ -32,7 +32,7 @@
 (views/defview qr-code [amount]
   (views/letsubs [account [:get-current-account]]
     [components.qr-code/qr-code
-     {:value   (eip67/generate-uri (:address account) {:value amount})
+     {:value   (eip67/generate-uri (:address account) (when amount {:value amount}))
       :size    256}]))
 
 (views/defview request-transaction []

--- a/src/status_im/utils/eip/eip67.cljs
+++ b/src/status_im/utils/eip/eip67.cljs
@@ -32,9 +32,13 @@
                                      (str (name k) key-value-separator  v))))
 
 (defn generate-uri
-  "Generate a EIP 67 URI based on `address` and an optional map of extra properties.
+  "Generate a EIP 67 URI based on `address` and an optional map (keyword, string) of extra properties.
    No validation of address format is performed."
   ([address] (generate-uri address nil))
   ([address m]
    (when address
-     (str scheme scheme-separator address (when m (str parameters-separator (generate-parameter-string m)))))))
+     (let [parameters (into {} (filter second m))] ;; filter nil values
+       (str scheme scheme-separator address
+            (when-not (empty? parameters)
+              (str parameters-separator (generate-parameter-string parameters))))))))
+

--- a/test/cljs/status_im/test/runner.cljs
+++ b/test/cljs/status_im/test/runner.cljs
@@ -12,6 +12,7 @@
             [status-im.test.utils.utils]
             [status-im.test.utils.money]
             [status-im.test.utils.clocks]
+            [status-im.test.utils.eip.eip67]
             [status-im.test.utils.erc20]
             [status-im.test.utils.random]
             [status-im.test.utils.gfycat.core]
@@ -38,6 +39,7 @@
  'status-im.test.utils.utils
  'status-im.test.utils.money
  'status-im.test.utils.clocks
+ 'status-im.test.utils.eip.eip67
  'status-im.test.utils.erc20
  'status-im.test.utils.random
  'status-im.test.utils.gfycat.core

--- a/test/cljs/status_im/test/utils/eip/eip67.cljs
+++ b/test/cljs/status_im/test/utils/eip/eip67.cljs
@@ -14,5 +14,8 @@
 (deftest generate-uri
   (is (= nil (eip67/generate-uri nil)))
   (is (= "ethereum:0x1234" (eip67/generate-uri "0x1234")))
+  (is (= "ethereum:0x1234" (eip67/generate-uri "0x1234" nil)))
+  (is (= "ethereum:0x1234" (eip67/generate-uri "0x1234" {})))
+  (is (= "ethereum:0x1234" (eip67/generate-uri "0x1234" {:to nil})))
   (is (= "ethereum:0x1234?to=0x5678" (eip67/generate-uri "0x1234" {:to "0x5678"})))
   (is (= "ethereum:0x1234?to=0x5678&value=1" (eip67/generate-uri "0x1234" {:to "0x5678" :value 1}))))


### PR DESCRIPTION
addresses #2189

### Summary:

QR code with no amount should not clear user set amount

### Steps to test:
- Open Status
- Navigate wallet/send
- Specify an amount
- Scan a QR code => original amount should be left intact in QR code doesn't contain amount

status: ready