### PR TITLE
Feature/offline inbox public chat support #2701

### DIFF
--- a/src/status_im/protocol/group.cljs
+++ b/src/status_im/protocol/group.cljs
@@ -2,6 +2,7 @@
   (:require
     [status-im.protocol.web3.delivery :as d]
     [status-im.protocol.web3.utils :as u]
+    [status-im.utils.config :as config]
     [cljs.spec.alpha :as s]
     [taoensso.timbre :refer-macros [debug]]
     [status-im.protocol.validation :refer-macros [valid?]]
@@ -136,9 +137,14 @@
     (fn [key-id]
       (f/add-filter!
         web3
-        {:topics [f/status-topic]
-         :key    key-id
-         :type   :sym}
+        (if config/offline-inbox-enabled?
+          {:topics   [f/status-topic]
+           :key      key-id
+           :allowP2P true
+           :type     :sym}
+          {:topics   [f/status-topic]
+           :key      key-id
+           :type     :sym})
         (l/message-listener {:web3     web3
                              :identity identity
                              :callback callback

--- a/src/status_im/protocol/handlers.cljs
+++ b/src/status_im/protocol/handlers.cljs
@@ -88,10 +88,12 @@
        :groups                      groups
        :callback                    #(re-frame/dispatch [:incoming-message %1 %2])
        :ack-not-received-s-interval 125
-       :default-ttl                 120
+       ;; XXX(oskarth): For offline inbox MVP QA only, normally 120
+       :default-ttl                 60
        :send-online-s-interval      180
        :ttl-config                  {:public-group-message 2400}
-       :max-attempts-number         3
+       ;; XXX(oskarth): For offline inbox MVP QA only, normally 3
+       :max-attempts-number         1
        :delivery-loop-ms-interval   500
        :profile-keypair             {:public  updates-public-key
                                      :private updates-private-key}

--- a/src/status_im/protocol/web3/inbox.cljs
+++ b/src/status_im/protocol/web3/inbox.cljs
@@ -47,8 +47,7 @@
                                           :params  [{:peer      enode
                                                      :topic     topic
                                                      :symKeyID  sym-key-id
-                                                     :from      0
-                                                     :to        1612505820}]}
+                                                     :from      0}]}
                                     payload (.stringify js/JSON (clj->js args))]
                                 (log/info "offline inbox: request-messages request")
                                 (log/info "offline inbox: request-messages args" (pr-str args))


### PR DESCRIPTION
Derived from PR: https://github.com/status-im/status-react/pull/2670
Addresses: https://github.com/status-im/status-react/issues/2701

### Summary

- Add `allowP2P` flag to group chats whisper filter
- Switch to `develop-gba6c9653` status-go build
- Remove `to` flag from `shh_requestMessages` call (it's `time.Now()` by default)

### Testing

#### Requirements:

Toggling on/off flag with parameterized build (`OFFLINE_INBOX_ENABLED=1` or 0).

#### Notes:
This branch uses modified TTL and max-retry-attempts to speed up verification of this capabilitty working.
By default we have TTL=120 and 3 retries = 6 minutes wait time. With PR upcoming TTL=1m and max retries = 1 = 1m wait time (+1m to be safe).

#### Control test (OFFLINE_INBOX_ENABLED flag off):

* User A joins public chat "test-chat"
* User B joins public chat "test-chat" (can be same device)
* User B goes offline
* User A sends message to test-chat
* Wait 2m
* User B goes online, signs in and opens test-chat
* User B does not see message in test-chat

#### Capability test (OFFLINE_INBOX_ENABLED flag on):

* User A joins public chat "test-chat"
* User B joins public chat "test-chat" (can be same device)
* User B goes offline
* User A sends message to test-chat
* Wait 2m
* User B goes online, signs in and opens test-chat
* User B sees message in test-chat

--- 

Status: wip (do not merge before https://github.com/status-im/status-react/pull/2670)