### PR TITLE
Upgrade Instabug to 2.12.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4096,9 +4096,9 @@
       }
     },
     "instabug-reactnative": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/instabug-reactnative/-/instabug-reactnative-2.8.1.tgz",
-      "integrity": "sha512-JhjtevebuOc7hDvfmrHnzutSMY03DuGnYJuX9kmNzd2JtmtlufQ79wU3AwbdOeouPYNwGTWmENJlRApBT4Mo+Q=="
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/instabug-reactnative/-/instabug-reactnative-2.12.0.tgz",
+      "integrity": "sha512-aD2JLofdXfZWvlcg3t3lEoUM+HN7qLaKry68Ypjuh+cFGCXtblbKz4ozEfEFBw4rvEm31s8BSd1e/aFiHPXBmQ=="
     },
     "invariant": {
       "version": "2.2.4",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "events": "1.1.1",
     "homoglyph-finder": "1.1.1",
     "identicon.js": "github:status-im/identicon.js",
-    "instabug-reactnative": "2.8.1",
+    "instabug-reactnative": "2.12.0",
     "level-filesystem": "1.2.0",
     "nfc-react-native": "github:status-im/nfc-react-native",
     "process": "0.11.10",


### PR DESCRIPTION
Fixes #4128

Surveys stopped working in 2.8.1 so we need to update Instabug to 2.12.0

Follow-up from PR https://github.com/status-im/status-react/pull/4571

status: ready
