### PR TITLE
bug #4381 - fixed regression in wallet qr code scanner caused by netw…

### DIFF
--- a/src/status_im/ui/screens/wallet/choose_recipient/events.cljs
+++ b/src/status_im/ui/screens/wallet/choose_recipient/events.cljs
@@ -38,7 +38,7 @@
  :wallet/fill-request-from-url
  (fn [{{:keys [network] :as db} :db} [_ data]]
    (let [{:keys [view-id]}                db
-         current-chain-id                 (get-in constants/default-networks [network :raw-config :NetworkId])
+         current-chain-id                 (get-in constants/default-networks [network :config :NetworkId])
          {:keys [address chain-id] :as details} (extract-details data current-chain-id)
          valid-network?                   (boolean (= current-chain-id chain-id))]
      (cond-> {:db         db


### PR DESCRIPTION
fixes #4381

### Summary:

Fixes network id lookup in Wallet QR code scanner. Same thing as in #4363 but in a different place

### Steps to test:
- Open Wallet > Send > Choose recipient > Qr code
- Try to scan a qr code on the same network

status: ready 