### PR TITLE
[FIX #3341] chat, translations, ui: fix chat delete confirmation

### DIFF
--- a/src/status_im/chat/views/actions.cljs
+++ b/src/status_im/chat/views/actions.cljs
@@ -1,20 +1,30 @@
 (ns status-im.chat.views.actions
   (:require [re-frame.core :as re-frame]
-            [status-im.i18n :as i18n]))
+            [status-im.i18n :as i18n]
+            [status-im.utils.utils :as utils]))
 
 (defn view-profile [chat-id group?]
   {:label  (i18n/label :t/view-profile)
    :action #(re-frame/dispatch [ (if group? :show-group-chat-profile :show-profile) chat-id])})
 
+(defn delete-confirmation [title message dispatch-fn]
+  (utils/show-confirmation
+    (str (i18n/label title) "?") (i18n/label message) (i18n/label :t/delete)
+    (fn[]
+      (dispatch-fn))))
+
 (defn delete-chat [chat-id]
-  {:label   (i18n/label :t/delete-chat)
-   ;; TODO(jeluard) Refactor this or Jan will have an heart attack
-   :action  #(do (re-frame/dispatch [:remove-chat chat-id])
-                 (re-frame/dispatch [:navigation-replace :home]))})
+  (let [dispatch-fn
+        ;; TODO(jeluard) Refactor this or Jan will have an heart attack
+        #(do (re-frame/dispatch [:remove-chat chat-id])
+             (re-frame/dispatch [:navigation-replace :home]))]
+    {:label   (i18n/label :t/delete-chat)
+     :action  #(delete-confirmation :t/delete-chat :t/delete-chat-confirmation dispatch-fn)}))
 
 (defn leave-group-chat [chat-id]
-  {:label   (i18n/label :t/leave-group-chat)
-   :action  #(re-frame/dispatch [:leave-group-chat chat-id])})
+  (let [dispatch-fn #(re-frame/dispatch [:leave-group-chat chat-id])]
+    {:label   (i18n/label :t/leave-group-chat)
+     :action  #(delete-confirmation :t/delete-group :t/delete-group-confirmation dispatch-fn)}))
 
 (defn- user-chat-actions [chat-id group?]
   [(view-profile chat-id group?)

--- a/src/status_im/translations/en.cljs
+++ b/src/status_im/translations/en.cljs
@@ -150,6 +150,7 @@
    :invite-friends                        "Invite friends"
    :chats                                 "Chats"
    :delete-chat                           "Delete chat"
+   :delete-chat-confirmation              "This chat will be removed from your list. This will not affect your contacts"
    :group-chat                            "Group chat"
    :new-group-chat                        "New group chat"
    :new-public-group-chat                 "Join public chat"

--- a/src/status_im/ui/screens/group/views.cljs
+++ b/src/status_im/ui/screens/group/views.cljs
@@ -2,6 +2,7 @@
   (:require-macros [status-im.utils.views :refer [defview letsubs]])
   (:require [cljs.spec.alpha :as spec]
             [re-frame.core :as re-frame]
+            [status-im.chat.views.actions :refer [delete-confirmation]]
             [status-im.i18n :as i18n]
             [status-im.ui.screens.contacts.styles :as cstyles]
             [status-im.ui.components.common.common :as common]
@@ -59,28 +60,32 @@
        (i18n/label :t/delete-group-prompt)]]]]])
 
 (defn group-chat-settings-btns []
-  [react/view styles/settings-group-container
-   [react/view {:opacity 0.4}
-    [react/touchable-highlight {:on-press #()}
-     [react/view styles/settings-group-item
-      [react/view styles/settings-icon-container
-       [vi/icon :icons/speaker {:color :blue}]]
-      [react/view styles/settings-group-text-container
-       [react/text {:style styles/settings-group-text}
-        (i18n/label :t/mute-notifications)]]]]]
-   [action-separator]
-   [action-button {:label     (i18n/label :t/clear-history)
-                   :icon      :icons/close
-                   :icon-opts {:color :blue}
-                   :on-press  #(re-frame/dispatch [:clear-history])}]
-   [action-separator]
-   [react/touchable-highlight {:on-press #(re-frame/dispatch [:leave-group-chat])}
-    [react/view styles/settings-group-item
-     [react/view styles/delete-icon-container
-      [vi/icon :icons/arrow-right {:color :red}]]
-     [react/view styles/settings-group-text-container
-      [react/text {:style styles/delete-group-text}
-       (i18n/label :t/leave-chat)]]]]])
+  (let [leave-group-dispatch-fn #(re-frame/dispatch [:leave-group-chat])]
+    [react/view styles/settings-group-container
+     [react/view {:opacity 0.4}
+      [react/touchable-highlight {:on-press #()}
+       [react/view styles/settings-group-item
+        [react/view styles/settings-icon-container
+         [vi/icon :icons/speaker {:color :blue}]]
+        [react/view styles/settings-group-text-container
+         [react/text {:style styles/settings-group-text}
+          (i18n/label :t/mute-notifications)]]]]]
+     [action-separator]
+     [action-button {:label     (i18n/label :t/clear-history)
+                     :icon      :icons/close
+                     :icon-opts {:color :blue}
+                     :on-press  #(re-frame/dispatch [:clear-history])}]
+     [action-separator]
+     [react/touchable-highlight {:on-press #(delete-confirmation
+                                              :t/delete-group
+                                              :t/delete-group-confirmation
+                                              leave-group-dispatch-fn)}
+      [react/view styles/settings-group-item
+       [react/view styles/delete-icon-container
+        [vi/icon :icons/arrow-right {:color :red}]]
+       [react/view styles/settings-group-text-container
+        [react/text {:style styles/delete-group-text}
+         (i18n/label :t/leave-chat)]]]]]))
 
 (defn more-btn [contacts-limit contacts-count on-press]
   [react/view


### PR DESCRIPTION
### Summary:

Add delete confirmation window for all the available cases:
* Delete chat
* Leave group
* Leave group (in group settings)

### Review notes (optional):
The PR should be coordinated with #3308.

status: ready