### PR TITLE
fix migration

### DIFF
--- a/src/status_im/data_store/realm/schemas/base/v9/account.cljs
+++ b/src/status_im/data_store/realm/schemas/base/v9/account.cljs
@@ -1,0 +1,30 @@
+(ns status-im.data-store.realm.schemas.base.v9.account)
+
+(def schema {:name       :account
+             :primaryKey :address
+             :properties {:address                :string
+                          :public-key             :string
+                          :name                   {:type :string :optional true}
+                          :email                  {:type :string :optional true}
+                          :status                 {:type :string :optional true}
+                          :debug?                 {:type :bool :default false}
+                          :photo-path             :string
+                          :signing-phrase         {:type :string}
+                          :mnemonic               {:type :string :optional true}
+                          :last-updated           {:type :int :default 0}
+                          :last-sign-in           {:type :int :default 0}
+                          :signed-up?             {:type    :bool
+                                                   :default false}
+                          :network                :string
+                          :networks               {:type       :list
+                                                   :objectType :network}
+                          :bootnodes              {:type       :list
+                                                   :objectType :bootnode}
+                          :last-request           {:type :int :optional true}
+                          :settings               {:type :string}
+                          :dev-mode?              {:type :bool :default false}
+                          :seed-backed-up?        {:type :bool :default false}
+                          :wallet-set-up-passed?  {:type    :bool
+                                                   :default false}
+                          :mainnet-warning-shown? {:type    :bool
+                                                   :default false}}})

--- a/src/status_im/data_store/realm/schemas/base/v9/core.cljs
+++ b/src/status_im/data_store/realm/schemas/base/v9/core.cljs
@@ -1,0 +1,12 @@
+(ns status-im.data-store.realm.schemas.base.v9.core
+  (:require [status-im.data-store.realm.schemas.base.v1.network :as network]
+            [status-im.data-store.realm.schemas.base.v4.bootnode :as bootnode]
+            [status-im.data-store.realm.schemas.base.v9.account :as account]
+            [taoensso.timbre :as log]))
+
+(def schema [network/schema
+             bootnode/schema
+             account/schema])
+
+(defn migration [old-realm new-realm]
+  (log/debug "migrating base database v9: " old-realm new-realm))


### PR DESCRIPTION
### Summary:

Fixes typo in schema version in account migration https://github.com/status-im/status-react/blob/develop/src/status_im/data_store/realm/schemas/base/v8/account.cljs#L5

`mainnet-warning-shown?` (cannot update field, stays always false) and `sharing-usage-data?` (field was removed in v7) account fields were affected.

### Testing notes:

Please test mainnet warning is shown only once.

status: ready
