### PR TITLE
Remove jail from desktop-related code

### DIFF
--- a/modules/react-native-status/desktop/rctstatus.cpp
+++ b/modules/react-native-status/desktop/rctstatus.cpp
@@ -63,35 +63,6 @@ QVariantMap RCTStatus::constantsToExport() {
     return QVariantMap();
 }
 
-void RCTStatus::initJail(QString js, double callbackId) {
-    Q_D(RCTStatus);
-    qDebug() << "call of RCTStatus::initJail with param js:" << " and callback id: " << callbackId;
-
-    InitJail(js.toUtf8().data());
-
-    d->bridge->invokePromiseCallback(callbackId, QVariantList{ "{\"result\":\"\"}" });
-}
-
-
-void RCTStatus::parseJail(QString chatId, QString js, double callbackId) {
-    Q_D(RCTStatus);
-    qDebug() << "call of RCTStatus::parseJail with param chatId: " << chatId << " js:" << " and callback id: " << callbackId;
-
-    const char* result = Parse(chatId.toUtf8().data(), js.toUtf8().data());
-    qDebug() << "RCTStatus::parseJail parseJail result: " << result;
-    d->bridge->invokePromiseCallback(callbackId, QVariantList{result});
-}
-
-
-void RCTStatus::callJail(QString chatId, QString path, QString params, double callbackId) {
-    Q_D(RCTStatus);
-    qDebug() << "call of RCTStatus::callJail with param chatId: " << chatId << " path: " << path << " params: " << params <<  " and callback id: " << callbackId;
-
-    const char* result = Call(chatId.toUtf8().data(), path.toUtf8().data(), params.toUtf8().data());
-    qDebug() << "RCTStatus::callJail callJail result: " << result;
-    d->bridge->invokePromiseCallback(callbackId, QVariantList{result});
-}
-
 void RCTStatus::getDeviceUUID(double callbackId) {
   Q_D(RCTStatus);
   qDebug() << "call of RCTStatus::getDeviceUUID";

--- a/modules/react-native-status/desktop/rctstatus.h
+++ b/modules/react-native-status/desktop/rctstatus.h
@@ -32,9 +32,6 @@ public:
     QList<ModuleMethod*> methodsToExport() override;
     QVariantMap constantsToExport() override;
 
-    Q_INVOKABLE void initJail(QString js, double callbackId);
-    Q_INVOKABLE void parseJail(QString chatId, QString js, double callbackId);
-    Q_INVOKABLE void callJail(QString chatId, QString path, QString params, double callbackId);
     Q_INVOKABLE void startNode(QString configString);
     Q_INVOKABLE void shouldMoveToInternalStorage(double callbackId);
     Q_INVOKABLE void moveToInternalStorage(double callbackId);


### PR DESCRIPTION
This simple change fixes the problem whereby `react-native run-desktop` throws the following error:
```
HEAD is now at 801053a1 Remove jail package (#1106)
status-react/modules/react-native-status/desktop/rctstatus.cpp:70:5: error: use of undeclared identifier 'InitJail'
    InitJail(js.toUtf8().data());
    ^
status-react/modules/react-native-status/desktop/rctstatus.cpp:80:26: error: use of undeclared identifier 'Parse'
    const char* result = Parse(chatId.toUtf8().data(), js.toUtf8().data());
                         ^
status-react/modules/react-native-status/desktop/rctstatus.cpp:90:26: error: use of undeclared identifier 'Call'
    const char* result = Call(chatId.toUtf8().data(), path.toUtf8().data(), params.toUtf8().data());
```

This was prompted by removal of Jail from status-react ([link](https://github.com/status-im/status-react/commit/9b990a8038e1289fd8d4b578a62ef55987d25118)) and status-go ([link](https://github.com/status-im/status-go/commit/801053a17de19df01e803ef1477e1ddc6d9646b0)) repositories.