### PR TITLE
bug #3877 - no longer possible to sign messages with empty password

### DIFF
--- a/src/status_im/ui/screens/wallet/send/events.cljs
+++ b/src/status_im/ui/screens/wallet/send/events.cljs
@@ -91,7 +91,8 @@
                                       :signing?        false
                                       :wrong-password? false
                                       :waiting-signal? false
-                                      :from-chat?      false})
+                                      :from-chat?      false
+                                      :password        nil})
 
 (defn on-transactions-completed [raw-results]
   (let [results (:results (types/json->clj raw-results))]
@@ -290,7 +291,8 @@
   (fn [{:keys [db]} _]
     {:db (update-in db [:wallet :send-transaction] assoc
                     :signing? false
-                    :wrong-password? false)}))
+                    :wrong-password? false
+                    :password nil)}))
 
 (handlers/register-handler-fx
   :wallet.send/set-password

--- a/src/status_im/ui/screens/wallet/send/views.cljs
+++ b/src/status_im/ui/screens/wallet/send/views.cljs
@@ -71,6 +71,7 @@
       (i18n/label :t/cancel)]
      [button/button {:style               (wallet.styles/button-container sign-enabled?)
                      :on-press            sign-handler
+                     :disabled?           (not sign-enabled?)
                      :accessibility-label :sign-transaction-button}
       (i18n/label (or sign-label :t/transactions-sign-transaction))
       [vector-icons/icon :icons/forward {:color :white}]]]))


### PR DESCRIPTION
fixes #3877 

### Summary:

This PR clears the password when signing is cancelled. Also, Sign button is now disabled when 
password is empty (tapping it does nothing as opposed to giving "Wrong password" which was previously the case).

### Steps to test:
See #3877 


status: ready 
