### PR TITLE
Use fastlane for diawi, slack & github comments 🌤

### DIFF
--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -53,7 +53,6 @@ timeout(90) {
           sh 'mvn -f modules/react-native-status/ios/RCTStatus dependency:unpack'
           sh 'cd ios && pod install && cd ..'
         }
-
         stage('Code style checks') {
             sh 'lein cljfmt check'
         }
@@ -72,16 +71,12 @@ timeout(90) {
         }
 
         stage('Deploy (Android)') {
-          withCredentials([string(credentialsId: 'diawi-token', variable: 'token')] ) {
-            def job = sh(returnStdout: true, script: 'curl https://upload.diawi.com/ -F token='+token+' -F file=@android/app/build/outputs/apk/release/app-release.apk -F find_by_udid=0 -F wall_of_apps=0 | jq -r ".job"').trim()
-            def hash = 'null'
-            for (int r = 0; r < 6 && hash == 'null'; r++) {
-              sh 'sleep 10'
-              hash = sh(returnStdout: true, script: "curl -vvv 'https://upload.diawi.com/status?token="+token+"&job="+job+"'|jq -r '.hash'").trim()
-            }
-            apkUrl = 'https://i.diawi.com/' + hash
-
-            sh ('echo ARTIFACT Android: ' + apkUrl)
+          withCredentials([
+              string(credentialsId: 'diawi-token', variable: 'DIAWI_TOKEN'),
+              string(credentialsId: 'GIT_HUB_TOKEN', variable: 'GITHUB_TOKEN'),
+              string(credentialsId: 'SLACK_JENKINS_WEBHOOK', variable: 'SLACK_URL')
+          ]) {
+            sh 'fastlane android upload_diawi'
           }
         }
 
@@ -101,28 +96,12 @@ timeout(90) {
         }
 
         stage('Deploy (iOS)') {
-          withCredentials([string(credentialsId: 'diawi-token', variable: 'token')]) {
-            def job = sh(returnStdout: true, script: 'curl https://upload.diawi.com/ -F token='+token+' -F file=@status-adhoc/StatusIm.ipa -F find_by_udid=0 -F wall_of_apps=0 | jq -r ".job"').trim()
-            def hash = 'null'
-            for (int r = 0; r < 6 && hash == 'null'; r++) {
-              sh 'sleep 10'
-              hash = sh(returnStdout: true, script: "curl -vvv 'https://upload.diawi.com/status?token="+token+"&job="+job+"'|jq -r '.hash'").trim()
-            }
-            ipaUrl = 'https://i.diawi.com/' + hash
-
-            sh ('echo ARTIFACT iOS: ' + ipaUrl)
-          }
-        }
-
-        stage('Slack/GH Notifications') {
-          def c = (testPassed ? 'good' : 'warning' )
-
-          slackSend color: c, message: ('Branch: ' + BRANCH_NAME + '\nAndroid: ' + apkUrl + '\niOS: ' + ipaUrl);
-
-          withCredentials([string(credentialsId: 'GIT_HUB_TOKEN', variable: 'githubToken')]) {
-            def commentMsg = ("branch " + BRANCH_NAME + ":\\napk uploaded to " + apkUrl + "\\nipa uploaded to " + ipaUrl)
-            def ghOutput = sh(returnStdout: true, script: "curl -u status-im:" + githubToken + " -H 'Content-Type: application/json'  --data '{\"body\": \"" + commentMsg + "\"}' https://api.github.com/repos/status-im/status-react/issues/" + CHANGE_ID + "/comments")
-            println("Result of github comment curl: " + ghOutput);
+          withCredentials([
+              string(credentialsId: 'diawi-token', variable: 'DIAWI_TOKEN'),
+              string(credentialsId: 'GIT_HUB_TOKEN', variable: 'GITHUB_TOKEN'),
+              string(credentialsId: 'SLACK_JENKINS_WEBHOOK', variable: 'SLACK_URL')
+          ]) {
+            sh 'fastlane ios upload_diawi'
           }
         }
 
@@ -132,20 +111,24 @@ timeout(90) {
         }
 
         stage('Upload apk for e2e tests') {
-          if (env.CHANGE_ID != null){
-          withCredentials([string(credentialsId: 'SAUCE_ACCESS_KEY', variable: 'key'), string(credentialsId: 'SAUCE_USERNAME', variable: 'username')]){
-            def apk_name = env.CHANGE_ID + '.apk'
-            sh('curl -u ' + username+ ':' + key + ' -X POST -H "Content-Type: application/octet-stream" https://saucelabs.com/rest/v1/storage/' + username + '/' + apk_name + '?overwrite=true --data-binary @android/app/build/outputs/apk/release/app-release.apk')
-          }
-          withCredentials([string(credentialsId: 'diawi-token', variable: 'token')]) {
-            def job = sh(returnStdout: true, script: 'curl https://upload.diawi.com/ -F token='+token+' -F file=@android/app/build/outputs/apk/release/app-release.apk -F find_by_udid=0 -F wall_of_apps=0 | jq -r ".job"').trim()
-            sh 'sleep 10'
-            def hash = sh(returnStdout: true, script: "curl -vvv 'https://upload.diawi.com/status?token="+token+"&job="+job+"'|jq -r '.hash'").trim()
-            apkUrl = 'https://i.diawi.com/' + hash
+          if (env.CHANGE_ID != null) {
 
-            sh ('echo ARTIFACT Android for e2e tests: ' + apkUrl)
+              withCredentials([
+                  string(credentialsId: 'SAUCE_ACCESS_KEY', variable: 'key'),
+                  string(credentialsId: 'SAUCE_USERNAME', variable: 'username')
+              ]) {
+                def apk_name = env.CHANGE_ID + '.apk'
+                sh('curl -u ' + username+ ':' + key + ' -X POST -H "Content-Type: application/octet-stream" https://saucelabs.com/rest/v1/storage/' + username + '/' + apk_name + '?overwrite=true --data-binary @android/app/build/outputs/apk/release/app-release.apk')
+              }
+
+              withCredentials([
+                  string(credentialsId: 'diawi-token', variable: 'DIAWI_TOKEN'),
+                  string(credentialsId: 'GIT_HUB_TOKEN', variable: 'GITHUB_TOKEN'),
+                  string(credentialsId: 'SLACK_JENKINS_WEBHOOK', variable: 'SLACK_URL')
+              ]) {
+                sh 'fastlane android upload_diawi'
+              }
           }
-         }
         }
 
       } catch (e) {

--- a/ci/Jenkinsfile.nightly_fastlane
+++ b/ci/Jenkinsfile.nightly_fastlane
@@ -123,13 +123,12 @@ timeout(90) {
         }
 
         stage('Deploy diawi (iOS)') {
-          withCredentials([string(credentialsId: 'diawi-token', variable: 'token')]) {
-            def job = sh(returnStdout: true, script: 'curl https://upload.diawi.com/ -F token='+token+' -F file=@status-adhoc/StatusIm.ipa -F find_by_udid=0 -F wall_of_apps=0 | jq -r ".job"').trim()
-            sh 'sleep 10'
-            def hash = sh(returnStdout: true, script: "curl -vvv 'https://upload.diawi.com/status?token="+token+"&job="+job+"'|jq -r '.hash'").trim()
-            ipaUrl = 'https://i.diawi.com/' + hash
-
-            sh ('echo ARTIFACT iOS: ' + ipaUrl)
+          withCredentials([
+              string(credentialsId: 'diawi-token', variable: 'DIAWI_TOKEN'),
+              string(credentialsId: 'GIT_HUB_TOKEN', variable: 'GITHUB_TOKEN'),
+              string(credentialsId: 'SLACK_JENKINS_WEBHOOK', variable: 'SLACK_URL')
+          ]) {
+              sh 'fastlane ios upload_diawi'
           }
         }
       } catch (e) {
@@ -156,13 +155,13 @@ timeout(90) {
           apk_name = 'im.status.ethereum-e2e-' + shortCommit + '.apk'
           sh('curl -u ' + username+ ':' + key + ' -X POST -H "Content-Type: application/octet-stream" https://saucelabs.com/rest/v1/storage/' + username + '/' + apk_name + '?overwrite=true --data-binary @android/app/build/outputs/apk/release/app-release.apk')
         }
-        withCredentials([string(credentialsId: 'diawi-token', variable: 'token')]) {
-          def job = sh(returnStdout: true, script: 'curl https://upload.diawi.com/ -F token='+token+' -F file=@android/app/build/outputs/apk/release/app-release.apk -F find_by_udid=0 -F wall_of_apps=0 | jq -r ".job"').trim()
-          sh 'sleep 10'
-          def hash = sh(returnStdout: true, script: "curl -vvv 'https://upload.diawi.com/status?token="+token+"&job="+job+"'|jq -r '.hash'").trim()
-          testApkUrl = 'https://i.diawi.com/' + hash
 
-          sh ('echo ARTIFACT Android for e2e tests: ' + testApkUrl)
+        withCredentials([
+            string(credentialsId: 'diawi-token', variable: 'DIAWI_TOKEN'),
+            string(credentialsId: 'GIT_HUB_TOKEN', variable: 'GITHUB_TOKEN'),
+            string(credentialsId: 'SLACK_JENKINS_WEBHOOK', variable: 'SLACK_URL')
+        ]) {
+            sh 'fastlane android upload_diawi'
         }
       }
 

--- a/ci/Jenkinsfile.parameters
+++ b/ci/Jenkinsfile.parameters
@@ -74,14 +74,13 @@ timeout(90) {
         sh 'cd android && ./gradlew react-native-android:installArchives && ./gradlew assembleRelease'
       }
       stage('Deploy (Android)') {
-        withCredentials([string(credentialsId: 'diawi-token', variable: 'token')]) {
-          def job = sh(returnStdout: true, script: 'curl https://upload.diawi.com/ -F token='+token+' -F file=@android/app/build/outputs/apk/release/app-release.apk -F find_by_udid=0 -F wall_of_apps=0 | jq -r ".job"').trim()
-          sh 'sleep 10'
-          def hash = sh(returnStdout: true, script: "curl -vvv 'https://upload.diawi.com/status?token="+token+"&job="+job+"'|jq -r '.hash'").trim()
-          apkUrl = 'https://i.diawi.com/' + hash
-
-          sh ('echo ARTIFACT Android: ' + apkUrl)
-        }
+          withCredentials([
+              string(credentialsId: 'diawi-token', variable: 'DIAWI_TOKEN'),
+              string(credentialsId: 'GIT_HUB_TOKEN', variable: 'GITHUB_TOKEN'),
+              string(credentialsId: 'SLACK_JENKINS_WEBHOOK', variable: 'SLACK_URL')
+          ]) {
+            sh 'fastlane android upload_diawi'
+          }
       }
 
       // iOS
@@ -100,14 +99,13 @@ timeout(90) {
           }
       }
       stage('Deploy (iOS)') {
-        withCredentials([string(credentialsId: 'diawi-token', variable: 'token')]) {
-          def job = sh(returnStdout: true, script: 'curl https://upload.diawi.com/ -F token='+token+' -F file=@status-adhoc/StatusIm.ipa -F find_by_udid=0 -F wall_of_apps=0 | jq -r ".job"').trim()
-          sh 'sleep 10'
-          def hash = sh(returnStdout: true, script: "curl -vvv 'https://upload.diawi.com/status?token="+token+"&job="+job+"'|jq -r '.hash'").trim()
-          ipaUrl = 'https://i.diawi.com/' + hash
-
-          sh ('echo ARTIFACT iOS: ' + ipaUrl)
-        }
+          withCredentials([
+              string(credentialsId: 'diawi-token', variable: 'DIAWI_TOKEN'),
+              string(credentialsId: 'GIT_HUB_TOKEN', variable: 'GITHUB_TOKEN'),
+              string(credentialsId: 'SLACK_JENKINS_WEBHOOK', variable: 'SLACK_URL')
+          ]) {
+            sh 'fastlane ios upload_diawi'
+          }
       }
 
       stage('Slack Notification') {

--- a/ci/Jenkinsfile.release
+++ b/ci/Jenkinsfile.release
@@ -108,13 +108,13 @@ timeout(90) {
         }
 
         stage('Deploy (iOS)') {
-          withCredentials([string(credentialsId: 'diawi-token', variable: 'token')]) {
-            def job = sh(returnStdout: true, script: 'curl https://upload.diawi.com/ -F token='+token+' -F file=@status-adhoc/StatusIm.ipa -F find_by_udid=0 -F wall_of_apps=0 | jq -r ".job"').trim()
-            sh 'sleep 10'
-            def hash = sh(returnStdout: true, script: "curl -vvv 'https://upload.diawi.com/status?token="+token+"&job="+job+"'|jq -r '.hash'").trim()
-            ipaUrl = 'https://i.diawi.com/' + hash
 
-            sh ('echo ARTIFACT iOS: ' + ipaUrl)
+          withCredentials([
+              string(credentialsId: 'diawi-token', variable: 'DIAWI_TOKEN'),
+              string(credentialsId: 'GIT_HUB_TOKEN', variable: 'GITHUB_TOKEN'),
+              string(credentialsId: 'SLACK_JENKINS_WEBHOOK', variable: 'SLACK_URL')
+          ]) {
+            sh 'fastlane ios upload_diawi'
           }
         }
 
@@ -137,12 +137,13 @@ timeout(90) {
          apk_name = 'release-e2e-' + shortCommit + '.apk'
          sh('curl -u ' + username+ ':' + key + ' -X POST -H "Content-Type: application/octet-stream" https://saucelabs.com/rest/v1/storage/' + username + '/' + apk_name + '?overwrite=true --data-binary @android/app/build/outputs/apk/release/app-release.apk')
         }
-        withCredentials([string(credentialsId: 'diawi-token', variable: 'token')]) {
-         def job = sh(returnStdout: true, script: 'curl https://upload.diawi.com/ -F token='+token+' -F file=@android/app/build/outputs/apk/release/app-release.apk -F find_by_udid=0 -F wall_of_apps=0 | jq -r ".job"').trim()
-         sh 'sleep 10'
-         def hash = sh(returnStdout: true, script: "curl -vvv 'https://upload.diawi.com/status?token="+token+"&job="+job+"'|jq -r '.hash'").trim()
-         testApkUrl = 'https://i.diawi.com/' + hash
-         sh ('echo ARTIFACT Android for e2e tests: ' + testApkUrl)
+
+        withCredentials([
+            string(credentialsId: 'diawi-token', variable: 'DIAWI_TOKEN'),
+            string(credentialsId: 'GIT_HUB_TOKEN', variable: 'GITHUB_TOKEN'),
+            string(credentialsId: 'SLACK_JENKINS_WEBHOOK', variable: 'SLACK_URL')
+        ]) {
+            sh 'fastlane android upload_diawi'
         }
       }
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -42,6 +42,47 @@ def build_ios_adhoc
 end
 
 
+def notify_about_new_build(source, url)
+
+    msg = "Branch: " + ENV["BRANCH_NAME"] + ", "
+
+    if source.end_with? ".ipa"
+        msg = msg + "iOS build uploaded to diawi: " + url
+    else
+        msg = msg + "Android build uploaded to diawi: " + url
+    end
+
+    slack(
+        message: msg,
+        slack_url: ENV["SLACK_URL"]
+    )
+
+    github_api(
+        server_url: "https://api.github.com",
+        api_token: ENV["GITHUB_TOKEN"],
+        http_method: "POST",
+        path: "/repos/status-im/status-react/issues/" + ENV["CHANGE_ID"] + "/comments",
+        body: {
+           "body": msg
+        }
+    )
+
+end
+
+
+def upload_to_diawi_and_notify(source)
+    diawi(
+        token: ENV["DIAWI_TOKEN"],
+        file: source
+    )
+
+    notify_about_new_build(
+        source,
+        lane_context[SharedValues::UPLOADED_FILE_LINK_TO_DIAWI]
+    )
+end
+
+
 platform :ios do
   desc "`fastlane ios adhoc` - ad-hoc lane for iOS."
   desc "This lane is used PRs, Releases, etc."
@@ -122,6 +163,19 @@ platform :ios do
   lane :clean do
     clean_testflight_testers
   end
+
+  desc "`fastlane ios upload-diawi` - upload .ipa to diawi"
+  desc "also notifies in a GitHub comments and in Slack #jenkins channel"
+  desc "expects to have an .ipa prepared: `status-adhoc/StatusIm.ipa`"
+  desc "expects to have a diawi token as DIAWI_TOKEN env variable"
+  desc "expects to have a github token as GITHUB_TOKEN env variable"
+  desc "expects to have a slack webhook URL as SLACK_URL env variable"
+  desc "will fails if file isn't there"
+  lane :upload_diawi do
+    upload_to_diawi_and_notify(
+        "status-adhoc/StatusIm.ipa"
+    )
+  end
 end
 
 
@@ -151,6 +205,19 @@ platform :android do
     slack(
         message: "New release build uploaded to Google Play",
         slack_url: ENV["SLACK_URL"]
+    )
+  end
+
+  desc "`fastlane android upload-diawi` - upload .ipa to diawi"
+  desc "also notifies in a GitHub comments and in Slack #jenkins channel"
+  desc "expects to have an .apk prepared: `android/app/build/outputs/apk/release/app-release.apk`"
+  desc "expects to have a diawi token as DIAWI_TOKEN env variable"
+  desc "expects to have a github token as GITHUB_TOKEN env variable"
+  desc "expects to have a slack webhook URL as SLACK_URL env variable"
+  desc "will fails if file isn't there"
+  lane :upload_diawi do
+    upload_to_diawi_and_notify(
+        "android/app/build/outputs/apk/release/app-release.apk"
     )
   end
 end

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -3,3 +3,4 @@
 # Ensure this file is checked in to source control!
 
 gem 'fastlane-plugin-clean_testflight_testers'
+gem 'fastlane-plugin-diawi'


### PR DESCRIPTION
in effort to minimize `curl` usages in Jenkinsfiles

### 1. upload releases (iOS and Android) to diawi using fastlane
use plugin [`diawi`](https://rubygems.org/gems/fastlane-plugin-diawi) to do this magic

### 2. comment to slack using fastlane
comment to Slack through fastlane [`slack`](https://docs.fastlane.tools/actions/slack/) action

### 3. comment to github using fastlane
replace curl usages with [`github_api`](https://docs.fastlane.tools/actions/github_api/) to comment on GitHub



status: ready <!-- Can be ready or wip -->
