### PR TITLE
bug #2949 - resolved unset gas info after send from chat

### DIFF
--- a/resources/js/bots/transactor/bot.js
+++ b/resources/js/bots/transactor/bot.js
@@ -407,7 +407,8 @@ function handleSend(groupChat, params, context) {
     var gasPrice = calculateGasPrice(params["bot-db"]["sliderValue"]);
     var data = {
         from: context.from, 
-        value: val
+        value: val,
+        gas: web3.toBigNumber(21000)
     };
 
     if (groupChat) {

--- a/src/status_im/ui/screens/wallet/navigation.cljs
+++ b/src/status_im/ui/screens/wallet/navigation.cljs
@@ -21,11 +21,8 @@
     db
     (update db :wallet dissoc :request-transaction)))
 
-(defn- dissoc-transaction-details [m]
-  (apply dissoc m (apply disj (set (keys m)) (keys db/transaction-send-default))))
-
 (defmethod navigation/preload-data! :wallet-send-transaction
   [db [event]]
   (if (= event :navigate-back)
     db
-    (update-in db [:wallet :send-transaction] dissoc-transaction-details)))
+    (assoc-in db [:wallet :send-transaction] db/transaction-send-default)))

--- a/src/status_im/ui/screens/wallet/send/events.cljs
+++ b/src/status_im/ui/screens/wallet/send/events.cljs
@@ -108,8 +108,8 @@
                          :symbol     symbol
                          :value      (money/bignumber (or value 0))
                          :data       data
-                         :gas        (money/to-decimal gas)
-                         :gas-price  (money/to-decimal gasPrice)
+                         :gas        (money/bignumber (money/to-decimal gas))
+                         :gas-price  (money/bignumber (money/to-decimal gasPrice))
                          :timestamp  now
                          :message-id message_id}
             sending-from-chat? (not (get-in db [:wallet :send-transaction :waiting-signal?]))


### PR DESCRIPTION
fixes #2949

### Summary:

Gas details (price and limit) were shared between the transactions which meant that the gas info used in the current transaction will be the default gas info in the next transaction.

This can cause a problem if the previous transaction was created by a bot, i.e. `/send` command from chat. Since bots can be created externally, allowing this behavior would make it easy for the bot creator to change the default transaction settings for the unsuspecting user who rarely or never opens Advanced settings. In this case, the bug was just an inconsistency between bot send and wallet send, but it highlights why we shouldn't allow this to happen.

The risk here is in the UX - user tries a bot and suddenly sending appears broken!

The solution in this PR is to always use the same default gas price and limit, regardless of the previous transaction settings, i.e. stateless.

The other change introduced here is that now we are setting the gas limit for /send transactions in the bot code, so it is available in status-go at the time when transaction.queued signal is being sent. This means that now we are showing the gas limit just fine in Wallet signing modal.

### Steps to test:
- Get some test ether
- Send a transaction from chat
- Try sending one from Wallet
- Verify that gas info is there
- Send from Wallet
- Send another from chat
- Verify that all 3 transactions are ok

status: ready
