### PR TITLE
WIP: Experiment. A simple `sleep mode` for the Ethereum node.

### DIFF
--- a/modules/react-native-status/android/build.gradle
+++ b/modules/react-native-status/android/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     implementation 'com.github.ericwlange:AndroidJSCore:3.0.1'
     implementation 'status-im:function:0.0.1'
 
-    String statusGoVersion = 'igorm-sleep-mode-simplistic-g23586bac-100'
+    String statusGoVersion = 'igorm-sleep-mode-simplistic-gf1779a4f-100'
     final String statusGoGroup = 'status-im', statusGoName = 'status-go'
 
     // Check if the local status-go jar exists, and compile against that if it does

--- a/modules/react-native-status/android/build.gradle
+++ b/modules/react-native-status/android/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     implementation 'com.github.ericwlange:AndroidJSCore:3.0.1'
     implementation 'status-im:function:0.0.1'
 
-    String statusGoVersion = 'develop-g3b92b61e'
+    String statusGoVersion = 'igorm-sleep-mode-simplistic-g23586bac-100'
     final String statusGoGroup = 'status-im', statusGoName = 'status-go'
 
     // Check if the local status-go jar exists, and compile against that if it does

--- a/modules/react-native-status/ios/RCTStatus/pom.xml
+++ b/modules/react-native-status/ios/RCTStatus/pom.xml
@@ -25,7 +25,7 @@
                         <artifactItem>
                             <groupId>status-im</groupId>
                             <artifactId>status-go-ios-simulator</artifactId>
-                            <version>igorm-sleep-mode-simplistic-g23586bac-100</version>
+                            <version>igorm-sleep-mode-simplistic-gf1779a4f-100</version>
                             <type>zip</type>
                             <overWrite>true</overWrite>
                             <outputDirectory>./</outputDirectory>

--- a/modules/react-native-status/ios/RCTStatus/pom.xml
+++ b/modules/react-native-status/ios/RCTStatus/pom.xml
@@ -25,7 +25,7 @@
                         <artifactItem>
                             <groupId>status-im</groupId>
                             <artifactId>status-go-ios-simulator</artifactId>
-                            <version>develop-g3b92b61e</version>
+                            <version>igorm-sleep-mode-simplistic-g23586bac-100</version>
                             <type>zip</type>
                             <overWrite>true</overWrite>
                             <outputDirectory>./</outputDirectory>


### PR DESCRIPTION
Essentially, we stop the node when the app goes to background.
When it restores, we restart the node again and restore all the
filters/keys, so that messages can be received again.

‼️ This is a PoC test implementation, not to be merged!



### Steps to test:
- Open Status
- Chat with a peer
- Put Status to background
- Chat with a peer again

Everything should work. Messages should be sent and received.


### Energy efficiency testing

- [ ] Compare energy consumption in *background* with 
        a. Status nightly
        b. Skype
        c. Telegram

status: wip <!-- Can be ready or wip -->

part of: https://github.com/status-im/ideas/issues/83