### PR TITLE
[Fix #2986] Figwheel reloads env.android.main / env.ios.main on every…

### DIFF
--- a/env/dev/run.clj
+++ b/env/dev/run.clj
@@ -1,4 +1,4 @@
-(ns dev-run
+(ns ^:figwheel-no-load dev-run
   (:use [figwheel-api]))
 
 (start)

--- a/project.clj
+++ b/project.clj
@@ -32,14 +32,14 @@
                     :source-paths ["src" "env/dev"]
                     :cljsbuild    {:builds
                                    {:ios
-                                    {:source-paths ["react-native/src" "src"]
+                                    {:source-paths ["react-native/src" "src" "env/dev"]
                                      :figwheel     true
                                      :compiler     {:output-to     "target/ios/app.js"
                                                     :main          "env.ios.main"
                                                     :output-dir    "target/ios"
                                                     :optimizations :none}}
                                     :android
-                                    {:source-paths ["react-native/src" "src"]
+                                    {:source-paths ["react-native/src" "src" "env/dev"]
                                      :figwheel     true
                                      :compiler     {:output-to     "target/android/app.js"
                                                     :main          "env.android.main"


### PR DESCRIPTION
… file change

I don't know why, but putting "env/dev" back to `:cljsbuild :source-paths` would have that issue #2986 fixed now.

status: ready <!-- Can be ready or wip -->
