### PR TITLE
[TESTS] Fixed job name in 'Run extended e2e tests' stage for nightly build

### DIFF
--- a/Jenkinsfile.nightly_fastlane
+++ b/Jenkinsfile.nightly_fastlane
@@ -134,6 +134,6 @@ node ('macos1'){
   }
 
   stage('Run extended e2e tests') {
-    build job: 'status-app-nightly', parameters: [string(name: 'apk', value: '--apk=' + apk_name)], wait: false
+    build job: 'end-to-end-tests/status-app-nightly', parameters: [string(name: 'apk', value: '--apk=' + apk_name)], wait: false
   }
 }


### PR DESCRIPTION
status: ready <!-- Can be ready or wip -->
