### PR TITLE
Abort git rebase on Jenkins failure

### DIFF
--- a/Jenkinsfile.desktopbuild
+++ b/Jenkinsfile.desktopbuild
@@ -16,6 +16,15 @@ def installJSDeps() {
     }
 }
 
+def doGitRebase() {
+  try {
+    sh 'git rebase origin/desktop'
+  } catch (e) {
+    sh 'git rebase --abort'
+    throw e
+  }
+}
+
 parallel (
   "MacOS parallel build stream" : {
     timeout(90) {
@@ -38,7 +47,8 @@ parallel (
             sh ('echo ' + scriptPath)
 
             checkout scm
-            sh 'git rebase origin/desktop'
+
+            doGitRebase()
 
             sh 'rm -rf node_modules'
             sh 'cp .env.jenkins .env'
@@ -110,7 +120,8 @@ parallel (
             sh ('echo ' + scriptPath)
 
             checkout scm
-            sh 'git rebase origin/desktop'
+
+            doGitRebase()
 
             sh 'rm -rf node_modules'
             sh 'cp .env.jenkins .env'


### PR DESCRIPTION
Running `git rebase --abort` should prevent leaving Jenkins pipeline build job directory in rebase failure state (Issue that we have seen recently)

Testing notes:
Verification is not required for this PR.