### PR TITLE
Selectable text in messages

### DIFF
--- a/src/status_im/ui/screens/desktop/main/chat/views.cljs
+++ b/src/status_im/ui/screens/desktop/main/chat/views.cljs
@@ -64,7 +64,8 @@
 (views/defview message-with-timestamp [text {:keys [timestamp] :as message} style]
   [react/view {:style style}
    [react/view {:style {:flex-direction :row :flex-wrap :wrap}}
-    [react/text {:style styles/message-text}
+    [react/text {:style      styles/message-text
+                 :selectable true}
      text]
     [react/text {:style (styles/message-timestamp-placeholder)}
      (time/timestamp->time timestamp)]


### PR DESCRIPTION


**partially** fixes #4283 

### Summary:

Now user can select message text by mouse and copy it by using standard system hotkey (cmd+c).

### Review notes (optional):

Original issue #4283 mentions the possibility to copy messages with a right-click context menu. It is not implemented so far.

### Testing notes (optional):
<!-- (Specify if something specific has to be tested, for example upgrade paths) -->
Multiselection of few messages not supported.


### Steps to test:
- Open Status
- Go to chat
- Select a message by mouse
- copy it with system shortcut 
- paste somewhere


<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->
