### PR TITLE
[FIX #3698] Decrease tapping area to make the version number not clic…

### DIFF
--- a/src/status_im/ui/screens/profile/user/styles.cljs
+++ b/src/status_im/ui/screens/profile/user/styles.cljs
@@ -42,6 +42,17 @@
 (defstyle my-profile-info-container
   {:background-color colors/white})
 
+(defstyle my-profile-settings-logout-wrapper
+  {:flex-direction  :row
+   :justify-content :space-between
+   :align-items     :center})
+
+(defstyle my-profile-settings-logout
+  {:min-width       "50%"})
+
+(defstyle my-profile-settings-logout-version
+  {:padding-horizontal 16})
+
 (def advanced-button
   {:margin-top    16
    :margin-bottom 12})

--- a/src/status_im/ui/screens/profile/user/views.cljs
+++ b/src/status_im/ui/screens/profile/user/views.cljs
@@ -111,12 +111,15 @@
          :action-fn    #(re-frame/dispatch [:navigate-to :backup-seed])
          :icon-content [components.common/counter {:size 22} 1]}])
      [profile.components/settings-item-separator]
-     [profile.components/settings-item {:label-kw            :t/logout
-                                        :accessibility-label :log-out-button
-                                        :value               build/version
-                                        :destructive?        true
-                                        :hide-arrow?         true
-                                        :action-fn           #(handle-logout)}]]))
+     [react/view styles/my-profile-settings-logout-wrapper
+       [react/view styles/my-profile-settings-logout
+         [profile.components/settings-item {:label-kw            :t/logout
+                                            :accessibility-label :log-out-button
+                                            :destructive?        true
+                                            :hide-arrow?         true
+                                            :action-fn           #(handle-logout)}]]
+       [react/view styles/my-profile-settings-logout-version
+         [react/text build/version]]]]))
 
 (defview advanced [{:keys [network networks dev-mode?]}]
   (letsubs [advanced?                     [:get :my-profile/advanced?]


### PR DESCRIPTION
fixes #3698

### Summary:

The build version is displayed in a separate component (no longer part of `profile.components/settings-item` as `value`). The row is split in half, which means that the left 50% of the total width is clickable. Note: using `pointer-events` on elements inside `react/touchable-highlight` doesn't seem to work and because of that components have to be apart.

### Review notes (optional):
<!-- (Specify if something in particular should be looked at, or ignored, during review) -->

### Testing notes (optional):
<!-- (Specify if something specific has to be tested, for example upgrade paths) -->

### Steps to test:
- Open Status
- Go to Profile
- Tap Version

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->
