### PR TITLE
Default to value if key is nil

### DIFF
--- a/src/status_im/transport/inbox.cljs
+++ b/src/status_im/transport/inbox.cljs
@@ -260,8 +260,9 @@
    (let [wnode                   (get-current-wnode db)
          web3                    (:web3 db)
          now-in-s                (quot now 1000)
-         last-request            (get-in db [:account/account :last-request]
-                                         (- now-in-s seven-days))
+         last-request            (or
+                                  (get-in db [:account/account :last-request])
+                                  (- now-in-s seven-days))
          request-messages-topics (get-request-messages-topics db)
          request-history-topics  (get-request-history-topics db)]
      (when (inbox-ready? wnode cofx)


### PR DESCRIPTION
partially adresses: #4624

The issue is due to the fact that the key is set but the value is `nil`. This happens when loading the account from realm and `last-request` has not been set before.

The easiest way to replicate is to recover the account and immediately logout, before being able to connect to the mailserver. (Creating an account is slower before you have to set up a name & close the share data popup, before you can logout, so generally it manages to connect to ms).

Another issue noticed is that `check-fetching` might be initiated in one account and end up running on a different one, potentially setting `last-request` for a different user, probably at some point worth considering how to handle this kind of scenario, as there are more examples of this in the codebase (a session id would do).


status: ready
