### PR TITLE
[#4043] 'GOT IT' screen is not shown after signing an unsigned transaction

### DIFF
--- a/src/status_im/ui/screens/wallet/events.cljs
+++ b/src/status_im/ui/screens/wallet/events.cljs
@@ -227,8 +227,9 @@
 
 (handlers/register-handler-fx
  :wallet/show-sign-transaction
- (fn [{:keys [db]} [_ id from-chat?]]
-   {:db       (assoc-in db [:wallet :send-transaction] {:id id
+ (fn [{:keys [db]} [_ {:keys [id method]} from-chat?]]
+   {:db       (assoc-in db [:wallet :send-transaction] {:id         id
+                                                        :method     method
                                                         :from-chat? from-chat?})
     :dispatch [:navigate-to-modal :wallet-send-transaction-modal]}))
 

--- a/src/status_im/ui/screens/wallet/send/events.cljs
+++ b/src/status_im/ui/screens/wallet/send/events.cljs
@@ -104,7 +104,7 @@
  (fn [_ _]
    {::show-transaction-moved  true}))
 
-(defn prepare-transaction [{:keys [id message_id args]} now]
+(defn prepare-transaction [{:keys [id message_id method args]} now]
   ;;NOTE(goranjovic): the transactions started from chat using /send command
   ;; are only in ether, so this parameter defaults to ETH
   (let [{:keys [from to value symbol data gas gasPrice] :or {symbol :ETH}} args]
@@ -114,6 +114,7 @@
      :to-name    (when (nil? to)
                    (i18n/label :t/new-contract))
      :symbol     symbol
+     :method     method
      :value      (money/bignumber (or value 0))
      :data       data
      :gas        (when (seq gas)
@@ -255,7 +256,7 @@
  (fn [{{:keys [web3] :as db} :db} [_ later?]]
    (let [db' (assoc-in db [:wallet :send-transaction :wrong-password?] false)
          network (:network db)
-         {:keys [amount id password to symbol gas gas-price]} (get-in db [:wallet :send-transaction])]
+         {:keys [amount id password to symbol method gas gas-price]} (get-in db [:wallet :send-transaction])]
      (if id
        {::accept-transaction {:id           id
                               :password     password
@@ -272,6 +273,7 @@
                             :gas       gas
                             :gas-price gas-price
                             :symbol    symbol
+                            :method    method
                             :network   network}}))))
 
 (handlers/register-handler-fx

--- a/src/status_im/ui/screens/wallet/transactions/views.cljs
+++ b/src/status_im/ui/screens/wallet/transactions/views.cljs
@@ -38,10 +38,10 @@
      nil)]) ;; TODO (andrey) implement [unsigned-action unsigned-transactions-count]
 
 
-(defn action-buttons [{:keys [id] :as transaction}]
+(defn action-buttons [transaction]
   [react/view {:style styles/action-buttons}
    [button/primary-button {:style               {:margin-right 12}
-                           :on-press            #(re-frame/dispatch [:wallet/show-sign-transaction id])
+                           :on-press            #(re-frame/dispatch [:wallet/show-sign-transaction transaction])
                            :accessibility-label :sign-button}
     (i18n/label :t/transactions-sign)]
    [button/secondary-button {:on-press            #(on-delete-transaction transaction)


### PR DESCRIPTION

fixes #4043

### Summary:

'GOT IT' screen is not shown after signing an unsigned transaction. It appears that `:method` is not present in `:wallet/send-transaction` when signing a transaction later.
...

status: ready <!-- Can be ready or wip -->
