### PR TITLE
Ensure valid timestamp for all messages

### DIFF
--- a/src/status_im/chat/models/message.cljs
+++ b/src/status_im/chat/models/message.cljs
@@ -124,8 +124,8 @@
     (transport/send (protocol/map->MessagesSeen {:message-ids #{message-id}}) chat-id cofx)))
 
 (defn- add-received-message
-  [batch?
-   {:keys [from message-id chat-id content content-type timestamp clock-value to-clock-value js-obj] :as message}
+  [batch? 
+   {:keys [from message-id chat-id content content-type clock-value to-clock-value js-obj] :as message}
    {:keys [db now] :as cofx}]
   (let [{:keys [web3 current-chat-id view-id access-scope->commands-responses]
          :contacts/keys [contacts]} db
@@ -158,6 +158,9 @@
 (def ^:private add-single-received-message (partial add-received-message false))
 (def ^:private add-batch-received-message (partial add-received-message true))
 
+(defn ensure-timestamp [now message]
+  (update message :timestamp (fnil identity now)))
+
 (defn receive
   [{:keys [chat-id message-id] :as message} {:keys [now] :as cofx}]
   (handlers-macro/merge-fx cofx
@@ -165,11 +168,11 @@
                                                     ;; We activate a chat again on new messages
                                                     :is-active true
                                                     :timestamp now})
-                           (add-single-received-message message)))
+                           (add-single-received-message (ensure-timestamp now message))))
 
 (defn receive-many
-  [messages {:keys [now] :as cofx}]
-  (let [chat-ids        (into #{} (map :chat-id) messages)
+  [raw-messages {:keys [now] :as cofx}]
+  (let [chat-ids        (into #{} (map :chat-id) raw-messages)
         chat-effects    (handlers-macro/merge-effects cofx
                                                       (fn [chat-id cofx]
                                                         (chat-model/upsert-chat {:chat-id   chat-id
@@ -177,6 +180,7 @@
                                                                                  :timestamp now}
                                                                                 cofx))
                                                       chat-ids)
+        messages        (map (partial ensure-timestamp now) raw-messages)
         message-effects (handlers-macro/merge-effects chat-effects cofx add-batch-received-message messages)]
     (handlers-macro/merge-effects message-effects
                                   cofx

--- a/test/cljs/status_im/test/chat/models/message.cljs
+++ b/test/cljs/status_im/test/chat/models/message.cljs
@@ -102,22 +102,16 @@
                        :clock-value 1
                        :timestamp   1
                        :show?       false}
-                      ;; TODO(janherich) : rewrite this so `receive-many` is
-                      ;; tested instead
-                      ;; dont' owerwrite existing timestamp
-                      (message/ensure-timestamp 4
-                                                {:message-id  2
-                                                 :content     "c"
-                                                 :clock-value 2
-                                                 :timestamp   2
-                                                 :show?       true})
-                      ;; provide timestmap if not present
-                      (message/ensure-timestamp 3
-                                                {:message-id  3
-                                                 :content     "d"
-                                                 :clock-value 3
-                                                 :timestamp   3
-                                                 :show?       true})]]
+                      {:message-id  2
+                       :content     "c"
+                       :clock-value 2
+                       :timestamp   2
+                       :show?       true}
+                      {:message-id  3
+                       :content     "d"
+                       :clock-value 3
+                       :timestamp   3
+                       :show?       true}]]
     (testing "New messages are grouped/sorted correctly, hidden messages are not grouped"
       (is (= '(2 3)
              (map :message-id

--- a/test/cljs/status_im/test/chat/models/message.cljs
+++ b/test/cljs/status_im/test/chat/models/message.cljs
@@ -97,21 +97,27 @@
                                                             :content     "d"
                                                             :clock-value 3
                                                             :timestamp   3}}}}}}
-        new-messages '({:message-id  1
-                        :content     "b"
-                        :clock-value 1
-                        :timestamp   1
-                        :show?       false}
-                       {:message-id  2
-                        :content     "c"
-                        :clock-value 2
-                        :timestamp   2
-                        :show?       true}
-                       {:message-id  3
-                        :content     "d"
-                        :clock-value 3
-                        :timestamp   3
-                        :show?       true})]
+        new-messages [{:message-id  1
+                       :content     "b"
+                       :clock-value 1
+                       :timestamp   1
+                       :show?       false}
+                      ;; TODO(janherich) : rewrite this so `receive-many` is
+                      ;; tested instead
+                      ;; dont' owerwrite existing timestamp
+                      (message/ensure-timestamp 4
+                                                {:message-id  2
+                                                 :content     "c"
+                                                 :clock-value 2
+                                                 :timestamp   2
+                                                 :show?       true})
+                      ;; provide timestmap if not present
+                      (message/ensure-timestamp 3
+                                                {:message-id  3
+                                                 :content     "d"
+                                                 :clock-value 3
+                                                 :timestamp   3
+                                                 :show?       true})]]
     (testing "New messages are grouped/sorted correctly, hidden messages are not grouped"
       (is (= '(2 3)
              (map :message-id


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes #4597

### Summary:

I recently removed timestamp checking in the `receive-message` function, as it had to be done outside anyway (because of the batch receive implemented via `receive-many` function) and then removed it altogether, as there should not be any way of messages getting into system without timestamps.
However it's apparently happening in very rare cases and I guess it's some bot using `#status` public channel which doesn't set the `:timestamp` value.
It's still good idea to be defensive and protect against such cases, so here I re-introduce the behaviour.

### Testing notes (optional):
Check that the bug is not happening anymore

status: ready
