### PR TITLE
[fix] update yellowbox ignore warning to new react-native api

### DIFF
--- a/src/status_im/core.cljs
+++ b/src/status_im/core.cljs
@@ -11,7 +11,7 @@
             cljs.core.specs.alpha))
 
 (when js/goog.DEBUG
-  (object/set js/console "ignoredYellowBox" #js ["re-frame: overwriting"]))
+  (.ignoreWarnings (.-YellowBox js-dependencies/react-native) #js ["re-frame: overwriting"]))
 
 (defn init [app-root]
   (log/set-level! config/log-level)


### PR DESCRIPTION
fix yellowbox warnings after react-native 0.56 update

# Tests (devs only)
- yellow warning should be gone when overwritting events and fxs

status: ready
