### PR TITLE
cleanup jenkinsfile and prepare for builds on new linux slaves

### DIFF
--- a/Jenkinsfile.desktopbuild
+++ b/Jenkinsfile.desktopbuild
@@ -1,29 +1,45 @@
 properties([
-    buildDiscarder(logRotator(
-        numToKeepStr: '2',
-        daysToKeepStr: '3',
-        artifactNumToKeepStr: '2',
-        artifactDaysToKeepStr: '3'
-    ))
+  buildDiscarder(logRotator(
+    numToKeepStr: '2',
+    daysToKeepStr: '3',
+    artifactNumToKeepStr: '2',
+    artifactDaysToKeepStr: '3'
+  ))
 ])
 
-env.LANG="en_US.UTF-8"
-env.LANGUAGE="en_US.UTF-8"
-env.LC_ALL="en_US.UTF-8"
+env.LANG = 'en_US.UTF-8'
+env.LANGUAGE = 'en_US.UTF-8'
+env.LC_ALL = 'en_US.UTF-8'
+
+apkUrl = ''
+ipaUrl = ''
+testPassed = true
+scriptOutput = ''
+packageFolder = './StatusImPackage'
+external_modules_dir = [
+  'node_modules/react-native-i18n/desktop',
+  'node_modules/react-native-config/desktop',
+  'node_modules/react-native-fs/desktop',
+  'node_modules/react-native-http-bridge/desktop',
+  'node_modules/react-native-webview-bridge/desktop',
+  'node_modules/react-native-keychain/desktop',
+  'node_modules/react-native-securerandom/desktop',
+  'modules/react-native-status/desktop',
+]
 
 def installJSDeps() {
-    def attempt = 1
-    def maxAttempts = 10
-    def installed = false
-    sh 'node -v'
-    sh 'npm -v'
-    while (!installed && attempt <= maxAttempts) {
-        println "#${attempt} attempt to install npm deps"
-        sh 'scripts/prepare-for-platform.sh desktop'
-        sh 'npm install --verbose'
-        installed = fileExists('node_modules/web3/index.js')
-        attemp = attempt + 1
-    }
+  def attempt = 1
+  def maxAttempts = 10
+  def installed = false
+  sh 'node -v'
+  sh 'npm -v'
+  while (!installed && attempt <= maxAttempts) {
+    println "#${attempt} attempt to install npm deps"
+    sh 'scripts/prepare-for-platform.sh desktop'
+    sh 'npm install'
+    installed = fileExists('node_modules/web3/index.js')
+    attemp = attempt + 1
+  }
 }
 
 def doGitRebase() {
@@ -35,170 +51,193 @@ def doGitRebase() {
   }
 }
 
-def cleanupBuild(packageFolder) {
+def cleanupBuild() {
   sh 'rm -rf node_modules'
-  sh ( 'rm -rf ' + packageFolder )
+  sh "rm -rf ${packageFolder}"
   sh 'rm -rf desktop/modules'
   sh 'rm -rf desktop/node_modules'
 }
 
-parallel (
-  "MacOS parallel build stream" : {
-    timeout(90) {
-      node ('macos1') {
-        def apkUrl = ''
-        def ipaUrl = ''
-        def testPassed = true
-        def branch;
-        def scriptOutput = ''
-        def packageFolder = './StatusImPackage'
-        def scriptPath = sh(script: 'pwd -P', returnStdout: true).trim()
+def cleanupAndDeps() {
+  cleanupBuild()
+  sh 'cp .env.jenkins .env'
+  sh 'lein deps'
+  installJSDeps()
+}
 
+def slackNotify(message, color = 'good') {
+  slackSend(
+    color: color,
+    channel: '#jenkins-desktop',
+    message: "${BRANCH_NAME}(${env.CHANGE_BRANCH}) ${message} ${env.BUILD_URL}"
+  )
+}
+
+def buildClojureScript() {
+  sh 'rm -f index.desktop.js'
+  sh 'lein prod-build-desktop'
+  sh "mkdir ${packageFolder}"
+  sh """
+    react-native bundle \\
+      --entry-file index.desktop.js \\
+      --dev false --platform desktop \\
+      --bundle-output ${packageFolder}/StatusIm.jsbundle \\
+      --assets-dest ${packageFolder}/assets
+  """
+}
+
+parallel(
+  'MacOS build': {
+    timeout(90) {
+      node('macos1') {
         load "$HOME/env.groovy"
 
         try {
-
-          stage('Git & Dependencies') {
-            slackSend channel: '#jenkins-desktop', color: 'good', message: BRANCH_NAME + '(' + env.CHANGE_BRANCH + ') MacOS build started. ' + env.BUILD_URL
-
-            sh ('echo ' + scriptPath)
-
+          stage('Git & Deps') {
+            slackNotify('MacOS build started.')
             checkout scm
-
             doGitRebase()
-
-            cleanupBuild(packageFolder)
-            sh 'cp .env.jenkins .env'
-            sh 'lein deps'
-
-            installJSDeps()
+            cleanupAndDeps()
           }
 
           stage('Build ClojureScript') {
-            sh 'rm -f index.desktop.js'
-            sh 'lein prod-build-desktop'
-
-            sh ( 'mkdir ' + packageFolder )
-            sh ( 'react-native bundle --entry-file index.desktop.js --bundle-output ' + packageFolder + '/StatusIm.jsbundle --dev false --platform desktop --assets-dest ' + packageFolder + '/assets' )
+            buildClojureScript()
           }
 
           stage('Build MacOS binaries') {
-            sh 'cd desktop && rm -rf CMakeFiles CMakeCache.txt cmake_install.cmake Makefile'
-            sh 'export PATH=/Users/administrator/qt/5.9.1/clang_64/bin:$PATH && cd desktop && cmake -DCMAKE_BUILD_TYPE=Release -DEXTERNAL_MODULES_DIR="node_modules/react-native-i18n/desktop;node_modules/react-native-config/desktop;node_modules/react-native-fs/desktop;node_modules/react-native-http-bridge/desktop;node_modules/react-native-webview-bridge/desktop;node_modules/react-native-keychain/desktop;node_modules/react-native-securerandom/desktop;modules/react-native-status/desktop"\
-            -DJS_BUNDLE_PATH="' + scriptPath + '/' + packageFolder + '/StatusIm.jsbundle" -DCMAKE_CXX_FLAGS:="-DBUILD_FOR_BUNDLE=1" . && make'
+            /* add path for QT installation binaries */
+            env.PATH = "/Users/administrator/qt/5.9.1/clang_64/bin:${env.PATH}"
+            dir('desktop') {
+              sh 'rm -rf CMakeFiles CMakeCache.txt cmake_install.cmake Makefile'
+              sh """
+                cmake -Wno-dev \\
+                  -DCMAKE_BUILD_TYPE=Release \\
+                  -DEXTERNAL_MODULES_DIR='${external_modules_dir.join(";")}' \\
+                  -DJS_BUNDLE_PATH='${workspace}/${packageFolder}/StatusIm.jsbundle' \\
+                  -DCMAKE_CXX_FLAGS:='-DBUILD_FOR_BUNDLE=1'
+              """
+              sh 'make'
+            }
           }
 
-          stage('Prepare and create MacOS Bundle') {
-            sh ('cd ' + packageFolder + ' && ../scripts/download-package-files.sh "StatusIm.app.zip" "1Vkb6MD3nsmT02Az6rRRZywQSwCz1ZN9V" && unzip ./StatusIm.app.zip')
-            sh ('cp -r ' + packageFolder + '/assets/share/assets ' + packageFolder +'/StatusIm.app/Contents/MacOs')
-            sh ('chmod +x ' + packageFolder + '/StatusIm.app/Contents/MacOs/ubuntu-server')
-            sh ('cp ./desktop/bin/StatusIm ' + packageFolder +'/StatusIm.app/Contents/MacOs')
-
-            sh ('export PATH=/Users/administrator/qt/5.9.1/clang_64/bin:$PATH && cd ' + packageFolder + ' && macdeployqt StatusIm.app -verbose=1 -dmg -qmldir="' + scriptPath + '/node_modules/react-native/ReactQt/runtime/src/qml/"')
-
-            sh 'rm -f StatusIm.app.zip'
+          stage('Create MacOS Bundle') {
+            dir(packageFolder) {
+              sh 'git clone https://github.com/vkjr/StatusAppFiles.git 
+              sh 'unzip StatusAppFiles/StatusIm.app.zip'
+              sh 'cp -r assets/share/assets StatusIm.app/Contents/MacOs'
+              sh 'chmod +x StatusIm.app/Contents/MacOs/ubuntu-server'
+              sh 'cp ../desktop/bin/StatusIm StatusIm.app/Contents/MacOs'
+              sh """
+                macdeployqt StatusIm.app -verbose=1 -dmg \\
+                  -qmldir='${workspace}/node_modules/react-native/ReactQt/runtime/src/qml/'
+              """
+              sh 'rm -f StatusAppFiles'
+            }
           }
 
-          stage('Archive built artifact') {
-            archiveArtifacts "StatusImPackage/*.dmg"
+          stage('Archive Artifact') {
+            archiveArtifacts 'StatusImPackage/*.dmg'
           }
 
-          cleanupBuild(packageFolder)
-          slackSend channel: '#jenkins-desktop', color: 'good', message: BRANCH_NAME + '(' + env.CHANGE_BRANCH + ') MacOS build finished successfully. ' + env.BUILD_URL
+          slackNotify('MacOS build finished successfully.')
         } catch (e) {
-          cleanupBuild(packageFolder)
-          slackSend channel: '#jenkins-desktop', color: 'bad', message: BRANCH_NAME + ' failed to build on MacOS. ' + env.BUILD_URL
+          slackNotify('Failed to build on MacOS.', color: 'bad')
           throw e
+        } finally {
+          cleanupBuild()
         }
       }
     }
   },
-  "Linux parallel build stream" : {
+  'Linux build': {
     timeout(90) {
-      node ('linux1') {
-        def apkUrl = ''
-        def ipaUrl = ''
-        def testPassed = true
-        def branch;
-        def scriptOutput = ''
-        def packageFolder = './StatusImPackage'
-        def scriptPath = sh(script: 'pwd -P', returnStdout: true).trim()
-
-        sh ('echo ' + scriptPath)
+      node ('linux-01') {
+        def qt_bin = '/opt/qt59/bin'
 
         try {
-
-          stage('Git & Dependencies') {
-            slackSend channel: '#jenkins-desktop', color: 'good', message: BRANCH_NAME + '(' + env.CHANGE_BRANCH + ') Linux build started. ' + env.BUILD_URL
-
-            sh ('echo ' + scriptPath)
-
+          stage('Git & Deps') {
+            slackNotify('Linux build started.')
             checkout scm
-
             doGitRebase()
-
-            cleanupBuild(packageFolder)
-            sh 'cp .env.jenkins .env'
-            sh 'lein deps'
-
-            installJSDeps()
+            cleanupAndDeps()
           }
 
           stage('Build ClojureScript') {
-            sh 'rm -f index.desktop.js'
-            sh 'lein prod-build-desktop'
-
-            sh ( 'mkdir ' + packageFolder )
-            sh ( 'react-native bundle --entry-file index.desktop.js --bundle-output ' + packageFolder + '/StatusIm.jsbundle --dev false --platform desktop --assets-dest ' + packageFolder + '/assets' )
+            buildClojureScript()
           }
 
           stage('Build Linux binaries') {
-            sh 'cd desktop && rm -rf CMakeFiles CMakeCache.txt cmake_install.cmake Makefile'
-            sh 'export PATH=/home/maxr/Qt5.9.1/5.9.1/gcc_64/bin:/usr/local/go/bin:$PATH && cd desktop && cmake -DCMAKE_BUILD_TYPE=Release -DEXTERNAL_MODULES_DIR="node_modules/react-native-i18n/desktop;node_modules/react-native-config/desktop;node_modules/react-native-fs/desktop;node_modules/react-native-http-bridge/desktop;node_modules/react-native-webview-bridge/desktop;node_modules/react-native-keychain/desktop;node_modules/react-native-securerandom/desktop;modules/react-native-status/desktop"\
-            -DJS_BUNDLE_PATH="' + scriptPath + '/' + packageFolder + '/StatusIm.jsbundle" -DCMAKE_CXX_FLAGS:="-DBUILD_FOR_BUNDLE=1" . && make'
+            /* add path for QT installation binaries */
+            env.PATH = "${qt_bin}:${env.PATH}"
+            dir('desktop') {
+              sh 'rm -rf CMakeFiles CMakeCache.txt cmake_install.cmake Makefile'
+              sh """
+                cmake -Wno-dev \\
+                  -DCMAKE_BUILD_TYPE=Release \\
+                  -DEXTERNAL_MODULES_DIR='${external_modules_dir.join(";")}' \\
+                  -DJS_BUNDLE_PATH='${workspace}/${packageFolder}/StatusIm.jsbundle' \\
+                  -DCMAKE_CXX_FLAGS:='-DBUILD_FOR_BUNDLE=1'
+              """
+              sh 'make'
+            }
           }
 
-          stage('Prepare and create Linux AppImage') {
-            sh ('rm -rf ' + packageFolder + '/StatusImAppImage')
-            sh ('cd ' + packageFolder + ' && cp /home/maxr/qttools/StatusImAppImage.zip ./ && unzip ./StatusImAppImage.zip')
-
-            sh ('rm -rf ' + packageFolder + '/AppDir && mkdir ' + packageFolder + '/AppDir')
-            sh ('cp -r ./deployment/linux/usr  ' + packageFolder + '/AppDir')
-            sh ('cp  ./deployment/linux/.env  ' + packageFolder + '/AppDir')
-            sh ('cp ./desktop/bin/StatusIm ' + packageFolder+ '/AppDir/usr/bin')
-
-            sh ('cp -f /home/maxr/qttools/linuxdeployqt-continuous-x86_64.AppImage ./')
-            sh ('chmod a+x ./linuxdeployqt-continuous-x86_64.AppImage')
+          stage('Create Linux AppImage') {
+            dir(packageFolder) {
+              sh 'rm -rf StatusImAppImage'
+              /* TODO this needs to be fixed: status-react/issues/5378 */
+              sh 'cp /opt/StatusImAppImage.zip ./'
+              sh 'unzip ./StatusImAppImage.zip'
+              sh 'rm -rf AppDir'
+              sh 'mkdir AppDir'
+            }
+            sh "cp -r ./deployment/linux/usr  ${packageFolder}/AppDir"
+            sh "cp ./deployment/linux/.env  ${packageFolder}/AppDir"
+            sh "cp ./desktop/bin/StatusIm ${packageFolder}/AppDir/usr/bin"
+            sh 'wget https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage'
+            sh 'chmod a+x ./linuxdeployqt-continuous-x86_64.AppImage'
 
             sh 'rm -f Application-x86_64.AppImage'
             sh 'rm -f StatusIm-x86_64.AppImage'
 
-            sh 'ldd ' + packageFolder+ '/AppDir/usr/bin/StatusIm'
-            sh ('export PATH=/home/maxr/Qt5.9.1/5.9.1/gcc_64/bin:/usr/local/go/bin:$PATH && ./linuxdeployqt-continuous-x86_64.AppImage ' + packageFolder+ '/AppDir/usr/share/applications/StatusIm.desktop -verbose=3 -always-overwrite -no-strip -no-translations -bundle-non-qt-libs -qmake=/home/maxr/Qt5.9.1/5.9.1/gcc_64/bin/qmake -extra-plugins=imageformats/libqsvg.so -qmldir="' + scriptPath + '/node_modules/react-native"')
-            sh 'ldd ' + packageFolder+ '/AppDir/usr/bin/StatusIm'
-
-            sh ('cp -r ' + packageFolder + '/assets/share/assets ' + packageFolder +'/AppDir/usr/bin')
-            sh ('cp -rf ' + packageFolder + '/StatusImAppImage/* ' + packageFolder +'/AppDir/usr/bin')
-            sh ('rm -f ' + packageFolder +'/AppDir/usr/bin/StatusIm.AppImage')
-
-            sh ('export PATH=/home/maxr/Qt5.9.1/5.9.1/gcc_64/bin:/usr/local/go/bin:$PATH && ./linuxdeployqt-continuous-x86_64.AppImage ' + packageFolder+ '/AppDir/usr/share/applications/StatusIm.desktop -verbose=3 -appimage -qmake=/home/maxr/Qt5.9.1/5.9.1/gcc_64/bin/qmake')
-            sh 'ldd ' + packageFolder+ '/AppDir/usr/bin/StatusIm'
-
-            sh ('rm -rf ' + packageFolder +'/StatusIm.AppImage')
-            sh ('cp -f ./StatusIm-x86_64.AppImage ' + packageFolder + '/StatusIm.AppImage')
-
+            sh "ldd ${packageFolder}/AppDir/usr/bin/StatusIm"
+            sh """
+              ./linuxdeployqt-continuous-x86_64.AppImage \\
+                ${packageFolder}/AppDir/usr/share/applications/StatusIm.desktop \\
+                -verbose=3 -always-overwrite -no-strip \\
+                -no-translations -bundle-non-qt-libs \\
+                -qmake=${qt_bin}/qmake \\
+                -extra-plugins=imageformats/libqsvg.so \\
+                -qmldir='${workspace}/node_modules/react-native'
+            """
+            dir(packageFolder) {
+              sh 'ldd AppDir/usr/bin/StatusIm'
+              sh 'cp -r assets/share/assets AppDir/usr/bin'
+              sh 'cp -rf StatusImAppImage/* AppDir/usr/bin'
+              sh 'rm -f AppDir/usr/bin/StatusIm.AppImage'
+            }
+            sh """
+              ./linuxdeployqt-continuous-x86_64.AppImage \\
+              ${packageFolder}/AppDir/usr/share/applications/StatusIm.desktop \\
+              -verbose=3 -appimage -qmake=${qt_bin}/qmake
+            """
+            dir(packageFolder) {
+              sh 'ldd AppDir/usr/bin/StatusIm'
+              sh 'rm -rf StatusIm.AppImage'
+              sh 'cp -f ../StatusIm-x86_64.AppImage StatusIm.AppImage'
+            }
           }
 
-          stage('Archive built artifact') {
-            archiveArtifacts "StatusImPackage/*.AppImage"
+          stage('Archive Artifact') {
+            archiveArtifacts 'StatusImPackage/*.AppImage'
           }
 
-          cleanupBuild(packageFolder)
-          slackSend channel: '#jenkins-desktop', color: 'good', message: BRANCH_NAME + '(' + env.CHANGE_BRANCH + ') Linux build finished successfully. ' + env.BUILD_URL
+          slackNotify('Linux build finished successfully.')
         } catch (e) {
-          cleanupBuild(packageFolder)
-          slackSend channel: '#jenkins-desktop', color: 'bad', message: BRANCH_NAME + ' failed to build on Linux. ' + env.BUILD_URL
+          slackNotify('Failed to build on Linux.', color: 'bad')
           throw e
+        } finally {
+          cleanupBuild()
         }
       }
     }


### PR DESCRIPTION
General `Jenkinsfile` cleanup for desktop builds an a few fixes to prepare it for use of new Linux Jenkins slaves.
Not ready yet, needs a fix for the steps referencing `/home/maxr/qttools/StatusImAppImage.zip`.