### PR TITLE
Rerun appium tests failed due to infrastructure reasons

### DIFF
--- a/test/appium/requirements.txt
+++ b/test/appium/requirements.txt
@@ -15,7 +15,7 @@ namedlist==1.7
 py==1.4.34
 pytest==3.2.1
 pytest-forked==0.2
-pytest-xdist==1.20.0
+pytest-xdist==1.22.2
 requests==2.18.3
 sauceclient==1.0.0
 selenium==3.8.1

--- a/test/appium/support/github_report.py
+++ b/test/appium/support/github_report.py
@@ -56,9 +56,10 @@ class GithubHtmlReport(BaseTestReport):
         html = "<tr><td><b>%d. %s</b></td></tr>" % (index+1, test.name)
         html += "<tr><td>"
         test_steps_html = list()
-        for step in test.steps:
+        last_testrun = test.testruns[-1]
+        for step in last_testrun.steps:
             test_steps_html.append("<div>%s</div>" % step)
-        if test.error:
+        if last_testrun.error:
             if test_steps_html:
                 html += "<p>"
                 html += "<blockquote>"
@@ -66,10 +67,10 @@ class GithubHtmlReport(BaseTestReport):
                 html += "%s" % ''.join(test_steps_html[-2:])
                 html += "</blockquote>"
                 html += "</p>"
-            html += "<code>%s</code>" % test.error
+            html += "<code>%s</code>" % last_testrun.error
             html += "<br/><br/>"
-        if test.jobs:
-            html += self.build_device_sessions_html(test.jobs)
+        if last_testrun.jobs:
+            html += self.build_device_sessions_html(last_testrun.jobs)
         html += "</td></tr>"
         return html
 
@@ -80,3 +81,4 @@ class GithubHtmlReport(BaseTestReport):
             html += "<li><a href=\"%s\">Device %d</a></li>" % (self.get_sauce_job_url(job_id), i+1)
         html += "</ul></p>"
         return html
+

--- a/test/appium/support/test_data.py
+++ b/test/appium/support/test_data.py
@@ -1,0 +1,30 @@
+class SingleTestData(object):
+    def __init__(self, name, testruns, testrail_case_id):
+        self.testrail_case_id = testrail_case_id
+        self.name = name
+        self.testruns = testruns
+
+    class TestRunData(object):
+        def __init__(self, steps, jobs, error):
+            self.steps = steps
+            self.jobs = jobs
+            self.error = error
+
+    def create_new_testrun(self):
+        self.testruns.append(SingleTestData.TestRunData(list(), list(), None))
+
+
+class TestSuiteData(object):
+    def __init__(self):
+        self.apk_name = None
+        self.current_test = None
+        self.tests = list()
+
+    def set_current_test(self, test_name, testrail_case_id):
+        existing_test = next((test for test in self.tests if test.name == test_name), None)
+        if existing_test:
+            self.current_test = existing_test
+        else:
+            test = SingleTestData(test_name, list(), testrail_case_id)
+            self.tests.append(test)
+            self.current_test = test

--- a/test/appium/support/test_rerun.py
+++ b/test/appium/support/test_rerun.py
@@ -1,0 +1,13 @@
+RERUN_ERRORS = [
+    'Original error: Error: ESOCKETTIMEDOUT',
+    "The server didn't respond in time.",
+    'An unknown server-side error occurred while processing the command.',
+    'Could not proxy command to remote server. Original error: Error: socket hang up'
+]
+
+
+def should_rerun_test(test_error):
+    for rerun_error in RERUN_ERRORS:
+        if rerun_error in test_error:
+            return True
+    return False

--- a/test/appium/support/testrail_report.py
+++ b/test/appium/support/testrail_report.py
@@ -62,11 +62,12 @@ class TestrailReport(BaseTestReport):
             test_steps = "# Steps: \n"
             devices = str()
             method = 'add_result_for_case/%s/%s' % (self.run_id, test.testrail_case_id)
-            for step in test.steps:
+            last_testrun = test.testruns[-1]
+            for step in last_testrun.steps:
                 test_steps += step + "\n"
-            for i, device in enumerate(test.jobs):
+            for i, device in enumerate(last_testrun.jobs):
                 devices += "# [Device %d](%s) \n" % (i + 1, self.get_sauce_job_url(device))
-            data = {'status_id': self.outcomes['undefined_fail'] if test.error else self.outcomes['passed'],
-                    'comment': '%s' % ('# Error: \n %s \n' % test.error) + devices + test_steps if test.error
+            data = {'status_id': self.outcomes['undefined_fail'] if last_testrun.error else self.outcomes['passed'],
+                    'comment': '%s' % ('# Error: \n %s \n' % last_testrun.error) + devices + test_steps if last_testrun.error
                     else devices + test_steps}
             self.post(method, data=data)

--- a/test/appium/tests/__init__.py
+++ b/test/appium/tests/__init__.py
@@ -2,6 +2,8 @@ import asyncio
 import logging
 from datetime import datetime
 
+from support.test_data import TestSuiteData
+
 
 @asyncio.coroutine
 def start_threads(quantity: int, func: type, returns: dict, *args):
@@ -20,27 +22,11 @@ def get_current_time():
 def info(text: str):
     if "Base" not in text:
         logging.info(text)
-        test_suite_data.current_test.steps.append(text)
+        test_suite_data.current_test.testruns[-1].steps.append(text)
 
 
-class SingleTestData(object):
-    def __init__(self, name, steps=list(), jobs=list(), error=None, testrail_case_id=None):
-        self.testrail_case_id = testrail_case_id
-        self.name = name
-        self.steps = steps
-        self.jobs = jobs
-        self.error = error
-
-
-class TestSuiteData(object):
-    def __init__(self):
-        self.apk_name = None
-        self.current_test = None
-        self.tests = list()
-
-    def add_test(self, test):
-        self.tests.append(test)
-        self.current_test = test
+def debug(text: str):
+        logging.debug(text)
 
 
 test_suite_data = TestSuiteData()

--- a/test/appium/tests/base_test_case.py
+++ b/test/appium/tests/base_test_case.py
@@ -121,7 +121,7 @@ class SingleDeviceTestCase(AbstractTestCase):
                                                capabilities[self.environment]['capabilities'])
                 self.driver.implicitly_wait(self.implicitly_wait)
                 BaseView(self.driver).accept_agreements()
-                test_suite_data.current_test.jobs.append(self.driver.session_id)
+                test_suite_data.current_test.testruns[-1].jobs.append(self.driver.session_id)
                 break
             except WebDriverException:
                 counter += 1
@@ -146,7 +146,7 @@ class LocalMultipleDeviceTestCase(AbstractTestCase):
             self.drivers[driver] = webdriver.Remote(self.executor_local, capabilities[driver])
             self.drivers[driver].implicitly_wait(self.implicitly_wait)
             BaseView(self.drivers[driver]).accept_agreements()
-            test_suite_data.current_test.jobs.append(self.drivers[driver].session_id)
+            test_suite_data.current_test.testruns[-1].jobs.append(self.drivers[driver].session_id)
 
     def teardown_method(self, method):
         for driver in self.drivers:
@@ -174,7 +174,7 @@ class SauceMultipleDeviceTestCase(AbstractTestCase):
         for driver in range(quantity):
             self.drivers[driver].implicitly_wait(self.implicitly_wait)
             BaseView(self.drivers[driver]).accept_agreements()
-            test_suite_data.current_test.jobs.append(self.drivers[driver].session_id)
+            test_suite_data.current_test.testruns[-1].jobs.append(self.drivers[driver].session_id)
 
     def teardown_method(self, method):
         for driver in self.drivers:


### PR DESCRIPTION
### Summary:

Automatically rerun failed appium tests: 

- rerun `--rerun_count` times. By default 0
- rerun only because of errors defined in `RERUN_ERRORS`
- each test can have multiple runs
- use latest testrun in the test report 

I tested it on sauce labs. 

- [x] run PR tests when http://artifacts.status.im:8081/artifactory/ is working again

status: ready
