### PR TITLE
[WIP] Dont send seen for public group chats

### DIFF
--- a/src/status_im/chat/views/message/message.cljs
+++ b/src/status_im/chat/views/message/message.cljs
@@ -248,8 +248,7 @@
     [react/view (style/group-message-view message)
      content
      (when last-outgoing?
-       (if (or (= (keyword message-type) :group-user-message)
-               group-chat)
+       (if (= message-type :group-user-message)
          [group-message-delivery-status message]
          [message-delivery-status message]))]]])
 
@@ -289,13 +288,15 @@
                   children)])}))
     (into [react/view] children)))
 
-(defn chat-message [{:keys [outgoing message-id chat-id from current-public-key] :as message}]
+(defn chat-message [{:keys [outgoing message-id message-type chat-id from current-public-key] :as message}]
   (reagent/create-class
     {:display-name
      "chat-message"
      :component-did-mount
      ;; send `:seen` signal when we have signed-in user, message not from us and we didn't sent it already
+     ;; + it's not public group message
      #(when (and current-public-key message-id chat-id (not outgoing)
+                 (not= :public-group-message message-type)
                  (not (models.message/message-seen-by? message current-public-key)))
         (re-frame/dispatch [:send-seen! {:chat-id    chat-id
                                          :from       from

--- a/src/status_im/chat/views/message/message.cljs
+++ b/src/status_im/chat/views/message/message.cljs
@@ -296,7 +296,7 @@
      ;; send `:seen` signal when we have signed-in user, message not from us and we didn't sent it already
      ;; + it's not public group message
      #(when (and current-public-key message-id chat-id (not outgoing)
-                 (not= :public-group-message message-type)
+                 (#{:user-message :group-user-message} message-type)
                  (not (models.message/message-seen-by? message current-public-key)))
         (re-frame/dispatch [:send-seen! {:chat-id    chat-id
                                          :from       from


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes #3336, fixes #3785 annoying regression where any sent message in public chat is immediately displayed as 'seen by everyone'

### Summary:

[comment]: # (Summarise the problem and how the pull request solves it)
This PR fixes recent bug where `group-message-status` is incorrectly used to display delivery status for  public group messages, instead simple message status logic should be used (so the states are just `sending` -> `sent`, as there is no way to tell the message was delivered/seen for unknown contacts).
Another important thing is that `seen` acknowledgments are not send for public group messages, as it makes no sense, so saving a lot of traffic + processing.

### Testing notes (optional):
Test the perf problem scenario in ticket + test that all messages delivery statuses are still working correctly for 1-1, private group and public group chats. No upgrade testing necessary

status: WIP