### PR TITLE
[#4754] discard transaction on closing :wallet-send-transaction-modal

### DIFF
--- a/src/status_im/ui/screens/views.cljs
+++ b/src/status_im/ui/screens/views.cljs
@@ -116,7 +116,15 @@
       [view common-styles/modal
        [modal {:animation-type   :slide
                :transparent      true
-               :on-request-close #(dispatch [:navigate-back])}
+               :on-request-close (fn []
+                                   (cond
+                                     (#{:wallet-send-transaction-modal
+                                        :wallet-transaction-fee}
+                                      modal-view)
+                                     (dispatch [:wallet/discard-transaction-navigate-back])
+
+                                     :else
+                                     (dispatch [:navigate-back])))}
         (let [component (get-modal-component modal-view)]
           [react/main-screen-modal-view modal-view
            [component]])]])))


### PR DESCRIPTION
fix #4754

status: ready <!-- Can be ready or wip -->
