### PR TITLE
less noisy fastlane slack notifications

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -15,7 +15,7 @@
 def unlock_keychain_if_needed
     if ENV["KEYCHAIN_PASSWORD"]
         unlock_keychain(
-            path:"login.keychain", 
+            path:"login.keychain",
             password:ENV["KEYCHAIN_PASSWORD"],
             set_default: true)
     end
@@ -34,7 +34,7 @@ def upload_to_saucelabs(file)
     upload_result = sh(
         "curl",
         "-u", username + ':' + key,
-        "-X", "POST", 
+        "-X", "POST",
         "-H", "Content-Type: application/octet-stream",
         url,
         # this command has `status-react/fastlane` as cwd
@@ -49,7 +49,7 @@ def upload_to_saucelabs(file)
 end
 
 
-# builds an ios app with ad-hoc configuration and put it 
+# builds an ios app with ad-hoc configuration and put it
 # to "status-adhoc" output folder
 def build_ios_adhoc
     match(
@@ -86,7 +86,8 @@ def notify_about_new_build(source, url)
 
     slack(
         message: msg,
-        slack_url: ENV["SLACK_URL"]
+        slack_url: ENV["SLACK_URL"],
+        default_payloads: []
     )
 
     change_id = ENV["CHANGE_ID"]
@@ -161,7 +162,8 @@ platform :ios do
 
     slack(
         message: "New nightly build uploaded to TestFlight",
-        slack_url: ENV["SLACK_URL"]
+        slack_url: ENV["SLACK_URL"],
+        default_payloads: []
     )
 
     # additional .ipa is for diawi
@@ -198,7 +200,8 @@ platform :ios do
     )
     slack(
         message: "New release build uploaded to TestFlight",
-        slack_url: ENV["SLACK_URL"]
+        slack_url: ENV["SLACK_URL"],
+        default_payloads: []
     )
   end
 
@@ -235,7 +238,7 @@ platform :ios do
           '../ci/download-realm.js',
           '../node_modules/realm/scripts',
           remove_destination: true
-      )    
+      )
   end
 
 end
@@ -253,7 +256,8 @@ platform :android do
 
     slack(
         message: "New nightly build uploaded to Google Play",
-        slack_url: ENV["SLACK_URL"]
+        slack_url: ENV["SLACK_URL"],
+        default_payloads: []
     )
   end
   lane :release do
@@ -266,7 +270,8 @@ platform :android do
     )
     slack(
         message: "New release build uploaded to Google Play",
-        slack_url: ENV["SLACK_URL"]
+        slack_url: ENV["SLACK_URL"],
+        default_payloads: []
     )
   end
 


### PR DESCRIPTION
This is a small change that quiets noisy Fastlane Slack notifications by removing the default payloads that don't add much context to the messages.

In the future we can add extra fields, eg

```
    payload: {
        "Release Notes" => changelog
      },
```

but for now I just wanted to reclaim slack a little bit.

<img width="527" alt="screen shot 2018-08-17 at 11 16 49 am" src="https://user-images.githubusercontent.com/116099/44258504-648d6f80-a20f-11e8-8227-ece8932239ff.png">

(ah I see my text editor Atom also removed some extra characters. not sure what the style guide is for this so I can setup Atom to correctly handle this?)