### PR TITLE
[BUG #2241] Fullscreen webview don't overlap topbar

### DIFF
--- a/src/status_im/chat/views/input/animations/expandable.cljs
+++ b/src/status_im/chat/views/input/animations/expandable.cljs
@@ -80,12 +80,8 @@
        :reagent-render
        (fn [{:keys [draggable? custom-header]} & elements]
          @to-changed-height @changes-counter @max-height
-         (let [{expandable-offset :expandable-offset
-                status-bar-height :height} (get-in p/platform-specific [:component-styles :status-bar :main])
-               bottom (+ @input-height @chat-input-margin)
-               height (if @fullscreen?
-                        (+ @max-height status-bar-height expandable-offset)
-                        anim-value)]
+         (let [bottom (+ @input-height @chat-input-margin)
+               height (if @fullscreen? @max-height anim-value)]
            [view style/overlap-container
             (when (and (not hide-overlay?)
                        (not @fullscreen?))


### PR DESCRIPTION
Fix for https://github.com/status-im/status-react/issues/2241

![image](https://user-images.githubusercontent.com/1552237/31817697-6c6f969a-b595-11e7-9ccb-683361fd8213.png)

status: ready