### PR TITLE
Bug/#2924 fix currency font style on send screen

### DIFF
--- a/src/status_im/ui/screens/wallet/components/styles.cljs
+++ b/src/status_im/ui/screens/wallet/components/styles.cljs
@@ -92,6 +92,9 @@
 (def asset-label
   {:margin-right 10})
 
+(def asset-text
+  {:color styles/color-white})
+
 (defstyle container-disabled
   {:border-width     1
    :border-color     styles/color-white-transparent-4

--- a/src/status_im/ui/screens/wallet/components/views.cljs
+++ b/src/status_im/ui/screens/wallet/components/views.cljs
@@ -59,7 +59,7 @@
    [react/text {:style styles/label}
     (i18n/label :t/wallet-asset)]
    [react/view styles/asset-container
-    [react/text
+    [react/text {:style styles/asset-text}
      (name symbol)]]])
 
 (defn- type->handler [k]


### PR DESCRIPTION
Fixes #2924 

Makes currency text white on send transaction screen.

Please refer to original issue for additional details