### PR TITLE
bug #5568 - correctly passing gasPrice param

### DIFF
--- a/src/status_im/models/wallet.cljs
+++ b/src/status_im/models/wallet.cljs
@@ -85,11 +85,11 @@
 
 ;; SEND TRANSACTION -> RPC TRANSACTION
 (defn prepare-send-transaction [from {:keys [amount to gas gas-price data nonce]}]
-  (cond-> {:from      (ethereum/normalized-address from)
-           :to        (ethereum/normalized-address to)
-           :value     (ethereum/int->hex amount)
-           :gas       (ethereum/int->hex gas)
-           :gas-price (ethereum/int->hex gas-price)}
+  (cond-> {:from     (ethereum/normalized-address from)
+           :to       (ethereum/normalized-address to)
+           :value    (ethereum/int->hex amount)
+           :gas      (ethereum/int->hex gas)
+           :gasPrice (ethereum/int->hex gas-price)}
     data
     (assoc :data data)
     nonce

--- a/src/status_im/ui/screens/wallet/send/events.cljs
+++ b/src/status_im/ui/screens/wallet/send/events.cljs
@@ -26,9 +26,9 @@
                            (security/unmask masked-password)
                            on-completed))
 
-(defn- send-tokens [symbol chain {:keys [from to value gas gas-price]} on-completed masked-password]
+(defn- send-tokens [symbol chain {:keys [from to value gas gasPrice]} on-completed masked-password]
   (let [contract (:address (tokens/symbol->token (keyword chain) symbol))]
-    (erc20/transfer contract from to value gas gas-price masked-password on-completed)))
+    (erc20/transfer contract from to value gas gasPrice masked-password on-completed)))
 
 (re-frame/reg-fx
  ::send-transaction


### PR DESCRIPTION
fixes #5568

### Summary:

gasPrice param wasn't correctly passed (kebab instead of camel) so some transactions used the default gas price regardless of what was selected.

### Steps to test:
see #5568

status: ready 