### PR TITLE
[TESTS] Changed browser refresh button locator, sign transaction method and transactions from DApps

### DIFF
--- a/test/appium/tests/atomic/transactions/test_daaps_transactions.py
+++ b/test/appium/tests/atomic/transactions/test_daaps_transactions.py
@@ -19,6 +19,9 @@ class TestTransactionDApp(SingleDeviceTestCase):
         status_test_dapp.wait_for_d_aap_to_load()
         status_test_dapp.assets_button.click()
         send_transaction_view = status_test_dapp.request_stt_button.click()
+        wallet_view = send_transaction_view.get_wallet_view()
+        wallet_view.done_button.click()
+        wallet_view.yes_button.click()
         send_transaction_view.sign_transaction(sender['password'])
         self.network_api.verify_balance_is_updated(initial_balance, address)
 
@@ -44,6 +47,8 @@ class TestTransactionDApp(SingleDeviceTestCase):
         sender = transaction_users['E_USER']
         sign_in_view = SignInView(self.driver)
         sign_in_view.recover_access(sender['passphrase'], sender['password'])
+        wallet_view = sign_in_view.wallet_button.click()
+        wallet_view.set_up_wallet()
         status_test_dapp = sign_in_view.open_status_test_dapp()
         status_test_dapp.wait_for_d_aap_to_load()
         status_test_dapp.transactions_button.click()
@@ -61,6 +66,8 @@ class TestTransactionDApp(SingleDeviceTestCase):
         sender = transaction_users['B_USER']
         sign_in_view = SignInView(self.driver)
         sign_in_view.recover_access(sender['passphrase'], sender['password'])
+        wallet_view = sign_in_view.wallet_button.click()
+        wallet_view.set_up_wallet()
         status_test_dapp = sign_in_view.open_status_test_dapp()
         status_test_dapp.wait_for_d_aap_to_load()
         status_test_dapp.assets_button.click()

--- a/test/appium/views/send_transaction_view.py
+++ b/test/appium/views/send_transaction_view.py
@@ -177,7 +177,7 @@ class SendTransactionView(BaseView):
     def sign_transaction(self, sender_password):
         self.sign_transaction_button.click_until_presence_of_element(self.enter_password_input)
         self.enter_password_input.send_keys(sender_password)
-        self.sign_transaction_button.click()
+        self.sign_transaction_button.click_until_presence_of_element(self.progress_bar)
         self.progress_bar.wait_for_invisibility_of_element(60)
         self.got_it_button.click()
 

--- a/test/appium/views/web_views/base_web_view.py
+++ b/test/appium/views/web_views/base_web_view.py
@@ -37,7 +37,8 @@ class BrowserNextPageButton(BaseButton):
 class BrowserRefreshPageButton(BaseButton):
     def __init__(self, driver):
         super(BrowserRefreshPageButton, self).__init__(driver)
-        self.locator = self.Locator.xpath_selector('(//android.view.ViewGroup[@content-desc="icon"])[4]')
+        self.locator = self.Locator.xpath_selector(
+            "//*[@content-desc='next-page-button']/following-sibling::*/*[@content-desc='icon']")
 
 
 class WebViewBrowserButton(BaseButton):


### PR DESCRIPTION
status: ready <!-- Can be ready or wip -->
