### PR TITLE
realm and status-go generated files location

### DIFF
--- a/modules/react-native-status/desktop/rctstatus.cpp
+++ b/modules/react-native-status/desktop/rctstatus.cpp
@@ -113,12 +113,12 @@ void RCTStatus::startNode(QString configString) {
     qDebug() << " RCTStatus::startNode configString: " << jsonDoc.toVariant().toMap();
     QVariantMap configJSON = jsonDoc.toVariant().toMap();
 
-    QString newKeystoreUrl = "keystore";
-
     int networkId = configJSON["NetworkId"].toInt();
     QString dataDir = configJSON["DataDir"].toString();
 
-    QString networkDir = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation) + "/" + dataDir;
+    QString rootDirPath = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation) + "/";
+    QString networkDir = rootDirPath + dataDir;
+    QString keyStoreDir = rootDirPath + "keystore";
     QDir dir(networkDir);
     if (!dir.exists()) {
       dir.mkpath(".");
@@ -136,7 +136,7 @@ void RCTStatus::startNode(QString configString) {
 
     qDebug() << " RCTStatus::startNode GenerateConfig configString: " << jsonDoc.toVariant().toMap();
     QVariantMap generatedConfig = jsonDoc.toVariant().toMap();
-    generatedConfig["KeyStoreDir"] = newKeystoreUrl;
+    generatedConfig["KeyStoreDir"] = keyStoreDir;
     generatedConfig["LogEnabled"] = true;
     generatedConfig["LogFile"] = networkDir + "/geth.log";
     //generatedConfig["LogLevel"] = "DEBUG";


### PR DESCRIPTION
### Summary:

Specify data folder as location for status-go's keychain and realm db files.

### Testing notes:
- No files should be generated in directory from where StatusIm is launched
- As bonus, on macOS it should be possible now to launch bundle directly from mounted .dmg ( Copying to /Applications is not necessary )
- Since keystore and db files location is moved from local working directory to system wide data directory, all old accounts should be not found by app on start

status: ready
