### PR TITLE
bug #2381 - updated statuses are broadcast

### DIFF
--- a/src/status_im/ui/screens/accounts/events.cljs
+++ b/src/status_im/ui/screens/accounts/events.cljs
@@ -150,17 +150,6 @@
       {:db            (assoc-in db [:accounts/accounts id] new-account)
        ::save-account new-account})))
 
-(handlers/register-handler-fx
-  :check-status-change
-  (fn [{{:accounts/keys [accounts current-account-id]} :db} [_ status]]
-    (let [{old-status :status} (get accounts current-account-id)
-          status-updated? (and (not= status nil)
-                               (not= status old-status))]
-      (when status-updated?
-        (let [hashtags (handlers/get-hashtags status)]
-          (when (seq hashtags)
-            {:dispatch [:broadcast-status status hashtags]}))))))
-
 (defn account-update
   "Takes map of coeffects containing `:db` and `:now` keys + new account fields,
   returns all effects necessary for account update."

--- a/test/cljs/status_im/test/profile/events.cljs
+++ b/test/cljs/status_im/test/profile/events.cljs
@@ -22,8 +22,7 @@
 
 (defn test-fixtures []
   (rf/reg-fx ::events/init-store #())
-  (rf/reg-fx ::account-events/save-account #())
-  (rf/reg-fx :check-status-change #()))
+  (rf/reg-fx ::account-events/save-account #()))
 
 (deftest profile-edit-events
   (run-test-sync
@@ -54,3 +53,17 @@
          (is (= new-status (-> @accounts
                                (get address)
                                :status))))))))
+
+(deftest test-status-change
+  (let [fx {:db {}}]
+    (is (= (profile-events/status-change fx {:old-status "this is old status"
+                                             :status     "this is new and CHANGED status"})
+           {:db         {}
+            :dispatch-n [[:broadcast-status "this is new and CHANGED status"]]}))
+    (is (= (profile-events/status-change fx {:old-status "this is old status"
+                                             :status     "this is new and #changed status"})
+           {:db         {}
+            :dispatch-n [[:broadcast-status "this is new and #changed status"]]}))
+    (is (= (profile-events/status-change fx {:old-status "this is old status"
+                                             :status     "this is old status"})
+           {:db {}}))))


### PR DESCRIPTION
addresses #2381 

### Summary:

Status broadcast is only triggered if the new version of the status (entered in profile screen or the drawer) is different than the version of status saved in account profile. 

The changes in #2256 affected the order in which code was processed and as the result account update would happen before status broadcasting. So, effectively old version of status was already lost by the time we did checks for the broadcast - new status was checked against itself, it was always seen as unchanged and no new statuses were broadcast to the network.

This PR solves the issue by checking the difference as soon as UI editing event was caught and if the new status is different we dispatch `:broadcast-status` event directly. 

The intermediary event `:check-status-change` was removed as it didn't add much value and passing the old version of status to it would only increase the complexity. As of now, difference between new and old version of status needs to be checked by the caller (i.e. `:my-profile.drawer/save-status` or `:my-profile/save-profile`) and presence of hashtags by `:broadcast-status`.


### Steps to test:
see #2381 


status: ready


