### PR TITLE
bug #3638 - fixed uneditable browser address bar in ios

### DIFF
--- a/src/status_im/ui/components/toolbar/view.cljs
+++ b/src/status_im/ui/components/toolbar/view.cljs
@@ -121,7 +121,7 @@
        {:key (str "action-" (or image icon))}))])
 
 (defn toolbar
-  ([props nav-item content-item] (toolbar props nav-item content-item [actions [{:image :blank}]]))
+  ([props nav-item content-item] (toolbar props nav-item content-item nil))
   ([{:keys [background-color style flat?]}
     nav-item
     content-item


### PR DESCRIPTION
fixes #3638

### Summary:

The issue was caused by empty list of actions that overshadowed the text input's tappable area on ios.
The solution in this PR is not to render action list when there are no actions.

### Testing notes (optional):
This PR changes how `toolbar` component works. Keep an eye on other screens and their toolbars just to see if they're still ok.

### Steps to test:
- Open browser with a custom URL
- Tap the address bar to change the url

status: ready 
