### PR TITLE
Dont throw error on empty data

### DIFF
--- a/android/app/src/main/java/im/status/ethereum/MainActivity.java
+++ b/android/app/src/main/java/im/status/ethereum/MainActivity.java
@@ -94,8 +94,8 @@ public class MainActivity extends ReactActivity
 
     @Override
     public void onNewIntent(final Intent intent) {
-        if (intent.getData().getScheme().startsWith("app-settings")) {
-            startActivity(createNotificationSettingsIntent());
+        if (intent.getDataString() != null && intent.getData().getScheme().startsWith("app-settings")) {
+          startActivity(createNotificationSettingsIntent());
         }
     }
 


### PR DESCRIPTION

fixes #3590 

### Summary:

This prevents the app crashing when resuming operations. 

It was introduced on https://github.com/status-im/status-react/commit/ed7705ca7feb8186d6d48d8b485bb77c2faa3df4

It does not tackle the issue as I was not able to get the feature working on my device (clicking on settings does not redirects me to settings).

Pushing this as a quick fix, but needs to be investigated further.


status: ready