### PR TITLE
[#4075] Clear invalid contact code error message when returning to "Start new chat"

### DIFF
--- a/src/status_im/ui/screens/add_new/new_chat/navigation.cljs
+++ b/src/status_im/ui/screens/add_new/new_chat/navigation.cljs
@@ -1,0 +1,6 @@
+(ns status-im.ui.screens.add-new.new-chat.navigation
+  (:require [status-im.ui.screens.navigation :as navigation]))
+
+(defmethod navigation/preload-data! :new-chat
+  [db _]
+  (assoc db :contacts/new-identity nil))

--- a/src/status_im/ui/screens/events.cljs
+++ b/src/status_im/ui/screens/events.cljs
@@ -14,6 +14,7 @@
             status-im.ui.screens.group.chat-settings.events
             status-im.ui.screens.group.events
             status-im.ui.screens.navigation
+            status-im.ui.screens.add-new.new-chat.navigation
             status-im.ui.screens.network-settings.events
             status-im.ui.screens.profile.events
             status-im.ui.screens.qr-scanner.events


### PR DESCRIPTION


fixes #4075

### Summary:

Clear the input field value so that it won't display invalid contact code error message when returning to the "Start new chat"

status: ready <!-- Can be ready or wip -->
