### PR TITLE
[ISSUE #2287] Push Notifications: Use status-go NotifyUsers instead of Notify

### DIFF
--- a/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusModule.java
+++ b/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusModule.java
@@ -404,8 +404,8 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
     }
 
     @ReactMethod
-    public void notify(final String token, final Callback callback) {
-        Log.d(TAG, "notify");
+    public void notifyUsers(final String message, final String payloadJSON, final String tokensJSON, final Callback callback) {
+        Log.d(TAG, "notifyUsers");
         if (!checkAvailability()) {
             callback.invoke(false);
             return;
@@ -414,7 +414,7 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
         Thread thread = new Thread() {
                 @Override
                 public void run() {
-                    String res = Statusgo.Notify(token);
+                    String res = Statusgo.NotifyUsers(message, payloadJSON, tokensJSON);
 
                     callback.invoke(res);
                 }

--- a/modules/react-native-status/ios/RCTStatus/RCTStatus.m
+++ b/modules/react-native-status/ios/RCTStatus/RCTStatus.m
@@ -276,14 +276,16 @@ RCT_EXPORT_METHOD(createAccount:(NSString *)password
 }
 
 ////////////////////////////////////////////////////////////////////
-#pragma mark - Notify method
-//////////////////////////////////////////////////////////////////// notify
-RCT_EXPORT_METHOD(notify:(NSString *)token
+#pragma mark - NotifyUsers method
+//////////////////////////////////////////////////////////////////// notifyUsers
+RCT_EXPORT_METHOD(notifyUsers:(NSString *)message
+                  payloadJSON:(NSString *)payloadJSON
+                  tokensJSON:(NSString *)tokensJSON
                   callback:(RCTResponseSenderBlock)callback) {
-    char * result = Notify((char *) [token UTF8String]);
+    char * result = NotifyUsers((char *) [message UTF8String], (char *) [payloadJSON UTF8String], (char *) [tokensJSON UTF8String]);
     callback(@[[NSString stringWithUTF8String: result]]);
 #if DEBUG
-    NSLog(@"Notify() method called");
+    NSLog(@"NotifyUsers() method called");
 #endif
 }
 

--- a/src/status_im/chat/events/send_message.cljs
+++ b/src/status_im/chat/events/send_message.cljs
@@ -10,9 +10,11 @@
 
 (re-frame/reg-fx
   :send-notification
-  (fn [fcm-token]
-    (log/debug "send-notification fcm-token: " fcm-token)
-    (status/notify fcm-token #(log/debug "send-notification cb result: " %))))
+  (fn [{:keys [message payload tokens]}]
+    (let [payload-json (types/clj->json payload)
+          tokens-json  (types/clj->json tokens)]
+      (log/debug "send-notification message: " message " payload-json: " payload-json " tokens-json: " tokens-json)
+      (status/notify-users {:message message :payload payload-json :tokens tokens-json} #(log/debug "send-notification cb result: " %)))))
 
 (re-frame/reg-fx
   :send-group-message

--- a/src/status_im/chat/models/message.cljs
+++ b/src/status_im/chat/models/message.cljs
@@ -186,7 +186,9 @@
 
           :else
           (merge {:send-message (assoc-in options [:message :to] chat-id)}
-                 (when-not command) {:send-notification fcm-token}))))))
+                 (when fcm-token {:send-notification {:message "message"
+                                                      :payload {:title "Status" :body "You have a new message"}
+                                                      :tokens [fcm-token]}})))))))
 
 (defn- prepare-message [params chat]
   (let [{:keys [chat-id identity message-text]} params

--- a/src/status_im/native_module/core.cljs
+++ b/src/status_im/native_module/core.cljs
@@ -84,8 +84,8 @@
 (defn should-move-to-internal-storage? [callback]
   (module-interface/-should-move-to-internal-storage? rns-module callback))
 
-(defn notify [token callback]
-  (module-interface/-notify rns-module token callback))
+(defn notify-users [{:keys [message payload tokens] :as m} callback]
+  (module-interface/-notify-users rns-module m callback))
 
 (defn add-peer [enode callback]
   (module-interface/-add-peer rns-module enode callback))

--- a/src/status_im/native_module/impl/module.cljs
+++ b/src/status_im/native_module/impl/module.cljs
@@ -103,9 +103,9 @@
                    true)
                  false))))))
 
-(defn notify [token on-result]
+(defn notify-users [{:keys [message payload tokens] :as m} on-result]
   (when status
-    (call-module #(.notify status token on-result))))
+    (call-module #(.notifyUsers status message payload tokens on-result))))
 
 (defn add-peer [enode on-result]
   (when status
@@ -259,8 +259,8 @@
     (call-function! params))
   (-call-web3 [this payload callback]
     (call-web3 payload callback))
-  (-notify [this token callback]
-    (notify token callback))
+  (-notify-users [this {:keys [message payload tokens] :as m} callback]
+    (notify-users m callback))
   (-add-peer [this enode callback]
     (add-peer enode callback))
 

--- a/src/status_im/native_module/impl/non_status_go_module.cljs
+++ b/src/status_im/native_module/impl/non_status_go_module.cljs
@@ -58,6 +58,6 @@
     (impl/module-initialized!))
   (-should-move-to-internal-storage? [this callback]
     (impl/should-move-to-internal-storage? callback))
-  (-notify [this token callback])
+  (-notify-users [this {:keys [message payload tokens] :as m} callback])
   (-add-peer [this enode callback])
   (-close-application [this]))

--- a/src/status_im/native_module/module.cljs
+++ b/src/status_im/native_module/module.cljs
@@ -18,7 +18,7 @@
   (-call-web3 [this payload callback])
   (-module-initialized! [this])
   (-should-move-to-internal-storage? [this callback])
-  (-notify [this token callback])
+  (-notify-users [this {:keys [message payload tokens] :as m} callback])
   (-add-peer [this enode callback])
   (-close-application [this]))
 


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

Fixes #2287 

### Summary:

[comment]: # (Summarise the problem and how the pull request solves it)
This PR updates the react-side code to use `Statusgo.NotifyUsers(message, payloadJSON, tokensArray *C.char)` instead of `Statusgo.Notify(token *C.char)`.

### Review notes:
<!-- (Specify if something in particular should be looked at, or ignored, during review) -->
I've made some temporary changes to logging code and set the [payload to some bogus data](https://github.com/PombeirP/status-react/commit/971a506df1b13921212c89dbd61a8d4004ee1c5b#diff-d20f50de78d011b1377e718e4c82fbb5R75), so this should be reset before merging to `develop`.

### Testing notes:
<!-- (Specify if something specific has to be tested, for example upgrade paths) -->
In order to test that the unencrypted payload has arrived correctly to the Go side, I changed the following code in `geth/api/api.go` on my machine:
![image](https://user-images.githubusercontent.com/138074/34560762-79cbf6a6-f147-11e7-88db-fde5a20c79c2.png)
You need to make sure that the `LOG_LEVEL_STATUS_GO` feature flag is set to at least `warn` level.

### Steps to test:
- Attach to adb logs using `adb logcat | grep -e ReactNativeJS -e notifyUsers -e send-notification -e NotifyUsers -e StatusModule`
- Open Status
- Open a chat
- Send a message

You should see something similar to the following:
![image](https://user-images.githubusercontent.com/138074/34561049-8a4c2d92-f148-11e7-919f-0300578979c1.png)
There's initially the call to `send-notification` on the CLJS side, then the fake `WARN` log message on the `geth` side, and then the success callback result appearing back on the CLJS side (`send-notification cb result:  {"status":true}`).

On the receiving device, you can see the title and content that come from the CLJS code:
![image](https://user-images.githubusercontent.com/138074/34564390-d758d05a-f156-11e7-9d5d-75849be9e145.png)

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->

  