### PR TITLE
[FIX #1200] updates to webview with bugfix for external links in webview

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6226,7 +6226,7 @@
       }
     },
     "react-native-webview-bridge": {
-      "version": "github:status-im/react-native-webview-bridge#9b40cce26f1732772dbbeac11fe2fda44fb8703c",
+      "version": "github:status-im/react-native-webview-bridge#80a798c4004bf38bf4e965e38a6f6bc59557278d",
       "requires": {
         "invariant": "2.2.0",
         "keymirror": "0.1.1"

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "react-native-tcp": "3.3.0",
     "react-native-testfairy": "2.10.0",
     "react-native-udp": "2.2.1",
-    "react-native-webview-bridge": "github:status-im/react-native-webview-bridge#fix-web3-injection",
+    "react-native-webview-bridge": "github:status-im/react-native-webview-bridge",
     "realm": "2.3.3",
     "rn-snoopy": "github:status-im/rn-snoopy",
     "string_decoder": "0.10.31",


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

Fixes #1200

### Summary:

[comment]: # (Summarise the problem and how the pull request solves it)
In iOS, links with target="_blank" or intended to open in new window will no longer open in safari, but will be navigated to in the in-app webview. Updates react-native-webview-bridge dependency to latest version which addressed this bug.

### Steps to test:
- Open Status
- Navigate to chat or console and enter a link to browse (bug was documented on the google search results page)
- Click on several links (any of the search results that go to a non google.com domain) to see if any of them open in safari.

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->
