### PR TITLE
Hide react native long timeout warnings

### DIFF
--- a/src/status_im/core.cljs
+++ b/src/status_im/core.cljs
@@ -9,7 +9,7 @@
             [goog.object :as object]))
 
 (when js/goog.DEBUG
-  (object/set js/console "ignoredYellowBox" #js ["re-frame: overwriting"]))
+  (object/set js/console "ignoredYellowBox" #js ["re-frame: overwriting" "Setting a timer"]))
 
 (defn init [app-root]
   (log/set-level! config/log-level)


### PR DESCRIPTION
Temporary hides warning for #2408 

### Summary:

It hides the warnings that RN generates for long timeouts.

status: ready