### PR TITLE
Fix/chat loading time

### DIFF
--- a/src/status_im/ui/screens/desktop/main/chat/views.cljs
+++ b/src/status_im/ui/screens/desktop/main/chat/views.cljs
@@ -157,15 +157,26 @@
            [react/view {:style (message.style/delivery-status outgoing)}
             [message/message-delivery-status message]]])}))))
 
+(def load-step 5)
+
+(defn load-more [all-messages-count messages-to-load]
+  (let [next-count (min all-messages-count (+ @messages-to-load load-step))]
+    (reset! messages-to-load next-count)))
+
 (views/defview messages-view [{:keys [chat-id group-chat]}]
   (views/letsubs [messages [:get-current-chat-messages-stream]
-                  current-public-key [:get-current-public-key]]
-    (let [chat-id* (atom nil)
-          scroll-ref (atom nil)
+                  current-public-key [:get-current-public-key]
+                  messages-to-load (reagent/atom load-step)
+                  chat-id* (reagent/atom nil)]
+    {:component-did-update #(load-more (count messages) messages-to-load)
+     :component-did-mount  #(load-more (count messages) messages-to-load)}
+    (let [scroll-ref (atom nil)
           scroll-timer (atom nil)
           scroll-height (atom nil)
           _ (when (or (not @chat-id*) (not= @chat-id* chat-id))
-              (reset! chat-id* chat-id))]
+              (do
+                (reset! messages-to-load load-step)
+                (reset! chat-id* chat-id)))]
       [react/view {:style styles/messages-view}
        [react/scroll-view {:scrollEventThrottle    16
                            :headerHeight styles/messages-list-vertical-padding
@@ -182,7 +193,7 @@
                            :ref                    #(reset! scroll-ref %)}
         [react/view
          (doall
-          (for [[index {:keys [from content message-id type value] :as message-obj}] (map-indexed vector messages)]
+          (for [[index {:keys [from content message-id type value] :as message-obj}] (map-indexed vector (take @messages-to-load messages))]
             ^{:key message-obj}
             [message (:text content) (= from current-public-key)
              (assoc message-obj :group-chat group-chat


### PR DESCRIPTION
fixes #5112

### Summary:
Loading a chat with a lot of messages takes huge time because ScrollView renders all elements at once. Optimizing `Text` loading time in `react-native-desktop` didn't make significant improvement in speed. But ScrollView has a good performance on adding new elements (it doesn't recreate old ones). So I tried "partial loading".  
Lets say we have 100 messages in a chat. At first render only 5 of them will be displayed. When rendering finished, 5 more will be requested until all messages processed. With this approach js doesn't require native side to render all elements immediately, so UI operates better.


### Steps to test:
- Open Status
- Open few chats with a lot of messages and try switching between them

status: ready
