### PR TITLE
[TESTS] Create e2e tests for `privacy links` and `network switch`

### DIFF
--- a/test/appium/tests/atomic/account_management/test_profile.py
+++ b/test/appium/tests/atomic/account_management/test_profile.py
@@ -233,6 +233,19 @@ class TestProfileSingleDevice(SingleDeviceTestCase):
         profile.select_from_gallery_button.click()
         profile.deny_button.wait_for_visibility_of_element(2)
 
+    @marks.testrail_id(5299)
+    @marks.critical
+    def test_user_can_switch_network(self):
+        signin_view = SignInView(self.driver)
+        home_view = signin_view.create_user()
+        network_name = 'Mainnet with upstream RPC'
+        profile = home_view.profile_button.click()
+        signin_view = profile.switch_network(network_name)
+        home_view = signin_view.sign_in()
+        profile = home_view.profile_button.click()
+        if not profile.current_active_network == network_name.upper():
+            self.driver.fail('Oops! Wrong network selected!')
+
 
 @marks.all
 @marks.account

--- a/test/appium/tests/test_general_verifications.py
+++ b/test/appium/tests/test_general_verifications.py
@@ -1,0 +1,47 @@
+from tests import marks
+from tests.base_test_case import SingleDeviceTestCase
+from views.sign_in_view import SignInView
+
+
+class TestLinksVerifications(SingleDeviceTestCase):
+
+    @marks.testrail_id(5453)
+    @marks.critical
+    def test_privacy_policy_is_accessible(self):
+        signin_view = SignInView(self.driver)
+        no_link_found_error_msg = 'Could not find privacy policy link at'
+        no_link_open_error_msg = 'Could not open our privacy policy from'
+
+        if not signin_view.privacy_policy_link.is_element_displayed():
+            self.driver.fail(f'{no_link_found_error_msg} Sign in view!')
+
+        base_web_view = signin_view.privacy_policy_link.click()
+        if not base_web_view.policy_summary.is_element_displayed():
+            self.errors.append(f'{no_link_open_error_msg} Sign in view!')
+
+        base_web_view.click_system_back_button()
+        signin_view = SignInView(self.driver)
+        home_view = signin_view.create_user()
+        profile = home_view.profile_button.click()
+        about_view = profile.about_button.click()
+        base_web_view = about_view.privacy_policy_button.click()
+
+        if not base_web_view.policy_summary.is_element_displayed():
+            self.errors.append(f'{no_link_open_error_msg} Profile about view!')
+
+        base_web_view.click_system_back_button()
+        if about_view.privacy_policy_button.is_element_displayed():
+            base_web_view.click_system_back_button()
+        signin_view = profile.logout()
+        if signin_view.ok_button.is_element_displayed():
+            signin_view.ok_button.click()
+        signin_view.other_accounts_button.click()
+
+        if not signin_view.privacy_policy_link.is_element_displayed():
+            self.driver.fail(f'{no_link_found_error_msg} Sign in view!')
+
+        base_web_view = signin_view.privacy_policy_link.click()
+        if not base_web_view.policy_summary.is_element_displayed():
+            self.errors.append(f'{no_link_open_error_msg} Sign in view!')
+
+        self.verify_no_errors()

--- a/test/appium/views/about_view.py
+++ b/test/appium/views/about_view.py
@@ -1,0 +1,28 @@
+from views.base_element import BaseButton, BaseText
+from views.base_view import BaseView
+
+
+class PrivacyPolicyButton(BaseButton):
+    def __init__(self, driver):
+        super(PrivacyPolicyButton, self).__init__(driver)
+        self.locator = self.Locator.xpath_selector(
+            '//*[@content-desc="privacy-policy"]')
+
+    def navigate(self):
+        from views.web_views.base_web_view import BaseWebView
+        return BaseWebView(self.driver)
+
+
+class VersionInfo(BaseText):
+    def __init__(self, driver):
+        super(VersionInfo, self).__init__(driver)
+        self.locator = self.Locator.xpath_selector(
+            '//*[@content-desc="version"]//android.widget.TextView')
+
+
+class AboutView(BaseView):
+    def __init__(self, driver):
+        super(AboutView, self).__init__(driver)
+
+        self.privacy_policy_button = PrivacyPolicyButton(self.driver)
+        self.version_info = VersionInfo(self.driver)

--- a/test/appium/views/profile_view.py
+++ b/test/appium/views/profile_view.py
@@ -374,6 +374,23 @@ class MailServerConnectButton(BaseButton):
         self.locator = self.Locator.accessibility_id('mailserver-connect-button')
 
 
+class ActiveNetworkName(BaseText):
+
+    def __init__(self, driver):
+        super(ActiveNetworkName, self).__init__(driver)
+        self.locator = self.Locator.text_part_selector('WITH UPSTREAM RPC')
+
+
+class AboutButton(BaseButton):
+    def __init__(self, driver):
+        super(AboutButton, self).__init__(driver)
+        self.locator = self.Locator.accessibility_id('about-button')
+
+    def navigate(self):
+        from views.about_view import AboutView
+        return AboutView(self.driver)
+
+
 class ProfileView(BaseView):
 
     def __init__(self, driver):
@@ -386,8 +403,10 @@ class ProfileView(BaseView):
         self.user_status_input = OptionsButton.UserStatusInput(self.driver)
         self.public_key_text = PublicKeyText(self.driver)
         self.profile_address_text = ProfileAddressText(self.driver)
+        self.about_button = AboutButton(self.driver)
 
         self.network_settings_button = NetworkSettingsButton(self.driver)
+        self.active_network_name = ActiveNetworkName(self.driver)
         self.plus_button = PlusButton(self.driver)
         self.ropsten_chain_button = RopstenChainButton(self.driver)
         self.custom_network_url = CustomNetworkURL(self.driver)
@@ -513,3 +532,9 @@ class ProfileView(BaseView):
 
     def mail_server_by_name(self, server_name):
         return MailServerElement(self.driver, server_name)
+
+    @property
+    def current_active_network(self):
+        self.advanced_button.click()
+        self.active_network_name.scroll_to_element()
+        return self.active_network_name.text

--- a/test/appium/views/sign_in_view.py
+++ b/test/appium/views/sign_in_view.py
@@ -80,6 +80,16 @@ class OtherAccountsButton(BaseButton):
         self.locator = self.Locator.text_selector('OTHER ACCOUNTS')
 
 
+class PrivacyPolicyLink(BaseButton):
+    def __init__(self, driver):
+        super(PrivacyPolicyLink, self).__init__(driver)
+        self.locator = self.Locator.text_part_selector('Privacy Policy')
+
+    def navigate(self):
+        from views.web_views.base_web_view import BaseWebView
+        return BaseWebView(self.driver)
+
+
 class SignInView(BaseView):
 
     def __init__(self, driver, skip_popups=True):
@@ -100,6 +110,7 @@ class SignInView(BaseView):
         self.confirm_password_input = ConfirmPasswordInput(self.driver)
         self.name_input = NameInput(self.driver)
         self.other_accounts_button = OtherAccountsButton(self.driver)
+        self.privacy_policy_link = PrivacyPolicyLink(self.driver)
 
     def create_user(self, username: str = '', password=common_password):
         self.create_account_button.click()

--- a/test/appium/views/web_views/base_web_view.py
+++ b/test/appium/views/web_views/base_web_view.py
@@ -1,7 +1,7 @@
 import time
 import pytest
 
-from views.base_element import BaseElement, BaseEditBox, BaseButton
+from views.base_element import BaseElement, BaseEditBox, BaseButton, BaseText
 from views.base_view import BaseView
 
 
@@ -63,6 +63,13 @@ class URLEditBoxLockIcon(BaseEditBox):
             "//*[@content-desc='wallet-modal-button']/../preceding-sibling::*[1]//*[@content-desc='icon']")
 
 
+class PolicySummary(BaseElement):
+
+    def __init__(self, driver):
+        super(PolicySummary, self).__init__(driver)
+        self.locator = self.Locator.accessibility_id('Policy summary')
+
+
 class BaseWebView(BaseView):
 
     def __init__(self, driver):
@@ -72,6 +79,7 @@ class BaseWebView(BaseView):
         self.progress_bar_icon = ProgressBarIcon(self.driver)
 
         self.url_edit_box_lock_icon = URLEditBoxLockIcon(self.driver)
+        self.policy_summary = PolicySummary(self.driver)
         self.back_to_home_button = BackToHomeButton(self.driver)
         self.browser_previous_page_button = BrowserPreviousPageButton(self.driver)
         self.browser_next_page_button = BrowserNextPageButton(self.driver)


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

### Summary:
PR covers e2e tests described in [the issue](https://github.com/status-im/status-react/issues/5724).
Added tests:
- privacy policy is accessible (testrail id is 4769)
- can switch network (testrail id is 690)

[comment]: # (Summarise the problem and how the pull request solves it)

### Review notes:
New view added:
_about_view.py_ describing the view Profile -> About

**NOTE:** When verifying privacy policy link we ensure that Privacy Policy summary title appears on the page opened in mobile browser (see screen)

<img width="391" alt="privacy_policy_summary" src="https://user-images.githubusercontent.com/15172961/45118153-46f15d00-b160-11e8-96dd-d5cb3de33a18.png">

<!-- (Specify if something in particular should be looked at, or ignored, during review) -->
<!-- (Specify if something specific has to be tested, for example upgrade paths) -->

### Steps to test:
#### 1. Privacy policy is accessible

|   | Step                                                                                          | Expected result                                                                                   |
|---|-----------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------|
| 1 | Open status and check Privacy policy is visible on signup                                     | The privacy policy is visible on signup                                                           |
| 2 | Click the privacy policy link                                                                 | Tapping privacy link opens in a browser (link >> https://www.iubenda.com/privacy-policy/45710059) |
| 3 | Open status - create account - log out - other accounts. Check Privacy is visible on recovery | Privacy is visible on recovery                                                                    |
| 4 | Click the privacy policy link                                                                 | Tapping privacy link opens in a browser (link >> https://www.iubenda.com/privacy-policy/45710059) |
| 5 | Open status - tap profile -> about. Check Privacy visible on the profile tab                  | Privacy visible on the profile tab                                                                |
| 6 | Tap the privacy policy item                                                                   | Tapping privacy link opens in a browser (link >> https://www.iubenda.com/privacy-policy/45710059) |

#### 2. Can switch network

|   | Step                                                                           | Expected result                                      |
|---|--------------------------------------------------------------------------------|------------------------------------------------------|
| 1 | Go to Profile, enable dev mode and switch network to Mainnet with Upstream RPC | app warns that restart is needed                     |
| 2 | agree to restart and login                                                     | go to Profile screen and verify the selected network |
<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->


<blockquote><img src="https://www.iubenda.com/images/site/fb-image.png" width="48" align="right"><div>iubenda</div><div><strong><a href="https://www.iubenda.com/privacy-policy/45710059">Privacy Policy of Status Mobile</a></strong></div><div>This Application collects some Personal Data from its Users.</div></blockquote>