### PR TITLE
Display correct status for console messages

### DIFF
--- a/src/status_im/chat/views/message/message.cljs
+++ b/src/status_im/chat/views/message/message.cljs
@@ -288,7 +288,7 @@
 
                               :else
                               (or delivery-status outgoing-status))]
-    (case outgoing-status
+    (case status
       :sending  [message-activity-indicator]
       :not-sent [message-not-sent-text chat-id message-id]
       (when last-outgoing?


### PR DESCRIPTION
fixes #4037 

### Summary:

Display correct status for console messages

(bug introduced by https://github.com/status-im/status-react/pull/3964)

### Steps to test:
- Open Status
- Open Console
- Send some messages to Console

status: ready