### PR TITLE
Insert newline by shift+enter

### DIFF
--- a/src/status_im/ui/screens/desktop/main/chat/views.cljs
+++ b/src/status_im/ui/screens/desktop/main/chat/views.cljs
@@ -148,8 +148,8 @@
                                                   modifiers (js->clj (.-modifiers native-event))
                                                   should-send (and (= key "Enter") (not (contains? (set modifiers) "shift")))]
                                               (when should-send
-                                                (do (.clear @inp-ref)
-                                                    (.focus @inp-ref))
+                                                (.clear @inp-ref)
+                                                (.focus @inp-ref)
                                                 (re-frame/dispatch [:send-current-message]))))
                           :on-change      (fn [e]
                                             (let [native-event (.-nativeEvent e)

--- a/src/status_im/ui/screens/desktop/main/chat/views.cljs
+++ b/src/status_im/ui/screens/desktop/main/chat/views.cljs
@@ -144,18 +144,20 @@
                           :ref            #(reset! inp-ref %)
                           :on-key-press   (fn [e]
                                             (let [native-event (.-nativeEvent e)
-                                                  key (.-key native-event)]
-                                              (when (= key "Enter")
-                                                (js/setTimeout #(do
-                                                                  (.clear @inp-ref)
-                                                                  (.focus @inp-ref)) 200)
+                                                  key (.-key native-event)
+                                                  modifiers (js->clj (.-modifiers native-event))
+                                                  should-send (and (= key "Enter") (not (contains? (set modifiers) "shift")))]
+                                              (when should-send
+                                                (do (.clear @inp-ref)
+                                                    (.focus @inp-ref))
                                                 (re-frame/dispatch [:send-current-message]))))
                           :on-change      (fn [e]
                                             (let [native-event (.-nativeEvent e)
                                                   text (.-text native-event)]
                                               (re-frame/dispatch [:set-chat-input-text text])))}]]
       [react/touchable-highlight {:on-press (fn []
-                                              (js/setTimeout #(do (.clear @inp-ref)(.focus @inp-ref)) 200)
+                                              (.clear @inp-ref)
+                                              (.focus @inp-ref)
                                               (re-frame/dispatch [:send-current-message]))}
        [react/view {:style {:margin-left     16 :width 30 :height 30 :border-radius 15 :background-color "#eef2f5" :align-items :center
                             :justify-content :center :transform [{ :rotate "90deg"}]}}

--- a/src/status_im/ui/screens/desktop/main/tabs/profile/views.cljs
+++ b/src/status_im/ui/screens/desktop/main/tabs/profile/views.cljs
@@ -16,9 +16,10 @@
     [react/text
      label]
     [react/view {:height 10}]
+    [react/touchable-opacity {:on-press #(react/copy-to-clipboard value)}
     [react/text {:number-of-lines 1
                  :ellipsizeMode   :middle}
-     value]]])
+     value]]]])
 
 (defn my-profile-info [{:keys [public-key]}]
   [react/view


### PR DESCRIPTION

fixes #4271

### Summary:

[comment]: # (Summarise the problem and how the pull request solves it)
- Newline can be inserted by shilft+enter
- account key copied to clipboard when pressed

### Review notes (optional):
<!-- (Specify if something in particular should be looked at, or ignored, during review) -->

### Testing notes (optional):
<!-- (Specify if something specific has to be tested, for example upgrade paths) -->

### Steps to test:
- Open Status Desktop
- Open chat
- Write multiline message using shilft+enter
<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->
