### PR TITLE
Stop waiting for Instabug popup in appium e2e tests

### DIFF
--- a/test/appium/views/sign_in_view.py
+++ b/test/appium/views/sign_in_view.py
@@ -98,7 +98,6 @@ class SignInView(BaseView):
         self.do_not_share = DonNotShare(self.driver)
 
     def create_user(self):
-        time.sleep(30) # wait for "Shake to provide your feedback" popup to disappear, it's not possible to interact with the element
         self.create_account_button.click()
         self.password_input.set_value('qwerty1234')
         self.next_button.click()
@@ -111,7 +110,6 @@ class SignInView(BaseView):
         self.do_not_share.click_until_presence_of_element(self.home_button)
 
     def recover_access(self, passphrase, password):
-        time.sleep(30) # wait for "Shake to provide your feedback" popup to disappear, it's not possible to interact with the element
         recover_access_view = self.i_have_account_button.click()
         recover_access_view.passphrase_input.set_value(passphrase)
         recover_access_view.password_input.click()


### PR DESCRIPTION
#3789 is fixed so there is no need to wait for it in appium e2e tests.