### PR TITLE
bug #4737 and #4736 android back button issues with send

### DIFF
--- a/src/status_im/chat/events.cljs
+++ b/src/status_im/chat/events.cljs
@@ -302,7 +302,7 @@
  (fn [cofx [_ chat-id]]
    (handlers-macro/merge-fx cofx
                             (events.commands/execute-stored-command)
-                            (navigate-to-chat chat-id {}))))
+                            (navigate-to-chat chat-id {:navigation-replace? true}))))
 
 (defn start-chat
   "Start a chat, making sure it exists"

--- a/src/status_im/chat/events/shortcuts.cljs
+++ b/src/status_im/chat/events/shortcuts.cljs
@@ -16,6 +16,7 @@
   (merge {:db (-> db
                   (send.events/set-and-validate-amount-db (:amount params) :ETH 18)
                   (choose-recipient.events/fill-request-details (transaction-details contact))
+                  (update-in [:wallet :send-transaction] dissoc :id :password :wrong-password?)
                   (navigation/navigate-to
                    (if (:wallet-set-up-passed? account)
                      :wallet-send-transaction-chat


### PR DESCRIPTION
fixes #4736 
fixes #4737 

### Summary:

Fixes two bugs in chat /send flow that happen when user uses android back button:

#4736

If user tries to sign the transaction A with an incorrect password, then goes back to chat starts transaction B and signs it successfully, A will appear in transaction history (and actually be sent, but B will be displayed in chat history.

The fix is to both transfer and display B in this case. 

#4737 

If user successfully completes a chat /send and then manually navigates back from chat to "Transaction sent" screen and taps "Got it" again, a duplicate payment message will appear.

The fix is not to navigate the user back to "Transaction sent", but to Wallet Send screen. 

### Steps to test:
- see #4736 and #4737

status: ready
