### PR TITLE
[Fix #3319] STT/SNT tokens are not shown by default for recovered account

### DIFF
--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -35,6 +35,10 @@
            #_
            {:id :postponed :label (i18n/label :t/postponed) :checked? true}]}})
 
+(def default-account-settings
+  {:wallet {:visible-tokens {:testnet #{:STT}
+                             :mainnet #{:SNT}}}})
+
 (defn- transform-config [networks]
   (->> networks
        (map (fn [[network-name {:keys [config] :as data}]]

--- a/src/status_im/ui/screens/accounts/events.cljs
+++ b/src/status_im/ui/screens/accounts/events.cljs
@@ -14,6 +14,7 @@
             [status-im.utils.signing-phrase.core :as signing-phrase]
             [status-im.utils.gfycat.core :refer [generate-gfy]]
             [status-im.utils.hex :as utils.hex]
+            [status-im.constants :as constants]
             status-im.ui.screens.accounts.create.navigation))
 
 ;;;; COFX
@@ -120,7 +121,7 @@
                               :photo-path          (identicon pubkey)
                               :signing-phrase      signing-phrase
                               :mnemonic            mnemonic
-                              :settings            {:wallet {:visible-tokens {:testnet #{:STT} :mainnet #{:SNT}}}}}]
+                              :settings            constants/default-account-settings}]
       (log/debug "account-created")
       (when-not (str/blank? pubkey)
         (-> (add-account db account)

--- a/src/status_im/ui/screens/accounts/recover/events.cljs
+++ b/src/status_im/ui/screens/accounts/recover/events.cljs
@@ -10,7 +10,8 @@
     [status-im.utils.handlers :as handlers]
     [status-im.utils.gfycat.core :as gfycat]
     [status-im.utils.signing-phrase.core :as signing-phrase]
-    [status-im.utils.hex :as utils.hex]))
+    [status-im.utils.hex :as utils.hex]
+    [status-im.constants :as constants]))
 
 ;;;; FX
 
@@ -41,7 +42,8 @@
                    :updates-private-key private
                    :mnemonic            ""
                    :signed-up?          true
-                   :signing-phrase      phrase}]
+                   :signing-phrase      phrase
+                   :settings            constants/default-account-settings}]
       (when-not (string/blank? public-key)
         (-> db 
             (accounts-events/add-account account)


### PR DESCRIPTION
### Summary:
Fix #3319 
STT/SNT tokens are not shown by default for recovered account

status: ready <!-- Can be ready or wip -->
