### PR TITLE
Remove old code which is not used anymore

### DIFF
--- a/resources/js/bots/console/bot.js
+++ b/resources/js/bots/console/bot.js
@@ -516,15 +516,6 @@ if (faucets.length > 0) {
     status.command(faucetCommandConfig);
 }
 
-status.response({
-    name: "grant-permissions",
-    scope: ["personal-chats", "anonymous", "registered", "dapps"],
-    color: "#7099e6",
-    description: "Grant permissions",
-    icon: "lock_white",
-    executeImmediately: true
-});
-
 status.addListener("on-message-input-change", function (params, context) {
     return jsSuggestions({code: params.message}, context);
 });

--- a/src/status_im/chat/events/commands.cljs
+++ b/src/status_im/chat/events/commands.cljs
@@ -83,16 +83,6 @@
      (shortcuts/shortcut-override-fx db message opts)
      (request-command-message-data db message opts))))
 
-(handlers/register-handler-fx
- :execute-command-immediately
- [re-frame/trim-v]
- (fn [_ [{command-name :name}]]
-   (case (keyword command-name)
-     :grant-permissions
-     {:dispatch [:request-permissions {:permissions [:read-external-storage]
-                                       :on-allowed  #(re-frame/dispatch [:initialize-geth])}]}
-     (log/debug "ignoring command: " command-name))))
-
 ;; NOTE(goranjovic) - continues execution of a command that was paused by a shortcut
 (defn execute-stored-command [{:keys [db]}]
   (let [{:keys [message opts]} (:commands/stored-command db)]

--- a/src/status_im/chat/views/message/request_message.cljs
+++ b/src/status_im/chat/views/message/request_message.cljs
@@ -95,7 +95,6 @@
           network-mismatch? (and request-network (not= request-network network))
           on-press-handler (cond
                              network-mismatch? nil
-                             (:execute-immediately? command) #(dispatch [:execute-command-immediately command])
                              (and (not answered?) status-initialized?) #(set-chat-command message-id command))]
       [view
        [touchable-highlight


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

Small PR removing hardcoded bot logic which is not used anymore (`grant-permissions` response was made obsolete with the demise of the `/location` command long ago).
No QA necessary as the change is super simple and I just decided to isolate it as a separate PR while working on the next stage (complete move of the commands/response logic to the cljs side, starting with `/send`/`/receive` commands), and as that change will be little bit larger, it's good to separate it into more smaller PRs like this one.

status: ready
