### PR TITLE
Add start-dev command in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,3 +125,14 @@ android-ports: ##@other Add reverse proxy to Android Device/Simulator
 	adb reverse tcp:8081 tcp:8081
 	adb reverse tcp:3449 tcp:3449
 	adb reverse tcp:4567 tcp:4567
+
+startdev-%:
+	$(eval SYSTEM := $(word 2, $(subst -, , $@)))
+	$(eval DEVICE := $(word 3, $(subst -, , $@)))
+	if [[ "$(SYSTEM)" == "android" ]]; then\
+	  ${MAKE} prepare && ${MAKE} android-ports; \
+	else \
+	  ${MAKE} prepare-ios; \
+	fi
+	${MAKE} dev-$(SYSTEM)-$(DEVICE)
+	${MAKE} -j3 react-native repl-$(SYSTEM) run-$(SYSTEM)


### PR DESCRIPTION
### Summary:

I have added a `start-dev` command to start up the stack in a single go.

Usage would be:

`make start-dev` which will default to `android` and `avd` emulator.

To override the default you can do:

`make start-dev -e SYSTEM=ios` for ios
or
`make start-dev -e EMULATOR=real` for android real
`make start-dev -e EMULATOR=genymotion` for genymotion

@yenda this should be pretty much as discussed, would you mind trying it out? 

I have only tested on android platform, as I don't have a mac.

It also does not start the emulator for you, as that's very much platform dependent.
I can update the wiki if merged.

status: ready
