### PR TITLE
Fix desktop signin text input field

### DIFF
--- a/src/status_im/ui/components/text_input/view.cljs
+++ b/src/status_im/ui/components/text_input/view.cljs
@@ -2,6 +2,7 @@
   (:require [status-im.ui.components.react :as react]
             [status-im.ui.components.text-input.styles :as styles]
             [status-im.ui.components.colors :as colors]
+            [status-im.utils.platform :as platform]
             [status-im.ui.components.tooltip.views :as tooltip]))
 
 (defn text-input-with-label [{:keys [label content error style height container text] :as props}]
@@ -15,9 +16,10 @@
       {:style                  (merge styles/input style)
        :placeholder-text-color colors/gray
        :auto-focus             true
-       :value text
        :auto-capitalize        :none}
-      (dissoc props :style :height))]
+      (dissoc props :style :height)
+      (when-not platform/desktop?
+        {:value text}))]
     (when content content)]
    (when error
      [tooltip/tooltip error (styles/error label)])])

--- a/src/status_im/ui/components/text_input/view.cljs
+++ b/src/status_im/ui/components/text_input/view.cljs
@@ -18,6 +18,8 @@
        :auto-focus             true
        :auto-capitalize        :none}
       (dissoc props :style :height)
+      ;; Workaround until `value` TextInput field is available on desktop:
+      ;; https://github.com/status-im/react-native-desktop/issues/320
       (when-not platform/desktop?
         {:value text}))]
     (when content content)]


### PR DESCRIPTION
This must be a temporary fix for signin field on Desktop. If value field is set (when password is available), text input does not process input and remains empty.

Problem surfaced after merge of #5617 

Fixes #5662 