### PR TITLE
[TESTS #3282] Added sanity automation tests for chats deletion

### DIFF
--- a/test/appium/tests/test_dapps_and_browsing.py
+++ b/test/appium/tests/test_dapps_and_browsing.py
@@ -21,3 +21,4 @@ class TestDappsAnsBrowsing(SingleDeviceTestCase):
         browsing_view.back_to_home_button.click()
 
         assert home_view.first_chat_element_title.text == 'Status | The Mobile Ethereum Client'
+        home_view.swipe_and_delete_chat('Status | The Mobile Ethereum Client')

--- a/test/appium/tests/test_messaging.py
+++ b/test/appium/tests/test_messaging.py
@@ -76,16 +76,11 @@ class TestMessages(MultipleDeviceTestCase):
             web_view.find_full_text('Browse, chat and make payments securely on the decentralized web.')
             device_1_chat.back_button.click()
 
-        device_1_chat.chat_options.click()
-        device_1_chat.delete_chat_button.click()
-        device_1_chat.delete_button.click()
-        if not device_1_home.plus_button.is_element_present() or \
-                device_1_chat.element_by_text_part(device_2_username[:25]).is_element_present():
-            self.errors.append('Chat was not deleted')
+        device_1_chat.delete_chat(device_2_username[:25], self.errors)
         self.verify_no_errors()
 
     @pytest.mark.pr
-    def test_group_chat_messages(self):
+    def test_group_chat_messages_and_delete_chat(self):
         self.create_drivers(3)
 
         device_1, device_2, device_3 = \
@@ -137,12 +132,12 @@ class TestMessages(MultipleDeviceTestCase):
 
         chat_1.chat_message_input.send_keys(unicode_text_message)
         chat_1.send_message_button.click()
-        for home in home_2, home_3:
-            home.element_by_text(chat_name, 'button').click()
 
-        chat_2, chat_3 = home_2.get_chat_view(), home_3.get_chat_view()
         for chat in chat_2, chat_3:
             chat.wait_for_messages_by_user(username_1, unicode_text_message, self.errors)
+
+        for chat in chat_1, chat_2, chat_3:
+            chat.delete_chat(chat_name, self.errors)
 
         self.verify_no_errors()
 
@@ -176,4 +171,6 @@ class TestMessages(MultipleDeviceTestCase):
         chat_2.send_as_keyevent(message_with_new_line)
         chat_2.send_message_button.click()
         chat_1.wait_for_messages_by_user(users[1], messages_to_receive_2, self.errors)
+        for chat in chat_1, chat_2:
+            chat.delete_chat(chat_name, self.errors)
         self.verify_no_errors()

--- a/test/appium/views/base_view.py
+++ b/test/appium/views/base_view.py
@@ -128,6 +128,12 @@ class DoneButton(BaseButton):
             "//android.widget.TextView[@text='DONE']")
 
 
+class DeleteButton(BaseButton):
+    def __init__(self, driver):
+        super(DeleteButton, self).__init__(driver)
+        self.locator = self.Locator.xpath_selector("//android.widget.Button[@text='Delete']")
+
+
 class AppsButton(BaseButton):
     def __init__(self, driver):
         super(AppsButton, self).__init__(driver)

--- a/test/appium/views/chat_view.py
+++ b/test/appium/views/chat_view.py
@@ -192,3 +192,12 @@ class ChatView(BaseView):
         send_transaction = self.get_send_transaction_view()
         self.send_message_button.click_until_presence_of_element(send_transaction.sign_transaction_button)
         send_transaction.sign_transaction(sender_password)
+
+    def delete_chat(self, chat_name: str, errors: list):
+        self.chat_options.click()
+        self.delete_chat_button.click()
+        self.delete_button.click()
+        from views.home_view import HomeView
+        if not HomeView(self.driver).plus_button.is_element_present() or \
+                self.element_by_text(chat_name).is_element_present():
+            errors.append('Chat was not deleted')

--- a/test/appium/views/home_view.py
+++ b/test/appium/views/home_view.py
@@ -8,8 +8,7 @@ from views.base_view import BaseView
 class PlusButton(BaseButton):
     def __init__(self, driver):
         super(PlusButton, self).__init__(driver)
-        self.locator = self.Locator.xpath_selector(
-            "//*[@text='+']")
+        self.locator = self.Locator.xpath_selector("//*[@text='+']")
 
     def navigate(self):
         from views.start_new_chat_view import StartNewChatView
@@ -31,6 +30,16 @@ class ChatElement(BaseButton):
     def navigate(self):
         from views.chat_view import ChatView
         return ChatView(self.driver)
+
+    @property
+    def swipe_delete_button(self):
+        class DeleteButton(BaseButton):
+            def __init__(self, driver, parent_locator: str):
+                super(DeleteButton, self).__init__(driver)
+                locator_str = "/../../following-sibling::*[1][name()='android.view.ViewGroup']/*[@content-desc='icon']"
+                self.locator = self.Locator.xpath_selector(parent_locator + locator_str)
+
+        return DeleteButton(self.driver, self.locator.value)
 
 
 class FirstChatElementTitle(BaseText):
@@ -99,3 +108,12 @@ class HomeView(BaseView):
         public_key = profile_view.get_text_from_qr()
         profile_view.cross_icon.click()
         return public_key
+
+    def swipe_and_delete_chat(self, chat_name: str):
+        chat_element = self.get_chat_with_user(chat_name)
+        location = chat_element.find_element().location
+        x, y = location['x'], location['y']
+        size = chat_element.find_element().size
+        width, height = size['width'], size['height']
+        self.driver.swipe(start_x=x + width / 2, start_y=y + height / 2, end_x=x, end_y=y + height / 2)
+        chat_element.swipe_delete_button.click()


### PR DESCRIPTION
## Summary:
Added tests for messaging and chat management requested in #3282:

- C2086 | Can delete group chat
- C2087 | Can delete "Dapp", "any opened link" chat - currently disabled till respective PR is merged
- Can delete public chat
