### PR TITLE
bug #5120 - fixes crash in wallet send if collectibles are enabled

### DIFF
--- a/src/status_im/ui/screens/wallet/components/views.cljs
+++ b/src/status_im/ui/screens/wallet/components/views.cljs
@@ -54,7 +54,7 @@
       [list/item-secondary (wallet.utils/format-amount amount decimals)]]]]])
 
 (views/defview assets [type]
-  (views/letsubs [assets [:wallet/visible-assets-with-amount]]
+  (views/letsubs [assets [:wallet/transferrable-assets-with-amount]]
     [components/simple-screen
      [components/toolbar (i18n/label :t/wallet-assets)]
      [react/view {:style (assoc components.styles/flex :background-color :white)}

--- a/src/status_im/ui/screens/wallet/subs.cljs
+++ b/src/status_im/ui/screens/wallet/subs.cljs
@@ -111,6 +111,11 @@
                   (fn [[balance visible-assets]]
                     (map #(assoc % :amount (get balance (:symbol %))) visible-assets)))
 
+(re-frame/reg-sub :wallet/transferrable-assets-with-amount
+                  :<- [:wallet/visible-assets-with-amount]
+                  (fn [all-assets]
+                    (filter #(not (:nft? %)) all-assets)))
+
 (re-frame/reg-sub :wallet/currency
                   :<- [:wallet.settings/currency]
                   (fn [currency-id]


### PR DESCRIPTION
fixes #5120

### Summary:

Fixes the crash in Wallet send > Choose asset when collectibles are enabled - by filtering out collectibles from the list of sendable tokens.

### Steps to test:
see #5120

status: ready 