### PR TITLE
bug #4926 and #4806 - showing correct fiat value in /send and /reques…

### DIFF
--- a/src/status_im/chat/views/message/message.cljs
+++ b/src/status_im/chat/views/message/message.cljs
@@ -77,7 +77,7 @@
 (defview message-content-command-send
   [{:keys [content timestamp-str outgoing group-chat]}]
   (letsubs [network [:network-name]]
-    (let [{{:keys [amount fiat-amount tx-hash asset] send-network :network} :params} content
+    (let [{{:keys [amount fiat-amount tx-hash asset currency] send-network :network} :params} content
           recipient-name (get-in content [:params :bot-db :public :recipient])
           amount-text-long? (< 10 (count amount))
           network-mismatch? (and (seq send-network) (not= network send-network))]
@@ -96,7 +96,7 @@
         (when fiat-amount
           [react/view style/command-send-fiat-amount
            [react/text {:style style/command-send-fiat-amount-text}
-            (str "~ " fiat-amount " " (i18n/label :usd-currency))]])
+            (str "~ " fiat-amount " " (or currency (i18n/label :usd-currency)))]])
         (when (and group-chat
                    recipient-name)
           [react/text {:style style/command-send-recipient-text}

--- a/src/status_im/chat/views/message/request_message.cljs
+++ b/src/status_im/chat/views/message/request_message.cljs
@@ -89,9 +89,8 @@
                     (merge command {:prefill        prefill
                                     :prefill-bot-db (or prefill-bot-db prefillBotDb)})
                     command)
-          {:keys [amount asset] request-network :network} params
+          {:keys [amount asset fiat-amount currency] request-network :network} params
           recipient-name (get-in params [:bot-db :public :recipient])
-          usd-amount (money/usd-amount amount (keyword asset) prices)
           network-mismatch? (and request-network (not= request-network network))
           on-press-handler (cond
                              network-mismatch? nil
@@ -119,7 +118,7 @@
                asset]]]
             [view st/command-request-fiat-amount-row
              [text {:style st/command-request-fiat-amount-text}
-              (str "~ " usd-amount " " (i18n/label :usd-currency))]]
+              (str "~ " fiat-amount " " (or currency (i18n/label :usd-currency)))]]
             (when (and group-chat
                        recipient-name)
               [text {:style st/command-request-recipient-text}

--- a/src/status_im/ui/screens/currency_settings/events.cljs
+++ b/src/status_im/ui/screens/currency_settings/events.cljs
@@ -1,10 +1,14 @@
 (ns status-im.ui.screens.currency-settings.events
   (:require [status-im.ui.screens.accounts.events :as accounts]
-            [status-im.utils.handlers :as handlers]))
+            [status-im.utils.handlers :as handlers]
+            [status-im.utils.handlers-macro :as handlers-macro]
+            [status-im.ui.screens.wallet.events :as wallet.events]))
 
 (handlers/register-handler-fx
  :wallet.settings/set-currency
  (fn [{:keys [db] :as cofx} [_ currency]]
    (let [settings     (get-in db [:account/account :settings])
          new-settings (assoc-in settings [:wallet :currency] currency)]
-     (accounts/update-settings new-settings cofx))))
+     (handlers-macro/merge-fx cofx
+                              (accounts/update-settings new-settings)
+                              (wallet.events/update-wallet)))))

--- a/src/status_im/ui/screens/currency_settings/subs.cljs
+++ b/src/status_im/ui/screens/currency_settings/subs.cljs
@@ -1,8 +1,10 @@
 (ns status-im.ui.screens.currency-settings.subs
   (:require [re-frame.core :as re-frame]))
 
+(defn get-user-currency [db]
+  (get-in db [:account/account :settings :wallet :currency] :usd))
+
 (re-frame/reg-sub
  :wallet.settings/currency
- :<- [:get-current-account]
- (fn [current-account]
-   (or (get-in current-account [:settings :wallet :currency]) :usd)))
+ (fn [db]
+   (get-user-currency db)))

--- a/src/status_im/utils/money.cljs
+++ b/src/status_im/utils/money.cljs
@@ -143,10 +143,10 @@
   (when (and amount balance)
     (.greaterThanOrEqualTo balance amount)))
 
-(defn usd-amount [amount-str from prices]
+(defn fiat-amount-value [amount-str from to prices]
   (-> amount-str
       (js/parseFloat)
       bignumber
-      (crypto->fiat (get-in prices [from :USD :price] (bignumber 0)))
+      (crypto->fiat (get-in prices [from to :price] (bignumber 0)))
       (with-precision 2)
       str))


### PR DESCRIPTION
fixes #4926 
fixes #4806

### Summary:

Shows the fiat value in `/send` and `/request` messages correctly - expressed in the user currency. If the user changes the currency at some point, the existing messages in chat will contain the old currency while any new messages sent or received after the change will be in the new currency. The prices update automatically after the change.

### Testing notes (optional):

Currency specific number format (decimal comma vs point and number of decimals) is still not correct - all currencies are formatted with decimal point and exactly two decimal places. This will be fixed separately along with #4848

### Steps to test:
- Send and receive `/send` and `/request` in chat
- Send and request assets in Wallet

status: ready 