### PR TITLE
[DO NOT MERGE] [fix 6017] fix random-id cofx

### DIFF
--- a/src/status_im/bootnodes/core.cljs
+++ b/src/status_im/bootnodes/core.cljs
@@ -59,16 +59,16 @@
                {:success-event (when (custom-bootnodes-in-use? cofx)
                                  [:accounts.update.callback/save-settings-success])}))))
 
-(fx/defn upsert [{{:bootnodes/keys [manage] :account/keys [account] :as db} :db :as cofx}]
-  (let [{:keys [name
-                id
-                url]} manage
-        network       (:network db)
-        bootnode      (build
-                       (or (:value id) (:random-id cofx))
-                       (:value name)
-                       (:value url)
-                       network)
+(fx/defn upsert
+  [{{:bootnodes/keys [manage] :account/keys [account] :as db} :db
+    random-id-generator :random-id-generator :as cofx}]
+  (let [{:keys [name id url]} manage
+        network (:network db)
+        bootnode (build
+                  (or (:value id) (random-id-generator))
+                  (:value name)
+                  (:value url)
+                  network)
         new-bootnodes (assoc-in
                        (:bootnodes account)
                        [network (:id bootnode)]

--- a/src/status_im/chat/commands/sending.cljs
+++ b/src/status_im/chat/commands/sending.cljs
@@ -45,7 +45,7 @@
 
 (fx/defn validate-and-send
   "Validates and sends command in current chat"
-  [{:keys [db now random-id] :as cofx} input-text {:keys [type params] :as command}]
+  [{:keys [db now] :as cofx} input-text {:keys [type params] :as command}]
   (let [chat-id       (:current-chat-id db)
         parameter-map (commands-input/parse-parameters params input-text)]
     (if-let [validation-error (protocol/validate type parameter-map cofx)]

--- a/src/status_im/chat/events.cljs
+++ b/src/status_im/chat/events.cljs
@@ -130,20 +130,21 @@
 
 (handlers/register-handler-fx
  :create-new-group-chat-and-open
- [(re-frame/inject-cofx :random-id)]
- (fn [{:keys [db random-id] :as cofx} [_ group-name]]
+ [(re-frame/inject-cofx :random-id-generator)]
+ (fn [{:keys [db random-id-generator] :as cofx} [_ group-name]]
    (let [selected-contacts (:group/selected-contacts db)
          chat-name         (if-not (string/blank? group-name)
                              group-name
                              (group-name-from-contacts selected-contacts
                                                        (:contacts/contacts db)
-                                                       (:username db)))]
+                                                       (:username db)))
+         chat-id           (random-id-generator)]
      (fx/merge cofx
                {:db (assoc db :group/selected-contacts #{})}
-               (models/add-group-chat random-id chat-name (:current-public-key db) selected-contacts)
+               (models/add-group-chat chat-id chat-name (:current-public-key db) selected-contacts)
                (navigation/navigate-to-cofx :home nil)
-               (models/navigate-to-chat random-id {})
-               #(transport.message/send (group-chat/GroupAdminUpdate. chat-name selected-contacts) random-id %)))))
+               (models/navigate-to-chat chat-id {})
+               #(transport.message/send (group-chat/GroupAdminUpdate. chat-name selected-contacts) chat-id %)))))
 
 (fx/defn show-profile [{:keys [db]} identity]
   (navigation/navigate-to-cofx {:db (assoc db :contacts/identity identity)} :profile nil))

--- a/src/status_im/chat/events/input.cljs
+++ b/src/status_im/chat/events/input.cljs
@@ -83,7 +83,7 @@
 
 (defn command-complete-fx
   "command is complete, set `:sending-in-progress?` flag and proceed with command processing"
-  [input-text command {:keys [db now random-id] :as cofx}]
+  [input-text command {:keys [db] :as cofx}]
   (fx/merge cofx
             {:db (model/set-chat-ui-props db {:sending-in-progress? true})}
             (commands-sending/validate-and-send input-text command)))
@@ -109,7 +109,7 @@
 
 (handlers/register-handler-fx
  :send-current-message
- message-model/send-interceptors
+ [(re-frame/inject-cofx :random-id-generator)]
  (fn [{{:keys [current-chat-id id->command access-scope->command-id] :as db} :db :as cofx} _]
    (when-not (get-in db [:chat-ui-props current-chat-id :sending-in-progress?])
      (let [input-text   (get-in db [:chats current-chat-id :input-text])
@@ -118,7 +118,7 @@
                                                                 access-scope->command-id
                                                                 (get-in db [:chats current-chat-id])))]
        (if command
-          ;; Returns true if current input contains command
+         ;; Returns true if current input contains command
          (if (= :complete (:command-completion command))
            (command-complete-fx input-text command cofx)
            (command-not-complete-fx input-text current-chat-id cofx))

--- a/src/status_im/chat/events/receive_message.cljs
+++ b/src/status_im/chat/events/receive_message.cljs
@@ -27,6 +27,6 @@
 
 (handlers/register-handler-fx
  :chat-received-message/add
- message-model/receive-interceptors
+ [(re-frame/inject-cofx :random-id-generator)]
  (fn [cofx [_ messages]]
    (message-model/receive-many cofx (filter-messages cofx messages))))

--- a/src/status_im/chat/models/group_chat.cljs
+++ b/src/status_im/chat/models/group_chat.cljs
@@ -30,8 +30,10 @@
       (seq removed-participants)
       (str admin-name " " (i18n/label :t/removed) " " (apply str (interpose ", " removed-participants-names))))))
 
-(defn handle-group-admin-update [{:keys [chat-name participants]} chat-id signature {:keys [now db random-id] :as cofx}]
-  (let [me (:current-public-key db)]
+(fx/defn handle-group-admin-update [{:keys [now db random-id-generator] :as cofx}
+                                    {:keys [chat-name participants]} chat-id signature]
+  (let [me (:current-public-key db)
+        system-message-id (random-id-generator)]
     ;; we have to check if we already have a chat, or it's a new one
     (if-let [{:keys [group-admin contacts] :as chat} (get-in db [:chats chat-id])]
       ;; update for existing group chat
@@ -43,7 +45,7 @@
           (if (removed me) ;; we were removed
             (fx/merge cofx
                       (models.message/receive
-                       (models.message/system-message chat-id random-id now
+                       (models.message/system-message chat-id system-message-id now
                                                       (str admin-name " " (i18n/label :t/removed-from-chat))))
                       (models.chat/upsert-chat {:chat-id         chat-id
                                                 :removed-from-at now
@@ -51,7 +53,7 @@
                       (transport.utils/unsubscribe-from-chat chat-id))
             (fx/merge cofx
                       (models.message/receive
-                       (models.message/system-message chat-id random-id now
+                       (models.message/system-message chat-id system-message-id now
                                                       (prepare-system-message admin-name
                                                                               added
                                                                               removed
@@ -63,8 +65,9 @@
         (models.chat/add-group-chat cofx chat-id chat-name signature participants)))))
 
 (fx/defn handle-group-leave
-  [{:keys [db random-id now] :as cofx} chat-id signature]
+  [{:keys [db random-id-generator now] :as cofx} chat-id signature]
   (let [me                       (:current-public-key db)
+        system-message-id        (random-id-generator)
         participant-leaving-name (or (get-in db [:contacts/contacts signature :name])
                                      signature)]
     (when (and
@@ -72,7 +75,7 @@
            (get-in db [:chats chat-id])) ;; chat is present
       (fx/merge cofx
                 (models.message/receive
-                 (models.message/system-message chat-id random-id now
+                 (models.message/system-message chat-id system-message-id now
                                                 (str participant-leaving-name " " (i18n/label :t/left))))
                 (group/participants-removed chat-id #{signature})
                 (transport.group-chat/send-new-group-key nil chat-id)))))

--- a/src/status_im/chat/models/message.cljs
+++ b/src/status_im/chat/models/message.cljs
@@ -21,9 +21,6 @@
             [clojure.string :as string]
             [status-im.utils.fx :as fx]))
 
-(def receive-interceptors
-  [(re-frame/inject-cofx :random-id)])
-
 (defn- emoji-only-content?
   [content]
   (and (string? content) (re-matches constants/regx-emoji content)))
@@ -198,10 +195,6 @@
              (>= deleted-at-clock-value clock-value)))))
 
 ;;;; Send message
-
-(def send-interceptors
-  [(re-frame/inject-cofx :random-id)
-   (re-frame/inject-cofx :random-id-seq)])
 
 (fx/defn send
   [{{:keys [network-status current-public-key]} :db :as cofx} chat-id message-id send-record]

--- a/src/status_im/dev_server/events.cljs
+++ b/src/status_im/dev_server/events.cljs
@@ -26,7 +26,7 @@
 
 (handlers/register-handler-fx
  :process-http-request
- [(re-frame/inject-cofx :random-id)]
+ [(re-frame/inject-cofx :random-id-generator)]
  (fn [cofx [_ url type data]]
    (try
      (models.dev-server/process-request! {:cofx cofx

--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -254,7 +254,7 @@
 
 (handlers/register-handler-fx
  :mailserver.ui/save-pressed
- [(re-frame/inject-cofx :random-id)]
+ [(re-frame/inject-cofx :random-id-generator)]
  (fn [cofx _]
    (mailserver/upsert cofx)))
 
@@ -292,7 +292,7 @@
 
 (handlers/register-handler-fx
  :network.ui/save-network-pressed
- [(re-frame/inject-cofx :random-id)]
+ [(re-frame/inject-cofx :random-id-generator)]
  (fn [cofx]
    (network/save-network cofx)))
 
@@ -377,7 +377,7 @@
 
 (handlers/register-handler-fx
  :bootnodes.ui/save-pressed
- [(re-frame/inject-cofx :random-id)]
+ [(re-frame/inject-cofx :random-id-generator)]
  (fn [cofx _]
    (bootnodes/upsert cofx)))
 

--- a/src/status_im/mailserver/core.cljs
+++ b/src/status_im/mailserver/core.cljs
@@ -138,12 +138,13 @@
               (navigation/navigate-to-cofx :edit-mailserver nil))))
 
 (fx/defn upsert
-  [{{:mailservers/keys [manage] :account/keys [account] :as db} :db :as cofx}]
+  [{{:mailservers/keys [manage] :account/keys [account] :as db} :db
+    random-id-generator :random-id-generator :as cofx}]
   (let [{:keys [name url id]} manage
         current-fleet         (fleet/current-fleet db)
         mailserver            (build
                                (or (:value id)
-                                   (keyword (string/replace (:random-id cofx) "-" "")))
+                                   (keyword (string/replace (random-id-generator) "-" "")))
                                (:value name)
                                (:value url))
         current               (connected? cofx (:id mailserver))]

--- a/src/status_im/network/core.cljs
+++ b/src/status_im/network/core.cljs
@@ -68,28 +68,26 @@
    (when handler
      (handler data cofx))))
 
-(defn save
-  ([cofx]
-   (save cofx nil))
-  ([{{:network/keys [manage]
-      :account/keys [account] :as db} :db :as cofx}
-    {:keys [data success-event on-success on-failure]}]
-   (let [data (or data manage)]
-     (if (valid-manage? data)
-       (let [{:keys [name url chain network-id]} data
-             network      (new-network (:random-id cofx)
-                                       (:value name)
-                                       (:value url)
-                                       (:value chain)
-                                       (:value network-id))
-             new-networks (merge {(:id network) network} (:networks account))]
-         (fx/merge cofx
-                   {:db (dissoc db :networks/manage)}
-                   #(action-handler on-success (:id network) %)
-                   (accounts.update/account-update
-                    {:networks new-networks}
-                    {:success-event success-event})))
-       (action-handler on-failure)))))
+(fx/defn save
+  [{{:network/keys [manage] :account/keys [account] :as db} :db
+    random-id-generator :random-id-generator :as cofx}
+   {:keys [data success-event on-success on-failure]}]
+  (let [data (or data manage)]
+    (if (valid-manage? data)
+      (let [{:keys [name url chain network-id]} data
+            network      (new-network (random-id-generator)
+                                      (:value name)
+                                      (:value url)
+                                      (:value chain)
+                                      (:value network-id))
+            new-networks (merge {(:id network) network} (:networks account))]
+        (fx/merge cofx
+                  {:db (dissoc db :networks/manage)}
+                  #(action-handler on-success (:id network) %)
+                  (accounts.update/account-update
+                   {:networks new-networks}
+                   {:success-event success-event})))
+      (action-handler on-failure))))
 
 ;; No edit functionality actually implemented
 (fx/defn edit

--- a/src/status_im/transport/handlers.cljs
+++ b/src/status_im/transport/handlers.cljs
@@ -52,7 +52,7 @@
 (handlers/register-handler-fx
  :protocol/receive-whisper-message
  [handlers/logged-in
-  (re-frame/inject-cofx :random-id)]
+  (re-frame/inject-cofx :random-id-generator)]
  receive-whisper-messages)
 
 (handlers/register-handler-fx
@@ -62,7 +62,8 @@
 
 (handlers/register-handler-fx
  :contact/send-new-sym-key
- (fn [{:keys [db random-id] :as cofx} [_ {:keys [chat-id topic message sym-key sym-key-id]}]]
+ (fn [{:keys [db] :as cofx}
+      [_ {:keys [chat-id topic message sym-key sym-key-id]}]]
    (let [{:keys [web3 current-public-key]} db
          chat-transport-info               (-> (get-in db [:transport/chats chat-id])
                                                (assoc :sym-key-id sym-key-id
@@ -130,7 +131,7 @@
 
 (handlers/register-handler-fx
  :group/add-new-sym-key
- [(re-frame/inject-cofx :random-id)]
+ [(re-frame/inject-cofx :random-id-generator)]
  (fn [{:keys [db] :as cofx} [_ {:keys [sym-key-id sym-key chat-id signature timestamp message]}]]
    (let [{:keys [web3 current-public-key]} db
          topic                            (transport.utils/get-topic chat-id)

--- a/src/status_im/transport/impl/receive.cljs
+++ b/src/status_im/transport/impl/receive.cljs
@@ -9,12 +9,12 @@
 (extend-type transport.group-chat/GroupAdminUpdate
   message/StatusMessage
   (receive [this chat-id signature _ cofx]
-    (models.group-chat/handle-group-admin-update this chat-id signature cofx)))
+    (models.group-chat/handle-group-admin-update cofx this chat-id signature)))
 
 (extend-type transport.group-chat/GroupLeave
   message/StatusMessage
   (receive [this chat-id signature _ cofx]
-    (models.group-chat/handle-group-leave chat-id signature cofx)))
+    (models.group-chat/handle-group-leave cofx chat-id signature)))
 
 (extend-type transport.contact/ContactRequest
   message/StatusMessage

--- a/src/status_im/transport/message/v1/contact.cljs
+++ b/src/status_im/transport/message/v1/contact.cljs
@@ -9,8 +9,8 @@
 
 (defrecord ContactRequest [name profile-image address fcm-token]
   message/StatusMessage
-  (send [this chat-id {:keys [db random-id] :as cofx}]
-    (let [topic      (transport.utils/get-topic random-id)
+  (send [this chat-id {:keys [db random-id-generator] :as cofx}]
+    (let [topic      (transport.utils/get-topic (random-id-generator))
           on-success (fn [sym-key sym-key-id]
                        (re-frame/dispatch [:contact/send-new-sym-key
                                            {:sym-key-id sym-key-id

--- a/src/status_im/ui/screens/contacts/events.cljs
+++ b/src/status_im/ui/screens/contacts/events.cljs
@@ -29,7 +29,7 @@
 
 (handlers/register-handler-fx
  :add-contact
- [(re-frame/inject-cofx :random-id)]
+ [(re-frame/inject-cofx :random-id-generator)]
  (fn [cofx [_ whisper-id]]
    (models.contact/add-contact cofx whisper-id)))
 
@@ -41,7 +41,7 @@
 
 (handlers/register-handler-fx
  :set-contact-identity-from-qr
- [(re-frame/inject-cofx :random-id)]
+ [(re-frame/inject-cofx :random-id-generator)]
  (fn [{:keys [db] :as cofx} [_ _ contact-identity]]
    (let [current-account (:account/account db)
          fx              {:db (assoc db :contacts/new-identity contact-identity)}
@@ -63,13 +63,13 @@
 
 (handlers/register-handler-fx
  :open-chat-with-contact
- [(re-frame/inject-cofx :random-id)]
+ [(re-frame/inject-cofx :random-id-generator)]
  (fn [cofx [_ {:keys [whisper-identity]}]]
    (add-contact-and-open-chat cofx whisper-identity)))
 
 (handlers/register-handler-fx
  :add-contact-handler
- [(re-frame/inject-cofx :random-id)]
+ [(re-frame/inject-cofx :random-id-generator)]
  (fn [{{:contacts/keys [new-identity]} :db :as cofx} _]
    (when (seq new-identity)
      (add-contact-and-open-chat cofx new-identity))))

--- a/src/status_im/ui/screens/group/chat_settings/events.cljs
+++ b/src/status_im/ui/screens/group/chat_settings/events.cljs
@@ -20,9 +20,11 @@
 
 (handlers/register-handler-fx
  :add-new-group-chat-participants
- [(re-frame/inject-cofx :random-id)]
- (fn [{{:keys [current-chat-id selected-participants] :as db} :db now :now message-id :random-id :as cofx} _]
-   (let [participants             (concat (get-in db [:chats current-chat-id :contacts]) selected-participants)
+ [(re-frame/inject-cofx :random-id-generator)]
+ (fn [{{:keys [current-chat-id selected-participants] :as db} :db
+       now :now random-id-generator :random-id-generator :as cofx} _]
+   (let [message-id               (random-id-generator)
+         participants             (concat (get-in db [:chats current-chat-id :contacts]) selected-participants)
          contacts                 (:contacts/contacts db)
          added-participants-names (map #(get-in contacts [% :name]) selected-participants)]
      (fx/merge cofx
@@ -37,9 +39,11 @@
 
 (handlers/register-handler-fx
  :remove-group-chat-participants
- [(re-frame/inject-cofx :random-id)]
- (fn [{{:keys [current-chat-id] :as db} :db now :now message-id :random-id :as cofx} [_ removed-participants]]
-   (let [participants               (remove removed-participants (get-in db [:chats current-chat-id :contacts]))
+ [(re-frame/inject-cofx :random-id-generator)]
+ (fn [{{:keys [current-chat-id] :as db} :db now :now random-id-generator :random-id-generator :as cofx}
+      [_ removed-participants]]
+   (let [message-id                 (random-id-generator)
+         participants               (remove removed-participants (get-in db [:chats current-chat-id :contacts]))
          contacts                   (:contacts/contacts db)
          removed-participants-names (map #(get-in contacts [% :name]) removed-participants)]
      (fx/merge cofx

--- a/src/status_im/ui/screens/wallet/send/events.cljs
+++ b/src/status_im/ui/screens/wallet/send/events.cljs
@@ -154,7 +154,7 @@
 
 (handlers/register-handler-fx
  :send-transaction-message
- (concat models.message/send-interceptors
+ (concat [(re-frame/inject-cofx :random-id-generator)]
          navigation/navigation-interceptors)
  (fn [{:keys [db] :as cofx} [_ chat-id params]]
    ;;NOTE(goranjovic): we want to send the payment message only when we have a whisper id

--- a/src/status_im/utils/random.cljs
+++ b/src/status_im/utils/random.cljs
@@ -28,11 +28,6 @@
    (assoc coeffects :random-guid-generator guid)))
 
 (re-frame/reg-cofx
- :random-id
+ :random-id-generator
  (fn [coeffects _]
-   (assoc coeffects :random-id (id))))
-
-(re-frame/reg-cofx
- :random-id-seq
- (fn [coeffects _]
-   (assoc coeffects :random-id-seq (repeatedly id))))
+   (assoc coeffects :random-id-generator id)))

--- a/test/cljs/status_im/test/mailserver/core.cljs
+++ b/test/cljs/status_im/test/mailserver/core.cljs
@@ -182,7 +182,7 @@
 
 (deftest delete-mailserver
   (testing "the user is not connected to the mailserver"
-    (let [cofx {:random-id "random-id"
+    (let [cofx {:random-id-generator #(identity "random-id")
                 :db {:inbox/wnodes {:eth.beta {"a" {:id           "a"
                                                     :name         "old-name"
                                                     :user-defined true
@@ -193,7 +193,7 @@
       (testing "it stores it in the db"
         (is (= 1 (count (:data-store/tx actual)))))))
   (testing "the mailserver is not user-defined"
-    (let [cofx {:random-id "random-id"
+    (let [cofx {:random-id-generator #(identity "random-id")
                 :db {:inbox/wnodes {:eth.beta {"a" {:id      "a"
                                                     :name    "old-name"
                                                     :address "enode://old-id:old-password@url:port"}}}}}
@@ -201,7 +201,7 @@
       (testing "it does not delete the mailserver"
         (is (= {:dispatch [:navigate-back]} actual)))))
   (testing "the user is connected to the mailserver"
-    (let [cofx {:random-id "random-id"
+    (let [cofx {:random-id-generator #(identity "random-id")
                 :db {:inbox/wnodes {:eth.beta {"a" {:id      "a"
                                                     :name    "old-name"
                                                     :address "enode://old-id:old-password@url:port"}}}}}
@@ -211,7 +211,7 @@
 
 (deftest upsert-mailserver
   (testing "new mailserver"
-    (let [cofx {:random-id "random-id"
+    (let [cofx {:random-id-generator #(identity "random-id")
                 :db {:mailservers/manage {:name {:value "test-name"}
                                           :url  {:value "enode://test-id:test-password@url:port"}}
 
@@ -231,7 +231,7 @@
       (testing "it stores it in the db"
         (is (= 1 (count (:data-store/tx actual)))))))
   (testing "existing mailserver"
-    (let [cofx {:random-id "random-id"
+    (let [cofx {:random-id-generator #(identity "random-id")
                 :db {:mailservers/manage {:id   {:value  :a}
                                           :name {:value "new-name"}
                                           :url  {:value "enode://new-id:new-password@url:port"}}

--- a/test/cljs/status_im/test/models/bootnode.cljs
+++ b/test/cljs/status_im/test/models/bootnode.cljs
@@ -16,7 +16,7 @@
                                                  :chain   "mainnet_rpc"
                                                  :id      "someid"}}}
           actual       (model/upsert
-                        {:random-id "some-id"
+                        {:random-id-generator #(identity "some-id")
                          :db {:bootnodes/manage new-bootnode
                               :network          "mainnet_rpc"
                               :account/account  {}}})]
@@ -30,7 +30,7 @@
                                             :chain   "mainnet_rpc"
                                             :id      "a"}}}
           actual       (model/upsert
-                        {:random-id "some-id"
+                        {:random-id-generator #(identity "some-id")
                          :db {:bootnodes/manage new-bootnode
                               :network          "mainnet_rpc"
                               :account/account  {:bootnodes

--- a/test/cljs/status_im/test/models/network.cljs
+++ b/test/cljs/status_im/test/models/network.cljs
@@ -96,8 +96,9 @@
 
 (deftest save
   (testing "it does not save a network with an invalid url"
-    (is (nil? (model/save {:random-id "random"
+    (is (nil? (model/save {:random-id-generator #(identity "random")
                            :db {:networks/manage {:url {:value "wrong"}
                                                   :chain {:value "1"}
                                                   :name {:value "empty"}}
-                                :account/account {}}})))))
+                                :account/account {}}}
+                          {})))))


### PR DESCRIPTION
replace random-id cofx by random-id-generator

this chance avoids the risk of using the same random-id
twice when it shouldn't be the case when merging many
fx producing functions

added to https://github.com/status-im/status-react/pull/6019 because requires same qa tests

status: ready <!-- Can be ready or wip -->
