### PR TITLE
Update cljs-rn to new version

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -15,7 +15,7 @@
  :aliases
  {:dev {:extra-deps
         {clj-rn {:git/url "https://github.com/status-im/clj-rn"
-                 :sha "d9b835701232cb1744a670e6dd21325712a43789"}
+                 :sha "d19290a6c908e1cab291c21dfe04c2a67316744b"}
 
          ;; Figwheel ClojureScript REPL
          com.cemerick/piggieback {:mvn/version "0.2.2"


### PR DESCRIPTION
### Summary

Update cljs-rn to new version.

clj-rn `watch` task use new defaults that don't run app and metro bundler by
default.

To start development you now could run 3 separate commands:

```
# start figwheel and cljs repl
clj -R:dev -m clj-rn.main watch -p android -a genymotion
# start bundler
react-native start
# run app
make run-android
```

status: ready
