### PR TITLE
Update status-go to `develop-g9cc9982a`.

### DIFF
--- a/modules/react-native-status/android/build.gradle
+++ b/modules/react-native-status/android/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     implementation 'com.github.ericwlange:AndroidJSCore:3.0.1'
     implementation 'status-im:function:0.0.1'
 
-    String statusGoVersion = 'develop-g607954bf'
+    String statusGoVersion = 'develop-g228bda9f'
     final String statusGoGroup = 'status-im', statusGoName = 'status-go'
 
     // Check if the local status-go jar exists, and compile against that if it does

--- a/modules/react-native-status/ios/RCTStatus/pom.xml
+++ b/modules/react-native-status/ios/RCTStatus/pom.xml
@@ -25,7 +25,7 @@
                         <artifactItem>
                             <groupId>status-im</groupId>
                             <artifactId>status-go-ios-simulator</artifactId>
-                            <version>develop-g607954bf</version>
+                            <version>develop-g228bda9f</version>
                             <type>zip</type>
                             <overWrite>true</overWrite>
                             <outputDirectory>./</outputDirectory>


### PR DESCRIPTION
### Summary:

```
commit 9cc9982a6a1c9c8d852a1b567bf933e2eaac548d (HEAD -> develop, upstream/develop)
[#639] Disable filter removal in `go-ethereum`. (#650)

commit 2d964bfe9f9554fdb34c6c19095f3c5e88c527e6
Remove async operations from node manager (#584)

commit 4cddc362acc2e05ad7b0538a7aaf10b7fea2b2ab
Fix all data races in jail package (#632)

commit 00df3ff9f8fcd75074bf2b403db8e7e874617146
[#618] Jail.Call to return valid JSON string based results (#619)

commit d0ef64a177aa609314b0680faf38bd5c80958c62
Maintain local copy of the nonce for each used address (#538)

commit ca719af71c2ecdc793673820a039b46d96e1ec7d
Sync blockchain before running e2e tests on public testnet #568 (#612)

commit ca5a8f666982a516c32740b1635c9fceff2c4fc1
Enable ethereum metrics collection (#616)

```
status: ready