### PR TITLE
Rename multi-send-with-pubkey into multi-send-by-pub-key

### DIFF
--- a/src/status_im/transport/message/v1/contact.cljs
+++ b/src/status_im/transport/message/v1/contact.cljs
@@ -76,8 +76,8 @@
     (let [message-id (transport.utils/message-id this)
           public-keys (remove nil? (map :public-key (vals (:contacts/contacts db))))]
       (handlers-macro/merge-fx cofx
-                               (protocol/multi-send-with-pubkey {:public-keys public-keys
-                                                                 :payload     this}))))
+                               (protocol/multi-send-by-pubkey {:public-keys public-keys
+                                                               :payload     this}))))
   (receive [this chat-id signature cofx]
     (let [message-id (transport.utils/message-id this)]
       (when (protocol/is-new? message-id)

--- a/src/status_im/transport/message/v1/group_chat.cljs
+++ b/src/status_im/transport/message/v1/group_chat.cljs
@@ -20,10 +20,10 @@
   message/StatusMessage
   (send [this _ cofx]
     (let [public-keys (get-in cofx [:db :chats chat-id :contacts])]
-      (protocol/multi-send-with-pubkey {:public-keys public-keys
-                                        :chat-id     chat-id
-                                        :payload     this}
-                                       cofx)))
+      (protocol/multi-send-by-pubkey {:public-keys public-keys
+                                      :chat-id     chat-id
+                                      :payload     this}
+                                     cofx)))
   (receive [this _ signature {:keys [db] :as cofx}]
     (handlers-macro/merge-fx cofx
                              {:shh/add-new-sym-key {:web3       (:web3 db)
@@ -129,4 +129,3 @@
                                                                  (str participant-leaving-name " " (i18n/label :t/left))))
                                  (group/participants-removed chat-id #{signature})
                                  (send-new-group-key nil chat-id))))))
-

--- a/src/status_im/transport/message/v1/protocol.cljs
+++ b/src/status_im/transport/message/v1/protocol.cljs
@@ -65,7 +65,7 @@
          (select-keys (get-in db [:transport/chats public-key]) [:topic :sym-key-id]))
        public-keys))
 
-(defn multi-send-with-pubkey
+(defn multi-send-by-pubkey
   "Sends payload to multiple participants selected by `:public-keys` key. "
   [{:keys [payload public-keys success-event]} {:keys [db] :as cofx}]
   (let [{:keys [current-public-key web3]} db


### PR DESCRIPTION
previous naming was confusing because it actually sends using
the symkey of each chat whose simkey is passed as an argument

This is just a renaming for clarity doesn't really need a testing cycle

status: ready <!-- Can be ready or wip -->
