### PR TITLE
with-activity-indicator component

### DIFF
--- a/src/status_im/ui/components/react.cljs
+++ b/src/status_im/ui/components/react.cljs
@@ -1,4 +1,5 @@
 (ns status-im.ui.components.react
+  (:require-macros [status-im.utils.views :as views])
   (:require [reagent.core :as r]
             [status-im.ui.components.styles :as st]
             [status-im.utils.utils :as u]
@@ -188,3 +189,18 @@
                        [keyboard-avoiding-view-class (merge {:behavior :padding} props)]
                        [view props])]
     (vec (concat view-element children))))
+
+(views/defview with-activity-indicator [{:keys [timeout style enabled?]} comp]
+  (views/letsubs
+    [loading (r/atom true)]
+    {:component-did-mount (fn []
+                            (if (or (nil? timeout)
+                                    (> 100 timeout))
+                              (reset! loading false)
+                              (js/setTimeout (fn []
+                                               (reset! loading false))
+                                             timeout)))}
+    (if (and (not enabled?) @loading)
+      [view {:style style}
+       [activity-indicator {:animating true}]]
+      comp)))

--- a/src/status_im/ui/components/tabs/views.cljs
+++ b/src/status_im/ui/components/tabs/views.cljs
@@ -48,7 +48,10 @@
                         :ref              #(reset! swiper %)
                         :on-index-changed #(re-frame/dispatch [navigation-event (index->tab %)])}
           (for [[index {:keys [screen view-id]}] indexed-tabs]
-            ^{:key index} [screen (is-current-tab? view-id)])]
+            ^{:key index}
+            [react/with-activity-indicator
+             {:enabled? (= current-tab view-id)}
+             [screen (is-current-tab? view-id)]])]
          (when (and bottom-tabs?
                     show-tabs?)
            [tabs tabs-container-style indexed-tabs tab-style on-press is-current-tab?])]))))


### PR DESCRIPTION
`with-activity-indicator` allows us to wrap other components which rendering should happen only after mounting of parent component. Be using this wrapper we can reduce the duration of initial rendering thus make app more responsive.

Currently used only for wrapping tabs inside `main-tabs`. 

Numbers may differ, though on relatively slow Android device navigation from `:chat` to `:chats-list` takes now ~0.85s (when it was ~2.1s). On faster devices difference can be less noticeable. 

status: ready

