### PR TITLE
[FIX #2620] Refactored double dispatch into single event-fx

### DIFF
--- a/src/status_im/ui/screens/discover/components/views.cljs
+++ b/src/status_im/ui/screens/discover/components/views.cljs
@@ -48,7 +48,7 @@
     :else (identicon/identicon whisper-id)))
 
 (defn chat-button [whisper-id]
-  [react/touchable-highlight {:on-press #(re-frame/dispatch [:start-chat whisper-id])}
+  [react/touchable-highlight {:on-press #(re-frame/dispatch [:start-chat whisper-id {:navigation-replace? true}])}
    [react/view styles/chat-button-container
     [react/view styles/chat-button-inner
       [vector-icons/icon :icons/chats {:color :active}]

--- a/src/status_im/ui/screens/discover/events.cljs
+++ b/src/status_im/ui/screens/discover/events.cljs
@@ -147,6 +147,13 @@
     (fn [_ _]
       (discoveries/delete :created-at :asc 1000 200))))
 
+(handlers/register-handler-db
+ :show-discovery
+ (fn [db [_ tags view-id]]
+   (-> db
+       (assoc :discover-search-tags tags)
+       (nav/navigate-to view-id))))
+
 (handlers/register-handler-fx
   :show-status-author-profile
   (fn [{db :db} [_ identity]]

--- a/src/status_im/ui/screens/discover/popular_hashtags/views.cljs
+++ b/src/status_im/ui/screens/discover/popular_hashtags/views.cljs
@@ -9,8 +9,8 @@
             [status-im.ui.components.toolbar.view :as toolbar]))
 
 (defn render-tag [tag]
-  [react/touchable-highlight {:on-press #(do (re-frame/dispatch [:set :discover-search-tags [tag]])
-                                             (re-frame/dispatch [:navigate-to :discover-search-results]))}
+  [react/touchable-highlight
+   {:on-press #(re-frame/dispatch [:show-discovery [tag] :discover-search-results])}
    [react/view styles/tag-view
     [react/text {:style styles/tag-title
                  :font  :default}

--- a/src/status_im/ui/screens/discover/views.cljs
+++ b/src/status_im/ui/screens/discover/views.cljs
@@ -41,20 +41,16 @@
     :nav-action         (actions/hamburger drawer/open-drawer!)
     :on-search-submit   (fn [text]
                           (when-not (string/blank? text)
-                            (let [hashtags (get-hashtags text)]
-                              ;; TODO (goranjovic) - refactor double dispatch to a single call
-                              (re-frame/dispatch [:set :discover-search-tags hashtags])
-                              (re-frame/dispatch [:navigate-to :discover-search-results]))))}])
-
+                            (let [tags (get-hashtags text)]
+                              (re-frame/dispatch [:show-discovery tags :discover-search-results]))))}])
 
 (defn top-status-for-popular-hashtag [{:keys [tag item current-account contacts]}]
   (let [{:keys [discovery total]} item]
     [react/view styles/popular-list-container
      [react/view styles/row
       [react/view {}
-       ;; TODO (goranjovic) - refactor double dispatch to a single call
-       [react/touchable-highlight {:on-press #(do (re-frame/dispatch [:set :discover-search-tags [tag]])
-                                                  (re-frame/dispatch [:navigate-to :discover-search-results]))}
+       [react/touchable-highlight
+        {:on-press #(re-frame/dispatch [:show-discovery [tag] :discover-search-results])}
         [react/view {}
          [react/text {:style styles/tag-name
                       :font  :medium}
@@ -69,11 +65,10 @@
                                      :contacts        contacts}]]))
 
 (defn popular-hashtags-preview [{:keys [popular-discoveries popular-tags contacts current-account]}]
-  (let [has-content? (seq popular-tags)]
+  (let [has-content? (seq popular-tags)
+        tags (map :name popular-tags)]
     [react/view styles/popular-container
-     ;; TODO (goranjovic) - refactor double dispatch to a single call
-     [components/title :t/popular-tags :t/all #(do (re-frame/dispatch [:set :discover-search-tags (map :name popular-tags)])
-                                                   (re-frame/dispatch [:navigate-to :discover-all-hashtags])) has-content?]
+     [components/title :t/popular-tags :t/all #(re-frame/dispatch [:show-discovery tags :discover-all-hashtags]) has-content?]
      (if has-content?
        [carousel/carousel {:pageStyle styles/carousel-page-style
                            :gap       8
@@ -165,9 +160,9 @@
       [recent-statuses-preview {:contacts        contacts
                                   :current-account current-account
                                   :discoveries     discoveries}]
-      [popular-hashtags-preview {:popular-tags        popular-tags
-                                   :popular-discoveries popular-discoveries
-                                   :contacts            contacts
+      [popular-hashtags-preview {:popular-tags     popular-tags
+                                 :popular-discoveries popular-discoveries
+                                 :contacts            contacts
                                  :current-account     current-account}]
       [all-dapps/preview all-dapps]
       [public-chats-teaser]]]))


### PR DESCRIPTION
Fixes [#2620](https://github.com/status-im/status-react/issues/2620)

### Summary:
Refactored do event on the discovery tab into single event-fx to fix navigation routing. 

The 2nd call on the double-dispatch was failing to properly populate the `:navigate-to` event, which in turn was causing the back button to refer to the previous nav state instead of the newly updated.

status: ready



