### PR TITLE
[fix 4212] update profiles with concurrent contact-requests

### DIFF
--- a/src/status_im/transport/handlers.cljs
+++ b/src/status_im/transport/handlers.cljs
@@ -74,7 +74,8 @@
    (let [{:keys [web3 current-public-key]} db
          chat-transport-info               (-> (get-in db [:transport/chats chat-id])
                                                (assoc :sym-key-id sym-key-id
-                                                      :sym-key sym-key))]
+                                                      :sym-key sym-key
+                                                      :topic topic))]
      (handlers-macro/merge-fx cofx
                               {:db (assoc-in db [:transport/chats chat-id] chat-transport-info)
                                :shh/add-filter {:web3       web3
@@ -92,7 +93,8 @@
    (let [{:keys [web3 current-public-key]} db
          chat-transport-info               (-> (get-in db [:transport/chats chat-id])
                                                (assoc :sym-key-id sym-key-id
-                                                      :sym-key sym-key))]
+                                                      :sym-key sym-key
+                                                      :topic topic))]
      (handlers-macro/merge-fx cofx
                               {:db             (assoc-in db
                                                          [:transport/chats chat-id]


### PR DESCRIPTION
fixes #4212

### Summary:
If 2 contacts add each other concurrently, make sure that their info is updated, and keep only one of the 2 sym-keys created

### Steps to test:
- Add contact B with A while offline
- Add contact A with B while A is offline
- Go back online, contact should see each other real names
- Restart the app and connect to A and B 2 times
- Profile update should still work

status: ready
