### PR TITLE
[#4779] fix Bootnodes are shown as enabled when they are not

### DIFF
--- a/src/status_im/ui/screens/profile/components/views.cljs
+++ b/src/status_im/ui/screens/profile/components/views.cljs
@@ -103,6 +103,6 @@
    [react/view styles/settings-item-text-wrapper
     [react/i18n-text {:style styles/settings-item-text :key label-kw}]]
    [react/switch {:on-tint-color   colors/blue
-                  :value           value
+                  :value           (boolean value)
                   :on-value-change action-fn
                   :disabled        (not active?)}]])


### PR DESCRIPTION
fix #4779

status: ready 
