### PR TITLE
Round robin mailserver on failure

### DIFF
--- a/test/cljs/status_im/test/models/mailserver.cljs
+++ b/test/cljs/status_im/test/models/mailserver.cljs
@@ -146,7 +146,6 @@
     (let [cofx {:db {:network "mainnet_rpc"
                      :account/account {:networks {"mainnet_rpc"
                                                   {:config {:NetworkId 1}}}}
-                     :inbox/current-id "a"
                      :inbox/wnodes {:mainnet {"a" {}
                                               "b" {}
                                               "c" {}
@@ -167,10 +166,31 @@
                                :db
                                :inbox/current-id))))))))
       (testing "the user has not set an explicit preference"
-        (testing "it sets a random mailserver"
-          (is (= "d" (-> (model/set-current-mailserver cofx)
-                         :db
-                         :inbox/current-id))))))))
+        (testing "current-id is not set"
+          (testing "it sets a random mailserver"
+            (is (= "d" (-> (model/set-current-mailserver cofx)
+                           :db
+                           :inbox/current-id)))))
+        (testing "current-id is set"
+          (testing "it sets the next mailserver"
+            (is (= "c" (-> (model/set-current-mailserver (assoc-in
+                                                          cofx
+                                                          [:db :inbox/current-id]
+                                                          "b"))
+                           :db
+                           :inbox/current-id)))
+            (is (= "a" (-> (model/set-current-mailserver (assoc-in
+                                                          cofx
+                                                          [:db :inbox/current-id]
+                                                          "d"))
+                           :db
+                           :inbox/current-id)))
+            (is (= "a" (-> (model/set-current-mailserver (assoc-in
+                                                          cofx
+                                                          [:db :inbox/current-id]
+                                                          "non-existing"))
+                           :db
+                           :inbox/current-id)))))))))
 
 (deftest delete-mailserver
   (testing "the user is not connected to the mailserver"


### PR DESCRIPTION
fixes #5130 

### Summary:

When a connection with a mailserver fails, the system will:

1) If no selection was explicitly set, pick the next mailserver and try to connect to it (will move from `a` to `b`). 
2) If a selection was already made, it will show the usual error.

The timeout has also been shortened to 15 seconds instead of 60.
Mailserver is still picked at random on each login, unless explicitly set.
Initially I thought about excluding custom mailservers from the rotation, but settled on not doing that as I can't see a good reason why.

### Testing notes:

You can test using this build:

apk uploaded to https://i.diawi.com/1QqK3M
ipa uploaded to https://i.diawi.com/TDXkin



All the mailservers but `f` are not working, it should eventually settle on `f` and you should be able to receive old messages.

status: ready