### PR TITLE
fix deps.edn and project.clj version diff

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,10 +1,10 @@
-{:paths ["components/src" "src" "resources"]
+{:paths ["components/src" "src" "react-native/src" "resources"]
  :deps  {org.clojure/clojure         {:mvn/version "1.9.0"}
          org.clojure/clojurescript   {:mvn/version "1.10.238"}
          org.clojure/core.async      {:mvn/version "0.4.474"}
          reagent                     {:mvn/version "0.7.0"
                                       :exclusions  [cljsjs/react cljsjs/react-dom cljsjs/react-dom-server cljsjs/create-react-class]}
-         status-im/re-frame          {:mvn/version "0.10.2"}
+         status-im/re-frame          {:mvn/version "0.10.5"}
          com.andrewmcveigh/cljs-time {:mvn/version "0.5.2"}
          com.taoensso/timbre         {:mvn/version "4.10.0"}
          hickory                     {:mvn/version "0.7.1"}
@@ -17,9 +17,10 @@
                                    :exclusions  [com.google.javascript/closure-compiler]}
           figwheel-sidecar        {:mvn/version "0.5.16-SNAPSHOT"
                                    :exclusions  [com.google.javascript/closure-compiler]}
-          re-frisk-remote         {:mvn/version "0.5.3"}
-          re-frisk-sidecar        {:mvn/version "0.5.4"}
+          re-frisk-remote         {:mvn/version "0.5.5"}
+          re-frisk-sidecar        {:mvn/version "0.5.7"}
           hawk                    {:mvn/version "0.2.11"}
+          day8.re-frame/tracing   {:mvn/version "0.5.0"}
 
           ;; CIDER compatible nREPL
           cider/cider-nrepl       {:mvn/version "0.16.0"}

--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
                  [com.andrewmcveigh/cljs-time "0.5.2"]
                  [com.taoensso/timbre "4.10.0"]
                  [hickory "0.7.1"]
-                 [com.cognitect/transit-cljs "0.8.243"]]
+                 [com.cognitect/transit-cljs "0.8.248"]]
   :plugins [[lein-cljsbuild "1.1.7"]
             [lein-re-frisk "0.5.8"]]
   :clean-targets ["target/" "index.ios.js" "index.android.js"]
@@ -59,7 +59,7 @@
                                         [hawk "0.2.11"]]
                          :source-paths ["src" "env/dev" "react-native/src" "components/src"]}]
              :test     {:dependencies [[day8.re-frame/test "0.1.5"]]
-                        :plugins      [[lein-doo "0.1.7"]]
+                        :plugins      [[lein-doo "0.1.9"]]
                         :cljsbuild    {:builds
                                        [{:id           "test"
                                          :source-paths ["components/src" "src" "test/cljs"]


### PR DESCRIPTION
just making sure libs versions are in sync between project.clj and deps.edn
I will create an issue for someone to fix the build.clj script before we decide to ditch project.clj

status: ready