### PR TITLE
feature #1996 - navigation from status author name to profile

### DIFF
--- a/src/status_im/ui/screens/discover/components/views.cljs
+++ b/src/status_im/ui/screens/discover/components/views.cljs
@@ -69,15 +69,17 @@
                          :style  styles/discover-item-status-text
                          :status status}]
       [react/view styles/discover-list-item-second-row
-       [react/view styles/discover-list-item-name-container
-        [react/view styles/discover-list-item-avatar-container
-         [chat-icon/chat-icon
-          (display-image me? account-photo-path contact-photo-path photo-path whisper-id)
-          {:size 24}]]
-        [react/text {:style           styles/discover-list-item-name
-                     :font            :medium
-                     :number-of-lines 1}
-         (display-name me? account-name contact-name name whisper-id)]]
+       [react/touchable-highlight {:on-press #(re-frame/dispatch [:show-status-author-profile whisper-id])}
+        [react/view styles/discover-list-item-name-container
+         [react/view styles/discover-list-item-avatar-container
+          [chat-icon/chat-icon
+           (display-image me? account-photo-path contact-photo-path photo-path whisper-id)
+           {:size 24}]]
+         [react/view
+          [react/text {:style           styles/discover-list-item-name
+                       :font            :medium
+                       :number-of-lines 1}
+           (display-name me? account-name contact-name name whisper-id)]]]]
 
        (when-not me?
          (chat-button whisper-id))]
@@ -101,15 +103,17 @@
                          :style  styles/discover-item-status-text
                          :status status}]
       [react/view styles/discover-list-item-second-row
-       [react/view styles/discover-list-item-name-container
-        [react/view styles/discover-list-item-avatar-container
-         [chat-icon/chat-icon
-          (display-image me? account-photo-path contact-photo-path photo-path whisper-id)
-          {:size 24}]]
-        [react/text {:style           styles/discover-list-item-name
-                     :font            :medium
-                     :number-of-lines 1}
-         (display-name me? account-name contact-name name whisper-id)]]
+       [react/touchable-highlight {:on-press #(re-frame/dispatch [:show-status-author-profile whisper-id])}
+        [react/view styles/discover-list-item-name-container
+         [react/view styles/discover-list-item-avatar-container
+          [chat-icon/chat-icon
+           (display-image me? account-photo-path contact-photo-path photo-path whisper-id)
+           {:size 24}]]
+         [react/view
+          [react/text {:style           styles/discover-list-item-name
+                       :font            :medium
+                       :number-of-lines 1}
+           (display-name me? account-name contact-name name whisper-id)]]]]
 
        (when-not me?
          (chat-button whisper-id))]]

--- a/src/status_im/ui/screens/discover/events.cljs
+++ b/src/status_im/ui/screens/discover/events.cljs
@@ -146,3 +146,9 @@
   (u/side-effect!
     (fn [_ _]
       (discoveries/delete :created-at :asc 1000 200))))
+
+(handlers/register-handler-fx
+  :show-status-author-profile
+  (fn [{db :db} [_ identity]]
+    {:db       (assoc db :contacts/identity identity)
+     :dispatch [:navigate-to :profile]}))


### PR DESCRIPTION
addresses #1996 

### Summary:

Tapping on author name or icon in Discover statuses leads to status author profile.

### Steps:

see #1996 

status: ready


