### PR TITLE
include current commit-sha next to desktop app version

### DIFF
--- a/src/status_im/ui/screens/desktop/main/tabs/profile/views.cljs
+++ b/src/status_im/ui/screens/desktop/main/tabs/profile/views.cljs
@@ -72,7 +72,7 @@
    [react/view {:style styles/logout-row}
     [react/touchable-highlight {:on-press #(re-frame/dispatch [:logout])}
      [react/text {:style (styles/logout-row-text colors/red)} (i18n/label :t/logout)]]
-    [react/view [react/text {:style (styles/logout-row-text colors/gray)} "V" build/version]]]])
+    [react/view [react/text {:style (styles/logout-row-text colors/gray)} "V" build/version " (" build/commit-sha ")"]]]])
 
 (views/defview profile-data []
   (views/letsubs

--- a/src/status_im/utils/build.clj
+++ b/src/status_im/utils/build.clj
@@ -26,6 +26,12 @@
       :out
       (string/replace "\n" "")))
 
+(defmacro get-current-sha []
+  "fetches the latest commit sha from the current branch"
+  (-> (shell/sh "bash" "-c" "git describe --always")
+      :out
+      (string/replace "\n" "")))
+
 (defmacro git-short-version []
   (let [version-file-path "VERSION"
         version-file      (io/file version-file-path)]

--- a/src/status_im/utils/build.cljs
+++ b/src/status_im/utils/build.cljs
@@ -2,3 +2,4 @@
   (:require-macros [status-im.utils.build :as build]))
 
 (def version (build/git-short-version))
+(def commit-sha (build/get-current-sha))


### PR DESCRIPTION
Fixes #5140 

includes the commit sha of the current branch next to the app version 