### PR TITLE
Remove library duplication

### DIFF
--- a/src/status_im/protocol/core.cljs
+++ b/src/status_im/protocol/core.cljs
@@ -6,7 +6,6 @@
             [status-im.protocol.web3.inbox :as inbox]
             [taoensso.timbre :refer-macros [debug] :as log]
             [status-im.protocol.validation :refer-macros [valid?]]
-            [status-im.protocol.web3.utils :as u]
             [status-im.protocol.web3.keys :as shh-keys]
             [status-im.protocol.chat :as chat]
             [status-im.protocol.group :as group]


### PR DESCRIPTION
I am not familiar with Clojure but the library [status-im.protocol.web3.utils :as u] is defined two times in the same file and believe that it is just a duplication.
I would suggest defining the libraries in alphabetical order, in order to avoid such kind of duplications in the future.