### PR TITLE
[#4026] Gas Price value is not fully shown (only first 4 digits) on iOS

### DIFF
--- a/src/status_im/ui/screens/wallet/components/styles.cljs
+++ b/src/status_im/ui/screens/wallet/components/styles.cljs
@@ -18,6 +18,7 @@
 (def text-input
   (merge text-content
     {:font-size      15
+     :flex           1
      :padding-bottom 0
      :padding-top    0
      :height         52

--- a/src/status_im/ui/screens/wallet/send/styles.cljs
+++ b/src/status_im/ui/screens/wallet/send/styles.cljs
@@ -74,9 +74,10 @@
   {:margin-top    24
    :margin-bottom 16})
 
-(def advanced-options-wrapper
-  {:align-items    :center
-   :flex-direction :row})
+(def gas-input-wrapper
+  {:align-items     :center
+   :justify-content :space-between
+   :flex-direction  :row})
 
 (def advanced-options-text-wrapper
   {:flex            1

--- a/src/status_im/ui/screens/wallet/send/views.cljs
+++ b/src/status_im/ui/screens/wallet/send/views.cljs
@@ -126,13 +126,14 @@
         [react/view {:flex-direction :row}
          [wallet.components/cartouche {}
           (i18n/label :t/gas-limit)
-          [react/text-input (merge styles/transaction-fee-input
-                                   {:on-change-text      #(re-frame/dispatch [:wallet.send/edit-gas %])
-                                    :default-value       (str (money/to-fixed gas))
-                                    :accessibility-label :gas-limit-input})]]
+          [react/view styles/gas-input-wrapper
+           [react/text-input (merge styles/transaction-fee-input
+                                    {:on-change-text      #(re-frame/dispatch [:wallet.send/edit-gas %])
+                                     :default-value       (str (money/to-fixed gas))
+                                     :accessibility-label :gas-limit-input})]]]
          [wallet.components/cartouche {}
           (i18n/label :t/gas-price)
-          [react/view styles/advanced-options-wrapper
+          [react/view styles/gas-input-wrapper
            [react/text-input (merge styles/transaction-fee-input
                                     {:on-change-text      #(re-frame/dispatch [:wallet.send/edit-gas-price (money/->wei :gwei %)])
                                      :default-value       (str (money/to-fixed (money/wei-> :gwei gas-price)))


### PR DESCRIPTION
fixes #4026

### Summary:
Fix gwei input styles.
![simulator screen shot - iphone 6 - 2018-05-02 at 15 45 54](https://user-images.githubusercontent.com/5045098/39511751-1d3b82e4-4e21-11e8-8c02-945a9f8f13c0.png)

status: ready