### PR TITLE
recover from rebase fail to avoid manual cleanup of git dir

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,13 @@ timeout(90) {
           slackSend color: 'good', message: BRANCH_NAME + '(' + env.CHANGE_BRANCH + ') build started. ' + env.BUILD_URL
 
           checkout scm
-          sh 'git rebase origin/develop'
+
+          try {
+            sh 'git rebase origin/desktop'
+          } catch (e) {
+            sh 'git rebase --abort'
+            throw e
+          }
 
           sh 'rm -rf node_modules'
           sh 'cp .env.jenkins .env'


### PR DESCRIPTION
When `git rebase` fails it leave the git repo in a semi-broken state.
Example:
https://jenkins.status.im/job/status-react/job/pull%20requests/view/change-requests/job/PR-5203/15/console
Then the following build fails:
https://jenkins.status.im/job/status-react/job/pull%20requests/view/change-requests/job/PR-5203/16/console

```
+ git rebase origin/develop

It seems that there is already a rebase-apply directory, and
I wonder if you are in the middle of another rebase.  If that is the
case, please try
	git rebase (--continue | --abort | --skip)
If that is not the case, please
	rm -fr "/Users/jenkins/workspace/react_pull_requests_PR-5203-QBRGMM5YEHOFF2WHZWQBZY46RQR2NIDLIL2LMDE2DQUXCDHLUGDA/.git/rebase-apply"
and run me again.  I am stopping in case you still have something
valuable there.
```

<blockquote><img src="/static/dcd3070e/favicon.ico" width="48" align="right"><div><strong><a href="https://jenkins.status.im/job/status-react/job/pull%20requests/view/change-requests/job/PR-5203/15/console">status-react » pull requests » PR-5203 #15 Console [Jenkins]</a></strong></div></blockquote>
<blockquote><img src="/static/dcd3070e/favicon.ico" width="48" align="right"><div><strong><a href="https://jenkins.status.im/job/status-react/job/pull%20requests/view/change-requests/job/PR-5203/16/console">status-react » pull requests » PR-5203 #16 Console [Jenkins]</a></strong></div></blockquote>