### PR TITLE
Update request messages to new status go interface #2785

### DIFF
--- a/modules/react-native-status/android/build.gradle
+++ b/modules/react-native-status/android/build.gradle
@@ -17,5 +17,5 @@ dependencies {
     compile 'com.instabug.library:instabug:3+'
     compile 'com.github.ericwlange:AndroidJSCore:3.0.1'
     compile 'status-im:function:0.0.1'
-    compile(group: 'status-im', name: 'status-go', version: 'develop-gba6c9653', ext: 'aar')
+    compile(group: 'status-im', name: 'status-go', version: 'develop-gb7fb51d9', ext: 'aar')
 }

--- a/modules/react-native-status/ios/RCTStatus/pom.xml
+++ b/modules/react-native-status/ios/RCTStatus/pom.xml
@@ -25,7 +25,7 @@
                         <artifactItem>
                             <groupId>status-im</groupId>
                             <artifactId>status-go-ios-simulator</artifactId>
-                            <version>develop-gba6c9653</version>
+                            <version>develop-gb7fb51d9</version>
                             <type>zip</type>
                             <overWrite>true</overWrite>
                             <outputDirectory>./</outputDirectory>

--- a/src/status_im/protocol/web3/inbox.cljs
+++ b/src/status_im/protocol/web3/inbox.cljs
@@ -45,10 +45,11 @@
                               (let [args {:jsonrpc "2.0"
                                           :id      2
                                           :method  "shh_requestMessages"
-                                          :params  [{:peer      enode
-                                                     :topic     topic
-                                                     :symKeyID  sym-key-id
-                                                     :from      0}]}
+                                          ;; NOTE: "from" and "to" parameters omitted here
+                                          ;; by default "from" is 24 hours ago and "to" is time now
+                                          :params  [{:mailServerPeer enode
+                                                     :topic          topic
+                                                     :symKeyID       sym-key-id}]}
                                     payload (.stringify js/JSON (clj->js args))]
                                 (log/info "offline inbox: request-messages request")
                                 (log/info "offline inbox: request-messages args" (pr-str args))


### PR DESCRIPTION
fixes #2785 

### Summary:

- Update status-go dependency to `develop-gb7fb51d9` https://github.com/status-im/status-go/commit/b7fb51d92ac5333afa4bcb340b1f17960cca33c8 
- Rename `peer` parameter to `mailServerPeer` conform to latest `requestMessages` method version
- Remove `from` parameter as it defaults to 0

### Notes:
App behaviour doesn't change. I'm going to make some refactoring of inbox.cljs, but decided to do that in separate PR to make reviewing easier.

status: ready <!-- Can be ready or wip -->
