### PR TITLE
Fixes #3417: App crashed when accessing camera view but access to camera denied for app [iOS]

### DIFF
--- a/src/status_im/ui/components/camera.cljs
+++ b/src/status_im/ui/components/camera.cljs
@@ -22,7 +22,7 @@
 
 (defn request-access-ios [then else]
   (-> (.checkVideoAuthorizationStatus default-camera)
-      (.then then)
+      (.then (fn [allowed?] (if allowed? (then) (else))))
       (.catch else)))
 
 (defn camera [props]

--- a/src/status_im/ui/screens/wallet/components/views.cljs
+++ b/src/status_im/ui/screens/wallet/components/views.cljs
@@ -21,7 +21,8 @@
             [status-im.utils.ethereum.core :as ethereum]
             [status-im.utils.ethereum.tokens :as tokens]
             [status-im.utils.platform :as platform]
-            [status-im.ui.components.tooltip.views :as tooltip]))
+            [status-im.ui.components.tooltip.views :as tooltip]
+            [status-im.utils.utils :as utils]))
 
 (defn view-asset [symbol]
   [react/view
@@ -157,7 +158,9 @@
 
 (defn- request-camera-permissions []
   (re-frame/dispatch [:request-permissions {:permissions [:camera]
-                                            :on-allowed  #(re-frame/dispatch [:navigate-to :recipient-qr-code])}]))
+                                            :on-allowed  #(re-frame/dispatch [:navigate-to :recipient-qr-code])
+                                            :on-denied   #(utils/show-popup (i18n/label :t/error)
+                                                                            (i18n/label :t/camera-access-error))}]))
 
 (defn- on-choose-recipient [contact-only?]
   (list-selection/show {:title   (i18n/label :t/wallet-choose-recipient)


### PR DESCRIPTION
Fixes #3417: App crashed when accessing camera view but access to camera denied for app [iOS]

### Summary:

Added a verification of the returned result of the camera permission check according to [react-native-camera doc](https://github.com/react-native-community/react-native-camera/blob/master/docs/RCTCamera.md#ios-cameracheckdeviceauthorizationstatus-promise)

### Steps to test 1:
 -  Instal fresh build
 -  Open Status and create account
 -  Navigate to Profile -> Edit -> Edit profile image
 -  Tap 'Capture'
 -  On request to access camera pop up tap - 'Don't allow'

### Steps to test 2:
 -  Instal fresh build
 -  Open Status and create account
 -  Navigate to + -> Start new chat
 -  Tap on scan QR code button from 'Enter contact code' field
 -  On request to access camera pop up tap - 'Don't allow'

### Steps to test 3:
Precondition: App installed, account created and access to camera allowed before
 -  From device settings for app - disable access to 'Camera'
 -  Open Status
 -  Log in to account (or create a new one)
 -  Navigate to Wallet -> Send transaction -> Specify recipient
 -  Tap 'Scan QR code'

status: ready 
