### PR TITLE
[fix #2681] remove autocapitalize field for numeric input

### DIFF
--- a/src/status_im/ui/screens/wallet/send/styles.cljs
+++ b/src/status_im/ui/screens/wallet/send/styles.cljs
@@ -144,7 +144,6 @@
 (def transaction-fee-input
   {:flex 1
    :keyboard-type          :numeric
-   :auto-capitalize        "none"
    :placeholder            "0.000"
    :placeholder-text-color styles/color-white-transparent
    :selection-color        :white


### PR DESCRIPTION
fix #2681 

test on Samsung device
test on other Android device
test on iOS

status: ready
