### PR TITLE
Ensure version compatibility

### DIFF
--- a/src/status_im/transport/message/transit.cljs
+++ b/src/status_im/transport/message/transit.cljs
@@ -46,9 +46,12 @@
 
 (deftype MessageHandler []
   Object
-  (tag [this v] "c7")
+  (tag [this v] "c4")
   (rep [this {:keys [content content-type message-type clock-value timestamp]}]
-    #js [content content-type message-type clock-value timestamp]))
+    (if (= content-type constants/text-content-type)
+      ;; append new content add the end, still pass content the old way at the old index
+      #js [(:text content) content-type message-type clock-value timestamp content]
+      #js [content content-type message-type clock-value timestamp content])))
 
 (deftype MessagesSeenHandler []
   Object
@@ -102,8 +105,8 @@
                                      (v1.contact/ContactRequest. name profile-image address fcm-token))
                               "c3" (fn [[name profile-image address fcm-token]]
                                      (v1.contact/ContactRequestConfirmed. name profile-image address fcm-token))
-                              "c4" (fn [[content content-type message-type clock-value timestamp]]
-                                     (v1.protocol/Message. (safe-content-parse content-type content) content-type message-type clock-value timestamp))
+                              "c4" (fn [[legacy-content content-type message-type clock-value timestamp content]]
+                                     (v1.protocol/Message. (safe-content-parse content-type (or content legacy-content)) content-type message-type clock-value timestamp))
                               "c7" (fn [[content content-type message-type clock-value timestamp]]
                                      (v1.protocol/Message. (safe-content-parse content-type content) content-type message-type clock-value timestamp))
                               "c5" (fn [message-ids]


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

Fixes recently introduced incompatibility between newer and older status version.

To test this, just create a new chat and write some messages there from this build. Join the chat from other device (older release) and test that message is received just fine (and vice versa), then check that it's the case for current nightly as well.

status: ready
