### PR TITLE
Added script for desktop mac bundle creation

### DIFF
--- a/desktop/main.cpp
+++ b/desktop/main.cpp
@@ -1,5 +1,4 @@
 
-
 /**
  * Copyright (C) 2016, Canonical Ltd.
  * All rights reserved.
@@ -9,9 +8,14 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+//#define BULID_FOR_BUNDLE
+
 #include <QCommandLineParser>
+#include <QFile>
 #include <QGuiApplication>
+#include <QProcess>
 #include <QQuickView>
+#include <QTimer>
 #include <QUrl>
 
 #include "attachedproperties.h"
@@ -19,145 +23,253 @@
 #include "rootview.h"
 #include "utilities.h"
 
+#ifdef BULID_FOR_BUNDLE
+QStringList consoleOutputStrings;
+bool ubuntuServerStarted = false;
+#endif
+
 // TODO: some way to change while running
 class ReactNativeProperties : public QObject {
-    Q_OBJECT
-    Q_PROPERTY(bool liveReload READ liveReload WRITE setLiveReload NOTIFY liveReloadChanged)
-    Q_PROPERTY(QUrl codeLocation READ codeLocation WRITE setCodeLocation NOTIFY codeLocationChanged)
-    Q_PROPERTY(QString pluginsPath READ pluginsPath WRITE setPluginsPath NOTIFY pluginsPathChanged)
-    Q_PROPERTY(QString executor READ executor WRITE setExecutor NOTIFY executorChanged)
+  Q_OBJECT
+  Q_PROPERTY(bool liveReload READ liveReload WRITE setLiveReload NOTIFY
+                 liveReloadChanged)
+  Q_PROPERTY(QUrl codeLocation READ codeLocation WRITE setCodeLocation NOTIFY
+                 codeLocationChanged)
+  Q_PROPERTY(QString pluginsPath READ pluginsPath WRITE setPluginsPath NOTIFY
+                 pluginsPathChanged)
+  Q_PROPERTY(
+      QString executor READ executor WRITE setExecutor NOTIFY executorChanged)
 public:
-    ReactNativeProperties(QObject* parent = 0) : QObject(parent) {
-        m_codeLocation = m_packagerTemplate.arg(m_packagerHost).arg(m_packagerPort);
-    }
-    bool liveReload() const {
-        return m_liveReload;
-    }
-    void setLiveReload(bool liveReload) {
-        if (m_liveReload == liveReload)
-            return;
-        m_liveReload = liveReload;
-        Q_EMIT liveReloadChanged();
-    }
-    QUrl codeLocation() const {
-        return m_codeLocation;
-    }
-    void setCodeLocation(const QUrl& codeLocation) {
-        if (m_codeLocation == codeLocation)
-            return;
-        m_codeLocation = codeLocation;
-        Q_EMIT codeLocationChanged();
-    }
-    QString pluginsPath() const {
-        return m_pluginsPath;
-    }
-    void setPluginsPath(const QString& pluginsPath) {
-        if (m_pluginsPath == pluginsPath)
-            return;
-        m_pluginsPath = pluginsPath;
-        Q_EMIT pluginsPathChanged();
-    }
-    QString executor() const {
-        return m_executor;
-    }
-    void setExecutor(const QString& executor) {
-        if (m_executor == executor)
-            return;
-        m_executor = executor;
-        Q_EMIT executorChanged();
-    }
-    QString packagerHost() const {
-        return m_packagerHost;
-    }
-    void setPackagerHost(const QString& packagerHost) {
-        if (m_packagerHost == packagerHost)
-            return;
-        m_packagerHost = packagerHost;
-        setCodeLocation(m_packagerTemplate.arg(m_packagerHost).arg(m_packagerPort));
-    }
-    QString packagerPort() const {
-        return m_packagerPort;
-    }
-    void setPackagerPort(const QString& packagerPort) {
-        if (m_packagerPort == packagerPort)
-            return;
-        m_packagerPort = packagerPort;
-        setCodeLocation(m_packagerTemplate.arg(m_packagerHost).arg(m_packagerPort));
-    }
-    void setLocalSource(const QString& source) {
-        if (m_localSource == source)
-            return;
+  ReactNativeProperties(QObject *parent = 0) : QObject(parent) {
+    m_codeLocation = m_packagerTemplate.arg(m_packagerHost).arg(m_packagerPort);
+  }
+  bool liveReload() const { return m_liveReload; }
+  void setLiveReload(bool liveReload) {
+    if (m_liveReload == liveReload)
+      return;
+    m_liveReload = liveReload;
+    Q_EMIT liveReloadChanged();
+  }
+  QUrl codeLocation() const { return m_codeLocation; }
+  void setCodeLocation(const QUrl &codeLocation) {
+    if (m_codeLocation == codeLocation)
+      return;
+    m_codeLocation = codeLocation;
+    Q_EMIT codeLocationChanged();
+  }
+  QString pluginsPath() const { return m_pluginsPath; }
+  void setPluginsPath(const QString &pluginsPath) {
+    if (m_pluginsPath == pluginsPath)
+      return;
+    m_pluginsPath = pluginsPath;
+    Q_EMIT pluginsPathChanged();
+  }
+  QString executor() const { return m_executor; }
+  void setExecutor(const QString &executor) {
+    if (m_executor == executor)
+      return;
+    m_executor = executor;
+    Q_EMIT executorChanged();
+  }
+  QString packagerHost() const { return m_packagerHost; }
+  void setPackagerHost(const QString &packagerHost) {
+    if (m_packagerHost == packagerHost)
+      return;
+    m_packagerHost = packagerHost;
+    setCodeLocation(m_packagerTemplate.arg(m_packagerHost).arg(m_packagerPort));
+  }
+  QString packagerPort() const { return m_packagerPort; }
+  void setPackagerPort(const QString &packagerPort) {
+    if (m_packagerPort == packagerPort)
+      return;
+    m_packagerPort = packagerPort;
+    setCodeLocation(m_packagerTemplate.arg(m_packagerHost).arg(m_packagerPort));
+  }
+  void setLocalSource(const QString &source) {
+    if (m_localSource == source)
+      return;
 
-        // overrides packager*
-        if (source.startsWith("file:")) {
-            setCodeLocation(source);
-        } else {
-            QFileInfo fi(source);
-            if (!fi.exists()) {
-                qWarning() << "Attempt to set non-existent local source file";
-                return;
-            }
-            setCodeLocation(QUrl::fromLocalFile(fi.absoluteFilePath()));
-            setLiveReload(false);
-        }
+    // overrides packager*
+    if (source.startsWith("file:")) {
+      setCodeLocation(source);
+    } else {
+      QFileInfo fi(source);
+      if (!fi.exists()) {
+        qWarning() << "Attempt to set non-existent local source file";
+        return;
+      }
+      setCodeLocation(QUrl::fromLocalFile(fi.absoluteFilePath()));
+      setLiveReload(false);
     }
+  }
 Q_SIGNALS:
-    void liveReloadChanged();
-    void codeLocationChanged();
-    void pluginsPathChanged();
-    void executorChanged();
+  void liveReloadChanged();
+  void codeLocationChanged();
+  void pluginsPathChanged();
+  void executorChanged();
 
 private:
-    bool m_liveReload = false;
-    QString m_packagerHost = "localhost";
-    QString m_packagerPort = "8081";
-    QString m_localSource;
-    QString m_packagerTemplate = "http://%1:%2/index.desktop.bundle?platform=desktop&dev=true";
-    QUrl m_codeLocation;
-    QString m_pluginsPath;
-    QString m_executor = "LocalServerConnection";
+  bool m_liveReload = false;
+  QString m_packagerHost = "localhost";
+  QString m_packagerPort = "8081";
+  QString m_localSource;
+  QString m_packagerTemplate =
+      "http://%1:%2/index.desktop.bundle?platform=desktop&dev=true";
+  QUrl m_codeLocation;
+  QString m_pluginsPath;
+#ifdef BULID_FOR_BUNDLE
+  QString m_executor = "RemoteServerConnection";
+#else
+  QString m_executor = "LocalServerConnection";
+#endif
 };
 
-int main(int argc, char** argv) {
-    QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
-    QGuiApplication app(argc, argv);
-    Q_INIT_RESOURCE(react_resources);
+#ifdef BULID_FOR_BUNDLE
+void runUbuntuServer();
+void logErrorToFile(QtMsgType type, const QMessageLogContext &context,
+                    const QString &msg);
+#endif
 
-    QQuickView view;
-    ReactNativeProperties* rnp = new ReactNativeProperties(&view);
+int main(int argc, char **argv) {
 
-    utilities::registerReactTypes();
+  QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+  QGuiApplication app(argc, argv);
 
-    QCommandLineParser p;
-    p.setApplicationDescription("React Native host application");
-    p.addHelpOption();
-    p.addOptions({
-        {{"R", "live-reload"}, "Enable live reload."},
-        {{"H", "host"}, "Set packager host address.", rnp->packagerHost()},
-        {{"P", "port"}, "Set packager port number.", rnp->packagerPort()},
-        {{"L", "local"}, "Set path to the local packaged source", "not set"},
-        {{"M", "plugins-path"}, "Set path to node modules", "./plugins"},
-        {{"E", "executor"}, "Set Javascript executor", rnp->executor()},
-    });
-    p.process(app);
-    rnp->setLiveReload(p.isSet("live-reload"));
-    if (p.isSet("host"))
-        rnp->setPackagerHost(p.value("host"));
-    if (p.isSet("port"))
-        rnp->setPackagerPort(p.value("port"));
-    if (p.isSet("local"))
-        rnp->setLocalSource(p.value("local"));
-    if (p.isSet("plugins-path"))
-        rnp->setPluginsPath(p.value("plugins-path"));
-    if (p.isSet("executor"))
-        rnp->setExecutor(p.value("executor"));
+  Q_INIT_RESOURCE(react_resources);
 
-    view.rootContext()->setContextProperty("ReactNativeProperties", rnp);
-    view.setSource(QUrl("qrc:///main.qml"));
-    view.setResizeMode(QQuickView::SizeRootObjectToView);
-    view.show();
+#ifdef BULID_FOR_BUNDLE
+  QString dataFolder = QDir::homePath() + "/Library/StatusIm/";
+  qInstallMessageHandler(logErrorToFile);
 
-    return app.exec();
+  QDir dir(dataFolder + "ethereum/mainnet_rpc");
+  if (!dir.exists()) {
+    dir.mkpath(".");
+  }
+
+  runUbuntuServer();
+#endif
+
+  QQuickView view;
+  ReactNativeProperties *rnp = new ReactNativeProperties(&view);
+#ifdef BULID_FOR_BUNDLE
+  rnp->setCodeLocation(QString("file:assets"));
+#endif
+
+  utilities::registerReactTypes();
+
+  QCommandLineParser p;
+  p.setApplicationDescription("React Native host application");
+  p.addHelpOption();
+  p.addOptions({
+      {{"R", "live-reload"}, "Enable live reload."},
+      {{"H", "host"}, "Set packager host address.", rnp->packagerHost()},
+      {{"P", "port"}, "Set packager port number.", rnp->packagerPort()},
+      {{"L", "local"}, "Set path to the local packaged source", "not set"},
+      {{"M", "plugins-path"}, "Set path to node modules", "./plugins"},
+      {{"E", "executor"}, "Set Javascript executor", rnp->executor()},
+  });
+  p.process(app);
+  rnp->setLiveReload(p.isSet("live-reload"));
+  if (p.isSet("host"))
+    rnp->setPackagerHost(p.value("host"));
+  if (p.isSet("port"))
+    rnp->setPackagerPort(p.value("port"));
+  if (p.isSet("local"))
+    rnp->setLocalSource(p.value("local"));
+  if (p.isSet("plugins-path"))
+    rnp->setPluginsPath(p.value("plugins-path"));
+  if (p.isSet("executor"))
+    rnp->setExecutor(p.value("executor"));
+
+  view.rootContext()->setContextProperty("ReactNativeProperties", rnp);
+  view.setSource(QUrl("qrc:///main.qml"));
+  view.setResizeMode(QQuickView::SizeRootObjectToView);
+  view.show();
+
+#ifdef BULID_FOR_BUNDLE
+  QTimer t;
+  t.setInterval(500);
+  QObject::connect(&t, &QTimer::timeout, [=]() {
+    QFile logFile(QDir::homePath() + "/Library/StatusIm/StatusIm.log");
+    logFile.open(QIODevice::WriteOnly | QIODevice::Append);
+    for (QString message : consoleOutputStrings) {
+      logFile.write(message.toStdString().c_str());
+    }
+    consoleOutputStrings.clear();
+
+    logFile.flush();
+    logFile.close();
+
+  });
+  t.start();
+#endif
+
+  return app.exec();
 }
+
+#ifdef BULID_FOR_BUNDLE
+void runUbuntuServer() {
+  QProcess *process = new QProcess();
+  process->setProgram(QGuiApplication::applicationDirPath() + "/ubuntu-server");
+  QObject::connect(process, &QProcess::errorOccurred,
+                   [=](QProcess::ProcessError) {
+                     qDebug() << "process name: " << process->program();
+                     qDebug() << "process error: " << process->errorString();
+                   });
+
+  QObject::connect(process, &QProcess::readyReadStandardOutput, [=] {
+    qDebug() << "ubuntu-server std: "
+             << process->readAllStandardOutput().trimmed();
+  });
+  QObject::connect(process, &QProcess::readyReadStandardError, [=] {
+    QString output = process->readAllStandardError().trimmed();
+    qDebug() << "ubuntu-server err: " << output;
+    if (output.contains("Server starting")) {
+      ubuntuServerStarted = true;
+    }
+  });
+
+  QObject::connect(QGuiApplication::instance(), &QCoreApplication::aboutToQuit,
+                   [=]() {
+                     qDebug() << "Kill ubuntu server";
+                     process->kill();
+                   });
+
+  qDebug() << "starting ubuntu server...";
+  process->start();
+  qDebug() << "wait for started...";
+
+  while (!ubuntuServerStarted) {
+    QGuiApplication::processEvents();
+  }
+
+  qDebug() << "waiting finished";
+}
+
+void logErrorToFile(QtMsgType type, const QMessageLogContext &context,
+                    const QString &msg) {
+
+  QByteArray localMsg = msg.toLocal8Bit();
+  QString message = localMsg + "\n";
+
+  switch (type) {
+  case QtDebugMsg:
+    consoleOutputStrings << "Debug: " << message << "\n";
+    break;
+  case QtInfoMsg:
+    consoleOutputStrings << "Info: " << message << "\n";
+    break;
+  case QtWarningMsg:
+    consoleOutputStrings << "Warning: " << message << "\n";
+    break;
+  case QtCriticalMsg:
+    consoleOutputStrings << "Critical: " << message << "\n";
+    break;
+  case QtFatalMsg:
+    consoleOutputStrings << "Fatal: " << message << "\n";
+    abort();
+  }
+}
+#endif
 
 #include "main.moc"

--- a/desktop/main.cpp
+++ b/desktop/main.cpp
@@ -1,0 +1,163 @@
+
+
+/**
+ * Copyright (C) 2016, Canonical Ltd.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#include <QCommandLineParser>
+#include <QGuiApplication>
+#include <QQuickView>
+#include <QUrl>
+
+#include "attachedproperties.h"
+#include "reactitem.h"
+#include "rootview.h"
+#include "utilities.h"
+
+// TODO: some way to change while running
+class ReactNativeProperties : public QObject {
+    Q_OBJECT
+    Q_PROPERTY(bool liveReload READ liveReload WRITE setLiveReload NOTIFY liveReloadChanged)
+    Q_PROPERTY(QUrl codeLocation READ codeLocation WRITE setCodeLocation NOTIFY codeLocationChanged)
+    Q_PROPERTY(QString pluginsPath READ pluginsPath WRITE setPluginsPath NOTIFY pluginsPathChanged)
+    Q_PROPERTY(QString executor READ executor WRITE setExecutor NOTIFY executorChanged)
+public:
+    ReactNativeProperties(QObject* parent = 0) : QObject(parent) {
+        m_codeLocation = m_packagerTemplate.arg(m_packagerHost).arg(m_packagerPort);
+    }
+    bool liveReload() const {
+        return m_liveReload;
+    }
+    void setLiveReload(bool liveReload) {
+        if (m_liveReload == liveReload)
+            return;
+        m_liveReload = liveReload;
+        Q_EMIT liveReloadChanged();
+    }
+    QUrl codeLocation() const {
+        return m_codeLocation;
+    }
+    void setCodeLocation(const QUrl& codeLocation) {
+        if (m_codeLocation == codeLocation)
+            return;
+        m_codeLocation = codeLocation;
+        Q_EMIT codeLocationChanged();
+    }
+    QString pluginsPath() const {
+        return m_pluginsPath;
+    }
+    void setPluginsPath(const QString& pluginsPath) {
+        if (m_pluginsPath == pluginsPath)
+            return;
+        m_pluginsPath = pluginsPath;
+        Q_EMIT pluginsPathChanged();
+    }
+    QString executor() const {
+        return m_executor;
+    }
+    void setExecutor(const QString& executor) {
+        if (m_executor == executor)
+            return;
+        m_executor = executor;
+        Q_EMIT executorChanged();
+    }
+    QString packagerHost() const {
+        return m_packagerHost;
+    }
+    void setPackagerHost(const QString& packagerHost) {
+        if (m_packagerHost == packagerHost)
+            return;
+        m_packagerHost = packagerHost;
+        setCodeLocation(m_packagerTemplate.arg(m_packagerHost).arg(m_packagerPort));
+    }
+    QString packagerPort() const {
+        return m_packagerPort;
+    }
+    void setPackagerPort(const QString& packagerPort) {
+        if (m_packagerPort == packagerPort)
+            return;
+        m_packagerPort = packagerPort;
+        setCodeLocation(m_packagerTemplate.arg(m_packagerHost).arg(m_packagerPort));
+    }
+    void setLocalSource(const QString& source) {
+        if (m_localSource == source)
+            return;
+
+        // overrides packager*
+        if (source.startsWith("file:")) {
+            setCodeLocation(source);
+        } else {
+            QFileInfo fi(source);
+            if (!fi.exists()) {
+                qWarning() << "Attempt to set non-existent local source file";
+                return;
+            }
+            setCodeLocation(QUrl::fromLocalFile(fi.absoluteFilePath()));
+            setLiveReload(false);
+        }
+    }
+Q_SIGNALS:
+    void liveReloadChanged();
+    void codeLocationChanged();
+    void pluginsPathChanged();
+    void executorChanged();
+
+private:
+    bool m_liveReload = false;
+    QString m_packagerHost = "localhost";
+    QString m_packagerPort = "8081";
+    QString m_localSource;
+    QString m_packagerTemplate = "http://%1:%2/index.desktop.bundle?platform=desktop&dev=true";
+    QUrl m_codeLocation;
+    QString m_pluginsPath;
+    QString m_executor = "LocalServerConnection";
+};
+
+int main(int argc, char** argv) {
+    QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+    QGuiApplication app(argc, argv);
+    Q_INIT_RESOURCE(react_resources);
+
+    QQuickView view;
+    ReactNativeProperties* rnp = new ReactNativeProperties(&view);
+
+    utilities::registerReactTypes();
+
+    QCommandLineParser p;
+    p.setApplicationDescription("React Native host application");
+    p.addHelpOption();
+    p.addOptions({
+        {{"R", "live-reload"}, "Enable live reload."},
+        {{"H", "host"}, "Set packager host address.", rnp->packagerHost()},
+        {{"P", "port"}, "Set packager port number.", rnp->packagerPort()},
+        {{"L", "local"}, "Set path to the local packaged source", "not set"},
+        {{"M", "plugins-path"}, "Set path to node modules", "./plugins"},
+        {{"E", "executor"}, "Set Javascript executor", rnp->executor()},
+    });
+    p.process(app);
+    rnp->setLiveReload(p.isSet("live-reload"));
+    if (p.isSet("host"))
+        rnp->setPackagerHost(p.value("host"));
+    if (p.isSet("port"))
+        rnp->setPackagerPort(p.value("port"));
+    if (p.isSet("local"))
+        rnp->setLocalSource(p.value("local"));
+    if (p.isSet("plugins-path"))
+        rnp->setPluginsPath(p.value("plugins-path"));
+    if (p.isSet("executor"))
+        rnp->setExecutor(p.value("executor"));
+
+    view.rootContext()->setContextProperty("ReactNativeProperties", rnp);
+    view.setSource(QUrl("qrc:///main.qml"));
+    view.setResizeMode(QQuickView::SizeRootObjectToView);
+    view.show();
+
+    return app.exec();
+}
+
+#include "main.moc"

--- a/desktop/main.cpp
+++ b/desktop/main.cpp
@@ -8,7 +8,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-// #define BULID_FOR_BUNDLE
+ // #define BUILD_FOR_BUNDLE
 
 #include <QCommandLineParser>
 #include <QFile>
@@ -17,13 +17,14 @@
 #include <QQuickView>
 #include <QTimer>
 #include <QUrl>
+#include <QStandardPaths>
 
 #include "attachedproperties.h"
 #include "reactitem.h"
 #include "rootview.h"
 #include "utilities.h"
 
-#ifdef BULID_FOR_BUNDLE
+#ifdef BUILD_FOR_BUNDLE
 QStringList consoleOutputStrings;
 bool ubuntuServerStarted = false;
 #endif
@@ -117,14 +118,14 @@ private:
       "http://%1:%2/index.desktop.bundle?platform=desktop&dev=true";
   QUrl m_codeLocation;
   QString m_pluginsPath;
-#ifdef BULID_FOR_BUNDLE
+#ifdef BUILD_FOR_BUNDLE
   QString m_executor = "RemoteServerConnection";
 #else
   QString m_executor = "LocalServerConnection";
 #endif
 };
 
-#ifdef BULID_FOR_BUNDLE
+#ifdef BUILD_FOR_BUNDLE
 void runUbuntuServer();
 void saveMessage(QtMsgType type, const QMessageLogContext &context,
                  const QString &msg);
@@ -139,7 +140,7 @@ int main(int argc, char **argv) {
 
   Q_INIT_RESOURCE(react_resources);
 
-#ifdef BULID_FOR_BUNDLE
+#ifdef BUILD_FOR_BUNDLE
   QString dataFolder = QDir::homePath() + "/Library/StatusIm/";
   qInstallMessageHandler(saveMessage);
 
@@ -153,7 +154,7 @@ int main(int argc, char **argv) {
 
   QQuickView view;
   ReactNativeProperties *rnp = new ReactNativeProperties(&view);
-#ifdef BULID_FOR_BUNDLE
+#ifdef BUILD_FOR_BUNDLE
   rnp->setCodeLocation("file:" + QGuiApplication::applicationDirPath() +
                        "/assets");
 #endif
@@ -189,7 +190,7 @@ int main(int argc, char **argv) {
   view.setResizeMode(QQuickView::SizeRootObjectToView);
   view.show();
 
-#ifdef BULID_FOR_BUNDLE
+#ifdef BUILD_FOR_BUNDLE
   QTimer t;
   t.setInterval(500);
   QObject::connect(&t, &QTimer::timeout, [=]() { writeLogsToFile(); });
@@ -199,10 +200,10 @@ int main(int argc, char **argv) {
   return app.exec();
 }
 
-#ifdef BULID_FOR_BUNDLE
+#ifdef BUILD_FOR_BUNDLE
 
 void writeLogsToFile() {
-  QFile logFile(QDir::homePath() + "/Library/StatusIm/StatusIm.log");
+  QFile logFile(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation) + "/StatusIm.log");
   logFile.open(QIODevice::WriteOnly | QIODevice::Append);
   for (QString message : consoleOutputStrings) {
     logFile.write(message.toStdString().c_str());

--- a/modules/react-native-status/desktop/rctstatus.cpp
+++ b/modules/react-native-status/desktop/rctstatus.cpp
@@ -17,6 +17,7 @@
 #include <QByteArray>
 #include <QVariantMap>
 #include <QDir>
+#include <QStandardPaths>
 
 #include "libstatus.h"
 
@@ -110,13 +111,13 @@ void RCTStatus::startNode(QString configString) {
     int networkId = configJSON["NetworkId"].toInt();
     QString dataDir = configJSON["DataDir"].toString();
 
-#ifndef __APPLE__
-    QString networkDir = "./" + dataDir;
-#else
-    QString appFolder = QDir::homePath() + "/Library/StatusIm";
-    QString networkDir = appFolder + dataDir;
-    qDebug()<<"RCTStatus::startNode networkDir: "<<networkDir<<" homePath: "<<QDir::homePath();
-#endif
+    QString networkDir = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation) + "/" + dataDir;
+    QDir dir(networkDir);
+    if (!dir.exists()) {
+      dir.mkpath(".");
+    }
+    qDebug()<<"RCTStatus::startNode networkDir: "<<networkDir;
+
 
     char *configChars = GenerateConfig(networkDir.toUtf8().data(), networkId);
     qDebug() << "RCTStatus::startNode GenerateConfig result: " << configChars;

--- a/modules/react-native-status/desktop/rctstatus.cpp
+++ b/modules/react-native-status/desktop/rctstatus.cpp
@@ -16,6 +16,7 @@
 #include <QJsonDocument>
 #include <QByteArray>
 #include <QVariantMap>
+#include <QDir>
 
 #include "libstatus.h"
 
@@ -109,7 +110,13 @@ void RCTStatus::startNode(QString configString) {
     int networkId = configJSON["NetworkId"].toInt();
     QString dataDir = configJSON["DataDir"].toString();
 
+#ifndef __APPLE__
     QString networkDir = "./" + dataDir;
+#else
+    QString appFolder = QDir::homePath() + "/Library/StatusIm";
+    QString networkDir = appFolder + dataDir;
+    qDebug()<<"RCTStatus::startNode networkDir: "<<networkDir<<" homePath: "<<QDir::homePath();
+#endif
 
     char *configChars = GenerateConfig(networkDir.toUtf8().data(), networkId);
     qDebug() << "RCTStatus::startNode GenerateConfig result: " << configChars;

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "node_modules/react-native-webview-bridge/desktop",
     "modules/react-native-status/desktop"
   ],
-  "desktopJSBundlePath": "/Users/vkjr/work/projects/github/status-im-mac-bundle/status-react/StatusIm.jsbundle",
   "dependencies": {
     "assert": "1.4.1",
     "asyncstorage-down": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "node_modules/react-native-webview-bridge/desktop",
     "modules/react-native-status/desktop"
   ],
+  "desktopJSBundlePath": "/Users/vkjr/work/projects/github/status-im-mac-bundle/status-react/StatusIm.jsbundle",
   "dependencies": {
     "assert": "1.4.1",
     "asyncstorage-down": "4.0.1",

--- a/scripts/create-desktop-mac-bundle.sh
+++ b/scripts/create-desktop-mac-bundle.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+STATUSREACTPATH="$SCRIPTPATH/.."
+WORKFOLDER="$SCRIPTPATH/../mac_bundle"
+MACDEPLOYQT=""
+
+#if no arguments passed, inform user about possible ones (one for making script interactive, one for path to macdeployqt)
+
+if [ $# -eq 0 ]
+  then
+    echo -e "${RED}You need to specify path to macdeployqt binary as an argument${NC}"
+    echo "Example: scripts/create-desktop-mac-bundle.sh /usr/bin/macdeployqt"
+    exit 1
+  else
+    MACDEPLOYQT=$1
+fi
+
+# check if gdrive installed
+command -v gdrive >/dev/null 2>&1 || { echo -e "${RED}gdrive tool need to be installed. (brew install gdrive). Aborting.${NC}" >&2; exit 1; }
+
+
+# inform user that define should be changed in "desktop/main.cpp"
+echo ""
+echo -e "${YELLOW}In desktop/main.cpp file please uncomment #define BULID_FOR_BUNDLE line.${NC}"
+read -p "When ready, plese press enter to continue"
+echo ""
+
+
+# create directory for all work related to bundling
+mkdir -p $WORKFOLDER
+echo -e "${GREEN}Work folder created: $WORKFOLDER${NC}"
+echo ""
+
+# from index.desktop.js create javascript bundle and resources folder
+echo "Generating StatusIm.bundle and assets folder..."
+react-native bundle --entry-file index.desktop.js --bundle-output $WORKFOLDER/StatusIm.jsbundle --dev false --platform desktop --assets-dest $WORKFOLDER/assets
+echo -e "${GREEN}Generating done.${NC}"
+echo ""
+
+# show path to javascript bundle and line that should be added to package.json
+echo -e "${YELLOW}Please add the following line to package.json:${NC}"
+echo "\"desktopJSBundlePath\": \"$WORKFOLDER/StatusIm.jsbundle\""
+echo ""
+read -p "When ready, plese press enter to continue"
+echo ""
+
+
+# build desktop app
+echo "Building StatusIm desktop..."
+react-native build-desktop
+echo -e "${GREEN}Building done.${NC}"
+echo ""
+
+
+# download prepared package with mac bundle files (it contains qt libraries, icon)
+echo "Downloading skeleton of mac bundle..."
+echo -e "${YELLOW}First time gdrive can ask you for permissions to google drive${NC}"
+gdrive download --path $WORKFOLDER 1fJbW9FzGGPvYkuJcSH5mCAcGdnyUeDSY
+echo -e "${GREEN}Downloading done.${NC}"
+echo ""
+
+
+# Unpacking downloaded archive
+echo "Unpacking bundle skeleton"
+unzip $WORKFOLDER/StatusIm.app.zip -d $WORKFOLDER
+chmod +x $WORKFOLDER/StatusIm.app/Contents/MacOs/ubuntu-server
+echo -e "${GREEN}Unzipping done.${NC}"
+echo ""
+
+
+# copy binary and resources to mac bundle
+echo "Copying resources and binary..."
+cp -r $WORKFOLDER/assets/share/assets $WORKFOLDER/StatusIm.app/Contents/MacOs
+cp $STATUSREACTPATH/desktop/bin/StatusIm $WORKFOLDER/StatusIm.app/Contents/MacOs
+echo -e "${GREEN}Copying done.${NC}"
+echo ""
+
+
+# invoke macdeployqt to create StatusIm.dmg
+echo "Creating bundle dmg..."
+$MACDEPLOYQT $WORKFOLDER/StatusIm.app -verbose=3 -qmldir="$STATUSREACTPATH/node_modules/react-native/ReactQt/application/src/" -qmldir="$STATUSREACTPATH/node_modules/react-native/ReactQt/runtime/src/qml/" -dmg
+echo -e "${GREEN}Bundle ready!${NC}"
+echo ""


### PR DESCRIPTION

fixes #4274 

### Summary:
- Added script `scripts/create-desktop-mac-bundle.sh` that allows creation of mac bundle
- in `desktop/main.cpp` added define `BUILD_FOR_BUNDLE` that changes app behavior to run as a standalone package (all logs redirected to file, ubuntu server executed at start, changed path to assets, manually created folder for ethereum files)
- in `react-native-status/desktop/rctstatus.cpp` added change to run node inside `~/Library/StatusIm` directory 

### Review notes (optional):
<!-- (Specify if something in particular should be looked at, or ignored, during review) -->

### Testing notes (optional):
<!-- (Specify if something specific has to be tested, for example upgrade paths) -->

### Steps to test:
- `git clone https://github.com/status-im/status-react.git`
- `git checkout desktop-bundle`
- `cd status-react`
- `npm install`
- `react-native desktop` (don't replace main.cpp file)
- `rm index.desktop.js` (you need to remove default index.desktop.js, or it won't be created in the next step)
- `lein prod-build-desktop` (compiles new index.desktop.js)
- `brew install gdrive` (bundling script uses gdrive tool to download prepared package from status google drive. during script execution you will be asked to give gdrive access to google drive)
- `scripts/create-desktop-mac-bundle.sh  PATH_TO_QT/5.9/clang_64/bin/macdeployqt`
**NOTE: Scripts will ask you to make changes to main.cpp and package.json to build standalone version of app!**


<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->