### PR TITLE
[WIP] Upgrade Instabug to 2.13.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3935,9 +3935,9 @@
       }
     },
     "instabug-reactnative": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/instabug-reactnative/-/instabug-reactnative-2.12.0.tgz",
-      "integrity": "sha512-aD2JLofdXfZWvlcg3t3lEoUM+HN7qLaKry68Ypjuh+cFGCXtblbKz4ozEfEFBw4rvEm31s8BSd1e/aFiHPXBmQ=="
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/instabug-reactnative/-/instabug-reactnative-2.13.2.tgz",
+      "integrity": "sha512-lrnHTAfBraJHG+uPmRhx+c7SZlIPgKa5B/Om+52LeKjr7lchpAk37l53ki8svBFUubcQcbflg4t6EbuUn5G6Og=="
     },
     "invariant": {
       "version": "2.2.4",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "events": "1.1.1",
     "homoglyph-finder": "1.1.1",
     "identicon.js": "git@github.com:status-im/identicon.js.git",
-    "instabug-reactnative": "2.12.0",
+    "instabug-reactnative": "2.13.2",
     "level-filesystem": "1.2.0",
     "nfc-react-native": "git@github.com:status-im/nfc-react-native.git",
     "process": "0.11.10",


### PR DESCRIPTION
### Summary:

Upgrade Instabug to 2.13.2

Their support suggested us to perform upgrade.

Changelog https://github.com/Instabug/instabug-reactnative/releases

status: ready


<blockquote><img src="https://avatars0.githubusercontent.com/u/4802335?s=400&v=4" width="48" align="right"><div><img src="https://assets-cdn.github.com/favicon.ico" height="14"> GitHub</div><div><strong><a href="https://github.com/Instabug/instabug-reactnative">Instabug/instabug-reactnative</a></strong></div><div>instabug-reactnative - In-App Feedback and Bug Reporting tool for react native</div></blockquote>