### PR TITLE
Add conditions to check for core-contributors in merge PR script

### DIFF
--- a/scripts/merge-pr.sh
+++ b/scripts/merge-pr.sh
@@ -53,7 +53,9 @@ get_pr_info() {
   if [[ $(echo "$pr_info" | jq -r .state) == closed ]]; then
     fatal "PR $pr is closed, will not merge"
   fi
-  if [[ $(echo "$pr_info" | jq -r .maintainer_can_modify) == true ]]; then
+  if [[ ($(echo "$pr_info" | jq -r .maintainer_can_modify) == true) ||\
+        ($(echo "$pr_info" | jq -r .author_association) ==  MEMBER) ||\
+        ($(echo "$pr_info" | jq -r .author_association) ==  OWNER)]]; then
     RW_PR_REPO=1
   else
     warn "PR does not allow 'edits from maintainers', so it will be kept open"


### PR DESCRIPTION
### Summary:

Fix for bug referenced by @yenda in #3104 .

We need to check if the PR comes from a core contributor (author_association field set to MEMBER or OWNER) in order to rename the remote branch to `pr-<PRID>` and prevent the following error during merging:

```
remote: error: GH006: Protected branch update failed for refs/heads/develop.
remote: error: At least one approved review is required by reviewers with write access.
``` 

status: ready 