### PR TITLE
bug #4476 - fixes reoccurrence of recovery phrase in logs

### DIFF
--- a/src/status_im/ui/screens/accounts/recover/models.cljs
+++ b/src/status_im/ui/screens/accounts/recover/models.cljs
@@ -47,10 +47,11 @@
 
 ;;;; Handlers
 
-(defn set-phrase [recovery-phrase {:keys [db]}]
-  {:db (update db :accounts/recover assoc
-               :passphrase (string/lower-case recovery-phrase)
-               :passphrase-valid? (not (check-phrase-errors recovery-phrase)))})
+(defn set-phrase [masked-recovery-phrase {:keys [db]}]
+  (let [recovery-phrase (security/unmask masked-recovery-phrase)]
+    {:db (update db :accounts/recover assoc
+                 :passphrase (string/lower-case recovery-phrase)
+                 :passphrase-valid? (not (check-phrase-errors recovery-phrase)))}))
 
 (defn validate-phrase [{:keys [db]}]
   (let [recovery-phrase (get-in db [:accounts/recover :passphrase])]

--- a/src/status_im/ui/screens/accounts/recover/views.cljs
+++ b/src/status_im/ui/screens/accounts/recover/views.cljs
@@ -28,7 +28,7 @@
       :multiline           true
       :default-value       passphrase
       :auto-correct        false
-      :on-change-text      #(re-frame/dispatch [:recover/set-phrase %])
+      :on-change-text      #(re-frame/dispatch [:recover/set-phrase (security/mask-data %)])
       :on-blur             #(re-frame/dispatch [:recover/validate-phrase])
       :error               (cond error (i18n/label error)
                                  warning (i18n/label warning))}]))

--- a/test/cljs/status_im/test/ui/screens/accounts/recover/models.cljs
+++ b/test/cljs/status_im/test/ui/screens/accounts/recover/models.cljs
@@ -44,19 +44,19 @@
 (deftest set-phrase
   (is (= {:db {:accounts/recover {:passphrase        "game buzz method pretty olympic fat quit display velvet unveil marine crater"
                                   :passphrase-valid? true}}}
-         (models/set-phrase "game buzz method pretty olympic fat quit display velvet unveil marine crater" {:db {}})))
+         (models/set-phrase (security/mask-data "game buzz method pretty olympic fat quit display velvet unveil marine crater") {:db {}})))
   (is (= {:db {:accounts/recover {:passphrase        "game buzz method pretty olympic fat quit display velvet unveil marine crater"
                                   :passphrase-valid? true}}}
-         (models/set-phrase "Game buzz method pretty Olympic fat quit DISPLAY velvet unveil marine crater" {:db {}})))
+         (models/set-phrase (security/mask-data "Game buzz method pretty Olympic fat quit DISPLAY velvet unveil marine crater") {:db {}})))
   (is (= {:db {:accounts/recover {:passphrase        "game buzz method pretty zeus fat quit display velvet unveil marine crater"
                                   :passphrase-valid? true}}}
-         (models/set-phrase "game buzz method pretty zeus fat quit display velvet unveil marine crater" {:db {}})))
+         (models/set-phrase (security/mask-data "game buzz method pretty zeus fat quit display velvet unveil marine crater") {:db {}})))
   (is (= {:db {:accounts/recover {:passphrase        "   game\t  buzz method pretty olympic fat quit\t   display velvet unveil marine crater  "
                                   :passphrase-valid? true}}}
-         (models/set-phrase "   game\t  buzz method pretty olympic fat quit\t   display velvet unveil marine crater  " {:db {}})))
+         (models/set-phrase (security/mask-data "   game\t  buzz method pretty olympic fat quit\t   display velvet unveil marine crater  ") {:db {}})))
   (is (= {:db {:accounts/recover {:passphrase        "game buzz method pretty 1234 fat quit display velvet unveil marine crater"
                                   :passphrase-valid? false}}}
-         (models/set-phrase "game buzz method pretty 1234 fat quit display velvet unveil marine crater" {:db {}}))))
+         (models/set-phrase (security/mask-data "game buzz method pretty 1234 fat quit display velvet unveil marine crater") {:db {}}))))
 
 (deftest validate-phrase
   (is (= {:db {:accounts/recover {:passphrase-error   nil


### PR DESCRIPTION
### Summary:

We had a regression (probably) in #5494 - recovery phrase visible in logs during recovery. The scenario is covered with automated tests against nightly, but not against the PRs.

This PR fixes the issue and updates unit tests. In addition @antdanchenko will enable all logcat related tests for PR testing, since logcat isn't visible on screen.

### Steps to test:
- run automated tests against this PR
- check logcat to see if passphrase (or password) are present in the log

status: ready 