### PR TITLE
Fix console responses

### DIFF
--- a/src/status_im/chat/console.cljs
+++ b/src/status_im/chat/console.cljs
@@ -1,21 +1,20 @@
 (ns status-im.chat.console
   (:require [status-im.ui.components.styles :refer [default-chat-color]]
-            [status-im.utils.random :as random]
             [status-im.constants :as constants]
             [status-im.utils.clocks :as utils.clocks]
-            [status-im.i18n :as i18n]
-            [clojure.string :as string]))
+            [status-im.i18n :as i18n]))
 
-(defn console-message [{:keys [message-id content content-type]
-                        :or   {message-id (random/id)}}]
+(defn console-message [{:keys [timestamp message-id content content-type]}]
   {:message-id   message-id
    :outgoing     false
    :chat-id      constants/console-chat-id
    :from         constants/console-chat-id
    :to           "me"
+   :timestamp    timestamp
    :clock-value  (utils.clocks/send 0)
    :content      content
-   :content-type content-type})
+   :content-type content-type
+   :show?        true})
 
 (def chat
   {:chat-id          constants/console-chat-id

--- a/src/status_im/chat/events/console.cljs
+++ b/src/status_im/chat/events/console.cljs
@@ -8,47 +8,52 @@
             goog.string.format))
 
 (defn console-respond-command-messages
-  [{:keys [name] :as command} handler-data random-id-seq]
-  (when command
-    (case name
-      "js" (let [{:keys [err data messages]} handler-data
-                 content                     (or err data)
-                 message-events              (mapv (fn [{:keys [message type]} id]
-                                                     (console-chat/console-message
-                                                      {:message-id id
-                                                       :content (str type ": " message)
-                                                       :content-type constants/text-content-type}))
-                                                   messages random-id-seq)]
-             (conj message-events
-                   (console-chat/console-message
-                    {:message-id   (first random-id-seq)
-                     :content      (str content)
-                     :content-type constants/text-content-type})))
-      (log/debug "ignoring command: " name))))
+  [{:keys [name] :as command} handler-data {:keys [random-id-seq now]}]
+  (when-let [messages (case name
+                        "js" (let [{:keys [err data messages]} handler-data
+                                   content                     (or err data)
+                                   message-events              (mapv (fn [{:keys [message type]} id]
+                                                                       (console-chat/console-message
+                                                                        {:message-id   id
+                                                                         :timestamp    now
+                                                                         :content      (str type ": " message)
+                                                                         :content-type constants/text-content-type}))
+                                                                     messages random-id-seq)]
+                               (conj message-events
+                                     (console-chat/console-message
+                                      {:message-id   (first random-id-seq)
+                                       :timestamp    now
+                                       :content      (str content)
+                                       :content-type constants/text-content-type})))
+                        (log/debug "ignoring command: " name))]
+    {:dispatch [:chat-received-message/add messages]}))
 
 (defn faucet-base-url->url [url]
   (str url "/donate/0x%s"))
 
-(defn- faucet-response-event [message-id content]
+(defn- faucet-response-event [now message-id content]
   [:chat-received-message/add
    [(console-chat/console-message
      {:message-id   message-id
+      :timestamp    now
       :content      content
       :content-type constants/text-content-type})]])
 
 (def console-commands->fx
   {"faucet"
-   (fn [{:keys [db random-id]} {:keys [params]}]
+   (fn [{:keys [db random-id now]} {:keys [params]}]
      (let [current-address (get-in db [:account/account :address])
            faucet-url      (faucet-base-url->url (:url params))]
        {:http-get {:url                   (gstring/format faucet-url current-address)
                    :success-event-creator (fn [_]
                                             (faucet-response-event
+                                             now
                                              random-id
                                              (i18n/label :t/faucet-success)))
                    :failure-event-creator (fn [event]
                                             (log/error "Faucet error" event)
                                             (faucet-response-event
+                                             now
                                              random-id
                                              (i18n/label :t/faucet-error)))}}))})
 


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes #4443 

### Summary:

In previous perf PR (introducing message-groups), the requirements of the `:chat-received-message/add` changed little bit, so the function requires knowledge whether message to be added is also to be shown or not (`:show?`) and timestamp is now required for proper grouping as well (`:timestamp` key). 
This PR merely updates the console code to adhere to those requirements and so, solves the bug

### Steps to test:
Test that the bug is not happening anymore

status: ready
