### PR TITLE
fix login after logout when opening app from a notification

### DIFF
--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -56,7 +56,7 @@
 (handlers/register-handler-fx
  :init/app-started
  (fn [cofx _]
-   (init/initialize-keychain cofx)))
+   (init/start-app cofx)))
 
 (handlers/register-handler-fx
  :init.callback/get-encryption-key-success
@@ -664,11 +664,6 @@
  :notifications/notification-event-received
  (fn [cofx [_ event]]
    (notifications/handle-push-notification cofx event)))
-
-(handlers/register-handler-fx
- :notifications.callback/notification-stored
- (fn [cofx _]
-   (accounts.login/user-login cofx)))
 
 (handlers/register-handler-fx
  :notifications.callback/get-fcm-token-success

--- a/src/status_im/notifications/core.cljs
+++ b/src/status_im/notifications/core.cljs
@@ -3,6 +3,7 @@
             [re-frame.core :as re-frame]
             [status-im.react-native.js-dependencies :as rn]
             [taoensso.timbre :as log]
+            [status-im.accounts.login.core :as accounts.login]
             [status-im.chat.models :as chat-model]
             [status-im.utils.platform :as platform]
             [status-im.utils.fx :as fx]))
@@ -73,26 +74,14 @@
           (then #(log/debug "Notification channel created:" channel-id)
                 #(log/error "Notification channel creation error:" channel-id %)))))
 
-  (fx/defn store-event [{:keys [db] :as cofx} {:keys [from to]}]
-    (let [{:keys [address photo-path name]} (->> (get-in cofx [:db :accounts/accounts])
-                                                 vals
-                                                 (filter #(= (:public-key %) to))
-                                                 first)]
-      (when address
-        {:db       (assoc-in db [:push-notifications/stored to] from)
-         :dispatch [:notifications.callback/notification-stored address photo-path name]})))
-
   (fx/defn handle-push-notification
     [{:keys [db] :as cofx} {:keys [from to] :as event}]
     (let [current-public-key (get-in cofx [:db :current-public-key])]
-      (if current-public-key
-        ;; TODO(yenda) why do we ignore the notification if
-        ;; it is not for the current account ?
-        (when (= to current-public-key)
-          (fx/merge cofx
-                    {:db (update db :push-notifications/stored dissoc to)}
-                    (chat-model/navigate-to-chat from nil)))
-        (store-event cofx event))))
+      (if (= to current-public-key)
+        (fx/merge cofx
+                  {:db (update db :push-notifications/stored dissoc to)}
+                  (chat-model/navigate-to-chat from nil))
+        {:db (assoc-in db [:push-notifications/stored to] from)})))
 
   (defn parse-notification-payload [s]
     (try


### PR DESCRIPTION
moves most of the fx that are suppose to happen only at app startup
to an init/start-app fn so that init/initialize-app which is also
called after logout doesn't repeat unecessary fxs

### Steps to test:
- Open Status from notification, make sure the app was previously closed and you have to login after opening the app from the notification
- logout
- you should be able to login again (in current develop you would have a spinner and won't be able to type password)

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->
