### PR TITLE
Less magic in setup new CI nodes 🧙‍♂️

### DIFF
--- a/ci/Jenkinsfile.nightly_fastlane
+++ b/ci/Jenkinsfile.nightly_fastlane
@@ -93,20 +93,28 @@ timeout(90) {
           def buildInfo = server.upload(uploadSpec)
           apkUrl = 'http://artifacts.status.im:8081/artifactory/nightlies-local/' + filename
 
-          sh ('bundle exec fastlane android nightly')
           sh ('echo ARTIFACT Android: ' + apkUrl)
+          withCredentials([
+              string(
+                credentialsId: "SUPPLY_JSON_KEY_DATA",
+                variable: 'GOOGLE_PLAY_JSON_KEY'
+              ),
+              string(
+                credentialsId: "SLACK_URL",
+                variable: 'SLACK_URL'
+              )
+          ]) {
+              sh ('bundle exec fastlane android nightly')
+          }
         }
 
         stage('Build & TestFlight (iOS)') {
           withCredentials([
-              string(
-                credentialsId: "slave-pass-${env.NODE_NAME}",
-                variable: 'KEYCHAIN_PASSWORD'
-              ),
-              string(
-                credentialsId: 'fastlane-match-password',
-                variable:'MATCH_PASSWORD'
-              )]) {
+              string(credentialsId: "slave-pass-${env.NODE_NAME}", variable: 'KEYCHAIN_PASSWORD'),
+              string(credentialsId: "SLACK_URL", variable: 'SLACK_URL'),
+              string(credentialsId: 'FASTLANE_PASSWORD', variable: 'FASTLANE_PASSWORD'),
+              string(credentialsId: 'APPLE_ID', variable: 'APPLE_ID'),
+              string(credentialsId: 'fastlane-match-password', variable:'MATCH_PASSWORD')]) {
 
                 sh "plutil -replace CFBundleShortVersionString  -string ${version} ios/StatusIm/Info.plist"
                 sh "plutil -replace CFBundleVersion -string ${build_no} ios/StatusIm/Info.plist"

--- a/ci/Jenkinsfile.upload_release_android
+++ b/ci/Jenkinsfile.upload_release_android
@@ -80,7 +80,18 @@ timeout(90) {
         }
 
         stage('Deploy (Android)') {
-          sh ('bundle exec fastlane android release')
+          withCredentials([
+              string(
+                credentialsId: "SUPPLY_JSON_KEY_DATA",
+                variable: 'GOOGLE_PLAY_JSON_KEY'
+              ),
+              string(
+                credentialsId: "SLACK_URL",
+                variable: 'SLACK_URL'
+              )
+          ]) {
+              sh ('bundle exec fastlane android release')
+          }
         }
       } catch (e) {
         slackSend color: 'bad', message: 'Release build failed uploading to the Play Market. ' + env.BUILD_URL

--- a/ci/Jenkinsfile.upload_release_ios
+++ b/ci/Jenkinsfile.upload_release_ios
@@ -76,16 +76,11 @@ timeout(90) {
 
         stage('Build & TestFlight (iOS)') {
           withCredentials([
-              string(
-                credentialsId: "slave-pass-${env.NODE_NAME}",
-                variable: 'KEYCHAIN_PASSWORD'
-              ),
-              string(
-                credentialsId: 'fastlane-match-password',
-                variable:'MATCH_PASSWORD'
-              )]) {
-
-
+              string(credentialsId: "slave-pass-${env.NODE_NAME}", variable: 'KEYCHAIN_PASSWORD'),
+              string(credentialsId: "SLACK_URL", variable: 'SLACK_URL'),
+              string(credentialsId: 'FASTLANE_PASSWORD', variable: 'FASTLANE_PASSWORD'),
+              string(credentialsId: 'APPLE_ID', variable: 'APPLE_ID'),
+              string(credentialsId: 'fastlane-match-password', variable:'MATCH_PASSWORD')]) {
                 sh "plutil -replace CFBundleShortVersionString  -string ${version} ios/StatusIm/Info.plist"
                 sh "plutil -replace CFBundleVersion  -string ${build_no} ios/StatusIm/Info.plist"
                 sh 'fastlane ios release'

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -16,7 +16,7 @@ def unlock_keychain_if_needed
     if ENV["KEYCHAIN_PASSWORD"]
         unlock_keychain(
             path:"login.keychain", 
-            password:ENV["password"],
+            password:ENV["KEYCHAIN_PASSWORD"],
             set_default: true)
     end
 end
@@ -73,9 +73,13 @@ platform :ios do
         output_directory: "status_appstore"
     )
     upload_to_testflight(
-      ipa: "status_appstore/StatusIm.ipa"
+        ipa: "status_appstore/StatusIm.ipa"
     )
-    slack(message: "New nightly build uploaded to TestFlight")
+
+    slack(
+        message: "New nightly build uploaded to TestFlight",
+        slack_url: ENV["SLACK_URL"]
+    )
 
     # additional .ipa is for diawi
     # we have to re-build it because it uses different config
@@ -104,9 +108,12 @@ platform :ios do
         }
     )
     upload_to_testflight(
-      ipa: "status_appstore/StatusIm.ipa"
+        ipa: "status_appstore/StatusIm.ipa"
     )
-    slack(message: "New release build uploaded to TestFlight")
+    slack(
+        message: "New release build uploaded to TestFlight",
+        slack_url: ENV["SLACK_URL"]
+    )
   end
 
   desc "`fastlane ios clean` - remove inactive TestFlight users"
@@ -120,18 +127,30 @@ end
 
 platform :android do
   desc "Deploy a new internal build to Google Play"
+  desc "expects GOOGLE_PLAY_JSON_KEY environment variable"
   lane :nightly do
     upload_to_play_store(
       track: "internal",
-      apk: "android/app/build/outputs/apk/release/app-release.apk"
+      apk: "android/app/build/outputs/apk/release/app-release.apk",
+      json_key_data: ENV["GOOGLE_PLAY_JSON_KEY"]
     )
-    slack(message: "New nightly build uploaded to Google Play")
+
+    slack(
+        message: "New nightly build uploaded to Google Play",
+        slack_url: ENV["SLACK_URL"]
+    )
   end
   lane :release do
+    desc "Deploy a new alpha (public) build to Google Play"
+    desc "expects GOOGLE_PLAY_JSON_KEY environment variable"
     upload_to_play_store(
       track: "alpha",
-      apk: "android/app/build/outputs/apk/release/app-release.apk"
+      apk: "android/app/build/outputs/apk/release/app-release.apk",
+      json_key_data: ENV["GOOGLE_PLAY_JSON_KEY"]
     )
-    slack(message: "New release build uploaded to Google Play")
+    slack(
+        message: "New release build uploaded to Google Play",
+        slack_url: ENV["SLACK_URL"]
+    )
   end
 end


### PR DESCRIPTION
### Don't require all the nodes to be provisioned manually to upload to Google Play

Pass it as a credential from Jenkins instead.

fixes nightlies ;-)

`macos1` had GP key setup in fastlane storage, that is why it worked before.
Other nodes don't (and shoudn't) have that (because it makes provisioning weird).

### Pass Slack keys from Jenkins variables too

This replaces this mechanics with more "normal" way of doing things — using Jenkins credentials.

status: ready <!-- Can be ready or wip -->