### PR TITLE
[BUG#2927] Fixed regression when showing transaction detail

### DIFF
--- a/src/status_im/ui/screens/wallet/transactions/views.cljs
+++ b/src/status_im/ui/screens/wallet/transactions/views.cljs
@@ -207,7 +207,9 @@
 
 (defn- pretty-print-asset [symbol amount]
   (case symbol
-    "ETH" (if amount (money/wei->str :eth amount) "...")))
+    ;; TODO (jeluard) Format tokens amount once tokens history is supported
+    :ETH (if amount (money/wei->str :eth amount) "...")))
+
 
 (defn details-header [{:keys [value date type symbol]}]
   [react/view {:style transactions.styles/details-header}
@@ -266,8 +268,8 @@
 
 (defview transaction-details []
   (letsubs [{:keys [hash url type] :as transaction} [:wallet.transactions/transaction-details]
-            confirmations                            [:wallet.transactions.details/confirmations]
-            confirmations-progress                   [:wallet.transactions.details/confirmations-progress]]
+            confirmations                           [:wallet.transactions.details/confirmations]
+            confirmations-progress                  [:wallet.transactions.details/confirmations-progress]]
     [react/view {:style styles/flex}
      [status-bar/status-bar]
      [toolbar/toolbar {}


### PR DESCRIPTION
fixes #2927

### Summary:

Fixes a regression due to recent token improvements

### Steps to test:
- Open Status
- Create a transaction to be signed later
- Display its details: it should not fail

status: ready

  