### PR TITLE
[Tests #3284] added sanity profile and browsing tests

### DIFF
--- a/test/appium/tests/test_dapps_and_browsing.py
+++ b/test/appium/tests/test_dapps_and_browsing.py
@@ -1,0 +1,24 @@
+import pytest
+from views.console_view import ConsoleView
+from tests.base_test_case import SingleDeviceTestCase
+
+
+@pytest.mark.all
+class TestDappsAnsBrowsing(SingleDeviceTestCase):
+
+    @pytest.mark.pr
+    def test_browse_link_entering_url_in_dapp_view(self):
+        console = ConsoleView(self.driver)
+        console.create_user()
+        console.back_button.click()
+        home_view = console.get_home_view()
+        start_new_chat = home_view.plus_button.click()
+        start_new_chat.open_d_app_button.click()
+        start_new_chat.enter_url_editbox.send_keys('status.im')
+        start_new_chat.confirm()
+        browsing_view = home_view.get_base_web_view()
+        browsing_view.wait_for_d_aap_to_load()
+        browsing_view.find_full_text('Status, the Ethereum discovery tool.')
+        browsing_view.back_to_home_button.click()
+
+        assert home_view.first_chat_element_title.text == 'Status | The Mobile Ethereum Client'

--- a/test/appium/tests/test_profile.py
+++ b/test/appium/tests/test_profile.py
@@ -1,0 +1,46 @@
+import pytest
+import time
+from tests.base_test_case import SingleDeviceTestCase
+from views.console_view import ConsoleView
+from tests import basic_user
+
+
+@pytest.mark.all
+class TestProfileView(SingleDeviceTestCase):
+
+    @pytest.mark.pr
+    def test_qr_code_and_its_value(self):
+        console_view = ConsoleView(self.driver)
+        console_view.create_user()
+        console_view.back_button.click()
+        profile_view = console_view.profile_button.click()
+        profile_view.share_my_contact_key_button.click()
+        key_value = profile_view.public_key_text.text
+        time.sleep(5)
+        key_value_from_qr = profile_view.get_text_from_qr()
+        assert key_value == key_value_from_qr
+
+    @pytest.mark.pr
+    def test_contact_profile_view(self):
+        console_view = ConsoleView(self.driver)
+        console_view.create_user()
+        console_view.back_button.click()
+        home_view = console_view.get_home_view()
+        home_view.add_contact(basic_user['public_key'])
+        chat_view = home_view.get_chat_view()
+        chat_view.user_profile_icon_top_right.click()
+        chat_view.user_profile_details.click()
+        chat_view.find_full_text(basic_user['username'])
+
+    @pytest.mark.pr
+    def test_network_switch(self):
+        console = ConsoleView(self.driver)
+        console.create_user()
+        console.back_button.click()
+        profile_view = console.profile_button.click()
+        sign_in_view = profile_view.switch_network('Rinkeby with upstream RPC')
+        sign_in_view.first_account_button.click()
+        sign_in_view.password_input.send_keys('qwerty1234')
+        sign_in_view.sign_in_button.click()
+        sign_in_view.profile_button.click()
+        sign_in_view.find_full_text('RINKEBY WITH UPSTREAM RPC', 20)

--- a/test/appium/views/base_view.py
+++ b/test/appium/views/base_view.py
@@ -222,6 +222,10 @@ class BaseView(object):
         from views.send_transaction_view import SendTransactionView
         return SendTransactionView(self.driver)
 
+    def get_base_web_view(self):
+        from views.web_views.base_web_view import BaseWebView
+        return BaseWebView(self.driver)
+
     def get_unique_amount(self):
         return '0.0%s' % datetime.now().strftime('%-m%-d%-H%-M%-S').strip('0')
 

--- a/test/appium/views/chat_view.py
+++ b/test/appium/views/chat_view.py
@@ -98,6 +98,18 @@ class MoreUsersButton(BaseButton):
         self.locator = self.Locator.xpath_selector("//android.widget.TextView[contains(@text, 'MORE')]")
 
 
+class UserProfileIconTopRight(BaseButton):
+    def __init__(self, driver):
+        super(UserProfileIconTopRight, self).__init__(driver)
+        self.locator = self.Locator.accessibility_id('chat-icon')
+
+
+class UserProfileDetails(BaseButton):
+    def __init__(self, driver):
+        super(UserProfileDetails, self).__init__(driver)
+        self.locator = self.Locator.xpath_selector("//*[@text='Profile']")
+
+
 class ChatView(BaseView):
     def __init__(self, driver):
         super(ChatView, self).__init__(driver)
@@ -119,6 +131,10 @@ class ChatView(BaseView):
         self.remove_button = RemoveButton(self.driver)
 
         self.first_recipient_button = FirstRecipient(self.driver)
+
+        self.user_profile_icon_top_right = UserProfileIconTopRight(self.driver)
+        self.user_profile_details = UserProfileDetails(self.driver)
+
 
     def wait_for_syncing_complete(self):
         info('Waiting for syncing complete:')

--- a/test/appium/views/home_view.py
+++ b/test/appium/views/home_view.py
@@ -1,7 +1,7 @@
 from tests import info
 import time
 from selenium.common.exceptions import TimeoutException
-from views.base_element import BaseButton
+from views.base_element import BaseButton, BaseText
 from views.base_view import BaseView
 
 
@@ -12,8 +12,8 @@ class PlusButton(BaseButton):
             "//android.view.ViewGroup/android.widget.TextView[@text='+']")
 
     def navigate(self):
-        from views.start_new_chat_view import StarNewChatView
-        return StarNewChatView(self.driver)
+        from views.start_new_chat_view import StartNewChatView
+        return StartNewChatView(self.driver)
 
 
 class ConsoleButton(BaseButton):
@@ -33,12 +33,19 @@ class ChatElement(BaseButton):
         return ChatView(self.driver)
 
 
+class FirstChatElementTitle(BaseText):
+    def __init__(self, driver):
+        super(FirstChatElementTitle, self).__init__(driver)
+        self.locator = self.Locator.xpath_selector('(//android.widget.ScrollView//android.widget.TextView)[1]')
+
+
 class HomeView(BaseView):
     def __init__(self, driver):
         super(HomeView, self).__init__(driver)
 
         self.plus_button = PlusButton(self.driver)
         self.console_button = ConsoleButton(self.driver)
+        self.first_chat_element_title = FirstChatElementTitle(self.driver)
 
     def wait_for_syncing_complete(self):
         info('Waiting for syncing complete:')

--- a/test/appium/views/profile_view.py
+++ b/test/appium/views/profile_view.py
@@ -1,4 +1,5 @@
 import time
+import pytest
 from tests import info
 from views.base_element import BaseText, BaseButton, BaseEditBox
 from views.base_view import BaseView
@@ -8,7 +9,7 @@ class PublicKeyText(BaseText):
 
     def __init__(self, driver):
         super(PublicKeyText, self).__init__(driver)
-        self.locator = self.Locator.accessibility_id('profile-public-key')
+        self.locator = self.Locator.xpath_selector('//*[contains(@text, "0x04")]')
 
     @property
     def text(self):
@@ -54,7 +55,7 @@ class NetworkSettingsButton(BaseButton):
 
     def __init__(self, driver):
         super(NetworkSettingsButton, self).__init__(driver)
-        self.locator = self.Locator.xpath_selector('//*[@text="Network settings"]')
+        self.locator = self.Locator.xpath_selector('//*[@text="Network"]')
 
     class NetworkButton(BaseButton):
         def __init__(self, driver, network):

--- a/test/appium/views/start_new_chat_view.py
+++ b/test/appium/views/start_new_chat_view.py
@@ -38,9 +38,15 @@ class OpenButton(BaseButton):
             "//android.widget.TextView[@text='Open']")
 
 
-class StarNewChatView(ContactsView):
+class EnterUrlEditbox(BaseEditBox):
     def __init__(self, driver):
-        super(StarNewChatView, self).__init__(driver)
+        super(EnterUrlEditbox, self).__init__(driver)
+        self.locator = self.Locator.xpath_selector("//android.widget.EditText")
+
+
+class StartNewChatView(ContactsView):
+    def __init__(self, driver):
+        super(StartNewChatView, self).__init__(driver)
 
         self.add_new_contact = AddNewContactButton(self.driver)
         self.new_group_chat_button = NewGroupChatButton(self.driver)
@@ -49,3 +55,4 @@ class StarNewChatView(ContactsView):
         self.open_button = OpenButton(self.driver)
 
         self.name_edit_box = NameEditBox(self.driver)
+        self.enter_url_editbox = EnterUrlEditbox(self.driver)

--- a/test/appium/views/web_views/base_web_view.py
+++ b/test/appium/views/web_views/base_web_view.py
@@ -9,6 +9,19 @@ class ProgressBarIcon(BaseElement):
         self.locator = self.Locator.xpath_selector("//android.widget.ProgressBar")
 
 
+class WebLinkEditBox(BaseEditBox):
+
+    def __init__(self, driver):
+        super(WebLinkEditBox, self).__init__(driver)
+        self.locator = self.Locator.xpath_selector("//android.widget.EditText")
+
+
+class BackToHomeButton(BaseButton):
+    def __init__(self, driver):
+        super(BackToHomeButton, self).__init__(driver)
+        self.locator = self.Locator.xpath_selector('(//android.view.ViewGroup[@content-desc="icon"])[1]')
+
+
 class BaseWebView(BaseView):
 
     def __init__(self, driver):
@@ -16,6 +29,9 @@ class BaseWebView(BaseView):
         self.driver = driver
 
         self.progress_bar_icon = ProgressBarIcon(self.driver)
+
+        self.web_link_edit_box = WebLinkEditBox(self.driver)
+        self.back_to_home_button = BackToHomeButton(self.driver)
 
     def wait_for_d_aap_to_load(self, wait_time=35):
         counter = 0


### PR DESCRIPTION
### Summary: 
Added three tests requested in #3284:
`C1937 | Profile view of contact from list of contacts (like Jarrad profile)`
`C2088 | Can switch network to Rinkeby with upstream. Sign in. Rinkeby with upstream is shown in`
`C2089 | Can open QR code, can share public key`

Please note that there is one more test added from #3285:
`C2082 | Browse link for Open DApp - can open, when closed - new Chat in Home`

