### PR TITLE
Allow only one wallet transactions sync running

### DIFF
--- a/src/status_im/ui/screens/events.cljs
+++ b/src/status_im/ui/screens/events.cljs
@@ -332,7 +332,7 @@
                          [:update-wallet]
                          [:update-transactions]
                          (when platform/mobile? [:get-fcm-token])
-                         [:sync-wallet-transactions]
+                         [:start-wallet-transactions-sync]
                          [:update-sign-in-time]]
                   (seq events-after) (into events-after))}))
 

--- a/src/status_im/ui/screens/wallet/send/events.cljs
+++ b/src/status_im/ui/screens/wallet/send/events.cljs
@@ -477,6 +477,13 @@
 (handlers/register-handler-fx
  :sync-wallet-transactions
  (fn [cofx _]
-   (handlers-macro/merge-fx cofx
-                            (wallet.transactions/load-missing-chat-transactions)
-                            (wallet.transactions/sync))))
+   (wallet.transactions/sync cofx)))
+
+(handlers/register-handler-fx
+ :start-wallet-transactions-sync
+ (fn [cofx _]
+   (when-not (get-in cofx [:db :wallet :transactions-sync-started?])
+     (handlers-macro/merge-fx cofx
+                              (wallet.transactions/load-missing-chat-transactions)
+                              (wallet.transactions/sync)
+                              (wallet.transactions/set-sync-started)))))

--- a/src/status_im/wallet/transactions.cljs
+++ b/src/status_im/wallet/transactions.cljs
@@ -88,6 +88,9 @@
         (< sync-interval-ms
            (- (time/timestamp) last-updated-at)))))
 
+(defn set-sync-started [{:keys [db]}]
+  {:db (assoc-in db [:wallet :transactions-sync-started?] true)})
+
 ; Fetch updated data for any unconfirmed transactions or incoming chat transactions missing in wallet
 ; and schedule new recurring sync request
 (defn sync [{:keys [db] :as cofx}]


### PR DESCRIPTION
### Summary:

Periodic wallet transactions sync was added in https://github.com/status-im/status-react/pull/5221 which is started each time user signs that lead to multiple syncs running in parallel.

Add flag to control that only one sync is running.

status: ready
