### PR TITLE
[Fix #2834] Migrate android build to latest gradle plugin

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -117,7 +117,7 @@ def getVersionName = { ->
 
 android {
     compileSdkVersion 24
-    buildToolsVersion "24.0.2"
+    buildToolsVersion "26.0.2"
 
     defaultConfig {
         applicationId "im.status.ethereum"
@@ -189,7 +189,7 @@ android {
 dependencies {
     compile project(':react-native-svg')
     compile project(':react-native-mapbox-gl')
-    compile 'com.android.support:multidex:1.0.1'
+    compile 'com.android.support:multidex:1.0.2'
     compile project(':react-native-http-bridge')
     compile project(':nfc-react-native')
     compile project(':instabug-reactnative')

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,10 +2,11 @@
 
 buildscript {
     repositories {
+        google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.0'
+        classpath 'com.android.tools.build:gradle:3.0.1'
         classpath 'com.google.gms:google-services:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
@@ -15,6 +16,7 @@ buildscript {
 
 allprojects {
     repositories {
+        google()
         mavenLocal()
         jcenter()
         maven { url "$rootDir/../node_modules/react-native/android" }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -24,3 +24,6 @@ STATUS_RELEASE_STORE_FILE=~/.gradle/status-im.keystore
 STATUS_RELEASE_STORE_PASSWORD=password
 STATUS_RELEASE_KEY_ALIAS=status
 STATUS_RELEASE_KEY_PASSWORD=password
+
+# Workaround for issue https://github.com/facebook/react-native/issues/16906
+android.enableAapt2=false

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip


### PR DESCRIPTION
Fixes #2834 :  Migrate android build to latest gradle plugin

### Summary:

Upgrade the android build to use gradle 3.0.1.

### Steps to test:

Follow usual Android build instructions at https://wiki.status.im/Building_Status#Building_Status_for_Development
