### PR TITLE
bug #6135 - made place for recovery phrase error tooltip on desktop

### DIFF
--- a/src/status_im/ui/screens/accounts/recover/styles.cljs
+++ b/src/status_im/ui/screens/accounts/recover/styles.cljs
@@ -1,12 +1,14 @@
 (ns status-im.ui.screens.accounts.recover.styles
+  (:require-macros [status-im.utils.styles :refer [defstyle]])
   (:require [status-im.ui.components.colors :as colors]))
 
 (def screen-container
   {:flex             1
    :background-color colors/white})
 
-(def inputs-container
-  {:margin 16})
+(defstyle inputs-container
+  {:margin  16
+   :desktop {:padding-top 15}})
 
 (def password-input
   {:margin-top 10})


### PR DESCRIPTION
fixes #6135

### Summary:

Moved recovery phrase input field a bit down on desktop to make place for the error tooltip

### Steps to test:
see |#6135

status: ready 
