### PR TITLE
Fix build with recent ndk

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -127,7 +127,7 @@ android {
         versionCode getVersionCode()
         versionName getVersionName()
         ndk {
-            abiFilters "armeabi-v7a", "x86"
+            abiFilters "armeabi-v7a", "arm64-v8a", "x86"
         }
     }
     /**
@@ -138,6 +138,11 @@ android {
     */
     packagingOptions {
         exclude 'META-INF/rxjava.properties'
+        /** Fix for: Execution failed for task ':app:transformNativeLibsWithStripDebugSymbolForDebug'.
+        *   with recent version of ndk (17.0.4754217)
+        */
+        doNotStrip '*/mips/*.so'
+        doNotStrip '*/mips64/*.so'
     }
     dexOptions {
         jumboMode true


### PR DESCRIPTION
On most recent versions of the android-ndk, there is no more support for mips architecture which we didn't use anyway.

status: ready
