### PR TITLE
[TESTS #3282] Added sanity automation tests for chats deletion

### DIFF
--- a/src/status_im/chat/screen.cljs
+++ b/src/status_im/chat/screen.cljs
@@ -24,7 +24,7 @@
             pending-contact? [:current-contact :pending?]]
     (when pending-contact?
       [react/touchable-highlight
-       {:on-press #(re-frame/dispatch [:add-pending-contact chat-id])}
+       {:on-press #(re-frame/dispatch [:add-contact chat-id])}
        [react/view style/add-contact
         [react/text {:style style/add-contact-text}
          (i18n/label :t/add-to-contacts)]]])))

--- a/src/status_im/ui/screens/contacts/subs.cljs
+++ b/src/status_im/ui/screens/contacts/subs.cljs
@@ -98,10 +98,15 @@
     (->> (remove :pending? (vals groups))
          (sort-by :order >))))
 
-(reg-sub :contact
+(reg-sub :current-contact-identity
   (fn [db]
-    (let [identity (:contacts/identity db)]
-      (get-in db [:contacts/contacts identity]))))
+    (:contacts/identity db)))
+
+(reg-sub :contact
+  :<- [:get-contacts]
+  :<- [:current-contact-identity]
+  (fn [[contacts identity]]
+    (contacts identity)))
 
 (reg-sub :contact-by-identity
   (fn [db [_ identity]]

--- a/src/status_im/ui/screens/profile/contact/views.cljs
+++ b/src/status_im/ui/screens/profile/contact/views.cljs
@@ -7,6 +7,7 @@
             [status-im.ui.components.status-bar.view :as status-bar]
             [status-im.i18n :as i18n]
             [re-frame.core :as re-frame]
+            [status-im.utils.contacts :as utils.contacts]
             [status-im.ui.components.toolbar.view :as toolbar]
             [status-im.ui.components.list.views :as list]))
 
@@ -19,7 +20,7 @@
   (concat (if pending?
             [{:label  (i18n/label :t/add-to-contacts)
               :icon   :icons/add-contact
-              :action #(re-frame/dispatch [:add-pending-contact chat-id])}]
+              :action #(re-frame/dispatch [:add-contact whisper-identity])}]
             [{:label     (i18n/label :t/in-contacts)
               :icon      :icons/in-contacts
               :disabled? true}])
@@ -52,19 +53,21 @@
    [profile-info-contact-code-item whisper-identity]])
 
 (defview profile []
-  (letsubs [contact [:contact]
+  (letsubs [identity        [:current-contact-identity]
+            maybe-contact   [:contact]
             chat-id [:get :current-chat-id]]
-    [react/view profile.components.styles/profile
-     [status-bar/status-bar]
-     [profile-contact-toolbar]
-     [react/scroll-view
-      [react/view profile.components.styles/profile-form
-       [profile.components/profile-header contact false false nil nil]]
-      [list/action-list (actions contact chat-id)
-       {:container-style        styles/action-container
-        :action-style           styles/action
-        :action-label-style     styles/action-label
-        :action-separator-style styles/action-separator
-        :icon-opts              styles/action-icon-opts}]
-      [react/view styles/contact-profile-info-container
-       [profile-info contact]]]]))
+    (let [contact (or maybe-contact (utils.contacts/whisper-id->new-contact identity))]
+      [react/view profile.components.styles/profile
+       [status-bar/status-bar]
+       [profile-contact-toolbar]
+       [react/scroll-view
+        [react/view profile.components.styles/profile-form
+         [profile.components/profile-header contact false false nil nil]]
+        [list/action-list (actions contact chat-id)
+         {:container-style        styles/action-container
+          :action-style           styles/action
+          :action-label-style     styles/action-label
+          :action-separator-style styles/action-separator
+          :icon-opts              styles/action-icon-opts}]
+        [react/view styles/contact-profile-info-container
+         [profile-info contact]]]])))

--- a/src/status_im/utils/contacts.cljs
+++ b/src/status_im/utils/contacts.cljs
@@ -1,0 +1,10 @@
+(ns status-im.utils.contacts
+  (:require
+    [status-im.utils.identicon :as identicon]
+    [status-im.utils.gfycat.core :as gfycat]))
+
+(defn whisper-id->new-contact [whisper-id]
+  {:name             (gfycat/generate-gfy whisper-id)
+   :photo-path       (identicon/identicon whisper-id)
+   :pending?         true
+   :whisper-identity whisper-id})

--- a/test/appium/tests/test_dapps_and_browsing.py
+++ b/test/appium/tests/test_dapps_and_browsing.py
@@ -21,3 +21,5 @@ class TestDappsAnsBrowsing(SingleDeviceTestCase):
         browsing_view.back_to_home_button.click()
 
         assert home_view.first_chat_element_title.text == 'Status | The Mobile Ethereum Client'
+        # TODO: enable when https://github.com/status-im/status-react/issues/3013 is closed
+        # home_view.swipe_and_delete_chat('Status | The Mobile Ethereum Client')

--- a/test/appium/tests/test_messaging.py
+++ b/test/appium/tests/test_messaging.py
@@ -75,16 +75,11 @@ class TestMessages(MultipleDeviceTestCase):
             web_view.find_full_text('Browse, chat and make payments securely on the decentralized web.')
             device_1_chat.back_button.click()
 
-        device_1_chat.chat_options.click()
-        device_1_chat.delete_chat_button.click()
-        device_1_chat.delete_button.click()
-        if not device_1_home.plus_button.is_element_present() or \
-                device_1_chat.element_by_text_part(device_2_username[:25]).is_element_present():
-            self.errors.append('Chat was not deleted')
+        device_1_chat.delete_chat(device_2_username[:25], self.errors)
         self.verify_no_errors()
 
     @pytest.mark.pr
-    def test_group_chat_messages(self):
+    def test_group_chat_messages_and_delete_chat(self):
         self.create_drivers(3)
         device_1, device_2, device_3 = SignInView(self.drivers[0]), SignInView(self.drivers[1]), \
                                        SignInView(self.drivers[2])
@@ -127,12 +122,11 @@ class TestMessages(MultipleDeviceTestCase):
 
         chat_1.chat_message_input.send_keys(unicode_text_message)
         chat_1.send_message_button.click()
-        for home in home_2, home_3:
-            home.element_by_text(chat_name, 'button').click()
-
-        chat_2, chat_3 = home_2.get_chat_view(), home_3.get_chat_view()
         for chat in chat_2, chat_3:
             chat.wait_for_messages_by_user(username_1, unicode_text_message, self.errors)
+
+        for chat in chat_1, chat_2, chat_3:
+            chat.delete_chat(chat_name, self.errors)
 
         self.verify_no_errors()
 
@@ -166,4 +160,6 @@ class TestMessages(MultipleDeviceTestCase):
         chat_2.send_as_keyevent(message_with_new_line)
         chat_2.send_message_button.click()
         chat_1.wait_for_messages_by_user(users[1], messages_to_receive_2, self.errors)
+        for chat in chat_1, chat_2:
+            chat.delete_chat(chat_name, self.errors)
         self.verify_no_errors()

--- a/test/appium/views/base_view.py
+++ b/test/appium/views/base_view.py
@@ -122,6 +122,13 @@ class DoneButton(BaseButton):
             "//android.widget.TextView[@text='DONE']")
 
 
+class DeleteButton(BaseButton):
+    def __init__(self, driver):
+        super(DeleteButton, self).__init__(driver)
+        self.locator = self.Locator.xpath_selector(
+            "//android.widget.Button[@text='Delete']")
+
+
 class AppsButton(BaseButton):
     def __init__(self, driver):
         super(AppsButton, self).__init__(driver)

--- a/test/appium/views/chat_view.py
+++ b/test/appium/views/chat_view.py
@@ -200,3 +200,12 @@ class ChatView(BaseView):
         send_transaction = self.get_send_transaction_view()
         self.send_message_button.click_until_presence_of_element(send_transaction.sign_transaction_button)
         send_transaction.sign_transaction(sender_password)
+
+    def delete_chat(self, chat_name: str, errors: list):
+        self.chat_options.click()
+        self.delete_chat_button.click()
+        self.delete_button.click()
+        from views.home_view import HomeView
+        if not HomeView(self.driver).plus_button.is_element_present() or \
+                self.element_by_text(chat_name).is_element_present():
+            errors.append('Chat was not deleted')

--- a/test/cljs/status_im/test/contacts/events.cljs
+++ b/test/cljs/status_im/test/contacts/events.cljs
@@ -110,7 +110,7 @@
    contact-request-received (update-contact, watch-contact ;TODO :update-chat!)
    contact-update-received (update-contact ;TODO :update-chat!)
    hide-contact (update-contact ;TODO :account-update-keys)
-   add-contact-handler (add-pending-contact, status-im.contacts.events/add-new-contact
+   add-contact-handler (add-contact, status-im.contacts.events/add-new-contact
                         status-im.contacts.events/send-contact-request ;TODO :discoveries-send-portions)
 
    create-new-contact-group
@@ -241,7 +241,8 @@
     (def new-contact {:name ""
                       :photo-path ""
                       :whisper-identity new-contact-public-key
-                      :address new-contact-address})
+                      :address new-contact-address
+                      :pending? false})
     (def contact (rf/subscribe [:contact-by-identity new-contact-public-key]))
     (def current-chat-id (rf/subscribe [:get-current-chat-id]))
 
@@ -338,11 +339,11 @@
         (is (= (assoc received-contact2 :pending? true)
                (get @contacts new-contact-public-key)))))
 
-    (testing ":add-contact-handler event - :add-pending-contact"
+    (testing ":add-contact-handler event - :add-contact"
 
       ;; :add-contact-handler event dispatches next 4 events
       ;;
-      ;; :add-pending-contact
+      ;; :add-contact
       ;; :status-im.contacts.events/add-new-contact
       ;; :status-im.contacts.events/send-contact-request
       ;;TODO :discoveries-send-portions


### PR DESCRIPTION
### Summary:
Added tests for messaging and chat management requested in #3282:

- C2086 | Can delete group chat
- C2087 | Can delete "Dapp", "any opened link" chat - currently disabled till respective PR is merged
- Can delete public chat