### PR TITLE
[#3817] Remove auto correct from passphrase recover

### DIFF
--- a/src/status_im/ui/screens/accounts/recover/views.cljs
+++ b/src/status_im/ui/screens/accounts/recover/views.cljs
@@ -32,6 +32,7 @@
       :placeholder         (i18n/label :t/enter-12-words)
       :multiline           true
       :default-value       passphrase
+      :auto-correct        false
       :on-change-text      #(re-frame/dispatch [:set-in [:accounts/recover :passphrase] %])
       :error               error}]))
 


### PR DESCRIPTION
Fixes #3817 

### Summary:
Removes iOS auto-complete words from passphrase recovery input

### Steps to test:
- Open Status iOS
- Create account for passphrase or recover existing account
- Passphrase keyboard should not display matching words from memory or expectations

status: Ready
