### PR TITLE
Handle mailserver connection error

### DIFF
--- a/src/status_im/translations/en.cljs
+++ b/src/status_im/translations/en.cljs
@@ -8,6 +8,7 @@
    :notifications-title                  "Notifications and sounds"
    :offline                              "Offline"
    :connection-problem                   "Messages connection problem"
+   :mailserver-reconnect                 "Could not connect to mailserver. Tap to reconnect"
    :search-for                           "Search for..."
    :cancel                               "Cancel"
    :next                                 "Next"

--- a/src/status_im/ui/components/connectivity/styles.cljs
+++ b/src/status_im/ui/components/connectivity/styles.cljs
@@ -1,7 +1,7 @@
 (ns status-im.ui.components.connectivity.styles
   (:require-macros [status-im.utils.styles :refer [defnstyle]]))
 
-(defnstyle offline-wrapper [top opacity window-width pending?]
+(defnstyle text-wrapper [top opacity window-width pending?]
   {:ios              {:z-index 0}
    :opacity          opacity
    :width            window-width
@@ -10,7 +10,7 @@
    :background-color "#828b92cc"
    :height           35})
 
-(def offline-text
+(def text
   {:text-align :center
    :color      :white
    :font-size  14

--- a/src/status_im/ui/components/connectivity/view.cljs
+++ b/src/status_im/ui/components/connectivity/view.cljs
@@ -31,11 +31,14 @@
       :display-name "connectivity-error-view"
       :reagent-render
       (fn [{:keys [top]}]
-        (when (or @offline? @connection-problem?)
+        (when-let [label (cond
+                           @offline? :t/offline
+                           @connection-problem? :t/mailserver-reconnect
+                           :else nil)]
           (let [pending? (and (:pending @current-chat-contact) (= :chat @view-id))]
-            [react/animated-view {:style (styles/offline-wrapper top offline-opacity window-width pending?)}
+            [react/animated-view {:style (styles/text-wrapper top offline-opacity window-width pending?)}
              [react/view
-              [react/text {:style styles/offline-text}
-               (i18n/label (if @connection-problem?
-                             :t/connection-problem
-                             :t/offline))]]])))})))
+              [react/text {:style    styles/text
+                           :on-press (when @connection-problem?
+                                       #(re-frame/dispatch [:inbox/reconnect]))}
+               (i18n/label label)]]])))})))


### PR DESCRIPTION
fixes #3787 

### Summary:

* Do not try to reconnect to mailserver when app is offline
* If app is online, but mailserver is disconnected, show notification to the user
* Tap on notification starts reconnecting process

### Testing notes (optional):
You could probably emulate mailserver disconnect by blocking IP 51.15.35.110 (for mainnet)

### Steps to test:
- Open Status
- Emulate mailserver disconnect
- Wait for couple of minutes for notification to appear (stay on Home screen or inside any chat)
- Tap on it to reconnect

status: ready
