### PR TITLE
Set macos deployment target to 10.9

### DIFF
--- a/desktop/CMakeLists.txt
+++ b/desktop/CMakeLists.txt
@@ -11,6 +11,8 @@ cmake_minimum_required(VERSION 2.8.11)
 set(APP_NAME StatusIm)
 set(REACT_BUILD_STATIC_LIB ON)
 
+set(CMAKE_OSX_DEPLOYMENT_TARGET "10.9")
+
 message(STATUS "EXTERNAL_MODULES_DIR: ${EXTERNAL_MODULES_DIR}")
 
 foreach(external_module ${EXTERNAL_MODULES_DIR})


### PR DESCRIPTION
### Summary:

Minimum supported MacOS version should be set as deployment target during the build to support running on MacOS versions older than build machine host (probably, depends on installed SDK).

status: ready
