### PR TITLE
[#4901]: Fix npm version issue; updated scripts/setup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,14 +24,14 @@
         "@babel/template": "7.0.0-beta.51",
         "@babel/traverse": "7.0.0-beta.51",
         "@babel/types": "7.0.0-beta.51",
-        "convert-source-map": "1.5.1",
-        "debug": "3.1.0",
-        "json5": "0.5.1",
-        "lodash": "4.17.10",
-        "micromatch": "3.1.10",
-        "resolve": "1.8.1",
-        "semver": "5.5.0",
-        "source-map": "0.5.7"
+        "convert-source-map": "^1.1.0",
+        "debug": "^3.1.0",
+        "json5": "^0.5.0",
+        "lodash": "^4.17.5",
+        "micromatch": "^3.1.10",
+        "resolve": "^1.3.2",
+        "semver": "^5.4.1",
+        "source-map": "^0.5.0"
       },
       "dependencies": {
         "debug": {
@@ -50,10 +50,10 @@
       "integrity": "sha1-bHV1/952HQdIXgS67cA5LG2eMPY=",
       "requires": {
         "@babel/types": "7.0.0-beta.51",
-        "jsesc": "2.5.1",
-        "lodash": "4.17.10",
-        "source-map": "0.5.7",
-        "trim-right": "1.0.1"
+        "jsesc": "^2.5.1",
+        "lodash": "^4.17.5",
+        "source-map": "^0.5.0",
+        "trim-right": "^1.0.1"
       },
       "dependencies": {
         "jsesc": {
@@ -86,7 +86,7 @@
       "integrity": "sha1-hsctZoO9JZfJOKEhU6bkgL8UASg=",
       "requires": {
         "@babel/types": "7.0.0-beta.51",
-        "esutils": "2.0.2"
+        "esutils": "^2.0.0"
       }
     },
     "@babel/helper-call-delegate": {
@@ -106,7 +106,7 @@
       "requires": {
         "@babel/helper-function-name": "7.0.0-beta.51",
         "@babel/types": "7.0.0-beta.51",
-        "lodash": "4.17.10"
+        "lodash": "^4.17.5"
       }
     },
     "@babel/helper-explode-assignable-expression": {
@@ -158,7 +158,7 @@
       "integrity": "sha1-zgBCgEX7t9XrwOp7+DV4nxU2arI=",
       "requires": {
         "@babel/types": "7.0.0-beta.51",
-        "lodash": "4.17.10"
+        "lodash": "^4.17.5"
       }
     },
     "@babel/helper-module-transforms": {
@@ -171,7 +171,7 @@
         "@babel/helper-split-export-declaration": "7.0.0-beta.51",
         "@babel/template": "7.0.0-beta.51",
         "@babel/types": "7.0.0-beta.51",
-        "lodash": "4.17.10"
+        "lodash": "^4.17.5"
       }
     },
     "@babel/helper-optimise-call-expression": {
@@ -217,7 +217,7 @@
       "requires": {
         "@babel/template": "7.0.0-beta.51",
         "@babel/types": "7.0.0-beta.51",
-        "lodash": "4.17.10"
+        "lodash": "^4.17.5"
       }
     },
     "@babel/helper-split-export-declaration": {
@@ -254,9 +254,9 @@
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.51.tgz",
       "integrity": "sha1-6IRK4loVlcz9QriWI7Q3bKBtIl0=",
       "requires": {
-        "chalk": "2.4.1",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
+        "chalk": "^2.0.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -264,7 +264,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -272,9 +272,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "supports-color": {
@@ -282,7 +282,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -376,7 +376,7 @@
       "integrity": "sha1-vlVcefDaTrFop/4W14eppxc3AeA=",
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0-beta.51",
-        "lodash": "4.17.10"
+        "lodash": "^4.17.5"
       }
     },
     "@babel/plugin-transform-classes": {
@@ -391,7 +391,7 @@
         "@babel/helper-plugin-utils": "7.0.0-beta.51",
         "@babel/helper-replace-supers": "7.0.0-beta.51",
         "@babel/helper-split-export-declaration": "7.0.0-beta.51",
-        "globals": "11.7.0"
+        "globals": "^11.1.0"
       },
       "dependencies": {
         "globals": {
@@ -520,7 +520,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0-beta.51.tgz",
       "integrity": "sha1-U28NWZ0nU9ygor6KZeLCRKe1YSs=",
       "requires": {
-        "regenerator-transform": "0.12.4"
+        "regenerator-transform": "^0.12.4"
       },
       "dependencies": {
         "regenerator-transform": {
@@ -528,7 +528,7 @@
           "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.12.4.tgz",
           "integrity": "sha512-p2I0fY+TbSLD2/VFTFb/ypEHxs3e3AjU0DzttdPqk2bSmDhfSh5E54b86Yc6XhUa5KykK1tgbvZ4Nr82oCJWkQ==",
           "requires": {
-            "private": "0.1.8"
+            "private": "^0.1.6"
           }
         }
       }
@@ -563,20 +563,15 @@
       "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.0.0-beta.51.tgz",
       "integrity": "sha1-MabSfxJMx6KgpgO2XSPVZEuXmqA=",
       "requires": {
-        "core-js": "2.5.7",
-        "find-cache-dir": "1.0.0",
-        "home-or-tmp": "3.0.0",
-        "lodash": "4.17.10",
-        "mkdirp": "0.5.1",
-        "pirates": "3.0.2",
-        "source-map-support": "0.4.18"
+        "core-js": "^2.5.7",
+        "find-cache-dir": "^1.0.0",
+        "home-or-tmp": "^3.0.0",
+        "lodash": "^4.17.5",
+        "mkdirp": "^0.5.1",
+        "pirates": "^3.0.1",
+        "source-map-support": "^0.4.2"
       },
       "dependencies": {
-        "core-js": {
-          "version": "2.5.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-          "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
-        },
         "home-or-tmp": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-3.0.0.tgz",
@@ -592,7 +587,7 @@
         "@babel/code-frame": "7.0.0-beta.51",
         "@babel/parser": "7.0.0-beta.51",
         "@babel/types": "7.0.0-beta.51",
-        "lodash": "4.17.10"
+        "lodash": "^4.17.5"
       }
     },
     "@babel/traverse": {
@@ -606,10 +601,10 @@
         "@babel/helper-split-export-declaration": "7.0.0-beta.51",
         "@babel/parser": "7.0.0-beta.51",
         "@babel/types": "7.0.0-beta.51",
-        "debug": "3.1.0",
-        "globals": "11.7.0",
-        "invariant": "2.2.4",
-        "lodash": "4.17.10"
+        "debug": "^3.1.0",
+        "globals": "^11.1.0",
+        "invariant": "^2.2.0",
+        "lodash": "^4.17.5"
       },
       "dependencies": {
         "debug": {
@@ -632,9 +627,9 @@
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.51.tgz",
       "integrity": "sha1-2AK3tUO1g2x3iqaReXq/APPZfqk=",
       "requires": {
-        "esutils": "2.0.2",
-        "lodash": "4.17.10",
-        "to-fast-properties": "2.0.0"
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.5",
+        "to-fast-properties": "^2.0.0"
       },
       "dependencies": {
         "to-fast-properties": {
@@ -642,6 +637,15 @@
           "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
           "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
         }
+      }
+    },
+    "@tradle/react-native-http": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tradle/react-native-http/-/react-native-http-2.0.1.tgz",
+      "integrity": "sha1-rxniQOHlgL+iSVY5JNG+RyaG9Is=",
+      "requires": {
+        "Base64": "~0.2.0",
+        "inherits": "~2.0.1"
       }
     },
     "Base64": {
@@ -664,7 +668,7 @@
       "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.1.tgz",
       "integrity": "sha1-+QFKVmm3RkGOFFFo3qSaBErhWQA=",
       "requires": {
-        "xtend": "4.0.1"
+        "xtend": "~4.0.0"
       }
     },
     "accepts": {
@@ -672,19 +676,17 @@
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
       "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
       "requires": {
-        "mime-types": "2.1.18",
+        "mime-types": "~2.1.18",
         "negotiator": "0.6.1"
       }
     },
     "ajv": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "version": "4.11.8",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
       "requires": {
-        "co": "4.6.0",
-        "fast-deep-equal": "1.1.0",
-        "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.3.1"
+        "co": "^4.6.0",
+        "json-stable-stringify": "^1.0.1"
       }
     },
     "align-text": {
@@ -692,9 +694,9 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "requires": {
-        "kind-of": "3.2.2",
-        "longest": "1.0.1",
-        "repeat-string": "1.6.1"
+        "kind-of": "^3.0.2",
+        "longest": "^1.0.1",
+        "repeat-string": "^1.5.2"
       },
       "dependencies": {
         "kind-of": {
@@ -702,7 +704,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -722,7 +724,7 @@
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
       "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
       "requires": {
-        "ansi-wrap": "0.1.0"
+        "ansi-wrap": "^0.1.0"
       }
     },
     "ansi-cyan": {
@@ -774,8 +776,8 @@
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
       "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
       "requires": {
-        "micromatch": "3.1.10",
-        "normalize-path": "2.1.1"
+        "micromatch": "^3.1.4",
+        "normalize-path": "^2.1.1"
       }
     },
     "aproba": {
@@ -789,12 +791,12 @@
       "integrity": "sha512-BLM56aPo9vLLFVa8+/+pJLnrZ7QGGTVHWsCwieAWT9o9K8UeGaQbzZbGoabWLOo2ksBCztoXdqBZBplqLDDCSg=="
     },
     "are-we-there-yet": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-      "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
       "requires": {
-        "delegates": "1.0.0",
-        "readable-stream": "2.3.6"
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
       }
     },
     "argsarray": {
@@ -808,7 +810,7 @@
       "integrity": "sha1-Jsu1r/ZBRLCoJb4YRuCxbPoAsR4=",
       "requires": {
         "ast-types-flow": "0.0.7",
-        "commander": "2.15.1"
+        "commander": "^2.11.0"
       }
     },
     "arr-diff": {
@@ -831,7 +833,7 @@
       "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
       "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
       "requires": {
-        "typical": "2.6.1"
+        "typical": "^2.6.1"
       }
     },
     "array-filter": {
@@ -844,8 +846,8 @@
       "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
       "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
       "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.11.0"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.7.0"
       }
     },
     "array-map": {
@@ -888,9 +890,9 @@
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
       "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
       "requires": {
-        "bn.js": "4.11.8",
-        "inherits": "2.0.1",
-        "minimalistic-assert": "1.0.1"
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "assert": {
@@ -902,9 +904,9 @@
       }
     },
     "assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
     },
     "assign-symbols": {
       "version": "1.0.0",
@@ -933,8 +935,8 @@
       "requires": {
         "abstract-leveldown": "2.6.1",
         "argsarray": "0.0.1",
-        "d64": "1.0.0",
-        "ltgt": "2.2.1",
+        "d64": "^1.0.0",
+        "ltgt": "^2.1.3",
         "tiny-queue": "0.2.0"
       }
     },
@@ -944,9 +946,9 @@
       "integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio="
     },
     "aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
     },
     "aws4": {
       "version": "1.7.0",
@@ -966,9 +968,9 @@
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
       }
     },
     "babel-core": {
@@ -976,25 +978,25 @@
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.24.1.tgz",
       "integrity": "sha1-jEKFZNzh4fQfszfsNPTDsCK1rYM=",
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-generator": "6.24.1",
-        "babel-helpers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-register": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "convert-source-map": "1.5.1",
-        "debug": "2.6.9",
-        "json5": "0.5.1",
-        "lodash": "4.17.10",
-        "minimatch": "3.0.4",
-        "path-is-absolute": "1.0.1",
-        "private": "0.1.8",
-        "slash": "1.0.0",
-        "source-map": "0.5.7"
+        "babel-code-frame": "^6.22.0",
+        "babel-generator": "^6.24.1",
+        "babel-helpers": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-register": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1",
+        "babylon": "^6.11.0",
+        "convert-source-map": "^1.1.0",
+        "debug": "^2.1.1",
+        "json5": "^0.5.0",
+        "lodash": "^4.2.0",
+        "minimatch": "^3.0.2",
+        "path-is-absolute": "^1.0.0",
+        "private": "^0.1.6",
+        "slash": "^1.0.0",
+        "source-map": "^0.5.0"
       },
       "dependencies": {
         "babel-core": {
@@ -1002,25 +1004,25 @@
           "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
           "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
           "requires": {
-            "babel-code-frame": "6.26.0",
-            "babel-generator": "6.26.1",
-            "babel-helpers": "6.24.1",
-            "babel-messages": "6.23.0",
-            "babel-register": "6.26.0",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "convert-source-map": "1.5.1",
-            "debug": "2.6.9",
-            "json5": "0.5.1",
-            "lodash": "4.17.10",
-            "minimatch": "3.0.4",
-            "path-is-absolute": "1.0.1",
-            "private": "0.1.8",
-            "slash": "1.0.0",
-            "source-map": "0.5.7"
+            "babel-code-frame": "^6.26.0",
+            "babel-generator": "^6.26.0",
+            "babel-helpers": "^6.24.1",
+            "babel-messages": "^6.23.0",
+            "babel-register": "^6.26.0",
+            "babel-runtime": "^6.26.0",
+            "babel-template": "^6.26.0",
+            "babel-traverse": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "babylon": "^6.18.0",
+            "convert-source-map": "^1.5.1",
+            "debug": "^2.6.9",
+            "json5": "^0.5.1",
+            "lodash": "^4.17.4",
+            "minimatch": "^3.0.4",
+            "path-is-absolute": "^1.0.1",
+            "private": "^0.1.8",
+            "slash": "^1.0.0",
+            "source-map": "^0.5.7"
           },
           "dependencies": {
             "babel-generator": {
@@ -1028,14 +1030,14 @@
               "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
               "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
               "requires": {
-                "babel-messages": "6.23.0",
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0",
-                "detect-indent": "4.0.0",
-                "jsesc": "1.3.0",
-                "lodash": "4.17.10",
-                "source-map": "0.5.7",
-                "trim-right": "1.0.1"
+                "babel-messages": "^6.23.0",
+                "babel-runtime": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "detect-indent": "^4.0.0",
+                "jsesc": "^1.3.0",
+                "lodash": "^4.17.4",
+                "source-map": "^0.5.7",
+                "trim-right": "^1.0.1"
               }
             }
           }
@@ -1045,13 +1047,13 @@
           "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
           "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
           "requires": {
-            "babel-core": "6.26.3",
-            "babel-runtime": "6.26.0",
-            "core-js": "2.5.6",
-            "home-or-tmp": "2.0.0",
-            "lodash": "4.17.10",
-            "mkdirp": "0.5.1",
-            "source-map-support": "0.4.18"
+            "babel-core": "^6.26.0",
+            "babel-runtime": "^6.26.0",
+            "core-js": "^2.5.0",
+            "home-or-tmp": "^2.0.0",
+            "lodash": "^4.17.4",
+            "mkdirp": "^0.5.1",
+            "source-map-support": "^0.4.15"
           },
           "dependencies": {
             "babel-core": {
@@ -1059,25 +1061,25 @@
               "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
               "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
               "requires": {
-                "babel-code-frame": "6.26.0",
-                "babel-generator": "6.26.1",
-                "babel-helpers": "6.24.1",
-                "babel-messages": "6.23.0",
-                "babel-register": "6.26.0",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0",
-                "babylon": "6.18.0",
-                "convert-source-map": "1.5.1",
-                "debug": "2.6.9",
-                "json5": "0.5.1",
-                "lodash": "4.17.10",
-                "minimatch": "3.0.4",
-                "path-is-absolute": "1.0.1",
-                "private": "0.1.8",
-                "slash": "1.0.0",
-                "source-map": "0.5.7"
+                "babel-code-frame": "^6.26.0",
+                "babel-generator": "^6.26.0",
+                "babel-helpers": "^6.24.1",
+                "babel-messages": "^6.23.0",
+                "babel-register": "^6.26.0",
+                "babel-runtime": "^6.26.0",
+                "babel-template": "^6.26.0",
+                "babel-traverse": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "babylon": "^6.18.0",
+                "convert-source-map": "^1.5.1",
+                "debug": "^2.6.9",
+                "json5": "^0.5.1",
+                "lodash": "^4.17.4",
+                "minimatch": "^3.0.4",
+                "path-is-absolute": "^1.0.1",
+                "private": "^0.1.8",
+                "slash": "^1.0.0",
+                "source-map": "^0.5.7"
               }
             },
             "babel-generator": {
@@ -1085,14 +1087,14 @@
               "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
               "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
               "requires": {
-                "babel-messages": "6.23.0",
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0",
-                "detect-indent": "4.0.0",
-                "jsesc": "1.3.0",
-                "lodash": "4.17.10",
-                "source-map": "0.5.7",
-                "trim-right": "1.0.1"
+                "babel-messages": "^6.23.0",
+                "babel-runtime": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "detect-indent": "^4.0.0",
+                "jsesc": "^1.3.0",
+                "lodash": "^4.17.4",
+                "source-map": "^0.5.7",
+                "trim-right": "^1.0.1"
               }
             }
           }
@@ -1104,14 +1106,14 @@
       "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.24.1.tgz",
       "integrity": "sha1-5xX0hsWN7SVknYiJRNUqoHxdlJc=",
       "requires": {
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "detect-indent": "4.0.0",
-        "jsesc": "1.3.0",
-        "lodash": "4.17.10",
-        "source-map": "0.5.7",
-        "trim-right": "1.0.1"
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1",
+        "detect-indent": "^4.0.0",
+        "jsesc": "^1.3.0",
+        "lodash": "^4.2.0",
+        "source-map": "^0.5.0",
+        "trim-right": "^1.0.1"
       }
     },
     "babel-helper-builder-binary-assignment-operator-visitor": {
@@ -1119,9 +1121,9 @@
       "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
       "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
       "requires": {
-        "babel-helper-explode-assignable-expression": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-explode-assignable-expression": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-builder-react-jsx": {
@@ -1129,10 +1131,10 @@
       "resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.18.0.tgz",
       "integrity": "sha1-qwLxmi63rOk23Yf6VYltAr5Zv3E=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "esutils": "2.0.2",
-        "lodash": "4.17.10"
+        "babel-runtime": "^6.9.0",
+        "babel-types": "^6.18.0",
+        "esutils": "^2.0.0",
+        "lodash": "^4.2.0"
       }
     },
     "babel-helper-call-delegate": {
@@ -1140,10 +1142,10 @@
       "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
       "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
       "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-hoist-variables": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-define-map": {
@@ -1151,10 +1153,10 @@
       "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
       "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.10"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-helper-explode-assignable-expression": {
@@ -1162,9 +1164,9 @@
       "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
       "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-function-name": {
@@ -1172,11 +1174,11 @@
       "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
       "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
       "requires": {
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-get-function-arity": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-get-function-arity": {
@@ -1184,8 +1186,8 @@
       "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
       "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-hoist-variables": {
@@ -1193,8 +1195,8 @@
       "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
       "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-optimise-call-expression": {
@@ -1202,8 +1204,8 @@
       "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
       "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-regex": {
@@ -1211,9 +1213,9 @@
       "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
       "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.10"
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-helper-remap-async-to-generator": {
@@ -1221,11 +1223,11 @@
       "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
       "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-replace-supers": {
@@ -1233,12 +1235,12 @@
       "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
       "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
       "requires": {
-        "babel-helper-optimise-call-expression": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-optimise-call-expression": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helpers": {
@@ -1246,8 +1248,8 @@
       "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-messages": {
@@ -1255,7 +1257,7 @@
       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-check-es2015-constants": {
@@ -1263,7 +1265,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
       "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-external-helpers": {
@@ -1271,7 +1273,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-external-helpers/-/babel-plugin-external-helpers-6.22.0.tgz",
       "integrity": "sha1-IoX0iwK9Xe3oUXXK+MYuhq3M76E=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-react-transform": {
@@ -1279,7 +1281,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-react-transform/-/babel-plugin-react-transform-3.0.0.tgz",
       "integrity": "sha512-4vJGddwPiHAOgshzZdGwYy4zRjjIr5SMY7gkOaCyIASjgpcsyLTlZNuB5rHOFoaTvGlhfo8/g4pobXPyHqm/3w==",
       "requires": {
-        "lodash": "4.17.10"
+        "lodash": "^4.6.1"
       }
     },
     "babel-plugin-syntax-async-functions": {
@@ -1327,9 +1329,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.16.0.tgz",
       "integrity": "sha1-Gew2yxSGtZ+fRorfpCzhOQjKKZk=",
       "requires": {
-        "babel-helper-remap-async-to-generator": "6.24.1",
-        "babel-plugin-syntax-async-functions": "6.13.0",
-        "babel-runtime": "6.26.0"
+        "babel-helper-remap-async-to-generator": "^6.16.0",
+        "babel-plugin-syntax-async-functions": "^6.8.0",
+        "babel-runtime": "^6.0.0"
       }
     },
     "babel-plugin-transform-class-properties": {
@@ -1337,10 +1339,10 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz",
       "integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-plugin-syntax-class-properties": "6.13.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-plugin-syntax-class-properties": "^6.8.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-arrow-functions": {
@@ -1348,7 +1350,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
       "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoped-functions": {
@@ -1356,7 +1358,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
       "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoping": {
@@ -1364,11 +1366,11 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.15.0.tgz",
       "integrity": "sha1-W0Q8oUK+jR22qMKuQvUZWLZrcPY=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.10"
+        "babel-runtime": "^6.9.0",
+        "babel-template": "^6.15.0",
+        "babel-traverse": "^6.15.0",
+        "babel-types": "^6.15.0",
+        "lodash": "^4.2.0"
       }
     },
     "babel-plugin-transform-es2015-classes": {
@@ -1376,15 +1378,15 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
       "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
       "requires": {
-        "babel-helper-define-map": "6.26.0",
-        "babel-helper-function-name": "6.24.1",
-        "babel-helper-optimise-call-expression": "6.24.1",
-        "babel-helper-replace-supers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-define-map": "^6.24.1",
+        "babel-helper-function-name": "^6.24.1",
+        "babel-helper-optimise-call-expression": "^6.24.1",
+        "babel-helper-replace-supers": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-computed-properties": {
@@ -1392,8 +1394,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
       "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-destructuring": {
@@ -1401,7 +1403,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
       "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-for-of": {
@@ -1409,7 +1411,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
       "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-function-name": {
@@ -1417,9 +1419,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
       "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-literals": {
@@ -1427,7 +1429,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
       "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
@@ -1435,10 +1437,10 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
       "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
       "requires": {
-        "babel-plugin-transform-strict-mode": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-plugin-transform-strict-mode": "^6.24.1",
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-types": "^6.26.0"
       }
     },
     "babel-plugin-transform-es2015-object-super": {
@@ -1446,8 +1448,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
       "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
       "requires": {
-        "babel-helper-replace-supers": "6.24.1",
-        "babel-runtime": "6.26.0"
+        "babel-helper-replace-supers": "^6.24.1",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-parameters": {
@@ -1455,12 +1457,12 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
       "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
       "requires": {
-        "babel-helper-call-delegate": "6.24.1",
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-call-delegate": "^6.24.1",
+        "babel-helper-get-function-arity": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
@@ -1468,8 +1470,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
       "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-spread": {
@@ -1477,7 +1479,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
       "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-sticky-regex": {
@@ -1485,9 +1487,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
       "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
       "requires": {
-        "babel-helper-regex": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-regex": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-template-literals": {
@@ -1495,7 +1497,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
       "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-unicode-regex": {
@@ -1503,9 +1505,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
       "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
       "requires": {
-        "babel-helper-regex": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "regexpu-core": "2.0.0"
+        "babel-helper-regex": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "regexpu-core": "^2.0.0"
       }
     },
     "babel-plugin-transform-es3-member-expression-literals": {
@@ -1513,7 +1515,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es3-member-expression-literals/-/babel-plugin-transform-es3-member-expression-literals-6.22.0.tgz",
       "integrity": "sha1-cz00RPPsxBvvjtGmpOCWV7iWnrs=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es3-property-literals": {
@@ -1521,7 +1523,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es3-property-literals/-/babel-plugin-transform-es3-property-literals-6.22.0.tgz",
       "integrity": "sha1-sgeNWELiKr9A9z6M3pzTcRq9V1g=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-exponentiation-operator": {
@@ -1529,9 +1531,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
       "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
       "requires": {
-        "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
-        "babel-plugin-syntax-exponentiation-operator": "6.13.0",
-        "babel-runtime": "6.26.0"
+        "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
+        "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-flow-strip-types": {
@@ -1539,8 +1541,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
       "integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
       "requires": {
-        "babel-plugin-syntax-flow": "6.18.0",
-        "babel-runtime": "6.26.0"
+        "babel-plugin-syntax-flow": "^6.18.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-object-assign": {
@@ -1548,7 +1550,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-assign/-/babel-plugin-transform-object-assign-6.22.0.tgz",
       "integrity": "sha1-+Z0vZvGgsNSY40bFNZaEdAyqILo=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-object-rest-spread": {
@@ -1556,8 +1558,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
       "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
       "requires": {
-        "babel-plugin-syntax-object-rest-spread": "6.13.0",
-        "babel-runtime": "6.26.0"
+        "babel-plugin-syntax-object-rest-spread": "^6.8.0",
+        "babel-runtime": "^6.26.0"
       }
     },
     "babel-plugin-transform-react-display-name": {
@@ -1565,7 +1567,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz",
       "integrity": "sha1-Z+K/Hx6ck6sI25Z5LgU5K/LMKNE=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-react-jsx": {
@@ -1573,9 +1575,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.24.1.tgz",
       "integrity": "sha1-hAoCjn30YN/DotKfDA2R9jduZqM=",
       "requires": {
-        "babel-helper-builder-react-jsx": "6.26.0",
-        "babel-plugin-syntax-jsx": "6.18.0",
-        "babel-runtime": "6.26.0"
+        "babel-helper-builder-react-jsx": "^6.24.1",
+        "babel-plugin-syntax-jsx": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       },
       "dependencies": {
         "babel-helper-builder-react-jsx": {
@@ -1583,9 +1585,9 @@
           "resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.26.0.tgz",
           "integrity": "sha1-Of+DE7dci2Xc7/HzHTg+D/KkCKA=",
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "esutils": "2.0.2"
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "esutils": "^2.0.2"
           }
         }
       }
@@ -1595,8 +1597,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.22.0.tgz",
       "integrity": "sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY=",
       "requires": {
-        "babel-plugin-syntax-jsx": "6.18.0",
-        "babel-runtime": "6.26.0"
+        "babel-plugin-syntax-jsx": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-regenerator": {
@@ -1604,7 +1606,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
       "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
       "requires": {
-        "regenerator-transform": "0.10.1"
+        "regenerator-transform": "^0.10.0"
       }
     },
     "babel-plugin-transform-strict-mode": {
@@ -1612,8 +1614,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
       "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-preset-es2015-node": {
@@ -1621,15 +1623,15 @@
       "resolved": "https://registry.npmjs.org/babel-preset-es2015-node/-/babel-preset-es2015-node-6.1.1.tgz",
       "integrity": "sha1-YLIxVwJLDP6/OmNVTLBe4DW05V8=",
       "requires": {
-        "babel-plugin-transform-es2015-destructuring": "6.23.0",
-        "babel-plugin-transform-es2015-function-name": "6.24.1",
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
-        "babel-plugin-transform-es2015-parameters": "6.24.1",
-        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-        "babel-plugin-transform-es2015-spread": "6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-        "semver": "5.5.0"
+        "babel-plugin-transform-es2015-destructuring": "6.x",
+        "babel-plugin-transform-es2015-function-name": "6.x",
+        "babel-plugin-transform-es2015-modules-commonjs": "6.x",
+        "babel-plugin-transform-es2015-parameters": "6.x",
+        "babel-plugin-transform-es2015-shorthand-properties": "6.x",
+        "babel-plugin-transform-es2015-spread": "6.x",
+        "babel-plugin-transform-es2015-sticky-regex": "6.x",
+        "babel-plugin-transform-es2015-unicode-regex": "6.x",
+        "semver": "5.x"
       }
     },
     "babel-preset-fbjs": {
@@ -1637,34 +1639,34 @@
       "resolved": "https://registry.npmjs.org/babel-preset-fbjs/-/babel-preset-fbjs-2.1.4.tgz",
       "integrity": "sha512-6XVQwlO26V5/0P9s2Eje8Epqkv/ihaMJ798+W98ktOA8fCn2IFM6wEi7CDW3fTbKFZ/8fDGvGZH01B6GSuNiWA==",
       "requires": {
-        "babel-plugin-check-es2015-constants": "6.22.0",
-        "babel-plugin-syntax-class-properties": "6.13.0",
-        "babel-plugin-syntax-flow": "6.18.0",
-        "babel-plugin-syntax-jsx": "6.18.0",
-        "babel-plugin-syntax-object-rest-spread": "6.13.0",
-        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
-        "babel-plugin-transform-class-properties": "6.24.1",
-        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "6.15.0",
-        "babel-plugin-transform-es2015-classes": "6.24.1",
-        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
-        "babel-plugin-transform-es2015-destructuring": "6.23.0",
-        "babel-plugin-transform-es2015-for-of": "6.23.0",
-        "babel-plugin-transform-es2015-function-name": "6.24.1",
-        "babel-plugin-transform-es2015-literals": "6.22.0",
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
-        "babel-plugin-transform-es2015-object-super": "6.24.1",
-        "babel-plugin-transform-es2015-parameters": "6.24.1",
-        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-        "babel-plugin-transform-es2015-spread": "6.22.0",
-        "babel-plugin-transform-es2015-template-literals": "6.22.0",
-        "babel-plugin-transform-es3-member-expression-literals": "6.22.0",
-        "babel-plugin-transform-es3-property-literals": "6.22.0",
-        "babel-plugin-transform-flow-strip-types": "6.22.0",
-        "babel-plugin-transform-object-rest-spread": "6.26.0",
-        "babel-plugin-transform-react-display-name": "6.25.0",
-        "babel-plugin-transform-react-jsx": "6.24.1"
+        "babel-plugin-check-es2015-constants": "^6.8.0",
+        "babel-plugin-syntax-class-properties": "^6.8.0",
+        "babel-plugin-syntax-flow": "^6.8.0",
+        "babel-plugin-syntax-jsx": "^6.8.0",
+        "babel-plugin-syntax-object-rest-spread": "^6.8.0",
+        "babel-plugin-syntax-trailing-function-commas": "^6.8.0",
+        "babel-plugin-transform-class-properties": "^6.8.0",
+        "babel-plugin-transform-es2015-arrow-functions": "^6.8.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "^6.8.0",
+        "babel-plugin-transform-es2015-block-scoping": "^6.8.0",
+        "babel-plugin-transform-es2015-classes": "^6.8.0",
+        "babel-plugin-transform-es2015-computed-properties": "^6.8.0",
+        "babel-plugin-transform-es2015-destructuring": "^6.8.0",
+        "babel-plugin-transform-es2015-for-of": "^6.8.0",
+        "babel-plugin-transform-es2015-function-name": "^6.8.0",
+        "babel-plugin-transform-es2015-literals": "^6.8.0",
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.8.0",
+        "babel-plugin-transform-es2015-object-super": "^6.8.0",
+        "babel-plugin-transform-es2015-parameters": "^6.8.0",
+        "babel-plugin-transform-es2015-shorthand-properties": "^6.8.0",
+        "babel-plugin-transform-es2015-spread": "^6.8.0",
+        "babel-plugin-transform-es2015-template-literals": "^6.8.0",
+        "babel-plugin-transform-es3-member-expression-literals": "^6.8.0",
+        "babel-plugin-transform-es3-property-literals": "^6.8.0",
+        "babel-plugin-transform-flow-strip-types": "^6.8.0",
+        "babel-plugin-transform-object-rest-spread": "^6.8.0",
+        "babel-plugin-transform-react-display-name": "^6.8.0",
+        "babel-plugin-transform-react-jsx": "^6.8.0"
       }
     },
     "babel-preset-react-native": {
@@ -1672,37 +1674,37 @@
       "resolved": "https://registry.npmjs.org/babel-preset-react-native/-/babel-preset-react-native-4.0.0.tgz",
       "integrity": "sha512-Wfbo6x244nUbBxjr7hQaNFdjj7FDYU+TVT7cFVPEdVPI68vhN52iLvamm+ErhNdHq6M4j1cMT6AJBYx7Wzdr0g==",
       "requires": {
-        "babel-plugin-check-es2015-constants": "6.22.0",
-        "babel-plugin-react-transform": "3.0.0",
-        "babel-plugin-syntax-async-functions": "6.13.0",
-        "babel-plugin-syntax-class-properties": "6.13.0",
-        "babel-plugin-syntax-dynamic-import": "6.18.0",
-        "babel-plugin-syntax-flow": "6.18.0",
-        "babel-plugin-syntax-jsx": "6.18.0",
-        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
-        "babel-plugin-transform-class-properties": "6.24.1",
-        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "6.15.0",
-        "babel-plugin-transform-es2015-classes": "6.24.1",
-        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
-        "babel-plugin-transform-es2015-destructuring": "6.23.0",
-        "babel-plugin-transform-es2015-for-of": "6.23.0",
-        "babel-plugin-transform-es2015-function-name": "6.24.1",
-        "babel-plugin-transform-es2015-literals": "6.22.0",
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
-        "babel-plugin-transform-es2015-parameters": "6.24.1",
-        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-        "babel-plugin-transform-es2015-spread": "6.22.0",
-        "babel-plugin-transform-es2015-template-literals": "6.22.0",
-        "babel-plugin-transform-flow-strip-types": "6.22.0",
-        "babel-plugin-transform-object-assign": "6.22.0",
-        "babel-plugin-transform-object-rest-spread": "6.26.0",
-        "babel-plugin-transform-react-display-name": "6.25.0",
-        "babel-plugin-transform-react-jsx": "6.24.1",
-        "babel-plugin-transform-react-jsx-source": "6.22.0",
-        "babel-plugin-transform-regenerator": "6.26.0",
-        "babel-template": "6.26.0",
-        "react-transform-hmr": "1.0.4"
+        "babel-plugin-check-es2015-constants": "^6.5.0",
+        "babel-plugin-react-transform": "^3.0.0",
+        "babel-plugin-syntax-async-functions": "^6.5.0",
+        "babel-plugin-syntax-class-properties": "^6.5.0",
+        "babel-plugin-syntax-dynamic-import": "^6.18.0",
+        "babel-plugin-syntax-flow": "^6.5.0",
+        "babel-plugin-syntax-jsx": "^6.5.0",
+        "babel-plugin-syntax-trailing-function-commas": "^6.5.0",
+        "babel-plugin-transform-class-properties": "^6.5.0",
+        "babel-plugin-transform-es2015-arrow-functions": "^6.5.0",
+        "babel-plugin-transform-es2015-block-scoping": "^6.5.0",
+        "babel-plugin-transform-es2015-classes": "^6.5.0",
+        "babel-plugin-transform-es2015-computed-properties": "^6.5.0",
+        "babel-plugin-transform-es2015-destructuring": "^6.5.0",
+        "babel-plugin-transform-es2015-for-of": "^6.5.0",
+        "babel-plugin-transform-es2015-function-name": "^6.5.0",
+        "babel-plugin-transform-es2015-literals": "^6.5.0",
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.5.0",
+        "babel-plugin-transform-es2015-parameters": "^6.5.0",
+        "babel-plugin-transform-es2015-shorthand-properties": "^6.5.0",
+        "babel-plugin-transform-es2015-spread": "^6.5.0",
+        "babel-plugin-transform-es2015-template-literals": "^6.5.0",
+        "babel-plugin-transform-flow-strip-types": "^6.5.0",
+        "babel-plugin-transform-object-assign": "^6.5.0",
+        "babel-plugin-transform-object-rest-spread": "^6.5.0",
+        "babel-plugin-transform-react-display-name": "^6.5.0",
+        "babel-plugin-transform-react-jsx": "^6.5.0",
+        "babel-plugin-transform-react-jsx-source": "^6.5.0",
+        "babel-plugin-transform-regenerator": "^6.5.0",
+        "babel-template": "^6.24.1",
+        "react-transform-hmr": "^1.0.4"
       }
     },
     "babel-register": {
@@ -1710,13 +1712,13 @@
       "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.18.0.tgz",
       "integrity": "sha1-iS4uA4ZQeN2QrSxxURHsREmzKmg=",
       "requires": {
-        "babel-core": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "core-js": "2.5.6",
-        "home-or-tmp": "2.0.0",
-        "lodash": "4.17.10",
-        "mkdirp": "0.5.1",
-        "source-map-support": "0.4.18"
+        "babel-core": "^6.18.0",
+        "babel-runtime": "^6.11.6",
+        "core-js": "^2.4.0",
+        "home-or-tmp": "^2.0.0",
+        "lodash": "^4.2.0",
+        "mkdirp": "^0.5.1",
+        "source-map-support": "^0.4.2"
       }
     },
     "babel-runtime": {
@@ -1724,8 +1726,8 @@
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "requires": {
-        "core-js": "2.5.6",
-        "regenerator-runtime": "0.11.1"
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
       }
     },
     "babel-template": {
@@ -1733,11 +1735,11 @@
       "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
       "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "lodash": "4.17.10"
+        "babel-runtime": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-traverse": {
@@ -1745,15 +1747,15 @@
       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "debug": "2.6.9",
-        "globals": "9.18.0",
-        "invariant": "2.2.4",
-        "lodash": "4.17.10"
+        "babel-code-frame": "^6.26.0",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "debug": "^2.6.8",
+        "globals": "^9.18.0",
+        "invariant": "^2.2.2",
+        "lodash": "^4.17.4"
       }
     },
     "babel-types": {
@@ -1761,10 +1763,10 @@
       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "esutils": "2.0.2",
-        "lodash": "4.17.10",
-        "to-fast-properties": "1.0.3"
+        "babel-runtime": "^6.26.0",
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.4",
+        "to-fast-properties": "^1.0.3"
       }
     },
     "babylon": {
@@ -1782,13 +1784,13 @@
       "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
       "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "requires": {
-        "cache-base": "1.0.1",
-        "class-utils": "0.3.6",
-        "component-emitter": "1.2.1",
-        "define-property": "1.0.0",
-        "isobject": "3.0.1",
-        "mixin-deep": "1.3.1",
-        "pascalcase": "0.1.1"
+        "cache-base": "^1.0.1",
+        "class-utils": "^0.3.5",
+        "component-emitter": "^1.2.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "mixin-deep": "^1.2.0",
+        "pascalcase": "^0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -1796,7 +1798,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "requires": {
-            "is-descriptor": "1.0.2"
+            "is-descriptor": "^1.0.0"
           }
         },
         "is-accessor-descriptor": {
@@ -1804,7 +1806,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -1812,7 +1814,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -1820,9 +1822,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         }
       }
@@ -1858,7 +1860,7 @@
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "optional": true,
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       }
     },
     "big-integer": {
@@ -1867,14 +1869,15 @@
       "integrity": "sha512-ljKJdR3wk9thHfLj4DtrNiOSTxvGFaMjWrG4pW75juXC4j7+XuKJVFdg4kgFMYp85PVkO05dFMj2dk2xVsH4xw=="
     },
     "bignumber.js": {
-      "version": "github:status-im/bignumber.js#cc066a0a3d6bfe0c436c9957f4ea8344bf963c89"
+      "version": "git+ssh://git@github.com/status-im/bignumber.js.git#cc066a0a3d6bfe0c436c9957f4ea8344bf963c89",
+      "from": "git+ssh://git@github.com/status-im/bignumber.js.git"
     },
     "bl": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/bl/-/bl-0.8.2.tgz",
       "integrity": "sha1-yba8oI0bwuoA/Ir7Txpf0eHGbk4=",
       "requires": {
-        "readable-stream": "1.0.34"
+        "readable-stream": "~1.0.26"
       },
       "dependencies": {
         "isarray": {
@@ -1887,10 +1890,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.1",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         }
       }
@@ -1900,7 +1903,7 @@
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
       "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
       "requires": {
-        "inherits": "2.0.1"
+        "inherits": "~2.0.0"
       }
     },
     "bn.js": {
@@ -1909,11 +1912,11 @@
       "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
     },
     "boom": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
-      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
       "requires": {
-        "hoek": "4.2.1"
+        "hoek": "2.x.x"
       }
     },
     "bower-config": {
@@ -1921,11 +1924,11 @@
       "resolved": "https://registry.npmjs.org/bower-config/-/bower-config-1.4.1.tgz",
       "integrity": "sha1-hf2d82fCuNu9DKpMXyutQM2Ewsw=",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "mout": "1.1.0",
-        "optimist": "0.6.1",
-        "osenv": "0.1.5",
-        "untildify": "2.1.0"
+        "graceful-fs": "^4.1.3",
+        "mout": "^1.0.0",
+        "optimist": "^0.6.1",
+        "osenv": "^0.1.3",
+        "untildify": "^2.1.0"
       }
     },
     "bplist-creator": {
@@ -1933,7 +1936,7 @@
       "resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.0.7.tgz",
       "integrity": "sha1-N98VNgkoJLh8QvlXsBNEEXNyrkU=",
       "requires": {
-        "stream-buffers": "2.2.0"
+        "stream-buffers": "~2.2.0"
       }
     },
     "bplist-parser": {
@@ -1941,7 +1944,7 @@
       "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.1.1.tgz",
       "integrity": "sha1-1g1dzCDLptx+HymbNdPh+V2vuuY=",
       "requires": {
-        "big-integer": "1.6.32"
+        "big-integer": "^1.6.7"
       }
     },
     "brace-expansion": {
@@ -1949,7 +1952,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -1958,16 +1961,16 @@
       "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
       "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
       "requires": {
-        "arr-flatten": "1.1.0",
-        "array-unique": "0.3.2",
-        "extend-shallow": "2.0.1",
-        "fill-range": "4.0.0",
-        "isobject": "3.0.1",
-        "repeat-element": "1.1.2",
-        "snapdragon": "0.8.2",
-        "snapdragon-node": "2.1.1",
-        "split-string": "3.1.0",
-        "to-regex": "3.0.2"
+        "arr-flatten": "^1.1.0",
+        "array-unique": "^0.3.2",
+        "extend-shallow": "^2.0.1",
+        "fill-range": "^4.0.0",
+        "isobject": "^3.0.1",
+        "repeat-element": "^1.1.2",
+        "snapdragon": "^0.8.1",
+        "snapdragon-node": "^2.0.1",
+        "split-string": "^3.0.2",
+        "to-regex": "^3.0.1"
       },
       "dependencies": {
         "extend-shallow": {
@@ -1975,7 +1978,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -1990,12 +1993,12 @@
       "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "requires": {
-        "buffer-xor": "1.0.3",
-        "cipher-base": "1.0.4",
-        "create-hash": "1.2.0",
-        "evp_bytestokey": "1.0.3",
-        "inherits": "2.0.1",
-        "safe-buffer": "5.1.2"
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "browserify-cipher": {
@@ -2003,9 +2006,9 @@
       "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
       "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
       "requires": {
-        "browserify-aes": "1.2.0",
-        "browserify-des": "1.0.1",
-        "evp_bytestokey": "1.0.3"
+        "browserify-aes": "^1.0.4",
+        "browserify-des": "^1.0.0",
+        "evp_bytestokey": "^1.0.0"
       }
     },
     "browserify-des": {
@@ -2013,9 +2016,9 @@
       "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.1.tgz",
       "integrity": "sha512-zy0Cobe3hhgpiOM32Tj7KQ3Vl91m0njwsjzZQK1L+JDf11dzP9qIvjreVinsvXrgfjhStXwUWAEpB9D7Gwmayw==",
       "requires": {
-        "cipher-base": "1.0.4",
-        "des.js": "1.0.0",
-        "inherits": "2.0.1"
+        "cipher-base": "^1.0.1",
+        "des.js": "^1.0.0",
+        "inherits": "^2.0.1"
       }
     },
     "browserify-rsa": {
@@ -2023,8 +2026,8 @@
       "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "requires": {
-        "bn.js": "4.11.8",
-        "randombytes": "2.0.6"
+        "bn.js": "^4.1.0",
+        "randombytes": "^2.0.1"
       }
     },
     "browserify-sign": {
@@ -2032,13 +2035,13 @@
       "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
       "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
       "requires": {
-        "bn.js": "4.11.8",
-        "browserify-rsa": "4.0.1",
-        "create-hash": "1.2.0",
-        "create-hmac": "1.1.7",
-        "elliptic": "6.4.0",
-        "inherits": "2.0.1",
-        "parse-asn1": "5.1.1"
+        "bn.js": "^4.1.1",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.2",
+        "elliptic": "^6.0.0",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^5.0.0"
       }
     },
     "bser": {
@@ -2046,7 +2049,7 @@
       "resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
       "integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
       "requires": {
-        "node-int64": "0.4.0"
+        "node-int64": "^0.4.0"
       }
     },
     "buffer": {
@@ -2055,23 +2058,23 @@
       "integrity": "sha1-pyyTb3e5a/UvX357RnGAYoVR3vs=",
       "requires": {
         "base64-js": "0.0.8",
-        "ieee754": "1.1.11",
-        "isarray": "1.0.0"
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
       }
     },
     "buffer-alloc": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.1.0.tgz",
-      "integrity": "sha1-BVFNM78WVtNUDGhPZbEgLpDsowM=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
       "requires": {
-        "buffer-alloc-unsafe": "0.1.1",
-        "buffer-fill": "0.1.1"
+        "buffer-alloc-unsafe": "^1.1.0",
+        "buffer-fill": "^1.0.0"
       }
     },
     "buffer-alloc-unsafe": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-0.1.1.tgz",
-      "integrity": "sha1-/+H2dVHdBVc33iUzN7/oU9+rGmo="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
     },
     "buffer-crc32": {
       "version": "0.2.13",
@@ -2079,14 +2082,14 @@
       "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
     },
     "buffer-fill": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-0.1.1.tgz",
-      "integrity": "sha512-YgBMBzdRLEfgxJIGu2wrvI2E03tMCFU1p7d1KhB4BOoMN0VxmTFjSyN5JtKt9z8Z9JajMHruI6SE25W96wNv7Q=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw="
     },
     "buffer-from": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
-      "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz",
+      "integrity": "sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ=="
     },
     "buffer-xor": {
       "version": "1.0.3",
@@ -2108,15 +2111,15 @@
       "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
       "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "requires": {
-        "collection-visit": "1.0.0",
-        "component-emitter": "1.2.1",
-        "get-value": "2.0.6",
-        "has-value": "1.0.0",
-        "isobject": "3.0.1",
-        "set-value": "2.0.0",
-        "to-object-path": "0.3.0",
-        "union-value": "1.0.0",
-        "unset-value": "1.0.0"
+        "collection-visit": "^1.0.0",
+        "component-emitter": "^1.2.1",
+        "get-value": "^2.0.6",
+        "has-value": "^1.0.0",
+        "isobject": "^3.0.1",
+        "set-value": "^2.0.0",
+        "to-object-path": "^0.3.0",
+        "union-value": "^1.0.0",
+        "unset-value": "^1.0.0"
       }
     },
     "camelcase": {
@@ -2130,7 +2133,7 @@
       "resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-1.2.0.tgz",
       "integrity": "sha1-HF/MSJ/QqwDU8ax64QcuMXP7q28=",
       "requires": {
-        "rsvp": "3.6.2"
+        "rsvp": "^3.3.3"
       }
     },
     "caseless": {
@@ -2144,8 +2147,8 @@
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
       "optional": true,
       "requires": {
-        "align-text": "0.1.4",
-        "lazy-cache": "1.0.4"
+        "align-text": "^0.1.3",
+        "lazy-cache": "^1.0.3"
       }
     },
     "chalk": {
@@ -2153,11 +2156,11 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "requires": {
-        "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
       }
     },
     "chance": {
@@ -2175,12 +2178,12 @@
       "resolved": "https://registry.npmjs.org/check-dependencies/-/check-dependencies-1.1.0.tgz",
       "integrity": "sha512-GDrbGzzJ6Gc6tQh87HBMGhrJ4UWIlR9MKJwgvlrJyj/gWvTYYb2jQetKbajt/EYK5Y8/4g7gH2LEvq8GdUWTag==",
       "requires": {
-        "bower-config": "1.4.1",
-        "chalk": "2.4.1",
-        "findup-sync": "2.0.0",
-        "lodash.camelcase": "4.3.0",
-        "minimist": "1.2.0",
-        "semver": "5.5.0"
+        "bower-config": "^1.4.0",
+        "chalk": "^2.1.0",
+        "findup-sync": "^2.0.0",
+        "lodash.camelcase": "^4.3.0",
+        "minimist": "^1.2.0",
+        "semver": "^5.4.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -2188,7 +2191,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -2196,9 +2199,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "minimist": {
@@ -2211,7 +2214,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -2221,8 +2224,8 @@
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "requires": {
-        "inherits": "2.0.1",
-        "safe-buffer": "5.1.2"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "class-utils": {
@@ -2230,10 +2233,10 @@
       "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
       "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
       "requires": {
-        "arr-union": "3.1.0",
-        "define-property": "0.2.5",
-        "isobject": "3.0.1",
-        "static-extend": "0.1.2"
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "static-extend": "^0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -2241,7 +2244,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         }
       }
@@ -2251,7 +2254,7 @@
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "requires": {
-        "restore-cursor": "2.0.0"
+        "restore-cursor": "^2.0.0"
       }
     },
     "cli-width": {
@@ -2264,8 +2267,8 @@
       "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-1.2.3.tgz",
       "integrity": "sha512-2WNImOvCRe6r63Gk9pShfkwXsVtKCroMAevIbiae021mS850UkWPbevxsBz3tnvjZIEGvlwaqCPsw+4ulzNgJA==",
       "requires": {
-        "arch": "2.1.1",
-        "execa": "0.8.0"
+        "arch": "^2.1.0",
+        "execa": "^0.8.0"
       }
     },
     "cliui": {
@@ -2274,8 +2277,8 @@
       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
       "optional": true,
       "requires": {
-        "center-align": "0.1.3",
-        "right-align": "0.1.3",
+        "center-align": "^0.1.1",
+        "right-align": "^0.1.1",
         "wordwrap": "0.0.2"
       },
       "dependencies": {
@@ -2312,8 +2315,8 @@
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "requires": {
-        "map-visit": "1.0.0",
-        "object-visit": "1.0.1"
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
       }
     },
     "color": {
@@ -2321,30 +2324,30 @@
       "resolved": "https://registry.npmjs.org/color/-/color-2.0.1.tgz",
       "integrity": "sha512-ubUCVVKfT7r2w2D3qtHakj8mbmKms+tThR8gI8zEYCbUBl8/voqFGt3kgBqGwXAopgXybnkuOq+qMYCRrp4cXw==",
       "requires": {
-        "color-convert": "1.9.1",
-        "color-string": "1.5.2"
+        "color-convert": "^1.9.1",
+        "color-string": "^1.5.2"
       }
     },
     "color-convert": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.2.tgz",
+      "integrity": "sha512-3NUJZdhMhcdPn8vJ9v2UQJoH0qqoGUkYTgFEPZaPjEtwmmKUfNV46zZmgB2M5M4DCEQHMaCfWHCxiBflLm04Tg==",
       "requires": {
-        "color-name": "1.1.3"
+        "color-name": "1.1.1"
       }
     },
     "color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok="
     },
     "color-string": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.2.tgz",
       "integrity": "sha1-JuRYFLw8mny9Z1FkikFDRRSnc6k=",
       "requires": {
-        "color-name": "1.1.3",
-        "simple-swizzle": "0.2.2"
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
       }
     },
     "color-support": {
@@ -2357,7 +2360,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
     },
     "command-line-args": {
@@ -2365,9 +2368,9 @@
       "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-4.0.7.tgz",
       "integrity": "sha512-aUdPvQRAyBvQd2n7jXcsMDz68ckBJELXNzBybCHOibUWEg0mWTnaYCSRU8h9R+aNRSvDihJtssSRCiDRpLaezA==",
       "requires": {
-        "array-back": "2.0.0",
-        "find-replace": "1.0.3",
-        "typical": "2.6.1"
+        "array-back": "^2.0.0",
+        "find-replace": "^1.0.3",
+        "typical": "^2.6.1"
       }
     },
     "commander": {
@@ -2390,7 +2393,7 @@
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.14.tgz",
       "integrity": "sha1-MmxfUH+7BV9UEWeCuWmoG2einac=",
       "requires": {
-        "mime-db": "1.34.0"
+        "mime-db": ">= 1.34.0 < 2"
       },
       "dependencies": {
         "mime-db": {
@@ -2405,13 +2408,13 @@
       "resolved": "http://registry.npmjs.org/compression/-/compression-1.7.2.tgz",
       "integrity": "sha1-qv+81qr4VLROuygDU9WtFlH1mmk=",
       "requires": {
-        "accepts": "1.3.5",
+        "accepts": "~1.3.4",
         "bytes": "3.0.0",
-        "compressible": "2.0.14",
+        "compressible": "~2.0.13",
         "debug": "2.6.9",
-        "on-headers": "1.0.1",
+        "on-headers": "~1.0.1",
         "safe-buffer": "5.1.1",
-        "vary": "1.1.2"
+        "vary": "~1.1.2"
       },
       "dependencies": {
         "safe-buffer": {
@@ -2431,17 +2434,10 @@
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "requires": {
-        "buffer-from": "1.0.0",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6",
-        "typedarray": "0.0.6"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-        }
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
       }
     },
     "connect": {
@@ -2451,7 +2447,7 @@
       "requires": {
         "debug": "2.6.9",
         "finalhandler": "1.1.0",
-        "parseurl": "1.3.2",
+        "parseurl": "~1.3.2",
         "utils-merge": "1.0.1"
       }
     },
@@ -2471,9 +2467,9 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
     },
     "core-js": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.6.tgz",
-      "integrity": "sha512-lQUVfQi0aLix2xpyjrrJEvfuYCqPc/HwmTKsC/VNf8q0zsjX7SQZtp4+oRONN5Tsur9GDETPjj+Ub2iDiGZfSQ=="
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -2485,8 +2481,8 @@
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
       "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
       "requires": {
-        "bn.js": "4.11.8",
-        "elliptic": "6.4.0"
+        "bn.js": "^4.1.0",
+        "elliptic": "^6.0.0"
       }
     },
     "create-hash": {
@@ -2494,11 +2490,11 @@
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "requires": {
-        "cipher-base": "1.0.4",
-        "inherits": "2.0.1",
-        "md5.js": "1.3.4",
-        "ripemd160": "2.0.2",
-        "sha.js": "2.4.11"
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
       }
     },
     "create-hmac": {
@@ -2506,12 +2502,12 @@
       "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "requires": {
-        "cipher-base": "1.0.4",
-        "create-hash": "1.2.0",
-        "inherits": "2.0.1",
-        "ripemd160": "2.0.2",
-        "safe-buffer": "5.1.2",
-        "sha.js": "2.4.11"
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
       }
     },
     "create-react-class": {
@@ -2519,9 +2515,9 @@
       "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.2.tgz",
       "integrity": "sha1-zx7RXxKq1/FO9fLf4F5sQvke8Co=",
       "requires": {
-        "fbjs": "0.8.16",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1"
+        "fbjs": "^0.8.9",
+        "loose-envify": "^1.3.1",
+        "object-assign": "^4.1.1"
       }
     },
     "cross-spawn": {
@@ -2529,27 +2525,17 @@
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "requires": {
-        "lru-cache": "4.1.3",
-        "shebang-command": "1.2.0",
-        "which": "1.3.0"
+        "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
       }
     },
     "cryptiles": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
-      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
       "requires": {
-        "boom": "5.2.0"
-      },
-      "dependencies": {
-        "boom": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-          "requires": {
-            "hoek": "4.2.1"
-          }
-        }
+        "boom": "2.x.x"
       }
     },
     "crypto-js": {
@@ -2572,7 +2558,14 @@
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
       }
     },
     "debug": {
@@ -2598,14 +2591,21 @@
       "resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.0.tgz",
       "integrity": "sha1-eu3YVCflqS2s/lVnSnxQXpbQH50=",
       "requires": {
-        "decompress-tar": "4.1.1",
-        "decompress-tarbz2": "4.1.1",
-        "decompress-targz": "4.1.1",
-        "decompress-unzip": "4.0.1",
-        "graceful-fs": "4.1.11",
-        "make-dir": "1.3.0",
-        "pify": "2.3.0",
-        "strip-dirs": "2.1.0"
+        "decompress-tar": "^4.0.0",
+        "decompress-tarbz2": "^4.0.0",
+        "decompress-targz": "^4.0.0",
+        "decompress-unzip": "^4.0.1",
+        "graceful-fs": "^4.1.10",
+        "make-dir": "^1.0.0",
+        "pify": "^2.3.0",
+        "strip-dirs": "^2.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+        }
       }
     },
     "decompress-tar": {
@@ -2613,9 +2613,9 @@
       "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
       "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
       "requires": {
-        "file-type": "5.2.0",
-        "is-stream": "1.1.0",
-        "tar-stream": "1.6.1"
+        "file-type": "^5.2.0",
+        "is-stream": "^1.1.0",
+        "tar-stream": "^1.5.2"
       }
     },
     "decompress-tarbz2": {
@@ -2623,11 +2623,11 @@
       "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz",
       "integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
       "requires": {
-        "decompress-tar": "4.1.1",
-        "file-type": "6.2.0",
-        "is-stream": "1.1.0",
-        "seek-bzip": "1.0.5",
-        "unbzip2-stream": "1.2.5"
+        "decompress-tar": "^4.1.0",
+        "file-type": "^6.1.0",
+        "is-stream": "^1.1.0",
+        "seek-bzip": "^1.0.5",
+        "unbzip2-stream": "^1.0.9"
       },
       "dependencies": {
         "file-type": {
@@ -2642,9 +2642,9 @@
       "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz",
       "integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
       "requires": {
-        "decompress-tar": "4.1.1",
-        "file-type": "5.2.0",
-        "is-stream": "1.1.0"
+        "decompress-tar": "^4.1.1",
+        "file-type": "^5.2.0",
+        "is-stream": "^1.1.0"
       }
     },
     "decompress-unzip": {
@@ -2652,10 +2652,10 @@
       "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-4.0.1.tgz",
       "integrity": "sha1-3qrM39FK6vhVePczroIQ+bSEj2k=",
       "requires": {
-        "file-type": "3.9.0",
-        "get-stream": "2.3.1",
-        "pify": "2.3.0",
-        "yauzl": "2.9.1"
+        "file-type": "^3.8.0",
+        "get-stream": "^2.2.0",
+        "pify": "^2.3.0",
+        "yauzl": "^2.4.2"
       },
       "dependencies": {
         "file-type": {
@@ -2668,16 +2668,21 @@
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
           "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
           "requires": {
-            "object-assign": "4.1.1",
-            "pinkie-promise": "2.0.1"
+            "object-assign": "^4.0.1",
+            "pinkie-promise": "^2.0.0"
           }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
         }
       }
     },
     "deep-extend": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
-      "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w=="
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
     },
     "deepmerge": {
       "version": "1.5.2",
@@ -2689,7 +2694,7 @@
       "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-0.2.0.tgz",
       "integrity": "sha1-LO8fER4cV4cNi7uK8mUOWHzS9bQ=",
       "requires": {
-        "abstract-leveldown": "0.12.4"
+        "abstract-leveldown": "~0.12.1"
       },
       "dependencies": {
         "abstract-leveldown": {
@@ -2697,7 +2702,7 @@
           "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-0.12.4.tgz",
           "integrity": "sha1-KeGOYy5g5OIh1YECR4UqY9ey5BA=",
           "requires": {
-            "xtend": "3.0.0"
+            "xtend": "~3.0.0"
           }
         },
         "xtend": {
@@ -2712,14 +2717,14 @@
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
       "requires": {
-        "foreach": "2.0.5",
-        "object-keys": "1.0.11"
+        "foreach": "^2.0.5",
+        "object-keys": "^1.0.8"
       },
       "dependencies": {
         "object-keys": {
-          "version": "1.0.11",
-          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-          "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
+          "version": "1.0.12",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
+          "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag=="
         }
       }
     },
@@ -2728,8 +2733,8 @@
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
       "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
       "requires": {
-        "is-descriptor": "1.0.2",
-        "isobject": "3.0.1"
+        "is-descriptor": "^1.0.2",
+        "isobject": "^3.0.1"
       },
       "dependencies": {
         "is-accessor-descriptor": {
@@ -2737,7 +2742,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -2745,7 +2750,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -2753,9 +2758,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         }
       }
@@ -2785,8 +2790,8 @@
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
       "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
       "requires": {
-        "inherits": "2.0.1",
-        "minimalistic-assert": "1.0.1"
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "destroy": {
@@ -2804,7 +2809,7 @@
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
       "requires": {
-        "repeating": "2.0.1"
+        "repeating": "^2.0.0"
       }
     },
     "detect-libc": {
@@ -2822,9 +2827,9 @@
       "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "requires": {
-        "bn.js": "4.11.8",
-        "miller-rabin": "4.0.1",
-        "randombytes": "2.0.6"
+        "bn.js": "^4.1.0",
+        "miller-rabin": "^4.0.0",
+        "randombytes": "^2.0.0"
       }
     },
     "dns.js": {
@@ -2843,7 +2848,7 @@
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "optional": true,
       "requires": {
-        "jsbn": "0.1.1"
+        "jsbn": "~0.1.0"
       }
     },
     "ee-first": {
@@ -2856,13 +2861,13 @@
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
       "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
       "requires": {
-        "bn.js": "4.11.8",
-        "brorand": "1.1.0",
-        "hash.js": "1.1.3",
-        "hmac-drbg": "1.0.1",
-        "inherits": "2.0.1",
-        "minimalistic-assert": "1.0.1",
-        "minimalistic-crypto-utils": "1.0.1"
+        "bn.js": "^4.4.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.0"
       }
     },
     "emoji-regex": {
@@ -2885,7 +2890,7 @@
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
       "requires": {
-        "iconv-lite": "0.4.23"
+        "iconv-lite": "~0.4.13"
       }
     },
     "end-of-stream": {
@@ -2893,7 +2898,7 @@
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "requires": {
-        "once": "1.4.0"
+        "once": "^1.4.0"
       }
     },
     "envinfo": {
@@ -2901,11 +2906,11 @@
       "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-3.11.1.tgz",
       "integrity": "sha512-hKkh7aKtont6Zuv4RmE4VkOc96TkBj9NXj7Ghsd/qCA9LuJI0Dh+ImwA1N5iORB9Vg+sz5bq9CHJzs51BILNCQ==",
       "requires": {
-        "clipboardy": "1.2.3",
-        "glob": "7.1.2",
-        "minimist": "1.2.0",
-        "os-name": "2.0.1",
-        "which": "1.3.0"
+        "clipboardy": "^1.2.2",
+        "glob": "^7.1.2",
+        "minimist": "^1.2.0",
+        "os-name": "^2.0.1",
+        "which": "^1.2.14"
       },
       "dependencies": {
         "minimist": {
@@ -2920,7 +2925,7 @@
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
       "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
       "requires": {
-        "prr": "1.0.1"
+        "prr": "~1.0.1"
       }
     },
     "error-ex": {
@@ -2928,7 +2933,7 @@
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "requires": {
-        "is-arrayish": "0.2.1"
+        "is-arrayish": "^0.2.1"
       }
     },
     "errorhandler": {
@@ -2936,20 +2941,20 @@
       "resolved": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.5.0.tgz",
       "integrity": "sha1-6rpkyl1UKjEayUX1gt78M2Fl2fQ=",
       "requires": {
-        "accepts": "1.3.5",
-        "escape-html": "1.0.3"
+        "accepts": "~1.3.3",
+        "escape-html": "~1.0.3"
       }
     },
     "es-abstract": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.11.0.tgz",
-      "integrity": "sha512-ZnQrE/lXTTQ39ulXZ+J1DTFazV9qBy61x2bY071B+qGco8Z8q1QddsLdt/EF8Ai9hcWH72dWS0kFqXLxOxqslA==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
+      "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
       "requires": {
-        "es-to-primitive": "1.1.1",
-        "function-bind": "1.1.1",
-        "has": "1.0.1",
-        "is-callable": "1.1.3",
-        "is-regex": "1.0.4"
+        "es-to-primitive": "^1.1.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.1",
+        "is-callable": "^1.1.3",
+        "is-regex": "^1.0.4"
       }
     },
     "es-to-primitive": {
@@ -2957,9 +2962,9 @@
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
       "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
       "requires": {
-        "is-callable": "1.1.3",
-        "is-date-object": "1.0.1",
-        "is-symbol": "1.0.1"
+        "is-callable": "^1.1.1",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.1"
       }
     },
     "escape-html": {
@@ -2977,13 +2982,13 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-5.1.1.tgz",
       "integrity": "sha512-5I9SpoP7gT4wBFOtXT8/tXNPYohHBVfyVfO17vkbC7r9kEIxYJF12D3pKqhk8+xnk12rfxKClS3WCFpVckFTPQ==",
       "requires": {
-        "aria-query": "0.7.1",
-        "array-includes": "3.0.3",
+        "aria-query": "^0.7.0",
+        "array-includes": "^3.0.3",
         "ast-types-flow": "0.0.7",
-        "axobject-query": "0.1.0",
-        "damerau-levenshtein": "1.0.4",
-        "emoji-regex": "6.5.1",
-        "jsx-ast-utils": "1.4.1"
+        "axobject-query": "^0.1.0",
+        "damerau-levenshtein": "^1.0.0",
+        "emoji-regex": "^6.1.0",
+        "jsx-ast-utils": "^1.4.0"
       }
     },
     "eslint-plugin-react-native": {
@@ -2991,7 +2996,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-native/-/eslint-plugin-react-native-3.2.1.tgz",
       "integrity": "sha512-1AnJO3JUCAoLpyOEsWCwN9hPJ0aQ72OT+JvLMuHjEWYb6QWxiNOszp24CEwegMzbREtJKI9OoRqYYDYxMxmjgQ==",
       "requires": {
-        "eslint-plugin-react-native-globals": "0.1.2"
+        "eslint-plugin-react-native-globals": "^0.1.1"
       }
     },
     "eslint-plugin-react-native-globals": {
@@ -3029,8 +3034,8 @@
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
       "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
       "requires": {
-        "md5.js": "1.3.4",
-        "safe-buffer": "5.1.2"
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
       }
     },
     "exec-sh": {
@@ -3038,7 +3043,7 @@
       "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.2.tgz",
       "integrity": "sha512-FIUCJz1RbuS0FKTdaAafAByGS0CPvU3R0MeHxgtl+djzCc//F8HakL8GzmVNZanasTbTAY/3DRFA0KpVqj/eAw==",
       "requires": {
-        "merge": "1.2.0"
+        "merge": "^1.2.0"
       }
     },
     "execa": {
@@ -3046,13 +3051,13 @@
       "resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
       "integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
       "requires": {
-        "cross-spawn": "5.1.0",
-        "get-stream": "3.0.0",
-        "is-stream": "1.1.0",
-        "npm-run-path": "2.0.2",
-        "p-finally": "1.0.0",
-        "signal-exit": "3.0.2",
-        "strip-eof": "1.0.0"
+        "cross-spawn": "^5.0.1",
+        "get-stream": "^3.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
       }
     },
     "expand-brackets": {
@@ -3060,13 +3065,13 @@
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
       "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
       "requires": {
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "posix-character-classes": "0.1.1",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
+        "debug": "^2.3.3",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "posix-character-classes": "^0.1.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -3074,7 +3079,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "extend-shallow": {
@@ -3082,7 +3087,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -3092,7 +3097,7 @@
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "requires": {
-        "fill-range": "2.2.4"
+        "fill-range": "^2.1.0"
       },
       "dependencies": {
         "fill-range": {
@@ -3100,11 +3105,11 @@
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
           "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
           "requires": {
-            "is-number": "2.1.0",
-            "isobject": "2.1.0",
-            "randomatic": "3.0.0",
-            "repeat-element": "1.1.2",
-            "repeat-string": "1.6.1"
+            "is-number": "^2.1.0",
+            "isobject": "^2.0.0",
+            "randomatic": "^3.0.0",
+            "repeat-element": "^1.1.2",
+            "repeat-string": "^1.5.2"
           }
         },
         "is-number": {
@@ -3112,7 +3117,7 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
           "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           }
         },
         "isobject": {
@@ -3128,7 +3133,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -3138,7 +3143,7 @@
       "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
       "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
       "requires": {
-        "homedir-polyfill": "1.0.1"
+        "homedir-polyfill": "^1.0.1"
       }
     },
     "extend": {
@@ -3151,8 +3156,8 @@
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "requires": {
-        "assign-symbols": "1.0.0",
-        "is-extendable": "1.0.1"
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -3160,7 +3165,7 @@
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "requires": {
-            "is-plain-object": "2.0.4"
+            "is-plain-object": "^2.0.4"
           }
         }
       }
@@ -3170,9 +3175,9 @@
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
       "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
       "requires": {
-        "chardet": "0.4.2",
-        "iconv-lite": "0.4.23",
-        "tmp": "0.0.33"
+        "chardet": "^0.4.0",
+        "iconv-lite": "^0.4.17",
+        "tmp": "^0.0.33"
       }
     },
     "extglob": {
@@ -3180,14 +3185,14 @@
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
       "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
       "requires": {
-        "array-unique": "0.3.2",
-        "define-property": "1.0.0",
-        "expand-brackets": "2.1.4",
-        "extend-shallow": "2.0.1",
-        "fragment-cache": "0.2.1",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
+        "array-unique": "^0.3.2",
+        "define-property": "^1.0.0",
+        "expand-brackets": "^2.1.4",
+        "extend-shallow": "^2.0.1",
+        "fragment-cache": "^0.2.1",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -3195,7 +3200,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "requires": {
-            "is-descriptor": "1.0.2"
+            "is-descriptor": "^1.0.0"
           }
         },
         "extend-shallow": {
@@ -3203,7 +3208,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         },
         "is-accessor-descriptor": {
@@ -3211,7 +3216,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -3219,7 +3224,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -3227,9 +3232,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         }
       }
@@ -3244,9 +3249,9 @@
       "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
       "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
       "requires": {
-        "ansi-gray": "0.1.1",
-        "color-support": "1.1.3",
-        "time-stamp": "1.1.0"
+        "ansi-gray": "^0.1.1",
+        "color-support": "^1.1.3",
+        "time-stamp": "^1.0.0"
       }
     },
     "fast-deep-equal": {
@@ -3264,21 +3269,21 @@
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
       "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
       "requires": {
-        "bser": "2.0.0"
+        "bser": "^2.0.0"
       }
     },
     "fbjs": {
-      "version": "0.8.16",
-      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
-      "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
+      "version": "0.8.17",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
+      "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
       "requires": {
-        "core-js": "1.2.7",
-        "isomorphic-fetch": "2.2.1",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1",
-        "promise": "7.3.1",
-        "setimmediate": "1.0.5",
-        "ua-parser-js": "0.7.18"
+        "core-js": "^1.0.0",
+        "isomorphic-fetch": "^2.1.1",
+        "loose-envify": "^1.0.0",
+        "object-assign": "^4.1.0",
+        "promise": "^7.1.1",
+        "setimmediate": "^1.0.5",
+        "ua-parser-js": "^0.7.18"
       },
       "dependencies": {
         "core-js": {
@@ -3293,24 +3298,24 @@
       "resolved": "https://registry.npmjs.org/fbjs-scripts/-/fbjs-scripts-0.8.3.tgz",
       "integrity": "sha512-aUJ/uEzMIiBYuj/blLp4sVNkQQ7ZEB/lyplG1IzzOmZ83meiWecrGg5jBo4wWrxXmO4RExdtsSV1QkTjPt2Gag==",
       "requires": {
-        "ansi-colors": "1.1.0",
-        "babel-core": "6.24.1",
-        "babel-preset-fbjs": "2.1.4",
-        "core-js": "2.5.6",
-        "cross-spawn": "5.1.0",
-        "fancy-log": "1.3.2",
-        "object-assign": "4.1.1",
-        "plugin-error": "0.1.2",
-        "semver": "5.5.0",
-        "through2": "2.0.3"
+        "ansi-colors": "^1.0.1",
+        "babel-core": "^6.7.2",
+        "babel-preset-fbjs": "^2.1.2",
+        "core-js": "^2.4.1",
+        "cross-spawn": "^5.1.0",
+        "fancy-log": "^1.3.2",
+        "object-assign": "^4.0.1",
+        "plugin-error": "^0.1.2",
+        "semver": "^5.1.0",
+        "through2": "^2.0.0"
       }
     },
     "fd-slicer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
-      "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
       "requires": {
-        "pend": "1.2.0"
+        "pend": "~1.2.0"
       }
     },
     "figures": {
@@ -3318,7 +3323,7 @@
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "requires": {
-        "escape-string-regexp": "1.0.5"
+        "escape-string-regexp": "^1.0.5"
       }
     },
     "file-type": {
@@ -3336,10 +3341,10 @@
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
       "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
       "requires": {
-        "extend-shallow": "2.0.1",
-        "is-number": "3.0.0",
-        "repeat-string": "1.6.1",
-        "to-regex-range": "2.1.1"
+        "extend-shallow": "^2.0.1",
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1",
+        "to-regex-range": "^2.1.0"
       },
       "dependencies": {
         "extend-shallow": {
@@ -3347,7 +3352,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -3358,12 +3363,12 @@
       "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
       "requires": {
         "debug": "2.6.9",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.2",
-        "statuses": "1.3.1",
-        "unpipe": "1.0.0"
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "statuses": "~1.3.1",
+        "unpipe": "~1.0.0"
       }
     },
     "find-cache-dir": {
@@ -3371,9 +3376,9 @@
       "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
       "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
       "requires": {
-        "commondir": "1.0.1",
-        "make-dir": "1.3.0",
-        "pkg-dir": "2.0.0"
+        "commondir": "^1.0.1",
+        "make-dir": "^1.0.0",
+        "pkg-dir": "^2.0.0"
       }
     },
     "find-replace": {
@@ -3381,8 +3386,8 @@
       "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-1.0.3.tgz",
       "integrity": "sha1-uI5zZNLZyVlVnziMZmcNYTBEH6A=",
       "requires": {
-        "array-back": "1.0.4",
-        "test-value": "2.1.0"
+        "array-back": "^1.0.4",
+        "test-value": "^2.1.0"
       },
       "dependencies": {
         "array-back": {
@@ -3390,7 +3395,7 @@
           "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
           "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
           "requires": {
-            "typical": "2.6.1"
+            "typical": "^2.6.0"
           }
         }
       }
@@ -3400,7 +3405,7 @@
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
       "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
       "requires": {
-        "locate-path": "2.0.0"
+        "locate-path": "^2.0.0"
       }
     },
     "findup-sync": {
@@ -3408,10 +3413,10 @@
       "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
       "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
       "requires": {
-        "detect-file": "1.0.0",
-        "is-glob": "3.1.0",
-        "micromatch": "3.1.10",
-        "resolve-dir": "1.0.1"
+        "detect-file": "^1.0.0",
+        "is-glob": "^3.1.0",
+        "micromatch": "^3.0.4",
+        "resolve-dir": "^1.0.1"
       }
     },
     "for-in": {
@@ -3424,7 +3429,7 @@
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "requires": {
-        "for-in": "1.0.2"
+        "for-in": "^1.0.1"
       }
     },
     "foreach": {
@@ -3438,13 +3443,13 @@
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
-      "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+      "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
       "requires": {
-        "asynckit": "0.4.0",
-        "combined-stream": "1.0.6",
-        "mime-types": "2.1.18"
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.5",
+        "mime-types": "^2.1.12"
       }
     },
     "fragment-cache": {
@@ -3452,7 +3457,7 @@
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "requires": {
-        "map-cache": "0.2.2"
+        "map-cache": "^0.2.2"
       }
     },
     "fresh": {
@@ -3470,11 +3475,11 @@
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz",
       "integrity": "sha1-muH92UiXeY7at20JGM9C0MMYT6k=",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "jsonfile": "2.4.0",
-        "klaw": "1.3.1",
-        "path-is-absolute": "1.0.1",
-        "rimraf": "2.6.2"
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^2.1.0",
+        "klaw": "^1.0.0",
+        "path-is-absolute": "^1.0.0",
+        "rimraf": "^2.2.8"
       }
     },
     "fs.realpath": {
@@ -3488,8 +3493,8 @@
       "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
       "optional": true,
       "requires": {
-        "nan": "2.10.0",
-        "node-pre-gyp": "0.10.0"
+        "nan": "^2.9.2",
+        "node-pre-gyp": "^0.10.0"
       },
       "dependencies": {
         "abbrev": {
@@ -3511,8 +3516,8 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.3.6"
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
           }
         },
         "balanced-match": {
@@ -3523,7 +3528,7 @@
           "version": "1.1.11",
           "bundled": true,
           "requires": {
-            "balanced-match": "1.0.0",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -3577,7 +3582,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "minipass": "2.2.4"
+            "minipass": "^2.2.1"
           }
         },
         "fs.realpath": {
@@ -3590,14 +3595,14 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "aproba": "1.2.0",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
           }
         },
         "glob": {
@@ -3605,12 +3610,12 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "has-unicode": {
@@ -3623,7 +3628,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "safer-buffer": "2.1.2"
+            "safer-buffer": "^2.1.0"
           }
         },
         "ignore-walk": {
@@ -3631,7 +3636,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "minimatch": "3.0.4"
+            "minimatch": "^3.0.4"
           }
         },
         "inflight": {
@@ -3639,8 +3644,8 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
@@ -3656,7 +3661,7 @@
           "version": "1.0.0",
           "bundled": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "isarray": {
@@ -3668,7 +3673,7 @@
           "version": "3.0.4",
           "bundled": true,
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
@@ -3679,8 +3684,8 @@
           "version": "2.2.4",
           "bundled": true,
           "requires": {
-            "safe-buffer": "5.1.1",
-            "yallist": "3.0.2"
+            "safe-buffer": "^5.1.1",
+            "yallist": "^3.0.0"
           }
         },
         "minizlib": {
@@ -3688,7 +3693,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "minipass": "2.2.4"
+            "minipass": "^2.2.1"
           }
         },
         "mkdirp": {
@@ -3708,9 +3713,9 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "debug": "2.6.9",
-            "iconv-lite": "0.4.21",
-            "sax": "1.2.4"
+            "debug": "^2.1.2",
+            "iconv-lite": "^0.4.4",
+            "sax": "^1.2.4"
           }
         },
         "node-pre-gyp": {
@@ -3718,16 +3723,16 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "detect-libc": "1.0.3",
-            "mkdirp": "0.5.1",
-            "needle": "2.2.0",
-            "nopt": "4.0.1",
-            "npm-packlist": "1.1.10",
-            "npmlog": "4.1.2",
-            "rc": "1.2.7",
-            "rimraf": "2.6.2",
-            "semver": "5.5.0",
-            "tar": "4.4.1"
+            "detect-libc": "^1.0.2",
+            "mkdirp": "^0.5.1",
+            "needle": "^2.2.0",
+            "nopt": "^4.0.1",
+            "npm-packlist": "^1.1.6",
+            "npmlog": "^4.0.2",
+            "rc": "^1.1.7",
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^4"
           }
         },
         "nopt": {
@@ -3735,8 +3740,8 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "abbrev": "1.1.1",
-            "osenv": "0.1.5"
+            "abbrev": "1",
+            "osenv": "^0.1.4"
           }
         },
         "npm-bundled": {
@@ -3749,8 +3754,8 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "ignore-walk": "3.0.1",
-            "npm-bundled": "1.0.3"
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
           }
         },
         "npmlog": {
@@ -3758,10 +3763,10 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
           }
         },
         "number-is-nan": {
@@ -3777,7 +3782,7 @@
           "version": "1.4.0",
           "bundled": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "os-homedir": {
@@ -3795,8 +3800,8 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
           }
         },
         "path-is-absolute": {
@@ -3814,10 +3819,10 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "deep-extend": "0.5.1",
-            "ini": "1.3.5",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
+            "deep-extend": "^0.5.1",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -3832,13 +3837,13 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "rimraf": {
@@ -3846,7 +3851,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "glob": "7.1.2"
+            "glob": "^7.0.5"
           }
         },
         "safe-buffer": {
@@ -3882,9 +3887,9 @@
           "version": "1.0.2",
           "bundled": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "string_decoder": {
@@ -3892,14 +3897,14 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         },
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "strip-json-comments": {
@@ -3912,13 +3917,13 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "chownr": "1.0.1",
-            "fs-minipass": "1.2.5",
-            "minipass": "2.2.4",
-            "minizlib": "1.1.0",
-            "mkdirp": "0.5.1",
-            "safe-buffer": "5.1.1",
-            "yallist": "3.0.2"
+            "chownr": "^1.0.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.2.4",
+            "minizlib": "^1.1.0",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.1",
+            "yallist": "^3.0.2"
           }
         },
         "util-deprecate": {
@@ -3931,7 +3936,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "string-width": "1.0.2"
+            "string-width": "^1.0.2"
           }
         },
         "wrappy": {
@@ -3949,10 +3954,10 @@
       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
       "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "inherits": "2.0.1",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.2"
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
       }
     },
     "fstream-ignore": {
@@ -3960,9 +3965,9 @@
       "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
       "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
       "requires": {
-        "fstream": "1.0.11",
-        "inherits": "2.0.1",
-        "minimatch": "3.0.4"
+        "fstream": "^1.0.0",
+        "inherits": "2",
+        "minimatch": "^3.0.0"
       }
     },
     "function-bind": {
@@ -3975,7 +3980,7 @@
       "resolved": "https://registry.npmjs.org/fwd-stream/-/fwd-stream-1.0.4.tgz",
       "integrity": "sha1-7Sgcq+1G/uz5Ie4y3ExQs3KsfPo=",
       "requires": {
-        "readable-stream": "1.0.34"
+        "readable-stream": "~1.0.26-4"
       },
       "dependencies": {
         "isarray": {
@@ -3988,10 +3993,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.1",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         }
       }
@@ -4001,11 +4006,11 @@
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
       "integrity": "sha1-6c7FSD09TuDvRLYKfZnkk14TbZM=",
       "requires": {
-        "ansi": "0.3.1",
-        "has-unicode": "2.0.1",
-        "lodash.pad": "4.5.1",
-        "lodash.padend": "4.6.1",
-        "lodash.padstart": "4.6.1"
+        "ansi": "^0.3.0",
+        "has-unicode": "^2.0.0",
+        "lodash.pad": "^4.1.0",
+        "lodash.padend": "^4.1.0",
+        "lodash.padstart": "^4.1.0"
       }
     },
     "get-caller-file": {
@@ -4028,7 +4033,14 @@
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
       }
     },
     "glob": {
@@ -4036,12 +4048,12 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.1",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "glob-base": {
@@ -4049,8 +4061,8 @@
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "requires": {
-        "glob-parent": "2.0.0",
-        "is-glob": "2.0.1"
+        "glob-parent": "^2.0.0",
+        "is-glob": "^2.0.0"
       },
       "dependencies": {
         "is-extglob": {
@@ -4063,7 +4075,7 @@
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "^1.0.0"
           }
         }
       }
@@ -4073,7 +4085,7 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "requires": {
-        "is-glob": "2.0.1"
+        "is-glob": "^2.0.0"
       },
       "dependencies": {
         "is-extglob": {
@@ -4086,7 +4098,7 @@
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "^1.0.0"
           }
         }
       }
@@ -4096,8 +4108,8 @@
       "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
       "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
       "requires": {
-        "min-document": "2.19.0",
-        "process": "0.5.2"
+        "min-document": "^2.19.0",
+        "process": "~0.5.1"
       },
       "dependencies": {
         "process": {
@@ -4112,9 +4124,9 @@
       "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
       "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
       "requires": {
-        "global-prefix": "1.0.2",
-        "is-windows": "1.0.2",
-        "resolve-dir": "1.0.1"
+        "global-prefix": "^1.0.1",
+        "is-windows": "^1.0.1",
+        "resolve-dir": "^1.0.0"
       }
     },
     "global-prefix": {
@@ -4122,11 +4134,11 @@
       "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
       "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
       "requires": {
-        "expand-tilde": "2.0.2",
-        "homedir-polyfill": "1.0.1",
-        "ini": "1.3.5",
-        "is-windows": "1.0.2",
-        "which": "1.3.0"
+        "expand-tilde": "^2.0.2",
+        "homedir-polyfill": "^1.0.1",
+        "ini": "^1.3.4",
+        "is-windows": "^1.0.1",
+        "which": "^1.2.14"
       }
     },
     "globals": {
@@ -4154,10 +4166,10 @@
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
       "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
       "requires": {
-        "async": "1.5.2",
-        "optimist": "0.6.1",
-        "source-map": "0.4.4",
-        "uglify-js": "2.8.29"
+        "async": "^1.4.0",
+        "optimist": "^0.6.1",
+        "source-map": "^0.4.4",
+        "uglify-js": "^2.6"
       },
       "dependencies": {
         "source-map": {
@@ -4165,31 +4177,31 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
     },
     "har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+      "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4="
     },
     "har-validator": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+      "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
       "requires": {
-        "ajv": "5.5.2",
-        "har-schema": "2.0.0"
+        "ajv": "^4.9.1",
+        "har-schema": "^1.0.5"
       }
     },
     "has": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
-      "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "requires": {
-        "function-bind": "1.1.1"
+        "function-bind": "^1.1.1"
       }
     },
     "has-ansi": {
@@ -4197,7 +4209,7 @@
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "has-flag": {
@@ -4215,9 +4227,9 @@
       "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "requires": {
-        "get-value": "2.0.6",
-        "has-values": "1.0.0",
-        "isobject": "3.0.1"
+        "get-value": "^2.0.6",
+        "has-values": "^1.0.0",
+        "isobject": "^3.0.0"
       }
     },
     "has-values": {
@@ -4225,8 +4237,8 @@
       "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -4234,7 +4246,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -4244,35 +4256,28 @@
       "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
       "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
       "requires": {
-        "inherits": "2.0.1",
-        "safe-buffer": "5.1.2"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "hash.js": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
-      "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.4.tgz",
+      "integrity": "sha512-A6RlQvvZEtFS5fLU43IDu0QUmBy+fDO9VMdTXvufKwIkt/rFfvICAViCax5fbDO4zdNzaC3/27ZhKUok5bAJyw==",
       "requires": {
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.1"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-        }
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "hawk": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
       "requires": {
-        "boom": "4.3.1",
-        "cryptiles": "3.1.2",
-        "hoek": "4.2.1",
-        "sntp": "2.1.0"
+        "boom": "2.x.x",
+        "cryptiles": "2.x.x",
+        "hoek": "2.x.x",
+        "sntp": "1.x.x"
       }
     },
     "hmac-drbg": {
@@ -4280,23 +4285,23 @@
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "requires": {
-        "hash.js": "1.1.3",
-        "minimalistic-assert": "1.0.1",
-        "minimalistic-crypto-utils": "1.0.1"
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
       }
     },
     "hoek": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-      "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
+      "version": "2.16.3",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
     },
     "home-or-tmp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
       "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.1"
       }
     },
     "homedir-polyfill": {
@@ -4304,7 +4309,7 @@
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
       "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
       "requires": {
-        "parse-passwd": "1.0.0"
+        "parse-passwd": "^1.0.0"
       }
     },
     "homoglyph-finder": {
@@ -4322,9 +4327,9 @@
       "resolved": "https://registry.npmjs.org/http-basic/-/http-basic-2.5.1.tgz",
       "integrity": "sha1-jORHvbW2xXf4pj4/p4BW7Eu02/s=",
       "requires": {
-        "caseless": "0.11.0",
-        "concat-stream": "1.6.2",
-        "http-response-object": "1.1.0"
+        "caseless": "~0.11.0",
+        "concat-stream": "^1.4.6",
+        "http-response-object": "^1.0.0"
       },
       "dependencies": {
         "caseless": {
@@ -4339,17 +4344,12 @@
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "requires": {
-        "depd": "1.1.2",
+        "depd": "~1.1.2",
         "inherits": "2.0.3",
         "setprototypeof": "1.1.0",
-        "statuses": "1.5.0"
+        "statuses": ">= 1.4.0 < 2"
       },
       "dependencies": {
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-        },
         "statuses": {
           "version": "1.5.0",
           "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
@@ -4363,35 +4363,36 @@
       "integrity": "sha1-p8TnWq6C87tJBOT0P2FWc7TVGMM="
     },
     "http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
       "requires": {
-        "assert-plus": "1.0.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.14.1"
+        "assert-plus": "^0.2.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "i18n-js": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/i18n-js/-/i18n-js-3.0.3.tgz",
-      "integrity": "sha512-u144MQhV/8mz4Y5wP86SQAWMwS8gpe/JavIa9hugSI4WreezGgbhJPdk2Q60KcdIltKLiNefGtHNh1N8SSmQqQ=="
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/i18n-js/-/i18n-js-3.0.9.tgz",
+      "integrity": "sha512-m3Cm+3EawVKmDtkeNglzevrHgeGF/LUbeRNgtu+eaF6IOv6QwhZnZj7bN4oIBcIh3VkGgFQmknBSAIluWEvNNQ=="
     },
     "iconv-lite": {
       "version": "0.4.23",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
       "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
       "requires": {
-        "safer-buffer": "2.1.2"
+        "safer-buffer": ">= 2.1.2 < 3"
       }
     },
     "identicon.js": {
-      "version": "github:status-im/identicon.js#4cd179daaf6f01384502b4b2c1876f982db0f57e"
+      "version": "git+ssh://git@github.com/status-im/identicon.js.git#4cd179daaf6f01384502b4b2c1876f982db0f57e",
+      "from": "git+ssh://git@github.com/status-im/identicon.js.git"
     },
     "ieee754": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.11.tgz",
-      "integrity": "sha512-VhDzCKN7K8ufStx/CLj5/PDTMgph+qwN5Pkd5i0sGnVwk56zJ0lkT8Qzi1xqWLS0Wp29DgDtNeS7v8/wMoZeHg=="
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
+      "integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA=="
     },
     "image-size": {
       "version": "0.6.3",
@@ -4413,14 +4414,14 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-      "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "ini": {
       "version": "1.3.5",
@@ -4432,20 +4433,20 @@
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
       "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
       "requires": {
-        "ansi-escapes": "3.1.0",
-        "chalk": "2.4.1",
-        "cli-cursor": "2.1.0",
-        "cli-width": "2.2.0",
-        "external-editor": "2.2.0",
-        "figures": "2.0.0",
-        "lodash": "4.17.10",
+        "ansi-escapes": "^3.0.0",
+        "chalk": "^2.0.0",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^2.0.4",
+        "figures": "^2.0.0",
+        "lodash": "^4.3.0",
         "mute-stream": "0.0.7",
-        "run-async": "2.3.0",
-        "rx-lite": "4.0.8",
-        "rx-lite-aggregates": "4.0.8",
-        "string-width": "2.1.1",
-        "strip-ansi": "4.0.0",
-        "through": "2.3.8"
+        "run-async": "^2.2.0",
+        "rx-lite": "^4.0.8",
+        "rx-lite-aggregates": "^4.0.8",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^4.0.0",
+        "through": "^2.3.6"
       },
       "dependencies": {
         "ansi-regex": {
@@ -4458,7 +4459,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -4466,9 +4467,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "strip-ansi": {
@@ -4476,7 +4477,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         },
         "supports-color": {
@@ -4484,7 +4485,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -4499,7 +4500,7 @@
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "requires": {
-        "loose-envify": "1.3.1"
+        "loose-envify": "^1.0.0"
       }
     },
     "invert-kv": {
@@ -4522,7 +4523,7 @@
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -4530,7 +4531,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -4550,7 +4551,7 @@
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "requires": {
-        "builtin-modules": "1.1.1"
+        "builtin-modules": "^1.0.0"
       }
     },
     "is-callable": {
@@ -4563,7 +4564,7 @@
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -4571,7 +4572,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -4586,9 +4587,9 @@
       "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
       "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
       "requires": {
-        "is-accessor-descriptor": "0.1.6",
-        "is-data-descriptor": "0.1.4",
-        "kind-of": "5.1.0"
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -4608,7 +4609,7 @@
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "requires": {
-        "is-primitive": "2.0.0"
+        "is-primitive": "^2.0.0"
       }
     },
     "is-extendable": {
@@ -4626,7 +4627,7 @@
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-fullwidth-code-point": {
@@ -4639,7 +4640,7 @@
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
       "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
       "requires": {
-        "is-extglob": "2.1.1"
+        "is-extglob": "^2.1.0"
       }
     },
     "is-natural-number": {
@@ -4652,7 +4653,7 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
       "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -4660,7 +4661,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -4670,27 +4671,12 @@
       "resolved": "https://registry.npmjs.org/is-object/-/is-object-0.1.2.tgz",
       "integrity": "sha1-AO+8CIFsM8/ErIJR0TLhDcZQmNc="
     },
-    "is-odd": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
-      "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
-      "requires": {
-        "is-number": "4.0.0"
-      },
-      "dependencies": {
-        "is-number": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
-        }
-      }
-    },
     "is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.1"
       }
     },
     "is-posix-bracket": {
@@ -4713,7 +4699,7 @@
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "requires": {
-        "has": "1.0.1"
+        "has": "^1.0.1"
       }
     },
     "is-stream": {
@@ -4756,8 +4742,8 @@
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
       "requires": {
-        "node-fetch": "1.7.3",
-        "whatwg-fetch": "2.0.4"
+        "node-fetch": "^1.0.1",
+        "whatwg-fetch": ">=0.10.0"
       }
     },
     "isstream": {
@@ -4770,7 +4756,7 @@
       "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-22.4.0.tgz",
       "integrity": "sha512-lDY7GZ+/CJb02oULYLBDj7Hs5shBhVpDYpIm8LUyqw9X2J22QRsM19gmGQwIFqGSJmpc/LRrSYudeSrG510xlQ==",
       "requires": {
-        "detect-newline": "2.1.0"
+        "detect-newline": "^2.1.0"
       }
     },
     "jest-haste-map": {
@@ -4778,13 +4764,13 @@
       "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-22.4.2.tgz",
       "integrity": "sha512-EdQADHGXRqHJYAr7q9B9YYHZnrlcMwhx1+DnIgc9uN05nCW3RvGCxJ91MqWXcC1AzatLoSv7SNd0qXMp2jKBDA==",
       "requires": {
-        "fb-watchman": "2.0.0",
-        "graceful-fs": "4.1.11",
-        "jest-docblock": "22.4.0",
-        "jest-serializer": "22.4.3",
-        "jest-worker": "22.2.2",
-        "micromatch": "2.3.11",
-        "sane": "2.5.2"
+        "fb-watchman": "^2.0.0",
+        "graceful-fs": "^4.1.11",
+        "jest-docblock": "^22.4.0",
+        "jest-serializer": "^22.4.0",
+        "jest-worker": "^22.2.2",
+        "micromatch": "^2.3.11",
+        "sane": "^2.0.0"
       },
       "dependencies": {
         "arr-diff": {
@@ -4792,7 +4778,7 @@
           "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
           "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
           "requires": {
-            "arr-flatten": "1.1.0"
+            "arr-flatten": "^1.0.1"
           }
         },
         "array-unique": {
@@ -4805,9 +4791,9 @@
           "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
           "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
           "requires": {
-            "expand-range": "1.8.2",
-            "preserve": "0.2.0",
-            "repeat-element": "1.1.2"
+            "expand-range": "^1.8.1",
+            "preserve": "^0.2.0",
+            "repeat-element": "^1.1.2"
           }
         },
         "expand-brackets": {
@@ -4815,7 +4801,7 @@
           "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
           "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
           "requires": {
-            "is-posix-bracket": "0.1.1"
+            "is-posix-bracket": "^0.1.0"
           }
         },
         "extglob": {
@@ -4823,7 +4809,7 @@
           "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
           "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "^1.0.0"
           }
         },
         "is-extglob": {
@@ -4836,7 +4822,7 @@
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "^1.0.0"
           }
         },
         "kind-of": {
@@ -4844,7 +4830,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         },
         "micromatch": {
@@ -4852,19 +4838,19 @@
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
           "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
           "requires": {
-            "arr-diff": "2.0.0",
-            "array-unique": "0.2.1",
-            "braces": "1.8.5",
-            "expand-brackets": "0.1.5",
-            "extglob": "0.3.2",
-            "filename-regex": "2.0.1",
-            "is-extglob": "1.0.0",
-            "is-glob": "2.0.1",
-            "kind-of": "3.2.2",
-            "normalize-path": "2.1.1",
-            "object.omit": "2.0.1",
-            "parse-glob": "3.0.4",
-            "regex-cache": "0.4.4"
+            "arr-diff": "^2.0.0",
+            "array-unique": "^0.2.1",
+            "braces": "^1.8.2",
+            "expand-brackets": "^0.1.4",
+            "extglob": "^0.3.1",
+            "filename-regex": "^2.0.0",
+            "is-extglob": "^1.0.0",
+            "is-glob": "^2.0.1",
+            "kind-of": "^3.0.2",
+            "normalize-path": "^2.0.1",
+            "object.omit": "^2.0.0",
+            "parse-glob": "^3.0.4",
+            "regex-cache": "^0.4.2"
           }
         }
       }
@@ -4879,7 +4865,7 @@
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-22.2.2.tgz",
       "integrity": "sha512-ZylDXjrFNt/OP6cUxwJFWwDgazP7hRjtCQbocFHyiwov+04Wm1x5PYzMGNJT53s4nwr0oo9ocYTImS09xOlUnw==",
       "requires": {
-        "merge-stream": "1.0.1"
+        "merge-stream": "^1.0.1"
       }
     },
     "js-tokens": {
@@ -4913,7 +4899,7 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "requires": {
-        "jsonify": "0.0.0"
+        "jsonify": "~0.0.0"
       }
     },
     "json-stringify-safe": {
@@ -4931,7 +4917,7 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.6"
       }
     },
     "jsonify": {
@@ -4948,6 +4934,13 @@
         "extsprintf": "1.3.0",
         "json-schema": "0.2.3",
         "verror": "1.10.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
       }
     },
     "jsx-ast-utils": {
@@ -4970,7 +4963,7 @@
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.9"
       }
     },
     "klaw-sync": {
@@ -4978,7 +4971,7 @@
       "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-2.1.0.tgz",
       "integrity": "sha1-PTvNhgDnv971MjHHOf8FOu1WDkQ=",
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.11"
       }
     },
     "lazy-cache": {
@@ -4992,7 +4985,7 @@
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "requires": {
-        "invert-kv": "1.0.0"
+        "invert-kv": "^1.0.0"
       }
     },
     "left-pad": {
@@ -5006,8 +4999,8 @@
       "integrity": "sha1-mrm5e7mfHtv594o0M+Ie1WOGva8=",
       "requires": {
         "level-peek": "1.0.6",
-        "once": "1.4.0",
-        "readable-stream": "1.1.14"
+        "once": "^1.3.0",
+        "readable-stream": "^1.0.26-4"
       },
       "dependencies": {
         "isarray": {
@@ -5020,10 +5013,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.1",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         }
       }
@@ -5033,15 +5026,15 @@
       "resolved": "https://registry.npmjs.org/level-filesystem/-/level-filesystem-1.2.0.tgz",
       "integrity": "sha1-oArKmRnEpN+v3KaoEI0iWq3/Y7M=",
       "requires": {
-        "concat-stream": "1.6.2",
-        "errno": "0.1.7",
-        "fwd-stream": "1.0.4",
-        "level-blobs": "0.1.7",
-        "level-peek": "1.0.6",
-        "level-sublevel": "5.2.3",
-        "octal": "1.0.0",
-        "once": "1.4.0",
-        "xtend": "2.2.0"
+        "concat-stream": "^1.4.4",
+        "errno": "^0.1.1",
+        "fwd-stream": "^1.0.4",
+        "level-blobs": "^0.1.7",
+        "level-peek": "^1.0.6",
+        "level-sublevel": "^5.2.0",
+        "octal": "^1.0.0",
+        "once": "^1.3.0",
+        "xtend": "^2.2.0"
       },
       "dependencies": {
         "xtend": {
@@ -5061,7 +5054,7 @@
       "resolved": "https://registry.npmjs.org/level-hooks/-/level-hooks-4.5.0.tgz",
       "integrity": "sha1-G5rmGSKTDzMF0aYfxNg8gQLA3ZM=",
       "requires": {
-        "string-range": "1.2.2"
+        "string-range": "~1.2"
       }
     },
     "level-peek": {
@@ -5069,7 +5062,7 @@
       "resolved": "https://registry.npmjs.org/level-peek/-/level-peek-1.0.6.tgz",
       "integrity": "sha1-vsUccqgu5GTTNkNMfIdsP8vM538=",
       "requires": {
-        "level-fix-range": "1.0.2"
+        "level-fix-range": "~1.0.2"
       }
     },
     "level-sublevel": {
@@ -5077,10 +5070,10 @@
       "resolved": "https://registry.npmjs.org/level-sublevel/-/level-sublevel-5.2.3.tgz",
       "integrity": "sha1-dEwSxy0ucr543eO5tc2E1iGRQTo=",
       "requires": {
-        "level-fix-range": "2.0.0",
-        "level-hooks": "4.5.0",
-        "string-range": "1.2.2",
-        "xtend": "2.0.6"
+        "level-fix-range": "2.0",
+        "level-hooks": ">=4.4.0 <5",
+        "string-range": "~1.2.1",
+        "xtend": "~2.0.4"
       },
       "dependencies": {
         "level-fix-range": {
@@ -5088,7 +5081,7 @@
           "resolved": "https://registry.npmjs.org/level-fix-range/-/level-fix-range-2.0.0.tgz",
           "integrity": "sha1-xBfWIVlEIVGhnZojZ4aPFyTC1Ug=",
           "requires": {
-            "clone": "0.1.19"
+            "clone": "~0.1.9"
           }
         },
         "xtend": {
@@ -5096,8 +5089,8 @@
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.0.6.tgz",
           "integrity": "sha1-XqZXptukRwacLlnFihE4ywxebO4=",
           "requires": {
-            "is-object": "0.1.2",
-            "object-keys": "0.2.0"
+            "is-object": "~0.1.2",
+            "object-keys": "~0.2.0"
           }
         }
       }
@@ -5107,13 +5100,13 @@
       "resolved": "https://registry.npmjs.org/levelup/-/levelup-0.18.6.tgz",
       "integrity": "sha1-5qAcsIlhbI7MApHCqb0/DETj5es=",
       "requires": {
-        "bl": "0.8.2",
-        "deferred-leveldown": "0.2.0",
-        "errno": "0.1.7",
-        "prr": "0.0.0",
-        "readable-stream": "1.0.34",
-        "semver": "2.3.2",
-        "xtend": "3.0.0"
+        "bl": "~0.8.1",
+        "deferred-leveldown": "~0.2.0",
+        "errno": "~0.1.1",
+        "prr": "~0.0.0",
+        "readable-stream": "~1.0.26",
+        "semver": "~2.3.1",
+        "xtend": "~3.0.0"
       },
       "dependencies": {
         "isarray": {
@@ -5131,10 +5124,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.1",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "semver": {
@@ -5154,10 +5147,17 @@
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
       "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "parse-json": "2.2.0",
-        "pify": "2.3.0",
-        "strip-bom": "3.0.0"
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "strip-bom": "^3.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+        }
       }
     },
     "locate-path": {
@@ -5165,8 +5165,8 @@
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "requires": {
-        "p-locate": "2.0.0",
-        "path-exists": "3.0.0"
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
       }
     },
     "lodash": {
@@ -5209,7 +5209,7 @@
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
       "requires": {
-        "js-tokens": "3.0.2"
+        "js-tokens": "^3.0.0"
       }
     },
     "lru-cache": {
@@ -5217,8 +5217,8 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
       "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
       "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
       }
     },
     "ltgt": {
@@ -5236,14 +5236,7 @@
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
       "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
       "requires": {
-        "pify": "3.0.0"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
-        }
+        "pify": "^3.0.0"
       }
     },
     "makeerror": {
@@ -5251,7 +5244,7 @@
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
       "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
       "requires": {
-        "tmpl": "1.0.4"
+        "tmpl": "1.0.x"
       }
     },
     "map-cache": {
@@ -5264,7 +5257,7 @@
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "requires": {
-        "object-visit": "1.0.1"
+        "object-visit": "^1.0.0"
       }
     },
     "math-random": {
@@ -5277,8 +5270,8 @@
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
       "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
       "requires": {
-        "hash-base": "3.0.4",
-        "inherits": "2.0.1"
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
       }
     },
     "mem": {
@@ -5286,7 +5279,7 @@
       "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
       "requires": {
-        "mimic-fn": "1.2.0"
+        "mimic-fn": "^1.0.0"
       }
     },
     "merge": {
@@ -5299,7 +5292,7 @@
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
       "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
       "requires": {
-        "readable-stream": "2.3.6"
+        "readable-stream": "^2.0.1"
       }
     },
     "metro": {
@@ -5307,69 +5300,69 @@
       "resolved": "https://registry.npmjs.org/metro/-/metro-0.30.2.tgz",
       "integrity": "sha512-wmdkh4AsfZjWaMM++KMDswQHdyo5L9a0XAaQBL4XTJdQIRG+x+Rmjixe7tDki5jKwe9XxsjjbpbdYKswOANuiw==",
       "requires": {
-        "@babel/core": "7.0.0-beta.51",
-        "@babel/generator": "7.0.0-beta.51",
-        "@babel/helper-remap-async-to-generator": "7.0.0-beta.51",
-        "@babel/plugin-external-helpers": "7.0.0-beta.51",
-        "@babel/plugin-proposal-class-properties": "7.0.0-beta.51",
-        "@babel/plugin-proposal-object-rest-spread": "7.0.0-beta.51",
-        "@babel/plugin-syntax-dynamic-import": "7.0.0-beta.51",
-        "@babel/plugin-transform-arrow-functions": "7.0.0-beta.51",
-        "@babel/plugin-transform-block-scoping": "7.0.0-beta.51",
-        "@babel/plugin-transform-classes": "7.0.0-beta.51",
-        "@babel/plugin-transform-computed-properties": "7.0.0-beta.51",
-        "@babel/plugin-transform-destructuring": "7.0.0-beta.51",
-        "@babel/plugin-transform-exponentiation-operator": "7.0.0-beta.51",
-        "@babel/plugin-transform-flow-strip-types": "7.0.0-beta.51",
-        "@babel/plugin-transform-for-of": "7.0.0-beta.51",
-        "@babel/plugin-transform-function-name": "7.0.0-beta.51",
-        "@babel/plugin-transform-literals": "7.0.0-beta.51",
-        "@babel/plugin-transform-modules-commonjs": "7.0.0-beta.51",
-        "@babel/plugin-transform-object-assign": "7.0.0-beta.51",
-        "@babel/plugin-transform-parameters": "7.0.0-beta.51",
-        "@babel/plugin-transform-react-display-name": "7.0.0-beta.51",
-        "@babel/plugin-transform-react-jsx": "7.0.0-beta.51",
-        "@babel/plugin-transform-react-jsx-source": "7.0.0-beta.51",
-        "@babel/plugin-transform-regenerator": "7.0.0-beta.51",
-        "@babel/plugin-transform-shorthand-properties": "7.0.0-beta.51",
-        "@babel/plugin-transform-spread": "7.0.0-beta.51",
-        "@babel/plugin-transform-template-literals": "7.0.0-beta.51",
-        "@babel/register": "7.0.0-beta.51",
-        "@babel/template": "7.0.0-beta.51",
-        "@babel/traverse": "7.0.0-beta.51",
-        "@babel/types": "7.0.0-beta.51",
-        "absolute-path": "0.0.0",
-        "async": "2.6.1",
-        "babel-core": "6.24.1",
-        "babel-generator": "6.26.1",
-        "babel-plugin-external-helpers": "6.22.0",
-        "babel-plugin-react-transform": "3.0.0",
-        "babel-plugin-transform-flow-strip-types": "6.22.0",
-        "babel-preset-es2015-node": "6.1.1",
-        "babel-preset-fbjs": "2.1.4",
-        "babel-preset-react-native": "4.0.0",
-        "babel-register": "6.26.0",
-        "babel-template": "6.26.0",
-        "babylon": "6.18.0",
-        "chalk": "1.1.3",
-        "concat-stream": "1.6.2",
-        "connect": "3.6.6",
-        "core-js": "2.5.6",
-        "debug": "2.6.9",
-        "denodeify": "1.2.1",
-        "eventemitter3": "3.1.0",
-        "fbjs": "0.8.16",
-        "fs-extra": "1.0.0",
-        "graceful-fs": "4.1.11",
-        "image-size": "0.6.3",
+        "@babel/core": "^7.0.0-beta",
+        "@babel/generator": "^7.0.0-beta",
+        "@babel/helper-remap-async-to-generator": "^7.0.0-beta",
+        "@babel/plugin-external-helpers": "^7.0.0-beta",
+        "@babel/plugin-proposal-class-properties": "^7.0.0-beta",
+        "@babel/plugin-proposal-object-rest-spread": "^7.0.0-beta",
+        "@babel/plugin-syntax-dynamic-import": "^7.0.0-beta",
+        "@babel/plugin-transform-arrow-functions": "^7.0.0-beta",
+        "@babel/plugin-transform-block-scoping": "^7.0.0-beta",
+        "@babel/plugin-transform-classes": "^7.0.0-beta",
+        "@babel/plugin-transform-computed-properties": "^7.0.0-beta",
+        "@babel/plugin-transform-destructuring": "^7.0.0-beta",
+        "@babel/plugin-transform-exponentiation-operator": "^7.0.0-beta",
+        "@babel/plugin-transform-flow-strip-types": "^7.0.0-beta",
+        "@babel/plugin-transform-for-of": "^7.0.0-beta",
+        "@babel/plugin-transform-function-name": "^7.0.0-beta",
+        "@babel/plugin-transform-literals": "^7.0.0-beta",
+        "@babel/plugin-transform-modules-commonjs": "^7.0.0-beta",
+        "@babel/plugin-transform-object-assign": "^7.0.0-beta",
+        "@babel/plugin-transform-parameters": "^7.0.0-beta",
+        "@babel/plugin-transform-react-display-name": "^7.0.0-beta",
+        "@babel/plugin-transform-react-jsx": "^7.0.0-beta",
+        "@babel/plugin-transform-react-jsx-source": "^7.0.0-beta",
+        "@babel/plugin-transform-regenerator": "^7.0.0-beta",
+        "@babel/plugin-transform-shorthand-properties": "^7.0.0-beta",
+        "@babel/plugin-transform-spread": "^7.0.0-beta",
+        "@babel/plugin-transform-template-literals": "^7.0.0-beta",
+        "@babel/register": "^7.0.0-beta",
+        "@babel/template": "^7.0.0-beta",
+        "@babel/traverse": "^7.0.0-beta",
+        "@babel/types": "^7.0.0-beta",
+        "absolute-path": "^0.0.0",
+        "async": "^2.4.0",
+        "babel-core": "^6.24.1",
+        "babel-generator": "^6.26.0",
+        "babel-plugin-external-helpers": "^6.22.0",
+        "babel-plugin-react-transform": "^3.0.0",
+        "babel-plugin-transform-flow-strip-types": "^6.21.0",
+        "babel-preset-es2015-node": "^6.1.1",
+        "babel-preset-fbjs": "^2.1.4",
+        "babel-preset-react-native": "^4.0.0",
+        "babel-register": "^6.24.1",
+        "babel-template": "^6.24.1",
+        "babylon": "^6.18.0",
+        "chalk": "^1.1.1",
+        "concat-stream": "^1.6.0",
+        "connect": "^3.6.5",
+        "core-js": "^2.2.2",
+        "debug": "^2.2.0",
+        "denodeify": "^1.2.1",
+        "eventemitter3": "^3.0.0",
+        "fbjs": "^0.8.14",
+        "fs-extra": "^1.0.0",
+        "graceful-fs": "^4.1.3",
+        "image-size": "^0.6.0",
         "jest-docblock": "22.4.0",
         "jest-haste-map": "22.4.2",
         "jest-worker": "22.2.2",
-        "json-stable-stringify": "1.0.1",
-        "json5": "0.4.0",
-        "left-pad": "1.3.0",
-        "lodash.throttle": "4.1.1",
-        "merge-stream": "1.0.1",
+        "json-stable-stringify": "^1.0.1",
+        "json5": "^0.4.0",
+        "left-pad": "^1.1.3",
+        "lodash.throttle": "^4.1.1",
+        "merge-stream": "^1.0.1",
         "metro-babylon7": "0.30.2",
         "metro-cache": "0.30.2",
         "metro-core": "0.30.2",
@@ -5377,19 +5370,19 @@
         "metro-resolver": "0.30.2",
         "metro-source-map": "0.30.2",
         "mime-types": "2.1.11",
-        "mkdirp": "0.5.1",
-        "node-fetch": "1.7.3",
-        "resolve": "1.8.1",
-        "rimraf": "2.6.2",
-        "serialize-error": "2.1.0",
-        "source-map": "0.5.7",
+        "mkdirp": "^0.5.1",
+        "node-fetch": "^1.3.3",
+        "resolve": "^1.5.0",
+        "rimraf": "^2.5.4",
+        "serialize-error": "^2.1.0",
+        "source-map": "^0.5.6",
         "temp": "0.8.3",
-        "throat": "4.1.0",
-        "wordwrap": "1.0.0",
-        "write-file-atomic": "1.3.4",
-        "ws": "1.1.5",
-        "xpipe": "1.0.5",
-        "yargs": "9.0.1"
+        "throat": "^4.1.0",
+        "wordwrap": "^1.0.0",
+        "write-file-atomic": "^1.2.0",
+        "ws": "^1.1.0",
+        "xpipe": "^1.0.5",
+        "yargs": "^9.0.0"
       },
       "dependencies": {
         "async": {
@@ -5397,7 +5390,7 @@
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
           "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
           "requires": {
-            "lodash": "4.17.10"
+            "lodash": "^4.17.10"
           }
         },
         "babel-generator": {
@@ -5405,14 +5398,14 @@
           "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
           "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
           "requires": {
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "detect-indent": "4.0.0",
-            "jsesc": "1.3.0",
-            "lodash": "4.17.10",
-            "source-map": "0.5.7",
-            "trim-right": "1.0.1"
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "detect-indent": "^4.0.0",
+            "jsesc": "^1.3.0",
+            "lodash": "^4.17.4",
+            "source-map": "^0.5.7",
+            "trim-right": "^1.0.1"
           }
         },
         "babel-register": {
@@ -5420,13 +5413,13 @@
           "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
           "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
           "requires": {
-            "babel-core": "6.26.3",
-            "babel-runtime": "6.26.0",
-            "core-js": "2.5.6",
-            "home-or-tmp": "2.0.0",
-            "lodash": "4.17.10",
-            "mkdirp": "0.5.1",
-            "source-map-support": "0.4.18"
+            "babel-core": "^6.26.0",
+            "babel-runtime": "^6.26.0",
+            "core-js": "^2.5.0",
+            "home-or-tmp": "^2.0.0",
+            "lodash": "^4.17.4",
+            "mkdirp": "^0.5.1",
+            "source-map-support": "^0.4.15"
           },
           "dependencies": {
             "babel-core": {
@@ -5434,25 +5427,25 @@
               "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
               "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
               "requires": {
-                "babel-code-frame": "6.26.0",
-                "babel-generator": "6.26.1",
-                "babel-helpers": "6.24.1",
-                "babel-messages": "6.23.0",
-                "babel-register": "6.26.0",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0",
-                "babylon": "6.18.0",
-                "convert-source-map": "1.5.1",
-                "debug": "2.6.9",
-                "json5": "0.5.1",
-                "lodash": "4.17.10",
-                "minimatch": "3.0.4",
-                "path-is-absolute": "1.0.1",
-                "private": "0.1.8",
-                "slash": "1.0.0",
-                "source-map": "0.5.7"
+                "babel-code-frame": "^6.26.0",
+                "babel-generator": "^6.26.0",
+                "babel-helpers": "^6.24.1",
+                "babel-messages": "^6.23.0",
+                "babel-register": "^6.26.0",
+                "babel-runtime": "^6.26.0",
+                "babel-template": "^6.26.0",
+                "babel-traverse": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "babylon": "^6.18.0",
+                "convert-source-map": "^1.5.1",
+                "debug": "^2.6.9",
+                "json5": "^0.5.1",
+                "lodash": "^4.17.4",
+                "minimatch": "^3.0.4",
+                "path-is-absolute": "^1.0.1",
+                "private": "^0.1.8",
+                "slash": "^1.0.0",
+                "source-map": "^0.5.7"
               }
             },
             "json5": {
@@ -5472,9 +5465,9 @@
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wrap-ansi": "2.1.0"
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
           },
           "dependencies": {
             "string-width": {
@@ -5482,9 +5475,9 @@
               "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
               }
             }
           }
@@ -5494,9 +5487,9 @@
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
           "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
           "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "2.4.0",
-            "klaw": "1.3.1"
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^2.1.0",
+            "klaw": "^1.0.0"
           }
         },
         "is-fullwidth-code-point": {
@@ -5504,7 +5497,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "json5": {
@@ -5522,7 +5515,7 @@
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
           "integrity": "sha1-wlnEcb2oCKhdbNGTtDCl+uRHOzw=",
           "requires": {
-            "mime-db": "1.23.0"
+            "mime-db": "~1.23.0"
           }
         },
         "wordwrap": {
@@ -5535,19 +5528,19 @@
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-9.0.1.tgz",
           "integrity": "sha1-UqzCP+7Kw0BCB47njAwAf1CF20w=",
           "requires": {
-            "camelcase": "4.1.0",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "2.1.0",
-            "read-pkg-up": "2.0.0",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "2.1.1",
-            "which-module": "2.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "7.0.0"
+            "camelcase": "^4.1.0",
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^2.0.0",
+            "read-pkg-up": "^2.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^7.0.0"
           }
         }
       }
@@ -5557,7 +5550,7 @@
       "resolved": "https://registry.npmjs.org/metro-babylon7/-/metro-babylon7-0.30.2.tgz",
       "integrity": "sha512-ZI0h4/3raGnzA6fFXwLUMidGOG4jkDi9fgFkoI8I4Ack3TDMabmZATu9RD6DaSolu3lylhfPd8DeAAMeopX9CA==",
       "requires": {
-        "babylon": "7.0.0-beta.47"
+        "babylon": "^7.0.0-beta"
       },
       "dependencies": {
         "babylon": {
@@ -5572,8 +5565,8 @@
       "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.30.2.tgz",
       "integrity": "sha512-XYd07OwgtZRHFXyip40wdNJ8abPJRziuE5bb3jjf8wvyHxCpzlZlvbe0ZhcR8ChBwFUjHMuVyoou52AC3a0f+g==",
       "requires": {
-        "jest-serializer": "22.4.3",
-        "mkdirp": "0.5.1"
+        "jest-serializer": "^22.4.0",
+        "mkdirp": "^0.5.1"
       }
     },
     "metro-core": {
@@ -5581,8 +5574,8 @@
       "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.30.2.tgz",
       "integrity": "sha512-2Y89PpD9sE/8QaHhYxaI21WFxkVmjbxdphiOPdsC9t7A3kQHMYOTQPYFon3bkYM7tL8k9YVBimXSv20JGglqUA==",
       "requires": {
-        "lodash.throttle": "4.1.1",
-        "wordwrap": "1.0.0"
+        "lodash.throttle": "^4.1.1",
+        "wordwrap": "^1.0.0"
       },
       "dependencies": {
         "wordwrap": {
@@ -5597,7 +5590,7 @@
       "resolved": "https://registry.npmjs.org/metro-minify-uglify/-/metro-minify-uglify-0.30.2.tgz",
       "integrity": "sha512-xwqMqYYKZEqJ66Wpf5OpyPJhApOQDb8rYiO94VInlDeHpN7eKGCVILclnx9AmVM3dStmebvXa5jrdgsbnJ1bSg==",
       "requires": {
-        "uglify-es": "3.3.9"
+        "uglify-es": "^3.1.9"
       },
       "dependencies": {
         "commander": {
@@ -5615,8 +5608,8 @@
           "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
           "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
           "requires": {
-            "commander": "2.13.0",
-            "source-map": "0.6.1"
+            "commander": "~2.13.0",
+            "source-map": "~0.6.1"
           }
         }
       }
@@ -5626,7 +5619,7 @@
       "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.30.2.tgz",
       "integrity": "sha512-bODCys/WYpqJ+KYbCIENZu1eqdQu3g/d2fXfhAROhutqojMqrT1eIGhzWpk3G1k/J6vlaf69uW6xrVuheg0ktg==",
       "requires": {
-        "absolute-path": "0.0.0"
+        "absolute-path": "^0.0.0"
       }
     },
     "metro-source-map": {
@@ -5634,7 +5627,7 @@
       "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.30.2.tgz",
       "integrity": "sha512-9tW3B1JOdXhyDJnR4wOPOsOlYWSL+xh6J+N5/DADGEK/X/+Up/lEHdEfpB+/+yGk1LHaRHcKCahtLPNl/to7Sg==",
       "requires": {
-        "source-map": "0.5.7"
+        "source-map": "^0.5.6"
       }
     },
     "micromatch": {
@@ -5642,19 +5635,19 @@
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
       "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
       "requires": {
-        "arr-diff": "4.0.0",
-        "array-unique": "0.3.2",
-        "braces": "2.3.2",
-        "define-property": "2.0.2",
-        "extend-shallow": "3.0.2",
-        "extglob": "2.0.4",
-        "fragment-cache": "0.2.1",
-        "kind-of": "6.0.2",
-        "nanomatch": "1.2.9",
-        "object.pick": "1.3.0",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "braces": "^2.3.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "extglob": "^2.0.4",
+        "fragment-cache": "^0.2.1",
+        "kind-of": "^6.0.2",
+        "nanomatch": "^1.2.9",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.2"
       }
     },
     "miller-rabin": {
@@ -5662,8 +5655,8 @@
       "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
       "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
       "requires": {
-        "bn.js": "4.11.8",
-        "brorand": "1.1.0"
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1"
       }
     },
     "mime": {
@@ -5681,7 +5674,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
       "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
       "requires": {
-        "mime-db": "1.33.0"
+        "mime-db": "~1.33.0"
       }
     },
     "mimic-fn": {
@@ -5694,7 +5687,7 @@
       "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
       "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
       "requires": {
-        "dom-walk": "0.1.1"
+        "dom-walk": "^0.1.0"
       }
     },
     "minimalistic-assert": {
@@ -5712,7 +5705,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -5725,8 +5718,8 @@
       "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
       "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
       "requires": {
-        "for-in": "1.0.2",
-        "is-extendable": "1.0.1"
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -5734,7 +5727,7 @@
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "requires": {
-            "is-plain-object": "2.0.4"
+            "is-plain-object": "^2.0.4"
           }
         }
       }
@@ -5752,11 +5745,11 @@
       "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.9.0.tgz",
       "integrity": "sha1-0B+mxlhZt2/PMbPLU6OCGjEdgFE=",
       "requires": {
-        "basic-auth": "2.0.0",
+        "basic-auth": "~2.0.0",
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "on-finished": "2.3.0",
-        "on-headers": "1.0.1"
+        "depd": "~1.1.1",
+        "on-finished": "~2.3.0",
+        "on-headers": "~1.0.1"
       }
     },
     "mout": {
@@ -5781,22 +5774,21 @@
       "optional": true
     },
     "nanomatch": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
-      "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+      "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
       "requires": {
-        "arr-diff": "4.0.0",
-        "array-unique": "0.3.2",
-        "define-property": "2.0.2",
-        "extend-shallow": "3.0.2",
-        "fragment-cache": "0.2.1",
-        "is-odd": "2.0.0",
-        "is-windows": "1.0.2",
-        "kind-of": "6.0.2",
-        "object.pick": "1.3.0",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "fragment-cache": "^0.2.1",
+        "is-windows": "^1.0.2",
+        "kind-of": "^6.0.2",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
       }
     },
     "negotiator": {
@@ -5805,15 +5797,16 @@
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
     },
     "nfc-react-native": {
-      "version": "github:status-im/nfc-react-native#ecdb55e470bb9fa569d26fcc8af4e5169511a4d3"
+      "version": "git+ssh://git@github.com/status-im/nfc-react-native.git#ecdb55e470bb9fa569d26fcc8af4e5169511a4d3",
+      "from": "git+ssh://git@github.com/status-im/nfc-react-native.git"
     },
     "node-fetch": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
       "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
       "requires": {
-        "encoding": "0.1.12",
-        "is-stream": "1.1.0"
+        "encoding": "^0.1.11",
+        "is-stream": "^1.0.1"
       }
     },
     "node-int64": {
@@ -5831,10 +5824,10 @@
       "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.2.1.tgz",
       "integrity": "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
       "requires": {
-        "growly": "1.3.0",
-        "semver": "5.5.0",
-        "shellwords": "0.1.1",
-        "which": "1.3.0"
+        "growly": "^1.3.0",
+        "semver": "^5.4.1",
+        "shellwords": "^0.1.1",
+        "which": "^1.3.0"
       }
     },
     "node-pre-gyp": {
@@ -5842,117 +5835,32 @@
       "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz",
       "integrity": "sha512-OsJV74qxnvz/AMGgcfZoDaeDXKD3oY3QVIbBmwszTFkRisTSXbMQyn4UWzUMOtA5SVhrBZOTp0wcoSBgfMfMmQ==",
       "requires": {
-        "detect-libc": "1.0.3",
+        "detect-libc": "^1.0.2",
         "hawk": "3.1.3",
-        "mkdirp": "0.5.1",
-        "nopt": "4.0.1",
-        "npmlog": "4.1.2",
-        "rc": "1.2.7",
+        "mkdirp": "^0.5.1",
+        "nopt": "^4.0.1",
+        "npmlog": "^4.0.2",
+        "rc": "^1.1.7",
         "request": "2.81.0",
-        "rimraf": "2.6.2",
-        "semver": "5.5.0",
-        "tar": "2.2.1",
-        "tar-pack": "3.4.1"
+        "rimraf": "^2.6.1",
+        "semver": "^5.3.0",
+        "tar": "^2.2.1",
+        "tar-pack": "^3.4.0"
       },
       "dependencies": {
-        "ajv": {
-          "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-          "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
-          }
-        },
-        "assert-plus": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
-        },
-        "boom": {
-          "version": "2.10.1",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "cryptiles": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-          "requires": {
-            "boom": "2.10.1"
-          }
-        },
-        "form-data": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-          "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.6",
-            "mime-types": "2.1.18"
-          }
-        },
         "gauge": {
           "version": "2.7.4",
           "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
           "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "requires": {
-            "aproba": "1.2.0",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
-          }
-        },
-        "har-schema": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-          "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4="
-        },
-        "har-validator": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-          "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-          "requires": {
-            "ajv": "4.11.8",
-            "har-schema": "1.0.5"
-          }
-        },
-        "hawk": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-          "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
-          }
-        },
-        "hoek": {
-          "version": "2.16.3",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
-        },
-        "http-signature": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-          "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.14.1"
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
           }
         },
         "is-fullwidth-code-point": {
@@ -5960,7 +5868,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "npmlog": {
@@ -5968,57 +5876,39 @@
           "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
           "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
           }
-        },
-        "performance-now": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-          "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
-        },
-        "qs": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
         },
         "request": {
           "version": "2.81.0",
           "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
           "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
           "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.7.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.6",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "4.2.1",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.18",
-            "oauth-sign": "0.8.2",
-            "performance-now": "0.2.0",
-            "qs": "6.4.0",
-            "safe-buffer": "5.1.2",
-            "stringstream": "0.0.6",
-            "tough-cookie": "2.3.4",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.2.1"
-          }
-        },
-        "sntp": {
-          "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-          "requires": {
-            "hoek": "2.16.3"
+            "aws-sign2": "~0.6.0",
+            "aws4": "^1.2.1",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.0",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.1.1",
+            "har-validator": "~4.2.1",
+            "hawk": "~3.1.3",
+            "http-signature": "~1.1.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.7",
+            "oauth-sign": "~0.8.1",
+            "performance-now": "^0.2.0",
+            "qs": "~6.4.0",
+            "safe-buffer": "^5.0.1",
+            "stringstream": "~0.0.4",
+            "tough-cookie": "~2.3.0",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.0.0"
           }
         },
         "string-width": {
@@ -6026,9 +5916,9 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         }
       }
@@ -6038,8 +5928,8 @@
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
       "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
       "requires": {
-        "abbrev": "1.1.1",
-        "osenv": "0.1.5"
+        "abbrev": "1",
+        "osenv": "^0.1.4"
       }
     },
     "normalize-package-data": {
@@ -6047,10 +5937,10 @@
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "requires": {
-        "hosted-git-info": "2.6.1",
-        "is-builtin-module": "1.0.0",
-        "semver": "5.5.0",
-        "validate-npm-package-license": "3.0.3"
+        "hosted-git-info": "^2.1.4",
+        "is-builtin-module": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
       }
     },
     "normalize-path": {
@@ -6058,7 +5948,7 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "requires": {
-        "remove-trailing-separator": "1.1.0"
+        "remove-trailing-separator": "^1.0.1"
       }
     },
     "npm-run-path": {
@@ -6066,7 +5956,7 @@
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "requires": {
-        "path-key": "2.0.1"
+        "path-key": "^2.0.0"
       }
     },
     "npmlog": {
@@ -6074,9 +5964,9 @@
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.4.tgz",
       "integrity": "sha1-mLUlMPJRTKkNCexbIsiEZyI3VpI=",
       "requires": {
-        "ansi": "0.3.1",
-        "are-we-there-yet": "1.1.4",
-        "gauge": "1.2.7"
+        "ansi": "~0.3.1",
+        "are-we-there-yet": "~1.1.2",
+        "gauge": "~1.2.5"
       }
     },
     "number-is-nan": {
@@ -6099,9 +5989,9 @@
       "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "requires": {
-        "copy-descriptor": "0.1.1",
-        "define-property": "0.2.5",
-        "kind-of": "3.2.2"
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
       },
       "dependencies": {
         "define-property": {
@@ -6109,7 +5999,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "kind-of": {
@@ -6117,7 +6007,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -6127,9 +6017,9 @@
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.2.0.tgz",
       "integrity": "sha1-zd7AKZiwkb5CvxA1rjLknxy26mc=",
       "requires": {
-        "foreach": "2.0.5",
-        "indexof": "0.0.1",
-        "is": "0.2.7"
+        "foreach": "~2.0.1",
+        "indexof": "~0.0.1",
+        "is": "~0.2.6"
       }
     },
     "object-visit": {
@@ -6137,7 +6027,7 @@
       "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.0"
       }
     },
     "object.omit": {
@@ -6145,8 +6035,8 @@
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "requires": {
-        "for-own": "0.1.5",
-        "is-extendable": "0.1.1"
+        "for-own": "^0.1.4",
+        "is-extendable": "^0.1.1"
       }
     },
     "object.pick": {
@@ -6154,7 +6044,7 @@
       "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.1"
       }
     },
     "octal": {
@@ -6180,7 +6070,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "onetime": {
@@ -6188,7 +6078,7 @@
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "requires": {
-        "mimic-fn": "1.2.0"
+        "mimic-fn": "^1.0.0"
       }
     },
     "opn": {
@@ -6196,7 +6086,7 @@
       "resolved": "https://registry.npmjs.org/opn/-/opn-3.0.3.tgz",
       "integrity": "sha1-ttmec5n3jWXDuq/+8fsojpuFJDo=",
       "requires": {
-        "object-assign": "4.1.1"
+        "object-assign": "^4.0.1"
       }
     },
     "optimist": {
@@ -6204,8 +6094,8 @@
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "requires": {
-        "minimist": "0.0.8",
-        "wordwrap": "0.0.3"
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
       }
     },
     "options": {
@@ -6223,9 +6113,9 @@
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
       "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
       "requires": {
-        "execa": "0.7.0",
-        "lcid": "1.0.0",
-        "mem": "1.1.0"
+        "execa": "^0.7.0",
+        "lcid": "^1.0.0",
+        "mem": "^1.1.0"
       },
       "dependencies": {
         "execa": {
@@ -6233,13 +6123,13 @@
           "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
           "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
           "requires": {
-            "cross-spawn": "5.1.0",
-            "get-stream": "3.0.0",
-            "is-stream": "1.1.0",
-            "npm-run-path": "2.0.2",
-            "p-finally": "1.0.0",
-            "signal-exit": "3.0.2",
-            "strip-eof": "1.0.0"
+            "cross-spawn": "^5.0.1",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
           }
         }
       }
@@ -6249,8 +6139,8 @@
       "resolved": "https://registry.npmjs.org/os-name/-/os-name-2.0.1.tgz",
       "integrity": "sha1-uaOGNhwXrjohc27wWZQFyajF3F4=",
       "requires": {
-        "macos-release": "1.1.0",
-        "win-release": "1.1.1"
+        "macos-release": "^1.0.0",
+        "win-release": "^1.0.0"
       }
     },
     "os-tmpdir": {
@@ -6263,8 +6153,8 @@
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
       "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
       "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
       }
     },
     "p-finally": {
@@ -6277,7 +6167,7 @@
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
       "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
       "requires": {
-        "p-try": "1.0.0"
+        "p-try": "^1.0.0"
       }
     },
     "p-locate": {
@@ -6285,7 +6175,7 @@
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "requires": {
-        "p-limit": "1.3.0"
+        "p-limit": "^1.1.0"
       }
     },
     "p-try": {
@@ -6298,11 +6188,11 @@
       "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
       "integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
       "requires": {
-        "asn1.js": "4.10.1",
-        "browserify-aes": "1.2.0",
-        "create-hash": "1.2.0",
-        "evp_bytestokey": "1.0.3",
-        "pbkdf2": "3.0.8"
+        "asn1.js": "^4.0.0",
+        "browserify-aes": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.0",
+        "pbkdf2": "^3.0.3"
       }
     },
     "parse-glob": {
@@ -6310,10 +6200,10 @@
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "requires": {
-        "glob-base": "0.3.0",
-        "is-dotfile": "1.0.3",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1"
+        "glob-base": "^0.3.0",
+        "is-dotfile": "^1.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.0"
       },
       "dependencies": {
         "is-extglob": {
@@ -6326,7 +6216,7 @@
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "^1.0.0"
           }
         }
       }
@@ -6336,7 +6226,7 @@
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "requires": {
-        "error-ex": "1.3.2"
+        "error-ex": "^1.2.0"
       }
     },
     "parse-passwd": {
@@ -6379,7 +6269,14 @@
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
       "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
       "requires": {
-        "pify": "2.3.0"
+        "pify": "^2.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+        }
       }
     },
     "pbkdf2": {
@@ -6387,7 +6284,7 @@
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.8.tgz",
       "integrity": "sha1-L4q/FuvsyCJ3lF10irodeHYfYeI=",
       "requires": {
-        "create-hmac": "1.1.7"
+        "create-hmac": "^1.1.2"
       }
     },
     "pegjs": {
@@ -6401,14 +6298,14 @@
       "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
     },
     "performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+      "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
     },
     "pify": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
     },
     "pinkie": {
       "version": "2.0.4",
@@ -6420,7 +6317,7 @@
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "^2.0.0"
       }
     },
     "pirates": {
@@ -6428,7 +6325,7 @@
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-3.0.2.tgz",
       "integrity": "sha512-c5CgUJq6H2k6MJz72Ak1F5sN9n9wlSlJyEnwvpm9/y3WB4E3pHBDT2c6PEiS1vyJvq2bUxUAIu0EGf8Cx4Ic7Q==",
       "requires": {
-        "node-modules-regexp": "1.0.0"
+        "node-modules-regexp": "^1.0.0"
       }
     },
     "pkg-dir": {
@@ -6436,7 +6333,7 @@
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
       "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
       "requires": {
-        "find-up": "2.1.0"
+        "find-up": "^2.1.0"
       }
     },
     "plist": {
@@ -6447,7 +6344,7 @@
         "base64-js": "0.0.8",
         "util-deprecate": "1.0.2",
         "xmlbuilder": "4.0.0",
-        "xmldom": "0.1.27"
+        "xmldom": "0.1.x"
       }
     },
     "plugin-error": {
@@ -6455,11 +6352,11 @@
       "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-0.1.2.tgz",
       "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
       "requires": {
-        "ansi-cyan": "0.1.1",
-        "ansi-red": "0.1.1",
-        "arr-diff": "1.1.0",
-        "arr-union": "2.1.0",
-        "extend-shallow": "1.1.4"
+        "ansi-cyan": "^0.1.1",
+        "ansi-red": "^0.1.1",
+        "arr-diff": "^1.0.1",
+        "arr-union": "^2.0.1",
+        "extend-shallow": "^1.1.2"
       },
       "dependencies": {
         "arr-diff": {
@@ -6467,8 +6364,8 @@
           "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
           "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
           "requires": {
-            "arr-flatten": "1.1.0",
-            "array-slice": "0.2.3"
+            "arr-flatten": "^1.0.1",
+            "array-slice": "^0.2.3"
           }
         },
         "arr-union": {
@@ -6481,7 +6378,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
           "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
           "requires": {
-            "kind-of": "1.1.0"
+            "kind-of": "^1.1.0"
           }
         },
         "kind-of": {
@@ -6531,7 +6428,7 @@
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
       "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
       "requires": {
-        "asap": "2.0.6"
+        "asap": "~2.0.3"
       }
     },
     "prop-types": {
@@ -6539,9 +6436,9 @@
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz",
       "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
       "requires": {
-        "fbjs": "0.8.16",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1"
+        "fbjs": "^0.8.16",
+        "loose-envify": "^1.3.1",
+        "object-assign": "^4.1.1"
       }
     },
     "prr": {
@@ -6559,11 +6456,11 @@
       "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.2.tgz",
       "integrity": "sha512-4kJ5Esocg8X3h8YgJsKAuoesBgB7mqH3eowiDzMUPKiRDDE7E/BqqZD1hnTByIaAFiwAw246YEltSq7tdrOH0Q==",
       "requires": {
-        "bn.js": "4.11.8",
-        "browserify-rsa": "4.0.1",
-        "create-hash": "1.2.0",
-        "parse-asn1": "5.1.1",
-        "randombytes": "2.0.6"
+        "bn.js": "^4.1.0",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "parse-asn1": "^5.0.0",
+        "randombytes": "^2.0.1"
       }
     },
     "punycode": {
@@ -6575,6 +6472,11 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/qr.js/-/qr.js-0.0.0.tgz",
       "integrity": "sha1-ys6GOG9ZoNuAUPqQ2baw6IoeNk8="
+    },
+    "qs": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+      "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
     },
     "querystring": {
       "version": "0.2.0",
@@ -6596,9 +6498,9 @@
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
       "integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
       "requires": {
-        "is-number": "4.0.0",
-        "kind-of": "6.0.2",
-        "math-random": "1.0.1"
+        "is-number": "^4.0.0",
+        "kind-of": "^6.0.0",
+        "math-random": "^1.0.1"
       },
       "dependencies": {
         "is-number": {
@@ -6613,7 +6515,7 @@
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
       "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "^5.1.0"
       }
     },
     "range-parser": {
@@ -6622,14 +6524,14 @@
       "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
     },
     "rc": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.7.tgz",
-      "integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "requires": {
-        "deep-extend": "0.5.1",
-        "ini": "1.3.5",
-        "minimist": "1.2.0",
-        "strip-json-comments": "2.0.1"
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
       },
       "dependencies": {
         "minimist": {
@@ -6644,15 +6546,15 @@
       "resolved": "https://registry.npmjs.org/re-natal/-/re-natal-0.8.1.tgz",
       "integrity": "sha512-fltbhe/P9PrQYLPncpzfRFOrSw53qSGehaIgnpU1EkrZFM7JwPuNUkJ6eY4yGW6ZB7FqhATZts7KybvRLqJXRA==",
       "requires": {
-        "chalk": "1.1.3",
-        "check-dependencies": "1.1.0",
-        "coffee-script": "1.12.7",
-        "commander": "2.15.1",
-        "deepmerge": "1.5.2",
-        "fs-extra": "0.26.7",
-        "handlebars": "4.0.11",
-        "klaw-sync": "2.1.0",
-        "semver": "5.5.0"
+        "chalk": "^1.1.1",
+        "check-dependencies": "^1.0.1",
+        "coffee-script": "^1.9.3",
+        "commander": "^2.8.1",
+        "deepmerge": "^1.5.2",
+        "fs-extra": "^0.26.5",
+        "handlebars": "^4.0.10",
+        "klaw-sync": "^2.1.0",
+        "semver": "^5.0.1"
       }
     },
     "react": {
@@ -6660,10 +6562,10 @@
       "resolved": "https://registry.npmjs.org/react/-/react-16.2.0.tgz",
       "integrity": "sha512-ZmIomM7EE1DvPEnSFAHZn9Vs9zJl5A9H7el0EGTE6ZbW9FKe/14IYAlPbC8iH25YarEQxZL+E8VW7Mi7kfQrDQ==",
       "requires": {
-        "fbjs": "0.8.16",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1",
-        "prop-types": "15.6.0"
+        "fbjs": "^0.8.16",
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.0"
       }
     },
     "react-clone-referenced-element": {
@@ -6681,8 +6583,8 @@
       "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-3.1.0.tgz",
       "integrity": "sha512-fO6SmpW16E9u6Lb6zQOHrjhJXGBNz+cJ0/a9cSF55nXfL0sQLlvYJR8DpU7f4rMUrVnVineg4XQyYYBZicmhJg==",
       "requires": {
-        "shell-quote": "1.6.1",
-        "ws": "2.3.1"
+        "shell-quote": "^1.6.1",
+        "ws": "^2.0.3"
       },
       "dependencies": {
         "safe-buffer": {
@@ -6700,8 +6602,8 @@
           "resolved": "https://registry.npmjs.org/ws/-/ws-2.3.1.tgz",
           "integrity": "sha1-a5Sz5EfLajY/eF6vlK9jWejoHIA=",
           "requires": {
-            "safe-buffer": "5.0.1",
-            "ultron": "1.1.1"
+            "safe-buffer": "~5.0.1",
+            "ultron": "~1.1.0"
           }
         }
       }
@@ -6711,74 +6613,75 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.2.0.tgz",
       "integrity": "sha512-zpGAdwHVn9K0091d+hr+R0qrjoJ84cIBFL2uU60KvWBPfZ7LPSrfqviTxGHWN0sjPZb2hxWzMexwrvJdKePvjg==",
       "requires": {
-        "fbjs": "0.8.16",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1",
-        "prop-types": "15.6.0"
+        "fbjs": "^0.8.16",
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.0"
       }
     },
     "react-native": {
       "version": "github:status-im/react-native#370bcffba748e895ad8afa825bfef40bff859c95",
+      "from": "github:status-im/react-native#v0.55.4",
       "requires": {
-        "absolute-path": "0.0.0",
-        "art": "0.10.2",
-        "babel-core": "6.24.1",
-        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
+        "absolute-path": "^0.0.0",
+        "art": "^0.10.0",
+        "babel-core": "^6.24.1",
+        "babel-plugin-syntax-trailing-function-commas": "^6.20.0",
         "babel-plugin-transform-async-to-generator": "6.16.0",
-        "babel-plugin-transform-class-properties": "6.24.1",
-        "babel-plugin-transform-exponentiation-operator": "6.24.1",
-        "babel-plugin-transform-flow-strip-types": "6.22.0",
-        "babel-plugin-transform-object-rest-spread": "6.26.0",
-        "babel-register": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "base64-js": "1.3.0",
-        "chalk": "1.1.3",
-        "commander": "2.15.1",
-        "compression": "1.7.2",
-        "connect": "3.6.6",
-        "create-react-class": "15.6.3",
-        "debug": "2.6.9",
-        "denodeify": "1.2.1",
-        "envinfo": "3.11.1",
-        "errorhandler": "1.5.0",
-        "eslint-plugin-react-native": "3.2.1",
-        "event-target-shim": "1.1.1",
-        "fbjs": "0.8.16",
-        "fbjs-scripts": "0.8.3",
-        "fs-extra": "1.0.0",
-        "glob": "7.1.2",
-        "graceful-fs": "4.1.11",
-        "inquirer": "3.3.0",
-        "lodash": "4.17.10",
-        "metro": "0.30.2",
-        "metro-core": "0.30.2",
-        "mime": "1.6.0",
-        "minimist": "1.2.0",
-        "mkdirp": "0.5.1",
-        "morgan": "1.9.0",
-        "node-fetch": "1.7.3",
-        "node-notifier": "5.2.1",
-        "npmlog": "2.0.4",
-        "opn": "3.0.3",
-        "optimist": "0.6.1",
-        "plist": "1.2.0",
-        "pretty-format": "4.3.1",
-        "promise": "7.3.1",
-        "prop-types": "15.6.0",
-        "react-clone-referenced-element": "1.0.1",
+        "babel-plugin-transform-class-properties": "^6.18.0",
+        "babel-plugin-transform-exponentiation-operator": "^6.5.0",
+        "babel-plugin-transform-flow-strip-types": "^6.21.0",
+        "babel-plugin-transform-object-rest-spread": "^6.20.2",
+        "babel-register": "^6.24.1",
+        "babel-runtime": "^6.23.0",
+        "base64-js": "^1.1.2",
+        "chalk": "^1.1.1",
+        "commander": "^2.9.0",
+        "compression": "^1.7.1",
+        "connect": "^3.6.5",
+        "create-react-class": "^15.6.3",
+        "debug": "^2.2.0",
+        "denodeify": "^1.2.1",
+        "envinfo": "^3.0.0",
+        "errorhandler": "^1.5.0",
+        "eslint-plugin-react-native": "^3.2.1",
+        "event-target-shim": "^1.0.5",
+        "fbjs": "^0.8.14",
+        "fbjs-scripts": "^0.8.1",
+        "fs-extra": "^1.0.0",
+        "glob": "^7.1.1",
+        "graceful-fs": "^4.1.3",
+        "inquirer": "^3.0.6",
+        "lodash": "^4.17.5",
+        "metro": "^0.30.0",
+        "metro-core": "^0.30.0",
+        "mime": "^1.3.4",
+        "minimist": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "morgan": "^1.9.0",
+        "node-fetch": "^1.3.3",
+        "node-notifier": "^5.2.1",
+        "npmlog": "^2.0.4",
+        "opn": "^3.0.2",
+        "optimist": "^0.6.1",
+        "plist": "^1.2.0",
+        "pretty-format": "^4.2.1",
+        "promise": "^7.1.1",
+        "prop-types": "^15.5.8",
+        "react-clone-referenced-element": "^1.0.1",
         "react-devtools-core": "3.1.0",
-        "react-timer-mixin": "0.13.3",
-        "regenerator-runtime": "0.11.1",
-        "rimraf": "2.6.2",
-        "semver": "5.5.0",
-        "serve-static": "1.13.2",
+        "react-timer-mixin": "^0.13.2",
+        "regenerator-runtime": "^0.11.0",
+        "rimraf": "^2.5.4",
+        "semver": "^5.0.3",
+        "serve-static": "^1.13.1",
         "shell-quote": "1.6.1",
-        "stacktrace-parser": "0.1.4",
-        "whatwg-fetch": "1.1.1",
-        "ws": "1.1.5",
-        "xcode": "0.9.3",
-        "xmldoc": "0.4.0",
-        "yargs": "9.0.1"
+        "stacktrace-parser": "^0.1.3",
+        "whatwg-fetch": "^1.0.0",
+        "ws": "^1.1.0",
+        "xcode": "^0.9.1",
+        "xmldoc": "^0.4.0",
+        "yargs": "^9.0.0"
       },
       "dependencies": {
         "babel-generator": {
@@ -6786,14 +6689,14 @@
           "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
           "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
           "requires": {
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "detect-indent": "4.0.0",
-            "jsesc": "1.3.0",
-            "lodash": "4.17.10",
-            "source-map": "0.5.7",
-            "trim-right": "1.0.1"
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "detect-indent": "^4.0.0",
+            "jsesc": "^1.3.0",
+            "lodash": "^4.17.4",
+            "source-map": "^0.5.7",
+            "trim-right": "^1.0.1"
           }
         },
         "babel-register": {
@@ -6801,13 +6704,13 @@
           "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
           "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
           "requires": {
-            "babel-core": "6.26.3",
-            "babel-runtime": "6.26.0",
-            "core-js": "2.5.6",
-            "home-or-tmp": "2.0.0",
-            "lodash": "4.17.10",
-            "mkdirp": "0.5.1",
-            "source-map-support": "0.4.18"
+            "babel-core": "^6.26.0",
+            "babel-runtime": "^6.26.0",
+            "core-js": "^2.5.0",
+            "home-or-tmp": "^2.0.0",
+            "lodash": "^4.17.4",
+            "mkdirp": "^0.5.1",
+            "source-map-support": "^0.4.15"
           },
           "dependencies": {
             "babel-core": {
@@ -6815,25 +6718,25 @@
               "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
               "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
               "requires": {
-                "babel-code-frame": "6.26.0",
-                "babel-generator": "6.26.1",
-                "babel-helpers": "6.24.1",
-                "babel-messages": "6.23.0",
-                "babel-register": "6.26.0",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0",
-                "babylon": "6.18.0",
-                "convert-source-map": "1.5.1",
-                "debug": "2.6.9",
-                "json5": "0.5.1",
-                "lodash": "4.17.10",
-                "minimatch": "3.0.4",
-                "path-is-absolute": "1.0.1",
-                "private": "0.1.8",
-                "slash": "1.0.0",
-                "source-map": "0.5.7"
+                "babel-code-frame": "^6.26.0",
+                "babel-generator": "^6.26.0",
+                "babel-helpers": "^6.24.1",
+                "babel-messages": "^6.23.0",
+                "babel-register": "^6.26.0",
+                "babel-runtime": "^6.26.0",
+                "babel-template": "^6.26.0",
+                "babel-traverse": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "babylon": "^6.18.0",
+                "convert-source-map": "^1.5.1",
+                "debug": "^2.6.9",
+                "json5": "^0.5.1",
+                "lodash": "^4.17.4",
+                "minimatch": "^3.0.4",
+                "path-is-absolute": "^1.0.1",
+                "private": "^0.1.8",
+                "slash": "^1.0.0",
+                "source-map": "^0.5.7"
               }
             }
           }
@@ -6853,9 +6756,9 @@
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wrap-ansi": "2.1.0"
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
           },
           "dependencies": {
             "string-width": {
@@ -6863,9 +6766,9 @@
               "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
               }
             }
           }
@@ -6875,9 +6778,9 @@
           "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.3.tgz",
           "integrity": "sha512-M+/3Q6E6DLO6Yx3OwrWjwHBnvfXXYA7W+dFjt/ZDBemHO1DDZhsalX/NUtnTYclN6GfnBDRh4qRHjcDHmlJBJg==",
           "requires": {
-            "fbjs": "0.8.16",
-            "loose-envify": "1.3.1",
-            "object-assign": "4.1.1"
+            "fbjs": "^0.8.9",
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
           }
         },
         "fs-extra": {
@@ -6885,9 +6788,9 @@
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
           "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
           "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "2.4.0",
-            "klaw": "1.3.1"
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^2.1.0",
+            "klaw": "^1.0.0"
           }
         },
         "is-fullwidth-code-point": {
@@ -6895,7 +6798,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "minimist": {
@@ -6913,19 +6816,19 @@
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-9.0.1.tgz",
           "integrity": "sha1-UqzCP+7Kw0BCB47njAwAf1CF20w=",
           "requires": {
-            "camelcase": "4.1.0",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "2.1.0",
-            "read-pkg-up": "2.0.0",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "2.1.1",
-            "which-module": "2.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "7.0.0"
+            "camelcase": "^4.1.0",
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^2.0.0",
+            "read-pkg-up": "^2.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^7.0.0"
           }
         }
       }
@@ -6940,7 +6843,7 @@
       "resolved": "https://registry.npmjs.org/react-native-camera/-/react-native-camera-0.10.0.tgz",
       "integrity": "sha512-qum5zdJ3GQZ/mB+SYdT8EhQVnIfmyLzwyIK9Ss4vsTGLKxKmt9tf7oGigT2t52aOy6tNglKcgYuU0cZREKGDDA==",
       "requires": {
-        "prop-types": "15.6.0"
+        "prop-types": "^15.5.10"
       }
     },
     "react-native-config": {
@@ -6953,15 +6856,15 @@
       "resolved": "https://registry.npmjs.org/react-native-crypto/-/react-native-crypto-2.1.1.tgz",
       "integrity": "sha512-JHwX0zobeYqCAwdSffRoivXeqlZR54WpCj8ICGcoNh7bvOh8khr63zvNk+fcqdRH3eI9Jhglygswijza0f3D4Q==",
       "requires": {
-        "browserify-cipher": "1.0.1",
-        "browserify-sign": "4.0.4",
-        "create-ecdh": "4.0.3",
-        "create-hash": "1.2.0",
-        "create-hmac": "1.1.7",
-        "diffie-hellman": "5.0.3",
-        "inherits": "2.0.1",
+        "browserify-cipher": "^1.0.0",
+        "browserify-sign": "^4.0.4",
+        "create-ecdh": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.0",
+        "diffie-hellman": "^5.0.0",
+        "inherits": "^2.0.1",
         "pbkdf2": "3.0.8",
-        "public-encrypt": "4.0.2"
+        "public-encrypt": "^4.0.0"
       }
     },
     "react-native-dialogs": {
@@ -6984,26 +6887,20 @@
       "resolved": "https://registry.npmjs.org/react-native-fs/-/react-native-fs-2.8.1.tgz",
       "integrity": "sha512-1v7NrbYlx47VkWaemcbXdzJHoG5GVKdkNIwwH8vJVFQTc5jJYaUxXdn+g+duc6+DD08Yt5Of6eFh3ILc88mNMw==",
       "requires": {
-        "base-64": "0.1.0",
-        "utf8": "2.1.2"
-      }
-    },
-    "react-native-http": {
-      "version": "github:tradle/react-native-http#834492dbc792b1dec8ec8f0a1c9671f640339f01",
-      "requires": {
-        "Base64": "0.2.1",
-        "inherits": "2.0.1"
+        "base-64": "^0.1.0",
+        "utf8": "^2.1.1"
       }
     },
     "react-native-http-bridge": {
-      "version": "github:status-im/react-native-http-bridge#86c56aa05dfb35ac2956c85dfadf77b9ca1da59c"
+      "version": "git+ssh://git@github.com/status-im/react-native-http-bridge.git#86c56aa05dfb35ac2956c85dfadf77b9ca1da59c",
+      "from": "git+ssh://git@github.com/status-im/react-native-http-bridge.git"
     },
     "react-native-i18n": {
       "version": "2.0.9",
       "resolved": "https://registry.npmjs.org/react-native-i18n/-/react-native-i18n-2.0.9.tgz",
       "integrity": "sha512-aHaXLvvEHwsSLLuK+IeE2plWyAXFwbCIEDsTrQZAN73iUFetZZfD97GkCWi+/yWfLQPlFHaMGJbGkd6fIUDaxA==",
       "requires": {
-        "i18n-js": "3.0.3"
+        "i18n-js": "^3.0.2"
       }
     },
     "react-native-image-crop-picker": {
@@ -7021,10 +6918,10 @@
       "resolved": "https://registry.npmjs.org/react-native-invertible-scroll-view/-/react-native-invertible-scroll-view-1.1.0.tgz",
       "integrity": "sha1-v9UKP11myhJjm3x6mETO3dHRaJA=",
       "requires": {
-        "create-react-class": "15.6.2",
-        "prop-types": "15.6.0",
-        "react-clone-referenced-element": "1.0.1",
-        "react-native-scrollable-mixin": "1.0.1"
+        "create-react-class": "^15.6.0",
+        "prop-types": "^15.5.10",
+        "react-clone-referenced-element": "^1.0.1",
+        "react-native-scrollable-mixin": "^1.0.1"
       }
     },
     "react-native-keychain": {
@@ -7037,8 +6934,8 @@
       "resolved": "https://registry.npmjs.org/react-native-level-fs/-/react-native-level-fs-3.0.0.tgz",
       "integrity": "sha1-uefSeEhbaWY0pifMYEV3yyr5698=",
       "requires": {
-        "level-filesystem": "1.2.0",
-        "levelup": "0.18.6"
+        "level-filesystem": "^1.0.1",
+        "levelup": "^0.18.2"
       }
     },
     "react-native-os": {
@@ -7051,8 +6948,8 @@
       "resolved": "https://registry.npmjs.org/react-native-qrcode/-/react-native-qrcode-0.2.6.tgz",
       "integrity": "sha1-3ZLxUcEYhgCSr5+lvAmV8vnd2xY=",
       "requires": {
-        "create-react-class": "15.6.2",
-        "prop-types": "15.6.0",
+        "create-react-class": "^15.6.0",
+        "prop-types": "^15.5.10",
         "qr.js": "0.0.0"
       }
     },
@@ -7066,7 +6963,7 @@
       "resolved": "https://registry.npmjs.org/react-native-securerandom/-/react-native-securerandom-0.1.1.tgz",
       "integrity": "sha1-8TBiOkEsM4sK+t7bwgTFy7i/IHA=",
       "requires": {
-        "base64-js": "0.0.8"
+        "base64-js": "*"
       }
     },
     "react-native-splash-screen": {
@@ -7079,9 +6976,9 @@
       "resolved": "https://registry.npmjs.org/react-native-svg/-/react-native-svg-6.3.1.tgz",
       "integrity": "sha512-0kmfUwKUBWnPuJpy+bdGIYKkXHg/M/X57ji8b3d3ZFB2rRTWMRkwI1D+AJ6FQRX109+FJn6L6hsIokDj1lckzA==",
       "requires": {
-        "color": "2.0.1",
-        "lodash": "4.17.10",
-        "pegjs": "0.10.0"
+        "color": "^2.0.1",
+        "lodash": "^4.16.6",
+        "pegjs": "^0.10.0"
       }
     },
     "react-native-tcp": {
@@ -7090,11 +6987,11 @@
       "integrity": "sha512-WAiL3IGhVxvmM0iw7/5ZRzdkiJBfBbLoFKNaHLJIsTZVqD/N5ZHUlJMjIQ+RrmB/f5nJ82bUEZ2vPCxe+rlNqQ==",
       "requires": {
         "base64-js": "0.0.8",
-        "buffer": "5.1.0",
-        "events": "1.1.1",
-        "ip-regex": "1.0.3",
-        "process": "0.11.10",
-        "util": "0.10.3"
+        "buffer": "^5.0.0",
+        "events": "^1.0.2",
+        "ip-regex": "^1.0.3",
+        "process": "^0.11.9",
+        "util": "^0.10.3"
       },
       "dependencies": {
         "buffer": {
@@ -7102,8 +6999,8 @@
           "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.1.0.tgz",
           "integrity": "sha512-YkIRgwsZwJWTnyQrsBTWefizHh+8GYj3kbL1BTiAQ/9pwpino0G7B2gp5tx/FUBqUlvtxV85KNR3mwfAtv15Yw==",
           "requires": {
-            "base64-js": "1.3.0",
-            "ieee754": "1.1.11"
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4"
           },
           "dependencies": {
             "base64-js": {
@@ -7126,14 +7023,15 @@
       "integrity": "sha1-Y1NsYVCzborhi870AMT66iT5QDU=",
       "requires": {
         "base64-js": "0.0.8",
-        "events": "1.1.1",
-        "inherits": "2.0.1",
-        "ip-regex": "1.0.3",
-        "util": "0.10.3"
+        "events": "^1.0.2",
+        "inherits": "^2.0.1",
+        "ip-regex": "^1.0.3",
+        "util": "^0.10.3"
       }
     },
     "react-native-webview-bridge": {
-      "version": "github:status-im/react-native-webview-bridge#80a798c4004bf38bf4e965e38a6f6bc59557278d",
+      "version": "git+ssh://git@github.com/status-im/react-native-webview-bridge.git#80a798c4004bf38bf4e965e38a6f6bc59557278d",
+      "from": "git+ssh://git@github.com/status-im/react-native-webview-bridge.git",
       "requires": {
         "invariant": "2.2.0",
         "keymirror": "0.1.1"
@@ -7144,7 +7042,7 @@
           "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
           "integrity": "sha1-yNfoRzZqScwYtiLwWKaJ1IHolfI=",
           "requires": {
-            "loose-envify": "1.3.1"
+            "loose-envify": "^1.0.0"
           }
         }
       }
@@ -7154,8 +7052,8 @@
       "resolved": "https://registry.npmjs.org/react-proxy/-/react-proxy-1.1.8.tgz",
       "integrity": "sha1-nb/Z2SdSjDqp9ETkVYw3gwq4wmo=",
       "requires": {
-        "lodash": "4.17.10",
-        "react-deep-force-update": "1.1.1"
+        "lodash": "^4.6.1",
+        "react-deep-force-update": "^1.0.0"
       }
     },
     "react-timer-mixin": {
@@ -7168,8 +7066,8 @@
       "resolved": "https://registry.npmjs.org/react-transform-hmr/-/react-transform-hmr-1.0.4.tgz",
       "integrity": "sha1-4aQL0Krvxy6N/Xp82gmvhQZjl7s=",
       "requires": {
-        "global": "4.3.2",
-        "react-proxy": "1.1.8"
+        "global": "^4.3.0",
+        "react-proxy": "^1.1.7"
       }
     },
     "read-pkg": {
@@ -7177,9 +7075,9 @@
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
       "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
       "requires": {
-        "load-json-file": "2.0.0",
-        "normalize-package-data": "2.4.0",
-        "path-type": "2.0.0"
+        "load-json-file": "^2.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^2.0.0"
       }
     },
     "read-pkg-up": {
@@ -7187,8 +7085,8 @@
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
       "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
       "requires": {
-        "find-up": "2.1.0",
-        "read-pkg": "2.0.0"
+        "find-up": "^2.0.0",
+        "read-pkg": "^2.0.0"
       }
     },
     "readable-stream": {
@@ -7196,26 +7094,21 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "2.0.0",
-        "safe-buffer": "5.1.2",
-        "string_decoder": "1.1.1",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       },
       "dependencies": {
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-        },
         "string_decoder": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
-            "safe-buffer": "5.1.2"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -7225,19 +7118,19 @@
       "resolved": "https://registry.npmjs.org/realm/-/realm-2.3.3.tgz",
       "integrity": "sha1-3Z3AE3+VsXAWVLqRk5KNUurEI50=",
       "requires": {
-        "command-line-args": "4.0.7",
-        "decompress": "4.2.0",
-        "fs-extra": "4.0.3",
-        "ini": "1.3.5",
+        "command-line-args": "^4.0.6",
+        "decompress": "^4.2.0",
+        "fs-extra": "^4.0.2",
+        "ini": "^1.3.4",
         "nan": "2.8.0",
-        "node-fetch": "1.7.3",
-        "node-pre-gyp": "0.6.39",
-        "progress": "2.0.0",
-        "prop-types": "15.6.0",
-        "request": "2.86.0",
-        "stream-counter": "1.0.0",
-        "sync-request": "3.0.1",
-        "url-parse": "1.4.0"
+        "node-fetch": "^1.6.3",
+        "node-pre-gyp": "^0.6.36",
+        "progress": "^2.0.0",
+        "prop-types": "^15.5.10",
+        "request": "^2.78.0",
+        "stream-counter": "^1.0.0",
+        "sync-request": "^3.0.1",
+        "url-parse": "^1.2.0"
       },
       "dependencies": {
         "fs-extra": {
@@ -7245,9 +7138,9 @@
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
           "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
           "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "4.0.0",
-            "universalify": "0.1.1"
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
           }
         },
         "jsonfile": {
@@ -7255,18 +7148,13 @@
           "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
           "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
           "requires": {
-            "graceful-fs": "4.1.11"
+            "graceful-fs": "^4.1.6"
           }
         },
         "nan": {
           "version": "2.8.0",
           "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
           "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo="
-        },
-        "stream-counter": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/stream-counter/-/stream-counter-1.0.0.tgz",
-          "integrity": "sha1-kc8lac5NxQYf6816yyY5SloRR1E="
         }
       }
     },
@@ -7285,9 +7173,9 @@
       "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
       "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "private": "0.1.8"
+        "babel-runtime": "^6.18.0",
+        "babel-types": "^6.19.0",
+        "private": "^0.1.6"
       }
     },
     "regex-cache": {
@@ -7295,7 +7183,7 @@
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
       "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "requires": {
-        "is-equal-shallow": "0.1.3"
+        "is-equal-shallow": "^0.1.3"
       }
     },
     "regex-not": {
@@ -7303,8 +7191,8 @@
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
       "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
       "requires": {
-        "extend-shallow": "3.0.2",
-        "safe-regex": "1.1.0"
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
       }
     },
     "regexpu-core": {
@@ -7312,9 +7200,9 @@
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
       "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
       "requires": {
-        "regenerate": "1.4.0",
-        "regjsgen": "0.2.0",
-        "regjsparser": "0.1.5"
+        "regenerate": "^1.2.1",
+        "regjsgen": "^0.2.0",
+        "regjsparser": "^0.1.4"
       }
     },
     "regjsgen": {
@@ -7327,7 +7215,7 @@
       "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
       "requires": {
-        "jsesc": "0.5.0"
+        "jsesc": "~0.5.0"
       },
       "dependencies": {
         "jsesc": {
@@ -7357,41 +7245,105 @@
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "requires": {
-        "is-finite": "1.0.2"
+        "is-finite": "^1.0.0"
       }
     },
     "request": {
-      "version": "2.86.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.86.0.tgz",
-      "integrity": "sha512-BQZih67o9r+Ys94tcIW4S7Uu8pthjrQVxhsZ/weOwHbDfACxvIyvnAbzFQxjy1jMtvFSzv5zf4my6cZsJBbVzw==",
+      "version": "2.87.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
+      "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
       "requires": {
-        "aws-sign2": "0.7.0",
-        "aws4": "1.7.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.6",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.3.2",
-        "har-validator": "5.0.3",
-        "hawk": "6.0.2",
-        "http-signature": "1.2.0",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.18",
-        "oauth-sign": "0.8.2",
-        "performance-now": "2.1.0",
-        "qs": "6.5.2",
-        "safe-buffer": "5.1.2",
-        "tough-cookie": "2.3.4",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.2.1"
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.6.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.5",
+        "extend": "~3.0.1",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.1",
+        "har-validator": "~5.0.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.17",
+        "oauth-sign": "~0.8.2",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.1",
+        "safe-buffer": "^5.1.1",
+        "tough-cookie": "~2.3.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.1.0"
       },
       "dependencies": {
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "requires": {
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
+          }
+        },
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        },
+        "aws-sign2": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+          "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+        },
+        "form-data": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+          "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "har-schema": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+          "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+        },
+        "har-validator": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+          "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+          "requires": {
+            "ajv": "^5.1.0",
+            "har-schema": "^2.0.0"
+          }
+        },
+        "http-signature": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+          "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+          "requires": {
+            "assert-plus": "^1.0.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
+          }
+        },
+        "performance-now": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+          "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+        },
         "qs": {
           "version": "6.5.2",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
           "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+        },
+        "uuid": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.0.tgz",
+          "integrity": "sha512-ijO9N2xY/YaOqQ5yz5c4sy2ZjWmA6AR6zASb/gdpeKZ8+948CxwfMW9RrKVk5may6ev8c0/Xguu32e2Llelpqw=="
         }
       }
     },
@@ -7415,7 +7367,7 @@
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
       "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
       "requires": {
-        "path-parse": "1.0.5"
+        "path-parse": "^1.0.5"
       }
     },
     "resolve-dir": {
@@ -7423,8 +7375,8 @@
       "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
       "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
       "requires": {
-        "expand-tilde": "2.0.2",
-        "global-modules": "1.0.0"
+        "expand-tilde": "^2.0.0",
+        "global-modules": "^1.0.0"
       }
     },
     "resolve-url": {
@@ -7437,8 +7389,8 @@
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "requires": {
-        "onetime": "2.0.1",
-        "signal-exit": "3.0.2"
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
       }
     },
     "ret": {
@@ -7452,7 +7404,7 @@
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
       "optional": true,
       "requires": {
-        "align-text": "0.1.4"
+        "align-text": "^0.1.1"
       }
     },
     "rimraf": {
@@ -7460,7 +7412,7 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "requires": {
-        "glob": "7.1.2"
+        "glob": "^7.0.5"
       }
     },
     "ripemd160": {
@@ -7468,15 +7420,16 @@
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
       "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
       "requires": {
-        "hash-base": "3.0.4",
-        "inherits": "2.0.1"
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
       }
     },
     "rn-snoopy": {
-      "version": "github:status-im/rn-snoopy#f23dc13469c6c2a694649f658cdc1d1eaf8def64",
+      "version": "git+ssh://git@github.com/status-im/rn-snoopy.git#f23dc13469c6c2a694649f658cdc1d1eaf8def64",
+      "from": "git+ssh://git@github.com/status-im/rn-snoopy.git",
       "requires": {
         "eslint-plugin-jsx-a11y": "5.1.1",
-        "lodash": "3.10.1",
+        "lodash": "^3.10.0",
         "rxjs": "5.5.2"
       },
       "dependencies": {
@@ -7497,7 +7450,7 @@
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
       "requires": {
-        "is-promise": "2.1.0"
+        "is-promise": "^2.1.0"
       }
     },
     "rx-lite": {
@@ -7510,7 +7463,7 @@
       "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
       "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
       "requires": {
-        "rx-lite": "4.0.8"
+        "rx-lite": "*"
       }
     },
     "rxjs": {
@@ -7518,7 +7471,7 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.2.tgz",
       "integrity": "sha512-oRYoIKWBU3Ic37fLA5VJu31VqQO4bWubRntcHSJ+cwaDQBwdnZ9x4zmhJfm/nFQ2E82/I4loSioHnACamrKGgA==",
       "requires": {
-        "symbol-observable": "1.2.0"
+        "symbol-observable": "^1.0.1"
       }
     },
     "safe-buffer": {
@@ -7531,7 +7484,7 @@
       "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "requires": {
-        "ret": "0.1.15"
+        "ret": "~0.1.10"
       }
     },
     "safer-buffer": {
@@ -7544,15 +7497,15 @@
       "resolved": "https://registry.npmjs.org/sane/-/sane-2.5.2.tgz",
       "integrity": "sha1-tNwYYcIbQn6SlQej51HiosuKs/o=",
       "requires": {
-        "anymatch": "2.0.0",
-        "capture-exit": "1.2.0",
-        "exec-sh": "0.2.2",
-        "fb-watchman": "2.0.0",
-        "fsevents": "1.2.4",
-        "micromatch": "3.1.10",
-        "minimist": "1.2.0",
-        "walker": "1.0.7",
-        "watch": "0.18.0"
+        "anymatch": "^2.0.0",
+        "capture-exit": "^1.2.0",
+        "exec-sh": "^0.2.0",
+        "fb-watchman": "^2.0.0",
+        "fsevents": "^1.2.3",
+        "micromatch": "^3.1.4",
+        "minimist": "^1.1.1",
+        "walker": "~1.0.5",
+        "watch": "~0.18.0"
       },
       "dependencies": {
         "minimist": {
@@ -7572,7 +7525,7 @@
       "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
       "integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
       "requires": {
-        "commander": "2.8.1"
+        "commander": "~2.8.1"
       },
       "dependencies": {
         "commander": {
@@ -7580,7 +7533,7 @@
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
           "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
           "requires": {
-            "graceful-readlink": "1.0.1"
+            "graceful-readlink": ">= 1.0.0"
           }
         }
       }
@@ -7596,18 +7549,18 @@
       "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
       "requires": {
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "destroy": "1.0.4",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "etag": "1.8.1",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "1.6.3",
+        "http-errors": "~1.6.2",
         "mime": "1.4.1",
         "ms": "2.0.0",
-        "on-finished": "2.3.0",
-        "range-parser": "1.2.0",
-        "statuses": "1.4.0"
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.4.0"
       },
       "dependencies": {
         "mime": {
@@ -7632,9 +7585,9 @@
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
       "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
       "requires": {
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "parseurl": "1.3.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.2",
         "send": "0.16.2"
       }
     },
@@ -7648,10 +7601,10 @@
       "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
       "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
       "requires": {
-        "extend-shallow": "2.0.1",
-        "is-extendable": "0.1.1",
-        "is-plain-object": "2.0.4",
-        "split-string": "3.1.0"
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
       },
       "dependencies": {
         "extend-shallow": {
@@ -7659,7 +7612,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -7679,8 +7632,8 @@
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "requires": {
-        "inherits": "2.0.1",
-        "safe-buffer": "5.1.2"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "shebang-command": {
@@ -7688,7 +7641,7 @@
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "requires": {
-        "shebang-regex": "1.0.0"
+        "shebang-regex": "^1.0.0"
       }
     },
     "shebang-regex": {
@@ -7701,10 +7654,10 @@
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
       "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
       "requires": {
-        "array-filter": "0.0.1",
-        "array-map": "0.0.0",
-        "array-reduce": "0.0.0",
-        "jsonify": "0.0.0"
+        "array-filter": "~0.0.0",
+        "array-map": "~0.0.0",
+        "array-reduce": "~0.0.0",
+        "jsonify": "~0.0.0"
       }
     },
     "shellwords": {
@@ -7739,7 +7692,7 @@
           "requires": {
             "base64-js": "1.1.2",
             "xmlbuilder": "8.2.2",
-            "xmldom": "0.1.27"
+            "xmldom": "0.1.x"
           }
         },
         "xmlbuilder": {
@@ -7754,13 +7707,13 @@
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
       "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
       "requires": {
-        "is-arrayish": "0.3.1"
+        "is-arrayish": "^0.3.1"
       },
       "dependencies": {
         "is-arrayish": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.1.tgz",
-          "integrity": "sha1-wt/DhquqDD4zxI2z/ocFnmkGXv0="
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+          "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
         }
       }
     },
@@ -7779,14 +7732,14 @@
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
       "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
       "requires": {
-        "base": "0.11.2",
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "map-cache": "0.2.2",
-        "source-map": "0.5.7",
-        "source-map-resolve": "0.5.2",
-        "use": "3.1.0"
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -7794,7 +7747,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "extend-shallow": {
@@ -7802,7 +7755,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -7812,9 +7765,9 @@
       "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
       "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
       "requires": {
-        "define-property": "1.0.0",
-        "isobject": "3.0.1",
-        "snapdragon-util": "3.0.1"
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -7822,7 +7775,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "requires": {
-            "is-descriptor": "1.0.2"
+            "is-descriptor": "^1.0.0"
           }
         },
         "is-accessor-descriptor": {
@@ -7830,7 +7783,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -7838,7 +7791,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -7846,9 +7799,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         }
       }
@@ -7858,7 +7811,7 @@
       "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
       "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.2.0"
       },
       "dependencies": {
         "kind-of": {
@@ -7866,17 +7819,17 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
     },
     "sntp": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
-      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
       "requires": {
-        "hoek": "4.2.1"
+        "hoek": "2.x.x"
       }
     },
     "source-map": {
@@ -7889,11 +7842,11 @@
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
       "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
       "requires": {
-        "atob": "2.1.1",
-        "decode-uri-component": "0.2.0",
-        "resolve-url": "0.2.1",
-        "source-map-url": "0.4.0",
-        "urix": "0.1.0"
+        "atob": "^2.1.1",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
       }
     },
     "source-map-support": {
@@ -7901,7 +7854,7 @@
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
       "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
       "requires": {
-        "source-map": "0.5.7"
+        "source-map": "^0.5.6"
       }
     },
     "source-map-url": {
@@ -7914,8 +7867,8 @@
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
       "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
       "requires": {
-        "spdx-expression-parse": "3.0.0",
-        "spdx-license-ids": "3.0.0"
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-exceptions": {
@@ -7928,8 +7881,8 @@
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
       "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "requires": {
-        "spdx-exceptions": "2.1.0",
-        "spdx-license-ids": "3.0.0"
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-license-ids": {
@@ -7942,22 +7895,30 @@
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "requires": {
-        "extend-shallow": "3.0.2"
+        "extend-shallow": "^3.0.0"
       }
     },
     "sshpk": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
-      "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
+      "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
       "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "tweetnacl": "0.14.5"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
       }
     },
     "stacktrace-parser": {
@@ -7970,8 +7931,8 @@
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "requires": {
-        "define-property": "0.2.5",
-        "object-copy": "0.1.0"
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -7979,7 +7940,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         }
       }
@@ -7994,6 +7955,11 @@
       "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
       "integrity": "sha1-kdX1Ew0c75bc+n9yaUUYh0HQnuQ="
     },
+    "stream-counter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/stream-counter/-/stream-counter-1.0.0.tgz",
+      "integrity": "sha1-kc8lac5NxQYf6816yyY5SloRR1E="
+    },
     "string-range": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/string-range/-/string-range-1.2.2.tgz",
@@ -8004,8 +7970,8 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "requires": {
-        "is-fullwidth-code-point": "2.0.0",
-        "strip-ansi": "4.0.0"
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -8018,7 +7984,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -8038,7 +8004,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "strip-bom": {
@@ -8051,7 +8017,7 @@
       "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
       "integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
       "requires": {
-        "is-natural-number": "4.0.1"
+        "is-natural-number": "^4.0.1"
       }
     },
     "strip-eof": {
@@ -8079,9 +8045,9 @@
       "resolved": "https://registry.npmjs.org/sync-request/-/sync-request-3.0.1.tgz",
       "integrity": "sha1-yqEjWq+Im6UBB2oYNMQ2gwqC+3M=",
       "requires": {
-        "concat-stream": "1.6.2",
-        "http-response-object": "1.1.0",
-        "then-request": "2.2.0"
+        "concat-stream": "^1.4.7",
+        "http-response-object": "^1.0.1",
+        "then-request": "^2.0.1"
       }
     },
     "tar": {
@@ -8089,9 +8055,9 @@
       "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
       "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
       "requires": {
-        "block-stream": "0.0.9",
-        "fstream": "1.0.11",
-        "inherits": "2.0.1"
+        "block-stream": "*",
+        "fstream": "^1.0.2",
+        "inherits": "2"
       }
     },
     "tar-pack": {
@@ -8099,14 +8065,14 @@
       "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.1.tgz",
       "integrity": "sha512-PPRybI9+jM5tjtCbN2cxmmRU7YmqT3Zv/UDy48tAh2XRkLa9bAORtSWLkVc13+GJF+cdTh1yEnHEk3cpTaL5Kg==",
       "requires": {
-        "debug": "2.6.9",
-        "fstream": "1.0.11",
-        "fstream-ignore": "1.0.5",
-        "once": "1.4.0",
-        "readable-stream": "2.3.6",
-        "rimraf": "2.6.2",
-        "tar": "2.2.1",
-        "uid-number": "0.0.6"
+        "debug": "^2.2.0",
+        "fstream": "^1.0.10",
+        "fstream-ignore": "^1.0.5",
+        "once": "^1.3.3",
+        "readable-stream": "^2.1.4",
+        "rimraf": "^2.5.1",
+        "tar": "^2.2.1",
+        "uid-number": "^0.0.6"
       }
     },
     "tar-stream": {
@@ -8114,13 +8080,13 @@
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.1.tgz",
       "integrity": "sha512-IFLM5wp3QrJODQFPm6/to3LJZrONdBY/otxcvDIQzu217zKye6yVR3hhi9lAjrC2Z+m/j5oDxMPb1qcd8cIvpA==",
       "requires": {
-        "bl": "1.2.2",
-        "buffer-alloc": "1.1.0",
-        "end-of-stream": "1.4.1",
-        "fs-constants": "1.0.0",
-        "readable-stream": "2.3.6",
-        "to-buffer": "1.1.1",
-        "xtend": "4.0.1"
+        "bl": "^1.0.0",
+        "buffer-alloc": "^1.1.0",
+        "end-of-stream": "^1.0.0",
+        "fs-constants": "^1.0.0",
+        "readable-stream": "^2.3.0",
+        "to-buffer": "^1.1.0",
+        "xtend": "^4.0.0"
       },
       "dependencies": {
         "bl": {
@@ -8128,8 +8094,8 @@
           "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
           "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
           "requires": {
-            "readable-stream": "2.3.6",
-            "safe-buffer": "5.1.2"
+            "readable-stream": "^2.3.5",
+            "safe-buffer": "^5.1.1"
           }
         }
       }
@@ -8139,8 +8105,8 @@
       "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
       "integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
       "requires": {
-        "os-tmpdir": "1.0.2",
-        "rimraf": "2.2.8"
+        "os-tmpdir": "^1.0.0",
+        "rimraf": "~2.2.6"
       },
       "dependencies": {
         "rimraf": {
@@ -8155,8 +8121,8 @@
       "resolved": "https://registry.npmjs.org/test-value/-/test-value-2.1.0.tgz",
       "integrity": "sha1-Edpv9nDzRxpztiXKTz/c97t0gpE=",
       "requires": {
-        "array-back": "1.0.4",
-        "typical": "2.6.1"
+        "array-back": "^1.0.3",
+        "typical": "^2.6.0"
       },
       "dependencies": {
         "array-back": {
@@ -8164,7 +8130,7 @@
           "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
           "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
           "requires": {
-            "typical": "2.6.1"
+            "typical": "^2.6.0"
           }
         }
       }
@@ -8174,23 +8140,18 @@
       "resolved": "https://registry.npmjs.org/then-request/-/then-request-2.2.0.tgz",
       "integrity": "sha1-ZnizL6DKIY/laZgbvYhxtZQGDYE=",
       "requires": {
-        "caseless": "0.11.0",
-        "concat-stream": "1.6.2",
-        "http-basic": "2.5.1",
-        "http-response-object": "1.1.0",
-        "promise": "7.3.1",
-        "qs": "6.5.2"
+        "caseless": "~0.11.0",
+        "concat-stream": "^1.4.7",
+        "http-basic": "^2.5.1",
+        "http-response-object": "^1.1.0",
+        "promise": "^7.1.1",
+        "qs": "^6.1.0"
       },
       "dependencies": {
         "caseless": {
           "version": "0.11.0",
           "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
           "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c="
-        },
-        "qs": {
-          "version": "6.5.2",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
         }
       }
     },
@@ -8209,8 +8170,8 @@
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "requires": {
-        "readable-stream": "2.3.6",
-        "xtend": "4.0.1"
+        "readable-stream": "^2.1.5",
+        "xtend": "~4.0.1"
       }
     },
     "time-stamp": {
@@ -8228,7 +8189,7 @@
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "requires": {
-        "os-tmpdir": "1.0.2"
+        "os-tmpdir": "~1.0.2"
       }
     },
     "tmpl": {
@@ -8251,7 +8212,7 @@
       "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -8259,7 +8220,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -8269,10 +8230,10 @@
       "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
       "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
       "requires": {
-        "define-property": "2.0.2",
-        "extend-shallow": "3.0.2",
-        "regex-not": "1.0.2",
-        "safe-regex": "1.1.0"
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "regex-not": "^1.0.2",
+        "safe-regex": "^1.1.0"
       }
     },
     "to-regex-range": {
@@ -8280,8 +8241,8 @@
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "requires": {
-        "is-number": "3.0.0",
-        "repeat-string": "1.6.1"
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1"
       }
     },
     "tough-cookie": {
@@ -8289,7 +8250,7 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
       "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
       "requires": {
-        "punycode": "1.4.1"
+        "punycode": "^1.4.1"
       }
     },
     "trim-right": {
@@ -8302,7 +8263,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
@@ -8332,9 +8293,9 @@
       "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
       "optional": true,
       "requires": {
-        "source-map": "0.5.7",
-        "uglify-to-browserify": "1.0.2",
-        "yargs": "3.10.0"
+        "source-map": "~0.5.1",
+        "uglify-to-browserify": "~1.0.0",
+        "yargs": "~3.10.0"
       }
     },
     "uglify-to-browserify": {
@@ -8358,8 +8319,8 @@
       "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.2.5.tgz",
       "integrity": "sha512-izD3jxT8xkzwtXRUZjtmRwKnZoeECrfZ8ra/ketwOcusbZEp4mjULMnJOCfTDZBgGQAAY1AJ/IgxcwkavcX9Og==",
       "requires": {
-        "buffer": "3.6.0",
-        "through": "2.3.8"
+        "buffer": "^3.0.1",
+        "through": "^2.3.6"
       }
     },
     "union-value": {
@@ -8367,10 +8328,10 @@
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
       "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
       "requires": {
-        "arr-union": "3.1.0",
-        "get-value": "2.0.6",
-        "is-extendable": "0.1.1",
-        "set-value": "0.4.3"
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^0.4.3"
       },
       "dependencies": {
         "extend-shallow": {
@@ -8378,7 +8339,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         },
         "set-value": {
@@ -8386,18 +8347,18 @@
           "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-extendable": "0.1.1",
-            "is-plain-object": "2.0.4",
-            "to-object-path": "0.3.0"
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.1",
+            "to-object-path": "^0.3.0"
           }
         }
       }
     },
     "universalify": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
-      "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc="
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
     "unpipe": {
       "version": "1.0.0",
@@ -8409,8 +8370,8 @@
       "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "requires": {
-        "has-value": "0.3.1",
-        "isobject": "3.0.1"
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
       },
       "dependencies": {
         "has-value": {
@@ -8418,9 +8379,9 @@
           "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "requires": {
-            "get-value": "2.0.6",
-            "has-values": "0.1.4",
-            "isobject": "2.1.0"
+            "get-value": "^2.0.3",
+            "has-values": "^0.1.4",
+            "isobject": "^2.0.0"
           },
           "dependencies": {
             "isobject": {
@@ -8445,7 +8406,7 @@
       "resolved": "https://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz",
       "integrity": "sha1-F+soB5h/dpUunASF/DEdBqgmouA=",
       "requires": {
-        "os-homedir": "1.0.2"
+        "os-homedir": "^1.0.0"
       }
     },
     "urix": {
@@ -8470,12 +8431,12 @@
       }
     },
     "url-parse": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.0.tgz",
-      "integrity": "sha512-ERuGxDiQ6Xw/agN4tuoCRbmwRuZP0cJ1lJxJubXr5Q/5cDa78+Dc4wfvtxzhzhkm5VvmW6Mf8EVj9SPGN4l8Lg==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.1.tgz",
+      "integrity": "sha512-x95Td74QcvICAA0+qERaVkRpTGKyBHHYdwL2LXZm5t/gBtCB9KQSO/0zQgSTYEV1p0WcvSg79TLNPSvd5IDJMQ==",
       "requires": {
-        "querystringify": "2.0.0",
-        "requires-port": "1.0.0"
+        "querystringify": "^2.0.0",
+        "requires-port": "^1.0.0"
       }
     },
     "use": {
@@ -8483,7 +8444,7 @@
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
       "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
       "requires": {
-        "kind-of": "6.0.2"
+        "kind-of": "^6.0.2"
       }
     },
     "utf8": {
@@ -8497,6 +8458,13 @@
       "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
       "requires": {
         "inherits": "2.0.1"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+        }
       }
     },
     "util-deprecate": {
@@ -8510,17 +8478,17 @@
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+      "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE="
     },
     "validate-npm-package-license": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
       "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
       "requires": {
-        "spdx-correct": "3.0.0",
-        "spdx-expression-parse": "3.0.0"
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
       }
     },
     "vary": {
@@ -8533,9 +8501,16 @@
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
+        "extsprintf": "^1.2.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
       }
     },
     "walker": {
@@ -8543,7 +8518,7 @@
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
       "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
       "requires": {
-        "makeerror": "1.0.11"
+        "makeerror": "1.0.x"
       }
     },
     "watch": {
@@ -8551,8 +8526,8 @@
       "resolved": "https://registry.npmjs.org/watch/-/watch-0.18.0.tgz",
       "integrity": "sha1-KAlUdsbffJDJYxOJkMClQj60uYY=",
       "requires": {
-        "exec-sh": "0.2.2",
-        "minimist": "1.2.0"
+        "exec-sh": "^0.2.0",
+        "minimist": "^1.2.0"
       },
       "dependencies": {
         "minimist": {
@@ -8563,13 +8538,20 @@
       }
     },
     "web3": {
-      "version": "github:status-im/web3.js#ff09ce57e9574a1c42138832a7d6bf6c2e699048",
+      "version": "git+ssh://git@github.com/status-im/web3.js.git#ff09ce57e9574a1c42138832a7d6bf6c2e699048",
+      "from": "git+ssh://git@github.com/status-im/web3.js.git#feature/shhext",
       "requires": {
         "bignumber.js": "github:status-im/bignumber.js#cc066a0a3d6bfe0c436c9957f4ea8344bf963c89",
-        "crypto-js": "3.1.8",
-        "utf8": "2.1.2",
-        "xhr2": "0.1.4",
-        "xmlhttprequest": "1.8.0"
+        "crypto-js": "^3.1.4",
+        "utf8": "^2.1.1",
+        "xhr2": "*",
+        "xmlhttprequest": "*"
+      },
+      "dependencies": {
+        "bignumber.js": {
+          "version": "github:status-im/bignumber.js#cc066a0a3d6bfe0c436c9957f4ea8344bf963c89",
+          "from": "github:status-im/bignumber.js#master"
+        }
       }
     },
     "whatwg-fetch": {
@@ -8578,11 +8560,11 @@
       "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
     },
     "which": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "which-module": {
@@ -8591,31 +8573,11 @@
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
     },
     "wide-align": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-      "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
       "requires": {
-        "string-width": "1.0.2"
-      },
-      "dependencies": {
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
-        }
+        "string-width": "^1.0.2 || 2"
       }
     },
     "win-release": {
@@ -8623,7 +8585,7 @@
       "resolved": "https://registry.npmjs.org/win-release/-/win-release-1.1.1.tgz",
       "integrity": "sha1-X6VeAr58qTTt/BJmVjLoSbcuUgk=",
       "requires": {
-        "semver": "5.5.0"
+        "semver": "^5.0.1"
       }
     },
     "window-size": {
@@ -8642,8 +8604,8 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1"
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
       },
       "dependencies": {
         "is-fullwidth-code-point": {
@@ -8651,7 +8613,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "string-width": {
@@ -8659,9 +8621,9 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         }
       }
@@ -8676,9 +8638,9 @@
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
       "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "imurmurhash": "0.1.4",
-        "slide": "1.1.6"
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "slide": "^1.1.5"
       }
     },
     "ws": {
@@ -8686,8 +8648,8 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.5.tgz",
       "integrity": "sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==",
       "requires": {
-        "options": "0.0.6",
-        "ultron": "1.0.2"
+        "options": ">=0.0.5",
+        "ultron": "1.0.x"
       }
     },
     "xcode": {
@@ -8695,16 +8657,9 @@
       "resolved": "https://registry.npmjs.org/xcode/-/xcode-0.9.3.tgz",
       "integrity": "sha1-kQqJwWrubMC0LKgFptC0z4chHPM=",
       "requires": {
-        "pegjs": "0.10.0",
-        "simple-plist": "0.2.1",
+        "pegjs": "^0.10.0",
+        "simple-plist": "^0.2.1",
         "uuid": "3.0.1"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
-          "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE="
-        }
       }
     },
     "xhr2": {
@@ -8717,7 +8672,7 @@
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.0.0.tgz",
       "integrity": "sha1-mLj2UcowqmJANvEn0RzGbce5B6M=",
       "requires": {
-        "lodash": "3.10.1"
+        "lodash": "^3.5.0"
       },
       "dependencies": {
         "lodash": {
@@ -8732,7 +8687,7 @@
       "resolved": "https://registry.npmjs.org/xmldoc/-/xmldoc-0.4.0.tgz",
       "integrity": "sha1-0lciS+g5PqrL+DfvIn/Y7CWzaIg=",
       "requires": {
-        "sax": "1.1.6"
+        "sax": "~1.1.1"
       }
     },
     "xmldom": {
@@ -8771,9 +8726,9 @@
       "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
       "optional": true,
       "requires": {
-        "camelcase": "1.2.1",
-        "cliui": "2.1.0",
-        "decamelize": "1.2.0",
+        "camelcase": "^1.0.2",
+        "cliui": "^2.1.0",
+        "decamelize": "^1.0.0",
         "window-size": "0.1.0"
       }
     },
@@ -8782,7 +8737,7 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
       "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
       "requires": {
-        "camelcase": "4.1.0"
+        "camelcase": "^4.1.0"
       },
       "dependencies": {
         "camelcase": {
@@ -8793,12 +8748,12 @@
       }
     },
     "yauzl": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.9.1.tgz",
-      "integrity": "sha1-qBmB6nCleUYTOIPwKcWCGok1mn8=",
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.9.2.tgz",
+      "integrity": "sha1-T7G8euH8L1cDe1SvasyP4QMcW3c=",
       "requires": {
-        "buffer-crc32": "0.2.13",
-        "fd-slicer": "1.0.1"
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "start": "node node_modules/react-native/local-cli/cli.js start"
   },
   "dependencies": {
+    "@tradle/react-native-http": "^2.0.1",
     "assert": "1.4.1",
     "asyncstorage-down": "4.0.1",
     "babel-core": "6.24.1",
@@ -14,7 +15,7 @@
     "babel-plugin-transform-es2015-block-scoping": "6.15.0",
     "babel-preset-react-native": "4.0.0",
     "babel-register": "6.18.0",
-    "bignumber.js": "github:status-im/bignumber.js#master",
+    "bignumber.js": "git@github.com:status-im/bignumber.js.git",
     "buffer": "3.6.0",
     "chance": "1.0.12",
     "create-react-class": "15.6.2",
@@ -22,10 +23,10 @@
     "emojilib": "2.2.9",
     "events": "1.1.1",
     "homoglyph-finder": "1.1.1",
-    "identicon.js": "github:status-im/identicon.js",
+    "identicon.js": "git@github.com:status-im/identicon.js.git",
     "instabug-reactnative": "2.12.0",
     "level-filesystem": "1.2.0",
-    "nfc-react-native": "github:status-im/nfc-react-native",
+    "nfc-react-native": "git@github.com:status-im/nfc-react-native.git",
     "process": "0.11.10",
     "prop-types": "15.6.0",
     "punycode": "1.4.1",
@@ -42,8 +43,7 @@
     "react-native-fcm": "10.0.3",
     "react-native-fetch-polyfill": "1.1.2",
     "react-native-fs": "2.8.1",
-    "react-native-http": "github:tradle/react-native-http#834492d",
-    "react-native-http-bridge": "github:status-im/react-native-http-bridge",
+    "react-native-http-bridge": "git@github.com:status-im/react-native-http-bridge.git",
     "react-native-i18n": "2.0.9",
     "react-native-image-crop-picker": "0.18.1",
     "react-native-image-resizer": "1.0.0",
@@ -58,11 +58,11 @@
     "react-native-tcp": "3.3.0",
     "react-native-testfairy": "2.10.0",
     "react-native-udp": "2.2.1",
-    "react-native-webview-bridge": "github:status-im/react-native-webview-bridge",
+    "react-native-webview-bridge": "git@github.com:status-im/react-native-webview-bridge.git",
     "realm": "2.3.3",
-    "rn-snoopy": "github:status-im/rn-snoopy",
+    "rn-snoopy": "git@github.com:status-im/rn-snoopy.git",
     "string_decoder": "0.10.31",
     "url": "0.10.3",
-    "web3": "github:status-im/web3.js#feature/shhext"
+    "web3": "git@github.com:status-im/web3.js.git#feature/shhext"
   }
 }

--- a/scripts/setup
+++ b/scripts/setup
@@ -25,6 +25,7 @@ setup_header "Installing requirements..."
 
 install_and_setup_package_manager
 install_java8
+install_clojure_cli
 install_leiningen
 install_node
 install_watchman


### PR DESCRIPTION
Fixes #4901 

Tested on **node v7.10.1 (npm v5.5.1)** and **node v9.11.2 (npm v6.1.0)**.
Node 10 is not supported by Realm: https://github.com/realm/realm-js/issues/1813

Also updated our build scripts, added the installation of Clojure CLI there (to build status with `clj-rn`) and made sure it works.