### PR TITLE
[fix 3806] Provide separate MailServers for each network

### DIFF
--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -38,7 +38,9 @@
 
 (def default-account-settings
   {:wallet {:visible-tokens {:testnet #{:STT}
-                             :mainnet #{:SNT}}}})
+                             :mainnet #{:SNT}}}
+   :wnode {:testnet "main"
+           :mainnet "main"}})
 
 (defn- transform-config [networks]
   (->> networks
@@ -87,19 +89,17 @@
    (merge testnet-networks
           (when config/mainnet-networks-enabled? mainnet-networks))))
 
-;; adamb's status-cluster enode
-(def default-wnode "main")
-
 (def default-wnodes
-  {"main"   {:id      "main"
-             :name    "Status mailserver A"
-             :address "enode://fa63a6cc730468c5456eab365b2a7a68a166845423c8c9acc363e5f8c4699ff6d954e7ec58f13ae49568600cff9899561b54f6fc2b9923136cd7104911f31cce@163.172.168.202:30303"}
-   "backup" {:id      "backup"
-             :name    "Status mailserver B"
-             :address "enode://90cbf961c87eb837adc1300a0a6722a57134d843f0028a976d35dff387f101a2754842b6b694e50a01093808f304440d4d968bcbc599259e895ff26e5a1a17cf@51.15.194.39:30303"}})
+  {:testnet {"main"   {:id      "main"
+                       :name    "Status testnet mailserver A"
+                       :address "enode://fa63a6cc730468c5456eab365b2a7a68a166845423c8c9acc363e5f8c4699ff6d954e7ec58f13ae49568600cff9899561b54f6fc2b9923136cd7104911f31cce@163.172.168.202:30303"}
+             "backup" {:id      "backup"
+                       :name    "Status testnet mailserver B"
+                       :address "enode://90cbf961c87eb837adc1300a0a6722a57134d843f0028a976d35dff387f101a2754842b6b694e50a01093808f304440d4d968bcbc599259e895ff26e5a1a17cf@51.15.194.39:30303"}}
+   :mainnet {"main" {:id      "main"
+                     :name    "Status mainnet mailserver"
+                     :address "enode://b963569aac14785f756ecf97e7549a513dea993a1bc744c4f8efe2b4e9479500dd3f5d18f3da19f6550b8bd0d8770350950c9a7da8168b44865402dcc9a51657@51.15.35.110:30403"}}})
 
-;; TODO(oskarth): Determine if this is the correct topic or not
-(def inbox-topic "0xaabb11ee")
 (def inbox-password "status-offline-inbox")
 
 ;; Used to generate topic for contact discoveries

--- a/src/status_im/data_store/realm/schemas/base/v1/account.cljs
+++ b/src/status_im/data_store/realm/schemas/base/v1/account.cljs
@@ -18,7 +18,6 @@
                           :network             :string
                           :networks            {:type       :list
                                                 :objectType :network}
-                          :wnode               :string
                           :settings            {:type :string}
                           :sharing-usage-data? {:type :bool :default false}
                           :dev-mode?           {:type :bool :default false}

--- a/src/status_im/ui/screens/accounts/events.cljs
+++ b/src/status_im/ui/screens/accounts/events.cljs
@@ -49,11 +49,10 @@
 
 (defn add-account
   "Takes db and new account, creates map of effects describing adding account to database and realm"
-  [{:keys [network inbox/wnode] :networks/keys [networks] :as db} {:keys [address] :as account}]
+  [{:keys [network] :networks/keys [networks] :as db} {:keys [address] :as account}]
   (let [enriched-account (assoc account
                                 :network  network
                                 :networks networks
-                                :wnode    wnode
                                 :address  address)]
     {:db           (assoc-in db [:accounts/accounts address] enriched-account)
      :data-store/save-account enriched-account}))
@@ -106,10 +105,11 @@
       {:db           (assoc-in db [:accounts/accounts id] new-account)
        :data-store/save-account new-account})))
 
-(defn update-wallet-settings [{:accounts/keys [current-account-id accounts] :as db} settings]
-  (let [new-account (-> (get accounts current-account-id)
-                        (assoc :settings settings))]
-    {:db           (assoc-in db [:accounts/accounts current-account-id] new-account)
+(defn update-settings [settings {:keys [db] :as cofx}]
+  (let [{:accounts/keys [current-account-id accounts]} db
+        new-account                                    (-> (get accounts current-account-id)
+                                                           (assoc :settings settings))]
+    {:db                      (assoc-in db [:accounts/accounts current-account-id] new-account)
      :data-store/save-account new-account}))
 
 (defn account-update

--- a/src/status_im/ui/screens/accounts/login/events.cljs
+++ b/src/status_im/ui/screens/accounts/login/events.cljs
@@ -67,9 +67,6 @@
     {:network network
      :config  config}))
 
-(defn get-wnode-by-address [db address]
-  (get-in db [:accounts/accounts address :wnode] constants/default-wnode))
-
 (defn wrap-with-initialize-geth-fx [db address password]
   (let [{:keys [network config]} (get-network-by-address db address)]
     {:initialize-geth-fx config
@@ -91,9 +88,7 @@
   :login-account
   (fn [{{:keys [network status-node-started?] :as db} :db} [_ address password]]
     (let [{account-network :network} (get-network-by-address db address)
-          wnode (get-wnode-by-address db address)
           db' (-> db
-                  (assoc :inbox/wnode wnode)
                   (assoc-in [:accounts/login :processing] true))
           wrap-fn (cond (not status-node-started?)
                         wrap-with-initialize-geth-fx

--- a/src/status_im/ui/screens/db.cljs
+++ b/src/status_im/ui/screens/db.cljs
@@ -41,9 +41,7 @@
              :notifications              {}
              :network                    constants/default-network
              :networks/networks          constants/default-networks
-             :inbox/wnode                constants/default-wnode
              :inbox/wnodes               constants/default-wnodes
-             :inbox/topic                constants/inbox-topic
              :inbox/password             constants/inbox-password
              :my-profile/editing?        false
              :transport/chats            {}
@@ -162,9 +160,7 @@
                   :networks/networks
                   :node/after-start
                   :node/after-stop
-                  :inbox/wnode
                   :inbox/wnodes
-                  :inbox/topic
                   :inbox/password
                   :browser/browsers
                   :browser/options

--- a/src/status_im/ui/screens/events.cljs
+++ b/src/status_im/ui/screens/events.cljs
@@ -244,10 +244,8 @@
   (fn [{:keys [accounts/accounts accounts/create contacts/contacts networks/networks
                network network-status view-id navigation-stack
                access-scope->commands-responses
-               status-module-initialized? status-node-started?
-               inbox/wnode]
-        :or [network (get app-db :network)
-             wnode   (get app-db :inbox/wnode)]} [_ address]]
+               status-module-initialized? status-node-started?]
+        :or [network (get app-db :network)]} [_ address]]
     (let [console-contact (get contacts constants/console-chat-id)]
       (cond-> (assoc app-db
                      :access-scope->commands-responses access-scope->commands-responses
@@ -264,8 +262,7 @@
                      :accounts/create create
                      :networks/networks networks
                      :network-status network-status
-                     :network network
-                     :inbox/wnode wnode)
+                     :network network)
         console-contact
         (assoc :contacts/contacts {constants/console-chat-id console-contact})))))
 
@@ -278,7 +275,7 @@
                           [:load-contacts]
                           [:load-contact-groups]
                           [:initialize-chats]
-                          [:initialize-browsers] 
+                          [:initialize-browsers]
                           [:initialize-debugging {:address address}]
                           [:send-account-update-if-needed]
                           [:update-wallet]

--- a/src/status_im/ui/screens/offline_messaging_settings/db.cljs
+++ b/src/status_im/ui/screens/offline_messaging_settings/db.cljs
@@ -11,7 +11,5 @@
 (spec/def :wnode/id ::not-blank-string)
 (spec/def :wnode/wnode (allowed-keys :req-un [:wnode/address :wnode/name :wnode/id]))
 
-(spec/def :inbox/topic ::not-blank-string)
 (spec/def :inbox/password ::not-blank-string)
-(spec/def :inbox/wnode ::not-blank-string)
-(spec/def :inbox/wnodes (spec/nilable (spec/map-of :wnode/id :wnode/wnode)))
+(spec/def :inbox/wnodes (spec/nilable (spec/map-of keyword? (spec/map-of :wnode/id :wnode/wnode))))

--- a/src/status_im/ui/screens/offline_messaging_settings/subs.cljs
+++ b/src/status_im/ui/screens/offline_messaging_settings/subs.cljs
@@ -1,0 +1,17 @@
+(ns status-im.ui.screens.offline-messaging-settings.subs
+  (:require [re-frame.core :as re-frame]
+            [status-im.utils.ethereum.core :as ethereum]))
+
+(re-frame/reg-sub :settings/current-wnode
+  :<- [:network]
+  :<- [:get-current-account]
+  (fn [[network current-account]]
+    (let [chain (ethereum/network->chain-keyword network)]
+      (get-in current-account [:settings :wnode chain]))))
+
+(re-frame/reg-sub :settings/network-wnodes
+  :<- [:network]
+  :<- [:get :inbox/wnodes]
+  (fn [[network wnodes]]
+    (let [chain (ethereum/network->chain-keyword network)]
+      (chain wnodes))))

--- a/src/status_im/ui/screens/offline_messaging_settings/views.cljs
+++ b/src/status_im/ui/screens/offline_messaging_settings/views.cljs
@@ -26,8 +26,8 @@
           name]]]])))
 
 (views/defview offline-messaging-settings []
-  (views/letsubs [current-wnode  [:get :inbox/wnode]
-                  wnodes         [:get :inbox/wnodes]]
+  (views/letsubs [current-wnode  [:settings/current-wnode]
+                  wnodes         [:settings/network-wnodes]]
     [react/view {:flex 1}
      [status-bar/status-bar]
      [toolbar/simple-toolbar (i18n/label :t/offline-messaging-settings)]

--- a/src/status_im/ui/screens/subs.cljs
+++ b/src/status_im/ui/screens/subs.cljs
@@ -13,6 +13,7 @@
             status-im.ui.screens.wallet.settings.subs
             status-im.ui.screens.wallet.transactions.subs
             status-im.ui.screens.network-settings.subs
+            status-im.ui.screens.offline-messaging-settings.subs
             status-im.ui.screens.browser.subs
             status-im.bots.subs
             status-im.ui.screens.add-new.new-chat.subs

--- a/src/status_im/ui/screens/wallet/settings/events.cljs
+++ b/src/status_im/ui/screens/wallet/settings/events.cljs
@@ -10,11 +10,8 @@
 
 (handlers/register-handler-fx
   :wallet.settings/toggle-visible-token
-  (fn [{{:keys [network] :accounts/keys [current-account-id] :as db} :db} [_ symbol checked?]]
+  (fn [{{:keys [network] :accounts/keys [current-account-id] :as db} :db :as cofx} [_ symbol checked?]]
     (let [chain        (ethereum/network->chain-keyword network)
-          path         [:accounts/accounts current-account-id :settings]
-          settings     (get-in db path)
+          settings     (get-in db [:accounts/accounts current-account-id :settings])
           new-settings (update-in settings [:wallet :visible-tokens chain] #(toggle-checked % symbol checked?))]
-      (-> db
-          (assoc-in path new-settings)
-          (accounts/update-wallet-settings new-settings)))))
+      (accounts/update-settings new-settings cofx))))


### PR DESCRIPTION
fix #3806 

### Summary:

Support mailserver configs per network. I did the minimal changes required to get wnode settings persisted, I think making things neater belongs to a separate PR that would fix settings globally https://github.com/status-im/status-react/issues/3864

### Steps to test:
Test that you can switch between ropsten and mainnet, change mailserver in advanced config and that it is persisted between logins and network switches

status: ready
