### PR TITLE
[TESTS] e2e test added for onboarding screen verification

### DIFF
--- a/test/appium/tests/atomic/account_management/test_recover.py
+++ b/test/appium/tests/atomic/account_management/test_recover.py
@@ -67,6 +67,7 @@ class TestRecoverAccountSingleDevice(SingleDeviceTestCase):
 
 class TestRecoverAccessFromSignInScreen(SingleDeviceTestCase):
     @marks.testrail_id(5363)
+    @marks.critical
     def test_pass_phrase_validation(self):
         signin_view = SignInView(self.driver)
         recover_access_view = signin_view.i_have_account_button.click()
@@ -136,11 +137,12 @@ class TestRecoverAccessFromSignInScreen(SingleDeviceTestCase):
         self.verify_no_errors()
 
     @marks.testrail_id(5499)
+    @marks.critical
     def test_passphrase_whitespaces_ignored_while_recovering_access(self):
         signin_view = SignInView(self.driver)
         sender = transaction_senders['U']
         passphrase = fill_string_with_char(sender['passphrase'], ' ', 3, True, True)
         home_view = signin_view.recover_access(passphrase=passphrase)
 
-        assert home_view.profile_button.is_element_displayed(), \
-            'Something went wrong. Probably, could not reach the home screen out.'
+        if not home_view.profile_button.is_element_displayed():
+            self.driver.fail('Something went wrong. Probably, could not reach the home screen out.')

--- a/test/appium/tests/atomic/transactions/test_daaps_transactions.py
+++ b/test/appium/tests/atomic/transactions/test_daaps_transactions.py
@@ -107,3 +107,38 @@ class TestTransactionDApp(SingleDeviceTestCase):
         wallet_view = sign_in_view.wallet_button.click()
         wallet_view.set_up_wallet()
         wallet_view.wait_balance_changed_on_wallet_screen()
+
+    @marks.testrail_id(5355)
+    @marks.critical
+    def test_onboarding_screen_is_shown_for_account_when_requesting_tokens(self):
+        signin_view = SignInView(self.driver)
+        home_view = signin_view.create_user()
+        status_test_dapp = home_view.open_status_test_dapp()
+        status_test_dapp.wait_for_d_aap_to_load()
+        status_test_dapp.assets_button.click()
+        send_transaction_view = status_test_dapp.request_stt_button.click()
+
+        onboarding_screen_error_msg = 'It seems onborading screen is not shown.'
+
+        if not send_transaction_view.onboarding_message.is_element_displayed():
+            self.driver.fail(onboarding_screen_error_msg)
+
+        send_transaction_view.click_system_back_button()
+        if not status_test_dapp.assets_button.is_element_displayed():
+            self.driver.fail('Could not back to status test dapp screen.')
+
+        status_test_dapp.click_system_back_button()
+        profile = home_view.profile_button.click()
+        signin_view = profile.logout()
+
+        sender = transaction_senders['U']
+        passphrase = sender['passphrase']
+
+        home_view = signin_view.recover_access(passphrase=passphrase)
+        status_test_dapp = home_view.open_status_test_dapp()
+        status_test_dapp.wait_for_d_aap_to_load()
+        status_test_dapp.assets_button.click()
+        send_transaction_view = status_test_dapp.request_stt_button.click()
+
+        if not send_transaction_view.onboarding_message.is_element_displayed():
+            self.driver.fail(onboarding_screen_error_msg)

--- a/test/appium/views/home_view.py
+++ b/test/appium/views/home_view.py
@@ -152,3 +152,15 @@ class HomeView(BaseView):
         chat_view = self.get_chat_view()
         start_new_chat.confirm_until_presence_of_element(chat_view.chat_message_input)
         return chat_view
+
+    def open_status_test_dapp(self):
+        profile_view = self.profile_button.click()
+        profile_view.advanced_button.click()
+        profile_view.debug_mode_toggle.click()
+        home_view = profile_view.home_button.click()
+        start_new_chat_view = home_view.plus_button.click()
+        start_new_chat_view.open_d_app_button.click()
+        start_new_chat_view.status_test_dapp_button.scroll_to_element()
+        status_test_dapp = start_new_chat_view.status_test_dapp_button.click()
+        start_new_chat_view.open_button.click()
+        return status_test_dapp

--- a/test/appium/views/send_transaction_view.py
+++ b/test/appium/views/send_transaction_view.py
@@ -1,5 +1,5 @@
 from tests import common_password
-from views.base_element import BaseText
+from views.base_element import BaseText, BaseElement
 from views.base_element import BaseButton, BaseEditBox
 from views.base_view import BaseView, OkButton, ProgressBar
 
@@ -137,6 +137,12 @@ class ShareButton(BaseButton):
         self.locator = self.Locator.accessibility_id('share-button')
 
 
+class OnboardingMessage(BaseElement):
+    def __init__(self, driver):
+        super().__init__(driver)
+        self.locator = self.Locator.text_selector('Set up your wallet')
+
+
 class SendTransactionView(BaseView):
     def __init__(self, driver):
         super(SendTransactionView, self).__init__(driver)
@@ -168,6 +174,8 @@ class SendTransactionView(BaseView):
 
         self.share_button = ShareButton(self.driver)
         self.progress_bar = ProgressBar(self.driver)
+
+        self.onboarding_message = OnboardingMessage(self.driver)
 
     def sign_transaction(self, sender_password: str = common_password):
         self.sign_transaction_button.click_until_presence_of_element(self.enter_password_input)

--- a/test/appium/views/sign_in_view.py
+++ b/test/appium/views/sign_in_view.py
@@ -127,7 +127,11 @@ class SignInView(BaseView):
         return self.get_home_view()
 
     def recover_access(self, passphrase: str, password: str = common_password):
-        recover_access_view = self.i_have_account_button.click()
+        if self.other_accounts_button.is_element_displayed():
+            self.other_accounts_button.click()
+            recover_access_view = self.add_existing_account_button.click()
+        else:
+            recover_access_view = self.i_have_account_button.click()
         recover_access_view.passphrase_input.click()
         recover_access_view.send_as_keyevent(passphrase)
         recover_access_view.password_input.click()


### PR DESCRIPTION
### Summary:

[comment]: # (Summarise the problem and how the pull request solves it)
New test added for [the case.](https://ethstatus.testrail.net/index.php?/cases/view/5355)
### Review notes:
<!-- (Specify if something in particular should be looked at, or ignored, during review) -->
- home view extended with one new method opening status test dapp 
- new element added to send transation view
- small chagne injected to _recover_access_ method
