### PR TITLE
add dependency on libcairo2-dev

### DIFF
--- a/desktop/docker/Dockerfile
+++ b/desktop/docker/Dockerfile
@@ -38,7 +38,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install curl software-p
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
       wget git unzip golang-go nodejs yarn file python \
       apt-transport-https locales openjdk-8-jdk-headless \
-      extra-cmake-modules build-essential gcc g++ fuse \
+      extra-cmake-modules build-essential gcc g++ fuse libcairo2-dev \
       libx11-xcb1 libxss1 libasound2 libgl-dev libsm6 libxrandr2 python-dev \
       libjasper-dev libegl1-mesa libxcomposite-dev libxcursor-dev && \
     locale-gen en_US.UTF-8 && \


### PR DESCRIPTION
Necessary for desktop builds.
Of course I will also have to build a new image and push it.