### PR TITLE
[#3789] do not show "Shake to provide your feedback" popup when app starts

### DIFF
--- a/android/app/src/main/java/im/status/ethereum/MainActivity.java
+++ b/android/app/src/main/java/im/status/ethereum/MainActivity.java
@@ -24,6 +24,7 @@ import com.facebook.react.ReactActivity;
 import com.facebook.react.modules.core.PermissionListener;
 import org.devio.rn.splashscreen.SplashScreen;
 import com.testfairy.TestFairy;
+import com.instabug.library.Instabug;
 
 import java.util.Properties;
 
@@ -112,6 +113,7 @@ public class MainActivity extends ReactActivity
         SplashScreen.show(this);
         super.onCreate(savedInstanceState);
 
+        Instabug.setIntroMessageEnabled(false);
         if(BuildConfig.TESTFAIRY_ENABLED == "1") {
             TestFairy.begin(this, "969f6c921cb435cea1d41d1ea3f5b247d6026d55");
         }

--- a/src/status_im/utils/instabug.cljs
+++ b/src/status_im/utils/instabug.cljs
@@ -25,4 +25,5 @@
 (defn init []
   (.startWithToken rn-dependencies/instabug
                    config/instabug-token
-                   (.. rn-dependencies/instabug -invocationEvent -shake)))
+                   (.. rn-dependencies/instabug -invocationEvent -shake))
+  (.setIntroMessageEnabled rn-dependencies/instabug false))


### PR DESCRIPTION
The popup is removed because:
- The popup prevents automated tests from entering valid passphrase and it's not possible to interact with this specific popup (to wait for presence/absence)
- A user loses focus from input field, after appearing of the popup. (This is happening on password entering in ~70% of cases , as result a user should enter a password from scratch)