### PR TITLE
Remove misleading wrap-call-once! fn

### DIFF
--- a/src/status_im/utils/core.cljc
+++ b/src/status_im/utils/core.cljc
@@ -36,16 +36,6 @@
 (defn hash-tag? [s]
   (= \# (first s)))
 
-(defn wrap-call-once!
-  "Returns a version of provided function that will be called only the first time wrapping function is called. Returns nil."
-  [f]
-  (let [called? (volatile! false)]
-    (fn [& args]
-      (when-not @called?
-        (vreset! called? true)
-        (apply f args)
-        nil))))
-
 (defn update-if-present
   "Like regular `clojure.core/update` but returns original map if update key is not present"
   [m k f & args]

--- a/test/cljs/status_im/test/utils/utils.cljs
+++ b/test/cljs/status_im/test/utils/utils.cljs
@@ -2,15 +2,6 @@
   (:require [cljs.test :refer-macros [deftest is]]
             [status-im.utils.core :as u]))
 
-(deftest wrap-as-call-once-test
-  (let [count (atom 0)]
-    (letfn [(inc-count [] (swap! count inc))]
-      (let [f (u/wrap-call-once! inc-count)]
-        (is (nil? (f)))
-        (is (= 1 @count))
-        (is (nil? (f)))
-        (is (= 1 @count))))))
-
 (deftest truncate-str-test
   (is (= (u/truncate-str "Long string" 7) "Long...")) ; threshold is less then string length
   (is (= (u/truncate-str "Long string" 7 true) "Lo...ng")) ; threshold is less then string length (truncate middle)


### PR DESCRIPTION
I propose we delete this function. Used nowhere at the moment

Already happened two times that someone tries to use this fn for a view in a PR. 
It is misleading because if the component refreshes, which usually happens anyway for the case it is used for, then it doesn't prevent a second execution of the function since it is refreshed as well.
For these use case writing a guard with a reagent atom is straightforward and simple enough.

status: ready
