### PR TITLE
[FIX #3351] chat: fix extra new lines adding in the text input on enter (ios)

### DIFF
--- a/src/status_im/chat/views/input/input.cljs
+++ b/src/status_im/chat/views/input/input.cljs
@@ -35,7 +35,7 @@
       :on-submit-editing      (fn [e]
                                 (if single-line-input?
                                   (re-frame/dispatch [:send-current-message])
-                                  (.setNativeProps @input-ref (clj->js {:text (str input-text "\n")}))))
+                                  (.setNativeProps @input-ref (clj->js {:text input-text}))))
       :on-layout              (fn [e]
                                 (set-container-width-fn (.-width (.-layout (.-nativeEvent e)))))
       :on-change              (fn [e]


### PR DESCRIPTION
### Summary:

Concatenation of the input text with a new line symbol "\n" looks exhaustive in iOS. But it may be required in Android. I cannot test Android at this moment. In case it fails in Android maybe we should add a platform check.

status: ready