### PR TITLE
[#4504] Sort assets alphabetically (send - asset)

### DIFF
--- a/src/status_im/ui/screens/wallet/subs.cljs
+++ b/src/status_im/ui/screens/wallet/subs.cljs
@@ -102,7 +102,7 @@
                   :<- [:wallet/visible-tokens-symbols]
                   (fn [[network visible-tokens-symbols]]
                     (conj (filter #(contains? visible-tokens-symbols (:symbol %))
-                                  (tokens/tokens-for (ethereum/network->chain-keyword network)))
+                                  (tokens/sorted-tokens-for (ethereum/network->chain-keyword network)))
                           tokens/ethereum)))
 
 (re-frame/reg-sub :wallet/visible-assets-with-amount


### PR DESCRIPTION
Fixes #4504

Sort assets alphabetically (by symbol).
Keep ETH as first symbol in the list (like before), sort the rest
alphabetically.

### Review notes (optional):
The ETH symbol was handled separatly from other currencies (always 1st in the list). I kept that behavior, only sorted the rest of the currencies (by their 3 letter symbol)

### Testing notes (optional):
<!-- (Specify if something specific has to be tested, for example upgrade paths) -->

### Steps to test:
Open Status
Open wallet
Send Transaction
Tap asset

status: ready
