### PR TITLE
[#5374] upgrade react-native-webview-bridge

### DIFF
--- a/mobile_files/package-lock.json
+++ b/mobile_files/package-lock.json
@@ -6356,7 +6356,7 @@
       }
     },
     "react-native-webview-bridge": {
-      "version": "git+https://github.com/status-im/react-native-webview-bridge.git#5613f8b04d3e0e7d6af1dc371f94e711155652ae",
+      "version": "git+https://github.com/status-im/react-native-webview-bridge.git#6195e9c13565060823d3d565b6b442d6e88cd8a9",
       "requires": {
         "invariant": "2.2.0",
         "keymirror": "0.1.1"

--- a/mobile_files/package.json
+++ b/mobile_files/package.json
@@ -56,7 +56,7 @@
     "react-native-tcp": "3.3.0",
     "react-native-testfairy": "2.14.1",
     "react-native-udp": "2.2.1",
-    "react-native-webview-bridge": "git+https://github.com/status-im/react-native-webview-bridge.git#feature/cached-webviews",
+    "react-native-webview-bridge": "git+https://github.com/status-im/react-native-webview-bridge.git#fix/cookies",
     "realm": "2.15.3",
     "rn-snoopy": "https://github.com/status-im/rn-snoopy.git",
     "string_decoder": "0.10.31",


### PR DESCRIPTION
fixes #5374 
fixes #5706

might be related to #4596 

Cookies were missing for intercepted requests https://github.com/status-im/react-native-webview-bridge/commit/6195e9c13565060823d3d565b6b442d6e88cd8a9 

status: ready 
