### PR TITLE
Fix account create and recover navigation

### DIFF
--- a/src/status_im/accounts/create/core.cljs
+++ b/src/status_im/accounts/create/core.cljs
@@ -99,10 +99,18 @@
     :enter-password (navigation/navigate-back cofx)
     :confirm-password (reset-account-creation cofx)))
 
+(defn navigate-to-create-account-screen [{:keys [db] :as cofx}]
+  (handlers-macro/merge-fx cofx
+                           {:db (update db :accounts/create
+                                        #(-> %
+                                             (assoc :step :enter-password)
+                                             (dissoc :password :password-confirm :name :error)))}
+                           (navigation/navigate-to-cofx :create-account nil)))
+
 (defn navigate-to-authentication-method [{:keys [db] :as cofx}]
   (if (hardwallet/hardwallet-supported? db)
     (navigation/navigate-to-cofx :hardwallet/authentication-method nil cofx)
-    (navigation/navigate-to-cofx :create-account nil cofx)))
+    (navigate-to-create-account-screen cofx)))
 
 ;;;; COFX
 

--- a/src/status_im/accounts/recover/core.cljs
+++ b/src/status_im/accounts/recover/core.cljs
@@ -5,6 +5,7 @@
             [status-im.accounts.db :as db]
             [status-im.i18n :as i18n]
             [status-im.native-module.core :as status]
+            [status-im.ui.screens.navigation :as navigation]
             [status-im.utils.ethereum.mnemonic :as mnemonic]
             [status-im.utils.handlers-macro :as handlers-macro]
             [status-im.utils.identicon :as identicon]
@@ -88,6 +89,11 @@
           :content             (i18n/label :recovery-typo-dialog-description)
           :confirm-button-text (i18n/label :recovery-confirm-phrase)
           :on-accept           #(re-frame/dispatch [:accounts.recover.ui/recover-account-confirmed])}}))))
+
+(defn navigate-to-recover-account-screen [{:keys [db] :as cofx}]
+  (handlers-macro/merge-fx cofx
+                           {:db (dissoc db :accounts/recover)}
+                           (navigation/navigate-to-cofx :recover nil)))
 
 (re-frame/reg-fx
  :accounts.recover/recover-account

--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -1,6 +1,5 @@
 (ns status-im.events
-  (:require status-im.ui.screens.accounts.recover.navigation
-            [re-frame.core :as re-frame]
+  (:require [re-frame.core :as re-frame]
             [status-im.accounts.core :as accounts]
             [status-im.accounts.create.core :as accounts.create]
             [status-im.accounts.login.core :as accounts.login]
@@ -147,6 +146,11 @@
    (accounts.create/navigate-to-authentication-method cofx)))
 
 ;; accounts recover module
+
+(handlers/register-handler-fx
+ :accounts.recover.ui/recover-account-button-pressed
+ (fn [cofx _]
+   (accounts.recover/navigate-to-recover-account-screen cofx)))
 
 (handlers/register-handler-fx
  :accounts.recover.ui/passphrase-input-changed

--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -1,6 +1,5 @@
 (ns status-im.events
-  (:require status-im.ui.screens.accounts.create.navigation
-            status-im.ui.screens.accounts.recover.navigation
+  (:require status-im.ui.screens.accounts.recover.navigation
             [re-frame.core :as re-frame]
             [status-im.accounts.core :as accounts]
             [status-im.accounts.create.core :as accounts.create]
@@ -509,6 +508,11 @@
  :hardwallet.ui/status-hardwallet-option-pressed
  (fn [cofx _]
    (hardwallet/navigate-to-connect-screen cofx)))
+
+(handlers/register-handler-fx
+ :hardwallet.ui/password-option-pressed
+ (fn [cofx _]
+   (accounts.create/navigate-to-create-account-screen cofx)))
 
 (handlers/register-handler-fx
  :hardwallet.ui/go-to-settings-button-pressed

--- a/src/status_im/ui/screens/accounts/create/navigation.cljs
+++ b/src/status_im/ui/screens/accounts/create/navigation.cljs
@@ -1,9 +1,0 @@
-(ns status-im.ui.screens.accounts.create.navigation
-  (:require [status-im.ui.screens.navigation :as nav]))
-
-(defmethod nav/preload-data! :create-account
-  [db]
-  (update db :accounts/create
-          #(-> %
-               (assoc :step :enter-password)
-               (dissoc :password :password-confirm :name :error))))

--- a/src/status_im/ui/screens/accounts/recover/navigation.cljs
+++ b/src/status_im/ui/screens/accounts/recover/navigation.cljs
@@ -1,6 +1,0 @@
-(ns status-im.ui.screens.accounts.recover.navigation
-  (:require [status-im.ui.screens.navigation :as nav]))
-
-(defmethod nav/preload-data! :recover
-  [db]
-  (update db :accounts/recover dissoc :password :passphrase :processing?))

--- a/src/status_im/ui/screens/accounts/views.cljs
+++ b/src/status_im/ui/screens/accounts/views.cljs
@@ -45,7 +45,7 @@
        [components.common/button {:on-press #(re-frame/dispatch [:accounts.create.ui/create-new-account-button-pressed])
                                   :label    (i18n/label :t/create-new-account)}]
        [react/view styles/bottom-button-container
-        [components.common/button {:on-press    #(re-frame/dispatch [:navigate-to :recover])
+        [components.common/button {:on-press    #(re-frame/dispatch [:accounts.recover.ui/recover-account-button-pressed])
                                    :label       (i18n/label :t/add-existing-account)
                                    :background? false}]]
        [privacy-policy/privacy-policy-button]]]]))

--- a/src/status_im/ui/screens/hardwallet/authentication_method/views.cljs
+++ b/src/status_im/ui/screens/hardwallet/authentication_method/views.cljs
@@ -39,4 +39,4 @@
                                  :on-press #(re-frame/dispatch [:hardwallet.ui/status-hardwallet-option-pressed])}]
      [authentication-method-row {:title    (i18n/label :t/password)
                                  :icon     :icons/password
-                                 :on-press #(re-frame/dispatch [:navigate-to :create-account])}]]]])
+                                 :on-press #(re-frame/dispatch [:hardwallet.ui/password-option-pressed])}]]]])

--- a/src/status_im/ui/screens/intro/views.cljs
+++ b/src/status_im/ui/screens/intro/views.cljs
@@ -20,7 +20,7 @@
                       :key   :intro-text-description}]]
    [react/view styles/buttons-container
     [components.common/button {:button-style {:flex-direction :row}
-                               :on-press     #(re-frame/dispatch [:navigate-to :create-account])
+                               :on-press     #(re-frame/dispatch [:accounts.create.ui/create-new-account-button-pressed])
                                :label        (i18n/label :t/create-account)}]
     [react/view styles/bottom-button-container
      [components.common/button {:on-press    #(re-frame/dispatch [:navigate-to :recover])

--- a/src/status_im/ui/screens/intro/views.cljs
+++ b/src/status_im/ui/screens/intro/views.cljs
@@ -23,7 +23,7 @@
                                :on-press     #(re-frame/dispatch [:accounts.create.ui/create-new-account-button-pressed])
                                :label        (i18n/label :t/create-account)}]
     [react/view styles/bottom-button-container
-     [components.common/button {:on-press    #(re-frame/dispatch [:navigate-to :recover])
+     [components.common/button {:on-press    #(re-frame/dispatch [:accounts.recover.ui/recover-account-button-pressed])
                                 :label       (i18n/label :t/already-have-account)
                                 :background? false}]]
     [privacy-policy/privacy-policy-button]]])


### PR DESCRIPTION
### Steps to test:

- Create account logout and try to create a new account, screen should not be blank
- Recover account, type invalid input and go back, return to recover account screen, error tooltips should be gone as well

status: ready
