### PR TITLE
bug #2899 - using /send command always uses ETH currency

### DIFF
--- a/src/status_im/ui/screens/wallet/send/events.cljs
+++ b/src/status_im/ui/screens/wallet/send/events.cljs
@@ -104,7 +104,9 @@
   [(re-frame/inject-cofx :now)]
   (fn [{:keys [db now]} [_ {:keys [id message_id args] :as transaction}]]
     (if (transaction-valid? transaction)
-      (let [{:keys [from to value symbol data gas gasPrice]} args
+      ;NOTE(goranjovic): the transactions started from chat using /send command
+      ; are only in ether, so this parameter defaults to ETH
+      (let [{:keys [from to value symbol data gas gasPrice] :or {symbol :ETH}} args
             ;;TODO (andrey) revisit this map later (this map from old transactions, idk if we need all these fields)
             transaction {:id         id
                          :from       from

--- a/src/status_im/ui/screens/wallet/send/subs.cljs
+++ b/src/status_im/ui/screens/wallet/send/subs.cljs
@@ -14,7 +14,13 @@
 (re-frame/reg-sub ::send-transaction
   :<- [:wallet]
   (fn [wallet]
-    (:send-transaction wallet)))
+    (let [transaction (:send-transaction wallet)]
+      ;NOTE(goranjovic): the transactions started from chat using /send command
+      ; are only in ether, so this parameter defaults to ETH
+      (if (:symbol transaction)
+        transaction
+        (assoc transaction :symbol :ETH)))))
+
 
 (re-frame/reg-sub :wallet.send/symbol
   :<- [::send-transaction]


### PR DESCRIPTION
fixes #2899

### Summary:

Using /send command from chat always creates ETH transactions
See #2899


### Steps to test:
- Get some test ether 
- Start a chat with a contact and try to /send some eth

status: ready 
