### PR TITLE
scripts/lib/setup/output.sh: Fix broken link to react-native docs

### DIFF
--- a/scripts/lib/setup/output.sh
+++ b/scripts/lib/setup/output.sh
@@ -67,7 +67,7 @@ There are a few @b[[manual steps]] you might want to do:
 
 2. Setup Android Development Environment + Simulator:
 
-    @blue[[https://facebook.github.io/react-native/docs/android-setup.html]]
+    @blue[[https://facebook.github.io/react-native/docs/getting-started.html]]
 
 3. Add your SSH public key to Github if it isn't already in there.
 "


### PR DESCRIPTION
DevelopmentSetupAndroid.md was removed from react-native docs around 2 years ago.
