### PR TITLE
Unread messages indicator

### DIFF
--- a/modules/react-native-desktop-notification/desktop/desktopnotification.cpp
+++ b/modules/react-native-desktop-notification/desktop/desktopnotification.cpp
@@ -115,3 +115,7 @@ void DesktopNotification::sendNotification(QString text) {
       text, Snore::Icon::defaultIcon());
   Snore::SnoreCore::instance().broadcastNotification(notification);
 }
+
+void DesktopNotification::setDockBadgeLabel(const QString label) {
+  Snore::SnoreCore::instance().setDockBadgeLabel(label);
+}

--- a/modules/react-native-desktop-notification/desktop/desktopnotification.h
+++ b/modules/react-native-desktop-notification/desktop/desktopnotification.h
@@ -36,6 +36,7 @@ public:
     QVariantMap constantsToExport() override;
 
     Q_INVOKABLE void sendNotification(QString text);
+    Q_INVOKABLE void setDockBadgeLabel(const QString label);
 private:
     QScopedPointer<DesktopNotificationPrivate> d_ptr;
     bool m_appHasFocus = false;

--- a/src/status_im/init/core.cljs
+++ b/src/status_im/init/core.cljs
@@ -27,7 +27,8 @@
             [status-im.utils.universal-links.core :as universal-links]
             [status-im.utils.utils :as utils]
             [taoensso.timbre :as log]
-            [status-im.utils.fx :as fx]))
+            [status-im.utils.fx :as fx]
+            [status-im.chat.models :as chat-model]))
 
 (defn init-store!
   "Try to decrypt the database, move on if successful otherwise go back to
@@ -188,7 +189,9 @@
             {:notifications/request-notifications-permissions nil}
             (navigation/navigate-to-cofx :home nil)
             (universal-links/process-stored-event)
-            (notifications/process-stored-event address)))
+            (notifications/process-stored-event address)
+            (when platform/desktop?
+              (chat-model/update-dock-badge-label))))
 
 (defn dev-mode? [cofx]
   (get-in cofx [:db :account/account :dev-mode?]))

--- a/test/cljs/status_im/test/chat/models.cljs
+++ b/test/cljs/status_im/test/chat/models.cljs
@@ -253,3 +253,29 @@
     (is (= #{"4" "5" "6"}
            (set (get-in (chat/mark-messages-seen {:db test-db} "1-1")
                         [:shh/post 0 :message :payload :message-ids]))))))
+
+(deftest update-dock-badge-label
+  (testing "When user has unseen private messages"
+    (is (= {:set-dock-badge-label 3}
+           (chat/update-dock-badge-label {:db {:chats {"0x0"    {:is-active         true
+                                                                 :public?           false
+                                                                 :unviewed-messages #{1 2 3}}
+                                                       "status" {:is-active         true
+                                                                 :public?           true
+                                                                 :unviewed-messages #{1 2}}}}}))))
+  (testing "When user has unseen public messages and no unseen private messages"
+    (is (= {:set-dock-badge-label "•"}
+           (chat/update-dock-badge-label {:db {:chats {"0x0"    {:is-active         true
+                                                                 :public?           false
+                                                                 :unviewed-messages #{}}
+                                                       "status" {:is-active         true
+                                                                 :public?           true
+                                                                 :unviewed-messages #{1 2}}}}}))))
+  (testing "When user has no unseen messages"
+    (is (= {:set-dock-badge-label nil}
+           (chat/update-dock-badge-label {:db {:chats {"0x0"    {:is-active         true
+                                                                 :public?           false
+                                                                 :unviewed-messages #{}}
+                                                       "status" {:is-active         true
+                                                                 :public?           true
+                                                                 :unviewed-messages #{}}}}})))))


### PR DESCRIPTION
fixes #4433 

### Summary:

Update dock badge to show unread messages count (OSX only for now):

* Shows number for private unseen messages
* Shows "•" sign for public unseen messages

Based on https://github.com/status-im/status-react/pull/6097, so depends on it to be merged first. 
Uses `snorenotify` branch https://github.com/status-im/snorenotify/compare/master...status-im:set-osx-dock-badge

### Notes

- [x] Merge https://github.com/status-im/snorenotify/pull/4 and switch to snorenotify master

status: ready

<img width="329" alt="screenshot 2018-10-05 20 05 36" src="https://user-images.githubusercontent.com/23836/46549280-1b39d200-c8da-11e8-9aa5-b37494453781.png">

<img width="335" alt="screenshot 2018-10-10 17 10 37" src="https://user-images.githubusercontent.com/23836/46742323-75a6aa00-ccaf-11e8-9c76-f95f2f21e5a7.png">
