### PR TITLE
Protect against duplicate messages

### DIFF
--- a/src/status_im/chat/events/receive_message.cljs
+++ b/src/status_im/chat/events/receive_message.cljs
@@ -14,7 +14,8 @@
  ::received-message
  message-model/receive-interceptors
  (fn [cofx [message]]
-   (message-model/receive message cofx)))
+   (when (message-model/add-to-chat? cofx message)
+     (message-model/receive message cofx))))
 
 (re-frame.core/reg-fx
  :chat-received-message/add-fx


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes #4486 

### Summary:

When command messages are received, the check for duplicates occurs before preview/shortPreview is requested from jail (asynchronously), which makes sense because we don't want to waste resources (js evaluation) on messages which won't be added anyway.
However, in rare cases (android phones issuing two offline inbox requests at the same time) this asynchronous behaviour can cause the check to be "outdated" because in the meantime (time between check and time between message is added to db after jail result is returned) the message was already added.
Therefore we need to check again even after jail result is returned.

Note - the way how we fetch jail results is super inefficient for batch message processing (offline inboxing) and contributes to the bug as well, it needs to be reworked so we fetch everything for message batch in one jail call. 

### Steps to test:
Check that the bug is not happening anymore

status: ready
