### PR TITLE
Add Fastlane action to upload Google Play metadata

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -179,9 +179,10 @@ platform :android do
         default_payloads: []
     )
   end
+
+  desc "Deploy a new alpha (public) build to Google Play"
+  desc "expects GOOGLE_PLAY_JSON_KEY environment variable"
   lane :release do
-    desc "Deploy a new alpha (public) build to Google Play"
-    desc "expects GOOGLE_PLAY_JSON_KEY environment variable"
     upload_to_play_store(
       track: "alpha",
       apk: "android/app/build/outputs/apk/release/app-release.apk",
@@ -191,6 +192,17 @@ platform :android do
         message: "New release build uploaded to Google Play",
         slack_url: ENV["SLACK_URL"],
         default_payloads: []
+    )
+  end
+
+  desc "Upload metadata to Google Play."
+  desc "Metadata is always updated when builds are uploaded,"
+  desc "but this action can update metadata without uploading a build."
+  desc "expects GOOGLE_PLAY_JSON_KEY environment variable"
+  lane :upload_metadata do
+    upload_to_play_store(
+      skip_upload_apk: true,
+      json_key_data: ENV["GOOGLE_PLAY_JSON_KEY"]
     )
   end
 


### PR DESCRIPTION

### Summary:

A recent change [adding Portuguese metadata to the Play Store](https://github.com/status-im/status-react/pull/5833) created a [problem](https://github.com/status-im/status-react/issues/5921) when uploading builds to the Play Store.

There was no way to test or change metadata without uploading a build, so this change adds a Fastlane action to update metadata on its own.



### Steps to test:

`bundle exec fastlane android upload_metadata`
<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready 