### PR TITLE
Temporarily use custom fork of re-natal in order to fix metro patching

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "prop-types": "15.6.0",
     "punycode": "1.4.1",
     "querystring-es3": "0.2.1",
-    "re-natal": "git+https://github.com/status-im/re-natal.git#master",
+    "re-natal": "git+https://github.com/siphiuel/re-natal.git#master",
     "react": "^16.2.0",
     "react-dom": "16.2.0",
     "react-native": "git+https://github.com/status-im/react-native-desktop.git",


### PR DESCRIPTION
This resolves the need to manually install metro-bundler in order for `re-natal enable-source-maps` to work. Old version of re-natal uses a patch regex for an older version metro-bundler, which does not work properly with new metro package.