### PR TITLE
Fix onboarding screen text and button overlap

### DIFF
--- a/src/status_im/translations/en.cljs
+++ b/src/status_im/translations/en.cljs
@@ -72,7 +72,7 @@
    :home                                 "Home"
    :no-recent-chats                      "There are no recent Chats or DApps here yet. Tap the “Plus” button to see the list of Dapps or discover people to chat with."
    :welcome-to-status                    "Welcome to Status"
-   :welcome-to-status-description        "Here you can securely chat with people, or browse and interact with DApps. Tap the “Plus” icon to begin."
+   :welcome-to-status-description        "Here you can chat with people in a secure\n private chat, browse and interact with DApps.\n Use the “Plus” icon to explore Status"
 
    ;;chat
    :is-typing                            "is typing"

--- a/src/status_im/ui/screens/home/styles.cljs
+++ b/src/status_im/ui/screens/home/styles.cljs
@@ -156,30 +156,32 @@
    :color          colors/gray})
 
 (def welcome-view
-  {:flex               1
-   :padding-horizontal 30})
+  {:flex 1})
 
-(def welcome-image-container
-  {:flex            1
-   :align-items     :center
-   :justify-content :center})
+(defstyle welcome-image-container
+  {:align-items :center
+   :android     {:margin-top 38}
+   :ios         {:margin-top 42}})
 
 (def welcome-image
   {:width  320
    :height 278})
 
-(def welcome-text
+(defstyle welcome-text
   {:line-height    28
    :font-size      22
    :font-weight    :bold
    :letter-spacing -0.3
+   :android        {:margin-top 22}
+   :ios            {:margin-top 96}
    :text-align     :center
    :color          colors/black})
 
-(def welcome-text-description
+(defstyle welcome-text-description
   {:line-height    21
    :margin-top     8
-   :margin-bottom  32
+   :android        {:margin-bottom 82}
+   :ios            {:margin-bottom 32}
    :font-size      14
    :letter-spacing -0.2
    :text-align     :center

--- a/src/status_im/ui/screens/home/views.cljs
+++ b/src/status_im/ui/screens/home/views.cljs
@@ -20,14 +20,16 @@
             [status-im.ui.components.icons.vector-icons :as icons]))
 
 (defn- toolbar [show-welcome?]
-  [toolbar/toolbar nil nil
-   (when-not show-welcome?
-     [toolbar/content-wrapper
-      [components.common/logo styles/toolbar-logo]])
-   [toolbar/actions
-    (when platform/ios?
-      [(-> (toolbar.actions/add true #(re-frame/dispatch [:navigate-to :new]))
-           (assoc-in [:icon-opts :accessibility-label] :new-chat-button))])]])
+  (when-not (and show-welcome?
+                 platform/android?)
+    [toolbar/toolbar nil nil
+     (when-not show-welcome?
+       [toolbar/content-wrapper
+        [components.common/logo styles/toolbar-logo]])
+     [toolbar/actions
+      (when platform/ios?
+        [(-> (toolbar.actions/add true #(re-frame/dispatch [:navigate-to :new]))
+             (assoc-in [:icon-opts :accessibility-label] :new-chat-button))])]]))
 
 (defn- home-action-button []
   [react/view styles/action-button-container
@@ -91,4 +93,5 @@
                                          [home-list-item home-item])}])
      (when platform/android?
        [home-action-button])
-     [connectivity/error-view]]))
+     (when-not show-welcome?
+       [connectivity/error-view])]))


### PR DESCRIPTION
fixes #4767

### Summary:

Fix layout on onboarding screen where text and button overlap

status: ready

<img width="410" alt="screenshot 2018-06-21 15 43 35" src="https://user-images.githubusercontent.com/23836/41725664-0c936e96-7579-11e8-9cb1-d54de1ddeb5a.png">
<img width="365" alt="screenshot 2018-06-21 15 43 02" src="https://user-images.githubusercontent.com/23836/41725665-0cb73aa6-7579-11e8-8a19-0fe3770a2f2c.png">

