### PR TITLE
Fetch short preview during sending

### DIFF
--- a/src/status_im/ui/screens/home/views/inner_item.cljs
+++ b/src/status_im/ui/screens/home/views/inner_item.cljs
@@ -16,42 +16,30 @@
             [taoensso.timbre :as log]
             [status-im.ui.components.chat-icon.screen :as chat-icon.screen]))
 
-(defn message-content-text [{:keys [content] :as message}]
-  (reagent/create-class
-    {:display-name "message-content-text"
-     :component-will-mount
-     #(when (and (or (:command content)
-                     (:content-command content))
-                 (not (:short-preview content)))
-        (re-frame/dispatch [:request-command-message-data message
-                            {:data-type   :short-preview
-                             :cache-data? true}]))
-     :reagent-render
-     (fn [{:keys [content] :as message}]
-       [react/view styles/last-message-container
-        (cond
+(defn message-content-text [{:keys [content] :as message}] 
+  [react/view styles/last-message-container
+   (cond
 
-          (not message)
-          [react/text {:style styles/last-message-text}
-           (i18n/label :t/no-messages)]
+     (not message)
+     [react/text {:style styles/last-message-text}
+      (i18n/label :t/no-messages)]
 
-          (str/blank? content)
-          [react/text {:style styles/last-message-text}
-           ""]
+     (str/blank? content)
+     [react/text {:style styles/last-message-text}
+      ""]
 
-          (:content content)
-          [react/text {:style           styles/last-message-text
-                       :number-of-lines 1}
-           (:content content)]
+     (:content content)
+     [react/text {:style           styles/last-message-text
+                  :number-of-lines 1}
+      (:content content)]
 
-          (and (:command content)
-               (-> content :short-preview :markup))
-          (commands-utils/generate-hiccup (-> content :short-preview :markup))
+     (and (:command content) (-> content :short-preview :markup))
+     (commands-utils/generate-hiccup (-> content :short-preview :markup))
 
-          :else
-          [react/text {:style           styles/last-message-text
-                       :number-of-lines 1}
-           content])])}))
+     :else
+     [react/text {:style           styles/last-message-text
+                  :number-of-lines 1}
+      content])])
 
 (defview message-status [{:keys [chat-id contacts]}
                          {:keys [message-id user-statuses outgoing] :as msg}]


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes #3267 

### Summary:

[comment]: # (Summarise the problem and how the pull request solves it)
Previously, short preview for send command messages was only fetched when last message was mounted in the chat-list (now home) screen, with the logic that it's unnecessary to always fetch short preview because sometimes the message will never be displayed as an last-message in the chat on chat-list (home) screen.
With various perf hacks to improve rendering (like having home tab always mounted, etc.), this approach is not reliable, so simple always requesting short preview during the send process works better.

### Testing notes (optional):
Test the scenario outlined in issue + make sure that `/send` and `/request` commands are still working as intended.

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready
