### PR TITLE
Set JVM heap size in gradle.properties so that dex can run in-process

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -30,3 +30,5 @@ android.enableAapt2=false
 
 # Disable Gradle Daemon https://stackoverflow.com/questions/38710327/jenkins-builds-fail-using-the-gradle-daemon
 org.gradle.daemon=false
+
+org.gradle.jvmargs=-Xmx4608M

--- a/scripts/lib/setup/installers.sh
+++ b/scripts/lib/setup/installers.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+_localPropertiesPath=./android/local.properties
+
 function install_node() {
   if nvm_installed; then
     install_node_via_nvm
@@ -294,15 +296,14 @@ function dependency_setup() {
 }
 
 function use_android_sdk() {
-  _localPropertiesPath=./android/local.properties
   if [ -n "$ANDROID_SDK" ]; then
     if ! grep -Fq "sdk.dir" $_localPropertiesPath; then
       echo "sdk.dir=$ANDROID_SDK" | tee -a $_localPropertiesPath
     fi
   else
-    _docURL="https://docs.status.im/docs/build_status_linux.html"
+    local _docUrl="https://docs.status.im/docs/build_status_linux.html"
     if is_macos; then
-      _docURL="https://docs.status.im/docs/build_status_osx.html"
+      _docUrl="https://docs.status.im/docs/build_status_osx.html"
     fi
     cecho "@yellow[[ANDROID_SDK environment variable not defined, please install the Android SDK.]]"
     cecho "@yellow[[(see $_docUrl).]]"
@@ -314,12 +315,11 @@ function use_android_sdk() {
 }
 
 function install_android_ndk() {
-  _localPropertiesPath=./android/local.properties
   if grep -Fq "ndk.dir" $_localPropertiesPath; then
     dependency_setup \
       "pushd android && ./gradlew react-native-android:installArchives && popd"
   else
-    _ndkParentDir=~/Android/Sdk
+    local _ndkParentDir=~/Android/Sdk
     mkdir -p $_ndkParentDir
     cecho "@cyan[[Downloading Android NDK.]]"
     wget --output-document=android-ndk.zip https://dl.google.com/android/repository/android-ndk-r10e-linux-x86_64.zip && \


### PR DESCRIPTION
### Summary:

[comment]: # (Summarise the problem and how the pull request solves it)
This PR addresses the following build warning: 
```
Running dex as a separate process.

To run dex in process, the Gradle daemon needs a larger heap.
It currently has 3844 MB.
For faster builds, increase the maximum heap size for the Gradle daemon to at least 4608 MB (based on the dexOptions.javaMaxHeapSize = 4g).
To do this set org.gradle.jvmargs=-Xmx4608M in the project gradle.properties.
For more information see https://docs.gradle.org/current/userguide/build_environment.html
```

It also contains a very simple unrelated file change to fix a variable name typo from a recently merged PR (was tested successfully locally).

status: ready <!-- Can be ready or wip -->
