### PR TITLE
[Fix #3076] Separate figwheel from dev lein profile

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -14,86 +14,91 @@
   :plugins [[lein-cljsbuild "1.1.7"]
             [lein-re-frisk "0.5.5"]]
   :clean-targets ["target/" "index.ios.js" "index.android.js"]
-  :aliases {"prod-build"       ^{:doc "Recompile code with prod profile."}
+  :aliases {"prod-build"         ^{:doc "Recompile code with prod profile."}
             ["do" "clean"
              ["with-profile" "prod" "cljsbuild" "once" "ios"]
              ["with-profile" "prod" "cljsbuild" "once" "android"]]
-            "figwheel-repl"    ["run" "-m" "clojure.main" "env/dev/run.clj"]
-            "test-cljs"        ["with-profile" "test" "doo" "node" "test" "once"]
-            "test-protocol"    ["with-profile" "test" "doo" "node" "protocol" "once"]
+            "figwheel-repl"      ["with-profile" "+figwheel" "run" "-m" "clojure.main" "env/dev/run.clj"]
+            "test-cljs"          ["with-profile" "test" "doo" "node" "test" "once"]
+            "test-protocol"      ["with-profile" "test" "doo" "node" "protocol" "once"]
             "test-env-dev-utils" ["with-profile" "test" "doo" "node" "env-dev-utils" "once"]}
-  :figwheel {:nrepl-port 7888}
-  :profiles {:dev  {:dependencies [[figwheel-sidecar "0.5.14"]
-                                   [re-frisk-remote "0.5.3"]
-                                   [re-frisk-sidecar "0.5.4"]
-                                   [com.cemerick/piggieback "0.2.2"]
-                                   [hawk "0.2.11"]]
-                    :source-paths ["src" "env/dev"]
-                    :cljsbuild    {:builds
-                                   {:ios
-                                    {:source-paths ["react-native/src" "src" "env/dev"]
-                                     :figwheel     true
-                                     :compiler     {:output-to     "target/ios/app.js"
-                                                    :main          "env.ios.main"
-                                                    :output-dir    "target/ios"
-                                                    :optimizations :none}}
-                                    :android
-                                    {:source-paths ["react-native/src" "src" "env/dev"]
-                                     :figwheel     true
-                                     :compiler     {:output-to     "target/android/app.js"
-                                                    :main          "env.android.main"
-                                                    :output-dir    "target/android"
-                                                    :optimizations :none}
-                                     :warning-handlers [status-im.utils.build/warning-handler]}}}
-                    :repl-options {:nrepl-middleware [cemerick.piggieback/wrap-cljs-repl]
-                                   :timeout          240000}}
-             :test {:dependencies [[day8.re-frame/test "0.1.5"]]
-                    :plugins   [[lein-doo "0.1.7"]]
-                    :cljsbuild {:builds
-                                [{:id           "test"
-                                  :source-paths ["src" "test/cljs"]
-                                  :compiler     {:main          status-im.test.runner
-                                                 :output-to     "target/test/test.js"
-                                                 :output-dir    "target/test"
-                                                 :optimizations :none
-                                                 :preamble      ["js/hook-require.js"]
-                                                 :target        :nodejs}}
-                                 {:id           "protocol"
-                                  :source-paths ["src" "test/cljs"]
-                                  :compiler     {:main          status-im.test.protocol.runner
-                                                 :output-to     "target/test/test.js"
-                                                 :output-dir    "target/test"
-                                                 :optimizations :none
-                                                 :target        :nodejs}}
-                                 {:id           "env-dev-utils"
-                                  :source-paths ["env/dev/env/utils.cljs" "test/env/dev"]
-                                  :compiler     {:main          env.test.runner
-                                                 :output-to     "target/test/test.js"
-                                                 :output-dir    "target/test"
-                                                 :optimizations :none
-                                                 :target        :nodejs}}]}}
-             :prod {:cljsbuild {:builds
-                                {:ios
-                                 {:source-paths ["react-native/src" "src" "env/prod"]
-                                  :compiler     {:output-to          "index.ios.js"
-                                                 :main               "env.ios.main"
-                                                 :output-dir         "target/ios-prod"
-                                                 :static-fns         true
-                                                 :optimize-constants true
-                                                 :optimizations      :simple
-                                                 :closure-defines    {"goog.DEBUG" false}
-                                                 :parallel-build     false
-                                                 :language-in        :ecmascript5}
-                                  :warning-handlers [status-im.utils.build/warning-handler]}
-                                 :android
-                                 {:source-paths ["react-native/src" "src" "env/prod"]
-                                  :compiler     {:output-to          "index.android.js"
-                                                 :main               "env.android.main"
-                                                 :output-dir         "target/android-prod"
-                                                 :static-fns         true
-                                                 :optimize-constants true
-                                                 :optimizations      :simple
-                                                 :closure-defines    {"goog.DEBUG" false}
-                                                 :parallel-build     false
-                                                 :language-in        :ecmascript5}
-                                  :warning-handlers [status-im.utils.build/warning-handler]}}}}})
+  :profiles {:dev      {:dependencies [[com.cemerick/piggieback "0.2.2"]]
+                        :cljsbuild    {:builds
+                                       {:ios
+                                        {:source-paths ["react-native/src" "src"]
+                                         :compiler     {:output-to     "target/ios/app.js"
+                                                        :main          "env.ios.main"
+                                                        :output-dir    "target/ios"
+                                                        :optimizations :none}}
+                                        :android
+                                        {:source-paths     ["react-native/src" "src"]
+                                         :compiler         {:output-to     "target/android/app.js"
+                                                            :main          "env.android.main"
+                                                            :output-dir    "target/android"
+                                                            :optimizations :none}
+                                         :warning-handlers [status-im.utils.build/warning-handler]}}}
+                        :repl-options {:nrepl-middleware [cemerick.piggieback/wrap-cljs-repl]
+                                       :timeout          240000}}
+             :figwheel [:dev
+                        {:dependencies [[figwheel-sidecar "0.5.14"]
+                                        [re-frisk-remote "0.5.3"]
+                                        [re-frisk-sidecar "0.5.4"]
+                                        [hawk "0.2.11"]]
+                         :source-paths ["src" "env/dev"]
+                         :cljsbuild    {:builds
+                                        {:ios
+                                         {:source-paths ["react-native/src" "src" "env/dev"]
+                                          :figwheel     true}
+                                         :android
+                                         {:source-paths ["react-native/src" "src" "env/dev"]
+                                          :figwheel     true}}}}]
+             :test     {:dependencies [[day8.re-frame/test "0.1.5"]]
+                        :plugins      [[lein-doo "0.1.7"]]
+                        :cljsbuild    {:builds
+                                       [{:id           "test"
+                                         :source-paths ["src" "test/cljs"]
+                                         :compiler     {:main          status-im.test.runner
+                                                        :output-to     "target/test/test.js"
+                                                        :output-dir    "target/test"
+                                                        :optimizations :none
+                                                        :preamble      ["js/hook-require.js"]
+                                                        :target        :nodejs}}
+                                        {:id           "protocol"
+                                         :source-paths ["src" "test/cljs"]
+                                         :compiler     {:main          status-im.test.protocol.runner
+                                                        :output-to     "target/test/test.js"
+                                                        :output-dir    "target/test"
+                                                        :optimizations :none
+                                                        :target        :nodejs}}
+                                        {:id           "env-dev-utils"
+                                         :source-paths ["env/dev/env/utils.cljs" "test/env/dev"]
+                                         :compiler     {:main          env.test.runner
+                                                        :output-to     "target/test/test.js"
+                                                        :output-dir    "target/test"
+                                                        :optimizations :none
+                                                        :target        :nodejs}}]}}
+             :prod     {:cljsbuild {:builds
+                                    {:ios
+                                     {:source-paths     ["react-native/src" "src" "env/prod"]
+                                      :compiler         {:output-to          "index.ios.js"
+                                                         :main               "env.ios.main"
+                                                         :output-dir         "target/ios-prod"
+                                                         :static-fns         true
+                                                         :optimize-constants true
+                                                         :optimizations      :simple
+                                                         :closure-defines    {"goog.DEBUG" false}
+                                                         :parallel-build     false
+                                                         :language-in        :ecmascript5}
+                                      :warning-handlers [status-im.utils.build/warning-handler]}
+                                     :android
+                                     {:source-paths     ["react-native/src" "src" "env/prod"]
+                                      :compiler         {:output-to          "index.android.js"
+                                                         :main               "env.android.main"
+                                                         :output-dir         "target/android-prod"
+                                                         :static-fns         true
+                                                         :optimize-constants true
+                                                         :optimizations      :simple
+                                                         :closure-defines    {"goog.DEBUG" false}
+                                                         :parallel-build     false
+                                                         :language-in        :ecmascript5}
+                                      :warning-handlers [status-im.utils.build/warning-handler]}}}}})

--- a/src/status_im/bots/events.cljs
+++ b/src/status_im/bots/events.cljs
@@ -1,6 +1,6 @@
 (ns status-im.bots.events
   (:require [re-frame.core :as re-frame]
-            [status-im.utils.utils :as utils]
+            [status-im.utils.core :as utils]
             [status-im.utils.handlers :as handlers]
             [status-im.chat.models.input :as input-model]
             [taoensso.timbre :as log]))

--- a/src/status_im/chat/views/bottom_info.cljs
+++ b/src/status_im/chat/views/bottom_info.cljs
@@ -8,7 +8,7 @@
             [status-im.i18n :as i18n]
             [status-im.ui.components.animation :as anim]
             [status-im.ui.components.list.views :as list]
-            [status-im.utils.utils :as utils]
+            [status-im.utils.core :as utils]
             [status-im.utils.identicon :as identicon]))
 
 (defn- container-animation-logic [{:keys [to-value val]}]

--- a/src/status_im/data_store/messages.cljs
+++ b/src/status_im/data_store/messages.cljs
@@ -4,7 +4,7 @@
             [status-im.constants :as constants]
             [status-im.data-store.realm.messages :as data-store]
             [status-im.utils.random :as random]
-            [status-im.utils.utils :as utils]))
+            [status-im.utils.core :as utils]))
 
 (defn- command-type?
   [type]
@@ -75,7 +75,7 @@
       prepare-statuses
       (utils/update-if-present :content prepare-content)))
 
-(defn save 
+(defn save
   [{:keys [message-id content from] :as message}]
   (when-not (data-store/exists? message-id)
     (data-store/save (prepare-message (merge default-values

--- a/src/status_im/ios/platform.cljs
+++ b/src/status_im/ios/platform.cljs
@@ -1,6 +1,6 @@
 (ns status-im.ios.platform
   (:require [status-im.i18n :refer [label]]
-            [status-im.utils.utils :as utils]
+            [status-im.utils.core :as utils]
             [status-im.react-native.js-dependencies :as rn-dependencies]))
 
 (def fonts

--- a/src/status_im/ui/components/action_sheet.cljs
+++ b/src/status_im/ui/components/action_sheet.cljs
@@ -1,6 +1,6 @@
 (ns status-im.ui.components.action-sheet
   (:require [status-im.i18n :as i18n]
-            [status-im.utils.utils :as utils]
+            [status-im.utils.core :as utils]
             [status-im.react-native.js-dependencies :as rn-dependencies]))
 
 (defn- callback [options]

--- a/src/status_im/ui/components/chat_preview.cljs
+++ b/src/status_im/ui/components/chat_preview.cljs
@@ -1,7 +1,7 @@
 (ns status-im.ui.components.chat-preview
   (:require [status-im.ui.components.react :as components]
             [status-im.ui.screens.home.styles :as home.styles]
-            [status-im.utils.utils :as utils]))
+            [status-im.utils.core :as utils]))
 
 (def default-attributes
   {:style           home.styles/last-message-text

--- a/src/status_im/ui/components/status_view/view.cljs
+++ b/src/status_im/ui/components/status_view/view.cljs
@@ -5,7 +5,7 @@
             [status-im.ui.components.react :refer [view text]]
             [status-im.utils.platform :refer [platform-specific]]
             [status-im.ui.components.styles :refer [color-blue color-black color-blue4-faded]]
-            [status-im.utils.utils :refer [hash-tag?]]))
+            [status-im.utils.core :refer [hash-tag?]]))
 
 (defn tag-view [tag]
   [text {:style {:color color-blue4-faded}

--- a/src/status_im/ui/components/sticky_button.cljs
+++ b/src/status_im/ui/components/sticky_button.cljs
@@ -2,7 +2,7 @@
   (:require-macros [status-im.utils.styles :refer [defstyle defnstyle]])
   (:require [status-im.ui.components.styles :as common]
             [status-im.utils.platform :refer [platform-specific]]
-            [status-im.utils.utils :as u]
+            [status-im.utils.core :as u]
             [status-im.ui.components.react :as react]))
 
 (def sticky-button-style

--- a/src/status_im/ui/screens/home/views/inner_item.cljs
+++ b/src/status_im/ui/screens/home/views/inner_item.cljs
@@ -8,7 +8,7 @@
             [status-im.ui.components.context-menu :as context-menu]
             [status-im.ui.screens.home.styles :as styles]
             [status-im.ui.components.styles :as component.styles]
-            [status-im.utils.utils :as utils]
+            [status-im.utils.core :as utils]
             [status-im.commands.utils :as commands-utils]
             [status-im.i18n :as i18n]
             [status-im.utils.datetime :as time]

--- a/src/status_im/ui/screens/profile/events.cljs
+++ b/src/status_im/ui/screens/profile/events.cljs
@@ -13,7 +13,7 @@
             [status-im.utils.gfycat.core :as gfycat]
             [status-im.utils.handlers :as handlers]
             [status-im.utils.image-processing :refer [img->base64]]
-            [status-im.utils.utils :as utils]
+            [status-im.utils.core :as utils]
             [taoensso.timbre :as log]))
 
 (re-frame/reg-fx

--- a/src/status_im/ui/screens/profile/views.cljs
+++ b/src/status_im/ui/screens/profile/views.cljs
@@ -19,6 +19,7 @@
             [status-im.ui.screens.profile.styles :as styles]
             [status-im.ui.components.colors :as colors]
             [status-im.utils.utils :as utils]
+            [status-im.utils.core :refer [hash-tag?]]
             [status-im.utils.datetime :as time]
             [status-im.utils.config :as config]
             [status-im.utils.platform :as platform]
@@ -194,7 +195,7 @@
 
 (defn colorize-status-hashtags [status]
   (for [[i status] (map-indexed vector (string/split status #" "))]
-    (if (utils/hash-tag? status)
+    (if (hash-tag? status)
       ^{:key (str "item-" i)}
       [tag-view status]
       ^{:key (str "item-" i)}

--- a/src/status_im/utils/core.cljc
+++ b/src/status_im/utils/core.cljc
@@ -1,0 +1,61 @@
+(ns status-im.utils.core
+  (:require [clojure.string :as str]))
+
+(defn truncate-str
+  "Given string and max threshold, trims the string to threshold length with `...`
+  appended to end if length of the string exceeds max threshold, returns the same
+  string if threshold is not exceeded"
+  [s threshold]
+  (if (and s (< threshold (count s)))
+    (str (subs s 0 (- threshold 3)) "...")
+    s))
+
+(defn clean-text [s]
+  (-> s
+      (str/replace #"\n" "")
+      (str/replace #"\r" "")
+      (str/trim)))
+
+(defn first-index
+  "Returns first index in coll where predicate on coll element is truthy"
+  [pred coll]
+  (->> coll
+       (keep-indexed (fn [idx e]
+                       (when (pred e)
+                         idx)))
+       first))
+
+(defn hash-tag? [s]
+  (= \# (first s)))
+
+(defn wrap-call-once!
+  "Returns a version of provided function that will be called only the first time wrapping function is called. Returns nil."
+  [f]
+  (let [called? (volatile! false)]
+    (fn [& args]
+      (when-not @called?
+        (vreset! called? true)
+        (apply f args)
+        nil))))
+
+(defn update-if-present
+  "Like regular `clojure.core/update` but returns original map if update key is not present"
+  [m k f & args]
+  (if (contains? m k)
+    (apply update m k f args)
+    m))
+
+(defn map-values
+  "Efficiently apply function to all map values"
+  [m f]
+  (into {}
+        (map (fn [[k v]]
+               [k (f v)]))
+        m))
+
+(defn deep-merge
+  "Recursively merge maps"
+  [& maps]
+  (if (every? map? maps)
+    (apply merge-with deep-merge maps)
+    (last maps)))

--- a/src/status_im/utils/utils.cljs
+++ b/src/status_im/utils/utils.cljs
@@ -1,7 +1,6 @@
 (ns status-im.utils.utils
   (:require [status-im.constants :as const]
             [status-im.i18n :as i18n]
-            [clojure.string :as str]
             [status-im.react-native.js-dependencies :as rn-dependencies]))
 
 (defn show-popup [title content]
@@ -81,62 +80,3 @@
        (.catch (or on-error
                    (fn [error]
                      (show-popup "Error" (str error))))))))
-
-(defn truncate-str
-  "Given string and max threshold, trims the string to threshold length with `...`
-  appended to end if length of the string exceeds max threshold, returns the same
-  string if threshold is not exceeded"
-  [s threshold]
-  (if (and s (< threshold (count s)))
-    (str (subs s 0 (- threshold 3)) "...")
-    s))
-
-(defn clean-text [s]
-  (-> s
-      (str/replace #"\n" "")
-      (str/replace #"\r" "")
-      (str/trim)))
-
-(defn first-index
-  "Returns first index in coll where predicate on coll element is truthy"
-  [pred coll]
-  (->> coll
-       (keep-indexed (fn [idx e]
-                       (when (pred e)
-                         idx)))
-       first))
-
-(defn hash-tag? [s]
-  (= \# (first s)))
-
-(defn wrap-call-once!
-  "Returns a version of provided function that will be called only the first time wrapping function is called. Returns nil."
-  [f]
-  (let [called? (volatile! false)]
-    (fn [& args]
-      (when-not @called?
-        (vreset! called? true)
-        (apply f args)
-        nil))))
-
-(defn update-if-present
-  "Like regular `clojure.core/update` but returns original map if update key is not present"
-  [m k f & args]
-  (if (contains? m k)
-    (apply update m k f args)
-    m))
-
-(defn map-values
-  "Efficiently apply function to all map values"
-  [m f]
-  (into {}
-        (map (fn [[k v]]
-               [k (f v)]))
-        m))
-
-(defn deep-merge
-  "Recursively merge maps"
-  [& maps]
-  (if (every? map? maps)
-    (apply merge-with deep-merge maps)
-    (last maps)))

--- a/test/cljs/status_im/test/utils/utils.cljs
+++ b/test/cljs/status_im/test/utils/utils.cljs
@@ -1,6 +1,6 @@
 (ns status-im.test.utils.utils
   (:require [cljs.test :refer-macros [deftest is]]
-            [status-im.utils.utils :as u]))
+            [status-im.utils.core :as u]))
 
 (deftest wrap-as-call-once-test
   (let [count (atom 0)]


### PR DESCRIPTION
fixes #3076 

### Summary:

I make `figwheel` profile extend `dev` profile to avoid having to duplicate some shared settings from `dev` profile. However, it's not very elegant that in `figweel-api` I have to load `dev` and `figwheel` profile cljsbuild settings than do a deep merge in order to get a combined settings.

Please note that if you now need to start nREPL with figwheel capability. You need to do `lein with-profile +figwheel repl` instead of just `lein repl`. 

status: ready <!-- Can be ready or wip -->
