### PR TITLE
[TESTS] 'delete 1to1 chat' test reworked in order to decrease execution time

### DIFF
--- a/test/appium/support/test_rerun.py
+++ b/test/appium/support/test_rerun.py
@@ -9,6 +9,7 @@ RERUN_ERRORS = [
     '504 Gateway Time-out',
     'Internal Server Error',
     'Invalid message: ERROR Internal Server Error',
+    'ERROR The test with session id'
     "Message: 'CreateAccountButton' is not found on screen",
     "503 Service Unavailable",
     "AttributeError: 'NoneType' object has no attribute 'find_element'"

--- a/test/appium/tests/test_chat_management.py
+++ b/test/appium/tests/test_chat_management.py
@@ -11,7 +11,7 @@ from views.sign_in_view import SignInView
 @marks.chat_management
 class TestChatManagementMultiple(MultipleDeviceTestCase):
 
-    @marks.testrail_case_id(3412)
+    @marks.skip
     def test_delete_1_1_chat(self):
         self.senders['g_user'] = transaction_users['G_USER']
         self.senders['h_user'] = transaction_users['H_USER']
@@ -146,6 +146,31 @@ class TestChatManagement(SingleDeviceTestCase):
         home_view.relogin()
         if home_view.get_chat_with_user(recipient['username']).is_element_present(20):
             pytest.fail('The chat is present after re-login')
+
+    @marks.testrail_case_id(3412)
+    def test_delete_1_1_chat(self):
+        sender = transaction_users['G_USER']
+        recipient = transaction_users['E_USER']
+        sign_in_view = SignInView(self.driver)
+        sign_in_view.recover_access(sender['passphrase'], sender['password'])
+        home_view = sign_in_view.get_home_view()
+        home_view.add_contact(recipient['public_key'])
+        chat_view = home_view.get_chat_view()
+        chat_view.chat_message_input.send_keys('test message')
+        chat_view.send_message_button.click()
+        transaction_amount = '0.00001'
+        chat_view.request_transaction_in_1_1_chat(transaction_amount)
+        chat_view.send_transaction_in_1_1_chat(transaction_amount, sender['password'])
+        chat_view.delete_chat(recipient['username'], self.errors)
+        if home_view.get_chat_with_user(recipient['username']).is_element_present(5):
+            pytest.fail('Deleted chat is shown on Home screen')
+        home_view.relogin(sender['password'])
+        if home_view.get_chat_with_user(recipient['username']).is_element_present(20):
+            pytest.fail('Deleted chat is shown on Home screen after re-login')
+        home_view.start_1_1_chat(recipient['username'])
+        if not chat_view.no_messages_in_chat.is_element_present():
+            pytest.fail('Message history is shown in a chat which was previously deleted')
+        self.verify_no_errors()
 
     @marks.testrail_case_id(3418)
     @marks.skip

--- a/test/appium/views/base_view.py
+++ b/test/appium/views/base_view.py
@@ -303,13 +303,13 @@ class BaseView(object):
             except (NoSuchElementException, TimeoutException):
                 counter += 1
 
-    def relogin(self):
+    def relogin(self, password='qwerty1234'):
         self.get_back_to_home_view()
         profile_view = self.profile_button.click()
         profile_view.logout_button.click()
         profile_view.confirm_logout_button.click()
         sign_in_view = self.get_sign_in_view()
         sign_in_view.click_account_by_position(0)
-        sign_in_view.password_input.send_keys('qwerty1234')
+        sign_in_view.password_input.send_keys(password)
         sign_in_view.sign_in_button.click()
         sign_in_view.home_button.wait_for_visibility_of_element()


### PR DESCRIPTION
'delete 1to1 chat' test was running for 26+ minutes, however in 80% of runs the test throws an infrastructure issue, so the test runs for additional 26 minutes. The test has been rework to run for ~5 minutes