### PR TITLE
disable colors for fastlane to keep jenkins logs cleaner

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,7 @@
 env.LANG="en_US.UTF-8"
 env.LANGUAGE="en_US.UTF-8"
 env.LC_ALL="en_US.UTF-8"
+env.FASTLANE_DISABLE_COLORS=1
 
 def installJSDeps() {
     def attempt = 1

--- a/Jenkinsfile.fastlane.clean
+++ b/Jenkinsfile.fastlane.clean
@@ -1,7 +1,7 @@
 env.LANG="en_US.UTF-8"
 env.LANGUAGE="en_US.UTF-8"
 env.LC_ALL="en_US.UTF-8"
-
+env.FASTLANE_DISABLE_COLORS=1
 
 timeout(90) {
     node ('macos'){

--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -4,6 +4,7 @@
 env.LANG="en_US.UTF-8"
 env.LANGUAGE="en_US.UTF-8"
 env.LC_ALL="en_US.UTF-8"
+env.FASTLANE_DISABLE_COLORS=1
 
 def installJSDeps() {
     def attempt = 1

--- a/Jenkinsfile.nightly_fastlane
+++ b/Jenkinsfile.nightly_fastlane
@@ -4,6 +4,7 @@
 env.LANG="en_US.UTF-8"
 env.LANGUAGE="en_US.UTF-8"
 env.LC_ALL="en_US.UTF-8"
+env.FASTLANE_DISABLE_COLORS=1
 
 def installJSDeps() {
     def attempt = 1

--- a/Jenkinsfile.parameters
+++ b/Jenkinsfile.parameters
@@ -1,6 +1,7 @@
 env.LANG="en_US.UTF-8"
 env.LANGUAGE="en_US.UTF-8"
 env.LC_ALL="en_US.UTF-8"
+env.FASTLANE_DISABLE_COLORS=1
 
 def installJSDeps() {
     def attempt = 1

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -4,6 +4,7 @@
 env.LANG="en_US.UTF-8"
 env.LANGUAGE="en_US.UTF-8"
 env.LC_ALL="en_US.UTF-8"
+env.FASTLANE_DISABLE_COLORS=1
 
 def installJSDeps() {
     def attempt = 1

--- a/Jenkinsfile.upload_release_android
+++ b/Jenkinsfile.upload_release_android
@@ -4,6 +4,7 @@
 env.LANG="en_US.UTF-8"
 env.LANGUAGE="en_US.UTF-8"
 env.LC_ALL="en_US.UTF-8"
+env.FASTLANE_DISABLE_COLORS=1
 
 def installJSDeps() {
     def attempt = 1

--- a/Jenkinsfile.upload_release_ios
+++ b/Jenkinsfile.upload_release_ios
@@ -4,6 +4,7 @@
 env.LANG="en_US.UTF-8"
 env.LANGUAGE="en_US.UTF-8"
 env.LC_ALL="en_US.UTF-8"
+env.FASTLANE_DISABLE_COLORS=1
 
 def installJSDeps() {
     def attempt = 1


### PR DESCRIPTION
Currently the logs look like this:
```
[11:54:29]: [32mDriving the lane 'ios nightly' 🚀[0m
[11:54:29]: [32m----------------------------------[0m
[11:54:29]: [32m--- Step: upload_to_testflight ---[0m
[11:54:29]: [32m----------------------------------[0m
```
Which affects readability of logs.
For details see: https://github.com/fastlane/fastlane/issues/316