### PR TITLE
add contact functionality 

### DIFF
--- a/src/status_im/chat/events.cljs
+++ b/src/status_im/chat/events.cljs
@@ -286,6 +286,11 @@
   (fn [cofx [chat-id opts]]
     (navigate-to-chat chat-id opts cofx)))
 
+(handlers/register-handler-db
+ :add-pending-contact
+ (fn [db [_ chat-id]]
+   (assoc-in db [:contacts/contacts chat-id :pending?] false)))
+
 (defn start-chat
   "Start a chat, making sure it exists"
   [chat-id opts {:keys [db] :as cofx}]


### PR DESCRIPTION
fix for #4276 

there just was no existing handler for the event `add-pending-contact`