### PR TITLE
Dont use denormalized name anymore

### DIFF
--- a/src/status_im/chat/screen.cljs
+++ b/src/status_im/chat/screen.cljs
@@ -30,14 +30,6 @@
             [status-im.ui.components.icons.vector-icons :as vector-icons]
             [status-im.ui.components.colors :as colors]))
 
-(defn toolbar-action [chat-id chat-name group-chat public?]
-  [react/touchable-highlight
-   {:on-press            #(list-selection/show {:title chat-name
-                                                :options (actions/actions chat-id group-chat public?)})
-    :accessibility-label :chat-menu}
-   [react/view style/action
-    [vector-icons/icon :icons/dots-horizontal]]])
-
 (defview add-contact-bar [contact-identity]
   (letsubs [contact [:get-contact-by-identity contact-identity]]
     (when (models.contact/can-add-to-contacts? contact)
@@ -53,7 +45,8 @@
                         :options (actions/actions group-chat? chat-id public?)}))
 
 (defview chat-toolbar [public?]
-  (letsubs [{:keys [group-chat name chat-id contacts]} [:get-current-chat]]
+  (letsubs [name                                  [:get-current-chat-name]
+            {:keys [group-chat chat-id contacts]} [:get-current-chat]]
     [react/view
      [status-bar/status-bar]
      (if (= chat-id constants/console-chat-id)

--- a/src/status_im/ui/components/qr_code_viewer/styles.cljs
+++ b/src/status_im/ui/components/qr_code_viewer/styles.cljs
@@ -34,18 +34,6 @@
   {:color     colors/white
    :font-size 12})
 
-(def toolbar-action-container
-  {:flex            0.2
-   :flex-direction  :column
-   :align-items     :center
-   :justify-content :center})
-
-(def toolbar-action-icon-container
-  {:width           40
-   :height          40
-   :align-items     :center
-   :justify-content :center})
-
 (def wallet-qr-code
   {:flex-grow      1
    :flex-direction :column})

--- a/src/status_im/ui/screens/home/styles.cljs
+++ b/src/status_im/ui/screens/home/styles.cljs
@@ -130,10 +130,6 @@
 
 (def native-button-offset 16)
 
-(def toolbar-actions
-  {:flex-direction :row
-   :padding-right  14})
-
 (def create-icon
   {:font-size 20
    :height    22


### PR DESCRIPTION
fixes #4937

### Summary:
We were using the denormalized chat-name which is not updated anymore, falls back on contact.
I have also removed a bunch of code that is not used anymore.

status: ready