### PR TITLE
cli clojurescript build

### DIFF
--- a/cli/status_im/cli/core.cljs
+++ b/cli/status_im/cli/core.cljs
@@ -1,0 +1,12 @@
+(ns status-im.cli.core
+  (:require [cljs.nodejs :as nodejs]
+            [status-im.utils.name :as name]))
+
+(nodejs/enable-util-print!)
+
+(defn -main [& args]
+  (println (str "Hello world! args: " args))
+  ;; just to show that we can use status-im.utils.* namespaces
+  (println (name/shortened-name "Verylongnameazazazazazazazaz" 5)))
+
+(set! *main-cli-fn* -main)

--- a/project.clj
+++ b/project.clj
@@ -27,7 +27,8 @@
             "figwheel-repl"      ["with-profile" "+figwheel" "run" "-m" "clojure.main" "env/dev/run.clj"]
             "test-cljs"          ["with-profile" "test" "doo" "node" "test" "once"]
             "test-protocol"      ["with-profile" "test" "doo" "node" "protocol" "once"]
-            "test-env-dev-utils" ["with-profile" "test" "doo" "node" "env-dev-utils" "once"]}
+            "test-env-dev-utils" ["with-profile" "test" "doo" "node" "env-dev-utils" "once"]
+            "compile-cli"        ["with-profile""dev" "cljsbuild" "auto" "cli"]}
   :profiles {:dev      {:dependencies [[com.cemerick/piggieback "0.2.2"]]
                         :cljsbuild    {:builds
                                        {:ios
@@ -42,7 +43,16 @@
                                                             :main          "env.android.main"
                                                             :output-dir    "target/android"
                                                             :optimizations :none}
-                                         :warning-handlers [status-im.utils.build/warning-handler]}}}
+                                         :warning-handlers [status-im.utils.build/warning-handler]}
+
+                                        :cli
+                                        {:source-paths ["src" "cli"],
+                                         :compiler     {:main          status-im.cli.core,
+                                                        :output-to     "target/cli/index.js",
+                                                        :output-dir    "target/cli",
+                                                        :optimizations :advanced,
+                                                        :target        :nodejs,
+                                                        :pretty-print  true}}}}
                         :repl-options {:nrepl-middleware [cemerick.piggieback/wrap-cljs-repl]
                                        :timeout          240000}}
              :figwheel [:dev


### PR DESCRIPTION
1. run `lein compile-cli` in one tab, wait for compilation 
2. and try `node target/cli/index.js arg1 arg2` in another
3. see output
```
Hello world! args ("arg1" "arg2")
Veryl...
```

further steps: adding figwheel support https://github.com/bhauman/lein-figwheel/wiki/Node.js-development-with-figwheel

status: ready 
