### PR TITLE
Remove username from outgoing messages

### DIFF
--- a/src/status_im/chat/styles/message/message.cljs
+++ b/src/status_im/chat/styles/message/message.cljs
@@ -19,8 +19,9 @@
    :height      16})
 
 (defn message-padding-top
-  [{:keys [first-in-group?]}]
-  (if first-in-group?
+  [{:keys [first-in-group? display-username?]}]
+  (if (and display-username?
+           first-in-group?)
     8
     4))
 

--- a/src/status_im/chat/views/message/message.cljs
+++ b/src/status_im/chat/views/message/message.cljs
@@ -304,18 +304,22 @@
                                                        (gfycat/generate-gfy from))])) ; TODO: We defensively generate the name for now, to be revisited when new protocol is defined
 
 (defn message-body
-  [{:keys [last-in-group? first-in-group? group-chat from outgoing username] :as message} content]
+  [{:keys [last-in-group?
+           display-photo?
+           display-username?
+           from
+           outgoing
+           username] :as message} content]
   [react/view (style/group-message-wrapper message)
    [react/view (style/message-body message)
-    (when (and (not outgoing)
-               group-chat)
+    (when display-photo?
       [react/view style/message-author
        (when last-in-group?
          [react/touchable-highlight {:on-press #(re-frame/dispatch [:show-profile from])}
           [react/view
            [photos/member-photo from]]])])
     [react/view (style/group-message-view outgoing)
-     (when first-in-group?
+     (when display-username?
        [message-author-name from username])
      [react/view {:style (style/timestamp-content-wrapper message)}
       content]]]

--- a/test/cljs/status_im/test/chat/subs.cljs
+++ b/test/cljs/status_im/test/chat/subs.cljs
@@ -87,6 +87,14 @@
         (is (:first-in-group? actual-m1))
         (is (not (:first-in-group? actual-m2)))
         (is (:first-in-group? actual-m3)))
+      (testing "it marks messages with display-photo? when they are not outgoing and we are in a group chat"
+        (is (:display-photo? actual-m1))
+        (is (not (:display-photo? actual-m2)))
+        (is (not (:display-photo? actual-m3))))
+      (testing "it marks messages with display-username? when we display the photo and are the first in a group"
+        (is (:display-username? actual-m1))
+        (is (not (:display-username? actual-m2)))
+        (is (not (:display-username? actual-m3))))
       (testing "it marks the last message from the same author with :last-in-group?"
         (is (:last-in-group? actual-m1))
         (is (:last-in-group? actual-m2))


### PR DESCRIPTION
fixes #4091

### Summary:

We don't display username anymore if the message originated with the user, removes extra paddings as well.


status: ready