### PR TITLE
scripts/setup: Fix call to mvn

### DIFF
--- a/scripts/setup
+++ b/scripts/setup
@@ -46,7 +46,7 @@ dependency_setup ./re-natal deps
 dependency_setup ./re-natal enable-source-maps
 
 dependency_setup \
-  "mvn -f modules/react-native-status/ios/RCTStatus dependency:unpack"
+  "mvn -f modules/react-native-status/ios/RCTStatus/pom.xml dependency:unpack"
 
 using_cocoapods && dependency_setup "cd ios && pod install && cd .."
 


### PR DESCRIPTION
Running Apache Maven 3.0.5 like this:

mvn -f modules/react-native-status/ios/RCTStatus dependency:unpack
errors:

[ERROR]   The project  (/home/oleh/git/status-react/modules/react-native-status/ios/RCTStatus) has 1 error
[ERROR]     Non-readable POM /home/oleh/git/status-react/modules/react-native-status/ios/RCTStatus: /home/oleh/git/status-react/modules/react-native-status/ios/RCTStatus (Is a directory)
The obvious fix is to pass -f flag the pom file, just like it says in the manpages:

mvn -f modules/react-native-status/ios/RCTStatus/pom.xml dependency:unpack
This works as expected:

[INFO] BUILD SUCCESS