### PR TITLE
[FIX #2538] Ignore errors for `rm` command when bundling status-go for iOS

### DIFF
--- a/scripts/bundle-status-go.sh
+++ b/scripts/bundle-status-go.sh
@@ -28,7 +28,7 @@ cd ..
 # Instead we are going to manually overwrite it.
 
 # For Xcode to pick up the new version, remove the whole framework first:
-rm -r status-react/modules/react-native-status/ios/RCTStatus/Statusgo.framework/
+rm -r status-react/modules/react-native-status/ios/RCTStatus/Statusgo.framework/ || true
 
 # Then copy over framework:
 cp -R status-go/build/bin/statusgo-ios-9.3-framework/Statusgo.framework status-react/modules/react-native-status/ios/RCTStatus/Statusgo.framework


### PR DESCRIPTION
### Summary:

Right after `git clone`, there is no `Statusgo.framework` in `react-native-status/ios/RCTStatus/` directory. Because of that, `scripts/bundle-status-go.sh` fails and stops on the `rm` operation.

Since it is a perfectly valid scenario, let's ignore this error.

### Steps to test:
- Clone `status-im/status-react` and `status-im/status-go` in sibling directories.
- Go to `status-im/status-react` directory and run `scripts/bundle-status-go.sh`
- Expect it to complete successfully.

status: ready