### PR TITLE
#2185: After upgrade faucet, send and location messages are shown as plain text, request is shown without a text

### DIFF
--- a/src/status_im/data_store/realm/schemas/account/v15/core.cljs
+++ b/src/status_im/data_store/realm/schemas/account/v15/core.cljs
@@ -37,4 +37,5 @@
              handler-data/schema])
 
 (defn migration [old-realm new-realm]
-  (log/debug "migrating v15 account database: " old-realm new-realm))
+  (log/debug "migrating v15 account database: " old-realm new-realm)
+  (contact/migration old-realm new-realm))


### PR DESCRIPTION
Fix for #2185 

There were two problems:
1) The migration didn't work (a very very stupid merge-related issue);
2) There was no "default" scope, which means that we used the wrong jail path for old commands and responses.