### PR TITLE
issue 3690: Use thread pool instead of new threads on Android

### DIFF
--- a/android/app/src/main/java/im/status/ethereum/MainActivity.java
+++ b/android/app/src/main/java/im/status/ethereum/MainActivity.java
@@ -27,6 +27,7 @@ import com.testfairy.TestFairy;
 import com.instabug.library.Instabug;
 
 import java.util.Properties;
+import im.status.ethereum.module.StatusThreadPoolExecutor;
 
 public class MainActivity extends ReactActivity
         implements ActivityCompat.OnRequestPermissionsResultCallback{
@@ -40,6 +41,7 @@ public class MainActivity extends ReactActivity
         Thread.setDefaultUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
             @Override
             public void uncaughtException(final Thread thread, final Throwable t) {
+                // High priority, so don't use StatusThreadPoolExecutor
                 new Thread() {
                     @Override
                     public void run() {
@@ -150,14 +152,14 @@ public class MainActivity extends ReactActivity
             dialog.show();
         }
 
-        Thread thread = new Thread() {
+        Runnable r = new Runnable() {
             @Override
             public void run() {
                 System.loadLibrary("status-logs");
             }
         };
 
-        thread.start();
+        StatusThreadPoolExecutor.getInstance().execute(r);
     }
 
     @Override

--- a/modules/react-native-status/android/src/main/java/im/status/ethereum/module/JSCJail.java
+++ b/modules/react-native-status/android/src/main/java/im/status/ethereum/module/JSCJail.java
@@ -102,7 +102,7 @@ class JSCJail implements Jail {
 
         JSFunction web3sendAsync = new JSFunction(context, "web3sendAsync") {
             public void web3sendAsync(final String payload, final JSValue callback) {
-                Thread thread = new Thread() {
+                Runnable r = new Runnable() {
                     @Override
                     public void run() {
                         String result = Statusgo.CallRPC(payload);
@@ -110,7 +110,7 @@ class JSCJail implements Jail {
                     }
                 };
 
-                thread.start();
+                StatusThreadPoolExecutor.getInstance().execute(r);
             }
         };
         context.property("web3sendAsync", web3sendAsync);

--- a/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusModule.java
+++ b/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusModule.java
@@ -356,20 +356,20 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
             return;
         }
 
-        Thread thread = new Thread() {
+        Runnable r = new Runnable() {
             @Override
             public void run() {
                 doStartNode(config);
             }
         };
 
-        thread.start();
+        StatusThreadPoolExecutor.getInstance().execute(r);
     }
 
     @ReactMethod
     public void stopNode() {
 
-        Thread thread = new Thread() {
+        Runnable r = new Runnable() {
             @Override
             public void run() {
                 Log.d(TAG, "stopNode");
@@ -377,7 +377,7 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
             }
         };
 
-        thread.start();
+        StatusThreadPoolExecutor.getInstance().execute(r);
     }
 
     @ReactMethod
@@ -390,7 +390,7 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
 
         jail.reset();
 
-        Thread thread = new Thread() {
+        Runnable r = new Runnable() {
             @Override
             public void run() {
                 String result = Statusgo.Login(address, password);
@@ -399,7 +399,7 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
             }
         };
 
-        thread.start();
+        StatusThreadPoolExecutor.getInstance().execute(r);
     }
 
     @ReactMethod
@@ -410,7 +410,7 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
             return;
         }
 
-        Thread thread = new Thread() {
+        Runnable r = new Runnable() {
             @Override
             public void run() {
                 String res = Statusgo.CreateAccount(password);
@@ -419,7 +419,7 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
             }
         };
 
-        thread.start();
+        StatusThreadPoolExecutor.getInstance().execute(r);
     }
 
     @ReactMethod
@@ -430,7 +430,7 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
             return;
         }
 
-        Thread thread = new Thread() {
+        Runnable r = new Runnable() {
                 @Override
                 public void run() {
                     String res = Statusgo.NotifyUsers(message, payloadJSON, tokensJSON);
@@ -439,7 +439,7 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
                 }
             };
 
-        thread.start();
+        StatusThreadPoolExecutor.getInstance().execute(r);
     }
 
     @ReactMethod
@@ -450,7 +450,7 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
             return;
         }
 
-        Thread thread = new Thread() {
+        Runnable r = new Runnable() {
                 @Override
                 public void run() {
                     String res = Statusgo.AddPeer(enode);
@@ -459,7 +459,7 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
                 }
             };
 
-        thread.start();
+        StatusThreadPoolExecutor.getInstance().execute(r);
     }
 
 
@@ -470,7 +470,7 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
             callback.invoke(false);
             return;
         }
-        Thread thread = new Thread() {
+        Runnable r = new Runnable() {
             @Override
             public void run() {
                 String res = Statusgo.RecoverAccount(password, passphrase);
@@ -479,7 +479,7 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
             }
         };
 
-        thread.start();
+        StatusThreadPoolExecutor.getInstance().execute(r);
     }
 
     private String createIdentifier() {
@@ -494,7 +494,7 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
             return;
         }
 
-        Thread thread = new Thread() {
+        Runnable r = new Runnable() {
             @Override
             public void run() {
                 String res = Statusgo.CompleteTransactions(hashes, password);
@@ -502,7 +502,7 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
             }
         };
 
-        thread.start();
+        StatusThreadPoolExecutor.getInstance().execute(r);
     }
 
 
@@ -513,14 +513,14 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
             return;
         }
 
-        Thread thread = new Thread() {
+        Runnable r = new Runnable() {
             @Override
             public void run() {
                 Statusgo.DiscardTransaction(id);
             }
         };
 
-        thread.start();
+        StatusThreadPoolExecutor.getInstance().execute(r);
     }
 
     // Jail
@@ -533,7 +533,7 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
             return;
         }
 
-        Thread thread = new Thread() {
+        Runnable r = new Runnable() {
             @Override
             public void run() {
                 jail.initJail(js);
@@ -542,7 +542,7 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
             }
         };
 
-        thread.start();
+        StatusThreadPoolExecutor.getInstance().execute(r);
     }
 
     @ReactMethod
@@ -684,7 +684,7 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
 
     @ReactMethod
     public void sendWeb3Request(final String payload, final Callback callback) {
-        Thread thread = new Thread() {
+        Runnable r = new Runnable() {
             @Override
             public void run() {
                 String res = Statusgo.CallRPC(payload);
@@ -692,7 +692,7 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
             }
         };
 
-        thread.start();
+        StatusThreadPoolExecutor.getInstance().execute(r);
     }
 
     @ReactMethod

--- a/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusThreadPoolExecutor.java
+++ b/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusThreadPoolExecutor.java
@@ -1,0 +1,37 @@
+package im.status.ethereum.module;
+
+import java.util.concurrent.*;
+
+public class StatusThreadPoolExecutor {
+    private static final int NUMBER_OF_CORES =
+            Runtime.getRuntime().availableProcessors();
+    private static final int KEEP_ALIVE_TIME = 1;
+    private static final TimeUnit KEEP_ALIVE_TIME_UNIT = TimeUnit.SECONDS;
+
+    private final BlockingQueue<Runnable> mQueue;
+    private final ThreadPoolExecutor mThreadPool;
+
+    private StatusThreadPoolExecutor() {
+        mQueue = new LinkedBlockingQueue<>();
+
+        mThreadPool = new ThreadPoolExecutor(
+            NUMBER_OF_CORES,
+            NUMBER_OF_CORES,
+            KEEP_ALIVE_TIME,
+            KEEP_ALIVE_TIME_UNIT,
+            mQueue);
+    }
+
+    /** Pugh singleton */
+    private static class Holder {
+        private static StatusThreadPoolExecutor instance = new StatusThreadPoolExecutor();
+    }
+
+    public static StatusThreadPoolExecutor getInstance() {
+        return Holder.instance;
+    }
+
+    public void execute(final Runnable r) {
+        mThreadPool.execute(r);
+    }
+}


### PR DESCRIPTION
Fixes #3690 : "Use thread pool instead of new threads on Android"

### Summary:
Replaces use of `new Thread()` with a global `StatusThreadPoolExecutor` class per the requirement in issue #3690.

### Steps to test:
General smoke test on the status client, especially account lifecycle operations.

status: ready 
