### PR TITLE
Explicitly disable Rendezvous  discovery when signing in to the account.

### DIFF
--- a/src/status_im/node/core.cljs
+++ b/src/status_im/node/core.cljs
@@ -76,7 +76,8 @@
       (get-base-node-config)
 
       current-fleet
-      (assoc :NoDiscovery false
+      (assoc :NoDiscovery   false
+             :Rendezvous    false
              :ClusterConfig {:Enabled true
                              :Fleet              (name current-fleet-key)
                              :BootNodes          (pick-nodes 4 (vals (:boot current-fleet)))


### PR DESCRIPTION
Looks like discovery takes a lot of time to start up, so we disable it explicititly.

fixes #5889

status: ready <!-- Can be ready or wip -->
