### PR TITLE
[FIX #3678] Allow interaction w/edit profile screen while keyboard vi…

### DIFF
--- a/src/status_im/ui/screens/profile/user/views.cljs
+++ b/src/status_im/ui/screens/profile/user/views.cljs
@@ -167,7 +167,7 @@
        (if editing?
          [my-profile-edit-toolbar]
          [my-profile-toolbar])
-       [react/scroll-view
+       [react/scroll-view {:keyboard-should-persist-taps :handled}
         [react/view profile.components.styles/profile-form
          [profile.components/profile-header shown-account editing? true profile-icon-options :my-profile/update-name]]
         [react/view action-button.styles/actions-list


### PR DESCRIPTION
Fixes #3678

### Summary:

Can now interact with elements on edit profile screen (e.g. user avatar) without first closing keyboard

### Steps to test:
- Open Status
- Log in, tap Profile tab
- Tap EDIT
- Tap user picture edit button
- Keyboard should close and edit image flow should begin

Status: Ready
