### PR TITLE
bug #4123 - fixes incorrect number of decimals for tokens, fixes inco…

### DIFF
--- a/src/status_im/chat/events/shortcuts.cljs
+++ b/src/status_im/chat/events/shortcuts.cljs
@@ -14,7 +14,7 @@
 
 (defn send-shortcut-fx [db contact params]
   (merge {:db (-> db
-                  (send.events/set-and-validate-amount-db (:amount params))
+                  (send.events/set-and-validate-amount-db (:amount params) :ETH 18)
                   (choose-recipient.events/fill-request-details (transaction-details contact))
                   (navigation/navigate-to :wallet-send-transaction-chat))}
          (send.events/update-gas-price db false)))

--- a/src/status_im/ui/screens/subs.cljs
+++ b/src/status_im/ui/screens/subs.cljs
@@ -86,3 +86,7 @@
          (fn [db [_ item-id]]
            (let [item-animation (get-in db [:chat-animations item-id])]
              (if (some? item-animation) (:delete-swiped item-animation) nil))))
+
+(reg-sub :get-current-account-network
+         (fn [{:keys [network] :as db} [_]]
+           (get-in db [:account/account :networks network])))

--- a/src/status_im/ui/screens/wallet/components/views.cljs
+++ b/src/status_im/ui/screens/wallet/components/views.cljs
@@ -185,7 +185,8 @@
       [recipient-contact address name request?]
       [recipient-address address])]])
 
-(defn- amount-input [{:keys [input-options amount amount-text disabled?]}]
+(defn- amount-input [{:keys [input-options amount amount-text disabled?]}
+                     {:keys [symbol decimals]}]
   [react/view {:style               components.styles/flex
                :accessibility-label :specify-amount-button}
    [components/text-input
@@ -195,7 +196,9 @@
      ;; Otherwise, user might want to fix his input and autocorrection will give more harm than good.
      ;; Positive check is because we don't want to replace unfinished 0.000 with just plain 0, that is annoying and
      ;; potentially dangerous on this screen (e.g. sending 7 ETH instead of 0.0007)
-     {:default-value  (if (empty? amount-text) (str (money/to-fixed (money/wei->ether amount))) amount-text)}
+     {:default-value  (if (empty? amount-text)
+                        (str (money/to-fixed (money/internal->formatted amount symbol decimals)))
+                        amount-text)}
      (if disabled?
        {:editable false}
        {:keyboard-type       :numeric
@@ -203,7 +206,7 @@
         :style               components.styles/flex
         :accessibility-label :amount-input}))]])
 
-(defn amount-selector [{:keys [error disabled?] :as m}]
+(defn amount-selector [{:keys [error disabled?] :as m} token]
   [react/view
    [components/cartouche {:disabled? disabled?}
     (i18n/label :t/amount)

--- a/src/status_im/ui/screens/wallet/db.cljs
+++ b/src/status_im/ui/screens/wallet/db.cljs
@@ -16,11 +16,11 @@
 ;; Placeholder namespace for wallet specs, which are a WIP depending on data
 ;; model we decide on for balances, prices, etc.
 
-(defn- too-precise-amount? [amount]
+(defn- too-precise-amount? [amount decimals]
   (let [amount-splited (string/split amount #"[.]")]
-    (and (= (count amount-splited) 2) (> (count (last amount-splited)) 18))))
+    (and (= (count amount-splited) 2) (> (count (last amount-splited)) decimals))))
 
-(defn parse-amount [amount]
+(defn parse-amount [amount decimals]
   (when-not (empty? amount)
     (let [normalized-amount (money/normalize amount)
           value (money/bignumber normalized-amount)]
@@ -28,7 +28,7 @@
         (not (money/valid? value))
         {:error (i18n/label :t/validation-amount-invalid-number) :value value}
 
-        (too-precise-amount? normalized-amount)
+        (too-precise-amount? normalized-amount decimals)
         {:error (i18n/label :t/validation-amount-is-too-precise) :value value}
 
         :else

--- a/src/status_im/ui/screens/wallet/request/events.cljs
+++ b/src/status_im/ui/screens/wallet/request/events.cljs
@@ -35,7 +35,7 @@
 (handlers/register-handler-fx
  :wallet.request/set-and-validate-amount
  (fn [{:keys [db]} [_ amount]]
-   (let [{:keys [value error]} (wallet-db/parse-amount amount)]
+   (let [{:keys [value error]} (wallet-db/parse-amount amount :ETH)]
      {:db (-> db
               (assoc-in [:wallet :request-transaction :amount] (money/ether->wei value))
               (assoc-in [:wallet :request-transaction :amount-text] amount)

--- a/src/status_im/ui/screens/wallet/request/views.cljs
+++ b/src/status_im/ui/screens/wallet/request/views.cljs
@@ -45,7 +45,9 @@
                                      :amount-text amount-text
                                      :input-options {:max-length     21
                                                      :on-focus       (fn [] (when @scroll (utils/set-timeout #(.scrollToEnd @scroll) 100)))
-                                                     :on-change-text #(re-frame/dispatch [:wallet.request/set-and-validate-amount %])}}]]]
+                                                     :on-change-text #(re-frame/dispatch [:wallet.request/set-and-validate-amount %])}}
+         {:decimals 18
+          :symbol  :ETH}]]]
       [bottom-buttons/bottom-buttons styles/bottom-buttons
        nil ;; Force a phantom button to ensure consistency with other transaction screens which define 2 buttons
        [button/button {:disabled?           (not (and to amount))

--- a/src/status_im/utils/ethereum/tokens.cljs
+++ b/src/status_im/utils/ethereum/tokens.cljs
@@ -380,30 +380,26 @@
                     :symbol   :STT
                     :decimals 18
                     :address  "0xc55cf4b03948d7ebc8b9e8bad92643703811d162"}
-                   {:name     "Aragon Test Token"
-                    :symbol   :ATT
-                    :decimals 1
-                    :address  "0x00a8e52df8f4f1f4b67bded9ae6090b35489a973"}
                    {:name     "Handy Test Token"
                     :symbol   :HND
-                    :decimals 18
-                    :address  "0x9e47fb3049f0d9c953f5428ce2e6c3a8321780bf"}
+                    :decimals 0
+                    :address  "0xdee43a267e8726efd60c2e7d5b81552dcd4fa35c"}
                    {:name     "Lucky XS Test"
                     :symbol   :LXS
-                    :decimals 18
-                    :address  "0xf29d2dc0687d7d49f57d4a731ac8bfb6edc23473"}
+                    :decimals 2
+                    :address  "0x703d7dc0bc8e314d65436adf985dda51e09ad43b"}
                    {:name     "Adi Test Token"
                     :symbol   :ADI
-                    :decimals 18
-                    :address  "0xd2a816110c1177478c7e644ae4853d8e80aaec35"}
+                    :decimals 7
+                    :address  "0xe639e24346d646e927f323558e6e0031bfc93581"}
                    {:name     "Wagner Test Token"
                     :symbol   :WGN
-                    :decimals 18
-                    :address  "0x65c69bc258afa0906683f42e576b272a95c203dd"}
+                    :decimals 10
+                    :address  "0x2e7cd05f437eb256f363417fd8f920e2efa77540"}
                    {:name     "Modest Test Token"
                     :symbol   :MDS
                     :decimals 18
-                    :address  "0x972b0570d9cd8b7c41aa8349f707ec7356daa825"}])})
+                    :address  "0x57cc9b83730e6d22b224e9dc3e370967b44a2de0"}])})
 
 (defn tokens-for [chain]
   (get all chain))

--- a/src/status_im/utils/money.cljs
+++ b/src/status_im/utils/money.cljs
@@ -90,6 +90,32 @@
   (when-let [bn (bignumber n)]
     (.dividedBy bn (bignumber (from-decimal decimals)))))
 
+(defn unit->token [n decimals]
+  (when-let [bn (bignumber n)]
+    (.times bn (bignumber (from-decimal decimals)))))
+
+;;NOTE(goranjovic) - We have two basic representations of values that refer to cryptocurrency amounts: formatted and
+;; internal. Formatted representation is the one we show on screens and include in reports, whereas internal
+;; representation is the one that we pass on to ethereum network for execution, transfer, etc.
+;; The difference between the two depends on the number of decimals, i.e. internal representation is expressed in terms
+;; of a whole number of smallest divisible parts of the formatted value.
+;;
+;; E.g. for Ether, it's smallest part is wei or 10^(-18) of 1 ether
+;; for arbitrary ERC20 token the smallest part is 10^(-decimals) of 1 token
+;;
+;; Different tokens can have different number of allowed decimals, so it's neccessary to include the decimals parameter
+;; to get the amount scale right.
+
+(defn formatted->internal [n symbol decimals]
+  (if (= :ETH symbol)
+    (ether->wei n)
+    (unit->token n decimals)))
+
+(defn internal->formatted [n symbol decimals]
+  (if (= :ETH symbol)
+    (wei->ether n)
+    (token->unit n decimals)))
+
 (defn fee-value [gas gas-price]
   (.times (bignumber gas) (bignumber gas-price)))
 


### PR DESCRIPTION
partially addresses #4123

### Summary:

This PR fixes a number of bugs with sending tokens:

- incorrect network id lookup that prevents user from sending tokens
- incorrect handling of  number of decimals depending on token info (previously assumed 18 for all tokens like ether-wei)
- fixes amount formatting due to decimals where needed
- removes ATT since its transfer method works in a confusing way for testing (transfer adds funds to recipient, but doesn't remove the same funds for sender)
- changes other test tokens to include multiple decimal counts to make testing of this or any other related bugs easier


### Testing notes (optional):

I'm also submitting a PR for Simple Dapp with updated token addresses. Until it is deployed you'll have to use the old way to get tokens - send 0 eth to the following addresses:

```
HND - 0xdee43a267e8726efd60c2e7d5b81552dcd4fa35c
LXS - 0x703d7dc0bc8e314d65436adf985dda51e09ad43b
ADI - 0xe639e24346d646e927f323558e6e0031bfc93581
WGN - 0x2e7cd05f437eb256f363417fd8f920e2efa77540
MDS - 0x57cc9b83730e6d22b224e9dc3e370967b44a2de0
```

Don't forget to increase gas! (Sorry)

### Steps to test:
- Request assets
- Send assets to other participants
- Check tx history
- Check etherscan

status: ready 