### PR TITLE
Force node restart during initialization on desktop

### DIFF
--- a/src/status_im/node/core.cljs
+++ b/src/status_im/node/core.cljs
@@ -146,7 +146,10 @@
   (let [restart {:db (assoc db :node/restart? true :node/address address)}]
     (case status
       :started (stop cofx)
-      :starting restart
+      :starting (do
+                  (when utils.platform/desktop?
+                    (status/stop-node))
+                  restart)
       :stopping restart
       (start cofx address))))
 


### PR DESCRIPTION
Fixes #6061 

### QA notes:
This can be tested in dev mode. Steps:
  - Launch app by following steps outlined in https://docs.status.im/docs/build_desktop.html
  - Press `Cmd+R` once app is running. There, click `Reload`
  - App should reload with no issues. Previously, it would hang on `Signing in...` step