### PR TITLE
[FIX #3603] Tabs are visible along with keyboard when focusing on inp…

### DIFF
--- a/src/status_im/ui/screens/profile/navigation.cljs
+++ b/src/status_im/ui/screens/profile/navigation.cljs
@@ -12,3 +12,7 @@
 (defmethod navigation/preload-data! :backup-seed
   [db]
   (assoc db :my-profile/seed {:step :intro}))
+
+(defmethod navigation/unload-data! :my-profile
+  [db]
+  (dissoc db :my-profile/editing?))


### PR DESCRIPTION
fixes #3603

### Summary:

The profile view uses `:my-profile/editing?` property which isn't cleared after leaving the view without the user's confirmation (by clicking the tick button). This keeps the edit mode active in the background even if the profile view isn't visible and altogether with the `:auto-focus` property on the user's name input causes this issue by automatically focusing the user's name input field. This bugfix globally unsets the `editing?` property when changing view.

Note: I'm not sure if there is a better place where to unset the property, I was looking for something that would be triggered when leaving a view but didn't find anything suitable. Please provide guidence if there is a better way.

### Steps to test:
- Open Status
- Profile - Edit (don't click the tick button, just hide the keyboard to keep edit mode active)
- Wallet - Send - Specify amount
- Go back to Wallet

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->
