### PR TITLE
cljfmt formatting fix

### DIFF
--- a/src/status_im/ui/screens/extensions/events.cljs
+++ b/src/status_im/ui/screens/extensions/events.cljs
@@ -1,7 +1,7 @@
 (ns status-im.ui.screens.extensions.events
   (:require [re-frame.core :as re-frame]
-            [pluto.registry :as registry] 
-            [status-im.utils.handlers :as handlers] 
+            [pluto.registry :as registry]
+            [status-im.utils.handlers :as handlers]
             status-im.ui.screens.extensions.add.events))
 
 (handlers/register-handler-db


### PR DESCRIPTION
### Summary:

cljfmt formatting fix that breaks jenkins builds

status: ready <!-- Can be ready or wip -->
