### PR TITLE
[DO NOT MERGE] Origin/release/0.9.29

### DIFF
--- a/src/status_im/transport/message/transit.cljs
+++ b/src/status_im/transport/message/transit.cljs
@@ -100,6 +100,8 @@
                                      (v1.contact/ContactRequestConfirmed. name profile-image address fcm-token))
                               "c4" (fn [[content content-type message-type clock-value timestamp]]
                                      (v1.protocol/Message. content content-type message-type clock-value timestamp))
+                              "c7" (fn [[content content-type message-type clock-value timestamp]]
+                                     (v1.protocol/Message. (:text content) content-type message-type clock-value timestamp))
                               "c5" (fn [message-ids]
                                      (v1.protocol/MessagesSeen. message-ids))
                               "c6" (fn [[name profile-image address fcm-token]]


### PR DESCRIPTION
Make a single commit release to have a smooth transition to the new Message format for future reply, thread and reaction features.

n-1: 0.9.28 ignores messages with new format
n: 0.9.29 supports both messages type, but ignores anything but the text content of the new ones
n+1: 0.9.30 ignores old messages, supports new messages fully

status: ready