### PR TITLE
[feature] log faucet error

### DIFF
--- a/src/status_im/chat/events/console.cljs
+++ b/src/status_im/chat/events/console.cljs
@@ -81,7 +81,8 @@
                                             (faucet-response-event
                                              random-id
                                              (i18n/label :t/faucet-success)))
-                   :failure-event-creator (fn [_]
+                   :failure-event-creator (fn [event]
+                                            (log/error "Faucet error" event)
                                             (faucet-response-event
                                              random-id
                                              (i18n/label :t/faucet-error)))}}))


### PR DESCRIPTION
Log the error returned by the faucet to speed up future resolution

status: ready
