### PR TITLE
fix / #3915

### DIFF
--- a/src/status_im/translations/en.cljs
+++ b/src/status_im/translations/en.cljs
@@ -41,7 +41,7 @@
    :creating-your-account                "Creating your account on the blockchain. We can't touch it, no one can, except for you!"
    :password-placeholder                 "Type your password"
    :password-placeholder2                "Confirm your password"
-   :name-placeholder                     "Enter your full name…"
+   :name-placeholder                     "Display name"
    :password_error1                      "Password confirmation doesn't match password."
    :password-description                 "You'll need this password to open the app, confirm transactions and whenever you need to regain access on a new device or install."
    :name-description                     "This will be the name everybody who uses Status will see. You can change it later."


### PR DESCRIPTION
Changed "enter your full name" to "Display name"

fixes #3915

Description
Type: Bug

Summary: we are using enter your full name placeholder when creating account now and it sounds a bit weird to me personally like why do i need my full name there? Some design input it required there @denis-sharypin @andmironov @hesterbruikman

Expected behavior
Copy is updated, for ex Choose your name or Display name. Should be confirmed with design team

Actual behavior
enter your full name placeholder when creating account

Reproduction
Open Status
Create account
Additional Information
Status version: develop
Operating System: Android|iOS

Bounty

Current balance: 0.000000 ETH
Tokens: SNT: 375.00
Contract address: 0x35951c9459c0f541c3138e8edc519ed10e9b13b1