### PR TITLE
[TESTS #3920] Add more tests about transactions

### DIFF
--- a/test/appium/tests/test_transaction.py
+++ b/test/appium/tests/test_transaction.py
@@ -2,7 +2,15 @@ from tests.base_test_case import SingleDeviceTestCase, MultipleDeviceTestCase
 from tests import transaction_users, api_requests, get_current_time, transaction_users_wallet, marks
 from selenium.common.exceptions import TimeoutException
 
+import time
+
+import pytest
+from selenium.common.exceptions import TimeoutException
+
+from tests import transaction_users, api_requests, get_current_time, transaction_users_wallet
+from tests.base_test_case import SingleDeviceTestCase, MultipleDeviceTestCase
 from views.sign_in_view import SignInView
+from views.web_views.base_web_view import BaseWebView
 
 
 @marks.all
@@ -102,8 +110,25 @@ class TestTransaction(SingleDeviceTestCase):
 
         api_requests.verify_balance_is_updated(initial_balance, address)
 
-    @marks.pr
-    @marks.testrail_case_id(3406)
+    @pytest.mark.transactions
+    @pytest.mark.testrail_case_id(3422)
+    def test_open_transaction_on_etherscan(self):
+        user = transaction_users['A_USER']
+        sign_in_view = SignInView(self.driver)
+        sign_in_view.recover_access(user['passphrase'], user['password'])
+        home_view = sign_in_view.get_home_view()
+        wallet_view = home_view.wallet_button.click()
+        transactions_view = wallet_view.transactions_button.click()
+        transaction_details = transactions_view.transactions_table.get_first_transaction().click()
+        transaction_hash = transaction_details.get_transaction_hash()
+        transaction_details.options_button.click()
+        transaction_details.open_transaction_on_etherscan_button.click()
+        base_web_view = BaseWebView(self.driver)
+        base_web_view.web_view_browser.click()
+        base_web_view.always_button.click()
+        base_web_view.find_text_part(transaction_hash)
+
+    @pytest.mark.pr
     def test_send_stt_from_wallet_via_enter_recipient_address(self):
         sender = transaction_users_wallet['A_USER']
         recipient = transaction_users_wallet['B_USER']

--- a/test/appium/tests/test_wallet.py
+++ b/test/appium/tests/test_wallet.py
@@ -1,4 +1,5 @@
 import pytest
+from selenium.common.exceptions import TimeoutException
 from tests import api_requests, transaction_users_wallet
 from tests.base_test_case import SingleDeviceTestCase
 from views.sign_in_view import SignInView
@@ -8,15 +9,62 @@ from views.sign_in_view import SignInView
 class TestWallet(SingleDeviceTestCase):
 
     @pytest.mark.wallet
+    @pytest.mark.testrail_case_id(3425)
     def test_wallet_error_messages(self):
+        sender = transaction_users_wallet['A_USER']
+        recipient = transaction_users_wallet['B_USER']
         sign_in_view = SignInView(self.driver)
-        sign_in_view.create_user()
-        wallet_view = sign_in_view.wallet_button.click()
+        sign_in_view.recover_access(sender['passphrase'], sender['password'])
+        home_view = sign_in_view.get_home_view()
+        wallet_view = home_view.wallet_button.click()
         send_transaction = wallet_view.send_button.click()
-        send_transaction.amount_edit_box.send_keys('asd')
-        send_transaction.find_full_text('Amount is not a valid number')
-        send_transaction.amount_edit_box.send_keys('0,1')
+
+        # Check valid amount
+        invalid_amount = 'asd'
+        error_message = 'Amount is not a valid number'
+        send_transaction.amount_edit_box.send_keys(invalid_amount)
+        try:
+            send_transaction.find_full_text(error_message)
+        except TimeoutException:
+            self.errors.append(error_message + ' error did not appear')
+        send_transaction.amount_edit_box.clear()
+
+        # Check insufficient funds
+        send_transaction.amount_edit_box.send_keys('100000')
         send_transaction.find_full_text('Insufficient funds')
+        send_transaction.amount_edit_box.clear()
+
+        # Check invalid address
+        incorrect_public_key = '5261ceba31e3a7204b498b2dd20220a6057738d'
+        send_transaction.chose_recipient_button.click()
+        send_transaction.enter_recipient_address_button.click()
+        send_transaction.enter_recipient_address_input.set_value(incorrect_public_key)
+        send_transaction.done_button.click()
+        error_message = 'Invalid address'
+        try:
+            send_transaction.error_dialog.wait_for_error_message(error_message)
+        except TimeoutException:
+            self.errors.append(error_message + ' error did not appear')
+        send_transaction.error_dialog.ok_button.click()
+
+        # Check wrong password
+        incorrect_password = 'wrongpasswd'
+        send_transaction.chose_recipient_button.click()
+        send_transaction.enter_recipient_address_button.click()
+        send_transaction.enter_recipient_address_input.set_value(recipient['address'])
+        send_transaction.done_button.click()
+        send_transaction.amount_edit_box.click()
+        send_transaction.amount_edit_box.set_value('0.00001')
+        send_transaction.sign_transaction_button.click()
+        send_transaction.enter_password_input.send_keys(incorrect_password)
+        send_transaction.sign_transaction_button.click()
+        error_message = 'Wrong password'
+        try:
+            send_transaction.find_full_text(error_message)
+        except TimeoutException:
+            self.errors.append(error_message + ' error did not appear')
+
+        self.verify_no_errors()
 
     @pytest.mark.wallet
     def test_eth_and_currency_balance(self):

--- a/test/appium/views/send_transaction_view.py
+++ b/test/appium/views/send_transaction_view.py
@@ -1,5 +1,5 @@
-from views.base_element import BaseButton, BaseEditBox
-from views.base_view import BaseView
+from views.base_element import BaseElement, BaseButton, BaseEditBox
+from views.base_view import BaseView, OkButton
 
 
 class FirstRecipient(BaseButton):
@@ -86,6 +86,16 @@ class STTButton(BaseButton):
         self.locator = self.Locator.xpath_selector("//*[@text='Status Test Token']")
 
 
+class ErrorDialog(BaseView):
+    def __init__(self, driver):
+        super(ErrorDialog, self).__init__(driver)
+        self.ok_button = OkButton(driver)
+
+    def wait_for_error_message(self, error_message, wait_time=30):
+        element = self.element_by_text_part(error_message)
+        return element.wait_for_element(wait_time)
+
+
 class SendTransactionView(BaseView):
     def __init__(self, driver):
         super(SendTransactionView, self).__init__(driver)
@@ -105,6 +115,8 @@ class SendTransactionView(BaseView):
 
         self.select_asset_button = SelectAssetButton(self.driver)
         self.stt_button = STTButton(self.driver)
+
+        self.error_dialog = ErrorDialog(self.driver)
 
     def sign_transaction(self, sender_password):
         self.sign_transaction_button.click_until_presence_of_element(self.enter_password_input)

--- a/test/appium/views/web_views/base_web_view.py
+++ b/test/appium/views/web_views/base_web_view.py
@@ -34,6 +34,17 @@ class BrowserNextPageButton(BaseButton):
         self.locator = self.Locator.accessibility_id('next-page-button')
 
 
+class WebViewBrowserButton(BaseButton):
+    def __init__(self, driver):
+        super(WebViewBrowserButton, self).__init__(driver)
+        self.locator = self.Locator.text_part_selector('WebView Browser Tester')
+
+
+class AlwaysButton(BaseButton):
+    def __init__(self, driver):
+        super(AlwaysButton, self).__init__(driver)
+        self.locator = self.Locator.text_part_selector('ALWAYS')
+
 
 class BaseWebView(BaseView):
 
@@ -47,6 +58,9 @@ class BaseWebView(BaseView):
         self.back_to_home_button = BackToHomeButton(self.driver)
         self.browser_previous_page_button = BrowserPreviousPageButton(self.driver)
         self.browser_next_page_button = BrowserNextPageButton(self.driver)
+
+        self.web_view_browser = WebViewBrowserButton(self.driver)
+        self.always_button = AlwaysButton(self.driver)
 
     def wait_for_d_aap_to_load(self, wait_time=35):
         counter = 0


### PR DESCRIPTION
Fixes #3920

### Summary:

* Adds "Can open transaction on etherscan.io"
* Extends wallet errors checks, "Check: Wallet error handling. Sign in Tx with incorrect pass. Sign in Tx with amount >= have, enter wrong address code when Send tx."

status: ready