### PR TITLE
[fix #3091] fix edit group chat contact list

### DIFF
--- a/src/status_im/ui/screens/group/edit_contacts/views.cljs
+++ b/src/status_im/ui/screens/group/edit_contacts/views.cljs
@@ -23,11 +23,10 @@
   [react/view {:flex 1}
    [list/flat-list {:data                      contacts
                     :enableEmptySections       true
-                    :renderRow                 (fn [contact]
+                    :render-fn                 (fn [contact]
                                                  [contact-view {:contact        contact
                                                                 :extended?      extended?
                                                                 :extend-options (extend-options contact)}])
-
                     :bounces                   false
                     :keyboardShouldPersistTaps :always
                     :footer                    list/default-footer


### PR DESCRIPTION
Fixes #3091 

### Summary

Fixes screen group chat contacts list edit.

Renames `renderRow` attribute to `render-fn` to comply with `flat-list` accepted attributes.

Please refer to #3091 for the details.