### PR TITLE
[FIX #4268] Broken message counter when having more than 999 messages

### DIFF
--- a/src/status_im/translations/en.cljs
+++ b/src/status_im/translations/en.cljs
@@ -237,6 +237,7 @@
    :set-a-topic                          "Set a topic"
    :empty-chat-description               "There are no messages \nin this chat yet"
    :empty-chat-description-console       "Look under the hood! Console is a javascript runtime environment that exposes the whole web3 API. Type \"web3.\" to get started."
+   :counter-99-plus                      "99+"
 
    ;;discover
    :discover                             "Discover"

--- a/src/status_im/ui/components/common/common.cljs
+++ b/src/status_im/ui/components/common/common.cljs
@@ -86,7 +86,7 @@
     [react/text (cond-> {:style (styles/counter-label size)}
                   accessibility-label
                   (assoc :accessibility-label accessibility-label))
-     value]]))
+     (if (<= value 99) value (i18n/label :t/counter-99-plus))]]))
 
 (defn image-contain [_ _]
   (let [content-width (reagent/atom 0)]


### PR DESCRIPTION
fixes #4268

### Summary:

Show '99+' if the number of messages is greater than 99. Tested for counters in the main navigation, home screen overview, and the upper toolbar.

### Steps to test:
- Open Status
- Receive more than 999 messages in public/group chat
- Pay attention to unread counter

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->

![screenshot_1526557049](https://user-images.githubusercontent.com/536331/40175999-147d8f00-5a04-11e8-9a1f-0aa840f6286b.png)
![screenshot_1526557563](https://user-images.githubusercontent.com/536331/40176000-14b1b690-5a04-11e8-9b47-fb6504fb96d1.png)
![screenshot_1526557654](https://user-images.githubusercontent.com/536331/40176001-14e6e252-5a04-11e8-98ea-0cdd5945d5ca.png)