### PR TITLE
[fixes #2445] make phone suggestions not clickable

### DIFF
--- a/resources/js/bots/console/bot.js
+++ b/resources/js/bots/console/bot.js
@@ -428,9 +428,7 @@ function phoneSuggestions(params, context) {
     }
 
     suggestions = ph.map(function (phone) {
-        return status.components.touchable(
-            {onPress: status.components.dispatch([status.events.SET_COMMAND_ARGUMENT, [0, phone.number]])},
-            status.components.view(suggestionContainerStyle,
+        return status.components.view(suggestionContainerStyle,
                 [status.components.view(suggestionSubContainerStyle,
                     [
                         status.components.text(
@@ -441,8 +439,7 @@ function phoneSuggestions(params, context) {
                             {style: descriptionStyle},
                             phone.description
                         )
-                    ])])
-        );
+                    ])]);
     });
 
     var view = status.components.scrollView(


### PR DESCRIPTION
Fixes #2445 
### Summary:

Make phone suggestions not clickable. This prevents populating text input with example phone numbers.

Please check #2445 for more information.

### Steps to test:
- Open Status
- Go to Console
- Tap on /phone
- Tap on any example phone number

status: ready