### PR TITLE
Handle cross-network /send and /receive commands

### DIFF
--- a/resources/js/bots/transactor/bot.js
+++ b/resources/js/bots/transactor/bot.js
@@ -563,13 +563,15 @@ var paramsGroupRequest = [recipientRequestParam, amountRequestParam];
 
 function handlePersonalRequest(params, context) {
     var val = params["amount"].replace(",", ".");
+    var network = context["network"];
 
     return {
         event: "request",
         request: {
             command: "send",
             params: {
-                amount: val
+                network: network,
+                amount: val,
             },
             prefill: [val]
         }
@@ -578,6 +580,7 @@ function handlePersonalRequest(params, context) {
 
 function handleGroupRequest(params, context) {
     var val = params["amount"].replace(",", ".");
+    var network = context["network"];
 
     return {
         event: "request",
@@ -585,6 +588,7 @@ function handleGroupRequest(params, context) {
             command: "send",
             params: {
                 recipient: context["current-account"]["name"],
+                network: network,
                 amount: val
             },
             prefill: [context["current-account"]["name"], val],

--- a/src/status_im/chat/events/commands.cljs
+++ b/src/status_im/chat/events/commands.cljs
@@ -2,6 +2,7 @@
   (:require [re-frame.core :as re-frame]
             [taoensso.timbre :as log]
             [status-im.chat.models.message :as models.message]
+            [status-im.utils.ethereum.core :as ethereum]
             [status-im.utils.handlers :as handlers]
             [status-im.i18n :as i18n]
             [status-im.utils.platform :as platform]))
@@ -10,8 +11,9 @@
 
 (defn- generate-context
   "Generates context for jail call"
-  [current-account-id chat-id group-chat? to]
+  [current-account-id chat-id group-chat? to network]
   (merge {:platform     platform/os
+          :network      (ethereum/network-names network)
           :from         current-account-id
           :to           to
           :chat         {:chat-id    chat-id
@@ -20,7 +22,7 @@
 
 (defn request-command-message-data
   "Requests command message data from jail"
-  [{:contacts/keys [contacts] :as db}
+  [{:contacts/keys [contacts] :keys [network] :as db}
    {{:keys [command command-scope-bitmask bot params type]} :content
     :keys [chat-id group-id] :as message}
    {:keys [data-type] :as opts}]
@@ -33,7 +35,7 @@
             to          (get-in contacts [chat-id :address])
             address     (get-in db [:account/account :address])
             jail-params {:parameters params
-                         :context    (generate-context address chat-id (models.message/group-message? message) to)}]
+                         :context    (generate-context address chat-id (models.message/group-message? message) to network)}]
         {:db        db
          :call-jail [{:jail-id                bot
                       :path                   path

--- a/src/status_im/chat/styles/message/message.cljs
+++ b/src/status_im/chat/styles/message/message.cljs
@@ -83,9 +83,12 @@
      :padding-right  10
      :align-items    align}))
 
-(def delivery-status
-  {:align-self    :flex-end
-   :padding-right 22})
+(defn delivery-status [outgoing]
+  (if outgoing
+    {:align-self    :flex-end
+     :padding-right 22}
+    {:align-self    :flex-start
+     :padding-left  16}))
 
 (def message-author
   {:width      photos/photo-size

--- a/src/status_im/translations/en.cljs
+++ b/src/status_im/translations/en.cljs
@@ -91,6 +91,7 @@
    :suggestions-commands                 "Commands"
    :faucet-success                       "Faucet request has been received"
    :faucet-error                         "Faucet request error"
+   :network-mismatch                     "Network mismatch"
 
    ;;sync
    :sync-in-progress                     "Syncing..."

--- a/src/status_im/ui/screens/subs.cljs
+++ b/src/status_im/ui/screens/subs.cljs
@@ -1,5 +1,6 @@
 (ns status-im.ui.screens.subs
   (:require [re-frame.core :refer [reg-sub subscribe]]
+            [status-im.utils.ethereum.core :as ethereum]
             status-im.chat.subs
             status-im.commands.subs
             status-im.ui.screens.accounts.subs
@@ -35,6 +36,8 @@
          :<- [:get-current-account]
          (fn [current-account]
            (get (:networks current-account) (:network current-account))))
+
+(reg-sub :network-name (comp ethereum/network-names :network))
 
 (reg-sub :sync-state :sync-state)
 (reg-sub :network-status :network-status)

--- a/src/status_im/utils/ethereum/core.cljs
+++ b/src/status_im/utils/ethereum/core.cljs
@@ -13,6 +13,14 @@
    :testnet {:id 3 :name "Ropsten"}
    :rinkeby {:id 4 :name "Rinkeby"}})
 
+(def network-names
+  {"mainnet"     "mainnet"
+   "mainnet_rpc" "mainnet"
+   "testnet"     "testnet"
+   "testnet_rpc" "testnet"
+   "rinkeby"     "rinkeby"
+   "rinkeby_rpc" "rinkeby"})
+
 (defn chain-id->chain-keyword [i]
   (some #(when (= i (:id (val %))) (key %)) chains))
 


### PR DESCRIPTION
Fixes #4171

If network mismatch:
* Disable on-press action for /receive command (i.e. it does not trigger /send command)
* Show warning message with network name where command was sent from

status: ready

<img width="530" alt="screenshot 2018-05-18 16 25 52" src="https://user-images.githubusercontent.com/23836/40244938-e0c7ed6c-5acc-11e8-8e07-56fde27545e3.png">
