### PR TITLE
[FIX #3143] Cannot sign in to Cryptokitties (chrome webstore)

### DIFF
--- a/src/status_im/utils/browser_config.edn
+++ b/src/status_im/utils/browser_config.edn
@@ -1,0 +1,4 @@
+;; Browser (webview) configuration
+;; :inject-js is a map of {<domain> <js-code>}, JS code will be injected if the domain name matches (www. is stripped away)
+
+{:inject-js {"cryptokitties.co" "; if (!window.chrome) { window.chrome = { webstore: true }; }"}}


### PR DESCRIPTION
fixes #3143

### Summary:

Injects `window.chrome = { webstore: true }` into webview.

### Steps to test:
- Open Status
- Browse to https://www.cryptokitties.co
- Click sign in

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->
