### PR TITLE
bug #5694 and #5709 - re-required request events

### DIFF
--- a/src/status_im/ui/screens/events.cljs
+++ b/src/status_im/ui/screens/events.cljs
@@ -30,6 +30,7 @@
             [status-im.models.wallet :as models.wallet]
             status-im.ui.screens.wallet.collectibles.events
             status-im.ui.screens.wallet.send.events
+            status-im.ui.screens.wallet.request.events
             status-im.ui.screens.wallet.settings.events
             status-im.ui.screens.wallet.transactions.events
             status-im.ui.screens.wallet.choose-recipient.events


### PR DESCRIPTION
fixes #5694 
fixes #5709 

### Summary:

The namespace with all Wallet > Request events somehow got removed from the compilation tree Couldn't find the exact spot where it was required, so I assume it was relying on a transitive dependency, that got severed in some unrelated change.

Added it to main events namespace


### Steps to test:
- Check if requesting assets from Wallet works fine

status: ready 