### PR TITLE
Generate node config in status-react

### DIFF
--- a/modules/react-native-status/android/build.gradle
+++ b/modules/react-native-status/android/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     implementation 'com.instabug.library:instabug:3+'
     implementation 'status-im:function:0.0.1'
 
-    String statusGoVersion = 'v0.14.1'
+    String statusGoVersion = 'v0.15.0'
     final String statusGoGroup = 'status-im', statusGoName = 'status-go'
 
     // Check if the local status-go jar exists, and compile against that if it does

--- a/modules/react-native-status/desktop/CMakeLists.txt
+++ b/modules/react-native-status/desktop/CMakeLists.txt
@@ -37,7 +37,7 @@ ExternalProject_Add(StatusGo_ep
   PREFIX ${StatusGo_PREFIX}
   SOURCE_DIR ${StatusGo_SOURCE_DIR}
   GIT_REPOSITORY https://github.com/status-im/status-go.git
-  GIT_TAG v0.14.1
+  GIT_TAG v0.15.0
   BUILD_BYPRODUCTS ${StatusGo_STATIC_LIB}
   CONFIGURE_COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/${CONFIGURE_SCRIPT} ${GO_ROOT_PATH} ${StatusGo_ROOT} ${StatusGo_SOURCE_DIR}
   BUILD_COMMAND ""

--- a/modules/react-native-status/desktop/rctstatus.cpp
+++ b/modules/react-native-status/desktop/rctstatus.cpp
@@ -18,6 +18,7 @@
 #include <QVariantMap>
 #include <QDir>
 #include <QStandardPaths>
+#include <QtConcurrent>
 
 #include "libstatus.h"
 
@@ -71,47 +72,39 @@ void RCTStatus::getDeviceUUID(double callbackId) {
 }
 
 
-void RCTStatus::startNode(QString configString, QString fleet) {
+void RCTStatus::startNode(QString configString) {
     Q_D(RCTStatus);
     qDebug() << "call of RCTStatus::startNode with param configString:" << configString;
 
     QJsonParseError jsonError;
-    QJsonDocument jsonDoc = QJsonDocument::fromJson(configString.toUtf8(), &jsonError);
+    const QJsonDocument& jsonDoc = QJsonDocument::fromJson(configString.toUtf8(), &jsonError);
     if (jsonError.error != QJsonParseError::NoError){
         qDebug() << jsonError.errorString();
     }
 
-    qDebug() << " RCTStatus::startNode configString: " << jsonDoc.toVariant().toMap();
     QVariantMap configJSON = jsonDoc.toVariant().toMap();
+    qDebug() << " RCTStatus::startNode configString: " << configJSON;
 
     int networkId = configJSON["NetworkId"].toInt();
-    QString dataDir = configJSON["DataDir"].toString();
+    QString relativeDataDirPath = configJSON["DataDir"].toString();
+    if (!relativeDataDirPath.startsWith("/"))
+        relativeDataDirPath.prepend("/");
 
-    QString rootDirPath = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation) + "/";
-    QString networkDir = rootDirPath + dataDir;
-    QString keyStoreDir = rootDirPath + "keystore";
-    QDir dir(networkDir);
-    if (!dir.exists()) {
-      dir.mkpath(".");
-    }
-    qDebug()<<"RCTStatus::startNode networkDir: "<<networkDir;
-
-
-    char *configChars = GenerateConfig(networkDir.toUtf8().data(), fleet.toUtf8().data(), networkId);
-    qDebug() << "RCTStatus::startNode GenerateConfig result: " << statusGoResultError(configChars);
-
-    jsonDoc = QJsonDocument::fromJson(QString(configChars).toUtf8(), &jsonError);
-    if (jsonError.error != QJsonParseError::NoError){
-        qDebug() << jsonError.errorString();
+    QString rootDirPath = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+    QDir rootDir(rootDirPath);
+    QString absDataDirPath = rootDirPath + relativeDataDirPath;
+    QDir dataDir(absDataDirPath);
+    if (!dataDir.exists()) {
+      dataDir.mkpath(".");
     }
 
-    qDebug() << " RCTStatus::startNode GenerateConfig configString: " << jsonDoc.toVariant().toMap();
-    QVariantMap generatedConfig = jsonDoc.toVariant().toMap();
-    generatedConfig["KeyStoreDir"] = keyStoreDir;
-    generatedConfig["LogFile"] = networkDir + "/geth.log";
-    generatedConfig["ClusterConfig.Fleet"] = fleet;
+    configJSON["DataDir"] = absDataDirPath;
+    configJSON["KeyStoreDir"] = rootDir.absoluteFilePath("keystore");
+    configJSON["LogFile"] = dataDir.absoluteFilePath("geth.log");
 
-    const char* result = StartNode(QString(QJsonDocument::fromVariant(generatedConfig).toJson(QJsonDocument::Compact)).toUtf8().data());
+    const QJsonDocument& updatedJsonDoc = QJsonDocument::fromVariant(configJSON);
+    qDebug() << " RCTStatus::startNode updated configString: " << updatedJsonDoc.toVariant().toMap();
+    const char* result = StartNode(QString(updatedJsonDoc.toJson(QJsonDocument::Compact)).toUtf8().data());
     qDebug() << "RCTStatus::startNode StartNode result: " << statusGoResultError(result);
 }
 
@@ -126,63 +119,77 @@ void RCTStatus::stopNode() {
 void RCTStatus::createAccount(QString password, double callbackId) {
     Q_D(RCTStatus);
     qDebug() << "call of RCTStatus::createAccount with param callbackId: " << callbackId;
-    const char* result = CreateAccount(password.toUtf8().data());
-    qDebug() << "RCTStatus::createAccount CreateAccount result: " << statusGoResultError(result);
-    d->bridge->invokePromiseCallback(callbackId, QVariantList{result});
+    QtConcurrent::run([&](QString password, double callbackId) {
+            const char* result = CreateAccount(password.toUtf8().data());
+            qDebug() << "RCTStatus::createAccount CreateAccount result: " << statusGoResultError(result);
+            d->bridge->invokePromiseCallback(callbackId, QVariantList{result});
+        }, password, callbackId);
 }
 
 
 void RCTStatus::notifyUsers(QString token, QString payloadJSON, QString tokensJSON, double callbackId) {
     Q_D(RCTStatus);
     qDebug() << "call of RCTStatus::notifyUsers with param callbackId: " << callbackId;
-    const char* result = NotifyUsers(token.toUtf8().data(), payloadJSON.toUtf8().data(), tokensJSON.toUtf8().data());
-    qDebug() << "RCTStatus::notifyUsers Notify result: " << statusGoResultError(result);
-    d->bridge->invokePromiseCallback(callbackId, QVariantList{result});
+    QtConcurrent::run([&](QString token, QString payloadJSON, QString tokensJSON, double callbackId) {
+            const char* result = NotifyUsers(token.toUtf8().data(), payloadJSON.toUtf8().data(), tokensJSON.toUtf8().data());
+            qDebug() << "RCTStatus::notifyUsers Notify result: " << statusGoResultError(result);
+            d->bridge->invokePromiseCallback(callbackId, QVariantList{result});
+        }, token, payloadJSON, tokensJSON, callbackId);
 }
 
 
 void RCTStatus::addPeer(QString enode, double callbackId) {
     Q_D(RCTStatus);
     qDebug() << "call of RCTStatus::addPeer with param callbackId: " << callbackId;
-    const char* result = AddPeer(enode.toUtf8().data());
-    qDebug() << "RCTStatus::addPeer AddPeer result: " << statusGoResultError(result);
-    d->bridge->invokePromiseCallback(callbackId, QVariantList{result});
+    QtConcurrent::run([&](QString enode, double callbackId) {
+            const char* result = AddPeer(enode.toUtf8().data());
+            qDebug() << "RCTStatus::addPeer AddPeer result: " << statusGoResultError(result);
+            d->bridge->invokePromiseCallback(callbackId, QVariantList{result});
+        }, enode, callbackId);
 }
 
 
 void RCTStatus::recoverAccount(QString passphrase, QString password, double callbackId) {
     Q_D(RCTStatus);
     qDebug() << "call of RCTStatus::recoverAccount with param callbackId: " << callbackId;
-    const char* result = RecoverAccount(password.toUtf8().data(), passphrase.toUtf8().data());
-    qDebug() << "RCTStatus::recoverAccount RecoverAccount result: " << statusGoResultError(result);
-    d->bridge->invokePromiseCallback(callbackId, QVariantList{result});
+    QtConcurrent::run([&](QString passphrase, QString password, double callbackId) {
+            const char* result = RecoverAccount(password.toUtf8().data(), passphrase.toUtf8().data());
+            qDebug() << "RCTStatus::recoverAccount RecoverAccount result: " << statusGoResultError(result);
+            d->bridge->invokePromiseCallback(callbackId, QVariantList{result});
+        }, passphrase, password, callbackId);
 }
 
 
 void RCTStatus::login(QString address, QString password, double callbackId) {
     Q_D(RCTStatus);
     qDebug() << "call of RCTStatus::login with param callbackId: " << callbackId;
-    const char* result = Login(address.toUtf8().data(), password.toUtf8().data());
-    qDebug() << "RCTStatus::login Login result: " << statusGoResultError(result);
-    d->bridge->invokePromiseCallback(callbackId, QVariantList{result});
+    QtConcurrent::run([&](QString address, QString password, double callbackId) {
+            const char* result = Login(address.toUtf8().data(), password.toUtf8().data());
+            qDebug() << "RCTStatus::login Login result: " << statusGoResultError(result);
+            d->bridge->invokePromiseCallback(callbackId, QVariantList{result});
+        }, address, password, callbackId);
 }
 
 
 void RCTStatus::sendTransaction(QString txArgsJSON, QString password, double callbackId) {
     Q_D(RCTStatus);
     qDebug() << "call of RCTStatus::sendTransaction with param callbackId: " << callbackId;
-    const char* result = SendTransaction(txArgsJSON.toUtf8().data(), password.toUtf8().data());
-    qDebug() << "RCTStatus::sendTransaction SendTransaction result: " << statusGoResultError(result);
-    d->bridge->invokePromiseCallback(callbackId, QVariantList{result});
+    QtConcurrent::run([&](QString txArgsJSON, QString password, double callbackId) {
+            const char* result = SendTransaction(txArgsJSON.toUtf8().data(), password.toUtf8().data());
+            qDebug() << "RCTStatus::sendTransaction SendTransaction result: " << statusGoResultError(result);
+            d->bridge->invokePromiseCallback(callbackId, QVariantList{result});
+        }, txArgsJSON, password, callbackId);
 }
 
 
 void RCTStatus::signMessage(QString rpcParams, double callbackId) {
     Q_D(RCTStatus);
     qDebug() << "call of RCTStatus::signMessage with param callbackId: " << callbackId;
-    const char* result = SignMessage(rpcParams.toUtf8().data());
-    qDebug() << "RCTStatus::signMessage SignMessage result: " << statusGoResultError(result);
-    d->bridge->invokePromiseCallback(callbackId, QVariantList{result});
+    QtConcurrent::run([&](QString rpcParams, double callbackId) {
+            const char* result = SignMessage(rpcParams.toUtf8().data());
+            qDebug() << "RCTStatus::signMessage SignMessage result: " << statusGoResultError(result);
+            d->bridge->invokePromiseCallback(callbackId, QVariantList{result});
+        }, rpcParams, callbackId);
 }
 
 
@@ -210,17 +217,21 @@ void RCTStatus::clearStorageAPIs() {
 void RCTStatus::callRPC(QString payload, double callbackId) {
     Q_D(RCTStatus);
     qDebug() << "call of RCTStatus::callRPC with param callbackId: " << callbackId;
-    const char* result = CallRPC(payload.toUtf8().data());
-    qDebug() << "RCTStatus::callRPC CallRPC result: " << statusGoResultError(result);
-    d->bridge->invokePromiseCallback(callbackId, QVariantList{result});
+    QtConcurrent::run([&](QString payload, double callbackId) {
+            const char* result = CallRPC(payload.toUtf8().data());
+            qDebug() << "RCTStatus::callRPC CallRPC result: " << statusGoResultError(result);
+            d->bridge->invokePromiseCallback(callbackId, QVariantList{result});
+        }, payload, callbackId);
 }
 
 void RCTStatus::callPrivateRPC(QString payload, double callbackId) {
     Q_D(RCTStatus);
     qDebug() << "call of RCTStatus::callPrivateRPC with param callbackId: " << callbackId;
-    const char* result = CallPrivateRPC(payload.toUtf8().data());
-    qDebug() << "RCTStatus::callPrivateRPC CallPrivateRPC result: " << statusGoResultError(result);
-    d->bridge->invokePromiseCallback(callbackId, QVariantList{result});
+    QtConcurrent::run([&](QString payload, double callbackId) {
+            const char* result = CallPrivateRPC(payload.toUtf8().data());
+            qDebug() << "RCTStatus::callPrivateRPC CallPrivateRPC result: " << statusGoResultError(result);
+            d->bridge->invokePromiseCallback(callbackId, QVariantList{result});
+        }, payload, callbackId);
 }
 
 void RCTStatus::closeApplication() {

--- a/modules/react-native-status/desktop/rctstatus.h
+++ b/modules/react-native-status/desktop/rctstatus.h
@@ -32,7 +32,7 @@ public:
     QList<ModuleMethod*> methodsToExport() override;
     QVariantMap constantsToExport() override;
 
-    Q_INVOKABLE void startNode(QString configString, QString fleet);
+    Q_INVOKABLE void startNode(QString configString);
     Q_INVOKABLE void stopNode();
     Q_INVOKABLE void createAccount(QString password, double callbackId);
     Q_INVOKABLE void notifyUsers(QString token, QString payloadJSON, QString tokensJSON, double callbackId);

--- a/modules/react-native-status/ios/RCTStatus/RCTStatus.m
+++ b/modules/react-native-status/ios/RCTStatus/RCTStatus.m
@@ -65,8 +65,7 @@ RCT_EXPORT_MODULE();
 ////////////////////////////////////////////////////////////////////
 #pragma mark - startNode
 //////////////////////////////////////////////////////////////////// startNode
-RCT_EXPORT_METHOD(startNode:(NSString *)configString
-                      fleet:(NSString *)fleet) {
+RCT_EXPORT_METHOD(startNode:(NSString *)configString) {
 #if DEBUG
     NSLog(@"StartNode() method called");
 #endif
@@ -75,18 +74,18 @@ RCT_EXPORT_METHOD(startNode:(NSString *)configString
     NSURL *rootUrl =[[fileManager
                       URLsForDirectory:NSDocumentDirectory inDomains:NSUserDomainMask]
                      lastObject];
-    NSURL *testnetFolderName = [rootUrl URLByAppendingPathComponent:@"ethereum/testnet"];
+    NSURL *absTestnetFolderName = [rootUrl URLByAppendingPathComponent:@"ethereum/testnet"];
 
-    if (![fileManager fileExistsAtPath:testnetFolderName.path])
-        [fileManager createDirectoryAtPath:testnetFolderName.path withIntermediateDirectories:YES attributes:nil error:&error];
+    if (![fileManager fileExistsAtPath:absTestnetFolderName.path])
+        [fileManager createDirectoryAtPath:absTestnetFolderName.path withIntermediateDirectories:YES attributes:nil error:&error];
 
     NSURL *flagFolderUrl = [rootUrl URLByAppendingPathComponent:@"ropsten_flag"];
 
     if(![fileManager fileExistsAtPath:flagFolderUrl.path]){
         NSLog(@"remove lightchaindata");
-        NSURL *lightChainData = [testnetFolderName URLByAppendingPathComponent:@"StatusIM/lightchaindata"];
-        if([fileManager fileExistsAtPath:lightChainData.path]) {
-            [fileManager removeItemAtPath:lightChainData.path
+        NSURL *absLightChainDataUrl = [absTestnetFolderName URLByAppendingPathComponent:@"StatusIM/lightchaindata"];
+        if([fileManager fileExistsAtPath:absLightChainDataUrl.path]) {
+            [fileManager removeItemAtPath:absLightChainDataUrl.path
                                     error:nil];
         }
         [fileManager createDirectoryAtPath:flagFolderUrl.path
@@ -97,12 +96,12 @@ RCT_EXPORT_METHOD(startNode:(NSString *)configString
 
     NSLog(@"after remove lightchaindata");
 
-    NSURL *oldKeystoreUrl = [testnetFolderName URLByAppendingPathComponent:@"keystore"];
-    NSURL *newKeystoreUrl = [rootUrl URLByAppendingPathComponent:@"keystore"];
-    if([fileManager fileExistsAtPath:oldKeystoreUrl.path]){
+    NSURL *absTestnetKeystoreUrl = [absTestnetFolderName URLByAppendingPathComponent:@"keystore"];
+    NSURL *absKeystoreUrl = [rootUrl URLByAppendingPathComponent:@"keystore"];
+    if([fileManager fileExistsAtPath:absTestnetKeystoreUrl.path]){
         NSLog(@"copy keystore");
-        [fileManager copyItemAtPath:oldKeystoreUrl.path toPath:newKeystoreUrl.path error:nil];
-        [fileManager removeItemAtPath:oldKeystoreUrl.path error:nil];
+        [fileManager copyItemAtPath:absTestnetKeystoreUrl.path toPath:absKeystoreUrl.path error:nil];
+        [fileManager removeItemAtPath:absTestnetKeystoreUrl.path error:nil];
     }
 
     NSLog(@"after lightChainData");
@@ -110,60 +109,34 @@ RCT_EXPORT_METHOD(startNode:(NSString *)configString
     NSLog(@"preconfig: %@", configString);
     NSData *configData = [configString dataUsingEncoding:NSUTF8StringEncoding];
     NSDictionary *configJSON = [NSJSONSerialization JSONObjectWithData:configData options:NSJSONReadingMutableContainers error:nil];
-    int networkId = [configJSON[@"NetworkId"] integerValue];
-    NSString *dataDir = [configJSON objectForKey:@"DataDir"];
-    NSString *upstreamURL = [configJSON valueForKeyPath:@"UpstreamConfig.URL"];
-    NSArray *bootnodes = [configJSON valueForKeyPath:@"ClusterConfig.BootNodes"];
-    NSString *networkDir = [rootUrl.path stringByAppendingString:dataDir];
-    NSString *devCluster = [ReactNativeConfig envFor:@"ETHEREUM_DEV_CLUSTER"];
-    NSString *logEnabled = [configJSON objectForKey:@"LogEnabled"];
-    NSString *logLevel = [configJSON objectForKey:@"LogLevel"];
-    char *configChars = GenerateConfig((char *)[networkDir UTF8String], (char *)[fleet UTF8String], networkId);
-    NSString *config = [NSString stringWithUTF8String: configChars];
-    configData = [config dataUsingEncoding:NSUTF8StringEncoding];
-    NSDictionary *resultingConfigJson = [NSJSONSerialization JSONObjectWithData:configData options:NSJSONReadingMutableContainers error:nil];
-    NSURL *networkDirUrl = [NSURL fileURLWithPath:networkDir];
-    NSURL *logUrl = [networkDirUrl URLByAppendingPathComponent:@"geth.log"];
-    [resultingConfigJson setValue:newKeystoreUrl.path forKey:@"KeyStoreDir"];
-    [resultingConfigJson setValue:logEnabled forKey:@"LogEnabled"];
-    [resultingConfigJson setValue:logUrl.path forKey:@"LogFile"];
-    [resultingConfigJson setValue:([logLevel length] == 0 ? [NSString stringWithUTF8String: "ERROR"] : logLevel) forKey:@"LogLevel"];
+    NSString *relativeDataDir = [configJSON objectForKey:@"DataDir"];
+    NSString *absDataDir = [rootUrl.path stringByAppendingString:relativeDataDir];
+    NSURL *absDataDirUrl = [NSURL fileURLWithPath:absDataDir];
+    NSURL *absLogUrl = [absDataDirUrl URLByAppendingPathComponent:@"geth.log"];
+    [configJSON setValue:absDataDirUrl.path forKey:@"DataDir"];
+    [configJSON setValue:absKeystoreUrl.path forKey:@"KeyStoreDir"];
+    [configJSON setValue:absLogUrl.path forKey:@"LogFile"];
 
-    [resultingConfigJson setValue:[NSNumber numberWithBool:YES] forKeyPath:@"WhisperConfig.LightClient"];
-
-    if(upstreamURL != nil) {
-        [resultingConfigJson setValue:[NSNumber numberWithBool:YES] forKeyPath:@"UpstreamConfig.Enabled"];
-        [resultingConfigJson setValue:upstreamURL forKeyPath:@"UpstreamConfig.URL"];
-    }
-
-    if(bootnodes != nil) {
-        [resultingConfigJson setValue:[NSNumber numberWithBool:YES] forKeyPath:@"ClusterConfig.Enabled"];
-        [resultingConfigJson setValue:bootnodes forKeyPath:@"ClusterConfig.BootNodes"];
-    }
-
-    if([fleet length] > 0) {
-        [resultingConfigJson setValue:fleet forKeyPath:@"ClusterConfig.Fleet"];
-    }
-
-    NSString *resultingConfig = [resultingConfigJson bv_jsonStringWithPrettyPrint:NO];
+    NSString *resultingConfig = [configJSON bv_jsonStringWithPrettyPrint:NO];
     NSLog(@"node config %@", resultingConfig);
 
-    if(![fileManager fileExistsAtPath:networkDirUrl.path]) {
-        [fileManager createDirectoryAtPath:networkDirUrl.path withIntermediateDirectories:YES attributes:nil error:nil];
+    if(![fileManager fileExistsAtPath:absDataDirUrl.path]) {
+        [fileManager createDirectoryAtPath:absDataDirUrl.path withIntermediateDirectories:YES attributes:nil error:nil];
     }
 
-    NSLog(@"logUrlPath %@", logUrl.path);
-    if(![fileManager fileExistsAtPath:logUrl.path]) {
+    NSLog(@"logUrlPath %@", absLogUrl.path);
+    if(![fileManager fileExistsAtPath:absLogUrl.path]) {
         NSMutableDictionary *dict = [[NSMutableDictionary alloc] init];
         [dict setObject:[NSNumber numberWithInt:511] forKey:NSFilePosixPermissions];
-        [fileManager createFileAtPath:logUrl.path contents:nil attributes:dict];
+        [fileManager createFileAtPath:absLogUrl.path contents:nil attributes:dict];
     }
 
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0),
                    ^(void)
                    {
                        char *res = StartNode((char *) [resultingConfig UTF8String]);
-                       NSLog(@"StartNode result %@", [NSString stringWithUTF8String: res]);                   });
+                       NSLog(@"StartNode result %@", [NSString stringWithUTF8String: res]);
+                   });
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/modules/react-native-status/ios/RCTStatus/pom.xml
+++ b/modules/react-native-status/ios/RCTStatus/pom.xml
@@ -25,7 +25,7 @@
                         <artifactItem>
                             <groupId>status-im</groupId>
                             <artifactId>status-go-ios-simulator</artifactId>
-                            <version>v0.14.1</version>
+                            <version>v0.15.0</version>
                             <type>zip</type>
                             <overWrite>true</overWrite>
                             <outputDirectory>./</outputDirectory>

--- a/src/status_im/init/core.cljs
+++ b/src/status_im/init/core.cljs
@@ -168,6 +168,13 @@
            console-contact
            (assoc :contacts/contacts {constants/console-chat-id console-contact}))}))
 
+(defn initialize-wallet [cofx]
+  (when-not platform/desktop?
+    (handlers-macro/merge-fx cofx
+                             (models.wallet/update-wallet)
+                             (transactions/run-update)
+                             (transactions/start-sync))))
+
 (defn login-only-events [address {:keys [db] :as cofx}]
   (when (not= (:view-id db) :create-account)
     (handlers-macro/merge-fx cofx
@@ -191,9 +198,7 @@
                            (chat/process-pending-messages)
                            (browser/initialize-browsers)
                            (browser/initialize-dapp-permissions)
-                           (models.wallet/update-wallet)
-                           (transactions/run-update)
-                           (transactions/start-sync)
+                           (initialize-wallet)
                            (accounts.update/update-sign-in-time)
                            (login-only-events address)))
 

--- a/src/status_im/native_module/core.cljs
+++ b/src/status_im/native_module/core.cljs
@@ -3,8 +3,8 @@
 
 (def adjust-resize 16)
 
-(defn start-node [config fleet]
-  (native-module/start-node config fleet))
+(defn start-node [config]
+  (native-module/start-node config))
 
 (defn stop-node []
   (native-module/stop-node))

--- a/src/status_im/native_module/impl/module.cljs
+++ b/src/status_im/native_module/impl/module.cljs
@@ -58,9 +58,9 @@
   (when status
     (call-module #(.stopNode status))))
 
-(defn start-node [config fleet]
+(defn start-node [config]
   (when status
-    (call-module #(.startNode status config fleet))))
+    (call-module #(.startNode status config))))
 
 (defonce account-creation? (atom false))
 


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes #5739 

### Summary:

[comment]: # (Summarise the problem and how the pull request solves it)
This PR stops relying on `Statusgo.GenerateConfig` (which will disappear with https://github.com/status-im/status-go/pull/1183) to generate the node config. It generates the JSON config from scratch in https://github.com/status-im/status-react/blob/feature%2F5739-config-gen/src/status_im/node/models.cljs#L27, which is then passed to native `StartNode`, which only modifies the paths slightly before forwarding to status-go. 

This is an example of the config reported by the Android `prettyPrintConfig` method
``` json
{
    "ClusterConfig": {
        "Enabled": true,
        "Fleet": "eth.staging",
        "BootNodes": [
            "enode://630b0342ca4e9552f50714b6c8e28d6955bc0fd14e7950f93bc3b2b8cc8c1f3b6d103df66f51a13d773b5db0f130661fb5c7b8fa21c48890c64c79b41a56a490@47.91.229.44:30404",
            "enode://f79fb3919f72ca560ad0434dcc387abfe41e0666201ebdada8ede0462454a13deb05cda15f287d2c4bd85da81f0eb25d0a486bbbc8df427b971ac51533bd00fe@174.138.107.239:30404"
        ],
        "TrustedMailServers": [
            "enode://b74859176c9751d314aeeffc26ec9f866a412752e7ddec91b19018a18e7cca8d637cfe2cedcb972f8eb64d816fbd5b4e89c7e8c7fd7df8a1329fa43db80b0bfe@47.52.90.156:30504",
            "enode://69f72baa7f1722d111a8c9c68c39a31430e9d567695f6108f31ccb6cd8f0adff4991e7fdca8fa770e75bc8a511a87d24690cbc80e008175f40c157d6f6788d48@206.189.240.16:30504",
            "enode://e4fc10c1f65c8aed83ac26bc1bfb21a45cc1a8550a58077c8d2de2a0e0cd18e40fd40f7e6f7d02dc6cd06982b014ce88d6e468725ffe2c138e958788d0002a7f@35.239.193.41:30504"
        ],
        "StaticNodes": [
            "enode://00395686f5954662a3796e170b9e87bbaf68a050d57e9987b78a2292502dae44aae2b8803280a017ec9af9be0b3121db9d6b3693ab3a0451a866bcbedd58fdac@47.52.226.137:30305",
            "enode://914c0b30f27bab30c1dfd31dad7652a46fda9370542aee1b062498b1345ee0913614b8b9e3e84622e84a7203c5858ae1d9819f63aece13ee668e4f6668063989@167.99.19.148:30305",
            "enode://2d897c6e846949f9dcf10279f00e9b8325c18fe7fa52d658520ad7be9607c83008b42b06aefd97cfe1fdab571f33a2a9383ff97c5909ed51f63300834913237e@35.192.0.86:30305"
        ]
    },
    "DataDir": "/data/user/0/im.status.ethereum/ethereum/mainnet_rpc",
    "LogLevel": "DEBUG",
    "Rendezvous": false,
    "WhisperConfig": {
        "Enabled": true,
        "LightClient": true,
        "MinimumPoW": 0.001,
        "EnableNTPSync": true
    },
    "LogEnabled": true,
    "RequireTopics": {
        "LES2@d4e56740f876aef8": {
            "Min": 2,
            "Max": 2
        },
        "whisper": {
            "Min": 2,
            "Max": 2
        }
    },
    "UpstreamConfig": {
        "Enabled": true,
        "URL": "https://mainnet.infura.io/z6GCTmjdP3FETEJmMBI4"
    },
    "NetworkId": 1,
    "NoDiscovery": false,
    "KeyStoreDir": "/data/user/0/im.status.ethereum/keystore",
    "LogFile": "/storage/emulated/0/Download/geth.log"
}
```

### Review notes (optional):
<!-- (Specify if something in particular should be looked at, or ignored, during review) -->

@yenda the logic is functional, but I'll leave code organization/any refactoring up to you.

### Testing notes (optional):
<!-- (Specify if something specific has to be tested, for example upgrade paths) -->

Disclaimer: I've tested on Android, but not on iOS nor desktop.

### Steps to test:
- Connected with adb to a phone
- Run `adb logcat | grep -e "Node config"`
- Open Status
- Sign in to an account
- Verify that config output makes sense for selected network, fleet and log level.

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->