### PR TITLE
Simplify setup script and fix Android build when setting up from scratch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@
 help: ##@other Show this help
 	@perl -e '$(HELP_FUN)' $(MAKEFILE_LIST)
 
+OS := $(shell uname)
+
 # This is a code for automatic help generator.
 # It supports ANSI colors and categories.
 # To add new item into help output, simply add comments
@@ -27,7 +29,7 @@ HELP_FUN = \
 # Main targets
 
 clean: ##@prepare Remove all output folders
-	git clean -qdxf -f modules/react-native-status/ node_modules/ target/ desktop/modules/ desktop/node_modules/
+	git clean -qdxf -f android/ modules/react-native-status/ node_modules/ target/ desktop/modules/ desktop/node_modules/
 
 setup: ##@prepare Install all the requirements for status-react
 	./scripts/setup
@@ -38,10 +40,12 @@ prepare: ##@prepare Install dependencies and prepare workspace
 
 prepare-ios: prepare ##@prepare Install iOS specific dependencies
 	mvn -f modules/react-native-status/ios/RCTStatus dependency:unpack
-	cd ios && pod install && cd ..
+ifeq ($(OS),Darwin)
+	cd ios && pod install
+endif
 
 prepare-android: prepare ##@prepare Install Android specific dependencies
-	cd android; ./gradlew react-native-android:installArchives
+	cd android && ./gradlew react-native-android:installArchives
 
 #----------------
 # Release builds

--- a/scripts/lib/setup/installers.sh
+++ b/scripts/lib/setup/installers.sh
@@ -333,7 +333,4 @@ function install_android_ndk() {
       echo "ndk.dir=$_ndkTargetDir" | tee -a $_localPropertiesPath && \
       cecho "@blue[[Android NDK installation completed in $_ndkTargetDir.]]"
   fi
-
-  dependency_setup \
-    "pushd android && ./gradlew react-native-android:installArchives && popd"
 }

--- a/scripts/setup
+++ b/scripts/setup
@@ -39,11 +39,7 @@ install_cocoapods
 ####
 echo && setup_header "Installing dependencies..."
 
-dependency_setup npm install
-
-dependency_setup \
-  "mvn -f modules/react-native-status/ios/RCTStatus/pom.xml dependency:unpack"
-
-using_cocoapods && dependency_setup "pushd ios && pod install && popd"
+dependency_setup make prepare-android
+dependency_setup make prepare-ios
 
 setup_complete


### PR DESCRIPTION
This PR fixes a problem that still persisted when running `make setup && make release-android` after having cleaned up the repo state.

- gradle was being called without `npm install` having had a chance to execute;
- `./android` folder still contained gradle state which caused gradle to believe that the NDK build step of react-native was up-to-date, leading to errors downstream;
- simplified `scripts/setup`, since it was doing the same as the make file targets.

One thing that needs to be confirmed in the review is the assumption that `mvn -f modules/react-native-status/ios/RCTStatus/pom.xml dependency:unpack` in the setup script can be replaced with `mvn -f modules/react-native-status/ios/RCTStatus dependency:unpack` from `make prepare-ios`. I assume so, but would prefer to have confirmation from someone who's more knowledgeable about maven.

status: ready <!-- Can be ready or wip -->
