### PR TITLE
update add-contact handler

### DIFF
--- a/src/status_im/ui/screens/desktop/main/chat/styles.cljs
+++ b/src/status_im/ui/screens/desktop/main/chat/styles.cljs
@@ -62,8 +62,7 @@
    :margin-right 8})
 
 (def toolbar-chat-view
-  {:align-items     :center
-   :padding         11
+  {:padding         11
    :justify-content :center})
 
 (def toolbar-chat-name
@@ -75,11 +74,11 @@
   {:background-color :white
    :border-radius    6
    :margin-top       3
-   :padding          4})
+   :padding-top      1})
 
 (def add-contact-text
   {:font-size 14
-   :color     colors/gray})
+   :color     colors/blue})
 
 (def message-text
   {:font-size 14})

--- a/src/status_im/ui/screens/desktop/main/chat/styles.cljs
+++ b/src/status_im/ui/screens/desktop/main/chat/styles.cljs
@@ -60,26 +60,22 @@
    :justify-content :center})
 
 (def photo-style
-  {:borderRadius 20
+  {:border-radius 20
    :width        40
    :height       40
    :margin-right 8})
 
 (def photo-style-toolbar
-  {:borderRadius 32
-   :width        32
-   :height       32
-   :margin-right 8})
+  {:border-radius 32
+   :width         32
+   :height        32
+   :margin-right  8})
 
 (defn topic-image [color]
-  {:background-color color
-   :align-items      :center
-   :justify-content  :center
-   ;; todo, combine these with photo-style
-   :width            32
-   :height           32
-   :border-radius    32
-   :margin-right     8})
+  (merge photo-style-toolbar
+         {:background-color color
+          :align-items      :center
+          :justify-content  :center}))
 
 (def topic-text
   {:font-size 18

--- a/src/status_im/ui/screens/desktop/main/chat/styles.cljs
+++ b/src/status_im/ui/screens/desktop/main/chat/styles.cljs
@@ -56,7 +56,7 @@
    :background-color colors/gray-lighter})
 
 (def img-container
-  {:height          78
+  {:height          56
    :justify-content :center})
 
 (def photo-style
@@ -71,8 +71,22 @@
    :height       32
    :margin-right 8})
 
+(defn topic-image [color]
+  {:background-color color
+   :align-items      :center
+   :justify-content  :center
+   ;; todo, combine these with photo-style
+   :width            32
+   :height           32
+   :border-radius    32
+   :margin-right     8})
+
+(def topic-text
+  {:font-size 18
+   :color     colors/white})
+
 (def toolbar-chat-view
-  {:padding         11
+  {:margin-left     11
    :justify-content :center})
 
 (def toolbar-chat-name

--- a/src/status_im/ui/screens/desktop/main/chat/styles.cljs
+++ b/src/status_im/ui/screens/desktop/main/chat/styles.cljs
@@ -55,10 +55,20 @@
   {:flex             1
    :background-color colors/gray-lighter})
 
+(def img-container
+  {:height          78
+   :justify-content :center})
+
 (def photo-style
   {:borderRadius 20
    :width        40
    :height       40
+   :margin-right 8})
+
+(def photo-style-toolbar
+  {:borderRadius 32
+   :width        32
+   :height       32
    :margin-right 8})
 
 (def toolbar-chat-view

--- a/src/status_im/ui/screens/desktop/main/chat/views.cljs
+++ b/src/status_im/ui/screens/desktop/main/chat/views.cljs
@@ -14,11 +14,12 @@
             [status-im.ui.components.colors :as colors]
             [status-im.chat.views.message.datemark :as message.datemark]
             [status-im.ui.screens.desktop.main.chat.styles :as styles]
+            [status-im.ui.screens.desktop.main.tabs.home.styles :as home.styles]
             [status-im.i18n :as i18n]))
 
 (views/defview toolbar-chat-view []
-  (views/letsubs [{:keys [chat-id name public-key public? group-chat]} [:get-current-chat]
-                  {:keys [pending? whisper-identity photo-path]}       [:get-current-chat-contact]]
+  (views/letsubs [{:keys [chat-id name public-key public? group-chat color]} [:get-current-chat]
+                  {:keys [pending? whisper-identity photo-path]}             [:get-current-chat-contact]]
     (let [chat-name (str
                      (if public? "#" "")
                      (if (string/blank? name)
@@ -28,20 +29,13 @@
       [react/view {:style styles/toolbar-chat-view}
        [react/view {:style {:flex-direction :row
                             :align-items :center}}
-
-        [react/image {:style styles/photo-style-toolbar
-                        :source {:uri photo-path}}]
-        
-        #_
         [react/view {:style styles/img-container}
          (if public?
-          #_[react/view {:style (styles/topic-image color)}
-           [react/text {:style styles/topic-text}
-            (string/capitalize (second name))]]
-          
-          [react/image {:style styles/photo-style
+          [react/view {:style (home.styles/topic-image color)}
+           [react/text {:style home.styles/topic-text}
+            (string/capitalize (first name))]]
+          [react/image {:style styles/photo-style-toolbar
                         :source {:uri photo-path}}])]
-        
         [react/view
          (when public?
            [icons/icon :icons/public-chat])
@@ -49,18 +43,12 @@
            [icons/icon :icons/group-chat])
          [react/text {:style styles/toolbar-chat-name}
           chat-name]
-
          (when pending?
          [react/touchable-highlight
           {:on-press #(re-frame/dispatch [:add-contact whisper-identity])}
           [react/view {:style styles/add-contact}
            [react/text {:style styles/add-contact-text}
-            (i18n/label :t/add-to-contacts)]]])
-
-         ]
-
-        ]
-       ])))
+            (i18n/label :t/add-to-contacts)]]])]]])))
 
 (views/defview message-author-name [{:keys [outgoing from] :as message}]
   (views/letsubs [current-account [:get-current-account]

--- a/src/status_im/ui/screens/desktop/main/chat/views.cljs
+++ b/src/status_im/ui/screens/desktop/main/chat/views.cljs
@@ -18,7 +18,7 @@
 
 (views/defview toolbar-chat-view []
   (views/letsubs [{:keys [chat-id name public-key public? group-chat]} [:get-current-chat]
-                  {:keys [pending?]}                                   [:get-current-chat-contact]]
+                  {:keys [pending? whisper-identity]}                  [:get-current-chat-contact]]
     (let [chat-name (str
                      (if public? "#" "")
                      (if (string/blank? name)
@@ -35,7 +35,7 @@
          chat-name]]
        (when pending?
          [react/touchable-highlight
-          {:on-press #(re-frame/dispatch [:add-pending-contact chat-id])}
+          {:on-press #(re-frame/dispatch [:add-contact whisper-identity])}
           [react/view {:style styles/add-contact}                                      ;style/add-contact
            [react/text {:style styles/add-contact-text}
             (i18n/label :t/add-to-contacts)]]])])))

--- a/src/status_im/ui/screens/desktop/main/chat/views.cljs
+++ b/src/status_im/ui/screens/desktop/main/chat/views.cljs
@@ -18,7 +18,7 @@
 
 (views/defview toolbar-chat-view []
   (views/letsubs [{:keys [chat-id name public-key public? group-chat]} [:get-current-chat]
-                  {:keys [pending? whisper-identity]}                  [:get-current-chat-contact]]
+                  {:keys [pending? whisper-identity photo-path]}       [:get-current-chat-contact]]
     (let [chat-name (str
                      (if public? "#" "")
                      (if (string/blank? name)
@@ -26,19 +26,41 @@
                        (or name
                            (i18n/label :t/chat-name))))]
       [react/view {:style styles/toolbar-chat-view}
-       [react/view {:style {:flex-direction :row}}
-        (when public?
-          [icons/icon :icons/public-chat])
-        (when (and group-chat (not public?))
-          [icons/icon :icons/group-chat])
-        [react/text {:style styles/toolbar-chat-name}
-         chat-name]]
-       (when pending?
+       [react/view {:style {:flex-direction :row
+                            :align-items :center}}
+
+        [react/image {:style styles/photo-style-toolbar
+                        :source {:uri photo-path}}]
+        
+        #_
+        [react/view {:style styles/img-container}
+         (if public?
+          #_[react/view {:style (styles/topic-image color)}
+           [react/text {:style styles/topic-text}
+            (string/capitalize (second name))]]
+          
+          [react/image {:style styles/photo-style
+                        :source {:uri photo-path}}])]
+        
+        [react/view
+         (when public?
+           [icons/icon :icons/public-chat])
+         (when (and group-chat (not public?))
+           [icons/icon :icons/group-chat])
+         [react/text {:style styles/toolbar-chat-name}
+          chat-name]
+
+         (when pending?
          [react/touchable-highlight
           {:on-press #(re-frame/dispatch [:add-contact whisper-identity])}
-          [react/view {:style styles/add-contact}                                      ;style/add-contact
+          [react/view {:style styles/add-contact}
            [react/text {:style styles/add-contact-text}
-            (i18n/label :t/add-to-contacts)]]])])))
+            (i18n/label :t/add-to-contacts)]]])
+
+         ]
+
+        ]
+       ])))
 
 (views/defview message-author-name [{:keys [outgoing from] :as message}]
   (views/letsubs [current-account [:get-current-account]

--- a/src/status_im/ui/screens/desktop/main/chat/views.cljs
+++ b/src/status_im/ui/screens/desktop/main/chat/views.cljs
@@ -36,8 +36,6 @@
           [react/image {:style styles/photo-style-toolbar
                         :source {:uri photo-path}}])]
         [react/view
-         (when public?
-           [icons/icon :icons/public-chat])
          (when (and group-chat (not public?))
            [icons/icon :icons/group-chat])
          [react/text {:style styles/toolbar-chat-name}

--- a/src/status_im/ui/screens/desktop/main/chat/views.cljs
+++ b/src/status_im/ui/screens/desktop/main/chat/views.cljs
@@ -14,7 +14,6 @@
             [status-im.ui.components.colors :as colors]
             [status-im.chat.views.message.datemark :as message.datemark]
             [status-im.ui.screens.desktop.main.chat.styles :as styles]
-            [status-im.ui.screens.desktop.main.tabs.home.styles :as home.styles]
             [status-im.i18n :as i18n]))
 
 (views/defview toolbar-chat-view []
@@ -31,8 +30,8 @@
                             :align-items :center}}
         [react/view {:style styles/img-container}
          (if public?
-          [react/view {:style (home.styles/topic-image color)}
-           [react/text {:style home.styles/topic-text}
+          [react/view {:style (styles/topic-image color)}
+           [react/text {:style styles/topic-text}
             (string/capitalize (first name))]]
           [react/image {:style styles/photo-style-toolbar
                         :source {:uri photo-path}}])]


### PR DESCRIPTION
Fixes: #4276 

This issue had lingered for a while before we merged the latest `develop` into `desktop`.

This PR updates the desktop version to use the most recent handler used by the mobile app. 

Testing instructions: 
1. message a desktop user by initiating the chat from mobile. 
2. On desktop, click "Add to contacts" in the chat tab. 
3. Verify that the :pending? flag is set to false and that this is the case upon app restart. 
4.  the "add to contacts" option should disappear on click. 