### PR TITLE
Console navigation bar text is not centered

### DIFF
--- a/src/status_im/chat/screen.cljs
+++ b/src/status_im/chat/screen.cljs
@@ -53,14 +53,15 @@
   (letsubs [{:keys [group-chat name chat-id contacts]} [:get-current-chat]]
     [react/view
      [status-bar/status-bar]
-     [toolbar/platform-agnostic-toolbar {}
-      toolbar/nav-back-count
-      [toolbar-content/toolbar-content-view]
-      (when (not= chat-id constants/console-chat-id)
+     (if (= chat-id constants/console-chat-id)
+       [toolbar/simple-toolbar name]
+       [toolbar/platform-agnostic-toolbar {}
+        toolbar/nav-back-count
+        [toolbar-content/toolbar-content-view]
         [toolbar/actions [{:icon      :icons/options
                            :icon-opts {:color               :black
                                        :accessibility-label :chat-menu-button}
-                           :handler   #(on-options chat-id name group-chat public?)}]])]
+                           :handler   #(on-options chat-id name group-chat public?)}]]])
      (when-not (or public? group-chat) [add-contact-bar (first contacts)])]))
 
 (defmulti message-row (fn [{{:keys [type]} :row}] type))


### PR DESCRIPTION
fixes #3885 
Use `simple-toolbar` instead of `platform-agnostic-toolbar` in console chat. This toolbar shows only nav-back button and chat title.
![simulator screen shot - iphone 6 - 2018-04-18 at 12 33 57](https://user-images.githubusercontent.com/5045098/38911884-c9a61454-4304-11e8-8da5-d824403ff36a.png)
