### PR TITLE
Add border to profile picture & style chat icon

### DIFF
--- a/src/status_im/chat/models.cljs
+++ b/src/status_im/chat/models.cljs
@@ -31,7 +31,7 @@
   (let [name (get-in db [:contacts/contacts chat-id :name])]
     {:chat-id            chat-id
      :name               (or name (gfycat/generate-gfy chat-id))
-     :color              styles/default-chat-color
+     :color              (styles/random-chat-color)
      :group-chat         false
      :is-active          true
      :timestamp          now

--- a/src/status_im/chat/styles/message/message.cljs
+++ b/src/status_im/chat/styles/message/message.cljs
@@ -101,7 +101,7 @@
      :padding-left  16}))
 
 (def message-author
-  {:width      photos/photo-size
+  {:width      photos/default-size
    :align-self :flex-end})
 
 (def delivery-view

--- a/src/status_im/chat/styles/photos.cljs
+++ b/src/status_im/chat/styles/photos.cljs
@@ -1,8 +1,24 @@
-(ns status-im.chat.styles.photos)
+(ns status-im.chat.styles.photos
+  (:require [status-im.ui.components.colors :as colors]))
 
-(def photo-size 36)
+(def default-size 36)
 
-(def photo
-  {:border-radius (/ photo-size 2)
-   :width         photo-size
-   :height        photo-size})
+(defn radius [size] (/ size 2))
+
+(defn photo-container [size]
+  {:position      :relative
+   :border-radius (radius size)})
+
+(defn photo-border [size]
+  {:position      :absolute
+   :width         size
+   :height        size
+   :opacity       0.4
+   :border-color  colors/photo-border-color
+   :border-width  1
+   :border-radius (radius size)})
+
+(defn photo [size]
+  {:border-radius (radius size)
+   :width         size
+   :height        size})

--- a/src/status_im/chat/styles/screen.cljs
+++ b/src/status_im/chat/styles/screen.cljs
@@ -171,10 +171,7 @@
    :padding-top    4
    :padding-bottom 4})
 
-(def bottom-info-row-photo
-  {:width         42
-   :height        42
-   :border-radius 21})
+(def bottom-info-row-photo-size 42)
 
 (def bottom-info-row-text-container
   {:margin-left  16

--- a/src/status_im/chat/views/bottom_info.cljs
+++ b/src/status_im/chat/views/bottom_info.cljs
@@ -8,6 +8,7 @@
             [status-im.i18n :as i18n]
             [status-im.ui.components.animation :as anim]
             [status-im.ui.components.list.views :as list]
+            [status-im.chat.views.photos :as photos]
             [status-im.utils.core :as utils]
             [status-im.utils.identicon :as identicon]))
 
@@ -41,8 +42,9 @@
 
 (defn- message-status-row [{:keys [photo-path name]} {:keys [whisper-identity status]}]
   [react/view styles/bottom-info-row
-   [react/image {:source {:uri (or photo-path (identicon/identicon whisper-identity))}
-                 :style  styles/bottom-info-row-photo}]
+   [photos/photo
+    (or photo-path (identicon/identicon whisper-identity))
+    styles/bottom-info-row-photo-size]
    [react/view styles/bottom-info-row-text-container
     [react/text {:style           styles/bottom-info-row-text1
                  :number-of-lines 1}

--- a/src/status_im/chat/views/photos.cljs
+++ b/src/status_im/chat/views/photos.cljs
@@ -6,18 +6,26 @@
             [clojure.string :as string]
             [status-im.react-native.resources :as resources]))
 
-(defn- photo [from photo-path]
-  [react/view
-   [react/image {:source (if (and (not (string/blank? photo-path))
-                                  (string/starts-with? photo-path "contacts://"))
-                           (->> (string/replace photo-path #"contacts://" "")
-                                (keyword)
-                                (get resources/contacts))
-                           {:uri photo-path})
-                 :style  style/photo}]])
+(defn- source [photo-path]
+  (if (and (not (string/blank? photo-path))
+           (string/starts-with? photo-path "contacts://"))
+    (->> (string/replace photo-path #"contacts://" "")
+         (keyword)
+         (get resources/contacts))
+    {:uri photo-path}))
+
+(defn photo [photo-path {:keys [size
+                                accessibility-label]}]
+  [react/view {:style (style/photo-container size)}
+   [react/image {:source              (source photo-path)
+                 :style               (style/photo size)
+                 :accessibility-label (or accessibility-label :chat-icon)}]
+   [react/view {:style (style/photo-border size)}]])
 
 (defview member-photo [from]
   (letsubs [photo-path [:get-photo-path from]]
-    (photo from  (if (string/blank? photo-path)
-                   (identicon/identicon from)
-                   photo-path))))
+    (photo (if (string/blank? photo-path)
+             (identicon/identicon from)
+             photo-path)
+           {:accessibility-label :member-photo
+            :size                style/default-size})))

--- a/src/status_im/ui/components/chat_icon/screen.cljs
+++ b/src/status_im/ui/components/chat_icon/screen.cljs
@@ -5,23 +5,13 @@
             [status-im.ui.components.react :as react]
             [status-im.ui.components.chat-icon.styles :as styles]
             [status-im.ui.components.styles :as components.styles]
+            [status-im.chat.views.photos :as photos]
             [status-im.react-native.resources :as resources]))
 
 (defn default-chat-icon [name styles]
   [react/view (:default-chat-icon styles)
    [react/text {:style (:default-chat-icon-text styles)}
-    (first name)]])
-
-(defn chat-icon [photo-path {:keys [size accessibility-label]}]
-  (let [photo (when photo-path
-                (if (string/starts-with? photo-path "contacts://")
-                  (->> (string/replace photo-path #"contacts://" "")
-                       (keyword)
-                       (get resources/contacts))
-                  {:uri photo-path}))]
-    [react/image {:source              photo
-                  :style               (styles/image-style size)
-                  :accessibility-label (or accessibility-label :chat-icon)}]))
+    (string/capitalize (first name))]])
 
 (defn dapp-badge [{:keys [online-view-wrapper online-view online-dot-left online-dot-right]}]
   [react/view online-view-wrapper
@@ -43,7 +33,7 @@
             dapp?      [:get-in [:contacts/contacts chat-id :dapp?]]]
     [react/view (:container styles)
      (if-not (string/blank? photo-path)
-       [chat-icon photo-path styles]
+       [photos/photo photo-path styles]
        [default-chat-icon name styles])
      (when (and dapp? (not hide-dapp?))
        [dapp-badge styles])
@@ -130,7 +120,7 @@
   (let [photo-path photo-path]
     [react/view container
      (if-not (string/blank? photo-path)
-       [chat-icon photo-path styles]
+       [photos/photo photo-path styles]
        [default-chat-icon name styles])
      (when dapp?
        [dapp-badge styles])]))
@@ -176,7 +166,7 @@
         [react/text {:style styles/profile-icon-edit-text}
          (i18n/label :t/edit)]])
      (if (and photo-path (seq photo-path))
-       [chat-icon photo-path styles]
+       [photos/photo photo-path styles]
        [default-chat-icon name styles])]))
 
 (defn my-profile-icon [{{:keys [photo-path name]} :account

--- a/src/status_im/ui/components/chat_icon/styles.cljs
+++ b/src/status_im/ui/components/chat_icon/styles.cljs
@@ -1,6 +1,6 @@
 (ns status-im.ui.components.chat-icon.styles
-  (:require [status-im.ui.components.styles :refer [color-white
-                                                    online-color]]))
+  (:require [status-im.ui.components.colors :as colors]
+            [status-im.ui.components.styles :refer [online-color]]))
 
 (defn default-chat-icon [color]
   {:margin           0
@@ -36,14 +36,14 @@
           :border-radius 32}))
 
 (def default-chat-icon-text
-  {:margin-top  -2
-   :color       color-white
-   :font-size   16
-   :line-height 20})
+  {:color       colors/white
+   :font-size   20
+   :opacity     0.8
+   :line-height 24})
 
 (def message-status-icon-text
   {:margin-top -2
-   :color      color-white
+   :color      colors/white
    :font-size  24})
 
 (def chat-icon
@@ -134,7 +134,7 @@
    :width            3
    :height           3
    :border-radius    2
-   :background-color color-white})
+   :background-color colors/white})
 (def online-dot-left (merge online-dot {:left 2.8}))
 (def online-dot-right (merge online-dot {:left 7.2}))
 

--- a/src/status_im/ui/components/colors.cljs
+++ b/src/status_im/ui/components/colors.cljs
@@ -23,6 +23,14 @@
 (def red-light "#ffe5ea") ;; error tooltip
 (def text-light-gray "#212121") ;; Used for labels (home items)
 (def cyan "#7adcfb") ;; Used by wallet transaction filtering icon
+(def photo-border-color "#ccd3d6")
+
+(def chat-colors ["#fa6565"
+                  "#7cda00"
+                  "#887af9"
+                  "#51d0f0"
+                  "#fe8f59"
+                  "#d37ef4"])
 
 (defn alpha [hex opacity]
   (let [hex (string/replace hex #"#" "")

--- a/src/status_im/ui/components/styles.cljs
+++ b/src/status_im/ui/components/styles.cljs
@@ -53,6 +53,9 @@
 (def separator-color "#0000001f")
 (def default-chat-color color-purple)
 
+(defn random-chat-color []
+  (rand-nth colors/chat-colors))
+
 ;;rgb 237 241 243
 
 (def flex

--- a/src/status_im/ui/screens/accounts/login/styles.cljs
+++ b/src/status_im/ui/screens/accounts/login/styles.cljs
@@ -30,10 +30,7 @@
 (def login-badge
   {:align-items :center})
 
-(def login-badge-image
-  {:width         56
-   :height        56
-   :border-radius 28})
+(def login-badge-image-size 56)
 
 (def login-badge-name
   {:font-size  15

--- a/src/status_im/ui/screens/accounts/login/views.cljs
+++ b/src/status_im/ui/screens/accounts/login/views.cljs
@@ -11,6 +11,7 @@
             [status-im.i18n :as i18n]
             [status-im.ui.components.react :as components]
             [status-im.ui.components.common.common :as components.common]
+            [status-im.chat.views.photos :as photos]
             [re-frame.core :as re-frame]
             [cljs.spec.alpha :as spec]
             [status-im.ui.screens.accounts.db :as db]))
@@ -41,8 +42,7 @@
 
 (defn account-login-badge [photo-path name]
   [react/view styles/login-badge
-   [react/image {:source {:uri (if (string/blank? photo-path) :avatar photo-path)}
-                 :style  styles/login-badge-image}]
+   [photos/photo photo-path {:size styles/login-badge-image-size}]
    [react/view
     [react/text {:style         styles/login-badge-name
                  :numberOfLines 1}

--- a/src/status_im/ui/screens/accounts/styles.cljs
+++ b/src/status_im/ui/screens/accounts/styles.cljs
@@ -15,10 +15,7 @@
 (def bottom-actions-container
   {:margin-bottom 16})
 
-(def photo-image
-  {:height        40
-   :width         40
-   :border-radius 20})
+(def account-image-size 40)
 
 (defstyle account-title-text
   {:color     :black

--- a/src/status_im/ui/screens/accounts/views.cljs
+++ b/src/status_im/ui/screens/accounts/views.cljs
@@ -2,6 +2,7 @@
   (:require-macros [status-im.utils.views :refer [defview letsubs]])
   (:require [clojure.string :as string]
             [re-frame.core :as re-frame]
+            [status-im.chat.views.photos :as photos]
             [status-im.ui.screens.accounts.styles :as styles]
             [status-im.ui.components.list.views :as list]
             [status-im.ui.components.status-bar.view :as status-bar]
@@ -15,8 +16,7 @@
 (defn account-view [{:keys [address photo-path name public-key]}]
   [react/touchable-highlight {:on-press #(re-frame/dispatch [:open-login address photo-path name])}
    [react/view styles/account-view
-    [react/image {:source {:uri (if (string/blank? photo-path) :avatar photo-path)}
-                  :style  styles/photo-image}]
+    [photos/photo photo-path {:size styles/account-image-size}]
     [react/view styles/account-badge-text-view
      [react/text {:style         styles/account-badge-text
                   :numberOfLines 1}

--- a/src/status_im/ui/screens/wallet/components/views.cljs
+++ b/src/status_im/ui/screens/wallet/components/views.cljs
@@ -6,7 +6,7 @@
             [status-im.i18n :as i18n]
             [status-im.ui.components.bottom-buttons.view :as bottom-buttons]
             [status-im.ui.components.button.view :as button]
-            [status-im.ui.components.chat-icon.screen :as chat-icon]
+            [status-im.chat.views.photos :as photos]
             [status-im.ui.components.list.views :as list]
             [status-im.ui.components.list.styles :as list.styles]
             [status-im.ui.components.list-selection :as list-selection]
@@ -106,7 +106,7 @@
     (let [address? (and (not (nil? address)) (not= address ""))]
       [react/view styles/recipient-container
        [react/view styles/recipient-icon
-        [chat-icon/chat-icon (:photo-path contact) {:size list.styles/image-size}]]
+        [photos/photo (:photo-path contact) {:size list.styles/image-size}]]
        [react/view {:style styles/recipient-name}
         [react/text {:style               (styles/participant true)
                      :accessibility-label (if request? :contact-name-text :recipient-name-text)
@@ -119,7 +119,7 @@
 (defn render-contact [contact]
   [list/touchable-item #(re-frame/dispatch [:wallet/fill-request-from-contact contact])
    [list/item
-    [chat-icon/chat-icon (:photo-path contact) {:size list.styles/image-size}]
+    [photos/photo (:photo-path contact) {:size list.styles/image-size}]
     [list/item-content
      [list/item-primary {:accessibility-label :contact-name-text}
       (:name contact)]

--- a/src/status_im/utils/identicon.cljs
+++ b/src/status_im/utils/identicon.cljs
@@ -4,7 +4,9 @@
 (def default-size 40)
 
 (defn identicon
-  ([hash] (identicon hash default-size))
+  ([hash] (identicon hash (clj->js {:background [255 255 255 255]
+                                    :margin     0.24
+                                    :size       default-size})))
   ([hash options]
    (str "data:image/png;base64,"
         (str (new dependencies/identicon-js hash options)))))

--- a/test/cljs/status_im/test/chat/views/photos.cljs
+++ b/test/cljs/status_im/test/chat/views/photos.cljs
@@ -1,0 +1,13 @@
+(ns status-im.test.chat.views.photos
+  (:require [cljs.test :refer [deftest testing is]]
+            [status-im.react-native.resources :as resources]
+            [status-im.chat.views.photos :as photos]))
+
+(deftest photos-test
+  (testing "a normal string"
+    (let [actual (photos/source "some-string")]
+      (is (= {:uri "some-string"} actual))))
+  (testing "a contact string"
+    (with-redefs [resources/contacts {:test "something"}]
+      (let [actual (photos/source "contacts://test")]
+        (is (= "something" actual))))))

--- a/test/cljs/status_im/test/contacts/subs.cljs
+++ b/test/cljs/status_im/test/contacts/subs.cljs
@@ -1,82 +1,104 @@
 (ns status-im.test.contacts.subs
   (:require [cljs.test :refer-macros [deftest is testing]]
+            [status-im.utils.identicon :as identicon]
             [status-im.ui.screens.contacts.subs :as contacts-subs]))
 
 (deftest contacts-subs
   (testing "get-all-contacts-in-group-chat"
-    (let [chat-contact-ids ["0x04fcf40c526b09ff9fb22f4a5dbd08490ef9b64af700870f8a0ba2133f4251d5607ed83cd9047b8c2796576bc83fa0de23a13a4dced07654b8ff137fe744047917"
-                            "0x048a2f8b80c60f89a91b4c1316e56f75b087f446e7b8701ceca06a40142d8efe1f5aa36bd0fee9e248060a8d5207b43ae98bef4617c18c71e66f920f324869c09f"]
-          group-admin-id   "0x04985040682b77a32bb4bb58268a0719bd24ca4d07c255153fe1eb2ccd5883669627bd1a092d7cc76e8e4b9104327667b19dcda3ac469f572efabe588c38c1985f"
-          contacts         {"demo-bot"
-                            {:description      nil,
-                             :last-updated     0,
-                             :hide-contact?    false,
-                             :address          nil,
-                             :name             "Demo bot",
-                             :jail-loaded?     true,
-                             :fcm-token        nil,
-                             :dapp-url         nil,
-                             :dapp-hash        nil,
-                             :photo-path       nil,
-                             :debug?           false,
-                             :status           nil,
-                             :bot-url          "local://demo-bot",
-                             :pending?         false,
-                             :whisper-identity "demo-bot",
-                             :last-online      0,
-                             :dapp?            true,
-                             :public-key       nil},
-                            "0x04985040682b77a32bb4bb58268a0719bd24ca4d07c255153fe1eb2ccd5883669627bd1a092d7cc76e8e4b9104327667b19dcda3ac469f572efabe588c38c1985f"
-                            {:description   nil,
-                             :last-updated  0,
-                             :hide-contact? false,
-                             :address       "eca8218b5ebeb2c47ba94c1b6e0a779d78fff7bc",
-                             :name          "User B",
-                             :fcm-token     nil,
-                             :dapp-url      nil,
-                             :dapp-hash     nil,
-                             :photo-path    "photo1",
-                             :debug?        false,
-                             :status        nil,
-                             :bot-url       nil,
-                             :pending?      true,
-                             :whisper-identity
-                             "0x04985040682b77a32bb4bb58268a0719bd24ca4d07c255153fe1eb2ccd5883669627bd1a092d7cc76e8e4b9104327667b19dcda3ac469f572efabe588c38c1985f",
-                             :last-online   0,
-                             :dapp?         false,
-                             :public-key
-                             "0x04985040682b77a32bb4bb58268a0719bd24ca4d07c255153fe1eb2ccd5883669627bd1a092d7cc76e8e4b9104327667b19dcda3ac469f572efabe588c38c1985f"},
-                            "cryptokitties"
-                            {:description      "Collect and breed adorable digital cats.",
-                             :last-updated     0,
-                             :hide-contact?    false,
-                             :address          nil,
-                             :name             "CryptoKitties",
-                             :fcm-token        nil,
-                             :dapp-url         "https://www.cryptokitties.co",
-                             :dapp-hash        nil,
-                             :photo-path       "contacts://cryptokitties",
-                             :debug?           false,
-                             :status           nil,
-                             :bot-url          nil,
-                             :pending?         false,
-                             :whisper-identity "cryptokitties",
-                             :last-online      0,
-                             :dapp?            true,
-                             :public-key       nil}}
-          current-account  {:last-updated        0,
-                            :address             "f23d28f538fd8cd4a90c2d96ca89f5bccca5383f",
-                            :email               nil,
-                            :signed-up?          true,
-                            :sharing-usage-data? false,
-                            :name                "User A",
-                            :photo-path          "photo2",
-                            :public-key
-                            "0x048a2f8b80c60f89a91b4c1316e56f75b087f446e7b8701ceca06a40142d8efe1f5aa36bd0fee9e248060a8d5207b43ae98bef4617c18c71e66f920f324869c09f"}]
-      (is (= (contacts-subs/get-all-contacts-in-group-chat chat-contact-ids
-                                                           group-admin-id
-                                                           contacts
-                                                           current-account)
-             [{:name "Snappy Impressive Leonberger", :photo-path "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAADAFBMVEXw8PCx2IwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGvqWjAAABAHRSTlP//wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKmfXxgAABnNJREFUeNoBaAaX+QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAQEBAQEBAQEBAQEBAQEBAQEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEBAQEBAQEBAQEBAQEBAQEBAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQEBAQEBAQEBAQEBAQEBAQEBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAQEBAQEBAQEBAQEBAQEBAQEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEBAQEBAQEBAQEBAQEBAQEBAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQEBAQEBAQEBAQEBAQEBAQEBAAAAAAAAAAAAAAAAAAAAAAABAQEBAQEAAAAAAAABAQEBAQEAAAAAAAABAQEBAQEAAAAAAAAAAAAAAAEBAQEBAQAAAAAAAAEBAQEBAQAAAAAAAAEBAQEBAQAAAAAAAAAAAAAAAQEBAQEBAAAAAAAAAQEBAQEBAAAAAAAAAQEBAQEBAAAAAAAAAAAAAAABAQEBAQEAAAAAAAABAQEBAQEAAAAAAAABAQEBAQEAAAAAAAAAAAAAAAEBAQEBAQAAAAAAAAEBAQEBAQAAAAAAAAEBAQEBAQAAAAAAAAAAAAAAAQEBAQEBAAAAAAAAAQEBAQEBAAAAAAAAAQEBAQEBAAAAAAAAAAAAAAABAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEAAAAAAAAAAAAAAAEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQAAAAAAAAAAAAAAAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAAAAAAAAAAAAAAABAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEAAAAAAAAAAAAAAAEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQAAAAAAAAAAAAAAAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAAAAAAAAAAAAAAAAAAAAAAABAQEBAQEBAQEBAQEBAQEBAQEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEBAQEBAQEBAQEBAQEBAQEBAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQEBAQEBAQEBAQEBAQEBAQEBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAQEBAQEBAQEBAQEBAQEBAQEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEBAQEBAQEBAQEBAQEBAQEBAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQEBAQEBAQEBAQEBAQEBAQEBAAAAAAAAAAAAAAAAAAAAAAABAQEBAQEBAQEBAQEAAAAAAAABAQEBAQEBAQEBAQEAAAAAAAAAAAAAAAEBAQEBAQEBAQEBAQAAAAAAAAEBAQEBAQEBAQEBAQAAAAAAAAAAAAAAAQEBAQEBAQEBAQEBAAAAAAAAAQEBAQEBAQEBAQEBAAAAAAAAAAAAAAABAQEBAQEBAQEBAQEAAAAAAAABAQEBAQEBAQEBAQEAAAAAAAAAAAAAAAEBAQEBAQEBAQEBAQAAAAAAAAEBAQEBAQEBAQEBAQAAAAAAAAAAAAAAAQEBAQEBAQEBAQEBAAAAAAAAAQEBAQEBAQEBAQEBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA3UECiaxw3MgAAAAASUVORK5CYII=", :whisper-identity "0x04fcf40c526b09ff9fb22f4a5dbd08490ef9b64af700870f8a0ba2133f4251d5607ed83cd9047b8c2796576bc83fa0de23a13a4dced07654b8ff137fe744047917"}
-              {:name "User A", :photo-path "photo2", :whisper-identity "0x048a2f8b80c60f89a91b4c1316e56f75b087f446e7b8701ceca06a40142d8efe1f5aa36bd0fee9e248060a8d5207b43ae98bef4617c18c71e66f920f324869c09f"}
-              {:description nil, :last-updated 0, :hide-contact? false, :address "eca8218b5ebeb2c47ba94c1b6e0a779d78fff7bc", :name "User B", :fcm-token nil, :dapp-url nil, :dapp-hash nil, :photo-path "photo1", :debug? false, :status nil, :bot-url nil, :pending? true, :whisper-identity "0x04985040682b77a32bb4bb58268a0719bd24ca4d07c255153fe1eb2ccd5883669627bd1a092d7cc76e8e4b9104327667b19dcda3ac469f572efabe588c38c1985f", :last-online 0, :dapp? false, :public-key "0x04985040682b77a32bb4bb58268a0719bd24ca4d07c255153fe1eb2ccd5883669627bd1a092d7cc76e8e4b9104327667b19dcda3ac469f572efabe588c38c1985f"}])))))
+    (with-redefs [identicon/identicon (constantly "generated")]
+      (let [chat-contact-ids ["0x04fcf40c526b09ff9fb22f4a5dbd08490ef9b64af700870f8a0ba2133f4251d5607ed83cd9047b8c2796576bc83fa0de23a13a4dced07654b8ff137fe744047917"
+                              "0x048a2f8b80c60f89a91b4c1316e56f75b087f446e7b8701ceca06a40142d8efe1f5aa36bd0fee9e248060a8d5207b43ae98bef4617c18c71e66f920f324869c09f"]
+            group-admin-id   "0x04985040682b77a32bb4bb58268a0719bd24ca4d07c255153fe1eb2ccd5883669627bd1a092d7cc76e8e4b9104327667b19dcda3ac469f572efabe588c38c1985f"
+            contacts         {"demo-bot"
+                              {:description      nil,
+                               :last-updated     0,
+                               :hide-contact?    false,
+                               :address          nil,
+                               :name             "Demo bot",
+                               :jail-loaded?     true,
+                               :fcm-token        nil,
+                               :dapp-url         nil,
+                               :dapp-hash        nil,
+                               :photo-path       nil,
+                               :debug?           false,
+                               :status           nil,
+                               :bot-url          "local://demo-bot",
+                               :pending?         false,
+                               :whisper-identity "demo-bot",
+                               :last-online      0,
+                               :dapp?            true,
+                               :public-key       nil},
+                              "0x04985040682b77a32bb4bb58268a0719bd24ca4d07c255153fe1eb2ccd5883669627bd1a092d7cc76e8e4b9104327667b19dcda3ac469f572efabe588c38c1985f"
+                              {:description   nil,
+                               :last-updated  0,
+                               :hide-contact? false,
+                               :address       "eca8218b5ebeb2c47ba94c1b6e0a779d78fff7bc",
+                               :name          "User B",
+                               :fcm-token     nil,
+                               :dapp-url      nil,
+                               :dapp-hash     nil,
+                               :photo-path    "photo1",
+                               :debug?        false,
+                               :status        nil,
+                               :bot-url       nil,
+                               :pending?      true,
+                               :whisper-identity
+                               "0x04985040682b77a32bb4bb58268a0719bd24ca4d07c255153fe1eb2ccd5883669627bd1a092d7cc76e8e4b9104327667b19dcda3ac469f572efabe588c38c1985f",
+                               :last-online   0,
+                               :dapp?         false,
+                               :public-key
+                               "0x04985040682b77a32bb4bb58268a0719bd24ca4d07c255153fe1eb2ccd5883669627bd1a092d7cc76e8e4b9104327667b19dcda3ac469f572efabe588c38c1985f"},
+                              "cryptokitties"
+                              {:description      "Collect and breed adorable digital cats.",
+                               :last-updated     0,
+                               :hide-contact?    false,
+                               :address          nil,
+                               :name             "CryptoKitties",
+                               :fcm-token        nil,
+                               :dapp-url         "https://www.cryptokitties.co",
+                               :dapp-hash        nil,
+                               :photo-path       "contacts://cryptokitties",
+                               :debug?           false,
+                               :status           nil,
+                               :bot-url          nil,
+                               :pending?         false,
+                               :whisper-identity "cryptokitties",
+                               :last-online      0,
+                               :dapp?            true,
+                               :public-key       nil}}
+            current-account  {:last-updated        0,
+                              :address             "f23d28f538fd8cd4a90c2d96ca89f5bccca5383f",
+                              :email               nil,
+                              :signed-up?          true,
+                              :sharing-usage-data? false,
+                              :name                "User A",
+                              :photo-path          "photo2",
+                              :public-key
+                              "0x048a2f8b80c60f89a91b4c1316e56f75b087f446e7b8701ceca06a40142d8efe1f5aa36bd0fee9e248060a8d5207b43ae98bef4617c18c71e66f920f324869c09f"}]
+        (is (= (contacts-subs/get-all-contacts-in-group-chat chat-contact-ids
+                                                             group-admin-id
+                                                             contacts
+                                                             current-account)
+               [{:name             "Snappy Impressive Leonberger"
+                 :photo-path       "generated"
+                 :whisper-identity "0x04fcf40c526b09ff9fb22f4a5dbd08490ef9b64af700870f8a0ba2133f4251d5607ed83cd9047b8c2796576bc83fa0de23a13a4dced07654b8ff137fe744047917"}
+                {:name             "User A"
+                 :photo-path       "photo2"
+                 :whisper-identity "0x048a2f8b80c60f89a91b4c1316e56f75b087f446e7b8701ceca06a40142d8efe1f5aa36bd0fee9e248060a8d5207b43ae98bef4617c18c71e66f920f324869c09f"}
+                {:description      nil
+                 :last-updated     0
+                 :hide-contact?    false
+                 :address          "eca8218b5ebeb2c47ba94c1b6e0a779d78fff7bc"
+                 :name             "User B"
+                 :fcm-token        nil
+                 :dapp-url         nil
+                 :dapp-hash        nil
+                 :photo-path       "photo1"
+                 :debug?           false
+                 :status           nil
+                 :bot-url          nil
+                 :pending?         true
+                 :whisper-identity "0x04985040682b77a32bb4bb58268a0719bd24ca4d07c255153fe1eb2ccd5883669627bd1a092d7cc76e8e4b9104327667b19dcda3ac469f572efabe588c38c1985f"
+                 :last-online      0
+                 :dapp?            false
+                 :public-key       "0x04985040682b77a32bb4bb58268a0719bd24ca4d07c255153fe1eb2ccd5883669627bd1a092d7cc76e8e4b9104327667b19dcda3ac469f572efabe588c38c1985f"}]))))))

--- a/test/cljs/status_im/test/runner.cljs
+++ b/test/cljs/status_im/test/runner.cljs
@@ -18,6 +18,7 @@
             [status-im.test.chat.models.message]
             [status-im.test.chat.subs]
             [status-im.test.chat.views.message]
+            [status-im.test.chat.views.photos]
             [status-im.test.i18n]
             [status-im.test.transport.inbox]
             [status-im.test.protocol.web3.inbox]
@@ -66,6 +67,7 @@
  'status-im.test.chat.models.input
  'status-im.test.chat.models.message
  'status-im.test.chat.views.message
+ 'status-im.test.chat.views.photos
  'status-im.test.i18n
  'status-im.test.transport.inbox
  'status-im.test.protocol.web3.inbox


### PR DESCRIPTION
Fixes #4419 

### Summary:

* Added a transparent border to profile images
* Allowed multiple colors in chat-icons
* Changed `identicon` to display smaller icons

### Review notes (optional):

I have consolidated most of the logic for creating pictures in a single place  `status-im.chat.views.photos`.

The method for adding a border is to superimpose a `div` with a invisible border, of all the method considered that is the simplest, afaics.

### Testing notes:

* Previously generated images will not change.
* I have tried to find all the profile pics in the app, but without a comprehensive list I might have missed some.


status: ready
