### PR TITLE
bug #3820 - main wallet screen is now scrollable because of assets

### DIFF
--- a/src/status_im/ui/screens/wallet/styles.cljs
+++ b/src/status_im/ui/screens/wallet/styles.cljs
@@ -68,11 +68,6 @@
 (def main-section
   {:flex 1})
 
-(def scrollable-section
-  {:flex             1
-   :zIndex           1
-   :background-color colors/white})
-
 (def scroll-top
   (let [height (:height (react/get-dimensions "window"))]
     {:background-color colors/blue
@@ -111,8 +106,7 @@
 ;; Actions section
 
 (def action-section
-  {:flex 1
-   :background-color colors/blue})
+  {:background-color colors/blue})
 
 (def action
   {:background-color colors/white-transparent

--- a/src/status_im/ui/screens/wallet/views.cljs
+++ b/src/status_im/ui/screens/wallet/views.cljs
@@ -80,8 +80,7 @@
                   portfolio-value [:portfolio-value]]
     [react/view styles/main-section
      [toolbar-view]
-     [react/scroll-view {:content-container-style styles/scrollable-section
-                         :refresh-control
+     [react/scroll-view {:refresh-control
                          (reagent/as-element
                           [react/refresh-control {:on-refresh #(re-frame/dispatch [:update-wallet])
                                                   :tint-color :white


### PR DESCRIPTION
fixes #3820 

### Summary:

Wallet screen is now scrollable so full list of assets is available. Pull to refresh is still available when
the screen is scrolled to the top.

- Open Wallet (in mainnet)
- Add more than 3 token types
- Try scrolling the screen
- Try pulling to refresh Wallet

status: ready 
