### PR TITLE
Performance benchmarks

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
                  [org.clojure/clojurescript "1.9.946"]
                  [org.clojure/core.async "0.4.474"]
                  [reagent "0.7.0" :exclusions [cljsjs/react cljsjs/react-dom cljsjs/react-dom-server cljsjs/create-react-class]]
-                 [re-frame "0.10.2"]
+                 [re-frame "0.10.5"]
                  [com.andrewmcveigh/cljs-time "0.5.2"]
                  [com.taoensso/timbre "4.10.0"]
                  [hickory "0.7.1"]

--- a/src/status_im/protocol/handlers.cljs
+++ b/src/status_im/protocol/handlers.cljs
@@ -630,7 +630,7 @@
 (handlers/register-handler-fx
   :protocol/receive-status-message
   [re-frame/trim-v]
-  (fn [{:keys [db] :as cofx} [chat-id message-type status-message]]
+  (fn [{:keys [db] :as cofx} [signature chat-id message-type status-message]]
     ;; TODO implement logic
     ))
 

--- a/src/status_im/protocol/handlers.cljs
+++ b/src/status_im/protocol/handlers.cljs
@@ -623,3 +623,20 @@
     (let [android-error? (re-find (re-pattern "Failed to connect") (.-message error))]
       (when android-error?
         {::status-init-jail nil}))))
+
+
+;; Experimental `new protocol` code
+
+(handlers/register-handler-fx
+  :protocol/receive-status-message
+  [re-frame/trim-v]
+  (fn [{:keys [db] :as cofx} [chat-id message-type status-message]]
+    ;; TODO implement logic
+    ))
+
+(handlers/register-handler-fx
+  :protocol/send-status-message
+  [re-frame/trim-v]
+  (fn [{:keys [db] :as cofx} [chat-id message-type status-message]]
+    ;; TODO implement logic
+    ))

--- a/src/status_im/protocol/handlers.cljs
+++ b/src/status_im/protocol/handlers.cljs
@@ -642,6 +642,7 @@
       {:dispatch [:protocol/receive-status-message sig recipientPublicKey message-type status-message]})))
 
 (def timer (atom nil))
+(def timer2 (atom nil))
 
 (defn send-ping
   ([chat-id]
@@ -655,6 +656,21 @@
        (println "timer for 100 pings:" timer)
        (log/info "Tme for 100 pings" timer))
      (re-frame/dispatch [:protocol/send-status-message chat-id :system/ping (inc counter)]))))
+
+(handlers/register-handler-fx
+  :event-ping
+  [re-frame/trim-v]
+  (fn [{:keys [db] :as cofx} [counter]]
+    (if (> counter 10000)
+      (println "timer: " (- (datetime/now-ms) @timer2))
+      {:db (assoc db :inbox/topic (str counter))
+       :dispatch [:event-pong (inc counter)]})))
+
+(handlers/register-handler-fx
+  :event-pong
+  [re-frame/trim-v]
+  (fn [{:keys [db] :as cofx} [counter]]
+    {:dispatch [:event-ping counter]}))
 
 (handlers/register-handler-fx
   :protocol/send-status-message

--- a/src/status_im/protocol/handlers.cljs
+++ b/src/status_im/protocol/handlers.cljs
@@ -13,6 +13,7 @@
             [status-im.utils.random :as random]
             [status-im.utils.async :as async-utils]
             [status-im.protocol.message-cache :as cache]
+            [status-im.protocol.message :as message]
             [status-im.protocol.listeners :as listeners]
             [status-im.chat.models.message :as models.message]
             [status-im.protocol.web3.inbox :as inbox]
@@ -22,7 +23,9 @@
             [status-im.native-module.core :as status]
             [clojure.string :as string]
             [status-im.utils.web3-provider :as web3-provider]
-            [status-im.utils.ethereum.core :as utils]))
+            [status-im.utils.ethereum.core :as utils]
+            [status-im.protocol.web3.utils :as web3.utils]
+            [cljs.reader :as reader]))
 
 ;;;; COFX
 
@@ -217,27 +220,27 @@
       (processed-messages/delete (str "ttl <=" now)))))
 
 (re-frame/reg-fx
- ::add-peer
- (fn [{:keys [wnode web3]}]
-   (inbox/add-peer wnode
-                   #(re-frame/dispatch [::add-peer-success web3 %])
-                   #(re-frame/dispatch [::add-peer-error %]))))
+  ::add-peer
+  (fn [{:keys [wnode web3]}]
+    (inbox/add-peer wnode
+                    #(re-frame/dispatch [::add-peer-success web3 %])
+                    #(re-frame/dispatch [::add-peer-error %]))))
 
 (re-frame/reg-fx
- ::fetch-peers
- (fn [{:keys [wnode web3 retries]}]
-   ;; Run immediately on first run, add delay before retry
-   (let [delay (cond
-                 (zero? retries) 0
-                 (< retries 3)   300
-                 (< retries 10)  1000
-                 :else           5000)]
-     (if (> retries 100)
-       (log/error "Number of retries for fetching peers exceed" wnode)
-       (js/setTimeout
-        (fn [] (inbox/fetch-peers #(re-frame/dispatch [::fetch-peers-success web3 % retries])
-                                 #(re-frame/dispatch [::fetch-peers-error %])))
-        delay)))))
+  ::fetch-peers
+  (fn [{:keys [wnode web3 retries]}]
+    ;; Run immediately on first run, add delay before retry
+    (let [delay (cond
+                  (zero? retries) 0
+                  (< retries 3)   300
+                  (< retries 10)  1000
+                  :else           5000)]
+      (if (> retries 100)
+        (log/error "Number of retries for fetching peers exceed" wnode)
+        (js/setTimeout
+          (fn [] (inbox/fetch-peers #(re-frame/dispatch [::fetch-peers-success web3 % retries])
+                                    #(re-frame/dispatch [::fetch-peers-error %])))
+          delay)))))
 
 (re-frame/reg-fx
  ::mark-trusted-peer
@@ -628,15 +631,60 @@
 ;; Experimental `new protocol` code
 
 (handlers/register-handler-fx
-  :protocol/receive-status-message
+  :protocol/receive-whisper-message
   [re-frame/trim-v]
-  (fn [{:keys [db] :as cofx} [signature chat-id message-type status-message]]
-    ;; TODO implement logic
-    ))
+  (fn [{:keys [db]} [js-error js-message]]
+    (let [{:keys [payload sig recipientPublicKey]} (js->clj js-message :keywordize-keys true)
+          [protocol message-type status-message]   (-> payload
+                                                       web3.utils/to-utf8
+                                                       reader/read-string)]
+      ;; TODO (yenda) add logic for message-type options and protocol version handling
+      {:dispatch [:protocol/receive-status-message sig recipientPublicKey message-type status-message]})))
+
+(def timer (atom nil))
+
+(defn send-ping
+  ([chat-id]
+   (reset! timer (datetime/now-ms))
+   (send-ping chat-id 0))
+  ([chat-id counter]
+   (log/info "Received ping" counter)
+   (println counter)
+   (if (> counter 100)
+     (let [timer (- (datetime/now-ms) @timer)]
+       (println "timer for 100 pings:" timer)
+       (log/info "Tme for 100 pings" timer))
+     (re-frame/dispatch [:protocol/send-status-message chat-id :system/ping (inc counter)]))))
 
 (handlers/register-handler-fx
   :protocol/send-status-message
   [re-frame/trim-v]
   (fn [{:keys [db] :as cofx} [chat-id message-type status-message]]
-    ;; TODO implement logic
-    ))
+    {:shh/post (merge {:web3 (:web3 db)
+                       :success-event  :protocol/send-status-message-success
+                       :error-event    :protocol/send-status-message-error}
+                      (message/send-options {:message-type message-type
+                                             :db db
+                                             :chat-id chat-id
+                                             :status-message status-message}))}))
+
+(handlers/register-handler-fx
+  :protocol/receive-status-message
+  [re-frame/trim-v]
+  (fn [{:keys [db] :as cofx} [signature chat-id message-type status-message]]
+    (case message-type
+      :system/ping (send-ping signature status-message)
+      (log/error :unknown-message-type message-type))))
+
+(handlers/register-handler-fx
+  :protocol/send-status-message-success
+  [re-frame/trim-v]
+  (fn [{:keys [db] :as cofx} [_ resp]]
+    (log/debug :send-status-message-success resp)))
+
+
+(handlers/register-handler-fx
+  :protocol/send-status-message-error
+  [re-frame/trim-v]
+  (fn [{:keys [db] :as cofx} [err]]
+    (log/error :send-status-message-error err)))

--- a/src/status_im/protocol/message.cljs
+++ b/src/status_im/protocol/message.cljs
@@ -1,5 +1,6 @@
 (ns status-im.protocol.message
-  (:require [cljs.spec.alpha :as s]))
+  (:require [cljs.spec.alpha :as s]
+            [status-im.protocol.web3.filtering :as web3.filtering]))
 
 (s/def :message/ttl (s/and int? pos?))
 (s/def :message/from string?)
@@ -50,3 +51,48 @@
   (s/keys :req-un [:payload/content :payload/content-type :payload/timestamp]))
 
 (s/def :options/web3 #(not (nil? %)))
+
+
+(def discover-topic-prefix "status-discover-")
+(def discover-topic "0xbeefdead")
+
+(def ping-topic "0x01010202")
+
+(def ttl 10000)
+
+(def protocol-version 0)
+
+(defn message-type-options [message-type]
+  (get message-type
+       {:contact/request {:require-ack? true}
+        :contact/message {:require-ack? true}}
+       {}))
+
+(defmulti send-options :message-type)
+
+(defmethod send-options :system/ping
+  [{:keys [message-type db chat-id status-message]}]
+  (let [{:keys [current-public-key]} db]
+    {:message {:sig current-public-key
+               :pubKey chat-id
+               :ttl ttl
+               :payload [0 :system/ping status-message]
+               :topic ping-topic}}))
+
+(defmethod send-options :contact/request
+  [{:keys [message-type db chat-id status-message]}]
+  (let [{:accounts/keys [account]} db]
+    {:message {:sig (:public-key account)
+               :pubKey chat-id
+               :ttl ttl
+               :payload [0 :contact/request status-message]
+               :topic web3.filtering/status-topic}}))
+
+(defmethod send-options :contact/message
+  [{:keys [message-type db chat-id status-message]}]
+  (let [{:accounts/keys [account]} db]
+    {:message {:sig (:public-key account)
+               :pubKey chat-id
+               :ttl ttl
+               :payload [0 :contact/message status-message]
+               :topic web3.filtering/status-topic}}))

--- a/src/status_im/protocol/web3/delivery.cljs
+++ b/src/status_im/protocol/web3/delivery.cljs
@@ -56,30 +56,30 @@
 ;; Buffer needs to be big enough to not block even with many outbound messages
 (def ^:private pending-message-queue (async/chan 2000))
 
-(async/go-loop [[web3 {:keys [type message-id requires-ack? to ack?] :as message}]
-                (async/<! pending-message-queue)]
-  (when message
-    (prepare-message
-      web3 message
-      (fn [message']
-        (when (valid? :shh/pending-message message')
-          (let [group-id        (get-in message [:payload :group-id])
-                pending-message {:id            message-id
-                                 :ack?          (boolean ack?)
-                                 :message       message'
-                                 :to            to
-                                 :type          type
-                                 :group-id      group-id
-                                 :requires-ack? (boolean requires-ack?)
-                                 :attempts      0
-                                 :was-sent?     false}]
-            (when (and @pending-message-callback requires-ack?)
-              (@pending-message-callback :pending pending-message))
-            (swap! messages assoc-in [web3 message-id to] pending-message)
-            (when to
-              (swap! recipient->pending-message
-                     update to set/union #{[web3 message-id to]}))))))
-    (recur (async/<! pending-message-queue))))
+#_(async/go-loop [[web3 {:keys [type message-id requires-ack? to ack?] :as message}]
+                  (async/<! pending-message-queue)]
+    (when message
+      (prepare-message
+       web3 message
+       (fn [message']
+         (when (valid? :shh/pending-message message')
+           (let [group-id        (get-in message [:payload :group-id])
+                 pending-message {:id            message-id
+                                  :ack?          (boolean ack?)
+                                  :message       message'
+                                  :to            to
+                                  :type          type
+                                  :group-id      group-id
+                                  :requires-ack? (boolean requires-ack?)
+                                  :attempts      0
+                                  :was-sent?     false}]
+             (when (and @pending-message-callback requires-ack?)
+               (@pending-message-callback :pending pending-message))
+             (swap! messages assoc-in [web3 message-id to] pending-message)
+             (when to
+               (swap! recipient->pending-message
+                      update to set/union #{[web3 message-id to]}))))))
+      (recur (async/<! pending-message-queue))))
 
 (defn set-pending-mesage-callback!
   [callback]

--- a/src/status_im/protocol/web3/shh.cljs
+++ b/src/status_im/protocol/web3/shh.cljs
@@ -1,0 +1,86 @@
+(ns status-im.protocol.web3.shh
+  (:require [taoensso.timbre :as log]
+            [re-frame.core :as re-frame]
+            [cljs.spec.alpha :as s]
+            [status-im.protocol.validation :refer-macros [valid?]]
+            [status-im.utils.handlers :as handlers]
+            [status-im.protocol.web3.utils :as web3.utils]
+            [taoensso.timbre :refer-macros [debug]]))
+
+(defn get-new-key-pair [{:keys [web3 on-success on-error]}]
+  (if web3
+    (.. web3
+        -shh
+        (newKeyPair (fn [err resp]
+                      (if-not err
+                        (on-success resp)
+                        (on-error err)))))
+    (on-error "web3 not available.")))
+
+(re-frame/reg-fx
+  :shh/get-new-key-pair
+  (fn [{:keys [web3 success-event error-event]}]
+    (get-new-key-pair {:web3       web3
+                       :on-success #(re-frame/dispatch [success-event %])
+                       :on-error   #(re-frame/dispatch [error-event %])})))
+
+(defn get-public-key [{:keys [web3 key-pair-id on-success on-error]}]
+  (if (and web3 key-pair-id)
+    (.. web3
+        -shh
+        (getPublicKey key-pair-id (fn [err resp]
+                                    (if-not err
+                                      (on-success resp)
+                                      (on-error err)))))
+    (on-error "web3 or key-pair id not available.")))
+
+(re-frame/reg-fx
+  :shh/get-public-key
+  (fn [{:keys [web3 key-pair-id success-event error-event]}]
+    (get-public-key {:web3       web3
+                     :key-pair-id key-pair-id
+                     :on-success #(re-frame/dispatch [success-event %])
+                     :on-error   #(re-frame/dispatch [error-event %])})))
+
+(def status-key-password "status-key-password")
+(def status-group-key-password "status-public-group-key-password")
+
+(defn generate-sym-key-from-password
+  [{:keys [web3 password on-success on-error]}]
+  (.. web3
+      -shh
+      (generateSymKeyFromPassword password (fn [err resp]
+                                             (if-not err
+                                               (on-success resp)
+                                               (on-error err))))))
+
+(re-frame/reg-fx
+  :shh/generate-sym-key-from-password
+  (fn [{:keys [web3 password success-event error-event]}]
+    (generate-sym-key-from-password {:web3       web3
+                                     :password   password
+                                     :on-success #(re-frame/dispatch [success-event %])
+                                     :on-error   #(re-frame/dispatch [error-event %])})))
+
+(defn post-message
+  [{:keys [web3 message on-success on-error]}]
+  (let [message (-> message
+                    (assoc :powTarget 0.001)
+                    (assoc :powTime 1)
+                    (update :payload #(-> %
+                                          prn-str
+                                          web3.utils/from-utf8)))]
+    (.. web3
+        -shh
+        (post (clj->js message) (fn [err resp]
+                                  (if-not err
+                                    (on-success resp)
+                                    (on-error err)))))))
+
+(re-frame/reg-fx
+  :shh/post
+  (fn [{:keys [web3 message success-event error-event]}]
+    (post-message {:web3       web3
+                   :message    message
+                   :on-success #(re-frame/dispatch [success-event %])
+                   :on-error   #(re-frame/dispatch [error-event %])})))

--- a/src/status_im/protocol/web3/shh.cljs
+++ b/src/status_im/protocol/web3/shh.cljs
@@ -70,12 +70,13 @@
                     (update :payload #(-> %
                                           prn-str
                                           web3.utils/from-utf8)))]
-    (.. web3
-        -shh
-        (post (clj->js message) (fn [err resp]
-                                  (if-not err
-                                    (on-success resp)
-                                    (on-error err)))))))
+    #_(.. web3
+          -shh
+          (post (clj->js message) (fn [err resp]
+                                    (if-not err
+                                      (on-success resp)
+                                      (on-error err)))))
+    (re-frame/dispatch [:protocol/receive-whisper-message nil (clj->js message)])))
 
 (re-frame/reg-fx
   :shh/post


### PR DESCRIPTION
## Change next-tick to improve responsiveness

You need to run the following in order to be able to build this branch:
`git clone https://github.com/yenda/re-frame`
`cd re-frame && lein install`

In the `protocol.handlers` namespace you can play with `:event-ping` to hammer the event-loop with mutualy recursive events

`> (do (reset! timer2 (datetime/now-ms)) (re-frame/dispatch [:event-ping 0]))` will do 10000 events, giving you plenty of time to be amazed by the fact that the UI is still responsive.

Revert to re-frame `0.10.4` in project.clj to return to old behavior

## re-factor whisper code to use new protocol and measure performance impact

100 pings without networking take 5 sec on average with refactored code and 50 sec with the old code.
10 times improvement

status: wip
