### PR TITLE
bug #4404 - removed the 21 char limit from amount field in send and r…

### DIFF
--- a/src/status_im/ui/screens/wallet/request/views.cljs
+++ b/src/status_im/ui/screens/wallet/request/views.cljs
@@ -47,8 +47,7 @@
           [components/amount-selector {:error         amount-error
                                        :amount        amount
                                        :amount-text   amount-text
-                                       :input-options {:max-length     21
-                                                       :on-focus       (fn [] (when @scroll (utils/set-timeout #(.scrollToEnd @scroll) 100)))
+                                       :input-options {:on-focus       (fn [] (when @scroll (utils/set-timeout #(.scrollToEnd @scroll) 100)))
                                                        :on-change-text #(re-frame/dispatch [:wallet.request/set-and-validate-amount % symbol decimals])}}
            token]]]
         [bottom-buttons/bottom-buttons styles/bottom-buttons

--- a/src/status_im/ui/screens/wallet/send/views.cljs
+++ b/src/status_im/ui/screens/wallet/send/views.cljs
@@ -244,8 +244,7 @@
                                                         (when-not sufficient-gas? (i18n/label :t/wallet-insufficient-gas)))
                                      :amount        amount
                                      :amount-text   amount-text
-                                     :input-options {:max-length     21
-                                                     :on-focus       (fn [] (when (and scroll @scroll) (utils/set-timeout #(.scrollToEnd @scroll) 100)))
+                                     :input-options {:on-focus       (fn [] (when (and scroll @scroll) (utils/set-timeout #(.scrollToEnd @scroll) 100)))
                                                      :on-change-text #(re-frame/dispatch [:wallet.send/set-and-validate-amount % symbol decimals])}} token]
         [advanced-options advanced? transaction modal? scroll]]]
       (if signing?


### PR DESCRIPTION
fixes #4404

### Summary:

Amount field in Wallet Send and Request had a 21 char limit, which made sending or requesting certain amounts impossible (e.g. `100000.123456789012345678`). To make things worse, if user A requested the amount like this via chat command, when user B replies by sending the payment, the amount would silently get cut off to comply with the limit.

This PR removes the 21 char limit from both fields.

### Steps to test:
- Try sending values that exceed 21 characters
- Try requesting values that exceed 21 characters

status: ready