### PR TITLE
Add 6 new languages as public channels in the localized language. Closes #4753

### DIFF
--- a/src/status_im/data_store/browser.cljs
+++ b/src/status_im/data_store/browser.cljs
@@ -14,7 +14,7 @@
   "Returns tx function for saving browser"
   [{:keys [browser-id] :as browser}]
   (fn [realm]
-    (core/create realm :browser browser (core/exists? realm :browser :browser-id browser-id))))
+    (core/create realm :browser browser true)))
 
 (defn remove-browser-tx
   "Returns tx function for removing browser"

--- a/src/status_im/data_store/chats.cljs
+++ b/src/status_im/data_store/chats.cljs
@@ -25,7 +25,7 @@
   "Returns tx function for saving chat"
   [{:keys [chat-id] :as chat}]
   (fn [realm]
-    (core/create realm :chat chat (core/exists? realm :chat :chat-id chat-id))))
+    (core/create realm :chat chat true)))
 
 ;; Only used in debug mode
 (defn delete-chat-tx

--- a/src/status_im/data_store/contacts.cljs
+++ b/src/status_im/data_store/contacts.cljs
@@ -16,7 +16,7 @@
     (core/create realm
                  :contact
                  (dissoc contact :command :response :subscriptions :jail-loaded-events)
-                 (core/exists? realm :contact :whisper-identity whisper-identity))))
+                 true)))
 
 (defn save-contacts-tx
   "Returns tx function for saving contacts"

--- a/src/status_im/data_store/mailservers.cljs
+++ b/src/status_im/data_store/mailservers.cljs
@@ -16,7 +16,7 @@
     (core/create realm
                  :mailserver
                  mailserver
-                 (core/exists? realm :mailserver :id id))))
+                 true)))
 
 (defn delete-tx
   "Returns tx function for deleting a mailserver"

--- a/src/status_im/data_store/messages.cljs
+++ b/src/status_im/data_store/messages.cljs
@@ -87,12 +87,12 @@
   "Returns tx function for saving message"
   [{:keys [message-id from] :as message}]
   (fn [realm]
-    (when-not (core/exists? realm :message :message-id message-id)
-      (core/create realm
-                   :message
-                   (prepare-message (merge default-values
-                                           message
-                                           {:from (or from "anonymous")}))))))
+    (core/create realm
+                 :message
+                 (prepare-message (merge default-values
+                                         message
+                                         {:from (or from "anonymous")}))
+                 true)))
 
 (defn delete-message-tx
   "Returns tx function for deleting message"
@@ -101,20 +101,6 @@
     (when-let [message (core/get-by-field realm :message :message-id message-id)]
       (core/delete realm message)
       (core/delete realm (core/get-by-field realm :user-status :message-id message-id)))))
-
-(defn update-message-tx
-  "Returns tx function for updating message"
-  [{:keys [message-id] :as message}]
-  (fn [realm]
-    (when (core/exists? realm :message :message-id message-id)
-      (core/create realm :message (prepare-message message) true))))
-
-(defn update-messages-tx
-  "Returns tx function for updating messages"
-  [messages]
-  (fn [realm]
-    (doseq [message messages]
-      ((update-message-tx message) realm))))
 
 (defn delete-messages-tx
   "Returns tx function for deleting messages with user statuses for given chat-id"

--- a/src/status_im/data_store/realm/core.cljs
+++ b/src/status_im/data_store/realm/core.cljs
@@ -9,8 +9,7 @@
             [status-im.utils.async :as utils.async]
             [cognitect.transit :as transit]
             [status-im.react-native.js-dependencies :as rn-dependencies]
-            [status-im.utils.utils :as utils])
-  (:refer-clojure :exclude [exists?]))
+            [status-im.utils.utils :as utils]))
 
 (def new-account-filename "new-account")
 
@@ -35,7 +34,7 @@
     (when encryption-key
       (log/debug "Using encryption key...")
       (set! (.-encryptionKey options-js) (to-buffer encryption-key)))
-    (when (cljs.core/exists? js/window)
+    (when (exists? js/window)
       (rn-dependencies/realm. options-js))))
 
 (defn- delete-realm
@@ -231,9 +230,8 @@
 
 (defmethod to-query :eq [schema-name _ field value]
   (let [field-type    (field-type schema-name field)
-        escaped-value (when value (gstr/escapeString (str value)))
         query         (str (name field) "=" (if (= "string" (name field-type))
-                                              (str "\"" escaped-value "\"")
+                                              (str "\"" value "\"")
                                               value))]
     query))
 
@@ -260,9 +258,3 @@
                (case op
                  :and (and-query queries)
                  :or (or-query queries)))))
-
-(defn exists?
-  "Returns true if object/s identified by schema-name and field and value
-  exists in realm"
-  [realm schema-name field value]
-  (pos? (.-length (get-by-field realm schema-name field value))))

--- a/src/status_im/data_store/transport.cljs
+++ b/src/status_im/data_store/transport.cljs
@@ -35,7 +35,7 @@
                      (update :seen pr-str)
                      (update :pending-ack pr-str)
                      (update :pending-send pr-str))
-                 (core/exists? realm :transport :chat-id chat-id))))
+                 true)))
 
 (defn delete-transport-tx
   "Returns tx function for deleting transport"

--- a/src/status_im/ui/screens/add_new/new_public_chat/view.cljs
+++ b/src/status_im/ui/screens/add_new/new_public_chat/view.cljs
@@ -53,7 +53,7 @@
      [list/item-icon {:icon      :icons/forward
                       :icon-opts {:color :gray}}]]]])
 
-(def default-public-chats ["status" "cryptostrikers" "dapps" "ethereum" "openbounty"])
+(def default-public-chats ["status" "status 中文" "status 日本語" "status 한국어" "status по-русски" "status español" "cryptostrikers" "dapps" "ethereum" "openbounty"])
 
 (views/defview new-public-chat []
   (views/letsubs [topic [:get :public-group-topic]


### PR DESCRIPTION
Closes #4753 

### Summary:

[comment]: # (Summarise the problem and how the pull request solves it)
This PR adds 6 new public chats to the default chat list. The Russian chat name was adapted according to a suggestion by Igor.

### Review notes (optional):
<!-- (Specify if something in particular should be looked at, or ignored, during review) -->
Test sending/receiving messages in each of these channels. 

status: ready <!-- Can be ready or wip -->
