### PR TITLE
Fix tests after wallet modal button moved

### DIFF
--- a/test/appium/tests/atomic/account_management/test_wallet_modal.py
+++ b/test/appium/tests/atomic/account_management/test_wallet_modal.py
@@ -5,7 +5,6 @@ from tests.base_test_case import SingleDeviceTestCase
 from tests.users import wallet_users
 from views.sign_in_view import SignInView
 
-
 @marks.wallet_modal
 class TestWalletModal(SingleDeviceTestCase):
 
@@ -22,6 +21,7 @@ class TestWalletModal(SingleDeviceTestCase):
         stt_value = wallet.get_stt_value()
         home = wallet.home_button.click()
         chat = home.join_public_chat(home.get_public_chat_name())
+        chat.chat_options.click()
         wallet_modal = chat.wallet_modal_button.click()
         if wallet_modal.address_text.text != '0x' + user['address']:
             self.errors.append('Wallet address is not shown in wallet modal')
@@ -51,8 +51,9 @@ class TestWalletModal(SingleDeviceTestCase):
         start_new_chat = home.plus_button.click()
         start_new_chat.open_d_app_button.click()
         start_new_chat.element_by_text('Airswap').click()
-        start_new_chat.open_button.click()
-        wallet_modal = start_new_chat.wallet_modal_button.click()
+        webview = start_new_chat.open_button.click()
+        webview.web_view_menu_button.click()
+        wallet_modal = webview.wallet_modal_button.click()
         if wallet_modal.address_text.text != '0x' + user['address']:
             self.errors.append('Wallet address is not shown in wallet modal')
         modal_usd_value = wallet_modal.get_usd_total_value()
@@ -75,8 +76,9 @@ class TestWalletModal(SingleDeviceTestCase):
         start_new_chat = home.plus_button.click()
         start_new_chat.open_d_app_button.click()
         start_new_chat.element_by_text('Airswap').click()
-        start_new_chat.open_button.click()
-        wallet_modal = start_new_chat.wallet_modal_button.click()
+        web_view = start_new_chat.open_button.click()
+        web_view.web_view_menu_button.click()
+        wallet_modal = web_view.wallet_modal_button.click()
         transaction_history = wallet_modal.transaction_history_button.click()
         transaction_history.transactions_table.wait_for_visibility_of_element()
         if transaction_history.transactions_table.get_transactions_number() < 1:
@@ -91,9 +93,9 @@ class TestWalletModal(SingleDeviceTestCase):
         start_new_chat = home.plus_button.click()
         start_new_chat.open_d_app_button.click()
         start_new_chat.element_by_text('Airswap').click()
-        start_new_chat.open_button.click()
-        web_view = start_new_chat.get_base_web_view()
-        wallet_modal = start_new_chat.wallet_modal_button.click()
+        web_view = start_new_chat.open_button.click()
+        web_view.web_view_menu_button.click()
+        wallet_modal = web_view.wallet_modal_button.click()
         if not wallet_modal.usd_total_value.is_element_displayed():
             pytest.fail("Wallet modal doesn't contain balance")
         transaction_history = wallet_modal.transaction_history_button.click()
@@ -104,6 +106,7 @@ class TestWalletModal(SingleDeviceTestCase):
             pytest.fail('Modal wallet was not closed')
         web_view.cross_icon.click()
         chat = home.join_public_chat(home.get_public_chat_name())
+        chat.chat_options.click()
         chat.wallet_modal_button.click()
         if not wallet_modal.usd_total_value.is_element_displayed():
             pytest.fail("Wallet modal was not opened")

--- a/test/appium/views/base_view.py
+++ b/test/appium/views/base_view.py
@@ -225,7 +225,7 @@ class ProgressBar(BaseElement):
 class WalletModalButton(BaseButton):
     def __init__(self, driver):
         super(WalletModalButton, self).__init__(driver)
-        self.locator = self.Locator.accessibility_id('wallet-modal-button')
+        self.locator = self.Locator.xpath_selector("//*[@text='View my wallet']")
 
     def navigate(self):
         from views.wallet_view import WalletView

--- a/test/appium/views/start_new_chat_view.py
+++ b/test/appium/views/start_new_chat_view.py
@@ -39,6 +39,10 @@ class OpenButton(BaseButton):
         super(OpenButton, self).__init__(driver)
         self.locator = self.Locator.accessibility_id('open-dapp-button')
 
+    def navigate(self):
+        from views.web_views.base_web_view import BaseWebView
+        return BaseWebView(self.driver)
+
 
 class CreateButton(BaseButton):
     def __init__(self, driver):

--- a/test/appium/views/web_views/base_web_view.py
+++ b/test/appium/views/web_views/base_web_view.py
@@ -55,12 +55,18 @@ class AlwaysButton(BaseButton):
         self.locator = self.Locator.text_part_selector('ALWAYS')
 
 
+class WebViewMenuButton(BaseButton):
+    def __init__(self, driver):
+        super(WebViewMenuButton, self).__init__(driver)
+        self.locator = self.Locator.accessibility_id('chat-menu-button')
+
+
 class URLEditBoxLockIcon(BaseEditBox):
 
     def __init__(self, driver):
         super(URLEditBoxLockIcon, self).__init__(driver)
         self.locator = self.Locator.xpath_selector(
-            "//*[@content-desc='wallet-modal-button']/../preceding-sibling::*[1]//*[@content-desc='icon']")
+            "//*[@content-desc='chat-menu-button']/../preceding-sibling::*[1]//*[@content-desc='icon']")
 
 
 class PolicySummary(BaseElement):
@@ -85,6 +91,7 @@ class BaseWebView(BaseView):
         self.browser_next_page_button = BrowserNextPageButton(self.driver)
 
         self.web_view_browser = WebViewBrowserButton(self.driver)
+        self.web_view_menu_button = WebViewMenuButton(self.driver)
         self.always_button = AlwaysButton(self.driver)
         self.browser_refresh_page_button = BrowserRefreshPageButton(self.driver)
 


### PR DESCRIPTION
Fixed all wallet modal related tests (Wallet modal button has been moved into the menu at top-left in the chat screens and webview screen) 
And test_connection_is_not_secure, test_connection_is_secure also fixed.