### PR TITLE
[#3825] Retain chat input text on blur

### DIFF
--- a/src/status_im/chat/views/input/input.cljs
+++ b/src/status_im/chat/views/input/input.cljs
@@ -30,7 +30,7 @@
       :editable               true
       :blur-on-submit         false
       :on-focus               #(re-frame/dispatch [:set-chat-ui-props {:input-focused?    true
-                                                                        :messages-focused? false}])
+                                                                       :messages-focused? false}])
       :on-blur                #(re-frame/dispatch [:set-chat-ui-props {:input-focused? false}])
       :on-submit-editing      (fn [_]
                                 (if single-line-input?


### PR DESCRIPTION
Fixes #3825 

### Summary:
No longer clears inputted chat text when focus lost

### Steps to test:
- Open Status
- Open chat, type in input field
- Tap elsewhere
- Text should stay in input

Status: Ready
