### PR TITLE
Fix missing effect and minor refactoring of chat events

### DIFF
--- a/src/status_im/chat/events/commands.cljs
+++ b/src/status_im/chat/events/commands.cljs
@@ -3,7 +3,7 @@
             [clojure.string :as str]
             [re-frame.core :as re-frame]
             [taoensso.timbre :as log]
-            [status-im.utils.handlers :as handlers] 
+            [status-im.utils.handlers :as handlers]
             [status-im.i18n :as i18n]
             [status-im.utils.platform :as platform]))
 


### PR DESCRIPTION
Cause:
- the conditional branches of :send-current-message event for commands was not applying expected changes to :db because one of the functions transforming the effects map was not returning any db effect in some cases
- :send-current-message effect had effects even when :sending-in-progress? was true

Class of bug: missing effects
This is at least the second time I encounter this class of bugs, this is the easy one with a full effect missing but there is a more vicious variation of this bug when merging effects.

To test:
- chat should work as previously on develop

status: ready


  
  