### PR TITLE
[#3520] Allow adding/chatting with contacts from public chats

### DIFF
--- a/src/status_im/chat/screen.cljs
+++ b/src/status_im/chat/screen.cljs
@@ -24,7 +24,7 @@
             pending-contact? [:current-contact :pending?]]
     (when pending-contact?
       [react/touchable-highlight
-       {:on-press #(re-frame/dispatch [:add-pending-contact chat-id])}
+       {:on-press #(re-frame/dispatch [:add-contact chat-id])}
        [react/view style/add-contact
         [react/text {:style style/add-contact-text}
          (i18n/label :t/add-to-contacts)]]])))

--- a/src/status_im/ui/screens/contacts/subs.cljs
+++ b/src/status_im/ui/screens/contacts/subs.cljs
@@ -98,10 +98,15 @@
     (->> (remove :pending? (vals groups))
          (sort-by :order >))))
 
-(reg-sub :contact
+(reg-sub :current-contact-identity
   (fn [db]
-    (let [identity (:contacts/identity db)]
-      (get-in db [:contacts/contacts identity]))))
+    (:contacts/identity db)))
+
+(reg-sub :contact
+  :<- [:get-contacts]
+  :<- [:current-contact-identity]
+  (fn [[contacts identity]]
+    (contacts identity)))
 
 (reg-sub :contact-by-identity
   (fn [db [_ identity]]

--- a/src/status_im/ui/screens/profile/contact/views.cljs
+++ b/src/status_im/ui/screens/profile/contact/views.cljs
@@ -7,6 +7,7 @@
             [status-im.ui.components.status-bar.view :as status-bar]
             [status-im.i18n :as i18n]
             [re-frame.core :as re-frame]
+            [status-im.utils.contacts :as utils.contacts]
             [status-im.ui.components.toolbar.view :as toolbar]
             [status-im.ui.components.list.views :as list]))
 
@@ -19,7 +20,7 @@
   (concat (if pending?
             [{:label  (i18n/label :t/add-to-contacts)
               :icon   :icons/add-contact
-              :action #(re-frame/dispatch [:add-pending-contact chat-id])}]
+              :action #(re-frame/dispatch [:add-contact whisper-identity])}]
             [{:label     (i18n/label :t/in-contacts)
               :icon      :icons/in-contacts
               :disabled? true}])
@@ -52,19 +53,21 @@
    [profile-info-contact-code-item whisper-identity]])
 
 (defview profile []
-  (letsubs [contact [:contact]
+  (letsubs [identity        [:current-contact-identity]
+            maybe-contact   [:contact]
             chat-id [:get :current-chat-id]]
-    [react/view profile.components.styles/profile
-     [status-bar/status-bar]
-     [profile-contact-toolbar]
-     [react/scroll-view
-      [react/view profile.components.styles/profile-form
-       [profile.components/profile-header contact false false nil nil]]
-      [list/action-list (actions contact chat-id)
-       {:container-style        styles/action-container
-        :action-style           styles/action
-        :action-label-style     styles/action-label
-        :action-separator-style styles/action-separator
-        :icon-opts              styles/action-icon-opts}]
-      [react/view styles/contact-profile-info-container
-       [profile-info contact]]]]))
+    (let [contact (or maybe-contact (utils.contacts/whisper-id->new-contact identity))]
+      [react/view profile.components.styles/profile
+       [status-bar/status-bar]
+       [profile-contact-toolbar]
+       [react/scroll-view
+        [react/view profile.components.styles/profile-form
+         [profile.components/profile-header contact false false nil nil]]
+        [list/action-list (actions contact chat-id)
+         {:container-style        styles/action-container
+          :action-style           styles/action
+          :action-label-style     styles/action-label
+          :action-separator-style styles/action-separator
+          :icon-opts              styles/action-icon-opts}]
+        [react/view styles/contact-profile-info-container
+         [profile-info contact]]]])))

--- a/src/status_im/utils/contacts.cljs
+++ b/src/status_im/utils/contacts.cljs
@@ -1,0 +1,10 @@
+(ns status-im.utils.contacts
+  (:require
+    [status-im.utils.identicon :as identicon]
+    [status-im.utils.gfycat.core :as gfycat]))
+
+(defn whisper-id->new-contact [whisper-id]
+  {:name             (gfycat/generate-gfy whisper-id)
+   :photo-path       (identicon/identicon whisper-id)
+   :pending?         true
+   :whisper-identity whisper-id})

--- a/test/cljs/status_im/test/contacts/events.cljs
+++ b/test/cljs/status_im/test/contacts/events.cljs
@@ -110,7 +110,7 @@
    contact-request-received (update-contact, watch-contact ;TODO :update-chat!)
    contact-update-received (update-contact ;TODO :update-chat!)
    hide-contact (update-contact ;TODO :account-update-keys)
-   add-contact-handler (add-pending-contact, status-im.contacts.events/add-new-contact
+   add-contact-handler (add-contact, status-im.contacts.events/add-new-contact
                         status-im.contacts.events/send-contact-request ;TODO :discoveries-send-portions)
 
    create-new-contact-group
@@ -241,7 +241,8 @@
     (def new-contact {:name ""
                       :photo-path ""
                       :whisper-identity new-contact-public-key
-                      :address new-contact-address})
+                      :address new-contact-address
+                      :pending? false})
     (def contact (rf/subscribe [:contact-by-identity new-contact-public-key]))
     (def current-chat-id (rf/subscribe [:get-current-chat-id]))
 
@@ -338,11 +339,11 @@
         (is (= (assoc received-contact2 :pending? true)
                (get @contacts new-contact-public-key)))))
 
-    (testing ":add-contact-handler event - :add-pending-contact"
+    (testing ":add-contact-handler event - :add-contact"
 
       ;; :add-contact-handler event dispatches next 4 events
       ;;
-      ;; :add-pending-contact
+      ;; :add-contact
       ;; :status-im.contacts.events/add-new-contact
       ;; :status-im.contacts.events/send-contact-request
       ;;TODO :discoveries-send-portions


### PR DESCRIPTION
fixes #3520 

### Summary:

When trying to add a user to a chat that is neither pending nor already in the contacts, it throws an error as it cannot find its details.

To avoid this I have changed the code so that it falls back on generating the profile if not in the contacts map.

I have also rationalized the code for adding a contact, it seems like adding a pending or a new contact where doing pretty much the same.

I understand @goranjovic you worked on public chat, do you mind having a look at this and provide some feedback? 

thanks

status: ready
