### PR TITLE
Show timestamp inside bubble for text messages

### DIFF
--- a/src/status_im/chat/styles/message/message.cljs
+++ b/src/status_im/chat/styles/message/message.cljs
@@ -1,10 +1,10 @@
 (ns status-im.chat.styles.message.message
   (:require-macros [status-im.utils.styles :refer [defstyle defnstyle]])
   (:require [status-im.ui.components.styles :as styles]
+            [status-im.chat.styles.photos :as photos]
             [status-im.ui.components.colors :as colors]
             [status-im.constants :as constants]))
 
-(def photo-size 36)
 
 (defstyle style-message-text
   {:font-size 15
@@ -48,13 +48,18 @@
             :align-self     align
             :align-items    align})))
 
-(def message-timestamp
-  {:margin-left     5
-   :margin-right    5
-   :margin-bottom   -2
-   :color           colors/gray
-   :opacity         0.5
-   :align-self      :flex-end})
+(defn message-timestamp [justify-timestamp?]
+  (merge {:color      colors/gray
+          :font-size  10
+          :align-self :flex-end
+          :opacity    0.5}
+         (when justify-timestamp? {:position :absolute
+                                   :bottom   10
+                                   :right    12})))
+
+(def message-timestamp-placeholder
+  (assoc (message-timestamp false)
+         :color styles/color-white))
 
 (def selected-message
   {:margin-top  18
@@ -83,13 +88,8 @@
    :padding-right 22})
 
 (def message-author
-  {:width      photo-size
+  {:width      photos/photo-size
    :align-self :flex-end})
-
-(def photo
-  {:border-radius (/ photo-size 2)
-   :width         photo-size
-   :height        photo-size})
 
 (def delivery-view
   {:flex-direction :row
@@ -136,8 +136,10 @@
 
 (defn message-view
   [{:keys [content-type outgoing group-chat selected]}]
-  (merge {:padding         12
-          :border-radius   8}
+  (merge {:padding-top        6
+          :padding-horizontal 12
+          :padding-bottom     8
+          :border-radius      8}
          (when-not (= content-type constants/content-type-emoji)
           {:background-color styles/color-white})
          (when (= content-type constants/content-type-command)

--- a/src/status_im/chat/styles/photos.cljs
+++ b/src/status_im/chat/styles/photos.cljs
@@ -1,0 +1,8 @@
+(ns status-im.chat.styles.photos)
+
+(def photo-size 36)
+
+(def photo
+  {:border-radius (/ photo-size 2)
+   :width         photo-size
+   :height        photo-size})

--- a/src/status_im/chat/styles/screen.cljs
+++ b/src/status_im/chat/styles/screen.cljs
@@ -12,7 +12,8 @@
    :background-color component.styles/chat-background})
 
 (def toolbar-container
-  {})
+  {:flex 1
+   :flex-direction :row})
 
 (def messages-container
   {:flex           1

--- a/src/status_im/chat/views/photos.cljs
+++ b/src/status_im/chat/views/photos.cljs
@@ -1,0 +1,23 @@
+(ns status-im.chat.views.photos
+  (:require-macros [status-im.utils.views :refer [defview letsubs]])
+  (:require [status-im.ui.components.react :as react]
+            [status-im.chat.styles.photos :as style]
+            [status-im.utils.identicon :as identicon]
+            [clojure.string :as string]
+            [status-im.react-native.resources :as resources]))
+
+(defn- photo [from photo-path]
+  [react/view
+   [react/image {:source (if (and (not (string/blank? photo-path))
+                                  (string/starts-with? photo-path "contacts://"))
+                           (->> (string/replace photo-path #"contacts://" "")
+                                (keyword)
+                                (get resources/contacts))
+                           {:uri photo-path})
+                 :style  style/photo}]])
+
+(defview member-photo [from]
+  (letsubs [photo-path [:get-photo-path from]]
+    (photo from  (if (string/blank? photo-path)
+                   (identicon/identicon from)
+                   photo-path))))

--- a/src/status_im/chat/views/toolbar_content.cljs
+++ b/src/status_im/chat/views/toolbar_content.cljs
@@ -5,6 +5,7 @@
             [status-im.ui.components.react :as react]
 
             [status-im.i18n :as i18n]
+            [status-im.chat.views.photos :as photos]
             [status-im.chat.styles.screen :as st]
             [status-im.utils.datetime :as time]
             [status-im.utils.platform :refer [platform-specific]]
@@ -60,17 +61,19 @@
             (i18n/label-pluralize cnt :t/members-active)))]])))
 
 (defview toolbar-content-view []
-  (letsubs [{:keys [group-chat name chat-id
-                    contacts public? public-key]} [:get-current-chat]
+  (letsubs [{:keys [group-chat name contacts
+                    public? chat-id]}             [:get-current-chat]
             show-actions?                         [:get-current-chat-ui-prop :show-actions?]
             accounts                              [:get-accounts]
-            contact                               [:get-current-chat-contact] 
+            contact                               [:get-current-chat-contact]
             sync-state                            [:sync-state]]
-    [react/view common.styles/flex
+    [react/view {:style st/toolbar-container}
+
+     [react/view (when-not group-chat [photos/member-photo chat-id])]
      [react/view (st/chat-name-view (or (empty? accounts)
                                         show-actions?))
       (let [chat-name (if (string/blank? name)
-                        (generate-gfy public-key)
+                        (generate-gfy chat-id)
                         (or (i18n/get-contact-translated chat-id :name name)
                             (i18n/label :t/chat-name)))]
         [react/text {:style               st/chat-name-text


### PR DESCRIPTION

fixes #3927 

### Summary:

Shows timestamp inside the bubble for text messages, updates also the padding according to designs, remove avatar from 1-to-1 chat and moves it to toolbar.
status: ready