### PR TITLE
[Fix #2590] Blank QR code on a quick double tap of the 'Show QR code'

### DIFF
--- a/src/status_im/ui/screens/profile/navigation.cljs
+++ b/src/status_im/ui/screens/profile/navigation.cljs
@@ -3,8 +3,8 @@
 
 (defmethod navigation/preload-data! :qr-code-view
   [{:accounts/keys [current-account-id] :as db} [_ _ {:keys [contact qr-source qr-value amount?]}]]
-  (assoc db :qr-modal {:contact   (or contact
-                                      (get-in db [:accounts/accounts current-account-id]))
-                       :qr-source qr-source
-                       :qr-value  qr-value
-                       :amount?   amount?}))
+  (update db :qr-modal #(merge % {:contact   (or contact
+                                                 (get-in db [:accounts/accounts current-account-id]))
+                                  :qr-source qr-source
+                                  :qr-value  qr-value
+                                  :amount?   amount?})))


### PR DESCRIPTION
Fix #2590

Somehow `:on-layout` is being invoked once only [here](https://github.com/status-im/status-react/blob/develop/src/status_im/ui/screens/profile/qr_code/views.cljs#L35) when you tap 'Show QR code' multiple times, dimensions of QR code view will then be unset. As a workaround, I guess we can update `:qr-modal` from `db` and merge it with new data instead of resetting it completely.

status: ready <!-- Can be ready or wip -->
