### PR TITLE
[ISSUE #3241] Do not use hardcoded gas price

### DIFF
--- a/src/status_im/ui/screens/db.cljs
+++ b/src/status_im/ui/screens/db.cljs
@@ -3,7 +3,6 @@
   (:require [cljs.spec.alpha :as spec]
             [status-im.constants :as constants]
             [status-im.utils.platform :as platform]
-            [status-im.utils.ethereum.core :as ethereum]
             status-im.ui.screens.accounts.db
             status-im.ui.screens.contacts.db
             status-im.ui.screens.qr-scanner.db
@@ -17,15 +16,6 @@
             status-im.ui.screens.offline-messaging-settings.db
             status-im.ui.screens.browser.db
             status-im.ui.screens.add-new.db))
-
-(defn gas-default [symbol]
-  {:gas       (ethereum/estimate-gas symbol)
-   :gas-price ethereum/default-gas-price})
-
-(def transaction-send-default
-  (let [symbol :ETH]
-    (merge (gas-default symbol)
-           {:symbol symbol})))
 
 ;; initial state of app-db
 (def app-db {:current-public-key         nil
@@ -46,7 +36,6 @@
              :tags                       []
              :sync-state                 :done
              :wallet.transactions        constants/default-wallet-transactions
-             :wallet                     {:send-transaction transaction-send-default}
              :wallet-selected-asset      {}
              :prices                     {}
              :notifications              {}

--- a/src/status_im/ui/screens/wallet/events.cljs
+++ b/src/status_im/ui/screens/wallet/events.cljs
@@ -79,6 +79,11 @@
                        #(re-frame/dispatch [success-event %])
                        #(re-frame/dispatch [error-event %]))))
 
+(reg-fx
+  :update-gas-price
+  (fn [{:keys [web3 success-event edit?]}]
+    (ethereum/gas-price web3 #(re-frame/dispatch [success-event %2 edit?]))))
+
 ;; Handlers
 
 (handlers/register-handler-fx
@@ -202,3 +207,15 @@
                          :content             (i18n/label :t/transactions-delete-content)
                          :confirm-button-text (i18n/label :t/confirm)
                          :on-accept           #(re-frame/dispatch [:wallet/discard-unsigned-transaction transaction-id])}}))
+
+(handlers/register-handler-fx
+  :wallet/update-gas-price
+  (fn [{:keys [db]} [_ edit?]]
+    {:update-gas-price {:web3          (:web3 db)
+                        :success-event :wallet/update-gas-price-success
+                        :edit?         edit?}}))
+
+(handlers/register-handler-db
+  :wallet/update-gas-price-success
+  (fn [db [_ price edit?]]
+    (assoc-in db [:wallet (if edit? :edit :send-transaction) :gas-price] price)))

--- a/src/status_im/ui/screens/wallet/navigation.cljs
+++ b/src/status_im/ui/screens/wallet/navigation.cljs
@@ -1,6 +1,5 @@
 (ns status-im.ui.screens.wallet.navigation
   (:require [re-frame.core :as re-frame]
-            [status-im.ui.screens.db :as db]
             [status-im.ui.screens.navigation :as navigation]
             [status-im.utils.ethereum.core :as ethereum]
             [status-im.utils.ethereum.tokens :as tokens]))
@@ -15,16 +14,23 @@
   (re-frame/dispatch [:update-transactions])
   db)
 
+(def transaction-send-default
+  (let [symbol :ETH]
+    {:gas    (ethereum/estimate-gas symbol)
+     :symbol symbol}))
+
+
 (defmethod navigation/preload-data! :wallet-request-transaction
   [db [event]]
   (if (= event :navigate-back)
     db
     (-> db
         (update :wallet dissoc :request-transaction)
-        (assoc-in [:wallet :send-transaction] db/transaction-send-default))))
+        (assoc-in [:wallet :send-transaction] transaction-send-default))))
 
 (defmethod navigation/preload-data! :wallet-send-transaction
   [db [event]]
+  (re-frame/dispatch [:wallet/update-gas-price])
   (if (= event :navigate-back)
     db
-    (assoc-in db [:wallet :send-transaction] db/transaction-send-default)))
+    (assoc-in db [:wallet :send-transaction] transaction-send-default)))

--- a/src/status_im/ui/screens/wallet/send/events.cljs
+++ b/src/status_im/ui/screens/wallet/send/events.cljs
@@ -291,6 +291,7 @@
 (handlers/register-handler-fx
   :wallet.send/reset-gas-default
   (fn [{:keys [db]}]
-    {:db (update-in db [:wallet :edit]
-                    merge
-                    (db/gas-default (get-in db [:wallet :send-transaction :symbol])))}))
+    {:dispatch [:wallet/update-gas-price true]
+     :db (update-in db [:wallet :edit]
+                    assoc
+                    :gas (ethereum/estimate-gas (get-in db [:wallet :send-transaction :symbol])))}))

--- a/src/status_im/utils/ethereum/core.cljs
+++ b/src/status_im/utils/ethereum/core.cljs
@@ -83,7 +83,9 @@
   (.sendTransaction (.-eth web3) (clj->js params) cb))
 
 (def default-transaction-gas (money/bignumber 21000))
-(def default-gas-price (money/->wei :gwei 21))
+
+(defn gas-price [web3 cb]
+  (.getGasPrice (.-eth web3) cb))
 
 (defn estimate-gas [symbol]
   (if (tokens/ethereum? symbol)


### PR DESCRIPTION

relates to #3241

### Summary:

Rely on geth to access current gas price

### Steps to test:
- Open Status
- Navigate wallet / send
- Verify it's not using default hardcoded value

status: ready
