### PR TITLE
Fix French Play Store title listing translation

### DIFF
--- a/fastlane/metadata/android/fr-FR/title.txt
+++ b/fastlane/metadata/android/fr-FR/title.txt
@@ -1,1 +1,1 @@
-Statut — Ethereum. Partout.
+Status — Ethereum. Partout.


### PR DESCRIPTION
Updates the French Play Store title listing fixing incorrect literal translation.

<img width="622" alt="screen shot 2018-09-06 at 12 00 25 pm" src="https://user-images.githubusercontent.com/116099/45151021-80ac7d00-b1cd-11e8-8b75-8083f3d9e2a2.png">
