### PR TITLE
[Fix #3172] Can return to Home after log out if tap device back button

### DIFF
--- a/src/status_im/ui/screens/profile/views.cljs
+++ b/src/status_im/ui/screens/profile/views.cljs
@@ -238,7 +238,7 @@
 (defn navigate-to-accounts []
   ;; TODO(rasom): probably not the best place for this call
   (protocol/stop-whisper!)
-  (re-frame/dispatch [:navigate-to :accounts]))
+  (re-frame/dispatch [:navigate-to-clean :accounts]))
 
 (defn handle-logout []
   (utils/show-confirmation (i18n/label :t/logout-title)


### PR DESCRIPTION
fixes #3172

Summary: After user taps on log out it's still possible to return to Home and see chats if tap on device back button. It should not be possible. To see Home tab user needs to log in again

status: ready <!-- Can be ready or wip -->
