### PR TITLE
Ask PN permissions on iOS when account recovered

### DIFF
--- a/src/status_im/ui/screens/accounts/events.cljs
+++ b/src/status_im/ui/screens/accounts/events.cljs
@@ -128,13 +128,13 @@
  (fn [{{:accounts/keys [create] :as db} :db :as cofx} _]
    (handlers-macro/merge-fx cofx
                             {:db       db
-                             :dispatch [:navigate-to-clean :usage-data [:account-finalized]]}
+                             :dispatch [:navigate-to-clean :usage-data [:account-finalized true]]}
                             (accounts.utils/account-update {:name (:name create)}))))
 
 (handlers/register-handler-fx
  :account-finalized
- (fn [{db :db} _]
-   {:db (assoc db :accounts/create {:show-welcome? true})
+ (fn [{db :db} [_ show-welcome?]]
+   {:db (assoc db :accounts/create {:show-welcome? show-welcome?})
     :dispatch-n [[:navigate-to-clean :home]
                  [:request-notifications]]}))
 

--- a/src/status_im/ui/screens/accounts/recover/events.cljs
+++ b/src/status_im/ui/screens/accounts/recover/events.cljs
@@ -45,7 +45,7 @@
        (-> db
            (accounts-events/add-account account)
            (assoc :dispatch [:login-account address password])
-           (assoc :dispatch-later [{:ms 2000 :dispatch [:navigate-to :usage-data]}]))))))
+           (assoc :dispatch-later [{:ms 2000 :dispatch [:navigate-to :usage-data [:account-finalized false]]}]))))))
 
 (handlers/register-handler-fx
  :recover-account


### PR DESCRIPTION
fixes #4240 

### Summary:

Ask push notifications permissions on iOS for recovered accounts.

### Steps to test:
- Uninstall Status
- Install Status
- Recover account
- Make sure app asks for PN access

status: ready
