### PR TITLE
[fix #2870] Mark 1-1 chat as inactive when user removes it

### DIFF
--- a/src/status_im/chat/handlers.cljs
+++ b/src/status_im/chat/handlers.cljs
@@ -28,16 +28,18 @@
     (messages/delete-by-chat-id id)))
 
 (defn delete-messages!
-  [{:keys [current-chat-id]} [_ chat-id]]
-  (let [id (or chat-id current-chat-id)]
-    (messages/delete-by-chat-id id)))
+  [{:keys [current-chat-id chats]} [_ chat-id]]
+  (let [id                   (or chat-id current-chat-id)
+        {:keys [group-chat]} (chats/get-by-id chat-id)]
+    (when group-chat
+      (messages/delete-by-chat-id id))))
 
 (defn delete-chat!
   [_ [_ chat-id]]
-  (let [{:keys [debug? group-chat]} (chats/get-by-id chat-id)]
-    (if (and (not debug?) group-chat)
-      (chats/set-inactive chat-id)
-      (chats/delete chat-id))))
+  (let [{:keys [debug?]} (chats/get-by-id chat-id)]
+    (if debug?
+      (chats/delete chat-id)
+      (chats/set-inactive chat-id))))
 
 (defn remove-pending-messages!
   [_ [_ chat-id]]

--- a/src/status_im/chat/models.cljs
+++ b/src/status_im/chat/models.cljs
@@ -44,8 +44,9 @@
   (let [chat (merge (or (get-stored-chat chat-id)
                         (create-new-chat cofx chat-id {}))
                     chat)]
-    {:db            (update-in db [:chats chat-id] merge chat)
-     :save-chat     chat}))
+    {:db        (cond-> db
+                  (:is-active chat) (update-in [:chats chat-id] merge chat))
+     :save-chat chat}))
 
 ;; TODO (yenda): an upsert is suppose to add the entry if it doesn't
 ;; exist and update it if it does

--- a/src/status_im/chat/models/message.cljs
+++ b/src/status_im/chat/models/message.cljs
@@ -42,13 +42,15 @@
     :or   {clock-value 0}}]
   (let [{:keys [access-scope->commands-responses] :contacts/keys [contacts]} db
         {:keys [public-key] :as current-account} (get-current-account db)
-        chat-identifier (or group-id chat-id from)]
+        chat-identifier (or group-id chat-id from)
+        direct-message? (nil? group-id)]
     ;; proceed with adding message if message is not already stored in realm,
     ;; it's not from current user (outgoing message) and it's for relevant chat
-    ;; (either current active chat or new chat not existing yet)
+    ;; (either current active chat or new chat not existing yet or it's a direct message)
     (when (and (not (message-exists? message-id))
                (not= from public-key)
-               (pop-up-chat? chat-identifier))
+               (or (pop-up-chat? chat-identifier)
+                   direct-message?))
       (let [fx               (if (get-in db [:chats chat-identifier])
                                (chat-model/upsert-chat cofx {:chat-id chat-identifier
                                                              :group-chat (boolean group-id)})


### PR DESCRIPTION
Fixes #2870 

### Summary:

When user removes 1-1 chat, it sets chat as inactive so user doesn't see it in a chat list. 
Before this change, 1-1 chat was deleted from db, and when new message arrives, chat gets inserted into db again (and pops up in chat list which confuses user).

### Testing notes (optional):

Please make sure chats deletion works and deleted chats doesn't appear again on next login. Also, please check that deleted chat could be restored by selecting user from contact list.

Change is related to 1-1 chat, but ensuring group chats also work would be great.

### Steps to test:
 Described in related issue #2870 

status: ready
