### PR TITLE
Rename notifications/request-notifications

### DIFF
--- a/src/status_im/init/core.cljs
+++ b/src/status_im/init/core.cljs
@@ -170,7 +170,7 @@
 (defn login-only-events [address {:keys [db] :as cofx}]
   (when (not= (:view-id db) :create-account)
     (handlers-macro/merge-fx cofx
-                             {:notifications/request-notifications nil}
+                             {:notifications/request-notifications-permissions nil}
                              (navigation/navigate-to-clean :home)
                              (universal-links/process-stored-event)
                              (notifications/process-stored-event address))))


### PR DESCRIPTION
### Summary:

Rename `:notifications/request-notifications` to `notifications/request-notifications-permissions` as it was missed during recent refactoring.

status: ready
