### PR TITLE
[ISSUE #3396] Fixed incorrect atom access

### DIFF
--- a/src/status_im/chat/views/input/input.cljs
+++ b/src/status_im/chat/views/input/input.cljs
@@ -32,10 +32,11 @@
       :blur-on-submit         false
       :on-focus               #(re-frame/dispatch [:set-chat-ui-props {:input-focused? true}])
       :on-blur                #(re-frame/dispatch [:set-chat-ui-props {:input-focused? false}])
-      :on-submit-editing      (fn [e]
+      :on-submit-editing      (fn [_]
                                 (if single-line-input?
                                   (re-frame/dispatch [:send-current-message])
-                                  (.setNativeProps input-ref (clj->js {:text input-text}))))
+                                  (when @input-ref
+                                    (.setNativeProps @input-ref (clj->js {:text input-text})))))
       :on-layout              (fn [e]
                                 (set-container-width-fn (.-width (.-layout (.-nativeEvent e)))))
       :on-change              (fn [e]


### PR DESCRIPTION
fixes #3396

### Summary:

Fixed issue when sending empty message

### Steps to test:
- Open Status
- Open a chat
- Send an empty message

status: ready
