### PR TITLE
bug #5057 - automatically converts recovery phrase to lowecase during…

### DIFF
--- a/src/status_im/ui/screens/accounts/recover/views.cljs
+++ b/src/status_im/ui/screens/accounts/recover/views.cljs
@@ -32,7 +32,7 @@
       :multiline           true
       :default-value       passphrase
       :auto-correct        false
-      :on-change-text      #(re-frame/dispatch [:set-in [:accounts/recover :passphrase] %])
+      :on-change-text      #(re-frame/dispatch [:set-in [:accounts/recover :passphrase] (string/lower-case %)])
       :error               error}]))
 
 (defview password-input [password]


### PR DESCRIPTION
fixes #5057

### Summary:

Changes recovery screen to automatically convert any typed uppercase letters to lowercase.

### Steps to test:
- Recover account
- Try to recover with uppercase letters in recovery phrase

status: ready 