### PR TITLE
Refactor timestamp

### DIFF
--- a/src/status_im/data_store/messages.cljs
+++ b/src/status_im/data_store/messages.cljs
@@ -4,7 +4,8 @@
             [status-im.constants :as constants]
             [status-im.data-store.realm.messages :as data-store]
             [status-im.utils.random :as random]
-            [status-im.utils.core :as utils]))
+            [status-im.utils.core :as utils]
+            [status-im.utils.datetime :as datetime]))
 
 (defn- command-type?
   [type]
@@ -76,7 +77,7 @@
     (data-store/save (prepare-message (merge default-values
                                              message
                                              {:from      (or from "anonymous")
-                                              :timestamp (random/timestamp)})))))
+                                              :timestamp (datetime/timestamp)})))))
 
 (defn update-message
   [{:keys [message-id] :as message}]

--- a/src/status_im/data_store/realm/browser.cljs
+++ b/src/status_im/data_store/realm/browser.cljs
@@ -1,6 +1,5 @@
 (ns status-im.data-store.realm.browser
-  (:require [status-im.data-store.realm.core :as realm]
-    [status-im.utils.random :refer [timestamp]])
+  (:require [status-im.data-store.realm.core :as realm])
   (:refer-clojure :exclude [exists?]))
 
 (defn get-all

--- a/src/status_im/data_store/realm/chats.cljs
+++ b/src/status_im/data_store/realm/chats.cljs
@@ -2,7 +2,7 @@
   (:require [goog.object :as object]
             [status-im.data-store.realm.core :as realm]
             [status-im.data-store.realm.messages :as messages]
-            [status-im.utils.random :refer [timestamp]]
+            [status-im.utils.datetime :as datetime]
             [taoensso.timbre :as log])
   (:refer-clojure :exclude [exists?]))
 
@@ -78,7 +78,7 @@
                  (fn []
                    (doto chat
                      (aset "is-active" false)
-                     (aset "removed-at" (timestamp)))))))
+                     (aset "removed-at" (datetime/timestamp)))))))
 
 (defn get-contacts
   [chat-id]
@@ -100,7 +100,7 @@
 (defn add-contacts
   [chat-id identities]
   (let [contacts (get-contacts chat-id)
-        added-at (timestamp)]
+        added-at (datetime/timestamp)]
     (realm/write @realm/account-realm
                  #(save-contacts identities contacts added-at))))
 

--- a/src/status_im/data_store/realm/contact_groups.cljs
+++ b/src/status_im/data_store/realm/contact_groups.cljs
@@ -1,7 +1,6 @@
 (ns status-im.data-store.realm.contact-groups
   (:require [goog.object :as object]
-            [status-im.data-store.realm.core :as realm]
-            [status-im.utils.random :refer [timestamp]])
+            [status-im.data-store.realm.core :as realm])
   (:refer-clojure :exclude [exists?]))
 
 (defn get-all

--- a/src/status_im/protocol/discoveries.cljs
+++ b/src/status_im/protocol/discoveries.cljs
@@ -8,7 +8,8 @@
     [cljs.spec.alpha :as s]
     [status-im.protocol.validation :refer-macros [valid?]]
     [status-im.utils.random :as random]
-    [status-im.protocol.web3.keys :as shh-keys]))
+    [status-im.protocol.web3.keys :as shh-keys]
+    [status-im.utils.datetime :as datetime]))
 
 (def discover-topic-prefix "status-discover-")
 (def discover-topic "0xbeefdead")
@@ -33,7 +34,7 @@
                    {:requires-ack? false
                     :type          :online
                     :key-password  discovery-key-password
-                    :payload       {:content {:timestamp (u/timestamp)}}
+                    :payload       {:content {:timestamp (datetime/timestamp)}}
                     :topics        [f/status-topic]})]
     (d/add-pending-message! web3 message')))
 
@@ -116,7 +117,7 @@
         (assoc :type :profile
                :topics [f/status-topic]
                :key-password discovery-key-password)
-        (assoc-in [:payload :timestamp] (u/timestamp))
+        (assoc-in [:payload :timestamp] (datetime/timestamp))
         (assoc-in [:payload :content :profile]
                   (get-in message [:payload :profile]))
         (update :payload dissoc :profile))))
@@ -139,7 +140,7 @@
                            :requires-ack? false
                            :key-password discovery-key-password
                            :topics [f/status-topic])
-                    (assoc-in [:payload :timestamp] (u/timestamp)))]
+                    (assoc-in [:payload :timestamp] (datetime/timestamp)))]
     (d/add-pending-message! web3 message)))
 
 (s/def :status/payload

--- a/src/status_im/protocol/group.cljs
+++ b/src/status_im/protocol/group.cljs
@@ -9,7 +9,8 @@
     [status-im.protocol.web3.filtering :as f]
     [status-im.protocol.listeners :as l]
     [clojure.string :as str]
-    [status-im.protocol.web3.keys :as shh-keys]))
+    [status-im.protocol.web3.keys :as shh-keys]
+    [status-im.utils.datetime :as datetime]))
 
 (defn prepare-mesage
   [{:keys [message group-id keypair new-keypair type username requires-ack?]}]
@@ -18,7 +19,7 @@
                              :username username
                              :group-id group-id
                              :type type
-                             :timestamp (u/timestamp))
+                             :timestamp (datetime/timestamp))
                      (assoc :topics [f/status-topic]
                             :key-password group-id
                             :requires-ack? (or (nil? requires-ack?) requires-ack?)
@@ -97,7 +98,7 @@
                             :requires-ack? true
                             :type type)
                      (update :payload assoc
-                             :timestamp (u/timestamp)
+                             :timestamp (datetime/timestamp)
                              :group-id id
                              :group-admin admin
                              :group-name name

--- a/src/status_im/protocol/handlers.cljs
+++ b/src/status_im/protocol/handlers.cljs
@@ -185,7 +185,7 @@
 (re-frame/reg-fx
   ::load-processed-messages!
   (fn []
-    (let [now      (datetime/now-ms)
+    (let [now      (datetime/timestamp)
           messages (processed-messages/get-filtered (str "ttl > " now))]
       (cache/init! messages)
       (processed-messages/delete (str "ttl <=" now)))))
@@ -465,7 +465,7 @@
               processed-message {:id         (random/id)
                                  :message-id message-id
                                  :type       type
-                                 :ttl        (+ (datetime/now-ms) ttl-s)}
+                                 :ttl        (+ (datetime/timestamp) ttl-s)}
               chat-message (#{:message :group-message} (:type payload))
               route-fx (case type
                          (:message

--- a/src/status_im/protocol/web3/delivery.cljs
+++ b/src/status_im/protocol/web3/delivery.cljs
@@ -8,7 +8,8 @@
             [status-im.protocol.validation :refer-macros [valid?]]
             [clojure.set :as set]
             [status-im.protocol.web3.keys :as shh-keys]
-            [status-im.utils.async :refer [timeout]]))
+            [status-im.utils.async :refer [timeout]]
+            [status-im.utils.datetime :as datetime]))
 
 (defonce loop-state (atom nil))
 (defonce messages (atom {}))
@@ -162,7 +163,7 @@
   (swap! messages update-in [web3 id to]
          (fn [{:keys [attempts] :as data}]
            (assoc data :attempts (inc attempts)
-                       :last-attempt (u/timestamp)))))
+                       :last-attempt (datetime/timestamp)))))
 
 (defn delivery-callback
   [web3 post-error-callback {:keys [id requires-ack? to]} message]
@@ -206,7 +207,7 @@
       ;; continue attempts
       (<= attempts max-attempts-number)
       ;; check retransmission interval
-      (<= (+ last-attempt (* 1000 ack-not-received-s-interval)) (u/timestamp)))))
+      (<= (+ last-attempt (* 1000 ack-not-received-s-interval)) (datetime/timestamp)))))
 
 (defn- check-ttl
   [message message-type ttl-config default-ttl]

--- a/src/status_im/protocol/web3/utils.cljs
+++ b/src/status_im/protocol/web3/utils.cljs
@@ -16,9 +16,6 @@
 (defn shh [web3]
   (.-shh web3))
 
-(defn timestamp []
-  (to-long (now)))
-
 (defn extract-enode-id [enode]
   (-> enode
       (string/split #"/")

--- a/src/status_im/ui/screens/contacts/events.cljs
+++ b/src/status_im/ui/screens/contacts/events.cljs
@@ -22,7 +22,8 @@
             [cljs.spec.alpha :as spec]
             [status-im.protocol.web3.utils :as web3.utils]
             [status-im.ui.screens.add-new.new-chat.db :as new-chat.db]
-            [clojure.string :as string]))
+            [clojure.string :as string]
+            [status-im.utils.datetime :as datetime]))
 ;;;; COFX
 
 (reg-cofx
@@ -71,7 +72,7 @@
                                        :fcm-token     fcm-token}
                              :keypair {:public  updates-public-key
                                        :private updates-private-key}
-                             :timestamp (web3.utils/timestamp)}}})))
+                             :timestamp (datetime/timestamp)}}})))
 
 (reg-fx
   ::reset-pending-messages
@@ -146,7 +147,7 @@
       {:group-id  id'
        :name      (:en name)
        :order     0
-       :timestamp (random/timestamp)
+       :timestamp (datetime/timestamp)
        :contacts  (mapv #(hash-map :identity %) contacts)})]])
 
 ;; NOTE(oskarth): We now overwrite default contacts upon upgrade with default_contacts.json data.

--- a/src/status_im/ui/screens/discover/subs.cljs
+++ b/src/status_im/ui/screens/discover/subs.cljs
@@ -29,7 +29,7 @@
   :<- [:get-contacts]
   :<- [:get :current-public-key]
   (fn [[discoveries chats contacts current-public-key]]
-    (let [now-ms (time/now-ms)]
+    (let [now-ms (time/timestamp)]
       (map #(assoc % :priority (calculate-priority now-ms chats current-public-key contacts %)) (vals discoveries)))))
 
 (reg-sub :discover/search-tags :discover-search-tags)

--- a/src/status_im/ui/screens/events.cljs
+++ b/src/status_im/ui/screens/events.cljs
@@ -69,7 +69,7 @@
 (re-frame/reg-cofx
  :now
  (fn [coeffects _]
-   (assoc coeffects :now (time/now-ms))))
+   (assoc coeffects :now (time/timestamp))))
 
 (re-frame/reg-cofx
  :random-id

--- a/src/status_im/ui/screens/group/events.cljs
+++ b/src/status_im/ui/screens/group/events.cljs
@@ -6,7 +6,9 @@
             [status-im.data-store.contact-groups :as groups]
             [clojure.string :as string]
             [status-im.utils.random :as random]
-            [status-im.ui.screens.group.navigation]))
+            [status-im.ui.screens.group.navigation]
+            [status-im.utils.datetime :as datetime]
+            [re-frame.core :as re-frame]))
 
 ;;;; COFX
 
@@ -65,12 +67,14 @@
 
 (register-handler-fx
   :create-new-contact-group
-  (fn [{{:group/keys [contact-groups selected-contacts] :as db} :db} [_ group-name]]
+  [(re-frame/inject-cofx :now)]
+  (fn [{{:group/keys [contact-groups selected-contacts] :as db} :db
+        now :now} [_ group-name]]
     (let [selected-contacts' (mapv #(hash-map :identity %) selected-contacts)
           new-group {:group-id    (random/id)
                      :name        group-name
                      :order       (count contact-groups)
-                     :timestamp   (random/timestamp)
+                     :timestamp   now
                      :contacts    selected-contacts'}]
       {:db (update db :group/contact-groups merge {(:group-id new-group) new-group})
        ::save-contact-group new-group})))

--- a/src/status_im/utils/datetime.cljs
+++ b/src/status_im/utils/datetime.cljs
@@ -108,8 +108,8 @@
 (defn to-date [ms]
   (from-long ms))
 
-(defn now-ms []
-  (to-long (now)))
+(defn timestamp []
+  (inst-ms (js/Date.)))
 
 (defn format-date [format date]
   (let [local (plus (from-date date) time-zone-offset)]

--- a/src/status_im/utils/gfycat/core.cljs
+++ b/src/status_im/utils/gfycat/core.cljs
@@ -3,7 +3,7 @@
             [status-im.utils.gfycat.adjectives :as adjectives]
             [clojure.string :as str]
             [status-im.utils.random :as rnd]
-            [status-im.utils.datetime :refer [now-ms]]))
+            [status-im.utils.datetime :as datetime]))
 
 (defn- pick-random
   [gen vector]
@@ -25,4 +25,4 @@
      nil unknown-gfy
      "0" unknown-gfy
      (build-gfy public-key)))
-  ([] (generate-gfy (now-ms))))
+  ([] (generate-gfy (datetime/timestamp))))

--- a/src/status_im/utils/random.cljs
+++ b/src/status_im/utils/random.cljs
@@ -1,13 +1,11 @@
 (ns status-im.utils.random
-  (:require [status-im.js-dependencies :as dependencies]))
-
-(defn timestamp []
-  (.getTime (js/Date.)))
+  (:require [status-im.js-dependencies :as dependencies]
+            [status-im.utils.datetime :as datetime]))
 
 (def chance (dependencies/Chance.))
 
 (defn id []
-  (str (timestamp) "-" (.guid chance)))
+  (str (datetime/timestamp) "-" (.guid chance)))
 
 (defn rand-gen
   [seed]

--- a/test/cljs/status_im/test/contacts/events.cljs
+++ b/test/cljs/status_im/test/contacts/events.cljs
@@ -308,7 +308,7 @@
       ;;
       ;; :update-contact!
       ;;TODO :update-chat!
-      (let [timestamp (datetime/now-ms)]
+      (let [timestamp (datetime/timestamp)]
         (def received-contact2 (assoc received-contact1
                                       :last-updated timestamp
                                       :status "new status"


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

Fixes #3304

### Summary:

[comment]: # (Summarise the problem and how the pull request solves it)

- rename utils.datetime/now-ms to timestamp
- replace protocol.web3.utils/timestamp with utils.datetime/timestamp
- replace cljs-time with inst-ms in timestamp

### Review notes

Getting the current timestamp seemed to be a common enough use case, so I kept the utils.datetime version (as it is higher up the hierarchy as a util namespace) instead of replacing all calls of now-ms/timestamp with `(inst-ms (js/Date.))`.

For the name change from `now-ms` to `timestamp`:
- `timestamp` feels more descriptive of intent
- we can visualize impacted call sites in diff

### Steps to test:

Interleave quick calls to the old and new implementations, and check the results monotonically increase. This is crude, but should be good enough to prove there is no behavior change between the two.

In REPL:
```
(do
    (defn old-timestamp []
      (cljs-time.coerce/to-long (cljs-time.core/now)))

    ;; interleave calls eagerly with reduce
    (->> (reduce
           (fn [z _]
             (into z [(old-timestamp) (status-im.utils.datetime/timestamp)]))
           [] (range 100000))
         (apply <=)))
=> true
```

status: ready
