### PR TITLE
Make run-ios accept the simulator name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,8 +111,13 @@ repl-android: ##@repl Start REPL for Android
 run-android: ##@run Run Android build
 	react-native run-android --appIdSuffix debug
 
+SIMULATOR = ""
 run-ios: ##@run Run iOS build
+ifneq ("$(SIMULATOR)", "")
+	react-native run-ios --simulator="$(SIMULATOR)"
+else
 	react-native run-ios
+endif
 
 #--------------
 # Tests


### PR DESCRIPTION
Allows to pass a simulator name to `make run-ios` command.

Examples:
`make run-ios SIMULATOR="iPhone X"`
`make run-ios SIMULATOR="iPad Pro (9.7-inch)"`

Providing no `SIMULATOR` variable reverts to the regular behaviour.

status: ready