### PR TITLE
Update status-go to develop-g607954bf

### DIFF
--- a/modules/react-native-status/android/build.gradle
+++ b/modules/react-native-status/android/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     implementation 'com.github.ericwlange:AndroidJSCore:3.0.1'
     implementation 'status-im:function:0.0.1'
 
-    String statusGoVersion = 'develop-gd71c66a2'
+    String statusGoVersion = 'develop-g607954bf'
     final String statusGoGroup = 'status-im', statusGoName = 'status-go'
 
     // Check if the local status-go jar exists, and compile against that if it does

--- a/modules/react-native-status/ios/RCTStatus/pom.xml
+++ b/modules/react-native-status/ios/RCTStatus/pom.xml
@@ -25,7 +25,7 @@
                         <artifactItem>
                             <groupId>status-im</groupId>
                             <artifactId>status-go-ios-simulator</artifactId>
-                            <version>develop-gd71c66a2</version>
+                            <version>develop-g607954bf</version>
                             <type>zip</type>
                             <overWrite>true</overWrite>
                             <outputDirectory>./</outputDirectory>


### PR DESCRIPTION
Another update after a bunch of refactoring we did recently.

Changelog (curated):
```
156bbe19 [#429] fix npe in geth's filter system.
def50018 [#429/partial] Add a patch to fix npe in go-ethereum. (#599)
653da5bc Result of tx processing returned as QueuedTxResult
680d0513 Refactoring of TxQueue and Manager (#530)
c153a60d Clean up whisper log delivery (#555)
0771e7d1 Use single codepath for sending transactions to a local and remote nodes (#527)
bffd2fda Add `Content-Type` to the whisper tests as required in geth 1.7.3. (#553)
f93cd81d Upgrade to geth 1.7.3 and add geth patches (#492)
7ab6a062 [#516] Fix panic based on wrong error in setImmediate function (#535)
21132a44 Remove creating global `_status_catalog` variable
```