### PR TITLE
Break v17 migration into two, v17 and v18, due to 0.9.12b release

### DIFF
--- a/src/status_im/data_store/realm/schemas/account/core.cljs
+++ b/src/status_im/data_store/realm/schemas/account/core.cljs
@@ -15,7 +15,9 @@
             [status-im.data-store.realm.schemas.account.v14.core :as v14]
             [status-im.data-store.realm.schemas.account.v15.core :as v15]
             [status-im.data-store.realm.schemas.account.v16.core :as v16]
-            [status-im.data-store.realm.schemas.account.v17.core :as v17]))
+            [status-im.data-store.realm.schemas.account.v17.core :as v17]
+            [status-im.data-store.realm.schemas.account.v18.core :as v18]
+            ))
 
 ;; TODO(oskarth): Add failing test if directory vXX exists but isn't in schemas.
 
@@ -70,4 +72,8 @@
                :migration     v16/migration}
               {:schema        v17/schema
                :schemaVersion 17
-               :migration     v17/migration}])
+               :migration     v17/migration}
+              {:schema        v18/schema
+               :schemaVersion 18
+               :migration     v18/migration}
+              ])

--- a/src/status_im/data_store/realm/schemas/account/v17/core.cljs
+++ b/src/status_im/data_store/realm/schemas/account/v17/core.cljs
@@ -7,7 +7,7 @@
             [status-im.data-store.realm.schemas.account.v1.discover :as discover]
             [status-im.data-store.realm.schemas.account.v1.kv-store :as kv-store]
             [status-im.data-store.realm.schemas.account.v10.message :as message]
-            [status-im.data-store.realm.schemas.account.v17.pending-message :as pending-message]
+            [status-im.data-store.realm.schemas.account.v12.pending-message :as pending-message]
             [status-im.data-store.realm.schemas.account.v1.processed-message :as processed-message]
             [status-im.data-store.realm.schemas.account.v15.request :as request]
             [status-im.data-store.realm.schemas.account.v1.tag :as tag]

--- a/src/status_im/data_store/realm/schemas/account/v18/core.cljs
+++ b/src/status_im/data_store/realm/schemas/account/v18/core.cljs
@@ -1,0 +1,41 @@
+(ns status-im.data-store.realm.schemas.account.v18.core
+  (:require [status-im.data-store.realm.schemas.account.v11.chat :as chat]
+            [status-im.data-store.realm.schemas.account.v1.chat-contact :as chat-contact]
+            [status-im.data-store.realm.schemas.account.v6.command :as command]
+            [status-im.data-store.realm.schemas.account.v9.command-parameter :as command-parameter]
+            [status-im.data-store.realm.schemas.account.v16.contact :as contact]
+            [status-im.data-store.realm.schemas.account.v1.discover :as discover]
+            [status-im.data-store.realm.schemas.account.v1.kv-store :as kv-store]
+            [status-im.data-store.realm.schemas.account.v10.message :as message]
+            [status-im.data-store.realm.schemas.account.v18.pending-message :as pending-message]
+            [status-im.data-store.realm.schemas.account.v1.processed-message :as processed-message]
+            [status-im.data-store.realm.schemas.account.v15.request :as request]
+            [status-im.data-store.realm.schemas.account.v1.tag :as tag]
+            [status-im.data-store.realm.schemas.account.v1.user-status :as user-status]
+            [status-im.data-store.realm.schemas.account.v5.contact-group :as contact-group]
+            [status-im.data-store.realm.schemas.account.v5.group-contact :as group-contact]
+            [status-im.data-store.realm.schemas.account.v8.local-storage :as local-storage]
+            [status-im.data-store.realm.schemas.account.v13.handler-data :as handler-data]
+            [taoensso.timbre :as log]
+            [cljs.reader :as reader]))
+
+(def schema [chat/schema
+             chat-contact/schema
+             command/schema
+             command-parameter/schema
+             contact/schema
+             discover/schema
+             kv-store/schema
+             message/schema
+             pending-message/schema
+             processed-message/schema
+             request/schema
+             tag/schema
+             user-status/schema
+             contact-group/schema
+             group-contact/schema
+             local-storage/schema
+             handler-data/schema])
+
+(defn migration [old-realm new-realm]
+  (log/debug "migrating v18 account database: " old-realm new-realm))

--- a/src/status_im/data_store/realm/schemas/account/v18/pending_message.cljs
+++ b/src/status_im/data_store/realm/schemas/account/v18/pending_message.cljs
@@ -1,4 +1,4 @@
-(ns status-im.data-store.realm.schemas.account.v17.pending-message
+(ns status-im.data-store.realm.schemas.account.v18.pending-message
   (:require [taoensso.timbre :as log]))
 
 (def schema {:name       :pending-message
@@ -23,4 +23,4 @@
                           :was-sent?        :bool}})
 
 (defn migration [old-realm new-realm]
-  (log/debug "migrating pending-message schema v12"))
+  (log/debug "migrating pending-message schema v18"))


### PR DESCRIPTION
Break v17 migration into two, v17 and v18, due to 0.9.12b release

We want minimal scope for 0.9.12b release so only relevant migrations made it into that. To ensure a happy upgrade path in future versions, other v17 migrations (all related to pending messages) have been moved into v18.

This means develop will break for current developers, but 0.9.12 -> 0.9.12b -> (next version / develop after this commit) will work as expected.

status: ready (but don't merge until we know for sure we don't want more things in v17 migration, see `release/0.9.12b` branch)