### PR TITLE
Uses branch version

### DIFF
--- a/mobile_files/package.json
+++ b/mobile_files/package.json
@@ -56,7 +56,7 @@
     "react-native-tcp": "3.3.0",
     "react-native-testfairy": "2.10.0",
     "react-native-udp": "2.2.1",
-    "react-native-webview-bridge": "https://github.com/status-im/react-native-webview-bridge.git",
+    "react-native-webview-bridge": "https://github.com/status-im/react-native-webview-bridge.git#upload",
     "realm": "2.3.3",
     "rn-snoopy": "https://github.com/status-im/rn-snoopy.git",
     "string_decoder": "0.10.31",


### PR DESCRIPTION
Do not merge, will be merged directly in the dependency itself.

fixes #5369

### Summary:

Support sending image files from android webview

