### PR TITLE
feature #4747 - ens usernames in wallet send

### DIFF
--- a/src/status_im/ui/screens/wallet/components/views.cljs
+++ b/src/status_im/ui/screens/wallet/components/views.cljs
@@ -234,7 +234,7 @@
                       :accessibility-label :recipient-address-input}]]
         [bottom-buttons/bottom-button
          [button/button {:disabled?    (string/blank? @content)
-                         :on-press     #(re-frame/dispatch [:wallet/fill-request-from-url @content :code])
+                         :on-press     #(re-frame/dispatch [:wallet.send/set-recipient @content])
                          :fit-to-text? false}
           (i18n/label :t/done)]]]])))
 

--- a/src/status_im/ui/screens/wallet/request/events.cljs
+++ b/src/status_im/ui/screens/wallet/request/events.cljs
@@ -28,11 +28,6 @@
                  [:start-chat whisper-identity]]}))
 
 (handlers/register-handler-fx
- :wallet.request/set-recipient
- (fn [{:keys [db]} [_ s]]
-   {:db (assoc-in db [:wallet :request-transaction :to] s)}))
-
-(handlers/register-handler-fx
  :wallet.request/set-and-validate-amount
  (fn [{:keys [db]} [_ amount symbol decimals]]
    (let [{:keys [value error]} (wallet-db/parse-amount amount decimals)]

--- a/src/status_im/utils/ethereum/ens.cljs
+++ b/src/status_im/utils/ethereum/ens.cljs
@@ -89,4 +89,15 @@
                                        (namehash ens-name))
                  (fn [_ key] (cb (add-uncompressed-public-key-prefix key)))))
 
+(defn is-valid-eth-name? [ens-name]
+  (and ens-name
+       (string/ends-with? ens-name ".eth")))
+
+(defn get-addr [web3 registry ens-name cb]
+  {:pre [(is-valid-eth-name? ens-name)]}
+  (resolver web3
+            registry
+            ens-name
+            #(addr web3 % ens-name cb)))
+
 ;; TODO ABI, pubkey

--- a/src/status_im/utils/ethereum/stateofus.cljs
+++ b/src/status_im/utils/ethereum/stateofus.cljs
@@ -1,18 +1,11 @@
 (ns status-im.utils.ethereum.stateofus
   (:refer-clojure :exclude [name])
   (:require [clojure.string :as string]
-            [status-im.utils.ethereum.core :as ethereum]
             [status-im.utils.ethereum.ens :as ens]))
 
 (defn is-valid-name? [ens-name]
-  (string/ends-with? ens-name ".stateofus.eth"))
-
-(defn addr [web3 registry ens-name cb]
-  {:pre [(is-valid-name? ens-name)]}
-  (ens/resolver web3
-                registry
-                ens-name
-                #(ens/addr web3 % ens-name cb)))
+  (and ens-name
+       (string/ends-with? ens-name ".stateofus.eth")))
 
 (defn pubkey
   [web3 registry ens-name cb]


### PR DESCRIPTION
fixes #4747 

### Summary:

Add ENS name resolution in Wallet Send

### Steps to test:
- Wallet > Send
- Choose recipient by address
- enter a registered ENS username
- Send the tx

status: ready 
