### PR TITLE
bug #5542 - fixed errors when no currency selected - using usd as def…

### DIFF
--- a/src/status_im/chat/commands/impl/transactions.cljs
+++ b/src/status_im/chat/commands/impl/transactions.cljs
@@ -21,6 +21,7 @@
             [status-im.utils.money :as money]
             [status-im.ui.screens.wallet.db :as wallet.db]
             [status-im.ui.screens.wallet.choose-recipient.events :as choose-recipient.events]
+            [status-im.ui.screens.currency-settings.subs :as currency-settings.subs]
             [status-im.models.transactions :as wallet.transactions]
             [status-im.ui.screens.navigation :as navigation]))
 
@@ -228,7 +229,7 @@
 (defn- inject-network-price-info [{:keys [amount asset] :as parameters} {:keys [db]}]
   (let [{:keys [chain prices]} db
         currency               (-> db
-                                   (get-in [:account/account :settings :wallet :currency] :usd)
+                                   currency-settings.subs/get-currency
                                    name
                                    string/upper-case)]
     (assoc parameters

--- a/src/status_im/chat/models/message.cljs
+++ b/src/status_im/chat/models/message.cljs
@@ -18,7 +18,6 @@
             [status-im.transport.message.v1.protocol :as protocol]
             [status-im.data-store.messages :as messages-store]
             [status-im.data-store.user-statuses :as user-statuses-store]
-            [status-im.ui.screens.currency-settings.subs :as currency-settings]
             [status-im.utils.datetime :as datetime]
             [clojure.string :as string]))
 

--- a/src/status_im/ui/screens/currency_settings/events.cljs
+++ b/src/status_im/ui/screens/currency_settings/events.cljs
@@ -1,14 +1,8 @@
 (ns status-im.ui.screens.currency-settings.events
-  (:require [status-im.models.wallet :as wallet]
-            [status-im.ui.screens.accounts.models :as accounts.models]
-            [status-im.utils.handlers :as handlers]
-            [status-im.utils.handlers-macro :as handlers-macro]))
+  (:require [status-im.ui.screens.currency-settings.models :as models]
+            [status-im.utils.handlers :as handlers]))
 
 (handlers/register-handler-fx
  :wallet.settings/set-currency
- (fn [{:keys [db] :as cofx} [_ currency]]
-   (let [settings     (get-in db [:account/account :settings])
-         new-settings (assoc-in settings [:wallet :currency] currency)]
-     (handlers-macro/merge-fx cofx
-                              (accounts.models/update-settings new-settings)
-                              (wallet/update-wallet)))))
+ (fn [cofx [_ currency]]
+   (models/set-currency currency cofx)))

--- a/src/status_im/ui/screens/currency_settings/models.cljs
+++ b/src/status_im/ui/screens/currency_settings/models.cljs
@@ -1,0 +1,11 @@
+(ns status-im.ui.screens.currency-settings.models
+  (:require [status-im.ui.screens.accounts.models :as accounts.models]
+            [status-im.models.wallet :as wallet]
+            [status-im.utils.handlers-macro :as handlers-macro]))
+
+(defn set-currency [currency {:keys [db] :as cofx}]
+  (let [settings     (get-in db [:account/account :settings])
+        new-settings (assoc-in settings [:wallet :currency] currency)]
+    (handlers-macro/merge-fx cofx
+                             (accounts.models/update-settings new-settings)
+                             (wallet/update-wallet))))

--- a/src/status_im/ui/screens/currency_settings/subs.cljs
+++ b/src/status_im/ui/screens/currency_settings/subs.cljs
@@ -1,10 +1,12 @@
 (ns status-im.ui.screens.currency-settings.subs
   (:require [re-frame.core :as re-frame]))
 
-(defn get-user-currency [db]
-  (get-in db [:account/account :settings :wallet :currency] :usd))
+;;TODO(goranjovic): this fn should go to `status-im.ui.screens.currency-settings.subs`
+;; but it can't because of cyclic dependencies
+(defn get-currency [db]
+  (or (get-in db [:account/account :settings :wallet :currency]) :usd))
 
 (re-frame/reg-sub
  :wallet.settings/currency
  (fn [db]
-   (get-user-currency db)))
+   (get-currency db)))

--- a/test/cljs/status_im/test/runner.cljs
+++ b/test/cljs/status_im/test/runner.cljs
@@ -50,6 +50,7 @@
             [status-im.test.init.core]
             [status-im.test.ui.screens.accounts.login.models]
             [status-im.test.ui.screens.accounts.recover.models]
+            [status-im.test.ui.screens.currency-settings.models]
             [status-im.test.ui.screens.wallet.db]))
 
 (enable-console-print!)
@@ -110,5 +111,6 @@
  'status-im.test.utils.http
  'status-im.test.ui.screens.accounts.login.models
  'status-im.test.ui.screens.accounts.recover.models
+ 'status-im.test.ui.screens.currency-settings.models
  'status-im.test.ui.screens.wallet.db
  'status-im.test.browser.events)

--- a/test/cljs/status_im/test/ui/screens/currency_settings/models.cljs
+++ b/test/cljs/status_im/test/ui/screens/currency_settings/models.cljs
@@ -1,0 +1,17 @@
+(ns status-im.test.ui.screens.currency-settings.models
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [status-im.ui.screens.currency-settings.subs :as subs]
+            [status-im.ui.screens.currency-settings.models :as models]))
+
+(deftest get-currency
+  (is (= :usd (subs/get-currency {:account/account {:settings {:wallet {:currency :usd}}}})))
+  (is (= :usd (subs/get-currency {:account/account {:settings {:wallet {:currency nil}}}})))
+  (is (= :usd (subs/get-currency {:account/account {:settings {:wallet {}}}})))
+  (is (= :aud (subs/get-currency {:account/account {:settings {:wallet {:currency :aud}}}}))))
+
+(deftest set-currency
+  (let [cofx (models/set-currency :usd {:db {:account/account {:settings {:wallet {}}}}})]
+    (is (= [:db :get-balance :get-tokens-balance :get-prices :data-store/base-tx] (keys cofx)))
+    (is (= :usd (get-in cofx [:db :account/account :settings :wallet :currency]))))
+  (is (= :jpy (get-in (models/set-currency :jpy {:db {:account/account {:settings {:wallet {}}}}})
+                      [:db :account/account :settings :wallet :currency]))))


### PR DESCRIPTION
fixes #5542 

### Summary:

Uses only one function to get the currently selected fiat currency and properly returns USD when either unset or nil.


### Steps to test:
- Open Status in dev mode
- In  REPL use following code to unset the currency:

```
(require '[re-frame.core :as re-frame])
(re-frame/dispatch [:wallet.settings/set-currency nil])
```

- Now navigate to Profile and verify that the currency is USD
- Send some transaction to someone 

status: ready 