### PR TITLE
Disable group chats even in dev mode. Closes #4506

### DIFF
--- a/src/status_im/transport/handlers.cljs
+++ b/src/status_im/transport/handlers.cljs
@@ -27,10 +27,12 @@
                            transport.utils/to-utf8
                            transit/deserialize)]
     (when (and sig status-message)
-      (handlers-macro/merge-fx
-       (assoc cofx :js-obj js-message)
-       (message/receive status-message (or chat-id sig) sig)
-       (update-last-received-from-inbox now-in-s timestamp ttl)))))
+      (try
+        (handlers-macro/merge-fx
+         (assoc cofx :js-obj js-message)
+         (message/receive status-message (or chat-id sig) sig)
+         (update-last-received-from-inbox now-in-s timestamp ttl))
+        (catch :default e nil))))) ; ignore unknown message types
 
 (defn- js-array->seq [array]
   (for [i (range (.-length array))]

--- a/src/status_im/transport/message/transit.cljs
+++ b/src/status_im/transport/message/transit.cljs
@@ -103,13 +103,7 @@
                               "c5" (fn [message-ids]
                                      (v1.protocol/MessagesSeen. message-ids))
                               "c6" (fn [[name profile-image]]
-                                     (v1.contact/ContactUpdate. name profile-image))
-                              "g1" (fn [[chat-id sym-key message]]
-                                     (v1.group-chat/NewGroupKey. chat-id sym-key message))
-                              "g2" (fn [[chat-name participants]]
-                                     (v1.group-chat/GroupAdminUpdate. chat-name participants))
-                              "g3" (fn [_]
-                                     (v1.group-chat/GroupLeave.))}}))
+                                     (v1.contact/ContactUpdate. name profile-image))}})) ; removed group chat handlers for https://github.com/status-im/status-react/issues/4506
 
 (defn serialize
   "Serializes a record implementing the StatusMessage protocol using the custom writers"

--- a/src/status_im/ui/screens/add_new/views.cljs
+++ b/src/status_im/ui/screens/add_new/views.cljs
@@ -13,7 +13,7 @@
             [status-im.ui.components.status-bar.view :as status-bar]
             [status-im.ui.components.toolbar.view :as toolbar]))
 
-(defn- options-list [{:keys [address dev-mode?]}]
+(defn- options-list [{:keys [address]}]
   [react/view action-button.styles/actions-list
    [action-button/action-button
     {:label               (i18n/label :t/start-new-chat)
@@ -23,7 +23,7 @@
      :on-press            #(re-frame/dispatch [:navigate-to :new-chat])}]
    [action-button/action-separator]
    ;; Hide behind flag (false by default), till everything is fixed in group chats
-   (when (or config/group-chats-enabled? dev-mode?)
+   (when config/group-chats-enabled?
      [action-button/action-button
       {:label               (i18n/label :t/start-group-chat)
        :accessibility-label :start-group-chat-button


### PR DESCRIPTION
fixes #4506

### Summary:

[comment]: # (Summarise the problem and how the pull request solves it)
Disables the option for group chats event when dev mode is active, and ignores chat message types received.

status: ready <!-- Can be ready or wip -->
