### PR TITLE
[Fixes #5828] Updated bounties network URL

### DIFF
--- a/src/status_im/ui/screens/browser/default_dapps.cljs
+++ b/src/status_im/ui/screens/browser/default_dapps.cljs
@@ -60,7 +60,7 @@
             :photo-path  "contacts://name-bazaar"
             :description "ENS name marketplace"}
            {:name        "The Bounties Network"
-            :dapp-url    "https://berlin.bounties.network/"
+            :dapp-url    "https://bounties.network/"
             :photo-path  "contacts://bounties-network"
             :description "Bounties on any task, paid in any token"}
            {:name        "Emoon"


### PR DESCRIPTION
fixes #5828

### Summary:

Updated `bounties.network` URL

status: ready
