### PR TITLE
Fix deleted chats behavior

### DIFF
--- a/src/status_im/chat/events.cljs
+++ b/src/status_im/chat/events.cljs
@@ -289,20 +289,29 @@
       (handlers/merge-fx cofx (transport/unsubscribe-from-chat chat-id)))))
 
 (handlers/register-handler-fx
-  :remove-chat
+  :leave-chat-and-navigate-home
   [re-frame/trim-v]
   (fn [cofx [chat-id]]
     (handlers/merge-fx cofx
                        (models/remove-chat chat-id)
+                       (navigation/replace-view :home)
                        (remove-transport chat-id))))
+
+(handlers/register-handler-fx
+  :leave-group-chat?
+  [re-frame/trim-v]
+  (fn [_ [chat-id]]
+    {:show-confirmation {:title               (i18n/label :t/leave-confirmation)
+                         :content             (i18n/label :t/leave-group-chat-confirmation)
+                         :confirm-button-text (i18n/label :t/leave)
+                         :on-accept           #(re-frame/dispatch [:leave-chat-and-navigate-home chat-id])}}))
 
 (handlers/register-handler-fx
   :remove-chat-and-navigate-home
   [re-frame/trim-v]
   (fn [cofx [chat-id]]
     (handlers/merge-fx cofx
-                       (models/remove-chat chat-id)
-                       (remove-transport chat-id)
+                       (models/remove-chat chat-id) 
                        (navigation/replace-view :home))))
 
 (handlers/register-handler-fx
@@ -350,15 +359,6 @@
                          (navigation/navigate-to-clean :home)
                          (navigate-to-chat random-id {})
                          (transport.message/send (group-chat/GroupAdminUpdate. chat-name selected-contacts) random-id)))))
-
-(handlers/register-handler-fx
-  :leave-group-chat?
-  [re-frame/trim-v]
-  (fn [_ [chat-id]]
-    {:show-confirmation {:title               (i18n/label :t/leave-confirmation)
-                         :content             (i18n/label :t/leave-group-chat-confirmation)
-                         :confirm-button-text (i18n/label :t/leave)
-                         :on-accept           #(re-frame/dispatch [:remove-chat-and-navigate-home chat-id])}}))
 
 (handlers/register-handler-fx
   :show-profile

--- a/src/status_im/chat/models.cljs
+++ b/src/status_im/chat/models.cljs
@@ -100,9 +100,7 @@
   (let [{:keys [chat-id group-chat debug?]} (get-in db [:chats chat-id])]
     (cond-> {:db (-> db
                      (update :chats dissoc chat-id)
-                     (update :deleted-chats (fnil conj #{}) chat-id))}
-      (or group-chat debug?)
-      (assoc :data-store/delete-messages chat-id)
+                     (update :deleted-chats (fnil conj #{}) chat-id))} 
       debug?
       (assoc :data-store/delete-chat chat-id)
       (not debug?)

--- a/src/status_im/chat/models/message.cljs
+++ b/src/status_im/chat/models/message.cljs
@@ -110,15 +110,11 @@
   [{:keys [db get-stored-message]} {:keys [chat-id from message-id] :as message}]
   (let [{:keys [chats deleted-chats current-public-key]} db
         {:keys [messages not-loaded-message-ids]}        (get chats chat-id)]
-    (when (not= from current-public-key)
-      (if (group-message? message)
-        (not (or (get deleted-chats chat-id)
-                 (get messages message-id)
-                 (get not-loaded-message-ids message-id)))
-        (not (or (get messages message-id)
-                 (get not-loaded-message-ids message-id)
-                 (and (get deleted-chats chat-id)
-                      (get-stored-message message-id))))))))
+    (when (not= from current-public-key) 
+      (not (or (get messages message-id)
+               (get not-loaded-message-ids message-id)
+               (and (get deleted-chats chat-id)
+                    (get-stored-message message-id)))))))
 
 (defn message-seen-by? [message user-pk]
   (= :seen (get-in message [:user-statuses user-pk])))

--- a/src/status_im/commands/handlers/debug.cljs
+++ b/src/status_im/commands/handlers/debug.cljs
@@ -55,8 +55,7 @@
           (do (re-frame/dispatch [:update-contact! dapp])
               (respond {:type :ok
                         :text "The DApp or bot has been updated."}))
-          (do (re-frame/dispatch [:add-contacts [dapp]])
-              (re-frame/dispatch [:open-chat-with-contact dapp])
+          (do (re-frame/dispatch [:open-chat-with-contact dapp])
               (respond {:type :ok
                         :text "The DApp or bot has been added."}))))
       (respond {:type :error

--- a/src/status_im/ui/screens/home/views.cljs
+++ b/src/status_im/ui/screens/home/views.cljs
@@ -38,7 +38,7 @@
 
 (views/defview home-list-item [[home-item-id home-item]]
   (views/letsubs [swiped? [:delete-swipe-position home-item-id]]
-    (let [delete-action (if (:chat-id home-item) :remove-chat :remove-browser)
+    (let [delete-action (if (:chat-id home-item) :remove-chat-and-navigate-home :remove-browser)
           inner-item-view (if (:chat-id home-item)
                             inner-item/home-list-chat-item-inner-view
                             inner-item/home-list-browser-item-inner-view)


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

Fixes #3814 

Also re-introduces expected semantics for deleting/leaving chats:
1. Only group chats (private & public) can be left (leave chat action), in which case user unsubscribes from chat and never receives messages from it again (unless he for example joins the same public chat again)
2. Deleting the chat (whether 1-1 or group) just means that the chat is hidden from home items list, whenever new message is received, the chat appears again.

### Testing notes (optional):
Test the scenario described in ticket + make sure that the statements above hold true (ask @denis-sharypin if there is anything not clear in how it should behave)

status: ready
