### PR TITLE
update developer dependencies

### DIFF
--- a/clj-rn.conf.edn
+++ b/clj-rn.conf.edn
@@ -46,7 +46,7 @@
  :figwheel-options {:nrepl-port 7888
                     :nrepl-middleware ["cider.nrepl/cider-middleware"
                                        "refactor-nrepl.middleware/wrap-refactor"
-                                       "cemerick.piggieback/wrap-cljs-repl"]}
+                                       "cider.piggieback/wrap-cljs-repl"]}
 
  :builds [{:id           :desktop
            :source-paths ["react-native/src/desktop" "src" "env/dev"]

--- a/deps.edn
+++ b/deps.edn
@@ -20,7 +20,7 @@
                  :sha "d19290a6c908e1cab291c21dfe04c2a67316744b"}
 
          ;; Figwheel ClojureScript REPL
-         com.cemerick/piggieback {:mvn/version "0.2.2"
+         cider/piggieback        {:mvn/version "0.3.9"
                                   :exclusions  [com.google.javascript/closure-compiler]}
          figwheel-sidecar        {:mvn/version "0.5.16"
                                   :exclusions  [com.google.javascript/closure-compiler]}
@@ -30,8 +30,7 @@
          day8.re-frame/tracing   {:mvn/version "0.5.0"}
 
          ;; CIDER compatible nREPL
-         cider/cider-nrepl       {:mvn/version "0.16.0"}
-         org.clojure/tools.nrepl {:mvn/version "0.2.13"}
-         refactor-nrepl          {:mvn/version "2.3.1"}}}
+         cider/cider-nrepl       {:mvn/version "0.18.0"}
+         refactor-nrepl          {:mvn/version "2.4.0"}}}
   :test {:extra-deps {day8.re-frame/test {:mvn/version "0.1.5"}
                       doo                {:mvn/version "0.1.9"}}}}}

--- a/project.clj
+++ b/project.clj
@@ -60,7 +60,7 @@
                                                         :main          "env.desktop.main"
                                                         :output-dir    "target/desktop"
                                                         :optimizations :none}}}}
-                        :repl-options {:nrepl-middleware [cemerick.piggieback/wrap-cljs-repl]
+                        :repl-options {:nrepl-middleware [cider.piggieback/wrap-cljs-repl]
                                        :timeout          240000}}
              :figwheel [:dev
                         {:dependencies [[figwheel-sidecar "0.5.16-SNAPSHOT"]


### PR DESCRIPTION
Fix cider-warning because we use an old version of cider-nrepl and piggieback.
Note to developpers:

After running `clj watch` command and figwheel repl has started, one can connect to it with cider using `cider-connect-clojurescript` after configuring a proper default cljs-repl in `.dir-locals.el`:
```
((nil . ((cider-cljs-repl-types . ((figwheel-repl "(do (require 'figwheel-sidecar.repl-api) (figwheel-sidecar.repl-api/cljs-repl))"
                                                  cider-check-figwheel-requirements)))
         (cider-default-cljs-repl . figwheel-repl))))
```


status: ready