### PR TITLE
[ISSUE # 2233] Fixed crash when showing QR code

### DIFF
--- a/src/status_im/ui/screens/profile/navigation.cljs
+++ b/src/status_im/ui/screens/profile/navigation.cljs
@@ -2,8 +2,9 @@
   (:require [status-im.ui.screens.navigation :as navigation]))
 
 (defmethod navigation/preload-data! :qr-code-view
-  [{:accounts/keys [current-account-id] :as db} [_ _ {:keys [contact qr-source amount?]}]]
+  [{:accounts/keys [current-account-id] :as db} [_ _ {:keys [contact qr-source qr-value amount?]}]]
   (assoc db :qr-modal {:contact   (or contact
                                       (get-in db [:accounts/accounts current-account-id]))
                        :qr-source qr-source
+                       :qr-value  qr-value
                        :amount?   amount?}))

--- a/src/status_im/ui/screens/profile/qr_code/views.cljs
+++ b/src/status_im/ui/screens/profile/qr_code/views.cljs
@@ -11,8 +11,8 @@
   (:require-macros [status-im.utils.views :refer [defview letsubs]]))
 
 (defview qr-code-view []
-  (letsubs [{:keys [photo-path address name] :as contact} [:get-in [:qr-modal :contact]]
-            {:keys [qr-source amount? dimensions]} [:get :qr-modal]
+  (letsubs [{:keys [photo-path address name]} [:get-in [:qr-modal :contact]]
+            {:keys [qr-source qr-value amount? dimensions]} [:get :qr-modal]
             {:keys [amount]} [:get :contacts/click-params]]
     [react/view styles/wallet-qr-code
      [status-bar {:type :modal}]
@@ -35,15 +35,18 @@
                                                                             :height (.-height layout)}]))}
       (when (:width dimensions)
         [react/view {:style (styles/qr-code-container dimensions)}
-         [qr-code {:value (eip67/generate-uri (get contact qr-source) (when amount? {:value  amount}))
-                   :size  (- (min (:width dimensions)
-                                  (:height dimensions))
-                             80)}]])]
+         (when-let [value (eip67/generate-uri qr-value (when amount? {:value  amount}))]
+           [qr-code {:value value
+                     :size  (- (min (:width dimensions)
+                                    (:height dimensions))
+                               80)}])])]
      [react/view styles/footer
-      [react/view styles/wallet-info
-       [react/text {:style styles/wallet-name-text} (label :t/main-wallet)]
-       [react/text {:style styles/wallet-address-text} address]]
-
+      (if (= :address qr-source)
+        [react/view styles/wallet-info
+         [react/text {:style styles/wallet-name-text} (label :t/main-wallet)]
+         [react/text {:style styles/wallet-address-text} address]]
+        [react/view styles/wallet-info
+         [react/text {:style styles/wallet-name-text} (label :t/public-key)]])
       [react/touchable-highlight {:onPress #(dispatch [:navigate-back])}
        [react/view styles/done-button
         [react/text {:style styles/done-button-text} (label :t/done)]]]]]))

--- a/src/status_im/ui/screens/profile/views.cljs
+++ b/src/status_im/ui/screens/profile/views.cljs
@@ -96,13 +96,14 @@
       nil
       styles/profile-info-item-button])])
 
-(defn show-qr [contact qr-source]
+(defn show-qr [contact qr-source qr-value]
   #(dispatch [:navigate-to-modal :qr-code-view {:contact   contact
-                                                :qr-source qr-source}]))
+                                                :qr-source qr-source
+                                                :qr-value  qr-value}]))
 
 (defn profile-options [contact k text]
   (into []
-        (concat [{:value (show-qr contact k)
+        (concat [{:value (show-qr contact k text)
                   :text  (label :t/show-qr)}]
                 (when text
                   (share-options text)))))
@@ -199,7 +200,7 @@
    [common/separator]])
 
 (defview my-profile []
-  (letsubs [{:keys [status] :as current-account} [:get-current-account]]
+  (letsubs [{:keys [status public-key] :as current-account} [:get-current-account]]
     [react/view styles/profile
      [status-bar]
      [my-profile-toolbar]
@@ -213,7 +214,7 @@
        [action-button {:label     (label :t/show-qr)
                        :icon      :icons/qr
                        :icon-opts {:color :blue}
-                       :on-press  (show-qr current-account :public-key)}]]
+                       :on-press  (show-qr current-account :public-key public-key)}]]
       [common/form-spacer]
       [react/view styles/profile-info-container
        [my-profile-info current-account]


### PR DESCRIPTION
addresses #2233

### Summary:

Fixed crash when displaying public key QR code. Also improved labels show (not wallet address anymore).

### Steps to test:
- Open Status
- Navigate Jarrad's profile
- Display it's public key as QR code: it should work fine

[comment]: # (PRs will only be accepted if squashed into single commit.)


status: ready

