### PR TITLE
Disable auto backup on IOS and android

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -25,7 +25,8 @@
     <uses-permission android:name="android.permission.READ_PHONE_STATE" tools:node="remove"/>
 
     <application
-            android:allowBackup="true"
+            tools:replace="android:allowBackup"
+            android:allowBackup="false"
             android:label="@string/app_name"
             android:icon="@mipmap/ic_launcher"
             android:theme="@style/AppTheme"

--- a/src/status_im/ui/screens/events.cljs
+++ b/src/status_im/ui/screens/events.cljs
@@ -143,13 +143,11 @@
 (re-frame/reg-fx
  ::init-store
  (fn [encryption-key]
-   (try
-     (do
-       (data-store/init encryption-key)
-       (re-frame/dispatch [:after-decryption]))
-     (catch js/Error error
-       (log/warn "Could not decrypt database" error)
-       (re-frame/dispatch [:initialize-app encryption-key :decryption-failed])))))
+   (.. (data-store/init encryption-key)
+       (then #(re-frame/dispatch [:after-decryption]))
+       (catch (fn [error]
+                (log/warn "Could not decrypt database" error)
+                (re-frame/dispatch [:initialize-app encryption-key :decryption-failed]))))))
 
 (re-frame/reg-fx
  :initialize-geth-fx

--- a/src/status_im/utils/fs.cljs
+++ b/src/status_im/utils/fs.cljs
@@ -1,10 +1,8 @@
 (ns status-im.utils.fs
   (:require [status-im.react-native.js-dependencies :as rn-dependencies]))
 
-(defn move-file [src dst handler]
-  (-> (.moveFile rn-dependencies/fs src dst)
-      (.then #(handler nil %))
-      (.catch #(handler % nil))))
+(defn move-file [src dst]
+  (.moveFile rn-dependencies/fs src dst))
 
 (defn read-file [path encoding on-read on-error]
   (-> (.readFile rn-dependencies/fs path encoding)
@@ -13,3 +11,9 @@
 
 (defn read-dir [path]
   (.readDir rn-dependencies/fs path))
+
+(defn mkdir [path]
+  (.mkdir rn-dependencies/fs path))
+
+(defn unlink [path]
+  (.unlink rn-dependencies/fs path))

--- a/test/cljs/status_im/react_native/js_dependencies.cljs
+++ b/test/cljs/status_im/react_native/js_dependencies.cljs
@@ -24,6 +24,7 @@
        :DeviceEventEmitter #js {:addListener (fn [])}
        :Dimensions         #js {:get  (fn [])}})
 (def realm                  #js {:schemaVersion (fn [])
+                                 :defaultPath   "/tmp/realm"
                                  :close         (fn [])})
 (def vector-icons           #js {:default #js {}})
 (def webview-bridge         #js {:default #js {}})

--- a/test/cljs/status_im/test/data_store/realm/core.cljs
+++ b/test/cljs/status_im/test/data_store/realm/core.cljs
@@ -1,6 +1,7 @@
 (ns status-im.test.data-store.realm.core
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [status-im.utils.utils :as utils]
+            [clojure.string :as string]
             [status-im.data-store.realm.core :as core]))
 
 (def migrated-realm? (atom nil))
@@ -8,6 +9,9 @@
 (defn fixtures [f]
   (reset! migrated-realm? nil)
   (f))
+
+(def valid-account-path
+  (str "/some/" (string/join (repeat 40 "a"))))
 
 (use-fixtures :each fixtures)
 
@@ -23,6 +27,33 @@
         (core/migrate-realm "test-filename" [] "encryption-key")
         (testing "it migrates the db"
           (is @migrated-realm?))))))
+
+(deftest is-account-file-test
+  (testing "not an account file"
+    (is (not (core/is-account-file? "not-one")))
+    (is (not (core/is-account-file? "000000000000000009212102"))))
+  (testing "an account file"
+    (is (core/is-account-file? valid-account-path))))
+
+(deftest is-realm-file-test
+  (testing "not a realm file"
+    (is (not (core/is-realm-file? "not-one")))
+    (is (not (core/is-realm-file? "000000000000000009212102"))))
+  (testing "realm files"
+    (is (core/is-realm-file? "/some/new-account"))
+    (is (core/is-realm-file? "/some/new-account.lock"))
+    (is (core/is-realm-file? "/some/new-account.management"))
+    (is (core/is-realm-file? "/some/new-account.note"))
+    (is (core/is-realm-file? "/some/default.realm"))
+    (is (core/is-realm-file? valid-account-path))))
+
+(deftest realm-management-file-test
+  (testing "not a management file"
+    (is (not (core/realm-management-file? "new-account"))))
+  (testing "management file"
+    (is (core/realm-management-file? "anything.management"))
+    (is (core/realm-management-file? "anything.lock"))
+    (is (core/realm-management-file? "anything.note"))))
 
 (deftest serialization
   (is (nil? (core/deserialize "")))


### PR DESCRIPTION
fixes #5127 

### Summary:

Move all the realm files from:

`files/` -> `no_backup` on android
`Documents/` -> `Library/` on IOS 

As those directories are not backed up by default.

It also changes the structure of the filesystem for easier management:

`realm/default.realm`
`realm/accounts/{sha3-of-address}`

It takes the `sha3` of the address so that we don't show which addresses the user has on the device in case someone gets access to the filesystem.


### Testing notes:
Upgrade from previous versions, the change should be transparent to the user.
Newly installed devices.
Tested on android simulator/real device, ios only simulator.

### Steps to test:

A bit difficult to test on android as you can't see what's being backed up. If you have access to the filesystem you can see that files that before were under `files` are not under `no_backup` using the hierarchy described above.
Similar for IOS (not sure if you can inspect icloud drive)


status: ready