### PR TITLE
Use re-frame fork to fix UI freezes

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
                  [org.clojure/clojurescript "1.9.946"]
                  [org.clojure/core.async "0.4.474"]
                  [reagent "0.7.0" :exclusions [cljsjs/react cljsjs/react-dom cljsjs/react-dom-server cljsjs/create-react-class]]
-                 [re-frame "0.10.2"]
+                 [status-im/re-frame "0.10.2"]
                  [com.andrewmcveigh/cljs-time "0.5.2"]
                  [com.taoensso/timbre "4.10.0"]
                  [hickory "0.7.1"]

--- a/src/status_im/core.cljs
+++ b/src/status_im/core.cljs
@@ -1,7 +1,6 @@
 (ns status-im.core
   (:require [status-im.utils.error-handler :as error-handler]
             [status-im.ui.components.react :as react]
-            [re-frame.core :as re-frame]
             [reagent.core :as reagent]
             [status-im.native-module.core :as status]
             [taoensso.timbre :as log]
@@ -15,5 +14,4 @@
   (log/set-level! config/log-level)
   (error-handler/register-exception-handler!)
   (status/init-jail)
-  (.registerComponent react/app-registry "StatusIm" #(reagent/reactify-component app-root))
-  (re-frame/dispatch-sync [:initialize-app]))
+  (.registerComponent react/app-registry "StatusIm" #(reagent/reactify-component app-root)))

--- a/src/status_im/native_module/impl/module.cljs
+++ b/src/status_im/native_module/impl/module.cljs
@@ -2,7 +2,7 @@
   (:require-macros
    [cljs.core.async.macros :refer [go-loop go]])
   (:require [status-im.ui.components.react :as r]
-            [re-frame.core :refer [dispatch]]
+            [re-frame.core :refer [dispatch] :as re-frame]
             [taoensso.timbre :as log]
             [cljs.core.async :as async :refer [<!]]
             [status-im.utils.js-resources :as js-res]
@@ -63,7 +63,8 @@
                                  "JavaScriptCore"
                                  "OttoVM")
                                " jail initialized")]
-          (.initJail status init-js' #(log/debug log-message)))))))
+          (.initJail status init-js' #(do (re-frame/dispatch [:initialize-app])
+                                          (log/debug log-message))))))))
 
 (defonce listener-initialized (atom false))
 

--- a/src/status_im/ui/screens/accounts/login/events.cljs
+++ b/src/status_im/ui/screens/accounts/login/events.cljs
@@ -33,10 +33,10 @@
       (utils/set-timeout
         (fn []
           (data-store/change-account address new-account?
-                                     #(dispatch [:change-account-handler % address new-account?])))
+                                     #(dispatch [:change-account-handler % address])))
         300)
       (data-store/change-account address new-account?
-                                 #(dispatch [:change-account-handler % address new-account?])))))
+                                 #(dispatch [:change-account-handler % address])))))
 
 ;;;; Handlers
 


### PR DESCRIPTION
Addresses https://github.com/status-im/status-react/issues/3318
Related to https://github.com/status-im/status-react/pull/3270

### Summary

This is experimental branch trying to fix app crash #3318 

### Description

* use re-frame fork with `js/setTimeout` as `next-tick` https://github.com/status-im/re-frame/tree/0.10.2
* Event `:initialize-app` is only dispatched after jail has been initialized.

### Notes

After this will be tested by QA, we need to upload custom jar to artifactory/clojars and change `dmitryn/re-frame-fork` dependency (currently uploaded to clojars under my personal account)

status: ready