### PR TITLE
Unify login flow after account recovery

### DIFF
--- a/src/status_im/ui/screens/accounts/events.cljs
+++ b/src/status_im/ui/screens/accounts/events.cljs
@@ -8,12 +8,12 @@
 ;;;; COFX
 
 (re-frame/reg-cofx
- ::get-signing-phrase
+ :get-signing-phrase
  (fn [cofx _]
    (models/get-signing-phrase cofx)))
 
 (re-frame/reg-cofx
- ::get-status
+ :get-status
  (fn [cofx _]
    (models/get-status cofx)))
 
@@ -32,9 +32,9 @@
 
 (handlers/register-handler-fx
  :account-created
- [re-frame/trim-v (re-frame/inject-cofx ::get-signing-phrase) (re-frame/inject-cofx ::get-status)]
- (fn [cofx [result password]]
-   (models/on-account-created result password cofx)))
+ [(re-frame/inject-cofx :get-signing-phrase) (re-frame/inject-cofx :get-status)]
+ (fn [cofx [_ result password]]
+   (models/on-account-created result password false cofx)))
 
 (handlers/register-handler-fx
  :send-account-update-if-needed

--- a/src/status_im/ui/screens/accounts/login/navigation.cljs
+++ b/src/status_im/ui/screens/accounts/login/navigation.cljs
@@ -3,4 +3,4 @@
 
 (defmethod nav/preload-data! :login
   [db]
-  (update db :accounts/login dissoc :error :password :processing))
+  (update db :accounts/login dissoc :error :password))

--- a/src/status_im/ui/screens/accounts/recover/events.cljs
+++ b/src/status_im/ui/screens/accounts/recover/events.cljs
@@ -35,13 +35,9 @@
 
 (handlers/register-handler-fx
  :account-recovered
+ [(re-frame/inject-cofx :get-signing-phrase) (re-frame/inject-cofx :get-status)]
  (fn [cofx [_ result password]]
    (models/on-account-recovered result password cofx)))
-
-(handlers/register-handler-fx
- :account-recovered-navigate
- (fn [cofx]
-   (models/account-recovered-navigate cofx)))
 
 (handlers/register-handler-fx
  :recover-account


### PR DESCRIPTION
fixes #5286

### Summary:

We had a delay to show the main screen while we are recovering account. That might lead for the node to be starting longer than this 2 seconds delay and causing all sorts of issues.
The fix is with replacing this with our typical login flow (showing the login dialog with a process indicator) right after we recovered the account. It handles node restarts gracefully.

TODO
- [x] use `merge-fx` instead of `dispatch-n` in the code

### Steps to test:
- Open Status
- Create an account, switch it to the test network. Join some noisy channel to have more stuff happening.
- Recover any account.

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->
