### PR TITLE
Edit username on desktop

### DIFF
--- a/src/status_im/ui/screens/desktop/main/tabs/profile/styles.cljs
+++ b/src/status_im/ui/screens/desktop/main/tabs/profile/styles.cljs
@@ -31,6 +31,11 @@
    :align-items     :center
    :flex            1})
 
+(def profile-edit
+  {:margin-top         24
+   :padding-horizontal 24
+   :align-items        :flex-end})
+
 (def profile-photo
   {:border-radius 100
    :width         100
@@ -38,6 +43,13 @@
 
 (def profile-user-name
   {:font-size   18})
+
+(def profile-editing-user-name
+  (merge profile-user-name
+         {:height           20
+          :width            80
+          :background-color colors/gray-lighter
+          :align-items      :flex-end}))
 
 (def share-contact-code
   {:flex-direction    :row


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

Adds possibility to edit username on desktop - due to the desktop but, `text-input` has to have fixed size in order to be actually visible and editable, therefore, styling is little bit "meh" - when in edit mode, the username to be edit usually "jumps" little bit to the left or right depending on it's original length, but it does the job and we will fix the styling once underlying `text-input` bug is resolved. 

contribute to #5456 

### Testing notes (optional):
Test that username editing on desktop works

status: ready
