### PR TITLE
Send signed transaction to deleted chats

### DIFF
--- a/src/status_im/chat/specs.cljs
+++ b/src/status_im/chat/specs.cljs
@@ -2,7 +2,6 @@
   (:require [cljs.spec.alpha :as s]))
 
 (s/def :chat/chats (s/nilable map?))                              ; {id (string) chat (map)} active chats on chat's tab
-(s/def :chat/deleted-chats (s/nilable set?))                      ; set of deleted chat ids
 (s/def :chat/current-chat-id (s/nilable string?))                 ; current or last opened chat-id
 (s/def :chat/chat-id (s/nilable string?))                         ; what is the difference ? ^
 (s/def :chat/new-chat-name (s/nilable string?))                   ; we have name in the new-chat why do we need this field

--- a/src/status_im/chat/subs.cljs
+++ b/src/status_im/chat/subs.cljs
@@ -1,7 +1,6 @@
 (ns status-im.chat.subs
   (:require [clojure.string :as string]
             [re-frame.core :refer [reg-sub subscribe]]
-            [status-im.constants :as constants]
             [status-im.chat.constants :as chat-constants]
             [status-im.chat.models.input :as input-model]
             [status-im.chat.models.commands :as commands-model]
@@ -52,18 +51,19 @@
       platform/ios? kb-height
       :default 0)))
 
-(defn active-chats [dev-mode?]
-  (fn [[_ chat]]
-    (and (:is-active chat)
-         (or dev-mode?
-             (not= const/console-chat-id (:chat-id chat))))))
+(defn- active-chat? [dev-mode? [_ chat]]
+  (and (:is-active chat)
+       (or dev-mode?
+           (not= const/console-chat-id (:chat-id chat)))))
+
+(defn active-chats [[chats {:keys [dev-mode?]}]]
+  (into {} (filter (partial active-chat? dev-mode?) chats)))
 
 (reg-sub
   :get-active-chats
   :<- [:get-chats]
   :<- [:get-current-account]
-  (fn [[chats {:keys [dev-mode?]}]]
-    (into {} (filter (active-chats dev-mode?) chats))))
+  active-chats)
 
 (reg-sub
   :get-chat

--- a/src/status_im/data_store/chats.cljs
+++ b/src/status_im/data_store/chats.cljs
@@ -8,23 +8,14 @@
 (re-frame/reg-cofx
   :data-store/all-chats
   (fn [cofx _]
-    (assoc cofx :all-stored-chats (data-store/get-all-active))))
-
-(re-frame/reg-cofx
-  :data-store/inactive-chat-ids
-  (fn [cofx _]
-    (assoc cofx :inactive-chat-ids (data-store/get-inactive-ids))))
-
-(re-frame/reg-cofx
-  :data-store/get-chat
-  (fn [cofx _]
-    (assoc cofx :get-stored-chat data-store/get-by-id)))
+    (assoc cofx :all-stored-chats (data-store/get-all))))
 
 (re-frame/reg-fx
   :data-store/save-chat
   (fn [{:keys [chat-id] :as chat}]
     (async/go (async/>! core/realm-queue #(data-store/save chat (data-store/exists? chat-id))))))
 
+; Only used in debug mode
 (re-frame/reg-fx
   :data-store/delete-chat
   (fn [chat-id]

--- a/src/status_im/data_store/realm/chats.cljs
+++ b/src/status_im/data_store/realm/chats.cljs
@@ -12,35 +12,13 @@
         (realm/fix-map->vec :contacts)
         (assoc :last-clock-value  (or last-clock-value 0)))))
 
-(defn get-all-active
+(defn get-all
   []
   (map normalize-chat
-       (-> (realm/get-by-field @realm/account-realm :chat :is-active true)
+       (-> @realm/account-realm
+           (realm/get-all :chat)
            (realm/sorted :timestamp :desc)
            realm/js-object->clj)))
-
-(defn get-inactive-ids
-  []
-  (-> (realm/get-by-field @realm/account-realm :chat :is-active false)
-      (.map (fn [chat _ _]
-              (aget chat "chat-id")))
-      realm/js-object->clj
-      set))
-
-(defn- groups
-  [active?]
-  (-> @realm/account-realm
-      (realm/get-all :chat)
-      (realm/sorted :timestamp :desc)
-      (realm/filtered (str "group-chat = true && is-active = "
-                           (if active? "true" "false")))))
-
-(defn get-active-group-chats
-  []
-  (map (fn [{:keys [chat-id public?]}]
-         {:group-id chat-id
-          :public?  public?})
-       (realm/js-object->clj (groups true))))
 
 (defn- get-by-id-obj
   [chat-id]
@@ -72,7 +50,7 @@
                  (fn []
                    (doto chat
                      (aset "is-active" false)
-                     (aset "removed-at" (datetime/timestamp))))))) 
+                     (aset "removed-at" (datetime/timestamp)))))))
 
 (defn add-contacts
   [chat-id identities]

--- a/src/status_im/transport/message/v1/group_chat.cljs
+++ b/src/status_im/transport/message/v1/group_chat.cljs
@@ -94,9 +94,9 @@
             (if (removed me) ;; we were removed
               (handlers/merge-fx cofx
                                  (models.message/receive
-                                  (models.message/system-message chat-id random-id now
-                                                                 (str admin-name " " (i18n/label :t/removed-from-chat))))
-                                 (models.chat/update-chat {:chat-id         chat-id
+                                   (models.message/system-message chat-id random-id now
+                                                                  (str admin-name " " (i18n/label :t/removed-from-chat))))
+                                 (models.chat/upsert-chat {:chat-id         chat-id
                                                            :removed-from-at now
                                                            :is-active       false})
                                  (transport/unsubscribe-from-chat chat-id))

--- a/src/status_im/ui/screens/contacts/core.cljs
+++ b/src/status_im/ui/screens/contacts/core.cljs
@@ -22,7 +22,7 @@
       (handlers/merge-fx cofx
                          {:db                      (update-in db [:contacts/contacts public-key] merge contact-props)
                           :data-store/save-contact contact-props}
-                         (chat.models/add-chat public-key chat-props)))))
+                         (chat.models/upsert-chat chat-props)))))
 
 (defn receive-contact-request-confirmation
   [public-key {:keys [name profile-image address fcm-token]}
@@ -59,6 +59,6 @@
             (if (chats public-key)
               (handlers/merge-fx cofx
                                  (update-contact contact)
-                                 (chat.models/update-chat {:chat-id chat-id
+                                 (chat.models/upsert-chat {:chat-id chat-id
                                                            :name    name}))
               (update-contact contact cofx))))))))

--- a/src/status_im/ui/screens/contacts/events.cljs
+++ b/src/status_im/ui/screens/contacts/events.cljs
@@ -80,7 +80,7 @@
 
 (handlers/register-handler-fx
   :set-contact-identity-from-qr
-  [(re-frame/inject-cofx :random-id) (re-frame/inject-cofx :data-store/get-chat)]
+  [(re-frame/inject-cofx :random-id)]
   (fn [{{:accounts/keys [accounts current-account-id] :as db} :db :as cofx} [_ _ contact-identity]]
     (let [current-account (get accounts current-account-id)
           fx              {:db (assoc db :contacts/new-identity contact-identity)}]
@@ -125,7 +125,7 @@
 
 (handlers/register-handler-fx
   :add-contact-handler
-  [(re-frame/inject-cofx :random-id) (re-frame/inject-cofx :data-store/get-chat)]
+  [(re-frame/inject-cofx :random-id)]
   (fn [{{:contacts/keys [new-identity] :as db} :db :as cofx} _]
     (when (seq new-identity)
       (add-contact-and-open-chat new-identity cofx))))

--- a/src/status_im/ui/screens/db.cljs
+++ b/src/status_im/ui/screens/db.cljs
@@ -195,7 +195,6 @@
                   :qr/qr-modal
                   :qr/current-qr-context
                   :chat/chats
-                  :chat/deleted-chats
                   :chat/current-chat-id
                   :chat/chat-id
                   :chat/new-chat

--- a/src/status_im/ui/screens/events.cljs
+++ b/src/status_im/ui/screens/events.cljs
@@ -81,9 +81,7 @@
 (re-frame/reg-cofx
  :random-id-seq
  (fn [coeffects _]
-   (assoc coeffects :random-id-seq
-          ((fn rand-id-seq []
-             (cons (random/id) (lazy-seq (rand-id-seq))))))))
+   (assoc coeffects :random-id-seq (repeatedly random/id))))
 
 ;;;; FX
 

--- a/src/status_im/ui/screens/profile/events.cljs
+++ b/src/status_im/ui/screens/profile/events.cljs
@@ -27,7 +27,7 @@
 
 (handlers/register-handler-fx
   :profile/send-transaction
-  [(re-frame/inject-cofx :data-store/get-chat) re-frame/trim-v]
+  [re-frame/trim-v]
   (fn [{{:contacts/keys [contacts]} :db :as cofx} [chat-id]]
     (let [send-command (get-in contacts chat-const/send-command-ref)]
       (handlers/merge-fx cofx

--- a/test/cljs/status_im/test/accounts/events.cljs
+++ b/test/cljs/status_im/test/accounts/events.cljs
@@ -23,7 +23,6 @@
    :status              "be the hero of your own journey"
    :network             constants/default-network
    :networks            constants/default-networks
-   :wnode               constants/default-wnode
    :public-key          "0x049b3a8c04f2c5bccda91c1f5e6434ae72957e93a31c0301b4563eda1d6ce419f63c503ebaee143115f96c1f04f232a7a22ca0454e9ee3d579ad1f870315b151d0"})
 
 (def new-account
@@ -34,7 +33,6 @@
    :status              "the future starts today, not tomorrow"
    :network             constants/default-network
    :networks            constants/default-networks
-   :wnode               constants/default-wnode
    :signing-phrase      "long loan limo"
    :public-key          "0x04f5722fba79eb36d73263417531007f43d13af76c6233573a8e3e60f667710611feba0785d751b50609bfc0b7cef35448875c5392c0a91948c95798a0ce600847"})
 

--- a/test/cljs/status_im/test/chat/models.cljs
+++ b/test/cljs/status_im/test/chat/models.cljs
@@ -1,0 +1,102 @@
+(ns status-im.test.chat.models
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [status-im.chat.models :as chat]))
+
+(deftest upsert-chat-test
+  (testing "upserting a non existing chat"
+    (let [chat-id        "some-chat-id"
+          contact-name   "contact-name"
+          chat-props     {:chat-id chat-id
+                          :extra-prop "some"}
+          cofx           {:now "now"
+                          :db {:contacts/contacts {chat-id
+                                                   {:name contact-name}}}}
+          response      (chat/upsert-chat chat-props cofx)
+          actual-chat   (get-in response [:db :chats chat-id])
+          store-chat-fx (:data-store/save-chat response)]
+      (testing "it adds the chat to the chats collection"
+        (is actual-chat))
+      (testing "it adds the extra props"
+        (is (= "some" (:extra-prop actual-chat))))
+      (testing "it adds the chat id"
+        (is (= chat-id (:chat-id actual-chat))))
+      (testing "it pulls the name from the contacts"
+        (is (= contact-name (:name actual-chat))))
+      (testing "it sets the timestamp"
+        (is (= "now" (:timestamp actual-chat))))
+      (testing "it adds the contact-id to the contact field"
+        (is (= chat-id (-> actual-chat :contacts first))))
+      (testing "it adds the fx to store a chat"
+        (is store-chat-fx))))
+  (testing "upserting an existing chat"
+    (let [chat-id        "some-chat-id"
+          chat-props     {:chat-id chat-id
+                          :name "new-name"
+                          :extra-prop "some"}
+          cofx           {:db {:chats {chat-id {:is-active true
+                                                :name "old-name"}}}}
+          response      (chat/upsert-chat chat-props cofx)
+          actual-chat   (get-in response [:db :chats chat-id])
+          store-chat-fx (:data-store/save-chat response)]
+      (testing "it adds the chat to the chats collection"
+        (is actual-chat))
+      (testing "it adds the extra props"
+        (is (= "some" (:extra-prop actual-chat))))
+      (testing "it updates existins props"
+        (is (= "new-name" (:name actual-chat))))
+      (testing "it adds the fx to store a chat"
+        (is store-chat-fx))))
+  (testing "upserting a deleted chat"
+    (let [chat-id        "some-chat-id"
+          contact-name   "contact-name"
+          chat-props     {:chat-id chat-id
+                          :name "new-name"
+                          :extra-prop "some"}
+          cofx           {:some-cofx "b"
+                          :db {:chats {chat-id {:is-active false
+                                                :name "old-name"}}}}]
+      (testing "it updates it if is-active is passed"
+        (is (get-in (chat/upsert-chat (assoc chat-props :is-active true) cofx) [:db :chats chat-id :is-active])))
+      (testing "it returns the db unchanged"
+         (is (= {:db (:db cofx)} (chat/upsert-chat chat-props cofx)))))))
+
+(deftest add-group-chat
+  (let [chat-id "chat-id"
+        chat-name "chat-name"
+        admin "admin"
+        participants ["a"]
+        fx (chat/add-group-chat chat-id chat-name admin participants {})
+        store-fx   (:data-store/save-chat fx)
+        group-chat (get-in fx [:db :chats chat-id])]
+    (testing "it saves the chat in the database"
+      (is store-fx))
+    (testing "it sets the name"
+      (is (= chat-name (:name group-chat))))
+    (testing "it sets the admin"
+      (is (= admin (:group-admin group-chat))))
+    (testing "it sets the participants"
+      (is (= participants (:contacts group-chat))))
+    (testing "it sets the chat-id"
+      (is (= chat-id (:chat-id group-chat))))
+    (testing "it sets the group-chat flag"
+      (is (:group-chat group-chat)))
+    (testing "it does not sets the public flag"
+      (is (not (:public? group-chat))))))
+
+(deftest add-public-chat
+  (let [topic "topic"
+        fx (chat/add-public-chat topic {})
+        store-fx   (:data-store/save-chat fx)
+        chat (get-in fx [:db :chats topic])]
+    (testing "it saves the chat in the database"
+      (is store-fx))
+    (testing "it sets the name"
+      (is (= topic (:name chat))))
+    (testing "it sets the participants"
+      (is (= [] (:contacts chat))))
+    (testing "it sets the chat-id"
+      (is (= topic (:chat-id chat))))
+    (testing "it sets the group-chat flag"
+      (is (:group-chat chat)))
+    (testing "it does not sets the public flag"
+      (is (:public? chat)))))

--- a/test/cljs/status_im/test/chat/models/message.cljs
+++ b/test/cljs/status_im/test/chat/models/message.cljs
@@ -1,0 +1,26 @@
+(ns status-im.test.chat.models.message
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [status-im.chat.models.message :as message]))
+
+(deftest add-to-chat?
+  (testing "it returns true when it's not in loaded message"
+    (is (message/add-to-chat? {:db {:chats {"a" {}}}}
+                              {:message-id "message-id"
+                               :from "a"
+                               :chat-id "a"})))
+  (testing "it returns false when from is the same as pk"
+    (is (not (message/add-to-chat? {:db {:current-public-key "pk"
+                                         :chats {"a" {}}}}
+                                   {:message-id "message-id"
+                                    :from "pk"
+                                    :chat-id "a"}))))
+  (testing "it returns false when it's already in the loaded message"
+    (is (not (message/add-to-chat? {:db {:chats {"a" {:messages {"message-id" {}}}}}}
+                                   {:message-id "message-id"
+                                    :from "a"
+                                    :chat-id "a"}))))
+  (testing "it returns false when it's already in the not-loaded-message-ids"
+    (is (not (message/add-to-chat? {:db {:chats {"a" {:not-loaded-message-ids #{"message-id" }}}}}
+                                   {:message-id "message-id"
+                                    :from "a"
+                                    :chat-id "a"})))))

--- a/test/cljs/status_im/test/chat/subs.cljs
+++ b/test/cljs/status_im/test/chat/subs.cljs
@@ -1,5 +1,6 @@
 (ns status-im.test.chat.subs
   (:require [cljs.test :refer-macros [deftest is testing]]
+            [status-im.constants :as const]
             [status-im.chat.subs :as s]))
 
 (deftest test-message-datemark-groups
@@ -134,3 +135,21 @@
         (is (:last-in-group? actual-m2))
         (is (:last-in-group? actual-m3))
         (is (not (:last-in-group? actual-m4)))))))
+
+(deftest active-chats-test
+  (let [active-chat-1 {:is-active true :chat-id 1}
+        active-chat-2 {:is-active true :chat-id 2}
+        console       {:is-active true :chat-id const/console-chat-id}
+        chats         {1 active-chat-1
+                       2 active-chat-2
+                       3 {:is-active false :chat-id 3}
+                       const/console-chat-id console}]
+    (testing "in normal it returns only chats with is-active, without console"
+      (is (= {1 active-chat-1
+              2 active-chat-2}
+             (s/active-chats [chats {:dev-mode? false}]))))
+    (testing "in dev-mode it returns only chats with is-active, keeping console"
+      (is (= {1 active-chat-1
+              2 active-chat-2
+              const/console-chat-id console}
+             (s/active-chats [chats {:dev-mode? true}]))))))

--- a/test/cljs/status_im/test/runner.cljs
+++ b/test/cljs/status_im/test/runner.cljs
@@ -8,7 +8,9 @@
             [status-im.test.wallet.transactions.views]
             [status-im.test.profile.events]
             [status-im.test.bots.events]
+            [status-im.test.chat.models]
             [status-im.test.chat.models.input]
+            [status-im.test.chat.models.message]
             [status-im.test.chat.subs]
             [status-im.test.chat.views.message]
             [status-im.test.i18n]
@@ -39,6 +41,7 @@
  'status-im.test.utils.async
  'status-im.test.chat.events
  'status-im.test.chat.subs
+ 'status-im.test.chat.models
  'status-im.test.accounts.events
  'status-im.test.contacts.events
  'status-im.test.profile.events
@@ -47,6 +50,7 @@
  'status-im.test.wallet.transactions.subs
  'status-im.test.wallet.transactions.views
  'status-im.test.chat.models.input
+ 'status-im.test.chat.models.message
  'status-im.test.chat.views.message
  'status-im.test.i18n
  'status-im.test.protocol.web3.inbox


### PR DESCRIPTION
fixes #3624 

### Summary:

When sending a transaction using sign later and the chat has been deleted, an error was displayed. 

I have changed so that we still add the message to the deleted chat.

I have also removed the old `upsert-chat` and renamed `update-chat` to `upsert-chat` as that is a more appropriate name.

Fixes also the error message displayed when sending messages to console.

status: ready
