### PR TITLE
Fix `make setup` on macOS.

### DIFF
--- a/scripts/lib/setup/installers.sh
+++ b/scripts/lib/setup/installers.sh
@@ -325,7 +325,13 @@ function install_android_ndk() {
     local _ndkParentDir=~/Android/Sdk
     mkdir -p $_ndkParentDir
     cecho "@cyan[[Downloading Android NDK.]]"
-    wget --output-document=android-ndk.zip https://dl.google.com/android/repository/android-ndk-r10e-linux-x86_64.zip && \
+
+    PLATFORM="linux"
+    if [ "$(uname)" == "Darwin" ]; then # we run osx
+        PLATFORM="darwin"
+    fi
+
+    wget --output-document=android-ndk.zip https://dl.google.com/android/repository/android-ndk-r10e-$PLATFORM-x86_64.zip && \
       cecho "@cyan[[Extracting Android NDK to $_ndkParentDir.]]" && \
       unzip -q -o android-ndk.zip -d "$_ndkParentDir" && \
       rm -f android-ndk.zip && \


### PR DESCRIPTION
Before, it always downloaded linux NDK no matter which platform you are
using. This way, `make setup` was actually able to break Android build
on macOS.

fixes my devenv

status: ready <!-- Can be ready or wip -->
