### PR TITLE
[#3478]: Buttons are to close to status bar on Edit profile for group chat

### DIFF
--- a/src/status_im/ui/screens/profile/group_chat/views.cljs
+++ b/src/status_im/ui/screens/profile/group_chat/views.cljs
@@ -8,6 +8,7 @@
             [status-im.ui.components.list.views :as list]
             [status-im.ui.components.colors :as colors]
             [status-im.ui.components.styles :as components.styles]
+            [status-im.ui.components.status-bar.view :as status-bar]
             [status-im.ui.components.toolbar.view :as toolbar]
             [re-frame.core :as re-frame]
             [status-im.ui.components.common.styles :as common.styles]
@@ -98,6 +99,7 @@
     (let [shown-chat (merge current-chat changed-chat)
           admin?     (= current-pk group-admin)]
       [react/view profile.components.styles/profile
+       [status-bar/status-bar]
        (if editing?
          [group-chat-profile-edit-toolbar]
          [group-chat-profile-toolbar])


### PR DESCRIPTION
Fixes #3478 by adding a status bar to group chat info/settings.