### PR TITLE
Fix latest nightly -> nigthly migration

### DIFF
--- a/src/status_im/data_store/realm/schemas/account/core.cljs
+++ b/src/status_im/data_store/realm/schemas/account/core.cljs
@@ -19,7 +19,8 @@
             [status-im.data-store.realm.schemas.account.v18.core :as v18]
             [status-im.data-store.realm.schemas.account.v19.core :as v19]
             [status-im.data-store.realm.schemas.account.v20.core :as v20]
-            [status-im.data-store.realm.schemas.account.v21.core :as v21]))
+            [status-im.data-store.realm.schemas.account.v21.core :as v21]
+            [status-im.data-store.realm.schemas.account.v22.core :as v22]))
 
 
 ;; TODO(oskarth): Add failing test if directory vXX exists but isn't in schemas.
@@ -87,5 +88,8 @@
                :migration     v20/migration}
               {:schema        v21/schema
                :schemaVersion 21
-               :migration     v21/migration}])
+               :migration     v21/migration}
+              {:schema        v22/schema
+               :schemaVersion 22
+               :migration     v22/migration}])
 

--- a/src/status_im/data_store/realm/schemas/account/v21/core.cljs
+++ b/src/status_im/data_store/realm/schemas/account/v21/core.cljs
@@ -1,5 +1,5 @@
 (ns status-im.data-store.realm.schemas.account.v21.core
-  (:require [status-im.data-store.realm.schemas.account.v21.chat :as chat]
+  (:require [status-im.data-store.realm.schemas.account.v19.chat :as chat]
             [status-im.data-store.realm.schemas.account.v1.chat-contact :as chat-contact]
             [status-im.data-store.realm.schemas.account.v19.contact :as contact]
             [status-im.data-store.realm.schemas.account.v20.discover :as discover]

--- a/src/status_im/data_store/realm/schemas/account/v22/chat.cljs
+++ b/src/status_im/data_store/realm/schemas/account/v22/chat.cljs
@@ -1,4 +1,4 @@
-(ns status-im.data-store.realm.schemas.account.v19.chat
+(ns status-im.data-store.realm.schemas.account.v22.chat
   (:require [status-im.ui.components.styles :refer [default-chat-color]]))
 
 (def schema {:name       :chat
@@ -25,8 +25,6 @@
                                              :optional true}
                           :updated-at       {:type     :int
                                              :optional true}
-                          :message-overhead {:type    :int
-                                             :default 0}
                           :public-key       {:type     :string
                                              :optional true}
                           :private-key      {:type     :string

--- a/src/status_im/data_store/realm/schemas/account/v22/core.cljs
+++ b/src/status_im/data_store/realm/schemas/account/v22/core.cljs
@@ -1,0 +1,34 @@
+(ns status-im.data-store.realm.schemas.account.v22.core
+  (:require [status-im.data-store.realm.schemas.account.v22.chat :as chat]
+            [status-im.data-store.realm.schemas.account.v1.chat-contact :as chat-contact]
+            [status-im.data-store.realm.schemas.account.v19.contact :as contact]
+            [status-im.data-store.realm.schemas.account.v20.discover :as discover]
+            [status-im.data-store.realm.schemas.account.v19.message :as message]
+            [status-im.data-store.realm.schemas.account.v12.pending-message :as pending-message]
+            [status-im.data-store.realm.schemas.account.v1.processed-message :as processed-message]
+            [status-im.data-store.realm.schemas.account.v19.request :as request]
+            [status-im.data-store.realm.schemas.account.v19.user-status :as user-status]
+            [status-im.data-store.realm.schemas.account.v5.contact-group :as contact-group]
+            [status-im.data-store.realm.schemas.account.v5.group-contact :as group-contact]
+            [status-im.data-store.realm.schemas.account.v8.local-storage :as local-storage]
+            [status-im.data-store.realm.schemas.account.v21.browser :as browser]
+            [taoensso.timbre :as log]
+            [cljs.reader :as reader]
+            [clojure.string :as string]))
+
+(def schema [chat/schema
+             chat-contact/schema
+             contact/schema
+             discover/schema
+             message/schema
+             pending-message/schema
+             processed-message/schema
+             request/schema
+             user-status/schema
+             contact-group/schema
+             group-contact/schema
+             local-storage/schema
+             browser/schema])
+
+(defn migration [old-realm new-realm]
+  (log/debug "migrating v22 account database: " old-realm new-realm))


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes #3337 

### Summary:

This commit just reverts previous migrations clumped into `v21` and established new `v22` migration with the identical functionality, as it was decided that we will always support commit -> commit migrations (technically nightly -> nightly, but it's not really feasible to rely on that) to better support dogfooding.

### Testing notes (optional):
Test the scenario described in the ticket

status: ready
