### PR TITLE
Fix chat list rendering

### DIFF
--- a/src/status_im/chat/models/message.cljs
+++ b/src/status_im/chat/models/message.cljs
@@ -4,7 +4,7 @@
             [status-im.constants :as constants]
             [status-im.chat.utils :as chat-utils]
             [status-im.chat.models :as chat-model]
-            [status-im.chat.models.commands :as commands-model] 
+            [status-im.chat.models.commands :as commands-model]
             [status-im.chat.events.requests :as requests-events]
             [taoensso.timbre :as log]))
 
@@ -30,17 +30,18 @@
     (:ref (get available-commands-responses response-name))))
 
 (defn- add-message-to-db
-  [db {:keys [message-id] :as message} chat-id]
-  (-> db
-      (update-in [:chats chat-id :unviewed-messages] (fnil conj #{}) message-id)
-      (chat-utils/add-message-to-db chat-id chat-id message (:new? message))))
+  [db {:keys [message-id] :as message} chat-id current-chat?]
+  (cond-> (chat-utils/add-message-to-db db chat-id chat-id message (:new? message))
+    (not current-chat?)
+    (update-in [:chats chat-id :unviewed-messages] (fnil conj #{}) message-id)))
 
 (defn receive
   [{:keys [db message-exists? pop-up-chat? get-last-clock-value now] :as cofx}
    {:keys [from group-id chat-id content-type content message-id timestamp clock-value]
     :as   message
     :or   {clock-value 0}}]
-  (let [{:keys [access-scope->commands-responses] :contacts/keys [contacts]} db
+  (let [{:keys [current-chat-id view-id
+                access-scope->commands-responses] :contacts/keys [contacts]} db
         {:keys [public-key] :as current-account} (get-current-account db)
         chat-identifier (or group-id chat-id from)
         direct-message? (nil? group-id)]
@@ -51,7 +52,9 @@
                (not= from public-key)
                (or (pop-up-chat? chat-identifier)
                    direct-message?))
-      (let [fx               (if (get-in db [:chats chat-identifier])
+      (let [current-chat?    (and (= :chat view-id)
+                                  (= current-chat-id chat-identifier))
+            fx               (if (get-in db [:chats chat-identifier])
                                (chat-model/upsert-chat cofx {:chat-id chat-identifier
                                                              :group-chat (boolean group-id)})
                                (chat-model/add-chat cofx chat-identifier))
@@ -65,7 +68,7 @@
                                                           clock-value
                                                           (get-last-clock-value chat-identifier)))
                                public-key
-                               (assoc :user-statuses {public-key :received})
+                               (assoc :user-statuses {public-key (if current-chat? :seen :received)})
                                (and command command-request?)
                                (assoc-in [:content :content-command-ref]
                                          (lookup-response-ref access-scope->commands-responses
@@ -74,7 +77,7 @@
                                                               contacts
                                                               command)))]
         (cond-> (-> fx
-                    (update :db add-message-to-db enriched-message chat-identifier)
+                    (update :db add-message-to-db enriched-message chat-identifier current-chat?)
                     (assoc :save-message (dissoc enriched-message :new?)))
           command-request?
           (requests-events/add-request chat-identifier enriched-message))))))

--- a/src/status_im/ui/screens/home/views.cljs
+++ b/src/status_im/ui/screens/home/views.cljs
@@ -45,7 +45,8 @@
      [toolbar-view]
      [list/flat-list {:style           styles/list-container
                       :data            chats
-                      :render-fn       (fn [chat] [chat-list-item chat edit?])
+                      :render-fn       (fn [[chat-id :as chat]]
+                                         ^{:key chat-id} [chat-list-item chat edit?])
                       :header          (when-not (empty? chats) list/default-header)
                       :footer          (when-not (empty? chats)
                                          [react/view


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes #2914 and #2991 

### Summary:

[comment]: # (Summarise the problem and how the pull request solves it)
The #2914 problem was caused by react-key not specified for the data returned by render-fn for each list item. For any repeated elements, we have to be careful it's always there and it's always unique at it's level (doesn't need to be globally unique for the whole screen), otherwise rendering could be unpredictable - https://facebook.github.io/react-native/docs/flatlist.html

It's more complex with #2914, as it looks like we can't rely on `:component-did-mount` component lifecycle method anymore, when such component is rendered as a child of `FlatList`. 
So the (hacky) fix is to check whenever some message is added to the currently opened chat when it's received, and when that's the case, the delivery status for receiver is set to `:seen` (as opposed to `:received` when it's not opened chat) and message-id is not added to the unseen set. 
The unfortunate consequence of that is that sending the `:seen` ack message via protocol will be borked, but as that is not working anyway (reason still unknown), it's not a big deal for the release.

### Testing notes (optional):
Try to simulate the behaviour described in relevant issue, it shouldn't be possible anymore.

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready 

  