### PR TITLE
remove deprecated navigate-to function

### DIFF
--- a/src/status_im/ui/screens/contacts/events.cljs
+++ b/src/status_im/ui/screens/contacts/events.cljs
@@ -54,11 +54,12 @@
 
 (handlers/register-handler-fx
  :open-contact-toggle-list
- (fn [{:keys [db]} _]
-   {:db (-> (assoc db
-                   :group/selected-contacts #{}
-                   :new-chat-name "")
-            (navigation/navigate-to :contact-toggle-list))}))
+ (fn [{:keys [db] :as cofx} _]
+   (handlers-macro/merge-fx cofx
+                            {:db (assoc db
+                                        :group/selected-contacts #{}
+                                        :new-chat-name "")}
+                            (navigation/navigate-to-cofx :contact-toggle-list nil))))
 
 (handlers/register-handler-fx
  :open-chat-with-contact

--- a/src/status_im/ui/screens/extensions/add/events.cljs
+++ b/src/status_im/ui/screens/extensions/add/events.cljs
@@ -31,10 +31,10 @@
 
 (handlers/register-handler-fx
  :extension/stage
- (fn [{:keys [db]} [_ extension-data]]
-   {:db (-> db
-            (assoc :staged-extension extension-data)
-            (navigation/navigate-to :show-extension))}))
+ (fn [{:keys [db] :as cofx} [_ extension-data]]
+   (handlers-macro/merge-fx cofx
+                            {:db (assoc db :staged-extension extension-data)}
+                            (navigation/navigate-to-cofx :show-extension nil))))
 
 (handlers/register-handler-fx
  :extension/show

--- a/src/status_im/ui/screens/group/chat_settings/events.cljs
+++ b/src/status_im/ui/screens/group/chat_settings/events.cljs
@@ -11,11 +11,12 @@
 
 (handlers/register-handler-fx
  :show-group-chat-profile
- (fn [{:keys [db]} [_ chat-id]]
-   {:db (-> db
-            (assoc :new-chat-name (get-in db [:chats chat-id :name])
-                   :group/group-type :chat-group)
-            (navigation/navigate-to :group-chat-profile))}))
+ (fn [{:keys [db] :as cofx} [_ chat-id]]
+   (handlers-macro/merge-fx cofx
+                            {:db (assoc db
+                                        :new-chat-name (get-in db [:chats chat-id :name])
+                                        :group/group-type :chat-group)}
+                            (navigation/navigate-to-cofx :group-chat-profile nil))))
 
 (handlers/register-handler-fx
  :add-new-group-chat-participants

--- a/src/status_im/ui/screens/navigation.cljs
+++ b/src/status_im/ui/screens/navigation.cljs
@@ -68,14 +68,6 @@
                            (:routeName (get actions index)))
    ::navigate-reset config})
 
-(defn navigate-to
-  "DEPRECATED, use navigate-to-cofx above.
-  Navigates to particular view"
-  ([db go-to-view-id]
-   (navigate-to db go-to-view-id nil))
-  ([db go-to-view-id screen-params]
-   (:db (navigate-to-cofx go-to-view-id screen-params {:db db}))))
-
 (def unload-data-interceptor
   (re-frame/->interceptor
    :id unload-data-interceptor


### PR DESCRIPTION
the `navigate-to` function has been deprecated for a while by `navigate-to-cofx`, only a few instances remained with confusing results as it was expected `db` instead of `cofx`
removes the function as well as all remaining instances

status: ready
