### PR TITLE
Fix swipe-based delete-action handler

### DIFF
--- a/src/status_im/ui/screens/home/views.cljs
+++ b/src/status_im/ui/screens/home/views.cljs
@@ -36,7 +36,7 @@
 
 (views/defview home-list-deletable [[home-item-id home-item]]
   (views/letsubs [swiped? [:delete-swipe-position home-item-id]]
-    (let [delete-action (if (:chat-id home-item) :remove-chat :remove-browser)
+    (let [delete-action (if (:chat-id home-item) :delete-chat :remove-browser)
           inner-item-view (if (:chat-id home-item)
                             inner-item/home-list-chat-item-inner-view
                             inner-item/home-list-browser-item-inner-view)


### PR DESCRIPTION
Fixes https://github.com/status-im/status-react/issues/3620 by using correct delete handler.

Regression likely introduced in https://github.com/status-im/status-react/commit/502a28ec7a82894dea97e5ae0e7a9ceeef1cc9ca

See https://github.com/status-im/status-react/issues/3620#issuecomment-376378990

Only very briefly tested in iOS simulator, but I got failing case and with this fix it seems to work.

status: ready