### PR TITLE
Strip unnecessary keys for saving

### DIFF
--- a/src/status_im/data_store/realm/core.cljs
+++ b/src/status_im/data_store/realm/core.cljs
@@ -131,7 +131,9 @@
   ([realm schema-name obj]
    (create realm schema-name obj false))
   ([realm schema-name obj update?]
-   (.create realm (name schema-name) (clj->js obj) update?)))
+   (let [obj-to-save (select-keys obj (keys (get-in entity->schemas
+                                                    [schema-name :properties])))]
+     (.create realm (name schema-name) (clj->js obj-to-save) update?))))
 
 (defn save
   ([realm schema-name obj]


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

As recently discovered by @rasom, we unnecessary passed complex objects to realm write functions, with potentially very bad impacts on performance, because those objects have to be first converted from cljs to js, by using the `clj->js` function. It was particularly bad for chats containing a lot of messages.

Luckily thanks to the recently merged #4002 PR which leverages realm schemas for fast `js->clj` conversions, we can very easily turn it around and use it to restrict set of keys when doing the opposite.
The resulting PR is very small and quite naive, for example it doesn't restrict keys of the child entities, but it's sufficient for us now, as we don't have situations where it would be necessary.

### Testing notes (optional):
Regression testing of the whole app, specially caring about persistence

status: ready
