### PR TITLE
Migrate automated tests to new testrail project

### DIFF
--- a/test/appium/support/testrail_report.py
+++ b/test/appium/support/testrail_report.py
@@ -15,8 +15,8 @@ class TestrailReport(BaseTestReport):
         self.user = environ.get('TESTRAIL_USER')
 
         self.run_id = None
-        self.suite_id = 15
-        self.project_id = 9
+        self.suite_id = 48
+        self.project_id = 14
 
         self.outcomes = {
             'passed': 1,
@@ -75,15 +75,13 @@ class TestrailReport(BaseTestReport):
 
     def get_regression_cases(self, is_pr=False):
         test_cases = dict()
-        test_cases['smoke_phase_1'] = 157
-        test_cases['smoke_phase_2'] = 308
-        test_cases['upgrade'] = 309
-        test_cases['error_handling'] = 458
-        test_cases['logcat_verifications'] = 718
+        test_cases['critical'] = 734
+        test_cases['high'] = 735
+        test_cases['medium'] = 736
+        test_cases['low'] = 737
         case_ids = list()
         if is_pr:
-            case_ids = [case['id'] for case in self.get_cases(test_cases['smoke_phase_1']) +
-                        self.get_cases(test_cases['logcat_verifications'])]
+            case_ids = [case['id'] for case in self.get_cases(test_cases['critical'])]
         else:
             for phase in test_cases:
                 for case in self.get_cases(test_cases[phase]):

--- a/test/appium/tests/atomic/account_management/test_create_account.py
+++ b/test/appium/tests/atomic/account_management/test_create_account.py
@@ -8,8 +8,8 @@ from views.sign_in_view import SignInView
 @marks.account
 class TestCreateAccount(SingleDeviceTestCase):
 
-    @marks.testrail_id(758)
-    @marks.smoke_1
+    @marks.testrail_id(5300)
+    @marks.critical
     def test_create_account(self):
         sign_in = SignInView(self.driver, skip_popups=False)
         if not sign_in.element_by_text_part(test_fairy_warning_text).is_element_displayed():
@@ -29,7 +29,8 @@ class TestCreateAccount(SingleDeviceTestCase):
         sign_in.next_button.click()
         self.verify_no_errors()
 
-    @marks.testrail_id(1433)
+    @marks.testrail_id(5356)
+    @marks.critical
     def test_switch_users_and_add_new_account(self):
         sign_in = SignInView(self.driver)
         sign_in.create_user()
@@ -43,8 +44,8 @@ class TestCreateAccount(SingleDeviceTestCase):
         if sign_in.get_public_key() == public_key:
             pytest.fail('New account was not created')
 
-    @marks.testrail_id(3787)
-    @marks.smoke_1
+    @marks.testrail_id(5379)
+    @marks.high
     def test_home_view(self):
         sign_in = SignInView(self.driver)
         home = sign_in.create_user()
@@ -61,7 +62,8 @@ class TestCreateAccount(SingleDeviceTestCase):
             self.errors.append("'%s' text is not shown" % text)
         self.verify_no_errors()
 
-    @marks.testrail_id(844)
+    @marks.testrail_id(5460)
+    @marks.medium
     def test_create_account_short_and_mismatch_password(self):
         sign_in = SignInView(self.driver)
         sign_in.create_account_button.click()
@@ -82,7 +84,8 @@ class TestCreateAccount(SingleDeviceTestCase):
             self.errors.append("'%s' is not shown")
         self.verify_no_errors()
 
-    @marks.testrail_id(3767)
+    @marks.testrail_id(5414)
+    @marks.critical
     @marks.logcat
     def test_password_in_logcat_creating_account(self):
         sign_in = SignInView(self.driver)

--- a/test/appium/tests/atomic/account_management/test_profile.py
+++ b/test/appium/tests/atomic/account_management/test_profile.py
@@ -11,8 +11,8 @@ from views.sign_in_view import SignInView
 @marks.account
 class TestProfileSingleDevice(SingleDeviceTestCase):
 
-    @marks.testrail_id(760)
-    @marks.smoke_1
+    @marks.testrail_id(5302)
+    @marks.critical
     def test_set_profile_picture(self):
         sign_in_view = SignInView(self.driver)
         sign_in_view.create_user()
@@ -24,8 +24,8 @@ class TestProfileSingleDevice(SingleDeviceTestCase):
         if not profile_view.profile_picture.is_element_image_equals_template():
             pytest.fail('Profile picture was not updated')
 
-    @marks.testrail_id(1403)
-    @marks.smoke_1
+    @marks.testrail_id(5323)
+    @marks.critical
     def test_share_contact_code_and_wallet_address(self):
         sign_in_view = SignInView(self.driver)
         sign_in_view.create_user()
@@ -48,8 +48,8 @@ class TestProfileSingleDevice(SingleDeviceTestCase):
             self.errors.append("Can't share address")
         self.verify_no_errors()
 
-    @marks.testrail_id(3704)
-    @marks.smoke_1
+    @marks.testrail_id(5375)
+    @marks.high
     def test_copy_contact_code_and_wallet_address(self):
         sign_in_view = SignInView(self.driver)
         sign_in_view.create_user()
@@ -84,7 +84,8 @@ class TestProfileSingleDevice(SingleDeviceTestCase):
             self.errors.append('Wallet address was not copied')
         self.verify_no_errors()
 
-    @marks.testrail_id(1407)
+    @marks.testrail_id(5475)
+    @marks.low
     def test_change_profile_picture_several_times(self):
         sign_in_view = SignInView(self.driver)
         sign_in_view.create_user()
@@ -95,8 +96,8 @@ class TestProfileSingleDevice(SingleDeviceTestCase):
             if not profile_view.profile_picture.is_element_image_equals_template():
                 pytest.fail('Profile picture was not updated')
 
-    @marks.testrail_id(2374)
-    @marks.smoke_1
+    @marks.testrail_id(5329)
+    @marks.critical
     def test_backup_recovery_phrase(self):
         sign_in_view = SignInView(self.driver)
         sign_in_view.create_user()
@@ -113,7 +114,8 @@ class TestProfileSingleDevice(SingleDeviceTestCase):
             self.errors.append('Profile button counter is shown after seed phrase backup')
         self.verify_no_errors()
 
-    @marks.testrail_id(3721)
+    @marks.testrail_id(5433)
+    @marks.medium
     def test_invite_friends(self):
         sign_in_view = SignInView(self.driver)
         home = sign_in_view.create_user()
@@ -122,7 +124,8 @@ class TestProfileSingleDevice(SingleDeviceTestCase):
         start_new_chat.share_via_messenger()
         start_new_chat.find_text_part("Get Status at http://status.im")
 
-    @marks.testrail_id(3450)
+    @marks.testrail_id(5429)
+    @marks.medium
     def test_set_currency(self):
         sign_in_view = SignInView(self.driver)
         sign_in_view.create_user()
@@ -134,7 +137,8 @@ class TestProfileSingleDevice(SingleDeviceTestCase):
         if 'EUR' != wallet_view.currency_text.text:
             pytest.fail('EUR currency is not displayed')
 
-    @marks.testrail_id(3707)
+    @marks.testrail_id(5431)
+    @marks.medium
     def test_add_custom_network(self):
         sign_in_view = SignInView(self.driver)
         sign_in_view.create_user()
@@ -145,7 +149,8 @@ class TestProfileSingleDevice(SingleDeviceTestCase):
         profile_view.advanced_button.click()
         profile_view.find_text_part('CUSTOM_ROPSTEN')
 
-    @marks.testrail_id(3774)
+    @marks.logcat
+    @marks.testrail_id(5419)
     def test_logcat_backup_recovery_phrase(self):
         sign_in_view = SignInView(self.driver)
         sign_in_view.create_user()
@@ -164,7 +169,8 @@ class TestProfileSingleDevice(SingleDeviceTestCase):
         profile_view.check_no_values_in_logcat(passphrase1=recovery_phrase[word_number],
                                                passphrase2=recovery_phrase[word_number_1])
 
-    @marks.testrail_id(3751)
+    @marks.testrail_id(5391)
+    @marks.high
     def test_need_help_section(self):
         sign_in_view = SignInView(self.driver)
         sign_in_view.create_user()
@@ -181,7 +187,8 @@ class TestProfileSingleDevice(SingleDeviceTestCase):
         base_web_view.open_in_webview()
         profile_view.find_text_part('Questions around beta')
 
-    @marks.testrail_id(1416)
+    @marks.testrail_id(5382)
+    @marks.high
     def test_contact_profile_view(self):
         sign_in_view = SignInView(self.driver)
         sign_in_view.create_user()
@@ -193,7 +200,8 @@ class TestProfileSingleDevice(SingleDeviceTestCase):
         for text in basic_user['username'], 'In contacts', 'Send transaction', 'Send message', 'Contact code':
             chat_view.find_full_text(text)
 
-    @marks.testrail_id(2177)
+    @marks.testrail_id(5468)
+    @marks.medium
     def test_deny_camera_access_changing_profile_photo(self):
         sign_in = SignInView(self.driver)
         sign_in.create_user()
@@ -209,7 +217,8 @@ class TestProfileSingleDevice(SingleDeviceTestCase):
         profile.capture_button.click()
         profile.deny_button.wait_for_visibility_of_element(2)
 
-    @marks.testrail_id(2178)
+    @marks.testrail_id(5469)
+    @marks.medium
     def test_deny_device_storage_access_changing_profile_photo(self):
         sign_in = SignInView(self.driver)
         sign_in.create_user()
@@ -229,7 +238,8 @@ class TestProfileSingleDevice(SingleDeviceTestCase):
 @marks.account
 class TestProfileMultipleDevice(MultipleDeviceTestCase):
 
-    @marks.testrail_id(3708)
+    @marks.testrail_id(5432)
+    @marks.medium
     def test_custom_bootnodes(self):
         self.create_drivers(2)
         sign_in_1, sign_in_2 = SignInView(self.drivers[0]), SignInView(self.drivers[1])
@@ -269,7 +279,8 @@ class TestProfileMultipleDevice(MultipleDeviceTestCase):
         chat_1.send_message_button.click()
         chat_2.chat_element_by_text(message_1).wait_for_visibility_of_element()
 
-    @marks.testrail_id(3737)
+    @marks.testrail_id(5436)
+    @marks.medium
     def test_switch_mailserver(self):
         self.create_drivers(2)
         sign_in_1, sign_in_2 = SignInView(self.drivers[0]), SignInView(self.drivers[1])

--- a/test/appium/tests/atomic/account_management/test_recover.py
+++ b/test/appium/tests/atomic/account_management/test_recover.py
@@ -10,8 +10,8 @@ from views.sign_in_view import SignInView
 @marks.account
 class TestRecoverAccountSingleDevice(SingleDeviceTestCase):
 
-    @marks.testrail_id(759)
-    @marks.smoke_1
+    @marks.testrail_id(5301)
+    @marks.critical
     def test_recover_account(self):
         sign_in = SignInView(self.driver)
         home = sign_in.create_user()
@@ -56,7 +56,8 @@ class TestRecoverAccountSingleDevice(SingleDeviceTestCase):
             pytest.fail('The same account is recovered with reversed passphrase')
 
     @marks.logcat
-    @marks.testrail_id(3769)
+    @marks.testrail_id(5366)
+    @marks.critical
     def test_logcat_recovering_account(self):
         sign_in = SignInView(self.driver)
         sign_in.recover_access(passphrase=basic_user['passphrase'], password=unique_password)

--- a/test/appium/tests/atomic/account_management/test_sign_in.py
+++ b/test/appium/tests/atomic/account_management/test_sign_in.py
@@ -9,8 +9,8 @@ from views.sign_in_view import SignInView
 @marks.sign_in
 class TestSignIn(SingleDeviceTestCase):
 
-    @marks.testrail_id(1381)
-    @marks.smoke_1
+    @marks.testrail_id(5312)
+    @marks.critical
     def test_login_with_new_account(self):
         sign_in = SignInView(self.driver)
         username = 'test_user'
@@ -25,7 +25,8 @@ class TestSignIn(SingleDeviceTestCase):
             self.errors.append('User is not logged in')
         self.verify_no_errors()
 
-    @marks.testrail_id(2169)
+    @marks.testrail_id(5463)
+    @marks.medium
     def test_login_with_incorrect_password(self):
         sign_in = SignInView(self.driver)
         sign_in.create_user()
@@ -38,7 +39,8 @@ class TestSignIn(SingleDeviceTestCase):
         sign_in.find_full_text('Wrong password')
 
     @marks.logcat
-    @marks.testrail_id(3768)
+    @marks.testrail_id(5415)
+    @marks.critical
     def test_password_in_logcat_sign_in(self):
         sign_in = SignInView(self.driver)
         sign_in.create_user(password=unique_password)
@@ -52,8 +54,8 @@ class TestSignIn(SingleDeviceTestCase):
 @marks.sign_in
 class TestSignInOffline(MultipleDeviceTestCase):
 
-    @marks.testrail_case_id(3740)
-    @marks.testrail_id(1432)
+    @marks.testrail_id(5327)
+    @marks.critical
     def test_offline_login(self):
         self.create_drivers(1, offline_mode=True)
         sign_in = SignInView(self.drivers[0])

--- a/test/appium/tests/atomic/account_management/test_wallet_management.py
+++ b/test/appium/tests/atomic/account_management/test_wallet_management.py
@@ -10,8 +10,8 @@ from views.sign_in_view import SignInView
 @marks.account
 class TestWalletManagement(SingleDeviceTestCase):
 
-    @marks.testrail_id(3698)
-    @marks.smoke_1
+    @marks.testrail_id(5335)
+    @marks.critical
     def test_wallet_set_up(self):
         sign_in = SignInView(self.driver)
         sign_in.create_user()
@@ -40,7 +40,8 @@ class TestWalletManagement(SingleDeviceTestCase):
                 self.errors.append('%s button is not shown after wallet setup' % element.name)
         self.verify_no_errors()
 
-    @marks.testrail_id(1449)
+    @marks.testrail_id(5384)
+    @marks.high
     def test_open_transaction_on_etherscan(self):
         user = wallet_users['A']
         sign_in_view = SignInView(self.driver)
@@ -56,7 +57,8 @@ class TestWalletManagement(SingleDeviceTestCase):
         base_web_view.open_in_webview()
         base_web_view.find_text_part(transaction_hash)
 
-    @marks.testrail_id(1450)
+    @marks.testrail_id(5427)
+    @marks.medium
     def test_copy_transaction_hash(self):
         user = wallet_users['A']
         sign_in_view = SignInView(self.driver)
@@ -75,8 +77,8 @@ class TestWalletManagement(SingleDeviceTestCase):
         if public_chat.chat_message_input.text != transaction_hash:
             pytest.fail('Transaction hash was not copied')
 
-    @marks.testrail_id(3713)
-    @marks.smoke_1
+    @marks.testrail_id(5341)
+    @marks.critical
     def test_manage_assets(self):
         sign_in = SignInView(self.driver)
         sign_in.create_user()
@@ -96,7 +98,8 @@ class TestWalletManagement(SingleDeviceTestCase):
             self.errors.append('%s asset is shown in wallet but was deselected' % deselect_asset)
         self.verify_no_errors()
 
-    @marks.testrail_id(3725)
+    @marks.testrail_id(5358)
+    @marks.critical
     def test_backup_recovery_phrase_warning_from_wallet(self):
         sign_in = SignInView(self.driver)
         sign_in.create_user()
@@ -115,7 +118,8 @@ class TestWalletManagement(SingleDeviceTestCase):
         profile = wallet.get_profile_view()
         profile.backup_recovery_phrase()
 
-    @marks.testrail_id(3777)
+    @marks.testrail_id(5440)
+    @marks.medium
     def test_no_collectibles_to_send_from_wallet(self):
         sign_in = SignInView(self.driver)
         sign_in.create_user()
@@ -134,7 +138,8 @@ class TestWalletManagement(SingleDeviceTestCase):
         if send_transaction.asset_by_name(asset_name).is_element_displayed():
             pytest.fail('Collectibles can be sent from wallet')
 
-    @marks.testrail_id(2176)
+    @marks.testrail_id(5467)
+    @marks.medium
     def test_deny_camera_access_scanning_wallet_adders(self):
         sign_in = SignInView(self.driver)
         sign_in.create_user()
@@ -150,7 +155,8 @@ class TestWalletManagement(SingleDeviceTestCase):
         send_transaction.scan_qr_code_button.click()
         send_transaction.deny_button.wait_for_visibility_of_element(2)
 
-    @marks.testrail_id(3730)
+    @marks.testrail_id(5435)
+    @marks.medium
     def test_filter_transactions_history(self):
         user = wallet_users['C']
         sign_in_view = SignInView(self.driver)

--- a/test/appium/tests/atomic/account_management/test_wallet_modal.py
+++ b/test/appium/tests/atomic/account_management/test_wallet_modal.py
@@ -9,7 +9,8 @@ from views.sign_in_view import SignInView
 @marks.wallet_modal
 class TestWalletModal(SingleDeviceTestCase):
 
-    @marks.testrail_id(3794)
+    @marks.testrail_id(5398)
+    @marks.high
     def test_wallet_modal_public_chat(self):
         user = wallet_users['A']
         sign_in = SignInView(self.driver)
@@ -35,7 +36,8 @@ class TestWalletModal(SingleDeviceTestCase):
             self.errors.append('Transaction history button is not visible in wallet modal')
         self.verify_no_errors()
 
-    @marks.testrail_id(3795)
+    @marks.testrail_id(5399)
+    @marks.high
     def test_wallet_modal_dapp(self):
         user = wallet_users['B']
         sign_in = SignInView(self.driver)
@@ -64,7 +66,8 @@ class TestWalletModal(SingleDeviceTestCase):
             self.errors.append('Transaction history button is not visible in wallet modal')
         self.verify_no_errors()
 
-    @marks.testrail_id(3797)
+    @marks.testrail_id(5400)
+    @marks.high
     def test_wallet_modal_transaction_history(self):
         user = wallet_users['B']
         sign_in = SignInView(self.driver)
@@ -79,7 +82,8 @@ class TestWalletModal(SingleDeviceTestCase):
         if transaction_history.transactions_table.get_transactions_number() < 1:
             pytest.fail('Transactions history is not shown')
 
-    @marks.testrail_id(3800)
+    @marks.testrail_id(5480)
+    @marks.low
     def test_close_and_open_wallet_modal(self):
         user = wallet_users['B']
         sign_in = SignInView(self.driver)

--- a/test/appium/tests/atomic/chats/test_chats_management.py
+++ b/test/appium/tests/atomic/chats/test_chats_management.py
@@ -10,7 +10,8 @@ from views.sign_in_view import SignInView
 @marks.chat
 class TestChatManagement(SingleDeviceTestCase):
 
-    @marks.testrail_id(1428)
+    @marks.testrail_id(5426)
+    @marks.medium
     def test_clear_history_one_to_one_chat(self):
         sign_in_view = SignInView(self.driver)
         home_view = sign_in_view.create_user()
@@ -26,8 +27,8 @@ class TestChatManagement(SingleDeviceTestCase):
         if not chat_view.no_messages_in_chat.is_element_present():
             pytest.fail('Message history is shown after re-login')
 
-    @marks.testrail_id(1395)
-    @marks.smoke_1
+    @marks.testrail_id(5319)
+    @marks.critical
     def test_swipe_to_delete_1_1_chat(self):
         sign_in = SignInView(self.driver)
         home = sign_in.create_user()
@@ -43,8 +44,8 @@ class TestChatManagement(SingleDeviceTestCase):
         if home.get_chat_with_user(basic_user['username']).is_element_displayed():
             pytest.fail('Deleted 1-1 chat is present after relaunch app')
 
-    @marks.testrail_id(3718)
-    @marks.smoke_1
+    @marks.testrail_id(5343)
+    @marks.critical
     def test_swipe_to_delete_public_chat(self):
         sign_in = SignInView(self.driver)
         home = sign_in.create_user()
@@ -65,8 +66,8 @@ class TestChatManagement(SingleDeviceTestCase):
             self.errors.append('Chat history is shown')
         self.verify_no_errors()
 
-    @marks.testrail_id(763)
-    @marks.smoke_1
+    @marks.testrail_id(5304)
+    @marks.critical
     def test_add_contact_by_pasting_public_key(self):
         sign_in = SignInView(self.driver)
         home = sign_in.create_user()
@@ -91,7 +92,8 @@ class TestChatManagement(SingleDeviceTestCase):
         if not start_new_chat.element_by_text(basic_user['username']).is_element_displayed():
             pytest.fail("List of contacts doesn't contain added user")
 
-    @marks.testrail_id(3719)
+    @marks.testrail_id(5387)
+    @marks.high
     def test_delete_one_to_one_chat_via_delete_button(self):
         sign_in = SignInView(self.driver)
         home = sign_in.create_user()
@@ -107,7 +109,8 @@ class TestChatManagement(SingleDeviceTestCase):
             self.errors.append("One-to-one' chat is shown after re-login, but the chat has been deleted")
         self.verify_no_errors()
 
-    @marks.testrail_id(3720)
+    @marks.testrail_id(5388)
+    @marks.high
     def test_delete_public_chat_via_delete_button(self):
         sign_in = SignInView(self.driver)
         home = sign_in.create_user()
@@ -123,7 +126,8 @@ class TestChatManagement(SingleDeviceTestCase):
             self.errors.append("Public chat '%s' is shown after re-login, but the chat has been deleted" % chat_name)
         self.verify_no_errors()
 
-    @marks.testrail_id(2172)
+    @marks.testrail_id(5464)
+    @marks.medium
     def test_incorrect_contact_code_start_new_chat(self):
         sign_in = SignInView(self.driver)
         home = sign_in.create_user()
@@ -135,7 +139,8 @@ class TestChatManagement(SingleDeviceTestCase):
         if not warning_text.is_element_displayed():
             pytest.fail('Error is not shown for invalid public key')
 
-    @marks.testrail_id(2175)
+    @marks.testrail_id(5466)
+    @marks.medium
     def test_deny_camera_access_scanning_contact_code(self):
         sign_in = SignInView(self.driver)
         home = sign_in.create_user()
@@ -152,8 +157,8 @@ class TestChatManagement(SingleDeviceTestCase):
 @marks.chat
 class TestChatManagementMultipleDevice(MultipleDeviceTestCase):
 
-    @marks.testrail_id(3694)
-    @marks.smoke_1
+    @marks.testrail_id(5332)
+    @marks.critical
     def test_add_contact_from_public_chat(self):
         self.create_drivers(2)
         device_1, device_2 = SignInView(self.drivers[0]), SignInView(self.drivers[1])

--- a/test/appium/tests/atomic/chats/test_commands.py
+++ b/test/appium/tests/atomic/chats/test_commands.py
@@ -13,8 +13,8 @@ from views.sign_in_view import SignInView
 @marks.transaction
 class TestCommandsMultipleDevices(MultipleDeviceTestCase):
 
-    @marks.smoke_1
-    @marks.testrail_id(3697)
+    @marks.critical
+    @marks.testrail_id(5334)
     def test_network_mismatch_for_send_request_commands(self):
         sender = transaction_senders['D']
         self.create_drivers(2)
@@ -70,8 +70,8 @@ class TestCommandsMultipleDevices(MultipleDeviceTestCase):
             self.errors.append('Request funds message was not received')
         self.verify_no_errors()
 
-    @marks.testrail_id(765)
-    @marks.smoke_1
+    @marks.testrail_id(5306)
+    @marks.critical
     def test_send_eth_in_1_1_chat(self):
         recipient = transaction_recipients['A']
         sender = transaction_senders['A']
@@ -137,8 +137,8 @@ class TestCommandsMultipleDevices(MultipleDeviceTestCase):
             self.errors.append(e.msg)
         self.verify_no_errors()
 
-    @marks.testrail_id(1391)
-    @marks.smoke_1
+    @marks.testrail_id(5318)
+    @marks.critical
     def test_request_and_receive_eth_in_1_1_chat(self):
         recipient = transaction_recipients['B']
         sender = transaction_senders['J']
@@ -174,8 +174,8 @@ class TestCommandsMultipleDevices(MultipleDeviceTestCase):
             self.errors.append(e.msg)
         self.verify_no_errors()
 
-    @marks.testrail_id(1429)
-    @marks.smoke_1
+    @marks.testrail_id(5324)
+    @marks.critical
     def test_request_eth_in_wallet(self):
         self.create_drivers(2)
         device_1, device_2 = SignInView(self.drivers[0]), SignInView(self.drivers[1])
@@ -215,7 +215,8 @@ class TestCommandsMultipleDevices(MultipleDeviceTestCase):
             self.errors.append('Request funds message was not received')
         self.verify_no_errors()
 
-    @marks.testrail_id(1417)
+    @marks.testrail_id(5383)
+    @marks.high
     def test_contact_profile_send_transaction(self):
         self.create_drivers(1)
         recipient = basic_user
@@ -243,8 +244,8 @@ class TestCommandsMultipleDevices(MultipleDeviceTestCase):
         send_transaction_view.sign_transaction()
         self.network_api.find_transaction_by_unique_amount(recipient['address'], amount)
 
-    @marks.testrail_id(3744)
-    @marks.smoke_1
+    @marks.testrail_id(5348)
+    @marks.critical
     def test_send_tokens_in_1_1_chat(self):
         recipient = transaction_recipients['C']
         sender = transaction_senders['C']
@@ -274,8 +275,8 @@ class TestCommandsMultipleDevices(MultipleDeviceTestCase):
             self.errors.append(e.msg)
         self.verify_no_errors()
 
-    @marks.testrail_id(3748)
-    @marks.smoke_1
+    @marks.testrail_id(5352)
+    @marks.critical
     def test_request_and_receive_tokens_in_1_1_chat(self):
         recipient = transaction_recipients['D']
         sender = transaction_senders['B']
@@ -309,8 +310,8 @@ class TestCommandsMultipleDevices(MultipleDeviceTestCase):
             self.errors.append(e.msg)
         self.verify_no_errors()
 
-    @marks.testrail_id(3749)
-    @marks.smoke_1
+    @marks.testrail_id(5376)
+    @marks.high
     def test_transaction_confirmed_on_recipient_side(self):
         recipient = transaction_recipients['E']
         sender = transaction_senders['E']
@@ -336,8 +337,8 @@ class TestCommandsMultipleDevices(MultipleDeviceTestCase):
 @marks.transaction
 class TestCommandsSingleDevices(SingleDeviceTestCase):
 
-    @marks.testrail_id(3745)
-    @marks.smoke_1
+    @marks.testrail_id(5349)
+    @marks.critical
     def test_send_request_not_enabled_tokens(self):
         sign_in = SignInView(self.driver)
         home = sign_in.create_user()
@@ -354,7 +355,8 @@ class TestCommandsSingleDevices(SingleDeviceTestCase):
         self.verify_no_errors()
 
     @marks.logcat
-    @marks.testrail_id(3771)
+    @marks.testrail_id(5417)
+    @marks.critical
     def test_logcat_send_transaction_in_1_1_chat(self):
         sender = transaction_senders['F']
         sign_in = SignInView(self.driver)
@@ -367,8 +369,8 @@ class TestCommandsSingleDevices(SingleDeviceTestCase):
         chat.send_transaction_in_1_1_chat('ETH', amount, unique_password)
         chat.check_no_values_in_logcat(password=unique_password)
 
-    @marks.testrail_id(3736)
-    @marks.smoke_1
+    @marks.testrail_id(5347)
+    @marks.critical
     def test_send_transaction_details_in_1_1_chat(self):
         recipient = basic_user
         sender = transaction_senders['G']
@@ -397,8 +399,8 @@ class TestCommandsSingleDevices(SingleDeviceTestCase):
             self.errors.append('Amount is not visible')
         self.verify_no_errors()
 
-    @marks.testrail_id(3750)
-    @marks.smoke_1
+    @marks.testrail_id(5377)
+    @marks.high
     def test_transaction_confirmed_on_sender_side(self):
         sender = transaction_senders['H']
         sign_in = SignInView(self.driver)
@@ -413,7 +415,8 @@ class TestCommandsSingleDevices(SingleDeviceTestCase):
         if not chat.chat_element_by_text(amount).contains_text('Confirmed', wait_time=90):
             pytest.fail('Status "Confirmed" is not shown under transaction for the sender')
 
-    @marks.testrail_id(3790)
+    @marks.testrail_id(5410)
+    @marks.high
     def test_insufficient_funds_1_1_chat_0_balance(self):
         sign_in_view = SignInView(self.driver)
         sign_in_view.create_user()
@@ -440,7 +443,8 @@ class TestCommandsSingleDevices(SingleDeviceTestCase):
             self.errors.append("'Insufficient funds' error is now shown when sending 1 STT from chat with balance 0")
         self.verify_no_errors()
 
-    @marks.testrail_id(3793)
+    @marks.testrail_id(5473)
+    @marks.medium
     def test_insufficient_funds_1_1_chat_positive_balance(self):
         sender = transaction_senders['I']
         sign_in_view = SignInView(self.driver)

--- a/test/appium/tests/atomic/chats/test_one_to_one.py
+++ b/test/appium/tests/atomic/chats/test_one_to_one.py
@@ -13,8 +13,8 @@ from views.sign_in_view import SignInView
 @marks.chat
 class TestMessagesOneToOneChatMultiple(MultipleDeviceTestCase):
 
-    @marks.testrail_id(764)
-    @marks.smoke_1
+    @marks.testrail_id(5305)
+    @marks.critical
     def test_text_message_1_1_chat(self):
         self.create_drivers(2)
         device_1, device_2 = SignInView(self.drivers[0]), SignInView(self.drivers[1])
@@ -32,8 +32,8 @@ class TestMessagesOneToOneChatMultiple(MultipleDeviceTestCase):
         device_2_chat = device_2_home.get_chat_with_user(username_1).click()
         device_2_chat.chat_element_by_text(message).wait_for_visibility_of_element()
 
-    @marks.testrail_id(772)
-    @marks.smoke_1
+    @marks.testrail_id(5310)
+    @marks.critical
     def test_offline_messaging_1_1_chat(self):
         self.create_drivers(2, offline_mode=True)
         sign_in_1, sign_in_2 = SignInView(self.drivers[0]), SignInView(self.drivers[1])
@@ -71,8 +71,8 @@ class TestMessagesOneToOneChatMultiple(MultipleDeviceTestCase):
         chat_1 = chat_element.click()
         chat_1.chat_element_by_text(message_2).wait_for_visibility_of_element(180)
 
-    @marks.testrail_id(3710)
-    @marks.smoke_1
+    @marks.testrail_id(5338)
+    @marks.critical
     def test_messaging_in_different_networks(self):
         self.create_drivers(2)
         sign_in_1, sign_in_2 = SignInView(self.drivers[0]), SignInView(self.drivers[1])
@@ -101,8 +101,8 @@ class TestMessagesOneToOneChatMultiple(MultipleDeviceTestCase):
         chat_1.send_message_button.click()
         chat_2.chat_element_by_text(message).wait_for_visibility_of_element()
 
-    @marks.testrail_id(1386)
-    @marks.smoke_1
+    @marks.testrail_id(5315)
+    @marks.critical
     def test_send_message_to_newly_added_contact(self):
         self.create_drivers(2)
         device_1, device_2 = SignInView(self.drivers[0]), SignInView(self.drivers[1])
@@ -138,8 +138,8 @@ class TestMessagesOneToOneChatMultiple(MultipleDeviceTestCase):
             self.errors.append("Updated profile picture is not shown in one-to-one chat")
         self.verify_no_errors()
 
-    @marks.testrail_id(1387)
-    @marks.smoke_1
+    @marks.testrail_id(5316)
+    @marks.critical
     def test_add_to_contacts(self):
         self.create_drivers(2)
         device_1, device_2 = SignInView(self.drivers[0]), SignInView(self.drivers[1])
@@ -181,8 +181,8 @@ class TestMessagesOneToOneChatMultiple(MultipleDeviceTestCase):
             self.errors.append("Updated profile picture is not shown in one-to-one chat")
         self.verify_no_errors()
 
-    @marks.testrail_id(1413)
-    @marks.smoke_1
+    @marks.testrail_id(5373)
+    @marks.high
     def test_send_and_open_links(self):
         self.create_drivers(2)
         device_1, device_2 = SignInView(self.drivers[0]), SignInView(self.drivers[1])
@@ -220,8 +220,8 @@ class TestMessagesOneToOneChatMultiple(MultipleDeviceTestCase):
             self.errors.append('URL was not opened from 1-1 chat')
         self.verify_no_errors()
 
-    @marks.testrail_id(1431)
-    @marks.smoke_1
+    @marks.testrail_id(5326)
+    @marks.critical
     def test_offline_status(self):
         self.create_drivers(1, offline_mode=True)
         sign_in = SignInView(self.drivers[0])
@@ -247,8 +247,8 @@ class TestMessagesOneToOneChatMultiple(MultipleDeviceTestCase):
             self.errors.append('Offline status is not shown in a public chat')
         self.verify_no_errors()
 
-    @marks.testrail_id(3695)
-    @marks.smoke_1
+    @marks.testrail_id(5374)
+    @marks.high
     def test_message_marked_as_sent_and_seen_1_1_chat(self):
         self.create_drivers(2)
         device_1, device_2 = SignInView(self.drivers[0]), SignInView(self.drivers[1])
@@ -272,7 +272,8 @@ class TestMessagesOneToOneChatMultiple(MultipleDeviceTestCase):
             self.errors.append("'Seen' status is not shown under the text message which was read by a receiver")
         self.verify_no_errors()
 
-    @marks.testrail_id(3784)
+    @marks.testrail_id(5362)
+    @marks.critical
     def test_unread_messages_counter_1_1_chat(self):
         self.create_drivers(2)
         device_1, device_2 = SignInView(self.drivers[0]), SignInView(self.drivers[1])
@@ -304,7 +305,8 @@ class TestMessagesOneToOneChatMultiple(MultipleDeviceTestCase):
             self.errors.append('New messages counter is shown on chat element for already seen message')
         self.verify_no_errors()
 
-    @marks.testrail_id(1414)
+    @marks.testrail_id(5425)
+    @marks.medium
     def test_bold_and_italic_text_in_messages(self):
         self.create_drivers(2)
         sign_in_1, sign_in_2 = SignInView(self.drivers[0]), SignInView(self.drivers[1])
@@ -359,7 +361,8 @@ class TestMessagesOneToOneChatMultiple(MultipleDeviceTestCase):
         self.verify_no_errors()
 
     @marks.skip
-    @marks.testrail_id(2781)
+    @marks.testrail_id(5385)
+    @marks.high
     def test_timestamp_in_chats(self):
         self.create_drivers(2)
         sign_in_1, sign_in_2 = SignInView(self.drivers[0]), SignInView(self.drivers[1])
@@ -411,8 +414,8 @@ class TestMessagesOneToOneChatMultiple(MultipleDeviceTestCase):
 @marks.chat
 class TestMessagesOneToOneChatSingle(SingleDeviceTestCase):
 
-    @marks.testrail_id(1390)
-    @marks.smoke_1
+    @marks.testrail_id(5317)
+    @marks.critical
     def test_copy_and_paste_messages(self):
         sign_in = SignInView(self.driver)
         home = sign_in.create_user()
@@ -444,8 +447,8 @@ class TestMessagesOneToOneChatSingle(SingleDeviceTestCase):
             self.errors.append('Message text was not copied in 1-1 chat')
         self.verify_no_errors()
 
-    @marks.testrail_id(1398)
-    @marks.smoke_1
+    @marks.testrail_id(5322)
+    @marks.critical
     def test_delete_cut_and_paste_messages(self):
         sign_in = SignInView(self.driver)
         home = sign_in.create_user()
@@ -467,8 +470,8 @@ class TestMessagesOneToOneChatSingle(SingleDeviceTestCase):
 
         chat.chat_element_by_text(message_text[:-2] + ' ').wait_for_visibility_of_element(2)
 
-    @marks.testrail_id(2106)
-    @marks.smoke_1
+    @marks.testrail_id(5328)
+    @marks.critical
     def test_send_emoji(self):
         sign_in = SignInView(self.driver)
         home = sign_in.create_user()

--- a/test/appium/tests/atomic/chats/test_public.py
+++ b/test/appium/tests/atomic/chats/test_public.py
@@ -7,8 +7,8 @@ from views.sign_in_view import SignInView
 @marks.chat
 class TestPublicChatMultipleDevice(MultipleDeviceTestCase):
 
-    @marks.testrail_id(1383)
-    @marks.smoke_1
+    @marks.testrail_id(5313)
+    @marks.critical
     def test_public_chat_messaging(self):
         self.create_drivers(2)
         device_1, device_2 = SignInView(self.drivers[0]), SignInView(self.drivers[1])
@@ -36,7 +36,8 @@ class TestPublicChatMultipleDevice(MultipleDeviceTestCase):
 
         self.verify_no_errors()
 
-    @marks.testrail_id(3706)
+    @marks.testrail_id(5386)
+    @marks.high
     def test_public_chat_clear_history(self):
         self.create_drivers(2)
         device_1, device_2 = SignInView(self.drivers[0]), SignInView(self.drivers[1])
@@ -70,7 +71,8 @@ class TestPublicChatMultipleDevice(MultipleDeviceTestCase):
                 chat_1.driver.fail(
                     "Message '%s' is shown after re-login, but public chat history has been cleared" % message)
 
-    @marks.testrail_id(3729)
+    @marks.testrail_id(5360)
+    @marks.critical
     def test_unread_messages_counter_public_chat(self):
         self.create_drivers(2)
         device_1, device_2 = SignInView(self.drivers[0]), SignInView(self.drivers[1])
@@ -106,7 +108,8 @@ class TestPublicChatMultipleDevice(MultipleDeviceTestCase):
 class TestPublicChatSingleDevice(SingleDeviceTestCase):
 
     @marks.skip
-    @marks.testrail_id(3752)
+    @marks.testrail_id(5392)
+    @marks.high
     def test_send_korean_characters(self):
         sign_in = SignInView(self.driver)
         home = sign_in.create_user()

--- a/test/appium/tests/atomic/dapps_and_browsing/test_browsing.py
+++ b/test/appium/tests/atomic/dapps_and_browsing/test_browsing.py
@@ -7,7 +7,8 @@ from views.sign_in_view import SignInView
 @pytest.mark.all
 class TestBrowsing(SingleDeviceTestCase):
 
-    @marks.testrail_id(1411)
+    @marks.testrail_id(5424)
+    @marks.medium
     def test_browse_page_with_non_english_text(self):
         sign_in = SignInView(self.driver)
         home_view = sign_in.create_user()
@@ -21,7 +22,8 @@ class TestBrowsing(SingleDeviceTestCase):
         for wiki_text in wiki_texts:
             browsing_view.find_text_part(wiki_text, 15)
 
-    @marks.testrail_id(2174)
+    @marks.testrail_id(5465)
+    @marks.medium
     def test_open_invalid_link(self):
         sign_in = SignInView(self.driver)
         home_view = sign_in.create_user()
@@ -35,7 +37,8 @@ class TestBrowsing(SingleDeviceTestCase):
         if home_view.element_by_text('Browser').is_element_displayed():
             pytest.fail('Browser entity is shown for an invalid link')
 
-    @marks.testrail_id(3705)
+    @marks.testrail_id(5430)
+    @marks.medium
     def test_connection_is_not_secure(self):
         sign_in = SignInView(self.driver)
         home_view = sign_in.create_user()
@@ -47,7 +50,8 @@ class TestBrowsing(SingleDeviceTestCase):
         browsing_view.url_edit_box_lock_icon.click()
         browsing_view.find_full_text(connection_not_secure_text)
 
-    @marks.testrail_id(3814)
+    @marks.testrail_id(5402)
+    @marks.high
     def test_connection_is_secure(self):
         sign_in = SignInView(self.driver)
         home_view = sign_in.create_user()
@@ -66,7 +70,8 @@ class TestBrowsing(SingleDeviceTestCase):
         browsing_view.url_edit_box_lock_icon.click()
         browsing_view.find_full_text(connection_is_secure_text)
 
-    @marks.testrail_id(3731)
+    @marks.testrail_id(5390)
+    @marks.high
     def test_swipe_to_delete_browser_entry(self):
         sign_in = SignInView(self.driver)
         home_view = sign_in.create_user()
@@ -81,8 +86,8 @@ class TestBrowsing(SingleDeviceTestCase):
         if home_view.get_chat_with_user('Browser').is_element_present(20):
             pytest.fail('The browser entry is present after re-login')
 
-    @marks.testrail_id(1396)
-    @marks.smoke_1
+    @marks.testrail_id(5320)
+    @marks.critical
     def test_open_google_com_via_open_dapp(self):
         sign_in_view = SignInView(self.driver)
         home = sign_in_view.create_user()
@@ -94,8 +99,8 @@ class TestBrowsing(SingleDeviceTestCase):
         browsing_view.wait_for_d_aap_to_load()
         browsing_view.element_by_text('Google').find_element()
 
-    @marks.testrail_id(1397)
-    @marks.smoke_1
+    @marks.testrail_id(5321)
+    @marks.critical
     def test_back_forward_buttons_browsing_website(self):
         sign_in = SignInView(self.driver)
         home = sign_in.create_user()
@@ -115,8 +120,8 @@ class TestBrowsing(SingleDeviceTestCase):
         browsing_view.find_text_part('Избранная статья')
         browsing_view.back_to_home_button.click()
 
-    @marks.testrail_id(3783)
-    @marks.smoke_1
+    @marks.testrail_id(5354)
+    @marks.critical
     def test_refresh_button_browsing_app_webview(self):
         sign_in_view = SignInView(self.driver)
         sign_in_view.create_user()

--- a/test/appium/tests/atomic/dapps_and_browsing/test_dapps.py
+++ b/test/appium/tests/atomic/dapps_and_browsing/test_dapps.py
@@ -8,8 +8,8 @@ from views.sign_in_view import SignInView
 @pytest.mark.all
 class TestDApps(SingleDeviceTestCase):
 
-    @marks.testrail_id(3782)
-    @marks.smoke_1
+    @marks.testrail_id(5353)
+    @marks.critical
     def test_filters_from_daap(self):
         sign_in_view = SignInView(self.driver)
         sign_in_view.create_user()
@@ -21,7 +21,8 @@ class TestDApps(SingleDeviceTestCase):
             if element.is_element_displayed(10):
                 pytest.fail("'Test filters' button produced an error")
 
-    @marks.testrail_id(3789)
+    @marks.testrail_id(5397)
+    @marks.high
     def test_request_public_key_status_test_daap(self):
         user = basic_user
         sign_in_view = SignInView(self.driver)

--- a/test/appium/tests/atomic/dapps_and_browsing/test_deep_links.py
+++ b/test/appium/tests/atomic/dapps_and_browsing/test_deep_links.py
@@ -9,7 +9,8 @@ from views.sign_in_view import SignInView
 
 class TestDeepLinks(SingleDeviceTestCase):
 
-    @marks.testrail_id(3781)
+    @marks.testrail_id(5396)
+    @marks.high
     def test_open_public_chat_using_deep_link(self):
         sign_in_view = SignInView(self.driver)
         sign_in_view.create_user()

--- a/test/appium/tests/atomic/transactions/test_daaps_transactions.py
+++ b/test/appium/tests/atomic/transactions/test_daaps_transactions.py
@@ -8,8 +8,8 @@ from views.sign_in_view import SignInView
 
 class TestTransactionDApp(SingleDeviceTestCase):
 
-    @marks.testrail_id(769)
-    @marks.smoke_1
+    @marks.testrail_id(5309)
+    @marks.critical
     def test_send_transaction_from_daap(self):
         sender = transaction_senders['K']
         sign_in_view = SignInView(self.driver)
@@ -26,8 +26,8 @@ class TestTransactionDApp(SingleDeviceTestCase):
         send_transaction_view.sign_transaction()
         self.network_api.verify_balance_is_updated(initial_balance, address)
 
-    @marks.testrail_id(3716)
-    @marks.smoke_1
+    @marks.testrail_id(5342)
+    @marks.critical
     def test_sign_message_from_daap(self):
         password = 'password_for_daap'
         sign_in_view = SignInView(self.driver)
@@ -42,8 +42,8 @@ class TestTransactionDApp(SingleDeviceTestCase):
         send_transaction_view.enter_password_input.send_keys(password)
         send_transaction_view.sign_transaction_button.click()
 
-    @marks.testrail_id(3696)
-    @marks.smoke_1
+    @marks.testrail_id(5333)
+    @marks.critical
     def test_deploy_contract_from_daap(self):
         sender = transaction_senders['L']
         sign_in_view = SignInView(self.driver)
@@ -61,7 +61,8 @@ class TestTransactionDApp(SingleDeviceTestCase):
                 pytest.fail('Contract was not created')
 
     @marks.logcat
-    @marks.testrail_id(3772)
+    @marks.testrail_id(5418)
+    @marks.critical
     def test_logcat_send_transaction_from_daap(self):
         sender = transaction_senders['M']
         sign_in_view = SignInView(self.driver)
@@ -76,7 +77,8 @@ class TestTransactionDApp(SingleDeviceTestCase):
         send_transaction_view.check_no_values_in_logcat(password=unique_password)
 
     @marks.logcat
-    @marks.testrail_id(3775)
+    @marks.testrail_id(5420)
+    @marks.critical
     def test_logcat_sign_message_from_daap(self):
         sign_in_view = SignInView(self.driver)
         sign_in_view.create_user(password=unique_password)
@@ -90,8 +92,8 @@ class TestTransactionDApp(SingleDeviceTestCase):
         send_transaction_view.sign_transaction_button.click()
         send_transaction_view.check_no_values_in_logcat(password=unique_password)
 
-    @marks.testrail_id(1380)
-    @marks.smoke_1
+    @marks.testrail_id(5372)
+    @marks.high
     def test_request_eth_in_status_test_dapp(self):
         sign_in_view = SignInView(self.driver)
         sign_in_view.create_user()

--- a/test/appium/tests/atomic/transactions/test_wallet.py
+++ b/test/appium/tests/atomic/transactions/test_wallet.py
@@ -11,8 +11,8 @@ from views.sign_in_view import SignInView
 @marks.transaction
 class TestTransactionWalletSingleDevice(SingleDeviceTestCase):
 
-    @marks.testrail_id(766)
-    @marks.smoke_1
+    @marks.testrail_id(5307)
+    @marks.critical
     def test_send_eth_from_wallet_to_contact(self):
         recipient = basic_user
         sender = transaction_senders['N']
@@ -36,8 +36,8 @@ class TestTransactionWalletSingleDevice(SingleDeviceTestCase):
         send_transaction.sign_transaction()
         self.network_api.find_transaction_by_unique_amount(sender['address'], transaction_amount)
 
-    @marks.testrail_id(767)
-    @marks.smoke_1
+    @marks.testrail_id(5308)
+    @marks.critical
     def test_send_eth_from_wallet_to_address(self):
         recipient = basic_user
         sender = transaction_senders['P']
@@ -57,8 +57,8 @@ class TestTransactionWalletSingleDevice(SingleDeviceTestCase):
         send_transaction.sign_transaction()
         self.network_api.find_transaction_by_unique_amount(sender['address'], transaction_amount)
 
-    @marks.testrail_id(1430)
-    @marks.smoke_1
+    @marks.testrail_id(5325)
+    @marks.critical
     def test_send_stt_from_wallet(self):
         recipient = basic_user
         sender = transaction_senders['Q']
@@ -84,7 +84,8 @@ class TestTransactionWalletSingleDevice(SingleDeviceTestCase):
         send_transaction.sign_transaction()
         self.network_api.find_transaction_by_unique_amount(recipient['address'], amount, token=True)
 
-    @marks.testrail_id(2164)
+    @marks.testrail_id(5408)
+    @marks.high
     def test_transaction_wrong_password_wallet(self):
         recipient = basic_user
         sender = wallet_users['A']
@@ -135,7 +136,8 @@ class TestTransactionWalletSingleDevice(SingleDeviceTestCase):
         transactions_view = wallet_view.transaction_history_button.click()
         transactions_view.transactions_table.find_transaction(amount=transaction_amount)
 
-    @marks.testrail_id(2163)
+    @marks.testrail_id(5461)
+    @marks.medium
     def test_send_eth_from_wallet_incorrect_address(self):
         recipient = basic_user
         sender = wallet_users['B']
@@ -156,7 +158,8 @@ class TestTransactionWalletSingleDevice(SingleDeviceTestCase):
         send_transaction.find_text_part('Invalid address:', 20)
 
     @marks.logcat
-    @marks.testrail_id(3770)
+    @marks.testrail_id(5416)
+    @marks.critical
     def test_logcat_send_transaction_from_wallet(self):
         sender = transaction_senders['R']
         recipient = basic_user
@@ -177,8 +180,8 @@ class TestTransactionWalletSingleDevice(SingleDeviceTestCase):
         send_transaction.sign_transaction(unique_password)
         send_transaction.check_no_values_in_logcat(password=unique_password)
 
-    @marks.testrail_id(3746)
-    @marks.smoke_1
+    @marks.testrail_id(5350)
+    @marks.critical
     def test_send_token_with_7_decimals(self):
         sender = transaction_senders['S']
         recipient = basic_user
@@ -204,8 +207,8 @@ class TestTransactionWalletSingleDevice(SingleDeviceTestCase):
         send_transaction.sign_transaction()
         self.network_api.find_transaction_by_unique_amount(recipient['address'], amount, token=True, decimals=7)
 
-    @marks.testrail_id(3747)
-    @marks.smoke_1
+    @marks.testrail_id(5351)
+    @marks.critical
     def test_token_with_more_than_allowed_decimals(self):
         sender = wallet_users['C']
         sign_in_view = SignInView(self.driver)
@@ -233,7 +236,8 @@ class TestTransactionWalletSingleDevice(SingleDeviceTestCase):
             self.errors.append('Warning about too precise amount is not shown when requesting a transaction')
         self.verify_no_errors()
 
-    @marks.testrail_id(1405)
+    @marks.testrail_id(5423)
+    @marks.medium
     def test_send_valid_amount_after_insufficient_funds_error(self):
         sender = transaction_senders['T']
         sign_in_view = SignInView(self.driver)
@@ -258,7 +262,8 @@ class TestTransactionWalletSingleDevice(SingleDeviceTestCase):
         send_transaction.sign_transaction()
         self.network_api.find_transaction_by_unique_amount(sender['address'], valid_amount)
 
-    @marks.testrail_id(3764)
+    @marks.testrail_id(5471)
+    @marks.medium
     def test_insufficient_funds_wallet_0_balance(self):
         sign_in_view = SignInView(self.driver)
         sign_in_view.create_user()
@@ -276,7 +281,8 @@ class TestTransactionWalletSingleDevice(SingleDeviceTestCase):
             self.errors.append("'Insufficient funds' error is now shown when sending 1 STT from wallet with balance 0")
         self.verify_no_errors()
 
-    @marks.testrail_id(3792)
+    @marks.testrail_id(5412)
+    @marks.high
     def test_insufficient_funds_wallet_positive_balance(self):
         sender = wallet_users['A']
         sign_in_view = SignInView(self.driver)
@@ -304,7 +310,8 @@ class TestTransactionWalletSingleDevice(SingleDeviceTestCase):
                     round(stt_value + 1), stt_value))
         self.verify_no_errors()
 
-    @marks.testrail_id(3728)
+    @marks.testrail_id(5359)
+    @marks.critical
     def test_modify_transaction_fee_values(self):
         sender = transaction_senders['U']
         sign_in_view = SignInView(self.driver)
@@ -360,8 +367,8 @@ class TestTransactionWalletSingleDevice(SingleDeviceTestCase):
 @marks.transaction
 class TestTransactionWalletMultipleDevice(MultipleDeviceTestCase):
 
-    @marks.testrail_id(3761)
-    @marks.smoke_1
+    @marks.testrail_id(5378)
+    @marks.high
     def test_transaction_message_sending_from_wallet(self):
         recipient = transaction_recipients['E']
         sender = transaction_senders['V']

--- a/test/appium/tests/marks.py
+++ b/test/appium/tests/marks.py
@@ -3,7 +3,10 @@ import pytest
 pr = pytest.mark.pr
 testrail_case_id = pytest.mark.testrail_case_id
 testrail_id = pytest.mark.testrail_id  # atomic tests
-smoke_1 = pytest.mark.smoke_1
+critical = pytest.mark.critical
+high = pytest.mark.high
+medium = pytest.mark.medium
+low = pytest.mark.low
 
 account = pytest.mark.account
 all = pytest.mark.all


### PR DESCRIPTION
Status: Ready implements https://github.com/status-im/status-react/issues/6003
In order to send autotest results to a new testrail project:

- Updated all ids from old test suite to test case ids from a new testsuite (new test suite data https://ethstatus.testrail.net/index.php?/suites/view/48)
- Updated testrail_report.py to use the new project 
- marks.status_1 replaced by marks.critical (we'll need to update Jenkins to use it as the default option for PR too)