### PR TITLE
[FIX #2538] Ignore errors for `rm` command when bundling status-go fo…

### DIFF
--- a/scripts/bundle-status-go.sh
+++ b/scripts/bundle-status-go.sh
@@ -28,7 +28,7 @@ cd ..
 # Instead we are going to manually overwrite it.
 
 # For Xcode to pick up the new version, remove the whole framework first:
-rm -r status-react/modules/react-native-status/ios/RCTStatus/Statusgo.framework/
+rm -r status-react/modules/react-native-status/ios/RCTStatus/Statusgo.framework/ || true
 
 # Then copy over framework:
 cp -R status-go/build/bin/statusgo-ios-9.3-framework/Statusgo.framework status-react/modules/react-native-status/ios/RCTStatus/Statusgo.framework


### PR DESCRIPTION
…r iOS.

Right after `git clone`, there is no `Statusgo.framework` in `react-native-status/ios/RCTStatus/` directory. Because of that, `scripts/bundle-status-go.sh` fails and stops on the `rm` operation.

Since it is a perfectly valid scenario, let's ignore this error.

[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

If you submit PR for issue with bounty then write here Fixes #NN where NN is issue number

*otherwise*

addresses #...

### Summary:

[comment]: # (Summarise the problem and how the pull request solves it)
...

### Review notes (optional):
<!-- (Specify if something in particular should be looked at, or ignored, during review) -->

### Testing notes (optional):
<!-- (Specify if something specific has to be tested, for example upgrade paths) -->

### Steps to test:
- Open Status
- ...
- Step 3, etc.

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready

*or*

status: wip

