### PR TITLE
Desktop switched to the same version of status-go as mobile

### DIFF
--- a/modules/react-native-status/desktop/CMakeLists.txt
+++ b/modules/react-native-status/desktop/CMakeLists.txt
@@ -37,7 +37,7 @@ ExternalProject_Add(StatusGo_ep
   PREFIX ${StatusGo_PREFIX}
   SOURCE_DIR ${StatusGo_SOURCE_DIR}
   GIT_REPOSITORY https://github.com/status-im/status-go.git
-  GIT_TAG origin/develop
+  GIT_TAG 03bf6e37
   BUILD_BYPRODUCTS ${StatusGo_STATIC_LIB}
   CONFIGURE_COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/${CONFIGURE_SCRIPT} ${GO_ROOT_PATH} ${StatusGo_ROOT} ${StatusGo_SOURCE_DIR}
   BUILD_COMMAND ""


### PR DESCRIPTION
### Summary:

Switch desktop to the same status-go version as mobile build after PR #5257 

### Testing notes (optional):
Change has no impact on mobile build

### Steps to test:
- Open Status desktop
- make sure login, create account, messaging works

status: ready
