### PR TITLE
Start chat when user adds a pending contact from the "new contact" view

### DIFF
--- a/src/status_im/chat/events/sign_up.cljs
+++ b/src/status_im/chat/events/sign_up.cljs
@@ -6,7 +6,6 @@
             [status-im.utils.phone-number :as phone-number-util]
             [status-im.utils.sms-listener :as sms-listener]
             [status-im.ui.screens.accounts.events :as accounts-events]
-            [status-im.ui.screens.contacts.events :as contacts-events]
             [taoensso.timbre :as log]))
 
 ;;;; Helpers fns

--- a/src/status_im/chat/handlers.cljs
+++ b/src/status_im/chat/handlers.cljs
@@ -1,5 +1,5 @@
-(ns status-im.chat.handlers 
-  (:require [re-frame.core :refer [enrich after debug dispatch reg-fx]] 
+(ns status-im.chat.handlers
+  (:require [re-frame.core :refer [enrich after debug dispatch reg-fx]]
             [clojure.string :as string]
             [status-im.ui.components.styles :refer [default-chat-color]]
             [status-im.chat.constants :as chat-consts]
@@ -13,7 +13,7 @@
                                          console-chat-id]]
             [status-im.utils.random :as random]
             [status-im.utils.handlers :refer [register-handler register-handler-fx] :as u]
-            status-im.chat.events 
+            status-im.chat.events
             status-im.chat.handlers.send-message))
 
 (defn remove-chat

--- a/src/status_im/ui/screens/contacts/events.cljs
+++ b/src/status_im/ui/screens/contacts/events.cljs
@@ -439,8 +439,9 @@
   (fn [{:keys [db]} [_ id]]
     (if (spec/valid? :global/address id)
       {::request-contact-by-address id}
-      {:dispatch (if (get-in db [:contacts/contacts id])
-                   [:add-pending-contact id]
-                   [:add-new-contact-and-open-chat {:name             (generate-gfy id)
-                                                    :photo-path       (identicon id)
-                                                    :whisper-identity id}])})))
+      {:dispatch-n (if (get-in db [:contacts/contacts id])
+                     [[:add-pending-contact id]
+                      [:start-chat id {:navigation-replace? true}]]
+                     [[:add-new-contact-and-open-chat {:name             (generate-gfy id)
+                                                       :photo-path       (identicon id)
+                                                       :whisper-identity id}]])})))

--- a/src/status_im/ui/screens/discover/events.cljs
+++ b/src/status_im/ui/screens/discover/events.cljs
@@ -41,15 +41,17 @@
 ;; HELPER-FN
 
 (defn send-portions-when-contact-exists
-  [{:keys [current-public-key web3 discoveries]
-    :contacts/keys [contacts]}
+  "Takes fx map and adds send-portions if contact exists"
+  [{{:keys [current-public-key web3 discoveries]
+     :contacts/keys [contacts]} :db :as fx}
    to]
-  (when (get contacts to)
-    {::send-portions {:current-public-key current-public-key
-                      :web3               web3
-                      :contacts           contacts
-                      :to                 to
-                      :discoveries        (mapv #(dissoc % :tags) (vals discoveries))}}))
+  (cond-> fx
+    (get contacts to)
+    (assoc ::send-portions {:current-public-key current-public-key
+                            :web3               web3
+                            :contacts           contacts
+                            :to                 to
+                            :discoveries        (mapv #(dissoc % :tags) (vals discoveries))})))
 
 (defn add-discover [db {:keys [message-id] :as discover}]
   (assoc-in db [:discoveries message-id] discover))
@@ -140,12 +142,12 @@
 (handlers/register-handler-fx
   :discoveries-send-portions
   (fn [{:keys [db]} [_ to]]
-    (send-portions-when-contact-exists db to)))
+    (send-portions-when-contact-exists {:db db} to)))
 
 (handlers/register-handler-fx
   :discoveries-request-received
   (fn [{:keys [db]} [_ {:keys [from]}]]
-    (send-portions-when-contact-exists db from)))
+    (send-portions-when-contact-exists {:db db} from)))
 
 (handlers/register-handler-fx
   :discoveries-response-received

--- a/src/status_im/ui/screens/navigation.cljs
+++ b/src/status_im/ui/screens/navigation.cljs
@@ -24,12 +24,12 @@
 (defn- can-navigate-back? [db]
   (not (get db :accounts/creating-account?)))
 
-(defn- navigate-to-clean [db view-id]
+;; public fns
+
+(defn navigate-to-clean [db view-id]
   (-> db
       (assoc :navigation-stack (list))
       (push-view view-id)))
-
-;; public fns
 
 (defmulti preload-data!
   (fn [db [_ view-id]] (or view-id (:view-id db))))


### PR DESCRIPTION
fixes #2960 

### Summary:

At the moment removing a contact hides it, setting the pending? flag to true.

If you remove and add the contact again from the "new contact" screen, the user is not sent to the 1-1 chat.

I have changed the code so that :start-chat is dispatched regardless whether the user is new or was already in the contacts.

### Steps to test:
- Open Status
- Remove a contact
- Copy their public key
- Go back to Home
- Go to Add a contact
- Insert their public key & click on add

status: ready