### PR TITLE
[fix #2754] Don't update contact with old data

### DIFF
--- a/src/status_im/ui/screens/contacts/events.cljs
+++ b/src/status_im/ui/screens/contacts/events.cljs
@@ -19,7 +19,8 @@
             [status-im.ui.screens.contacts.navigation]
             [status-im.chat.console :as console-chat]
             [status-im.commands.events.loading :as loading-events]
-            [cljs.spec.alpha :as spec]))
+            [cljs.spec.alpha :as spec]
+            [status-im.protocol.web3.utils :as web3.utils]))
 
 ;;;; COFX
 
@@ -68,7 +69,8 @@
                                         :status        status
                                         :fcm-token     fcm-token}
                               :keypair {:public  updates-public-key
-                                        :private updates-private-key}}}})))
+                                        :private updates-private-key}
+                              :timestamp (web3.utils/timestamp)}}})))
 
 (reg-fx
   ::reset-pending-messages


### PR DESCRIPTION
Fixes #2754

### Summary:

On restart app could change profile avatar back to the old one. This is happening because it receives `contact-request` message multiple times. This message contains outdated info about contact (including old photo).

### Review notes (optional):
I'm not really sure whether is current logic right:
* why do we receive `contact-request` message continiously after app gets reopened? (event when contact was already added). 
* when we receive that message, why do we need to trigger contact and chat updates? 
https://github.com/status-im/status-react/blob/develop/src/status_im/protocol/handlers.cljs#L495

### Steps to test:
- Have chat for user A and B
- Change pic on user A
- Reopen app for user B
- Wait for 10-15 seconds for updates to come

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready
