### PR TITLE
[ref status-im/status-go#229] Do not delete the geth.log file at star…

### DIFF
--- a/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusModule.java
+++ b/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusModule.java
@@ -197,9 +197,6 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
             jsonConfig.put("KeyStoreDir", newKeystoreDir);
             String gethLogPath = dataFolder + "/" + gethLogFileName;
             File logFile = new File(gethLogPath);
-            if (logFile.exists()) {
-                logFile.delete();
-            }
             try {
                 logFile.setReadable(true);
                 File parent = logFile.getParentFile();

--- a/modules/react-native-status/ios/RCTStatus/RCTStatus.m
+++ b/modules/react-native-status/ios/RCTStatus/RCTStatus.m
@@ -211,9 +211,6 @@ RCT_EXPORT_METHOD(startNode:(NSString *)configString) {
     }
     NSString *resultingConfig = [resultingConfigJson bv_jsonStringWithPrettyPrint:NO];
     NSLog(@"node config %@", resultingConfig);
-    if([fileManager fileExistsAtPath:logUrl.path]) {
-        [fileManager removeItemAtPath:logUrl.path error:nil];
-    }
     
     if(![fileManager fileExistsAtPath:networkDirUrl.path]) {
         [fileManager createDirectoryAtPath:networkDirUrl.path withIntermediateDirectories:YES attributes:nil error:nil];


### PR DESCRIPTION
…tup. Allow the new log rotate logic in status geth to handle that

fixes status-im/status-go#229

### Summary:

This is a simple change that goes hand-in-hand with the main status-im/status-go#524 PR. It simply gets rid of the logic that deletes the geth.log log file at startup, and leaves that to the lumberjack log rotate layer.

### Review notes:
Although this PR works independently, it would probably be easier to test when https://github.com/status-im/status-react/pull/2803 is accepted, since that allows setting the log level through a feature flag.

### Testing notes:
Please check that the log is indeed created. On my stock Nexus 6P, I had to hardcode a full path rooted at `/storage/emulated/0/...` to geth for the `geth.log` log file to be created at the right place. With the logic as is, it will attempt to create it in the data dir for the current activity, which for me appeared in the logcat as `/data/users/0/...` and failed to get created on-device.

### Steps to test:
- Set the `LOG_LEVEL_STATUS_GO` log level to `debug`, so that the logs fill up more quickly.
- Maybe seed a geth.log file that is just below 16MB in size, so that when you open the app, the log will be rotated.
- Open Status.
- Confirm that the log doesn't grow above 16MB.
- Confirm that as more logs are generated, only 3 backup files are kept.

status: ready
