### PR TITLE
re-frisk improvements

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,7 @@
                  [hickory "0.7.1"]
                  [com.cognitect/transit-cljs "0.8.243"]]
   :plugins [[lein-cljsbuild "1.1.7"]
-            [lein-re-frisk "0.5.5"]]
+            [lein-re-frisk "0.5.6"]]
   :clean-targets ["target/" "index.ios.js" "index.android.js"]
   :aliases {"prod-build"         ^{:doc "Recompile code with prod profile."}
             ["do" "clean"
@@ -53,8 +53,8 @@
                                        :timeout          240000}}
              :figwheel [:dev
                         {:dependencies [[figwheel-sidecar "0.5.14"]
-                                        [re-frisk-remote "0.5.3"]
-                                        [re-frisk-sidecar "0.5.4"]
+                                        [re-frisk-remote "0.5.4"]
+                                        [re-frisk-sidecar "0.5.5"]
                                         [hawk "0.2.11"]]
                          :source-paths ["src" "env/dev" "react-native/src" "components/src"]}]
              :test     {:dependencies [[day8.re-frame/test "0.1.5"]]


### PR DESCRIPTION
re-frisk sends only changed deltas not all app-db
re-frisk doesnt encrypt data if there is no opened clients, so let's say it disabled until you open `localhost:4567`