### PR TITLE
Fix realm migration

### DIFF
--- a/src/status_im/data_store/realm/messages.cljs
+++ b/src/status_im/data_store/realm/messages.cljs
@@ -64,4 +64,6 @@
   [chat-id]
   (let [current-realm @realm/account-realm]
     (realm/delete current-realm
-                  (realm/get-by-field current-realm :message :chat-id chat-id))))
+                  (realm/get-by-field current-realm :message :chat-id chat-id))
+    (realm/delete current-realm
+                  (realm/get-by-field current-realm :user-status :chat-id chat-id))))


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes #2313 and #3016 

### Summary:

[comment]: # (Summarise the problem and how the pull request solves it)
Apparently, in some specific situations, old (`0.9.12`) app creates user status objects duplicates (maybe that's why there was seemingly illogical uuid as a user status primary key, while it should be identified by combination of message-id and whisper identity).
The migration didn't count with such possibility, now that is enforced. 

Also, after further investigation, I discovered that realm **doesn't** delete child objects when parent object is deleted automatically (and there is no possibility to switch such cascading delete) - what does it mean is that whenever some chat is deleted, orphaned user-status objects for messages of such chat remain in realm for forever, and as we are working from the parent object (message) during migration (as we need some fields from associated message when migrating statuses), we just skip such orphaned statuses and they are consequently not updated, this PR fixed it in the app (whenever deleting some chat, all it's messages **and** user statuses are deleted) and in migration, where we simply delete such orphaned statuses.

Also, I really, really don't like realm and the complexity + runtime cost (in-memory db) it imposes upon us.

### Testing notes (optional):
Test the exact scenario described in last comment in issue ticket

status: ready
