### PR TITLE
Improve custom figwheel script usability

### DIFF
--- a/env/dev/run.clj
+++ b/env/dev/run.clj
@@ -1,0 +1,5 @@
+(ns dev-run
+  (:use [figwheel-api]))
+
+(start)
+(start-cljs-repl)

--- a/project.clj
+++ b/project.clj
@@ -19,7 +19,7 @@
             ["do" "clean"
              ["with-profile" "prod" "cljsbuild" "once" "ios"]
              ["with-profile" "prod" "cljsbuild" "once" "android"]]
-            "figwheel-repl"    ["run" "-m" "clojure.main" "env/dev/figwheel_api.clj"]
+            "figwheel-repl"    ["run" "-m" "clojure.main" "env/dev/run.clj"]
             "test-cljs"        ["with-profile" "test" "doo" "node" "test" "once"]
             "test-protocol"    ["with-profile" "test" "doo" "node" "protocol" "once"]}
   :figwheel {:nrepl-port 7888}


### PR DESCRIPTION
Fixes #2921 

- `figwheel-api` provides just functions to start / stop figwheel, and start CLJS REPL, but don't do any actions itself when requiring the file.
- Make start figwheel and start CLJS REPL two separete functions as `(start)` and `(start-cljs-repl)`, so we can call each separately.
- Use `run.clj` to call functions in `figwheel-api` to start figwheel and start CLJS RPEL when issuing command `lein figwheel-repl`.
- `(start)` can accept optional function argument `build-ids`, otherwise it will also take command line arguments.

status: ready <!-- Can be ready or wip -->
