### PR TITLE
Hide sensitive data from TestFairy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7265,9 +7265,9 @@
       }
     },
     "react-native-testfairy": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/react-native-testfairy/-/react-native-testfairy-2.8.0.tgz",
-      "integrity": "sha512-wWQ8xaYq1enjZKM3C7T4jOHHkXW2mBwWoF1p64mbpk0tuFiyH2U1lr9FLNfYDaiqWkMN13iqzZjXciF0f+IS9Q=="
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/react-native-testfairy/-/react-native-testfairy-2.10.0.tgz",
+      "integrity": "sha512-l9Ywc69WTnraPuq5wZS7/GWcSuBxVKxaFzCIhsrIzWhByIh/1o/UqwRb8Eb06h8/e3IP7fd1LD5hXF2NMDRg3g=="
     },
     "react-native-udp": {
       "version": "2.2.1",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "react-native-splash-screen": "3.0.6",
     "react-native-svg": "6.3.1",
     "react-native-tcp": "3.3.0",
-    "react-native-testfairy": "2.8.0",
+    "react-native-testfairy": "2.10.0",
     "react-native-udp": "2.2.1",
     "react-native-webview-bridge": "github:status-im/react-native-webview-bridge#fix-web3-injection",
     "realm": "2.3.3",

--- a/src/status_im/ui/screens/accounts/recover/views.cljs
+++ b/src/status_im/ui/screens/accounts/recover/views.cljs
@@ -20,10 +20,7 @@
   (letsubs [error [:get-in [:accounts/recover :passphrase-error]]
             input-ref (reagent/atom nil)]
     {:component-did-mount (fn [_] (when config/testfairy-enabled?
-                                    ;; NOTE(dmitryn) Doesn't work on Android without setTimeout
-                                    (js/setTimeout
-                                      #(.hideView js-dependencies/testfairy @input-ref)
-                                      100)))}
+                                    (.hideView js-dependencies/testfairy @input-ref)))}
     [text-input/text-input-with-label
      {:style               components.styles/flex
       :height              92

--- a/src/status_im/ui/screens/profile/seed/views.cljs
+++ b/src/status_im/ui/screens/profile/seed/views.cljs
@@ -63,10 +63,7 @@
   (letsubs [mnemonic-vec (vec (map-indexed vector (clojure.string/split mnemonic #" ")))
             ref (reagent/atom nil)]
     {:component-did-mount (fn [_] (when config/testfairy-enabled?
-                                    ;; NOTE(dmitryn) Doesn't work on Android without setTimeout
-                                    (js/setTimeout
-                                      #(.hideView js-dependencies/testfairy @ref)
-                                      100)))}
+                                    (.hideView js-dependencies/testfairy @ref)))}
     [react/view {:style styles/twelve-words-container}
      [react/text {:style styles/twelve-words-label}
       (i18n/label :t/your-seed-phrase)]
@@ -84,11 +81,15 @@
         :on-press #(re-frame/dispatch [:my-profile/enter-two-random-words])}]]]))
 
 (defview input [error]
-  [text-input/text-input-with-label
-   {:placeholder    (i18n/label :t/enter-word)
-    :auto-focus     true
-    :on-change-text #(re-frame/dispatch [:set-in [:my-profile/seed :word] %])
-    :error          error}])
+  (letsubs [ref (reagent/atom nil)]
+    {:component-did-mount (fn [_] (when config/testfairy-enabled?
+                                    (.hideView js-dependencies/testfairy @ref)))}
+    [text-input/text-input-with-label
+     {:placeholder    (i18n/label :t/enter-word)
+      :ref            (partial reset! ref)
+      :auto-focus     true
+      :on-change-text #(re-frame/dispatch [:set-in [:my-profile/seed :word] %])
+      :error          error}]))
 
 (defn enter-word [step [idx word] error entered-word]
   ^{:key word}


### PR DESCRIPTION
fixes #3876 https://github.com/testfairy/react-native-testfairy/issues/18

### Summary:

* Hide secret words on backup screen
* Upgrade TF to 2.10.0 to fix `hideView()` bug

status: ready
