### PR TITLE
Add specs for clojure.core macros and special forms

### DIFF
--- a/src/status_im/core.cljs
+++ b/src/status_im/core.cljs
@@ -7,7 +7,8 @@
             [taoensso.timbre :as log]
             [status-im.utils.config :as config]
             [status-im.react-native.js-dependencies :as js-dependencies]
-            [goog.object :as object]))
+            [goog.object :as object]
+            cljs.core.specs.alpha))
 
 (when js/goog.DEBUG
   (object/set js/console "ignoredYellowBox" #js ["re-frame: overwriting"]))


### PR DESCRIPTION
This prevents errors like this from slipping by the compiler:
#5609 (review)