### PR TITLE
[fix #2314] do not try to update wallet and transactions when offline

### DIFF
--- a/src/status_im/ui/screens/events.cljs
+++ b/src/status_im/ui/screens/events.cljs
@@ -245,13 +245,13 @@
 (register-handler-db
   :initialize-account-db
   (fn [{:keys [accounts/accounts contacts/contacts networks/networks
-               network view-id navigation-stack chats
+               network network-status view-id navigation-stack chats
                access-scope->commands-responses layout-height
                status-module-initialized? status-node-started?]
         :or [network (get app-db :network)]
         :as db} [_ address]]
     (let [console-contact (get contacts console-chat-id)]
-      (cond-> (assoc app-db 
+      (cond-> (assoc app-db
                      :access-scope->commands-responses access-scope->commands-responses
                      :accounts/current-account-id address
                      :layout-height layout-height
@@ -266,6 +266,7 @@
                      :accounts/accounts accounts
                      :accounts/creating-account? false
                      :networks/networks networks
+                     :network-status network-status
                      :network network)
         console-contact
         (assoc :contacts/contacts {console-chat-id console-contact})))))
@@ -279,7 +280,7 @@
                           [:initialize-sync-listener]
                           [:initialize-chats]
                           [:load-contacts]
-                          [:load-contact-groups] 
+                          [:load-contact-groups]
                           [:init-discoveries]
                           [:initialize-debugging {:address address}]
                           [:send-account-update-if-needed]

--- a/src/status_im/ui/screens/wallet/events.cljs
+++ b/src/status_im/ui/screens/wallet/events.cljs
@@ -87,7 +87,7 @@
 (handlers/register-handler-fx
   :update-wallet
   (fn [{{:keys [web3 accounts/current-account-id network network-status] :as db} :db} [_ symbols]]
-    (when-not (= network-status :offline)
+    (when (not= network-status :offline)
       {:get-balance {:web3          web3
                      :account-id    current-account-id
                      :success-event :update-balance-success
@@ -111,7 +111,7 @@
 (handlers/register-handler-fx
   :update-transactions
   (fn [{{:keys [accounts/current-account-id network network-status] :as db} :db} _]
-    (when-not (= network-status :offline)
+    (when (not= network-status :offline)
       {:get-transactions {:account-id    current-account-id
                           :network       network
                           :success-event :update-transactions-success

--- a/src/status_im/ui/screens/wallet/events.cljs
+++ b/src/status_im/ui/screens/wallet/events.cljs
@@ -86,37 +86,39 @@
 
 (handlers/register-handler-fx
   :update-wallet
-  (fn [{{:keys [web3 accounts/current-account-id network] :as db} :db} [_ symbols]]
-    {:get-balance {:web3          web3
-                   :account-id    current-account-id
-                   :success-event :update-balance-success
-                   :error-event   :update-balance-fail}
-     :get-tokens-balance {:web3          web3
-                          :account-id    current-account-id
-                          :symbols       symbols
-                          :chain         (ethereum/network->chain-keyword network)
-                          :success-event :update-token-balance-success
-                          :error-event   :update-token-balance-fail}
-     :get-prices  {:from          "ETH"
-                   :to            "USD"
-                   :success-event :update-prices-success
-                   :error-event   :update-prices-fail}
-     :db          (-> db
-                      (clear-error-message :prices-update)
-                      (clear-error-message :balance-update)
-                      (assoc-in [:wallet :balance-loading?] true)
-                      (assoc :prices-loading? true))}))
+  (fn [{{:keys [web3 accounts/current-account-id network network-status] :as db} :db} [_ symbols]]
+    (when-not (= network-status :offline)
+      {:get-balance {:web3          web3
+                     :account-id    current-account-id
+                     :success-event :update-balance-success
+                     :error-event   :update-balance-fail}
+       :get-tokens-balance {:web3          web3
+                            :account-id    current-account-id
+                            :symbols       symbols
+                            :chain         (ethereum/network->chain-keyword network)
+                            :success-event :update-token-balance-success
+                            :error-event   :update-token-balance-fail}
+       :get-prices  {:from          "ETH"
+                     :to            "USD"
+                     :success-event :update-prices-success
+                     :error-event   :update-prices-fail}
+       :db          (-> db
+                        (clear-error-message :prices-update)
+                        (clear-error-message :balance-update)
+                        (assoc-in [:wallet :balance-loading?] true)
+                        (assoc :prices-loading? true))})))
 
 (handlers/register-handler-fx
   :update-transactions
-  (fn [{{:keys [accounts/current-account-id network] :as db} :db} _]
-    {:get-transactions {:account-id    current-account-id
-                        :network       network
-                        :success-event :update-transactions-success
-                        :error-event   :update-transactions-fail}
-     :db               (-> db
-                           (clear-error-message :transaction-update)
-                           (assoc-in [:wallet :transactions-loading?] true))}))
+  (fn [{{:keys [accounts/current-account-id network network-status] :as db} :db} _]
+    (when-not (= network-status :offline)
+      {:get-transactions {:account-id    current-account-id
+                          :network       network
+                          :success-event :update-transactions-success
+                          :error-event   :update-transactions-fail}
+       :db               (-> db
+                             (clear-error-message :transaction-update)
+                             (assoc-in [:wallet :transactions-loading?] true))})))
 
 (handlers/register-handler-db
   :update-transactions-success


### PR DESCRIPTION
This is a quickfix that prevents http calls to update wallet and transactions when device is not online

Fix https://github.com/status-im/status-react/issues/2314

see #1785 for fix of the root problem (lack of timeout in fetch api)

### Steps to test:
- Open Status
- Login on a account witht transactions
- Go in airplane mode
- Open transaction details
  