### PR TITLE
Simplify Jenkins files and remove needs for develop branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,10 +28,6 @@ node ('macos1') {
       slackSend color: 'good', message: BRANCH_NAME + '(' + env.CHANGE_BRANCH + ') build started. ' + env.BUILD_URL
 
       checkout scm
-      sh 'git checkout -- .'
-      sh 'git checkout develop'
-      sh 'git checkout remotes/origin/' + BRANCH_NAME
-      sh 'git rebase origin/develop'
 
       sh 'rm -rf node_modules'
       sh 'cp .env.jenkins .env'

--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -28,11 +28,9 @@ node ('macos1'){
 
     stage('Git & Dependencies') {
       slackSend color: 'good', message: 'Nightly build started. ' + env.BUILD_URL
-      git([url: 'https://github.com/status-im/status-react.git', branch: 'develop'])
-      // Checkout master because used for iOS Plist version information
-      sh 'git fetch --tags'
-      sh 'git checkout -- .'
-      sh 'git checkout develop'
+
+      checkout scm
+
       sh 'rm -rf node_modules'
       sh 'cp .env.jenkins .env'
       sh 'lein deps'

--- a/Jenkinsfile.parameters
+++ b/Jenkinsfile.parameters
@@ -26,11 +26,9 @@ node ('macos1') {
 
     stage('Git & Dependencies') {
       slackSend color: 'good', message: REPO + ":" + BRANCH_NAME + ' build started. ' + env.BUILD_URL
-      git([url: 'https://github.com/' + REPO + '/status-react.git', branch: BRANCH_NAME])
-      // Checkout master because used for iOS Plist version information
-      sh 'git checkout -- .'
-      sh 'git checkout develop'
-      sh 'git checkout ' + BRANCH_NAME
+
+      checkout scm
+
       sh 'rm -rf node_modules'
 
       sh 'test ${JENKINS_REBASE_DEVELOP} -eq 1 && git rebase origin/develop || echo "Not rebasing on develop."'

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -30,9 +30,6 @@ node ('macos1'){
       slackSend color: 'good', message: BRANCH_NAME + ' build started. ' + env.BUILD_URL
 
       checkout scm
-      sh 'git checkout -- .'
-      sh 'git checkout remotes/origin/' + BRANCH_NAME
-      sh 'git fetch --tags'
 
       sh 'rm -rf node_modules'
       sh 'cp .env.prod .env'

--- a/ios/scripts/set_xcode_version.sh
+++ b/ios/scripts/set_xcode_version.sh
@@ -6,8 +6,6 @@
 # To use this script in Xcode, add the script's path to a "Run Script" build
 # phase for your application target.
 
-MAIN_GIT_BRANCH="develop"  # status-react uses develop instead of master as the main dev tree
-
 set -o errexit
 set -o nounset
 
@@ -50,30 +48,11 @@ else
     IFS=$OLD_IFS
 fi
 
-# Bundle version (commits-on-master[-until-branch "." commits-on-branch])
-# Assumes that two release branches will not diverge from the same commit on master.
-if [ $(git rev-parse --abbrev-ref HEAD) = "$MAIN_GIT_BRANCH" ]; then
-    MASTER_COMMIT_COUNT=$(git rev-list --count HEAD)
-    BRANCH_COMMIT_COUNT=0
-    BUNDLE_VERSION="$MASTER_COMMIT_COUNT"
-else
-    MASTER_COMMIT_COUNT=$(git rev-list --count $(git rev-list ${MAIN_GIT_BRANCH}.. | tail -n 1)^)
-    BRANCH_COMMIT_COUNT=$(git rev-list --count ${MAIN_GIT_BRANCH}..)
-    if [ $BRANCH_COMMIT_COUNT = 0 ]
-    then BUNDLE_VERSION="$MASTER_COMMIT_COUNT"
-    else BUNDLE_VERSION="${MASTER_COMMIT_COUNT}.${BRANCH_COMMIT_COUNT}"
-    fi
-fi
-
 # For debugging:
 echo "BUILD VERSION: $BUILD_VERSION"
 echo "LATEST_TAG: $LATEST_TAG"
 echo "COMMIT_COUNT_SINCE_TAG: $COMMIT_COUNT_SINCE_TAG"
 echo "SHORT VERSION: $SHORT_VERSION"
-echo "MASTER_COMMIT_COUNT: $MASTER_COMMIT_COUNT"
-echo "BRANCH_COMMIT_COUNT: $BRANCH_COMMIT_COUNT"
-echo "BUNDLE_VERSION: $BUNDLE_VERSION"
 
 /usr/libexec/PlistBuddy -c "Add :CFBundleBuildVersion string $BUILD_VERSION" "$INFO_PLIST" 2>/dev/null || /usr/libexec/PlistBuddy -c "Set :CFBundleBuildVersion $BUILD_VERSION" "$INFO_PLIST"
 /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $SHORT_VERSION" "$INFO_PLIST"
-/usr/libexec/PlistBuddy -c "Set :CFBundleVersion $BUNDLE_VERSION" "$INFO_PLIST"


### PR DESCRIPTION

fixes #3462

### Summary:

Simplify Jenkins files and iOS version setting so that local `develop` checkout is not required anymore

`CFBundleVersion` used to be set to a number of commits : this has been removed (allows to remove the `develop` dependency)

status: ready
