### PR TITLE
[TESTS][skip ci] Several fixes for false failures in e2e tests

### DIFF
--- a/test/appium/support/api/network_api.py
+++ b/test/appium/support/api/network_api.py
@@ -70,7 +70,7 @@ class NetworkApi:
         start_time = time.time()
         while round(time.time() - start_time, ndigits=2) < 900:  # should be < idleTimeout capability
             transaction = self.find_transaction_by_unique_amount(address, amount)
-            if int(transaction['confirmations']) > 1:
+            if int(transaction['confirmations']) >= 12:
                 return
             time.sleep(10)
             pytest.fail('Transaction with amount %s was not confirmed, address is %s' % (amount, address))

--- a/test/appium/tests/atomic/chats/test_commands.py
+++ b/test/appium/tests/atomic/chats/test_commands.py
@@ -328,7 +328,7 @@ class TestCommandsMultipleDevices(MultipleDeviceTestCase):
         chat_2 = home_2.get_chat_with_user(sender['username']).click()
         self.network_api.wait_for_confirmation_of_transaction(recipient['address'], amount)
         if not chat_2.chat_element_by_text(amount).contains_text('Confirmed', 60):
-            chat_2.driver.fail('Transaction state is not updated on the recipient side')
+            chat_2.driver.fail('Status "Confirmed" is not shown under transaction for the recipient')
 
 
 @marks.chat
@@ -410,7 +410,7 @@ class TestCommandsSingleDevices(SingleDeviceTestCase):
         chat.send_transaction_in_1_1_chat('ETH', amount, sender['password'])
         self.network_api.wait_for_confirmation_of_transaction(sender['address'], amount)
         if not chat.chat_element_by_text(amount).contains_text('Confirmed', wait_time=90):
-            pytest.fail('Transaction state is not updated on the sender side')
+            pytest.fail('Status "Confirmed" is not shown under transaction for the sender')
 
     @marks.testrail_id(3790)
     def test_insufficient_funds_1_1_chat_0_balance(self):

--- a/test/appium/tests/atomic/transactions/test_daaps_transactions.py
+++ b/test/appium/tests/atomic/transactions/test_daaps_transactions.py
@@ -1,5 +1,4 @@
 import pytest
-import random
 
 from tests import transaction_users, marks, unique_password
 from tests.base_test_case import SingleDeviceTestCase

--- a/test/appium/tests/atomic/transactions/test_wallet.py
+++ b/test/appium/tests/atomic/transactions/test_wallet.py
@@ -193,7 +193,7 @@ class TestTransactionWalletSingleDevice(SingleDeviceTestCase):
         send_transaction.select_asset_button.click_until_presence_of_element(adi_button)
         adi_button.click()
         send_transaction.amount_edit_box.click()
-        amount = '0.0%s' % str(random.randint(100000, 999999)).strip('0')
+        amount = '0.0%s' % str(random.randint(10000, 99999)) + '1'
         send_transaction.amount_edit_box.set_value(amount)
         send_transaction.confirm()
         send_transaction.chose_recipient_button.click()
@@ -201,7 +201,7 @@ class TestTransactionWalletSingleDevice(SingleDeviceTestCase):
         send_transaction.enter_recipient_address_input.set_value(recipient['address'])
         send_transaction.done_button.click()
         send_transaction.sign_transaction(sender['password'])
-        self.network_api.find_transaction_by_unique_amount(sender['address'], amount, token=True, decimals=7)
+        self.network_api.find_transaction_by_unique_amount(recipient['address'], amount, token=True, decimals=7)
 
     @marks.testrail_id(3747)
     @marks.smoke_1
@@ -216,7 +216,7 @@ class TestTransactionWalletSingleDevice(SingleDeviceTestCase):
         send_transaction.select_asset_button.click_until_presence_of_element(adi_button)
         adi_button.click()
         send_transaction.amount_edit_box.click()
-        amount = '0.0%s' % str(random.randint(1000000, 9999999)).strip('0')
+        amount = '0.0%s' % str(random.randint(100000, 999999)) + '1'
         send_transaction.amount_edit_box.set_value(amount)
         error_text = 'Amount is too precise. Max number of decimals is 7.'
         if not send_transaction.element_by_text(error_text).is_element_displayed():

--- a/test/appium/tests/conftest.py
+++ b/test/appium/tests/conftest.py
@@ -145,7 +145,7 @@ def pytest_runtest_makereport(item, call):
         current_test = test_suite_data.current_test
         if report.failed:
             error = report.longreprtext
-            exception = re.findall('E.*:', error)
+            exception = re.findall('E.*Message:|E.*Error:|E.*Failed:', error)
             if exception:
                 error = error.replace(re.findall('E.*Message:|E.*Error:|E.*Failed:', report.longreprtext)[0], '')
             current_test.testruns[-1].error = error

--- a/test/appium/views/base_element.py
+++ b/test/appium/views/base_element.py
@@ -81,6 +81,14 @@ class BaseElement(object):
             raise TimeoutException(
                 "Device %s: '%s' is not found on the screen" % (self.driver.number, self.name)) from None
 
+    def wait_for_elements(self, seconds=10):
+        try:
+            return WebDriverWait(self.driver, seconds) \
+                .until(expected_conditions.presence_of_all_elements_located((self.locator.by, self.locator.value)))
+        except TimeoutException:
+            raise TimeoutException(
+                "Device %s: '%s' is not found on the screen" % (self.driver.number, self.name)) from None
+
     def wait_for_visibility_of_element(self, seconds=10, ignored_exceptions=None):
         try:
             return WebDriverWait(self.driver, seconds, ignored_exceptions=ignored_exceptions) \

--- a/test/appium/views/chat_view.py
+++ b/test/appium/views/chat_view.py
@@ -36,11 +36,21 @@ class SendCommand(BaseButton):
         super(SendCommand, self).__init__(driver)
         self.locator = self.Locator.accessibility_id('send-button')
 
+    def click(self):
+        self.wait_for_element().click()
+        self.driver.info('Tap on %s' % self.name)
+        return self.navigate()
+
 
 class RequestCommand(BaseButton):
     def __init__(self, driver):
         super(RequestCommand, self).__init__(driver)
         self.locator = self.Locator.accessibility_id('request-button')
+
+    def click(self):
+        self.wait_for_element().click()
+        self.driver.info('Tap on %s' % self.name)
+        return self.navigate()
 
 
 class AssetCommand(BaseButton):

--- a/test/appium/views/transactions_view.py
+++ b/test/appium/views/transactions_view.py
@@ -101,7 +101,7 @@ class TransactionTable(BaseElement):
     def get_transactions_number(self):
         element = self.TransactionElement(self.driver)
         element.locator = element.Locator.xpath_selector('//android.view.ViewGroup[@content-desc="transaction-item"]')
-        return len(element.find_elements())
+        return len(element.wait_for_elements())
 
 
 class FiltersButton(BaseButton):


### PR DESCRIPTION
- wait for 12 confirmation instead of 1 according to https://github.com/status-im/status-react/blob/develop/src/status_im/models/transactions.cljs#L11
- wait for send/request commands in chats
- wait for transactions on transaction history screen
- more readable error for `Confirmed` state under transaction
- no strip(0) in` more than allowed decimals` test

<blockquote><img src="https://avatars3.githubusercontent.com/u/11767950?s=400&v=4" width="48" align="right"><div><img src="https://assets-cdn.github.com/favicon.ico" height="14"> GitHub</div><div><strong><a href="https://github.com/status-im/status-react">status-im/status-react</a></strong></div><div>a free (libre) open source, mobile OS for Ethereum - status-im/status-react</div></blockquote>