### PR TITLE
bug #5154 - disabled default password autocapitalize in wallet send

### DIFF
--- a/src/status_im/ui/screens/wallet/send/views.cljs
+++ b/src/status_im/ui/screens/wallet/send/views.cljs
@@ -53,7 +53,8 @@
          :placeholder-text-color components.styles/color-gray4
          :on-change-text         #(re-frame/dispatch [:wallet.send/set-password (security/mask-data %)])
          :style                  styles/password
-         :accessibility-label    :enter-password-input}]
+         :accessibility-label    :enter-password-input
+         :auto-capitalize        :none}]
        (when wrong-password?
          [tooltip/tooltip (i18n/label :t/wrong-password)])]]]))
 


### PR DESCRIPTION
fixes #5154 

### Summary:

Disabled default autocapitalize for password field in Wallet Send

### Steps to test:
see #5154

status: ready 