### PR TITLE
Copy on stack status-go signal data

### DIFF
--- a/modules/react-native-status/desktop/CMakeLists.txt
+++ b/modules/react-native-status/desktop/CMakeLists.txt
@@ -37,7 +37,7 @@ ExternalProject_Add(StatusGo_ep
   PREFIX ${StatusGo_PREFIX}
   SOURCE_DIR ${StatusGo_SOURCE_DIR}
   GIT_REPOSITORY https://github.com/status-im/status-go.git
-  GIT_TAG 03bf6e37
+  GIT_TAG develop-ga6d69eba
   BUILD_BYPRODUCTS ${StatusGo_STATIC_LIB}
   CONFIGURE_COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/${CONFIGURE_SCRIPT} ${GO_ROOT_PATH} ${StatusGo_ROOT} ${StatusGo_SOURCE_DIR}
   BUILD_COMMAND ""

--- a/modules/react-native-status/desktop/rctstatus.cpp
+++ b/modules/react-native-status/desktop/rctstatus.cpp
@@ -40,8 +40,8 @@ RCTStatus* RCTStatusPrivate::rctStatus = nullptr;
 
 RCTStatus::RCTStatus(QObject* parent) : QObject(parent), d_ptr(new RCTStatusPrivate) {
     RCTStatusPrivate::rctStatus = this;
-    SetSignalEventCallback((void*)&RCTStatus::jailSignalEventCallback);
-    connect(this, &RCTStatus::jailSignalEvent, this, &RCTStatus::onJailSignalEvent);
+    SetSignalEventCallback((void*)&RCTStatus::statusGoEventCallback);
+    connect(this, &RCTStatus::statusGoEvent, this, &RCTStatus::onStatusGoEvent);
 }
 
 RCTStatus::~RCTStatus() {}
@@ -241,17 +241,17 @@ bool RCTStatus::JSCEnabled() {
     return false;
 }
 
-void RCTStatus::jailSignalEventCallback(const char* signal) {
-    qDebug() << "call of RCTStatus::jailSignalEventCallback ... signal: " << signal;
-    RCTStatusPrivate::rctStatus->emitSignalEvent(signal);
+void RCTStatus::statusGoEventCallback(const char* event) {
+    qDebug() << "call of RCTStatus::statusGoEventCallback ... event: " << event;
+    RCTStatusPrivate::rctStatus->emitStatusGoEvent(event);
 }
 
-void RCTStatus::emitSignalEvent(const char* signal) {
-    qDebug() << "call of RCTStatus::emitSignalEvent ... signal: " << signal;
-    Q_EMIT jailSignalEvent(signal);
+void RCTStatus::emitStatusGoEvent(QString event) {
+    qDebug() << "call of RCTStatus::emitStatusGoEvent ... event: " << event;
+    Q_EMIT statusGoEvent(event);
 }
 
-void RCTStatus::onJailSignalEvent(const char* signal) {
-    qDebug() << "call of RCTStatus::onJailSignalEvent ... signal: " << signal;
-    RCTStatusPrivate::bridge->eventDispatcher()->sendDeviceEvent("gethEvent", QVariantMap{{"jsonEvent", signal}});
+void RCTStatus::onStatusGoEvent(QString event) {
+    qDebug() << "call of RCTStatus::onStatusGoEvent ... event: " << event.toUtf8().data();
+    RCTStatusPrivate::bridge->eventDispatcher()->sendDeviceEvent("gethEvent", QVariantMap{{"jsonEvent", event.toUtf8().data()}});
 }

--- a/modules/react-native-status/desktop/rctstatus.h
+++ b/modules/react-native-status/desktop/rctstatus.h
@@ -56,15 +56,15 @@ public:
     Q_INVOKABLE void getDeviceUUID(double callbackId);
 
     Q_INVOKABLE static bool JSCEnabled();
-    Q_INVOKABLE static void jailSignalEventCallback(const char* signal);
+    Q_INVOKABLE static void statusGoEventCallback(const char* event);
 
-    void emitSignalEvent(const char* signal);
+    void emitStatusGoEvent(QString event);
 
 Q_SIGNALS:
-    void jailSignalEvent(const char* signal);
+    void statusGoEvent(QString event);
 
 private Q_SLOTS:
-    void onJailSignalEvent(const char* signal);
+    void onStatusGoEvent(QString event);
 
 private:
     QScopedPointer<RCTStatusPrivate> d_ptr;


### PR DESCRIPTION
fixes #5483

### Summary:

Resolves issues appeared with status-go 0.10.0 upgrade during login

Additional info:
App hanging after user log in, because geth node is crashed, because there was attempt to start it twice, because after first try to start geth node "is-node-started" variable was not set in CLJS, because the signal with event about successful "node.started" was not propagated at first time from RCTStatus.cpp native module, because signal event data of type `char *` was corrupted after passed to main app thread from status-go thread, because something was changed internally in status-go (before it worked fine). Current solution is to copy signal event data by keeping it withing QString type by value on stack.

### Steps to test:
- Open Status
- Login into account

status: ready
