### PR TITLE
feature #4199 - remove sign later and unsigned transactions

### DIFF
--- a/src/status_im/translations/en.cljs
+++ b/src/status_im/translations/en.cljs
@@ -534,7 +534,7 @@
    :transactions-sign-later              "Sign later"
    :transactions-delete                  "Delete transaction"
    :transactions-delete-content          "Transaction will be removed from 'Unsigned' list"
-   :transactions-history                 "History"
+   :transactions-history                 "Transaction history"
    :transactions-unsigned                "Unsigned"
    :transactions-history-empty           "No transactions in your history yet"
    :transactions-unsigned-empty          "You don't have any unsigned transactions"

--- a/src/status_im/ui/screens/wallet/events.cljs
+++ b/src/status_im/ui/screens/wallet/events.cljs
@@ -236,19 +236,6 @@
     :dispatch [:navigate-to-modal :wallet-send-transaction-modal]}))
 
 (handlers/register-handler-fx
- :wallet/discard-unsigned-transaction
- (fn [_ [_ transaction-id]]
-   {:discard-transaction transaction-id}))
-
-(handlers/register-handler-fx
- :wallet/discard-unsigned-transaction-with-confirmation
- (fn [_ [_ transaction-id]]
-   {:show-confirmation {:title               (i18n/label :t/transactions-delete)
-                        :content             (i18n/label :t/transactions-delete-content)
-                        :confirm-button-text (i18n/label :t/confirm)
-                        :on-accept           #(re-frame/dispatch [:wallet/discard-unsigned-transaction transaction-id])}}))
-
-(handlers/register-handler-fx
  :wallet/update-gas-price
  (fn [{:keys [db]} [_ edit?]]
    {:update-gas-price {:web3          (:web3 db)

--- a/src/status_im/ui/screens/wallet/send/events.cljs
+++ b/src/status_im/ui/screens/wallet/send/events.cljs
@@ -143,13 +143,13 @@
           ;;SEND TRANSACTION
          (= method constants/web3-send-transaction)
 
-         (let [{:keys [gas gasPrice]} args
-               transaction (prepare-transaction queued-transaction now)
+         (let [{:keys [gas gasPrice]}    args
+               transaction               (prepare-transaction queued-transaction now)
                sending-from-bot-or-dapp? (not (get-in db [:wallet :send-transaction :waiting-signal?]))
-               new-db (assoc-in db' [:wallet :transactions-unsigned id] transaction)
-               sending-db {:id         id
-                           :method     method
-                           :from-chat? sending-from-bot-or-dapp?}]
+               new-db                    (assoc-in db' [:wallet :transactions-unsigned id] transaction)
+               sending-db                {:id         id
+                                          :method     method
+                                          :from-chat? sending-from-bot-or-dapp?}]
            (if sending-from-bot-or-dapp?
               ;;SENDING FROM BOT (CHAT) OR DAPP
              {:db         (assoc-in new-db [:wallet :send-transaction] sending-db) ; we need to completely reset sending state here
@@ -159,19 +159,13 @@
                              [:wallet/update-estimated-gas transaction])
                            (when-not (seq gasPrice)
                              [:wallet/update-gas-price])]}
-              ;;WALLET SEND SCREEN WAITING SIGNAL
-             (let [{:keys [later? password]} (get-in db [:wallet :send-transaction])
-                   new-db' (update-in new-db [:wallet :send-transaction] merge sending-db)] ; just update sending state as we are in wallet flow
-               (if later?
-                  ;;SIGN LATER
-                 {:db                      (assoc-in new-db' [:wallet :send-transaction :waiting-signal?] false)
-                  :dispatch                [:navigate-back]
-                  ::show-transaction-moved false}
-                  ;;SIGN NOW
-                 {:db                  new-db'
-                  ::accept-transaction {:id           id
-                                        :password     password
-                                        :on-completed on-transactions-completed}}))))
+             ;;WALLET SEND SCREEN WAITING SIGNAL
+             (let [{:keys [password]} (get-in db [:wallet :send-transaction])
+                   new-db'            (update-in new-db [:wallet :send-transaction] merge sending-db)] ; just update sending state as we are in wallet flow
+               {:db                  new-db'
+                ::accept-transaction {:id           id
+                                      :password     password
+                                      :on-completed on-transactions-completed}})))
           ;;SIGN MESSAGE
          (= method constants/web3-personal-sign)
 

--- a/src/status_im/ui/screens/wallet/send/views.cljs
+++ b/src/status_im/ui/screens/wallet/send/views.cljs
@@ -88,11 +88,7 @@
         immediate-sign-enabled? (or modal? (and sign-enabled? sufficient-funds?))]
     [bottom-buttons/bottom-buttons
      styles/sign-buttons
-     (when sign-enabled?
-       [button/button {:style               components.styles/flex
-                       :on-press            sign-later-handler
-                       :accessibility-label :sign-later-button}
-        (i18n/label :t/transactions-sign-later)])
+     [react/view]
      [button/button {:style               components.styles/flex
                      :disabled?           (not immediate-sign-enabled?)
                      :on-press            #(re-frame/dispatch [:wallet.send/set-signing? true])


### PR DESCRIPTION
fixes #4199 

### Summary:

Removes Sign later in Wallet Send. Also removes Unsigned transactions tab in Transaction history

### Steps to test:
- Wallet > Send > Sign later should be gone
- Wallet > Transaction history > Unsigned should be gone, only history 


status: ready 