### PR TITLE
set useNativeDriver to true in request-button animation

### DIFF
--- a/src/status_im/chat/views/message/request_message.cljs
+++ b/src/status_im/chat/views/message/request_message.cljs
@@ -29,7 +29,8 @@
       (if (and @loop? (not @answered?))
         request-message-icon-scale-delay
         0))
-     (anim/spring val {:toValue to-value})]))
+     (anim/spring val {:toValue         to-value
+                       :useNativeDriver true})]))
 
 (defn request-button-animation-logic
   [{:keys [to-value val loop? answered?] :as context}]


### PR DESCRIPTION
`useNativeDriver: true` significantly reduces the number of messages from/to RN bridge, each animation caused ~60 messages per second. 

https://facebook.github.io/react-native/blog/2017/02/14/using-native-driver-for-animated.html

related to #2963 

status: ready 