### PR TITLE
Add eth-keys to appium requirements

### DIFF
--- a/test/appium/requirements.txt
+++ b/test/appium/requirements.txt
@@ -24,4 +24,5 @@ urllib3==1.22
 yarl==0.12.0
 zbarlight==1.2
 eth-utils==0.7.4
+eth-keys==0.1.0b4
 ethereum==2.3.0


### PR DESCRIPTION
I had to setup appium tests from scratch and it turned out that `eth-keys` was missed. This PR adds it to the dependency list.