### PR TITLE
[fixes #2437] show password validation message when password is blank

### DIFF
--- a/src/status_im/chat/events/input.cljs
+++ b/src/status_im/chat/events/input.cljs
@@ -512,6 +512,21 @@
     (set-chat-seq-arg-input-text db text)))
 
 (handlers/register-handler-fx
+ :submit-seq-input
+ [re-frame/trim-v]
+ (fn [{{:keys [current-chat-id chats] :as db} :db} _]
+   (let [text              (get-in chats [current-chat-id :seq-argument-input-text])
+         seq-arguments     (get-in chats [current-chat-id :seq-arguments])
+         command           (-> (input-model/selected-chat-command db current-chat-id)
+                               (assoc :args (into [] (conj seq-arguments text))))
+         have-text?        (or (not (str/blank? text))
+                               (commands-model/password? command))
+         hide-send-button? (get-in command [:command :hide-send-button])]
+     (cond-> {:db db}
+       (and have-text? (not hide-send-button?))
+       (assoc :dispatch [:send-seq-argument])))))
+
+(handlers/register-handler-fx
   :update-text-selection
   [re-frame/trim-v]
   (fn [{:keys [db]} [selection]]

--- a/src/status_im/chat/models/commands.cljs
+++ b/src/status_im/chat/models/commands.cljs
@@ -42,3 +42,6 @@
   (let [requested-responses (map :response requests)
         responses-map (commands-responses :response access-scope->commands-responses account chat contacts)]
     (select-keys responses-map requested-responses)))
+
+(defn password? [command]
+  (= "password" (get-in command [:command :name])))

--- a/src/status_im/chat/views/input/input.cljs
+++ b/src/status_im/chat/views/input/input.cljs
@@ -159,12 +159,10 @@
                               :editable            (not @sending-in-progress?)
                               :on-focus            #(dispatch [:set-chat-ui-props {:show-emoji? false}])
                               :on-submit-editing   (fn []
-                                                     (when-not (or (str/blank? @seq-arg-input-text)
-                                                                   (get-in @command [:command :hide-send-button]))
-                                                       (dispatch [:send-seq-argument]))
+                                                     (dispatch [:submit-seq-input])
                                                      (js/setTimeout
-                                                       #(dispatch [:chat-input-focus :seq-input-ref])
-                                                       100))}
+                                                      #(dispatch [:chat-input-focus :seq-input-ref])
+                                                      100))}
                              (get-options type))])))))
 
 (defn input-view [_]


### PR DESCRIPTION
Fixes #2437 

### Summary:

[comment]: # (Summarise the problem and how the pull request solves it)
No hint was shown when entering password containing spaces only. 

### Steps to test:
- Open Status
- Create new account
- Tap /password
- Enter 1 or more spaces
- Hit enter

status: ready