### PR TITLE
Remove message data remnants

### DIFF
--- a/src/status_im/ui/screens/home/subs.cljs
+++ b/src/status_im/ui/screens/home/subs.cljs
@@ -9,7 +9,7 @@
     (not= (str/index-of name text) nil)))
 
 (reg-sub :filtered-chats
-  :<- [:get :chats]
+  :<- [:chats]
   :<- [:get-in [:toolbar-search :text]]
   :<- [:get-in [:toolbar-search :show]]
   (fn [[chats search-text show-search]]


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

### Summary:

[comment]: # (Summarise the problem and how the pull request solves it)
In the recent #1875 and #2807 PRs, `:message-data` key in db was completely removed and replaced by messages indexed by their id.
I discovered that I forgot to remove this last place where it was used, so this PR finishes the work. 

### Testing notes (optional):
Make sure that chats in chat list are still displayed correctly. No upgrade testing necessary

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready
