### PR TITLE
[fix #5063] calculate fiat amount on recipient side

### DIFF
--- a/src/status_im/chat/models/message.cljs
+++ b/src/status_im/chat/models/message.cljs
@@ -97,11 +97,28 @@
 (defn add-outgoing-status [{:keys [from] :as message} {:keys [db]}]
   (assoc message :outgoing (= from (:current-public-key db))))
 
+(defn set-fiat-amount [{:keys [content-type content] :as message} cofx]
+  (if (= constants/content-type-command content-type)
+    (let [account-currency (-> cofx
+                               (get-in [:db :account/account :settings :wallet :currency] :usd)
+                               name
+                               string/upper-case)
+          {:keys [amount asset]} (:params content)
+          prices (get-in cofx [:db :prices])]
+      (-> message
+          (assoc-in [:content :params :fiat-amount] (money/fiat-amount-value amount
+                                                                             (keyword asset)
+                                                                             (keyword account-currency)
+                                                                             prices))
+          (assoc-in [:content :params :currency] account-currency)))
+    message))
+
 (defn- add-message
   [batch? {:keys [chat-id message-id clock-value content] :as message} current-chat? {:keys [db] :as cofx}]
   (let [prepared-message (-> message
                              (prepare-message chat-id current-chat?)
-                             (add-outgoing-status cofx))]
+                             (add-outgoing-status cofx)
+                             (set-fiat-amount cofx))]
     (let [fx {:db            (cond->
                               (-> db
                                   (update-in [:chats chat-id :messages] assoc message-id prepared-message)

--- a/test/cljs/status_im/test/chat/models/message.cljs
+++ b/test/cljs/status_im/test/chat/models/message.cljs
@@ -169,3 +169,20 @@
              (get-in fx2 [:db :chats "chat-id" :messages])))
       (is (= {}
              (get-in fx2 [:db :chats "chat-id" :message-groups]))))))
+
+(deftest set-fiat-amount
+  (let [message {:content-type "text/plain"}
+        command-message {:content-type "command"
+                         :content      {:params {:amount "2"
+                                                 :asset  "ETH"}}}
+        cofx {:db {:prices          {:ETH {:EUR {:from     "ETH"
+                                                 :to       "EUR"
+                                                 :price    300
+                                                 :last-day 299}}}
+                   :account/account {:settings {:wallet {:currency :eur}}}}}]
+    (testing "Not a command message"
+      (is (= message (message/set-fiat-amount message cofx))))
+    (testing "Command message"
+      (is (= (-> command-message
+                 (assoc-in [:content :params :fiat-amount] "600")
+                 (assoc-in [:content :params :currency] "EUR")) (message/set-fiat-amount command-message cofx))))))


### PR DESCRIPTION
fixes #5063 

### Summary:

Calculate fiat amount on recipient side for /send /receive commands depending on account currency.

status: ready