### PR TITLE
Fast message grouping/sorting

### DIFF
--- a/src/status_im/chat/screen.cljs
+++ b/src/status_im/chat/screen.cljs
@@ -100,7 +100,7 @@
        message-view]]]))
 
 (defview messages-view [group-chat]
-  (letsubs [messages           [:get-current-chat-messages]
+  (letsubs [messages           [:get-current-chat-messages-stream]
             chat-id            [:get-current-chat-id]
             current-public-key [:get-current-public-key]]
     {:component-did-mount #(re-frame/dispatch [:set-chat-ui-props {:messages-focused? true

--- a/src/status_im/chat/specs.cljs
+++ b/src/status_im/chat/specs.cljs
@@ -15,6 +15,7 @@
 (s/def :chat/public-group-topic (s/nilable string?))
 (s/def :chat/public-group-topic-error (s/nilable string?))
 (s/def :chat/messages (s/nilable map?))                           ; messages indexed by message-id
+(s/def :chat/message-groups (s/nilable map?))                     ; grouped/sorted messages
 (s/def :chat/not-loaded-message-ids (s/nilable set?))             ; set of message-ids not yet fully loaded from persisted state
 (s/def :chat/last-clock-value (s/nilable number?))                ; last logical clock value of messages in chat
 (s/def :chat/loaded-chats (s/nilable seq?))

--- a/src/status_im/transport/message/v1/protocol.cljs
+++ b/src/status_im/transport/message/v1/protocol.cljs
@@ -99,8 +99,9 @@
     {:chat-received-message/add-fx
      [(assoc (into {} this)
              :message-id (transport.utils/message-id this)
-             :chat-id chat-id
-             :from signature)]}))
+             :show?      true
+             :chat-id    chat-id
+             :from       signature)]}))
 
 (defrecord MessagesSeen [message-ids]
   message/StatusMessage

--- a/src/status_im/ui/screens/db.cljs
+++ b/src/status_im/ui/screens/db.cljs
@@ -232,6 +232,7 @@
                  :chat/public-group-topic
                  :chat/public-group-topic-error
                  :chat/messages
+                 :chat/message-groups
                  :chat/not-loaded-message-ids
                  :chat/last-clock-value
                  :chat/loaded-chats

--- a/src/status_im/ui/screens/desktop/main/chat/views.cljs
+++ b/src/status_im/ui/screens/desktop/main/chat/views.cljs
@@ -111,7 +111,7 @@
     (let [_ (when (or (not @chat-id*) (not= @chat-id* chat-id))
               (reset! chat-id* chat-id)
               (js/setTimeout #(when scroll-ref (.scrollToEnd @scroll-ref)) 400))
-          messages (re-frame/subscribe [:get-current-chat-messages])
+          messages (re-frame/subscribe [:get-current-chat-messages-stream])
           current-public-key (re-frame/subscribe [:get-current-public-key])]
       [react/view {:style {:flex 1 :background-color :white :margin-horizontal 16}}
        [react/scroll-view {:scrollEventThrottle    16

--- a/src/status_im/ui/screens/group/chat_settings/events.cljs
+++ b/src/status_im/ui/screens/group/chat_settings/events.cljs
@@ -61,7 +61,9 @@
 (handlers/register-handler-fx
  :clear-history
  (fn [{{:keys [current-chat-id] :as db} :db} _]
-   {:db            (assoc-in db [:chats current-chat-id :messages] {})
+   {:db            (-> db
+                       (assoc-in [:chats current-chat-id :messages] {})
+                       (assoc-in [:chats current-chat-id :message-groups] {}))
     :data-store/tx [(messages-store/hide-messages-tx current-chat-id)]}))
 
 (handlers/register-handler-fx

--- a/src/status_im/utils/handlers_macro.cljs
+++ b/src/status_im/utils/handlers_macro.cljs
@@ -25,11 +25,15 @@
                            (select-keys new-fx mergable-keys)))
         {:merging-fx-with-common-keys common-keys}))))
 
-(defn merge-effects [{:keys [db] :as initial-cofx} handler args]
-  (reduce (fn [fx arg]
-            (let [temp-cofx (update-db initial-cofx fx)]
-              (safe-merge
-               fx
-               (handler arg temp-cofx))))
-          {:db db}
-          args))
+(defn merge-effects
+  ([{:keys [db] :as cofx} handler args]
+   (merge-effects {:db db} cofx handler args))
+  ([initial-fx {:keys [db] :as cofx} handler args]
+   (reduce (fn [fx arg]
+             (let [temp-cofx (update-db cofx fx)]
+               (safe-merge
+                fx
+                (handler arg temp-cofx))))
+           (or initial-fx
+               {:db db})
+           args)))

--- a/test/cljs/status_im/test/chat/subs.cljs
+++ b/test/cljs/status_im/test/chat/subs.cljs
@@ -3,57 +3,6 @@
             [status-im.constants :as const]
             [status-im.chat.subs :as s]))
 
-(deftest test-message-datemark-groups
-  (testing "it orders a map of messages by clock-values desc, breaking ties by message-id asc and removing hidden messages"
-    (let [message-1 {:show? true
-                     :message-id "doesn't matter 1"
-                     :clock-value 1}
-          message-2 {:show? true
-                     :message-id "doesn't matter 2"
-                     :clock-value 2}
-          message-3 {:show? true
-                     :message-id "does matter 2"
-                     :clock-value 3}
-          message-4 {:show? true
-                     :message-id "does matter 1"
-                     :clock-value 3}
-          hidden-message {:show? false
-                          :clock-value 1}
-          unordered-messages (->> [message-1
-                                   message-2
-                                   message-3
-                                   message-4
-                                   hidden-message]
-                                  (map (juxt :message-id identity))
-                                  shuffle ; clojure maps are sorted for n <= 32
-                                  (into {}))]
-      (is (= [message-4
-              message-3
-              message-2
-              message-1] (s/sort-messages unordered-messages))))))
-
-(deftest intersperse-datemarks
-  (testing "it mantains the order even when timestamps are across days"
-    (let [message-1 {:timestamp 946641600000} ; 1999}
-          message-2 {:timestamp 946728000000} ; 2000 this will displayed in 1999
-          message-3 {:timestamp 946641600000} ; 1999
-          message-4 {:timestamp 946728000000} ; 2000
-          ordered-messages [message-4
-                            message-3
-                            message-2
-                            message-1]
-          [m1 d1 m2 m3 m4 d2] (s/intersperse-datemarks ordered-messages)]
-      (is (= "Jan 1, 2000"
-             (:datemark m1)))
-      (is (= {:type :datemark
-              :value "Jan 1, 2000"} d1))
-      (is (= "Dec 31, 1999"
-             (:datemark m2)
-             (:datemark m3)
-             (:datemark m4)))
-      (is (= {:type :datemark
-              :value "Dec 31, 1999"} d2)))))
-
 (deftest message-stream-tests
   (testing "messages with no interspersed datemarks"
     (let [m1 {:from "1"


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

This PR implements significantly faster re-computation of chat messages stream.
Previously we always re-computed chat messages stream from scratch each time anything in `message-id->message` datastructure in `app-db` changed, that means even if just `:user-status` of one message was altered.
This computation was quite heavy especially because we needed to group messages according to their datemark (time/day-relative function) + need to re-sort all of them from scratch (grouping being ~ 3 more expensive then re-sorting).
So instead of doing that in subscriptions, this PR introduces new chat-specific `app-db` index called `:message-groups` which contains correctly grouped and sorted references to messages (+ additional expensive to compute data which is not "live", eq never changes, currently only `:timestamp-str`), like this:
```clj
{:message-groups {"today" '({:message-id 1 :timestamp-str "12:00 AM"}
                            {:message-id 2 :timestamp-str "3:00 PM"})}}
```
Everytime message is added to db through `status-im.chat.models.message/add-message` function, this index is updated (no re-grouping each time necessary) and messages in the affected datetime group are re-sorted (that's unfortunately necessary because of the possibility of out-of-band messages, nevertheless it's still better then before because at least, only one day worth of messages is re-sorted, not the **whole** currently loaded message history).

Care needs to be taken whenever the message is added/removed from db to update the `:message-group` index, but not when live message data (like statuses, etc.) is updated, that's exactly as easy as before.

Subscriptions are now significantly leaner and don't need to do any grouping and much less sorting (just sorting the groups itself is necessary).

Demonstrating the difference in time to re-compute between the "old way" and "new way", it's around 4x improvement (chat with ~300 messages, likely to be much more significant on slower platform then iOS simulator:)
![screen shot 2018-05-11 at 13 31 36](https://user-images.githubusercontent.com/1910609/39923849-a61d56e0-5525-11e8-8f23-9ee2baeeb02b.png)

Future improvement can be done by utilising  priority-queue (with priority function being message-ref -> message -> `:clock-value` function) instead of plain sequence for values in `:message-groups` map, but unfortunately unlike clojure, clojurescript doesn't offer such data-structure out of the box.

Additional thing which occurred to me was that chat datemarks (eq "today") or not "live", eq they were recomputed only when something in messages changed, but it could happen that nothing in messages changed, only time passed (with app and some chat being open), and suddenly, as midnight passes "today" group becomes "yesterday" group :)
In this PR, the behaviour (re-computation of the datemarks) is hooked into `add-message` function, so it happens each time new message is received or sent, but the right place to hook it into would be some periodic event, like `:sync-state`.

### Testing notes (optional):
Complete regression testing with focus on performance with larger number of messages in chat (ideally chat history spanning multiple days) + making sure that chat messages are still being rendered correctly

status: ready
