### PR TITLE
Supported locales and translation ids

### DIFF
--- a/src/status_im/i18n.cljs
+++ b/src/status_im/i18n.cljs
@@ -1,5 +1,6 @@
 (ns status-im.i18n
   (:require
+    [cljs.spec.alpha :as spec]
     [status-im.react-native.js-dependencies :as rn-dependencies]
     [status-im.translations.af :as af]
     [status-im.translations.ar :as ar]
@@ -52,73 +53,277 @@
     [status-im.translations.zh-yue :as zh-yue]
     [status-im.utils.js-resources :refer [default-contacts]]
     [taoensso.timbre :as log]
-    [clojure.string :as str]))
+    [clojure.string :as string]
+    [clojure.set :as set]))
 
 (set! (.-fallbacks rn-dependencies/i18n) true)
 (set! (.-defaultSeparator rn-dependencies/i18n) "/")
 
+;; translations
+
+(def translations-by-locale {:af          af/translations
+                             :ar          ar/translations
+                             :be          be/translations
+                             :cs          cs/translations
+                             :da          da/translations
+                             :de          de/translations
+                             :de-ch       de-ch/translations
+                             :en          en/translations
+                             :es          es/translations
+                             :es-ar       es-ar/translations
+                             :es-mx       es-mx/translations
+                             :fi          fi/translations
+                             :fr          fr/translations
+                             :fr-ch       fr-ch/translations
+                             :fy          fy/translations
+                             :he          he/translations
+                             :hi          hi/translations
+                             :hu          hu/translations
+                             :id          id/translations
+                             :it          it/translations
+                             :it-ch       it-ch/translations
+                             :ja          ja/translations
+                             :ko          ko/translations
+                             :la          la/translations
+                             :lt          lt/translations
+                             :lv          lv/translations
+                             :ms          ms/translations
+                             :nb          nb/translations
+                             :ne          ne/translations
+                             :nl          nl/translations
+                             :pl          pl/translations
+                             :pt-br       pt-br/translations
+                             :pt-pt       pt-pt/translations
+                             :ro          ro/translations
+                             :ru          ru/translations
+                             :sl          sl/translations
+                             :sr          sr-rs-cyrl/translations
+                             :sr-RS_#Latn sr-rs-latn/translations
+                             :sr-RS_#Cyrl sr-rs-cyrl/translations
+                             :sv          sv/translations
+                             :sw          sw/translations
+                             :th          th/translations
+                             :tr          tr/translations
+                             :uk          uk/translations
+                             :ur          ur/translations
+                             :vi          vi/translations
+                             :zh          zh-hans/translations
+                             :zh-hans     zh-hans/translations
+                             :zh-hans-tw  zh-hans/translations
+                             :zh-hans-sg  zh-hans/translations
+                             :zh-hans-hk  zh-hans/translations
+                             :zh-hans-cn  zh-hans/translations
+                             :zh-hans-mo  zh-hans/translations
+                             :zh-hant     zh-hant/translations
+                             :zh-hant-tw  zh-hant/translations
+                             :zh-hant-sg  zh-hant/translations
+                             :zh-hant-hk  zh-hant/translations
+                             :zh-hant-cn  zh-hant/translations
+                             :zh-hant-mo  zh-hant/translations
+                             :zh-wuu      zh-wuu/translations
+                             :zh-yue      zh-yue/translations})
+
+;; english as source of truth
+(def labels (set (keys en/translations)))
+
+(spec/def ::label labels)
+(spec/def ::labels (spec/coll-of ::label :kind set? :into #{}))
+
+(defn labels-for-all-locales []
+  (->> translations-by-locale
+       (mapcat #(-> % val keys))
+       set))
+
+;; checkpoints
+
+;; Checkpoints specify milestones for locales.
+;;
+;; With milestones we can ensure that expected supported languages
+;; are actually supported, and visualize the translation state for
+;; the rest of locales according to these milestones.
+;;
+;; Checkpoints are defined by indicating the labels that need to be present
+;; in a locale to achieve that checkpoint.
+;;
+;; We need to define the checkpoint that needs to be achieved for
+;; a locale to be considered supported. This is why as we develop
+;; we add translations, so we need to be defining a new target
+;; for supported languages to achieve.
+;;
+;; Checkpoints are only used in dev and test. In dev when we want to
+;; manually check the state of checkpoints for locales, and in test
+;; to automatically check supported locales against the target checkpoint.
+
+(spec/def ::checkpoint.id keyword?)
+(spec/def ::checkpoint-defs (spec/map-of ::checkpoint.id ::labels))
+
+;; We define here the labels for the first specified checkpoint.
+(def checkpoint-0-9-12-labels
+  #{:validation-amount-invalid-number :transaction-details :confirm :description
+    :phone-national :amount :open :close-app-title :members-active :chat-name
+    :phew-here-is-your-passphrase :public-group-topic :debug-enabled
+    :chat-settings :offline :update-status :invited :chat-send-eth :address
+    :new-public-group-chat :datetime-hour :dropped-pin :wallet-settings
+    :datetime-ago-format :close-app-button :block :camera-access-error
+    :wallet-invalid-address :address-explication :remove
+    :transactions-delete-content :transactions-unsigned-empty
+    :transaction-moved-text :add-members :sign-later-title :sharing-cancel
+    :yes :dapps :popular-tags :network-settings :twelve-words-in-correct-order
+    :transaction-moved-title :phone-number :photos-access-error :hash
+    :removed-from-chat :done :remove-from-contacts :delete-chat :new-group-chat
+    :edit-chats :wallet :wallet-exchange :wallet-request :sign-in
+    :datetime-yesterday :create-new-account :sign-in-to-status :dapp-profile
+    :sign-later-text :datetime-ago :no-hashtags-discovered-body :contacts
+    :search-chat :got-it :delete-group-confirmation :public-chats
+    :not-applicable :move-to-internal-failure-message :active-online
+    :password :status-seen-by-everyone :edit-group :not-specified
+    :delete-group :send-request :paste-json :browsing-title
+    :wallet-add-asset :reorder-groups :transactions-history-empty
+    :sharing-copy-to-clipboard-coordinates :discover :wallet-error
+    :browsing-cancel :faucet-success :intro-status :name :gas-price
+    :phone-number-required :view-transaction-details
+    :validation-amount-is-too-precise :copy-transaction-hash :unknown-address
+    :received-invitation :show-qr :edit-network-config :connect
+    :choose-from-contacts :edit :wallet-address-from-clipboard
+    :account-generation-message :remove-network :no-messages :passphrase
+    :recipient :members-title :new-group :phone-e164 :suggestions-requests
+    :connected :rpc-url :settings :remove-from-group :specify-rpc-url
+    :contacts-syncronized :transactions-sign-all :gas-limit :wallet-browse-photos
+    :add-new-contact :no-statuses-discovered-body :add-json-file :delete
+    :search-contacts :chats :transaction-sent :transaction :public-group-status
+    :leave-chat :transactions-delete :mainnet-text :image-source-make-photo
+    :chat :start-conversation :topic-format :add-new-network :save
+    :enter-valid-public-key :faucet-error :phone-significant :all
+    :confirmations-helper-text :search-for :sharing-copy-to-clipboard
+    :your-wallets :phone-international :sync-in-progress :enter-password
+    :enter-address :switch-users :send-transaction :confirmations
+    :recover-access :incorrect-code :image-source-gallery :sync-synced
+    :currency :status-pending :delete-contact :connecting-requires-login
+    :no-hashtags-discovered-title :datetime-day :request-transaction
+    :wallet-send :mute-notifications :invalid-phone :scan-qr :contact-s
+    :unsigned-transaction-expired :status-sending :gas-used
+    :transactions-filter-type :next :recent :confirmation-code
+    :open-on-etherscan :share :status :from :your-current-location
+    :wrong-password :search-chats :transactions-sign-later :in-contacts
+    :transactions-sign :sharing-share :type-a-message :type-a-command
+    :usd-currency :existing-networks :node-unavailable :url :shake-your-phone
+    :add-network :unknown-status-go-error :contacts-group-new-chat :and-you
+    :wallets :clear-history :wallet-choose-from-contacts
+    :signing-phrase-description :no-contacts :here-is-your-signing-phrase
+    :soon :close-app-content :status-sent :status-prompt :testfairy-title
+    :delete-contact-confirmation :datetime-today :add-a-status
+    :web-view-error :notifications-title :error :transactions-sign-transaction
+    :edit-contacts :more :cancel :no-statuses-found :can-not-add-yourself
+    :transaction-description :add-to-contacts :available :open-map
+    :paste-json-as-text :You :main-wallet :process-json :testnet-text
+    :transactions :transactions-unsigned :members :intro-message1
+    :public-chat-user-count :eth :transactions-history :not-implemented
+    :new-contact :datetime-second :search-results :status-failed :is-typing
+    :sharing-copy-to-clipboard-address :recover :wallet-total-value
+    :places-nearby :suggestions-commands :nonce :new-network
+    :contact-already-added :datetime-minute :location
+    :browsing-open-in-web-browser :delete-group-prompt
+    :wallet-insufficient-funds :edit-profile :active-unknown :testfairy-message
+    :search-tags :transaction-failed :public-key :error-processing-json
+    :status-seen :transactions-filter-tokens :status-delivered :profile
+    :wallet-choose-recipient :no-statuses-discovered :none :removed :empty-topic
+    :no :transactions-filter-select-all :transactions-filter-title :message
+    :here-is-your-passphrase :wallet-assets :image-source-title :current-network
+    :left :edit-network-warning :to :data :cost-fee})
+
+;; NOTE: the rest checkpoints are based on the previous one, defined
+;;       like this:
+;; (def checkpoint-2-labels (set/union checkpoint-1-labels #{:foo :bar})
+;; (def checkpoint-3-labels (set/union checkpoint-2-labels #{:baz})
+
+;; NOTE: This defines the scope of each checkpoint. To support a checkpoint,
+;;       change the var `checkpoint-to-consider-locale-supported` a few lines
+;;       below.
+(def checkpoints-def (spec/assert ::checkpoint-defs
+                                  {::checkpoint-0-9-12 checkpoint-0-9-12-labels}))
+(def checkpoints (set (keys checkpoints-def)))
+
+(spec/def ::checkpoint checkpoints)
+
+(def checkpoint-to-consider-locale-supported ::checkpoint-0-9-12)
+
+(defn checkpoint->labels [checkpoint]
+  (get checkpoints-def checkpoint))
+
+(defn checkpoint-val-to-compare [c]
+  (-> c name (string/replace #"^.*\|" "") int))
+
+(defn >checkpoints [& cs]
+  (apply > (map checkpoint-val-to-compare cs)))
+
+(defn labels-that-are-not-in-current-checkpoint []
+  (set/difference labels (checkpoint->labels checkpoint-to-consider-locale-supported)))
+
+;; locales
+
+(def locales (set (keys translations-by-locale)))
+
+(spec/def ::locale locales)
+(spec/def ::locales (spec/coll-of ::locale :kind set? :into #{}))
+
+;; NOTE: Add new locale keywords here to indicate support for them.
+(def supported-locales (spec/assert ::locales #{:fr
+                                                :zh-hans-cn
+                                                :zh-hans-sg
+                                                :sr-RS_#Cyrl
+                                                :zh-hans-tw
+                                                :en
+                                                :zh
+                                                :de
+                                                :zh-hans
+                                                :lt
+                                                :zh-hans-mo
+                                                :zh-hans-hk
+                                                :sr-RS_#Latn
+                                                :sr}))
+
+(spec/def ::supported-locale supported-locales)
+(spec/def ::supported-locales (spec/coll-of ::supported-locale :kind set? :into #{}))
+
+(defn locale->labels [locale]
+  (-> translations-by-locale (get locale) keys set))
+
+(defn locale->checkpoint [locale]
+  (let [locale-labels (locale->labels locale)
+        checkpoint    (->> checkpoints-def
+                           (filter (fn [[checkpoint checkpoint-labels]]
+                                     (set/subset? checkpoint-labels locale-labels)))
+                           ffirst)]
+    checkpoint))
+
+(defn locales-with-checkpoint []
+  (->> locales
+       (map (fn [locale]
+              [locale (locale->checkpoint locale)]))
+       (into {})))
+
+(defn locale-is-supported-based-on-translations? [locale]
+  (let [c (locale->checkpoint locale)]
+    (and c (or (= c checkpoint-to-consider-locale-supported)
+               (>checkpoints checkpoint-to-consider-locale-supported c)))))
+
+(defn actual-supported-locales []
+  (->> locales
+       (filter locale-is-supported-based-on-translations?)
+       set))
+
+(defn locales-with-full-support []
+  (->> locales
+       (filter (fn [locale]
+                 (set/subset? labels (locale->labels locale))))
+       set))
+
+(defn supported-locales-that-are-not-considered-supported []
+  (set/difference (actual-supported-locales) supported-locales))
+
+
 (set! (.-translations rn-dependencies/i18n)
-      (clj->js {:af          af/translations
-                :ar          ar/translations
-                :be          be/translations
-                :cs          cs/translations
-                :da          da/translations
-                :de          de/translations
-                :de-ch       de-ch/translations
-                :en          en/translations
-                :es          es/translations
-                :es-ar       es-ar/translations
-                :es-mx       es-mx/translations
-                :fi          fi/translations
-                :fr          fr/translations
-                :fr-ch       fr-ch/translations
-                :fy          fy/translations
-                :he          he/translations
-                :hi          hi/translations
-                :hu          hu/translations
-                :id          id/translations
-                :it          it/translations
-                :it-ch       it-ch/translations
-                :ja          ja/translations
-                :ko          ko/translations
-                :la          la/translations
-                :lt          lt/translations
-                :lv          lv/translations
-                :ms          ms/translations
-                :nb          nb/translations
-                :ne          ne/translations
-                :nl          nl/translations
-                :pl          pl/translations
-                :pt-br       pt-br/translations
-                :pt-pt       pt-pt/translations
-                :ro          ro/translations
-                :ru          ru/translations
-                :sl          sl/translations
-                :sr          sr-rs-cyrl/translations
-                :sr-RS_#Latn sr-rs-latn/translations
-                :sr-RS_#Cyrl sr-rs-cyrl/translations
-                :sv          sv/translations
-                :sw          sw/translations
-                :th          th/translations
-                :tr          tr/translations
-                :uk          uk/translations
-                :ur          ur/translations
-                :vi          vi/translations
-                :zh          zh-hans/translations
-                :zh-hans     zh-hans/translations
-                :zh-hans-tw  zh-hans/translations
-                :zh-hans-sg  zh-hans/translations
-                :zh-hans-hk  zh-hans/translations
-                :zh-hans-cn  zh-hans/translations
-                :zh-hans-mo  zh-hans/translations
-                :zh-hant     zh-hant/translations
-                :zh-hant-tw  zh-hant/translations
-                :zh-hant-sg  zh-hant/translations
-                :zh-hant-hk  zh-hant/translations
-                :zh-hant-cn  zh-hant/translations
-                :zh-hant-mo  zh-hant/translations
-                :zh-wuu      zh-wuu/translations
-                :zh-yue      zh-yue/translations}))
+      (clj->js translations-by-locale))
 
 ;:zh, :zh-hans-xx, :zh-hant-xx have been added until this bug will be fixed https://github.com/fnando/i18n-js/issues/460
 
@@ -137,7 +342,7 @@
   (when number
     (let [{:keys [delimiter separator]} delimeters]
       (.toNumber rn-dependencies/i18n
-                 (str/replace number #"," ".")
+                 (string/replace number #"," ".")
                  (clj->js {:precision                 10
                            :strip_insignificant_zeros true
                            :delimiter                 delimiter

--- a/src/status_im/translations/af.cljs
+++ b/src/status_im/translations/af.cljs
@@ -10,8 +10,6 @@
    :offline                               "Aflyn"
 
    ;drawer
-   :invite-friends                        "Nooi vriende"
-   :faq                                   "Vrae"
    :switch-users                          "Verander gebruikers"
 
    ;chat
@@ -53,41 +51,30 @@
                                            :other "ure"}
    :datetime-day                          {:one   "dag"
                                            :other "dae"}
-   :datetime-multiple                     "e"               ; TODO probably wrong
    :datetime-ago                          "gelede"
    :datetime-yesterday                    "gister"
    :datetime-today                        "vandag"
 
    ;profile
    :profile                               "Profiel"
-   :report-user                           "RAPPORTEER GEBRUIKER"
    :message                               "Boodskap"
-   :username                              "Gebruikernaam"
    :not-specified                         "Nie gespesifiseer nie"
    :public-key                            "Openbare sleutel"
    :phone-number                          "Telefoonnommer"
-   :email                                 "Epos"
-   :profile-no-status                     "Geen status"
    :add-to-contacts                       "Voeg by kontakte"
-   :error-incorrect-name                  "Kies asseblief 'n ander naam"
-   :error-incorrect-email                 "Verkeerde epos"
 
    ;;make_photo
    :image-source-title                    "Profielbeeld"
    :image-source-make-photo               "Opname"
    :image-source-gallery                  "Kies uit galery"
-   :image-source-cancel                   "Kanselleer"
 
    ;sign-up
    :contacts-syncronized                  "U kontakte is gesinchroniseer"
    :confirmation-code                     (str "Dankie! Ons het vir u 'n SMS gestuur met 'n bevestigings "
                                                "kode. Verskaf asseblief daardie kode om u telefoonnommer te bevestig")
    :incorrect-code                        (str "Jammer, die kode was nie korrek nie, voer asseblief weer in")
-   :generate-passphrase                   (str "Ek sal 'n tydelike wagwoord vir jou skep sodat jy jou "
-                                               "toegang kan herstel of van 'n ander toestel af kan aanteken")
    :phew-here-is-your-passphrase          "*Sjoe* dit was moeilik, hier is jou tydelike wagwoord, *skryf dit neer en hou dit veilig!* Jy sal dit nodig hê om jou rekening te herwin."
    :here-is-your-passphrase               "Hier is jou tydelike wagwoord, *skryf dit neer en hou dit veilig!* Jy sal dit nodig hê om jou rekening te herwin."
-   :written-down                          "Maak seker dat jy dit veilig neergeskryf het"
    :phone-number-required                 "Tik hier om jou telefoonnommer in te voer & ek sal jou vriende opspoor"
    :intro-status                          "Gesels met my om jou rekening op te stel en jou stellings te verander!"
    :intro-message1                        "Welkom by Status\nTik tik hierdie boodskap om jou wagwoord te stel & laat ons begin!"
@@ -95,7 +82,6 @@
 
    ;chats
    :chats                                 "Geselsies"
-   :new-chat                              "Nuwe geselsie"
    :new-group-chat                        "Nuwe groepgeselsie"
 
    ;discover
@@ -112,9 +98,6 @@
    ;contacts
    :contacts                              "Kontakte"
    :new-contact                           "Nuwe kontak"
-   :show-all                              "WYS ALMAL"
-   :contacts-group-dapps                  "ÐApps"
-   :contacts-group-people                 "Mense"
    :contacts-group-new-chat               "Begin nuwe geselsie"
    :no-contacts                           "Nog geen kontakte nie"
    :show-qr                               "Wys QR"
@@ -122,41 +105,17 @@
    ;group-settings
    :remove                                "Verwyder"
    :save                                  "Stoor"
-   :change-color                          "Verander kleur"
    :clear-history                         "Maak geskiedenis skoon"
-   :delete-and-leave                      "Vee uit en gaan uit"
    :chat-settings                         "Geselsie-stellings"
    :edit                                  "Wysig"
    :add-members                           "Voeg lede by"
-   :blue                                  "Blou"
-   :purple                                "Pers"
-   :green                                 "Groen"
-   :red                                   "Rooi"
 
    ;commands
-   :money-command-description             "Stuur geld"
-   :location-command-description          "Stuur ligging"
-   :phone-command-description             "Stuur telefoonnommer"
-   :phone-request-text                    "Telefoonnommer-versoek"
-   :confirmation-code-command-description "Stuur bevestigingskode"
-   :confirmation-code-request-text        "Bevestigingskode-versoek"
-   :send-command-description              "Stuur ligging"
-   :request-command-description           "Stuur versoek"
-   :keypair-password-command-description  ""
-   :help-command-description              "Help"
-   :request                               "Versoek"
    :chat-send-eth                         "{{amount}} ETH"
-   :chat-send-eth-to                      "{{amount}} ETH aan {{chat-name}}"
-   :chat-send-eth-from                    "{{amount}} ETH van {{chat-name}}"
 
    ;new-group
-   :group-chat-name                       "Bynaam"
-   :empty-group-chat-name                 "Voer assseblief 'n naam in"
-   :illegal-group-chat-name               "Kies asseblief 'n ander naam"
 
    ;participants
-   :add-participants                      "Voeg deelnemers by"
-   :remove-participants                   "Verwyder deelnemers"
 
    ;protocol
    :received-invitation                   "geselsie-uitnodiging ontvang"
@@ -168,12 +127,9 @@
 
    ;new-contact
    :add-new-contact                       "Voeg nuwe kontak by"
-   :import-qr                             "Voer in"
    :scan-qr                               "Skandeer QR"
    :name                                  "Naam"
-   :whisper-identity                      "Whisper-identiteit"
    :address-explication                   "Miskien moet hier 'n bietjie teks wees wat verduidelik wat 'n adres is en waar om daarvoor te soek."
-   :enter-valid-address                   "Voer asseblief 'n geldige adres in of skandeer 'n QR-kode"
    :contact-already-added                 "Die kontak is alreeds bygevoeg"
    :can-not-add-yourself                  "Jy kan nie jouself byvoeg nie"
    :unknown-address                       "Onbekende adres"
@@ -183,20 +139,14 @@
    :connect                               "Konnekteer"
    :address                               "Adres"
    :password                              "Wagwoord"
-   :login                                 "Teken aan"
    :wrong-password                        "Verkeerde wagwoord"
 
    ;recover
-   :recover-from-passphrase               "Herstel van tydelike wagwoord"
-   :recover-explain                       "Voer asseblief die tydelike wagwoord vir jou wagwoord in om toegang te herstel"
    :passphrase                            "Tydelike wagwoord"
    :recover                               "Herstel"
-   :enter-valid-passphrase                "Voer asseblief 'n tydelike wagwoord in"
-   :enter-valid-password                  "Voer asseblief 'n wagwoord in"
 
    ;accounts
    :recover-access                        "Herwin toegang"
-   :add-account                           "Voeg rekening by"
 
    ;wallet-qr-code
    :done                                  "Gedoen"
@@ -205,34 +155,20 @@
    ;validation
    :invalid-phone                         "Ongeldige telefoonnommer"
    :amount                                "Bedrag"
-   :not-enough-eth                        (str "Nie genoeg ETH in die rekening nie "
-                                               "({{balance}} ETH)")
    ;transactions
-   :confirm-transactions                  {:one   "Bevestig transaksie"
-                                           :other "Bevestig {{count}} transaksies"
-                                           :zero  "Geen transaksies"}
    :status                                "Status"
-   :pending-confirmation                  "Bevestiging hangende"
    :recipient                             "Ontvanger"
-   :one-more-item                         "Nog een item"
-   :fee                                   "Fooi"
-   :value                                 "Waarde"
 
    ;:webview
    :web-view-error                        "oepsie, fout"
 
    :confirm                               "Bevestig"
    :phone-national                        "Nasionaal"
-   :transactions-confirmed                {:one   "Transaksie bevestig"
-                                           :other "{{count}} transaksies bevestig"
-                                           :zero  "Geen transaksies bevestig"}
    :public-group-topic                    "Onderwerp"
    :debug-enabled                         "Ontfout-bediener is bekendgestel! U kan nou u DApp byvoeg deur *status-dev-cli scan* te hardloop vanaf u rekenaar"
    :new-public-group-chat                 "Sluit aan by openbare klets"
    :datetime-ago-format                   "{{number}} {{time-intervals}} {{ago}}"
    :sharing-cancel                        "Kanselleer"
-   :share-qr                              "Deel QR"
-   :feedback                              "Terugvoer ontvang?\nSkud u foon!"
    :twelve-words-in-correct-order         "12 woorde in korrekte volgorde"
    :remove-from-contacts                  "Verwyder van kontakte"
    :delete-chat                           "Skrap klets"
@@ -272,7 +208,6 @@
 
    :contact-s                             {:one   "kontak"
                                            :other "kontakte"}
-   :group-name                            "Groepnaam"
    :next                                  "Volgende"
    :from                                  "Van"
    :search-chats                          "Soek kletse"
@@ -289,17 +224,11 @@
    :more                                  "meer"
    :cancel                                "Kanselleer"
    :no-statuses-found                     "Geen statusse gevind nie"
-   :swow-qr                               "Wys QR"
    :browsing-open-in-web-browser          "Maak oop in webblaaier"
    :delete-group-prompt                   "Dit sal nie kontakte affekteer nie"
    :edit-profile                          "Redigeer profiel"
 
 
-   :enter-password-transactions           {:one   "Bevestig transaksie deur u wagwoord te verskaf"
-                                           :other "Bevestig transaksies deur u wagwoord te verskaf"}
-   :unsigned-transactions                 "Ongetekende transaksies"
    :empty-topic                           "Leë onderwerp"
    :to                                    "Aan"
-   :group-members                         "Groeplede"
-   :estimated-fee                         "Geraamde fooi"
    :data                                  "Data"})

--- a/src/status_im/translations/ar.cljs
+++ b/src/status_im/translations/ar.cljs
@@ -10,8 +10,6 @@
    :offline                               "غير متصل"
 
    ;drawer
-   :invite-friends                        "دعوة الأصدقاء"
-   :faq                                   "الأسئلة الشائعة"
    :switch-users                          "التبديل بين المستخدمين"
 
    ;chat
@@ -53,41 +51,30 @@
                                            :other "ساعات"}
    :datetime-day                          {:one   "يوم"
                                            :other "أيام"}
-   :datetime-multiple                     "ث" ; TODO
    :datetime-ago                          "منذ"
    :datetime-yesterday                    "الأمس"
    :datetime-today                        "اليوم"
 
    ;profile
    :profile                               "الملف الشخصي"
-   :report-user                           "الإبلاغ عن مستخدم"
    :message                               "الرسالة"
-   :username                              "اسم المستخدم"
    :not-specified                         "غير محدد"
    :public-key                            "المفتاح العمومي"
    :phone-number                          "رقم الهاتف"
-   :email                                 "البريد الإلكتروني"
-   :profile-no-status                     "لا توجد حالة"
    :add-to-contacts                       "أضف إلى جهات الاتصال"
-   :error-incorrect-name                  "الرجاء اختيار اسم آخر"
-   :error-incorrect-email                 "بريد إلكتروني غير صحيح"
 
    ;;make_photo
    :image-source-title                    "الصورة الشخصية"
    :image-source-make-photo               "التقاط صورة"
    :image-source-gallery                  "الاختيار من معرض الصور"
-   :image-source-cancel                   "إلغاء"
 
    ;sign-up
    :contacts-syncronized                  "تمت مزامنة جهات الاتصال الخاصة بك"
    :confirmation-code                     (str "شكراً! لقد أرسلنا لك رسالة نصية تتضمن رمز تأكيد"
                                                "يرجى إدخال هذا الرمز لتأكيد رقم هاتفك")
    :incorrect-code                        (str "عذراً الرمز غير صحيح، يرجى إدخاله مرة أخرى")
-   :generate-passphrase                   (str "سوف أقوم بإنشاء عبارة مرور لك حتى تتمكن من "
-                                               "الوصول أو الدخول ثانية من جهاز آخر")
    :phew-here-is-your-passphrase          "*أف* لقد كان أمراً شاقاً، إليك عبارة المرور الخاصة بك، * قم بتسجيلها واحتفظ بها في مكان آمن!* سوف تحتاج إليها لاسترداد حسابك."
    :here-is-your-passphrase               "إليك عبارة المرور الخاصة بك، * قم بتسجيلها واحتفظ بها في مكان آمن! *سوف تحتاج إليها لاسترداد حسابك"
-   :written-down                          "تأكد بأنك قد دونتها بشكل آمن"
    :phone-number-required                 "اضغط هنا لإدخال رقم الهاتف الخاص بك وسوف تعثر على أصدقائك"
    :intro-status                          "دردش معي لتثبيت حسابك وقم بتغيير الإعدادات الخاصة بك!"
    :intro-message1                        "مرحبا بك في Status \n اضغط على هذه الرسالة لتعيين كلمة المرور الخاصة بك وابدأ!"
@@ -95,7 +82,6 @@
 
    ;chats
    :chats                                 "الدردشات"
-   :new-chat                              "دردشة جديدة"
    :new-group-chat                        "مجموعة دردشة جديدة"
 
    ;discover
@@ -112,9 +98,6 @@
    ;contacts
    :contacts                              "جهات الاتصال"
    :new-contact                           "جهة اتصال جديدة"
-   :show-all                              "عرض الكل"
-   :contacts-group-dapps                  "ÐApps"
-   :contacts-group-people                 "الناس"
    :contacts-group-new-chat               "ابدأ دردشة جديدة"
    :no-contacts                           "لا توجد جهات اتصال بعد"
    :show-qr                               "عرض شفرة التعريف"
@@ -122,41 +105,17 @@
    ;group-settings
    :remove                                "إزالة"
    :save                                  "حفظ"
-   :change-color                          "تغيير اللون"
    :clear-history                         "حذف التاريخ"
-   :delete-and-leave                      "الحذف والمغادرة"
    :chat-settings                         "إعدادات الدردشة"
    :edit                                  "تحرير"
    :add-members                           "إضافة أعضاء"
-   :blue                                  "أزرق"
-   :purple                                "أرجواني"
-   :green                                 "أخضر"
-   :red                                   "أحمر"
 
    ;commands
-   :money-command-description             "إرسال الأموال"
-   :location-command-description          "إرسال الموقع"
-   :phone-command-description             "إرسال رقم الهاتف"
-   :phone-request-text                    "طلب رقم الهاتف"
-   :confirmation-code-command-description "إرسال رمز التأكيد"
-   :confirmation-code-request-text        "طلب رمز التأكيد"
-   :send-command-description              "إرسال الموقع"
-   :request-command-description           "إرسال طلب"
-   :keypair-password-command-description  ""
-   :help-command-description              "المساعدة"
-   :request                               "طلب"
    :chat-send-eth                         "{{amount}} ETH"
-   :chat-send-eth-to                      "{{amount}} ETH إلى {{chat-name}}"
-   :chat-send-eth-from                    "{{amount}} ETH من {{chat-name}}"
 
    ;new-group
-   :group-chat-name                       "اسم الدردشة"
-   :empty-group-chat-name                 "الرجاء إدخال اسم"
-   :illegal-group-chat-name               "الرجاء اختيار اسم آخر"
 
    ;participants
-   :add-participants                      "إضافة مشاركين"
-   :remove-participants                   "إزالة مشاركين"
 
    ;protocol
    :received-invitation                   "تسلم دعوة الدردشة"
@@ -168,12 +127,9 @@
 
    ;new-contact
    :add-new-contact                       "إضافة جهة اتصال جديدة"
-   :import-qr                             "جلب"
    :scan-qr                               "مسح شفرة التعريف"
    :name                                  "اسم"
-   :whisper-identity                      "Whisper Identity"
    :address-explication                   "ربما يتعين أن تتوافر هنا بعض النصوص التي تشرح ما هو العنوان وأين تبحث عنه"
-   :enter-valid-address                   "الرجاء إدخال عنوان صحيح أو قم بمسح شفرة التعريف"
    :contact-already-added                 "تمت إضافة جهة الاتصال"
    :can-not-add-yourself                  "لا يمكنك إضافة نفسك"
    :unknown-address                       "عنوان غير معروف"
@@ -183,20 +139,14 @@
    :connect                               "اتصال"
    :address                               "عنوان"
    :password                              "كلمة مرور"
-   :login                                 "تسجيل الدخول"
    :wrong-password                        "كلمة مرور خاطئة"
 
    ;recover
-   :recover-from-passphrase               "استرداد بواسطة عبارة المرور"
-   :recover-explain                       "الرجاء إدخال عبارة المرور الخاصة بكلمة المرور الخاصة بك لاستعادة إمكانية الوصول"
    :passphrase                            "عبارة المرور"
    :recover                               "استعادة"
-   :enter-valid-passphrase                "الرجاء إدخال عبارة المرور"
-   :enter-valid-password                  "الرجاء إدخال كلمة المرور"
 
    ;accounts
    :recover-access                        "استعادة إمكانية الوصول"
-   :add-account                           "إضافة حساب"
 
    ;wallet-qr-code
    :done                                  "تم التنفيذ"
@@ -205,18 +155,9 @@
    ;validation
    :invalid-phone                         "رقم هاتف غير صحيح"
    :amount                                "الكمية"
-   :not-enough-eth                        (str "لا يوجدETH كافي بالحساب "
-                                               "({{balance}} ETH)")
    ;transactions
-   :confirm-transactions                  {:one   "تأكيد المعاملة"
-                                           :other "تأكيد {{count}}  معاملات"
-                                           :zero  "لا توجد معاملات"}
    :status                                "الحالة"
-   :pending-confirmation                  "في انتظار التأكيد"
    :recipient                             "المستلم"
-   :one-more-item                         "بند واحد آخر"
-   :fee                                   "الرسوم"
-   :value                                 "القيمة"
 
    ;:webview
    :web-view-error                        "عفواً، حدث خطأ ما"})

--- a/src/status_im/translations/bel.cljs
+++ b/src/status_im/translations/bel.cljs
@@ -12,8 +12,6 @@
    :next                                  "Працягнуць"
 
    ;drawer
-   :invite-friends                        "Запрасіць сяброў"
-   :faq                                   "ЧАВО"
    :switch-users                          "Пераключыць карыстальнікау"
 
    ;chat
@@ -55,30 +53,22 @@
                                            :other "гадзін"}
    :datetime-day                          {:one   "дзень"
                                            :other "дні"}
-   :datetime-multiple                     "c" ; TODO probably wrong
    :datetime-ago                          "назад"
    :datetime-yesterday                    "учора"
    :datetime-today                        "сёння"
 
    ;profile
    :profile                               "Профіль"
-   :report-user                           "ПАСКАРДЗIЦЦА НА КАРЫСТАЛЬНIКА"
    :message                               "Паведамленне"
-   :username                              "Імя карыстальніка"
    :not-specified                         "Не пазначана"
    :public-key                            "Публічны ключ"
    :phone-number                          "Нумар тэлефона"
-   :email                                 "Электронная пошта"
-   :profile-no-status                     "Няма статусу"
    :add-to-contacts                       "Дадаць у кантакты"
-   :error-incorrect-name                  "Выбраць іншае імя"
-   :error-incorrect-email                 "Няправільная электронная пошта"
 
    ;;make_photo
    :image-source-title                    "Mалюнак профілю"
    :image-source-make-photo               "Сфатаграфаваць"
    :image-source-gallery                  "Выбраць з галерэі"
-   :image-source-cancel                   "Адмена"
 
    ;;sharing
    :sharing-copy-to-clipboard             "Скапіяваць"
@@ -90,13 +80,10 @@
    :confirmation-code                     (str "Дзякуй! Мы адправілі вам СМС з кодам пацверджання."
                                                "Калі ласка, увядзіце гэты код для пацвярджэння свайго нумара тэлефона")
    :incorrect-code                        (str "Выбачайце, код няправільны, увядзіце яшчэ раз")
-   :generate-passphrase                   (str "Я ствару для вас парольную фразу, каб вы змаглі аднавіць ваш"
-                                               "доступ або ўвайсці з іншага прылады")
    :phew-here-is-your-passphrase          (str "*Уф*, эгэта было няпроста, вось ваша парольная фраза, *запішыце яе і захавайце ў надзейным месцы!* "
                                                "Яна будзе патрэбна вам для аднаўлення акаўнта.")
    :here-is-your-passphrase               (str "Вось ваша парольная фраза, *запішыце яе і захавайце ў надзейным месцы!* "
                                                "Яна будзе патрэбна вам для аднаўлення акаўнта.")
-   :written-down                          "Пераканайцеся, што вы запісалі яе ў надзейным месцы"
    :phone-number-required                 "Націсніце сюды для ўводу свайго нумара тэлефона і пошуку сваіх сяброў"
    :intro-status                          "Пагутарыце са мной у чаце, каб наладзіць свой рахунак і змяніць свае налады!"
    :intro-message1                        "Сардэчна запрашаем у Статус\nНацісніце на гэтае паведамленне, каб усталяваць пароль і пачаць!"
@@ -104,7 +91,6 @@
 
    ;chats
    :chats                                 "Чаты"
-   :new-chat                              "Новы чат"
    :new-group-chat                        "Новы групавы чат"
 
    ;discover
@@ -122,9 +108,6 @@
    :contacts                              "Кантакты"
    :new-contact                           "Новы кантакт"
    :edit-contacts                         "Рэдагаванне кантактаў"
-   :show-all                              "ПАКАЗАЦЬ УСЕ"
-   :contacts-group-dapps                  "ÐApps"
-   :contacts-group-people                 "Людзі"
    :contacts-group-new-chat               "Пачаць новы чат"
    :no-contacts                           "Пакуль няма кантактаў"
    :show-qr                               "Паказаць QR"
@@ -133,44 +116,19 @@
    ;group-settings
    :remove                                "Выдаліць"
    :save                                  "Захаваць"
-   :change-color                          "Змяніць колер"
    :clear-history                         "Ачысціць гісторыю"
-   :delete-and-leave                      "Выдаліць і пакінуць"
    :chat-settings                         "Налады чата"
    :edit                                  "Змяніць"
    :add-members                           "Дадаць членаў"
-   :blue                                  "Сіні"
-   :purple                                "Фіялетавы"
-   :green                                 "Зялёны"
-   :red                                   "Чырвоны"
 
    ;commands
-   :money-command-description             "Адправіць грошы"
-   :location-command-description          "Адправіць месцазнаходжанне"
-   :phone-command-description             "Адправіць нумар тэлефона"
-   :phone-request-text                    "Запыт нумара тэлефона"
-   :confirmation-code-command-description "Адправіць код пацверджання"
-   :confirmation-code-request-text        "Запыт кода пацверджання"
-   :send-command-description              "адправіць месцазнаходжанне"
-   :request-command-description           "Адправіць запыт"
-   :keypair-password-command-description  ""
-   :help-command-description              "Дапамога"
-   :request                               "Запыт"
    :chat-send-eth                         "{{amount}} ETH"
-   :chat-send-eth-to                      "{{amount}} ETH на адрас {{chat-name}}"
-   :chat-send-eth-from                    "{{amount}} ETH ад {{chat-name}}"
 
    ;new-group
-   :group-chat-name                       "Імя чата"
-   :empty-group-chat-name                 "Ўвядзіце імя"
-   :illegal-group-chat-name               "Трэба выбраць іншае імя"
    :new-group                             "Новая група"
-   :group-name                            "Назва групы"
    :reorder-groups                        "Упарадкаваць групы"
 
    ;participants
-   :add-participants                      "Дадаць удзельнікаў"
-   :remove-participants                   "Выдаліць удзельнікаў"
 
    ;protocol
    :received-invitation                   "атрымаў(ла) запрашэнне ў чат"
@@ -182,12 +140,9 @@
 
    ;new-contact
    :add-new-contact                       "Дадаць новы кантакт"
-   :import-qr                             "Iмпарт"
    :scan-qr                               "Сканаваць QR"
    :name                                  "Імя"
-   :whisper-identity                      "Прыхаваная асоба"
    :address-explication                   "Можа быць, тут павінен быць нейкі тэкст, які тлумачыць адрас і тое, дзе яго шукаць"
-   :enter-valid-address                   "Калі ласка, увядзіце сапраўдны адрас або скануйце QR-код"
    :enter-valid-public-key                "Калі ласка, увядзіце сапраўдны публічны ключ ці скануйце QR-код"
    :contact-already-added                 "Кантакт ўжо дададзены"
    :can-not-add-yourself                  "Вы не можаце дадаць сябе"
@@ -198,20 +153,14 @@
    :connect                               "Падлучыцца"
    :address                               "Адрас"
    :password                              "Пароль"
-   :login                                 "Уваход"
    :wrong-password                        "Няправільны пароль"
 
    ;recover
-   :recover-from-passphrase               "Аднаўленне з дапамогай парольной фразы"
-   :recover-explain                       "Увядзіце парольную фразу замест вашага пароля для аднаўлення доступу"
    :passphrase                            "Парольная фраза"
    :recover                               "Аднавіць"
-   :enter-valid-passphrase                "Увядзіце парольную фразу"
-   :enter-valid-password                  "Увядзіце пароль"
 
    ;accounts
    :recover-access                        "Аднавіць доступ"
-   :add-account                           "Дадаць аккаунт"
 
    ;wallet-qr-code
    :done                                  "Гатова"
@@ -220,18 +169,9 @@
    ;validation
    :invalid-phone                         "Няправільны нумар тэлефона"
    :amount                                "Сума"
-   :not-enough-eth                        (str "Не хапае ETH на балансе "
-                                               "({{balance}} ETH)")
    ;transactions
-   :confirm-transactions                  {:one   "Пацвердзіць транзакцыю"
-                                           :other "Пацвердзіце {{count}} транзакции(ый)"
-                                           :zero  "Няма транзакций"}
    :status                                "Статус"
-   :pending-confirmation                  "У чаканні пацверджання"
    :recipient                             "Атрымальнік"
-   :one-more-item                         "Яшчэ адна пазіцыя"
-   :fee                                   "Камісія"
-   :value                                 "Сума"
 
    ;:webview
    :web-view-error                        "ой, памылка"})

--- a/src/status_im/translations/cs.cljs
+++ b/src/status_im/translations/cs.cljs
@@ -19,11 +19,7 @@
    :photos-access-error                   "Pro udělení potřebných oprávnění k fotoaparátu přejděte do nastavení systému a ujistěte se, že je vybráno Status > Fotoaparát."
 
    ;drawer
-   :invite-friends                        "Pozvat přátele"
-   :faq                                   "Otázky a odpovědi"
    :switch-users                          "Přepnout uživatele"
-   :feedback                              "Máte návrh?\nZatřeste telefonem!"
-   :view-all                              "Zobrazit vše"
    :current-network                       "Aktuální síť"
 
    ;chat
@@ -69,7 +65,6 @@
                                            :other "hodin(y)"}
    :datetime-day                          {:one   "den"
                                            :other "dny(ů)"}
-   :datetime-multiple                     "s"
    :datetime-ago                          "uplynulo:"
    :datetime-yesterday                    "včera"
    :datetime-today                        "dnes"
@@ -77,13 +72,10 @@
    ;profile
    :profile                               "Profil"
    :edit-profile                          "Upravit profil"
-   :report-user                           "NAHLÁSIT UŽIVATELE"
    :message                               "Zpráva"
-   :username                              "Uživatel"
    :not-specified                         "Není zadáno"
    :public-key                            "Veřejný klíč"
    :phone-number                          "Telefonní číslo"
-   :email                                 "E-mail"
    :update-status                         "Aktualizovat svůj status..."
    :add-a-status                          "Přidat status..."
    :status-prompt                         "Můžete vytvořit status, aby ostatní věděli, co nabízíte. Můžete používat i #hashtagy."
@@ -92,15 +84,11 @@
    :remove-from-contacts                  "Odstranit z kontaktů"
    :start-conversation                    "Zahájit konverzaci"
    :send-transaction                      "Odeslat transakci"
-   :share-qr                              "Sdílet QR kód"
-   :error-incorrect-name                  "Prosím vyberte jiné jméno"
-   :error-incorrect-email                 "Nesprávný e-mail"
 
    ;;make_photo
    :image-source-title                    "Profilový obrázek"
    :image-source-make-photo               "Vyfotit"
    :image-source-gallery                  "Vybrat z galerie"
-   :image-source-cancel                   "Storno"
 
    ;;sharing
    :sharing-copy-to-clipboard             "Kopírovat do schránky"
@@ -108,7 +96,6 @@
    :sharing-cancel                        "Storno"
 
    :browsing-title                        "Prohlížet"
-   :browsing-browse                       "@prohlížet"
    :browsing-open-in-web-browser          "Otevřít ve webovém prohlížeči"
    :browsing-cancel                       "Storno"
 
@@ -117,11 +104,8 @@
    :confirmation-code                     (str "Díky! Poslali jsme Ti textovou zprávu s kódem pro potvrzení. "
                                                "Prosím potvrď své telefonní číslo zadáním tohoto kódu.")
    :incorrect-code                        (str "Tento kód není správný, prosím zkus to znovu.")
-   :generate-passphrase                   (str "Teď vytvořím skupinu anglických slov, se kterou se"
-                                               "dá obnovit přístup nebo přihlásit z jiného zařízení")
    :phew-here-is-your-passphrase          "*Uf*, to byla fuška, tady jsou bezpečnostní slova, *zapiš je a ulož na bezpečném místě!* Budou potřeba pro obnovení přístupu k účtu."
    :here-is-your-passphrase               "Tady jsou bezpečnostní slova, *zapiš je a ulož na bezpečném místě!* Budou potřeba pro obnovení přístupu k účtu."
-   :written-down                          "Ujisti se, že je máš uložené na bezpečném místě."
    :phone-number-required                 "Klepnutím zde můžeš zadat své telefonní číslo a hledat přátele."
    :shake-your-phone                      "Našel jsi chybu nebo máš návrh? Prostě --zatřes-- telefonem!"
    :intro-status                          "Chat se mnou ti může pomoci nastavit ůčet a změnit další nastavení!"
@@ -138,7 +122,6 @@
 
    ;chats
    :chats                                 "Chaty"
-   :new-chat                              "Nový chat"
    :delete-chat                           "Smazat chat"
    :new-group-chat                        "Nový skupinový chat"
    :new-public-group-chat                 "Přidat se k veřejnému chatu"
@@ -168,9 +151,6 @@
    :remove-from-group                     "Odstranit ze skupiny"
    :edit-contacts                         "Upravit kontakty"
    :search-contacts                       "Hledat kontakty"
-   :show-all                              "UKÁZAT VŠE"
-   :contacts-group-dapps                  "ÐApky"
-   :contacts-group-people                 "Lidé"
    :contacts-group-new-chat               "Zahájit nový chat"
    :choose-from-contacts                  "Vybrat z kontaktů"
    :no-contacts                           "Ještě tu nejsou žádné kontakty"
@@ -182,52 +162,26 @@
    :remove                                "Odstranit"
    :save                                  "Uložit"
    :delete                                "Smazat"
-   :change-color                          "Změnit barvu"
    :clear-history                         "Vymazat historii"
    :mute-notifications                    "Vypnout oznámení"
    :leave-chat                            "Opustit chat"
-   :delete-and-leave                      "Smazat a odejít"
    :chat-settings                         "Nastavení chatu"
    :edit                                  "Upravit"
    :add-members                           "Přidat členy"
-   :blue                                  "Modrá"
-   :purple                                "Purpurová"
-   :green                                 "Zelená"
-   :red                                   "Červená"
 
    ;commands
-   :money-command-description             "Poslat peníze"
-   :location-command-description          "Poslat umístění"
-   :phone-command-description             "Poslat telefonní číslo"
-   :phone-request-text                   "Požadavek na telefonní číslo"
-   :confirmation-code-command-description "Poslat kód pro potvrzení"
-   :confirmation-code-request-text        "Požadavek na kód pro potvrzení"
-   :send-command-description              "Poslat umístění"
-   :request-command-description           "Poslat požadavek"
-   :keypair-password-command-description  ""
-   :help-command-description              "Nápověda"
-   :request                               "Požadavek"
    :chat-send-eth                         "{{amount}} ETH"
-   :chat-send-eth-to                      "{{amount}} ETH pro {{chat-name}}"
-   :chat-send-eth-from                    "{{amount}} ETH od {{chat-name}}"
 
    ;new-group
-   :group-chat-name                       "Název chatu"
-   :empty-group-chat-name                 "Prosím zadejte název"
-   :illegal-group-chat-name               "Prosím vyberte jiný název"
    :new-group                             "Nová skupina"
    :reorder-groups                        "Uspořádat skupiny"
-   :group-name                            "Název skupiny"
    :edit-group                            "Upravit skupinu"
    :delete-group                          "Smazat skupinu"
    :delete-group-confirmation             "Tato skupina bude odstraněna z tvých skupin. Kontaktů se to nedotkne."
    :delete-group-prompt                   "Kontaktů se to nedotkne"
-   :group-members                         "Členové skupiny"
    :contact-s                             {:one   "kontakt"
                                            :other "kontakty(ů)"}
    ;participants
-   :add-participants                      "Přidat účastníky"
-   :remove-participants                   "Odebrat účastníky"
 
    ;protocol
    :received-invitation                   "přijata pozvánka k chatu"
@@ -239,13 +193,9 @@
 
    ;new-contact
    :add-new-contact                       "Přidat nový kontakt"
-   :import-qr                             "Importovat"
    :scan-qr                               "Načíst QR kód"
-   :swow-qr                               "Ukázat QR kód"
    :name                                  "Jméno"
-   :whisper-identity                      "Identita na Whisperu"
    :address-explication                   "Identita na Whisperu je adresa blockchainové sítě Ethereum"
-   :enter-valid-address                   "Prosím zadejte platnou adresu nebo načtěte QR kód"
    :enter-valid-public-key              "Prosím zadejte platný veřejný klíč nebo načtěte QR kód"
    :contact-already-added                 "Tento kontakt již byl přidán"
    :can-not-add-yourself                  "Nemůžeš přidat sebe"
@@ -256,23 +206,17 @@
    :connect                             "Připojit"
    :address                               "Adresa"
    :password                              "Heslo"
-   :login                                 "Přihlášení"
    :sign-in-to-status                     "Přihlásit se do Statusu"
    :sign-in                               "Přihlásit se"
    :wrong-password                        "Špatné heslo"
 
    ;recover
-   :recover-from-passphrase               "Obnovit z bezpečnostních slov"
-   :recover-explain                       "Pro obnovení přístupu prosím zadej bezpečnostní slova ke svému účtu"
    :passphrase                            "Bezpečnostní slova"
    :recover                               "Obnovit"
-   :enter-valid-passphrase                "Prosím zadej bezpečnostní slova"
-   :enter-valid-password                  "Prosím zadej heslo"
    :twelve-words-in-correct-order         "12 anglických slov ve správném pořadí"
 
    ;accounts
    :recover-access                        "Obnovit přístup"
-   :add-account                           "Přidat účet"
    :create-new-account                    "Vytvořit nový účet"
 
    ;wallet-qr-code
@@ -281,33 +225,15 @@
    ;validation
    :invalid-phone                         "Neplatné telefonní číslo"
    :amount                                "Množství"
-   :not-enough-eth                        (str "Nemáš na účtu dost ETH: "
-                                               "({{balance}} ETH)")
    ;transactions
    :confirm                               "Potvrdit"
-   :confirm-transactions                  {:one   "Potvrdit transakci"
-                                           :other "Potvrdit {{count}} transakce(í)"
-                                           :zero  "Žádné transakce"}
-   :transactions-confirmed                {:one   "Transakce potvrzena"
-                                           :other "Potvrzeno transakcí: {{count}}"
-                                           :zero  "Žádná transakce nebyla potvrzena"}
    :transaction                           "Transakce"
-   :unsigned-transactions                 "Nepodepsané transakce"
-   :no-unsigned-transactions              "Žádné nepodepsané transakce"
-   :enter-password-transactions           {:one   "Potvrdit transakce zadáním hesla"
-                                           :other "Potvrdit transakce zadáním hesla"}
    :status                                "Status"
-   :pending-confirmation                  "Čekající na potvrzení"
    :recipient                             "Příjemce"
-   :one-more-item                         "Jedna další položka"
-   :fee                                   "Poplatek"
-   :estimated-fee                         "Odhadovaný poplatek"
-   :value                                 "Množství"
    :to                                    "Komu"
    :from                                  "Od"
    :data                                  "Data"
    :got-it                                "Mám to"
-   :contract-creation                     "Vytvoření kontaktu"
 
    ;:webview
    :web-view-error                        "ups, chyba"
@@ -325,12 +251,8 @@
    :wallet-exchange                       "Směnárna"
    :wallet-assets                         "Aktiva"
    :transactions                          "Transakce"
-   :transactions-to                       "Komu"
    :transactions-sign                     "Podepsat"
    :transactions-sign-all                 "Podepsat vše"
-   :transactions-sign-all-text            "Podepište transakci zadáním hesla.\nUjistěte se, že slova zobrazená výše odpovídají Vašim bezpečnostním slovům."
-   :transactions-sign-input-placeholder   "Zadejte své heslo"
-   :transactions-sign-all-done            "Hotovo"
    :transactions-delete                   "Smazat"
    :transactions-history                  "Historie"
    :transactions-unsigned                 "Nepodepsáno"

--- a/src/status_im/translations/da.cljs
+++ b/src/status_im/translations/da.cljs
@@ -19,11 +19,7 @@
    :photos-access-error                   "Gå venligst til dine systemindstillinger og sørg  for at du Status > Billeder er tilladt."
 
    ;drawer
-   :invite-friends                        "Inviter venner"
-   :faq                                   "FAQ"
    :switch-users                          "Skift bruger"
-   :feedback                              "Ryst din telefon for at give os feedback!"
-   :view-all                              "Vis alle"
    :current-network                       "Nuværende netværk"
 
    ;chat
@@ -69,7 +65,6 @@
                                            :other "timer"}
    :datetime-day                          {:one   "dag"
                                            :other "dage"}
-   :datetime-multiple                     "s"
    :datetime-ago                          "siden"
    :datetime-yesterday                    "i går"
    :datetime-today                        "i dag"
@@ -77,32 +72,23 @@
    ;profile
    :profile                               "Profil"
    :edit-profile                          "Rediger profil"
-   :report-user                           "Anmeld bruger"
    :message                               "Meddelelser"
-   :username                              "Brugrenavn"
    :not-specified                         "Ikke angivet"
    :public-key                            "Offentlig nøgle"
    :phone-number                          "Telefonnummer"
-   :email                                 "Email"
    :update-status                         "Opdater din status..."
    :add-a-status                          "Tilføj en status..."
    :status-prompt                         "Lav en status for at lade folk vide hvad du tilbyder. Du kan også bruge #hashtags."
-   :profile-no-status                     "Ingen status"
    :add-to-contacts                       "Tilføj til kontakter"
    :in-contacts                           "I kontakter"
    :remove-from-contacts                  "Fjern fra kontakter"
    :start-conversation                    "Begynd samtale"
    :send-transaction                      "Send transaktion"
-   :share-qr                              "Del QR-kode"
-   :error-incorrect-name                  "Fejl: Forkert navn"
-   :error-incorrect-email                 "Fejl: Forkert email"
 
    ;;make_photo
    :image-source-title                    "Profilbillede"
    :image-source-make-photo               "Tag billede"
    :image-source-gallery                  "Vælg fra galleri"
-   :image-source-cancel                   "Afbryd"
-   
    ;;sharing
    :sharing-copy-to-clipboard             "Kopier til udklipsholderen"
    :sharing-share                         "Del..."
@@ -117,10 +103,8 @@
    :confirmation-code                     (str "Tak! Vi har sendt dig en sms med en bekræftelseskode. "
                                                "Vær venlig at indtaste koden for at bekræfte dit telefonnummer")
    :incorrect-code                        (str "Koden var desværre forkert. Prøv venligst igen")
-   :generate-passphrase                   (str "Jeg vil generere en kodesætning (passphrase) til dig, så du kan gendanne din adgang eller logge ind fra en anden enhed")
    :phew-here-is-your-passphrase          "*Puha* det var hårdt, her er din kodesætning (passphrase), *skriv den ned og gem den sikkert!* Du skal bruge den for at kunne gendanne din konto."
    :here-is-your-passphrase               "Her er din kodesætning (passphrase), *skriv den ned og gem den sikkert!* Du behøver den for at gendanne din konto."
-   :written-down                          "Sørg for at du har skrevet den sikkert ned"
    :phone-number-required                 "Klik her for at indtaste dit telefonnummer, så vil jeg finde dine venner"
    :shake-your-phone                      "Fundet en bug eller har du et foreslag. Blot ryst din telefon!"
    :intro-status                          "Chat med mig for at opsætte din konto og ændre dine indstillinger!!"
@@ -137,7 +121,6 @@
 
    ;chats
    :chats                                 "Samtaler"
-   :new-chat                              "Ny samtale"
    :delete-chat                           "Fjern samtale"
    :new-group-chat                        "Ny gruppsamtale"
    :new-public-group-chat                  "Deltag i offentlig samtale"
@@ -167,9 +150,6 @@
    :remove-from-group                     "Fjern fra gruppe"
    :edit-contacts                         "Rediger kontakter"
    :search-contacts                       "Søg efter kontakter"
-   :show-all                              "Vis alle"
-   :contacts-group-dapps                  "ÐApps"
-   :contacts-group-people                 "Mennesker"
    :contacts-group-new-chat               "Start en ny samtale"
    :choose-from-contacts                  "Vælg fra kontakter"
    :no-contacts                           "Ingen kontakter endnu"
@@ -181,52 +161,26 @@
    :remove                                "Fjern"
    :save                                  "Gem"
    :delete                                "Slet"
-   :change-color                          "Ændre farve"
    :clear-history                         "Fjern historik"
    :mute-notifications                    "Sluk for notifikationer"
    :leave-chat                            "Forlad samtale"
-   :delete-and-leave                      "Slet og forlad"
    :chat-settings                         "Chatindstillinger"
    :edit                                  "Rediger"
    :add-members                           "Tilføj medlemmere"
-   :blue                                  "Blå"
-   :purple                                "Lilla"
-   :green                                 "Grøn"
-   :red                                   "Rød"
 
    ;commands
-   :money-command-description             "Send penge"
-   :location-command-description          "Send placering"
-   :phone-command-description             "Send telefonnummer"
-   :phone-request-text                    "Telefonnummeranmodning"
-   :confirmation-code-command-description "Send bekræftelseskode"
-   :confirmation-code-request-text        "Bekræftelseskodeanmodning"
-   :send-command-description              "Send placering"
-   :request-command-description           "Send anmodning"
-   :keypair-password-command-description  ""
-   :help-command-description              "Hjælp"
-   :request                               "Anmod"
    :chat-send-eth                         "{{amount}} ETH"
-   :chat-send-eth-to                      "{{amount}} ETH til {{chat-name}}"
-   :chat-send-eth-from                    "{{amount}} ETH fra {{chat-name}}"
 
    ;new-group
-   :group-chat-name                       "Gruppechat navn"
-   :empty-group-chat-name                 "Angiv et navn"
-   :illegal-group-chat-name               "Vælg venligst et andet navn"
    :new-group                             "Ny gruppe"
    :reorder-groups                        "Arranger grupper"
-   :group-name                            "Gruppenavn"
    :edit-group                            "Rediger gruppe"
    :delete-group                          "Slet gruppe"
    :delete-group-confirmation             "Denne gruppe vil blivve fjernet fra dine grupper. Dette vil ikke påvirke dine kontakter."
    :delete-group-prompt                   "Dette vil ikke påvirke dine kontakter"
-   :group-members                         "Gruppemedlemmer"
    :contact-s                             {:one   "kontakt"
                                            :other "kontakter"}
    ;participants
-   :add-participants                      "Tilføj deltagere"
-   :remove-participants                   "Fjern deltagere"
 
    ;protocol
    :received-invitation                   "Accepterede chatinvitaion"
@@ -238,13 +192,9 @@
 
    ;new-contact
    :add-new-contact                       "Tilføj ny kontakt"
-   :import-qr                             "Importer QR-kode"
    :scan-qr                               "Skan QR-kode"
-   :swow-qr                               "Vis QR"
    :name                                  "Navn"
-   :whisper-identity                      "Whisper identitet"
    :address-explication                   "Maybe here should be some text explaining what an address is and where to look for it"
-   :enter-valid-address                   "Indtast venligst en gyldig adresse eller scan en QR-kode"
    :enter-valid-public-key                "Indtast venligst en gyldig offentlig nøgle eller scan en QR-kode"
    :contact-already-added                 "Kontakten er allerede tilføjet"
    :can-not-add-yourself                  "Du kan ikke tilføje dig selv fjolle"
@@ -255,23 +205,17 @@
    :connect                               "Tilslut"
    :address                               "Adresse"
    :password                              "Kodeord"
-   :login                                 "Login"
    :sign-in-to-status                     "Log på Status"
    :sign-in                               "Log på"
    :wrong-password                        "Forkert kodeord"
 
    ;recover
-   :recover-from-passphrase               "Gendan fra kodesætning (passphrase)"
-   :recover-explain                       "Indtast kodesætningen (passphrase) til dit kodeord for at genoprette adgangen"
    :passphrase                            "Kodesætning (passphrase)"
    :recover                               "Gendan"
-   :enter-valid-passphrase                "Angiv korrekt kodesætning (passphrase)"
-   :enter-valid-password                  "Angiv korrekt kodeord"
    :twelve-words-in-correct-order         "12 ord i den korrekte rækkefølge"
 
    ;accounts
    :recover-access                        "Gendan adgang"
-   :add-account                           "Tilføj konto"
    :create-new-account                    "Opret en ny konto"
 
    ;wallet-qr-code
@@ -281,33 +225,15 @@
    ;validation
    :invalid-phone                         "Ugyldigt telefonnummer"
    :amount                                "Beløb"
-   :not-enough-eth                        (str "'Ikke tilstrækkeligt ETH på kontoen "
-                                               "({{balance}} ETH)")
    ;transactions
    :confirm                               "Bekræft"
-   :confirm-transactions                  {:one   "Bekræft transaktionen"
-                                           :other "Bekræft {{count}} transaktioner"
-                                           :zero  "Ingen transaktioner"}
-   :transactions-confirmed                {:one   "Transaktionen bekræftet"
-                                           :other "{{count}} transaktioner bekræftet"
-                                           :zero  "Ingen transaktioner bekræftet"}
    :transaction                           "Transaktion"
-   :unsigned-transactions                 "Usignerede transaktioner"
-   :no-unsigned-transactions              "Ingen usignerede transaktioner"
-   :enter-password-transactions           {:one   "Bekræft transaktionen ved at indtaste dit kodeord"
-                                           :other "Bekræft transaktionerne ved at indtaste dit kodeord"}                                        
    :status                                "Status"
-   :pending-confirmation                  "Venter på bekræftelse"
    :recipient                             "Modtager"
-   :one-more-item                         "En ting til"
-   :fee                                   "Gebyr"
-   :estimated-fee                         "Forventet gebyr"
-   :value                                 "Værdi"
    :to                                    "Til"
    :from                                  "Fra"
    :data                                  "Data"
    :got-it                                "Forstået"
-   :contract-creation                     "Kontraktoprettelse"
 
    ;:webview
    :web-view-error                        "hovsa, fejl"})

--- a/src/status_im/translations/de_ch.cljs
+++ b/src/status_im/translations/de_ch.cljs
@@ -10,8 +10,6 @@
    :offline                               "Offline"
 
    ;drawer
-   :invite-friends                        "Lade Freunde ein"
-   :faq                                   "FAQ"
    :switch-users                          "Benutzer wechseln"
 
    ;chat
@@ -53,41 +51,30 @@
                                            :other "Stunden"}
    :datetime-day                          {:one   "Tag"
                                            :other "Tage"}
-   :datetime-multiple                     "s"
    :datetime-ago                          "vor"
    :datetime-yesterday                    "gestern"
    :datetime-today                        "heute"
 
    ;profile
    :profile                               "Profil"
-   :report-user                           "Benutzer melden"
    :message                               "Nachricht"
-   :username                              "Benutzername"
    :not-specified                         "Nicht spezifiziert"
    :public-key                            "Öffentlicher Schlüssel"
    :phone-number                          "Telefonnummer"
-   :email                                 "Email"
-   :profile-no-status                     "Kein Status"
    :add-to-contacts                       "Zu Kontakten hinzufügen"
-   :error-incorrect-name                  "Bitte wähle einen anderen Namen"
-   :error-incorrect-email                 "Inkorrekte E-mail"
 
    ;;make_photo
    :image-source-title                    "Profilbild"
    :image-source-make-photo               "Erfassen"
    :image-source-gallery                  "Aus der Galerie auswählen"
-   :image-source-cancel                   "Stornieren"
 
    ;sign-up
    :contacts-syncronized                  "Deine Kontakte wurden synchronisiert"
    :confirmation-code                     (str "Vielen Dank! Wir haben Dir eine SMS mit einem Bestätigungcode"
                                                "zugesandt. Bitte gebe diesen Code zur Bestätigung deiner Telefonnummer ein")
    :incorrect-code                        (str "Leider ist der Code nicht korrekt. Bitte versuche es nochmals")
-   :generate-passphrase                   (str "Ich generiere eine Passphrase für dich, so dass du dein Zugriff wiederherstellen kannst "
-                                               "Zugriff und Anmeldung von einem anderen Gerät")
    :phew-here-is-your-passphrase          "*Phew* das war hart, hier ist deine Passphrase, *Schreibe diese auf und bewahre diese sicher auf!* Du benötigst diese, um dein Konto wiederherzustellen."
    :here-is-your-passphrase               "Hier ist deine Passphrase, *Schreibe diese auf und bewahre diese sicher auf!* Du benötigst diese, um dein Konto wiederherzustellen."
-   :written-down                          "Stelle sicher, dass du diese aufgeschrieben hast!"
    :phone-number-required                 "Klicke hier, um deine Telefonnummer einzugeben & Ich finde deine Freunde für dich"
    :intro-status                          "Chat mit mir, damit ich dein Konto einrichten und deine Einstellungen ändern kann!"
    :intro-message1                        "Willkommen zu Status\nTap diese Nachricht um dein Passwort einzurichten & loszulegen!"
@@ -95,7 +82,6 @@
 
    ;chats
    :chats                                 "Chats"
-   :new-chat                              "Neuer Chat"
    :new-group-chat                        "Neuer Gruppenchat"
 
    ;discover
@@ -112,9 +98,6 @@
    ;contacts
    :contacts                              "Kontakte"
    :new-contact                           "Neuer Kontakt"
-   :show-all                              "Alle Kontakte anzeigen"
-   :contacts-group-dapps                  "ÐApps"
-   :contacts-group-people                 "Leute"
    :contacts-group-new-chat               "Starte neuen Gruppenchat"
    :no-contacts                           "Noch keine Kontakte"
    :show-qr                               "QR-Code anzeigen"
@@ -122,41 +105,17 @@
    ;group-settings
    :remove                                "Entfernen"
    :save                                  "Speichern"
-   :change-color                          "Farbe ändern"
    :clear-history                         "Verlauf löschen"
-   :delete-and-leave                      "Löschen und Verlassen"
    :chat-settings                         "Chat Einstellungen"
    :edit                                  "Bearbeiten"
    :add-members                           "Mitglieder hinzufügen"
-   :blue                                  "Blau"
-   :purple                                "Lila"
-   :green                                 "Grün"
-   :red                                   "Rot"
 
    ;commands
-   :money-command-description             "Geld senden"
-   :location-command-description          "Standort senden"
-   :phone-command-description             "Telefonnummer senden"
-   :phone-request-text                    "Telefonnummer anfordern"
-   :confirmation-code-command-description "Bestätigungscode senden"
-   :confirmation-code-request-text        "Bestätigungscode anfordern"
-   :send-command-description              "Standort senden"
-   :request-command-description           "Anforderung senden"
-   :keypair-password-command-description  ""
-   :help-command-description              "Hilfe"
-   :request                               "Anforderung"
    :chat-send-eth                         "{{amount}} ETH"
-   :chat-send-eth-to                      "{{amount}} ETH zu {{chat-name}}"
-   :chat-send-eth-from                    "{{amount}} ETH von {{chat-name}}"
 
    ;new-group
-   :group-chat-name                       "Chat Name"
-   :empty-group-chat-name                 "Bitte gib einen Namen ein"
-   :illegal-group-chat-name               "Bitte wähle einen anderen Namen aus"
 
    ;participants
-   :add-participants                      "Teilnehmer hinzufügen"
-   :remove-participants                   "Teilnehmer entfernen"
 
    ;protocol
    :received-invitation                   "Chat Einladung erhalten"
@@ -168,12 +127,9 @@
 
    ;new-contact
    :add-new-contact                       "Teilnehmer hinzufügen"
-   :import-qr                             "Importieren"
    :scan-qr                               "QR scannen"
    :name                                  "Name"
-   :whisper-identity                      "Identität flüstern" 
    :address-explication                   "Vielleicht sollte hier ein Text stehen der erklärt, was eine Adresse ist und wo man suchen soll"
-   :enter-valid-address                   "Bitte gebe eine gültige Adresse ein oder scanne den QR-Code"
    :contact-already-added                 "Der Kontakt wurde bereits hinzugefügt"
    :can-not-add-yourself                  "Du kannst dich nicht selbst hinzufügen"
    :unknown-address                       "Unbekannte Adresse"
@@ -183,20 +139,14 @@
    :connect                               "Verbinden"
    :address                               "Adresse"
    :password                              "Passwort"
-   :login                                 "Login"
    :wrong-password                        "Falsches Passwort"
 
    ;recover
-   :recover-from-passphrase               "Wiederherstellung von Passphrase"
-   :recover-explain                       "Bitte gebe die Passphrase für dein Passwort ein, um den Zugang wiederherzustellen"
    :passphrase                            "Passphrase"
    :recover                               "Wiederherstellen"
-   :enter-valid-passphrase                "Bitte Passphrase eingeben"
-   :enter-valid-password                  "Bitte Passwort eingeben"
 
    ;accounts
    :recover-access                        "Zugriff wiederherstellen"
-   :add-account                           "Konto hinzufügen"
 
    ;wallet-qr-code
    :done                                  "Erledigt"
@@ -205,18 +155,9 @@
    ;validation
    :invalid-phone                         "Ungültige Telefonnummer"
    :amount                                "Betrag"
-   :not-enough-eth                        (str "Nicht genug ETH zur Verfügung "
-                                               "({{balance}} ETH)")
    ;transactions
-   :confirm-transactions                  {:one   "Transaktion bestätigen"
-                                           :other "Bestätige {{count}} Transaktion"
-                                           :zero  "Keine Transaktion"}
    :status                                "Status"
-   :pending-confirmation                  "Konfirmation ausstehend"
    :recipient                             "Empfänger"
-   :one-more-item                         "Noch ein Element"
-   :fee                                   "Gebühren"
-   :value                                 "Valuta"
 
    ;:webview
    :web-view-error                        "oops, Fehler"})

--- a/src/status_im/translations/es_ar.cljs
+++ b/src/status_im/translations/es_ar.cljs
@@ -10,8 +10,6 @@
    :offline                               "Fuera de línea"
 
    ;drawer
-   :invite-friends                        "Invitar amigos"
-   :faq                                   "Preguntas frecuentes"
    :switch-users                          "Cambiar de usuario"
 
    ;chat
@@ -53,30 +51,22 @@
                                            :other "horas"}
    :datetime-day                          {:one   "día"
                                            :other "días"}
-   :datetime-multiple                     "s"
    :datetime-ago                          "atrás"
    :datetime-yesterday                    "ayer"
    :datetime-today                        "hoy"
 
    ;profile
    :profile                               "Perfil"
-   :report-user                           "REPORTAR USUARIO"
    :message                               "Mensaje"
-   :username                              "Nombre de usuario"
    :not-specified                         "No especificado"
    :public-key                            "Clave pública"
    :phone-number                          "Número telefónico"
-   :email                                 "Correo electrónico"
-   :profile-no-status                     "Sin estatus"
    :add-to-contacts                       "Agregar a contactos"
-   :error-incorrect-name                  "Elecciona otro nombre"
-   :error-incorrect-email                 "Correo electrónico incorrecto"
 
    ;;make_photo
    :image-source-title                    "Imagen de perfil"
    :image-source-make-photo               "Capturar"
    :image-source-gallery                  "Seleccionar de la galería"
-   :image-source-cancel                   "Cancelar"
 
    ;;sharing
    :sharing-copy-to-clipboard             "Copiar"
@@ -88,11 +78,8 @@
    :confirmation-code                     (str "¡Gracias! Te hemos enviado un código de confirmación por mensaje de texto. "
                                                "Ingresa este código para confirmar tu número telefónico")
    :incorrect-code                        (str "Lo siento, el código no era correcto; ingrésalo de nuevo")
-   :generate-passphrase                   (str "Voy a generar una frase de contraseña para que puedas restablecer tu "
-                                               "acceso o iniciar sesión desde otro dispositivo")
    :phew-here-is-your-passphrase          "*Wow* eso estuvo difícil, aquí tienes tu contraseña, *¡anótala y mantenla segura!* La necesitarás para recuperar tu cuenta."
    :here-is-your-passphrase               "Aquí tienes tu frase de contraseña, *¡Anótala y mantenga segura!* La necesitarás para recuperar tu cuenta."
-   :written-down                          "Asegúrate de haberla anotado en un lugar seguro"
    :phone-number-required                 "Pulsa aquí para ingresar tu número telefónico y yo encontraré a tus amigos"
    :intro-status                          "Chatea conmigo para establecer tu cuenta y cambiar tu configuración!"
    :intro-message1                        "Bienvenido(a) a Status\n¡Pulsa en este mensaje para establecer tu contraseña y comenzar!"
@@ -100,7 +87,6 @@
 
    ;chats
    :chats                                 "Chats"
-   :new-chat                              "Nuevo chat"
    :new-group-chat                        "Nuevo chat de grupo"
 
    ;discover
@@ -117,9 +103,6 @@
    ;contacts
    :contacts                              "Contactos"
    :new-contact                           "Nuevo contacto"
-   :show-all                              "MOSTRAR TODOS"
-   :contacts-group-dapps                  "ÐApps"
-   :contacts-group-people                 "Gente"
    :contacts-group-new-chat               "Iniciar nuevo chat"
    :no-contacts                           "No hay contactos todavía"
    :show-qr                               "Mostrar QR"
@@ -127,41 +110,17 @@
    ;group-settings
    :remove                                "Eliminar"
    :save                                  "Guardar"
-   :change-color                          "Cambiar color"
    :clear-history                         "Borrar historial"
-   :delete-and-leave                      "Suprimir y dejar"
    :chat-settings                         "Configuración del chat"
    :edit                                  "Editar"
    :add-members                           "Agregar miembros"
-   :blue                                  "Azul"
-   :purple                                "Púrpura"
-   :green                                 "Verde"
-   :red                                   "Rojo"
 
    ;commands
-   :money-command-description             "Enviar dinero"
-   :location-command-description          "Enviar ubicación"
-   :phone-command-description             "Enviar número telefónico"
-   :phone-request-text                    "Solicitud de número telefónico"
-   :confirmation-code-command-description "Enviar código de confirmación"
-   :confirmation-code-request-text        "Solicitud de código de confirmación"
-   :send-command-description              "Enviar ubicación"
-   :request-command-description           "Enviar solicitud"
-   :keypair-password-command-description  ""
-   :help-command-description              "Ayuda"
-   :request                               "Solicitud"
    :chat-send-eth                         "{{amount}} ETH"
-   :chat-send-eth-to                      "{{amount}} ETH a {{chat-name}}"
-   :chat-send-eth-from                    "{{amount}} ETH de {{chat-name}}"
 
    ;new-group
-   :group-chat-name                       "Nombre del chat"
-   :empty-group-chat-name                 "Ingresa un nombre"
-   :illegal-group-chat-name               "Selecciona otro nombre"
 
    ;participants
-   :add-participants                      "Agregar participantes"
-   :remove-participants                   "Retirar participantes"
 
    ;protocol
    :received-invitation                   "recibió invitación a chat"
@@ -173,12 +132,9 @@
 
    ;new-contact
    :add-new-contact                       "Agregar nuevo contacto"
-   :import-qr                             "Importar"
    :scan-qr                               "Escanear QR"
    :name                                  "Nombre"
-   :whisper-identity                      "Identidad de Whisper"
    :address-explication                   "Tal vez, aquí debería haber alguna indicación explicando qué es una dirección y dónde buscarla"
-   :enter-valid-address                   "Ingresa una dirección válida o escanea un código QR"
    :contact-already-added                 "El contacto ya ha sido agregado"
    :can-not-add-yourself                  "No puedes agregarte a ti mismo(a)"
    :unknown-address                       "Dirección desconocida"
@@ -188,20 +144,14 @@
    :connect                               "Conectar"
    :address                               "Dirección"
    :password                              "Contraseña"
-   :login                                 "Inicio de sesión"
    :wrong-password                        "Contraseña incorrecta"
 
    ;recover
-   :recover-from-passphrase               "Recuperar con frase de contraseña"
-   :recover-explain                       "Ingresa la frase de contraseña para tu contraseña para recuperar el acceso"
    :passphrase                            "Frase de contraseña"
    :recover                               "Recuperar"
-   :enter-valid-passphrase                "Ingresa una frase de contraseña"
-   :enter-valid-password                  "Ingresa una contraseña"
 
    ;accounts
    :recover-access                        "Recuperar acceso"
-   :add-account                           "Agregar cuenta"
 
    ;wallet-qr-code
    :done                                  "Completado"
@@ -210,33 +160,19 @@
    ;validation
    :invalid-phone                         "Número telefónico inválido"
    :amount                                "Monto"
-   :not-enough-eth                        (str "No hay suficiente ETH en tu saldo "
-                                               "({{balance}} ETH)")
    ;transactions
-   :confirm-transactions                  {:one   "Confirmar transacción"
-                                           :other "Confirmar {{count}} transacciones"
-                                           :zero  "No hay transacciones"}
    :status                                "Estatus"
-   :pending-confirmation                  "Esperando confirmación"
    :recipient                             "Destinatario"
-   :one-more-item                         "Un artículo más"
-   :fee                                   "Tarifa"
-   :value                                 "Valor"
 
    ;:webview
    :web-view-error                        "oops, error"
 
    :confirm                               "Confirmar"
    :phone-national                        "Nacional"
-   :transactions-confirmed                {:one   "Transacción confirmada"
-                                           :other "{{count}} transacciones confirmadas"
-                                           :zero  "No hay transacciones confirmadas"}
    :public-group-topic                    "Tema"
    :debug-enabled                         "¡Se inició el servidor de depuración! Ahora puede agregar su DApp ejecutando *status-dev-cli scan* desde su computadora"
    :new-public-group-chat                 "Unirse al chat público"
    :datetime-ago-format                   "{{number}} {{time-intervals}} {{ago}}"
-   :share-qr                              "Compartir QR"
-   :feedback                              "¿Tiene comentarios?\n¡Sacuda su teléfono!"
    :twelve-words-in-correct-order         "12 palabras en el orden correcto"
    :remove-from-contacts                  "Eliminar de los contactos"
    :delete-chat                           "Eliminar chat"
@@ -275,7 +211,6 @@
 
    :contact-s                             {:one   "contacto"
                                            :other "contactos"}
-   :group-name                            "Nombre del grupo"
    :next                                  "Siguiente"
    :from                                  "De"
    :search-chats                          "Buscar chats"
@@ -291,17 +226,11 @@
    :more                                  "más"
    :cancel                                "Cancelar"
    :no-statuses-found                     "No se encontraron estados"
-   :swow-qr                               "Mostrar QR"
    :browsing-open-in-web-browser          "Abrir en navegador web"
    :delete-group-prompt                   "Esto no afectará a los contactos"
    :edit-profile                          "Editar perfil"
 
 
-   :enter-password-transactions           {:one   "Confirme la transacción ingresando su contraseña"
-                                           :other "Confirme las transacciones ingresando su contraseña"}
-   :unsigned-transactions                 "Transacciones sin firma"
    :empty-topic                           "Tema vacío"
    :to                                    "Para"
-   :group-members                         "Miembros del grupo"
-   :estimated-fee                         "Costo calc."
    :data                                  "Datos"})

--- a/src/status_im/translations/es_mx.cljs
+++ b/src/status_im/translations/es_mx.cljs
@@ -19,11 +19,7 @@
    :photos-access-error                   "Para permitir el acceso a fotos, porfavor, ve a configuración de sistema y asegúrate que la opción 'Status > Fotos' está seleccionada."
 
    ;drawer
-   :invite-friends                        "Invitar amigos"
-   :faq                                   "Preguntas frecuentes"
    :switch-users                          "Cambiar usuarios"
-   :feedback                              "Tienes comentarios?\n¡Agita tu teléfono!"
-   :view-all                              "Ver todo"
    :current-network                       "Red actual"
 
    ;chat
@@ -69,7 +65,6 @@
                                            :other "horas"}
    :datetime-day                          {:one   "día"
                                            :other "días"}
-   :datetime-multiple                     "s"
    :datetime-ago                          "hace"
    :datetime-yesterday                    "ayer"
    :datetime-today                        "hoy"
@@ -77,13 +72,10 @@
    ;profile
    :profile                               "Perfil"
    :edit-profile                          "Editar perfil"
-   :report-user                           "REPORTAR USUARIO"
    :message                               "Mensaje"
-   :username                              "Nombre de usuario"
    :not-specified                         "No especificado"
    :public-key                            "Llave pública"
    :phone-number                          "Número de teléfono"
-   :email                                 "Correo electrónico"
    :update-status                         "Actualizar tu estado..."
    :add-a-status                          "Agregar un estado..."
    :status-prompt                         "Crea un estado para informar a los demás lo que ofreces. También puedes usar #hashtags."
@@ -92,15 +84,11 @@
    :remove-from-contacts                  "Eliminar de contactos"
    :start-conversation                    "Empezar conversación"
    :send-transaction                      "Enviar transacción"
-   :share-qr                              "Compartir QR"
-   :error-incorrect-name                  "Por favor, selecciona otro nombre"
-   :error-incorrect-email                 "Correo electrónico incorrecto"
 
    ;;make_photo
    :image-source-title                    "Imagen de perfil"
    :image-source-make-photo               "Tomar foto"
    :image-source-gallery                  "Seleccionar de la galería"
-   :image-source-cancel                   "Cancelar"
 
    ;;sharing
    :sharing-copy-to-clipboard             "Copiar"
@@ -108,7 +96,6 @@
    :sharing-cancel                        "Cancelar"
 
    :browsing-title                        "Navegar"
-   :browsing-browse                       "@navegar"
    :browsing-open-in-web-browser          "Abrir en navegador"
    :browsing-cancel                       "Cancelar"
 
@@ -117,11 +104,8 @@
    :confirmation-code                     (str "¡Gracias! Te hemos enviado un mensaje de texto con un código de confirmación "
                                                ". Por favor, usa el código para confirmar tu número de teléfono")
    :incorrect-code                        (str "Lo sentimos, el código es incorrecto, escríbelo de nuevo")
-   :generate-passphrase                   (str "Te generaré una frase de contraseña para poder restablecer tu "
-                                               "acceso o inicia sesión desde otro dispositivo")
    :phew-here-is-your-passphrase          "*Uff* eso fue difícil, esta es tu frase de contraseña, *¡escríbela y guárdala en un lugar seguro!* La necesitarás para recuperar tu cuenta."
    :here-is-your-passphrase               "Esta es tu frase de contraseña, *¡escríbela y guárdala en un lugar seguro!* La necesitarás para recuperar tu cuenta."
-   :written-down                          "Cerciórate de haberla escrito de manera segura"
    :phone-number-required                 "Toca aquí para ingresar tu número de teléfono y encontraré a tus amigos"
    :shake-your-phone                      "¿Encontraste un bug o tienes una sugerencia? ¡~Agíta tu teléfono~!"
    :intro-status                          "¡Chatea conmigo para establecer tu cuenta y modificar tu configuración!"
@@ -138,7 +122,6 @@
 
    ;chats
    :chats                                 "Chats"
-   :new-chat                              "Nuevo chat"
    :delete-chat                           "Eliminar chat"
    :new-group-chat                        "Nuevo grupo de chat"
    :new-public-group-chat                 "Unirte a chat público"
@@ -167,9 +150,6 @@
    :remove-from-group                     "Eliminar del grupo"
    :edit-contacts                         "Editar contactos"
    :search-contacts                       "Buscar contactos"
-   :show-all                              "MOSTAR TODOS"
-   :contacts-group-dapps                  "ÐApps"
-   :contacts-group-people                 "Personas"
    :contacts-group-new-chat               "Iniciar chat nuevo"
    :choose-from-contacts                  "Seleccionar de contactos"
    :no-contacts                           "Aún no hay contactos"
@@ -181,52 +161,26 @@
    :remove                                "Remover"
    :save                                  "Guardar"
    :delete                                "Eliminar"
-   :change-color                          "Cambiar color"
    :clear-history                         "Borrar historial"
    :mute-notifications                    "Silenciar notificaciones"
    :leave-chat                            "Abandonar chat"
-   :delete-and-leave                      "Eliminar y salir"
    :chat-settings                         "Ajustes de chat"
    :edit                                  "Editar"
    :add-members                           "Agregar miembros"
-   :blue                                  "Azul"
-   :purple                                "Morado"
-   :green                                 "Verde"
-   :red                                   "Rojo"
 
    ;commands
-   :money-command-description             "Enviar dinero"
-   :location-command-description          "Enviar ubicación"
-   :phone-command-description             "Enviar número de teléfono"
-   :phone-request-text                    "Solicitar número de teléfono"
-   :confirmation-code-command-description "Enviar código de confirmación"
-   :confirmation-code-request-text        "Solicitar código de confirmación"
-   :send-command-description              "Enviar ubicación"
-   :request-command-description           "Enviar solicitud"
-   :keypair-password-command-description  ""
-   :help-command-description              "Ayuda"
-   :request                               "Solicitar"
    :chat-send-eth                         "{{amount}} ETH"
-   :chat-send-eth-to                      "{{amount}} ETH a {{chat-name}}"
-   :chat-send-eth-from                    "{{amount}} ETH de {{chat-name}}"
 
    ;new-group
-   :group-chat-name                       "Nombre del chat"
-   :empty-group-chat-name                 "Por favor ingresa un nombre"
-   :illegal-group-chat-name               "Por favor selecciona otro nombre"
    :new-group                             "Nuevo grupo"
    :reorder-groups                        "Reordenar grupos"
-   :group-name                            "Nombre del grupo"
    :edit-group                            "Editar grupo"
    :delete-group                          "Eliminar grupo"
    :delete-group-confirmation             "Este grupo será eliminado de tus grupos. Esto no afectará tus contactos"
    :delete-group-prompt                   "Esto no afectará tus contactos"
-   :group-members                         "Miembros del grupo"
    :contact-s                             {:one   "contacto"
                                            :other "contactos"}
    ;participants
-   :add-participants                      "Agregar participantes"
-   :remove-participants                   "Eliminar participantes"
 
    ;protocol
    :received-invitation                   "recibió invitación de chat"
@@ -238,13 +192,9 @@
 
    ;new-contact
    :add-new-contact                       "Agregar nuevo contacto"
-   :import-qr                             "Importar"
    :scan-qr                               "Escanear QR"
-   :swow-qr                               "Mostrar QR"
    :name                                  "Nombre"
-   :whisper-identity                      "Identidad whisper"
    :address-explication                   "Tal vez aquí debería haber algún texto explicando qué es una dirección y dónde encontrarla"
-   :enter-valid-address                   "Por favor ingresa una dirección válida o escanea un código QR"
    :enter-valid-public-key                "Por favor ingresa una llave pública o escanea un código QR"
    :contact-already-added                 "El contacto ya ha sido agregado"
    :can-not-add-yourself                  "No puedes agregarte a ti mismo"
@@ -255,23 +205,17 @@
    :connect                               "Conectar"
    :address                               "Dirección"
    :password                              "Contraseña"
-   :login                                 "Iniciar sesión"
    :sign-in-to-status                     "Regístrate a Status"
    :sign-in                               "Regístrate"
    :wrong-password                        "Contraseña incorrecta"
 
    ;recover
-   :recover-from-passphrase               "Recuperar con frase de contraseña"
-   :recover-explain                       "Por favor ingresa la frase de contraseña para recuperar acceso"
    :passphrase                            "Frase de contraseña"
    :recover                               "Recuperar"
-   :enter-valid-passphrase                "Por favor ingresa la frase de contraseña"
-   :enter-valid-password                  "Por favor ingresa una contraseña"
    :twelve-words-in-correct-order         "12 palabras en orden correcto"
 
    ;accounts
    :recover-access                        "Recuperar acceso"
-   :add-account                           "Agregar cuenta"
    :create-new-account                    "Crear nueva cuenta"
 
    ;wallet-qr-code
@@ -281,34 +225,16 @@
    ;validation
    :invalid-phone                         "Número de teléfono incorrecto"
    :amount                                "Cantidad"
-   :not-enough-eth                        (str "No hay suficiente ETH en tu balance"
-                                               "({{balance}} ETH)")
 
    ;transactions
    :confirm                               "Confirmar"
-   :confirm-transactions                  {:one   "Confirmar transacción"
-                                           :other "Confirmar {{count}} transacciones"
-                                           :zero  "Sin transacciones"}
-   :transactions-confirmed                {:one   "Transacción confirmada"
-                                           :other "{{count}} transacciones confirmadas"
-                                           :zero  "Sin transacciones confirmadas"}
    :transaction                           "Transacción"
-   :unsigned-transactions                 "Transacción firmada"
-   :no-unsigned-transactions              "No hay transacciones sin firmar"
-   :enter-password-transactions           {:one   "Confirma la transacción ingresando tu contraseña"
-                                           :other "Confirma las transacciones ingresando tu contraseña"}
    :status                                "Estado"
-   :pending-confirmation                  "Confirmación pendiente"
    :recipient                             "Receptor"
-   :one-more-item                         "Un artículo más"
-   :fee                                   "Comisión"
-   :estimated-fee                         "Comisión estimada"
-   :value                                 "Valor"
    :to                                    "Para"
    :from                                  "De"
    :data                                  "Datos"
    :got-it                                "Entendido"
-   :contract-creation                     "Creación de contrato"
 
    ;:webview
    :web-view-error                        "oops, error"})

--- a/src/status_im/translations/fi.cljs
+++ b/src/status_im/translations/fi.cljs
@@ -19,11 +19,7 @@
    :photos-access-error                   "Myöntääksesi vaadittu kuvien käyttölupa, siirry järjestelmäasetuksiin ja varmista, että Status > Kuvat on valittu."
 
    ;drawer
-   :invite-friends                        "Kutsu ystäviä"
-   :faq                                   "UKK"
    :switch-users                          "Vaihda käyttäjää"
-   :feedback                              "Anna palautetta?\nRavista puhelintasi!"
-   :view-all                              "Näytä kaikki"
    :current-network                       "Nykyinen verkko"
 
    ;chat
@@ -69,7 +65,6 @@
                                            :other "tuntia"}
    :datetime-day                          {:one   "päivä"
                                            :other "päivää"}
-   :datetime-multiple                     "s"
    :datetime-ago                          "sitten"
    :datetime-yesterday                    "eilen"
    :datetime-today                        "tänään"
@@ -77,13 +72,10 @@
    ;profile
    :profile                               "Profiili"
    :edit-profile                          "Muokkaa profiilia"
-   :report-user                           "ILMIANNA KÄYTTÄJÄ"
    :message                               "Viesti"
-   :username                              "Käyttäjätunnus"
    :not-specified                         "Ei määritelty"
    :public-key                            "Julkinen avain"
    :phone-number                          "Puhelinnumero"
-   :email                                 "Sähköposti"
    :update-status                         "Päivitä tila..."
    :add-a-status                          "Lisää tila..."
    :status-prompt                         "Luo tila, jonka avulla ihmiset tietävät mitä asioita tarjoat. Voit myös käyttää #hashtag-merkintöjä."
@@ -92,15 +84,11 @@
    :remove-from-contacts                  "Poista kontakteista"
    :start-conversation                    "Aloita keskustelu"
    :send-transaction                      "Lähetä tapahtuma"
-   :share-qr                              "Jaa QR koodi"
-   :error-incorrect-name                  "Ole hyvä ja valitse toinen nimi"
-   :error-incorrect-email                 "Virheellinen sähköposti"
 
    ;;make_photo
    :image-source-title                    "Profiilikuva"
    :image-source-make-photo               "Kuvakaappaus"
    :image-source-gallery                  "Valitse galleriasta"
-   :image-source-cancel                   "Peruuta"
 
    ;;sharing
    :sharing-copy-to-clipboard             "Kopioi leikepöydälle"
@@ -108,7 +96,6 @@
    :sharing-cancel                        "Peruuta"
 
    :browsing-title                        "Selaa"
-   :browsing-browse                       "@selaa"
    :browsing-open-in-web-browser          "Avaa selaimessa"
    :browsing-cancel                       "Peruuta"
 
@@ -117,11 +104,8 @@
    :confirmation-code                     (str "Kiitos! Olemme lähettäneet sinulle tekstiviestin, jossa on vahvistus "
                                                "koodi. Ole hyvä ja anna koodi vahvistaaksesi puhelinnumerosi")
    :incorrect-code                        (str "Virheellinen koodi, ole hyvä ja yritä uudelleen")
-   :generate-passphrase                   (str "Luon sinulle tunnuslauseen, jotta voit palauttaa sinun "
-                                               "pääsysi tai kirjautua toisesta laitteesta")
    :phew-here-is-your-passphrase          "*Phew* se oli vaikeaa, tässä on tunnuslauseesi, *kirjoita tämä ylös ja pidä tallessa!* Tarvitset sitä palauttaaksesi tilisi."
    :here-is-your-passphrase               "Tässä on tunnuslauseesi, *kirjoita tämä ylös ja pidä tallessa!* Tarvitset sitä palauttaaksesi tilisi."
-   :written-down                          "Varmista, että olet tarkasti kirjoittanut sen talteen"
    :phone-number-required                 "Napauta tähän syöttääksesi puhelinnumerosi niin löydän ystäväsi"
    :shake-your-phone                      "Löysitkö vian tai onko sinulla ehdotus? Ravista puhelintasi!"
    :intro-status                          "Keskustele kanssani määrittääksesi tai muuttaaksesi tilisi asetuksia!"
@@ -138,7 +122,6 @@
 
    ;chats
    :chats                                 "Keskustelut"
-   :new-chat                              "Uusi keskustelu"
    :delete-chat                           "Poista keskustelu"
    :new-group-chat                        "Uusi ryhmäkeskustelu"
    :new-public-group-chat                 "Liity julkiseen keskusteluun"
@@ -168,9 +151,6 @@
    :remove-from-group                     "Poista ryhmästä"
    :edit-contacts                         "Muokkaa yhteystietoja"
    :search-contacts                       "Etsi yhteystietoja"
-   :show-all                              "NÄYTÄ KAIKKI"
-   :contacts-group-dapps                  "ÐApps"
-   :contacts-group-people                 "Ihmiset"
    :contacts-group-new-chat               "Aloita uusi keskustelu"
    :choose-from-contacts                  "Valitse yhteystiedoista"
    :no-contacts                           "No contacts yet"
@@ -182,52 +162,26 @@
    :remove                                "Poista"
    :save                                  "Tallenna"
    :delete                                "Poista"
-   :change-color                          "Muuta väriä"
    :clear-history                         "Tyhjennä historia"
    :mute-notifications                    "Mykistä ilmoitukset"
    :leave-chat                            "Poistu keskustelusta"
-   :delete-and-leave                      "Poista ja poistu"
    :chat-settings                         "Keskustelun asetukset"
    :edit                                  "Muokkaa"
    :add-members                           "Lisää käyttäjiä"
-   :blue                                  "Sininen"
-   :purple                                "Violetti"
-   :green                                 "Vihreä"
-   :red                                   "Punainen"
 
    ;commands
-   :money-command-description             "Lähetä rahaa"
-   :location-command-description          "Lähetä sijainti"
-   :phone-command-description             "Lähetä puhelinnumero"
-   :phone-request-text                    "Puhelinnumero pyyntö"
-   :confirmation-code-command-description "Lähetä vahvistuskoodi"
-   :confirmation-code-request-text        "Vahvistuskoodi pyyntö"
-   :send-command-description              "Lähetä sijainti"
-   :request-command-description           "Lähetä pyyntö"
-   :keypair-password-command-description  ""
-   :help-command-description              "Apua"
-   :request                               "Pyyntö"
    :chat-send-eth                         "{{amount}} ETH"
-   :chat-send-eth-to                      "{{amount}} ETH käyttäjälle {{chat-name}}"
-   :chat-send-eth-from                    "{{amount}} ETH käyttäjältä {{chat-name}}"
 
    ;new-group
-   :group-chat-name                       "Keskustelun nimi"
-   :empty-group-chat-name                 "Ole hyvä ja annan nimi"
-   :illegal-group-chat-name               "Ole hyvä ja valitse toinen nimi"
    :new-group                             "Uusi ryhmä"
    :reorder-groups                        "Järjestele ryhmät uudelleen"
-   :group-name                            "Ryhmän nimi"
    :edit-group                            "Muokkaa ryhmää"
    :delete-group                          "Poista ryhmä"
    :delete-group-confirmation             "Tämä ryhmä poistetaan ryhmistäsi. Tämä ei vaikuta yhteystietoihin"
    :delete-group-prompt                   "Tämä ei vaikuta yhteystietoihin"
-   :group-members                         "Ryhmän jäsenet"
    :contact-s                             {:one   "yhteystieto"
                                            :other "yhteystietoa"}
    ;participants
-   :add-participants                      "Lisää Osallistujia"
-   :remove-participants                   "Poista Osallistujia"
 
    ;protocol
    :received-invitation                   "poista keskustelukutsu"
@@ -239,13 +193,9 @@
 
    ;new-contact
    :add-new-contact                       "Lisää uusi yhteystieto"
-   :import-qr                             "Tuo"
    :scan-qr                               "Skannaa QR"
-   :swow-qr                               "Näytä QR"
    :name                                  "Nimi"
-   :whisper-identity                      "Whisper Identiteetti"
    :address-explication                   "Ehkä tässä pitäisi olla jokin teksti, jossa selitetään, mikä osoite on ja mistä etsiä sitä"
-   :enter-valid-address                   "Anna voimassaoleva osoite tai skannaa QR koodi"
    :enter-valid-public-key                "Anna voimassaoleva julkinen osoite tai skannaa QR koodi"
    :contact-already-added                 "Tämä yhteystieto on jo lisätty"
    :can-not-add-yourself                  "Et voi lisätä itseäsi"
@@ -256,23 +206,17 @@
    :connect                               "Yhdistä"
    :address                               "Osoite"
    :password                              "Salasana"
-   :login                                 "Kirjaudu"
    :sign-in-to-status                     "Luo Status -tili"
    :sign-in                               "Luo tili"
    :wrong-password                        "Väärä salasana"
 
    ;recover
-   :recover-from-passphrase               "Palauta tunnuslauseella"
-   :recover-explain                       "Ole hyvä ja anna tunnuslause salasanan palauttamiseksi"
    :passphrase                            "Tunnuslause"
    :recover                               "Palauta"
-   :enter-valid-passphrase                "Ole hyvä ja syötä tunnuslause"
-   :enter-valid-password                  "Ole hyvä ja anna salasana"
    :twelve-words-in-correct-order         "12 sanaa oikeassa järjestyksessä"
 
    ;accounts
    :recover-access                        "Palauta käyttöoikeus"
-   :add-account                           "Lisää tili"
    :create-new-account                    "Luo uusi tili"
 
    ;wallet-qr-code
@@ -282,33 +226,15 @@
    ;validation
    :invalid-phone                         "Virheellinen puhelinnumero"
    :amount                                "Määrä"
-   :not-enough-eth                        (str "Not enough ETH on balance "
-                                               "({{balance}} ETH)")
    ;transactions
    :confirm                               "Vahvista"
-   :confirm-transactions                  {:one   "Vahvista tapahtuma"
-                                           :other "Vahvista {{count}} tapahtumaa"
-                                           :zero  "Ei tapahtumia"}
-   :transactions-confirmed                {:one   "Tapahtuma vahvistettu"
-                                           :other "{{count}} tapahtumaa vahvistettu"
-                                           :zero  "Ei vahvistettuja tapahtumia"}
    :transaction                           "Tapahtuma"
-   :unsigned-transactions                 "Allekirjoittamattomat tapahtumat"
-   :no-unsigned-transactions              "Ei allekirjoitettuja tapahtumia"
-   :enter-password-transactions           {:one   "Vahvista tapahtuma syöttämällä salasana"
-                                           :other "Vahvista tapahtumat syöttämällä salasana"}
    :status                                "Tila"
-   :pending-confirmation                  "Odottaa vahvistusta"
    :recipient                             "Vastaanottaja"
-   :one-more-item                         "One more item"
-   :fee                                   "Kulu"
-   :estimated-fee                         "Arvioitu kulu"
-   :value                                 "Arvo"
    :to                                    "Vastaanottajalle"
    :from                                  "Lähettäjältä"
    :data                                  "Tieto"
    :got-it                                "Vastaanotettu"
-   :contract-creation                     "Sopimusten Luominen"
 
    ;:webview
    :web-view-error                        "oops, virhe"})

--- a/src/status_im/translations/fr_ch.cljs
+++ b/src/status_im/translations/fr_ch.cljs
@@ -10,8 +10,6 @@
    :offline                               "Hors ligne"
 
    ;drawer
-   :invite-friends                        "Inviter des amis"
-   :faq                                   "FAQ"
    :switch-users                          "Changer d'utilisateur"
 
    ;chat
@@ -53,41 +51,30 @@
                                            :other "heures"}
    :datetime-day                          {:one   "jour"
                                            :other "jours"}
-   :datetime-multiple                     "s"
    :datetime-ago                          "avant"
    :datetime-yesterday                    "hier"
    :datetime-today                        "aujourd'hui"
 
    ;profile
    :profile                               "Profil"
-   :report-user                           "SIGNALER UTILISATEUR"
    :message                               "Message"
-   :username                              "Nom d'utilisateur"
    :not-specified                         "Non spécifié"
    :public-key                            "Clé publique"
    :phone-number                          "Numéro de téléphone"
-   :email                                 "E-mail"
-   :profile-no-status                     "Pas de statut"
    :add-to-contacts                       "Ajouter aux contacts"
-   :error-incorrect-name                  "Veuillez sélectionner un autre nom"
-   :error-incorrect-email                 "E-mail incorrect"
 
    ;;make_photo
    :image-source-title                    "Image du profil"
    :image-source-make-photo               "Capture"
    :image-source-gallery                  "Sélectionner dans la galerie"
-   :image-source-cancel                   "Annuler"
 
    ;sign-up
    :contacts-syncronized                  "Vos contacts ont été synchronisés"
    :confirmation-code                     (str "Merci! Nous vous avons envoyé un message de texte avec un code "
                                                "de confirmation. Veuillez fournir ce code pour confirmer votre numéro de téléphone")
    :incorrect-code                        (str "Désolé, le code est incorrect, veuillez réessayer")
-   :generate-passphrase                   (str "Je vais générer une phrase de passe pour vous afin que vous puissiez "
-                                               "rétablir l'accès ou vous connecter depuis un autre appareil")
    :phew-here-is-your-passphrase          "*Pffff* c'était dur, voici votre phrase de passe, *notez-la et gardez-la en sécurité!* Vous en aurez besoin pour récupérer votre compte."
    :here-is-your-passphrase               "Voici votre phrase de passe, *notez-la et gardez-la en sécurité!* Vous en aurez besoin pour récupérer votre compte."
-   :written-down                          "Assurez-vous de l'avoir notée de manière sûre"
    :phone-number-required                 "Tapez ici pour saisir votre numéro de téléphone et je trouverai vos amis"
    :intro-status                          "Chattez avec moi pour configurer votre compte et changer vos paramètres !"
    :intro-message1                        "Bienvenue dans le statut\nTapez ce message pour établir votre mot de passe et vous lancer !"
@@ -95,7 +82,6 @@
 
    ;chats
    :chats                                 "Chats"
-   :new-chat                              "Nouveau chat"
    :new-group-chat                        "Nouveau chat de groupe"
 
    ;discover
@@ -112,9 +98,6 @@
    ;contacts
    :contacts                              "Contacts"
    :new-contact                           "Nouveau Contact"
-   :show-all                              "MONTRER TOUS"
-   :contacts-group-dapps                  "ÐApps"
-   :contacts-group-people                 "Personnes"
    :contacts-group-new-chat               "Lancer un nouveau chat"
    :no-contacts                           "Pas encore de contacts"
    :show-qr                               "Montrer QR"
@@ -122,41 +105,17 @@
    ;group-settings
    :remove                                "Supprimer"
    :save                                  "Sauvegarder"
-   :change-color                          "Changer la couleur"
    :clear-history                         "Effacer l'historique"
-   :delete-and-leave                      "Supprimer et quitter"
    :chat-settings                         "Paramètres de chat"
    :edit                                  "Modifier"
    :add-members                           "Ajouter des membres"
-   :blue                                  "Bleu"
-   :purple                                "Violet"
-   :green                                 "Vert"
-   :red                                   "Rouge"
 
    ;commands
-   :money-command-description             "Envoyer de l'argent"
-   :location-command-description          "Envoyer un emplacement"
-   :phone-command-description             "Envoyer un numéro de téléphone"
-   :phone-request-text                    "Demande de numéro de téléphone"
-   :confirmation-code-command-description "Envoyer un code de confirmation"
-   :confirmation-code-request-text        "Demande de code de confirmation"
-   :send-command-description              "Envoyer un emplacement"
-   :request-command-description           "Envoyer une demande"
-   :keypair-password-command-description  ""
-   :help-command-description              "Aide"
-   :request                               "Demande"
    :chat-send-eth                         "{{amount}} ETH"
-   :chat-send-eth-to                      "{{amount}} ETH pour {{chat-name}}"
-   :chat-send-eth-from                    "{{amount}} ETH de {{chat-name}}"
 
    ;new-group
-   :group-chat-name                       "Nom du chat"
-   :empty-group-chat-name                 "Veuillez entrer un nom"
-   :illegal-group-chat-name               "Veuillez sélectionner un autre nom"
 
    ;participants
-   :add-participants                      "Ajouter des participants"
-   :remove-participants                   "Supprimer des participants"
 
    ;protocol
    :received-invitation                   "reçu une invitation à un chat"
@@ -168,12 +127,9 @@
 
    ;new-contact
    :add-new-contact                       "Ajouter un nouveau contact"
-   :import-qr                             "Importer"
    :scan-qr                               "Scannner QR"
    :name                                  "Nom"
-   :whisper-identity                      "Murmurer l'identité"
    :address-explication                   "On pourrait mettre ici un texte qui explique ce qu'est une adresse et comment la rechercher"
-   :enter-valid-address                   "Veuillez saisir une adresse valable ou scanner un code QR"
    :contact-already-added                 "Le contact a déjà été ajouté"
    :can-not-add-yourself                  "Vous ne pouvez pas vous ajouter vous-même"
    :unknown-address                       "Adresse inconnue"
@@ -183,20 +139,14 @@
    :connect                               "Se connecter"
    :address                               "Adresse"
    :password                              "Mot de passe"
-   :login                                 "Nom d'utilisateur"
    :wrong-password                        "Mauvais mot de passe"
 
    ;recover
-   :recover-from-passphrase               "Restaurer à partir d'une phrase de passe"
-   :recover-explain                       "Veuillez saisir la phrase de passe pour votre mot de passe afin de récupérer l'accès"
    :passphrase                            "Phrase de passe"
    :recover                               "Restaurer"
-   :enter-valid-passphrase                "Veuillez taper une phrase de passe"
-   :enter-valid-password                  "Veuillez taper un mot de passe"
 
    ;accounts
    :recover-access                        "Récupérer l'accès"
-   :add-account                           "Ajouter un compte"
 
    ;wallet-qr-code
    :done                                  "Terminé"
@@ -205,34 +155,20 @@
    ;validation
    :invalid-phone                         "Numéro de téléphone non valable"
    :amount                                "Montant"
-   :not-enough-eth                        (str "Pas assez d'ETH sur le solde "
-                                               "({{balance}} ETH)")
    ;transactions
-   :confirm-transactions                  {:one   "Confirmer la transaction"
-                                           :other "Confirmer {{count}} transactions"
-                                           :zero  "Pas de transactions"}
    :status                                "Statut"
-   :pending-confirmation                  "Confirmation en attente"
    :recipient                             "Destinataire"
-   :one-more-item                         "Encore un objet"
-   :fee                                   "Tarif"
-   :value                                 "Valeur"
 
    ;:webview
    :web-view-error                        "oups, erreur"
 
    :confirm                               "Confirmer"
    :phone-national                        "National"
-   :transactions-confirmed                {:one   "Transaction confirmée"
-                                           :other "{{count}} transactions confirmées"
-                                           :zero  "Aucune transaction confirmée"}
    :public-group-topic                    "Sujet"
    :debug-enabled                         "Le serveur de débogage a été lancé ! Vous pouvez maintenant ajouter votre Dapp en exécutant *status-dev-cli scan* depuis votre ordinateur"
    :new-public-group-chat                 "Rejoindre le chat public"
    :datetime-ago-format                   "{{number}} {{time-intervals}} {{ago}}"
    :sharing-cancel                        "Annuler"
-   :share-qr                              "Partager le QR"
-   :feedback                              "Des commentaires ?\nSecouez votre natel !"
    :twelve-words-in-correct-order         "12 mots dans le bon ordre"
    :remove-from-contacts                  "Retirer des contacts"
    :delete-chat                           "Supprimer la discussion"
@@ -272,7 +208,6 @@
 
    :contact-s                             {:one   "contact"
                                            :other "contacts"}
-   :group-name                            "Nom du groupe"
    :next                                  "Suivant"
    :from                                  "De"
    :search-chats                          "Rechercher dans les discussions"
@@ -289,17 +224,11 @@
    :more                                  "plus"
    :cancel                                "Annuler"
    :no-statuses-found                     "Aucun statut trouvé"
-   :swow-qr                               "Montrer le QR"
    :browsing-open-in-web-browser          "Ouvrir dans le navigateur"
    :delete-group-prompt                   "Cela n'affectera pas les contacts"
    :edit-profile                          "Modifier le profil"
 
 
-   :enter-password-transactions           {:one   "Confirmez la transaction en entrant votre mot de passe"
-                                           :other "Confirmez les transactions en entrant votre mot de passe"}
-   :unsigned-transactions                 "Transactions non signées"
    :empty-topic                           "Sujet vide"
    :to                                    "À"
-   :group-members                         "Membres du groupe"
-   :estimated-fee                         "Frais estimés"
    :data                                  "Données"})

--- a/src/status_im/translations/fy.cljs
+++ b/src/status_im/translations/fy.cljs
@@ -19,11 +19,7 @@
    :photos-access-error                   "Om ús tastimming te jaan oan dyn foto's, gea nei dyn systeem ynstellings en wêz wis dat Status > Foto's selektearre is."
     
    ;drawer
-   :invite-friends                        "Freonen útnoegje"
-   :faq                                   "FAQ"
    :switch-users                          "Skeakel tusken brûkers "
-   :feedback                              "Hast do feedback?\nSkodzje dyn telefoan!"
-   :view-all                              "Alles besjen"
    :current-network                       "Aktuele netwurk"
 
    ;chat
@@ -69,7 +65,6 @@
                                            :other "oeren"}
    :datetime-day                          {:one   "dei"
                                            :other "dagen"}
-   :datetime-multiple                     "s"
    :datetime-ago                          "lyn"
    :datetime-yesterday                    "juster"
    :datetime-today                        "hjoed"
@@ -77,13 +72,10 @@
    ;profile
    :profile                               "Profyl"
    :edit-profile                          "Profyl oanpasse"
-   :report-user                           "MELD BRÛKER"
    :message                               "Berjocht"
-   :username                              "Brûkersnamme"
    :not-specified                         "Net opjûn"
    :public-key                            "Iepenbiere kaai"
    :phone-number                          "Telefoannûmer"
-   :email                                 "E-mailadres"
    :update-status                         "Fernij dyn status..."
    :add-a-status                          "Foegje in status ta..."
    :status-prompt                         "Foeg in status ta om oare minsken te litte witte wast do oanbiedest, do kinst ek #hashtags gebroeke."
@@ -92,15 +84,11 @@
    :remove-from-contacts                  "Fuortsmite út kontakten"
    :start-conversation                    "Start konversaasje"
    :send-transaction                      "Stjoer transaksje"
-   :share-qr                              "Deel QR"
-   :error-incorrect-name                  "Kies in oare namme"
-   :error-incorrect-email                 "ferkeard e-mailadres"
 
    ;;make_photo
    :image-source-title                    "Profylfoto"
    :image-source-make-photo               "Foto nimme"
    :image-source-gallery                  "Kies út galerij"
-   :image-source-cancel                   "Annulearje"
 
    ;;sharing
    :sharing-copy-to-clipboard             "Nei it klamboerd ta kopiearje"
@@ -108,7 +96,6 @@
    :sharing-cancel                        "Ôfbrekke"
 
    :browsing-title                        "Blêdzje"
-   :browsing-browse                       "@blêdzje"
    :browsing-open-in-web-browser          "Iepenje yn web blêder"
    :browsing-cancel                       "Ôfbrekke"
     
@@ -117,11 +104,8 @@
    :confirmation-code                     (str "Tiige tank! Wy ha dy in sms stjoerd mei in befêstigingskoade"
                                                ". Jou dyn koade op om dyn telefoannûmer te befêstigje")
    :incorrect-code                        (str "Sorry, de koade wie ferkeard, fier hem opnei yn")
-   :generate-passphrase                   (str "Ik sil in wachtsin meitsje, sadatsto dyn"
-                                               "tagong kist kreie of fanôf in oar apparaat kist ynlogge")
    :phew-here-is-your-passphrase          "*Poah* dat wie dreech, hjir is dyn wachtsin, *skriuw dizze op en bewarje him goed!* Do silst him nedich ha om dyn account te herstelle."
    :here-is-your-passphrase               "Dat wie dreech, hjir is dyn wachtsin, *skriuw dizze op en bewarje him goed!* Do silst him nedich ha om dyn account te herstelle."
-   :written-down                          "Soarch derfoar datsto him feilich hast opskreaun"
    :phone-number-required                 "Tik hjir om dyn telefoannûmer yn te fieren, dan sykje ik dyn freonen"
    :shake-your-phone                      "Hast in bug fûn of hast in suggestje? ~Skodzje~ dyn telefoan!"
    :intro-status                          "Chat mei my om dyn account yn te stellen en dyn ynstellingen te wizigjen!"
@@ -138,7 +122,6 @@
     
    ;chats
    :chats                                 "Chats"
-   :new-chat                              "Nije chat"
    :delete-chat                           "Chat fuortsmite"
    :new-group-chat                        "Nije groepchat"
    :new-public-group-chat                 "Doch mei yn iepenbare chat"
@@ -168,9 +151,6 @@
    :remove-from-group                     "Fuortsmite út groep"
    :edit-contacts                         "Bewurkje kontakten"
    :search-contacts                       "Sykje kontakten"
-   :show-all                              "Toan alles"
-   :contacts-group-dapps                  "ÐApps"
-   :contacts-group-people                 "Minsken"
    :contacts-group-new-chat               "Start neie chat"
    :choose-from-contacts                  "Kies út de kontakten"
    :no-contacts                           "Noch gjin kontaktpersoanen"
@@ -182,52 +162,26 @@
    :remove                                "Fuortsmite"
    :save                                  "Opslaan"
    :delete                                "Wiskje"
-   :change-color                          "Wizigje kleur"
    :clear-history                         "Wis skiednis"
    :mute-notifications                    "Mute notifikaasjes"
    :leave-chat                            "Ferlit chat"
-   :delete-and-leave                      "Fuortsmite en ôfslute"
    :chat-settings                         "Chatynstellingen"
    :edit                                  "Bewurkje"
    :add-members                           "Foegje leden ta"
-   :blue                                  "Blau"
-   :purple                                "Pears"
-   :green                                 "Grien"
-   :red                                   "Read"
 
    ;commands
-   :money-command-description             "Stjoer jild"
-   :location-command-description          "Stjoer lokaasje"
-   :phone-command-description             "Stjoer telefoannûmer"
-   :phone-request-text                    "Telefoannûmer oanfraach"
-   :confirmation-code-command-description "Telefoannûmer oanfraach"
-   :confirmation-code-request-text        "Befêstigingskoade oanfraach"
-   :send-command-description              "Stjoer lokaasje"
-   :request-command-description           "Stjoer oanfraach"
-   :keypair-password-command-description  ""
-   :help-command-description              "Help"
-   :request                               "Oanfraach"
    :chat-send-eth                         "{{amount}} ETH"
-   :chat-send-eth-to                      "{{amount}} ETH nei {{chat-name}}"
-   :chat-send-eth-from                    "{{amount}} ETH fan {{chat-name}}"
 
    ;new-group
-   :group-chat-name                       "Chatnamme"
-   :empty-group-chat-name                 "Fear in namme yn"
-   :illegal-group-chat-name               "Kies in oare namme"
    :new-group                             "Nije groep"
    :reorder-groups                        "Reorder groepen"
-   :group-name                            "Groepsnamme"
    :edit-group                            "Bewurkje group"
    :delete-group                          "Wiskje groep"
    :delete-group-confirmation             "Dizze groep sille fuortsmiten wurde fan dyn groepen. Dit sil gjin ynfloed ha mei jo kontakten"
    :delete-group-prompt                   "Dit sil gjin ynfloed ha mei jo kontakten"
-   :group-members                         "Groep leden"
    :contact-s                             {:one   "kontakt"
                                            :other "kontakten"}
    ;participants
-   :add-participants                      "Foegje dielnimmers ta"
-   :remove-participants                   "Ferwiderje dielnimmers"
 
    ;protocol
    :received-invitation                   "Chatútnoeging ûntfange"
@@ -239,13 +193,9 @@
 
    ;new-contact
    :add-new-contact                       "Foegje nij kontaktpersoan ta "
-   :import-qr                             "QR ymportearje"
    :scan-qr                               "QR scanne"
-   :swow-qr                               "Lit QR sjin"
    :name                                  "Namme"
-   :whisper-identity                      "Flúster identiteit"
    :address-explication                   "Maybe here should be some text explaining what an address is and where to look for it"
-   :enter-valid-address                   "Fear in jildich adres yn of scan in QR-koade"
    :enter-valid-public-key                "Fear in jildich adres public kaai yn of scan in QR koade"
    :contact-already-added                 "De kontaktpersoan is ol tafoege"
    :can-not-add-yourself                  "Do kinst dysels net tafoegje"
@@ -256,23 +206,17 @@
    :connect                               "Ferbine"
    :address                               "Adres"
    :password                              "Wachtwurd"
-   :login                                 "Ynlogge"
    :sign-in-to-status                     "Oanmelde by Status"
    :sign-in                               "Ynlogge"
    :wrong-password                        "Ferkeard wachtwurd"
 
    ;recover
-   :recover-from-passphrase               "Herstelle mei wachtsin"
-   :recover-explain                       "Fear dyn wachtsin yn fan dyn account om tagong te herstelle"
    :passphrase                            "Wachtsin"
    :recover                               "Herstelle"
-   :enter-valid-passphrase                "Fear in wachtsin yn"
-   :enter-valid-password                  "Fear in wachtwurd yn"
    :twelve-words-in-correct-order         "12 wurden yn de goeie folchoarder"
 
    ;accounts
    :recover-access                        "Tagong herstelle"
-   :add-account                           "Foegje account ta"
    :create-new-account                    "Nij akkount oanmeitsje"
 
    ;wallet-qr-code
@@ -282,33 +226,15 @@
    ;validation
    :invalid-phone                         "Ûnjildich telefoannûmer"
    :amount                                "Bedrach"
-   :not-enough-eth                        (str "Net genôch ETH op saldo"
-                                               "({{balance}} ETH)")
    ;transactions
    :confirm                               "Befestigje"
-   :confirm-transactions                  {:one   "Befestigje transaksje"
-                                           :other "Befestigje {{count}} transaksjes"
-                                           :zero  "Gjin transaksjes"}
-   :transactions-confirmed                {:one   "Transaksje befêstige"
-                                           :other "{{count}} Transaksjes befêstige"
-                                           :zero "Gjin transaksjes befêstige"}
    :transaction                           "Transaksje"
-   :unsigned-transactions                 "Net-ûndertekene transaksjes"
-   :no-unsigned-transactions              "Gjin unsigned transaksjes"
-   :enter-password-transactions           {:one   "Befêstigje transaksje mei jo wachtwurd"
-                                           :other "Befêstigje transaksjes mei jo wachtwurd"}
    :status                                "Status"
-   :pending-confirmation                  "Yn ôfwachting fan bevestiging"
    :recipient                             "Ûntfanger"
-   :one-more-item                         "Noch in item"
-   :fee                                   "Kosten"
-   :estimated-fee                         "Est. kosten"
-   :value                                 "Wearde"
    :to                                    "Ta"
    :from                                  "Fan"
    :data                                  "Data"
    :got-it                                "Befetsje ik"
-   :contract-creation                     "Kontrakt kreaasje"
 
    ;:webview
    :web-view-error                        "oeps, flater"})

--- a/src/status_im/translations/he.cljs
+++ b/src/status_im/translations/he.cljs
@@ -19,11 +19,7 @@
    :photos-access-error                   ".כדי להעניק את הרשאת התמונות הנדרשת, בבקשה, תלכו להגדרות המערכת ותוודאו שהאופציה שנבחרה היא סטטוס > תמונות"
 
    ;drawer
-   :invite-friends                        "הזמן חברים"
-   :faq                                   "שאלות נפוצות"
    :switch-users                          "שנה משתמש"
-   :feedback                              "Got feedback?\nShake your phone!"
-   :view-all                              "View all"
    :current-network                       "Current network"
 
    ;chat
@@ -69,7 +65,6 @@
                                            :other "שעות"}
    :datetime-day                          {:one   "יום"
                                            :other "ימים"}
-   :datetime-multiple                     "s"
    :datetime-ago                          "לפני"
    :datetime-yesterday                    "אתמול"
    :datetime-today                        "היום"
@@ -77,13 +72,10 @@
     ;profile
    :profile                               "פרופיל"
    :edit-profile                          "ערוך פרופיל"
-   :report-user                           "דווח על המשתמש"
    :message                               "הודעה"
-   :username                              "שם משתמש"
    :not-specified                         "לא מוגדר"
    :public-key                            "מפתח פומבי"
    :phone-number                          "מספר טלפון"
-   :email                                 "אי-מייל"
    :update-status                         "...עדכן סטטוס"
    :add-a-status                          "...הוסף סטטוס"
    :status-prompt                         ".#hashtags צור סטטוס כדי ליידע אחרים בקשר לדברים אותם אתה מציע. אתה יכול גם להשתמש ב"
@@ -93,15 +85,11 @@
    :remove-from-contacts                  "הסר מאנשי קשר"
    :start-conversation                    "התחל שיחה"
    :send-transaction                      "שלח עיסקה"
-   :share-qr                              "שתף ברקוד"
-   :error-incorrect-name                  "אנא בחר שם אחר"
-   :error-incorrect-email                 "כתובת מייל שגויה"
 
    ;;make_photo
    :image-source-title                    "תמונת פרופיל"
    :image-source-make-photo               "צלם"
    :image-source-gallery                  "בחר מהגלריה"
-   :image-source-cancel                   "בטל"
 
    ;;sharing
    :sharing-copy-to-clipboard             "העתק לשולחן העבודה"
@@ -117,10 +105,8 @@
    :confirmation-code                     (str "תודה! שלחנו לך הודעה עם קוד"
                                                "אישור. אנא ספק את הקוד כדי לאשר את מספר הטלפון שלך")
    :incorrect-code                        (str "סליחה הקוד שגוי, אנא נסה שנית")
-   :generate-passphrase                   (str "אנא צור משפט קוד כדי שתוכל לשחזר את הגישה שלך או להתחבר ממכשיר אחר")                                               
    :phew-here-is-your-passphrase          "פוו זה היה קשה, הנה משפט הקוד שלך, *תרשום אותו ותשמור עליו!* אתה תצטרך אותו כדי לשחזר את המשתמש שלך"
    :here-is-your-passphrase               "הנה משפט הקוד שלך, *תרשום אותו ותשמור עליו!* אתה תצטרך אותו כדי לשחזר את המשתמש שלך."
-   :written-down                          "אנא וודא ששמרת אותו בצורה מאובטחת"
    :phone-number-required                 "הקש כאן כדי להזין את מספר הטלפון שלך ואני אמצא את החברים שלך"
    :shake-your-phone                      "!מצאת באג או שיש לך הצעה? פשוט טלטל את הפלאפון"
    :intro-status                          "דבר איתי כדי להסדיר את המשתמש שלך ולשנות את ההגדרות"
@@ -137,7 +123,6 @@
 
    ;chats
    :chats                                 "צ'אטים"
-   :new-chat                              "צ'אט חדש"
    :delete-chat                           "מחק צ'אט"
    :new-group-chat                        "צ'אט קבוצתי חדש"
    :new-public-group-chat                 "הצטרף לצ'אט פומבי"
@@ -167,9 +152,6 @@
    :remove-from-group                     "הסר מהקבוצה"
    :edit-contacts                         "ערוך אנשי קשר"
    :search-contacts                       "חפש באנשי הקשר"
-   :show-all                              "הראה את כולם"
-   :contacts-group-dapps                  "אפליקציות מבוזרות"
-   :contacts-group-people                 "אנשים"
    :contacts-group-new-chat               "התחל צ'אט חדש"
    :choose-from-contacts                  "בחר מאנשי הקשר"
    :no-contacts                           "אין שום אנשי קשר"
@@ -181,52 +163,26 @@
    :remove                                "הסר"
    :save                                  "שמור"
    :delete                                "מחק"
-   :change-color                          "שנה צבע"
    :clear-history                         "נקה היסטוריה"
    :mute-notifications                    "השתק התראות"
    :leave-chat                            "צא מהצ'אט"
-   :delete-and-leave                      "מחק וצא"
    :chat-settings                         "הגדרות צ'אט"
    :edit                                  "ערוך"
    :add-members                           "הוסף מספרים"
-   :blue                                  "כחול"
-   :purple                                "סגול"
-   :green                                 "ירוק"
-   :red                                   "אדום"
 
    ;commands
-   :money-command-description             "שלח כסף"
-   :location-command-description          "שלח מיקום"
-   :phone-command-description             "שלח מספר טלפון"
-   :phone-request-text                    "בקשת מספר טלפון"
-   :confirmation-code-command-description "שלח קוד אישור"
-   :confirmation-code-request-text        "בקשת קוד אישור"
-   :send-command-description              "שלח מיקום"
-   :request-command-description           "שלח בקשה"
-   :keypair-password-command-description  ""
-   :help-command-description              "עזרה"
-   :request                               "בקשה"
    :chat-send-eth                         "{{amount}} אתר"
-   :chat-send-eth-to                      "{{amount}} אתר ל {{chat-name}}"
-   :chat-send-eth-from                    "{{amount}} מאתר {{chat-name}}"
 
    ;new-group
-   :group-chat-name                       "שם הצ'אט"
-   :empty-group-chat-name                 "אנא הזן שם"
-   :illegal-group-chat-name               "אנא בחר שם שונה"
    :new-group                             "קבוצה חדשה"
    :reorder-groups                        "סדר מחדש את הקבוצה"
-   :group-name                            "שם הקבוצה"
    :edit-group                            "ערוך את הקבוצה"
    :delete-group                          "מחר את הקבוצה"
    :delete-group-confirmation             "הקבוצה הזאת תמחק מרשימת הקבוצות. פעולה זאת לא תשפיע על אנשי הקשר"
    :delete-group-prompt                   "זה לא ישפיע על אנשי הקשר"
-   :group-members                         "חברי הקבוצה"
    :contact-s                             {:one   "איש קשר"
                                            :other "אנשי קשר"}
    ;participants
-   :add-participants                      "הוסף משתתפים"
-   :remove-participants                   "הסר משתתפים"
 
    ;protocol
    :received-invitation                   "התקבלה הזמנה לצ'אט"
@@ -238,13 +194,9 @@
 
    ;new-contact
    :add-new-contact                       "הוסף איש קשר חדש"
-   :import-qr                             "לייבא"
    :scan-qr                               "סרוק ברקוד"
-   :swow-qr                               "הראה ברקוד"
    :name                                  "שם"
-   :whisper-identity                      "לחש זהות"
    :address-explication                   "Maybe here should be some text explaining what an address is and where to look for it"
-   :enter-valid-address                   "אנא הזן כתובת תקפה או סרוק ברקוד"
    :enter-valid-public-key                "אנא הזן קוד פומבי תקף או סרוק ברקוד"
    :contact-already-added                 "איש הקשר כבר קיים"
    :can-not-add-yourself                  "אתה לא יכול להוסיף את עצמך"
@@ -255,23 +207,17 @@
    :connect                               "התחבר"
    :address                               "כתובת"
    :password                              "סיסמא"
-   :login                                 "כניסה תלמערכת"
    :sign-in-to-status                     "התחבר לסטטוס"
    :sign-in                               "התחבר"
    :wrong-password                        "סיסמא שגויה"
 
    ;recover
-   :recover-from-passphrase               "שחזר סיסמא ממשפט קוד"
-   :recover-explain                       "אנא הזן את משפט הקוד של הסיסמא שלך כדי לשחזר גישה"
    :passphrase                            "משפט קוד"
    :recover                               "שחזר"
-   :enter-valid-passphrase                "אנא הקש משפט קוד"
-   :enter-valid-password                  "אנא הקש סיסמא"
    :twelve-words-in-correct-order         "12 מילים בסדר הנכון"
 
    ;accounts
    :recover-access                        "שחזר גישה"
-   :add-account                           "הוסף איש קשר"
    :create-new-account                    "יצר איש קשר חדש"
 
    ;wallet-qr-code
@@ -281,33 +227,15 @@
    ;validation
    :invalid-phone                         "מספר טלפון שגוי"
    :amount                                "כמות"
-   :not-enough-eth                        (str "לא מספיק אתר בחשבון "
-                                               "({{balance}} אתר)")
    ;transactions
    :confirm                               "אשר"
-   :confirm-transactions                  {:one   "אשר העברה"
-                                           :other "אשר {{count}} העברות"
-                                           :zero  "אין העברות"}
-   :transactions-confirmed                {:one   "העברה אושרה"
-                                           :other "{{count}} העברות אושרו"
-                                           :zero  "אין העברות שהושלמו"}
    :transaction                           "העברות"
-   :unsigned-transactions                 "העברות ללא חתימה"
-   :no-unsigned-transactions              "אין העברות ללא חתימה"
-   :enter-password-transactions           {:one   "אשר העברה אל ידי הקשת סיסמתך"
-                                           :other "אשר העברות על ידי הקשת סיסמתך"}
    :status                                "סטטוס"
-   :pending-confirmation                  "ממתיך לאישור העברה"
    :recipient                             "מקבל"
-   :one-more-item                         "עוד פריט אחד"
-   :fee                                   "עמלה"
-   :estimated-fee                         "עמלה מעורכת"
-   :value                                 "שווי"
    :to                                    "ל"
    :from                                  "מ"
    :data                                  "נתונים"
    :got-it                                "קיבלתי"
-   :contract-creation                     "יצירת חוזה"
 
    ;:webview
    :web-view-error                        "אופס,טעות"})

--- a/src/status_im/translations/hi.cljs
+++ b/src/status_im/translations/hi.cljs
@@ -10,8 +10,6 @@
    :offline                               "ऑफ़लाइन"
 
    ;drawer
-   :invite-friends                        "दोस्तों को आमंत्रित करें"
-   :faq                                   "अक्सर पूछे जाने वाले प्रश्न"
    :switch-users                          "उपयोगकर्ताओं को स्विच करें"
 
    ;chat
@@ -53,41 +51,30 @@
                                            :other "घंटे"}
    :datetime-day                          {:one   "दिन"
                                            :other "दिन"}
-   :datetime-multiple                     "एस"
    :datetime-ago                          "पहले"
    :datetime-yesterday                    "बीता हुआ कल"
    :datetime-today                        "आज"
 
    ;profile
    :profile                               "प्रोफाइल"
-   :report-user                           "उपयोगकर्ता को रिपोर्ट करें"
    :message                               "संदेश"
-   :username                              "उपयोगकर्ता नाम"
    :not-specified                         "निर्दिष्ट नहीं"
    :public-key                            "सार्वजनिक कुंजी"
    :phone-number                          "फ़ोन नंबर"
-   :email                                 "ईमेल"
-   :profile-no-status                     "कोई स्थिति नहीं"
    :add-to-contacts                       "संपर्क में जोड़ें"
-   :error-incorrect-name                  "कृपया दूसरा नाम चयन करें"
-   :error-incorrect-email                 "गलत ई-मेल"
 
    ;;make_photo
    :image-source-title                    "प्रोफ़ाइल छवि"
    :image-source-make-photo               "प्राप्त करें"
    :image-source-gallery                  "गैलरी से चयन करें"
-   :image-source-cancel                   "रद्द करें"
 
    ;sign-up
    :contacts-syncronized                  "आपके संपर्कों को सिंक्रनाइज़ किया गया है"
    :confirmation-code                     (str "धन्यवाद! हमने आपको \"पुष्टि कोड\" के साथ एक टेक्स्ट संदेश भेजा है "
                                                "कृपया अपने फोन नंबर की पुष्टि करने के लिए वह कोड डालें।")
    :incorrect-code                        (str "क्षमा करें, कोड गलत था, कृपया फिर से डालें")
-   :generate-passphrase                   (str "मैं आपके लिए एक पासफ्रेज जनरेट करूंगा ताकि आप अपना पासफ्रेज बहाल कर सकें "
-                                               "अन्य डिवाइस से उपयोग या लॉगिन करें")
    :phew-here-is-your-passphrase          "*उफ़्फ़* यह बहुत मुश्किल था, यह रहा आपका पासफ्रेज, *इसे लिख लें और सुरक्षित रखें! * अपने खाते को ठीक करने के लिए आपको इसकी आवश्यकता होगी।"
    :here-is-your-passphrase               "यह रहा आपका पासफ्रेज, *इसे लिख लें और सुरक्षित रखें! * अपने खाते को ठीक करने के लिए आपको इसकी आवश्यकता होगी।"
-   :written-down                          "पक्का करें कि आपने इसे सुरक्षित रूप से लिख लिया था"
    :phone-number-required                 "अपना फोन नंबर दर्ज करने के लिए यहां टैप करें और मैं आपके दोस्तों को ढूंढ निकालूंगा"
    :intro-status                          "अपना खाता सेट करने और अपनी सेटिंग्स बदलने के लिए मेरे साथ चैट करें!"
    :intro-message1                        "स्टेटस में आपका स्वागत है\n अपना पासवर्ड सेट करने और शुरुआत करने के लिए इस संदेश पर करें!"
@@ -95,7 +82,6 @@
 
    ;chats
    :chats                                 "चैट"
-   :new-chat                              "नई चैट"
    :new-group-chat                        "नई ग्रुप चैट"
 
    ;discover
@@ -112,9 +98,6 @@
    ;contacts
    :contacts                              "संपर्क"
    :new-contact                           "नया संपर्क"
-   :show-all                              "सभी दिखाएं"
-   :contacts-group-dapps                  "ÐApps"
-   :contacts-group-people                 "लोग"
    :contacts-group-new-chat               "नई चैट शुरू करें"
    :no-contacts                           "अभी तक कोई संपर्क नहीं"
    :show-qr                               "QR दिखाएं"
@@ -122,41 +105,17 @@
    ;group-settings
    :remove                                "निकालें"
    :save                                  "सहेजें"
-   :change-color                          "रंग बदलें"
    :clear-history                         "इतिहास साफ़ करें"
-   :delete-and-leave                      "हटाएं और छोड़ें"
    :chat-settings                         "चैट सेटिंग्स"
    :edit                                  "संपादित करें"
    :add-members                           "सदस्य जोड़ें"
-   :blue                                  "नीला"
-   :purple                                "बैंगनी"
-   :green                                 "हरा"
-   :red                                   "लाल"
 
    ;commands
-   :money-command-description             "पैसे भेजें"
-   :location-command-description          "स्थान भेजें"
-   :phone-command-description             "फोन नंबर भेजें"
-   :phone-request-text                    "फ़ोन नंबर अनुरोध"
-   :confirmation-code-command-description "पुष्टि कोड भेजें"
-   :confirmation-code-request-text        "पुष्टि कोड अनुरोध"
-   :send-command-description              "स्थान भेजें"
-   :request-command-description           "अनुरोध भेजें"
-   :keypair-password-command-description  ""
-   :help-command-description              "मदद करें"
-   :request                               "अनुरोध करें"
    :chat-send-eth                         "{{amount}} ETH"
-   :chat-send-eth-to                      "{{amount}} {{chat-name}} को ETH"
-   :chat-send-eth-from                    "{{amount}} {{chat-name}} से ETH"
 
    ;new-group
-   :group-chat-name                       "चैट नाम"
-   :empty-group-chat-name                 "कोई नाम दर्ज करें"
-   :illegal-group-chat-name               "कृपया दूसरा नाम चयन करें"
 
    ;participants
-   :add-participants                      "प्रतिभागियों को जोड़ें"
-   :remove-participants                   "प्रतिभागियों को निकालें"
 
    ;protocol
    :received-invitation                   "चैट आमंत्रण प्राप्त हुआ"
@@ -168,12 +127,9 @@
 
    ;new-contact
    :add-new-contact                       "नया संपर्क जोड़ें"
-   :import-qr                             "आयात करें"
    :scan-qr                               "QR स्कैन करें"
    :name                                  "नाम"
-   :whisper-identity                      "पहचान बताएं"
    :address-explication                   "संभवतः यहाँ कुछ टेक्स्ट विवरण होना चाहिए कि पता क्या है और इसे कहाँ खोजा जाए"
-   :enter-valid-address                   "कृपया एक वैध पता दर्ज करें या एक QR कोड स्कैन करें"
    :contact-already-added                 "संपर्क पहले से जोड़ लिया गया है"
    :can-not-add-yourself                  "आप अपने आपको नहीं जोड़ सकते"
    :unknown-address                       "अज्ञात पता"
@@ -183,20 +139,14 @@
    :connect                               "कनेक्ट करें"
    :address                               "पता"
    :password                              "पासवर्ड"
-   :login                                 "लॉगिन करें"
    :wrong-password                        "गलत पासवर्ड"
 
    ;recover
-   :recover-from-passphrase               "पासफ्रेज से ठीक करें"
-   :recover-explain                       "पहुंच को ठीक करने के लिए कृपया अपने पासवर्ड का पासफ्रेज दर्ज करें"
    :passphrase                            "पासफ्रेज"
    :recover                               "ठीक करें"
-   :enter-valid-passphrase                "कृपया एक पासफ्रेज दर्ज करें"
-   :enter-valid-password                  "कृपया पासवर्ड दर्ज करें"
 
    ;accounts
    :recover-access                        "पहुंच को ठीक करें"
-   :add-account                           "खाता जोड़ें"
 
    ;wallet-qr-code
    :done                                  "पूरा हो गया"
@@ -205,34 +155,20 @@
    ;validation
    :invalid-phone                         "अमान्य फोन नंबर"
    :amount                                "राशि"
-   :not-enough-eth                        (str "बैलेंस पर पर्याप्त ETH नहीं "
-                                               "({{balance}} ETH)")
    ;transactions
-   :confirm-transactions                  {:one   "लेनदेन की पुष्टि करें"
-                                           :other "{{count}} लेनदेनों की पुष्टि करें"
-                                           :zero  "कोई लेनदेन नहीं"}
    :status                                "स्टेटस"
-   :pending-confirmation                  "लंबित पुष्टि"
    :recipient                             "प्राप्तकर्ता"
-   :one-more-item                         "एक अन्य आइटम"
-   :fee                                   "शुल्क"
-   :value                                 "मूल्य"
 
    ;:webview
    :web-view-error                        "ओह, त्रुटि"
 
    :confirm                               "पुष्टि करें"
    :phone-national                        "राष्ट्रीय"
-   :transactions-confirmed                {:one   "लेनदेन की पुष्टि की गई"
-                                           :other "{{count}} लेनदेनों की पुष्टि की गई"
-                                           :zero  "किसी भी लेनदेन की पुष्टि नहीं हुई"}
    :public-group-topic                    "विषय"
    :debug-enabled                         "डीबग सर्वर लाँच कर दिया गया है! है। अब आप अपने कम्प्यूटर से *status-dev-cli scan* चलाकर अपने DApp को शामिल कर सकते हैं"
    :new-public-group-chat                 "सार्वजनिक चैट में शामिल हों"
    :datetime-ago-format                   "{{number}} {{time-intervals}} {{ago}}"
    :sharing-cancel                        "रद्द करें"
-   :share-qr                              "QR साझा करें"
-   :feedback                              "फीडबैक देना चाहते हैं?\nअपने फोन को हिलाएं!"
    :twelve-words-in-correct-order         "सही क्रम में 12 शब्द"
    :remove-from-contacts                  "संपर्कों से हटाएं"
    :delete-chat                           "चैट मिटाएं"
@@ -272,7 +208,6 @@
 
    :contact-s                             {:one   "संपर्क"
                                            :other "संपर्क"}
-   :group-name                            "समूह का नाम"
    :next                                  "अगला"
    :from                                  "द्वारा"
    :search-chats                          "चैट्स खोजें"
@@ -289,17 +224,11 @@
    :more                                  "अधिक"
    :cancel                                "रद्द करें"
    :no-statuses-found                     "कोई स्टैटस नहीं मिले"
-   :swow-qr                               "QR दिखाएं"
    :browsing-open-in-web-browser          "वेब ब्राउज़र में खोलें"
    :delete-group-prompt                   "इससे संपर्क प्रभावित नहीं होंगे"
    :edit-profile                          "प्रोफाइल का संपादन करें"
 
 
-   :enter-password-transactions           {:one   "अपना पासवर्ड प्रविष्ट करके लेनदेन की पुष्टि करें"
-                                           :other "अपना पासवर्ड प्रविष्ट करके लेनदेनों की पुष्टि करें"}
-   :unsigned-transactions                 "साइन न किए गए लेनदेन"
    :empty-topic                           "रिक्त विषय"
    :to                                    "प्रति"
-   :group-members                         "समूह के सदस्य"
-   :estimated-fee                         "संस्थान शुल्क"
    :data                                  "डेटा"})

--- a/src/status_im/translations/hu.cljs
+++ b/src/status_im/translations/hu.cljs
@@ -10,8 +10,6 @@
    :offline                               "Offline"
 
    ;drawer
-   :invite-friends                        "Barátok meghívása"
-   :faq                                   "GYIK"
    :switch-users                          "Felhasználók váltása"
 
    ;chat
@@ -53,41 +51,30 @@
                                            :other "óra"}
    :datetime-day                          {:one   "nap"
                                            :other "nap"}
-   :datetime-multiple                     "k"
    :datetime-ago                          "ezelőtt"
    :datetime-yesterday                    "tegnap"
    :datetime-today                        "ma"
 
    ;profile
    :profile                               "Profil"
-   :report-user                           "FELHASZNÁLÓ JELENTÉSE"
    :message                               "Üzenet"
-   :username                              "Felhasználónév"
    :not-specified                         "Nincs megadva"
    :public-key                            "Nyilvános kulcs"
    :phone-number                          "Telefonszám"
-   :email                                 "E-mail"
-   :profile-no-status                     "Nincs állapot"
    :add-to-contacts                       "Hozzáadás a kapcsolatokhoz"
-   :error-incorrect-name                  "Kérjük, válassz ki másik nevet"
-   :error-incorrect-email                 "Hibás e-mail"
 
    ;;make_photo
    :image-source-title                    "Profilkép"
    :image-source-make-photo               "Rögzítés"
    :image-source-gallery                  "Kiválasztás a galériából"
-   :image-source-cancel                   "Mégsem"
 
    ;sign-up
    :contacts-syncronized                  "Kapcsolataid szinkronizálásra kerültek"
    :confirmation-code                     (str "Köszönjük! Küldtünk neked egy szöveges üzenetet megerősítési "
                                                "kóddal. Kérjük, add meg a kódot telefonszámod megerősítése érdekében")
    :incorrect-code                        (str "Sajnáljuk, hibás kód, kérjük, add meg újból")
-   :generate-passphrase                   (str "Generálok neked egy jelmondatot hozzáférésed helyreállításához "
-                                               "vagy egy másik eszközről történő bejelentkezéshez")
    :phew-here-is-your-passphrase          "*Hűha* ez nehéz volt, de kész a jelmondatod, *írd fel valahova és vigyázz rá!* Szükséged lesz hozzá felhasználói fiókod helyreállításához."
    :here-is-your-passphrase               "Kész a jelmondatod, *írd fel valahová és őrizd meg!* Szükséged lesz hozzá felhasználói fiókod helyreállításához."
-   :written-down                          "Bizonyosodj meg arról, hogy biztonságos helyen tárolod"
    :phone-number-required                 "Érints ide telefonszámod megadásához és megtalálom a barátaidat"
    :intro-status                          "Csevegj velem felhasználói fiókod létrehozásáról és beállításaid megváltoztatásáról!"
    :intro-message1                        "Üdv az Állapotnál\nÉrints erre a üzenetre, állítsd be a jelszavad és fogj hozzá!"
@@ -95,7 +82,6 @@
 
    ;chats
    :chats                                 "Csevegések"
-   :new-chat                              "Új csevegés"
    :new-group-chat                        "Új csoportos csevegés"
 
    ;discover
@@ -112,9 +98,6 @@
    ;contacts
    :contacts                              "Kapcsolatok"
    :new-contact                           "Új kapcsolat"
-   :show-all                              "ÖSSZES MUTATÁSA"
-   :contacts-group-dapps                  "ÐApps"
-   :contacts-group-people                 "Emberek"
    :contacts-group-new-chat               "Új csevegés indítása"
    :no-contacts                           "Még nincsenek kapcsolatok"
    :show-qr                               "QR mutatása"
@@ -122,41 +105,17 @@
    ;group-settings
    :remove                                "Eltávolítás"
    :save                                  "Mentés"
-   :change-color                          "Szín megváltoztatása"
    :clear-history                         "Előzmények törlése"
-   :delete-and-leave                      "Törlés és kilépés"
    :chat-settings                         "Csevegés beállítások"
    :edit                                  "Szerkesztés"
    :add-members                           "Tagok hozzáadása"
-   :blue                                  "Kék"
-   :purple                                "Lila"
-   :green                                 "Zöld"
-   :red                                   "Piros"
 
    ;commands
-   :money-command-description             "Pénz küldése"
-   :location-command-description          "Halyszín küldése"
-   :phone-command-description             "Telefonszám küldése"
-   :phone-request-text                    "Telefonszám irénylése"
-   :confirmation-code-command-description "Megerősítési kód küldése"
-   :confirmation-code-request-text        "Megerősítési kód igénylése"
-   :send-command-description              "Helyszín küldése"
-   :request-command-description           "Küldési igény"
-   :keypair-password-command-description  ""
-   :help-command-description              "Segítség"
-   :request                               "Kérés"
    :chat-send-eth                         "{{amount}} ETH"
-   :chat-send-eth-to                      "{{amount}} ETH ide {{chat-name}}"
-   :chat-send-eth-from                    "{{amount}} ETH innen {{chat-name}}"
 
    ;new-group
-   :group-chat-name                       "Csevegés neve"
-   :empty-group-chat-name                 "Kérjük, add meg egy új nevet"
-   :illegal-group-chat-name               "Kérjük, válassz egy új nevet"
 
    ;participants
-   :add-participants                      "Résztvevők hozzáadása"
-   :remove-participants                   "Résztvevők eltávolítása"
 
    ;protocol
    :received-invitation                   "csevegési meghívásban részesült"
@@ -168,12 +127,9 @@
 
    ;new-contact
    :add-new-contact                       "Új kapcsolat hozzáadása"
-   :import-qr                             "Importálás"
    :scan-qr                               "QR beolvasása"
    :name                                  "Név"
-   :whisper-identity                      "Whisper személyazonosság"
    :address-explication                   "Itt talán szükség lenne egy kis szövegre, ami elmagyarázná, mi is az a cím és hol lehet megtalálni"
-   :enter-valid-address                   "Kérjük, adj meg egy helyes címet vagy olvass be egy QR kódot"
    :contact-already-added                 "A kapcsolat már hozzáadásra került"
    :can-not-add-yourself                  "Magadat nem adhatod hozzá"
    :unknown-address                       "Ismeretlen cím"
@@ -183,20 +139,14 @@
    :connect                               "Kapcsolódás"
    :address                               "Cím"
    :password                              "Jelszó"
-   :login                                 "Bejelentkezés"
    :wrong-password                        "Hibás jelszó"
 
    ;recover
-   :recover-from-passphrase               "Visszaállítás jelmondatból"
-   :recover-explain                       "Kérjük, adj meg egy jelmondatot a jelszavaddal történő hozzáférés helyreállításához"
    :passphrase                            "Jelmondat"
    :recover                               "Visszaállítás"
-   :enter-valid-passphrase                "Kérjük, adj meg egy jelmondatote"
-   :enter-valid-password                  "Kérjük, adj meg egy jelszót"
 
    ;accounts
    :recover-access                        "Hozzáférés helyreállítása"
-   :add-account                           "Felhasználói fiók hozzáadása"
 
    ;wallet-qr-code
    :done                                  "Kész"
@@ -205,34 +155,20 @@
    ;validation
    :invalid-phone                         "Hibás telefonszám"
    :amount                                "Összeg"
-   :not-enough-eth                        (str "Nincs elég ETH a számlán "
-                                               "({{balance}} ETH)")
    ;transactions
-   :confirm-transactions                  {:one   "Tranzakció megerősítése"
-                                           :other "{{count}} tranzakció megerősítése"
-                                           :zero  "Nincsenek tranzakciók"}
    :status                                "Állapot"
-   :pending-confirmation                  "Függőben lévő megerősítés"
    :recipient                             "Címzett"
-   :one-more-item                         "Még egy tétel"
-   :fee                                   "Díj"
-   :value                                 "Érték"
 
    ;:webview
    :web-view-error                        "hoppá, hiba"
 
    :confirm                               "Megerősít"
    :phone-national                        "Nemzeti"
-   :transactions-confirmed                {:one   "Tranzakció megerősítve"
-                                           :other "{{count}} tranzakció megerősítve"
-                                           :zero  "Nincs megerősített tranzakció"}
    :public-group-topic                    "Téma"
    :debug-enabled                         "A hibakereső szerver elindításra került! Mostantól hozzáadhatod a DAppod, ha futtatod a számítógépeden a következőt: *status-dev-cli scan*"
    :new-public-group-chat                 "Csatlakozás nyilvános csevegéshez"
    :datetime-ago-format                   "{{number}} {{time-intervals}} {{ago}}"
    :sharing-cancel                        "Mégse"
-   :share-qr                              "QR megosztása"
-   :feedback                              "Visszajelzésed van?\nRázd meg a telefonod!"
    :twelve-words-in-correct-order         "12 szó helyes sorrendben"
    :remove-from-contacts                  "Eltávolítás a névjegyekből"
    :delete-chat                           "Csevegés törlése"
@@ -272,7 +208,6 @@
 
    :contact-s                             {:one   "névjegy"
                                            :other "névjegyek"}
-   :group-name                            "Csoportnév"
    :next                                  "Következő"
    :from                                  "Feladó"
    :search-chats                          "Csevegések keresése"
@@ -289,17 +224,11 @@
    :more                                  "több"
    :cancel                                "Mégse"
    :no-statuses-found                     "Nem található állapot"
-   :swow-qr                               "QR megjelenítése"
    :browsing-open-in-web-browser          "Megnyitás új böngészőben"
    :delete-group-prompt                   "Nem lesz hatással a névjegyekre"
    :edit-profile                          "Profil szerkesztése"
 
 
-   :enter-password-transactions           {:one   "Erősítsd meg a tranzakciót a jelszavad megadásával"
-                                           :other "Erősítsd meg a tranzakciókat a jelszavad megadásával"}
-   :unsigned-transactions                 "Aláíratlan tranzakciók"
    :empty-topic                           "Üres téma"
    :to                                    "Címzett"
-   :group-members                         "Csoporttagok"
-   :estimated-fee                         "Becs. díj"
    :data                                  "Adatok"})

--- a/src/status_im/translations/id.cljs
+++ b/src/status_im/translations/id.cljs
@@ -10,8 +10,6 @@
    :offline                               "offline"
 
    ;drawer
-   :invite-friends                        "undang teman"
-   :faq                                   "faq"
    :switch-users                          "beralih pengguna"
 
    ;chat
@@ -53,41 +51,30 @@
                                            :other "jam"}
    :datetime-day                          {:one   "hari"
                                            :other "hari"}
-   :datetime-multiple                     "detik"
    :datetime-ago                          "dari"
    :datetime-yesterday                    "kemarin"
    :datetime-today                        "hari ini"
 
    ;profile
    :profile                               "profil"
-   :report-user                           "laporkan penguna"
    :message                               "pesan"
-   :username                              "nama pengguna"
    :not-specified                         "tidak ditentukan"
    :public-key                            "public key"
    :phone-number                          "nomor telepon"
-   :email                                 "email"
-   :profile-no-status                     "tidak ada informasi status"
    :add-to-contacts                       "tambahkan ke Kontak"
-   :error-incorrect-name                  "nama tidak valid"
-   :error-incorrect-email                 "email tidak valid"
 
    ;;make_photo
    :image-source-title                    "foto profil"
    :image-source-make-photo               "capture"
    :image-source-gallery                  "pilih dari Galeri"
-   :image-source-cancel                   "batalkan"
 
    ;sign-up
    :contacts-syncronized                  "kontak telah disinkronkan"
    :confirmation-code                     (str "terima kasih! Kami telah mengirim pesan teks untuk mengkonfirmasi akun anda "
                                                "kode. untuk mengkonfirmasi nomor telepon Anda, masukkan kode ini")
    :incorrect-code                        (str "maaf, kode yang anda masukan salah. Silakan coba lagi")
-   :generate-passphrase                   (str "generate passphrase "
-                                               "agar Anda dapat memulihkan akses atau login pada perangkat lain")
    :phew-here-is-your-passphrase          "* wah * hal yang rumit, inilah passphrase anda, * simpan dan jaga baik - baik! * anda akan membutuhkannya untuk mengembalikan akun Anda."
    :here-is-your-passphrase               "berikut adalah passphrase anda. * jaga agar tetap aman dan menyimpannya! * bila anda perlu untuk memulihkan akun Anda."
-   :written-down                          "pastikan Anda telah menulisnya dengan aman"
    :phone-number-required                 "ketuk di sini untuk memasukkan nomor telepon Anda, anda akan menemukan teman-teman anda"
    :intro-status                          "berbicara dengan saya untuk mengatur akun Anda dan mengubah pengaturan Anda!"
    :intro-message1                        "selamat datang di Status \n klik pesan ini untuk mengatur sandi Anda & memulai!"
@@ -95,7 +82,6 @@
 
    ;chats
    :chats                                 "obrolan"
-   :new-chat                              "obrolan baru"
    :new-group-chat                        "obrolan grup baru"
 
    ;discover
@@ -112,9 +98,6 @@
    ;contacts
    :contacts                              "kontak"
    :new-contact                           "kontak baru"
-   :show-all                              "tampilkan semua"
-   :contacts-group-dapps                  "ÐApps"
-   :contacts-group-people                 "pengguna"
    :contacts-group-new-chat               "untuk memulai obrolan baru"
    :no-contacts                           "tidak ada kontak"
    :show-qr                               "show QR kode"
@@ -122,41 +105,17 @@
    ;group-settings
    :remove                                "menghapus"
    :save                                  "menyimpan"
-   :change-color                          "ubah warna"
    :clear-history                         "bersihkan riwayat"
-   :delete-and-leave                      "hapus dan tinggalkan"
    :chat-settings                         "pengaturan obrolan"
    :edit                                  "edit"
    :add-members                           "tambah anggota"
-   :blue                                  "biru"
-   :purple                                "ungu"
-   :green                                 "hijau"
-   :red                                   "merah"
 
    ;commands
-   :money-command-description             "kirim dana"
-   :location-command-description          "kirim lokasi"
-   :phone-command-description             "kirim nomor telepon"
-   :phone-request-text                    "meminta nomor telepon"
-   :confirmation-code-command-description "kirim kode verifikasi"
-   :confirmation-code-request-text        "meminta kode konfirmasi"
-   :send-command-description              "kirim lokasi"
-   :request-command-description           "kirim permintaan"
-   :keypair-password-command-description  ""
-   :help-command-description              "bantuan"
-   :request                               "permintaan"
    :chat-send-eth                         "{{amount}} ETH"
-   :chat-send-eth-to                      "{{amount}} ETH untuk: {{chat-name}}"
-   :chat-send-eth-from                    "{{amount}} ETH dari: {{chat-name}}"
 
    ;new-group
-   :group-chat-name                       "nama obrolan"
-   :empty-group-chat-name                 "silakan masukkan nama"
-   :illegal-group-chat-name               "silakan pilih nama lain"
 
    ;participants
-   :add-participants                      "tambahkan peserta"
-   :remove-participants                   "hapus peserta"
 
    ;protocol
    :received-invitation                   "telah menerima undangan untuk obrolan"
@@ -168,12 +127,9 @@
 
    ;new-contact
    :add-new-contact                       "menambahkan kontak baru"
-   :import-qr                             "import"
    :scan-qr                               "memindai kode QR ini"
    :name                                  "nama"
-   :whisper-identity                      "whisper ID"
    :address-explication                   "mungkin harus ada beberapa konten untuk menjelaskan alamat ini dan di mana menemukannya"
-   :enter-valid-address                   "harap masukkan alamat valid atau pindai kode QR"
    :contact-already-added                 "Kontak yang telah ditambahkan"
    :can-not-add-yourself                  "tidak dapat menambahkan anda sendiri"
    :unknown-address                       "alamat tidak diketahui"
@@ -183,20 +139,14 @@
    :connect                               "terhubung"
    :address                               "alamat"
    :password                              "kata sandi"
-   :login                                 "masuk"
    :wrong-password                        "kata sandi salah"
 
    ;recover
-   :recover-from-passphrase               "pulihkan dari passphrase"
-   :recover-explain                       "masukkan kata sandi anda untuk memulihkan akses"
    :passphrase                            "passphrase"
    :recover                               "pemulihan"
-   :enter-valid-passphrase                "masukkan valid passphrase"
-   :enter-valid-password                  "masukkan kata sandi yang valid"
 
    ;accounts
    :recover-access                        "akses Pemulihan"
-   :add-account                           "tambahkan Akun"
 
    ;wallet-qr-code
    :done                                  "lengkap"
@@ -205,18 +155,9 @@
    ;validation
    :invalid-phone                         "nomor telepon salah"
    :amount                                "jumlah dana"
-   :not-enough-eth                        (str "balance ETH tidak cukup"
-                                               "({{balance}} ETH)")
    ;transactions
-   :confirm-transactions                  {:one   "konfirmasi transaksi"
-                                           :other "{{count}} transaksi terkonfirmasi"
-                                           :zero  "tidak ada transaksi"}
    :status                                "kondisi"
-   :pending-confirmation                  "konfirmasi pending"
    :recipient                             "penerima"
-   :one-more-item                         "tambahkan lagi item "
-   :fee                                   "fee"
-   :value                                 "nilai"
 
    ;:webview
    :web-view-error                        "oopss, error"})

--- a/src/status_im/translations/it_ch.cljs
+++ b/src/status_im/translations/it_ch.cljs
@@ -10,8 +10,6 @@
    :offline                               "Offline"
 
    ;drawer
-   :invite-friends                        "Invita amici"
-   :faq                                   "FAQ"
    :switch-users                          "Cambia utenti"
 
    ;chat
@@ -53,41 +51,30 @@
                                            :other "ore"}
    :datetime-day                          {:one   "giorno"
                                            :other "giorni"}
-   :datetime-multiple                     "s"
    :datetime-ago                          "fa"
    :datetime-yesterday                    "ieri"
    :datetime-today                        "oggi"
 
    ;profile
    :profile                               "Profilo"
-   :report-user                           "SEGNALA UTENTE"
    :message                               "Messaggio"
-   :username                              "Nome utente"
    :not-specified                         "Non specificato"
    :public-key                            "Chiave pubblica"
    :phone-number                          "Numero di telefono"
-   :email                                 "Email"
-   :profile-no-status                     "Nessuno stato"
    :add-to-contacts                       "Aggiungi ai contatti"
-   :error-incorrect-name                  "Seleziona un altro nome"
-   :error-incorrect-email                 "Email errata"
 
    ;;make_photo
    :image-source-title                    "Immagine profilo"
    :image-source-make-photo               "Scatta"
    :image-source-gallery                  "Seleziona dalla galleria immagini"
-   :image-source-cancel                   "Annulla"
 
    ;sign-up
    :contacts-syncronized                  "I tuoi contatti sono stati sincronizzati"
    :confirmation-code                     (str "Grazie! Ti abbiamo inviato un messaggio con un codice di "
                                                "conferma. Utilizza tale codice per confermare il tuo numero di telefono")
    :incorrect-code                        (str "Il codice inserito è errato, riprova")
-   :generate-passphrase                   (str "Provvederò a generare una passphrase così potrai ripristinare il tuo "
-                                               "accesso o effettuare il login da un altro dispositivo")
    :phew-here-is-your-passphrase          "*Wow* È stato difficile, ecco qui la tua passphrase, *prendi nota e conservala in un luogo sicuro!* Ti servirà per ripristinare il tuo conto."
    :here-is-your-passphrase               "Ecco qui la tua passphrase, *prendi nota e conservala in un luogo sicuro!* Ti servirà per ripristinare il tuo conto."
-   :written-down                          "Assicurati di averla scritta correttamente"
    :phone-number-required                 "Clicca qui per inserire il tuo numero di telefono e trovare i tuoi amici"
    :intro-status                          "Avvia una conversazione con me per impostare il tuo conto e modificare le tue impostazioni!"
    :intro-message1                        "Benvenuto su Status\nTocca questo messaggio per impostare la tua password e iniziare!"
@@ -95,7 +82,6 @@
 
    ;chats
    :chats                                 "Conversazioni"
-   :new-chat                              "Nuova conversazione"
    :new-group-chat                        "Nuova conversazione di gruppo"
 
    ;discover
@@ -112,9 +98,6 @@
    ;contacts
    :contacts                              "Contatti"
    :new-contact                           "Nuovo contatto"
-   :show-all                              "MOSTRA TUTTI"
-   :contacts-group-dapps                  "ÐApps"
-   :contacts-group-people                 "Persone"
    :contacts-group-new-chat               "Inizia una nuova conversazione"
    :no-contacts                           "Nessun contatto registrato"
    :show-qr                               "Mostra QR"
@@ -122,41 +105,17 @@
    ;group-settings
    :remove                                "Rimuovi"
    :save                                  "Salva"
-   :change-color                          "Cambia colore"
    :clear-history                         "Cancella cronologia"
-   :delete-and-leave                      "Elimina ed esci"
    :chat-settings                         "Impostazioni conversazioni"
    :edit                                  "Modifica"
    :add-members                           "Aggiungi membri"
-   :blue                                  "Blu"
-   :purple                                "Viola"
-   :green                                 "Verde"
-   :red                                   "Rosso"
 
    ;commands
-   :money-command-description             "Invia denaro"
-   :location-command-description          "Invia posizione"
-   :phone-command-description             "Invia numero di telefono"
-   :phone-request-text                    "Richiesta numero di telefono"
-   :confirmation-code-command-description "Invia codice di conferma"
-   :confirmation-code-request-text        "Richiesta codice di conferma"
-   :send-command-description              "Invia posizione"
-   :request-command-description           "Invia richiesta"
-   :keypair-password-command-description  ""
-   :help-command-description              "Aiuto"
-   :request                               "Richiedi"
    :chat-send-eth                         "{{amount}} ETH"
-   :chat-send-eth-to                      "{{amount}} ETH a {{chat-name}}"
-   :chat-send-eth-from                    "{{amount}} ETH da {{chat-name}}"
 
    ;new-group
-   :group-chat-name                       "Nome conversazione"
-   :empty-group-chat-name                 "Inserire un nome"
-   :illegal-group-chat-name               "Selezionare un altro nome"
 
    ;participants
-   :add-participants                      "Aggiungi partecipanti"
-   :remove-participants                   "Rimuovi partecipanti"
 
    ;protocol
    :received-invitation                   "ha ricevuto un invito di conversazione"
@@ -168,12 +127,9 @@
 
    ;new-contact
    :add-new-contact                       "Aggiungi nuovo contatto"
-   :import-qr                             "Importa"
    :scan-qr                               "Scansiona QR"
    :name                                  "Nome"
-   :whisper-identity                      "Whisper Identity"
    :address-explication                   "Forse qui dovremmo spiegare cos'è un indirizzo e dove cercarlo"
-   :enter-valid-address                   "Inserire un indirizzo valido oppure effettuare la scansione del codice QR"
    :contact-already-added                 "Il contatto è già stato aggiunto"
    :can-not-add-yourself                  "Non puoi aggiungere te stesso"
    :unknown-address                       "Indirizzo sconosciuto"
@@ -183,20 +139,14 @@
    :connect                               "Effettua connessione"
    :address                               "Indirizzo"
    :password                              "Password"
-   :login                                 "Login"
    :wrong-password                        "Password errata"
 
    ;recover
-   :recover-from-passphrase               "Ripristina tramite passphrase"
-   :recover-explain                       "Inserire la passphrase per ripristinare la password di accesso"
    :passphrase                            "Passphrase"
    :recover                               "Ripristina"
-   :enter-valid-passphrase                "Inserire una passphrase"
-   :enter-valid-password                  "Inserire una password"
 
    ;accounts
    :recover-access                        "Ripristina l'accesso"
-   :add-account                           "Aggiungi conto"
 
    ;wallet-qr-code
    :done                                  "OK"
@@ -205,34 +155,20 @@
    ;validation
    :invalid-phone                         "Numero di telefono non valido"
    :amount                                "Saldo"
-   :not-enough-eth                        (str "Saldo ETH non sufficiente "
-                                               "({{balance}} ETH)")
    ;transactions
-   :confirm-transactions                  {:one   "Conferma transazione"
-                                           :other "Conferma {{count}} transazioni"
-                                           :zero  "Nessuna transazione"}
    :status                                "Stato"
-   :pending-confirmation                  "Conferma pendente"
    :recipient                             "Beneficiario"
-   :one-more-item                         "Ancora un elemento"
-   :fee                                   "Commissione"
-   :value                                 "Valore"
 
    ;:webview
    :web-view-error                        "Ops, si è verificato un errore"
 
    :confirm                               "Conferma"
    :phone-national                        "Nazionale"
-   :transactions-confirmed                {:one   "Transazione confermata"
-                                           :other "{{count}} transazioni confermata"
-                                           :zero  "Nessuna transazione confermata"}
    :public-group-topic                    "Argomento"
    :debug-enabled                         "Il server di debug è stato avviato! Ora puoi aggiungere la tua DApp eseguendo *status-dev-cli scan* dal tuo computer"
    :new-public-group-chat                 "Entra in chat pubblica"
    :datetime-ago-format                   "{{number}} {{time-intervals}} {{ago}}"
    :sharing-cancel                        "Annulla"
-   :share-qr                              "Condividi QR"
-   :feedback                              "Hai ricevuto un feedback?\nScuoti il tuo telefono!"
    :twelve-words-in-correct-order         "12 parole in ordine corretto"
    :remove-from-contacts                  "Rimuovi dai contatti"
    :delete-chat                           "Elimina chat"
@@ -272,7 +208,6 @@
 
    :contact-s                             {:one   "contatto"
                                            :other "contatti"}
-   :group-name                            "Nome del gruppo"
    :next                                  "Avanti"
    :from                                  "Da"
    :search-chats                          "Cerca nelle chat"
@@ -289,17 +224,11 @@
    :more                                  "altro"
    :cancel                                "Annulla"
    :no-statuses-found                     "Nessuno stato trovato"
-   :swow-qr                               "Mostra QR"
    :browsing-open-in-web-browser          "Apri nel browser"
    :delete-group-prompt                   "Questo non intaccherà i contatti"
    :edit-profile                          "Modifica profilo"
 
 
-   :enter-password-transactions           {:one   "Conferma la transazione inserendo la tua password"
-                                           :other "Conferma le transazioni inserendo la tua password"}
-   :unsigned-transactions                 "Transazioni non firmate"
    :empty-topic                           "Argomento non definito"
    :to                                    "A"
-   :group-members                         "Membri del gruppo"
-   :estimated-fee                         "Commissione stimata"
    :data                                  "Dati"})

--- a/src/status_im/translations/ja.cljs
+++ b/src/status_im/translations/ja.cljs
@@ -19,11 +19,7 @@
    :photos-access-error                   "写真を取得できません。設定より写真へのアクセスを許可してください。"
 
    ;drawer
-   :invite-friends                        "友だちを招待"
-   :faq                                   "よくある質問"
    :switch-users                          "ユーザーの切り替え"
-   :feedback                              "フィードバックがある場合はスマホを振って下さい！"
-   :view-all                              "全て見る"
    :current-network                       "現在のネットワーク"
 
    ;chat
@@ -69,7 +65,6 @@
                                            :other "時間"}
    :datetime-day                          {:one   "日"
                                            :other "日"}
-   :datetime-multiple                     ""
    :datetime-ago                          "前"
    :datetime-yesterday                    "昨日"
    :datetime-today                        "今日"
@@ -77,13 +72,10 @@
    ;profile
    :profile                               "プロフィール"
    :edit-profile                          "プロフィールを編集"
-   :report-user                           "ユーザーを通報"
    :message                               "メッセージ"
-   :username                              "ユーザー名"
    :not-specified                         "特定されていません"
    :public-key                            "公開鍵"
    :phone-number                          "電話番号"
-   :email                                 "メールアドレス"
    :update-status                         "ステータスを更新..."
    :add-a-status                          "ステータスを追加..."
    :status-prompt                         "あなたのオファーを知らせるためにステータスを作成してください。#hashtagsも使用できます。"
@@ -92,15 +84,11 @@
    :remove-from-contacts                  "連絡先から削除"
    :start-conversation                    "会話を始める"
    :send-transaction                      "トランザクションを送信"
-   :share-qr                              "QRを共有"
-   :error-incorrect-name                  "別の名前を選択してください"
-   :error-incorrect-email                 "メールアドレスが正しくありません"
 
    ;;make_photo
    :image-source-title                    "プロフィール画像"
    :image-source-make-photo               "カメラを起動"
    :image-source-gallery                  "ギャラリーから選択"
-   :image-source-cancel                   "キャンセル"
 
    ;;sharing
    :sharing-copy-to-clipboard             "クリップボードにコピー"
@@ -108,7 +96,6 @@
    :sharing-cancel                        "キャンセル"
 
    :browsing-title                        "閲覧"
-   :browsing-browse                       "@閲覧"
    :browsing-open-in-web-browser          "ブラウザーで閲覧"
    :browsing-cancel                       "キャンセル"
 
@@ -117,11 +104,8 @@
    :confirmation-code                     (str "ありがとうございます！ 確認コードが記載されたメッセージが"
                                                "送信されました。電話番号を確認するにはそのコードを入力してください")
    :incorrect-code                        (str "申し訳ありません。コードが間違っています。もう一度入力してください")
-   :generate-passphrase                   (str "パスフレーズを生成すると、アクセスを復元したり、"
-                                               "別のデバイスからログインしたりすることができます。")
    :phew-here-is-your-passphrase          "*お疲れ様でした。*これがパスフレーズです。*書き留めて安全な場所に保管してください！*アカウントの復元に必要になります。"
    :here-is-your-passphrase               "これがパスフレーズです。*書き留めて安全な場所に保管してください！*アカウントの復元に必要になります。"
-   :written-down                          "書き留めて安全な場所に保管してください。"
    :phone-number-required                 "ここをタップして電話番号を入力するとお友達を検索します。"
    :shake-your-phone                      "問題点や改善点を報告する場合は、スマホを振って下さい！"
    :intro-status                          "チャットしてアカウントを設定し、設定を変更してください！"
@@ -138,7 +122,6 @@
 
    ;chats
    :chats                                 "チャット"
-   :new-chat                              "新規チャット"
    :delete-chat                           "チャットを削除"
    :new-group-chat                        "新規グループチャット"
    :new-public-group-chat                 "公開チャットに参加"
@@ -168,9 +151,6 @@
    :remove-from-group                     "グループから削除"
    :edit-contacts                         "連絡先を偏執"
    :search-contacts                       "連絡先を検索"
-   :show-all                              "全て表示"
-   :contacts-group-dapps                  "ÐApps"
-   :contacts-group-people                 "人々"
    :contacts-group-new-chat               "新規チャットを開始"
    :choose-from-contacts                  "連絡先から選択"
    :no-contacts                           "まだ連絡先がありません"
@@ -182,52 +162,26 @@
    :remove                                "削除"
    :save                                  "保存"
    :delete                                "削除"
-   :change-color                          "色を変更"
    :clear-history                         "履歴の消去"
    :mute-notifications                    "お知らせをミュート"
    :leave-chat                            "チャットから退出"
-   :delete-and-leave                      "削除し退出する"
    :chat-settings                         "チャット設定"
    :edit                                  "偏執"
    :add-members                           "メンバーを追加"
-   :blue                                  "ブルー"
-   :purple                                "パープル"
-   :green                                 "グリーン"
-   :red                                   "レッド"
 
    ;commands
-   :money-command-description             "送金"
-   :location-command-description          "位置を送信"
-   :phone-command-description             "電話番号を送信"
-   :phone-request-text                    "電話番号をリクエスト"
-   :confirmation-code-command-description "確認コードを送信"
-   :confirmation-code-request-text        "確認コードをリクエスト"
-   :send-command-description              "位置を送信"
-   :request-command-description           "リクエストを送信"
-   :keypair-password-command-description  ""
-   :help-command-description              "ヘルプ"
-   :request                               "リクエスト"
    :chat-send-eth                         "{{amount}} ETH"
-   :chat-send-eth-to                      "{{amount}} ETHを{{chat-name}}に"
-   :chat-send-eth-from                    "{{amount}} ETHを{{chat-name}}から"
 
    ;new-group
-   :group-chat-name                       "チャット名"
-   :empty-group-chat-name                 "名前を入力して下さい"
-   :illegal-group-chat-name               "別の名前を洗濯して下さい"
    :new-group                             "新しいグループ"
    :reorder-groups                        "グループを並び替え"
-   :group-name                            "グループ名"
    :edit-group                            "グループを偏執"
    :delete-group                          "グループを削除"
    :delete-group-confirmation             "このグループを削除します。連絡先には影響を与えません。"
    :delete-group-prompt                   "連絡先には影響を与えません。"
-   :group-members                         "グループメンバー"
    :contact-s                             {:one   "連絡先"
                                            :other "連絡先"}
    ;participants
-   :add-participants                      "参加者を追加"
-   :remove-participants                   "参加者を削除"
 
    ;protocol
    :received-invitation                   "チャット招待状を受信しました"
@@ -239,13 +193,9 @@
 
    ;new-contact
    :add-new-contact                       "新規連絡先を追加"
-   :import-qr                             "インポート"
    :scan-qr                               "QRをスキャン"
-   :swow-qr                               "QRを表示"
    :name                                  "名前"
-   :whisper-identity                      "Whisper識別子"
    :address-explication                   "ここにアドレスについての説明や、どこで見つけられるのかを入力してください"
-   :enter-valid-address                   "有効なアドレスを入力するかQRコードをスキャンしてください"
    :enter-valid-public-key                "有効な公開鍵を入力するかQRコードをスキャンしてください"
    :contact-already-added                 "連絡先はすでに追加されています"
    :can-not-add-yourself                  "自分自身を追加することはできません"
@@ -256,23 +206,17 @@
    :connect                               "接続"
    :address                               "アドレス"
    :password                              "パスワード"
-   :login                                 "ログイン"
    :sign-in-to-status                     "ステータスにサインイン"
    :sign-in                               "サインイン"
    :wrong-password                        "パスワードが間違っています"
 
    ;recover
-   :recover-from-passphrase               "パスフレーズから復元"
-   :recover-explain                       "アクセスを復元するには、パスワードのパスフレーズを入力してください"
    :passphrase                            "パスフレーズ"
    :recover                               "復元"
-   :enter-valid-passphrase                "パスフレーズを入力してください"
-   :enter-valid-password                  "パスワードを入力してください"
    :twelve-words-in-correct-order         "正しい順序で12ワード"
 
    ;accounts
    :recover-access                        "アクセスを復元"
-   :add-account                           "アカウントを追加"
    :create-new-account                    "新規アカウントを作成"
 
    ;wallet-qr-code
@@ -282,33 +226,15 @@
    ;validation
    :invalid-phone                         "無効な電話番号"
    :amount                                "金額"
-   :not-enough-eth                        (str "十分なETH残高がありません"
-                                               "({{balance}} ETH)")
    ;transactions
    :confirm                               "確認"
-   :confirm-transactions                  {:one   "トランザクションを確認"
-                                           :other "{{count}}トランザクションを確認"
-                                           :zero  "トランザクションがありません"}
-   :transactions-confirmed                {:one   "トランザクションを確認済み"
-                                           :other "{{count}}トランザクションを確認済み"
-                                           :zero  "確認済みトランザクションはありません"}
    :transaction                           "トランザクション"
-   :unsigned-transactions                 "署名されていないトランザクション"
-   :no-unsigned-transactions              "署名されていないトランザクションはありません"
-   :enter-password-transactions           {:one   "パスワードを入力してトランザクションを確認する"
-                                           :other "パスワードを入力してトランザクションを確認する"}
    :status                                "ステータス"
-   :pending-confirmation                  "確認作業が保留中です"
    :recipient                             "受信者"
-   :one-more-item                         "もう一つの項目"
-   :fee                                   "手数料"
-   :estimated-fee                         "予想される手数料"
-   :value                                 "値"
    :to                                    "宛先"
    :from                                  "送信元"
    :data                                  "データ"
    :got-it                                "理解しました"
-   :contract-creation                     "契約作成"
 
    ;:webview
    :web-view-error                        "おっと、エラーが発生しました。"})

--- a/src/status_im/translations/la.cljs
+++ b/src/status_im/translations/la.cljs
@@ -10,8 +10,6 @@
    :offline                               "abesse"
  
    ;drawer
-   :invite-friends                        "invitare amico"
-   :faq                                   "FAQ"
    :switch-users                          "utens ex cambit"
  
    ;chat
@@ -54,41 +52,28 @@
                                            :other "horae"}
    :datetime-day                          {:one   "dies"
                                            :other "dies"}
-   :datetime-multiple                     "s"
    :datetime-ago                          "anto"
    :datetime-yesterday                    "heri"
    :datetime-today                        "hodie"
  
    ;profile
    :profile                               "biographia"
-   :report-user                           "UTENS QUADRUPLARI"
    :message                               "nuntium"
-   :username                              "utens nominis"
    :not-specified                         "ne adnotans"
    :public-key                            "publica clavis"
    :phone-number                          "nummerus telephonicus"
-   :email                                 "smaltum"
-   :profile-no-status                     "nullus status"
    :add-to-contacts                       "adicere ad contagio"
-   :error-incorrect-name                  "optare alium nomen suis"
-   :error-incorrect-email                 "falsum smaltum"
- 
    ;;make_photo
    :image-source-title                    "photographia bigraphiae"
    :image-source-make-photo               "photographere"
    :image-source-gallery                  "eligere ad pinacothecae"
-   :image-source-cancel                   "defringere"
- 
    ;sign-up
    :contacts-syncronized                  "contagium sui synchronizatum esse."
    :confirmation-code                     (str "gratias tibi! misimus nuntium conscriptionis cum notae. "
                                                "transcribe notam, ut nummerum telefonicum possimus verificare.")
    :incorrect-code                        (str "nos paenite, nota falsa, perscribe denuo")
-   :generate-passphrase                   (str "computo phrasis arcana pro suo, ut "
-                                               "arripiens recreare aut arripere alii instrumento profiteri potest.")
    :phew-here-is-your-passphrase          "*uph* erat gravor. hic phrasis arcana sui est, *exscribe et adserva!* necesse est, ut benificium sui recreare."
    :here-is-your-passphrase               "hic phrasis arcana sui est, *exscribe et adserva!* necesse est, ut benificium sui recreare."
-   :written-down                          "exscribere omnes? nisi exscribe nunc"
    :phone-number-required                 "attige ipse, et transcribe numerus telephonicus sui. deinde inveniar amici sui."
    :intro-status                          "habere colloquium cum me, ut syngraphus sui congerit et moderationes sui mutare!"
    :intro-message1                        "salve! hic Status est!.\n attige id nuntium, ut signum arcanum sui congere et incipere!"
@@ -96,7 +81,6 @@
  
    ;chats
    :chats                                 "colloquia"
-   :new-chat                              "novum  colloquium"
    :new-group-chat                        "novum colloquium circli"
  
    ;discover
@@ -113,9 +97,6 @@
    ;contacts
    :contacts                              "contagiis"
    :new-contact                           "novum contagium"
-   :show-all                              "elucere omnibus"
-   :contacts-group-dapps                  "ÐApps"
-   :contacts-group-people                 "poplus"
    :contacts-group-new-chat               "novum colloquium circli"
    :no-contacts                           "Nulla contagio"
    :show-qr                               "QR-nota elucere"
@@ -123,42 +104,14 @@
    ;group-settings
    :remove                                "amovere"
    :save                                  "apothecare"
-   :change-color                          "color mutare"
    :clear-history                         "processus amovere"
-   :delete-and-leave                      "amovere et relinquere"
    :chat-settings                         "moderationes colloquiorum"
    :edit                                  "commutare"
    :add-members                           "sodalis adjungere"
-   :blue                                  "caeruleum"
-   :purple                                "austrum"
-   :green                                 "viridis"
-   :red                                   "rubius"
- 
    ;commands
-   :money-command-description             "pecunia mittere"
-   :location-command-description          "locum mittere"
-   :phone-command-description             "numerus telephonicus mittere"
-   :phone-request-text                    "numerus telephonicus exquirere"
-   :confirmation-code-command-description "nota mittere"
-   :confirmation-code-request-text        "nota exquirere"
-   :send-command-description              "locum mittere"
-   :request-command-description           "consulatio mittere"
-   :keypair-password-command-description  ""
-   :help-command-description              "auxilium"
-   :request                               "consulatio"
    :chat-send-eth                         "{{amount}} ETH"
-   :chat-send-eth-to                      "{{amount}} ETH ad {{chat-name}}"
-   :chat-send-eth-from                    "{{amount}} ETH ab {{chat-name}}"
- 
    ;new-group
-   :group-chat-name                       "nomen colloquio circli"
-   :empty-group-chat-name                 "perscribe nomen colloquio circli"
-   :illegal-group-chat-name               "perscribe nomen aliud"
- 
    ;participants
-   :add-participants                      "adsecula adjungere"
-   :remove-participants                   "adsecula relinquere"
- 
    ;protocol
    :received-invitation                   "nancisci colloquium circli"
    :removed-from-chat                     "ex colloquium circli relinquere"
@@ -169,12 +122,9 @@
  
    ;new-contact
    :add-new-contact                       "nova  contagio adjungere"
-   :import-qr                             "importare"
    :scan-qr                               "QR-nota photographere"
    :name                                  "nomen"
-   :whisper-identity                      "identitas susurrare"
    :address-explication                   "explain what adresses are" ; TODO
-   :enter-valid-address                   "perscribe ratum adloquium aut photographare QR-nota"
    :contact-already-added                 "iste contagio jam adjunctum esse"
    :can-not-add-yourself                  "ne potest adjungere ipse!"
    :unknown-address                       "ignotum adloquium"
@@ -184,21 +134,13 @@
    :connect                               "iungere"
    :address                               "adloquium"
    :password                              "signum arcanum"
-   :login                                 "profitere"
    :wrong-password                        "falsum signum acranum"
  
    ;recover
-   :recover-from-passphrase               "recreare alcis auxilio phrasis arcana"
-   :recover-explain                       "perscribe phrasis arcana pro signo arcano, ut recreare dicionem"
    :passphrase                            "phrasis arcana"
    :recover                               "recreare"
-   :enter-valid-passphrase                "perscribe phrasis arcana"
-   :enter-valid-password                  "perscribe signum arcanum"
- 
    ;accounts
    :recover-access                        "restituere possessio"
-   :add-account                           "benificium addere"
- 
    ;wallet-qr-code
    :done                                  "paratus"
    :main-wallet                           "crumera caput"
@@ -206,18 +148,8 @@
    ;validation
    :invalid-phone                         "nummerus telephonicus"
    :amount                                "summa"
-   :not-enough-eth                        (str "crumera haud satis EHT habet"
-                                               "({{balance}} ETH)")
    ;transactions
-   :confirm-transactions                  {:one   "authenticare transmissio"
-                                           :other "{{count}} authenticare transmissiones"
-                                           :zero  "nulla transmissio"}
    :status                                "status"
-   :pending-confirmation                  "Confirmatio in tractatio"
    :recipient                             "acceptor"
-   :one-more-item                         "etiam res"
-   :fee                                   "theolonium"
-   :value                                 "precium"
- 
    ;:webview
    :web-view-error                        "Erratum ad adspectus"})

--- a/src/status_im/translations/lt.cljs
+++ b/src/status_im/translations/lt.cljs
@@ -111,7 +111,7 @@
    ;;sign-up
    :contacts-syncronized                  "Jūsų kontaktai buvo sinchronizuoti"
    :confirmation-code                     (str "Dėkui! Mes išsiuntėme jums teksto pranešimą su patvirtinimo kodu. "
-						"Prašau nurodyti šį kodą, kad patvirtintumėte savo telefono numerį")
+                                               "Prašau nurodyti šį kodą, kad patvirtintumėte savo telefono numerį")
    :incorrect-code                        (str "Atsiprašome, kodas neteisingas, prašome įvesti jį dar kartą")
    :phew-here-is-your-passphrase          "Vajė, buvo sunkoka, čia yra jūsų slaptažodis, *išsaugokite jį!* jeigu reikės atkurti jūsų paskyrą."
    :here-is-your-passphrase               "Čia yra jūsų slaptafrazė, *išsaugokite ją!* jeigu reikės atkurti jūsų paskyrą."

--- a/src/status_im/translations/lv.cljs
+++ b/src/status_im/translations/lv.cljs
@@ -19,11 +19,7 @@
    :photos-access-error                   "Kļūda, nav atļaujas piekļūt fotogrāfijām. Lūdzu, iestatījumos pārliecinies, ka Status > Photos ir izvēlēts."
 
    ;drawer
-   :invite-friends                        "Uzaicināt draugus"
-   :faq                                   "FAQ un biežāk uzdotie jautājumi"
    :switch-users                          "Mainīt lietotāju"
-   :feedback                              "Gribi atstāt atsauksmi? Krati telefonu!"
-   :view-all                              "Skatīt visu"
    :current-network                       "Tīkls"
 
    ;chat
@@ -69,7 +65,6 @@
                                            :other "stundas"}
    :datetime-day                          {:one   "diena"
                                            :other "dienas"}
-   :datetime-multiple                     "s"
    :datetime-ago                          "pirms"
    :datetime-yesterday                    "vakar"
    :datetime-today                        "šodien"
@@ -77,13 +72,10 @@
    ;profile
    :profile                               "Profils"
    :edit-profile                          "Rediģēt profilu"
-   :report-user                           "Ziņot"
    :message                               "Īsziņa"
-   :username                              "Lietotājvārds"
    :not-specified                         "Nav norādīts"
    :public-key                            "Public key"
    :phone-number                          "Telefona numurs"
-   :email                                 "E-pasts"
    :update-status                         "Rediģēt aprakstu..."
    :add-a-status                          "Pievienot aprakstu..."
    :status-prompt                         "Pievieno aprakstu lai cilvēki zinātu ko tu piedāvā. Tu vari arī izlietot #hashtagus."
@@ -92,16 +84,10 @@
    :remove-from-contacts                  "Izdzēst kontaktu"
    :start-conversation                    "Sākt sarunu"
    :send-transaction                      "Sūtīt transakciju"
-   :share-qr                              "Dalīties ar QR kodu"
-   :error-incorrect-name                  "Lūdzu izmanto citu vārdu"
-   :error-incorrect-email                 "Nepareizs e-pasts"
-
-   
    ;;make_photo
    :image-source-title                    "Profila bilde"
    :image-source-make-photo               "Fotografēt"
    :image-source-gallery                  "Izvēlēties no galerijas"
-   :image-source-cancel                   "Atcelt"
 
    ;;sharing
    :sharing-copy-to-clipboard             "Copy to clipboard"
@@ -117,11 +103,8 @@
    :confirmation-code                     (str "Paldies! Mēs nosūtijām tev īsziņu ar apstiprinājuma kodu"
                                                "code. Lūdzu ievadi apstiprinājuma kodu lai verificētu savu telefona numuru")
    :incorrect-code                        (str "Nepareizs kods, mēģiniet vēlreiz")
-   :generate-passphrase                   (str "Tu saņemsi jaunu passphrase lai"
-                                               "tu varētu ieiet no cita telefona")
    :phew-here-is-your-passphrase          "*Fuh* tas bija grūti, re, te ir tavs jauns passphrase, *pieraksti un sargā to!* Tev viņš būs vajadzīgs lai atgūtu pieju."
    :here-is-your-passphrase               "Te ir tavs jauns passphrase, *pieraksti un sargā to!* Tev viņš būs vajadzīgs lai atgūtu pieju savam kontam."
-   :written-down                          "Pārliecinies, ka pareizi pierakstīji to."
    :phone-number-required                 "Ievadi savu telefonu un es atradīšu tavus draugus."
    :shake-your-phone                      "Atradi kļūdu? Pastāsti mums par to! Krati telefonu!"
    :intro-status                          "Čato ar mani, ja gribi mainīt ustatījumus!"
@@ -138,7 +121,6 @@
 
    ;chats
    :chats                                 "Čati"
-   :new-chat                              "Jaunais čāts"
    :delete-chat                           "Dzēst čatu"
    :new-group-chat                        "Jauna grupa"
    :new-public-group-chat                 "Pievienoties publiskajam čatam"
@@ -168,9 +150,6 @@
    :remove-from-group                     "Dzēst no grupas"
    :edit-contacts                         "Rediģēt kontakts"
    :search-contacts                       "Meklēt kontaktus"
-   :show-all                              "PARĀDĪT VISUS"
-   :contacts-group-dapps                  "ÐApps"
-   :contacts-group-people                 "Cilvēki"
    :contacts-group-new-chat               "Sākt jaunu čatu"
    :choose-from-contacts                  "Izvēlēties no kontaktiem"
    :no-contacts                           "Kontaktu nav"
@@ -182,52 +161,26 @@
    :remove                                "Noņemt"
    :save                                  "Saglabāt"
    :delete                                "Dzēst"
-   :change-color                          "Mainīt krāsu"
    :clear-history                         "Dzēst vēsturi"
    :mute-notifications                    "Mute"
    :leave-chat                            "Iziet no čata"
-   :delete-and-leave                      "Dzēst un iziet"
    :chat-settings                         "Čata iestatījumi"
    :edit                                  "Rediģēt"
    :add-members                           "Pievienot biedrus"
-   :blue                                  "Blue"
-   :purple                                "Purple"
-   :green                                 "Green"
-   :red                                   "Red"
 
    ;commands
-   :money-command-description             "Sūtīt naudu"
-   :location-command-description          "Sūtīt lokāciju"
-   :phone-command-description             "Sūtīt numuru"
-   :phone-request-text                    "Telefona numura pieprasījums"
-   :confirmation-code-command-description "Sūtīt apstiprinājuma kodu"
-   :confirmation-code-request-text        "Apstiprinājuma koda pieprasījums"
-   :send-command-description              "Sūtīt lokāciju"
-   :request-command-description           "Sūtīt pieprasījumu"
-   :keypair-password-command-description  ""
-   :help-command-description              "Palīdzība"
-   :request                               "Pieprasījums"
    :chat-send-eth                         "{{amount}} ETH"
-   :chat-send-eth-to                      "{{amount}} ETH kam {{chat-name}}"
-   :chat-send-eth-from                    "{{amount}} ETH no {{chat-name}}"
 
    ;new-group
-   :group-chat-name                       "Čata nosaukums"
-   :empty-group-chat-name                 "Ievadi vārdu"
-   :illegal-group-chat-name               "Lūdzu, izvēlaties citu vārdu"
    :new-group                             "Jauna grupa"
    :reorder-groups                        "Reorder groups"
-   :group-name                            "Grupas nosaukums"
    :edit-group                            "Rediģēt grupu"
    :delete-group                          "Dzēst grupu"
    :delete-group-confirmation             "Grupa tiks noņēmta. Tas neietikmēs tavus kontaktus"
    :delete-group-prompt                   "Tas neietikmēs kontaktus"
-   :group-members                         "Grupas biedri"
    :contact-s                             {:one   "kontakts"
                                            :other "kontakti"}
    ;participants
-   :add-participants                      "Pievienot biedrus"
-   :remove-participants                   "Noņemt biedrus"
 
    ;protocol
    :received-invitation                   "čata uzaicinājums"
@@ -239,13 +192,9 @@
 
    ;new-contact
    :add-new-contact                       "Pievienot jaunu kontaktu"
-   :import-qr                             "Importēt"
    :scan-qr                               "Skanēt QR"
-   :swow-qr                               "Parādīt QR"
    :name                                  "Vārds"
-   :whisper-identity                      "Whisper Identity"
    :address-explication                   "Maybe here should be some text explaining what an address is and where to look for it"
-   :enter-valid-address                   "Lūdzu ievadi adresi jeb skanē QR kodu"
    :enter-valid-public-key                "Lūdzu ievadi publisko atslēgu, jeb skanē QR kodu"
    :contact-already-added                 "Kontakts jau bija pievienots"
    :can-not-add-yourself                  "Tu nevari pievienot sevi"
@@ -256,23 +205,17 @@
    :connect                               "Savienoties"
    :address                               "Adrese"
    :password                              "Parole"
-   :login                                 "Lietotājvārds"
    :sign-in-to-status                     "Ieiet Status"
    :sign-in                               "Ieiet"
    :wrong-password                        "Parole ievadīta nepareizi"
 
    ;recover
-   :recover-from-passphrase               "Atgūt no passphrase"
-   :recover-explain                       "Ievadi passphrase lai atgūtu pieeju"
    :passphrase                            "Passphrase"
    :recover                               "Atgūt"
-   :enter-valid-passphrase                "Ievadi passphrase"
-   :enter-valid-password                  "Ievadi paroli"
    :twelve-words-in-correct-order         "12 vārdi"
 
    ;accounts
    :recover-access                        "Atgūt pieeju"
-   :add-account                           "Pievienot kontu"
    :create-new-account                    "Izveidot jaunu kontu"
 
    ;wallet-qr-code
@@ -282,33 +225,15 @@
    ;validation
    :invalid-phone                         "Nepareizs telefona numurs"
    :amount                                "Summa"
-   :not-enough-eth                        (str "Kontā nepietiek ETH "
-                                               "({{balance}} ETH)")
    ;transactions
    :confirm                               "Apstiprināt"
-   :confirm-transactions                  {:one   "Apstiprināt transakciju"
-                                           :other "Apstiprināt {{count}} transakcijas"
-                                           :zero  "Nav transakciju"}
-   :transactions-confirmed                {:one   "Transakcija apstiprināta"
-                                           :other "{{count}} transakcija apstiprinātas"
-                                           :zero  "Nav apstiprinātas transakcijas"}
    :transaction                           "Transakcija"
-   :unsigned-transactions                 "Neparakstītas transakcijas"
-   :no-unsigned-transactions              "Nav neparakstītas transakcijas"
-   :enter-password-transactions           {:one   "Apstiprināt transakciju (ievadi savu paroli)"
-                                           :other "Apstiprināt transakcija (ievadi savu paroli)"}
    :status                                "Status"
-   :pending-confirmation                  "Neizlemts apstiprinājums"
    :recipient                             "Saņēmējs"
-   :one-more-item                         "Vel viena lieta"
-   :fee                                   "Maksa"
-   :estimated-fee                         "~Maksa"
-   :value                                 "Vērtība"
    :to                                    "Kam"
    :from                                  "No"
    :data                                  "Dati"
    :got-it                                "Got it"
-   :contract-creation                     "Līguma izveidošana"
 
    ;:webview
    :web-view-error                        "ups, kļūda"})

--- a/src/status_im/translations/ms.cljs
+++ b/src/status_im/translations/ms.cljs
@@ -19,11 +19,7 @@
    :photos-access-error                   "Untuk memberi keizinan akses gambar yang diperlukan, sila pergi ke aturan sistem anda dan pastikan bahawa Status > Gambar telah dipilih."
 
    ;drawer
-   :invite-friends                        "Jemput Rakan"
-   :faq                                   "Soalan sering ditanya"
    :switch-users                          "Tukar pengguna"
-   :feedback                              "Ada maklum balas?\nGoncang telefon anda!"
-   :view-all                              "Lihat semua"
    :current-network                       "Rangkaian sekarang"
 
    ;chat
@@ -69,7 +65,6 @@
                                            :other "jam"}
    :datetime-day                          {:one   "hari"
                                            :other "hari"}
-   :datetime-multiple                     "2"
    :datetime-ago                          "lalu"
    :datetime-yesterday                    "semalam"
    :datetime-today                        "hari ini"
@@ -77,13 +72,10 @@
    ;profile
    :profile                               "Profail"
    :edit-profile                          "Ubah profail"
-   :report-user                           "LAPOR PENGGUNA"
    :message                               "Mesej"
-   :username                              "Nama pengguna"
    :not-specified                         "Tidak diberikan"
    :public-key                            "Public key"
    :phone-number                          "Nombor telefon"
-   :email                                 "Emel"
    :update-status                         "Kemaskini status anda..."
    :add-a-status                          "Tambah pada status..."
    :status-prompt                         "Ciptakan satu status untuk membantu pengguna lain mengetahui tentang perkara yang anda tawarkan. Anda juga boleh menggunakan #hashtag. "
@@ -92,15 +84,11 @@
    :remove-from-contacts                  "Buang dari senarai kenalan"
    :start-conversation                    "Mulakan perbualan"
    :send-transaction                      "Hantar transaksi"
-   :share-qr                              "Kongsi kod QR"
-   :error-incorrect-name                  "Sila pilih nama lain"
-   :error-incorrect-email                 "Emel salah"
 
    ;;make_photo
    :image-source-title                    "Gambar profail"
    :image-source-make-photo               "Rakam"
    :image-source-gallery                  "Pilih dari galeri"
-   :image-source-cancel                   "Batal"
 
    ;;sharing
    :sharing-copy-to-clipboard             "Salin ke clipboard"
@@ -108,7 +96,6 @@
    :sharing-cancel                        "Batal"
 
    :browsing-title                        "Pelayar"
-   :browsing-browse                       "@layar"
    :browsing-open-in-web-browser          "Buka dalam pelayar web"
    :browsing-cancel                       "Batal"
 
@@ -117,11 +104,8 @@
    :confirmation-code                     (str "Terima kasih! Kami telah menghantar kepada anda satu mesej mengandungi kod"
                                                "pengesahan. Sila berikan kod tersebut untuk mengesahkan nombor telefon anda")
    :incorrect-code                        (str "Maaf kod salah, sila masukkan sekali lagi")
-   :generate-passphrase                   (str "Saya akan mencipta satu ayat pengesahan supaya anda dapat  "
-                                               "memulihkan akses atau log masuk dari perangkat baru")
    :phew-here-is-your-passphrase          "*Wah* itu sangatlah susah, ini adalah ayat pengesahan anda, *sila tulis dan pastikan ini selamat!* Anda akan memerlukan ia untuk memulihkan akses ke akaun anda."
    :here-is-your-passphrase               "Ini adalah ayat pengesahan anda, *sila tulis dan pastikan ini selamat!* Anda akan memerlukan ia untuk memulihkan akses ke akaun anda."
-   :written-down                          "Sila pastikan anda telah menulisnya"
    :phone-number-required                 "Sentuh disini untuk memasukkan nombor telefon anda & saya akan mecari rakan anda"
    :shake-your-phone                      "Jumpa kerentanan atau terdapat cadangan? Hanya ~goncang~ telefon anda!"
    :intro-status                          "Mulakan perbualan dengan saya untuk mencipta akaun anda dan mengubah aturan akaun anda!"
@@ -138,7 +122,6 @@
 
    ;chats
    :chats                                 "Perbualan"
-   :new-chat                              "Perbualan baru"
    :delete-chat                           "Padam perbualan"
    :new-group-chat                        "Perbualan kumpulan baru"
    :new-public-group-chat                 "Sertai perbualan umum"
@@ -168,9 +151,6 @@
    :remove-from-group                     "Buang dari kumpulan"
    :edit-contacts                         "Ubah kenalan"
    :search-contacts                       "Cari kenalan"
-   :show-all                              "TUNJUK SEMUA"
-   :contacts-group-dapps                  "ÐApps"
-   :contacts-group-people                 "Pengguna"
    :contacts-group-new-chat               "Mulakan perbualan baru"
    :choose-from-contacts                  "Pilih dari kenalan"
    :no-contacts                           "Masih tiada kenalan"
@@ -182,34 +162,15 @@
    :remove                                "Buang"
    :save                                  "Simpan"
    :delete                                "Padam"
-   :change-color                          "Tukar warna"
    :clear-history                         "Padam sejarah perbualan"
    :mute-notifications                    "Pemberitahuan senyap"
    :leave-chat                            "Tinggalkan perbualan"
-   :delete-and-leave                      "Padam dan tinggalkan"
    :chat-settings                         "Aturan perbualan"
    :edit                                  "Ubah"
    :add-members                           "Tambah ahli"
-   :blue                                  "Biru"
-   :purple                                "Ungu"
-   :green                                 "Hijau"
-   :red                                   "Merah"
 
    ;commands
-   :money-command-description             "Hantar wang"
-   :location-command-description          "Hantar lokasi"
-   :phone-command-description             "Hantar nombor telefon"
-   :phone-request-text                    "Permintaan nombor telefon"
-   :confirmation-code-command-description "Hantar kod pengesahan"
-   :confirmation-code-request-text        "Permintaan kod pengesahan"
-   :send-command-description              "Hantar arahan"
-   :request-command-description           "Hantar permintaan"
-   :keypair-password-command-description  ""
-   :help-command-description              "Bantuan"
-   :request                               "Permintaan"
    :chat-send-eth                         "{{amount}} ETH"
-   :chat-send-eth-to                      "{{amount}} ETH ke {{chat-name}}"
-   :chat-send-eth-from                    "{{amount}} ETH dari {{chat-name}}"
 
    ;location command
    :your-current-location                 "Lokasi terkini anda"
@@ -222,22 +183,15 @@
    :sharing-copy-to-clipboard-coordinates "Salin koordinat"
 
    ;new-group
-   :group-chat-name                       "Nama perbualan"
-   :empty-group-chat-name                 "Sila masukkan satu nama"
-   :illegal-group-chat-name               "Sila pilih nama lain"
    :new-group                             "Kumpulan baru"
    :reorder-groups                        "Susun kumpulan"
-   :group-name                            "Nama kumpulan"
    :edit-group                            "Ubah kumpulan"
    :delete-group                          "Padam kumpulan"
    :delete-group-confirmation             "Kumpulan ini akan dipadam dari senarai kumpulan anda. Ini tidak akan menjejaskan senarai kenalan anda"
    :delete-group-prompt                   "Ini tidak akan menjejaskan senarai kenalan anda"
-   :group-members                         "Ahli kumpulan"
    :contact-s                             {:one   "kenalan"
                                            :other "kenalan"}
    ;participants
-   :add-participants                      "Tambah ahli"
-   :remove-participants                   "Buang ahli"
 
    ;protocol
    :received-invitation                   "menerima permintaan bual"
@@ -249,13 +203,9 @@
 
    ;new-contact
    :add-new-contact                       "Tambah kenalan baru"
-   :import-qr                             "Impot kod QR"
    :scan-qr                               "Imbas kod QR"
-   :swow-qr                               "Tunjuk kod QR"
    :name                                  "Nama"
-   :whisper-identity                      "Identiti Whisper"
    :address-explication                   "Mungkin disini sepatutnya terdapat sedikit teks menjelaskan apa itu address dan dimana untuk melihatnya"
-   :enter-valid-address                   "Sila masukkan address yang sah atau imbas satu kod QR"
    :enter-valid-public-key                "Sila masukkan public key yang sah atau imbas kod QR"
    :contact-already-added                 "Kenalan telah ditambah"
    :can-not-add-yourself                  "Anda tidak boleh menambah diri anda sendiri"
@@ -266,23 +216,17 @@
    :connect                               "Sambung"
    :address                               "Address"
    :password                              "Kata laluan"
-   :login                                 "Daftar masuk"
    :sign-in-to-status                     "Daftar masuk ke Status"
    :sign-in                               "Daftar masuk"
    :wrong-password                        "Kata laluan salah"
 
    ;recover
-   :recover-from-passphrase               "Pulihkn akaun daripada ayat pengesahan"
-   :recover-explain                       "Sila masukkan ayat pengesahan kepada kata laluan anda untuk memulihkan akses ke akaun anda"
    :passphrase                            "Ayat pengesahan"
    :recover                               "Pulihkan"
-   :enter-valid-passphrase                "Sila masukkan ayat pengesahan"
-   :enter-valid-password                  "Sila masukkan kata laluan"
    :twelve-words-in-correct-order         "12 perkataan dalam susunan yang betul"
 
    ;accounts
    :recover-access                        "Pulihkan akses"
-   :add-account                           "Tambah akaun"
    :create-new-account                    "Cipta akaun baru"
 
    ;wallet-qr-code
@@ -292,33 +236,15 @@
    ;validation
    :invalid-phone                         "Nombor telefon salah"
    :amount                                "Jumlah"
-   :not-enough-eth                        (str "Tidak cukup ETH dalam baki "
-                                               "({{balance}} ETH)")
    ;transactions
    :confirm                               "Sahkan"
-   :confirm-transactions                  {:one   "Sahkan transaksi"
-                                           :other "Sahkan {{count}} transaksi"
-                                           :zero  "Tiada transaksi"}
-   :transactions-confirmed                {:one   "Transaksi disahkan"
-                                           :other "{{count}} transaksi disahkan"
-                                           :zero  "Tiada transaksi disahkan"}
    :transaction                           "Transaksi"
-   :unsigned-transactions                 "Transaksi tidak berdaftar"
-   :no-unsigned-transactions              "Tiada transaksi tidak berdaftar"
-   :enter-password-transactions           {:one   "Sila sahkan transaksi dengan memasukkan kata laluan anda"
-                                           :other "Sila sahkan transaksi dengan memasukkan kata laluan anda"}
    :status                                "Status"
-   :pending-confirmation                  "Pengesahan belum selesai"
    :recipient                             "Penerima"
-   :one-more-item                         "Satu lagi"
-   :fee                                   "Bayaran transaksi"
-   :estimated-fee                         "Anggaran jumlah bayaran transaksi"
-   :value                                 "Nilai"
    :to                                    "Ke"
    :from                                  "Dari"
    :data                                  "Maklumat"
    :got-it                                "Ya"
-   :contract-creation                     "Cipta kontrak"
 
    ;:webview
    :web-view-error                        "oops, gagal"})

--- a/src/status_im/translations/nb.cljs
+++ b/src/status_im/translations/nb.cljs
@@ -21,11 +21,7 @@
    :photos-access-error                   "For å tillate bruk av bilder, gå til systeminstillinger og sørg for at Status > Bilder er aktivert."
 
    ;drawer
-   :invite-friends                        "Inviter venner"
-   :faq                                   "FAQ"
    :switch-users                          "Bytt brukere"
-   :feedback                              "Tilbakemelding?\nRist telefonen!"
-   :view-all                              "Vis alle"
    :current-network                       "Nåværende nettverk"
 
    ;chat
@@ -71,7 +67,6 @@
                                            :other "timer"}
    :datetime-day                          {:one   "dag"
                                            :other "dager"}
-   :datetime-multiple                     "er"
    :datetime-ago                          "siden"
    :datetime-yesterday                    "i går"
    :datetime-today                        "i dag"
@@ -79,13 +74,10 @@
    ;profile
    :profile                               "Profil"
    :edit-profile                          "Rediger profil"
-   :report-user                           "RAPPORTER BRUKER"
    :message                               "Melding"
-   :username                              "Brukernavn"
    :not-specified                         "Ikke spesifisert"
    :public-key                            "Offentlig nøkkel"
    :phone-number                          "Telefonnummer"
-   :email                                 "E-post"
    :update-status                         "Oppdater din status..."
    :add-a-status                          "Legg til en status..."
    :status-prompt                         "Legg til en status slik at andre forstår hva du tilbyr. Bruk gjerne #hashtag."
@@ -94,15 +86,11 @@
    :remove-from-contacts                  "Fjern fra kontakter"
    :start-conversation                    "Start en samtale"
    :send-transaction                      "Send overføring"
-   :share-qr                              "Del QR-kode"
-   :error-incorrect-name                  "Vennligst velg et annet navn"
-   :error-incorrect-email                 "Feil e-post adresse"
 
    ;;make_photo
    :image-source-title                    "Profilbilde"
    :image-source-make-photo               "Opptak"
    :image-source-gallery                  "Velg fra bilder"
-   :image-source-cancel                   "Avbryt"
 
    ;;sharing
    :sharing-copy-to-clipboard             "Kopier til utklippstavle"
@@ -110,7 +98,6 @@
    :sharing-cancel                        "Avbryt"
 
    :browsing-title                        "Utforsk"
-   :browsing-browse                       "@utforsk"
    :browsing-open-in-web-browser          "Åpne i nettleser"
    :browsing-cancel                       "Avbryt"
 
@@ -119,13 +106,10 @@
    :confirmation-code                     (str "Topp! Vi har sendt deg en tekstmelding med bekreftelseskode."
                                                "Vennligst send oss tilbake koden for å verifisere at dette er din telefon")
    :incorrect-code                        (str "Beklager, prøv på ny")
-   :generate-passphrase                   (str "Jeg genererer en passordfrase til deg, så du kan gjenopprette tilgang "
-                                               "eller logge på fra andre enheter")
 
    :phew-here-is-your-passphrase          "*Phew* det var vrient, her er din nye passordfrase, *skriv den ned og hold den for deg selv!* Du vil trenge den for å kunne gjenopprette kontoen."
    :here-is-your-passphrase               "Her er din nye passordfrase, *skriv den ned og hold den for deg selv!* Du vil trenge den for å kunne gjenopprette kontoen."
    :here-is-your-signing-phrase           "Her er din signeringsfrase. Du vil bruke den til å verifisere dine transaksjoner. *skriv den ned og hold den for deg selv!*"
-   :written-down                          "Vær sikker på at du har skrevet den ned"
    :phone-number-required                 "Trykk her og skriv ditt telefonnummer, så skal jeg finne vennene dine"
    :shake-your-phone                      "Har du funnet en feil eller har du tilbakemelding til oss? Bare ~rist~ på telefonen!"
    :intro-status                          "Chat med meg for å sette opp kontoen din og endre instillinger!"
@@ -142,7 +126,6 @@
 
    ;chats
    :chats                                 "Chats"
-   :new-chat                              "Ny melding"
    :delete-chat                           "Fjern melding"
    :new-group-chat                        "Ny gruppemelding"
    :new-public-group-chat                 "Bli med i offentlig chat"
@@ -172,9 +155,6 @@
    :remove-from-group                     "Fjern fra gruppen"
    :edit-contacts                         "Rediger kontakter"
    :search-contacts                       "Søk kontakter"
-   :show-all                              "VIS ALLE"
-   :contacts-group-dapps                  "ÐApps"
-   :contacts-group-people                 "Folk"
    :contacts-group-new-chat               "Start ny chat"
    :choose-from-contacts                  "Velg fra kontaker"
    :no-contacts                           "Ingen kontaker enda"
@@ -186,36 +166,17 @@
    :remove                                "Fjern"
    :save                                  "Lagre"
    :delete                                "Slett"
-   :change-color                          "Endre farge"
    :clear-history                         "Fjern historikk"
 
    :mute-notifications                    "Demp notifikasjoner"
 
    :leave-chat                            "Forlat chat"
-   :delete-and-leave                      "Slett og forlat"
    :chat-settings                         "Chat instillinger"
    :edit                                  "Rediger"
    :add-members                           "Legg til medlemmer"
-   :blue                                  "Blå"
-   :purple                                "Lilla"
-   :green                                 "Grønn"
-   :red                                   "Rød"
 
    ;commands
-   :money-command-description             "Send penger"
-   :location-command-description          "Send posisjon"
-   :phone-command-description             "Send telefonnummer"
-   :phone-request-text                    "Etterspør telefonnummer"
-   :confirmation-code-command-description "Send bekreftelseskode"
-   :confirmation-code-request-text        "Etterspør befkreftelseskode"
-   :send-command-description              "Send kommando"
-   :request-command-description           "Send forespørsel"
-   :keypair-password-command-description  ""
-   :help-command-description              "Hjelp"
-   :request                               "Forespørsel"
    :chat-send-eth                         "{{amount}} ETH"
-   :chat-send-eth-to                      "{{amount}} ETH til {{chat-name}}"
-   :chat-send-eth-from                    "{{amount}} ETH fra {{chat-name}}"
 
    ;location command
    :your-current-location                 "Din nåværende posisjon"
@@ -228,23 +189,16 @@
    :sharing-copy-to-clipboard-coordinates "Kopier koordinater"
 
    ;new-group
-   :group-chat-name                       "Chat navn"
-   :empty-group-chat-name                 "Skriv et navn"
-   :illegal-group-chat-name               "Vennligst velg et annet navn"
    :new-group                             "Ny gruppe"
    :reorder-groups                        "Organiser grupper"
-   :group-name                            "Gruppenavn"
    :edit-group                            "Rediger gruppe"
    :delete-group                          "Slett gruppe"
    :delete-group-confirmation             "Denne slettes fra gruppen, men vil fortsatt være tilgjengelig fra kontakter"
    :delete-group-prompt                   "Dette vil ikke affektere kontakter"
-   :group-members                         "Gruppemedlemmer"
    :contact-s                             {:one   "kontakt"
                                            :other "kontaker"}
 
    ;participants
-   :add-participants                      "Legg til deltager"
-   :remove-participants                   "Fjern deltager"
 
    ;protocol
    :received-invitation                   "Motatt chat-invitasjon"
@@ -256,13 +210,9 @@
 
    ;new-contact
    :add-new-contact                       "Legg til ny kontakt"
-   :import-qr                             "Importer"
    :scan-qr                               "Skan QR-kode"
-   :swow-qr                               "Vis QR-kode"
    :name                                  "Navn"
-   :whisper-identity                      "Hvisk identiteten"
    :address-explication                   "Her bør det kanskje være tekst som forklarer hva en adresse er og hvor du finner den"
-   :enter-valid-address                   "Skriv en adresse eller skan en QR-kode"
    :enter-valid-public-key                "Skriv en offentlig nøkkel eller skan en QR-kode"
    :contact-already-added                 "Kontakten er allerede i kontaktlisten"
    :can-not-add-yourself                  "Du kan ikke legge til deg selv"
@@ -272,23 +222,17 @@
    :connect                               "Koble til"
    :address                               "Adresse"
    :password                              "Passord"
-   :login                                 "Logg på"
    :sign-in-to-status                     "Logg på Status"
    :sign-in                               "Logg på"
    :wrong-password                        "Feil passord"
 
    ;recover
-   :recover-from-passphrase               "Gjenopprett fra passordfrase"
-   :recover-explain                       "Vennligst skriv din passordfrase for å gjenopprette tilgang"
    :passphrase                            "Passordfrase"
    :recover                               "Gjenopprett"
-   :enter-valid-passphrase                "Vennligst skriv passordfrase"
-   :enter-valid-password                  "Vennligst skriv passord"
    :twelve-words-in-correct-order         "12 ord i riktig rekkefølge"
 
    ;accounts
    :recover-access                        "Få tilbake tilgang"
-   :add-account                           "Legg til konto"
    :create-new-account                    "Opprett konto"
 
    ;wallet-qr-code
@@ -297,33 +241,16 @@
    ;validation
    :invalid-phone                         "Feil telefonnummer"
    :amount                                "Beløp"
-   :not-enough-eth                        (str "Du har ikke nok ETH på kontoen ({{balance}} ETH)")
 
    ;transactions
    :confirm                               "Bekreft"
-   :confirm-transactions                  {:one   "Bekreft transaksjon"
-                                           :other "Bekreft {{count}} transaksjon"
-                                           :zero  "Ingen transaksjoner"}
-   :transactions-confirmed                {:one   "Transaksjon bekreftet"
-                                           :other "{{count}} transaksjoner bekreftet"
-                                           :zero  "Ingen transaksjoner bekreftet"}
    :transaction                           "Transaksjon"
-   :unsigned-transactions                 "Usigner transaksjon"
-   :no-unsigned-transactions              "Ingen usignerte transaksjoner"
-   :enter-password-transactions           {:one   "Bekreft transaksjon ved å skrive passord"
-                                           :other "Bekreft transaksjon ved å skrive passord"}
    :status                                "Status"
-   :pending-confirmation                  "Venter på bekreftelse"
    :recipient                             "Mottager"
-   :one-more-item                         "En artikkel til"
-   :fee                                   "Avgift"
-   :estimated-fee                         "Estimert avgift"
-   :value                                 "Verdi"
    :to                                    "Til"
    :from                                  "Fra"
    :data                                  "Data"
    :got-it                                "Mottatt"
-   :contract-creation                     "Kontrakt opprettelse"
 
    ;:webview
    :web-view-error                        "oops, feil"
@@ -348,8 +275,6 @@
    :transactions                          "Transaksjoner"
    :transactions-sign                     "Signer"
    :transactions-sign-all                 "Signer alle"
-   :transactions-sign-all-text            "Signer transaksjonen ved å bruke ditt passord.\nSjekk at ordene ovenfor passer med din hemmlige signeringsfrase"
-   :transactions-sign-input-placeholder   "Skriv passordfrase"
    :transactions-history                  "Historikk"
    :transactions-unsigned                 "Usignert"
    :transactions-history-empty            "Du har ingen tidligere transaksjoner"

--- a/src/status_im/translations/ne.cljs
+++ b/src/status_im/translations/ne.cljs
@@ -19,11 +19,7 @@
    :photos-access-error                   "कृपया फोटो उपयोग गर्न आवश्यक अनुमति प्रदान गर्न, सिस्टम सेटिङ्ग भित्र गएर स्टेटस > फोटो चयन भएको स्थिति निश्चित गर्नुहोस् ।"
 
    ;;drawer
-   :invite-friends                        "साथीहरुलाई निम्त्याऔं"
-   :faq                                   "प्राय सोधिने प्रश्नोत्तर"
    :switch-users                          "उपयोगकर्ता बदलौं"
-   :feedback                              "प्रतिक्रिया"
-   :view-all                              "सबै हेर्ने"
    :current-network                       "चल्ती नेटवर्क"
 
    ;;chat
@@ -69,7 +65,6 @@
                                            :other "घण्टा"}
    :datetime-day                          {:one   "दिन"
                                            :other "दिन"}
-   :datetime-multiple                     "से"
    :datetime-ago                          "पहिले"
    :datetime-yesterday                    "हिजो"
    :datetime-today                        "आज"
@@ -77,13 +72,10 @@
    ;;profile
    :profile                               "प्रोफाइल"
    :edit-profile                          "प्रोफाइल सम्पादन"
-   :report-user                           "उपयोगकर्ताबारे उजुरी पठाउनुहोस्"
    :message                               "सन्देश"
-   :username                              "उपयोगकर्ता नाम"
    :not-specified                         "नतोकिएको"
    :public-key                            "सार्वजनिक सांचो"
    :phone-number                          "फोन नम्बर"
-   :email                                 "इमेल"
    :update-status                         "तपाईंको स्टेटस अद्यतन गर्नुहोस् ॰॰॰"
    :add-a-status                          "नया स्टेटस जोड्नुहोस् ॰॰॰"
    :status-prompt                         "एउटा स्टेटस बनाउनुहोस् जसद्वारा तपांईले प्रस्ताव गर्नुभएको कुराहरु अरुहरुले थाहापाउन मद्दत पुगोस । तपांईले #ह्यास्ट्याग पनि प्रयोग गर्न सक्नुहुन्छ ।"
@@ -92,15 +84,11 @@
    :remove-from-contacts                  "सम्पर्कहरुबाट हटाउनुहोस्"
    :start-conversation                    "कुराकानी सुरु गर्नुहोस्"
    :send-transaction                      "कारोबार पठाउनुहोस्"
-   :share-qr                              "QR बांड्नुहोस"
-   :error-incorrect-name                  "कृपया अरुनै नाम चयन गर्नुहोस्"
-   :error-incorrect-email                 "इमेल मिलेन"
 
    ;;make_photo
    :image-source-title                    "प्रोफाइल तस्विर"
    :image-source-make-photo               "खिच्नुहोस"
    :image-source-gallery                  "ग्यालेरीबाट चयन गर्नुहोस्"
-   :image-source-cancel                   "रद्द गर्नुहोस्"
 
    ;;sharing
    :sharing-copy-to-clipboard             "क्लिप्बोर्डमा प्रतिलिपि राख्नुहोस्"
@@ -108,7 +96,6 @@
    :sharing-cancel                        "रद्द गर्नुहोस्"
 
    :browsing-title                        "ब्राउज"
-   :browsing-browse                       "@ब्राउज"
    :browsing-open-in-web-browser          "वेब ब्राउजरमा खोल्ने"
    :browsing-cancel                       "रद्द गर्नुहोस्"
 
@@ -117,11 +104,8 @@
    :confirmation-code                     (str "धन्यवाद! हामीले तपाईंलाई पुष्टि कोड सहितको सन्देश पठाएका छौं । "
                                                "कृपया आफ्नो फोन नम्बर पुष्टि गर्न त्यो कोड प्रस्तुत गर्नुहोस् ।")
    :incorrect-code                        (str "माफ गर्नुहोस्, त्यो कोड गलत रहेछ, कृपया पुनः प्रविष्ट गर्नुहोस्")
-   :generate-passphrase                   (str "तपाईंकोलागि म एउट गुप्तवाक्यांश उन्पन्न गर्छु, ताकि तपाईंले आफ्नो "
-                                               "पहुँच पुनर्स्थापना गर्न सक्नुहुन्छ, अथवा अर्को यन्त्रबाट लग इन गर्न सक्नुहुन्छ ।")
    :phew-here-is-your-passphrase          "*उफऽऽऽ* त्यो कठिन थियो, तपाईंको गुप्तवाक्यांश प्रस्तुत छ, *यसलाई लेखेर सुरक्षित राख्नुहोस्* आफ्नो खाता पुनर्स्थापना गर्न यो अति आवश्यक छ ।"
    :here-is-your-passphrase               "तपाईंको गुप्तवाक्यांश प्रस्तुत छ, *यसलाई लेखेर सुरक्षित राख्नुहोस्* आफ्नो खाता पुनर्स्थापना गर्न यो अति आवश्यक छ ।"
-   :written-down                          "निश्चित गर्नुहोस् कि तपाईंले त्यो सुरक्षित हिसाबले लेखेर राख्नुभयो ।"
    :phone-number-required                 "यहाँ ट्याप गरेर तपाईंको फोन नम्बर प्रविष्ट गर्नुहोस् अनि म तपाईंको साथीहरु भेट्टाइ दिन्छु ।"
    :shake-your-phone                      "त्रुटि फेलापार्नुभयो, अथवा सुझाव दिनु छ? बस फोन ~हल्लाउनुहोस्~!"
    :intro-status                          "तपाईंको खाता सेटअप गर्न र सेटिङ्ग बदल्नको लागि म सँग च्याट गर्नुहोस् ।"
@@ -138,7 +122,6 @@
 
    ;;chats
    :chats                                 "च्याटहरु"
-   :new-chat                              "नया च्याट"
    :delete-chat                           "च्याट मेटाउने"
    :new-group-chat                        "नया सामूहिक च्याट"
    :new-public-group-chat                 "सार्वजनिक च्याटमा भाग लिने"
@@ -168,9 +151,6 @@
    :remove-from-group                     "समूह बाट हटाउने"
    :edit-contacts                         "सम्पर्क सम्पादन"
    :search-contacts                       "सम्पर्कहरुमा खोज"
-   :show-all                              "सबै देखाउने"
-   :contacts-group-dapps                  "डीएयापहरु"
-   :contacts-group-people                 "मानिसहरु"
    :contacts-group-new-chat               "नया च्याट सुरु"
    :choose-from-contacts                  "सम्पर्कहरुबाट चयन गर्नुहोस्"
    :no-contacts                           "हाल कुनै सम्पर्कहरु छैनन्"
@@ -182,53 +162,27 @@
    :remove                                "हटाउनुहोस्"
    :save                                  "साँच्नुहोस्"
    :delete                                "मेटाउनुहोस्"
-   :change-color                          "रंग बदल्नुहोस्"
    :clear-history                         "इतिहास खाली गर्नुहोस्"
    :mute-notifications                    "सूचनाहरु मौन बनाउनुहोस्"
    :leave-chat                            "च्याटबाट बाहिरिनुहोस्"
-   :delete-and-leave                      "मेटाउनुहोस् अनि बाहिरिनुहोस्"
    :chat-settings                         "च्याट सेटिङ्गहरु"
    :edit                                  "सम्पादन"
    :add-members                           "सदस्यहरु जोड्नुहोस्"
-   :blue                                  "नीलो"
-   :purple                                "बैजनी"
-   :green                                 "हरियो"
-   :red                                   "रातो"
 
    ;;commands
-   :money-command-description             "पैसा पठाउनुहोस्"
-   :location-command-description          "स्थान पठाउनुहोस्"
-   :phone-command-description             "फोन नम्बर पठाउनुहोस्"
-   :phone-request-text                    "फोन नम्बर अनुरोध"
-   :confirmation-code-command-description "पुष्टि कोड पठाउनुहोस्"
-   :confirmation-code-request-text        "पुष्टि कोड अनुरोध"
-   :send-command-description              "स्थान पठाउनुहोस्"
-   :request-command-description           "अनुरोध पठाउनुहोस्"
-   :keypair-password-command-description  ""
-   :help-command-description              "मदत"
-   :request                               "अनुरोध"
    :chat-send-eth                         "{{amount}} ETH"
-   :chat-send-eth-to                      "{{amount}} ETH तर्फ {{chat-name}}"
-   :chat-send-eth-from                    "{{amount}} ETH बाट {{chat-name}}"
 
    ;;new-group
-   :group-chat-name                       "च्याट नाम"
-   :empty-group-chat-name                 "कृपया नाम प्रविष्ट गर्नुहोस्"
-   :illegal-group-chat-name               "कृपया अन्यै नाम चयन गर्नुहोस्"
    :new-group                             "नया समूह"
    :reorder-groups                        "समूह पुन: क्रमबद्ध गर्नुहोस्"
-   :group-name                            "समूह नाम"
    :edit-group                            "समूह सम्पादन"
    :delete-group                          "समूह मेटाउनुहोस्"
    :delete-group-confirmation             "यो समूह तपाईंको समूहहरुबाट हटाइने छ । यसले सम्पर्कहरुमा असर गर्दैन ।"
    :delete-group-prompt                   "यसले सम्पर्कहरुमा असर गर्दैन ।"
-   :group-members                         "समूहको सदस्यहरु"
    :contact-s                             {:one   "सम्पर्क"
                                            :other "सम्पर्कहरु"}
 
    ;;participants
-   :add-participants                      "सहभागीहरु जोड्नुहोस्"
-   :remove-participants                   "सहभागीहरु हटाउनुहोस्"
 
    ;;protocol
    :received-invitation                   "च्याट निमन्त्रणा पाइयो"
@@ -240,13 +194,9 @@
 
    ;;new-contact
    :add-new-contact                       "नया सम्पर्क जोड्नुहोस्"
-   :import-qr                             "आयात गर्नुहोस्"
    :scan-qr                               "QR स्क्यान गर्नुहोस्"
-   :swow-qr                               "QR देखाउनुहोस्"
    :name                                  "नाम"
-   :whisper-identity                      "व्हिस्पर पहिचान"
    :address-explication                   "सायद यहां ठेगाना बारे बयान गर्ने अनि त्यो कहाँ खोज्ने भन्ने कुराको कुनै पाठ हुनुपर्छ ।"
-   :enter-valid-address                   "कृपया एक मान्य ठेगाना प्रविष्ट गर्नुहोस् वा QR कोड स्क्यान गर्नुहोस्"
    :enter-valid-public-key                "कृपया एक मान्य सार्वजनिक सांचो प्रविष्ट गर्नुहोस् वा QR कोड स्क्यान गर्नुहोस् "
    :contact-already-added                 "यो सम्पर्क पहिल्यै जोडीसकिएको छ"
    :can-not-add-yourself                  "आफुले आफुलाइनै जोड्न मिल्दैन"
@@ -256,23 +206,17 @@
    :connect                               "कनेक्ट"
    :address                               "ठेगाना"
    :password                              "पासवर्ड"
-   :login                                 "लगइन"
    :sign-in-to-status                     "स्टेटसमा साइन-इन गर्नुहोस्"
    :sign-in                               "साइन-इन"
    :wrong-password                        "गलत पासवर्ड"
 
    ;;recover
-   :recover-from-passphrase               "गुप्तवाक्यांश मार्फत पुनर्स्थापना गर्नुहोस्"
-   :recover-explain                       "कृपया तपाईंको पहुँच पुनर्स्थापना गर्नको लागि पासवर्डको गुप्तवाक्यांश प्रविष्ट गर्नुहोस्"
    :passphrase                            "गुप्तवाक्यांश"
    :recover                               "पुनर्स्थापना"
-   :enter-valid-passphrase                "कृपया गुप्तवाक्यांश प्रविष्ट गर्नुहोस्"
-   :enter-valid-password                  "कृपया पासवर्ड प्रविष्ट गर्नुहोस्"
    :twelve-words-in-correct-order         "१२ सब्दहरु सही क्रममा"
 
    ;;accounts
    :recover-access                        "पहुँच पुनर्स्थापना गर्नुहोस्"
-   :add-account                           "खाता जोड्नुहोस्"
    :create-new-account                    "नया खाता सिर्जना गर्नुहोस्"
 
    ;;wallet-qr-code
@@ -282,34 +226,16 @@
    ;;validation
    :invalid-phone                         "नमिल्ने फोन नम्बर"
    :amount                                "रकम"
-   :not-enough-eth                        (str "ब्यालेन्समा अपर्याप्त ETH "
-                                               "({{balance}} ETH)")
 
    ;;transactions
    :confirm                               "पुष्टि गर्नुहोस्"
-   :confirm-transactions                  {:one   "कारोबार पुष्टि गर्नुहोस्"
-                                           :other "{{count}} कारोबारहरु पुष्टि गर्नुहोस्"
-                                           :zero  "कुनै कारोबारहरु छैनन्"}
-   :transactions-confirmed                {:one   "कारोबार पुष्टि भयो"
-                                           :other "{{count}} कारोबारहरु पुष्टि भए"
-                                           :zero  "कुनैपनि कारोबारहरु पुष्टि भएका छैन"}
    :transaction                           "कारोबार"
-   :unsigned-transactions                 "हस्ताक्षर नभएका कारोबारहरु"
-   :no-unsigned-transactions              "हस्ताक्षर नभएका कारोबारहरु छैनन्"
-   :enter-password-transactions           {:one   "तपाईंको पास्वर्ड प्रविष्ट गरेर कारोबार पुष्टि गर्नुहोस्"
-                                           :other "तपाईंको पास्वर्ड प्रविष्ट गरेर कारोबारहरु पुष्टि गर्नुहोस्"}
    :status                                "स्टेटस"
-   :pending-confirmation                  "बांकि पुष्टिकरण"
    :recipient                             "प्रापक"
-   :one-more-item                         "एउटा अरु आइटम"
-   :fee                                   "शुल्क"
-   :estimated-fee                         "अनुमानित शुल्क"
-   :value                                 "मूल्य"
    :to                                    "तर्फ"
    :from                                  "बाट"
    :data                                  "डाटा"
    :got-it                                "पाइयो"
-   :contract-creation                     "सम्झौता सिर्जना"
 
    ;;webview
    :web-view-error                        "ओहोऽऽऽ, त्रुटि"})

--- a/src/status_im/translations/nl.cljs
+++ b/src/status_im/translations/nl.cljs
@@ -19,11 +19,7 @@
    :photos-access-error                   "Om fototoegang te geven, ga je naar systeem instellingen en zorg je dat Status > Foto's geselecteerd is."
 
    ;drawer
-   :invite-friends                        "Nodig vrienden uit"
-   :faq                                   "FAQ"
    :switch-users                          "Schakel tussen gebruikers"
-   :feedback                              "Heb je feedback?\nSchud je telefoon!"
-   :view-all                              "Laat alles zien"
    :current-network                       "Huidige netwerk"
 
    ;chat
@@ -67,7 +63,6 @@
                                            :other "uren"}
    :datetime-day                          {:one   "dag"
                                            :other "dagen"}
-   :datetime-multiple                     "s"
    :datetime-ago                          "geleden"
    :datetime-yesterday                    "gisteren"
    :datetime-today                        "vandaag"
@@ -75,13 +70,10 @@
    ;profile
    :profile                               "Profiel"
    :edit-profile                          "Bewerk profiel"
-   :report-user                           "MELD GEBRUIKER"
    :message                               "Bericht"
-   :username                              "Gebruikersnaam"
    :not-specified                         "Niet opgegeven"
    :public-key                            "Openbare sleutel"
    :phone-number                          "Telefoonnummer"
-   :email                                 "E-mailadres"
    :update-status                         "Wijzig je status..."
    :add-a-status                          "Voeg een status toe..."
    :status-prompt                         "Maak een status aan om mensen te laten weten wat je te bieden hebt. Je kan ook #hashtags gebruiken."
@@ -90,15 +82,11 @@
    :remove-from-contacts                  "Remove from contacts"
    :start-conversation                    "Begin een gesprek"
    :send-transaction                      "Verstuur een transactie"
-   :share-qr                              "Deel de QR"
-   :error-incorrect-name                  "Kies een andere naam"
-   :error-incorrect-email                 "Onjuist e-mailadres"
 
    ;;make_photo
    :image-source-title                    "Profielfoto"
    :image-source-make-photo               "Foto nemen"
    :image-source-gallery                  "Kies uit galerij"
-   :image-source-cancel                   "Annuleren"
 
    ;;sharing
    :sharing-copy-to-clipboard             "Kopieer naar klembord"
@@ -114,11 +102,8 @@
    :confirmation-code                     (str "Bedankt! We hebben je een sms gestuurd met een bevestigingscode"
                                                ". Geef die code op om jouw telefoonnummer te bevestigen")
    :incorrect-code                        (str "Sorry, de code was onjuist, voer hem opnieuw in")
-   :generate-passphrase                   (str "Ik zal een wachtzin maken, zodat je jouw"
-                                               "toegang kunt herstellen of vanaf een ander apparaat kunt inloggen")
    :phew-here-is-your-passphrase          "*Foei* dat was moeilijk, hier is jouw wachtzin, *schrijf deze op en bewaar hem goed!* Je zult hem nodig hebben om jouw account te herstellen."
    :here-is-your-passphrase               "Hier is jouw wachtzin, *schrijf deze op en bewaar hem goed!* Je zult hem nodig hebben om jouw account te herstellen."
-   :written-down                          "Zorg ervoor dat je hem veilig hebt opgeschreven"
    :phone-number-required                 "Tik hier om je telefoonnummer in te voeren, dan zoek ik jouw vrienden"
    :shake-your-phone                      "Bug gevonden, of heb je een suggestie? ~Schud~ je telefoon!"
    :intro-status                          "Chat met me om jouw account in te stellen en jouw instellingen te wijzigen!"
@@ -135,7 +120,6 @@
 
    ;chats
    :chats                                 "Chats"
-   :new-chat                              "Nieuwe chat"
    :delete-chat                           "Verwijder chat"
    :new-group-chat                        "Nieuwe groepchat"
    :new-public-group-chat                 "Neem deel in publieke chat"
@@ -165,9 +149,6 @@
    :remove-from-group                     "Remove from group"
    :edit-contacts                         "Edit contacts"
    :search-contacts                       "Search contacts"
-   :show-all                              "TOON ALLES"
-   :contacts-group-dapps                  "ÐApps"
-   :contacts-group-people                 "Mensen"
    :contacts-group-new-chat               "Start nieuwe chat"
    :choose-from-contacts                  "Choose from contacts"
    :no-contacts                           "Nog geen contactpersonen"
@@ -179,53 +160,27 @@
    :remove                                "Verwijderen"
    :save                                  "Opslaan"
    :delete                                "Delete"
-   :change-color                          "Wijzig kleur"
    :clear-history                         "Wis geschiedenis"
    :mute-notifications                    "Stille notificaties"
    :leave-chat                            "Verlaat chat"
-   :delete-and-leave                      "Verwijderen en verlaten"
    :chat-settings                         "Chatinstellingen"
    :edit                                  "Bewerken"
    :add-members                           "Voeg leden toe"
-   :blue                                  "Blauw"
-   :purple                                "Paars"
-   :green                                 "Groen"
-   :red                                   "Rood"
 
    ;commands
-   :money-command-description             "Stuur geld"
-   :location-command-description          "Stuur locatie"
-   :phone-command-description             "Stuur telefoonnummer"
-   :phone-request-text                    "Telefoonnummer aanvraag"
-   :confirmation-code-command-description "Stuur bevestigingscode"
-   :confirmation-code-request-text        "Bevestigingscode aanvraag"
-   :send-command-description              "Stuur locatie"
-   :request-command-description           "Stuur aanvraag"
-   :keypair-password-command-description  ""
-   :help-command-description              "Help"
-   :request                               "Aanvraag"
    :chat-send-eth                         "{{amount}} ETH"
-   :chat-send-eth-to                      "{{amount}} ETH naar {{chat-name}}"
-   :chat-send-eth-from                    "{{amount}} ETH van {{chat-name}}"
 
    ;new-group
-   :group-chat-name                       "Chatnaam"
-   :empty-group-chat-name                 "Voer een naam in"
-   :illegal-group-chat-name               "Kies een andere naam"
    :new-group                             "Nieuwe groep"
    :reorder-groups                        "Hergroepeer groep"
-   :group-name                            "Groepsnaam"
    :edit-group                            "Bewerk groep"
    :delete-group                          "Verwijder groep"
    :delete-group-confirmation             "Deze groep zal worden verwijderd van jouw groepen. Dit heeft geen effect op je contacten."
    :delete-group-prompt                   "This will not affect contacts"
-   :group-members                         "Groepsleden"
    :contact-s                             {:one   "contact"
                                            :other "contacten"}
 
    ;participants
-   :add-participants                      "Voeg deelnemers toe"
-   :remove-participants                   "Verwijder deelnemers"
 
    ;protocol
    :received-invitation                   "ontving chatuitnodiging"
@@ -237,13 +192,9 @@
 
    ;new-contact
    :add-new-contact                       "Voeg nieuwe contactpersoon toe"
-   :import-qr                             "Importeren"
    :scan-qr                               "QR scannen"
-   :swow-qr                               "QR weergeven"
    :name                                  "Naam"
-   :whisper-identity                      "Fluister identiteit"
    :address-explication                   "Misschien zou hier wat tekst moeten staan waarin wordt uitgelegd wat een adres is en waar je deze kunt vinden"
-   :enter-valid-address                   "Voer een geldig adres in of scan een QR-code"
    :enter-valid-public-key                "Voer een geldig publieke sleutel in of scan een QR code"
    :contact-already-added                 "De contactpersoon is al toegevoegd"
    :can-not-add-yourself                  "Je kunt niet zelf toevoegen"
@@ -253,23 +204,17 @@
    :connect                               "Verbinden"
    :address                               "Adres"
    :password                              "Wachtwoord"
-   :login                                 "Inloggen"
    :sign-in-to-status                     "Meld u aan bij Status"
    :sign-in                               "Meld aan"
    :wrong-password                        "Verkeerd wachtwoord"
 
    ;recover
-   :recover-from-passphrase               "Herstellen met wachtzin"
-   :recover-explain                       "Voer de wachtzin in voor jouw wachtwoord om toegang te herstellen"
    :passphrase                            "Wachtzin"
    :recover                               "Herstellen"
-   :enter-valid-passphrase                "Voer een wachtzin in"
-   :enter-valid-password                  "Voer een wachtwoord in"
    :twelve-words-in-correct-order         "12 woorden in goede volgorde"
 
    ;accounts
    :recover-access                        "Toegang herstellen"
-   :add-account                           "Voeg account toe"
    :create-new-account                    "Maake een nieuwe account aan"
 
    ;wallet-qr-code
@@ -279,34 +224,16 @@
    ;validation
    :invalid-phone                         "Ongeldig telefoonnummer"
    :amount                                "Bedrag"
-   :not-enough-eth                        (str "Niet genoeg ETH op saldo"
-                                               "({{balance}} ETH)")
 
    ;transactions
    :confirm                               "Bevestigen"
-   :confirm-transactions                  {:one   "Bevestig transactie"
-                                           :other "Bevestig {{count}} transacties"
-                                           :zero  "Geen transacties"}
-   :transactions-confirmed                {:one   "Transactie bevestigd"
-                                           :other "{{count}} transacties bevestigd"
-                                           :zero  "Geen transacties bevestigd"}
    :transaction                           "Transactie"
-   :unsigned-transactions                 "Ongetekend transacties"
-   :no-unsigned-transactions              "Geen ongetekende transacties"
-   :enter-password-transactions           {:one   "Bevetig de transactie door je wachtwoord in te voeren"
-                                           :other "Bevetig de transacties door je wachtwoord in te voeren"}
    :status                                "Status"
-   :pending-confirmation                  "In afwachting van bevestiging"
    :recipient                             "Ontvanger"
-   :one-more-item                         "Nog één item"
-   :fee                                   "Kosten"
-   :estimated-fee                         "Geschatte kosten"
-   :value                                 "Waarde"
    :to                                    "Naar"
    :from                                  "Van"
    :data                                  "Data"
    :got-it                                "Got it"
-   :contract-creation                     "Contract Aanmaak"
 
    ;:webview
    :web-view-error                        "oeps, fout"

--- a/src/status_im/translations/pl.cljs
+++ b/src/status_im/translations/pl.cljs
@@ -10,8 +10,6 @@
    :offline                               "Offline"
 
    ;drawer
-   :invite-friends                        "Zaproś znajomych"
-   :faq                                   "FAQ"
    :switch-users                          "Przełącz użytkowników"
 
    ;chat
@@ -53,41 +51,30 @@
                                            :other "godziny(y)"}
    :datetime-day                          {:one   "dzień"
                                            :other "dni"}
-   :datetime-multiple                     "s"
    :datetime-ago                          "temu"
    :datetime-yesterday                    "wczoraj"
    :datetime-today                        "dzisiaj"
 
    ;profile
    :profile                               "Profil"
-   :report-user                           "ZGŁOŚ UŻYTOWNIKA"
    :message                               "Wiadomość"
-   :username                              "Nazwa użytkownika"
    :not-specified                         "Nie określono"
    :public-key                            "Klucz publiczny"
    :phone-number                          "Numer telefonu "
-   :email                                 "E-mail"
-   :profile-no-status                     "Brak statusu"
    :add-to-contacts                       "Dodaj do kontaktów"
-   :error-incorrect-name                  "Wybierz inną nazwę "
-   :error-incorrect-email                 "Nieprawidłowy e-mail"
 
    ;;make_photo
    :image-source-title                    "Zdjęcie profilowe "
    :image-source-make-photo               "Przechwyć"
    :image-source-gallery                  "Wybierz z galerii "
-   :image-source-cancel                   "Anuluj"
 
    ;sign-up
    :contacts-syncronized                  "Twoje kontakty zostały zsynchronizowane"
    :confirmation-code                     (str "Dziękujemy! Wysłaliśmy ci SMS-a z kodem"
                                                "potwierdzającym. Prosimy o podanie kodu w celu zweryfikowania swojego numeru telefonu")
    :incorrect-code                        (str "Przepraszamy, kod jest nieprawidłowy. Prosimy wprowadzić kod ponownie")
-   :generate-passphrase                   (str "Wygenerujemy specjalne hasło, dzięki któremu będzie można przywrócić "
-                                               "dostęp lub zalogować się z innego urządzenia")
    :phew-here-is-your-passphrase          "*Uff*, to nie było łatwe. Oto twoje specjalne hasło, *zapisz je i	 przechowuj w bezpiecznym miejscu!* Będzie ci potrzebne podczas procedury odzyskiwania konta."
    :here-is-your-passphrase               "Oto twoje specjalne hasło, *zapisz je i przechowuj w bezpiecznym miejscu!* Będzie ci potrzebne podczas procedury odzyskiwania konta."
-   :written-down                          "Upewnij się, że je zapisałeś i przechowujesz w bezpiecznym miejscu"
    :phone-number-required                 "Dotknij tutaj, aby wprowadzić swój numer telefonu, a my znajdziemy twoich znajomych "
    :intro-status                          "Porozmawiaj ze mną na czacie, aby skonfigurować swoje konto i zmienić ustawienia!"
    :intro-message1                        "Witamy w sekcji Status\nWybierz tę wiadomość, aby ustawić hasło i rozpocząć!"
@@ -95,7 +82,6 @@
 
    ;chats
    :chats                                 "Czaty"
-   :new-chat                              "Nowy czat"
    :new-group-chat                        "Nowy czat grupowy"
 
    ;discover
@@ -112,9 +98,6 @@
    ;contacts
    :contacts                              "Kontakty"
    :new-contact                           "Nowy kontakt"
-   :show-all                              "POKAŻ WSZYSTKIE"
-   :contacts-group-dapps                  "ÐApps"
-   :contacts-group-people                 "Ludzie"
    :contacts-group-new-chat               "Rozpocznij nowy czat"
    :no-contacts                           "W tej chwili brak kontaktów"
    :show-qr                               "Pokaż QR"
@@ -122,41 +105,17 @@
    ;group-settings
    :remove                                "Usuń"
    :save                                  "Zapisz"
-   :change-color                          "Zmień kolor"
    :clear-history                         "Wyczyść historię"
-   :delete-and-leave                      "Usuń i wyjdź"
    :chat-settings                         "Ustawienia czatu"
    :edit                                  "Edytuj"
    :add-members                           "Dodaj użytkowników"
-   :blue                                  "Niebieski"
-   :purple                                "Fioletowy"
-   :green                                 "Zielony"
-   :red                                   "Czerwony"
 
    ;commands
-   :money-command-description             "Wyślij pieniądze"
-   :location-command-description          "Wyślij  lokalizację"
-   :phone-command-description             "Wyślij numer telefonu"
-   :phone-request-text                    "Prośba o numer telefonu"
-   :confirmation-code-command-description "Wyślij kod potwierdzający"
-   :confirmation-code-request-text        "Prośba o kod potwierdzający"
-   :send-command-description              "Wyślij lokalizację"
-   :request-command-description           "Wyślij prośbę"
-   :keypair-password-command-description  ""
-   :help-command-description              "Pomoc"
-   :request                               "Prośba"
    :chat-send-eth                         "{{amount}} ETH"
-   :chat-send-eth-to                      "{{amount}} ETH do {{chat-name}}"
-   :chat-send-eth-from                    "{{amount}} ETH od {{chat-name}}"
 
    ;new-group
-   :group-chat-name                       "Nazwa czatu"
-   :empty-group-chat-name                 "Wprowadź nazwę"
-   :illegal-group-chat-name               "Wybierz inną nazwę"
 
    ;participants
-   :add-participants                      "Dodaj uczestników"
-   :remove-participants                   "Usuń uczestników"
 
    ;protocol
    :received-invitation                   "otrzymano zaproszenie na czat"
@@ -168,12 +127,9 @@
 
    ;new-contact
    :add-new-contact                       "Dodaj nowy kontakt"
-   :import-qr                             "Importuj"
    :scan-qr                               "Skanuj QR"
    :name                                  "Nazwa"
-   :whisper-identity                      "Sekretna tożsamość"
    :address-explication                   "Być może tutaj powinien znajdować się tekst wyjaśniający, czym jest adres i gdzie go szukać"
-   :enter-valid-address                   "Wprowadź prawidłowy adres lub przeskanuj kod QR"
    :contact-already-added                 "Kontakt został już dodany"
    :can-not-add-yourself                  "Nie możesz dodać samego siebie"
    :unknown-address                       "Nieznany adres"
@@ -183,20 +139,14 @@
    :connect                               "Połącz"
    :address                               "Adres"
    :password                              "Hasło"
-   :login                                 "Login"
    :wrong-password                        "Nieprawidłowe hasło"
 
    ;recover
-   :recover-from-passphrase               "Odzyskaj na podstawie hasła specjalnego"
-   :recover-explain                       "Wprowadź hasło specjalne dla swojego hasła, aby odzyskać dostęp"
    :passphrase                            "Hasło specjalne"
    :recover                               "Odzyskaj"
-   :enter-valid-passphrase                "Wprowadź hasło specjalne"
-   :enter-valid-password                  "Wprowadź hasło"
 
    ;accounts
    :recover-access                        "Odzyskaj dostęp"
-   :add-account                           "Dodaj konto "
 
    ;wallet-qr-code
    :done                                  "Zrobione"
@@ -205,34 +155,20 @@
    ;validation
    :invalid-phone                         "Nieprawidłowy numer telefonu"
    :amount                                "Kwota"
-   :not-enough-eth                        (str "Brak ETH na koncie "
-                                               "({{balance}} ETH)")
    ;transactions
-   :confirm-transactions                  {:one   "Potwierdź transakcję"
-                                           :other "Potwierdź {{count}} transakcje(-i)"
-                                           :zero  "Brak transakcji"}
    :status                                "Status"
-   :pending-confirmation                  "Oczekuje na potwierdzenie"
    :recipient                             "Odbiorca"
-   :one-more-item                         "Dodatkowy element"
-   :fee                                   "Opłata"
-   :value                                 "Wartość"
 
    ;:webview
    :web-view-error                        "oj, mamy błąd"
 
    :confirm                               "Potwierdź"
    :phone-national                        "Krajowy"
-   :transactions-confirmed                {:one   "Potwierdzono transakcję"
-                                           :other "Potwierdzone transakcje: {{count}}"
-                                           :zero  "Brak potwierdzonych transakcji"}
    :public-group-topic                    "Temat"
    :debug-enabled                         "Uruchomiono serwer debugowania! Możesz teraz dodać program DApp, uruchamiając *status-dev-cli scan* na swoim komputerze"
    :new-public-group-chat                 "Dołącz do publicznego czatu"
    :datetime-ago-format                   "{{number}} {{time-intervals}} {{ago}}"
    :sharing-cancel                        "Anuluj"
-   :share-qr                              "Udostępnij QR"
-   :feedback                              "Chcesz przesłać opinię?\nPotrząśnij telefonem!"
    :twelve-words-in-correct-order         "12 słów w prawidłowym porządku"
    :remove-from-contacts                  "Usuń z kontaktów"
    :delete-chat                           "Usuń czat"
@@ -272,7 +208,6 @@
 
    :contact-s                             {:one   "kontakt"
                                            :other "kontakty"}
-   :group-name                            "Nazwa grupy"
    :next                                  "Dalej"
    :from                                  "Z"
    :search-chats                          "Przeszukaj czaty"
@@ -289,17 +224,11 @@
    :more                                  "więcej"
    :cancel                                "Anuluj"
    :no-statuses-found                     "Nie znaleziono statusów"
-   :swow-qr                               "Pokaż QR"
    :browsing-open-in-web-browser          "Otwórz w przeglądarce"
    :delete-group-prompt                   "To nie będzie miało wpływu na kontakty"
    :edit-profile                          "Edytuj profil"
 
 
-   :enter-password-transactions           {:one   "Potwierdź transakcję, wprowadzając hasło"
-                                           :other "Potwierdź transakcje, wprowadzając hasło"}
-   :unsigned-transactions                 "Nieautoryzowane transakcje"
    :empty-topic                           "Pusty temat"
    :to                                    "Do"
-   :group-members                         "Członkowie grupy"
-   :estimated-fee                         "Szacowana opłata"
    :data                                  "Dane"})

--- a/src/status_im/translations/pt_br.cljs
+++ b/src/status_im/translations/pt_br.cljs
@@ -10,8 +10,6 @@
    :offline                               "Offline"
 
    ;drawer
-   :invite-friends                        "Convidar amigos"
-   :faq                                   "Dúvidas frequentes"
    :switch-users                          "Trocar usuário"
 
    ;chat
@@ -53,41 +51,30 @@
                                            :other "horas"}
    :datetime-day                          {:one   "dia"
                                            :other "dias"}
-   :datetime-multiple                     "s"
    :datetime-ago                          "atrás"
    :datetime-yesterday                    "ontem"
    :datetime-today                        "hoje"
 
    ;profile
    :profile                               "Perfil"
-   :report-user                           "Denunciar usuário"
    :message                               "Mensagem"
-   :username                              "Nome de usuário"
    :not-specified                         "Não especificado"
    :public-key                            "Chave pública"
    :phone-number                          "Número de telefone"
-   :email                                 "E-mail"
-   :profile-no-status                     "Nenhum status"
    :add-to-contacts                       "Adicionar aos contatos"
-   :error-incorrect-name                  "Nome incorreto"
-   :error-incorrect-email                 "E-mail incorreto"
 
    ;;make_photo
    :image-source-title                    "Imagem do perfil"
    :image-source-make-photo               "Tirar foto"
    :image-source-gallery                  "Escolher na galeria"
-   :image-source-cancel                   "Cancelar"
 
    ;sign-up
    :contacts-syncronized                  "Seus contatos foram sincronizados"
    :confirmation-code                     (str "Obrigado! Nós lhe enviamos uma mensagem de texto com um código de "
                                                "confirmação. Por favor, informe esse código para confirmar seu número de telefone")
    :incorrect-code                        (str "Desculpe, o código estava incorreto. Por favor, digite novamente")
-   :generate-passphrase                   (str "Vou gerar uma frase secreta para você poder restaurar o seu "
-                                               "acesso ou entrar a partir de outro dispositivo")
    :phew-here-is-your-passphrase          "*Ufa* isso foi difícil. Aqui está a sua frase secreta. *Anote-a e guarde-a em segurança!* Você precisará dela para recuperar a sua conta."
    :here-is-your-passphrase               "Aqui está a sua frase secreta. *Anote-a e guarde-a em segurança!* Você precisará dela para recuperar a sua conta."
-   :written-down                          "Certifique-se de tê-la anotado em segurança"
    :phone-number-required                 "Toque aqui para inserir seu número de telefone e eu vou encontrar seus amigos"
    :intro-status                          "Converse comigo para configurar a sua conta e alterar suas definições!"
    :intro-message1                        "Bem-vindo ao Status\nToque nesta mensagem para definir sua senha e começar!"
@@ -95,7 +82,6 @@
 
    ;chats
    :chats                                 "Chats"
-   :new-chat                              "Novo chat"
    :new-group-chat                        "Novo grupo de chat"
 
    ;discover
@@ -112,9 +98,6 @@
    ;contacts
    :contacts                              "Contatos"
    :new-contact                           "Novo contato"
-   :show-all                              "Mostrar Todos"
-   :contacts-group-dapps                  "DApps"
-   :contacts-group-people                 "Pessoas"
    :contacts-group-new-chat               "Iniciar novo chat"
    :no-contacts                           "Você ainda não tem contatos"
    :show-qr                               "Mostrar QR"
@@ -122,41 +105,17 @@
    ;group-settings
    :remove                                "Remover"
    :save                                  "Salvar"
-   :change-color                          "Alterar cor"
    :clear-history                         "Apagar histórico"
-   :delete-and-leave                      "Excluir e sair"
    :chat-settings                         "Configurações do chat"
    :edit                                  "Editar"
    :add-members                           "Adicionar membros"
-   :blue                                  "Azul"
-   :purple                                "Roxo"
-   :green                                 "Verde"
-   :red                                   "Vermelho"
 
    ;commands
-   :money-command-description             "Enviar dinheiro"
-   :location-command-description          "Enviar localização"
-   :phone-command-description             "Enviar número de telefone"
-   :phone-request-text                    "Solicitação de número de telefone"
-   :confirmation-code-command-description "Enviar código de confirmação"
-   :confirmation-code-request-text        "Solicitação de código de confirmação"
-   :send-command-description              "Enviar localização"
-   :request-command-description           "Enviar solicitação"
-   :keypair-password-command-description  ""
-   :help-command-description              "Ajuda"
-   :request                               "Solicitar"
    :chat-send-eth                         "{{amount}} ETH"
-   :chat-send-eth-to                      "{{amount}} ETH para {{chat-name}}"
-   :chat-send-eth-from                    "{{amount}} ETH de {{chat-name}}"
 
    ;new-group
-   :group-chat-name                       "Nome do chat"
-   :empty-group-chat-name                 "Por favor, informe um nome"
-   :illegal-group-chat-name               "Por favor, selecione outro nome"
 
    ;participants
-   :add-participants                      "Adicionar participantes"
-   :remove-participants                   "Remover participantes"
 
    ;protocol
    :received-invitation                   "recebeu o convite para o chat"
@@ -168,12 +127,9 @@
 
    ;new-contact
    :add-new-contact                       "Adicionar novo contato"
-   :import-qr                             "Importar"
    :scan-qr                               "Escanear QR"
    :name                                  "Nome"
-   :whisper-identity                      "Identidade Whisper"
    :address-explication                   "Talvez aqui deveria haver algum texto explicando o que é um endereço e onde procurá-lo"
-   :enter-valid-address                   "Por favor, digite um endereço válido ou escaneie um código QR"
    :contact-already-added                 "O contato já foi adicionado"
    :can-not-add-yourself                  "Não é possível adicionar a si mesmo"
    :unknown-address                       "E-mail desconhecido"
@@ -183,20 +139,14 @@
    :connect                               "Conectar"
    :address                               "Endereço"
    :password                              "Senha"
-   :login                                 "Entrar"
    :wrong-password                        "Senha incorreta"
 
    ;recover
-   :recover-from-passphrase               "Recuperar a partir da frase secreta"
-   :recover-explain                       "Por favor, digite a frase secreta da sua senha para recuperar o acesso"
    :passphrase                            "Frase secreta"
    :recover                               "Recuperar"
-   :enter-valid-passphrase                "Por favor, digite uma frase secreta"
-   :enter-valid-password                  "Por favor, digite uma senha"
 
    ;accounts
    :recover-access                        "Recuperar o acesso"
-   :add-account                           "Adicionar conta"
 
    ;wallet-qr-code
    :done                                  "Concluído"
@@ -205,34 +155,20 @@
    ;validation
    :invalid-phone                         "Número de telefone inválido"
    :amount                                "Quantia"
-   :not-enough-eth                        (str "ETH insuficiente no saldo "
-                                               "({{balance}} ETH)")
    ;transactions
-   :confirm-transactions                  {:one   "Confirmar a transação"
-                                           :other "Confirmar {{count}} transações"
-                                           :zero  "Nenhuma transação"}
    :status                                "Status"
-   :pending-confirmation                  "Confirmação pendente"
    :recipient                             "Destinatário"
-   :one-more-item                         "Mais um item"
-   :fee                                   "Tarifa"
-   :value                                 "Valor"
 
    ;:webview
    :web-view-error                        "Ops, erro"
 
    :confirm                               "Confirmar"
    :phone-national                        "Nacional"
-   :transactions-confirmed                {:one   "Transação confirmada"
-                                           :other "{{count}} transações confirmadas"
-                                           :zero  "Nenhuma transação confirmada"}
    :public-group-topic                    "Assunto"
    :debug-enabled                         "O servidor de debug foi inicializado! Você agora pode adicionar seu DApp ao executar *status-dev-cli scan* a partir de seu computador."
    :new-public-group-chat                 "Juntar-se a bate-papo público."
    :datetime-ago-format                   "{{number}} {{time-intervals}} {{ago}}"
    :sharing-cancel                        "Cancelar"
-   :share-qr                              "Compartilhar QR"
-   :feedback                              "Tem comentários a fazer?\nAgite seu telefone!"
    :twelve-words-in-correct-order         "12 palavras na ordem correta"
    :remove-from-contacts                  "Remover dos contatos"
    :delete-chat                           "Excluir bate-papo"
@@ -272,7 +208,6 @@
 
    :contact-s                             {:one   "contato"
                                            :other "contatos"}
-   :group-name                            "Nome do grupo"
    :next                                  "Próximo"
    :from                                  "De"
    :search-chats                          "Buscar bate-papos"
@@ -289,17 +224,11 @@
    :more                                  "mais"
    :cancel                                "Cancelar"
    :no-statuses-found                     "Nenhum status encontrado"
-   :swow-qr                               "Exibir QR"
    :browsing-open-in-web-browser          "Abrir no navegador de internet"
    :delete-group-prompt                   "Isso não afetará os contatos"
    :edit-profile                          "Editar perfil"
 
 
-   :enter-password-transactions           {:one   "Confirme a transação ao inserir sua senha"
-                                           :other "Confirme as transações ao inserir sua senha"}
-   :unsigned-transactions                 "Transações não assinadas"
    :empty-topic                           "Assunto vazio"
    :to                                    "Para"
-   :group-members                         "Participantes do grupo"
-   :estimated-fee                         "Taxa estimada"
    :data                                  "Dados"})

--- a/src/status_im/translations/pt_pt.cljs
+++ b/src/status_im/translations/pt_pt.cljs
@@ -10,8 +10,6 @@
    :offline                               "Offline"
 
    ;drawer
-   :invite-friends                        "Convidar amigos"
-   :faq                                   "FAQ"
    :switch-users                          "Mudar de utilizadores"
 
    ;chat
@@ -53,41 +51,30 @@
                                            :other "horas"}
    :datetime-day                          {:one   "dia"
                                            :other "dias"}
-   :datetime-multiple                     "s"
    :datetime-ago                          "atrás"
    :datetime-yesterday                    "ontem"
    :datetime-today                        "hoje"
 
    ;profile
    :profile                               "Perfil"
-   :report-user                           "DENUNCIAR O UTILIZADOR"
    :message                               "Mensagem"
-   :username                              "Nome de utilizador"
    :not-specified                         "Não especificado"
    :public-key                            "Chave Pública"
    :phone-number                          "Número de telefone"
-   :email                                 "E-mail"
-   :profile-no-status                     "Sem estado"
    :add-to-contacts                       "Adicionar aos contactos"
-   :error-incorrect-name                  "Por favor, selecione outro nome"
-   :error-incorrect-email                 "E-mail incorreto"
 
    ;;make_photo
    :image-source-title                    "Imagem de perfil"
    :image-source-make-photo               "Capturar"
    :image-source-gallery                  "Selecionar a partir da galeria"
-   :image-source-cancel                   "Cancelar"
 
    ;sign-up
    :contacts-syncronized                  "Os seus contactos foram sincronizados"
    :confirmation-code                     (str "Obrigado! Enviámos-lhe uma mensagem de texto com um código de "
                                                "confirmação. Por favor, forneça esse código para confirmar o seu número de telefone")
    :incorrect-code                        (str "Desculpe, o código estava incorreto. Por favor, volte a digitar")
-   :generate-passphrase                   (str "Vou gerar uma frase-chave para si para poder recuperar o seu "
-                                               "acesso ou log in a partir de outro dispositivo")
    :phew-here-is-your-passphrase          "*Ufa* foi complicado, aqui está a sua frase-chave, *anote-a e mantenha-a em segurança!* Vai precisar dela para recuperar a sua conta."
    :here-is-your-passphrase               "Aqui está a sua frase-chave, *anote-a e mantenha-a em segurança!* Vai precisar dela para recuperar a sua conta."
-   :written-down                          "Certifique-se de que a anotou de forma segura"
    :phone-number-required                 "Toque aqui para digitar o seu número de telefone e vou encontrar os seus amigos"
    :intro-status                          "Fale comigo para configurar a sua conta e alterar as suas definições!"
    :intro-message1                        "Bem-vindo ao Status\nToque nesta mensagem para definir a sua palavra-passe e começar!"
@@ -95,7 +82,6 @@
 
    ;chats
    :chats                                 "Chats"
-   :new-chat                              "Novo chat"
    :new-group-chat                        "Novo chat em grupo"
 
    ;discover
@@ -112,9 +98,6 @@
    ;contacts
    :contacts                              "Contactos"
    :new-contact                           "Novo Contacto"
-   :show-all                              "MOSTRAR TUDO"
-   :contacts-group-dapps                  "ÐApps"
-   :contacts-group-people                 "Pessoas"
    :contacts-group-new-chat               "Iniciar um novo chat"
    :no-contacts                           "Ainda sem contactos"
    :show-qr                               "Mostrar QR"
@@ -122,41 +105,17 @@
    ;group-settings
    :remove                                "Remover"
    :save                                  "Guardar"
-   :change-color                          "Mudar de cor"
    :clear-history                         "Limpar o histórico"
-   :delete-and-leave                      "Eliminar e sair"
    :chat-settings                         "Definições de chat"
    :edit                                  "Editar"
    :add-members                           "Adicionar Membros"
-   :blue                                  "Azul"
-   :purple                                "Roxo"
-   :green                                 "Verde"
-   :red                                   "Vermelho"
 
    ;commands
-   :money-command-description             "Enviar dinheiro"
-   :location-command-description          "Enviar a localização"
-   :phone-command-description             "Enviar o número de telefone"
-   :phone-request-text                    "Pedido de número de telefone"
-   :confirmation-code-command-description "Enviar o código de confirmação"
-   :confirmation-code-request-text        "Pedido de código de confirmação"
-   :send-command-description              "Enviar a localização"
-   :request-command-description           "Enviar o pedido"
-   :keypair-password-command-description  ""
-   :help-command-description              "Ajuda"
-   :request                               "Pedido"
    :chat-send-eth                         "{{amount}} ETH"
-   :chat-send-eth-to                      "{{amount}} ETH para {{chat-name}}"
-   :chat-send-eth-from                    "{{amount}} ETH de {{chat-name}}"
 
    ;new-group
-   :group-chat-name                       "Nome no chat"
-   :empty-group-chat-name                 "Por favor, digite um nome"
-   :illegal-group-chat-name               "Por favor, selecione outro nome"
 
    ;participants
-   :add-participants                      "Adicionar Participantes"
-   :remove-participants                   "Remover os Participantes"
 
    ;protocol
    :received-invitation                   "recebeu um convite de chat"
@@ -168,12 +127,9 @@
 
    ;new-contact
    :add-new-contact                       "Adicionar novo contacto"
-   :import-qr                             "Importar"
    :scan-qr                               "Digitalizar QR"
    :name                                  "Nome"
-   :whisper-identity                      "Sussurar a Identidade"
    :address-explication                   "Talvez aqui devesse aparecer algum texto a explicar o que é um endereço e onde procurá-lo"
-   :enter-valid-address                   "Por favor, digite um endereço válido ou digitalize um código QR"
    :contact-already-added                 "O contacto já foi adicionado"
    :can-not-add-yourself                  "Não pode adicionar-se a si mesmo"
    :unknown-address                       "Endereço desconhecido"
@@ -183,20 +139,14 @@
    :connect                               "Ligar"
    :address                               "Endereço"
    :password                              "Palavra-passe"
-   :login                                 "Login"
    :wrong-password                        "Palavra-passe errada"
 
    ;recover
-   :recover-from-passphrase               "Recuperar a partir da frase-chave"
-   :recover-explain                       "Por favor, digite a frase-chave para a sua palavra-passe recuperar o acesso"
    :passphrase                            "Frase-chave"
    :recover                               "Recuperar"
-   :enter-valid-passphrase                "Por favor, digite uma frase-chave"
-   :enter-valid-password                  "Por favor, digite uma palavra-passe"
 
    ;accounts
    :recover-access                        "Recuperar o acesso"
-   :add-account                           "Adicionar conta"
 
    ;wallet-qr-code
    :done                                  "Concluído"
@@ -205,34 +155,20 @@
    ;validation
    :invalid-phone                         "Número de telefone inválido"
    :amount                                "Montante"
-   :not-enough-eth                        (str "Não há ETH suficiente no saldo "
-                                               "({{balance}} ETH)")
    ;transactions
-   :confirm-transactions                  {:one   "Confirmar a transação"
-                                           :other "Confirmar as {{count}} transações"
-                                           :zero  "Sem transações"}
    :status                                "Estado"
-   :pending-confirmation                  "Confirmação pendente"
    :recipient                             "Destinatário"
-   :one-more-item                         "Mais um item"
-   :fee                                   "Taxa"
-   :value                                 "Valor"
 
    ;:webview
    :web-view-error                        "ups, erro"
 
    :confirm                               "Confirmar"
    :phone-national                        "Nacional"
-   :transactions-confirmed                {:one   "Transação confirmada"
-                                           :other "{{count}} transações confirmadas"
-                                           :zero  "Nenhuma transação confirmada"}
    :public-group-topic                    "Tema"
    :debug-enabled                         "Foi lançado o servidor de depuração! Agora, pode adicionar a sua DApp executando *status-dev-cli scan* do seu computador"
    :new-public-group-chat                 "Juntar-se ao chat público"
    :datetime-ago-format                   "{{number}} {{time-intervals}} {{ago}}"
    :sharing-cancel                        "Cancelar"
-   :share-qr                              "Partilhar QR"
-   :feedback                              "Tem feedback?\nAbane o seu telefone!"
    :twelve-words-in-correct-order         "12 palavras na ordem correta"
    :remove-from-contacts                  "Remover dos contactos"
    :delete-chat                           "Eliminar o chat"
@@ -272,7 +208,6 @@
 
    :contact-s                             {:one   "contacto"
                                            :other "Contactos"}
-   :group-name                            "Nome do grupo"
    :next                                  "Próximo"
    :from                                  "De"
    :search-chats                          "Pesquisar chats"
@@ -289,17 +224,11 @@
    :more                                  "mais"
    :cancel                                "Cancelar"
    :no-statuses-found                     "Nenhum estado encontrado"
-   :swow-qr                               "Mostrar QR"
    :browsing-open-in-web-browser          "Abrir no navegador Web"
    :delete-group-prompt                   "Isto não afetará os contactos"
    :edit-profile                          "Editar perfil"
 
 
-   :enter-password-transactions           {:one   "Confirmar a transação digitando a sua palavra-passe"
-                                           :other "Confirmar as transações digitando a sua palavra-passe"}
-   :unsigned-transactions                 "Transações sem assinatura"
    :empty-topic                           "Tema em branco"
    :to                                    "Para"
-   :group-members                         "Membros do grupo"
-   :estimated-fee                         "Taxa Est."
    :data                                  "Dados"})

--- a/src/status_im/translations/ro.cljs
+++ b/src/status_im/translations/ro.cljs
@@ -10,8 +10,6 @@
    :offline                               "Offline"
 
    ;drawer
-   :invite-friends                        "Invită prieteni"
-   :faq                                   "Întrebări frecvente"
    :switch-users                          "Schimbă utilizatori"
 
    ;chat
@@ -53,41 +51,30 @@
                                            :other "ore"}
    :datetime-day                          {:one   "zi"
                                            :other "zile"}
-   :datetime-multiple                     "s"
    :datetime-ago                          "în urmă"
    :datetime-yesterday                    "ieri"
    :datetime-today                        "azi"
 
    ;profile
    :profile                               "Profil"
-   :report-user                           "RAPORTEAZĂ UTILIZATOR"
    :message                               "Mesaj"
-   :username                              "Nume de utilizator"
    :not-specified                         "Nu este specificat"
    :public-key                            "Cheie publică"
    :phone-number                          "Număr de telefon"
-   :email                                 "E-mail"
-   :profile-no-status                     "Nici un status"
    :add-to-contacts                       "Adaugă la contacte"
-   :error-incorrect-name                  "Te rugăm să alegi un alt nume"
-   :error-incorrect-email                 "E-mail greșit"
 
    ;;make_photo
    :image-source-title                    "Imagine de profil"
    :image-source-make-photo               "Captează"
    :image-source-gallery                  "Selectează din galerie"
-   :image-source-cancel                   "Anulează"
 
    ;sign-up
    :contacts-syncronized                  "Contactele tale au fost sincronizate"
    :confirmation-code                     (str "Mulțumim! Ți-am trims un mesaj text cu un cod "
                                                "de confirmare. Te rugăm să ne transmiți acel cod pentru a-ți confirma numărul de telefon")
    :incorrect-code                        (str "Ne pare rău, dar codul este greșit, te rugăm să-l introduci încă o dată")
-   :generate-passphrase                   (str "Voi genera o frază de acces pentru tine, ca să poți redobândi "
-                                               "accesul sau să te poți conecta de pe alt dispozitiv")
    :phew-here-is-your-passphrase          "*Pfui* a fost greu, iată fraza ta de acces, *noteaz-o și păstreaz-o în siguranță!* Vei avea nevoie de ea pentru a-ți redobândi accesul la cont."
    :here-is-your-passphrase               "Iată fraza ta de acces, *noteaz-o și păstreaz-o în siguranță!* Vei avea nevoie de ea pentru a-ți redobândi accesul la cont."
-   :written-down                          "Ai grijă să o notezi în condiții de siguranță"
    :phone-number-required                 "Apasă aici ca să-ți introduci numărul de telefon și eu îți voi invita prietenii"
    :intro-status                          "Hai să vorbim pe chat pentru a-ți seta contul și modifica setările!"
    :intro-message1                        "Bine ai vent în Status\nApasă pe acest mesaj pentru a-ți seta parola și a începe!"
@@ -95,7 +82,6 @@
 
    ;chats
    :chats                                 "Discuții pe chat"
-   :new-chat                              "Discuție nouă"
    :new-group-chat                        "Grup nou de chat"
 
    ;discover
@@ -112,9 +98,6 @@
    ;contacts
    :contacts                              "Contacte"
    :new-contact                           "Contact nou"
-   :show-all                              "AFIȘEAZĂ TOATE"
-   :contacts-group-dapps                  "ÐApps"
-   :contacts-group-people                 "Oameni"
    :contacts-group-new-chat               "Începe discuție nouă"
    :no-contacts                           "Nici un contact deocamdată"
    :show-qr                               "Afișează QR"
@@ -122,41 +105,17 @@
    ;group-settings
    :remove                                "Elimină"
    :save                                  "Salvează"
-   :change-color                          "Schimbă culoarea"
    :clear-history                         "Șterge istoricul"
-   :delete-and-leave                      "Șterge și ieși"
    :chat-settings                         "Setări chat"
    :edit                                  "Editare"
    :add-members                           "Adăugare membri"
-   :blue                                  "Albastru"
-   :purple                                "Violet"
-   :green                                 "Verde"
-   :red                                   "Roșu"
 
    ;commands
-   :money-command-description             "Trimite bani"
-   :location-command-description          "Trimite locație"
-   :phone-command-description             "Trimite număr de telefon"
-   :phone-request-text                    "Solicitare număr de telefon"
-   :confirmation-code-command-description "Trimite cod de confirmare"
-   :confirmation-code-request-text        "Solicitare cod de confirmare"
-   :send-command-description              "Trimite locația"
-   :request-command-description           "Trimite solicitarea"
-   :keypair-password-command-description  ""
-   :help-command-description              "Ajutor"
-   :request                               "Solicitare"
    :chat-send-eth                         "{{amount}} ETH"
-   :chat-send-eth-to                      "{{amount}} ETH pentru {{chat-name}}"
-   :chat-send-eth-from                    "{{amount}} ETH de la {{chat-name}}"
 
    ;new-group
-   :group-chat-name                       "Nume chat"
-   :empty-group-chat-name                 "Te rugăm să introduci un nume"
-   :illegal-group-chat-name               "Te rugăm să selectezi un alt nume"
 
    ;participants
-   :add-participants                      "Adaugă participanți"
-   :remove-participants                   "Elimină participanți"
 
    ;protocol
    :received-invitation                   "A primit invitația de chat"
@@ -168,12 +127,9 @@
 
    ;new-contact
    :add-new-contact                       "Adaugă contact nou"
-   :import-qr                             "Importă"
    :scan-qr                               "Scanează QR"
    :name                                  "Nume"
-   :whisper-identity                      "Identitatea"
    :address-explication                   "Poate că aici ar trebui să fie un text care să explice ce este o adresă și unde să o cauți"
-   :enter-valid-address                   "Te rugăm să introduci o adresă validă sau să scanezi un cod QR"
    :contact-already-added                 "Contactul a fost adăugat deja"
    :can-not-add-yourself                  "Nu te poți adăuga pe tine"
    :unknown-address                       "Adresă necunoscută"
@@ -183,20 +139,14 @@
    :connect                               "Conectare"
    :address                               "Adresă"
    :password                              "Parolă"
-   :login                                 "Conectează-te"
    :wrong-password                        "Parola greșită"
 
    ;recover
-   :recover-from-passphrase               "Recuperează folosind fraza de acces"
-   :recover-explain                       "Te rugăm să introduci fraza de acces si parola ta pentru a redobandi accesul"
    :passphrase                            "Fraza de acces"
    :recover                               "Recuperează"
-   :enter-valid-passphrase                "Te rugăm să introduci o frază de acces"
-   :enter-valid-password                  "Te rugăm să introduci o parolă"
 
    ;accounts
    :recover-access                        "Recuperează acces"
-   :add-account                           "Adaugă cont"
 
    ;wallet-qr-code
    :done                                  "Gata"
@@ -205,34 +155,20 @@
    ;validation
    :invalid-phone                         "Număr de telefon nevalid"
    :amount                                "Sumă"
-   :not-enough-eth                        (str "Sold ETH insuficient "
-                                               "({{balance}} ETH)")
    ;transactions
-   :confirm-transactions                  {:one   "Confirmare tranzacție"
-                                           :other "Confirmare {{count}} tranzacții"
-                                           :zero  "Nicio tranzacție"}
    :status                                "Status"
-   :pending-confirmation                  "Se așteaptă confirmarea"
    :recipient                             "Beneficiar"
-   :one-more-item                         "Încă un articol"
-   :fee                                   "Comision"
-   :value                                 "Valoare"
 
    ;:webview
    :web-view-error                        "ups, eroare"
 
    :confirm                               "Confirmare"
    :phone-national                        "Național"
-   :transactions-confirmed                {:one   "Tranzacție confirmată"
-                                           :other "{{count}} (de) tranzacții confirmate"
-                                           :zero  "Nicio tranzacție confirmată"}
    :public-group-topic                    "Subiect"
    :debug-enabled                         "Serverul de curățare a fost lansat! Adresa dvs. Acum vă puteți adăuga DApp rulând *status-dev-cli scan* de pe computerul dvs."
    :new-public-group-chat                 "Alăturați-vă chat-ului public"
    :datetime-ago-format                   "{{number}} {{time-intervals}} {{ago}}"
    :sharing-cancel                        "Anulare"
-   :share-qr                              "Partajare QR"
-   :feedback                              "Aveți feedback?\nScuturați telefonul!"
    :twelve-words-in-correct-order         "12 de cuvinte în ordinea corectă"
    :remove-from-contacts                  "Eliminare din contacte"
    :delete-chat                           "Ștergere chat"
@@ -272,7 +208,6 @@
 
    :contact-s                             {:one   "contact"
                                            :other "contacte"}
-   :group-name                            "Nume grup"
    :next                                  "Mai departe"
    :from                                  "De la"
    :search-chats                          "Căutare discuții"
@@ -289,17 +224,11 @@
    :more                                  "mai mult"
    :cancel                                "Anulare"
    :no-statuses-found                     "Niciun status găsit"
-   :swow-qr                               "Afișare QR"
    :browsing-open-in-web-browser          "Deschide în browser web"
    :delete-group-prompt                   "Aceasta nu va afecta contactele"
    :edit-profile                          "Editare profil"
 
 
-   :enter-password-transactions           {:one   "Confirmați tranzacția introducând parola"
-                                           :other "Confirmați tranzacțiile introducând parola"}
-   :unsigned-transactions                 "Tranzacții nesemnate"
    :empty-topic                           "Subiect gol"
    :to                                    "Către"
-   :group-members                         "Membrii grupului"
-   :estimated-fee                         "Comision est."
    :data                                  "Date"})

--- a/src/status_im/translations/sl.cljs
+++ b/src/status_im/translations/sl.cljs
@@ -10,8 +10,6 @@
    :offline                               "Nedosegljiv/-a"
 
    ;drawer
-   :invite-friends                        "Povabi prijatelje"
-   :faq                                   "Pogosta vprašanja"
    :switch-users                          "Preklopi med uporabniki"
 
    ;chat
@@ -53,41 +51,30 @@
                                            :other "ur"}
    :datetime-day                          {:one   "dan"
                                            :other "dni"}
-   :datetime-multiple                     "s"
    :datetime-ago                          "nazaj"
    :datetime-yesterday                    "včeraj"
    :datetime-today                        "danes"
 
    ;profile
    :profile                               "Profil"
-   :report-user                           "PRIJAVI UPORABNIKA"
    :message                               "Sporočilo"
-   :username                              "Uporabniško ime"
    :not-specified                         "Ni navedeno"
    :public-key                            "Javni ključ"
    :phone-number                          "Telefonska številka"
-   :email                                 "E-pošta"
-   :profile-no-status                     "Brez statusa"
    :add-to-contacts                       "Dodaj med stike"
-   :error-incorrect-name                  "Prosimo, izberi drugo ime"
-   :error-incorrect-email                 "Nepravilna e-pošta"
 
    ;;make_photo
    :image-source-title                    "Fotografija profila"
    :image-source-make-photo               "Zajemi"
    :image-source-gallery                  "Izberi iz galerije"
-   :image-source-cancel                   "Prekliči"
 
    ;sign-up
    :contacts-syncronized                  "Tvoji stiki so bili sinhronizirani"
    :confirmation-code                     (str "Hvala! Poslali smo ti sporočilo s potrditveno "
                                                "kodo. Prosimo, vnesi to kodo in potrdi svojo telefonsko številko")
    :incorrect-code                        (str "Koda na žalost ni bila pravilna, prosimo, da jo ponovno vneseš")
-   :generate-passphrase                   (str "Zate bom ustvaril šifrirno geslo, tako da boš lahko obnovil/-a svoj "
-                                               "dostop, ali se prijavil/-a iz druge naprave")
    :phew-here-is-your-passphrase          "*Pfuu* to pa je bilo težko, tukaj je tvoje šifrirno geslo, *zapiši si ga in shrani na varno mesto!* Potreboval/-a ga boš, da obnoviš svoj račun."
    :here-is-your-passphrase               "Tukaj je tvoje geslo, *zapiši si ga in shrani na varno mesto!* Potreboval/-a ga boš, da obnoviš svoj račun."
-   :written-down                          "Poskrbi, da si ga pazljivo zapišeš"
    :phone-number-required                 "Pritisni tukaj in vnesi svojo telefonsko številko ter poiskal bom tvoje prijatelje"
    :intro-status                          "Klepetaj z mano in nastavi svoj račun ter spremeni svoje nastavitve!"
    :intro-message1                        "Dobrodošel/-la v status\nPritisni to sporočilo in nastavi svoje geslo ter začni!"
@@ -95,7 +82,6 @@
 
    ;chats
    :chats                                 "Klepeti"
-   :new-chat                              "Nov klepet"
    :new-group-chat                        "Nov skupinski klepet"
 
    ;discover
@@ -112,9 +98,6 @@
    ;contacts
    :contacts                              "Stiki"
    :new-contact                           "Nov stik"
-   :show-all                              "POKAŽI VSE"
-   :contacts-group-dapps                  "ÐApps"
-   :contacts-group-people                 "Osebe"
    :contacts-group-new-chat               "Začni nov klepet"
    :no-contacts                           "Zaenkrat še ni stikov"
    :show-qr                               "Prikaži QR"
@@ -122,41 +105,17 @@
    ;group-settings
    :remove                                "Odstrani"
    :save                                  "Shrani"
-   :change-color                          "Spremeni barvo"
    :clear-history                         "Počisti zgodovino"
-   :delete-and-leave                      "Izbriši in zapri"
    :chat-settings                         "Nastavitve klepeta"
    :edit                                  "Uredi"
    :add-members                           "Dodaj člane"
-   :blue                                  "Modra"
-   :purple                                "Vijolična"
-   :green                                 "Zelena"
-   :red                                   "Rdeča"
 
    ;commands
-   :money-command-description             "Pošlji denar"
-   :location-command-description          "Pošlji lokacijo"
-   :phone-command-description             "Pošlji telefonsko številko"
-   :phone-request-text                    "Prošnja za telefonsko številko"
-   :confirmation-code-command-description "Pošlji potrditveno kodo"
-   :confirmation-code-request-text        "Prošnja za potrditveno kodo"
-   :send-command-description              "Pošlji lokacijo"
-   :request-command-description           "Pošlji prošnjo"
-   :keypair-password-command-description  ""
-   :help-command-description              "Pomoč"
-   :request                               "Prošnja"
    :chat-send-eth                         "{{amount}} ETH"
-   :chat-send-eth-to                      "{{amount}} ETH osebi {{chat-name}}"
-   :chat-send-eth-from                    "{{amount}} ETH od osebe {{chat-name}}"
 
    ;new-group
-   :group-chat-name                       "Ime za klepet"
-   :empty-group-chat-name                 "Prosimo, vnesi ime"
-   :illegal-group-chat-name               "Prosimo, izberi drugo ime"
 
    ;participants
-   :add-participants                      "Dodaj udeležence"
-   :remove-participants                   "Odstrani udeležence"
 
    ;protocol
    :received-invitation                   "je prejel/-a povabilo za klepet"
@@ -168,12 +127,9 @@
 
    ;new-contact
    :add-new-contact                       "Dodaj nov stik"
-   :import-qr                             "Uvozi"
    :scan-qr                               "Skeniraj QR"
    :name                                  "Ime"
-   :whisper-identity                      "Skrivna identiteta"
    :address-explication                   "Sem morda sodi besedilo, ki razlaga, kaj je naslov ter kje ga najti"
-   :enter-valid-address                   "Prosimo, vnesi veljaven naslov ali skeniraj QR kodo"
    :contact-already-added                 "Stik je bil že dodan"
    :can-not-add-yourself                  "Sebe ni mogoče dodati"
    :unknown-address                       "Neznan naslov"
@@ -183,20 +139,14 @@
    :connect                               "Poveži"
    :address                               "Naslov"
    :password                              "Geslo"
-   :login                                 "Prijava"
    :wrong-password                        "Napačno geslo"
 
    ;recover
-   :recover-from-passphrase               "Povrni prek šifrirnega gesla"
-   :recover-explain                       "Prosimo, vnesi šifrirno geslo svojega gesla za povrnitev dostopa"
    :passphrase                            "Šifrirno geslo"
    :recover                               "Povrni"
-   :enter-valid-passphrase                "Prosimo, vnesi šifrirno geslo"
-   :enter-valid-password                  "Prosimo, vnesi geslo"
 
    ;accounts
    :recover-access                        "Povrni dostop"
-   :add-account                           "Dodaj račun"
 
    ;wallet-qr-code
    :done                                  "Končano"
@@ -205,34 +155,20 @@
    ;validation
    :invalid-phone                         "Neveljavna telefonska številka"
    :amount                                "Vsota"
-   :not-enough-eth                        (str "Stanje ETH na računu je prenizko "
-                                               "({{balance}} ETH)")
    ;transactions
-   :confirm-transactions                  {:one   "Potrdi transakcijo"
-                                           :other "Potrdi {{count}} transakcij"
-                                           :zero  "Ni transakcij"}
    :status                                "Status"
-   :pending-confirmation                  "Potrditev v teku"
    :recipient                             "Prejemnik"
-   :one-more-item                         "Še en predmet"
-   :fee                                   "Plačilo"
-   :value                                 "Vrednost"
 
    ;:webview
    :web-view-error                        "ups, napaka"
 
    :confirm                               "Potrdi"
    :phone-national                        "Državno"
-   :transactions-confirmed                {:one   "Transakcija potrjena"
-                                           :other "Št. potrjenih transakcij: {{count}}"
-                                           :zero  "Ni potrjenih transakcij"}
    :public-group-topic                    "Tema"
    :debug-enabled                         "Strežnik za odpravljanje napak je bil zagnan! Sedaj lahko aplikacijo DApp dodate tako, da zaženete *status-dev-cli scan* na vašem računalniku"
    :new-public-group-chat                 "Pridruži se javnemu klepetu"
    :datetime-ago-format                   "{{number}} {{time-intervals}} {{ago}}"
    :sharing-cancel                        "Prekliči"
-   :share-qr                              "Deli QR kodo"
-   :feedback                              "Imate povratne informacije?\nStresite vaš telefon!"
    :twelve-words-in-correct-order         "12 besed v pravilnem vrstnem redu"
    :remove-from-contacts                  "Odstrani iz stikov"
    :delete-chat                           "Izbriši klepet"
@@ -272,7 +208,6 @@
 
    :contact-s                             {:one   "stik"
                                            :other "stiki"}
-   :group-name                            "Ime skupine"
    :next                                  "Naprej"
    :from                                  "Od"
    :search-chats                          "Išči klepete"
@@ -289,17 +224,11 @@
    :more                                  "več"
    :cancel                                "Prekliči"
    :no-statuses-found                     "Ni statusov"
-   :swow-qr                               "Prikaži QR kodo"
    :browsing-open-in-web-browser          "Odpri v spletnem brskalniku"
    :delete-group-prompt                   "To ne bo vplivalo na stike"
    :edit-profile                          "Uredi profil"
 
 
-   :enter-password-transactions           {:one   "Potrdite transakcijo z vnosom vašega gesla"
-                                           :other "Potrdite transakcije z vnosom vašega gesla"}
-   :unsigned-transactions                 "Nepodpisane transakcije"
    :empty-topic                           "Prazna tema"
    :to                                    "Za"
-   :group-members                         "Člani skupine"
-   :estimated-fee                         "Predvideno plačilo"
    :data                                  "Podatki"})

--- a/src/status_im/translations/sv.cljs
+++ b/src/status_im/translations/sv.cljs
@@ -10,8 +10,6 @@
    :offline                               "Offline"
 
    ;drawer
-   :invite-friends                        "Bjud in vänner"
-   :faq                                   "FAQ"
    :switch-users                          "Byt användare"
 
    ;chat
@@ -53,41 +51,30 @@
                                            :other "timmar"}
    :datetime-day                          {:one   "dag"
                                            :other "dagar"}
-   :datetime-multiple                     "s"
    :datetime-ago                          "sedan"
    :datetime-yesterday                    "igår"
    :datetime-today                        "idag"
 
    ;profile
    :profile                               "Profil"
-   :report-user                           "RAPPORTERA ANVÄNDARE"
    :message                               "Meddelande"
-   :username                              "Användarnamn"
    :not-specified                         "Inte angivet"
    :public-key                            "Offentlig nyckel"
    :phone-number                          "Telefonnummer"
-   :email                                 "E-post"
-   :profile-no-status                     "Ingen status"
    :add-to-contacts                       "Lägg till i kontakter"
-   :error-incorrect-name                  "Var god välj ett annat namn"
-   :error-incorrect-email                 "Inkorrekt e-post"
 
    ;;make_photo
    :image-source-title                    "Profilbild"
    :image-source-make-photo               "Fånga"
    :image-source-gallery                  "Välj från galleri"
-   :image-source-cancel                   "Avbryt"
 
    ;sign-up
    :contacts-syncronized                  "Dina kontakter har synkroniserats"
    :confirmation-code                     (str "Tack! Vi har skickat dig ett textmeddelande med en bekräftelse "
                                                "kod. Var god ange den koden för att bekräfta ditt telefonnummer")
    :incorrect-code                        (str "Tyvärr var koden felaktig, var god ange den igen")
-   :generate-passphrase                   (str "Jag kommer att generera en lösenordsfras för dig så att du kan återställa din "
-                                               "åtkomst eller logga in från en annan enhet")
    :phew-here-is-your-passphrase          "*Pust* det var svårt, här är din lösenordsfras, *skriv ner det här och förvara det säkert!* Du kommer att behöva det för att återställa ditt konto."
    :here-is-your-passphrase               "Här är din lösenordsfras, *skriv ner det här och förvara det säkert!* Du kommer att behöva det för att återställa ditt konto."
-   :written-down                          "Se till att du hade skrivit ner det säkert"
    :phone-number-required                 "Tryck här för att ange ditt telefonnummer och jag kommer att hitta dina vänner"
    :intro-status                          "Chatta med mig för att konfigurera ditt konto och ändra dina inställningar!"
    :intro-message1                        "Välkommen till Status\nTryck på detta meddelande för att ställa in ditt lösenord och komma igång!"
@@ -95,7 +82,6 @@
 
    ;chats
    :chats                                 "Chattar"
-   :new-chat                              "Ny chatt"
    :new-group-chat                        "Ny gruppchatt"
 
    ;discover
@@ -112,9 +98,6 @@
    ;contacts
    :contacts                              "Kontakter"
    :new-contact                           "Ny kontakt"
-   :show-all                              "VISA ALLA"
-   :contacts-group-dapps                  "ÐApps"
-   :contacts-group-people                 "Människor"
    :contacts-group-new-chat               "Starta ny chatt"
    :no-contacts                           "Inga kontakter ännu"
    :show-qr                               "Visa QR"
@@ -122,41 +105,17 @@
    ;group-settings
    :remove                                "Ta bort"
    :save                                  "Spara"
-   :change-color                          "Ändra färg"
    :clear-history                         "Rensa historik"
-   :delete-and-leave                      "Radera och lämna"
    :chat-settings                         "Chattinställningar"
    :edit                                  "Redigera"
    :add-members                           "Lägg till medlemmar"
-   :blue                                  "Blå"
-   :purple                                "Lila"
-   :green                                 "Grön"
-   :red                                   "Röd"
 
    ;commands
-   :money-command-description             "Skicka pengar"
-   :location-command-description          "Skicka plats"
-   :phone-command-description             "Skicka telefonnummer"
-   :phone-request-text                    "Telefonnummerbegäran"
-   :confirmation-code-command-description "Skicka bekräftelsekod"
-   :confirmation-code-request-text        "Bekräftelsekodbegäran"
-   :send-command-description              "Skicka plats"
-   :request-command-description           "Skicka begäran"
-   :keypair-password-command-description  ""
-   :help-command-description              "Hjälp"
-   :request                               "Begäran"
    :chat-send-eth                         "{{amount}} ETH"
-   :chat-send-eth-to                      "{{amount}} ETH till {{chat-name}}"
-   :chat-send-eth-from                    "{{amount}} ETH från {{chat-name}}"
 
    ;new-group
-   :group-chat-name                       "Chattnamn"
-   :empty-group-chat-name                 "Var god ange ett namn"
-   :illegal-group-chat-name               "Var god välj ett annat namn"
 
    ;participants
-   :add-participants                      "Lägg till Deltagare"
-   :remove-participants                   "Ta bort Deltagare"
 
    ;protocol
    :received-invitation                   "tog emot chattinbjudan"
@@ -168,12 +127,9 @@
 
    ;new-contact
    :add-new-contact                       "Lägg till ny kontakt"
-   :import-qr                             "Importera"
    :scan-qr                               "Skanna QR"
    :name                                  "Namn"
-   :whisper-identity                      "Viskningsidentitet"
    :address-explication                   "Kanske borde det finnas lite text som förklarar vad en adress är och var man hittar den"
-   :enter-valid-address                   "Var god ange en giltig adress eller skanna en QR-kod"
    :contact-already-added                 "Kontakten har redan lagts till"
    :can-not-add-yourself                  "Du kan inte lägga till dig själv"
    :unknown-address                       "Okänd adress"
@@ -183,20 +139,14 @@
    :connect                               "Anslut"
    :address                               "Adress"
    :password                              "Lösenord"
-   :login                                 "Inloggning"
    :wrong-password                        "Fel lösenord"
 
    ;recover
-   :recover-from-passphrase               "Återställ från lösenordsfras"
-   :recover-explain                       "Var god ange lösenordsfrasen för ditt lösenord för att återställa åtkomsten"
    :passphrase                            "Lösenordsfras"
    :recover                               "Återställ"
-   :enter-valid-passphrase                "Var god ange en lösenordsfras"
-   :enter-valid-password                  "Var god ange ett lösenord"
 
    ;accounts
    :recover-access                        "Återställ åtkomst"
-   :add-account                           "Lägg till konto"
 
    ;wallet-qr-code
    :done                                  "Klar"
@@ -205,34 +155,20 @@
    ;validation
    :invalid-phone                         "Ogiltigt telefonnummer"
    :amount                                "Belopp"
-   :not-enough-eth                        (str "'Inte tillräcklig ETH på balansen "
-                                               "({{balance}} ETH)")
    ;transactions
-   :confirm-transactions                  {:one   "Bekräfta transaktion"
-                                           :other "Bekräfta {{count}} transaktioner"
-                                           :zero  "Inga transaktioner"}
    :status                                "Status"
-   :pending-confirmation                  "I väntan på bekräftelse"
    :recipient                             "Mottagare"
-   :one-more-item                         "En artikel till"
-   :fee                                   "Avgift"
-   :value                                 "Värde"
 
    ;:webview
    :web-view-error                        "hoppsan, fel"
 
    :confirm                               "Bekräfta"
    :phone-national                        "Nationell"
-   :transactions-confirmed                {:one   "Transaktion bekräftad"
-                                           :other "{{count}} transaktioner bekräftade"
-                                           :zero  "Inga bekräftade transaktioner"}
    :public-group-topic                    "Ämne"
    :debug-enabled                         "Felsökningsserver startad! Lägg till din DApp genom att ange *status-dev-cli scan* på datorn"
    :new-public-group-chat                 "Gå med i offentlig chatt"
    :datetime-ago-format                   "{{number}} {{time-intervals}} {{ago}}"
    :sharing-cancel                        "Avbryt"
-   :share-qr                              "Dela QR"
-   :feedback                              "Har du synpunkter?\nSkaka din telefon!"
    :twelve-words-in-correct-order         "12 ord i korrekt följd"
    :remove-from-contacts                  "Ta bort från kontakter"
    :delete-chat                           "Radera chatt"
@@ -272,7 +208,6 @@
 
    :contact-s                             {:one   "kontakt"
                                            :other "kontakter"}
-   :group-name                            "Gruppnamn"
    :next                                  "Nästa"
    :from                                  "Från"
    :search-chats                          "Sök i chattar"
@@ -289,17 +224,11 @@
    :more                                  "mer"
    :cancel                                "Avbryt"
    :no-statuses-found                     "Inga statusar hittades"
-   :swow-qr                               "Visa QR"
    :browsing-open-in-web-browser          "Öppna i webbläsare"
    :delete-group-prompt                   "Detta påverkar inte kontakter"
    :edit-profile                          "Redigera profil"
 
 
-   :enter-password-transactions           {:one   "Bekräfta transaktion genom att ange ditt lösenord"
-                                           :other "Bekräfta transaktioner genom att ange ditt lösenord"}
-   :unsigned-transactions                 "Osignerade transaktioner"
    :empty-topic                           "Tomt ämne"
    :to                                    "Till"
-   :group-members                         "Gruppmedlemmar"
-   :estimated-fee                         "Uppsk. avgift"
    :data                                  "Data"})

--- a/src/status_im/translations/sw.cljs
+++ b/src/status_im/translations/sw.cljs
@@ -10,8 +10,6 @@
    :offline                               "Nje ya mtandao"
 
    ;drawer
-   :invite-friends                        "Karibisha marafiki"
-   :faq                                   "Maswali Ya Mara kwa mara"
    :switch-users                          "Badili kwa watumiaji"
 
    ;chat
@@ -53,30 +51,22 @@
                                            :other "masaa"}
    :datetime-day                          {:one   "siku"
                                            :other "siku"}
-   :datetime-multiple                     "s"
    :datetime-ago                          "iliyopita"
    :datetime-yesterday                    "jana"
    :datetime-today                        "leo"
 
    ;profile
    :profile                               "Profaili"
-   :report-user                           "RIPOTI MTUMIAJI"
    :message                               "Ujumbe"
-   :username                              "Jina la mtumiaji"
    :not-specified                         "Haijafafanuliwa"
    :public-key                            "Ufunguo wa Umma"
    :phone-number                          "Namba ya Simu"
-   :email                                 "Barua pepe"
-   :profile-no-status                     "Hakuna hadhi"
    :add-to-contacts                       "Ongeza kwa mawasiliano"
-   :error-incorrect-name                  "Tafadhali chagua jina lingine"
-   :error-incorrect-email                 "Barua pepe sio sahihi"
 
    ;;make_photo
    :image-source-title                    "Picha ya profaili"
    :image-source-make-photo               "Chukua picha"
    :image-source-gallery                  "Chagua kutoka nyumba ya sanaa"
-   :image-source-cancel                   "Ghairi"
 
    ;;sharing
    :sharing-copy-to-clipboard             "Kopiera"
@@ -88,11 +78,8 @@
    :confirmation-code                     (str "Asante! Tumekutumia ujumbe mfupi na uthibitisho "
                                                "kificho. Tafadhali peana hicho kificho kuthibitisha namba yako ya simu")
    :incorrect-code                        (str "Samahani kificho hakikuwa sahihi, tafadhali ingiza tena")
-   :generate-passphrase                   (str "Nitakutengenezea kaulisiri ili uweze kurejesha "
-                                               "upatikanaji au kuingia kwa kutumia kifaa kingine")
    :phew-here-is-your-passphrase          "*Phew* hiyo ilikuwa ngumu, hapa ni kaulisiri yako, *iandike na uiweke salama!* Utaihitaji kwa ajili ya kufufua akaunti yako."
    :here-is-your-passphrase               "Hapa ni kaulisiri yako, *iandike na uiweke salama!* Utaihitaji kwa ajili ya kufufua akaunti yako."
-   :written-down                          "Hakikisha umeiandika salama"
    :phone-number-required                 "Bofya hapa kuingiza namba yako ya simu na nitapata marafiki zako"
    :intro-status                          "Ongea nami kuanzisha akaunti yako na kubadilisha mipangilio yako!"
    :intro-message1                        "Karibu kwa Hali na Ubofye ujumbe huu ili kuweka nenosiri lako na uanze!"
@@ -100,7 +87,6 @@
 
    ;chats
    :chats                                 "Gumzo"
-   :new-chat                              "Gumzo mpya"
    :new-group-chat                        "Gumzo mpya ya kikundi"
 
    ;discover
@@ -117,9 +103,6 @@
    ;contacts
    :contacts                              "Mawasiliano"
    :new-contact                           "Mawasiliano mapya"
-   :show-all                              "ONYESHA YOTE"
-   :contacts-group-dapps                  "ÐApps"
-   :contacts-group-people                 "Watu"
    :contacts-group-new-chat               "Anza gumzo mpya"
    :no-contacts                           "Bado hakuna mawasiliano"
    :show-qr                               "Onyesha QR"
@@ -127,41 +110,17 @@
    ;group-settings
    :remove                                "Ondoa"
    :save                                  "Hifadhi"
-   :change-color                          "Badilisha rangi"
    :clear-history                         "Futa historia"
-   :delete-and-leave                      "Futa na uondoke"
    :chat-settings                         "Mipangilio ya gumzo"
    :edit                                  "Hariri"
    :add-members                           "Ongeza wanachama"
-   :blue                                  "Bluu"
-   :purple                                "Zambarau"
-   :green                                 "Kijani"
-   :red                                   "Nyekundu"
 
    ;commands
-   :money-command-description             "Tuma pesa"
-   :location-command-description          "Tuma eneo"
-   :phone-command-description             "Tuma namba ya simu"
-   :phone-request-text                    "Ombi la namba ya simu"
-   :confirmation-code-command-description "Tuma kificho cha uthibitisho"
-   :confirmation-code-request-text        "Ombi la kificho cha uthibitisho"
-   :send-command-description              "Tuma eneo"
-   :request-command-description           "Tuma ombi"
-   :keypair-password-command-description  ""
-   :help-command-description              "Msaada"
-   :request                               "Ombi"
    :chat-send-eth                         "{{amount}} ETH"
-   :chat-send-eth-to                      "{{amount}} ETH kwa {{chat-name}}"
-   :chat-send-eth-from                    "{{amount}} ETH kutoka {{chat-name}}"
 
    ;new-group
-   :group-chat-name                       "Jina la gumzo"
-   :empty-group-chat-name                 "Tafadhali ingiza jina"
-   :illegal-group-chat-name               "Tafadhali chagua jina lingine"
 
    ;participants
-   :add-participants                      "Ongeza Washirika"
-   :remove-participants                   "Ondoa Washirika"
 
    ;protocol
    :received-invitation                   "mwaliko wa gumzo ulipokelewa"
@@ -173,12 +132,9 @@
 
    ;new-contact
    :add-new-contact                       "Ongeza mawasiliano mapya"
-   :import-qr                             "Agiza"
    :scan-qr                               "Piga picha QR"
    :name                                  "Jina"
-   :whisper-identity                      "Utambulisho wa Tetesi"
    :address-explication                   "Labda hapa kunapaswa kuwa na baadhi ya maandishi kueleza anwani ni nini na ni wapi pa kuitafuta"
-   :enter-valid-address                   "Tafadhali ingiza anwani sahihi au upige picha ya kificho cha QR"
    :contact-already-added                 "Tayari mawasiliano yameongezwa"
    :can-not-add-yourself                  "Huwezi kujiongeza mwenyewe"
    :unknown-address                       "Anwani Haijulikani"
@@ -188,20 +144,14 @@
    :connect                               "Unganisha"
    :address                               "Anwani"
    :password                              "Nenosiri"
-   :login                                 "Ingia"
    :wrong-password                        "Nenosiri sio halali"
 
    ;recover
-   :recover-from-passphrase               "Okoa/fufua kutoka kaulisiri"
-   :recover-explain                       "Tafadhali ingiza kaulisiri ili nenosiri lako liokoe upatikanaji"
    :passphrase                            "Kaulisiri"
    :recover                               "Okoa"
-   :enter-valid-passphrase                "Tafadhali ingiza kaulisiri"
-   :enter-valid-password                  "Tafadhali ingiza nenosiri"
 
    ;accounts
    :recover-access                        "Okoa ufikiaji/Upatikanaji"
-   :add-account                           "Ongeza akaunti"
 
    ;wallet-qr-code
    :done                                  "Imefanyika"
@@ -210,18 +160,9 @@
    ;validation
    :invalid-phone                         "Namba ya simu ni batili"
    :amount                                "Kiasi"
-   :not-enough-eth                        (str "ETH haitoshi kwenye salio "
-                                               "({{balance}} ETH)")
    ;transactions
-   :confirm-transactions                  {:one   "Thibitisha mashirikiano"
-                                           :other "Thibitisha {{count}} mashirikiano"
-                                           :zero  "Hakuna mashirikiano"}
    :status                                "Hali"
-   :pending-confirmation                  "Uthibitisho unasubiriwa"
    :recipient                             "Mpokeaji"
-   :one-more-item                         "Bidhaa moja zaidi"
-   :fee                                   "Ada"
-   :value                                 "Thamani"
 
    ;:webview
    :web-view-error                        "nadhani, hitilafu"})

--- a/src/status_im/translations/th.cljs
+++ b/src/status_im/translations/th.cljs
@@ -10,8 +10,6 @@
    :offline                               "ออฟไลน์"
 
    ;drawer
-   :invite-friends                        "เชิญเพื่อน"
-   :faq                                   "คำถามที่พบบ่อย"
    :switch-users                          "สลับผู้ใช้"
 
    ;chat
@@ -53,41 +51,30 @@
                                            :other "ชั่วโมง"}
    :datetime-day                          {:one   "วัน"
                                            :other "วัน"}
-   :datetime-multiple                     ""
    :datetime-ago                          "ที่ผ่านมา"
    :datetime-yesterday                    "เมื่อวาน"
    :datetime-today                        "วันนี้"
 
    ;profile
    :profile                               "โปรไฟล์"
-   :report-user                           "รายงานผู้ใช้"
    :message                               "ข้อความ"
-   :username                              "ชื่อผู้ใช้"
    :not-specified                         "ไม่ระบุ"
    :public-key                            "คีย์สาธารณะ"
    :phone-number                          "หมายเลขโทรศัพท์"
-   :email                                 "อีเมล"
-   :profile-no-status                     "ไม่มีสถานะ"
    :add-to-contacts                       "เพิ่มไปยังผู้ติดต่อ"
-   :error-incorrect-name                  "โปรดเลือกชื่ออื่น"
-   :error-incorrect-email                 "อีเมลไม่ถูกต้อง"
 
    ;;make_photo
    :image-source-title                    "รูปโปรไฟล์"
    :image-source-make-photo               "ถ่ายภาพ"
    :image-source-gallery                  "เลือกจากแกลเลอรี"
-   :image-source-cancel                   "ยกเลิก"
 
    ;sign-up
    :contacts-syncronized                  "ไซิงค์รายชื่อผู้ติดต่อของคุณแล้ว"
    :confirmation-code                     (str "ขอขอบคุณ! เราได้ส่งข้อความตัวอักษรพร้อมรหัสยืนยันแล้ว"
                                                "โปรดมอบรหัสนั้นเพื่อยืนยันหมายเลขโทรศัพท์ของคุณ")
    :incorrect-code                        (str "ขออภัย รหัสไม่ถูกต้อง โปรดกรอกอีกครั้ง")
-   :generate-passphrase                   (str "ฉันจะสร้างวลีรหัสผ่านให้คุณเพื่อให้คุณสามารถกู้คืน"
-                                               "การเข้าถึงของคุณหรือล็อกอินจากอุปกรณ์อื่นได้")
    :phew-here-is-your-passphrase          "*โล่งอกไปที* มันไม่ง่ายเลย นี่คือวลีรหัสผ่านของคุณ *จดมันไว้และรักษามันให้ปลอดภัย!* คุณจะจำเป็นต้องใช้มันเพื่อกู้คืนบัญชีของคุณ"
    :here-is-your-passphrase               "นี่คือวลีรหัสผ่านของคุณ *จดมันไว้และรักษามันให้ปลอดภัย!* คุณจะจำเป็นต้องใช้มันเพื่อกู้คืนบัญชีของคุณ"
-   :written-down                          "ตรวจสอบให้มั่นใจว่าคุณได้จดบันทึกมันไว้อย่างปลอดภัยแล้ว"
    :phone-number-required                 "แตะที่นี่เพื่อกรอกหมายเลขโทรศัพท์ของคุณ & ฉันจะค้นหาเพื่อนของคุณ"
    :intro-status                          "แชทกับฉันเพื่อตั้งค่าบัญชีของคุณและเปลี่ยนการตั้งค่าของคุณ!"
    :intro-message1                        "ยินดีต้อนรับสู่สถานะ \n แตะข้อความนี้เพื่อตั้งรหัสผ่านของคุณ & เริ่มต้น!"
@@ -95,7 +82,6 @@
 
    ;chats
    :chats                                 "แชท"
-   :new-chat                              "แชทใหม่"
    :new-group-chat                        "แชทกลุ่มใหม่"
 
    ;discover
@@ -112,9 +98,6 @@
    ;contacts
    :contacts                              "ผู้ติดต่อ"
    :new-contact                           "ผู้ติดต่อใหม่"
-   :show-all                              "แสดงทั้งหมด"
-   :contacts-group-dapps                  "ÐApps"
-   :contacts-group-people                 "ผู้คน"
    :contacts-group-new-chat               "เริ่มแชทใหม่"
    :no-contacts                           "ยังไม่มีผู้ติดต่อ"
    :show-qr                               "แสดง QR"
@@ -122,41 +105,17 @@
    ;group-settings
    :remove                                "ลบ"
    :save                                  "บันทึก"
-   :change-color                          "เปลี่ยนสี"
    :clear-history                         "ลบประวัติ"
-   :delete-and-leave                      "ลบและออก"
    :chat-settings                         "การตั้งค่าแชท"
    :edit                                  "แก้ไข"
    :add-members                           "เพิ่มสมาชิก"
-   :blue                                  "น้ำเงิน"
-   :purple                                "ม่วง"
-   :green                                 "เขียว"
-   :red                                   "แดง"
 
    ;commands
-   :money-command-description             "ส่งเงิน"
-   :location-command-description          "ส่งตำแหน่ง"
-   :phone-command-description             "ส่งหมายเลขโทรศัพท์"
-   :phone-request-text                    "คำร้องขอหมายเลขโทรศัพท์"
-   :confirmation-code-command-description "ส่งรหัสยืนยัน"
-   :confirmation-code-request-text        "คำร้องขอรหัสยืนยัน"
-   :send-command-description              "ส่งตำแหน่ง"
-   :request-command-description           "ส่งคำร้องขอ"
-   :keypair-password-command-description  ""
-   :help-command-description              "ช่วยเหลือ"
-   :request                               "คำร้องขอ"
    :chat-send-eth                         "{{amount}} ETH"
-   :chat-send-eth-to                      "{{amount}} ETH ไปยัง {{chat-name}}"
-   :chat-send-eth-from                    "{{amount}} ETH จาก {{chat-name}}"
 
    ;new-group
-   :group-chat-name                       "ชื่อแชท"
-   :empty-group-chat-name                 "โปรดกรอกชื่อ"
-   :illegal-group-chat-name               "โปรดเลือกชื่ออื่น"
 
    ;participants
-   :add-participants                      "เพิ่มผู้เข้าร่วม"
-   :remove-participants                   "ลบผู้เข้าร่วม"
 
    ;protocol
    :received-invitation                   "คำเชิญแชทที่ได้รับ"
@@ -168,12 +127,9 @@
 
    ;new-contact
    :add-new-contact                       "เพิ่มผู้ติดต่อใหม่"
-   :import-qr                             "นำเข้า"
    :scan-qr                               "สแกน QR"
    :name                                  "ชื่อ"
-   :whisper-identity                      "กระซิบตัวตน"
    :address-explication                   "บางที ในที่นี้คุณควรกรอกข้อความสักเล็กน้อยเพื่อแสดงที่อยู่หรือสถานที่ที่จะมองหามันได้"
-   :enter-valid-address                   "โปรดกรอกที่อยู่ที่ถูกต้องหรือสแกนรหัส QR"
    :contact-already-added                 "ได้มีการเพิ่มผู้ติดต่อนี้แล้ว"
    :can-not-add-yourself                  "คุณไม่สามารถเพิ่มตัวคุณเอง"
    :unknown-address                       "ที่อยู่ที่ไม่ทราบ"
@@ -183,20 +139,14 @@
    :connect                               "เชื่อมต่อ"
    :address                               "ที่อยู่"
    :password                              "รหัสผ่าน"
-   :login                                 "ล็อกอิน"
    :wrong-password                        "รหัสผ่านไม่ถูกต้อง"
 
    ;recover
-   :recover-from-passphrase               "กู้คืนจากวลีรหัสผ่าน"
-   :recover-explain                       "โปรดกรอกวลีรหัสผ่านสำหรับรหัสผ่านของคุณเพื่อกู้คืนการเข้าถึง"
    :passphrase                            "วลีรหัสผ่าน"
    :recover                               "กู้คืน"
-   :enter-valid-passphrase                "โปรดกรอกวลีรหัสผ่าน"
-   :enter-valid-password                  "โปรดกรอกรหัสผ่าน"
 
    ;accounts
    :recover-access                        "กู้คืนการเข้าถึง"
-   :add-account                           "เพิ่มบัญชี"
 
    ;wallet-qr-code
    :done                                  "เสร็จสิ้น"
@@ -205,34 +155,20 @@
    ;validation
    :invalid-phone                         "หมายเลขโทรศัพท์ไม่ถูกต้อง"
    :amount                                "จำนวน"
-   :not-enough-eth                        (str "ETH ไม่เพียงพอในยอดคงเหลือ "
-                                               "({{balance}} ETH)")
    ;transactions
-   :confirm-transactions                  {:one   "ยืนยันธุรกรรม"
-                                           :other "ยืนยัน {{count}} ธุรกรรม"
-                                           :zero  "ไม่มีธุรกรรม"}
    :status                                "สถานะ"
-   :pending-confirmation                  "การยืนยันที่ค้างอยู่"
    :recipient                             "ผู้รับ"
-   :one-more-item                         "อีกหนึ่งรายการ"
-   :fee                                   "ค่าธรรมเนียม"
-   :value                                 "มูลค่า"
 
    ;:webview
    :web-view-error                        "อุ๊ย มีข้อผิดพลาด"
 
    :confirm                               "ยืนยัน"
    :phone-national                        "ระดับชาติ"
-   :transactions-confirmed                {:one   "ยืนยันการทำธุรกรรมแล้ว"
-                                           :other "ยืนยันการทำธุรกรรมแล้ว {{count}} รายการ"
-                                           :zero  "ไม่มีการยืนยันการทำธุรกรรม"}
    :public-group-topic                    "หัวข้อ"
    :debug-enabled                         "มีการเปิดการดำเนินงานของเซิร์ฟเวอร์ที่ได้แก้ไขข้อบกพร่องแล้ว! ตอนนี้คุณสามารถเพิ่ม DApp ของคุณโดยการเปิดดำเนินการ *status-dev-cli scan* จากคอมพิวเตอร์ของคุณ"
    :new-public-group-chat                 "เข้าร่วมแชทสาธารณะ"
    :datetime-ago-format                   "{{number}} {{time-intervals}} {{ago}}"
    :sharing-cancel                        "ยกเลิก"
-   :share-qr                              "แชร์ QR"
-   :feedback                              "ได้รับคำติชม?\nเขย่าโทรศัพท์ของคุณ"
    :twelve-words-in-correct-order         "12 คำตามลำดับที่ถูกต้อง"
    :remove-from-contacts                  "ลบออกจากรายชื่อติดต่อ"
    :delete-chat                           "ลบแชท"
@@ -272,7 +208,6 @@
    :contact-s
                                           {:one   "รายชื่อติดต่อ"
                                            :other "รายชื่อติดต่อ"}
-   :group-name                            "ชื่อกลุ่ม"
    :next                                  "ถัดไป"
    :from                                  "จาก"
    :search-chats                          "ค้นหาแชท"
@@ -289,17 +224,10 @@
    :more                                  "เพิ่มเติม"
    :cancel                                "ยกเลิก"
    :no-statuses-found                     "ไม่พบสถานะ"
-   :swow-qr                               "แสดง QR"
    :browsing-open-in-web-browser          "เปิดในเว็บเบราว์เซอร์"
    :delete-group-prompt                   "การดำเนินการนี้จะไม่ส่งผลต่อรายชื่อติดต่อ"
    :edit-profile                          "แก้ไขโปรไฟล์"
 
-   :enter-password-transactions
-                                          {:one   "ยืนยันการทำธุรกรรมโดยการใส่รหัสผ่านของคุณ"
-                                           :other "ยืนยันการทำธุรกรรมโดยการใส่รหัสผ่านของคุณ"}
-   :unsigned-transactions                 "การทำธุรกรรมที่ยังไม่ได้ลงนาม"
    :empty-topic                           "หัวข้อว่างเปล่า"
    :to                                    "ถึง"
-   :group-members                         "สมาชิกกลุ่ม"
-   :estimated-fee                         "ค่าธรรมเนียมโดยประมาณ"
    :data                                  "ข้อมูล"})

--- a/src/status_im/translations/tr.cljs
+++ b/src/status_im/translations/tr.cljs
@@ -10,8 +10,6 @@
    :offline                               "Çevrimdışı"
 
    ;drawer
-   :invite-friends                        "Arkadaşlarınızı davet edin"
-   :faq                                   "SSS"
    :switch-users                          "Kullanıcıları değiştir"
 
    ;chat
@@ -53,41 +51,30 @@
                                            :other "saat"}
    :datetime-day                          {:one   "gün"
                                            :other "gün"}
-   :datetime-multiple                     "sn"
    :datetime-ago                          "önce"
    :datetime-yesterday                    "dün"
    :datetime-today                        "bugün"
 
    ;profile
    :profile                               "Profil"
-   :report-user                           "KULLANICIYI ŞİKAYET ET"
    :message                               "Mesaj"
-   :username                              "Kullanıcı Adı"
    :not-specified                         "Belirtilmemiş"
    :public-key                            "Ortak Anahtar"
    :phone-number                          "Telefon Numarası'"
-   :email                                 "E-posta"
-   :profile-no-status                     "Durum yok"
    :add-to-contacts                       "Kişi listesine ekle"
-   :error-incorrect-name                  "Hatalı isim"
-   :error-incorrect-email                 "Hatalı e-posta adresi"
 
    ;make_photo
    :image-source-title                    "Profil Fotoğrafı"
    :image-source-make-photo               "Çek"
    :image-source-gallery                  "Galeriden seç"
-   :image-source-cancel                   "İptal"
 
    ;sign-up
    :contacts-syncronized                  "Kişi listeniz eşitlendi"
    :confirmation-code                     (str "Teşekkürler! Size onay kodunu içeren bir kısa mesaj "
                                                "gönderdim. Telefon numaranızı onaylamak için lütfen bu kodu girin")
    :incorrect-code                        (str "Üzgünüm kod hatalıydı, lütfen yeniden girin")
-   :generate-passphrase                   (str "sizin için bir parola oluşturacağım, böylece başka bir cihazdan "
-                                               "erişebilecek ya da girişinizi kurtarabileceksiniz")
    :phew-here-is-your-passphrase          "*Oh* bu oldukça zor oldu işte parolanız, *bu parolayı bir yere not ederek saklayın!* Hesabınızı kurtarmak için bu parolaya ihtiyacınız olacaktır."
    :here-is-your-passphrase               "İşte parolanız, *bu parolayı bir yere not ederek saklayın!* Hesabınızı kurtarmak için bu parolaya ihtiyacınız olacaktır."
-   :written-down                          "Güvenli bir şekilde not ettiğinizden emin olun"
    :phone-number-required                 "Telefon numaranızı girmek için buraya dokunun, arkadaşlarınızı ben bulacağım"
    :intro-status                          "Hesabınızı kurmak ve ayarlarınızı değiştirmek için benimle sohbet edin!"
    :intro-message1                        "Status'e hoş geldiniz\nŞifrenizi oluşturmak ve hemen başlamak için bu mesaja dokunun!"
@@ -95,7 +82,6 @@
 
    ;chats
    :chats                                 "Sohbetler"
-   :new-chat                              "Yeni sohbet"
    :new-group-chat                        "Yeni grup sohbeti"
 
    ;discover
@@ -112,9 +98,6 @@
    ;contacts
    :contacts                              "Kişiler"
    :new-contact                           "Yeni Kişi"
-   :show-all                              "TÜMÜNÜ GÖSTER"
-   :contacts-group-dapps                  "ÐApps"
-   :contacts-group-people                 "Kişiler"
    :contacts-group-new-chat               "Yeni sohbet başlat"
    :no-contacts                           "Henüz herhangi bir kişi yok"
    :show-qr                               "Kare Kodu göster"
@@ -122,41 +105,17 @@
    ;group-settings
    :remove                                "Kaldır"
    :save                                  "Kaydet"
-   :change-color                          "Rengi değiştir"
    :clear-history                         "Geçmişi temizle"
-   :delete-and-leave                      "Sil ve ayrıl"
    :chat-settings                         "Sohbet ayarları"
    :edit                                  "Düzenle"
    :add-members                           "Üye ekle"
-   :blue                                  "Mavi"
-   :purple                                "Mor"
-   :green                                 "Yeşil"
-   :red                                   "Kırmızı"
 
    ;commands
-   :money-command-description             "Para gönder"
-   :location-command-description          "Konum gönder"
-   :phone-command-description             "Telefon numarasını gönder"
-   :phone-request-text                    "Telefon numarası iste"
-   :confirmation-code-command-description "Onay kodunu gönder"
-   :confirmation-code-request-text        "Onay kodu iste"
-   :send-command-description              "Konum gönder"
-   :request-command-description           "İstek gönder"
-   :keypair-password-command-description  "Şifre gönder"
-   :help-command-description              "Yardım"
-   :request                               "İstek"
    :chat-send-eth                         "{{amount}} ETH"
-   :chat-send-eth-to                      "{{amount}} ETH alıcı: {{chat-name}}"
-   :chat-send-eth-from                    "{{amount}} ETH gönderen: {{chat-name}}"
 
    ;new-group
-   :group-chat-name                       "Sohbet adı"
-   :empty-group-chat-name                 "Lütfen bir isim girin"
-   :illegal-group-chat-name               "Lütfen başka bir isim seçin"
 
    ;participants
-   :add-participants                      "Katılımcı Ekle"
-   :remove-participants                   "Katılımcıları Sil"
 
    ;protocol
    :received-invitation                   "sohbet daveti alındı"
@@ -168,12 +127,9 @@
 
    ;new-contact
    :add-new-contact                       "Yeni kişi ekle"
-   :import-qr                             "İçe aktar"
    :scan-qr                               "Kare Kod tara"
    :name                                  "İsim"
-   :whisper-identity                      "Whisper Kimliği"
    :address-explication                   "Burada belki de bir adresin ne olduğu ve bunu bulmak için nereye bakılmasıyla ilgili bazı metinler yer alabilir"
-   :enter-valid-address                   "Lütfen geçerli bir adres girin ya da bir Kare Kod tarayın"
    :contact-already-added                 "Kişi zaten eklendi"
    :can-not-add-yourself                  "Kendinizi ekleyemezsiniz"
    :unknown-address                       "Bilinmeyen adres"
@@ -183,20 +139,14 @@
    :connect                               "Bağlan"
    :address                               "Adres"
    :password                              "Şifre"
-   :login                                 "Oturum Aç"
    :wrong-password                        "Hatalı Şifre"
 
    ;recover
-   :recover-from-passphrase               "Parolayı kullanarak kurtar"
-   :recover-explain                       "Erişimi kurtarmak için lütfen şifreniz için parolanızı girin"
    :passphrase                            "Parola"
    :recover                               "Kurtar"
-   :enter-valid-passphrase                "Lütfen geçerli bir parola girin"
-   :enter-valid-password                  "Lütfen geçerli bir şifre girin"
 
    ;accounts
    :recover-access                        "Erişimi kurtar"
-   :add-account                           "Hesap ekle"
 
    ;wallet-qr-code
    :done                                  "Yapıldı"
@@ -205,34 +155,20 @@
    ;validation
    :invalid-phone                         "Geçersiz telefon numarası"
    :amount                                "Miktar"
-   :not-enough-eth                        (str "Yeterli ETH bakiyesi yok"
-                                               "({{balance}} ETH)")
    ;transactions
-   :confirm-transactions                  {:one   "İşlemi onayla"
-                                           :other "{{count}} işlemi onayla"
-                                           :zero  "İşlem yok"}
    :status                                "Durum"
-   :pending-confirmation                  "Bekleyen onay"
    :recipient                             "Alıcı"
-   :one-more-item                         "Bir öğe daha"
-   :fee                                   "Ücret"
-   :value                                 "Değer"
 
    ;:webview
    :web-view-error                        "hoppala, hata"
 
    :confirm                               "Onayla"
    :phone-national                        "Ulusal"
-   :transactions-confirmed                {:one   "İşlem onaylandı"
-                                           :other "{{count}} işlem onaylandı"
-                                           :zero  "Hiçbir işlem onaylanmadı"}
    :public-group-topic                    "Başlık"
    :debug-enabled                         "Hata ayıklama sunucusu başlatıldı! Artık şimdi bilgisayarınızdan *status-dev-cli scan* çalıştırarak DApp'inizi ekleyebilirsiniz"
    :new-public-group-chat                 "Herkese açık sohbete katılın"
    :datetime-ago-format                   "{{number}} {{time-intervals}} {{ago}}"
    :sharing-cancel                        "İptal Et"
-   :share-qr                              "QR Paylaş"
-   :feedback                              "Geri bildirimde bulunmak ister misiniz?\nTelefonunuzu sallayın!"
    :twelve-words-in-correct-order         "Doğru sırayla 12 kelime"
    :remove-from-contacts                  "Kişi listesinden çıkarın"
    :delete-chat                           "Sohbeti silin"
@@ -272,7 +208,6 @@
    :contact-s
                                           {:one   "kişi"
                                            :other "kişiler"}
-   :group-name                            "Grup ismi"
    :next                                  "Sonraki"
    :from                                  "Şuradan:"
    :search-chats                          "Sohbetlerde arayın"
@@ -289,17 +224,10 @@
    :more                                  "dahası"
    :cancel                                "İptal Et"
    :no-statuses-found                     "Durum bulunamadı"
-   :swow-qr                               "QR Göster"
    :browsing-open-in-web-browser          "Web tarayıcısında açın"
    :delete-group-prompt                   "Bu, kişi listesini etkilemeyecektir"
    :edit-profile                          "Profili düzenleyin"
 
-   :enter-password-transactions
-                                          {:one   "Şifrenizi girerek işlemi onaylayın"
-                                           :other "Şifrenizi girerek işlemleri onaylayın"}
-   :unsigned-transactions                 "İmzalanmamış işlemler"
    :empty-topic                           "Boş başlık"
    :to                                    "Gönderilen:"
-   :group-members                         "Grup üyeleri"
-   :estimated-fee                         "Tahmini ücret"
    :data                                  "Veri"})

--- a/src/status_im/translations/uk.cljs
+++ b/src/status_im/translations/uk.cljs
@@ -10,8 +10,6 @@
    :offline                               "Оффлайн"
 
    ;drawer
-   :invite-friends                        "Запросити друзів"
-   :faq                                   "Часті питання"
    :switch-users                          "Зміна користувача"
 
    ;chat
@@ -53,30 +51,22 @@
                                            :other "годин"}
    :datetime-day                          {:one   "день"
                                            :other "днів"}
-   :datetime-multiple                     "с"
    :datetime-ago                          "тому"
    :datetime-yesterday                    "вчора"
    :datetime-today                        "сьогодні"
 
    ;profile
    :profile                               "Профіль"
-   :report-user                           "ДОПОВІСТИ ПРО КОРИСТУВАЧА"
    :message                               "Повідомлення"
-   :username                              "Ім'я користувача"
    :not-specified                         "Не вказано"
    :public-key                            "Відкритий ключ"
    :phone-number                          "Номер телефону"
-   :email                                 "Ел. пошта"
-   :profile-no-status                     "Немає статусу"
    :add-to-contacts                       "Додати до контактів"
-   :error-incorrect-name                  "Будь ласка, виберіть інше ім'я"
-   :error-incorrect-email                 "Невірна ел. пошта"
 
    ;;make_photo
    :image-source-title                    "Фото профілю"
    :image-source-make-photo               "Зробити знімок"
    :image-source-gallery                  "Вибрати з галереї"
-   :image-source-cancel                   "Відміна"
 
    ;;sharing
    :sharing-copy-to-clipboard             "Скопіювати"
@@ -88,11 +78,8 @@
    :confirmation-code                     (str "Дякуємо! Ми відправили вам текстове повідомлення з кодом "
                                                "підтвердження. Будь ласка, надайте цей код, щоб підтвердити свій номер телефону")
    :incorrect-code                        (str "На жаль, код невірний, будь ласка, введіть ще раз")
-   :generate-passphrase                   (str "Я створю ключову фразу для вас, щоб ви могли відновити ваш "
-                                               "доступ або увійти з іншого пристрою")
    :phew-here-is-your-passphrase          "*Оце так*, було складно, ось ваша ключова фраза, *запишіть її та надійно зберігайте!* Вона вам знадобиться для відновлення облікового запису."
    :here-is-your-passphrase               "Ось ваша ключова фраза, *запишіть її та надійно зберігайте!* Вона вам знадобиться для відновлення облікового запису."
-   :written-down                          "Переконайтеся, що ви надійно її записали"
    :phone-number-required                 "Торкніться тут, щоб ввести ваш номер телефону і я знайду ваших друзів"
    :intro-status                          "Спілкуйтеся зі мною, щоб налаштувати свій обліковий запис і змінити налаштування!"
    :intro-message1                        "Вітаємо в Статус\nТоркніться цього повідомлення, щоб встановити пароль і почати!"
@@ -100,7 +87,6 @@
 
    ;chats
    :chats                                 "Групи"
-   :new-chat                              "Новий чат"
    :new-group-chat                        "Новий груповий чат"
 
    ;discover
@@ -117,9 +103,6 @@
    ;contacts
    :contacts                              "Контакти"
    :new-contact                           "Новий контакт"
-   :show-all                              "ПОКАЗАТИ ВСІ"
-   :contacts-group-dapps                  "ÐApps"
-   :contacts-group-people                 "Люди"
    :contacts-group-new-chat               "Почати нову розмову"
    :no-contacts                           "Поки що контактів немає"
    :show-qr                               "Показати QR"
@@ -127,41 +110,17 @@
    ;group-settings
    :remove                                "Видалити"
    :save                                  "Зберегти"
-   :change-color                          "Змінити колір"
    :clear-history                         "Очистити історію"
-   :delete-and-leave                      "Видалити та залишити"
    :chat-settings                         "Налаштування розмови"
    :edit                                  "Редагувати"
    :add-members                           "Додати учасників"
-   :blue                                  "Голубий"
-   :purple                                "Фіолетовий"
-   :green                                 "Зелений"
-   :red                                   "Червоний"
 
    ;commands
-   :money-command-description             "Надіслати гроші"
-   :location-command-description          "Надіслати місцезнаходження"
-   :phone-command-description             "Надіслати номер телефону"
-   :phone-request-text                    "Запит номеру телефону"
-   :confirmation-code-command-description "Надіслати код підтвердження"
-   :confirmation-code-request-text        "Запит коду підтвердження"
-   :send-command-description              "Надіслати місцезнаходження"
-   :request-command-description           "Надіслати запит"
-   :keypair-password-command-description  ""
-   :help-command-description              "Допомога"
-   :request                               "Запит"
    :chat-send-eth                         "{{amount}} ETH"
-   :chat-send-eth-to                      "{{amount}} ETH для {{chat-name}}"
-   :chat-send-eth-from                    "{{amount}} ETH від {{chat-name}}"
 
    ;new-group
-   :group-chat-name                       "Назва розмови"
-   :empty-group-chat-name                 "Будь ласка, введіть назву"
-   :illegal-group-chat-name               "Будь ласка, виберіть іншу назву"
 
    ;participants
-   :add-participants                      "Додайте учасників"
-   :remove-participants                   "Видаліть учасників"
 
    ;protocol
    :received-invitation                   "отримано запрошення до розмови"
@@ -173,12 +132,9 @@
 
    ;new-contact
    :add-new-contact                       "Додати новий контакт"
-   :import-qr                             "Імпорт"
    :scan-qr                               "Сканувати QR"
    :name                                  "Назва"
-   :whisper-identity                      "Прошепотіти справжність"
    :address-explication                   "Можливо тут повинен бути текст, який пояснює, що таке адреса і де її шукати"
-   :enter-valid-address                   "Будь ласка, введіть дійсну адресу або відскануйте QR-код"
    :enter-valid-public-key                "Будь ласка, введіть дійсний відкритий ключ або відскануйте QR-код"
    :contact-already-added                 "Контакт вже додано"
    :can-not-add-yourself                  "Ви не можете додати себе"
@@ -189,20 +145,14 @@
    :connect                               "Підключитися"
    :address                               "Адреса"
    :password                              "Пароль"
-   :login                                 "Логін"
    :wrong-password                        "Невірний пароль"
 
    ;recover
-   :recover-from-passphrase               "Відновити з ключовою фразою"
-   :recover-explain                       "Будь ласка, введіть ключову фразу для вашого пароля, щоб відновити доступ"
    :passphrase                            "Ключова фраза"
    :recover                               "Відновити"
-   :enter-valid-passphrase                "Будь ласка, введіть ключову фразу"
-   :enter-valid-password                  "Будь ласка, введіть пароль"
 
    ;accounts
    :recover-access                        "Відновити доступ"
-   :add-account                           "Додати обліковий запис"
 
    ;wallet-qr-code
    :done                                  "Готово"
@@ -211,33 +161,19 @@
    ;validation
    :invalid-phone                         "Невірний номер телефону"
    :amount                                "Сума"
-   :not-enough-eth                        (str "Недостатньо ETH на балансі "
-                                               "({{balance}} ETH)")
    ;transactions
-   :confirm-transactions                  {:one   "Підтвердити транзакцію"
-                                           :other "Підтвердити {{count}} транзакції"
-                                           :zero  "Немає транзакцій"}
    :status                                "Статус"
-   :pending-confirmation                  "Очікує підтвердження"
    :recipient                             "Отримувач"
-   :one-more-item                         "Ще один пункт"
-   :fee                                   "Комісія"
-   :value                                 "Значення"
 
    ;:webview
    :web-view-error                        "ой, помилка"
 
    :confirm                               "Підтвердити"
    :phone-national                        "Національне"
-   :transactions-confirmed                {:one   "Транзакцію підтверджено"
-                                           :other "Підтверджено {{count}} транзакцій"
-                                           :zero  "Підтверджені транзакції відсутні"}
    :public-group-topic                    "Тема"
    :debug-enabled                         "Debug server запущено! Тепер ви можете додати свій DApp запустивши *status-dev-cli scan* зі свого комп’ютера"
    :new-public-group-chat                 "Приєднатися до публічного чату"
    :datetime-ago-format                   "{{number}} {{time-intervals}} {{ago}}"
-   :share-qr                              "Поділитись QR"
-   :feedback                              "Маєте відгук?\nСтряхніть свій телефон!"
    :twelve-words-in-correct-order         "12 слів в правильному порядку"
    :remove-from-contacts                  "Видалити з контактів"
    :delete-chat                           "Видалити чат"
@@ -275,7 +211,6 @@
    :contact-s
                                           {:one   "контакт"
                                            :other "контакти"}
-   :group-name                            "Назва групи"
    :next                                  "Наступне"
    :from                                  "З"
    :search-chats                          "Шукати чати"
@@ -291,17 +226,10 @@
    :more                                  "ще"
    :cancel                                "Відмінити"
    :no-statuses-found                     "Статуси не знайдено"
-   :swow-qr                               "Показати QR"
    :browsing-open-in-web-browser          "Відкрити у браузері"
    :delete-group-prompt                   "Це не вплине на контакти"
    :edit-profile                          "Редагувати профіль"
 
-   :enter-password-transactions
-                                          {:one   "Підтвердіть операцію, ввівши пароль"
-                                           :other "Підтвердіть операції, ввівши пароль"}
-   :unsigned-transactions                 "Непідписані транзакції"
    :empty-topic                           "Тема пуста"
    :to                                    "До"
-   :group-members                         "Члени групи"
-   :estimated-fee                         "Прибл. комісія"
    :data                                  "Дані"})

--- a/src/status_im/translations/ur.cljs
+++ b/src/status_im/translations/ur.cljs
@@ -10,8 +10,6 @@
    :offline                               "آف لائن"
 
    ;drawer
-   :invite-friends                        "دوستوں کو مدعو کریں"
-   :faq                                   "FAQ"
    :switch-users                          "صارف تبدیل کریں"
 
    ;chat
@@ -53,41 +51,30 @@
                                            :other "گھنٹے"}
    :datetime-day                          {:one   "دن"
                                            :other "دن"}
-   :datetime-multiple                     "s"
    :datetime-ago                          "قبل"
    :datetime-yesterday                    "کل"
    :datetime-today                        "آج"
 
    ;profile
    :profile                               "پروفائل"
-   :report-user                           "صارف کی رپورٹ کریں"
    :message                               "پیغام"
-   :username                              "صارف کا نام"
    :not-specified                         "واضح نہیں کیا گیا"
    :public-key                            "Public Key"
    :phone-number                          "فون نمبر"
-   :email                                 "ای میل"
-   :profile-no-status                     "کوئی سٹیٹس نہیں"
    :add-to-contacts                       "اپنے رابطوں میں درج کریں"
-   :error-incorrect-name                  "برائے مہربانی کوئی اور نام چنیں"
-   :error-incorrect-email                 "غلط ای میل"
 
    ;;make_photo
    :image-source-title                    "پروفائل تصویر"
    :image-source-make-photo               "کھینچیں"
    :image-source-gallery                  "گیلری سے چنیں"
-   :image-source-cancel                   "کینسل"
 
    ;sign-up
    :contacts-syncronized                  "آپ کے کانٹیکٹس سنکرونائز ہو گئے ہیں"
    :confirmation-code                     (str "شکریہ! ہم نے آپ کو تصدیق کا پیغام بھیج دیا ہے "
                                                "کوڈ کے ساتھ۔ برائے مہربانی اپنا نمبر کنفرم کرنے کے لیے وہ کوڈ فراہم کریں۔")
    :incorrect-code                        (str "معذرت، کوڈ غلط تھا، برائے مہربانی دوبارہ درج کریں")
-   :generate-passphrase                   (str "میں آپ کے لیے passphrase تشکیل دوں گا تا کہ آپ "
-                                               "کسی دوسری ڈیوائس سے لاگ ان یا رسائی حاصل کر سکیں")
    :phew-here-is-your-passphrase          "*اف* یہ مشکل تھا, یہ آپ کی passphrase ہے۔, *اسے لکھ لیں اور اپنے پاس محفوظ کر لیں۔* آپ کو اپنا اکاؤنٹ بحال کرنے کے لیے اس کی ضرورت ہو گی۔"
    :here-is-your-passphrase               "یہ آپ کی passphrase ہے۔, *ا اکاؤنٹ بحال کرنے کے لیے اس کی ضرورت * ہے۔, *اسے لکھ لیں اور اپنے پاس محفوظ کر لیں۔* آپ کو ا"
-   :written-down                          "یہ یقینی بنا لیں کہ آپ نے اسے بحفاظت لکھ لیا ہے۔"
    :phone-number-required                 "اپنا فون نمبر درج کرنے کے لیے یہاں ٹیپ کریں اور میں آپ کے دوستوں کو تلاش کروں گا"
    :intro-status                          "اپنا اکاؤنٹ سیٹ اپ کرنے اور سیٹنگز تبدیل کرنے کے لیے مجھ سے چیٹ کریں!"
    :intro-message1                        "سٹیٹس میں خوش آمدید اور اپنا پاسورڈ سیٹ کرنے کے لیے اس کو ٹیپ کریں اور شروعات کریں۔"
@@ -95,7 +82,6 @@
 
    ;chats
    :chats                                 "چیٹ"
-   :new-chat                              "نئی چیٹ"
    :new-group-chat                        "نئی گروپ چیٹ"
 
    ;discover
@@ -112,9 +98,6 @@
    ;contacts
    :contacts                              "رابطے"
    :new-contact                           "نئے رابطے"
-   :show-all                              "سب دکھائیں"
-   :contacts-group-dapps                  "ÐApps"
-   :contacts-group-people                 "لوگ"
    :contacts-group-new-chat               "نئی چیٹ شروع کریں"
    :no-contacts                           "ابھی یہاں کوئی کنٹیکٹ نہیں"
    :show-qr                               "دکھائیں QR"
@@ -122,41 +105,17 @@
    ;group-settings
    :remove                                "نکالیں"
    :save                                  "محفوظ کریں"
-   :change-color                          "رنگ تبدیل کریں"
    :clear-history                         "تاریخ مٹا دیں"
-   :delete-and-leave                      "حذف کریں اور چھوڑ دیں"
    :chat-settings                         "چیٹ کی سیٹنگز"
    :edit                                  "تصحیح"
    :add-members                           "ممبران شامل کریں"
-   :blue                                  "نیلا"
-   :purple                                "جامنی"
-   :green                                 "سبز"
-   :red                                   "سرخ"
 
    ;commands
-   :money-command-description             "رقم بھیجیں"
-   :location-command-description          "مقام بھیجیں"
-   :phone-command-description             "فون نمبر بھیجیں"
-   :phone-request-text                    "فون نمبر کی درخواست کریں"
-   :confirmation-code-command-description "برائے مہربانی یقین دہانی کا کوڈ بھیجیں"
-   :confirmation-code-request-text        "تصدیقی کوڈ کی درخواست"
-   :send-command-description              "مقام بھیجیں"
-   :request-command-description           "درخواست بھیجیں"
-   :keypair-password-command-description  ""
-   :help-command-description              "مدد"
-   :request                               "درخواست"
    :chat-send-eth                         "{{amount}} ETH"
-   :chat-send-eth-to                      "{{amount}} ETH کرنے {{chat-name}}"
-   :chat-send-eth-from                    "{{amount}} ETH سے {{chat-name}}"
 
    ;new-group
-   :group-chat-name                       "چیٹ کا نام"
-   :empty-group-chat-name                 "برائے مہربانی کو ایک نام درج کریں"
-   :illegal-group-chat-name               "برائے مہربانی کوئی اور نام درج کریں"
 
    ;participants
-   :add-participants                      "ساتھیوں کو شامل کریں"
-   :remove-participants                   "ساتھیوں کو نکالیں"
 
    ;protocol
    :received-invitation                   "چیٹ کا دعوت نامہ وصول ہوا ہے"
@@ -168,12 +127,9 @@
 
    ;new-contact
    :add-new-contact                       "نیا کانٹیکٹ شامل کریں"
-   :import-qr                             "امپورٹ"
    :scan-qr                               "سکین کریں QR"
    :name                                  "نام"
-   :whisper-identity                      "شناخت بتائیں"
    :address-explication                   "شائد یہاں آپ کو کچھ لکھنا چاہیے دیکھنے کے لیے کہ پتہ کیا ہے اور اسے کہاں ہونا چاہیے"
-   :enter-valid-address                   "برائے مہربانی  درست  پتہ یا QR سکین کریں"
    :contact-already-added                 "کانٹیکٹ پہلے سے شامل ہے"
    :can-not-add-yourself                  "آپ خود کو شامل نہیں کر سکتے"
    :unknown-address                       "نامعلوم پتہ"
@@ -183,20 +139,14 @@
    :connect                               "ملیں"
    :address                               "پتہ"
    :password                              "پاسورڈ"
-   :login                                 "لاگ ان"
    :wrong-password                        "غلط پاسورڈ"
 
    ;recover
-   :recover-from-passphrase               "passphrase کے ذریعے بحال کریں"
-   :recover-explain                       "رسائی حاصل کرنے کے لیے اپنے پاسورڈ کا passphrase درج کریں"
    :passphrase                            "Passphrase"
    :recover                               "بحال کریں"
-   :enter-valid-passphrase                "برائے مہربانی passphrase درج کریں"
-   :enter-valid-password                  "برائے مہربانی پاسورڈ لکھیں"
 
    ;accounts
    :recover-access                        "رسائی بحال کریں"
-   :add-account                           "اکاؤنٹ شامل کریں"
 
    ;wallet-qr-code
    :done                                  "ہو گیا"
@@ -205,34 +155,20 @@
    ;validation
    :invalid-phone                         "غلط فون نمبر"
    :amount                                "رقم"
-   :not-enough-eth                        (str "بیلنس میں کافی ETH موجود نہیں۔ "
-                                               "({{balance}} ETH)")
    ;transactions
-   :confirm-transactions                  {:one   "بیوپار کی تصدیق کریں"
-                                           :other "تصدیق {{count}} بیوپار"
-                                           :zero  "کوئی بیوپار نہیں ہوا"}
    :status                                "سٹیٹس"
-   :pending-confirmation                  "تصدیق کی ضرورت ہے"
    :recipient                             "وصول کنندہ"
-   :one-more-item                         "ایک اور چیز"
-   :fee                                   "فیس"
-   :value                                 "رقم"
 
    ;:webview
    :web-view-error                        "اوہ، غلطی ہو گئی"
 
    :confirm                               "توثیق کریں"
    :phone-national                        "قومی"
-   :transactions-confirmed                {:one   "لین دین کی تصدیق ہوئی"
-                                           :other "{{count}} لین دین کی توثیق ہوئی"
-                                           :zero  "کسی لین دین کی توثیق نہیں ہوئی"}
    :public-group-topic                    "موضوع"
    :debug-enabled                         "ڈی بگ سرور کو لانچ کیا گیا ہے! آپ کا آئی پتہ ہے۔ اب آپ اپنے کمپیوٹر سے *status-dev-cli scan* کو چلاتے ہوئے اپنا DApp شامل کر سکتے ہیں"
    :new-public-group-chat                 "عوامی چیٹ میں شامل ہوں"
    :datetime-ago-format                   "{{number}} {{time-intervals}} {{ago}}"
    :sharing-cancel                        "منسوخ کریں"
-   :share-qr                              "کیو آر کوڈ کا اشتراک کریں"
-   :feedback                              "رائے موصول ہوئی؟\nاپنے فون کو ہلائیں!"
    :twelve-words-in-correct-order         "درست ترتیب میں 12 الفاظ"
    :remove-from-contacts                  "روابط سے خارج کریں"
    :delete-chat                           "چیٹ کو حذف کریں"
@@ -272,7 +208,6 @@
    :contact-s
                                           {:one   "رابطہ"
                                            :other "روابط"}
-   :group-name                            "گروپ کا نام"
    :next                                  "اگلا"
    :from                                  "سے"
    :search-chats                          "چیٹس تلاش کریں"
@@ -289,17 +224,10 @@
    :more                                  "مزید"
    :cancel                                "منسوخ کریں"
    :no-statuses-found                     "کسی اسٹیٹس کا پتہ نہیں چلا"
-   :swow-qr                               "کیو آر دکھائیں"
    :browsing-open-in-web-browser          "ویب براؤزر میں کھولیں"
    :delete-group-prompt                   "اس سے روابط متاثر نہیں ہونگے"
    :edit-profile                          "پروفائل میں ترمیم کریں"
 
-   :enter-password-transactions
-                                          {:one   "اپنا پاس ورڈ داخل کرتے ہوئے لین دین کی توثیق کریں"
-                                           :other "اپنا پاس ورڈ داخل کرتے ہوئے لین دین کی توثیق کریں"}
-   :unsigned-transactions                 "غیر دستخط شدہ لین دین"
    :empty-topic                           "خالی موضوع"
    :to                                    "بجانب"
-   :group-members                         "گروپ کا رکن"
-   :estimated-fee                         "ادارہ کی فیس"
    :data                                  "ڈیٹا"})

--- a/src/status_im/translations/vi.cljs
+++ b/src/status_im/translations/vi.cljs
@@ -10,8 +10,6 @@
    :offline                               "Không trực tuyến"
 
    ;drawer
-   :invite-friends                        "Mời bạn bè "
-   :faq                                   "FAQ"
    :switch-users                          "Đổi người dùng"
 
    ;chat
@@ -53,41 +51,30 @@
                                            :other "giờ"}
    :datetime-day                          {:one   "ngày"
                                            :other "ngày"}
-   :datetime-multiple                     "s"
    :datetime-ago                          "trước đây"
    :datetime-yesterday                    "hôm qua"
    :datetime-today                        "hôm nay"
 
    ;profile
    :profile                               "Hồ sơ"
-   :report-user                           "BÁO CÁO NGƯỜI DÙNG"
    :message                               "Tin nhắn"
-   :username                              "Tên người dùng"
    :not-specified                         "Không được xác định"
    :public-key                            "Khóa công khai"
    :phone-number                          "Số điện thoại"
-   :email                                 "Email"
-   :profile-no-status                     "Không có trạng thái"
    :add-to-contacts                       "Thêm vào liên hệ"
-   :error-incorrect-name                  "Vui lòng chọn một tên khác"
-   :error-incorrect-email                 "E-mail không chính xách"
 
    ;;make_photo
    :image-source-title                    "Ảnh đại diện"
    :image-source-make-photo               "Chụp"
    :image-source-gallery                  "Chọn từ gallery"
-   :image-source-cancel                   "Hủy"
 
    ;sign-up
    :contacts-syncronized                  "Các liên hệ của bạn đã được đồng bộ hóa"
    :confirmation-code                     (str "Cảm ơn! Chúng tôi đã gửi cho bạn một tin nhắn văn bản với một xác nhận "
                                                "Vui lòng cung cấp mã đó để xác nhận số điện thoại của bạn")
    :incorrect-code                        (str "Xin lỗi mã không chính xác, vui lòng nhập lại")
-   :generate-passphrase                   (str "Tôi sẽ tạo ra một cụm mật khẩu để cho bạn có thể khôi phục "
-                                               "quyền truy cập của bạn hoặc đăng nhập từ một thiết bị khác")
    :phew-here-is-your-passphrase          "*Phù* điều đó thật khó khăn, đây là cụm mật khẩu của bạn, *hãy viết cụm này ra và giữ nó an toàn!* Bạn sẽ cần nó để khôi phục tài khoản của bạn."
    :here-is-your-passphrase               "Đây là cụm mật khẩu của bạn, *hãy viết cụm này ra và giữ nó an toàn!* Bạn sẽ cần nó để khôi phục tài khoản của bạn."
-   :written-down                          "Hãy đảm bảo rằng bạn đã viết nó ra một cách bảo mật"
    :phone-number-required                 "Nhấp vào đây để nhập số điện thoại của bạn & tôi sẽ tìm kiếm bạn bè của bạn"
    :intro-status                          "Trò chuyện với tôi để thiết lập tài khoản của bạn và thay đổi các thiết lập của bạn!"
    :intro-message1                        "Chào mừng đến với trang Trạng thái\nNhấp vào tin nhắn này để thiết lập mật khẩu của bạn & bắt đầu!"
@@ -95,7 +82,6 @@
 
    ;chats
    :chats                                 "Trò chuyện"
-   :new-chat                              "Cuộc trò chuyện mới"
    :new-group-chat                        "Cuộc trò chuyện theo nhóm mới"
 
    ;discover
@@ -112,9 +98,6 @@
    ;contacts
    :contacts                              "Các liên hệ"
    :new-contact                           "Liên hệ mới"
-   :show-all                              "HIỂN THỊ TOÀN BỘ"
-   :contacts-group-dapps                  "ÐApps"
-   :contacts-group-people                 "Cá nhân"
    :contacts-group-new-chat               "Bắt đầu cuộc trò chuyện mới"
    :no-contacts                           "Chưa có liên hệ"
    :show-qr                               "Hiển thị QR"
@@ -122,41 +105,17 @@
    ;group-settings
    :remove                                "Xóa"
    :save                                  "Lưu"
-   :change-color                          "Thay đổi màu sắc"
    :clear-history                         "Xóa lịch sử"
-   :delete-and-leave                      "Xóa và rời đi"
    :chat-settings                         "Thiết lập trò chuyện"
    :edit                                  "Điều chỉnh"
    :add-members                           "Thêm Thành viên"
-   :blue                                  "Màu xanh da trời"
-   :purple                                "Màu tím"
-   :green                                 "Màu xanh lá cây"
-   :red                                   "Màu đỏ"
 
    ;commands
-   :money-command-description             "Gửi tiền"
-   :location-command-description          "Gửi vị trí"
-   :phone-command-description             "Gửi số điện thoại"
-   :phone-request-text                    "Yêu cầu số điện thoại"
-   :confirmation-code-command-description "Gửi mã xác nhận"
-   :confirmation-code-request-text        "Yêu cầu mã xác nhận"
-   :send-command-description              "Gửi vị trí"
-   :request-command-description           "Gửi yêu cầu"
-   :keypair-password-command-description  ""
-   :help-command-description              "Giúp đỡ"
-   :request                               "Yêu cầu"
    :chat-send-eth                         "{{amount}} ETH"
-   :chat-send-eth-to                      "{{amount}} ETH đến {{chat-name}}"
-   :chat-send-eth-from                    "{{amount}} ETH từ {{chat-name}}"
 
    ;new-group
-   :group-chat-name                       "Tên trò chuyện"
-   :empty-group-chat-name                 "Vui lòng nhập một tên"
-   :illegal-group-chat-name               "Vui lòng chọn một tên khác"
 
    ;participants
-   :add-participants                      "Thêm Người tham gia"
-   :remove-participants                   "Xóa Người tham gia"
 
    ;protocol
    :received-invitation                   "đã nhận lời mời trò chuyện"
@@ -168,12 +127,9 @@
 
    ;new-contact
    :add-new-contact                       "Thêm liên hệ mới"
-   :import-qr                             "Nhập"
    :scan-qr                               "Quét QR"
    :name                                  "Tên"
-   :whisper-identity                      "Danh tính Whisper"
    :address-explication                   "Có lẽ ở đây nên có một vài nội dung để giải thích địa chỉ này là gì và phải tìm nó ở đâu"
-   :enter-valid-address                   "Vui lòng nhập một địa chỉ hợp lệ hoặc quét một mã QR"
    :contact-already-added                 "Liên hệ đã được thêm vào"
    :can-not-add-yourself                  "Bạn không thể tự thêm mình"
    :unknown-address                       "Địa chỉ không xác định"
@@ -183,20 +139,14 @@
    :connect                               "Kết nối"
    :address                               "Địa chỉ"
    :password                              "Mật khẩu"
-   :login                                 "Đăng nhập"
    :wrong-password                        "Mật khẩu sai"
 
    ;recover
-   :recover-from-passphrase               "Khôi phục từ cụm mật khẩu"
-   :recover-explain                       "Vui lòng nhập cụm mật khẩu cho mật khẩu của bạn để khôi phục quyền truy cập"
    :passphrase                            "Cụm mật khẩu"
    :recover                               "Khôi phục"
-   :enter-valid-passphrase                "Vui lòng nhập một cụm mật khẩu"
-   :enter-valid-password                  "Vui lòng nhập một mật khẩu"
 
    ;accounts
    :recover-access                        "Khôi phục quyền truy cập"
-   :add-account                           "Thêm tài khoản"
 
    ;wallet-qr-code
    :done                                  "Đã hoàn thành"
@@ -205,34 +155,20 @@
    ;validation
    :invalid-phone                         "Số điện thoại không hợp lệ"
    :amount                                "Số tiền"
-   :not-enough-eth                        (str "Không đủ ETH trong số dư "
-                                               "({{balance}} ETH)")
    ;transactions
-   :confirm-transactions                  {:one   "Xác nhận giao dịch"
-                                           :other "Xác nhận {{count}} giao dịch"
-                                           :zero  "Không có giao dịch"}
    :status                                "Trạng thái"
-   :pending-confirmation                  "Chờ xác nhận"
    :recipient                             "Người nhận"
-   :one-more-item                         "Thêm một mục nữa"
-   :fee                                   "Phí"
-   :value                                 "Giá trị"
 
    ;:webview
    :web-view-error                        "Ối, lỗi"
 
    :confirm                               "Xác nhận"
    :phone-national                        "Quốc gia"
-   :transactions-confirmed                {:one   "Đã xác nhận giao dịch"
-                                           :other "{{Count}} giao dịch đã được xác nhận"
-                                           :zero  "Không có giao dịch nào được xác nhận"}
    :public-group-topic                    "Chủ đề"
    :debug-enabled                         "Máy chủ gỡ lỗi đã được khởi chạy! Bạn có thể thêm DApp bằng cách chạy *status-dev-cli scan* từ máy tính của mình"
    :new-public-group-chat                 "Tham gia cuộc trò chuyện công khai"
    :datetime-ago-format                   "{{number}} {{time-intervals}} {{ago}}"
    :sharing-cancel                        "Hủy"
-   :share-qr                              "Chia sẻ mã QR"
-   :feedback                              "Nhận phản hồi?\nLắc điện thoại của bạn!"
    :twelve-words-in-correct-order         "12 từ theo đúng thứ tự"
    :remove-from-contacts                  "Xóa khỏi danh bạ"
    :delete-chat                           "Xóa cuộc trò chuyện"
@@ -272,7 +208,6 @@
    :contact-s
                                           {:one   "liên hệ"
                                            :other "Danh bạ"}
-   :group-name                            "Tên nhóm"
    :next                                  "Tiếp theo"
    :from                                  "Từ"
    :search-chats                          "Tìm kiếm các cuộc trò chuyện"
@@ -289,17 +224,10 @@
    :more                                  "thêm"
    :cancel                                "Hủy"
    :no-statuses-found                     "Không tìm thấy trạng thái nào"
-   :swow-qr                               "Hiển thị mã QR"
    :browsing-open-in-web-browser          "Mở trong trình duyệt web"
    :delete-group-prompt                   "Điều này sẽ không ảnh hưởng đến danh bạ"
    :edit-profile                          "Chỉnh sửa hồ sơ"
 
-   :enter-password-transactions
-                                          {:one   "Xác nhận giao dịch bằng cách nhập mật khẩu"
-                                           :other "Xác nhận giao dịch bằng cách nhập mật khẩu"}
-   :unsigned-transactions                 "Các giao dịch chưa được ký"
    :empty-topic                           "Chủ đề trống"
    :to                                    "Đến"
-   :group-members                         "Thành viên nhóm"
-   :estimated-fee                         "Chi phí ước tính"
    :data                                  "Dữ liệu"})

--- a/src/status_im/translations/zh_hant.cljs
+++ b/src/status_im/translations/zh_hant.cljs
@@ -19,11 +19,7 @@
    :photos-access-error                   "要授予所需的照片許可，請轉到系統設置，並確保選擇“狀態“>“照片“。"
 
    ;drawer
-   :invite-friends                        "邀請好友"
-   :faq                                   "常見問題"
    :switch-users                          "切換使用者"
-   :feedback                              "有反饋？\n搖動你的手機！"
-   :view-all                              "查看所有"
    :current-network                       "當前網絡"
 
    ;chat
@@ -69,7 +65,6 @@
                                            :other "時"}
    :datetime-day                          {:one   "天"
                                            :other "天"}
-   :datetime-multiple                     "秒"
    :datetime-ago                          "以前"
    :datetime-yesterday                    "昨天"
    :datetime-today                        "今天"
@@ -77,13 +72,10 @@
    ;profile
    :profile                               "個人資料"
    :edit-profile                          "編輯個人資料"
-   :report-user                           "檢舉使用者"
    :message                               "訊息"
-   :username                              "使用者名稱"
    :not-specified                         "未指定"
    :public-key                            "公開金鑰"
    :phone-number                          "電話號碼"
-   :email                                 "電子郵件"
    :update-status                         "更新你的狀態..."
    :add-a-status                          "添加狀態..."
    :status-prompt                         "建立一個狀態以幫助人們了解您提供的內容。 你也可以使用#hashtags。"
@@ -92,15 +84,11 @@
    :remove-from-contacts                  "從聯絡資訊中刪除"
    :start-conversation                    "開始對話"
    :send-transaction                      "發送交易"
-   :share-qr                              "分享QR碼"
-   :error-incorrect-name                  "錯誤的名稱"
-   :error-incorrect-email                 "錯誤的電子郵件地址"
 
    ;;make_photo
    :image-source-title                    "個人圖片"
    :image-source-make-photo               "拍攝"
    :image-source-gallery                  "從相簿中選擇"
-   :image-source-cancel                   "取消"
 
    ;;sharing
    :sharing-copy-to-clipboard             "複製到剪貼板"
@@ -116,11 +104,8 @@
    :confirmation-code                     (str "謝謝！我們已向您發送了帶有 "
                                                "確認代碼的訊息。請輸入此代碼以驗證您的手機號碼")
    :incorrect-code                        (str "很抱歉，代碼錯誤，請重新輸入")
-   :generate-passphrase                   (str "我會為您產生一個密碼短語，您可以使用它 "
-                                               "在其他裝置上回復帳號或登入")
    :phew-here-is-your-passphrase          "*啊哈*，這是您的密碼短語，*請寫下來，並好好保管！* 您需要它來回復您的帳號。"
    :here-is-your-passphrase               "這是您的密碼短語，*請寫下來，並好好保管！* 您需要它來回復您的帳號。"
-   :written-down                          "請確認您已將密碼短語寫下，並存放在安全的地點"
    :phone-number-required                 "點選這裡輸入您的手機號碼，我會找到您的好友"
    :shake-your-phone                      "發現錯誤或有建議？ 只要〜搖一搖〜你的手機！"
    :intro-status                          "與我聊天以設定您的帳號並變更設定！"
@@ -137,7 +122,6 @@
 
    ;chats
    :chats                                 "聊天室"
-   :new-chat                              "新對話"
    :delete-chat                           "刪除對話"
    :new-group-chat                        "新群組"
    :new-public-group-chat                 "加入公開聊天"
@@ -167,9 +151,6 @@
    :remove-from-group                     "從群組中移除"
    :edit-contacts                         "編輯聯絡人"
    :search-contacts                       "搜尋聯絡人"
-   :show-all                              "顯示全部"
-   :contacts-group-dapps                  "ÐApps"
-   :contacts-group-people                 "成員"
    :contacts-group-new-chat               "開始新對話"
    :choose-from-contacts                  "從聯絡人中選擇"
    :no-contacts                           "尚無聯絡資訊"
@@ -181,52 +162,26 @@
    :remove                                "移除"
    :save                                  "保存"
    :delete                                "刪除"
-   :change-color                          "更改顏色"
    :clear-history                         "清理歷史記錄"
-   :delete-and-leave                      "刪除並離開"
    :mute-notifications                    "靜音通知"
    :leave-chat                            "離開對話"
    :chat-settings                         "聊天設定"
    :edit                                  "編輯"
    :add-members                           "新增成員"
-   :blue                                  "藍色"
-   :purple                                "紫色"
-   :green                                 "綠色"
-   :red                                   "紅色"
 
    ;commands
-   :money-command-description             "匯款"
-   :location-command-description          "傳送位置"
-   :phone-command-description             "傳送手機號碼"
-   :phone-request-text                    "請求手機號碼"
-   :confirmation-code-command-description "傳送確認碼"
-   :confirmation-code-request-text        "請求確認碼"
-   :send-command-description              "傳送位置"
-   :request-command-description           "傳送請求"
-   :keypair-password-command-description  ""
-   :help-command-description              "幫助"
-   :request                               "請求"
    :chat-send-eth                         "{{amount}} ETH"
-   :chat-send-eth-to                      "{{amount}} ETH 給 {{chat-name}}"
-   :chat-send-eth-from                    "{{amount}} ETH 來自 {{chat-name}}"
 
    ;new-group
-   :group-chat-name                       "群組名稱"
-   :empty-group-chat-name                 "請輸入名稱"
-   :illegal-group-chat-name               "請選擇其他名稱"
    :new-group                             "新增群組"
    :reorder-groups                        "重新排序群組"
-   :group-name                            "群組名稱"
    :edit-group                            "編輯群組"
    :delete-group                          "刪除群組"
    :delete-group-confirmation             "此群組將從你的群組中移除。 這不會影響聯絡人"
    :delete-group-prompt                   "這不會影響聯絡人"
-   :group-members                         "群組成員"
    :contact-s                             {:one   "contact"
                                            :other "contacts"}
    ;participants
-   :add-participants                      "新增參與者"
-   :remove-participants                   "移除參與者"
 
    ;protocol
    :received-invitation                   "收到的聊天邀請"
@@ -238,13 +193,9 @@
 
    ;new-contact
    :add-new-contact                       "新增新的聯絡人"
-   :import-qr                             "匯入"
    :scan-qr                               "掃描QR碼"
-   :swow-qr                               "顯示QR碼"
    :name                                  "名稱"
-   :whisper-identity                      "Whisper身份"
    :address-explication                   "也許這裡要有些文字介紹位址是什麼，又能在哪裡找到它"
-   :enter-valid-address                   "請輸入有效位址或掃描QR碼"
    :enter-valid-public-key                "請輸入有效公鑰或掃描QR碼"
    :contact-already-added                 "已新增該聯絡人"
    :can-not-add-yourself                  "您不能新增自己"
@@ -255,23 +206,17 @@
    :connect                               "連線"
    :address                               "地址"
    :password                              "密碼"
-   :login                                 "登入"
    :sign-in-to-status                     "登入Status"
    :sign-in                               "登入"
    :wrong-password                        "密碼錯誤"
 
    ;recover
-   :recover-from-passphrase               "使用密碼短語回復"
-   :recover-explain                       "請輸入此密碼的密碼短語來回復登入權限"
    :passphrase                            "密碼短語"
    :recover                               "回復"
-   :enter-valid-passphrase                "請輸入密碼短語"
-   :enter-valid-password                  "請輸入密碼"
    :twelve-words-in-correct-order         "正確排序12個字"
 
    ;accounts
    :recover-access                        "回復登入權限"
-   :add-account                           "新增帳號"
    :create-new-account                    "建立新帳號"
 
    ;wallet-qr-code
@@ -281,33 +226,15 @@
    ;validation
    :invalid-phone                         "無效的手機號碼"
    :amount                                "金額"
-   :not-enough-eth                        (str "ETH餘額不足 "
-                                               "({{balance}} ETH)")
    ;transactions
    :confirm                               "確認"
-   :confirm-transactions                  {:one   "確認交易"
-                                           :other "確認 {{count}} 筆交易"
-                                           :zero  "無交易"}
-   :transactions-confirmed                {:one   "已確認交易"
-                                           :other "已確認 {{count}} 筆交易"
-                                           :zero  "無確認交易"}
    :transaction                           "交易"
-   :unsigned-transactions                 "未確認交易"
-   :no-unsigned-transactions              "無未確認交易"
-   :enter-password-transactions           {:one   "輸入密碼以確認交易"
-                                           :other "輸入密碼以確認交易"}
    :status                                "狀態"
-   :pending-confirmation                  "等待確認中"
    :recipient                             "接收方"
-   :one-more-item                         "再一項"
-   :fee                                   "費用"
-   :estimated-fee                         "預算費用"
-   :value                                 "價值"
    :to                                    "至"
    :from                                  "從"
    :data                                  "數據"
    :got-it                                "得到了"
-   :contract-creation                     "創建合同"
 
    ;:webview
    :web-view-error                        "哎呀，出錯了"})

--- a/src/status_im/translations/zh_wuu.cljs
+++ b/src/status_im/translations/zh_wuu.cljs
@@ -19,11 +19,7 @@
    :photos-access-error                   "要授予所需的照片许可，请转到系统设置，并确保选择“状态“>“照片“。"
 
    ;drawer
-   :invite-friends                        "邀请朋友"
-   :faq                                   "常见问题"
    :switch-users                          "切换用户"
-   :feedback                              "有反馈？\n摇动你的手机！"
-   :view-all                              "查看所有"
    :current-network                       "当前网络"
 
    ;chat
@@ -69,7 +65,6 @@
                                            :other "小时"}
    :datetime-day                          {:one   "日"
                                            :other "日"}
-   :datetime-multiple                     "s"
    :datetime-ago                          "之前"
    :datetime-yesterday                    "昨天"
    :datetime-today                        "今天"
@@ -77,13 +72,10 @@
    ;profile
    :profile                               "个人资料"
    :edit-profile                          "编辑个人资料"
-   :report-user                           "报告用户"
    :message                               "消息"
-   :username                              "用户名"
    :not-specified                         "未指定"
    :public-key                            "公共密钥"
    :phone-number                          "电话号码"
-   :email                                 "电子邮箱"
    :update-status                         "更新你的状态..."
    :add-a-status                          "添加状态..."
    :status-prompt                         "建立一个状态以帮助人们了解您提供的内容。 你也可以使用#hashtags。"
@@ -92,15 +84,11 @@
    :remove-from-contacts                  "从联系人中删除"
    :start-conversation                    "开始对话"
    :send-transaction                      "发送交易"
-   :share-qr                              "分享QR码"
-   :error-incorrect-name                  "请选择另一个名字"
-   :error-incorrect-email                 "不正确的电子邮箱"
 
    ;;make_photo
    :image-source-title                    "个人资料照片"
    :image-source-make-photo               "截图"
    :image-source-gallery                  "从相册中选择"
-   :image-source-cancel                   "取消"
 
    ;;sharing
    :sharing-copy-to-clipboard             "复制到剪贴板"
@@ -116,11 +104,8 @@
    :confirmation-code                     (str "谢谢！我们已经给您发了一个确认短信"
                                                "代码。请提供该代码以确认您的电话号码")
    :incorrect-code                        (str "对不起，代码不正确，请再输入一次")
-   :generate-passphrase                   (str "我会为您生成一个口令短语，您可以恢复您的 "
-                                               "从另一个设备访问或登录")
    :phew-here-is-your-passphrase          "*唷* 是很难的，这是您的口令短语，*写下来并保证安全！* 您将需要它来恢复您的帐户。"
    :here-is-your-passphrase               "这是您的口令短语，*写下来并保证安全！* 您将需要它来恢复您的帐户。"
-   :written-down                          "确保您已经安全地写下来"
    :phone-number-required                 "点击这里进入您的电话号码，我会找到您的朋友"
    :shake-your-phone                      "发现错误或有建议？ 只要〜摇一摇〜你的手机！"
    :intro-status                          "与我聊天设置您的帐户，并更改您的设置！"
@@ -137,7 +122,6 @@
 
    ;chats
    :chats                                 "聊天"
-   :new-chat                              "新的聊天"
    :delete-chat                           "刪除聊天"
    :new-group-chat                        "新的群聊"
    :new-public-group-chat                 "加入公开聊天"
@@ -167,9 +151,6 @@
    :remove-from-group                     "从群组中移除"
    :edit-contacts                         "编辑联络人"
    :search-contacts                       "搜寻联络人"
-   :show-all                              "显示全部"
-   :contacts-group-dapps                  "ÐApps"
-   :contacts-group-people                 "人"
    :contacts-group-new-chat               "开始新的聊天"
    :choose-from-contacts                  "从联络人中选择"
    :no-contacts                           "暂无联系人"
@@ -180,53 +161,27 @@
    ;group-settings
    :remove                                "移动"
    :save                                  "保存"
-   :change-color                          "改变颜色"
    :clear-history                         "清除历史"
-   :delete-and-leave                      "删除并离开"
    :delete                                "刪除"
    :mute-notifications                    "静音通知"
    :leave-chat                            "离开对话"
    :chat-settings                         "聊天设置"
    :edit                                  "编辑"
    :add-members                           "添加会员"
-   :blue                                  "蓝色"
-   :purple                                "紫色"
-   :green                                 "绿色"
-   :red                                   "红色"
 
    ;commands
-   :money-command-description             "发送钱"
-   :location-command-description          "发送地址"
-   :phone-command-description             "发送电话号码"
-   :phone-request-text                    "请求电话号码"
-   :confirmation-code-command-description "发送确认码"
-   :confirmation-code-request-text        "请求确认码"
-   :send-command-description              "发送地址"
-   :request-command-description           "发送请求"
-   :keypair-password-command-description  ""
-   :help-command-description              "帮助"
-   :request                               "请求"
    :chat-send-eth                         "{{amount}} ETH"
-   :chat-send-eth-to                      "{{amount}} ETH至 {{chat-name}}"
-   :chat-send-eth-from                    "{{amount}} ETH来自 {{chat-name}}"
 
    ;new-group
-   :group-chat-name                       "聊天名称"
-   :empty-group-chat-name                 "请输入一个名称"
-   :illegal-group-chat-name               "选择另一个名称"
    :new-group                             "新增群組"
    :reorder-groups                        "重新排序群組"
-   :group-name                            "群組名稱"
    :edit-group                            "編輯群組"
    :delete-group                          "刪除群組"
    :delete-group-confirmation             "此群組將從你的群組中移除。 這不會影響聯絡人"
    :delete-group-prompt                   "這不會影響聯絡人"
-   :group-members                         "群組成員"
    :contact-s                             {:one   "contact"
                                            :other "contacts"}
    ;participants
-   :add-participants                      "添加参与者"
-   :remove-participants                   "删除参与者"
 
    ;protocol
    :received-invitation                   "接受聊天邀请"
@@ -238,13 +193,9 @@
 
    ;new-contact
    :add-new-contact                       "增加新的联系人"
-   :import-qr                             "导入"
    :scan-qr                               "扫描QR"
-   :swow-qr                               "顯示QR碼"
    :name                                  "名称"
-   :whisper-identity                      "耳语身份"
    :address-explication                   "也许这应该有一个文本，解释地址是什么以及在哪里寻找它"
-   :enter-valid-address                   "请输入一个有效的地址或扫描QR码"
    :enter-valid-public-key                "请输入有效公钥或扫描QR码"
    :contact-already-added                 "联系人已被添加"
    :can-not-add-yourself                  "您不能添加您自己"
@@ -255,23 +206,17 @@
    :connect                               "连接"
    :address                               "地址"
    :password                              "密码"
-   :login                                 "登录"
    :wrong-password                        "错误的密码"
    :sign-in-to-status                     "登录Status"
    :sign-in                               "登录"
 
    ;recover
-   :recover-from-passphrase               "恢复口令短语"
-   :recover-explain                       "请输入密码的口令短语来恢复访问"
    :passphrase                            "口令短语"
    :recover                               "恢复"
-   :enter-valid-passphrase                "请输入口令短语"
-   :enter-valid-password                  "请输入密码"
    :twelve-words-in-correct-order         "正确排序12个字"
 
    ;accounts
    :recover-access                        "恢复访问"
-   :add-account                           "添加账户"
    :create-new-account                    "建立新帐户"
 
    ;wallet-qr-code
@@ -281,33 +226,15 @@
    ;validation
    :invalid-phone                         "无效的电话号码"
    :amount                                "金额"
-   :not-enough-eth                        (str "ETH余额不足"
-                                               "({{balance}} ETH)")
    ;transactions
    :confirm                               "确认"
-   :confirm-transactions                  {:one   "确认交易"
-                                           :other "确认{{count}} 交易"
-                                           :zero  "无交易"}
-   :transactions-confirmed                {:one   "已确认交易"
-                                           :other "已确认 {{count}} 笔交易"
-                                           :zero  "无确认交易"}
    :transaction                           "交易"
-   :unsigned-transactions                 "未确认交易"
-   :no-unsigned-transactions              "无未确认交易"
-   :enter-password-transactions           {:one   "输入密码以确认交易"
-                                           :other "输入密码以确认交易"}
    :status                                "状态"
-   :pending-confirmation                  "待确认"
    :recipient                             "收件人"
-   :one-more-item                         "一个以上项目"
-   :fee                                   "金额"
-   :value                                 "价值"
-   :estimated-fee                         "预算费用"
    :to                                    "至"
    :from                                  "从"
    :data                                  "数据"
    :got-it                                "得到了"
-   :contract-creation                     "创建合同"
 
    ;:webview
    :web-view-error                        "啊哦，错误"})

--- a/src/status_im/translations/zh_yue.cljs
+++ b/src/status_im/translations/zh_yue.cljs
@@ -19,11 +19,7 @@
    :photos-access-error                   "要授予所需的照片許可，請轉到系統設置，並確保選擇“狀態“>“照片“。"
 
    ;drawer
-   :invite-friends                        "邀請好友"
-   :faq                                   "常見問題"
    :switch-users                          "切換用戶"
-   :feedback                              "有反饋？\n搖動你的手機！"
-   :view-all                              "查看所有"
    :current-network                       "當前網絡"
 
    ;chat
@@ -69,7 +65,6 @@
                                            :other "小時"}
    :datetime-day                          {:one   "天"
                                            :other "天"}
-   :datetime-multiple                     "s"
    :datetime-ago                          "之前"
    :datetime-yesterday                    "昨天"
    :datetime-today                        "今天"
@@ -77,13 +72,10 @@
    ;profile
    :profile                               "用戶簡介"
    :edit-profile                          "編輯個人資料"
-   :report-user                           "投訴用戶"
    :message                               "短訊"
-   :username                              "用戶名稱"
    :not-specified                         "未標明"
    :public-key                            "公共鑰匙"
    :phone-number                          "電話號碼"
-   :email                                 "電郵"
    :update-status                         "更新你的狀態..."
    :add-a-status                          "添加狀態..."
    :status-prompt                         "建立一個狀態以幫助人們了解您提供的內容。 你也可以使用#hashtags。"
@@ -92,15 +84,11 @@
    :remove-from-contacts                  "從聯絡資訊中刪除"
    :start-conversation                    "開始對話"
    :send-transaction                      "發送交易"
-   :share-qr                              "分享QR"
-   :error-incorrect-name                  "請選擇其他名稱"
-   :error-incorrect-email                 "電郵錯誤"
 
    ;;make_photo
    :image-source-title                    "封面照片"
    :image-source-make-photo               "捕獲照片"
    :image-source-gallery                  "從圖庫中選取"
-   :image-source-cancel                   "取消"
 
    ;;sharing
    :sharing-copy-to-clipboard             "複製到剪貼板"
@@ -116,11 +104,8 @@
    :confirmation-code                     (str "謝謝！我們已以短訊形式將確認信息發送給你"
                                                "代碼。請提供該代碼，以確認你的電話號碼")
    :incorrect-code                        (str "對不起，代碼不正確，請重新輸入")
-   :generate-passphrase                   (str "正在為你產生臨時登入碼，以便恢復你的"
-                                               "從另一設備訪問或登錄")
    :phew-here-is-your-passphrase          "*啊* 那可真不簡單。 這是你的臨時登入碼。 *請記錄並保存於安全地方!* 你將會需要它，以恢復你的帳戶。"
    :here-is-your-passphrase               "這是你的臨時登入碼。 *請記錄並保存於安全地方!* 你將會需要它，以恢復你的帳戶。"
-   :written-down                          "請確保你已經將其安全寫下來"
    :phone-number-required                 "請點擊這裡輸入您的電話號碼，我們將為你尋覓你的好友"
    :shake-your-phone                      "發現錯誤或有建議？ 只要〜搖一搖〜你的手機！"
    :intro-status                          "如需設置新帳戶或更改現有設置，請與我聊天！"
@@ -137,7 +122,6 @@
 
    ;chats
    :chats                                 "聊天史"
-   :new-chat                              "新增聊天"
    :delete-chat                           "刪除對話"
    :new-group-chat                        "新增群聊"
    :new-public-group-chat                 "加入公開聊天"
@@ -167,9 +151,6 @@
    :remove-from-group                     "從群組中移除"
    :edit-contacts                         "編輯聯絡人"
    :search-contacts                       "搜尋聯絡人"
-   :show-all                              "顯示所有"
-   :contacts-group-dapps                  "ÐApps"
-   :contacts-group-people                 "用戶"
    :contacts-group-new-chat               "開啟新聊天"
    :choose-from-contacts                  "從聯絡人中選擇"
    :no-contacts                           "No contacts yet"
@@ -181,52 +162,26 @@
    :remove                                "刪除"
    :save                                  "儲存"
    :delete                                "刪除"
-   :change-color                          "更改顏色"
    :clear-history                         "清除歷史記錄"
-   :delete-and-leave                      "刪除並離開"
    :mute-notifications                    "靜音通知"
    :leave-chat                            "離開對話"
    :chat-settings                         "聊天設置"
    :edit                                  "編輯"
    :add-members                           "增添成員"
-   :blue                                  "藍"
-   :purple                                "紫"
-   :green                                 "綠"
-   :red                                   "紅"
 
    ;commands
-   :money-command-description             "發送金錢"
-   :location-command-description          "發送位置"
-   :phone-command-description             "發送電話號碼"
-   :phone-request-text                    "請求電話號碼"
-   :confirmation-code-command-description "發送確認碼"
-   :confirmation-code-request-text        "徵求確認碼"
-   :send-command-description              "發送位置"
-   :request-command-description           "發送請求"
-   :keypair-password-command-description  ""
-   :help-command-description              "幫助"
-   :request                               "徵求"
    :chat-send-eth                         "{{amount}} ETH"
-   :chat-send-eth-to                      "{{amount}} ETH 予 {{chat-name}}"
-   :chat-send-eth-from                    "{{amount}} ETH 來自 {{chat-name}}"
 
    ;new-group
-   :group-chat-name                       "聊天用戶名稱"
-   :empty-group-chat-name                 "請輸入名稱"
-   :illegal-group-chat-name               "請選擇其他名稱"
    :new-group                             "新增群組"
    :reorder-groups                        "重新排序群組"
-   :group-name                            "群組名稱"
    :edit-group                            "編輯群組"
    :delete-group                          "刪除群組"
    :delete-group-confirmation             "此群組將從你的群組中移除。 這不會影響聯絡人"
    :delete-group-prompt                   "這不會影響聯絡人"
-   :group-members                         "群組成員"
    :contact-s                             {:one   "contact"
                                            :other "contacts"}
    ;participants
-   :add-participants                      "增添參與者"
-   :remove-participants                   "刪除參與者"
 
    ;protocol
    :received-invitation                   "收到聊天邀請"
@@ -238,13 +193,9 @@
 
    ;new-contact
    :add-new-contact                       "添加新聯繫人"
-   :import-qr                             "輸入"
    :scan-qr                               "掃描 QR"
-   :swow-qr                               "顯示QR碼"
    :name                                  "名稱"
-   :whisper-identity                      "秘密身份"
    :address-explication                   "請注意： 此文本解釋地址是什麼，以及在何處可找到它。"
-   :enter-valid-address                   "請輸入有效地址或掃描QR碼"
    :enter-valid-public-key                "請輸入有效公鑰或掃描QR碼"
    :contact-already-added                 "此聯繫人已添加"
    :can-not-add-yourself                  "你不能添加自己"
@@ -255,23 +206,17 @@
    :connect                               "連接"
    :address                               "地址"
    :password                              "密碼"
-   :login                                 "登入"
    :sign-in-to-status                     "登入Status"
    :sign-in                               "登入"
    :wrong-password                        "密碼錯誤"
 
    ;recover
-   :recover-from-passphrase               "以臨時登入碼恢復"
-   :recover-explain                       "請輸入密碼的臨時登入碼，以恢復訪問"
    :passphrase                            "臨時登入碼"
    :recover                               "還原"
-   :enter-valid-passphrase                "請輸入臨時登入碼"
-   :enter-valid-password                  "請輸入密碼"
    :twelve-words-in-correct-order         "正確排序12個字"
 
    ;accounts
    :recover-access                        "恢復訪問"
-   :add-account                           "新增帳戶"
    :create-new-account                    "建立新帳號"
 
    ;wallet-qr-code
@@ -281,33 +226,15 @@
    ;validation
    :invalid-phone                         "電話號碼無效"
    :amount                                "金額"
-   :not-enough-eth                        (str "沒有足夠ETH餘額"
-                                               "({{balance}} ETH)")
    ;transactions
    :confirm                               "確認"
-   :confirm-transactions                  {:one   "確認交易"
-                                           :other "確認{{{count}}個交易"
-                                           :zero  "無交易"}
-   :transactions-confirmed                {:one   "已確認交易"
-                                           :other "已確認 {{count}} 筆交易"
-                                           :zero  "無確認交易"}
    :transaction                           "交易"
-   :unsigned-transactions                 "未確認交易"
-   :no-unsigned-transactions              "無未確認交易"
-   :enter-password-transactions           {:one   "輸入密碼以確認交易"
-                                           :other "輸入密碼以確認交易"}
    :status                                "狀態"
-   :pending-confirmation                  "待確認"
    :recipient                             "收件人"
-   :one-more-item                         "多一件"
-   :fee                                   "費用"
-   :estimated-fee                         "預算費用"
-   :value                                 "價值"
    :to                                    "至"
    :from                                  "從"
    :data                                  "數據"
    :got-it                                "得到了"
-   :contract-creation                     "創建合同"
 
    ;:webview
    :web-view-error                        "抱歉，錯誤"})

--- a/test/cljs/status_im/test/i18n.cljs
+++ b/test/cljs/status_im/test/i18n.cljs
@@ -1,6 +1,29 @@
 (ns status-im.test.i18n
   (:require [cljs.test :refer-macros [deftest is]]
-            [status-im.i18n :as i18n]))
+            [status-im.i18n :as i18n]
+            [clojure.set :as set]
+            [cljs.spec.alpha :as spec]))
 
 (deftest label-options
   (is (not (nil? (:key (i18n/label-options {:key nil}))))))
+
+(deftest locales-only-have-existing-tran-ids
+  (is (spec/valid? ::i18n/labels (i18n/labels-for-all-locales))
+      (->> i18n/locales
+           (remove #(spec/valid? ::i18n/labels (i18n/locale->labels %)))
+           (map (fn [l]
+                  (str "Extra translations in locale " l "\n"
+                       (set/difference (i18n/locale->labels l) i18n/labels)
+                       "\n\n")))
+           (apply str))))
+
+(deftest supported-locales-are-actually-supported
+  (is (set/subset? i18n/supported-locales (i18n/actual-supported-locales))
+      (->> i18n/supported-locales
+           (remove i18n/locale-is-supported-based-on-translations?)
+           (map (fn [l]
+                  (str "Missing translations in supported locale " l "\n"
+                       (set/difference (i18n/checkpoint->labels i18n/checkpoint-to-consider-locale-supported)
+                                       (i18n/locale->labels l))
+                       "\n\n")))
+           (apply str))))


### PR DESCRIPTION
Fixes #2456

### User Stories

#### User Story 1
As a translator I want to ensure that I translate all English labels for the locale I am translated to be supported if that language is considered supported. If I don't, tests should fail, and I should be able to see what labels are missing from the tests report.

#### User Story 2

As a translator I want to be able to send translations for a locale, even if I don't send all translations for that locale to be supported, if that locale is not considered supported. Tests should not fail if I do so.

#### User story 3

As a reviewer I want to ensure that when a locale is considered supported in a PR, it has all translations to be really supported. Tests should fail otherwise, and I should be able to see that labels are missing in the tests report to tell them to the PR creator.

#### User story 4

As a reviewer I want to ensure that when translations are added, they are added to labels that exist in English. Tests should fail otherwise, and I should be able to see what labels don't exist in the tests report to tell them to the PR creator.

#### User story 5

As X I want to ensure that when I level up the checkpoint that specifies what labels are needed for a locale to be supported, all locales specified as supported actually pass that checkpoint. Tests should fail otherwise and I should see in the tests report what locales are not ready for those checkpoints, and the labels that are missing, so that I can ask for translations.

#### User story 6

As someone concerned with UX, I want to see what labels are missing in supported languages compared to English. Tests should not fail though, since tests should only fail if supported locale don't pass the current checkpoint.

### Steps to test

1. Run `lein test-cljs` and notice tests pass.
2. Add an unsupported language (for example `:ja`) to supported language list (var `supported-locales` in file `src/status_im/i18n.cljs`) and notice that tests fail. Undo the change.
3. Add a new label (for example `:foobar`) to English translations (file `src/status_im/translations/en.cljs`), and notice tests pass.
4. Define a new checkpoint using the label from step 3 (for example  `::checkpoint-0-9-13 (set/union checkpoint-0-9-12-labels #{:foobar}`, added in var `checkpoints-def` of file `src/status_im/i18n.cljs`), and notice that tests pass.
5. Make the checkpoint in step 4 the required one (by changing the var `checkpoint-to-consider-locale-supported` in file `src/status_im/i18n.cljs`), and notice that tests fail for languages where it previously passed, since they do not have the new locale that now is in the required checkpoint. Notice that  you can see the exact translations that are missing and in what languages.
6. Add the translation `:foobar` to language `:de` (a supported language), and notice that tests continue failing, but the report does not include the `:de` locale now.

### Status

Ready.

### Additional

I added specs for some i18n things:

* trans-id/s
* locale/s
* supported-locale/s
* checkpoint/s

**Translation ids**

English is used as the source of truth, that is, to know the translation ids that really exist.

So I added a test to check whether other locales have extra translations that actually do not exist. This way we can easily keep translation ids consistent with the original ones.

It seems that right now there are quite a lot of translation ids in other languages that are not in English, so the test is failing.

**Supported locales**

The biggest concern was to know what locales we support and to give feedback to translators and ourselves about how supported they really are.

So firstly I added a var to specify what locales we expect to be supported, `supported-locales`.

The support we expect for those locales isn’t full, that is, all translations, but it can be partial. So I added to specify incremental checkpoints to define what translations should be present for a language to support a checkpoint.

The fn `locales-with-checkpoint` tells us the checkpoint for every locale, or `nil` it it doesn’t support any.

Once we have checkpoints, we can specify the one that is required for a language to be really supported. This is done in the var `checkpoint-to-consider-locale-supported`.

And finally, with the expected supported locales and the checkpoint we expect for those languages, I added a test to check whether those locales really support that checkpoint.

We can also check whether there are locales that are supported and we do not have them as supported with the fn `supported-locales-that-are-not-considered-supported`.

This way we are not very strict with translators (they can even add a new locale with just one translation without tests failing), but we check what we really care about: the supported languages we define against the checkpoints we define. And if a locale that was supported becomes unsupported we notice from the test and can ask for missing translations or unmark it as supported.

What checkpoints and supported locales should we have right now?

Let me know if there is anything I am missing.