### PR TITLE
Simplified message loading

### DIFF
--- a/src/status_im/chat/specs.cljs
+++ b/src/status_im/chat/specs.cljs
@@ -9,8 +9,7 @@
 (s/def :chat/chat-ui-props (s/nilable map?))                                ;;{id (string) props (map)}
 (s/def :chat/chat-list-ui-props (s/nilable map?))
 (s/def :chat/layout-height (s/nilable number?))                             ;;height of chat's view layout
-(s/def :chat/expandable-view-height-to-value (s/nilable number?))
-(s/def :chat/loading-allowed (s/nilable boolean?))                          ;;allow to load more messages 
+(s/def :chat/expandable-view-height-to-value (s/nilable number?)) 
 (s/def :chat/message-data (s/nilable map?))
 (s/def :chat/message-id->transaction-id (s/nilable map?))
 (s/def :chat/message-status (s/nilable map?))

--- a/src/status_im/data_store/messages.cljs
+++ b/src/status_im/data_store/messages.cljs
@@ -32,10 +32,6 @@
     (when (command-type? content-type)
       (reader/read-string content))))
 
-(defn get-count-by-chat-id
-  [chat-id]
-  (data-store/get-count-by-chat-id chat-id))
-
 (defn get-by-chat-id
   ([chat-id]
    (get-by-chat-id chat-id 0))

--- a/src/status_im/data_store/realm/messages.cljs
+++ b/src/status_im/data_store/realm/messages.cljs
@@ -16,10 +16,7 @@
   (when-let [message (realm/get-one-by-field-clj @realm/account-realm :message :message-id message-id)]
     (realm/fix-map message :user-statuses :whisper-identity)))
 
-(defn get-by-chat-id
-  "arity-1 returns realm object for queries"
-  ([chat-id]
-   (realm/get-by-field @realm/account-realm :message :chat-id chat-id))
+(defn get-by-chat-id 
   ([chat-id number-of-messages]
    (get-by-chat-id chat-id 0 number-of-messages))
   ([chat-id from number-of-messages]
@@ -28,10 +25,6 @@
                       (realm/page from (+ from number-of-messages))
                       realm/js-object->clj)]
      (mapv #(realm/fix-map % :user-statuses :whisper-identity) messages))))
-
-(defn get-count-by-chat-id
-  [chat-id]
-  (realm/get-count (get-by-chat-id chat-id)))
 
 (defn get-by-fields
   [fields from number-of-messages]
@@ -64,5 +57,6 @@
 
 (defn delete-by-chat-id
   [chat-id]
-  (realm/delete @realm/account-realm
-                (get-by-chat-id chat-id)))
+  (let [current-realm @realm/account-realm]
+    (realm/delete current-realm
+                  (realm/get-by-field current-realm :message :chat-id chat-id))))

--- a/src/status_im/ui/screens/db.cljs
+++ b/src/status_im/ui/screens/db.cljs
@@ -25,8 +25,7 @@
              :group/contact-groups       {}
              :group/selected-contacts    #{}
              :chats                      {}
-             :current-chat-id            constants/console-chat-id
-             :loading-allowed            true
+             :current-chat-id            constants/console-chat-id 
              :selected-participants      #{}
              :discoveries                {}
              :discover-search-tags       '()
@@ -154,7 +153,6 @@
                   :chat/chat-list-ui-props
                   :chat/layout-height
                   :chat/expandable-view-height-to-value 
-                  :chat/loading-allowed
                   :chat/message-data
                   :chat/message-id->transaction-id
                   :chat/message-status


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

This is super small partial change related to much bigger refactor for consistency and (most importantly) performance gains (resulting from drastically decreased number of subscriptions) which I'm doing as part of the #1875 story. 
After last feedback from @oskarth, I'm trying to split the work into small, easy to review chunks, that's why this PR.

Changes:
* Simplified logic of the `:load-more-messages` handler
* Got rid of the global `:loading-allowed?` key in the app-db, with associated delayed dispatch, according to my testing, it buys us nothing (it doesn't decrease number of `:load-more-messages` dispatches) and it's wrongly scoped anyway (if anything, it should be per chat and not global)
* Removed the super confusing 1-arity `get-by-chat-id` realm message query function
* Removed the unused `get-count-by-id`/`get-count-by-chat-id` functions not used anymore

Prerequisite for #1875

### Steps to test:
- Open Status
- Create more then 20 messages in some chat and close Status
- Open Status again, go to the same chat, scroll to the very top and check if all the messages are loaded correctly.

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready

