### PR TITLE
[#3832] Hide tab bar on Android when keyboard visible

### DIFF
--- a/src/status_im/android/core.cljs
+++ b/src/status_im/android/core.cljs
@@ -44,13 +44,16 @@
                        "keyboardDidShow"
                        (fn [e]
                          (let [h (.. e -endCoordinates -height)]
+                           (dispatch [:hide-tab-bar])
                            (when-not (= h @keyboard-height)
                              (dispatch [:set :keyboard-height h])
                              (dispatch [:set :keyboard-max-height h])))))
          (.addListener react/keyboard
                        "keyboardDidHide"
-                       #(when-not (= 0 @keyboard-height)
-                          (dispatch [:set :keyboard-height 0])))
+                       (fn [_]
+                         (dispatch [:show-tab-bar])
+                         (when (zero? @keyboard-height)
+                           (dispatch [:set :keyboard-height 0]))))
          (.hide react/splash-screen)
          (.addEventListener react/app-state "change" app-state-change-handler))
        :component-did-mount

--- a/src/status_im/ui/screens/db.cljs
+++ b/src/status_im/ui/screens/db.cljs
@@ -21,6 +21,7 @@
 (def app-db {:current-public-key          nil
              :status-module-initialized?  (or platform/ios? js/goog.DEBUG)
              :keyboard-height             0
+             :tab-bar-visible?            true
              :accounts/accounts           {}
              :navigation-stack            '()
              :contacts/contacts           {}
@@ -64,6 +65,7 @@
 ;;height of native keyboard if shown
 (spec/def ::keyboard-height (spec/nilable number?))
 (spec/def ::keyboard-max-height (spec/nilable number?))
+(spec/def ::tab-bar-visible? (spec/nilable boolean?))
 ;;:online - presence of internet connection in the phone
 (spec/def ::network-status (spec/nilable keyword?))
 
@@ -184,6 +186,7 @@
                   ::status-node-started?
                   ::keyboard-height
                   ::keyboard-max-height
+                  ::tab-bar-visible?
                   ::network-status
                   ::mailserver-status
                   ::peers-count

--- a/src/status_im/ui/screens/events.cljs
+++ b/src/status_im/ui/screens/events.cljs
@@ -400,3 +400,13 @@
   [re-frame/trim-v]
   (fn [db [item-id value]]
     (assoc-in db [:chat-animations item-id :delete-swiped] value)))
+
+(handlers/register-handler-db
+  :show-tab-bar
+  (fn [db _]
+    (assoc db :tab-bar-visible? true)))
+
+(handlers/register-handler-db
+  :hide-tab-bar
+  (fn [db _]
+    (assoc db :tab-bar-visible? false)))

--- a/src/status_im/ui/screens/main_tabs/views.cljs
+++ b/src/status_im/ui/screens/main_tabs/views.cljs
@@ -65,7 +65,8 @@
      ^{:key view-id} [tab view-id content (= view-id current-view-id) accessibility-label count-subscription])])
 
 (views/defview main-tabs []
-  (views/letsubs [view-id [:get :view-id]]
+  (views/letsubs [view-id          [:get :view-id]
+                  tab-bar-visible? [:tab-bar-visible?]]
     [react/view common.styles/flex
      [status-bar.view/status-bar {:type (if (= view-id :wallet) :wallet-tab :main)}]
      [react/view common.styles/main-container
@@ -93,4 +94,5 @@
         {:component    profile.user/my-profile
          :views        :my-profile
          :current-view view-id}]]
-      [tabs view-id]]]))
+      (when tab-bar-visible?
+        [tabs view-id])]]))

--- a/src/status_im/ui/screens/subs.cljs
+++ b/src/status_im/ui/screens/subs.cljs
@@ -57,6 +57,10 @@
   (fn [sync-state]
     (#{:pending :in-progress} sync-state)))
 
+(reg-sub :tab-bar-visible?
+  (fn [db _]
+    (get db :tab-bar-visible?)))
+
 (reg-sub :get-screen-params
   (fn [db [_ view-id]]
     (get-in db [:navigation/screen-params (or view-id (:view-id db))])))


### PR DESCRIPTION
Fixes #3832

### Summary:
Hides tab bar on Android when keyboard is visible (i.e. editing user profile)

### Steps to test:
- Open Status
- Create account, login, Profile, tap Edit
- Tab bar should hide while keyboard is up

Status: Ready
