### PR TITLE
feature #4255 - backup recovery phrase in desktop app

### DIFF
--- a/src/status_im/ui/components/desktop/tabs.cljs
+++ b/src/status_im/ui/components/desktop/tabs.cljs
@@ -53,11 +53,12 @@
                                 :disabled active?
                                 :on-press #(re-frame/dispatch [:show-desktop-tab view-id])}
      [react/view
-      [content active? (if (= view-id :home) cnt nil)]]]))
+      [content active? cnt]]]))
 
 (views/defview main-tabs []
   (views/letsubs [current-tab [:get-in [:desktop/desktop :tab-view-id]]]
     [react/view
      [react/view {:style tabs.styles/tabs-container}
       (for [[index {:keys [content view-id count-subscription]}] tabs-list-indexed]
-        ^{:key index} [tab index content view-id (= current-tab view-id) count-subscription])]]))
+        ^{:key index}
+        [tab index content view-id (= current-tab view-id) count-subscription])]]))

--- a/src/status_im/ui/screens/desktop/main/views.cljs
+++ b/src/status_im/ui/screens/desktop/main/views.cljs
@@ -30,6 +30,7 @@
                       :qr-code      profile.views/qr-code
                       :advanced-settings profile.views/advanced-settings
                       :chat-profile chat.views/chat-profile
+                      :backup-recovery-phrase profile.views/backup-recovery-phrase
                       status-view)]
       [react/view {:style {:flex 1}}
        [component]])))

--- a/src/status_im/ui/screens/desktop/views.cljs
+++ b/src/status_im/ui/screens/desktop/views.cljs
@@ -24,9 +24,11 @@
                       :contact-toggle-list contact-toggle-list
                       (:new-contact
                        :advanced-settings
-                       :chat :home
+                       :chat
+                       :home
                        :qr-code
-                       :chat-profile) main.views/main-views
+                       :chat-profile
+                       :backup-recovery-phrase) main.views/main-views
                       :login login.views/login
                       react/view)]
       [react/view {:style {:flex 1}}

--- a/src/status_im/ui/screens/profile/navigation.cljs
+++ b/src/status_im/ui/screens/profile/navigation.cljs
@@ -9,10 +9,6 @@
                                   :source  source
                                   :value   value})))
 
-(defmethod navigation/preload-data! :backup-seed
-  [db]
-  (assoc db :my-profile/seed {:step :intro}))
-
 (defmethod navigation/unload-data! :my-profile
   [db]
   (dissoc db :my-profile/editing?))

--- a/src/status_im/ui/screens/profile/seed/styles.cljs
+++ b/src/status_im/ui/screens/profile/seed/styles.cljs
@@ -37,7 +37,7 @@
   {:flex-direction :row})
 
 (def six-word-num
-  {:width          20
+  {:width          25
    :text-align     :right
    :opacity        0.4
    :font-size      15

--- a/src/status_im/ui/screens/profile/subs.cljs
+++ b/src/status_im/ui/screens/profile/subs.cljs
@@ -1,21 +1,27 @@
 (ns status-im.ui.screens.profile.subs
-  (:require [re-frame.core :refer [reg-sub]]
+  (:require [re-frame.core :as re-frame]
             [clojure.string :as string]
             [status-im.utils.build :as build]
             [status-im.utils.platform :as platform]))
 
-(reg-sub
+(re-frame/reg-sub
  :get-profile-unread-messages-number
  :<- [:get-current-account]
  (fn [{:keys [seed-backed-up? mnemonic]}]
    (if (or seed-backed-up? (string/blank? mnemonic)) 0 1)))
 
-(reg-sub
+(re-frame/reg-sub
  :get-app-version
  (fn [{:keys [web3-node-version]}]
    (let [version (if platform/desktop? build/version build/build-no)]
      (str build/version " (" version "); node " (or web3-node-version "N/A") ""))))
 
-(reg-sub :get-device-UUID
-         (fn [db]
-           (:device-UUID db)))
+(re-frame/reg-sub
+ :get-device-UUID
+ (fn [db]
+   (:device-UUID db)))
+
+(re-frame/reg-sub
+ :my-profile/recovery
+ (fn [db]
+   (or (:my-profile/seed db) {:step :intro})))


### PR DESCRIPTION
fixes #4255 

### Summary:

Adds the option to Backup recovery phrase in user profile, the same way it works in mobile app.

### Testing notes (optional):
The image is intentionally omitted from the first (intro) step, due to an issue with screen dimensions on desktop.

### Steps to test:
- Upgrade desktop app with existing account and then back up the recovery phrase from Profile
- Create an account on desktop and back up the recovery phrase
- Try recovering it either on another desktop or on mobile
- Double check that recovery phrase backup is still ok on mobile 

status: ready