### PR TITLE
Fix of status-im.models.network/action-handler to make tests pass again

### DIFF
--- a/src/status_im/models/network.cljs
+++ b/src/status_im/models/network.cljs
@@ -59,7 +59,7 @@
 
 (defn- action-handler
   ([handler]
-   (handler nil nil))
+   (action-handler handler nil nil))
   ([handler data cofx]
    (when handler
      (handler data cofx))))


### PR DESCRIPTION
Status: ready.

Fixes `status-im.models.network/action-handler` to make everything buildable again.