### PR TITLE
Format translations

### DIFF
--- a/src/status_im/translations/af.cljs
+++ b/src/status_im/translations/af.cljs
@@ -2,17 +2,17 @@
 
 (def translations
   {
-   ;common
+   ;;common
    :members-title                         "lede"
    :not-implemented                       "!nie geimplimenteer nie"
    :chat-name                             "Bynaam"
    :notifications-title                   "Kennisgewings en klanke"
    :offline                               "Aflyn"
 
-   ;drawer
+   ;;drawer
    :switch-users                          "Verander gebruikers"
 
-   ;chat
+   ;;chat
    :is-typing                             "is besig om te tik"
    :and-you                               "en jy"
    :search-chat                           "Deursoek geselsies"
@@ -29,11 +29,11 @@
    :suggestions-requests                  "Versoeke"
    :suggestions-commands                  "Opdragte"
 
-   ;sync
+   ;;sync
    :sync-in-progress                      "Besig om te sinchroniseer..."
    :sync-synced                           "gesinchroniseer"
 
-   ;messages
+   ;;messages
    :status-sending                        "Besig om te stuur"
    :status-pending                        "Hangende"
    :status-sent                           "Gestuur"
@@ -42,7 +42,7 @@
    :status-delivered                      "Afgelewer"
    :status-failed                         "Gefaal"
 
-   ;datetime
+   ;;datetime
    :datetime-second                       {:one   "sekonde"
                                            :other "sekondes"}
    :datetime-minute                       {:one   "minuut"
@@ -55,7 +55,7 @@
    :datetime-yesterday                    "gister"
    :datetime-today                        "vandag"
 
-   ;profile
+   ;;profile
    :profile                               "Profiel"
    :message                               "Boodskap"
    :not-specified                         "Nie gespesifiseer nie"
@@ -68,7 +68,7 @@
    :image-source-make-photo               "Opname"
    :image-source-gallery                  "Kies uit galery"
 
-   ;sign-up
+   ;;sign-up
    :contacts-syncronized                  "U kontakte is gesinchroniseer"
    :confirmation-code                     (str "Dankie! Ons het vir u 'n SMS gestuur met 'n bevestigings "
                                                "kode. Verskaf asseblief daardie kode om u telefoonnommer te bevestig")
@@ -80,11 +80,11 @@
    :intro-message1                        "Welkom by Status\nTik tik hierdie boodskap om jou wagwoord te stel & laat ons begin!"
    :account-generation-message            "Net 'n oomblik, ek moet mal somme doen om jou rekening te skep!"
 
-   ;chats
+   ;;chats
    :chats                                 "Geselsies"
    :new-group-chat                        "Nuwe groepgeselsie"
 
-   ;discover
+   ;;discover
    :discover                              "Ontdekking"
    :none                                  "Geen"
    :search-tags                           "Tik jou soek-oortjies hier in"
@@ -92,17 +92,17 @@
    :recent                                "Onlangs"
    :no-statuses-discovered                "Geen statusse gevind nie"
 
-   ;settings
+   ;;settings
    :settings                              "Stellings"
 
-   ;contacts
+   ;;contacts
    :contacts                              "Kontakte"
    :new-contact                           "Nuwe kontak"
    :contacts-group-new-chat               "Begin nuwe geselsie"
    :no-contacts                           "Nog geen kontakte nie"
    :show-qr                               "Wys QR"
 
-   ;group-settings
+   ;;group-settings
    :remove                                "Verwyder"
    :save                                  "Stoor"
    :clear-history                         "Maak geskiedenis skoon"
@@ -110,14 +110,14 @@
    :edit                                  "Wysig"
    :add-members                           "Voeg lede by"
 
-   ;commands
+   ;;commands
    :chat-send-eth                         "{{amount}} ETH"
 
-   ;new-group
+   ;;new-group
 
-   ;participants
+   ;;participants
 
-   ;protocol
+   ;;protocol
    :received-invitation                   "geselsie-uitnodiging ontvang"
    :removed-from-chat                     "het jou van groepsgeselsie verwyder"
    :left                                  "uitgegaan"
@@ -125,7 +125,7 @@
    :removed                               "verwyder"
    :You                                   "Jou"
 
-   ;new-contact
+   ;;new-contact
    :add-new-contact                       "Voeg nuwe kontak by"
    :scan-qr                               "Skandeer QR"
    :name                                  "Naam"
@@ -135,31 +135,31 @@
    :unknown-address                       "Onbekende adres"
 
 
-   ;login
+   ;;login
    :connect                               "Konnekteer"
    :address                               "Adres"
    :password                              "Wagwoord"
    :wrong-password                        "Verkeerde wagwoord"
 
-   ;recover
+   ;;recover
    :passphrase                            "Tydelike wagwoord"
    :recover                               "Herstel"
 
-   ;accounts
+   ;;accounts
    :recover-access                        "Herwin toegang"
 
-   ;wallet-qr-code
+   ;;wallet-qr-code
    :done                                  "Gedoen"
    :main-wallet                           "Hoofbeursie"
 
-   ;validation
+   ;;validation
    :invalid-phone                         "Ongeldige telefoonnommer"
    :amount                                "Bedrag"
-   ;transactions
+   ;;transactions
    :status                                "Status"
    :recipient                             "Ontvanger"
 
-   ;:webview
+   ;;:webview
    :web-view-error                        "oepsie, fout"
 
    :confirm                               "Bevestig"

--- a/src/status_im/translations/ar.cljs
+++ b/src/status_im/translations/ar.cljs
@@ -2,17 +2,17 @@
 
 (def translations
   {
-   ;common
+   ;;common
    :members-title                         "الأعضاء"
    :not-implemented                       "!غير مُطَبّق"
    :chat-name                             "اسم الدردشة"
    :notifications-title                   "الإخطارات والأصوات"
    :offline                               "غير متصل"
 
-   ;drawer
+   ;;drawer
    :switch-users                          "التبديل بين المستخدمين"
 
-   ;chat
+   ;;chat
    :is-typing                             "يكتب"
    :and-you                               "وأنت أيضاً"
    :search-chat                           "البحث في الدردشة"
@@ -29,11 +29,11 @@
    :suggestions-requests                  "الطلبات"
    :suggestions-commands                  "الأوامر"
 
-   ;sync
+   ;;sync
    :sync-in-progress                      "قيد المزامنة..."
    :sync-synced                           "بالتزامن"
 
-   ;messages
+   ;;messages
    :status-sending                        "إرسال"
    :status-pending                        "ريثما"
    :status-sent                           "تم الإرسال"
@@ -42,7 +42,7 @@
    :status-delivered                      "تم الاستلام"
    :status-failed                         "فشل"
 
-   ;datetime
+   ;;datetime
    :datetime-second                       {:one   "ثانية"
                                            :other "ثوان"}
    :datetime-minute                       {:one   "دقيقة"
@@ -55,7 +55,7 @@
    :datetime-yesterday                    "الأمس"
    :datetime-today                        "اليوم"
 
-   ;profile
+   ;;profile
    :profile                               "الملف الشخصي"
    :message                               "الرسالة"
    :not-specified                         "غير محدد"
@@ -68,7 +68,7 @@
    :image-source-make-photo               "التقاط صورة"
    :image-source-gallery                  "الاختيار من معرض الصور"
 
-   ;sign-up
+   ;;sign-up
    :contacts-syncronized                  "تمت مزامنة جهات الاتصال الخاصة بك"
    :confirmation-code                     (str "شكراً! لقد أرسلنا لك رسالة نصية تتضمن رمز تأكيد"
                                                "يرجى إدخال هذا الرمز لتأكيد رقم هاتفك")
@@ -80,11 +80,11 @@
    :intro-message1                        "مرحبا بك في Status \n اضغط على هذه الرسالة لتعيين كلمة المرور الخاصة بك وابدأ!"
    :account-generation-message            "امنحني ثانية واحدة، سوف أحتاج إلى إجراء بعض الحسابات الرياضية المجنونة لإنتاج الحساب الخاص بك!"
 
-   ;chats
+   ;;chats
    :chats                                 "الدردشات"
    :new-group-chat                        "مجموعة دردشة جديدة"
 
-   ;discover
+   ;;discover
    :discover                             "اكتشاف"
    :none                                  "لا شيء"
    :search-tags                           "اكتب بيانات بحثك هنا"
@@ -92,17 +92,17 @@
    :recent                                "حديثة"
    :no-statuses-discovered                "لم يتم الكشف عن حالات"
 
-   ;settings
+   ;;settings
    :settings                              "الإعدادات"
 
-   ;contacts
+   ;;contacts
    :contacts                              "جهات الاتصال"
    :new-contact                           "جهة اتصال جديدة"
    :contacts-group-new-chat               "ابدأ دردشة جديدة"
    :no-contacts                           "لا توجد جهات اتصال بعد"
    :show-qr                               "عرض شفرة التعريف"
 
-   ;group-settings
+   ;;group-settings
    :remove                                "إزالة"
    :save                                  "حفظ"
    :clear-history                         "حذف التاريخ"
@@ -110,14 +110,14 @@
    :edit                                  "تحرير"
    :add-members                           "إضافة أعضاء"
 
-   ;commands
+   ;;commands
    :chat-send-eth                         "{{amount}} ETH"
 
-   ;new-group
+   ;;new-group
 
-   ;participants
+   ;;participants
 
-   ;protocol
+   ;;protocol
    :received-invitation                   "تسلم دعوة الدردشة"
    :removed-from-chat                     "قام بإزالتك من مجموعة الدردشة"
    :left                                  "غادر"
@@ -125,7 +125,7 @@
    :removed                               "مُسْتَبْعَد"
    :You                                   "أنت"
 
-   ;new-contact
+   ;;new-contact
    :add-new-contact                       "إضافة جهة اتصال جديدة"
    :scan-qr                               "مسح شفرة التعريف"
    :name                                  "اسم"
@@ -135,29 +135,29 @@
    :unknown-address                       "عنوان غير معروف"
 
 
-   ;login
+   ;;login
    :connect                               "اتصال"
    :address                               "عنوان"
    :password                              "كلمة مرور"
    :wrong-password                        "كلمة مرور خاطئة"
 
-   ;recover
+   ;;recover
    :passphrase                            "عبارة المرور"
    :recover                               "استعادة"
 
-   ;accounts
+   ;;accounts
    :recover-access                        "استعادة إمكانية الوصول"
 
-   ;wallet-qr-code
+   ;;wallet-qr-code
    :done                                  "تم التنفيذ"
    :main-wallet                           "المحفظة الرئيسية"
 
-   ;validation
+   ;;validation
    :invalid-phone                         "رقم هاتف غير صحيح"
    :amount                                "الكمية"
-   ;transactions
+   ;;transactions
    :status                                "الحالة"
    :recipient                             "المستلم"
 
-   ;:webview
+   ;;:webview
    :web-view-error                        "عفواً، حدث خطأ ما"})

--- a/src/status_im/translations/bel.cljs
+++ b/src/status_im/translations/bel.cljs
@@ -2,7 +2,7 @@
 
 (def translations
   {
-   ;common
+   ;;common
    :members-title                         "Удзельнікі"
    :not-implemented                       "!не рэалізавана"
    :chat-name                             "Імя чата"
@@ -11,10 +11,10 @@
    :cancel                                "Адмена"
    :next                                  "Працягнуць"
 
-   ;drawer
+   ;;drawer
    :switch-users                          "Пераключыць карыстальнікау"
 
-   ;chat
+   ;;chat
    :is-typing                             "друкуе"
    :and-you                               "і вы"
    :search-chat                           "Пошук па чату"
@@ -31,11 +31,11 @@
    :suggestions-requests                  "Запыты"
    :suggestions-commands                  "Каманды"
 
-   ;sync
+   ;;sync
    :sync-in-progress                      "Сінхранізацыя..."
    :sync-synced                           "Сінхранізуецца"
 
-   ;messages
+   ;;messages
    :status-sending                        "Адпраўляецца"
    :status-pending                        "у чаканні"
    :status-sent                           "Адправіць"
@@ -44,7 +44,7 @@
    :status-delivered                      "Дастаўлена"
    :status-failed                         "Памылка"
 
-   ;datetime
+   ;;datetime
    :datetime-second                       {:one   "секунда"
                                            :other "секунды"}
    :datetime-minute                       {:one   "хвіліна"
@@ -57,7 +57,7 @@
    :datetime-yesterday                    "учора"
    :datetime-today                        "сёння"
 
-   ;profile
+   ;;profile
    :profile                               "Профіль"
    :message                               "Паведамленне"
    :not-specified                         "Не пазначана"
@@ -75,7 +75,7 @@
    :sharing-share                         "Падзяліцца..."
    :sharing-cancel                        "Адмена"
 
-   ;sign-up
+   ;;sign-up
    :contacts-syncronized                  "Вашы кантакты сінхранізаваныя"
    :confirmation-code                     (str "Дзякуй! Мы адправілі вам СМС з кодам пацверджання."
                                                "Калі ласка, увядзіце гэты код для пацвярджэння свайго нумара тэлефона")
@@ -89,11 +89,11 @@
    :intro-message1                        "Сардэчна запрашаем у Статус\nНацісніце на гэтае паведамленне, каб усталяваць пароль і пачаць!"
    :account-generation-message            "Секундачку, мне трэба выканаць вар'яцка складаныя разлікі для стварэння вашага акаўнта!"
 
-   ;chats
+   ;;chats
    :chats                                 "Чаты"
    :new-group-chat                        "Новы групавы чат"
 
-   ;discover
+   ;;discover
    :discover                             "Пошук"
    :none                                  "Няма"
    :search-tags                           "Увядзіце тэгі для пошуку сюды"
@@ -101,10 +101,10 @@
    :recent                                "Апошнія"
    :no-statuses-discovered                "Статусы не выяўлены"
 
-   ;settings
+   ;;settings
    :settings                              "Налады"
 
-   ;contacts
+   ;;contacts
    :contacts                              "Кантакты"
    :new-contact                           "Новы кантакт"
    :edit-contacts                         "Рэдагаванне кантактаў"
@@ -113,7 +113,7 @@
    :show-qr                               "Паказаць QR"
    :enter-address                         "Ўвесці адрас"
 
-   ;group-settings
+   ;;group-settings
    :remove                                "Выдаліць"
    :save                                  "Захаваць"
    :clear-history                         "Ачысціць гісторыю"
@@ -121,16 +121,16 @@
    :edit                                  "Змяніць"
    :add-members                           "Дадаць членаў"
 
-   ;commands
+   ;;commands
    :chat-send-eth                         "{{amount}} ETH"
 
-   ;new-group
+   ;;new-group
    :new-group                             "Новая група"
    :reorder-groups                        "Упарадкаваць групы"
 
-   ;participants
+   ;;participants
 
-   ;protocol
+   ;;protocol
    :received-invitation                   "атрымаў(ла) запрашэнне ў чат"
    :removed-from-chat                     "выдаліў(ла) вас з групавога чата"
    :left                                  "засталося"
@@ -138,7 +138,7 @@
    :removed                               "выдалены(на)"
    :You                                   "Вы"
 
-   ;new-contact
+   ;;new-contact
    :add-new-contact                       "Дадаць новы кантакт"
    :scan-qr                               "Сканаваць QR"
    :name                                  "Імя"
@@ -149,29 +149,29 @@
    :unknown-address                       "Невядомы адрас"
 
 
-   ;login
+   ;;login
    :connect                               "Падлучыцца"
    :address                               "Адрас"
    :password                              "Пароль"
    :wrong-password                        "Няправільны пароль"
 
-   ;recover
+   ;;recover
    :passphrase                            "Парольная фраза"
    :recover                               "Аднавіць"
 
-   ;accounts
+   ;;accounts
    :recover-access                        "Аднавіць доступ"
 
-   ;wallet-qr-code
+   ;;wallet-qr-code
    :done                                  "Гатова"
    :main-wallet                           "Асноўны кашалёк"
 
-   ;validation
+   ;;validation
    :invalid-phone                         "Няправільны нумар тэлефона"
    :amount                                "Сума"
-   ;transactions
+   ;;transactions
    :status                                "Статус"
    :recipient                             "Атрымальнік"
 
-   ;:webview
+   ;;:webview
    :web-view-error                        "ой, памылка"})

--- a/src/status_im/translations/cs.cljs
+++ b/src/status_im/translations/cs.cljs
@@ -2,7 +2,7 @@
 
 (def translations
   {
-   ;common
+   ;;common
    :members-title                         "Členové"
    :not-implemented                       "!není implementováno"
    :chat-name                             "Název chatu"
@@ -18,11 +18,11 @@
    :camera-access-error                   "Pro udělení potřebných oprávnění ke kameře přejděte do nastavení systému a ujistěte se, že je vybráno Status > Kamera."
    :photos-access-error                   "Pro udělení potřebných oprávnění k fotoaparátu přejděte do nastavení systému a ujistěte se, že je vybráno Status > Fotoaparát."
 
-   ;drawer
+   ;;drawer
    :switch-users                          "Přepnout uživatele"
    :current-network                       "Aktuální síť"
 
-   ;chat
+   ;;chat
    :is-typing                             "píše"
    :and-you                               "a ty"
    :search-chat                           "Hledat v chatu"
@@ -42,11 +42,11 @@
    :faucet-success                        "Požadavek na faucet byl přijat"
    :faucet-error                          "Chyba požadavku na faucet"
 
-   ;sync
+   ;;sync
    :sync-in-progress                      "Synchronizuji..."
    :sync-synced                           "Synchronizováno"
 
-   ;messages
+   ;;messages
    :status-sending                        "Odesílám"
    :status-pending                        "Čekám"
    :status-sent                           "Odesláno"
@@ -55,7 +55,7 @@
    :status-delivered                      "Doručeno"
    :status-failed                         "Selhalo"
 
-   ;datetime
+   ;;datetime
    :datetime-ago-format                   "{{ago}} {{number}} {{time-intervals}}"
    :datetime-second                       {:one   "sekunda"
                                            :other "sekund(y)"}
@@ -69,7 +69,7 @@
    :datetime-yesterday                    "včera"
    :datetime-today                        "dnes"
 
-   ;profile
+   ;;profile
    :profile                               "Profil"
    :edit-profile                          "Upravit profil"
    :message                               "Zpráva"
@@ -99,7 +99,7 @@
    :browsing-open-in-web-browser          "Otevřít ve webovém prohlížeči"
    :browsing-cancel                       "Storno"
 
-   ;sign-up
+   ;;sign-up
    :contacts-syncronized                  "Vaše kontakty byly synchronizovány"
    :confirmation-code                     (str "Díky! Poslali jsme Ti textovou zprávu s kódem pro potvrzení. "
                                                "Prosím potvrď své telefonní číslo zadáním tohoto kódu.")
@@ -114,13 +114,13 @@
    :move-to-internal-failure-message      "Potřebujeme přesunout některé důležité soubory z externího na interní úložiště. K tomu potřebujeme tvoje povolení. V dalších verzích už nebudeme externí úložiště používat."
    :debug-enabled                         "Server pro ladění byl spuštěn! Nyní můžeš spustit *status-dev-cli scan* pro nalezení serveru z počítače ve stejné síti."
 
-   ;phone types
+   ;;phone types
    :phone-e164                            "Mezinárodní 1"
    :phone-international                   "Mezinárodní 2"
    :phone-national                        "Národní"
    :phone-significant                     "Významný"
 
-   ;chats
+   ;;chats
    :chats                                 "Chaty"
    :delete-chat                           "Smazat chat"
    :new-group-chat                        "Nový skupinový chat"
@@ -131,7 +131,7 @@
    :topic-format                          "Špatný formát [a-z0-9\\-]+"
    :public-group-topic                    "Téma"
 
-   ;discover
+   ;;discover
    :discover                              "Objevit"
    :none                                  "Žádný"
    :search-tags                           "Napište tagy pro hledání"
@@ -140,10 +140,10 @@
    :no-statuses-discovered                "Žádné statusy nebyly objeveny"
    :no-statuses-found                     "Žádné statusy nebyly nalezeny"
 
-   ;settings
+   ;;settings
    :settings                              "Nastavení"
 
-   ;contacts
+   ;;contacts
    :contacts                              "Kontakty"
    :new-contact                          "Nový kontakt"
    :delete-contact                        "Smazat kontakt"
@@ -158,7 +158,7 @@
    :enter-address                         "Zadejte adresu"
    :more                                  "více"
 
-   ;group-settings
+   ;;group-settings
    :remove                                "Odstranit"
    :save                                  "Uložit"
    :delete                                "Smazat"
@@ -169,10 +169,10 @@
    :edit                                  "Upravit"
    :add-members                           "Přidat členy"
 
-   ;commands
+   ;;commands
    :chat-send-eth                         "{{amount}} ETH"
 
-   ;new-group
+   ;;new-group
    :new-group                             "Nová skupina"
    :reorder-groups                        "Uspořádat skupiny"
    :edit-group                            "Upravit skupinu"
@@ -181,9 +181,9 @@
    :delete-group-prompt                   "Kontaktů se to nedotkne"
    :contact-s                             {:one   "kontakt"
                                            :other "kontakty(ů)"}
-   ;participants
+   ;;participants
 
-   ;protocol
+   ;;protocol
    :received-invitation                   "přijata pozvánka k chatu"
    :removed-from-chat                    "přijata pozvánka k skupinovému chatu"
    :left                                  "opuštěno"
@@ -191,7 +191,7 @@
    :removed                               "odstraněn"
    :You                                   "Ty"
 
-   ;new-contact
+   ;;new-contact
    :add-new-contact                       "Přidat nový kontakt"
    :scan-qr                               "Načíst QR kód"
    :name                                  "Jméno"
@@ -202,7 +202,7 @@
    :unknown-address                       "Neznámá adresa"
 
 
-   ;login
+   ;;login
    :connect                             "Připojit"
    :address                               "Adresa"
    :password                              "Heslo"
@@ -210,22 +210,22 @@
    :sign-in                               "Přihlásit se"
    :wrong-password                        "Špatné heslo"
 
-   ;recover
+   ;;recover
    :passphrase                            "Bezpečnostní slova"
    :recover                               "Obnovit"
    :twelve-words-in-correct-order         "12 anglických slov ve správném pořadí"
 
-   ;accounts
+   ;;accounts
    :recover-access                        "Obnovit přístup"
    :create-new-account                    "Vytvořit nový účet"
 
-   ;wallet-qr-code
+   ;;wallet-qr-code
    :done                                  "Hotovo"
 
-   ;validation
+   ;;validation
    :invalid-phone                         "Neplatné telefonní číslo"
    :amount                                "Množství"
-   ;transactions
+   ;;transactions
    :confirm                               "Potvrdit"
    :transaction                           "Transakce"
    :status                                "Status"
@@ -235,7 +235,7 @@
    :data                                  "Data"
    :got-it                                "Mám to"
 
-   ;:webview
+   ;;:webview
    :web-view-error                        "ups, chyba"
    ;;testfairy warning
    :testfairy-title                       "Varování!"
@@ -262,4 +262,3 @@
    :transactions-filter-tokens            "Tokeny"
    :transactions-filter-type              "Typ"
    :transactions-filter-select-all        "Označit vše"})
-

--- a/src/status_im/translations/da.cljs
+++ b/src/status_im/translations/da.cljs
@@ -2,7 +2,7 @@
 
 (def translations
   {
-   ;common
+   ;;common
    :members-title                         "Medlemmere"
    :not-implemented                       "Ikke implementeret!"
    :chat-name                             "Chatnavn"
@@ -14,15 +14,15 @@
    :type-a-message                        "Skriv en besked..."
    :type-a-command                        "Skriv en kommando..."
    :error                                 "Fejl"
-   
+
    :camera-access-error                   "Gå venligst til dine systemindstillinger og sørg  for at du Status > Kamera er tilladt."
    :photos-access-error                   "Gå venligst til dine systemindstillinger og sørg  for at du Status > Billeder er tilladt."
 
-   ;drawer
+   ;;drawer
    :switch-users                          "Skift bruger"
    :current-network                       "Nuværende netværk"
 
-   ;chat
+   ;;chat
    :is-typing                             "skriver"
    :and-you                               "og du"
    :search-chat                           "Søg i chat"
@@ -42,11 +42,11 @@
    :faucet-success                        "Faucet request er modtaget"
    :faucet-error                          "Faucet request fejl"
 
-   ;sync
+   ;;sync
    :sync-in-progress                      "Synkroniserer..."
    :sync-synced                           "Synkroniseret"
 
-   ;messages
+   ;;messages
    :status-sending                        "Sender"
    :status-pending                        "Under behandling"
    :status-sent                           "Sendt"
@@ -55,7 +55,7 @@
    :status-delivered                      "Leveret"
    :status-failed                         "Mislykket"
 
-   ;datetime
+   ;;datetime
    :datetime-ago-format                   "{{number}} {{time-intervals}} {{ago}}"
    :datetime-second                       {:one   "sekund"
                                            :other "sekunder"}
@@ -69,7 +69,7 @@
    :datetime-yesterday                    "i går"
    :datetime-today                        "i dag"
 
-   ;profile
+   ;;profile
    :profile                               "Profil"
    :edit-profile                          "Rediger profil"
    :message                               "Meddelelser"
@@ -98,7 +98,7 @@
    :browsing-open-in-web-browser          "Åben i web browser"
    :browsing-cancel                       "Annullér"
 
-   ;sign-up
+   ;;sign-up
    :contacts-syncronized                  "Dine kontakter er synkroniseret"
    :confirmation-code                     (str "Tak! Vi har sendt dig en sms med en bekræftelseskode. "
                                                "Vær venlig at indtaste koden for at bekræfte dit telefonnummer")
@@ -113,13 +113,13 @@
    :move-to-internal-failure-message      "Vi skal flyyte nogle vigtige filer fra din eksterne til din interne hukommelse. For at gøre dette har vi brug for din tilladelse. Vi vil ikke bruge din eksterne hukkomelse i kommende versioner."
    :debug-enabled                         "Debug server has been launched! You can now execute *status-dev-cli scan* to find the server from your computer on the same network."
 
-   ;phone types
+   ;;phone types
    :phone-e164                            "International 1"
    :phone-international                   "International 2"
    :phone-national                        "National"
    :phone-significant                     "Significant"
 
-   ;chats
+   ;;chats
    :chats                                 "Samtaler"
    :delete-chat                           "Fjern samtale"
    :new-group-chat                        "Ny gruppsamtale"
@@ -130,7 +130,7 @@
    :topic-format                          "Forkert format [a-z0-9\\-]+"
    :public-group-topic                    "Emne"
 
-   ;discover
+   ;;discover
    :discover                              "Opdag"
    :none                                  "Ingen"
    :search-tags                           "Skrive de tags du vil søge efter her"
@@ -139,10 +139,10 @@
    :no-statuses-discovered                "Ingen statusser opdaget"
    :no-statuses-found                     "Inger statusser fundet"
 
-   ;settings
+   ;;settings
    :settings                              "Indstillinger"
 
-   ;contacts
+   ;;contacts
    :contacts                              "Kontakter"
    :new-contact                           "Ny kontakt"
    :delete-contact                        "Fjern kontakt"
@@ -157,7 +157,7 @@
    :enter-address                         "Indtast adresse"
    :more                                  "mere"
 
-   ;group-settings
+   ;;group-settings
    :remove                                "Fjern"
    :save                                  "Gem"
    :delete                                "Slet"
@@ -168,10 +168,10 @@
    :edit                                  "Rediger"
    :add-members                           "Tilføj medlemmere"
 
-   ;commands
+   ;;commands
    :chat-send-eth                         "{{amount}} ETH"
 
-   ;new-group
+   ;;new-group
    :new-group                             "Ny gruppe"
    :reorder-groups                        "Arranger grupper"
    :edit-group                            "Rediger gruppe"
@@ -180,9 +180,9 @@
    :delete-group-prompt                   "Dette vil ikke påvirke dine kontakter"
    :contact-s                             {:one   "kontakt"
                                            :other "kontakter"}
-   ;participants
+   ;;participants
 
-   ;protocol
+   ;;protocol
    :received-invitation                   "Accepterede chatinvitaion"
    :removed-from-chat                     "Fjernede dig fra gruppechatten"
    :left                                  "Forlod"
@@ -190,7 +190,7 @@
    :removed                               "Fjernet"
    :You                                   "Du"
 
-   ;new-contact
+   ;;new-contact
    :add-new-contact                       "Tilføj ny kontakt"
    :scan-qr                               "Skan QR-kode"
    :name                                  "Navn"
@@ -201,7 +201,7 @@
    :unknown-address                       "Ukendt adresse"
 
 
-   ;login
+   ;;login
    :connect                               "Tilslut"
    :address                               "Adresse"
    :password                              "Kodeord"
@@ -209,23 +209,23 @@
    :sign-in                               "Log på"
    :wrong-password                        "Forkert kodeord"
 
-   ;recover
+   ;;recover
    :passphrase                            "Kodesætning (passphrase)"
    :recover                               "Gendan"
    :twelve-words-in-correct-order         "12 ord i den korrekte rækkefølge"
 
-   ;accounts
+   ;;accounts
    :recover-access                        "Gendan adgang"
    :create-new-account                    "Opret en ny konto"
 
-   ;wallet-qr-code
+   ;;wallet-qr-code
    :done                                  "Klar"
    :main-wallet                           "Hovedpung"
 
-   ;validation
+   ;;validation
    :invalid-phone                         "Ugyldigt telefonnummer"
    :amount                                "Beløb"
-   ;transactions
+   ;;transactions
    :confirm                               "Bekræft"
    :transaction                           "Transaktion"
    :status                                "Status"
@@ -235,5 +235,5 @@
    :data                                  "Data"
    :got-it                                "Forstået"
 
-   ;:webview
+   ;;:webview
    :web-view-error                        "hovsa, fejl"})

--- a/src/status_im/translations/de_ch.cljs
+++ b/src/status_im/translations/de_ch.cljs
@@ -2,17 +2,17 @@
 
 (def translations
   {
-   ;common
+   ;;common
    :members-title                         "Mitglieder"
    :not-implemented                       "!nicht implementiert"
    :chat-name                             "Chat Name"
    :notifications-title                   "Notifikationen and Klänge"
    :offline                               "Offline"
 
-   ;drawer
+   ;;drawer
    :switch-users                          "Benutzer wechseln"
 
-   ;chat
+   ;;chat
    :is-typing                             "tippt"
    :and-you                               "und du"
    :search-chat                           "Suche Chat"
@@ -29,11 +29,11 @@
    :suggestions-requests                  "Fragt an"
    :suggestions-commands                  "Kommandiert"
 
-   ;sync
+   ;;sync
    :sync-in-progress                      "Synchronisierung..."
    :sync-synced                           "Synchron"
 
-   ;messages
+   ;;messages
    :status-sending                        "Senden"
    :status-pending                        "Anhängig"
    :status-sent                           "Gesendet"
@@ -42,7 +42,7 @@
    :status-delivered                      "Geliefert"
    :status-failed                         "Fehlgeschlagen"
 
-   ;datetime
+   ;;datetime
    :datetime-second                       {:one   "Sekunde"
                                            :other "Sekunden"}
    :datetime-minute                       {:one   "Minute"
@@ -55,7 +55,7 @@
    :datetime-yesterday                    "gestern"
    :datetime-today                        "heute"
 
-   ;profile
+   ;;profile
    :profile                               "Profil"
    :message                               "Nachricht"
    :not-specified                         "Nicht spezifiziert"
@@ -68,7 +68,7 @@
    :image-source-make-photo               "Erfassen"
    :image-source-gallery                  "Aus der Galerie auswählen"
 
-   ;sign-up
+   ;;sign-up
    :contacts-syncronized                  "Deine Kontakte wurden synchronisiert"
    :confirmation-code                     (str "Vielen Dank! Wir haben Dir eine SMS mit einem Bestätigungcode"
                                                "zugesandt. Bitte gebe diesen Code zur Bestätigung deiner Telefonnummer ein")
@@ -80,11 +80,11 @@
    :intro-message1                        "Willkommen zu Status\nTap diese Nachricht um dein Passwort einzurichten & loszulegen!"
    :account-generation-message            "Gib mir eine Sekunde, Ich muss wie verrückt etwas berechnen um dein Konto zu generieren!"
 
-   ;chats
+   ;;chats
    :chats                                 "Chats"
    :new-group-chat                        "Neuer Gruppenchat"
 
-   ;discover
+   ;;discover
    :discover                             "Entdecken"
    :none                                  "Keine"
    :search-tags                           "Gebe hier deine Suchbegriffe ein"
@@ -92,17 +92,17 @@
    :recent                                "Kürzlich"
    :no-statuses-discovered                "Es wurden keine Status gefunden"
 
-   ;settings
+   ;;settings
    :settings                              "Einstellungen"
 
-   ;contacts
+   ;;contacts
    :contacts                              "Kontakte"
    :new-contact                           "Neuer Kontakt"
    :contacts-group-new-chat               "Starte neuen Gruppenchat"
    :no-contacts                           "Noch keine Kontakte"
    :show-qr                               "QR-Code anzeigen"
 
-   ;group-settings
+   ;;group-settings
    :remove                                "Entfernen"
    :save                                  "Speichern"
    :clear-history                         "Verlauf löschen"
@@ -110,14 +110,14 @@
    :edit                                  "Bearbeiten"
    :add-members                           "Mitglieder hinzufügen"
 
-   ;commands
+   ;;commands
    :chat-send-eth                         "{{amount}} ETH"
 
-   ;new-group
+   ;;new-group
 
-   ;participants
+   ;;participants
 
-   ;protocol
+   ;;protocol
    :received-invitation                   "Chat Einladung erhalten"
    :removed-from-chat                     "du wurdest vom Gruppenchat entfernt"
    :left                                  "verlassen"
@@ -125,7 +125,7 @@
    :removed                               "entfernt"
    :You                                   "Du"
 
-   ;new-contact
+   ;;new-contact
    :add-new-contact                       "Teilnehmer hinzufügen"
    :scan-qr                               "QR scannen"
    :name                                  "Name"
@@ -135,29 +135,29 @@
    :unknown-address                       "Unbekannte Adresse"
 
 
-   ;login
+   ;;login
    :connect                               "Verbinden"
    :address                               "Adresse"
    :password                              "Passwort"
    :wrong-password                        "Falsches Passwort"
 
-   ;recover
+   ;;recover
    :passphrase                            "Passphrase"
    :recover                               "Wiederherstellen"
 
-   ;accounts
+   ;;accounts
    :recover-access                        "Zugriff wiederherstellen"
 
-   ;wallet-qr-code
+   ;;wallet-qr-code
    :done                                  "Erledigt"
    :main-wallet                           "Haupt-Portemonnaie"
 
-   ;validation
+   ;;validation
    :invalid-phone                         "Ungültige Telefonnummer"
    :amount                                "Betrag"
-   ;transactions
+   ;;transactions
    :status                                "Status"
    :recipient                             "Empfänger"
 
-   ;:webview
+   ;;:webview
    :web-view-error                        "oops, Fehler"})

--- a/src/status_im/translations/es_ar.cljs
+++ b/src/status_im/translations/es_ar.cljs
@@ -2,17 +2,17 @@
 
 (def translations
   {
-   ;common
+   ;;common
    :members-title                         "Miembros"
    :not-implemented                       "!no implementado"
    :chat-name                             "Nombre del chat"
    :notifications-title                   "Notificaciones y sonidos"
    :offline                               "Fuera de línea"
 
-   ;drawer
+   ;;drawer
    :switch-users                          "Cambiar de usuario"
 
-   ;chat
+   ;;chat
    :is-typing                             "está escribiendo"
    :and-you                               "y tú"
    :search-chat                           "Buscar chat"
@@ -29,11 +29,11 @@
    :suggestions-requests                  "Solicitudes"
    :suggestions-commands                  "Comandos"
 
-   ;sync
+   ;;sync
    :sync-in-progress                      "Sincronizando..."
    :sync-synced                           "Sincronizado"
 
-   ;messages
+   ;;messages
    :status-sending                        "Enviando"
    :status-pending                        "Pendiente"
    :status-sent                           "Enviado"
@@ -42,7 +42,7 @@
    :status-delivered                      "Enviado"
    :status-failed                         "Fallido"
 
-   ;datetime
+   ;;datetime
    :datetime-second                       {:one   "segundo"
                                            :other "segundos"}
    :datetime-minute                       {:one   "minuto"
@@ -55,7 +55,7 @@
    :datetime-yesterday                    "ayer"
    :datetime-today                        "hoy"
 
-   ;profile
+   ;;profile
    :profile                               "Perfil"
    :message                               "Mensaje"
    :not-specified                         "No especificado"
@@ -73,11 +73,11 @@
    :sharing-share                         "Compartir..."
    :sharing-cancel                        "Cancelar"
 
-   ;sign-up
+   ;;sign-up
    :contacts-syncronized                  "Tus contactos se han sincronizado"
    :confirmation-code                     (str "¡Gracias! Te hemos enviado un código de confirmación por mensaje de texto. "
                                                "Ingresa este código para confirmar tu número telefónico")
-   :incorrect-code                        (str "Lo siento, el código no era correcto; ingrésalo de nuevo")
+   :incorrect-code                        (str "Lo siento, el código no era correcto;; ingrésalo de nuevo")
    :phew-here-is-your-passphrase          "*Wow* eso estuvo difícil, aquí tienes tu contraseña, *¡anótala y mantenla segura!* La necesitarás para recuperar tu cuenta."
    :here-is-your-passphrase               "Aquí tienes tu frase de contraseña, *¡Anótala y mantenga segura!* La necesitarás para recuperar tu cuenta."
    :phone-number-required                 "Pulsa aquí para ingresar tu número telefónico y yo encontraré a tus amigos"
@@ -85,11 +85,11 @@
    :intro-message1                        "Bienvenido(a) a Status\n¡Pulsa en este mensaje para establecer tu contraseña y comenzar!"
    :account-generation-message            "¡Dame un segundo, necesito realizar un súper cálculo para generar tu cuenta!"
 
-   ;chats
+   ;;chats
    :chats                                 "Chats"
    :new-group-chat                        "Nuevo chat de grupo"
 
-   ;discover
+   ;;discover
    :discover                              "Descubrimiento"
    :none                                  "Ninguno"
    :search-tags                           "Ingresa aquí tus etiquetas de búsqueda"
@@ -97,17 +97,17 @@
    :recent                                "Reciente"
    :no-statuses-discovered                "No se encontró ningún estatus"
 
-   ;settings
+   ;;settings
    :settings                              "Configuración"
 
-   ;contacts
+   ;;contacts
    :contacts                              "Contactos"
    :new-contact                           "Nuevo contacto"
    :contacts-group-new-chat               "Iniciar nuevo chat"
    :no-contacts                           "No hay contactos todavía"
    :show-qr                               "Mostrar QR"
 
-   ;group-settings
+   ;;group-settings
    :remove                                "Eliminar"
    :save                                  "Guardar"
    :clear-history                         "Borrar historial"
@@ -115,14 +115,14 @@
    :edit                                  "Editar"
    :add-members                           "Agregar miembros"
 
-   ;commands
+   ;;commands
    :chat-send-eth                         "{{amount}} ETH"
 
-   ;new-group
+   ;;new-group
 
-   ;participants
+   ;;participants
 
-   ;protocol
+   ;;protocol
    :received-invitation                   "recibió invitación a chat"
    :removed-from-chat                     "te retiró del grupo de chat"
    :left                                  "restantes"
@@ -130,7 +130,7 @@
    :removed                               "retirado"
    :You                                   "Tú"
 
-   ;new-contact
+   ;;new-contact
    :add-new-contact                       "Agregar nuevo contacto"
    :scan-qr                               "Escanear QR"
    :name                                  "Nombre"
@@ -140,31 +140,31 @@
    :unknown-address                       "Dirección desconocida"
 
 
-   ;login
+   ;;login
    :connect                               "Conectar"
    :address                               "Dirección"
    :password                              "Contraseña"
    :wrong-password                        "Contraseña incorrecta"
 
-   ;recover
+   ;;recover
    :passphrase                            "Frase de contraseña"
    :recover                               "Recuperar"
 
-   ;accounts
+   ;;accounts
    :recover-access                        "Recuperar acceso"
 
-   ;wallet-qr-code
+   ;;wallet-qr-code
    :done                                  "Completado"
    :main-wallet                           "Cartera principal"
 
-   ;validation
+   ;;validation
    :invalid-phone                         "Número telefónico inválido"
    :amount                                "Monto"
-   ;transactions
+   ;;transactions
    :status                                "Estatus"
    :recipient                             "Destinatario"
 
-   ;:webview
+   ;;:webview
    :web-view-error                        "oops, error"
 
    :confirm                               "Confirmar"

--- a/src/status_im/translations/es_mx.cljs
+++ b/src/status_im/translations/es_mx.cljs
@@ -2,7 +2,7 @@
 
 (def translations
   {
-   ;common
+   ;;common
    :members-title                         "Miembros"
    :not-implemented                       "!No implementado!"
    :chat-name                             "Nombre del chat"
@@ -18,11 +18,11 @@
    :camera-access-error                   "Para permitir el acceso a la cámara, porfavor, ve a configuración de sistema y asegúrate que la opción 'Status > Cámara' está seleccionada."
    :photos-access-error                   "Para permitir el acceso a fotos, porfavor, ve a configuración de sistema y asegúrate que la opción 'Status > Fotos' está seleccionada."
 
-   ;drawer
+   ;;drawer
    :switch-users                          "Cambiar usuarios"
    :current-network                       "Red actual"
 
-   ;chat
+   ;;chat
    :is-typing                             "está escribiendo"
    :and-you                               "y tú"
    :search-chat                           "Buscar chat"
@@ -42,11 +42,11 @@
    :faucet-success                        "Se recibió la solicitud de Faucet"
    :faucet-error                          "Error de solicitud de Faucet"
 
-   ;sync
+   ;;sync
    :sync-in-progress                      "Sincronizando..."
    :sync-synced                           "Sincronizado"
 
-   ;messages
+   ;;messages
    :status-sending                        "Enviando"
    :status-pending                        "Pendiente"
    :status-sent                           "Enviado"
@@ -55,7 +55,7 @@
    :status-delivered                      "Entregado"
    :status-failed                         "Fallido"
 
-   ;datetime
+   ;;datetime
    :datetime-ago-format                   "{{number}} {{time-intervals}} {{ago}}"
    :datetime-second                       {:one   "segundo"
                                            :other "segundos"}
@@ -69,7 +69,7 @@
    :datetime-yesterday                    "ayer"
    :datetime-today                        "hoy"
 
-   ;profile
+   ;;profile
    :profile                               "Perfil"
    :edit-profile                          "Editar perfil"
    :message                               "Mensaje"
@@ -99,7 +99,7 @@
    :browsing-open-in-web-browser          "Abrir en navegador"
    :browsing-cancel                       "Cancelar"
 
-   ;sign-up
+   ;;sign-up
    :contacts-syncronized                  "Tus contactos se han sincronizado"
    :confirmation-code                     (str "¡Gracias! Te hemos enviado un mensaje de texto con un código de confirmación "
                                                ". Por favor, usa el código para confirmar tu número de teléfono")
@@ -114,13 +114,13 @@
    :move-to-internal-failure-message      "Necesitamos mover algunos datos importantes de almacenamiento externo a interno. Necesitamos tu permiso para hacerlo. No usaremos almacenamiento externo en futuras versiones."
    :debug-enabled                         "¡El servidor de depuración ha sido lanzado! Ahora puedes ejecutar *status-dev-cli scan* para encontrar el servidor desde tu computadora en la misma red."
 
-   ;phone types
+   ;;phone types
    :phone-e164                            "Internacional 1"
    :phone-international                   "Internacional 2"
    :phone-national                        "Nacional"
    :phone-significant                     "Importante"
 
-   ;chats
+   ;;chats
    :chats                                 "Chats"
    :delete-chat                           "Eliminar chat"
    :new-group-chat                        "Nuevo grupo de chat"
@@ -131,7 +131,7 @@
    :topic-format                          "Formato incorrecto [a-z0-9\\-]+"
    :public-group-topic                    "Tema"
 
-   ;discover
+   ;;discover
    :discover                              "Descubrir"
    :none                                  "Ninguno"
    :search-tags                           "Escribe tus etiquetas de búsqueda aquí"
@@ -140,10 +140,10 @@
    :no-statuses-discovered                "No se descubrieron estados"
    :no-statuses-found                     "No se encontraron estados"
 
-   ;settings
+   ;;settings
    :settings                              "Ajustes"
 
-   ;contacts
+   ;;contacts
    :contacts                              "Nuevo contacto"
    :delete-contact                        "Borrar contacto"
    :delete-contact-confirmation           "Este contacto será eliminado de tus contactos"
@@ -157,7 +157,7 @@
    :enter-address                         "Ingresar dirección"
    :more                                  "más"
 
-   ;group-settings
+   ;;group-settings
    :remove                                "Remover"
    :save                                  "Guardar"
    :delete                                "Eliminar"
@@ -168,10 +168,10 @@
    :edit                                  "Editar"
    :add-members                           "Agregar miembros"
 
-   ;commands
+   ;;commands
    :chat-send-eth                         "{{amount}} ETH"
 
-   ;new-group
+   ;;new-group
    :new-group                             "Nuevo grupo"
    :reorder-groups                        "Reordenar grupos"
    :edit-group                            "Editar grupo"
@@ -180,9 +180,9 @@
    :delete-group-prompt                   "Esto no afectará tus contactos"
    :contact-s                             {:one   "contacto"
                                            :other "contactos"}
-   ;participants
+   ;;participants
 
-   ;protocol
+   ;;protocol
    :received-invitation                   "recibió invitación de chat"
    :removed-from-chat                     "te removió del chat"
    :left                                  "salió"
@@ -190,7 +190,7 @@
    :removed                               "eliminado"
    :You                                   "Tú"
 
-   ;new-contact
+   ;;new-contact
    :add-new-contact                       "Agregar nuevo contacto"
    :scan-qr                               "Escanear QR"
    :name                                  "Nombre"
@@ -201,7 +201,7 @@
    :unknown-address                       "Dirección desconocida"
 
 
-   ;login
+   ;;login
    :connect                               "Conectar"
    :address                               "Dirección"
    :password                              "Contraseña"
@@ -209,24 +209,24 @@
    :sign-in                               "Regístrate"
    :wrong-password                        "Contraseña incorrecta"
 
-   ;recover
+   ;;recover
    :passphrase                            "Frase de contraseña"
    :recover                               "Recuperar"
    :twelve-words-in-correct-order         "12 palabras en orden correcto"
 
-   ;accounts
+   ;;accounts
    :recover-access                        "Recuperar acceso"
    :create-new-account                    "Crear nueva cuenta"
 
-   ;wallet-qr-code
+   ;;wallet-qr-code
    :done                                  "Listo"
    :main-wallet                           "Wallet principal"
 
-   ;validation
+   ;;validation
    :invalid-phone                         "Número de teléfono incorrecto"
    :amount                                "Cantidad"
 
-   ;transactions
+   ;;transactions
    :confirm                               "Confirmar"
    :transaction                           "Transacción"
    :status                                "Estado"
@@ -236,5 +236,5 @@
    :data                                  "Datos"
    :got-it                                "Entendido"
 
-   ;:webview
+   ;;:webview
    :web-view-error                        "oops, error"})

--- a/src/status_im/translations/fi.cljs
+++ b/src/status_im/translations/fi.cljs
@@ -2,7 +2,7 @@
 
 (def translations
   {
-   ;common
+   ;;common
    :members-title                         "Jäsenet"
    :not-implemented                       "!ei toteutettu"
    :chat-name                             "Keskustelun nimi"
@@ -18,11 +18,11 @@
    :camera-access-error                   "Myöntääksesi vaadittu kameran käyttölupa, siirry järjestelmäasetuksiin ja varmista, että Status > Kamera on valittu."
    :photos-access-error                   "Myöntääksesi vaadittu kuvien käyttölupa, siirry järjestelmäasetuksiin ja varmista, että Status > Kuvat on valittu."
 
-   ;drawer
+   ;;drawer
    :switch-users                          "Vaihda käyttäjää"
    :current-network                       "Nykyinen verkko"
 
-   ;chat
+   ;;chat
    :is-typing                             "kirjoittaa"
    :and-you                               "ja sinä"
    :search-chat                           "Etsi keskustelusta"
@@ -42,11 +42,11 @@
    :faucet-success                        "Faucet pyyntö vastaanotettu"
    :faucet-error                          "Faucet pyyntö virhe"
 
-   ;sync
+   ;;sync
    :sync-in-progress                      "Synkronoidaan..."
    :sync-synced                           "Synkronoitu"
 
-   ;messages
+   ;;messages
    :status-sending                        "Lähetetään"
    :status-pending                        "Odottaa"
    :status-sent                           "Lähetetty"
@@ -55,7 +55,7 @@
    :status-delivered                      "Toimitettu"
    :status-failed                         "Epäonnistui"
 
-   ;datetime
+   ;;datetime
    :datetime-ago-format                   "{{number}} {{time-intervals}} {{ago}}"
    :datetime-second                       {:one   "sekunti"
                                            :other "sekuntia"}
@@ -69,7 +69,7 @@
    :datetime-yesterday                    "eilen"
    :datetime-today                        "tänään"
 
-   ;profile
+   ;;profile
    :profile                               "Profiili"
    :edit-profile                          "Muokkaa profiilia"
    :message                               "Viesti"
@@ -99,7 +99,7 @@
    :browsing-open-in-web-browser          "Avaa selaimessa"
    :browsing-cancel                       "Peruuta"
 
-   ;sign-up
+   ;;sign-up
    :contacts-syncronized                  "Yhteystietosi ovat synkronoitu"
    :confirmation-code                     (str "Kiitos! Olemme lähettäneet sinulle tekstiviestin, jossa on vahvistus "
                                                "koodi. Ole hyvä ja anna koodi vahvistaaksesi puhelinnumerosi")
@@ -114,13 +114,13 @@
    :move-to-internal-failure-message      "Meidän on siirrettävä joitain tärkeitä tiedostoja ulkoisesta sisäiseen tallennustilaan. Tätä varten tarvitsemme luvan. Emme tule käyttämään ulkoista tallennustilaa tulevissa versioissa."
    :debug-enabled                         "Debug-palvelin käynnistetty! Löytääksesi palvelimen suorita samaan verkkoon kuuluvalta tietokoneeltasi *status-dev-cli scan*."
 
-   ;phone types
+   ;;phone types
    :phone-e164                            "Kansainvälinen 1"
    :phone-international                   "Kansainvälinen 2"
    :phone-national                        "Kansallinen"
    :phone-significant                     "Merkittävä"
 
-   ;chats
+   ;;chats
    :chats                                 "Keskustelut"
    :delete-chat                           "Poista keskustelu"
    :new-group-chat                        "Uusi ryhmäkeskustelu"
@@ -131,7 +131,7 @@
    :topic-format                          "Virheellinen muoto [a-z0-9\\-]+"
    :public-group-topic                    "Otsikko"
 
-   ;discover
+   ;;discover
    :discover                              "Löydä"
    :none                                  "Tyhjä"
    :search-tags                           "Kirjoita hakutunnisteesi tähän"
@@ -140,10 +140,10 @@
    :no-statuses-discovered                "Ei hakutuloksia"
    :no-statuses-found                     "Ei hakutuloksia"
 
-   ;settings
+   ;;settings
    :settings                              "Asetukset"
 
-   ;contacts
+   ;;contacts
    :contacts                              "Yhteystiedot"
    :new-contact                           "Uusi yhteystieto"
    :delete-contact                        "Poista yhteystieto"
@@ -158,7 +158,7 @@
    :enter-address                         "Syötä osoite"
    :more                                  "lisää"
 
-   ;group-settings
+   ;;group-settings
    :remove                                "Poista"
    :save                                  "Tallenna"
    :delete                                "Poista"
@@ -169,10 +169,10 @@
    :edit                                  "Muokkaa"
    :add-members                           "Lisää käyttäjiä"
 
-   ;commands
+   ;;commands
    :chat-send-eth                         "{{amount}} ETH"
 
-   ;new-group
+   ;;new-group
    :new-group                             "Uusi ryhmä"
    :reorder-groups                        "Järjestele ryhmät uudelleen"
    :edit-group                            "Muokkaa ryhmää"
@@ -181,9 +181,9 @@
    :delete-group-prompt                   "Tämä ei vaikuta yhteystietoihin"
    :contact-s                             {:one   "yhteystieto"
                                            :other "yhteystietoa"}
-   ;participants
+   ;;participants
 
-   ;protocol
+   ;;protocol
    :received-invitation                   "poista keskustelukutsu"
    :removed-from-chat                     "poista itsesi keskustelusta"
    :left                                  "poistui"
@@ -191,7 +191,7 @@
    :removed                               "poistettu"
    :You                                   "Sinä"
 
-   ;new-contact
+   ;;new-contact
    :add-new-contact                       "Lisää uusi yhteystieto"
    :scan-qr                               "Skannaa QR"
    :name                                  "Nimi"
@@ -202,7 +202,7 @@
    :unknown-address                       "Tuntematon osoite"
 
 
-   ;login
+   ;;login
    :connect                               "Yhdistä"
    :address                               "Osoite"
    :password                              "Salasana"
@@ -210,23 +210,23 @@
    :sign-in                               "Luo tili"
    :wrong-password                        "Väärä salasana"
 
-   ;recover
+   ;;recover
    :passphrase                            "Tunnuslause"
    :recover                               "Palauta"
    :twelve-words-in-correct-order         "12 sanaa oikeassa järjestyksessä"
 
-   ;accounts
+   ;;accounts
    :recover-access                        "Palauta käyttöoikeus"
    :create-new-account                    "Luo uusi tili"
 
-   ;wallet-qr-code
+   ;;wallet-qr-code
    :done                                  "Valmis"
    :main-wallet                           "Ensisijainen Lompakko"
 
-   ;validation
+   ;;validation
    :invalid-phone                         "Virheellinen puhelinnumero"
    :amount                                "Määrä"
-   ;transactions
+   ;;transactions
    :confirm                               "Vahvista"
    :transaction                           "Tapahtuma"
    :status                                "Tila"
@@ -236,5 +236,5 @@
    :data                                  "Tieto"
    :got-it                                "Vastaanotettu"
 
-   ;:webview
+   ;;:webview
    :web-view-error                        "oops, virhe"})

--- a/src/status_im/translations/fr.cljs
+++ b/src/status_im/translations/fr.cljs
@@ -62,7 +62,7 @@
    :status-delivered                      "Délivré"
    :status-failed                         "Échec"
 
-   ;datetime
+   ;;datetime
    :datetime-ago-format                   "{{number}} {{time-intervals}} {{ago}}"
    :datetime-second                       {:one   "seconde"
                                            :other "secondes"}

--- a/src/status_im/translations/fr_ch.cljs
+++ b/src/status_im/translations/fr_ch.cljs
@@ -2,17 +2,17 @@
 
 (def translations
   {
-   ;common
+   ;;common
    :members-title                         "Membres"
    :not-implemented                       "!pas mis en place"
    :chat-name                             "Nom de chat"
    :notifications-title                   "Notifications et sons"
    :offline                               "Hors ligne"
 
-   ;drawer
+   ;;drawer
    :switch-users                          "Changer d'utilisateur"
 
-   ;chat
+   ;;chat
    :is-typing                             "est en train de taper"
    :and-you                               "et vous"
    :search-chat                           "Chercher dans une conversation"
@@ -29,11 +29,11 @@
    :suggestions-requests                  "Demandes"
    :suggestions-commands                  "Commandes"
 
-   ;sync
+   ;;sync
    :sync-in-progress                      "En cours de synchronisation..."
    :sync-synced                           "Synchronisé"
 
-   ;messages
+   ;;messages
    :status-sending                        "Envoi en cours"
    :status-pending                        "En attendant"
    :status-sent                           "Envoyé"
@@ -42,7 +42,7 @@
    :status-delivered                      "Livré"
    :status-failed                         "Echoué"
 
-   ;datetime
+   ;;datetime
    :datetime-second                       {:one   "seconde"
                                            :other "secondes"}
    :datetime-minute                       {:one   "minute"
@@ -55,7 +55,7 @@
    :datetime-yesterday                    "hier"
    :datetime-today                        "aujourd'hui"
 
-   ;profile
+   ;;profile
    :profile                               "Profil"
    :message                               "Message"
    :not-specified                         "Non spécifié"
@@ -68,7 +68,7 @@
    :image-source-make-photo               "Capture"
    :image-source-gallery                  "Sélectionner dans la galerie"
 
-   ;sign-up
+   ;;sign-up
    :contacts-syncronized                  "Vos contacts ont été synchronisés"
    :confirmation-code                     (str "Merci! Nous vous avons envoyé un message de texte avec un code "
                                                "de confirmation. Veuillez fournir ce code pour confirmer votre numéro de téléphone")
@@ -80,11 +80,11 @@
    :intro-message1                        "Bienvenue dans le statut\nTapez ce message pour établir votre mot de passe et vous lancer !"
    :account-generation-message            "Une seconde svp, je dois lancer quelques formules magiques pour générer votre compte !"
 
-   ;chats
+   ;;chats
    :chats                                 "Chats"
    :new-group-chat                        "Nouveau chat de groupe"
 
-   ;discover
+   ;;discover
    :discover                              "Découverte"
    :none                                  "Aucun"
    :search-tags                           "Tapez vos clés de recherche ici"
@@ -92,17 +92,17 @@
    :recent                                "Récent"
    :no-statuses-discovered                "Aucun statut trouvé"
 
-   ;settings
+   ;;settings
    :settings                              "Paramètres"
 
-   ;contacts
+   ;;contacts
    :contacts                              "Contacts"
    :new-contact                           "Nouveau Contact"
    :contacts-group-new-chat               "Lancer un nouveau chat"
    :no-contacts                           "Pas encore de contacts"
    :show-qr                               "Montrer QR"
 
-   ;group-settings
+   ;;group-settings
    :remove                                "Supprimer"
    :save                                  "Sauvegarder"
    :clear-history                         "Effacer l'historique"
@@ -110,14 +110,14 @@
    :edit                                  "Modifier"
    :add-members                           "Ajouter des membres"
 
-   ;commands
+   ;;commands
    :chat-send-eth                         "{{amount}} ETH"
 
-   ;new-group
+   ;;new-group
 
-   ;participants
+   ;;participants
 
-   ;protocol
+   ;;protocol
    :received-invitation                   "reçu une invitation à un chat"
    :removed-from-chat                     "vous a supprimé du chat de groupe"
    :left                                  "restant"
@@ -125,7 +125,7 @@
    :removed                               "supprimé"
    :You                                   "Vous"
 
-   ;new-contact
+   ;;new-contact
    :add-new-contact                       "Ajouter un nouveau contact"
    :scan-qr                               "Scannner QR"
    :name                                  "Nom"
@@ -135,31 +135,31 @@
    :unknown-address                       "Adresse inconnue"
 
 
-   ;login
+   ;;login
    :connect                               "Se connecter"
    :address                               "Adresse"
    :password                              "Mot de passe"
    :wrong-password                        "Mauvais mot de passe"
 
-   ;recover
+   ;;recover
    :passphrase                            "Phrase de passe"
    :recover                               "Restaurer"
 
-   ;accounts
+   ;;accounts
    :recover-access                        "Récupérer l'accès"
 
-   ;wallet-qr-code
+   ;;wallet-qr-code
    :done                                  "Terminé"
    :main-wallet                           "Portefeuille principal"
 
-   ;validation
+   ;;validation
    :invalid-phone                         "Numéro de téléphone non valable"
    :amount                                "Montant"
-   ;transactions
+   ;;transactions
    :status                                "Statut"
    :recipient                             "Destinataire"
 
-   ;:webview
+   ;;:webview
    :web-view-error                        "oups, erreur"
 
    :confirm                               "Confirmer"

--- a/src/status_im/translations/fy.cljs
+++ b/src/status_im/translations/fy.cljs
@@ -2,7 +2,7 @@
 
 (def translations
   {
-   ;common
+   ;;common
    :members-title                         "Leden"
    :not-implemented                       "!net ymplemintearre"
    :chat-name                             "Chatnamme"
@@ -17,12 +17,12 @@
 
    :camera-access-error                   "Om de kamera tastimming te jaan, gea nei dyn systeem ynstellings en wêz wis dat Status > Camera selektearre is."
    :photos-access-error                   "Om ús tastimming te jaan oan dyn foto's, gea nei dyn systeem ynstellings en wêz wis dat Status > Foto's selektearre is."
-    
-   ;drawer
+
+   ;;drawer
    :switch-users                          "Skeakel tusken brûkers "
    :current-network                       "Aktuele netwurk"
 
-   ;chat
+   ;;chat
    :is-typing                             "typt"
    :and-you                               "en do"
    :search-chat                           "Sykje yn de chat"
@@ -42,11 +42,11 @@
    :faucet-success                        "Faucet fersyk is ûntfongen"
    :faucet-error                          "Faucet fersyk flater"
 
-   ;sync
+   ;;sync
    :sync-in-progress                      "Wurdt syngronisearre ..."
    :sync-synced                           "Syngronisearre"
 
-   ;messages
+   ;;messages
    :status-sending                        "Wurdt ferstjoerd "
    :status-pending                        "Yn behanneling"
    :status-sent                           "Ferstjoerd"
@@ -55,7 +55,7 @@
    :status-delivered                      "Besoarge"
    :status-failed                         "Mislearre"
 
-   ;datetime
+   ;;datetime
    :datetime-ago-format                   "{{number}} {{time-intervals}} {{ago}}"
    :datetime-second                       {:one   "sekonde "
                                            :other " sekonden"}
@@ -69,7 +69,7 @@
    :datetime-yesterday                    "juster"
    :datetime-today                        "hjoed"
 
-   ;profile
+   ;;profile
    :profile                               "Profyl"
    :edit-profile                          "Profyl oanpasse"
    :message                               "Berjocht"
@@ -98,8 +98,8 @@
    :browsing-title                        "Blêdzje"
    :browsing-open-in-web-browser          "Iepenje yn web blêder"
    :browsing-cancel                       "Ôfbrekke"
-    
-   ;sign-up
+
+   ;;sign-up
    :contacts-syncronized                  "Dyn kontaktpersoanen binne syngroniseard"
    :confirmation-code                     (str "Tiige tank! Wy ha dy in sms stjoerd mei in befêstigingskoade"
                                                ". Jou dyn koade op om dyn telefoannûmer te befêstigje")
@@ -113,14 +113,14 @@
    :account-generation-message            "Jou my in momintsje, ik moat wat yngewikkelde berekkeningen dwaan om dyn account oan te meitsjen !"
    :move-to-internal-failure-message      "We need to move some important files from external to internal storage. To do this, we need your permission. We won't be using external storage in future versions."
    :debug-enabled                         "Debug server has been launched! You can now execute *status-dev-cli scan* to find the server from your computer on the same network."
-    
-   ;phone types
+
+   ;;phone types
    :phone-e164                            "Ynternasjonaal 1"
    :phone-international                   "Ynternasjonaal 2"
    :phone-national                        "Lanlik"
    :phone-significant                     "Significant"
-    
-   ;chats
+
+   ;;chats
    :chats                                 "Chats"
    :delete-chat                           "Chat fuortsmite"
    :new-group-chat                        "Nije groepchat"
@@ -131,7 +131,7 @@
    :topic-format                          "Ferkearde yndieling [a-z0-9\\-]+"
    :public-group-topic                    "Ûnderwerp"
 
-   ;discover
+   ;;discover
    :discover                              "Ûntdekking"
    :none                                  "Gjin"
    :search-tags                           "Typ hjir dyn syktags"
@@ -140,10 +140,10 @@
    :no-statuses-discovered                "Gjin statussen ûntdutsen"
    :no-statuses-found                     "Gjin statussen fûn"
 
-   ;settings
+   ;;settings
    :settings                              "Ynstellingen"
 
-   ;contacts
+   ;;contacts
    :contacts                              "Kontaktpersoanen"
    :new-contact                           "Nije kontaktpersoanen"
    :delete-contact                        "Wiskje kontakt"
@@ -158,7 +158,7 @@
    :enter-address                         "Fier adres yn"
    :more                                  "mear"
 
-   ;group-settings
+   ;;group-settings
    :remove                                "Fuortsmite"
    :save                                  "Opslaan"
    :delete                                "Wiskje"
@@ -169,10 +169,10 @@
    :edit                                  "Bewurkje"
    :add-members                           "Foegje leden ta"
 
-   ;commands
+   ;;commands
    :chat-send-eth                         "{{amount}} ETH"
 
-   ;new-group
+   ;;new-group
    :new-group                             "Nije groep"
    :reorder-groups                        "Reorder groepen"
    :edit-group                            "Bewurkje group"
@@ -181,9 +181,9 @@
    :delete-group-prompt                   "Dit sil gjin ynfloed ha mei jo kontakten"
    :contact-s                             {:one   "kontakt"
                                            :other "kontakten"}
-   ;participants
+   ;;participants
 
-   ;protocol
+   ;;protocol
    :received-invitation                   "Chatútnoeging ûntfange"
    :removed-from-chat                     "ferwidere dy út de chat"
    :left                                  "gie fuort"
@@ -191,7 +191,7 @@
    :removed                               "ferwidere"
    :You                                   "Do"
 
-   ;new-contact
+   ;;new-contact
    :add-new-contact                       "Foegje nij kontaktpersoan ta "
    :scan-qr                               "QR scanne"
    :name                                  "Namme"
@@ -202,7 +202,7 @@
    :unknown-address                       "Ûnbekend adres"
 
 
-   ;login
+   ;;login
    :connect                               "Ferbine"
    :address                               "Adres"
    :password                              "Wachtwurd"
@@ -210,23 +210,23 @@
    :sign-in                               "Ynlogge"
    :wrong-password                        "Ferkeard wachtwurd"
 
-   ;recover
+   ;;recover
    :passphrase                            "Wachtsin"
    :recover                               "Herstelle"
    :twelve-words-in-correct-order         "12 wurden yn de goeie folchoarder"
 
-   ;accounts
+   ;;accounts
    :recover-access                        "Tagong herstelle"
    :create-new-account                    "Nij akkount oanmeitsje"
 
-   ;wallet-qr-code
+   ;;wallet-qr-code
    :done                                  "Klear"
    :main-wallet                           "Haadbeurs"
 
-   ;validation
+   ;;validation
    :invalid-phone                         "Ûnjildich telefoannûmer"
    :amount                                "Bedrach"
-   ;transactions
+   ;;transactions
    :confirm                               "Befestigje"
    :transaction                           "Transaksje"
    :status                                "Status"
@@ -236,5 +236,5 @@
    :data                                  "Data"
    :got-it                                "Befetsje ik"
 
-   ;:webview
+   ;;:webview
    :web-view-error                        "oeps, flater"})

--- a/src/status_im/translations/he.cljs
+++ b/src/status_im/translations/he.cljs
@@ -2,7 +2,7 @@
 
 (def translations
   {
-   ;common
+   ;;common
    :members-title                         "חבר"
    :not-implemented                       "!עדיין לא יושם"
    :chat-name                             "שם הצ'אט"
@@ -18,11 +18,11 @@
    :camera-access-error                   ".כדי להעניק את הרשאת המצלמה הנדרשת, בבקשה, תלכו להגדרות המערכת ותוודאו שהאופציה שנבחרה היא סטטוס > מצלמה"
    :photos-access-error                   ".כדי להעניק את הרשאת התמונות הנדרשת, בבקשה, תלכו להגדרות המערכת ותוודאו שהאופציה שנבחרה היא סטטוס > תמונות"
 
-   ;drawer
+   ;;drawer
    :switch-users                          "שנה משתמש"
    :current-network                       "Current network"
 
-   ;chat
+   ;;chat
    :is-typing                             "מקליד"
    :and-you                               "גם אתה"
    :search-chat                           "חפש בצ'אט"
@@ -42,11 +42,11 @@
    :faucet-success                        "בקשת הברז התקבלה"
    :faucet-error                          "שגיאה בבקשת הברז"
 
-   ;sync
+   ;;sync
    :sync-in-progress                      "...מסנכרן"
    :sync-synced                           "מסונכרן"
 
-   ;messages
+   ;;messages
    :status-sending                        "שולח"
    :status-pending                        "ממתין"
    :status-sent                           "נשלחה"
@@ -55,7 +55,7 @@
    :status-delivered                      "התקבל"
    :status-failed                         "נכשל"
 
-   ;datetime
+   ;;datetime
    :datetime-ago-format                   "{{number}} {{time-intervals}} {{ago}}"
    :datetime-second                       {:one   "שניה"
                                            :other "שניות"}
@@ -69,7 +69,7 @@
    :datetime-yesterday                    "אתמול"
    :datetime-today                        "היום"
 
-    ;profile
+   ;;profile
    :profile                               "פרופיל"
    :edit-profile                          "ערוך פרופיל"
    :message                               "הודעה"
@@ -100,7 +100,7 @@
    :browsing-open-in-web-browser          "פתח בדפדפן"
    :browsing-cancel                       "בטל"
 
-   ;sign-up
+   ;;sign-up
    :contacts-syncronized                  "אנשי הקשר שלך סונכרנו"
    :confirmation-code                     (str "תודה! שלחנו לך הודעה עם קוד"
                                                "אישור. אנא ספק את הקוד כדי לאשר את מספר הטלפון שלך")
@@ -115,13 +115,13 @@
    :move-to-internal-failure-message      "אנו זקוקים לאישורך כדי להזיז קבצים חשובים מהזיכרון החיצוני לפנימי. אנחנו לא נשתמש בזיכרון חיצוני בגרסאות עתידיות"
    :debug-enabled                         ".שרת הניפוי הותחל! אתה יכול כעת לבצע *status-dev-cli scan* כדי למצוא את השרת מהמחשב שלך על אותה הרשת"
 
-   ;phone types
+   ;;phone types
    :phone-e164                            "בין לאומי 1"
    :phone-international                   "בין לאומי 2"
    :phone-national                        "לאומי"
    :phone-significant                     "משמעותי"
 
-   ;chats
+   ;;chats
    :chats                                 "צ'אטים"
    :delete-chat                           "מחק צ'אט"
    :new-group-chat                        "צ'אט קבוצתי חדש"
@@ -132,7 +132,7 @@
    :topic-format                          "פורמט שגוי [a-z0-9\\-]+"
    :public-group-topic                    "נושא"
 
-   ;discover
+   ;;discover
    :discover                              "גילוי"
    :none                                  "אף אחד"
    :search-tags                           "תקליד את תג החיפוש שלך כאן"
@@ -141,10 +141,10 @@
    :no-statuses-discovered                "לא התגלה שום סטטוס"
    :no-statuses-found                     "לא נמצא שום סטטוס"
 
-   ;settings
+   ;;settings
    :settings                              "הגדרות"
 
-   ;contacts
+   ;;contacts
    :contacts                              "אנשי קשר"
    :new-contact                           "איש קשר חדש"
    :delete-contact                        "מחק איש קשר"
@@ -159,7 +159,7 @@
    :enter-address                         "הזן כתובת"
    :more                                  "עוד"
 
-   ;group-settings
+   ;;group-settings
    :remove                                "הסר"
    :save                                  "שמור"
    :delete                                "מחק"
@@ -170,10 +170,10 @@
    :edit                                  "ערוך"
    :add-members                           "הוסף מספרים"
 
-   ;commands
+   ;;commands
    :chat-send-eth                         "{{amount}} אתר"
 
-   ;new-group
+   ;;new-group
    :new-group                             "קבוצה חדשה"
    :reorder-groups                        "סדר מחדש את הקבוצה"
    :edit-group                            "ערוך את הקבוצה"
@@ -182,9 +182,9 @@
    :delete-group-prompt                   "זה לא ישפיע על אנשי הקשר"
    :contact-s                             {:one   "איש קשר"
                                            :other "אנשי קשר"}
-   ;participants
+   ;;participants
 
-   ;protocol
+   ;;protocol
    :received-invitation                   "התקבלה הזמנה לצ'אט"
    :removed-from-chat                     "הוסרת מהצ'אט הקבוצתי"
    :left                                  "עזב"
@@ -192,7 +192,7 @@
    :removed                               "הוסר"
    :You                                   "אתה"
 
-   ;new-contact
+   ;;new-contact
    :add-new-contact                       "הוסף איש קשר חדש"
    :scan-qr                               "סרוק ברקוד"
    :name                                  "שם"
@@ -203,7 +203,7 @@
    :unknown-address                       "כתובת לא ידועה"
 
 
-   ;login
+   ;;login
    :connect                               "התחבר"
    :address                               "כתובת"
    :password                              "סיסמא"
@@ -211,23 +211,23 @@
    :sign-in                               "התחבר"
    :wrong-password                        "סיסמא שגויה"
 
-   ;recover
+   ;;recover
    :passphrase                            "משפט קוד"
    :recover                               "שחזר"
    :twelve-words-in-correct-order         "12 מילים בסדר הנכון"
 
-   ;accounts
+   ;;accounts
    :recover-access                        "שחזר גישה"
    :create-new-account                    "יצר איש קשר חדש"
 
-   ;wallet-qr-code
+   ;;wallet-qr-code
    :done                                  "הושלם"
    :main-wallet                           "ארנק ראשי"
 
-   ;validation
+   ;;validation
    :invalid-phone                         "מספר טלפון שגוי"
    :amount                                "כמות"
-   ;transactions
+   ;;transactions
    :confirm                               "אשר"
    :transaction                           "העברות"
    :status                                "סטטוס"
@@ -237,5 +237,5 @@
    :data                                  "נתונים"
    :got-it                                "קיבלתי"
 
-   ;:webview
+   ;;:webview
    :web-view-error                        "אופס,טעות"})

--- a/src/status_im/translations/hi.cljs
+++ b/src/status_im/translations/hi.cljs
@@ -2,17 +2,17 @@
 
 (def translations
   {
-   ;common
+   ;;common
    :members-title                         "सदस्य"
    :not-implemented                       "!कार्यान्वित नहीं"
    :chat-name                             "चैट नाम"
    :notifications-title                   "सूचनाएं और आवाज"
    :offline                               "ऑफ़लाइन"
 
-   ;drawer
+   ;;drawer
    :switch-users                          "उपयोगकर्ताओं को स्विच करें"
 
-   ;chat
+   ;;chat
    :is-typing                             "टाइप कर रहा है"
    :and-you                               "और आप"
    :search-chat                           "चैट खोजें"
@@ -29,11 +29,11 @@
    :suggestions-requests                  "अनुरोध"
    :suggestions-commands                  "कमांड"
 
-   ;sync
+   ;;sync
    :sync-in-progress                      "सिंक किया जा रहा है..."
    :sync-synced                           "सिंक में"
 
-   ;messages
+   ;;messages
    :status-sending                        "भेज रहे हैं"
    :status-pending                        "विचाराधीन"
    :status-sent                           "भेज दिया"
@@ -42,7 +42,7 @@
    :status-delivered                      "सौंप दिया"
    :status-failed                         "विफल रहा"
 
-   ;datetime
+   ;;datetime
    :datetime-second                       {:one   "सेकंड"
                                            :other "सेकंड"}
    :datetime-minute                       {:one   "मिनट"
@@ -55,7 +55,7 @@
    :datetime-yesterday                    "बीता हुआ कल"
    :datetime-today                        "आज"
 
-   ;profile
+   ;;profile
    :profile                               "प्रोफाइल"
    :message                               "संदेश"
    :not-specified                         "निर्दिष्ट नहीं"
@@ -68,7 +68,7 @@
    :image-source-make-photo               "प्राप्त करें"
    :image-source-gallery                  "गैलरी से चयन करें"
 
-   ;sign-up
+   ;;sign-up
    :contacts-syncronized                  "आपके संपर्कों को सिंक्रनाइज़ किया गया है"
    :confirmation-code                     (str "धन्यवाद! हमने आपको \"पुष्टि कोड\" के साथ एक टेक्स्ट संदेश भेजा है "
                                                "कृपया अपने फोन नंबर की पुष्टि करने के लिए वह कोड डालें।")
@@ -80,11 +80,11 @@
    :intro-message1                        "स्टेटस में आपका स्वागत है\n अपना पासवर्ड सेट करने और शुरुआत करने के लिए इस संदेश पर करें!"
    :account-generation-message            "मुझे एक सेकंड का समय दें, आपका खाता जनरेट करने के लिए मुझे कुछ क्रेजी गणित का प्रयोग करना होगा!"
 
-   ;chats
+   ;;chats
    :chats                                 "चैट"
    :new-group-chat                        "नई ग्रुप चैट"
 
-   ;discover
+   ;;discover
    :discover                              "खोज"
    :none                                  "कोई नहीं"
    :search-tags                           "अपने खोज टैग यहां टाइप करें"
@@ -92,17 +92,17 @@
    :recent                                "नया"
    :no-statuses-discovered                "कोई स्टेटस नहीं मिला"
 
-   ;settings
+   ;;settings
    :settings                              "सेटिंग्स"
 
-   ;contacts
+   ;;contacts
    :contacts                              "संपर्क"
    :new-contact                           "नया संपर्क"
    :contacts-group-new-chat               "नई चैट शुरू करें"
    :no-contacts                           "अभी तक कोई संपर्क नहीं"
    :show-qr                               "QR दिखाएं"
 
-   ;group-settings
+   ;;group-settings
    :remove                                "निकालें"
    :save                                  "सहेजें"
    :clear-history                         "इतिहास साफ़ करें"
@@ -110,14 +110,14 @@
    :edit                                  "संपादित करें"
    :add-members                           "सदस्य जोड़ें"
 
-   ;commands
+   ;;commands
    :chat-send-eth                         "{{amount}} ETH"
 
-   ;new-group
+   ;;new-group
 
-   ;participants
+   ;;participants
 
-   ;protocol
+   ;;protocol
    :received-invitation                   "चैट आमंत्रण प्राप्त हुआ"
    :removed-from-chat                     "आपको ग्रुप चैट से निकाल दिया"
    :left                                  "बाएं"
@@ -125,7 +125,7 @@
    :removed                               "निकाल दिया"
    :You                                   "आप"
 
-   ;new-contact
+   ;;new-contact
    :add-new-contact                       "नया संपर्क जोड़ें"
    :scan-qr                               "QR स्कैन करें"
    :name                                  "नाम"
@@ -135,31 +135,31 @@
    :unknown-address                       "अज्ञात पता"
 
 
-   ;login
+   ;;login
    :connect                               "कनेक्ट करें"
    :address                               "पता"
    :password                              "पासवर्ड"
    :wrong-password                        "गलत पासवर्ड"
 
-   ;recover
+   ;;recover
    :passphrase                            "पासफ्रेज"
    :recover                               "ठीक करें"
 
-   ;accounts
+   ;;accounts
    :recover-access                        "पहुंच को ठीक करें"
 
-   ;wallet-qr-code
+   ;;wallet-qr-code
    :done                                  "पूरा हो गया"
    :main-wallet                           "मुख्य वॉलेट"
 
-   ;validation
+   ;;validation
    :invalid-phone                         "अमान्य फोन नंबर"
    :amount                                "राशि"
-   ;transactions
+   ;;transactions
    :status                                "स्टेटस"
    :recipient                             "प्राप्तकर्ता"
 
-   ;:webview
+   ;;:webview
    :web-view-error                        "ओह, त्रुटि"
 
    :confirm                               "पुष्टि करें"

--- a/src/status_im/translations/hu.cljs
+++ b/src/status_im/translations/hu.cljs
@@ -2,17 +2,17 @@
 
 (def translations
   {
-   ;common
+   ;;common
    :members-title                         "Tagok"
    :not-implemented                       "!nem végrehajtott"
    :chat-name                             "Csevegés neve"
    :notifications-title                   "Értesítések és hangok"
    :offline                               "Offline"
 
-   ;drawer
+   ;;drawer
    :switch-users                          "Felhasználók váltása"
 
-   ;chat
+   ;;chat
    :is-typing                             "gépel"
    :and-you                               "és te"
    :search-chat                           "Csevegés keresése"
@@ -29,11 +29,11 @@
    :suggestions-requests                  "Kérések"
    :suggestions-commands                  "Parancsok"
 
-   ;sync
+   ;;sync
    :sync-in-progress                      "Szinkronizálás..."
    :sync-synced                           "Szinkronizálás folyamatban"
 
-   ;messages
+   ;;messages
    :status-sending                        "Küldés"
    :status-pending                        "Függőben levő"
    :status-sent                           "Elküldve"
@@ -42,7 +42,7 @@
    :status-delivered                      "Kézbesítve"
    :status-failed                         "Nem sikerült"
 
-   ;datetime
+   ;;datetime
    :datetime-second                       {:one   "másodperc"
                                            :other "másodperc"}
    :datetime-minute                       {:one   "perc"
@@ -55,7 +55,7 @@
    :datetime-yesterday                    "tegnap"
    :datetime-today                        "ma"
 
-   ;profile
+   ;;profile
    :profile                               "Profil"
    :message                               "Üzenet"
    :not-specified                         "Nincs megadva"
@@ -68,7 +68,7 @@
    :image-source-make-photo               "Rögzítés"
    :image-source-gallery                  "Kiválasztás a galériából"
 
-   ;sign-up
+   ;;sign-up
    :contacts-syncronized                  "Kapcsolataid szinkronizálásra kerültek"
    :confirmation-code                     (str "Köszönjük! Küldtünk neked egy szöveges üzenetet megerősítési "
                                                "kóddal. Kérjük, add meg a kódot telefonszámod megerősítése érdekében")
@@ -80,11 +80,11 @@
    :intro-message1                        "Üdv az Állapotnál\nÉrints erre a üzenetre, állítsd be a jelszavad és fogj hozzá!"
    :account-generation-message            "Adj egy percet, varázsolok egy kicsit és létre is hozom a felhasználói fiókodat!"
 
-   ;chats
+   ;;chats
    :chats                                 "Csevegések"
    :new-group-chat                        "Új csoportos csevegés"
 
-   ;discover
+   ;;discover
    :discover                              "Felfedezés"
    :none                                  "Semmi"
    :search-tags                           "Add meg keresési címkéidet itt"
@@ -92,17 +92,17 @@
    :recent                                "Legutóbbi"
    :no-statuses-discovered                "Nincsenek felfedezett állapotok"
 
-   ;settings
+   ;;settings
    :settings                              "Beállítások"
 
-   ;contacts
+   ;;contacts
    :contacts                              "Kapcsolatok"
    :new-contact                           "Új kapcsolat"
    :contacts-group-new-chat               "Új csevegés indítása"
    :no-contacts                           "Még nincsenek kapcsolatok"
    :show-qr                               "QR mutatása"
 
-   ;group-settings
+   ;;group-settings
    :remove                                "Eltávolítás"
    :save                                  "Mentés"
    :clear-history                         "Előzmények törlése"
@@ -110,14 +110,14 @@
    :edit                                  "Szerkesztés"
    :add-members                           "Tagok hozzáadása"
 
-   ;commands
+   ;;commands
    :chat-send-eth                         "{{amount}} ETH"
 
-   ;new-group
+   ;;new-group
 
-   ;participants
+   ;;participants
 
-   ;protocol
+   ;;protocol
    :received-invitation                   "csevegési meghívásban részesült"
    :removed-from-chat                     "eltávolítva a csoportos csevegésből"
    :left                                  "maradt"
@@ -125,7 +125,7 @@
    :removed                               "eltávolított"
    :You                                   "Te"
 
-   ;new-contact
+   ;;new-contact
    :add-new-contact                       "Új kapcsolat hozzáadása"
    :scan-qr                               "QR beolvasása"
    :name                                  "Név"
@@ -135,31 +135,31 @@
    :unknown-address                       "Ismeretlen cím"
 
 
-   ;login
+   ;;login
    :connect                               "Kapcsolódás"
    :address                               "Cím"
    :password                              "Jelszó"
    :wrong-password                        "Hibás jelszó"
 
-   ;recover
+   ;;recover
    :passphrase                            "Jelmondat"
    :recover                               "Visszaállítás"
 
-   ;accounts
+   ;;accounts
    :recover-access                        "Hozzáférés helyreállítása"
 
-   ;wallet-qr-code
+   ;;wallet-qr-code
    :done                                  "Kész"
    :main-wallet                           "Fő zseb"
 
-   ;validation
+   ;;validation
    :invalid-phone                         "Hibás telefonszám"
    :amount                                "Összeg"
-   ;transactions
+   ;;transactions
    :status                                "Állapot"
    :recipient                             "Címzett"
 
-   ;:webview
+   ;;:webview
    :web-view-error                        "hoppá, hiba"
 
    :confirm                               "Megerősít"

--- a/src/status_im/translations/id.cljs
+++ b/src/status_im/translations/id.cljs
@@ -2,17 +2,17 @@
 
 (def translations
   {
-   ;common
+   ;;common
    :members-title                         "anggota"
    :not-implemented                       "tidak diimplementasikan !"
    :chat-name                             "nama obrolan"
    :notifications-title                   "judul notifikasi"
    :offline                               "offline"
 
-   ;drawer
+   ;;drawer
    :switch-users                          "beralih pengguna"
 
-   ;chat
+   ;;chat
    :is-typing                             "sedang mengetik"
    :and-you                               "dan kamu"
    :search-chat                           "cari obrolan"
@@ -29,11 +29,11 @@
    :suggestions-requests                  "permintaan"
    :suggestions-commands                  "perintah"
 
-   ;sync
+   ;;sync
    :sync-in-progress                      "sinkronisasi..."
    :sync-synced                           "disinkronisasi"
 
-   ;messages
+   ;;messages
    :status-sending                        "mengirim"
    :status-pending                        "pending"
    :status-sent                           "dikirim"
@@ -42,7 +42,7 @@
    :status-delivered                      "terkirim"
    :status-failed                         "gagal"
 
-   ;datetime
+   ;;datetime
    :datetime-second                       {:one   "detik"
                                            :other "detik"}
    :datetime-minute                       {:one   "menit"
@@ -55,7 +55,7 @@
    :datetime-yesterday                    "kemarin"
    :datetime-today                        "hari ini"
 
-   ;profile
+   ;;profile
    :profile                               "profil"
    :message                               "pesan"
    :not-specified                         "tidak ditentukan"
@@ -68,7 +68,7 @@
    :image-source-make-photo               "capture"
    :image-source-gallery                  "pilih dari Galeri"
 
-   ;sign-up
+   ;;sign-up
    :contacts-syncronized                  "kontak telah disinkronkan"
    :confirmation-code                     (str "terima kasih! Kami telah mengirim pesan teks untuk mengkonfirmasi akun anda "
                                                "kode. untuk mengkonfirmasi nomor telepon Anda, masukkan kode ini")
@@ -80,11 +80,11 @@
    :intro-message1                        "selamat datang di Status \n klik pesan ini untuk mengatur sandi Anda & memulai!"
    :account-generation-message            "beri kami waktu, kami harus membuat perhitungan super untuk menghasilkan akun anda sendiri"
 
-   ;chats
+   ;;chats
    :chats                                 "obrolan"
    :new-group-chat                        "obrolan grup baru"
 
-   ;discover
+   ;;discover
    :discover                              "mendeteksi"
    :none                                  "apa saja"
    :search-tags                           "silakan memasukkan pencarian di tag"
@@ -92,17 +92,17 @@
    :recent                                "terbaru"
    :no-statuses-discovered                "informasi status tidak ditemukan"
 
-   ;settings
+   ;;settings
    :settings                              "pengaturan"
 
-   ;contacts
+   ;;contacts
    :contacts                              "kontak"
    :new-contact                           "kontak baru"
    :contacts-group-new-chat               "untuk memulai obrolan baru"
    :no-contacts                           "tidak ada kontak"
    :show-qr                               "show QR kode"
 
-   ;group-settings
+   ;;group-settings
    :remove                                "menghapus"
    :save                                  "menyimpan"
    :clear-history                         "bersihkan riwayat"
@@ -110,14 +110,14 @@
    :edit                                  "edit"
    :add-members                           "tambah anggota"
 
-   ;commands
+   ;;commands
    :chat-send-eth                         "{{amount}} ETH"
 
-   ;new-group
+   ;;new-group
 
-   ;participants
+   ;;participants
 
-   ;protocol
+   ;;protocol
    :received-invitation                   "telah menerima undangan untuk obrolan"
    :removed-from-chat                     "anda dihapus dari grup obrolan"
    :left                                  "tinggalkan"
@@ -125,7 +125,7 @@
    :removed                               "hapus"
    :You                                   "kamu"
 
-   ;new-contact
+   ;;new-contact
    :add-new-contact                       "menambahkan kontak baru"
    :scan-qr                               "memindai kode QR ini"
    :name                                  "nama"
@@ -135,29 +135,29 @@
    :unknown-address                       "alamat tidak diketahui"
 
 
-   ;login
+   ;;login
    :connect                               "terhubung"
    :address                               "alamat"
    :password                              "kata sandi"
    :wrong-password                        "kata sandi salah"
 
-   ;recover
+   ;;recover
    :passphrase                            "passphrase"
    :recover                               "pemulihan"
 
-   ;accounts
+   ;;accounts
    :recover-access                        "akses Pemulihan"
 
-   ;wallet-qr-code
+   ;;wallet-qr-code
    :done                                  "lengkap"
    :main-wallet                           "wallet utama"
 
-   ;validation
+   ;;validation
    :invalid-phone                         "nomor telepon salah"
    :amount                                "jumlah dana"
-   ;transactions
+   ;;transactions
    :status                                "kondisi"
    :recipient                             "penerima"
 
-   ;:webview
+   ;;:webview
    :web-view-error                        "oopss, error"})

--- a/src/status_im/translations/it_ch.cljs
+++ b/src/status_im/translations/it_ch.cljs
@@ -2,17 +2,17 @@
 
 (def translations
   {
-   ;common
+   ;;common
    :members-title                         "Membri"
    :not-implemented                       "!non implementato"
    :chat-name                             "Nome chat"
    :notifications-title                   "Notifiche e suoni"
    :offline                               "Offline"
 
-   ;drawer
+   ;;drawer
    :switch-users                          "Cambia utenti"
 
-   ;chat
+   ;;chat
    :is-typing                             "sta scrivendo"
    :and-you                               "e tu"
    :search-chat                           "Cerca chat"
@@ -29,11 +29,11 @@
    :suggestions-requests                  "Richieste"
    :suggestions-commands                  "Comandi"
 
-   ;sync
+   ;;sync
    :sync-in-progress                      "Sincronizzazione in corso..."
    :sync-synced                           "Sincronizzato"
 
-   ;messages
+   ;;messages
    :status-sending                        "Invio in corso"
    :status-pending                        "In attesa di"
    :status-sent                           "Inviato"
@@ -42,7 +42,7 @@
    :status-delivered                      "Consegnato"
    :status-failed                         "Invio fallito"
 
-   ;datetime
+   ;;datetime
    :datetime-second                       {:one   "secondo"
                                            :other "secondi"}
    :datetime-minute                       {:one   "minuto"
@@ -55,7 +55,7 @@
    :datetime-yesterday                    "ieri"
    :datetime-today                        "oggi"
 
-   ;profile
+   ;;profile
    :profile                               "Profilo"
    :message                               "Messaggio"
    :not-specified                         "Non specificato"
@@ -68,7 +68,7 @@
    :image-source-make-photo               "Scatta"
    :image-source-gallery                  "Seleziona dalla galleria immagini"
 
-   ;sign-up
+   ;;sign-up
    :contacts-syncronized                  "I tuoi contatti sono stati sincronizzati"
    :confirmation-code                     (str "Grazie! Ti abbiamo inviato un messaggio con un codice di "
                                                "conferma. Utilizza tale codice per confermare il tuo numero di telefono")
@@ -80,11 +80,11 @@
    :intro-message1                        "Benvenuto su Status\nTocca questo messaggio per impostare la tua password e iniziare!"
    :account-generation-message            "Dammi un secondo, devo eseguire dei calcoli matematici complessi per generare il tuo conto!"
 
-   ;chats
+   ;;chats
    :chats                                 "Conversazioni"
    :new-group-chat                        "Nuova conversazione di gruppo"
 
-   ;discover
+   ;;discover
    :discover                              "Scoperta"
    :none                                  "Nessuna"
    :search-tags                           "Inserisci qui i tag di ricerca"
@@ -92,17 +92,17 @@
    :recent                                "Recente"
    :no-statuses-discovered                "Nessuno stato identificato"
 
-   ;settings
+   ;;settings
    :settings                              "Impostazioni"
 
-   ;contacts
+   ;;contacts
    :contacts                              "Contatti"
    :new-contact                           "Nuovo contatto"
    :contacts-group-new-chat               "Inizia una nuova conversazione"
    :no-contacts                           "Nessun contatto registrato"
    :show-qr                               "Mostra QR"
 
-   ;group-settings
+   ;;group-settings
    :remove                                "Rimuovi"
    :save                                  "Salva"
    :clear-history                         "Cancella cronologia"
@@ -110,14 +110,14 @@
    :edit                                  "Modifica"
    :add-members                           "Aggiungi membri"
 
-   ;commands
+   ;;commands
    :chat-send-eth                         "{{amount}} ETH"
 
-   ;new-group
+   ;;new-group
 
-   ;participants
+   ;;participants
 
-   ;protocol
+   ;;protocol
    :received-invitation                   "ha ricevuto un invito di conversazione"
    :removed-from-chat                     "ti ha rimosso dalla conversazione di gruppo"
    :left                                  "È uscito"
@@ -125,7 +125,7 @@
    :removed                               "È stato rimosso"
    :You                                   "Tu"
 
-   ;new-contact
+   ;;new-contact
    :add-new-contact                       "Aggiungi nuovo contatto"
    :scan-qr                               "Scansiona QR"
    :name                                  "Nome"
@@ -135,31 +135,31 @@
    :unknown-address                       "Indirizzo sconosciuto"
 
 
-   ;login
+   ;;login
    :connect                               "Effettua connessione"
    :address                               "Indirizzo"
    :password                              "Password"
    :wrong-password                        "Password errata"
 
-   ;recover
+   ;;recover
    :passphrase                            "Passphrase"
    :recover                               "Ripristina"
 
-   ;accounts
+   ;;accounts
    :recover-access                        "Ripristina l'accesso"
 
-   ;wallet-qr-code
+   ;;wallet-qr-code
    :done                                  "OK"
    :main-wallet                           "Wallet principale"
 
-   ;validation
+   ;;validation
    :invalid-phone                         "Numero di telefono non valido"
    :amount                                "Saldo"
-   ;transactions
+   ;;transactions
    :status                                "Stato"
    :recipient                             "Beneficiario"
 
-   ;:webview
+   ;;:webview
    :web-view-error                        "Ops, si è verificato un errore"
 
    :confirm                               "Conferma"

--- a/src/status_im/translations/ja.cljs
+++ b/src/status_im/translations/ja.cljs
@@ -2,7 +2,7 @@
 
 (def translations
   {
-   ;common
+   ;;common
    :members-title                         "メンバー"
    :not-implemented                       "実装されていません"
    :chat-name                             "チャット名"
@@ -25,11 +25,11 @@
    :camera-access-error                   "必要なカメラの許可を与えるには、システム設定に行き、ステータス>カメラが選択されていることを確認してください。"
    :photos-access-error                   "必要な写真の許可を与えるには、あなたのシステム設定に行き、ステータス> 写真が選択されていることを確認してください。"
 
-   ;drawer
+   ;;drawer
    :switch-users                          "ユーザーの切り替え"
    :current-network                       "現在のネットワーク"
 
-   ;chat
+   ;;chat
    :is-typing                             "が入力中"
    :and-you                               "とあなた"
    :search-chat                           "チャットを検索"
@@ -49,11 +49,11 @@
    :faucet-success                        "フォーセットリクエストを受け取りました"
    :faucet-error                          "フォーセットリクエストエラー"
 
-   ;sync
+   ;;sync
    :sync-in-progress                      "同期中..."
    :sync-synced                           "同期しました"
 
-   ;messages
+   ;;messages
    :status-sending                        "送信中"
    :status-pending                        "保留中"
    :status-sent                           "送信済み"
@@ -62,7 +62,7 @@
    :status-delivered                      "配達済み"
    :status-failed                         "失敗しました"
 
-   ;datetime
+   ;;datetime
    :datetime-ago-format                   "{{number}} {{time-intervals}} {{ago}}"
    :datetime-second                       {:one   "秒"
                                            :other "秒"}
@@ -76,7 +76,7 @@
    :datetime-yesterday                    "昨日"
    :datetime-today                        "今日"
 
-   ;profile
+   ;;profile
    :profile                               "プロフィール"
    :edit-profile                          "プロフィールを編集"
    :message                               "メッセージ"
@@ -108,7 +108,7 @@
    :browsing-open-in-web-browser          "ブラウザーで閲覧"
    :browsing-cancel                       "キャンセル"
 
-   ;sign-up
+   ;;sign-up
    :contacts-syncronized                  "連絡先が同期されました"
    :confirmation-code                     (str "ありがとうございます！ 確認コードが記載されたメッセージが"
                                                "送信されました。電話番号を確認するにはそのコードを入力してください")

--- a/src/status_im/translations/la.cljs
+++ b/src/status_im/translations/la.cljs
@@ -1,18 +1,18 @@
 (ns status-im.translations.la)
- 
+
 (def translations
   {
-   ;common
+   ;;common
    :members-title                         "sodalis"
    :not-implemented                       "ne attexit"
    :chat-name                             "nomen colloquii"
    :notifications-title                   "nuntiationes"
    :offline                               "abesse"
- 
-   ;drawer
+
+   ;;drawer
    :switch-users                          "utens ex cambit"
- 
-   ;chat
+
+   ;;chat
    :is-typing                             "conscribit"
    :and-you                               "et tu"
    :search-chat                           "perscruta colloquii"
@@ -28,12 +28,12 @@
    :no-messages                           "ne nuntii"
    :suggestions-requests                  "precatus"
    :suggestions-commands                  "jussum"
- 
-   ;sync
+
+   ;;sync
    :sync-in-progress                      "synchronizari..."
    :sync-synced                           "synchronizatum esse"
- 
-   ;messages
+
+   ;;messages
    :status-sending                        "allegere"
    :status-pending                        "tractare"
    :status-sent                           "deditum iri"
@@ -41,8 +41,8 @@
    :status-seen                           "adspectatum esse"
    :status-delivered                      "deditum esse"
    :status-failed                         "vitiosus"
- 
-   ;datetime
+
+   ;;datetime
    :datetime-ago-format                   "{{ago}} {{number}} {{time-intervals}}"
    :datetime-second                       {:one   "pars minuta secunda horae"
                                            :other "pars minuta secunda horae"}
@@ -55,8 +55,8 @@
    :datetime-ago                          "anto"
    :datetime-yesterday                    "heri"
    :datetime-today                        "hodie"
- 
-   ;profile
+
+   ;;profile
    :profile                               "biographia"
    :message                               "nuntium"
    :not-specified                         "ne adnotans"
@@ -67,7 +67,7 @@
    :image-source-title                    "photographia bigraphiae"
    :image-source-make-photo               "photographere"
    :image-source-gallery                  "eligere ad pinacothecae"
-   ;sign-up
+   ;;sign-up
    :contacts-syncronized                  "contagium sui synchronizatum esse."
    :confirmation-code                     (str "gratias tibi! misimus nuntium conscriptionis cum notae. "
                                                "transcribe notam, ut nummerum telefonicum possimus verificare.")
@@ -78,78 +78,78 @@
    :intro-status                          "habere colloquium cum me, ut syngraphus sui congerit et moderationes sui mutare!"
    :intro-message1                        "salve! hic Status est!.\n attige id nuntium, ut signum arcanum sui congere et incipere!"
    :account-generation-message            "mane! cumputo benificium sui."
- 
-   ;chats
+
+   ;;chats
    :chats                                 "colloquia"
    :new-group-chat                        "novum colloquium circli"
- 
-   ;discover
+
+   ;;discover
    :discover                              "invenite"
    :none                                  "nihil"
    :search-tags                           "perscribe hic verbum querentis"
    :popular-tags                          "favorabilis opiones"
    :recent                                "novae"
    :no-statuses-discovered                "nullus status repertum esse"
- 
-   ;settings
+
+   ;;settings
    :settings                              "moderationes"
- 
-   ;contacts
+
+   ;;contacts
    :contacts                              "contagiis"
    :new-contact                           "novum contagium"
    :contacts-group-new-chat               "novum colloquium circli"
    :no-contacts                           "Nulla contagio"
    :show-qr                               "QR-nota elucere"
- 
-   ;group-settings
+
+   ;;group-settings
    :remove                                "amovere"
    :save                                  "apothecare"
    :clear-history                         "processus amovere"
    :chat-settings                         "moderationes colloquiorum"
    :edit                                  "commutare"
    :add-members                           "sodalis adjungere"
-   ;commands
+   ;;commands
    :chat-send-eth                         "{{amount}} ETH"
-   ;new-group
-   ;participants
-   ;protocol
+   ;;new-group
+   ;;participants
+   ;;protocol
    :received-invitation                   "nancisci colloquium circli"
    :removed-from-chat                     "ex colloquium circli relinquere"
    :left                                  "desse"
    :invited                               "invitavisse"
    :removed                               "reliquisse"
    :You                                   "tu"
- 
-   ;new-contact
+
+   ;;new-contact
    :add-new-contact                       "nova  contagio adjungere"
    :scan-qr                               "QR-nota photographere"
    :name                                  "nomen"
-   :address-explication                   "explain what adresses are" ; TODO
+   :address-explication                   "explain what adresses are" ;; TODO
    :contact-already-added                 "iste contagio jam adjunctum esse"
    :can-not-add-yourself                  "ne potest adjungere ipse!"
    :unknown-address                       "ignotum adloquium"
- 
- 
-   ;login
+
+
+   ;;login
    :connect                               "iungere"
    :address                               "adloquium"
    :password                              "signum arcanum"
    :wrong-password                        "falsum signum acranum"
- 
-   ;recover
+
+   ;;recover
    :passphrase                            "phrasis arcana"
    :recover                               "recreare"
-   ;accounts
+   ;;accounts
    :recover-access                        "restituere possessio"
-   ;wallet-qr-code
+   ;;wallet-qr-code
    :done                                  "paratus"
    :main-wallet                           "crumera caput"
- 
-   ;validation
+
+   ;;validation
    :invalid-phone                         "nummerus telephonicus"
    :amount                                "summa"
-   ;transactions
+   ;;transactions
    :status                                "status"
    :recipient                             "acceptor"
-   ;:webview
+   ;;:webview
    :web-view-error                        "Erratum ad adspectus"})

--- a/src/status_im/translations/lv.cljs
+++ b/src/status_im/translations/lv.cljs
@@ -2,7 +2,7 @@
 
 (def translations
   {
-   ;common
+   ;;common
    :members-title                         "Dalībnieki"
    :not-implemented                       "!tādas funkcijas pagaidām nav"
    :chat-name                             "Čata nosaukums"
@@ -18,11 +18,11 @@
    :camera-access-error                   "Kļūda, nav atļaujas piekļūt kamerai. Lūdzu, iestatījumos pārliecinies, ka  Status > Camera ir izvēlēts."
    :photos-access-error                   "Kļūda, nav atļaujas piekļūt fotogrāfijām. Lūdzu, iestatījumos pārliecinies, ka Status > Photos ir izvēlēts."
 
-   ;drawer
+   ;;drawer
    :switch-users                          "Mainīt lietotāju"
    :current-network                       "Tīkls"
 
-   ;chat
+   ;;chat
    :is-typing                             "raksta"
    :and-you                               "un tu"
    :search-chat                           "Meklēt čatu"
@@ -42,11 +42,11 @@
    :faucet-success                        "Faucet pieprasījums saņemts"
    :faucet-error                          "Faucet pieprasījuma kļūda"
 
-   ;sync
+   ;;sync
    :sync-in-progress                      "Sinhronizē..."
    :sync-synced                           "Sinhronizēts"
 
-   ;messages
+   ;;messages
    :status-sending                        "Sūta"
    :status-pending                        "Neizlemts"
    :status-sent                           "Aizsūtīts"
@@ -55,7 +55,7 @@
    :status-delivered                      "Piegādāts"
    :status-failed                         "Neizdevās"
 
-   ;datetime
+   ;;datetime
    :datetime-ago-format                   "{{number}} {{time-intervals}} {{ago}}"
    :datetime-second                       {:one   "sekunde"
                                            :other "sekundes"}
@@ -69,7 +69,7 @@
    :datetime-yesterday                    "vakar"
    :datetime-today                        "šodien"
 
-   ;profile
+   ;;profile
    :profile                               "Profils"
    :edit-profile                          "Rediģēt profilu"
    :message                               "Īsziņa"
@@ -98,7 +98,7 @@
    :browsing-open-in-web-browser          "Atvert pārlūkprogrammā"
    :browsing-cancel                       "Atcelt"
 
-   ;sign-up
+   ;;sign-up
    :contacts-syncronized                  "Jūsu kontakti ir sinhronizēti"
    :confirmation-code                     (str "Paldies! Mēs nosūtijām tev īsziņu ar apstiprinājuma kodu"
                                                "code. Lūdzu ievadi apstiprinājuma kodu lai verificētu savu telefona numuru")
@@ -113,13 +113,13 @@
    :move-to-internal-failure-message      "Mums vajag pārvietot dažus failus no eksternās uz interno glabātuvi. Lai mēs to varētu izdarīt mums vajag jūsu atļauju."
    :debug-enabled                         "Debug serveris startēja! Tu vari izlietot *status-dev-cli scan* lai atrastu serveri."
 
-   ;phone types
+   ;;phone types
    :phone-e164                            "International 1"
    :phone-international                   "International 2"
    :phone-national                        "National"
    :phone-significant                     "Significant"
 
-   ;chats
+   ;;chats
    :chats                                 "Čati"
    :delete-chat                           "Dzēst čatu"
    :new-group-chat                        "Jauna grupa"
@@ -130,7 +130,7 @@
    :topic-format                          "Nepareiz formāts [a-z0-9\\-]+"
    :public-group-topic                    "Temats"
 
-   ;discover
+   ;;discover
    :discover                              "Discover"
    :none                                  "None"
    :search-tags                           "Type your search tags here"
@@ -139,10 +139,10 @@
    :no-statuses-discovered                "No statuses discovered"
    :no-statuses-found                     "No statuses found"
 
-   ;settings
+   ;;settings
    :settings                              "Iestatījumi"
 
-   ;contacts
+   ;;contacts
    :contacts                              "Kontakti"
    :new-contact                           "Jauns kontakts"
    :delete-contact                        "Dzēst kontaktu"
@@ -157,7 +157,7 @@
    :enter-address                         "Ieraksti adresi"
    :more                                  "vairāk"
 
-   ;group-settings
+   ;;group-settings
    :remove                                "Noņemt"
    :save                                  "Saglabāt"
    :delete                                "Dzēst"
@@ -168,10 +168,10 @@
    :edit                                  "Rediģēt"
    :add-members                           "Pievienot biedrus"
 
-   ;commands
+   ;;commands
    :chat-send-eth                         "{{amount}} ETH"
 
-   ;new-group
+   ;;new-group
    :new-group                             "Jauna grupa"
    :reorder-groups                        "Reorder groups"
    :edit-group                            "Rediģēt grupu"
@@ -180,9 +180,9 @@
    :delete-group-prompt                   "Tas neietikmēs kontaktus"
    :contact-s                             {:one   "kontakts"
                                            :other "kontakti"}
-   ;participants
+   ;;participants
 
-   ;protocol
+   ;;protocol
    :received-invitation                   "čata uzaicinājums"
    :removed-from-chat                     "noņema jūs no grupas čata"
    :left                                  "atstāja grupu"
@@ -190,7 +190,7 @@
    :removed                               "noņemts"
    :You                                   "Tu"
 
-   ;new-contact
+   ;;new-contact
    :add-new-contact                       "Pievienot jaunu kontaktu"
    :scan-qr                               "Skanēt QR"
    :name                                  "Vārds"
@@ -201,7 +201,7 @@
    :unknown-address                       "Nezināmā adrese"
 
 
-   ;login
+   ;;login
    :connect                               "Savienoties"
    :address                               "Adrese"
    :password                              "Parole"
@@ -209,23 +209,23 @@
    :sign-in                               "Ieiet"
    :wrong-password                        "Parole ievadīta nepareizi"
 
-   ;recover
+   ;;recover
    :passphrase                            "Passphrase"
    :recover                               "Atgūt"
    :twelve-words-in-correct-order         "12 vārdi"
 
-   ;accounts
+   ;;accounts
    :recover-access                        "Atgūt pieeju"
    :create-new-account                    "Izveidot jaunu kontu"
 
-   ;wallet-qr-code
+   ;;wallet-qr-code
    :done                                  "Darīts"
    :main-wallet                           "Galvenais maks"
 
-   ;validation
+   ;;validation
    :invalid-phone                         "Nepareizs telefona numurs"
    :amount                                "Summa"
-   ;transactions
+   ;;transactions
    :confirm                               "Apstiprināt"
    :transaction                           "Transakcija"
    :status                                "Status"
@@ -235,5 +235,5 @@
    :data                                  "Dati"
    :got-it                                "Got it"
 
-   ;:webview
+   ;;:webview
    :web-view-error                        "ups, kļūda"})

--- a/src/status_im/translations/ms.cljs
+++ b/src/status_im/translations/ms.cljs
@@ -2,7 +2,7 @@
 
 (def translations
   {
-   ;common
+   ;;common
    :members-title                         "Ahli"
    :not-implemented                       "!tidak diimplementasikan"
    :chat-name                             "Nama perbualan"
@@ -18,11 +18,11 @@
    :camera-access-error                   "Untuk memberi keizinan akses kamera yang diperlukan, sila pergi ke aturan sistem anda dan pastikan bahawa Status > Kamera telah dipilih."
    :photos-access-error                   "Untuk memberi keizinan akses gambar yang diperlukan, sila pergi ke aturan sistem anda dan pastikan bahawa Status > Gambar telah dipilih."
 
-   ;drawer
+   ;;drawer
    :switch-users                          "Tukar pengguna"
    :current-network                       "Rangkaian sekarang"
 
-   ;chat
+   ;;chat
    :is-typing                             "sedang menaip"
    :and-you                               "dan anda"
    :search-chat                           "Cari perbualan"
@@ -42,11 +42,11 @@
    :faucet-success                        "Permintaan Faucet telah diterima"
    :faucet-error                          "Permintaan Faucet gagal"
 
-   ;sync
+   ;;sync
    :sync-in-progress                      "sedang disegerakan..."
    :sync-synced                           "Dalam penyegeraan"
 
-   ;messages
+   ;;messages
    :status-sending                        "Menghantar"
    :status-pending                        "Belum selesai"
    :status-sent                           "Dihantar"
@@ -55,7 +55,7 @@
    :status-delivered                      "Dihantar"
    :status-failed                         "Gagal"
 
-   ;datetime
+   ;;datetime
    :datetime-ago-format                   "{{number}} {{time-intervals}} {{ago}}"
    :datetime-second                       {:one   "saat"
                                            :other "saat"}
@@ -69,7 +69,7 @@
    :datetime-yesterday                    "semalam"
    :datetime-today                        "hari ini"
 
-   ;profile
+   ;;profile
    :profile                               "Profail"
    :edit-profile                          "Ubah profail"
    :message                               "Mesej"
@@ -99,7 +99,7 @@
    :browsing-open-in-web-browser          "Buka dalam pelayar web"
    :browsing-cancel                       "Batal"
 
-   ;sign-up
+   ;;sign-up
    :contacts-syncronized                  "Senarai kenalan anda telah disegerakan"
    :confirmation-code                     (str "Terima kasih! Kami telah menghantar kepada anda satu mesej mengandungi kod"
                                                "pengesahan. Sila berikan kod tersebut untuk mengesahkan nombor telefon anda")
@@ -114,13 +114,13 @@
    :move-to-internal-failure-message      "Kita perlu mengubah lokasi sedikit fail penting dari memori dalaman ke memori luaran. Untuk itu, kami perlukan kebenaran anda. Kami tidak akan menggunakan memori luaran pada versi akan datang."
    :debug-enabled                         "Debug server telah dijalankan! Sekarang anda boleh menjalankan *status-dev-cli scan* untuk mecari sambungan server dari komputer anda dalam jaringan yang sama."
 
-   ;phone types
+   ;;phone types
    :phone-e164                            "Internasional 1"
    :phone-international                   "Internasional 2"
    :phone-national                        "Nasional"
    :phone-significant                     "Penting"
 
-   ;chats
+   ;;chats
    :chats                                 "Perbualan"
    :delete-chat                           "Padam perbualan"
    :new-group-chat                        "Perbualan kumpulan baru"
@@ -131,7 +131,7 @@
    :topic-format                          "Format salah [a-z0-9\\-]+"
    :public-group-topic                    "Topik"
 
-   ;discover
+   ;;discover
    :discover                              "Jelajah"
    :none                                  "Tiada"
    :search-tags                           "Taip carian anda disini"
@@ -140,10 +140,10 @@
    :no-statuses-discovered                "Tiada status ditemui"
    :no-statuses-found                     "Tiada status ditemui"
 
-   ;settings
+   ;;settings
    :settings                              "Aturan"
 
-   ;contacts
+   ;;contacts
    :contacts                              "Kenalan"
    :new-contact                           "Kenalan baru"
    :delete-contact                        "Padam kenalan"
@@ -158,7 +158,7 @@
    :enter-address                         "Masukkan address"
    :more                                  "seterusnya"
 
-   ;group-settings
+   ;;group-settings
    :remove                                "Buang"
    :save                                  "Simpan"
    :delete                                "Padam"
@@ -169,10 +169,10 @@
    :edit                                  "Ubah"
    :add-members                           "Tambah ahli"
 
-   ;commands
+   ;;commands
    :chat-send-eth                         "{{amount}} ETH"
 
-   ;new-group
+   ;;new-group
    :new-group                             "Kumpulan baru"
    :reorder-groups                        "Susun kumpulan"
    :edit-group                            "Ubah kumpulan"
@@ -181,9 +181,9 @@
    :delete-group-prompt                   "Ini tidak akan menjejaskan senarai kenalan anda"
    :contact-s                             {:one   "kenalan"
                                            :other "kenalan"}
-   ;participants
+   ;;participants
 
-   ;protocol
+   ;;protocol
    :received-invitation                   "menerima permintaan bual"
    :removed-from-chat                     "membuang anda dari perbualan kumpulan"
    :left                                  "pergi"
@@ -191,7 +191,7 @@
    :removed                               "dibuang"
    :You                                   "Anda"
 
-   ;new-contact
+   ;;new-contact
    :add-new-contact                       "Tambah kenalan baru"
    :scan-qr                               "Imbas kod QR"
    :name                                  "Nama"
@@ -202,7 +202,7 @@
    :unknown-address                       "Address tidak diketahui"
 
 
-   ;login
+   ;;login
    :connect                               "Sambung"
    :address                               "Address"
    :password                              "Kata laluan"
@@ -210,23 +210,23 @@
    :sign-in                               "Daftar masuk"
    :wrong-password                        "Kata laluan salah"
 
-   ;recover
+   ;;recover
    :passphrase                            "Ayat pengesahan"
    :recover                               "Pulihkan"
    :twelve-words-in-correct-order         "12 perkataan dalam susunan yang betul"
 
-   ;accounts
+   ;;accounts
    :recover-access                        "Pulihkan akses"
    :create-new-account                    "Cipta akaun baru"
 
-   ;wallet-qr-code
+   ;;wallet-qr-code
    :done                                  "Selesai"
    :main-wallet                           "Dompet utama"
 
-   ;validation
+   ;;validation
    :invalid-phone                         "Nombor telefon salah"
    :amount                                "Jumlah"
-   ;transactions
+   ;;transactions
    :confirm                               "Sahkan"
    :transaction                           "Transaksi"
    :status                                "Status"
@@ -236,5 +236,5 @@
    :data                                  "Maklumat"
    :got-it                                "Ya"
 
-   ;:webview
+   ;;:webview
    :web-view-error                        "oops, gagal"})

--- a/src/status_im/translations/nb.cljs
+++ b/src/status_im/translations/nb.cljs
@@ -2,7 +2,7 @@
 
 (def translations
   {
-   ;common
+   ;;common
    :members-title                         "Medlemmer"
    :not-implemented                       "!ikke implementert"
    :chat-name                             "Kallenavn"
@@ -20,11 +20,11 @@
    :camera-access-error                   "For å tillate bruk av kamera, gå til systeminstillinger og sørg for at Status > Kamera er aktivert."
    :photos-access-error                   "For å tillate bruk av bilder, gå til systeminstillinger og sørg for at Status > Bilder er aktivert."
 
-   ;drawer
+   ;;drawer
    :switch-users                          "Bytt brukere"
    :current-network                       "Nåværende nettverk"
 
-   ;chat
+   ;;chat
    :is-typing                             "skriver"
    :and-you                               "og du"
    :search-chat                           "Søk i meldinger"
@@ -44,11 +44,11 @@
    :faucet-success                        "Du har mottatt en faucet forespørsel"
    :faucet-error                          "Faucet forespørselen feilet"
 
-   ;sync
+   ;;sync
    :sync-in-progress                      "Synkroniserer..."
    :sync-synced                           "Synkronisert"
 
-   ;messages
+   ;;messages
    :status-sending                        "Sender"
    :status-pending                        "Venter"
    :status-sent                           "Sendt"
@@ -57,7 +57,7 @@
    :status-delivered                      "Levert"
    :status-failed                         "Feilet"
 
-   ;datetime
+   ;;datetime
    :datetime-ago-format                   "{{number}} {{time-intervals}} {{ago}}"
    :datetime-second                       {:one   "sekund"
                                            :other "sekunder"}
@@ -71,7 +71,7 @@
    :datetime-yesterday                    "i går"
    :datetime-today                        "i dag"
 
-   ;profile
+   ;;profile
    :profile                               "Profil"
    :edit-profile                          "Rediger profil"
    :message                               "Melding"
@@ -101,7 +101,7 @@
    :browsing-open-in-web-browser          "Åpne i nettleser"
    :browsing-cancel                       "Avbryt"
 
-   ;sign-up
+   ;;sign-up
    :contacts-syncronized                  "Dine kontaker har blitt synkronisert"
    :confirmation-code                     (str "Topp! Vi har sendt deg en tekstmelding med bekreftelseskode."
                                                "Vennligst send oss tilbake koden for å verifisere at dette er din telefon")
@@ -118,13 +118,13 @@
    :move-to-internal-failure-message      "Vi må flytte noen viktige filer fra ekstern til intern lagring. For å kunne gjøre dette, trenger vi din godkjenning. Vi kommer ikke til å bruke ekstern lagring i fremtidige versjoner."
    :debug-enabled                         "Debug server har blitt satt i gang! Du kan nå kjøre *status-dev-cli scan* for å finne serveren på PC'n din fra samme nettverk."
 
-   ;phone types
+   ;;phone types
    :phone-e164                            "Internasjonal 1"
    :phone-international                   "Internasjonal 2"
    :phone-national                        "Nasjonal"
    :phone-significant                     "Betydningsfull"
 
-   ;chats
+   ;;chats
    :chats                                 "Chats"
    :delete-chat                           "Fjern melding"
    :new-group-chat                        "Ny gruppemelding"
@@ -135,7 +135,7 @@
    :topic-format                          "Feil format [a-z0-9\\-]+"
    :public-group-topic                    "Emne"
 
-   ;discover
+   ;;discover
    :discover                              "Oppdag"
    :none                                  "Ingen"
    :search-tags                           "Søk etter etikett her"
@@ -144,10 +144,10 @@
    :no-statuses-discovered                "Ingen status oppdaget"
    :no-statuses-found                     "Ingen status funnet"
 
-   ;settings
+   ;;settings
    :settings                              "Instillinger"
 
-   ;contacts
+   ;;contacts
    :contacts                              "Kontaker"
    :new-contact                           "Ny kontakt"
    :delete-contact                        "Slett kontakt"
@@ -162,7 +162,7 @@
    :enter-address                         "Adresse"
    :more                                  "mer"
 
-   ;group-settings
+   ;;group-settings
    :remove                                "Fjern"
    :save                                  "Lagre"
    :delete                                "Slett"
@@ -175,10 +175,10 @@
    :edit                                  "Rediger"
    :add-members                           "Legg til medlemmer"
 
-   ;commands
+   ;;commands
    :chat-send-eth                         "{{amount}} ETH"
 
-   ;new-group
+   ;;new-group
    :new-group                             "Ny gruppe"
    :reorder-groups                        "Organiser grupper"
    :edit-group                            "Rediger gruppe"
@@ -188,9 +188,9 @@
    :contact-s                             {:one   "kontakt"
                                            :other "kontaker"}
 
-   ;participants
+   ;;participants
 
-   ;protocol
+   ;;protocol
    :received-invitation                   "Motatt chat-invitasjon"
    :removed-from-chat                     "fjernet deg fra gruppechatten"
    :left                                  "venstre"
@@ -198,7 +198,7 @@
    :removed                               "fjernet"
    :You                                   "Du"
 
-   ;new-contact
+   ;;new-contact
    :add-new-contact                       "Legg til ny kontakt"
    :scan-qr                               "Skan QR-kode"
    :name                                  "Navn"
@@ -208,7 +208,7 @@
    :can-not-add-yourself                  "Du kan ikke legge til deg selv"
    :unknown-address                       "Ukjent adresse"
 
-   ;login
+   ;;login
    :connect                               "Koble til"
    :address                               "Adresse"
    :password                              "Passord"
@@ -216,23 +216,23 @@
    :sign-in                               "Logg på"
    :wrong-password                        "Feil passord"
 
-   ;recover
+   ;;recover
    :passphrase                            "Passordfrase"
    :recover                               "Gjenopprett"
    :twelve-words-in-correct-order         "12 ord i riktig rekkefølge"
 
-   ;accounts
+   ;;accounts
    :recover-access                        "Få tilbake tilgang"
    :create-new-account                    "Opprett konto"
 
-   ;wallet-qr-code
+   ;;wallet-qr-code
    :done                                  "Ferdig"
 
-   ;validation
+   ;;validation
    :invalid-phone                         "Feil telefonnummer"
    :amount                                "Beløp"
 
-   ;transactions
+   ;;transactions
    :confirm                               "Bekreft"
    :transaction                           "Transaksjon"
    :status                                "Status"
@@ -242,7 +242,7 @@
    :data                                  "Data"
    :got-it                                "Mottatt"
 
-   ;:webview
+   ;;:webview
    :web-view-error                        "oops, feil"
 
    ;;testfairy warning

--- a/src/status_im/translations/nl.cljs
+++ b/src/status_im/translations/nl.cljs
@@ -2,7 +2,7 @@
 
 (def translations
   {
-   ;common
+   ;;common
    :members-title                         "Leden"
    :not-implemented                       "!niet geïmplementeerd"
    :chat-name                             "Chatnaam"
@@ -18,11 +18,11 @@
    :camera-access-error                   "Om cameratoegang te geven, ga je naar systeem instellingen en zorg je dat Status > Camera geselecteerd is."
    :photos-access-error                   "Om fototoegang te geven, ga je naar systeem instellingen en zorg je dat Status > Foto's geselecteerd is."
 
-   ;drawer
+   ;;drawer
    :switch-users                          "Schakel tussen gebruikers"
    :current-network                       "Huidige netwerk"
 
-   ;chat
+   ;;chat
    :is-typing                             "is aan het typen"
    :and-you                               "en jij"
    :search-chat                           "Zoek in chat"
@@ -41,11 +41,11 @@
    :faucet-success                        "Faucet aanvraag is ontvangen"
    :faucet-error                          "Error bij Faucet aanvraag "
 
-   ;sync
+   ;;sync
    :sync-in-progress                      "Wordt gesynchroniseerd..."
    :sync-synced                           "Gesynchroniseerd"
 
-   ;messages
+   ;;messages
    :status-sending                        "Wordt verstuurd"
    :status-pending                        "Hangende"
    :status-sent                           "Verstuurd"
@@ -54,7 +54,7 @@
    :status-delivered                      "Bezorgd"
    :status-failed                         "Mislukt"
 
-   ;datetime
+   ;;datetime
    :datetime-second                       {:one   "seconde"
                                            :other "seconden"}
    :datetime-minute                       {:one   "minuut"
@@ -67,7 +67,7 @@
    :datetime-yesterday                    "gisteren"
    :datetime-today                        "vandaag"
 
-   ;profile
+   ;;profile
    :profile                               "Profiel"
    :edit-profile                          "Bewerk profiel"
    :message                               "Bericht"
@@ -97,7 +97,7 @@
    :browsing-open-in-web-browser          "Open in een web browser"
    :browsing-cancel                       "Annuleren"
 
-   ;sign-up
+   ;;sign-up
    :contacts-syncronized                  "Jouw contactpersonen zijn gesynchroniseerd"
    :confirmation-code                     (str "Bedankt! We hebben je een sms gestuurd met een bevestigingscode"
                                                ". Geef die code op om jouw telefoonnummer te bevestigen")
@@ -112,13 +112,13 @@
    :move-to-internal-failure-message      "We moeten wat belangrijke bestanden van externe naar interne opslag verplaatsen. Om dit te doen hebben we je toestemming interne opslag niet meer gebruiken in volgende versies."
    :debug-enabled                         "Debug-server is gelanceerd! Je kan nu *status-dev-cli scan* uitvoeren om de server te vinden vanaf je computer op het zelfde netwerk."
 
-   ;phone types
+   ;;phone types
    :phone-e164                            "International 1"
    :phone-international                   "International 2"
    :phone-national                        "Nationaal"
    :phone-significant                     "Significant"
 
-   ;chats
+   ;;chats
    :chats                                 "Chats"
    :delete-chat                           "Verwijder chat"
    :new-group-chat                        "Nieuwe groepchat"
@@ -129,7 +129,7 @@
    :topic-format                          "Verkeert formaat [a-z0-9\\-]+"
    :public-group-topic                    "Onderwerp"
 
-   ;discover
+   ;;discover
    :discover                              "Ontdekking"
    :none                                  "Geen"
    :search-tags                           "Typ hier jouw zoektags"
@@ -138,10 +138,10 @@
    :no-statuses-discovered                "Geen statussen ontdekt"
    :no-statuses-found                     "Geen statussen gevonden"
 
-   ;settings
+   ;;settings
    :settings                              "Instellingen"
 
-   ;contacts
+   ;;contacts
    :contacts                              "Contactpersonen"
    :new-contact                           "Nieuwe contactpersonen"
    :delete-contact                        "Delete contact"
@@ -156,7 +156,7 @@
    :enter-address                         "Enter address"
    :more                                  "more"
 
-   ;group-settings
+   ;;group-settings
    :remove                                "Verwijderen"
    :save                                  "Opslaan"
    :delete                                "Delete"
@@ -167,10 +167,10 @@
    :edit                                  "Bewerken"
    :add-members                           "Voeg leden toe"
 
-   ;commands
+   ;;commands
    :chat-send-eth                         "{{amount}} ETH"
 
-   ;new-group
+   ;;new-group
    :new-group                             "Nieuwe groep"
    :reorder-groups                        "Hergroepeer groep"
    :edit-group                            "Bewerk groep"
@@ -180,9 +180,9 @@
    :contact-s                             {:one   "contact"
                                            :other "contacten"}
 
-   ;participants
+   ;;participants
 
-   ;protocol
+   ;;protocol
    :received-invitation                   "ontving chatuitnodiging"
    :removed-from-chat                     "verwijderde jou van groepchat"
    :left                                  "ging weg"
@@ -190,7 +190,7 @@
    :removed                               "verwijderd"
    :You                                   "Jou"
 
-   ;new-contact
+   ;;new-contact
    :add-new-contact                       "Voeg nieuwe contactpersoon toe"
    :scan-qr                               "QR scannen"
    :name                                  "Naam"
@@ -200,7 +200,7 @@
    :can-not-add-yourself                  "Je kunt niet zelf toevoegen"
    :unknown-address                       "Onbekend adres"
 
-   ;login
+   ;;login
    :connect                               "Verbinden"
    :address                               "Adres"
    :password                              "Wachtwoord"
@@ -208,24 +208,24 @@
    :sign-in                               "Meld aan"
    :wrong-password                        "Verkeerd wachtwoord"
 
-   ;recover
+   ;;recover
    :passphrase                            "Wachtzin"
    :recover                               "Herstellen"
    :twelve-words-in-correct-order         "12 woorden in goede volgorde"
 
-   ;accounts
+   ;;accounts
    :recover-access                        "Toegang herstellen"
    :create-new-account                    "Maake een nieuwe account aan"
 
-   ;wallet-qr-code
+   ;;wallet-qr-code
    :done                                  "Klaar"
    :main-wallet                           "Hoofdportemonnee"
 
-   ;validation
+   ;;validation
    :invalid-phone                         "Ongeldig telefoonnummer"
    :amount                                "Bedrag"
 
-   ;transactions
+   ;;transactions
    :confirm                               "Bevestigen"
    :transaction                           "Transactie"
    :status                                "Status"
@@ -235,7 +235,7 @@
    :data                                  "Data"
    :got-it                                "Got it"
 
-   ;:webview
+   ;;:webview
    :web-view-error                        "oeps, fout"
 
    :public-group-status                   "Publiek"})

--- a/src/status_im/translations/pl.cljs
+++ b/src/status_im/translations/pl.cljs
@@ -2,17 +2,17 @@
 
 (def translations
   {
-   ;common
+   ;;common
    :members-title                         "Użytkownicy"
    :not-implemented                       "nie wprowadzono"
    :chat-name                             "Nazwa czatu"
    :notifications-title                   "Powiadomienia i dźwięki"
    :offline                               "Offline"
 
-   ;drawer
+   ;;drawer
    :switch-users                          "Przełącz użytkowników"
 
-   ;chat
+   ;;chat
    :is-typing                             "wpisuje tekst"
    :and-you                               "i ty"
    :search-chat                           "Przeszukaj czat"
@@ -29,11 +29,11 @@
    :suggestions-requests                  "Żądania"
    :suggestions-commands                  "Polecenia"
 
-   ;sync
+   ;;sync
    :sync-in-progress                      "Synchronizacja..."
    :sync-synced                           "W synchronizacji"
 
-   ;messages
+   ;;messages
    :status-sending                        "Wysyłanie"
    :status-pending                        "W oczekiwaniu"
    :status-sent                           "Wysłano"
@@ -42,7 +42,7 @@
    :status-delivered                      "Dostarczono"
    :status-failed                         "Niepowodzenie"
 
-   ;datetime
+   ;;datetime
    :datetime-second                       {:one   "sekunda"
                                            :other "sekund(y)"}
    :datetime-minute                       {:one   "minuta"
@@ -55,7 +55,7 @@
    :datetime-yesterday                    "wczoraj"
    :datetime-today                        "dzisiaj"
 
-   ;profile
+   ;;profile
    :profile                               "Profil"
    :message                               "Wiadomość"
    :not-specified                         "Nie określono"
@@ -68,23 +68,23 @@
    :image-source-make-photo               "Przechwyć"
    :image-source-gallery                  "Wybierz z galerii "
 
-   ;sign-up
+   ;;sign-up
    :contacts-syncronized                  "Twoje kontakty zostały zsynchronizowane"
    :confirmation-code                     (str "Dziękujemy! Wysłaliśmy ci SMS-a z kodem"
                                                "potwierdzającym. Prosimy o podanie kodu w celu zweryfikowania swojego numeru telefonu")
    :incorrect-code                        (str "Przepraszamy, kod jest nieprawidłowy. Prosimy wprowadzić kod ponownie")
-   :phew-here-is-your-passphrase          "*Uff*, to nie było łatwe. Oto twoje specjalne hasło, *zapisz je i	 przechowuj w bezpiecznym miejscu!* Będzie ci potrzebne podczas procedury odzyskiwania konta."
+   :phew-here-is-your-passphrase          "*Uff*, to nie było łatwe. Oto twoje specjalne hasło, *zapisz je i   przechowuj w bezpiecznym miejscu!* Będzie ci potrzebne podczas procedury odzyskiwania konta."
    :here-is-your-passphrase               "Oto twoje specjalne hasło, *zapisz je i przechowuj w bezpiecznym miejscu!* Będzie ci potrzebne podczas procedury odzyskiwania konta."
    :phone-number-required                 "Dotknij tutaj, aby wprowadzić swój numer telefonu, a my znajdziemy twoich znajomych "
    :intro-status                          "Porozmawiaj ze mną na czacie, aby skonfigurować swoje konto i zmienić ustawienia!"
    :intro-message1                        "Witamy w sekcji Status\nWybierz tę wiadomość, aby ustawić hasło i rozpocząć!"
    :account-generation-message            "Daj mi chwilkę, muszę wykonać szalone obliczenia, żeby utworzyć dla Ciebie konto!"
 
-   ;chats
+   ;;chats
    :chats                                 "Czaty"
    :new-group-chat                        "Nowy czat grupowy"
 
-   ;discover
+   ;;discover
    :discover                              "Odkryte"
    :none                                  "Brak"
    :search-tags                           "Tutaj wpisz swoje tagi wyszukiwania"
@@ -92,17 +92,17 @@
    :recent                                "Najnowsze"
    :no-statuses-discovered                "Nie odkryto statusów"
 
-   ;settings
+   ;;settings
    :settings                              "Ustawienia"
 
-   ;contacts
+   ;;contacts
    :contacts                              "Kontakty"
    :new-contact                           "Nowy kontakt"
    :contacts-group-new-chat               "Rozpocznij nowy czat"
    :no-contacts                           "W tej chwili brak kontaktów"
    :show-qr                               "Pokaż QR"
 
-   ;group-settings
+   ;;group-settings
    :remove                                "Usuń"
    :save                                  "Zapisz"
    :clear-history                         "Wyczyść historię"
@@ -110,14 +110,14 @@
    :edit                                  "Edytuj"
    :add-members                           "Dodaj użytkowników"
 
-   ;commands
+   ;;commands
    :chat-send-eth                         "{{amount}} ETH"
 
-   ;new-group
+   ;;new-group
 
-   ;participants
+   ;;participants
 
-   ;protocol
+   ;;protocol
    :received-invitation                   "otrzymano zaproszenie na czat"
    :removed-from-chat                     "usunięto z czatu grupowego"
    :left                                  "pozostało"
@@ -125,7 +125,7 @@
    :removed                               "usunięci"
    :You                                   "Ty"
 
-   ;new-contact
+   ;;new-contact
    :add-new-contact                       "Dodaj nowy kontakt"
    :scan-qr                               "Skanuj QR"
    :name                                  "Nazwa"
@@ -135,31 +135,31 @@
    :unknown-address                       "Nieznany adres"
 
 
-   ;login
+   ;;login
    :connect                               "Połącz"
    :address                               "Adres"
    :password                              "Hasło"
    :wrong-password                        "Nieprawidłowe hasło"
 
-   ;recover
+   ;;recover
    :passphrase                            "Hasło specjalne"
    :recover                               "Odzyskaj"
 
-   ;accounts
+   ;;accounts
    :recover-access                        "Odzyskaj dostęp"
 
-   ;wallet-qr-code
+   ;;wallet-qr-code
    :done                                  "Zrobione"
    :main-wallet                           "Portfel główny"
 
-   ;validation
+   ;;validation
    :invalid-phone                         "Nieprawidłowy numer telefonu"
    :amount                                "Kwota"
-   ;transactions
+   ;;transactions
    :status                                "Status"
    :recipient                             "Odbiorca"
 
-   ;:webview
+   ;;:webview
    :web-view-error                        "oj, mamy błąd"
 
    :confirm                               "Potwierdź"

--- a/src/status_im/translations/pt_br.cljs
+++ b/src/status_im/translations/pt_br.cljs
@@ -2,17 +2,17 @@
 
 (def translations
   {
-   ;common
+   ;;common
    :members-title                         "Membros"
    :not-implemented                       "não implementado"
    :chat-name                             "Nome do chat"
    :notifications-title                   "Notificações e sons"
    :offline                               "Offline"
 
-   ;drawer
+   ;;drawer
    :switch-users                          "Trocar usuário"
 
-   ;chat
+   ;;chat
    :is-typing                             "está digitando"
    :and-you                               "e você"
    :search-chat                           "Pesquisar chat"
@@ -29,11 +29,11 @@
    :suggestions-requests                  "Solicitações"
    :suggestions-commands                  "Comandos"
 
-   ;sync
+   ;;sync
    :sync-in-progress                      "Sincronizando..."
    :sync-synced                           "Sincronizado"
 
-   ;messages
+   ;;messages
    :status-sending                        "Enviando..."
    :status-pending                        "Pendente"
    :status-sent                           "Enviado"
@@ -42,7 +42,7 @@
    :status-delivered                      "Entregue"
    :status-failed                         "Malsucedido"
 
-   ;datetime
+   ;;datetime
    :datetime-second                       {:one   "segundo"
                                            :other "segundos"}
    :datetime-minute                       {:one   "minuto"
@@ -55,7 +55,7 @@
    :datetime-yesterday                    "ontem"
    :datetime-today                        "hoje"
 
-   ;profile
+   ;;profile
    :profile                               "Perfil"
    :message                               "Mensagem"
    :not-specified                         "Não especificado"
@@ -68,7 +68,7 @@
    :image-source-make-photo               "Tirar foto"
    :image-source-gallery                  "Escolher na galeria"
 
-   ;sign-up
+   ;;sign-up
    :contacts-syncronized                  "Seus contatos foram sincronizados"
    :confirmation-code                     (str "Obrigado! Nós lhe enviamos uma mensagem de texto com um código de "
                                                "confirmação. Por favor, informe esse código para confirmar seu número de telefone")
@@ -80,11 +80,11 @@
    :intro-message1                        "Bem-vindo ao Status\nToque nesta mensagem para definir sua senha e começar!"
    :account-generation-message            "Mê dê um segundinho. Tenho de fazer uns cálculos malucos para gerar a sua conta!"
 
-   ;chats
+   ;;chats
    :chats                                 "Chats"
    :new-group-chat                        "Novo grupo de chat"
 
-   ;discover
+   ;;discover
    :discover                              "Descobrir"
    :none                                  "Nenhum(a)"
    :search-tags                           "Digite suas tags de pesquisa aqui"
@@ -92,17 +92,17 @@
    :recent                                "Recentes"
    :no-statuses-discovered                "Nenhum status descoberto"
 
-   ;settings
+   ;;settings
    :settings                              "Configurações"
 
-   ;contacts
+   ;;contacts
    :contacts                              "Contatos"
    :new-contact                           "Novo contato"
    :contacts-group-new-chat               "Iniciar novo chat"
    :no-contacts                           "Você ainda não tem contatos"
    :show-qr                               "Mostrar QR"
 
-   ;group-settings
+   ;;group-settings
    :remove                                "Remover"
    :save                                  "Salvar"
    :clear-history                         "Apagar histórico"
@@ -110,14 +110,14 @@
    :edit                                  "Editar"
    :add-members                           "Adicionar membros"
 
-   ;commands
+   ;;commands
    :chat-send-eth                         "{{amount}} ETH"
 
-   ;new-group
+   ;;new-group
 
-   ;participants
+   ;;participants
 
-   ;protocol
+   ;;protocol
    :received-invitation                   "recebeu o convite para o chat"
    :removed-from-chat                     "removeu você do grupo"
    :left                                  "saiu"
@@ -125,7 +125,7 @@
    :removed                               "removeu"
    :You                                   "Você"
 
-   ;new-contact
+   ;;new-contact
    :add-new-contact                       "Adicionar novo contato"
    :scan-qr                               "Escanear QR"
    :name                                  "Nome"
@@ -135,31 +135,31 @@
    :unknown-address                       "E-mail desconhecido"
 
 
-   ;login
+   ;;login
    :connect                               "Conectar"
    :address                               "Endereço"
    :password                              "Senha"
    :wrong-password                        "Senha incorreta"
 
-   ;recover
+   ;;recover
    :passphrase                            "Frase secreta"
    :recover                               "Recuperar"
 
-   ;accounts
+   ;;accounts
    :recover-access                        "Recuperar o acesso"
 
-   ;wallet-qr-code
+   ;;wallet-qr-code
    :done                                  "Concluído"
    :main-wallet                           "Carteira principal"
 
-   ;validation
+   ;;validation
    :invalid-phone                         "Número de telefone inválido"
    :amount                                "Quantia"
-   ;transactions
+   ;;transactions
    :status                                "Status"
    :recipient                             "Destinatário"
 
-   ;:webview
+   ;;:webview
    :web-view-error                        "Ops, erro"
 
    :confirm                               "Confirmar"

--- a/src/status_im/translations/pt_pt.cljs
+++ b/src/status_im/translations/pt_pt.cljs
@@ -2,17 +2,17 @@
 
 (def translations
   {
-   ;common
+   ;;common
    :members-title                         "Membros"
    :not-implemented                       "!não implementado"
    :chat-name                             "Nome no chat"
    :notifications-title                   "Notificações e sons"
    :offline                               "Offline"
 
-   ;drawer
+   ;;drawer
    :switch-users                          "Mudar de utilizadores"
 
-   ;chat
+   ;;chat
    :is-typing                             "está a digitar"
    :and-you                               "e você"
    :search-chat                           "Pesquisar chat"
@@ -29,11 +29,11 @@
    :suggestions-requests                  "Pedidos"
    :suggestions-commands                  "Comandos"
 
-   ;sync
+   ;;sync
    :sync-in-progress                      "A sincronizar..."
    :sync-synced                           "Em sincronização"
 
-   ;messages
+   ;;messages
    :status-sending                        "A enviar"
    :status-pending                        "Pendente"
    :status-sent                           "Enviado"
@@ -42,7 +42,7 @@
    :status-delivered                      "Entregue"
    :status-failed                         "Falhou"
 
-   ;datetime
+   ;;datetime
    :datetime-second                       {:one   "segundo"
                                            :other "segundos"}
    :datetime-minute                       {:one   "minuto"
@@ -55,7 +55,7 @@
    :datetime-yesterday                    "ontem"
    :datetime-today                        "hoje"
 
-   ;profile
+   ;;profile
    :profile                               "Perfil"
    :message                               "Mensagem"
    :not-specified                         "Não especificado"
@@ -68,7 +68,7 @@
    :image-source-make-photo               "Capturar"
    :image-source-gallery                  "Selecionar a partir da galeria"
 
-   ;sign-up
+   ;;sign-up
    :contacts-syncronized                  "Os seus contactos foram sincronizados"
    :confirmation-code                     (str "Obrigado! Enviámos-lhe uma mensagem de texto com um código de "
                                                "confirmação. Por favor, forneça esse código para confirmar o seu número de telefone")
@@ -80,11 +80,11 @@
    :intro-message1                        "Bem-vindo ao Status\nToque nesta mensagem para definir a sua palavra-passe e começar!"
    :account-generation-message            "Dê-me um segundo, tenho de fazer alguns cálculos doidos para gerar a sua conta!"
 
-   ;chats
+   ;;chats
    :chats                                 "Chats"
    :new-group-chat                        "Novo chat em grupo"
 
-   ;discover
+   ;;discover
    :discover                              "Descoberta"
    :none                                  "Nenhum"
    :search-tags                           "Digite aqui os seus tags de pesquisa"
@@ -92,17 +92,17 @@
    :recent                                "Recente"
    :no-statuses-discovered                "Não foi descoberto nenhum estado"
 
-   ;settings
+   ;;settings
    :settings                              "Definições"
 
-   ;contacts
+   ;;contacts
    :contacts                              "Contactos"
    :new-contact                           "Novo Contacto"
    :contacts-group-new-chat               "Iniciar um novo chat"
    :no-contacts                           "Ainda sem contactos"
    :show-qr                               "Mostrar QR"
 
-   ;group-settings
+   ;;group-settings
    :remove                                "Remover"
    :save                                  "Guardar"
    :clear-history                         "Limpar o histórico"
@@ -110,14 +110,14 @@
    :edit                                  "Editar"
    :add-members                           "Adicionar Membros"
 
-   ;commands
+   ;;commands
    :chat-send-eth                         "{{amount}} ETH"
 
-   ;new-group
+   ;;new-group
 
-   ;participants
+   ;;participants
 
-   ;protocol
+   ;;protocol
    :received-invitation                   "recebeu um convite de chat"
    :removed-from-chat                     "removeu-o do chat em grupo"
    :left                                  "saiu"
@@ -125,7 +125,7 @@
    :removed                               "removido"
    :You                                   "Você"
 
-   ;new-contact
+   ;;new-contact
    :add-new-contact                       "Adicionar novo contacto"
    :scan-qr                               "Digitalizar QR"
    :name                                  "Nome"
@@ -135,31 +135,31 @@
    :unknown-address                       "Endereço desconhecido"
 
 
-   ;login
+   ;;login
    :connect                               "Ligar"
    :address                               "Endereço"
    :password                              "Palavra-passe"
    :wrong-password                        "Palavra-passe errada"
 
-   ;recover
+   ;;recover
    :passphrase                            "Frase-chave"
    :recover                               "Recuperar"
 
-   ;accounts
+   ;;accounts
    :recover-access                        "Recuperar o acesso"
 
-   ;wallet-qr-code
+   ;;wallet-qr-code
    :done                                  "Concluído"
    :main-wallet                           "Carteira Principal"
 
-   ;validation
+   ;;validation
    :invalid-phone                         "Número de telefone inválido"
    :amount                                "Montante"
-   ;transactions
+   ;;transactions
    :status                                "Estado"
    :recipient                             "Destinatário"
 
-   ;:webview
+   ;;:webview
    :web-view-error                        "ups, erro"
 
    :confirm                               "Confirmar"

--- a/src/status_im/translations/ro.cljs
+++ b/src/status_im/translations/ro.cljs
@@ -2,17 +2,17 @@
 
 (def translations
   {
-   ;common
+   ;;common
    :members-title                         "Membri"
    :not-implemented                       "!nu a fost implementat"
    :chat-name                             "Nume chat"
    :notifications-title                   "Notificări și sunete"
    :offline                               "Offline"
 
-   ;drawer
+   ;;drawer
    :switch-users                          "Schimbă utilizatori"
 
-   ;chat
+   ;;chat
    :is-typing                             "tastează"
    :and-you                               "Și cu tine"
    :search-chat                           "Caută în chat"
@@ -29,11 +29,11 @@
    :suggestions-requests                  "Solicitări"
    :suggestions-commands                  "Comenzi"
 
-   ;sync
+   ;;sync
    :sync-in-progress                      "Se sincronizează…"
    :sync-synced                           "Sincronizat"
 
-   ;messages
+   ;;messages
    :status-sending                        "Se trimite"
    :status-pending                        "În așteptare"
    :status-sent                           "Trimis"
@@ -42,7 +42,7 @@
    :status-delivered                      "Livrat"
    :status-failed                         "Eșuat"
 
-   ;datetime
+   ;;datetime
    :datetime-second                       {:one   "secundă"
                                            :other "secunde"}
    :datetime-minute                       {:one   "minut"
@@ -55,7 +55,7 @@
    :datetime-yesterday                    "ieri"
    :datetime-today                        "azi"
 
-   ;profile
+   ;;profile
    :profile                               "Profil"
    :message                               "Mesaj"
    :not-specified                         "Nu este specificat"
@@ -68,7 +68,7 @@
    :image-source-make-photo               "Captează"
    :image-source-gallery                  "Selectează din galerie"
 
-   ;sign-up
+   ;;sign-up
    :contacts-syncronized                  "Contactele tale au fost sincronizate"
    :confirmation-code                     (str "Mulțumim! Ți-am trims un mesaj text cu un cod "
                                                "de confirmare. Te rugăm să ne transmiți acel cod pentru a-ți confirma numărul de telefon")
@@ -80,11 +80,11 @@
    :intro-message1                        "Bine ai vent în Status\nApasă pe acest mesaj pentru a-ți seta parola și a începe!"
    :account-generation-message            "O secundă, trebuie să fac niște calcule complicate ca să-ți generez contul!"
 
-   ;chats
+   ;;chats
    :chats                                 "Discuții pe chat"
    :new-group-chat                        "Grup nou de chat"
 
-   ;discover
+   ;;discover
    :discover                              "Descoperire"
    :none                                  "Niciuna"
    :search-tags                           "Tastează aici etichetele de căutat"
@@ -92,17 +92,17 @@
    :recent                                "Recente"
    :no-statuses-discovered                "Nici un status găsit"
 
-   ;settings
+   ;;settings
    :settings                              "Setări"
 
-   ;contacts
+   ;;contacts
    :contacts                              "Contacte"
    :new-contact                           "Contact nou"
    :contacts-group-new-chat               "Începe discuție nouă"
    :no-contacts                           "Nici un contact deocamdată"
    :show-qr                               "Afișează QR"
 
-   ;group-settings
+   ;;group-settings
    :remove                                "Elimină"
    :save                                  "Salvează"
    :clear-history                         "Șterge istoricul"
@@ -110,14 +110,14 @@
    :edit                                  "Editare"
    :add-members                           "Adăugare membri"
 
-   ;commands
+   ;;commands
    :chat-send-eth                         "{{amount}} ETH"
 
-   ;new-group
+   ;;new-group
 
-   ;participants
+   ;;participants
 
-   ;protocol
+   ;;protocol
    :received-invitation                   "A primit invitația de chat"
    :removed-from-chat                     "te-a elimination din grupul de chat"
    :left                                  "a plecat"
@@ -125,7 +125,7 @@
    :removed                               "eliminat"
    :You                                   "Tu"
 
-   ;new-contact
+   ;;new-contact
    :add-new-contact                       "Adaugă contact nou"
    :scan-qr                               "Scanează QR"
    :name                                  "Nume"
@@ -135,31 +135,31 @@
    :unknown-address                       "Adresă necunoscută"
 
 
-   ;login
+   ;;login
    :connect                               "Conectare"
    :address                               "Adresă"
    :password                              "Parolă"
    :wrong-password                        "Parola greșită"
 
-   ;recover
+   ;;recover
    :passphrase                            "Fraza de acces"
    :recover                               "Recuperează"
 
-   ;accounts
+   ;;accounts
    :recover-access                        "Recuperează acces"
 
-   ;wallet-qr-code
+   ;;wallet-qr-code
    :done                                  "Gata"
    :main-wallet                           "Portofelul principal"
 
-   ;validation
+   ;;validation
    :invalid-phone                         "Număr de telefon nevalid"
    :amount                                "Sumă"
-   ;transactions
+   ;;transactions
    :status                                "Status"
    :recipient                             "Beneficiar"
 
-   ;:webview
+   ;;:webview
    :web-view-error                        "ups, eroare"
 
    :confirm                               "Confirmare"

--- a/src/status_im/translations/ru.cljs
+++ b/src/status_im/translations/ru.cljs
@@ -61,7 +61,7 @@
    :status-seen                           "Просмотрено"
    :status-delivered                      "Доставлено"
    :status-failed                         "Ошибка"
-    
+
    ;;datetime
    :datetime-ago-format                   "{{number}} {{time-intervals}} {{ago}}"
    :datetime-second                       {:one   "секунда"

--- a/src/status_im/translations/sl.cljs
+++ b/src/status_im/translations/sl.cljs
@@ -2,17 +2,17 @@
 
 (def translations
   {
-   ;common
+   ;;common
    :members-title                         "Člani"
    :not-implemented                       "!ni implementirano"
    :chat-name                             "Ime za klepet"
    :notifications-title                   "Obvestila in zvoki"
    :offline                               "Nedosegljiv/-a"
 
-   ;drawer
+   ;;drawer
    :switch-users                          "Preklopi med uporabniki"
 
-   ;chat
+   ;;chat
    :is-typing                             "piše"
    :and-you                               "in ti"
    :search-chat                           "Iskanje po klepetu"
@@ -29,11 +29,11 @@
    :suggestions-requests                  "Prošnje"
    :suggestions-commands                  "Ukazi"
 
-   ;sync
+   ;;sync
    :sync-in-progress                      "Sinhronizacija..."
    :sync-synced                           "Sinhronizirano"
 
-   ;messages
+   ;;messages
    :status-sending                        "Pošiljanje"
    :status-pending                        "V teku"
    :status-sent                           "Poslano"
@@ -42,7 +42,7 @@
    :status-delivered                      "Dostavljeno"
    :status-failed                         "Ni uspelo"
 
-   ;datetime
+   ;;datetime
    :datetime-second                       {:one   "sekunda"
                                            :other "sekund"}
    :datetime-minute                       {:one   "minuta"
@@ -55,7 +55,7 @@
    :datetime-yesterday                    "včeraj"
    :datetime-today                        "danes"
 
-   ;profile
+   ;;profile
    :profile                               "Profil"
    :message                               "Sporočilo"
    :not-specified                         "Ni navedeno"
@@ -68,7 +68,7 @@
    :image-source-make-photo               "Zajemi"
    :image-source-gallery                  "Izberi iz galerije"
 
-   ;sign-up
+   ;;sign-up
    :contacts-syncronized                  "Tvoji stiki so bili sinhronizirani"
    :confirmation-code                     (str "Hvala! Poslali smo ti sporočilo s potrditveno "
                                                "kodo. Prosimo, vnesi to kodo in potrdi svojo telefonsko številko")
@@ -80,11 +80,11 @@
    :intro-message1                        "Dobrodošel/-la v status\nPritisni to sporočilo in nastavi svoje geslo ter začni!"
    :account-generation-message            "Počakaj sekundo, opraviti moram noro računico, da ustvarim tvoj račun!"
 
-   ;chats
+   ;;chats
    :chats                                 "Klepeti"
    :new-group-chat                        "Nov skupinski klepet"
 
-   ;discover
+   ;;discover
    :discover                              "Odkrivanje"
    :none                                  "Brez"
    :search-tags                           "Sem vnesi svoje priljubljene oznake"
@@ -92,17 +92,17 @@
    :recent                                "Nedavno"
    :no-statuses-discovered                "Ni odkritih statusov"
 
-   ;settings
+   ;;settings
    :settings                              "Nastavitve"
 
-   ;contacts
+   ;;contacts
    :contacts                              "Stiki"
    :new-contact                           "Nov stik"
    :contacts-group-new-chat               "Začni nov klepet"
    :no-contacts                           "Zaenkrat še ni stikov"
    :show-qr                               "Prikaži QR"
 
-   ;group-settings
+   ;;group-settings
    :remove                                "Odstrani"
    :save                                  "Shrani"
    :clear-history                         "Počisti zgodovino"
@@ -110,14 +110,14 @@
    :edit                                  "Uredi"
    :add-members                           "Dodaj člane"
 
-   ;commands
+   ;;commands
    :chat-send-eth                         "{{amount}} ETH"
 
-   ;new-group
+   ;;new-group
 
-   ;participants
+   ;;participants
 
-   ;protocol
+   ;;protocol
    :received-invitation                   "je prejel/-a povabilo za klepet"
    :removed-from-chat                     "te je odstranil/-a iz skupinskega klepeta"
    :left                                  "preostane"
@@ -125,7 +125,7 @@
    :removed                               "odstranil/-a"
    :You                                   "Ti"
 
-   ;new-contact
+   ;;new-contact
    :add-new-contact                       "Dodaj nov stik"
    :scan-qr                               "Skeniraj QR"
    :name                                  "Ime"
@@ -135,31 +135,31 @@
    :unknown-address                       "Neznan naslov"
 
 
-   ;login
+   ;;login
    :connect                               "Poveži"
    :address                               "Naslov"
    :password                              "Geslo"
    :wrong-password                        "Napačno geslo"
 
-   ;recover
+   ;;recover
    :passphrase                            "Šifrirno geslo"
    :recover                               "Povrni"
 
-   ;accounts
+   ;;accounts
    :recover-access                        "Povrni dostop"
 
-   ;wallet-qr-code
+   ;;wallet-qr-code
    :done                                  "Končano"
    :main-wallet                           "Glavna denarnica"
 
-   ;validation
+   ;;validation
    :invalid-phone                         "Neveljavna telefonska številka"
    :amount                                "Vsota"
-   ;transactions
+   ;;transactions
    :status                                "Status"
    :recipient                             "Prejemnik"
 
-   ;:webview
+   ;;:webview
    :web-view-error                        "ups, napaka"
 
    :confirm                               "Potrdi"

--- a/src/status_im/translations/sv.cljs
+++ b/src/status_im/translations/sv.cljs
@@ -360,4 +360,3 @@
    :close-app-title                       "Varning!"
    :close-app-content                     "Denna app kommer att avslutas. När du öppnar den på nytt kommer det valda nätverket att användas"
    :close-app-button                      "Bekräfta"})
-

--- a/src/status_im/translations/sw.cljs
+++ b/src/status_im/translations/sw.cljs
@@ -2,17 +2,17 @@
 
 (def translations
   {
-   ;common
+   ;;common
    :members-title                         "Wanachama"
    :not-implemented                       "!haijatekelezwa"
    :chat-name                             "Jina la gumzo"
    :notifications-title                   "Notisi na sauti"
    :offline                               "Nje ya mtandao"
 
-   ;drawer
+   ;;drawer
    :switch-users                          "Badili kwa watumiaji"
 
-   ;chat
+   ;;chat
    :is-typing                             "anaandika"
    :and-you                               "na wewe"
    :search-chat                           "Tafuta gumzo"
@@ -29,11 +29,11 @@
    :suggestions-requests                  "Maombi"
    :suggestions-commands                  "Amri"
 
-   ;sync
+   ;;sync
    :sync-in-progress                      "Kulandanisha..."
    :sync-synced                           "Katika ulandanishaji"
 
-   ;messages
+   ;;messages
    :status-sending                        "Kutuma"
    :status-pending                        "Inasubiri"
    :status-sent                           "Tuma"
@@ -42,7 +42,7 @@
    :status-delivered                      "Imefikishwa"
    :status-failed                         "Imeshindwa"
 
-   ;datetime
+   ;;datetime
    :datetime-second                       {:one   "sekunde"
                                            :other "sekunde"}
    :datetime-minute                       {:one   "dakika"
@@ -55,7 +55,7 @@
    :datetime-yesterday                    "jana"
    :datetime-today                        "leo"
 
-   ;profile
+   ;;profile
    :profile                               "Profaili"
    :message                               "Ujumbe"
    :not-specified                         "Haijafafanuliwa"
@@ -73,7 +73,7 @@
    :sharing-share                         "Dela..."
    :sharing-cancel                        "Ghairi"
 
-   ;sign-up
+   ;;sign-up
    :contacts-syncronized                  "Mawasiliano yako yamelandanishwa"
    :confirmation-code                     (str "Asante! Tumekutumia ujumbe mfupi na uthibitisho "
                                                "kificho. Tafadhali peana hicho kificho kuthibitisha namba yako ya simu")
@@ -85,11 +85,11 @@
    :intro-message1                        "Karibu kwa Hali na Ubofye ujumbe huu ili kuweka nenosiri lako na uanze!"
    :account-generation-message            "Nipe sekunde, naenda kufanya baadhi ya hisabati kutengeneza akaunti yako!"
 
-   ;chats
+   ;;chats
    :chats                                 "Gumzo"
    :new-group-chat                        "Gumzo mpya ya kikundi"
 
-   ;discover
+   ;;discover
    :discover                             "Ugunduzi"
    :none                                  "Hakuna"
    :search-tags                           "Andika vitambulisho vyako vya kutafuta hapa"
@@ -97,17 +97,17 @@
    :recent                                "Hivi karibuni"
    :no-statuses-discovered                "Hakuna hali zimegundulika"
 
-   ;settings
+   ;;settings
    :settings                              "Mipangilio"
 
-   ;contacts
+   ;;contacts
    :contacts                              "Mawasiliano"
    :new-contact                           "Mawasiliano mapya"
    :contacts-group-new-chat               "Anza gumzo mpya"
    :no-contacts                           "Bado hakuna mawasiliano"
    :show-qr                               "Onyesha QR"
 
-   ;group-settings
+   ;;group-settings
    :remove                                "Ondoa"
    :save                                  "Hifadhi"
    :clear-history                         "Futa historia"
@@ -115,14 +115,14 @@
    :edit                                  "Hariri"
    :add-members                           "Ongeza wanachama"
 
-   ;commands
+   ;;commands
    :chat-send-eth                         "{{amount}} ETH"
 
-   ;new-group
+   ;;new-group
 
-   ;participants
+   ;;participants
 
-   ;protocol
+   ;;protocol
    :received-invitation                   "mwaliko wa gumzo ulipokelewa"
    :removed-from-chat                     "uliondolewa kwenye kikundi cha gumzo"
    :left                                  "uliondoka"
@@ -130,7 +130,7 @@
    :removed                               "uliondolewa"
    :You                                   "Wewe"
 
-   ;new-contact
+   ;;new-contact
    :add-new-contact                       "Ongeza mawasiliano mapya"
    :scan-qr                               "Piga picha QR"
    :name                                  "Jina"
@@ -140,29 +140,29 @@
    :unknown-address                       "Anwani Haijulikani"
 
 
-   ;login
+   ;;login
    :connect                               "Unganisha"
    :address                               "Anwani"
    :password                              "Nenosiri"
    :wrong-password                        "Nenosiri sio halali"
 
-   ;recover
+   ;;recover
    :passphrase                            "Kaulisiri"
    :recover                               "Okoa"
 
-   ;accounts
+   ;;accounts
    :recover-access                        "Okoa ufikiaji/Upatikanaji"
 
-   ;wallet-qr-code
+   ;;wallet-qr-code
    :done                                  "Imefanyika"
    :main-wallet                           "Mkoba Mkuu"
 
-   ;validation
+   ;;validation
    :invalid-phone                         "Namba ya simu ni batili"
    :amount                                "Kiasi"
-   ;transactions
+   ;;transactions
    :status                                "Hali"
    :recipient                             "Mpokeaji"
 
-   ;:webview
+   ;;:webview
    :web-view-error                        "nadhani, hitilafu"})

--- a/src/status_im/translations/th.cljs
+++ b/src/status_im/translations/th.cljs
@@ -2,17 +2,17 @@
 
 (def translations
   {
-   ;common
+   ;;common
    :members-title                         "สมาชิก"
    :not-implemented                       "!ยังไม่ได้ดำเนินการ"
    :chat-name                             "ชื่อแชท"
    :notifications-title                   "การแจ้งเตือนและเสียง"
    :offline                               "ออฟไลน์"
 
-   ;drawer
+   ;;drawer
    :switch-users                          "สลับผู้ใช้"
 
-   ;chat
+   ;;chat
    :is-typing                             "กำลังพิมพ์"
    :and-you                               "และคุณ"
    :search-chat                           "ค้นหาแชท"
@@ -29,11 +29,11 @@
    :suggestions-requests                  "คำร้องขอ"
    :suggestions-commands                  "คำสั่ง"
 
-   ;sync
+   ;;sync
    :sync-in-progress                      "กำลังซิงค์..."
    :sync-synced                           "ระหว่างการซิงค์"
 
-   ;messages
+   ;;messages
    :status-sending                        "กำลังส่ง"
    :status-pending                        "อยู่ระหว่างดำเนินการ"
    :status-sent                           "ส่งแล้ว"
@@ -42,7 +42,7 @@
    :status-delivered                      "ส่งแล้ว"
    :status-failed                         "ล้มเหลว"
 
-   ;datetime
+   ;;datetime
    :datetime-second                       {:one   "วินาที"
                                            :other "วินาที"}
    :datetime-minute                       {:one   "นาที"
@@ -55,7 +55,7 @@
    :datetime-yesterday                    "เมื่อวาน"
    :datetime-today                        "วันนี้"
 
-   ;profile
+   ;;profile
    :profile                               "โปรไฟล์"
    :message                               "ข้อความ"
    :not-specified                         "ไม่ระบุ"
@@ -68,7 +68,7 @@
    :image-source-make-photo               "ถ่ายภาพ"
    :image-source-gallery                  "เลือกจากแกลเลอรี"
 
-   ;sign-up
+   ;;sign-up
    :contacts-syncronized                  "ไซิงค์รายชื่อผู้ติดต่อของคุณแล้ว"
    :confirmation-code                     (str "ขอขอบคุณ! เราได้ส่งข้อความตัวอักษรพร้อมรหัสยืนยันแล้ว"
                                                "โปรดมอบรหัสนั้นเพื่อยืนยันหมายเลขโทรศัพท์ของคุณ")
@@ -80,11 +80,11 @@
    :intro-message1                        "ยินดีต้อนรับสู่สถานะ \n แตะข้อความนี้เพื่อตั้งรหัสผ่านของคุณ & เริ่มต้น!"
    :account-generation-message            "ให้เวลาฉันหนึ่งวินาที ฉันจะต้องคำนวณอย่างหนักเพื่อสร้างบัญชีของคุณ!"
 
-   ;chats
+   ;;chats
    :chats                                 "แชท"
    :new-group-chat                        "แชทกลุ่มใหม่"
 
-   ;discover
+   ;;discover
    :discover                              "การค้นพบ"
    :none                                  "ไม่มี"
    :search-tags                           "พิมพ์แท็กการค้นหาของคุณที่นี่"
@@ -92,17 +92,17 @@
    :recent                                "เมื่อเร็ว ๆ นี้"
    :no-statuses-discovered                "ไม่พบสถานะใด ๆ"
 
-   ;settings
+   ;;settings
    :settings                              "การตั้งค่า"
 
-   ;contacts
+   ;;contacts
    :contacts                              "ผู้ติดต่อ"
    :new-contact                           "ผู้ติดต่อใหม่"
    :contacts-group-new-chat               "เริ่มแชทใหม่"
    :no-contacts                           "ยังไม่มีผู้ติดต่อ"
    :show-qr                               "แสดง QR"
 
-   ;group-settings
+   ;;group-settings
    :remove                                "ลบ"
    :save                                  "บันทึก"
    :clear-history                         "ลบประวัติ"
@@ -110,14 +110,14 @@
    :edit                                  "แก้ไข"
    :add-members                           "เพิ่มสมาชิก"
 
-   ;commands
+   ;;commands
    :chat-send-eth                         "{{amount}} ETH"
 
-   ;new-group
+   ;;new-group
 
-   ;participants
+   ;;participants
 
-   ;protocol
+   ;;protocol
    :received-invitation                   "คำเชิญแชทที่ได้รับ"
    :removed-from-chat                     "ลบคุณออกจากแชทกลุ่ม"
    :left                                  "ออกไปแล้ว"
@@ -125,7 +125,7 @@
    :removed                               "ลบแล้ว"
    :You                                   "คุณ"
 
-   ;new-contact
+   ;;new-contact
    :add-new-contact                       "เพิ่มผู้ติดต่อใหม่"
    :scan-qr                               "สแกน QR"
    :name                                  "ชื่อ"
@@ -135,31 +135,31 @@
    :unknown-address                       "ที่อยู่ที่ไม่ทราบ"
 
 
-   ;login
+   ;;login
    :connect                               "เชื่อมต่อ"
    :address                               "ที่อยู่"
    :password                              "รหัสผ่าน"
    :wrong-password                        "รหัสผ่านไม่ถูกต้อง"
 
-   ;recover
+   ;;recover
    :passphrase                            "วลีรหัสผ่าน"
    :recover                               "กู้คืน"
 
-   ;accounts
+   ;;accounts
    :recover-access                        "กู้คืนการเข้าถึง"
 
-   ;wallet-qr-code
+   ;;wallet-qr-code
    :done                                  "เสร็จสิ้น"
    :main-wallet                           "กระเป๋าเงินหลัก"
 
-   ;validation
+   ;;validation
    :invalid-phone                         "หมายเลขโทรศัพท์ไม่ถูกต้อง"
    :amount                                "จำนวน"
-   ;transactions
+   ;;transactions
    :status                                "สถานะ"
    :recipient                             "ผู้รับ"
 
-   ;:webview
+   ;;:webview
    :web-view-error                        "อุ๊ย มีข้อผิดพลาด"
 
    :confirm                               "ยืนยัน"
@@ -206,8 +206,8 @@
    :mute-notifications                    "ปิดเสียงการแจ้งเตือน"
 
    :contact-s
-                                          {:one   "รายชื่อติดต่อ"
-                                           :other "รายชื่อติดต่อ"}
+   {:one   "รายชื่อติดต่อ"
+    :other "รายชื่อติดต่อ"}
    :next                                  "ถัดไป"
    :from                                  "จาก"
    :search-chats                          "ค้นหาแชท"

--- a/src/status_im/translations/tr.cljs
+++ b/src/status_im/translations/tr.cljs
@@ -2,17 +2,17 @@
 
 (def translations
   {
-   ;common
+   ;;common
    :members-title                         "Üyeler"
    :not-implemented                       "Uygulanmadı!"
    :chat-name                             "Sohbet adı"
    :notifications-title                   "Bildirimler ve sesler"
    :offline                               "Çevrimdışı"
 
-   ;drawer
+   ;;drawer
    :switch-users                          "Kullanıcıları değiştir"
 
-   ;chat
+   ;;chat
    :is-typing                             "yazıyor"
    :and-you                               "ve siz"
    :search-chat                           "Sohbette ara"
@@ -29,11 +29,11 @@
    :suggestions-requests                  "İstekler"
    :suggestions-commands                  "Komutlar"
 
-   ;sync
+   ;;sync
    :sync-in-progress                      "Eşitleniyor..."
    :sync-synced                           "Eşitlendi"
 
-   ;messages
+   ;;messages
    :status-sending                        "Gönderiliyor..."
    :status-pending                        "Beklemede"
    :status-sent                           "Gönderildi"
@@ -42,7 +42,7 @@
    :status-delivered                      "Teslim edildi"
    :status-failed                         "Başarısız"
 
-   ;datetime
+   ;;datetime
    :datetime-second                       {:one   "saniye"
                                            :other "saniye"}
    :datetime-minute                       {:one   "dakika"
@@ -55,7 +55,7 @@
    :datetime-yesterday                    "dün"
    :datetime-today                        "bugün"
 
-   ;profile
+   ;;profile
    :profile                               "Profil"
    :message                               "Mesaj"
    :not-specified                         "Belirtilmemiş"
@@ -63,12 +63,12 @@
    :phone-number                          "Telefon Numarası'"
    :add-to-contacts                       "Kişi listesine ekle"
 
-   ;make_photo
+   ;;make_photo
    :image-source-title                    "Profil Fotoğrafı"
    :image-source-make-photo               "Çek"
    :image-source-gallery                  "Galeriden seç"
 
-   ;sign-up
+   ;;sign-up
    :contacts-syncronized                  "Kişi listeniz eşitlendi"
    :confirmation-code                     (str "Teşekkürler! Size onay kodunu içeren bir kısa mesaj "
                                                "gönderdim. Telefon numaranızı onaylamak için lütfen bu kodu girin")
@@ -80,11 +80,11 @@
    :intro-message1                        "Status'e hoş geldiniz\nŞifrenizi oluşturmak ve hemen başlamak için bu mesaja dokunun!"
    :account-generation-message            "Bana birkaç saniye ayırın, hesabınızı oluşturmak için biraz matematik hesabı yapmam gerekecek!"
 
-   ;chats
+   ;;chats
    :chats                                 "Sohbetler"
    :new-group-chat                        "Yeni grup sohbeti"
 
-   ;discover
+   ;;discover
    :discover                              "Keşfet"
    :none                                  "Hiçbiri"
    :search-tags                           "Aramak istediğiniz etiketleri buraya girin"
@@ -92,17 +92,17 @@
    :recent                                "Güncel"
    :no-statuses-discovered                "Herhangi bir durum keşfedilmedi"
 
-   ;settings
+   ;;settings
    :settings                              "Ayarlar"
 
-   ;contacts
+   ;;contacts
    :contacts                              "Kişiler"
    :new-contact                           "Yeni Kişi"
    :contacts-group-new-chat               "Yeni sohbet başlat"
    :no-contacts                           "Henüz herhangi bir kişi yok"
    :show-qr                               "Kare Kodu göster"
 
-   ;group-settings
+   ;;group-settings
    :remove                                "Kaldır"
    :save                                  "Kaydet"
    :clear-history                         "Geçmişi temizle"
@@ -110,14 +110,14 @@
    :edit                                  "Düzenle"
    :add-members                           "Üye ekle"
 
-   ;commands
+   ;;commands
    :chat-send-eth                         "{{amount}} ETH"
 
-   ;new-group
+   ;;new-group
 
-   ;participants
+   ;;participants
 
-   ;protocol
+   ;;protocol
    :received-invitation                   "sohbet daveti alındı"
    :removed-from-chat                     "sizi grup sohbetinden sildi"
    :left                                  "ayrıldı"
@@ -125,7 +125,7 @@
    :removed                               "silindi"
    :You                                   "Siz"
 
-   ;new-contact
+   ;;new-contact
    :add-new-contact                       "Yeni kişi ekle"
    :scan-qr                               "Kare Kod tara"
    :name                                  "İsim"
@@ -135,31 +135,31 @@
    :unknown-address                       "Bilinmeyen adres"
 
 
-   ;login
+   ;;login
    :connect                               "Bağlan"
    :address                               "Adres"
    :password                              "Şifre"
    :wrong-password                        "Hatalı Şifre"
 
-   ;recover
+   ;;recover
    :passphrase                            "Parola"
    :recover                               "Kurtar"
 
-   ;accounts
+   ;;accounts
    :recover-access                        "Erişimi kurtar"
 
-   ;wallet-qr-code
+   ;;wallet-qr-code
    :done                                  "Yapıldı"
    :main-wallet                           "Ana Cüzdan"
 
-   ;validation
+   ;;validation
    :invalid-phone                         "Geçersiz telefon numarası"
    :amount                                "Miktar"
-   ;transactions
+   ;;transactions
    :status                                "Durum"
    :recipient                             "Alıcı"
 
-   ;:webview
+   ;;:webview
    :web-view-error                        "hoppala, hata"
 
    :confirm                               "Onayla"
@@ -206,8 +206,8 @@
    :mute-notifications                    "Bildirimleri kapat"
 
    :contact-s
-                                          {:one   "kişi"
-                                           :other "kişiler"}
+   {:one   "kişi"
+    :other "kişiler"}
    :next                                  "Sonraki"
    :from                                  "Şuradan:"
    :search-chats                          "Sohbetlerde arayın"

--- a/src/status_im/translations/ur.cljs
+++ b/src/status_im/translations/ur.cljs
@@ -2,17 +2,17 @@
 
 (def translations
   {
-   ;common
+   ;;common
    :members-title                         "ممبران"
    :not-implemented                       "نافذ نہیں ہوا!"
    :chat-name                             "چیٹ کا نام"
    :notifications-title                   "نوٹیفیکیشن اور آوازیں"
    :offline                               "آف لائن"
 
-   ;drawer
+   ;;drawer
    :switch-users                          "صارف تبدیل کریں"
 
-   ;chat
+   ;;chat
    :is-typing                             "اندراج کر رہا ہے"
    :and-you                               "اور آپ"
    :search-chat                           "چیٹ تلاش کریں"
@@ -29,11 +29,11 @@
    :suggestions-requests                  "درخواستیں"
    :suggestions-commands                  "کمانڈ"
 
-   ;sync
+   ;;sync
    :sync-in-progress                      "سنکرونائز ہو رہا ہے"
    :sync-synced                           "دوران سنکرونائز"
 
-   ;messages
+   ;;messages
    :status-sending                        "بھیجا جا رہا ہے"
    :status-pending                        "زیر غور"
    :status-sent                           "بھیج دیا گیا"
@@ -42,7 +42,7 @@
    :status-delivered                      "پہنچا دیا گیا"
    :status-failed                         "ناکام ہو گیا"
 
-   ;datetime
+   ;;datetime
    :datetime-second                       {:one   "سیکنڈ"
                                            :other "سیکنڈ"}
    :datetime-minute                       {:one   "منٹ"
@@ -55,7 +55,7 @@
    :datetime-yesterday                    "کل"
    :datetime-today                        "آج"
 
-   ;profile
+   ;;profile
    :profile                               "پروفائل"
    :message                               "پیغام"
    :not-specified                         "واضح نہیں کیا گیا"
@@ -68,7 +68,7 @@
    :image-source-make-photo               "کھینچیں"
    :image-source-gallery                  "گیلری سے چنیں"
 
-   ;sign-up
+   ;;sign-up
    :contacts-syncronized                  "آپ کے کانٹیکٹس سنکرونائز ہو گئے ہیں"
    :confirmation-code                     (str "شکریہ! ہم نے آپ کو تصدیق کا پیغام بھیج دیا ہے "
                                                "کوڈ کے ساتھ۔ برائے مہربانی اپنا نمبر کنفرم کرنے کے لیے وہ کوڈ فراہم کریں۔")
@@ -80,11 +80,11 @@
    :intro-message1                        "سٹیٹس میں خوش آمدید اور اپنا پاسورڈ سیٹ کرنے کے لیے اس کو ٹیپ کریں اور شروعات کریں۔"
    :account-generation-message            "مجھے ایک سیکنڈ دیں، اپ کا اکاؤنٹ تشکیل دینے کے لیے مجھے کچھ ریاضی سے کام کرنا ہے۔!"
 
-   ;chats
+   ;;chats
    :chats                                 "چیٹ"
    :new-group-chat                        "نئی گروپ چیٹ"
 
-   ;discover
+   ;;discover
    :discover                              "دریافت"
    :none                                  "کوئی نہیں"
    :search-tags                           "اپنا تلاش کا ٹیگ یہاں درج کریں"
@@ -92,17 +92,17 @@
    :recent                                "حالیہ"
    :no-statuses-discovered                "کوئی سٹیٹس نہیں پایا گیا"
 
-   ;settings
+   ;;settings
    :settings                              "سیٹنگز"
 
-   ;contacts
+   ;;contacts
    :contacts                              "رابطے"
    :new-contact                           "نئے رابطے"
    :contacts-group-new-chat               "نئی چیٹ شروع کریں"
    :no-contacts                           "ابھی یہاں کوئی کنٹیکٹ نہیں"
    :show-qr                               "دکھائیں QR"
 
-   ;group-settings
+   ;;group-settings
    :remove                                "نکالیں"
    :save                                  "محفوظ کریں"
    :clear-history                         "تاریخ مٹا دیں"
@@ -110,14 +110,14 @@
    :edit                                  "تصحیح"
    :add-members                           "ممبران شامل کریں"
 
-   ;commands
+   ;;commands
    :chat-send-eth                         "{{amount}} ETH"
 
-   ;new-group
+   ;;new-group
 
-   ;participants
+   ;;participants
 
-   ;protocol
+   ;;protocol
    :received-invitation                   "چیٹ کا دعوت نامہ وصول ہوا ہے"
    :removed-from-chat                     "گروپ سے نکال دیا ہے"
    :left                                  "چھوڑ دیا"
@@ -125,7 +125,7 @@
    :removed                               "نکال دیا گیا"
    :You                                   "آپ"
 
-   ;new-contact
+   ;;new-contact
    :add-new-contact                       "نیا کانٹیکٹ شامل کریں"
    :scan-qr                               "سکین کریں QR"
    :name                                  "نام"
@@ -135,31 +135,31 @@
    :unknown-address                       "نامعلوم پتہ"
 
 
-   ;login
+   ;;login
    :connect                               "ملیں"
    :address                               "پتہ"
    :password                              "پاسورڈ"
    :wrong-password                        "غلط پاسورڈ"
 
-   ;recover
+   ;;recover
    :passphrase                            "Passphrase"
    :recover                               "بحال کریں"
 
-   ;accounts
+   ;;accounts
    :recover-access                        "رسائی بحال کریں"
 
-   ;wallet-qr-code
+   ;;wallet-qr-code
    :done                                  "ہو گیا"
    :main-wallet                           "مرکزی والٹ"
 
-   ;validation
+   ;;validation
    :invalid-phone                         "غلط فون نمبر"
    :amount                                "رقم"
-   ;transactions
+   ;;transactions
    :status                                "سٹیٹس"
    :recipient                             "وصول کنندہ"
 
-   ;:webview
+   ;;:webview
    :web-view-error                        "اوہ، غلطی ہو گئی"
 
    :confirm                               "توثیق کریں"
@@ -206,8 +206,8 @@
    :mute-notifications                    "اطلاع نامے خاموش کریں"
 
    :contact-s
-                                          {:one   "رابطہ"
-                                           :other "روابط"}
+   {:one   "رابطہ"
+    :other "روابط"}
    :next                                  "اگلا"
    :from                                  "سے"
    :search-chats                          "چیٹس تلاش کریں"

--- a/src/status_im/translations/vi.cljs
+++ b/src/status_im/translations/vi.cljs
@@ -2,17 +2,17 @@
 
 (def translations
   {
-   ;common
+   ;;common
    :members-title                         "Các thành viên"
    :not-implemented                       "!không được thực hiện"
    :chat-name                             "Tên trò chuyện"
    :notifications-title                   "Thông báo và âm thanh"
    :offline                               "Không trực tuyến"
 
-   ;drawer
+   ;;drawer
    :switch-users                          "Đổi người dùng"
 
-   ;chat
+   ;;chat
    :is-typing                             "đang gõ"
    :and-you                               "và bạn"
    :search-chat                           "Tìm kiếm trò chuyện"
@@ -29,11 +29,11 @@
    :suggestions-requests                  "Các yêu cầu"
    :suggestions-commands                  "Các lệnh"
 
-   ;sync
+   ;;sync
    :sync-in-progress                      "Đang đồng bộ..."
    :sync-synced                           "Đồng bộ"
 
-   ;messages
+   ;;messages
    :status-sending                        "Đang gửi"
    :status-pending                        "Chưa giải quyết"
    :status-sent                           "Đã gửi"
@@ -42,7 +42,7 @@
    :status-delivered                      "Đã gửi"
    :status-failed                         "Đã thất bại"
 
-   ;datetime
+   ;;datetime
    :datetime-second                       {:one   "giây"
                                            :other "giây"}
    :datetime-minute                       {:one   "phút"
@@ -55,7 +55,7 @@
    :datetime-yesterday                    "hôm qua"
    :datetime-today                        "hôm nay"
 
-   ;profile
+   ;;profile
    :profile                               "Hồ sơ"
    :message                               "Tin nhắn"
    :not-specified                         "Không được xác định"
@@ -68,7 +68,7 @@
    :image-source-make-photo               "Chụp"
    :image-source-gallery                  "Chọn từ gallery"
 
-   ;sign-up
+   ;;sign-up
    :contacts-syncronized                  "Các liên hệ của bạn đã được đồng bộ hóa"
    :confirmation-code                     (str "Cảm ơn! Chúng tôi đã gửi cho bạn một tin nhắn văn bản với một xác nhận "
                                                "Vui lòng cung cấp mã đó để xác nhận số điện thoại của bạn")
@@ -80,11 +80,11 @@
    :intro-message1                        "Chào mừng đến với trang Trạng thái\nNhấp vào tin nhắn này để thiết lập mật khẩu của bạn & bắt đầu!"
    :account-generation-message            "Cho tôi một giây, tôi phải làm vài thuật toán điên khùng để khởi tạo tài khoản của bạn!"
 
-   ;chats
+   ;;chats
    :chats                                 "Trò chuyện"
    :new-group-chat                        "Cuộc trò chuyện theo nhóm mới"
 
-   ;discover
+   ;;discover
    :discover                              "Khám phá"
    :none                                  "Không"
    :search-tags                           "Gõ các thẻ tìm kiếm của bạn tại đây"
@@ -92,17 +92,17 @@
    :recent                                "Gần đây"
    :no-statuses-discovered                "Không có trạng thái được tìm thấy"
 
-   ;settings
+   ;;settings
    :settings                              "Các thiết lập"
 
-   ;contacts
+   ;;contacts
    :contacts                              "Các liên hệ"
    :new-contact                           "Liên hệ mới"
    :contacts-group-new-chat               "Bắt đầu cuộc trò chuyện mới"
    :no-contacts                           "Chưa có liên hệ"
    :show-qr                               "Hiển thị QR"
 
-   ;group-settings
+   ;;group-settings
    :remove                                "Xóa"
    :save                                  "Lưu"
    :clear-history                         "Xóa lịch sử"
@@ -110,14 +110,14 @@
    :edit                                  "Điều chỉnh"
    :add-members                           "Thêm Thành viên"
 
-   ;commands
+   ;;commands
    :chat-send-eth                         "{{amount}} ETH"
 
-   ;new-group
+   ;;new-group
 
-   ;participants
+   ;;participants
 
-   ;protocol
+   ;;protocol
    :received-invitation                   "đã nhận lời mời trò chuyện"
    :removed-from-chat                     "đã xóa bạn khỏi cuộc trò chuyện theo nhóm"
    :left                                  "đã rời đi"
@@ -125,7 +125,7 @@
    :removed                               "đã xóa"
    :You                                   "Bạn"
 
-   ;new-contact
+   ;;new-contact
    :add-new-contact                       "Thêm liên hệ mới"
    :scan-qr                               "Quét QR"
    :name                                  "Tên"
@@ -135,31 +135,31 @@
    :unknown-address                       "Địa chỉ không xác định"
 
 
-   ;login
+   ;;login
    :connect                               "Kết nối"
    :address                               "Địa chỉ"
    :password                              "Mật khẩu"
    :wrong-password                        "Mật khẩu sai"
 
-   ;recover
+   ;;recover
    :passphrase                            "Cụm mật khẩu"
    :recover                               "Khôi phục"
 
-   ;accounts
+   ;;accounts
    :recover-access                        "Khôi phục quyền truy cập"
 
-   ;wallet-qr-code
+   ;;wallet-qr-code
    :done                                  "Đã hoàn thành"
    :main-wallet                           "Ví chính"
 
-   ;validation
+   ;;validation
    :invalid-phone                         "Số điện thoại không hợp lệ"
    :amount                                "Số tiền"
-   ;transactions
+   ;;transactions
    :status                                "Trạng thái"
    :recipient                             "Người nhận"
 
-   ;:webview
+   ;;:webview
    :web-view-error                        "Ối, lỗi"
 
    :confirm                               "Xác nhận"
@@ -206,8 +206,8 @@
    :mute-notifications                    "Tắt tiếng thông báo"
 
    :contact-s
-                                          {:one   "liên hệ"
-                                           :other "Danh bạ"}
+   {:one   "liên hệ"
+    :other "Danh bạ"}
    :next                                  "Tiếp theo"
    :from                                  "Từ"
    :search-chats                          "Tìm kiếm các cuộc trò chuyện"

--- a/src/status_im/translations/zh_wuu.cljs
+++ b/src/status_im/translations/zh_wuu.cljs
@@ -2,7 +2,7 @@
 
 (def translations
   {
-   ;common
+   ;;common
    :members-title                         "会员"
    :not-implemented                       "!未实现"
    :chat-name                             "聊天名称"
@@ -18,11 +18,11 @@
    :camera-access-error                   "要授予所需的摄像机许可，请转到系统设置，并确定选择了“状态”>“摄像机”。"
    :photos-access-error                   "要授予所需的照片许可，请转到系统设置，并确保选择“状态“>“照片“。"
 
-   ;drawer
+   ;;drawer
    :switch-users                          "切换用户"
    :current-network                       "当前网络"
 
-   ;chat
+   ;;chat
    :is-typing                             "正在输入"
    :and-you                               "和您"
    :search-chat                           "搜索聊天"
@@ -42,11 +42,11 @@
    :faucet-success                        "水龙头请求已经收到"
    :faucet-error                          "水龙头请求错误"
 
-   ;sync
+   ;;sync
    :sync-in-progress                      "同步中..."
    :sync-synced                           "同步"
 
-   ;messages
+   ;;messages
    :status-sending                        "发送中"
    :status-pending                        "待定"
    :status-sent                           "已发送"
@@ -55,7 +55,7 @@
    :status-delivered                      "已发送"
    :status-failed                         "发送失败"
 
-   ;datetime
+   ;;datetime
    :datetime-ago-format                   "{{number}} {{time-intervals}} {{ago}}"
    :datetime-second                       {:one   "秒"
                                            :other "秒"}
@@ -69,7 +69,7 @@
    :datetime-yesterday                    "昨天"
    :datetime-today                        "今天"
 
-   ;profile
+   ;;profile
    :profile                               "个人资料"
    :edit-profile                          "编辑个人资料"
    :message                               "消息"
@@ -99,7 +99,7 @@
    :browsing-open-in-web-browser          "在网络浏览器中打开"
    :browsing-cancel                       "取消"
 
-   ;sign-up
+   ;;sign-up
    :contacts-syncronized                  "您的联系人已同步"
    :confirmation-code                     (str "谢谢！我们已经给您发了一个确认短信"
                                                "代码。请提供该代码以确认您的电话号码")
@@ -114,13 +114,13 @@
    :move-to-internal-failure-message      "我们需要将一些重要的文件从外部存储移动到内部存储。 为此，我们需要你的许可。 我们在将来的版本不会使用外部存储。"
    :debug-enabled                         "调试服务器已经推出！ 现在你可以执行* status-dev-cli scan *在同一网络上的电脑上查找服务器。"
 
-   ;phone types
+   ;;phone types
    :phone-e164                            "国际1"
    :phone-international                   "国际2"
    :phone-national                        "国内"
    :phone-significant                     "显着"
 
-   ;chats
+   ;;chats
    :chats                                 "聊天"
    :delete-chat                           "刪除聊天"
    :new-group-chat                        "新的群聊"
@@ -131,7 +131,7 @@
    :topic-format                          "格式错误 [a-z0-9\\-]+"
    :public-group-topic                    "主题"
 
-   ;discover
+   ;;discover
    :discover                             "发现"
    :none                                  "无"
    :search-tags                           "在这里键入您的搜索标签"
@@ -140,10 +140,10 @@
    :no-statuses-discovered                "未发现状态"
    :no-statuses-found                     "找不到状态"
 
-   ;settings
+   ;;settings
    :settings                              "设置"
 
-   ;contacts
+   ;;contacts
    :contacts                              "联系人"
    :new-contact                           "新的联系人"
    :delete-contact                        "删除联络人"
@@ -158,7 +158,7 @@
    :enter-address                         "輸入地址"
    :more                                  "更多"
 
-   ;group-settings
+   ;;group-settings
    :remove                                "移动"
    :save                                  "保存"
    :clear-history                         "清除历史"
@@ -169,10 +169,10 @@
    :edit                                  "编辑"
    :add-members                           "添加会员"
 
-   ;commands
+   ;;commands
    :chat-send-eth                         "{{amount}} ETH"
 
-   ;new-group
+   ;;new-group
    :new-group                             "新增群組"
    :reorder-groups                        "重新排序群組"
    :edit-group                            "編輯群組"
@@ -181,9 +181,9 @@
    :delete-group-prompt                   "這不會影響聯絡人"
    :contact-s                             {:one   "contact"
                                            :other "contacts"}
-   ;participants
+   ;;participants
 
-   ;protocol
+   ;;protocol
    :received-invitation                   "接受聊天邀请"
    :removed-from-chat                     "将您从群聊中移除"
    :left                                  "离开"
@@ -191,7 +191,7 @@
    :removed                               "已移除"
    :You                                   "您"
 
-   ;new-contact
+   ;;new-contact
    :add-new-contact                       "增加新的联系人"
    :scan-qr                               "扫描QR"
    :name                                  "名称"
@@ -202,7 +202,7 @@
    :unknown-address                       "未知地址"
 
 
-   ;login
+   ;;login
    :connect                               "连接"
    :address                               "地址"
    :password                              "密码"
@@ -210,23 +210,23 @@
    :sign-in-to-status                     "登录Status"
    :sign-in                               "登录"
 
-   ;recover
+   ;;recover
    :passphrase                            "口令短语"
    :recover                               "恢复"
    :twelve-words-in-correct-order         "正确排序12个字"
 
-   ;accounts
+   ;;accounts
    :recover-access                        "恢复访问"
    :create-new-account                    "建立新帐户"
 
-   ;wallet-qr-code
+   ;;wallet-qr-code
    :done                                  "完成"
    :main-wallet                           "主要钱包"
 
-   ;validation
+   ;;validation
    :invalid-phone                         "无效的电话号码"
    :amount                                "金额"
-   ;transactions
+   ;;transactions
    :confirm                               "确认"
    :transaction                           "交易"
    :status                                "状态"
@@ -236,5 +236,5 @@
    :data                                  "数据"
    :got-it                                "得到了"
 
-   ;:webview
+   ;;:webview
    :web-view-error                        "啊哦，错误"})

--- a/src/status_im/translations/zh_yue.cljs
+++ b/src/status_im/translations/zh_yue.cljs
@@ -2,7 +2,7 @@
 
 (def translations
   {
-   ;common
+   ;;common
    :members-title                         "會員"
    :not-implemented                       "!未能實現"
    :chat-name                             "用戶名稱"
@@ -18,11 +18,11 @@
    :camera-access-error                   "要授予所需的攝像機許可，請轉到系統設置，並確定選擇了“狀態”>“攝像機”。"
    :photos-access-error                   "要授予所需的照片許可，請轉到系統設置，並確保選擇“狀態“>“照片“。"
 
-   ;drawer
+   ;;drawer
    :switch-users                          "切換用戶"
    :current-network                       "當前網絡"
 
-   ;chat
+   ;;chat
    :is-typing                             "正在輸入"
    :and-you                               "與你"
    :search-chat                           "搜索聊天記錄"
@@ -42,11 +42,11 @@
    :faucet-success                        "水龍頭請求已經收到"
    :faucet-error                          "水龍頭請求錯誤"
 
-   ;sync
+   ;;sync
    :sync-in-progress                      "正在同步..."
    :sync-synced                           "已同步"
 
-   ;messages
+   ;;messages
    :status-sending                        "發送中"
    :status-pending                        "待定"
    :status-sent                           "發送成功"
@@ -55,7 +55,7 @@
    :status-delivered                      "已發送"
    :status-failed                         "失敗"
 
-   ;datetime
+   ;;datetime
    :datetime-ago-format                   "{{number}} {{time-intervals}} {{ago}}"
    :datetime-second                       {:one   "秒"
                                            :other "秒"}
@@ -69,7 +69,7 @@
    :datetime-yesterday                    "昨天"
    :datetime-today                        "今天"
 
-   ;profile
+   ;;profile
    :profile                               "用戶簡介"
    :edit-profile                          "編輯個人資料"
    :message                               "短訊"
@@ -99,7 +99,7 @@
    :browsing-open-in-web-browser          "在網絡瀏覽器中打開"
    :browsing-cancel                       "取消"
 
-   ;sign-up
+   ;;sign-up
    :contacts-syncronized                  "你的聯繫人已同步"
    :confirmation-code                     (str "謝謝！我們已以短訊形式將確認信息發送給你"
                                                "代碼。請提供該代碼，以確認你的電話號碼")
@@ -114,13 +114,13 @@
    :move-to-internal-failure-message      "我們需要將一些重要的文件從外部存儲移動到內部存儲。 為此，我們需要你的許可。 我們在將來的版本不會使用外部存儲。"
    :debug-enabled                         "調試服務器已經推出！ 現在你可以執行* status-dev-cli scan *在同一網絡上的電腦上查找服務器。"
 
-   ;phone types
+   ;;phone types
    :phone-e164                            "國際1"
    :phone-international                   "國際2"
    :phone-national                        "國內"
    :phone-significant                     "顯著"
 
-   ;chats
+   ;;chats
    :chats                                 "聊天史"
    :delete-chat                           "刪除對話"
    :new-group-chat                        "新增群聊"
@@ -131,7 +131,7 @@
    :topic-format                          "格式錯誤 [a-z0-9\\-]+"
    :public-group-topic                    "主題"
 
-   ;discover
+   ;;discover
    :discover                             "新發現"
    :none                                  "不存在"
    :search-tags                           "請輸入你的搜索標籤"
@@ -140,10 +140,10 @@
    :no-statuses-discovered                "沒有發現任何狀態"
    :no-statuses-found                     "找不到狀態"
 
-   ;settings
+   ;;settings
    :settings                              "設置"
 
-   ;contacts
+   ;;contacts
    :contacts                              "聯絡人"
    :new-contact                           "新增聯絡"
    :delete-contact                        "刪除聯絡人"
@@ -158,7 +158,7 @@
    :enter-address                         "輸入地址"
    :more                                  "更多"
 
-   ;group-settings
+   ;;group-settings
    :remove                                "刪除"
    :save                                  "儲存"
    :delete                                "刪除"
@@ -169,10 +169,10 @@
    :edit                                  "編輯"
    :add-members                           "增添成員"
 
-   ;commands
+   ;;commands
    :chat-send-eth                         "{{amount}} ETH"
 
-   ;new-group
+   ;;new-group
    :new-group                             "新增群組"
    :reorder-groups                        "重新排序群組"
    :edit-group                            "編輯群組"
@@ -181,9 +181,9 @@
    :delete-group-prompt                   "這不會影響聯絡人"
    :contact-s                             {:one   "contact"
                                            :other "contacts"}
-   ;participants
+   ;;participants
 
-   ;protocol
+   ;;protocol
    :received-invitation                   "收到聊天邀請"
    :removed-from-chat                     "已將你從群組聊天中刪除"
    :left                                  "離開"
@@ -191,7 +191,7 @@
    :removed                               "刪除"
    :You                                   "你"
 
-   ;new-contact
+   ;;new-contact
    :add-new-contact                       "添加新聯繫人"
    :scan-qr                               "掃描 QR"
    :name                                  "名稱"
@@ -202,7 +202,7 @@
    :unknown-address                       "未知地址"
 
 
-   ;login
+   ;;login
    :connect                               "連接"
    :address                               "地址"
    :password                              "密碼"
@@ -210,23 +210,23 @@
    :sign-in                               "登入"
    :wrong-password                        "密碼錯誤"
 
-   ;recover
+   ;;recover
    :passphrase                            "臨時登入碼"
    :recover                               "還原"
    :twelve-words-in-correct-order         "正確排序12個字"
 
-   ;accounts
+   ;;accounts
    :recover-access                        "恢復訪問"
    :create-new-account                    "建立新帳號"
 
-   ;wallet-qr-code
+   ;;wallet-qr-code
    :done                                  "完成"
    :main-wallet                           "主錢包"
 
-   ;validation
+   ;;validation
    :invalid-phone                         "電話號碼無效"
    :amount                                "金額"
-   ;transactions
+   ;;transactions
    :confirm                               "確認"
    :transaction                           "交易"
    :status                                "狀態"
@@ -236,5 +236,5 @@
    :data                                  "數據"
    :got-it                                "得到了"
 
-   ;:webview
+   ;;:webview
    :web-view-error                        "抱歉，錯誤"})


### PR DESCRIPTION
Fixes the comments in translations so that auto-formatting doesn't change files when adding/removing single translations

status: ready