### PR TITLE
Faster msg status updates

### DIFF
--- a/src/status_im/data_store/messages.cljs
+++ b/src/status_im/data_store/messages.cljs
@@ -64,7 +64,8 @@
   (utils/update-if-present message
                            :user-statuses
                            (partial map (fn [[whisper-identity status]]
-                                          {:whisper-identity whisper-identity
+                                          {:status-id        (str message-id "-" whisper-identity)
+                                           :whisper-identity whisper-identity
                                            :status           status
                                            :chat-id          chat-id
                                            :message-id       message-id}))))

--- a/src/status_im/data_store/realm/schemas/account/v19/core.cljs
+++ b/src/status_im/data_store/realm/schemas/account/v19/core.cljs
@@ -112,9 +112,11 @@
                         statuses   (aget msg "user-statuses")]
                     (when statuses 
                       (.map statuses (fn [status _ _]
+                                       (aset status "status-id" (str message-id "-" from))
                                        (aset status "message-id" message-id)
                                        (aset status "chat-id"    chat-id)))
-                      (.push statuses (clj->js {"message-id"       message-id
+                      (.push statuses (clj->js {"status-id"        (str message-id "-anonymous")
+                                                "message-id"       message-id
                                                 "chat-id"          chat-id
                                                 "status"           (or msg-status "received")
                                                 "whisper-identity" (or from "anonymous")}))))))))

--- a/src/status_im/data_store/realm/schemas/account/v19/user_status.cljs
+++ b/src/status_im/data_store/realm/schemas/account/v19/user_status.cljs
@@ -1,7 +1,12 @@
 (ns status-im.data-store.realm.schemas.account.v19.user-status)
 
-(def schema {:name       :user-status 
-             :properties {:message-id       :string
+(def schema {:name       :user-status
+             :primaryKey :status-id
+             :properties {;; Unfortunately, realm doesn't support composite primary keys,
+                          ;; so we have to keep separate `:status-id` property, which is just
+                          ;; `:message-id`-`:whisper-identity` concatenated
+                          :status-id        :string
+                          :message-id       :string
                           :chat-id          :string
                           :whisper-identity :string
                           :status           :string}})


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

Partially fixes #2852 

### Summary:

The app experiences significant lags when the situation arises that a lot of messages need delivery status updates at once.
One of the culprit was identified as realm reads/writes which need to happen for each such update, this PR removes one unnecessary read (`::chats-is-active?`, because only active chats are present in app-db, so it's enough to check for them there) and introduces additional checks (no update if the status received is the same as the existing one) + queueing of message updates with asynchronous writes.
By doing so, the time spend in the `:update-message-status` handler is cut down significantly (down from ~60ms per invocation to less then ~10ms per invocation on iOS simulator with 50-100msgs in 1-1 chat). 

Additionally, this PR also fixes recently introduced bug where messages statuses are not updated correctly, because realm can't intelligently update child entities if they don't contain primary key.
The Reason why it's included in this PR is the fact that without that, it's not possible to verify that messages statuses work correctly (it's necessary to test it in scope of this PR).

On the side note, I'm starting to think of Realm JS as a real burden for us - it slows the development significantly because of the need to be super careful with migrations, complicates and slows down every business logic and the only place where it's actually needed is chunk-wise reading of messages.
But as @oskarth already suggested some time ago, maybe we don't need that and we can hold all messages in memory with just rendering of some "window" (messages from - to) in the current chat stream.
It's definitely worth trying, if it will be proven to work with real-world data amount, we can get rid of realm for good and replace it with simple cljs de/serialisation into file. 

### Testing notes (optional):
Test that messages statuses work as they should in all types of chats.
Additionally, test the upgrade path from last release in regard to message statuses as well.

status: ready

  