### PR TITLE
[fix #5612 #5613] improve contact code validation

### DIFF
--- a/src/status_im/ui/screens/add_new/new_chat/db.cljs
+++ b/src/status_im/ui/screens/add_new/new_chat/db.cljs
@@ -4,13 +4,14 @@
             [cljs.spec.alpha :as spec]
             [clojure.string :as string]))
 
-(defn validate-pub-key [whisper-identity {:keys [address public-key]}]
-  (cond
-    (string/blank? whisper-identity)
-    (i18n/label :t/use-valid-contact-code)
-    (#{(hex/normalize-hex address) (hex/normalize-hex public-key)}
-     (hex/normalize-hex whisper-identity))
-    (i18n/label :t/can-not-add-yourself)
+(defn own-whisper-identity?
+  [{{:keys [public-key]} :account/account} whisper-identity]
+  (= whisper-identity public-key))
 
+(defn validate-pub-key [db whisper-identity]
+  (cond
     (not (spec/valid? :global/public-key whisper-identity))
-    (i18n/label :t/use-valid-contact-code)))
+    (i18n/label :t/use-valid-contact-code)
+
+    (own-whisper-identity? db whisper-identity)
+    (i18n/label :t/can-not-add-yourself)))

--- a/src/status_im/ui/screens/add_new/new_chat/events.cljs
+++ b/src/status_im/ui/screens/add_new/new_chat/events.cljs
@@ -16,7 +16,7 @@
 (handlers/register-handler-fx
  :new-chat/set-new-identity
  (fn [{{:keys [web3 network network-status] :as db} :db} [_ new-identity]]
-   (let [new-identity-error (db/validate-pub-key new-identity (:account/account db))]
+   (let [new-identity-error (db/validate-pub-key db new-identity)]
      (if (stateofus/is-valid-name? new-identity)
        (let [network (get-in db [:account/account :networks network])
              chain   (ethereum/network->chain-keyword network)]

--- a/src/status_im/ui/screens/contacts/events.cljs
+++ b/src/status_im/ui/screens/contacts/events.cljs
@@ -55,7 +55,7 @@
  (fn [{:keys [db] :as cofx} [_ _ contact-identity]]
    (let [current-account (:account/account db)
          fx              {:db (assoc db :contacts/new-identity contact-identity)}
-         validation-result (new-chat.db/validate-pub-key contact-identity current-account)]
+         validation-result (new-chat.db/validate-pub-key db contact-identity)]
      (if (some? validation-result)
        (utils/show-popup (i18n/label :t/unable-to-read-this-code) validation-result #(re-frame/dispatch [:navigate-to-clean :home]))
        (handlers-macro/merge-fx cofx

--- a/src/status_im/utils/db.cljs
+++ b/src/status_im/utils/db.cljs
@@ -4,22 +4,9 @@
             [status-im.js-dependencies :as dependencies]
             [status-im.utils.ethereum.core :as ethereum]))
 
-(defn hex-string? [s]
-  (let [s' (if (string/starts-with? s "0x")
-             (subs s 2)
-             s)]
-    (boolean (re-matches #"(?i)[0-9a-f]+" s'))))
-
-(defn valid-length? [identity]
-  (let [length (count identity)]
-    (and
-     (hex-string? identity)
-     (or
-      (and (= 128 length) (not (string/includes? identity "0x")))
-      (and (= 130 length) (string/starts-with? identity "0x"))
-      (and (= 132 length) (string/starts-with? identity "0x04"))
-      (ethereum/address? identity)))))
+(defn valid-public-key? [s]
+  (boolean (re-matches #"0x04[0-9a-f]{128}" s)))
 
 (spec/def :global/not-empty-string (spec/and string? not-empty))
-(spec/def :global/public-key (spec/and :global/not-empty-string valid-length?))
+(spec/def :global/public-key (spec/and :global/not-empty-string valid-public-key?))
 (spec/def :global/address ethereum/address?)

--- a/test/cljs/status_im/test/utils/universal_links/core.cljs
+++ b/test/cljs/status_im/test/utils/universal_links/core.cljs
@@ -29,10 +29,14 @@
                                          {:db db}))))))
       (testing "a user profile link"
         (testing "it loads the profile"
-          (let [actual (links/handle-url "status-im://user/profile-id"
+          (let [actual (links/handle-url "status-im://user/0x04fbce10971e1cd7253b98c7b7e54de3729ca57ce41a2bfb0d1c4e0a26f72c4b6913c3487fa1b4bb86125770f1743fb4459da05c1cbe31d938814cfaf36e252073"
                                          {:db db})]
-            (is (= "profile-id" (get-in actual [:db :contacts/identity])))
+            (is (= "0x04fbce10971e1cd7253b98c7b7e54de3729ca57ce41a2bfb0d1c4e0a26f72c4b6913c3487fa1b4bb86125770f1743fb4459da05c1cbe31d938814cfaf36e252073" (get-in actual [:db :contacts/identity])))
             (is (= :profile (get-in actual [:db :view-id]))))))
+      (testing "if does nothing because the link is invalid"
+        (is (= (links/handle-url "status-im://user/CONTACTCODE"
+                                 {:db db})
+               nil)))
       (testing "a not found url"
         (testing "it does nothing"
           (is (nil? (links/handle-url "status-im://not-existing"


### PR DESCRIPTION
fix #5612 
fix #5613 

### Note for reviewers
I noticed that opening a universal link fires a handfull of :handle-universal-link events, not sure why, this is not related directly to this PR but maybe we should fix that

### Summary:

- fix contact code validation for universal links
- go to profile when following universal link pointing to
user own contact code
- fix contact code validation for add contact field

spec for validating public-key has been changed to a
regexp that only accept valid normalized public-key

### Steps to test:
- try universal link leading to user own profile: should redirect to profile tab
- try universal link leading to another user: should open that user profile
- try universal link leading to invalid user contact-code: should do nothing and open the app where it was
- try adding contact in chat using ethereum address: should warn in read to add a valid contact code

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready 