### PR TITLE
[#5467] Make app searchable with Spotlight

### DIFF
--- a/ci/Jenkinsfile.desktopbuild
+++ b/ci/Jenkinsfile.desktopbuild
@@ -133,11 +133,12 @@ timeout(90) {
 
               stage('Create MacOS Bundle') {
                 dir(packageFolder) {
-                  sh 'git clone https://github.com/vkjr/StatusAppFiles.git'
-                  sh 'unzip StatusAppFiles/StatusIm.app.zip'
+                  sh 'curl -L -O "https://github.com/status-im/StatusAppFiles/raw/master/StatusIm.app.zip"'
+                  sh 'unzip StatusIm.app.zip'
                   sh 'cp -r assets/share/assets StatusIm.app/Contents/MacOs'
                   sh 'chmod +x StatusIm.app/Contents/MacOs/ubuntu-server'
                   sh 'cp ../desktop/bin/StatusIm StatusIm.app/Contents/MacOs'
+                  sh 'cp -f ../deployment/macos/Info.plist StatusIm.app/Contents'
                   sh """
                     macdeployqt StatusIm.app -verbose=1 -dmg \\
                       -qmldir='${workspace}/node_modules/react-native/ReactQt/runtime/src/qml/'

--- a/ci/Jenkinsfile.nightly_desktop
+++ b/ci/Jenkinsfile.nightly_desktop
@@ -152,11 +152,12 @@ parallel(
 
           stage('Create MacOS Bundle') {
             dir(packageFolder) {
-              sh 'git clone https://github.com/vkjr/StatusAppFiles.git'
-              sh 'unzip StatusAppFiles/StatusIm.app.zip'
+              sh 'curl -L -O "https://github.com/status-im/StatusAppFiles/raw/master/StatusIm.app.zip"'
+              sh 'unzip StatusIm.app.zip'
               sh 'cp -r assets/share/assets StatusIm.app/Contents/MacOs'
               sh 'chmod +x StatusIm.app/Contents/MacOs/ubuntu-server'
               sh 'cp ../desktop/bin/StatusIm StatusIm.app/Contents/MacOs'
+              sh 'cp -f ../deployment/macos/Info.plist StatusIm.app/Contents'
               sh """
                 macdeployqt StatusIm.app -verbose=1 -dmg \\
                   -qmldir='${workspace}/node_modules/react-native/ReactQt/runtime/src/qml/'

--- a/deployment/macos/Info.plist
+++ b/deployment/macos/Info.plist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleIconFile</key>
+	<string>status-icon</string>
+	<key>NSHighResolutionCapable</key>
+	<string>True</string>
+	<key>CFBundleIdentifier</key>
+	<string>im.status.statusim</string>
+	<key>CFBundleExecutable</key>
+	<string>StatusIm</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+</dict>
+</plist>


### PR DESCRIPTION
Add metadata to `Info.plist` to allow application bundle to be properly indexed by Spotlight. Fixes #5467. 

Before:
<img width="596" alt="screen shot 2018-08-17 at 11 40 12" src="https://user-images.githubusercontent.com/1690961/44278777-b13c6f00-a23e-11e8-87da-39966ce141ee.png">

After:
<img width="598" alt="screen shot 2018-08-17 at 20 01 40" src="https://user-images.githubusercontent.com/1690961/44278971-3fb0f080-a23f-11e8-8b7a-14f98b5bc2d6.png">
