### PR TITLE
[FIX #3123] ui: fix network field overflow on long network names in profile

### DIFF
--- a/src/status_im/ui/screens/profile/styles.cljs
+++ b/src/status_im/ui/screens/profile/styles.cljs
@@ -121,12 +121,16 @@
 
 (defstyle settings-item-text
   {:flex      1
+   :flex-wrap :nowrap
    :font-size 15
    :ios       {:letter-spacing -0.2}
    :android   {:color colors/black}})
 
 (def settings-item-value
-  {:padding-right 10
+  {:flex          2
+   :flex-wrap     :nowrap
+   :text-align    :right
+   :padding-right 10
    :font-size     15
    :color         colors/gray})
 

--- a/src/status_im/ui/screens/profile/views.cljs
+++ b/src/status_im/ui/screens/profile/views.cljs
@@ -215,8 +215,11 @@
    [react/view styles/settings-item
     [react/text {:style styles/settings-item-text}
      (i18n/label label-kw)]
-    [react/text {:style      styles/settings-item-value
-                 :uppercase? component.styles/uppercase?} value]
+    (when-not (string/blank? value)
+      [react/text {:style           styles/settings-item-value
+                   :number-of-lines 1
+                   :uppercase?      component.styles/uppercase?}
+       value])
     (when active?
       [vector-icons/icon :icons/forward {:color colors/gray}])]])
 


### PR DESCRIPTION
fixes #3123 

### Summary

Introduced proportions between field title and value and ellipsis endings on text overflow.

Note: In case of longer network names, this bug may be probably reproducible even with latest ios/android devices.

status: ready
