### PR TITLE
[Fix #3588] "There are no messages in this chat yet" is left-aligned instead of centred as in design

### DIFF
--- a/src/status_im/chat/styles/screen.cljs
+++ b/src/status_im/chat/styles/screen.cljs
@@ -222,4 +222,5 @@
   {:color          colors/gray
    :font-size      14
    :line-height    20
-   :letter-spacing -0.2})
+   :letter-spacing -0.2
+   :text-align     :center})


### PR DESCRIPTION
### Summary:

Fix #3588 
"There are no messages in this chat yet" is left-aligned instead of centred as in design

status: ready <!-- Can be ready or wip -->
