### PR TITLE
Update transactions when navigate to tx details from chat

### DIFF
--- a/src/status_im/chat/views/message/message.cljs
+++ b/src/status_im/chat/views/message/message.cljs
@@ -62,6 +62,7 @@
   (letsubs [confirmed? [:transaction-confirmed? tx-hash]
             tx-exists? [:wallet-transaction-exists? tx-hash]]
     [react/touchable-highlight {:on-press #(when tx-exists?
+                                             (re-frame/dispatch [:update-transactions])
                                              (re-frame/dispatch [:show-transaction-details tx-hash]))}
      [react/view style/command-send-status-container
       [vector-icons/icon (if confirmed? :icons/check :icons/dots)


### PR DESCRIPTION
Addresses #4851

### Summary:

Update transactions when navigate to tx details from chat message generated with /send command.

### Review notes (optional):

Data isn't getting updated if user stays on that screen for a while. But that's a part of another issue https://github.com/status-im/status-react/issues/4851

status: ready
