### PR TITLE
No more `:account-update` handler + /phone command fix (#2256)

### DIFF
--- a/resources/js/bots/console/bot.js
+++ b/resources/js/bots/console/bot.js
@@ -429,7 +429,7 @@ function phoneSuggestions(params, context) {
 
     suggestions = ph.map(function (phone) {
         return status.components.touchable(
-            {onPress: status.components.dispatch([status.events.SET_VALUE, phone.number])},
+            {onPress: status.components.dispatch([status.events.SET_COMMAND_ARGUMENT, [0, phone.number]])},
             status.components.view(suggestionContainerStyle,
                 [status.components.view(suggestionSubContainerStyle,
                     [

--- a/src/status_im/chat/events/console.cljs
+++ b/src/status_im/chat/events/console.cljs
@@ -87,19 +87,22 @@
                                              (i18n/label :t/faucet-error)))}}))
 
    "debug"
-   (fn [{:keys [random-id db] :as cofx} {:keys [params id]}]
+   (fn [{:keys [db random-id now] :as cofx} {:keys [params id]}]
      (let [debug? (= "On" (:mode params))]
-       (assoc fx :dispatch-n (if debug?
-                               [[:initialize-debugging {:force-start? true}]
-                                [:received-message
-                                 {:message-id   random-id
-                                  :content      (i18n/label :t/debug-enabled)
-                                  :content-type const/text-content-type
-                                  :outgoing     false
-                                  :chat-id      const/console-chat-id
-                                  :from         const/console-chat-id
-                                  :to           "me"}]]
-                               [[:stop-debugging]]))))})
+       (-> {:db db}
+           (accounts-events/account-update {:debug?       debug?
+                                            :last-updated now})
+           (assoc :dispatch-n (if debug?
+                                [[:initialize-debugging {:force-start? true}]
+                                 [:received-message
+                                  {:message-id   random-id
+                                   :content      (i18n/label :t/debug-enabled)
+                                   :content-type const/text-content-type
+                                   :outgoing     false
+                                   :chat-id      const/console-chat-id
+                                   :from         const/console-chat-id
+                                   :to           "me"}]]
+                                [[:stop-debugging]])))))})
 
 (def commands-names (set (keys console-commands->fx)))
 

--- a/src/status_im/ui/screens/events.cljs
+++ b/src/status_im/ui/screens/events.cljs
@@ -26,7 +26,6 @@
             [status-im.i18n :as i18n]
             [status-im.js-dependencies :as dependencies]
             [status-im.ui.screens.db :refer [app-db]]
-            [status-im.utils.sms-listener :as sms-listener-util]
             [status-im.utils.datetime :as time]
             [status-im.utils.random :as random]
             [status-im.utils.config :as config]
@@ -114,11 +113,6 @@
     (utils/http-get url
                     #(dispatch (success-event-creator %))
                     #(dispatch (failure-event-creator %)))))
-
-(reg-fx
-  :remove-sms-listener
-  (fn [subscription]
-    (sms-listener-util/remove-sms-listener subscription)))
 
 (reg-fx
   ::init-store

--- a/src/status_im/ui/screens/profile/events.cljs
+++ b/src/status_im/ui/screens/profile/events.cljs
@@ -6,6 +6,7 @@
             [status-im.constants :refer [console-chat-id]]
             [status-im.ui.screens.profile.db :as db]
             [status-im.ui.screens.profile.navigation]
+            [status-im.ui.screens.accounts.events :as accounts-events]
             [status-im.utils.gfycat.core :as gfycat]
             [status-im.utils.handlers :as handlers]
             [status-im.utils.image-processing :refer [img->base64]]
@@ -131,36 +132,39 @@
       name
       (get-in db [:accounts/accounts current-account-id :name]))))
 
-(defn clear-profile [db]
-  (dissoc db :my-profile/profile :my-profile/drawer :my-profile/default-name))
+(defn clear-profile [fx]
+  (update fx :db dissoc :my-profile/profile :my-profile/drawer :my-profile/default-name))
 
 (handlers/register-handler-fx
   :my-profile.drawer/save-name
-  (fn [{:keys [db]} _]
+  (fn [{:keys [db now]} _]
     (let [cleaned-name (clean-name db :my-profile/drawer)]
-      {:db (clear-profile db)
-       :dispatch [:account-update {:name cleaned-name}]})))
+      (-> (clear-profile {:db db})
+          (accounts-events/account-update {:name         cleaned-name
+                                           :last-updated now})))))
 
 (handlers/register-handler-fx
   :my-profile.drawer/save-status
-  (fn [{:keys [db]} _]
+  (fn [{:keys [db now]} _]
     (let [status (get-in db [:my-profile/drawer :status])
-          new-db (clear-profile db)]
+          new-fx (clear-profile {:db db})]
       (if (string/blank? status)
-        {:db new-db}
-        {:db new-db
-         :dispatch-n [[:check-status-change status]
-                      [:account-update {:status status}]]}))))
+        new-fx
+        (-> new-fx
+            (accounts-events/account-update {:status       status
+                                             :last-updated now})
+            (assoc :dispatch-n [[:check-status-change status]]))))))
 
 (handlers/register-handler-fx
   :my-profile/save-profile
-  (fn [{:keys [db]} _]
+  (fn [{:keys [db now]} _]
     (let [{:keys [status photo-path]} (:my-profile/profile db)
-          cleaned-name                (clean-name db :my-profile/profile)
-          cleaned-edit                {:name cleaned-name
-                                       :status status
-                                       :photo-path photo-path}]
-      {:db (clear-profile db)
-       :dispatch-n [[:check-status-change status]
-                    [:account-update cleaned-edit]
-                    [:navigate-back]]})))
+          cleaned-name (clean-name db :my-profile/profile)
+          cleaned-edit {:name         cleaned-name
+                        :status       status
+                        :photo-path   photo-path
+                        :last-updated now}]
+      (-> (clear-profile {:db db})
+          (accounts-events/account-update cleaned-edit)
+          (assoc :dispatch-n [[:check-status-change status]
+                              [:navigate-back]])))))

--- a/src/status_im/ui/screens/profile/views.cljs
+++ b/src/status_im/ui/screens/profile/views.cljs
@@ -175,7 +175,7 @@
    [info-item-separator]
    [profile-info-phone-item
     phone
-    [{:value #(dispatch [:my-profile/change-phone-number])
+    [{:value #(dispatch [:my-profile/update-phone-number])
       :text  (label :t/edit)}]]
    [info-item-separator]
    [network-settings]])

--- a/src/status_im/utils/sms_listener.cljs
+++ b/src/status_im/utils/sms_listener.cljs
@@ -4,6 +4,7 @@
             [status-im.react-native.js-dependencies :as rn-dependencies]))
 
 ;; Only android is supported!
+
 (defn add-sms-listener
   "Message format: {:originatingAddress string, :body string}. Returns
   cancelable subscription."

--- a/test/cljs/status_im/test/accounts/events.cljs
+++ b/test/cljs/status_im/test/accounts/events.cljs
@@ -88,26 +88,12 @@
           (is (= {(:address account-from-realm) account-from-realm
                   (:address new-account)        new-account'} @accounts))
 
-          (testing ":account-update event"
+          (testing ":account-update-keys event"
 
-            (let [new-account'' (assoc new-account'
-                                  :status "new status"
-                                  :name "new name")]
+            (rf/dispatch [:account-update-keys])
 
-              (rf/dispatch [:set-current-account (:address new-account)])
-
-              (rf/dispatch [:account-update {:status "new status" :name "new name"}])
-
-              (is (= {(:address account-from-realm) account-from-realm
-                      (:address new-account)        new-account''}
-                     (update @accounts (:address new-account) dissoc :last-updated)))
-
-              (testing ":account-update-keys event"
-
-                (rf/dispatch [:account-update-keys])
-
-                (is (= {(:address account-from-realm) account-from-realm
-                        (:address new-account)        (assoc new-account''
-                                                        :updates-private-key "new private"
-                                                        :updates-public-key "new public")}
-                       (update @accounts (:address new-account) dissoc :last-updated)))))))))))
+            (is (= {(:address account-from-realm) account-from-realm
+                    (:address new-account)        (assoc new-account'
+                                                    :updates-private-key "new private"
+                                                    :updates-public-key "new public")}
+                   (update @accounts (:address new-account) dissoc :last-updated)))))))))


### PR DESCRIPTION
Addresses #2256 
The issue was there because of huge refactoring and changes to events/handlers made not so long ago.