### PR TITLE
Buildscript fix: we used a wrong comment indicator before

### DIFF
--- a/scripts/lib/setup/installers.sh
+++ b/scripts/lib/setup/installers.sh
@@ -41,7 +41,7 @@ function install_wget() {
   if is_macos; then
     brew_install wget
   fi
-  // it's installed on ubuntu/debian by default
+  # it's installed on ubuntu/debian by default
 }
 
 function needs_java8_linux() {


### PR DESCRIPTION
Fixes a very small mistake in buildscript and allows to build the project again.