### PR TITLE
Fix _test_privacy_policy_is_accessible_ test

### DIFF
--- a/test/appium/tests/test_general_verifications.py
+++ b/test/appium/tests/test_general_verifications.py
@@ -16,6 +16,7 @@ class TestLinksVerifications(SingleDeviceTestCase):
             self.driver.fail('{} Sign in view!'.format(no_link_found_error_msg))
 
         base_web_view = signin_view.privacy_policy_link.click()
+        base_web_view.open_in_webview()
         if not base_web_view.policy_summary.is_element_displayed():
             self.errors.append('{} Sign in view!'.format(no_link_open_error_msg))
 

--- a/test/appium/views/web_views/base_web_view.py
+++ b/test/appium/views/web_views/base_web_view.py
@@ -73,7 +73,7 @@ class PolicySummary(BaseElement):
 
     def __init__(self, driver):
         super(PolicySummary, self).__init__(driver)
-        self.locator = self.Locator.accessibility_id('Policy summary')
+        self.locator = self.Locator.xpath_selector('//*[@content-desc="Policy summary"] | //*[@text="Policy summary"]')
 
 
 class BaseWebView(BaseView):
@@ -105,4 +105,5 @@ class BaseWebView(BaseView):
 
     def open_in_webview(self):
         self.web_view_browser.click()
-        self.always_button.click()
+        if self.always_button.is_element_displayed():
+            self.always_button.click()


### PR DESCRIPTION
### Review notes:
<!-- (Specify if something in particular should be looked at, or ignored, during review) -->
- fix for test_privacy_policy_is_accessible 
- changed string formatting to support python 3.5 

Take a note that locator for _PolicySummary_ element supports both local and sauce env.

More details on the failed test here: 
https://github.com/status-im/status-react/pull/6145#issuecomment-427797463
_test_privacy_policy_is_accessible_