### PR TITLE
Restore migrations

### DIFF
--- a/src/status_im/data_store/realm/core.cljs
+++ b/src/status_im/data_store/realm/core.cljs
@@ -30,29 +30,17 @@
   (when realm
     (.close realm)))
 
-(defn- migrate-realm [file-name schemas]
+(defn- migrate [file-name schemas]
   (let [current-version (realm-version file-name)]
     (doseq [schema schemas
             :when (> (:schemaVersion schema) current-version)
             :let [migrated-realm (open-realm schema file-name)]]
-      (close migrated-realm)))
-  (open-realm (last schemas) file-name))
-
-(defn- reset-realm [file-name schemas]
-  (utils/show-popup "Please note" "You must recover or create a new account with this upgrade. Also chatting with accounts in previous releases is incompatible")
-  (delete-realm file-name)
-  (open-realm (last schemas) file-name))
+      (close migrated-realm))))
 
 (defn- open-migrated-realm
   [file-name schemas]
-  ;; TODO: remove for release 0.9.18
-  ;; delete the realm file if its schema version is higher
-  ;; than existing schema version (this means the previous
-  ;; install has incompatible database schemas)
-  (if (> (realm-version file-name)
-         (apply max (map :schemaVersion base/schemas)))
-    (reset-realm file-name schemas)
-    (migrate-realm file-name schemas)))
+  (migrate file-name schemas)
+  (open-realm (last schemas) file-name))
 
 (defn- index-entity-schemas [all-schemas]
   (into {} (map (juxt :name identity)) (-> all-schemas last :schema)))


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

In release `0.9.17`, we turned off migrations and introduced warning that all old data will be lost upon app-install. As we are past breaking changes in `0.9.17` -> `0.9.18`, we need to re-introduce previous behaviour, which this PR does.

### Testing notes (optional):
Test that installing this PR build on top of `0.9.17` works flawlessly with no data lost.

status: ready
