### PR TITLE
Update status-go to 0.10.0

### DIFF
--- a/modules/react-native-status/android/build.gradle
+++ b/modules/react-native-status/android/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     implementation 'com.instabug.library:instabug:3+'
     implementation 'status-im:function:0.0.1'
 
-    String statusGoVersion = 'develop-g03bf6e37'
+    String statusGoVersion = 'develop-ga6d69eba'
     final String statusGoGroup = 'status-im', statusGoName = 'status-go'
 
     // Check if the local status-go jar exists, and compile against that if it does

--- a/modules/react-native-status/ios/RCTStatus/pom.xml
+++ b/modules/react-native-status/ios/RCTStatus/pom.xml
@@ -25,7 +25,7 @@
                         <artifactItem>
                             <groupId>status-im</groupId>
                             <artifactId>status-go-ios-simulator</artifactId>
-                            <version>develop-g03bf6e37</version>
+                            <version>develop-ga6d69eba</version>
                             <type>zip</type>
                             <overWrite>true</overWrite>
                             <outputDirectory>./</outputDirectory>

--- a/src/status_im/protocol/handlers.cljs
+++ b/src/status_im/protocol/handlers.cljs
@@ -17,7 +17,7 @@
 (re-frame/reg-cofx
  ::get-web3
  (fn [coeffects _]
-   (let [web3 (web3-provider/make-web3)
+   (let [web3 (web3-provider/make-internal-web3)
          address (get-in coeffects [:db :account/account :address])]
      (set! (.-defaultAccount (.-eth web3))
            (ethereum/normalized-address address))

--- a/src/status_im/utils/web3_provider.cljs
+++ b/src/status_im/utils/web3_provider.cljs
@@ -3,10 +3,13 @@
             [status-im.native-module.core :as status]
             [status-im.js-dependencies :as dependencies]))
 
-(defn make-web3 []
+;; This Web3 object will allow access to private RPC calls
+;; It should be only used for internal application needs and never provided to any
+;; 3rd parties (DApps, etc)
+(defn make-internal-web3 []
   (dependencies/Web3.
    #js {:sendAsync (fn [payload callback]
-                     (status/call-web3
+                     (status/call-web3-private
                       (.stringify js/JSON payload)
                       (fn [response]
                         (if (= "" response)


### PR DESCRIPTION
Update to release 0.10.0. The first RC is here: https://github.com/status-im/status-go/releases/tag/0.10.0-rc.0

The most important additions:
- geth 1.8.11,
- `RequestMessages` returns a hash now,
- validate query range on `requestMessages` API,
- mailserver pagination,
- Add asymmetric key support for MailServer requests.


<blockquote><img src="https://avatars3.githubusercontent.com/u/11767950?s=400&v=4" width="48" align="right"><div><img src="https://assets-cdn.github.com/favicon.ico" height="14"> GitHub</div><div><strong><a href="https://github.com/status-im/status-go">status-im/status-go</a></strong></div><div>status-go - The Status module that consumes go-ethereum</div></blockquote>

status: ready