### PR TITLE
Refactor subs + fix group chat issues

### DIFF
--- a/src/status_im/chat/screen.cljs
+++ b/src/status_im/chat/screen.cljs
@@ -36,7 +36,7 @@
     [vector-icons/icon :icons/dots-horizontal]]])
 
 (defview add-contact-bar [contact-identity]
-  (letsubs [{:keys [pending?] :as contact} [:contact-by-identity contact-identity]]
+  (letsubs [{:keys [pending?] :as contact} [:get-contact-by-identity contact-identity]]
     (when (or pending? (not contact)) ;; contact is pending or not in contact list at all
       [react/touchable-highlight
        {:on-press            #(re-frame/dispatch [:add-contact contact-identity])

--- a/src/status_im/chat/subs.cljs
+++ b/src/status_im/chat/subs.cljs
@@ -84,13 +84,6 @@
   (fn [{:keys [messages]} [_ message-id]]
     (get messages message-id)))
 
-(reg-sub
-  :chat
-  :<- [:get-active-chats]
-  :<- [:get-current-chat-id]
-  (fn [[chats id] [_ k chat-id]]
-    (get-in chats [(or chat-id id) k])))
-
 (defn- partition-by-datemark
   "Reduce step which expects the input list of messages to be sorted by clock value.
   It makes best effort to group them by day.
@@ -238,9 +231,9 @@
 
 (reg-sub
   :chat-input-placeholder
-  :<- [:chat :input-text]
+  :<- [:get-current-chat]
   :<- [:selected-chat-command]
-  (fn [[input-text command]]
+  (fn [[{:keys [input-text]} command]]
     (when (and (string/ends-with? (or input-text "") chat-constants/spacing-char)
                (not (get-in command [:command :sequential-params])))
       (let [input     (string/trim (or input-text ""))

--- a/src/status_im/chat/views/api/choose_contact.cljs
+++ b/src/status_im/chat/views/api/choose_contact.cljs
@@ -17,7 +17,7 @@
 (defview choose-contact-view [{title      :title
                                arg-index  :index
                                bot-db-key :bot-db-key}]
-  (letsubs [contacts [:people-in-current-chat]]
+  (letsubs [contacts [:get-people-in-current-chat]]
     [react/view
      [react/text {:style {:font-size      14
                           :color          "rgb(147, 155, 161)"

--- a/src/status_im/chat/views/input/input.cljs
+++ b/src/status_im/chat/views/input/input.cljs
@@ -17,9 +17,9 @@
             [status-im.utils.utils :as utils]))
 
 (defview basic-text-input [{:keys [set-layout-height-fn set-container-width-fn height single-line-input?]}]
-  (letsubs [input-text     [:chat :input-text] 
-            input-focused? [:get-current-chat-ui-prop :input-focused?]
-            input-ref      (atom nil)]
+  (letsubs [{:keys [input-text]} [:get-current-chat] 
+            input-focused?       [:get-current-chat-ui-prop :input-focused?]
+            input-ref            (atom nil)]
     [react/text-input
      {:ref                    #(when %
                                  (re-frame/dispatch [:set-chat-ui-props {:input-ref %}])
@@ -64,7 +64,7 @@
       :auto-capitalize        :sentences}]))
 
 (defview invisible-input [{:keys [set-layout-width-fn value]}]
-  (letsubs [input-text [:chat :input-text]]
+  (letsubs [{:keys [input-text]} [:get-current-chat]]
     [react/text {:style     style/invisible-input-text
                  :on-layout #(let [w (-> (.-nativeEvent %)
                                          (.-layout)
@@ -73,7 +73,7 @@
      (or input-text "")]))
 
 (defview invisible-input-height [{:keys [set-layout-height-fn container-width]}]
-  (letsubs [input-text [:chat :input-text]]
+  (letsubs [{:keys [input-text]} [:get-current-chat]]
     [react/text {:style     (style/invisible-input-text-height container-width)
                  :on-layout #(let [h (-> (.-nativeEvent %)
                                          (.-layout)
@@ -107,9 +107,9 @@
     nil))
 
 (defview seq-input [{:keys [command-width container-width]}]
-  (letsubs [command            [:selected-chat-command]
-            arg-pos            [:current-chat-argument-position]
-            seq-arg-input-text [:chat :seq-argument-input-text]]
+  (letsubs [command                      [:selected-chat-command]
+            arg-pos                      [:current-chat-argument-position]
+            {:keys [seq-arg-input-text]} [:get-current-chat]]
     (when (get-in command [:command :sequential-params])
       (let [{:keys [placeholder type]} (get-in command [:command :params arg-pos])]
         [react/text-input (merge {:ref                 #(re-frame/dispatch [:set-chat-ui-props {:seq-input-ref %}])
@@ -162,9 +162,9 @@
                                         :color           :dark}]]])))
 
 (defview input-container []
-  (letsubs [margin     [:chat-input-margin]
-            input-text [:chat :input-text]
-            result-box [:get-current-chat-ui-prop :result-box]]
+  (letsubs [margin               [:chat-input-margin]
+            {:keys [input-text]} [:get-current-chat]
+            result-box           [:get-current-chat-ui-prop :result-box]]
     (let [single-line-input? (:singleLineInput result-box)]
       [react/view {:style     (style/root margin)
                    :on-layout #(let [h (-> (.-nativeEvent %)

--- a/src/status_im/chat/views/input/send_button.cljs
+++ b/src/status_im/chat/views/input/send_button.cljs
@@ -16,13 +16,12 @@
                                       :duration 300})))))
 
 (defview send-button-view []
-  (letsubs [command-completion [:command-completion]
-            selected-command   [:selected-chat-command]
-            input-text         [:chat :input-text]
-            seq-arg-input-text [:chat :seq-argument-input-text]
-            spin-value         (animation/create-value 1)
-            on-update          (send-button-view-on-update {:spin-value         spin-value
-                                                            :command-completion command-completion})]
+  (letsubs [command-completion                      [:command-completion]
+            selected-command                        [:selected-chat-command]
+            {:keys [input-text seq-arg-input-text]} [:get-current-chat]
+            spin-value                              (animation/create-value 1)
+            on-update                               (send-button-view-on-update {:spin-value         spin-value
+                                                                                 :command-completion command-completion})]
     {:component-did-update on-update}
     (let [{:keys [hide-send-button sequential-params]} (:command selected-command)]
       (when (and (not (string/blank? input-text))
@@ -34,8 +33,8 @@
                                                    (when-not (string/blank? seq-arg-input-text)
                                                      (re-frame/dispatch [:send-seq-argument]))
                                                    (utils/set-timeout
-                                                     (fn [] (re-frame/dispatch [:chat-input-focus :seq-input-ref]))
-                                                     100))
+                                                    (fn [] (re-frame/dispatch [:chat-input-focus :seq-input-ref]))
+                                                    100))
                                                  (re-frame/dispatch [:send-current-message]))}
          (let [spin (.interpolate spin-value (clj->js {:inputRange  [0 1]
                                                        :outputRange ["0deg" "90deg"]}))]

--- a/src/status_im/chat/views/message/message.cljs
+++ b/src/status_im/chat/views/message/message.cljs
@@ -27,7 +27,7 @@
 
 (defview message-content-status []
   (letsubs [{:keys [chat-id group-id name color public-key]} [:get-current-chat]
-            members                                          [:current-chat-contacts]]
+            members                                          [:get-current-chat-contacts]]
     (let [{:keys [status]} (if group-id
                              {:status nil}
                              (first members))]
@@ -275,7 +275,7 @@
     (photo from photo-path)))
 
 (defview message-author-name [from message-username]
-  (letsubs [username    [:contact-name-by-identity from]]
+  (letsubs [username [:get-contact-name-by-identity from]]
     [react/text {:style style/message-author-name} (or username
                                                        message-username
                                                        (gfycat/generate-gfy from))])) ; TODO: We defensively generate the name for now, to be revisited when new protocol is defined

--- a/src/status_im/chat/views/toolbar_content.cljs
+++ b/src/status_im/chat/views/toolbar_content.cljs
@@ -60,16 +60,12 @@
             (i18n/label-pluralize cnt :t/members-active)))]])))
 
 (defview toolbar-content-view []
-  (letsubs [group-chat    [:chat :group-chat]
-            name          [:chat :name]
-            chat-id       [:chat :chat-id]
-            contacts      [:chat :contacts]
-            public?       [:chat :public?]
-            public-key    [:chat :public-key]
-            show-actions? [:get-current-chat-ui-prop :show-actions?]
-            accounts      [:get-accounts]
-            contact       [:get-in [:contacts/contacts @chat-id]]
-            sync-state    [:sync-state]]
+  (letsubs [{:keys [group-chat name chat-id
+                    contacts public? public-key]} [:get-current-chat]
+            show-actions?                         [:get-current-chat-ui-prop :show-actions?]
+            accounts                              [:get-accounts]
+            contact                               [:get-current-chat-contact] 
+            sync-state                            [:sync-state]]
     [react/view common.styles/flex
      [react/view (st/chat-name-view (or (empty? accounts)
                                         show-actions?))

--- a/src/status_im/transport/message/v1/group_chat.cljs
+++ b/src/status_im/transport/message/v1/group_chat.cljs
@@ -55,16 +55,16 @@
   (let [added-participants-names   (map #(get-in contacts [% :name] %) added-participants)
         removed-participants-names (map #(get-in contacts [% :name] %) removed-participants)]
     (cond
-      (and added-participants removed-participants)
+      (and (seq added-participants) (seq removed-participants))
       (str admin-name " "
            (i18n/label :t/invited) " " (apply str (interpose ", " added-participants-names))
            " and "
            (i18n/label :t/removed) " " (apply str (interpose ", " removed-participants-names)))
 
-      added-participants
+      (seq added-participants)
       (str admin-name " " (i18n/label :t/invited) " " (apply str (interpose ", " added-participants-names)))
 
-      removed-participants
+      (seq removed-participants)
       (str admin-name " " (i18n/label :t/removed) " " (apply str (interpose ", " removed-participants-names))))))
 
 (defn- init-chat-if-new [chat-id cofx]
@@ -89,7 +89,7 @@
         (when (and (= signature group-admin)  ;; make sure that admin is the one making changes
                    (not= (set contacts) (set participants))) ;; make sure it's actually changing something
           (let [{:keys [removed added]} (participants-diff (set contacts) (set participants))
-                admin-name              (or (get-in cofx [db :contacts/contacts group-admin :name])
+                admin-name              (or (get-in db [:contacts/contacts group-admin :name])
                                             group-admin)]
             (if (removed me) ;; we were removed
               (handlers/merge-fx cofx

--- a/src/status_im/ui/components/connectivity/view.cljs
+++ b/src/status_im/ui/components/connectivity/view.cljs
@@ -14,15 +14,15 @@
                                        :duration 250})))
 
 (defn error-view [_]
-  (let [offline?            (re-frame/subscribe [:offline?])
-        connection-problem? (re-frame/subscribe [:connection-problem?])
-        offline-opacity     (animation/create-value 0.0)
-        on-update           (fn [_ _]
-                              (animation/set-value offline-opacity 0)
-                              (when (or @offline? @connection-problem?)
-                                (start-error-animation offline-opacity)))
-        pending-contact?    (re-frame/subscribe [:current-contact :pending?])
-        view-id             (re-frame/subscribe [:get :view-id])]
+  (let [offline?             (re-frame/subscribe [:offline?])
+        connection-problem?  (re-frame/subscribe [:connection-problem?])
+        offline-opacity      (animation/create-value 0.0)
+        on-update            (fn [_ _]
+                               (animation/set-value offline-opacity 0)
+                               (when (or @offline? @connection-problem?)
+                                 (start-error-animation offline-opacity)))
+        current-chat-contact (re-frame/subscribe [:get-current-chat-contact])
+        view-id              (re-frame/subscribe [:get :view-id])]
     (reagent/create-class
       {:component-did-mount
        on-update
@@ -32,7 +32,7 @@
        :reagent-render
        (fn [{:keys [top]}]
          (when (or @offline? @connection-problem?)
-           (let [pending? (and @pending-contact? (= :chat @view-id))]
+           (let [pending? (and (:pending @current-chat-contact) (= :chat @view-id))]
              [react/animated-view {:style (styles/offline-wrapper top offline-opacity window-width pending?)}
               [react/view
                [react/text {:style styles/offline-text}

--- a/src/status_im/ui/screens/browser/views.cljs
+++ b/src/status_im/ui/screens/browser/views.cljs
@@ -16,7 +16,7 @@
             [status-im.i18n :as i18n]))
 
 (views/defview toolbar-content-dapp [contact-identity]
-  (views/letsubs [contact [:contact-by-identity contact-identity]]
+  (views/letsubs [contact [:get-contact-by-identity contact-identity]]
     [react/view
      [react/view styles/toolbar-content-dapp
       [chat-icon.screen/dapp-icon-browser contact 36]

--- a/src/status_im/ui/screens/contacts/contact_list/views.cljs
+++ b/src/status_im/ui/screens/contacts/contact_list/views.cljs
@@ -29,7 +29,7 @@
       (or (:name group) (i18n/label :t/contacts-group-new-chat)))]])
 
 (defview contacts-list-view [group edit?]
-  (letsubs [contacts [:all-added-group-contacts (:group-id group)]]
+  (letsubs [contacts [:get-all-added-group-contacts (:group-id group)]]
     [list/flat-list {:style                     styles/contacts-list
                      :data                      contacts
                      :key-fn                    :address

--- a/src/status_im/ui/screens/contacts/subs.cljs
+++ b/src/status_im/ui/screens/contacts/subs.cljs
@@ -4,13 +4,21 @@
             [status-im.utils.ethereum.core :as ethereum]
             [status-im.utils.identicon :as identicon]))
 
-(reg-sub :current-contact
-  (fn [db [_ k]]
-    (get-in db [:contacts/contacts (:current-chat-id db) k])))
+(reg-sub :get-current-contact-identity :contacts/identity)
 
-(reg-sub :get-contacts
-  (fn [db _]
-    (:contacts/contacts db)))
+(reg-sub :get-contacts :contacts/contacts)
+
+(reg-sub :get-current-contact
+  :<- [:get-contacts]
+  :<- [:get-current-contact-identity]
+  (fn [[contacts identity]]
+    (contacts identity)))
+
+(reg-sub :get-current-chat-contact
+  :<- [:get-contacts]
+  :<- [:get-current-chat-id] 
+  (fn [[contacts chat-id]]
+    (get contacts chat-id)))
 
 (defn sort-contacts [contacts]
   (sort (fn [c1 c2]
@@ -31,15 +39,15 @@
 (reg-sub :all-added-people-contacts
   :<- [:all-added-contacts]
   (fn [contacts]
-    (remove #(true? (:dapp? %)) contacts)))
+    (remove :dapp? contacts)))
 
 (reg-sub :all-dapp-with-url-contacts
   :<- [:all-added-contacts]
   (fn [contacts]
-    (filter #(and (true? (:dapp? %)) (:dapp-url %)) contacts)))
+    (filter #(and (:dapp? %) (:dapp-url %)) contacts)))
 
-(reg-sub :people-in-current-chat
-  :<- [:current-chat-contacts]
+(reg-sub :get-people-in-current-chat
+  :<- [:get-current-chat-contacts]
   (fn [contacts]
     (remove #(true? (:dapp? %)) contacts)))
 
@@ -47,72 +55,18 @@
   (let [group-contacts' (into #{} group-contacts)]
     (filter #(group-contacts' (:whisper-identity %)) contacts)))
 
-(reg-sub :group-contacts
-  (fn [db [_ group-id]]
-    (get-in db [:group/contact-groups group-id :contacts])))
-
-(reg-sub :all-added-group-contacts
-  (fn [[_ group-id] _]
-    [(subscribe [:all-added-contacts])
-     (subscribe [:group-contacts group-id])])
-  (fn [[contacts group-contacts] _]
-    (filter-group-contacts group-contacts contacts)))
-
-(defn filter-not-group-contacts [group-contacts contacts]
-  (let [group-contacts' (into #{} group-contacts)]
-    (remove #(group-contacts' (:whisper-identity %)) contacts)))
-
-(reg-sub :all-not-added-group-contacts
-  (fn [[_ group-id] _]
-    [(subscribe [:all-added-contacts])
-     (subscribe [:group-contacts group-id])])
-  (fn [[contacts group-contacts]]
-    (filter-not-group-contacts group-contacts contacts)))
-
-(reg-sub
-  :all-added-group-contacts-with-limit
-  (fn [[_ group-id limit] _]
-    (subscribe [:all-added-group-contacts group-id]))
-  (fn [contacts [_ group-id limit]]
-    (take limit contacts)))
-
-(reg-sub :all-added-group-contacts-count
-  (fn [[_ group-id] _]
-    (subscribe [:all-added-group-contacts group-id]))
-  (fn [contacts _]
-    (count contacts)))
-
-(reg-sub :get-added-contacts-with-limit
+(reg-sub :get-all-added-group-contacts
   :<- [:all-added-contacts]
-  (fn [contacts [_ limit]]
-    (take limit contacts)))
+  :<- [:get-contact-groups] 
+  (fn [[contacts contact-groups] [_ group-id]]
+    (filter-group-contacts (get-in contact-groups [group-id :contacts]) contacts)))
 
-(reg-sub :added-contacts-count
-  :<- [:all-added-contacts]
-  (fn [contacts]
-    (count contacts)))
-
-(reg-sub :all-added-groups
-  :<- [:get-contact-groups]
-  (fn [groups]
-    (->> (remove :pending? (vals groups))
-         (sort-by :order >))))
-
-(reg-sub :current-contact-identity
-  (fn [db]
-    (:contacts/identity db)))
-
-(reg-sub :contact
+(reg-sub :get-contact-by-identity
   :<- [:get-contacts]
-  :<- [:current-contact-identity]
-  (fn [[contacts identity]]
-    (contacts identity)))
+  (fn [contacts [_ identity]]
+    (get contacts identity)))
 
-(reg-sub :contact-by-identity
-  (fn [db [_ identity]]
-    (get-in db [:contacts/contacts identity])))
-
-(reg-sub :contact-name-by-identity
+(reg-sub :get-contact-name-by-identity
   :<- [:get-contacts]
   :<- [:get-current-account]
  (fn [[contacts current-account] [_ identity]]
@@ -121,37 +75,33 @@
        (:name current-account)
        (:name (contacts identity))))))
 
-(defn chat-contacts [[chat contacts] [_ fn]]
-  (when chat
-    (let [current-participants (-> chat :contacts set)]
-      (fn #(current-participants (:whisper-identity %))
-        (vals contacts)))))
+(defn query-chat-contacts [[{:keys [contacts group-admin]} all-contacts] [_ query-fn]] 
+  (let [participant-set (into #{} (filter identity) (conj contacts group-admin))]
+    (query-fn (comp participant-set :whisper-identity) (vals all-contacts))))
 
-(reg-sub :contacts-current-chat
+(reg-sub :query-current-chat-contacts
   :<- [:get-current-chat]
   :<- [:get-contacts]
-  chat-contacts)
+  query-chat-contacts)
 
-(reg-sub :all-new-contacts
-  :<- [:contacts-current-chat remove]
-  (fn [contacts]
-    contacts))
+(reg-sub :get-all-contacts-not-in-current-chat
+  :<- [:query-current-chat-contacts remove]
+  identity)
 
-(reg-sub :current-chat-contacts
-  :<- [:contacts-current-chat filter]
-  (fn [contacts]
-    contacts))
+(reg-sub :get-current-chat-contacts
+  :<- [:query-current-chat-contacts filter]
+  identity)
 
-(reg-sub :contacts-by-chat
+(reg-sub :get-contacts-by-chat
   (fn [[_ _ chat-id] _]
     [(subscribe [:get-chat chat-id])
      (subscribe [:get-contacts])])
-  chat-contacts)
+  query-chat-contacts)
 
 (reg-sub :get-chat-photo
   (fn [[_ chat-id] _]
     [(subscribe [:get-chat chat-id])
-     (subscribe [:contacts-by-chat filter chat-id])])
+     (subscribe [:get-contacts-by-chat filter chat-id])])
   (fn [[chat contacts] [_ chat-id]]
     (when (and chat (not (:group-chat chat)))
       (cond
@@ -173,12 +123,12 @@
   (when (address= contact s)
     contact))
 
-(reg-sub :contact/by-address
+(reg-sub :get-contact-by-address
   :<- [:get-contacts]
   (fn [contacts [_ address]]
     (some #(contact-by-address % address) contacts)))
 
-(reg-sub :contacts/by-address
+(reg-sub :get-contacts-by-address
   :<- [:get-contacts]
   (fn [contacts]
     (reduce (fn [acc [_ {:keys [address] :as contact}]]

--- a/src/status_im/ui/screens/desktop/main/chat/views.cljs
+++ b/src/status_im/ui/screens/desktop/main/chat/views.cljs
@@ -13,10 +13,8 @@
             [status-im.ui.components.react :as react]))
 
 (views/defview toolbar-chat-view []
-  (views/letsubs [{:keys [name public? group-chat]} [:get-current-chat]
-                  chat-id [:get-current-chat-id]
-                  pending-contact? [:current-contact :pending?]
-                  public-key [:chat :public-key]]
+  (views/letsubs [{:keys [chat-id name public-key public? group-chat]} [:get-current-chat] 
+                  {:keys [pending?]}                                   [:get-current-chat-contact]]
     (let [chat-name (str
                       (if public? "#" "")
                       (if (string/blank? name)
@@ -31,7 +29,7 @@
           [icons/icon :icons/group-chat])
         [react/text {:style {:font-size 16 :color :black :font-weight "600"}}
          chat-name]]
-       (when pending-contact?
+       (when pending?
          [react/touchable-highlight
           {:on-press #(re-frame/dispatch [:add-pending-contact chat-id])}
           [react/view {:style {:background-color :white :border-radius 6 :margin-top 3 :padding 4}}                                      ;style/add-contact
@@ -40,7 +38,7 @@
 
 (views/defview message-author-name [{:keys [outgoing from] :as message}]
   (views/letsubs [current-account [:get-current-account]
-                  incoming-name [:contact-name-by-identity from]]
+                  incoming-name   [:get-contact-name-by-identity from]]
     (if outgoing
       [react/text {:style message.style/author} (:name current-account)]
       (let [name (or incoming-name (gfycat/generate-gfy from))]
@@ -134,8 +132,8 @@
              [message content (= from @current-public-key) (assoc message-obj :group-chat group-chat)]))]]])))
 
 (views/defview chat-text-input []
-  (views/letsubs [input-text [:chat :input-text]
-                  inp-ref (atom nil)]
+  (views/letsubs [{:keys [input-text]} [:get-current-chat]
+                  inp-ref              (atom nil)]
     [react/view {:style {:height 90 :margin-horizontal 16  :background-color :white :border-radius 12}}
      [react/view {:style {:flex-direction :row :margin-horizontal 16 :margin-top 16 :flex 1 :margin-bottom 16}}
       [react/view {:style {:flex 1}}

--- a/src/status_im/ui/screens/group/add_contacts/views.cljs
+++ b/src/status_im/ui/screens/group/add_contacts/views.cljs
@@ -70,8 +70,8 @@
      [toggle-list contacts group-toggle-contact]]))
 
 (defview add-participants-toggle-list []
-  (letsubs [contacts                [:all-new-contacts]
-            chat-name               [:chat :name]
+  (letsubs [contacts                [:get-all-contacts-not-in-current-chat]
+            {:keys [name]}          [:get-current-chat]
             selected-contacts-count [:selected-participants-count]]
     [react/keyboard-avoiding-view {:style styles/group-container}
      [status-bar]
@@ -80,5 +80,5 @@
                                        (re-frame/dispatch [:add-new-group-chat-participants])
                                        (re-frame/dispatch [:navigate-back]))
                            :label   (i18n/label :t/add)}
-      chat-name]
+      name]
      [toggle-list contacts group-toggle-participant]]))

--- a/src/status_im/ui/screens/group/chat_settings/events.cljs
+++ b/src/status_im/ui/screens/group/chat_settings/events.cljs
@@ -2,6 +2,7 @@
   (:require [re-frame.core :as re-frame]
             [status-im.i18n :as i18n]
             [status-im.chat.models.message :as models.message]
+            [status-im.ui.screens.navigation :as navigation]
             [status-im.transport.message.v1.group-chat :as group-chat]
             [status-im.transport.message.core :as transport]
             [status-im.utils.handlers :as handlers]))
@@ -11,10 +12,12 @@
 
 (handlers/register-handler-fx
   :show-group-chat-profile
-  (fn [{db :db} [_ chat-id]]
-    {:db (assoc db :new-chat-name (get-in db [:chats chat-id :name])
-                :group/group-type :chat-group)
-     :dispatch [:navigate-to :group-chat-profile]}))
+  [re-frame/trim-v]
+  (fn [{:keys [db] :as cofx} [chat-id]] 
+    {:db (-> db
+             (assoc :new-chat-name (get-in db [:chats chat-id :name])
+                    :group/group-type :chat-group)
+             (navigation/navigate-to :group-chat-profile))}))
 
 (handlers/register-handler-fx
   :add-new-group-chat-participants

--- a/src/status_im/ui/screens/group/edit_contacts/views.cljs
+++ b/src/status_im/ui/screens/group/edit_contacts/views.cljs
@@ -36,7 +36,7 @@
       :label               (i18n/label :t/remove-from-group)}]))
 
 (defview contacts-list-view [group-id]
-  (letsubs [contacts [:all-added-group-contacts group-id]]
+  (letsubs [contacts [:get-all-added-group-contacts group-id]]
     [contacts-list
      contacts
      true

--- a/src/status_im/ui/screens/home/views/inner_item.cljs
+++ b/src/status_im/ui/screens/home/views/inner_item.cljs
@@ -112,7 +112,7 @@
           [unviewed-indicator chat-id]]]]])))
 
 (defview home-list-browser-item-inner-view [{:keys [browser-id name url dapp? contact] :as browser}]
-  (letsubs [contact' [:contact-by-identity contact]]
+  (letsubs [contact' [:get-contact-by-identity contact]]
     [react/touchable-highlight {:on-press #(re-frame/dispatch [:open-browser browser])}
      [react/view styles/chat-container
       [react/view styles/chat-icon-container

--- a/src/status_im/ui/screens/profile/contact/views.cljs
+++ b/src/status_im/ui/screens/profile/contact/views.cljs
@@ -57,8 +57,8 @@
    [profile-info-contact-code-item whisper-identity]])
 
 (defview profile []
-  (letsubs [identity        [:current-contact-identity]
-            maybe-contact   [:contact]]
+  (letsubs [identity        [:get-current-contact-identity]
+            maybe-contact   [:get-current-contact]]
     (let [contact (or maybe-contact (utils.contacts/whisper-id->new-contact identity))]
       [react/view profile.components.styles/profile
        [status-bar/status-bar]

--- a/src/status_im/ui/screens/profile/group_chat/views.cljs
+++ b/src/status_im/ui/screens/profile/group_chat/views.cljs
@@ -82,7 +82,7 @@
      :inner-props         {:accessibility-label :member-name-text}}]])
 
 (defview chat-group-contacts-view [admin?]
-  (letsubs [contacts [:current-chat-contacts]]
+  (letsubs [contacts [:get-current-chat-contacts]]
     [react/view
      [list/flat-list {:data      contacts
                       :separator list/default-separator
@@ -95,11 +95,10 @@
    [chat-group-contacts-view admin?]])
 
 (defview group-chat-profile []
-  (letsubs [current-chat [:get-current-chat]
-            editing?     [:get :group-chat-profile/editing?]
-            changed-chat [:get :group-chat-profile/profile]
-            current-pk   [:get :current-public-key]
-            group-admin  [:chat :group-admin]]
+  (letsubs [{:keys [group-admin] :as current-chat} [:get-current-chat]
+            editing?                               [:get :group-chat-profile/editing?]
+            changed-chat                           [:get :group-chat-profile/profile]
+            current-pk                             [:get :current-public-key]]
     (let [shown-chat (merge current-chat changed-chat)
           admin?     (= current-pk group-admin)]
       [react/view profile.components.styles/profile

--- a/src/status_im/ui/screens/wallet/components/views.cljs
+++ b/src/status_im/ui/screens/wallet/components/views.cljs
@@ -99,7 +99,7 @@
    (or (ethereum/normalized-address address) (i18n/label :t/specify-recipient))])
 
 (views/defview recipient-contact [address name request?]
-  (views/letsubs [contact [:contact/by-address address]]
+  (views/letsubs [contact [:get-contact-by-address address]]
     (let [address? (and (not (nil? address)) (not= address ""))]
       [react/view styles/recipient-container
        [react/view styles/recipient-icon

--- a/src/status_im/ui/screens/wallet/send/subs.cljs
+++ b/src/status_im/ui/screens/wallet/send/subs.cljs
@@ -81,7 +81,7 @@
 
 (re-frame/reg-sub :wallet.send/unsigned-transaction
   :<- [::unsigned-transaction]
-  :<- [:contacts/by-address]
+  :<- [:get-contacts-by-address]
   :<- [:balance]
   (fn [[{:keys [value to symbol] :as transaction} contacts balance]]
     (when transaction

--- a/src/status_im/ui/screens/wallet/transactions/subs.cljs
+++ b/src/status_im/ui/screens/wallet/transactions/subs.cljs
@@ -29,7 +29,7 @@
 
 (reg-sub :wallet.transactions/transactions
   :<- [:wallet]
-  :<- [:contacts/by-address]
+  :<- [:get-contacts-by-address]
   (fn [[wallet contacts]]
     (reduce (fn [acc [hash transaction]]
               (assoc acc hash (enrich-transaction transaction contacts)))
@@ -50,7 +50,7 @@
 
 (reg-sub :wallet/unsigned-transactions
   :<- [:wallet]
-  :<- [:contacts/by-address]
+  :<- [:get-contacts-by-address]
   (fn [[wallet contacts]]
     (map #(enrich-transaction % contacts) (vals (:transactions-unsigned wallet)))))
 


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes #3705 and #3701 

### Summary:

Refactores `contact`/`chat` subscriptions by deleting unused and duplicate ones, changes names to be consistent (subscription keywords are always `:get-` starting) as well in addition to fixing the bugs.

### Testing notes (optional):
Test all the bugs + general regression testing (just UI visual stuff) because of the refactored subscriptions

status: ready
