### PR TITLE
bug 4123 - fixed dapp transactions and incorrect amount formatting in…

### DIFF
--- a/src/status_im/ui/screens/wallet/components/views.cljs
+++ b/src/status_im/ui/screens/wallet/components/views.cljs
@@ -210,7 +210,7 @@
   [react/view
    [components/cartouche {:disabled? disabled?}
     (i18n/label :t/amount)
-    [amount-input m]]
+    [amount-input m token]]
    (when error
      [tooltip/tooltip error])])
 

--- a/src/status_im/ui/screens/wallet/send/views.cljs
+++ b/src/status_im/ui/screens/wallet/send/views.cljs
@@ -115,9 +115,11 @@
 
 (defview transaction-fee []
   (letsubs [{:keys [amount symbol] :as transaction} [:wallet.send/transaction]
+            network [:get-current-account-network]
             edit [:wallet/edit]]
     (let [gas (or (:gas edit) (:gas transaction))
-          gas-price (or (:gas-price edit) (:gas-price transaction))]
+          gas-price (or (:gas-price edit) (:gas-price transaction))
+          {:keys [decimals]} (tokens/asset-for (ethereum/network->chain-keyword network) symbol)]
       [wallet.components/simple-screen {:status-toolbar-type :modal-wallet}
        [toolbar true act/close-white
         (i18n/label :t/wallet-transaction-fee)]
@@ -151,7 +153,7 @@
           (i18n/label :t/amount)
           [react/view {:accessibility-label :amount-input}
            [wallet.components/cartouche-text-content
-            (str (money/to-fixed (money/wei->ether amount)))
+            (str (money/to-fixed (money/internal->formatted amount symbol decimals)))
             (name symbol)]]]
          [wallet.components/cartouche {:disabled? true}
           (i18n/label :t/wallet-transaction-total-fee)
@@ -280,7 +282,7 @@
          (i18n/label :t/message)
          [components/amount-input {:disabled?     true
                                    :input-options {:multiline     true
-                                                   :default-value data}}]]]]
+                                                   :default-value data}} nil]]]]
       [signing-buttons
        #(re-frame/dispatch [:wallet/discard-transaction-navigate-back])
        #(re-frame/dispatch [:wallet/sign-transaction-modal])


### PR DESCRIPTION
fixes #4123

### Summary:

Missed two spots in PR #4428 - this PR fixes those issues
 - failing transactions that came from dapps
 - incorrect amount formatting in Transaction fee screen for non-18 tokens

### Steps to test:
- Try transactions from dapps
- Try transactions from 1:1 chat
- Request tokens from Simple Dapp
- Try transactions from Simple Dapp
- Check amount formatting in Send screen, Fee screen, Tx history screen
- Check transactions on etherscan

status: ready 