### PR TITLE
Display 3-word names even for known contacts (and for yourself).

### DIFF
--- a/src/status_im/ui/screens/chat/input/input.cljs
+++ b/src/status_im/ui/screens/chat/input/input.cljs
@@ -10,6 +10,7 @@
             [status-im.ui.screens.chat.input.suggestions :as suggestions]
             [status-im.ui.screens.chat.input.validation-messages :as validation-messages]
             [status-im.ui.screens.chat.photos :as photos]
+            [status-im.ui.screens.chat.utils :as chat-utils]
             [status-im.i18n :as i18n]
             [status-im.ui.components.animation :as animation]
             [status-im.ui.components.colors :as colors]
@@ -108,10 +109,7 @@
   (letsubs [username           [:get-contact-name-by-identity from]
             current-public-key [:get-current-public-key]]
     [react/view {:style style/reply-message-content}
-     [react/text {:style style/reply-message-author} (or (and (= from current-public-key)
-                                                              (i18n/label :t/You))
-                                                         username
-                                                         (gfycat/generate-gfy from))]
+     [react/text {:style style/reply-message-author} (chat-utils/format-reply-author from username current-public-key)]
      [react/text {:style message-style/style-message-text} message-text]]))
 
 (defview reply-message-view []

--- a/src/status_im/ui/screens/chat/message/message.cljs
+++ b/src/status_im/ui/screens/chat/message/message.cljs
@@ -15,6 +15,7 @@
             [status-im.constants :as constants]
             [status-im.ui.components.chat-icon.screen :as chat-icon.screen]
             [status-im.utils.core :as utils]
+            [status-im.ui.screens.chat.utils :as chat-utils]
             [status-im.utils.identicon :as identicon]
             [status-im.utils.gfycat.core :as gfycat]
             [status-im.utils.platform :as platform]
@@ -171,10 +172,8 @@
     [react/view {:style (style/quoted-message-container outgoing)}
      [react/view {:style style/quoted-message-author-container}
       [vector-icons/icon :icons/reply {:color (if outgoing colors/wild-blue-yonder colors/gray)}]
-      [react/text {:style (style/quoted-message-author outgoing)} (or (and (= from current-public-key)
-                                                                           (i18n/label :t/You))
-                                                                      username
-                                                                      (gfycat/generate-gfy from))]]
+      [react/text {:style (style/quoted-message-author outgoing)}
+       (chat-utils/format-reply-author from username current-public-key)]]
      [react/text {:style           (style/quoted-message-text outgoing)
                   :number-of-lines 5}
       text]]))
@@ -328,9 +327,8 @@
 
 (defview message-author-name [from message-username]
   (letsubs [username [:get-contact-name-by-identity from]]
-    [react/text {:style style/message-author-name} (or username
-                                                       message-username
-                                                       (gfycat/generate-gfy from))])) ; TODO: We defensively generate the name for now, to be revisited when new protocol is defined
+    [react/text {:style style/message-author-name}
+     (chat-utils/format-author from (or username message-username))]))
 
 (defn message-body
   [{:keys [last-in-group?

--- a/src/status_im/ui/screens/chat/utils.cljs
+++ b/src/status_im/ui/screens/chat/utils.cljs
@@ -1,0 +1,12 @@
+(ns status-im.ui.screens.chat.utils
+  (:require [status-im.utils.gfycat.core :as gfycat]
+            [status-im.i18n :as i18n]))
+
+(defn format-author [from username]
+  (str (when username (str username " :: "))
+       (gfycat/generate-gfy from))) ; TODO: We defensively generate the name for now, to be revisited when new protocol is defined
+
+(defn format-reply-author [from username current-public-key]
+  (or (and (= from current-public-key) (i18n/label :t/You))
+      (format-author from username)))
+

--- a/src/status_im/ui/screens/desktop/main/chat/views.cljs
+++ b/src/status_im/ui/screens/desktop/main/chat/views.cljs
@@ -8,6 +8,7 @@
             [status-im.utils.gfycat.core :as gfycat.core]
             [taoensso.timbre :as log]
             [reagent.core :as reagent]
+            [status-im.ui.screens.chat.utils :as chat-utils]
             [status-im.utils.gfycat.core :as gfycat]
             [status-im.constants :as constants]
             [status-im.utils.identicon :as identicon]
@@ -69,7 +70,7 @@
 (views/defview message-author-name [{:keys [outgoing from] :as message}]
   (views/letsubs [current-account [:get-current-account]
                   incoming-name   [:get-contact-name-by-identity from]]
-    (let [name (or incoming-name (gfycat/generate-gfy from))]
+    (let [name (chat-utils/format-author from incoming-name)]
       [react/touchable-highlight {:on-press #(re-frame/dispatch [:show-contact-dialog from name (boolean incoming-name)])}
        [react/text {:style styles/author} name]])))
 

--- a/src/status_im/ui/screens/profile/components/styles.cljs
+++ b/src/status_im/ui/screens/profile/components/styles.cljs
@@ -21,6 +21,12 @@
    :ios              {:letter-spacing -0.2}
    :android          {:color colors/black}})
 
+(defstyle profile-three-words
+  {:font-size        12
+   :text-align       :center
+   :ios              {:letter-spacing -0.2}
+   :android          {:color colors/black}})
+
 (defstyle profile-name-input-text
   {:font-size   15
    :text-align  :center

--- a/src/status_im/ui/screens/profile/components/views.cljs
+++ b/src/status_im/ui/screens/profile/components/views.cljs
@@ -7,6 +7,7 @@
             [status-im.ui.components.common.common :as common]
             [status-im.ui.components.icons.vector-icons :as vector-icons]
             [status-im.ui.components.react :as react]
+            [status-im.utils.gfycat.core :as gfy]
             [status-im.ui.components.list-selection :as list-selection]
             [status-im.ui.screens.profile.components.styles :as styles]))
 
@@ -38,7 +39,12 @@
     [react/text {:style           styles/profile-name-text
                  :font            :medium
                  :number-of-lines 1}
-     name]]])
+     name]
+    (when (:public-key contact)
+      [react/text {:style styles/profile-three-words
+                   :font :medium
+                   :number-of-lines 1}
+       (gfy/generate-gfy (:public-key contact))])]])
 
 (defn- profile-header-edit [{:keys [name group-chat] :as contact}
                             icon-options on-change-text-event allow-icon-change?]


### PR DESCRIPTION
For me, it is very annoying to remember who is who taking into account that the data can be lost sometimes. It is much simpler to just remember 3 word names. So let's display them always.

**in someone's profile**
[simulator screen shot - iphone xs max - 2018-10-04 at 11 59 33](https://user-images.githubusercontent.com/466427/46467228-834ec200-c7cd-11e8-980b-45ad22f214fa.png?s=200)

**in your own profile**
[simulator screen shot - iphone xs max - 2018-10-04 at 11 59 39](https://user-images.githubusercontent.com/466427/46467229-834ec200-c7cd-11e8-80ad-3074e693bb25.png?s=200)

**in a chatroom**
[simulator screen shot - iphone xs max - 2018-10-04 at 12 00 11](https://user-images.githubusercontent.com/466427/46467230-834ec200-c7cd-11e8-9a82-2f838234be29.png)


status: ready <!-- Can be ready or wip -->