### PR TITLE
[#5226] Migrate clj scripts to latest clj-rn

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,9 @@ prepare-ios: prepare ##@prepare Install iOS specific dependencies
 	mvn -f modules/react-native-status/ios/RCTStatus dependency:unpack
 	cd ios && pod install && cd ..
 
+prepare-android: prepare ##@prepare Install Android specific dependencies
+	cd android; ./gradlew react-native-android:installArchives
+
 #----------------
 # Release builds
 #----------------
@@ -71,26 +74,25 @@ full-prod-build: ##@build build prod for both Android and iOS
 # REPL
 # -------------
 
-repl-ios-real: ##@repl Start REPL for iOS real device
-	clj -R:repl build.clj figwheel --platform ios --ios-device real
+watch-ios-real: ##@watch Start development for iOS real device
+	clj -R:dev build.clj watch --platform ios --ios-device real
 
-repl-ios-simulator: ##@repl Start REPL for iOS simulator
-	clj -R:repl build.clj figwheel --platform ios --ios-device simulator
+watch-ios-simulator: ##@watch Start development for iOS simulator
+	clj -R:dev build.clj watch --platform ios --ios-device simulator
 
-repl-android-real: ##@repl Start REPL for Android real device
-	clj -R:repl build.clj figwheel --platform android --android-device real
+watch-android-real: ##@watch Start development for Android real device
+	clj -R:dev build.clj watch --platform android --android-device real
 
-repl-android-avd: ##@repl Start REPL for Android AVD
-	clj -R:repl build.clj figwheel --platform android --android-device avd
+watch-android-avd: ##@watch Start development for Android AVD
+	clj -R:dev build.clj watch --platform android --android-device avd
 
-repl-android-genymotion: ##@repl Start REPL for Android Genymotion
-	clj -R:repl build.clj figwheel --platform android --android-device genymotion
+watch-android-genymotion: ##@watch Start development for Android Genymotion
+	clj -R:dev build.clj watch --platform android --android-device genymotion
 
 #--------------
 # Run
 # -------------
 run-android: ##@run Run Android build
-	cd android; ./gradlew react-native-android:installArchives
 	react-native run-android --appIdSuffix debug
 
 SIMULATOR=
@@ -140,8 +142,5 @@ android-ports-real: ##@other Add reverse proxy to Android Device/Simulator
 startdev-%:
 	$(eval SYSTEM := $(word 2, $(subst -, , $@)))
 	$(eval DEVICE := $(word 3, $(subst -, , $@)))
-	case "$(SYSTEM)" in \
-	  "android") ${MAKE} prepare;; \
-	  "ios")      ${MAKE} prepare-ios;; \
-	esac
-	${MAKE} repl-$(SYSTEM)-$(DEVICE)
+	${MAKE} prepare-${SYSTEM}
+	${MAKE} watch-$(SYSTEM)-$(DEVICE)

--- a/build.clj
+++ b/build.clj
@@ -81,10 +81,10 @@
                       "[env] (required): Pre-defined build environment. Allowed values: \"dev\", \"prod\", \"test\""
                       "[build-id] (optional): Build ID. When omitted, this task will compile all builds from the specified [env]."
                       "[type] (optional): Build type - value could be \"once\" or \"watch\". Default: \"once\"."]}
-   :figwheel {:desc  "Start figwheel + CLJS REPL / nREPL"
-              :usage ["Usage: clj -R:repl build.clj figwheel [options]"
-                      ""
-                      "[-h|--help] to see all available options"]}
+   :watch {:desc  "Start development"
+           :usage ["Usage: clj -R:dev build.clj watch [options]"
+                   ""
+                   "[-h|--help] to see all available options"]}
    :test     {:desc  "Run tests"
               :usage ["Usage: clj -R:test build.clj test [build-id]"
                       ""
@@ -202,86 +202,27 @@
     (compile-cljs :test build-id)
     (doo/run-script :node (->> build-id (get-cljsbuild-config :test) :compiler))))
 
-;;; Figwheeling task
+;;; :watch task
 
-(def figwheel-cli-opts
-  [["-p" "--platform BUILD-IDS" "CLJS Build IDs for platforms <android|ios>"
-    :id       :build-ids
-    :default  [:android]
-    :parse-fn #(->> (.split % ",")
-                    (map (comp keyword str/lower-case str/trim))
-                    vec)
-    :validate [(fn [build-ids] (every? #(some? (#{:android :ios} %)) build-ids)) "Allowed \"android\", and/or \"ios\""]]
-   ["-n" "--nrepl-port PORT" "nREPL Port"
-    :id       :port
-    :parse-fn #(if (string? %) (Integer/parseInt %) %)
-    :validate [#(or (true? %) (< 0 % 0x10000)) "Must be a number between 0 and 65536"]]
-   ["-a" "--android-device TYPE" "Android Device Type <avd|genymotion|real>"
-    :id       :android-device
-    :parse-fn #(keyword (str/lower-case %))
-    :validate [#(some? (#{:avd :genymotion :real} %)) "Must be \"avd\", \"genymotion\", or \"real\""]]
-   ["-i" "--ios-device TYPE" "iOS Device Type <simulator|real>"
-    :id       :ios-device
-    :parse-fn #(keyword (str/lower-case %))
-    :validate [#(some? (#{:simulator :real} %)) "Must be \"simulator\", or \"real\""]]
-   ["-h" "--help"]])
+(defn hawk-handler
+  [ctx e]
+  (let [path "src/status_im/utils/js_resources.cljs"
+        js-resourced (slurp path)]
+    (spit path (str js-resourced " ;;"))
+    (spit path js-resourced))
+  ctx)
 
-(defn print-and-exit [msg]
-  (println msg)
-  (System/exit 1))
-
-(defn parse-figwheel-cli-opts [args]
-  (with-namespaces [[clojure.tools.cli :as cli]]
-    (let [{:keys [options errors summary]} (cli/parse-opts args figwheel-cli-opts)]
-      (cond
-        (:help options)     (print-and-exit summary)
-        (not (nil? errors)) (print-and-exit errors)
-        :else               options))))
-
-(defmethod task "figwheel" [[_ & args]]
-  (with-namespaces [[figwheel-sidecar.repl-api :as ra]
-                    [hawk.core :as hawk]
+(defmethod task "watch" [[_ & args]]
+  (with-namespaces [[hawk.core :as hawk]
                     [re-frisk-sidecar.core :as rfs]
+                    [figwheel-sidecar.repl-api :as ra]
                     [clj-rn.core :as clj-rn]
-                    [clj-rn.main :refer [get-main-config] :rename {get-main-config get-cljrn-config}]]
-    (let [{:keys [build-ids
-                  port
-                  android-device
-                  ios-device]} (parse-figwheel-cli-opts args)
-          hosts-map            {:android (clj-rn/resolve-dev-host :android android-device)
-                                :ios     (clj-rn/resolve-dev-host :ios ios-device)}]
-      (clj-rn/enable-source-maps)
-      (clj-rn/write-env-dev hosts-map)
-      (doseq [build-id build-ids
-              :let     [host-ip                 (get hosts-map build-id)
-                        platform-name           (if (= build-id :ios) "iOS" "Android")
-                        {:keys [js-modules
-                                name
-                                resource-dirs]} (get-cljrn-config)]]
-        (clj-rn/rebuild-index-js build-id {:app-name      name
-                                           :host-ip       host-ip
-                                           :js-modules    js-modules
-                                           :resource-dirs resource-dirs})
-        (when (= build-id :ios)
-          (clj-rn/update-ios-rct-web-socket-executor host-ip)
-          (println-colorized "Host in RCTWebSocketExecutor.m was updated" green-color))
-        (println-colorized (format "Dev server host for %s: %s" platform-name host-ip) green-color))
-      (ra/start-figwheel!
-       {:figwheel-options (cond-> {:builds-to-start build-ids}
-                            port (merge {:nrepl-port       port
-                                         :nrepl-middleware ["cider.nrepl/cider-middleware"
-                                                            "refactor-nrepl.middleware/wrap-refactor"
-                                                            "cemerick.piggieback/wrap-cljs-repl"]}))
-        :all-builds       (into [] (for [[build-id {:keys [source-paths compiler warning-handlers]}]
-                                         (get-cljsbuild-config :dev)]
-                                     {:id           build-id
-                                      :source-paths (conj source-paths "env/dev")
-                                      :compiler     compiler
-                                      :figwheel     true}))})
+                    [clj-rn.main :as main]]
+    (let [options (main/parse-cli-options args main/watch-task-options)]
+      (clj-rn/watch (assoc options :start-cljs-repl false))
       (rfs/-main)
-      (if-not port
-        (ra/cljs-repl)
-        (spit ".nrepl-port" port)))))
+      (hawk/watch! [{:paths ["resources"] :handler hawk-handler}])
+      (when (:start-cljs-repl options) (ra/cljs-repl)))))
 
 ;;; Help
 

--- a/clj-rn.conf.edn
+++ b/clj-rn.conf.edn
@@ -1,5 +1,8 @@
 {:name "StatusIm"
 
+ :run-options {:android {"appIdSuffix" "debug"}}
+
+ :figwheel-bridge "figwheel-bridge.js"
  ;; JS modules
  :js-modules ["realm"
               "react-native-i18n"
@@ -37,4 +40,35 @@
               "react-native-testfairy"]
 
  ;; Resoures
- :resource-dirs ["resources/images"]}
+ :resource-dirs ["resources/images"]
+
+ :figwheel-options {:nrepl-port 7888
+                    :nrepl-middleware ["cider.nrepl/cider-middleware"
+                                       "refactor-nrepl.middleware/wrap-refactor"
+                                       "cemerick.piggieback/wrap-cljs-repl"]}
+
+ :builds [{:id           :desktop
+           :source-paths ["react-native/src" "src" "env/dev"]
+           :compiler     {:output-to     "target/ios/desktop.js"
+                          :main          "env.desktop.main"
+                          :output-dir    "target/desktop"
+                          :npm-deps      false
+                          :optimizations :none}
+           :figwheel     true}
+          {:id           :ios
+           :source-paths ["react-native/src" "src" "env/dev"]
+           :compiler     {:output-to     "target/ios/app.js"
+                          :main          "env.ios.main"
+                          :output-dir    "target/ios"
+                          :npm-deps      false
+                          :optimizations :none}
+           :figwheel     true}
+          {:id               :android
+           :source-paths     ["react-native/src" "src" "env/dev"]
+           :compiler         {:output-to     "target/android/app.js"
+                              :main          "env.android.main"
+                              :output-dir    "target/android"
+                              :npm-deps      false
+                              :optimizations :none}
+           :warning-handlers [status-im.utils.build/warning-handler]
+           :figwheel         true}]}

--- a/deps.edn
+++ b/deps.edn
@@ -13,22 +13,23 @@
          com.cognitect/transit-cljs  {:mvn/version "0.8.248"}}
 
  :aliases
- {:repl {:extra-deps
-         {;; Figwheel ClojureScript REPL
-          com.cemerick/piggieback {:mvn/version "0.2.2"
-                                   :exclusions  [com.google.javascript/closure-compiler]}
-          figwheel-sidecar        {:mvn/version "0.5.16-SNAPSHOT"
-                                   :exclusions  [com.google.javascript/closure-compiler]}
-          re-frisk-remote         {:mvn/version "0.5.5"}
-          re-frisk-sidecar        {:mvn/version "0.5.7"}
-          hawk                    {:mvn/version "0.2.11"}
-          day8.re-frame/tracing   {:mvn/version "0.5.0"}
+ {:dev {:extra-deps
+        {clj-rn {:git/url "https://github.com/status-im/clj-rn"
+                 :sha "d9b835701232cb1744a670e6dd21325712a43789"}
 
-          ;; CIDER compatible nREPL
-          cider/cider-nrepl       {:mvn/version "0.16.0"}
-          org.clojure/tools.nrepl {:mvn/version "0.2.13"}
-          refactor-nrepl          {:mvn/version "2.3.1"}
-          org.clojure/tools.cli   {:mvn/version "0.3.7"}
-          clj-rn                  {:git/url "https://github.com/status-im/clj-rn" :sha "e3fe471c601b2fa890f8692757aab74adf96fa28"}}}
+         ;; Figwheel ClojureScript REPL
+         com.cemerick/piggieback {:mvn/version "0.2.2"
+                                  :exclusions  [com.google.javascript/closure-compiler]}
+         figwheel-sidecar        {:mvn/version "0.5.16"
+                                  :exclusions  [com.google.javascript/closure-compiler]}
+         re-frisk-remote         {:mvn/version "0.5.5"}
+         re-frisk-sidecar        {:mvn/version "0.5.7"}
+         hawk                    {:mvn/version "0.2.11"}
+         day8.re-frame/tracing   {:mvn/version "0.5.0"}
+
+         ;; CIDER compatible nREPL
+         cider/cider-nrepl       {:mvn/version "0.16.0"}
+         org.clojure/tools.nrepl {:mvn/version "0.2.13"}
+         refactor-nrepl          {:mvn/version "2.3.1"}}}
   :test {:extra-deps {day8.re-frame/test {:mvn/version "0.1.5"}
                       doo                {:mvn/version "0.1.9"}}}}}


### PR DESCRIPTION
fixes #5226

### Summary:
Use `clj-rn` for development.

### Steps to test:
- Run `make stardev-ios-simulator` or similar.

status: ready