### PR TITLE
Fleet settings: use fleet names from the JSON file.

### DIFF
--- a/src/status_im/ui/screens/fleet_settings/views.cljs
+++ b/src/status_im/ui/screens/fleet_settings/views.cljs
@@ -7,6 +7,7 @@
             [status-im.ui.components.status-bar.view :as status-bar]
             [status-im.ui.components.toolbar.view :as toolbar]
             [status-im.ui.screens.fleet-settings.styles :as styles]
+            [status-im.fleet.core :as fleet-core]
             [status-im.utils.platform :as platform])
   (:require-macros [status-im.utils.views :as views]))
 
@@ -34,7 +35,7 @@
           fleet]]]])))
 
 (def fleets
-  ["eth.staging" "eth.beta" "eth.test"])
+  (map name (keys fleet-core/fleets)))
 
 (views/defview fleet-settings []
   (views/letsubs [current-fleet [:settings/current-fleet]]


### PR DESCRIPTION
Instead of hardcoding the values in fleet selection screen, use the ones that we have read from fleets.json file.

status: ready <!-- Can be ready or wip -->
