### PR TITLE
[ISSUE #4166] Fixed incorrect DApps name changes

### DIFF
--- a/src/status_im/ui/screens/browser/events.cljs
+++ b/src/status_im/ui/screens/browser/events.cljs
@@ -26,9 +26,9 @@
     (:url browser)
     (update :url match-url)))
 
-(defn add-browser-fx [{:keys [db now] :as cofx} browser]
+(defn add-browser-fx [{:keys [db now]} browser]
   (let [new-browser (get-new-browser browser now)]
-    {:db           (update-in db [:browser/browsers (:browser-id new-browser)] merge new-browser)
+    {:db                      (update-in db [:browser/browsers (:browser-id new-browser)] merge new-browser)
      :data-store/save-browser new-browser}))
 
 (handlers/register-handler-fx
@@ -54,7 +54,7 @@
 (handlers/register-handler-fx
  :update-browser
  [re-frame/trim-v]
- (fn [{:keys [db now] :as cofx} [browser]]
+ (fn [{:keys [now] :as cofx} [browser]]
    (let [new-browser (get-new-browser browser now)]
      (-> (add-browser-fx cofx new-browser)
          (update-in [:db :browser/options] #(assoc % :browser-id (:browser-id new-browser)))))))
@@ -62,7 +62,7 @@
 (handlers/register-handler-fx
  :update-browser-options
  [re-frame/trim-v]
- (fn [{:keys [db now] :as cofx} [options]]
+ (fn [{:keys [db]} [options]]
    {:db (update db :browser/options merge options)}))
 
 (handlers/register-handler-fx

--- a/src/status_im/ui/screens/browser/views.cljs
+++ b/src/status_im/ui/screens/browser/views.cljs
@@ -61,9 +61,9 @@
     [components/activity-indicator {:animating true}]]))
 
 (defn on-navigation-change [event browser]
-  (let [{:strs [url title canGoBack canGoForward]} (js->clj event)]
+  (let [{:strs [url canGoBack canGoForward]} (js->clj event)]
     (when-not (= "about:blank" url)
-      (re-frame/dispatch [:update-browser (assoc browser :url url :name title)]))
+      (re-frame/dispatch [:update-browser (assoc browser :url url)]))
     (re-frame/dispatch [:update-browser-options {:can-go-back? canGoBack :can-go-forward? canGoForward}])))
 
 (defn get-inject-js [url]


### PR DESCRIPTION
fixes #4166

### Summary:

Do not update DApp name when inserted as contact.

### Steps to test:

- Open Status
- Add a DApp
- While loading, go back to home screen
- Contact name is correct

status: ready 
