### PR TITLE
adjust desktop screen dimensions

### DIFF
--- a/desktop/main.cpp
+++ b/desktop/main.cpp
@@ -188,6 +188,7 @@ int main(int argc, char **argv) {
   view.rootContext()->setContextProperty("ReactNativeProperties", rnp);
   view.setSource(QUrl("qrc:///main.qml"));
   view.setResizeMode(QQuickView::SizeRootObjectToView);
+  view.resize(650, 400);
   view.show();
 
 #ifdef BUILD_FOR_BUNDLE

--- a/desktop/main.cpp
+++ b/desktop/main.cpp
@@ -29,8 +29,8 @@ QStringList consoleOutputStrings;
 bool ubuntuServerStarted = false;
 #endif
 
-const int MAIN_WINDOW_WIDTH = 650;
-const int MAIN_WINDOW_HEIGHT = 400;
+const int MAIN_WINDOW_WIDTH = 1024;
+const int MAIN_WINDOW_HEIGHT = 768;
 
 // TODO: some way to change while running
 class ReactNativeProperties : public QObject {

--- a/desktop/main.cpp
+++ b/desktop/main.cpp
@@ -29,6 +29,9 @@ QStringList consoleOutputStrings;
 bool ubuntuServerStarted = false;
 #endif
 
+const int MAIN_WINDOW_WIDTH = 650;
+const int MAIN_WINDOW_HEIGHT = 400;
+
 // TODO: some way to change while running
 class ReactNativeProperties : public QObject {
   Q_OBJECT
@@ -188,7 +191,7 @@ int main(int argc, char **argv) {
   view.rootContext()->setContextProperty("ReactNativeProperties", rnp);
   view.setSource(QUrl("qrc:///main.qml"));
   view.setResizeMode(QQuickView::SizeRootObjectToView);
-  view.resize(650, 400);
+  view.resize(MAIN_WINDOW_WIDTH, MAIN_WINDOW_HEIGHT);
   view.show();
 
 #ifdef BUILD_FOR_BUNDLE


### PR DESCRIPTION
Fixes #4824 

Testing instructions: open up the app as you normally would and verify that the screen dimensions are now no longer set for mobile. 