### PR TITLE
[bug] fix #1784 db fields passed from one account to the other

### DIFF
--- a/src/status_im/ui/screens/accounts/events.cljs
+++ b/src/status_im/ui/screens/accounts/events.cljs
@@ -189,11 +189,3 @@
         ;; TODO(janherich): this is very strange and misleading, need to figure out why it'd necessary to update
         ;; account with network update when last update was more then week ago
         (account-update {:db db} nil)))))
-
-(handlers/register-handler-db
-  :set-current-account
-  (fn [{:accounts/keys [accounts] :as db} [_ address]]
-    (let [key (:public-key (accounts address))]
-      (assoc db
-             :accounts/current-account-id address
-             :current-public-key key))))

--- a/src/status_im/ui/screens/accounts/login/events.cljs
+++ b/src/status_im/ui/screens/accounts/login/events.cljs
@@ -84,7 +84,6 @@
        [_ address password account-creation?]]
     (let [{account-network :network} (get-network-by-address db address)
           db' (-> db
-                  (dissoc :db)
                   (assoc :accounts/account-creation? account-creation?)
                   (assoc-in [:accounts/login :processing] true))
           wrap-fn (cond (not status-node-started?)
@@ -118,14 +117,11 @@
   :change-account-handler
   (fn [{db :db} [_ error address new-account?]]
     (if (nil? error)
-      {:db         (assoc db :accounts/login {})
-       :dispatch-n (concat
-                     [[:stop-debugging]
-                      [:set-current-account address]
-                      [:initialize-account address]]
-                     (if new-account?
-                       [[:navigate-to-clean :chat-list]
-                        [:navigate-to-chat console-chat-id]]
-                       [[:navigate-to-clean :chat-list]
-                        [:navigate-to :chat-list]]))}
+      {:db         (dissoc db :accounts/login)
+       :dispatch-n [[:stop-debugging]
+                    [:initialize-account address]
+                    [:navigate-to-clean :chat-list]
+                    (if new-account?
+                      [:navigate-to-chat console-chat-id]
+                      [:navigate-to :chat-list])]}
       (log/debug "Error changing acount: " error))))

--- a/src/status_im/ui/screens/contacts/events.cljs
+++ b/src/status_im/ui/screens/contacts/events.cljs
@@ -274,7 +274,10 @@
     (let [contacts-list (map #(vector (:whisper-identity %) %) all-contacts)
           contacts (into {} contacts-list)]
       {:db         (assoc db :contacts/contacts contacts)
-       :dispatch-n (mapv (fn [_ contact] [:watch-contact contact]) contacts)})))
+       ;; TODO (yenda) this mapv was dispatching useless events, fixed but is it necessary if
+       ;; it was dispatching useless events before with nil
+       ;;:dispatch-n (mapv (fn [[_ contact]] [:watch-contact contact]) contacts)
+       })))
 
 (register-handler-fx
   :add-contacts

--- a/test/cljs/status_im/test/profile/events.cljs
+++ b/test/cljs/status_im/test/profile/events.cljs
@@ -31,7 +31,7 @@
          address (:address new-account)]
      (rf/dispatch [:initialize-db])
      (rf/dispatch [:add-account new-account])
-     (rf/dispatch [:set-current-account address])
+     (rf/dispatch [:initialize-account-db address])
 
      (testing "Setting status from edit profile screen"
        (let [new-status "New edit profile status"]


### PR DESCRIPTION
addresses #1784 

### Summary:

initialize-db now uses a fresh app-db and initializes it instead of resuing the re-frame app-db, preventing accounts from exchanging data accidentally as it happened a few times already for profile and wallet

status: ready

### Steps to test:

- play with profile and unsigned transaction while switching profile and see if there is any shared state (though I am pretty sure there won't because the db is flushed when switching accounts now)