### PR TITLE
bug #3775 - fixed missing dapp descriptions

### DIFF
--- a/src/status_im/ui/screens/add_new/open_dapp/views.cljs
+++ b/src/status_im/ui/screens/add_new/open_dapp/views.cljs
@@ -47,7 +47,7 @@
                       :keyboardShouldPersistTaps :always}]]))
 
 (views/defview dapp-description []
-  (views/letsubs [{:keys [name dapp-url] :as dapp} [:get-screen-params]]
+  (views/letsubs [{:keys [name dapp-url description] :as dapp} [:get-screen-params]]
     [react/keyboard-avoiding-view styles/main-container
      [status-bar/status-bar]
      [toolbar.view/simple-toolbar]
@@ -70,7 +70,8 @@
      [react/view styles/description-container
       [react/text {:style styles/gray-label}
        (i18n/label :t/description)]
-      [react/text {:style (merge styles/black-label {:padding-top 18})}]
+      [react/text {:style (merge styles/black-label {:padding-top 18})}
+       description]
       [components/separator {:margin-top 15}]
       [react/text {:style (merge styles/gray-label {:padding-top 18})}
        (i18n/label :t/url)]


### PR DESCRIPTION
fixes #3775 
also fixes #1664

### Summary:

Dapp descriptions were missing on the screen before dapp is opened in the browser. This PR adds them back.

### Steps to test:
- Open Status
- Try opening a few listed dapps and see if descriptions are there

status: ready 
