### PR TITLE
Use whisper-id when in profile to navigate to chat

### DIFF
--- a/src/status_im/ui/screens/profile/contact/views.cljs
+++ b/src/status_im/ui/screens/profile/contact/views.cljs
@@ -16,7 +16,7 @@
    toolbar/default-nav-back
    [toolbar/content-title ""]])
 
-(defn actions [{:keys [pending? whisper-identity dapp?]} chat-id]
+(defn actions [{:keys [pending? whisper-identity dapp?]}]
   (concat (if pending?
             [{:label  (i18n/label :t/add-to-contacts)
               :icon   :icons/add-contact
@@ -30,7 +30,7 @@
           (when-not dapp?
             [{:label  (i18n/label :t/send-transaction)
               :icon   :icons/arrow-right
-              :action #(re-frame/dispatch [:profile/send-transaction chat-id whisper-identity])}])))
+              :action #(re-frame/dispatch [:profile/send-transaction whisper-identity])}])))
 
 (defn profile-info-item [{:keys [label value options accessibility-label]}]
   [react/view styles/profile-info-item
@@ -54,8 +54,7 @@
 
 (defview profile []
   (letsubs [identity        [:current-contact-identity]
-            maybe-contact   [:contact]
-            chat-id [:get :current-chat-id]]
+            maybe-contact   [:contact]]
     (let [contact (or maybe-contact (utils.contacts/whisper-id->new-contact identity))]
       [react/view profile.components.styles/profile
        [status-bar/status-bar]
@@ -63,7 +62,7 @@
        [react/scroll-view
         [react/view profile.components.styles/profile-form
          [profile.components/profile-header contact false false nil nil]]
-        [list/action-list (actions contact chat-id)
+        [list/action-list (actions contact)
          {:container-style        styles/action-container
           :action-style           styles/action
           :action-label-style     styles/action-label

--- a/src/status_im/ui/screens/profile/events.cljs
+++ b/src/status_im/ui/screens/profile/events.cljs
@@ -27,12 +27,11 @@
 
 (handlers/register-handler-fx
   :profile/send-transaction
-  [re-frame/trim-v]
+  [(re-frame/inject-cofx :get-stored-chat) re-frame/trim-v]
   (fn [{{:contacts/keys [contacts] :as db} :db :as cofx} [chat-id]]
-    (let [send-command (get-in contacts chat-const/send-command-ref)]
-      (-> (chat-events/navigate-to-chat cofx chat-id)
-          (as-> fx
-              (merge fx (input-events/select-chat-input-command (:db fx) send-command nil true)))))))
+    (let [send-command (get-in contacts chat-const/send-command-ref)
+          fx (chat-events/start-chat chat-id true cofx)]
+      (merge fx (input-events/select-chat-input-command (:db fx) send-command nil true)))))
 
 (defn get-current-account [{:accounts/keys [current-account-id] :as db}]
   (get-in db [:accounts/accounts current-account-id]))


### PR DESCRIPTION
fixes #3580 

### Summary:

When the user clicks on Sent transaction, we should use `whisper-id` instead of `chat-id`, as `chat-id` might be from a public or group chat.

I have also fixed a small issue with the navigation history. ( If you click on sent-transaction from the profile you would have to click twice on back to go to the home screen).

status: ready
