### PR TITLE
Show a progress indicator while logging in account using saved password.

### DIFF
--- a/src/status_im/ui/screens/accounts/login/models.cljs
+++ b/src/status_im/ui/screens/accounts/login/models.cljs
@@ -77,5 +77,6 @@
   (if password
     (handlers-macro/merge-fx cofx
                              {:db (assoc-in db [:accounts/login :password] password)}
+                             (navigation/navigate-to-cofx :progress nil)
                              (user-login))
     (navigation/navigate-to-cofx :login nil cofx)))

--- a/src/status_im/ui/screens/progress/styles.cljs
+++ b/src/status_im/ui/screens/progress/styles.cljs
@@ -1,0 +1,10 @@
+(ns status-im.ui.screens.progress.styles
+  (:require [status-im.ui.components.colors :as colors]
+            [status-im.ui.components.toolbar.styles :as toolbar.styles]))
+
+(def container
+  {:flex             1
+   :align-items      :center
+   :justify-content  :center
+   :background-color colors/white})
+

--- a/src/status_im/ui/screens/progress/views.cljs
+++ b/src/status_im/ui/screens/progress/views.cljs
@@ -1,0 +1,10 @@
+(ns status-im.ui.screens.progress.views
+  (:require-macros [status-im.utils.views :refer [defview letsubs]])
+  (:require [status-im.ui.screens.progress.styles :as styles]
+            [status-im.ui.components.react :as react]
+            [status-im.ui.components.react :as components]))
+
+;; a simple view with animated progress indicator in its center
+(defview progress [_]
+  [react/keyboard-avoiding-view {:style styles/container}
+   [components/activity-indicator {:animating true}]])

--- a/src/status_im/ui/screens/views.cljs
+++ b/src/status_im/ui/screens/views.cljs
@@ -11,6 +11,8 @@
             [status-im.ui.screens.accounts.recover.views :refer [recover]]
             [status-im.ui.screens.accounts.views :refer [accounts]]
 
+            [status-im.ui.screens.progress.views :refer [progress]]
+
             [status-im.chat.screen :refer [chat]]
             [status-im.ui.screens.add-new.views :refer [add-new]]
             [status-im.ui.screens.add-new.new-chat.views :refer [new-chat]]
@@ -87,6 +89,7 @@
     :profile-photo-capture profile-photo-capture
     :accounts accounts
     :login login
+    :progress progress
     :recover recover
     :network-settings network-settings
     :extensions-settings extensions-settings


### PR DESCRIPTION
On slower devices the white screen is shown for a few seconds after the
status logo. It looks like that something is wrong with the app.

This commit adds a simple progress screen (full-screen with an animated
activity indicator) that is shown before the main screen is loaded.

### Steps to test:
- Open Status on iOS (better use a slower device)
- Login and save your password
- Kill the app and restart it
- The progress indicator is shown after the status logo and until the main UI appears.

status: ready
