### PR TITLE
issue 3037: Fix android compilation warnings

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -116,8 +116,7 @@ def getVersionName = { ->
 }
 
 android {
-    compileSdkVersion 24
-    buildToolsVersion "26.0.2"
+    compileSdkVersion 27
 
     defaultConfig {
         applicationId "im.status.ethereum"
@@ -187,38 +186,38 @@ android {
 }
 
 dependencies {
-    compile project(':react-native-svg')
-    compile project(':react-native-mapbox-gl')
-    compile 'com.android.support:multidex:1.0.2'
-    compile project(':react-native-http-bridge')
-    compile project(':nfc-react-native')
-    compile project(':instabug-reactnative')
-    compile project(':react-native-splash-screen')
-    compile project(':react-native-image-resizer')
-    compile project(':react-native-dialogs')
-    compile project(':react-native-randombytes')
-    compile project(':react-native-android-sms-listener')
-    compile project(':realm')
-    compile project(':react-native-vector-icons')
-    compile fileTree(dir: "libs", include: ["*.jar"])
-    compile "com.android.support:appcompat-v7:23.0.1"
-    compile "com.facebook.react:react-native:+"  // From node_modules
-    compile project(':react-native-contacts')
-    compile project(':react-native-i18n')
-    compile project(':react-native-linear-gradient')
-    compile project(':react-native-camera')
-    compile project(':react-native-status')
-    compile project(':react-native-orientation')
-    compile project(':react-native-fs')
-    compile project(':react-native-image-crop-picker')
-    compile project(':react-native-webview-bridge')
-    compile 'testfairy:testfairy-android-sdk:1.+@aar'
-    compile project(':react-native-config')
-    compile project(':react-native-fcm')
-    compile 'com.google.firebase:firebase-core:10.0.1' //this decides your firebase SDK version
+    implementation project(':react-native-svg')
+    implementation project(':react-native-mapbox-gl')
+    implementation 'com.android.support:multidex:1.0.2'
+    implementation project(':react-native-http-bridge')
+    implementation project(':nfc-react-native')
+    implementation project(':instabug-reactnative')
+    implementation project(':react-native-splash-screen')
+    implementation project(':react-native-image-resizer')
+    implementation project(':react-native-dialogs')
+    implementation project(':react-native-randombytes')
+    implementation project(':react-native-android-sms-listener')
+    implementation project(':realm')
+    implementation project(':react-native-vector-icons')
+    implementation fileTree(dir: "libs", include: ["*.jar"])
+    implementation "com.android.support:appcompat-v7:23.0.1"
+    implementation "com.facebook.react:react-native:+"  // From node_modules
+    implementation project(':react-native-contacts')
+    implementation project(':react-native-i18n')
+    implementation project(':react-native-linear-gradient')
+    implementation project(':react-native-camera')
+    implementation project(':react-native-status')
+    implementation project(':react-native-orientation')
+    implementation project(':react-native-fs')
+    implementation project(':react-native-image-crop-picker')
+    implementation project(':react-native-webview-bridge')
+    implementation 'testfairy:testfairy-android-sdk:1.+@aar'
+    implementation project(':react-native-config')
+    implementation project(':react-native-fcm')
+    implementation 'com.google.firebase:firebase-core:10.0.1' //this decides your firebase SDK version
 
-    compile 'status-im:function:0.0.1'
-    compile fileTree(dir: "node_modules/realm/android/libs", include: ["*.jar"])
+    implementation 'status-im:function:0.0.1'
+    implementation fileTree(dir: "node_modules/realm/android/libs", include: ["*.jar"])
 }
 // Run this once to be able to run the application with BUCK
 // puts all compile dependencies into folder libs for BUCK to use

--- a/android/app/jni/Application.mk
+++ b/android/app/jni/Application.mk
@@ -1,4 +1,4 @@
-APP_ABI := all
-APP_PLATFORM := android-15
+APP_ABI := armeabi-v7a arm64-v8a x86 x86_64
+APP_PLATFORM := android-18
 APP_STL := gnustl_static
 NDK_TOOLCHAIN_VERSION=4.9

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -21,13 +21,8 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 
     <!-- these permissions should be removed -->
-    <!-- react-native-orientation adds an unnecessary permission; here we remove it -->
-    <uses-permission android:name="android.permission.BLUETOOTH" tools:node="remove"/>
-    <!-- react-native-contacts -->
-    <uses-permission android:name="android.permission.WRITE_CONTACTS" tools:node="remove"/>
-    <!-- react-native-camera -->
+    <!-- RECORD_AUDIO is pulled in by instabug-reactnative, not needed for status-react -->
     <uses-permission android:name="android.permission.RECORD_AUDIO" tools:node="remove"/>
-    <uses-permission android:name="android.permission.RECORD_VIDEO" tools:node="remove"/>
     <!-- React Native unnecessary permissions (https://github.com/facebook/react-native/issues/5886) -->
     <uses-permission android:name="android.permission.READ_PHONE_STATE" tools:node="remove"/>
 

--- a/modules/react-native-status/android/build.gradle
+++ b/modules/react-native-status/android/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 24
-    buildToolsVersion "23.0.1"
 
     defaultConfig {
         minSdkVersion 18
@@ -13,10 +12,10 @@ android {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
-    compile 'com.instabug.library:instabug:3+'
-    compile 'com.github.ericwlange:AndroidJSCore:3.0.1'
-    compile 'status-im:function:0.0.1'
+    implementation 'com.facebook.react:react-native:+'
+    implementation 'com.instabug.library:instabug:3+'
+    implementation 'com.github.ericwlange:AndroidJSCore:3.0.1'
+    implementation 'status-im:function:0.0.1'
 
     String statusGoVersion = 'develop-gd71c66a2'
     final String statusGoGroup = 'status-im', statusGoName = 'status-go'
@@ -28,5 +27,5 @@ dependencies {
         statusGoVersion = localVersion
     }
 
-    compile(group: statusGoGroup, name: statusGoName, version: statusGoVersion, ext: 'aar')
+    implementation(group: statusGoGroup, name: statusGoName, version: statusGoVersion, ext: 'aar')
 }

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "react-native-randombytes": "3.0.0",
     "react-native-sortable-listview": "0.2.6",
     "react-native-splash-screen": "3.0.6",
-    "react-native-svg": "6.0.0",
+    "react-native-svg": "6.0.1-rc.3",
     "react-native-tcp": "3.3.0",
     "react-native-udp": "2.2.1",
     "react-native-vector-icons": "4.4.2",


### PR DESCRIPTION
Fixes #3037 "Fix android compilation warnings"

### Summary:

Remove nearly all android build warnings, using sed to modify build.gradle files of node_modules. For node_modules already forked by status there are separate PRs (see refs below).

4 warnings left:
* "Task.leftShift(Closure) method has been deprecated" -- from node_modules/realm/android/build.gradle. Have tested fix for this, but cannot use sed as fix is multiline. Should we fork realm or leave this one?
* "registerResGeneratingTask is deprecated, use registerGeneratedFolders(FileCollection)" -- from one of the plugins, not from status code.
* "warning: the transform cache was reset" -- from XCode build, not android.
* "Configuration 'compile' in project ':app' is deprecated. Use 'implementation' instead." -- [stackoverflow](https://stackoverflow.com/questions/47300679/configuration-compile-in-is-deprecated-but-all-configurations-are-implementa?rq=1) says could also be from a plugin.

The warnings (now silenced) about unnecessary removal of BLUETOOTH, WRITE_CONTACTS and RECORD_VIDEO permissions were leftovers from when some node_modules were adding these. 

### Testing notes:
Need to run scripts/setup again before building.

### Steps to test:
- scripts/setup
- build as normal
- observe log for build warnings

status: ready
