### PR TITLE
bug #4890 - reverts the quickfix for vertical alignment of chat comma…

### DIFF
--- a/src/status_im/chat/styles/input/input.cljs
+++ b/src/status_im/chat/styles/input/input.cljs
@@ -74,7 +74,7 @@
    :text-align-vertical :center
    :flex                1
    :android             {:top -1}
-   :ios                 {:line-height 43}})
+   :ios                 {:line-height min-input-height}})
 
 (defnstyle seq-input-text [left container-width]
   {:min-width           (- container-width left)


### PR DESCRIPTION
fixes #4890

### Summary:

1. Commit with chat styles introduced a small vertical misalignment of command parameter placeholders.
2. I quick "fixed" it in "send tokens in chat" PR
3. Now, the styling commit has been [reverted](https://github.com/status-im/status-react/commit/424d7cc6ae6d803479532b57b3b6b69f380a992e)
4. So, my fix is no longer valid and have to revert it too.

### Steps to test:
- Open a chat
- Start a `/send` command
- See if placeholders are aligned ok

status: ready 