### PR TITLE
[FIX #4296] Rename Recent Recipients to Contacts in Wallet

### DIFF
--- a/src/status_im/translations/en.cljs
+++ b/src/status_im/translations/en.cljs
@@ -376,7 +376,7 @@
    :recipient                            "Recipient"
    :specify-recipient                    "Specify recipient..."
    :recipient-code                       "Enter recipient address"
-   :recent-recipients                    "Recent recipients"
+   :recent-recipients                    "Contacts"
    :to                                   "To"
    :from                                 "From"
    :data                                 "Data"

--- a/test/appium/views/send_transaction_view.py
+++ b/test/appium/views/send_transaction_view.py
@@ -85,7 +85,7 @@ class EnterRecipientAddressInput(BaseEditBox):
 class RecentRecipientsButton(BaseButton):
     def __init__(self, driver):
         super(RecentRecipientsButton, self).__init__(driver)
-        self.locator = self.Locator.xpath_selector("//*[@text='Recent recipients']")
+        self.locator = self.Locator.xpath_selector("//*[@text='Contacts']")
 
 
 class SelectAssetButton(BaseButton):


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes #4296 

### Summary:

[comment]: # (Summarise the problem and how the pull request solves it)
Renames the "Recent recipients" label in wallet to "Contacts".

### Steps to test:
- Open Status
- Go to Wallet tab
- Verify that label is correct

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->
