### PR TITLE
[Fix #3572] regx parse string bug in formatted texts

### DIFF
--- a/src/status_im/chat/views/message/message.cljs
+++ b/src/status_im/chat/views/message/message.cljs
@@ -103,7 +103,7 @@
 (defn- parse-str-regx [string regx matched-fn unmatched-fn]
   (if (string? string)
     (let [unmatched-text (as-> (->> (string/split string regx)
-                                    (remove empty?)
+                                    (remove nil?)
                                     vec) $
                            (if (zero? (count $))
                              [nil]

--- a/test/cljs/status_im/test/chat/views/message.cljs
+++ b/test/cljs/status_im/test/chat/views/message.cljs
@@ -3,13 +3,16 @@
             [status-im.chat.views.message.message :as message]))
 
 (deftest parse-url
-  (is (= (lazy-seq [nil {:text "www.google.com" :url? true}])
+  (is (= (lazy-seq [{:text "" :url? false}
+                    {:text "www.google.com" :url? true}])
          (message/parse-url "www.google.com")))
-  (is (= (lazy-seq [nil {:text "status.im" :url? true}])
+  (is (= (lazy-seq [{:text "" :url? false}
+                    {:text "status.im" :url? true}])
          (message/parse-url "status.im")))
   (is (= (lazy-seq [{:text "$33.90" :url? false} nil])
          (message/parse-url "$33.90")))
-  (is (= (lazy-seq [nil {:text "https://www.google.com/?gfe_rd=cr&dcr=0&ei=P9-CWuyBGaro8AeqkYGQDQ&gws_rd=cr&fg=1" :url? true}])
+  (is (= (lazy-seq [{:text "" :url? false}
+                    {:text "https://www.google.com/?gfe_rd=cr&dcr=0&ei=P9-CWuyBGaro8AeqkYGQDQ&gws_rd=cr&fg=1" :url? true}])
          (message/parse-url "https://www.google.com/?gfe_rd=cr&dcr=0&ei=P9-CWuyBGaro8AeqkYGQDQ&gws_rd=cr&fg=1")))
   (is (= (lazy-seq [{:text "Status - " :url? false}
                     {:text "https://github.com/status-im/status-react" :url? true}


### PR DESCRIPTION
### Summary:
Fix  #3572
This bug was introduced in #3299 while trying to make `parse-str-regx` support regx with multiple sub-matches like that for URL. `string/split` could return a list of matches with multiple `nil` values, we should filter out `nil` but keep empty string "" as is.

status: ready <!-- Can be ready or wip -->
