### PR TITLE
Retry hash retrieval from i.diawi.com if it returns null. Fixes #3455

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,8 +60,11 @@ timeout(90) {
         stage('Deploy (Android)') {
           withCredentials([string(credentialsId: 'diawi-token', variable: 'token')] ) {
             def job = sh(returnStdout: true, script: 'curl https://upload.diawi.com/ -F token='+token+' -F file=@android/app/build/outputs/apk/release/app-release.apk -F find_by_udid=0 -F wall_of_apps=0 | jq -r ".job"').trim()
-            sh 'sleep 10'
-            def hash = sh(returnStdout: true, script: "curl -vvv 'https://upload.diawi.com/status?token="+token+"&job="+job+"'|jq -r '.hash'").trim()
+            def hash = 'null'
+            for (int r = 0; r < 6 && hash == 'null'; r++) {
+              sh 'sleep 10'
+              hash = sh(returnStdout: true, script: "curl -vvv 'https://upload.diawi.com/status?token="+token+"&job="+job+"'|jq -r '.hash'").trim()
+            }
             apkUrl = 'https://i.diawi.com/' + hash
             
             sh ('echo ARTIFACT Android: ' + apkUrl)
@@ -77,8 +80,11 @@ timeout(90) {
         stage('Deploy (iOS)') {
           withCredentials([string(credentialsId: 'diawi-token', variable: 'token')]) {
             def job = sh(returnStdout: true, script: 'curl https://upload.diawi.com/ -F token='+token+' -F file=@status/StatusIm.ipa -F find_by_udid=0 -F wall_of_apps=0 | jq -r ".job"').trim()
-            sh 'sleep 10'
-            def hash = sh(returnStdout: true, script: "curl -vvv 'https://upload.diawi.com/status?token="+token+"&job="+job+"'|jq -r '.hash'").trim()
+            def hash = 'null'
+            for (int r = 0; r < 6 && hash == 'null'; r++) {
+              sh 'sleep 10'
+              hash = sh(returnStdout: true, script: "curl -vvv 'https://upload.diawi.com/status?token="+token+"&job="+job+"'|jq -r '.hash'").trim()
+            }
             ipaUrl = 'https://i.diawi.com/' + hash
 
             sh ('echo ARTIFACT iOS: ' + ipaUrl)


### PR DESCRIPTION
Fixes #3455 

### Summary:

[comment]: # (Summarise the problem and how the pull request solves it)
This PR introduces logic to retry retrieving the hash every 10 seconds up to 60 seconds before giving up.

### Review notes (optional):
<!-- (Specify if something in particular should be looked at, or ignored, during review) -->

Since the hash value starts with `'null'`, then whenever curl returns `null` the same logic should apply.

status: ready <!-- Can be ready or wip -->
