### PR TITLE
Fix ens resolution in "start new chat" according to latest dapp developments

### DIFF
--- a/src/status_im/ui/screens/add_new/new_chat/events.cljs
+++ b/src/status_im/ui/screens/add_new/new_chat/events.cljs
@@ -10,7 +10,7 @@
 (re-frame/reg-fx
  :resolve-whisper-identity
  (fn [{:keys [web3 registry ens-name cb]}]
-   (stateofus/text web3 registry ens-name cb)))
+   (stateofus/pubkey web3 registry ens-name cb)))
 
 (handlers/register-handler-fx
  :new-chat/set-new-identity

--- a/src/status_im/utils/ethereum/ens.cljs
+++ b/src/status_im/utils/ethereum/ens.cljs
@@ -73,4 +73,15 @@
 (def ABI-hash "0x2203ab56")
 (def pubkey-hash "0xc8690233")
 
+(defn add-uncompressed-public-key-prefix [key]
+  (when key
+    (str "0x04" (subs key 2))))
+
+(defn pubkey [web3 resolver ens-name cb]
+  (ethereum/call web3
+                 (ethereum/call-params resolver
+                                       "pubkey(bytes32)"
+                                       (namehash ens-name))
+                 (fn [_ key] (cb (add-uncompressed-public-key-prefix key)))))
+
 ;; TODO ABI, pubkey

--- a/src/status_im/utils/ethereum/stateofus.cljs
+++ b/src/status_im/utils/ethereum/stateofus.cljs
@@ -14,21 +14,13 @@
                 ens-name
                 #(ens/addr web3 % ens-name cb)))
 
-(defn text
-  "calls the text function on the stateofus resolver contract for `statusAccount` key
-  TODO: https://solidity.readthedocs.io/en/develop/abi-spec.html needs to be implemented
-  to replace this by dynamic parameters"
+(defn pubkey
   [web3 registry ens-name cb]
   {:pre [(is-valid-name? ens-name)]}
   (ens/resolver web3
                 registry
                 ens-name
-                #(ethereum/call web3
-                                {:to %
-                                 :data (str "0x59d1d43c"
-                                            (subs (ens/namehash ens-name) 2)
-                                            "0000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000d7374617475734163636f756e7400000000000000000000000000000000000000")}
-                                (fn [_ text] (cb (ethereum/hex->string (subs text 130 394)))))))
+                #(ens/pubkey web3 % ens-name cb)))
 
-#_(addr (:web3 @re-frame.db/app-db) "0x112234455c3a32fd11230c42e7bccd4a84e02010" "erictest.stateofus.eth" println)
-#_(text (:web3 @re-frame.db/app-db) "0x112234455c3a32fd11230c42e7bccd4a84e02010" "erictest.stateofus.eth" println)
+#_(addr (:web3 @re-frame.db/app-db) "0x112234455c3a32fd11230c42e7bccd4a84e02010" "qweqwe.stateofus.eth" println)
+#_(pubkey (:web3 @re-frame.db/app-db) "0x112234455c3a32fd11230c42e7bccd4a84e02010" "qweqwe.stateofus.eth" println)


### PR DESCRIPTION
### Summary:

Add support for pubkey method on ens contract

https://ipfs.infura.io/ipfs/QmdpwmuM3UN7Zb93QYKeMobHqpyWevNzL9nYxK7S3cYJbS/
In latest version of the name registration dapp for stateofus.eth names, the pubkey is now stored using X and Y coordinates on the elliptic curve. To resolve it we must now use the pubkey method instead of the text method


### Steps to test:
- create a name in the dapp on ropsten (need eth and stt) https://ipfs.infura.io/ipfs/QmdpwmuM3UN7Zb93QYKeMobHqpyWevNzL9nYxK7S3cYJbS/
- change account, try to add contact using registered user name


<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready 

<blockquote><div><strong><a href="https://ipfs.infura.io/ipfs/QmdpwmuM3UN7Zb93QYKeMobHqpyWevNzL9nYxK7S3cYJbS/">Status.im Domain Registration</a></strong></div></blockquote>