### PR TITLE
bug #5224 - showing gas info in unconfirmed transactions

### DIFF
--- a/src/status_im/models/wallet.cljs
+++ b/src/status_im/models/wallet.cljs
@@ -140,12 +140,12 @@
           (assoc :confirmations "0"
                  :timestamp (str now)
                  :type :outbound
-                 :hash hash)
+                 :hash hash
+                 :value (:amount transaction)
+                 :token token
+                 :gas-limit (str (:gas transaction)))
           (update :gas-price str)
-          (assoc :value (:amount transaction))
-          (assoc :token token)
-          (update :gas str)
-          (dissoc :message-id :id)))))
+          (dissoc :message-id :id :gas)))))
 
 (defn handle-transaction-error [db {:keys [code message]}]
   (let [{:keys [dapp-transaction]} (get-in db [:wallet :send-transaction])]


### PR DESCRIPTION
fixes #5224 

### Summary:

Showing gas and gas price in unconfirmed transactions in history. This was already mostly fixed in wallet refactoring PR (#5455) - this PR fixes the field name mismatch for gas limit.

### Steps to test:
- Send a transaction (from dapp, chat or wallet) with custom gas limit and price
- Quickly navigate to Transaction history before the tx is through
- Check if displayed gas limit and cost correspond to what you specified

status: ready
