### PR TITLE
fix which job is run to update nightly URLs

### DIFF
--- a/ci/Jenkinsfile.nightly
+++ b/ci/Jenkinsfile.nightly
@@ -96,7 +96,13 @@ timeout(90) {
       stage('Slack Notification') {
         def c = (testPassed ? 'good' : 'warning' )
         slackSend color: c, message: 'Nightly build (develop) \nTests: ' + (testPassed ? ':+1:' : ':-1:') + ')\nAndroid: ' + apkUrl + '\n iOS: ' + ipaUrl
-        build job: 'status-react/status-nightly-publish-link', parameters: [[$class: 'StringParameterValue', name: 'APK_URL', value: apkUrl], [$class: 'StringParameterValue', name: 'IOS_URL', value: ipaUrl]]
+        build(
+          job: 'misc/status-im.github.io-update_env',
+          parameters: [
+            [$class: 'StringParameterValue', name: 'APK_URL', value: apkUrl],
+            [$class: 'StringParameterValue', name: 'IOS_URL', value: ipaUrl]
+          ]
+        )
       }
 
       stage('Build (Android) for e2e tests') {

--- a/ci/Jenkinsfile.nightly_fastlane
+++ b/ci/Jenkinsfile.nightly_fastlane
@@ -121,7 +121,13 @@ timeout(90) {
       }
 
       stage('Run status-nightly-publish-link job') {
-        build job: 'status-react/status-nightly-publish-link', parameters: [[$class: 'StringParameterValue', name: 'APK_URL', value: apkUrl], [$class: 'StringParameterValue', name: 'IOS_URL', value: ipaUrl]]
+        build(
+          job: 'misc/status-im.github.io-update_env',
+          parameters: [
+            [$class: 'StringParameterValue', name: 'APK_URL', value: apkUrl],
+            [$class: 'StringParameterValue', name: 'IOS_URL', value: ipaUrl]
+          ]
+        )
       }
 
       stage('Build (Android) for e2e tests') {


### PR DESCRIPTION
A new job is now used to publish URL links for nightlies:
* https://ci.status.im/job/misc/job/status-im.github.io-update_env/ - updated `env.groovy`
* https://ci.status.im/job/misc/job/status-im.github.io/ - actually builds the page and updates `master` branch

<blockquote><img src="/static/503f105d/favicon.ico" width="48" align="right"><div><strong><a href="https://ci.status.im/job/misc/job/status-im.github.io-update_env/">status-im.github.io-update_env [misc] [Jenkins]</a></strong></div></blockquote>
<blockquote><img src="/static/503f105d/favicon.ico" width="48" align="right"><div><strong><a href="https://ci.status.im/job/misc/job/status-im.github.io/">status-im.github.io [misc] [Jenkins]</a></strong></div></blockquote>