### PR TITLE
Delete any open chats with removed default contacts

### DIFF
--- a/resources/default_contacts.json
+++ b/resources/default_contacts.json
@@ -248,37 +248,8 @@
         },
         "groups": ["dapps"],
         "description": "The future of work is now. Hire people or work yourself in return for ETH."
-    },
-    
-    "Commiteth":
-    {
-        "name":
-        {
-            "en": "Commiteth"
-        },
-        "photo-path": "contacts://commiteth",
-        "dapp?": true,
-        "dapp-url":
-        {
-            "en": "https://commiteth.com"
-        },
-        "groups": ["dapps"],
-        "description": "CommitETH is a GitHub bounty bot that incentivizes pull request submissions by attaching ETH or any ERC20-compatible token to open issues in GitHub."
-    },
-
-    "Etherplay":
-    {
-        "name":
-        {
-            "en": "Etherplay"
-        },
-        "photo-path": "contacts://etherplay",
-        "dapp?": true,
-        "dapp-url":
-        {
-            "en": "http://test.etherplay.io"
-        },
-        "groups": ["dapps"],
-        "description": "A transparent skill game platform. Play games and win ETH!"
     }
+
+
+
 }

--- a/src/status_im/data_store/realm/schemas/account/v17/core.cljs
+++ b/src/status_im/data_store/realm/schemas/account/v17/core.cljs
@@ -37,6 +37,21 @@
              local-storage/schema
              handler-data/schema])
 
+
+(defn remove-chat-with-contact! [new-realm whisper-identity]
+  (when-let [chat-contact (some-> new-realm
+                                  (.objects "chat-contact")
+                                  (.filtered (str "identity = \"" whisper-identity "\""))
+                                  (aget 0))]
+    (log/debug "v17 Removing chat-contact with contact" (pr-str chat-contact))
+    (.delete new-realm chat-contact))
+  (when-let [chat (some-> new-realm
+                          (.objects "chat")
+                          (.filtered (str "chat-id = \"" whisper-identity "\""))
+                          (aget 0))]
+    (log/debug "v17 Removing chat with contact" (pr-str chat))
+    (.delete new-realm chat)))
+
 (defn remove-contact! [new-realm whisper-identity]
   (when-let [contact (some-> new-realm
                              (.objects "contact")
@@ -69,7 +84,8 @@
 ;; NOTE(oskarth): Resets Realm for some dApps to be loaded by default_contacts.json instead.
 (defn migration [old-realm new-realm]
   (log/debug "migrating v17 account database: " old-realm new-realm)
-  (doseq [contact ["oaken-water-meter" "gnosis" "Commiteth" "melonport"]]
-    (remove-contact! new-realm contact))
+  (doseq [contact-id ["oaken-water-meter" "gnosis" "Commiteth" "melonport" "Etherplay"]]
+    (remove-chat-with-contact! new-realm contact-id)
+    (remove-contact! new-realm contact-id))
   (update-commands new-realm "command")
   (update-commands new-realm "command-request"))


### PR DESCRIPTION
amends this PR - #2319 

### Summary:

When a default contact is removed, any chats with that contact should also be removed to avoid the red screen.

Also removed Etherplay and Commiteth

status: ready


