### PR TITLE
[#4361] Don't autocorrect incomplete and erroneous entries for transactions.

### DIFF
--- a/src/status_im/ui/screens/wallet/request/db.cljs
+++ b/src/status_im/ui/screens/wallet/request/db.cljs
@@ -5,7 +5,8 @@
 
 (spec/def ::amount (spec/nilable money/valid?))
 (spec/def ::amount-error (spec/nilable string?))
+(spec/def ::amount-text (spec/nilable string?))
 (spec/def ::symbol (spec/nilable keyword?))
 
 (spec/def :wallet/request-transaction (allowed-keys
-                                       :opt-un [::amount ::amount-error ::symbol]))
+                                       :opt-un [::amount ::amount-error ::amount-text ::symbol]))

--- a/src/status_im/ui/screens/wallet/request/events.cljs
+++ b/src/status_im/ui/screens/wallet/request/events.cljs
@@ -38,4 +38,5 @@
    (let [{:keys [value error]} (wallet-db/parse-amount amount)]
      {:db (-> db
               (assoc-in [:wallet :request-transaction :amount] (money/ether->wei value))
+              (assoc-in [:wallet :request-transaction :amount-text] amount)
               (assoc-in [:wallet :request-transaction :amount-error] error))})))

--- a/src/status_im/ui/screens/wallet/request/views.cljs
+++ b/src/status_im/ui/screens/wallet/request/views.cljs
@@ -27,7 +27,7 @@
 (views/defview send-transaction-request []
   ;; TODO(jeluard) both send and request flows should be merged
   (views/letsubs [{:keys [to to-name whisper-identity]} [:wallet.send/transaction]
-                  {:keys [amount amount-error]}         [:wallet.request/transaction]
+                  {:keys [amount amount-error amount-text]}         [:wallet.request/transaction]
                   scroll (atom nil)]
     [comp/simple-screen {:avoid-keyboard? true}
      [comp/toolbar (i18n/label :t/new-request)]
@@ -42,10 +42,17 @@
         [components/asset-selector {:disabled? true
                                     :symbol    :ETH}]
         [components/amount-selector {:error         amount-error
-                                     :input-options {:default-value  (str (money/to-fixed (money/wei->ether amount)))
-                                                     :max-length     21
+                                     :input-options {:max-length     21
                                                      :on-focus       (fn [] (when @scroll (utils/set-timeout #(.scrollToEnd @scroll) 100)))
-                                                     :on-change-text #(re-frame/dispatch [:wallet.request/set-and-validate-amount %])}}]]]
+                                                     :on-change-text #(re-frame/dispatch [:wallet.request/set-and-validate-amount %])
+                                                     ;; (similarly to status-im.ui.screens.wallet.send.views `send-transaction-panel`)
+                                                     ;; We only auto-correct and prettify user's input when it is valid and positive.
+                                                     ;; Otherwise, user might want to fix his input and autocorrection will give more harm than good.
+                                                     ;; Positive check is because we don't want to replace unfinished 0.000 with just plain 0, that is annoying and
+                                                     ;; potentially dangerous on this screen (e.g. sending 7 ETH instead of 0.0007)
+                                                     :default-value (if (pos? amount)
+                                                                      (str (money/to-fixed (money/wei->ether amount)))
+                                                                      amount-text)}}]]]
       [bottom-buttons/bottom-buttons styles/bottom-buttons
        nil ;; Force a phantom button to ensure consistency with other transaction screens which define 2 buttons
        [button/button {:disabled?           (not (and to amount))

--- a/src/status_im/ui/screens/wallet/send/db.cljs
+++ b/src/status_im/ui/screens/wallet/send/db.cljs
@@ -7,6 +7,7 @@
 (spec/def ::to (spec/nilable string?))
 (spec/def ::to-name (spec/nilable string?))
 (spec/def ::amount-error (spec/nilable string?))
+(spec/def ::amount-text (spec/nilable string?))
 (spec/def ::password (spec/nilable string?))
 (spec/def ::wrong-password? (spec/nilable boolean?))
 (spec/def ::id (spec/nilable string?))
@@ -26,7 +27,7 @@
 (spec/def ::method (spec/nilable string?))
 
 (spec/def :wallet/send-transaction (allowed-keys
-                                    :opt-un [::amount ::to ::to-name ::amount-error ::password
+                                    :opt-un [::amount ::to ::to-name ::amount-error ::amount-text ::password
                                              ::waiting-signal? ::signing? ::id ::later?
                                              ::camera-flashlight ::in-progress?
                                              ::wrong-password? ::from-chat? ::symbol ::advanced?

--- a/src/status_im/ui/screens/wallet/send/events.cljs
+++ b/src/status_im/ui/screens/wallet/send/events.cljs
@@ -74,6 +74,7 @@
    (let [{:keys [value error]} (wallet.db/parse-amount amount)]
      {:db (-> db
               (assoc-in [:wallet :send-transaction :amount] (money/ether->wei value))
+              (assoc-in [:wallet :send-transaction :amount-text] amount)
               (assoc-in [:wallet :send-transaction :amount-error] error))})))
 
 (handlers/register-handler-fx


### PR DESCRIPTION
When a user types an invalid number (like "0..0") or he just pauses during typing a long list of zeroes (0.00000<pause>), don't auto replace his text with the parsed amount.

fixes #4361 

### Steps to test:
- Open Status
- Go to wallet
- Type "0.000<pause>07".
- 0.00007 should be in the window.

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->
