### PR TITLE
[Fix #3369] Migrate checkboxes to native widget

### DIFF
--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -1,5 +1,5 @@
 <resources>
-    <color name="primary">#7099e6</color>
+    <color name="primary">#4360df</color>
     <color name="primary_dark">#5c6bc0</color>
     <color name="accent">#5c6bc0</color>
 </resources>

--- a/src/status_im/ui/components/checkbox/view.cljs
+++ b/src/status_im/ui/components/checkbox/view.cljs
@@ -1,13 +1,15 @@
 (ns status-im.ui.components.checkbox.view
   (:require [status-im.ui.components.checkbox.styles :as styles]
-            [status-im.ui.components.react :as react]))
-
-;; TODO(jeluard) Migrate to native checkbox provided by RN 0.49
-;; https://facebook.github.io/react-native/docs/checkbox.html
+            [status-im.ui.components.react :as react]
+            [status-im.utils.platform :as platform]))
 
 (defn checkbox [{:keys [on-value-change checked?]}]
-  [react/touchable-highlight (merge {:style styles/wrapper}
-                                    (when on-value-change {:on-press #(on-value-change (not checked?))}))
-   [react/view (styles/icon-check-container checked?)
-    (when checked?
-      [react/icon :check_on styles/check-icon])]])
+  (if platform/android?
+    [react/view {:style styles/wrapper}
+     [react/check-box {:on-value-change on-value-change
+                       :value           checked?}]]
+    [react/touchable-highlight (merge {:style styles/wrapper}
+                                      (when on-value-change {:on-press #(on-value-change (not checked?))}))
+     [react/view (styles/icon-check-container checked?)
+      (when checked?
+        [react/icon :check_on styles/check-icon])]]))

--- a/src/status_im/ui/components/react.cljs
+++ b/src/status_im/ui/components/react.cljs
@@ -46,6 +46,7 @@
 (def text-class (get-class "Text"))
 (def text-input-class (get-class "TextInput"))
 (def image (get-class "Image"))
+(def check-box (get-class "CheckBox"))
 
 (def touchable-without-feedback (get-class "TouchableWithoutFeedback"))
 (def touchable-highlight-class (get-class "TouchableHighlight"))


### PR DESCRIPTION
fixes #3369 

### Summary:

OK, this is quite a simple task. But I guess the native checkboxes cannot be styled. Not sure if they fit well in the design now.

![screenshot from 2018-03-05 23-37-39](https://user-images.githubusercontent.com/4666757/37003852-6a1f4248-2109-11e8-8ddf-9ea9a3c0a0a5.png)


status: ready <!-- Can be ready or wip -->
