### PR TITLE
No redirect to sign in screen when back button clicked [#3903]

### DIFF
--- a/src/status_im/ui/screens/navigation.cljs
+++ b/src/status_im/ui/screens/navigation.cljs
@@ -23,7 +23,7 @@
   ([view-id {:keys [db]} screen-params]
    ;; TODO (jeluard) Unify all :navigate-to flavours. Maybe accept a map of parameters?
 
-   (let [db (cond-> db
+   (let [db (cond-> (assoc db :navigation-stack (list))
               (seq screen-params)
               (assoc-in [:navigation/screen-params view-id] screen-params))]
      {:db (push-view db view-id)})))
@@ -97,8 +97,8 @@
 
 (handlers/register-handler-fx
   :navigate-to-clean
-  (fn [{:keys [db]} [_ & params]]
-    {:db (apply navigate-to db params)}))
+  (fn [cofx [_ view-id params]]
+    (navigate-to-clean view-id cofx params)))
 
 (handlers/register-handler-fx
   :navigate-to-tab


### PR DESCRIPTION


fixes #3903

### Summary:

When user logs in and presses device back button she is being redirected to sign in screen. Instead, the app should go into the background.


### Steps to test:

- Open Status
-   Sign in and wait for the home screen to appear
 -  Press device back button


<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->
