### PR TITLE
fix/3509 workaround for permissions callback not working

### DIFF
--- a/src/status_im/chat/events/commands.cljs
+++ b/src/status_im/chat/events/commands.cljs
@@ -47,7 +47,7 @@
                        :params                  jail-params
                        :callback-events-creator (fn [jail-response]
                                                   [[::jail-command-data-response
-                                                    jail-response message opts]])}}) 
+                                                    jail-response message opts]])}})
         {:db (update-in db [:contacts/contacts jail-id :jail-loaded-events]
                         conj [:request-command-message-data message opts])}))))
 
@@ -72,7 +72,6 @@
   (fn [_ [{command-name :name :as command}]]
     (case (keyword command-name)
       :grant-permissions
-      {:dispatch [:request-permissions
-                  [:read-external-storage]
-                  #(re-frame/dispatch [:initialize-geth])]}
+      {:dispatch [:request-permissions {:permissions [:read-external-storage]
+                                        :on-allowed  #(re-frame/dispatch [:initialize-geth])}]}
       (log/debug "ignoring command: " command-name))))

--- a/src/status_im/ui/screens/events.cljs
+++ b/src/status_im/ui/screens/events.cljs
@@ -163,10 +163,8 @@
     (status/should-move-to-internal-storage?
       (fn [should-move?]
         (if should-move?
-          (re-frame/dispatch [:request-permissions
-                              [:read-external-storage]
-                              #(move-to-internal-storage config)
-                              #()])
+          (re-frame/dispatch [:request-permissions {:permissions [:read-external-storage]
+                                                    :on-allowed  #(move-to-internal-storage config)}])
           (status/start-node config))))))
 
 (re-frame/reg-fx
@@ -175,9 +173,9 @@
     (status/module-initialized!)))
 
 (re-frame/reg-fx
-  ::request-permissions-fx
-  (fn [[permissions then else]]
-    (permissions/request-permissions permissions then else)))
+  :request-permissions-fx
+  (fn [options]
+    (permissions/request-permissions options)))
 
 (re-frame/reg-fx
   ::testfairy-alert
@@ -379,8 +377,10 @@
 (handlers/register-handler-fx
   :status-module-initialized
   (fn [{:keys [db]} _]
-    {:db                            (assoc db :status-module-initialized? true)
-     ::status-module-initialized-fx nil}))
+    (merge {:db                            (assoc db :status-module-initialized? true)
+            ::status-module-initialized-fx nil}
+           (when-let [permissions-event @status-im.ui.components.permissions/pending-permissions-event]
+             {:dispatch permissions-event}))))
 
 (handlers/register-handler-fx
   :status-node-started
@@ -401,8 +401,8 @@
 
 (handlers/register-handler-fx
   :request-permissions
-  (fn [_ [_ permissions then else]]
-    {::request-permissions-fx [permissions then else]}))
+  (fn [_ [_ options]]
+    {:request-permissions-fx options}))
 
 (handlers/register-handler-db
   :set-swipe-position

--- a/src/status_im/ui/screens/profile/user/views.cljs
+++ b/src/status_im/ui/screens/profile/user/views.cljs
@@ -43,11 +43,10 @@
     :action #(re-frame/dispatch [:my-profile/update-picture])}
    {:label  (i18n/label :t/image-source-make-photo)
     :action (fn []
-              (re-frame/dispatch [:request-permissions
-                                  [:camera :write-external-storage]
-                                  #(re-frame/dispatch [:navigate-to :profile-photo-capture])
-                                  #(utils/show-popup (i18n/label :t/error)
-                                                     (i18n/label :t/camera-access-error))]))}])
+              (re-frame/dispatch [:request-permissions {:permissions [:camera :write-external-storage]
+                                                        :on-allowed  #(re-frame/dispatch [:navigate-to :profile-photo-capture])
+                                                        :on-denied   #(utils/show-popup (i18n/label :t/error)
+                                                                                        (i18n/label :t/camera-access-error))}]))}])
 
 (defn qr-viewer-toolbar [label value]
   [toolbar/toolbar {}

--- a/src/status_im/ui/screens/qr_scanner/events.cljs
+++ b/src/status_im/ui/screens/qr_scanner/events.cljs
@@ -1,46 +1,32 @@
 (ns status-im.ui.screens.qr-scanner.events
   (:require [re-frame.core :as re-frame]
             [status-im.ui.components.camera :as camera]
-            [status-im.utils.handlers :as u :refer [register-handler]]
+            [status-im.utils.handlers :as handlers]
             [status-im.utils.utils :as utils]
             [status-im.i18n :as i18n]))
 
-(defn set-current-identifier [db [_ identifier handler]]
-  (assoc-in db [:qr-codes identifier] handler))
+(handlers/register-handler-fx
+  :scan-qr-code
+  (fn [{:keys [db]} [_ identifier handler]]
+    {:db (assoc-in db [:qr-codes identifier] handler)
+     :request-permissions-fx {:permissions [:camera]
+                              :on-allowed  #(re-frame/dispatch [:navigate-to :qr-scanner {:current-qr-context identifier}])
+                              :on-denied   #(utils/show-popup (i18n/label :t/error)
+                                                              (i18n/label :t/camera-access-error))}}))
 
-(defn navigate-to-scanner
-  [_ [_ identifier]]
-  (re-frame/dispatch [:request-permissions
-                      [:camera]
-                      #(re-frame/dispatch [:navigate-to :qr-scanner {:current-qr-context identifier}])
-                      #(utils/show-popup (i18n/label :t/error)
-                                         (i18n/label :t/camera-access-error))]))
+(handlers/register-handler-fx
+  :clear-qr-code
+  (fn [{:keys [db]} [_ identifier]]
+    {:db (update db :qr-codes dissoc identifier)}))
 
-(register-handler :scan-qr-code
-  (re-frame/after navigate-to-scanner)
-  set-current-identifier)
-
-(register-handler :clear-qr-code
-  (fn [db [_ identifier]]
-    (update db :qr-codes dissoc identifier)))
-
-(defn- handle-qr-request
-  [db [_ context data]]
-  (when-let [handler (get-in db [:qr-codes context])]
-    (re-frame/dispatch [handler context data])))
-
-(defn clear-qr-request [db [_ context]]
-  (-> db
-      (update :qr-codes dissoc context)
-      (dissoc :current-qr-context)))
-
-(defn navigate-back!
-  [{:keys [view-id]} _]
-  (when (= :qr-scanner view-id)
-    (re-frame/dispatch [:navigate-back])))
-
-(register-handler :set-qr-code
-  (u/handlers->
-    handle-qr-request
-    clear-qr-request
-    navigate-back!))
+(handlers/register-handler-fx
+  :set-qr-code
+  (fn [{:keys [db]} [_ context data]]
+    (let [handler-event       (when-let [handler (get-in db [:qr-codes context])]
+                                [handler context data])
+          navigate-back-event (when (= :qr-scanner (:view-id db))
+                                [:navigate-back])]
+      {:dispatch-n [handler-event navigate-back-event]
+       :db (-> db
+               (update :qr-codes dissoc context)
+               (dissoc :current-qr-context))})))

--- a/src/status_im/ui/screens/wallet/components/views.cljs
+++ b/src/status_im/ui/screens/wallet/components/views.cljs
@@ -148,8 +148,8 @@
   [choose-recipient/choose-recipient])
 
 (defn- request-camera-permissions []
-  (re-frame/dispatch [:request-permissions [:camera]
-                      #(re-frame/dispatch [:navigate-to :recipient-qr-code])]))
+  (re-frame/dispatch [:request-permissions {:permissions [:camera]
+                                            :on-allowed  #(re-frame/dispatch [:navigate-to :recipient-qr-code])}]))
 
 (defn- on-choose-recipient [contact-only?]
   (list-selection/show {:title   (i18n/label :t/wallet-choose-recipient)

--- a/src/status_im/utils/handlers.clj
+++ b/src/status_im/utils/handlers.clj
@@ -1,22 +1,5 @@
 (ns status-im.utils.handlers)
 
-(defmacro handlers->
-  "Help thread multiple handler functions.
-   All functions are expected to accept [db event] as parameters.
-   If one handler returns a modified db it will be used as parameters for subsequent handlers."
-  [& forms]
-  (let [db     (gensym "db")
-        event  (gensym "event")
-        new-db (gensym "new-db")]
-    `(fn [~db ~event]
-       (let [~@(interleave (repeat db)
-                           (map (fn [form]
-                                  `(let [~new-db (~form ~db ~event)]
-                                     (if (map? ~new-db)
-                                       ~new-db
-                                       ~db))) forms))]
-         ~db))))
-
 (defmacro merge-fx*
   "This macro is called recursively from merge-fx
   It wraps each form in a let binding that captures


### PR DESCRIPTION
Fixes #3509 

This is a workaround to get a callback for the permission request on android. 

When prompting the user for a permission request the promise never executes the  `.then` however there is a `status-module-initialized` event that is triggered when the user grants or denies the permissions.
So we reset this atom in `request-permissions` for android and if it is not `nil` we dispatch it in the `:status-module-initialized` event this time `.then` will be called. 
If the user denies he will be asked a second time but it is better than nothing happening when the user accepts.

To fix definitively: find out why the promise doesn't executes it's then the first time, might have something to do with the fact that the app is apparently resumed once the user responds to the pop-up (that's what triggers status-module-initialized event)

I also cleaned up the last `handlers->` macro usage

status: ready
