### PR TITLE
Refactor bot db updates & subscriptions along with unit tests covering the functionality

### DIFF
--- a/src/status_im/bots/subs.cljs
+++ b/src/status_im/bots/subs.cljs
@@ -1,8 +1,13 @@
 (ns status-im.bots.subs
-  (:require [re-frame.core :refer [reg-sub subscribe]]))
+  (:require [re-frame.core :as re-frame]
+            [status-im.chat.models.input :as input-model]))
 
-(reg-sub
+(re-frame/reg-sub
   :current-bot-db
   (fn [db]
-    (let [chat-id (subscribe [:get-current-chat-id])]
-      (get-in db [:bot-db @chat-id]))))
+    (let [current-chat-id (re-frame/subscribe [:get-current-chat-id])
+          command-owner (-> db
+                            (input-model/selected-chat-command @current-chat-id)
+                            :command
+                            :owner-id)]
+      [command-owner (get-in db [:bot-db command-owner])])))

--- a/src/status_im/chat/handlers/send_message.cljs
+++ b/src/status_im/chat/handlers/send_message.cljs
@@ -218,15 +218,16 @@
 
 (register-handler :received-bot-response
   (u/side-effect!
-    (fn [{:contacts/keys [contacts]} [_ {:keys [chat-id] :as params} {:keys [result] :as data}]]
+    (fn [{:contacts/keys [contacts]} [_ {:keys [chat-id] :as params} {:keys [result bot-id] :as data}]]
       (let [{:keys [returned context]} result
             {:keys [markup text-message err]} returned
             {:keys [log-messages update-db default-db]} context
             content (or err text-message)]
         (when update-db
-          (dispatch [:update-bot-db {:bot chat-id
+          (dispatch [:update-bot-db {:bot bot-id
                                      :db  update-db}]))
         (dispatch [:suggestions-handler (assoc params
+                                          :bot-id bot-id
                                           :result data
                                           :default-db default-db)])
         (doseq [message log-messages]

--- a/src/status_im/chat/views/input/parameter_box.cljs
+++ b/src/status_im/chat/views/input/parameter_box.cljs
@@ -8,9 +8,9 @@
 
 (defview parameter-box-container []
   [{:keys [markup]} [:chat-parameter-box]
-   bot-db [:current-bot-db]]
+   bot-id-bot-db [:current-bot-db]]
   (when markup
-    (command-utils/generate-hiccup markup bot-db)))
+    (command-utils/generate-hiccup markup (first bot-id-bot-db) (second bot-id-bot-db))))
 
 (defview parameter-box-view []
   [show-parameter-box? [:show-parameter-box?]

--- a/src/status_im/native_module/impl/module.cljs
+++ b/src/status_im/native_module/impl/module.cljs
@@ -120,9 +120,9 @@
   (when status
     (call-module #(.discardTransaction status id))))
 
-(defn parse-jail [chat-id file callback]
+(defn parse-jail [bot-id file callback]
   (when status
-    (call-module #(.parseJail status chat-id file callback))))
+    (call-module #(.parseJail status bot-id file callback))))
 
 (defn execute-call [{:keys [jail-id path params callback]}]
   (when status

--- a/src/status_im/ui/screens/profile/events.cljs
+++ b/src/status_im/ui/screens/profile/events.cljs
@@ -30,10 +30,11 @@
 (handlers/register-handler-fx
   :profile/send-transaction
   [trim-v]
-  (fn [_ [chat-id]]
-    {:dispatch [:navigate-to :chat chat-id]
-     ;;TODO get rid of timeout
-     :dispatch-later [{:ms 100 :dispatch [:select-chat-input-command {:name "send"}]}]}))
+  (fn [{:keys [db]} [chat-id]]
+    (let [send-command (first (get-in db [:contacts/contacts "transactor-personal" :commands :send]))]
+      {:dispatch [:navigate-to :chat chat-id]
+       ;;TODO get rid of timeout
+       :dispatch-later [{:ms 100 :dispatch [:select-chat-input-command send-command]}]})))
 
 (handlers/register-handler-fx
   :profile/send-message
@@ -45,9 +46,10 @@
   :my-profile/update-phone-number
   ;; Switch user to the console issuing the !phone command automatically to let him change his phone number.
   ;; We allow to change phone number only from console because this requires entering SMS verification code.
-  (fn [_ _]
-    {:dispatch-n [[:navigate-to :chat console-chat-id]
-                  [:select-chat-input-command {:name "phone"}]]}))
+  (fn [{:keys [db]} _]
+    (let [phone-command (first (get-in db [:contacts/contacts "console" :responses :phone]))]
+      {:dispatch-n [[:navigate-to :chat console-chat-id]
+                    [:select-chat-input-command phone-command]]})))
 
 (defn get-current-account [{:keys [:accounts/current-account-id] :as db}]
   (get-in db [:accounts/accounts current-account-id]))

--- a/src/status_im/utils/utils.cljs
+++ b/src/status_im/utils/utils.cljs
@@ -34,9 +34,9 @@
            title
            content
            (clj->js
-             (vector (merge {:text (i18n/label :t/no)}
-                            (when on-cancel {:onPress on-cancel}))
-                     {:text (i18n/label :t/yes) :onPress on-accept})))))
+            (vector (merge {:text (i18n/label :t/no)}
+                           (when on-cancel {:onPress on-cancel}))
+                    {:text (i18n/label :t/yes) :onPress on-accept})))))
 
 (defn http-post
   ([action data on-success]
@@ -125,3 +125,11 @@
   (if (contains? m k)
     (apply update m k f args)
     m))
+
+(defn map-values
+  "Efficiently apply function to all map values"
+  [m f]
+  (into {}
+        (map (fn [[k v]]
+               [k (f v)]))
+        m))

--- a/test/cljs/status_im/test/bots/events.cljs
+++ b/test/cljs/status_im/test/bots/events.cljs
@@ -1,0 +1,50 @@
+(ns status-im.test.bots.events
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [status-im.bots.events :as bots-events]))
+
+(def ^:private initial-db
+  {:bot-db {}
+   :bot-subscriptions {}
+   :contacts/contacts
+   {"bot1" {:subscriptions
+            {:feeExplanation
+             {:subscriptions {:fee ["sliderValue"]
+                              :tx ["transaction"]}}}}
+    "bot2" {:subscriptions
+            {:roundedValue
+             {:subscriptions {:amount ["input"]}}}}
+    "bot3" {:subscriptions
+            {:warning
+             {:subscriptions {:amount ["input"]}}}}}})
+
+(deftest add-active-bot-subscriptions-test
+  (testing "That active bot subscriptions are correctly transformed and added to db"
+    (let [db (bots-events/add-active-bot-subscriptions initial-db #{"bot1" "bot3"})]
+      (is (= #{"bot1" "bot3"} (-> db :bot-subscriptions keys set)))
+      (is (= {[:sliderValue] {:feeExplanation {:fee [:sliderValue]
+                                               :tx [:transaction]}}
+              [:transaction] {:feeExplanation {:fee [:sliderValue]
+                                               :tx [:transaction]}}}
+             (-> db :bot-subscriptions (get "bot1")))))))
+
+(defn- fake-subscription-call
+  [db {:keys [chat-id parameters]}]
+  (let [{:keys [name subscriptions]} parameters
+        simulated-jail-response {:result {:returned {:sub-call-arg-map subscriptions}}}]
+    (bots-events/calculated-subscription db {:bot chat-id
+                                             :path [name]
+                                             :result simulated-jail-response})))
+
+(deftest set-in-bot-db-test
+  (let [{:keys [db call-jail-function-n]} (-> initial-db
+                                              (bots-events/add-active-bot-subscriptions #{"bot1" "bot2"})
+                                              (bots-events/set-in-bot-db {:bot "bot1"
+                                                                          :path [:sliderValue]
+                                                                          :value 2}))
+        new-db (reduce fake-subscription-call db call-jail-function-n)] 
+    (testing "That setting in value in bot-db correctly updates bot-db"
+      (is (= 2 (get-in new-db [:bot-db "bot1" :sliderValue]))))
+    (testing "That subscriptions are fired-off"
+      (is (= {:sub-call-arg-map {:fee 2
+                                 :tx nil}}
+             (get-in new-db [:bot-db "bot1" :feeExplanation]))))))

--- a/test/cljs/status_im/test/runner.cljs
+++ b/test/cljs/status_im/test/runner.cljs
@@ -6,6 +6,7 @@
             [status-im.test.wallet.events]
             [status-im.test.wallet.transactions.subs]
             [status-im.test.profile.events]
+            [status-im.test.bots.events]
             [status-im.test.chat.models.input]
             [status-im.test.components.main-tabs]
             [status-im.test.i18n]
@@ -35,6 +36,7 @@
  ;;'status-im.test.contacts.events
  'status-im.test.profile.events
  'status-im.test.wallet.events
+ 'status-im.test.bots.events
  'status-im.test.wallet.transactions.subs
  'status-im.test.chat.models.input
  'status-im.test.components.main-tabs

--- a/test/cljs/status_im/test/utils/utils.cljs
+++ b/test/cljs/status_im/test/utils/utils.cljs
@@ -36,3 +36,8 @@
   (is (= {:a 1} (u/update-if-present {:a 0} :a inc)))
   (is (= {:a 2} (u/update-if-present {:a 0} :a + 2)))
   (is (= {:a 0} (u/update-if-present {:a 0} :b inc))))
+
+(deftest map-values-test
+  (is (= {} (u/map-values {} inc)))
+  (is (= {:a 1} (u/map-values {:a 0} inc)))
+  (is (= {:a 1 :b 2} (u/map-values {:a 0 :b 1} inc))))


### PR DESCRIPTION
### Summary:

This is follow-up on work I did over the weekend, fixing bot subscriptions broken by the recent changes. 
So first the explanation why the subscriptions were broken:
With introduction of the command-scopes & removal of the old wallet bot, we changed the way how jail cells are created - previously each chat had it's own jail cell (identified by recipient `:whisper-id` in 1-1 chats, or newly generated random-id in group chats) and `wallet` bot was parsed in this jail, so we had wallet commands/requests/subscriptions available in each-chat. 
I don't think it was the intention, but somehow the code "organically grew" around this assumption and all our updates to the `[:bot-db bot-id]` path were done assuming that there is only one jail identified by the `current-chat-id` = `bot-id`.
By the way in case anyone doesn't know it already, `[:bot-db bot-id]` path in our db is a place where any bot could set it's own data through status api and it's also a place against which bot-subscriptions could be made (so each bot can define subscription at some path in `:bot-db` and then refer to this subscription when generating command suggestion markup, we will handle it on the RN side so that those subscriptions are automatically recalculated whenever their subscribe path changes).

But back to the problem, with the recent changes, there is no "chat-id" jail anymore, jail cells are only created for bots and DApps, so when we tried to evaluate subscription calls (for example for `transactor_personal` bot) in "chat-id" jail, the jail cell didn't exist anymore + there was only `[:bot-db bot-id]` entry for "chat-id", so we didn't have input data for subscriptions.

This PR ensures that `:bot-subscriptions` and `:bot-db` are now correctly keyed by the `:owner-id` of the relevant command, because that's also the jail-id for the cell where commands/responses/subscriptions are evaluated.
I deliberately tried to limit the changes to minimum, and didn't refactor anything in the existing Status API, the way how we interact with it, loading commands or input events, even if I think improvements there are badly needed (in separate PR).
I quite extensively tested commands/subscriptions in all possible contexts and everything seems to work fine + there are actually unit tests exercising bot update/subs so we should sleep better now :)

So what this PR does:
* Nicer and more readable way to calculate active bot subscriptions, with proper docstring
* Reworked all updates to `:bot-db` which incorrectly assume there is only one jail identified by `current-chat-id`
* Unit tests exercising the complete roundtrip (update in `:bot-db`, lookup of relevant subscriptions, calling it with proper values from `:bot-db` and again updating `:bot-db` with calculated subscription)

### Steps to test:
- Test all commands in all contexts, including things like `/request` from somebody

[comment]: # (PRs will only be accepted if squashed into single commit.)


status: ready

