### PR TITLE
[fix #6087] error on empty messages

### DIFF
--- a/src/status_im/ui/screens/chat/message/message.cljs
+++ b/src/status_im/ui/screens/chat/message/message.cljs
@@ -52,8 +52,9 @@
 (def rtl-characters-regex #"[^\u0591-\u06EF\u06FA-\u07FF\u200F\u202B\u202E\uFB1D-\uFDFD\uFE70-\uFEFC]*?[\u0591-\u06EF\u06FA-\u07FF\u200F\u202B\u202E\uFB1D-\uFDFD\uFE70-\uFEFC]")
 
 (defn right-to-left-text? [content]
-  (let [char (first content)]
-    (re-matches rtl-characters-regex char)))
+  (when-not (empty? content)
+    (let [char (first content)]
+      (re-matches rtl-characters-regex char))))
 
 (defview message-timestamp [t justify-timestamp? outgoing command? content]
   (when-not command?


### PR DESCRIPTION
fix #6087 

add a guard so that `right-to-left-text?` function doesn't throw
an error on empty content

future empty messages aren't going to pass validation

### Steps to test:
- Upgrade an version of status affected by the bug described in #6087 
- Bug shouldn't be there anymore when reopening chat with empty messages (#status)

status: ready
