### PR TITLE
[TESTS] Added new e2e tests

### DIFF
--- a/test/appium/tests/base_test_case.py
+++ b/test/appium/tests/base_test_case.py
@@ -68,6 +68,11 @@ class AbstractTestCase:
         desired_caps['ignoreUnimportantViews'] = False
         return desired_caps
 
+    def update_capabilities_sauce_lab(self, key, value):
+        caps = self.capabilities_sauce_lab.copy()
+        caps[key] = value
+        return caps
+
     @property
     def capabilities_local(self):
         desired_caps = dict()
@@ -167,10 +172,14 @@ class SauceMultipleDeviceTestCase(AbstractTestCase):
         self.drivers = dict()
 
     def create_drivers(self, quantity=2):
+        if self.__class__.__name__ == 'TestOfflineMessages':
+            capabilities = self.update_capabilities_sauce_lab('platformVersion', '6.0')
+        else:
+            capabilities = self.capabilities_sauce_lab
         self.drivers = self.loop.run_until_complete(start_threads(quantity, webdriver.Remote,
                                                     self.drivers,
                                                     self.executor_sauce_lab,
-                                                    self.capabilities_sauce_lab))
+                                                    capabilities))
         for driver in range(quantity):
             self.drivers[driver].implicitly_wait(self.implicitly_wait)
             BaseView(self.drivers[driver]).accept_agreements()

--- a/test/appium/tests/marks.py
+++ b/test/appium/tests/marks.py
@@ -2,6 +2,9 @@ import pytest
 
 pr = pytest.mark.pr
 testrail_case_id = pytest.mark.testrail_case_id
-chat = pytest.mark.chat
+
 all = pytest.mark.all
+chat = pytest.mark.chat
+chat_management = pytest.mark.chat_management
 transaction = pytest.mark.transaction
+wallet = pytest.mark.wallet

--- a/test/appium/tests/test_messaging.py
+++ b/test/appium/tests/test_messaging.py
@@ -1,8 +1,7 @@
 import random
 import string
-import pytest
 import emoji
-
+import time
 from tests.base_test_case import MultipleDeviceTestCase
 from tests import group_chat_users, get_current_time, marks
 from views.sign_in_view import SignInView
@@ -149,30 +148,197 @@ class TestMessages(MultipleDeviceTestCase):
         users = []
         chat_name = ''.join(random.choice(string.ascii_lowercase) for _ in range(7))
         for sign_in in device_1, device_2:
-            sign_in.create_user()
+            users.append(sign_in.create_user())
             home = sign_in.get_home_view()
-            profile = home.profile_button.click()
-            users.append(profile.username_text.text)
-            profile.home_button.click()
             home.join_public_chat(chat_name)
         chat_1, chat_2 = device_1.get_chat_view(), device_2.get_chat_view()
 
-        messages_to_send_1 = ['/command', '%s %s' % (unicode_text_message, unicode_chinese), 'This is text message.']
-        for message in messages_to_send_1:
-            chat_1.chat_message_input.send_keys(message)
-            chat_1.send_message_button.click()
-        chat_2.wait_for_messages(users[0], messages_to_send_1, self.errors)
+        chat_1.chat_message_input.send_keys('/command')
+        chat_1.send_message_button.click()
 
         message_with_emoji = 'message with emoji'
-        messages_to_send_2 = [emoji.emojize(emoji_name), emoji.emojize('%s %s' % (message_with_emoji, emoji_name_1))]
-        messages_to_receive_2 = [emoji_unicode, '%s %s' % (message_with_emoji, emoji_unicode_1), message_with_new_line]
-        for message in messages_to_send_2:
-            chat_2.chat_message_input.send_keys(message)
-            chat_2.send_message_button.click()
+
+        chat_2.chat_message_input.send_keys(emoji.emojize(emoji_name))
+        chat_2.send_message_button.click()
+
+        chat_1.chat_message_input.send_keys('%s %s' % (unicode_text_message, unicode_chinese))
+        chat_1.send_message_button.click()
+
+        chat_2.chat_message_input.send_keys('%s %s' % (message_with_emoji, emoji_unicode_1))
+        chat_2.send_message_button.click()
+
+        chat_1.chat_message_input.send_keys('This is text message.')
+        chat_1.send_message_button.click()
+
         chat_2.chat_message_input.click()
         chat_2.send_as_keyevent(message_with_new_line)
         chat_2.send_message_button.click()
-        chat_1.wait_for_messages(users[1], messages_to_receive_2, self.errors)
+
+        messages_from_user_2 = [emoji_unicode, '%s %s' % (message_with_emoji, emoji_unicode_1), message_with_new_line]
+        chat_1.wait_for_messages(users[1], messages_from_user_2, self.errors)
+        chat_1.verify_username_is_shown_per_message(users[1], messages_from_user_2, self.errors)
+
+        messages_from_user_1 = ['/command', '%s %s' % (unicode_text_message, unicode_chinese), 'This is text message.']
+        chat_2.wait_for_messages(users[0], messages_from_user_1, self.errors)
+        chat_2.verify_username_is_shown_per_message(users[0], messages_from_user_1, self.errors)
+
         for chat in chat_1, chat_2:
             chat.delete_chat(chat_name, self.errors)
+        self.verify_no_errors()
+
+    @marks.testrail_case_id(3423)
+    def test_username_and_profile_picture_in_chats(self):
+        self.create_drivers(2)
+        device_1, device_2 = SignInView(self.drivers[0]), SignInView(self.drivers[1])
+        username_1, username_2 = device_1.create_user(), device_2.create_user()
+        home_1, home_2 = device_1.get_home_view(), device_2.get_home_view()
+
+        device_2_public_key = home_2.get_public_key()
+        profile_2 = home_2.get_profile_view()
+        file_name = 'sauce_logo.png'
+        profile_2.edit_profile_picture(file_name)
+
+        home_1.add_contact(device_2_public_key)
+        profile_2.home_button.click()
+        chat_2 = home_2.get_chat_with_user(username_1).click()
+        chat_2.add_to_contacts.click()
+
+        chat_1 = home_1.get_chat_view()
+        time.sleep(3)
+        if chat_1.user_name_text.text != username_2:
+            self.errors.append("Real username '%s' is not shown in one-to-one chat" % username_2)
+        chat_1.chat_options.click()
+        chat_1.view_profile_button.click()
+        if not chat_1.contact_profile_picture.is_element_image_equals_template(file_name):
+            self.errors.append("Updated profile picture is not shown in one-to-one chat")
+
+        home_1.get_back_to_home_view()
+        chat_name = 'a_chat_%s' % get_current_time()
+        home_1.create_group_chat([username_2], chat_name)
+        group_chat_1 = home_1.get_chat_view()
+
+        home_2.get_back_to_home_view()
+        group_chat_2 = home_2.get_chat_with_user(chat_name).click()
+        message_text = 'test message'
+        group_chat_2.chat_message_input.send_keys(message_text)
+        group_chat_2.send_message_button.click()
+
+        group_chat_1.wait_for_messages(username_2, message_text, self.errors)
+        group_chat_1.verify_username_is_shown_per_message(username_2, message_text, self.errors)
+        self.verify_no_errors()
+
+    @marks.testrail_case_id(3429)
+    def test_copy_and_paste_messages(self):
+        self.create_drivers(1)
+        sign_in = SignInView(self.drivers[0])
+        sign_in.create_user()
+        home = sign_in.get_home_view()
+        home.join_public_chat(''.join(random.choice(string.ascii_lowercase) for _ in range(7)))
+        chat = sign_in.get_chat_view()
+        message_text = 'test'
+        message_input = chat.chat_message_input
+        message_input.send_keys(message_text)
+        chat.send_message_button.click()
+
+        # copy text message
+        chat.chat_element_by_text(message_text).long_press_element()
+        chat.element_by_text('Copy to clipboard').click()
+
+        # paste text into the input field
+        message_input.paste_text_from_clipboard()
+        assert message_input.text == message_text
+
+        # delete part of the message
+        message_input.delete_last_symbols(2)
+        assert message_input.text == message_text[:-2]
+
+        # cut message text
+        message_input.cut_text()
+
+        # paste selected text
+        message_input.paste_text_from_clipboard()
+        chat.send_message_button.click()
+
+        # verify correct text is sent
+        chat.chat_element_by_text(message_text[:-2] + ' ')
+
+
+@marks.all
+@marks.chat
+class TestOfflineMessages(MultipleDeviceTestCase):
+
+    @marks.testrail_case_id(3420)
+    def test_offline_messaging_1_1_chat(self):
+        self.create_drivers(2)
+        device_1, device_2 = self.drivers[0], self.drivers[1]
+        sign_in_1, sign_in_2 = SignInView(device_1), SignInView(device_2)
+        username_1 = sign_in_1.create_user()
+        sign_in_2.create_user()
+        home_1, home_2 = sign_in_1.get_home_view(), sign_in_2.get_home_view()
+        device_2_public_key = home_2.get_public_key()
+        home_1.add_contact(device_2_public_key)
+        chat_1 = home_1.get_chat_view()
+        profile_2 = home_2.get_profile_view()
+        profile_2.logout()
+        device_2.set_network_connection(1)  # airplane mode
+
+        message_text = 'test message'
+        chat_1.chat_message_input.send_keys(message_text)
+        chat_1.send_message_button.click()
+
+        sign_in_2.click_account_by_position(0)
+        sign_in_2.sign_in('qwerty1234')
+        sign_in_2.home_button.wait_for_visibility_of_element()
+
+        if not home_2.offline_label.is_element_displayed():
+            self.errors.append('Offline label is not shown on Home view while being offline')
+        chat_2 = home_2.get_chat_with_user(username_1).click()
+        if not chat_2.offline_label.is_element_displayed():
+            self.errors.append('Offline label is not shown on Chat view while being offline')
+        device_2.set_network_connection(2)  # turning on WiFi connection
+        chat_2.wait_for_message_in_one_to_one_chat(message_text, self.errors, wait_time=120)
+        self.verify_no_errors()
+
+    @marks.testrail_case_id(3430)
+    def test_offline_messaging_group_chat(self):
+        self.create_drivers(2)
+        device_1, device_2 = self.drivers[0], self.drivers[1]
+        sign_in_1, sign_in_2 = SignInView(device_1), SignInView(device_2)
+        username_1 = sign_in_1.create_user()
+        username_2 = sign_in_2.create_user()
+        home_1, home_2 = sign_in_1.get_home_view(), sign_in_2.get_home_view()
+
+        device_2_public_key = home_2.get_public_key()
+        home_1.add_contact(device_2_public_key)
+        home_1.get_back_to_home_view()
+
+        home_2.home_button.click()
+        chat_view_2 = home_2.get_chat_with_user(username_1).click()
+        chat_view_2.add_to_contacts.click()
+        chat_view_2.get_back_to_home_view()
+
+        chat_name = 'a_chat_%s' % get_current_time()
+        home_1.create_group_chat([username_2], chat_name)
+        chat_1 = home_1.get_chat_view()
+
+        chat_element_2 = home_2.get_chat_with_user(chat_name)
+        chat_element_2.wait_for_visibility_of_element()
+        device_2.set_network_connection(1)  # airplane mode
+
+        if not home_2.offline_label.is_element_displayed():
+            self.errors.append('Offline label is not shown on Home view while being offline')
+        chat_2 = chat_element_2.click()
+        if not chat_2.offline_label.is_element_displayed():
+            self.errors.append('Offline label is not shown on Chat view while being offline')
+
+        message_text = 'test message'
+        chat_1.chat_message_input.send_keys(message_text)
+        chat_1.send_message_button.click()
+
+        chat_1.get_back_to_home_view()
+        profile_1 = home_1.profile_button.click()
+        profile_1.logout()
+
+        device_2.set_network_connection(2)  # turning on WiFi connection
+        chat_2.wait_for_messages(username_1, message_text, self.errors, wait_time=120)
         self.verify_no_errors()

--- a/test/appium/tests/test_profile.py
+++ b/test/appium/tests/test_profile.py
@@ -34,7 +34,7 @@ class TestProfileView(SingleDeviceTestCase):
         self.verify_no_errors()
 
     @marks.pr
-    @pytest.mark.testrail_case_id(3396)
+    @marks.testrail_case_id(3396)
     def test_contact_profile_view(self):
         sign_in_view = SignInView(self.driver)
         sign_in_view.create_user()
@@ -69,7 +69,7 @@ class TestProfileView(SingleDeviceTestCase):
         desired_network.scroll_to_element()
         assert desired_network.is_element_displayed()
 
-    @pytest.mark.testrail_case_id(3398)
+    @marks.testrail_case_id(3398)
     def test_profile_picture(self):
         sign_in_view = SignInView(self.driver)
         sign_in_view.create_user()
@@ -80,7 +80,7 @@ class TestProfileView(SingleDeviceTestCase):
         if not profile_view.profile_picture.is_element_image_equals_template():
             pytest.fail('Profile picture was not updated')
 
-    @pytest.mark.testrail_case_id(3399)
+    @marks.testrail_case_id(3399)
     def test_backup_seed_phrase_and_recover_account(self):
         sign_in_view = SignInView(self.driver)
         sign_in_view.create_user(password='qwerty1234')
@@ -109,7 +109,7 @@ class TestProfileView(SingleDeviceTestCase):
         public_key_1 = home_view.get_public_key()
         assert public_key == public_key_1
 
-    @pytest.mark.testrail_case_id(3411)
+    @marks.testrail_case_id(3411)
     def test_faucet_console_command(self):
         sign_in_view = SignInView(self.driver)
         sign_in_view.create_user()
@@ -130,8 +130,7 @@ class TestProfileView(SingleDeviceTestCase):
         wallet_view.set_up_wallet()
         wallet_view.wait_balance_changed_on_wallet_screen()
 
-
-    @pytest.mark.testrail_case_id(3421)
+    @marks.testrail_case_id(3421)
     def test_switch_users(self):
         sign_in_view = SignInView(self.driver)
         for _ in range(3):
@@ -145,7 +144,7 @@ class TestProfileView(SingleDeviceTestCase):
         sign_in_view.sign_in_button.click()
         sign_in_view.home_button.wait_for_visibility_of_element()
 
-    @pytest.mark.testrail_case_id(3424)
+    @marks.testrail_case_id(3424)
     def test_incorrect_password(self):
         sign_in_view = SignInView(self.driver)
         sign_in_view.create_account_button.click()

--- a/test/appium/views/base_view.py
+++ b/test/appium/views/base_view.py
@@ -69,7 +69,7 @@ class OkButton(BaseButton):
 class ContinueButton(BaseButton):
     def __init__(self, driver):
         super(ContinueButton, self).__init__(driver)
-        self.locator = self.Locator.xpath_selector("//*[@text='CONTINUE']")
+        self.locator = self.Locator.xpath_selector("//*[@text='CONTINUE' or @text='Continue']")
 
 
 class HomeButton(BaseButton):
@@ -86,11 +86,6 @@ class WalletButton(BaseButton):
     def __init__(self, driver):
         super(WalletButton, self).__init__(driver)
         self.locator = self.Locator.accessibility_id('wallet-tab-button')
-
-    def click(self):
-        from views.wallet_view import TransactionsButton
-        self.click_until_presence_of_element(desired_element=TransactionsButton(self.driver), attempts=3)
-        return self.navigate()
 
     def navigate(self):
         from views.wallet_view import WalletView
@@ -151,6 +146,12 @@ class SendMessageButton(BaseButton):
         info('Tap on %s' % self.name)
 
 
+class OfflineLabelText(BaseText):
+    def __init__(self, driver):
+        super(OfflineLabelText, self).__init__(driver)
+        self.locator = self.Locator.text_selector('Offline')
+
+
 class BaseView(object):
     def __init__(self, driver):
         self.driver = driver
@@ -171,6 +172,7 @@ class BaseView(object):
         self.save_button = SaveButton(self.driver)
         self.done_button = DoneButton(self.driver)
         self.delete_button = DeleteButton(self.driver)
+        self.offline_label = OfflineLabelText(self.driver)
 
         self.apps_button = AppsButton(self.driver)
         self.status_app_icon = StatusAppIcon(self.driver)
@@ -219,13 +221,13 @@ class BaseView(object):
     def find_full_text(self, text, wait_time=60):
         info("Looking for full text: '%s'" % text)
         element = BaseElement(self.driver)
-        element.locator = element.Locator.xpath_selector('//*[@text="' + text + '"]')
+        element.locator = element.Locator.text_selector(text)
         return element.wait_for_element(wait_time)
 
     def find_text_part(self, text, wait_time=60):
         info("Looking for a text part: '%s'" % text)
         element = BaseElement(self.driver)
-        element.locator = element.Locator.xpath_selector('//*[contains(@text, "' + text + '")]')
+        element.locator = element.Locator.text_part_selector(text)
         return element.wait_for_element(wait_time)
 
     def element_by_text(self, text, element_type='button'):

--- a/test/appium/views/home_view.py
+++ b/test/appium/views/home_view.py
@@ -1,6 +1,6 @@
 from tests import info
 import time
-from selenium.common.exceptions import TimeoutException, NoSuchElementException
+from selenium.common.exceptions import TimeoutException
 from views.base_element import BaseButton, BaseText
 from views.base_view import BaseView
 
@@ -29,9 +29,9 @@ class ConsoleButton(BaseButton):
 
 
 class ChatElement(BaseButton):
-    def __init__(self, driver, username):
+    def __init__(self, driver, username_part):
         super(ChatElement, self).__init__(driver)
-        self.locator = self.Locator.xpath_selector("//*[@text='%s']" % username)
+        self.locator = self.Locator.xpath_selector("//*[starts-with(@text,'%s')]" % username_part)
 
     def navigate(self):
         from views.chat_view import ChatView
@@ -124,13 +124,9 @@ class HomeView(BaseView):
 
     def swipe_and_delete_chat(self, chat_name: str):
         chat_element = self.get_chat_with_user(chat_name)
-        location = chat_element.find_element().location
-        x, y = location['x'], location['y']
-        size = chat_element.find_element().size
-        width, height = size['width'], size['height']
         counter = 0
         while counter < 10:
-            self.driver.swipe(start_x=x + width / 2, start_y=y + height / 2, end_x=x, end_y=y + height / 2)
+            chat_element.swipe_element()
             if chat_element.swipe_delete_button.is_element_present():
                 break
             time.sleep(10)

--- a/test/appium/views/profile_view.py
+++ b/test/appium/views/profile_view.py
@@ -84,7 +84,7 @@ class LogoutDialog(BaseView):
     class LogoutButton(BaseButton):
         def __init__(self, driver):
             super(LogoutDialog.LogoutButton, self).__init__(driver)
-            self.locator = self.Locator.text_selector('LOG OUT')
+            self.locator = self.Locator.xpath_selector("//*[@text='LOG OUT' or @text='Log out']")
 
         def navigate(self):
             from views.sign_in_view import SignInView
@@ -285,17 +285,16 @@ class ProfileView(BaseView):
         return dict(zip(map(int, text[::2]), text[1::2]))
 
     def edit_profile_picture(self, file_name: str):
-        if AbstractTestCase().environment == 'sauce':
-            self.profile_picture.template = file_name
-            self.edit_button.click()
-            self.edit_picture_button.click()
-            self.select_from_gallery_button.click()
-            if self.allow_button.is_element_displayed(sec=10):
-                self.allow_button.click()
-            self.element_by_text(file_name).click()
-            self.confirm_button.click()
-        else:
+        if not AbstractTestCase().environment == 'sauce':
             raise NotImplementedError('Test case is implemented to run on SauceLabs only')
+        self.profile_picture.template = file_name
+        self.edit_button.click()
+        self.edit_picture_button.click()
+        self.select_from_gallery_button.click()
+        if self.allow_button.is_element_displayed(sec=10):
+            self.allow_button.click()
+        self.element_by_text(file_name).click()
+        self.confirm_button.click()
 
     def logout(self):
         self.logout_button.click()

--- a/test/appium/views/send_transaction_view.py
+++ b/test/appium/views/send_transaction_view.py
@@ -1,3 +1,5 @@
+from views.base_element import BaseButton, BaseEditBox, BaseText
+from views.base_view import BaseView
 from views.base_element import BaseElement, BaseButton, BaseEditBox
 from views.base_view import BaseView, OkButton
 
@@ -6,6 +8,12 @@ class FirstRecipient(BaseButton):
     def __init__(self, driver):
         super(FirstRecipient, self).__init__(driver)
         self.locator = self.Locator.accessibility_id('chat-icon')
+
+
+class CancelButton(BaseButton):
+    def __init__(self, driver):
+        super(CancelButton, self).__init__(driver)
+        self.locator = self.Locator.accessibility_id('cancel-button')
 
 
 class SignTransactionButton(BaseButton):
@@ -19,6 +27,12 @@ class AmountEditBox(BaseEditBox, BaseButton):
     def __init__(self, driver):
         super(AmountEditBox, self).__init__(driver)
         self.locator = self.Locator.accessibility_id('amount-input')
+
+
+class SignInPhraseText(BaseText):
+    def __init__(self, driver):
+        super(SignInPhraseText, self).__init__(driver)
+        self.locator = self.Locator.accessibility_id('signing-phrase-text')
 
 
 class PasswordInput(BaseEditBox):
@@ -107,8 +121,10 @@ class SendTransactionView(BaseView):
         self.recent_recipients_button = RecentRecipientsButton(self.driver)
 
         self.amount_edit_box = AmountEditBox(self.driver)
+        self.cancel_button = CancelButton(self.driver)
         self.sign_transaction_button = SignTransactionButton(self.driver)
         self.confirm_button = ConfirmButton(self.driver)
+        self.sign_in_phrase_text = SignInPhraseText(self.driver)
         self.password_input = PasswordInput(self.driver)
         self.enter_password_input = EnterPasswordInput(self.driver)
         self.got_it_button = GotItButton(self.driver)

--- a/test/appium/views/sign_in_view.py
+++ b/test/appium/views/sign_in_view.py
@@ -1,7 +1,7 @@
 from tests import get_current_time
 from views.base_element import BaseButton, BaseEditBox
 from views.base_view import BaseView
-
+import time
 
 class AccountButton(BaseButton):
 
@@ -104,11 +104,18 @@ class SignInView(BaseView):
         self.next_button.click()
         self.confirm_password_input.set_value(password)
         self.next_button.click()
-        self.name_input.wait_for_element(45)
-        self.name_input.send_keys('user_%s' % get_current_time())
+
+        # bypass StaleElementReferenceException
+        time.sleep(5)
+        self.name_input.wait_for_element(10)
+        self.name_input.click()
+        username = 'user_%s' % get_current_time()
+        self.send_as_keyevent(username)
+
         self.next_button.click()
-        self.do_not_share.wait_for_element(10)
+        self.do_not_share.wait_for_visibility_of_element(10)
         self.do_not_share.click_until_presence_of_element(self.home_button)
+        return username
 
     def recover_access(self, passphrase, password):
         recover_access_view = self.i_have_account_button.click()

--- a/test/appium/views/wallet_view.py
+++ b/test/appium/views/wallet_view.py
@@ -118,6 +118,13 @@ class SetUpButton(BaseButton):
         self.locator = self.Locator.text_selector("LET’S GET SET UP")
 
 
+class SignInPhraseText(BaseText):
+    def __init__(self, driver):
+        super(SignInPhraseText, self).__init__(driver)
+        self.locator = self.Locator.xpath_selector(
+            "//*[contains(@text,'phrase')]/preceding-sibling::*[1]/android.widget.TextView")
+
+
 class WalletView(BaseView):
     def __init__(self, driver):
         super(WalletView, self).__init__(driver)
@@ -141,6 +148,7 @@ class WalletView(BaseView):
         self.address_text = AddressText(self.driver)
 
         self.set_up_button = SetUpButton(self.driver)
+        self.sign_in_phrase = SignInPhraseText(self.driver)
 
     def get_usd_total_value(self):
         return float(self.usd_total_value.text)
@@ -172,7 +180,12 @@ class WalletView(BaseView):
                 info('Transaction received, balance updated!')
                 return
 
+    def get_sign_in_phrase(self):
+        return ' '.join([element.text for element in self.sign_in_phrase.find_elements()])
+
     def set_up_wallet(self):
         self.set_up_button.click()
+        phrase = self.get_sign_in_phrase()
         self.done_button.click()
         self.yes_button.click()
+        return phrase


### PR DESCRIPTION
fixes #3966, #3919 

### Summary:
Tests added:

- C3413 | Delete 1-1 chat via 'Swipe-to-delete' option
- C3418 | Delete Group chat via 'Swipe-to-delete' option. Re-login -> no chat present for now
- C3420 | Offline inbox: 1-1 chat created. C2 logs out and enables airplane mode. C1 logs in while in offline -> offline label on home screen. Navigate to 1-1 chat -> offline label on home screen. C2 disables airplane mode
- C3430 | Offline inbox: Group Chat chat created. C2 enables airplane mode. C1 sends text messages in Group Chat and loges out. C2 disables airplane mode and waits for message to arrive.
- C3423 | C1 'Add to contacts' from 1-1 chat C2. C2 can see: real username and profile image in 1-1 chat, Group chat, public chat (verification of username in public chat is implemented in test_public_chat - C3392)
- C3429 | Can copy text message and paste into the input field. Can delete part of the message. Can select all and Cut. Can delete part of the message in the input field. Can select all and Cut.
- C3452 | Signing transaction twice
- C3453 | Wallet set up

Updated tests:
- C3407 | Signing transaction from wallet (added verification of password in logcat)

status: ready
