### PR TITLE
Added missed packages to re-natal config

### DIFF
--- a/desktop_files/.re-natal
+++ b/desktop_files/.re-natal
@@ -56,7 +56,9 @@
     "rn-snoopy/stream/filter",
     "rn-snoopy/stream/buffer",
     "react-native/Libraries/vendor/emitter/EventEmitter",
-    "react-native-fetch-polyfill"
+    "react-native-fetch-polyfill",
+    "text-encoding",
+    "js-sha3"
   ],
   "imageDirs": [
     "resources/images",


### PR DESCRIPTION
fixes desktop build

### Summary:
Added missed packages to .re-natal config

### Testing notes (optional):
No need for testing, this PR doesn't affect mobile, since mobile doesn't rely on re-natal

### Steps to test:
- Open Status
- Close Status

status: ready
