### PR TITLE
Fixes #3847: Half of the line is cut in the input field if focus is on the next line [Android]

### DIFF
--- a/src/status_im/chat/views/input/input.cljs
+++ b/src/status_im/chat/views/input/input.cljs
@@ -14,7 +14,15 @@
             [status-im.ui.components.colors :as colors]
             [status-im.ui.components.react :as react]
             [status-im.ui.components.icons.vector-icons :as vi]
+            [status-im.utils.platform :as platform]
             [status-im.utils.utils :as utils]))
+
+;; TODO(pacamara) Symptomatic fix, root cause is react-native onLayout returning
+;; inconsistent height values, more investigation needed
+(defn android-blank-line-extra-height [input-text] 
+  (if (and platform/android? input-text (string/ends-with? input-text "\n"))
+    (/ style/min-input-height 2)
+    0))
 
 (defview basic-text-input [{:keys [set-layout-height-fn set-container-width-fn height single-line-input?]}]
   (letsubs [{:keys [input-text]} [:get-current-chat] 
@@ -77,7 +85,8 @@
     [react/text {:style     (style/invisible-input-text-height container-width)
                  :on-layout #(let [h (-> (.-nativeEvent %)
                                          (.-layout)
-                                         (.-height))]
+                                         (.-height)
+                                         (+ (android-blank-line-extra-height input-text)))]
                                (set-layout-height-fn h))}
      (or input-text "")]))
 


### PR DESCRIPTION
Fixes #3847: Half of the line is cut in the input field if focus is on the next line [Android]

### Summary:

Increase input height by 18 iff platform is Android and last line of input is blank.

### Steps to test:
- Open Status
- Join a chat
- Type multiple lines of text and verify behaviour reported in PR no longer observed on Android.
- Especially check IOS has no regression since I cannot test on that platform.

status: ready 
