### PR TITLE
Select random ms until users explicitly choose one

### DIFF
--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -140,10 +140,7 @@
 
 (defn default-account-settings []
   {:wallet {:visible-tokens {:testnet #{:STT :ATT}
-                             :mainnet #{:SNT}}}
-   :wnode {:testnet (rand-nth (keys (:testnet default-wnodes)))
-           :mainnet (rand-nth (keys (:mainnet default-wnodes)))
-           :rinkeby (rand-nth (keys (:rinkeby default-wnodes)))}})
+                             :mainnet #{:SNT}}}})
 
 (def currencies
   {:aed {:id :aed :code "AED" :display-name (i18n/label :t/currency-display-name-aed) :symbol "د.إ"}

--- a/src/status_im/models/network.cljs
+++ b/src/status_im/models/network.cljs
@@ -45,6 +45,10 @@
      :name       network-name
      :config     config}))
 
+(defn get-chain [{:keys [db]}]
+  (let [network  (get (:networks (:account/account db)) (:network db))]
+    (ethereum/network->chain-keyword network)))
+
 (defn set-input [input-key value {:keys [db]}]
   {:db (-> db
            (update-in [:networks/manage input-key] assoc :value value)

--- a/src/status_im/protocol/handlers.cljs
+++ b/src/status_im/protocol/handlers.cljs
@@ -43,7 +43,7 @@
                                        :web3 web3
                                        :rpc-url (or ethereum-rpc-url constants/ethereum-rpc-url)
                                        :transport/chats transport)}
-                           (transport.inbox/add-custom-mailservers mailservers)
+                           (transport.inbox/initialize-offline-inbox mailservers)
                            (transport/init-whisper current-account-id)))
 ;;; INITIALIZE PROTOCOL
 (handlers/register-handler-fx

--- a/src/status_im/ui/screens/db.cljs
+++ b/src/status_im/ui/screens/db.cljs
@@ -127,6 +127,7 @@
 (spec/def ::peers-count (spec/nilable integer?))
 (spec/def ::peers-summary (spec/nilable vector?))
 (spec/def :inbox/fetching? (spec/nilable boolean?))
+(spec/def :inbox/current-id (spec/nilable string?))
 
 ;;;;NODE
 
@@ -174,6 +175,7 @@
                  :node/after-stop
                  :inbox/wnodes
                  :inbox/last-received
+                 :inbox/current-id
                  :inbox/fetching?
                  :browser/browsers
                  :browser/options

--- a/src/status_im/ui/screens/offline_messaging_settings/subs.cljs
+++ b/src/status_im/ui/screens/offline_messaging_settings/subs.cljs
@@ -4,11 +4,8 @@
             [status-im.utils.ethereum.core :as ethereum]))
 
 (re-frame/reg-sub :settings/current-wnode
-                  :<- [:network]
-                  :<- [:get-current-account]
-                  (fn [[network current-account]]
-                    (let [chain (ethereum/network->chain-keyword network)]
-                      (get-in current-account [:settings :wnode chain]))))
+                  (fn [db _]
+                    (:inbox/current-id db)))
 
 (re-frame/reg-sub :settings/network-wnodes
                   :<- [:network]

--- a/test/cljs/status_im/test/transport/core.cljs
+++ b/test/cljs/status_im/test/transport/core.cljs
@@ -4,7 +4,10 @@
             [status-im.transport.core :as transport]))
 
 (deftest init-whisper
-  (let [cofx {:db {:account/account {:public-key "1"}}}]
+  (let [cofx {:db {:network "mainnet_rpc"
+                   :account/account
+                   {:networks {"mainnet_rpc" {:config {:NetworkId 1}}}
+                    :public-key "1"}}}]
     (testing "it adds the discover filter"
       (is (= (:shh/add-discovery-filter (protocol.handlers/initialize-protocol cofx [])))))
     (testing "it restores the sym-keys"
@@ -40,4 +43,6 @@
                                     ms-2
                                     ms-3])]
         (is (= expected-wnodes
-               (get-in (protocol.handlers/initialize-protocol cofx-with-ms []) [:db :inbox/wnodes])))))))
+               (get-in
+                (protocol.handlers/initialize-protocol cofx-with-ms [])
+                [:db :inbox/wnodes])))))))

--- a/test/cljs/status_im/test/transport/inbox.cljs
+++ b/test/cljs/status_im/test/transport/inbox.cljs
@@ -9,8 +9,8 @@
         :peers-summary (if registered-peer?
                          [{:id "wnode-id"}]
                          [])
-        :account/account {:networks constants/default-networks
-                          :settings {:wnode {:mainnet "mailserver-a"}}}
+        :account/account {:networks constants/default-networks}
+        :inbox/current-id "mailserver-a"
         :inbox/wnodes {:mainnet {"mailserver-a" {:sym-key-id sym-key
                                                  :address "enode://wnode-id@ip"}}}}})
 
@@ -46,6 +46,7 @@
 
 (deftest connect-to-mailserver
   (let [db {:network "mainnet"
+            :inbox/current-id "wnodeid"
             :inbox/wnodes
             {:mainnet {"wnodeid" {:address  "wnode-address"
                                   :password "wnode-password"}}}
@@ -70,13 +71,13 @@
 (deftest request-messages
   (let [db {:network "mainnet"
             :mailserver-status :connected
+            :inbox/current-id "wnodeid"
             :inbox/wnodes
             {:mainnet {"wnodeid" {:address    "wnode-address"
                                   :sym-key-id "something"
                                   :password   "wnode-password"}}}
             :account/account
-            {:settings {:wnode {:mainnet "wnodeid"}}
-             :networks {"mainnet" {:config {:NetworkId 1}}}}}
+            {:networks {"mainnet" {:config {:NetworkId 1}}}}}
         cofx {:db db :now 1000000000}]
     (testing "inbox is ready"
       (testing "last-request is set"


### PR DESCRIPTION
Fixes #4643 

### Summary:

I have changed the logic for selecting mailservers, it is as follow now:

1) If the user has not explicitly selected a mailserver, a random mailserver will be chosen every time he logs in.
2) If the user has explicitly set a mailserver, the selection is as before sticky, unless the mailserver has been removed, in which case 1) applies

The reason for 1) is that it helps in cases such as one mailserver is down (like we had today) for users not very tech savvy, and also it loads balance better when we increase the number of mailservers, otherwise old users will be using still using only x mailservers, leading to non-random load.

### Testing notes:

1) Login, check mailserver in `profile`->`advanced`->`mailserver`
2) Logout, check mailservers, it should be a different one (1/8 probability that is the same)
3) Select a mailserver
4) Login/Logout again, mailserver should not change.

To test that we fallback on a random mailserver when we change the list, you can install a previous nightly and select mailserver `g`. Install this version, you should see it's using a different random mailserver.


status: ready
