### PR TITLE
Tiny PR to add `prod-build-android` and `prod-build-ios` aliases to project.clj

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,14 +41,20 @@ prepare-ios: prepare ##@prepare Install iOS specific dependencies
 #----------------
 release: release-android release-ios ##@build build release for Android and iOS
 
-release-android: prod-build ##@build build release for Android
+release-android: prod-build-android ##@build build release for Android
 	react-native run-android --variant=release
 
-release-ios: prod-build ##@build build release for iOS release
+release-ios: prod-build-ios ##@build build release for iOS release
 	@echo "Build in XCode, see https://wiki.status.im/TBD for instructions"
 
 prod-build:
 	lein prod-build
+
+prod-build-android:
+	lein prod-build-android
+
+prod-build-ios:
+	lein prod-build-ios
 
 #----------------
 # Dev builds

--- a/project.clj
+++ b/project.clj
@@ -18,6 +18,12 @@
             ["do" "clean"
              ["with-profile" "prod" "cljsbuild" "once" "ios"]
              ["with-profile" "prod" "cljsbuild" "once" "android"]]
+            "prod-build-android" ^{:doc "Recompile code for Android with prod profile."}
+            ["do" "clean"
+             ["with-profile" "prod" "cljsbuild" "once" "android"]]
+            "prod-build-ios"     ^{:doc "Recompile code for iOS with prod profile."}
+            ["do" "clean"
+             ["with-profile" "prod" "cljsbuild" "once" "ios"]]
             "figwheel-repl"      ["with-profile" "+figwheel" "run" "-m" "clojure.main" "env/dev/run.clj"]
             "test-cljs"          ["with-profile" "test" "doo" "node" "test" "once"]
             "test-protocol"      ["with-profile" "test" "doo" "node" "protocol" "once"]


### PR DESCRIPTION
... so that `release-*` make targets only build selected platform, saving developer's time.

status: ready <!-- Can be ready or wip -->
