### PR TITLE
[FIX #3683] Advanced option does not autoscroll the screen up

### DIFF
--- a/src/status_im/ui/screens/profile/user/views.cljs
+++ b/src/status_im/ui/screens/profile/user/views.cljs
@@ -167,13 +167,17 @@
   (letsubs [{:keys [public-key] :as current-account} [:get-current-account]
             editing?        [:get :my-profile/editing?]
             changed-account [:get :my-profile/profile]
-            currency        [:wallet/currency]]
+            currency        [:wallet/currency]
+            scroll          (atom nil)]
     (let [shown-account (merge current-account changed-account)]
       [react/view profile.components.styles/profile
        (if editing?
          [my-profile-edit-toolbar]
          [my-profile-toolbar])
-       [react/scroll-view {:keyboard-should-persist-taps :handled}
+       [react/scroll-view {:ref                          #(reset! scroll %)
+                           :keyboard-should-persist-taps :handled
+                           :on-content-size-change       #(when (and scroll @scroll)
+                                                            (.scrollToEnd @scroll))}
         [react/view profile.components.styles/profile-form
          [profile.components/profile-header shown-account editing? true profile-icon-options :my-profile/update-name]]
         [react/view action-button.styles/actions-list


### PR DESCRIPTION
fixes #3683

### Summary:

Auto-scroll to the bottom when 'advanced' options are shown. This implements `on-content-size-change` on the scroll-view in the profile. The same handler is already implemented in the transaction view and no further change is needed here as it already works.

### Steps to test:
- Open Status (should be tested on a small-resolution device)
- Profile -> toggle advanced
- Wallet -> toggle advanced


status: ready <!-- Can be ready or wip -->
