### PR TITLE
Install gradle archives during setup.

### DIFF
--- a/scripts/setup
+++ b/scripts/setup
@@ -31,6 +31,7 @@ install_node
 install_watchman
 install_react_native_cli
 install_android_sdk
+install_android_ndk
 install_maven
 install_cocoapods
 
@@ -49,6 +50,6 @@ dependency_setup ./re-natal enable-source-maps
 dependency_setup \
   "mvn -f modules/react-native-status/ios/RCTStatus/pom.xml dependency:unpack"
 
-using_cocoapods && dependency_setup "cd ios && pod install && cd .."
+using_cocoapods && dependency_setup "pushd ios && pod install && popd"
 
 setup_complete


### PR DESCRIPTION
Fixes broken `make release-android` step on new machines.

Addresses the same issue as https://github.com/status-im/status-react/pull/5110, but on the setup script.
Tested the build on a new machine where it was previously failing, and build now passes on the first attempt.

status: ready <!-- Can be ready or wip -->
