### PR TITLE
remove :browsing-browse from the translations

### DIFF
--- a/src/status_im/translations/da.cljs
+++ b/src/status_im/translations/da.cljs
@@ -109,7 +109,6 @@
    :sharing-cancel                        "Annullér"
 
    :browsing-title                        "Browse"
-   :browsing-browse                       "@browse"
    :browsing-open-in-web-browser          "Åben i web browser"
    :browsing-cancel                       "Annullér"
 

--- a/src/status_im/translations/de.cljs
+++ b/src/status_im/translations/de.cljs
@@ -106,7 +106,6 @@
    :sharing-cancel                        "Abbrechen"
 
    :browsing-title                        "Browse"
-   :browsing-browse                       "@browse"
    :browsing-open-in-web-browser          "In Webbrowser öffnen"
    :browsing-cancel                       "Abbrechen"
 

--- a/src/status_im/translations/en.cljs
+++ b/src/status_im/translations/en.cljs
@@ -105,7 +105,6 @@
    :sharing-cancel                        "Cancel"
 
    :browsing-title                        "Browse"
-   :browsing-browse                       "@browse"
    :browsing-open-in-web-browser          "Open in web browser"
    :browsing-cancel                       "Cancel"
 

--- a/src/status_im/translations/es.cljs
+++ b/src/status_im/translations/es.cljs
@@ -104,7 +104,6 @@
    :sharing-cancel                        "Cancelar"
 
    :browsing-title                        "Navegar"
-   :browsing-browse                       "@browse"
    :browsing-open-in-web-browser          "Abrir en el navegador"
    :browsing-cancel                       "Cancelar"
 

--- a/src/status_im/translations/he.cljs
+++ b/src/status_im/translations/he.cljs
@@ -109,7 +109,6 @@
    :sharing-cancel                        "בטל"
 
    :browsing-title                        "דפדף"
-   :browsing-browse                       "@browse"
    :browsing-open-in-web-browser          "פתח בדפדפן"
    :browsing-cancel                       "בטל"
 

--- a/src/status_im/translations/it.cljs
+++ b/src/status_im/translations/it.cljs
@@ -104,7 +104,6 @@
    :sharing-cancel                        "Annulla"
 
    :browsing-title                        "Naviga"
-   :browsing-browse                       "@browse"
    :browsing-open-in-web-browser          "Apri nel web browser"
    :browsing-cancel                       "Annulla"
 

--- a/src/status_im/translations/ko.cljs
+++ b/src/status_im/translations/ko.cljs
@@ -108,7 +108,6 @@
    :sharing-cancel                        "취소"
 
    :browsing-title                        "브라우저"
-   :browsing-browse                       "@browse"
    :browsing-open-in-web-browser          "웹 브라우저로 열기"
    :browsing-cancel                       "취소"
 

--- a/src/status_im/translations/lv.cljs
+++ b/src/status_im/translations/lv.cljs
@@ -109,7 +109,6 @@
    :sharing-cancel                        "Atcelt"
 
    :browsing-title                        "Browse"
-   :browsing-browse                       "@browse"
    :browsing-open-in-web-browser          "Atvert pārlūkprogrammā"
    :browsing-cancel                       "Atcelt"
 

--- a/src/status_im/translations/nl.cljs
+++ b/src/status_im/translations/nl.cljs
@@ -106,7 +106,6 @@
    :sharing-cancel                        "Annuleren"
 
    :browsing-title                        "Browse"
-   :browsing-browse                       "@browse"
    :browsing-open-in-web-browser          "Open in een web browser"
    :browsing-cancel                       "Annuleren"
 

--- a/src/status_im/translations/ru.cljs
+++ b/src/status_im/translations/ru.cljs
@@ -104,7 +104,6 @@
    :sharing-cancel                        "Отмена"
 
    :browsing-title                        "Просматривать"
-   :browsing-browse                       "@browse"
    :browsing-open-in-web-browser          "Открыть в веб-браузере"
    :browsing-cancel                       "Отмена"
 

--- a/src/status_im/translations/zh_hans.cljs
+++ b/src/status_im/translations/zh_hans.cljs
@@ -108,7 +108,6 @@
    :sharing-cancel                        "取消"
 
    :browsing-title                        "浏览"
-   :browsing-browse                       "@browse"
    :browsing-open-in-web-browser          "在网络浏览器中打开"
    :browsing-cancel                       "取消"
 

--- a/src/status_im/translations/zh_hant.cljs
+++ b/src/status_im/translations/zh_hant.cljs
@@ -108,7 +108,6 @@
    :sharing-cancel                        "取消"
 
    :browsing-title                        "瀏覽"
-   :browsing-browse                       "@browse"
    :browsing-open-in-web-browser          "在網絡瀏覽器中打開"
    :browsing-cancel                       "取消"
 

--- a/src/status_im/translations/zh_wuu.cljs
+++ b/src/status_im/translations/zh_wuu.cljs
@@ -108,7 +108,6 @@
    :sharing-cancel                        "取消"
 
    :browsing-title                        "浏览"
-   :browsing-browse                       "@browse"
    :browsing-open-in-web-browser          "在网络浏览器中打开"
    :browsing-cancel                       "取消"
 

--- a/src/status_im/translations/zh_yue.cljs
+++ b/src/status_im/translations/zh_yue.cljs
@@ -108,7 +108,6 @@
    :sharing-cancel                        "取消"
 
    :browsing-title                        "瀏覽"
-   :browsing-browse                       "@browse"
    :browsing-open-in-web-browser          "在網絡瀏覽器中打開"
    :browsing-cancel                       "取消"
 

--- a/src/status_im/ui/components/list_selection.cljs
+++ b/src/status_im/ui/components/list_selection.cljs
@@ -31,7 +31,7 @@
 (defn browse [command link]
   (let [list-selection-fn (:list-selection-fn platform-specific)]
     (list-selection-fn {:title       (label :t/browsing-title)
-                        :options     [{:text (label :t/browsing-browse)}
+                        :options     [{:text "@browse"}
                                       {:text (label :t/browsing-open-in-web-browser)}]
                         :callback    (fn [index]
                                        (case index


### PR DESCRIPTION
it shouldn't be translated because it is the command name

status: ready