### PR TITLE
Desktop chat replies

### DIFF
--- a/src/status_im/ui/screens/desktop/main/chat/styles.cljs
+++ b/src/status_im/ui/screens/desktop/main/chat/styles.cljs
@@ -132,6 +132,9 @@
 (def message-text
   {:font-size 14})
 
+(def message-container
+  {:flex-direction  :column})
+
 (def message-wrapper
   {:flex-direction  :row
    :flex-wrap       :wrap})
@@ -208,3 +211,51 @@
   {:margin-bottom  4
    :font-size      14
    :color          colors/black})
+
+(def reply-wrapper
+  {:flex-direction :column-reverse})
+
+(def reply-photo-style
+  {:width         40
+   :height        40
+   :margin-right  5})
+
+(def reply-container
+  {:flex-direction   :row
+   :align-items      :flex-start
+   :border-width     1
+   :border-radius    10
+   :border-color     colors/gray-light
+   :margin           10})
+
+(def reply-content-container
+  {:flex-direction :column
+   :padding-bottom 10})
+
+(def reply-content-author
+  {:margin-top     5
+   :color          colors/gray
+   :font-size      12
+   :padding-bottom 3})
+
+(def reply-content-message
+  {:padding-left   7
+   :margin-right   50
+   :max-height     140
+   :overflow       :scroll})
+
+(def reply-close-highlight
+  {:position :absolute
+   :z-index  5
+   :top      3
+   :right    8
+   :height   26})
+
+(def reply-close-icon
+  {:border-radius     12
+   :background-color  colors/gray
+   :tint-color        colors/white})
+
+(defn reply-icon [outgoing]
+  {:tint-color (if outgoing colors/wild-blue-yonder colors/gray)})
+


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

Implements #4608 for desktop, for now with little bit crude styling, till we get proper styles for desktop, especially for reply input box.

What differs from mobile is also how you reply to some message, in absence of the pop-up menu (will be done soon), it's done by clicking on message body which you want to quote.

### Steps to test:
No upgrade or compatibility testing necessary (that was already fully solved by mobile PR), just making sure that message replies/reply input is displayed correctly in all cases and all types of chat

status: ready
