### PR TITLE
feature #4842 - initially autoconfiguring visible tokens based on bal…

### DIFF
--- a/src/status_im/ui/screens/accounts/events.cljs
+++ b/src/status_im/ui/screens/accounts/events.cljs
@@ -4,7 +4,6 @@
             [status-im.native-module.core :as status]
             [status-im.utils.types :refer [json->clj]]
             [status-im.utils.identicon :refer [identicon]]
-            [status-im.utils.random :as random]
             [clojure.string :as str]
             [status-im.i18n :as i18n]
             [status-im.utils.config :as config]
@@ -17,12 +16,11 @@
             [status-im.utils.gfycat.core :refer [generate-gfy]]
             [status-im.utils.hex :as utils.hex]
             [status-im.constants :as constants]
-            [status-im.transport.message.core :as transport]
             status-im.ui.screens.accounts.create.navigation
-            [status-im.chat.models :as chat.models]
             [status-im.ui.screens.accounts.utils :as accounts.utils]
             [status-im.data-store.accounts :as accounts-store]
-            [status-im.ui.screens.navigation :as navigation]))
+            [status-im.ui.screens.navigation :as navigation]
+            [status-im.ui.screens.wallet.settings.models :as wallet.settings.models]))
 
 ;;;; COFX
 
@@ -173,4 +171,5 @@
    (handlers-macro/merge-fx
     cofx
     (wallet-set-up-passed db modal?)
+    (wallet.settings.models/wallet-autoconfig-tokens)
     (accounts.utils/account-update {:wallet-set-up-passed? true}))))

--- a/src/status_im/ui/screens/wallet/events.cljs
+++ b/src/status_im/ui/screens/wallet/events.cljs
@@ -207,12 +207,15 @@
        (assoc-error-message :balance-update err)
        (assoc-in [:wallet :balance-loading?] false))))
 
-(handlers/register-handler-db
+(defn update-token-balance-success [symbol balance {:keys [db]}]
+  {:db (-> db
+           (assoc-in [:wallet :balance symbol] balance)
+           (assoc-in [:wallet :balance-loading?] false))})
+
+(handlers/register-handler-fx
  :update-token-balance-success
- (fn [db [_ symbol balance]]
-   (-> db
-       (assoc-in [:wallet :balance symbol] balance)
-       (assoc-in [:wallet :balance-loading?] false))))
+ (fn [cofx [_ symbol balance]]
+   (update-token-balance-success symbol balance cofx)))
 
 (handlers/register-handler-db
  :update-token-balance-fail

--- a/src/status_im/ui/screens/wallet/settings/events.cljs
+++ b/src/status_im/ui/screens/wallet/settings/events.cljs
@@ -1,18 +1,14 @@
 (ns status-im.ui.screens.wallet.settings.events
-  (:require [status-im.ui.screens.accounts.events :as accounts]
-            [status-im.utils.ethereum.core :as ethereum]
+  (:require [status-im.ui.screens.wallet.settings.models :as models]
+            [status-im.ui.screens.accounts.events :as accounts]
             [status-im.utils.handlers :as handlers]))
-
-(defn- toggle-checked [ids id checked?]
-  (if checked?
-    (conj (or ids #{}) id)
-    (disj ids id)))
 
 (handlers/register-handler-fx
  :wallet.settings/toggle-visible-token
- (fn [{{:keys [account/account] :as db} :db :as cofx} [_ symbol checked?]]
-   (let [network      (get (:networks account) (:network account))
-         chain        (ethereum/network->chain-keyword network)
-         settings     (get account :settings)
-         new-settings (update-in settings [:wallet :visible-tokens chain] #(toggle-checked % symbol checked?))]
-     (accounts/update-settings new-settings cofx))))
+ (fn [cofx [_ symbol checked?]]
+   (models/toggle-visible-token symbol checked? accounts/update-settings cofx)))
+
+(handlers/register-handler-fx
+ :configure-token-balance-and-visibility
+ (fn [cofx [_ symbol balance]]
+   (models/configure-token-balance-and-visibility symbol balance accounts/update-settings cofx)))

--- a/src/status_im/ui/screens/wallet/settings/models.cljs
+++ b/src/status_im/ui/screens/wallet/settings/models.cljs
@@ -1,0 +1,38 @@
+(ns status-im.ui.screens.wallet.settings.models
+  (:require [status-im.utils.ethereum.core :as ethereum]
+            [status-im.utils.handlers-macro :as handlers-macro]
+            [status-im.ui.screens.wallet.events :as wallet.events]
+            [status-im.utils.ethereum.tokens :as tokens]
+            [re-frame.core :as re-frame]))
+
+(defn- set-checked [ids id checked?]
+  (if checked?
+    (conj (or ids #{}) id)
+    (disj ids id)))
+
+(defn toggle-visible-token [symbol checked? update-settings-fx {{:keys [account/account]} :db :as cofx}]
+  (let [network      (get (:networks account) (:network account))
+        chain        (ethereum/network->chain-keyword network)
+        settings     (get account :settings)
+        new-settings (update-in settings [:wallet :visible-tokens chain] #(set-checked % symbol checked?))]
+    (update-settings-fx new-settings cofx)))
+
+(defn configure-token-balance-and-visibility [symbol balance update-settings-fx cofx]
+  (handlers-macro/merge-fx cofx
+                           (toggle-visible-token symbol true update-settings-fx)
+                           ;;TODO(goranjovic): move `update-token-balance-success` function to wallet models
+                           (wallet.events/update-token-balance-success symbol balance)))
+
+(defn wallet-autoconfig-tokens [{:keys [db]}]
+  (let [{:keys [account/account web3]} db
+        network   (get (:networks account) (:network account))
+        chain     (ethereum/network->chain-keyword network)
+        contracts (->> (tokens/tokens-for chain)
+                       (remove :hidden?))]
+    (doseq [{:keys [address symbol]} contracts]
+      ;;TODO(goranjovic): move `get-token-balance` function to wallet models
+      (wallet.events/get-token-balance {:web3       web3
+                                        :contract   address
+                                        :account-id (:address account)
+                                        :on-success #(when (> % 0)
+                                                       (re-frame/dispatch [:configure-token-balance-and-visibility symbol %]))}))))


### PR DESCRIPTION
fixes #4842

### Summary:

If the user recovers account where they have lots of various collectibles, they'd see only ETH and SNT after the recovery and until they manually enable all the other tokens. This is both tedious and may be a bit scary to see all the tokens seemingly lost after recovery.

This PR checks the balance of all tokens supported by Status during the Wallet Onboarding and automatically enables those with non-zero balance.

For starters, we'll do this only initially - as a setup helper. Eventually, it may be nice to have a special option to autoconfig tokens on-demand.

### Review notes:

This PR also contains very limited `events -> models` refactoring, restricted specifically to `wallet.settings` package. The reason to include this refactoring in this PR was to remove circular dependencies. The reason not to carry out the same kind of refactoring in other touched namespaces was to limit the scope of the PR.


### Steps to test:
- Recover an account with some tokens already on balance (ideally both tokens and collectibles)
- See if they are displayed in main wallet screen

status: ready 