### PR TITLE
Embed status-go sources build #4278

### DIFF
--- a/modules/react-native-status/desktop/CMakeLists.txt
+++ b/modules/react-native-status/desktop/CMakeLists.txt
@@ -1,17 +1,64 @@
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR})
+find_package(Go REQUIRED)
+
 set(REACT_NATIVE_DESKTOP_EXTERNAL_MODULES_TYPE_NAMES ${REACT_NATIVE_DESKTOP_EXTERNAL_MODULES_TYPE_NAMES}
                                                      \"RCTStatus\" PARENT_SCOPE)
 
 set(REACT_NATIVE_DESKTOP_EXTERNAL_MODULES_SRC ${REACT_NATIVE_DESKTOP_EXTERNAL_MODULES_SRC}
                                               ${CMAKE_CURRENT_SOURCE_DIR}/rctstatus.cpp PARENT_SCOPE)
 
+include(${CMAKE_ROOT}/Modules/ExternalProject.cmake)
+
+if (WIN32 AND NOT CUSTOM_STATUSGO_BUILD_DIR_PATH)
+  set(CUSTOM_STATUSGO_BUILD_DIR_PATH "C:/srd-build/StatusGo")
+endif()
+if (CUSTOM_STATUSGO_BUILD_DIR_PATH)
+  set(StatusGo_ROOT ${CUSTOM_STATUSGO_BUILD_DIR_PATH})
+else()
+  set(StatusGo_ROOT "${CMAKE_CURRENT_BINARY_DIR}/StatusGo")
+endif()
+set(StatusGo_PREFIX "${StatusGo_ROOT}/src/github.com/status-im")
+set(StatusGo_SOURCE_DIR  "${StatusGo_PREFIX}/status-go")
+set(StatusGo_INCLUDE_DIR "${StatusGo_SOURCE_DIR}/build/bin")
+set(StatusGo_STATIC_LIB
+     "${StatusGo_SOURCE_DIR}/build/bin/${CMAKE_STATIC_LIBRARY_PREFIX}status${CMAKE_STATIC_LIBRARY_SUFFIX}")
+
+include_directories(${StatusGo_INCLUDE_DIR})
+
+if (WIN32)
+  set(CONFIGURE_SCRIPT build-status-go.bat)
+else()
+  set(CONFIGURE_SCRIPT build-status-go.sh)
+endif()
+
+ExternalProject_Add(StatusGo_ep
+  PREFIX ${StatusGo_PREFIX}
+  SOURCE_DIR ${StatusGo_SOURCE_DIR}
+  GIT_REPOSITORY https://github.com/status-im/status-go.git
+  GIT_TAG origin/develop-desktop
+  BUILD_BYPRODUCTS ${StatusGo_STATIC_LIB}
+  CONFIGURE_COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/${CONFIGURE_SCRIPT} ${GO_ROOT_PATH} ${StatusGo_ROOT} ${StatusGo_SOURCE_DIR}
+  BUILD_COMMAND ""
+  INSTALL_COMMAND ""
+)
+
+set(REACT_NATIVE_DESKTOP_EXTERNAL_PROJECT_DEPS ${REACT_NATIVE_DESKTOP_EXTERNAL_PROJECT_DEPS} StatusGo_ep PARENT_SCOPE)
+
+if (APPLE)
+  set(STATUSGO_DEPS_LIBS "-framework Foundation"
+                         "-framework CoreServices"
+                         "-framework IOKit"
+                         "-framework Security" pthread)
+elseif (WIN32)
+  set(STATUSGO_DEPS_LIBS -lWinMM -lWS2_32 -lsetupapi)
+else()
+  set(STATUSGO_DEPS_LIBS pthread)
+endif()
+
 set(REACT_NATIVE_DESKTOP_EXTERNAL_MODULES_LIBS ${REACT_NATIVE_DESKTOP_EXTERNAL_MODULES_LIBS}
-                                               "/Users/vkjr/work/projects/github/build_status_go/src/github.com/status-im/status-go/build/bin/libstatus.a"
-                                                "-framework Foundation"
-                                                "-framework CoreServices"
-                                                "-framework IOKit"
-                                                "-framework Security" pthread PARENT_SCOPE)
+  ${StatusGo_STATIC_LIB} ${STATUSGO_DEPS_LIBS} PARENT_SCOPE)
 
 set(REACT_NATIVE_DESKTOP_EXTERNAL_MODULES_INCLUDE_DIRS ${REACT_NATIVE_DESKTOP_EXTERNAL_MODULES_INCLUDE_DIRS}
-                                               "/Users/vkjr/work/projects/github/build_status_go/src/github.com/status-im/status-go/build/bin/" PARENT_SCOPE)
+  ${StatusGo_INCLUDE_DIR} PARENT_SCOPE)

--- a/modules/react-native-status/desktop/FindGo.cmake
+++ b/modules/react-native-status/desktop/FindGo.cmake
@@ -1,0 +1,34 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# The module defines the following variables:
+#   GO_FOUND - true if the Go was found
+#   GO_EXECUTABLE - path to the executable
+#   GO_VERSION - Go version number
+#   GO_PLATFORM - i.e. linux
+#   GO_ARCH - i.e. amd64
+# Example usage:
+#   find_package(Go 1.2 REQUIRED)
+
+
+find_program(GO_EXECUTABLE go PATHS ENV GOROOT GOPATH GOBIN PATH_SUFFIXES bin)
+if (GO_EXECUTABLE)
+    get_filename_component(GO_ROOT_PATH ${GO_EXECUTABLE}/../.. ABSOLUTE)
+    message(STATUS "GO_ROOT_PATH is set to: ${GO_ROOT_PATH}")
+    execute_process(COMMAND ${GO_EXECUTABLE} version OUTPUT_VARIABLE GO_VERSION_OUTPUT OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if(GO_VERSION_OUTPUT MATCHES "go([0-9]+\\.[0-9]+\\.?[0-9]*)[a-zA-Z0-9]* ([^/]+)/(.*)")
+        set(GO_VERSION ${CMAKE_MATCH_1})
+        set(GO_PLATFORM ${CMAKE_MATCH_2})
+        set(GO_ARCH ${CMAKE_MATCH_3})
+    elseif(GO_VERSION_OUTPUT MATCHES "go version devel .* ([^/]+)/(.*)$")
+        set(GO_VERSION "99-devel")
+        set(GO_PLATFORM ${CMAKE_MATCH_1})
+        set(GO_ARCH ${CMAKE_MATCH_2})
+        message("WARNING: Development version of Go being used, can't determine compatibility.")
+    endif()
+endif()
+mark_as_advanced(GO_EXECUTABLE)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Go REQUIRED_VARS GO_EXECUTABLE GO_VERSION GO_PLATFORM GO_ARCH VERSION_VAR GO_VERSION)

--- a/modules/react-native-status/desktop/build-status-go.bat
+++ b/modules/react-native-status/desktop/build-status-go.bat
@@ -1,0 +1,8 @@
+ set GOROOT=%1
+ set GOPATH=%2
+ set PATH=%GOROOT%/bin;%GOROOT%;%GOPATH%;%PATH%
+ 
+ cd %3/lib
+ go get .
+ cd ..
+ mingw32-make statusgo-library

--- a/modules/react-native-status/desktop/build-status-go.sh
+++ b/modules/react-native-status/desktop/build-status-go.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+ export GOROOT=$1
+ export GOPATH=$2
+ export PATH=$GOROOT/bin:$GOROOT:$GOPATH:$PATH
+ 
+ cd $3/lib
+ go get .
+ cd ..
+ make statusgo-library


### PR DESCRIPTION
status-go library is built automatically (as external cmake project) from the sources during cmake build scripts run.
Tested on Windows and Ubuntu.