### PR TITLE
Protect against nil chain

### DIFF
--- a/src/status_im/chat/models/message.cljs
+++ b/src/status_im/chat/models/message.cljs
@@ -332,13 +332,12 @@
                          :tokens  [fcm-token]}}))
 
 (defn update-message-status [{:keys [chat-id message-id from]} status {:keys [db]}]
-  (let [updated-status (-> db
-                           (get-in [:chats chat-id :message-statuses message-id from])
-                           (assoc :status status))]
-    {:db            (assoc-in db
-                              [:chats chat-id :message-statuses message-id from]
-                              updated-status)
-     :data-store/tx [(user-statuses-store/save-status-tx updated-status)]}))
+  (when-let [message-status (get-in db [:chats chat-id :message-statuses message-id from])]
+    (let [updated-status (assoc message-status :status status)]
+      {:db            (assoc-in db
+                                [:chats chat-id :message-statuses message-id from]
+                                updated-status)
+       :data-store/tx [(user-statuses-store/save-status-tx updated-status)]})))
 
 (defn resend-message [chat-id message-id cofx]
   (let [message (get-in cofx [:db :chats chat-id :messages message-id])

--- a/src/status_im/ui/screens/wallet/events.cljs
+++ b/src/status_im/ui/screens/wallet/events.cljs
@@ -139,20 +139,20 @@
 (handlers/register-handler-fx
  :update-transactions
  (fn [{{:keys [network network-status web3] :as db} :db} _]
-   (when (not= network-status :offline)
-     (let [network         (get-in db [:account/account :networks network])
-           chain           (ethereum/network->chain-keyword network)
-           all-tokens      (tokens/tokens-for chain)
-           token-addresses (map :address all-tokens)]
-       {:get-transactions {:account-id      (get-in db [:account/account :address])
-                           :token-addresses token-addresses
-                           :chain           chain
-                           :web3            web3
-                           :success-event   :update-transactions-success
-                           :error-event     :update-transactions-fail}
-        :db               (-> db
-                              (clear-error-message :transactions-update)
-                              (assoc-in [:wallet :transactions-loading?] true))}))))
+   (let [chain (ethereum/network->chain-keyword network)]
+     (when (and (not= network-status :offline) chain)
+       (let [network         (get-in db [:account/account :networks network])
+             all-tokens      (tokens/tokens-for chain)
+             token-addresses (map :address all-tokens)]
+         {:get-transactions {:account-id      (get-in db [:account/account :address])
+                             :token-addresses token-addresses
+                             :chain           chain
+                             :web3            web3
+                             :success-event   :update-transactions-success
+                             :error-event     :update-transactions-fail}
+          :db               (-> db
+                                (clear-error-message :transactions-update)
+                                (assoc-in [:wallet :transactions-loading?] true))})))))
 
 (defn combine-entries [transaction token-transfer]
   (merge transaction (select-keys token-transfer


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes #4892 

### Summary:

`get-transactions` functions fetching network transactions is called as an effect of the `:update-transactions` handler -> as this is sometimes called with delayed dispatch (so it could be performed when the user is not logged-in anymore), we have to be sure to actually check there is valid network (and chain-id) present when performing the effect.

### Steps to test:
Check that #4892 is not happening anymore

status: ready 
