### PR TITLE
[fix #2957] no matching clause error in transaction details

### DIFF
--- a/src/status_im/ui/screens/wallet/transactions/views.cljs
+++ b/src/status_im/ui/screens/wallet/transactions/views.cljs
@@ -208,7 +208,8 @@
 (defn- pretty-print-asset [symbol amount]
   (case symbol
     ;; TODO (jeluard) Format tokens amount once tokens history is supported
-    :ETH (if amount (money/wei->str :eth amount) "...")))
+    :ETH (if amount (money/wei->str :eth amount) "...")
+    (throw (str "Unknown asset symbol: " symbol))))
 
 
 (defn details-header [{:keys [value date type symbol]}]

--- a/src/status_im/utils/transactions.cljs
+++ b/src/status_im/utils/transactions.cljs
@@ -25,7 +25,7 @@
     {:value value
      ;; timestamp is in seconds, we convert it in ms
      :timestamp (str timeStamp "000")
-     :symbol "ETH"
+     :symbol :ETH
      :type (if inbound? :inbound :outbound)
      :block blockNumber
      :hash  hash


### PR DESCRIPTION
symbol is a string, add readable error in case happens again

# steps to test

- open transaction details for a transaction, if it works it is fixed