### PR TITLE
Fixed test_balance_and_eth_rate to verify USD balance instead of eth

### DIFF
--- a/test/appium/tests/test_wallet.py
+++ b/test/appium/tests/test_wallet.py
@@ -118,7 +118,7 @@ class TestWallet(SingleDeviceTestCase):
                                       transaction_hash=transaction_hash)
 
     @pytest.mark.wallet
-    def test_balance_and_eth_rate(self):
+    def test_eth_and_currency_balance(self):
         errors = list()
         home = HomeView(self.driver)
         recover_access(home,
@@ -128,10 +128,10 @@ class TestWallet(SingleDeviceTestCase):
         chats = home.get_chats()
         address = transaction_users_wallet['A_USER']['address']
         balance = get_balance(address) / 1000000000000000000
-        eth_rate = get_ethereum_price_in_usd()
         wallet = chats.wallet_button.click()
+        eth_rate = get_ethereum_price_in_usd()
         wallet_balance = wallet.get_eth_value()
         if wallet_balance != balance:
             errors.append('Balance %s is not equal to the expected %s' % (wallet_balance, balance))
-        wallet.verify_eth_rate(eth_rate, errors)
+        wallet.verify_currency_balance(eth_rate, errors)
         assert not errors, 'errors occurred:\n{}'.format('\n'.join(errors))

--- a/test/appium/views/wallet.py
+++ b/test/appium/views/wallet.py
@@ -89,10 +89,10 @@ class WalletViewObject(BaseViewObject):
     def get_eth_value(self):
         return float(self.eth_asset.text)
 
-    def verify_eth_rate(self, expected_rate: int, errors: list):
+    def verify_currency_balance(self, expected_rate: int, errors: list):
         usd = self.get_usd_total_value()
         eth = self.get_eth_value()
-        current_rate = usd / eth
-        if round(current_rate, 2) != expected_rate:
-            errors.append('Current ETH rate %s is not equal to the expected %s' % (current_rate, expected_rate))
-        logging.info('Current ETH rate %s is ok' % current_rate)
+        expected_usd = round(eth * expected_rate, 2)
+        if expected_usd != usd:
+            errors.append('Current USD balance %s is not equal to the expected %s' % (usd, expected_usd))
+        logging.info('Current USD balance %s is ok' % usd)


### PR DESCRIPTION
* Reworked test_balance_and_eth_rate method to verify_currency_balance value in Wallet instead of ETH rate
* get_ethereum_price_in_usd moved closer to step where we take USD value from Wallet