### PR TITLE
bug #2281 - wrong hashtags in discover main screen

### DIFF
--- a/src/status_im/ui/screens/discover/subs.cljs
+++ b/src/status_im/ui/screens/discover/subs.cljs
@@ -35,6 +35,14 @@
         {:discoveries (take limit discoveries)
          :total       (count discoveries)}))))
 
+(reg-sub :get-top-discovery-per-tag
+  (fn [{:keys [discoveries tags]} [_ limit]]
+    (let [tag-names (map :name (take limit tags))]
+     (for [tag tag-names]
+       (let [results (get-discoveries-by-tags discoveries tag nil)]
+          [tag {:discovery (first results)
+                :total     (count results)}])))))
+
 (reg-sub :get-recent-discoveries
   (fn [db]
     (sort-by :created-at > (vals (:discoveries db)))))


### PR DESCRIPTION


addresses #2281 

### Summary:

In Discover main screen, if there are statuses with multiple hashtags, those statuses or some other can be shown with a wrong hashtag in title section - doesn't match the actual status shown below.

The issue was also caused by mixing of function parameters and subscriptions just like #2270. The solution submitted is the same - using only function parameters in inner components and subs in entire screens.

### Steps to test:
See #2281 

[comment]: # (PRs will only be accepted if squashed into single commit.)


status: ready

