### PR TITLE
[fix] add public-key when adding contact

### DIFF
--- a/src/status_im/ui/screens/contacts/core.cljs
+++ b/src/status_im/ui/screens/contacts/core.cljs
@@ -19,8 +19,7 @@
                          :fcm-token        fcm-token
                          :pending?         true}
           chat-props    {:name         name
-                         :chat-id      public-key
-                         :contact-info (prn-str contact-props)}]
+                         :chat-id      public-key}]
       (handlers-macro/merge-fx cofx
                                {:db            (update-in db [:contacts/contacts public-key]
                                                           merge contact-props)


### PR DESCRIPTION
Previously the public-key wasn't added when a contact was added until
a contact-request-confirmation was received. This was causing contact-update
not to be sent to contacts whose confirmation was not received yet when user
was updating his profile.

Part of https://github.com/status-im/status-react/issues/4212

# test

- create account A and B
- add contact B with A
- do not accept A with B
- update profile of A
- A profile should be updated on B

status: ready