### PR TITLE
bug #4360 - fixed regression with inconsistent use of network and cha…

### DIFF
--- a/src/status_im/ui/screens/wallet/events.cljs
+++ b/src/status_im/ui/screens/wallet/events.cljs
@@ -66,14 +66,14 @@
 
 (reg-fx
  :get-transactions
- (fn [{:keys [web3 network account-id token-addresses success-event error-event]}]
-   (transactions/get-transactions network
+ (fn [{:keys [web3 chain account-id token-addresses success-event error-event]}]
+   (transactions/get-transactions chain
                                   account-id
                                   #(re-frame/dispatch [success-event %])
                                   #(re-frame/dispatch [error-event %]))
    (doseq [direction [:inbound :outbound]]
      (erc20/get-token-transactions web3
-                                   network
+                                   chain
                                    token-addresses
                                    direction
                                    account-id
@@ -139,7 +139,7 @@
            token-addresses (map :address all-tokens)]
        {:get-transactions {:account-id      (get-in db [:account/account :address])
                            :token-addresses token-addresses
-                           :network         chain
+                           :chain           chain
                            :web3            web3
                            :success-event   :update-transactions-success
                            :error-event     :update-transactions-fail}

--- a/src/status_im/utils/ethereum/erc20.cljs
+++ b/src/status_im/utils/ethereum/erc20.cljs
@@ -149,9 +149,8 @@
 (defn get-token-transfer-logs
   ;; NOTE(goranjovic): here we use direct JSON-RPC calls to get event logs because of web3 event issues with infura
   ;; we still use web3 to get other data, such as block info
-  [web3 current-block-number network contracts direction address cb]
-  (let [chain (ethereum/network->chain-keyword network)
-        [from to] (if (= :inbound direction)
+  [web3 current-block-number chain contracts direction address cb]
+  (let [[from to] (if (= :inbound direction)
                     [nil (ethereum/normalized-address address)]
                     [(ethereum/normalized-address address) nil])
         args {:jsonrpc "2.0"
@@ -167,6 +166,6 @@
                               (response-handler web3 current-block-number chain direction ethereum/handle-error cb))))
 
 (defn get-token-transactions
-  [web3 network contracts direction address cb]
+  [web3 chain contracts direction address cb]
   (ethereum/get-block-number web3
-                             #(get-token-transfer-logs web3 % network contracts direction address cb)))
+                             #(get-token-transfer-logs web3 % chain contracts direction address cb)))

--- a/src/status_im/utils/transactions.cljs
+++ b/src/status_im/utils/transactions.cljs
@@ -2,26 +2,26 @@
   (:require [status-im.utils.http :as http]
             [status-im.utils.types :as types]))
 
-(defn- get-network-subdomain [network]
-  (case network
+(defn- get-network-subdomain [chain]
+  (case chain
     (:testnet) "ropsten"
     (:mainnet) nil
     (:rinkeby) "rinkeby"))
 
-(defn get-transaction-details-url [network hash]
-  (let [network-subdomain (get-network-subdomain network)]
+(defn get-transaction-details-url [chain hash]
+  (let [network-subdomain (get-network-subdomain chain)]
     (str "https://" (when network-subdomain (str network-subdomain ".")) "etherscan.io/tx/" hash)))
 
 (def etherscan-api-key "DMSI4UAAKUBVGCDMVP3H2STAMSAUV7BYFI")
 
-(defn- get-api-network-subdomain [network]
-  (case network
+(defn- get-api-network-subdomain [chain]
+  (case chain
     (:testnet) "api-ropsten"
     (:mainnet) "api"
     (:rinkeby) "api-rinkeby"))
 
-(defn get-transaction-url [network account]
-  (let [network-subdomain (get-api-network-subdomain network)]
+(defn get-transaction-url [chain account]
+  (let [network-subdomain (get-api-network-subdomain chain)]
     (str "https://" network-subdomain ".etherscan.io/api?module=account&action=txlist&address=0x"
          account "&startblock=0&endblock=99999999&sort=desc&apikey=" etherscan-api-key "?q=json")))
 
@@ -51,7 +51,7 @@
                  (assoc transactions hash (format-transaction account transaction)))
                {})))
 
-(defn get-transactions [network account on-success on-error]
-  (http/get (get-transaction-url network account)
+(defn get-transactions [chain account on-success on-error]
+  (http/get (get-transaction-url chain account)
             #(on-success (format-transactions-response % account))
             on-error))


### PR DESCRIPTION
fixes #4360

### Summary:

In #4239 code was updated to use chain id instead of network id (i.e. `:testnet` vs say `"testnet_rpc"`) but didn't propagate the change to the code that gets token transactions which caused a regression.

This PR fixes the issue and updates parameter names to avoid the confusion.

### Steps to test:
- Open Status
- Get some tokens
- Open transaction history

status: ready 