### PR TITLE
[FIX #3706] collect mixpanel events while offline

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3083,6 +3083,795 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
+    "fsevents": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
+      "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
+      "optional": true,
+      "requires": {
+        "nan": "2.10.0",
+        "node-pre-gyp": "0.6.39"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.0",
+          "bundled": true,
+          "optional": true
+        },
+        "ajv": {
+          "version": "4.11.8",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
+          }
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "aproba": {
+          "version": "1.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "delegates": "1.0.0",
+            "readable-stream": "2.2.9"
+          }
+        },
+        "asn1": {
+          "version": "0.2.3",
+          "bundled": true,
+          "optional": true
+        },
+        "assert-plus": {
+          "version": "0.2.0",
+          "bundled": true,
+          "optional": true
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "bundled": true,
+          "optional": true
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "bundled": true,
+          "optional": true
+        },
+        "aws4": {
+          "version": "1.6.0",
+          "bundled": true,
+          "optional": true
+        },
+        "balanced-match": {
+          "version": "0.4.2",
+          "bundled": true
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "tweetnacl": "0.14.5"
+          }
+        },
+        "block-stream": {
+          "version": "0.0.9",
+          "bundled": true,
+          "requires": {
+            "inherits": "2.0.3"
+          }
+        },
+        "boom": {
+          "version": "2.10.1",
+          "bundled": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.7",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "0.4.2",
+            "concat-map": "0.0.1"
+          }
+        },
+        "buffer-shims": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "bundled": true,
+          "optional": true
+        },
+        "co": {
+          "version": "4.6.0",
+          "bundled": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "combined-stream": {
+          "version": "1.0.5",
+          "bundled": true,
+          "requires": {
+            "delayed-stream": "1.0.0"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "bundled": true,
+          "requires": {
+            "boom": "2.10.1"
+          }
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "debug": {
+          "version": "2.6.8",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.4.2",
+          "bundled": true,
+          "optional": true
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "ecc-jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "extend": {
+          "version": "3.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "extsprintf": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "bundled": true,
+          "optional": true
+        },
+        "form-data": {
+          "version": "2.1.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.15"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "fstream": {
+          "version": "1.0.11",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "inherits": "2.0.3",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.1"
+          }
+        },
+        "fstream-ignore": {
+          "version": "1.0.5",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "fstream": "1.0.11",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4"
+          }
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "aproba": "1.1.1",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
+          }
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "bundled": true
+        },
+        "har-schema": {
+          "version": "1.0.5",
+          "bundled": true,
+          "optional": true
+        },
+        "har-validator": {
+          "version": "4.2.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "ajv": "4.11.8",
+            "har-schema": "1.0.5"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "bundled": true,
+          "requires": {
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
+          }
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "bundled": true
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.0",
+            "sshpk": "1.13.0"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "ini": {
+          "version": "1.3.4",
+          "bundled": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "bundled": true,
+          "optional": true
+        },
+        "jodid25519": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "bundled": true,
+          "optional": true
+        },
+        "json-stable-stringify": {
+          "version": "1.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "jsonify": "0.0.0"
+          }
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "jsonify": {
+          "version": "0.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "jsprim": {
+          "version": "1.4.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.0.2",
+            "json-schema": "0.2.3",
+            "verror": "1.3.6"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "mime-db": {
+          "version": "1.27.0",
+          "bundled": true
+        },
+        "mime-types": {
+          "version": "2.1.15",
+          "bundled": true,
+          "requires": {
+            "mime-db": "1.27.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "node-pre-gyp": {
+          "version": "0.6.39",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "detect-libc": "1.0.2",
+            "hawk": "3.1.3",
+            "mkdirp": "0.5.1",
+            "nopt": "4.0.1",
+            "npmlog": "4.1.0",
+            "rc": "1.2.1",
+            "request": "2.81.0",
+            "rimraf": "2.6.1",
+            "semver": "5.3.0",
+            "tar": "2.2.1",
+            "tar-pack": "3.4.0"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1.1.0",
+            "osenv": "0.1.4"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "bundled": true,
+          "optional": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "performance-now": {
+          "version": "0.2.0",
+          "bundled": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "bundled": true
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "bundled": true,
+          "optional": true
+        },
+        "qs": {
+          "version": "6.4.0",
+          "bundled": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "deep-extend": "0.4.2",
+            "ini": "1.3.4",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.2.9",
+          "bundled": true,
+          "requires": {
+            "buffer-shims": "1.0.0",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "1.0.1",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "request": {
+          "version": "2.81.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.15",
+            "oauth-sign": "0.8.2",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.0.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.2",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.0.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.1",
+          "bundled": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.0.1",
+          "bundled": true
+        },
+        "semver": {
+          "version": "5.3.0",
+          "bundled": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "bundled": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "sshpk": {
+          "version": "1.13.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "asn1": "0.2.3",
+            "assert-plus": "1.0.0",
+            "bcrypt-pbkdf": "1.0.1",
+            "dashdash": "1.14.1",
+            "ecc-jsbn": "0.1.1",
+            "getpass": "0.1.7",
+            "jodid25519": "1.0.2",
+            "jsbn": "0.1.1",
+            "tweetnacl": "0.14.5"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
+        "stringstream": {
+          "version": "0.0.5",
+          "bundled": true,
+          "optional": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "2.2.1",
+          "bundled": true,
+          "requires": {
+            "block-stream": "0.0.9",
+            "fstream": "1.0.11",
+            "inherits": "2.0.3"
+          }
+        },
+        "tar-pack": {
+          "version": "3.4.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "debug": "2.6.8",
+            "fstream": "1.0.11",
+            "fstream-ignore": "1.0.5",
+            "once": "1.4.0",
+            "readable-stream": "2.2.9",
+            "rimraf": "2.6.1",
+            "tar": "2.2.1",
+            "uid-number": "0.0.6"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.3.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "punycode": "1.4.1"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "bundled": true,
+          "optional": true
+        },
+        "uid-number": {
+          "version": "0.0.6",
+          "bundled": true,
+          "optional": true
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "uuid": {
+          "version": "3.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "verror": {
+          "version": "1.3.6",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "extsprintf": "1.0.2"
+          }
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "string-width": "1.0.2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true
+        }
+      }
+    },
     "fstream": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
@@ -7534,6 +8323,7 @@
         "anymatch": "2.0.0",
         "exec-sh": "0.2.1",
         "fb-watchman": "2.0.0",
+        "fsevents": "1.1.3",
         "micromatch": "3.1.10",
         "minimist": "1.2.0",
         "walker": "1.0.7",

--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -6,10 +6,6 @@
 
 (def ethereum-rpc-url "http://localhost:8545")
 
-(def server-address "http://api.status.im/")
-;; (def server-address "http://10.0.3.2:3000/")
-;; (def server-address "http://localhost:3000/")
-
 (def text-content-type "text/plain")
 (def content-type-log-message "log-message")
 (def content-type-command "command")

--- a/src/status_im/ui/screens/accounts/login/events.cljs
+++ b/src/status_im/ui/screens/accounts/login/events.cljs
@@ -127,7 +127,6 @@
                            (assoc-in [:accounts/create :step] :enter-name))
        :dispatch-n (concat
                      [[:stop-debugging]
-                      (when (:sharing-usage-data? (accounts address)) [:register-mixpanel-tracking address])
                       [:initialize-account address
                        (when (not= view-id :create-account)
                          [[:navigate-to-clean :home]])]])}

--- a/src/status_im/ui/screens/usage_data/events.cljs
+++ b/src/status_im/ui/screens/usage_data/events.cljs
@@ -4,12 +4,6 @@
 
 (handlers/register-handler-fx
   :help-improve-handler
-  (fn [{{:accounts/keys [accounts current-account-id] :as db} :db} [_ yes? address next]]
-    (let [{:keys [sharing-usage-data?]} (get accounts current-account-id)]
-      (merge (accounts/account-update {:sharing-usage-data? yes?} {:db db})
-             {:dispatch-n [(if yes?
-                             [:register-mixpanel-tracking address]
-                             (when (and next sharing-usage-data?)
-                               [:unregister-mixpanel-tracking]))
-                           (or next [:navigate-to-clean :home])]}))))
-
+  (fn [{db :db} [_ yes? next]]
+    (merge (accounts/account-update {:sharing-usage-data? yes?} {:db db})
+           {:dispatch (or next [:navigate-to-clean :home])})))

--- a/src/status_im/ui/screens/usage_data/views.cljs
+++ b/src/status_im/ui/screens/usage_data/views.cljs
@@ -9,8 +9,7 @@
             [status-im.ui.screens.usage-data.styles :as styles]))
 
 (views/defview usage-data []
-  (views/letsubs [next    [:get-screen-params]
-                  account [:get-current-account]]
+  (views/letsubs [next [:get-screen-params]]
     [react/view {:style styles/usage-data-view}
      [status-bar/status-bar {:flat? true}]
      [react/view {:style styles/logo-container}
@@ -24,9 +23,9 @@
        (i18n/label :t/help-improve-description)]]
      [react/view styles/buttons-container
       [components.common/button {:style    {:flex-direction :row}
-                                 :on-press #(re-frame/dispatch [:help-improve-handler true (:address account) next])
+                                 :on-press #(re-frame/dispatch [:help-improve-handler true next])
                                  :label    (i18n/label :t/share-usage-data)}]
       [react/view styles/bottom-button-container
-       [components.common/button {:on-press    #(re-frame/dispatch [:help-improve-handler false (:address account) next])
+       [components.common/button {:on-press    #(re-frame/dispatch [:help-improve-handler false next])
                                   :label       (i18n/label :t/dont-want-to-share)
                                   :background? false}]]]]))

--- a/src/status_im/utils/http.cljs
+++ b/src/status_im/utils/http.cljs
@@ -9,23 +9,20 @@
 
 (defn post
   "Performs an HTTP POST request"
-  ([action data on-success]
-   (post action data on-success nil))
-  ([action data on-success on-error]
-   (post action data on-success on-error nil))
-  ([action data on-success on-error {:keys [timeout-ms]}]
-   (-> (rn-dependencies/fetch (str const/server-address action)
-                              (clj->js {:method  "POST"
-                                        :headers {:accept       "application/json"
-                                                  :content-type "application/json"}
-                                        :body    (.stringify js/JSON (clj->js data))
-                                        :timeout (or timeout-ms http-request-default-timeout-ms)}))
+  ([url data on-success]
+   (post url data on-success nil))
+  ([url data on-success on-error]
+   (post url data on-success on-error nil))
+  ([url data on-success on-error {:keys [timeout-ms headers]}]
+   (-> (rn-dependencies/fetch
+        url
+        (clj->js (merge {:method  "POST"
+                         :body    data
+                         :timeout (or timeout-ms http-request-default-timeout-ms)}
+                        (when headers
+                          {:headers headers}))))
        (.then (fn [response]
-                (.text response)))
-       (.then (fn [text]
-                (let [json (.parse js/JSON text)
-                      obj  (js->clj json :keywordize-keys true)]
-                  (on-success obj))))
+                (on-success response)))
        (.catch (or on-error
                    (fn [error]
                      (utils/show-popup "Error" (str error))))))))

--- a/src/status_im/utils/mixpanel.cljs
+++ b/src/status_im/utils/mixpanel.cljs
@@ -1,13 +1,15 @@
 (ns status-im.utils.mixpanel
   (:require-macros [status-im.utils.slurp :as slurp])
-  (:require [cljs.reader :as reader]
+  (:require [cljs.core.async :as async]
+            [cljs.reader :as reader]
             [goog.crypt.base64 :as b64]
             [status-im.utils.build :as build]
             [status-im.utils.config :as config]
             [status-im.utils.datetime :as datetime]
             [status-im.utils.http :as http]
             [status-im.utils.platform :as platform]
-            [status-im.utils.types :as types]))
+            [status-im.utils.types :as types]
+            [taoensso.timbre :as log]))
 
 (def base-url "http://api.mixpanel.com/")
 (def base-track-url (str base-url "track/"))
@@ -15,24 +17,65 @@
 (defn encode [m]
   (b64/encodeString (types/clj->json m)))
 
-(defn- build-url [id label props]
-  (str base-track-url
-       "?data="
-       (encode {:event      label
-                :properties (merge
-                              {:token       config/mixpanel-token
-                               :distinct_id id
-                               :os          platform/os
-                               :os-version  platform/version
-                               :app-version build/version
-                               :time        (datetime/timestamp)}
-                              props)})))
+(defn- make-event [id label props]
+  {:event      label
+   :properties (merge
+                {:token       config/mixpanel-token
+                 :distinct_id id
+                 :os          platform/os
+                 :os-version  platform/version
+                 :app-version build/version
+                 :time        (datetime/timestamp)}
+                props)})
 
-(defn track [id label props]
-  (http/get (build-url id label props) nil identity))
+;; holds events that are accumulated while offline. will start throwing away old
+;; events if we accumulate more than 2000
+(def ^:private pending-events-queue (async/chan (async/sliding-buffer 2000)))
+
+(defn- submit-batch
+  "Submit a batch of events to mixpanel via POST"
+  [events]
+  (let [done-chan (async/chan)]
+    (log/debug "submitting" (count events) "events")
+    (http/post base-track-url
+               (str "data=" (encode (into [] events)))
+               (fn [_]
+                 (log/debug "successfully submitted events")
+                 (async/go (async/close! done-chan)))
+               (fn [error]
+                 (log/error "error while submitting events" error)
+                 (async/go (async/close! done-chan))))
+    done-chan))
+
+;; maximum number of events that should be submitted to mixpanel's batch
+;; endpoint at once (see https://mixpanel.com/help/reference/http)
+(def max-batch-size 50)
+
+(defn drain-events-queue!
+  "Drains accumulated events and submits them in batches of <max-batch-size>"
+  ([]
+   (drain-events-queue! pending-events-queue submit-batch))
+  ([queue callback]
+   (let [events (loop [accumulator []]
+                  (if-let [event (async/poll! queue)]
+                    (recur (conj accumulator event))
+                    accumulator))]
+     (async/go
+       (doseq [batch (partition-all max-batch-size events)]
+         (async/<! (callback batch)))))))
+
+(defn track
+  "Track or accumulate an event"
+  [id label props offline?]
+  (log/debug "tracking" id label props offline?)
+  (let [event (make-event id label props)]
+    ;; enqueue event
+    (async/go (async/>! pending-events-queue event))
+    ;; drain queue if we are online
+    (when-not offline?
+      (async/go (async/<! (drain-events-queue!))))))
 
 ;; Mixpanel events definition
-
 (def events (reader/read-string (slurp/slurp "./src/status_im/utils/mixpanel_events.edn")))
 (def event-by-trigger (reduce-kv #(assoc %1 (:trigger %3) %3) {} events))
 

--- a/test/cljs/status_im/test/utils/mixpanel.cljs
+++ b/test/cljs/status_im/test/utils/mixpanel.cljs
@@ -1,6 +1,7 @@
 (ns status-im.test.utils.mixpanel
-  (:require [cljs.test :refer-macros [deftest is testing async]]
-            [status-im.utils.mixpanel :as mixpanel]))
+  (:require [cljs.test :refer [async deftest is]]
+            [status-im.utils.mixpanel :as mixpanel]
+            [cljs.core.async :as async]))
 
 (deftest events
   (is (not (nil? mixpanel/events))))
@@ -18,3 +19,23 @@
   (is (= 1 (count (mixpanel/matching-events [:key] definitions))))
   (is (= 2 (count (mixpanel/matching-events [:key :subkey] definitions))))
   (is (empty? (mixpanel/matching-events [:key1 :another-subkey] definitions))))
+
+(deftest drain-events-queue!-test
+  (async
+   done
+   (let [queue (async/chan (async/sliding-buffer 2000))
+         results (atom [])]
+     (async/go
+       (async/<! (async/onto-chan queue (range 123) false))
+       (async/<!
+        (mixpanel/drain-events-queue!
+         queue
+         (fn [events]
+           (let [result-chan (async/chan)]
+             (swap! results conj events)
+             (async/go (async/close! result-chan))
+             result-chan))))
+       (is (= @results [(range 50)
+                        (range 50 100)
+                        (range 100 123)]))
+       (done)))))


### PR DESCRIPTION
fixes #3706 

### Summary:

Collect mixpanel events on request failure and retry on new event using batch endpoint.

Current implementation:
- if online, submit event to mixpanel
- if offline, enqueue event
- when the next event happens, try to submit the new event and the accumulated ones to mixpanel (in batches of 50, as that is the maximum number of events the mixpanel endpoint accepts)

Edge cases:
- Since we wait for a new event before trying to submit again, we might lose events if the user closes the app or the app gets killed

Possible improvements:
- Instead of waiting until the next event occurs, use a timer to periodically flush the event queue to mixpanel. However, this adds complexity because it requires a go-loop that is constantly running (the current solution only spawns a temporary go-loop for draining the queue)

It would be great if some of the core contributors could chime in with some guidance.

Thanks, I hope this makes sense!

### Steps to test:
- open Status
- turn on airplane mode
- tap around in the app
- turn off airplane mode
- tap once more
- see the events in mixpanel

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready