### PR TITLE
[fix #2925] Fix invalid log level string passed in JSON to geth

### DIFF
--- a/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusModule.java
+++ b/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusModule.java
@@ -182,7 +182,7 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
             String gethLogFileName = "geth.log";
             jsonConfig.put("LogEnabled", !TextUtils.isEmpty(this.logLevel));
             jsonConfig.put("LogFile", gethLogFileName);
-            jsonConfig.put("LogLevel", this.logLevel.toUpperCase());
+            jsonConfig.put("LogLevel", TextUtils.isEmpty(this.logLevel) ? "ERROR" : this.logLevel.toUpperCase());
             jsonConfig.put("DataDir", root + customConfig.get("DataDir"));
             jsonConfig.put("NetworkId", customConfig.get("NetworkId"));
             try {
@@ -228,7 +228,12 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
         Log.d(TAG, "Node config " + config);
 
         String res = Statusgo.StartNode(config);
-        Log.d(TAG, "StartNode result: " + res);
+        if (res.startsWith("{\"error\":\"\"")) {
+            Log.d(TAG, "StartNode result: " + res);
+        }
+        else {
+            Log.e(TAG, "StartNode result: " + res);
+        }
         Log.d(TAG, "Geth node started");
 	status.sendMessage();
     }

--- a/modules/react-native-status/ios/RCTStatus/RCTStatus.m
+++ b/modules/react-native-status/ios/RCTStatus/RCTStatus.m
@@ -203,7 +203,7 @@ RCT_EXPORT_METHOD(startNode:(NSString *)configString) {
     [resultingConfigJson setValue:newKeystoreUrl.path forKey:@"KeyStoreDir"];
     [resultingConfigJson setValue:[NSNumber numberWithBool:[logLevel length] != 0] forKey:@"LogEnabled"];
     [resultingConfigJson setValue:logUrl.path forKey:@"LogFile"];
-    [resultingConfigJson setValue:logLevel forKey:@"LogLevel"];
+    [resultingConfigJson setValue:([logLevel length] == 0 ? "ERROR" : logLevel) forKey:@"LogLevel"];
     
     if(upstreamURL != nil) {
         [resultingConfigJson setValue:[NSNumber numberWithBool:YES] forKeyPath:@"UpstreamConfig.Enabled"];


### PR DESCRIPTION
Caused missing password prompt regression

[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes #2925 

### Summary:

[comment]: # (Summarise the problem and how the pull request solves it)
This PR implements the solution described in https://github.com/status-im/status-react/pull/2939#issuecomment-355958439, so that the JSON validation in geth doesn't fail, and there is no unexpected behavior.

### Review notes (optional):
<!-- (Specify if something in particular should be looked at, or ignored, during review) -->
Added code to adapt the log level in Android to make it easier to spot an error like this by marking it as ERROR instead of DEBUG. The iOS logging method `NSLog` doesn't seem to support log levels, but ideally would do the same.

### Testing notes (optional):
<!-- (Specify if something specific has to be tested, for example upgrade paths) -->
Should pass the test in https://github.com/status-im/status-react/issues/2925.

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->
