### PR TITLE
[FIX: #2262]: DApp description for default contacts (partial fix)

### DIFF
--- a/src/status_im/data_store/realm/schemas/account/v16/contact.cljs
+++ b/src/status_im/data_store/realm/schemas/account/v16/contact.cljs
@@ -13,6 +13,7 @@
                           :mixable?         {:type :bool :default false}
                           :status           {:type :string :optional true}
                           :fcm-token        {:type :string :optional true}
+                          :description      {:type :string :optional true}
                           :public-key       {:type     :string
                                              :optional true}
                           :private-key      {:type     :string

--- a/src/status_im/ui/screens/contacts/db.cljs
+++ b/src/status_im/ui/screens/contacts/db.cljs
@@ -23,6 +23,7 @@
 (spec/def :contact/photo-path (spec/nilable string?))
 (spec/def :contact/status (spec/nilable string?))
 (spec/def :contact/fcm-token (spec/nilable string?))
+(spec/def :contact/description (spec/nilable string?))
 
 (spec/def :contact/last-updated (spec/nilable int?))
 (spec/def :contact/last-online (spec/nilable int?))
@@ -67,7 +68,8 @@
              :contact/responses
              :contact/debug?
              :contact/subscriptions
-             :contact/fcm-token]))
+             :contact/fcm-token
+             :contact/description]))
 
 ;;Contact list ui props
 (spec/def :contact-list-ui/edit? boolean?)

--- a/src/status_im/ui/screens/contacts/events.cljs
+++ b/src/status_im/ui/screens/contacts/events.cljs
@@ -211,9 +211,12 @@
        :timestamp (random/timestamp)
        :contacts  (mapv #(hash-map :identity %) contacts)})]])
 
+;; TODO(oskarth): Consider getting rid of the :when so we can overwrite default
+;; contacts with default_contacts.json This requires changing semantics of
+;; update-pending-status (from :add-contacts handler) too.
 (defn- prepare-default-contacts-events [contacts default-contacts]
   [[:add-contacts
-    (for [[id {:keys [name photo-path public-key add-chat? pending?
+    (for [[id {:keys [name photo-path public-key add-chat? pending? description
                       dapp? dapp-url dapp-hash bot-url unremovable? mixable?]}] default-contacts
           :let [id' (clojure.core/name id)]
           :when (not (get contacts id'))]
@@ -228,6 +231,7 @@
        :dapp?            dapp?
        :dapp-url         (:en dapp-url)
        :bot-url          bot-url
+       :description      description
        :dapp-hash        dapp-hash})]])
 
 (defn- prepare-add-chat-events [contacts default-contacts]


### PR DESCRIPTION
Adds description to default contacts load. Partial fix in the sense that overwriting contacts don't work yet. Add description key to v16 migration.

Partially addresses #2262. Descriptions show with fresh device, but not when upgrading. Three possible solutions:

1. Fix `prepare-default-contacts-events` and `update-pending-status` to overwrite default contacts  - unclear what implications this has, especially wrt `pending?` contact
2. Manual migrations for all descriptions in Realm (seems ugly to me)
3. Leave it as it is for release
![image](https://user-images.githubusercontent.com/1552237/31852904-4a7bf204-b680-11e7-94f1-6aab914afac7.png)

status: ready