### PR TITLE
bug #4180 and revert #4038 - amount number formatting in wallet send

### DIFF
--- a/src/status_im/ui/screens/wallet/request/views.cljs
+++ b/src/status_im/ui/screens/wallet/request/views.cljs
@@ -28,8 +28,7 @@
   ;; TODO(jeluard) both send and request flows should be merged
   (views/letsubs [{:keys [to to-name whisper-identity]} [:wallet.send/transaction]
                   {:keys [amount amount-error]}         [:wallet.request/transaction]
-                  scroll (atom nil)
-                  amount-text-value (atom nil)]
+                  scroll (atom nil)]
     [comp/simple-screen {:avoid-keyboard? true}
      [comp/toolbar (i18n/label :t/new-request)]
      [react/view components.styles/flex
@@ -46,8 +45,7 @@
                                      :input-options {:default-value  (str (money/to-fixed (money/wei->ether amount)))
                                                      :max-length     21
                                                      :on-focus       (fn [] (when @scroll (utils/set-timeout #(.scrollToEnd @scroll) 100)))
-                                                     :on-change-text #(reset! amount-text-value %)
-                                                     :on-end-editing #(re-frame/dispatch [:wallet.request/set-and-validate-amount @amount-text-value])}}]]]
+                                                     :on-change-text #(re-frame/dispatch [:wallet.request/set-and-validate-amount %])}}]]]
       [bottom-buttons/bottom-buttons styles/bottom-buttons
        nil ;; Force a phantom button to ensure consistency with other transaction screens which define 2 buttons
        [button/button {:disabled?           (not (and to amount))


### PR DESCRIPTION
fixes #4038
maybe also #3151 
fixes #4180

### Summary:

This PR reverts [this](https://github.com/status-im/status-react/commit/0ed067af6a5d737beab1e9c98b03f18e512f3d5f) change and fixes the problem by using a timeout during which user can edit the amount without it being reformatted. (Kudos to Andrey for this idea).


### Testing notes (optional):

There are two bugs reported around this problem, please check both #4038 and #3151

status: ready 
