### PR TITLE
[FIX #4127] Sign In button is shown when recovering account (android)

### DIFF
--- a/src/status_im/ui/screens/accounts/recover/events.cljs
+++ b/src/status_im/ui/screens/accounts/recover/events.cljs
@@ -54,9 +54,16 @@
        (-> db
            (accounts-events/add-account account)
            (assoc :dispatch [:login-account address password])
-           (assoc :dispatch-later [{:ms 2000 :dispatch [:navigate-to :usage-data [:account-finalized false]]}]))))))
+           (assoc :dispatch-later [{:ms 2000 :dispatch [:account-recovered-navigate]}]))))))
+
+(handlers/register-handler-fx
+ :account-recovered-navigate
+ (fn [{:keys [db]}]
+   {:db (assoc-in db [:accounts/recover :processing] false)
+    :dispatch [:navigate-to :usage-data [:account-finalized false]]}))
 
 (handlers/register-handler-fx
  :recover-account
- (fn [_ [_ masked-passphrase password]]
-   {::recover-account-fx [masked-passphrase password]}))
+ (fn [{:keys [db]} [_ masked-passphrase password]]
+   {:db (assoc-in db [:accounts/recover :processing] true)
+    ::recover-account-fx [masked-passphrase password]}))

--- a/src/status_im/ui/screens/accounts/recover/navigation.cljs
+++ b/src/status_im/ui/screens/accounts/recover/navigation.cljs
@@ -3,4 +3,4 @@
 
 (defmethod nav/preload-data! :recover
   [db]
-  (update db :accounts/recover dissoc :password :passphrase))
+  (update db :accounts/recover dissoc :password :passphrase :processing))

--- a/src/status_im/ui/screens/accounts/recover/styles.cljs
+++ b/src/status_im/ui/screens/accounts/recover/styles.cljs
@@ -9,3 +9,14 @@
   {:flex-direction    :row
    :margin-horizontal 12
    :margin-vertical   15})
+
+(def processing-view
+  {:flex            1
+   :align-items     :center
+   :justify-content :center})
+
+(def sign-you-in
+  {:margin-top     16
+   :font-size      13
+   :letter-spacing -0.2
+   :color          colors/text-light-gray})

--- a/src/status_im/ui/screens/accounts/recover/views.cljs
+++ b/src/status_im/ui/screens/accounts/recover/views.cljs
@@ -48,7 +48,7 @@
        :error             error}]]))
 
 (defview recover []
-  (letsubs [{:keys [passphrase password]} [:get :accounts/recover]]
+  (letsubs [{:keys [passphrase password processing]} [:get :accounts/recover]]
     (let [valid-form? (and
                        (spec/valid? ::recover.db/passphrase passphrase)
                        (spec/valid? ::db/password password))]
@@ -61,12 +61,17 @@
         [passphrase-input (or passphrase "")]
         [password-input (or password "")]]
        [react/view {:flex 1}]
-       [react/view {:style styles/bottom-button-container}
-        [react/view {:style {:flex 1}}]
-        [components.common/bottom-button
-         {:forward?  true
-          :label     (i18n/label :t/sign-in)
-          :disabled? (not valid-form?)
-          :on-press  (fn [_]
-                       (let [masked-passphrase (security/mask-data (string/trim passphrase))]
-                         (re-frame/dispatch [:recover-account masked-passphrase password])))}]]])))
+       (if processing
+         [react/view styles/processing-view
+          [react/activity-indicator {:animating true}]
+          [react/text {:style styles/sign-you-in}
+           (i18n/label :t/sign-you-in)]]
+         [react/view {:style styles/bottom-button-container}
+          [react/view {:style {:flex 1}}]
+          [components.common/bottom-button
+           {:forward?  true
+            :label     (i18n/label :t/sign-in)
+            :disabled? (not valid-form?)
+            :on-press  (fn [_]
+                         (let [masked-passphrase (security/mask-data (string/trim passphrase))]
+                           (re-frame/dispatch [:recover-account masked-passphrase password])))}]])])))


### PR DESCRIPTION
fixes #4127

### Summary:

Show 'Signing you in...' in the account recovery view and hide 'sign-in' button while processing.

### Steps to test:
- Open Status
- Go to Account recovery and recover an account

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->

![screenshot_1526566576](https://user-images.githubusercontent.com/536331/40183259-97fc3a1c-5a17-11e8-8f77-5d59a4d6bc1a.png)
