### PR TITLE
fix pending messages with symmetric keys

### DIFF
--- a/src/status_im/data_store/pending_messages.cljs
+++ b/src/status_im/data_store/pending_messages.cljs
@@ -25,13 +25,13 @@
 
 (defn save
   [{:keys [id to group-id message] :as pending-message}]
-  (let [{:keys [sig symKeyID pubKey topic payload]} message
+  (let [{:keys [sig sym-key-password pubKey topic payload]} message
         id'      (get-id id to)
         chat-id  (or group-id to)
         message' (-> pending-message
                      (assoc :id id'
                             :sig sig
-                            :sym-key-id symKeyID
+                            :sym-key-password sym-key-password
                             :pub-key pubKey
                             :message-id id
                             :chat-id chat-id

--- a/src/status_im/data_store/realm/schemas/account/core.cljs
+++ b/src/status_im/data_store/realm/schemas/account/core.cljs
@@ -14,7 +14,8 @@
             [status-im.data-store.realm.schemas.account.v13.core :as v13]
             [status-im.data-store.realm.schemas.account.v14.core :as v14]
             [status-im.data-store.realm.schemas.account.v15.core :as v15]
-            [status-im.data-store.realm.schemas.account.v16.core :as v16]))
+            [status-im.data-store.realm.schemas.account.v16.core :as v16]
+            [status-im.data-store.realm.schemas.account.v17.core :as v17]))
 
 ;; TODO(oskarth): Add failing test if directory vXX exists but isn't in schemas.
 
@@ -67,4 +68,6 @@
               {:schema        v16/schema
                :schemaVersion 16
                :migration     v16/migration}
-              ])
+              {:schema        v17/schema
+               :schemaVersion 17
+               :migration     v17/migration}])

--- a/src/status_im/data_store/realm/schemas/account/v17/core.cljs
+++ b/src/status_im/data_store/realm/schemas/account/v17/core.cljs
@@ -1,0 +1,41 @@
+(ns status-im.data-store.realm.schemas.account.v17.core
+  (:require [status-im.data-store.realm.schemas.account.v11.chat :as chat]
+            [status-im.data-store.realm.schemas.account.v1.chat-contact :as chat-contact]
+            [status-im.data-store.realm.schemas.account.v6.command :as command]
+            [status-im.data-store.realm.schemas.account.v9.command-parameter :as command-parameter]
+            [status-im.data-store.realm.schemas.account.v16.contact :as contact]
+            [status-im.data-store.realm.schemas.account.v1.discover :as discover]
+            [status-im.data-store.realm.schemas.account.v1.kv-store :as kv-store]
+            [status-im.data-store.realm.schemas.account.v10.message :as message]
+            [status-im.data-store.realm.schemas.account.v17.pending-message :as pending-message]
+            [status-im.data-store.realm.schemas.account.v1.processed-message :as processed-message]
+            [status-im.data-store.realm.schemas.account.v15.request :as request]
+            [status-im.data-store.realm.schemas.account.v1.tag :as tag]
+            [status-im.data-store.realm.schemas.account.v1.user-status :as user-status]
+            [status-im.data-store.realm.schemas.account.v5.contact-group :as contact-group]
+            [status-im.data-store.realm.schemas.account.v5.group-contact :as group-contact]
+            [status-im.data-store.realm.schemas.account.v8.local-storage :as local-storage]
+            [status-im.data-store.realm.schemas.account.v13.handler-data :as handler-data]
+            [taoensso.timbre :as log]
+            [cljs.reader :as reader]))
+
+(def schema [chat/schema
+             chat-contact/schema
+             command/schema
+             command-parameter/schema
+             contact/schema
+             discover/schema
+             kv-store/schema
+             message/schema
+             pending-message/schema
+             processed-message/schema
+             request/schema
+             tag/schema
+             user-status/schema
+             contact-group/schema
+             group-contact/schema
+             local-storage/schema
+             handler-data/schema])
+
+(defn migration [old-realm new-realm]
+  (log/debug "migrating v17 account database: " old-realm new-realm))

--- a/src/status_im/data_store/realm/schemas/account/v17/pending_message.cljs
+++ b/src/status_im/data_store/realm/schemas/account/v17/pending_message.cljs
@@ -1,0 +1,26 @@
+(ns status-im.data-store.realm.schemas.account.v17.pending-message
+  (:require [taoensso.timbre :as log]))
+
+(def schema {:name       :pending-message
+             :primaryKey :id
+             :properties {:id               :string
+                          :message-id       :string
+                          :chat-id          {:type     :string
+                                             :optional true}
+                          :ack?             :bool
+                          :requires-ack?    :bool
+                          :sig              :string
+                          :pub-key          {:type     :string
+                                             :optional true}
+                          :sym-key-password {:type     :string
+                                             :optional true}
+                          :to               {:type     :string
+                                             :optional true}
+                          :payload          :string
+                          :type             :string
+                          :topic            :string
+                          :attempts         :int
+                          :was-sent?        :bool}})
+
+(defn migration [old-realm new-realm]
+  (log/debug "migrating pending-message schema v12"))

--- a/src/status_im/protocol/message.cljs
+++ b/src/status_im/protocol/message.cljs
@@ -6,7 +6,7 @@
 (s/def :message/sig :message/from)
 (s/def :message/privateKeyID (s/nilable string?))
 (s/def :message/pub-key (s/nilable string?))
-(s/def :message/sym-key-id (s/nilable string?))
+(s/def :message/sym-key-password (s/nilable string?))
 (s/def :message/topic string?)
 (s/def :message/to (s/nilable string?))
 (s/def :message/message-id string?)


### PR DESCRIPTION
Before this PR we stored `sym-key-id` in `pending-message`, but this id is valid only for the current session. That's why when we were trying to send stored pending message after application restart we got `Error: non-existent key ID ...` error. So now we store `sym-key-password` which is used for generation of `sym-key-id` fr each session. Just reminder, currently sym keys are used mostly as "topics" for messages, payload of such messages is additionally encrypted.  
 
status: ready

