### PR TITLE
Cap maximum number of days requested to mailserver

### DIFF
--- a/src/status_im/transport/inbox.cljs
+++ b/src/status_im/transport/inbox.cljs
@@ -253,7 +253,7 @@
    (let [wnode                   (models.mailserver/fetch-current cofx)
          web3                    (:web3 db)
          now-in-s                (quot now 1000)
-         last-request            (or
+         last-request            (max
                                   (get-in db [:account/account :last-request])
                                   (- now-in-s seven-days))
          request-messages-topics (get-request-messages-topics db)

--- a/test/cljs/status_im/test/transport/inbox.cljs
+++ b/test/cljs/status_im/test/transport/inbox.cljs
@@ -81,10 +81,16 @@
         cofx {:db db :now 1000000000}]
     (testing "inbox is ready"
       (testing "last-request is set"
-        (let [cofx-with-last-request (assoc-in cofx [:db :account/account :last-request] 2)
-              actual (inbox/request-messages cofx-with-last-request)]
-          (testing "it uses last request"
-            (is (= 2 (get-in actual [::inbox/request-messages :from]))))))
+        (testing "last request is > the 7 days ago"
+          (let [cofx-with-last-request (assoc-in cofx [:db :account/account :last-request] 400000)
+                actual (inbox/request-messages cofx-with-last-request)]
+            (testing "it uses last request"
+              (is (= 400000 (get-in actual [::inbox/request-messages :from]))))))
+        (testing "last request is < the 7 days ago"
+          (let [cofx-with-last-request (assoc-in cofx [:db :account/account :last-request] 2)
+                actual (inbox/request-messages cofx-with-last-request)]
+            (testing "it uses last 7 days"
+              (is (= 395200 (get-in actual [::inbox/request-messages :from])))))))
       (testing "last-request is not set"
         (let [actual (inbox/request-messages cofx)]
           (testing "it defaults to the last 7 days"


### PR DESCRIPTION
### Summary:

Caps the maximum number of days requested to the mailserver ( to 7).

This is useful in the case the user leaves the app not running for some time, at which point it will ask for a potentially large amount of data to the mailserver, and might not be able to handle the load.

### Testing notes:
light regression tests on mailserver

status: ready
