### PR TITLE
Fix browser saving

### DIFF
--- a/src/status_im/ui/screens/browser/events.cljs
+++ b/src/status_im/ui/screens/browser/events.cljs
@@ -29,7 +29,7 @@
 (defn add-browser-fx [{:keys [db now] :as cofx} browser]
   (let [new-browser (get-new-browser browser now)]
     {:db           (update-in db [:browser/browsers (:browser-id new-browser)] merge new-browser)
-     :save-browser new-browser}))
+     :data-store/save-browser new-browser}))
 
 (handlers/register-handler-fx
   :open-dapp-in-browser


### PR DESCRIPTION
After user opens the browser and navigate to any link the application shows an error:
```
console.error: "re-frame: no handler registered for effect: "", {"ns":null,"name":"save-browser","fqn":"save-browser","_hash":-2140820428,"cljs$lang$protocol_mask$partition0$":2153775105,"cljs$lang$protocol_mask$partition1$":4096}, "". Ignoring."

error
    YellowBox.js:71:16
_callTimer
    JSTimers.js:154:6
callTimers
    JSTimers.js:411:17
__callFunction
    MessageQueue.js:353:47
<unknown>
    MessageQueue.js:118:26
__guardSafe
    MessageQueue.js:316:6
callFunctionReturnFlushedQueue
    MessageQueue.js:117:17
```
![simulator screen shot - iphone 6 - 2018-04-09 at 12 12 40](https://user-images.githubusercontent.com/5045098/38479040-603d9738-3bef-11e8-8da8-db5526deeba8.png)
