### PR TITLE
bug #4876 - cleaning up failed transactions and added stricter check …

### DIFF
--- a/src/status_im/ui/screens/accounts/events.cljs
+++ b/src/status_im/ui/screens/accounts/events.cljs
@@ -184,10 +184,12 @@
    (accounts.utils/account-update {:dev-mode? dev-mode} cofx)))
 
 (defn wallet-set-up-passed [db cofx]
-  (let [transaction (seq (get-in db [:wallet :send-transaction]))]
+  (let [transaction (get-in db [:wallet :send-transaction])]
     (merge
      {:db (navigation/navigate-back db)}
-     (when transaction
+     (when (and (seq transaction)
+                (not (:in-progress? transaction))
+                (:from-chat? transaction))
        {:dispatch [:navigate-to :wallet-send-transaction-chat]}))))
 
 (handlers/register-handler-fx

--- a/src/status_im/ui/screens/wallet/send/events.cljs
+++ b/src/status_im/ui/screens/wallet/send/events.cljs
@@ -119,6 +119,8 @@
                                       :signing?        false
                                       :wrong-password? false
                                       :waiting-signal? false
+                                      :from-chat?      false
+                                      :in-progress?    false
                                       :password        nil})
 
 (defn on-transactions-completed [raw-results]
@@ -213,6 +215,11 @@
            (= modal :wallet-send-transaction-modal)
            (= modal :wallet-sign-message-modal))))
 
+(defn handle-failed-tx [cofx error_message]
+  (-> cofx
+      (assoc ::show-transaction-error error_message)
+      (update-in [:db :wallet] dissoc :send-transaction)))
+
 ;;TRANSACTION FAILED signal from status-go
 (handlers/register-handler-fx
  :sign-request-failed
@@ -232,7 +239,7 @@
                                                (update-in [:wallet :send-transaction] merge clear-send-properties))
                   :dispatch                [:navigate-back]}
            (= method constants/web3-send-transaction)
-           (assoc ::show-transaction-error error_message))
+           (handle-failed-tx error_message))
          {:db (update-in db [:wallet :transactions-unsigned] dissoc id)})))))
 
 (defn prepare-unconfirmed-transaction [db now hash id]


### PR DESCRIPTION
fixes #4876

### Summary:

We check if there is a current transaction when we do wallet onboarding because it tells us the difference between wallet onboarding directly vs onboarding triggered by `/send` commands. The cause of the problem was that failed transactions were not cleaned up and remained "current", which means that if the user did have a failed transaction before finishing onboarding, we'd get this error

The solution in this PR is to clean up the current transaction when failed and also to add more defensive checks in onboarding, just in case.

EDIT: This PR now also marks successful transactions as not in progress and not from chat any more (if they were). This should prevent them from triggering the same behavior as the one with failed ones described above.

### Steps to test:
see #4876

status: ready 