### PR TITLE
[ISSUE #3432] Make sure public chat topic can be fully erased

### DIFF
--- a/src/status_im/ui/screens/add_new/new_public_chat/view.cljs
+++ b/src/status_im/ui/screens/add_new/new_public_chat/view.cljs
@@ -34,7 +34,7 @@
      :on-change-text    #(re-frame/dispatch [:set :public-group-topic %])
      :on-submit-editing #(when topic (re-frame/dispatch [:create-new-public-chat topic]))
      :value             topic
-     :validator         #(re-matches #"[a-z\-]+" %)
+     :validator         #(re-matches #"[a-z\-]*" %)
      :auto-capitalize   :none}]])
 
 (defn- public-chat-icon [topic]


### PR DESCRIPTION

fixes #3432

### Summary:

Allow user to delete full topic name

### Steps to test:
- Open Status
- Create a public chat
- Enter some name, try to erase it

status: ready
