### PR TITLE
Validate minimum wei & fix decimal issue

### DIFF
--- a/src/status_im/models/wallet.cljs
+++ b/src/status_im/models/wallet.cljs
@@ -1,0 +1,53 @@
+(ns status-im.models.wallet
+  (:require [status-im.utils.money :as money]))
+
+(def min-gas-price-wei (money/bignumber 1))
+
+(defmulti invalid-send-parameter? (fn [type _] type))
+
+(defmethod invalid-send-parameter? :gas-price [_ value]
+  (cond
+    (not value) :invalid-number
+    (< (money/->wei :gwei value) min-gas-price-wei) :not-enough-wei))
+
+(defmethod invalid-send-parameter? :default [_ value]
+  (when (or (not value)
+            (<= value 0))
+    :invalid-number))
+
+(defn- calculate-max-fee
+  [gas gas-price]
+  (if (and gas gas-price)
+    (money/to-fixed (money/wei->ether (.times gas gas-price)))
+    "0"))
+
+(defn- edit-max-fee [edit]
+  (let [gas (get-in edit [:gas-price :value-number])
+        gas-price (get-in edit [:gas :value-number])]
+    (assoc edit :max-fee (calculate-max-fee gas gas-price))))
+
+(defn add-max-fee [{:keys [gas gas-price] :as transaction}]
+  (assoc transaction :max-fee (calculate-max-fee gas gas-price)))
+
+(defn build-edit [edit-value key value]
+  "Takes the previous edit, either :gas or :gas-price and a value as string.
+  Wei for gas, and gwei for gas price.
+  Validates them and sets max fee"
+  (let [bn-value (money/bignumber value)
+        invalid? (invalid-send-parameter? key bn-value)
+        data     (if invalid?
+                   {:value    value
+                    :max-fee  0
+                    :invalid? invalid?}
+                   {:value        value
+                    :value-number (if (= :gas-price key)
+                                    (money/->wei :gwei bn-value)
+                                    bn-value)
+                    :invalid?     false})]
+    (-> edit-value
+        (assoc key data)
+        edit-max-fee)))
+
+(defn edit-value
+  [key value {:keys [db]}]
+  {:db (update-in db [:wallet :edit] build-edit key value)})

--- a/src/status_im/translations/en.cljs
+++ b/src/status_im/translations/en.cljs
@@ -454,6 +454,7 @@
    :share                                "Share"
    :eth                                  "ETH"
    :gwei                                 "Gwei"
+   :wallet-send-min-wei                  "Min 1 wei"
    :currency                             "Currency"
    :usd-currency                         "USD"
    :currency-display-name-aed            "Emirati Dirham"

--- a/src/status_im/ui/screens/wallet/events.cljs
+++ b/src/status_im/ui/screens/wallet/events.cljs
@@ -8,6 +8,7 @@
             [status-im.utils.handlers :as handlers]
             [status-im.utils.prices :as prices]
             [status-im.utils.transactions :as transactions]
+            [status-im.models.wallet :as models.wallet]
             [taoensso.timbre :as log]
             status-im.ui.screens.wallet.request.events
             [status-im.utils.money :as money]
@@ -248,7 +249,11 @@
  :wallet/update-gas-price-success
  (fn [db [_ price edit?]]
    (if edit?
-     (assoc-in db [:wallet :edit :gas-price] {:value price :invalid? false})
+     (:db (models.wallet/edit-value
+           :gas-price
+           (money/to-fixed
+            (money/wei-> :gwei price))
+           {:db db}))
      (assoc-in db [:wallet :send-transaction :gas-price] price))))
 
 (handlers/register-handler-fx

--- a/test/cljs/status_im/test/models/wallet.cljs
+++ b/test/cljs/status_im/test/models/wallet.cljs
@@ -1,0 +1,52 @@
+(ns status-im.test.models.wallet
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [status-im.utils.money :as money]
+            [status-im.models.wallet :as model]))
+
+(deftest valid-min-gas-price-test
+  (testing "not an number"
+    (is (= :invalid-number (model/invalid-send-parameter? :gas-price nil))))
+  (testing "a number less than the minimum"
+    (is (= :not-enough-wei (model/invalid-send-parameter? :gas-price (money/bignumber "0.0000000001")))))
+  (testing "a number greater than the mininum"
+    (is (not (model/invalid-send-parameter? :gas-price 3))))
+  (testing "the minimum"
+    (is (not (model/invalid-send-parameter? :gas-price (money/bignumber "0.000000001"))))))
+
+(deftest valid-gas
+  (testing "not an number"
+    (is (= :invalid-number (model/invalid-send-parameter? :gas nil))))
+  (testing "0"
+    (is (= :invalid-number (model/invalid-send-parameter? :gas 0))))
+  (testing "a number"
+    (is (not (model/invalid-send-parameter? :gas 1)))))
+
+(deftest build-edit-test
+  (testing "an invalid edit"
+    (let [actual (-> {}
+                     (model/build-edit :gas "invalid")
+                     (model/build-edit :gas-price "0.00000000001"))]
+      (testing "it marks gas-price as invalid"
+        (is (get-in actual [:gas-price :invalid?])))
+      (testing "it does not change value"
+        (is (= "0.00000000001" (get-in actual [:gas-price :value]))))
+      (testing "it marks gas as invalid"
+        (is (get-in actual [:gas :invalid?])))
+      (testing "it does not change gas value"
+        (is (= "invalid" (get-in actual [:gas :value]))))
+      (testing "it sets max-fee to 0"
+        (is (= "0" (:max-fee actual))))))
+  (testing "an valid edit"
+    (let [actual (-> {}
+                     (model/build-edit :gas "21000")
+                     (model/build-edit :gas-price "10"))]
+      (testing "it does not mark gas-price as invalid"
+        (is (not (get-in actual [:gas-price :invalid?]))))
+      (testing "it sets the value in number for gas-price, in gwei"
+        (is (= "10000000000" (str (get-in actual [:gas-price :value-number])))))
+      (testing "it does not mark gas as invalid"
+        (is (not (get-in actual [:gas :invalid?]))))
+      (testing "it sets the value in number for gasi"
+        (is (= "21000" (str (get-in actual [:gas :value-number])))))
+      (testing "it calculates max-fee"
+        (is (= "0.00021" (:max-fee actual)))))))

--- a/test/cljs/status_im/test/runner.cljs
+++ b/test/cljs/status_im/test/runner.cljs
@@ -15,6 +15,7 @@
             [status-im.test.models.account]
             [status-im.test.models.contact]
             [status-im.test.models.network]
+            [status-im.test.models.wallet]
             [status-im.test.transport.core]
             [status-im.test.transport.inbox]
             [status-im.test.transport.handlers]
@@ -65,6 +66,7 @@
  'status-im.test.models.account
  'status-im.test.models.contact
  'status-im.test.models.network
+ 'status-im.test.models.wallet
  'status-im.test.bots.events
  'status-im.test.wallet.subs
  'status-im.test.wallet.transactions.subs


### PR DESCRIPTION
fixes #4756 
fixes #4696

### Summary:

* Added validation for `gas-price`
* I have changed the logic in `wallet.send` moving it into the model, now we only accepts `strings` as input which are immutable and we then use those to compute `max-fee` and the actual numbers, with a single entry point `build-edit`.

### Review
I have not updated the copy for the `gas-limit` as we are not sure what it is, but I could change it to minimum `0`.

### Testing notes (optional):
* Sending transactions and updates of gas prices
* DApp transactions

status: ready