### PR TITLE
Faster seen marking

### DIFF
--- a/src/status_im/chat/specs.cljs
+++ b/src/status_im/chat/specs.cljs
@@ -16,6 +16,7 @@
 (s/def :chat/public-group-topic-error (s/nilable string?))
 (s/def :chat/messages (s/nilable map?))                           ; messages indexed by message-id
 (s/def :chat/message-groups (s/nilable map?))                     ; grouped/sorted messages
+(s/def :chat/message-statuses (s/nilable map?))                   ; message/user statuses indexed by two level index
 (s/def :chat/not-loaded-message-ids (s/nilable set?))             ; set of message-ids not yet fully loaded from persisted state
 (s/def :chat/last-clock-value (s/nilable number?))                ; last logical clock value of messages in chat
 (s/def :chat/loaded-chats (s/nilable seq?))

--- a/src/status_im/chat/views/message/message.cljs
+++ b/src/status_im/chat/views/message/message.cljs
@@ -264,11 +264,11 @@
 (defview group-message-delivery-status [{:keys [message-id current-public-key user-statuses] :as msg}]
   (letsubs [{participants :contacts} [:get-current-chat]
             contacts                 [:get-contacts]]
-    (let [outgoing-status         (or (get user-statuses current-public-key) :sending)
+    (let [outgoing-status         (or (get-in user-statuses [current-public-key :status]) :sending)
           delivery-statuses       (dissoc user-statuses current-public-key)
           delivery-statuses-count (count delivery-statuses)
           seen-by-everyone        (and (= delivery-statuses-count (count participants))
-                                       (every? (comp (partial = :seen) second) delivery-statuses)
+                                       (every? (comp (partial = :seen) :status second) delivery-statuses)
                                        :seen-by-everyone)]
       (if (or seen-by-everyone (zero? delivery-statuses-count))
         [text-status (or seen-by-everyone outgoing-status)]
@@ -321,8 +321,8 @@
 
 (defn message-delivery-status
   [{:keys [chat-id message-id current-public-key user-statuses content last-outgoing? outgoing message-type] :as message}]
-  (let [outgoing-status (or (get user-statuses current-public-key) :not-sent)
-        delivery-status (get user-statuses chat-id)
+  (let [outgoing-status (or (get-in user-statuses [current-public-key :status]) :not-sent)
+        delivery-status (get-in user-statuses [chat-id :status])
         status          (cond (and (= constants/console-chat-id chat-id)
                                    (not (console/commands-with-delivery-status (:command content))))
                               :seen

--- a/src/status_im/data_store/realm/schemas/account/core.cljs
+++ b/src/status_im/data_store/realm/schemas/account/core.cljs
@@ -5,7 +5,8 @@
    [status-im.data-store.realm.schemas.account.v3.core :as v3]
    [status-im.data-store.realm.schemas.account.v4.core :as v4]
    [status-im.data-store.realm.schemas.account.v5.core :as v5]
-   [status-im.data-store.realm.schemas.account.v6.core :as v6]))
+   [status-im.data-store.realm.schemas.account.v6.core :as v6]
+   [status-im.data-store.realm.schemas.account.v7.core :as v7]))
 
 ;; TODO(oskarth): Add failing test if directory vXX exists but isn't in schemas.
 
@@ -27,4 +28,7 @@
                :migration     v5/migration}
               {:schema        v6/schema
                :schemaVersion 6
-               :migration     v6/migration}])
+               :migration     v6/migration}
+              {:schema        v7/schema
+               :schemaVersion 7
+               :migration     v7/migration}])

--- a/src/status_im/data_store/realm/schemas/account/v7/core.cljs
+++ b/src/status_im/data_store/realm/schemas/account/v7/core.cljs
@@ -1,0 +1,25 @@
+(ns status-im.data-store.realm.schemas.account.v7.core
+  (:require [status-im.data-store.realm.schemas.account.v5.chat :as chat]
+            [status-im.data-store.realm.schemas.account.v6.transport :as transport]
+            [status-im.data-store.realm.schemas.account.v1.contact :as contact]
+            [status-im.data-store.realm.schemas.account.v7.message :as message]
+            [status-im.data-store.realm.schemas.account.v1.request :as request]
+            [status-im.data-store.realm.schemas.account.v1.user-status :as user-status]
+            [status-im.data-store.realm.schemas.account.v1.local-storage :as local-storage]
+            [status-im.data-store.realm.schemas.account.v2.mailserver :as mailserver]
+            [status-im.data-store.realm.schemas.account.v1.browser :as browser]
+            [taoensso.timbre :as log]))
+
+(def schema [chat/schema
+             transport/schema
+             contact/schema
+             message/schema
+             request/schema
+             mailserver/schema
+             user-status/schema
+             local-storage/schema
+             browser/schema])
+
+(defn migration [old-realm new-realm]
+  (log/debug "migrating v7 account database: " old-realm new-realm)
+  (message/migration old-realm new-realm))

--- a/src/status_im/data_store/realm/schemas/account/v7/message.cljs
+++ b/src/status_im/data_store/realm/schemas/account/v7/message.cljs
@@ -1,0 +1,33 @@
+(ns status-im.data-store.realm.schemas.account.v7.message
+  (:require [taoensso.timbre :as log]))
+
+(def schema {:name       :message
+             :primaryKey :message-id
+             :properties {:message-id       :string
+                          :from             :string
+                          :to               {:type     :string
+                                             :optional true}
+                          :content          :string ; TODO make it ArrayBuffer
+                          :content-type     :string
+                          :username         {:type     :string
+                                             :optional true}
+                          :timestamp        :int
+                          :chat-id          {:type    :string
+                                             :indexed true}
+                          :outgoing         :bool
+                          :retry-count      {:type    :int
+                                             :default 0}
+                          :message-type     {:type     :string
+                                             :optional true}
+                          :message-status   {:type     :string
+                                             :optional true}
+                          :clock-value      {:type    :int
+                                             :default 0}
+                          :show?            {:type    :bool
+                                             :default true}}})
+
+(defn migration [old-realm new-realm]
+  (log/debug "migrating messages schema v7")
+  (let [messages (.objects new-realm "message")]
+    (dotimes [i (.-length messages)]
+      (js-delete (aget messages i) "user-statuses"))))

--- a/src/status_im/data_store/user_statuses.cljs
+++ b/src/status_im/data_store/user_statuses.cljs
@@ -1,0 +1,50 @@
+(ns status-im.data-store.user-statuses
+  (:require [clojure.string :as string]
+            [cljs.reader :as reader]
+            [re-frame.core :as re-frame]
+            [status-im.data-store.realm.core :as core]))
+
+(defn- in-query [message-ids]
+  (string/join " or " (map #(str "message-id=\"" % "\"") message-ids)))
+
+(defn- prepare-statuses [statuses]
+  (reduce (fn [acc {:keys [message-id whisper-identity] :as user-status}]
+            (assoc-in acc
+                      [message-id whisper-identity]
+                      (-> user-status
+                          (update :status keyword)
+                          (dissoc :status-id))))
+          {}
+          statuses))
+
+(defn- get-by-chat-and-messages-ids
+  [chat-id message-ids]
+  (-> @core/account-realm
+      (.objects "user-status")
+      (.filtered (str "chat-id=\"" chat-id "\""
+                      (when (seq message-ids)
+                        (str " and (" (in-query message-ids) ")"))))
+      (core/all-clj :user-status)
+      prepare-statuses))
+
+(re-frame/reg-cofx
+ :data-store/get-user-statuses
+ (fn [cofx _]
+   (assoc cofx :get-stored-user-statuses get-by-chat-and-messages-ids)))
+
+(defn- compute-status-id [{:keys [message-id whisper-identity]}]
+  (str message-id "-" whisper-identity))
+
+(defn save-status-tx
+  "Returns tx function for saving message user status"
+  [user-status]
+  (fn [realm]
+    (let [status-id (compute-status-id user-status)]
+      (core/create realm :user-status (assoc user-status :status-id status-id) true))))
+
+(defn save-statuses-tx
+  "Returns tx function for saving message user statuses"
+  [user-statuses]
+  (fn [realm]
+    (doseq [user-status user-statuses]
+      ((save-status-tx user-status) realm))))

--- a/src/status_im/transport/handlers.cljs
+++ b/src/status_im/transport/handlers.cljs
@@ -231,12 +231,12 @@
                                   (remove-hash envelope-hash)
                                   (update-resend-contact-message chat-id)))
 
-       (let [message (get-in db [:chats chat-id :messages message-id])
-             {:keys [fcm-token]} (get-in db [:contacts/contacts chat-id])]
-         (handlers-macro/merge-fx cofx
-                                  (remove-hash envelope-hash)
-                                  (models.message/update-message-status message status)
-                                  (models.message/send-push-notification fcm-token status)))))))
+       (when-let [message (get-in db [:chats chat-id :messages message-id])]
+         (let [{:keys [fcm-token]} (get-in db [:contacts/contacts chat-id])]
+           (handlers-macro/merge-fx cofx
+                                    (remove-hash envelope-hash)
+                                    (models.message/update-message-status message status)
+                                    (models.message/send-push-notification fcm-token status))))))))
 
 (defn- own-info [db]
   (let [{:keys [name photo-path address]} (:account/account db)

--- a/src/status_im/ui/screens/db.cljs
+++ b/src/status_im/ui/screens/db.cljs
@@ -229,6 +229,7 @@
                  :chat/public-group-topic-error
                  :chat/messages
                  :chat/message-groups
+                 :chat/message-statuses
                  :chat/not-loaded-message-ids
                  :chat/last-clock-value
                  :chat/loaded-chats

--- a/test/cljs/status_im/test/chat/models/message.cljs
+++ b/test/cljs/status_im/test/chat/models/message.cljs
@@ -78,12 +78,7 @@
       (is (nil? (extract-seen
                  (message/receive
                   message
-                  (assoc-in db [:db :view-id] :home))))))
-    (testing "it does not send any when no public key is in account"
-      (is (nil? (extract-seen
-                 (message/receive
-                  message
-                  (assoc-in db [:db :account/account :public-key] nil))))))))
+                  (assoc-in db [:db :view-id] :home))))))))
 
 (deftest group-messages
   (let [cofx         {:db {:chats {"chat-id" {:messages {0 {:message-id  0


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)
fixes (or rather significantly improves) #3336 

### Summary:

Perf important changes:
This PR separates `:user-status` realm objects from `:message` realm objects, so the first is no longer "child" object of the second. The reason for this change is very slow realm performance when updating child objects (could be caused also by js<->cljs conversions, so whenever we wanted to update some message statuses, we previously had to update them through messages, which essentially required to loop over the whole `:user-statuses` map of message every-time to convert it to sequence of objects suitable for realm (the more statuses any message had, the worse, would be really, really bad in bigger group chats...).
In my testing on Nexus 5 on genymotion simulator, updating 2k statuses in an old way takes more then 2s (that's just the time to run the realm transaction, real perceived lag is worse), compared to ~600ms when done in a new way. Still not ideal, ideally, we would have persistent updates offloaded to level-db not occupying the js thread :)

Less perf important changes:
Leverages already existing `:unviewed-messages` set (containing set of all unviewed-message ids, not only those of currently loaded messages) for faster `mark-messages-seen` function (roughly 2x in my testing of `#status` chat with 2k unread messages on android simulator).
Also features micro-optimisation that when you navigate to chat with no new messages, it takes almost no time to detect it, compared to 2-3 dropped frames (~40ms @ 2k messages in chat) in develop, which is really unnecessary.

### Steps to test:
Check the time to open chat with no/moderate-amount/large-amount of unseen messages and compare it with develop, it should be improvement in all cases.

Requires complete regression testing of message statuses behaviour as well.

status: ready
