### PR TITLE
[#3038] Add buffer to process incoming messages asynchronously

### DIFF
--- a/src/status_im/chat/views/message/message.cljs
+++ b/src/status_im/chat/views/message/message.cljs
@@ -14,6 +14,7 @@
             [status-im.chat.views.message.request-message :as request-message]
             [status-im.constants :as constants]
             [status-im.ui.components.chat-icon.screen :as chat-icon.screen]
+            [status-im.utils.events-buffer :as events-buffer]
             [status-im.utils.identicon :as identicon]
             [status-im.utils.gfycat.core :as gfycat]
             [status-im.utils.platform :as platform]
@@ -266,7 +267,7 @@
   (if (:new? message)
     (let [layout-height (reagent/atom 0)
           anim-value    (animation/create-value 1)
-          anim-callback #(re-frame/dispatch [:set-message-shown message])
+          anim-callback #(events-buffer/dispatch [:set-message-shown message])
           context       {:to-value layout-height
                          :val      anim-value
                          :callback anim-callback}
@@ -293,10 +294,10 @@
      ;; send `:seen` signal when we have signed-in user, message not from us and we didn't sent it already
      #(when (and current-public-key message-id chat-id (not outgoing)
                  (not (chat.utils/message-seen-by? message current-public-key)))
-        (re-frame/dispatch [:send-seen! {:chat-id    chat-id
-                                         :from       from
-                                         :me         current-public-key
-                                         :message-id message-id}]))
+        (events-buffer/dispatch [:send-seen! {:chat-id    chat-id
+                                              :from       from
+                                              :me         current-public-key
+                                              :message-id message-id}]))
      :reagent-render
      (fn [{:keys [outgoing group-chat content-type content] :as message}]
        [message-container message

--- a/src/status_im/protocol/listeners.cljs
+++ b/src/status_im/protocol/listeners.cljs
@@ -4,7 +4,8 @@
             [status-im.protocol.web3.utils :as u]
             [status-im.protocol.encryption :as e]
             [taoensso.timbre :as log]
-            [status-im.utils.hex :as i]))
+            [status-im.utils.hex :as i]
+            [status-im.utils.events-buffer :as events-buffer]))
 
 (defn empty-public-key? [public-key]
   (or (= "0x0" public-key)
@@ -84,13 +85,16 @@
       (callback (if ack? :ack (:type payload)) message)
       (ack/check-ack! web3 sig payload identity))))
 
+(defn- handle-whisper-message [{:keys [error msg options]}]
+  (-> (init-scope error msg options)
+      parse-payload
+      filter-messages-from-same-user
+      parse-content
+      handle-message))
+
 (defn message-listener
   "Valid options are: web3, identity, callback, keypair"
   [options]
   (fn [js-error js-message]
-    (-> (init-scope js-error js-message options)
-        parse-payload
-        filter-messages-from-same-user
-        parse-content
-        handle-message)))
+    (events-buffer/dispatch [:handle-whisper-message js-error js-message options])))
 

--- a/src/status_im/utils/events_buffer.cljs
+++ b/src/status_im/utils/events_buffer.cljs
@@ -1,0 +1,28 @@
+(ns status-im.utils.events-buffer
+  (:require [cljs.core.async :as async]
+            [re-frame.core :as re-frame])
+  (:require-macros [cljs.core.async.macros :refer [go-loop]]))
+
+;; NOTE:(dmitryn) Ideally we should not exceed current buffer size.
+;; Buffer length is an experimental number, consider to change it.
+(defonce ^:private buffer (async/chan 10000))
+
+;; NOTE:(dmitryn) Reference to re-frame event loop mechanism
+;; https://github.com/Day8/re-frame/blob/master/src/re_frame/router.cljc#L8
+;; Might need future improvements.
+;; "Fast" events could be processed in batches to speed up things,
+;; so multiple buffers/channels could be introduced.
+(defn- start-loop! [c t]
+  "Dispatches events to re-frame processing queue,
+   but in a way that doesn't block events processing."
+  (go-loop [e (async/<! c)]
+    (re-frame/dispatch e)
+    (async/<! (async/timeout t))
+    (recur (async/<! c))))
+
+(defonce ^:private dispatch-loop (start-loop! buffer 0))
+
+;; Accepts re-frame event vector [:event-id args]
+;; NOTE(dmitryn) Puts all events into a single buffer (naive approach).
+(defn dispatch [event]
+  (async/put! buffer event))


### PR DESCRIPTION
Experiment around #3038 
Addresses #2852 

### Summary:

[comment]: # (Summarise the problem and how the pull request solves it)

Process events related to incoming messages asynchronous using buffer. This allows other events (UI-related) to be dispatched and processed so app is not freezing when getting a lot of chat messages.

### Testing notes (optional):
* App with a lot of messages in chats should not freeze on start.
* Chats with a lot of messages should not freeze UI.

status: ready