### PR TITLE
fix event vector

### DIFF
--- a/src/status_im/transport/filters.cljs
+++ b/src/status_im/transport/filters.cljs
@@ -53,7 +53,7 @@
 
 (handlers/register-handler-fx
  ::discovery-filter-added
- (fn [{:keys [db]} [filter]]
+ (fn [{:keys [db]} [_ filter]]
    {:db (assoc db :transport/discovery-filter filter)}))
 
 (re-frame/reg-fx


### PR DESCRIPTION

### Summary:

an event vector wasn't properly refactored after removing trim-v

status: ready 
