### PR TITLE
Adding hide? to react/navigation-wrapper if the onboarding is not passed

### DIFF
--- a/src/status_im/ui/screens/main_tabs/views.cljs
+++ b/src/status_im/ui/screens/main_tabs/views.cljs
@@ -66,7 +66,8 @@
 
 (views/defview main-tabs []
   (views/letsubs [view-id          [:get :view-id]
-                  tab-bar-visible? [:tab-bar-visible?]]
+                  tab-bar-visible? [:tab-bar-visible?]
+                  {:keys [wallet-set-up-passed?]} [:get-current-account]]
     [react/view common.styles/flex
      [status-bar.view/status-bar {:type (if (= view-id :wallet) :wallet-tab :main)}]
      [react/view common.styles/main-container
@@ -84,6 +85,7 @@
         :preview  [react/view {}]}
        [react/navigation-wrapper
         {:component    wallet/wallet
+         :hide?        (not wallet-set-up-passed?)
          :views        :wallet
          :current-view view-id}]]
 


### PR DESCRIPTION
Fixes the issue described here: https://status-im.slack.com/archives/C8KB9DR60/p1527088583001042

<blockquote><img src="https://a.slack-edge.com/436da/marketing/img/meta/favicon-32.png" width="48" align="right"><div><strong><a href="https://status-im.slack.com/archives/C8KB9DR60/p1527088583001042">Slack</a></strong></div></blockquote>