### PR TITLE
bug #3735 - fixed broken send and request commands in chat

### DIFF
--- a/src/status_im/chat/events/send_message.cljs
+++ b/src/status_im/chat/events/send_message.cljs
@@ -35,7 +35,7 @@
 (handlers/register-handler-fx
   :chat-send-message/send-command
   message-model/send-interceptors
-  (fn [cofx [_ params]]
+  (fn [cofx [params]]
     (message-model/send-command cofx params)))
 
 (handlers/register-handler-fx


### PR DESCRIPTION
fixes #3735 

### Summary:

Fixes wrong number of positional arguments that caused an error when commands are sent.

### Steps to test:
- Open Status
- Open chat
- Try to request some ether

status: ready 
