### PR TITLE
remove git tag steps that seem pointless

### DIFF
--- a/Jenkinsfile.nightly_fastlane
+++ b/Jenkinsfile.nightly_fastlane
@@ -34,7 +34,6 @@ node ('macos1'){
 
       sh 'git fetch --tags'
       latest_tag = sh(returnStdout: true, script: 'git describe --tags `git rev-list --tags=release --max-count=1`').trim()
-      sh 'git tag -d ' + latest_tag
       sh 'rm -rf node_modules'
       sh 'cp .env.nightly .env'
       sh 'lein deps'
@@ -58,8 +57,6 @@ node ('macos1'){
 
     stage('Build (iOS)') {
       withCredentials([string(credentialsId: 'jenkins_pass', variable: 'password')]) {
-        sh ('git tag -d ' + latest_tag + ' || exit 0')
-        sh ('git tag ' + latest_tag)
         def build_no = sh(returnStdout: true, script: 'git rev-list --count HEAD').trim()
         sh ('plutil -replace CFBundleShortVersionString  -string ' + latest_tag + ' ios/StatusIm/Info.plist')
         sh ('plutil -replace CFBundleVersion  -string ' + build_no + ' ios/StatusIm/Info.plist')


### PR DESCRIPTION
I really don't see what these are for so I'm just gonna drop them
This is causing nightly builds to fail:
https://jenkins.status.im/job/status-react/job/nightly/391/console
```
+ git tag -d 0.9.16-189-g436ac1d7-1-gc80d4bd6
error: tag '0.9.16-189-g436ac1d7-1-gc80d4bd6' not found
```
We had a thread about this here:
https://status-im.slack.com/archives/C8QP8S5UH/p1526475180000522

If anyone knows what this is for please tell me.

<blockquote></blockquote>
<blockquote><img src="https://a.slack-edge.com/436da/marketing/img/meta/favicon-32.png" width="48" align="right"><div><strong><a href="https://status-im.slack.com/archives/C8QP8S5UH/p1526475180000522">Slack</a></strong></div></blockquote>