### PR TITLE
Handle hyperlinks in messages

### DIFF
--- a/src/status_im/ui/components/list_selection.cljs
+++ b/src/status_im/ui/components/list_selection.cljs
@@ -1,6 +1,7 @@
 (ns status-im.ui.components.list-selection
   (:require [re-frame.core :as re-frame]
             [status-im.i18n :as i18n]
+            [taoensso.timbre :as log]
             [status-im.ui.components.action-sheet :as action-sheet]
             [status-im.ui.components.dialog :as dialog]
             [status-im.ui.components.react :as react]
@@ -31,12 +32,16 @@
          :cancel-text (i18n/label :t/message-options-cancel)}))
 
 (defn browse [link]
-  (show {:title       (i18n/label :t/browsing-title)
-         :options     [{:label  (i18n/label :t/browsing-open-in-status)
-                        :action #(re-frame/dispatch [:browser.ui/open-in-status-option-selected link])}
-                       {:label  (i18n/label :t/browsing-open-in-web-browser)
-                        :action #(.openURL react/linking (http/normalize-url link))}]
-         :cancel-text (i18n/label :t/browsing-cancel)}))
+  (if platform/desktop?
+    (do
+      (log/debug "### open-url " link)
+      (.openURL react/linking (http/normalize-url link)))
+    (show {:title       (i18n/label :t/browsing-title)
+           :options     [{:label  (i18n/label :t/browsing-open-in-status)
+                          :action #(re-frame/dispatch [:browser.ui/open-in-status-option-selected link])}
+                         {:label  (i18n/label :t/browsing-open-in-web-browser)
+                          :action #(.openURL react/linking (http/normalize-url link))}]
+           :cancel-text (i18n/label :t/browsing-cancel)})))
 
 (defn browse-dapp [link]
   (show {:title       (i18n/label :t/browsing-title)

--- a/src/status_im/ui/screens/chat/message/message.cljs
+++ b/src/status_im/ui/screens/chat/message/message.cljs
@@ -105,14 +105,14 @@
                   (fn [text-seq]
                     (map (fn [text] {:text text :url? false}) text-seq))))
 
-(defn- autolink [string event-on-press]
+(defn- autolink [string event-on-press style]
   (->> (parse-url string)
        (map-indexed (fn [idx {:keys [text url?]}]
                       (if url?
                         (let [[url _ _ _ text] (re-matches #"(?i)^((\w+://)?(www\d{0,3}[.])?)?(.*)$" text)]
                           [react/text
                            {:key      idx
-                            :style    {:color colors/blue}
+                            :style    (or style {:color colors/blue})
                             :on-press #(re-frame/dispatch [event-on-press url])}
                            url])
                         text)))
@@ -128,7 +128,7 @@
        replacements))
 
 ;; todo rewrite this, naive implementation
-(defn- parse-text [string event-on-press]
+(defn- parse-text [string event-on-press style]
   (parse-str-regx string
                   regx-styled
                   (fn [text-seq]
@@ -143,7 +143,7 @@
                     (map-indexed (fn [idx string]
                                    (apply react/text
                                           {:key (str idx "_" string)}
-                                          (autolink string event-on-press)))
+                                          (autolink string event-on-press style)))
                                  text-seq))))
 
 ; We can't use CSS as nested Text element don't accept margins nor padding
@@ -181,7 +181,7 @@
 (defn text-message
   [{:keys [content timestamp-str group-chat outgoing current-public-key] :as message}]
   [message-view message
-   (let [parsed-text (cached-parse-text (:text content) :browser.ui/message-link-pressed)
+   (let [parsed-text (cached-parse-text (:text content) :browser.ui/message-link-pressed nil)
          ref (reagent/atom nil)
          collapsible? (should-collapse? (:text content) group-chat)
          collapsed? (reagent/atom collapsible?)

--- a/src/status_im/ui/screens/desktop/main/chat/styles.cljs
+++ b/src/status_im/ui/screens/desktop/main/chat/styles.cljs
@@ -208,3 +208,7 @@
   {:margin-bottom  4
    :font-size      14
    :color          colors/black})
+
+(def hyperlink
+  (assoc message-text
+         :color colors/blue))

--- a/src/status_im/ui/screens/desktop/main/chat/views.cljs
+++ b/src/status_im/ui/screens/desktop/main/chat/views.cljs
@@ -4,6 +4,7 @@
             [status-im.ui.components.icons.vector-icons :as icons]
             [clojure.string :as string]
             [status-im.ui.screens.chat.styles.message.message :as message.style]
+            [status-im.ui.components.list-selection :as ls]
             [status-im.ui.screens.chat.message.message :as message]
             [status-im.utils.gfycat.core :as gfycat.core]
             [taoensso.timbre :as log]
@@ -97,7 +98,7 @@
     [react/text {:style           (styles/message-text message)
                  :selectable      true
                  :selection-color (if outgoing colors/white colors/hawkes-blue)}
-     text]
+     (message/cached-parse-text text :browser.ui/message-link-pressed styles/hyperlink)]
     [react/text {:style (styles/message-timestamp-placeholder)}
      (time/timestamp->time timestamp)]
     [react/text {:style (styles/message-timestamp)}


### PR DESCRIPTION
Fixes #4275 

Re-use `parse-text` fn to highlight hyperlinks in messages. `parse-text` now also accepts additional nillable style parameter.

Currently `onPress` handler on nested hyperlinks is not firing due to https://github.com/status-im/react-native-desktop/issues/290.