### PR TITLE
Use MaskedData check in the app-db for wallet's password.

### DIFF
--- a/src/status_im/ui/screens/wallet/send/db.cljs
+++ b/src/status_im/ui/screens/wallet/send/db.cljs
@@ -1,14 +1,15 @@
 (ns status-im.ui.screens.wallet.send.db
   (:require-macros [status-im.utils.db :refer [allowed-keys]])
   (:require [cljs.spec.alpha :as spec]
-            [status-im.utils.money :as money]))
+            [status-im.utils.money :as money]
+            [status-im.utils.security :as security]))
 
 (spec/def ::amount (spec/nilable money/valid?))
 (spec/def ::to (spec/nilable string?))
 (spec/def ::to-name (spec/nilable string?))
 (spec/def ::amount-error (spec/nilable string?))
 (spec/def ::amount-text (spec/nilable string?))
-(spec/def ::password (spec/nilable string?))
+(spec/def ::password (spec/nilable #(instance? security/MaskedData %)))
 (spec/def ::wrong-password? (spec/nilable boolean?))
 (spec/def ::id (spec/nilable string?))
 (spec/def ::waiting-signal? (spec/nilable boolean?))


### PR DESCRIPTION
Fixes the regression introduced in `789ee61`, leading to being unable to
sign transactions.

## Steps to test
- send any transaction
- signing should work properly

status: ready <!-- Can be ready or wip -->
