### PR TITLE
Add :elide-asserts compiler option for release builds

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -87,6 +87,7 @@
                                                          :optimizations      :simple
                                                          :closure-defines    {"goog.DEBUG" false}
                                                          :parallel-build     false
+                                                         :elide-asserts      true
                                                          :language-in        :ecmascript5}
                                       :warning-handlers [status-im.utils.build/warning-handler]}
                                      :android
@@ -99,5 +100,6 @@
                                                          :optimizations      :simple
                                                          :closure-defines    {"goog.DEBUG" false}
                                                          :parallel-build     false
+                                                         :elide-asserts      true
                                                          :language-in        :ecmascript5}
                                       :warning-handlers [status-im.utils.build/warning-handler]}}}}})


### PR DESCRIPTION
Based on discussions https://github.com/status-im/status-react/pull/3507#issuecomment-371089673

Removes all asserts calls including `:pre` and `:post` condition checks for release builds.
https://cljs.github.io/api/compiler-options/elide-asserts

status: ready
