### PR TITLE
Feature/desktop discard old builds

### DIFF
--- a/Jenkinsfile.desktopbuild
+++ b/Jenkinsfile.desktopbuild
@@ -1,3 +1,12 @@
+properties([
+    buildDiscarder(logRotator(
+        numToKeepStr: '2',
+        daysToKeepStr: '3',
+        artifactNumToKeepStr: '2',
+        artifactDaysToKeepStr: '3'
+    ))
+])
+
 env.LANG="en_US.UTF-8"
 env.LANGUAGE="en_US.UTF-8"
 env.LC_ALL="en_US.UTF-8"


### PR DESCRIPTION
There's far too many desktop builds on Jenkins hosts that take up too much space. The UI misses settings for the discard plugin so I need to set this here.