### PR TITLE
[#3856] Keep url in browser if no change

### DIFF
--- a/src/status_im/ui/screens/browser/views.cljs
+++ b/src/status_im/ui/screens/browser/views.cljs
@@ -33,7 +33,7 @@
   (reader/read-string (slurp "./src/status_im/utils/browser_config.edn")))
 
 (defn toolbar-content [{:keys [url] :as browser}]
-  (let [url-text (atom nil)]
+  (let [url-text (atom url)]
     [react/view
      [react/view (styles/toolbar-content false)
       [react/text-input {:on-change-text    #(reset! url-text %)


### PR DESCRIPTION
Fixes #3856 

### Summary:
- Do nothing if user edits URL, does not change it, then closes keyboard

### Steps to test:
- Open Status
- Open browser dapp
- Go to URL, tap input, tap keyboard done
- Input and window should not change

Status: Ready
