### PR TITLE
bug #4930 - atomic navigation after error prevents send screen being …

### DIFF
--- a/src/status_im/ui/screens/wallet/components/views.cljs
+++ b/src/status_im/ui/screens/wallet/components/views.cljs
@@ -92,7 +92,7 @@
            [react/text {:style styles/text-secondary-content}
             (clojure.core/name symbol)]]
           [react/text {:style (merge styles/text-secondary-content styles/asset-label)}
-           (str (wallet.utils/format-amount (symbol balance) decimals))]]]]
+           (str (wallet.utils/format-amount (get balance symbol) decimals))]]]]
        (when error
          [tooltip/tooltip error {}])])))
 

--- a/src/status_im/ui/screens/wallet/send/events.cljs
+++ b/src/status_im/ui/screens/wallet/send/events.cljs
@@ -257,10 +257,10 @@
         ;;NO ERROR, DISCARDED, TIMEOUT or DEFAULT ERROR
        (if (this-transaction-signing? id (:id send-transaction) view-id modal)
          (cond-> {:db                      (-> db
+                                               navigation/navigate-back
                                                (assoc-in [:wallet :transactions-queue] nil)
                                                (update-in [:wallet :transactions-unsigned] dissoc id)
-                                               (update-in [:wallet :send-transaction] merge clear-send-properties))
-                  :dispatch                [:navigate-back]}
+                                               (update-in [:wallet :send-transaction] merge clear-send-properties))}
            (= method constants/web3-send-transaction)
            (handle-failed-tx error_message))
          {:db (update-in db [:wallet :transactions-unsigned] dissoc id)})))))


### PR DESCRIPTION
fixes #4930 

### Summary:

Navigation away from Wallet Send was fired in a dispatch, not bundled together with other effects. So, when other effects created the state that was invalid for the previous screen (that was only visible between the moment event was fired and the navigation dispatch handled) the app crashed.

This PR replaces the separate dispatch with an atomic app-db change. 


### Steps to test:
see #4930

status: ready 