### PR TITLE
Add expand/collapse button to long chat messages

### DIFF
--- a/src/status_im/chat/styles/message/message.cljs
+++ b/src/status_im/chat/styles/message/message.cljs
@@ -61,6 +61,12 @@
   (assoc (message-timestamp false)
          :color styles/color-white))
 
+(def message-expand-button
+  {:color         colors/gray
+   :font-size     12
+   :opacity       0.7
+   :margin-bottom 1})
+
 (def selected-message
   {:margin-top  18
    :margin-left 40
@@ -125,9 +131,10 @@
   {:padding-top 4})
 
 (defn text-message
-  [{:keys [outgoing group-chat incoming-group]}]
+  [{:keys [incoming-group]} collapsed?]
   (merge style-message-text
-         {:margin-top (if incoming-group 4 0)}))
+         {:margin-top    (if incoming-group 4 0)
+          :margin-bottom (if collapsed? 2 0)}))
 
 (defnstyle emoji-message
   [{:keys [incoming-group]}]

--- a/src/status_im/translations/en.cljs
+++ b/src/status_im/translations/en.cljs
@@ -243,6 +243,8 @@
    :empty-chat-description               "There are no messages \nin this chat yet"
    :empty-chat-description-console       "Look under the hood! Console is a javascript runtime environment that exposes the whole web3 API. Type \"web3.\" to get started."
    :counter-99-plus                      "99+"
+   :show-more                            "Show more"
+   :show-less                            "Show less"
 
    ;;discover
    :discover                             "Discover"


### PR DESCRIPTION
fixes #4343 

Add expand/collapse button to long chat messages in public and group chats.

status: ready

