### PR TITLE
[#4394] *Really* hide inactive tabs on the main screen (using zIndex).

### DIFF
--- a/components/src/status_im/ui/components/react.cljs
+++ b/components/src/status_im/ui/components/react.cljs
@@ -192,9 +192,11 @@
                         (= views current-view))
 
         style (if current-view?
-                {:flex 1}
+                {:flex   1
+                 :zIndex 0}
                 {:opacity 0
-                 :flex    0})
+                 :flex    0
+                 :zIndex -1})
 
         component' (if (fn? component) [component] component)]
 


### PR DESCRIPTION
fixes #4394 

Otherwise, leftovers from other screens (like images and labels) are still present and preventing from tapping certain areas.

status: ready <!-- Can be ready or wip -->
