### PR TITLE
use dashes instead of dots in artifact filenames

### DIFF
--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -53,8 +53,8 @@ pipeline {
     }
     stage('Upload') {
       steps { script {
-        e2eUrl = cmn.uploadArtifact(findFiles(glob: 'pkg/*.e2e.apk')[0].path)
-        apkUrl = cmn.uploadArtifact(findFiles(glob: "pkg/*.${cmn.getBuildType()}.apk")[0].path)
+        e2eUrl = cmn.uploadArtifact(findFiles(glob: 'pkg/*e2e.apk')[0].path)
+        apkUrl = cmn.uploadArtifact(findFiles(glob: "pkg/*${cmn.getBuildType()}.apk")[0].path)
         dmgUrl = cmn.uploadArtifact(findFiles(glob: 'pkg/*.dmg')[0].path)
         appUrl = cmn.uploadArtifact(findFiles(glob: 'pkg/*.AppImage')[0].path)
         /* special case for iOS Diawi links */

--- a/ci/common.groovy
+++ b/ci/common.groovy
@@ -115,7 +115,7 @@ def uploadArtifact(path) {
 
 def timestamp() {
   def now = new Date(currentBuild.timeInMillis)
-  return now.format('yyMMdd.HHmmss', TimeZone.getTimeZone('UTC'))
+  return now.format('yyMMdd-HHmmss', TimeZone.getTimeZone('UTC'))
 }
 
 def gitCommit() {
@@ -123,7 +123,7 @@ def gitCommit() {
 }
 
 def pkgFilename(type, ext) {
-  return "StatusIm.${timestamp()}.${gitCommit()}.${type}.${ext}"
+  return "StatusIm-${timestamp()}-${gitCommit()}-${type}.${ext}"
 }
 
 


### PR DESCRIPTION
Apparently dots cause issues on Android.