### PR TITLE
Fix Appium uuid matching for Android emulators

### DIFF
--- a/test/appium/tests/base_test_case.py
+++ b/test/appium/tests/base_test_case.py
@@ -41,10 +41,10 @@ class AbstractTestCase:
         updated_capabilities = list()
         raw_out = re.split(r'[\r\\n]+', str(subprocess.check_output(['adb', 'devices'])).rstrip())
         for line in raw_out[1:]:
-            serial = re.findall(r"([\d.\d:]*\d+)", line)
+            serial = re.findall(r"(([\d.\d:]*\d+)|\bemulator-\d+)", line)
             if serial:
                 capabilities = self.capabilities_local
-                capabilities['udid'] = serial[0]
+                capabilities['udid'] = serial[0][0]
                 updated_capabilities.append(capabilities)
         return updated_capabilities
 


### PR DESCRIPTION
Fixes Appium uuid matching for Android emulators. 

Previously, "emulator-9394" was matched as "9394". Now, the full id is matched: "emulator-9394".

Tested locally on:
- 2 emulators
- 1 real device