### PR TITLE
[#3932] Use :npm-deps false to speed up Figwheel startup

### DIFF
--- a/build.clj
+++ b/build.clj
@@ -12,6 +12,7 @@
      :compiler         {:output-to     "target/ios/app.js"
                         :main          "env.ios.main"
                         :output-dir    "target/ios"
+                        :npm-deps false
                         :optimizations :none}
      :warning-handlers '[status-im.utils.build/warning-handler]}
     :android
@@ -19,6 +20,7 @@
      :compiler         {:output-to     "target/android/app.js"
                         :main          "env.android.main"
                         :output-dir    "target/android"
+                        :npm-deps false
                         :optimizations :none}
      :warning-handlers '[status-im.utils.build/warning-handler]}}
 

--- a/deps.edn
+++ b/deps.edn
@@ -15,7 +15,7 @@
          {;; Figwheel ClojureScript REPL
           com.cemerick/piggieback {:mvn/version "0.2.2"
                                    :exclusions  [com.google.javascript/closure-compiler]}
-          figwheel-sidecar        {:mvn/version "0.5.14"
+          figwheel-sidecar        {:mvn/version "0.5.16-SNAPSHOT"
                                    :exclusions  [com.google.javascript/closure-compiler]}
           re-frisk-remote         {:mvn/version "0.5.3"}
           re-frisk-sidecar        {:mvn/version "0.5.4"}

--- a/env/dev/figwheel.clj
+++ b/env/dev/figwheel.clj
@@ -8,6 +8,7 @@
                  :compiler     {:output-to     "target/ios/desktop.js"
                                 :main          "env.desktop.main"
                                 :output-dir    "target/desktop"
+                                :npm-deps false
                                 :optimizations :none}
                  :figwheel     true}
                 {:id           :ios
@@ -15,6 +16,7 @@
                  :compiler     {:output-to     "target/ios/app.js"
                                 :main          "env.ios.main"
                                 :output-dir    "target/ios"
+                                :npm-deps false
                                 :optimizations :none}
                  :figwheel     true}
                 {:id               :android
@@ -22,6 +24,7 @@
                  :compiler         {:output-to     "target/android/app.js"
                                     :main          "env.android.main"
                                     :output-dir    "target/android"
+                                    :npm-deps false
                                     :optimizations :none}
                  :warning-handlers '[status-im.utils.build/warning-handler]
                  :figwheel         true}]

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :license {:name "Eclipse Public License"
             :url  "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.9.0"]
-                 [org.clojure/clojurescript "1.9.946"]
+                 [org.clojure/clojurescript "1.10.238"]
                  [org.clojure/core.async "0.4.474"]
                  [reagent "0.7.0" :exclusions [cljsjs/react cljsjs/react-dom cljsjs/react-dom-server cljsjs/create-react-class]]
                  [status-im/re-frame "0.10.5"]
@@ -52,7 +52,7 @@
                         :repl-options {:nrepl-middleware [cemerick.piggieback/wrap-cljs-repl]
                                        :timeout          240000}}
              :figwheel [:dev
-                        {:dependencies [[figwheel-sidecar "0.5.14"]
+                        {:dependencies [[figwheel-sidecar "0.5.16-SNAPSHOT"]
                                         [re-frisk-remote "0.5.5"]
                                         [re-frisk-sidecar "0.5.7"]
                                         [day8.re-frame/tracing "0.5.0"]


### PR DESCRIPTION
fixes #3932

### Summary:
Speed up clojurescript compilation 2 times.

```
Successfully compiled build :android to “target/android/app.js" in 144.678 seconds.
Successfully compiled build :android to "target/android/app.js" in 64.963 seconds.

Successfully compiled build :ios to "target/ios/app.js" in 133.19 seconds.
Successfully compiled build :ios to "target/ios/app.js" in 73.528 seconds.
```

status: ready