### PR TITLE
Ignore errors for `rm` command when bundling status-go for iOS.

### DIFF
--- a/scripts/bundle-status-go.sh
+++ b/scripts/bundle-status-go.sh
@@ -28,7 +28,7 @@ cd ..
 # Instead we are going to manually overwrite it.
 
 # For Xcode to pick up the new version, remove the whole framework first:
-rm -r status-react/modules/react-native-status/ios/RCTStatus/Statusgo.framework/
+rm -r status-react/modules/react-native-status/ios/RCTStatus/Statusgo.framework/ || true
 
 # Then copy over framework:
 cp -R status-go/build/bin/statusgo-ios-9.3-framework/Statusgo.framework status-react/modules/react-native-status/ios/RCTStatus/Statusgo.framework


### PR DESCRIPTION
Right after `git clone`, there is no `Statusgo.framework` in `react-native-status/ios/RCTStatus/` directory. Because of that, `scripts/bundle-status-go.sh` fails and stops on the `rm` operation.

Since it is a perfectly valid scenario, let's ignore this error.

Signed-off-by: Oskar Thoren <ot@oskarthoren.com>
