### PR TITLE
[#5031] Remove additional # to chat title when it is a public chat

### DIFF
--- a/src/status_im/chat/screen.cljs
+++ b/src/status_im/chat/screen.cljs
@@ -39,7 +39,7 @@
         [react/i18n-text {:style style/add-contact-text :key :add-to-contacts}]]])))
 
 (defn- on-options [chat-id chat-name group-chat? public?]
-  (list-selection/show {:title   (if public? (str "#" chat-name) chat-name)
+  (list-selection/show {:title   chat-name
                         :options (actions/actions group-chat? chat-id public?)}))
 
 (defview chat-toolbar [public?]


### PR DESCRIPTION
Fixes #5031



### Summary:
Fixes the double # in the options dialog for public chats. Just removes the additional # as there is already one in the chat-name. 
Removed the public check as I don't see a need for it unless there still needs to be some other difference between public and private chat in this dialog title.


### Review notes (optional):
<!-- (Specify if something in particular should be looked at, or ignored, during review) -->

### Testing notes (optional):
<!-- (Specify if something specific has to be tested, for example upgrade paths) -->

### Steps to test:
See issue

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->
