### PR TITLE
[#4755] Keep the transaction source intact on errors/discards.

### DIFF
--- a/src/status_im/ui/screens/wallet/send/events.cljs
+++ b/src/status_im/ui/screens/wallet/send/events.cljs
@@ -118,7 +118,6 @@
                                       :signing?        false
                                       :wrong-password? false
                                       :waiting-signal? false
-                                      :from-chat?      false
                                       :password        nil})
 
 (defn on-transactions-completed [raw-results]
@@ -175,7 +174,9 @@
                new-db                    (assoc-in db' [:wallet :transactions-unsigned id] transaction)
                sending-db                {:id         id
                                           :method     method
-                                          :from-chat? sending-from-bot-or-dapp?}]
+                                          :from-chat? (or
+                                                       sending-from-bot-or-dapp?
+                                                       (get-in db [:wallet :send-transaction :from-chat?]))}]
            (if sending-from-bot-or-dapp?
               ;;SENDING FROM BOT (CHAT) OR DAPP
              {:db         (assoc-in new-db [:wallet :send-transaction] sending-db) ; we need to completely reset sending state here


### PR DESCRIPTION
If a tx was send from a chat, that fact is recorded in its properties, `from-chat?` property.
On errors and discards, this property was reset to `false`, hence, making any chat transaction editable if an error happens or user discards it.
This commit makes this property stay as it is.


### Steps to test:
- Open Status
- Open 1:1 chat
- Use `/send` command to show a tx screen, tap "Sign"
- Press "Cancel"
- Tx fields should still be read-only

<!-- (PRs will only be accepted if squashed into single commit.) -->

fixes: #4755 

status: ready <!-- Can be ready or wip -->
