### PR TITLE
[#3459] Done button in Recipient screen clickable area whole row

### DIFF
--- a/src/status_im/ui/screens/wallet/components/views.cljs
+++ b/src/status_im/ui/screens/wallet/components/views.cljs
@@ -147,8 +147,9 @@
                                  :on-change-text      #(reset! content %)
                                  :accessibility-label :recipient-address-input}]]
         [bottom-buttons/bottom-button
-         [button/button {:disabled? (string/blank? @content)
-                         :on-press  #(re-frame/dispatch [:wallet/fill-request-from-url @content])}
+         [button/button {:disabled?    (string/blank? @content)
+                         :on-press     #(re-frame/dispatch [:wallet/fill-request-from-url @content])
+                         :fit-to-text? false}
           (i18n/label :t/done)]]]])))
 
 (defn recipient-qr-code []


### PR DESCRIPTION

fixes #3459 The whole row of "Done" button in "Recipient" is clickable


status: ready <!-- Can be ready or wip -->
