### PR TITLE
[fix 6052] check empty filters

### DIFF
--- a/src/status_im/transport/filters.cljs
+++ b/src/status_im/transport/filters.cljs
@@ -65,4 +65,4 @@
  :shh/remove-filters
  (fn [filters]
    (doseq [filter filters]
-     (remove-filter! filter))))
+     (when filter (remove-filter! filter)))))


### PR DESCRIPTION
fixes #6052

# steps to test

- add custom mailserver that doesn't exist (I assume it's the easiest way to have mailserver connection error
- logout

status: ready
