### PR TITLE
Sort Assets in alphabetical order on Wallet -> Manage Assets screen [#3926]

### DIFF
--- a/src/status_im/ui/screens/wallet/settings/views.cljs
+++ b/src/status_im/ui/screens/wallet/settings/views.cljs
@@ -33,6 +33,6 @@
       [toolbar/content-title {:color :white}
        (i18n/label :t/wallet-assets)]]
      [react/view {:style components.styles/flex}
-      [list/flat-list {:data      (tokens/tokens-for (ethereum/network->chain-keyword network))
+      [list/flat-list {:data      (tokens/sorted-tokens-for (ethereum/network->chain-keyword network))
                        :key-fn    (comp str :symbol)
                        :render-fn #(render-token % visible-tokens)}]]]))

--- a/src/status_im/utils/ethereum/tokens.cljs
+++ b/src/status_im/utils/ethereum/tokens.cljs
@@ -1,5 +1,6 @@
 (ns status-im.utils.ethereum.tokens
-  (:require-macros [status-im.utils.ethereum.macros :refer [resolve-icons]]))
+  (:require-macros [status-im.utils.ethereum.macros :refer [resolve-icons]])
+  (:require [clojure.string :as string]))
 
 (defn- asset-border [color]
   {:border-color color :border-width 1 :border-radius 32})
@@ -406,6 +407,11 @@
 
 (defn tokens-for [chain]
   (get all chain))
+
+(defn sorted-tokens-for [chain]
+  (->> (tokens-for chain)
+       (sort #(compare (string/lower-case (:name %1))
+                       (string/lower-case (:name %2))))))
 
 (defn symbol->token [chain symbol]
   (some #(when (= symbol (:symbol %)) %) (tokens-for chain)))


### PR DESCRIPTION
### Summary:

fixes #3926 Sort assets in alphabetical order


status: ready <!-- Can be ready or wip -->
