### PR TITLE
move archive.plist settings to the repo

### DIFF
--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -80,8 +80,9 @@ timeout(90) {
 
         // iOS
         stage('Build (iOS)') {
-          sh 'export RCT_NO_LAUNCH_PACKAGER=true && xcodebuild -workspace ios/StatusIm.xcworkspace -scheme StatusIm -configuration release -archivePath status clean archive'
-          sh 'xcodebuild -exportArchive -exportPath status -archivePath status.xcarchive -exportOptionsPlist ~/archive.plist'
+          env.RCT_NO_LAUNCH_PACKAGER = true
+          sh 'xcodebuild -workspace ios/StatusIm.xcworkspace -scheme StatusIm -configuration release -archivePath status clean archive'
+          sh 'xcodebuild -exportArchive -exportPath status -archivePath status.xcarchive -exportOptionsPlist ios/archive-develop.plist'
         }
 
         stage('Deploy (iOS)') {

--- a/ci/Jenkinsfile.nightly
+++ b/ci/Jenkinsfile.nightly
@@ -56,8 +56,9 @@ timeout(90) {
         }
 
         stage('Build (iOS)') {
-          sh 'export RCT_NO_LAUNCH_PACKAGER=true && xcodebuild -workspace ios/StatusIm.xcworkspace -scheme StatusIm -configuration release -archivePath status clean archive'
-          sh 'xcodebuild -exportArchive -exportPath status -archivePath status.xcarchive -exportOptionsPlist ~/archive.plist'
+          env.RCT_NO_LAUNCH_PACKAGER = true
+          sh 'xcodebuild -workspace ios/StatusIm.xcworkspace -scheme StatusIm -configuration release -archivePath status clean archive'
+          sh 'xcodebuild -exportArchive -exportPath status -archivePath status.xcarchive -exportOptionsPlist ios/archive-develop.plist'
         }
 
         stage('Deploy (Android)') {

--- a/ci/Jenkinsfile.nightly_fastlane
+++ b/ci/Jenkinsfile.nightly_fastlane
@@ -74,13 +74,16 @@ timeout(90) {
         }
 
         stage('Build (iOS)') {
-          withCredentials([string(credentialsId: 'jenkins_pass', variable: 'password')]) {
-            sh ('plutil -replace CFBundleShortVersionString  -string ' + version + ' ios/StatusIm/Info.plist')
-            sh ('plutil -replace CFBundleVersion  -string ' + build_no + ' ios/StatusIm/Info.plist')
-            sh 'export RCT_NO_LAUNCH_PACKAGER=true && xcodebuild -workspace ios/StatusIm.xcworkspace -scheme StatusIm -configuration release -archivePath status clean archive'
-            sh ('security unlock-keychain -p ' + password + ' login.keychain')
-            sh 'xcodebuild -exportArchive -exportPath status_appstore -archivePath status.xcarchive -exportOptionsPlist ~/archive-release.plist'
-            sh 'xcodebuild -exportArchive -exportPath status -archivePath status.xcarchive -exportOptionsPlist ~/archive.plist'
+          withCredentials([
+            string(credentialsId: 'jenkins_pass', variable: 'password')
+          ]) {
+            sh "plutil -replace CFBundleShortVersionString  -string ${version} ios/StatusIm/Info.plist"
+            sh "plutil -replace CFBundleVersion -string ${build_no} ios/StatusIm/Info.plist"
+            env.RCT_NO_LAUNCH_PACKAGER = true
+            sh 'xcodebuild -workspace ios/StatusIm.xcworkspace -scheme StatusIm -configuration release -archivePath status clean archive'
+            sh "security unlock-keychain -p ${password} login.keychain"
+            sh 'xcodebuild -exportArchive -exportPath status_appstore -archivePath status.xcarchive -exportOptionsPlist ios/archive-release.plist'
+            sh 'xcodebuild -exportArchive -exportPath status -archivePath status.xcarchive -exportOptionsPlist ios/archive.plist'
           }
         }
 

--- a/ci/Jenkinsfile.parameters
+++ b/ci/Jenkinsfile.parameters
@@ -4,124 +4,124 @@ env.LC_ALL="en_US.UTF-8"
 env.FASTLANE_DISABLE_COLORS=1
 
 def installJSDeps() {
-    def attempt = 1
-    def maxAttempts = 10
-    def installed = false
-    while (!installed && attempt <= maxAttempts) {
-        println "#${attempt} attempt to install npm deps"
-        sh 'scripts/prepare-for-platform.sh mobile'
-        sh 'npm install'
-        installed = fileExists('node_modules/web3/index.js')
-        attemp = attempt + 1
-    }
+  def attempt = 1
+  def maxAttempts = 10
+  def installed = false
+  while (!installed && attempt <= maxAttempts) {
+    println "#${attempt} attempt to install npm deps"
+    sh 'scripts/prepare-for-platform.sh mobile'
+    sh 'npm install'
+    installed = fileExists('node_modules/web3/index.js')
+    attemp = attempt + 1
+  }
 }
 
 timeout(90) {
-    node ('macos') {
-      def apkUrl = ''
-      def ipaUrl = ''
-      def testPassed = true
-      def branch;
+  node ('macos') {
+    def apkUrl = ''
+    def ipaUrl = ''
+    def testPassed = true
+    def branch;
 
-       load "$HOME/env.groovy"
+    load "$HOME/env.groovy"
 
-      try {
+    try {
+      stage('Git & Dependencies') {
+        slackSend color: 'good', message: REPO + ":" + BRANCH_NAME + ' build started. ' + env.BUILD_URL
 
-        stage('Git & Dependencies') {
-          slackSend color: 'good', message: REPO + ":" + BRANCH_NAME + ' build started. ' + env.BUILD_URL
+        checkout scm
 
-          checkout scm
+        sh 'rm -rf node_modules'
 
-          sh 'rm -rf node_modules'
+        sh 'test ${JENKINS_REBASE_DEVELOP} -eq 1 && git rebase origin/develop || echo "Not rebasing on develop."'
 
-          sh 'test ${JENKINS_REBASE_DEVELOP} -eq 1 && git rebase origin/develop || echo "Not rebasing on develop."'
+        // Assume all parameters are set in Jenkins 'Parameterized build'
+        // TODO(oskarth): Consider read/write from .env to avoid having to specify in Jenkins again
+        // sh 'cp .env.jenkins .env'
+        sh 'echo TESTFAIRY_ENABLED='           + TESTFAIRY_ENABLED            + '>>' + '.env'
+        sh 'echo ETHEREUM_DEV_CLUSTER='        + ETHEREUM_DEV_CLUSTER         + '>>' + '.env'
+        sh 'echo MAINNET_NETWORKS_ENABLED='    + MAINNET_NETWORKS_ENABLED     + '>>' + '.env'
+        sh 'echo LOG_LEVEL='                   + LOG_LEVEL                    + '>>' + '.env'
+        sh 'echo LOG_LEVEL_STATUS_GO='         + LOG_LEVEL_STATUS_GO          + '>>' + '.env'
+        sh 'echo OFFLINE_INBOX_ENABLED='       + OFFLINE_INBOX_ENABLED        + '>>' + '.env'
+        sh 'echo POW_TARGET='                  + POW_TARGET                   + '>>' + '.env'
+        sh 'echo POW_TIME='                    + POW_TIME                     + '>>' + '.env'
+        sh 'echo MAINNET_WARNING_ENABLED='     + MAINNET_WARNING_ENABLED      + '>>' + '.env'
+        sh 'echo DEFAULT_NETWORK='             + DEFAULT_NETWORK              + '>>' + '.env'
 
-          // Assume all parameters are set in Jenkins 'Parameterized build'
-          // TODO(oskarth): Consider read/write from .env to avoid having to specify in Jenkins again
-          // sh 'cp .env.jenkins .env'
-          sh 'echo TESTFAIRY_ENABLED='           + TESTFAIRY_ENABLED            + '>>' + '.env'
-          sh 'echo ETHEREUM_DEV_CLUSTER='        + ETHEREUM_DEV_CLUSTER         + '>>' + '.env'
-          sh 'echo MAINNET_NETWORKS_ENABLED='    + MAINNET_NETWORKS_ENABLED     + '>>' + '.env'
-          sh 'echo LOG_LEVEL='                   + LOG_LEVEL                    + '>>' + '.env'
-          sh 'echo LOG_LEVEL_STATUS_GO='         + LOG_LEVEL_STATUS_GO          + '>>' + '.env'
-          sh 'echo OFFLINE_INBOX_ENABLED='       + OFFLINE_INBOX_ENABLED        + '>>' + '.env'
-          sh 'echo POW_TARGET='                  + POW_TARGET                   + '>>' + '.env'
-          sh 'echo POW_TIME='                    + POW_TIME                     + '>>' + '.env'
-          sh 'echo MAINNET_WARNING_ENABLED='     + MAINNET_WARNING_ENABLED      + '>>' + '.env'
-          sh 'echo DEFAULT_NETWORK='             + DEFAULT_NETWORK              + '>>' + '.env'
+        sh 'echo "**********************************************************************"'
+        sh 'echo PARAMETERIZED BUILD - USING CUSTOM ENVIRONMENT'
+        sh 'cat .env'
+        sh 'echo "**********************************************************************"'
 
-          sh 'echo "**********************************************************************"'
-          sh 'echo PARAMETERIZED BUILD - USING CUSTOM ENVIRONMENT'
-          sh 'cat .env'
-          sh 'echo "**********************************************************************"'
+        installJSDeps()
 
-          installJSDeps()
-
-          sh 'mvn -f modules/react-native-status/ios/RCTStatus dependency:unpack'
-          sh 'cd ios && pod install && cd ..'
-        }
-
-        stage('Tests') {
-          sh 'lein test-cljs'
-        }
-
-        stage('Build') {
-          sh 'lein prod-build'
-        }
-
-            // Android
-            stage('Build (Android)') {
-              sh 'cd android && ./gradlew react-native-android:installArchives && ./gradlew assembleRelease'
-            }
-            stage('Deploy (Android)') {
-                withCredentials([string(credentialsId: 'diawi-token', variable: 'token')]) {
-                    def job = sh(returnStdout: true, script: 'curl https://upload.diawi.com/ -F token='+token+' -F file=@android/app/build/outputs/apk/release/app-release.apk -F find_by_udid=0 -F wall_of_apps=0 | jq -r ".job"').trim()
-                    sh 'sleep 10'
-                    def hash = sh(returnStdout: true, script: "curl -vvv 'https://upload.diawi.com/status?token="+token+"&job="+job+"'|jq -r '.hash'").trim()
-                    apkUrl = 'https://i.diawi.com/' + hash
-
-                    sh ('echo ARTIFACT Android: ' + apkUrl)
-                }
-            }
-
-            // try {
-            //   stage('Test (Android)') {
-            //     sauce('b9aded57-5cc1-4f6b-b5ea-42d989987852') {
-            //         sh 'cd test/appium && mvn -DapkUrl=' + apkUrl + ' test'
-            //         saucePublisher()
-            //     }
-            //   }
-            // } catch(e) {
-            //   testPassed = false
-            // }
-
-        // iOS
-        stage('Build (iOS)') {
-              sh 'export RCT_NO_LAUNCH_PACKAGER=true && xcodebuild -workspace ios/StatusIm.xcworkspace -scheme StatusIm -configuration release -archivePath status clean archive'
-              sh 'xcodebuild -exportArchive -exportPath status -archivePath status.xcarchive -exportOptionsPlist ~/archive.plist'
-        }
-        stage('Deploy (iOS)') {
-            withCredentials([string(credentialsId: 'diawi-token', variable: 'token')]) {
-                def job = sh(returnStdout: true, script: 'curl https://upload.diawi.com/ -F token='+token+' -F file=@status/StatusIm.ipa -F find_by_udid=0 -F wall_of_apps=0 | jq -r ".job"').trim()
-                sh 'sleep 10'
-                def hash = sh(returnStdout: true, script: "curl -vvv 'https://upload.diawi.com/status?token="+token+"&job="+job+"'|jq -r '.hash'").trim()
-                ipaUrl = 'https://i.diawi.com/' + hash
-
-                sh ('echo ARTIFACT iOS: ' + ipaUrl)
-
-            }
-        }
-
-        stage('Slack Notification') {
-                def c = (testPassed ? 'good' : 'warning' )
-                slackSend color: c, message: 'Branch: ' + REPO + ":" + BRANCH_NAME +
-                '\nAndroid: ' + apkUrl +
-                '\niOS: ' + ipaUrl
-        }
-
-      } catch (e) {
-        slackSend color: 'bad', message: REPO + ":" + BRANCH_NAME + ' failed to build. ' + env.BUILD_URL
-        throw e
+        sh 'mvn -f modules/react-native-status/ios/RCTStatus dependency:unpack'
+        sh 'cd ios && pod install && cd ..'
       }
+
+      stage('Tests') {
+        sh 'lein test-cljs'
+      }
+
+      stage('Build') {
+        sh 'lein prod-build'
+      }
+
+      // Android
+      stage('Build (Android)') {
+        sh 'cd android && ./gradlew react-native-android:installArchives && ./gradlew assembleRelease'
+      }
+      stage('Deploy (Android)') {
+        withCredentials([string(credentialsId: 'diawi-token', variable: 'token')]) {
+          def job = sh(returnStdout: true, script: 'curl https://upload.diawi.com/ -F token='+token+' -F file=@android/app/build/outputs/apk/release/app-release.apk -F find_by_udid=0 -F wall_of_apps=0 | jq -r ".job"').trim()
+          sh 'sleep 10'
+          def hash = sh(returnStdout: true, script: "curl -vvv 'https://upload.diawi.com/status?token="+token+"&job="+job+"'|jq -r '.hash'").trim()
+          apkUrl = 'https://i.diawi.com/' + hash
+
+          sh ('echo ARTIFACT Android: ' + apkUrl)
+        }
+      }
+
+      // try {
+      //   stage('Test (Android)') {
+      //     sauce('b9aded57-5cc1-4f6b-b5ea-42d989987852') {
+      //         sh 'cd test/appium && mvn -DapkUrl=' + apkUrl + ' test'
+      //         saucePublisher()
+      //     }
+      //   }
+      // } catch(e) {
+      //   testPassed = false
+      // }
+
+      // iOS
+      stage('Build (iOS)') {
+        env.RCT_NO_LAUNCH_PACKAGER = true
+        sh 'xcodebuild -workspace ios/StatusIm.xcworkspace -scheme StatusIm -configuration release -archivePath status clean archive'
+        sh 'xcodebuild -exportArchive -exportPath status -archivePath status.xcarchive -exportOptionsPlist ios/archive-develop.plist'
+      }
+      stage('Deploy (iOS)') {
+        withCredentials([string(credentialsId: 'diawi-token', variable: 'token')]) {
+          def job = sh(returnStdout: true, script: 'curl https://upload.diawi.com/ -F token='+token+' -F file=@status/StatusIm.ipa -F find_by_udid=0 -F wall_of_apps=0 | jq -r ".job"').trim()
+          sh 'sleep 10'
+          def hash = sh(returnStdout: true, script: "curl -vvv 'https://upload.diawi.com/status?token="+token+"&job="+job+"'|jq -r '.hash'").trim()
+          ipaUrl = 'https://i.diawi.com/' + hash
+
+          sh ('echo ARTIFACT iOS: ' + ipaUrl)
+        }
+      }
+
+      stage('Slack Notification') {
+        def c = (testPassed ? 'good' : 'warning' )
+        slackSend(
+          color: c,
+          message: "Branch: ${REPO}:${BRANCH_NAME}\nAndroid: ${apkUrl}\niOS: ${ipaUrl}"
+        )
+      }
+
+    } catch (e) {
+      slackSend color: 'bad', message: REPO + ":" + BRANCH_NAME + ' failed to build. ' + env.BUILD_URL
+        throw e
     }
+  }
 }

--- a/ci/Jenkinsfile.release
+++ b/ci/Jenkinsfile.release
@@ -75,10 +75,11 @@ timeout(90) {
         }
 
         stage('Build (iOS)') {
-          sh ('plutil -replace CFBundleShortVersionString  -string ' + version + ' ios/StatusIm/Info.plist')
-          sh ('plutil -replace CFBundleVersion  -string ' + build_no + ' ios/StatusIm/Info.plist')
-          sh 'export RCT_NO_LAUNCH_PACKAGER=true && xcodebuild -workspace ios/StatusIm.xcworkspace -scheme StatusIm -configuration release -archivePath status clean archive'
-          sh 'xcodebuild -exportArchive -exportPath status -archivePath status.xcarchive -exportOptionsPlist ~/archive.plist'
+          sh "plutil -replace CFBundleShortVersionString  -string ${version} ios/StatusIm/Info.plist"
+          sh "plutil -replace CFBundleVersion  -string ${build_no} ios/StatusIm/Info.plist"
+          env.RCT_NO_LAUNCH_PACKAGER = true
+          sh 'xcodebuild -workspace ios/StatusIm.xcworkspace -scheme StatusIm -configuration release -archivePath status clean archive'
+          sh 'xcodebuild -exportArchive -exportPath status -archivePath status.xcarchive -exportOptionsPlist ios/archive-develop.plist'
         }
 
         stage('Deploy (Android)') {

--- a/ci/Jenkinsfile.upload_release_ios
+++ b/ci/Jenkinsfile.upload_release_ios
@@ -75,11 +75,12 @@ timeout(90) {
 
         stage('Build (iOS)') {
           withCredentials([string(credentialsId: 'jenkins_pass', variable: 'password')]) {
-            sh ('plutil -replace CFBundleShortVersionString  -string ' + version + ' ios/StatusIm/Info.plist')
-            sh ('plutil -replace CFBundleVersion  -string ' + build_no + ' ios/StatusIm/Info.plist')
-            sh 'export RCT_NO_LAUNCH_PACKAGER=true && xcodebuild -workspace ios/StatusIm.xcworkspace -scheme StatusIm -configuration release -archivePath status clean archive'
-            sh ('security unlock-keychain -p ' + password + ' login.keychain')
-            sh 'xcodebuild -exportArchive -exportPath status_appstore -archivePath status.xcarchive -exportOptionsPlist ~/archive-release.plist'
+            sh "plutil -replace CFBundleShortVersionString  -string ${version} ios/StatusIm/Info.plist"
+            sh "plutil -replace CFBundleVersion  -string ${build_no} ios/StatusIm/Info.plist"
+            env.RCT_NO_LAUNCH_PACKAGER = true
+            sh 'xcodebuild -workspace ios/StatusIm.xcworkspace -scheme StatusIm -configuration release -archivePath status clean archive'
+            sh "security unlock-keychain -p ${password} login.keychain"
+            sh 'xcodebuild -exportArchive -exportPath status_appstore -archivePath status.xcarchive -exportOptionsPlist ios/archive-release.plist'
           }
         }
 

--- a/ios/archive-develop.plist
+++ b/ios/archive-develop.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>teamID</key>
+    <string>DTX7Z4U3YA</string>
+    <key>method</key>
+    <string>development</string>
+</dict>
+</plist>

--- a/ios/archive-release.plist
+++ b/ios/archive-release.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>teamID</key>
+    <string>DTX7Z4U3YA</string>
+    <key>method</key>
+    <string>app-store</string>
+    <key>uploadBitcode</key>
+    <false/>
+    <key>compileBitcode</key>
+    <true/>
+    <key>ITSAppUsesNonExemptEncryption</key>
+    <false/>
+</dict>
+</plist>


### PR DESCRIPTION
This is a fix for Jenkins nightlies failing on the new `macos2` host:
https://ci.status.im/job/status-react/job/nightly/541/
```
+ xcodebuild -exportArchive -exportPath status_appstore -archivePath status.xcarchive -exportOptionsPlist /Users/jenkins/archive-release.plist
error: Couldn't load -exportOptionsPlist: The file “archive-release.plist” couldn’t be opened because there is no such file.

Error Domain=NSCocoaErrorDomain Code=260 "The file “archive-release.plist” couldn’t be opened because there is no such file." UserInfo={NSFilePath=/Users/jenkins/archive-release.plist, NSUnderlyingError=0x7f8812a792a0 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}

** EXPORT FAILED **
```
This fails because the build depends on files existing in `jenkins` user home dir:
/Users/jenkins/archive-release.plist

That's awful, so I've added them to the repo. Not sure if the `ios` folder is the right place though.

The Team ID is not secret, it's already here:
https://github.com/status-im/status-react/blob/develop/ios/StatusIm.xcodeproj/project.pbxproj#L1189

<blockquote><img src="/static/d6f7b33b/favicon.ico" width="48" align="right"><div><strong><a href="https://ci.status.im/job/status-react/job/nightly/541/">status-react » nightly #541 [Jenkins]</a></strong></div></blockquote>
<blockquote><img src="https://avatars3.githubusercontent.com/u/11767950?s=400&v=4" width="48" align="right"><div><img src="https://assets-cdn.github.com/favicon.ico" height="14"> GitHub</div><div><strong><a href="https://github.com/status-im/status-react">status-im/status-react</a></strong></div><div>status-react - a free (libre) open source, mobile OS for Ethereum</div></blockquote>