### PR TITLE
introduce from parameter for mailserver requests

### DIFF
--- a/src/status_im/data_store/realm/schemas/base/core.cljs
+++ b/src/status_im/data_store/realm/schemas/base/core.cljs
@@ -1,6 +1,7 @@
 (ns status-im.data-store.realm.schemas.base.core
   (:require [status-im.data-store.realm.schemas.base.v1.core :as v1]
-            [status-im.data-store.realm.schemas.base.v2.core :as v2]))
+            [status-im.data-store.realm.schemas.base.v2.core :as v2]
+            [status-im.data-store.realm.schemas.base.v3.core :as v3]))
 
 ;; put schemas ordered by version
 (def schemas [{:schema        v1/schema
@@ -8,4 +9,7 @@
                :migration     v1/migration}
               {:schema        v2/schema
                :schemaVersion 2
-               :migration     v2/migration}])
+               :migration     v2/migration}
+              {:schema        v3/schema
+               :schemaVersion 3
+               :migration     v3/migration}])

--- a/src/status_im/data_store/realm/schemas/base/v3/account.cljs
+++ b/src/status_im/data_store/realm/schemas/base/v3/account.cljs
@@ -1,0 +1,27 @@
+(ns status-im.data-store.realm.schemas.base.v3.account)
+
+(def schema {:name       :account
+             :primaryKey :address
+             :properties {:address               :string
+                          :public-key            :string
+                          :name                  {:type :string :optional true}
+                          :email                 {:type :string :optional true}
+                          :status                {:type :string :optional true}
+                          :debug?                {:type :bool :default false}
+                          :photo-path            :string
+                          :signing-phrase        {:type :string}
+                          :mnemonic              {:type :string}
+                          :last-updated          {:type :int :default 0}
+                          :last-sign-in          {:type :int :default 0}
+                          :signed-up?            {:type    :bool
+                                                  :default false}
+                          :network               :string
+                          :networks              {:type       :list
+                                                  :objectType :network}
+                          :last-request          {:type :int :optional true}
+                          :settings              {:type :string}
+                          :sharing-usage-data?   {:type :bool :default false}
+                          :dev-mode?             {:type :bool :default false}
+                          :seed-backed-up?       {:type :bool :default false}
+                          :wallet-set-up-passed? {:type    :bool
+                                                  :default false}}})

--- a/src/status_im/data_store/realm/schemas/base/v3/core.cljs
+++ b/src/status_im/data_store/realm/schemas/base/v3/core.cljs
@@ -1,0 +1,10 @@
+(ns status-im.data-store.realm.schemas.base.v3.core
+  (:require [status-im.data-store.realm.schemas.base.v1.network :as network]
+            [status-im.data-store.realm.schemas.base.v3.account :as account]
+            [taoensso.timbre :as log]))
+
+(def schema [network/schema
+             account/schema])
+
+(defn migration [old-realm new-realm]
+  (log/debug "migrating base database v3: " old-realm new-realm))

--- a/src/status_im/transport/inbox.cljs
+++ b/src/status_im/transport/inbox.cljs
@@ -219,18 +219,25 @@
  :inbox/request-messages
  (fn [{:keys [db now]} [_ {:keys [from topics discover?]}]]
    (let [web3       (:web3 db)
+         account    (:account/account db)
          wnode      (get-current-wnode-address db)
          topics     (or topics
                         (map #(:topic %) (vals (:transport/chats db))))
-         from       (or from (:inbox/last-request db) nil)
-         sym-key-id (:inbox/sym-key-id db)]
-     {::request-messages {:wnode      wnode
-                          :topics     (if discover?
-                                        (conj topics (transport.utils/get-topic constants/contact-discovery))
-                                        topics)
-                          ;;TODO (yenda) fix from, right now mailserver is dropping us
-                          ;;when we send a requestMessage with a from field
-                          ;;:from       from
-                          :sym-key-id sym-key-id
-                          :web3       web3}
-      :db (assoc db :inbox/last-request (quot now 1000))})))
+         from       (or from (:last-request account))
+         sym-key-id (:inbox/sym-key-id db)
+         now-in-s   (quot now 1000)
+         fx         {:data-store/save-account (assoc account :last-request now-in-s)
+                     :db                      (assoc-in db [:account/account :last-request] now-in-s)}]
+     (if from
+       ;; NOTE (yenda) we ensure a delay of 10 seconds between mailserver requests
+       (when (< 10 (- now-in-s from))
+         (merge fx
+                {::request-messages       {:wnode      wnode
+                                           :topics     (if discover?
+                                                         (conj topics
+                                                               (transport.utils/get-topic constants/contact-discovery))
+                                                         topics)
+                                           :from       from
+                                           :sym-key-id sym-key-id
+                                           :web3       web3}}))
+       fx))))

--- a/src/status_im/transport/message/v1/contact.cljs
+++ b/src/status_im/transport/message/v1/contact.cljs
@@ -76,8 +76,8 @@
     (let [message-id (transport.utils/message-id this)
           public-keys (remove nil? (map :public-key (vals (:contacts/contacts db))))]
       (handlers-macro/merge-fx cofx
-                               (protocol/multi-send-with-pubkey {:public-keys public-keys
-                                                                 :payload     this}))))
+                               (protocol/multi-send-by-pubkey {:public-keys public-keys
+                                                               :payload     this}))))
   (receive [this chat-id signature cofx]
     (let [message-id (transport.utils/message-id this)]
       (when (protocol/is-new? message-id)

--- a/src/status_im/transport/message/v1/group_chat.cljs
+++ b/src/status_im/transport/message/v1/group_chat.cljs
@@ -20,10 +20,10 @@
   message/StatusMessage
   (send [this _ cofx]
     (let [public-keys (get-in cofx [:db :chats chat-id :contacts])]
-      (protocol/multi-send-with-pubkey {:public-keys public-keys
-                                        :chat-id     chat-id
-                                        :payload     this}
-                                       cofx)))
+      (protocol/multi-send-by-pubkey {:public-keys public-keys
+                                      :chat-id     chat-id
+                                      :payload     this}
+                                     cofx)))
   (receive [this _ signature {:keys [db] :as cofx}]
     (handlers-macro/merge-fx cofx
                              {:shh/add-new-sym-key {:web3       (:web3 db)
@@ -129,4 +129,3 @@
                                                                  (str participant-leaving-name " " (i18n/label :t/left))))
                                  (group/participants-removed chat-id #{signature})
                                  (send-new-group-key nil chat-id))))))
-

--- a/src/status_im/transport/message/v1/protocol.cljs
+++ b/src/status_im/transport/message/v1/protocol.cljs
@@ -62,10 +62,11 @@
 
 (defn- prepare-recipients [public-keys db]
   (map (fn [public-key]
-         (select-keys (get-in db [:transport/chats public-key]) [:topic :sym-key-id]))
+         (assoc (select-keys (get-in db [:transport/chats public-key]) [:topic :sym-key-id])
+                :public-key public-key))
        public-keys))
 
-(defn multi-send-with-pubkey
+(defn multi-send-by-pubkey
   "Sends payload to multiple participants selected by `:public-keys` key. "
   [{:keys [payload public-keys success-event]} {:keys [db] :as cofx}]
   (let [{:keys [current-public-key web3]} db

--- a/src/status_im/transport/shh.cljs
+++ b/src/status_im/transport/shh.cljs
@@ -82,11 +82,11 @@
        :or {error-event :protocol/send-status-message-error}}]
    (let [whisper-message (update message :payload (comp transport.utils/from-utf8
                                                         transit/serialize))]
-     (doseq [{:keys [sym-key-id topic]} recipients]
+     (doseq [{:keys [sym-key-id topic public-key]} recipients]
        (post-message {:web3            web3
-                      :whisper-message (assoc whisper-message
-                                              :topic topic
-                                              :symKeyID sym-key-id)
+                      :whisper-message (cond-> (assoc whisper-message :topic topic)
+                                         sym-key-id       (assoc :symKeyID sym-key-id)
+                                         (not sym-key-id) (assoc :pubKey   public-key))
                       :on-success      (if success-event
                                          #(re-frame/dispatch success-event)
                                          #(log/debug :shh/post-success))

--- a/src/status_im/ui/screens/accounts/db.cljs
+++ b/src/status_im/ui/screens/accounts/db.cljs
@@ -18,6 +18,7 @@
 (spec/def :account/signed-up? (spec/nilable boolean?))
 (spec/def :account/last-updated (spec/nilable int?))
 (spec/def :account/last-sign-in (spec/nilable int?))
+(spec/def :account/last-request (spec/nilable int?))
 (spec/def :account/photo-path (spec/nilable string?))
 (spec/def :account/debug? (spec/nilable boolean?))
 (spec/def :account/status (spec/nilable string?))
@@ -40,7 +41,7 @@
                                       :account/networks :account/settings :account/wnode
                                       :account/last-sign-in :account/sharing-usage-data? :account/dev-mode?
                                       :account/seed-backed-up? :account/mnemonic
-                                      :account/wallet-set-up-passed?]))
+                                      :account/wallet-set-up-passed? :account/last-request]))
 
 (spec/def :accounts/accounts (spec/nilable (spec/map-of :account/address :accounts/account)))
 


### PR DESCRIPTION
- starts at current time so that nothing is fetched from mailserver when
recovering account
- still fetches history of a public chat when joining

Steps to test:
- create new account, open public chat, history should be fetched
- restore an account, nothing should be fetched
- be @chadyj  and have a slow client, update to this version and check if it's faster

Part of #4387

status: ready
