### PR TITLE
bug #3232 - fixed profile image setting

### DIFF
--- a/src/status_im/ui/components/camera.cljs
+++ b/src/status_im/ui/components/camera.cljs
@@ -7,7 +7,9 @@
 (def default-camera (.-default js-dependecies/camera))
 
 (defn constants [t]
-  (-> (object/get js-dependecies/camera "constants" t)
+  (-> js-dependecies/camera
+      (object/get "constants")
+      (object/get t)
       (js->clj)
       (walk/keywordize-keys)))
 

--- a/src/status_im/utils/image_processing.cljs
+++ b/src/status_im/utils/image_processing.cljs
@@ -6,7 +6,9 @@
             [status-im.react-native.js-dependencies :as rn-dependencies]))
 
 (defn- resize [path max-width max-height on-resize on-error]
-  (let [resize-fn (object/get rn-dependencies/image-resizer "default" "createResizedImage")]
+  (let [resize-fn (-> rn-dependencies/image-resizer
+                      (object/get "default")
+                      (object/get "createResizedImage"))]
     (-> (resize-fn path max-width max-height "JPEG" 75 0 nil)
         (.then on-resize)
         (.catch on-error))))


### PR DESCRIPTION
fixes #3232

### Summary:

Fixes bug where profile image can't be set (choosing from gallery does nothing, choosing from camera crashes)

### Steps to test:
- Open Profile and try to set profile image from gallery
- Also try to set image with camera

status: ready
