### PR TITLE
[#3582] No "Add to contact" button when conversation was started from public chat

### DIFF
--- a/src/status_im/chat/screen.cljs
+++ b/src/status_im/chat/screen.cljs
@@ -37,7 +37,8 @@
 (defview add-contact-bar []
   (letsubs [chat-id          [:get-current-chat-id]
             pending-contact? [:current-contact :pending?]]
-    (when pending-contact?
+    (when (or (nil? pending-contact?) ; user not in contact list
+              pending-contact?)
       [react/touchable-highlight
        {:on-press #(re-frame/dispatch [:add-contact chat-id])}
        [react/view style/add-contact
@@ -59,7 +60,7 @@
       [toolbar/actions [{:icon      :icons/options
                          :icon-opts {:color :black}
                          :handler   #(on-options chat-id name group-chat public?)}]]]
-     [add-contact-bar]]))
+     (when-not (or public? group-chat) [add-contact-bar])]))
 
 (defmulti message-row (fn [{{:keys [type]} :row}] type))
 


### PR DESCRIPTION
Fixes #3582 

### Summary:

When in a 1-to-1 with a user not in the contact list we don't check whether the contact is not existing, we only checked whether is was `pending?`. This PR adds a check to also show the message when the contact does not exist.

status: ready
