### PR TITLE
handle multiple incoming messages at once

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3046,6 +3046,468 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
+    "fsevents": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.3.tgz",
+      "integrity": "sha512-X+57O5YkDTiEQGiw8i7wYc2nQgweIekqkepI8Q3y4wVlurgBt2SuwxTeYUYMZIGpLZH3r/TsMjczCMXE5ZOt7Q==",
+      "optional": true,
+      "requires": {
+        "nan": "2.10.0",
+        "node-pre-gyp": "0.9.1"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "aproba": {
+          "version": "1.2.0",
+          "bundled": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "delegates": "1.0.0",
+            "readable-stream": "2.3.6"
+          }
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "chownr": {
+          "version": "1.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.4.2",
+          "bundled": true,
+          "optional": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.3",
+          "bundled": true,
+          "optional": true
+        },
+        "fs-minipass": {
+          "version": "1.2.5",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "minipass": "2.2.4"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "aproba": "1.2.0",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "iconv-lite": {
+          "version": "0.4.21",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "safer-buffer": "2.1.2"
+          }
+        },
+        "ignore-walk": {
+          "version": "3.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "minimatch": "3.0.4"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "ini": {
+          "version": "1.3.5",
+          "bundled": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "1.1.11"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true
+        },
+        "minipass": {
+          "version": "2.2.4",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.1.1",
+            "yallist": "3.0.2"
+          }
+        },
+        "minizlib": {
+          "version": "1.1.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "minipass": "2.2.4"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "needle": {
+          "version": "2.2.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "debug": "2.6.9",
+            "iconv-lite": "0.4.21",
+            "sax": "1.2.4"
+          }
+        },
+        "node-pre-gyp": {
+          "version": "0.9.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "detect-libc": "1.0.3",
+            "mkdirp": "0.5.1",
+            "needle": "2.2.0",
+            "nopt": "4.0.1",
+            "npm-packlist": "1.1.10",
+            "npmlog": "4.1.2",
+            "rc": "1.2.6",
+            "rimraf": "2.6.2",
+            "semver": "5.5.0",
+            "tar": "4.4.1"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1.1.1",
+            "osenv": "0.1.5"
+          }
+        },
+        "npm-bundled": {
+          "version": "1.0.3",
+          "bundled": true,
+          "optional": true
+        },
+        "npm-packlist": {
+          "version": "1.1.10",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "ignore-walk": "3.0.1",
+            "npm-bundled": "1.0.3"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.5",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.6",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "deep-extend": "0.4.2",
+            "ini": "1.3.5",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.1",
+          "bundled": true
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true,
+          "optional": true
+        },
+        "sax": {
+          "version": "1.2.4",
+          "bundled": true,
+          "optional": true
+        },
+        "semver": {
+          "version": "5.5.0",
+          "bundled": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "4.4.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "chownr": "1.0.1",
+            "fs-minipass": "1.2.5",
+            "minipass": "2.2.4",
+            "minizlib": "1.1.0",
+            "mkdirp": "0.5.1",
+            "safe-buffer": "5.1.1",
+            "yallist": "3.0.2"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "string-width": "1.0.2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "yallist": {
+          "version": "3.0.2",
+          "bundled": true
+        }
+      }
+    },
     "fstream": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
@@ -4875,6 +5337,12 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
     },
+    "nan": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
+      "optional": true
+    },
     "nanomatch": {
       "version": "1.2.9",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
@@ -6655,6 +7123,7 @@
         "capture-exit": "1.2.0",
         "exec-sh": "0.2.1",
         "fb-watchman": "2.0.0",
+        "fsevents": "1.2.3",
         "micromatch": "3.1.10",
         "minimist": "1.2.0",
         "walker": "1.0.7",
@@ -7780,7 +8249,7 @@
       }
     },
     "web3": {
-      "version": "github:status-im/web3.js#d8bd6a834cae4f677d2745cb79314b7c53959fcf",
+      "version": "github:status-im/web3.js#47318ea76453ced83efa8538825c17d0c4e4b86b",
       "requires": {
         "bignumber.js": "github:status-im/bignumber.js#cc066a0a3d6bfe0c436c9957f4ea8344bf963c89",
         "crypto-js": "3.1.8",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,6 @@
     "rn-snoopy": "github:status-im/rn-snoopy",
     "string_decoder": "0.10.31",
     "url": "0.10.3",
-    "web3": "github:status-im/web3.js#extshh_post"
+    "web3": "github:status-im/web3.js#experiment/filter"
   }
 }

--- a/src/status_im/chat/events/commands.cljs
+++ b/src/status_im/chat/events/commands.cljs
@@ -35,12 +35,12 @@
             jail-params {:parameters params
                          :context    (generate-context address chat-id (models.message/group-message? message) to)}]
         {:db        db
-         :call-jail {:jail-id                bot
-                     :path                   path
-                     :params                 jail-params
-                     :callback-event-creator (fn [jail-response]
-                                               [::jail-command-data-response
-                                                jail-response message opts])}})
+         :call-jail [{:jail-id                bot
+                      :path                   path
+                      :params                 jail-params
+                      :callback-event-creator (fn [jail-response]
+                                                [::jail-command-data-response
+                                                 jail-response message opts])}]})
       {:db (update-in db [:contacts/contacts bot :jail-loaded-events]
                       conj [:request-command-message-data message opts])})))
 

--- a/src/status_im/chat/events/console.cljs
+++ b/src/status_im/chat/events/console.cljs
@@ -35,16 +35,17 @@
 
 (defn- faucet-response-event [message-id content]
   [:chat-received-message/add
-   (console-chat/console-message {:message-id message-id
-                                  :content content
-                                  :content-type constants/text-content-type})])
+   [(console-chat/console-message
+     {:message-id   message-id
+      :content      content
+      :content-type constants/text-content-type})]])
 
 (def console-commands->fx
   {"faucet"
    (fn [{:keys [db random-id] :as cofx} {:keys [params]}]
      (let [current-address (get-in db [:account/account :address])
-           faucet-url (faucet-base-url->url (:url params))]
-       {:http-get {:url (gstring/format faucet-url current-address)
+           faucet-url      (faucet-base-url->url (:url params))]
+       {:http-get {:url                   (gstring/format faucet-url current-address)
                    :success-event-creator (fn [_]
                                             (faucet-response-event
                                              random-id
@@ -62,12 +63,12 @@
                                 {:dispatch-n (if debug?
                                                [[:initialize-debugging {:force-start? true}]
                                                 [:chat-received-message/add
-                                                 (console-chat/console-message
-                                                  {:message-id random-id
-                                                   :content (i18n/label :t/debug-enabled)
-                                                   :content-type constants/text-content-type})]]
+                                                 [(console-chat/console-message
+                                                   {:message-id   random-id
+                                                    :content      (i18n/label :t/debug-enabled)
+                                                    :content-type constants/text-content-type})]]]
                                                [[:stop-debugging]])}
-                                (account.utils/account-update {:debug? debug?
+                                (account.utils/account-update {:debug?       debug?
                                                                :last-updated now}))))})
 
 (def commands-names (set (keys console-commands->fx)))

--- a/src/status_im/chat/events/input.cljs
+++ b/src/status_im/chat/events/input.cljs
@@ -145,15 +145,15 @@
                      :context    {:data data
                                   :from from
                                   :to   to}}]
-        {:call-jail {:jail-id owner-id
-                     :path    path
-                     :params  params
-                     :callback-event-creator (fn [jail-response]
-                                               [:chat-received-message/bot-response
-                                                {:chat-id         current-chat-id
-                                                 :command         command
-                                                 :parameter-index parameter-index}
-                                                jail-response])}}))))
+        {:call-jail [{:jail-id                owner-id
+                      :path                   path
+                      :params                 params
+                      :callback-event-creator (fn [jail-response]
+                                                [:chat-received-message/bot-response
+                                                 {:chat-id         current-chat-id
+                                                  :command         command
+                                                  :parameter-index parameter-index}
+                                                 jail-response])}]}))))
 
 (defn chat-input-focus
   "Returns fx for focusing on active chat input reference"

--- a/src/status_im/chat/models/message.cljs
+++ b/src/status_im/chat/models/message.cljs
@@ -280,8 +280,8 @@
 
 (defn- add-console-responses
   [command handler-data {:keys [random-id-seq]}]
-  {:dispatch-n (->> (console-events/console-respond-command-messages command handler-data random-id-seq)
-                    (mapv (partial vector :chat-received-message/add)))})
+  {:dispatch (->> (console-events/console-respond-command-messages command handler-data random-id-seq)
+                  (vector :chat-received-message/add))})
 
 (defn send-command
   [{{:keys [current-public-key chats] :as db} :db :keys [now] :as cofx} params]
@@ -322,12 +322,12 @@
                                            :message-id      id}
                                     (:async-handler command)
                                     (assoc :orig-params orig-params))}]
-    {:call-jail {:jail-id                 identity
-                 :path                    [handler-type [name scope-bitmask] :handler]
-                 :params                  jail-params
-                 :callback-event-creator (fn [jail-response]
-                                           (when-not (:async-handler command)
-                                             [:command-handler! chat-id orig-params jail-response]))}}))
+    {:call-jail [{:jail-id                identity
+                  :path                   [handler-type [name scope-bitmask] :handler]
+                  :params                 jail-params
+                  :callback-event-creator (fn [jail-response]
+                                            (when-not (:async-handler command)
+                                              [:command-handler! chat-id orig-params jail-response]))}]}))
 
 (defn process-command
   [cofx {:keys [command chat-id] :as params}]

--- a/src/status_im/transport/handlers.cljs
+++ b/src/status_im/transport/handlers.cljs
@@ -18,16 +18,25 @@
             [status-im.transport.message.v1.group-chat :as v1.group-chat]
             [status-im.data-store.transport :as transport-store]))
 
+(defn receive-message [cofx chat-id message]
+  (let [{:keys [payload sig]} message
+        status-message (-> payload
+                           transport.utils/to-utf8
+                           transit/deserialize)]
+    (when (and sig status-message)
+      (message/receive status-message (or chat-id sig) sig cofx))))
+
+(defn receive-whisper-messages [cofx [js-error js-messages chat-id]]
+  (handlers-macro/merge-effects
+   cofx
+   (fn [message temp-cofx]
+     (receive-message temp-cofx chat-id message))
+   (js->clj js-messages :keywordize-keys true)))
+
 (handlers/register-handler-fx
  :protocol/receive-whisper-message
  [re-frame/trim-v (re-frame/inject-cofx :random-id)]
- (fn [cofx [js-error js-message chat-id]]
-   (let [{:keys [payload sig]} (js->clj js-message :keywordize-keys true)
-         status-message        (-> payload
-                                   transport.utils/to-utf8
-                                   transit/deserialize)]
-     (when (and sig status-message)
-       (message/receive status-message (or chat-id sig) sig cofx)))))
+ receive-whisper-messages)
 
 (handlers/register-handler-fx
  :protocol/send-status-message-success

--- a/src/status_im/transport/message/v1/contact.cljs
+++ b/src/status_im/transport/message/v1/contact.cljs
@@ -22,9 +22,9 @@
                                             :topic      topic
                                             :message    message}]))]
       (handlers-macro/merge-fx cofx
-                               {:shh/add-new-sym-key {:web3       (get-in cofx [:db :web3])
-                                                      :sym-key    sym-key
-                                                      :on-success on-success}}
+                               {:shh/add-new-sym-keys [{:web3       (get-in cofx [:db :web3])
+                                                        :sym-key    sym-key
+                                                        :on-success on-success}]}
                                (protocol/init-chat chat-id topic)))))
 
 (defrecord ContactRequest [name profile-image address fcm-token]
@@ -39,8 +39,8 @@
                                             :topic      topic
                                             :message    this}]))]
       (handlers-macro/merge-fx cofx
-                               {:shh/get-new-sym-key {:web3       (:web3 db)
-                                                      :on-success on-success}}
+                               {:shh/get-new-sym-keys [{:web3       (:web3 db)
+                                                        :on-success on-success}]}
                                (protocol/init-chat chat-id topic))))
   (receive [this chat-id signature {:keys [db] :as cofx}]
     (contacts/receive-contact-request signature this cofx)))

--- a/src/status_im/transport/message/v1/protocol.cljs
+++ b/src/status_im/transport/message/v1/protocol.cljs
@@ -96,10 +96,11 @@
         (send params cofx)
         (send-with-pubkey params cofx))))
   (receive [this chat-id signature cofx]
-    {:dispatch [:chat-received-message/add (assoc (into {} this)
-                                                  :message-id (transport.utils/message-id this)
-                                                  :chat-id    chat-id
-                                                  :from       signature)]}))
+    {:chat-received-message/add-fx
+     [(assoc (into {} this)
+             :message-id (transport.utils/message-id this)
+             :chat-id chat-id
+             :from signature)]}))
 
 (defrecord MessagesSeen [message-ids]
   message/StatusMessage

--- a/src/status_im/transport/shh.cljs
+++ b/src/status_im/transport/shh.cljs
@@ -133,26 +133,31 @@
                                  (on-success chat-id sym-key sym-key-id))
                    :on-error   log-error}))))
 
-(re-frame/reg-fx
- :shh/add-new-sym-key
- (fn [{:keys [web3 sym-key on-success]}]
-   (add-sym-key {:web3       web3
-                 :sym-key    sym-key
-                 :on-success (fn [sym-key-id]
-                               (on-success sym-key sym-key-id))
-                 :on-error   log-error})))
+(defn add-new-sym-key [{:keys [web3 sym-key on-success]}]
+  (add-sym-key {:web3       web3
+                :sym-key    sym-key
+                :on-success (fn [sym-key-id]
+                              (on-success sym-key sym-key-id))
+                :on-error   log-error}))
 
 (re-frame/reg-fx
- :shh/get-new-sym-key
- (fn [{:keys [web3 on-success]}]
-   (new-sym-key {:web3       web3
-                 :on-success (fn [sym-key-id]
-                               (get-sym-key {:web3       web3
-                                             :sym-key-id sym-key-id
-                                             :on-success (fn [sym-key]
-                                                           (on-success sym-key sym-key-id))
-                                             :on-error   log-error}))
-                 :on-error   log-error})))
+ :shh/add-new-sym-keys
+ (fn [args]
+   (doseq [add-new-sym-key-params args]
+     (add-new-sym-key add-new-sym-key-params))))
+
+(re-frame/reg-fx
+ :shh/get-new-sym-keys
+ (fn [args]
+   (doseq [{:keys [web3 on-success]} args]
+     (new-sym-key {:web3       web3
+                   :on-success (fn [sym-key-id]
+                                 (get-sym-key {:web3       web3
+                                               :sym-key-id sym-key-id
+                                               :on-success (fn [sym-key]
+                                                             (on-success sym-key sym-key-id))
+                                               :on-error   log-error}))
+                   :on-error   log-error}))))
 
 (re-frame/reg-fx
  :shh/generate-sym-key-from-password

--- a/src/status_im/ui/screens/events.cljs
+++ b/src/status_im/ui/screens/events.cljs
@@ -92,14 +92,15 @@
 
 (re-frame/reg-fx
  :call-jail
- (fn [{:keys [callback-event-creator] :as opts}]
-   (status/call-jail
-    (-> opts
-        (dissoc :callback-event-creator)
-        (assoc :callback
-               (fn [jail-response]
-                 (when-let [event (callback-event-creator jail-response)]
-                   (re-frame/dispatch event))))))))
+ (fn [args]
+   (doseq [{:keys [callback-event-creator] :as opts} args]
+     (status/call-jail
+      (-> opts
+          (dissoc :callback-event-creator)
+          (assoc :callback
+                 (fn [jail-response]
+                   (when-let [event (callback-event-creator jail-response)]
+                     (re-frame/dispatch event)))))))))
 
 (re-frame/reg-fx
  :call-jail-function

--- a/src/status_im/utils/mixpanel.cljs
+++ b/src/status_im/utils/mixpanel.cljs
@@ -128,10 +128,13 @@
          (filter (fn [{:keys [filter-fn]}]
                    (or (not filter-fn) (filter-fn db event))))
 
-         (map (fn [{:keys [data-fn] :as trigger}]
-                (if data-fn
-                  (update trigger :properties merge (data-fn db event))
-                  trigger))))))
+         (mapcat (fn [{:keys [data-fn] :as trigger}]
+                   (if data-fn
+                     (let [data (data-fn db event)]
+                       (if (map? data)
+                         [(update trigger :properties merge data)]
+                         (map (partial update trigger :properties merge) data)))
+                     [trigger]))))))
 
 (defn force-tracking? [event-name]
   (and config/force-sr-ratio-tracking

--- a/src/status_im/utils/mixpanel_events.cljs
+++ b/src/status_im/utils/mixpanel_events.cljs
@@ -219,9 +219,17 @@
    {:label      "SRratio"
     :trigger    [:chat-received-message/add]
     :properties {:target :user-message-received}
-    :filter-fn  (fn [db [_ {:keys [message-type] :as message}]]
-                  (and (= :user-message message-type)
-                       (message-model/add-to-chat? {:db db} message)))
-    :data-fn    (fn [db [_ {:keys [message-id message-type]}]]
-                  {:message-type message-type
-                   :message-id   message-id})}])
+    :filter-fn  (fn [db [_ messages]]
+                  (some
+                   (fn [{:keys [message-type] :as message}]
+                     (and (= :user-message message-type)
+                          (message-model/add-to-chat? {:db db} message)))
+                   messages))
+    :data-fn    (fn [db [_ messages]]
+                  (keep
+                   (fn [{:keys [message-id message-type] :as message}]
+                     (when (and (= :user-message message-type)
+                                (message-model/add-to-chat? {:db db} message))
+                       {:message-type message-type
+                        :message-id   message-id}))
+                   messages))}])


### PR DESCRIPTION
Idea of this PR https://github.com/status-im/status-react/pull/4260 is to make changes to web3 so that all messages received from go-ethereum side as a batch are sent to client all together, instead of separate event for each. https://github.com/status-im/web3.js/commit/47318ea76453ced83efa8538825c17d0c4e4b86b#diff-2ccb13c15898607b8166dd84c582b56dL124

Thus all these messages are handled together in react app. 
I run the next test:

1. sent 100 messages to empty chat when chat is opened. Measured time between calling http://offsite.chat:8099/ping/ and first rendered message with “PING no 99X”
2. went back to chats list. Sent same 1000 messages. Measured time between http://offsite.chat:8099/ping/ and appearing of label with 100 unread messages
3. went again to chat, waited for all messages to be rendered. Then sent 1000 messages again an d measured time as in 1.

for develop results are 
02:00,41 (minutes:seconds)
02:24,03
02:09,71

for experiment
00:54,76
00:35,02
01:01,17

Though for 100 messages results are less noticeable:

Old
00:12,53
00:08,01
00:17,24

New
00:10,02
00:04,58
00:15,54

status: ready
