### PR TITLE
Change messages subscription

### DIFF
--- a/src/status_im/chat/screen.cljs
+++ b/src/status_im/chat/screen.cljs
@@ -73,8 +73,8 @@
                                :group-chat group-chat
                                :current-public-key current-public-key)])
 
-(defview messages-view [chat-id group-chat]
-  (letsubs [messages           [:get-chat-messages chat-id]
+(defview messages-view [group-chat]
+  (letsubs [messages           [:get-current-chat-messages]
             current-public-key [:get-current-public-key]]
     [list/flat-list {:data                      messages
                      :render-fn                 #(message-row {:group-chat         group-chat
@@ -86,11 +86,11 @@
                      :keyboardShouldPersistTaps (if platform/android? :always :handled)}]))
 
 (defview chat []
-  (letsubs [{:keys [chat-id group-chat input-text]} [:get-current-chat]
-            show-actions?                           [:get-current-chat-ui-prop :show-actions?]
-            show-bottom-info?                       [:get-current-chat-ui-prop :show-bottom-info?]
-            show-emoji?                             [:get-current-chat-ui-prop :show-emoji?]
-            layout-height                           [:get :layout-height]]
+  (letsubs [{:keys [group-chat input-text]} [:get-current-chat]
+            show-actions?                   [:get-current-chat-ui-prop :show-actions?]
+            show-bottom-info?               [:get-current-chat-ui-prop :show-bottom-info?]
+            show-emoji?                     [:get-current-chat-ui-prop :show-emoji?]
+            layout-height                   [:get :layout-height]]
     {:component-did-mount    #(re-frame/dispatch [:check-and-open-dapp!])
      :component-will-unmount #(re-frame/dispatch [:set-chat-ui-props {:show-emoji? false}])}
     [react/view {:style style/chat-view
@@ -99,7 +99,7 @@
                                 (when (not= height layout-height)
                                   (re-frame/dispatch [:set-layout-height height]))))}
      [chat-toolbar]
-     [messages-view chat-id group-chat]
+     [messages-view group-chat]
      [input/container {:text-empty? (string/blank? input-text)}]
      (when show-actions?
        [actions/actions-view])

--- a/src/status_im/chat/subs.cljs
+++ b/src/status_im/chat/subs.cljs
@@ -133,11 +133,10 @@
            :value (i18n/label :t/datetime-today)})))
 
 (reg-sub
-  :get-chat-messages
-  (fn [[_ chat-id]]
-    (subscribe [:get-chat-message-datemark-groups chat-id]))
-  (fn [message-datemark-groups]
-    (messages-stream message-datemark-groups)))
+  :get-current-chat-messages
+  :<- [:get-current-chat]
+  (fn [{:keys [messages]}]
+    (-> messages message-datemark-groups messages-stream)))
 
 (reg-sub
   :get-commands-for-chat


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

Address recent point raised by @rasom and @flexsurfer about chat messages subscription being parametrised by chat id, so subscriber needs to pass `:current-chat-id` in the opened chat view.
Apparently, this is somehow problematic for `status-desktop`, so here I reworked the subscription to be non-parametrised and automatically return chat messages stream for currently selected chat.
The downside is less efficiency, as the no part of the sub computation is shared with subscription for `:last-message` (which is established for each chat in chat-list), but as those two subs are (currently) never active at the same time, it's probably moot point.

### Testing notes (optional):
Super basic regression testing, basically if the messages in any chat are loaded correctly, it's working fine.

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready 
