### PR TITLE
disable gradle daemon to make builds more stable

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -27,3 +27,6 @@ STATUS_RELEASE_KEY_PASSWORD=password
 
 # Workaround for issue https://github.com/facebook/react-native/issues/16906
 android.enableAapt2=false
+
+# Disable Gradle Daemon https://stackoverflow.com/questions/38710327/jenkins-builds-fail-using-the-gradle-daemon
+org.gradle.daemon=false


### PR DESCRIPTION
This __might__ make builds more stable, since we've been seeing more random failures like this one:
https://jenkins.status.im/job/status-react/job/nightly_release/35/console
```
The message received from the daemon indicates that the daemon has disappeared.
Build request sent: Build{id=c8166be1-2ca7-4dbe-b9bf-101c672a8844.1, currentDir=/Users/jenkins/workspace/status-react/nightly_release/android}
Attempting to read last messages from the daemon log...
Daemon pid: 77958
  log file: /Users/jenkins/.gradle/daemon/4.1/daemon-77958.out.log
----- Last  20 lines from daemon log file - daemon-77958.out.log -----
:react-native-svg:packageReleaseResources UP-TO-DATE
:react-native-testfairy:compileReleaseRenderscript UP-TO-DATE
:react-native-testfairy:generateReleaseResValues UP-TO-DATE
:react-native-testfairy:generateReleaseResources UP-TO-DATE
:react-native-testfairy:packageReleaseResources UP-TO-DATE
:react-native-webview-bridge:compileReleaseRenderscript UP-TO-DATE
:react-native-webview-bridge:generateReleaseResValues UP-TO-DATE
:react-native-webview-bridge:generateReleaseResources UP-TO-DATE
:react-native-webview-bridge:packageReleaseResources UP-TO-DATE
:realm:compileReleaseRenderscript UP-TO-DATE
:realm:generateReleaseResValues UP-TO-DATE
:realm:generateReleaseResources UP-TO-DATE
:realm:packageReleaseResources UP-TO-DATE
:app:mergeReleaseResources
:app:bundleReleaseJsAndAssets
Scanning folders for symlinks in /Users/jenkins/workspace/status-react/nightly_release/node_modules (11ms)
Scanning folders for symlinks in /Users/jenkins/workspace/status-react/nightly_release/node_modules (49ms)
Loading dependency graph, done.
warning: the transform cache was reset.
Daemon vm is shutting down... The daemon has exited normally or was terminated in response to a user interrupt.
----- End of the daemon log -----

FAILURE: Build failed with an exception.
```

<blockquote></blockquote>