### PR TITLE
Feature/qtbreakpad integration

### DIFF
--- a/ci/Jenkinsfile.desktopbuild
+++ b/ci/Jenkinsfile.desktopbuild
@@ -26,6 +26,7 @@ external_modules_dir = [
   'node_modules/react-native-keychain/desktop',
   'node_modules/react-native-securerandom/desktop',
   'modules/react-native-status/desktop',
+  'node_modules/google-breakpad',
 ]
 
 external_fonts = [
@@ -145,7 +146,10 @@ timeout(90) {
                   sh 'cp -r assets/share/assets StatusIm.app/Contents/MacOs'
                   sh 'chmod +x StatusIm.app/Contents/MacOs/ubuntu-server'
                   sh 'cp ../desktop/bin/StatusIm StatusIm.app/Contents/MacOs'
+                  sh 'cp ../desktop/reportApp/reportApp StatusIm.app/Contents/MacOs'
+                  sh 'install_name_tool -add_rpath "@executable_path/../Frameworks" StatusIm.app/Contents/MacOs/reportApp'
                   sh 'cp -f ../deployment/macos/Info.plist StatusIm.app/Contents'
+                  sh 'cp -f ../deployment/macos/qt.conf StatusIm.app/Contents/MacOs'
                   sh """
                     macdeployqt StatusIm.app -verbose=1 -dmg \\
                       -qmldir='${workspace}/node_modules/react-native/ReactQt/runtime/src/qml/'
@@ -212,6 +216,7 @@ timeout(90) {
                 sh "cp -r ./deployment/linux/usr  ${packageFolder}/AppDir"
                 sh "cp ./deployment/linux/.env  ${packageFolder}/AppDir"
                 sh "cp ./desktop/bin/StatusIm ${packageFolder}/AppDir/usr/bin"
+                sh "cp ./desktop/reportApp/reportApp ${packageFolder}/AppDir/usr/bin"
                 sh 'wget https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage'
                 sh 'chmod a+x ./linuxdeployqt-continuous-x86_64.AppImage'
 
@@ -219,6 +224,12 @@ timeout(90) {
                 sh 'rm -f StatusIm-x86_64.AppImage'
 
                 sh "ldd ${packageFolder}/AppDir/usr/bin/StatusIm"
+                sh """
+                  ./linuxdeployqt-continuous-x86_64.AppImage  \\
+                  ${packageFolder}/AppDir/usr/bin/reportApp \\
+                  -verbose=3 -always-overwrite -no-strip -no-translations -qmake=${qt_bin}/qmake \\
+                  -qmldir='${workspace}/desktop/reportApp'
+                """
                 sh """
                   ./linuxdeployqt-continuous-x86_64.AppImage \\
                     ${packageFolder}/AppDir/usr/share/applications/StatusIm.desktop \\

--- a/ci/desktop.groovy
+++ b/ci/desktop.groovy
@@ -11,6 +11,7 @@ external_modules_dir = [
   'node_modules/react-native-keychain/desktop',
   'node_modules/react-native-securerandom/desktop',
   'modules/react-native-status/desktop',
+  'node_modules/google-breakpad',
 ]
 
 external_fonts = [
@@ -116,6 +117,7 @@ def bundleLinux(type = 'nightly') {
   sh "cp -r ./deployment/linux/usr  ${packageFolder}/AppDir"
   sh "cp ./deployment/linux/.env  ${packageFolder}/AppDir"
   sh "cp ./desktop/bin/StatusIm ${packageFolder}/AppDir/usr/bin"
+  sh "cp ./desktop/reportApp/reportApp ${packageFolder}/AppDir/usr/bin"
   sh 'wget https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage'
   sh 'chmod a+x ./linuxdeployqt-continuous-x86_64.AppImage'
 
@@ -123,6 +125,12 @@ def bundleLinux(type = 'nightly') {
   sh 'rm -f StatusIm-x86_64.AppImage'
 
   sh "ldd ${packageFolder}/AppDir/usr/bin/StatusIm"
+  sh """
+    ./linuxdeployqt-continuous-x86_64.AppImage  \\
+    ${packageFolder}/AppDir/usr/bin/reportApp \\
+    -verbose=3 -always-overwrite -no-strip -no-translations -qmake=${qtBin}/qmake \\
+    -qmldir='${workspace}/desktop/reportApp'
+  """
   sh """
     ./linuxdeployqt-continuous-x86_64.AppImage \\
       ${packageFolder}/AppDir/usr/share/applications/StatusIm.desktop \\
@@ -177,6 +185,9 @@ def bundleMacOS(type = 'nightly') {
     sh 'cp -r assets/share/assets StatusIm.app/Contents/MacOs'
     sh 'chmod +x StatusIm.app/Contents/MacOs/ubuntu-server'
     sh 'cp ../desktop/bin/StatusIm StatusIm.app/Contents/MacOs'
+    sh 'cp ../desktop/reportApp/reportApp StatusIm.app/Contents/MacOs'
+    sh 'cp -f ../deployment/macos/qt.conf StatusIm.app/Contents/MacOs'
+    sh 'install_name_tool -add_rpath "@executable_path/../Frameworks" StatusIm.app/Contents/MacOs/reportApp'
     sh 'cp -f ../deployment/macos/Info.plist StatusIm.app/Contents'
     sh """
       macdeployqt StatusIm.app -verbose=1 -dmg \\

--- a/deployment/macos/qt.conf
+++ b/deployment/macos/qt.conf
@@ -1,0 +1,4 @@
+[Paths]
+Plugins = ../PlugIns
+Imports = ../Resources/qml
+Qml2Imports = ../Resources/qml

--- a/desktop/CMakeLists.txt
+++ b/desktop/CMakeLists.txt
@@ -20,6 +20,8 @@ foreach(external_module ${EXTERNAL_MODULES_DIR})
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../${external_module} ${CMAKE_CURRENT_BINARY_DIR}/${external_module})
 endforeach(external_module)
 
+add_subdirectory(reportApp)
+
 # APPLICATION_MAIN_CPP_PATH contains absolute path to generated template copy of main.cpp for application executable
 get_filename_component(APPLICATION_MAIN_CPP_PATH main.cpp ABSOLUTE)
 

--- a/desktop/reportApp/CMakeLists.txt
+++ b/desktop/reportApp/CMakeLists.txt
@@ -1,0 +1,36 @@
+# Copyright (c) 2017-present, Status Research and Development GmbH.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c11")
+
+set(APP_NAME "reportApp")
+
+find_package(Qt5Core REQUIRED)
+find_package(Qt5Qml REQUIRED)
+find_package(Qt5Quick REQUIRED)
+find_package(Qt5WebSockets REQUIRED)
+find_package(Qt5Svg REQUIRED)
+
+set(MAIN_CPP_SOURCE reportpublisher.cpp
+                    reportpublisher.cpp
+                    main.cpp)
+
+add_executable(
+  ${APP_NAME}
+  ${MAIN_CPP_SOURCE}
+  main.qrc
+)
+
+set(USED_QT_MODULES Core Qml Quick WebSockets Svg)
+
+qt5_use_modules(${APP_NAME} ${USED_QT_MODULES})
+
+set(REACT_NATIVE_DESKTOP_EXTERNAL_PROJECT_DEPS ${REACT_NATIVE_DESKTOP_EXTERNAL_PROJECT_DEPS} reportApp PARENT_SCOPE)

--- a/desktop/reportApp/main.cpp
+++ b/desktop/reportApp/main.cpp
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2017-present, Status Research and Development GmbH.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <QDebug>
+#include <QGuiApplication>
+#include <QQmlContext>
+#include <QQuickView>
+
+#include "reportpublisher.h"
+
+const int MAIN_WINDOW_WIDTH = 1024;
+const int MAIN_WINDOW_HEIGHT = 768;
+const int INPUT_ARGUMENTS_COUNT = 5;
+
+int main(int argc, char **argv) {
+
+  QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+  QGuiApplication app(argc, argv);
+
+  if (argc != INPUT_ARGUMENTS_COUNT) {
+    return 1;
+  }
+
+  app.setApplicationName("Crash Report");
+
+  ReportPublisher reportPublisher(argv[1], argv[2]);
+
+  QQuickView view;
+  view.rootContext()->setContextProperty("reportPublisher", &reportPublisher);
+  view.setSource(QUrl("qrc:///main.qml"));
+  view.setResizeMode(QQuickView::SizeRootObjectToView);
+  view.resize(MAIN_WINDOW_WIDTH, MAIN_WINDOW_HEIGHT);
+  view.show();
+
+  return app.exec();
+}

--- a/desktop/reportApp/main.qml
+++ b/desktop/reportApp/main.qml
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2017-present, Status Research and Development GmbH.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+import QtQuick 2.4
+import QtQuick.Controls 2.2
+import QtQuick.Layouts 1.3
+
+Rectangle {
+  id: root
+  width: 384
+  height: 640
+
+  ColumnLayout {
+      anchors.centerIn: parent
+      Text {
+        Layout.alignment: Qt.AlignCenter
+        text: "Oh, no! StatusIm application just crashed!"
+        font.bold: true
+        font.pointSize: 25
+      }
+      Text {
+        Layout.alignment: Qt.AlignCenter
+        Layout.topMargin: 20
+        text: "Please report us crash log files to allow us fix the issue!"
+        font.bold: true
+        font.pointSize: 20
+      }
+      RowLayout {
+          Layout.alignment: Qt.AlignCenter
+          Layout.topMargin: 40
+          spacing: 25
+
+          Button {
+            Layout.minimumWidth: 150
+            text: "Report (highly appreciated)"
+            onClicked: reportPublisher.submit()
+          }
+
+          Button {
+            text: "Restart and Quit"
+            onClicked: reportPublisher.restartAndQuit()
+          }
+
+          Button {
+            text: "Just Quit"
+            onClicked: reportPublisher.quit()
+          }
+      }
+      RowLayout {
+          Layout.alignment: Qt.AlignCenter
+          Layout.topMargin: 100
+
+          TextEdit {
+              readOnly: true
+              Layout.maximumWidth: 500
+              wrapMode: TextEdit.Wrap
+              selectByMouse: true
+              font.pointSize: 12
+              text: "Log files directory:\n" + reportPublisher.resolveDataStoragePath()
+          }
+
+          Button {
+            text: "View"
+            onClicked: reportPublisher.showDirectory()
+          }
+      }
+  }
+}
+

--- a/desktop/reportApp/main.qrc
+++ b/desktop/reportApp/main.qrc
@@ -1,0 +1,5 @@
+<RCC>
+  <qresource>
+    <file>main.qml</file>
+  </qresource>
+</RCC>

--- a/desktop/reportApp/reportpublisher.cpp
+++ b/desktop/reportApp/reportpublisher.cpp
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2017-present, Status Research and Development GmbH.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include "reportpublisher.h"
+
+#include <QApplication>
+#include <QDebug>
+#include <QDesktopServices>
+#include <QDir>
+#include <QFile>
+#include <QProcess>
+#include <QUrl>
+
+const QString REPORT_SUBMIT_URL =
+    QStringLiteral("https://goo.gl/forms/0705ZN0EMW3xLDpI2");
+
+ReportPublisher::ReportPublisher(QString minidumpFilePath,
+                                 QString crashedExecutablePath, QObject *parent)
+    : QObject(parent), m_minidumpFilePath(minidumpFilePath),
+      m_crashedExecutablePath(crashedExecutablePath) {}
+
+void ReportPublisher::submit() {
+  QDesktopServices::openUrl(QUrl(REPORT_SUBMIT_URL));
+  showDirectory();
+}
+
+void ReportPublisher::restartAndQuit() {
+  QString appPath = m_crashedExecutablePath;
+
+#ifdef Q_OS_MACOS
+  QFileInfo crashedExecutableFileInfo(m_crashedExecutablePath);
+  QString fullPath = crashedExecutableFileInfo.dir().absolutePath();
+  const QString bundleExtension = QStringLiteral(".app");
+  if (fullPath.contains(bundleExtension)) {
+    appPath = fullPath.left(fullPath.indexOf(bundleExtension) +
+                            bundleExtension.size());
+  }
+  QString cmd = QString("open %1").arg(appPath);
+#elif defined(Q_OS_LINUX)
+  QString cmd = appPath;
+#endif
+
+  QProcess::startDetached(cmd);
+
+  qApp->quit();
+}
+
+void ReportPublisher::quit() { qApp->quit(); }
+
+void ReportPublisher::showDirectory() {
+  QString dataStoragePath = resolveDataStoragePath();
+  if (!m_logFilesPrepared) {
+    m_logFilesPrepared = prepareReportFiles(dataStoragePath);
+  }
+  QDesktopServices::openUrl(
+      QUrl("file://" + dataStoragePath, QUrl::TolerantMode));
+}
+
+bool ReportPublisher::prepareReportFiles(QString reportDirPath) {
+  QFileInfo minidumpFileInfo(m_minidumpFilePath);
+  QFileInfo crashedExecutableFileInfo(m_crashedExecutablePath);
+  if (!minidumpFileInfo.exists() || !crashedExecutableFileInfo.exists())
+    return false;
+
+  return QFile::copy(m_minidumpFilePath,
+                     reportDirPath + QDir::separator() + "crash.dmp") &&
+         QFile::copy(m_crashedExecutablePath,
+                     reportDirPath + QDir::separator() +
+                         crashedExecutableFileInfo.fileName());
+}
+
+QString ReportPublisher::resolveDataStoragePath() {
+  QFileInfo minidumpFileInfo(m_minidumpFilePath);
+  QString dataStoragePath =
+      QStandardPaths::writableLocation(QStandardPaths::AppDataLocation) +
+      QDir::separator() + minidumpFileInfo.baseName();
+  QDir dir(dataStoragePath);
+  if (!dir.exists()) {
+    dir.mkpath(".");
+  }
+  return dataStoragePath;
+}

--- a/desktop/reportApp/reportpublisher.h
+++ b/desktop/reportApp/reportpublisher.h
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2017-present, Status Research and Development GmbH.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#ifndef REPORTPUBLISHER
+#define REPORTPUBLISHER
+
+#include <QObject>
+#include <QString>
+
+class ReportPublisher : public QObject {
+    Q_OBJECT
+
+public:
+    ReportPublisher(QString minidumpFilePath, QString crashedExecutablePath, QObject* parent = 0);
+
+    Q_INVOKABLE void submit();
+    Q_INVOKABLE void restartAndQuit();
+    Q_INVOKABLE void quit();
+    Q_INVOKABLE void showDirectory();
+    Q_INVOKABLE QString resolveDataStoragePath();
+
+private:
+
+    bool prepareReportFiles(QString reportDirPath);
+
+    QString m_minidumpFilePath;
+    QString m_crashedExecutablePath;
+    bool m_logFilesPrepared = false;
+};
+
+
+#endif // REPORTPUBLISHER

--- a/desktop_files/package.json
+++ b/desktop_files/package.json
@@ -14,7 +14,8 @@
     "node_modules/react-native-webview-bridge/desktop",
     "node_modules/react-native-keychain/desktop",
     "node_modules/react-native-securerandom/desktop",
-    "modules/react-native-status/desktop"
+    "modules/react-native-status/desktop",
+    "node_modules/google-breakpad"
   ],
   "desktopFonts": [
     "../../../../../resources/fonts/SF-Pro-Text-Regular.otf",
@@ -37,6 +38,7 @@
     "dns.js": "1.0.1",
     "emojilib": "2.2.9",
     "events": "1.1.1",
+    "google-breakpad": "git+https://github.com/status-im/google-breakpad.git",
     "homoglyph-finder": "1.1.1",
     "identicon.js": "github:status-im/identicon.js",
     "instabug-reactnative": "2.12.0",


### PR DESCRIPTION
### Summary:

Integrates google's breakpad library to intercept unhandled exceptions and launch reportApp to ask user report crash dump related files. reportApp opens folder with files prepared for uploading and at the same time navigates to dedicated Google Web Form in default web browser. On Google Web Form user submit new GitHub issue is created.

Related PR on which current depends - https://github.com/status-im/react-native-desktop/pull/318

### Review notes (optional):
Google Breakpad lib sources and wrapper to use lib in our main.cpp is moved to https://github.com/status-im/google-breakpad

### Testing notes (optional):
App forced to crash just after the start.

### Steps to test:
- Open Status
- Status should crash and report app window should be opened
- Press report button
- Google Web form should be opened in browser and directory with files to upload should be opened on desktop
- Fill Google Web form and upload the files, submit.
- New issue with provided information should appear at https://github.com/MaxRis/StatusImDesktopReports/issues

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready
