### PR TITLE
Align toolbar titles to the left for network & offline-messaging screens

### DIFF
--- a/src/status_im/ui/components/toolbar/styles.cljs
+++ b/src/status_im/ui/components/toolbar/styles.cljs
@@ -36,7 +36,9 @@
   {:color          colors/black
    :letter-spacing -0.2
    :font-size      17
-   :text-align     :center})
+   :ios            {:text-align     :center}
+   :android        {:text-align     :left
+                    :margin-left    22}})
 
 (def toolbar-actions
   {:flex           0


### PR DESCRIPTION
Fixes #3748 

### Summary:

Toolbar titles have been aligned to the left for network & offline-messaging screens

### Steps to test:
- Open Status
- Go to profile
- Advanced -> settings && Advanced -> Offline messages
- Check titles alignment

status: ready <!-- Can be ready or wip -->
