### PR TITLE
bug #4192 - removing mnemonic from db after user backs up seed phrase

### DIFF
--- a/src/status_im/data_store/realm/schemas/base/core.cljs
+++ b/src/status_im/data_store/realm/schemas/base/core.cljs
@@ -1,7 +1,11 @@
 (ns status-im.data-store.realm.schemas.base.core
-  (:require [status-im.data-store.realm.schemas.base.v1.core :as v1]))
+  (:require [status-im.data-store.realm.schemas.base.v1.core :as v1]
+            [status-im.data-store.realm.schemas.base.v2.core :as v2]))
 
 ;; put schemas ordered by version
 (def schemas [{:schema        v1/schema
                :schemaVersion 1
-               :migration     v1/migration}])
+               :migration     v1/migration}
+              {:schema        v2/schema
+               :schemaVersion 2
+               :migration     v2/migration}])

--- a/src/status_im/data_store/realm/schemas/base/v2/account.cljs
+++ b/src/status_im/data_store/realm/schemas/base/v2/account.cljs
@@ -1,0 +1,26 @@
+(ns status-im.data-store.realm.schemas.base.v2.account)
+
+(def schema {:name       :account
+             :primaryKey :address
+             :properties {:address               :string
+                          :public-key            :string
+                          :name                  {:type :string :optional true}
+                          :email                 {:type :string :optional true}
+                          :status                {:type :string :optional true}
+                          :debug?                {:type :bool :default false}
+                          :photo-path            :string
+                          :signing-phrase        {:type :string}
+                          :mnemonic              {:type :string :optional true}
+                          :last-updated          {:type :int :default 0}
+                          :last-sign-in          {:type :int :default 0}
+                          :signed-up?            {:type    :bool
+                                                  :default false}
+                          :network               :string
+                          :networks              {:type       :list
+                                                  :objectType :network}
+                          :settings              {:type :string}
+                          :sharing-usage-data?   {:type :bool :default false}
+                          :dev-mode?             {:type :bool :default false}
+                          :seed-backed-up?       {:type :bool :default false}
+                          :wallet-set-up-passed? {:type    :bool
+                                                  :default false}}})

--- a/src/status_im/data_store/realm/schemas/base/v2/core.cljs
+++ b/src/status_im/data_store/realm/schemas/base/v2/core.cljs
@@ -1,0 +1,10 @@
+(ns status-im.data-store.realm.schemas.base.v2.core
+  (:require [status-im.data-store.realm.schemas.base.v1.network :as network]
+            [status-im.data-store.realm.schemas.base.v2.account :as account]
+            [taoensso.timbre :as log]))
+
+(def schema [network/schema
+             account/schema])
+
+(defn migration [old-realm new-realm]
+  (log/debug "migrating base database v2: " old-realm new-realm))

--- a/src/status_im/ui/screens/accounts/utils.cljs
+++ b/src/status_im/ui/screens/accounts/utils.cljs
@@ -21,3 +21,10 @@
      (if (or (:name new-account-fields) (:photo-path new-account-fields))
        (handlers-macro/merge-fx cofx fx (transport/send (message.contact/ContactUpdate. name photo-path) nil))
        fx))))
+
+(defn clean-seed-phrase
+  "A helper function that removes seed phrase from storage."
+  [cofx]
+  (account-update {:seed-backed-up? true
+                   :mnemonic        nil}
+                  cofx))

--- a/src/status_im/ui/screens/profile/events.cljs
+++ b/src/status_im/ui/screens/profile/events.cljs
@@ -112,4 +112,4 @@
  (fn [{:keys [db] :as cofx} _]
    (handlers-macro/merge-fx cofx
                             {:db (update db :my-profile/seed assoc :step :finish :error nil :word nil)}
-                            (accounts.utils/account-update {:seed-backed-up? true}))))
+                            (accounts.utils/clean-seed-phrase))))

--- a/test/cljs/status_im/test/screens/accounts/utils.cljs
+++ b/test/cljs/status_im/test/screens/accounts/utils.cljs
@@ -1,0 +1,13 @@
+(ns status-im.test.screens.accounts.utils
+  (:require [clojure.test :refer-macros [deftest is]]
+            [status-im.ui.screens.accounts.utils :as accounts.utils]))
+
+(deftest test-account-update
+  (is (= (accounts.utils/account-update {} nil)
+         {:db                      {:account/account {}},
+          :data-store/save-account {:after-update-event nil}})))
+
+(deftest test-clean-seed-phrase
+  (is (= (accounts.utils/clean-seed-phrase nil)
+         {:db                      {:account/account {:seed-backed-up? true, :mnemonic nil}},
+          :data-store/save-account {:seed-backed-up? true, :mnemonic nil, :after-update-event nil}})))


### PR DESCRIPTION
fixes #4192 

### Summary:

When user confirms backing up seed phrase we clear out the `mnemonic` field from `account/account` in db.

status: ready 
