### PR TITLE
Fix clearing unread counter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - Fixed mailservers connectivity issue
+- Clear chat action correctly clear the unread messages counter
 
 ### Changed
 - Downgraded React Native to 0.53.3 for improved performance and decreased battery consumption

--- a/test/cljs/status_im/test/chat/models.cljs
+++ b/test/cljs/status_im/test/chat/models.cljs
@@ -104,16 +104,24 @@
 
 (deftest clear-history-test
   (let [chat-id "1"
-        cofx    {:db {:chats {chat-id {:message-groups {:something "a"}
-                                       :messages       {"1" {:clock-value 1}
-                                                        "2" {:clock-value 10}
-                                                        "3" {:clock-value 2}}}}}}]
+        cofx    {:db {:chats {chat-id {:message-groups        {:something "a"}
+                                       :messages              {"1" {:clock-value 1}
+                                                               "2" {:clock-value 10}
+                                                               "3" {:clock-value 2}}
+                                       :unviewed-messages      #{"3"}
+                                       :not-loaded-message-ids #{"2" "3"}}}}}]
     (testing "it deletes all the messages"
       (let [actual (chat/clear-history chat-id cofx)]
         (is (= {} (get-in actual [:db :chats chat-id :messages])))))
     (testing "it deletes all the message groups"
       (let [actual (chat/clear-history chat-id cofx)]
         (is (= {} (get-in actual [:db :chats chat-id :message-groups])))))
+    (testing "it deletes unviewed messages set"
+      (let [actual (chat/clear-history chat-id cofx)]
+        (is (= #{} (get-in actual [:db :chats chat-id :unviewed-messages])))))
+    (testing "it deletes not loaded message ids set"
+      (let [actual (chat/clear-history chat-id cofx)]
+        (is (= #{} (get-in actual [:db :chats chat-id :not-loaded-message-ids])))))
     (testing "it sets a deleted-at-clock-value equal to the last message clock-value"
       (let [actual (chat/clear-history chat-id cofx)]
         (is (= 10 (get-in actual [:db :chats chat-id :deleted-at-clock-value])))))


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes #4820 

The `clear history` action in chat didn't correctly clear `unviewed-messages` and `not-loaded-message-ids` set, the code is now updated to do it, together with updated unit test so we can catch if it's broken again in the future.

### Steps to test:
Test that #4820 is not happening anymore

status: ready
