### PR TITLE
Don't navigate back after saving profile

### DIFF
--- a/src/status_im/ui/screens/profile/events.cljs
+++ b/src/status_im/ui/screens/profile/events.cljs
@@ -78,7 +78,6 @@
                               (if photo-path
                                 {:photo-path photo-path}))]
       (handlers/merge-fx cofx
-                         {:dispatch [:navigate-back]}
                          (clear-profile)
                          (accounts-events/account-update cleaned-edit)))))
 


### PR DESCRIPTION
After user tap "Done" on profile editing page application redirects back.

Before:
![before1](https://user-images.githubusercontent.com/5045098/38478436-40c4b700-3beb-11e8-9ed1-ec8704c0eba2.gif)

After:
![after1](https://user-images.githubusercontent.com/5045098/38478443-498df5a4-3beb-11e8-9045-887d99fa7a3d.gif)

