### PR TITLE
Use blocking puts

### DIFF
--- a/src/status_im/protocol/handlers.cljs
+++ b/src/status_im/protocol/handlers.cljs
@@ -70,7 +70,7 @@
 
 ;;;; FX
 
-(def ^:private protocol-realm-queue (async-utils/task-queue 200))
+(def ^:private protocol-realm-queue (async-utils/task-queue 2000))
 
 (re-frame/reg-fx
   :stop-whisper
@@ -116,7 +116,7 @@
 (re-frame/reg-fx
   ::save-processed-messages
   (fn [processed-message]
-    (async/put! protocol-realm-queue #(processed-messages/save processed-message))))
+    (async/go (async/>! protocol-realm-queue #(processed-messages/save processed-message)))))
 
 (defn system-message [message-id timestamp content]
   {:from         "system"
@@ -196,12 +196,12 @@
 (re-frame/reg-fx
   ::pending-messages-delete
   (fn [message-id]
-    (async/put! protocol-realm-queue #(pending-messages/delete message-id))))
+    (async/go (async/>! protocol-realm-queue #(pending-messages/delete message-id)))))
 
 (re-frame/reg-fx
   ::pending-messages-save
   (fn [pending-message]
-    (async/put! protocol-realm-queue #(pending-messages/save pending-message))))
+    (async/go (async/>! protocol-realm-queue #(pending-messages/save pending-message)))))
 
 (re-frame/reg-fx
   ::status-init-jail


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes #3126 

### Summary:

Kudos to @dmitryn for actually finding the root cause of the bug, which is the fact, that we have been using `put!` on the bounded buffer, while `put!` is always unblocking and subject to `1024` put buffer limitation.
Basically `put!` is to be used only in situations where channel has no buffer, we want do to unblocking write and we are sure that the rate of writing will never exceed channel flush interval (good example is `call-jail` implementation with windowed channel).

Whenever we want to control channel back-pressure and utilise channel buffers, we have to use blocking `>!` calls in conjunction with appropriately size buffer.

So this PR does that, blocking put + greatly increased channel size.

### Testing notes (optional):
Test the scenario from related bug ticket + basic check that message sending still works (any type of chat can be used for that)

status: ready
