### PR TITLE
Bump status-go to develop-g6927638

### DIFF
--- a/modules/react-native-status/android/build.gradle
+++ b/modules/react-native-status/android/build.gradle
@@ -16,5 +16,5 @@ dependencies {
     compile 'com.facebook.react:react-native:+'
     compile 'com.instabug.library:instabug:3+'
     compile 'status-im:function:0.0.1'
-    compile(group: 'status-im', name: 'status-go', version: 'develop-gad9a877', ext: 'aar')
+    compile(group: 'status-im', name: 'status-go', version: 'develop-g6927638', ext: 'aar')
 }

--- a/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusModule.java
+++ b/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusModule.java
@@ -11,7 +11,7 @@ import android.webkit.WebStorage;
 
 import com.facebook.react.bridge.*;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
-import com.github.status_im.status_go.cmd.Statusgo;
+import com.github.status_im.status_go.Statusgo;
 
 import java.io.File;
 import java.io.IOException;

--- a/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusPackage.java
+++ b/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusPackage.java
@@ -5,7 +5,7 @@ import com.facebook.react.bridge.JavaScriptModule;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.uimanager.ViewManager;
-import com.github.status_im.status_go.cmd.Statusgo;
+import com.github.status_im.status_go.Statusgo;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/modules/react-native-status/ios/RCTStatus/pom.xml
+++ b/modules/react-native-status/ios/RCTStatus/pom.xml
@@ -25,7 +25,7 @@
                         <artifactItem>
                             <groupId>status-im</groupId>
                             <artifactId>status-go-ios-simulator</artifactId>
-                            <version>develop-gad9a877</version>
+                            <version>develop-g6927638</version>
                             <type>zip</type>
                             <overWrite>true</overWrite>
                             <outputDirectory>./</outputDirectory>


### PR DESCRIPTION
Addresses https://github.com/status-im/status-react/issues/2513.

We haven't upgraded status-go in a long time so it's about time. Also need this for some perf testing, but this will happen in a separate PR.

## Review notes
Nothing

## Testing notes

- Go through normal app flow with things that usually breaks with status-go upgrades
- Check with GoTeam on any hotspots for breaking changes

## Changelog

```
69276386d205293709856919ea2e80f2bc17755c Merge pull request #472 from status-im/bugfix/bring-back-parse
a22638f4215d865a745aff34b91cf5151cd3c644 be consistent with comments
47d16bffd01f35dc784d3ff0d621c382df5971c3 fix Parse
98b3f330afd433f2784d0db8fab9f3fe24ca92fb bring back Parse binding
4cd362213f81b1f15df790b41a1b631eb3faf51e Add env var to tune header writes delay (#464)
74d3e5e625b3fd4ff8c409c32877bffdb4a720e8 Add workaround for testing/cgo issue (#469)
001a9024079f8fb8a90d11700b651d3a353dabb5 Fix xgo invocation path after removal of env.sh (#466)
f0beeb38297ecc27ff44e65ae63f7ef579497ca2 fix failing tests in PRs from other repos, fixes #459 (#461)
e34a580143028752b568d0e7684b2ee61da394f9 travis timeout is now a sum of all timeouts
332e18a3a9023b82f9f93a0418c4b295d1a8ccbb travis timeouts has been increased
209d5fed7448c170d688d7e9540e6c51b02273eb Issue/fix public testnet tests #424 (#438)
9a3302ac3695e4f9b348ff3e4f71982f39242afd Makes random panics on node manager tests less frequent (#433)
086747a69599129e15cb7567193c454a20a7448a Refactor jail part 2 (#401)
cb5ccb52c43151306a569b0e7cfacfdb01012e3a Emit messages logs for processing and sorting out messaging problems (#420)
fb75054a3568c836ea4492df892d9b55a111e8b7 Fix TestJailWhisper e2e test (#442)
c6e98b948b8e1b69888d073eec50211dab1ca708 Get rid of build/env.sh Fixes #418 (#446)
a19e50268654032d97b2a327541d26314c8f42bc Remove go.rice in favour of go generate (#444)
4536e992758ab7ea825d61f1c182f81c0d3137de Improve statusd CLI usage (#441)
987cdd6221242823cc566f05d49107518d3bf8a4 Update Ropsten CHT to number 478 (#428)
21beb685b4d99c19e0999373c2037e7e5ea42b42 Add -network flag for Makefile to chose a network to run tests on #430
cf8aad90c039d5f5189ee20e768b7c94dec36248 Remove extra spacing
004aa83d845a959e5333b1642124823382cbab34 Remove unnecessary return
7a2c7651db1931a7d8d77c5e98317aeb0f9d71e3 Skip does not need return
df2100bf491c7f4fb54104d04557208c47393e33 Update readme
f0c992974cf0bb0c4c9fac903bede3168196801c Add network id to make file
2897f0ec0fd75cfa1380096ada4998c168a19638 Merge pull request #390 from status-im/issue/refactor-api-notify-send-messages-#342
61c277cccde685ba75d3a9f2137be1a481fc618b Revise to seperate go test commands
8145412d1ca8d9c92a65f2c70ac26fedc1fc9f3b Ensure to return err for nil RPCCLient
efa10134e89de9ba197361769683ce127cfd4b72 Fixing missing imports
1cc90541da77da4a290637603b14b837b98687a5 Update makefiles and make changes regards review
34e851a57f114535aa9c6a00fc6b7f55e05272b7 Merge pull request #425 from status-im/feature/pull-request-template
681a2d2d83275b6fd6ebe97453c21b78a5aac1ea Skip test requiring network url for statuschain
55b10483be81c75b8b5200a1b7be831aeebb50cc Merge pull request #436 from status-im/bugfix/fix-linter-435
71c259dd95608ca5b5cba2682d38b0bba6627721 turn off vet shadow
d058b9105a8f966a23ccd690b6c7bc4712b40dfd remove goimports
8cbd7ed1c436dc62cb0b6c32e1f4fe6411ab9206 fix linter across the whole project
41d883a5641ac88f6bb2cf8b8c05adbc810c6d5d Update makefile with network flag for needed test and fix failing tests
e80768a0908c4ccfab21b7b2d111774a0d62b4f6 Swap GetNetworkIDHash/GetHeadHashForNetworkID
8207a2724d8800db2baf2d61fa24ad6bb4d68bc1 Update usage of direct network id
4d356e08734ea8e9746ce718a6a14dd88017024d Update regards review
8275391c094a3e947b288fe6325775d1956d6a4e Merge pull request #419 from status-im/feature/linter-in-travis
53cea066e7742c5c86dd524867e86aa129673f68 Fix duplicate lint
ec18e0843e13155fc0f6b6a7b85e797b10075baa Removing mainnet from testing networks
a2fbe0c1a88e05276aeea7d11bdf14635187e821 Remove -networkurl flag
468a52737a162c32b2655944d751ab7f2f5449c4 Fixing changes and url bug in accounts and transactions
ed61a1b19c9f8d36818bffa0c86fee2997416c1f Update code with network id and url returner
cdd2a314495cb406b4420929c831cd2f3d0f96ca Fixed according to comments
96212b912cb146e290bc0d614a6bcc3c93298f3e Fixed make lint (goimports)
39cc60b8a7d9686e7665b12284b5597a1d8316c2 Fixed make lint
d1c47c53588a079c7e329095c7f1994a3acf21a7 Merge branch 'develop' into feature/linter-in-travis
f80827dc1f665e8f0f47de532900c1aeddcfd1df Feature/integrate linters into ci#387 (#427)
6b9298fbc16372661e4357a060daf9b4f99d9baa Update readme
aed88e234e02b2f185b9226ebb07a8e141674170 Restore usage of string for -network flag
ca221f41f586b32af76c55e35411b94ad6cfda3b Fix import usage for jail test
33fdc7dc82b4e080ac6610f0bc7ab97b02dde439 Fix import usage for jail test
46c46436f75279efe3f8a874f4e29de3273537ba Fix conflicts with develop
a2cabd9d685d80f608114df080116e45f0c942b7 Fix test to ensure consistency with checks
a1668add06e78b4a397ed7c027fbf35f79d39347 Update readme and update code for testing
0e72e3d6b4812bf40f4cc1ba2cac7f11c6294e9f Update notify interface and mark old one as deprecated
e14b2331ebc4c26efd30e3df471a00d71586bbfc Made EnsureNodeSync() throws a panic instead of returning an error (#431)
a257d1c2013c89127cde048bf2c0f0ecfa65c761 Fix errors on network chain id validation in tests
d856660d0979a49b58912f348757ed016868b62a Update readme and fix pointer bug
aa2779d3a93d238693439e2b4e72d6b3fdf35772 Fix missed call of StartTestBackend
14c124aef86006dc69cc3400e6c453ed08693823 Switch to flag.String from flag.StringVar, removing init()
7718bd5990ac110c7418201ee79e3045a5158873 Move all tests to retrieve NetworkId from flag or default to statuschain
a98238ad9737a2325da53d9aba90da5ef0d1f45e Add GetNetworkID function for tests
d341e385fa9ba486752bed793cc6461b96571635 Add networkSelected flag for test
c500fbc42380eba902a1945a6fa034480a52a086 Made all tests run on StatusChain instead of Rinkeby or Ropsten (#426)
1de852134b1706cfa83e6753cf22df7e86a998b0 fix linters warnings
22fb4dfc30f9153a2943d183819de0cb2e5d8d90 integrate linters into travis
1dcf30142d322ce6cb12439009a0e54bc18d75de Merge branch 'develop' into feature/linter-in-travis
a3bca52f513c4f0cf06fe59f9328c152fe0333d6 Fmt
c823acfd04c4330b026de11f8f8f0bf9a7a56e95 All notifiers remaned into notification
d22cdc5cbb4870ae5273934bf9b81bee367374f9 NotifyResult doesnt return error field if success
9efed591dab6f0bcaa316e3a5f54f5ce1b795b3a Notifier constructor renamed
f159ea85a0d48e9d18fa327a6a16038934300420 References for marshal library responces removed
42cb6446b95fadb37d85975240e65359e690bf80 Return error for notify
4f9788a1585acac387cedb1fbf5ba10c4a0e22a7 Fix tests and rename field in Notifier
390495342c05fe854913c2589003fba1ac5f5774 Make FCM client interface private
c304d3e7ae0ea3802d2a17a68183d6095370be1a Update PN tests
804ed7c10c613baa637c6d6c21c60fa3c7f9283a Remove provider interface
c36a51d0cf657cf7449a6584e77f8ca23caaa5a7 Firebase provider tests
7195fe3f9293aebdf0dff1c56651953a0b057c00 Create message provider interface
9c1aff3655e3dd208ef0b351803dc3c2e8577b73 Unnecessary test checks removed
acd1c1527cb9a41f3987b7f95e15be4682cb31df Basic unit testing for notification service
4aaeeb6ebfbfa4ac78db131ee62a1d6b2dd74ac2 Extract notification into separete package and interface
b1aa57de25867eb93e305bb62f7d591b270ad41c Rephrase a list
a7a53152581952c8de01dc2ac7a6405482b699d9 Make checks checked by default
1fa14aaa9f279371e3cc5597a10809abb1519972 Fix spelling in PULL_REQUEST_TEMPLATE.md
c23435ca37d2efb650601552e8aa5d774facfb76 Add PULL_REQUEST_TEMPLATE.md
1c8d32c451ec0f16d3a592e1909019008f56a0b0 Ensuring node synchronisation to avoid "no suitable peers available" errors (#410)
a2f6889c14480c3a49ba366a16f05784901e787e remove email notifications
a21fd963de7202b2c9d7b8ab1bfe47646b8b5d7e improve travis integration
e911666b5db7f1b39c4556dd232eb1949391aeed Fix make lint warnings (#417)
ad9a8777a89562f56027b7c859faa4407a9097c6 fix node unit tests (#416)
```

status: ready