### PR TITLE
[bug] #2144 warning not shown when app is syncing

### DIFF
--- a/src/status_im/ui/screens/subs.cljs
+++ b/src/status_im/ui/screens/subs.cljs
@@ -57,4 +57,4 @@
 (reg-sub :syncing?
   :<- [:sync-state]
   (fn [sync-state]
-    (= sync-state :syncing)))
+    (#{:pending :in-progress} sync-state)))

--- a/src/status_im/ui/screens/wallet/main/views.cljs
+++ b/src/status_im/ui/screens/wallet/main/views.cljs
@@ -145,7 +145,7 @@
             portfolio-value  [:portfolio-value]
             portfolio-change [:portfolio-change]
             prices-loading?  [:prices-loading?]
-            syncing?        [:syncing?]
+            syncing?         [:syncing?]
             balance-loading? [:wallet/balance-loading?]
             error-message    [:wallet/error-message?]]
     [react/view {:style wallet.styles/wallet-container}


### PR DESCRIPTION
fix #2144 

Sub was using wrong keyword, syncing-state when syncing is actually called ":in-progress". Don't know what I was `thyncing` :rofl: 

Ready