### PR TITLE
[#3852] Back button from new chat goes to home screen

### DIFF
--- a/src/status_im/android/core.cljs
+++ b/src/status_im/android/core.cljs
@@ -20,11 +20,15 @@
                        ;; in handlers
                        (let [stack      (subscribe [:get :navigation-stack])
                              result-box (subscribe [:get-current-chat-ui-prop :result-box])
-                             webview    (subscribe [:get :webview-bridge])]
+                             webview    (subscribe [:get :webview-bridge])
+                             view-id    (subscribe [:get :view-id])]
                          (cond
 
                            (and @webview (:can-go-back? @result-box))
                            (do (.goBack @webview) true)
+
+                           (#{:home :wallet :my-profile} view-id)
+                           (do (.exitApp react/back-handler))
 
                            (< 1 (count @stack))
                            (do (dispatch [:navigate-back]) true)

--- a/src/status_im/chat/screen.cljs
+++ b/src/status_im/chat/screen.cljs
@@ -57,7 +57,7 @@
      (if (= chat-id constants/console-chat-id)
        [toolbar/simple-toolbar name]
        [toolbar/platform-agnostic-toolbar {}
-        toolbar/nav-back-count
+        (toolbar/nav-back-count {:home? true})
         [toolbar-content/toolbar-content-view]
         [toolbar/actions [{:icon      :icons/options
                            :icon-opts {:color               :black

--- a/src/status_im/ui/components/toolbar/actions.cljs
+++ b/src/status_im/ui/components/toolbar/actions.cljs
@@ -18,8 +18,13 @@
 
 (def default-handler #(re-frame/dispatch [:navigate-back]))
 
+(def home-handler #(re-frame/dispatch [:navigate-to-clean :home]))
+
 (def default-back
   (back default-handler))
+
+(def home-back
+  (back home-handler))
 
 (defn back-white [handler]
   {:icon                :icons/back

--- a/src/status_im/ui/components/toolbar/view.cljs
+++ b/src/status_im/ui/components/toolbar/view.cljs
@@ -51,7 +51,11 @@
 
 (def default-nav-back [nav-button actions/default-back])
 
-(def nav-back-count [nav-button-with-count actions/default-back])
+(defn nav-back-count
+  ([]
+   [nav-button-with-count actions/default-back])
+  ([{:keys [home?]}]
+   [nav-button-with-count (if home? actions/home-back actions/default-back)]))
 
 (defn default-done
   "Renders a touchable icon on Android or a label or iOS."

--- a/src/status_im/ui/screens/browser/views.cljs
+++ b/src/status_im/ui/screens/browser/views.cljs
@@ -80,7 +80,7 @@
     [react/keyboard-avoiding-view styles/browser
      [status-bar/status-bar]
      [toolbar.view/toolbar {}
-      toolbar.view/nav-back-count
+      (toolbar.view/nav-back-count)
       (if dapp?
         [toolbar-content-dapp contact unread-messages-number]
         [toolbar-content browser unread-messages-number])]


### PR DESCRIPTION
Fixes #3852 

### Summary:
- Extends replace-view to allow popping multiple views
- Newly created chat can navigate back to home screen immediately 

### Steps to test:
- Open Status
- Log in, create new chat from home screen
- Tap back button
- View should navigate to home screen instead of "New" options menu

Status: Ready
