### PR TITLE
bug #4952 - moved the wrong password tooltip a bit up to make the fie…

### DIFF
--- a/src/status_im/ui/screens/wallet/send/styles.cljs
+++ b/src/status_im/ui/screens/wallet/send/styles.cljs
@@ -144,3 +144,7 @@
 
 (def fee-buttons
   {:background-color colors/blue})
+
+(def password-error-tooltip
+  {:bottom-value 15
+   :color        colors/red-light})

--- a/src/status_im/ui/screens/wallet/send/views.cljs
+++ b/src/status_im/ui/screens/wallet/send/views.cljs
@@ -33,6 +33,8 @@
             opacity-value   (animation/create-value 0)]
     {:component-did-mount #(send.animations/animate-sign-panel opacity-value bottom-value)}
     [react/animated-view {:style (styles/animated-sign-panel bottom-value)}
+     (when wrong-password?
+       [tooltip/tooltip (i18n/label :t/wrong-password) styles/password-error-tooltip])
      [react/animated-view {:style (styles/sign-panel opacity-value)}
       [react/view styles/spinner-container
        ;;NOTE(goranjovic) - android build doesn't seem to react on change in `:animating` property, so
@@ -54,9 +56,7 @@
          :on-change-text         #(re-frame/dispatch [:wallet.send/set-password (security/mask-data %)])
          :style                  styles/password
          :accessibility-label    :enter-password-input
-         :auto-capitalize        :none}]
-       (when wrong-password?
-         [tooltip/tooltip (i18n/label :t/wrong-password)])]]]))
+         :auto-capitalize        :none}]]]]))
 
 ;; "Cancel" and "Sign Transaction >" buttons, signing with password
 (defview signing-buttons [spinning? cancel-handler sign-handler sign-label]


### PR DESCRIPTION
fixes #4952 
also fixes #4835 

### Summary:

The "Wrong password" tooltip was blocking access to the password field, making it unfocusable if the user ever loses focus on it. This PR fixes the immediate issue by moving the tooltip just a little bit up.

### Steps to test:
see #4952 

status: ready 