### PR TITLE
fix CVE-2018-6341

### DIFF
--- a/desktop_files/package-lock.json
+++ b/desktop_files/package-lock.json
@@ -5,11 +5,11 @@
   "requires": true,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.0.0-beta.47",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.47.tgz",
-      "integrity": "sha512-W7IeG4MoVf4oUvWfHUx9VG9if3E0xSUDf1urrnNYtC2ow1dz2ptvQ6YsJfyVXDuPTFXz66jkHhzMW7a5Eld7TA==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-rc.2.tgz",
+      "integrity": "sha512-+cVix+HBNakVp7IU1WReJV8dnJl/yaBA5JRXc758BSrvJCH2hKp1Z0xHIiUaOvxMwKXc3EXGIYhlnx5T+6ofGA==",
       "requires": {
-        "@babel/highlight": "7.0.0-beta.47"
+        "@babel/highlight": "7.0.0-rc.2"
       }
     },
     "@babel/core": {
@@ -31,36 +31,6 @@
         "resolve": "1.8.1",
         "semver": "5.5.1",
         "source-map": "0.5.7"
-      },
-      "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.0.0-rc.2",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-rc.2.tgz",
-          "integrity": "sha512-+cVix+HBNakVp7IU1WReJV8dnJl/yaBA5JRXc758BSrvJCH2hKp1Z0xHIiUaOvxMwKXc3EXGIYhlnx5T+6ofGA==",
-          "requires": {
-            "@babel/highlight": "7.0.0-rc.2"
-          }
-        },
-        "@babel/highlight": {
-          "version": "7.0.0-rc.2",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-rc.2.tgz",
-          "integrity": "sha512-96V6XHAh9XHzjmucShCP8tULwXsC446doZ6REaLVdZDPNj3NsWbsC7OBeY+u6UWiFxHTTv6YmA4Veh4wXuucYw==",
-          "requires": {
-            "chalk": "2.4.1",
-            "esutils": "2.0.2",
-            "js-tokens": "4.0.0"
-          }
-        },
-        "@babel/template": {
-          "version": "7.0.0-rc.2",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-rc.2.tgz",
-          "integrity": "sha512-CryGZ01Nko2/g8gkYiiPc7x9ZinrX59/BTWMZV1sDj5cAeia64vhyNnXTcNeim885IdGOdYyia1PNBWKnFxuSw==",
-          "requires": {
-            "@babel/code-frame": "7.0.0-rc.2",
-            "@babel/parser": "7.0.0-rc.2",
-            "@babel/types": "7.0.0-rc.2"
-          }
-        }
       }
     },
     "@babel/generator": {
@@ -73,18 +43,6 @@
         "lodash": "4.17.11",
         "source-map": "0.5.7",
         "trim-right": "1.0.1"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.0.0-rc.2",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-rc.2.tgz",
-          "integrity": "sha512-I2SMGD8bUX7sysOwGM8TcwCoaHiOx2YWZmT9h5oAncsPQ9Wy068yJneCF4vkOGTCzPFIETPDR5i3EIEm5QgMFg==",
-          "requires": {
-            "esutils": "2.0.2",
-            "lodash": "4.17.11",
-            "to-fast-properties": "2.0.0"
-          }
-        }
       }
     },
     "@babel/helper-annotate-as-pure": {
@@ -135,18 +93,6 @@
       "requires": {
         "@babel/types": "7.0.0-rc.2",
         "esutils": "2.0.2"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.0.0-rc.2",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-rc.2.tgz",
-          "integrity": "sha512-I2SMGD8bUX7sysOwGM8TcwCoaHiOx2YWZmT9h5oAncsPQ9Wy068yJneCF4vkOGTCzPFIETPDR5i3EIEm5QgMFg==",
-          "requires": {
-            "esutils": "2.0.2",
-            "lodash": "4.17.11",
-            "to-fast-properties": "2.0.0"
-          }
-        }
       }
     },
     "@babel/helper-call-delegate": {
@@ -253,11 +199,6 @@
             "to-fast-properties": "2.0.0"
           }
         },
-        "babylon": {
-          "version": "7.0.0-beta.47",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.47.tgz",
-          "integrity": "sha512-+rq2cr4GDhtToEzKFD6KZZMDBXhjFAr9JjPw9pAppZACeEWqNM294j+NdBzkSHYXwzzBmVjZ3nEVJlOhbR2gOQ=="
-        },
         "js-tokens": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
@@ -331,11 +272,6 @@
             "lodash": "4.17.11",
             "to-fast-properties": "2.0.0"
           }
-        },
-        "babylon": {
-          "version": "7.0.0-beta.47",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.47.tgz",
-          "integrity": "sha512-+rq2cr4GDhtToEzKFD6KZZMDBXhjFAr9JjPw9pAppZACeEWqNM294j+NdBzkSHYXwzzBmVjZ3nEVJlOhbR2gOQ=="
         },
         "js-tokens": {
           "version": "3.0.2",
@@ -447,11 +383,6 @@
             "to-fast-properties": "2.0.0"
           }
         },
-        "babylon": {
-          "version": "7.0.0-beta.47",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.47.tgz",
-          "integrity": "sha512-+rq2cr4GDhtToEzKFD6KZZMDBXhjFAr9JjPw9pAppZACeEWqNM294j+NdBzkSHYXwzzBmVjZ3nEVJlOhbR2gOQ=="
-        },
         "js-tokens": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
@@ -467,36 +398,6 @@
         "@babel/helper-get-function-arity": "7.0.0-rc.2",
         "@babel/template": "7.0.0-rc.2",
         "@babel/types": "7.0.0-rc.2"
-      },
-      "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.0.0-rc.2",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-rc.2.tgz",
-          "integrity": "sha512-+cVix+HBNakVp7IU1WReJV8dnJl/yaBA5JRXc758BSrvJCH2hKp1Z0xHIiUaOvxMwKXc3EXGIYhlnx5T+6ofGA==",
-          "requires": {
-            "@babel/highlight": "7.0.0-rc.2"
-          }
-        },
-        "@babel/highlight": {
-          "version": "7.0.0-rc.2",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-rc.2.tgz",
-          "integrity": "sha512-96V6XHAh9XHzjmucShCP8tULwXsC446doZ6REaLVdZDPNj3NsWbsC7OBeY+u6UWiFxHTTv6YmA4Veh4wXuucYw==",
-          "requires": {
-            "chalk": "2.4.1",
-            "esutils": "2.0.2",
-            "js-tokens": "4.0.0"
-          }
-        },
-        "@babel/template": {
-          "version": "7.0.0-rc.2",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-rc.2.tgz",
-          "integrity": "sha512-CryGZ01Nko2/g8gkYiiPc7x9ZinrX59/BTWMZV1sDj5cAeia64vhyNnXTcNeim885IdGOdYyia1PNBWKnFxuSw==",
-          "requires": {
-            "@babel/code-frame": "7.0.0-rc.2",
-            "@babel/parser": "7.0.0-rc.2",
-            "@babel/types": "7.0.0-rc.2"
-          }
-        }
       }
     },
     "@babel/helper-get-function-arity": {
@@ -628,11 +529,6 @@
             "to-fast-properties": "2.0.0"
           }
         },
-        "babylon": {
-          "version": "7.0.0-beta.47",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.47.tgz",
-          "integrity": "sha512-+rq2cr4GDhtToEzKFD6KZZMDBXhjFAr9JjPw9pAppZACeEWqNM294j+NdBzkSHYXwzzBmVjZ3nEVJlOhbR2gOQ=="
-        },
         "js-tokens": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
@@ -661,9 +557,9 @@
       }
     },
     "@babel/helper-plugin-utils": {
-      "version": "7.0.0-beta.47",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
-      "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-rc.2.tgz",
+      "integrity": "sha512-kavwJYTgdd5W12MpfMJMznrfsx3sCl0HMSJ0vsPcbwT9jhF0EmYL1eyfeYbo4pToYmQgPKp+VGtSHQ3wL8N5lQ=="
     },
     "@babel/helper-regex": {
       "version": "7.0.0-beta.47",
@@ -779,11 +675,6 @@
             "to-fast-properties": "2.0.0"
           }
         },
-        "babylon": {
-          "version": "7.0.0-beta.47",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.47.tgz",
-          "integrity": "sha512-+rq2cr4GDhtToEzKFD6KZZMDBXhjFAr9JjPw9pAppZACeEWqNM294j+NdBzkSHYXwzzBmVjZ3nEVJlOhbR2gOQ=="
-        },
         "js-tokens": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
@@ -896,11 +787,6 @@
             "to-fast-properties": "2.0.0"
           }
         },
-        "babylon": {
-          "version": "7.0.0-beta.47",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.47.tgz",
-          "integrity": "sha512-+rq2cr4GDhtToEzKFD6KZZMDBXhjFAr9JjPw9pAppZACeEWqNM294j+NdBzkSHYXwzzBmVjZ3nEVJlOhbR2gOQ=="
-        },
         "js-tokens": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
@@ -956,11 +842,6 @@
             "lodash": "4.17.11",
             "to-fast-properties": "2.0.0"
           }
-        },
-        "babylon": {
-          "version": "7.0.0-beta.47",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.47.tgz",
-          "integrity": "sha512-+rq2cr4GDhtToEzKFD6KZZMDBXhjFAr9JjPw9pAppZACeEWqNM294j+NdBzkSHYXwzzBmVjZ3nEVJlOhbR2gOQ=="
         },
         "js-tokens": {
           "version": "3.0.2",
@@ -1082,11 +963,6 @@
             "to-fast-properties": "2.0.0"
           }
         },
-        "babylon": {
-          "version": "7.0.0-beta.47",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.47.tgz",
-          "integrity": "sha512-+rq2cr4GDhtToEzKFD6KZZMDBXhjFAr9JjPw9pAppZACeEWqNM294j+NdBzkSHYXwzzBmVjZ3nEVJlOhbR2gOQ=="
-        },
         "js-tokens": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
@@ -1102,53 +978,16 @@
         "@babel/template": "7.0.0-rc.2",
         "@babel/traverse": "7.0.0-rc.2",
         "@babel/types": "7.0.0-rc.2"
-      },
-      "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.0.0-rc.2",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-rc.2.tgz",
-          "integrity": "sha512-+cVix+HBNakVp7IU1WReJV8dnJl/yaBA5JRXc758BSrvJCH2hKp1Z0xHIiUaOvxMwKXc3EXGIYhlnx5T+6ofGA==",
-          "requires": {
-            "@babel/highlight": "7.0.0-rc.2"
-          }
-        },
-        "@babel/highlight": {
-          "version": "7.0.0-rc.2",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-rc.2.tgz",
-          "integrity": "sha512-96V6XHAh9XHzjmucShCP8tULwXsC446doZ6REaLVdZDPNj3NsWbsC7OBeY+u6UWiFxHTTv6YmA4Veh4wXuucYw==",
-          "requires": {
-            "chalk": "2.4.1",
-            "esutils": "2.0.2",
-            "js-tokens": "4.0.0"
-          }
-        },
-        "@babel/template": {
-          "version": "7.0.0-rc.2",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-rc.2.tgz",
-          "integrity": "sha512-CryGZ01Nko2/g8gkYiiPc7x9ZinrX59/BTWMZV1sDj5cAeia64vhyNnXTcNeim885IdGOdYyia1PNBWKnFxuSw==",
-          "requires": {
-            "@babel/code-frame": "7.0.0-rc.2",
-            "@babel/parser": "7.0.0-rc.2",
-            "@babel/types": "7.0.0-rc.2"
-          }
-        }
       }
     },
     "@babel/highlight": {
-      "version": "7.0.0-beta.47",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.47.tgz",
-      "integrity": "sha512-d505K3Hth1eg0b2swfEF7oFMw3J9M8ceFg0s6dhCSxOOF+07WDvJ0HKT/YbK/Jk9wn8Wyr6HIRAUPKJ9Wfv8Rg==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-rc.2.tgz",
+      "integrity": "sha512-96V6XHAh9XHzjmucShCP8tULwXsC446doZ6REaLVdZDPNj3NsWbsC7OBeY+u6UWiFxHTTv6YmA4Veh4wXuucYw==",
       "requires": {
         "chalk": "2.4.1",
         "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
-      },
-      "dependencies": {
-        "js-tokens": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
-        }
+        "js-tokens": "4.0.0"
       }
     },
     "@babel/parser": {
@@ -1162,6 +1001,13 @@
       "integrity": "sha512-R45V1hsr5DQIbhJajyQm5p2KS+qvmAqkEytP+DhrrEUrx0J1OfqWKZPNDiPe3xdLJtgTNZaDBq1iqfs0gnfslg==",
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+        }
       }
     },
     "@babel/plugin-proposal-class-properties": {
@@ -1201,6 +1047,11 @@
             "@babel/types": "7.0.0-beta.47"
           }
         },
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+        },
         "@babel/highlight": {
           "version": "7.0.0-beta.47",
           "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.47.tgz",
@@ -1232,11 +1083,6 @@
             "to-fast-properties": "2.0.0"
           }
         },
-        "babylon": {
-          "version": "7.0.0-beta.47",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.47.tgz",
-          "integrity": "sha512-+rq2cr4GDhtToEzKFD6KZZMDBXhjFAr9JjPw9pAppZACeEWqNM294j+NdBzkSHYXwzzBmVjZ3nEVJlOhbR2gOQ=="
-        },
         "js-tokens": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
@@ -1251,6 +1097,13 @@
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0-beta.47",
         "@babel/plugin-syntax-object-rest-spread": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+        }
       }
     },
     "@babel/plugin-proposal-optional-chaining": {
@@ -1260,6 +1113,13 @@
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0-beta.47",
         "@babel/plugin-syntax-optional-chaining": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+        }
       }
     },
     "@babel/plugin-syntax-class-properties": {
@@ -1268,6 +1128,13 @@
       "integrity": "sha512-vLoAuLSjHSenX3TQmri6ttQWZp3rEtGcRp4LgYEBQ012fN5h+KmcssvkCAqm6V6ozS5KzUWpBlZ6t7YhZG6oBw==",
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+        }
       }
     },
     "@babel/plugin-syntax-dynamic-import": {
@@ -1276,6 +1143,13 @@
       "integrity": "sha512-J2y7RAH2NwQ+ahJahj2eS1PqS2NWNWTDaEibqrE55VTJU7nPL8AhthRwIQfQkCH+8UIeL/T3Jh1iHIRkvJ6dXA==",
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+        }
       }
     },
     "@babel/plugin-syntax-flow": {
@@ -1284,6 +1158,13 @@
       "integrity": "sha512-+3ZLKNV8tSDnTWL4QRNx5uZB/hUzY71WcgCwoXWy+8ma7EjZ3e3vbR69VR8dJwG1DqGsug6ZzM+afR0G4gKgPA==",
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+        }
       }
     },
     "@babel/plugin-syntax-jsx": {
@@ -1292,6 +1173,13 @@
       "integrity": "sha512-5scuJzIYZY8M+A1ra8mcKANIwB5TtsRD6Aw94xZxfvnjhhVMFR5RYE9HshVlBrZVY+r3cJDNIQLJMC/fGJHImA==",
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+        }
       }
     },
     "@babel/plugin-syntax-nullish-coalescing-operator": {
@@ -1300,6 +1188,13 @@
       "integrity": "sha512-o0v9WRQwatyMSGoPIdYoK8VTDrjdHU3MQgHLcbveetueKHZGYN3MhZvkCFa86l5WKUGDF81FOk/mta/7QuDI9g==",
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+        }
       }
     },
     "@babel/plugin-syntax-object-rest-spread": {
@@ -1308,6 +1203,13 @@
       "integrity": "sha512-UOGQCmzvNlZMQOuys7xPiTa2EjTT3xHuhUghcdJnYikqGV43obpIIaP+VDCWPvIT8g0QDIvmRWx5UefvkWXN+w==",
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+        }
       }
     },
     "@babel/plugin-syntax-optional-chaining": {
@@ -1316,6 +1218,13 @@
       "integrity": "sha512-lt6JV/D7QeAEf3qqUT4JTPkbU6vNCfeMW7BB7JD+HYivITkmXuGIVl7w4JrRB9LkfjkYE5vgiz3Nc733AD7v8w==",
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+        }
       }
     },
     "@babel/plugin-transform-arrow-functions": {
@@ -1324,6 +1233,13 @@
       "integrity": "sha512-xiU+7RJAsqx+iZqWSQQWBu9ZDTruWimkg4puDSdRVfEwgZQdOtiU2LuO0+xGFyitJPHkKuje0WvK1tFu1dmxCw==",
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+        }
       }
     },
     "@babel/plugin-transform-async-to-generator": {
@@ -1334,6 +1250,13 @@
         "@babel/helper-module-imports": "7.0.0-beta.47",
         "@babel/helper-plugin-utils": "7.0.0-beta.47",
         "@babel/helper-remap-async-to-generator": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+        }
       }
     },
     "@babel/plugin-transform-block-scoping": {
@@ -1343,13 +1266,6 @@
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0-rc.2",
         "lodash": "4.17.11"
-      },
-      "dependencies": {
-        "@babel/helper-plugin-utils": {
-          "version": "7.0.0-rc.2",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-rc.2.tgz",
-          "integrity": "sha512-kavwJYTgdd5W12MpfMJMznrfsx3sCl0HMSJ0vsPcbwT9jhF0EmYL1eyfeYbo4pToYmQgPKp+VGtSHQ3wL8N5lQ=="
-        }
       }
     },
     "@babel/plugin-transform-classes": {
@@ -1393,6 +1309,11 @@
             "@babel/types": "7.0.0-beta.47"
           }
         },
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+        },
         "@babel/helper-split-export-declaration": {
           "version": "7.0.0-beta.47",
           "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.47.tgz",
@@ -1432,11 +1353,6 @@
             "to-fast-properties": "2.0.0"
           }
         },
-        "babylon": {
-          "version": "7.0.0-beta.47",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.47.tgz",
-          "integrity": "sha512-+rq2cr4GDhtToEzKFD6KZZMDBXhjFAr9JjPw9pAppZACeEWqNM294j+NdBzkSHYXwzzBmVjZ3nEVJlOhbR2gOQ=="
-        },
         "js-tokens": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
@@ -1450,6 +1366,13 @@
       "integrity": "sha512-V78qyzmjj4aq/tjpkMFbV5gPtrx7xdclW1Rn6vV9hIwMSMbtstYEXF4msy614MofvYj6gYbPbNfyhXFIUvz/xw==",
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+        }
       }
     },
     "@babel/plugin-transform-destructuring": {
@@ -1458,6 +1381,13 @@
       "integrity": "sha512-3AaXC9H7qPybJbSs/QMhhj9EZF9MYrb/HRytwki1tckaYifqCJquENIZxDAYmwsWIGIHiq34WqwPRMIsz/b5uQ==",
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+        }
       }
     },
     "@babel/plugin-transform-exponentiation-operator": {
@@ -1467,6 +1397,13 @@
       "requires": {
         "@babel/helper-builder-binary-assignment-operator-visitor": "7.0.0-beta.47",
         "@babel/helper-plugin-utils": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+        }
       }
     },
     "@babel/plugin-transform-flow-strip-types": {
@@ -1476,6 +1413,13 @@
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0-beta.47",
         "@babel/plugin-syntax-flow": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+        }
       }
     },
     "@babel/plugin-transform-for-of": {
@@ -1484,6 +1428,13 @@
       "integrity": "sha512-tfH5OMzV9fWLYJTzWDhoRJKr8kvBZWH26jiCgM0ayNq75ES/X947MqMNAgBjJdTAVEV2kOyks2ItgNAJT4rOUw==",
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+        }
       }
     },
     "@babel/plugin-transform-function-name": {
@@ -1521,6 +1472,11 @@
             "@babel/types": "7.0.0-beta.47"
           }
         },
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+        },
         "@babel/highlight": {
           "version": "7.0.0-beta.47",
           "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.47.tgz",
@@ -1552,11 +1508,6 @@
             "to-fast-properties": "2.0.0"
           }
         },
-        "babylon": {
-          "version": "7.0.0-beta.47",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.47.tgz",
-          "integrity": "sha512-+rq2cr4GDhtToEzKFD6KZZMDBXhjFAr9JjPw9pAppZACeEWqNM294j+NdBzkSHYXwzzBmVjZ3nEVJlOhbR2gOQ=="
-        },
         "js-tokens": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
@@ -1570,6 +1521,13 @@
       "integrity": "sha512-PxBw+52qWypwR76YfS2FlW4wZfp61SjIyt3OSPZeWnf0zVQWNVrlRRunJ7lBYudDYvyMwStAE/VynZ0fHtPgng==",
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+        }
       }
     },
     "@babel/plugin-transform-modules-commonjs": {
@@ -1580,6 +1538,13 @@
         "@babel/helper-module-transforms": "7.0.0-beta.47",
         "@babel/helper-plugin-utils": "7.0.0-beta.47",
         "@babel/helper-simple-access": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+        }
       }
     },
     "@babel/plugin-transform-object-assign": {
@@ -1588,6 +1553,13 @@
       "integrity": "sha512-5Cc/5TsUjxiAuEQ4WUu+ccP0RI2/qcZWEZA7U87RH26rnhc0NDBZfUbEf1RGM5gBFLFVNzUAoFX8kRykHvl/nQ==",
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+        }
       }
     },
     "@babel/plugin-transform-parameters": {
@@ -1608,6 +1580,11 @@
             "@babel/types": "7.0.0-beta.47"
           }
         },
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+        },
         "@babel/types": {
           "version": "7.0.0-beta.47",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.47.tgz",
@@ -1626,6 +1603,13 @@
       "integrity": "sha512-Rw1KWihSkGHbqHiQuiFu/beMakDtobW3eLSABw1w3BvRIc/UhBXxwyIxa/q/R9hWFBholAjmx9cKey8FnZPykw==",
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+        }
       }
     },
     "@babel/plugin-transform-react-jsx": {
@@ -1633,8 +1617,35 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.0.0-beta.47.tgz",
       "integrity": "sha512-HGian2BbCsyAqs6LntVVRpjXG9TkzhHfTynjUoMxOFL29doKEy/0s96SMvmbBSR/wMRKMd1OPvCiEYYxqZtr3g==",
       "requires": {
+        "@babel/helper-builder-react-jsx": "7.0.0-beta.47",
         "@babel/helper-plugin-utils": "7.0.0-beta.47",
         "@babel/plugin-syntax-jsx": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/helper-builder-react-jsx": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.0.0-beta.47.tgz",
+          "integrity": "sha512-oBGX/MyT4kNGuINK2k/KLHD77Ih1oTROtoxnV3uAPS9rLYhmZn3W8qy2L4bbyMwQ89nVSM427b0bTTXUEEReXA==",
+          "requires": {
+            "@babel/types": "7.0.0-beta.47",
+            "esutils": "2.0.2"
+          }
+        },
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+        },
+        "@babel/types": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.47.tgz",
+          "integrity": "sha512-MOP5pOosg7JETrVGg8OQyzmUmbyoSopT5j2HlblHsto89mPz3cmxzn1IA4UNUmnWKgeticSwfhS+Gdy25IIlBQ==",
+          "requires": {
+            "esutils": "2.0.2",
+            "lodash": "4.17.11",
+            "to-fast-properties": "2.0.0"
+          }
+        }
       }
     },
     "@babel/plugin-transform-react-jsx-source": {
@@ -1644,6 +1655,13 @@
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0-beta.47",
         "@babel/plugin-syntax-jsx": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+        }
       }
     },
     "@babel/plugin-transform-regenerator": {
@@ -1652,16 +1670,6 @@
       "integrity": "sha512-JEPIiJyqYRfjOYUTZguLkb2HTwudReqLyOljpOXnJ/1ymwsiof4D6ul611DGlMxJMZJGQ6TBi59iY9GoJ6j4Iw==",
       "requires": {
         "regenerator-transform": "0.12.4"
-      },
-      "dependencies": {
-        "regenerator-transform": {
-          "version": "0.12.4",
-          "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.12.4.tgz",
-          "integrity": "sha512-p2I0fY+TbSLD2/VFTFb/ypEHxs3e3AjU0DzttdPqk2bSmDhfSh5E54b86Yc6XhUa5KykK1tgbvZ4Nr82oCJWkQ==",
-          "requires": {
-            "private": "0.1.8"
-          }
-        }
       }
     },
     "@babel/plugin-transform-shorthand-properties": {
@@ -1670,6 +1678,13 @@
       "integrity": "sha512-+o7/yb0Nrk4Gg/tnBgfBf+G1uGZbtkSluUnj8RyD37ajpDlWmysDjFEHSfktKcuD8YHeGz2M9AYNGcClk1fr/g==",
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+        }
       }
     },
     "@babel/plugin-transform-spread": {
@@ -1678,6 +1693,13 @@
       "integrity": "sha512-LFAozFdfT4bE2AQw2BnjzLufTX4GBsTUHUGRhT8XNoDYuGnV+7k9Yj6JU3/7csJc9u6W91PArYgoO+D56CMw6Q==",
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+        }
       }
     },
     "@babel/plugin-transform-sticky-regex": {
@@ -1687,6 +1709,13 @@
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0-beta.47",
         "@babel/helper-regex": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+        }
       }
     },
     "@babel/plugin-transform-template-literals": {
@@ -1696,6 +1725,13 @@
       "requires": {
         "@babel/helper-annotate-as-pure": "7.0.0-beta.47",
         "@babel/helper-plugin-utils": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+        }
       }
     },
     "@babel/plugin-transform-unicode-regex": {
@@ -1706,6 +1742,13 @@
         "@babel/helper-plugin-utils": "7.0.0-beta.47",
         "@babel/helper-regex": "7.0.0-beta.47",
         "regexpu-core": "4.2.0"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+        }
       }
     },
     "@babel/register": {
@@ -1720,49 +1763,16 @@
         "mkdirp": "0.5.1",
         "pirates": "4.0.0",
         "source-map-support": "0.4.18"
-      },
-      "dependencies": {
-        "home-or-tmp": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-3.0.0.tgz",
-          "integrity": "sha1-V6j+JM8zzdUkhgoVgh3cJchmcfs="
-        },
-        "pirates": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.0.tgz",
-          "integrity": "sha512-8t5BsXy1LUIjn3WWOlOuFDuKswhQb/tkak641lvBgmPOBUQHXveORtlMCp6OdPV1dtuTaEahKA8VNz6uLfKBtA==",
-          "requires": {
-            "node-modules-regexp": "1.0.0"
-          }
-        }
       }
     },
     "@babel/template": {
-      "version": "7.0.0-beta.47",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.47.tgz",
-      "integrity": "sha512-mAzrOCLwOb4jAobHi0kTwIkoamP1Do28c6zxvrDXjYSJFZHz6KGuzMaT0AV7ZCq7M3si7QypVVMVX2bE6IsuOg==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-rc.2.tgz",
+      "integrity": "sha512-CryGZ01Nko2/g8gkYiiPc7x9ZinrX59/BTWMZV1sDj5cAeia64vhyNnXTcNeim885IdGOdYyia1PNBWKnFxuSw==",
       "requires": {
-        "@babel/code-frame": "7.0.0-beta.47",
-        "@babel/types": "7.0.0-beta.47",
-        "babylon": "7.0.0-beta.47",
-        "lodash": "4.17.11"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.0.0-beta.47",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.47.tgz",
-          "integrity": "sha512-MOP5pOosg7JETrVGg8OQyzmUmbyoSopT5j2HlblHsto89mPz3cmxzn1IA4UNUmnWKgeticSwfhS+Gdy25IIlBQ==",
-          "requires": {
-            "esutils": "2.0.2",
-            "lodash": "4.17.11",
-            "to-fast-properties": "2.0.0"
-          }
-        },
-        "babylon": {
-          "version": "7.0.0-beta.47",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.47.tgz",
-          "integrity": "sha512-+rq2cr4GDhtToEzKFD6KZZMDBXhjFAr9JjPw9pAppZACeEWqNM294j+NdBzkSHYXwzzBmVjZ3nEVJlOhbR2gOQ=="
-        }
+        "@babel/code-frame": "7.0.0-rc.2",
+        "@babel/parser": "7.0.0-rc.2",
+        "@babel/types": "7.0.0-rc.2"
       }
     },
     "@babel/traverse": {
@@ -1779,26 +1789,6 @@
         "debug": "3.2.5",
         "globals": "11.7.0",
         "lodash": "4.17.11"
-      },
-      "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.0.0-rc.2",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-rc.2.tgz",
-          "integrity": "sha512-+cVix+HBNakVp7IU1WReJV8dnJl/yaBA5JRXc758BSrvJCH2hKp1Z0xHIiUaOvxMwKXc3EXGIYhlnx5T+6ofGA==",
-          "requires": {
-            "@babel/highlight": "7.0.0-rc.2"
-          }
-        },
-        "@babel/highlight": {
-          "version": "7.0.0-rc.2",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-rc.2.tgz",
-          "integrity": "sha512-96V6XHAh9XHzjmucShCP8tULwXsC446doZ6REaLVdZDPNj3NsWbsC7OBeY+u6UWiFxHTTv6YmA4Veh4wXuucYw==",
-          "requires": {
-            "chalk": "2.4.1",
-            "esutils": "2.0.2",
-            "js-tokens": "4.0.0"
-          }
-        }
       }
     },
     "@babel/types": {
@@ -1865,7 +1855,7 @@
     },
     "acorn-jsx": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "requires": {
         "acorn": "3.3.0"
@@ -2471,6 +2461,45 @@
         "ast-types-flow": "0.0.7"
       }
     },
+    "babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "requires": {
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "js-tokens": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+        }
+      }
+    },
     "babel-core": {
       "version": "6.26.3",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
@@ -2497,79 +2526,10 @@
         "source-map": "0.5.7"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-        },
-        "babel-code-frame": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-          "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-          "requires": {
-            "chalk": "1.1.3",
-            "esutils": "2.0.2",
-            "js-tokens": "3.0.2"
-          }
-        },
-        "babel-register": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
-          "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
-          "requires": {
-            "babel-core": "6.26.3",
-            "babel-runtime": "6.26.0",
-            "core-js": "2.5.7",
-            "home-or-tmp": "2.0.0",
-            "lodash": "4.17.11",
-            "mkdirp": "0.5.1",
-            "source-map-support": "0.4.18"
-          }
-        },
-        "babel-template": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
-          "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
-          "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "lodash": "4.17.11"
-          }
-        },
-        "babel-traverse": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-          "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-          "requires": {
-            "babel-code-frame": "6.26.0",
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "debug": "2.6.9",
-            "globals": "9.18.0",
-            "invariant": "2.2.4",
-            "lodash": "4.17.11"
-          }
-        },
         "babylon": {
           "version": "6.18.0",
           "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
           "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
         },
         "debug": {
           "version": "2.6.9",
@@ -2579,25 +2539,10 @@
             "ms": "2.0.0"
           }
         },
-        "globals": {
-          "version": "9.18.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
-        },
-        "js-tokens": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
-        },
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
         }
       }
     },
@@ -2623,6 +2568,16 @@
         }
       }
     },
+    "babel-helper-builder-react-jsx": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.26.0.tgz",
+      "integrity": "sha1-Of+DE7dci2Xc7/HzHTg+D/KkCKA=",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "esutils": "2.0.2"
+      }
+    },
     "babel-helper-call-delegate": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
@@ -2632,84 +2587,6 @@
         "babel-runtime": "6.26.0",
         "babel-traverse": "6.26.0",
         "babel-types": "6.26.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-        },
-        "babel-code-frame": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-          "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-          "requires": {
-            "chalk": "1.1.3",
-            "esutils": "2.0.2",
-            "js-tokens": "3.0.2"
-          }
-        },
-        "babel-traverse": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-          "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-          "requires": {
-            "babel-code-frame": "6.26.0",
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "debug": "2.6.9",
-            "globals": "9.18.0",
-            "invariant": "2.2.4",
-            "lodash": "4.17.11"
-          }
-        },
-        "babylon": {
-          "version": "6.18.0",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "globals": {
-          "version": "9.18.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
-        },
-        "js-tokens": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-        }
       }
     },
     "babel-helper-define-map": {
@@ -2721,117 +2598,27 @@
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0",
         "lodash": "4.17.11"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-        },
-        "babel-code-frame": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-          "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-          "requires": {
-            "chalk": "1.1.3",
-            "esutils": "2.0.2",
-            "js-tokens": "3.0.2"
-          }
-        },
-        "babel-helper-function-name": {
-          "version": "6.24.1",
-          "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
-          "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
-          "requires": {
-            "babel-helper-get-function-arity": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0"
-          }
-        },
-        "babel-helper-get-function-arity": {
-          "version": "6.24.1",
-          "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
-          "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
-          "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0"
-          }
-        },
-        "babel-template": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
-          "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
-          "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "lodash": "4.17.11"
-          }
-        },
-        "babel-traverse": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-          "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-          "requires": {
-            "babel-code-frame": "6.26.0",
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "debug": "2.6.9",
-            "globals": "9.18.0",
-            "invariant": "2.2.4",
-            "lodash": "4.17.11"
-          }
-        },
-        "babylon": {
-          "version": "6.18.0",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "globals": {
-          "version": "9.18.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
-        },
-        "js-tokens": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-        }
+      }
+    },
+    "babel-helper-function-name": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+      "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
+      "requires": {
+        "babel-helper-get-function-arity": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-helper-get-function-arity": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+      "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-hoist-variables": {
@@ -2873,96 +2660,6 @@
         "babel-template": "6.26.0",
         "babel-traverse": "6.26.0",
         "babel-types": "6.26.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-        },
-        "babel-code-frame": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-          "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-          "requires": {
-            "chalk": "1.1.3",
-            "esutils": "2.0.2",
-            "js-tokens": "3.0.2"
-          }
-        },
-        "babel-template": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
-          "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
-          "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "lodash": "4.17.11"
-          }
-        },
-        "babel-traverse": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-          "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-          "requires": {
-            "babel-code-frame": "6.26.0",
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "debug": "2.6.9",
-            "globals": "9.18.0",
-            "invariant": "2.2.4",
-            "lodash": "4.17.11"
-          }
-        },
-        "babylon": {
-          "version": "6.18.0",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "globals": {
-          "version": "9.18.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
-        },
-        "js-tokens": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-        }
       }
     },
     "babel-helpers": {
@@ -2972,96 +2669,6 @@
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-template": "6.26.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-        },
-        "babel-code-frame": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-          "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-          "requires": {
-            "chalk": "1.1.3",
-            "esutils": "2.0.2",
-            "js-tokens": "3.0.2"
-          }
-        },
-        "babel-template": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
-          "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
-          "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "lodash": "4.17.11"
-          }
-        },
-        "babel-traverse": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-          "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-          "requires": {
-            "babel-code-frame": "6.26.0",
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "debug": "2.6.9",
-            "globals": "9.18.0",
-            "invariant": "2.2.4",
-            "lodash": "4.17.11"
-          }
-        },
-        "babylon": {
-          "version": "6.18.0",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "globals": {
-          "version": "9.18.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
-        },
-        "js-tokens": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-        }
       }
     },
     "babel-messages": {
@@ -3122,117 +2729,6 @@
         "babel-plugin-syntax-class-properties": "6.13.0",
         "babel-runtime": "6.26.0",
         "babel-template": "6.26.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-        },
-        "babel-code-frame": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-          "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-          "requires": {
-            "chalk": "1.1.3",
-            "esutils": "2.0.2",
-            "js-tokens": "3.0.2"
-          }
-        },
-        "babel-helper-function-name": {
-          "version": "6.24.1",
-          "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
-          "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
-          "requires": {
-            "babel-helper-get-function-arity": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0"
-          }
-        },
-        "babel-helper-get-function-arity": {
-          "version": "6.24.1",
-          "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
-          "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
-          "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0"
-          }
-        },
-        "babel-template": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
-          "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
-          "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "lodash": "4.17.11"
-          }
-        },
-        "babel-traverse": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-          "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-          "requires": {
-            "babel-code-frame": "6.26.0",
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "debug": "2.6.9",
-            "globals": "9.18.0",
-            "invariant": "2.2.4",
-            "lodash": "4.17.11"
-          }
-        },
-        "babylon": {
-          "version": "6.18.0",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "globals": {
-          "version": "9.18.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
-        },
-        "js-tokens": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-        }
       }
     },
     "babel-plugin-transform-es2015-arrow-functions": {
@@ -3251,6 +2747,18 @@
         "babel-runtime": "6.26.0"
       }
     },
+    "babel-plugin-transform-es2015-block-scoping": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
+      "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "lodash": "4.17.11"
+      }
+    },
     "babel-plugin-transform-es2015-classes": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
@@ -3265,117 +2773,6 @@
         "babel-template": "6.26.0",
         "babel-traverse": "6.26.0",
         "babel-types": "6.26.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-        },
-        "babel-code-frame": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-          "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-          "requires": {
-            "chalk": "1.1.3",
-            "esutils": "2.0.2",
-            "js-tokens": "3.0.2"
-          }
-        },
-        "babel-helper-function-name": {
-          "version": "6.24.1",
-          "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
-          "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
-          "requires": {
-            "babel-helper-get-function-arity": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0"
-          }
-        },
-        "babel-helper-get-function-arity": {
-          "version": "6.24.1",
-          "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
-          "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
-          "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0"
-          }
-        },
-        "babel-template": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
-          "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
-          "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "lodash": "4.17.11"
-          }
-        },
-        "babel-traverse": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-          "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-          "requires": {
-            "babel-code-frame": "6.26.0",
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "debug": "2.6.9",
-            "globals": "9.18.0",
-            "invariant": "2.2.4",
-            "lodash": "4.17.11"
-          }
-        },
-        "babylon": {
-          "version": "6.18.0",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "globals": {
-          "version": "9.18.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
-        },
-        "js-tokens": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-        }
       }
     },
     "babel-plugin-transform-es2015-computed-properties": {
@@ -3385,96 +2782,6 @@
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-template": "6.26.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-        },
-        "babel-code-frame": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-          "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-          "requires": {
-            "chalk": "1.1.3",
-            "esutils": "2.0.2",
-            "js-tokens": "3.0.2"
-          }
-        },
-        "babel-template": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
-          "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
-          "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "lodash": "4.17.11"
-          }
-        },
-        "babel-traverse": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-          "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-          "requires": {
-            "babel-code-frame": "6.26.0",
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "debug": "2.6.9",
-            "globals": "9.18.0",
-            "invariant": "2.2.4",
-            "lodash": "4.17.11"
-          }
-        },
-        "babylon": {
-          "version": "6.18.0",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "globals": {
-          "version": "9.18.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
-        },
-        "js-tokens": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-        }
       }
     },
     "babel-plugin-transform-es2015-destructuring": {
@@ -3501,117 +2808,6 @@
         "babel-helper-function-name": "6.24.1",
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-        },
-        "babel-code-frame": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-          "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-          "requires": {
-            "chalk": "1.1.3",
-            "esutils": "2.0.2",
-            "js-tokens": "3.0.2"
-          }
-        },
-        "babel-helper-function-name": {
-          "version": "6.24.1",
-          "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
-          "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
-          "requires": {
-            "babel-helper-get-function-arity": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0"
-          }
-        },
-        "babel-helper-get-function-arity": {
-          "version": "6.24.1",
-          "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
-          "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
-          "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0"
-          }
-        },
-        "babel-template": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
-          "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
-          "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "lodash": "4.17.11"
-          }
-        },
-        "babel-traverse": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-          "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-          "requires": {
-            "babel-code-frame": "6.26.0",
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "debug": "2.6.9",
-            "globals": "9.18.0",
-            "invariant": "2.2.4",
-            "lodash": "4.17.11"
-          }
-        },
-        "babylon": {
-          "version": "6.18.0",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "globals": {
-          "version": "9.18.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
-        },
-        "js-tokens": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-        }
       }
     },
     "babel-plugin-transform-es2015-literals": {
@@ -3631,96 +2827,6 @@
         "babel-runtime": "6.26.0",
         "babel-template": "6.26.0",
         "babel-types": "6.26.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-        },
-        "babel-code-frame": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-          "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-          "requires": {
-            "chalk": "1.1.3",
-            "esutils": "2.0.2",
-            "js-tokens": "3.0.2"
-          }
-        },
-        "babel-template": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
-          "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
-          "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "lodash": "4.17.11"
-          }
-        },
-        "babel-traverse": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-          "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-          "requires": {
-            "babel-code-frame": "6.26.0",
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "debug": "2.6.9",
-            "globals": "9.18.0",
-            "invariant": "2.2.4",
-            "lodash": "4.17.11"
-          }
-        },
-        "babylon": {
-          "version": "6.18.0",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "globals": {
-          "version": "9.18.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
-        },
-        "js-tokens": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-        }
       }
     },
     "babel-plugin-transform-es2015-object-super": {
@@ -3743,105 +2849,6 @@
         "babel-template": "6.26.0",
         "babel-traverse": "6.26.0",
         "babel-types": "6.26.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-        },
-        "babel-code-frame": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-          "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-          "requires": {
-            "chalk": "1.1.3",
-            "esutils": "2.0.2",
-            "js-tokens": "3.0.2"
-          }
-        },
-        "babel-helper-get-function-arity": {
-          "version": "6.24.1",
-          "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
-          "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
-          "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0"
-          }
-        },
-        "babel-template": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
-          "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
-          "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "lodash": "4.17.11"
-          }
-        },
-        "babel-traverse": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-          "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-          "requires": {
-            "babel-code-frame": "6.26.0",
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "debug": "2.6.9",
-            "globals": "9.18.0",
-            "invariant": "2.2.4",
-            "lodash": "4.17.11"
-          }
-        },
-        "babylon": {
-          "version": "6.18.0",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "globals": {
-          "version": "9.18.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
-        },
-        "js-tokens": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-        }
       }
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
@@ -3969,18 +2976,6 @@
         "babel-helper-builder-react-jsx": "6.26.0",
         "babel-plugin-syntax-jsx": "6.18.0",
         "babel-runtime": "6.26.0"
-      },
-      "dependencies": {
-        "babel-helper-builder-react-jsx": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.26.0.tgz",
-          "integrity": "sha1-Of+DE7dci2Xc7/HzHTg+D/KkCKA=",
-          "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "esutils": "2.0.2"
-          }
-        }
       }
     },
     "babel-plugin-transform-strict-mode": {
@@ -4041,108 +3036,6 @@
         "babel-plugin-transform-object-rest-spread": "6.26.0",
         "babel-plugin-transform-react-display-name": "6.25.0",
         "babel-plugin-transform-react-jsx": "6.24.1"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-        },
-        "babel-code-frame": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-          "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-          "requires": {
-            "chalk": "1.1.3",
-            "esutils": "2.0.2",
-            "js-tokens": "3.0.2"
-          }
-        },
-        "babel-plugin-transform-es2015-block-scoping": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
-          "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
-          "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "lodash": "4.17.11"
-          }
-        },
-        "babel-template": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
-          "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
-          "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "lodash": "4.17.11"
-          }
-        },
-        "babel-traverse": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-          "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-          "requires": {
-            "babel-code-frame": "6.26.0",
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "debug": "2.6.9",
-            "globals": "9.18.0",
-            "invariant": "2.2.4",
-            "lodash": "4.17.11"
-          }
-        },
-        "babylon": {
-          "version": "6.18.0",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "globals": {
-          "version": "9.18.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
-        },
-        "js-tokens": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-        }
       }
     },
     "babel-preset-react-native": {
@@ -4179,6 +3072,29 @@
         "metro-babel7-plugin-react-transform": "0.39.1"
       },
       "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.47.tgz",
+          "integrity": "sha512-W7IeG4MoVf4oUvWfHUx9VG9if3E0xSUDf1urrnNYtC2ow1dz2ptvQ6YsJfyVXDuPTFXz66jkHhzMW7a5Eld7TA==",
+          "requires": {
+            "@babel/highlight": "7.0.0-beta.47"
+          }
+        },
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+        },
+        "@babel/highlight": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.47.tgz",
+          "integrity": "sha512-d505K3Hth1eg0b2swfEF7oFMw3J9M8ceFg0s6dhCSxOOF+07WDvJ0HKT/YbK/Jk9wn8Wyr6HIRAUPKJ9Wfv8Rg==",
+          "requires": {
+            "chalk": "2.4.1",
+            "esutils": "2.0.2",
+            "js-tokens": "3.0.2"
+          }
+        },
         "@babel/plugin-transform-block-scoping": {
           "version": "7.0.0-beta.47",
           "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.0.0-beta.47.tgz",
@@ -4188,13 +3104,55 @@
             "lodash": "4.17.11"
           }
         },
-        "metro-babel7-plugin-react-transform": {
-          "version": "0.39.1",
-          "resolved": "https://registry.npmjs.org/metro-babel7-plugin-react-transform/-/metro-babel7-plugin-react-transform-0.39.1.tgz",
-          "integrity": "sha512-7atigK+8EZ1DAWhpcw2a60OhCPihe9TsRHGOKUUwJjXmXDxmYxoxejh1kK5vJSaW38P45PkUBwnfNwISWFv4mQ==",
+        "@babel/template": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.47.tgz",
+          "integrity": "sha512-mAzrOCLwOb4jAobHi0kTwIkoamP1Do28c6zxvrDXjYSJFZHz6KGuzMaT0AV7ZCq7M3si7QypVVMVX2bE6IsuOg==",
           "requires": {
-            "@babel/helper-module-imports": "7.0.0-beta.47",
+            "@babel/code-frame": "7.0.0-beta.47",
+            "@babel/types": "7.0.0-beta.47",
+            "babylon": "7.0.0-beta.47",
             "lodash": "4.17.11"
+          }
+        },
+        "@babel/types": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.47.tgz",
+          "integrity": "sha512-MOP5pOosg7JETrVGg8OQyzmUmbyoSopT5j2HlblHsto89mPz3cmxzn1IA4UNUmnWKgeticSwfhS+Gdy25IIlBQ==",
+          "requires": {
+            "esutils": "2.0.2",
+            "lodash": "4.17.11",
+            "to-fast-properties": "2.0.0"
+          }
+        },
+        "js-tokens": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+        }
+      }
+    },
+    "babel-register": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
+      "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
+      "requires": {
+        "babel-core": "6.26.3",
+        "babel-runtime": "6.26.0",
+        "core-js": "2.5.7",
+        "home-or-tmp": "2.0.0",
+        "lodash": "4.17.11",
+        "mkdirp": "0.5.1",
+        "source-map-support": "0.4.18"
+      },
+      "dependencies": {
+        "home-or-tmp": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+          "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
           }
         }
       }
@@ -4206,6 +3164,66 @@
       "requires": {
         "core-js": "2.5.7",
         "regenerator-runtime": "0.11.1"
+      }
+    },
+    "babel-template": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+      "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "lodash": "4.17.11"
+      },
+      "dependencies": {
+        "babylon": {
+          "version": "6.18.0",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+        }
+      }
+    },
+    "babel-traverse": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+      "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+      "requires": {
+        "babel-code-frame": "6.26.0",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "debug": "2.6.9",
+        "globals": "9.18.0",
+        "invariant": "2.2.4",
+        "lodash": "4.17.11"
+      },
+      "dependencies": {
+        "babylon": {
+          "version": "6.18.0",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "globals": {
+          "version": "9.18.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
       }
     },
     "babel-types": {
@@ -4225,6 +3243,11 @@
           "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
         }
       }
+    },
+    "babylon": {
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.47.tgz",
+      "integrity": "sha512-+rq2cr4GDhtToEzKFD6KZZMDBXhjFAr9JjPw9pAppZACeEWqNM294j+NdBzkSHYXwzzBmVjZ3nEVJlOhbR2gOQ=="
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -4681,6 +3704,13 @@
         "lodash.camelcase": "4.3.0",
         "minimist": "1.2.0",
         "semver": "5.5.1"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        }
       }
     },
     "cheerio": {
@@ -5267,7 +4297,7 @@
         "is-tar": "1.0.0",
         "object-assign": "2.1.1",
         "strip-dirs": "1.1.1",
-        "tar-stream": "1.6.1",
+        "tar-stream": "1.6.2",
         "through2": "0.6.5",
         "vinyl": "0.4.6"
       },
@@ -5327,7 +4357,7 @@
         "object-assign": "2.1.1",
         "seek-bzip": "1.0.5",
         "strip-dirs": "1.1.1",
-        "tar-stream": "1.6.1",
+        "tar-stream": "1.6.2",
         "through2": "0.6.5",
         "vinyl": "0.4.6"
       },
@@ -5386,7 +4416,7 @@
         "is-gzip": "1.0.0",
         "object-assign": "2.1.1",
         "strip-dirs": "1.1.1",
-        "tar-stream": "1.6.1",
+        "tar-stream": "1.6.2",
         "through2": "0.6.5",
         "vinyl": "0.4.6"
       },
@@ -5455,7 +4485,7 @@
           "requires": {
             "file-type": "5.2.0",
             "is-stream": "1.1.0",
-            "tar-stream": "1.6.1"
+            "tar-stream": "1.6.2"
           },
           "dependencies": {
             "file-type": {
@@ -5896,7 +4926,7 @@
       "requires": {
         "is-callable": "1.1.4",
         "is-date-object": "1.0.1",
-        "is-symbol": "1.0.1"
+        "is-symbol": "1.0.2"
       }
     },
     "escape-html": {
@@ -6964,6 +5994,11 @@
             "once": "1.4.0",
             "path-is-absolute": "1.0.1"
           }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
         }
       }
     },
@@ -7122,6 +6157,11 @@
           "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
           "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI="
         },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        },
         "object-assign": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
@@ -7237,6 +6277,11 @@
         "sparkles": "1.0.1"
       }
     },
+    "has-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
+    },
     "has-unicode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
@@ -7341,13 +6386,9 @@
       "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
     },
     "home-or-tmp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
-      "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
-      "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
-      }
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-3.0.0.tgz",
+      "integrity": "sha1-V6j+JM8zzdUkhgoVgh3cJchmcfs="
     },
     "homedir-polyfill": {
       "version": "1.0.1",
@@ -7384,6 +6425,11 @@
             "get-stdin": "4.0.1",
             "minimist": "1.2.0"
           }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
     },
@@ -7846,9 +6892,12 @@
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
     "is-symbol": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
-      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+      "requires": {
+        "has-symbols": "1.0.0"
+      }
     },
     "is-tar": {
       "version": "1.0.0",
@@ -8280,6 +7329,13 @@
         "parse-json": "2.2.0",
         "pify": "2.3.0",
         "strip-bom": "3.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+        }
       }
     },
     "locate-path": {
@@ -9227,13 +8283,6 @@
       "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
       "requires": {
         "pify": "3.0.0"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
-        }
       }
     },
     "makeerror": {
@@ -9356,6 +8405,11 @@
             "strip-bom": "2.0.0"
           }
         },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        },
         "path-exists": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
@@ -9373,6 +8427,11 @@
             "pify": "2.3.0",
             "pinkie-promise": "2.0.1"
           }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
         },
         "read-pkg": {
           "version": "1.1.0",
@@ -9431,6 +8490,7 @@
         "@babel/plugin-syntax-nullish-coalescing-operator": "7.0.0-beta.47",
         "@babel/plugin-transform-arrow-functions": "7.0.0-beta.47",
         "@babel/plugin-transform-async-to-generator": "7.0.0-beta.47",
+        "@babel/plugin-transform-block-scoping": "7.0.0-beta.47",
         "@babel/plugin-transform-classes": "7.0.0-beta.47",
         "@babel/plugin-transform-computed-properties": "7.0.0-beta.47",
         "@babel/plugin-transform-destructuring": "7.0.0-beta.47",
@@ -9450,6 +8510,7 @@
         "@babel/plugin-transform-spread": "7.0.0-beta.47",
         "@babel/plugin-transform-template-literals": "7.0.0-beta.47",
         "@babel/plugin-transform-unicode-regex": "7.0.0-beta.47",
+        "@babel/register": "7.0.0-beta.47",
         "@babel/template": "7.0.0-beta.47",
         "@babel/traverse": "7.0.0-beta.47",
         "@babel/types": "7.0.0-beta.47",
@@ -9580,6 +8641,11 @@
             "@babel/types": "7.0.0-beta.47"
           }
         },
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+        },
         "@babel/helper-split-export-declaration": {
           "version": "7.0.0-beta.47",
           "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.47.tgz",
@@ -9618,6 +8684,29 @@
                 "supports-color": "5.5.0"
               }
             }
+          }
+        },
+        "@babel/plugin-transform-block-scoping": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.0.0-beta.47.tgz",
+          "integrity": "sha512-V/u3Zdy40KjVQeyYUaQnCGiHQbRNJoc6IEtNDERltuW9vYPHS1n6YGc+EHKi8JVYT4kE6UHOjD+BrbCCV4kjRw==",
+          "requires": {
+            "@babel/helper-plugin-utils": "7.0.0-beta.47",
+            "lodash": "4.17.11"
+          }
+        },
+        "@babel/register": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.0.0-beta.47.tgz",
+          "integrity": "sha512-r5aS1bAqW0tHvwUNPRRdmIedSWGK/oyv598EENpV/+VZF8EkX9TiVqCpJyg6zucPPyMjtdXN1pK/Yljp5NdGGA==",
+          "requires": {
+            "core-js": "2.5.7",
+            "find-cache-dir": "1.0.0",
+            "home-or-tmp": "3.0.0",
+            "lodash": "4.17.11",
+            "mkdirp": "0.5.1",
+            "pirates": "3.0.2",
+            "source-map-support": "0.4.18"
           }
         },
         "@babel/template": {
@@ -9676,69 +8765,6 @@
             "lodash": "4.17.11"
           }
         },
-        "babel-preset-react-native": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/babel-preset-react-native/-/babel-preset-react-native-5.0.2.tgz",
-          "integrity": "sha512-Ua5JeQ1yGK8UoydMPzE2Ghq5raOKxXzpyApYDuHi4etIbXi5+GnCin19Nu+1obLQCf2Dxy9Y/GZwI0rnNOjggA==",
-          "requires": {
-            "@babel/plugin-proposal-class-properties": "7.0.0-beta.47",
-            "@babel/plugin-proposal-object-rest-spread": "7.0.0-beta.47",
-            "@babel/plugin-proposal-optional-chaining": "7.0.0-beta.47",
-            "@babel/plugin-transform-arrow-functions": "7.0.0-beta.47",
-            "@babel/plugin-transform-classes": "7.0.0-beta.47",
-            "@babel/plugin-transform-computed-properties": "7.0.0-beta.47",
-            "@babel/plugin-transform-destructuring": "7.0.0-beta.47",
-            "@babel/plugin-transform-exponentiation-operator": "7.0.0-beta.47",
-            "@babel/plugin-transform-flow-strip-types": "7.0.0-beta.47",
-            "@babel/plugin-transform-for-of": "7.0.0-beta.47",
-            "@babel/plugin-transform-function-name": "7.0.0-beta.47",
-            "@babel/plugin-transform-literals": "7.0.0-beta.47",
-            "@babel/plugin-transform-modules-commonjs": "7.0.0-beta.47",
-            "@babel/plugin-transform-object-assign": "7.0.0-beta.47",
-            "@babel/plugin-transform-parameters": "7.0.0-beta.47",
-            "@babel/plugin-transform-react-display-name": "7.0.0-beta.47",
-            "@babel/plugin-transform-react-jsx": "7.0.0-beta.47",
-            "@babel/plugin-transform-react-jsx-source": "7.0.0-beta.47",
-            "@babel/plugin-transform-regenerator": "7.0.0-beta.47",
-            "@babel/plugin-transform-shorthand-properties": "7.0.0-beta.47",
-            "@babel/plugin-transform-spread": "7.0.0-beta.47",
-            "@babel/plugin-transform-sticky-regex": "7.0.0-beta.47",
-            "@babel/plugin-transform-template-literals": "7.0.0-beta.47",
-            "@babel/plugin-transform-unicode-regex": "7.0.0-beta.47",
-            "@babel/template": "7.0.0-beta.47",
-            "metro-babel7-plugin-react-transform": "0.39.1"
-          },
-          "dependencies": {
-            "metro-babel7-plugin-react-transform": {
-              "version": "0.39.1",
-              "resolved": "https://registry.npmjs.org/metro-babel7-plugin-react-transform/-/metro-babel7-plugin-react-transform-0.39.1.tgz",
-              "integrity": "sha512-7atigK+8EZ1DAWhpcw2a60OhCPihe9TsRHGOKUUwJjXmXDxmYxoxejh1kK5vJSaW38P45PkUBwnfNwISWFv4mQ==",
-              "requires": {
-                "@babel/helper-module-imports": "7.0.0-beta.47",
-                "lodash": "4.17.11"
-              }
-            }
-          }
-        },
-        "babel-register": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
-          "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
-          "requires": {
-            "babel-core": "6.26.3",
-            "babel-runtime": "6.26.0",
-            "core-js": "2.5.7",
-            "home-or-tmp": "2.0.0",
-            "lodash": "4.17.11",
-            "mkdirp": "0.5.1",
-            "source-map-support": "0.4.18"
-          }
-        },
-        "babylon": {
-          "version": "7.0.0-beta.47",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.47.tgz",
-          "integrity": "sha512-+rq2cr4GDhtToEzKFD6KZZMDBXhjFAr9JjPw9pAppZACeEWqNM294j+NdBzkSHYXwzzBmVjZ3nEVJlOhbR2gOQ=="
-        },
         "chalk": {
           "version": "1.1.3",
           "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
@@ -9792,6 +8818,23 @@
           "version": "0.4.0",
           "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
           "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0="
+        },
+        "metro-babel7-plugin-react-transform": {
+          "version": "0.38.4",
+          "resolved": "https://registry.npmjs.org/metro-babel7-plugin-react-transform/-/metro-babel7-plugin-react-transform-0.38.4.tgz",
+          "integrity": "sha512-1mEK3NzZ6fd6cgFtQV+T8q4+Fqzw9rMsLEReLBXvCYZJ/imamTsuIyCBnPy4WhnVcBQON3pFjd/7fV8OOuD/9w==",
+          "requires": {
+            "@babel/helper-module-imports": "7.0.0-beta.47",
+            "lodash": "4.17.11"
+          }
+        },
+        "pirates": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/pirates/-/pirates-3.0.2.tgz",
+          "integrity": "sha512-c5CgUJq6H2k6MJz72Ak1F5sN9n9wlSlJyEnwvpm9/y3WB4E3pHBDT2c6PEiS1vyJvq2bUxUAIu0EGf8Cx4Ic7Q==",
+          "requires": {
+            "node-modules-regexp": "1.0.0"
+          }
         }
       }
     },
@@ -9806,14 +8849,39 @@
         "@babel/plugin-transform-async-to-generator": "7.0.0-beta.47",
         "@babel/plugin-transform-flow-strip-types": "7.0.0-beta.47",
         "@babel/plugin-transform-modules-commonjs": "7.0.0-beta.47",
+        "@babel/register": "7.0.0-beta.47",
         "core-js": "2.5.7",
         "escape-string-regexp": "1.0.5"
+      },
+      "dependencies": {
+        "@babel/register": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.0.0-beta.47.tgz",
+          "integrity": "sha512-r5aS1bAqW0tHvwUNPRRdmIedSWGK/oyv598EENpV/+VZF8EkX9TiVqCpJyg6zucPPyMjtdXN1pK/Yljp5NdGGA==",
+          "requires": {
+            "core-js": "2.5.7",
+            "find-cache-dir": "1.0.0",
+            "home-or-tmp": "3.0.0",
+            "lodash": "4.17.11",
+            "mkdirp": "0.5.1",
+            "pirates": "3.0.2",
+            "source-map-support": "0.4.18"
+          }
+        },
+        "pirates": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/pirates/-/pirates-3.0.2.tgz",
+          "integrity": "sha512-c5CgUJq6H2k6MJz72Ak1F5sN9n9wlSlJyEnwvpm9/y3WB4E3pHBDT2c6PEiS1vyJvq2bUxUAIu0EGf8Cx4Ic7Q==",
+          "requires": {
+            "node-modules-regexp": "1.0.0"
+          }
+        }
       }
     },
     "metro-babel7-plugin-react-transform": {
-      "version": "0.38.4",
-      "resolved": "https://registry.npmjs.org/metro-babel7-plugin-react-transform/-/metro-babel7-plugin-react-transform-0.38.4.tgz",
-      "integrity": "sha512-1mEK3NzZ6fd6cgFtQV+T8q4+Fqzw9rMsLEReLBXvCYZJ/imamTsuIyCBnPy4WhnVcBQON3pFjd/7fV8OOuD/9w==",
+      "version": "0.39.1",
+      "resolved": "https://registry.npmjs.org/metro-babel7-plugin-react-transform/-/metro-babel7-plugin-react-transform-0.39.1.tgz",
+      "integrity": "sha512-7atigK+8EZ1DAWhpcw2a60OhCPihe9TsRHGOKUUwJjXmXDxmYxoxejh1kK5vJSaW38P45PkUBwnfNwISWFv4mQ==",
       "requires": {
         "@babel/helper-module-imports": "7.0.0-beta.47",
         "lodash": "4.17.11"
@@ -9949,9 +9017,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+      "version": "0.0.8",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "mixin-deep": {
       "version": "1.3.1",
@@ -9978,13 +9046,6 @@
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-        }
       }
     },
     "morgan": {
@@ -10435,15 +9496,10 @@
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "requires": {
-        "minimist": "0.0.10",
+        "minimist": "0.0.8",
         "wordwrap": "0.0.3"
       },
       "dependencies": {
-        "minimist": {
-          "version": "0.0.10",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
-        },
         "wordwrap": {
           "version": "0.0.3",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
@@ -10713,6 +9769,12 @@
             "graceful-fs": "4.1.11"
           }
         },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
         "supports-color": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
@@ -10762,6 +9824,13 @@
       "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
       "requires": {
         "pify": "2.3.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+        }
       }
     },
     "pbkdf2": {
@@ -10788,9 +9857,9 @@
       "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
     },
     "pify": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
     },
     "pinkie": {
       "version": "2.0.4",
@@ -10803,6 +9872,14 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "requires": {
         "pinkie": "2.0.4"
+      }
+    },
+    "pirates": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.0.tgz",
+      "integrity": "sha512-8t5BsXy1LUIjn3WWOlOuFDuKswhQb/tkak641lvBgmPOBUQHXveORtlMCp6OdPV1dtuTaEahKA8VNz6uLfKBtA==",
+      "requires": {
+        "node-modules-regexp": "1.0.0"
       }
     },
     "pkg-dir": {
@@ -11045,6 +10122,13 @@
         "ini": "1.3.5",
         "minimist": "1.2.0",
         "strip-json-comments": "2.0.1"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        }
       }
     },
     "re-natal": {
@@ -11145,9 +10229,9 @@
       }
     },
     "react-dom": {
-      "version": "16.4.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.4.1.tgz",
-      "integrity": "sha512-1Gin+wghF/7gl4Cqcvr1DxFX2Osz7ugxSwl6gBqCMpdrxHjIFUS7GYxrFftZ9Ln44FHw0JxCFD9YtZsrbR5/4A==",
+      "version": "16.4.2",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.4.2.tgz",
+      "integrity": "sha512-Usl73nQqzvmJN+89r97zmeUpQDKDlh58eX6Hbs/ERdDHzeBzWy+ENk7fsGQ+5KxArV1iOFPT46/VneklK9zoWw==",
       "requires": {
         "fbjs": "0.8.17",
         "loose-envify": "1.4.0",
@@ -11156,7 +10240,7 @@
       }
     },
     "react-native": {
-      "version": "git+https://github.com/status-im/react-native-desktop.git#3f9b5f656891c237b3fd371f9e571fe35a37b40f",
+      "version": "git+https://github.com/status-im/react-native-desktop.git#81d48f1e78ca3517f70ddb54889d68ec02e46f6b",
       "requires": {
         "absolute-path": "0.0.0",
         "art": "0.10.3",
@@ -11271,6 +10355,11 @@
             "setimmediate": "1.0.5",
             "ua-parser-js": "0.7.18"
           }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         },
         "ms": {
           "version": "2.0.0",
@@ -11636,7 +10725,7 @@
           "requires": {
             "file-type": "5.2.0",
             "is-stream": "1.1.0",
-            "tar-stream": "1.6.1"
+            "tar-stream": "1.6.2"
           }
         },
         "decompress-tarbz2": {
@@ -11723,6 +10812,11 @@
             "graceful-fs": "4.1.11"
           }
         },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+        },
         "strip-dirs": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
@@ -11759,6 +10853,14 @@
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
       "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+    },
+    "regenerator-transform": {
+      "version": "0.12.4",
+      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.12.4.tgz",
+      "integrity": "sha512-p2I0fY+TbSLD2/VFTFb/ypEHxs3e3AjU0DzttdPqk2bSmDhfSh5E54b86Yc6XhUa5KykK1tgbvZ4Nr82oCJWkQ==",
+      "requires": {
+        "private": "0.1.8"
+      }
     },
     "regex-cache": {
       "version": "0.4.4",
@@ -12422,6 +11524,11 @@
             "to-regex": "3.0.2"
           }
         },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        },
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -13074,6 +12181,11 @@
             "supports-color": "2.0.0"
           }
         },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        },
         "supports-color": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
@@ -13203,9 +12315,9 @@
       }
     },
     "tar-stream": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.1.tgz",
-      "integrity": "sha512-IFLM5wp3QrJODQFPm6/to3LJZrONdBY/otxcvDIQzu217zKye6yVR3hhi9lAjrC2Z+m/j5oDxMPb1qcd8cIvpA==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
+      "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
       "requires": {
         "bl": "1.2.2",
         "buffer-alloc": "1.2.0",
@@ -13883,6 +12995,11 @@
         "vinyl": "1.2.0"
       },
       "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+        },
         "strip-bom": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
@@ -13964,6 +13081,13 @@
       "requires": {
         "exec-sh": "0.2.2",
         "minimist": "1.2.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        }
       }
     },
     "web3": {

--- a/desktop_files/package.json
+++ b/desktop_files/package.json
@@ -53,7 +53,7 @@
     "querystring-es3": "0.2.1",
     "re-natal": "git+https://github.com/status-im/re-natal.git#master",
     "react": "16.4.1",
-    "react-dom": "16.4.1",
+    "react-dom": "16.4.2",
     "react-native": "git+https://github.com/status-im/react-native-desktop.git#master",
     "react-native-background-timer": "2.0.0",
     "react-native-camera": "0.10.0",

--- a/mobile_files/package-lock.json
+++ b/mobile_files/package-lock.json
@@ -24,10 +24,10 @@
         "@babel/traverse": "7.0.0-beta.47",
         "@babel/types": "7.0.0-beta.47",
         "babylon": "7.0.0-beta.47",
-        "convert-source-map": "1.5.1",
-        "debug": "3.1.0",
+        "convert-source-map": "1.6.0",
+        "debug": "3.2.5",
         "json5": "0.5.1",
-        "lodash": "4.17.10",
+        "lodash": "4.17.11",
         "micromatch": "2.3.11",
         "resolve": "1.8.1",
         "semver": "5.5.1",
@@ -41,28 +41,20 @@
           "requires": {
             "@babel/types": "7.0.0-beta.47",
             "jsesc": "2.5.1",
-            "lodash": "4.17.10",
+            "lodash": "4.17.11",
             "source-map": "0.5.7",
             "trim-right": "1.0.1"
           }
         },
-        "babylon": {
+        "@babel/types": {
           "version": "7.0.0-beta.47",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.47.tgz",
-          "integrity": "sha512-+rq2cr4GDhtToEzKFD6KZZMDBXhjFAr9JjPw9pAppZACeEWqNM294j+NdBzkSHYXwzzBmVjZ3nEVJlOhbR2gOQ=="
-        },
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.47.tgz",
+          "integrity": "sha512-MOP5pOosg7JETrVGg8OQyzmUmbyoSopT5j2HlblHsto89mPz3cmxzn1IA4UNUmnWKgeticSwfhS+Gdy25IIlBQ==",
           "requires": {
-            "ms": "2.0.0"
+            "esutils": "2.0.2",
+            "lodash": "4.17.11",
+            "to-fast-properties": "2.0.0"
           }
-        },
-        "jsesc": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
-          "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4="
         }
       }
     },
@@ -73,31 +65,9 @@
       "requires": {
         "@babel/types": "7.0.0-rc.2",
         "jsesc": "2.5.1",
-        "lodash": "4.17.10",
+        "lodash": "4.17.11",
         "source-map": "0.5.7",
         "trim-right": "1.0.1"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.0.0-rc.2",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-rc.2.tgz",
-          "integrity": "sha512-I2SMGD8bUX7sysOwGM8TcwCoaHiOx2YWZmT9h5oAncsPQ9Wy068yJneCF4vkOGTCzPFIETPDR5i3EIEm5QgMFg==",
-          "requires": {
-            "esutils": "2.0.2",
-            "lodash": "4.17.10",
-            "to-fast-properties": "2.0.0"
-          }
-        },
-        "jsesc": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
-          "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4="
-        },
-        "to-fast-properties": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
-        }
       }
     },
     "@babel/helper-annotate-as-pure": {
@@ -106,6 +76,18 @@
       "integrity": "sha512-Pjxb/PrxyKWc7jcAXlawvNAQMxxY+tSSNC5wxJstJjpO10mocmGzBOqNYjxdvVhMb3d0BEPQ8mR+D65fFpZ+TA==",
       "requires": {
         "@babel/types": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.47.tgz",
+          "integrity": "sha512-MOP5pOosg7JETrVGg8OQyzmUmbyoSopT5j2HlblHsto89mPz3cmxzn1IA4UNUmnWKgeticSwfhS+Gdy25IIlBQ==",
+          "requires": {
+            "esutils": "2.0.2",
+            "lodash": "4.17.11",
+            "to-fast-properties": "2.0.0"
+          }
+        }
       }
     },
     "@babel/helper-builder-binary-assignment-operator-visitor": {
@@ -115,6 +97,18 @@
       "requires": {
         "@babel/helper-explode-assignable-expression": "7.0.0-beta.47",
         "@babel/types": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.47.tgz",
+          "integrity": "sha512-MOP5pOosg7JETrVGg8OQyzmUmbyoSopT5j2HlblHsto89mPz3cmxzn1IA4UNUmnWKgeticSwfhS+Gdy25IIlBQ==",
+          "requires": {
+            "esutils": "2.0.2",
+            "lodash": "4.17.11",
+            "to-fast-properties": "2.0.0"
+          }
+        }
       }
     },
     "@babel/helper-builder-react-jsx": {
@@ -124,23 +118,6 @@
       "requires": {
         "@babel/types": "7.0.0-rc.2",
         "esutils": "2.0.2"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.0.0-rc.2",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-rc.2.tgz",
-          "integrity": "sha512-I2SMGD8bUX7sysOwGM8TcwCoaHiOx2YWZmT9h5oAncsPQ9Wy068yJneCF4vkOGTCzPFIETPDR5i3EIEm5QgMFg==",
-          "requires": {
-            "esutils": "2.0.2",
-            "lodash": "4.17.10",
-            "to-fast-properties": "2.0.0"
-          }
-        },
-        "to-fast-properties": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
-        }
       }
     },
     "@babel/helper-call-delegate": {
@@ -151,6 +128,18 @@
         "@babel/helper-hoist-variables": "7.0.0-beta.47",
         "@babel/traverse": "7.0.0-beta.47",
         "@babel/types": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.47.tgz",
+          "integrity": "sha512-MOP5pOosg7JETrVGg8OQyzmUmbyoSopT5j2HlblHsto89mPz3cmxzn1IA4UNUmnWKgeticSwfhS+Gdy25IIlBQ==",
+          "requires": {
+            "esutils": "2.0.2",
+            "lodash": "4.17.11",
+            "to-fast-properties": "2.0.0"
+          }
+        }
       }
     },
     "@babel/helper-define-map": {
@@ -160,7 +149,19 @@
       "requires": {
         "@babel/helper-function-name": "7.0.0-beta.47",
         "@babel/types": "7.0.0-beta.47",
-        "lodash": "4.17.10"
+        "lodash": "4.17.11"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.47.tgz",
+          "integrity": "sha512-MOP5pOosg7JETrVGg8OQyzmUmbyoSopT5j2HlblHsto89mPz3cmxzn1IA4UNUmnWKgeticSwfhS+Gdy25IIlBQ==",
+          "requires": {
+            "esutils": "2.0.2",
+            "lodash": "4.17.11",
+            "to-fast-properties": "2.0.0"
+          }
+        }
       }
     },
     "@babel/helper-explode-assignable-expression": {
@@ -170,6 +171,18 @@
       "requires": {
         "@babel/traverse": "7.0.0-beta.47",
         "@babel/types": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.47.tgz",
+          "integrity": "sha512-MOP5pOosg7JETrVGg8OQyzmUmbyoSopT5j2HlblHsto89mPz3cmxzn1IA4UNUmnWKgeticSwfhS+Gdy25IIlBQ==",
+          "requires": {
+            "esutils": "2.0.2",
+            "lodash": "4.17.11",
+            "to-fast-properties": "2.0.0"
+          }
+        }
       }
     },
     "@babel/helper-function-name": {
@@ -180,6 +193,18 @@
         "@babel/helper-get-function-arity": "7.0.0-beta.47",
         "@babel/template": "7.0.0-beta.47",
         "@babel/types": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.47.tgz",
+          "integrity": "sha512-MOP5pOosg7JETrVGg8OQyzmUmbyoSopT5j2HlblHsto89mPz3cmxzn1IA4UNUmnWKgeticSwfhS+Gdy25IIlBQ==",
+          "requires": {
+            "esutils": "2.0.2",
+            "lodash": "4.17.11",
+            "to-fast-properties": "2.0.0"
+          }
+        }
       }
     },
     "@babel/helper-get-function-arity": {
@@ -188,6 +213,18 @@
       "integrity": "sha512-63j0i3YUW8CO//uQc3ACffJdIlYcIlysuHjMF0yzQhqKoQ/CUPv0hf3nBwdRGjiWrr3JcL6++NF4XmXdwSU+fA==",
       "requires": {
         "@babel/types": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.47.tgz",
+          "integrity": "sha512-MOP5pOosg7JETrVGg8OQyzmUmbyoSopT5j2HlblHsto89mPz3cmxzn1IA4UNUmnWKgeticSwfhS+Gdy25IIlBQ==",
+          "requires": {
+            "esutils": "2.0.2",
+            "lodash": "4.17.11",
+            "to-fast-properties": "2.0.0"
+          }
+        }
       }
     },
     "@babel/helper-hoist-variables": {
@@ -196,6 +233,18 @@
       "integrity": "sha512-5BcKFhyzrsInlrfO/tGoe6khUuJzGfROD7oozF/5MWsKo/c3gVJfQ5y83lZ4XoTKJt/x4PQlLU0aHd/SJpYONA==",
       "requires": {
         "@babel/types": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.47.tgz",
+          "integrity": "sha512-MOP5pOosg7JETrVGg8OQyzmUmbyoSopT5j2HlblHsto89mPz3cmxzn1IA4UNUmnWKgeticSwfhS+Gdy25IIlBQ==",
+          "requires": {
+            "esutils": "2.0.2",
+            "lodash": "4.17.11",
+            "to-fast-properties": "2.0.0"
+          }
+        }
       }
     },
     "@babel/helper-member-expression-to-functions": {
@@ -204,6 +253,18 @@
       "integrity": "sha512-gpipslnZw2hcVGADUtqQII9KF8FPpRZsVUXwKP/0EnWwtujRFSVL+u2Fh+VXODRAxFmTLo6eGcOr/Vfan0MqYw==",
       "requires": {
         "@babel/types": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.47.tgz",
+          "integrity": "sha512-MOP5pOosg7JETrVGg8OQyzmUmbyoSopT5j2HlblHsto89mPz3cmxzn1IA4UNUmnWKgeticSwfhS+Gdy25IIlBQ==",
+          "requires": {
+            "esutils": "2.0.2",
+            "lodash": "4.17.11",
+            "to-fast-properties": "2.0.0"
+          }
+        }
       }
     },
     "@babel/helper-module-imports": {
@@ -212,7 +273,19 @@
       "integrity": "sha512-Rk43Ty+a6npu9znK22IqFlseStRGWxEHi2cjmLbbi63VGiseofdUtIJI65F9MTCuMTXAX7VbY/ghef1Jp5qpvw==",
       "requires": {
         "@babel/types": "7.0.0-beta.47",
-        "lodash": "4.17.10"
+        "lodash": "4.17.11"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.47.tgz",
+          "integrity": "sha512-MOP5pOosg7JETrVGg8OQyzmUmbyoSopT5j2HlblHsto89mPz3cmxzn1IA4UNUmnWKgeticSwfhS+Gdy25IIlBQ==",
+          "requires": {
+            "esutils": "2.0.2",
+            "lodash": "4.17.11",
+            "to-fast-properties": "2.0.0"
+          }
+        }
       }
     },
     "@babel/helper-module-transforms": {
@@ -225,7 +298,19 @@
         "@babel/helper-split-export-declaration": "7.0.0-beta.47",
         "@babel/template": "7.0.0-beta.47",
         "@babel/types": "7.0.0-beta.47",
-        "lodash": "4.17.10"
+        "lodash": "4.17.11"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.47.tgz",
+          "integrity": "sha512-MOP5pOosg7JETrVGg8OQyzmUmbyoSopT5j2HlblHsto89mPz3cmxzn1IA4UNUmnWKgeticSwfhS+Gdy25IIlBQ==",
+          "requires": {
+            "esutils": "2.0.2",
+            "lodash": "4.17.11",
+            "to-fast-properties": "2.0.0"
+          }
+        }
       }
     },
     "@babel/helper-optimise-call-expression": {
@@ -234,19 +319,31 @@
       "integrity": "sha512-NhnGhjwrhzGas4A/PoBDEtEPCGJHrzhaT6qGmo1hmkA2orG4UNi7KENC38DhJII0n2oUrKUuzTwgCvxKOTiHbw==",
       "requires": {
         "@babel/types": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.47.tgz",
+          "integrity": "sha512-MOP5pOosg7JETrVGg8OQyzmUmbyoSopT5j2HlblHsto89mPz3cmxzn1IA4UNUmnWKgeticSwfhS+Gdy25IIlBQ==",
+          "requires": {
+            "esutils": "2.0.2",
+            "lodash": "4.17.11",
+            "to-fast-properties": "2.0.0"
+          }
+        }
       }
     },
     "@babel/helper-plugin-utils": {
-      "version": "7.0.0-beta.47",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
-      "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-rc.2.tgz",
+      "integrity": "sha512-kavwJYTgdd5W12MpfMJMznrfsx3sCl0HMSJ0vsPcbwT9jhF0EmYL1eyfeYbo4pToYmQgPKp+VGtSHQ3wL8N5lQ=="
     },
     "@babel/helper-regex": {
       "version": "7.0.0-beta.47",
       "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.0.0-beta.47.tgz",
       "integrity": "sha512-dafidvVkjJP5AIWkJspV+7RGj1jeNts0qYvlmVzqAGb6BmQzEldJr6ZPzrmlpW/AW1YJGdw7br2yiwvlCRqDvQ==",
       "requires": {
-        "lodash": "4.17.10"
+        "lodash": "4.17.11"
       }
     },
     "@babel/helper-remap-async-to-generator": {
@@ -259,6 +356,18 @@
         "@babel/template": "7.0.0-beta.47",
         "@babel/traverse": "7.0.0-beta.47",
         "@babel/types": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.47.tgz",
+          "integrity": "sha512-MOP5pOosg7JETrVGg8OQyzmUmbyoSopT5j2HlblHsto89mPz3cmxzn1IA4UNUmnWKgeticSwfhS+Gdy25IIlBQ==",
+          "requires": {
+            "esutils": "2.0.2",
+            "lodash": "4.17.11",
+            "to-fast-properties": "2.0.0"
+          }
+        }
       }
     },
     "@babel/helper-replace-supers": {
@@ -270,6 +379,18 @@
         "@babel/helper-optimise-call-expression": "7.0.0-beta.47",
         "@babel/traverse": "7.0.0-beta.47",
         "@babel/types": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.47.tgz",
+          "integrity": "sha512-MOP5pOosg7JETrVGg8OQyzmUmbyoSopT5j2HlblHsto89mPz3cmxzn1IA4UNUmnWKgeticSwfhS+Gdy25IIlBQ==",
+          "requires": {
+            "esutils": "2.0.2",
+            "lodash": "4.17.11",
+            "to-fast-properties": "2.0.0"
+          }
+        }
       }
     },
     "@babel/helper-simple-access": {
@@ -279,7 +400,19 @@
       "requires": {
         "@babel/template": "7.0.0-beta.47",
         "@babel/types": "7.0.0-beta.47",
-        "lodash": "4.17.10"
+        "lodash": "4.17.11"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.47.tgz",
+          "integrity": "sha512-MOP5pOosg7JETrVGg8OQyzmUmbyoSopT5j2HlblHsto89mPz3cmxzn1IA4UNUmnWKgeticSwfhS+Gdy25IIlBQ==",
+          "requires": {
+            "esutils": "2.0.2",
+            "lodash": "4.17.11",
+            "to-fast-properties": "2.0.0"
+          }
+        }
       }
     },
     "@babel/helper-split-export-declaration": {
@@ -288,6 +421,18 @@
       "integrity": "sha512-jx8GmxryT6Qy4+24W6M6TnVL9T8bxqdyg5UKHjxBdw0Y2Sano1n0WphUS2seuOugn04W2ZQLqGc0ut8nGe/taA==",
       "requires": {
         "@babel/types": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.47.tgz",
+          "integrity": "sha512-MOP5pOosg7JETrVGg8OQyzmUmbyoSopT5j2HlblHsto89mPz3cmxzn1IA4UNUmnWKgeticSwfhS+Gdy25IIlBQ==",
+          "requires": {
+            "esutils": "2.0.2",
+            "lodash": "4.17.11",
+            "to-fast-properties": "2.0.0"
+          }
+        }
       }
     },
     "@babel/helper-wrap-function": {
@@ -299,6 +444,18 @@
         "@babel/template": "7.0.0-beta.47",
         "@babel/traverse": "7.0.0-beta.47",
         "@babel/types": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.47.tgz",
+          "integrity": "sha512-MOP5pOosg7JETrVGg8OQyzmUmbyoSopT5j2HlblHsto89mPz3cmxzn1IA4UNUmnWKgeticSwfhS+Gdy25IIlBQ==",
+          "requires": {
+            "esutils": "2.0.2",
+            "lodash": "4.17.11",
+            "to-fast-properties": "2.0.0"
+          }
+        }
       }
     },
     "@babel/helpers": {
@@ -309,6 +466,18 @@
         "@babel/template": "7.0.0-beta.47",
         "@babel/traverse": "7.0.0-beta.47",
         "@babel/types": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.47.tgz",
+          "integrity": "sha512-MOP5pOosg7JETrVGg8OQyzmUmbyoSopT5j2HlblHsto89mPz3cmxzn1IA4UNUmnWKgeticSwfhS+Gdy25IIlBQ==",
+          "requires": {
+            "esutils": "2.0.2",
+            "lodash": "4.17.11",
+            "to-fast-properties": "2.0.0"
+          }
+        }
       }
     },
     "@babel/highlight": {
@@ -319,34 +488,6 @@
         "chalk": "2.4.1",
         "esutils": "2.0.2",
         "js-tokens": "3.0.2"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "requires": {
-            "color-convert": "1.9.2"
-          }
-        },
-        "chalk": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-          "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.5.0"
-          }
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "requires": {
-            "has-flag": "3.0.0"
-          }
-        }
       }
     },
     "@babel/plugin-external-helpers": {
@@ -355,6 +496,13 @@
       "integrity": "sha512-R45V1hsr5DQIbhJajyQm5p2KS+qvmAqkEytP+DhrrEUrx0J1OfqWKZPNDiPe3xdLJtgTNZaDBq1iqfs0gnfslg==",
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+        }
       }
     },
     "@babel/plugin-proposal-class-properties": {
@@ -366,6 +514,13 @@
         "@babel/helper-plugin-utils": "7.0.0-beta.47",
         "@babel/helper-replace-supers": "7.0.0-beta.47",
         "@babel/plugin-syntax-class-properties": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+        }
       }
     },
     "@babel/plugin-proposal-object-rest-spread": {
@@ -375,6 +530,13 @@
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0-beta.47",
         "@babel/plugin-syntax-object-rest-spread": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+        }
       }
     },
     "@babel/plugin-proposal-optional-chaining": {
@@ -384,6 +546,13 @@
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0-beta.47",
         "@babel/plugin-syntax-optional-chaining": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+        }
       }
     },
     "@babel/plugin-syntax-class-properties": {
@@ -392,6 +561,13 @@
       "integrity": "sha512-vLoAuLSjHSenX3TQmri6ttQWZp3rEtGcRp4LgYEBQ012fN5h+KmcssvkCAqm6V6ozS5KzUWpBlZ6t7YhZG6oBw==",
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+        }
       }
     },
     "@babel/plugin-syntax-dynamic-import": {
@@ -400,6 +576,13 @@
       "integrity": "sha512-J2y7RAH2NwQ+ahJahj2eS1PqS2NWNWTDaEibqrE55VTJU7nPL8AhthRwIQfQkCH+8UIeL/T3Jh1iHIRkvJ6dXA==",
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+        }
       }
     },
     "@babel/plugin-syntax-flow": {
@@ -408,6 +591,13 @@
       "integrity": "sha512-+3ZLKNV8tSDnTWL4QRNx5uZB/hUzY71WcgCwoXWy+8ma7EjZ3e3vbR69VR8dJwG1DqGsug6ZzM+afR0G4gKgPA==",
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+        }
       }
     },
     "@babel/plugin-syntax-jsx": {
@@ -416,6 +606,13 @@
       "integrity": "sha512-5scuJzIYZY8M+A1ra8mcKANIwB5TtsRD6Aw94xZxfvnjhhVMFR5RYE9HshVlBrZVY+r3cJDNIQLJMC/fGJHImA==",
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+        }
       }
     },
     "@babel/plugin-syntax-nullish-coalescing-operator": {
@@ -424,6 +621,13 @@
       "integrity": "sha512-o0v9WRQwatyMSGoPIdYoK8VTDrjdHU3MQgHLcbveetueKHZGYN3MhZvkCFa86l5WKUGDF81FOk/mta/7QuDI9g==",
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+        }
       }
     },
     "@babel/plugin-syntax-object-rest-spread": {
@@ -432,6 +636,13 @@
       "integrity": "sha512-UOGQCmzvNlZMQOuys7xPiTa2EjTT3xHuhUghcdJnYikqGV43obpIIaP+VDCWPvIT8g0QDIvmRWx5UefvkWXN+w==",
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+        }
       }
     },
     "@babel/plugin-syntax-optional-chaining": {
@@ -440,6 +651,13 @@
       "integrity": "sha512-lt6JV/D7QeAEf3qqUT4JTPkbU6vNCfeMW7BB7JD+HYivITkmXuGIVl7w4JrRB9LkfjkYE5vgiz3Nc733AD7v8w==",
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+        }
       }
     },
     "@babel/plugin-transform-arrow-functions": {
@@ -448,6 +666,13 @@
       "integrity": "sha512-xiU+7RJAsqx+iZqWSQQWBu9ZDTruWimkg4puDSdRVfEwgZQdOtiU2LuO0+xGFyitJPHkKuje0WvK1tFu1dmxCw==",
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+        }
       }
     },
     "@babel/plugin-transform-async-to-generator": {
@@ -458,6 +683,13 @@
         "@babel/helper-module-imports": "7.0.0-beta.47",
         "@babel/helper-plugin-utils": "7.0.0-beta.47",
         "@babel/helper-remap-async-to-generator": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+        }
       }
     },
     "@babel/plugin-transform-block-scoping": {
@@ -466,14 +698,7 @@
       "integrity": "sha512-bJ8717eZ0Y3oY8t5qnCS0f9AQd6aDt5gJiNjqtEYs9OZkwxKfcadnRuIiC49UdfrgbNqVPbXHz/y6ueJiLtheA==",
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0-rc.2",
-        "lodash": "4.17.10"
-      },
-      "dependencies": {
-        "@babel/helper-plugin-utils": {
-          "version": "7.0.0-rc.2",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-rc.2.tgz",
-          "integrity": "sha512-kavwJYTgdd5W12MpfMJMznrfsx3sCl0HMSJ0vsPcbwT9jhF0EmYL1eyfeYbo4pToYmQgPKp+VGtSHQ3wL8N5lQ=="
-        }
+        "lodash": "4.17.11"
       }
     },
     "@babel/plugin-transform-classes": {
@@ -491,10 +716,10 @@
         "globals": "11.7.0"
       },
       "dependencies": {
-        "globals": {
-          "version": "11.7.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
-          "integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg=="
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
         }
       }
     },
@@ -504,6 +729,13 @@
       "integrity": "sha512-V78qyzmjj4aq/tjpkMFbV5gPtrx7xdclW1Rn6vV9hIwMSMbtstYEXF4msy614MofvYj6gYbPbNfyhXFIUvz/xw==",
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+        }
       }
     },
     "@babel/plugin-transform-destructuring": {
@@ -512,6 +744,13 @@
       "integrity": "sha512-3AaXC9H7qPybJbSs/QMhhj9EZF9MYrb/HRytwki1tckaYifqCJquENIZxDAYmwsWIGIHiq34WqwPRMIsz/b5uQ==",
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+        }
       }
     },
     "@babel/plugin-transform-exponentiation-operator": {
@@ -521,6 +760,13 @@
       "requires": {
         "@babel/helper-builder-binary-assignment-operator-visitor": "7.0.0-beta.47",
         "@babel/helper-plugin-utils": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+        }
       }
     },
     "@babel/plugin-transform-flow-strip-types": {
@@ -530,6 +776,13 @@
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0-beta.47",
         "@babel/plugin-syntax-flow": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+        }
       }
     },
     "@babel/plugin-transform-for-of": {
@@ -538,6 +791,13 @@
       "integrity": "sha512-tfH5OMzV9fWLYJTzWDhoRJKr8kvBZWH26jiCgM0ayNq75ES/X947MqMNAgBjJdTAVEV2kOyks2ItgNAJT4rOUw==",
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+        }
       }
     },
     "@babel/plugin-transform-function-name": {
@@ -547,6 +807,13 @@
       "requires": {
         "@babel/helper-function-name": "7.0.0-beta.47",
         "@babel/helper-plugin-utils": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+        }
       }
     },
     "@babel/plugin-transform-literals": {
@@ -555,6 +822,13 @@
       "integrity": "sha512-PxBw+52qWypwR76YfS2FlW4wZfp61SjIyt3OSPZeWnf0zVQWNVrlRRunJ7lBYudDYvyMwStAE/VynZ0fHtPgng==",
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+        }
       }
     },
     "@babel/plugin-transform-modules-commonjs": {
@@ -565,6 +839,13 @@
         "@babel/helper-module-transforms": "7.0.0-beta.47",
         "@babel/helper-plugin-utils": "7.0.0-beta.47",
         "@babel/helper-simple-access": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+        }
       }
     },
     "@babel/plugin-transform-object-assign": {
@@ -573,6 +854,13 @@
       "integrity": "sha512-5Cc/5TsUjxiAuEQ4WUu+ccP0RI2/qcZWEZA7U87RH26rnhc0NDBZfUbEf1RGM5gBFLFVNzUAoFX8kRykHvl/nQ==",
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+        }
       }
     },
     "@babel/plugin-transform-parameters": {
@@ -583,6 +871,13 @@
         "@babel/helper-call-delegate": "7.0.0-beta.47",
         "@babel/helper-get-function-arity": "7.0.0-beta.47",
         "@babel/helper-plugin-utils": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+        }
       }
     },
     "@babel/plugin-transform-react-display-name": {
@@ -591,6 +886,13 @@
       "integrity": "sha512-Rw1KWihSkGHbqHiQuiFu/beMakDtobW3eLSABw1w3BvRIc/UhBXxwyIxa/q/R9hWFBholAjmx9cKey8FnZPykw==",
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+        }
       }
     },
     "@babel/plugin-transform-react-jsx": {
@@ -611,6 +913,21 @@
             "@babel/types": "7.0.0-beta.47",
             "esutils": "2.0.2"
           }
+        },
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+        },
+        "@babel/types": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.47.tgz",
+          "integrity": "sha512-MOP5pOosg7JETrVGg8OQyzmUmbyoSopT5j2HlblHsto89mPz3cmxzn1IA4UNUmnWKgeticSwfhS+Gdy25IIlBQ==",
+          "requires": {
+            "esutils": "2.0.2",
+            "lodash": "4.17.11",
+            "to-fast-properties": "2.0.0"
+          }
         }
       }
     },
@@ -621,6 +938,13 @@
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0-beta.47",
         "@babel/plugin-syntax-jsx": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+        }
       }
     },
     "@babel/plugin-transform-regenerator": {
@@ -629,16 +953,6 @@
       "integrity": "sha512-JEPIiJyqYRfjOYUTZguLkb2HTwudReqLyOljpOXnJ/1ymwsiof4D6ul611DGlMxJMZJGQ6TBi59iY9GoJ6j4Iw==",
       "requires": {
         "regenerator-transform": "0.12.4"
-      },
-      "dependencies": {
-        "regenerator-transform": {
-          "version": "0.12.4",
-          "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.12.4.tgz",
-          "integrity": "sha512-p2I0fY+TbSLD2/VFTFb/ypEHxs3e3AjU0DzttdPqk2bSmDhfSh5E54b86Yc6XhUa5KykK1tgbvZ4Nr82oCJWkQ==",
-          "requires": {
-            "private": "0.1.8"
-          }
-        }
       }
     },
     "@babel/plugin-transform-shorthand-properties": {
@@ -647,6 +961,13 @@
       "integrity": "sha512-+o7/yb0Nrk4Gg/tnBgfBf+G1uGZbtkSluUnj8RyD37ajpDlWmysDjFEHSfktKcuD8YHeGz2M9AYNGcClk1fr/g==",
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+        }
       }
     },
     "@babel/plugin-transform-spread": {
@@ -655,6 +976,13 @@
       "integrity": "sha512-LFAozFdfT4bE2AQw2BnjzLufTX4GBsTUHUGRhT8XNoDYuGnV+7k9Yj6JU3/7csJc9u6W91PArYgoO+D56CMw6Q==",
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+        }
       }
     },
     "@babel/plugin-transform-sticky-regex": {
@@ -664,6 +992,13 @@
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0-beta.47",
         "@babel/helper-regex": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+        }
       }
     },
     "@babel/plugin-transform-template-literals": {
@@ -673,6 +1008,13 @@
       "requires": {
         "@babel/helper-annotate-as-pure": "7.0.0-beta.47",
         "@babel/helper-plugin-utils": "7.0.0-beta.47"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+        }
       }
     },
     "@babel/plugin-transform-unicode-regex": {
@@ -683,6 +1025,13 @@
         "@babel/helper-plugin-utils": "7.0.0-beta.47",
         "@babel/helper-regex": "7.0.0-beta.47",
         "regexpu-core": "4.2.0"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+        }
       }
     },
     "@babel/register": {
@@ -693,17 +1042,10 @@
         "core-js": "2.5.7",
         "find-cache-dir": "1.0.0",
         "home-or-tmp": "3.0.0",
-        "lodash": "4.17.10",
+        "lodash": "4.17.11",
         "mkdirp": "0.5.1",
         "pirates": "4.0.0",
         "source-map-support": "0.4.18"
-      },
-      "dependencies": {
-        "home-or-tmp": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-3.0.0.tgz",
-          "integrity": "sha1-V6j+JM8zzdUkhgoVgh3cJchmcfs="
-        }
       }
     },
     "@babel/template": {
@@ -714,13 +1056,18 @@
         "@babel/code-frame": "7.0.0-beta.47",
         "@babel/types": "7.0.0-beta.47",
         "babylon": "7.0.0-beta.47",
-        "lodash": "4.17.10"
+        "lodash": "4.17.11"
       },
       "dependencies": {
-        "babylon": {
+        "@babel/types": {
           "version": "7.0.0-beta.47",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.47.tgz",
-          "integrity": "sha512-+rq2cr4GDhtToEzKFD6KZZMDBXhjFAr9JjPw9pAppZACeEWqNM294j+NdBzkSHYXwzzBmVjZ3nEVJlOhbR2gOQ=="
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.47.tgz",
+          "integrity": "sha512-MOP5pOosg7JETrVGg8OQyzmUmbyoSopT5j2HlblHsto89mPz3cmxzn1IA4UNUmnWKgeticSwfhS+Gdy25IIlBQ==",
+          "requires": {
+            "esutils": "2.0.2",
+            "lodash": "4.17.11",
+            "to-fast-properties": "2.0.0"
+          }
         }
       }
     },
@@ -735,10 +1082,10 @@
         "@babel/helper-split-export-declaration": "7.0.0-beta.47",
         "@babel/types": "7.0.0-beta.47",
         "babylon": "7.0.0-beta.47",
-        "debug": "3.1.0",
+        "debug": "3.2.5",
         "globals": "11.7.0",
         "invariant": "2.2.4",
-        "lodash": "4.17.10"
+        "lodash": "4.17.11"
       },
       "dependencies": {
         "@babel/generator": {
@@ -748,51 +1095,31 @@
           "requires": {
             "@babel/types": "7.0.0-beta.47",
             "jsesc": "2.5.1",
-            "lodash": "4.17.10",
+            "lodash": "4.17.11",
             "source-map": "0.5.7",
             "trim-right": "1.0.1"
           }
         },
-        "babylon": {
+        "@babel/types": {
           "version": "7.0.0-beta.47",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.47.tgz",
-          "integrity": "sha512-+rq2cr4GDhtToEzKFD6KZZMDBXhjFAr9JjPw9pAppZACeEWqNM294j+NdBzkSHYXwzzBmVjZ3nEVJlOhbR2gOQ=="
-        },
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.47.tgz",
+          "integrity": "sha512-MOP5pOosg7JETrVGg8OQyzmUmbyoSopT5j2HlblHsto89mPz3cmxzn1IA4UNUmnWKgeticSwfhS+Gdy25IIlBQ==",
           "requires": {
-            "ms": "2.0.0"
+            "esutils": "2.0.2",
+            "lodash": "4.17.11",
+            "to-fast-properties": "2.0.0"
           }
-        },
-        "globals": {
-          "version": "11.7.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
-          "integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg=="
-        },
-        "jsesc": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
-          "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4="
         }
       }
     },
     "@babel/types": {
-      "version": "7.0.0-beta.47",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.47.tgz",
-      "integrity": "sha512-MOP5pOosg7JETrVGg8OQyzmUmbyoSopT5j2HlblHsto89mPz3cmxzn1IA4UNUmnWKgeticSwfhS+Gdy25IIlBQ==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-rc.2.tgz",
+      "integrity": "sha512-I2SMGD8bUX7sysOwGM8TcwCoaHiOx2YWZmT9h5oAncsPQ9Wy068yJneCF4vkOGTCzPFIETPDR5i3EIEm5QgMFg==",
       "requires": {
         "esutils": "2.0.2",
-        "lodash": "4.17.10",
+        "lodash": "4.17.11",
         "to-fast-properties": "2.0.0"
-      },
-      "dependencies": {
-        "to-fast-properties": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
-        }
       }
     },
     "@tradle/react-native-http": {
@@ -854,7 +1181,7 @@
     },
     "ansi-colors": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
       "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
       "requires": {
         "ansi-wrap": "0.1.0"
@@ -895,9 +1222,12 @@
       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
     },
     "ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "requires": {
+        "color-convert": "1.9.3"
+      }
     },
     "ansi-wrap": {
       "version": "0.1.0",
@@ -948,6 +1278,14 @@
                 "is-extendable": "0.1.1"
               }
             }
+          }
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
           }
         },
         "expand-brackets": {
@@ -1179,6 +1517,11 @@
             "snapdragon": "0.8.2",
             "to-regex": "3.0.2"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
@@ -1207,7 +1550,7 @@
       "integrity": "sha1-Jsu1r/ZBRLCoJb4YRuCxbPoAsR4=",
       "requires": {
         "ast-types-flow": "0.0.7",
-        "commander": "2.16.0"
+        "commander": "2.18.0"
       }
     },
     "arr-diff": {
@@ -1247,7 +1590,7 @@
       "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
       "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
       "requires": {
-        "define-properties": "1.1.2",
+        "define-properties": "1.1.3",
         "es-abstract": "1.12.0"
       }
     },
@@ -1327,7 +1670,7 @@
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
       "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
       "requires": {
-        "lodash": "4.17.10"
+        "lodash": "4.17.11"
       }
     },
     "async-limiter": {
@@ -1383,6 +1726,30 @@
         "chalk": "1.1.3",
         "esutils": "2.0.2",
         "js-tokens": "3.0.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+        }
       }
     },
     "babel-core": {
@@ -1400,15 +1767,35 @@
         "babel-traverse": "6.26.0",
         "babel-types": "6.26.0",
         "babylon": "6.18.0",
-        "convert-source-map": "1.5.1",
+        "convert-source-map": "1.6.0",
         "debug": "2.6.9",
         "json5": "0.5.1",
-        "lodash": "4.17.10",
+        "lodash": "4.17.11",
         "minimatch": "3.0.4",
         "path-is-absolute": "1.0.1",
         "private": "0.1.8",
         "slash": "1.0.0",
         "source-map": "0.5.7"
+      },
+      "dependencies": {
+        "babylon": {
+          "version": "6.18.0",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
       }
     },
     "babel-generator": {
@@ -1421,9 +1808,16 @@
         "babel-types": "6.26.0",
         "detect-indent": "4.0.0",
         "jsesc": "1.3.0",
-        "lodash": "4.17.10",
+        "lodash": "4.17.11",
         "source-map": "0.5.7",
         "trim-right": "1.0.1"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+          "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
+        }
       }
     },
     "babel-helper-builder-react-jsx": {
@@ -1455,7 +1849,7 @@
         "babel-helper-function-name": "6.24.1",
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0",
-        "lodash": "4.17.10"
+        "lodash": "4.17.11"
       }
     },
     "babel-helper-function-name": {
@@ -1504,7 +1898,7 @@
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0",
-        "lodash": "4.17.10"
+        "lodash": "4.17.11"
       }
     },
     "babel-helper-replace-supers": {
@@ -1555,22 +1949,22 @@
     },
     "babel-plugin-syntax-class-properties": {
       "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
       "integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94="
     },
     "babel-plugin-syntax-flow": {
       "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
       "integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0="
     },
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
       "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
     },
     "babel-plugin-syntax-object-rest-spread": {
       "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
       "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
     },
     "babel-plugin-syntax-trailing-function-commas": {
@@ -1614,7 +2008,7 @@
         "babel-template": "6.26.0",
         "babel-traverse": "6.26.0",
         "babel-types": "6.26.0",
-        "lodash": "4.17.10"
+        "lodash": "4.17.11"
       }
     },
     "babel-plugin-transform-es2015-classes": {
@@ -1930,22 +2324,18 @@
         "metro-babel7-plugin-react-transform": "0.39.1"
       },
       "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
+        },
         "@babel/plugin-transform-block-scoping": {
           "version": "7.0.0-beta.47",
           "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.0.0-beta.47.tgz",
           "integrity": "sha512-V/u3Zdy40KjVQeyYUaQnCGiHQbRNJoc6IEtNDERltuW9vYPHS1n6YGc+EHKi8JVYT4kE6UHOjD+BrbCCV4kjRw==",
           "requires": {
             "@babel/helper-plugin-utils": "7.0.0-beta.47",
-            "lodash": "4.17.10"
-          }
-        },
-        "metro-babel7-plugin-react-transform": {
-          "version": "0.39.1",
-          "resolved": "https://registry.npmjs.org/metro-babel7-plugin-react-transform/-/metro-babel7-plugin-react-transform-0.39.1.tgz",
-          "integrity": "sha512-7atigK+8EZ1DAWhpcw2a60OhCPihe9TsRHGOKUUwJjXmXDxmYxoxejh1kK5vJSaW38P45PkUBwnfNwISWFv4mQ==",
-          "requires": {
-            "@babel/helper-module-imports": "7.0.0-beta.47",
-            "lodash": "4.17.10"
+            "lodash": "4.17.11"
           }
         }
       }
@@ -1959,9 +2349,20 @@
         "babel-runtime": "6.26.0",
         "core-js": "2.5.7",
         "home-or-tmp": "2.0.0",
-        "lodash": "4.17.10",
+        "lodash": "4.17.11",
         "mkdirp": "0.5.1",
         "source-map-support": "0.4.18"
+      },
+      "dependencies": {
+        "home-or-tmp": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+          "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
+        }
       }
     },
     "babel-runtime": {
@@ -1971,13 +2372,6 @@
       "requires": {
         "core-js": "2.5.7",
         "regenerator-runtime": "0.11.1"
-      },
-      "dependencies": {
-        "regenerator-runtime": {
-          "version": "0.11.1",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
-        }
       }
     },
     "babel-template": {
@@ -1989,7 +2383,14 @@
         "babel-traverse": "6.26.0",
         "babel-types": "6.26.0",
         "babylon": "6.18.0",
-        "lodash": "4.17.10"
+        "lodash": "4.17.11"
+      },
+      "dependencies": {
+        "babylon": {
+          "version": "6.18.0",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+        }
       }
     },
     "babel-traverse": {
@@ -2005,7 +2406,32 @@
         "debug": "2.6.9",
         "globals": "9.18.0",
         "invariant": "2.2.4",
-        "lodash": "4.17.10"
+        "lodash": "4.17.11"
+      },
+      "dependencies": {
+        "babylon": {
+          "version": "6.18.0",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "globals": {
+          "version": "9.18.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
       }
     },
     "babel-types": {
@@ -2015,14 +2441,21 @@
       "requires": {
         "babel-runtime": "6.26.0",
         "esutils": "2.0.2",
-        "lodash": "4.17.10",
+        "lodash": "4.17.11",
         "to-fast-properties": "1.0.3"
+      },
+      "dependencies": {
+        "to-fast-properties": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+          "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+        }
       }
     },
     "babylon": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+      "version": "7.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.47.tgz",
+      "integrity": "sha512-+rq2cr4GDhtToEzKFD6KZZMDBXhjFAr9JjPw9pAppZACeEWqNM294j+NdBzkSHYXwzzBmVjZ3nEVJlOhbR2gOQ=="
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -2100,18 +2533,11 @@
       "integrity": "sha1-EQHpVE9KdrG8OybUUsqW16NeeXg="
     },
     "basic-auth": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.0.tgz",
-      "integrity": "sha1-AV2z81PgLlY3d1X5YnQuiYHnu7o=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
       "requires": {
-        "safe-buffer": "5.1.1"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
-        }
+        "safe-buffer": "5.1.2"
       }
     },
     "bcrypt-pbkdf": {
@@ -2124,9 +2550,9 @@
       }
     },
     "big-integer": {
-      "version": "1.6.34",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.34.tgz",
-      "integrity": "sha512-+w6B0Uo0ZvTSzDkXjoBCTNK0oe+aVL+yPi7kwGZm8hd8+Nj1AFPoxoq1Bl/mEu/G/ivOkUc1LRqVR0XeWFUzuA=="
+      "version": "1.6.36",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.36.tgz",
+      "integrity": "sha512-t70bfa7HYEA1D9idDbmuv7YbsbVkQ+Hp+8KFSul4aE5e/i1bjCNIRYJZlA8Q8p0r9T8cF/RVvwUgRA//FydEyg=="
     },
     "bignumber.js": {
       "version": "git+https://github.com/status-im/bignumber.js.git#cc066a0a3d6bfe0c436c9957f4ea8344bf963c89"
@@ -2146,7 +2572,7 @@
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
             "core-util-is": "1.0.2",
@@ -2175,7 +2601,7 @@
       "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.1.1.tgz",
       "integrity": "sha1-1g1dzCDLptx+HymbNdPh+V2vuuY=",
       "requires": {
-        "big-integer": "1.6.34"
+        "big-integer": "1.6.36"
       }
     },
     "brace-expansion": {
@@ -2204,7 +2630,7 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "requires": {
         "buffer-xor": "1.0.3",
@@ -2221,23 +2647,24 @@
       "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
       "requires": {
         "browserify-aes": "1.2.0",
-        "browserify-des": "1.0.1",
+        "browserify-des": "1.0.2",
         "evp_bytestokey": "1.0.3"
       }
     },
     "browserify-des": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.1.tgz",
-      "integrity": "sha512-zy0Cobe3hhgpiOM32Tj7KQ3Vl91m0njwsjzZQK1L+JDf11dzP9qIvjreVinsvXrgfjhStXwUWAEpB9D7Gwmayw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
+      "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
       "requires": {
         "cipher-base": "1.0.4",
         "des.js": "1.0.0",
-        "inherits": "2.0.3"
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.2"
       }
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "requires": {
         "bn.js": "4.11.8",
@@ -2253,7 +2680,7 @@
         "browserify-rsa": "4.0.1",
         "create-hash": "1.2.0",
         "create-hmac": "1.1.7",
-        "elliptic": "6.4.0",
+        "elliptic": "6.4.1",
         "inherits": "2.0.3",
         "parse-asn1": "5.1.1"
       }
@@ -2268,7 +2695,7 @@
     },
     "buffer": {
       "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
+      "resolved": "http://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
       "integrity": "sha1-pyyTb3e5a/UvX357RnGAYoVR3vs=",
       "requires": {
         "base64-js": "0.0.8",
@@ -2301,9 +2728,9 @@
       "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw="
     },
     "buffer-from": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz",
-      "integrity": "sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
     "buffer-xor": {
       "version": "1.0.3",
@@ -2362,15 +2789,13 @@
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "chalk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+      "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
       "requires": {
-        "ansi-styles": "2.2.1",
+        "ansi-styles": "3.2.1",
         "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
+        "supports-color": "5.5.0"
       }
     },
     "chance": {
@@ -2505,29 +2930,29 @@
       "resolved": "https://registry.npmjs.org/color/-/color-2.0.1.tgz",
       "integrity": "sha512-ubUCVVKfT7r2w2D3qtHakj8mbmKms+tThR8gI8zEYCbUBl8/voqFGt3kgBqGwXAopgXybnkuOq+qMYCRrp4cXw==",
       "requires": {
-        "color-convert": "1.9.2",
-        "color-string": "1.5.2"
+        "color-convert": "1.9.3",
+        "color-string": "1.5.3"
       }
     },
     "color-convert": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.2.tgz",
-      "integrity": "sha512-3NUJZdhMhcdPn8vJ9v2UQJoH0qqoGUkYTgFEPZaPjEtwmmKUfNV46zZmgB2M5M4DCEQHMaCfWHCxiBflLm04Tg==",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "requires": {
-        "color-name": "1.1.1"
+        "color-name": "1.1.3"
       }
     },
     "color-name": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
-      "integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok="
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "color-string": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.2.tgz",
-      "integrity": "sha1-JuRYFLw8mny9Z1FkikFDRRSnc6k=",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
+      "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
       "requires": {
-        "color-name": "1.1.1",
+        "color-name": "1.1.3",
         "simple-swizzle": "0.2.2"
       }
     },
@@ -2555,9 +2980,9 @@
       }
     },
     "commander": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.16.0.tgz",
-      "integrity": "sha512-sVXqklSaotK9at437sFlFpyOcJonxe0yST/AG9DkQKUdIE6IqGIMv4SfAQSKaJbSdVEJYItASCrBiVQHq1HQew=="
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.18.0.tgz",
+      "integrity": "sha512-6CYPa+JP2ftfRU2qkDK+UTVeQYosOg/2GbcjIcKPHfinyOLPVGXu/ovN86RP49Re5ndJK1N0kuiidFFuepc4ZQ=="
     },
     "commondir": {
       "version": "1.0.1",
@@ -2570,9 +2995,9 @@
       "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
     },
     "compressible": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.14.tgz",
-      "integrity": "sha1-MmxfUH+7BV9UEWeCuWmoG2einac=",
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.15.tgz",
+      "integrity": "sha512-4aE67DL33dSW9gw4CI2H/yTxqHLNcxp0yS6jB+4h+wr3e43+1z7vm0HU9qXOH8j+qjKuL8+UtkOxYQSMq60Ylw==",
       "requires": {
         "mime-db": "1.36.0"
       }
@@ -2584,11 +3009,26 @@
       "requires": {
         "accepts": "1.3.5",
         "bytes": "3.0.0",
-        "compressible": "2.0.14",
+        "compressible": "2.0.15",
         "debug": "2.6.9",
         "on-headers": "1.0.1",
         "safe-buffer": "5.1.2",
         "vary": "1.1.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
       }
     },
     "concat-map": {
@@ -2601,7 +3041,7 @@
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "requires": {
-        "buffer-from": "1.1.0",
+        "buffer-from": "1.1.1",
         "inherits": "2.0.3",
         "readable-stream": "2.3.6",
         "typedarray": "0.0.6"
@@ -2616,6 +3056,21 @@
         "finalhandler": "1.1.0",
         "parseurl": "1.3.2",
         "utils-merge": "1.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
       }
     },
     "console-control-strings": {
@@ -2624,9 +3079,12 @@
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
     },
     "convert-source-map": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-      "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
+      "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
     },
     "copy-descriptor": {
       "version": "0.1.1",
@@ -2649,12 +3107,12 @@
       "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
       "requires": {
         "bn.js": "4.11.8",
-        "elliptic": "6.4.0"
+        "elliptic": "6.4.1"
       }
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "requires": {
         "cipher-base": "1.0.4",
@@ -2666,7 +3124,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "requires": {
         "cipher-base": "1.0.4",
@@ -2683,14 +3141,14 @@
       "integrity": "sha1-zx7RXxKq1/FO9fLf4F5sQvke8Co=",
       "requires": {
         "fbjs": "0.8.17",
-        "loose-envify": "1.3.1",
+        "loose-envify": "1.4.0",
         "object-assign": "4.1.1"
       }
     },
     "create-react-context": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.2.3.tgz",
-      "integrity": "sha512-CQBmD0+QGgTaxDL3OX1IDXYqjkp2It4RIbcb99jS6AEg27Ga+a9G3JtK6SIu0HBwPLZlmwt9F7UwWA4Bn92Rag==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.2.2.tgz",
+      "integrity": "sha512-KkpaLARMhsTsgp0d2NA/R94F/eDLbhXERdIq3LvX2biCAXcDvHYoOqHfWCHf1+OLj+HKBotLG3KqaOOf+C1C+A==",
       "requires": {
         "fbjs": "0.8.17",
         "gud": "1.0.0"
@@ -2713,7 +3171,7 @@
     },
     "d64": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/d64/-/d64-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/d64/-/d64-1.0.0.tgz",
       "integrity": "sha1-QAKofoUMv8n52XBrYPymE6MzbpA="
     },
     "damerau-levenshtein": {
@@ -2730,11 +3188,11 @@
       }
     },
     "debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
+      "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
       "requires": {
-        "ms": "2.0.0"
+        "ms": "2.1.1"
       }
     },
     "decamelize": {
@@ -2874,11 +3332,10 @@
       }
     },
     "define-properties": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
-      "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
       "requires": {
-        "foreach": "2.0.5",
         "object-keys": "1.0.12"
       },
       "dependencies": {
@@ -2990,7 +3447,7 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "requires": {
         "bn.js": "4.11.8",
@@ -3024,9 +3481,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "elliptic": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
-      "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
+      "integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
       "requires": {
         "bn.js": "4.11.8",
         "brorand": "1.1.0",
@@ -3057,7 +3514,7 @@
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
       "requires": {
-        "iconv-lite": "0.4.23"
+        "iconv-lite": "0.4.24"
       }
     },
     "end-of-stream": {
@@ -3117,7 +3574,7 @@
       "requires": {
         "is-callable": "1.1.4",
         "is-date-object": "1.0.1",
-        "is-symbol": "1.0.1"
+        "is-symbol": "1.0.2"
       }
     },
     "escape-html": {
@@ -3239,11 +3696,11 @@
     },
     "external-editor": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
       "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
       "requires": {
         "chardet": "0.4.2",
-        "iconv-lite": "0.4.23",
+        "iconv-lite": "0.4.24",
         "tmp": "0.0.33"
       }
     },
@@ -3300,7 +3757,7 @@
       "requires": {
         "core-js": "1.2.7",
         "isomorphic-fetch": "2.2.1",
-        "loose-envify": "1.3.1",
+        "loose-envify": "1.4.0",
         "object-assign": "4.1.1",
         "promise": "7.3.1",
         "setimmediate": "1.0.5",
@@ -3381,6 +3838,21 @@
         "parseurl": "1.3.2",
         "statuses": "1.3.1",
         "unpipe": "1.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
       }
     },
     "find-cache-dir": {
@@ -3504,468 +3976,6 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
-    "fsevents": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
-      "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
-      "optional": true,
-      "requires": {
-        "nan": "2.11.0",
-        "node-pre-gyp": "0.10.0"
-      },
-      "dependencies": {
-        "abbrev": {
-          "version": "1.1.1",
-          "bundled": true,
-          "optional": true
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "bundled": true
-        },
-        "aproba": {
-          "version": "1.2.0",
-          "bundled": true,
-          "optional": true
-        },
-        "are-we-there-yet": {
-          "version": "1.1.4",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.3.6"
-          }
-        },
-        "balanced-match": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "brace-expansion": {
-          "version": "1.1.11",
-          "bundled": true,
-          "requires": {
-            "balanced-match": "1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "chownr": {
-          "version": "1.0.1",
-          "bundled": true,
-          "optional": true
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true
-        },
-        "console-control-strings": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true,
-          "optional": true
-        },
-        "debug": {
-          "version": "2.6.9",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "deep-extend": {
-          "version": "0.5.1",
-          "bundled": true,
-          "optional": true
-        },
-        "delegates": {
-          "version": "1.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "detect-libc": {
-          "version": "1.0.3",
-          "bundled": true,
-          "optional": true
-        },
-        "fs-minipass": {
-          "version": "1.2.5",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "minipass": "2.2.4"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "gauge": {
-          "version": "2.7.4",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "aproba": "1.2.0",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
-          }
-        },
-        "glob": {
-          "version": "7.1.2",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
-        "has-unicode": {
-          "version": "2.0.1",
-          "bundled": true,
-          "optional": true
-        },
-        "iconv-lite": {
-          "version": "0.4.21",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "safer-buffer": "2.1.2"
-          }
-        },
-        "ignore-walk": {
-          "version": "3.0.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "minimatch": "3.0.4"
-          }
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true
-        },
-        "ini": {
-          "version": "1.3.5",
-          "bundled": true,
-          "optional": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "bundled": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true,
-          "requires": {
-            "brace-expansion": "1.1.11"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "bundled": true
-        },
-        "minipass": {
-          "version": "2.2.4",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "5.1.1",
-            "yallist": "3.0.2"
-          }
-        },
-        "minizlib": {
-          "version": "1.1.0",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "minipass": "2.2.4"
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "needle": {
-          "version": "2.2.0",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "debug": "2.6.9",
-            "iconv-lite": "0.4.21",
-            "sax": "1.2.4"
-          }
-        },
-        "node-pre-gyp": {
-          "version": "0.10.0",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "detect-libc": "1.0.3",
-            "mkdirp": "0.5.1",
-            "needle": "2.2.0",
-            "nopt": "4.0.1",
-            "npm-packlist": "1.1.10",
-            "npmlog": "4.1.2",
-            "rc": "1.2.7",
-            "rimraf": "2.6.2",
-            "semver": "5.5.0",
-            "tar": "4.4.1"
-          }
-        },
-        "nopt": {
-          "version": "4.0.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "abbrev": "1.1.1",
-            "osenv": "0.1.5"
-          }
-        },
-        "npm-bundled": {
-          "version": "1.0.3",
-          "bundled": true,
-          "optional": true
-        },
-        "npm-packlist": {
-          "version": "1.1.10",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "ignore-walk": "3.0.1",
-            "npm-bundled": "1.0.3"
-          }
-        },
-        "npmlog": {
-          "version": "4.1.2",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "optional": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "requires": {
-            "wrappy": "1.0.2"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "optional": true
-        },
-        "os-tmpdir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "optional": true
-        },
-        "osenv": {
-          "version": "0.1.5",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true,
-          "optional": true
-        },
-        "process-nextick-args": {
-          "version": "2.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "rc": {
-          "version": "1.2.7",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "deep-extend": "0.5.1",
-            "ini": "1.3.5",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "bundled": true,
-              "optional": true
-            }
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.6",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "rimraf": {
-          "version": "2.6.2",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "glob": "7.1.2"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.1",
-          "bundled": true
-        },
-        "safer-buffer": {
-          "version": "2.1.2",
-          "bundled": true,
-          "optional": true
-        },
-        "sax": {
-          "version": "1.2.4",
-          "bundled": true,
-          "optional": true
-        },
-        "semver": {
-          "version": "5.5.0",
-          "bundled": true,
-          "optional": true
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "bundled": true,
-          "optional": true
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "bundled": true,
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "bundled": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "bundled": true,
-          "optional": true
-        },
-        "tar": {
-          "version": "4.4.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "chownr": "1.0.1",
-            "fs-minipass": "1.2.5",
-            "minipass": "2.2.4",
-            "minizlib": "1.1.0",
-            "mkdirp": "0.5.1",
-            "safe-buffer": "5.1.1",
-            "yallist": "3.0.2"
-          }
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "bundled": true,
-          "optional": true
-        },
-        "wide-align": {
-          "version": "1.1.2",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "string-width": "1.0.2"
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "yallist": {
-          "version": "3.0.2",
-          "bundled": true
-        }
-      }
-    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -3986,7 +3996,7 @@
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
             "core-util-is": "1.0.2",
@@ -4079,9 +4089,9 @@
       }
     },
     "globals": {
-      "version": "9.18.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+      "version": "11.7.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
+      "integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg=="
     },
     "graceful-fs": {
       "version": "4.1.11",
@@ -4137,6 +4147,11 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+    },
+    "has-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
     },
     "has-unicode": {
       "version": "2.0.1",
@@ -4231,13 +4246,9 @@
       "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
     },
     "home-or-tmp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
-      "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
-      "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
-      }
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-3.0.0.tgz",
+      "integrity": "sha1-V6j+JM8zzdUkhgoVgh3cJchmcfs="
     },
     "homoglyph-finder": {
       "version": "1.1.1",
@@ -4268,7 +4279,7 @@
     },
     "http-errors": {
       "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "requires": {
         "depd": "1.1.2",
@@ -4305,9 +4316,9 @@
       "integrity": "sha512-v7dG3kYJTQTyox3NqDabPDE/ZotWntyMI9kh4cYi+XlCSnsIR+KBTS2opPyObL8WndnklcLzbNU92FP/mLge3Q=="
     },
     "iconv-lite": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
-      "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "requires": {
         "safer-buffer": "2.1.2"
       }
@@ -4373,7 +4384,7 @@
         "cli-width": "2.2.0",
         "external-editor": "2.2.0",
         "figures": "2.0.0",
-        "lodash": "4.17.10",
+        "lodash": "4.17.11",
         "mute-stream": "0.0.7",
         "run-async": "2.3.0",
         "rx-lite": "4.0.8",
@@ -4388,38 +4399,12 @@
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "requires": {
-            "color-convert": "1.9.2"
-          }
-        },
-        "chalk": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-          "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.5.0"
-          }
-        },
         "strip-ansi": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "requires": {
             "ansi-regex": "3.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "requires": {
-            "has-flag": "3.0.0"
           }
         }
       }
@@ -4434,7 +4419,7 @@
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "requires": {
-        "loose-envify": "1.3.1"
+        "loose-envify": "1.4.0"
       }
     },
     "invert-kv": {
@@ -4449,7 +4434,7 @@
     },
     "is": {
       "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/is/-/is-0.2.7.tgz",
+      "resolved": "http://registry.npmjs.org/is/-/is-0.2.7.tgz",
       "integrity": "sha1-OzSixI81mXLzUEKEkZOucmS2NWI="
     },
     "is-accessor-descriptor": {
@@ -4482,7 +4467,7 @@
     },
     "is-builtin-module": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "requires": {
         "builtin-modules": "1.1.1"
@@ -4649,9 +4634,12 @@
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
     "is-symbol": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
-      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+      "requires": {
+        "has-symbols": "1.0.0"
+      }
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -4687,7 +4675,7 @@
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
       "requires": {
         "node-fetch": "1.7.3",
-        "whatwg-fetch": "2.0.4"
+        "whatwg-fetch": "3.0.0"
       }
     },
     "isstream": {
@@ -4747,9 +4735,9 @@
       "optional": true
     },
     "jsesc": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-      "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
+      "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4="
     },
     "json-schema": {
       "version": "0.2.3",
@@ -4781,7 +4769,7 @@
     },
     "jsonfile": {
       "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+      "resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "requires": {
         "graceful-fs": "4.1.11"
@@ -4856,7 +4844,7 @@
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
             "core-util-is": "1.0.2",
@@ -4892,12 +4880,12 @@
     },
     "level-fix-range": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/level-fix-range/-/level-fix-range-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/level-fix-range/-/level-fix-range-1.0.2.tgz",
       "integrity": "sha1-vxW5Fa422EcMgh6IPd95zRZCCCg="
     },
     "level-hooks": {
       "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/level-hooks/-/level-hooks-4.5.0.tgz",
+      "resolved": "http://registry.npmjs.org/level-hooks/-/level-hooks-4.5.0.tgz",
       "integrity": "sha1-G5rmGSKTDzMF0aYfxNg8gQLA3ZM=",
       "requires": {
         "string-range": "1.2.2"
@@ -4905,7 +4893,7 @@
     },
     "level-peek": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/level-peek/-/level-peek-1.0.6.tgz",
+      "resolved": "http://registry.npmjs.org/level-peek/-/level-peek-1.0.6.tgz",
       "integrity": "sha1-vsUccqgu5GTTNkNMfIdsP8vM538=",
       "requires": {
         "level-fix-range": "1.0.2"
@@ -4913,7 +4901,7 @@
     },
     "level-sublevel": {
       "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/level-sublevel/-/level-sublevel-5.2.3.tgz",
+      "resolved": "http://registry.npmjs.org/level-sublevel/-/level-sublevel-5.2.3.tgz",
       "integrity": "sha1-dEwSxy0ucr543eO5tc2E1iGRQTo=",
       "requires": {
         "level-fix-range": "2.0.0",
@@ -4924,7 +4912,7 @@
       "dependencies": {
         "level-fix-range": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/level-fix-range/-/level-fix-range-2.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/level-fix-range/-/level-fix-range-2.0.0.tgz",
           "integrity": "sha1-xBfWIVlEIVGhnZojZ4aPFyTC1Ug=",
           "requires": {
             "clone": "0.1.19"
@@ -4967,7 +4955,7 @@
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
             "core-util-is": "1.0.2",
@@ -4990,7 +4978,7 @@
     },
     "load-json-file": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
       "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
       "requires": {
         "graceful-fs": "4.1.11",
@@ -5016,9 +5004,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
     "lodash.pad": {
       "version": "4.5.1",
@@ -5041,9 +5029,9 @@
       "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
     },
     "loose-envify": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "requires": {
         "js-tokens": "3.0.2"
       }
@@ -5224,10 +5212,15 @@
           "requires": {
             "@babel/types": "7.0.0-beta.47",
             "jsesc": "2.5.1",
-            "lodash": "4.17.10",
+            "lodash": "4.17.11",
             "source-map": "0.5.7",
             "trim-right": "1.0.1"
           }
+        },
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
+          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
         },
         "@babel/plugin-transform-block-scoping": {
           "version": "7.0.0-beta.47",
@@ -5235,7 +5228,7 @@
           "integrity": "sha512-V/u3Zdy40KjVQeyYUaQnCGiHQbRNJoc6IEtNDERltuW9vYPHS1n6YGc+EHKi8JVYT4kE6UHOjD+BrbCCV4kjRw==",
           "requires": {
             "@babel/helper-plugin-utils": "7.0.0-beta.47",
-            "lodash": "4.17.10"
+            "lodash": "4.17.11"
           }
         },
         "@babel/register": {
@@ -5246,31 +5239,60 @@
             "core-js": "2.5.7",
             "find-cache-dir": "1.0.0",
             "home-or-tmp": "3.0.0",
-            "lodash": "4.17.10",
+            "lodash": "4.17.11",
             "mkdirp": "0.5.1",
             "pirates": "3.0.2",
             "source-map-support": "0.4.18"
           }
         },
-        "babylon": {
+        "@babel/types": {
           "version": "7.0.0-beta.47",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.47.tgz",
-          "integrity": "sha512-+rq2cr4GDhtToEzKFD6KZZMDBXhjFAr9JjPw9pAppZACeEWqNM294j+NdBzkSHYXwzzBmVjZ3nEVJlOhbR2gOQ=="
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.47.tgz",
+          "integrity": "sha512-MOP5pOosg7JETrVGg8OQyzmUmbyoSopT5j2HlblHsto89mPz3cmxzn1IA4UNUmnWKgeticSwfhS+Gdy25IIlBQ==",
+          "requires": {
+            "esutils": "2.0.2",
+            "lodash": "4.17.11",
+            "to-fast-properties": "2.0.0"
+          }
         },
-        "home-or-tmp": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-3.0.0.tgz",
-          "integrity": "sha1-V6j+JM8zzdUkhgoVgh3cJchmcfs="
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
         },
-        "jsesc": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
-          "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4="
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
         },
         "json5": {
           "version": "0.4.0",
           "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
           "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0="
+        },
+        "metro-babel7-plugin-react-transform": {
+          "version": "0.38.4",
+          "resolved": "https://registry.npmjs.org/metro-babel7-plugin-react-transform/-/metro-babel7-plugin-react-transform-0.38.4.tgz",
+          "integrity": "sha512-1mEK3NzZ6fd6cgFtQV+T8q4+Fqzw9rMsLEReLBXvCYZJ/imamTsuIyCBnPy4WhnVcBQON3pFjd/7fV8OOuD/9w==",
+          "requires": {
+            "@babel/helper-module-imports": "7.0.0-beta.47",
+            "lodash": "4.17.11"
+          }
         },
         "mime-db": {
           "version": "1.23.0",
@@ -5285,6 +5307,11 @@
             "mime-db": "1.23.0"
           }
         },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
         "pirates": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/pirates/-/pirates-3.0.2.tgz",
@@ -5292,6 +5319,11 @@
           "requires": {
             "node-modules-regexp": "1.0.0"
           }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
         }
       }
     },
@@ -5319,16 +5351,11 @@
             "core-js": "2.5.7",
             "find-cache-dir": "1.0.0",
             "home-or-tmp": "3.0.0",
-            "lodash": "4.17.10",
+            "lodash": "4.17.11",
             "mkdirp": "0.5.1",
             "pirates": "3.0.2",
             "source-map-support": "0.4.18"
           }
-        },
-        "home-or-tmp": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-3.0.0.tgz",
-          "integrity": "sha1-V6j+JM8zzdUkhgoVgh3cJchmcfs="
         },
         "pirates": {
           "version": "3.0.2",
@@ -5341,12 +5368,12 @@
       }
     },
     "metro-babel7-plugin-react-transform": {
-      "version": "0.38.4",
-      "resolved": "https://registry.npmjs.org/metro-babel7-plugin-react-transform/-/metro-babel7-plugin-react-transform-0.38.4.tgz",
-      "integrity": "sha512-1mEK3NzZ6fd6cgFtQV+T8q4+Fqzw9rMsLEReLBXvCYZJ/imamTsuIyCBnPy4WhnVcBQON3pFjd/7fV8OOuD/9w==",
+      "version": "0.39.1",
+      "resolved": "https://registry.npmjs.org/metro-babel7-plugin-react-transform/-/metro-babel7-plugin-react-transform-0.39.1.tgz",
+      "integrity": "sha512-7atigK+8EZ1DAWhpcw2a60OhCPihe9TsRHGOKUUwJjXmXDxmYxoxejh1kK5vJSaW38P45PkUBwnfNwISWFv4mQ==",
       "requires": {
         "@babel/helper-module-imports": "7.0.0-beta.47",
-        "lodash": "4.17.10"
+        "lodash": "4.17.11"
       }
     },
     "metro-cache": {
@@ -5498,7 +5525,7 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "minipass": {
@@ -5546,39 +5573,48 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
       }
     },
     "morgan": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.9.0.tgz",
-      "integrity": "sha1-0B+mxlhZt2/PMbPLU6OCGjEdgFE=",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.9.1.tgz",
+      "integrity": "sha512-HQStPIV4y3afTiCYVxirakhlCfGkI161c76kKFca7Fk1JusM//Qeo1ej2XaMniiNeaZklMVrh3vTtIzpzwbpmA==",
       "requires": {
-        "basic-auth": "2.0.0",
+        "basic-auth": "2.0.1",
         "debug": "2.6.9",
         "depd": "1.1.2",
         "on-finished": "2.3.0",
         "on-headers": "1.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
       }
     },
     "ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
     },
     "mute-stream": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
-    },
-    "nan": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.0.tgz",
-      "integrity": "sha512-F4miItu2rGnV2ySkXOQoA8FKz/SR2Q2sWP0sbTxNxz/tuokeC8WxOhPMcwi0qIyGtVn/rrSeLbvVkznqCdwYnw==",
-      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -5638,10 +5674,23 @@
       "integrity": "sha512-HyoqEb4wr/rsoaIDfTH2aVL9nWtQqba2/HvMv+++m8u0dz808MaagKILxtfeSN7QU7nvbQ79zk3vYOJp9zsNEA==",
       "requires": {
         "debug": "2.6.9",
-        "iconv-lite": "0.4.23",
+        "iconv-lite": "0.4.24",
         "sax": "1.2.4"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
         "sax": {
           "version": "1.2.4",
           "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
@@ -5940,7 +5989,7 @@
     },
     "opn": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/opn/-/opn-3.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/opn/-/opn-3.0.3.tgz",
       "integrity": "sha1-ttmec5n3jWXDuq/+8fsojpuFJDo=",
       "requires": {
         "object-assign": "4.1.1"
@@ -6024,7 +6073,7 @@
     },
     "parse-asn1": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
       "integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
       "requires": {
         "asn1.js": "4.10.1",
@@ -6115,7 +6164,7 @@
     },
     "pbkdf2": {
       "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.8.tgz",
+      "resolved": "http://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.8.tgz",
       "integrity": "sha1-L4q/FuvsyCJ3lF10irodeHYfYeI=",
       "requires": {
         "create-hmac": "1.1.7"
@@ -6123,7 +6172,7 @@
     },
     "pegjs": {
       "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/pegjs/-/pegjs-0.10.0.tgz",
+      "resolved": "http://registry.npmjs.org/pegjs/-/pegjs-0.10.0.tgz",
       "integrity": "sha1-z4uvrm7d/0tafvsYUmnqr0YQ3b0="
     },
     "pend": {
@@ -6211,7 +6260,7 @@
     },
     "pretty-format": {
       "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-4.3.1.tgz",
+      "resolved": "http://registry.npmjs.org/pretty-format/-/pretty-format-4.3.1.tgz",
       "integrity": "sha1-UwvlxCs8BbNkFKeipDN6qArNDo0="
     },
     "private": {
@@ -6248,7 +6297,7 @@
       "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
       "requires": {
         "fbjs": "0.8.17",
-        "loose-envify": "1.3.1",
+        "loose-envify": "1.4.0",
         "object-assign": "4.1.1"
       }
     },
@@ -6269,7 +6318,7 @@
     },
     "public-encrypt": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.2.tgz",
       "integrity": "sha512-4kJ5Esocg8X3h8YgJsKAuoesBgB7mqH3eowiDzMUPKiRDDE7E/BqqZD1hnTByIaAFiwAw246YEltSq7tdrOH0Q==",
       "requires": {
         "bn.js": "4.11.8",
@@ -6366,7 +6415,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
@@ -6377,15 +6426,15 @@
       "integrity": "sha512-3GEs0giKp6E0Oh/Y9ZC60CmYgUPnp7voH9fbjWsvXtYFb4EWtgQub0ADSq0sJR0BbHc4FThLLtzlcFaFXIorwg==",
       "requires": {
         "fbjs": "0.8.17",
-        "loose-envify": "1.3.1",
+        "loose-envify": "1.4.0",
         "object-assign": "4.1.1",
         "prop-types": "15.6.0"
       }
     },
     "react-clone-referenced-element": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/react-clone-referenced-element/-/react-clone-referenced-element-1.0.1.tgz",
-      "integrity": "sha1-K7qMaUBMXkqUQ5hgC8xMlB+GBoI="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/react-clone-referenced-element/-/react-clone-referenced-element-1.1.0.tgz",
+      "integrity": "sha512-FKOsfKbBkPxYE8576EM6uAfHC4rnMpLyH6/TJUL4WcHUEB3EUn8AxPjnnV/IiwSSzsClvHYK+sDELKN/EJ0WYg=="
     },
     "react-deep-force-update": {
       "version": "1.1.2",
@@ -6393,9 +6442,9 @@
       "integrity": "sha512-WUSQJ4P/wWcusaH+zZmbECOk7H5N2pOIl0vzheeornkIMhu+qrNdGFm0bDZLCb0hSF0jf/kH1SgkNGfBdTc4wA=="
     },
     "react-devtools-core": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-3.3.2.tgz",
-      "integrity": "sha512-e6CX94GZKF9qBgoK8tj/cCrPBL6quZeJGBSuvaDlOVYTT9tnH1KOWuCpB9V5ct1u5T/hfqBTy+cShIJ1qZdl1g==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-3.4.0.tgz",
+      "integrity": "sha512-yV3LLhoRwbfcQyVPNwb1EZ9W7CGu+kX2EqyZ3Cl5C+cbXcb6FJ3YSeeBt9BQB+hjyjRMBjQSKqnpPS6OMSEUow==",
       "requires": {
         "shell-quote": "1.6.1",
         "ws": "3.3.3"
@@ -6419,12 +6468,12 @@
       }
     },
     "react-dom": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.2.0.tgz",
-      "integrity": "sha512-zpGAdwHVn9K0091d+hr+R0qrjoJ84cIBFL2uU60KvWBPfZ7LPSrfqviTxGHWN0sjPZb2hxWzMexwrvJdKePvjg==",
+      "version": "16.4.2",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.4.2.tgz",
+      "integrity": "sha512-Usl73nQqzvmJN+89r97zmeUpQDKDlh58eX6Hbs/ERdDHzeBzWy+ENk7fsGQ+5KxArV1iOFPT46/VneklK9zoWw==",
       "requires": {
         "fbjs": "0.8.17",
-        "loose-envify": "1.3.1",
+        "loose-envify": "1.4.0",
         "object-assign": "4.1.1",
         "prop-types": "15.6.0"
       }
@@ -6441,7 +6490,7 @@
         "art": "0.10.3",
         "base64-js": "1.3.0",
         "chalk": "1.1.3",
-        "commander": "2.16.0",
+        "commander": "2.18.0",
         "compression": "1.7.3",
         "connect": "3.6.6",
         "create-react-class": "15.6.3",
@@ -6457,7 +6506,7 @@
         "glob": "7.1.3",
         "graceful-fs": "4.1.11",
         "inquirer": "3.3.0",
-        "lodash": "4.17.10",
+        "lodash": "4.17.11",
         "metro": "0.38.4",
         "metro-babel-register": "0.38.4",
         "metro-core": "0.38.4",
@@ -6465,7 +6514,7 @@
         "mime": "1.6.0",
         "minimist": "1.2.0",
         "mkdirp": "0.5.1",
-        "morgan": "1.9.0",
+        "morgan": "1.9.1",
         "node-fetch": "1.7.3",
         "node-notifier": "5.2.1",
         "npmlog": "2.0.4",
@@ -6475,8 +6524,8 @@
         "pretty-format": "4.3.1",
         "promise": "7.3.1",
         "prop-types": "15.6.0",
-        "react-clone-referenced-element": "1.0.1",
-        "react-devtools-core": "3.3.2",
+        "react-clone-referenced-element": "1.1.0",
+        "react-devtools-core": "3.4.0",
         "react-timer-mixin": "0.13.4",
         "regenerator-runtime": "0.11.1",
         "rimraf": "2.6.2",
@@ -6490,10 +6539,27 @@
         "yargs": "9.0.1"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+        },
         "base64-js": {
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
           "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
         },
         "core-js": {
           "version": "1.2.7",
@@ -6506,8 +6572,16 @@
           "integrity": "sha512-M+/3Q6E6DLO6Yx3OwrWjwHBnvfXXYA7W+dFjt/ZDBemHO1DDZhsalX/NUtnTYclN6GfnBDRh4qRHjcDHmlJBJg==",
           "requires": {
             "fbjs": "0.8.16",
-            "loose-envify": "1.3.1",
+            "loose-envify": "1.4.0",
             "object-assign": "4.1.1"
+          }
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
           }
         },
         "fbjs": {
@@ -6517,7 +6591,7 @@
           "requires": {
             "core-js": "1.2.7",
             "isomorphic-fetch": "2.2.1",
-            "loose-envify": "1.3.1",
+            "loose-envify": "1.4.0",
             "object-assign": "4.1.1",
             "promise": "7.3.1",
             "setimmediate": "1.0.5",
@@ -6528,6 +6602,16 @@
           "version": "1.2.0",
           "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
         }
       }
     },
@@ -6539,7 +6623,7 @@
     "react-native-camera": {
       "version": "git+https://github.com/status-im/react-native-camera.git#6de8c8d1ba28906ab014d717a33a7b6f73c433c5",
       "requires": {
-        "lodash": "4.17.10",
+        "lodash": "4.17.11",
         "prop-types": "15.6.0"
       }
     },
@@ -6605,7 +6689,7 @@
           "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
           "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
           "requires": {
-            "loose-envify": "1.3.1",
+            "loose-envify": "1.4.0",
             "object-assign": "4.1.1"
           }
         }
@@ -6646,7 +6730,7 @@
       "requires": {
         "create-react-class": "15.6.2",
         "prop-types": "15.6.0",
-        "react-clone-referenced-element": "1.0.1",
+        "react-clone-referenced-element": "1.1.0",
         "react-native-scrollable-mixin": "1.0.1"
       }
     },
@@ -6698,7 +6782,7 @@
         },
         "buffer": {
           "version": "4.9.1",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+          "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
           "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
           "requires": {
             "base64-js": "1.3.0",
@@ -6716,9 +6800,14 @@
         "hoist-non-react-statics": "2.5.5"
       }
     },
+    "react-native-screens": {
+      "version": "1.0.0-alpha.12",
+      "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-1.0.0-alpha.12.tgz",
+      "integrity": "sha512-n/XyqUStDjtCymXUhAxG98asvgI8/OSH+v9AaAzUFEqfBwJLY8/UjY6m8PIJSgqRt4aR/Z9nO+A1mcMXw6dMdA=="
+    },
     "react-native-scrollable-mixin": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/react-native-scrollable-mixin/-/react-native-scrollable-mixin-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/react-native-scrollable-mixin/-/react-native-scrollable-mixin-1.0.1.tgz",
       "integrity": "sha1-NKMhZ7ZCSFlBVP0NaosD8idAVI4="
     },
     "react-native-securerandom": {
@@ -6738,7 +6827,7 @@
       "integrity": "sha512-r9SXx/AOzlo/jkahAo9WjNTRJ+A2lDHE3yS3WtgZ4Gzqqyxb3L6LpuAG02x1TaKEowdTEG3r6u7vhnCZON8N/A==",
       "requires": {
         "color": "2.0.1",
-        "lodash": "4.17.10",
+        "lodash": "4.17.11",
         "pegjs": "0.10.0"
       }
     },
@@ -6804,27 +6893,38 @@
           "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
           "integrity": "sha1-yNfoRzZqScwYtiLwWKaJ1IHolfI=",
           "requires": {
-            "loose-envify": "1.3.1"
+            "loose-envify": "1.4.0"
           }
         }
       }
     },
     "react-navigation": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/react-navigation/-/react-navigation-2.12.1.tgz",
-      "integrity": "sha512-C+do+STPvvd/5LbaDhrZyf1P8tCeffttdlHyIRe1NgGg8Nj93FZHWOThi2hnmEZ75kXsS/JGxox4DDPqYVAxeQ==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/react-navigation/-/react-navigation-2.16.0.tgz",
+      "integrity": "sha512-AB+zS9bDBjD6xxRWvKnGLcMN/2gmP7+ARKb7nfwNmDjtJDswY55HaMiMUOrKYzDJi3bY45O0XHroPF9aArF3nw==",
       "requires": {
         "clamp": "1.0.1",
-        "create-react-context": "0.2.3",
+        "create-react-context": "0.2.2",
         "hoist-non-react-statics": "2.5.5",
         "path-to-regexp": "1.7.0",
         "query-string": "6.1.0",
         "react-lifecycles-compat": "3.0.4",
-        "react-native-safe-area-view": "0.9.0",
+        "react-native-safe-area-view": "0.11.0",
+        "react-native-screens": "1.0.0-alpha.12",
         "react-navigation-deprecated-tab-navigator": "1.3.0",
         "react-navigation-drawer": "0.5.0",
-        "react-navigation-stack": "0.2.3",
-        "react-navigation-tabs": "0.6.0"
+        "react-navigation-stack": "0.6.0",
+        "react-navigation-tabs": "0.8.2"
+      },
+      "dependencies": {
+        "react-native-safe-area-view": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/react-native-safe-area-view/-/react-native-safe-area-view-0.11.0.tgz",
+          "integrity": "sha512-N3nElaahu1Me2ltnfc9acpgt1znm6pi8DSadKy79kvdzKwvVIzw0IXueA/Hjr51eCW1BsfNw7D1SgBT9U6qEkA==",
+          "requires": {
+            "hoist-non-react-statics": "2.5.5"
+          }
+        }
       }
     },
     "react-navigation-deprecated-tab-navigator": {
@@ -6844,19 +6944,18 @@
       }
     },
     "react-navigation-stack": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/react-navigation-stack/-/react-navigation-stack-0.2.3.tgz",
-      "integrity": "sha512-xjVqiI/ztcQt45jxQ3vfO8Lr+9bVq+0J/lRhMdZCvCDwiyOVuB64wx7qPNJW16pnBBLiI5h6H7uhWE3rAT0r/w=="
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/react-navigation-stack/-/react-navigation-stack-0.6.0.tgz",
+      "integrity": "sha512-6+33KKqHq+OTK5CRcj3fpXfTpfU/56aFG/WB7a/9QKThfkVTuxAJ1Z5+qZNJMH5BAJvzhqBiPNYb6uH1TcoecA=="
     },
     "react-navigation-tabs": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/react-navigation-tabs/-/react-navigation-tabs-0.6.0.tgz",
-      "integrity": "sha512-Ax1rujJ51R1Jrz7b5bHUAIgsYC1VrFws+d3hxlPy5dXG84iJdV5dnDFRvdQMDDfDZc+NDx2a223lAYsc3p2+XA==",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/react-navigation-tabs/-/react-navigation-tabs-0.8.2.tgz",
+      "integrity": "sha512-q2xfY79ERj4XJek3rceveifUny3Qcg7y6bNlN6wQg6c7D/pMFOGZsSALGenF7CuNDhYyEkijlnGTHl1laZgbDw==",
       "requires": {
         "hoist-non-react-statics": "2.5.5",
         "prop-types": "15.6.2",
         "react-lifecycles-compat": "3.0.4",
-        "react-native-safe-area-view": "0.7.0",
         "react-native-tab-view": "1.0.2"
       },
       "dependencies": {
@@ -6865,16 +6964,8 @@
           "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
           "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
           "requires": {
-            "loose-envify": "1.3.1",
+            "loose-envify": "1.4.0",
             "object-assign": "4.1.1"
-          }
-        },
-        "react-native-safe-area-view": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/react-native-safe-area-view/-/react-native-safe-area-view-0.7.0.tgz",
-          "integrity": "sha512-SjLdW/Th0WVMhyngH4O6yC21S+O4U4AAG3QxBr7fZ2ftgjXSpKbDHAhEpxBdFwei6HsnsC2h9oYMtPpaW9nfGg==",
-          "requires": {
-            "hoist-non-react-statics": "2.5.5"
           }
         },
         "react-native-tab-view": {
@@ -6892,7 +6983,7 @@
       "resolved": "https://registry.npmjs.org/react-proxy/-/react-proxy-1.1.8.tgz",
       "integrity": "sha1-nb/Z2SdSjDqp9ETkVYw3gwq4wmo=",
       "requires": {
-        "lodash": "4.17.10",
+        "lodash": "4.17.11",
         "react-deep-force-update": "1.1.2"
       }
     },
@@ -6931,7 +7022,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
         "core-util-is": "1.0.2",
@@ -7016,6 +7107,14 @@
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
       "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+    },
+    "regenerator-transform": {
+      "version": "0.12.4",
+      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.12.4.tgz",
+      "integrity": "sha512-p2I0fY+TbSLD2/VFTFb/ypEHxs3e3AjU0DzttdPqk2bSmDhfSh5E54b86Yc6XhUa5KykK1tgbvZ4Nr82oCJWkQ==",
+      "requires": {
+        "private": "0.1.8"
+      }
     },
     "regex-cache": {
       "version": "0.4.4",
@@ -7278,7 +7377,6 @@
         "capture-exit": "1.2.0",
         "exec-sh": "0.2.2",
         "fb-watchman": "2.0.0",
-        "fsevents": "1.2.4",
         "micromatch": "3.1.10",
         "minimist": "1.2.0",
         "walker": "1.0.7",
@@ -7320,6 +7418,14 @@
                 "is-extendable": "0.1.1"
               }
             }
+          }
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
           }
         },
         "expand-brackets": {
@@ -7554,14 +7660,19 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
     "sax": {
       "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.6.tgz",
+      "resolved": "http://registry.npmjs.org/sax/-/sax-1.1.6.tgz",
       "integrity": "sha1-XWFr6KXmB9VOEUr65Vt+ry/MMkA="
     },
     "seek-bzip": {
@@ -7574,7 +7685,7 @@
       "dependencies": {
         "commander": {
           "version": "2.8.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+          "resolved": "http://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
           "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
           "requires": {
             "graceful-readlink": "1.0.1"
@@ -7607,10 +7718,23 @@
         "statuses": "1.4.0"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "mime": {
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
           "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
         "statuses": {
           "version": "1.4.0",
@@ -7673,7 +7797,7 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "requires": {
         "inherits": "2.0.3",
@@ -7791,6 +7915,14 @@
         "use": "3.1.1"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "define-property": {
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
@@ -7806,6 +7938,11 @@
           "requires": {
             "is-extendable": "0.1.1"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
@@ -7919,7 +8056,7 @@
       "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
       "requires": {
         "spdx-expression-parse": "3.0.0",
-        "spdx-license-ids": "3.0.0"
+        "spdx-license-ids": "3.0.1"
       }
     },
     "spdx-exceptions": {
@@ -7933,13 +8070,13 @@
       "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "requires": {
         "spdx-exceptions": "2.1.0",
-        "spdx-license-ids": "3.0.0"
+        "spdx-license-ids": "3.0.1"
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
-      "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.1.tgz",
+      "integrity": "sha512-TfOfPcYGBB5sDuPn3deByxPhmfegAhpDYKSOXZQN81Oyrrif8ZCodOLzK3AesELnCx03kikhyDwh0pfvvQvF8w=="
     },
     "split-string": {
       "version": "3.1.0",
@@ -8030,7 +8167,7 @@
     },
     "string-range": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/string-range/-/string-range-1.2.2.tgz",
+      "resolved": "http://registry.npmjs.org/string-range/-/string-range-1.2.2.tgz",
       "integrity": "sha1-qJPtNH5yKZvIO++78qaSqNI51d0="
     },
     "string-width": {
@@ -8094,9 +8231,12 @@
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
     },
     "supports-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "requires": {
+        "has-flag": "3.0.0"
+      }
     },
     "symbol-observable": {
       "version": "1.2.0",
@@ -8170,7 +8310,7 @@
       "dependencies": {
         "rimraf": {
           "version": "2.2.8",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+          "resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
           "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI="
         }
       }
@@ -8226,7 +8366,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
@@ -8267,9 +8407,9 @@
       "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg=="
     },
     "to-fast-properties": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
     },
     "to-object-path": {
       "version": "0.3.0",
@@ -8649,7 +8789,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
@@ -8670,9 +8810,9 @@
       }
     },
     "whatwg-fetch": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
-      "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
+      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
     },
     "which": {
       "version": "1.3.1",
@@ -8702,7 +8842,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
         "string-width": "1.0.2",

--- a/mobile_files/package.json
+++ b/mobile_files/package.json
@@ -32,7 +32,7 @@
     "punycode": "1.4.1",
     "querystring-es3": "0.2.1",
     "react": "16.4.1",
-    "react-dom": "16.2.0",
+    "react-dom": "16.4.2",
     "react-native": "github:status-im/react-native#status-0.56-1",
     "react-native-background-timer": "2.1.0-alpha.6",
     "react-native-camera": "https://github.com/status-im/react-native-camera#1.1.5-1",


### PR DESCRIPTION
update react-dom to CVE-2018-6341
https://reactjs.org/blog/2018/08/01/react-v-16-4-2.html

status: ready <!-- Can be ready or wip -->


<blockquote><img src="/logo-og.png" width="48" align="right"><div><strong><a href="https://reactjs.org/blog/2018/08/01/react-v-16-4-2.html">React v16.4.2: Server-side vulnerability fix – React Blog</a></strong></div><div>We discovered a minor vulnerability that might affect some apps using ReactDOMServer. We are releasing a patch version for every affected React minor release so that you can upgrade with no friction. Read on for more details. Short Description Today, we are releasing a fix for a vulnerability we discovered in the   implementation. It was introduced with the version 16.0.0 and has existed in all subsequent releases until today. This vulnerability  can only affect some server-rendered React apps…</div></blockquote>