### PR TITLE
[FIX #3591] always show full link

### DIFF
--- a/src/status_im/chat/views/message/message.cljs
+++ b/src/status_im/chat/views/message/message.cljs
@@ -127,7 +127,7 @@
                            {:key      idx
                             :style    {:color colors/blue}
                             :on-press #(on-press url)}
-                           (utils/truncate-str text 32 true)])
+                           url])
                         text)))
        vec))
 


### PR DESCRIPTION
fixes #3591 


### Summary:

always show the full URL in Chat message


### Review notes (optional):
This is my first PR and I am completely new to the software. Please check if my changes have any side-effects I did not think about.


### Steps to test:

    Open Status
    Open 1:1 chat with Jarrad
    Send https://wiki.status.im/Send_Transaction_flow and check how it's displayed in the chat


status: ready
