### PR TITLE
Allow to build any branch in release configuration.

### DIFF
--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -31,10 +31,6 @@ timeout(90) {
         stage('Git & Dependencies') {
           slackSend color: 'good', message: BRANCH_NAME + ' build started. ' + env.BUILD_URL
 
-          if (!BRANCH_NAME.startsWith("release/")){
-            error "Wrong branch name format: " + BRANCH_NAME + ", but it should be `release/version`"
-          }
-
           checkout scm
 
           version = readFile("${env.WORKSPACE}/VERSION").trim()


### PR DESCRIPTION
Important to be able to implement nightlies with the release conf.

status: ready <!-- Can be ready or wip -->
