### PR TITLE
[ISSUE #2449] Make sure DApps transaction amount is never nil

### DIFF
--- a/src/status_im/ui/screens/wallet/db.cljs
+++ b/src/status_im/ui/screens/wallet/db.cljs
@@ -22,23 +22,20 @@
 ;; TODO(oskarth): spec for balance as BigNumber
 ;; TODO(oskarth): Spec for prices as as: {:from ETH, :to USD, :price 290.11, :last-day 304.17}
 
-(defn- empty-amount? [amount]
-  (or (nil? amount) (= amount "") (= amount "0") (re-matches #"0[,.]0*$" amount)))
-
 (defn- too-precise-amount? [amount]
   (let [amount-splited (string/split amount #"[.]")]
     (and (= (count amount-splited) 2) (> (count (last amount-splited)) 18))))
 
 (defn parse-amount [amount]
-  (when-not (empty-amount? amount)
+  (when-not (empty? amount)
     (let [normalized-amount (money/normalize amount)
           value (money/bignumber normalized-amount)]
       (cond
         (not (money/valid? value))
-        {:error (i18n/label :t/validation-amount-invalid-number)}
+        {:error (i18n/label :t/validation-amount-invalid-number) :value value}
 
         (too-precise-amount? normalized-amount)
-        {:error (i18n/label :t/validation-amount-is-too-precise)}
+        {:error (i18n/label :t/validation-amount-is-too-precise) :value value}
 
         :else
         {:value value}))))

--- a/src/status_im/ui/screens/wallet/send/events.cljs
+++ b/src/status_im/ui/screens/wallet/send/events.cljs
@@ -81,7 +81,7 @@
             transaction {:id         id
                          :from       from
                          :to         to
-                         :value      (money/bignumber value)
+                         :value      (money/bignumber (or value 0))
                          :data       data
                          :gas        (money/to-decimal gas)
                          :gas-price  (money/to-decimal gasPrice)
@@ -93,7 +93,7 @@
                         :from-chat? sending-from-chat?}]
         (if sending-from-chat?
           ;;SENDING FROM CHAT
-          {:db       (assoc-in new-db [:wallet :send-transaction] sending-db) ; we need to completly reset sending state here
+          {:db       (assoc-in new-db [:wallet :send-transaction] sending-db) ; we need to completely reset sending state here
            :dispatch [:navigate-to-modal :wallet-send-transaction-modal]}
           ;;SEND SCREEN WAITING SIGNAL
           (let [{:keys [later? password]} (get-in db [:wallet :send-transaction])

--- a/src/status_im/ui/screens/wallet/send/views.cljs
+++ b/src/status_im/ui/screens/wallet/send/views.cljs
@@ -126,7 +126,7 @@
                                 (when-not sufficient-funds? (i18n/label :t/wallet-insufficient-funds)))
              :input-options {:auto-focus     true
                              :on-focus       (fn [] (when @scroll (js/setTimeout #(.scrollToEnd @scroll) 100)))
-                             :default-value  (str (money/wei->ether amount))
+                             :default-value  (str (money/to-fixed (money/wei->ether amount)))
                              :on-change-text #(re-frame/dispatch [:wallet.send/set-and-validate-amount %])}}]
            [react/view wallet.styles/choose-currency-container
             [components/choose-currency wallet.styles/choose-currency]]]]]


### PR DESCRIPTION
fixes #2449

### Summary:

Transactions created with no amount should be valid.
Also improves how small amount are displayed (no scientific notation) and allows sending transaction with 0 amount (regression).

### Steps to test:
- Open Status
- Navigate `Auction House`
- Click `Register name`
- Wallet should open, display `0` as amount and allow to send the transaction

status: ready

