### PR TITLE
[Fixes #5000] Use timestamp from last message if available

### DIFF
--- a/src/status_im/ui/screens/home/views/inner_item.cljs
+++ b/src/status_im/ui/screens/home/views/inner_item.cljs
@@ -105,7 +105,8 @@
          [react/view styles/item-upper-container
           [chat-list-item-name truncated-chat-name group-chat public? public-key]
           [react/view styles/message-status-container
-           [message-timestamp timestamp]]]
+           [message-timestamp (or (:timestamp last-message)
+                                  timestamp)]]]
          [react/view styles/item-lower-container
           [message-content-text last-message]
           [unviewed-indicator chat-id]]]]])))


### PR DESCRIPTION
fixes #5000 

### Testing notes

1) An empty chat will show the creation time
2) A chat with a message will show the last timestamp
3) Chats are still ordered by the last message received, not the timestamp of the last message (i.e If you receive a message from the mailserver with an old timestamp it goes on top )

status: ready
