### PR TITLE
Implement status-go native methods invoking

### DIFF
--- a/.re-natal
+++ b/.re-natal
@@ -19,7 +19,8 @@
     "react-native-status",
     "react-native-autolink",
     "react-native-invertible-scroll-view",
-    "react-native-drawer-layout"
+    "react-native-drawer-layout",
+    "react-native-action-button"
   ],
   "imageDirs": [
     "resources/images",

--- a/modules/react-native-status/desktop/CMakeLists.txt
+++ b/modules/react-native-status/desktop/CMakeLists.txt
@@ -5,3 +5,9 @@ set(REACT_NATIVE_DESKTOP_EXTERNAL_MODULES_TYPE_NAMES ${REACT_NATIVE_DESKTOP_EXTE
 
 set(REACT_NATIVE_DESKTOP_EXTERNAL_MODULES_SRC ${REACT_NATIVE_DESKTOP_EXTERNAL_MODULES_SRC}
                                               ${CMAKE_CURRENT_SOURCE_DIR}/rctstatus.cpp PARENT_SCOPE)
+
+set(REACT_NATIVE_DESKTOP_EXTERNAL_MODULES_LIBS ${REACT_NATIVE_DESKTOP_EXTERNAL_MODULES_LIBS}
+                                               "/home/max/work/status-go/status-go-new/src/github.com/status-im/status-go/build/bin/libstatus.a" pthread PARENT_SCOPE)
+
+set(REACT_NATIVE_DESKTOP_EXTERNAL_MODULES_INCLUDE_DIRS ${REACT_NATIVE_DESKTOP_EXTERNAL_MODULES_INCLUDE_DIRS}
+                                               "/home/max/work/status-go/status-go-new/src/github.com/status-im/status-go/build/bin" PARENT_SCOPE)

--- a/modules/react-native-status/desktop/rctstatus.cpp
+++ b/modules/react-native-status/desktop/rctstatus.cpp
@@ -17,6 +17,8 @@
 #include <QByteArray>
 #include <QVariantMap>
 
+#include "libstatus.h"
+
 namespace {
 struct RegisterQMLMetaType {
     RegisterQMLMetaType() {
@@ -55,6 +57,8 @@ void RCTStatus::initJail(QString js, double callbackId) {
     Q_D(RCTStatus);
     qDebug() << "call of RCTStatus::initJail with param js:" << " and callback id: " << callbackId;
 
+    InitJail(js.toUtf8().data());
+
     d->bridge->invokePromiseCallback(callbackId, QVariantList{ "{\"result\":\"\"}" });
 }
 
@@ -62,36 +66,61 @@ void RCTStatus::initJail(QString js, double callbackId) {
 void RCTStatus::parseJail(QString chatId, QString js, double callbackId) {
     Q_D(RCTStatus);
     qDebug() << "call of RCTStatus::parseJail with param chatId: " << chatId << " js:" << " and callback id: " << callbackId;
-    if (chatId == "console") {
-        QString response = "{\"result\":\"{\\\"commands\\\":{\\\"phone,50\\\":{\\\"name\\\":\\\"phone\\\",\\\"title\\\":\\\"Send Phone Number\\\",\\\"description\\\":\\\"Find friends using your number\\\",\\\"has-handler\\\":true,\\\"async-handler\\\":false,\\\"color\\\":\\\"#5bb2a2\\\",\\\"icon\\\":\\\"phone_white\\\",\\\"params\\\":[{\\\"name\\\":\\\"phone\\\",\\\"type\\\":\\\"phone\\\",\\\"placeholder\\\":\\\"Phone number\\\"}],\\\"sequential-params\\\":true,\\\"scope\\\":[\\\"personal-chats\\\",\\\"registered\\\",\\\"dapps\\\"],\\\"scope-bitmask\\\":50},\\\"faucet,50\\\":{\\\"name\\\":\\\"faucet\\\",\\\"title\\\":\\\"Faucet\\\",\\\"description\\\":\\\"Get some ETH\\\",\\\"has-handler\\\":true,\\\"async-handler\\\":false,\\\"color\\\":\\\"#7099e6\\\",\\\"params\\\":[{\\\"name\\\":\\\"url\\\",\\\"type\\\":\\\"text\\\",\\\"placeholder\\\":\\\"Faucet URL\\\"}],\\\"scope\\\":[\\\"personal-chats\\\",\\\"registered\\\",\\\"dapps\\\"],\\\"scope-bitmask\\\":50},\\\"debug,50\\\":{\\\"name\\\":\\\"debug\\\",\\\"title\\\":\\\"Debug mode\\\",\\\"description\\\":\\\"Starts\\/stops a debug mode\\\",\\\"has-handler\\\":true,\\\"async-handler\\\":false,\\\"color\\\":\\\"#7099e6\\\",\\\"params\\\":[{\\\"name\\\":\\\"mode\\\",\\\"type\\\":\\\"text\\\"}],\\\"scope\\\":[\\\"personal-chats\\\",\\\"registered\\\",\\\"dapps\\\"],\\\"scope-bitmask\\\":50}},\\\"responses\\\":{\\\"phone,50\\\":{\\\"name\\\":\\\"phone\\\",\\\"title\\\":\\\"Send Phone Number\\\",\\\"description\\\":\\\"Find friends using your number\\\",\\\"has-handler\\\":true,\\\"async-handler\\\":false,\\\"color\\\":\\\"#5bb2a2\\\",\\\"icon\\\":\\\"phone_white\\\",\\\"params\\\":[{\\\"name\\\":\\\"phone\\\",\\\"type\\\":\\\"phone\\\",\\\"placeholder\\\":\\\"Phone number\\\"}],\\\"sequential-params\\\":true,\\\"scope\\\":[\\\"personal-chats\\\",\\\"registered\\\",\\\"dapps\\\"],\\\"scope-bitmask\\\":50},\\\"confirmation-code,50\\\":{\\\"name\\\":\\\"confirmation-code\\\",\\\"description\\\":\\\"Confirmation code\\\",\\\"has-handler\\\":true,\\\"async-handler\\\":false,\\\"color\\\":\\\"#7099e6\\\",\\\"params\\\":[{\\\"name\\\":\\\"code\\\",\\\"type\\\":\\\"number\\\"}],\\\"sequential-params\\\":true,\\\"scope\\\":[\\\"personal-chats\\\",\\\"registered\\\",\\\"dapps\\\"],\\\"scope-bitmask\\\":50},\\\"password,42\\\":{\\\"name\\\":\\\"password\\\",\\\"description\\\":\\\"Password\\\",\\\"has-handler\\\":true,\\\"async-handler\\\":false,\\\"color\\\":\\\"#7099e6\\\",\\\"icon\\\":\\\"lock_white\\\",\\\"params\\\":[{\\\"name\\\":\\\"password\\\",\\\"type\\\":\\\"password\\\",\\\"placeholder\\\":\\\"Type your password\\\",\\\"hidden\\\":true},{\\\"name\\\":\\\"password-confirmation\\\",\\\"type\\\":\\\"password\\\",\\\"placeholder\\\":\\\"Confirm\\\",\\\"hidden\\\":true}],\\\"sequential-params\\\":true,\\\"scope\\\":[\\\"personal-chats\\\",\\\"anonymous\\\",\\\"dapps\\\"],\\\"scope-bitmask\\\":42},\\\"grant-permissions,58\\\":{\\\"name\\\":\\\"grant-permissions\\\",\\\"description\\\":\\\"Grant permissions\\\",\\\"has-handler\\\":true,\\\"async-handler\\\":false,\\\"color\\\":\\\"#7099e6\\\",\\\"icon\\\":\\\"lock_white\\\",\\\"params\\\":[],\\\"execute-immediately?\\\":true,\\\"scope\\\":[\\\"personal-chats\\\",\\\"anonymous\\\",\\\"registered\\\",\\\"dapps\\\"],\\\"scope-bitmask\\\":58}},\\\"functions\\\":{},\\\"subscriptions\\\":{}}\"}";
-        d->bridge->invokePromiseCallback(callbackId, QVariantList{response});
-    } else {
-        d->bridge->invokePromiseCallback(callbackId, QVariantList{ "{\"result\":\"\"}" });
-    }
+
+    const char* result = Parse(chatId.toUtf8().data(), js.toUtf8().data());
+    qDebug() << "RCTStatus::parseJail parseJail result: " << result;
+    d->bridge->invokePromiseCallback(callbackId, QVariantList{result});
 }
 
 
 void RCTStatus::callJail(QString chatId, QString path, QString params, double callbackId) {
     Q_D(RCTStatus);
-    
     qDebug() << "call of RCTStatus::callJail with param chatId: " << chatId << " path: " << path << " params: " << params <<  " and callback id: " << callbackId;
-    if (path == "[\"commands\",[\"password\",null],\"preview\"]") {
-        qDebug() << "Password preview";
 
-        QString response = "{ \"result\":\
-                              { \"context\":{},\"messages\":[], \"returned\":\
-                                                                  {\"markup\":[\"text\", {\"style\":{\"color\":\"black\", \"fontSize\":8, \"letterSpacing\":1, \"marginTop\":10}}, \"aaaa\"]}\
-                               }}";
-         d->bridge->invokePromiseCallback(callbackId, QVariantList{response});
-    } else {
-        d->bridge->invokePromiseCallback(callbackId, QVariantList{ "{\"result\":\"\"}" });
-    }
+    const char* result = Call(chatId.toUtf8().data(), path.toUtf8().data(), params.toUtf8().data());
+    qDebug() << "RCTStatus::callJail callJail result: " << result;
+    d->bridge->invokePromiseCallback(callbackId, QVariantList{result});
 }
 
 
 void RCTStatus::startNode(QString configString) {
     Q_D(RCTStatus);
     qDebug() << "call of RCTStatus::startNode with param configString:" << configString;
+
+    QJsonParseError jsonError;
+    QJsonDocument jsonDoc = QJsonDocument::fromJson(configString.toUtf8(), &jsonError);
+    if (jsonError.error != QJsonParseError::NoError){
+        qDebug() << jsonError.errorString();
+    }
+
+    qDebug() << " RCTStatus::startNode configString: " << jsonDoc.toVariant().toMap();
+    QVariantMap configJSON = jsonDoc.toVariant().toMap();
+
+    QString newKeystoreUrl = "keystore";
+
+    int networkId = configJSON["NetworkId"].toInt();
+    QString dataDir = configJSON["DataDir"].toString();
+
+    QString networkDir = "./" + dataDir;
+    int dev = 0;
+
+    char *configChars = GenerateConfig(networkDir.toUtf8().data(), networkId, dev);
+    qDebug() << "RCTStatus::startNode GenerateConfig result: " << configChars;
+
+    jsonDoc = QJsonDocument::fromJson(QString(configChars).toUtf8(), &jsonError);
+    if (jsonError.error != QJsonParseError::NoError){
+        qDebug() << jsonError.errorString();
+    }
+
+    qDebug() << " RCTStatus::startNode GenerateConfig configString: " << jsonDoc.toVariant().toMap();
+    QVariantMap generatedConfig = jsonDoc.toVariant().toMap();
+    generatedConfig["KeyStoreDir"] = newKeystoreUrl;
+    generatedConfig["LogEnabled"] = "1";
+    generatedConfig["LogFile"] = networkDir + "/geth.log";
+    //generatedConfig["LogLevel"] = "DEBUG";
+
+    const char* result = StartNode(QString(QJsonDocument::fromVariant(generatedConfig).toJson(QJsonDocument::Compact)).toUtf8().data());
+    qDebug() << "RCTStatus::startNode StartNode result: " << result;
 
     d->bridge->eventDispatcher()->sendDeviceEvent("gethEvent", QVariantMap{{"jsonEvent", "{\"type\":\"node.started\"}"}});
     d->bridge->eventDispatcher()->sendDeviceEvent("gethEvent", QVariantMap{{"jsonEvent", "{\"type\":\"node.ready\"}"}});
@@ -113,55 +142,69 @@ void RCTStatus::moveToInternalStorage(double callbackId) {
 
 
 void RCTStatus::stopNode() {
+    qDebug() << "call of RCTStatus::stopNode";
+    const char* result = StopNode();
+    qDebug() << "RCTStatus::stopNode StopNode result: " << result;
 }
 
 
 void RCTStatus::createAccount(QString password, double callbackId) {
     Q_D(RCTStatus);
     qDebug() << "call of RCTStatus::createAccount with param callbackId: " << callbackId;
-    d->bridge->invokePromiseCallback(callbackId, QVariantList{ "{\"result\":\"\"}" });
+    const char* result = CreateAccount(password.toUtf8().data());
+    qDebug() << "RCTStatus::createAccount CreateAccount result: " << result;
+    d->bridge->invokePromiseCallback(callbackId, QVariantList{result});
 }
 
 
 void RCTStatus::notify(QString token, double callbackId) {
     Q_D(RCTStatus);
     qDebug() << "call of RCTStatus::notify with param callbackId: " << callbackId;
-    d->bridge->invokePromiseCallback(callbackId, QVariantList{ "{\"result\":\"\"}" });
+    const char* result = Notify(token.toUtf8().data());
+    qDebug() << "RCTStatus::notify Notify result: " << result;
+    d->bridge->invokePromiseCallback(callbackId, QVariantList{result});
 }
 
 
 void RCTStatus::addPeer(QString enode, double callbackId) {
     Q_D(RCTStatus);
     qDebug() << "call of RCTStatus::addPeer with param callbackId: " << callbackId;
-    d->bridge->invokePromiseCallback(callbackId, QVariantList{ "{\"result\":\"\"}" });
+    const char* result = AddPeer(enode.toUtf8().data());
+    qDebug() << "RCTStatus::addPeer AddPeer result: " << result;
+    d->bridge->invokePromiseCallback(callbackId, QVariantList{result});
 }
 
 
 void RCTStatus::recoverAccount(QString passphrase, QString password, double callbackId) {
     Q_D(RCTStatus);
     qDebug() << "call of RCTStatus::recoverAccount with param callbackId: " << callbackId;
-    d->bridge->invokePromiseCallback(callbackId, QVariantList{ "{\"result\":\"\"}" });
+    const char* result = RecoverAccount(password.toUtf8().data(), passphrase.toUtf8().data());
+    qDebug() << "RCTStatus::recoverAccount RecoverAccount result: " << result;
+    d->bridge->invokePromiseCallback(callbackId, QVariantList{result});
 }
 
 
 void RCTStatus::login(QString address, QString password, double callbackId) {
     Q_D(RCTStatus);
     qDebug() << "call of RCTStatus::login with param callbackId: " << callbackId;
-    d->bridge->invokePromiseCallback(callbackId, QVariantList{ "{\"result\":\"\"}" });
+    const char* result = Login(address.toUtf8().data(), password.toUtf8().data());
+    qDebug() << "RCTStatus::login Login result: " << result;
+    d->bridge->invokePromiseCallback(callbackId, QVariantList{result});
 }
 
 
 void RCTStatus::completeTransactions(QString hashes, QString password, double callbackId) {
     Q_D(RCTStatus);
     qDebug() << "call of RCTStatus::completeTransactions with param callbackId: " << callbackId;
-    d->bridge->invokePromiseCallback(callbackId, QVariantList{ "{\"result\":\"\"}" });
+    const char* result = CompleteTransactions(hashes.toUtf8().data(), password.toUtf8().data());
+    qDebug() << "RCTStatus::completeTransactions CompleteTransactions result: " << result;
+    d->bridge->invokePromiseCallback(callbackId, QVariantList{result});
 }
-
 
 void RCTStatus::discardTransaction(QString id) {
+    qDebug() << "call of RCTStatus::discardTransaction with id: " << id;
+    DiscardTransaction(id.toUtf8().data());
 }
-
-
 
 void RCTStatus::setAdjustResize() {
 }
@@ -192,6 +235,23 @@ void RCTStatus::sendWeb3Request(QString payload, double callbackId) {
 
 
 void RCTStatus::closeApplication() {
+}
+
+bool RCTStatus::JSCEnabled()
+{
+    qDebug() << "call of RCTStatus::JSCEnabled";
+    return false;
+}
+
+void RCTStatus::signalEvent(const char* signal)
+{
+    qDebug() << "call of RCTStatus::signalEvent ... signal: " << signal;
+
+}
+
+void RCTStatus::jailEvent(QString chatId, QString data)
+{
+    qDebug() << "call of RCTStatus::jailEvent ... chatId: " << chatId << " data: " << data;
 }
 
 

--- a/modules/react-native-status/desktop/rctstatus.h
+++ b/modules/react-native-status/desktop/rctstatus.h
@@ -56,6 +56,10 @@ public:
     Q_INVOKABLE void sendWeb3Request(QString payload, double callbackId);
     Q_INVOKABLE void closeApplication();
 
+    Q_INVOKABLE static bool JSCEnabled();
+    Q_INVOKABLE static void signalEvent(const char* signal);
+    Q_INVOKABLE static void jailEvent(QString chatId, QString data);
+
 private:
     QScopedPointer<RCTStatusPrivate> d_ptr;
 };

--- a/react-native/src/status_im/react_native/js_dependencies.cljs
+++ b/react-native/src/status_im/react_native/js_dependencies.cljs
@@ -1,6 +1,6 @@
 (ns status-im.react-native.js-dependencies)
 
-(def action-button          "");;(js/require "react-native-action-button"))
+(def action-button          (js/require "react-native-action-button"))
 (def android-sms-listener   "");;(js/require "react-native-android-sms-listener"))
 (def autolink               (js/require "react-native-autolink"))
 (def camera                 "");;(js/require "react-native-camera"))

--- a/src/status_im/chat/events.cljs
+++ b/src/status_im/chat/events.cljs
@@ -155,7 +155,6 @@
 
 (defn init-console-chat
   [{:keys [chats] :accounts/keys [current-account-id] :as db}]
-  (print "init-console-chat call. chats:"chats" db:"db)
   (if (and chats (chats const/console-chat-id))
     {:db db}
     (cond-> {:db (-> db
@@ -174,7 +173,6 @@
 (handlers/register-handler-fx
   :init-console-chat
   (fn [{:keys [db]} _]
-    (print "register-handler-fx before call of init-console-chat")
     (init-console-chat db)))
 
 (handlers/register-handler-fx
@@ -190,7 +188,6 @@
                stored-unviewed-messages
                get-last-stored-message
                message-previews]} _]
-    (print "call :initialize-chats db:"db)
     (let [{:accounts/keys [account-creation?] :contacts/keys [contacts]} db
           new-db (unviewed-messages-model/load-unviewed-messages db stored-unviewed-messages)
           event  [:load-default-contacts!]]
@@ -210,7 +207,6 @@
           (-> new-db
               (assoc-in [:message-data :preview] message-previews) 
               (assoc :chats chats)
-              (print "before call of init-console-chat from :initialize-chats")
               init-console-chat
               (update :dispatch-n conj event)))))))
 

--- a/src/status_im/chat/handlers/send_message.cljs
+++ b/src/status_im/chat/handlers/send_message.cljs
@@ -173,7 +173,7 @@
                           {:message-id   (random/id)
                            :chat-id      chat-id
                            :content      message
-                           :from         "c9f5c0e2bea0aabb6b0b618e9f45ab095811111"
+                           :from         identity
                            :content-type text-content-type
                            :outgoing     true
                            :timestamp    (datetime/now-ms)

--- a/src/status_im/chat/styles/input/input.cljs
+++ b/src/status_im/chat/styles/input/input.cljs
@@ -47,7 +47,8 @@
    :padding-left     10
    :padding-right    10
    :android          {:border-radius 4}
-   :ios              {:border-radius 8}})
+   :ios              {:border-radius 8}
+   :desktop          {:border-radius 8}})
 
 (defnstyle input-touch-handler-view [container-width]
   {:position :absolute
@@ -93,6 +94,8 @@
    :android             {:left (+ 15 left)
                          :top  -1}
    :ios                 {:line-height min-input-height
+                         :left        (+ 10 left)}
+   :desktop             {:line-height min-input-height
                          :left        (+ 10 left)}})
 
 (defnstyle seq-input-text [left container-width]
@@ -105,6 +108,8 @@
    :android             {:left (+ 10 left)
                          :top  0.5}
    :ios                 {:line-height min-input-height
+                         :left        (+ 9 left)}
+   :desktop             {:line-height min-input-height
                          :left        (+ 9 left)}})
 
 (def input-emoji-icon

--- a/src/status_im/commands/events/loading.cljs
+++ b/src/status_im/commands/events/loading.cljs
@@ -27,10 +27,9 @@
        jail-id jail-resource
        (fn [jail-response]
          (let [converted (types/json->clj jail-response)]
-           (re-frame/dispatch [::proceed-loading jail-id (update converted :result types/json->clj)])))))))
-           ;(re-frame/dispatch [::proceed-loading jail-id (if config/jsc-enabled?
-           ;                                                (update converted :result types/json->clj)
-           ;                                                converted)])))))))
+           (re-frame/dispatch [::proceed-loading jail-id (if config/jsc-enabled?
+                                                           (update converted :result types/json->clj)
+                                                           converted)])))))))
 
 (re-frame/reg-fx
   ::show-popup

--- a/src/status_im/core.cljs
+++ b/src/status_im/core.cljs
@@ -12,6 +12,5 @@
   (log/set-level! :debug)
   ;;(error-handler/register-exception-handler!)
   (status/init-jail)
-  (print "status-im.core init call")
   (.registerComponent react/app-registry "StatusIm" #(reagent/reactify-component app-root))
   (re-frame/dispatch-sync [:initialize-app]))

--- a/src/status_im/ui/components/icons/vector_icons.cljs
+++ b/src/status_im/ui/components/icons/vector_icons.cljs
@@ -64,7 +64,6 @@
   ([name] (icon name nil))
   ([name {:keys [color container-style style accessibility-label]
           :or {accessibility-label :icon}}]
-   (print "Icon")
    [react/view {:style               container-style
                 :accessibility-label accessibility-label}
     [react/image {:source (get icons (normalize-property-name name))

--- a/src/status_im/ui/components/react.cljs
+++ b/src/status_im/ui/components/react.cljs
@@ -196,5 +196,3 @@
 ;; Emoji
 
 ;;(def emojilib (js/require "emojilib"))
-
-(print "----react.cljs is loaded")

--- a/src/status_im/ui/screens/events.cljs
+++ b/src/status_im/ui/screens/events.cljs
@@ -240,8 +240,7 @@
                          :network-status network-status
                          :status-module-initialized? (or platform/ios? js/goog.DEBUG status-module-initialized?)
                          :status-node-started? status-node-started?
-                         :network network)}
-    (print ":initialize-db call")))
+                         :network network)}))
 
 (register-handler-db
   :initialize-account-db
@@ -252,7 +251,6 @@
         :or [network (get app-db :network)]
         :as db} [_ address]]
     (let [console-contact (get contacts console-chat-id)]
-      (print "call of :initialize-account-db address: "address)
       (cond-> (assoc app-db 
                      :access-scope->commands-responses access-scope->commands-responses
                      :accounts/current-account-id address
@@ -300,7 +298,6 @@
     (let [view (if (empty? accounts)
                  :chat
                  :accounts)]
-      (print ":check-console-chat call")
       (merge
        {:db (assoc db
                    :view-id view


### PR DESCRIPTION
- react-native-status module invokes C status-go methods. Path to libstatus.a and libstatus.h is hardcoded and should be adjusted manually.
- Status-go `libstatus.lib` should be pre-built
- react-native-status doesn't emit geth node events at this moment. It just generates fake node.started and node.ready events after startNode() is executed. 

Instructions to build static status-go C library at Ubuntu (similar should work for OS X as well):

1. Download and unpack latest golang version. Move the files to /usr/local. So you will have /usr/local/go (https://tecadmin.net/install-go-on-ubuntu)
2. Set GOROOT to /usr/local/go
3. cd to folder where the status-go sources will be copied later in. Set this folder as $GOPATH
4. Copy status-go sources root directory content into new created folder $GOPATH/src/github.com/status-im/status-go/status-go
5. Add GOROOT and GOPATH to the PATH
6. Install go dependency by cd to $GOPATH/src/github.com/status-im/status-go/status-go/lib and running "go get ./"
7. cd to $GOPATH/src/github.com/status-im/status-go/status-go and build binaries with make command. For example, "make statusgo"