### PR TITLE
[fix #5604] Fixed the problem of tooltips being cropped on the android platform.

### DIFF
--- a/src/status_im/ui/screens/accounts/create/styles.cljs
+++ b/src/status_im/ui/screens/accounts/create/styles.cljs
@@ -1,4 +1,5 @@
 (ns status-im.ui.screens.accounts.create.styles
+  (:require-macros [status-im.utils.styles :refer [defstyle]])
   (:require [status-im.ui.components.colors :as colors]))
 
 (def create-account-view
@@ -42,9 +43,11 @@
   {:size      82
    :icon-size 34})
 
-(def input-container
+(defstyle input-container
   {:margin-horizontal 16
-   :margin-top        105})
+   :margin-top        105
+   :android           {:padding-top 13
+                       :margin-top  92}})
 
 (def input-description
   {:font-size      14

--- a/src/status_im/ui/screens/accounts/login/styles.cljs
+++ b/src/status_im/ui/screens/accounts/login/styles.cljs
@@ -37,7 +37,9 @@
    :margin-top 8})
 
 (def password-container
-  {:margin-top 24})
+  {:margin-top 24
+   :android    {:margin-top  11
+                :padding-top 13}})
 
 (def save-password-checkbox-container
   {:margin-top 0

--- a/src/status_im/ui/screens/wallet/send/styles.cljs
+++ b/src/status_im/ui/screens/wallet/send/styles.cljs
@@ -1,4 +1,5 @@
 (ns status-im.ui.screens.wallet.send.styles
+  (:require-macros [status-im.utils.styles :refer [defstyle]])
   (:require [status-im.ui.components.colors :as colors]
             [status-im.ui.components.styles :as styles]
             [status-im.ui.screens.wallet.components.styles :as wallet.components.styles]))
@@ -148,3 +149,6 @@
 (def password-error-tooltip
   {:bottom-value 15
    :color        colors/red-light})
+
+(defstyle gas-input-error-tooltip
+  {:android {:bottom-value -38}})

--- a/src/status_im/ui/screens/wallet/transaction_fee/views.cljs
+++ b/src/status_im/ui/screens/wallet/transaction_fee/views.cljs
@@ -52,7 +52,7 @@
                                       :default-value       gas
                                       :accessibility-label :gas-limit-input})]]]
           (when (:invalid? gas-edit)
-            [tooltip/tooltip (i18n/label :t/invalid-number)])]
+            [tooltip/tooltip (i18n/label :t/invalid-number) styles/gas-input-error-tooltip])]
 
          [react/view styles/gas-container-wrapper
           [components/cartouche {}
@@ -65,9 +65,11 @@
             [components/cartouche-secondary-text
              (i18n/label :t/gwei)]]]
           (when (:invalid? gas-price-edit)
-            [tooltip/tooltip (i18n/label (if (= :invalid-number (:invalid? gas-price-edit))
-                                           :t/invalid-number
-                                           :t/wallet-send-min-wei))])]]
+            [tooltip/tooltip
+             (i18n/label (if (= :invalid-number (:invalid? gas-price-edit))
+                           :t/invalid-number
+                           :t/wallet-send-min-wei))
+             styles/gas-input-error-tooltip])]]
 
         [react/view styles/transaction-fee-info
          [react/view styles/transaction-fee-info-icon


### PR DESCRIPTION
Fixes #5604 

### Summary:

Tooltips on three screens: account/create, account/login and wallet/transaction-fee are known to be cropped out. In the former two screens, the fixes incur no visible UI changes; in the last screen, the tooltips are shifted down by 8 points.

### Steps to test:
- Open Status on android platform
- Press the "Create new Account" button, enter a valid password, then press "Next"
- In the "Confirm" input box, enter a different password, then press "Next". 
- Verify that the tooltip is fully shown.
- Select an account to sign in and enter a wrong password, press "SIGN IN"
- Wait and verify that the tooltip is fully shown.
- Sign in your account and navigate to Wallet -> Send Transaction -> Advanced -> Transaction Fee.
- Delete the default values in the "Gas limit" and "Gas price" input boxes.
- Verify that both tooltips are fully shown.

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->
