### PR TITLE
bug #3911 - fixed balance in asset field when value too long

### DIFF
--- a/src/status_im/ui/screens/wallet/components/styles.cljs
+++ b/src/status_im/ui/screens/wallet/components/styles.cljs
@@ -138,11 +138,13 @@
   {:flex            1
    :flex-direction  :row
    :justify-content :space-between
-   :align-items     :center})
+   :align-items     :center
+   :flex-wrap       :wrap
+   :margin-left     10})
 
 (def asset-label-content
-  {:flex-direction    :row
-   :margin-horizontal 10})
+  {:flex-direction :row
+   :margin-right   10})
 
 (def asset-label
   {:margin-right 10})


### PR DESCRIPTION
fixes #3911 

### Summary:

Fixes asset selector when current balance (and asset name) are too long to fit the field.

### Steps to test:
- Get some STT (or another token with a long name and 18 decimals)
- Add a contact
- Send smallest possible amount to that contact (e.g. 0.000000000000000001)
- See how it looks, did it break into new line or continue beyond the screen


status: ready