### PR TITLE
Fix translation zero plural

### DIFF
--- a/src/status_im/chat/views/toolbar_content.cljs
+++ b/src/status_im/chat/views/toolbar_content.cljs
@@ -62,7 +62,9 @@
         (if public?
           (i18n/label :t/public-group-status)
           (let [cnt (inc (count contacts))]
-            (i18n/label-pluralize cnt :t/members-active)))]])))
+            (if (zero? cnt)
+              (i18n/label :members-active-none)
+              (i18n/label-pluralize cnt :t/members-active))))]])))
 
 (defview toolbar-content-view []
   (letsubs [{:keys [group-chat color online contacts

--- a/translations/en.json
+++ b/translations/en.json
@@ -21,9 +21,9 @@
     "currency-display-name-sos": "Somalia Shilling",
     "members-active": {
         "one": "1 member",
-        "other": "{{count}} members",
-        "zero": "no members"
+        "other": "{{count}} members"
     },
+    "members-active-none": "no members",
     "chat-name": "Chat name",
     "currency-display-name-zar": "South Africa Rand",
     "phew-here-is-your-passphrase": "Phew, that was hard. Here is your passphrase, *write this down and keep it safe!* You will need it to recover your account.",
@@ -561,9 +561,9 @@
     "transactions-unsigned": "Unsigned",
     "members": {
         "one": "1 member",
-        "other": "{{count}} members",
-        "zero": "no members"
+        "other": "{{count}} members"
     },
+    "members-none": "no members",
     "delete-mailserver-title": "Delete mailserver",
     "intro-message1": "Welcome to Status!\nTap this message to set your password and get started.",
     "public-chat-user-count": "{{count}} people",


### PR DESCRIPTION
> 1. We use zero plurals that aren’t unicode standards and we need to do a work around in Lokalise. But it is a bit janky. Simple fix is to change those 2 keys

status: ready 
