### PR TITLE
Migrate figwheel conf from project.clj to figwheel ns

### DIFF
--- a/env/dev/figwheel.clj
+++ b/env/dev/figwheel.clj
@@ -1,0 +1,21 @@
+(ns figwheel
+  (:require [clojure.string :as s]))
+
+(defn system-options [builds-to-start]
+  {:nrepl-port 7888
+   :builds     [{:id           :ios
+                 :source-paths ["react-native/src" "src" "env/dev"]
+                 :compiler     {:output-to     "target/ios/app.js"
+                                :main          "env.ios.main"
+                                :output-dir    "target/ios"
+                                :optimizations :none}
+                 :figwheel     true}
+                {:id               :android
+                 :source-paths     ["react-native/src" "src" "env/dev"]
+                 :compiler         {:output-to     "target/android/app.js"
+                                    :main          "env.android.main"
+                                    :output-dir    "target/android"
+                                    :optimizations :none}
+                 :warning-handlers '[status-im.utils.build/warning-handler]
+                 :figwheel         true}]
+   :builds-to-start builds-to-start})

--- a/project.clj
+++ b/project.clj
@@ -50,18 +50,7 @@
                                         [re-frisk-remote "0.5.3"]
                                         [re-frisk-sidecar "0.5.4"]
                                         [hawk "0.2.11"]]
-                         :source-paths ["src" "env/dev"]
-                         :cljsbuild    {:builds
-                                        {:ios
-                                         {:source-paths ["react-native/src" "src" "env/dev"]
-                                          :compiler     {:output-to     "target/ios/app.js"
-                                                         :output-dir    "target/ios"}
-                                          :figwheel     true}
-                                         :android
-                                         {:source-paths ["react-native/src" "src" "env/dev"]
-                                          :compiler     {:output-to     "target/android/app.js"
-                                                         :output-dir    "target/android"}
-                                          :figwheel     true}}}}]
+                         :source-paths ["src" "env/dev"]}]
              :test     {:dependencies [[day8.re-frame/test "0.1.5"]]
                         :plugins      [[lein-doo "0.1.7"]]
                         :cljsbuild    {:builds


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

Fixes #2999

### Summary:

[comment]: # (Summarise the problem and how the pull request solves it)
Replaced the figwheel profile :cljsbuild section with the equivalent in figwheel.edn format (along with the config reshaping code in figwheel-api), making sure not to change the behavior of `figwheel-api/start`.

### Review notes (optional):

I erred on the conservative side with the changes, preserving the *-test builds and warning-handler in the android build.

### Steps to test:
- Confirm `lein figwheel-repl` behavior has not changed

status: ready
