### PR TITLE
[Fix #1048] Timestamp format in chat

### DIFF
--- a/.re-natal
+++ b/.re-natal
@@ -50,7 +50,8 @@
     "emojilib",
     "react-native-mapbox-gl",
     "react-native-config",
-    "react-native-svg"
+    "react-native-svg",
+    "moment/min/moment-with-locales"
   ],
   "imageDirs": [
     "resources/images"

--- a/package-lock.json
+++ b/package-lock.json
@@ -6287,6 +6287,11 @@
         "minimist": "0.0.8"
       }
     },
+    "moment": {
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.20.1.tgz",
+      "integrity": "sha512-Yh9y73JRljxW5QxN08Fner68eFLxM5ynNOAw2LbIB1YAGeQzZT8QFSUvkAz609Zf+IHhhaUxqZK8dG3W/+HEvg=="
+    },
     "morgan": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.6.1.tgz",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "identicon.js": "github:status-im/identicon.js",
     "instabug-reactnative": "git+https://github.com/status-im/instabug-reactnative.git",
     "level-filesystem": "1.2.0",
+    "moment": "^2.20.1",
     "nfc-react-native": "github:status-im/nfc-react-native",
     "os-browserify": "^0.1.2",
     "path-browserify": "0.0.0",

--- a/src/status_im/js_dependencies.cljs
+++ b/src/status_im/js_dependencies.cljs
@@ -7,3 +7,4 @@
 (def homoglyph-finder    (js/require "homoglyph-finder"))
 (def identicon-js        (js/require "identicon.js"))
 (def Web3                (js/require "web3"))
+(def moment              (js/require "moment/min/moment-with-locales"))

--- a/test/cljs/status_im/test/runner.cljs
+++ b/test/cljs/status_im/test/runner.cljs
@@ -21,7 +21,8 @@
             [status-im.test.utils.gfycat.core]
             [status-im.test.utils.signing-phrase.core]
             [status-im.test.utils.transducers]
-            [status-im.test.utils.async]))
+            [status-im.test.utils.async]
+            [status-im.test.utils.datetime]))
 
 (enable-console-print!)
 
@@ -47,6 +48,7 @@
  'status-im.test.utils.utils
  'status-im.test.utils.money
  'status-im.test.utils.clocks
+ 'status-im.test.utils.datetime
  'status-im.test.utils.pre-receiver
  'status-im.test.utils.ethereum.eip681
  'status-im.test.utils.ethereum.core

--- a/test/cljs/status_im/test/utils/datetime.cljs
+++ b/test/cljs/status_im/test/utils/datetime.cljs
@@ -1,0 +1,26 @@
+(ns status-im.test.utils.datetime
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [status-im.utils.datetime :as datetime]))
+
+(def timestamp
+  (.getTime (new js/Date "2017-12-28 20:17:36")))
+
+(deftest datetime
+  (testing "moment locale conversion"
+    (is (= "de" (datetime/->moment-locale "de")))
+    (is (= "de-CH" (datetime/->moment-locale "de-CH")))
+    (is (= "zh-HK" (datetime/->moment-locale "zh-Hant-HK")))
+    (is (= "en" (datetime/->moment-locale "na-NA")))
+    (is (= "en" (datetime/->moment-locale nil))))
+
+  (testing "Localized short date time format"
+    (with-redefs [datetime/format-locale-datetime (datetime/get-locale-datetime-formatter "zh-Hant-HK")]
+      (is (= "2017年12月28日 20:17" (datetime/to-short-str timestamp)))))
+
+  (testing "Localized mini date time format"
+    (with-redefs [datetime/format-locale-datetime (datetime/get-locale-datetime-formatter "de-CH")]
+      (is (= "28 Dez." (datetime/timestamp->mini-date timestamp)))))
+
+  (testing "Localized long date time format"
+    (with-redefs [datetime/format-locale-datetime (datetime/get-locale-datetime-formatter "ru")]
+      (is (= (keyword "28 дек. 2017 г. 20:17:36") (datetime/timestamp->long-date timestamp))))))


### PR DESCRIPTION
Another attempt for #1048

I think `moment.js` could be a better alternative, so I'd give it a try :)

status: ready <!-- Can be ready or wip -->
