### PR TITLE
[fix 6051] log error during connexion and pass cofx

### DIFF
--- a/src/status_im/transport/handlers.cljs
+++ b/src/status_im/transport/handlers.cljs
@@ -46,7 +46,8 @@
                                      (receive-message now-in-s chat-id message))
                                    (js-array->seq js-messages))]
       (apply fx/merge cofx receive-message-fxs))
-    (log/error "Something went wrong" js-error js-messages)))
+    (do (log/error "Something went wrong" js-error js-messages)
+        cofx)))
 
 (handlers/register-handler-fx
  :protocol/receive-whisper-message

--- a/test/cljs/status_im/test/transport/handlers.cljs
+++ b/test/cljs/status_im/test/transport/handlers.cljs
@@ -15,9 +15,9 @@
 
 (deftest receive-whisper-messages-test
   (testing "an error is reported"
-    (is (nil? (handlers/receive-whisper-messages {:db {}} "error" #js [] nil))))
+    (is (nil? (:chat-received-message/add-fx (handlers/receive-whisper-messages {:db {}} "error" #js [] nil)))))
   (testing "messages is undefined"
-    (is (nil? (handlers/receive-whisper-messages {:db {}} nil js/undefined nil))))
+    (is (nil? (:chat-received-message/add-fx (handlers/receive-whisper-messages {:db {}} nil js/undefined nil)))))
   (testing "happy path"
     (let [actual (handlers/receive-whisper-messages {:db {}} nil messages sig)]
       (testing "it add an fx for the message"


### PR DESCRIPTION
fixes #6051 

### Steps to test:
- login to an account that has a contact
- leave the app
- send a message with another account on another phone to the first account after some time so that status have been long enough in the background to be logged out
- tap on notification to open status and try to login

status: ready <!-- Can be ready or wip -->
