### PR TITLE
[#3983] Confirmation popup when signing tx later from chat

### DIFF
--- a/src/status_im/ui/screens/wallet/send/events.cljs
+++ b/src/status_im/ui/screens/wallet/send/events.cljs
@@ -40,8 +40,12 @@
 
 (re-frame/reg-fx
   ::show-transaction-moved
-  (fn []
-    (utils/show-popup (i18n/label :t/transaction-moved-title) (i18n/label :t/transaction-moved-text))))
+  (fn [modal?]
+    (utils/show-popup
+      (i18n/label :t/transaction-moved-title)
+      (i18n/label :t/transaction-moved-text)
+      (when modal?
+        #(re-frame/dispatch [:navigate-back])))))
 
 (re-frame/reg-fx
   ::show-transaction-error
@@ -93,6 +97,11 @@
     (doseq [result results]
       (dispatch-transaction-completed result))))
 
+(handlers/register-handler-fx
+  :sign-later-from-chat
+  (fn [_ _]
+    {::show-transaction-moved  true}))
+
 ;;TRANSACTION QUEUED signal from status-go
 (handlers/register-handler-fx
   :sign-request-queued
@@ -140,7 +149,7 @@
               ;;SIGN LATER
               {:db                      (assoc-in new-db' [:wallet :send-transaction :waiting-signal?] false)
                :dispatch                [:navigate-back]
-               ::show-transaction-moved nil}
+               ::show-transaction-moved false}
               ;;SIGN NOW
               {:db                  new-db'
                ::accept-transaction {:id           id

--- a/src/status_im/ui/screens/wallet/send/views.cljs
+++ b/src/status_im/ui/screens/wallet/send/views.cljs
@@ -29,7 +29,7 @@
     (i18n/label :t/sign-later-title)
     (i18n/label :t/sign-later-text)
     #(re-frame/dispatch (if from-chat?
-                          [:navigate-back]
+                          [:sign-later-from-chat]
                           [:wallet/sign-transaction true]))))
 
 (defview sign-panel [message?]

--- a/src/status_im/utils/utils.cljs
+++ b/src/status_im/utils/utils.cljs
@@ -2,10 +2,20 @@
   (:require [status-im.i18n :as i18n]
             [status-im.react-native.js-dependencies :as rn-dependencies]))
 
-(defn show-popup [title content]
-  (.alert (.-Alert rn-dependencies/react-native)
-          title
-          content))
+(defn show-popup
+  ([title content]
+    (show-popup title content nil))
+  ([title content on-dismiss]
+    (.alert (.-Alert rn-dependencies/react-native)
+            title
+            content
+            (clj->js
+             (vector (merge {:text                "OK"
+                             :style               "cancel"
+                             :accessibility-label :cancel-button}
+                            (when on-dismiss {:onPress on-dismiss}))))
+            (when on-dismiss
+              (clj->js {:cancelable false})))))
 
 (defn show-confirmation
   ([title content on-accept]


### PR DESCRIPTION
Fixes #3983 

### Summary:
- Event handler correctly displays second popup when signing transactions later from chat

### Steps to test:
- Open Status
- Create 1x1 or group chat
- Use /send macro to send ETH, sign later, confirm
- Should navigate back and show "will stay in transaction history for 5 mins" popup

status: ready