### PR TITLE
advanced does not scroll down the Profile screen

### DIFF
--- a/src/status_im/utils/views.clj
+++ b/src/status_im/utils/views.clj
@@ -45,7 +45,10 @@
                        rest-body)
         [subs component-map body] (case (count rest-body')
                                     1 [nil {} (first rest-body')]
-                                    2 [(first rest-body') {} (second rest-body')]
+                                    2 (let [first-element (first rest-body')]
+                                        (if (map? first-element)
+                                          [nil first-element (second rest-body')]
+                                          [(first rest-body') {} (second rest-body')]))
                                     3 rest-body')
         [subs-bindings vars-bindings] (prepare-subs subs)]
     `(do


### PR DESCRIPTION
adjust defview so that component-map can be passed as the second arg 

issue appeared after this change https://github.com/status-im/status-react/commit/a20facd895647535e284e310e35d4fccefcd35f0#diff-54cfa5eebf84c0b8c40945ba521cd55cR140

status: ready
