### PR TITLE
[TESTS] Added e2e tests apk building in Jenkinsfile.nightly_fastlane

### DIFF
--- a/Jenkinsfile.nightly_fastlane
+++ b/Jenkinsfile.nightly_fastlane
@@ -105,9 +105,35 @@ node ('macos1'){
     throw e
   }
 
+  stage('Run status-nightly-publish-link job') {
+    build job: 'status-react/status-nightly-publish-link', parameters: [[$class: 'StringParameterValue', name: 'APK_URL', value: apkUrl], [$class: 'StringParameterValue', name: 'IOS_URL', value: ipaUrl]]
+  }
+
+  stage('Build (Android) for e2e tests') {
+    sh 'cd android && mv app/build/outputs/apk/release/app-release.apk app/build/outputs/apk/release/app-release.original.apk && ENVFILE=.env.e2e ./gradlew assembleRelease'
+  }
+
+  stage('Upload apk for e2e tests') {
+    withCredentials([string(credentialsId: 'SAUCE_ACCESS_KEY', variable: 'key'), string(credentialsId: 'SAUCE_USERNAME', variable: 'username')]){
+      apk_name = 'im.status.ethereum-e2e-' + shortCommit + '.apk'
+      sh('curl -u ' + username+ ':' + key + ' -X POST -H "Content-Type: application/octet-stream" https://saucelabs.com/rest/v1/storage/' + username + '/' + apk_name + '?overwrite=true --data-binary @android/app/build/outputs/apk/release/app-release.apk')
+    }
+    withCredentials([string(credentialsId: 'diawi-token', variable: 'token')]) {
+      def job = sh(returnStdout: true, script: 'curl https://upload.diawi.com/ -F token='+token+' -F file=@android/app/build/outputs/apk/release/app-release.apk -F find_by_udid=0 -F wall_of_apps=0 | jq -r ".job"').trim()
+      sh 'sleep 10'
+      def hash = sh(returnStdout: true, script: "curl -vvv 'https://upload.diawi.com/status?token="+token+"&job="+job+"'|jq -r '.hash'").trim()
+      testApkUrl = 'https://i.diawi.com/' + hash
+
+      sh ('echo ARTIFACT Android for e2e tests: ' + testApkUrl)
+    }
+  }
+
   stage('Slack Notification') {
     def c = (testPassed ? 'good' : 'warning' )
-    slackSend color: c, message: 'Nightly build (develop) \nTests: ' + (testPassed ? ':+1:' : ':-1:') + ')\nAndroid: ' + apkUrl + '\n iOS: ' + ipaUrl
-    build job: 'status-react/status-nightly-publish-link', parameters: [[$class: 'StringParameterValue', name: 'APK_URL', value: apkUrl], [$class: 'StringParameterValue', name: 'IOS_URL', value: ipaUrl]]
+    slackSend color: c, message: 'Nightly build (develop) \nTests: ' + (testPassed ? ':+1:' : ':-1:') + ')\nAndroid: ' + apkUrl + '\n iOS: ' + ipaUrl + '\n Android for e2e: ' + testApkUrl
+  }
+
+  stage('Run extended e2e tests') {
+    build job: 'status-app-nightly', parameters: [string(name: 'apk', value: '--apk=' + apk_name)], wait: false
   }
 }

--- a/test/appium/tests/conftest.py
+++ b/test/appium/tests/conftest.py
@@ -1,14 +1,11 @@
 from tests import test_suite_data, SingleTestData
 import requests
-import re
 import pytest
 from datetime import datetime
 from os import environ
 from io import BytesIO
 from sauceclient import SauceClient
 from support.github_test_report import GithubHtmlReport
-
-storage = 'http://artifacts.status.im:8081/artifactory/nightlies-local/'
 
 sauce_username = environ.get('SAUCE_USERNAME')
 sauce_access_key = environ.get('SAUCE_ACCESS_KEY')
@@ -18,22 +15,10 @@ sauce = SauceClient(sauce_username, sauce_access_key)
 github_report = GithubHtmlReport(sauce_username, sauce_access_key)
 
 
-def get_latest_apk():
-    raw_data = requests.request('GET', storage).text
-    dates = re.findall("\d{2}-[a-zA-Z]{3}-\d{4} \d{2}:\d{2}", raw_data)
-    dates.sort(key=lambda date: datetime.strptime(date, "%d-%b-%Y %H:%M"), reverse=True)
-    return re.findall('>(.*k)</a>\s*%s' % dates[0], raw_data)[0]
-
-
-latest_nightly_apk = dict()
-latest_nightly_apk['name'] = get_latest_apk()
-latest_nightly_apk['url'] = storage + latest_nightly_apk['name']
-
-
 def pytest_addoption(parser):
     parser.addoption("--build",
                      action="store",
-                     default=datetime.now().strftime('%Y-%m-%d-%H-%M'),  # 'build_' + latest_nightly_apk['name'],
+                     default=datetime.now().strftime('%Y-%m-%d-%H-%M'),
                      help="Specify build name")
     parser.addoption('--apk',
                      action='store',


### PR DESCRIPTION
### Summary:

Added stages in `Jenkinsfile.nightly_fastlane`:

- building e2e tests apk
- uploading e2e tests apk to SauceLabs and Diawi
- triggering `end-to-end-tests/status-app-nightly` job for each nightly build
- added e2e tests apk URL to Slack notifications


status: ready
