### PR TITLE
Always load messages referenced in responses

### DIFF
--- a/src/status_im/chat/specs.cljs
+++ b/src/status_im/chat/specs.cljs
@@ -17,6 +17,7 @@
 (s/def :chat/message-groups (s/nilable map?))                     ; grouped/sorted messages
 (s/def :chat/message-statuses (s/nilable map?))                   ; message/user statuses indexed by two level index
 (s/def :chat/not-loaded-message-ids (s/nilable set?))             ; set of message-ids not yet fully loaded from persisted state
+(s/def :chat/referenced-messages (s/nilable map?))                ; map of messages indexed by message-id which are not displayed directly, but referenced by other messages
 (s/def :chat/last-clock-value (s/nilable number?))                ; last logical clock value of messages in chat
 (s/def :chat/loaded-chats (s/nilable seq?))
 (s/def :chat/bot-db (s/nilable map?))

--- a/src/status_im/data_store/messages.cljs
+++ b/src/status_im/data_store/messages.cljs
@@ -20,6 +20,16 @@
                       (core/all-clj :message))]
      (map transform-message messages))))
 
+(defn- get-by-chat-and-messages-ids
+  [chat-id message-ids]
+  (when (seq message-ids)
+    (let [messages (-> @core/account-realm
+                       (.objects "message")
+                       (.filtered (str "chat-id=\"" chat-id "\""
+                                       (str " and (" (core/in-query "message-id" message-ids) ")")))
+                       (core/all-clj :message))]
+      (map transform-message messages))))
+
 (def default-values
   {:to             nil})
 
@@ -58,9 +68,12 @@
 (re-frame/reg-cofx
  :data-store/get-unviewed-messages
  (fn [cofx _]
-   (assoc cofx
-          :get-stored-unviewed-messages
-          get-unviewed-messages)))
+   (assoc cofx :get-stored-unviewed-messages get-unviewed-messages)))
+
+(re-frame/reg-cofx
+ :data-store/get-referenced-messages
+ (fn [cofx _]
+   (assoc cofx :get-referenced-messages get-by-chat-and-messages-ids)))
 
 (defn- prepare-content [content]
   (if (string? content)

--- a/src/status_im/data_store/realm/core.cljs
+++ b/src/status_im/data_store/realm/core.cljs
@@ -337,3 +337,8 @@
                (case op
                  :and (and-query queries)
                  :or (or-query queries)))))
+
+(defn in-query
+  "Constructs IN query"
+  [field-name ids]
+  (string/join " or " (map #(str field-name "=\"" % "\"") ids)))

--- a/src/status_im/data_store/user_statuses.cljs
+++ b/src/status_im/data_store/user_statuses.cljs
@@ -3,9 +3,6 @@
             [re-frame.core :as re-frame]
             [status-im.data-store.realm.core :as core]))
 
-(defn- in-query [message-ids]
-  (string/join " or " (map #(str "message-id=\"" % "\"") message-ids)))
-
 (defn- prepare-statuses [statuses]
   (reduce (fn [acc {:keys [message-id whisper-identity] :as user-status}]
             (assoc-in acc
@@ -22,7 +19,7 @@
       (.objects "user-status")
       (.filtered (str "chat-id=\"" chat-id "\""
                       (when (seq message-ids)
-                        (str " and (" (in-query message-ids) ")"))))
+                        (str " and (" (core/in-query "message-id" message-ids) ")"))))
       (core/all-clj :user-status)
       prepare-statuses))
 

--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -83,6 +83,7 @@
   (re-frame/inject-cofx :data-store/get-messages)
   (re-frame/inject-cofx :data-store/get-user-statuses)
   (re-frame/inject-cofx :data-store/get-unviewed-messages)
+  (re-frame/inject-cofx :data-store/get-referenced-messages)
   (re-frame/inject-cofx :data-store/message-ids)
   (re-frame/inject-cofx :data-store/get-local-storage-data)
   (re-frame/inject-cofx :data-store/get-all-contacts)
@@ -500,7 +501,8 @@
 (handlers/register-handler-fx
  :chat.ui/load-more-messages
  [(re-frame/inject-cofx :data-store/get-messages)
-  (re-frame/inject-cofx :data-store/get-user-statuses)]
+  (re-frame/inject-cofx :data-store/get-user-statuses)
+  (re-frame/inject-cofx :data-store/get-referenced-messages)]
  (fn [cofx _]
    (chat.loading/load-more-messages cofx)))
 

--- a/src/status_im/ui/screens/db.cljs
+++ b/src/status_im/ui/screens/db.cljs
@@ -281,6 +281,7 @@
                  :chat/message-groups
                  :chat/message-statuses
                  :chat/not-loaded-message-ids
+                 :chat/referenced-messages
                  :chat/last-clock-value
                  :chat/loaded-chats
                  :chat/bot-db

--- a/src/status_im/ui/screens/desktop/main/chat/views.cljs
+++ b/src/status_im/ui/screens/desktop/main/chat/views.cljs
@@ -133,14 +133,18 @@
                         :margin-right 5}}
     link]])
 
+(defn- message-sent? [user-statuses current-public-key]
+  (not= (get-in user-statuses [current-public-key :status]) :not-sent))
+
 (views/defview message-with-timestamp
-  [text {:keys [message-id timestamp outgoing content current-public-key]} style]
+  [text {:keys [message-id timestamp outgoing content current-public-key user-statuses]} style]
   [react/view {:style style}
    [react/touchable-highlight {:style {}
                                :on-press #(if (= "right" (.-button (.-nativeEvent %)))
                                             (do (utils/show-popup "" "Message copied to clipboard")
                                                 (react/copy-to-clipboard text))
-                                            (re-frame/dispatch [:chat.ui/reply-to-message message-id]))}
+                                            (when (message-sent? user-statuses current-public-key)
+                                              (re-frame/dispatch [:chat.ui/reply-to-message message-id])))}
     [react/view {:style styles/message-container}
      (when (:response-to content)
        [quoted-message (:response-to content) outgoing current-public-key])


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

There was a problem with partial loading of messages (pagination), when some message referenced reply not yet loaded, resulting in blank "response to" section.
This PR fixes it in a reasonable effective way, however we should seriously think about redoing our pagination altogether and getting rid of the fields like `:not-loaded-message-ids` and (added in this PR) `:referenced-messages` in favour of always holding all messages in the memory (should be feasible, needs proof) and modelling the rendered range by by `:range [from to]` properties in `app-db`.

## Testing notes
* Test that when app is open and not all messages are loaded from db, you can still see the the referenced messages in replies. The only exception is when those referenced messages are older then 24h, eq they are never fetched from mailserver.

status: ready
