### PR TITLE
Send user events to Instabug

### DIFF
--- a/src/status_im/ui/screens/currency_settings/events.cljs
+++ b/src/status_im/ui/screens/currency_settings/events.cljs
@@ -3,8 +3,8 @@
             [status-im.utils.handlers :as handlers]))
 
 (handlers/register-handler-fx
-  :wallet.settings/set-currency
-  (fn [{:keys [db] :as cofx} [_ currency]]
-    (let [settings     (get-in db [:account/account :settings])
-          new-settings (assoc-in settings [:wallet :currency] currency)]
-      (accounts/update-settings new-settings cofx))))
+ :wallet.settings/set-currency
+ (fn [{:keys [db] :as cofx} [_ currency]]
+   (let [settings     (get-in db [:account/account :settings])
+         new-settings (assoc-in settings [:wallet :currency] currency)]
+     (accounts/update-settings new-settings cofx))))

--- a/src/status_im/ui/screens/wallet/views.cljs
+++ b/src/status_im/ui/screens/wallet/views.cljs
@@ -50,24 +50,24 @@
 
 (defn- render-asset [currency]
   (fn [{:keys [symbol icon decimals amount]}]
-   (let [asset-value (re-frame/subscribe [:asset-value symbol (-> currency :code keyword)])]
-     [react/view {:style styles/asset-item-container}
-      [list/item
-       [list/item-image icon]
-       [react/view {:style styles/asset-item-value-container}
-        [react/text {:style               styles/asset-item-value
-                     :number-of-lines     1
-                     :ellipsize-mode      :tail
-                     :accessibility-label (str (-> symbol name clojure.string/lower-case) "-asset-value-text")}
-         (wallet.utils/format-amount amount decimals)]
-        [react/text {:style           styles/asset-item-currency
+    (let [asset-value (re-frame/subscribe [:asset-value symbol (-> currency :code keyword)])]
+      [react/view {:style styles/asset-item-container}
+       [list/item
+        [list/item-image icon]
+        [react/view {:style styles/asset-item-value-container}
+         [react/text {:style               styles/asset-item-value
+                      :number-of-lines     1
+                      :ellipsize-mode      :tail
+                      :accessibility-label (str (-> symbol name clojure.string/lower-case) "-asset-value-text")}
+          (wallet.utils/format-amount amount decimals)]
+         [react/text {:style           styles/asset-item-currency
+                      :uppercase?      true
+                      :number-of-lines 1}
+          (clojure.core/name symbol)]]
+        [react/text {:style           styles/asset-item-price
                      :uppercase?      true
                      :number-of-lines 1}
-         (clojure.core/name symbol)]]
-       [react/text {:style           styles/asset-item-price
-                    :uppercase?      true
-                    :number-of-lines 1}
-        (if @asset-value (str (:symbol currency) @asset-value) "...")]]])))
+         (if @asset-value (str (:symbol currency) @asset-value) "...")]]])))
 
 (defn- asset-section [assets currency]
   [react/view styles/asset-section

--- a/src/status_im/utils/handlers.cljs
+++ b/src/status_im/utils/handlers.cljs
@@ -101,9 +101,8 @@
                anon-id  (:device-UUID new-db)]
            (doseq [{:keys [label properties]}
                    (mixpanel/matching-events new-db event mixpanel/event-by-trigger)]
-             (mixpanel/track anon-id label properties offline?))
-           (when (= :send-current-message (first event))
-             (instabug/maybe-show-survey new-db)))))
+             (mixpanel/track anon-id label properties offline?)
+             (instabug/track label properties)))))
      context)))
 
 (defn register-handler


### PR DESCRIPTION
fixes #3738 

Send user events to Instabug to allow running custom surveys based on user behavior.

PR also removes custom hacks to manually show survey when N events has happened (this was done as a workaround while Instabug User Events API was not working)

status: ready
