### PR TITLE
Command scopes spec fix, removed contacts leftovers

### DIFF
--- a/src/status_im/data_store/contacts.cljs
+++ b/src/status_im/data_store/contacts.cljs
@@ -2,32 +2,9 @@
   (:require [status-im.data-store.realm.contacts :as data-store])
   (:refer-clojure :exclude [exists?]))
 
-(defn- command->map-item
-  [[_ {:keys [name] :as command}]]
-  [(keyword name) command])
-
-(defn- enrich-with-owner-id [owner-id]
-  (fn [[k v]]
-    [k (assoc v :owner-id owner-id)]))
-
-(defn- commands-map->commands-list
-  [commands-map]
-  (or (if (and commands-map (map? commands-map))
-        (vals commands-map)
-        commands-map)
-      '()))
-
 (defn get-all
   []
-  (map
-    (fn [{:keys [commands responses whisper-identity] :as contact}]
-      (assoc contact
-        :commands (->> commands
-                       (map command->map-item)
-                       (map (enrich-with-owner-id whisper-identity))
-                       (into {}))
-        :responses (into {} (map command->map-item responses))))
-    (data-store/get-all-as-list)))
+  (data-store/get-all-as-list))
 
 (defn get-by-id
   [whisper-identity]
@@ -41,8 +18,7 @@
                      (assoc :pending? (boolean (if contact-db
                                                  (if (nil? pending?) pending-db? pending?)
                                                  pending?)))
-                     (update :commands commands-map->commands-list)
-                     (update :responses commands-map->commands-list))]
+                     (dissoc :commands :responses :global-command))]
     (data-store/save contact' (boolean contact-db))))
 
 (defn save-all

--- a/src/status_im/data_store/realm/schemas/account/v16/contact.cljs
+++ b/src/status_im/data_store/realm/schemas/account/v16/contact.cljs
@@ -1,0 +1,32 @@
+(ns status-im.data-store.realm.schemas.account.v16.contact
+  (:require [taoensso.timbre :as log]))
+
+(def schema {:name       :contact
+             :primaryKey :whisper-identity
+             :properties {:address          {:type :string :optional true}
+                          :whisper-identity :string
+                          :name             {:type :string :optional true}
+                          :photo-path       {:type :string :optional true}
+                          :last-updated     {:type :int :default 0}
+                          :last-online      {:type :int :default 0}
+                          :pending?         {:type :bool :default false}
+                          :mixable?         {:type :bool :default false}
+                          :status           {:type :string :optional true}
+                          :fcm-token        {:type :string :optional true}
+                          :public-key       {:type     :string
+                                             :optional true}
+                          :private-key      {:type     :string
+                                             :optional true}
+                          :dapp?            {:type    :bool
+                                             :default false}
+                          :dapp-url         {:type     :string
+                                             :optional true}
+                          :bot-url          {:type     :string
+                                             :optional true}
+                          :dapp-hash        {:type     :int
+                                             :optional true}
+                          :debug?           {:type    :bool
+                                             :default false}}})
+
+(defn migration [old-realm new-realm]
+  (log/debug "migrating contact schema v16"))

--- a/src/status_im/data_store/realm/schemas/account/v16/core.cljs
+++ b/src/status_im/data_store/realm/schemas/account/v16/core.cljs
@@ -3,7 +3,7 @@
             [status-im.data-store.realm.schemas.account.v1.chat-contact :as chat-contact]
             [status-im.data-store.realm.schemas.account.v6.command :as command]
             [status-im.data-store.realm.schemas.account.v9.command-parameter :as command-parameter]
-            [status-im.data-store.realm.schemas.account.v15.contact :as contact]
+            [status-im.data-store.realm.schemas.account.v16.contact :as contact]
             [status-im.data-store.realm.schemas.account.v1.discover :as discover]
             [status-im.data-store.realm.schemas.account.v1.kv-store :as kv-store]
             [status-im.data-store.realm.schemas.account.v10.message :as message]


### PR DESCRIPTION
This PR fixes the validation error by removing redundant contact values from db schema.

(haven't found a separate bug about this issue, so created a PR without any link to existing bug)