### PR TITLE
fixes figwheel repl for android builds on linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,4 +164,5 @@ startdev-%:
 	  "ios")      ${MAKE} prepare-ios;; \
 	esac
 	${MAKE} dev-$(SYSTEM)-$(DEVICE)
-	${MAKE} -j2 react-native repl-$(SYSTEM)
+	${MAKE} react-native &
+	${MAKE} repl-$(SYSTEM)


### PR DESCRIPTION
### Summary:

For some reason starting repl from `make -j2` messes up its input/output so it can't be used, at least not in linux/android combination.

Separating tasks into an explicitly background process for `react-native` server followed by a regular process for repl apparently fixes the problem.

### Testing notes (optional):
Only dev tools changed, nothing to test.

status: ready
