### PR TITLE
bug #4775 - showing spinner when signing transaction

### DIFF
--- a/src/status_im/ui/screens/wallet/send/events.cljs
+++ b/src/status_im/ui/screens/wallet/send/events.cljs
@@ -250,7 +250,9 @@
 
         ;;WRONG PASSWORD
        constants/send-transaction-password-error-code
-       {:db (assoc-in db [:wallet :send-transaction :wrong-password?] true)}
+       {:db (-> db
+                (assoc-in [:wallet :send-transaction :wrong-password?] true)
+                (assoc-in [:wallet :send-transaction :waiting-signal?] false))}
 
         ;;NO ERROR, DISCARDED, TIMEOUT or DEFAULT ERROR
        (if (this-transaction-signing? id (:id send-transaction) view-id modal)

--- a/src/status_im/ui/screens/wallet/send/styles.cljs
+++ b/src/status_im/ui/screens/wallet/send/styles.cljs
@@ -20,6 +20,14 @@
    :padding-top        12
    :padding-horizontal 12})
 
+(def spinner-container
+  {:position        :absolute
+   :left            0
+   :top             0
+   :right           0
+   :bottom          0
+   :justify-content :center})
+
 (def signing-phrase-container
   {:border-radius    8
    :height           36


### PR DESCRIPTION
fixes #4775 
fixes #4858 

### Summary:

Adds a spinner while transaction is being signed. Also locks the Sign button during that time so this should also fix #4858

### Testing notes (optional):
To ensure that the process would be slow enough for the spinner to be visible, either use mainnet or 
connect to ropsten via slow internet (e.g. edge)

### Steps to test:
- Send a transaction

status: ready 