### PR TITLE
Restore long tap for long messages

### DIFF
--- a/src/status_im/chat/views/message/message.cljs
+++ b/src/status_im/chat/views/message/message.cljs
@@ -208,8 +208,7 @@
      [react/view
       [react/text {:style           (style/text-message message collapsible?)
                    :number-of-lines (when collapsible? number-of-lines)
-                   :ref             (partial reset! ref)
-                   :on-press        on-press}
+                   :ref             (partial reset! ref)}
        parsed-text
        [react/text {:style (style/message-timestamp-placeholder-text outgoing)} (timestamp-with-padding timestamp-str)]]
       (when collapsible?


### PR DESCRIPTION
### Summary

Restore back ability to long tap on message (it was broken by expand/collapse PR https://github.com/status-im/status-react/pull/4430 which added ability to expand/collapse by tapping on message, which is unnecessary because it already has "Show more/less" button)

Thanks @asemiankevich for pointing this out.

status: ready
