### PR TITLE
[#4227] Allow DApps to identify status host

### DIFF
--- a/resources/js/web3_init.js
+++ b/resources/js/web3_init.js
@@ -22,6 +22,8 @@ var StatusHttpProvider = function (host, timeout) {
     this.timeout = timeout || 0;
 };
 
+StatusHttpProvider.prototype.isStatus = true;
+
 function syncResponse(payload, result){
     return {id: payload.id,
             jsonrpc: "2.0",


### PR DESCRIPTION


fixes #4227

### Summary:

DApps can now detect status using `web3.currentProvider.isStatus`.

status: ready 
