### PR TITLE
[DO NOT MERGE FOR NOW] Dont use discovery topic

### DIFF
--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -195,9 +195,6 @@
 
 (def inbox-password "status-offline-inbox")
 
-;; Used to generate topic for contact discoveries
-(def contact-discovery "contact-discovery")
-
 (def ^:const send-transaction-no-error-code        "0")
 (def ^:const send-transaction-default-error-code   "1")
 (def ^:const send-transaction-password-error-code  "2")

--- a/src/status_im/data_store/realm/schemas/account/core.cljs
+++ b/src/status_im/data_store/realm/schemas/account/core.cljs
@@ -1,10 +1,10 @@
 (ns status-im.data-store.realm.schemas.account.core
-  (:require [status-im.data-store.realm.schemas.account.v1.core :as v1]))
+  (:require [status-im.data-store.realm.schemas.account.v2.core :as v2]))
 
 ;; TODO(oskarth): Add failing test if directory vXX exists but isn't in schemas.
 
 ;; put schemas ordered by version
-(def schemas [{:schema        v1/schema
-               :schemaVersion 1
-               :migration     v1/migration}])
+(def schemas [{:schema        v2/schema
+               :schemaVersion 2
+               :migration     v2/migration}])
 

--- a/src/status_im/data_store/realm/schemas/account/v2/core.cljs
+++ b/src/status_im/data_store/realm/schemas/account/v2/core.cljs
@@ -1,0 +1,27 @@
+(ns status-im.data-store.realm.schemas.account.v2.core
+  (:require [status-im.data-store.realm.schemas.account.v1.chat :as chat]
+            [status-im.data-store.realm.schemas.account.v2.transport :as transport]
+            [status-im.data-store.realm.schemas.account.v1.contact :as contact]
+            [status-im.data-store.realm.schemas.account.v1.message :as message]
+            [status-im.data-store.realm.schemas.account.v1.request :as request]
+            [status-im.data-store.realm.schemas.account.v1.user-status :as user-status]
+            [status-im.data-store.realm.schemas.account.v1.contact-group :as contact-group]
+            [status-im.data-store.realm.schemas.account.v1.local-storage :as local-storage]
+            [status-im.data-store.realm.schemas.account.v1.browser :as browser]
+            [goog.object :as object]
+            [taoensso.timbre :as log]
+            [cljs.reader :as reader]
+            [clojure.string :as string]))
+
+(def schema [chat/schema
+             transport/schema
+             contact/schema
+             message/schema
+             request/schema
+             user-status/schema
+             contact-group/schema
+             local-storage/schema
+             browser/schema])
+
+(defn migration [old-realm new-realm]
+  (log/debug "migrating v2 account database: " old-realm new-realm))

--- a/src/status_im/data_store/realm/schemas/account/v2/transport.cljs
+++ b/src/status_im/data_store/realm/schemas/account/v2/transport.cljs
@@ -1,0 +1,17 @@
+(ns status-im.data-store.realm.schemas.account.v2.transport)
+
+(def schema {:name       :transport
+             :primaryKey :chat-id
+             :properties {:chat-id          :string
+                          :ack              :string
+                          :seen             :string
+                          :pending-ack      :string
+                          :pending-send     :string
+                          :topic            :string
+                          :one-to-one       {:type :bool
+                                             :optional true}
+                          :sym-key-id       {:type :string
+                                             :optional true}
+                          ;;TODO (yenda) remove once go implements persistence
+                          :sym-key          {:type :string
+                                             :optional true}}})

--- a/src/status_im/transport/core.cljs
+++ b/src/status_im/transport/core.cljs
@@ -26,14 +26,14 @@
                                    (re-frame/dispatch [::sym-key-added {:chat-id    chat-id
                                                                         :sym-key    sym-key
                                                                         :sym-key-id sym-key-id}]))
-          topic (transport.utils/get-topic constants/contact-discovery)]
+          discover-topic         (transport.utils/get-topic public-key)]
       (handlers-macro/merge-fx cofx
                                {:shh/add-discovery-filter {:web3           web3
                                                            :private-key-id public-key
-                                                           :topic topic}
-                                :shh/restore-sym-keys {:web3       web3
-                                                       :transport  (:transport/chats db)
-                                                       :on-success sym-key-added-callback}}
+                                                           :topic          discover-topic}
+                                :shh/restore-sym-keys     {:web3       web3
+                                                           :transport  (:transport/chats db)
+                                                           :on-success sym-key-added-callback}}
                                (inbox/initialize-offline-inbox)))))
 
 ;;TODO (yenda) remove once go implements persistence
@@ -51,6 +51,7 @@
                                                             :chat    (assoc chat :sym-key-id sym-key-id)})]
       :shh/add-filter {:web3       web3
                        :sym-key-id sym-key-id
+                       :one-to-one (get-in db [:transport/chats chat-id :one-to-one])
                        :topic      topic
                        :chat-id    chat-id}})))
 
@@ -72,6 +73,6 @@
   account A messages without this."
   [{:keys [db]}]
   (let [{:transport/keys [chats discovery-filter]} db
-        chat-filters                               (mapv :filter (vals chats))
+        chat-filters                               (mapcat :filters (vals chats))
         all-filters                                (conj chat-filters discovery-filter)]
     {:shh/remove-filters all-filters}))

--- a/src/status_im/transport/db.cljs
+++ b/src/status_im/transport/db.cljs
@@ -14,10 +14,11 @@
 (spec/def ::sym-key-id string?)
 ;;TODO (yenda) remove once go implements persistence
 (spec/def ::sym-key string?)
-(spec/def ::filter any?)
+(spec/def ::filters any?)
+(spec/def ::one-to-one (spec/nilable boolean?))
 
 (spec/def :transport/chat (allowed-keys :req-un [::ack ::seen ::pending-ack ::pending-send ::topic]
-                                        :opt-un [::sym-key-id ::sym-key ::filter]))
+                                        :opt-un [::sym-key-id ::sym-key ::filters ::one-to-one]))
 
 (spec/def :transport/chats (spec/map-of :global/not-empty-string :transport/chat))
 (spec/def :transport/discovery-filter (spec/nilable any?))
@@ -25,9 +26,11 @@
 (defn create-chat
   "Initialize datastructure for chat representation at the transport level
   Currently only :topic is actually used"
-  [topic]
-  {:ack          []
-   :seen         []
-   :pending-ack  []
-   :pending-send []
-   :topic        topic})
+  [topic opts]
+  (merge {:ack              []
+          :filters          []
+          :one-to-one       false
+          :seen             []
+          :pending-ack      []
+          :pending-send     []
+          :topic            topic} opts))

--- a/src/status_im/transport/filters.cljs
+++ b/src/status_im/transport/filters.cljs
@@ -6,6 +6,9 @@
             [status-im.utils.config :as config]
             [taoensso.timbre :as log]))
 
+(defn- receive-message [chat-id js-error js-message]
+  (re-frame/dispatch [:protocol/receive-whisper-message js-error js-message chat-id]))
+
 (defn remove-filter! [filter]
   (.stopWatching filter
                  (fn [error _]
@@ -20,43 +23,55 @@
                      #(log/warn :add-filter-error (.stringify js/JSON (clj->js options)) %)))
 
 (defn add-filter!
-  [web3 {:keys [topics to] :as options} callback]
+  [web3 {:keys [chat-id topics to event] :as options} callback]
   (let [options  (if config/offline-inbox-enabled?
                    (assoc options :allowP2P true)
                    options)]
     (log/debug :add-filter options)
-    (add-shh-filter! web3 options callback)))
+    (if-let [filter (add-shh-filter! web3 options callback)]
+      (re-frame/dispatch [event chat-id filter])
+      (log/error "Could not create filter for" options))))
 
 (re-frame/reg-fx
  :shh/add-filter
- (fn [{:keys [web3 sym-key-id topic chat-id]}]
-   (when-let [filter (add-filter! web3
-                                  {:topics [topic]
-                                   :symKeyID sym-key-id}
-                                  (fn [js-error js-message]
-                                    (re-frame/dispatch [:protocol/receive-whisper-message js-error js-message chat-id])))]
-     (re-frame/dispatch [::filter-added chat-id filter]))))
+ (fn [{:keys [web3 sym-key-id topic chat-id one-to-one]}]
+   (add-filter!
+    web3
+    {:topics  [topic]
+     :event ::filter-added
+     :chat-id chat-id
+     :symKeyID sym-key-id}
+    (partial receive-message chat-id))
+   ;; We add a noop filter to avoid identification
+   (when one-to-one
+     (add-filter!
+      web3
+      {:topics [(utils/get-topic chat-id)]
+       :event  ::filter-added
+       :chat-id chat-id
+       :minPow 1
+       :symKeyId sym-key-id}
+      (constantly nil)))))
 
 (handlers/register-handler-db
  ::filter-added
  [re-frame/trim-v]
  (fn [db [chat-id filter]]
-   (assoc-in db [:transport/chats chat-id :filter] filter)))
+   (update-in db [:transport/chats chat-id :filters] conj filter)))
 
 (re-frame/reg-fx
  :shh/add-discovery-filter
  (fn [{:keys [web3 private-key-id topic]}]
-   (when-let [filter (add-filter! web3
-                                  {:topics [topic]
-                                   :privateKeyID private-key-id}
-                                  (fn [js-error js-message]
-                                    (re-frame/dispatch [:protocol/receive-whisper-message js-error js-message])))]
-     (re-frame/dispatch [::discovery-filter-added filter]))))
+   (add-filter! web3
+                {:topics [topic]
+                 :event ::discovery-filter-added
+                 :privateKeyID private-key-id}
+                (partial receive-message nil))))
 
 (handlers/register-handler-db
  ::discovery-filter-added
  [re-frame/trim-v]
- (fn [db [filter]]
+ (fn [db [_ filter]]
    (assoc db :transport/discovery-filter filter)))
 
 (re-frame/reg-fx

--- a/src/status_im/transport/handlers.cljs
+++ b/src/status_im/transport/handlers.cljs
@@ -53,6 +53,7 @@
                               {:db (assoc-in db [:transport/chats chat-id :sym-key-id] sym-key-id)
                                :shh/add-filter {:web3       web3
                                                 :sym-key-id sym-key-id
+                                                :one-to-one true
                                                 :topic      topic
                                                 :chat-id    chat-id}
                                :data-store/tx  [(transport-store/save-transport-tx {:chat-id chat-id
@@ -71,6 +72,7 @@
      (handlers-macro/merge-fx cofx
                               {:db (assoc-in db [:transport/chats chat-id :sym-key-id] sym-key-id)
                                :shh/add-filter {:web3       web3
+                                                :one-to-one true
                                                 :sym-key-id sym-key-id
                                                 :topic      topic
                                                 :chat-id    chat-id}

--- a/src/status_im/transport/inbox.cljs
+++ b/src/status_im/transport/inbox.cljs
@@ -220,13 +220,14 @@
  (fn [{:keys [db now]} [_ {:keys [from topics discover?]}]]
    (let [web3       (:web3 db)
          wnode      (get-current-wnode-address db)
+         public-key (:current-public-key db)
          topics     (or topics
                         (map #(:topic %) (vals (:transport/chats db))))
          from       (or from (:inbox/last-request db) nil)
          sym-key-id (:inbox/sym-key-id db)]
      {::request-messages {:wnode      wnode
                           :topics     (if discover?
-                                        (conj topics (transport.utils/get-topic constants/contact-discovery))
+                                        (conj topics (transport.utils/get-topic public-key))
                                         topics)
                           ;;TODO (yenda) fix from, right now mailserver is dropping us
                           ;;when we send a requestMessage with a from field

--- a/src/status_im/transport/message/v1/contact.cljs
+++ b/src/status_im/transport/message/v1/contact.cljs
@@ -25,7 +25,7 @@
                                {:shh/add-new-sym-key {:web3       (get-in cofx [:db :web3])
                                                       :sym-key    sym-key
                                                       :on-success on-success}}
-                               (protocol/init-chat chat-id topic)))))
+                               (protocol/init-chat chat-id topic {:one-to-one true})))))
 
 (defrecord ContactRequest [name profile-image address fcm-token]
   message/StatusMessage
@@ -42,7 +42,7 @@
       (handlers-macro/merge-fx cofx
                                {:shh/get-new-sym-key {:web3       (:web3 db)
                                                       :on-success on-success}}
-                               (protocol/init-chat chat-id topic)
+                               (protocol/init-chat chat-id topic {:one-to-one true})
                                #_(protocol/requires-ack message-id chat-id))))
   (receive [this chat-id signature {:keys [db] :as cofx}]
     (let [message-id (transport.utils/message-id this)

--- a/src/status_im/transport/message/v1/protocol.cljs
+++ b/src/status_im/transport/message/v1/protocol.cljs
@@ -18,9 +18,9 @@
   2 arities are provided, 2arg arity initialises the chat with topic derived from first argument (`chat-id`),
   using the 3arg arity, you can specify the topic as well (second argument)"
   ([chat-id cofx]
-   (init-chat chat-id (transport.utils/get-topic chat-id) cofx))
-  ([chat-id topic {:keys [db] :as cofx}]
-   {:db (assoc-in db [:transport/chats chat-id] (transport.db/create-chat topic))}))
+   (init-chat chat-id (transport.utils/get-topic chat-id) {} cofx))
+  ([chat-id topic opts {:keys [db] :as cofx}]
+   {:db (assoc-in db [:transport/chats chat-id] (transport.db/create-chat topic opts))}))
 
 (defn is-new?
   "Determines if given message-id already exists in in-memory message cache"
@@ -57,7 +57,7 @@
                 :message       (merge {:sig     current-public-key
                                        :pubKey  chat-id
                                        :payload payload
-                                       :topic   (transport.utils/get-topic constants/contact-discovery)}
+                                       :topic   (transport.utils/get-topic chat-id)}
                                       whisper-opts)}}))
 
 (defn- prepare-recipients [public-keys db]

--- a/src/status_im/transport/utils.cljs
+++ b/src/status_im/transport/utils.cljs
@@ -9,10 +9,10 @@
 (defn unsubscribe-from-chat
   "Unsubscribe from chat on transport layer"
   [chat-id {:keys [db]}]
-  (let [filter (get-in db [:transport/chats chat-id :filter])]
-    {:db                (update db :transport/chats dissoc chat-id)
-     :data-store/tx     [(transport-store/delete-transport-tx chat-id)]
-     :shh/remove-filter filter}))
+  (let [filters (get-in db [:transport/chats chat-id :filters])]
+    {:db                 (update db :transport/chats dissoc chat-id)
+     :data-store/tx      [(transport-store/delete-transport-tx chat-id)]
+     :shh/remove-filters filters}))
 
 (defn from-utf8 [s]
   (.fromUtf8 dependencies/Web3.prototype s))


### PR DESCRIPTION
Moves to public key topic instead of discovery.

This will reduce the amount of messages that needs to be fetched from the mailserver.

Having a single topic eventually will not scale, from the client perspective, as it scales with the number of clients in the network (total number of contact messages exchanged), moving to a public key topic scales based on how much activity there is for a given user.

The tradeoff is that we need to also listen to the topic we publish, in order to avoid giving away who we are communicating with (light nodes do not forward messages that are not in bloom filter).

This is a breaking change, users with older version of the app will not be able to communicate with this version.

This is only a performance improvement so no functionality should be fixed nor broken.

status: ready