### PR TITLE
don't logout on version # click

### DIFF
--- a/src/status_im/ui/screens/desktop/main/tabs/profile/styles.cljs
+++ b/src/status_im/ui/screens/desktop/main/tabs/profile/styles.cljs
@@ -2,4 +2,5 @@
 
 (def logout-row
   {:justify-content :space-between
-   :flex-direction  :row})
+   :flex-direction  :row
+   :margin-top      60})

--- a/src/status_im/ui/screens/desktop/main/tabs/profile/views.cljs
+++ b/src/status_im/ui/screens/desktop/main/tabs/profile/views.cljs
@@ -40,9 +40,7 @@
      [react/view
       [my-profile-info current-account]]
      [react/view {:style {:height 1 :background-color "#e8ebec" :margin-horizontal 16}}]
-     [react/touchable-highlight {:on-press #(re-frame/dispatch [:logout])
-                                 :style {:margin-top 60}}
-
-      [react/view {:style styles/logout-row}
-       [react/text {:style {:color colors/red}} (i18n/label :t/logout)]
-       [react/text {:style {:color colors/gray}} "V" build/version]]]]))
+     [react/view {:style styles/logout-row}
+      [react/touchable-highlight {:on-press #(re-frame/dispatch [:logout])}
+       [react/text {:style {:color colors/red}} (i18n/label :t/logout)]]
+      [react/text {:style {:color colors/gray}} "V" build/version]]]))


### PR DESCRIPTION
Fixes #4976 

In my other PR the logout action was encompassing the version number as that was part of the same row. This fix reduces the clickable surface area that results in a logout action to just the `Log out` text. 

Thanks for spotting @EugeOrtiz :)