### PR TITLE
Add back icons/chats icon

### DIFF
--- a/src/status_im/ui/components/icons/vector_icons.cljs
+++ b/src/status_im/ui/components/icons/vector_icons.cljs
@@ -50,6 +50,7 @@
             :icons/fullscreen          (slurp-svg "./resources/icons/fullscreen.svg")
             :icons/group-big           (slurp-svg "./resources/icons/group_big.svg")
             :icons/group-chat          (slurp-svg "./resources/icons/group_chat.svg")
+            :icons/chats               (slurp-svg "./resources/icons/chats.svg")
             :icons/hamburger           (slurp-svg "./resources/icons/hamburger.svg")
             :icons/hidden              (slurp-svg "./resources/icons/hidden.svg")
             :icons/mic                 (slurp-svg "./resources/icons/mic.svg")


### PR DESCRIPTION
fixes #3028 

### Summary:
Seems like a needed icon was removed on a3cffebb , I have added the icon back so that the profile section loads.

status: ready
