### PR TITLE
Add setup and full-prod-build targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,9 @@ HELP_FUN = \
 
 # Main targets
 
+setup: ##@prepare Install all the requirements for status-react
+	./scripts/setup
+
 prepare: ##@prepare Install dependencies and prepare workspace
 	lein deps
 	npm install
@@ -49,6 +52,11 @@ release-ios: prod-build-ios ##@build build release for iOS release
 
 prod-build:
 	lein prod-build
+
+full-prod-build: ##@build build prod for both Android and iOS
+	./scripts/bundle-status-go.sh ios
+	./scripts/bundle-status-go.sh android
+	$(MAKE) prod-build
 
 prod-build-android:
 	lein prod-build-android


### PR DESCRIPTION


### Summary:
[comment]: # (Summarise the problem and how the pull request solves it)
In order to have a working status-react both for android and iOS easily, the `setup` target calls `scripts/setup` and `full-prod-build` calls `scripts/bundle-status-go.sh` both for iOS and Android, and then triggers `prod-build`.

### Review notes (optional):
Since `scripts/bundle-status-go.sh` requires `STATUS_GO_HOME` and `STATUS_REACT_HOME` these environment variables must be defined before calling `make full-prod-build`.

### Steps to test:
- go to status-react path
- set up required environment variables
- run `make setup && make full-prod-build`

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->