### PR TITLE
refactor - extracted all model functions from profile events

### DIFF
--- a/src/status_im/ui/screens/profile/events.cljs
+++ b/src/status_im/ui/screens/profile/events.cljs
@@ -1,125 +1,69 @@
 (ns status-im.ui.screens.profile.events
-  (:require [clojure.spec.alpha :as spec]
-            [re-frame.core :as re-frame]
-            [status-im.ui.components.react :as react]
-            [status-im.chat.constants :as chat-const]
+  (:require [re-frame.core :as re-frame]
             [status-im.ui.screens.profile.navigation]
-            [status-im.ui.screens.accounts.utils :as accounts.utils]
-            [status-im.chat.events :as chat-events]
-            [status-im.chat.commands.core :as commands]
             [status-im.utils.handlers :as handlers]
-            [status-im.utils.handlers-macro :as handlers-macro]
-            [status-im.utils.image-processing :refer [img->base64]]
-            [taoensso.timbre :as log]))
+            [status-im.ui.screens.profile.models :as profile.models]))
 
 (re-frame/reg-fx
  :open-image-picker
-  ;; the image picker is only used here for now, this effect can be use in other scenarios as well
+ ;; the image picker is only used here for now, this effect can be use in other scenarios as well
  (fn [callback-event]
-   (react/show-image-picker
-    (fn [image]
-      (let [path (get (js->clj image) "path")
-            _ (log/debug path)
-            on-success (fn [base64]
-                         (re-frame/dispatch [callback-event base64]))
-            on-error   (fn [type error]
-                         (.log js/console type error))]
-        (img->base64 path on-success on-error))))))
+   (profile.models/open-image-picker! callback-event)))
 
 (handlers/register-handler-fx
  :profile/send-transaction
- [re-frame/trim-v]
- (fn [{:keys [db] :as cofx} [chat-id]]
-   (let [send-command (get-in db [:id->command ["send" #{:personal-chats}]])]
-     (handlers-macro/merge-fx cofx
-                              (chat-events/start-chat chat-id {:navigation-replace? true})
-                              (commands/select-chat-input-command send-command nil)))))
-
-(defn valid-name? [name]
-  (spec/valid? :profile/name name))
+ (fn [cofx [_ chat-id]]
+   (profile.models/send-transaction chat-id cofx)))
 
 (handlers/register-handler-fx
  :my-profile/update-name
- (fn [{:keys [db]} [_ name]]
-   {:db (-> db
-            (assoc-in [:my-profile/profile :valid-name?] (valid-name? name))
-            (assoc-in [:my-profile/profile :name] name))}))
+ (fn [cofx [_ name]]
+   (profile.models/update-name name cofx)))
 
 (handlers/register-handler-fx
  :my-profile/update-picture
- (fn [{:keys [db]} [this-event base64-image]]
-   (if base64-image
-     {:db       (-> db
-                    (assoc-in [:my-profile/profile :photo-path]
-                              (str "data:image/jpeg;base64," base64-image))
-                    (assoc :my-profile/editing? true))}
-     {:open-image-picker this-event})))
-
-(defn clean-name [db edit-view]
-  (let [name (get-in db [edit-view :name])]
-    (if (valid-name? name)
-      name
-      (get-in db [:account/account :name]))))
-
-(defn clear-profile [{:keys [db] :as cofx}]
-  {:db (dissoc db :my-profile/profile :my-profile/default-name :my-profile/editing?)})
+ (fn [cofx [this-event base64-image]]
+   (profile.models/update-picture this-event base64-image cofx)))
 
 (handlers/register-handler-fx
  :my-profile/start-editing-profile
- (fn [{:keys [db]} []]
-   (let [profile (select-keys (:account/account db) [:name :photo-path])]
-     {:db (assoc db :my-profile/editing? true
-                 :my-profile/profile profile)})))
+ (fn [cofx _]
+   (profile.models/start-editing cofx)))
 
 (handlers/register-handler-fx
  :my-profile/save-profile
- (fn [{:keys [db now] :as cofx} _]
-   (let [{:keys [photo-path]} (:my-profile/profile db)
-         cleaned-name (clean-name db :my-profile/profile)
-         cleaned-edit (merge {:name         cleaned-name
-                              :last-updated now}
-                             (if photo-path
-                               {:photo-path photo-path}))]
-     (handlers-macro/merge-fx cofx
-                              (clear-profile)
-                              (accounts.utils/account-update cleaned-edit)))))
+ (fn [cofx _]
+   (profile.models/save cofx)))
 
 (handlers/register-handler-fx
  :group-chat-profile/start-editing
- (fn [{:keys [db]} _]
-   {:db (assoc db :group-chat-profile/editing? true)}))
+ (fn [cofx _]
+   (profile.models/start-editing-group-chat-profile cofx)))
 
 (handlers/register-handler-fx
  :group-chat-profile/save-profile
- (fn [{:keys [db]} _]
-   (-> {:db db}
-       (update :db dissoc :group-chat-profile/editing?))))
+ (fn [cofx _]
+   (profile.models/save-group-chat-profile cofx)))
 
 (handlers/register-handler-fx
  :my-profile/enter-two-random-words
- (fn [{:keys [db]} []]
-   (let [{:keys [mnemonic]} (:account/account db)
-         shuffled-mnemonic (shuffle (map-indexed vector (clojure.string/split mnemonic #" ")))]
-     {:db (assoc db :my-profile/seed {:step :first-word
-                                      :first-word (first shuffled-mnemonic)
-                                      :second-word (second shuffled-mnemonic)})})))
+ (fn [cofx _]
+   (profile.models/enter-two-random-words cofx)))
 
 (handlers/register-handler-fx
  :my-profile/set-step
- (fn [{:keys [db]} [_ step]]
-   {:db (update db :my-profile/seed assoc :step step :error nil :word nil)}))
+ (fn [cofx [_ step]]
+   (profile.models/set-step step cofx)))
 
 (handlers/register-handler-fx
  :my-profile/finish
- (fn [{:keys [db] :as cofx} _]
-   (handlers-macro/merge-fx cofx
-                            {:db (update db :my-profile/seed assoc :step :finish :error nil :word nil)}
-                            (accounts.utils/clean-seed-phrase))))
+ (fn [cofx _]
+   (profile.models/finish cofx)))
 
 (re-frame/reg-fx
  :copy-to-clipboard
  (fn [value]
-   (react/copy-to-clipboard value)))
+   (profile.models/copy-to-clipboard! value)))
 
 (handlers/register-handler-fx
  :copy-to-clipboard
@@ -128,25 +72,7 @@
 
 (re-frame/reg-fx
  :show-tooltip
- (let [tooltips (atom {})]
-   (fn [tooltip-id]
-     (when-let [{:keys [interval-id]} (@tooltips tooltip-id)]
-       (js/clearInterval interval-id))
-     (let [interval-id (js/setInterval
-                        #(let [{:keys [opacity interval-id cnt]} (@tooltips tooltip-id)]
-                           (when opacity
-                             (swap! tooltips assoc-in [tooltip-id :cnt] (inc cnt))
-                             (if (and opacity (>= 0.0 opacity))
-                               (do
-                                 (log/debug "remove interval:" interval-id)
-                                 (js/clearInterval interval-id)
-                                 (re-frame/dispatch [:set-in [:tooltips tooltip-id] nil])
-                                 (swap! tooltips dissoc interval-id))
-                               (do (re-frame/dispatch [:set-in [:tooltips tooltip-id] opacity])
-                                   (when (< 10 cnt)
-                                     (swap! tooltips assoc-in [tooltip-id :opacity] (- opacity 0.05)))))))
-                        100)]
-       (swap! tooltips assoc tooltip-id {:opacity 1.0 :interval-id interval-id :cnt 0})))))
+ profile.models/show-tooltip!)
 
 (handlers/register-handler-fx
  :show-tooltip

--- a/src/status_im/ui/screens/profile/models.cljs
+++ b/src/status_im/ui/screens/profile/models.cljs
@@ -1,0 +1,116 @@
+(ns status-im.ui.screens.profile.models
+  (:require [clojure.spec.alpha :as spec]
+            [re-frame.core :as re-frame]
+            [status-im.ui.components.react :as react]
+            [status-im.ui.screens.profile.navigation]
+            [status-im.ui.screens.accounts.utils :as accounts.utils]
+            [status-im.chat.events :as chat-events]
+            [status-im.chat.commands.core :as commands]
+            [status-im.utils.handlers-macro :as handlers-macro]
+            [status-im.utils.image-processing :as image-processing]
+            [taoensso.timbre :as log]))
+
+(defn open-image-picker! [callback-event]
+  (react/show-image-picker
+   (fn [image]
+     (let [path (get (js->clj image) "path")
+           _ (log/debug path)
+           on-success (fn [base64]
+                        (re-frame/dispatch [callback-event base64]))
+           on-error (fn [type error]
+                      (.log js/console type error))]
+       (image-processing/img->base64 path on-success on-error)))))
+
+(defn send-transaction [chat-id {:keys [db] :as cofx}]
+  (let [send-command (get-in db [:id->command ["send" #{:personal-chats}]])]
+    (handlers-macro/merge-fx cofx
+                             (chat-events/start-chat chat-id {:navigation-replace? true})
+                             (commands/select-chat-input-command send-command nil))))
+
+(defn- valid-name? [name]
+  (spec/valid? :profile/name name))
+
+(defn update-name [name {:keys [db]}]
+  {:db (-> db
+           (assoc-in [:my-profile/profile :valid-name?] (valid-name? name))
+           (assoc-in [:my-profile/profile :name] name))})
+
+(defn update-picture [this-event base64-image {:keys [db]}]
+  (if base64-image
+    {:db       (-> db
+                   (assoc-in [:my-profile/profile :photo-path]
+                             (str "data:image/jpeg;base64," base64-image))
+                   (assoc :my-profile/editing? true))}
+    {:open-image-picker this-event}))
+
+(defn- clean-name [db edit-view]
+  (let [name (get-in db [edit-view :name])]
+    (if (valid-name? name)
+      name
+      (get-in db [:account/account :name]))))
+
+(defn clear-profile [{:keys [db]}]
+  {:db (dissoc db :my-profile/profile :my-profile/default-name :my-profile/editing?)})
+
+(defn start-editing [{:keys [db]}]
+  (let [profile (select-keys (:account/account db) [:name :photo-path])]
+    {:db (assoc db
+                :my-profile/editing? true
+                :my-profile/profile profile)}))
+
+(defn save [{:keys [db now] :as cofx}]
+  (let [{:keys [photo-path]} (:my-profile/profile db)
+        cleaned-name (clean-name db :my-profile/profile)
+        cleaned-edit (merge {:name         cleaned-name
+                             :last-updated now}
+                            (if photo-path
+                              {:photo-path photo-path}))]
+    (handlers-macro/merge-fx cofx
+                             (clear-profile)
+                             (accounts.utils/account-update cleaned-edit))))
+
+(defn start-editing-group-chat-profile [{:keys [db]}]
+  {:db (assoc db :group-chat-profile/editing? true)})
+
+(defn save-group-chat-profile [{:keys [db]}]
+  (-> {:db db}
+      (update :db dissoc :group-chat-profile/editing?)))
+
+(defn enter-two-random-words [{:keys [db]}]
+  (let [{:keys [mnemonic]} (:account/account db)
+        shuffled-mnemonic (shuffle (map-indexed vector (clojure.string/split mnemonic #" ")))]
+    {:db (assoc db :my-profile/seed {:step        :first-word
+                                     :first-word  (first shuffled-mnemonic)
+                                     :second-word (second shuffled-mnemonic)})}))
+
+(defn set-step [step {:keys [db]}]
+  {:db (update db :my-profile/seed assoc :step step :error nil :word nil)})
+
+(defn finish [{:keys [db] :as cofx}]
+  (handlers-macro/merge-fx cofx
+                           {:db (update db :my-profile/seed assoc :step :finish :error nil :word nil)}
+                           (accounts.utils/clean-seed-phrase)))
+
+(defn copy-to-clipboard! [value]
+  (react/copy-to-clipboard value))
+
+(def show-tooltip!
+  (let [tooltips (atom {})]
+    (fn [tooltip-id]
+      (when-let [{:keys [interval-id]} (@tooltips tooltip-id)]
+        (js/clearInterval interval-id))
+      (let [interval-id (js/setInterval
+                         #(let [{:keys [opacity interval-id cnt]} (@tooltips tooltip-id)]
+                            (when opacity
+                              (swap! tooltips assoc-in [tooltip-id :cnt] (inc cnt))
+                              (if (and opacity (>= 0.0 opacity))
+                                (do
+                                  (log/debug "remove interval:" interval-id)
+                                  (js/clearInterval interval-id)
+                                  (re-frame/dispatch [:set-in [:tooltips tooltip-id] nil])
+                                  (swap! tooltips dissoc interval-id))
+                                (do (re-frame/dispatch [:set-in [:tooltips tooltip-id] opacity])
+                                    (when (< 10 cnt)
+                                      (swap! tooltips assoc-in [tooltip-id :opacity] (- opacity 0.05)))))))
+                         100)]
+        (swap! tooltips assoc tooltip-id {:opacity 1.0 :interval-id interval-id :cnt 0})))))


### PR DESCRIPTION
Light Profile refactoring

### Summary:

Extracted model functions from profile events. Proposing naming convention where model functions with side effects end with `!` (the functions used for re-frame effects, as opposed to handlers).

### Testing notes (optional):

No behavior changes - everything should work the same. Only light testing of Profile tab and chat profile is needed. 

status: ready 