### PR TITLE
[#4201] Prevent bad URLs from being opened in the browser

### DIFF
--- a/src/status_im/ui/components/toolbar/view.cljs
+++ b/src/status_im/ui/components/toolbar/view.cljs
@@ -54,8 +54,9 @@
 (defn nav-back-count
   ([]
    [nav-button-with-count actions/default-back])
-  ([{:keys [home?]}]
-   [nav-button-with-count (if home? actions/home-back actions/default-back)]))
+  ([{:keys [home?] :as props}]
+   [nav-button-with-count (merge (if home? actions/home-back actions/default-back)
+                                 (dissoc props :home?))]))
 
 (defn default-done
   "Renders a touchable icon on Android or a label or iOS."

--- a/src/status_im/ui/screens/add_new/open_dapp/views.cljs
+++ b/src/status_im/ui/screens/add_new/open_dapp/views.cljs
@@ -31,7 +31,7 @@
       [react/text-input {:on-change-text      #(reset! url-text %)
                          :on-submit-editing   #(do
                                                  (re-frame/dispatch [:navigate-to-clean :home])
-                                                 (re-frame/dispatch [:open-browser {:url @url-text}]))
+                                                 (re-frame/dispatch [:open-browser {:url @url-text} true]))
                          :placeholder         (i18n/label :t/enter-url)
                          :auto-capitalize     :none
                          :auto-correct        false

--- a/src/status_im/ui/screens/browser/db.cljs
+++ b/src/status_im/ui/screens/browser/db.cljs
@@ -13,6 +13,7 @@
 (spec/def :browser/can-go-back? (spec/nilable boolean?))
 (spec/def :browser/can-go-forward? (spec/nilable boolean?))
 (spec/def :browser/new? (spec/nilable boolean?))
+(spec/def :browser/error? (spec/nilable boolean?))
 
 (spec/def :browser/options
   (allowed-keys
@@ -20,7 +21,8 @@
             :browser/can-go-back?
             :browser/can-go-forward?
             :browser/fullscreen?
-            :browser/new?]))
+            :browser/new?
+            :browser/error?]))
 
 (spec/def :browser/browser
   (allowed-keys

--- a/src/status_im/ui/screens/browser/db.cljs
+++ b/src/status_im/ui/screens/browser/db.cljs
@@ -12,13 +12,15 @@
 (spec/def :browser/fullscreen? (spec/nilable boolean?))
 (spec/def :browser/can-go-back? (spec/nilable boolean?))
 (spec/def :browser/can-go-forward? (spec/nilable boolean?))
+(spec/def :browser/new? (spec/nilable boolean?))
 
 (spec/def :browser/options
   (allowed-keys
    :opt-un [:browser/browser-id
             :browser/can-go-back?
             :browser/can-go-forward?
-            :browser/fullscreen?]))
+            :browser/fullscreen?
+            :browser/new?]))
 
 (spec/def :browser/browser
   (allowed-keys

--- a/src/status_im/ui/screens/browser/events.cljs
+++ b/src/status_im/ui/screens/browser/events.cljs
@@ -46,10 +46,11 @@
 (handlers/register-handler-fx
  :open-browser
  [re-frame/trim-v]
- (fn [{:keys [now] :as cofx} [browser]]
+ (fn [{:keys [now] :as cofx} [browser new?]]
    (let [new-browser (get-new-browser browser now)]
      (merge (add-browser-fx cofx new-browser)
-            {:dispatch [:navigate-to :browser {:browser/browser-id (:browser-id new-browser)}]}))))
+            {:dispatch [:navigate-to :browser {:browser/browser-id (:browser-id new-browser)
+                                               :browser/new?       new?}]}))))
 
 (handlers/register-handler-fx
  :update-browser

--- a/src/status_im/ui/screens/browser/navigation.cljs
+++ b/src/status_im/ui/screens/browser/navigation.cljs
@@ -2,5 +2,6 @@
   (:require [status-im.ui.screens.navigation :as navigation]))
 
 (defmethod navigation/preload-data! :browser
-  [db [_ _ {:keys [browser/browser-id]}]]
-  (assoc db :browser/options {:browser-id browser-id}))
+  [db [_ _ {:keys [browser/browser-id browser/new?]}]]
+  (assoc db :browser/options {:browser-id browser-id
+                              :new?       new?}))

--- a/src/status_im/ui/screens/browser/navigation.cljs
+++ b/src/status_im/ui/screens/browser/navigation.cljs
@@ -2,6 +2,6 @@
   (:require [status-im.ui.screens.navigation :as navigation]))
 
 (defmethod navigation/preload-data! :browser
-  [db [_ _ {:keys [browser/browser-id browser/new?]}]]
+  [db [_ _ {:browser/keys [browser-id new?]}]]
   (assoc db :browser/options {:browser-id browser-id
                               :new?       new?}))

--- a/src/status_im/ui/screens/browser/views.cljs
+++ b/src/status_im/ui/screens/browser/views.cljs
@@ -14,7 +14,8 @@
             [status-im.ui.components.chat-icon.screen :as chat-icon.screen]
             [status-im.ui.components.icons.vector-icons :as vector-icons]
             [status-im.i18n :as i18n]
-            [status-im.utils.ethereum.core :as ethereum]))
+            [status-im.utils.ethereum.core :as ethereum]
+            [status-im.utils.utils :as utils]))
 
 (views/defview toolbar-content-dapp [contact-identity]
   (views/letsubs [contact [:get-contact-by-identity contact-identity]]
@@ -73,7 +74,7 @@
 (views/defview browser []
   (views/letsubs [webview (atom nil)
                   {:keys [address]} [:get-current-account]
-                  {:keys [dapp? contact url] :as browser} [:get-current-browser]
+                  {:keys [dapp? contact url browser-id] :as browser} [:get-current-browser]
                   {:keys [can-go-back? can-go-forward?]} [:get :browser/options]
                   extra-js [:web-view-extra-js]
                   rpc-url [:get :rpc-url]
@@ -95,6 +96,12 @@
          :local-storage-enabled                 true
          :start-in-loading-state                true
          :render-error                          web-view-error
+         :on-error                              (fn [_]
+                                                  (utils/show-popup "Error"
+                                                                    (i18n/label :t/web-view-error)
+                                                                    #(do
+                                                                       (re-frame/dispatch [:remove-browser browser-id])
+                                                                       (re-frame/dispatch [:navigation-replace :open-dapp]))))
          :render-loading                        web-view-loading
          :on-navigation-state-change            #(on-navigation-change % browser)
          :injected-on-start-loading-java-script (str js-res/web3

--- a/src/status_im/ui/screens/browser/views.cljs
+++ b/src/status_im/ui/screens/browser/views.cljs
@@ -6,6 +6,7 @@
             [status-im.ui.components.react :as react]
             [status-im.ui.screens.browser.styles :as styles]
             [status-im.ui.components.status-bar.view :as status-bar]
+            [status-im.ui.components.toolbar.actions :as toolbar.actions]
             [status-im.ui.components.toolbar.view :as toolbar.view]
             [status-im.ui.components.webview-bridge :as components.webview-bridge]
             [status-im.utils.js-resources :as js-res]
@@ -14,8 +15,7 @@
             [status-im.ui.components.chat-icon.screen :as chat-icon.screen]
             [status-im.ui.components.icons.vector-icons :as vector-icons]
             [status-im.i18n :as i18n]
-            [status-im.utils.ethereum.core :as ethereum]
-            [status-im.utils.utils :as utils]))
+            [status-im.utils.ethereum.core :as ethereum]))
 
 (views/defview toolbar-content-dapp [contact-identity]
   (views/letsubs [contact [:get-contact-by-identity contact-identity]]
@@ -73,9 +73,10 @@
 
 (views/defview browser []
   (views/letsubs [webview (atom nil)
+                  open-new-url-error? (atom false)
                   {:keys [address]} [:get-current-account]
                   {:keys [dapp? contact url browser-id] :as browser} [:get-current-browser]
-                  {:keys [can-go-back? can-go-forward?]} [:get :browser/options]
+                  {:keys [can-go-back? can-go-forward? new?] :as opts} [:get :browser/options]
                   extra-js [:web-view-extra-js]
                   rpc-url [:get :rpc-url]
                   unread-messages-number [:get-chats-unread-messages-number]
@@ -83,7 +84,10 @@
     [react/keyboard-avoiding-view styles/browser
      [status-bar/status-bar]
      [toolbar.view/toolbar {}
-      (toolbar.view/nav-back-count)
+      (if @open-new-url-error?
+        (toolbar.view/nav-button (toolbar.actions/back #(do (re-frame/dispatch [:navigate-back])
+                                                            (re-frame/dispatch [:remove-browser browser-id]))))
+        (toolbar.view/nav-back-count))
       (if dapp?
         [toolbar-content-dapp contact unread-messages-number]
         [toolbar-content browser unread-messages-number])]
@@ -96,12 +100,9 @@
          :local-storage-enabled                 true
          :start-in-loading-state                true
          :render-error                          web-view-error
-         :on-error                              (fn [_]
-                                                  (utils/show-popup "Error"
-                                                                    (i18n/label :t/web-view-error)
-                                                                    #(do
-                                                                       (re-frame/dispatch [:remove-browser browser-id])
-                                                                       (re-frame/dispatch [:navigation-replace :open-dapp]))))
+         :on-error                              #(when new?
+                                                   (re-frame/dispatch [:navigation-replace :open-dapp true])
+                                                   (reset! open-new-url-error? true))
          :render-loading                        web-view-loading
          :on-navigation-state-change            #(on-navigation-change % browser)
          :injected-on-start-loading-java-script (str js-res/web3

--- a/src/status_im/ui/screens/db.cljs
+++ b/src/status_im/ui/screens/db.cljs
@@ -90,7 +90,7 @@
 (spec/def :navigation/prev-view-id (spec/nilable keyword?))
 ;; navigation screen params
 (spec/def :navigation.screen-params/network-details (allowed-keys :req [:networks/selected-network]))
-(spec/def :navigation.screen-params/browser (allowed-keys :req [:browser/browser-id]))
+(spec/def :navigation.screen-params/browser (allowed-keys :req [:browser/browser-id] :opt [:browser/new?]))
 (spec/def :navigation.screen-params.profile-qr-viewer/contact (spec/nilable map?))
 (spec/def :navigation.screen-params.profile-qr-viewer/source (spec/nilable keyword?))
 (spec/def :navigation.screen-params.profile-qr-viewer/value (spec/nilable string?))


### PR DESCRIPTION
### Summary:

Fixes #4201 Stop adding navigation errors to Home screen



In the case of a bad search, the user should be returned to the "Open DApp" screen when navigating back. The bad search should not be presented as if it were a working DApp.

**Expected behavior**

User types a bad address into the URL bar of the "Open DApp" screen. Status presents an error.

User navigates back and is returned to the "Open DApp" screen.

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->
