### PR TITLE
adds a filter to pre-commit hook to prevent analysis of deleted files

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -16,7 +16,7 @@
             [lein-cljfmt "0.5.7"]
             [rasom/lein-githooks "0.1.3"]]
   :githooks {:auto-install true
-             :pre-commit   ["lein cljfmt check src/status_im/core.cljs $(git diff --cached --name-only src test/cljs)"]}
+             :pre-commit   ["lein cljfmt check src/status_im/core.cljs $(git diff --diff-filter=d --cached --name-only src test/cljs)"]}
   :cljfmt {:indents {letsubs [[:inner 0]]}}
   :clean-targets ["target/" "index.ios.js" "index.android.js"]
   :aliases {"prod-build"         ^{:doc "Recompile code with prod profile."}


### PR DESCRIPTION
### Summary:

Pre-commit hook selects which files to check by looking at the git diff. If any file was deleted or renamed, the diff will also show the deleted file in the list of changes. Then when `cljfmt` tries to check it we have a no file found error and it's impossible to commit.

This PR adds a filter to exclude deleted files from analysis.

### Testing notes (optional):
Only changes dev tools. No need to test the build.

status: ready 
