### PR TITLE
bug #3735 - fixed broken send and request commands in chat (again)

### DIFF
--- a/src/status_im/chat/events/send_message.cljs
+++ b/src/status_im/chat/events/send_message.cljs
@@ -35,7 +35,7 @@
 (handlers/register-handler-fx
   :chat-send-message/send-command
   message-model/send-interceptors
-  (fn [cofx [params]]
+  (fn [cofx [_ params]]
     (message-model/send-command cofx params)))
 
 (handlers/register-handler-fx


### PR DESCRIPTION
This PR fixes the same issue that #3736 fixed previously and then was overwritten probably in a rebase.

### Summary:

An issue with inconsistent number of positional arguments between event definition and event dispatch caused `/send` and `/request` commands in chat to raise an error.

status: ready 
