### PR TITLE
[Feature #3616] Add 'Selectable' to a Text component on profile and wallet screens

### DIFF
--- a/src/status_im/ui/components/qr_code_viewer/views.cljs
+++ b/src/status_im/ui/components/qr_code_viewer/views.cljs
@@ -13,7 +13,8 @@
   [react/view styles/footer
    [react/view styles/wallet-info
     [react/text {:style               (merge styles/hash-value-text style)
-                 :accessibility-label :address-text}
+                 :accessibility-label :address-text
+                 :selectable          true}
      value]]])
 
 (defn qr-code-viewer [{:keys [style hint-style footer-style]} value hint legend]

--- a/src/status_im/ui/screens/profile/contact/views.cljs
+++ b/src/status_im/ui/screens/profile/contact/views.cljs
@@ -39,7 +39,8 @@
      label]
     [react/view styles/profile-setting-spacing]
     [react/text {:style               styles/profile-setting-text
-                 :accessibility-label accessibility-label}
+                 :accessibility-label accessibility-label
+                 :selectable          true}
      value]]])
 
 (defn profile-info-contact-code-item [whisper-identity]


### PR DESCRIPTION
fixes #3616 

### Summary:
add selectable to text component on profile and wallet screens



status: ready
