### PR TITLE
[WIP] experiment getTransaction from web3 (#1762)

### DIFF
--- a/src/status_im/ui/screens/wallet/events.cljs
+++ b/src/status_im/ui/screens/wallet/events.cljs
@@ -64,7 +64,8 @@
 (re-frame/reg-fx
  :get-transactions
  (fn [{:keys [web3 chain account-id token-addresses success-event error-event]}]
-   (transactions/get-transactions chain
+   (transactions/get-transactions web3
+                                  chain
                                   account-id
                                   #(re-frame/dispatch [success-event % account-id])
                                   #(re-frame/dispatch [error-event %]))

--- a/src/status_im/utils/ethereum/core.cljs
+++ b/src/status_im/utils/ethereum/core.cljs
@@ -139,6 +139,12 @@
                        (cb result)
                        (handle-error error)))))
 
+(defn get-block-info-with-txs [web3 number cb]
+  (.getBlock (.-eth web3) number :true (fn [error result]
+                                         (if-not error
+                                           (cb (js->clj result :keywordize-keys true))
+                                           (handle-error error)))))
+
 (defn get-block-info [web3 number cb]
   (.getBlock (.-eth web3) number (fn [error result]
                                    (if-not error


### PR DESCRIPTION
This is a PR to show some experiments I did around #1762 

it currently:
- get current block and recursively search for 50 blocks any transaction related to the current account
- prints some stats on stdout. In my iOS simulator take 7.6 seconds to finish, Rinkeby testnet.

as suspected it is very slow. I don't think even a multithreaded solution gathering blocks in parallel can reach an acceptable performance to search for a meaningful time frame in the past (days?).

The hybrid solution to still get transactions from etherscan could be enhanced by adding a lookup on web3 to check them, but txs not returned by etherscan will never be found.

Hope it helps.
Any suggestion on if\how to procede is welcome!