### PR TITLE
Set JS_APP_NAME to exported one from Status JS bundle

### DIFF
--- a/desktop/CMakeLists.txt
+++ b/desktop/CMakeLists.txt
@@ -9,6 +9,7 @@
 cmake_minimum_required(VERSION 2.8.11)
 
 set(APP_NAME StatusIm)
+set(JS_APP_NAME StatusIm)
 set(REACT_BUILD_STATIC_LIB ON)
 
 set(CMAKE_OSX_DEPLOYMENT_TARGET "10.9")


### PR DESCRIPTION
Resolves build regression introduced by [commit](https://github.com/status-im/react-native-desktop/pull/356/commits/47571b3f1d2575b44f9c0e7e1cf66fa71ff19172) into react-native-desktop