### PR TITLE
Don't unnecessary load jail upon figwheel reload

### DIFF
--- a/env/dev/env/android/main.cljs
+++ b/env/dev/env/android/main.cljs
@@ -10,15 +10,11 @@
 (def cnt (r/atom 0))
 (defn reloader [] @cnt [core/app-root])
 (def root-el (r/as-element [reloader]))
-(defn callback []
-  (swap! cnt inc)
-  (status-im.native-module.core/init-jail)
-  (re-frame.core/dispatch [:load-commands!]))
 
 (figwheel/watch-and-reload
   :websocket-url "ws://10.0.3.2:3449/figwheel-ws"
   :heads-up-display false
-  :jsload-callback callback)
+  :jsload-callback #(swap! cnt inc))
 
 (utils.handlers/add-pre-event-callback rr/pre-event-callback)
 


### PR DESCRIPTION
### Summary:
Super small PR impacting only dev-workflow (no QA testing necessary).
Removed `[:load-commands!]` events dispatch from figwheel reload event,
as the event was already removed and it was causing red screen error upon
figwheel reload on android.

status: ready

