### PR TITLE
Moved push notification request (iOS) to Home screen

### DIFF
--- a/src/status_im/ios/core.cljs
+++ b/src/status_im/ios/core.cljs
@@ -32,7 +32,6 @@
          (.hide react/splash-screen))
        :component-did-mount
        (fn []
-         (notifications/request-permissions)
          (notifications/on-refresh-fcm-token)
          (notifications/on-notification))
        :component-will-unmount

--- a/src/status_im/ui/screens/accounts/events.cljs
+++ b/src/status_im/ui/screens/accounts/events.cljs
@@ -212,7 +212,8 @@
   :account-finalized
   (fn [{db :db} _]
     {:db db
-     :dispatch [:navigate-to-clean :home]}))
+     :dispatch-n [[:navigate-to-clean :home]
+                  [:request-notifications]]}))
 
 (handlers/register-handler-fx
   :update-sign-in-time

--- a/src/status_im/ui/screens/events.cljs
+++ b/src/status_im/ui/screens/events.cljs
@@ -177,6 +177,11 @@
     (permissions/request-permissions options)))
 
 (re-frame/reg-fx
+  ::request-notifications-fx
+  (fn [_]
+    (notifications/request-permissions)))
+
+(re-frame/reg-fx
   ::testfairy-alert
   (fn []
     (when config/testfairy-enabled?
@@ -417,6 +422,11 @@
   :request-permissions
   (fn [_ [_ options]]
     {:request-permissions-fx options}))
+
+(handlers/register-handler-fx
+  :request-notifications
+  (fn [_ _]
+    {::request-notifications-fx {}}))
 
 (handlers/register-handler-db
   :set-swipe-position

--- a/src/status_im/utils/mixpanel_events.edn
+++ b/src/status_im/utils/mixpanel_events.edn
@@ -21,6 +21,14 @@
  {:label      "Logout"
   :trigger    [:navigate-to :accounts]}
 
+ ; Push notification settings
+
+ {:label      "Granted push notifications"
+  :trigger    [:request-notifications-granted]}
+
+ {:label      "Denied push notifications"
+  :trigger    [:request-notifications-denied]}
+
  ;; Tab navigation
 
  {:label      "Tap"

--- a/src/status_im/utils/notifications.cljs
+++ b/src/status_im/utils/notifications.cljs
@@ -16,9 +16,24 @@
  (fn [db [_ fcm-token]]
    (assoc-in db [:notifications :fcm-token] fcm-token)))
 
+(handlers/register-handler-fx
+ :request-notifications-granted
+ (fn [_ _]))
+
+(handlers/register-handler-fx
+ :request-notifications-denied
+ (fn [_ _]))
+
 ;; NOTE: Only need to explicitly request permissions on iOS.
 (defn request-permissions []
-  (.requestPermissions (.-default rn/react-native-fcm)))
+  (-> (.requestPermissions (.-default rn/react-native-fcm))
+      (.then
+        (fn [_]
+          (log/debug "notifications-granted")
+          (dispatch [:request-notifications-granted {}]))
+        (fn [_]
+          (log/debug "notifications-denied")
+          (dispatch [:request-notifications-denied {}])))))
 
 (defn get-fcm-token []
     (-> (.getFCMToken (object/get rn/react-native-fcm "default"))


### PR DESCRIPTION
Fixes #3684 

### Summary:
Relocated iOS push notification request to post-login home screen

### Steps to test:
- Run Status on iOS device/simulator
- Create account and login
- Device should display popup asking user to allow push notifications above Home screen

status: ready
