### PR TITLE
Fixes #4309: Do not allow empty command to be sent

### DIFF
--- a/src/status_im/chat/views/input/send_button.cljs
+++ b/src/status_im/chat/views/input/send_button.cljs
@@ -15,6 +15,10 @@
        (animation/timing spin-value {:toValue  to-spin-value
                                      :duration 300})))))
 
+(defn sendable? [input-text]
+  (let [trimmed (string/trim input-text)]
+    (not (or (string/blank? trimmed) (= trimmed "/")))))
+
 (defview send-button-view []
   (letsubs [command-completion                      [:command-completion]
             selected-command                        [:selected-chat-command]
@@ -24,10 +28,11 @@
                                                                                  :command-completion command-completion})]
     {:component-did-update on-update}
     (let [{:keys [hide-send-button sequential-params]} (:command selected-command)]
-      (when (and (not (string/blank? input-text))
-                 (or (not selected-command)
-                     (some #{:complete :less-than-needed} [command-completion]))
-                 (not hide-send-button))
+      (when
+       (and (sendable? input-text)
+            (or (not selected-command)
+                (some #{:complete :less-than-needed} [command-completion]))
+            (not hide-send-button))
         [react/touchable-highlight {:on-press #(if sequential-params
                                                  (do
                                                    (when-not (string/blank? seq-arg-input-text)


### PR DESCRIPTION
Fixes #4309: Do not allow empty command to be sent

### Summary:

Disable the Send button if the user has only typed "/".

### Steps to test:
- Open Status
- Join a chat
- Test commands functionality 

status: ready 
