### PR TITLE
Revert "Use the private RPC client for requests to Status backend when not coming from Dapps"

### DIFF
--- a/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusModule.java
+++ b/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusModule.java
@@ -703,7 +703,7 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
         Runnable r = new Runnable() {
             @Override
             public void run() {
-                String res = Statusgo.CallPrivateRPC(payload);
+                String res = Statusgo.CallRPC(payload);
                 callback.invoke(res);
             }
         };

--- a/modules/react-native-status/ios/RCTStatus/RCTStatus.m
+++ b/modules/react-native-status/ios/RCTStatus/RCTStatus.m
@@ -375,7 +375,7 @@ RCT_EXPORT_METHOD(clearStorageAPIs) {
 RCT_EXPORT_METHOD(sendWeb3Request:(NSString *)payload
                   callback:(RCTResponseSenderBlock)callback) {
     dispatch_async( dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-        char * result = CallPrivateRPC((char *) [payload UTF8String]);
+        char * result = CallRPC((char *) [payload UTF8String]);
         dispatch_async( dispatch_get_main_queue(), ^{
             callback(@[[NSString stringWithUTF8String: result]]);
         });


### PR DESCRIPTION
This reverts commits 2136fe62ce5505e14fb0eeabaf6a0c925156309c and 18aaa890a316c49012f6185dd45cbdf457f0737e.

Confirmed that with the https://github.com/status-im/status-go/pull/993 PR, you get this in react:

```
06-06 23:51:50.734 27094 27184 E ReactNativeJS: ERROR [status-im.transport.shh:124] - :shh/get-new-sym-key-error Error: The method shh_addSymKey does not exist/is not available
06-06 23:51:50.750 27094 27184 E ReactNativeJS: ERROR [status-im.transport.shh:124] - :shh/get-new-sym-key-error Error: The method shh_addSymKey does not exist/is not available
06-06 23:51:50.755 27094 27184 W ReactNativeJS: WARN [status-im.transport.filters:20] - :add-filter-error {"topics":["0xf8946aac"],"privateKeyID":"0x04325367620ae20dd878dbb39f69f02c567d789dd21af8a88623dc5b529827c2812571c380a2cd8236a2851b8843d6486481166c39debf60a5d30b9099c66213e4","allowP2P":true} Error: The method shh_newMessageFilter does not exist/is not available
06-06 23:51:50.758 27094 27184 E ReactNativeJS: ERROR [status-im.transport.shh:124] - :shh/get-new-sym-key-error Error: The method shh_addSymKey does not exist/is not available
06-06 23:51:50.761 27094 27184 E ReactNativeJS: ERROR [status-im.transport.shh:124] - :shh/get-new-sym-key-error Error: The method shh_addSymKey does not exist/is not available
06-06 23:51:50.765 27094 27184 E ReactNativeJS: ERROR [status-im.transport.shh:124] - :shh/get-new-sym-key-error Error: The method shh_addSymKey does not exist/is not available
06-06 23:51:50.786 27094 27184 E ReactNativeJS: ERROR [status-im.transport.shh:124] - :shh/get-new-sym-key-error Error: The method shh_addSymKey does not exist/is not available
```

By trying to fix it in react by moving to the private RPC endpoint, we break transaction signing, so we need to spend some time to figure out why that happens. In the meantime, I'll merge this commit and update react to use latest develop.

Can skip manual QA since we're just getting back to a known state.

status: ready <!-- Can be ready or wip -->
