### PR TITLE
scripts: Improve `bundle-status-go.sh` so that it can bundle Android …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,7 @@ re-natal
 
 # Status
 Statusgo.framework
+status-go-local.aar
 status-dev-cli
 
 #ios

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,6 +18,7 @@ allprojects {
         mavenLocal()
         jcenter()
         maven { url "$rootDir/../node_modules/react-native/android" }
+        maven { url "$rootDir/../modules/react-native-status/android/libs" }
         // for geth
         flatDir { dirs 'libs' }
         maven { url "http://139.162.11.12:8081/artifactory/libs-release-local" }

--- a/modules/react-native-status/android/build.gradle
+++ b/modules/react-native-status/android/build.gradle
@@ -17,5 +17,16 @@ dependencies {
     compile 'com.instabug.library:instabug:3+'
     compile 'com.github.ericwlange:AndroidJSCore:3.0.1'
     compile 'status-im:function:0.0.1'
-    compile(group: 'status-im', name: 'status-go', version: 'develop-gb7fb51d9', ext: 'aar')
+
+    String statusGoVersion = 'develop-gb7fb51d9'
+    final String statusGoGroup = 'status-im', statusGoName = 'status-go'
+
+    // Check if the local status-go jar exists, and compile against that if it does
+    final String localStatusLibOutputDir = "${rootDir}/../modules/react-native-status/android/libs", localVersion = 'local'
+    if ( new File("${localStatusLibOutputDir}/${statusGoGroup}/${statusGoName}/${localVersion}/${statusGoName}-${localVersion}.aar").exists() ) {
+        // Use the local version
+        statusGoVersion = localVersion
+    }
+
+    compile(group: statusGoGroup, name: statusGoName, version: statusGoVersion, ext: 'aar')
 }

--- a/scripts/build-android.sh
+++ b/scripts/build-android.sh
@@ -24,7 +24,7 @@ case $TARGET in
     ;;
   prod)
     STORE_FILE=$(property_gradle 'STATUS_RELEASE_STORE_FILE')
-    [[ ! -e "${STORE_FILE/#\~/$HOME}" ]] && echo "Please generate keystore first using ./generate-kesytore.sh" && exit 0
+    [[ ! -e "${STORE_FILE/#\~/$HOME}" ]] && echo "Please generate keystore first using ./generate-keystore.sh" && exit 0
     lein do clean, with-profile prod cljsbuild once android && ./android/gradlew ${GRADLE_PROPERTIES} assembleRelease
     cecho "Generated @b@blueandroid/app/build/outputs/apk/app-release.apk"
     echo


### PR DESCRIPTION
…package as well (#2539)

Fixes #2539 

### Summary:

[comment]: # (Summarise the problem and how the pull request solves it)
Currently the `scripts/bundle-status-go.sh` script only handles iOS bundles. This PR expands the script logic and the gradle config to allow building an Android status-go package and deploying it for local usage.

### Review notes:
`scripts/bundle-status-go.sh` needs to be passed one or more platforms. E.g.
- `scripts/bundle-status-go.sh android`
- `scripts/bundle-status-go.sh ios android`

Since I'm not sure of how the script will end up being used, I've changed the `react-native-status/android/build.gradle` config file so that debug builds consume the `.aar` file generated by the updated `scripts/bundle-status-go.sh`. The generated Android package gets copied into the `modules/react-native-status/android/libs` folder.

### Steps to test:
- Make a change to the Go codebase that can easily be spotted in the app once you integrate the go package.
- Run `scripts/bundle-status-go.sh android`
- Deploy the app as a debug build and verify that the Go package is what you expected it to be.

status: ready
