### PR TITLE
[FIX #3641] Modify chat input to retain text, parameter box on blur

### DIFF
--- a/components/src/status_im/ui/components/react.cljs
+++ b/components/src/status_im/ui/components/react.cljs
@@ -51,6 +51,7 @@
 (def check-box (get-class "CheckBox"))
 
 (def touchable-highlight-class (get-class "TouchableHighlight"))
+(def touchable-without-feedback-class (get-class "TouchableWithoutFeedback"))
 (def touchable-opacity (get-class "TouchableOpacity"))
 (def activity-indicator (get-class "ActivityIndicator"))
 
@@ -113,6 +114,11 @@
   [touchable-highlight-class
    (merge {:underlay-color :transparent} props)
    content])
+
+(defn touchable-without-feedback [props content]
+ [touchable-without-feedback-class
+  props
+  content])
 
 (defn get-dimensions [name]
   (js->clj (.get dimensions name) :keywordize-keys true))

--- a/src/status_im/chat/screen.cljs
+++ b/src/status_im/chat/screen.cljs
@@ -89,13 +89,19 @@
     [react/with-activity-indicator
      {:style   style/message-view-preview
       :preview [react/view style/message-view-preview]}
-     [react/animated-view {:style (style/message-view-animated opacity)}
-      message-view]]))
+      [react/touchable-without-feedback
+       {:on-press (fn [_]
+                    (re-frame/dispatch [:set-chat-ui-props {:messages-focused? true}])
+                    (react/dismiss-keyboard!))}
+       [react/animated-view {:style (style/message-view-animated opacity)}
+        message-view]]]))
 
 (defview messages-view [group-chat]
   (letsubs [messages           [:get-current-chat-messages]
-            current-public-key [:get-current-public-key]
-            chat-id            [:get-current-chat-id]]
+            chat-id            [:get-current-chat-id]
+            current-public-key [:get-current-public-key]]
+    {:component-did-mount #(re-frame/dispatch [:set-chat-ui-props {:messages-focused? true
+                                                                   :input-focused? false}])}
     (if (empty? messages)
       [react/view style/empty-chat-container
        [react/text {:style style/empty-chat-text}
@@ -111,7 +117,7 @@
                        :inverted                  true
                        :onEndReached              #(re-frame/dispatch [:load-more-messages])
                        :enableEmptySections       true
-                       :keyboardShouldPersistTaps (if platform/android? :always :handled)}])))
+                       :keyboardShouldPersistTaps :handled}])))
 
 (defview chat []
   (letsubs [{:keys [group-chat public? input-text]} [:get-current-chat]

--- a/src/status_im/chat/views/input/animations/expandable.cljs
+++ b/src/status_im/chat/views/input/animations/expandable.cljs
@@ -19,10 +19,11 @@
 (defview expandable-view [{:keys [key]} & elements]
   (letsubs [anim-value         (animation/create-value 0)
             input-height       [:get-current-chat-ui-prop :input-height]
+            input-focused?     [:get-current-chat-ui-prop :input-focused?]
+            messages-focused?  [:get-current-chat-ui-prop :messages-focused?]
             chat-input-margin  [:chat-input-margin]
             keyboard-height    [:get :keyboard-height]
-            chat-layout-height [:get :layout-height]
-            input-focused?     [:get-current-chat-ui-prop :input-focused?]]
+            chat-layout-height [:get :layout-height]]
     (let [input-height (or input-height (+ input-style/padding-vertical
                                            input-style/min-input-height
                                            input-style/padding-vertical
@@ -34,5 +35,5 @@
         (into [react/scroll-view {:keyboard-should-persist-taps :always
                                   :on-content-size-change       #(expandable-view-on-update anim-value %2)
                                   :bounces                      false}]
-              (when input-focused?
-                elements))]])))
+          (when (or input-focused? (not messages-focused?))
+            elements))]])))

--- a/src/status_im/chat/views/input/input.cljs
+++ b/src/status_im/chat/views/input/input.cljs
@@ -29,10 +29,9 @@
       :default-value          (or input-text "")
       :editable               true
       :blur-on-submit         false
-      :on-focus               #(re-frame/dispatch [:set-chat-ui-props {:input-focused? true}])
-      :on-blur                (fn []
-                                (re-frame/dispatch [:set-chat-ui-props {:input-focused? false}])
-                                (re-frame/dispatch [:set-chat-input-text ""]))
+      :on-focus               #(re-frame/dispatch [:set-chat-ui-props {:input-focused?    true
+                                                                        :messages-focused? false}])
+      :on-blur                #(re-frame/dispatch [:set-chat-ui-props {:input-focused? false}])
       :on-submit-editing      (fn [_]
                                 (if single-line-input?
                                   (re-frame/dispatch [:send-current-message])

--- a/src/status_im/chat/views/message/message.cljs
+++ b/src/status_im/chat/views/message/message.cljs
@@ -339,10 +339,11 @@
 
 (defn chat-message [{:keys [outgoing group-chat current-public-key content-type content] :as message}]
   [message-container message
-   [react/touchable-highlight {:on-press      #(when platform/ios?
-                                                 (react/dismiss-keyboard!))
-                               :on-long-press #(when (= content-type constants/text-content-type)
-                                                 (list-selection/share content (i18n/label :t/message)))}
+  [react/touchable-highlight {:on-press      (fn [_]
+                                               (re-frame/dispatch [:set-chat-ui-props {:messages-focused? true}])
+                                               (react/dismiss-keyboard!))
+                              :on-long-press #(when (= content-type constants/text-content-type)
+                                                (list-selection/share content (i18n/label :t/message)))}
     [react/view {:accessibility-label :chat-item}
      (let [incoming-group (and group-chat (not outgoing))]
        [message-content message-body (merge message


### PR DESCRIPTION
Fixes #3641

### Summary:
Chat input now continues to show entered text and command parameter box on blur

### Steps to test:
- Open Status
- Open chat with user
- Type /send to activate command parameter box
- Tap on parameter box or messages scroll view
- The input text and parameter box should persist after keyboard closes

status: ready
