### PR TITLE
#5028 Option to use ENS address instead of contact code

### DIFF
--- a/src/status_im/translations/en.cljs
+++ b/src/status_im/translations/en.cljs
@@ -295,7 +295,7 @@
    :copy-qr                              "Copy code"
    :qr-code-public-key-hint              "Share this code to \nstart chatting"
    :enter-address                        "Enter address"
-   :enter-contact-code                   "Enter contact code"
+   :enter-contact-code                   "Enter contact code or username"
    :more                                 "more"
 
    ;;group-settings
@@ -362,7 +362,7 @@
    :specify-name                         "Specify a name"
    :address-explication                  "Your public key is used to generate your address on Ethereum and is a series of numbers and letters. You can find it easily in your profile"
    :unable-to-read-this-code             "Unable to read this code"
-   :use-valid-contact-code               "Please scan a valid contact code"
+   :use-valid-contact-code               "Please enter or scan a valid contact code or username"
    :enter-valid-public-key               "Please enter a valid public key or scan a QR code"
    :contact-already-added                "The contact has already been added"
    :can-not-add-yourself                 "You can't add yourself"

--- a/src/status_im/ui/screens/add_new/new_chat/db.cljs
+++ b/src/status_im/ui/screens/add_new/new_chat/db.cljs
@@ -4,7 +4,7 @@
             [cljs.spec.alpha :as spec]
             [clojure.string :as string]))
 
-(defn- validate-pub-key [whisper-identity {:keys [address public-key]}]
+(defn validate-pub-key [whisper-identity {:keys [address public-key]}]
   (cond
     (string/blank? whisper-identity)
     (i18n/label :t/use-valid-contact-code)

--- a/src/status_im/ui/screens/add_new/new_chat/events.cljs
+++ b/src/status_im/ui/screens/add_new/new_chat/events.cljs
@@ -1,0 +1,30 @@
+(ns status-im.ui.screens.add-new.new-chat.events
+  (:require [re-frame.core :as re-frame]
+            [status-im.utils.handlers :as handlers]
+            [status-im.utils.handlers-macro :as handlers-macro]
+            [status-im.ui.screens.add-new.new-chat.db :as db]
+            [status-im.utils.ethereum.stateofus :as stateofus]
+            [status-im.utils.ethereum.ens :as ens]
+            [status-im.utils.ethereum.core :as ethereum]))
+
+(re-frame/reg-fx
+ :resolve-whisper-identity
+ (fn [{:keys [web3 registry ens-name cb]}]
+   (println registry ens-name)
+   (stateofus/text web3 registry ens-name cb)))
+
+(handlers/register-handler-fx
+ :new-chat/set-new-identity
+ (fn [{{:keys [web3 network network-status] :as db} :db} [_ new-identity]]
+   (let [new-identity-error (db/validate-pub-key new-identity (:account/account db))]
+     (if (stateofus/is-stateofus-name? new-identity)
+       (let [network (get-in db [:account/account :networks network])
+             chain   (ethereum/network->chain-keyword network)]
+         {:resolve-whisper-identity {:web3 web3
+                                     :registry (get ens/ens-registries
+                                                    chain)
+                                     :ens-name new-identity
+                                     :cb #(re-frame/dispatch [:new-chat/set-new-identity %])}})
+       {:db (assoc db
+                   :contacts/new-identity       new-identity
+                   :contacts/new-identity-error new-identity-error)}))))

--- a/src/status_im/ui/screens/add_new/new_chat/events.cljs
+++ b/src/status_im/ui/screens/add_new/new_chat/events.cljs
@@ -17,7 +17,7 @@
  :new-chat/set-new-identity
  (fn [{{:keys [web3 network network-status] :as db} :db} [_ new-identity]]
    (let [new-identity-error (db/validate-pub-key new-identity (:account/account db))]
-     (if (stateofus/is-stateofus-name? new-identity)
+     (if (stateofus/is-valid-name? new-identity)
        (let [network (get-in db [:account/account :networks network])
              chain   (ethereum/network->chain-keyword network)]
          {:resolve-whisper-identity {:web3 web3

--- a/src/status_im/ui/screens/add_new/new_chat/subs.cljs
+++ b/src/status_im/ui/screens/add_new/new_chat/subs.cljs
@@ -1,10 +1,6 @@
 (ns status-im.ui.screens.add-new.new-chat.subs
-  (:require [re-frame.core :as re-frame]
-            [status-im.ui.screens.add-new.new-chat.db :as db]))
+  (:require [re-frame.core :as re-frame]))
 
-(re-frame/reg-sub
- :new-contact-error-message
- :<- [:get :contacts/new-identity]
- :<- [:get-current-account]
- (fn [[new-identity account]]
-   (db/validate-pub-key new-identity account)))
+(re-frame/reg-sub :new-identity-error
+                  (fn [db _]
+                    (get db :contacts/new-identity-error nil)))

--- a/src/status_im/ui/screens/add_new/new_chat/views.cljs
+++ b/src/status_im/ui/screens/add_new/new_chat/views.cljs
@@ -20,13 +20,13 @@
 
 (views/defview new-chat []
   (views/letsubs [contacts      [:all-added-people-contacts]
-                  error-message [:new-contact-error-message]]
+                  error-message [:new-identity-error]]
     [react/keyboard-avoiding-view open-dapp.styles/main-container
      [status-bar/status-bar]
      [toolbar.view/simple-toolbar (i18n/label :t/new-chat)]
      [react/view add-new.styles/new-chat-container
       [react/view add-new.styles/new-chat-input-container
-       [react/text-input {:on-change-text      #(re-frame/dispatch [:set :contacts/new-identity %])
+       [react/text-input {:on-change-text      #(re-frame/dispatch [:new-chat/set-new-identity %])
                           :on-submit-editing   #(when-not error-message
                                                   (re-frame/dispatch [:add-contact-handler]))
                           :placeholder         (i18n/label :t/enter-contact-code)

--- a/src/status_im/ui/screens/contacts/db.cljs
+++ b/src/status_im/ui/screens/contacts/db.cljs
@@ -70,7 +70,7 @@
 (spec/def :contacts/contacts (spec/nilable (spec/map-of :global/not-empty-string :contact/contact)))
 ;public key of new contact during adding this new contact
 (spec/def :contacts/new-identity (spec/nilable string?))
-(spec/def :contacts/new-public-key-error (spec/nilable string?))
+(spec/def :contacts/new-identity-error (spec/nilable string?))
 ;on showing this contact's profile (andrey: better to move into profile ns)
 (spec/def :contacts/identity (spec/nilable :global/not-empty-string))
 (spec/def :contacts/list-ui-props (spec/nilable (allowed-keys :opt-un [:contact-list-ui/edit?])))

--- a/src/status_im/ui/screens/db.cljs
+++ b/src/status_im/ui/screens/db.cljs
@@ -174,7 +174,7 @@
                 [:contacts/contacts
                  :contacts/dapps
                  :contacts/new-identity
-                 :contacts/new-public-key-error
+                 :contacts/new-identity-error
                  :contacts/identity
                  :contacts/ui-props
                  :contacts/list-ui-props

--- a/src/status_im/ui/screens/events.cljs
+++ b/src/status_im/ui/screens/events.cljs
@@ -7,6 +7,7 @@
             status-im.ui.screens.accounts.login.events
             status-im.ui.screens.accounts.recover.events
             [status-im.ui.screens.contacts.events :as contacts]
+            status-im.ui.screens.add-new.new-chat.events
             status-im.ui.screens.group.chat-settings.events
             status-im.ui.screens.group.events
             [status-im.ui.screens.navigation :as navigation]

--- a/src/status_im/utils/ethereum/core.cljs
+++ b/src/status_im/utils/ethereum/core.cljs
@@ -97,7 +97,11 @@
 (defn hex->bignumber [s]
   (money/bignumber (if (= s hex-prefix) 0 s)))
 
-(defn hex->address [s]
+(defn hex->address
+  "When hex value is 66 char in length (2 for 0x, 64 for
+  the 32 bytes used by abi-spec for an address), only keep
+  the part that constitute the address and normalize it,"
+  [s]
   (when (= 66 (count s))
     (normalized-address (subs s 26))))
 

--- a/src/status_im/utils/ethereum/core.cljs
+++ b/src/status_im/utils/ethereum/core.cljs
@@ -70,8 +70,15 @@
       network->chain-keyword
       name))
 
-(defn sha3 [s]
-  (.sha3 dependencies/Web3.prototype (str s)))
+(defn sha3
+  ([s]
+   (.sha3 dependencies/Web3.prototype (str s)))
+  ([s opts]
+   (.sha3 dependencies/Web3.prototype (str s) (clj->js opts))))
+
+(defn hex->string [s]
+  (when s
+    (.toAscii dependencies/Web3.prototype s)))
 
 (defn hex->boolean [s]
   (= s "0x0"))

--- a/src/status_im/utils/ethereum/core.cljs
+++ b/src/status_im/utils/ethereum/core.cljs
@@ -87,7 +87,9 @@
   (if b "0x0" "0x1"))
 
 (defn hex->int [s]
-  (js/parseInt s 16))
+  (if (= s hex-prefix)
+    0
+    (js/parseInt s 16)))
 
 (defn int->hex [i]
   (.toHex dependencies/Web3.prototype i))
@@ -95,8 +97,15 @@
 (defn hex->bignumber [s]
   (money/bignumber (if (= s hex-prefix) 0 s)))
 
+(defn hex->address [s]
+  (when (= 66 (count s))
+    (normalized-address (subs s 26))))
+
 (defn zero-pad-64 [s]
   (str (apply str (drop (count s) (repeat 64 "0"))) s))
+
+(defn string->hex [i]
+  (.fromAscii dependencies/Web3.prototype i))
 
 (defn format-param [param]
   (if (number? param)

--- a/src/status_im/utils/ethereum/eip165.cljs
+++ b/src/status_im/utils/ethereum/eip165.cljs
@@ -1,0 +1,22 @@
+(ns status-im.utils.ethereum.eip165
+  "Utility function related to [EIP165](https://eips.ethereum.org/EIPS/eip-165)"
+  (:require [status-im.utils.ethereum.core :as ethereum]))
+
+(def supports-interface-hash "0x01ffc9a7")
+(def marker-hash "0xffffffff")
+
+(defn supports-interface? [web3 contract hash cb]
+  (ethereum/call web3
+                 (ethereum/call-params contract "supportsInterface(bytes4)" hash)
+                 #(cb %1 %2)))
+
+(defn supports?
+  "Calls cb with true if `supportsInterface` is supported by this contract.
+   See EIP for details."
+  [web3 contract cb]
+  (supports-interface? web3 contract supports-interface-hash
+                       #(if (true? (ethereum/hex->boolean %2))
+                          (supports-interface? web3 contract marker-hash
+                                               (fn [o oo]
+                                                 (cb o (false? (ethereum/hex->boolean oo)))))
+                          (cb %1 false))))

--- a/src/status_im/utils/ethereum/eip681.cljs
+++ b/src/status_im/utils/ethereum/eip681.cljs
@@ -1,5 +1,5 @@
 (ns status-im.utils.ethereum.eip681
-  "Utility function related to [EIP681](https://github.com/ethereum/EIPs/issues/681)
+  "Utility function related to [EIP681](https://eips.ethereum.org/EIPS/eip-681)
 
    This EIP standardize how ethereum payment request can be represented as URI (say to embed them in a QR code).
 

--- a/src/status_im/utils/ethereum/ens.cljs
+++ b/src/status_im/utils/ethereum/ens.cljs
@@ -48,12 +48,6 @@
                  (fn [_ ttl] (cb (ethereum/hex->int ttl)))))
 
 ;; Resolver contract
-
-(def status-resolvers
-  {:mainnet "0x314159265dd8dbb310642f98f50c066173c1259b"
-   :ropsten "0x5FfC014343cd971B7eb70732021E26C35B744cc4"
-   :rinkeby "0xe7410170f87102DF0055eB195163A03B7F2Bff4A"})
-
 ;; Resolver must implement EIP65 (supportsInterface). When interacting with an unknown resolver it's safer to rely on it.
 
 (def addr-hash "0x3b3b57de")
@@ -62,13 +56,6 @@
   (ethereum/call web3
                  (ethereum/call-params resolver "addr(bytes32)" (namehash ens-name))
                  (fn [_ address] (cb (ethereum/hex->address address)))))
-
-(defn content [web3 resolver ens-name cb]
-  (ethereum/call web3
-                 (ethereum/call-params resolver
-                                       "content(bytes32)"
-                                       (namehash ens-name))
-                 (fn [_ content] (cb content #_(ethereum/hex->string content)))))
 
 (def name-hash "0x691f3431")
 
@@ -81,30 +68,7 @@
                                        (namehash ens-name))
                  (fn [_ address] (cb (ethereum/hex->address address)))))
 
-(defn text [web3 resolver ens-name key cb]
-  (ethereum/call web3
-                 (ethereum/call-params resolver
-                                       "text(bytes32)"
-                                       (namehash ens-name)
-                                       (ethereum/string->hex key))
-                 (fn [err text] (cb err text))))
-
 (def ABI-hash "0x2203ab56")
 (def pubkey-hash "0xc8690233")
 
 ;; TODO ABI, pubkey
-
-(comment
-  (let [web3-o (:web3 @re-frame.db/app-db)]
-    (resolver web3-o (:ropsten ens-registries) "test.stateofus.eth" println))
-
-  (let [web3-o (:web3 @re-frame.db/app-db)]
-    (addr web3-o  "0x5FfC014343cd971B7eb70732021E26C35B744cc4" "test.stateofus.eth" #(println %)))
-
-  (let [web3-o (:web3 @re-frame.db/app-db)]
-    (text web3-o  "0x5FfC014343cd971B7eb70732021E26C35B744cc4" "test.stateofus.eth" "statusAccount" println))
-
-  (ethereum/call-params "0x5FfC014343cd971B7eb70732021E26C35B744cc4"
-                        "text(bytes32,string)"
-                        (namehash "test.stateofus.eth")
-                        (ethereum/string->hex "statusAccount")))

--- a/src/status_im/utils/ethereum/ens.cljs
+++ b/src/status_im/utils/ethereum/ens.cljs
@@ -11,7 +11,7 @@
 ;; this is the addresses of ens registries for the different networks
 (def ens-registries
   {:mainnet "0x314159265dd8dbb310642f98f50c066173c1259b"
-   :ropsten "0x112234455c3a32fd11230c42e7bccd4a84e02010"
+   :testnet "0x112234455c3a32fd11230c42e7bccd4a84e02010"
    :rinkeby "0xe7410170f87102DF0055eB195163A03B7F2Bff4A"})
 
 (def default-namehash "0000000000000000000000000000000000000000000000000000000000000000")

--- a/src/status_im/utils/ethereum/ens.cljs
+++ b/src/status_im/utils/ethereum/ens.cljs
@@ -1,0 +1,73 @@
+(ns status-im.utils.ethereum.ens
+  "
+  https://docs.ens.domains/en/latest/index.html
+  https://eips.ethereum.org/EIPS/eip-137
+  https://eips.ethereum.org/EIPS/eip-181
+  "
+  (:require [clojure.string :as string]
+            [status-im.utils.ethereum.core :as ethereum]))
+
+(def registries
+  {:mainnet "0x314159265dd8dbb310642f98f50c066173c1259b"
+   :ropsten "0x112234455c3a32fd11230c42e7bccd4a84e02010"
+   :rinkeby "0xe7410170f87102DF0055eB195163A03B7F2Bff4A"})
+
+(def default-namehash "0000000000000000000000000000000000000000000000000000000000000000")
+
+(defn namehash [s]
+  (if (string/blank? s)
+    default-namehash
+    (let [[label remainder] (string/split s #"\." 2)]
+      (ethereum/sha3 (+ (namehash remainder) (subs (ethereum/sha3 label) 2)) {:encoding "hex"}))))
+
+;; Registry contract
+
+(defn resolver [web3 registry name cb]
+  (ethereum/call web3
+                 (ethereum/call-params registry "resolver(bytes32)" (namehash name))
+                 #(cb %1 (ethereum/hex->string %2))))
+
+(defn owner [web3 registry name cb]
+  (ethereum/call web3
+                 (ethereum/call-params registry "owner(bytes32)" (namehash name))
+                 #(cb %1 (ethereum/hex->string %2))))
+
+(defn ttl [web3 registry name cb]
+  (ethereum/call web3
+                 (ethereum/call-params registry "ttl(bytes32)" (namehash name))
+                 #(cb %1 (ethereum/hex->int %2))))
+
+;; Resolver contract
+
+;; Resolver must implement EIP65 (supportsInterface). When interacting with an unknown resolver it's safer to rely on it.
+
+(def addr-hash "0x3b3b57de")
+
+(defn addr [web3 resolver name cb]
+  (ethereum/call web3
+                 (ethereum/call-params resolver "addr(bytes32)" (namehash name))
+                 #(cb %1 %2)))
+
+(defn content [web3 resolver name cb]
+  (ethereum/call web3
+                 (ethereum/call-params resolver "content(bytes32)" (namehash name))
+                 #(cb %1 (ethereum/hex->string %2))))
+
+(def name-hash "0x691f3431")
+
+;; Defined by https://eips.ethereum.org/EIPS/eip-181
+
+(defn name [web3 resolver name cb]
+  (ethereum/call web3
+                 (ethereum/call-params resolver "name(bytes32)" (namehash name))
+                 #(cb %1 (ethereum/hex->string %2))))
+
+(defn text [web3 resolver name key cb]
+  (ethereum/call web3
+                 (ethereum/call-params resolver "text(bytes32,string)" (namehash name) key)
+                 #(cb %1 (ethereum/hex->string %2))))
+
+(def ABI-hash "0x2203ab56")
+(def pubkey-hash "0xc8690233")
+
+;; TODO ABI, pubkey

--- a/src/status_im/utils/ethereum/ens.cljs
+++ b/src/status_im/utils/ethereum/ens.cljs
@@ -19,7 +19,9 @@
 (defn namehash [s]
   (ethereum/normalized-address (if (string/blank? s)
                                  default-namehash
-                                 (let [[label remainder] (string/split s #"\." 2)]
+                                 (let [[label remainder] (-> s
+                                                             string/lower-case
+                                                             (string/split #"\." 2))]
                                    (ethereum/sha3 (+ (namehash remainder)
                                                      (subs (ethereum/sha3 label) 2))
                                                   {:encoding "hex"})))))

--- a/src/status_im/utils/ethereum/ens.cljs
+++ b/src/status_im/utils/ethereum/ens.cljs
@@ -4,10 +4,12 @@
   https://eips.ethereum.org/EIPS/eip-137
   https://eips.ethereum.org/EIPS/eip-181
   "
+  (:refer-clojure :exclude [name])
   (:require [clojure.string :as string]
             [status-im.utils.ethereum.core :as ethereum]))
 
-(def registries
+;; this is the addresses of ens registries for the different networks
+(def ens-registries
   {:mainnet "0x314159265dd8dbb310642f98f50c066173c1259b"
    :ropsten "0x112234455c3a32fd11230c42e7bccd4a84e02010"
    :rinkeby "0xe7410170f87102DF0055eB195163A03B7F2Bff4A"})
@@ -15,59 +17,94 @@
 (def default-namehash "0000000000000000000000000000000000000000000000000000000000000000")
 
 (defn namehash [s]
-  (if (string/blank? s)
-    default-namehash
-    (let [[label remainder] (string/split s #"\." 2)]
-      (ethereum/sha3 (+ (namehash remainder) (subs (ethereum/sha3 label) 2)) {:encoding "hex"}))))
+  (ethereum/normalized-address (if (string/blank? s)
+                                 default-namehash
+                                 (let [[label remainder] (string/split s #"\." 2)]
+                                   (ethereum/sha3 (+ (namehash remainder)
+                                                     (subs (ethereum/sha3 label) 2))
+                                                  {:encoding "hex"})))))
 
 ;; Registry contract
 
-(defn resolver [web3 registry name cb]
+(defn resolver [web3 registry ens-name cb]
   (ethereum/call web3
-                 (ethereum/call-params registry "resolver(bytes32)" (namehash name))
-                 #(cb %1 (ethereum/hex->string %2))))
+                 (ethereum/call-params registry
+                                       "resolver(bytes32)"
+                                       (namehash ens-name))
+                 (fn [_ address] (cb  (ethereum/hex->address address)))))
 
-(defn owner [web3 registry name cb]
+(defn owner [web3 registry ens-name cb]
   (ethereum/call web3
-                 (ethereum/call-params registry "owner(bytes32)" (namehash name))
-                 #(cb %1 (ethereum/hex->string %2))))
+                 (ethereum/call-params registry
+                                       "owner(bytes32)"
+                                       (namehash ens-name))
+                 (fn [_ address] (cb address))))
 
-(defn ttl [web3 registry name cb]
+(defn ttl [web3 registry ens-name cb]
   (ethereum/call web3
-                 (ethereum/call-params registry "ttl(bytes32)" (namehash name))
-                 #(cb %1 (ethereum/hex->int %2))))
+                 (ethereum/call-params registry
+                                       "ttl(bytes32)"
+                                       (namehash ens-name))
+                 (fn [_ ttl] (cb (ethereum/hex->int ttl)))))
 
 ;; Resolver contract
+
+(def status-resolvers
+  {:mainnet "0x314159265dd8dbb310642f98f50c066173c1259b"
+   :ropsten "0x5FfC014343cd971B7eb70732021E26C35B744cc4"
+   :rinkeby "0xe7410170f87102DF0055eB195163A03B7F2Bff4A"})
 
 ;; Resolver must implement EIP65 (supportsInterface). When interacting with an unknown resolver it's safer to rely on it.
 
 (def addr-hash "0x3b3b57de")
 
-(defn addr [web3 resolver name cb]
+(defn addr [web3 resolver ens-name cb]
   (ethereum/call web3
-                 (ethereum/call-params resolver "addr(bytes32)" (namehash name))
-                 #(cb %1 %2)))
+                 (ethereum/call-params resolver "addr(bytes32)" (namehash ens-name))
+                 (fn [_ address] (cb (ethereum/hex->address address)))))
 
-(defn content [web3 resolver name cb]
+(defn content [web3 resolver ens-name cb]
   (ethereum/call web3
-                 (ethereum/call-params resolver "content(bytes32)" (namehash name))
-                 #(cb %1 (ethereum/hex->string %2))))
+                 (ethereum/call-params resolver
+                                       "content(bytes32)"
+                                       (namehash ens-name))
+                 (fn [_ content] (cb content #_(ethereum/hex->string content)))))
 
 (def name-hash "0x691f3431")
 
 ;; Defined by https://eips.ethereum.org/EIPS/eip-181
 
-(defn name [web3 resolver name cb]
+(defn name [web3 resolver ens-name cb]
   (ethereum/call web3
-                 (ethereum/call-params resolver "name(bytes32)" (namehash name))
-                 #(cb %1 (ethereum/hex->string %2))))
+                 (ethereum/call-params resolver
+                                       "name(bytes32)"
+                                       (namehash ens-name))
+                 (fn [_ address] (cb (ethereum/hex->address address)))))
 
-(defn text [web3 resolver name key cb]
+(defn text [web3 resolver ens-name key cb]
   (ethereum/call web3
-                 (ethereum/call-params resolver "text(bytes32,string)" (namehash name) key)
-                 #(cb %1 (ethereum/hex->string %2))))
+                 (ethereum/call-params resolver
+                                       "text(bytes32)"
+                                       (namehash ens-name)
+                                       (ethereum/string->hex key))
+                 (fn [err text] (cb err text))))
 
 (def ABI-hash "0x2203ab56")
 (def pubkey-hash "0xc8690233")
 
 ;; TODO ABI, pubkey
+
+(comment
+  (let [web3-o (:web3 @re-frame.db/app-db)]
+    (resolver web3-o (:ropsten ens-registries) "test.stateofus.eth" println))
+
+  (let [web3-o (:web3 @re-frame.db/app-db)]
+    (addr web3-o  "0x5FfC014343cd971B7eb70732021E26C35B744cc4" "test.stateofus.eth" #(println %)))
+
+  (let [web3-o (:web3 @re-frame.db/app-db)]
+    (text web3-o  "0x5FfC014343cd971B7eb70732021E26C35B744cc4" "test.stateofus.eth" "statusAccount" println))
+
+  (ethereum/call-params "0x5FfC014343cd971B7eb70732021E26C35B744cc4"
+                        "text(bytes32,string)"
+                        (namehash "test.stateofus.eth")
+                        (ethereum/string->hex "statusAccount")))

--- a/src/status_im/utils/ethereum/stateofus.cljs
+++ b/src/status_im/utils/ethereum/stateofus.cljs
@@ -4,11 +4,11 @@
             [status-im.utils.ethereum.core :as ethereum]
             [status-im.utils.ethereum.ens :as ens]))
 
-(defn is-stateofus-name? [ens-name]
+(defn is-valid-name? [ens-name]
   (string/ends-with? ens-name ".stateofus.eth"))
 
 (defn addr [web3 registry ens-name cb]
-  {:pre [(is-stateofus-name? ens-name)]}
+  {:pre [(is-valid-name? ens-name)]}
   (ens/resolver web3
                 registry
                 ens-name
@@ -19,7 +19,7 @@
   TODO: https://solidity.readthedocs.io/en/develop/abi-spec.html needs to be implemented
   to replace this by dynamic parameters"
   [web3 registry ens-name cb]
-  {:pre [(is-stateofus-name? ens-name)]}
+  {:pre [(is-valid-name? ens-name)]}
   (ens/resolver web3
                 registry
                 ens-name

--- a/src/status_im/utils/ethereum/stateofus.cljs
+++ b/src/status_im/utils/ethereum/stateofus.cljs
@@ -4,6 +4,31 @@
             [status-im.utils.ethereum.core :as ethereum]
             [status-im.utils.ethereum.ens :as ens]))
 
-(defn name [web3 registry name cb]
-  (ens/resolver web3 registry name
-                #(ens/name web3 %2 name cb)))
+(defn is-stateofus-name? [ens-name]
+  (string/ends-with? ens-name ".stateofus.eth"))
+
+(defn addr [web3 registry ens-name cb]
+  {:pre [(is-stateofus-name? ens-name)]}
+  (ens/resolver web3
+                registry
+                ens-name
+                #(ens/addr web3 % ens-name cb)))
+
+(defn text
+  "calls the text function on the stateofus resolver contract for `statusAccount` key
+  TODO: https://solidity.readthedocs.io/en/develop/abi-spec.html needs to be implemented
+  to replace this by dynamic parameters"
+  [web3 registry ens-name cb]
+  {:pre [(is-stateofus-name? ens-name)]}
+  (ens/resolver web3
+                registry
+                ens-name
+                #(ethereum/call web3
+                                {:to %
+                                 :data (str "0x59d1d43c"
+                                            (subs (ens/namehash ens-name) 2)
+                                            "0000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000d7374617475734163636f756e7400000000000000000000000000000000000000")}
+                                (fn [_ text] (cb (ethereum/hex->string (subs text 130 214)))))))
+
+#_(addr (:web3 @re-frame.db/app-db) "0x112234455c3a32fd11230c42e7bccd4a84e02010" "test.stateofus.eth" println)
+#_(text (:web3 @re-frame.db/app-db) "0x112234455c3a32fd11230c42e7bccd4a84e02010" "test.stateofus.eth" println)

--- a/src/status_im/utils/ethereum/stateofus.cljs
+++ b/src/status_im/utils/ethereum/stateofus.cljs
@@ -28,7 +28,7 @@
                                  :data (str "0x59d1d43c"
                                             (subs (ens/namehash ens-name) 2)
                                             "0000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000d7374617475734163636f756e7400000000000000000000000000000000000000")}
-                                (fn [_ text] (cb (ethereum/hex->string (subs text 130 214)))))))
+                                (fn [_ text] (cb (ethereum/hex->string (subs text 130 394)))))))
 
-#_(addr (:web3 @re-frame.db/app-db) "0x112234455c3a32fd11230c42e7bccd4a84e02010" "test.stateofus.eth" println)
-#_(text (:web3 @re-frame.db/app-db) "0x112234455c3a32fd11230c42e7bccd4a84e02010" "test.stateofus.eth" println)
+#_(addr (:web3 @re-frame.db/app-db) "0x112234455c3a32fd11230c42e7bccd4a84e02010" "erictest.stateofus.eth" println)
+#_(text (:web3 @re-frame.db/app-db) "0x112234455c3a32fd11230c42e7bccd4a84e02010" "erictest.stateofus.eth" println)

--- a/src/status_im/utils/ethereum/stateofus.cljs
+++ b/src/status_im/utils/ethereum/stateofus.cljs
@@ -1,0 +1,8 @@
+(ns status-im.utils.ethereum.stateofus
+  (:require [clojure.string :as string]
+            [status-im.utils.ethereum.core :as ethereum]
+            [status-im.utils.ethereum.ens :as ens]))
+
+(defn name [web3 registry name cb]
+  (ens/resolver web3 registry name
+                #(ens/name web3 %2 name cb)))

--- a/src/status_im/utils/ethereum/stateofus.cljs
+++ b/src/status_im/utils/ethereum/stateofus.cljs
@@ -1,4 +1,5 @@
 (ns status-im.utils.ethereum.stateofus
+  (:refer-clojure :exclude [name])
   (:require [clojure.string :as string]
             [status-im.utils.ethereum.core :as ethereum]
             [status-im.utils.ethereum.ens :as ens]))

--- a/test/cljs/status_im/test/runner.cljs
+++ b/test/cljs/status_im/test/runner.cljs
@@ -35,6 +35,7 @@
             [status-im.test.utils.clocks]
             [status-im.test.utils.ethereum.eip681]
             [status-im.test.utils.ethereum.core]
+            [status-im.test.utils.ethereum.ens]
             [status-im.test.utils.random]
             [status-im.test.utils.gfycat.core]
             [status-im.test.utils.signing-phrase.core]
@@ -93,6 +94,7 @@
  'status-im.test.utils.clocks
  'status-im.test.utils.ethereum.eip681
  'status-im.test.utils.ethereum.core
+ 'status-im.test.utils.ethereum.ens
  'status-im.test.utils.random
  'status-im.test.utils.gfycat.core
  'status-im.test.utils.signing-phrase.core

--- a/test/cljs/status_im/test/utils/ethereum/ens.cljs
+++ b/test/cljs/status_im/test/utils/ethereum/ens.cljs
@@ -3,8 +3,8 @@
             [status-im.utils.ethereum.ens :as ens]))
 
 (deftest namehash
-  (is (= ens/default-namehash (ens/namehash nil)))
-  (is (= ens/default-namehash (ens/namehash "")))
+  (is (= (str "0x" ens/default-namehash) (ens/namehash nil)))
+  (is (= (str "0x" ens/default-namehash) (ens/namehash "")))
   (is (= "0x93cdeb708b7545dc668eb9280176169d1c33cfd8ed6f04690a0bcc88a93fc4ae"
          (ens/namehash "eth")))
   (is (= "0xde9b09fd7c5f901e23a3f19fecc54828e9c848539801e86591bd9801b019f84f"

--- a/test/cljs/status_im/test/utils/ethereum/ens.cljs
+++ b/test/cljs/status_im/test/utils/ethereum/ens.cljs
@@ -1,0 +1,11 @@
+(ns status-im.test.utils.ethereum.ens
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [status-im.utils.ethereum.ens :as ens]))
+
+(deftest namehash
+  (is (= ens/default-namehash (ens/namehash nil)))
+  (is (= ens/default-namehash (ens/namehash "")))
+  (is (= "0x93cdeb708b7545dc668eb9280176169d1c33cfd8ed6f04690a0bcc88a93fc4ae"
+         (ens/namehash "eth")))
+  (is (= "0xde9b09fd7c5f901e23a3f19fecc54828e9c848539801e86591bd9801b019f84f"
+         (ens/namehash "foo.eth"))))


### PR DESCRIPTION
Feature #5028 

### Summary:
Adds code to resolve ens usernames
Adds code to be able to add a contact with username

### Testing notes (optional):
Can be tested on `ropsten`

### Steps to test:
- Open Status 
- Logging into an account with STT on Ropsten (get STT with dapp https://status-im.github.io/dapp)
- Open dapp https://ipfs.io/ipfs/QmPTrxFqE44HLwB2auBPDjjXuZ4t5wbkPD6MWa7TxSTgZd
- Enable Token permissions in the dapp (makes a transaction)
- enter domain, press lookup address
- enter whisper key and ethereum address, register domain
- Logging into new account, add contact, enter ens username previously registered
- First account should now be in contacts

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: done


<blockquote><div><strong><a href="https://status-im.github.io/dapp">DAPP</a></strong></div></blockquote>
<blockquote><div><strong><a href="https://ipfs.io/ipfs/QmPTrxFqE44HLwB2auBPDjjXuZ4t5wbkPD6MWa7TxSTgZd">Status.im Domain Registration</a></strong></div></blockquote>