### PR TITLE
[fix #1604] Commands send, request, location are sent several times if quickly tap on send button

### DIFF
--- a/src/status_im/chat/events/commands.cljs
+++ b/src/status_im/chat/events/commands.cljs
@@ -39,7 +39,8 @@
             to          (get-in contacts [chat-id :address])
             jail-params {:parameters params
                          :context    (generate-context current-account-id chat-id to group-id)}]
-        {:call-jail {:jail-id                 jail-id
+        {:db        db
+         :call-jail {:jail-id                 jail-id
                      :path                    path
                      :params                  jail-params
                      :callback-events-creator (fn [jail-response]

--- a/src/status_im/chat/events/input.cljs
+++ b/src/status_im/chat/events/input.cljs
@@ -384,8 +384,7 @@
 
                    validationHandler
                    [[::execute-validation-handler
-                     validationHandler parameters error-events-creator proceed-events]
-                    [:set-chat-ui-props {:sending-in-progress? false}]]
+                     validationHandler parameters error-events-creator proceed-events]]
 
                    :default
                    proceed-events)]

--- a/src/status_im/chat/views/input/input.cljs
+++ b/src/status_im/chat/views/input/input.cljs
@@ -46,11 +46,10 @@
        [command-view (= index 0) command])]]])
 
 (defn- basic-text-input [_]
-  (let [input-text           (subscribe [:chat :input-text])
-        command              (subscribe [:selected-chat-command])
-        sending-in-progress? (subscribe [:get-current-chat-ui-prop :sending-in-progress?])
-        input-focused?       (subscribe [:get-current-chat-ui-prop :input-focused?])
-        input-ref            (atom nil)]
+  (let [input-text     (subscribe [:chat :input-text])
+        command        (subscribe [:selected-chat-command])
+        input-focused? (subscribe [:get-current-chat-ui-prop :input-focused?])
+        input-ref      (atom nil)]
     (fn [{:keys [set-layout-height-fn set-container-width-fn height single-line-input?]}]
       [react/text-input
        {:ref                    #(when %
@@ -59,7 +58,7 @@
         :accessibility-label    :chat-message-input
         :multiline              (not single-line-input?)
         :default-value          (or @input-text "")
-        :editable               (not @sending-in-progress?)
+        :editable               true
         :blur-on-submit         false
         :on-focus               #(dispatch [:set-chat-ui-props {:input-focused? true
                                                                 :show-emoji?    false}])
@@ -142,10 +141,9 @@
     nil))
 
 (defn- seq-input [_]
-  (let [command              (subscribe [:selected-chat-command])
-        arg-pos              (subscribe [:current-chat-argument-position])
-        seq-arg-input-text   (subscribe [:chat :seq-argument-input-text])
-        sending-in-progress? (subscribe [:get-current-chat-ui-prop :sending-in-progress?])]
+  (let [command            (subscribe [:selected-chat-command])
+        arg-pos            (subscribe [:current-chat-argument-position])
+        seq-arg-input-text (subscribe [:chat :seq-argument-input-text])]
     (fn [{:keys [command-width container-width]}]
       (when (get-in @command [:command :sequential-params])
         (let [{:keys [placeholder hidden type]} (get-in @command [:command :params @arg-pos])]
@@ -158,7 +156,7 @@
                                     :placeholder         placeholder
                                     :accessibility-label :chat-request-input
                                     :blur-on-submit      false
-                                    :editable            (not @sending-in-progress?)
+                                    :editable            true
                                     :on-focus            #(dispatch [:set-chat-ui-props {:show-emoji? false}])
                                     :on-submit-editing   (fn []
                                                            (when-not (or (str/blank? @seq-arg-input-text)


### PR DESCRIPTION
Fixes #1604 by doing the following:
1) adding a condition (there were no `:sending-in-progress?` check in a proper place)
2) fixing `src/status_im/chat/events/commands.cljs` (`:db` key was missing there)
  
Status: ready