### PR TITLE
Rerun tests when Connection reset by peer happens

### DIFF
--- a/test/appium/support/test_rerun.py
+++ b/test/appium/support/test_rerun.py
@@ -13,7 +13,8 @@ RERUN_ERRORS = [
     'ERROR The test with session id'
     "Message: 'CreateAccountButton' is not found on screen",
     "503 Service Unavailable",
-    "AttributeError: 'NoneType' object has no attribute 'find_element'"
+    "AttributeError: 'NoneType' object has no attribute 'find_element'",
+    "[Errno 104] Connection reset by peer"
 ]
 
 


### PR DESCRIPTION
Rerun tests when `[Errno 104] Connection reset by peer` happens

Happened for https://github.com/status-im/status-react/pull/4661: 
![image](https://user-images.githubusercontent.com/7532782/41104034-cd09daa8-6a6a-11e8-9ff0-3128ab72c27d.png)
