### PR TITLE
Show 3-word names in profile screens in Desktop.

### DIFF
--- a/src/status_im/ui/screens/desktop/main/tabs/profile/styles.cljs
+++ b/src/status_im/ui/screens/desktop/main/tabs/profile/styles.cljs
@@ -44,6 +44,9 @@
 (def profile-user-name
   {:font-size   18})
 
+(def profile-three-words
+  {:font-size   14})
+
 (def profile-editing-user-name
   (merge profile-user-name
          {:height           20

--- a/src/status_im/ui/screens/desktop/main/tabs/profile/views.cljs
+++ b/src/status_im/ui/screens/desktop/main/tabs/profile/views.cljs
@@ -8,6 +8,7 @@
             [status-im.i18n :as i18n]
             [status-im.ui.components.icons.vector-icons :as vector-icons]
             [taoensso.timbre :as log]
+            [status-im.utils.gfycat.core :as gfy]
             [clojure.string :as string]
             [status-im.ui.screens.offline-messaging-settings.views :as offline-messaging.views]
             [status-im.ui.components.qr-code-viewer.views :as qr-code-viewer]
@@ -16,7 +17,7 @@
             [status-im.ui.screens.profile.seed.views :as profile.recovery]
             [status-im.ui.components.common.common :as components.common]))
 
-(defn profile-badge [{:keys [name photo-path]} editing?]
+(defn profile-badge [{:keys [name photo-path public-key]} editing?]
   [react/view styles/profile-badge
    [react/image {:source {:uri photo-path}
                  :style  styles/profile-photo}]
@@ -31,7 +32,13 @@
      [react/text {:style           styles/profile-user-name
                   :font           :medium
                   :number-of-lines 1}
-      name])])
+      name])
+   (let [gfy-name (gfy/generate-gfy public-key)]
+     (when (and (not= gfy-name gfy/unknown-gfy)
+                (not= gfy-name name))
+       [react/text {:style           styles/profile-three-words
+                    :number-of-lines 1}
+        gfy-name]))])
 
 (views/defview copied-tooltip [opacity]
   (views/letsubs []


### PR DESCRIPTION

fixes #6154

### Testing notes (optional):
<!-- (Specify if something specific has to be tested, for example upgrade paths) -->

### Steps to test:
- Open Status (Desktop)
- a. Go to your profile
- b. Open profile of any chat user

Expected:
- see 3-word names under the selected profile name

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->
