### PR TITLE
[#5745] validate account recover result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [0.9.28 - Unreleased]
 ### Added
 ### Fixed
+Fix app freeze on recover with wrong password
 ### Changed
 
 ## [0.9.27]

--- a/translations/en.json
+++ b/translations/en.json
@@ -460,6 +460,7 @@
     "invalid-number": "Invalid number",
     "type-a-message": "Type a message...",
     "recover-password-too-short": "Password is too short",
+    "recover-password-invalid": "This account already exists but passwords do not match",
     "rinkeby-network": "Rinkeby test network",
     "faq": "Frequently asked questions",
     "currency-display-name-sar": "Saudi Arabia Riyal",


### PR DESCRIPTION
fixes #5745

### Summary:

Validate account recover result and show error to the user in case of unsuccessful recovery (password is not valid).

status: ready
