### PR TITLE
[#5942] reduce touching area for Privacy Policy link

### DIFF
--- a/src/status_im/ui/screens/privacy_policy/views.cljs
+++ b/src/status_im/ui/screens/privacy_policy/views.cljs
@@ -5,11 +5,10 @@
             [re-frame.core :as re-frame]))
 
 (defn privacy-policy-button []
-  [react/touchable-highlight
-   {:on-press #(re-frame/dispatch [:privacy-policy/privacy-policy-button-pressed])}
-   [react/view styles/privacy-policy-button-container
-    [react/text {:style styles/privacy-policy-button-text-gray}
-     (i18n/label :t/agree-by-continuing)
-     [react/text
-      {:style styles/privacy-policy-button-text}
-      (i18n/label :t/privacy-policy)]]]])
+  [react/view styles/privacy-policy-button-container
+   [react/text {:style    styles/privacy-policy-button-text-gray
+                :on-press #(re-frame/dispatch [:privacy-policy/privacy-policy-button-pressed])}
+    (i18n/label :t/agree-by-continuing)
+    [react/text
+     {:style styles/privacy-policy-button-text}
+     (i18n/label :t/privacy-policy)]]])


### PR DESCRIPTION
fix #5942 

The black area here:

<img width="700" alt="screen shot 2018-09-22 at 11 04 00" src="https://user-images.githubusercontent.com/2364994/45915097-b8672600-be57-11e8-92f9-8e0f1494e7c3.png">

and here

<img width="380" alt="screen shot 2018-09-22 at 10 52 50" src="https://user-images.githubusercontent.com/2364994/45915100-cb79f600-be57-11e8-9db5-0fc5c2745386.png">


There is no sense in making it smaller on mobile device, while on desktop it's not possible to make only "Privacy Policy" words touchable.
Also while on mobile only "a black area" is touchable, on desktop link will be opened if touch screen to the left/right of the text. 

status: ready 
