### PR TITLE
Preset keychain username on desktop

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "react-native-image-crop-picker": "0.18.1",
     "react-native-image-resizer": "1.0.0",
     "react-native-invertible-scroll-view": "1.1.0",
-    "react-native-keychain": "git+https://github.com/MaxRis/react-native-keychain.git#bug/linux-support",
+    "react-native-keychain": "git+https://github.com/status-im/react-native-keychain.git",
     "react-native-level-fs": "3.0.0",
     "react-native-os": "1.1.0",
     "react-native-qrcode": "0.2.6",

--- a/src/status_im/utils/keychain/core.cljs
+++ b/src/status_im/utils/keychain/core.cljs
@@ -1,7 +1,8 @@
 (ns status-im.utils.keychain.core
   (:require [re-frame.core :as re-frame]
             [taoensso.timbre :as log]
-            [status-im.react-native.js-dependencies :as rn]))
+            [status-im.react-native.js-dependencies :as rn]
+            [status-im.utils.platform :as platform]))
 
 (def key-bytes 64)
 (def username "status-im.encryptionkey")
@@ -65,3 +66,6 @@
 (defn reset []
   (log/debug "resetting key...")
   (.resetGenericPassword rn/keychain))
+
+(defn set-username []
+  (when platform/desktop? (.setUsername rn/keychain username)))

--- a/src/status_im/utils/keychain/events.cljs
+++ b/src/status_im/utils/keychain/events.cljs
@@ -1,7 +1,8 @@
 (ns status-im.utils.keychain.events
   (:require [re-frame.core :as re-frame]
             [taoensso.timbre :as log]
-            [status-im.utils.keychain.core :as keychain]))
+            [status-im.utils.keychain.core :as keychain]
+            [status-im.utils.platform :as platform]))
 
 (defn handle-key-error [event {:keys [error key]}]
   (if (= :weak-key error)
@@ -12,6 +13,7 @@
 (re-frame/reg-fx
  :get-encryption-key
  (fn [event]
+   (when platform/desktop? (keychain/set-username))
    (.. (keychain/get-encryption-key)
        (then #(re-frame/dispatch (conj event %)))
        (catch (partial handle-key-error event)))))


### PR DESCRIPTION
### Summary:

On Linux underlying keychain records access requires username (on macOS it works fine without passing of username). PR unifies access to keychain both for macOS and linux systems.

### Overview and steps to test:

Both macOS and linux builds affected. username key is used additionally to access keychain to get db encryption keys.

Testing on mac:
At least creation of new database and further logins into the app should work fine. (Compatibility with older db openning might be broken, because new path to new encryption key probably is used)

Testing on linux:
Since used underlying qtkeychain library supports gnome-keyring or kwallet keychains it requires to have installed components of supported keychains.

gnome-keyring usage has priority under kwallet if both are installed.

gnome-keyring requires additionally package `libgnome-keyring0` installed on linux system.
kwallet setup instructions can be found there https://askubuntu.com/a/913594

### Status: ready


