### PR TITLE
[WIP] Upgrade Instabug to 2.12.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4106,9 +4106,9 @@
       }
     },
     "instabug-reactnative": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/instabug-reactnative/-/instabug-reactnative-2.8.1.tgz",
-      "integrity": "sha512-JhjtevebuOc7hDvfmrHnzutSMY03DuGnYJuX9kmNzd2JtmtlufQ79wU3AwbdOeouPYNwGTWmENJlRApBT4Mo+Q=="
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/instabug-reactnative/-/instabug-reactnative-2.12.0.tgz",
+      "integrity": "sha512-aD2JLofdXfZWvlcg3t3lEoUM+HN7qLaKry68Ypjuh+cFGCXtblbKz4ozEfEFBw4rvEm31s8BSd1e/aFiHPXBmQ=="
     },
     "invariant": {
       "version": "2.2.4",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "events": "1.1.1",
     "homoglyph-finder": "1.1.1",
     "identicon.js": "github:status-im/identicon.js",
-    "instabug-reactnative": "2.8.1",
+    "instabug-reactnative": "2.12.0",
     "level-filesystem": "1.2.0",
     "nfc-react-native": "github:status-im/nfc-react-native",
     "process": "0.11.10",

--- a/src/status_im/ui/screens/profile/subs.cljs
+++ b/src/status_im/ui/screens/profile/subs.cljs
@@ -12,4 +12,4 @@
 (reg-sub
  :get-app-version
  (fn [{:keys [web3-node-version]}]
-   (str build/version " (" (or web3-node-version "N/A") ")")))
+   (str build/version " (" build/build-no ")\nnode " (or web3-node-version "N/A") "")))

--- a/src/status_im/utils/build.clj
+++ b/src/status_im/utils/build.clj
@@ -21,6 +21,11 @@
         (println (analyzer/message env (str "\u001B[31mWARNING\u001B[0m: " s))))
       (System/exit 1))))
 
+(defmacro get-build-no []
+  (-> (shell/sh "bash" "-c" "sh ./scripts/build_no.sh")
+      :out
+      (string/replace "\n" "")))
+
 (defmacro git-short-version []
   (let [version-file-path "VERSION"
         version-file      (io/file version-file-path)]

--- a/src/status_im/utils/build.cljs
+++ b/src/status_im/utils/build.cljs
@@ -1,4 +1,5 @@
 (ns status-im.utils.build
-  (:require-macros [status-im.utils.build :refer [git-short-version]]))
+  (:require-macros [status-im.utils.build :as build]))
 
-(def version (git-short-version))
+(def version (build/git-short-version))
+(def build-no (build/get-build-no))


### PR DESCRIPTION
Hotfix for release/0.9.19 (do not merge)

Upgrade Instabug to 2.12.0 as surveys stopped working in 2.8.1 (as confirmed with Instabug support team).

We could also use "App version" condition in survey. Example format: `0.9.18 (6000)`

status: wip <!-- Can be ready or wip -->
