### PR TITLE
upload PR build artifacts to a separate bucket

### DIFF
--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -17,7 +17,8 @@ pipeline {
         println "Current JOB: ${env.JOB_NAME}"
         /* load common lib */
         cmn = load('ci/common.groovy')
-
+        /* just for a shorter access */
+        btype = cmn.getBuildType() 
         /* to avoid missing build tag parallel builds */
         print "Build Number: ${cmn.tagBuild(true)}"
       } }
@@ -25,20 +26,20 @@ pipeline {
     stage('Build') {
       parallel {
         stage('MacOS') {
-        when { expression { cmn.getBuildType() != 'release' } }
+        when { expression { btype != 'release' } }
         steps { script {
-          osx = cmn.buildBranch('status-react/combined/desktop-macos', cmn.getBuildType())
+          osx = cmn.buildBranch('status-react/combined/desktop-macos')
         } } }
         stage('Linux') {
-        when { expression { cmn.getBuildType() != 'release' } }
+        when { expression { btype != 'release' } }
         steps { script {
-          nix = cmn.buildBranch('status-react/combined/desktop-linux', cmn.getBuildType())
+          nix = cmn.buildBranch('status-react/combined/desktop-linux')
         } } }
         stage('iOS') { steps { script {
-          ios = cmn.buildBranch('status-react/combined/mobile-ios', cmn.getBuildType())
+          ios = cmn.buildBranch('status-react/combined/mobile-ios')
         } } }
         stage('Android') { steps { script {
-          dro = cmn.buildBranch('status-react/combined/mobile-android', cmn.getBuildType())
+          dro = cmn.buildBranch('status-react/combined/mobile-android')
         } } }
         stage('Android e2e') { steps { script {
           e2e = cmn.buildBranch('status-react/combined/mobile-android', 'e2e')
@@ -49,29 +50,38 @@ pipeline {
       steps { script {
         sh('rm -f pkg/*')
 
-        if (cmn.getBuildType() != 'release') {
+        if (btype != 'release') {
           cmn.copyArts('status-react/combined/desktop-macos', osx.number)
           cmn.copyArts('status-react/combined/desktop-linux', nix.number)
         }
         cmn.copyArts('status-react/combined/mobile-android', dro.number)
         cmn.copyArts('status-react/combined/mobile-android', e2e.number)
+        cmn.copyArts('status-react/combined/mobile-ios', ios.number)
         archiveArtifacts('pkg/*')
       } }
     }
     stage('Upload') {
       steps { script {
-        e2eUrl = cmn.uploadArtifact(findFiles(glob: 'pkg/*e2e.apk')[0].path)
-        apkUrl = cmn.uploadArtifact(findFiles(glob: "pkg/*${cmn.getBuildType()}.apk")[0].path)
+        e2eUrl = cmn.uploadArtifact(cmn.pkgFind('e2e.apk'))
+        apkUrl = cmn.uploadArtifact(cmn.pkgFind("${btype}.apk"))
 
-        if (cmn.getBuildType() != 'release') {
-          dmgUrl = cmn.uploadArtifact(findFiles(glob: 'pkg/*.dmg')[0].path)
-          appUrl = cmn.uploadArtifact(findFiles(glob: 'pkg/*.AppImage')[0].path)
+        if (btype != 'release') {
+          dmgUrl = cmn.uploadArtifact(cmn.pkgFind('dmg'))
+          appUrl = cmn.uploadArtifact(cmn.pkgFind('AppImage'))
         } else {
           dmgUrl = null
           appUrl = null
         }
         /* special case for iOS Diawi links */
         ipaUrl = ios.getBuildVariables().get('DIAWI_URL')
+        /* add URLs to the build description */
+        cmn.setBuildDesc(
+          Apk: apkUrl,
+          e2e: e2eUrl,
+          iOS: ipaUrl,
+          App: appUrl,
+          Mac: dmgUrl
+        )
       } }
     }
     stage('Notify') {
@@ -81,7 +91,7 @@ pipeline {
         def message = (
           (env.CHANGE_ID != null ?
             "Build PR #${BRANCH_NAME}(${CHANGE_BRANCH}) success! " :
-            "Build ${cmn.getBuildType()} success! "
+            "Build ${btype} success! "
           )+
           "<${currentBuild.absoluteUrl}|${currentBuild.displayName}> "+
           "(${currentBuild.durationString})\n"+
@@ -110,7 +120,7 @@ pipeline {
     }
     stage('Publish') {
       steps { script {
-        switch (cmn.getBuildType()) {
+        switch (btype) {
           case 'nightly':
             build(
               job: 'misc/status-im.github.io-update_env',
@@ -132,7 +142,7 @@ pipeline {
       } }
     }
     stage('Run e2e') {
-      when { expression { cmn.getBuildType() == 'nightly' } }
+      when { expression { btype == 'nightly' } }
       steps { script {
         e2eApk = e2e.getBuildVariables().get('SAUCE_URL')
           build(


### PR DESCRIPTION
All of our builds end up in the same bucket: `status-im`
https://status-im.ams3.digitaloceanspaces.com/index.html
Which is already ~300 GB in size and really hard to browse through.
I've created a separate bucket named `status-im-prs` so we can keep them separate.
This will also make it easier to clean up old ones we don't care about anymore.

<blockquote></blockquote>