### PR TITLE
events.cljs: Refactor

### DIFF
--- a/test/cljs/status_im/test/contacts/events.cljs
+++ b/test/cljs/status_im/test/contacts/events.cljs
@@ -192,280 +192,272 @@
 
     (rf/dispatch [:initialize-db])
 
-    (let [contacts        (rf/subscribe [:get-contacts])
-          contact-groups  (rf/subscribe [:get-contact-groups])
-          view-id         (rf/subscribe [:get :view-id])]
+    (def contacts (rf/subscribe [:get-contacts]))
+    (def contact-groups (rf/subscribe [:get-contact-groups]))
+    (def view-id         (rf/subscribe [:get :view-id]))
+
+    (testing ":load-contacts event"
+
+      ;;Assert the initial state
+      (is (and (map? @contacts) (empty? @contacts)))
+      (rf/dispatch [:load-contacts]))
+
+    (testing ":load-contact-groups event"
+
+      ;;Assert the initial state
+      (is (and (map? @contact-groups) (empty? @contact-groups)))
+      (rf/dispatch [:load-contact-groups])
+      (is (= {(:group-id test-contact-group) test-contact-group}
+             @contact-groups)))
+
+    (testing ":load-default-contacts! event"
+
+      ;; :load-default-contacts! event dispatches next 5 events
+      ;;
+      ;; :add-contact-groups
+      ;; :add-contacts
+      ;; :add-contacts-to-group
+      ;;TODO :add-chat
+      ;;TODO :load-commands!
+      (rf/dispatch [:load-default-contacts!])
+
+      (rf/dispatch [:set-in [:group/contact-groups "dapps" :timestamp] 0])
+
+      (is (= {"dapps" dapps-contact-group
+              (:group-id test-contact-group) test-contact-group}
+             @contact-groups))
+
+      (testing "it adds a default contact"
+        (is (= demo-bot-contact (get @contacts "demo-bot"))))
+
+      (testing "it adds the console bot"
+        (is (= console-contact (get @contacts "console"))))
+
+      (testing "it does not add any other contact"
+        (is (= 2 (count (keys @contacts))))))
+
+    (def new-contact-public-key "0x048f7d5d4bda298447bbb5b021a34832509bd1a8dbe4e06f9b7223d00a59b6dc14f6e142b21d3220ceb3155a6d8f40ec115cd96394d3cc7c55055b433a1758dc74")
+    (def new-contact-address "5392ccb49f2e9fef8b8068b3e3b5ba6c020a9aca")
+    (def new-contact {:name ""
+                      :photo-path ""
+                      :whisper-identity new-contact-public-key
+                      :address new-contact-address})
+    (def contact (rf/subscribe [:contact-by-identity new-contact-public-key]))
+    (def current-chat-id (rf/subscribe [:get-current-chat-id]))
+
+    (testing ":add-contact-handler event - new contact"
+
+      (rf/dispatch [:set :view-id nil])
+      (rf/dispatch [:set :current-chat-id nil])
+
+      ;; :add-contact-handler event dispatches next 4 events for new contact
+      ;;
+      ;; :add-new-contact-and-open-chat
+      ;; :status-im.contacts.events/add-new-contact
+      ;; :status-im.contacts.events/send-contact-request
+      ;;TODO :start-chat
+
+      (rf/dispatch [:set :contacts/new-identity new-contact-public-key])
+      (rf/dispatch [:add-contact-handler])
+
+      (testing "it returns the new contact from the contact-by-identity sub"
+        (is (= new-contact (assoc @contact :photo-path "" :name ""))))
+
+      (testing "it adds the new contact to the list of contacts"
+        (is (= new-contact
+               (-> @contacts
+                   (get new-contact-public-key)
+                   (assoc :photo-path "" :name "")))))
+
+      (testing "it loads the 1-1 chat"
+        (is (= :chat @view-id)))
+
+      (testing "it adds the new contact to the chat"
+        (is (= new-contact-public-key @current-chat-id))))
+
+    (testing ":contact-request-received event"
+
+      ;; :contact-request-received event dispatches next 3 events
+      ;;
+      ;; :update-contact!
+      ;; :watch-contact
+      ;;TODO :update-chat!
+      (rf/reg-event-db :update-chat! (fn [db _] db))
+      (def received-contact {:name "test"
+                             :profile-image ""
+                             :address new-contact-address
+                             :status "test status"
+                             :fcm-token "0xwhatever"})
+      (def received-contact1 (merge new-contact
+                                    (dissoc received-contact :profile-image)
+                                    {:public-key new-contact-public-key
+                                     :private-key ""}))
+
+      (rf/dispatch [:contact-request-received {:from new-contact-public-key
+                                               :payload {:contact received-contact
+                                                         :keypair {:public new-contact-public-key
+                                                                   :private ""}}}])
+
+      (testing "it adds the new contact to the list of contacts"
+        (is (= received-contact1
+               (get @contacts new-contact-public-key)))))
+
+    (testing ":contact-update-received event"
+
+      ;; :contact-update-received event dispatches next 2 events
+      ;;
+      ;; :update-contact!
+      ;;TODO :update-chat!
+      (let [timestamp (datetime/now-ms)]
+        (def received-contact2 (assoc received-contact1
+                                      :last-updated timestamp
+                                      :status "new status"
+                                      :name "new name"))
+
+        (rf/dispatch [:contact-update-received {:from new-contact-public-key
+                                                :payload {:content {:profile {:profile-image ""
+                                                                              :status "new status"
+                                                                              :name "new name"}}
+                                                          :timestamp timestamp}}]))
+
+      (testing "it updates the contact and set the :last-updated key"
+        (is (= received-contact2
+               (get @contacts new-contact-public-key)))))
+
+    (testing ":hide-contact event"
+
+      ;; :hide-contact event dispatches next 2 events
+      ;;
+      ;; :update-contact!
+      ;;TODO :account-update-keys
+      (rf/reg-event-db :account-update-keys (fn [db _] db))
+
+      (rf/dispatch [:hide-contact @contact])
+
+      (testing "it sets the pending? flag to true"
+        (is (= (assoc received-contact2 :pending? true)
+               (get @contacts new-contact-public-key)))))
+
+    (testing ":add-contact-handler event - :add-pending-contact"
+
+      ;; :add-contact-handler event dispatches next 4 events
+      ;;
+      ;; :add-pending-contact
+      ;; :status-im.contacts.events/add-new-contact
+      ;; :status-im.contacts.events/send-contact-request
+      ;;TODO :discoveries-send-portions
+      (rf/reg-event-db :discoveries-send-portions (fn [db _] db))
 
-      (testing ":load-contacts event"
+      (rf/dispatch [:set :view-id nil])
+      (rf/dispatch [:set :current-chat-id nil])
+      (rf/dispatch [:set :contacts/new-identity new-contact-public-key])
+      (rf/dispatch [:add-contact-handler])
 
-        ;;Assert the initial state
-        (is (and (map? @contacts) (empty? @contacts)))
+      (testing "it sets the pending? flag to false"
+        (is (= (assoc received-contact2 :pending? false)
+               (get @contacts new-contact-public-key))))
 
-        (rf/dispatch [:load-contacts]))
+      (testing "it loads the 1-1 chat"
+        (is (= :chat @view-id)))
 
-      (testing ":load-contact-groups event"
+      (testing "it adds the new contact to the chat"
+        (is (= new-contact-public-key @current-chat-id))))
 
-        ;;Assert the initial state
-        (is (and (map? @contact-groups) (empty? @contact-groups)))
+    (testing ":create-new-contact-group event"
 
-        (rf/dispatch [:load-contact-groups])
+      (def new-group-name "new group")
+      (rf/dispatch [:select-contact new-contact-public-key])
+      (rf/dispatch [:select-contact "demo-bot"])
+      (rf/dispatch [:select-contact "browse"])
+      (rf/dispatch [:deselect-contact "browse"])
 
-        (is (= {(:group-id test-contact-group) test-contact-group}
-               @contact-groups)))
+      (rf/dispatch [:create-new-contact-group new-group-name])
 
-      (testing ":load-default-contacts! event"
-
-        ;; :load-default-contacts! event dispatches next 5 events
-        ;;
-        ;; :add-contact-groups
-        ;; :add-contacts
-        ;; :add-contacts-to-group
-        ;;TODO :add-chat
-        ;;TODO :load-commands!
-        (rf/dispatch [:load-default-contacts!])
-
-        (rf/dispatch [:set-in [:group/contact-groups "dapps" :timestamp] 0])
-
-        (is (= {"dapps" dapps-contact-group
-                (:group-id test-contact-group) test-contact-group}
-               @contact-groups))
-
-        (testing "it adds a default contact"
-          (is (= demo-bot-contact (get @contacts "demo-bot"))))
-
-        (testing "it adds the console bot"
-          (is (= console-contact (get @contacts "console"))))
-
-        (testing "it does not add any other contact"
-          (is (= 2 (count (keys @contacts))))))
-
-      (let [new-contact-public-key "0x048f7d5d4bda298447bbb5b021a34832509bd1a8dbe4e06f9b7223d00a59b6dc14f6e142b21d3220ceb3155a6d8f40ec115cd96394d3cc7c55055b433a1758dc74"
-            new-contact-address "5392ccb49f2e9fef8b8068b3e3b5ba6c020a9aca"
-            new-contact {:name ""
-                         :photo-path ""
-                         :whisper-identity new-contact-public-key
-                         :address new-contact-address}
-            contact (rf/subscribe [:contact-by-identity new-contact-public-key])
-            current-chat-id (rf/subscribe [:get-current-chat-id])]
-
-        (testing ":add-contact-handler event - new contact"
-
-          (rf/dispatch [:set :view-id nil])
-          (rf/dispatch [:set :current-chat-id nil])
-
-          ;; :add-contact-handler event dispatches next 4 events for new contact
-          ;;
-          ;; :add-new-contact-and-open-chat
-          ;; :status-im.contacts.events/add-new-contact
-          ;; :status-im.contacts.events/send-contact-request
-          ;;TODO :start-chat
-
-          (rf/dispatch [:set :contacts/new-identity new-contact-public-key])
-          (rf/dispatch [:add-contact-handler])
-
-          (testing "it returns the new contact from the contact-by-identity sub"
-            (is (= new-contact (assoc @contact :photo-path "" :name ""))))
-
-          (testing "it adds the new contact to the list of contacts"
-            (is (= new-contact
-                   (-> @contacts
-                       (get new-contact-public-key)
-                       (assoc :photo-path "" :name "")))))
+      (rf/dispatch [:deselect-contact "demo-bot"])
+      (rf/dispatch [:deselect-contact new-contact-public-key])
+      (def new-group-id (->> @contact-groups
+                             (vals)
+                             (filter #(= (:name %) new-group-name))
+                             (first)
+                             (:group-id)))
+      (def new-group {:group-id new-group-id
+                      :name new-group-name
+                      :order 2
+                      :timestamp 0
+                      :contacts [{:identity new-contact-public-key}
+                                 {:identity "demo-bot"}]})
+      (def groups-with-new-group {new-group-id new-group
+                                  "dapps" dapps-contact-group
+                                  (:group-id test-contact-group) test-contact-group})
+      (def groups-with-new-group1 (update groups-with-new-group new-group-id assoc :name "new group name"))
+      (def groups-with-new-group2 (-> groups-with-new-group1
+                                      (update new-group-id assoc :order 1)
+                                      (update "dapps" assoc :order 2)))
 
-          (testing "it loads the 1-1 chat"
-            (is (= :chat @view-id)))
-
-          (testing "it adds the new contact to the chat"
-            (is (= new-contact-public-key @current-chat-id))))
-
-        (testing ":contact-request-received event"
+      (rf/dispatch [:set-in [:group/contact-groups new-group-id :timestamp] 0])
 
-          ;; :contact-request-received event dispatches next 3 events
-          ;;
-          ;; :update-contact!
-          ;; :watch-contact
-          ;;TODO :update-chat!
-          (rf/reg-event-db :update-chat! (fn [db _] db))
-
-          (let [received-contact {:name "test"
-                                  :profile-image ""
-                                  :address new-contact-address
-                                  :status "test status"
-                                  :fcm-token "0xwhatever"}
-                received-contact' (merge new-contact
-                                         (dissoc received-contact :profile-image)
-                                         {:public-key new-contact-public-key
-                                          :private-key ""})]
-
-            (rf/dispatch [:contact-request-received {:from new-contact-public-key
-                                                     :payload {:contact received-contact
-                                                               :keypair {:public new-contact-public-key
-                                                                         :private ""}}}])
-
-            (testing "it adds the new contact to the list of contacts"
-              (is (= received-contact'
-                     (get @contacts new-contact-public-key))))
-
-            (testing ":contact-update-received event"
-
-              ;; :contact-update-received event dispatches next 2 events
-              ;;
-              ;; :update-contact!
-              ;;TODO :update-chat!
-              (let [timestamp (datetime/now-ms)
-                    received-contact'' (assoc received-contact'
-                                              :last-updated timestamp
-                                              :status "new status"
-                                              :name "new name")]
-
-                (rf/dispatch [:contact-update-received {:from new-contact-public-key
-                                                        :payload {:content {:profile {:profile-image ""
-                                                                                      :status "new status"
-                                                                                      :name "new name"}}
-                                                                  :timestamp timestamp}}])
-
-                (testing "it updates the contact and set the :last-updated key"
-                  (is (= received-contact''
-                         (get @contacts new-contact-public-key))))
-
-                (testing ":hide-contact event"
-
-                  ;; :hide-contact event dispatches next 2 events
-                  ;;
-                  ;; :update-contact!
-                  ;;TODO :account-update-keys
-                  (rf/reg-event-db :account-update-keys (fn [db _] db))
-
-                  (rf/dispatch [:hide-contact @contact])
-
-                  (testing "it sets the pending? flag to true"
-                    (is (= (assoc received-contact'' :pending? true)
-                           (get @contacts new-contact-public-key)))))
-
-                (testing ":add-contact-handler event - :add-pending-contact"
-
-                  ;; :add-contact-handler event dispatches next 4 events
-                  ;;
-                  ;; :add-pending-contact
-                  ;; :status-im.contacts.events/add-new-contact
-                  ;; :status-im.contacts.events/send-contact-request
-                  ;;TODO :discoveries-send-portions
-                  (rf/reg-event-db :discoveries-send-portions (fn [db _] db))
+      (is (= groups-with-new-group @contact-groups)))
 
-                  (rf/dispatch [:set :view-id nil])
-                  (rf/dispatch [:set :current-chat-id nil])
-                  (rf/dispatch [:set :contacts/new-identity new-contact-public-key])
-                  (rf/dispatch [:add-contact-handler])
+    (testing ":set-contact-group-name event"
 
-                  (testing "it sets the pending? flag to false"
-                    (is (= (assoc received-contact'' :pending? false)
-                           (get @contacts new-contact-public-key))))
+      (rf/reg-event-db ::prepare-group-name
+                       (fn [db _] (assoc db
+                                         :new-chat-name "new group name"
+                                         :group/contact-group-id new-group-id)))
 
-                  (testing "it loads the 1-1 chat"
-                    (is (= :chat @view-id)))
+      (rf/dispatch [::prepare-group-name])
+      (rf/dispatch [:set-contact-group-name])
 
-                  (testing "it adds the new contact to the chat"
-                    (is (= new-contact-public-key @current-chat-id))))
+      (is (= groups-with-new-group1 @contact-groups)))
 
-                (testing ":create-new-contact-group event"
+    (testing ":save-contact-group-order event"
 
-                  (let [new-group-name "new group"]
+      (rf/reg-event-db ::prepare-groups-order
+                       (fn [db _]
+                         (assoc db :group/groups-order
+                                (->> (vals (:group/contact-groups db))
+                                     (remove :pending?)
+                                     (sort-by :order >)
+                                     (map :group-id)))))
 
-                    (rf/dispatch [:select-contact new-contact-public-key])
-                    (rf/dispatch [:select-contact "demo-bot"])
-                    (rf/dispatch [:select-contact "browse"])
-                    (rf/dispatch [:deselect-contact "browse"])
+      (rf/dispatch [::prepare-groups-order])
+      (rf/dispatch [:change-contact-group-order 1 0])
+      (rf/dispatch [:save-contact-group-order])
 
-                    (rf/dispatch [:create-new-contact-group new-group-name])
+      (is (= groups-with-new-group2 @contact-groups)))
 
-                    (rf/dispatch [:deselect-contact "demo-bot"])
-                    (rf/dispatch [:deselect-contact new-contact-public-key])
+    (testing ":add-selected-contacts-to-group event"
 
-                    (let [new-group-id (->> @contact-groups
-                                            (vals)
-                                            (filter #(= (:name %) new-group-name))
-                                            (first)
-                                            (:group-id))
-                          new-group {:group-id    new-group-id
-                                     :name        new-group-name
-                                     :order       2
-                                     :timestamp   0
-                                     :contacts   [{:identity new-contact-public-key}
-                                                  {:identity "demo-bot"}]}
-                          groups-with-new-group {new-group-id new-group
-                                                 "dapps" dapps-contact-group
-                                                 (:group-id test-contact-group) test-contact-group}]
+      (rf/dispatch [:select-contact "browse"])
+      (rf/dispatch [:add-selected-contacts-to-group])
+      (rf/dispatch [:deselect-contact "browse"])
 
-                      (rf/dispatch [:set-in [:group/contact-groups new-group-id :timestamp] 0])
+      (is (= (update groups-with-new-group2 new-group-id assoc :contacts [{:identity new-contact-public-key}
+                                                                          {:identity "demo-bot"}
+                                                                          {:identity "browse"}])
+             @contact-groups)))
 
-                      (is (= groups-with-new-group @contact-groups))
+    (testing ":remove-contact-from-group event"
 
-                      (let [groups-with-new-group' (update groups-with-new-group new-group-id assoc :name "new group name")]
+      (rf/dispatch [:remove-contact-from-group "browse" new-group-id])
 
-                        (testing ":set-contact-group-name event"
+      (is (= groups-with-new-group2 @contact-groups)))
 
-                          (rf/reg-event-db ::prepare-group-name
-                                           (fn [db _] (assoc db
-                                                             :new-chat-name "new group name"
-                                                             :group/contact-group-id new-group-id)))
 
-                          (rf/dispatch [::prepare-group-name])
-                          (rf/dispatch [:set-contact-group-name])
+    (testing ":add-contacts-to-group event"
 
-                          (is (= groups-with-new-group' @contact-groups)))
+      (rf/dispatch [:add-contacts-to-group new-group-id ["browse"]])
 
-                        (let [groups-with-new-group'' (-> groups-with-new-group'
-                                                          (update new-group-id assoc :order 1)
-                                                          (update "dapps" assoc :order 2))]
+      (is (= (update groups-with-new-group2 new-group-id assoc :contacts [{:identity new-contact-public-key}
+                                                                          {:identity "demo-bot"}
+                                                                          {:identity "browse"}])
+             @contact-groups))
 
-                          (testing ":save-contact-group-order event"
+      (rf/dispatch [:remove-contact-from-group "browse" new-group-id]))
 
-                            (rf/reg-event-db ::prepare-groups-order
-                                             (fn [db _]
-                                               (assoc db :group/groups-order
-                                                      (->> (vals (:group/contact-groups db))
-                                                           (remove :pending?)
-                                                           (sort-by :order >)
-                                                           (map :group-id)))))
+    (testing ":delete-contact-group event"
 
-                            (rf/dispatch [::prepare-groups-order])
-                            (rf/dispatch [:change-contact-group-order 1 0])
-                            (rf/dispatch [:save-contact-group-order])
+      (rf/dispatch [:delete-contact-group])
 
-                            (is (= groups-with-new-group'' @contact-groups)))
-
-                          (testing ":add-selected-contacts-to-group event"
-
-                            (rf/dispatch [:select-contact "browse"])
-                            (rf/dispatch [:add-selected-contacts-to-group])
-                            (rf/dispatch [:deselect-contact "browse"])
-
-                            (is (= (update groups-with-new-group'' new-group-id assoc :contacts [{:identity new-contact-public-key}
-                                                                                                 {:identity "demo-bot"}
-                                                                                                 {:identity "browse"}])
-                                   @contact-groups)))
-
-                          (testing ":remove-contact-from-group event"
-
-                            (rf/dispatch [:remove-contact-from-group "browse" new-group-id])
-
-                            (is (= groups-with-new-group'' @contact-groups)))
-
-
-                          (testing ":add-contacts-to-group event"
-
-                            (rf/dispatch [:add-contacts-to-group new-group-id ["browse"]])
-
-                            (is (= (update groups-with-new-group'' new-group-id assoc :contacts [{:identity new-contact-public-key}
-                                                                                                 {:identity "demo-bot"}
-                                                                                                 {:identity "browse"}])
-                                   @contact-groups))
-
-                            (rf/dispatch [:remove-contact-from-group "browse" new-group-id]))
-
-                          (testing ":delete-contact-group event"
-
-                            (rf/dispatch [:delete-contact-group])
-
-                            (is (= (update groups-with-new-group'' new-group-id assoc :pending? true)
-                                   @contact-groups))))))))))))))))
+      (is (= (update groups-with-new-group2 new-group-id assoc :pending? true)
+             @contact-groups)))))


### PR DESCRIPTION
Reduce the overall nesting level in the test.  Each `testing' statement now fits on a single screen, instead of spanning hundreds of lines.
The final top-level expression went from 16 to 5 consecutive closing parens.
