### PR TITLE
Remove unnecessary from-pk check

### DIFF
--- a/src/status_im/chat/models/message.cljs
+++ b/src/status_im/chat/models/message.cljs
@@ -193,18 +193,12 @@
   (#{:group-user-message :public-group-user-message} message-type))
 
 (defn add-to-chat?
-  [{:keys [db]} {:keys [chat-id
-                        clock-value
-                        from
-                        message-id] :as message}]
-  (let [{:keys [chats current-public-key]} db
-        {:keys [deleted-at-clock-value
-                messages
-                not-loaded-message-ids]} (get chats chat-id)]
-    (when (not= from current-public-key)
-      (not (or (get messages message-id)
-               (get not-loaded-message-ids message-id)
-               (>= deleted-at-clock-value clock-value))))))
+  [{:keys [db]} {:keys [chat-id clock-value message-id] :as message}]
+  (let [{:keys [deleted-at-clock-value messages not-loaded-message-ids]}
+        (get-in db [:chats chat-id])]
+    (not (or (get messages message-id)
+             (get not-loaded-message-ids message-id)
+             (>= deleted-at-clock-value clock-value)))))
 
 (defn message-seen-by? [message user-pk]
   (= :seen (get-in message [:user-statuses user-pk])))

--- a/test/cljs/status_im/test/chat/models/message.cljs
+++ b/test/cljs/status_im/test/chat/models/message.cljs
@@ -11,13 +11,6 @@
                                :from "a"
                                :clock-value 1
                                :chat-id "a"})))
-  (testing "it returns false when from is the same as pk"
-    (is (not (message/add-to-chat? {:db {:current-public-key "pk"
-                                         :chats {"a" {}}}}
-                                   {:message-id "message-id"
-                                    :from "pk"
-                                    :clock-value 1
-                                    :chat-id "a"}))))
   (testing "it returns false when it's already in the loaded message"
     (is (not (message/add-to-chat? {:db {:chats {"a" {:messages {"message-id" {}}}}}}
                                    {:message-id "message-id"


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes #4543 (and potentially #4542 as well)

### Summary:

We were doing unnecessary checking that `:from` field of the message is not `:current-public-pk` before adding the message to the system when it was received from whisper.
This prevented us from receiving our own messages when reconstructing history from offline messages (the case when account is recovered and app-state is blank).
The reason why it's not necessary to do such check is that just making sure that the received message id is either not in `:messages` map or set of `:not-loaded-message-ids`  is enough + upon sending, message is always added to the app-db sooner (synchronous `swap!` of the `:db` effect in send handler function) then whisper callback could add our own message.

### Steps to test:
Test that the bug is happening anymore + chat sending/receiving messages works fine in all cases (1-1, public chats).

status: ready
