### PR TITLE
[#3694] Ignore mixpanel/track http error when offline

### DIFF
--- a/src/status_im/utils/mixpanel.cljs
+++ b/src/status_im/utils/mixpanel.cljs
@@ -29,7 +29,7 @@
                               props)})))
 
 (defn track [id label props]
-  (http/get (build-url id label props)))
+  (http/get (build-url id label props) nil identity))
 
 ;; Mixpanel events definition
 


### PR DESCRIPTION
Fixes #3694 

### Summary

Quickfix to ignore http error when calling mixpanel/track while offline

@jeluard this fix seems like workaround, i.e. mixpanel events would be lost.
What do you think about idea to collect mixpanel events while offline and send them later (maybe in batch) when client becomes online?