### PR TITLE
restored fetch tags to release jenkinsfile as we need it for release …

### DIFF
--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -31,6 +31,8 @@ node ('macos1'){
 
       checkout scm
 
+      sh 'git fetch --tags'
+
       sh 'rm -rf node_modules'
       sh 'cp .env.prod .env'
       sh 'lein deps'


### PR DESCRIPTION
We need git tags for release versions to work. 
In a recent change pulling tags was removed, so this PR adds it back