### PR TITLE
setup: Run gradlew task even if NDK was just installed

### DIFF
--- a/scripts/lib/setup/installers.sh
+++ b/scripts/lib/setup/installers.sh
@@ -320,8 +320,7 @@ function use_android_sdk() {
 
 function install_android_ndk() {
   if grep -Fq "ndk.dir" $_localPropertiesPath; then
-    dependency_setup \
-      "pushd android && ./gradlew react-native-android:installArchives && popd"
+    cecho "@green[[Android NDK already declared.]]"
   else
     local _ndkParentDir=~/Android/Sdk
     mkdir -p $_ndkParentDir
@@ -334,4 +333,7 @@ function install_android_ndk() {
       echo "ndk.dir=$_ndkTargetDir" | tee -a $_localPropertiesPath && \
       cecho "@blue[[Android NDK installation completed in $_ndkTargetDir.]]"
   fi
+
+  dependency_setup \
+    "pushd android && ./gradlew react-native-android:installArchives && popd"
 }


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

This PR fixes an issue I came across after doing a `git cleanup -xf` on the local repo. After running `make setup && make prepare && make release-android`, I got a ton of errors:

```
> Task :react-native-firebase:compileReleaseJavaWithJavac FAILED
/home/pedro/src/github.com/status-im/status-react/node_modules/react-native-firebase/android/src/main/java/io/invertase/f
irebase/messaging/RNFirebaseMessagingService.java:7: error: cannot find symbol
import com.facebook.react.HeadlessJsTaskService;
                         ^
  symbol:   class HeadlessJsTaskService
  location: package com.facebook.react
/home/pedro/src/github.com/status-im/status-react/node_modules/react-native-firebase/android/src/main/java/io/invertase/firebase/messaging/RNFirebaseBackgroundMessagingService.java:6: error: cannot find symbol
import com.facebook.react.HeadlessJsTaskService;
                         ^
  symbol:   class HeadlessJsTaskService
  location: package com.facebook.react
/home/pedro/src/github.com/status-im/status-react/node_modules/react-native-firebase/android/src/main/java/io/invertase/firebase/messaging/RNFirebaseBackgroundMessagingService.java:9: error: package com.facebook.react.jstasks does not exist
import com.facebook.react.jstasks.HeadlessJsTaskConfig;
                                 ^
/home/pedro/src/github.com/status-im/status-react/node_modules/react-native-firebase/android/src/main/java/io/invertase/firebase/messaging/RNFirebaseBackgroundMessagingService.java:14: error: cannot find symbol
public class RNFirebaseBackgroundMessagingService extends HeadlessJsTaskService {
...
```

The problem is that `./gradlew react-native-android:installArchives` was only being run if the NDK was already present.

status: ready <!-- Can be ready or wip -->
