### PR TITLE
[fix 6009] do not allow public chat named with valid contact key

### DIFF
--- a/src/status_im/ui/screens/add_new/new_public_chat/db.cljs
+++ b/src/status_im/ui/screens/add_new/new_public_chat/db.cljs
@@ -8,3 +8,8 @@
 
 (spec/def ::topic (spec/and :global/not-empty-string
                             (partial re-matches #"[a-z0-9\-]+")))
+
+(defn valid-topic? [topic]
+  (and topic
+       (spec/valid? ::topic topic)
+       (not (spec/valid? :global/public-key topic))))

--- a/src/status_im/ui/screens/add_new/new_public_chat/subs.cljs
+++ b/src/status_im/ui/screens/add_new/new_public_chat/subs.cljs
@@ -5,8 +5,9 @@
             [cljs.spec.alpha :as spec]))
 
 (re-frame/reg-sub
- :new-topic-error-message
+ :public-chat.new/topic-error-message
  :<- [:get :public-group-topic]
  (fn [topic]
-   (when-not (spec/valid? ::db/topic topic)
+   (when-not (or (empty? topic)
+                 (db/valid-topic? topic))
      (i18n/label :topic-name-error))))

--- a/src/status_im/ui/screens/add_new/new_public_chat/view.cljs
+++ b/src/status_im/ui/screens/add_new/new_public_chat/view.cljs
@@ -9,7 +9,7 @@
             [status-im.ui.components.text-input.view :as text-input.view]
             [status-im.ui.components.toolbar.view :as toolbar]
             [status-im.ui.components.tooltip.views :as tooltip]
-            [status-im.ui.screens.add-new.new-public-chat.db :as v]
+            [status-im.ui.screens.add-new.new-public-chat.db :as db]
             [status-im.ui.screens.add-new.new-public-chat.styles :as styles]
             [status-im.ui.screens.add-new.styles :as add-new.styles]
             status-im.utils.db
@@ -25,11 +25,8 @@
     [react/view common.styles/flex
      [text-input.view/text-input-with-label
       {:container           styles/input-container
-       :on-change-text      #(do
-                               (re-frame/dispatch [:set :public-group-topic-error (when-not (spec/valid? ::v/topic %)
-                                                                                    (i18n/label :t/topic-name-error))])
-                               (re-frame/dispatch [:set :public-group-topic %]))
-       :on-submit-editing   #(when (and topic (spec/valid? ::v/topic topic))
+       :on-change-text      #(re-frame/dispatch [:set :public-group-topic %])
+       :on-submit-editing   #(when (db/valid-topic? topic)
                                (re-frame/dispatch [:chat.ui/start-public-chat topic]))
        :auto-capitalize     :none
        :auto-focus          false
@@ -61,7 +58,7 @@
 
 (views/defview new-public-chat []
   (views/letsubs [topic [:get :public-group-topic]
-                  error [:get :public-group-topic-error]]
+                  error [:public-chat.new/topic-error-message]]
     [react/keyboard-avoiding-view styles/group-container
      [status-bar/status-bar]
      [toolbar/simple-toolbar

--- a/src/status_im/ui/screens/desktop/main/add_new/styles.cljs
+++ b/src/status_im/ui/screens/desktop/main/add_new/styles.cljs
@@ -87,17 +87,17 @@
    :width         5
    :height        16
    :margin-bottom -16})
+
 (def tooltip-container
   {:position    :absolute
    :align-items :center
    :align-self  :center
-   :top         -34})
+   :bottom         34})
 
 (def tooltip-icon-text
   {:justify-content  :center
    :align-items      :center
    :flex 1
-   :height           24
    :border-radius    8
    :padding-left     10
    :padding-right    10

--- a/src/status_im/ui/screens/group/navigation.cljs
+++ b/src/status_im/ui/screens/group/navigation.cljs
@@ -4,7 +4,3 @@
 (defmethod nav/preload-data! :add-participants-toggle-list
   [db _]
   (assoc db :selected-participants #{}))
-
-(defmethod nav/preload-data! :new-public-chat
-  [db]
-  (dissoc db :public-group-topic :public-group-topic-error))

--- a/translations/en.json
+++ b/translations/en.json
@@ -516,7 +516,7 @@
     "word-n-description": "In order to check if you have backed up your recovery phrase correctly, enter the word #{{number}} above.",
     "status-sent": "Sent",
     "status-prompt": "Set your status. Using #hastags will help others discover you and talk about what's on your mind",
-    "topic-name-error": "Topic names use only lowercase letters (a to z) & dashes (-)",
+    "topic-name-error": "Use only lowercase letters (a to z), numbers & dashes (-). Do not use contact codes",
     "delete-contact-confirmation": "This contact will be removed from your contacts",
     "datetime-today": "today",
     "dapp-would-like-to-connect-wallet": "would like\n to connect to your wallet",


### PR DESCRIPTION
fixes #6009 

### Review notes (optional):
Should we update other translations for the error message when creating public chat ? Or should we delete the current one to make it obvious they should be updated ? @chadyj 

![screenshot_1537964878](https://user-images.githubusercontent.com/1181225/46080005-fc7c6280-c198-11e8-8186-ccf171cc7aab.png)


status: ready <!-- Can be ready or wip -->
