### PR TITLE
[#3912] Typing comma separator in Gas limit or Gas price fields removes entered value and sets default one 

### DIFF
--- a/src/status_im/utils/money.cljs
+++ b/src/status_im/utils/money.cljs
@@ -30,7 +30,7 @@
 (defn bignumber [n]
   (when n
     (try
-      (dependencies/Web3.prototype.toBigNumber (str n))
+      (dependencies/Web3.prototype.toBigNumber (normalize (str n)))
       (catch :default err nil))))
 
 (defn valid? [bn]


### PR DESCRIPTION
fixes #3912 

### Summary:
Normalize gas limit and gas price input values.
<img width=300 src=https://user-images.githubusercontent.com/5045098/39231602-314a696e-489d-11e8-92a0-4bd6ec93d992.gif />

status: ready