### PR TITLE
[ISSUE #3246] Fixed regression when opening URL

### DIFF
--- a/src/status_im/ui/components/list_selection.cljs
+++ b/src/status_im/ui/components/list_selection.cljs
@@ -29,8 +29,8 @@
 
 (defn browse [link]
   (show {:title       (i18n/label :t/browsing-title)
-         :options     [{:text   (i18n/label :t/browsing-open-in-browser)
-                        :action (re-frame/dispatch [:open-browser {:url link}])}
-                       {:text   (i18n/label :t/browsing-open-in-web-browser)
-                        :action (.openURL react/linking link)}]
+         :options     [{:label  (i18n/label :t/browsing-open-in-browser)
+                        :action #(re-frame/dispatch [:open-browser {:url link}])}
+                       {:label  (i18n/label :t/browsing-open-in-web-browser)
+                        :action #(.openURL react/linking link)}]
          :cancel-text (i18n/label :t/browsing-cancel)}))


### PR DESCRIPTION

fixes #3246

### Summary:

Fixed regression leading to multiple window opened when clicking on an URL

### Steps to test:
- Open Status
- Chat with someone
- Enter a URL
- Click on it: a single popup should show

status: ready
