### PR TITLE
fix git tag push credentials, needs to use token instead of pass

### DIFF
--- a/ci/Jenkinsfile.nightly_fastlane
+++ b/ci/Jenkinsfile.nightly_fastlane
@@ -50,7 +50,7 @@ timeout(90) {
         stage('Tag Build') {
           withCredentials([[
             $class: 'UsernamePasswordMultiBinding',
-            credentialsId: 'jenkins-status-im',
+            credentialsId: 'status-im-auto',
             usernameVariable: 'GIT_USER',
             passwordVariable: 'GIT_PASS'
           ]]) {

--- a/ci/Jenkinsfile.release
+++ b/ci/Jenkinsfile.release
@@ -51,7 +51,7 @@ timeout(90) {
         stage('Tag Build') {
           withCredentials([[
             $class: 'UsernamePasswordMultiBinding',
-            credentialsId: 'jenkins-status-im',
+            credentialsId: 'status-im-auto',
             usernameVariable: 'GIT_USER',
             passwordVariable: 'GIT_PASS'
           ]]) {

--- a/ci/Jenkinsfile.upload_release_android
+++ b/ci/Jenkinsfile.upload_release_android
@@ -55,7 +55,7 @@ timeout(90) {
         stage('Tag Build') {
           withCredentials([[
             $class: 'UsernamePasswordMultiBinding',
-            credentialsId: 'jenkins-status-im',
+            credentialsId: 'status-im-auto',
             usernameVariable: 'GIT_USER',
             passwordVariable: 'GIT_PASS'
           ]]) {
@@ -80,17 +80,6 @@ timeout(90) {
 
         stage('Deploy (Android)') {
           sh ('bundle exec fastlane android release')
-        }
-
-        stage('Push build tag') {
-          withCredentials([[
-            $class: 'UsernamePasswordMultiBinding',
-            credentialsId: 'jenkins-status-im',
-            usernameVariable: 'GIT_USER',
-            passwordVariable: 'GIT_PASS'
-          ]]) {
-            sh ('git push --tags https://${GIT_USER}:${GIT_PASS}@github.com/status-im/status-react --tags')
-          }
         }
       } catch (e) {
         slackSend color: 'bad', message: 'Release build failed uploading to the Play Market. ' + env.BUILD_URL

--- a/ci/Jenkinsfile.upload_release_ios
+++ b/ci/Jenkinsfile.upload_release_ios
@@ -54,7 +54,7 @@ timeout(90) {
         stage('Tag Build') {
           withCredentials([[
             $class: 'UsernamePasswordMultiBinding',
-            credentialsId: 'jenkins-status-im',
+            credentialsId: 'status-im-auto',
             usernameVariable: 'GIT_USER',
             passwordVariable: 'GIT_PASS'
           ]]) {
@@ -86,17 +86,6 @@ timeout(90) {
 
         stage('Deploy (iOS)') {
           sh ('bundle exec fastlane ios release')
-        }
-
-        stage('Push build tag') {
-          withCredentials([[
-            $class: 'UsernamePasswordMultiBinding',
-            credentialsId: 'jenkins-status-im',
-            usernameVariable: 'GIT_USER',
-            passwordVariable: 'GIT_PASS'
-          ]]) {
-            sh ('git push --tags https://${GIT_USER}:${GIT_PASS}@github.com/status-im/status-react --tags')
-          }
         }
       } catch (e) {
         slackSend color: 'bad', message: 'Release build failed uploading to iTunes Connect. ' + env.BUILD_URL


### PR DESCRIPTION
For some reason GitHub stopped accepting the account password when pushing via https, so we need to use the token. `status-im-auto` is a new automation account I've created for Jenkins because I couldn't get accee to `jenkins-status-im`.