### PR TITLE
search explicitly for release/xyz tags

### DIFF
--- a/Jenkinsfile.nightly_fastlane
+++ b/Jenkinsfile.nightly_fastlane
@@ -33,7 +33,7 @@ node ('macos1'){
       checkout scm
 
       sh 'git fetch --tags'
-      latest_tag = sh(returnStdout: true, script: 'git describe --tags `git rev-list --tags --max-count=1`').trim()
+      latest_tag = sh(returnStdout: true, script: 'git describe --tags `git rev-list --tags=release --max-count=1`').trim()
       sh 'git tag -d ' + latest_tag
       sh 'rm -rf node_modules'
       sh 'cp .env.nightly .env'


### PR DESCRIPTION
This fixes the latest nightly build that failed because of `Jenkinsfile.nightly_fastlane` assuming the only tags in the repo are `release/xyz` tags, this resulted in:
```
[Transporter Error Output]: ERROR ITMS-90060: "This bundle is invalid. The value for key CFBundleShortVersionString 'build-2428' in the Info.plist file must be a period-separated list of at most three non-negative integers."
```
https://jenkins.status.im/job/status-react/job/nightly/383/consoleFull

<blockquote></blockquote>