### PR TITLE
Fix hot reloading broken for dev profile

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -31,14 +31,14 @@
                     :source-paths ["src" "env/dev"]
                     :cljsbuild    {:builds
                                    {:ios
-                                    {:source-paths ["react-native/src"]
+                                    {:source-paths ["react-native/src" "src"]
                                      :figwheel     true
                                      :compiler     {:output-to     "target/ios/app.js"
                                                     :main          "env.ios.main"
                                                     :output-dir    "target/ios"
                                                     :optimizations :none}}
                                     :android
-                                    {:source-paths ["react-native/src"]
+                                    {:source-paths ["react-native/src" "src"]
                                      :figwheel     true
                                      :compiler     {:output-to     "target/android/app.js"
                                                     :main          "env.android.main"


### PR DESCRIPTION
Hot reloading for dev profile is broken after https://github.com/status-im/status-react/commit/3e940b5bd437eb348b77570147eb44a1bf09b817 because "src" got removed from `:source-paths`.