### PR TITLE
Feature/use from param

### DIFF
--- a/src/status_im/data_store/realm/schemas/account/core.cljs
+++ b/src/status_im/data_store/realm/schemas/account/core.cljs
@@ -2,7 +2,8 @@
   (:require
    [status-im.data-store.realm.schemas.account.v1.core :as v1]
    [status-im.data-store.realm.schemas.account.v2.core :as v2]
-   [status-im.data-store.realm.schemas.account.v3.core :as v3]))
+   [status-im.data-store.realm.schemas.account.v3.core :as v3]
+   [status-im.data-store.realm.schemas.account.v4.core :as v4]))
 
 ;; TODO(oskarth): Add failing test if directory vXX exists but isn't in schemas.
 
@@ -15,4 +16,7 @@
                :migration     v2/migration}
               {:schema        v3/schema
                :schemaVersion 3
-               :migration     v3/migration}])
+               :migration     v3/migration}
+              {:schema        v4/schema
+               :schemaVersion 4
+               :migration     v4/migration}])

--- a/src/status_im/data_store/realm/schemas/account/v4/core.cljs
+++ b/src/status_im/data_store/realm/schemas/account/v4/core.cljs
@@ -1,12 +1,12 @@
-(ns status-im.data-store.realm.schemas.account.v3.core
+(ns status-im.data-store.realm.schemas.account.v4.core
   (:require [status-im.data-store.realm.schemas.account.v3.chat :as chat]
-            [status-im.data-store.realm.schemas.account.v1.transport :as transport]
+            [status-im.data-store.realm.schemas.account.v4.transport :as transport]
             [status-im.data-store.realm.schemas.account.v1.contact :as contact]
             [status-im.data-store.realm.schemas.account.v1.message :as message]
             [status-im.data-store.realm.schemas.account.v1.request :as request]
-            [status-im.data-store.realm.schemas.account.v2.mailserver :as mailserver]
             [status-im.data-store.realm.schemas.account.v1.user-status :as user-status]
             [status-im.data-store.realm.schemas.account.v1.local-storage :as local-storage]
+            [status-im.data-store.realm.schemas.account.v2.mailserver :as mailserver]
             [status-im.data-store.realm.schemas.account.v1.browser :as browser]
             [taoensso.timbre :as log]))
 
@@ -21,4 +21,4 @@
              browser/schema])
 
 (defn migration [old-realm new-realm]
-  (log/debug "migrating v3 account database: " old-realm new-realm))
+  (log/debug "migrating v4 account database: " old-realm new-realm))

--- a/src/status_im/data_store/realm/schemas/account/v4/transport.cljs
+++ b/src/status_im/data_store/realm/schemas/account/v4/transport.cljs
@@ -1,0 +1,17 @@
+(ns status-im.data-store.realm.schemas.account.v4.transport)
+
+(def schema {:name       :transport
+             :primaryKey :chat-id
+             :properties {:chat-id          :string
+                          :ack              :string
+                          :seen             :string
+                          :pending-ack      :string
+                          :pending-send     :string
+                          :topic            :string
+                          :fetch-history?   {:type :bool
+                                             :default false}
+                          :sym-key-id       {:type :string
+                                             :optional true}
+                          ;;TODO (yenda) remove once go implements persistence
+                          :sym-key          {:type :string
+                                             :optional true}}})

--- a/src/status_im/data_store/realm/schemas/base/core.cljs
+++ b/src/status_im/data_store/realm/schemas/base/core.cljs
@@ -1,6 +1,7 @@
 (ns status-im.data-store.realm.schemas.base.core
   (:require [status-im.data-store.realm.schemas.base.v1.core :as v1]
-            [status-im.data-store.realm.schemas.base.v2.core :as v2]))
+            [status-im.data-store.realm.schemas.base.v2.core :as v2]
+            [status-im.data-store.realm.schemas.base.v3.core :as v3]))
 
 ;; put schemas ordered by version
 (def schemas [{:schema        v1/schema
@@ -8,4 +9,7 @@
                :migration     v1/migration}
               {:schema        v2/schema
                :schemaVersion 2
-               :migration     v2/migration}])
+               :migration     v2/migration}
+              {:schema        v3/schema
+               :schemaVersion 3
+               :migration     v3/migration}])

--- a/src/status_im/data_store/realm/schemas/base/v3/account.cljs
+++ b/src/status_im/data_store/realm/schemas/base/v3/account.cljs
@@ -1,0 +1,27 @@
+(ns status-im.data-store.realm.schemas.base.v3.account)
+
+(def schema {:name       :account
+             :primaryKey :address
+             :properties {:address               :string
+                          :public-key            :string
+                          :name                  {:type :string :optional true}
+                          :email                 {:type :string :optional true}
+                          :status                {:type :string :optional true}
+                          :debug?                {:type :bool :default false}
+                          :photo-path            :string
+                          :signing-phrase        {:type :string}
+                          :mnemonic              {:type :string :optional true}
+                          :last-updated          {:type :int :default 0}
+                          :last-sign-in          {:type :int :default 0}
+                          :signed-up?            {:type    :bool
+                                                  :default false}
+                          :network               :string
+                          :networks              {:type       :list
+                                                  :objectType :network}
+                          :last-request          {:type :int :optional true}
+                          :settings              {:type :string}
+                          :sharing-usage-data?   {:type :bool :default false}
+                          :dev-mode?             {:type :bool :default false}
+                          :seed-backed-up?       {:type :bool :default false}
+                          :wallet-set-up-passed? {:type    :bool
+                                                  :default false}}})

--- a/src/status_im/data_store/realm/schemas/base/v3/core.cljs
+++ b/src/status_im/data_store/realm/schemas/base/v3/core.cljs
@@ -1,0 +1,10 @@
+(ns status-im.data-store.realm.schemas.base.v3.core
+  (:require [status-im.data-store.realm.schemas.base.v1.network :as network]
+            [status-im.data-store.realm.schemas.base.v3.account :as account]
+            [taoensso.timbre :as log]))
+
+(def schema [network/schema
+             account/schema])
+
+(defn migration [old-realm new-realm]
+  (log/debug "migrating base database v3: " old-realm new-realm))

--- a/src/status_im/network/events.cljs
+++ b/src/status_im/network/events.cljs
@@ -31,7 +31,7 @@
  (fn [{{:keys [network-status mailserver-status] :as db} :db :as cofx} [is-connected?]]
    (cond-> (handlers-macro/merge-fx cofx
                                     {:db (assoc db :network-status (if is-connected? :online :offline))}
-                                    (inbox/request-messages {:discover? true}))
+                                    (inbox/request-messages))
      is-connected?
      (assoc :drain-mixpanel-events nil))))
 

--- a/src/status_im/transport/db.cljs
+++ b/src/status_im/transport/db.cljs
@@ -9,6 +9,7 @@
 (spec/def ::pending-ack (spec/coll-of string? :kind vector?))
 (spec/def ::pending-send (spec/coll-of string? :kind vector?))
 (spec/def ::topic string?)
+(spec/def ::fetch-history? boolean?)
 
 ;; optional
 (spec/def ::sym-key-id string?)
@@ -16,7 +17,7 @@
 (spec/def ::sym-key string?)
 (spec/def ::filter any?)
 
-(spec/def :transport/chat (allowed-keys :req-un [::ack ::seen ::pending-ack ::pending-send ::topic]
+(spec/def :transport/chat (allowed-keys :req-un [::ack ::seen ::pending-ack ::pending-send ::topic ::fetch-history?]
                                         :opt-un [::sym-key-id ::sym-key ::filter]))
 
 (spec/def :transport/chats (spec/map-of :global/not-empty-string :transport/chat))
@@ -26,8 +27,9 @@
   "Initialize datastructure for chat representation at the transport level
   Currently only :topic is actually used"
   [topic]
-  {:ack          []
-   :seen         []
-   :pending-ack  []
-   :pending-send []
-   :topic        topic})
+  {:ack            []
+   :seen           []
+   :pending-ack    []
+   :pending-send   []
+   :fetch-history? true
+   :topic          topic})

--- a/src/status_im/transport/handlers.cljs
+++ b/src/status_im/transport/handlers.cljs
@@ -97,7 +97,7 @@
                               {:db             (assoc-in db
                                                          [:transport/chats chat-id :sym-key-id]
                                                          sym-key-id)
-                               :dispatch       [:inbox/request-messages {:topics [topic] :discover? false}]
+                               :dispatch       [:inbox/request-chat-history chat-id]
                                :shh/add-filter {:web3       web3
                                                 :sym-key-id sym-key-id
                                                 :topic      topic
@@ -156,7 +156,7 @@
          fx {:db             (assoc-in db
                                        [:transport/chats chat-id :sym-key-id]
                                        sym-key-id)
-             :dispatch       [:inbox/request-messages {:topics [topic]}]
+             :dispatch       [:inbox/request-chat-history chat-id]
              :shh/add-filter {:web3       web3
                               :sym-key-id sym-key-id
                               :topic      topic

--- a/src/status_im/transport/message/v1/public_chat.cljs
+++ b/src/status_im/transport/message/v1/public_chat.cljs
@@ -30,7 +30,7 @@
  (fn [{:keys [db] :as cofx} [_ {:keys [sym-key-id sym-key chat-id]}]]
    (let [{:keys [web3]} db
          topic          (transport.utils/get-topic chat-id)]
-     {:db (assoc-in db [:transport/chats chat-id :sym-key-id] sym-key-id)
+     {:db             (assoc-in db [:transport/chats chat-id :sym-key-id] sym-key-id)
       :shh/add-filter {:web3       web3
                        :sym-key-id sym-key-id
                        :topic      topic
@@ -41,6 +41,4 @@
                                       (assoc :sym-key-id sym-key-id)
                                       ;;TODO (yenda) remove once go implements persistence
                                       (assoc :sym-key sym-key))})]
-      :dispatch [:inbox/request-messages {:topics    [topic]
-                                          :discover? false
-                                          :from      0}]})))
+      :dispatch       [:inbox/request-chat-history chat-id]})))

--- a/src/status_im/ui/screens/accounts/db.cljs
+++ b/src/status_im/ui/screens/accounts/db.cljs
@@ -18,6 +18,7 @@
 (spec/def :account/signed-up? (spec/nilable boolean?))
 (spec/def :account/last-updated (spec/nilable int?))
 (spec/def :account/last-sign-in (spec/nilable int?))
+(spec/def :account/last-request (spec/nilable int?))
 (spec/def :account/photo-path (spec/nilable string?))
 (spec/def :account/debug? (spec/nilable boolean?))
 (spec/def :account/status (spec/nilable string?))
@@ -40,7 +41,7 @@
                                       :account/networks :account/settings :account/wnode
                                       :account/last-sign-in :account/sharing-usage-data? :account/dev-mode?
                                       :account/seed-backed-up? :account/mnemonic
-                                      :account/wallet-set-up-passed?]))
+                                      :account/wallet-set-up-passed? :account/last-request]))
 
 (spec/def :accounts/accounts (spec/nilable (spec/map-of :account/address :accounts/account)))
 

--- a/src/status_im/ui/screens/db.cljs
+++ b/src/status_im/ui/screens/db.cljs
@@ -42,7 +42,6 @@
              :notifications               {}
              :network                     constants/default-network
              :networks/networks           constants/default-networks
-             :inbox/topics                #{}
              :inbox/wnodes                constants/default-wnodes
              :inbox/password              constants/inbox-password
              :my-profile/editing?         false
@@ -72,7 +71,6 @@
 (spec/def ::network-status (spec/nilable keyword?))
 
 (spec/def ::mailserver-status (spec/nilable keyword?))
-(spec/def :inbox/topics set?)
 
 ;;;;NODE
 
@@ -175,10 +173,8 @@
                  :node/after-start
                  :node/after-stop
                  :inbox/wnodes
-                 :inbox/topics
                  :inbox/password
                  :inbox/sym-key-id
-                 :inbox/last-request
                  :inbox/last-received
                  :inbox/fetching?
                  :browser/browsers

--- a/src/status_im/ui/screens/db.cljs
+++ b/src/status_im/ui/screens/db.cljs
@@ -179,6 +179,7 @@
                  :inbox/password
                  :inbox/sym-key-id
                  :inbox/last-request
+                 :inbox/last-received
                  :inbox/fetching?
                  :browser/browsers
                  :browser/options

--- a/src/status_im/ui/screens/events.cljs
+++ b/src/status_im/ui/screens/events.cljs
@@ -456,8 +456,7 @@
    (let [app-coming-from-background? (= state "active")]
      (handlers-macro/merge-fx cofx
                               {::app-state-change-fx state}
-                              (inbox/request-messages {:should-recover? app-coming-from-background?
-                                                       :discover?       true})))))
+                              (inbox/request-messages app-coming-from-background?)))))
 
 (handlers/register-handler-fx
  :request-permissions

--- a/src/status_im/ui/screens/offline_messaging_settings/db.cljs
+++ b/src/status_im/ui/screens/offline_messaging_settings/db.cljs
@@ -17,5 +17,4 @@
 (spec/def :inbox/password ::not-blank-string)
 (spec/def :inbox/wnodes (spec/nilable (spec/map-of keyword? (spec/map-of :wnode/id :wnode/wnode))))
 (spec/def :inbox/sym-key-id string?)
-(spec/def :inbox/last-request integer?)
 (spec/def :inbox/last-received integer?)

--- a/src/status_im/ui/screens/offline_messaging_settings/db.cljs
+++ b/src/status_im/ui/screens/offline_messaging_settings/db.cljs
@@ -18,3 +18,4 @@
 (spec/def :inbox/wnodes (spec/nilable (spec/map-of keyword? (spec/map-of :wnode/id :wnode/wnode))))
 (spec/def :inbox/sym-key-id string?)
 (spec/def :inbox/last-request integer?)
+(spec/def :inbox/last-received integer?)

--- a/test/cljs/status_im/test/transport/inbox.cljs
+++ b/test/cljs/status_im/test/transport/inbox.cljs
@@ -3,40 +3,6 @@
             [status-im.transport.inbox :as inbox]
             [status-im.constants :as constants]))
 
-(deftest request-messages
-  (testing "mailserver not connected"
-    (is (= (inbox/request-messages {} {:db {:mailserver-status :connecting :inbox/sym-key-id :sym-key}})
-           {:db
-            {:mailserver-status :connecting,
-             :inbox/sym-key-id :sym-key,
-             :inbox/topics #{"0xf8946aac"}}}))
-    (is (= (inbox/request-messages {:discover? false :topics ["Oxaaaaaaaa"]} {:db {:mailserver-status :connecting :inbox/sym-key-id :sym-key}})
-           {:db
-            {:mailserver-status :connecting,
-             :inbox/sym-key-id :sym-key,
-             :inbox/topics #{"Oxaaaaaaaa"}}})))
-  (testing "mailserver is connected"
-    (is (= (inbox/request-messages {} {:db {:mailserver-status :connected :inbox/sym-key-id :sym-key}})
-           {:status-im.transport.inbox/request-messages
-            {:wnode nil, :topics ["0xf8946aac"], :sym-key-id :sym-key, :web3 nil},
-            :db
-            {:mailserver-status :connected,
-             :inbox/sym-key-id :sym-key,
-             :inbox/fetching? true,
-             :inbox/topics #{}},
-            :dispatch-later
-            [{:ms 5000, :dispatch [:inbox/remove-fetching-notification]}]})
-        (= (inbox/request-messages {:discover? false :topics ["Oxaaaaaaaa"]} {:db {:mailserver-status :connected :inbox/sym-key-id :sym-key}})
-           {:status-im.transport.inbox/request-messages
-            {:wnode nil, :topics ["Oxaaaaaaaa"], :sym-key-id :sym-key, :web3 nil},
-            :db
-            {:mailserver-status :connected,
-             :inbox/sym-key-id :sym-key,
-             :inbox/fetching? true,
-             :inbox/topics #{}},
-            :dispatch-later
-            [{:ms 5000, :dispatch [:inbox/remove-fetching-notification]}]}))))
-
 (defn cofx-fixtures [sym-key registered-peer?]
   {:db {:mailserver-status :connected
         :inbox/sym-key-id sym-key


### PR DESCRIPTION
fixes #4427
The first commit in this PR can be ignored as it is alreay in #4467 
The second commit introduces a way to differentiate mailserver messages from other whisper messages to keep a timestamp of the last mailserver message received. To do that we compare current time with message time stamp + ttl, if message is expired it comes from the mailserver.
Finally the third commit reimplement a similar mechanism to what was proposed in #4230 except that the :last-request is only updated 10 seconds after the latest message from mailserver has been received without a change of connection state:

When logging in, request messages from last-request for all chats, except chats added while offline for which we request full history. Same when connectivity is re-established after connectivity loss
When adding a chat, request full history for the chat  

# notes for testing
requires some chaos testing
killing the app while fetching, shutting down network while fetching,  joining chat while offline...


status: ready
