### PR TITLE
Obscure CreateAccount result to put into the log; .re-natal config updated.

### DIFF
--- a/desktop_files/.re-natal
+++ b/desktop_files/.re-natal
@@ -56,7 +56,9 @@
     "rn-snoopy/stream/filter",
     "rn-snoopy/stream/buffer",
     "react-native/Libraries/vendor/emitter/EventEmitter",
-    "react-native-fetch-polyfill"
+    "react-native-fetch-polyfill",
+    "text-encoding",
+    "js-sha3"
   ],
   "imageDirs": [
     "resources/images",

--- a/modules/react-native-status/desktop/rctstatus.cpp
+++ b/modules/react-native-status/desktop/rctstatus.cpp
@@ -98,7 +98,7 @@ void RCTStatus::startNode(QString configString, QString fleet) {
 
 
     char *configChars = GenerateConfig(networkDir.toUtf8().data(), fleet.toUtf8().data(), networkId);
-    qDebug() << "RCTStatus::startNode GenerateConfig result: " << configChars;
+    qDebug() << "RCTStatus::startNode GenerateConfig result: " << statusGoResultError(configChars);
 
     jsonDoc = QJsonDocument::fromJson(QString(configChars).toUtf8(), &jsonError);
     if (jsonError.error != QJsonParseError::NoError){
@@ -112,14 +112,14 @@ void RCTStatus::startNode(QString configString, QString fleet) {
     generatedConfig["ClusterConfig.Fleet"] = fleet;
 
     const char* result = StartNode(QString(QJsonDocument::fromVariant(generatedConfig).toJson(QJsonDocument::Compact)).toUtf8().data());
-    qDebug() << "RCTStatus::startNode StartNode result: " << result;
+    qDebug() << "RCTStatus::startNode StartNode result: " << statusGoResultError(result);
 }
 
 
 void RCTStatus::stopNode() {
     qDebug() << "call of RCTStatus::stopNode";
     const char* result = StopNode();
-    qDebug() << "RCTStatus::stopNode StopNode result: " << result;
+    qDebug() << "RCTStatus::stopNode StopNode result: " << statusGoResultError(result);
 }
 
 
@@ -127,7 +127,7 @@ void RCTStatus::createAccount(QString password, double callbackId) {
     Q_D(RCTStatus);
     qDebug() << "call of RCTStatus::createAccount with param callbackId: " << callbackId;
     const char* result = CreateAccount(password.toUtf8().data());
-    qDebug() << "RCTStatus::createAccount CreateAccount result: " << result;
+    qDebug() << "RCTStatus::createAccount CreateAccount result: " << statusGoResultError(result);
     d->bridge->invokePromiseCallback(callbackId, QVariantList{result});
 }
 
@@ -136,7 +136,7 @@ void RCTStatus::notifyUsers(QString token, QString payloadJSON, QString tokensJS
     Q_D(RCTStatus);
     qDebug() << "call of RCTStatus::notifyUsers with param callbackId: " << callbackId;
     const char* result = NotifyUsers(token.toUtf8().data(), payloadJSON.toUtf8().data(), tokensJSON.toUtf8().data());
-    qDebug() << "RCTStatus::notifyUsers Notify result: " << result;
+    qDebug() << "RCTStatus::notifyUsers Notify result: " << statusGoResultError(result);
     d->bridge->invokePromiseCallback(callbackId, QVariantList{result});
 }
 
@@ -145,7 +145,7 @@ void RCTStatus::addPeer(QString enode, double callbackId) {
     Q_D(RCTStatus);
     qDebug() << "call of RCTStatus::addPeer with param callbackId: " << callbackId;
     const char* result = AddPeer(enode.toUtf8().data());
-    qDebug() << "RCTStatus::addPeer AddPeer result: " << result;
+    qDebug() << "RCTStatus::addPeer AddPeer result: " << statusGoResultError(result);
     d->bridge->invokePromiseCallback(callbackId, QVariantList{result});
 }
 
@@ -154,7 +154,7 @@ void RCTStatus::recoverAccount(QString passphrase, QString password, double call
     Q_D(RCTStatus);
     qDebug() << "call of RCTStatus::recoverAccount with param callbackId: " << callbackId;
     const char* result = RecoverAccount(password.toUtf8().data(), passphrase.toUtf8().data());
-    qDebug() << "RCTStatus::recoverAccount RecoverAccount result: " << result;
+    qDebug() << "RCTStatus::recoverAccount RecoverAccount result: " << statusGoResultError(result);
     d->bridge->invokePromiseCallback(callbackId, QVariantList{result});
 }
 
@@ -163,7 +163,7 @@ void RCTStatus::login(QString address, QString password, double callbackId) {
     Q_D(RCTStatus);
     qDebug() << "call of RCTStatus::login with param callbackId: " << callbackId;
     const char* result = Login(address.toUtf8().data(), password.toUtf8().data());
-    qDebug() << "RCTStatus::login Login result: " << result;
+    qDebug() << "RCTStatus::login Login result: " << statusGoResultError(result);
     d->bridge->invokePromiseCallback(callbackId, QVariantList{result});
 }
 
@@ -172,7 +172,7 @@ void RCTStatus::sendTransaction(QString txArgsJSON, QString password, double cal
     Q_D(RCTStatus);
     qDebug() << "call of RCTStatus::sendTransaction with param callbackId: " << callbackId;
     const char* result = SendTransaction(txArgsJSON.toUtf8().data(), password.toUtf8().data());
-    qDebug() << "RCTStatus::sendTransaction SendTransaction result: " << result;
+    qDebug() << "RCTStatus::sendTransaction SendTransaction result: " << statusGoResultError(result);
     d->bridge->invokePromiseCallback(callbackId, QVariantList{result});
 }
 
@@ -181,7 +181,7 @@ void RCTStatus::signMessage(QString rpcParams, double callbackId) {
     Q_D(RCTStatus);
     qDebug() << "call of RCTStatus::signMessage with param callbackId: " << callbackId;
     const char* result = SignMessage(rpcParams.toUtf8().data());
-    qDebug() << "RCTStatus::signMessage SignMessage result: " << result;
+    qDebug() << "RCTStatus::signMessage SignMessage result: " << statusGoResultError(result);
     d->bridge->invokePromiseCallback(callbackId, QVariantList{result});
 }
 
@@ -211,7 +211,7 @@ void RCTStatus::callRPC(QString payload, double callbackId) {
     Q_D(RCTStatus);
     qDebug() << "call of RCTStatus::callRPC with param callbackId: " << callbackId;
     const char* result = CallRPC(payload.toUtf8().data());
-    qDebug() << "RCTStatus::callRPC CallRPC result: " << result;
+    qDebug() << "RCTStatus::callRPC CallRPC result: " << statusGoResultError(result);
     d->bridge->invokePromiseCallback(callbackId, QVariantList{result});
 }
 
@@ -219,7 +219,7 @@ void RCTStatus::callPrivateRPC(QString payload, double callbackId) {
     Q_D(RCTStatus);
     qDebug() << "call of RCTStatus::callPrivateRPC with param callbackId: " << callbackId;
     const char* result = CallPrivateRPC(payload.toUtf8().data());
-    qDebug() << "RCTStatus::callPrivateRPC CallPrivateRPC result: " << result;
+    qDebug() << "RCTStatus::callPrivateRPC CallPrivateRPC result: " << statusGoResultError(result);
     d->bridge->invokePromiseCallback(callbackId, QVariantList{result});
 }
 
@@ -244,4 +244,16 @@ void RCTStatus::emitStatusGoEvent(QString event) {
 void RCTStatus::onStatusGoEvent(QString event) {
     qDebug() << "call of RCTStatus::onStatusGoEvent ... event: " << event.toUtf8().data();
     RCTStatusPrivate::bridge->eventDispatcher()->sendDeviceEvent("gethEvent", QVariantMap{{"jsonEvent", event.toUtf8().data()}});
+}
+
+QString RCTStatus::statusGoResultError(const char* result)
+{
+    QJsonParseError jsonError;
+    QJsonDocument jsonDoc = QJsonDocument::fromJson(QString(result).toUtf8(), &jsonError);
+    if (jsonError.error != QJsonParseError::NoError){
+        qDebug() << jsonError.errorString();
+        return QString("");
+    }
+
+    return QString("Error: %1").arg(jsonDoc.toVariant().toMap().value("error").toString());
 }

--- a/modules/react-native-status/desktop/rctstatus.h
+++ b/modules/react-native-status/desktop/rctstatus.h
@@ -65,6 +65,8 @@ private Q_SLOTS:
     void onStatusGoEvent(QString event);
 
 private:
+    QString statusGoResultError(const char *result);
+
     QScopedPointer<RCTStatusPrivate> d_ptr;
 };
 


### PR DESCRIPTION
fixes #5816

### Summary:

Don't log CreateAccount result details #5816;
Update .re-natal config with new JS modules

status: ready

CreateAccount output to be put into the log file changed to:

```
call of RCTStatus::createAccount with param callbackId:  2699
RCTStatus::createAccount CreateAccount result:  "Success"
```
