### PR TITLE
Action button functinoality restored for desktop

### DIFF
--- a/src/status_im/ui/components/action_button/action_button.cljs
+++ b/src/status_im/ui/components/action_button/action_button.cljs
@@ -5,21 +5,22 @@
             [status-im.ui.components.react :as rn]))
 
 (defn action-button [{:keys [label icon icon-opts on-press label-style cyrcle-color]}]
-   [rn/view st/action-button
-    [rn/view (st/action-button-icon-container cyrcle-color)
-     [vi/icon icon icon-opts]]
-    [rn/view st/action-button-label-container
-     [rn/text {:style (merge st/action-button-label label-style)}
-      label]]])
+      [rn/touchable-highlight {:on-press on-press}
+       [rn/view st/action-button
+        [rn/view (st/action-button-icon-container cyrcle-color)
+         [vi/icon icon icon-opts]]
+        [rn/view st/action-button-label-container
+         [rn/text {:style (merge st/action-button-label label-style)}
+          label]]]])
 
 (defn action-button-disabled [{:keys [label icon]}]
-  [rn/view st/action-button
-   [rn/view st/action-button-icon-container-disabled
-    [rn/view {:opacity 0.4}
-     [vi/icon icon]]]
-   [rn/view st/action-button-label-container
-    [rn/text {:style st/action-button-label-disabled}
-     label]]])
+      [rn/view st/action-button
+       [rn/view st/action-button-icon-container-disabled
+        [rn/view {:opacity 0.4}
+         [vi/icon icon]]]
+       [rn/view st/action-button-label-container
+        [rn/text {:style st/action-button-label-disabled}
+         label]]])
 
 (defn action-separator []
-  [list-separator])
+      [list-separator])

--- a/src/status_im/ui/components/action_button/styles.cljs
+++ b/src/status_im/ui/components/action_button/styles.cljs
@@ -13,6 +13,7 @@
    :flex-direction :row
    :align-items    :center
    :ios            {:height 63}
+   :desktop        {:height 63}
    :android        {:height 56}})
 
 (defnstyle action-button-icon-container [cyrcle-color]
@@ -21,13 +22,18 @@
    :height           40
    :align-items      :center
    :justify-content  :center
-   :ios              {:background-color (or cyrcle-color color-light-blue-transparent)}})
+   :ios              {:background-color (or cyrcle-color color-light-blue-transparent)}
+   :desktop          {:background-color (or cyrcle-color color-light-blue-transparent)}})
 
 (def action-button-label-container
   {:padding-left 16})
 
 (defstyle action-button-label
   {:ios     {:color          color-light-blue
+             :letter-spacing -0.2
+             :font-size      17
+             :line-height    20}
+   :desktop {:color          color-light-blue
              :letter-spacing -0.2
              :font-size      17
              :line-height    20}
@@ -50,5 +56,6 @@
    :height           40
    :align-items      :center
    :justify-content  :center
-   :ios              {:background-color color-light-gray}})
+   :ios              {:background-color color-light-gray}
+   :desktop          {:background-color color-light-gray}})
 

--- a/src/status_im/ui/screens/events.cljs
+++ b/src/status_im/ui/screens/events.cljs
@@ -297,7 +297,7 @@
   :check-console-chat
   (fn [{{:accounts/keys [accounts] :as db} :db} [_ open-console?]]
     (let [view (if (empty? accounts)
-                 :login
+                 :profile
                  :accounts)]
       (merge
        {:db (assoc db

--- a/src/status_im/ui/screens/profile/views.cljs
+++ b/src/status_im/ui/screens/profile/views.cljs
@@ -200,8 +200,10 @@
      [profile-status]]
     [common/form-spacer]
     [react/view styles/profile-badge
-          (vi/icon :icons/qr)
-    [action-button {:label "Show QR"}]]
+    [action-button {:icon :icons/qr
+                    :icon-opts {:style {:tintColor color-blue}}
+                    :label "Show QR"
+                    :on-press #(print "Show QR pressed")}]]
     [common/form-spacer]
     [react/view styles/profile-info-container
        [my-profile-info {:phone "+44 7911 123456"


### PR DESCRIPTION
- `TouchableHighlight` component returned back to `action-button`
- `action-button` styles updated to have dimensions for desktop
- Profile screen now have working `action-button` example