### PR TITLE
run bundle install, specify bundle home for jenkins

### DIFF
--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -1,5 +1,5 @@
 pipeline {
-  agent { label 'macos' }
+  agent { label 'linux' }
 
   options {
     buildDiscarder(logRotator(
@@ -15,6 +15,7 @@ pipeline {
     LC_ALL = 'en_US.UTF-8'
     FASTLANE_DISABLE_COLORS = 1
     REALM_DISABLE_ANALYTICS = 1
+    BUNDLE_PATH = "${HOME}/.bundle"
     ANDROID_HOME = '/usr/local/share/android-sdk'
     ANDROID_SDK_ROOT = '/usr/local/share/android-sdk'
     ANDROID_NDK = '/Users/jenkins/android-ndk-r10e'

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -15,6 +15,7 @@ pipeline {
     LC_ALL = 'en_US.UTF-8'
     FASTLANE_DISABLE_COLORS=1
     REALM_DISABLE_ANALYTICS=1
+    BUNDLE_PATH = "${HOME}/.bundle"
   }
   
   stages {

--- a/ci/mobile.groovy
+++ b/ci/mobile.groovy
@@ -48,6 +48,9 @@ def prep(type = 'nightly') {
       sh 'cp .env.jenkins .env'; break
   }
   common.installJSDeps('mobile')
+  print env.BUNDLE_PATH
+  /* install ruby dependencies */
+  sh 'bundle install --quiet'
   /* install Maven dependencies */
   sh 'mvn -f modules/react-native-status/ios/RCTStatus dependency:unpack'
   /* generate ios/StatusIm.xcworkspace */


### PR DESCRIPTION
Fixes errors like:
```
+ bundle exec fastlane android saucelabs
bundler: failed to load command: fastlane (/usr/local/bin/fastlane)
Bundler::GemNotFound: Could not find atomos-0.1.2 in any of the sources
  /usr/lib/ruby/vendor_ruby/bundler/spec_set.rb:88:in `block in materialize'
  /usr/lib/ruby/vendor_ruby/bundler/spec_set.rb:82:in `map!'
  /usr/lib/ruby/vendor_ruby/bundler/spec_set.rb:82:in `materialize'
  /usr/lib/ruby/vendor_ruby/bundler/definition.rb:170:in `specs'
  /usr/lib/ruby/vendor_ruby/bundler/definition.rb:237:in `specs_for'
  /usr/lib/ruby/vendor_ruby/bundler/definition.rb:226:in `requested_specs'
  /usr/lib/ruby/vendor_ruby/bundler/runtime.rb:108:in `block in definition_method'
  /usr/lib/ruby/vendor_ruby/bundler/runtime.rb:20:in `setup'
  /usr/lib/ruby/vendor_ruby/bundler.rb:107:in `setup'
  /usr/lib/ruby/vendor_ruby/bundler/setup.rb:20:in `<top (required)>'
  /usr/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require'
  /usr/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require'
```