### PR TITLE
bug #3441 - considering gas costs when validating send transaction ag…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed chat message layout for right-to-left languages
 - Fixed parsing of messages containing multiple dots (elipsis)
 - Fixed Webview: Screen cut off when using ERC dEX DApp [#3131]
+- Fixed gas validation: Showing message when total amount being sent plus the max gas cost exceed the balance [#3441]
  
 ## [0.9.22] - 2018-07-09
 ### Added

--- a/src/status_im/translations/en.cljs
+++ b/src/status_im/translations/en.cljs
@@ -455,6 +455,7 @@
    :signing-message-phrase-description   "Sign the message by entering your password. Make sure that the words above match your secret signing phrase"
    :signing-phrase-description           "Sign the transaction by entering your password. Make sure that the words above match your secret signing phrase"
    :wallet-insufficient-funds            "Insufficient funds"
+   :wallet-insufficient-gas              "Not enough ETH for gas"
    :receive                              "Receive"
    :request-qr-legend                    "Share this code to receive assets"
    :send-request                         "Send request"


### PR DESCRIPTION
fixes #3441

### Summary:

Considers estimated gas cost when validating required send transaction cost against the available balance.

### Steps to test:
- Try sending an ETH transaction with amount equal to total balance
- Try sending a token transaction without having any ETH
- Try requesting tokens from Simple Dapp without having any ETH
- Try transacting with any dapp without having any ETH

status: ready 