### PR TITLE
[FIX #4080] Paid mailservers

### DIFF
--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -2,7 +2,8 @@
   (:require [status-im.i18n :as i18n]
             [status-im.utils.ethereum.core :as ethereum]
             [status-im.utils.types :as types]
-            [status-im.utils.config :as config]))
+            [status-im.utils.config :as config]
+            [status-im.utils.money :as money]))
 
 (def ethereum-rpc-url "http://localhost:8545")
 
@@ -73,12 +74,18 @@
          mainnet-networks))
 
 (def default-wnodes
-  {:testnet {"mailserver-a" {:id      "mailserver-a"
-                             :name    "Status mailserver A"
-                             :address "enode://1da276e34126e93babf24ec88aac1a7602b4cbb2e11b0961d0ab5e989ca9c261aa7f7c1c85f15550a5f1e5a5ca2305b53b9280cf5894d5ecf7d257b173136d40@167.99.209.61:30504"}
-             "mailserver-b" {:id      "mailserver-b"
-                             :name    "Status mailserver B"
-                             :address "enode://07ac64fe0e9b2d4ecbfe0ccaeab3d8d95fa8858754f511104bb403b19255d7bf47a8416bdd0df01f6720ff82164451b7a028c93d15ddd37b7e8382d74e91ebc2@167.99.209.72:30504"}}
+  {:testnet {"mailserver-a"    {:id      "mailserver-a"
+                                :name    "Status mailserver A"
+                                :address "enode://1da276e34126e93babf24ec88aac1a7602b4cbb2e11b0961d0ab5e989ca9c261aa7f7c1c85f15550a5f1e5a5ca2305b53b9280cf5894d5ecf7d257b173136d40@167.99.209.61:30504"}
+             "mailserver-b"    {:id      "mailserver-b"
+                                :name    "Status mailserver B"
+                                :address "enode://07ac64fe0e9b2d4ecbfe0ccaeab3d8d95fa8858754f511104bb403b19255d7bf47a8416bdd0df01f6720ff82164451b7a028c93d15ddd37b7e8382d74e91ebc2@167.99.209.72:30504"}
+             "mailserver-paid" {:id      "mailserver-paid"
+                                :name    "Status mailserver paid, experimental"
+                                :address "enode://9f0a55f116aedb40d4036d9a385d505d9c183fd708ef1aa2f883895df97864f758eee911c26c86732ae13a57664a076de2527189f983ee24dda2a4cb5f5db777@127.0.0.1:30303"
+                                :payment {:address "0x744d70FDBE2Ba4CF95131626614a1763DF805B9E"
+                                          :amount  (money/bignumber 500000000000)
+                                          :symbol  :STT}}}
    :mainnet {"mailserver-a" {:id      "mailserver-a"
                              :name    "Status mailserver A"
                              :address "enode://1da276e34126e93babf24ec88aac1a7602b4cbb2e11b0961d0ab5e989ca9c261aa7f7c1c85f15550a5f1e5a5ca2305b53b9280cf5894d5ecf7d257b173136d40@167.99.209.61:30504"}

--- a/src/status_im/ui/screens/accounts/db.cljs
+++ b/src/status_im/ui/screens/accounts/db.cljs
@@ -30,6 +30,7 @@
 (spec/def :account/sharing-usage-data? (spec/nilable boolean?))
 (spec/def :account/dev-mode? (spec/nilable boolean?))
 (spec/def :account/seed-backed-up? (spec/nilable boolean?))
+(spec/def :account/wnode-payment (spec/nilable string?))
 (spec/def :account/wallet-set-up-passed? (spec/nilable boolean?))
 
 (spec/def :accounts/account (allowed-keys
@@ -40,7 +41,7 @@
                                       :account/networks :account/settings :account/wnode
                                       :account/last-sign-in :account/sharing-usage-data? :account/dev-mode?
                                       :account/seed-backed-up? :account/mnemonic
-                                      :account/wallet-set-up-passed?]))
+                                      :account/wallet-set-up-passed? :account/wnode-payment]))
 
 (spec/def :accounts/accounts (spec/nilable (spec/map-of :account/address :accounts/account)))
 

--- a/src/status_im/ui/screens/offline_messaging_settings/db.cljs
+++ b/src/status_im/ui/screens/offline_messaging_settings/db.cljs
@@ -1,6 +1,7 @@
 (ns status-im.ui.screens.offline-messaging-settings.db
   (:require-macros [status-im.utils.db :refer [allowed-keys]])
-  (:require [cljs.spec.alpha :as spec]))
+  (:require [cljs.spec.alpha :as spec]
+            [status-im.utils.money :as money]))
 
 (def enode-address-regex #"enode://[a-zA-Z0-9]+\@\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b:(\d{1,5})")
 
@@ -9,7 +10,15 @@
 (spec/def :wnode/address (spec/and string? #(re-matches enode-address-regex %)))
 (spec/def :wnode/name ::not-blank-string)
 (spec/def :wnode/id ::not-blank-string)
-(spec/def :wnode/wnode (allowed-keys :req-un [:wnode/address :wnode/name :wnode/id]))
+
+(spec/def ::address :global/address)
+(spec/def ::amount (spec/nilable money/valid?))
+(spec/def ::symbol (spec/nilable keyword?))
+
+(spec/def :wnode/payment (allowed-keys :req-un [::address ::amount ::symbol]))
+(spec/def :wnode/wnode (allowed-keys
+                        :req-un [:wnode/address :wnode/name :wnode/id]
+                        :opt-un [:wnode/payment]))
 
 (spec/def :inbox/password ::not-blank-string)
 (spec/def :inbox/wnodes (spec/nilable (spec/map-of keyword? (spec/map-of :wnode/id :wnode/wnode))))

--- a/src/status_im/ui/screens/offline_messaging_settings/events.cljs
+++ b/src/status_im/ui/screens/offline_messaging_settings/events.cljs
@@ -1,19 +1,66 @@
 (ns status-im.ui.screens.offline-messaging-settings.events
-  (:require [re-frame.core :refer [dispatch]]
+  (:require [re-frame.core :refer [reg-fx dispatch]]
             [status-im.utils.handlers :as handlers]
             [status-im.utils.handlers-macro :as handlers-macro]
             [status-im.ui.screens.accounts.events :as accounts-events]
             [status-im.i18n :as i18n]
-            [status-im.transport.core :as transport]
-            [status-im.utils.ethereum.core :as ethereum]))
+            [status-im.utils.ethereum.core :as ethereum]
+            [status-im.utils.ethereum.erc20 :as erc20]
+            [status-im.utils.ethereum.tokens :as tokens]
+            [status-im.utils.money :as money]))
 
 (handlers/register-handler-fx
  ::save-wnode
  (fn [{:keys [db now] :as cofx} [_ chain wnode]]
    (let [settings (get-in db [:account/account :settings])]
      (handlers-macro/merge-fx cofx
-                              {:dispatch [:logout]}
+                              {:dispatch-n [[:load-accounts]
+                                            [:navigate-to-clean :accounts]]}
                               (accounts-events/update-settings (assoc-in settings [:wnode chain] wnode))))))
+
+(handlers/register-handler-fx
+ ::save-wnode-transaction
+ (fn [{:keys [db] :as cofx} [_ chain wnode hash]]
+   (let [settings    (get-in db [:account/account :settings])
+         transaction (get-in db [:wallet :transactions hash])]
+     (when (seq transaction)
+       (handlers-macro/merge-fx cofx
+                                {:dispatch [::save-wnode chain wnode]}
+                                (accounts-events/update-settings
+                                 (assoc-in settings [:wnode-payment chain wnode] hash)))))))
+
+(reg-fx
+ ::send-token-transaction
+ (fn [{:keys [web3 contract from address amount gas gas-price on-sent] :as haha}]
+   (erc20/transfer web3
+                   contract
+                   from
+                   address
+                   amount
+                   {:gas gas :gasPrice gas-price}
+                   on-sent)))
+
+(handlers/register-handler-fx
+ ::pay-wnode
+ (fn [{{:keys [web3] :as db} :db} [_ chain wnode]]
+   (let [{:keys [address amount symbol]} (get-in db [:inbox/wnodes chain wnode :payment])]
+     {::send-token-transaction {:web3      web3
+                                :address   address
+                                :amount    amount
+                                :contract  (:address (tokens/symbol->token chain symbol))
+                                :from      (get-in db [:account/account :address])
+                                :gas       (ethereum/estimate-gas symbol)
+                                :gas-price (money/->wei :gwei 5)
+                                :on-sent   #(dispatch [::save-wnode-transaction chain wnode %])}})))
+
+(handlers/register-handler-fx
+ ::select-wnode
+ (fn [{:keys [db]} [_ chain wnode]]
+   (let [payment?    (contains? (get-in db [:inbox/wnodes chain wnode]) :payment)
+         payment-tx? (contains? (get-in db [:account/account :settings :wnode-payment chain]) wnode)]
+     {:dispatch (if (and payment? (not payment-tx?))
+                  [::pay-wnode chain wnode]
+                  [::save-wnode chain wnode])})))
 
 (handlers/register-handler-fx
  :connect-wnode
@@ -24,5 +71,5 @@
                           :content             (i18n/label :t/connect-wnode-content
                                                            {:name (get-in db [:inbox/wnodes chain wnode :name])})
                           :confirm-button-text (i18n/label :t/close-app-button)
-                          :on-accept           #(dispatch [::save-wnode chain wnode])
+                          :on-accept           #(dispatch [::select-wnode chain wnode])
                           :on-cancel           nil}})))

--- a/src/status_im/ui/screens/wallet/send/subs.cljs
+++ b/src/status_im/ui/screens/wallet/send/subs.cljs
@@ -75,10 +75,17 @@
                   :<- [::unsigned-transaction]
                   :<- [:get-contacts-by-address]
                   :<- [:balance]
-                  (fn [[{:keys [value to symbol] :as transaction} contacts balance]]
+                  (fn [[{:keys [value to symbol token] :as transaction} contacts balance]]
                     (when transaction
-                      (let [contact           (contacts (utils.hex/normalize-hex to))
-                            sufficient-funds? (money/sufficient-funds? value (get balance symbol))]
+                      (let [contact                 (contacts (utils.hex/normalize-hex to))
+                            sufficient-base-funds?  (money/sufficient-funds?
+                                                     value (get balance symbol))
+                            sufficient-token-funds? (money/sufficient-funds?
+                                                     (:value token) (get balance (:symbol token)))
+                            sufficient-funds?       (and sufficient-base-funds?
+                                                         (if (nil? token)
+                                                           true
+                                                           sufficient-token-funds?))]
                         (cond-> (assoc transaction
                                        :amount value
                                        :sufficient-funds? sufficient-funds?)

--- a/src/status_im/ui/screens/wallet/send/views.cljs
+++ b/src/status_im/ui/screens/wallet/send/views.cljs
@@ -199,7 +199,9 @@
     (reset! timeout (utils/set-timeout #(re-frame/dispatch [:wallet.send/set-and-validate-amount amount]) 500))))
 
 (defn- send-transaction-panel [{:keys [modal? transaction scroll advanced? symbol]}]
-  (let [{:keys [amount amount-text amount-error signing? to to-name sufficient-funds? in-progress? from-chat?]} transaction
+  (let [{:keys [amount amount-text amount-error signing? to to-name token sufficient-funds? in-progress? from-chat?]} transaction
+        symbol  (or (:symbol token) symbol)
+        amount  (or (:value token) amount)
         timeout (atom nil)]
     [wallet.components/simple-screen {:avoid-keyboard? (not modal?)
                                       :status-bar-type (if modal? :modal-wallet :wallet)}

--- a/src/status_im/utils/ethereum/erc20.cljs
+++ b/src/status_im/utils/ethereum/erc20.cljs
@@ -46,7 +46,7 @@
                              (merge (ethereum/call-params contract "transfer(address,uint256)" (ethereum/normalized-address address) (ethereum/int->hex value))
                                     {:from from}
                                     params)
-                             #(cb %1 (ethereum/hex->boolean %2))))
+                             #(cb %2)))
 
 (defn transfer-from [web3 contract from-address to-address value cb]
   (ethereum/call web3


### PR DESCRIPTION
Fixes: #4080 

### Summary:

[comment]: # (Summarise the problem and how the pull request solves it)
Paid master nodes are coming soon and with that we want the app to prompt for payment upon selecting a mailserver that requires payment. When the user switches to a new mailserver and a payment transaction doesn't already exist, the user is prompted to send a transaction to that node's contract.

Upon selecting the new node, the user is prompted with a send transaction modal which initiates a token transfer to the master node's contract. After a successful transfer, the user is connected to the selected node.

### Testing notes (ensure the following still work):
* Sending a transaction from the wallet
* Signing a transaction at a later time
* Sending a txn through a chat
* Sending a txn through the browser to a dapp

### Steps to test:
1. Open Status
2. Navigate to the settings tab
3. Click on change mail server under advanced
4. Select a paid mailserver
5. Sign the transaction when prompted
6. Observe that the new mailserver has been selected

status: ready <!-- Can be ready or wip -->
