### PR TITLE
Advanced optimizations and better js object usage

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,8 @@
                  [com.andrewmcveigh/cljs-time "0.5.0"]
                  [com.taoensso/timbre "4.10.0"]
                  [hickory "0.7.1"]
-                 [com.cognitect/transit-cljs "0.8.243"]]
+                 [com.cognitect/transit-cljs "0.8.243"]
+                 [binaryage/oops "0.5.6"]]
   :plugins [[lein-cljsbuild "1.1.7"]
             [lein-figwheel "0.5.13"]
             [lein-re-frisk "0.5.2"]]
@@ -71,7 +72,7 @@
                                                  :output-dir         "target/ios-prod"
                                                  :static-fns         true
                                                  :optimize-constants true
-                                                 :optimizations      :simple
+                                                 :optimizations      :advanced
                                                  :closure-defines    {"goog.DEBUG" false}
                                                  :parallel-build     false
                                                  :language-in        :ecmascript5}
@@ -83,7 +84,7 @@
                                                  :output-dir         "target/android-prod"
                                                  :static-fns         true
                                                  :optimize-constants true
-                                                 :optimizations      :simple
+                                                 :optimizations      :advanced
                                                  :closure-defines    {"goog.DEBUG" false}
                                                  :parallel-build     false
                                                  :language-in        :ecmascript5}

--- a/src/status_im/ui/components/react.cljs
+++ b/src/status_im/ui/components/react.cljs
@@ -4,11 +4,12 @@
             [status-im.utils.utils :as u]
             [status-im.utils.platform :refer [platform-specific ios?]]
             [status-im.i18n :as i18n]
-            [status-im.react-native.js-dependencies :as rn-dependencies]))
+            [status-im.react-native.js-dependencies :as rn-dependencies]
+            [oops.core :as o]))
 
 (defn get-react-property [name]
   (if rn-dependencies/react-native
-    (aget rn-dependencies/react-native name)
+    (o/oget rn-dependencies/react-native name)
     #js {}))
 
 (defn adapt-class [class]
@@ -156,16 +157,15 @@
   (.setString (.-Clipboard rn-dependencies/react-native) text))
 
 (defn get-from-clipboard [clbk]
-  (let [clipboard-contents (.getString (.-Clipboard rn-dependencies/react-native))]
-    (.then clipboard-contents #(clbk %))))
-
+  (-> (o/oget rn-dependencies/react-native "Clipboard.getString")
+      (o/ocall "then" #(clbk %))))
 
 ;; Emoji
 
 (def emoji-picker-class rn-dependencies/emoji-picker)
 
 (def emoji-picker
-  (let [emoji-picker (.-default emoji-picker-class)]
+  (let [emoji-picker (o/oget emoji-picker-class "default")]
     (r/adapt-react-class emoji-picker)))
 
 ;; Autolink


### PR DESCRIPTION
Advanced optimizations would help to reduce the binary size of the app, as well as to save a lot of bandwidth and time for the user when serving new versions from the internet with something like Code Push.

I just compiled the Status cljs with simple and advanced, and the size of each is:

Simple: 7.7M
Advanced 2.2M

3x, and the more the code, the bigger the difference.

Those optimizations also help to obfuscate the code, but in the case of Status it doesn’t make sense since the code is already open.

The [oops](https://github.com/binaryage/cljs-oops) library helps to work better with javascript objects from cljs, and in turn, to get code working well with advanced optimizations easier.

The goal is to have the same behaviour in both dev and prod when using js objects, so that when you run advanced optimizations things work the same.

Here you can see its [motivation](https://github.com/binaryage/cljs-oops#motivation) and its [benefits](https://github.com/binaryage/cljs-oops#benefits).

By the way, it also solves using `aget` and `aset` with objects, which is not recommended since their use is for arrays.

This pull request enables advanced optimizations, adds the library, and shows some examples of usage. It still needs to use the library in the whole code so as to use advanced optimizations safely.

A possible problem with advanced optimizations is not having good feedback when something breaks. Actually with simple optimizations the feedback is not encrypted like in advanced optimizations, but it is not the actual clojure code, but the compiled javascript. Using source maps in prod probably solves this issue. [Here](http://austinbirch.co.uk/clojurescript-react-native-bundling-release.html) you go how that could be done with cljs and react native.

Let me know what you think. :)