### PR TITLE
[FIX #3629] remove extra hyphenation of text in empty home tab

### DIFF
--- a/src/status_im/translations/en.cljs
+++ b/src/status_im/translations/en.cljs
@@ -58,7 +58,7 @@
 
    ;;home
    :home                                 "Home"
-   :no-recent-chats                      "There are no recent Chats or DApps here yet.\nUse the “Plus” button to see the list of Dapps or discover people to chat with"
+   :no-recent-chats                      "There are no recent Chats or DApps here yet. Use the “Plus” button to see the list of Dapps or discover people to chat with."
    :welcome-to-status                    "Welcome to Status"
    :welcome-to-status-description        "Here you can chat with people in a secure private chat, browse and interact with DApps. Use the “Plus” icon above to explore Status"
 


### PR DESCRIPTION
fixes #3629

### Summary:

The description text on the empty home tab has a linebreak that makes the formatting look ugly depending on the user's screen size. This PR removes the linebreak for more consistent formatting across devices..

### Steps to test:
- Open Status
- navigate to home tab
- delete all conversations
- behold the consistent formatting ;)

status: ready
