### PR TITLE
[#5593] Disallow decimal wei value for gas price

### DIFF
--- a/src/status_im/models/wallet.cljs
+++ b/src/status_im/models/wallet.cljs
@@ -16,7 +16,8 @@
 (defmethod invalid-send-parameter? :gas-price [_ value]
   (cond
     (not value) :invalid-number
-    (< (money/->wei :gwei value) min-gas-price-wei) :not-enough-wei))
+    (< (money/->wei :gwei value) min-gas-price-wei) :not-enough-wei
+    (-> (money/->wei :gwei value) .decimalPlaces pos?) :invalid-number))
 
 (defmethod invalid-send-parameter? :default [_ value]
   (when (or (not value)

--- a/test/cljs/status_im/test/models/wallet.cljs
+++ b/test/cljs/status_im/test/models/wallet.cljs
@@ -36,6 +36,11 @@
         (is (= "invalid" (get-in actual [:gas :value]))))
       (testing "it sets max-fee to 0"
         (is (= "0" (:max-fee actual))))))
+  (testing "gas price in wei should be round"
+    (let [actual (-> {}
+                     (model/build-edit :gas "21000")
+                     (model/build-edit :gas-price "0.0000000023"))]
+      (is (get-in actual [:gas-price :invalid?]))))
   (testing "an valid edit"
     (let [actual (-> {}
                      (model/build-edit :gas "21000")


### PR DESCRIPTION
fixes #5593

### Summary:

Don't allow setting decimal values like "0.0000000023" Gwei (2.3 Wei) for transaction gas price such that the gas price in Wei should be round value.

status: ready