### PR TITLE
Use partitioned topic for discovery

### DIFF
--- a/src/status_im/data_store/realm/schemas/account/core.cljs
+++ b/src/status_im/data_store/realm/schemas/account/core.cljs
@@ -6,7 +6,8 @@
    [status-im.data-store.realm.schemas.account.v4.core :as v4]
    [status-im.data-store.realm.schemas.account.v5.core :as v5]
    [status-im.data-store.realm.schemas.account.v6.core :as v6]
-   [status-im.data-store.realm.schemas.account.v7.core :as v7]))
+   [status-im.data-store.realm.schemas.account.v7.core :as v7]
+   [status-im.data-store.realm.schemas.account.v8.core :as v8]))
 
 ;; TODO(oskarth): Add failing test if directory vXX exists but isn't in schemas.
 
@@ -31,4 +32,7 @@
                :migration     v6/migration}
               {:schema        v7/schema
                :schemaVersion 7
-               :migration     v7/migration}])
+               :migration     v7/migration}
+              {:schema        v8/schema
+               :schemaVersion 8
+               :migration     v8/migration}])

--- a/src/status_im/data_store/realm/schemas/account/v8/core.cljs
+++ b/src/status_im/data_store/realm/schemas/account/v8/core.cljs
@@ -1,0 +1,25 @@
+(ns status-im.data-store.realm.schemas.account.v8.core
+  (:require [status-im.data-store.realm.schemas.account.v5.chat :as chat]
+            [status-im.data-store.realm.schemas.account.v8.transport :as transport]
+            [status-im.data-store.realm.schemas.account.v1.contact :as contact]
+            [status-im.data-store.realm.schemas.account.v7.message :as message]
+            [status-im.data-store.realm.schemas.account.v1.request :as request]
+            [status-im.data-store.realm.schemas.account.v1.user-status :as user-status]
+            [status-im.data-store.realm.schemas.account.v1.local-storage :as local-storage]
+            [status-im.data-store.realm.schemas.account.v2.mailserver :as mailserver]
+            [status-im.data-store.realm.schemas.account.v1.browser :as browser]
+            [taoensso.timbre :as log]))
+
+(def schema [chat/schema
+             transport/schema
+             contact/schema
+             message/schema
+             request/schema
+             mailserver/schema
+             user-status/schema
+             local-storage/schema
+             browser/schema])
+
+(defn migration [old-realm new-realm]
+  (log/debug "migrating v8 account database: " old-realm new-realm)
+  (transport/migration old-realm new-realm))

--- a/src/status_im/data_store/realm/schemas/account/v8/transport.cljs
+++ b/src/status_im/data_store/realm/schemas/account/v8/transport.cljs
@@ -1,0 +1,38 @@
+(ns status-im.data-store.realm.schemas.account.v8.transport
+  (:require
+   [clojure.string :as string]
+   [taoensso.timbre :as log]))
+
+(def schema {:name       :transport
+             :primaryKey :chat-id
+             :properties {:chat-id               :string
+                          :ack                   :string
+                          :seen                  :string
+                          :pending-ack           :string
+                          :pending-send          :string
+                          :topic                 :string
+                          :one-to-one            {:type    :bool
+                                                  :optional true}
+                          :fetch-history?        {:type    :bool
+                                                  :default false}
+                          :resend?               {:type     :string
+                                                  :optional true}
+                          :sym-key-id            {:type    :string
+                                                  :optional true}
+                          ;;TODO (yenda) remove once go implements persistence
+                          :sym-key               {:type     :string
+                                                  :optional true}}})
+
+(defn one-to-one? [chat-id]
+  (re-matches #"^0x[0-9a-fA-F]+$" chat-id))
+
+(defn migration [old-realm new-realm]
+  (log/debug "migrating transport chats")
+  (let [old-chats (.objects old-realm "transport")
+        new-chats (.objects new-realm "transport")]
+    (dotimes [i (.-length old-chats)]
+      (let [old-chat (aget old-chats i)
+            new-chat (aget new-chats i)
+            chat-id  (aget old-chat "chat-id")]
+        (when (one-to-one? chat-id)
+          (aset new-chat "one-to-one" true))))))

--- a/src/status_im/transport/db.cljs
+++ b/src/status_im/transport/db.cljs
@@ -16,10 +16,10 @@
 (spec/def ::sym-key-id string?)
 ;;TODO (yenda) remove once go implements persistence
 (spec/def ::sym-key string?)
-(spec/def ::filter any?)
+(spec/def ::filters (spec/coll-of any?))
 
 (spec/def :transport/chat (allowed-keys :req-un [::ack ::seen ::pending-ack ::pending-send ::topic ::fetch-history?]
-                                        :opt-un [::sym-key-id ::sym-key ::filter ::resend?]))
+                                        :opt-un [::sym-key-id ::sym-key ::filters ::resend? ::one-to-one]))
 
 (spec/def :transport/chats (spec/map-of :global/not-empty-string :transport/chat))
 (spec/def :transport/discovery-filter (spec/nilable any?))
@@ -32,6 +32,7 @@
    :seen                  []
    :pending-ack           []
    :pending-send          []
+   :one-to-one            false
    :fetch-history?        true
    :resend?               resend?
    :topic                 topic})

--- a/src/status_im/transport/filters.cljs
+++ b/src/status_im/transport/filters.cljs
@@ -4,7 +4,47 @@
             [status-im.utils.handlers :as handlers]
             [status-im.transport.utils :as utils]
             [status-im.utils.config :as config]
+            [status-im.utils.random :as random]
+            [status-im.constants :as constants]
+            [status-im.utils.random]
             [taoensso.timbre :as log]))
+
+;; Number of different personal topics
+(def n-partitions 5000)
+
+(defn expected-number-of-collisions
+  "Expected number of topic collision given the number of expected users,
+  we want this value to be greater than a threshold to avoid positive
+  identification given the attacker has a topic & public key.
+  Used only for safety-checking n-partitions"
+  [total-users]
+  (+
+   (- total-users
+      n-partitions)
+   (* n-partitions
+      (js/Math.pow
+       (/
+        (- n-partitions 1)
+        n-partitions)
+       total-users))))
+
+(defn partition-topic
+  "Given a public key return a partitioned topic between 0 and n"
+  [pk]
+  (let [gen (random/rand-gen pk)]
+    (-> (random/seeded-rand-int gen n-partitions)
+        (str "-discovery")
+        utils/get-topic)))
+
+(def discovery-topic
+  (utils/get-topic constants/contact-discovery))
+
+(defn discovery-topics [pk]
+  [(partition-topic pk)
+   discovery-topic])
+
+(defn- receive-message [chat-id js-error js-message]
+  (re-frame/dispatch [:protocol/receive-whisper-message js-error js-message chat-id]))
 
 (defn remove-filter! [filter]
   (.stopWatching filter
@@ -21,38 +61,49 @@
                      #(log/warn :add-filter-error (.stringify js/JSON (clj->js options)) %)))
 
 (defn add-filter!
-  [web3 {:keys [topics to] :as options} callback]
-  (let [options  (if config/offline-inbox-enabled?
-                   (assoc options :allowP2P true)
-                   options)]
-    (log/debug :add-filter options)
-    (add-shh-filter! web3 options callback)))
+  [web3 {:keys [chat-id event]} raw-shh-options callback]
+  (let [shh-options  (if config/offline-inbox-enabled?
+                       (assoc raw-shh-options :allowP2P true)
+                       raw-shh-options)]
+    (log/debug :add-filter chat-id shh-options)
+    (if-let [filter (add-shh-filter! web3 shh-options callback)]
+      (re-frame/dispatch [event filter chat-id])
+      (log/error "Could not create filter for" shh-options))))
 
 (re-frame/reg-fx
  :shh/add-filter
- (fn [{:keys [web3 sym-key-id topic chat-id]}]
-   (when-let [filter (add-filter! web3
-                                  {:topics [topic]
-                                   :symKeyID sym-key-id}
-                                  (fn [js-error js-message]
-                                    (re-frame/dispatch [:protocol/receive-whisper-message js-error js-message chat-id])))]
-     (re-frame/dispatch [::filter-added chat-id filter]))))
+ (fn [{:keys [web3 sym-key-id one-to-one topic chat-id]}]
+   (add-filter! web3
+                {:chat-id chat-id
+                 :event ::filter-added}
+                {:topics [topic]
+                 :symKeyID sym-key-id}
+                (partial receive-message chat-id))
+   ;; We add a noop filter to avoid identification
+   (when one-to-one
+     (add-filter!
+      web3
+      {:chat-id chat-id
+       :event ::filter-added}
+      {:topics [(partition-topic chat-id)]
+       :minPow 1
+       :symKeyId sym-key-id}
+      (constantly nil)))))
 
 (handlers/register-handler-db
  ::filter-added
  [re-frame/trim-v]
- (fn [db [chat-id filter]]
-   (assoc-in db [:transport/chats chat-id :filter] filter)))
+ (fn [db [filter chat-id]]
+   (update-in db [:transport/chats chat-id :filters] conj filter)))
 
 (re-frame/reg-fx
  :shh/add-discovery-filter
- (fn [{:keys [web3 private-key-id topic]}]
-   (when-let [filter (add-filter! web3
-                                  {:topics [topic]
-                                   :privateKeyID private-key-id}
-                                  (fn [js-error js-message]
-                                    (re-frame/dispatch [:protocol/receive-whisper-message js-error js-message])))]
-     (re-frame/dispatch [::discovery-filter-added filter]))))
+ (fn [{:keys [web3 private-key-id topics]}]
+   (add-filter! web3
+                {:event ::discovery-filter-added}
+                {:topics topics
+                 :privateKeyID private-key-id}
+                (partial receive-message nil))))
 
 (handlers/register-handler-db
  ::discovery-filter-added

--- a/src/status_im/transport/handlers.cljs
+++ b/src/status_im/transport/handlers.cljs
@@ -75,11 +75,13 @@
          chat-transport-info               (-> (get-in db [:transport/chats chat-id])
                                                (assoc :sym-key-id sym-key-id
                                                       :sym-key sym-key
+                                                      :one-to-one true
                                                       :topic topic))]
      (handlers-macro/merge-fx cofx
                               {:db (assoc-in db [:transport/chats chat-id] chat-transport-info)
                                :shh/add-filter {:web3       web3
                                                 :sym-key-id sym-key-id
+                                                :one-to-one true
                                                 :topic      topic
                                                 :chat-id    chat-id}
                                :data-store/tx  [(transport-store/save-transport-tx {:chat-id chat-id
@@ -94,6 +96,7 @@
          chat-transport-info               (-> (get-in db [:transport/chats chat-id])
                                                (assoc :sym-key-id sym-key-id
                                                       :sym-key sym-key
+                                                      :one-to-one true
                                                       :topic topic))]
      (handlers-macro/merge-fx cofx
                               {:db             (assoc-in db
@@ -102,6 +105,7 @@
                                :dispatch       [:inbox/request-chat-history chat-id]
                                :shh/add-filter {:web3       web3
                                                 :sym-key-id sym-key-id
+                                                :one-to-one true
                                                 :topic      topic
                                                 :chat-id    chat-id}
                                :data-store/tx  [(transport-store/save-transport-tx {:chat-id chat-id

--- a/src/status_im/transport/inbox.cljs
+++ b/src/status_im/transport/inbox.cljs
@@ -5,6 +5,7 @@
             [status-im.utils.handlers :as handlers]
             [status-im.utils.handlers-macro :as handlers-macro]
             [status-im.transport.utils :as transport.utils]
+            [status-im.transport.filters :as transport.filters]
             [status-im.utils.config :as config]
             [taoensso.timbre :as log]
             [status-im.constants :as constants]
@@ -233,10 +234,11 @@
 (defn get-request-messages-topics
   "Returns topics for which full history has already been recovered"
   [db]
-  (conj (map :topic
-             (remove :fetch-history?
-                     (vals (:transport/chats db))))
-        (transport.utils/get-topic constants/contact-discovery)))
+  (concat
+   (map :topic
+        (remove :fetch-history?
+                (vals (:transport/chats db))))
+   (transport.filters/discovery-topics (:current-public-key db))))
 
 (defn get-request-history-topics
   "Returns topics for which full history has not been recovered"

--- a/src/status_im/transport/message/v1/contact.cljs
+++ b/src/status_im/transport/message/v1/contact.cljs
@@ -22,9 +22,10 @@
       (handlers-macro/merge-fx cofx
                                {:shh/get-new-sym-keys [{:web3       (:web3 db)
                                                         :on-success on-success}]}
-                               (protocol/init-chat {:chat-id chat-id
-                                                    :topic   topic
-                                                    :resend? "contact-request"})))))
+                               (protocol/init-chat {:chat-id    chat-id
+                                                    :topic      topic
+                                                    :one-to-one true
+                                                    :resend?    "contact-request"})))))
 
 (defrecord ContactRequestConfirmed [name profile-image address fcm-token]
   message/StatusMessage

--- a/src/status_im/transport/utils.cljs
+++ b/src/status_im/transport/utils.cljs
@@ -9,10 +9,10 @@
 (defn unsubscribe-from-chat
   "Unsubscribe from chat on transport layer"
   [chat-id {:keys [db]}]
-  (let [filter (get-in db [:transport/chats chat-id :filter])]
-    {:db                (update db :transport/chats dissoc chat-id)
-     :data-store/tx     [(transport-store/delete-transport-tx chat-id)]
-     :shh/remove-filter filter}))
+  (let [filters (get-in db [:transport/chats chat-id :filters])]
+    {:db                 (update db :transport/chats dissoc chat-id)
+     :data-store/tx      [(transport-store/delete-transport-tx chat-id)]
+     :shh/remove-filters filters}))
 
 (defn from-utf8 [s]
   (.fromUtf8 dependencies/Web3.prototype s))

--- a/src/status_im/utils/config.cljs
+++ b/src/status_im/utils/config.cljs
@@ -23,6 +23,7 @@
 (def offline-inbox-enabled? (enabled? (get-config :OFFLINE_INBOX_ENABLED "1")))
 (def bootnodes-settings-enabled? (enabled? (get-config :BOOTNODES_SETTINGS_ENABLED "1")))
 (def universal-links-enabled? (enabled? (get-config :UNIVERSAL_LINK_ENABLED "1")))
+(def partitioned-topic-enabled? (enabled? (get-config :PARTITIONED_TOPIC "0")))
 (def log-level
   (-> (get-config :LOG_LEVEL "error")
       string/lower-case

--- a/test/cljs/status_im/test/runner.cljs
+++ b/test/cljs/status_im/test/runner.cljs
@@ -20,6 +20,7 @@
             [status-im.test.transport.core]
             [status-im.test.transport.inbox]
             [status-im.test.transport.handlers]
+            [status-im.test.transport.filters]
             [status-im.test.chat.models]
             [status-im.test.chat.models.input]
             [status-im.test.chat.models.message]
@@ -85,6 +86,7 @@
  'status-im.test.transport.core
  'status-im.test.transport.inbox
  'status-im.test.transport.handlers
+ 'status-im.test.transport.filters
  'status-im.test.protocol.web3.inbox
  'status-im.test.utils.utils
  'status-im.test.utils.handlers-macro

--- a/test/cljs/status_im/test/transport/core.cljs
+++ b/test/cljs/status_im/test/transport/core.cljs
@@ -9,9 +9,14 @@
                    {:networks {"mainnet_rpc" {:config {:NetworkId 1}}}
                     :public-key "1"}}}]
     (testing "it adds the discover filter"
-      (is (= (:shh/add-discovery-filter (protocol.handlers/initialize-protocol cofx [])))))
+      (let [actual (:shh/add-discovery-filter (protocol.handlers/initialize-protocol cofx []))]
+        (is actual)
+        (testing "it adds the topics"
+          (is (=
+               ["0x2af2e6e7" "0xf8946aac"]
+               (:topics actual))))))
     (testing "it restores the sym-keys"
-      (is (= (:shh/restore-sym-keys (protocol.handlers/initialize-protocol cofx [])))))
+      (is (:shh/restore-sym-keys (protocol.handlers/initialize-protocol cofx []))))
     (testing "custom mailservers"
       (let [ms-1            {:id "1"
                              :chain "mainnet"

--- a/test/cljs/status_im/test/transport/filters.cljs
+++ b/test/cljs/status_im/test/transport/filters.cljs
@@ -1,0 +1,39 @@
+(ns status-im.test.transport.filters
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [status-im.transport.filters :as t]
+            [status-im.constants :as constants]))
+
+(def pk "0x04985040682b77a32bb4bb58268a0719bd24ca4d07c255153fe1eb2ccd5883669627bd1a092d7cc76e8e4b9104327667b19dcda3ac469f572efabe588c38c1985f")
+
+(def expected-users 40000)
+(def average-number-of-contacts 100)
+;; Minimum number of identical personal topics
+(def min-number-of-clashes 1000)
+;; Maximum share of traffic that each users will be receiving
+(def max-share-of-traffic (/ 1 250))
+(def partitioned-topic "0xed2fdbad")
+(def discovery-topic "0xf8946aac")
+
+(deftest partition-topic
+  (testing "it returns a seeded topic based on an input string"
+    (is (= partitioned-topic (t/partition-topic pk))))
+  (testing "same input same output"
+    (is (= (t/partition-topic "a") (t/partition-topic "a")))))
+
+(deftest discovery-topics
+  (testing "it returns a partition topic & the discovery topic"
+    (is (= [partitioned-topic discovery-topic]
+           (t/discovery-topics pk)))))
+
+(deftest minimum-number-of-clashes-test
+  (testing (str "it needs to be greater than " min-number-of-clashes)
+    (is (<= min-number-of-clashes (t/expected-number-of-collisions expected-users)))))
+
+(deftest max-avg-share-of-traffic-test
+  (testing (str "it needs to be less than " max-share-of-traffic)
+    (is (>= max-share-of-traffic
+            ;; we always listen to our personal topic +
+            ;; we listen to contact topics - collissions
+            (/ (+ 1 (- average-number-of-contacts
+                       (t/expected-number-of-collisions average-number-of-contacts)))
+               expected-users)))))

--- a/test/cljs/status_im/test/transport/inbox.cljs
+++ b/test/cljs/status_im/test/transport/inbox.cljs
@@ -71,6 +71,7 @@
 (deftest request-messages
   (let [db {:network "mainnet"
             :mailserver-status :connected
+            :current-public-key "a"
             :inbox/current-id "wnodeid"
             :inbox/wnodes
             {:mainnet {"wnodeid" {:address    "wnode-address"
@@ -95,8 +96,8 @@
           (testing "it uses last 7 days for catching up"
             (is (= 395200 (get-in actual [::inbox/request-messages 0 :from]))))
           (testing "it only uses topics that dont have fetch history set"
-            (is (= ["0xf8946aac" "dont-fetch-history"]
-                   (get-in actual [::inbox/request-messages 0 :topics]))))
+            (is (= (sort ["0xf8946aac" "0xe5c5274a" "dont-fetch-history"])
+                   (sort (get-in actual [::inbox/request-messages 0 :topics])))))
           (testing "it uses the last 24 hours to request history"
             (is (= 913600
                    (get-in actual [::inbox/request-messages 1 :from]))))


### PR DESCRIPTION
Updated version of https://github.com/status-im/status-react/pull/4135
### Summary:

Currently we use a single topic for discovery.
This provides the best obscurity at the cost of bandwidth, as a message
sent on the discovery topic will be received by any peer.
This PR changes this behavior and start listening on a partitioned
topic.
Each pk will be hashed to a limited number of topics.

Everytime someone is in a conversation with someone from another topic
they will have to listen as well to avoid loosing obscurity, because we
only forward messages that we also advertise in the bloom filter.

The choice for the number of partitions depends on 2 factors:

1) The expected number of users using the network
2) The average number of contacts each user has

Any change to the discovery topic will need to be split across 3
releases, to avoid breaking compatibility:

1) Listen to the new and old topic, publish to the old topic
2) Listen to the new and old topic, publish to the new topic
3) Listen to the new topic, publish to the new topic

This is step 1, probably worth documenting somewhere the steps, code or wiki?

### Review notes
I have added some that might be a bit more mathematically inclined, just to make sure the math checks out, calculations don't take into consideration bloom filters, which will skew the result towards more bandwidth & more anonymity.

### Testing notes:
This is a fully backward compatible change, no differences should be detected.
Regression tests on publishing messages on one-to-one and contact updates, compatibility between Beta and current PR

status: ready