### PR TITLE
Remove obsolete input handling

### DIFF
--- a/src/status_im/chat/screen.cljs
+++ b/src/status_im/chat/screen.cljs
@@ -17,7 +17,6 @@
             [status-im.chat.views.message.options :as message-options]
             [status-im.chat.views.message.datemark :as message-datemark]
             [status-im.chat.views.message.message :as message]
-            [status-im.chat.views.input.input :as input]
             [status-im.chat.views.toolbar-content :as toolbar-content]
             [status-im.ui.components.animation :as animation]
             [status-im.ui.components.list.views :as list]

--- a/src/status_im/chat/specs.cljs
+++ b/src/status_im/chat/specs.cljs
@@ -8,8 +8,7 @@
 (s/def :chat/chat-animations (s/nilable map?))                    ; {id (string) props (map)}
 (s/def :chat/chat-ui-props (s/nilable map?))                      ; {id (string) props (map)}
 (s/def :chat/chat-list-ui-props (s/nilable map?))
-(s/def :chat/layout-height (s/nilable number?))                   ; height of chat's view layout
-(s/def :chat/expandable-view-height-to-value (s/nilable number?))
+(s/def :chat/layout-height (s/nilable number?))                   ; height of chat's view layout 
 (s/def :chat/selected-participants (s/nilable set?))
 (s/def :chat/chat-loaded-callbacks (s/nilable map?))
 (s/def :chat/public-group-topic (s/nilable string?))

--- a/src/status_im/chat/styles/animations.cljs
+++ b/src/status_im/chat/styles/animations.cljs
@@ -1,7 +1,6 @@
 (ns status-im.chat.styles.animations
   (:require [status-im.ui.components.styles :as common]))
 
-(def color-root-border "rgba(192, 198, 202, 0.28)")
 (def header-draggable-icon "rgba(73, 84, 93, 0.23)")
 
 (def overlap-container
@@ -18,8 +17,6 @@
    :right            0
    :bottom           bottom
    :position         :absolute
-   :border-top-color color-root-border
-   :border-top-width 1
    :elevation        2
    :max-height       max-height})
 

--- a/src/status_im/chat/styles/input/input.cljs
+++ b/src/status_im/chat/styles/input/input.cljs
@@ -5,7 +5,7 @@
 (def min-input-height 36)
 (def padding-vertical 8)
 (def border-height 1)
-(def max-input-height (* 4 min-input-height))
+(def max-input-height (* 5 min-input-height))
 
 (defnstyle root [margin-bottom]
   {:background-color colors/white
@@ -25,21 +25,23 @@
    :padding-bottom padding-vertical
    :flex           1})
 
-(defn input-animated [content-height]
-  {:align-items      :flex-start
-   :flex-direction   :row
-   :flex-grow        1
-   :height           (min (max min-input-height content-height) max-input-height)})
+(def input-animated
+  {:align-items    :flex-start
+   :flex-direction :row
+   :flex-grow      1
+   :min-height     min-input-height
+   :max-height     max-input-height})
 
-(defnstyle input-view [content-height single-line-input?]
+(defnstyle input-view [single-line-input?]
   {:flex           1
    :font-size      15
    :padding-top    9
    :padding-bottom 5
    :padding-right  12
-   :height         (if single-line-input?
+   :min-height     min-input-height
+   :max-height     (if single-line-input?
                      min-input-height
-                     (+ (min (max min-input-height content-height) max-input-height)))
+                     max-input-height)
    :android        {:padding-top 3}})
 
 (def invisible-input-text

--- a/src/status_im/chat/styles/input/parameter_box.cljs
+++ b/src/status_im/chat/styles/input/parameter_box.cljs
@@ -3,7 +3,7 @@
             [status-im.ui.components.colors :as colors]))
 
 (def root
-  {:background-color common/color-white
-   :border-top-color colors/gray-light
-   :border-top-width 1})
+  {:background-color    common/color-white
+   :border-bottom-color colors/gray-light
+   :border-bottom-width 1})
 

--- a/src/status_im/chat/styles/input/suggestions.cljs
+++ b/src/status_im/chat/styles/input/suggestions.cljs
@@ -12,14 +12,13 @@
    :border-top-color colors/gray-light
    :border-top-width 1})
 
-(defn item-suggestion-container [last?]
+(def item-suggestion-container
   {:flex-direction      :row
    :align-items         :center
    :height              item-height
-   :margin-left         14
-   :padding-right       14
+   :padding-horizontal  14
    :border-bottom-color colors/gray-light
-   :border-bottom-width (if last? 0 border-height)})
+   :border-bottom-width border-height})
 
 (def item-suggestion-name
   {:color     common/color-black

--- a/src/status_im/chat/views/input/input.cljs
+++ b/src/status_im/chat/views/input/input.cljs
@@ -18,23 +18,12 @@
             [status-im.utils.platform :as platform]
             [status-im.utils.utils :as utils]))
 
-;; TODO(pacamara) Symptomatic fix, root cause is react-native onLayout returning
-;; inconsistent height values, more investigation needed
-(defn android-blank-line-extra-height [input-text]
-  (if (and platform/android? input-text (string/ends-with? input-text "\n"))
-    (/ style/min-input-height 2)
-    0))
-
-(defview basic-text-input [{:keys [set-layout-height-fn set-container-width-fn height single-line-input?]}]
+(defview basic-text-input [{:keys [set-container-width-fn height single-line-input?]}]
   (letsubs [{:keys [input-text]} [:get-current-chat]
-            input-focused?       [:get-current-chat-ui-prop :input-focused?]
-            input-ref            (atom nil)
             cooldown-enabled?    [:chat-cooldown-enabled?]]
     [react/text-input
      (merge
-      {:ref                    #(when %
-                                  (re-frame/dispatch [:set-chat-ui-props {:input-ref %}])
-                                  (reset! input-ref %))
+      {:ref                    #(when % (re-frame/dispatch [:set-chat-ui-props {:input-ref %}]))
        :accessibility-label    :chat-message-input
        :multiline              (not single-line-input?)
        :default-value          (or input-text "")
@@ -43,34 +32,14 @@
        :on-focus               #(re-frame/dispatch [:set-chat-ui-props {:input-focused?    true
                                                                         :messages-focused? false}])
        :on-blur                #(re-frame/dispatch [:set-chat-ui-props {:input-focused? false}])
-       :on-submit-editing      (fn [_]
-                                 (if single-line-input?
-                                   (re-frame/dispatch [:send-current-message])
-                                   (when @input-ref
-                                     (.setNativeProps @input-ref (clj->js {:text input-text})))))
-       :on-layout              (fn [e]
-                                 (set-container-width-fn (.-width (.-layout (.-nativeEvent e)))))
-       :on-change              (fn [e]
-                                 (let [native-event (.-nativeEvent e)
-                                       text (.-text native-event)
-                                       content-size (.. native-event -contentSize)]
-                                   (when (and (not single-line-input?)
-                                              content-size)
-                                     (set-layout-height-fn (.-height content-size)))
-                                   (when (not= text input-text)
-                                     (re-frame/dispatch [:set-chat-input-text text]))))
-       :on-content-size-change (when (and (not input-focused?)
-                                          (not single-line-input?))
-                                 #(let [s (.-contentSize (.-nativeEvent %))
-                                        w (.-width s)
-                                        h (.-height s)]
-                                    (set-container-width-fn w)
-                                    (set-layout-height-fn h)))
+       :on-submit-editing      #(re-frame/dispatch [:send-current-message])
+       :on-layout              #(set-container-width-fn (.-width (.-layout (.-nativeEvent %))))
+       :on-change              #(re-frame/dispatch [:set-chat-input-text (.-text (.-nativeEvent %))])
        :on-selection-change    #(let [s (-> (.-nativeEvent %)
                                             (.-selection))
                                       end (.-end s)]
                                   (re-frame/dispatch [:update-text-selection end]))
-       :style                  (style/input-view height single-line-input?)
+       :style                  (style/input-view single-line-input?)
        :placeholder-text-color colors/gray
        :auto-capitalize        :sentences}
       (when cooldown-enabled?
@@ -83,16 +52,6 @@
                                          (.-layout)
                                          (.-width))]
                                (set-layout-width-fn w))}
-     (or input-text "")]))
-
-(defview invisible-input-height [{:keys [set-layout-height-fn container-width]}]
-  (letsubs [{:keys [input-text]} [:get-current-chat]]
-    [react/text {:style     (style/invisible-input-text-height container-width)
-                 :on-layout #(let [h (-> (.-nativeEvent %)
-                                         (.-layout)
-                                         (.-height)
-                                         (+ (android-blank-line-extra-height input-text)))]
-                               (set-layout-height-fn h))}
      (or input-text "")]))
 
 (defn- input-helper-view-on-update [{:keys [opacity-value placeholder]}]
@@ -119,49 +78,18 @@
     :number {:keyboard-type "numeric"}
     nil))
 
-(defview seq-input [{:keys [command-width container-width]}]
-  (letsubs [command                      [:selected-chat-command]
-            arg-pos                      [:current-chat-argument-position]
-            {:keys [seq-arg-input-text]} [:get-current-chat]]
-    (when (get-in command [:command :sequential-params])
-      (let [{:keys [placeholder type]} (get-in command [:command :params arg-pos])]
-        [react/text-input (merge {:ref                 #(re-frame/dispatch [:set-chat-ui-props {:seq-input-ref %}])
-                                  :style               (style/seq-input-text command-width container-width)
-                                  :default-value       (or seq-arg-input-text "")
-                                  :on-change-text      #(do (re-frame/dispatch [:set-chat-seq-arg-input-text %])
-                                                            (re-frame/dispatch [:set-chat-ui-props {:validation-messages nil}]))
-                                  :placeholder         placeholder
-                                  :accessibility-label :chat-request-input
-                                  :blur-on-submit      false
-                                  :editable            true
-                                  :on-submit-editing   (fn []
-                                                         (when-not (or (string/blank? seq-arg-input-text)
-                                                                       (get-in command [:command :hide-send-button]))
-                                                           (re-frame/dispatch [:send-seq-argument]))
-                                                         (utils/set-timeout
-                                                          #(re-frame/dispatch [:chat-input-focus :seq-input-ref])
-                                                          100))}
-                                 (get-options type))]))))
-
 (defview input-view [{:keys [single-line-input?]}]
   (letsubs [command [:selected-chat-command]]
     (let [component              (reagent/current-component)
           set-layout-width-fn    #(reagent/set-state component {:width %})
-          set-layout-height-fn   #(reagent/set-state component {:height %})
           set-container-width-fn #(reagent/set-state component {:container-width %})
-          {:keys [width height container-width]} (reagent/state component)]
+          {:keys [width]} (reagent/state component)]
       [react/view {:style style/input-root}
-       [react/animated-view {:style (style/input-animated height)}
+       [react/animated-view {:style style/input-animated}
         [invisible-input {:set-layout-width-fn set-layout-width-fn}]
-        [invisible-input-height {:set-layout-height-fn set-layout-height-fn
-                                 :container-width      container-width}]
-        [basic-text-input {:set-layout-height-fn   set-layout-height-fn
-                           :set-container-width-fn set-container-width-fn
-                           :height                 height
+        [basic-text-input {:set-container-width-fn set-container-width-fn
                            :single-line-input?     single-line-input?}]
-        [input-helper {:width width}]
-        [seq-input {:command-width   width
-                    :container-width container-width}]]])))
+        [input-helper {:width width}]]])))
 
 (defview commands-button []
   (letsubs [commands-responses [:get-available-commands-responses]]

--- a/src/status_im/chat/views/input/send_button.cljs
+++ b/src/status_im/chat/views/input/send_button.cljs
@@ -27,24 +27,14 @@
             on-update                               (send-button-view-on-update {:spin-value         spin-value
                                                                                  :command-completion command-completion})]
     {:component-did-update on-update}
-    (let [{:keys [hide-send-button sequential-params]} (:command selected-command)]
-      (when
-       (and (sendable? input-text)
-            (or (not selected-command)
-                (some #{:complete :less-than-needed} [command-completion]))
-            (not hide-send-button))
-        [react/touchable-highlight {:on-press #(if sequential-params
-                                                 (do
-                                                   (when-not (string/blank? seq-arg-input-text)
-                                                     (re-frame/dispatch [:send-seq-argument]))
-                                                   (utils/set-timeout
-                                                    (fn [] (re-frame/dispatch [:chat-input-focus :seq-input-ref]))
-                                                    100))
-                                                 (re-frame/dispatch [:send-current-message]))}
-         (let [spin (.interpolate spin-value (clj->js {:inputRange  [0 1]
-                                                       :outputRange ["0deg" "90deg"]}))]
-           [react/animated-view
-            {:style               (style/send-message-container spin)
-             :accessibility-label :send-message-button}
-            [vi/icon :icons/input-send {:container-style style/send-message-icon
-                                        :color           :white}]])]))))
+    (when (and (sendable? input-text)
+               (or (not selected-command)
+                   (some #{:complete :less-than-needed} [command-completion])))
+      [react/touchable-highlight {:on-press #(re-frame/dispatch [:send-current-message])}
+       (let [spin (.interpolate spin-value (clj->js {:inputRange  [0 1]
+                                                     :outputRange ["0deg" "90deg"]}))]
+         [react/animated-view
+          {:style               (style/send-message-container spin)
+           :accessibility-label :send-message-button}
+          [vi/icon :icons/input-send {:container-style style/send-message-icon
+                                      :color           :white}]])])))

--- a/src/status_im/chat/views/input/suggestions.cljs
+++ b/src/status_im/chat/views/input/suggestions.cljs
@@ -11,7 +11,7 @@
 (defn suggestion-item [{:keys [on-press name description last? accessibility-label]}]
   [react/touchable-highlight (cond-> {:on-press on-press}
                                accessibility-label (assoc :accessibility-label accessibility-label))
-   [react/view (style/item-suggestion-container last?)
+   [react/view style/item-suggestion-container
     [react/text {:style style/item-suggestion-name}
      name]
     [react/text {:style           style/item-suggestion-description

--- a/src/status_im/ui/screens/db.cljs
+++ b/src/status_im/ui/screens/db.cljs
@@ -241,7 +241,6 @@
                  :chat/chat-ui-props
                  :chat/chat-list-ui-props
                  :chat/layout-height
-                 :chat/expandable-view-height-to-value
                  :chat/message-data
                  :chat/message-status
                  :chat/selected-participants


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

This PR removes multiple obsolete and outdated things which complicate our codebase:
1. It re-introduces automatic input height sizing done through `:min`/`:max-height` style props rather then explicit height which is calculated and set, it also removes this calculation which was done on each `onChange` event.
2. It removes notion of `seq-arguments` (we have no such commands anymore), which was clunky and complicated handling of the input very much

### Steps to test:
Test that there are no regressions related to the chat input component, that's styling, sizing, behaviour of suggestions to command arguments, etc. 
Test that there are no performance regressions as well.

status: ready
