### PR TITLE
fix wrong :bot in command and requests

### DIFF
--- a/src/status_im/chat/events.cljs
+++ b/src/status_im/chat/events.cljs
@@ -57,7 +57,7 @@
 (re-frame/reg-fx
   :update-message
   (fn [message]
-    (msg-store/update message)))
+    (msg-store/update-message message)))
 
 (re-frame/reg-fx
   :save-message

--- a/src/status_im/data_store/messages.cljs
+++ b/src/status_im/data_store/messages.cljs
@@ -5,8 +5,7 @@
             [status-im.utils.utils :refer [update-if-present]]
             [clojure.walk :refer [stringify-keys keywordize-keys]]
             [cljs.reader :refer [read-string]]
-            [status-im.constants :as c])
-  (:refer-clojure :exclude [update]))
+            [status-im.constants :as c]))
 
 (defn- user-statuses-to-map
   [user-statuses]
@@ -105,13 +104,17 @@
                  (assoc acc message-id (read-string preview)))
                {})))
 
+(defn- prepare-content [content]
+  (pr-str
+   (update content :params dissoc :password :password-confirmation)))
+
 (defn save
   ;; todo remove chat-id parameter
   [chat-id {:keys [message-id content] :as message}]
   (when-not (data-store/exists? message-id)
     (let [content' (if (string? content)
                      content
-                     (pr-str content))
+                     (prepare-content content))
           message' (merge default-values
                           message
                           {:chat-id   chat-id
@@ -119,7 +122,7 @@
                            :timestamp (timestamp)})]
       (data-store/save message'))))
 
-(defn update
+(defn update-message
   [{:keys [message-id] :as message}]
   (when (data-store/exists? message-id)
     (let [message (update-if-present message :user-statuses vals)]

--- a/src/status_im/protocol/handlers.cljs
+++ b/src/status_im/protocol/handlers.cljs
@@ -302,7 +302,7 @@
                                (assoc message :message-status status))
                              ;; we need to dissoc preview because it has been saved before
                              (dissoc :preview))]
-            (messages/update message')))))))
+            (messages/update-message message')))))))
 
 (defn update-message-status [status]
   (fn [db
@@ -347,8 +347,8 @@
     (fn [_ [_ {:keys [type id] :as pending-message}]]
       (pending-messages/save pending-message)
       (when (#{:message :group-message} type)
-        (messages/update {:message-id      id
-                          :delivery-status :pending}))))
+        (messages/update-message {:message-id id
+                          :delivery-status    :pending}))))
   (fn [db [_ {:keys [type id to group-id]}]]
     (if (#{:message :group-message} type)
       (let [chat-id        (or group-id to)


### PR DESCRIPTION
fix for #2315
Migration for the previous version of database set `:bot` to "transactor-personal" and "transactor-group" for all commands and requests which had nil `:bot`. That was wrong assumption (was made because i checked console's command in wrong version of app and these commands already had `:bot` = "console"). That's why console's commands were broken after migration.
 Also removes password from db.

status: ready

