### PR TITLE
[ISSUE #3320] Fixed incorrect label

### DIFF
--- a/src/status_im/ui/screens/wallet/components/views.cljs
+++ b/src/status_im/ui/screens/wallet/components/views.cljs
@@ -167,7 +167,7 @@
                                    (when-not contact-only?
                                      [{:label  (i18n/label :t/scan-qr)
                                        :action request-camera-permissions}
-                                      {:label  (i18n/label :t/enter-contact-code)
+                                      {:label  (i18n/label :t/recipient-code)
                                        :action #(re-frame/dispatch [:navigate-to :contact-code])}]))}))
 
 (defn recipient-selector [{:keys [name address disabled? contact-only?]}]


### PR DESCRIPTION
fixes #3320

### Summary:

Fixed incorrect label in wallet / send

### Steps to test:
- Open Status
- Navigate wallet / send
- Validate the proper label is used


status: ready 
