### PR TITLE
fix for the build problem on android

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -243,7 +243,7 @@ dependencies {
     implementation project(':react-native-webview-bridge')
     implementation project(':react-native-config')
     implementation project(':react-native-firebase')
-    compile ('com.google.android.gms:play-services-base:15.0.1') {
+    compile ('com.google.android.gms:play-services-base:16.0.1') {
         force = true
     }
     compile (project(':react-native-camera')) {


### PR DESCRIPTION
Fixes the following build error on android:

```
* What went wrong:
Execution failed for task ':app:transformDexArchiveWithExternalLibsDexMergerForDebug'.
> java.lang.RuntimeException: com.android.builder.dexing.DexArchiveMergerException: Unable to merge dex
```

thanks @cammellos 