### PR TITLE
Update `status-go` go `gaabbcbe5`.

### DIFF
--- a/modules/react-native-status/android/build.gradle
+++ b/modules/react-native-status/android/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     implementation 'com.github.ericwlange:AndroidJSCore:3.0.1'
     implementation 'status-im:function:0.0.1'
 
-    String statusGoVersion = 'develop-gabb5df88'
+    String statusGoVersion = 'develop-gaabbcbe5'
     final String statusGoGroup = 'status-im', statusGoName = 'status-go'
 
     // Check if the local status-go jar exists, and compile against that if it does

--- a/modules/react-native-status/ios/RCTStatus/pom.xml
+++ b/modules/react-native-status/ios/RCTStatus/pom.xml
@@ -25,7 +25,7 @@
                         <artifactItem>
                             <groupId>status-im</groupId>
                             <artifactId>status-go-ios-simulator</artifactId>
-                            <version>develop-gabb5df88</version>
+                            <version>develop-gaabbcbe5</version>
                             <type>zip</type>
                             <overWrite>true</overWrite>
                             <outputDirectory>./</outputDirectory>


### PR DESCRIPTION
DiscV5 discovery protocol is controlled by the same config flag as
a regular discovery.
Should theoretically consume less energy and less CPU than the "normal" version.

Part of https://github.com/status-im/ideas/issues/83

status: ready