### PR TITLE
bug #5058 - aligned words in recovery backup phrase screen

### DIFF
--- a/src/status_im/ui/screens/profile/seed/styles.cljs
+++ b/src/status_im/ui/screens/profile/seed/styles.cljs
@@ -36,12 +36,14 @@
   {:flex-direction :row})
 
 (def six-word-num
-  {:opacity        0.4
+  {:width          20
+   :text-align     :right
+   :opacity        0.4
    :font-size      15
    :letter-spacing -0.2})
 
 (def six-words-word
-  {:margin-left    16
+  {:margin-left    24
    :font-size      15
    :letter-spacing -0.2})
 


### PR DESCRIPTION
fixes #5058 

### Summary:

Aligned words on Backup recovery phrase screen to avoid ambiguity about leading whitespace.

### Steps to test:
- Create a new account
- Go to Profile screen and open Backup recovery phrase

status: ready 