### PR TITLE
[#5474] Handle offline wallet onboarding

### DIFF
--- a/src/status_im/ui/screens/wallet/main/views.cljs
+++ b/src/status_im/ui/screens/wallet/main/views.cljs
@@ -176,7 +176,7 @@
         [transactions.views/history-list true]]
        [react/scroll-view {:refresh-control
                            (reagent/as-element
-                            [react/refresh-control {:on-refresh #(re-frame/dispatch [:update-wallet])
+                            [react/refresh-control {:on-refresh #(re-frame/dispatch [:wallet.ui/pull-to-refresh])
                                                     :tint-color :white
                                                     :refreshing false}])}
         (if error-message

--- a/src/status_im/ui/screens/wallet/settings/events.cljs
+++ b/src/status_im/ui/screens/wallet/settings/events.cljs
@@ -12,3 +12,8 @@
  :configure-token-balance-and-visibility
  (fn [cofx [_ symbol balance]]
    (models/configure-token-balance-and-visibility symbol balance accounts.update/update-settings cofx)))
+
+(handlers/register-handler-fx
+ :wallet.ui/pull-to-refresh
+ (fn [cofx _]
+   (models/wallet-autoconfig-tokens cofx)))


### PR DESCRIPTION
fixes #5474

### Summary:

* Add `:on-error` callback to `get-token-balance`
* Check if online before doing token balance update
* Pull to refresh makes full wallet update, i.e. for all known tokens,
to properly update balances for new tokens that might appear in user
wallet with time and for tokens that were missed during offline

status: ready
