### PR TITLE
[fix #2908] 0.00 ETH is shown instead of specified amount (with comma) on Send transaction screen after /send command

### DIFF
--- a/resources/js/bots/transactor/bot.js
+++ b/resources/js/bots/transactor/bot.js
@@ -77,7 +77,7 @@ function amountParameterBox(groupChat, params, context) {
     var amountIndex = groupChat ? 1 : 0;
     
     try {
-        amount = params.args[amountIndex];
+        amount = params.args[amountIndex].replace(",", ".");
         txData = {
             to: contactAddress,
             value: web3.toWei(amount) || 0
@@ -102,7 +102,6 @@ function amountParameterBox(groupChat, params, context) {
         });
 
     } catch (err) {
-
         status.setDefaultDb({
             transaction: txData,
             calculatedFee: "0",


### PR DESCRIPTION
Fixes #2908 

### Summary

Pretty easy fix that allows to use `,` in /send command. It uses the same approach we use everywhere else — before parsing we can simply replace `,` with `.` 