### PR TITLE
[fix #4282] mailserver selection bugs and random attribution for new accounts

### DIFF
--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -34,13 +34,6 @@
            ;; TODO(jeluard) Restore once we support postponing transaction
            #_{:id :postponed :label (i18n/label :t/postponed) :checked? true}]}})
 
-(def default-account-settings
-  {:wallet {:visible-tokens {:testnet #{:STT :ATT}
-                             :mainnet #{:SNT}}}
-   :wnode {:testnet "main"
-           :mainnet "main"
-           :rinkeby "main"}})
-
 (defn- transform-config [networks]
   (->> networks
        (map (fn [[network-name {:keys [config] :as data}]]
@@ -89,24 +82,31 @@
           mainnet-networks)))
 
 (def default-wnodes
-  {:testnet {"main" {:id      "main"
-                     :name    "Status mailserver A"
-                     :address "enode://1da276e34126e93babf24ec88aac1a7602b4cbb2e11b0961d0ab5e989ca9c261aa7f7c1c85f15550a5f1e5a5ca2305b53b9280cf5894d5ecf7d257b173136d40@167.99.209.61:30504"}
-             "backup" {:id      "backup"
-                       :name    "Status mailserver B"
-                       :address "enode://07ac64fe0e9b2d4ecbfe0ccaeab3d8d95fa8858754f511104bb403b19255d7bf47a8416bdd0df01f6720ff82164451b7a028c93d15ddd37b7e8382d74e91ebc2@167.99.209.72:30504"}}
-   :mainnet {"main" {:id      "main"
-                     :name    "Status mailserver A"
-                     :address "enode://1da276e34126e93babf24ec88aac1a7602b4cbb2e11b0961d0ab5e989ca9c261aa7f7c1c85f15550a5f1e5a5ca2305b53b9280cf5894d5ecf7d257b173136d40@167.99.209.61:30504"}
-             "backup" {:id      "backup"
-                       :name    "Status mailserver B"
-                       :address "enode://07ac64fe0e9b2d4ecbfe0ccaeab3d8d95fa8858754f511104bb403b19255d7bf47a8416bdd0df01f6720ff82164451b7a028c93d15ddd37b7e8382d74e91ebc2@167.99.209.72:30504"}}
-   :rinkeby {"main" {:id     "main"
-                     :name   "Status mailserver A"
-                     :address "enode://43829580446ad138386dadb7fa50b6bd4d99f7c28659a0bc08115f8c0380005922a340962496f6af756a42b94a1522baa38a694fa27de59c3a73d4e08d5dbb31@206.189.6.48:30504"}
-             "backup" {:id      "backup"
-                       :name    "Status mailserver B"
-                       :address "enode://70a2004e78399075f566033c42e9a0b1d43c683d4742755bb5457d03191be66a1b48c2b4fb259696839f28646a5828a1958b900860e27897f984ad0fc8482404@206.189.56.154:30504"}}})
+  {:testnet {"mailserver-a" {:id      "mailserver-a"
+                             :name    "Status mailserver A"
+                             :address "enode://1da276e34126e93babf24ec88aac1a7602b4cbb2e11b0961d0ab5e989ca9c261aa7f7c1c85f15550a5f1e5a5ca2305b53b9280cf5894d5ecf7d257b173136d40@167.99.209.61:30504"}
+             "mailserver-b" {:id      "mailserver-b"
+                             :name    "Status mailserver B"
+                             :address "enode://07ac64fe0e9b2d4ecbfe0ccaeab3d8d95fa8858754f511104bb403b19255d7bf47a8416bdd0df01f6720ff82164451b7a028c93d15ddd37b7e8382d74e91ebc2@167.99.209.72:30504"}}
+   :mainnet {"mailserver-a" {:id      "mailserver-a"
+                             :name    "Status mailserver A"
+                             :address "enode://1da276e34126e93babf24ec88aac1a7602b4cbb2e11b0961d0ab5e989ca9c261aa7f7c1c85f15550a5f1e5a5ca2305b53b9280cf5894d5ecf7d257b173136d40@167.99.209.61:30504"}
+             "mailserver-b" {:id      "mailserver-b"
+                             :name    "Status mailserver B"
+                             :address "enode://07ac64fe0e9b2d4ecbfe0ccaeab3d8d95fa8858754f511104bb403b19255d7bf47a8416bdd0df01f6720ff82164451b7a028c93d15ddd37b7e8382d74e91ebc2@167.99.209.72:30504"}}
+   :rinkeby {"mailserver-a" {:id     "mailserver-a"
+                             :name   "Status mailserver A"
+                             :address "enode://43829580446ad138386dadb7fa50b6bd4d99f7c28659a0bc08115f8c0380005922a340962496f6af756a42b94a1522baa38a694fa27de59c3a73d4e08d5dbb31@206.189.6.48:30504"}
+             "mailserver-b" {:id      "mailserver-b"
+                             :name    "Status mailserver B"
+                             :address "enode://70a2004e78399075f566033c42e9a0b1d43c683d4742755bb5457d03191be66a1b48c2b4fb259696839f28646a5828a1958b900860e27897f984ad0fc8482404@206.189.56.154:30504"}}})
+
+(defn default-account-settings []
+  {:wallet {:visible-tokens {:testnet #{:STT :ATT}
+                             :mainnet #{:SNT}}}
+   :wnode {:testnet (rand-nth (keys (:testnet default-wnodes)))
+           :mainnet (rand-nth (keys (:mainnet default-wnodes)))
+           :rinkeby (rand-nth (keys (:rinkeby default-wnodes)))}})
 
 (def currencies
   {:aed {:id :aed :code "AED" :display-name (i18n/label :t/currency-display-name-aed) :symbol "د.إ"}

--- a/src/status_im/ui/screens/accounts/events.cljs
+++ b/src/status_im/ui/screens/accounts/events.cljs
@@ -78,7 +78,7 @@
                              :photo-path          (identicon pubkey)
                              :signing-phrase      signing-phrase
                              :mnemonic            mnemonic
-                             :settings            constants/default-account-settings}]
+                             :settings            (constants/default-account-settings)}]
      (log/debug "account-created")
      (when-not (str/blank? pubkey)
        (-> (add-account db account)

--- a/src/status_im/ui/screens/accounts/recover/events.cljs
+++ b/src/status_im/ui/screens/accounts/recover/events.cljs
@@ -39,7 +39,7 @@
                      :mnemonic              ""
                      :signed-up?            true
                      :signing-phrase        phrase
-                     :settings              constants/default-account-settings
+                     :settings              (constants/default-account-settings)
                      :wallet-set-up-passed? true}]
      (when-not (string/blank? public-key)
        (-> db


### PR DESCRIPTION
fix #4282
- current wnode is randomly selected for new and recovered accounts and saved
- fix bug when changing mailserver config because encryption key was not
provided for realm file
- fix bug when logging out with mixpanel tracking because
:unregister-mixpanel-tracking event was removed some time ago

status: ready <!-- Can be ready or wip -->
