### PR TITLE
Move all the legacy handling into transit

### DIFF
--- a/src/status_im/chat/commands/receiving.cljs
+++ b/src/status_im/chat/commands/receiving.cljs
@@ -2,20 +2,11 @@
   (:require [status-im.chat.commands.protocol :as protocol]
             [status-im.utils.fx :as fx]))
 
-;; TODO(janherich) remove after couple of releases when danger of messages
-;; with old command references will be low
-(def ^:private old->new-path
-  {["transactor" :command 83 "send"]    ["send" #{:personal-chats}]
-   ["transactor" :command 83 "request"] ["request" #{:personal-chats}]})
-
 (defn lookup-command-by-ref
   "Function which takes message object and looks up associated entry from the
   `id->command` map if it can be found"
   [{:keys [content]} id->command]
-  (when-let [path (or (:command-path content)
-                      (:command-ref content))]
-    (or (get id->command path)
-        (get id->command (get old->new-path path)))))
+  (get id->command (:command-path content)))
 
 (fx/defn receive
   "Performs receive effects for command message. Does nothing

--- a/src/status_im/chat/commands/sending.cljs
+++ b/src/status_im/chat/commands/sending.cljs
@@ -7,40 +7,16 @@
             [status-im.chat.models.message :as chat.message]
             [status-im.utils.fx :as fx]))
 
-;; TODO(janherich) remove after couple of releases when danger of messages
-;; with old command references will be low
-(defn- new->old
-  [path parameter-map]
-  (get {["send" #{:personal-chats}]    {:content {:command-ref ["transactor" :command 83 "send"]
-                                                  :command "send"
-                                                  :bot "transactor"
-                                                  :command-scope-bitmask 83}
-                                        :content-type constants/content-type-command}
-        ["request" #{:personal-chats}] {:content {:command-ref ["transactor" :command 83 "request"]
-                                                  :request-command-ref ["transactor" :command 83 "send"]
-                                                  :command "request"
-                                                  :request-command "send"
-                                                  :bot "transactor"
-                                                  :command-scope-bitmask 83
-                                                  :prefill [(get parameter-map :asset)
-                                                            (get parameter-map :amount)]}
-                                        :content-type constants/content-type-command-request}}
-       path
-       {:content-type constants/content-type-command}))
-
 (defn- create-command-message
   "Create message map from chat-id, command & input parameters"
   [chat-id type parameter-map cofx]
-  (let [command-path                   (commands/command-id type)
-        ;; TODO(janherich) this is just for backward compatibility, can be removed later
-        {:keys [content content-type]} (new->old command-path parameter-map)
-        new-parameter-map              (and (satisfies? protocol/EnhancedParameters type)
-                                            (protocol/enhance-send-parameters type parameter-map cofx))]
+  (let [command-path      (commands/command-id type)
+        new-parameter-map (and (satisfies? protocol/EnhancedParameters type)
+                               (protocol/enhance-send-parameters type parameter-map cofx))]
     {:chat-id      chat-id
-     :content-type content-type
-     :content      (merge {:command-path command-path
-                           :params       (or new-parameter-map parameter-map)}
-                          content)}))
+     :content-type constants/content-type-command
+     :content      {:command-path command-path
+                    :params       (or new-parameter-map parameter-map)}}))
 
 (fx/defn validate-and-send
   "Validates and sends command in current chat"

--- a/src/status_im/chat/models/input.cljs
+++ b/src/status_im/chat/models/input.cljs
@@ -125,7 +125,7 @@
       (fx/merge cofx
                 {:db (assoc-in db [:chats current-chat-id :metadata :responding-to-message] nil)}
                 (chat.message/send-message {:chat-id      current-chat-id
-                                            :content-type constants/text-content-type
+                                            :content-type constants/content-type-text
                                             :content      (cond-> {:text input-text}
                                                             reply-to-message
                                                             (assoc :response-to reply-to-message))})

--- a/src/status_im/chat/models/message.cljs
+++ b/src/status_im/chat/models/message.cljs
@@ -101,11 +101,6 @@
     message
     (assoc message :clock-value (utils.clocks/send last-clock-value))))
 
-(defn- update-legacy-data [{:keys [content-type content] :as message}]
-  (cond-> message
-    (= constants/content-type-command-request content-type)
-    (assoc :content-type constants/content-type-command)))
-
 (fx/defn display-notification
   [cofx chat-id]
   (when config/in-app-notifications-enabled?
@@ -130,9 +125,7 @@
                                           (commands-receiving/enhance-receive-parameters cofx)
                                           (ensure-clock-value chat)
                                           ;; TODO (cammellos): Refactor so it's not computed twice
-                                          (add-outgoing-status cofx)
-                                          ;; TODO (janherich): Remove after couple of releases
-                                          update-legacy-data)]
+                                          (add-outgoing-status cofx))]
     (fx/merge cofx
               {:confirm-messages-processed [{:web3   web3
                                              :js-obj js-obj}]}
@@ -207,7 +200,7 @@
    :timestamp    timestamp
    :show?        true
    :content      content
-   :content-type constants/text-content-type})
+   :content-type constants/content-type-text})
 
 (defn group-message? [{:keys [message-type]}]
   (#{:group-user-message :public-group-user-message} message-type))

--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -6,14 +6,14 @@
 
 (def ethereum-rpc-url "http://localhost:8545")
 
-(def text-content-type "text/plain")
+(def content-type-text "text/plain")
 (def content-type-command "command")
 (def content-type-command-request "command-request")
 (def content-type-status "status")
 (def content-type-emoji "emoji")
 
 (def desktop-content-types
-  #{text-content-type content-type-emoji})
+  #{content-type-text content-type-emoji})
 
 (def min-password-length 6)
 (def max-chat-name-length 20)

--- a/src/status_im/data_store/realm/schemas/account/core.cljs
+++ b/src/status_im/data_store/realm/schemas/account/core.cljs
@@ -142,6 +142,16 @@
           browser/v8
           dapp-permissions/v9])
 
+(def v14 [chat/v6
+          transport/v6
+          contact/v1
+          message/v7
+          mailserver/v11
+          user-status/v1
+          local-storage/v1
+          browser/v8
+          dapp-permissions/v9])
+
 ;; put schemas ordered by version
 (def schemas [{:schema        v1
                :schemaVersion 1
@@ -181,4 +191,7 @@
                :migration     migrations/v12}
               {:schema        v13
                :schemaVersion 13
-               :migration     migrations/v13}])
+               :migration     migrations/v13}
+              {:schema        v14
+               :schemaVersion 14
+               :migration     migrations/v14}])

--- a/src/status_im/data_store/realm/schemas/account/migrations.cljs
+++ b/src/status_im/data_store/realm/schemas/account/migrations.cljs
@@ -86,3 +86,11 @@
 
 (defn v13 [old-realm new-realm]
   (log/debug "migrating v13 account database"))
+
+(defn v14 [old-realm new-realm]
+  (log/debug "migrating v14 account database")
+  (some-> new-realm
+          (.objects "message")
+          (.filtered (str "content-type = \"command-request\""))
+          (.map (fn [message _ _]
+                  (aset message "content-type" "command")))))

--- a/src/status_im/ui/screens/chat/message/message.cljs
+++ b/src/status_im/ui/screens/chat/message/message.cljs
@@ -211,20 +211,13 @@
 
 (defmulti message-content (fn [_ message _] (message :content-type)))
 
-(defmethod message-content constants/text-content-type
+(defmethod message-content constants/content-type-text
   [wrapper message]
   [wrapper message [text-message message]])
 
 (defmethod message-content constants/content-type-status
   [_ _]
   [message-content-status])
-
-;; TODO(janherich) in the future, `content-type-command-request` will be deprecated
-;; as it's the same thing as command
-(defmethod message-content constants/content-type-command-request
-  [wrapper message]
-  [wrapper message
-   [message-view message [message-content-command message]]])
 
 (defmethod message-content constants/content-type-command
   [wrapper message]
@@ -359,7 +352,7 @@
    [react/touchable-highlight {:on-press      (fn [_]
                                                 (re-frame/dispatch [:chat.ui/set-chat-ui-props {:messages-focused? true}])
                                                 (react/dismiss-keyboard!))
-                               :on-long-press #(when (= content-type constants/text-content-type)
+                               :on-long-press #(when (= content-type constants/content-type-text)
                                                  (list-selection/chat-message message-id (:text content) (i18n/label :t/message)))}
     [react/view {:accessibility-label :chat-item}
      (let [incoming-group (and group-chat (not outgoing))]

--- a/src/status_im/ui/screens/home/views/inner_item.cljs
+++ b/src/status_im/ui/screens/home/views/inner_item.cljs
@@ -44,9 +44,7 @@
                   :accessibility-label :chat-message-text}
       (:text content)]
 
-     (contains? #{constants/content-type-command
-                  constants/content-type-command-request}
-                content-type)
+     (= constants/content-type-command content-type)
      [command-short-preview message]
 
      :else


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

This PR moves all the legacy message handling into `transit` namespace, so the outermost "edge" of `status-react`.
Doing so has several benefits:
* All the legacy handling (sending&receiving) is in one place and easy to inspect
* Inside logic of the application can be now bit simpler and easier to reason about
* Less potential "traps" for anybody working on the message/command-message logic
* We can finally almost completely delete the legacy `content-type-command-request` from the project, keeping its use just for the legacy code in the `transit` namespace.

Please take your patience to review the code changes and do it with scrutiny.

### Testing notes (optional):
*  Please do all your testing with special test public/1-1 channels first, then proceed to make sure that known public channel like `#status` can be displayed correctly on the PR build and only post messages from the PR build there as a last thing if everything worked fine previously. Doing so will minimise the danger of breaking public communications with protocol changes. It should be the case for all protocol touching PRs from now and will be better described and documented in `Protocol compatibility practises ADR` (coming soon)
* Test that account with previous `/send` and `/request` message is OK upon upgrading to this PR build and all command messages are displayed correctly
* Test that communication between this PR and any other builds (including the oldest build you can get your hands on, providing it's newer then `0.9.22`) is fine, with special regard to command messages

status: ready
