### PR TITLE
Offline inbox: Mark mailserver as trusted peer with RPC

### DIFF
--- a/src/status_im/protocol/web3/keys.cljs
+++ b/src/status_im/protocol/web3/keys.cljs
@@ -11,7 +11,9 @@
       -shh
       (generateSymKeyFromPassword password callback)))
 
-(defn get-sym-key [web3 password callback]
+(defn get-sym-key
+  "Memoizes expensive calls by password."
+  [web3 password callback]
   (if-let [key-id (get @password->keys password)]
     (callback key-id)
     (add-sym-key-from-password


### PR DESCRIPTION
Addresses #2576 

### Summary:

Offline inbox: Mark mailserver as trusted peer with RPC

Also document get-sym-key memoization

### Review notes (optional):
Sanity check. Callback heavy code will be cleaned up with web3 bindings, coeffects/csp and memoization later.

### Testing notes (optional):
All under flag, no change in behavior.

### Logs when running it with flag and custom status-go
```
Dec  7 13:55:40 Oskars-MacBook-Pro StatusIm[7814]: INFO [status-im.protocol.web3.inbox:41]- 
offline inbox: mark-trusted-peer response 
enode://0f51d75c9469de0852571c4618fe151265d4930ea35f968eb1a12e69c12f7cbabed856a12b31268a825ca2c9bafa47ef665b1b17be1ab71de83338c4b7439b24@127.0.0.1:30303 
{"jsonrpc":"2.0","id":1,"result":true}
```

status: ready