### PR TITLE
Notify github for desktop builds

### DIFF
--- a/ci/Jenkinsfile.desktopbuild
+++ b/ci/Jenkinsfile.desktopbuild
@@ -28,6 +28,13 @@ external_modules_dir = [
   'modules/react-native-status/desktop',
 ]
 
+def gitHubNotify(commentMsg) {
+  withCredentials([string(credentialsId: 'GIT_HUB_TOKEN', variable: 'githubToken')]) {
+    def ghOutput = sh(returnStdout: true, script: "curl -u status-im:" + githubToken + " -H 'Content-Type: application/json'  --data '{\"body\": \"" + commentMsg + "\"}' https://api.github.com/repos/status-im/status-react/issues/" + CHANGE_ID + "/comments")
+    println("Result of github comment curl: " + ghOutput);
+  }
+}
+
 def installJSDeps() {
   def attempt = 1
   def maxAttempts = 10
@@ -87,160 +94,167 @@ def buildClojureScript() {
   """
 }
 
-parallel(
-  'MacOS build': {
-    timeout(90) {
-      node('macos1') {
-        load "$HOME/env.groovy"
+node() {
+  gitHubNotify("Desktop Jenkins build job started at ${env.BUILD_URL}")
+  try {
+    parallel(
+      'MacOS build': {
+        timeout(90) {
+          node('macos1') {
+            load "$HOME/env.groovy"
 
-        try {
-          stage('Git & Deps') {
-            slackNotify('MacOS build started.')
-            checkout scm
-            doGitRebase()
-            cleanupAndDeps()
-          }
+            try {
+              stage('Git & Deps') {
+                slackNotify('MacOS build started.')
+                checkout scm
+                doGitRebase()
+                cleanupAndDeps()
+              }
 
-          stage('Build ClojureScript') {
-            buildClojureScript()
-          }
+              stage('Build ClojureScript') {
+                buildClojureScript()
+              }
 
-          stage('Build MacOS binaries') {
-            /* add path for QT installation binaries */
-            env.PATH = "/Users/administrator/qt/5.9.1/clang_64/bin:${env.PATH}"
-            dir('desktop') {
-              sh 'rm -rf CMakeFiles CMakeCache.txt cmake_install.cmake Makefile'
-              sh """
-                cmake -Wno-dev \\
-                  -DCMAKE_BUILD_TYPE=Release \\
-                  -DEXTERNAL_MODULES_DIR='${external_modules_dir.join(";")}' \\
-                  -DJS_BUNDLE_PATH='${workspace}/${packageFolder}/StatusIm.jsbundle' \\
-                  -DCMAKE_CXX_FLAGS:='-DBUILD_FOR_BUNDLE=1'
-              """
-              sh 'make'
+              stage('Build MacOS binaries') {
+                /* add path for QT installation binaries */
+                env.PATH = "/Users/administrator/qt/5.9.1/clang_64/bin:${env.PATH}"
+                dir('desktop') {
+                  sh 'rm -rf CMakeFiles CMakeCache.txt cmake_install.cmake Makefile'
+                  sh """
+                    cmake -Wno-dev \\
+                      -DCMAKE_BUILD_TYPE=Release \\
+                      -DEXTERNAL_MODULES_DIR='${external_modules_dir.join(";")}' \\
+                      -DJS_BUNDLE_PATH='${workspace}/${packageFolder}/StatusIm.jsbundle' \\
+                      -DCMAKE_CXX_FLAGS:='-DBUILD_FOR_BUNDLE=1'
+                  """
+                  sh 'make'
+                }
+              }
+
+              stage('Create MacOS Bundle') {
+                dir(packageFolder) {
+                  sh 'git clone https://github.com/vkjr/StatusAppFiles.git'
+                  sh 'unzip StatusAppFiles/StatusIm.app.zip'
+                  sh 'cp -r assets/share/assets StatusIm.app/Contents/MacOs'
+                  sh 'chmod +x StatusIm.app/Contents/MacOs/ubuntu-server'
+                  sh 'cp ../desktop/bin/StatusIm StatusIm.app/Contents/MacOs'
+                  sh """
+                    macdeployqt StatusIm.app -verbose=1 -dmg \\
+                      -qmldir='${workspace}/node_modules/react-native/ReactQt/runtime/src/qml/'
+                  """
+                  sh 'rm -fr StatusAppFiles'
+                }
+              }
+
+              stage('Archive Artifact') {
+                archiveArtifacts 'StatusImPackage/*.dmg'
+              }
+
+              slackNotify('MacOS build finished successfully.')
+            } catch (e) {
+              slackNotify('Failed to build on MacOS.', color: 'bad')
+              throw e
+            } finally {
+              cleanupBuild()
             }
           }
+        }
+      },
+      'Linux build': {
+        timeout(90) {
+          node ('linux-01') {
+            def qt_bin = '/opt/qt59/bin'
 
-          stage('Create MacOS Bundle') {
-            dir(packageFolder) {
-              sh 'git clone https://github.com/vkjr/StatusAppFiles.git'
-              sh 'unzip StatusAppFiles/StatusIm.app.zip'
-              sh 'cp -r assets/share/assets StatusIm.app/Contents/MacOs'
-              sh 'chmod +x StatusIm.app/Contents/MacOs/ubuntu-server'
-              sh 'cp ../desktop/bin/StatusIm StatusIm.app/Contents/MacOs'
-              sh """
-                macdeployqt StatusIm.app -verbose=1 -dmg \\
-                  -qmldir='${workspace}/node_modules/react-native/ReactQt/runtime/src/qml/'
-              """
-              sh 'rm -fr StatusAppFiles'
+            try {
+              stage('Git & Deps') {
+                slackNotify('Linux build started.')
+                checkout scm
+                doGitRebase()
+                cleanupAndDeps()
+              }
+
+              stage('Build ClojureScript') {
+                buildClojureScript()
+              }
+
+              stage('Build Linux binaries') {
+                /* add path for QT installation binaries */
+                env.PATH = "${qt_bin}:${env.PATH}"
+                dir('desktop') {
+                  sh 'rm -rf CMakeFiles CMakeCache.txt cmake_install.cmake Makefile'
+                  sh """
+                    cmake -Wno-dev \\
+                      -DCMAKE_BUILD_TYPE=Release \\
+                      -DEXTERNAL_MODULES_DIR='${external_modules_dir.join(";")}' \\
+                      -DJS_BUNDLE_PATH='${workspace}/${packageFolder}/StatusIm.jsbundle' \\
+                      -DCMAKE_CXX_FLAGS:='-DBUILD_FOR_BUNDLE=1'
+                  """
+                  sh 'make'
+                }
+              }
+
+              stage('Create Linux AppImage') {
+                dir(packageFolder) {
+                  sh 'rm -rf StatusImAppImage'
+                  /* TODO this needs to be fixed: status-react/issues/5378 */
+                  sh 'cp /opt/StatusImAppImage.zip ./'
+                  sh 'unzip ./StatusImAppImage.zip'
+                  sh 'rm -rf AppDir'
+                  sh 'mkdir AppDir'
+                }
+                sh "cp -r ./deployment/linux/usr  ${packageFolder}/AppDir"
+                sh "cp ./deployment/linux/.env  ${packageFolder}/AppDir"
+                sh "cp ./desktop/bin/StatusIm ${packageFolder}/AppDir/usr/bin"
+                sh 'wget https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage'
+                sh 'chmod a+x ./linuxdeployqt-continuous-x86_64.AppImage'
+
+                sh 'rm -f Application-x86_64.AppImage'
+                sh 'rm -f StatusIm-x86_64.AppImage'
+
+                sh "ldd ${packageFolder}/AppDir/usr/bin/StatusIm"
+                sh """
+                  ./linuxdeployqt-continuous-x86_64.AppImage \\
+                    ${packageFolder}/AppDir/usr/share/applications/StatusIm.desktop \\
+                    -verbose=3 -always-overwrite -no-strip \\
+                    -no-translations -bundle-non-qt-libs \\
+                    -qmake=${qt_bin}/qmake \\
+                    -extra-plugins=imageformats/libqsvg.so \\
+                    -qmldir='${workspace}/node_modules/react-native'
+                """
+                dir(packageFolder) {
+                  sh 'ldd AppDir/usr/bin/StatusIm'
+                  sh 'cp -r assets/share/assets AppDir/usr/bin'
+                  sh 'cp -rf StatusImAppImage/* AppDir/usr/bin'
+                  sh 'rm -f AppDir/usr/bin/StatusIm.AppImage'
+                }
+                sh """
+                  ./linuxdeployqt-continuous-x86_64.AppImage \\
+                  ${packageFolder}/AppDir/usr/share/applications/StatusIm.desktop \\
+                  -verbose=3 -appimage -qmake=${qt_bin}/qmake
+                """
+                dir(packageFolder) {
+                  sh 'ldd AppDir/usr/bin/StatusIm'
+                  sh 'rm -rf StatusIm.AppImage'
+                  sh 'cp -f ../StatusIm-x86_64.AppImage StatusIm.AppImage'
+                }
+              }
+
+              stage('Archive Artifact') {
+                archiveArtifacts 'StatusImPackage/*.AppImage'
+              }
+
+              slackNotify('Linux build finished successfully.')
+            } catch (e) {
+              slackNotify('Failed to build on Linux.', color: 'bad')
+              throw e
+            } finally {
+              cleanupBuild()
             }
           }
-
-          stage('Archive Artifact') {
-            archiveArtifacts 'StatusImPackage/*.dmg'
-          }
-
-          slackNotify('MacOS build finished successfully.')
-        } catch (e) {
-          slackNotify('Failed to build on MacOS.', color: 'bad')
-          throw e
-        } finally {
-          cleanupBuild()
         }
       }
-    }
-  },
-  'Linux build': {
-    timeout(90) {
-      node ('linux-01') {
-        def qt_bin = '/opt/qt59/bin'
-
-        try {
-          stage('Git & Deps') {
-            slackNotify('Linux build started.')
-            checkout scm
-            doGitRebase()
-            cleanupAndDeps()
-          }
-
-          stage('Build ClojureScript') {
-            buildClojureScript()
-          }
-
-          stage('Build Linux binaries') {
-            /* add path for QT installation binaries */
-            env.PATH = "${qt_bin}:${env.PATH}"
-            dir('desktop') {
-              sh 'rm -rf CMakeFiles CMakeCache.txt cmake_install.cmake Makefile'
-              sh """
-                cmake -Wno-dev \\
-                  -DCMAKE_BUILD_TYPE=Release \\
-                  -DEXTERNAL_MODULES_DIR='${external_modules_dir.join(";")}' \\
-                  -DJS_BUNDLE_PATH='${workspace}/${packageFolder}/StatusIm.jsbundle' \\
-                  -DCMAKE_CXX_FLAGS:='-DBUILD_FOR_BUNDLE=1'
-              """
-              sh 'make'
-            }
-          }
-
-          stage('Create Linux AppImage') {
-            dir(packageFolder) {
-              sh 'rm -rf StatusImAppImage'
-              /* TODO this needs to be fixed: status-react/issues/5378 */
-              sh 'cp /opt/StatusImAppImage.zip ./'
-              sh 'unzip ./StatusImAppImage.zip'
-              sh 'rm -rf AppDir'
-              sh 'mkdir AppDir'
-            }
-            sh "cp -r ./deployment/linux/usr  ${packageFolder}/AppDir"
-            sh "cp ./deployment/linux/.env  ${packageFolder}/AppDir"
-            sh "cp ./desktop/bin/StatusIm ${packageFolder}/AppDir/usr/bin"
-            sh 'wget https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage'
-            sh 'chmod a+x ./linuxdeployqt-continuous-x86_64.AppImage'
-
-            sh 'rm -f Application-x86_64.AppImage'
-            sh 'rm -f StatusIm-x86_64.AppImage'
-
-            sh "ldd ${packageFolder}/AppDir/usr/bin/StatusIm"
-            sh """
-              ./linuxdeployqt-continuous-x86_64.AppImage \\
-                ${packageFolder}/AppDir/usr/share/applications/StatusIm.desktop \\
-                -verbose=3 -always-overwrite -no-strip \\
-                -no-translations -bundle-non-qt-libs \\
-                -qmake=${qt_bin}/qmake \\
-                -extra-plugins=imageformats/libqsvg.so \\
-                -qmldir='${workspace}/node_modules/react-native'
-            """
-            dir(packageFolder) {
-              sh 'ldd AppDir/usr/bin/StatusIm'
-              sh 'cp -r assets/share/assets AppDir/usr/bin'
-              sh 'cp -rf StatusImAppImage/* AppDir/usr/bin'
-              sh 'rm -f AppDir/usr/bin/StatusIm.AppImage'
-            }
-            sh """
-              ./linuxdeployqt-continuous-x86_64.AppImage \\
-              ${packageFolder}/AppDir/usr/share/applications/StatusIm.desktop \\
-              -verbose=3 -appimage -qmake=${qt_bin}/qmake
-            """
-            dir(packageFolder) {
-              sh 'ldd AppDir/usr/bin/StatusIm'
-              sh 'rm -rf StatusIm.AppImage'
-              sh 'cp -f ../StatusIm-x86_64.AppImage StatusIm.AppImage'
-            }
-          }
-
-          stage('Archive Artifact') {
-            archiveArtifacts 'StatusImPackage/*.AppImage'
-          }
-
-          slackNotify('Linux build finished successfully.')
-        } catch (e) {
-          slackNotify('Failed to build on Linux.', color: 'bad')
-          throw e
-        } finally {
-          cleanupBuild()
-        }
-      }
-    }
+    )
+  } catch (e) {
+     gitHubNotify("Desktop Jenkins build was failed or cancelled. More details at ${env.BUILD_URL}")
   }
-)
+}


### PR DESCRIPTION
Post comment at GitHub PR page on Desktop build start or failure.

Changes details:

- parallel build job was wrapped into node block to call gitHubNotify() once on the start of build job process
- try/catch block on top `node` block was added to intercept build failures and generate build failure message