### PR TITLE
set default ios simulator to empty string

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ repl-android: ##@repl Start REPL for Android
 run-android: ##@run Run Android build
 	react-native run-android --appIdSuffix debug
 
-SIMULATOR = ""
+SIMULATOR=
 run-ios: ##@run Run iOS build
 ifneq ("$(SIMULATOR)", "")
 	react-native run-ios --simulator="$(SIMULATOR)"


### PR DESCRIPTION
### Summary:

This PR sets the default value of SIMULATOR env var in Makefile to empty string (instead of two double quotes).

### Review notes (optional):
typo PR 

### Testing notes (optional):
dev tools only changed, skip QA

### Steps to test:
- run `make run-ios` without simulator version

status: ready 