### PR TITLE
[#3841] Fix remove-browser event handler

### DIFF
--- a/src/status_im/ui/screens/browser/events.cljs
+++ b/src/status_im/ui/screens/browser/events.cljs
@@ -70,4 +70,4 @@
   [re-frame/trim-v]
   (fn [{:keys [db]} [browser-id]]
     {:db (update-in db [:browser/browsers] dissoc browser-id)
-     :remove-browser browser-id}))
+     :data-store/remove-browser browser-id}))


### PR DESCRIPTION
 Fix #3841
Fix effect name from `:remove-browser` to `:data-store/remove-browser`.
Similar fix #3802