### PR TITLE
bug #4485 - shows warning when scanned qr code changes pre-selected a…

### DIFF
--- a/src/status_im/translations/en.cljs
+++ b/src/status_im/translations/en.cljs
@@ -573,6 +573,8 @@
    :wallet-address-from-clipboard        "Use Address From Clipboard"
    :wallet-invalid-address               "Invalid address: \n {{data}}"
    :wallet-invalid-chain-id              "Network does not match: \n {{data}} but current chain is {{chain}}"
+   :changed-asset-warning                "Asset was changed from {{old}} to {{new}}"
+   :changed-amount-warning               "Amount was changed from {{old}} to {{new}}"
    :wallet-browse-photos                 "Browse Photos"
    :wallet-advanced                      "Advanced"
    :wallet-transaction-fee               "Transaction Fee"

--- a/src/status_im/ui/screens/wallet/choose_recipient/views.cljs
+++ b/src/status_im/ui/screens/wallet/choose_recipient/views.cljs
@@ -63,7 +63,7 @@
                        :torchMode     (camera/set-torch camera-flashlight)
                        :onBarCodeRead #(when-not @read-once?
                                          (reset! read-once? true)
-                                         (re-frame/dispatch [:wallet/fill-request-from-url (camera/get-qr-code-data %) nil]))}]]
+                                         (re-frame/dispatch [:wallet/fill-request-from-url (camera/get-qr-code-data %) :qr]))}]]
       [viewfinder dimensions (size dimensions)]]
      [bottom-buttons/bottom-button
       [button/button {:disabled?           false

--- a/src/status_im/ui/screens/wallet/components/views.cljs
+++ b/src/status_im/ui/screens/wallet/components/views.cljs
@@ -75,23 +75,26 @@
     :request :wallet-request-assets
     (throw (str "Unknown type: " k))))
 
-(views/defview asset-selector [{:keys [disabled? type symbol]}]
+(views/defview asset-selector [{:keys [disabled? type symbol error]}]
   (views/letsubs [balance  [:balance]
                   network  [:network]]
     (let [{:keys [name icon decimals]} (tokens/asset-for (ethereum/network->chain-keyword network) symbol)]
-      [components/cartouche {:disabled? disabled? :on-press #(re-frame/dispatch [:navigate-to (type->view type)])}
-       (i18n/label :t/wallet-asset)
-       [react/view {:style               styles/asset-content-container
-                    :accessibility-label :choose-asset-button}
-        [list/item-image (assoc icon :style styles/asset-icon :image-style {:width 32 :height 32})]
-        [react/view styles/asset-text-content
-         [react/view styles/asset-label-content
-          [react/text {:style (merge styles/text-content styles/asset-label)}
-           name]
-          [react/text {:style styles/text-secondary-content}
-           (clojure.core/name symbol)]]
-         [react/text {:style (merge styles/text-secondary-content styles/asset-label)}
-          (str (wallet.utils/format-amount (symbol balance) decimals))]]]])))
+      [react/view
+       [components/cartouche {:disabled? disabled? :on-press #(re-frame/dispatch [:navigate-to (type->view type)])}
+        (i18n/label :t/wallet-asset)
+        [react/view {:style               styles/asset-content-container
+                     :accessibility-label :choose-asset-button}
+         [list/item-image (assoc icon :style styles/asset-icon :image-style {:width 32 :height 32})]
+         [react/view styles/asset-text-content
+          [react/view styles/asset-label-content
+           [react/text {:style (merge styles/text-content styles/asset-label)}
+            name]
+           [react/text {:style styles/text-secondary-content}
+            (clojure.core/name symbol)]]
+          [react/text {:style (merge styles/text-secondary-content styles/asset-label)}
+           (str (wallet.utils/format-amount (symbol balance) decimals))]]]]
+       (when error
+         [tooltip/tooltip error {}])])))
 
 (defn- recipient-address [address]
   [react/text {:style               (merge styles/recipient-address (when-not address styles/recipient-no-address))
@@ -150,7 +153,7 @@
                                  :accessibility-label :recipient-address-input}]]
         [bottom-buttons/bottom-button
          [button/button {:disabled?    (string/blank? @content)
-                         :on-press     #(re-frame/dispatch [:wallet/fill-request-from-url @content])
+                         :on-press     #(re-frame/dispatch [:wallet/fill-request-from-url @content :code])
                          :fit-to-text? false}
           (i18n/label :t/done)]]]])))
 

--- a/src/status_im/ui/screens/wallet/send/db.cljs
+++ b/src/status_im/ui/screens/wallet/send/db.cljs
@@ -8,6 +8,7 @@
 (spec/def ::to (spec/nilable string?))
 (spec/def ::to-name (spec/nilable string?))
 (spec/def ::amount-error (spec/nilable string?))
+(spec/def ::asset-error (spec/nilable string?))
 (spec/def ::amount-text (spec/nilable string?))
 (spec/def ::password (spec/nilable #(instance? security/MaskedData %)))
 (spec/def ::wrong-password? (spec/nilable boolean?))
@@ -28,7 +29,7 @@
 (spec/def ::method (spec/nilable string?))
 
 (spec/def :wallet/send-transaction (allowed-keys
-                                    :opt-un [::amount ::to ::to-name ::amount-error ::amount-text ::password
+                                    :opt-un [::amount ::to ::to-name ::amount-error ::asset-error ::amount-text ::password
                                              ::waiting-signal? ::signing? ::id ::later?
                                              ::camera-flashlight ::in-progress?
                                              ::wrong-password? ::from-chat? ::symbol ::advanced?

--- a/src/status_im/ui/screens/wallet/send/events.cljs
+++ b/src/status_im/ui/screens/wallet/send/events.cljs
@@ -89,6 +89,7 @@
             (assoc-in [:wallet :send-transaction :symbol] symbol)
             (assoc-in [:wallet :send-transaction :amount] nil)
             (assoc-in [:wallet :send-transaction :amount-text] nil)
+            (assoc-in [:wallet :send-transaction :asset-error] nil)
             (assoc-in [:wallet :send-transaction :gas] (ethereum/estimate-gas symbol)))}))
 
 (handlers/register-handler-fx

--- a/src/status_im/ui/screens/wallet/send/views.cljs
+++ b/src/status_im/ui/screens/wallet/send/views.cljs
@@ -198,7 +198,7 @@
      [advanced-cartouche transaction modal?])])
 
 (defn- send-transaction-panel [{:keys [modal? transaction scroll advanced? network]}]
-  (let [{:keys [amount amount-text amount-error signing? to to-name sufficient-funds? in-progress? from-chat? symbol]} transaction
+  (let [{:keys [amount amount-text amount-error asset-error signing? to to-name sufficient-funds? in-progress? from-chat? symbol]} transaction
         {:keys [decimals] :as token} (tokens/asset-for (ethereum/network->chain-keyword network) symbol)
         timeout (atom nil)]
     [wallet.components/simple-screen {:avoid-keyboard? (not modal?)
@@ -216,6 +216,7 @@
                                         :address   to
                                         :name      to-name}]
         [components/asset-selector {:disabled? (or from-chat? modal?)
+                                    :error     asset-error
                                     :type      :send
                                     :symbol    symbol}]
         [components/amount-selector {:disabled?     (or from-chat? modal?)


### PR DESCRIPTION
fixes #4485 

### Summary:

In Wallet Send, if user sets asset to anything other than ETH and then proceeds to scan the QR, metadata from the scanned QR will overwrite the asset to ETH. This PR adds a validation warning to let the user know about the change.

### Steps to test:
See #4485

status: ready 
