### PR TITLE
Safe message confirmations

### DIFF
--- a/src/status_im/transport/handlers.cljs
+++ b/src/status_im/transport/handlers.cljs
@@ -171,6 +171,8 @@
                           (keep :js-obj)
                           (apply array))]
      (when (pos? (.-length js-messages))
-       (.. web3
-           -shh
-           (confirmMessagesProcessed js-messages (fn [_ _])))))))
+       (.confirmMessagesProcessed (transport.utils/shh web3)
+                                  js-messages
+                                  (fn [err resp]
+                                    (when err
+                                      (log/info "Confirming message processed failed"))))))))

--- a/src/status_im/transport/message/v1/protocol.cljs
+++ b/src/status_im/transport/message/v1/protocol.cljs
@@ -33,25 +33,25 @@
   ;; we assume that the chat contains the contact public-key
   (let [{:keys [current-public-key web3]} db
         {:keys [sym-key-id topic]} (get-in db [:transport/chats chat-id])]
-    {:shh/post {:web3          web3
-                :success-event success-event
-                :message       (merge {:sig      current-public-key
-                                       :symKeyID sym-key-id
-                                       :payload  payload
-                                       :topic    topic}
-                                      whisper-opts)}}))
+    {:shh/post [{:web3          web3
+                 :success-event success-event
+                 :message       (merge {:sig      current-public-key
+                                        :symKeyID sym-key-id
+                                        :payload  payload
+                                        :topic    topic}
+                                       whisper-opts)}]}))
 
 (defn send-with-pubkey
   "Sends the payload using asymetric key (`:current-public-key` in db) and fixed discovery topic"
   [{:keys [payload chat-id success-event]} {:keys [db] :as cofx}]
   (let [{:keys [current-public-key web3]} db]
-    {:shh/post {:web3          web3
-                :success-event success-event
-                :message       (merge {:sig     current-public-key
-                                       :pubKey  chat-id
-                                       :payload payload
-                                       :topic   (transport.utils/get-topic constants/contact-discovery)}
-                                      whisper-opts)}}))
+    {:shh/post [{:web3          web3
+                 :success-event success-event
+                 :message       (merge {:sig     current-public-key
+                                        :pubKey  chat-id
+                                        :payload payload
+                                        :topic   (transport.utils/get-topic constants/contact-discovery)}
+                                       whisper-opts)}]}))
 
 (defn- prepare-recipients [public-keys db]
   (map (fn [public-key]

--- a/src/status_im/transport/shh.cljs
+++ b/src/status_im/transport/shh.cljs
@@ -60,15 +60,16 @@
 
 (re-frame/reg-fx
  :shh/post
- (fn [{:keys [web3 message success-event error-event]
-       :or {error-event :protocol/send-status-message-error}}]
-   (post-message {:web3            web3
-                  :whisper-message (update message :payload (comp transport.utils/from-utf8
-                                                                  transit/serialize))
-                  :on-success      (if success-event
-                                     #(re-frame/dispatch (conj success-event %))
-                                     #(log/debug :shh/post-success))
-                  :on-error        #(re-frame/dispatch [error-event %])})))
+ (fn [post-calls]
+   (doseq [{:keys [web3 message success-event error-event]
+            :or   {error-event :protocol/send-status-message-error}} post-calls]
+     (post-message {:web3            web3
+                    :whisper-message (update message :payload (comp transport.utils/from-utf8
+                                                                    transit/serialize))
+                    :on-success      (if success-event
+                                       #(re-frame/dispatch (conj success-event %))
+                                       #(log/debug :shh/post-success))
+                    :on-error        #(re-frame/dispatch [error-event %])}))))
 
 ;; This event params contain a recipients key because it's a vector of map with public-key and topic keys.
 ;; the :shh/post event has public-key and topic keys at the top level of the args map.

--- a/src/status_im/utils/handlers_macro.cljs
+++ b/src/status_im/utils/handlers_macro.cljs
@@ -9,8 +9,8 @@
 
 (def ^:private mergable-keys
   #{:data-store/tx :data-store/base-tx :chat-received-message/add-fx
-    :shh/add-new-sym-keys :call-jail :shh/get-new-sym-keys
-    :confirm-message-processed})
+    :shh/add-new-sym-keys :shh/get-new-sym-keys :shh/post
+    :confirm-message-processed :call-jail})
 
 (defn safe-merge [fx new-fx]
   (if (:merging-fx-with-common-keys fx)

--- a/test/cljs/status_im/test/chat/models/message.cljs
+++ b/test/cljs/status_im/test/chat/models/message.cljs
@@ -34,7 +34,7 @@
         message      {:chat-id "chat-id"
                       :from "a"
                       :message-id "1"}
-        extract-seen (comp :payload :message :shh/post)]
+        extract-seen (comp :payload :message first :shh/post)]
     (testing "it send a seen message when the chat is 1-to-1 and is open"
       (is (instance? protocol/MessagesSeen
                      (extract-seen (message/receive message db))))


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes #4395 

`:shh/post` effect (created by sending `Seen` confirmation) was not accumulated correctly, causing `:merging-with-common-keys-fx` being created (we should probably create some handler which will show us more info when such effect happens)

### Testing notes (optional):
Check that #4395 doesn't happen anymore

status: ready