### PR TITLE
bug #2210 - alignment and margins for smaller screens

### DIFF
--- a/src/status_im/ui/screens/discover/styles.cljs
+++ b/src/status_im/ui/screens/discover/styles.cljs
@@ -183,23 +183,19 @@
    :background-color background-color})
 
 (def all-dapps-flat-list
-  {:justify-content  :center
-   :flex-direction   :row
+  {:flex-direction   :column
    :flex-wrap        :wrap
+   :justify-content  :center
+   :align-items      :center
    :margin-top       8
    :background-color styles/color-white})
 
 (def all-dapps-flat-list-item
   {:margin          10
-   :width           100
+   :width           90
    :height          140
    :justify-content :center
    :align-items     :center})
-
-(def dapps-list-item-second-row
-  {:flex    1
-   :padding 4
-   :margin  4})
 
 (def dapps-list-item-name-container
   {:background-color styles/color-white


### PR DESCRIPTION
addresses #2210 

### Summary:

The alignment of the dapp grid was wrong mostly because the support for grid layout in flat list is quite rudimentary. It only works right if the number of items is evenly divisible with the number of columns. This PR solves the issue by adding invisible elements to the grid to make it aligned. The proper solution could be to find a better grid component.

### Steps to test:
see #2210


status: ready

6s:

![simulator screen shot nov 9 2017 1 31 54 pm](https://user-images.githubusercontent.com/711764/32606449-a49bf994-c555-11e7-8f8c-2b223692e1ec.png)

5s: 

![simulator screen shot nov 9 2017 1 18 14 pm](https://user-images.githubusercontent.com/711764/32606451-a4c08db8-c555-11e7-81db-a5028c7f2f2b.png)
