### PR TITLE
[ISSUE #3316] Do not avoid keyboard in wallet/fee screen

### DIFF
--- a/src/status_im/ui/screens/wallet/send/views.cljs
+++ b/src/status_im/ui/screens/wallet/send/views.cljs
@@ -106,10 +106,9 @@
 (defview transaction-fee []
   (letsubs [{:keys [amount symbol] :as transaction} [:wallet.send/transaction]
             edit [:wallet/edit]]
-    (let [gas (or (:gas edit) (:gas transaction))
+    (let [gas       (or (:gas edit) (:gas transaction))
           gas-price (or (:gas-price edit) (:gas-price transaction))]
-      [wallet.components/simple-screen {:avoid-keyboard?     true
-                                        :status-toolbar-type :modal-wallet}
+      [wallet.components/simple-screen {:status-toolbar-type :modal-wallet}
        [toolbar true act/close-white
         (i18n/label :t/wallet-transaction-fee)]
        [react/view components.styles/flex


### PR DESCRIPTION
fixes #3316

### Summary:

Do not avoid keyboard in fee screen. This enforce bottom buttons being at the bottom of the screen

### Steps to test:
- Open Status
- Navigate wallet / send
- Go to advanced / fee screen
- Enter o new fee

status: ready
