### PR TITLE
[Fixes #1774] Fixes Android feature permission

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -12,6 +12,8 @@
 
     <!-- dangerous permissions -->
     <uses-permission android:name="android.permission.CAMERA"/>
+    <uses-feature android:name="android.hardware.camera" />
+    <uses-feature android:name="android.hardware.camera.autofocus" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.READ_CONTACTS"/>


### PR DESCRIPTION
fixes #1774 

### Summary:
After hearing back from`react-native-camera` dev, it looks like this is a permission problem. See [Android docs](https://developer.android.com/reference/android/hardware/Camera.html) and `uses-feature`.

status: ready 