### PR TITLE
[Fix #3609] Remove showing users profile from 'Creating New Chat' flow

### DIFF
--- a/src/status_im/ui/screens/add_new/new_chat/views.cljs
+++ b/src/status_im/ui/screens/add_new/new_chat/views.cljs
@@ -15,7 +15,7 @@
 
 (defn- render-row [row _ _]
   [contact-view/contact-view {:contact       row
-                              :on-press      #(re-frame/dispatch [:show-profile (:whisper-identity %)])
+                              :on-press      #(re-frame/dispatch [:start-chat (:whisper-identity %) {:navigation-replace? true}])
                               :show-forward? true}])
 
 (views/defview new-chat []


### PR DESCRIPTION
### Summary:

Fix #3609 
Remove showing users profile from 'Creating New Chat' flow

status: ready <!-- Can be ready or wip -->
