### PR TITLE
Use the correct group chat id

### DIFF
--- a/src/status_im/protocol/handlers.cljs
+++ b/src/status_im/protocol/handlers.cljs
@@ -121,13 +121,12 @@
   (fn [processed-message]
     (processed-messages/save processed-message)))
 
-(defn system-message
-  ([message-id timestamp content]
-   {:from         "system"
-    :message-id   message-id
-    :timestamp    timestamp
-    :content      content
-    :content-type constants/text-content-type}))
+(defn system-message [message-id timestamp content]
+  {:from         "system"
+   :message-id   message-id
+   :timestamp    timestamp
+   :content      content
+   :content-type constants/text-content-type})
 
 (re-frame/reg-fx
   ::participant-removed-from-group-message
@@ -499,8 +498,10 @@
          {:keys [group-id timestamp message-id]} :payload}]]
     (when (and (not= current-public-key from)
                chats-is-active-and-timestamp)
-      {::participant-left-group-message {:group-id group-id :from from :message-id message-id
-                                         :timestamp timestamp}
+      {::participant-left-group-message {:chat-id    group-id
+                                         :from       from
+                                         :message-id message-id
+                                         :timestamp  timestamp}
        ::chats-remove-contact [group-id from]
        :db (update-in db [:chats group-id :contacts]
                       #(remove (fn [{:keys [identity]}]


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

addresses #2727 

### Summary:

[comment]: # (Summarise the problem and how the pull request solves it)
We mistakenly referred to `:chat-id` field of the group-message, even when group messages have no such field and group-chats/group-messages associated with them have `:group-id` field, so we just need to use that. 

### Testing notes (optional):
No upgrade path testing necessary, otherwise just perform steps according to detailed description in the issue 

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready

