### PR TITLE
Fixed desktop api for using fleet

### DIFF
--- a/modules/react-native-status/desktop/CMakeLists.txt
+++ b/modules/react-native-status/desktop/CMakeLists.txt
@@ -37,7 +37,7 @@ ExternalProject_Add(StatusGo_ep
   PREFIX ${StatusGo_PREFIX}
   SOURCE_DIR ${StatusGo_SOURCE_DIR}
   GIT_REPOSITORY https://github.com/status-im/status-go.git
-  GIT_TAG v0.11.0
+  GIT_TAG develop-g19b53030
   BUILD_BYPRODUCTS ${StatusGo_STATIC_LIB}
   CONFIGURE_COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/${CONFIGURE_SCRIPT} ${GO_ROOT_PATH} ${StatusGo_ROOT} ${StatusGo_SOURCE_DIR}
   BUILD_COMMAND ""

--- a/modules/react-native-status/desktop/rctstatus.cpp
+++ b/modules/react-native-status/desktop/rctstatus.cpp
@@ -71,7 +71,7 @@ void RCTStatus::getDeviceUUID(double callbackId) {
 }
 
 
-void RCTStatus::startNode(QString configString) {
+void RCTStatus::startNode(QString configString, QString fleet) {
     Q_D(RCTStatus);
     qDebug() << "call of RCTStatus::startNode with param configString:" << configString;
 
@@ -97,7 +97,7 @@ void RCTStatus::startNode(QString configString) {
     qDebug()<<"RCTStatus::startNode networkDir: "<<networkDir;
 
 
-    char *configChars = GenerateConfig(networkDir.toUtf8().data(), networkId);
+    char *configChars = GenerateConfig(networkDir.toUtf8().data(), fleet.toUtf8().data(), networkId);
     qDebug() << "RCTStatus::startNode GenerateConfig result: " << configChars;
 
     jsonDoc = QJsonDocument::fromJson(QString(configChars).toUtf8(), &jsonError);
@@ -110,6 +110,7 @@ void RCTStatus::startNode(QString configString) {
     generatedConfig["KeyStoreDir"] = keyStoreDir;
     generatedConfig["LogEnabled"] = true;
     generatedConfig["LogFile"] = networkDir + "/geth.log";
+    generatedConfig["ClusterConfig.Fleet"] = fleet;
     //generatedConfig["LogLevel"] = "DEBUG";
 
     const char* result = StartNode(QString(QJsonDocument::fromVariant(generatedConfig).toJson(QJsonDocument::Compact)).toUtf8().data());

--- a/modules/react-native-status/desktop/rctstatus.h
+++ b/modules/react-native-status/desktop/rctstatus.h
@@ -32,7 +32,7 @@ public:
     QList<ModuleMethod*> methodsToExport() override;
     QVariantMap constantsToExport() override;
 
-    Q_INVOKABLE void startNode(QString configString);
+    Q_INVOKABLE void startNode(QString configString, QString fleet);
     Q_INVOKABLE void stopNode();
     Q_INVOKABLE void createAccount(QString password, double callbackId);
     Q_INVOKABLE void notifyUsers(QString token, QString payloadJSON, QString tokensJSON, double callbackId);


### PR DESCRIPTION
Fixes broken desktop build that uses not the same `status-go` as mobile.


### Summary:

This PR complements #5503. 
`react-native-status` api changed to be used with new `status-go`


### Steps to test:
- Open Status
- Try to login, make sure you don' have startNode error


status: ready