### PR TITLE
Fix missing 'Not sent' where is no internet connection

### DIFF
--- a/desktop_files/package.json
+++ b/desktop_files/package.json
@@ -55,7 +55,7 @@
     "re-natal": "git+https://github.com/status-im/re-natal.git#master",
     "react": "16.4.1",
     "react-dom": "16.4.2",
-    "react-native": "git+https://github.com/status-im/react-native-desktop.git#master",
+    "react-native": "git+https://github.com/siphiuel/react-native-desktop.git",
     "react-native-background-timer": "2.0.0",
     "react-native-camera": "0.10.0",
     "react-native-config": "git+https://github.com/status-im/react-native-config.git",

--- a/translations/en.json
+++ b/translations/en.json
@@ -231,6 +231,7 @@
     "wallet-onboarding-title": "Simple and secure cryptocurrency wallet",
     "logout": "Log out",
     "status-not-sent": "Not sent. Tap for options",
+    "status-not-sent-without-tap": "Not sent",
     "edit-network-config": "Edit network config",
     "clear-history-confirmation": "Clear history?",
     "connect": "Connect",


### PR DESCRIPTION
Fixes #5840 

This PR relies on an external rn-desktop fork, PR is open in https://github.com/status-im/react-native-desktop/pull/339. Once the latter is merged, rn-desktop link will be reverted to the original one.

Two items are fixed:
1. `Not sent` not appearing when messages are sent in offline mode
2. `Offline` grey status message not appearing while in offline mode.