### PR TITLE
Fix stale subscriptions

### DIFF
--- a/src/status_im/chat/screen.cljs
+++ b/src/status_im/chat/screen.cljs
@@ -73,8 +73,8 @@
                                                 :group-chat group-chat
                                                 :current-public-key current-public-key)]))
 
-(defview messages-view [group-chat]
-  (letsubs [messages           [:get-current-chat-messages]
+(defview messages-view [chat-id group-chat]
+  (letsubs [messages           [:get-chat-messages chat-id]
             current-public-key [:get-current-public-key]]
     [react/list-view {:renderRow                 (fn [row _ index]
                                                    (message-row {:group-chat         group-chat
@@ -87,11 +87,11 @@
                       :dataSource                (listview/to-datasource-inverted messages)}]))
 
 (defview chat []
-  (letsubs [{:keys [group-chat input-text]} [:get-current-chat]
-            show-actions?                   [:get-current-chat-ui-prop :show-actions?]
-            show-bottom-info?               [:get-current-chat-ui-prop :show-bottom-info?]
-            show-emoji?                     [:get-current-chat-ui-prop :show-emoji?]
-            layout-height                   [:get :layout-height]]
+  (letsubs [{:keys [chat-id group-chat input-text]} [:get-current-chat]
+            show-actions?                           [:get-current-chat-ui-prop :show-actions?]
+            show-bottom-info?                       [:get-current-chat-ui-prop :show-bottom-info?]
+            show-emoji?                             [:get-current-chat-ui-prop :show-emoji?]
+            layout-height                           [:get :layout-height]]
     {:component-did-mount    #(re-frame/dispatch [:check-and-open-dapp!])
      :component-will-unmount #(re-frame/dispatch [:set-chat-ui-props {:show-emoji? false}])}
     [react/view {:style style/chat-view
@@ -100,7 +100,7 @@
                                 (when (not= height layout-height)
                                   (re-frame/dispatch [:set-layout-height height]))))}
      [chat-toolbar]
-     [messages-view group-chat]
+     [messages-view chat-id group-chat]
      [input/container {:text-empty? (string/blank? input-text)}]
      (when show-actions?
        [actions/actions-view])

--- a/src/status_im/chat/subs.cljs
+++ b/src/status_im/chat/subs.cljs
@@ -56,10 +56,10 @@
 
 (reg-sub
   :get-current-chat
-  (fn [_]
-    (let [current-chat-id (subscribe [:get-current-chat-id])]
-      (subscribe [:get-chat @current-chat-id])))
-  identity)
+  :<- [:chats]
+  :<- [:get-current-chat-id]
+  (fn [[chats current-chat-id]]
+    (get chats current-chat-id)))
 
 (reg-sub
   :chat
@@ -133,10 +133,9 @@
            :value (i18n/label :t/datetime-today)})))
 
 (reg-sub
-  :get-current-chat-messages
-  (fn [_]
-    (let [current-chat-id (subscribe [:get-current-chat-id])]
-      (subscribe [:get-chat-message-datemark-groups @current-chat-id])))
+  :get-chat-messages 
+  (fn [[_ chat-id]] 
+    (subscribe [:get-chat-message-datemark-groups chat-id]))
   (fn [message-datemark-groups]
     (messages-stream message-datemark-groups)))
 


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

### Summary:

As @rasom correctly pointed out, I added/reworked 2 subscriptions in my last PR where the signal input function was wrong, in the sense that those 2 subscriptions would never be recomputed if their input sources changed.
It was not a problem because those subscriptions were only ever mounted on a chat screen, so `:current-chat-id` never changed while they were mounted, but it was still wrong and could give us problems in the case we decided to not unmount screens during navigation.
This PR just fixes the situation.

### Steps to test:
- Open Status
- Open any chat and verify it's working (messages are there)

status: ready


