### PR TITLE
Fixes #5293: Messaging/transacting take too long to be processed if there is a 'Pending...' tx message

### DIFF
--- a/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusThreadPoolExecutor.java
+++ b/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusThreadPoolExecutor.java
@@ -2,9 +2,13 @@ package im.status.ethereum.module;
 
 import java.util.concurrent.*;
 
+/** Uses an unbounded queue, but allows timeout of core threads
+ * (modified case 2 in
+ * https://docs.oracle.com/javase/7/docs/api/java/util/concurrent/ThreadPoolExecutor.html ) */
 public class StatusThreadPoolExecutor {
     private static final int NUMBER_OF_CORES =
             Runtime.getRuntime().availableProcessors();
+    private static final int THREADS_TO_CORES_RATIO = 100;
     private static final int KEEP_ALIVE_TIME = 1;
     private static final TimeUnit KEEP_ALIVE_TIME_UNIT = TimeUnit.SECONDS;
 
@@ -15,11 +19,14 @@ public class StatusThreadPoolExecutor {
         mQueue = new LinkedBlockingQueue<>();
 
         mThreadPool = new ThreadPoolExecutor(
-            NUMBER_OF_CORES,
-            NUMBER_OF_CORES,
+            THREADS_TO_CORES_RATIO * NUMBER_OF_CORES,
+            THREADS_TO_CORES_RATIO * NUMBER_OF_CORES,
             KEEP_ALIVE_TIME,
             KEEP_ALIVE_TIME_UNIT,
             mQueue);
+
+        // Allow pool to drain
+        mThreadPool.allowCoreThreadTimeOut(true);
     }
 
     /** Pugh singleton */


### PR DESCRIPTION
Fixes #5293: Messaging/transacting take too long to be processed if there is a 'Pending...' tx message

### Summary:

Fixes poor choice of thread pool parameters in #3889 .
Still use an unbounded queue, but increase `corePoolSize` to a generous `100*NUMBER_OF_CORES`.
Allow it to drain by setting `allowCoreThreadTimeOut(true)`. Gives this behaviour:

* Pool initially has zero threads in it.
* New tasks add threads to the pool up to `corePoolSize`.
* Once pool is at `corePoolSize` threads, tasks get queued.
* After 1 second of inactivity, threads are killed. Pool can return to zero size if no tasks.

### Testing notes:

Have written ` StatusThreadPoolExecutorTest` to verify above behaviour. Unfortunately, integrating with react-native build is knarly (there are currently no native android tests), so posted as gist for now: https://gist.github.com/pacamara/9dbbd0a2780a107a37c197a9ec26bd43 . To use just create a dummy android project and add both files.

### Steps to test:

Existing reproduce steps for issue #5293 .

status: ready 
