### PR TITLE
Simplify input handling

### DIFF
--- a/src/status_im/chat/events/requests.cljs
+++ b/src/status_im/chat/events/requests.cljs
@@ -12,7 +12,7 @@
 
 ;; Effects
 (re-frame/reg-fx
- :chat-requests/mark-as-answered
+ ::mark-as-answered
  (fn [{:keys [chat-id message-id]}]
    (requests-store/mark-as-answered chat-id message-id)))
 
@@ -21,15 +21,15 @@
   (fn [request]
     (requests-store/save request)))
 
-;; Handlers
+;; Functions
 
-(handlers/register-handler-fx
- :request-answered
- [re-frame/trim-v]
- (fn [{:keys [db]} [chat-id message-id]]
-   {:db (update-in db [:chats chat-id :requests] dissoc message-id)
-    :chat-requests/mark-as-answered {:chat-id  chat-id
-                                     :message-id message-id}}))
+(defn request-answered
+  "Takes fx, chat-id and message, updates fx with necessary data for markin request as answered"
+  [fx chat-id message-id]
+  (-> fx
+      (update-in [:db :chats chat-id :requests] dissoc message-id)
+      (assoc ::mark-as-answered {:chat-id    chat-id
+                                 :message-id message-id})))
 
 (defn add-request
   "Takes fx, chat-id and message, updates fx with necessary data for adding new request"

--- a/src/status_im/chat/events/send_message.cljs
+++ b/src/status_im/chat/events/send_message.cljs
@@ -37,7 +37,7 @@
   :chat-send-message/send-command
   message-model/send-interceptors
   (fn [cofx [add-to-chat-id params]]
-    (message-model/send-command cofx nil add-to-chat-id params)))
+    (message-model/send-command cofx add-to-chat-id params)))
 
 (handlers/register-handler-fx
   :chat-send-message/from-jail

--- a/src/status_im/chat/views/message/message.cljs
+++ b/src/status_im/chat/views/message/message.cljs
@@ -65,11 +65,7 @@
 
 (defview message-content-command
   [{:keys [content params] :as message}]
-  (letsubs [command [:get-command (:content-command-ref content)]]
-    {:component-will-mount #(when-not (:preview content)
-                              (re-frame/dispatch [:request-command-message-data
-                                                  message {:data-type   :preview
-                                                           :cache-data? true}]))}
+  (letsubs [command [:get-command (:content-command-ref content)]] 
     (let [preview (:preview content)
           {:keys [type color] icon-path :icon} command]
       [react/view style/content-command-view

--- a/src/status_im/chat/views/message/request_message.cljs
+++ b/src/status_im/chat/views/message/request_message.cljs
@@ -77,11 +77,7 @@
   [{:keys [message-id content] :as message}]
   (letsubs [command             [:get-command (:content-command-ref content)]
             answered?           [:is-request-answered? message-id]
-            status-initialized? [:get :status-module-initialized?]]
-    {:component-will-mount #(when-not (:preview content)
-                              (dispatch [:request-command-message-data
-                                         message {:data-type   :preview
-                                                  :cache-data? true}]))}
+            status-initialized? [:get :status-module-initialized?]] 
     (let [{:keys        [prefill prefill-bot-db prefillBotDb params preview]
            text-content :text} content 
           command          (if (and params command)


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

Follow-up on #3309, erasing tech debt.

### Summary:

After #3309 was merged, we can rely on command message previews/short previews always being generated before message is actually written into app-db and realm, both when sending and receiving.
So it makes no sense to support `:cache-data?` option when requesting jail data for message and also requesting previews/short-previews when message is mounted in view (unreliable anyway with lazy rendered `FlatList` + pre-rendering perf hacks).
This PR cleans up the unused code associated with that option + removes complicated and redundant `request-command-data` function/event in the `chat.events.input` namespace.

Additionally, it cleans the `model/message` namespace, improving some hard to read code, always making all coeffects pure and never generating random-id/timestamp in event handlers, removing some needless duplication + fixing the request bug where command request marking as answered didn't work as it should (change was propagated to realm only, so the request was answered only once you restarted the app and not immediately after sending the response).

### Testing notes (optional):
Test that commands in chats are still working correctly and previews/short-previews are generated without problem in all situations

status: ready
