### PR TITLE
[refs #3210] Replace realm reads for chats with app-db reads

### DIFF
--- a/src/status_im/chat/models.cljs
+++ b/src/status_im/chat/models.cljs
@@ -59,3 +59,8 @@
   "Just like `update-chat` only implicitely updates timestamp"
   [cofx chat]
   (update-chat cofx (assoc chat :timestamp (:now cofx))))
+
+(defn new-update? [{:keys [added-to-at removed-at removed-from-at]} timestamp]
+  (and (> timestamp added-to-at)
+       (> timestamp removed-at)
+       (> timestamp removed-from-at)))

--- a/src/status_im/data_store/chats.cljs
+++ b/src/status_im/data_store/chats.cljs
@@ -34,10 +34,6 @@
   [chat-id]
   (data-store/get-contacts chat-id))
 
-(defn has-contact?
-  [chat-id identity]
-  (data-store/has-contact? chat-id identity))
-
 (defn add-contacts
   [chat-id identities]
   (data-store/add-contacts chat-id identities))
@@ -54,10 +50,6 @@
   [chat-id property-name]
   (data-store/get-property chat-id property-name))
 
-(defn is-active?
-  [chat-id]
-  (get-property chat-id :is-active))
-
 (defn removed-at
   [chat-id]
   (get-property chat-id :removed-at))
@@ -69,13 +61,3 @@
 (defn set-active
   [chat-id active?]
   (save-property chat-id :is-active active?))
-
-(defn new-update?
-  [timestamp chat-id]
-  (let
-      [{:keys [added-to-at removed-at removed-from-at added-at]}
-       (get-by-id chat-id)]
-    (and (> timestamp added-to-at)
-         (> timestamp removed-at)
-         (> timestamp removed-from-at)
-         (> timestamp added-at))))

--- a/src/status_im/data_store/realm/chats.cljs
+++ b/src/status_im/data_store/realm/chats.cljs
@@ -84,13 +84,6 @@
       (realm/get-one-by-field :chat :chat-id chat-id)
       (object/get "contacts")))
 
-(defn has-contact?
-  [chat-id identity]
-  (let [contacts (get-contacts chat-id)
-        contact  (.find contacts (fn [object _ _]
-                                   (= identity (object/get object "identity"))))]
-    (if contact true false)))
-
 (defn- save-contacts
   [identities contacts added-at]
   (doseq [contact-identity identities]


### PR DESCRIPTION
Addresses #3210 
This second part of ongoing work, part 1 is here https://github.com/status-im/status-react/pull/3212

### Summary:

Replace realm read for chats data with app-db read as we don't need to touch realm since data is already in app-db.

### Review notes:

This is part of further work at https://github.com/status-im/status-react/issues/3210 

### Testing notes:
App behavior should not change. Code changed related to interactions with the chats:
- chat created
- member invited
- member removed
- member left
- chat removed

status: ready
