### PR TITLE
Addresses the ClassNotFoundException issue

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -23,6 +23,7 @@
             "test-protocol"    ["with-profile" "test" "doo" "node" "protocol" "once"]
             "test-env-dev-utils" ["with-profile" "test" "doo" "node" "env-dev-utils" "once"]}
   :figwheel {:nrepl-port 7888}
+  :jvm-opts ["--add-modules" "java.xml.bind"]
   :profiles {:dev  {:dependencies [[figwheel-sidecar "0.5.14"]
                                    [re-frisk-remote "0.5.3"]
                                    [re-frisk-sidecar "0.5.4"]


### PR DESCRIPTION
fixes the `ClassNotFoundException` issue explained here: https://github.com/bhauman/lein-figwheel/issues/612

### Summary:
Running `brew cask install java` command installs the [latest JDK](https://wiki.status.im/Building_Status#Requirements) as one of the requirements, which results in installing Java 9. As explained [here](https://stackoverflow.com/questions/43574426/how-to-resolve-java-lang-noclassdeffounderror-javax-xml-bind-jaxbexception-in-j?answertab=votes#tab-top): 
>Java 9 introduces the concepts of modules, and by default the `java.se` aggregate module is available on the class path (or rather, module path). As the name implies, the `java.se` aggregate module does not include the Java EE APIs that have been traditionally bundled with Java 6/7/8.
The JAXB APIs are considered to be Java EE APIs, and therefore are no longer contained on the default class path in Java SE 9. These Java EE APIs that were provided in JDK 6/7/8 are still in the JDK, but they just aren't on the class path by default. The extra Java EE APIs are provided in the following modules:

```
java.activation
java.corba
java.transaction
java.xml.bind  << This one contains the JAXB APIs
java.xml.ws
java.xml.ws.annotation
```
Adding `:jvm-opts ["--add-modules" "java.xml.bind"]` to the `project.clj` file would make JAXB APIs available at runtime and solve the issue.

status: ready <!-- Can be ready or wip -->