### PR TITLE
Feature/build_no with push

### DIFF
--- a/Jenkinsfile.nightly_fastlane
+++ b/Jenkinsfile.nightly_fastlane
@@ -46,6 +46,20 @@ timeout(90) {
           sh 'cd ios && pod install && cd ..'
         }
 
+        stage('Tag Build') {
+          withCredentials([[
+            $class: 'UsernamePasswordMultiBinding',
+            credentialsId: 'jenkins-status-im',
+            usernameVariable: 'GIT_USER',
+            passwordVariable: 'GIT_PASS'
+          ]]) {
+            def build_no = sh(
+              returnStdout: true,
+              script: './scripts/build_no.sh --increment'
+            ).trim()
+          }
+        }
+
         stage('Tests') {
           sh 'lein test-cljs'
         }
@@ -60,7 +74,6 @@ timeout(90) {
 
         stage('Build (iOS)') {
           withCredentials([string(credentialsId: 'jenkins_pass', variable: 'password')]) {
-            def build_no = sh(returnStdout: true, script: './scripts/build_no.sh --tag').trim()
             sh ('plutil -replace CFBundleShortVersionString  -string ' + version + ' ios/StatusIm/Info.plist')
             sh ('plutil -replace CFBundleVersion  -string ' + build_no + ' ios/StatusIm/Info.plist')
             sh 'export RCT_NO_LAUNCH_PACKAGER=true && xcodebuild -workspace ios/StatusIm.xcworkspace -scheme StatusIm -configuration release -archivePath status clean archive'

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -43,8 +43,22 @@ timeout(90) {
           installJSDeps()
 
           sh 'mvn -f modules/react-native-status/ios/RCTStatus dependency:unpack'
-            sh 'cd ios && pod install && cd ..'
+          sh 'cd ios && pod install && cd ..'
+        }
+
+        stage('Tag Build') {
+          withCredentials([[
+            $class: 'UsernamePasswordMultiBinding',
+            credentialsId: 'jenkins-status-im',
+            usernameVariable: 'GIT_USER',
+            passwordVariable: 'GIT_PASS'
+          ]]) {
+            def build_no = sh(
+              returnStdout: true,
+              script: './scripts/build_no.sh --increment'
+            ).trim()
           }
+        }
 
         stage('Tests') {
           sh 'lein test-cljs'
@@ -59,7 +73,6 @@ timeout(90) {
         }
 
         stage('Build (iOS)') {
-          def build_no = sh(returnStdout: true, script: './scripts/build_no.sh --tag').trim()
           sh ('plutil -replace CFBundleShortVersionString  -string ' + version + ' ios/StatusIm/Info.plist')
           sh ('plutil -replace CFBundleVersion  -string ' + build_no + ' ios/StatusIm/Info.plist')
           sh 'export RCT_NO_LAUNCH_PACKAGER=true && xcodebuild -workspace ios/StatusIm.xcworkspace -scheme StatusIm -configuration release -archivePath status clean archive'
@@ -94,16 +107,6 @@ timeout(90) {
           }
         }
 
-        stage('Push build tag') {
-          withCredentials([[
-            $class: 'UsernamePasswordMultiBinding',
-            credentialsId: 'jenkins-status-im',
-            usernameVariable: 'GIT_USER',
-            passwordVariable: 'GIT_PASS'
-          ]]) {
-            sh ('git push --tags https://${GIT_USER}:${GIT_PASS}@github.com/status-im/status-react --tags')
-          }
-        }
       } catch (e) {
         slackSend color: 'bad', message: 'Release build failed to build. ' + env.BUILD_URL
         throw e

--- a/Jenkinsfile.upload_release_android
+++ b/Jenkinsfile.upload_release_android
@@ -47,8 +47,22 @@ timeout(90) {
           installJSDeps()
 
           sh 'mvn -f modules/react-native-status/ios/RCTStatus dependency:unpack'
-            sh 'cd ios && pod install && cd ..'
+          sh 'cd ios && pod install && cd ..'
+        }
+
+        stage('Tag Build') {
+          withCredentials([[
+            $class: 'UsernamePasswordMultiBinding',
+            credentialsId: 'jenkins-status-im',
+            usernameVariable: 'GIT_USER',
+            passwordVariable: 'GIT_PASS'
+          ]]) {
+            def build_no = sh(
+              returnStdout: true,
+              script: './scripts/build_no.sh --increment'
+            ).trim()
           }
+        }
 
         stage('Tests') {
           sh 'lein test-cljs'

--- a/Jenkinsfile.upload_release_ios
+++ b/Jenkinsfile.upload_release_ios
@@ -46,8 +46,22 @@ timeout(90) {
           installJSDeps()
 
           sh 'mvn -f modules/react-native-status/ios/RCTStatus dependency:unpack'
-            sh 'cd ios && pod install && cd ..'
+          sh 'cd ios && pod install && cd ..'
+        }
+
+        stage('Tag Build') {
+          withCredentials([[
+            $class: 'UsernamePasswordMultiBinding',
+            credentialsId: 'jenkins-status-im',
+            usernameVariable: 'GIT_USER',
+            passwordVariable: 'GIT_PASS'
+          ]]) {
+            def build_no = sh(
+              returnStdout: true,
+              script: './scripts/build_no.sh --increment'
+            ).trim()
           }
+        }
 
         stage('Tests') {
           sh 'lein test-cljs'
@@ -59,7 +73,6 @@ timeout(90) {
 
         stage('Build (iOS)') {
           withCredentials([string(credentialsId: 'jenkins_pass', variable: 'password')]) {
-            def build_no = sh(returnStdout: true, script: './scripts/build_no.sh --tag').trim()
             sh ('plutil -replace CFBundleShortVersionString  -string ' + version + ' ios/StatusIm/Info.plist')
             sh ('plutil -replace CFBundleVersion  -string ' + build_no + ' ios/StatusIm/Info.plist')
             sh 'export RCT_NO_LAUNCH_PACKAGER=true && xcodebuild -workspace ios/StatusIm.xcworkspace -scheme StatusIm -configuration release -archivePath status clean archive'


### PR DESCRIPTION
Since the tagging behavior is a bit flaky after discussing this with Igor we've decided all builds should be tagged. Now if you rung `build_no.sh` with `--increment` it fetches, tags, and pushes, all in one.