### PR TITLE
bug #4826 - fixed the issue when navigating back from sign message wi…

### DIFF
--- a/src/status_im/ui/screens/views.cljs
+++ b/src/status_im/ui/screens/views.cljs
@@ -120,6 +120,7 @@
                :on-request-close (fn []
                                    (cond
                                      (#{:wallet-send-transaction-modal
+                                        :wallet-sign-message-modal
                                         :wallet-transaction-fee}
                                       modal-view)
                                      (dispatch [:wallet/discard-transaction-navigate-back])


### PR DESCRIPTION
fixes #4826

### Summary:

Navigating back from Sign Message modal screen using android back button should discard the transaction. It already works that way for regular transactions.

### Steps to test:
see #4826 

status: ready 
