### PR TITLE
Use status-go develop branch

### DIFF
--- a/modules/react-native-status/desktop/CMakeLists.txt
+++ b/modules/react-native-status/desktop/CMakeLists.txt
@@ -37,7 +37,7 @@ ExternalProject_Add(StatusGo_ep
   PREFIX ${StatusGo_PREFIX}
   SOURCE_DIR ${StatusGo_SOURCE_DIR}
   GIT_REPOSITORY https://github.com/status-im/status-go.git
-  GIT_TAG origin/develop-desktop
+  GIT_TAG origin/develop
   BUILD_BYPRODUCTS ${StatusGo_STATIC_LIB}
   CONFIGURE_COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/${CONFIGURE_SCRIPT} ${GO_ROOT_PATH} ${StatusGo_ROOT} ${StatusGo_SOURCE_DIR}
   BUILD_COMMAND ""

--- a/modules/react-native-status/desktop/rctstatus.cpp
+++ b/modules/react-native-status/desktop/rctstatus.cpp
@@ -40,7 +40,7 @@ RCTStatus* RCTStatusPrivate::rctStatus = nullptr;
 
 RCTStatus::RCTStatus(QObject* parent) : QObject(parent), d_ptr(new RCTStatusPrivate) {
     RCTStatusPrivate::rctStatus = this;
-    SetJailSignalCallback((void*)&RCTStatus::jailSignalEventCallback);
+    SetSignalEventCallback((void*)&RCTStatus::jailSignalEventCallback);
     connect(this, &RCTStatus::jailSignalEvent, this, &RCTStatus::onJailSignalEvent);
 }
 


### PR DESCRIPTION
fixes #4996

### Summary:
Use status-go main development branch

### Testing notes:
communication with geth node affected (login, messaging, etc) Since we recently have updated used status-go version there should be not big history of new changes in develop branch of status-go and possibility to introduce new issues is low.
