### PR TITLE
[FIX #2118] ui: store search-key under [:toolbar-search :show]

### DIFF
--- a/src/status_im/ui/screens/chats_list/subs.cljs
+++ b/src/status_im/ui/screens/chats_list/subs.cljs
@@ -11,8 +11,9 @@
 (reg-sub :filtered-chats
   :<- [:get :chats]
   :<- [:get-in [:toolbar-search :text]]
-  (fn [[chats search-text]]
-    (let [unordered-chats (if search-text
+  :<- [:get-in [:toolbar-search :show]]
+  (fn [[chats search-text show-search]]
+    (let [unordered-chats (if (and (= show-search :chat-list) search-text)
                             (filter #(search-filter search-text (second %))
                                     chats)
                             chats)]

--- a/src/status_im/ui/screens/chats_list/views.cljs
+++ b/src/status_im/ui/screens/chats_list/views.cljs
@@ -26,12 +26,12 @@
   [{:text (i18n/label :t/edit) :value #(re-frame/dispatch [:set-in [:chat-list-ui-props :edit?] true])}])
 
 (defn android-toolbar-actions []
-  [(act/search #(re-frame/dispatch [:set-in [:toolbar-search :show] true]))
+  [(act/search #(re-frame/dispatch [:set-in [:toolbar-search :show] :chat-list]))
    (act/opts android-toolbar-popup-options)])
 
 (def ios-toolbar-popup-options
   [{:text (i18n/label :t/edit-chats) :value #(re-frame/dispatch [:set-in [:chat-list-ui-props :edit?] true])}
-   {:text (i18n/label :t/search-chats) :value #(re-frame/dispatch [:set-in [:toolbar-search :show] true])}])
+   {:text (i18n/label :t/search-chats) :value #(re-frame/dispatch [:set-in [:toolbar-search :show] :chat-list])}])
 
 (defn ios-toolbar-actions []
   [(act/opts ios-toolbar-popup-options)
@@ -77,13 +77,13 @@
 (defview chats-list []
   (letsubs [chats        [:filtered-chats]
             edit?        [:get-in [:chat-list-ui-props :edit?]]
-            search?      [:get-in [:toolbar-search :show]]
+            show-search  [:get-in [:toolbar-search :show]]
             tabs-hidden? [:tabs-hidden?]]
     [react/view st/chats-container
      (cond
-       edit?   [toolbar-edit]
-       search? [toolbar-search]
-       :else   [toolbar-view])
+       edit?                      [toolbar-edit]
+       (= show-search :chat-list) [toolbar-search]
+       :else                      [toolbar-view])
      [react/list-view {:dataSource      (to-datasource chats)
                        :renderRow       (fn [[id :as row] _ _]
                                           (react/list-item ^{:key id} [chat-list-item row edit?]))
@@ -95,7 +95,7 @@
                        :renderSeparator renderers/list-separator-renderer
                        :style           st/list-container}]
      (when (and (not edit?)
-                (not search?)
+                (not= show-search :chat-list) 
                 (get-in platform-specific [:chats :action-button?]))
        [chats-action-button])
      [offline-view]]))


### PR DESCRIPTION
Addresses #2118.

### Summary:
Chat list used to store booleans under [:toolbar-search :show] which is
different from other views and caused the toolbar to appear in Chats if search was used in Discover or Contacts. With this change search key (= :chat-list) is stored under the above path.

### Review notes (optional):
<!-- (Specify if something in particular should be looked at, or ignored, during review) -->

### Testing notes (optional):
<!-- (Specify if something specific has to be tested, for example upgrade paths) -->

### Steps to test:
- Open Status
- Go to Discover tab
- Click on Search icon in the toolbar and type some text
- Go to Chats tab
- Actual result: no chats visible
- Expected result: should see the list of recent chats. Search filter from another tab should not be applied.

status: ready