### PR TITLE
[tests #3281] added/reworked transaction tests (sanity)

### DIFF
--- a/test/appium/tests/base_test_case.py
+++ b/test/appium/tests/base_test_case.py
@@ -88,7 +88,7 @@ class AbstractTestCase:
 
     @property
     def implicitly_wait(self):
-        return 10
+        return 8
 
     def update_test_info_dict(self):
         test_data.test_info[test_data.test_name] = dict()
@@ -145,7 +145,8 @@ class SauceMultipleDeviceTestCase(AbstractTestCase):
 
     @classmethod
     def setup_class(cls):
-        cls.loop = asyncio.get_event_loop()
+        cls.loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(cls.loop)
 
     def setup_method(self, method):
         self.update_test_info_dict()

--- a/test/appium/tests/test_transaction.py
+++ b/test/appium/tests/test_transaction.py
@@ -1,76 +1,99 @@
 import pytest
 import time
 from views.console_view import ConsoleView
-from tests.base_test_case import SingleDeviceTestCase
-from tests import transaction_users, api_requests, get_current_time
+from tests.base_test_case import SingleDeviceTestCase, MultipleDeviceTestCase
+from tests import transaction_users, api_requests, get_current_time, transaction_users_wallet
 from selenium.common.exceptions import TimeoutException
 
 
 @pytest.mark.all
-class TestTransactions(SingleDeviceTestCase):
+class TestTransaction(SingleDeviceTestCase):
 
-    @pytest.mark.transaction
-    @pytest.mark.parametrize("test, recipient", [('group_chat', 'A_USER'),
-                                                 ('one_to_one_chat', 'B_USER'),
-                                                 ('wrong_password', 'A_USER')],
-                             ids=['group_chat',
-                                  'one_to_one_chat',
-                                  'wrong_password'])
-    def test_transaction_send_command(self, test, recipient):
+    @pytest.mark.pr
+    def test_transaction_send_command_one_to_one_chat(self):
+        recipient = transaction_users['B_USER']
         console_view = ConsoleView(self.driver)
         console_view.create_user()
         console_view.back_button.click()
         home_view = console_view.get_home_view()
-        recipient_address = transaction_users[recipient]['address']
-        recipient_key = transaction_users[recipient]['public_key']
+        transaction_amount = home_view.get_unique_amount()
+        sender_public_key = home_view.get_public_key()
+        sender_address = home_view.public_key_to_address(sender_public_key)
+        home_view.home_button.click()
+        api_requests.get_donate(sender_address)
+        initial_balance_recipient = api_requests.get_balance(recipient['address'])
+        home_view.add_contact(recipient['public_key'])
+        chat_view = home_view.get_chat_with_user(recipient['username']).click()
+        chat_view.send_command.click()
+        chat_view.send_as_keyevent(transaction_amount)
+        send_transaction_view = chat_view.get_send_transaction_view()
+        chat_view.send_message_button.click_until_presence_of_element(send_transaction_view.sign_transaction_button)
+        send_transaction_view.sign_transaction('qwerty1234')
+        send_transaction_view.find_full_text(transaction_amount)
+        try:
+            chat_view.find_full_text('Sent', 10)
+        except TimeoutException:
+            chat_view.find_full_text('Delivered', 10)
+        api_requests.verify_balance_is_updated(initial_balance_recipient, recipient['address'])
+        send_transaction_view.back_button.click()
+        wallet_view = home_view.wallet_button.click()
+        transactions_view = wallet_view.transactions_button.click()
+        transactions_view.transactions_table.find_transaction(amount=transaction_amount)
+
+    @pytest.mark.pr
+    def test_transaction_send_command_wrong_password(self):
+        sender = transaction_users['A_USER']
+        recipient = transaction_users['B_USER']
+        console_view = ConsoleView(self.driver)
+        console_view.recover_access(sender['passphrase'], sender['password'], sender['username'])
+        home_view = console_view.get_home_view()
+        transaction_amount = '0.001'
+        home_view.add_contact(recipient['public_key'])
+        chat_view = home_view.get_chat_with_user(recipient['username']).click()
+        chat_view.send_command.click()
+        chat_view.send_as_keyevent(transaction_amount)
+        send_transaction_view = chat_view.get_send_transaction_view()
+        chat_view.send_message_button.click_until_presence_of_element(send_transaction_view.sign_transaction_button)
+        send_transaction_view.sign_transaction_button.click_until_presence_of_element(
+            send_transaction_view.enter_password_input)
+        send_transaction_view.enter_password_input.send_keys('wrong_password')
+        send_transaction_view.sign_transaction_button.click()
+        send_transaction_view.find_full_text('Wrong password', 20)
+
+    @pytest.mark.pr
+    def test_transaction_send_command_group_chat(self):
+        recipient = transaction_users['A_USER']
+        console_view = ConsoleView(self.driver)
+        console_view.create_user()
+        console_view.back_button.click()
+        home_view = console_view.get_home_view()
         transaction_amount = '0.001'
         sender_public_key = home_view.get_public_key()
         sender_address = home_view.public_key_to_address(sender_public_key)
         home_view.home_button.click()
         api_requests.get_donate(sender_address)
-        initial_balance_recipient = api_requests.get_balance(recipient_address)
-
-        home_view.add_contact(recipient_key)
-        if test == 'group_chat':
-            home_view.back_button.click(times_to_click=2)
-            home_view.create_group_chat([transaction_users[recipient]['username']],
-                                        'trg_%s' % get_current_time())
-            chat_view = home_view.get_chat_view()
-        else:
-            chat_view = home_view.get_chat_with_user(transaction_users[recipient]['username']).click()
+        initial_balance_recipient = api_requests.get_balance(recipient['address'])
+        home_view.add_contact(recipient['public_key'])
+        home_view.get_back_to_home_view()
+        home_view.create_group_chat([recipient['username']], 'trg_%s' % get_current_time())
+        chat_view = home_view.get_chat_view()
         chat_view.send_command.click()
-        if test == 'group_chat':
-            chat_view.first_recipient_button.click()
-            chat_view.send_as_keyevent(transaction_amount)
-        else:
-            chat_view.send_as_keyevent(transaction_amount)
-        chat_view.send_message_button.click()
+        chat_view.first_recipient_button.click()
+        chat_view.send_as_keyevent(transaction_amount)
         send_transaction_view = chat_view.get_send_transaction_view()
-        send_transaction_view.sign_transaction_button.wait_for_element(5)
-        send_transaction_view.sign_transaction_button.click()
-        if test == 'wrong_password':
-            send_transaction_view.enter_password_input.send_keys('invalid')
-            send_transaction_view.sign_transaction_button.click()
-            send_transaction_view.find_full_text('Wrong password', 20)
-        else:
-            send_transaction_view.enter_password_input.send_keys('qwerty1234')
-            send_transaction_view.sign_transaction_button.click()
-            send_transaction_view.got_it_button.click()
-            send_transaction_view.find_full_text(transaction_amount)
-            try:
-                chat_view.find_full_text('Sent', 10)
-            except TimeoutException:
-                chat_view.find_full_text('Delivered', 10)
-            if test == 'group_chat':
-                chat_view.find_full_text('to  ' + transaction_users[recipient]['username'], 60)
-            api_requests.verify_balance_is_updated(initial_balance_recipient, recipient_address)
+        chat_view.send_message_button.click_until_presence_of_element(send_transaction_view.sign_transaction_button)
+        send_transaction_view.sign_transaction('qwerty1234')
+        send_transaction_view.find_full_text(transaction_amount)
+        chat_view.find_full_text('to  ' + recipient['username'], 10)
+        api_requests.verify_balance_is_updated(initial_balance_recipient, recipient['address'])
 
-    @pytest.mark.transaction
+    @pytest.mark.pr
     def test_send_transaction_from_daap(self):
         console = ConsoleView(self.driver)
-        console.recover_access(transaction_users['B_USER']['passphrase'],
-                               transaction_users['B_USER']['password'],
-                               transaction_users['B_USER']['username'])
+        sender = transaction_users['B_USER']
+        console.recover_access(sender['passphrase'],
+                               sender['password'],
+                               sender['username'])
         home_view = console.get_home_view()
         address = transaction_users['B_USER']['address']
         initial_balance = api_requests.get_balance(address)
@@ -86,10 +109,203 @@ class TestTransactions(SingleDeviceTestCase):
         auction_house.send_as_keyevent(auction_name)
         auction_house.register_name_button.click()
         send_transaction_view = home_view.get_send_transaction_view()
-        send_transaction_view.sign_transaction_button.wait_for_element(20)
-        send_transaction_view.sign_transaction_button.click()
-        send_transaction_view.enter_password_input.send_keys(transaction_users['B_USER']['password'])
-        send_transaction_view.sign_transaction_button.click()
-        send_transaction_view.got_it_button.click()
+        send_transaction_view.sign_transaction(sender['password'])
         auction_house.find_full_text('You are the proud owner of the name: ' + auction_name, 120)
         api_requests.verify_balance_is_updated(initial_balance, address)
+
+    @pytest.mark.pr
+    def test_send_eth_from_wallet_sign_later(self):
+        sender = transaction_users_wallet['B_USER']
+        recipient = transaction_users_wallet['A_USER']
+        console_view = ConsoleView(self.driver)
+        console_view.recover_access(sender['passphrase'],
+                                    sender['password'],
+                                    sender['username'])
+        home_view = console_view.get_home_view()
+        initial_balance_recipient = api_requests.get_balance(recipient['address'])
+        home_view.add_contact(recipient['public_key'])
+        home_view.get_back_to_home_view()
+        wallet_view = home_view.wallet_button.click()
+        send_transaction = wallet_view.send_button.click()
+        send_transaction.amount_edit_box.click()
+        amount = send_transaction.get_unique_amount()
+        send_transaction.amount_edit_box.set_value(amount)
+        send_transaction.confirm()
+        send_transaction.chose_recipient_button.click()
+        send_transaction.enter_contact_code_button.click()
+        send_transaction.enter_recipient_address_input.set_value(recipient['address'])
+        send_transaction.done_button.click()
+        send_transaction.sign_later_button.click()
+        send_transaction.yes_button.click()
+        send_transaction.ok_button_apk.click()
+        transactions_view = wallet_view.transactions_button.click()
+        transactions_view.unsigned_tab.click()
+        transactions_view.sign_button.click()
+        send_transaction.sign_transaction_button.click()
+        send_transaction.enter_password_input.send_keys(sender['password'])
+        send_transaction.sign_transaction_button.click()
+        send_transaction.got_it_button.click()
+        api_requests.verify_balance_is_updated(initial_balance_recipient, recipient['address'])
+        transactions_view.history_tab.click()
+        transaction = transactions_view.transactions_table.find_transaction(amount=amount)
+        details_view = transaction.click()
+        details_view.get_transaction_hash()
+
+    @pytest.mark.pr
+    def test_send_stt_from_wallet_via_enter_contact_code(self):
+        sender = transaction_users_wallet['A_USER']
+        recipient = transaction_users_wallet['B_USER']
+        console_view = ConsoleView(self.driver)
+        console_view.recover_access(sender['passphrase'],
+                                    sender['password'],
+                                    sender['username'])
+        home_view = console_view.get_home_view()
+        home_view.add_contact(recipient['public_key'])
+        home_view.get_back_to_home_view()
+        wallet_view = home_view.wallet_button.click()
+        wallet_view.options_button.click_until_presence_of_element(wallet_view.manage_assets_button)
+        wallet_view.manage_assets_button.click()
+        wallet_view.stt_check_box.click()
+        wallet_view.done_button.click()
+        send_transaction = wallet_view.send_button.click()
+        send_transaction.select_asset_button.click_until_presence_of_element(send_transaction.stt_button)
+        send_transaction.stt_button.click()
+        send_transaction.amount_edit_box.click()
+        send_transaction.amount_edit_box.set_value(send_transaction.get_unique_amount())
+        send_transaction.confirm()
+        send_transaction.chose_recipient_button.click()
+        send_transaction.enter_contact_code_button.click()
+        send_transaction.enter_recipient_address_input.set_value(recipient['address'])
+        send_transaction.done_button.click()
+        send_transaction.sign_transaction_button.click()
+        send_transaction.enter_password_input.send_keys(sender['password'])
+        send_transaction.sign_transaction_button.click()
+        send_transaction.got_it_button.click()
+
+    @pytest.mark.pr
+    def test_send_eth_from_wallet_sign_now(self):
+        sender = transaction_users_wallet['A_USER']
+        console_view = ConsoleView(self.driver)
+        console_view.recover_access(sender['passphrase'],
+                                    sender['password'],
+                                    sender['username'])
+        home_view = console_view.get_home_view()
+        wallet_view = home_view.wallet_button.click()
+        send_transaction = wallet_view.send_button.click()
+        send_transaction.amount_edit_box.click()
+        send_transaction.amount_edit_box.set_value(send_transaction.get_unique_amount())
+        send_transaction.confirm()
+        send_transaction.chose_recipient_button.click()
+        send_transaction.recent_recipients_button.click()
+        recent_recipient = send_transaction.element_by_text('Jarrad')
+        send_transaction.recent_recipients_button.click_until_presence_of_element(recent_recipient)
+        recent_recipient.click()
+        send_transaction.sign_transaction_button.click()
+        send_transaction.enter_password_input.send_keys(sender['password'])
+        send_transaction.sign_transaction_button.click()
+        send_transaction.got_it_button.click()
+
+
+@pytest.mark.all
+class TestTransactions(MultipleDeviceTestCase):
+
+    @pytest.mark.pr
+    def test_send_eth_to_request_in_group_chat(self):
+        recipient = transaction_users['A_USER']
+        sender = transaction_users['B_USER']
+        self.create_drivers(2)
+        device_1, device_2 = \
+            ConsoleView(self.drivers[0]), ConsoleView(self.drivers[1])
+        for user_details in (recipient, device_1), (sender, device_2):
+            user_details[1].recover_access(passphrase=user_details[0]['passphrase'],
+                                           password=user_details[0]['password'],
+                                           username=user_details[0]['username'])
+        device_2_home = device_2.get_home_view()
+        device_1_home = device_1.get_home_view()
+        device_1_home.add_contact(sender['public_key'])
+        device_1_home.get_back_to_home_view()
+        group_chat_name = 'gtr_%s' % get_current_time()
+        device_1_home.create_group_chat([sender['username']], group_chat_name)
+        device_2_home.element_by_text(group_chat_name, 'button').click()
+        device_1_chat = device_1_home.get_chat_view()
+        device_2_chat = device_2_home.get_chat_view()
+        amount = device_1_chat.get_unique_amount()
+        device_1_chat.request_command.click()
+        device_1_chat.first_recipient_button.click()
+        device_1_chat.send_as_keyevent(amount)
+        device_1_chat.send_message_button.click()
+        initial_balance_recipient = api_requests.get_balance(recipient['address'])
+        request_button = device_2_chat.element_by_text_part('Requesting  %s ETH' % amount, 'button')
+        device_2_chat.send_eth_to_request(request_button, sender['password'])
+        api_requests.verify_balance_is_updated(initial_balance_recipient, recipient['address'])
+
+    @pytest.mark.pr
+    def test_send_eth_to_request_in_one_to_one_chat(self):
+        recipient = transaction_users['B_USER']
+        sender = transaction_users['A_USER']
+        self.create_drivers(2)
+        device_1, device_2 = \
+            ConsoleView(self.drivers[0]), ConsoleView(self.drivers[1])
+        for user_details in (recipient, device_1), (sender, device_2):
+            user_details[1].recover_access(passphrase=user_details[0]['passphrase'],
+                                           password=user_details[0]['password'],
+                                           username=user_details[0]['username'])
+        device_2_home = device_2.get_home_view()
+        device_1_home = device_1.get_home_view()
+        device_1_home.add_contact(sender['public_key'])
+        device_1_home.get_back_to_home_view()
+        one_to_one_chat_device_1 = device_1_home.element_by_text_part(sender['username'][:25], 'button')
+        one_to_one_chat_device_1.scroll_to_element()
+        one_to_one_chat_device_1.click()
+        device_1_chat = device_1_home.get_chat_view()
+        device_2_chat = device_2_home.get_chat_view()
+        amount = device_1_chat.get_unique_amount()
+        one_to_one_chat_device_2 = device_2_chat.element_by_text_part(recipient['username'][:25], 'button')
+        one_to_one_chat_device_2.click()
+        device_1_chat.request_command.click()
+        device_1_chat.send_as_keyevent(amount)
+        device_1_chat.send_message_button.click()
+        initial_balance_recipient = api_requests.get_balance(recipient['address'])
+        request_button = device_2_chat.element_by_text_part('Requesting  %s ETH' % amount, 'button')
+        device_2_chat.send_eth_to_request(request_button, sender['password'])
+        api_requests.verify_balance_is_updated(initial_balance_recipient, recipient['address'])
+        device_2_chat.back_button.click()
+        device_2_wallet = device_2_home.wallet_button.click()
+        transactions_view = device_2_wallet.transactions_button.click()
+        transactions_view.transactions_table.find_transaction(amount=amount)
+
+    @pytest.mark.pr
+    def test_send_eth_to_request_from_wallet(self):
+        recipient = transaction_users_wallet['B_USER']
+        sender = transaction_users_wallet['A_USER']
+        self.create_drivers(2)
+        device_1, device_2 = \
+            ConsoleView(self.drivers[0]), ConsoleView(self.drivers[1])
+        for user_details in (recipient, device_1), (sender, device_2):
+            user_details[1].recover_access(passphrase=user_details[0]['passphrase'],
+                                           password=user_details[0]['password'],
+                                           username=user_details[0]['username'])
+        device_2_home = device_2.get_home_view()
+        device_1_home = device_1.get_home_view()
+        device_1_home.add_contact(sender['public_key'])
+        device_1_home.get_back_to_home_view()
+        wallet_view_device_1 = device_1_home.wallet_button.click()
+        send_transaction_device_1 = wallet_view_device_1.request_button.click_until_presence_of_element(
+            wallet_view_device_1.send_transaction_request)
+        wallet_view_device_1.send_transaction_request.click()
+        send_transaction_device_1.amount_edit_box.scroll_to_element()
+        amount = device_1_home.get_unique_amount()
+        send_transaction_device_1.amount_edit_box.set_value(amount)
+        send_transaction_device_1.confirm()
+        send_transaction_device_1.chose_recipient_button.click()
+        sender_button = send_transaction_device_1.element_by_text(sender['username'])
+        send_transaction_device_1.recent_recipients_button.click_until_presence_of_element(sender_button)
+        sender_button.click()
+        wallet_view_device_1.send_request_button.click()
+        device_2_chat = device_2_home.get_chat_view()
+        one_to_one_chat_device_2 = device_2_chat.element_by_text_part(recipient['username'][:25], 'button')
+        one_to_one_chat_device_2.click()
+        initial_balance_recipient = api_requests.get_balance(recipient['address'])
+        request_button = device_2_chat.element_by_text_part('Requesting  %s ETH' % amount, 'button')
+        device_2_chat.send_eth_to_request(request_button, sender['password'])
+        api_requests.verify_balance_is_updated(initial_balance_recipient, recipient['address'])

--- a/test/appium/tests/test_wallet.py
+++ b/test/appium/tests/test_wallet.py
@@ -20,69 +20,6 @@ class TestWallet(SingleDeviceTestCase):
         send_transaction.find_full_text('Insufficient funds')
 
     @pytest.mark.wallet
-    def test_request_transaction_from_wallet(self):
-        console_view = ConsoleView(self.driver)
-        console_view.recover_access(transaction_users_wallet['A_USER']['passphrase'],
-                                    transaction_users_wallet['A_USER']['password'],
-                                    transaction_users_wallet['A_USER']['username'])
-        home_view = console_view.get_home_view()
-        recipient_key = transaction_users_wallet['B_USER']['public_key']
-        home_view.add_contact(recipient_key)
-        home_view.back_button.click(times_to_click=2)
-        wallet_view = home_view.wallet_button.click()
-        send_transaction_view = wallet_view.request_button.click()
-        send_transaction_view.amount_edit_box.scroll_to_element()
-        send_transaction_view.amount_edit_box.send_keys('0.1')
-        wallet_view.send_request_button.click()
-        user_chat = home_view.get_chat_with_user(transaction_users_wallet['B_USER']['username']).click()
-        user_chat.find_text_part('Requesting  0.1 ETH')
-
-    @pytest.mark.parametrize("test, recipient, sender", [('sign_now', 'A_USER', 'B_USER'),
-                                                         ('sign_later', 'B_USER', 'A_USER')],
-                             ids=['sign_now','sign_later'])
-    def test_send_transaction_from_wallet(self, test, recipient, sender):
-        console_view = ConsoleView(self.driver)
-        console_view.recover_access(transaction_users_wallet[sender]['passphrase'],
-                                    transaction_users_wallet[sender]['password'],
-                                    transaction_users_wallet[sender]['username'])
-        home_view = console_view.get_home_view()
-        recipient_key = transaction_users_wallet[recipient]['public_key']
-        recipient_address = transaction_users_wallet[recipient]['address']
-        initial_balance_recipient = api_requests.get_balance(recipient_address)
-        home_view.add_contact(recipient_key)
-        home_view.back_button.click(times_to_click=2)
-        wallet_view = home_view.wallet_button.click()
-        send_transaction = wallet_view.send_button.click()
-        send_transaction.amount_edit_box.click()
-        amount = send_transaction.get_unique_amount()
-        send_transaction.send_as_keyevent(amount)
-        send_transaction.confirm()
-        send_transaction.chose_recipient_button.click()
-        send_transaction.enter_contact_code_button.click()
-        send_transaction.enter_recipient_address_input.set_value(recipient_address)
-        send_transaction.done_button.click()
-        if test == 'sign_later':
-            send_transaction.sign_later_button.click()
-            send_transaction.yes_button.click()
-            send_transaction.ok_button_apk.click()
-            transactions_view = wallet_view.transactions_button.click()
-            transactions_view.unsigned_tab.click()
-            transactions_view.sign_button.click()
-        send_transaction.sign_transaction_button.click()
-        send_transaction.enter_password_input.send_keys(transaction_users_wallet[sender]['password'])
-        send_transaction.sign_transaction_button.click()
-        send_transaction.got_it_button.click()
-        api_requests.verify_balance_is_updated(initial_balance_recipient, recipient_address)
-        if test == 'sign_later':
-            transactions_view.history_tab.click()
-        else:
-            home_view.wallet_button.click()
-            transactions_view = wallet_view.transactions_button.click()
-        transaction = transactions_view.transactions_table.find_transaction(amount=amount)
-        details_view = transaction.click()
-        details_view.get_transaction_hash()
-
-    @pytest.mark.wallet
     def test_eth_and_currency_balance(self):
         errors = list()
         console = ConsoleView(self.driver)

--- a/test/appium/views/base_element.py
+++ b/test/appium/views/base_element.py
@@ -67,6 +67,7 @@ class BaseElement(object):
 
     def is_element_present(self, sec=5):
         try:
+            info('Wait for %s' % self.name)
             self.wait_for_element(sec)
             return True
         except TimeoutException:
@@ -120,3 +121,15 @@ class BaseButton(BaseElement):
         self.find_element().click()
         info('Tap on %s' % self.name)
         return self.navigate()
+
+    def click_until_presence_of_element(self, desired_element, attempts=5):
+        counter = 0
+        while not desired_element.is_element_present() and counter <= attempts:
+            try:
+                info('Tap on %s' % self.name)
+                self.find_element().click()
+                info('Wait for %s' % desired_element.name)
+                desired_element.wait_for_element(5)
+                return self.navigate()
+            except (NoSuchElementException, TimeoutException):
+                counter += 1

--- a/test/appium/views/base_view.py
+++ b/test/appium/views/base_view.py
@@ -81,6 +81,11 @@ class WalletButton(BaseButton):
         super(WalletButton, self).__init__(driver)
         self.locator = self.Locator.xpath_selector("//*[@text='Wallet']/..")
 
+    def click(self):
+        from views.wallet_view import TransactionsButton
+        self.click_until_presence_of_element(desired_element=TransactionsButton(self.driver), attempts=3)
+        return self.navigate()
+
     def navigate(self):
         from views.wallet_view import WalletView
         return WalletView(self.driver)
@@ -135,8 +140,7 @@ class BaseView(object):
         self.driver = driver
 
         self.home_button = HomeButton(self.driver)
-        self.button = WalletButton(self.driver)
-        self.wallet_button = self.button
+        self.wallet_button = WalletButton(self.driver)
         self.profile_button = ProfileButton(self.driver)
 
         self.yes_button = YesButton(self.driver)
@@ -194,7 +198,7 @@ class BaseView(object):
         element.locator = element.Locator.xpath_selector('//*[contains(@text, "' + text + '")]')
         return element.wait_for_element(wait_time)
 
-    def element_by_text(self, text, element_type='base'):
+    def element_by_text(self, text, element_type='button'):
         info("Looking for an element by text: '%s'" % text)
         element = self.element_types[element_type](self.driver)
         element.locator = element.Locator.xpath_selector('//*[@text="' + text + '"]')

--- a/test/appium/views/chat_view.py
+++ b/test/appium/views/chat_view.py
@@ -1,4 +1,4 @@
-from selenium.common.exceptions import TimeoutException
+from selenium.common.exceptions import TimeoutException, NoSuchElementException
 from tests import info
 from views.base_element import BaseButton, BaseEditBox, BaseText
 from views.base_view import BaseView
@@ -34,10 +34,20 @@ class UserNameText(BaseText):
                                         '//..//android.widget.TextView)[1]')
 
 
+class TransactionPopupText(BaseText):
+    def __init__(self, driver):
+        super(TransactionPopupText, self).__init__(driver)
+        self.locator = self.Locator.xpath_selector("//*[@text='Send transaction']")
+
+
 class SendCommand(BaseButton):
     def __init__(self, driver):
         super(SendCommand, self).__init__(driver)
         self.locator = self.Locator.xpath_selector("//*[@text='/send']")
+
+    def click(self):
+        desired_element = TransactionPopupText(self.driver)
+        self.click_until_presence_of_element(desired_element=desired_element)
 
 
 class RequestCommand(BaseButton):
@@ -147,3 +157,10 @@ class ChatView(BaseView):
 
     def get_messages_sent_by_user(self, username):
         return MessageByUsername(self.driver, username).find_elements()
+
+    def send_eth_to_request(self, request, sender_password):
+        gas_popup = self.element_by_text_part('Send transaction')
+        request.click_until_presence_of_element(gas_popup)
+        send_transaction = self.get_send_transaction_view()
+        self.send_message_button.click_until_presence_of_element(send_transaction.sign_transaction_button)
+        send_transaction.sign_transaction(sender_password)

--- a/test/appium/views/console_view.py
+++ b/test/appium/views/console_view.py
@@ -73,4 +73,4 @@ class ConsoleView(BaseView):
         recovered_user.click()
         recover_access_view.password_input.send_keys(password)
         recover_access_view.sign_in_button.click()
-        recover_access_view.find_full_text('Wallet', 30)
+        recover_access_view.find_full_text('Wallet', 60)

--- a/test/appium/views/home_view.py
+++ b/test/appium/views/home_view.py
@@ -1,6 +1,6 @@
 from tests import info
 import time
-from selenium.common.exceptions import TimeoutException
+from selenium.common.exceptions import TimeoutException, NoSuchElementException
 from views.base_element import BaseButton, BaseText
 from views.base_view import BaseView
 
@@ -58,6 +58,16 @@ class HomeView(BaseView):
 
     def get_chat_with_user(self, username):
         return ChatElement(self.driver, username)
+
+    def get_back_to_home_view(self):
+        counter = 0
+        while not self.home_button.is_element_present():
+            try:
+                if counter >= 5:
+                    return
+                self.back_button.click()
+            except (NoSuchElementException, TimeoutException):
+                counter += 1
 
     def add_contact(self, public_key):
         start_new_chat = self.plus_button.click()

--- a/test/appium/views/send_transaction_view.py
+++ b/test/appium/views/send_transaction_view.py
@@ -59,6 +59,10 @@ class ChooseRecipientButton(BaseButton):
         super(ChooseRecipientButton, self).__init__(driver)
         self.locator = self.Locator.xpath_selector("//*[@text='Specify recipient...']")
 
+    def click(self):
+        desired_element = EnterContactCodeButton(self.driver)
+        self.click_until_presence_of_element(desired_element=desired_element)
+
 
 class EnterContactCodeButton(BaseButton):
     def __init__(self, driver):
@@ -72,6 +76,24 @@ class EnterRecipientAddressInput(BaseEditBox):
         self.locator = self.Locator.xpath_selector("//*[@text='Enter recipient address']")
 
 
+class RecentRecipientsButton(BaseButton):
+    def __init__(self, driver):
+        super(RecentRecipientsButton, self).__init__(driver)
+        self.locator = self.Locator.xpath_selector("//*[@text='Recent recipients']")
+
+
+class SelectAssetButton(BaseButton):
+    def __init__(self, driver):
+        super(SelectAssetButton, self).__init__(driver)
+        self.locator = self.Locator.xpath_selector('(//android.view.ViewGroup[@content-desc="icon"])[4]/..')
+
+
+class STTButton(BaseButton):
+    def __init__(self, driver):
+        super(STTButton, self).__init__(driver)
+        self.locator = self.Locator.xpath_selector("//*[@text='Status Test Token']")
+
+
 class SendTransactionView(BaseView):
     def __init__(self, driver):
         super(SendTransactionView, self).__init__(driver)
@@ -80,6 +102,7 @@ class SendTransactionView(BaseView):
         self.enter_contact_code_button = EnterContactCodeButton(self.driver)
         self.enter_recipient_address_input = EnterRecipientAddressInput(self.driver)
         self.first_recipient_button = FirstRecipient(self.driver)
+        self.recent_recipients_button = RecentRecipientsButton(self.driver)
 
         self.amount_edit_box = AmountEditBox(self.driver)
         self.sign_transaction_button = SignTransactionButton(self.driver)
@@ -89,11 +112,11 @@ class SendTransactionView(BaseView):
         self.enter_password_input = EnterPasswordInput(self.driver)
         self.got_it_button = GotItButton(self.driver)
 
-    def try_to_sing_transaction(self):
-        for _ in range(4):
-            try:
-                self.sign_transaction_button.click()
-                self.enter_password_input.wait_for_element(5)
-                return
-            except (NoSuchElementException, TimeoutException):
-                pass
+        self.select_asset_button = SelectAssetButton(self.driver)
+        self.stt_button = STTButton(self.driver)
+
+    def sign_transaction(self, sender_password):
+        self.sign_transaction_button.click_until_presence_of_element(self.enter_password_input)
+        self.enter_password_input.send_keys(sender_password)
+        self.sign_transaction_button.click_until_presence_of_element(self.got_it_button)
+        self.got_it_button.click()

--- a/test/appium/views/wallet_view.py
+++ b/test/appium/views/wallet_view.py
@@ -68,6 +68,36 @@ class UsdTotalValueText(BaseText):
         self.locator = self.Locator.xpath_selector("//*[@text='USD']/../android.widget.TextView[1]")
 
 
+class SendTransactionRequestButton(BaseButton):
+    def __init__(self, driver):
+        super(SendTransactionRequestButton, self).__init__(driver)
+        self.locator = self.Locator.xpath_selector("//*[@text='SEND A TRANSACTION REQUEST']")
+
+
+class OptionsButton(BaseButton):
+    def __init__(self, driver):
+        super(OptionsButton, self).__init__(driver)
+        self.locator = self.Locator.xpath_selector('(//android.view.ViewGroup[@content-desc="icon"])[1]')
+
+
+class ManageAssetsButton(BaseButton):
+    def __init__(self, driver):
+        super(ManageAssetsButton, self).__init__(driver)
+        self.locator = self.Locator.xpath_selector("//*[@text='Manage Assets']")
+
+
+class STTCheckBox(BaseButton):
+    def __init__(self, driver):
+        super(STTCheckBox, self).__init__(driver)
+        self.locator = self.Locator.xpath_selector("(//*[@text='STT']//..//android.view.ViewGroup)[1]")
+
+
+class DoneButton(BaseButton):
+    def __init__(self, driver):
+        super(DoneButton, self).__init__(driver)
+        self.locator = self.Locator.xpath_selector("//*[@text='Done']")
+
+
 class WalletView(BaseView):
     def __init__(self, driver):
         super(WalletView, self).__init__(driver)
@@ -77,9 +107,15 @@ class WalletView(BaseView):
         self.transactions_button = TransactionsButton(self.driver)
         self.eth_asset = EthAssetText(self.driver)
         self.usd_total_value = UsdTotalValueText(self.driver)
+
+        self.send_transaction_request = SendTransactionRequestButton(self.driver)
         self.request_button = RequestButton(self.driver)
 
         self.send_request_button = SendRequestButton(self.driver)
+        self.options_button = OptionsButton(self.driver)
+        self.manage_assets_button = ManageAssetsButton(self.driver)
+        self.stt_check_box = STTCheckBox(self.driver)
+        self.done_button = DoneButton(self.driver)
 
     def get_usd_total_value(self):
         return float(self.usd_total_value.text)


### PR DESCRIPTION
**Added new suite of tests for transactions. The suite will run against each PR:**
- C1925 | Send transaction from Wallet screen to contact (via Recent recipients)
- C1935 | Send transaction from Wallet screen to contact (via 'Enter contact code' - STT address)
- C1926 | Request transaction from Wallet screen
- C1927 | Send Request in 1-1 chat. Other user can tap on request and send me ETH. Transaction history shows this transaction
- C1928 | Send Request in Group Chat. Other user can tap on request and send me ETH in Group Chat
- C1936 | Send transaction from 'History' -> 'Unsigned'
- C2076 | Can send ETH in 1:1 chat (by using send command). Transaction history shows this transaction
- C2077 | Can send ETH in Group chat with 2 participants (by using send command)