### PR TITLE
bug #2222 - dapp name in two lines and centered

### DIFF
--- a/src/status_im/ui/screens/discover/all_dapps/views.cljs
+++ b/src/status_im/ui/screens/discover/all_dapps/views.cljs
@@ -23,7 +23,7 @@
          [react/view [chat-icon/contact-icon-view dapp {:size 80}]]]
         [react/text {:style           styles/dapps-list-item-name
                      :font            :medium
-                     :number-of-lines 1}
+                     :number-of-lines 2}
          name]]]]])
 
 ;; TODO(oskarth): Move this to top level discover ns

--- a/src/status_im/ui/screens/discover/styles.cljs
+++ b/src/status_im/ui/screens/discover/styles.cljs
@@ -210,7 +210,8 @@
    :padding     4
    :margin      4
    :color       styles/text1-color
-   :font-size   14})
+   :font-size   14
+   :text-align  :center})
 
 (defstyle dapps-list-item-avatar-container
   {:flex-direction :column


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

addresses #2222 but specifically the issue with dapp name in dapp list screen

### Summary:

Dapp name is now displayed in two lines (any extra text behind an ellipsis) and it is aligned to center.

[comment]: # (PRs will only be accepted if squashed into single commit.)


status: ready

![simulator screen shot oct 25 2017 9 13 44 am](https://user-images.githubusercontent.com/711764/31985288-d9a876fa-b964-11e7-8a17-feab722be282.png)

