### PR TITLE
Replace `npm prune` with cleaning `node_modules/`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,7 @@ HELP_FUN = \
 # Main targets
 
 clean: ##@prepare Remove all output folders
-	git clean -qdxf modules/react-native-status/ target/ desktop/modules desktop/node_modules
-	npm prune
+	git clean -qdxf -f modules/react-native-status/ node_modules/ target/ desktop/modules/ desktop/node_modules/
 
 setup: ##@prepare Install all the requirements for status-react
 	./scripts/setup


### PR DESCRIPTION
This PR fixes the build error in https://ci.status.im/job/status-react/job/combined/job/mobile-ios/455/console

status: ready <!-- Can be ready or wip -->


<blockquote><img src="/static/c32cacaf/favicon.ico" width="48" align="right"><div><strong><a href="https://ci.status.im/job/status-react/job/combined/job/mobile-ios/455/console">status-react » combined » mobile-ios #455 Console [Jenkins]</a></strong></div></blockquote>