### PR TITLE
Enable emojis in desktop chat

### DIFF
--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -14,6 +14,9 @@
 (def content-type-placeholder "placeholder")
 (def content-type-emoji "emoji")
 
+(def desktop-content-types
+  #{text-content-type content-type-emoji})
+
 (def command-send "send")
 (def command-request "request")
 (def command-send-status-update-interval-ms 60000)

--- a/src/status_im/ui/screens/desktop/main/chat/views.cljs
+++ b/src/status_im/ui/screens/desktop/main/chat/views.cljs
@@ -127,7 +127,7 @@
   (if (= type :datemark)
     ^{:key (str "datemark" message-id)}
     [message.datemark/chat-datemark value]
-    (when (= content-type constants/text-content-type)
+    (when (contains? constants/desktop-content-types content-type)
       (reagent.core/create-class
        {:component-did-mount
         #(when (and message-id


### PR DESCRIPTION
fixes #5064 

### Summary:
Emojis without text now also displayed


### Steps to test:
- Open Status
- go to chat and send to that chat emoji from mobile app 
- make sure they are visible from desktop

status: ready
