### PR TITLE
WIP [#3783] Add outdated version warning

### DIFF
--- a/src/status_im/translations/en.cljs
+++ b/src/status_im/translations/en.cljs
@@ -27,6 +27,7 @@
    :no                                   "No"
    :on                                   "On"
    :off                                  "Off"
+   :incompatible-message                 "Your version of Status is outdated and was not able to process a message you received"
 
    :camera-access-error                  "To grant the required camera permission, please go to your system settings and make sure that Status > Camera is selected."
    :photos-access-error                  "To grant the required photos permission, please go to your system settings and make sure that Status > Photos is selected."

--- a/src/status_im/transport/message/transit.cljs
+++ b/src/status_im/transport/message/transit.cljs
@@ -118,6 +118,11 @@
   (transit/write writer o))
 
 (defn deserialize
-  "Deserializes a record implementing the StatusMessage protocol using the custom readers"
+  "Deserializes a record implementing the StatusMessage protocol using the custom readers
+  Returns nil if there is an error during deserialization (invalid transit for instance)"
   [o]
-  (try (transit/read reader o) (catch :default e nil)))
+  (try
+    (transit/read reader o)
+    (catch :default e nil)))
+
+(def unknown-message-type? transit/tagged-value?)

--- a/src/status_im/ui/components/connectivity/styles.cljs
+++ b/src/status_im/ui/components/connectivity/styles.cljs
@@ -1,14 +1,14 @@
 (ns status-im.ui.components.connectivity.styles
   (:require-macros [status-im.utils.styles :refer [defnstyle]]))
 
-(defnstyle offline-wrapper [top opacity window-width pending?]
+(defnstyle offline-wrapper [top opacity window-width pending? second-line?]
   {:ios              {:z-index 0}
    :opacity          opacity
    :width            window-width
    :top              (+ (+ 56 top) (if pending? 35 0))
    :position         :absolute
    :background-color "#828b92cc"
-   :height           35})
+   :height           (if second-line? 56 35)})
 
 (def offline-text
   {:text-align :center

--- a/src/status_im/ui/components/connectivity/view.cljs
+++ b/src/status_im/ui/components/connectivity/view.cljs
@@ -14,15 +14,16 @@
                                        :duration 250})))
 
 (defn error-view [_]
-  (let [offline?            (re-frame/subscribe [:offline?])
-        connection-problem? (re-frame/subscribe [:connection-problem?])
-        offline-opacity     (animation/create-value 0.0)
-        on-update           (fn [_ _]
-                              (animation/set-value offline-opacity 0)
-                              (when (or @offline? @connection-problem?)
-                                (start-error-animation offline-opacity)))
-        pending-contact?    (re-frame/subscribe [:current-contact :pending?])
-        view-id             (re-frame/subscribe [:get :view-id])]
+  (let [offline?              (re-frame/subscribe [:offline?])
+        connection-problem?   (re-frame/subscribe [:connection-problem?])
+        incompatible-message? (re-frame/subscribe [:incompatible-message-received?])
+        offline-opacity       (animation/create-value 0.0)
+        on-update             (fn [_ _]
+                                (animation/set-value offline-opacity 0)
+                                (when (or @incompatible-message? @offline? @connection-problem?)
+                                  (start-error-animation offline-opacity)))
+        pending-contact?      (re-frame/subscribe [:current-contact :pending?])
+        view-id               (re-frame/subscribe [:get :view-id])]
     (reagent/create-class
       {:component-did-mount
        on-update
@@ -31,11 +32,12 @@
        :display-name "connectivity-error-view"
        :reagent-render
        (fn [{:keys [top]}]
-         (when (or @offline? @connection-problem?)
-           (let [pending? (and @pending-contact? (= :chat @view-id))]
-             [react/animated-view {:style (styles/offline-wrapper top offline-opacity window-width pending?)}
-              [react/view
-               [react/text {:style styles/offline-text}
-                (i18n/label (if @connection-problem?
-                              :t/connection-problem
-                              :t/offline))]]])))})))
+         (when true (or @offline? @connection-problem? @incompatible-message?)
+               (let [pending? (and @pending-contact? (= :chat @view-id))]
+                 [react/animated-view {:style (styles/offline-wrapper top offline-opacity window-width pending? @incompatible-message?)}
+                  [react/view
+                   [react/text {:style styles/offline-text}
+                    (i18n/label (cond
+                                  @connection-problem?   :t/connection-problem
+                                  @incompatible-message? :t/incompatible-message
+                                  @offline?              :t/offline))]]])))})))

--- a/src/status_im/ui/screens/db.cljs
+++ b/src/status_im/ui/screens/db.cljs
@@ -68,6 +68,7 @@
 ;;:online - presence of internet connection in the phone
 (spec/def ::network-status (spec/nilable keyword?))
 
+(spec/def ::incompatible-message-received (spec/nilable boolean?))
 (spec/def ::mailserver-status (spec/nilable keyword?))
 (spec/def ::peers-count (spec/nilable integer?))
 
@@ -187,6 +188,7 @@
                   ::network-status
                   ::mailserver-status
                   ::peers-count
+                  ::incompatible-message-received
                   ::sync-listening-started
                   ::sync-state
                   ::sync-data

--- a/src/status_im/ui/screens/subs.cljs
+++ b/src/status_im/ui/screens/subs.cljs
@@ -37,6 +37,7 @@
 (reg-sub :network-status :network-status)
 (reg-sub :peers-count :peers-count)
 (reg-sub :mailserver-status :mailserver-status)
+(reg-sub :incompatible-message-received? :incompatible-message-received)
 
 (reg-sub :offline?
   :<- [:network-status]


### PR DESCRIPTION
fix #3783 

this allows the recipient of a message to know that his version
of status is outdated when the message has a message-type that
is not supported

### Testing notes (optional):
Use the build in this PR https://github.com/status-im/status-react/pull/3811 for testing, it's the same code except it doesn't support it's own messages, so you can create 2 contacts and when they send message to each other an error should appear

status: waiting for https://github.com/status-im/status-react/issues/3787 design
