### PR TITLE
Add default command scope

### DIFF
--- a/resources/js/status.js
+++ b/resources/js/status.js
@@ -6,16 +6,24 @@ var _status_catalog = {
     },
     status = {};
 
+// This is default 'common sense' scope for commands/response which don't
+// define any.
+// We want the command/response to apply for 1-1 chats with registered user,
+// as most of the bot developers will expect the sole registered user (for
+// things like sending, etc.) and it will be non global, available only
+// for that particular bot (that's what "dapps" in scope)
+var defaultScope = ["personal-chats", "registered", "dapps"];
+
 function scopeToBitMask(scope) {
     // this function transforms scopes array to a single integer by generating a bit mask 
-    return ((scope != null && scope.indexOf("global") > -1) ? 1 : 0) |
-        ((scope != null && scope.indexOf("personal-chats") > -1) ? 2 : 0) |
-        ((scope != null && scope.indexOf("group-chats") > -1) ? 4 : 0) |
-        ((scope != null && scope.indexOf("anonymous") > -1) ? 8 : 0) |
-        ((scope != null && scope.indexOf("registered") > -1) ? 16 : 0) |
-        ((scope != null && scope.indexOf("dapps") > -1) ? 32 : 0) |
-        ((scope != null && scope.indexOf("humans") > -1) ? 64 : 0) |
-        ((scope != null && scope.indexOf("public-chats") > -1) ? 128 : 0);
+    return ((scope.indexOf("global") > -1) ? 1 : 0) |
+        ((scope.indexOf("personal-chats") > -1) ? 2 : 0) |
+        ((scope.indexOf("group-chats") > -1) ? 4 : 0) |
+        ((scope.indexOf("anonymous") > -1) ? 8 : 0) |
+        ((scope.indexOf("registered") > -1) ? 16 : 0) |
+        ((scope.indexOf("dapps") > -1) ? 32 : 0) |
+        ((scope.indexOf("humans") > -1) ? 64 : 0) |
+        ((scope.indexOf("public-chats") > -1) ? 128 : 0);
 }
 
 function Command() {
@@ -55,7 +63,7 @@ Command.prototype.create = function (com) {
     this["hide-send-button"] = com.hideSendButton;
 
     // scopes
-    this.scope = com.scope; 
+    this.scope = com.scope || defaultScope; 
     this["scope-bitmask"] = scopeToBitMask(this["scope"]);
 
     this.addToCatalog();


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes #2855

### Summary:

[comment]: # (Summarise the problem and how the pull request solves it)
Since we introduced command scopes this summer, we didn't properly document them to the outside world, so people developing bots just omit them, which has unfortunate consequence of commands/responses not being available anymore (see our `DemoBot` for example).
Also while command scopes are nice and flexible, it feels like unnecessary to specify them always, where in most cases people writing bots just want commands defined by it to be available in chat with that bot and nothing more. 
This PR solves it by providing meaningful default scope which is used when command/response scope is not otherwise specified.

### Testing notes (optional):
Super basic testing of command/response availability, eq, make sure that no commands/responses disappeared, we still have console commands. send/request etc. available. Also observe that `DemoBot` is actually working again.

EDIT:
Esseentially, you need to have 
1. A build of Jan's branch running on your device/emulator (something it is not currently trivial for me to set up, otherwise I would just test myself and report).
2. Clone the repo in the link I provided in the issue to get the DApp to be tested. 
3. Follow the steps given to get the DApp running locally and connected to the build of Jan's branch (i.e. `npm install`, figure out the IP of your device emulator using `status-dev-cli scan` and then `IP=<device_ip> npm run start` and then navigate to the DApp that gets added by virtue of that start script.
4. Click `/start` to get the bot going and test that the full interaction works, rather than getting stuck on when you try to confirm that the offered price is ok (currently sending `yes` to the `status.response` question just results in that message hanging with `Sending...` displayed below it and no response from the bot)

status: ready
