### PR TITLE
[fix #5303] Improve amount validation for /send and /request commands

### DIFF
--- a/src/status_im/chat/commands/impl/transactions.cljs
+++ b/src/status_im/chat/commands/impl/transactions.cljs
@@ -167,11 +167,13 @@
       (let [sanitised-str (string/replace amount #"," ".")
             portions      (string/split sanitised-str ".")
             decimals      (count (get portions 1))
-            amount        (js/parseFloat sanitised-str)]
+            amount-string (str amount)
+            amount        (js/Number sanitised-str)]
         (cond
 
           (or (js/isNaN amount)
-              (> (count portions) 2))
+              (> (count portions) 2)
+              (re-matches #".+(\.|,)$" amount-string))
           {:title       "Amount"
            :description "Amount is not valid number"}
 

--- a/test/cljs/status_im/test/chat/commands/impl/transactions.cljs
+++ b/test/cljs/status_im/test/chat/commands/impl/transactions.cljs
@@ -57,6 +57,21 @@
     (is (= (protocol/validate personal-request-command {:asset "SNT" :amount "a"} cofx)
            {:title       "Amount"
             :description "Amount is not valid number"}))
+    (is (= (protocol/validate personal-request-command {:asset "ETH" :amount "0,1Aaa"} cofx)
+           {:title       "Amount"
+            :description "Amount is not valid number"}))
+    (is (= (protocol/validate personal-request-command {:asset "ETH" :amount "1-45"} cofx)
+           {:title       "Amount"
+            :description "Amount is not valid number"}))
+    (is (= (protocol/validate personal-request-command {:asset "SNT" :amount "1$#@8"} cofx)
+           {:title       "Amount"
+            :description "Amount is not valid number"}))
+    (is (= (protocol/validate personal-request-command {:asset "SNT" :amount "20,"} cofx)
+           {:title       "Amount"
+            :description "Amount is not valid number"}))
+    (is (= (protocol/validate personal-request-command {:asset "SNT" :amount "20."} cofx)
+           {:title       "Amount"
+            :description "Amount is not valid number"}))
     (is (= (protocol/validate personal-request-command {:asset "ETH" :amount "0.54354353454353453453454353453445345545"} cofx)
            {:title       "Amount"
             :description "Max number of decimals is 18"}))


### PR DESCRIPTION
fixes #5303

### Summary:

Improve amount validation for /send and /request commands so values like "0,1Aaa" won't be valid.

status: ready
