### PR TITLE
[#4823] AppStoreConnect: Mark our iOS app as encryption-compliant.

### DIFF
--- a/ios/StatusIm/Info.plist
+++ b/ios/StatusIm/Info.plist
@@ -113,5 +113,9 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<true/> 
+	<key>ITSEncryptionExportComplianceCode</key>
+	<string>1aa92c4d-6194-4d7d-b70a-16b48256b87e</string> 
 </dict>
 </plist>


### PR DESCRIPTION
To avoid specifying that we are compliant manually for every build,
we put these values into build setting of the iOS app.
More information on how to do that is here: https://stackoverflow.com/a/36028077

No manual testing needed, since it is a AppStoreConnect configuration change.

fixes #4823 

status: ready <!-- Can be ready or wip -->

<blockquote><img src="https://cdn.sstatic.net/Sites/stackoverflow/img/apple-touch-icon@2.png?v=73d79a89bded" width="48" align="right"><div>Stack Overflow</div><div><strong><a href="https://stackoverflow.com/questions/35739361/itsappusesnonexemptencryption-export-compliance-while-internal-testing/36028077">ITSAppUsesNonExemptEncryption export compliance while internal testing?</a></strong></div><div>I got this message while selecting build for internal testing.it says about setting ITSAppUsesNonExemptEncryption in info.plist what does it mean? is it necessary?</div></blockquote>