### PR TITLE
bug #4593 - fixed gas update after default gas

### DIFF
--- a/src/status_im/ui/screens/wallet/events.cljs
+++ b/src/status_im/ui/screens/wallet/events.cljs
@@ -241,7 +241,9 @@
 (handlers/register-handler-db
  :wallet/update-gas-price-success
  (fn [db [_ price edit?]]
-   (assoc-in db [:wallet (if edit? :edit :send-transaction) :gas-price] price)))
+   (if edit?
+     (assoc-in db [:wallet :edit :gas-price] {:value price :invalid? false})
+     (assoc-in db [:wallet :send-transaction :gas-price] price))))
 
 (handlers/register-handler-fx
  :wallet/update-estimated-gas

--- a/src/status_im/ui/screens/wallet/send/events.cljs
+++ b/src/status_im/ui/screens/wallet/send/events.cljs
@@ -353,7 +353,9 @@
  :wallet.send/reset-gas-default
  (fn [{:keys [db]}]
    {:dispatch [:wallet/update-gas-price true]
-    :db       (assoc-in db [:wallet :edit :gas] nil)}))
+    :db       (assoc-in db [:wallet :edit :gas]
+                        {:value    (ethereum/estimate-gas (-> db :wallet :send-transaction :symbol))
+                         :invalid? false})}))
 
 (defn update-gas-price [db edit?]
   {:update-gas-price {:web3          (:web3 db)


### PR DESCRIPTION
fixes #4593 

### Summary:

Uses the new gas settings format `{:field {:value ... :invalid? false}}` in all update gas setting events.


### Steps to test:
- Wallet > Send > advanced > tap gas 
- Update gas
- Reset to default
- Update gas again 

see #4593 

status: ready