### PR TITLE
Update `react-native-http-bridge`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7566,7 +7566,7 @@
       }
     },
     "react-native-http-bridge": {
-      "version": "github:status-im/react-native-http-bridge#187ca6b8f3d5b9fa2508c9f2a3d72b621c3af0dd"
+      "version": "github:status-im/react-native-http-bridge#86c56aa05dfb35ac2956c85dfadf77b9ca1da59c"
     },
     "react-native-i18n": {
       "version": "2.0.9",


### PR DESCRIPTION
### Summary:

Use a patched version of `react-native-http-bridge` that solves the compilation error on some systems.

### Steps to test:
Build the iOS version. No compilation errors should happen.


status: ready