### PR TITLE
[BUG#2417] Update balance when sending request from chat

### DIFF
--- a/src/status_im/ui/screens/wallet/send/events.cljs
+++ b/src/status_im/ui/screens/wallet/send/events.cljs
@@ -119,7 +119,7 @@
         (if sending-from-chat?
           ;;SENDING FROM CHAT
           {:db       (assoc-in new-db [:wallet :send-transaction] sending-db) ; we need to completely reset sending state here
-           :dispatch [:navigate-to-modal :wallet-send-transaction-modal]}
+           :dispatch-n [[:update-wallet (map :symbol (tokens/tokens-for (ethereum/network->chain-keyword (:network db))))] [:navigate-to-modal :wallet-send-transaction-modal]]}
           ;;SEND SCREEN WAITING SIGNAL
           (let [{:keys [later? password]} (get-in db [:wallet :send-transaction])
                 new-db' (update-in new-db [:wallet :send-transaction] merge sending-db)] ; just update sending state as we are in wallet flow


### PR DESCRIPTION
fixes #2417

### Summary:

Update balance before we open the send transaction screen from chat.

### Steps to test:
- Open Status
- Make sure you have some ETH
- *Do not navigate wallet*
- Send a transaction from a chat
- If transaction is lower than balance, everything should be ok

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->
