### PR TITLE
[fix #2985] Show sent transaction immediatly in history

### DIFF
--- a/src/status_im/ui/screens/wallet/events.cljs
+++ b/src/status_im/ui/screens/wallet/events.cljs
@@ -124,7 +124,7 @@
   :update-transactions-success
   (fn [db [_ transactions]]
     (-> db
-        (assoc-in [:wallet :transactions] transactions)
+        (update-in [:wallet :transactions] merge transactions)
         (assoc-in [:wallet :transactions-loading?] false))))
 
 (handlers/register-handler-db

--- a/src/status_im/ui/screens/wallet/transactions/subs.cljs
+++ b/src/status_im/ui/screens/wallet/transactions/subs.cljs
@@ -144,7 +144,8 @@
                   :gas-used  (i18n/label :not-applicable)
                   :nonce     (i18n/label :not-applicable)
                   :hash      (i18n/label :not-applicable)}
-                 {:cost (money/wei->str :eth (money/fee-value gas-used gas-price))
+                 {:cost (when gas-used
+                          (money/wei->str :eth (money/fee-value gas-used gas-price)))
                   :url  (transactions/get-transaction-details-url network hash)}))))))
 
 (reg-sub :wallet.transactions.details/confirmations


### PR DESCRIPTION
fixes #2985 

### Steps to test:
- Open Status
- Send transaction and go immediatly in transaction history
- Verify that transaction is there, check transaction details
- Wait a bit and refresh transaction history
- Verify that transaction details have updated with new information available

Previous behavior:
Transaction was not visible at all in transaction history until it could be seen on etherscan

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready
