### PR TITLE
[FIX #4038] All symbols after dot/comma erased if editing decimal num…

### DIFF
--- a/src/status_im/ui/screens/wallet/request/views.cljs
+++ b/src/status_im/ui/screens/wallet/request/views.cljs
@@ -28,7 +28,8 @@
   ;; TODO(jeluard) both send and request flows should be merged
   (views/letsubs [{:keys [to to-name whisper-identity]} [:wallet.send/transaction]
                   {:keys [amount amount-error]}         [:wallet.request/transaction]
-                  scroll (atom nil)]
+                  scroll (atom nil)
+                  amount-text-value (atom nil)]
     [comp/simple-screen {:avoid-keyboard? true}
      [comp/toolbar (i18n/label :t/new-request)]
      [react/view components.styles/flex
@@ -45,7 +46,8 @@
                                      :input-options {:default-value  (str (money/to-fixed (money/wei->ether amount)))
                                                      :max-length     21
                                                      :on-focus       (fn [] (when @scroll (utils/set-timeout #(.scrollToEnd @scroll) 100)))
-                                                     :on-change-text #(re-frame/dispatch [:wallet.request/set-and-validate-amount %])}}]]]
+                                                     :on-change-text #(reset! amount-text-value %)
+                                                     :on-end-editing #(re-frame/dispatch [:wallet.request/set-and-validate-amount @amount-text-value])}}]]]
       [bottom-buttons/bottom-buttons styles/bottom-buttons
        nil ;; Force a phantom button to ensure consistency with other transaction screens which define 2 buttons
        [button/button {:disabled?           (not (and to amount))

--- a/src/status_im/ui/screens/wallet/send/views.cljs
+++ b/src/status_im/ui/screens/wallet/send/views.cljs
@@ -195,7 +195,8 @@
      [advanced-cartouche transaction modal?])])
 
 (defn- send-transaction-panel [{:keys [modal? transaction scroll advanced? symbol]}]
-  (let [{:keys [amount amount-error signing? to to-name sufficient-funds? in-progress? from-chat?]} transaction]
+  (let [{:keys [amount amount-error signing? to to-name sufficient-funds? in-progress? from-chat?]} transaction
+        amount-text-value (atom nil)]
     [wallet.components/simple-screen {:avoid-keyboard? (not modal?)
                                       :status-bar-type (if modal? :modal-wallet :wallet)}
      [toolbar from-chat? (if modal? act/close-white act/back-white)
@@ -220,7 +221,8 @@
                                      :input-options {:default-value  (str (money/to-fixed (money/wei->ether amount)))
                                                      :max-length     21
                                                      :on-focus       (fn [] (when (and scroll @scroll) (utils/set-timeout #(.scrollToEnd @scroll) 100)))
-                                                     :on-change-text #(re-frame/dispatch [:wallet.send/set-and-validate-amount %])}}]
+                                                     :on-change-text #(reset! amount-text-value %)
+                                                     :on-end-editing #(re-frame/dispatch [:wallet.send/set-and-validate-amount @amount-text-value])}}]
         [advanced-options advanced? transaction modal?]]]
       (if signing?
         [signing-buttons


### PR DESCRIPTION
fixes #4038 

### Summary:

Apply amount formatting with `on-end-editing` handler which allows for natural editing of invalid inputs. The previous implementation applies formatting on every input change thus the value '0.000' is immediately formatted as '0'.

### Steps to test:
- Open Status
- Navigate to Wallet
- Click Send transaction button
- Type 0.0005 into the Amount field
- Tap Delete (backspace) button on the keyboard once
- The value should be re-formatted after leaving the input (hiding the keyboard)

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->
