### PR TITLE
[#3946] Improved webview error rendering

### DIFF
--- a/src/status_im/translations/en.cljs
+++ b/src/status_im/translations/en.cljs
@@ -398,7 +398,7 @@
    :postponed                            "Postponed"
 
    ;;webview
-   :web-view-error                       "oops, error"
+   :web-view-error                       "Unable to load page"
 
    ;;testfairy warning
    :testfairy-title                      "Warning!"

--- a/src/status_im/ui/screens/browser/styles.cljs
+++ b/src/status_im/ui/screens/browser/styles.cljs
@@ -42,9 +42,13 @@
    :justify-content :center})
 
 (def web-view-error
-  {:justify-content :center
-   :align-items     :center
-   :flex-direction  :row})
+  {:flex             1
+   :justify-content  :center
+   :align-items      :center
+   :background-color colors/gray-lighter})
+
+(def web-view-error-text
+  {:color colors/gray})
 
 (defnstyle toolbar-content [show-actions]
   {:flex-direction     :row

--- a/src/status_im/ui/screens/browser/views.cljs
+++ b/src/status_im/ui/screens/browser/views.cljs
@@ -50,10 +50,15 @@
          [react/view
           [vector-icons/icon :icons/refresh]]]]]))
 
-(defn web-view-error []
+(defn- web-view-error [_ code desc]
   (reagent/as-element
    [react/view styles/web-view-error
-    [react/text (i18n/label :t/web-view-error)]]))
+    [react/text {:style styles/web-view-error-text}
+     (i18n/label :t/web-view-error)]
+    [react/text {:style styles/web-view-error-text}
+     (str code)]
+    [react/text {:style styles/web-view-error-text}
+     (str desc)]]))
 
 (defn web-view-loading []
   (reagent/as-element


### PR DESCRIPTION
fixes #3946

### Summary:

Improve webview error rendering. Note the data itself is incorrect (error code always -1). This will be addressed in another PR.

UPD: not always, same URL (http://j in my case) - shows error code -1 on Android and -1003 on IOS.

### Steps to test:
- Open Status
- Navigate an incorrect URL
- See the new error rendering

status: ready