### PR TITLE
Properly open/navigate-to chat

### DIFF
--- a/src/status_im/ui/screens/profile/events.cljs
+++ b/src/status_im/ui/screens/profile/events.cljs
@@ -39,12 +39,6 @@
           (as-> fx
               (merge fx (input-events/select-chat-input-command (:db fx) send-command nil true)))))))
 
-(handlers/register-handler-fx
-  :profile/send-message
-  (fn [_ [_ identity]]
-    (when identity
-      {:dispatch [:navigation-replace :chat identity]})))
-
 (defn get-current-account [{:keys [:accounts/current-account-id] :as db}]
   (get-in db [:accounts/accounts current-account-id]))
 

--- a/src/status_im/ui/screens/profile/views.cljs
+++ b/src/status_im/ui/screens/profile/views.cljs
@@ -116,7 +116,7 @@
    [action-button/action-button {:label     (i18n/label :t/start-conversation)
                                  :icon      :icons/chats
                                  :icon-opts {:color :blue}
-                                 :on-press  #(re-frame/dispatch [:profile/send-message whisper-identity])}]
+                                 :on-press  #(re-frame/dispatch [:start-chat whisper-identity {:navigation-replace? true}])}]
    (when-not dapp?
      [react/view
       [action-button/action-separator]


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes #3380 

### Summary:

[comment]: # (Summarise the problem and how the pull request solves it)
For some strange reason, action for starting chat with contact was replaced with insufficient `:navigate-to` (what if chat is there before navigating to it ?). 
This PR restores the previous behaviour and proper `:start-chat` event is used, which checks if chat is present and if not, creates the one.

### Testing notes (optional):
Test the scenario described in bug ticket + make sure that it works (navigating from profile to chat) in both scenarios, eq when chat with contact is not present and also when it's present.

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready
