### PR TITLE
prepare-for-platform.sh script doesn't remove node_modules

### DIFF
--- a/scripts/prepare-for-platform.sh
+++ b/scripts/prepare-for-platform.sh
@@ -23,9 +23,6 @@ if [ $# -eq 0 ]
 fi
 
 
-echo "Removing node_modules"
-rm -rf  node_modules
-
 echo "Creating link: package.json -> ${PLATFORM_FOLDER}/package.json "
 ln -sf  ${PLATFORM_FOLDER}/package.json package.json
 


### PR DESCRIPTION
fixes #...

### Summary:

We don't need to remove `node_modules` from `prepare_for_platform.sh` because npm do this for us every time `package.json` changed.
With this change consequent calls to `make startdev-ios-simulator` doesn't result in constant `node_modules` rewriting.

No testing required because this change covers only cases when app builds couple times in the same directory (dev case). This behavior never occurs on Jenkins so won't affect builds.

### Steps to test:
- Open Status
- ...
- Step 3, etc.

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready
