### PR TITLE
[Fix] python 35 string formatting 

### DIFF
--- a/test/appium/tests/test_general_verifications.py
+++ b/test/appium/tests/test_general_verifications.py
@@ -13,11 +13,11 @@ class TestLinksVerifications(SingleDeviceTestCase):
         no_link_open_error_msg = 'Could not open our privacy policy from'
 
         if not signin_view.privacy_policy_link.is_element_displayed():
-            self.driver.fail(f'{no_link_found_error_msg} Sign in view!')
+            self.driver.fail('{} Sign in view!'.format(no_link_found_error_msg))
 
         base_web_view = signin_view.privacy_policy_link.click()
         if not base_web_view.policy_summary.is_element_displayed():
-            self.errors.append(f'{no_link_open_error_msg} Sign in view!')
+            self.errors.append('{} Sign in view!'.format(no_link_open_error_msg))
 
         base_web_view.click_system_back_button()
         signin_view = SignInView(self.driver)
@@ -27,7 +27,7 @@ class TestLinksVerifications(SingleDeviceTestCase):
         base_web_view = about_view.privacy_policy_button.click()
 
         if not base_web_view.policy_summary.is_element_displayed():
-            self.errors.append(f'{no_link_open_error_msg} Profile about view!')
+            self.errors.append('{} Profile about view!'.format(no_link_open_error_msg))
 
         base_web_view.click_system_back_button()
         if about_view.privacy_policy_button.is_element_displayed():
@@ -38,10 +38,10 @@ class TestLinksVerifications(SingleDeviceTestCase):
         signin_view.other_accounts_button.click()
 
         if not signin_view.privacy_policy_link.is_element_displayed():
-            self.driver.fail(f'{no_link_found_error_msg} Sign in view!')
+            self.driver.fail('{} Sign in view!'.format(no_link_found_error_msg))
 
         base_web_view = signin_view.privacy_policy_link.click()
         if not base_web_view.policy_summary.is_element_displayed():
-            self.errors.append(f'{no_link_open_error_msg} Sign in view!')
+            self.errors.append('{} Sign in view!'.format(no_link_open_error_msg))
 
         self.verify_no_errors()


### PR DESCRIPTION
### Summary:
Just a fix to support python v.3.5 string formatting

### Review notes:
`f'{var}'` style became available since python 3.6 version. so it will fail on evns where the version is lower.