### PR TITLE
Finish jail-call deduplication

### DIFF
--- a/src/status_im/utils/async.cljs
+++ b/src/status_im/utils/async.cljs
@@ -1,0 +1,25 @@
+(ns status-im.utils.async
+  "Utility namespace containing `core.async` helper constructs"
+  (:require-macros [cljs.core.async.macros :as async])
+  (:require [cljs.core.async :as async]))
+
+(defn chunked-pipe!
+  "Connects input channel to the output channel with time-based chunking.
+  `flush-time` parameter decides for how long we are waiting to accumulate
+  value from input channel in a vector before it's put on the output channel.
+  When `flush-time` interval elapses and there are no values accumulated, nothing
+  is put on the output channel till the next input arrives, which is then put on
+  the output channel immediately (wrapped in a vector).
+  When input channel is closed, output channel is closed as well and go-loop exits."
+  [input-ch output-ch flush-time]
+  (async/go-loop [acc []
+                  flush? false]
+    (if flush?
+      (do (async/put! output-ch acc)
+          (recur [] false))
+      (let [[v ch] (async/alts! [input-ch (async/timeout flush-time)])]
+        (if (= ch input-ch)
+          (if v
+            (recur (conj acc v) (and (seq acc) flush?))
+            (async/close! output-ch))
+          (recur acc (seq acc)))))))

--- a/src/status_im/utils/transducers.cljs
+++ b/src/status_im/utils/transducers.cljs
@@ -1,0 +1,26 @@
+(ns status-im.utils.transducers
+  "Utility namespace containing various usefull transducers")
+
+(defn last-distinct-by
+  "Just like regular `distinct`, but you provide function
+  computing the distinctness of input elements and when
+  duplicate elements are removed, the last, not the first
+  one is removed."
+  [compare-fn]
+  (fn [rf]
+    (let [accumulated-input (volatile! {:seen {}
+                                        :input []})]
+      (fn
+        ([] (rf))
+        ([result]
+         (reduce rf result (:input @accumulated-input)))
+        ([result input]
+         (let [compare-value (compare-fn input)]
+           (if-let [previous-duplicate-index (get-in @accumulated-input [:seen compare-value])]
+             (do (vswap! accumulated-input assoc-in [:input previous-duplicate-index] input)
+                 result)
+             (do (vswap! accumulated-input (fn [{previous-input :input :as accumulated-input}]
+                                             (-> accumulated-input
+                                                 (update :seen assoc compare-value (count previous-input))
+                                                 (update :input conj input))))
+                 result))))))))

--- a/test/cljs/status_im/test/runner.cljs
+++ b/test/cljs/status_im/test/runner.cljs
@@ -16,7 +16,9 @@
             [status-im.test.utils.erc20]
             [status-im.test.utils.random]
             [status-im.test.utils.gfycat.core]
-            [status-im.test.utils.signing-phrase.core]))
+            [status-im.test.utils.signing-phrase.core]
+            [status-im.test.utils.transducers]
+            [status-im.test.utils.async]))
 
 (enable-console-print!)
 
@@ -27,6 +29,7 @@
 (set! goog.DEBUG false)
 
 (doo-tests
+ 'status-im.test.utils.async
  'status-im.test.chat.events
  'status-im.test.accounts.events
  ;;'status-im.test.contacts.events
@@ -43,4 +46,5 @@
  'status-im.test.utils.erc20
  'status-im.test.utils.random
  'status-im.test.utils.gfycat.core
- 'status-im.test.utils.signing-phrase.core)
+ 'status-im.test.utils.signing-phrase.core
+ 'status-im.test.utils.transducers)

--- a/test/cljs/status_im/test/utils/async.cljs
+++ b/test/cljs/status_im/test/utils/async.cljs
@@ -1,0 +1,36 @@
+(ns status-im.test.utils.async
+  (:require-macros [cljs.core.async.macros :as async])
+  (:require [cljs.test :refer-macros [deftest is testing async]]
+            [cljs.core.async :as async]
+            [status-im.utils.async :as async-util]))
+
+(deftest chunking-test
+  (testing "Accumulating result works as expected for `chunked-pipe!`"
+    (let [input (async/chan)
+          output (async/chan)]
+      (async-util/chunked-pipe! input output 100)
+      (async done
+             (async/go
+               (async/put! input 1)
+               (async/put! input 2)
+               (async/put! input 3)
+               (<! (async/timeout 110))
+               (async/put! input 1)
+               (async/put! input 2)
+               (<! (async/timeout 300))
+               (async/put! input 1)
+               (is (= [1 2 3] (async/<! output)))
+               (is (= [1 2] (async/<! output)))
+               (is (= [1] (async/<! output)))
+               (done))))))
+
+(deftest chunking-closing-test
+  (testing "Closing input channel closes output channel connected through `chunked-pipe!`"
+    (let [input (async/chan)
+          output (async/chan)]
+      (async-util/chunked-pipe! input output 100)
+      (async done
+             (async/go
+               (async/close! input)
+               (is (= nil (async/<! output)))
+               (done))))))

--- a/test/cljs/status_im/test/utils/transducers.cljs
+++ b/test/cljs/status_im/test/utils/transducers.cljs
@@ -1,0 +1,58 @@
+(ns status-im.test.utils.transducers
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [status-im.utils.transducers :as transducers]
+            [status-im.native-module.impl.module :as native-module]))
+
+(def ^:private preview-call-1
+  {:jail-id 1
+   :path [:preview]
+   :params {:chat-id 1}
+   :callback (fn []
+               [[:msg-id 1]])})
+
+(def ^:private preview-call-2
+  {:jail-id 1
+   :path [:preview]
+   :params {:chat-id 1}
+   :callback (fn []
+               [[:msg-id 2]])})
+
+(def ^:private jail-calls
+  '({:jail-id 1
+     :path [:suggestions]
+     :params {:arg 0}}
+    {:jail-id 1
+     :path [:function]
+     :params {:sub :a}}
+    {:jail-id 1
+     :path [:function]
+     :params {:sub :b}}
+    {:jail-id 1
+     :path [:suggestions]
+     :params {:arg 1}}
+    {:jail-id 1
+     :path [:suggestions]
+     :params {:arg 2}}
+    preview-call-1
+    preview-call-2))
+
+(deftest last-distinct-by-test
+  (testing "Elements are removed from input according to provided `compare-fn`,
+           when duplicate elements are removed, the last one stays"
+    (is (= (sequence (transducers/last-distinct-by native-module/compare-calls) jail-calls)
+           '({:jail-id 1
+              :path [:suggestions]
+              :params {:arg 2}}
+             {:jail-id 1
+              :path [:function]
+              :params {:sub :a}}
+             {:jail-id 1
+              :path [:function]
+              :params {:sub :b}}
+             preview-call-1
+             preview-call-2))))
+  (testing "Edge cases with input size `N=0` and `N=1` work as well"
+    (is (= (sequence (transducers/last-distinct-by identity) '())
+           '()))
+    (is (= (sequence (transducers/last-distinct-by identity) '(1))
+           '(1)))))


### PR DESCRIPTION
### Summary:

[comment]: # (Summarise the problem and how the pull request solves it)
This PR fixes #2310 and removes previous temporary solution for jail-call de-duplication and replaces it with general primitives (parametrised time-windowed async pipe + transducer removing duplicates) which are unit-tested. 
We no longer space each jail-call at least 100ms apart (as the bug in `status-go` which made this hack necessary has already been resolved), but we maintain 400ms time-window during which we can de-duplicate jail-calls by custom criteria (which is helpful for jail-calls for example triggered by user typing, as are the command suggestions).

### Steps to test:
- Open `/send` command in 1-1 chat and type the amount fast

[comment]: # (PRs will only be accepted if squashed into single commit.)


status: ready

