### PR TITLE
bug #4963 - removed balance from asset suggestion box to prevent text…

### DIFF
--- a/src/status_im/chat/views/api/choose_asset.cljs
+++ b/src/status_im/chat/views/api/choose_asset.cljs
@@ -21,8 +21,10 @@
                      :style  styles/asset-icon}]
        [react/text {:style styles/asset-symbol} symbol]
        [react/text {:style styles/asset-name} name]]
-      [react/text {:style styles/asset-balance}
-       (str (money/internal->formatted amount symbol decimals))]]]))
+      ;;TODO(goranjovic) : temporarily disabled to fix https://github.com/status-im/status-react/issues/4963
+      ;;until the resolution of https://github.com/status-im/status-react/issues/4972
+      #_[react/text {:style styles/asset-balance}
+         (str (money/internal->formatted amount symbol decimals))]]]))
 
 (def assets-separator [react/view styles/asset-separator])
 


### PR DESCRIPTION
fixes #4963

### Summary:

Removes the balance from asset suggestion box in /send command in order to prevent text overlap when both asset name and current balance are long.

This is just a quick fix, the proper solution will be submitted as a part of issue #4972 once the final designs are ready.

### Steps to test:
- Try `/send` and `/request` from chat


status: ready <!-- Can be ready or wip -->
