### PR TITLE
Build macos dmg from locally copied official qt distribution

### DIFF
--- a/Jenkinsfile.desktopbuild
+++ b/Jenkinsfile.desktopbuild
@@ -72,7 +72,7 @@ parallel (
 
           stage('Build MacOS binaries') {
             sh 'cd desktop && rm -rf CMakeFiles CMakeCache.txt cmake_install.cmake Makefile'
-            sh 'cd desktop && cmake -DCMAKE_BUILD_TYPE=Release -DEXTERNAL_MODULES_DIR="node_modules/react-native-i18n/desktop;node_modules/react-native-config/desktop;node_modules/react-native-fs/desktop;node_modules/react-native-http-bridge/desktop;node_modules/react-native-webview-bridge/desktop;node_modules/react-native-keychain/desktop;node_modules/react-native-securerandom/desktop;modules/react-native-status/desktop"\
+            sh 'export PATH=/Users/administrator/qt/5.9.1/clang_64/bin:$PATH && cd desktop && cmake -DCMAKE_BUILD_TYPE=Release -DEXTERNAL_MODULES_DIR="node_modules/react-native-i18n/desktop;node_modules/react-native-config/desktop;node_modules/react-native-fs/desktop;node_modules/react-native-http-bridge/desktop;node_modules/react-native-webview-bridge/desktop;node_modules/react-native-keychain/desktop;node_modules/react-native-securerandom/desktop;modules/react-native-status/desktop"\
             -DJS_BUNDLE_PATH="' + scriptPath + '/' + packageFolder + '/StatusIm.jsbundle" -DCMAKE_CXX_FLAGS:="-DBUILD_FOR_BUNDLE=1" . && make'
           }
 
@@ -82,17 +82,13 @@ parallel (
 
             sh ('cp ./desktop/bin/StatusIm ' + packageFolder +'/StatusIm.app/Contents/MacOs')
 
-            sh ('macdeployqt ' + packageFolder + '/StatusIm.app -always-overwrite -verbose=1 -qmldir="' + scriptPath + '/node_modules/react-native/ReactQt/runtime/src/qml/"') // do not forget about -dmg
-            sh ('python /Users/administrator/macdeployqtfix/macdeployqtfix/macdeployqtfix.py ' + packageFolder + '/StatusIm.app/Contents/MacOs/StatusIm /usr/local/Cellar/qt/5.9.1')
+            sh ('export PATH=/Users/administrator/qt/5.9.1/clang_64/bin:$PATH && cd ' + packageFolder + ' && macdeployqt StatusIm.app -verbose=1 -dmg -qmldir="' + scriptPath + '/node_modules/react-native/ReactQt/runtime/src/qml/"')
 
-            sh 'rm -f StatusImBundle.app.zip'
             sh 'rm -f StatusIm.app.zip'
-            sh ('cd ' + packageFolder + ' && zip -r StatusImBundle.app.zip StatusIm.app')
           }
 
           stage('Archive built artifact') {
-            // archiveArtifacts "StatusImPackage/*.dmg"
-            archiveArtifacts "StatusImPackage/*.app.zip"
+            archiveArtifacts "StatusImPackage/*.dmg"
           }
 
           cleanupBuild(packageFolder)


### PR DESCRIPTION
Jenkins MacOS build changes to produce .dmg

- Manually copied official Qt 5.9.1 distribution is used
- macdeployqtfix.py step is removed (since official Qt build doesn't have such macdeployqt issues)
- `-always-overwrite` macdeployqt input param is removed (it makes .app bundle not runnable) 