### PR TITLE
[FIX #3379] Support platform specific :uppercase as a text prop

### DIFF
--- a/src/status_im/android/platform.cljs
+++ b/src/status_im/android/platform.cljs
@@ -16,7 +16,6 @@
    :chats                        {:action-button?       true
                                   :new-chat-in-toolbar? false
                                   :render-separator?    false}
-   :uppercase?                   true
    :contacts                     {:action-button?          true
                                   :new-contact-in-toolbar? false}
    :group-block-shadows?         true

--- a/src/status_im/ios/platform.cljs
+++ b/src/status_im/ios/platform.cljs
@@ -26,7 +26,6 @@
    :chats                        {:action-button?       false
                                   :new-chat-in-toolbar? true
                                   :render-separator?    true}
-   :uppercase?                   false
    :contacts                     {:action-button?          false
                                   :new-contact-in-toolbar? true}
    :group-block-shadows?         false

--- a/src/status_im/ui/components/button/view.cljs
+++ b/src/status_im/ui/components/button/view.cljs
@@ -18,7 +18,7 @@
                                     (when disabled?
                                       {:opacity 0.4}))
                  :font       (if platform/android? :medium :default)
-                 :uppercase? (get-in platform/platform-specific [:uppercase?])}
+                 :uppercase? true}
      label]
     icon]])
 

--- a/src/status_im/ui/components/common/common.cljs
+++ b/src/status_im/ui/components/common/common.cljs
@@ -76,7 +76,7 @@
   [react/touchable-highlight {:on-press on-press :disabled disabled?}
    [react/view (styles/bottom-button disabled?)
     [react/text {:style      styles/bottom-button-label
-                 :uppercase? platform/android?}
+                 :uppercase? true}
      (or label (i18n/label :t/next))]
     (when forward?
       [icons/icon :icons/forward {:color colors/blue}])]])
@@ -84,6 +84,7 @@
 (defn button [{:keys [on-press label background? style] :or {background? true}}]
   [react/touchable-highlight {:on-press on-press}
    [react/view {:style (styles/button style background?)}
-    [react/text {:uppercase? platform/android?
-                 :style styles/button-label}
+    [react/text {:uppercase? true
+                 :style      styles/button-label}
      label]]])
+

--- a/src/status_im/ui/components/react.cljs
+++ b/src/status_im/ui/components/react.cljs
@@ -78,17 +78,20 @@
         (dissoc :font)
         (assoc style-key (merge style font)))))
 
+
+(defn transform-to-uppercase [{:keys [uppercase? force-uppercase?] :as opts} ts]
+  (if (or force-uppercase? (and uppercase? platform/android?))
+    (vec (map string/upper-case ts))
+    ts))
+
 (defn text
   ([t]
-   (reagent/as-element [text-class t]))
-  ([{:keys [uppercase?] :as opts} t & ts]
-   (reagent/as-element
-     (let [ts (cond->> (conj ts t)
-                       uppercase? (map #(when % (string/upper-case %))))]
-       (vec (concat
-              [text-class (add-font-style :style opts)]
-              ts))))))
-
+   [text-class t])
+  ([opts t & ts]
+   (->> (conj ts t)
+        (transform-to-uppercase opts)
+        (concat [text-class (add-font-style :style opts)])
+        (vec))))
 
 (defn text-input [{:keys [font style] :as opts
                    :or   {font :default}} text]

--- a/src/status_im/ui/components/sticky_button.cljs
+++ b/src/status_im/ui/components/sticky_button.cljs
@@ -25,6 +25,6 @@
   ([label on-press once?]
    [react/touchable-highlight {:on-press (if once? (u/wrap-call-once! on-press) on-press)}
     [react/view sticky-button-style
-     [react/text {:style sticky-button-label-style
-                  :uppercase? (get-in platform/platform-specific [:uppercase?])}
+     [react/text {:style      sticky-button-label-style
+                  :uppercase? true}
            label]]]))

--- a/src/status_im/ui/components/styles.cljs
+++ b/src/status_im/ui/components/styles.cljs
@@ -155,10 +155,3 @@
    :flex             1})
 
 (def border-radius 8)
-
-;; TODO(goranjovic): replace all platform conditional uppercase styling with a reference to this var
-(def uppercase?
-  (condp = platform/platform
-    "android" true
-    "ios"     false
-    false))

--- a/src/status_im/ui/components/toolbar/view.cljs
+++ b/src/status_im/ui/components/toolbar/view.cljs
@@ -76,7 +76,7 @@
   [react/text (cond-> {:style      (merge styles/item styles/item-text style
                                           (when disabled? styles/toolbar-text-action-disabled))
                        :on-press   (when-not disabled? handler)
-                       :uppercase? components.styles/uppercase?}
+                       :uppercase? true}
                 accessibility-label
                 (assoc :accessibility-label accessibility-label))
    title])

--- a/src/status_im/ui/screens/discover/components/views.cljs
+++ b/src/status_im/ui/screens/discover/components/views.cljs
@@ -23,7 +23,7 @@
      ;; NOTE(oskarth): text-transform to uppercase not supported as RN style
      ;; https://github.com/facebook/react-native/issues/2088
      [react/text {:style      (styles/title-action-text active?)
-                  :uppercase? (:uppercase? styles/subtitle-text-augment)}
+                  :uppercase? true}
       (i18n/label action-kw)]]]])
 
  ;; TODO(oskarth): Reconcile with above fn
@@ -53,7 +53,8 @@
     [react/view styles/chat-button-inner
       [vector-icons/icon :icons/chats {:color :active}]
       [react/text {:style      styles/chat-button-text
-                   :uppercase? (:uppercase? styles/chat-button-text-case)} (i18n/label :t/chat)]]]])
+                   :uppercase? true}
+       (i18n/label :t/chat)]]]])
 
 (defn discover-list-item [{:keys [message show-separator? current-account contacts]}]
   (let [{contact-name       :name

--- a/src/status_im/ui/screens/discover/styles.cljs
+++ b/src/status_im/ui/screens/discover/styles.cljs
@@ -37,12 +37,6 @@
    :android {:color     styles/color-gray2
              :font-size 14}})
 
-;; NOTE(oskarth): Hacky use of defstyle to get
-;; platform specific styles in place where they belong
-(defstyle subtitle-text-augment
-  {:ios     {:uppercase? false}
-   :android {:uppercase? true}})
-
 (defstyle discover-item-status-text
   {:ios     {:font-size      14
              :letter-spacing -0.1}
@@ -155,12 +149,6 @@
    :padding-left   7
    :padding-right  8
    :padding-bottom 5})
-
-;; NOTE(goranjovic): Another hacky use of defstyle to get
-;; platform specific styles in place where they belong
-(defstyle chat-button-text-case
-  {:ios     {:uppercase? false}
-   :android {:uppercase? true}})
 
 (defstyle chat-button-text
   {:color   styles/color-blue4

--- a/src/status_im/ui/screens/network_settings/network_details/views.cljs
+++ b/src/status_im/ui/screens/network_settings/network_details/views.cljs
@@ -37,7 +37,7 @@
            [react/view {:style               st/connect-button
                         :accessibility-label :network-connect-button}
             [react/text {:style      st/connect-button-label
-                         :uppercase? (get-in platform/platform-specific [:uppercase?])}
+                         :uppercase? true}
              (i18n/label :t/connect)]]
            [react/text {:style st/connect-button-description}
             (i18n/label :t/connecting-requires-login)]]])
@@ -51,7 +51,7 @@
           [react/view st/edit-button-container
            [react/view st/edit-button
             [react/text {:style      st/edit-button-label
-                         :uppercase? (get-in platform/platform-specific [:uppercase?])}
+                         :uppercase? true}
              (i18n/label :t/edit-network-config)]]
            #_[context-menu                                      ; TODO should be implemented later
               [view st/edit-button

--- a/src/status_im/ui/screens/profile/components/views.cljs
+++ b/src/status_im/ui/screens/profile/components/views.cljs
@@ -77,7 +77,7 @@
      (when-not (string/blank? value)
        [react/text {:style           styles/settings-item-value
                     :number-of-lines 1
-                    :uppercase?      components.styles/uppercase?}
+                    :uppercase?      true}
         value])]
     (when active?
       [vector-icons/icon :icons/forward {:color colors/gray}])]])

--- a/src/status_im/ui/screens/profile/group_chat/views.cljs
+++ b/src/status_im/ui/screens/profile/group_chat/views.cljs
@@ -23,7 +23,8 @@
     {:on-press #(re-frame/dispatch [:group-chat-profile/start-editing])}
     [react/view
      [react/text {:style      common.styles/label-action-text
-                  :uppercase? components.styles/uppercase?} (i18n/label :t/edit)]]]])
+                  :uppercase? true}
+      (i18n/label :t/edit)]]]])
 
 (defn group-chat-profile-edit-toolbar []
   [toolbar/toolbar {}

--- a/src/status_im/ui/screens/profile/user/views.cljs
+++ b/src/status_im/ui/screens/profile/user/views.cljs
@@ -30,7 +30,8 @@
      :accessibility-label :edit-button}
     [react/view
      [react/text {:style      common.styles/label-action-text
-                  :uppercase? components.styles/uppercase?} (i18n/label :t/edit)]]]])
+                  :uppercase? true}
+      (i18n/label :t/edit)]]]])
 
 (defn my-profile-edit-toolbar []
   [toolbar/toolbar {}
@@ -80,7 +81,7 @@
    [react/view styles/share-contact-code
     [react/view styles/share-contact-code-text-container
      [react/text {:style      styles/share-contact-code-text
-                  :uppercase? components.styles/uppercase?}
+                  :uppercase? true}
       (i18n/label :t/share-contact-code)]]
     [react/view {:style               styles/share-contact-icon-container
                  :accessibility-label :share-my-contact-code-button}

--- a/src/status_im/ui/screens/wallet/components/views.cljs
+++ b/src/status_im/ui/screens/wallet/components/views.cljs
@@ -47,7 +47,7 @@
       [react/view {:flex-direction :row}
        [react/text {:style styles/text-list-primary-content}
         name]
-       [react/text {:uppercase? true}
+       [react/text {:force-uppercase? true}
         (clojure.core/name symbol)]]
       [list/item-secondary (wallet.utils/format-amount (symbol balance) decimals)]]]]])
 
@@ -207,4 +207,5 @@
 (defn button-text [label]
   [react/text {:style      styles/button-text
                :font       (if platform/android? :medium :default)
-               :uppercase? (get-in platform/platform-specific [:uppercase?])} label])
+               :uppercase? true}
+   label])

--- a/src/status_im/ui/screens/wallet/send/transaction_sent/views.cljs
+++ b/src/status_im/ui/screens/wallet/send/transaction_sent/views.cljs
@@ -30,7 +30,7 @@
         [react/view styles/transaction-details-container
          [react/text {:style      styles/transaction-details
                       :font       (if platform/android? :medium :default)
-                      :uppercase? (get-in platform/platform-specific [:uppercase?])}
+                      :uppercase? true}
           (i18n/label :t/view-transaction-details)]]]
      [components/separator]
      [react/touchable-highlight {:on-press            #(re-frame/dispatch close-transaction-screen-event)
@@ -38,7 +38,7 @@
       [react/view styles/got-it-container
        [react/text {:style      styles/got-it
                     :font       (if platform/android? :medium :default)
-                    :uppercase? (get-in platform/platform-specific [:uppercase?])}
+                    :uppercase? true}
         (i18n/label :t/got-it)]]]]))
 
 (defview transaction-sent-modal []

--- a/src/status_im/ui/screens/wallet/transactions/views.cljs
+++ b/src/status_im/ui/screens/wallet/transactions/views.cljs
@@ -174,7 +174,7 @@
       [list/section-list {:sections (wrap-filter-data filter-data)}]]]))
 
 (defn history-tab [active?]
-  [react/text {:uppercase?          true
+  [react/text {:force-uppercase?    true
                :style               (styles/tab-title active?)
                :accessibility-label :history-button}
    (i18n/label :t/transactions-history)])
@@ -183,7 +183,7 @@
   (letsubs [unsigned-transactions-count [:wallet.transactions/unsigned-transactions-count]]
     [react/view {:flex-direction :row}
      [react/text {:style               (styles/tab-title active?)
-                  :uppercase?          true
+                  :force-uppercase?    true
                   :accessibility-label :unsigned-transactions-button}
       (i18n/label :t/transactions-unsigned)]
      (when (pos? unsigned-transactions-count)


### PR DESCRIPTION
Fixes #3379 

### Summary:
- Remove all of the conditional code using platform specific `:uppercase?`.
- Support this feature inside of the `text` component so that it can be used like this.
```clj
[text {:uppercase? true} "Text"]  ;; for Android
[text {:force-uppercase? true} "Text"] ;; for both ios and Android
```

status: ready