### PR TITLE
Link to settings on Android 8

### DIFF
--- a/android/app/src/main/java/im/status/ethereum/MainActivity.java
+++ b/android/app/src/main/java/im/status/ethereum/MainActivity.java
@@ -82,8 +82,7 @@ public class MainActivity extends ReactActivity
         final Intent intent = new Intent();
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             intent.setAction(Settings.ACTION_APP_NOTIFICATION_SETTINGS);
-            intent.putExtra("app_package", getPackageName());
-            intent.putExtra("app_uid", getApplicationInfo().uid);
+            intent.putExtra(Settings.EXTRA_APP_PACKAGE, getPackageName());
         } else {
             intent.setAction(Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
             intent.addCategory(Intent.CATEGORY_DEFAULT);


### PR DESCRIPTION

fixes #3644 

### Summary:

When clicking on settings on android 8 an error was show, it should now correctly link to settings.

### Steps to test:
- Open Status
- Go to profile
- Click on notifications

status: ready