### PR TITLE
[FIX #1209] resources/js: wrap undefined responses from jail in a String

### DIFF
--- a/resources/js/bots/console/bot.js
+++ b/resources/js/bots/console/bot.js
@@ -360,7 +360,7 @@ function jsHandler(params, context) {
     };
     messages = [];
     try {
-        result["text-message"] = JSON.stringify(eval(params.code));
+        result["text-message"] = String(JSON.stringify(eval(params.code)));
         localStorage.setItem("previousMessage", params.code);
     } catch (e) {
         result.err = e;


### PR DESCRIPTION
Addresses #1209.

### Summary:
Sometimes jail returns responses as 'undefined'. These are not getting displayed in the chat screen. Adding 'undefined' as a string instead of a value ensures that it will be added to the result under :message-text key instead of being dropped. Hence, it will be displayed on screen in the chat window. 

### Steps to test:
- Open Status
- Open Console
- Type any text that will refer to undefined endpoint, e.g. web3.abcd
- Actual result: no response from Console
- Expected result: should see 'undefined', same as when issuing the same command in Geth for instance

status: ready