### PR TITLE
Dont open chat on contact request

### DIFF
--- a/src/status_im/chat/subs.cljs
+++ b/src/status_im/chat/subs.cljs
@@ -8,6 +8,7 @@
             [status-im.commands.utils :as commands-utils]
             [status-im.utils.datetime :as time]
             [status-im.utils.platform :as platform]
+            [status-im.utils.gfycat.core :as gfycat]
             [status-im.i18n :as i18n]
             [status-im.constants :as const]))
 
@@ -23,6 +24,33 @@
  :<- [:get-current-chat-id]
  (fn [[chat-ui-props id]]
    (get chat-ui-props id)))
+
+(defn chat-name [{:keys [group-chat
+                         chat-id
+                         public?
+                         name]}
+                 {contact-name :name}]
+  (cond
+    public?    (str "#" name)
+    group-chat name
+    :else      (i18n/get-contact-translated
+                chat-id
+                :name
+                (or contact-name
+                    (gfycat/generate-gfy chat-id)))))
+(reg-sub
+ :get-current-chat-name
+ :<- [:get-current-chat-contact]
+ :<- [:get-current-chat]
+ (fn [[contact chat]]
+   (chat-name chat contact)))
+
+(reg-sub
+ :get-chat-name
+ :<- [:get-contacts]
+ :<- [:get-chats]
+ (fn [[contacts chats] [_ chat-id]]
+   (chat-name (get chats chat-id) (get contacts chat-id))))
 
 (reg-sub
  :get-current-chat-ui-prop

--- a/src/status_im/chat/views/toolbar_content.cljs
+++ b/src/status_im/chat/views/toolbar_content.cljs
@@ -62,8 +62,9 @@
             (i18n/label-pluralize cnt :t/members-active)))]])))
 
 (defview toolbar-content-view []
-  (letsubs [{:keys [group-chat name color online contacts
-                    public? chat-id]}             [:get-current-chat]
+  (letsubs [{:keys [group-chat color online contacts
+                    public? chat-id] :as chat}    [:get-current-chat]
+            chat-name                             [:get-current-chat-name]
             show-actions?                         [:get-current-chat-ui-prop :show-actions?]
             accounts                              [:get-accounts]
             contact                               [:get-current-chat-contact]
@@ -71,19 +72,13 @@
     (let [has-subtitle? (or group-chat (not= :done sync-state))]
       [react/view {:style st/toolbar-container}
        [react/view {:margin-right 8}
-        [chat-icon.screen/chat-icon-view-toolbar chat-id group-chat name color online]]
+        [chat-icon.screen/chat-icon-view-toolbar chat-id group-chat chat-name color online]]
        [react/view {:style st/chat-name-view}
-        (let [chat-name (if (string/blank? name)
-                          (generate-gfy chat-id)
-                          (or (i18n/get-contact-translated chat-id :name name)
-                              (i18n/label :t/chat-name)))]
-          [react/text {:style               st/chat-name-text
-                       :number-of-lines     1
-                       :font                :toolbar-title
-                       :accessibility-label :chat-name-text}
-           (if public?
-             (str "#" chat-name)
-             chat-name)])
+        [react/text {:style               st/chat-name-text
+                     :number-of-lines     1
+                     :font                :toolbar-title
+                     :accessibility-label :chat-name-text}
+         chat-name]
         (if group-chat
           [group-last-activity {:contacts   contacts
                                 :public?    public?

--- a/src/status_im/data_store/realm/schemas/account/core.cljs
+++ b/src/status_im/data_store/realm/schemas/account/core.cljs
@@ -3,7 +3,8 @@
    [status-im.data-store.realm.schemas.account.v1.core :as v1]
    [status-im.data-store.realm.schemas.account.v2.core :as v2]
    [status-im.data-store.realm.schemas.account.v3.core :as v3]
-   [status-im.data-store.realm.schemas.account.v4.core :as v4]))
+   [status-im.data-store.realm.schemas.account.v4.core :as v4]
+   [status-im.data-store.realm.schemas.account.v5.core :as v5]))
 
 ;; TODO(oskarth): Add failing test if directory vXX exists but isn't in schemas.
 
@@ -19,4 +20,7 @@
                :migration     v3/migration}
               {:schema        v4/schema
                :schemaVersion 4
-               :migration     v4/migration}])
+               :migration     v4/migration}
+              {:schema        v5/schema
+               :schemaVersion 5
+               :migration     v5/migration}])

--- a/src/status_im/data_store/realm/schemas/account/v5/chat.cljs
+++ b/src/status_im/data_store/realm/schemas/account/v5/chat.cljs
@@ -1,0 +1,40 @@
+(ns status-im.data-store.realm.schemas.account.v5.chat
+  (:require
+   [taoensso.timbre :as log]
+   [status-im.ui.components.styles :refer [default-chat-color]]))
+
+(def schema {:name       :chat
+             :primaryKey :chat-id
+             :properties {:chat-id                :string
+                          :name                   :string
+                          :color                  {:type    :string
+                                                   :default default-chat-color}
+                          :group-chat             {:type    :bool
+                                                   :indexed true}
+                          :group-admin            {:type     :string
+                                                   :optional true}
+                          :is-active              :bool
+                          :timestamp              :int
+                          :contacts               {:type     "string[]"}
+                          :removed-at             {:type     :int
+                                                   :optional true}
+                          :removed-from-at        {:type     :int
+                                                   :optional true}
+                          :deleted-at-clock-value {:type :int
+                                                   :optional true}
+                          :added-to-at            {:type     :int
+                                                   :optional true}
+                          :updated-at             {:type     :int
+                                                   :optional true}
+                          :message-overhead       {:type    :int
+                                                   :default 0}
+                          :debug?                 {:type    :bool
+                                                   :default false}
+                          :public?                {:type    :bool
+                                                   :default false}}})
+
+(defn migration [old-realm new-realm]
+  (log/debug "migrating chats schema v5")
+  (let [chats (.objects new-realm "chat")]
+    (dotimes [i (.-length chats)]
+      (js-delete (aget chats i) "contact-info"))))

--- a/src/status_im/data_store/realm/schemas/account/v5/core.cljs
+++ b/src/status_im/data_store/realm/schemas/account/v5/core.cljs
@@ -1,0 +1,25 @@
+(ns status-im.data-store.realm.schemas.account.v5.core
+  (:require [status-im.data-store.realm.schemas.account.v5.chat :as chat]
+            [status-im.data-store.realm.schemas.account.v4.transport :as transport]
+            [status-im.data-store.realm.schemas.account.v1.contact :as contact]
+            [status-im.data-store.realm.schemas.account.v1.message :as message]
+            [status-im.data-store.realm.schemas.account.v1.request :as request]
+            [status-im.data-store.realm.schemas.account.v1.user-status :as user-status]
+            [status-im.data-store.realm.schemas.account.v1.local-storage :as local-storage]
+            [status-im.data-store.realm.schemas.account.v2.mailserver :as mailserver]
+            [status-im.data-store.realm.schemas.account.v1.browser :as browser]
+            [taoensso.timbre :as log]))
+
+(def schema [chat/schema
+             transport/schema
+             contact/schema
+             message/schema
+             request/schema
+             mailserver/schema
+             user-status/schema
+             local-storage/schema
+             browser/schema])
+
+(defn migration [old-realm new-realm]
+  (log/debug "migrating v5 account database: " old-realm new-realm)
+  (chat/migration old-realm new-realm))

--- a/src/status_im/ui/screens/contacts/core.cljs
+++ b/src/status_im/ui/screens/contacts/core.cljs
@@ -14,15 +14,12 @@
                          :photo-path       profile-image
                          :name             name
                          :fcm-token        fcm-token
-                         :pending?         true}
-          chat-props    {:name         name
-                         :chat-id      public-key}]
+                         :pending?         true}]
       (handlers-macro/merge-fx cofx
                                {:db            (update-in db [:contacts/contacts public-key]
                                                           merge contact-props)
                                 :data-store/tx [(contacts-store/save-contact-tx
-                                                 contact-props)]}
-                               (chat.models/upsert-chat chat-props)))))
+                                                 contact-props)]}))))
 
 (defn receive-contact-request-confirmation
   [public-key {:keys [name profile-image address fcm-token]}
@@ -33,15 +30,12 @@
                          :address          address
                          :photo-path       profile-image
                          :name             name
-                         :fcm-token        fcm-token}
-          chat-props    {:name    name
-                         :chat-id public-key}]
+                         :fcm-token        fcm-token}]
       (handlers-macro/merge-fx cofx
                                {:db            (update-in db [:contacts/contacts public-key]
                                                           merge contact-props)
                                 :data-store/tx [(contacts-store/save-contact-tx
-                                                 contact-props)]}
-                               (chat.models/upsert-chat chat-props)))))
+                                                 contact-props)]}))))
 
 (defn- update-contact [{:keys [whisper-identity] :as contact} {:keys [db]}]
   (when (get-in db [:contacts/contacts whisper-identity])
@@ -57,9 +51,4 @@
                          :name             name
                          :photo-path       profile-image
                          :last-updated     now}]
-            (if (chats public-key)
-              (handlers-macro/merge-fx cofx
-                                       (update-contact contact)
-                                       (chat.models/upsert-chat {:chat-id chat-id
-                                                                 :name    name}))
-              (update-contact contact cofx))))))))
+            (update-contact contact cofx)))))))

--- a/src/status_im/ui/screens/home/views/inner_item.cljs
+++ b/src/status_im/ui/screens/home/views/inner_item.cljs
@@ -57,12 +57,9 @@
                                   :accessibility-label :unread-messages-count-text}
        unviewed-messages-count])))
 
-(defn chat-list-item-name [name group-chat? public? public-key]
+(defn chat-list-item-name [chat-name group-chat? public? public-key]
   (let [private-group? (and group-chat? (not public?))
-        public-group?  (and group-chat? public?)
-        chat-name      (if (str/blank? name)
-                         (gfycat/generate-gfy public-key)
-                         (utils/truncate-str name 30))]
+        public-group?  (and group-chat? public?)]
     [react/view styles/name-view
      (when public-group?
        [react/view styles/public-group-icon-container
@@ -74,25 +71,23 @@
       [react/text {:style               styles/name-text
                    :number-of-lines     1
                    :accessibility-label :chat-name-text}
-       (if public-group?
-         (str "#" chat-name)
-         chat-name)]]]))
+       chat-name]]]))
 
 (defview home-list-chat-item-inner-view [{:keys [chat-id name color online
                                                  group-chat public?
                                                  public-key
                                                  timestamp]}]
-  (letsubs [last-message [:get-last-message chat-id]]
-    (let [name (or (i18n/get-contact-translated chat-id :name name)
-                   (gfycat/generate-gfy public-key))
-          hide-dapp? (= chat-id const/console-chat-id)]
+  (letsubs [last-message [:get-last-message chat-id]
+            chat-name    [:get-chat-name chat-id]]
+    (let [hide-dapp?          (= chat-id const/console-chat-id)
+          truncated-chat-name (utils/truncate-str chat-name 30)]
       [react/touchable-highlight {:on-press #(re-frame/dispatch [:navigate-to-chat chat-id])}
        [react/view styles/chat-container
         [react/view styles/chat-icon-container
-         [chat-icon.screen/chat-icon-view-chat-list chat-id group-chat name color online hide-dapp?]]
+         [chat-icon.screen/chat-icon-view-chat-list chat-id group-chat truncated-chat-name color online hide-dapp?]]
         [react/view styles/chat-info-container
          [react/view styles/item-upper-container
-          [chat-list-item-name name group-chat public? public-key]
+          [chat-list-item-name truncated-chat-name group-chat public? public-key]
           [react/view styles/message-status-container
            [message-timestamp timestamp]]]
          [react/view styles/item-lower-container

--- a/test/appium/tests/test_messaging.py
+++ b/test/appium/tests/test_messaging.py
@@ -191,18 +191,17 @@ class TestMessages(MultipleDeviceTestCase):
         device_1, device_2 = SignInView(self.drivers[0]), SignInView(self.drivers[1])
         username_1, username_2 = device_1.create_user(), device_2.create_user()
         home_1, home_2 = device_1.get_home_view(), device_2.get_home_view()
-
         device_2_public_key = home_2.get_public_key()
         profile_2 = home_2.get_profile_view()
         file_name = 'sauce_logo.png'
         profile_2.edit_profile_picture(file_name)
-
         home_1.add_contact(device_2_public_key)
+        chat_1 = home_1.get_chat_view()
+        chat_1.chat_message_input.send_keys('ping')
+        chat_1.send_message_button.click()
         profile_2.home_button.click()
         chat_2 = home_2.get_chat_with_user(username_1).click()
         chat_2.add_to_contacts.click()
-
-        chat_1 = home_1.get_chat_view()
         time.sleep(3)
         if chat_1.user_name_text.text != username_2:
             self.errors.append("Real username '%s' is not shown in one-to-one chat" % username_2)
@@ -278,18 +277,19 @@ class TestOfflineMessages(MultipleDeviceTestCase):
         device_2_public_key = home_2.get_public_key()
         home_1.add_contact(device_2_public_key)
         chat_1 = home_1.get_chat_view()
-        profile_2 = home_2.get_profile_view()
+        chat_1.chat_message_input.send_keys('ping')
+        chat_1.send_message_button.click()
+        home_2.home_button.click()
+        home_2.get_chat_with_user(username_1).is_element_present(20)
+        profile_2 = home_2.profile_button.click()
         profile_2.logout()
         device_2.set_network_connection(1)  # airplane mode
-
         message_text = 'test message'
         chat_1.chat_message_input.send_keys(message_text)
         chat_1.send_message_button.click()
-
         sign_in_2.click_account_by_position(0)
         sign_in_2.sign_in('qwerty1234')
         sign_in_2.home_button.wait_for_visibility_of_element()
-
         if not home_2.offline_label.is_element_displayed():
             self.errors.append('Offline label is not shown on Home view while being offline')
         chat_2 = home_2.get_chat_with_user(username_1).click()

--- a/test/cljs/status_im/react_native/js_dependencies.cljs
+++ b/test/cljs/status_im/react_native/js_dependencies.cljs
@@ -8,7 +8,7 @@
 (def emoji-picker           #js {:default #js {}})
 (def fs                     #js {})
 (def http-bridge            #js {})
-(def i18n                   #js {})
+(def i18n                   #js {:locale "en"})
 (def image-crop-picker      #js {})
 (def image-resizer          #js {})
 (def instabug               #js {})

--- a/test/cljs/status_im/test/chat/subs.cljs
+++ b/test/cljs/status_im/test/chat/subs.cljs
@@ -3,6 +3,23 @@
             [status-im.constants :as const]
             [status-im.chat.subs :as s]))
 
+(deftest chat-name
+  (testing "it prepends # if it's a public chat"
+    (is (= "#withhash" (s/chat-name {:group-chat true
+                                     :chat-id "1"
+                                     :public? true
+                                     :name "withhash"} nil))))
+  (testing "it leaves the name unchanged if it's a group chat"
+    (is (= "unchanged" (s/chat-name {:group-chat true
+                                     :chat-id "1"
+                                     :name "unchanged"} nil))))
+  (testing "it pulls the name from contact if it's a one-to-one"
+    (is (= "this-one" (s/chat-name {:chat-id "1"
+                                    :name "not-this-one"} {:name "this-one"}))))
+  (testing "it generates the name from chat id if no contact"
+    (is (= "Blond Cooperative Coelacanth" (s/chat-name {:chat-id "1"
+                                                        :name "not-this-one"} nil)))))
+
 (deftest message-stream-tests
   (testing "messages with no interspersed datemarks"
     (let [m1 {:from "1"


### PR DESCRIPTION
fixes #4325

### Summary:

We don't create anymore chats on contact requests/updates. 

I have also moved the name generation in subs as it was in 2 places, and removed the denormalization of `name` in 1-to-1 chats.

I have migrated the data as well, not sure if `js-delete` is needed when removing fields, but I had written it already, so leaving it here, let me know if it's not needed.

status: ready 