### PR TITLE
Put status-go in geth.log again

### DIFF
--- a/modules/react-native-status/ios/RCTStatus/RCTStatus.m
+++ b/modules/react-native-status/ios/RCTStatus/RCTStatus.m
@@ -162,9 +162,11 @@ RCT_EXPORT_METHOD(startNode:(NSString *)configString) {
     NSString *config = [NSString stringWithUTF8String: configChars];
     configData = [config dataUsingEncoding:NSUTF8StringEncoding];
     NSDictionary *resultingConfigJson = [NSJSONSerialization JSONObjectWithData:configData options:NSJSONReadingMutableContainers error:nil];
+    NSURL *networkDirUrl = [NSURL fileURLWithPath:networkDir];
+    NSURL *logUrl = [networkDirUrl URLByAppendingPathComponent:@"geth.log"];
     [resultingConfigJson setValue:newKeystoreUrl.path forKey:@"KeyStoreDir"];
     [resultingConfigJson setValue:[NSNumber numberWithBool:YES] forKey:@"LogEnabled"];
-    [resultingConfigJson setValue:@"geth.log" forKey:@"LogFile"];
+    [resultingConfigJson setValue:logUrl.path forKey:@"LogFile"];
     [resultingConfigJson setValue:@"DEBUG" forKey:@"LogLevel"];
 
     if(upstreamURL != nil) {
@@ -173,8 +175,6 @@ RCT_EXPORT_METHOD(startNode:(NSString *)configString) {
     }
     NSString *resultingConfig = [resultingConfigJson bv_jsonStringWithPrettyPrint:NO];
     NSLog(@"node config %@", resultingConfig);
-    NSURL *networkDirUrl = [NSURL fileURLWithPath:networkDir];
-    NSURL *logUrl = [networkDirUrl URLByAppendingPathComponent:@"geth.log"];
     if([fileManager fileExistsAtPath:logUrl.path]) {
         [fileManager removeItemAtPath:logUrl.path error:nil];
     }


### PR DESCRIPTION
### Summary
Fix absolute dir and statement order. Regression appears to have been introduced during network configuration changes 2-3 months ago and noone checked this file since then.

### Review notes (optional):
Sanity check

### Testing notes (optional):
Tooling only.

### Steps to test:
```
# Find device ID
instruments -s devices | grep "iPhone 6s (10.3.1) \["
# => iPhone 6s (10.3.1) [9C95EE2B-47A5-498E-8085-6A3FFB769E8F] (Simulator)

# cd into it
cd /Users/oskarth/Library/Developer/CoreSimulator/Devices/9C95EE2B-47A5-498E-8085-6A3FFB769E8F/data/Containers/Data/Application

# Confirm device is clean of logs
find . -iname "geth.log" | xargs ls -ll

# Run device on iOS simulator to produce geth.logs

# You should now see it in the application folder
Oskars-MBP:Application oskarth$ find . -iname "geth.log" | xargs ls -ll
-rwxrwxrwx  1 oskarth  access_bpf  478475 Nov 28 20:20 ./0FD880A9-F65B-44FF-A2EC-29FC2C7C1357/Documents/ethereum/testnet_rpc/geth.log

# Check file contents
Oskars-MBP:Application oskarth$ head -n 10 ./0FD880A9-F65B-44FF-A2EC-29FC2C7C1357/Documents/ethereum/testnet_rpc/geth.log
DEBUG[11-28|20:19:53] FS scan times                            list=461.375µs set=914ns diff=14.571µs
INFO [11-28|20:19:53] start Manager                            geth=StatusIM
INFO [11-28|20:19:53] starting transaction queue               geth=StatusIM
INFO [11-28|20:19:53] Starting peer-to-peer node               instance=StatusIM/v0.9.9-unstable/darwin-amd64/go1.7.1
...
```

status:ready
