### PR TITLE
Jenkins now downloads package with correct Info.plist

### DIFF
--- a/Jenkinsfile.desktopbuild
+++ b/Jenkinsfile.desktopbuild
@@ -79,7 +79,7 @@ parallel (
           stage('Prepare and create MacOS Bundle') {
             sh ('cd ' + packageFolder + ' && ../scripts/download-package-files.sh "StatusIm.app.zip" "1Vkb6MD3nsmT02Az6rRRZywQSwCz1ZN9V" && unzip ./StatusIm.app.zip')
             sh ('cp -r ' + packageFolder + '/assets/share/assets ' + packageFolder +'/StatusIm.app/Contents/MacOs')
-
+            sh ('chmod +x ' + packageFolder + '/StatusIm.app/Contents/MacOs/ubuntu-server')
             sh ('cp ./desktop/bin/StatusIm ' + packageFolder +'/StatusIm.app/Contents/MacOs')
 
             sh ('export PATH=/Users/administrator/qt/5.9.1/clang_64/bin:$PATH && cd ' + packageFolder + ' && macdeployqt StatusIm.app -verbose=1 -dmg -qmldir="' + scriptPath + '/node_modules/react-native/ReactQt/runtime/src/qml/"')

--- a/Jenkinsfile.desktopbuild
+++ b/Jenkinsfile.desktopbuild
@@ -77,7 +77,7 @@ parallel (
           }
 
           stage('Prepare and create MacOS Bundle') {
-            sh ('cd ' + packageFolder + ' && ../scripts/download-package-files.sh "StatusIm.app.zip" "1AVi8QvIB8zNF6oMsMBgOqmxa5nl1xdWC" && unzip ./StatusIm.app.zip')
+            sh ('cd ' + packageFolder + ' && ../scripts/download-package-files.sh "StatusIm.app.zip" "1Vkb6MD3nsmT02Az6rRRZywQSwCz1ZN9V" && unzip ./StatusIm.app.zip')
             sh ('cp -r ' + packageFolder + '/assets/share/assets ' + packageFolder +'/StatusIm.app/Contents/MacOs')
 
             sh ('cp ./desktop/bin/StatusIm ' + packageFolder +'/StatusIm.app/Contents/MacOs')
@@ -118,7 +118,7 @@ parallel (
 
           stage('Git & Dependencies') {
             slackSend channel: '#jenkins-desktop', color: 'good', message: BRANCH_NAME + '(' + env.CHANGE_BRANCH + ') Linux build started. ' + env.BUILD_URL
-            
+
             sh ('echo ' + scriptPath)
 
             checkout scm
@@ -160,7 +160,7 @@ parallel (
 
             sh 'rm -f Application-x86_64.AppImage'
             sh 'rm -f StatusIm-x86_64.AppImage'
-            
+
             sh 'ldd ' + packageFolder+ '/AppDir/usr/bin/StatusIm'
             sh ('export PATH=/home/maxr/Qt5.9.1/5.9.1/gcc_64/bin:/usr/local/go/bin:$PATH && ./linuxdeployqt-continuous-x86_64.AppImage ' + packageFolder+ '/AppDir/usr/share/applications/StatusIm.desktop -verbose=3 -always-overwrite -no-strip -no-translations -bundle-non-qt-libs -qmake=/home/maxr/Qt5.9.1/5.9.1/gcc_64/bin/qmake -extra-plugins=imageformats/libqsvg.so -qmldir="' + scriptPath + '/node_modules/react-native"')
             sh 'ldd ' + packageFolder+ '/AppDir/usr/bin/StatusIm'
@@ -171,10 +171,10 @@ parallel (
 
             sh ('export PATH=/home/maxr/Qt5.9.1/5.9.1/gcc_64/bin:/usr/local/go/bin:$PATH && ./linuxdeployqt-continuous-x86_64.AppImage ' + packageFolder+ '/AppDir/usr/share/applications/StatusIm.desktop -verbose=3 -appimage -qmake=/home/maxr/Qt5.9.1/5.9.1/gcc_64/bin/qmake')
             sh 'ldd ' + packageFolder+ '/AppDir/usr/bin/StatusIm'
-            
+
             sh ('rm -rf ' + packageFolder +'/StatusIm.AppImage')
             sh ('cp -f ./StatusIm-x86_64.AppImage ' + packageFolder + '/StatusIm.AppImage')
-            
+
           }
 
           stage('Archive built artifact') {


### PR DESCRIPTION
fixes #4270

### Summary:

It turned out that we have to specify one more key in desktop bundle Info.plist file to turn on the support of hdpi. The line is following:
```
<key>NSHighResolutionCapable</key>
<string>True</string>
```

During the build Jenkins downloads prepared desktop bundle from google drive, adds compiled binaries and wraps all abovementioned in StatusIm.dmg.
I modified the `Info.plist` in the prepared bundle to contain abovementioned changes. So only change in this PR is an id of package on google drive.

Full package link - https://drive.google.com/uc?export=download&id=1Vkb6MD3nsmT02Az6rRRZywQSwCz1ZN9V


### Steps to test:
- Open Status
- Check that fonts and images doesn't look blurry

status: ready