### PR TITLE
bug #4491 - changed the copy for amount too precise validation error

### DIFF
--- a/resources/js/bots/console/translations.js
+++ b/resources/js/bots/console/translations.js
@@ -16,7 +16,10 @@ I18n.translations = {
         faucet_title: 'Faucet',
         faucet_description: 'Get some ETH',
         faucet_placeholder: 'Faucet URL'
-    },
+    }
+
+    /*
+    ,
     ru: {
         password_description: 'Пароль',
         password_placeholder: 'Введите свой пароль',
@@ -410,5 +413,5 @@ I18n.translations = {
         password_error1: 'Xác nhận mật khẩu không khớp với mật khẩu.',
         password_validation_title: 'Mật khẩu'
 
-    }
+    } */
 };

--- a/resources/js/bots/transactor/translations.js
+++ b/resources/js/bots/transactor/translations.js
@@ -20,9 +20,12 @@ I18n.translations = {
         validation_tx_failed: 'Transaction failed',
         validation_amount_specified: 'Amount must be specified',
         validation_invalid_number: 'Amount is not valid number',
-        validation_amount_is_too_small: 'Amount is too precise. The smallest unit you can send is 1 Wei (1x10^-18 ETH)',
+        validation_amount_is_too_small: 'Amount is too precise. Max number of decimals is 18.',
         validation_insufficient_amount: 'Insufficient funds for gas * price + value (balance '
-    },
+    }
+
+    /*
+    ,
     ru: {
         send_title: 'Отправить транзакцию',
         send_description: 'Отправить платеж',
@@ -479,4 +482,6 @@ I18n.translations = {
         validation_invalid_number: 'Số tiền không phải là một số hợp lệ',
         validation_insufficient_amount: 'Không đủ ETH trong số dư ('
     }
+
+    */
 };

--- a/src/status_im/translations/en.cljs
+++ b/src/status_im/translations/en.cljs
@@ -579,7 +579,7 @@
    :wallet-transaction-fee-details       "Gas limit is the amount of gas to send with your transaction. Increasing this number will not get your transaction processed faster"
    :wallet-transaction-total-fee         "Total Fee"
    :validation-amount-invalid-number     "Amount is not a valid number"
-   :validation-amount-is-too-precise     "Amount is too precise. The smallest unit you can send is 1 Wei (1x10^-18 ETH)"
+   :validation-amount-is-too-precise     "Amount is too precise. Max number of decimals is {{decimals}}."
    :scan-qr-code                         "Scan a QR code with a wallet address"
    :reset-default                        "Reset to default"
 

--- a/src/status_im/ui/screens/wallet/db.cljs
+++ b/src/status_im/ui/screens/wallet/db.cljs
@@ -29,7 +29,7 @@
         {:error (i18n/label :t/validation-amount-invalid-number) :value value}
 
         (too-precise-amount? normalized-amount decimals)
-        {:error (i18n/label :t/validation-amount-is-too-precise) :value value}
+        {:error (i18n/label :t/validation-amount-is-too-precise {:decimals decimals}) :value value}
 
         :else
         {:value value}))))


### PR DESCRIPTION
fixes #4491

### Summary:

Small copy change PR - now that we have tokens, validation message should depend on number of decimals that the selected asset supports.

### Steps to test:
- Try sending ETH amount with too many decimals from chat
- Try sending ETH amount with too many decimals from wallet
- Try sending token amount with too many decimals from wallet for a number of token types

status: ready 