### PR TITLE
Chat messages layout fixes

### DIFF
--- a/src/status_im/chat/styles/message/datemark.cljs
+++ b/src/status_im/chat/styles/message/datemark.cljs
@@ -1,4 +1,5 @@
 (ns status-im.chat.styles.message.datemark
+  (:require-macros [status-im.utils.styles :refer [defstyle]])
   (:require [status-im.ui.components.styles :as common]))
 
 (def datemark-wrapper
@@ -9,7 +10,7 @@
   {:margin-top       16
    :height           22})
 
-(def datemark-text
-  {:color          common/color-gray4
-   :letter-spacing -0.2
-   :font-size      15})
+(defstyle datemark-text
+  {:color     common/color-gray4
+   :ios       {:letter-spacing -0.2}
+   :font-size 15})

--- a/src/status_im/chat/styles/message/message.cljs
+++ b/src/status_im/chat/styles/message/message.cljs
@@ -10,7 +10,7 @@
    :color          styles/text1-color
    :letter-spacing -0.2
    :android        {:line-height 22}
-   :ios            {:line-height 23}})
+   :ios            {:line-height 22}})
 
 (def style-sub-text
   {:top         -2
@@ -23,15 +23,11 @@
   [{:keys [first-in-group? display-username?]}]
   (if (and display-username?
            first-in-group?)
-    8
-    4))
+    6
+    2))
 
 (def message-empty-spacing
   {:height 16})
-
-(def message-body-base
-  {:padding-right 10
-   :padding-left  10})
 
 (defn last-message-padding
   [{:keys [last? typing]}]
@@ -39,15 +35,17 @@
     {:padding-bottom 16}))
 
 (defn message-body
-  [{:keys [outgoing] :as message}]
-  (let [align     (if outgoing :flex-end :flex-start)
+  [{:keys [outgoing display-photo?] :as message}]
+  (let [align (if outgoing :flex-end :flex-start)
         direction (if outgoing :row-reverse :row)]
-    (merge message-body-base
-           {:flex-direction direction
+    (merge {:flex-direction direction
             :width          230
             :padding-top    (message-padding-top message)
             :align-self     align
-            :align-items    align})))
+            :align-items    align}
+           (when display-photo?
+             {:padding-right 8
+              :padding-left  8}))))
 
 (def message-timestamp
   {:font-size      10
@@ -89,17 +87,17 @@
   [outgoing]
   (let [align (if outgoing :flex-end :flex-start)]
     {:flex-direction :column
-     :width          260
-     :padding-left   10
-     :padding-right  10
+     :width          230
+     :padding-left   8
+     :padding-right  8
      :align-items    align}))
 
 (defn delivery-status [outgoing]
   (if outgoing
     {:align-self    :flex-end
-     :padding-right 22}
+     :padding-right 8}
     {:align-self    :flex-start
-     :padding-left  16}))
+     :padding-left  8}))
 
 (def message-author
   {:width      photos/default-size

--- a/src/status_im/chat/views/message/message.cljs
+++ b/src/status_im/chat/views/message/message.cljs
@@ -79,6 +79,7 @@
   (letsubs [network [:network-name]]
     (let [{{:keys [amount fiat-amount tx-hash asset] send-network :network} :params} content
           recipient-name (get-in content [:params :bot-db :public :recipient])
+          amount-text-long? (< 10 (count amount))
           network-mismatch? (and (seq send-network) (not= network send-network))]
       [react/view style/command-send-message-view
        [react/view
@@ -88,7 +89,7 @@
                        :font  :medium}
            amount
            [react/text {:style (style/command-amount-currency-separator outgoing)}
-            "."]
+            (if amount-text-long? "\n" ".")]
            [react/text {:style (style/command-send-currency-text outgoing)
                         :font  :default}
             asset]]]]


### PR DESCRIPTION
### Summary:

There were some mismatches in current messages design and zeplin mockup:
* Set chat message left&right paddings to 8
* Set message width to 230
* Move currency name to next line if amount is long enough in transaction message

### Screenshots
<img width="485" alt="screenshot 2018-06-25 16 18 54" src="https://user-images.githubusercontent.com/23836/41852346-788dc732-7893-11e8-9f5f-95d226e967c2.png">


status: ready
