### PR TITLE
Update transactions after /send command executed

### DIFF
--- a/src/status_im/chat/models/message.cljs
+++ b/src/status_im/chat/models/message.cljs
@@ -404,13 +404,17 @@
 
 ;; dispatch :update-transactions to update confirmations count
 ;; to verify tx initiated with /send command is confirmed
-(defn update-transactions [command-name tx-hash {:keys [with-delay?]} _]
+(defn update-transactions [command-name tx-hash {:keys [with-delay?]} cofx]
   (when (and tx-hash
              (= command-name constants/command-send))
-    (cond-> {:dispatch [:update-transactions]}
+    (cond-> {:update-transactions-fx cofx}
       with-delay?
-      (assoc :dispatch-later [{:ms       constants/command-send-status-update-interval-ms
-                               :dispatch [:update-transactions]}]))))
+      (assoc :utils/dispatch-later [{:ms       30000
+                                     :dispatch [:update-transactions]}
+                                    {:ms       60000
+                                     :dispatch [:update-transactions]}
+                                    {:ms       90000
+                                     :dispatch [:update-transactions]}]))))
 
 (defn send-command
   [{{:keys [current-public-key chats network prices] :as db} :db :keys [now] :as cofx} params]
@@ -424,7 +428,7 @@
                              (upsert-and-send (prepare-command-message current-public-key chat now request content network prices tx-hash))
                              (console-events/console-respond-command-messages command handler-data)
                              (requests-events/request-answered chat-id to-message)
-                             (update-transactions command-name tx-hash {:with-delay? false}))))
+                             (update-transactions command-name tx-hash {:with-delay? true}))))
 
 (defn invoke-console-command-handler
   [{:keys [db] :as cofx} {:keys [command] :as command-params}]

--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -16,7 +16,6 @@
 
 (def command-send "send")
 (def command-request "request")
-(def command-send-status-update-interval-ms 60000)
 
 (def min-password-length 6)
 (def max-chat-name-length 20)

--- a/src/status_im/network/events.cljs
+++ b/src/status_im/network/events.cljs
@@ -33,7 +33,8 @@
                                     {:db (assoc db :network-status (if is-connected? :online :offline))}
                                     (inbox/request-messages))
      is-connected?
-     (assoc :drain-mixpanel-events nil))))
+     (assoc :drain-mixpanel-events  nil
+            :update-transactions-fx cofx))))
 
 (handlers/register-handler-fx
  ::update-network-status

--- a/src/status_im/ui/screens/wallet/events.cljs
+++ b/src/status_im/ui/screens/wallet/events.cljs
@@ -138,9 +138,9 @@
                                 (assoc-in [:wallet :balance-loading?] true)
                                 (assoc :prices-loading? true))}))))
 
-(handlers/register-handler-fx
- :update-transactions
- (fn [{{:keys [network network-status web3] :as db} :db} _]
+(re-frame/reg-fx
+ :update-transactions-fx
+ (fn [{{:keys [network network-status web3] :as db} :db}]
    (when (not= network-status :offline)
      (let [network         (get-in db [:account/account :networks network])
            chain           (ethereum/network->chain-keyword network)
@@ -155,6 +155,11 @@
         :db               (-> db
                               (clear-error-message :transactions-update)
                               (assoc-in [:wallet :transactions-loading?] true))}))))
+
+(handlers/register-handler-fx
+ :update-transactions
+ (fn [cofx _]
+   {:update-transactions-fx cofx}))
 
 (defn combine-entries [transaction token-transfer]
   (merge transaction (select-keys token-transfer


### PR DESCRIPTION
fixes #4865

### Summary:

As a quick solution to issue described in #4865 we schedule 3 transaction state updates after funds got sent in chat – in 30, 60 and 90 seconds. These numbers are still experimental. Instead of 1 update 60 seconds later, we do 3 here – adds a bit of overhead, but brings faster feedback to the user and more confidence we get data from etherscan (additional request in 90 seconds).

status: ready
