### PR TITLE
small changes for coordination of docs and latest addition of RN fork

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,7 @@ repl-android: ##@repl Start REPL for Android
 # Run
 # -------------
 run-android: ##@run Run Android build
+	cd android; ./gradlew react-native-android:installArchives
 	react-native run-android --appIdSuffix debug
 
 SIMULATOR=

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -248,7 +248,7 @@ task hemroidBuild(type: Exec) {
     def rootDir = project.rootDir
     def localProperties = new File(rootDir, "local.properties")
 
-    def ndkDir = "$System.env.ANDROID_NDK_HOME"
+    def ndkDir = "$System.env.ANDROID_NDK"
     if (localProperties.exists()) {
         Properties properties = new Properties()
         localProperties.withInputStream { instr ->

--- a/scripts/run-osx
+++ b/scripts/run-osx
@@ -76,7 +76,7 @@ sleep 10s
 
 adb reverse tcp:8081 tcp:8081 && adb reverse tcp:3449 tcp:3449
 
-react-native run-android
+make run-android
 
 if [ ! -z $3 ]
 then


### PR DESCRIPTION
1) only `ANDROID_NDK` is necessary for setup
2) call `./gradlew react-native-android:installArchives` in `make run-android`

status: ready 
