### PR TITLE
Add probot settings

### DIFF
--- a/.github/github-bot.yml
+++ b/.github/github-bot.yml
@@ -1,0 +1,1 @@
+_extends: probot-settings


### PR DESCRIPTION
This tiny PR adds a file that references the `probot-settings` repo, for use of the GitHub bot.