### PR TITLE
Integrate re-frame-10x for tracing/debugging

### DIFF
--- a/figwheel-bridge.js
+++ b/figwheel-bridge.js
@@ -211,7 +211,11 @@ function loadApp(platform, devHost, onLoadCb) {
                 // This is needed because of RN packager
                 // seriously React packager? why.
                 var googreq = goog.require;
-
+                // NOTE: :closure-defines is not working with RN
+                goog.global.CLOSURE_UNCOMPILED_DEFINES = {
+                    "re_frame.trace.trace_enabled_QMARK_":true,
+                    "day8.re_frame.tracing.trace_enabled_QMARK_": true
+                };
                 googreq(`env.${platform}.main`);
             });
         });

--- a/project.clj
+++ b/project.clj
@@ -6,13 +6,13 @@
                  [org.clojure/clojurescript "1.9.946"]
                  [org.clojure/core.async "0.4.474"]
                  [reagent "0.7.0" :exclusions [cljsjs/react cljsjs/react-dom cljsjs/react-dom-server cljsjs/create-react-class]]
-                 [status-im/re-frame "0.10.2"]
+                 [status-im/re-frame "0.10.5"]
                  [com.andrewmcveigh/cljs-time "0.5.2"]
                  [com.taoensso/timbre "4.10.0"]
                  [hickory "0.7.1"]
                  [com.cognitect/transit-cljs "0.8.243"]]
   :plugins [[lein-cljsbuild "1.1.7"]
-            [lein-re-frisk "0.5.6"]]
+            [lein-re-frisk "0.5.7"]]
   :clean-targets ["target/" "index.ios.js" "index.android.js"]
   :aliases {"prod-build"         ^{:doc "Recompile code with prod profile."}
             ["do" "clean"
@@ -53,8 +53,9 @@
                                        :timeout          240000}}
              :figwheel [:dev
                         {:dependencies [[figwheel-sidecar "0.5.14"]
-                                        [re-frisk-remote "0.5.4"]
-                                        [re-frisk-sidecar "0.5.5"]
+                                        [re-frisk-remote "0.5.5"]
+                                        [re-frisk-sidecar "0.5.6"]
+                                        [day8.re-frame/tracing "0.5.0"]
                                         [hawk "0.2.11"]]
                          :source-paths ["src" "env/dev" "react-native/src" "components/src"]}]
              :test     {:dependencies [[day8.re-frame/test "0.1.5"]]


### PR DESCRIPTION
Fixes https://github.com/flexsurfer/re-frisk-remote/issues/7
Fixes https://github.com/status-im/status-react/issues/3082
Fixes https://github.com/status-im/status-react/issues/3085
### Summary:

Brings re-frame-10x integration.

### Changes

- Update re-frisk-remote and re-frisk-sidecar
- Use re-frame 0.10.5 as required by re-frame-10x
- Enable re-frame tracing by adding hack to figwheel-bridge.js as there is no :closure-defines support in RN yet
- Add support for event handler step-by-step debug/tracing https://github.com/Day8/re-frame-debux#show-me

### Steps to test:
- Run Status in dev mode
- Add `:enable-re-frame-10x? true` option to `enable-re-frisk-remote!` fn call (go to `env.android.main` or `env.ios.main` depending on your preference) (re-frame-10x is disabled by default due to perfomance implications)
- Go to http://localhost:4567/10x

Detailed instructions on how to enable it https://gist.github.com/dmitryn/d97f05a0ff2a653d07d696daa4880ad1

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready
