### PR TITLE
[fix 5738] unread counter disappears after app restart

### DIFF
--- a/src/status_im/init/events.cljs
+++ b/src/status_im/init/events.cljs
@@ -68,7 +68,7 @@
   (re-frame/inject-cofx :data-store/all-chats)
   (re-frame/inject-cofx :data-store/get-messages)
   (re-frame/inject-cofx :data-store/get-user-statuses)
-  (re-frame/inject-cofx :data-store/unviewed-messages)
+  (re-frame/inject-cofx :data-store/get-unviewed-messages)
   (re-frame/inject-cofx :data-store/message-ids)
   (re-frame/inject-cofx :data-store/get-unanswered-requests)
   (re-frame/inject-cofx :data-store/get-local-storage-data)

--- a/src/status_im/models/chat.cljs
+++ b/src/status_im/models/chat.cljs
@@ -46,12 +46,13 @@
                                 stored-unanswered-requests
                                 get-stored-messages
                                 get-stored-user-statuses
-                                stored-unviewed-messages
+                                get-stored-unviewed-messages
                                 stored-message-ids] :as cofx}]
   (let [chat->message-id->request (reduce (fn [acc {:keys [chat-id message-id] :as request}]
                                             (assoc-in acc [chat-id message-id] request))
                                           {}
                                           stored-unanswered-requests)
+        stored-unviewed-messages (get-stored-unviewed-messages (:current-public-key db))
         chats (reduce (fn [acc {:keys [chat-id] :as chat}]
                         (let [chat-messages (index-messages (get-stored-messages chat-id))
                               message-ids   (keys chat-messages)


### PR DESCRIPTION
fixes #5738

`get-unviewed-messages` cofx was using the `current-public-key`
field from app-db
since it is not set at the point cofx are computed during the init
phase this field is nil and therefore no unread messages were found

the fix changes the cofx so that it returns a function as it is
already done for many cofx that needs parameters that are not
known at the time cofx are computed.

### Steps to test:
- Receive unread messages
- restart app
- unread counter should be present

status: ready 
