### PR TITLE
prevent app from crashing on "share data" click 

### DIFF
--- a/src/status_im/ui/screens/usage_data/views.cljs
+++ b/src/status_im/ui/screens/usage_data/views.cljs
@@ -7,33 +7,41 @@
             [status-im.ui.components.react :as react]
             [status-im.ui.components.status-bar.view :as status-bar]
             [status-im.ui.screens.usage-data.styles :as styles]
+            [status-im.utils.platform :as platform]
             [status-im.utils.utils :as utils]))
 
 (views/defview usage-data []
   (views/letsubs [next [:get-screen-params]]
-    [react/view {:style styles/usage-data-view}
-     [status-bar/status-bar {:flat? true}]
-     [react/view
-      [react/view {:style styles/image-container}
-       [react/image {:source (:analytics-image resources/ui)
-                     :style  styles/usage-data-image}]]
-      [react/text {:style styles/help-improve-text}
-       (i18n/label :t/help-improve)]
+                 (let [usage-data-click (if platform/desktop?
+                                          ;; desktop is currently not collecting data usage
+                                          #(re-frame/dispatch [:help-improve-handler false next])
+                                          #(utils/show-confirmation {:ios-confirm-style "default"}
+                                                                    (i18n/label :t/confirmation-title)
+                                                                    (i18n/label :t/confirmation-text)
+                                                                    (i18n/label :t/confirmation-action)
+                                                                    (fn [] (re-frame/dispatch [:help-improve-handler true next]))
+                                                                    nil))]
+                   [react/view {:style styles/usage-data-view}
+                    [status-bar/status-bar {:flat? true}]
       [react/view
-       [react/text {:style styles/help-improve-text-description}
-        (i18n/label :t/help-improve-description)]]
-      [react/text {:style    styles/learn-what-we-collect-link
-                   :on-press #(.openURL react/linking "https://wiki.status.im/Help_Improve_Status#Help_Improve_Status")}
-       (i18n/label :t/learn-what-we-collect-link)]]
-     [react/view styles/bottom-button-container
-      [components.common/button {:button-style      styles/share-button
-                                 :uppercase?        false
-                                 ;; this is a desktop hack. we are currently not collecting data usage
-                                 ;; on behalf of the user
-                                 :on-press          #(re-frame/dispatch [:help-improve-handler false next])
-                                 :label             (i18n/label :t/share-usage-data)}]
-      [components.common/button {:button-style      styles/dont-share-button
-                                 :uppercase?        false
-                                 :on-press          #(re-frame/dispatch [:help-improve-handler false next])
-                                 :label             (i18n/label :t/dont-want-to-share)}]]]))
+       [react/view {:style styles/image-container}
+        [react/image {:source (:analytics-image resources/ui)
+                      :style  styles/usage-data-image}]]
+       [react/text {:style styles/help-improve-text}
+        (i18n/label :t/help-improve)]
+       [react/view
+        [react/text {:style styles/help-improve-text-description}
+         (i18n/label :t/help-improve-description)]]
+       [react/text {:style    styles/learn-what-we-collect-link
+                    :on-press #(.openURL react/linking "https://wiki.status.im/Help_Improve_Status#Help_Improve_Status")}
+        (i18n/label :t/learn-what-we-collect-link)]]
+      [react/view styles/bottom-button-container
+       [components.common/button {:button-style styles/share-button
+                                  :uppercase?   false
+                                  :on-press     usage-data-click
+                                  :label        (i18n/label :t/share-usage-data)}]
+       [components.common/button {:button-style styles/dont-share-button
+                                  :uppercase?   false
+                                  :on-press     #(re-frame/dispatch [:help-improve-handler false next])
+                                  :label        (i18n/label :t/dont-want-to-share)}]]])))
 

--- a/src/status_im/ui/screens/usage_data/views.cljs
+++ b/src/status_im/ui/screens/usage_data/views.cljs
@@ -28,12 +28,9 @@
      [react/view styles/bottom-button-container
       [components.common/button {:button-style      styles/share-button
                                  :uppercase?        false
-                                 :on-press          #(utils/show-confirmation {:ios-confirm-style "default"}
-                                                                              (i18n/label :t/confirmation-title)
-                                                                              (i18n/label :t/confirmation-text)
-                                                                              (i18n/label :t/confirmation-action)
-                                                                              (fn [] (re-frame/dispatch [:help-improve-handler true next]))
-                                                                              nil)
+                                 ;; this is a desktop hack. we are currently not collecting data usage
+                                 ;; on behalf of the user
+                                 :on-press          #(re-frame/dispatch [:help-improve-handler false next])
                                  :label             (i18n/label :t/share-usage-data)}]
       [components.common/button {:button-style      styles/dont-share-button
                                  :uppercase?        false


### PR DESCRIPTION
Fixes #4970 

Simple fix. Assuming for now we just want the app to "not crash" for desktop P0. Instabug, etc... to be revisited later. 