### PR TITLE
[FIX #3650] Blue open dapp button

### DIFF
--- a/src/status_im/ui/components/action_button/styles.cljs
+++ b/src/status_im/ui/components/action_button/styles.cljs
@@ -16,7 +16,7 @@
    :height           40
    :align-items      :center
    :justify-content  :center
-   :ios              {:background-color (or circle-color styles/color-light-blue-transparent)}})
+   :background-color (or circle-color styles/color-light-blue-transparent)})
 
 (def action-button-label-container
   {:padding-left 16})
@@ -41,5 +41,5 @@
    :height           40
    :align-items      :center
    :justify-content  :center
-   :ios              {:background-color styles/color-light-gray}})
+   :background-color styles/color-light-gray})
 

--- a/src/status_im/ui/screens/add_new/open_dapp/views.cljs
+++ b/src/status_im/ui/screens/add_new/open_dapp/views.cljs
@@ -4,6 +4,7 @@
             [status-im.i18n :as i18n]
             [status-im.ui.components.react :as react]
             [status-im.ui.components.action-button.action-button :as action-button]
+            [status-im.ui.components.colors :as colors]
             [status-im.ui.components.common.common :as components]
             [status-im.ui.components.status-bar.view :as status-bar]
             [status-im.ui.components.toolbar.view :as toolbar.view]
@@ -60,6 +61,7 @@
      [react/view {:margin-top 24}
       [action-button/action-button {:label               (i18n/label :t/open)
                                     :icon                :icons/address
+                                    :icon-opts           {:color colors/blue}
                                     :accessibility-label :open-dapp-button
                                     :on-press            #(do
                                                             (re-frame/dispatch [:navigate-to-clean :home])


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes #3650 

### Summary:

[comment]: # (Summarise the problem and how the pull request solves it)
Arrow and _ sign should be blue by design. Created a style for the button with a blue transparent background.

### Review notes (optional):
<!-- (Specify if something in particular should be looked at, or ignored, during review) -->

### Testing notes (optional):
<!-- (Specify if something specific has to be tested, for example upgrade paths) -->

### Steps to test:
- Open Status
- Tap Open dapp
- Tap any dapp

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->
