### PR TITLE
move PR pipeline to macos_pr nodes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@ def installJSDeps() {
 }
 
 timeout(90) {
-    node ('macos') {
+    node ('macos_pr') {
       def apkUrl = ''
       def ipaUrl = ''
       def testPassed = true


### PR DESCRIPTION
As long as i'm not 100% that pipelines related to release will work on `macos2` and `macos3`, `macos_pr` label was created for nodes which can build PRs (all `macosN` nodes).

status: ready
