### PR TITLE
Allow editing/deleting custom bootnodes

### DIFF
--- a/src/status_im/models/bootnode.cljs
+++ b/src/status_im/models/bootnode.cljs
@@ -43,21 +43,39 @@
                           (set-input :name (str name)))]
     (assoc fxs :dispatch [:navigate-to :edit-bootnode])))
 
-(defn save [{{:bootnodes/keys [manage] :account/keys [account] :as db} :db :as cofx}]
-  (let [{:keys [name url]} manage
-        network            (:network db)
-        bootnode           (build
-                            (:random-id cofx)
-                            (:value name)
-                            (:value url)
-                            network)
-        new-bootnodes      (assoc-in
-                            (:bootnodes account)
-                            [network (:id bootnode)]
-                            bootnode)]
+(defn custom-bootnodes-in-use? [{:keys [db] :as cofx}]
+  (let [network (:network db)]
+    (get-in db [:account/account :settings :bootnodes network])))
+
+(defn delete [id {{:account/keys [account] :as db} :db :as cofx}]
+  (let [network     (:network db)
+        new-account (update-in account [:bootnodes network] dissoc id)]
+    (handlers-macro/merge-fx {:db (assoc db :account/account new-account)}
+                             (accounts.utils/account-update
+                              (select-keys new-account [:bootnodes])
+                              (when (custom-bootnodes-in-use? cofx)
+                                [:logout])))))
+
+(defn upsert [{{:bootnodes/keys [manage] :account/keys [account] :as db} :db :as cofx}]
+  (let [{:keys [name
+                id
+                url]} manage
+        network       (:network db)
+        bootnode      (build
+                       (or (:value id) (:random-id cofx))
+                       (:value name)
+                       (:value url)
+                       network)
+        new-bootnodes (assoc-in
+                       (:bootnodes account)
+                       [network (:id bootnode)]
+                       bootnode)]
 
     (handlers-macro/merge-fx
      cofx
      {:db       (dissoc db :bootnodes/manage)
       :dispatch [:navigate-back]}
-     (accounts.utils/account-update {:bootnodes new-bootnodes}))))
+     (accounts.utils/account-update
+      {:bootnodes new-bootnodes}
+      (when (custom-bootnodes-in-use? cofx)
+        [:logout])))))

--- a/src/status_im/translations/en.cljs
+++ b/src/status_im/translations/en.cljs
@@ -597,6 +597,7 @@
    ;; TODO(dmitryn): come up with better description/naming. Suggested namings: Mailbox and Master Node
    :existing-wnodes                      "Existing mailservers"
    :add-mailserver                       "Add Mailserver"
+   :mailserver-details                   "Mailserver details"
    :delete-mailserver-title              "Delete mailserver"
    :delete-mailserver-are-you-sure       "Are you sure you want to delete this mailserver?"
    :delete-mailserver                    "Delete mailserver"
@@ -632,7 +633,11 @@
    :bootnodes-enabled                    "Bootnodes enabled"
    :bootnode-address                     "Bootnode address"
    :add-bootnode                         "Add bootnode"
+   :bootnode-details                     "Bootnode details"
    :specify-bootnode-address             "Specify bootnode address"
+   :delete-bootnode-title                "Delete bootnode"
+   :delete-bootnode-are-you-sure         "Are you sure you want to delete this bootnode?"
+   :delete-bootnode                      "Delete bootnode"
 
    :mainnet-warning-title                "Warning!"
    :mainnet-warning-text                 "While we highly appreciate your contribution as a tester of Status, we’d like to point out the dangers. You’re switching to Mainnet mode which is still in Alpha. This means it is still in development and has not been audited yet. Some of the risks you may be exposed to include:\n\n- Accounts may be unrecoverable due to breaking changes\n- Loss of ETH and tokens\n- Failure to send or receive messages\n\nSwitching to Mainnet should be done for testing purposes only. By tapping \"I understand\", you confirm that you assume the full responsibility for all risks concerning your data and funds. "

--- a/src/status_im/ui/screens/bootnodes_settings/edit_bootnode/events.cljs
+++ b/src/status_im/ui/screens/bootnodes_settings/edit_bootnode/events.cljs
@@ -8,7 +8,7 @@
  :save-new-bootnode
  [(re-frame/inject-cofx :random-id)]
  (fn [cofx _]
-   (models.bootnode/save cofx)))
+   (models.bootnode/upsert cofx)))
 
 (handlers/register-handler-fx
  :bootnode-set-input
@@ -19,6 +19,12 @@
  :edit-bootnode
  (fn [cofx [_ bootnode-id]]
    (models.bootnode/edit bootnode-id cofx)))
+
+(handlers/register-handler-fx
+ :delete-bootnode
+ (fn [cofx [_ bootnode-id]]
+   (assoc (models.bootnode/delete bootnode-id cofx)
+          :dispatch [:navigate-back])))
 
 (handlers/register-handler-fx
  :set-bootnode-from-qr

--- a/src/status_im/ui/screens/bootnodes_settings/edit_bootnode/styles.cljs
+++ b/src/status_im/ui/screens/bootnodes_settings/edit_bootnode/styles.cljs
@@ -29,3 +29,25 @@
   {:flex-direction    :row
    :margin-horizontal 12
    :margin-vertical   15})
+
+(def button-container
+  {:margin-top        8
+   :margin-bottom     16
+   :margin-horizontal 16})
+
+(def button
+  {:height           52
+   :align-items      :center
+   :justify-content  :center
+   :border-radius    8
+   :ios              {:opacity 0.9}})
+
+(defstyle button-label
+  {:color   colors/white
+   :ios     {:font-size      17
+             :letter-spacing -0.2}
+   :android {:font-size 14}})
+
+(defstyle delete-button
+  (assoc button
+         :background-color colors/red))

--- a/src/status_im/ui/screens/bootnodes_settings/edit_bootnode/views.cljs
+++ b/src/status_im/ui/screens/bootnodes_settings/edit_bootnode/views.cljs
@@ -4,6 +4,7 @@
    [re-frame.core :as re-frame]
    [status-im.ui.components.react :as react]
    [status-im.i18n :as i18n]
+   [status-im.utils.utils :as utils]
    [status-im.ui.components.styles :as components.styles]
    [status-im.ui.components.common.common :as components.common]
    [status-im.ui.components.colors :as colors]
@@ -12,6 +13,21 @@
    [status-im.ui.components.toolbar.view :as toolbar]
    [status-im.ui.components.text-input.view :as text-input]
    [status-im.ui.screens.bootnodes-settings.edit-bootnode.styles :as styles]))
+
+(defn handle-delete [id]
+  (utils/show-confirmation (i18n/label :t/delete-bootnode-title)
+                           (i18n/label :t/delete-bootnode-are-you-sure)
+                           (i18n/label :t/delete-bootnode)
+                           #(re-frame/dispatch [:delete-bootnode id])))
+
+(defn delete-button [id]
+  [react/touchable-highlight {:on-press #(handle-delete id)}
+   [react/view styles/button-container
+    [react/view {:style               styles/delete-button
+                 :accessibility-label :bootnode-delete-button}
+     [react/text {:style      styles/button-label
+                  :uppercase? true}
+      (i18n/label :t/delete)]]]])
 
 (def qr-code
   [react/touchable-highlight {:on-press #(re-frame/dispatch [:scan-qr-code
@@ -25,12 +41,13 @@
   (views/letsubs [manage-bootnode [:get-manage-bootnode]
                   is-valid?       [:manage-bootnode-valid?]]
     (let [url  (get-in manage-bootnode [:url :value])
+          id   (get-in manage-bootnode [:id :value])
           name (get-in manage-bootnode [:name :value])]
 
       [react/view components.styles/flex
        [status-bar/status-bar]
        [react/keyboard-avoiding-view components.styles/flex
-        [toolbar/simple-toolbar (i18n/label :t/add-bootnode)]
+        [toolbar/simple-toolbar (i18n/label (if id :t/bootnode-details :t/add-bootnode))]
         [react/scroll-view
          [react/view styles/edit-bootnode-view
           [text-input/text-input-with-label
@@ -48,7 +65,9 @@
             :style           styles/input
             :container       styles/input-container
             :default-value   url
-            :on-change-text  #(re-frame/dispatch [:bootnode-set-input :url %])}]]]
+            :on-change-text  #(re-frame/dispatch [:bootnode-set-input :url %])}]
+          (when id
+            [delete-button id])]]
         [react/view styles/bottom-container
          [react/view components.styles/flex]
          [components.common/bottom-button

--- a/src/status_im/ui/screens/bootnodes_settings/views.cljs
+++ b/src/status_im/ui/screens/bootnodes_settings/views.cljs
@@ -13,12 +13,13 @@
             [status-im.ui.screens.profile.components.views :as profile.components]
             [status-im.ui.screens.bootnodes-settings.styles :as styles]))
 
-(defn navigate-to-add-bootnode []
-  (re-frame/dispatch [:edit-bootnode]))
+(defn navigate-to-add-bootnode [id]
+  (re-frame/dispatch [:edit-bootnode id]))
 
 (defn render-row [{:keys [name id]}]
-  [react/view
-   {:accessibility-label :bootnode-item}
+  [react/touchable-highlight
+   {:on-press            #(navigate-to-add-bootnode id)
+    :accessibility-label :bootnode-item}
    [react/view styles/bootnode-item
     [react/view styles/bootnode-item-inner
      [react/text {:style styles/bootnode-item-name-text}
@@ -33,7 +34,7 @@
       toolbar/default-nav-back
       [toolbar/content-title (i18n/label :t/bootnodes-settings)]
       [toolbar/actions
-       [(toolbar.actions/add false navigate-to-add-bootnode)]]]
+       [(toolbar.actions/add false #(navigate-to-add-bootnode nil))]]]
      [react/view styles/switch-container
       [profile.components/settings-switch-item
        {:label-kw  :t/bootnodes-enabled

--- a/src/status_im/ui/screens/offline_messaging_settings/edit_mailserver/views.cljs
+++ b/src/status_im/ui/screens/offline_messaging_settings/edit_mailserver/views.cljs
@@ -57,7 +57,7 @@
       [react/view components.styles/flex
        [status-bar/status-bar]
        [react/keyboard-avoiding-view components.styles/flex
-        [toolbar/simple-toolbar (i18n/label :t/add-mailserver)]
+        [toolbar/simple-toolbar (i18n/label (if id :t/mailserver-details :t/add-mailserver))]
         [react/scroll-view
          [react/view styles/edit-mailserver-view
           [text-input/text-input-with-label


### PR DESCRIPTION
Part of: #4264
fixes #4585 #4584

### Summary:

Allow editing and deleting bootnodes.

### Review notes (optional):
All code is feature flagged, so skips qa.

status: ready
