### PR TITLE
bug #5214 - allows empty recipient only in dapp transactions (for con…

### DIFF
--- a/src/status_im/ui/screens/wallet/send/views.cljs
+++ b/src/status_im/ui/screens/wallet/send/views.cljs
@@ -76,7 +76,7 @@
 (defn- sign-enabled? [amount-error to amount modal?]
   (and
    (nil? amount-error)
-   (or modal? (not (nil? to)) (not= to "")) ;;NOTE(goranjovic) - contract creation will have empty `to`
+   (or modal? (not (empty? to))) ;;NOTE(goranjovic) - contract creation will have empty `to`
    (not (nil? amount))))
 
 ;; "Sign Later" and "Sign Transaction >" buttons


### PR DESCRIPTION
fixes #5214 

### Summary:

Recipient field in Send is supposed to be optional only for dapp transactions. This is to allow contract creation, in which case recipient doesn't exist. This PR fixes an error in validation conditions that allowed it for regular Wallet Send as well.

### Steps to test:
- see #5214
-also try creating a contract from Simple Dapp


status: ready 