### PR TITLE
Use the private RPC client for requests to Status backend

### DIFF
--- a/modules/react-native-status/android/src/main/java/im/status/ethereum/module/JSCJail.java
+++ b/modules/react-native-status/android/src/main/java/im/status/ethereum/module/JSCJail.java
@@ -95,7 +95,7 @@ class JSCJail implements Jail {
 
         JSFunction web3send = new JSFunction(context, "web3send") {
             public String web3send(String payload) {
-                return Statusgo.CallRPC(payload);
+                return Statusgo.CallPrivateRPC(payload);
             }
         };
         context.property("web3send", web3send);
@@ -105,7 +105,7 @@ class JSCJail implements Jail {
                 Runnable r = new Runnable() {
                     @Override
                     public void run() {
-                        String result = Statusgo.CallRPC(payload);
+                        String result = Statusgo.CallPrivateRPC(payload);
                         callback.toFunction().call(null, result);
                     }
                 };

--- a/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusModule.java
+++ b/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusModule.java
@@ -703,7 +703,7 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
         Runnable r = new Runnable() {
             @Override
             public void run() {
-                String res = Statusgo.CallRPC(payload);
+                String res = Statusgo.CallPrivateRPC(payload);
                 callback.invoke(res);
             }
         };

--- a/modules/react-native-status/ios/RCTStatus/Jail.m
+++ b/modules/react-native-status/ios/RCTStatus/Jail.m
@@ -13,7 +13,7 @@
 
 - (NSString *)send:(JSValue *)payload
 {
-    char * result = CallRPC((char *) [[payload toString] UTF8String]);
+    char * result = CallPrivateRPC((char *) [[payload toString] UTF8String]);
     
     return [NSString stringWithUTF8String: result];
 }

--- a/modules/react-native-status/ios/RCTStatus/RCTStatus.m
+++ b/modules/react-native-status/ios/RCTStatus/RCTStatus.m
@@ -375,7 +375,7 @@ RCT_EXPORT_METHOD(clearStorageAPIs) {
 RCT_EXPORT_METHOD(sendWeb3Request:(NSString *)payload
                   callback:(RCTResponseSenderBlock)callback) {
     dispatch_async( dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-        char * result = CallRPC((char *) [payload UTF8String]);
+        char * result = CallPrivateRPC((char *) [payload UTF8String]);
         dispatch_async( dispatch_get_main_queue(), ^{
             callback(@[[NSString stringWithUTF8String: result]]);
         });


### PR DESCRIPTION
- For any RPC call not coming from the web view (Dapps) we should use the private endpoint

App is currently broken as shh and shhext namespaces have been marked private only

Not completely sure if any of the calls I changed to `CallPrivateRPC` shouldn't have been, would appreciate a few more eyeballs on it (especially on the iOS code).
 
status: ready <!-- Can be ready or wip -->
