### PR TITLE
Check admin.peers() before markTrustedPeer() call

### DIFF
--- a/src/status_im/protocol/web3/inbox.cljs
+++ b/src/status_im/protocol/web3/inbox.cljs
@@ -1,10 +1,8 @@
 (ns status-im.protocol.web3.inbox
-  (:require [status-im.native-module.core :as status]
-            [taoensso.timbre :as log]
-            [re-frame.core :as re-frame]
-            [clojure.string :as string]
-            [status-im.protocol.web3.keys :as keys]
-            [status-im.protocol.web3.utils :as utils]))
+  (:require [re-frame.core :as re-frame]
+            [status-im.native-module.core :as status]
+            [status-im.protocol.web3.utils :as web3.utils]
+            [taoensso.timbre :as log]))
 
 (def peers (atom #{}))
 (def trusted-peers (atom #{}))
@@ -44,14 +42,29 @@
                                                   (swap! peers conj enode)
                                                   (success-fn result))))))
 
-(defn mark-trusted-peer [web3 enode success-fn error-fn]
+(defn registered-peer? [peers enode]
+  (let [peer-ids (set (map :id peers))
+        enode-id (web3.utils/extract-enode-id enode)]
+    (contains? peer-ids enode-id)))
+
+(defn mark-trusted-peer [web3 enode peers success-fn error-fn]
   (if (@trusted-peers enode)
     (success-fn true)
-    (.markTrustedPeer (utils/shh web3)
-                      enode
-                      (response-handler error-fn (fn [result]
-                                                   (swap! trusted-peers conj enode)
-                                                   (success-fn result))))))
+    (.markTrustedPeer (web3.utils/shh web3)
+                       enode
+                       (response-handler error-fn (fn [result]
+                                                    (swap! trusted-peers conj enode)
+                                                    (success-fn result))))))
+
+;; TODO(dmitryn): use web3 instead of rpc call
+(defn fetch-peers [success-fn error-fn]
+  (let [args {:jsonrpc "2.0"
+              :id 2
+              :method "admin_peers"
+              :params []}
+        payload (.stringify js/JSON (clj->js args))]
+    (status/call-web3 payload
+                      (response-handler error-fn success-fn))))
 
 (defn request-messages [web3 wnode topic sym-key-id success-fn error-fn]
   (log/info "offline inbox: sym-key-id" sym-key-id)
@@ -60,7 +73,7 @@
               :symKeyID       sym-key-id}]
     (log/info "offline inbox: request-messages request")
     (log/info "offline inbox: request-messages args" (pr-str opts))
-    (.requestMessages (utils/shh web3)
+    (.requestMessages (web3.utils/shh web3)
                       (clj->js opts)
                       (response-handler error-fn success-fn))))
 

--- a/src/status_im/protocol/web3/utils.cljs
+++ b/src/status_im/protocol/web3/utils.cljs
@@ -1,7 +1,7 @@
 (ns status-im.protocol.web3.utils
-  (:require [cljs-time.core :refer [now]]
-            [cljs-time.coerce :refer [to-long]]
-            [status-im.utils.web3-provider :as w3]
+  (:require [cljs-time.coerce :refer [to-long]]
+            [cljs-time.core :refer [now]]
+            [clojure.string :as string]
             [status-im.js-dependencies :as dependencies]))
 
 (defn from-utf8 [s]
@@ -18,3 +18,12 @@
 
 (defn timestamp []
   (to-long (now)))
+
+(defn extract-enode-id [enode]
+  (-> enode
+      (string/split #"/")
+      (get 2 "")
+      (string/split #":")
+      (get 0 "")
+      (string/split "@")
+      (get 0)))

--- a/test/cljs/status_im/test/protocol/web3/inbox.cljs
+++ b/test/cljs/status_im/test/protocol/web3/inbox.cljs
@@ -1,0 +1,40 @@
+(ns status-im.test.protocol.web3.inbox
+  (:require [status-im.protocol.web3.inbox :as inbox]
+            [status-im.protocol.web3.utils :as utils]
+            [cljs.test :refer-macros [deftest is testing]]))
+
+
+(def enode "enode://08d8eb6177b187049f6c97ed3f6c74fbbefb94c7ad10bafcaf4b65ce89c314dcfee0a8bc4e7a5b824dfa08b45b360cc78f34f0aff981f8386caa07652d2e601b@163.172.177.138:40404")
+(def enode2 "enode://12d8eb6177b187049f6c97ed3f6c74fbbefb94c7ad10bafcaf4b65ce89c314dcfee0a8bc4e7a5b824dfa08b45b360cc78f34f0aff981f8386caa07652d2e601b@163.172.177.138:40404")
+
+(deftest test-extract-enode-id
+  (testing "Get enode id from enode uri"
+    (is (= "08d8eb6177b187049f6c97ed3f6c74fbbefb94c7ad10bafcaf4b65ce89c314dcfee0a8bc4e7a5b824dfa08b45b360cc78f34f0aff981f8386caa07652d2e601b"
+           (utils/extract-enode-id enode))))
+  (testing "Get enode id from mailformed enode uri"
+    (is (= ""
+           (utils/extract-enode-id "08d8eb6177b187049f6c97ed3f6c74fbbefb94c7ad10bafcaf4b65ce89c314dcfee0a8bc4e7a5b824dfa08b45b360cc78f34f0aff981f8386caa07652d2e601b@163.172.177.138:40404"))))
+  (testing "Test empty string"
+    (is (= ""
+           (utils/extract-enode-id ""))))
+  (testing "Test nil"
+    (is (= ""
+           (utils/extract-enode-id nil)))))
+
+(def peers
+  [{:id "08d8eb6177b187049f6c97ed3f6c74fbbefb94c7ad10bafcaf4b65ce89c314dcfee0a8bc4e7a5b824dfa08b45b360cc78f34f0aff981f8386caa07652d2e601b"
+    :name "StatusIM/v0.9.9-unstable/linux-amd64/go1.9.2"}
+   {:id "0f7c65277f916ff4379fe520b875082a56e587eb3ce1c1567d9ff94206bdb05ba167c52272f20f634cd1ebdec5d9dfeb393018bfde1595d8e64a717c8b46692f"
+    :name "Geth/v1.7.2-stable/linux-amd64/go1.9.1"}])
+
+(deftest test-registered-peer?
+  (testing "Peer is registered"
+    (is (inbox/registered-peer? peers enode)))
+  (testing "Peer is not peers list"
+    (is (not (inbox/registered-peer? peers enode2))))
+  (testing "Empty peers"
+    (is (not (inbox/registered-peer? [] enode))))
+  (testing "Empty peer"
+    (is (not (inbox/registered-peer? peers ""))))
+  (testing "Nil peer"
+    (is (not (inbox/registered-peer? peers nil)))))

--- a/test/cljs/status_im/test/runner.cljs
+++ b/test/cljs/status_im/test/runner.cljs
@@ -11,6 +11,7 @@
             [status-im.test.bots.events]
             [status-im.test.chat.models.input]
             [status-im.test.i18n]
+            [status-im.test.protocol.web3.inbox]
             [status-im.test.utils.utils]
             [status-im.test.utils.money]
             [status-im.test.utils.clocks]
@@ -45,6 +46,7 @@
  'status-im.test.wallet.transactions.views
  'status-im.test.chat.models.input
  'status-im.test.i18n
+ 'status-im.test.protocol.web3.inbox
  'status-im.test.utils.utils
  'status-im.test.utils.money
  'status-im.test.utils.clocks


### PR DESCRIPTION
Fixes #3055 

### Summary

`addPeer` call doesn't add peer right away, so `markTrustedPeer` fails. Check #3055 for details.

Current solution adds retry mechanism: we make 3 retry requests (with delay) for fetching peers until we know peer was registered.

### Testing notes

PR doesn't change app logic or UI. Just make sure offline messaging work (you're able to receive at least 1 message).

status: ready