### PR TITLE
[refs #3055] increase number of retries before mark-trusted-peer call

### DIFF
--- a/src/status_im/protocol/handlers.cljs
+++ b/src/status_im/protocol/handlers.cljs
@@ -229,9 +229,9 @@
    ;; Run immediately on first run, add delay before retry
    (let [delay (cond
                  (zero? retries) 0
-                 (< retries 3) 300
-                 (< retries 10) 1000
-                 :else 5000)]
+                 (< retries 3)   300
+                 (< retries 10)  1000
+                 :else           5000)]
      (if (> retries 100)
        (log/error "Number of retries for fetching peers exceed" wnode)
        (js/setTimeout

--- a/src/status_im/protocol/handlers.cljs
+++ b/src/status_im/protocol/handlers.cljs
@@ -227,8 +227,12 @@
  ::fetch-peers
  (fn [{:keys [wnode web3 retries]}]
    ;; Run immediately on first run, add delay before retry
-   (let [delay (if (zero? retries) 0 300)]
-     (if (> retries 3)
+   (let [delay (cond
+                 (zero? retries) 0
+                 (< retries 3) 300
+                 (< retries 10) 1000
+                 :else 5000)]
+     (if (> retries 100)
        (log/error "Number of retries for fetching peers exceed" wnode)
        (js/setTimeout
         (fn [] (inbox/fetch-peers #(re-frame/dispatch [::fetch-peers-success web3 % retries])


### PR DESCRIPTION
fixes #3055 

### Summary:

Sometimes 3 retries with 300ms interval is not enough for peer to be registered after `add-peer` call. Increase number of attempts and interval between them.

### Review notes (optional):


### Testing notes (optional):
PR doesn't change app logic or UI. Just make sure offline messaging work (you're able to receive at least 1 message).

status: ready <!-- Can be ready or wip -->
