### PR TITLE
[ISSUE#3099] Do not hardocde list item height

### DIFF
--- a/src/status_im/ui/components/list/styles.cljs
+++ b/src/status_im/ui/components/list/styles.cljs
@@ -5,8 +5,7 @@
 
 (def item
   {:flex-direction :row
-   :justify-content :center
-   :height          64})
+   :justify-content :center})
 
 (def item-content-view
   {:flex            1


### PR DESCRIPTION
fixes #3099

### Summary:

Do not hardcode list item height so that any elements can be visible.

### Steps to test:
- Open Status
- Go to wallet tab
- Create a transaction to be signed later
- Verify action buttons are visible in the transaction history

status: ready
