### PR TITLE
Feature/offline inbox public chat support #2701

### DIFF
--- a/src/status_im/protocol/group.cljs
+++ b/src/status_im/protocol/group.cljs
@@ -2,6 +2,7 @@
   (:require
     [status-im.protocol.web3.delivery :as d]
     [status-im.protocol.web3.utils :as u]
+    [status-im.utils.config :as config]
     [cljs.spec.alpha :as s]
     [taoensso.timbre :refer-macros [debug]]
     [status-im.protocol.validation :refer-macros [valid?]]
@@ -136,9 +137,14 @@
     (fn [key-id]
       (f/add-filter!
         web3
-        {:topics [f/status-topic]
-         :key    key-id
-         :type   :sym}
+        (if config/offline-inbox-enabled?
+          {:topics   [f/status-topic]
+           :key      key-id
+           :allowP2P true
+           :type     :sym}
+          {:topics   [f/status-topic]
+           :key      key-id
+           :type     :sym})
         (l/message-listener {:web3     web3
                              :identity identity
                              :callback callback

--- a/src/status_im/protocol/web3/inbox.cljs
+++ b/src/status_im/protocol/web3/inbox.cljs
@@ -47,8 +47,7 @@
                                           :params  [{:peer      enode
                                                      :topic     topic
                                                      :symKeyID  sym-key-id
-                                                     :from      0
-                                                     :to        1612505820}]}
+                                                     :from      0}]}
                                     payload (.stringify js/JSON (clj->js args))]
                                 (log/info "offline inbox: request-messages request")
                                 (log/info "offline inbox: request-messages args" (pr-str args))


### PR DESCRIPTION
Derived from PR: https://github.com/status-im/status-react/pull/2670
Addresses: https://github.com/status-im/status-react/issues/2701

### Summary

- Add `allowP2P` flag to group chats whisper filter
- Switch to `develop-gba6c9653` status-go build
- Remove `to` flag from `shh_requestMessages` call (it's `time.Now()` by default)

### Testing

#### Requirements:

Toggling on/off flag with parameterized build (`OFFLINE_INBOX_ENABLED=1` or 0).

#### Notes:
This branch uses modified TTL and max-retry-attempts to speed up verification of this capabilitty working.
By default we have TTL=120 and 3 retries = 6 minutes wait time. With PR upcoming TTL=1m and max retries = 1 = 1m wait time (+1m to be safe).

#### Control test (OFFLINE_INBOX_ENABLED flag off):

* User A joins public chat "test-chat"
* User B joins public chat "test-chat" (can be same device)
* User B goes offline
* User A sends message to test-chat
* Wait 2m
* User B goes online, signs in and opens test-chat
* User B does not see message in test-chat

#### Capability test (OFFLINE_INBOX_ENABLED flag on):

* User A joins public chat "test-chat"
* User B joins public chat "test-chat" (can be same device)
* User B goes offline
* User A sends message to test-chat
* Wait 2m
* User B goes online, signs in and opens test-chat
* User B sees message in test-chat

--- 

Status: ready

(clone of https://github.com/status-im/status-react/pull/2707 but based on org branch, not fork)