### PR TITLE
remove unused replace-view function

### DIFF
--- a/src/status_im/chat/events.cljs
+++ b/src/status_im/chat/events.cljs
@@ -115,7 +115,7 @@
   (fx/merge cofx
             (models/add-public-chat topic)
             (models/navigate-to-chat topic {:modal?              modal?
-                                            :navigation-replace? true})
+                                            :navigation-reset? true})
             (public-chat/join-public-chat topic)))
 
 (handlers/register-handler-fx

--- a/src/status_im/chat/models.cljs
+++ b/src/status_im/chat/models.cljs
@@ -172,14 +172,14 @@
 
 (fx/defn navigate-to-chat
   "Takes coeffects map and chat-id, returns effects necessary for navigation and preloading data"
-  [cofx chat-id {:keys [modal? navigation-replace?]}]
+  [cofx chat-id {:keys [modal? navigation-reset?]}]
   (cond
     modal?
     (fx/merge cofx
               (navigation/navigate-to-cofx :chat-modal {})
               (preload-chat-data chat-id))
 
-    navigation-replace?
+    navigation-reset?
     (fx/merge cofx
               (navigation/navigate-reset {:index   1
                                           :actions [{:routeName :home}

--- a/src/status_im/ui/screens/add_new/new_chat/views.cljs
+++ b/src/status_im/ui/screens/add_new/new_chat/views.cljs
@@ -15,7 +15,7 @@
 
 (defn- render-row [row _ _]
   [contact-view/contact-view {:contact       row
-                              :on-press      #(re-frame/dispatch [:start-chat (:whisper-identity %) {:navigation-replace? true}])
+                              :on-press      #(re-frame/dispatch [:start-chat (:whisper-identity %) {:navigation-reset? true}])
                               :show-forward? true}])
 
 (views/defview new-chat []

--- a/src/status_im/ui/screens/contacts/events.cljs
+++ b/src/status_im/ui/screens/contacts/events.cljs
@@ -15,7 +15,7 @@
   [cofx whisper-id]
   (fx/merge cofx
             (models.contact/add-contact whisper-id)
-            (chat.models/start-chat whisper-id {:navigation-replace? true})))
+            (chat.models/start-chat whisper-id {:navigation-reset? true})))
 
 (re-frame/reg-cofx
  :get-default-contacts

--- a/src/status_im/ui/screens/navigation.cljs
+++ b/src/status_im/ui/screens/navigation.cljs
@@ -30,10 +30,6 @@
     {:db                 (push-view db view-id)
      ::navigate-to-clean view-id}))
 
-(fx/defn replace-view
-  [_ view-id]
-  {::navigate-replace view-id})
-
 (fx/defn navigate-forget
   [{:keys [db]} view-id]
   {:db (assoc db :view-id view-id)})
@@ -97,12 +93,6 @@
    (navigation/navigate-back)))
 
 (re-frame/reg-fx
- ::navigate-replace
- (fn [view-id]
-   (log/debug :navigate-replace view-id)
-   (navigation/navigate-replace view-id)))
-
-(re-frame/reg-fx
  ::navigate-reset
  (fn [config]
    (log/debug :navigate-reset config)
@@ -129,12 +119,6 @@
  navigation-interceptors
  (fn [{:keys [db]} [_ modal-view]]
    {:db (assoc db :modal modal-view)}))
-
-(handlers/register-handler-fx
- :navigation-replace
- navigation-interceptors
- (fn [cofx [_ view-id]]
-   (replace-view cofx view-id)))
 
 (fx/defn navigate-back
   [{{:keys [navigation-stack view-id] :as db} :db}]

--- a/src/status_im/ui/screens/profile/models.cljs
+++ b/src/status_im/ui/screens/profile/models.cljs
@@ -24,7 +24,7 @@
 (defn send-transaction [chat-id {:keys [db] :as cofx}]
   (let [send-command (get-in db [:id->command ["send" #{:personal-chats}]])]
     (fx/merge cofx
-              (chat-models/start-chat chat-id {:navigation-replace? true})
+              (chat-models/start-chat chat-id {:navigation-reset? true})
               (commands-input/select-chat-input-command send-command nil))))
 
 (defn- valid-name? [name]

--- a/src/status_im/utils/navigation.cljs
+++ b/src/status_im/utils/navigation.cljs
@@ -30,16 +30,6 @@
       navigation-actions
       #js {:routeName (name route)}))))
 
-;; 'Navigation/REPLACE'
-;; https://github.com/react-navigation/react-navigation/blob/master/src/routers/StackActions.js#L5
-(defn navigate-replace [route]
-  (when (can-be-called?)
-    (.dispatch
-     @navigator-ref
-     (.replace
-      stack-actions
-      #js {:routeName (name route)}))))
-
 (defn- navigate [params]
   (when (can-be-called?)
     (.navigate navigation-actions (clj->js params))))


### PR DESCRIPTION
The fn is not used anywhere probably not worth keeping it, might even be problematic for mobile/desktop differences

status: ready <!-- Can be ready or wip -->
