### PR TITLE
Feature/remove seen from public chats

### DIFF
--- a/src/status_im/chat/models/message.cljs
+++ b/src/status_im/chat/models/message.cljs
@@ -65,7 +65,8 @@
          :contacts/keys [contacts]}               db
         {:keys [public-key] :as current-account}  (:account/account db)
         current-chat?                             (and (= :chat view-id) (= current-chat-id chat-id))
-        {:keys [last-clock-value] :as chat}       (get-in db [:chats chat-id])
+        {:keys [last-clock-value
+                public?] :as chat}                (get-in db [:chats chat-id])
         request-command                           (:request-command content)
         command-request?                          (and (= content-type constants/content-type-command-request)
                                                        request-command)
@@ -86,6 +87,7 @@
                                                                      current-account chat contacts request-command)))
                                     current-chat?)
                        (send-message-seen chat-id message-id (and public-key
+                                                                  (not public?)
                                                                   current-chat?
                                                                   (not (chat-model/bot-only-chat? db chat-id))
                                                                   (not (= constants/system from)))))))

--- a/src/status_im/ui/screens/home/views/inner_item.cljs
+++ b/src/status_im/ui/screens/home/views/inner_item.cljs
@@ -44,17 +44,6 @@
                   :accessibility-label :chat-message-text}
       content])])
 
-(defview message-status [{:keys [chat-id contacts]}
-                         {:keys [message-id user-statuses outgoing] :as msg}]
-  (letsubs [current-public-key [:get-current-public-key]]
-    (let [delivery-statuses (dissoc user-statuses current-public-key)
-          seen-by-everyone  (and (= (count delivery-statuses) (count contacts)
-                                    (every? (comp (partial = :seen) second)
-                                            delivery-statuses)))]
-      (when (and outgoing (or (= chat-id const/console-chat-id)
-                              seen-by-everyone))
-        [vector-icons/icon :icons/ok {:style styles/status-image}]))))
-
 (defn message-timestamp [{:keys [timestamp]}]
   (when timestamp
     [react/text {:style               styles/datetime-text
@@ -90,8 +79,8 @@
          chat-name)]]]))
 
 (defview home-list-chat-item-inner-view [{:keys [chat-id name color online
-                                                 group-chat contacts public?
-                                                 public-key unremovable? :as chat]}]
+                                                 group-chat public?
+                                                 public-key]}]
   (letsubs [last-message [:get-last-message chat-id]]
     (let [name (or (i18n/get-contact-translated chat-id :name name)
                    (gfycat/generate-gfy public-key))
@@ -105,7 +94,6 @@
           [chat-list-item-name name group-chat public? public-key]
           (when last-message
             [react/view styles/message-status-container
-             [message-status chat last-message]
              [message-timestamp last-message]])]
          [react/view styles/item-lower-container
           [message-content-text last-message]

--- a/test/cljs/status_im/test/chat/models/message.cljs
+++ b/test/cljs/status_im/test/chat/models/message.cljs
@@ -1,5 +1,6 @@
 (ns status-im.test.chat.models.message
   (:require [cljs.test :refer-macros [deftest is testing]]
+            [status-im.transport.message.v1.protocol :as protocol]
             [status-im.chat.models.message :as message]))
 
 (deftest add-to-chat?
@@ -24,3 +25,37 @@
                                    {:message-id "message-id"
                                     :from "a"
                                     :chat-id "a"})))))
+
+(deftest receive-send-seen
+  (let [db           {:db {:chats {"chat-id" {}}
+                           :account/account {:public-key "a"}
+                           :current-chat-id "chat-id"
+                           :view-id :chat}}
+        message      {:chat-id "chat-id"
+                      :from "a"
+                      :message-id "1"}
+        extract-seen (comp :payload :message :shh/post)]
+    (testing "it send a seen message when the chat is 1-to-1 and is open"
+      (is (instance? protocol/MessagesSeen
+                     (extract-seen (message/receive message db))))
+      (is (= #{"1"} (:message-ids (extract-seen (message/receive message db))))))
+    (testing "it does not send any when the chat is public"
+      (is (nil? (extract-seen
+                  (message/receive
+                    message
+                    (assoc-in db [:db :chats "chat-id" :public?] true))))))
+    (testing "it does not send any when we are in a different chat"
+      (is (nil? (extract-seen
+                  (message/receive
+                    message
+                    (assoc-in db [:db :current-chat-id] :different))))))
+    (testing "it does not send any when we are not in a chat view"
+      (is (nil? (extract-seen
+                  (message/receive
+                    message
+                    (assoc-in db [:db :view-id] :home))))))
+    (testing "it does not send any when no public key is in account"
+      (is (nil? (extract-seen
+                  (message/receive
+                    message
+                    (assoc-in db [:db :account/account :public-key] nil))))))))


### PR DESCRIPTION
### Summary:

Remove sending seen from public chat as it is not used anymore.

I have also fixed some code that has not been running for a while (3/4 months): we used to show a checkmark if the last message is "seen" on the chat, is this something we want to keep or remove @denis-sharypin ?

status: ready
