### PR TITLE
[CI] Renamed apk for e2e tests

### DIFF
--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -107,7 +107,7 @@ timeout(90) {
 
         stage('Upload apk for e2e tests') {
           if (env.CHANGE_ID != null) {
-              env.SAUCE_LABS_APK = 'im.status.ethereum-e2e-' + env.CHANGE_ID + '.apk'
+              env.SAUCE_LABS_APK = env.CHANGE_ID + '.apk'
               withCredentials([
                   string(credentialsId: 'SAUCE_ACCESS_KEY', variable: 'SAUCE_ACCESS_KEY'),
                   string(credentialsId: 'SAUCE_USERNAME', variable: 'SAUCE_USERNAME'),


### PR DESCRIPTION
probot is triggering e2e tests with parameters, one of them is apk e.g. (0000.apk, where 0000 is a PR number)
builds which were named in the old way won't be found by tests in case if we will change the setting in porbot to use new names

so it worth to be renamed back