### PR TITLE
[#3850] Add Aragon Test (ATT) to testnet wallet

### DIFF
--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -38,7 +38,7 @@
            {:id :postponed :label (i18n/label :t/postponed) :checked? true}]}})
 
 (def default-account-settings
-  {:wallet {:visible-tokens {:testnet #{:STT}
+  {:wallet {:visible-tokens {:testnet #{:STT :ATT}
                              :mainnet #{:SNT}}}
    :wnode {:testnet "main"
            :mainnet "main"}})

--- a/src/status_im/utils/ethereum/tokens.cljs
+++ b/src/status_im/utils/ethereum/tokens.cljs
@@ -379,6 +379,10 @@
        :symbol   :STT
        :decimals 18
        :address  "0xc55cf4b03948d7ebc8b9e8bad92643703811d162"}
+      {:name     "Aragon Test Token"
+       :symbol   :ATT
+       :decimals 8
+       :address  "0xfff28fb56b2a53597c55e1a767c906f339335025"}
       {:name     "Handy Test Token"
        :symbol   :HND
        :decimals 18


### PR DESCRIPTION
Fixes #3850

### Summary:
Adds [Aragon Test Token](https://ropsten.etherscan.io/token/0xfff28fb56b2a53597c55e1a767c906f339335025) to default asset list on Ropsten/Rinkeby

### Steps to test:
- Open Status
- Switch to testnet
- Visit Wallet tab
- ATT should appear in list

Status: Ready
