### PR TITLE
[FIX #2530] Create `catalog` variable on client-side.

### DIFF
--- a/src/status_im/native_module/impl/module.cljs
+++ b/src/status_im/native_module/impl/module.cljs
@@ -132,9 +132,15 @@
   (when status
     (call-module #(.discardTransaction status id))))
 
+(defn- append-catalog-init [js]
+    (str js "\n" "var catalog = JSON.stringify(_status_catalog); catalog;"))
+
 (defn parse-jail [bot-id file callback]
   (when status
-    (call-module #(.parseJail status bot-id file callback))))
+    (call-module #(.parseJail status
+                              bot-id
+                              (append-catalog-init file)
+                              callback))))
 
 (defn execute-call [{:keys [jail-id path params callback]}]
   (when status


### PR DESCRIPTION
### Summary:

Addresses https://github.com/status-im/status-react/issues/2530

This is my second attempt to prepare the client codebase to the go library refactoring mentioned in [status-go#450](https://github.com/status-im/status-go/issues/450).
This time `executeJS` is not exposed.

### Review notes:
Backward compatible, tested on [`status-go/develop`](https://github.com/status-im/status-go/commit/cbd05535ae72e96f38340d5245b075e06b0cf96c) and [`status-go/PR489`](https://github.com/status-im/status-go/pull/489)

### Steps to test (UPDATED):
- Open Status
- Create an account
- Expect `/password` and other `/`-commands to show up and work

status: done
  