### PR TITLE
[FIX #3640] No Join button when joining public chat

### DIFF
--- a/src/status_im/ui/screens/add_new/new_chat/views.cljs
+++ b/src/status_im/ui/screens/add_new/new_chat/views.cljs
@@ -30,7 +30,8 @@
                                                  (re-frame/dispatch [:add-contact-handler]))
                          :placeholder         (i18n/label :t/enter-contact-code)
                          :style               add-new.styles/input
-                         :accessibility-label :enter-contact-code-input}]
+                         :accessibility-label :enter-contact-code-input
+                         :return-key-type     :go}]
       [react/touchable-highlight {:on-press            #(re-frame/dispatch [:scan-qr-code
                                                                             {:toolbar-title (i18n/label :t/new-contact)}
                                                                             :set-contact-identity-from-qr])

--- a/src/status_im/ui/screens/add_new/new_public_chat/view.cljs
+++ b/src/status_im/ui/screens/add_new/new_public_chat/view.cljs
@@ -30,7 +30,8 @@
                                (re-frame/dispatch [:create-new-public-chat topic]))
        :auto-capitalize     :none
        :accessibility-label :chat-name-input
-       :placeholder         nil}]]]
+       :placeholder         nil
+       :return-key-type     :go}]]]
    (when error
      [tooltip/tooltip error styles/tooltip])])
 

--- a/src/status_im/ui/screens/add_new/open_dapp/views.cljs
+++ b/src/status_im/ui/screens/add_new/open_dapp/views.cljs
@@ -36,7 +36,8 @@
                          :auto-capitalize     :none
                          :auto-correct        false
                          :style               add-new.styles/input
-                         :accessibility-label :dapp-url-input}]]
+                         :accessibility-label :dapp-url-input
+                         :return-key-type     :go}]]
      [react/text {:style styles/list-title}
       (i18n/label :t/selected-dapps)]
      [list/flat-list {:data                      dapps


### PR DESCRIPTION
fixes #3640

### Summary:

Change the keyboard type (return button type) when joining a public chat group. The requested keyboard type 'web-search' works only on ios and has no effect on Android. React native introduces `returnKeyType` which works on both platforms. Setting this property to `:go` displays "Go" on ios and "->" on Android. (Note: there's also `returnKeyLabel` which is Android-only and should display a label but it doesn't seem to work with the current version of android 8.0 or react native).

### Steps to test:
- Open Status
- Create new public chat

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->
