### PR TITLE
bug #5243 - using correct error code for image picker compononent

### DIFF
--- a/components/src/status_im/ui/components/react.cljs
+++ b/components/src/status_im/ui/components/react.cljs
@@ -136,7 +136,7 @@
 (def image-picker-class js-dependencies/image-crop-picker)
 
 (defn show-access-error [o]
-  (when (= "ERROR_PICKER_UNAUTHORIZED_KEY" (object/get o "code")) ; Do not show error when user cancel selection
+  (when (= "E_PERMISSION_MISSING" (object/get o "code"))
     (utils/show-popup (i18n/label :t/error)
                       (i18n/label :t/photos-access-error))))
 


### PR DESCRIPTION
fixes #5243 

### Summary:

At some point, error codes were changed in a dependency component and we upgraded the dependency without changing the error code. This PR fixes the issue.

### Steps to test:
- Go to profile tab
- edit > change photo > from gallery
- when prompted for permissions deny

status: ready 
