### PR TITLE
add build metadata for Jenkins combined builds

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -116,6 +116,15 @@ def getVersionName = { ->
     }
 }
 
+def getBuildUrl = { ->
+    new ByteArrayOutputStream().withStream { stdOut ->
+        if (project.hasProperty("buildUrl")) {
+            return project.buildUrl
+        }
+        return 'Local Build'
+    }
+}
+
 android {
     compileSdkVersion 27
 
@@ -129,6 +138,13 @@ android {
         ndk {
             abiFilters "armeabi-v7a", "arm64-v8a", "x86"
         }
+    }
+    /**
+     * Arbitrary project metadata
+     * https://docs.gradle.org/current/dsl/org.gradle.api.plugins.ExtraPropertiesExtension.html
+     **/
+    project.ext {
+        buildUrl = getBuildUrl()
     }
     /**
     * Fix for: (https://github.com/ReactiveX/RxJava/issues/4445)

--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -3,9 +3,9 @@ pipeline {
 
   options {
     buildDiscarder(logRotator(
-      numToKeepStr: '10',
+      numToKeepStr: '20',
       daysToKeepStr: '30',
-      artifactNumToKeepStr: '6',
+      artifactNumToKeepStr: '10',
     ))
   }
   

--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -13,48 +13,47 @@ pipeline {
   stages {
     stage('Tag') {
       steps { script {
-        common = load('ci/common.groovy')
+        cmn = load('ci/common.groovy')
         /* to avoid missing build tag parallel builds */
-        print "Build Number: ${common.tagBuild()}"
+        print "Build Number: ${cmn.tagBuild(true)}"
       } }
     }
     stage('Build') {
       parallel {
         stage('MacOS') { steps { script {
-          osx = common.buildBranch('status-react/combined/desktop-macos')
+          osx = cmn.buildBranch('status-react/combined/desktop-macos')
         } } }
         stage('Linux') { steps { script {
-          nix = common.buildBranch('status-react/combined/desktop-linux')
+          nix = cmn.buildBranch('status-react/combined/desktop-linux')
         } } }
         stage('iOS') { steps { script {
-          ios = common.buildBranch('status-react/combined/mobile-ios')
+          ios = cmn.buildBranch('status-react/combined/mobile-ios')
         } } }
         stage('Android') { steps { script {
-          dro = common.buildBranch('status-react/combined/mobile-android')
+          dro = cmn.buildBranch('status-react/combined/mobile-android')
         } } }
         stage('Android e2e') { steps { script {
-          e2e = common.buildBranch('status-react/combined/mobile-android', 'e2e')
+          e2e = cmn.buildBranch('status-react/combined/mobile-android', 'e2e')
         } } }
       }
     }
     stage('Archive') {
       steps { script {
         sh('rm -f pkg/*')
-        common.copyArts('status-react/combined/desktop-macos', osx.number)
-        common.copyArts('status-react/combined/desktop-linux', nix.number)
-        common.copyArts('status-react/combined/mobile-android', dro.number)
-        common.copyArts('status-react/combined/mobile-android', e2e.number)
+        cmn.copyArts('status-react/combined/desktop-macos', osx.number)
+        cmn.copyArts('status-react/combined/desktop-linux', nix.number)
+        cmn.copyArts('status-react/combined/mobile-android', dro.number)
+        cmn.copyArts('status-react/combined/mobile-android', e2e.number)
         archiveArtifacts('pkg/*')
       } }
     }
     stage('Upload') {
       when { expression { params.BUILD_TYPE == 'nightly' } }
       steps { script {
-        def pkg = "StatusIm-${GIT_COMMIT.take(6)}"
-        e2eUrl = common.uploadArtifact('pkg', "${pkg}-e2e.apk")
-        apkUrl = common.uploadArtifact('pkg', "${pkg}.apk")
-        dmgUrl = common.uploadArtifact('pkg', "${pkg}.dmg")
-        appUrl = common.uploadArtifact('pkg', "${pkg}.AppImage")
+        e2eUrl = cmn.uploadArtifact(findFiles(glob: 'pkg/*.e2e.apk')[0].path)
+        apkUrl = cmn.uploadArtifact(findFiles(glob: "pkg/*.${params.BUILD_TYPE}.apk")[0].path)
+        dmgUrl = cmn.uploadArtifact(findFiles(glob: 'pkg/*.dmg')[0].path)
+        appUrl = cmn.uploadArtifact(findFiles(glob: 'pkg/*.AppImage')[0].path)
         /* special case for iOS Diawi link */
         ipaUrl = ios.getBuildVariables().get('DIAWI_URL')
       } }
@@ -67,11 +66,12 @@ pipeline {
             "<${currentBuild.absoluteUrl}|${currentBuild.displayName}> "+
             "(${currentBuild.durationString})\n"+
             (params.BUILD_TYPE == 'nightly' ?
-              "E2E: ${e2eUrl}\n"+
-              "APK: ${apkUrl}\n"+
-              "IPA: ${ipaUrl}\n"+
-              "DMG: ${dmgUrl}\n"+
-              "APP: ${appUrl}\n"
+              "Packages: "+
+              "<${apkUrl}|Android>, "+
+              "(<${e2eUrl}|e2e>), "+
+              "<${ipaUrl}|iOS>, "+
+              "<${dmgUrl}|MacOS>, "+
+              "<${appUrl}|AppImage>"
             : '')
           ),
           color: 'good'

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -11,9 +11,9 @@ pipeline {
 
   options {
     buildDiscarder(logRotator(
-      numToKeepStr: '10',
+      numToKeepStr: '20',
       daysToKeepStr: '30',
-      artifactNumToKeepStr: '1',
+      artifactNumToKeepStr: '10',
     ))
   }
   

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -3,9 +3,9 @@ pipeline {
 
   options {
     buildDiscarder(logRotator(
-      numToKeepStr: '10',
+      numToKeepStr: '20',
       daysToKeepStr: '30',
-      artifactNumToKeepStr: '1',
+      artifactNumToKeepStr: '10',
     ))
   }
   
@@ -37,7 +37,7 @@ pipeline {
     }
     stage('Bundle') {
       steps {
-        script { app = desktop.bundleLinux() }
+        script { app = desktop.bundleLinux(params.BUILD_TYPE) }
       }
     }
     stage('Archive') {

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -3,9 +3,9 @@ pipeline {
 
   options {
     buildDiscarder(logRotator(
-      numToKeepStr: '10',
+      numToKeepStr: '20',
       daysToKeepStr: '30',
-      artifactNumToKeepStr: '1',
+      artifactNumToKeepStr: '10',
     ))
   }
   
@@ -37,7 +37,7 @@ pipeline {
     }
     stage('Bundle') {
       steps {
-        script { dmg = desktop.bundleMacOS() }
+        script { dmg = desktop.bundleMacOS(params.BUILD_TYPE) }
       }
     }
     stage('Archive') {

--- a/ci/android.groovy
+++ b/ci/android.groovy
@@ -15,15 +15,15 @@ def uploadArtifact() {
 
 def compile(type = 'nightly') {
   common.tagBuild()
-  def gradleOpt = ''
+  def gradleOpt = "-PbuildUrl='${currentBuild.absoluteUrl}' "
   if (type == 'release') {
-    gradleOpt = "-PreleaseVersion=${common.version()}"
+    gradleOpt += "-PreleaseVersion='${common.version()}'"
   }
   dir('android') {
     sh './gradlew react-native-android:installArchives'
     sh "./gradlew assembleRelease ${gradleOpt}"
   }
-  def pkg = "StatusIm-${GIT_COMMIT.take(6)}${(type == 'e2e' ? '-e2e' : '')}.apk"
+  def pkg = common.pkgFilename(type, 'apk')
   sh "cp android/app/build/outputs/apk/release/app-release.apk ${pkg}"
   return pkg
 }

--- a/ci/desktop.groovy
+++ b/ci/desktop.groovy
@@ -102,8 +102,8 @@ def compileLinux() {
   }
 }
   
-def bundleLinux() {
-  def appFile
+def bundleLinux(type = 'nightly') {
+  def pkg
 
   dir(packageFolder) {
     sh 'rm -rf StatusImAppImage'
@@ -146,10 +146,10 @@ def bundleLinux() {
   dir(packageFolder) {
     sh 'ldd AppDir/usr/bin/StatusIm'
     sh 'rm -rf StatusIm.AppImage'
-    appFile = "StatusIm-${GIT_COMMIT.take(6)}.AppImage"
-    sh "mv ../StatusIm-x86_64.AppImage ${appFile}"
+    pkg = common.pkgFilename(type, 'AppImage')
+    sh "mv ../StatusIm-x86_64.AppImage ${pkg}"
   }
-  return "${packageFolder}/${appFile}".drop(2)
+  return "${packageFolder}/${pkg}".drop(2)
 }
 
 def compileMacOS() {
@@ -169,8 +169,8 @@ def compileMacOS() {
   }
 }
 
-def bundleMacOS() {
-  def dmgFile
+def bundleMacOS(type = 'nightly') {
+  def pkg = common.pkgFilename(type, 'dmg')
   dir(packageFolder) {
     sh 'git clone https://github.com/vkjr/StatusAppFiles.git'
     sh 'unzip StatusAppFiles/StatusIm.app.zip'
@@ -182,10 +182,9 @@ def bundleMacOS() {
         -qmldir='${workspace}/node_modules/react-native/ReactQt/runtime/src/qml/'
     """
     sh 'rm -fr StatusAppFiles'
-    dmgFile = "StatusIm-${GIT_COMMIT.take(6)}.dmg"
-    sh "mv StatusIm.dmg ${dmgFile}"
+    sh "mv StatusIm.dmg ${pkg}"
   }
-  return "${packageFolder}/${dmgFile}".drop(2)
+  return "${packageFolder}/${pkg}".drop(2)
 }
 
 return this

--- a/ci/mobile.groovy
+++ b/ci/mobile.groovy
@@ -2,7 +2,7 @@ common = load 'ci/common.groovy'
 ios = load 'ci/ios.groovy'
 android = load 'ci/android.groovy'
 
-def prep(type = 'debug') {
+def prep(type = 'nightly') {
   /* select type of build */
   switch (type) {
     case 'nightly':

--- a/ios/StatusIm/Info.plist
+++ b/ios/StatusIm/Info.plist
@@ -31,6 +31,8 @@
 	<string>1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
+	<key>CFBundleBuildUrl</key>
+	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSApplicationQueriesSchemes</key>

--- a/scripts/build_no.sh
+++ b/scripts/build_no.sh
@@ -20,37 +20,61 @@ set -e
 # * https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 #
 
-getNumber () {
-    echo "$BUILD" | sed 's/[^0-9]*//g'
-}
-
 REGEX='^build-[0-9]\+$'
 
-# make sure we have all the tags
-git fetch --tags --quiet >/dev/null || >&2 echo "Could not fetch tags from remote"
+getNumber () {
+    echo "$1" | sed 's/[^0-9]*//g'
+}
 
-# even if the current commit has a tag already, it is normal that the same commit
-# is built multiple times (with different build configurations, for instance),
-# so we increment the build number every time.
-
-# find the last used build number
-BUILD=$(git tag -l --sort=-v:refname | grep -e "$REGEX" | head -n 1)
-# extract the number
-BUILD_NO=$(getNumber "$BUILD")
-
-if [ "$1" = "--increment" ]; then
-    # These need to be provided by Jenkins
-    if [ -z "${GIT_USER}" ] || [ -z "${GIT_PASS}" ]; then
-        echo "Git credentials not specified! (GIT_USER, GIT_PASS)" >&2
-        exit 1
+findNumber () (
+    # check if current commit has a build tag
+    # since we are building in separate jobs we have to check for a tag
+    BUILD_TAG=$(git tag --points-at HEAD | grep -e "$REGEX" | tail -n1)
+    
+    # use already existing build number if applicable
+    if [ -n "$BUILD_TAG" ]; then
+        echo "Current commit already tagged: $BUILD_TAG" >&2
+        getNumber $BUILD_TAG
     fi
+)
+
+tagBuild () {
+    echo "Tagging HEAD: build-$1" >&2
+    git tag "build-$1" HEAD
+    if [ -n "$GIT_USER" ] && [ -n "$GIT_PASS" ]; then
+        git push --tags \
+          https://${GIT_USER}:${GIT_PASS}@github.com/status-im/status-react
+    else
+        git push --tags git@github.com:status-im/status-react
+    fi
+}
+
+increment () {
+    # find the last used build number
+    BUILD=$(git tag -l --sort=-v:refname | grep -e "$REGEX" | head -n 1)
+    # extract the number
+    BUILD_NO=$(getNumber "$BUILD")
+    
     # increment
     BUILD_NO="$((BUILD_NO+1))"
+    # finally print build number
+    echo "$BUILD_NO"
+}
 
-    echo "Tagging HEAD: build-$BUILD_NO" >&2
-    git tag "build-$BUILD_NO" HEAD
-    git push --tags https://${GIT_USER}:${GIT_PASS}@github.com/status-im/status-react
+#####################################################################
+
+# make sure we have all the tags
+git fetch --tags --quiet >/dev/null || \
+    >&2 echo "Could not fetch tags from remote"
+
+# check if this commit already has a build number
+NUMBER=$(findNumber)
+
+# if it doesn't, or we are forcing via cli option, increment
+if [ -z "$NUMBER" ] || [ "$1" = "--increment" ]; then
+    NUMBER=$(increment)
+    tagBuild $NUMBER
 fi
 
-# finally print build number
-echo "$BUILD_NO"
+# print build number
+echo $NUMBER


### PR DESCRIPTION
Changes:

* Changed how the build names look:
  - Template: `StatusIm.${date}.${time}.${commit}.${type}.${ext}`
  - Example: `StatusIm.180823.184924.8ff20f.nightly.apk`
* Added metadata to Android and iOS builds with Jenkins build link
* Bumps build archive limits for new Jenkins jobs
* Shortens the format of Slack message after successful build
* Changes the DigitalOcean space used to generic `status-im`