### PR TITLE
[#5030 TESTS] added 10 atomic tests from `Smoke tests - phase 1`

### DIFF
--- a/test/appium/tests/atomic/account_management/test_recover.py
+++ b/test/appium/tests/atomic/account_management/test_recover.py
@@ -1,74 +1,42 @@
 import pytest
 
-from tests import marks, common_password, group_chat_users
-from tests.base_test_case import SingleDeviceTestCase, MultipleDeviceTestCase
+from tests import marks, common_password
+from tests.base_test_case import SingleDeviceTestCase
 from views.sign_in_view import SignInView
-
-
-@marks.all
-@marks.account
-class TestRecoverAccountMultipleDevice(MultipleDeviceTestCase):
-
-    @marks.testrail_id(759)
-    def test_recover_account(self):
-        self.create_drivers(2)
-        device, device_2 = self.drivers[0], self.drivers[1]
-        sign_in, sign_in_2 = SignInView(device), SignInView(device_2)
-        username_1 = 'user_1'
-        username_2 = group_chat_users['A_USER']['username']
-        home = sign_in.create_user(username_1)
-        home_2 = sign_in_2.recover_access(passphrase=group_chat_users['A_USER']['passphrase'],
-                                          password=group_chat_users['A_USER']['password'])
-        public_key = home.get_public_key()
-        chat_2 = home_2.add_contact(public_key)
-        message = 'test message'
-        chat_2.chat_message_input.send_keys(message)
-        chat_2.send_message_button.click()
-        device_2.quit()
-
-        profile = home.get_profile_view()
-        profile.backup_seed_phrase_button.click()
-        profile.ok_continue_button.click()
-        seed_phrase = profile.get_seed_phrase()
-        profile.back_button.click()
-        profile.advanced_button.click()
-        profile.debug_mode_toggle.click()
-        profile.home_button.click()
-        console_chat = home.get_chat_with_user('Status Console').click()
-        console_chat.send_faucet_request()
-        console_chat.get_back_to_home_view()
-        wallet = home.wallet_button.click()
-        wallet.set_up_wallet()
-        address = wallet.get_wallet_address()
-        wallet.wait_balance_changed_on_wallet_screen()
-
-        device.reset()
-        sign_in.accept_agreements()
-        sign_in.recover_access(passphrase=' '.join(seed_phrase.values()), password=common_password)
-        home.connection_status.wait_for_invisibility_of_element(30)
-        chat_element = home.get_chat_with_user(username_2)
-        if chat_element.is_element_displayed():
-            chat = chat_element.click()
-            if not chat.chat_element_by_text(message).is_element_displayed():
-                self.errors.append("Message with text '%s' was not received" % message)
-            chat.get_back_to_home_view()
-        else:
-            self.errors.append('Chat with user %s is not recovered' % username_2)
-        home.wallet_button.click()
-        wallet.set_up_wallet()
-        if wallet.get_wallet_address() != address:
-            self.errors.append('Wallet address is changed after recover')
-        if wallet.get_eth_value() != 0.1:
-            self.errors.append('Wallet balance is changed after recover')
-        if wallet.get_public_key() != public_key:
-            self.errors.append('Public key is changed after recover')
-        self.verify_no_errors()
 
 
 @marks.all
 @marks.account
 class TestRecoverAccountSingleDevice(SingleDeviceTestCase):
 
+    @marks.testrail_id(759)
+    def test_recover_account(self):
+        sign_in = SignInView(self.driver)
+        home = sign_in.create_user()
+        public_key = home.get_public_key()
+        profile = home.get_profile_view()
+        profile.backup_seed_phrase_button.click()
+        profile.ok_continue_button.click()
+        seed_phrase = profile.get_seed_phrase()
+        profile.back_button.click()
+        wallet = profile.wallet_button.click()
+        wallet.set_up_wallet()
+        address = wallet.get_wallet_address()
+        self.driver.reset()
+        sign_in.accept_agreements()
+        sign_in.recover_access(passphrase=' '.join(seed_phrase.values()), password=common_password)
+        home.connection_status.wait_for_invisibility_of_element(30)
+        home.wallet_button.click()
+        wallet.set_up_wallet()
+        address2 = wallet.get_wallet_address()
+        if address2 != address:
+            self.errors.append('Wallet address is %s after recovery, but %s is expected' % (address2, address))
+        public_key2 = wallet.get_public_key()
+        if public_key2 != public_key:
+            self.errors.append('Public key is %s after recovery, but %s is expected' % (public_key2, public_key))
+        self.verify_no_errors()
+
+    @marks.skip
     @marks.testrail_id(845)
     def test_recover_account_with_incorrect_passphrase(self):
         sign_in = SignInView(self.driver)

--- a/test/appium/tests/atomic/account_management/test_wallet.py
+++ b/test/appium/tests/atomic/account_management/test_wallet.py
@@ -69,9 +69,9 @@ class TestWallet(SingleDeviceTestCase):
         transaction_details.copy_transaction_hash_button.click()
         transaction_details.get_back_to_home_view()
         wallet_view.home_button.click()
-        chat_view = home_view.get_chat_with_user('user').click()
-        chat_view.chat_message_input.paste_text_from_clipboard()
-        if chat_view.chat_message_input.text != transaction_hash:
+        public_chat = home_view.join_public_chat('testchat')
+        public_chat.chat_message_input.paste_text_from_clipboard()
+        if public_chat.chat_message_input.text != transaction_hash:
             pytest.fail('Transaction hash was not copied')
 
     @marks.testrail_id(3713)

--- a/test/appium/tests/atomic/chats/test_one_to_one.py
+++ b/test/appium/tests/atomic/chats/test_one_to_one.py
@@ -3,7 +3,7 @@ import string
 import emoji
 import pytest
 from selenium.common.exceptions import TimeoutException
-from tests import marks, get_current_time, group_chat_users, transaction_users
+from tests import marks, get_current_time, group_chat_users, basic_user
 from tests.base_test_case import MultipleDeviceTestCase, SingleDeviceTestCase
 from views.sign_in_view import SignInView
 
@@ -366,20 +366,33 @@ class TestMessagesOneToOneChatSingle(SingleDeviceTestCase):
 class TestChatManagement(SingleDeviceTestCase):
 
     @marks.testrail_id(1428)
-    def test_clear_history(self):
-        recipient = transaction_users['E_USER']
+    def test_clear_history_one_to_one_chat(self):
         sign_in_view = SignInView(self.driver)
-        sign_in_view.create_user()
-        home_view = sign_in_view.get_home_view()
-        home_view.add_contact(recipient['public_key'])
-        chat_view = home_view.get_chat_view()
-        for _ in range(4):
+        home_view = sign_in_view.create_user()
+        chat_view = home_view.add_contact(basic_user['public_key'])
+        for _ in range(2):
             chat_view.chat_message_input.send_keys('test message')
             chat_view.send_message_button.click()
         chat_view.clear_history()
         if not chat_view.no_messages_in_chat.is_element_present():
             pytest.fail('Message history is shown')
         home_view.relogin()
-        home_view.get_chat_with_user(recipient['username']).click()
+        home_view.get_chat_with_user(basic_user['username']).click()
         if not chat_view.no_messages_in_chat.is_element_present():
             pytest.fail('Message history is shown after re-login')
+
+    @marks.testrail_id(3720)
+    def test_delete_one_to_one_chat_via_delete_button(self):
+        sign_in = SignInView(self.driver)
+        home = sign_in.create_user()
+        chat_view = home.add_contact(basic_user['public_key'])
+        for _ in range(2):
+            chat_view.chat_message_input.send_keys('test message')
+            chat_view.send_message_button.click()
+        chat_view.delete_chat()
+        if home.get_chat_with_user(basic_user['username']).is_element_present(10):
+            self.errors.append("One-to-one' chat is shown, but the chat has been deleted")
+        home.relogin()
+        if home.get_chat_with_user(basic_user['username']).is_element_present(10):
+            self.errors.append("One-to-one' chat is shown after re-login, but the chat has been deleted")
+        self.verify_no_errors()

--- a/test/appium/tests/atomic/chats/test_public.py
+++ b/test/appium/tests/atomic/chats/test_public.py
@@ -1,16 +1,14 @@
-import random
-import string
-
+import pytest
 from tests import marks
 from tests.base_test_case import MultipleDeviceTestCase
 from views.sign_in_view import SignInView
 
 
 @marks.chat
-class TestMessagesPublicChat(MultipleDeviceTestCase):
+class TestPublicChat(MultipleDeviceTestCase):
 
     @marks.testrail_id(1383)
-    def test_public_chat(self):
+    def test_public_chat_messaging(self):
         self.create_drivers(2)
         device_1, device_2 = SignInView(self.drivers[0]), SignInView(self.drivers[1])
         username_1, username_2 = 'user_1', 'user_2'
@@ -38,4 +36,54 @@ class TestMessagesPublicChat(MultipleDeviceTestCase):
         if chat_1.element_by_text(username_1).is_element_displayed():
             self.errors.append("Username '%s' is shown for the sender" % username_1)
 
+        self.verify_no_errors()
+
+    @marks.testrail_id(3706)
+    def test_public_chat_clear_history(self):
+        self.create_drivers(2)
+        device_1, device_2 = SignInView(self.drivers[0]), SignInView(self.drivers[1])
+        chat_name = device_1.get_public_chat_name()
+        for sign_in in device_1, device_2:
+            home = sign_in.create_user()
+            home.join_public_chat(chat_name)
+        chat_1, chat_2 = device_1.get_chat_view(), device_2.get_chat_view()
+        message_1, message_2, message_3 = 'm1', 'm2', 'm3'
+        chat_1.chat_message_input.send_keys(message_1)
+        chat_1.send_message_button.click()
+        chat_2.element_by_text(message_1).is_element_present()
+
+        chat_2.chat_message_input.send_keys(message_2)
+        chat_2.send_message_button.click()
+        chat_1.element_by_text(message_2).is_element_present()
+        chat_1.chat_options.click()
+        chat_1.clear_history_button.click()
+        chat_1.clear_button.click()
+        chat_2.chat_message_input.send_keys(message_3)
+        chat_2.send_message_button.click()
+        chat_1.element_by_text(message_3).is_element_present()
+        for message in message_1, message_2:
+            if chat_1.element_starts_with_text(message).is_element_present():
+                pytest.fail("Message '%s' is shown, but public chat history has been cleared" % message)
+        home_1 = chat_1.get_back_to_home_view()
+        home_1.relogin()
+        home_1.element_by_text('#' + chat_name).click()
+        for message in message_1, message_2:
+            if chat_1.element_starts_with_text(message).is_element_present():
+                pytest.fail("Message '%s' is shown after re-login, but public chat history has been cleared" % message)
+
+    @marks.testrail_id(3720)
+    def test_delete_public_chat_via_delete_button(self):
+        self.create_drivers(1)
+        sign_in = SignInView(self.drivers[0])
+        home = sign_in.create_user()
+        chat_name = home.get_public_chat_name()
+        public_chat = home.join_public_chat(chat_name)
+        public_chat.chat_message_input.send_keys('takoe')
+        public_chat.send_message_button.click()
+        public_chat.delete_chat()
+        if home.element_by_text(chat_name).is_element_present(5):
+            self.errors.append("Public chat '%s' is shown, but the chat has been deleted" % chat_name)
+        home.relogin()
+        if home.element_by_text(chat_name).is_element_present(5):
+            self.errors.append("Public chat '%s' is shown after re-login, but the chat has been deleted" % chat_name)
         self.verify_no_errors()

--- a/test/appium/tests/atomic/test_browsing.py
+++ b/test/appium/tests/atomic/test_browsing.py
@@ -1,0 +1,63 @@
+import pytest
+from tests import transaction_users, marks
+from tests.base_test_case import SingleDeviceTestCase
+from views.sign_in_view import SignInView
+
+
+@pytest.mark.all
+class TestBrowsing(SingleDeviceTestCase):
+
+    @marks.testrail_id(1411)
+    def test_browse_page_with_non_english_text(self):
+        sign_in = SignInView(self.driver)
+        sign_in.create_user()
+        home_view = sign_in.get_home_view()
+        start_new_chat = home_view.plus_button.click()
+        start_new_chat.open_d_app_button.click()
+        start_new_chat.enter_url_editbox.set_value('www.wikipedia.org')
+        start_new_chat.confirm()
+        browsing_view = home_view.get_base_web_view()
+        browsing_view.wait_for_d_aap_to_load()
+        wiki_texts = ['Español', '日本語', 'Français', '中文', 'Português']
+        for wiki_text in wiki_texts:
+            browsing_view.find_text_part(wiki_text, 15)
+
+    @marks.testrail_id(1412)
+    def test_open_invalid_link(self):
+        sign_in = SignInView(self.driver)
+        sign_in.create_user()
+        home_view = sign_in.get_home_view()
+        start_new_chat = home_view.plus_button.click()
+        start_new_chat.open_d_app_button.click()
+        start_new_chat.enter_url_editbox.set_value('invalid.takoe')
+        start_new_chat.confirm()
+        browsing_view = home_view.get_base_web_view()
+        browsing_view.find_text_part('Unable to load page')
+
+    @marks.testrail_id(3705)
+    def test_connection_is_not_secure(self):
+        sign_in = SignInView(self.driver)
+        sign_in.create_user()
+        home_view = sign_in.get_home_view()
+        start_new_chat = home_view.plus_button.click()
+        start_new_chat.open_d_app_button.click()
+        start_new_chat.enter_url_editbox.set_value('google.com')
+        start_new_chat.confirm()
+        browsing_view = home_view.get_base_web_view()
+        browsing_view.find_full_text("Connection is not proven secure. Make sure you trust this site before signing "
+                                     "transactions or entering personal data.")
+
+    @marks.testrail_id(3731)
+    def test_swipe_to_delete_browser_entry(self):
+        sign_in = SignInView(self.driver)
+        home_view = sign_in.create_user()
+        start_new_chat = home_view.plus_button.click()
+        start_new_chat.open_d_app_button.click()
+        start_new_chat.enter_url_editbox.set_value('google.com')
+        start_new_chat.confirm()
+        browsing_view = home_view.get_base_web_view()
+        browsing_view.browser_cross_icon.click()
+        home_view.swipe_and_delete_chat('Browser')
+        home_view.relogin()
+        if home_view.get_chat_with_user('Browser').is_element_present(20):
+            pytest.fail('The browser entry is present after re-login')

--- a/test/appium/views/base_element.py
+++ b/test/appium/views/base_element.py
@@ -151,7 +151,7 @@ class BaseElement(object):
         location, size = element.location, element.size
         x, y = location['x'], location['y']
         width, height = size['width'], size['height']
-        self.driver.swipe(start_x=x + width / 2, start_y=y + height / 2, end_x=x, end_y=y + height / 2)
+        self.driver.swipe(start_x=x + width * 2, start_y=y + height / 2, end_x=x, end_y=y + height / 2)
 
     def long_press_element(self):
         element = self.find_element()

--- a/test/appium/views/base_view.py
+++ b/test/appium/views/base_view.py
@@ -280,7 +280,7 @@ class BaseView(object):
         element.locator = element.Locator.text_selector(text)
         return element
 
-    def element_by_text_part(self, text, element_type='base'):
+    def element_by_text_part(self, text, element_type='button'):
         info("Looking for an element by text part: '%s'" % text)
         element = self.element_types[element_type](self.driver)
         element.locator = element.Locator.text_part_selector(text)
@@ -297,6 +297,12 @@ class BaseView(object):
         element = BaseElement(self.driver)
         element.locator = element.Locator.xpath_selector("//*[starts-with(@text,'%s')]" % text)
         return element.wait_for_element(wait_time)
+
+    def element_by_accessibility_id(self, accessibility_id, element_type='button'):
+        info("Looking for an element by text: '%s'" % accessibility_id)
+        element = self.element_types[element_type](self.driver)
+        element.locator = element.Locator.accessibility_id(accessibility_id)
+        return element
 
     def swipe_down(self):
         self.driver.swipe(500, 500, 500, 1000)
@@ -358,6 +364,7 @@ class BaseView(object):
                 self.back_button.click()
             except (NoSuchElementException, TimeoutException):
                 counter += 1
+        return self.get_home_view()
 
     def relogin(self, password=common_password):
         self.get_back_to_home_view()
@@ -377,3 +384,10 @@ class BaseView(object):
         public_key = profile_view.public_key_text.text
         profile_view.cross_icon.click()
         return public_key
+
+    def share_via_messenger(self):
+        self.element_by_text('Messenger').click()
+        self.element_by_text('NEW MESSAGE').click()
+        self.send_as_keyevent('+0')
+        self.confirm()
+        self.element_by_accessibility_id('Send Message').click()

--- a/test/appium/views/chat_view.py
+++ b/test/appium/views/chat_view.py
@@ -302,14 +302,10 @@ class ChatView(BaseView):
             self.send_message_button.click_until_presence_of_element(send_transaction.sign_transaction_button)
         send_transaction.sign_transaction(sender_password)
 
-    def delete_chat(self, chat_name: str, errors: list):
+    def delete_chat(self):
         self.chat_options.click()
         self.delete_chat_button.click()
         self.delete_button.click()
-        from views.home_view import HomeView
-        if not HomeView(self.driver).plus_button.is_element_present() or \
-                self.element_by_text(chat_name).is_element_present():
-            errors.append('Chat was not deleted')
 
     def clear_history(self):
         self.chat_options.click()

--- a/test/appium/views/profile_view.py
+++ b/test/appium/views/profile_view.py
@@ -231,13 +231,49 @@ class SelectFromGalleryButton(BaseButton):
         self.locator = self.Locator.xpath_selector("//*[@text='Select from gallery']")
 
 
+class MainCurrencyButton(BaseButton):
+
+    def __init__(self, driver):
+        super(MainCurrencyButton, self).__init__(driver)
+        self.locator = self.Locator.accessibility_id("currency-button")
+
+
+class NetworkPlusButton(BaseButton):
+
+    def __init__(self, driver):
+        super(NetworkPlusButton, self).__init__(driver)
+        self.locator = self.Locator.xpath_selector("(//android.view.ViewGroup[@content-desc='icon'])[2]")
+
+
+class RopstenChainButton(BaseButton):
+
+    def __init__(self, driver):
+        super(RopstenChainButton, self).__init__(driver)
+        self.locator = self.Locator.xpath_selector(
+            "//*[contains(@text,'Ropsten test network')]/following-sibling::android.widget.CheckBox[1]")
+
+
+class CustomNetworkName(BaseEditBox):
+
+    def __init__(self, driver):
+        super(CustomNetworkName, self).__init__(driver)
+        self.locator = self.Locator.xpath_selector("//*[@text='Name']/following-sibling::*[1]/android.widget.EditText")
+
+
+class CustomNetworkURL(BaseEditBox):
+
+    def __init__(self, driver):
+        super(CustomNetworkURL, self).__init__(driver)
+        self.locator = self.Locator.xpath_selector(
+            "//*[@text='RPC URL']/following-sibling::*[1]/android.widget.EditText")
+
+
 class ProfileView(BaseView):
 
     def __init__(self, driver):
         super(ProfileView, self).__init__(driver)
         self.driver = driver
 
-        # old design
         self.options_button = OptionsButton(self.driver)
         self.username_input = OptionsButton.UsernameInput(self.driver)
         self.user_status_box = OptionsButton.UserStatusBox(self.driver)
@@ -246,12 +282,16 @@ class ProfileView(BaseView):
         self.profile_address_text = ProfileAddressText(self.driver)
 
         self.network_settings_button = NetworkSettingsButton(self.driver)
+        self.network_plus_button = NetworkPlusButton(self.driver)
+        self.ropsten_chain_button = RopstenChainButton(self.driver)
+        self.custom_network_url = CustomNetworkURL(self.driver)
+        self.custom_network_name = CustomNetworkName(self.driver)
         self.connect_button = NetworkSettingsButton.ConnectButton(self.driver)
         self.logout_button = LogoutButton(self.driver)
         self.logout_dialog = LogoutDialog(self.driver)
         self.confirm_logout_button = ConfirmLogoutButton(self.driver)
 
-        # new design
+        self.main_currency_button = MainCurrencyButton(self.driver)
 
         self.username_text = UserNameText(self.driver)
         self.share_my_contact_key_button = ShareMyContactKeyButton(self.driver)
@@ -283,6 +323,20 @@ class ProfileView(BaseView):
         self.connect_button.click()
         from views.sign_in_view import SignInView
         return SignInView(self.driver)
+
+    def add_custom_network(self):
+        self.advanced_button.click()
+        self.debug_mode_toggle.click()
+        self.network_settings_button.scroll_to_element()
+        self.network_settings_button.click()
+        self.network_plus_button.click_until_presence_of_element(self.ropsten_chain_button)
+        self.ropsten_chain_button.click()
+        self.custom_network_url.send_keys('https://ropsten.infura.io/iMko0kJNQUdhbCSaJcox')
+        self.custom_network_name.send_keys('custom_ropsten')
+        self.save_button.click()
+        self.element_by_text_part('custom_ropsten').click_until_presence_of_element(self.connect_button)
+        self.connect_button.click()
+        return self.get_sign_in_view()
 
     def get_address(self):
         profile_view = self.profile_button.click()
@@ -323,4 +377,10 @@ class ProfileView(BaseView):
     def logout(self):
         self.logout_button.click()
         return self.logout_dialog.logout_button.click()
+
+    def set_currency(self, desired_currency='Euro (EUR)'):
+        self.main_currency_button.click()
+        desired_currency = self.element_by_text(desired_currency)
+        desired_currency.scroll_to_element()
+        desired_currency.click()
 

--- a/test/appium/views/start_new_chat_view.py
+++ b/test/appium/views/start_new_chat_view.py
@@ -58,6 +58,12 @@ class UsernameCheckbox(BaseButton):
         self.locator = self.Locator.xpath_selector("//*[@text='%s']/../../android.widget.CheckBox" % username)
 
 
+class InviteFriendsButton(BaseButton):
+    def __init__(self, driver):
+        super(InviteFriendsButton, self).__init__(driver)
+        self.locator = self.Locator.accessibility_id('invite-friends-button')
+
+
 class StartNewChatView(ContactsView):
     def __init__(self, driver):
         super(StartNewChatView, self).__init__(driver)
@@ -68,6 +74,7 @@ class StartNewChatView(ContactsView):
 
         self.open_d_app_button = OpenDAppButton(self.driver)
         self.open_button = OpenButton(self.driver)
+        self.invite_friends_button = InviteFriendsButton(self.driver)
 
         self.chat_name_editbox = ChatNameEditBox(self.driver)
         self.enter_url_editbox = EnterUrlEditbox(self.driver)

--- a/test/appium/views/wallet_view.py
+++ b/test/appium/views/wallet_view.py
@@ -144,6 +144,20 @@ class AssetCheckBox(BaseButton):
         self.locator = self.Locator.xpath_selector("//*[@text='%s']/../android.widget.CheckBox" % asset_name)
 
 
+class TotalAmountText(BaseText):
+
+    def __init__(self, driver):
+        super(TotalAmountText, self).__init__(driver)
+        self.locator = self.Locator.accessibility_id('total-amount-value-text')
+
+
+class CurrencyText(BaseText):
+
+    def __init__(self, driver):
+        super(CurrencyText, self).__init__(driver)
+        self.locator = self.Locator.accessibility_id('total-amount-currency-text')
+
+
 class WalletView(BaseView):
     def __init__(self, driver):
         super(WalletView, self).__init__(driver)
@@ -168,6 +182,9 @@ class WalletView(BaseView):
 
         self.set_up_button = SetUpButton(self.driver)
         self.sign_in_phrase = SignInPhraseText(self.driver)
+
+        self.total_amount_text = TotalAmountText(self.driver)
+        self.currency_text = CurrencyText(self.driver)
 
     def get_usd_total_value(self):
         import re

--- a/test/appium/views/web_views/base_web_view.py
+++ b/test/appium/views/web_views/base_web_view.py
@@ -46,6 +46,17 @@ class AlwaysButton(BaseButton):
         self.locator = self.Locator.text_part_selector('ALWAYS')
 
 
+class BrowserCrossIcon(BaseButton):
+
+    def __init__(self, driver):
+        super(BrowserCrossIcon, self).__init__(driver)
+        self.locator = self.Locator.xpath_selector('(//android.view.ViewGroup[@content-desc="icon"])[1]')
+
+    def navigate(self):
+        from views.home_view import HomeView
+        return HomeView(self.driver)
+
+
 class BaseWebView(BaseView):
 
     def __init__(self, driver):
@@ -61,6 +72,7 @@ class BaseWebView(BaseView):
 
         self.web_view_browser = WebViewBrowserButton(self.driver)
         self.always_button = AlwaysButton(self.driver)
+        self.browser_cross_icon = BrowserCrossIcon(self.driver)
 
     def wait_for_d_aap_to_load(self, wait_time=35):
         counter = 0


### PR DESCRIPTION
added tests: 

- [x] C3706 Can clear history of public chat. After re-login no past history is shown in chat
- [x] C3450 Can set currency for assets other than USD (profile->main currency)
- [x] C3705 Connection is not secure warning appears when custom URL is opened
- [x] C3707 | Can add custom network
- [x] C3719 | Can delete 1:1 chat with Delete chat
- [x] C3720 | Can delete public chat with Delete chat
- [x] C3731 | Delete Browser entry with swipe to delete
- [x] C3721 Can invite friends to Status app
- [x] C1412 use Open DApp with non-exiting or invalid link. e.g aaabbb -> Unable to load page
- [x] C1411 Can use Open DApp and open page with non-English text, e.g. ozon.ru  
