### PR TITLE
Fix to make develop buildable again (should be merged ASAP)

### DIFF
--- a/src/status_im/translations/el.cljs
+++ b/src/status_im/translations/el.cljs
@@ -195,16 +195,6 @@
    ;;commands
    :chat-send-eth                         "{{amount}} ETH"
 
-   ;;location command
-   :your-current-location                 "Η τρέχουσα τοποθεσία σας"
-   :places-nearby                         "Τοποθεσίες κοντά μου"
-   :search-results                        "Αποτελέσματα αναζήτησης"
-   :dropped-pin                           "Καρφίτσωμα"
-   :location                              "Τοποθεσία"
-   :open-map                              "Άνοιγμα χάρτη"
-   :sharing-copy-to-clipboard-address     "Αντιγραφή διεύθυνσης"
-   :sharing-copy-to-clipboard-coordinates "Αντιγραφή συντεταγμένων"
-
    ;;new-group
    :new-group                             "Νέα ομάδα"
    :reorder-groups                        "Επαναδιαρθρώστε τις ομάδες"

--- a/src/status_im/ui/components/toolbar/view.cljs
+++ b/src/status_im/ui/components/toolbar/view.cljs
@@ -9,7 +9,7 @@
             [status-im.ui.components.toolbar.actions :as actions]
             [status-im.ui.components.toolbar.styles :as styles]
             [status-im.utils.platform :as platform]
-            [status-im.utils.utils :as utils]))
+            [status-im.utils.core :as utils]))
 
 ;; Navigation item
 

--- a/src/status_im/ui/screens/wallet/components.cljs
+++ b/src/status_im/ui/screens/wallet/components.cljs
@@ -2,7 +2,7 @@
   "
   Higher-level components used in the wallet screens.
   "
-  (:require [status-im.utils.utils :as utils]
+  (:require [status-im.utils.core :as utils]
             [status-im.ui.components.colors :as colors]
             [status-im.ui.components.icons.vector-icons :as vector-icons]
             [status-im.ui.components.react :as react]


### PR DESCRIPTION
1) Greek translation was merged almost at the same time when some /location-specific commands were removed. It led to the fact that the code in our develop branch doesn't pass tests at the moment. This PR removes some strings from Greek translation and makes things buildable again.
2) There are incorrect usages of namespace status-im.utils.utils — also fixed.