### PR TITLE
bug #2950 - missing action buttons in unsigned transactions list

### DIFF
--- a/src/status_im/ui/screens/wallet/transactions/views.cljs
+++ b/src/status_im/ui/screens/wallet/transactions/views.cljs
@@ -52,8 +52,8 @@
    [button/secondary-button {:on-press #(on-delete-transaction transaction)}
     (i18n/label :t/delete)]])
 
-(defn- inbound? [type] (= "inbound" type))
-(defn- unsigned? [type] (= "unsigned" type))
+(defn- inbound? [type] (= :inbound type))
+(defn- unsigned? [type] (= :unsigned type))
 
 (defn- transaction-icon [k background-color color]
   {:icon      k


### PR DESCRIPTION
fixes #2950

### Summary:

Fixed the issue where Sign and Delete buttons were missing from the list of unsigned transactions.

The cause was that transaction type is sometimes a string and other times a keyword, i.e. `"unsigned"` vs `:unsigned`. This fix resolves the immediate issue by rendering the action buttons in either of the two cases.

### Steps to test:
- Open Status and get some test ether
- Send transaction in Wallet, but then tap Sign later
- Open Transaction history to see that/if the buttons are there and work

status: ready 
