### PR TITLE
Enhanced receive params

### DIFF
--- a/src/status_im/chat/commands/impl/transactions.cljs
+++ b/src/status_im/chat/commands/impl/transactions.cljs
@@ -306,8 +306,9 @@
                           :success-event :wallet/update-gas-price-success
                           :edit?         false}}))
   protocol/EnhancedParameters
-  (enhance-parameters [_ parameters cofx]
-    (inject-network-price-info parameters cofx)))
+  (enhance-send-parameters [_ parameters cofx]
+    (inject-network-price-info parameters cofx))
+  (enhance-receive-parameters [_ _ _]))
 
 ;; `/request` command
 
@@ -452,5 +453,6 @@
   (preview [_ command-message]
     (request-preview command-message))
   protocol/EnhancedParameters
-  (enhance-parameters [_ parameters cofx]
-    (inject-network-price-info parameters cofx)))
+  (enhance-send-parameters [_ parameters cofx]
+    (inject-network-price-info parameters cofx))
+  (enhance-receive-parameters [_ _ _]))

--- a/src/status_im/chat/commands/protocol.cljs
+++ b/src/status_im/chat/commands/protocol.cljs
@@ -54,11 +54,17 @@
 (defprotocol EnhancedParameters
   "Protocol for command messages which wish to modify/inject additional data into parameters,
   other then those collected from the chat input.
-  Good example would be the `/send` and `/receive` commands - we would like to indicate
+  Good example would be the `/send` and `/request` commands - we would like to indicate
   network selected in sender's device, but we of course don't want to force user to type
   it in when it could be effortlessly looked up from context.
   Another usage would be for example command where one of the input parameters will be
   hashed after validation and we would want to avoid the original unhashed parameter
-  to be ever saved on the sender device, nor to be sent over the wire."
-  (enhance-parameters [this parameters cofx]
+  to be ever saved on the sender device, nor to be sent over the wire.
+  For maximal flexibility, parameters can be enhanced both on the sending side and receiving
+  side, as sometimes thing needs to be added/enhanced in parameters map which are depending
+  on the receiver context - as for example calculated fiat price values for the `/request`
+  command"
+  (enhance-send-parameters [this parameters cofx]
+    "Function which takes original parameters + cofx map and returns new map of parameters")
+  (enhance-receive-parameters [this parameters cofx]
     "Function which takes original parameters + cofx map and returns new map of parameters"))

--- a/src/status_im/chat/commands/sending.cljs
+++ b/src/status_im/chat/commands/sending.cljs
@@ -31,15 +31,15 @@
 (defn- create-command-message
   "Create message map from chat-id, command & input parameters"
   [chat-id type parameter-map cofx]
-  (let [command-path               (commands/command-id type)
+  (let [command-path                   (commands/command-id type)
         ;; TODO(janherich) this is just for backward compatibility, can be removed later
-        {:keys [content content-type]} (new->old command-path parameter-map)]
+        {:keys [content content-type]} (new->old command-path parameter-map)
+        new-parameter-map              (and (satisfies? protocol/EnhancedParameters type)
+                                            (protocol/enhance-send-parameters type parameter-map cofx))]
     {:chat-id      chat-id
      :content-type content-type
      :content      (merge {:command-path command-path
-                           :params       (if (satisfies? protocol/EnhancedParameters type)
-                                           (protocol/enhance-parameters type parameter-map cofx)
-                                           parameter-map)}
+                           :params       (or new-parameter-map parameter-map)}
                           content)}))
 
 (defn validate-and-send

--- a/src/status_im/chat/models/message.cljs
+++ b/src/status_im/chat/models/message.cljs
@@ -155,6 +155,7 @@
         {:keys [public?] :as chat} (get-in db [:chats chat-id])
         add-message-fn             (if batch? add-batch-message add-single-message)
         message                    (-> raw-message
+                                       (commands-receiving/enhance-receive-parameters cofx)
                                        (ensure-clock-value chat)
                                        ;; TODO (cammellos): Refactor so it's not computed twice
                                        (add-outgoing-status cofx)


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

Lately, it has been discovered that there is no easy way to plug-in custom command parameters enrichment on the recipient side.

This is resulting again in bloated code with command checking/branching where it should not be at all, eq in the generic `chat/models/message` ns which should be only concerned with generic message handling and nothing command specific - https://github.com/status-im/status-react/pull/5743.

The solution is easy, we already have `EnhancedParams` protocol with method `enhance-parameters` for commands which wish to enrich their parameters during sending (like adding sender network there), we just add the the receive equivalent and rename it accordingly, eq `enhance-send-parameters` and `enhance-receive-parameters` are now two methods of the protocol.

### Testing notes (optional):
Only very superficial regression testing is necessary (ensuring that `/send` and `/request` commands are correctly sent/received just like before)

status: ready
