### PR TITLE
bug #2205 - discover all links are disabled when empty

### DIFF
--- a/src/status_im/ui/screens/discover/components/views.cljs
+++ b/src/status_im/ui/screens/discover/components/views.cljs
@@ -17,7 +17,8 @@
    [react/text {:style      styles/title-text
                 :font       :medium}
     (i18n/label label-kw)]
-   [react/touchable-highlight {:on-press action-fn}
+   [react/touchable-highlight {:on-press action-fn
+                               :disabled (not active?)}
     [react/view {}
      ;; NOTE(oskarth): text-transform to uppercase not supported as RN style
      ;; https://github.com/facebook/react-native/issues/2088


### PR DESCRIPTION


addresses #2205 

### Summary:

Links to "all" recent statuses and popular hashtags were enabled even in the empty state. This PR makes them disabled when empty.

### Steps to test:
- Open Status and create a fresh account
- Open Discover
- Try to tap "all" on either recent or popular section, should be grey and disabled
- Create a status and try again, should be blue and enabled

[comment]: # (PRs will only be accepted if squashed into single commit.)


status: ready

