### PR TITLE
Offline inbox: Requests messages on startup

### DIFF
--- a/src/status_im/protocol/core.cljs
+++ b/src/status_im/protocol/core.cljs
@@ -93,18 +93,17 @@
         (group/start-watching-group! options)))
     ;; start listening to user's inbox
     (if config/offline-inbox-enabled?
-      (do (log/info "offline-inbox-enabled, allowp2p")
+      (do (log/info "offline inbox: flag enabled")
           (f/add-filter!
             web3
             {:key      identity
              :allowP2P true
              :topics   [f/status-topic]}
             (l/message-listener listener-options))
-          ;; TODO(oskarth): Clarify opts (status-go #470)
           (inbox/request-messages!
            web3
            {}
-           #(log/info "offline-inbox request-messages response:" %)))
+           #(log/info "offline inbox: request-messages response" %)))
       (f/add-filter!
         web3
         {:key    identity

--- a/src/status_im/protocol/web3/inbox.cljs
+++ b/src/status_im/protocol/web3/inbox.cljs
@@ -1,13 +1,47 @@
 (ns status-im.protocol.web3.inbox
   (:require [status-im.protocol.web3.utils :as utils]
+            [status-im.native-module.core :as status]
+            [status-im.protocol.web3.keys :as keys]
             [taoensso.timbre :as log]))
 
-;; TODO(oskarth): NYI yet (both in web3.js and status-go)
-(defn request-messages! [web3 opts callback]
-  (log/info "offline-inbox: request-messages")
-  (.requestMessages (utils/shh web3)
-                    (clj->js opts)
-                    callback
-                    #(log/warn :request-messages-error
-                               (.stringify js/JSON (clj->js opts)) %)))
 
+;; TODO(oskarth): Determine if this is the correct topic or not
+;; If it is, use constant in other namespace
+(def default-topic "0xaabb11ee")
+
+(def inbox-password "status-offline-inbox")
+
+;; TODO(oskarth): Hardcoded to local enode for preMVP, will be in bootnodes later
+(def default-enode "enode://0f51d75c9469de0852571c4618fe151265d4930ea35f968eb1a12e69c12f7cbabed856a12b31268a825ca2c9bafa47ef665b1b17be1ab71de83338c4b7439b24@127.0.0.1:30303")
+
+;; TODO(oskarth): Rewrite callback-heavy code with CSP and/or coeffects
+;; NOTE(oskarth): Exact params still being determined
+(defn request-messages! [web3 {:keys [enode topic password]
+                               :or {enode    default-enode
+                                    password inbox-password
+                                    topic    default-topic}} callback]
+  (status/add-peer
+   enode
+   (fn [res]
+     (log/info "offline inbox: add peer" enode res)
+     (keys/get-sym-key web3 password
+                       (fn [sym-key-id]
+                         (log/info "offline inbox: sym-key-id" sym-key-id)
+                         (let [args {:jsonrpc "2.0"
+                                     :id      1
+                                     :method  "shh_requestMessages"
+                                     :params  [{:enode     enode
+                                                :topic     topic
+                                                :symKeyID  sym-key-id
+                                                :from      0
+                                                :to        1612505820}]}
+                               payload (.stringify js/JSON (clj->js args))]
+                           (log/info "offline inbox: request-messages request")
+                           (status/call-web3 payload callback)))))))
+
+;; TODO(oskarth): Use web3 binding instead of raw RPC above, pending binding and deps:
+;; (.requestMessages (utils/shh web3)
+;;                   (clj->js opts)
+;;                   callback
+;;                   #(log/warn :request-messages-error
+;;                             (.stringify js/JSON (clj->js opts)) %))


### PR DESCRIPTION
Addresses #2512 

### Summary:

- protocol/web3/inbox: make request-messages work by adding enode peer,
  generating and using symkey, and finally using raw CallRPC for
  shh_requestMessages.

- protocol/core: Clean up log lines

### Review notes (optional):
Sanity check.

### Testing notes (optional):
Nothing to test - zero changes in default configuration.

### Notes
With flag on and a running mailserver with correct enode, here is what happens at login:

```
> find  ~/Library/Logs/CoreSimulator/ -name "system.log" | xargs ls -t | head -n 1 | xargs tail -n 1000 -f | grep "offline"
Dec  6 12:51:11 Oskars-MacBook-Pro StatusIm[85820]: INFO [status-im.protocol.core:96] - offline inbox: flag enabled
Dec  6 12:51:12 Oskars-MacBook-Pro StatusIm[85820]: INFO [status-im.protocol.web3.inbox:26] - offline inbox: add peer enode://0f51d75c9469de0852571c4618fe151265d4930ea35f968eb1a12e69c12f7cbabed856a12b31268a825ca2c9bafa47ef665b1b17be1ab71de83338c4b7439b24@127.0.0.1:30303 {"error":""}
Dec  6 12:51:12 Oskars-MacBook-Pro StatusIm[85820]: offline-inbox: sym-key-id 839eedf8d626b3352c35d773939c10d637a207d5b16a69359093597e58f87252
Dec  6 12:51:12 Oskars-MacBook-Pro StatusIm[85820]: INFO [status-im.protocol.web3.inbox:39] - offline-inbox: request-messages
Dec  6 12:51:13 Oskars-MacBook-Pro StatusIm[85820]: INFO [status-im.protocol.core:106] - offline inbox: request-messages {"jsonrpc":"2.0","id":1,"result":true}
```

Note `{"jsonrpc":"2.0","id":1,"result":true}`. Doesn't mean it works but at least accepted.

status: ready

