### PR TITLE
Add re-natal commands to make prepare-desktop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,9 @@ setup: ##@prepare Install all the requirements for status-react
 prepare-desktop: ##@prepare Install desktop platform dependencies and prepare workspace
 	scripts/prepare-for-platform.sh desktop
 	npm install
+	ln -sf './node_modules/re-natal/index.js' './re-natal'
+	./re-natal use-figwheel
+	./re-natal enable-source-maps
 
 _prepare-mobile: ##@prepare Install mobile platform dependencies and prepare workspace
 	scripts/prepare-for-platform.sh mobile

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,8 @@ setup: ##@prepare Install all the requirements for status-react
 prepare-desktop: ##@prepare Install desktop platform dependencies and prepare workspace
 	scripts/prepare-for-platform.sh desktop
 	npm install
+
+dev-desktop: prepare-desktop
 	ln -sf './node_modules/re-natal/index.js' './re-natal'
 	./re-natal use-figwheel
 	./re-natal enable-source-maps


### PR DESCRIPTION
Minor convenience: add `dev-desktop` target that runs `prepare-desktop` and sets up `re-natal`.