### PR TITLE
restored the previously removed switch user ie logout action

### DIFF
--- a/src/status_im/translations/en.cljs
+++ b/src/status_im/translations/en.cljs
@@ -27,6 +27,7 @@
 
    ;;drawer
    :switch-users                          "Switch users"
+   :logout                                "Logout"
    :current-network                       "Current network"
 
    ;;home

--- a/src/status_im/ui/screens/profile/styles.cljs
+++ b/src/status_im/ui/screens/profile/styles.cljs
@@ -119,6 +119,13 @@
    :android {:font-size 16
              :color     color-black}})
 
+(defstyle logout-text
+  {:padding-left 16
+   :color        styles/color-red
+   :ios          {:font-size      17
+                  :letter-spacing -0.2}
+   :android      {:font-size 16}})
+
 (defstyle profile-setting-spacing
   {:ios     {:height 10}
    :android {:height 7}})


### PR DESCRIPTION
Partially addresses #2906 

This is an emergency PR that puts the Logout action to Profile tab.

Since we no longer have the sidebar, we also lost Switch user functionality, which is currently blocking anyone who needs the whole auth workflow, e.g. test team.

This PR only restores the exact logout functionality we had in the sidebar, since that's the blocker. All other Profile features to be submitted in a separate PR.

status: ready