### PR TITLE
[fix] show connecting to peers popup when no peers at startup

### DIFF
--- a/src/status_im/ui/screens/events.cljs
+++ b/src/status_im/ui/screens/events.cljs
@@ -278,8 +278,8 @@
     :db          (assoc app-db
                         :contacts/contacts {}
                         :network-status network-status
-                        :peers-count peers-count
-                        :peers-summary peers-summary
+                        :peers-count (or peers-count 0)
+                        :peers-summary (or peers-summary [])
                         :status-module-initialized? (or platform/ios? js/goog.DEBUG status-module-initialized?)
                         :status-node-started? status-node-started?
                         :network network


### PR DESCRIPTION
previously was only showing up when there was 0 peers after some
disconnection but sometimes the app starts and user logs in without being
connected to any peer this means the peers-summary is nil peers count is nil
and the user only noticed something was wrong after one minute because the mailserver
would not connect

status: ready
