### PR TITLE
Add merge-pr.sh script

### DIFF
--- a/scripts/merge-pr.sh
+++ b/scripts/merge-pr.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env sh
+
+set -eof pipefail
+
+BRANCH=$1
+if [[ $# -eq 0 ]] ; then
+    echo 'Branch required as first argument'
+    exit 0
+fi
+
+echo "[Merge PR from ${BRANCH}]"
+
+echo "[Update remote and checkout branch]"
+git remote update origin
+git checkout -B $BRANCH origin/$BRANCH && git pull
+
+echo "[Rebase and squash to one commit (manual)]"
+git rebase -i origin/develop
+
+echo "[Verify signature and commit (manual), update PR]"
+git show --show-signature
+git push -f
+
+echo "[Checkout develop and merge with same SHA]"
+git checkout develop && git pull
+git merge --ff-only $BRANCH
+
+echo "[Push to protected develop branch]"
+git push
+
+echo "[Clean up remote branch]"
+git push origin --delete $BRANCH
+
+echo "[Done]"


### PR DESCRIPTION
Add script per https://wiki.status.im/Code_signing_commits_into_develop instruction for core contributors. This ensures (in a soft way) that only changes that core contributors signed are introduced into develop.

This would be used instead of merging PRs through Github. So once a PR has passed review, call script with `./merge-pr.sh feature/merge-pr-script`, verify changes and (auto)sign with PGP key, then push to develop.

reviewers: check if it makes sense and if you'd run it
testers: only tooling, no QA

status: ready