### PR TITLE
[#3558] Show the revision of status-go in the version label

### DIFF
--- a/src/status_im/ui/screens/db.cljs
+++ b/src/status_im/ui/screens/db.cljs
@@ -57,6 +57,7 @@
 (spec/def ::rpc-url (spec/nilable string?))
 ;;object? doesn't work
 (spec/def ::web3 (spec/nilable any?))
+(spec/def ::web3-node-version (spec/nilable string?))
 ;;object?
 (spec/def ::webview-bridge (spec/nilable any?))
 (spec/def ::status-module-initialized? (spec/nilable boolean?))
@@ -186,6 +187,7 @@
                  ::was-modal?
                  ::rpc-url
                  ::web3
+                 ::web3-node-version
                  ::webview-bridge
                  ::status-module-initialized?
                  ::status-node-started?

--- a/src/status_im/ui/screens/profile/subs.cljs
+++ b/src/status_im/ui/screens/profile/subs.cljs
@@ -1,9 +1,15 @@
 (ns status-im.ui.screens.profile.subs
   (:require [re-frame.core :refer [reg-sub]]
-            [clojure.string :as string]))
+            [clojure.string :as string]
+            [status-im.utils.build :as build]))
 
 (reg-sub
  :get-profile-unread-messages-number
  :<- [:get-current-account]
  (fn [{:keys [seed-backed-up? mnemonic]}]
    (if (or seed-backed-up? (string/blank? mnemonic)) 0 1)))
+
+(reg-sub
+ :get-app-version
+ (fn [{:keys [web3-node-version]}]
+   (str build/version " (" (or web3-node-version "N/A") ")")))

--- a/src/status_im/ui/screens/profile/user/views.cljs
+++ b/src/status_im/ui/screens/profile/user/views.cljs
@@ -123,7 +123,7 @@
                                           :hide-arrow?         true
                                           :action-fn           #(handle-logout)}]]
       [react/view styles/my-profile-settings-logout-version
-       [react/text build/version]]]]))
+       [react/text @(re-frame/subscribe [:get-app-version])]]]]))
 
 (defview advanced [{:keys [network networks dev-mode?]}]
   (letsubs [advanced?                     [:get :my-profile/advanced?]


### PR DESCRIPTION
fixes #3558

### Summary:

Renders status-go version (from web3_clientVersion RPC) next to the logout button.

### Steps to test:
- Open Status
- Go to Profile

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->
