### PR TITLE
[#4053] Quickfix to not log passwords from the transaction screen.

### DIFF
--- a/src/status_im/utils/handlers.cljs
+++ b/src/status_im/utils/handlers.cljs
@@ -22,9 +22,12 @@
 
 (defn- pretty-print-event [ctx]
   (let [[first second] (get-coeffect ctx :event)]
-    (if (or (string? second) (keyword? second) (boolean? second))
-      (str first " " second)
-      first)))
+    ;; TODO wrap passwords in a custom type so it won't be possible to print them occasionally
+    (if (= first :wallet.send/set-password)
+      (str first " " "******") ;; special case not to expose password to the logs
+      (if (or (string? second) (keyword? second) (boolean? second))
+        (str first " " second)
+        first))))
 
 (def debug-handlers-names
   "Interceptor which logs debug information to js/console for each event."

--- a/test/appium/tests/__init__.py
+++ b/test/appium/tests/__init__.py
@@ -73,7 +73,7 @@ transaction_users['D_USER']['public_key'] = "0x049191be3d0b0258732a4c3bd66d2e68c
                                             "f51345417e42f56e16926b685f99448ac05b9608b0d42cf65ee58853f104696"
 
 transaction_users['E_USER'] = dict()
-transaction_users['E_USER']['password'] = "qwerty"
+transaction_users['E_USER']['password'] = "newuniquepassword12"
 transaction_users['E_USER']['passphrase'] = "sea ill guard bounce gesture tomato walnut fitness plastic affair oven transfer"
 transaction_users['E_USER']['username'] = "Chartreuse Comfortable Spadefoot"
 transaction_users['E_USER']['address'] = "f7cb60839c0de25e37be0391c33bb34a8f0f8414"
@@ -81,7 +81,7 @@ transaction_users['E_USER']['public_key'] = "0x04d27bda317be9b3d943db5e098b3ab1c
                                             "09499522623dc686f5d0a3233c7f1f9724849127cedb5511945e12ca3b4d297"
 
 transaction_users['F_USER'] = dict()
-transaction_users['F_USER']['password'] = "qwerty"
+transaction_users['F_USER']['password'] = "newuniquepassword12"
 transaction_users['F_USER']['passphrase'] = "style case lazy pole general section dawn royal slice evoke crowd boat"
 transaction_users['F_USER']['username'] = "Happygolucky Zigzag Stoat"
 transaction_users['F_USER']['address'] = "a94a2a7584620677d290549a96046e59a18f09ef"

--- a/test/appium/tests/test_transaction.py
+++ b/test/appium/tests/test_transaction.py
@@ -177,7 +177,8 @@ class TestTransaction(SingleDeviceTestCase):
         send_transaction.recent_recipients_button.click_until_presence_of_element(recent_recipient)
         recent_recipient.click()
         send_transaction.sign_transaction_button.click()
-        send_transaction.enter_password_input.send_keys(sender['password'])
+        send_transaction.enter_password_input.click()
+        send_transaction.send_as_keyevent(sender['password'])
         send_transaction.sign_transaction_button.click()
         send_transaction.got_it_button.click()
         if sender['password'] in str(home_view.logcat):


### PR DESCRIPTION
This is a quick fix to avoid printing a plaintext password for `:wallet.send/set-password` event. 
This PR is done in that quick manner to be able to land before the next release cut.

More proper implementation will follow and feedback on how to handle the proper implementation is welcome!

fixes #4053 

### Summary:


### Steps to test:
- Open Status
- Go to the Wallet
- Sent someone 0.1 ETH
- Type your password
- Open LogCat, search for `set-password`
- Make sure that you see `******` instead of a real password

status: ready