### PR TITLE
Ignore messages with too high clock-value

### DIFF
--- a/src/status_im/transport/db.cljs
+++ b/src/status_im/transport/db.cljs
@@ -3,6 +3,7 @@
   (:require-macros [status-im.utils.db :refer [allowed-keys]])
   (:require [cljs.spec.alpha :as spec]
             status-im.ui.screens.contacts.db
+            [status-im.utils.clocks :as utils.clocks]
             [clojure.string :as s]))
 
 ;; required
@@ -60,7 +61,8 @@
 
 (spec/def ::content-type #{"text/plain" "command" "command-request"})
 (spec/def ::message-type #{:group-user-message :public-group-user-message :user-message})
-(spec/def ::clock-value (spec/nilable pos-int?))
+(spec/def ::clock-value (spec/and pos-int?
+                                  utils.clocks/safe-timestamp?))
 (spec/def ::timestamp (spec/nilable pos-int?))
 
 (spec/def :message/id string?)

--- a/src/status_im/transport/message/v1/protocol.cljs
+++ b/src/status_im/transport/message/v1/protocol.cljs
@@ -5,6 +5,7 @@
             [taoensso.timbre :as log]
             [status-im.utils.config :as config]
             [status-im.chat.core :as chat]
+            [status-im.utils.clocks :as utils.clocks]
             [status-im.transport.db :as transport.db]
             [status-im.transport.message.core :as message]
             [status-im.transport.message.v1.core :as transport]
@@ -110,8 +111,9 @@
              :from       signature
              :js-obj     (:js-obj cofx))]})
   (validate [this]
-    (when (spec/valid? :message/message this)
-      this)))
+    (if (spec/valid? :message/message this)
+      this
+      (log/warn "failed to validate Message" (spec/explain :message/message this)))))
 
 (defrecord MessagesSeen [message-ids]
   message/StatusMessage

--- a/src/status_im/utils/clocks.cljs
+++ b/src/status_im/utils/clocks.cljs
@@ -75,6 +75,8 @@
 (defn- ->timestamp-bid []
   (* (utils.datetime/timestamp) post-id-digits))
 
+(defn max-timestamp []
+  (* (+ one-month-in-ms (utils.datetime/timestamp)) post-id-digits))
 ; The timestamp has an upper limit of Number.MAX_SAFE_INTEGER
 ; A malicious client could send a crafted message with timestamp = Number.MAX_SAFE_INTEGER
 ; which effectively would DoS the chat, as any new message would get
@@ -83,7 +85,10 @@
 ; then now + 20s.
 ; We cap the timestamp to time now + 1 month to give some room for trusted peers
 (defn- safe-timestamp [t]
-  (min t (* (+ one-month-in-ms (utils.datetime/timestamp)) post-id-digits)))
+  (min t (max-timestamp)))
+
+(defn safe-timestamp? [t]
+  (<= t (max-timestamp)))
 
 (defn send [local-clock]
   (inc (max local-clock (->timestamp-bid))))

--- a/test/cljs/status_im/test/utils/clocks.cljs
+++ b/test/cljs/status_im/test/utils/clocks.cljs
@@ -92,6 +92,12 @@
     (is (< (clocks/receive js/Number.MAX_SAFE_INTEGER 0)
            js/Number.MAX_SAFE_INTEGER))))
 
+(deftest safe-timestamp?-test
+  (testing "it returns false for a high number"
+    (is (not (clocks/safe-timestamp? js/Number.MAX_SAFE_INTEGER))))
+  (testing "it returns true for a normal timestamp number"
+    (is (clocks/safe-timestamp? (clocks/send 0)))))
+
   ;; Debugging
 ;;(println "******************************************")
 ;;(println "A's POV :foo" (format-thread (thread a :foo)))


### PR DESCRIPTION

fixes #6196

### Summary:

We never made sure `clock-value` is a reasonable value before storing the message in the database, therefore effectively allowing `pinning` of the messages in a chat.

Although this problem is not completely preventable (`clock-value` is theoretically boundless), we can make checks to detect malicious usage, assuming that if the initial part of the clock value (a `timestamp` in ms), is too high (currently set to `now` + `1 month`), the message is to be considered malicious.

Previously this check was only made when setting our own clock value, but the message was stored in the database.

The consequences is that if your clock is skewed +/- 1 month you either won't be receiving other people messages (-1 month), or peers won't be receiving yours (+1 month).


### Review notes (optional):
<!-- (Specify if something in particular should be looked at, or ignored, during review) -->

### Testing notes :

1) Go to status chat with a new account
2) There should be no pinned `Test` message from yesterday, nor `Does anyone here...`

For more malformed messages please let me know and we can send some to a chat.

status: ready