### PR TITLE
[#3818] If a message contains only an emoji, show it without chat bubble

### DIFF
--- a/src/status_im/chat/styles/message/message.cljs
+++ b/src/status_im/chat/styles/message/message.cljs
@@ -43,12 +43,12 @@
   [{:keys [outgoing] :as message}]
   (let [align     (if outgoing :flex-end :flex-start)
         direction (if outgoing :row-reverse :row)]
-    (merge message-body-base
-           {:flex-direction direction
+    (assoc message-body-base
+            :flex-direction direction
             :width          260
             :padding-top    (message-padding-top message)
             :align-self     align
-            :align-items    align})))
+            :align-items    align)))
 
 (def selected-message
   {:margin-top  18
@@ -94,18 +94,29 @@
    :ios        {:font-size 14}})
 
 (defn text-message
-  [{:keys [outgoing group-chat incoming-group]}]
-  (merge style-message-text
-         {:margin-top (if incoming-group 4 0)}))
+  [{:keys [incoming-group]}]
+  (assoc style-message-text
+          :margin-top (if incoming-group 4 0)))
+
+(defn emoji-message
+  [{:keys [incoming-group]}]
+  (assoc style-message-text
+          :margin-top (if incoming-group 4 0)
+          :font-size      40
+          :line-height    50))
 
 (defn message-view
-  [{:keys [content-type outgoing group-chat selected]}]
+  [{:keys [content-type]}]
   (merge {:padding         12
           :background-color styles/color-white
           :border-radius   8}
-         (when (= content-type constants/content-type-command)
-           {:padding-top    10
-            :padding-bottom 14})))
+          (when (= content-type constants/content-type-emoji)
+            {:background-color nil
+             :border-radius  0
+             :padding        0})
+          (when (= content-type constants/content-type-command)
+            {:padding-top    10
+             :padding-bottom 14})))
 
 (defstyle author
   {:color         styles/color-gray4
@@ -123,7 +134,7 @@
    :background-color styles/color-white})
 
 (def command-request-from-text
-  (merge style-sub-text {:margin-bottom 2}))
+  (assoc style-sub-text :margin-bottom 2))
 
 (defn command-request-image-touchable []
   {:position        :absolute
@@ -176,9 +187,9 @@
    :tint-color :#a9a9a9cc})
 
 (def command-text
-  (merge style-message-text
-         {:margin-top        8
-          :margin-horizontal 0}))
+  (assoc style-message-text
+          :margin-top        8
+          :margin-horizontal 0))
 
 (def audio-container
   {:flex-direction :row

--- a/src/status_im/chat/subs.cljs
+++ b/src/status_im/chat/subs.cljs
@@ -12,6 +12,14 @@
             [status-im.i18n :as i18n]
             [status-im.constants :as const]))
 
+;; lodash's emoji regex, more info: https://medium.com/reactnative/emojis-in-javascript-f693d0eb79fb
+(def regx-emoji #"^((?:[\u2700-\u27bf]|[\u2600-\u26ff]|(?:\ud83c[\udde6-\uddff]){2}|[\ud800-\udbff][\udc00-\udfff])[\ufe0e\ufe0f]?(?:[\u0300-\u036f\ufe20-\ufe23\u20d0-\u20f0]|\ud83c[\udffb-\udfff])?(?:\u200d(?:[^\ud800-\udfff]|(?:\ud83c[\udde6-\uddff]){2}|[\ud800-\udbff][\udc00-\udfff])[\ufe0e\ufe0f]?(?:[\u0300-\u036f\ufe20-\ufe23\u20d0-\u20f0]|\ud83c[\udffb-\udfff]|[\ufe00-\ufe0f])?)*)+$")
+
+(defn- contains-only-emoji? [text]
+  (let [length-threshold 20] ;; Emoji symbols require 4 bytes and JS evaluates their length as 2 characters (`"💩".length === 2`). The threshold of 20 equals 10 emoji.
+    (when (and (not= text nil) (<= (.-length text) length-threshold))
+      (not= (re-matches regx-emoji text) nil))))
+
 (reg-sub :get-chats :chats)
 
 (reg-sub :get-current-chat-id :current-chat-id)
@@ -176,11 +184,18 @@
                        (conj prepared-messages {:type :datemark
                                                 :value datemark}))))))))
 
+(defn messages-emoji
+  "Change content-type if the message consists only of emoji symbols"
+  [messages]
+  (map (fn [message]
+    (if (contains-only-emoji? (:content message)) (assoc message :content-type "emoji") message))
+      messages))
+
 (reg-sub
   :get-current-chat-messages
   :<- [:get-current-chat]
   (fn [{:keys [messages]}]
-    (-> messages message-datemark-groups messages-stream)))
+    (-> messages message-datemark-groups messages-stream messages-emoji)))
 
 (reg-sub
   :get-commands-for-chat

--- a/src/status_im/chat/views/message/message.cljs
+++ b/src/status_im/chat/views/message/message.cljs
@@ -164,9 +164,14 @@
 
 (defn text-message
   [{:keys [content] :as message}]
+  (let [parsed-text (cached-parse-text content :browse-link-from-message)]
+    [message-view message
+      [react/text {:style (style/text-message message)} parsed-text]]))
+
+(defn emoji-message
+  [{:keys [content] :as message}]
   [message-view message
-   (let [parsed-text (cached-parse-text content :browse-link-from-message)]
-     [react/text {:style (style/text-message message)} parsed-text])])
+    [react/text {:style (style/emoji-message message)} content]])
 
 (defn placeholder-message
   [{:keys [content] :as message}]
@@ -200,6 +205,10 @@
 (defmethod message-content constants/content-type-placeholder
   [wrapper message]
   [wrapper message [placeholder-message message]])
+
+(defmethod message-content constants/content-type-emoji
+  [wrapper message]
+  [wrapper message [emoji-message message]])
 
 (defmethod message-content :default
   [wrapper {:keys [content-type content] :as message}]

--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -16,6 +16,7 @@
 (def content-type-command-request "command-request")
 (def content-type-status "status")
 (def content-type-placeholder "placeholder")
+(def content-type-emoji "emoji")
 
 (def min-password-length 6)
 (def max-chat-name-length 20)


### PR DESCRIPTION
fixes #3818

### Summary:

Messages consisting only of emoji (up to 10) are shown w/out a bubble background and with larger font size. If a message contains more than 10 emoji, it is displayed with normal white background and with normal font size. The threshold of 10 is set as a performance optimization.

### Steps to test:
- Open Status
- Send or receive messages consisting only of emoji.

<!-- (PRs will only be accepted if squashed into single commit.) -->

![screenshot_20180411-224657](https://user-images.githubusercontent.com/536331/38624454-af295ee4-3dda-11e8-83ba-0823b529b81f.png)

status: wip <!-- Can be ready or wip -->
