### PR TITLE
[feature #5422] universal links scannable via QR code scanner

### DIFF
--- a/src/status_im/translations/en.cljs
+++ b/src/status_im/translations/en.cljs
@@ -376,6 +376,7 @@
    :address-explication                  "Your public key is used to generate your address on Ethereum and is a series of numbers and letters. You can find it easily in your profile"
    :unable-to-read-this-code             "Unable to read this code"
    :use-valid-contact-code               "Please enter or scan a valid contact code or username"
+   :use-valid-qr-code                    "This QR code doesn't contain a valid universal link, contact code or username: {{data}}"
    :enter-valid-public-key               "Please enter a valid public key or scan a QR code"
    :contact-already-added                "The contact has already been added"
    :can-not-add-yourself                 "You can't add yourself"

--- a/src/status_im/ui/screens/add_new/events.cljs
+++ b/src/status_im/ui/screens/add_new/events.cljs
@@ -1,0 +1,10 @@
+(ns status-im.ui.screens.add-new.events
+  (:require [status-im.ui.screens.add-new.models :as models]
+            [status-im.utils.handlers :as handlers]
+            [taoensso.timbre :as log]))
+
+(handlers/register-handler-fx
+ :handle-qr-code
+ (fn [cofx [_ _ data]]
+   (log/debug "qr code scanned with data " data)
+   (models/handle-qr-code data cofx)))

--- a/src/status_im/ui/screens/add_new/models.cljs
+++ b/src/status_im/ui/screens/add_new/models.cljs
@@ -1,0 +1,20 @@
+(ns status-im.ui.screens.add-new.models
+  (:require [cljs.spec.alpha :as spec]
+            [re-frame.core :as re-frame]
+            [status-im.i18n :as i18n]
+            [status-im.ui.screens.navigation :as navigation]
+            [status-im.utils.universal-links.core :as universal-links]
+            [status-im.utils.handlers-macro :as handlers-macro]))
+
+(defn- process-qr-code [data cofx]
+  (if (spec/valid? :global/public-key data)
+    (universal-links/handle-view-profile data cofx)
+    (or (universal-links/handle-url data cofx)
+        {:utils/show-popup [(i18n/label :t/unable-to-read-this-code)
+                            (i18n/label :t/use-valid-qr-code {:data data})
+                            #(re-frame/dispatch [:navigate-to-clean :home])]})))
+
+(defn handle-qr-code [data cofx]
+  (handlers-macro/merge-fx cofx
+                           (navigation/navigate-to-clean :home)
+                           (process-qr-code data)))

--- a/src/status_im/ui/screens/add_new/views.cljs
+++ b/src/status_im/ui/screens/add_new/views.cljs
@@ -30,7 +30,8 @@
        :icon                :icons/contacts
        :icon-opts           {:color colors/blue}
        :on-press            #(re-frame/dispatch [:open-contact-toggle-list])}])
-   [action-button/action-separator]
+   (when config/group-chats-enabled?
+     [action-button/action-separator])
    [action-button/action-button
     {:label               (i18n/label :t/new-public-group-chat)
      :accessibility-label :join-public-chat-button
@@ -50,7 +51,16 @@
      :accessibility-label :invite-friends-button
      :icon                :icons/share
      :icon-opts           {:color colors/blue}
-     :on-press            #(list-selection/open-share {:message (i18n/label :t/get-status-at)})}]])
+     :on-press            #(list-selection/open-share {:message (i18n/label :t/get-status-at)})}]
+   [action-button/action-separator]
+   [action-button/action-button
+    {:label               (i18n/label :t/scan-qr)
+     :accessibility-label :scan-qr-code-button
+     :icon                :icons/qr
+     :icon-opts           {:color colors/blue}
+     :on-press            #(re-frame/dispatch [:scan-qr-code
+                                               {:toolbar-title (i18n/label :t/scan-qr)}
+                                               :handle-qr-code])}]])
 
 (views/defview add-new []
   (views/letsubs [account     [:get-current-account]

--- a/src/status_im/ui/screens/events.cljs
+++ b/src/status_im/ui/screens/events.cljs
@@ -10,6 +10,7 @@
             [status-im.ui.screens.accounts.login.models :as login]
             status-im.ui.screens.accounts.recover.events
             [status-im.models.contacts :as models.contacts]
+            status-im.ui.screens.add-new.events
             status-im.ui.screens.add-new.new-chat.events
             status-im.ui.screens.group.chat-settings.events
             status-im.ui.screens.group.events

--- a/src/status_im/utils/utils.cljs
+++ b/src/status_im/utils/utils.cljs
@@ -18,6 +18,11 @@
            (when on-dismiss
              (clj->js {:cancelable false})))))
 
+(re-frame/reg-fx
+ :utils/show-popup
+ (fn [[title content on-dismiss]]
+   (show-popup title content on-dismiss)))
+
 (defn show-confirmation
   ([title content on-accept]
    (show-confirmation title content nil on-accept))

--- a/test/cljs/status_im/test/runner.cljs
+++ b/test/cljs/status_im/test/runner.cljs
@@ -48,6 +48,7 @@
             [status-im.test.utils.universal-links.core]
             [status-im.test.utils.http]
             [status-im.test.init.core]
+            [status-im.test.ui.screens.add-new.models]
             [status-im.test.ui.screens.accounts.login.models]
             [status-im.test.ui.screens.accounts.recover.models]
             [status-im.test.ui.screens.currency-settings.models]
@@ -109,6 +110,7 @@
  'status-im.test.utils.keychain.core
  'status-im.test.utils.universal-links.core
  'status-im.test.utils.http
+ 'status-im.test.ui.screens.add-new.models
  'status-im.test.ui.screens.accounts.login.models
  'status-im.test.ui.screens.accounts.recover.models
  'status-im.test.ui.screens.currency-settings.models

--- a/test/cljs/status_im/test/ui/screens/add-new/models.cljs
+++ b/test/cljs/status_im/test/ui/screens/add-new/models.cljs
@@ -1,0 +1,18 @@
+(ns status-im.test.ui.screens.add-new.models
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [status-im.ui.screens.add-new.models :as models]))
+
+(def cofx {:db {:account/account {:public-key "0x04e1433c1a8ad71280e6d4b1814aa3958ba6eb451da47ea1d4a4bfc4a04969c445548f3bd9d40fa7e4356aa62075b4d7615179ef1332f1d6a7c59b96c4ab8e04c1"}}})
+
+(deftest test-handle-qr-code
+  (testing "handle contact code"
+    (is (= :profile
+           (get-in (models/handle-qr-code "0x04405dfcf94380f9159a1bf8d7dbfce19dd2a3552695bf5e6dd96fb8c3c016c62adaf036b387e7f68621c366186f59dae2561374752996aa13ffc57aad9e6e7202" cofx) [:db :view-id]))))
+  (testing "handle own contact code"
+    (is (= :my-profile
+           (get-in (models/handle-qr-code "0x04e1433c1a8ad71280e6d4b1814aa3958ba6eb451da47ea1d4a4bfc4a04969c445548f3bd9d40fa7e4356aa62075b4d7615179ef1332f1d6a7c59b96c4ab8e04c1" cofx) [:db :view-id]))))
+  (testing "handle universal link"
+    (is (= (:browse (models/handle-qr-code "status-im://browse/www.cryptokitties.co" cofx))
+           "status-im://browse/www.cryptokitties.co")))
+  (testing "handle invalid qr code"
+    (is (:utils/show-popup (models/handle-qr-code "a random string" cofx)))))


### PR DESCRIPTION
fixes #5422 

### Summary:

### Steps to test:
- any universal link should work when using qr code scanner from + button -> Scan QR code
- any contact code should work and redirect to contact profile, or own profile when scanning own contact code
- other QR codes should show a pop-up explaining that scanner was unable to read qr code

status: ready
