### PR TITLE
Use `if-not` for error handling in ethereum core functions.

### DIFF
--- a/src/status_im/utils/ethereum/core.cljs
+++ b/src/status_im/utils/ethereum/core.cljs
@@ -109,24 +109,24 @@
 (defn get-block-number [web3 cb]
   (.getBlockNumber (.-eth web3)
                    (fn [error result]
-                     (if (seq error)
-                       (handle-error error)
-                       (cb result)))))
+                     (if-not error
+                       (cb result)
+                       (handle-error error)))))
 
 (defn get-block-info [web3 number cb]
   (.getBlock (.-eth web3) number (fn [error result]
-                                   (if (seq error)
-                                     (handle-error error)
-                                     (cb (js->clj result :keywordize-keys true))))))
+                                   (if-not error
+                                     (cb (js->clj result :keywordize-keys true))
+                                     (handle-error error)))))
 
 (defn get-transaction [web3 number cb]
   (.getTransaction (.-eth web3) number (fn [error result]
-                                         (if (seq error)
-                                           (handle-error error)
-                                           (cb (js->clj result :keywordize-keys true))))))
+                                         (if-not error
+                                           (cb (js->clj result :keywordize-keys true))
+                                           (handle-error error)))))
 
 (defn get-transaction-receipt [web3 number cb]
   (.getTransactionReceipt (.-eth web3) number (fn [error result]
-                                                (if (seq error)
-                                                  (handle-error error)
-                                                  (cb (js->clj result :keywordize-keys true))))))
+                                                (if-not error
+                                                  (cb (js->clj result :keywordize-keys true))
+                                                  (handle-error error)))))


### PR DESCRIPTION
That fixes the exception if we have an error that isn't a string and does not conform to `ISeqable`.

Also, it makes this file follow the pattern in the other parts of the code (like `transport.shh`, `transport.inbox` and `wallet.events`.

fixes #4312, #4316

### Steps to test:
- Open Status, create your account normally
- Quit Status
- On your firewall, block traffic to infura.io
- Open Status
- You should be able to sign-in successfully


status: ready
