### PR TITLE
Lower survey trigger

### DIFF
--- a/src/status_im/utils/instabug.cljs
+++ b/src/status_im/utils/instabug.cljs
@@ -11,7 +11,7 @@
 
 (def survey-triggers
   [{:event :send-current-message :count 4  :token "UqtvIKgVDUTo4l_sDS-fwA"}
-   {:event :send-current-message :count 29 :token "Hr9Dk3krPK7PPxuDbHAmXg"}])
+   {:event :send-current-message :count 5 :token "Hr9Dk3krPK7PPxuDbHAmXg"}])
 
 ;; 2018-05-07 12:00:00
 (def survey-enabled-timestamp 1525694400000)


### PR DESCRIPTION
Show "Confidence Test Survey April 2018" after 6 messages (survey is disabled for now in Instabug dashboard and going to be enabled after "Messaging UX" will be finished)

This is release-only commit, not going into develop.