### PR TITLE
[Fix #3604] ui, screens, browser, events: deduplicate browser history

### DIFF
--- a/src/status_im/ui/screens/browser/events.cljs
+++ b/src/status_im/ui/screens/browser/events.cljs
@@ -73,10 +73,13 @@
  :open-url-in-browser
  [re-frame/trim-v]
  (fn [cofx [url]]
-   (let [browser {:browser-id    (random/id)
+   (let [normalized-url          (http/normalize-and-decode-url url)
+         browser {:browser-id    (or (http/url-host normalized-url)
+                                     ;; purely as a fallback should url not parse...
+                                     (random/id))
                   :name          (i18n/label :t/browser)
                   :history-index 0
-                  :history       [(http/normalize-and-decode-url url)]}]
+                  :history       [normalized-url]}]
      (model/update-browser-and-navigate cofx browser))))
 
 (handlers/register-handler-fx

--- a/src/status_im/utils/http.cljs
+++ b/src/status_im/utils/http.cljs
@@ -1,7 +1,9 @@
 (ns status-im.utils.http
   (:require [status-im.utils.utils :as utils]
             [status-im.react-native.js-dependencies :as rn-dependencies]
-            [taoensso.timbre :as log])
+            [taoensso.timbre :as log]
+            [goog.Uri :as uri]
+            [clojure.string :as string])
   (:refer-clojure :exclude [get]))
 
 ;; Default HTTP request timeout ms
@@ -64,6 +66,13 @@
   (str (when (and (string? url) (not (re-find #"^[a-zA-Z-_]+:/" url))) "http://") url))
 
 (def normalize-and-decode-url (comp js/decodeURI normalize-url))
+
+(defn url-host [url]
+  (try
+    (when-let [host (.getDomain (goog.Uri. url))]
+      (when-not (string/blank? host)
+        host))
+    (catch :default _ nil)))
 
 (defn parse-payload [o]
   (when o

--- a/test/cljs/status_im/test/utils/http.cljs
+++ b/test/cljs/status_im/test/utils/http.cljs
@@ -38,3 +38,18 @@
   (testing "https://www.etheremon.com/assets/images/mons'><script>\\\\x3Bjavascript:alert(1)</script>origin/025.png"
     (testing "it returns false"
       (is (not (http/url-sanitized? "https://www.etheremon.com/assets/images/mons'><script>\\\\x3Bjavascript:alert(1)</script>origin/025.png"))))))
+
+(deftest url-host-check
+  (testing "Extract host/domain from URL"
+    (testing "Valid URL with endpoint"
+      (is (= "status.im" (http/url-host "https://status.im/testing"))))
+    (testing "Valid URL"
+      (is (= "status.im" (http/url-host "http://status.im"))))
+    (testing "Blank domainlocalhost"
+      (is (nil? (http/url-host "localhost:3000/testing")))))
+  (testing "Return nil for Invalid URL"
+    (testing "Bad scheme"
+      (is (nil? (http/url-host "invalid//status.im/testing"))))
+    (testing "No scheme"
+      (is (nil? (http/url-host "status.im/testing"))))))
+


### PR DESCRIPTION
This PR addresses the original issue of chat list clutter by deduplicating the underlying browser history used to populate the chat list.

Fixes #3604

### Summary:

[comment]: # The user chat list screen showed duplicate elements for repeated browser visits to the same URL. By changing the :browser-id in browser objects to be the URL visited instead of a random key, we arrange for repeated visits to be collected under one history. This parallels the use of Dapp names for Dapp launch history. The browser history structure drives the user chat list screen, so this change has the desired effect of reducing chat list clutter.

### Review notes:
Nothing is done about existing browser history pulled from device storage, so historical browsing data will still be keyed by a random key. In turn, new visits to an historical URL will be recorded as new sites and the chat list will still show duplicates. 

### Testing notes:
This has been tested only on an iOS sim. We first tested with historical browsing history still in place, then erased the virtual device and re-tested.

Note that logic existing prior to this change already de-duplicated *consecutive* visits to the same URL, so to fully exercise the fix we need to alternate with a second URL then return to the first.

### Steps to test:
- Open Status
- Visit a public chat
- Look for a URL, or send a message with a URL, then visit that URL in Status
- Repeat by visiting a second URL
- Return to the chat/browser list and confirm both URLs appear
- Visit the first URL
- Return to the chat/browser list and confirm the URL just visited appears only once.

status: ready 