### PR TITLE
[fix #4369] add mailserver settings migrations

### DIFF
--- a/src/status_im/data_store/realm/schemas/base/core.cljs
+++ b/src/status_im/data_store/realm/schemas/base/core.cljs
@@ -1,7 +1,11 @@
 (ns status-im.data-store.realm.schemas.base.core
-  (:require [status-im.data-store.realm.schemas.base.v1.core :as v1]))
+  (:require [status-im.data-store.realm.schemas.base.v1.core :as v1]
+            [status-im.data-store.realm.schemas.base.v2.core :as v2]))
 
 ;; put schemas ordered by version
 (def schemas [{:schema        v1/schema
                :schemaVersion 1
-               :migration     v1/migration}])
+               :migration     v1/migration}
+              {:schema        v2/schema
+               :schemaVersion 2
+               :migration     v2/migration}])

--- a/src/status_im/data_store/realm/schemas/base/v2/account.cljs
+++ b/src/status_im/data_store/realm/schemas/base/v2/account.cljs
@@ -1,0 +1,43 @@
+(ns status-im.data-store.realm.schemas.base.v2.account
+  (:require [status-im.data-store.realm.core :as core]
+            [status-im.constants :as constants]
+            [taoensso.timbre :as log]
+            [goog.object :as object]))
+
+(def schema {:name       :account
+             :primaryKey :address
+             :properties {:address               :string
+                          :public-key            :string
+                          :name                  {:type :string :optional true}
+                          :email                 {:type :string :optional true}
+                          :status                {:type :string :optional true}
+                          :debug?                {:type :bool :default false}
+                          :photo-path            :string
+                          :signing-phrase        {:type :string}
+                          :mnemonic              {:type :string}
+                          :last-updated          {:type :int :default 0}
+                          :last-sign-in          {:type :int :default 0}
+                          :signed-up?            {:type    :bool
+                                                  :default false}
+                          :network               :string
+                          :networks              {:type       :list
+                                                  :objectType :network}
+                          :settings              {:type :string}
+                          :sharing-usage-data?   {:type :bool :default false}
+                          :dev-mode?             {:type :bool :default false}
+                          :seed-backed-up?       {:type :bool :default false}
+                          :wallet-set-up-passed? {:type    :bool
+                                                  :default false}}})
+
+(defn migration [old-realm new-realm]
+  (log/debug "migrating account schema v2")
+  (let [accounts     (.objects old-realm "account")
+        new-accounts (.objects new-realm "account")]
+    (dotimes [i (.-length accounts)]
+      (let [account     (aget accounts i)
+            new-account (aget new-accounts i)
+            settings    (core/deserialize (object/get account "settings"))]
+        (aset new-account
+              "settings"
+              (core/serialize (assoc settings
+                                     :wnode (:wnode (constants/default-account-settings)))))))))

--- a/src/status_im/data_store/realm/schemas/base/v2/core.cljs
+++ b/src/status_im/data_store/realm/schemas/base/v2/core.cljs
@@ -1,0 +1,11 @@
+(ns status-im.data-store.realm.schemas.base.v2.core
+  (:require [status-im.data-store.realm.schemas.base.v1.network :as network]
+            [status-im.data-store.realm.schemas.base.v2.account :as account]
+            [taoensso.timbre :as log]))
+
+(def schema [network/schema
+             account/schema])
+
+(defn migration [old-realm new-realm]
+  (log/debug "migrating base database v2: " old-realm new-realm)
+  (account/migration old-realm new-realm))


### PR DESCRIPTION
fix #4369 (see issue for details)

migrate mailserver settings so that old accounts can still fetch offline messages after upgrade

status: ready
