### PR TITLE
Changelog for release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+- Added Farsi public #status channel
+- Spam moderation
+
+## [0.9.21] - 2018-06-25
+### Added
+- Mainnet is enabled by default on new installations. Upgrades will need to manually switch.
+- Chat now supports sending SNT and other tokens in 1-1 chats
+- New chat UI for /send and /receive commands
+- Updated chat message styling
+- Updated toolbar style
+- Updated DApp list
+- New help links on the Profile tab. Read our Beta FAQ, file a bug, or suggest and vote on features.
+- Performance improvements when fetching old messages
+- Added 5 new default public chats for our friends speaking Korean, Chinese, Japanese, Russian and Spanish.
+
+### Fixed
+- Prevented empty commands from being sent in chat
+- Fixed minimum amounts in transactions
+- Fixed an issue where contacts names may not be shown
+- Removed log files from release builds
+- Fixed an issue with transactions when navigating back


### PR DESCRIPTION
Fixes #5013 

### Summary:

Creating and managing release notes is a single point of failure and doesn't benefit from the contributor's input and context.  A CHANGELOG.md file addresses this issue.

It has additional benefits for automating releases notes using Fastlane (in the near future).


### Review notes (optional):

I expect to manage this to start while trying to get team buy-in. For now just check it out and offer feedback :)


### Testing notes (optional):

None



status: ready 
