### PR TITLE
[#2990] Use the correct dictionary key for messages in `pre_receiver`.

### DIFF
--- a/src/status_im/utils/pre_receiver.cljs
+++ b/src/status_im/utils/pre_receiver.cljs
@@ -28,15 +28,15 @@
         mature-ch (async/chan)
         seen      (atom #{})]
     (async/go-loop []
-      (let [{:keys [id clock-value] :as msg} (async/<! in-ch)]
-        (swap! seen conj [clock-value id])
+      (let [{:keys [message-id clock-value] :as msg} (async/<! in-ch)]
+        (swap! seen conj [clock-value message-id])
         (delay-message msg mature-ch delay-ms))
       (recur))
     (async/go-loop []
-      (let [{:keys [id clock-value] :as msg} (async/<! mature-ch)]
+      (let [{:keys [message-id clock-value] :as msg} (async/<! mature-ch)]
         (if reorder?
-          (if (earliest-clock-value-seen? @seen id clock-value)
-            (do (swap! seen disj [clock-value id])
+          (if (earliest-clock-value-seen? @seen message-id clock-value)
+            (do (swap! seen disj [clock-value message-id])
                 (add-fn msg))
             (async/put! mature-ch msg))
           (add-fn msg))


### PR DESCRIPTION
fixes #2990

### Summary:
Use `:message-id` instead of `:id` when parsing messages.

### Testing notes (optional):
Test that #2990 doesn't reproduce anymore.

status: ready