### PR TITLE
bug #4858 - not signing transactions with nil password

### DIFF
--- a/src/status_im/ui/screens/wallet/send/events.cljs
+++ b/src/status_im/ui/screens/wallet/send/events.cljs
@@ -25,9 +25,10 @@
  ::accept-transaction
  (fn [{:keys [masked-password id on-completed]}]
   ;; unmasking the password as late as possible to avoid being exposed from app-db
-   (status/approve-sign-request id
-                                (security/unmask masked-password)
-                                on-completed)))
+   (when masked-password
+     (status/approve-sign-request id
+                                  (security/unmask masked-password)
+                                  on-completed))))
 
 (re-frame/reg-fx
  ::accept-transaction-with-changed-gas
@@ -336,13 +337,16 @@
   ;;TODO(goranjovic) - unify send-transaction and unsigned-transaction
   (let [{:keys [id password] :as send-transaction}   (get-in db [:wallet :send-transaction])
         {:keys [gas gas-price]} [:wallet.send/unsigned-transaction]]
-    {:db                                   (assoc-in db [:wallet :send-transaction :in-progress?] true)
-     ::accept-transaction-with-changed-gas {:id                id
-                                            :masked-password   password
-                                            :gas               (or gas (:gas send-transaction))
-                                            :gas-price         (or gas-price (:gas-price send-transaction))
-                                            :default-gas-price default-gas-price
-                                            :on-completed      on-transactions-modal-completed}}))
+    ;;TODO(goranjovic) - `when password` check is to prevent this bug - https://github.com/status-im/status-react/issues/4858
+    ;; ideally this should be fixed by disabling the button after first tap
+    (when password
+      {:db                                   (assoc-in db [:wallet :send-transaction :in-progress?] true)
+       ::accept-transaction-with-changed-gas {:id                id
+                                              :masked-password   password
+                                              :gas               (or gas (:gas send-transaction))
+                                              :gas-price         (or gas-price (:gas-price send-transaction))
+                                              :default-gas-price default-gas-price
+                                              :on-completed      on-transactions-modal-completed}})))
 
 (handlers/register-handler-fx
  :wallet/sign-transaction-modal-update-gas-success


### PR DESCRIPTION
fixes #4858

### Summary:

If Sign button is quickly tapped multiple times, there is a crash error, due to password being nil in the subseqent calls. I couldn't make the button tappable only once so I changed the handler to do nothing in the case when `password` is nil

### Steps to test:
See #4858

status: ready 
