### PR TITLE
[#4588] Workaround ellipsis issue on public key in the login screen.

### DIFF
--- a/src/status_im/ui/screens/accounts/styles.cljs
+++ b/src/status_im/ui/screens/accounts/styles.cljs
@@ -48,9 +48,9 @@
    :letter-spacing -0.2
    :color          common/color-black})
 
-(def account-badge-pub-key-text
+(defstyle account-badge-pub-key-text
   {:font-size      14
-   :letter-spacing -0.2
+   :ios            {:letter-spacing -0.2}
    :color          colors/gray
    :margin-top     4})
 


### PR DESCRIPTION
In the latest RN update it seems like `ellipsizeMode: middle` doesn't
play well with negative letter spacing anymore. This workaround remove negative letter spacing.


fixes #4588 

### Steps to test:
- Open Status
- Look at the list of account
- No text should overlap

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->
