### PR TITLE
bug #3300 - updated leftover sub after rebase

### DIFF
--- a/src/status_im/ui/screens/wallet/components/views.cljs
+++ b/src/status_im/ui/screens/wallet/components/views.cljs
@@ -129,7 +129,7 @@
       (ethereum/normalized-address (:address contact))]]]])
 
 (views/defview recent-recipients []
-  (views/letsubs [contacts [:contacts-filtered :all-added-people-contacts]]
+  (views/letsubs [contacts [:all-added-people-contacts]]
     [components/simple-screen
      [components/toolbar (i18n/label :t/recipient)]
      [react/view styles/recent-recipients


### PR DESCRIPTION
fixes #3300 

### Summary:

Updates the leftover removed sub after rebase,

### Steps to test:
- Open Status
- Wallet > Send > Choose recipient


status: ready
