### PR TITLE
Use correct chain name if custom network added

### DIFF
--- a/src/status_im/chat/events/shortcuts.cljs
+++ b/src/status_im/chat/events/shortcuts.cljs
@@ -15,7 +15,7 @@
              :from-chat? true)))
 
 (defn send-shortcut-fx [{:account/keys [account] :as db} contact params]
-  (let [chain              (keyword (ethereum/network-names (:network db)))
+  (let [chain              (keyword (:chain db))
         symbol             (-> params :asset keyword)
         {:keys [decimals]} (tokens/asset-for chain symbol)]
     (merge {:db (-> db

--- a/src/status_im/ui/screens/db.cljs
+++ b/src/status_im/ui/screens/db.cljs
@@ -131,6 +131,7 @@
 ;;;;NETWORK
 
 (spec/def ::network (spec/nilable string?))
+(spec/def ::chain (spec/nilable string?))
 (spec/def ::peers-count (spec/nilable integer?))
 (spec/def ::peers-summary (spec/nilable vector?))
 (spec/def :inbox/fetching? (spec/nilable boolean?))
@@ -225,6 +226,7 @@
                  ::sync-state
                  ::sync-data
                  ::network
+                 ::chain
                  :navigation/view-id
                  :navigation/navigation-stack
                  :navigation/prev-tab-view-id

--- a/src/status_im/ui/screens/events.cljs
+++ b/src/status_im/ui/screens/events.cljs
@@ -337,7 +337,9 @@
               status-module-initialized? status-node-started? device-UUID]
        :or   [network (get app-db :network)]} [_ address]]
    (let [console-contact (get contacts constants/console-chat-id)
-         current-account (accounts address)]
+         current-account (accounts address)
+         account-network-id (get current-account :network network)
+         account-network (get-in current-account [:networks account-network-id])]
      (cond-> (assoc app-db
                     :access-scope->commands-responses access-scope->commands-responses
                     :current-public-key (:public-key current-account)
@@ -350,6 +352,7 @@
                     :account/account current-account
                     :network-status network-status
                     :network network
+                    :chain (ethereum/network->chain-name account-network)
                     :peers-summary peers-summary
                     :peers-count peers-count
                     :device-UUID device-UUID)

--- a/src/status_im/ui/screens/subs.cljs
+++ b/src/status_im/ui/screens/subs.cljs
@@ -39,7 +39,7 @@
          (fn [current-account]
            (get (:networks current-account) (:network current-account))))
 
-(reg-sub :network-name (comp ethereum/network-names :network))
+(reg-sub :network-name :chain)
 
 (reg-sub :sync-state :sync-state)
 (reg-sub :network-status :network-status)

--- a/src/status_im/utils/ethereum/core.cljs
+++ b/src/status_im/utils/ethereum/core.cljs
@@ -12,14 +12,6 @@
    :testnet {:id 3 :name "Ropsten"}
    :rinkeby {:id 4 :name "Rinkeby"}})
 
-(def network-names
-  {"mainnet"     "mainnet"
-   "mainnet_rpc" "mainnet"
-   "testnet"     "testnet"
-   "testnet_rpc" "testnet"
-   "rinkeby"     "rinkeby"
-   "rinkeby_rpc" "rinkeby"})
-
 (defn chain-id->chain-keyword [i]
   (some #(when (= i (:id (val %))) (key %)) chains))
 
@@ -71,6 +63,11 @@
 
 (defn network->chain-keyword [network]
   (chain-id->chain-keyword (network->chain-id network)))
+
+(defn network->chain-name [network]
+  (-> network
+      network->chain-keyword
+      name))
 
 (defn sha3 [s]
   (.sha3 dependencies/Web3.prototype (str s)))


### PR DESCRIPTION
fixes #4920

### Summary:

When user switches to custom network,  new network id like `15300013659147f5dc020c2a55b8596efa37b1341e410` is generated. That caused chain name detection failure as it was as using this mappings  for conversion:
```
(def network-names	
  {"mainnet"     "mainnet"	
   "mainnet_rpc" "mainnet"	
   "testnet"     "testnet"	
   "testnet_rpc" "testnet"	
   "rinkeby"     "rinkeby"	
   "rinkeby_rpc" "rinkeby"})
```

### Solution

* Use network id (number) to properly detect chain name. 
* Store chain name in app-db for future usages

### Testing notes (optional):
Except testing the discovered bug i'd also suggest to test wallet transactions and /send /receive from chat. 

status: ready
