### PR TITLE
[fixes #2546] Add chat-preview-text component to status.js

### DIFF
--- a/resources/js/bots/console/bot.js
+++ b/resources/js/bots/console/bot.js
@@ -483,7 +483,7 @@ var phoneConfig = {
     shortPreview: function (params) {
         if (params) {
             return {
-                markup: status.components.text(
+                markup: status.components.chatPreviewText(
                     {},
                     params.phone
                 )
@@ -576,7 +576,7 @@ var faucetCommandConfig ={
     },
     shortPreview: function (params) {
         return {
-            markup: status.components.text(
+            markup: status.components.chatPreviewText(
                 {},
                 I18n.t('faucet_title') + ": " + params.url
             )
@@ -651,7 +651,7 @@ status.command({
     },
     shortPreview: function (params) {
         return {
-            markup: status.components.text(
+            markup: status.components.chatPreviewText(
                 {},
                 I18n.t('debug_mode_title') + ": " + params.mode
             )
@@ -689,7 +689,7 @@ status.response({
     },
     shortPreview: function (params) {
         return {
-            markup: status.components.text(
+            markup: status.components.chatPreviewText(
                 {},
                 params.code
             )

--- a/resources/js/bots/mailman/bot.js
+++ b/resources/js/bots/mailman/bot.js
@@ -90,7 +90,7 @@ status.command({
     },
     shortPreview: function (params) {
         return {
-            markup: status.components.text(
+            markup: status.components.chatPreviewText(
                 {},
                 I18n.t('location_title') + ": " + params.address
             )

--- a/resources/js/bots/transactor/bot.js
+++ b/resources/js/bots/transactor/bot.js
@@ -524,7 +524,7 @@ function previewSend(showRecipient, params, context) {
 
 function shortPreviewSend(params, context) {
     return {
-        markup: status.components.text(
+        markup: status.components.chatPreviewText(
             {},
             I18n.t('send_title') + ": "
             + status.localizeNumber(params.amount, context.delimiter, context.separator)
@@ -669,7 +669,7 @@ function previewRequest(showRecipient, params, context) {
 
 function shortPreviewRequest(params, context) {
     return {
-        markup: status.components.text(
+        markup: status.components.chatPreviewText(
             {},
             I18n.t('request_requesting') + " "
             + status.localizeNumber(params.amount, context.delimiter, context.separator)

--- a/resources/js/status.js
+++ b/resources/js/status.js
@@ -130,6 +130,10 @@ function text(options, s) {
     return ['text', options].concat(s);
 }
 
+function chatPreviewText(options, s) {
+    return ['chat-preview-text', options, s];
+}
+
 function textInput(options) {
     return ['text-input', options];
 }
@@ -273,6 +277,7 @@ var status = {
     components: {
         view: view,
         text: text,
+        chatPreviewText: chatPreviewText,
         textInput: textInput,
         slider: slider,
         image: image,

--- a/src/status_im/commands/utils.cljs
+++ b/src/status_im/commands/utils.cljs
@@ -7,6 +7,7 @@
             [status-im.chat.views.input.validation-messages :as chat-validation-messages]
             [status-im.chat.views.api.choose-contact :as choose-contact]
             [status-im.ui.components.qr-code :as qr]
+            [status-im.ui.components.chat-preview :as chat-preview]
             [status-im.chat.views.api.geolocation.views :as geolocation]
             [status-im.utils.handlers :refer [register-handler]]
             [taoensso.timbre :as log]))
@@ -22,6 +23,7 @@
   {:view                 components/view
    :text                 components/text
    :text-input           components/text-input
+   :chat-preview-text    chat-preview/text
    :image                components/image
    :qr-code              qr/qr-code
    :linking              components/linking

--- a/src/status_im/ui/components/chat_preview.cljs
+++ b/src/status_im/ui/components/chat_preview.cljs
@@ -1,0 +1,13 @@
+(ns status-im.ui.components.chat-preview
+  (:require [status-im.ui.components.react :as components]
+            [status-im.ui.screens.chats-list.styles :as st]
+            [status-im.utils.utils :as utils]))
+
+(def default-attributes
+  {:style           st/last-message-text
+   :number-of-lines 1})
+
+(defn text [attributes s]
+  (-> default-attributes
+      (utils/deep-merge attributes)
+      (components/text s)))

--- a/src/status_im/utils/utils.cljs
+++ b/src/status_im/utils/utils.cljs
@@ -133,3 +133,10 @@
         (map (fn [[k v]]
                [k (f v)]))
         m))
+
+(defn deep-merge
+  "Recursively merge maps"
+  [& maps]
+  (if (every? map? maps)
+    (apply merge-with deep-merge maps)
+    (last maps)))

--- a/test/cljs/status_im/test/utils/utils.cljs
+++ b/test/cljs/status_im/test/utils/utils.cljs
@@ -41,3 +41,9 @@
   (is (= {} (u/map-values {} inc)))
   (is (= {:a 1} (u/map-values {:a 0} inc)))
   (is (= {:a 1 :b 2} (u/map-values {:a 0 :b 1} inc))))
+
+(deftest deep-merge-test
+  (is (= {} (u/deep-merge {} {})))
+  (is (= {:a 1 :b 2} (u/deep-merge {:a 1} {:b 2})))
+  (is (= {:a {:b 1 :c 2}} (u/deep-merge {:a {:b 1 :c 1}} {:a {:c 2}})))
+  (is (= {:a {:b {:c 2}} :d 1} (u/deep-merge {:a {:b {:c 1}} :d 1} {:a {:b {:c 2}}}))))


### PR DESCRIPTION
Duplicate of https://github.com/status-im/status-react/pull/2568 , but based on this repo branch

Fixes #2546 

Changes style of command message in chat list to look it identical to regular messages (gray color and oneliners).

status: ready
