### PR TITLE
Read version from the VERSION file.

### DIFF
--- a/Jenkinsfile.upload_release_android
+++ b/Jenkinsfile.upload_release_android
@@ -38,7 +38,6 @@ timeout(90) {
           checkout scm
 
           version = readFile("${env.WORKSPACE}/VERSION").trim()
-          sh 'echo "' + version + '" > .version'
 
           sh 'git fetch --tags'
 

--- a/src/status_im/utils/build.clj
+++ b/src/status_im/utils/build.clj
@@ -22,7 +22,7 @@
       (System/exit 1))))
 
 (defmacro git-short-version []
-  (let [version-file-path ".version"
+  (let [version-file-path "VERSION"
         version-file      (io/file version-file-path)]
     (if (.exists version-file)
       (string/trim (slurp version-file-path))


### PR DESCRIPTION
Remove unnecessary `echo` to `.version` if we already have `VERSION` in the root folder.

Follow-up for #4480 

## Steps to test:
- build this PR
- go to the Account screen
- make sure that the version label still shows `0.9.19 (<status-go sha>)`

status: ready <!-- Can be ready or wip -->
