### PR TITLE
[#5991] Dapp cant recognise Status as web3 provider with enabled Web3…

### DIFF
--- a/resources/js/web3_opt_in.js
+++ b/resources/js/web3_opt_in.js
@@ -84,6 +84,7 @@ function getSyncResponse (payload) {
 
 var ReadOnlyProvider = function () {};
 
+ReadOnlyProvider.prototype.isStatus = true;
 ReadOnlyProvider.prototype.isConnected = function () { return true; };
 
 ReadOnlyProvider.prototype.send = function (payload) {


### PR DESCRIPTION
Many Dapps use `isStatus` to recognise Status, so we should keep it in read only provider
fixes #5991
