### PR TITLE
Fix network id lookup

### DIFF
--- a/src/status_im/commands/events/loading.cljs
+++ b/src/status_im/commands/events/loading.cljs
@@ -37,7 +37,7 @@
   [{:keys [db get-local-storage-data]} commands-resource whisper-identity]
   (let [data                  (get-local-storage-data whisper-identity)
         local-storage-snippet (js-resources/local-storage-data data)
-        network-id            (get-in db [:account/account :networks (:network db) :raw-config :NetworkId])
+        network-id            (get-in db [:account/account :networks (:network db) :config :NetworkId])
         ethereum-id-snippet   (js-resources/network-id network-id)
         commands-snippet      (str local-storage-snippet ethereum-id-snippet commands-resource)]
     {::evaluate-jail-n [{:jail-id       whisper-identity

--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -34,14 +34,6 @@
            ;; TODO(jeluard) Restore once we support postponing transaction
            #_{:id :postponed :label (i18n/label :t/postponed) :checked? true}]}})
 
-(defn- transform-config [networks]
-  (->> networks
-       (map (fn [[network-name {:keys [config] :as data}]]
-              [network-name (assoc data
-                                   :config (types/clj->json config)
-                                   :raw-config config)]))
-       (into {})))
-
 (def mainnet-networks
   {"mainnet"     {:id     "mainnet",
                   :name   "Mainnet",
@@ -77,9 +69,8 @@
                                             :URL     "https://rinkeby.infura.io/z6GCTmjdP3FETEJmMBI4"}}}})
 
 (def default-networks
-  (transform-config
-   (merge testnet-networks
-          mainnet-networks)))
+  (merge testnet-networks
+         mainnet-networks))
 
 (def default-wnodes
   {:testnet {"mailserver-a" {:id      "mailserver-a"

--- a/src/status_im/data_store/accounts.cljs
+++ b/src/status_im/data_store/accounts.cljs
@@ -1,6 +1,7 @@
 (ns status-im.data-store.accounts
   (:require [re-frame.core :as re-frame]
-            [status-im.data-store.realm.core :as core]))
+            [status-im.data-store.realm.core :as core]
+            [status-im.utils.types :as types]))
 
 ;; TODO janherich: define as cofx once debug handlers are refactored
 (defn get-by-address [address]
@@ -9,6 +10,15 @@
       (core/single-clj :account)
       (update :settings core/deserialize)))
 
+(defn- deserialize-account [account]
+  (-> account
+      (update :settings core/deserialize)
+      (update :networks (partial reduce-kv
+                                 (fn [acc network-id props]
+                                   (assoc acc network-id
+                                          (update props :config types/json->clj)))
+                                 {}))))
+
 (re-frame/reg-cofx
  :data-store/get-all-accounts
  (fn [coeffects _]
@@ -16,16 +26,20 @@
                                       (core/get-all :account)
                                       (core/all-clj :account)
                                       (as-> accounts
-                                            (map #(update % :settings core/deserialize) accounts))))))
+                                            (map deserialize-account accounts))))))
+
+(defn- serialize-account [account]
+  (-> account
+      (update :settings core/serialize)
+      (update :networks (partial map (fn [[_ props]]
+                                       (update props :config types/clj->json))))))
 
 (defn save-account-tx
   "Returns tx function for saving account"
   [{:keys [after-update-event] :as account}]
   (fn [realm]
-    (let [account-to-save (-> account
-                              (dissoc :after-update-event)
-                              (update :settings core/serialize)
-                              (update :networks vals))]
+    (let [account-to-save (-> (serialize-account account)
+                              (dissoc :after-update-event))]
       (core/create realm :account account-to-save true)
       (when after-update-event
         (re-frame/dispatch after-update-event)))))

--- a/src/status_im/ui/screens/events.cljs
+++ b/src/status_im/ui/screens/events.cljs
@@ -165,7 +165,7 @@
       (if should-move?
         (re-frame/dispatch [:request-permissions {:permissions [:read-external-storage]
                                                   :on-allowed  #(move-to-internal-storage config)}])
-        (status/start-node config))))))
+        (status/start-node (types/clj->json config)))))))
 
 (re-frame/reg-fx
  ::status-module-initialized-fx

--- a/src/status_im/ui/screens/network_settings/db.cljs
+++ b/src/status_im/ui/screens/network_settings/db.cljs
@@ -4,7 +4,7 @@
 
 (spec/def :networks/id string?)
 (spec/def :networks/name string?)
-(spec/def :networks/config string?)
+(spec/def :networks/config map?)
 
 (spec/def :networks/network
   (spec/keys :req-un [:networks/id :networks/name :networks/config]))

--- a/src/status_im/utils/ethereum/core.cljs
+++ b/src/status_im/utils/ethereum/core.cljs
@@ -22,11 +22,8 @@
 (defn testnet? [id]
   (contains? #{(chain-keyword->chain-id :testnet) (chain-keyword->chain-id :rinkeby)} id))
 
-(defn network-config [network]
-  (or (:raw-config network) (types/json->clj (:config network))))
-
 (defn network-with-upstream-rpc? [network]
-  (get-in (network-config network) [:UpstreamConfig :Enabled]))
+  (get-in network [:config :UpstreamConfig :Enabled]))
 
 (def hex-prefix "0x")
 
@@ -41,7 +38,7 @@
     (.isAddress dependencies/Web3.prototype s)))
 
 (defn network->chain-id [network]
-  (:NetworkId (network-config network)))
+  (get-in network [:config :NetworkId]))
 
 (defn network->chain-keyword [network]
   (chain-id->chain-keyword (network->chain-id network)))


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes #4351 

### Summary:

In recent PR, we changed the structure of `:networks` in accounts, by removing `:rawConfig` property and leaving only serialised `:config` there. This broke the `:NetworkId` lookup necessary for bots.
Besides that, having serialised data in `:app-db` felt quite wrong, as that should be cljs datastructure and when data needs to be serialised/deserialised on peripheries (like realm/ethereum-node, etc.) it should be done there, so I changed it to work that way, fixing the bug in the progress.

### Testing notes (optional):
Test that #4351 doesn't happen anymore + wallet is still working fine

status: ready
