### PR TITLE
workaround for dependency failures when doing pod update

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -8,6 +8,9 @@ target 'StatusIm' do
   # Uncomment the next line if you're using Swift or would like to use dynamic frameworks
   # use_frameworks!
 
+  # Fix for CocoaPods/issues/8110
+  pod 'GoogleUtilities/MethodSwizzler', '5.2.0'
+
   # Pods for StatusIm
   pod 'Firebase/Core'
   pod 'Firebase/Messaging'


### PR DESCRIPTION
This is related to a `pod update` issue we are having:
```
...
[!] CocoaPods could not find compatible versions for pod "Firebase/Core":
  In Podfile:
    Firebase/Core

Specs satisfying the `Firebase/Core` dependency were found, but they required a higher minimum deployment target.
CocoaPods could not find compatible versions for pod "GoogleUtilities/MethodSwizzler":
  In Podfile:
    Firebase/Core was resolved to 5.8.0, which depends on
      FirebaseAnalytics (= 5.1.2) was resolved to 5.1.2, which depends on
        GoogleUtilities/MethodSwizzler (~> 5.2.0)

Specs satisfying the `GoogleUtilities/MethodSwizzler (~> 5.2.0)` dependency were found, but they required a higher minimum deployment target.
```
Related issues:
https://github.com/CocoaPods/CocoaPods/issues/8110
https://github.com/firebase/firebase-ios-sdk/issues/1845#issuecomment-422831481