### PR TITLE
Update non-dapp browsing test

### DIFF
--- a/test/appium/tests/test_dapps_and_browsing.py
+++ b/test/appium/tests/test_dapps_and_browsing.py
@@ -7,18 +7,34 @@ from views.sign_in_view import SignInView
 class TestDAppsAndBrowsing(SingleDeviceTestCase):
 
     @pytest.mark.pr
+    @pytest.mark.testrail_case_id(3389)
     def test_browse_link_entering_url_in_dapp_view(self):
+        """
+        Navigate to non-Dapp site with non-english content
+        Check back and forward browsing buttons works as expected
+        """
+
         sign_in = SignInView(self.driver)
         sign_in.create_user()
         home_view = sign_in.get_home_view()
         start_new_chat = home_view.plus_button.click()
         start_new_chat.open_d_app_button.click()
-        start_new_chat.enter_url_editbox.set_value('status.im')
+        start_new_chat.enter_url_editbox.set_value('www.wikipedia.org')
         start_new_chat.confirm()
         browsing_view = home_view.get_base_web_view()
         browsing_view.wait_for_d_aap_to_load()
-        browsing_view.find_full_text('Status, the Ethereum discovery tool.')
+
+        wikipedia_home_text_list = ['Español','日本語', 'Français', 'English']
+        for wikitext in wikipedia_home_text_list:
+            browsing_view.find_text_part(wikitext, 15)
+        browsing_view.element_by_text_part('Русский', 'button').click()
+        browsing_view.find_text_part('Избранная статья')
+        browsing_view.browser_previous_page_button.click()
+        browsing_view.find_text_part(wikipedia_home_text_list[0], 15)
+
+        browsing_view.browser_next_page_button.click()
+        browsing_view.find_text_part('Избранная статья')
         browsing_view.back_to_home_button.click()
 
-        assert home_view.chat_name_text.text in 'Status | The Mobile Ethereum Client'
-        assert home_view.chat_url_text.text in 'https://status.im/'
+        assert home_view.chat_name_text.text.startswith('Википедия')
+        assert home_view.chat_url_text.text.startswith('https://ru.m.wikipedia.org')

--- a/test/appium/views/web_views/base_web_view.py
+++ b/test/appium/views/web_views/base_web_view.py
@@ -22,6 +22,19 @@ class BackToHomeButton(BaseButton):
         self.locator = self.Locator.xpath_selector('(//android.view.ViewGroup[@content-desc="icon"])[1]')
 
 
+class BrowserPreviousPageButton(BaseButton):
+    def __init__(self, driver):
+        super(BrowserPreviousPageButton, self).__init__(driver)
+        self.locator = self.Locator.accessibility_id('previou-page-button')
+
+
+class BrowserNextPageButton(BaseButton):
+    def __init__(self, driver):
+        super(BrowserNextPageButton, self).__init__(driver)
+        self.locator = self.Locator.accessibility_id('next-page-button')
+
+
+
 class BaseWebView(BaseView):
 
     def __init__(self, driver):
@@ -32,6 +45,8 @@ class BaseWebView(BaseView):
 
         self.web_link_edit_box = WebLinkEditBox(self.driver)
         self.back_to_home_button = BackToHomeButton(self.driver)
+        self.browser_previous_page_button = BrowserPreviousPageButton(self.driver)
+        self.browser_next_page_button = BrowserNextPageButton(self.driver)
 
     def wait_for_d_aap_to_load(self, wait_time=35):
         counter = 0


### PR DESCRIPTION
### Summary:

Implements #3922 by updating the existing test for browsing non-dapp:
- changed a website link to check the non-english content in web view
- add a check for back and forward browser button usage