### PR TITLE
Only interpret extension universal links if flag is enabled

### DIFF
--- a/src/status_im/utils/universal_links/core.cljs
+++ b/src/status_im/utils/universal_links/core.cljs
@@ -78,7 +78,7 @@
     (match-url url browse-regex)
     (handle-browse url cofx)
 
-    (match-url url extension-regex)
+    (and config/extensions-enabled? (match-url url extension-regex))
     (handle-extension url cofx)
 
     :else (handle-not-found url)))


### PR DESCRIPTION
### Summary:

Make sure extensions links are not interpreted if extension support is disabled.