### PR TITLE
[fix #2731] Allow feature flags to be turned on/off

### DIFF
--- a/src/status_im/ui/screens/db.cljs
+++ b/src/status_im/ui/screens/db.cljs
@@ -13,7 +13,8 @@
             status-im.commands.specs
             status-im.ui.screens.profile.db
             status-im.ui.screens.discover.db
-            status-im.ui.screens.network-settings.db))
+            status-im.ui.screens.network-settings.db
+            status-im.ui.screens.dev.db))
 
 (def transaction-send-default
   {:symbol    :ETH
@@ -31,7 +32,7 @@
              :group/contact-groups       {}
              :group/selected-contacts    #{}
              :chats                      {}
-             :current-chat-id            constants/console-chat-id 
+             :current-chat-id            constants/console-chat-id
              :selected-participants      #{}
              :discoveries                {}
              :discover-search-tags       '()
@@ -44,7 +45,9 @@
              :prices                     {}
              :notifications              {}
              :network                    constants/default-network
-             :networks/networks          constants/default-networks})
+             :networks/networks          constants/default-networks
+             ;; TODO-FLAG include only in dev env?
+             :dev/settings               {}})
 
 ;;;;GLOBAL
 
@@ -123,7 +126,10 @@
                   :networks/selected-network
                   :networks/networks
                   :node/after-start
-                  :node/after-stop]
+                  :node/after-stop
+                  ;; TODO-FLAG
+                  ;; include dev-settings spec only in dev env
+                  :dev/settings]
                  :opt-un
                  [::current-public-key
                   ::modal
@@ -158,11 +164,11 @@
                   :chat/chat-ui-props
                   :chat/chat-list-ui-props
                   :chat/layout-height
-                  :chat/expandable-view-height-to-value 
+                  :chat/expandable-view-height-to-value
                   :chat/message-data
-                  :chat/message-status 
+                  :chat/message-status
                   :chat/selected-participants
-                  :chat/chat-loaded-callbacks 
+                  :chat/chat-loaded-callbacks
                   :chat/public-group-topic
                   :chat/confirmation-code-sms-listener
                   :chat/messages

--- a/src/status_im/ui/screens/dev/db.cljs
+++ b/src/status_im/ui/screens/dev/db.cljs
@@ -1,0 +1,27 @@
+(ns status-im.ui.screens.dev.db
+  (:require-macros [status-im.utils.db :refer [allowed-keys]])
+  (:require [cljs.spec.alpha :as spec]))
+
+(spec/def :dev/testfairy-enabled? boolean?)
+(spec/def :dev/stub-status-go? boolean?)
+(spec/def :dev/mainnet-networks-enabled? boolean?)
+(spec/def :dev/erc20-enabled? boolean?)
+(spec/def :dev/offline-inbox-enabled? boolean?)
+(spec/def :dev/log-level #{"error"
+                           "warn"
+                           "info"
+                           "debug"
+                           "trace"})
+(spec/def :dev/jsc-enabled? boolean?)
+(spec/def :dev/queue-message-enabled? boolean?)
+
+(spec/def :dev/settings
+  (allowed-keys
+    :opt-un [:dev/testfairy-enabled?
+             :dev/stub-status-go?
+             :dev/mainnet-networks-enabled?
+             :dev/erc20-enabled?
+             :dev/offline-inbox-enabled?
+             :dev/log-level
+             :dev/jsc-enabled?
+             :dev/queue-message-enabled?]))

--- a/src/status_im/ui/screens/dev/events.cljs
+++ b/src/status_im/ui/screens/dev/events.cljs
@@ -1,0 +1,12 @@
+(ns status-im.ui.screens.dev.events
+  (:require [status-im.utils.handlers :refer [register-handler-db register-handler-fx]]))
+
+(register-handler-db
+  :toggle-dev-setting
+  (fn [db [_ id]]
+    (update-in db [:dev/settings id] not)))
+
+(register-handler-db
+  :set-dev-setting
+  (fn [db [_ id value]]
+    (assoc-in db [:dev/settings id] value)))

--- a/src/status_im/ui/screens/dev/styles.cljs
+++ b/src/status_im/ui/screens/dev/styles.cljs
@@ -1,0 +1,42 @@
+(ns status-im.ui.screens.dev.styles
+  (:require-macros [status-im.utils.styles :refer [defstyle defnstyle]])
+  (:require [status-im.ui.components.styles :as styles]))
+
+;; setting
+(defstyle setting-container
+  {:flex-direction      :row
+   :align-items         :center
+   :justify-content     :space-between
+   :padding-vertical    15
+   :padding-horizontal  15
+   :background-color    styles/color-white
+   :border-bottom-width 1
+   :border-color        styles/color-gray5})
+
+(defstyle setting-text
+  {:color   styles/text1-color
+   :android {:font-size      16}
+   :ios     {:font-size      17
+             :letter-spacing -0.2}})
+
+;; select-log-level
+(defstyle select-log-level-container
+  {:flex           1
+   :flex-direction :column})
+
+;; check-box
+(defnstyle check-box [checked?]
+  {:background-color (if checked? styles/color-light-blue styles/color-gray5)
+   :align-items     :center
+   :justify-content :center
+   :margin-right    16
+   :android         {:border-radius 2
+                     :width         17
+                     :height        17}
+   :ios             {:border-radius 50
+                     :width         24
+                     :height        24}})
+
+(def check-icon
+  {:width  12
+   :height 12})

--- a/src/status_im/ui/screens/dev/subs.cljs
+++ b/src/status_im/ui/screens/dev/subs.cljs
@@ -1,0 +1,6 @@
+(ns status-im.ui.screens.dev.subs
+  (:require [re-frame.core :refer [reg-sub]]))
+
+(reg-sub :dev-settings
+  (fn [db _]
+    (:dev/settings db)))

--- a/src/status_im/ui/screens/dev/views.cljs
+++ b/src/status_im/ui/screens/dev/views.cljs
@@ -1,0 +1,59 @@
+(ns status-im.ui.screens.dev.views
+  (:require-macros [status-im.utils.views :refer [defview letsubs]])
+  (:require [re-frame.core :refer [dispatch]]
+            [status-im.ui.components.react :refer [picker
+                                                   scroll-view
+                                                   text
+                                                   touchable-highlight
+                                                   view]]
+            [status-im.ui.components.icons.vector-icons :as vi]
+            [status-im.ui.components.status-bar.view :refer [status-bar]]
+            [status-im.ui.components.toolbar.view :as toolbar]
+            [status-im.ui.screens.dev.styles :as styles]))
+
+(defn check-box [checked?]
+  [view (styles/check-box checked?)
+   (when checked?
+     [vi/icon :icons/ok {:style styles/check-icon}])])
+
+(defview toggle-setting [title id]
+  (letsubs [settings [:dev-settings]]
+    [touchable-highlight {:on-press #(dispatch [:toggle-dev-setting id])}
+     [view styles/setting-container
+      [text {:style styles/setting-text}
+        title]
+      [check-box (get settings id)]]]))
+
+(def log-levels
+  [{:label "Error" :value "error"}
+   {:label "Warn"  :value "warn"}
+   {:label "Info"  :value "info"}
+   {:label "Debug" :value "debug"}
+   {:label "Trace" :value "trace"}])
+
+(defview select-log-level []
+  (letsubs [{:keys [log-level]} [:dev-settings]]
+    [view styles/setting-container
+     [view styles/select-log-level-container
+      [text {:style styles/setting-text}
+       "Log level"]
+      [picker {:selected log-level
+               :on-change #(dispatch [:set-dev-setting :log-level %])}
+       log-levels]]]))
+
+(defn dev-settings []
+  [view
+   [status-bar]
+   [toolbar/toolbar {:modal? false} toolbar/default-nav-back
+    [toolbar/content-title "Dev Settings"]]
+   [scroll-view
+    [toggle-setting "TestFairy" :testfairy-enabled?]
+    [toggle-setting "Stub status-go" :stub-status-go?]
+    [toggle-setting "Mainnet networks" :mainnet-networks-enabled?]
+    [toggle-setting "ERC20" :erc20-enabled?]
+    [toggle-setting "Offline inbox" :offline-inbox-enabled?]
+
+    [select-log-level]
+
+    [toggle-setting "JSC" :jsc-enabled?]
+    [toggle-setting "Queue message" :queue-message-enabled?]]])

--- a/src/status_im/ui/screens/events.cljs
+++ b/src/status_im/ui/screens/events.cljs
@@ -22,6 +22,7 @@
             status-im.ui.screens.wallet.settings.events
             status-im.ui.screens.wallet.transactions.events
             status-im.ui.screens.wallet.choose-recipient.events
+            status-im.ui.screens.dev.events
             [re-frame.core :refer [dispatch reg-fx reg-cofx] :as re-frame]
             [status-im.native-module.core :as status]
             [status-im.ui.components.react :as react]
@@ -251,7 +252,7 @@
         :or [network (get app-db :network)]
         :as db} [_ address]]
     (let [console-contact (get contacts console-chat-id)]
-      (cond-> (assoc app-db 
+      (cond-> (assoc app-db
                      :access-scope->commands-responses access-scope->commands-responses
                      :accounts/current-account-id address
                      :layout-height layout-height
@@ -279,7 +280,7 @@
                           [:initialize-sync-listener]
                           [:initialize-chats]
                           [:load-contacts]
-                          [:load-contact-groups] 
+                          [:load-contact-groups]
                           [:init-discoveries]
                           [:initialize-debugging {:address address}]
                           [:send-account-update-if-needed]

--- a/src/status_im/ui/screens/subs.cljs
+++ b/src/status_im/ui/screens/subs.cljs
@@ -17,6 +17,7 @@
             status-im.ui.screens.wallet.wallet-list.subs
             status-im.ui.screens.wallet.assets.subs
             status-im.ui.screens.network-settings.subs
+            status-im.ui.screens.dev.subs
             status-im.bots.subs))
 
 (reg-sub :get
@@ -27,7 +28,7 @@
   (fn [db [_ path]]
     (get-in db path)))
 
-(reg-sub :signed-up? 
+(reg-sub :signed-up?
   :<- [:get-current-account]
   (fn [current-account]
     (:signed-up? current-account)))

--- a/src/status_im/ui/screens/views.cljs
+++ b/src/status_im/ui/screens/views.cljs
@@ -57,14 +57,21 @@
             [status-im.ui.screens.offline-messaging-settings.views :refer [offline-messaging-settings]]
             [status-im.ui.screens.network-settings.add-rpc.views :refer [add-rpc-url]]
             [status-im.ui.screens.network-settings.network-details.views :refer [network-details]]
-            [status-im.ui.screens.network-settings.parse-json.views :refer [paste-json-text]]))
+            [status-im.ui.screens.network-settings.parse-json.views :refer [paste-json-text]]
+
+            [status-im.ui.screens.dev.views :refer [dev-settings]]))
+
+;; TODO-FLAG allow :dev-settings for dev env
+; (defn validate-current-view
+;   [current-view signed-up?]
+;   (if (or (contains? #{:login :chat :recover :accounts} current-view)
+;           true)
+;     current-view
+;     :chat))
 
 (defn validate-current-view
   [current-view signed-up?]
-  (if (or (contains? #{:login :chat :recover :accounts} current-view)
-          signed-up?)
-    current-view
-    :chat))
+  :dev-settings)
 
 (defview main []
   (letsubs [signed-up? [:signed-up?]
@@ -103,8 +110,8 @@
                           :discover-all-recent discover-recent/discover-all-recent
                           :discover-all-hashtags discover-popular/discover-all-hashtags
                           :discover-search-results discover-search/discover-search-results
-                          :discover-dapp-details discover-dapp-details/dapp-details
                           :discover-all-dapps discover-all-dapps/main
+                          :discover-dapp-details discover-dapp-details/dapp-details
                           :profile-photo-capture profile-photo-capture
                           :accounts accounts
                           :login login
@@ -114,6 +121,9 @@
                           :paste-json-text paste-json-text
                           :add-rpc-url add-rpc-url
                           :network-details network-details
+
+                          ;;TODO-FLAG include only in dev env
+                          :dev-settings dev-settings
                           (throw (str "Unknown view: " current-view)))]
           [(if android? menu-context view) common-styles/flex
            [view common-styles/flex


### PR DESCRIPTION
Allow feature flags to be turned on/off from a developer screen

Fixes #2731 

### Summary:
TODO:
- [x] Create developer settings screen
- [x] On app init, load `.env` config to `db`
- [ ] Also load config from local storage and override config in `db`
- [ ] Upon updating a setting, update `db` and store it to local storage
- [ ] Wherever [config functions](https://github.com/status-im/status-react/blob/develop/src/status_im/utils/config.cljs) are called, update logic to get value from `db`
- [ ]  "reinject" flags into native code or remove it from the list
- [ ] Include developer settings screen only in dev environment
- [ ] In development, add a link to navigate to developer screen

Sample Screen:
![screenshot_15154201001](https://user-images.githubusercontent.com/8084705/34674251-c06a1f48-f4b7-11e7-98a7-c63c9a55c149.png)

### Steps to test:

status: wip

  