### PR TITLE
Stop node before starting on desktop platform

### DIFF
--- a/src/status_im/ui/screens/events.cljs
+++ b/src/status_im/ui/screens/events.cljs
@@ -151,7 +151,11 @@
       (if should-move?
         (re-frame/dispatch [:request-permissions {:permissions [:read-external-storage]
                                                   :on-allowed  #(move-to-internal-storage config)}])
-        (status/start-node (types/clj->json config)))))))
+        (do
+          ;; Preemptively stop node if it's already running
+          ;; in order to prevent "node is already running" errors
+          (when platform/desktop? (status/stop-node))
+          (status/start-node (types/clj->json config))))))))
 
 (re-frame/reg-fx
  ::status-module-initialized-fx


### PR DESCRIPTION
Dumb solution how to prevent app crashing when e.g. `Reload JS` is invoked from RN menu. This only affects dev environment.

As I understand, there is a `IsRunning` fn in status-go module, but it is not exported to `libstatus.h`, at least that's my understanding. Maybe it would've been better to export `IsRunning` and use it, but this approach is much simpler and still effective.