### PR TITLE
use trim() to remove newlines when reading VERSION

### DIFF
--- a/Jenkinsfile.nightly_fastlane
+++ b/Jenkinsfile.nightly_fastlane
@@ -33,7 +33,7 @@ timeout(90) {
 
           checkout scm
 
-          version = readFile "${env.WORKSPACE}/VERSION"
+          version = readFile("${env.WORKSPACE}/VERSION").trim()
 
           sh 'git fetch --tags'
           sh 'rm -rf node_modules'

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -37,7 +37,7 @@ timeout(90) {
 
           checkout scm
 
-          version = readFile "${env.WORKSPACE}/VERSION"
+          version = readFile("${env.WORKSPACE}/VERSION").trim()
 
           sh 'git fetch --tags'
 

--- a/Jenkinsfile.upload_release
+++ b/Jenkinsfile.upload_release
@@ -37,7 +37,7 @@ timeout(90) {
 
           checkout scm
 
-          version = readFile "${env.WORKSPACE}/VERSION"
+          version = readFile("${env.WORKSPACE}/VERSION").trim()
 
           sh 'git fetch --tags'
 


### PR DESCRIPTION
Fix for failing nightly:
https://jenkins.status.im/job/status-react/job/nightly/405/
With:
```
+ plutil -replace CFBundleShortVersionString -string 0.9.19
No files specified.
plutil: [command_option] [other_options] file...
...
```

<blockquote></blockquote>