### PR TITLE
[refs #3210] remove unnecessary reads from Realm for messages

### DIFF
--- a/src/status_im/chat/constants.cljs
+++ b/src/status_im/chat/constants.cljs
@@ -8,6 +8,7 @@
 (def max-input-height 66)
 (def input-spacing-top 16)
 
+(def console-chat-id "console")
 (def crazy-math-message-id "crazy-math-message")
 (def move-to-internal-failure-message-id "move-to-internal-failure-message")
 (def passphrase-message-id "passphraze-message")


### PR DESCRIPTION
Addresses #3210 

### Summary:

Replace realm read for messages data with app-db read as we don't need to touch realm since data is already in app-db.

### Testing notes:
App behavior should not change. Code changed related to messages:
- intro/account creation messages
- regular messages

status: ready
