### PR TITLE
Avoid compiler warnings

### DIFF
--- a/src/status_im/chat/styles/input/suggestions.cljs
+++ b/src/status_im/chat/styles/input/suggestions.cljs
@@ -1,6 +1,7 @@
 (ns status-im.chat.styles.input.suggestions
   (:require-macros [status-im.utils.styles :refer [defnstyle]])
-  (:require [status-im.ui.components.styles :as common]))
+  (:require [status-im.ui.components.styles :as common]
+            [status-im.utils.platform :as platform]))
 
 (def color-item-title-text "rgb(147, 155, 161)")
 (def color-item-suggestion-name "rgb(98, 143, 227)")


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

### Summary:

When compiling the app, we get following warning:
`WARNING: Use of undeclared Var status-im.utils.platform/platform at line 19 /Users/janherich/Development/status-react/src/status_im/chat/styles/input/suggestions.cljs`

It's because of the `defnstyle`/`defstyle` macros, we should eventually fix them, but this ultra small fix just ensures no warnings for now. 

### Testing notes (optional):
No dev testing necessary

status: ready

