### PR TITLE
Prices handling in commands impl

### DIFF
--- a/src/status_im/chat/commands/receiving.cljs
+++ b/src/status_im/chat/commands/receiving.cljs
@@ -29,9 +29,9 @@
   If the message is not of the command type, or command doesn't implement the
   `EnhancedParameters` protocol, returns unaltered message, otherwise updates
   its parameters."
-  [message {:keys [db] :as cofx}]
+  [{:keys [content] :as message} {:keys [db] :as cofx}]
   (let [id->command    (:id->command db)
-        {:keys [type content]} (lookup-command-by-ref message id->command)]
+        {:keys [type]} (lookup-command-by-ref message id->command)]
     (if-let [new-params (and (satisfies? protocol/EnhancedParameters type)
                              (protocol/enhance-receive-parameters type (:params content) cofx))]
       (assoc-in message [:content :params] new-params)

--- a/test/cljs/status_im/test/chat/models/message.cljs
+++ b/test/cljs/status_im/test/chat/models/message.cljs
@@ -169,20 +169,3 @@
              (get-in fx2 [:db :chats "chat-id" :messages])))
       (is (= {}
              (get-in fx2 [:db :chats "chat-id" :message-groups]))))))
-
-(deftest set-fiat-amount
-  (let [message {:content-type "text/plain"}
-        command-message {:content-type "command"
-                         :content      {:params {:amount "2"
-                                                 :asset  "ETH"}}}
-        cofx {:db {:prices          {:ETH {:EUR {:from     "ETH"
-                                                 :to       "EUR"
-                                                 :price    300
-                                                 :last-day 299}}}
-                   :account/account {:settings {:wallet {:currency :eur}}}}}]
-    (testing "Not a command message"
-      (is (= message (message/set-fiat-amount message cofx))))
-    (testing "Command message"
-      (is (= (-> command-message
-                 (assoc-in [:content :params :fiat-amount] "600")
-                 (assoc-in [:content :params :currency] "EUR")) (message/set-fiat-amount command-message cofx))))))


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

Erasing tech-debt introduced in last commit, with better `EnhancedParameters` protocol, we can again decouple generic message handling from command nuances completely.

### Testing notes (optional):
Only superficial regression testing is necessary, eq sending `/send` and `/request` commands and confirming that it looks good (amount and currency is displayed) on the receiver side.

status: ready
