### PR TITLE
[#5798] change wallet balance tilde color

### DIFF
--- a/src/status_im/ui/screens/wallet/main/styles.cljs
+++ b/src/status_im/ui/screens/wallet/main/styles.cljs
@@ -58,6 +58,9 @@
 (def total-value
   {:color colors/white-transparent})
 
+(def total-balance-tilde
+  {:color colors/white-transparent})
+
 (defstyle total-balance-currency
   {:font-size   37
    :margin-left 9

--- a/src/status_im/ui/screens/wallet/main/views.cljs
+++ b/src/status_im/ui/screens/wallet/main/views.cljs
@@ -51,6 +51,11 @@
     [react/view {:style styles/total-balance}
      [react/text {:style               styles/total-balance-value
                   :accessibility-label :total-amount-value-text}
+      (when (and
+             (not= "0" value)
+             (not= "..." value))
+        [react/text {:style styles/total-balance-tilde}
+         "~"])
       value]
      [react/text {:style               styles/total-balance-currency
                   :accessibility-label :total-amount-currency-text}

--- a/src/status_im/ui/screens/wallet/subs.cljs
+++ b/src/status_im/ui/screens/wallet/subs.cljs
@@ -65,11 +65,12 @@
                                                      (or currency-code
                                                          (-> currency :code keyword))
                                                      token->decimals)]
-                        (-> balance-total-value
-                            (money/with-precision 2)
-                            str
-                            (i18n/format-currency (:code currency) false)
-                            (->> (str "~"))))
+                        (if (pos? balance-total-value)
+                          (-> balance-total-value
+                              (money/with-precision 2)
+                              str
+                              (i18n/format-currency (:code currency) false))
+                          "0"))
                       "...")))
 
 (re-frame/reg-sub :prices-loading?


### PR DESCRIPTION
fixes #5798

### Summary:

* Change total balance tilde color 
* Remove it when 0 balance

status: ready

<img width="526" alt="screenshot 2018-09-12 19 26 10" src="https://user-images.githubusercontent.com/23836/45439158-bb2c8300-b6c1-11e8-99d8-00b4aa20c229.png">

