### PR TITLE
Effects should be dumb, without any logic

### DIFF
--- a/src/status_im/chat/models/message.cljs
+++ b/src/status_im/chat/models/message.cljs
@@ -219,9 +219,8 @@
   (let [chat    (get-in db [:chats chat-id])
         message (prepare-message params chat)
         params' (assoc params :message message)
-        fx      {:db                      (add-message-to-db db chat-id message true)
-                 :update-message-overhead [chat-id network-status]
-                 :save-message             message}]
+        fx      {:db                      (add-message-to-db db chat-id message true) 
+                 :save-message            message}]
     (-> (merge fx (chat-model/upsert-chat (assoc fx :now now)
                                           {:chat-id chat-id}))
         (as-> fx'
@@ -283,8 +282,7 @@
         params'          (assoc params :command command')
 
         fx               {:db                      (-> (merge db (:db result))
-                                                       (add-message-to-db chat-id command' true))
-                          :update-message-overhead [chat-id network-status]
+                                                       (add-message-to-db chat-id command' true)) 
                           :save-message            (-> command'
                                                        (assoc :chat-id chat-id)
                                                        (update-in [:content :params]

--- a/src/status_im/data_store/chats.cljs
+++ b/src/status_im/data_store/chats.cljs
@@ -62,10 +62,6 @@
   [chat-id]
   (get-property chat-id :removed-at))
 
-(defn get-message-overhead
-  [chat-id]
-  (get-property chat-id :message-overhead))
-
 (defn get-active-group-chats
   []
   (data-store/get-active-group-chats))
@@ -73,14 +69,6 @@
 (defn set-active
   [chat-id active?]
   (save-property chat-id :is-active active?))
-
-(defn inc-message-overhead
-  [chat-id]
-  (save-property chat-id :message-overhead (inc (get-message-overhead chat-id))))
-
-(defn reset-message-overhead
-  [chat-id]
-  (save-property chat-id :message-overhead 0))
 
 (defn new-update?
   [timestamp chat-id]

--- a/src/status_im/data_store/realm/schemas/account/v21/chat.cljs
+++ b/src/status_im/data_store/realm/schemas/account/v21/chat.cljs
@@ -1,0 +1,37 @@
+(ns status-im.data-store.realm.schemas.account.v21.chat
+  (:require [status-im.ui.components.styles :refer [default-chat-color]]))
+
+(def schema {:name       :chat
+             :primaryKey :chat-id
+             :properties {:chat-id          :string
+                          :name             :string
+                          :color            {:type    :string
+                                             :default default-chat-color}
+                          :group-chat       {:type    :bool
+                                             :indexed true}
+                          :group-admin      {:type     :string
+                                             :optional true}
+                          :is-active        :bool
+                          :timestamp        :int
+                          :contacts         {:type       :list
+                                             :objectType :chat-contact}
+                          :unremovable?     {:type     :bool
+                                             :default  false}
+                          :removed-at       {:type     :int
+                                             :optional true}
+                          :removed-from-at  {:type     :int
+                                             :optional true}
+                          :added-to-at      {:type     :int
+                                             :optional true}
+                          :updated-at       {:type     :int
+                                             :optional true} 
+                          :public-key       {:type     :string
+                                             :optional true}
+                          :private-key      {:type     :string
+                                             :optional true}
+                          :contact-info     {:type     :string
+                                             :optional true}
+                          :debug?           {:type    :bool
+                                             :default false}
+                          :public?          {:type    :bool
+                                             :default false}}})

--- a/src/status_im/data_store/realm/schemas/account/v21/core.cljs
+++ b/src/status_im/data_store/realm/schemas/account/v21/core.cljs
@@ -1,5 +1,5 @@
 (ns status-im.data-store.realm.schemas.account.v21.core
-  (:require [status-im.data-store.realm.schemas.account.v19.chat :as chat]
+  (:require [status-im.data-store.realm.schemas.account.v21.chat :as chat]
             [status-im.data-store.realm.schemas.account.v1.chat-contact :as chat-contact]
             [status-im.data-store.realm.schemas.account.v19.contact :as contact]
             [status-im.data-store.realm.schemas.account.v20.discover :as discover]

--- a/src/status_im/ui/screens/contacts/events.cljs
+++ b/src/status_im/ui/screens/contacts/events.cljs
@@ -84,7 +84,7 @@
     (contacts/save contact)))
 
 (reg-fx
-  ::save-contacts!
+  :save-all-contacts
   (fn [new-contacts]
     (contacts/save-all new-contacts)))
 
@@ -223,8 +223,8 @@
                              ;;(remove #(identities (:whisper-identity %)))
                              (map #(vector (:whisper-identity %) %))
                              (into {}))
-          fx            {:db              (update db :contacts/contacts merge new-contacts')
-                         ::save-contacts! (vals new-contacts')}]
+          fx            {:db                (update db :contacts/contacts merge new-contacts')
+                         :save-all-contacts (vals new-contacts')}]
       (transduce (map second)
                  (completing (partial loading-events/load-commands (assoc cofx :db (:db fx))))
                  fx

--- a/src/status_im/ui/screens/group/chat_settings/events.cljs
+++ b/src/status_im/ui/screens/group/chat_settings/events.cljs
@@ -2,8 +2,7 @@
   (:require [re-frame.core :refer [dispatch reg-fx]]
             [status-im.utils.handlers :refer [register-handler-fx]]
             [status-im.protocol.core :as protocol]
-            [status-im.utils.random :as random]
-            [status-im.chat.handlers :as chat-events]
+            [status-im.utils.random :as random] 
             [status-im.data-store.contacts :as contacts]
             [status-im.data-store.messages :as messages]
             [status-im.data-store.chats :as chats]
@@ -173,4 +172,4 @@
   :clear-history
   (fn [{{:keys [current-chat-id] :as db} :db} _]
     {:db (assoc-in db [:chats current-chat-id :messages] {})
-     ::chat-events/delete-messages current-chat-id}))
+     :delete-messages current-chat-id}))

--- a/test/cljs/status_im/test/contacts/events.cljs
+++ b/test/cljs/status_im/test/contacts/events.cljs
@@ -64,7 +64,7 @@
 (defn test-fixtures []
   (rf/reg-fx ::events/init-store #())
 
-  (rf/reg-fx ::contacts-events/save-contacts! #())
+  (rf/reg-fx :save-all-contacts #())
   (rf/reg-fx ::contacts-events/save-contact #())
   (rf/reg-fx ::contacts-events/watch-contact #())
   (rf/reg-fx ::contacts-events/stop-watching-contact #())


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

Works towards https://github.com/status-im/ideas/issues/74 idea

### Summary:

[comment]: # (Summarise the problem and how the pull request solves it)
Coeffects/effects should be simple and not contain any logic other then implementation details about how the side effects are actually translated (whether it's direct call, queueing for later processing, batching, etc.) so they can be re-used to maximal extent.

Having actual application logic is them is bad because:
1. They are less re-usable
2. Hard to test

Also, I removed `:message-overhead` field in chat realm/app-db entity and every logic associated with it. It looks like some relict from older code, we were setting it, but it was never actually red.

As another thing, it fixes #3249 

### Testing notes (optional):
Chat regression testing

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready
