### PR TITLE
bug #5248 - updated REP contract address to match the re-deployed con…

### DIFF
--- a/src/status_im/utils/ethereum/tokens.cljs
+++ b/src/status_im/utils/ethereum/tokens.cljs
@@ -41,7 +41,7 @@
                     :decimals 8}
                    {:symbol   :REP
                     :name     "Reputation"
-                    :address  "0xe94327d07fc17907b4db788e5adf2ed424addff6"
+                    :address  "0x1985365e9f78359a9B6AD760e32412f4a445E862"
                     :decimals 18}
                    {:symbol   :POWR
                     :name     "PowerLedger"


### PR DESCRIPTION
fixes #5248

### Summary:

The contract for REP tokens was re-deployed. The new version of the contract is at `0x1985365e9f78359a9B6AD760e32412f4a445E862`. 

https://support.binance.com/hc/en-us/articles/360007145411-Notice-Regarding-Updated-Augur-REP-Token-Contract

https://medium.com/@AugurProject/augur-launches-794fa7f88c6a

https://etherscan.io/token/0x1985365e9f78359a9b6ad760e32412f4a445e862

The old contract is marked as `RepTokenContract_Old`: https://etherscan.io/address/0xe94327d07fc17907b4db788e5adf2ed424addff6


### Steps to test:
- On mainnet, try buying, selling and sending REP tokens

status: ready

<blockquote></blockquote>
<blockquote><img src="https://cdn-images-1.medium.com/max/1200/1*BBdoCj_a-JXI1wcBNO43ug.png" width="48" align="right"><div><img src="https://cdn-static-1.medium.com/_/fp/icons/favicon-rebrand-medium.3Y6xpZ-0FSdWDnPM3hSBIA.ico" height="14"> Medium</div><div><strong><a href="https://medium.com/@AugurProject/augur-launches-794fa7f88c6a">Augur Launches – Augur – Medium</a></strong></div><div>The REP migration has been successfully completed. New production REP has been minted to all 56,338 unique accounts that held REP at the…</div></blockquote>
<blockquote><img src="/images/favicon2.ico" width="48" align="right"><div><strong><a href="https://etherscan.io/token/0x1985365e9f78359a9b6ad760e32412f4a445e862">Reputation (REP) Token Tracker</a></strong></div><div>The Ethereum BlockChain Explorer, API and Analytics Platform</div></blockquote>
<blockquote><img src="/images/favicon2.ico" width="48" align="right"><div><strong><a href="https://etherscan.io/address/0xe94327d07fc17907b4db788e5adf2ed424addff6">Ethereum Accounts, Address and Contracts</a></strong></div><div>The Ethereum BlockChain Explorer, API and Analytics Platform</div></blockquote>