### PR TITLE
[FIX #3765] Improved chat interface for development console

### DIFF
--- a/src/status_im/chat/screen.cljs
+++ b/src/status_im/chat/screen.cljs
@@ -56,10 +56,11 @@
      [toolbar/platform-agnostic-toolbar {}
       toolbar/nav-back-count
       [toolbar-content/toolbar-content-view]
-      [toolbar/actions [{:icon      :icons/options
-                         :icon-opts {:color               :black
-                                     :accessibility-label :chat-menu-button}
-                         :handler   #(on-options chat-id name group-chat public?)}]]]
+      (when (not= chat-id constants/console-chat-id)
+        [toolbar/actions [{:icon      :icons/options
+                           :icon-opts {:color               :black
+                                       :accessibility-label :chat-menu-button}
+                           :handler   #(on-options chat-id name group-chat public?)}]])]
      (when-not (or public? group-chat) [add-contact-bar (-> contacts first :identity)])]))
 
 (defmulti message-row (fn [{{:keys [type]} :row}] type))


### PR DESCRIPTION
Fixes #3765 and #3788

### Summary:

Hides options menu for development console chat and removed ability to swipe-delete from home screen. Also fixed incidental issue where the delete button got error calling :delete-chat instead of :remove-chat

### Steps to test:
- Open Status
- Create account
- Turn on development mode in profile
- Go to home screen, open console
- Menu button (dots) should not appear
- On home screen, console row should not be swipeable & no delete button

Status: Ready