### PR TITLE
[fix 3346] remove unknown status subtitle from 1-1 chat

### DIFF
--- a/src/status_im/chat/styles/screen.cljs
+++ b/src/status_im/chat/styles/screen.cljs
@@ -46,13 +46,9 @@
   {:flex-direction :row
    :flex           1})
 
-(defnstyle chat-name-view [show-actions]
-  {:flex            1
-   :justify-content :center
-   :android         {:align-items    :flex-start
-                     :margin-left    (if show-actions 66 18)
-                     :padding-bottom 6}
-   :ios             {:align-items :center}})
+(defnstyle chat-name-view [has-subtitle?]
+  {:flex       1
+   :margin-top (if has-subtitle? 0 6)})
 
 (def chat-name-text
   {:color     component.styles/color-gray6


### PR DESCRIPTION

fixes #3346 

remove unknown status subtitle from 1-1 chat and move chat name to the left according to issue description

### Summary:

![screenshot from 2018-05-10 15-45-59](https://user-images.githubusercontent.com/1181225/39875895-2762defa-5472-11e8-8d8b-193985346ca5.png)

![screenshot from 2018-05-10 15-46-23](https://user-images.githubusercontent.com/1181225/39875901-296a9328-5472-11e8-8d12-694f6f489c39.png)


status: ready
