### PR TITLE
Remove Jarrad from contacts

### DIFF
--- a/resources/default_contacts.json
+++ b/resources/default_contacts.json
@@ -19,17 +19,6 @@
         "bot-url": "local://demo-bot"
     },
 
-    "0x0428c9d6c1aaaa8369a7c63819684f30e34396dc0907d49afeac85a0a774ccb919b3482097d992e66bcc538e7a0c6acf874c77748f396f53c0a102e10d1a37765b":
-    {
-        "name":
-        {
-            "en": "Jarrad"
-        },
-        "photo-path": "contacts://jarrad",
-        "public-key": "0x0428c9d6c1aaaa8369a7c63819684f30e34396dc0907d49afeac85a0a774ccb919b3482097d992e66bcc538e7a0c6acf874c77748f396f53c0a102e10d1a37765b",
-        "dapp?": false
-    },
-
     "auction-house":
     {
         "name":

--- a/src/status_im/transport/message/v1/protocol.cljs
+++ b/src/status_im/transport/message/v1/protocol.cljs
@@ -63,17 +63,11 @@
 
 (defn- prepare-recipients [public-keys db]
   (map (fn [public-key]
-         (if-let [{:keys [topic sym-key-id]} (get-in db [:transport/chats public-key])]
-           {:topic      topic
-            :sym-key-id sym-key-id}
-           {:topic   (transport.utils/get-topic constants/contact-discovery)
-            :pub-key public-key}))
+         (select-keys (get-in db [:transport/chats public-key]) [:topic :sym-key-id]))
        public-keys))
 
 (defn multi-send-with-pubkey
-  "Sends payload to multiple participants selected by `:public-keys` key.
-  If there is already established symmetric key with the participant, uses that (for efficiency),
-  if not, uses asymetric encryption."
+  "Sends payload to multiple participants selected by `:public-keys` key. "
   [{:keys [payload public-keys success-event]} {:keys [db] :as cofx}]
   (let [{:keys [current-public-key web3]} db
         recipients                        (prepare-recipients public-keys db)]

--- a/src/status_im/transport/shh.cljs
+++ b/src/status_im/transport/shh.cljs
@@ -82,11 +82,11 @@
         :or {error-event :protocol/send-status-message-error}}]
     (let [whisper-message (update message :payload (comp transport.utils/from-utf8
                                                          transit/serialize))]
-      (doseq [{:keys [sym-key-id pub-key topic]} recipients]
+      (doseq [{:keys [sym-key-id topic]} recipients]
         (post-message {:web3            web3
-                       :whisper-message (cond-> (assoc whisper-message :topic topic)
-                                          sym-key-id (assoc :symKeyID sym-key-id)
-                                          pub-key (assoc :pubKey pub-key))
+                       :whisper-message (assoc whisper-message
+                                               :topic topic
+                                               :symKeyID sym-key-id)
                        :on-success      (if success-event
                                           #(re-frame/dispatch success-event)
                                           #(log/debug :shh/post-success))


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes #3851 

### Summary:

Removes Jarrad from default contacts, because hardcoded contacts without pre-negotiated shared symmetric keys are not allowed in the new protocol. Also removes fallback options in `:shh/multipost` which were there only for such hardcoded contacts

### Testing notes (optional):
Test that Jarrad is not in Contacts anymore (on fresh install) + all chats (1-1, group and public) still work fine (it's enough that messages are being exchanged, no more detailed testing is necessary)

status: ready 
