### PR TITLE
Persist unseen messages

### DIFF
--- a/src/status_im/data_store/messages.cljs
+++ b/src/status_im/data_store/messages.cljs
@@ -73,7 +73,7 @@
                               (core/get-by-fields
                                :user-status
                                :and {:whisper-identity (:current-public-key db)
-                                     :status           :received})
+                                     :status           "received"})
                               (core/all-clj :user-status)))))))
 
 (defn- prepare-content [content]

--- a/src/status_im/data_store/realm/core.cljs
+++ b/src/status_im/data_store/realm/core.cljs
@@ -235,14 +235,14 @@
   [results schema-name]
   (realm-list->clj-coll results [] #(realm-obj->clj (object/get results %) schema-name)))
 
-(defn- field-type [realm schema-name field]
+(defn- field-type [schema-name field]
   (let [field-def (get-in entity->schemas [schema-name :properties field])]
     (or (:type field-def) field-def)))
 
-(defmulti to-query (fn [_ _ operator _ _] operator))
+(defmulti to-query (fn [_ operator _ _] operator))
 
-(defmethod to-query :eq [schema schema-name _ field value]
-  (let [field-type    (field-type schema schema-name field)
+(defmethod to-query :eq [schema-name _ field value]
+  (let [field-type    (field-type schema-name field)
         escaped-value (when value (gstr/escapeString (str value)))
         query         (str (name field) "=" (if (= "string" (name field-type))
                                               (str "\"" escaped-value "\"")
@@ -252,7 +252,7 @@
 (defn get-by-field
   "Selects objects from realm identified by schema-name based on value of field"
   [realm schema-name field value]
-  (let [q (to-query realm schema-name :eq field value)]
+  (let [q (to-query schema-name :eq field value)]
     (.filtered (.objects realm (name schema-name)) q)))
 
 (defn- and-query [queries]
@@ -266,7 +266,7 @@
   combined by `:and`/`:or` operator"
   [realm schema-name op fields]
   (let [queries (map (fn [[k v]]
-                       (to-query realm schema-name :eq k v))
+                       (to-query schema-name :eq k v))
                      fields)]
     (.filtered (.objects realm (name schema-name))
                (case op


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes #4632 

### Summary:

We passed keyword `:received` instead of the string as the value for `AND` query when fetching unseen messages at the app start. 
This PR fixes it + it removes unnecessary from the `schema` argument from the `to-query` multimethod.

### Steps to test:
Ensure that the bug is not happening anymore

status: ready
