### PR TITLE
bugs #4724 and #5131 - fixed by adding wallet onboarding for dapp txs

### DIFF
--- a/src/status_im/ui/screens/views.cljs
+++ b/src/status_im/ui/screens/views.cljs
@@ -111,6 +111,7 @@
     :wallet-transaction-sent-modal transaction-sent-modal
     :wallet-sign-message-modal sign-message-modal
     :wallet-transaction-fee wallet.send/transaction-fee
+    :wallet-onboarding-setup-modal wallet.onboarding.setup/modal
     [react/view [react/text (str "Unknown modal view: " modal-view)]]))
 
 (defview main-modal []

--- a/src/status_im/ui/screens/wallet/onboarding/setup/styles.cljs
+++ b/src/status_im/ui/screens/wallet/onboarding/setup/styles.cljs
@@ -41,3 +41,7 @@
 
 (def got-it-button-text
   {:padding-horizontal 0})
+
+(def modal
+  {:flex             1
+   :background-color colors/blue})

--- a/src/status_im/ui/screens/wallet/send/views.cljs
+++ b/src/status_im/ui/screens/wallet/send/views.cljs
@@ -260,22 +260,20 @@
 
 (defview send-transaction []
   (letsubs [transaction [:wallet.send/transaction]
-            symbol      [:wallet.send/symbol]
             advanced?   [:wallet.send/advanced?]
             network     [:get-current-account-network]
             scroll      (atom nil)]
     [send-transaction-panel {:modal? false :transaction transaction :scroll scroll :advanced? advanced?
-                             :symbol symbol :network network}]))
+                             :network network}]))
 
 (defview send-transaction-modal []
   (letsubs [transaction [:wallet.send/unsigned-transaction]
-            symbol      [:wallet.send/symbol]
             advanced?   [:wallet.send/advanced?]
             network     [:get-current-account-network]
             scroll      (atom nil)]
     (if transaction
       [send-transaction-panel {:modal? true :transaction transaction :scroll scroll :advanced? advanced?
-                               symbol  symbol :network network}]
+                               :network network}]
       [react/view wallet.styles/wallet-modal-container
        [react/view components.styles/flex
         [status-bar/status-bar {:type :modal-wallet}]


### PR DESCRIPTION
fixes #4724 
fixes #5131 

### Summary:

Adds Wallet Onboarding redirection for dapp transactions. That also fixes #5131 because it invalidates its conditions.

### Steps to test:
- try sending a dapp transaction for the first time and then go to Wallet
- try onboarding from chat `/send` and directly from Wallet

status: ready 