### PR TITLE
[#4492]: Invalid values for `gas limit` and `gas price` are immediately replaced by default ones instead of warning

### DIFF
--- a/src/status_im/translations/en.cljs
+++ b/src/status_im/translations/en.cljs
@@ -374,6 +374,7 @@
    ;;validation
    :invalid-phone                        "Invalid phone number"
    :amount                               "Amount"
+   :invalid-number                       "Invalid number"
 
    ;;transactions
    :confirm                              "Confirm"

--- a/src/status_im/ui/screens/wallet/send/events.cljs
+++ b/src/status_im/ui/screens/wallet/send/events.cljs
@@ -327,14 +327,14 @@
    {:db (assoc-in db [:wallet :send-transaction :signing?] signing?)}))
 
 (handlers/register-handler-fx
- :wallet.send/edit-gas
- (fn [{:keys [db]} [_ gas]]
-   {:db (assoc-in db [:wallet :edit :gas] (money/bignumber gas))}))
-
-(handlers/register-handler-fx
- :wallet.send/edit-gas-price
- (fn [{:keys [db]} [_ gas-price]]
-   {:db (assoc-in db [:wallet :edit :gas-price] (money/bignumber gas-price))}))
+ :wallet.send/edit-value
+ (fn [{:keys [db]} [_ key value]]
+   (let [bn-value (money/bignumber value)
+         data     (if bn-value
+                    {:value    bn-value
+                     :invalid? false}
+                    {:invalid? true})]
+     {:db (update-in db [:wallet :edit key] merge data)})))
 
 (handlers/register-handler-fx
  :wallet.send/set-gas-details
@@ -352,9 +352,7 @@
  :wallet.send/reset-gas-default
  (fn [{:keys [db]}]
    {:dispatch [:wallet/update-gas-price true]
-    :db       (update-in db [:wallet :edit]
-                         assoc
-                         :gas (ethereum/estimate-gas (get-in db [:wallet :send-transaction :symbol])))}))
+    :db       (assoc-in db [:wallet :edit :gas] nil)}))
 
 (defn update-gas-price [db edit?]
   {:update-gas-price {:web3          (:web3 db)

--- a/src/status_im/ui/screens/wallet/send/styles.cljs
+++ b/src/status_im/ui/screens/wallet/send/styles.cljs
@@ -74,6 +74,10 @@
   {:margin-top    24
    :margin-bottom 16})
 
+(def gas-container-wrapper
+  {:flex           1
+   :flex-direction :row})
+
 (def gas-input-wrapper
   {:align-items     :center
    :justify-content :space-between


### PR DESCRIPTION
Fixes #4492 
Status: ready