### PR TITLE
Fix "Invalid arity: 0" error on sign in screen

### DIFF
--- a/src/status_im/ui/components/list/views.cljs
+++ b/src/status_im/ui/components/list/views.cljs
@@ -96,7 +96,7 @@
   (let [separator (or separator (when (and platform/ios? default-separator?) default-separator))]
     (merge {:keyExtractor (fn [_ i] i)}
            (when render-fn               {:renderItem (wrap-render-fn render-fn)})
-           (when separator               {:ItemSeparatorComponent (fn [] (reagent/as-element [separator]))})
+           (when separator               {:ItemSeparatorComponent (fn [] (reagent/as-element separator))})
            (when empty-component         {:ListEmptyComponent (fn [] (reagent/as-element empty-component))})
            (when header                  {:ListHeaderComponent (fn [] (reagent/as-element header))}))))
 


### PR DESCRIPTION
Partially fixes #2903

Screenshot and details here https://github.com/status-im/status-react/issues/2903#issuecomment-356025989

### Summary:

Fixes redbox error "Invalid arity: 0" on account sign in screen when you have multiple accounts

### Steps to test:
- Open Status
- Create 2 accounts
- Go to sign in page

status: ready


  #
  