### PR TITLE
[#3761] App DB contains clear text password under :accounts/create

### DIFF
--- a/src/status_im/ui/screens/accounts/events.cljs
+++ b/src/status_im/ui/screens/accounts/events.cljs
@@ -126,14 +126,14 @@
   :account-set-name
   (fn [{{:accounts/keys [create] :as db} :db :as cofx} _]
     (handlers-macro/merge-fx cofx
-                       {:db       (assoc-in db [:accounts/create :show-welcome?] true)
+                       {:db       db
                         :dispatch [:navigate-to-clean :usage-data [:account-finalized]]}
                        (accounts.utils/account-update {:name (:name create)}))))
 
 (handlers/register-handler-fx
   :account-finalized
   (fn [{db :db} _]
-    {:db db
+    {:db (assoc db :accounts/create {:show-welcome? true})
      :dispatch-n [[:navigate-to-clean :home]
                   [:request-notifications]]}))
 


### PR DESCRIPTION
fixes #3761

### Summary:
Clean `accounts/create` after account creation.

### Steps to test:
- Open re-frisk
- Create new account
- On the last screen when click 'Share' or 'No, I don't want to share' `accounts/create` should be cleaned from app-db.

status: ready