### PR TITLE
bug #5155 - fixed the bug where every token is unknown in send command

### DIFF
--- a/src/status_im/chat/events/commands.cljs
+++ b/src/status_im/chat/events/commands.cljs
@@ -15,8 +15,8 @@
 ;; because balances are only fetched for them. Revisit this decision with regard to battery/network consequences
 ;; if we were to update all balances.
 (defn- allowed-assets [chain account]
-  (let [visible-token-symbols (get-in account [:settings :wallet :visible-tokens chain])]
-    (->> (tokens/tokens-for chain)
+  (let [visible-token-symbols (get-in account [:settings :wallet :visible-tokens (keyword chain)])]
+    (->> (tokens/tokens-for (keyword chain))
          (filter #(not (:nft? %)))
          (filter #(contains? visible-token-symbols (:symbol %)))
          (map #(vector (-> % :symbol clojure.core/name)


### PR DESCRIPTION
fixes #5155

### Summary:

Recently format of `chain` was changed from keyword to string, which broke the token validation in `/send` command. This PR amends the issue.

### Steps to test:
- Try sending any token in chat

status: ready 