### PR TITLE
Always try to assert that saved network is the one which node was act…

### DIFF
--- a/src/status_im/protocol/handlers.cljs
+++ b/src/status_im/protocol/handlers.cljs
@@ -3,8 +3,9 @@
             [re-frame.core :as re-frame]
             [status-im.constants :as constants]
             [status-im.native-module.core :as status]
+            [status-im.utils.utils :as utils]
             [status-im.utils.datetime :as datetime]
-            [status-im.utils.ethereum.core :as utils]
+            [status-im.utils.ethereum.core :as ethereum-utils]
             [status-im.utils.handlers :as handlers]
             [status-im.utils.handlers-macro :as handlers-macro]
             [status-im.utils.web3-provider :as web3-provider]
@@ -36,6 +37,21 @@
  (fn []
    (status/init-jail)))
 
+(defn- assert-correct-network
+  [{:keys [db]}]
+  ;; Assure that node was started correctly
+  (let [{:keys [network web3]} db]
+    (when-let [network-id (str (get-in db [:account/account :networks network :config :NetworkId]))]
+      (when web3 ; necessary because of the unit tests
+        (.getNetwork (.-version web3)
+                     (fn [error fetched-network-id]
+                       (when (and (not error) ; error most probably means we are offline
+                                  (not= network-id fetched-network-id))
+                         (utils/show-popup
+                          "Ethereum node started incorrectly"
+                          "Ethereum node was started with incorrect configuration, application will be stopped to recover from that condition."
+                          #(re-frame/dispatch [:close-application])))))))))
+
 (defn initialize-protocol
   [{:data-store/keys [transport mailservers] :keys [db web3] :as cofx} [current-account-id ethereum-rpc-url]]
   (handlers-macro/merge-fx cofx
@@ -43,6 +59,7 @@
                                        :web3 web3
                                        :rpc-url (or ethereum-rpc-url constants/ethereum-rpc-url)
                                        :transport/chats transport)}
+                           (assert-correct-network)
                            (transport.inbox/initialize-offline-inbox mailservers)
                            (transport/init-whisper current-account-id)))
 ;;; INITIALIZE PROTOCOL
@@ -87,6 +104,6 @@
  :initialize-sync-listener
  (fn [{{:keys [sync-listening-started network account/account] :as db} :db} _]
    (when (and (not sync-listening-started)
-              (not (utils/network-with-upstream-rpc? (get-in account [:networks network]))))
+              (not (ethereum-utils/network-with-upstream-rpc? (get-in account [:networks network]))))
      {:db       (assoc db :sync-listening-started true)
       :dispatch [:check-sync]})))

--- a/src/status_im/ui/screens/network_settings/events.cljs
+++ b/src/status_im/ui/screens/network_settings/events.cljs
@@ -14,7 +14,7 @@
 ;; handlers
 
 (handlers/register-handler-fx
- ::close-application
+ :close-application
  (fn [_ _]
    {:close-application nil}))
 


### PR DESCRIPTION
Partially fixes #4734 

### Summary:

The problem causing the #4734 bug was the fact that sometimes, for unknown reasons, `status-go` node was started with different config then the one passed to it and it wasn't intercepted anywhere. 
So for example you changed the network from mainnet to testnet, and while the app showed you are indeed on testnet, node was still on mainnet and everything which has to be fetched through `web3` api (wallet ballance, etc.) behaved accordingly, causing great user confusion.
This PR unfortunately doesn't solve the main issue (node started with different config then what was passed as startup arguments), but it at least detects and catches the condition, raising error "Ethereum node was started with incorrect configuration" so user immediately knows something it wrong and is forced to close the app to recover from the condition.

### Steps to test:
Check that #4734 is not happening like before, but error is raised instead

status: ready
