### PR TITLE
Returning expandable animations back, removing :get-max-container-area-height

### DIFF
--- a/resources/js/bots/transactor/bot.js
+++ b/resources/js/bots/transactor/bot.js
@@ -115,7 +115,8 @@ function amountParameterBox(groupChat, params, context) {
         showBack: true,
         markup: status.components.scrollView(
             {
-                keyboardShouldPersistTaps: "always"
+                keyboardShouldPersistTaps: "always",
+                bounces: false,
             },
             [status.components.view(
                 {

--- a/src/status_im/chat/subs.cljs
+++ b/src/status_im/chat/subs.cljs
@@ -320,15 +320,6 @@
       (input-utils/default-container-area-height bottom layout-height))))
 
 (reg-sub
-  :get-max-container-area-height
-  :<- [:get-current-chat-ui-prop :input-height]
-  :<- [:get :layout-height]
-  :<- [:chat-input-margin]
-  (fn [[input-height layout-height chat-input-margin]]
-    (let [bottom (+ input-height chat-input-margin)]
-      (input-utils/max-container-area-height bottom layout-height))))
-
-(reg-sub
   :chat-animations
   (fn [db [_ key type]]
     (let [chat-id (subscribe [:get-current-chat-id])]

--- a/src/status_im/chat/views/input/animations/expandable.cljs
+++ b/src/status_im/chat/views/input/animations/expandable.cljs
@@ -25,7 +25,7 @@
             to-change-height  (if (= to-changed-height :max)
                                 (input-utils/max-container-area-height @chat-input-margin @layout-height)
                                 to-changed-height)
-            to-value          (or to-change-height (or height @to-default-height))]
+            to-value          (or to-change-height height @to-default-height)]
         (re-frame/dispatch [:set :expandable-view-height-to-value to-value])
         (animation/start
           (animation/spring anim-value {:toValue  to-value

--- a/src/status_im/chat/views/input/animations/expandable.cljs
+++ b/src/status_im/chat/views/input/animations/expandable.cljs
@@ -3,30 +3,13 @@
   (:require [reagent.core :as reagent]
             [re-frame.core :as re-frame]
             [status-im.ui.components.animation :as animation]
-            [status-im.ui.components.drag-drop :as drag]
             [status-im.ui.components.react :as react]
             [status-im.chat.views.input.animations.responder :as responder]
             [status-im.chat.views.input.utils :as input-utils]
             [status-im.chat.styles.animations :as style]
             [status-im.chat.styles.input.input :as input-style]))
 
-(defn header [key container-height custom-header]
-  (let [set-container-height (re-frame/subscribe [:chat-animations key :height])
-        max-container-height (re-frame/subscribe [:get-max-container-area-height])
-        pan-responder        (responder/pan-responder container-height
-                                                      max-container-height
-                                                      :fix-expandable-height
-                                                      key)]
-    (fn [_]
-      [react/view (merge (drag/pan-handlers pan-responder)
-                         {:style style/header-container})
-       [react/view style/header-icon]
-       (when (and custom-header
-                  (or (= @set-container-height :max)
-                      (> @set-container-height (:min-height style/header-container))))
-         [custom-header])])))
-
-(defn expandable-view-on-update [{:keys [anim-value to-changed-height max-height chat-input-margin height]}]
+(defn expandable-view-on-update [{:keys [anim-value to-changed-height chat-input-margin height]}]
   (let [to-default-height (re-frame/subscribe [:get-default-container-area-height])
         layout-height     (re-frame/subscribe [:get :layout-height])]
     (fn [component]
@@ -42,8 +25,7 @@
             to-change-height  (if (= to-changed-height :max)
                                 (input-utils/max-container-area-height @chat-input-margin @layout-height)
                                 to-changed-height)
-            to-value          (min (or to-change-height (or height @to-default-height))
-                                   @max-height)]
+            to-value          (or to-change-height (or height @to-default-height))]
         (re-frame/dispatch [:set :expandable-view-height-to-value to-value])
         (animation/start
           (animation/spring anim-value {:toValue  to-value
@@ -53,14 +35,12 @@
 (defn expandable-view [{:keys [key height hide-overlay?]} & _]
   (let [anim-value        (animation/create-value 0)
         input-height      (re-frame/subscribe [:get-current-chat-ui-prop :input-height])
-        max-height        (re-frame/subscribe [:get-max-container-area-height])
         fullscreen?       (re-frame/subscribe [:get-current-chat-ui-prop :fullscreen?])
         chat-input-margin (re-frame/subscribe [:chat-input-margin])
         to-changed-height (re-frame/subscribe [:chat-animations key :height])
         changes-counter   (re-frame/subscribe [:chat-animations key :changes-counter])
         on-update         (expandable-view-on-update {:anim-value        anim-value
                                                       :to-changed-height to-changed-height
-                                                      :max-height        max-height
                                                       :chat-input-margin chat-input-margin
                                                       :height            height})]
     (reagent/create-class
@@ -77,17 +57,13 @@
        :display-name
        "expandable-view"
        :reagent-render
-       (fn [{:keys [draggable? custom-header]} & elements]
-         @to-changed-height @changes-counter @max-height
+       (fn [{:keys [custom-header]} & elements]
+         @to-changed-height @changes-counter
          (let [input-height (or @input-height (+ input-style/padding-vertical
                                                  input-style/min-input-height
                                                  input-style/padding-vertical
                                                  input-style/border-height))
-               bottom       (+ input-height @chat-input-margin)
-               height       (if @fullscreen? @max-height anim-value)]
+               bottom       (+ input-height @chat-input-margin)]
            [react/view style/overlap-container
-            (into [react/animated-view {:style (style/expandable-container height bottom)}
-                   (when (and draggable?
-                              (not @fullscreen?))
-                     [header key anim-value custom-header])]
+            (into [react/animated-view {:style (style/expandable-container anim-value bottom)}]
                   elements)]))})))


### PR DESCRIPTION
Seems like `:get-max-container-area-height` became useless not so long ago. More importantly, it now returns incorrect negative value which means all awesome animations introduced here https://github.com/status-im/status-react/pull/3259 don't work anymore. 

This PR fixes this issue, removes `:get-max-container-area-height`, introduces some small changes to `expandable` and make animations work again.