### PR TITLE
Fixed regression when sending transaction

### DIFF
--- a/src/status_im/ui/screens/wallet/send/subs.cljs
+++ b/src/status_im/ui/screens/wallet/send/subs.cljs
@@ -66,7 +66,8 @@
   :<- [:balance]
   (fn [[{:keys [amount to] :as transaction} balance]]
     (assoc transaction :sufficient-funds? (or (nil? amount)
-                                              (money/sufficient-funds? amount balance)))))
+                                              ;; TODO(jeluard) Modify to consider tokens
+                                              (money/sufficient-funds? amount (get balance :ETH))))))
 
 (re-frame/reg-sub :wallet.send/unsigned-transaction
   :<- [::unsigned-transaction]
@@ -75,7 +76,8 @@
   (fn [[{:keys [value to] :as transaction} contacts balance]]
     (when transaction
       (let [contact           (contacts (utils.hex/normalize-hex to))
-            sufficient-funds? (money/sufficient-funds? value balance)]
+            ;; TODO(jeluard) Modify to consider tokens
+            sufficient-funds? (money/sufficient-funds? value (get balance :ETH))]
         (cond-> (assoc transaction
                        :amount value
                        :sufficient-funds? sufficient-funds?)


### PR DESCRIPTION
### Summary:

Balance is now a map indexed by tokens symbols. Some old usages of balance were not properly updated

### Steps to test:
- Open Status
- Navigate wallet
- Send a transaction

status: ready
