### PR TITLE
Fix incorrect ns for deep-merge fn

### DIFF
--- a/src/status_im/ui/components/toolbar/view.cljs
+++ b/src/status_im/ui/components/toolbar/view.cljs
@@ -9,7 +9,7 @@
             [status-im.ui.components.toolbar.actions :as actions]
             [status-im.ui.components.toolbar.styles :as styles]
             [status-im.utils.platform :as platform]
-            [status-im.utils.utils :as utils]))
+            [status-im.utils.core :as utils]))
 
 ;; Navigation item
 

--- a/src/status_im/ui/screens/wallet/components.cljs
+++ b/src/status_im/ui/screens/wallet/components.cljs
@@ -2,7 +2,7 @@
   "
   Higher-level components used in the wallet screens.
   "
-  (:require [status-im.utils.utils :as utils]
+  (:require [status-im.utils.core :as utils]
             [status-im.ui.components.colors :as colors]
             [status-im.ui.components.icons.vector-icons :as vector-icons]
             [status-im.ui.components.react :as react]


### PR DESCRIPTION
`(deep-merge)` has been moved to a new ns `status-im.utils.core`.

status: ready <!-- Can be ready or wip -->
