### PR TITLE
Replace accounts/accounts by account/account in app-db [#3907]

### DIFF
--- a/src/status_im/chat/events/commands.cljs
+++ b/src/status_im/chat/events/commands.cljs
@@ -20,7 +20,7 @@
 
 (defn request-command-message-data
   "Requests command message data from jail"
-  [{:accounts/keys [current-account-id] :contacts/keys [contacts] :as db}
+  [{:contacts/keys [contacts] :as db}
    {{:keys [command command-scope-bitmask bot params type]} :content
     :keys [chat-id group-id] :as message}
    {:keys [data-type] :as opts}]
@@ -31,8 +31,9 @@
                          [command command-scope-bitmask]
                          data-type]
             to          (get-in contacts [chat-id :address])
+            address     (get-in db [:account/account :address])
             jail-params {:parameters params
-                         :context    (generate-context current-account-id chat-id (models.message/group-message? message) to)}]
+                         :context    (generate-context address chat-id (models.message/group-message? message) to)}]
         {:db        db
          :call-jail {:jail-id                bot
                      :path                   path

--- a/src/status_im/chat/events/console.cljs
+++ b/src/status_im/chat/events/console.cljs
@@ -42,8 +42,7 @@
 (def console-commands->fx
   {"faucet"
    (fn [{:keys [db random-id] :as cofx} {:keys [params]}]
-     (let [{:accounts/keys [accounts current-account-id]} db
-           current-address (get-in accounts [current-account-id :address])
+     (let [current-address (get-in db [:account/account :address])
            faucet-url (faucet-base-url->url (:url params))]
        {:http-get {:url (gstring/format faucet-url current-address)
                    :success-event-creator (fn [_]

--- a/src/status_im/chat/models/input.cljs
+++ b/src/status_im/chat/models/input.cljs
@@ -110,10 +110,9 @@
                              (rest command-args)
                              seq-arguments))})))
   ([{:keys [chats current-chat-id access-scope->commands-responses]
-     :contacts/keys [contacts]
-     :accounts/keys [accounts current-account-id] :as db}]
+     :contacts/keys [contacts] :as db}]
    (let [chat (get chats current-chat-id)
-         account (get accounts current-account-id)]
+         account (:account/account db)]
      (selected-chat-command chat
                             (commands-model/commands-responses :command
                                                                access-scope->commands-responses

--- a/src/status_im/commands/events/loading.cljs
+++ b/src/status_im/commands/events/loading.cljs
@@ -157,7 +157,7 @@
         (cond-> {:db (add-jail-result db jail-id result)
                  :call-jail-function {:chat-id jail-id
                                       :function :init :context
-                                      {:from (:accounts/current-account-id db)}}}
+                                      {:from (get-in db [:account/account :address])}}}
           (seq jail-loaded-events)
           (-> (assoc :dispatch-n jail-loaded-events)
               (update-in [:db :contacts/contacts jail-id] dissoc :jail-loaded-events)))))))

--- a/src/status_im/commands/handlers/debug.cljs
+++ b/src/status_im/commands/handlers/debug.cljs
@@ -91,8 +91,8 @@
             :text "Command has been executed."}))
 
 (defn switch-node
-  [{:accounts/keys [current-account-id]} {:keys [url]}]
-  (re-frame/dispatch [:initialize-protocol current-account-id url])
+  [{:keys [account/account]} {:keys [url]}]
+  (re-frame/dispatch [:initialize-protocol (:address account) url])
   (respond {:type :ok
             :text "You've successfully switched the node."}))
 

--- a/src/status_im/transport/core.cljs
+++ b/src/status_im/transport/core.cljs
@@ -19,7 +19,7 @@
   - (optionally) initializing offline inboxing"
   [current-account-id {:keys [db web3] :as cofx}]
   (log/debug :init-whisper)
-  (when-let [public-key (get-in db [:accounts/accounts current-account-id :public-key])]
+  (when-let [public-key (get-in db [:account/account :public-key])]
     (let [sym-key-added-callback (fn [chat-id sym-key sym-key-id]
                                    (re-frame/dispatch [::sym-key-added {:chat-id    chat-id
                                                                         :sym-key    sym-key

--- a/src/status_im/transport/inbox.cljs
+++ b/src/status_im/transport/inbox.cljs
@@ -36,9 +36,9 @@
        (error-fn error)
        (success-fn result)))))
 
-(defn get-current-wnode-address [{:accounts/keys [current-account-id accounts] :as db}]
+(defn get-current-wnode-address [db]
   (let [network  (ethereum/network->chain-keyword (get db :network))
-        wnode-id (get-in accounts [current-account-id :settings :wnode network])]
+        wnode-id (get-in db [:account/account :settings :wnode network])]
     (get-in db [:inbox/wnodes network wnode-id :address])))
 
 (defn initialize-offline-inbox

--- a/src/status_im/ui/screens/accounts/db.cljs
+++ b/src/status_im/ui/screens/accounts/db.cljs
@@ -42,12 +42,11 @@
 
 (spec/def :accounts/accounts (spec/nilable (spec/map-of :account/address :accounts/account)))
 
-;;id of logged in account
-(spec/def :accounts/current-account-id (spec/nilable string?))
-
 ;;used during creating account
 (spec/def :accounts/create (spec/nilable map?))
 ;;used during recovering account
 (spec/def :accounts/recover (spec/nilable map?))
 ;;used during logging
 (spec/def :accounts/login (spec/nilable map?))
+;;logged in account
+(spec/def :account/account (spec/nilable :accounts/account))

--- a/src/status_im/ui/screens/accounts/subs.cljs
+++ b/src/status_im/ui/screens/accounts/subs.cljs
@@ -13,19 +13,13 @@
   (fn [db]
     (:accounts/accounts db)))
 
-(reg-sub :get-current-account-id
-  (fn [db]
-    (:accounts/current-account-id db)))
-
 (reg-sub :get-current-account
-  :<- [:get-current-account-id]
-  :<- [:get-accounts]
-  (fn [[account-id accounts]]
-    (some-> accounts (get account-id))))
+  (fn [db]
+    (:account/account db)))
 
 (reg-sub :get-current-account-hex
-  :<- [:get-current-account-id]
-  (fn [address]
+  :<- [:get-current-account]
+  (fn [{:keys [address]}]
     (ethereum/normalized-address address)))
 
 (reg-sub

--- a/src/status_im/ui/screens/contacts/events.cljs
+++ b/src/status_im/ui/screens/contacts/events.cljs
@@ -40,8 +40,8 @@
                                   (assoc-in [:contacts/new-identity] ""))
      :data-store/save-contact new-contact}))
 
-(defn- own-info [{:accounts/keys [accounts current-account-id] :as db}]
-  (let [{:keys [name photo-path address]} (get accounts current-account-id)
+(defn- own-info [db]
+  (let [{:keys [name photo-path address]} (:account/account db)
         fcm-token (get-in db [:notifications :fcm-token])]
     {:name          name
      :profile-image photo-path
@@ -82,8 +82,8 @@
 (handlers/register-handler-fx
   :set-contact-identity-from-qr
   [(re-frame/inject-cofx :random-id)]
-  (fn [{{:accounts/keys [accounts current-account-id] :as db} :db :as cofx} [_ _ contact-identity]]
-    (let [current-account (get accounts current-account-id)
+  (fn [{:keys [db] :as cofx} [_ _ contact-identity]]
+    (let [current-account (:account/account db)
           fx              {:db (assoc db :contacts/new-identity contact-identity)}]
       (if (new-chat.db/validate-pub-key contact-identity current-account)
         fx

--- a/src/status_im/ui/screens/db.cljs
+++ b/src/status_im/ui/screens/db.cljs
@@ -22,7 +22,6 @@
              :status-module-initialized?  (or platform/ios? js/goog.DEBUG)
              :keyboard-height             0
              :tab-bar-visible?            true
-             :accounts/accounts           {}
              :navigation-stack            '()
              :contacts/contacts           {}
              :qr-codes                    {}
@@ -151,9 +150,9 @@
                   :group/groups-order
                   :accounts/accounts
                   :accounts/create
-                  :accounts/current-account-id
                   :accounts/recover
                   :accounts/login
+                  :account/account
                   :my-profile/profile
                   :my-profile/default-name
                   :my-profile/editing?

--- a/src/status_im/ui/screens/network_settings/events.cljs
+++ b/src/status_im/ui/screens/network_settings/events.cljs
@@ -43,10 +43,11 @@
           chats           (:transport/chats db)]
       (if (utils/network-with-upstream-rpc? networks current-network)
         (handlers-macro/merge-fx cofx
-                           {:dispatch               [:navigate-to-clean :accounts]}
-                           (transport/stop-whisper)
-                           (accounts-events/account-update {:network      network
-                                                            :last-updated now}))
+                                 {:dispatch-n            [[:load-accounts]
+                                                          [:navigate-to-clean :accounts]]}
+                                 (transport/stop-whisper)
+                                 (accounts-events/account-update {:network      network
+                                                                  :last-updated now}))
         {:show-confirmation {:title               (i18n/label :t/close-app-title)
                              :content             (i18n/label :t/close-app-content)
                              :confirm-button-text (i18n/label :t/close-app-button)

--- a/src/status_im/ui/screens/offline_messaging_settings/events.cljs
+++ b/src/status_im/ui/screens/offline_messaging_settings/events.cljs
@@ -10,12 +10,11 @@
 (handlers/register-handler-fx
   ::save-wnode
   (fn [{:keys [db now] :as cofx} [_ wnode]]
-    (let [{:accounts/keys [current-account-id accounts]} db
-          network                                        (ethereum/network->chain-keyword (:network db))
-          settings                                       (get-in accounts [current-account-id :settings])]
+    (let [network  (ethereum/network->chain-keyword (:network db))
+          settings (get-in db [:account/account :settings])]
       (handlers-macro/merge-fx cofx
-                         {:dispatch [:logout]}
-                         (accounts-events/update-settings (assoc-in settings [:wnode network] wnode))))))
+                               {:dispatch [:logout]}
+                               (accounts-events/update-settings (assoc-in settings [:wnode network] wnode))))))
 
 (handlers/register-handler-fx
   :connect-wnode

--- a/src/status_im/ui/screens/profile/events.cljs
+++ b/src/status_im/ui/screens/profile/events.cljs
@@ -35,8 +35,8 @@
                          (chat-events/start-chat chat-id {:navigation-replace? true})
                          (input-events/select-chat-input-command send-command nil true)))))
 
-(defn get-current-account [{:accounts/keys [current-account-id] :as db}]
-  (get-in db [:accounts/accounts current-account-id]))
+(defn get-current-account [db]
+  (:account/account db))
 
 (defn valid-name? [name]
   (spec/valid? :profile/name name))
@@ -55,11 +55,11 @@
       {:db (assoc-in db [:my-profile/profile :photo-path] (str "data:image/jpeg;base64," base64-image))}
       {:open-image-picker this-event})))
 
-(defn clean-name [{:accounts/keys [current-account-id] :as db} edit-view]
+(defn clean-name [db edit-view]
   (let [name (get-in db [edit-view :name])]
     (if (valid-name? name)
       name
-      (get-in db [:accounts/accounts current-account-id :name]))))
+      (get-in db [:account/account :name]))))
 
 (defn clear-profile [{:keys [db] :as cofx}]
   {:db (dissoc db :my-profile/profile :my-profile/default-name :my-profile/editing?)})

--- a/src/status_im/ui/screens/profile/navigation.cljs
+++ b/src/status_im/ui/screens/profile/navigation.cljs
@@ -4,8 +4,8 @@
 ;;TODO(goranjovic) - replace this with an atomic navigation event that calls functions, not dispatch
 ;; possibly use the generic event, see https://github.com/status-im/status-react/issues/2987
 (defmethod navigation/preload-data! :profile-qr-viewer
-  [{:accounts/keys [current-account-id] :as db} [_ _ {:keys [contact source value]}]]
-  (update db :qr-modal #(merge % {:contact (or contact (get-in db [:accounts/accounts current-account-id]))
+  [db [_ _ {:keys [contact source value]}]]
+  (update db :qr-modal #(merge % {:contact (or contact (get db :account/account))
                                   :source  source
                                   :value   value})))
 

--- a/src/status_im/ui/screens/wallet/events.cljs
+++ b/src/status_im/ui/screens/wallet/events.cljs
@@ -93,16 +93,17 @@
 ;; Handlers
 (handlers/register-handler-fx
   :update-wallet
-  (fn [{{:keys [web3 accounts/current-account-id network network-status] :as db} :db} _]
+  (fn [{{:keys [web3 account/account network network-status] :as db} :db} _]
     (let [chain   (ethereum/network->chain-keyword network)
-          symbols (get-in db [:accounts/accounts current-account-id :settings :wallet :visible-tokens chain])]
+          address (:address account)
+          symbols (get-in account [:settings :wallet :visible-tokens chain])]
       (when (not= network-status :offline)
         {:get-balance {:web3          web3
-                       :account-id    current-account-id
+                       :account-id    address
                        :success-event :update-balance-success
                        :error-event   :update-balance-fail}
          :get-tokens-balance {:web3          web3
-                              :account-id    current-account-id
+                              :account-id    address
                               :symbols       symbols
                               :chain         chain
                               :success-event :update-token-balance-success
@@ -119,9 +120,9 @@
 
 (handlers/register-handler-fx
   :update-transactions
-  (fn [{{:keys [accounts/current-account-id network network-status] :as db} :db} _]
+  (fn [{{:keys [network network-status] :as db} :db} _]
     (when (not= network-status :offline)
-      {:get-transactions {:account-id    current-account-id
+      {:get-transactions {:account-id    (get-in db [:account/account :address])
                           :network       network
                           :success-event :update-transactions-success
                           :error-event   :update-transactions-fail}

--- a/src/status_im/ui/screens/wallet/send/events.cljs
+++ b/src/status_im/ui/screens/wallet/send/events.cljs
@@ -232,8 +232,7 @@
 
 (handlers/register-handler-fx
   :wallet/sign-transaction
-  (fn [{{:keys          [web3]
-         :accounts/keys [accounts current-account-id] :as db} :db} [_ later?]]
+  (fn [{{:keys [web3] :as db} :db} [_ later?]]
     (let [db' (assoc-in db [:wallet :send-transaction :wrong-password?] false)
           network (:network db)
           {:keys [amount id password to symbol gas gas-price]} (get-in db [:wallet :send-transaction])]
@@ -247,7 +246,7 @@
                                        :later? later?
                                        :in-progress? true)
          ::send-transaction {:web3      web3
-                             :from      (get-in accounts [current-account-id :address])
+                             :from      (get-in db [:account/account :address])
                              :to        to
                              :value     amount
                              :gas       gas

--- a/src/status_im/ui/screens/wallet/settings/events.cljs
+++ b/src/status_im/ui/screens/wallet/settings/events.cljs
@@ -10,8 +10,8 @@
 
 (handlers/register-handler-fx
   :wallet.settings/toggle-visible-token
-  (fn [{{:keys [network] :accounts/keys [current-account-id] :as db} :db :as cofx} [_ symbol checked?]]
+  (fn [{{:keys [network account/account] :as db} :db :as cofx} [_ symbol checked?]]
     (let [chain        (ethereum/network->chain-keyword network)
-          settings     (get-in db [:accounts/accounts current-account-id :settings])
+          settings     (get account :settings)
           new-settings (update-in settings [:wallet :visible-tokens chain] #(toggle-checked % symbol checked?))]
       (accounts/update-settings new-settings cofx))))

--- a/src/status_im/utils/handlers.cljs
+++ b/src/status_im/utils/handlers.cljs
@@ -91,10 +91,8 @@
    (fn track-handler
      [context]
      (let [new-db             (get-coeffect context :db)
-           current-account-id (:accounts/current-account-id new-db)]
-       (when (get-in new-db [:accounts/accounts
-                             current-account-id
-                             :sharing-usage-data?])
+           current-account-id (get-in new-db [:account/account :address])]
+       (when (get-in new-db [:account/account :sharing-usage-data?])
          (let [event    (get-coeffect context :event)
                offline? (or (= :offline (:network-status new-db))
                             (= :offline (:sync-state new-db)))

--- a/test/cljs/status_im/test/chat/events.cljs
+++ b/test/cljs/status_im/test/chat/events.cljs
@@ -21,8 +21,7 @@
       (is (not fx))))
 
   (testing "initialising console without existing account and console chat not initialisated"
-    (let [fresh-db {:chats {}
-                    :accounts/current-account-id nil}
+    (let [fresh-db {:chats {}}
           {:keys [db dispatch-n]} (chat-events/init-console-chat {:db fresh-db})]
       (is (= (:current-chat-id db)
              (:chat-id console-chat/chat)))
@@ -30,8 +29,7 @@
              const/console-chat-id))))
 
   (testing "initialising console with existing account and console chat not initialisated"
-    (let [fresh-db {:chats {}
-                    :accounts/current-account-id (:whisper-identity contact)}
+    (let [fresh-db {:chats {}}
           {:keys [db dispatch-n]} (chat-events/init-console-chat {:db fresh-db})]
       (is (= (:current-chat-id db)
              (:chat-id console-chat/chat)))


### PR DESCRIPTION
fixes #3907

### Summary:

Replace accounts/accounts by account/account in app-db

- move all informations that are not necessary to login from the base realm to account specific realm
- remove accounts/accounts and accounts/current-account-id from app-db, replace by account/account when user is logged in (logged out can have dedicated key)


status: ready <!-- Can be ready or wip -->
