### PR TITLE
Add `clean` makefile target to ensure build leftover state is removed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,13 +26,16 @@ HELP_FUN = \
 
 # Main targets
 
+clean: ##@prepare Remove all output folders
+	git clean -qdxf modules/react-native-status/ target/ desktop/modules desktop/node_modules
+	npm prune
+
 setup: ##@prepare Install all the requirements for status-react
 	./scripts/setup
 
 prepare: ##@prepare Install dependencies and prepare workspace
 	scripts/prepare-for-platform.sh mobile
 	npm install
-
 
 prepare-ios: prepare ##@prepare Install iOS specific dependencies
 	mvn -f modules/react-native-status/ios/RCTStatus dependency:unpack
@@ -64,8 +67,7 @@ prod-build-ios:
 	lein prod-build-ios
 
 full-prod-build: ##@build build prod for both Android and iOS
-	./scripts/bundle-status-go.sh ios
-	./scripts/bundle-status-go.sh android
+	./scripts/bundle-status-go.sh ios android
 	$(MAKE) prod-build
 	rm -r ./modules/react-native-status/ios/RCTStatus/Statusgo.framework/ 2> /dev/null || true
 	rm ./modules/react-native-status/android/libs/status-im/status-go/local/status-go-local.aar 2> /dev/null

--- a/ci/desktop.groovy
+++ b/ci/desktop.groovy
@@ -22,10 +22,9 @@ external_fonts = [
 
 def cleanupBuild() {
   sh """
-    rm -rf \\
-      node_modules ${packageFolder} \\
-      desktop/modules desktop/node_modules
+    rm -rf ${packageFolder}
   """
+  sh 'make clean'
 }
 
 def cleanupAndDeps() {

--- a/ci/mobile.groovy
+++ b/ci/mobile.groovy
@@ -34,6 +34,8 @@ def podUpdate() {
 }
 
 def prep(type = 'nightly') {
+  /* ensure that we start from a known state */
+  sh 'make clean'
   /* select type of build */
   switch (type) {
     case 'nightly':

--- a/scripts/bundle-status-go.sh
+++ b/scripts/bundle-status-go.sh
@@ -15,6 +15,9 @@ fi
 
 set -euf
 
+# Ensure we start with a clean state, so as to e.g., not reuse old native status-go bindings 
+make clean
+
 for platform in "$@"; do
     case $platform in
     ios | android)


### PR DESCRIPTION
Part of #5563 

This PR adds a `make clean` command to status-react, and calls it from Jenkins as well as `scripts/bundle-status-go.sh` (as we've come across old bindings being used in that scenario). There are some changes to how `desktop.groovy` works, so I'd appreciate @MaxRis's opinion on whether we're good with that.

status: ready <!-- Can be ready or wip -->
