### PR TITLE
bug #4496 - taking decimals into account when calculating fiat value …

### DIFF
--- a/src/status_im/ui/screens/wallet/views.cljs
+++ b/src/status_im/ui/screens/wallet/views.cljs
@@ -61,7 +61,7 @@
 
 (defn- render-asset [currency]
   (fn [{:keys [symbol icon decimals amount]}]
-    (let [asset-value (re-frame/subscribe [:asset-value symbol (-> currency :code keyword)])]
+    (let [asset-value (re-frame/subscribe [:asset-value symbol decimals (-> currency :code keyword)])]
       [react/view {:style styles/asset-item-container}
        [list/item
         [list/item-image icon]

--- a/src/status_im/utils/money.cljs
+++ b/src/status_im/utils/money.cljs
@@ -119,8 +119,8 @@
 (defn fee-value [gas gas-price]
   (.times (bignumber gas) (bignumber gas-price)))
 
-(defn eth->fiat [eth fiat-price]
-  (when-let [bn (bignumber eth)]
+(defn crypto->fiat [crypto fiat-price]
+  (when-let [bn (bignumber crypto)]
     (.times bn (bignumber fiat-price))))
 
 (defn percent-change [from to]

--- a/test/cljs/status_im/test/wallet/subs.cljs
+++ b/test/cljs/status_im/test/wallet/subs.cljs
@@ -5,8 +5,13 @@
 
 (deftest test-balance-total-value
   (is (= (s/get-balance-total-value {:ETH (money/bignumber 1000000000000000000)
-                                     :SNT (money/bignumber 100000000000000000000)}
+                                     :SNT (money/bignumber 100000000000000000000)
+                                     :AST (money/bignumber 10000)}
                                     {:ETH {:USD {:from "ETH", :to "USD", :price 677.91, :last-day 658.688}}
-                                     :SNT {:USD {:from "SNT", :to "USD", :price 0.1562, :last-day 0.15}}}
-                                    :USD)
-         693.53)))
+                                     :SNT {:USD {:from "SNT", :to "USD", :price 0.1562, :last-day 0.15}}
+                                     :AST {:USD {:from "AST", :to "USD", :price 4,      :last-day 3}}}
+                                    :USD
+                                    {:ETH 18
+                                     :SNT 18
+                                     :AST 4})
+         697.53)))


### PR DESCRIPTION
fixes #4496

### Summary:

Fiat value of tokens was displayed as zero for tokens that have less than 18 decimals. This PR fixes the issue by using correct number of decimals in calculation of fiat value.

### Steps to test:
- Open Status in Mainnet
- Get some tokens that have less  than 18 decimals (reproduced with ETHOS and AST)
- Check that fiat value of that asset is correct (keep in mind that amounts smaller than 0.005 cents will be rounded to zero anyway because of fiat rounding)
- Check the fiat value of the whole portfolio

status: ready 
