### PR TITLE
[FIX #1048] Localize timestamps in chat history

### DIFF
--- a/test/cljs/status_im/test/runner.cljs
+++ b/test/cljs/status_im/test/runner.cljs
@@ -21,7 +21,8 @@
             [status-im.test.utils.gfycat.core]
             [status-im.test.utils.signing-phrase.core]
             [status-im.test.utils.transducers]
-            [status-im.test.utils.async]))
+            [status-im.test.utils.async]
+            [status-im.test.utils.datetime]))
 
 (enable-console-print!)
 
@@ -53,4 +54,5 @@
  'status-im.test.utils.random
  'status-im.test.utils.gfycat.core
  'status-im.test.utils.signing-phrase.core
- 'status-im.test.utils.transducers)
+ 'status-im.test.utils.transducers
+ 'status-im.test.utils.datetime)

--- a/test/cljs/status_im/test/utils/datetime.cljs
+++ b/test/cljs/status_im/test/utils/datetime.cljs
@@ -1,0 +1,51 @@
+(ns status-im.test.utils.datetime
+  (:require [cljs.test :refer-macros [deftest is]]
+            [status-im.utils.datetime :as d]
+            [cljs-time.core :as t]))
+
+(defn match [name symbols]
+  (is (identical? (.-dateTimeSymbols_ (d/mk-fmt name d/short-date-format))
+                  symbols)))
+
+(deftest date-time-formatter-test
+  (match "en-US" goog.i18n.DateTimeSymbols_en_US)
+  (match "en-ZZ" goog.i18n.DateTimeSymbols_en)
+  (match "en" goog.i18n.DateTimeSymbols_en)
+  (match "nb-NO" goog.i18n.DateTimeSymbols_nb)
+  (match "nb" goog.i18n.DateTimeSymbols_nb)
+  (match "whoa-WHOA" goog.i18n.DateTimeSymbols_en)
+  (match "whoa" goog.i18n.DateTimeSymbols_en))
+
+;; 1970-01-01 00:00:00 UTC
+(def epoch 0)
+;; 1970-01-03 00:00:00 UTC
+(def epoch-plus-3d 172800000)
+
+(deftest to-short-str-today-test
+  (with-redefs [t/*ms-fn* (constantly epoch-plus-3d)
+                d/time-zone-offset (t/period :hours 0)]
+   (is (= (d/to-short-str epoch-plus-3d) "00:00"))))
+
+(deftest to-short-str-before-yesterday-us-test
+  (with-redefs [t/*ms-fn* (constantly epoch-plus-3d)
+                d/time-zone-offset (t/period :hours 0)
+                d/date-fmt (d/mk-fmt "us" d/short-date-format)]
+    (is (= (d/to-short-str epoch) "Jan 1, 1970"))))
+
+(deftest to-short-str-before-yesterday-nb-test
+  (with-redefs [d/time-zone-offset (t/period :hours 0)
+                d/date-fmt (d/mk-fmt "nb-NO" d/short-date-format)
+                t/*ms-fn* (constantly epoch-plus-3d)]
+    (is (= (d/to-short-str epoch) "1. jan. 1970"))))
+
+(deftest day-relative-before-yesterday-us-test
+  (with-redefs [t/*ms-fn* (constantly epoch-plus-3d)
+                d/time-zone-offset (t/period :hours 0)
+                d/date-time-fmt (d/mk-fmt "us" d/short-date-time-format)]
+    (is (= (d/day-relative epoch) "Jan 1, 1970, 12:00:00 AM"))))
+
+(deftest day-relative-before-yesterday-nb-test
+  (with-redefs [t/*ms-fn* (constantly epoch-plus-3d)
+                d/time-zone-offset (t/period :hours 0)
+                d/date-time-fmt (d/mk-fmt "nb-NO" d/short-date-time-format)]
+    (is (= (d/day-relative epoch) "1. jan. 1970, 00:00:00"))))


### PR DESCRIPTION
If current locale is `zz-YY`, looks up `zz_YY` first, `zz` then and finally
falls back to `us`.

`goog.i18n.DateTimeSymbols` database is used for localization.

### Steps to test:
- Open Status
- Write a message (or have initial setup process send you a message)
- Close Status
- Set the device clock to 2 days ahead
- Open Status
- Verify that the messages in the chat log have timestamps in your language
- Close Status
- Set device locale to another language
- Open Status
- Verify that the messages in the chat log have timestamps formatted in the newly selected language

status: ready

Fixes #1048.
