### PR TITLE
Hook require to prevent tests failures when loading images

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -55,6 +55,7 @@
                                                  :output-to     "target/test/test.js"
                                                  :output-dir    "target/test"
                                                  :optimizations :none
+                                                 :preamble      ["js/hook-require.js"]
                                                  :target        :nodejs}}
                                  {:id           "protocol"
                                   :source-paths ["src" "test/cljs"]

--- a/resources/js/hook-require.js
+++ b/resources/js/hook-require.js
@@ -1,0 +1,14 @@
+const m = require('module');
+const originalLoader = m._load;
+
+/*
+ Hook `require` so that RN abuse of require does not break when running tests in nodejs.
+*/
+
+m._load = function hookedLoader(request, parent, isMain) {
+  if (request.match(/.jpeg|.jpg|.png$/)) {
+    return { uri: request };
+  }
+
+  return originalLoader(request, parent, isMain);
+};

--- a/test/cljs/status_im/utils/ethereum/tokens.cljs
+++ b/test/cljs/status_im/utils/ethereum/tokens.cljs
@@ -1,5 +1,0 @@
-(ns status-im.utils.ethereum.tokens)
-
-(def ethereum {})
-
-(def all {})


### PR DESCRIPTION
### Summary:

Hook `require` so that tests running under nodejs don't fail when loading images.

status: ready