### PR TITLE
default public chats use a-z instead of unicode

### DIFF
--- a/resources/default_public_chats.json
+++ b/resources/default_public_chats.json
@@ -1,1 +1,1 @@
-["status", "status 中文", "status 日本語", "status 한국어", "status по-русски", "status español", "status فارسی", "cryptocurrency", "cryptostrikers", "dapps", "ethereum", "cryptolife", "introductions"]
+["status", "status-chinese", "status-japanese", "status-korean", "status-russian", "status-spanish", "status-farsi", "cryptocurrency", "cryptostrikers", "dapps", "ethereum", "cryptolife", "introductions"]


### PR DESCRIPTION
fixed #5074 

### Summary:

Status has default public chats in various languages such as `status 日本語` for Japanese, but the unicode channel names don't work with universal links.  Also public chats are only meant to have [a-z], hyphen, and numbers. The unicode public channel names breaks convention.

This PR changes our unicode channel names to English/a-z and makes it compatible with the channel format and fixes universal links.

### Steps to test:
- Open Status
- New
- See that default chats are `status-japanese` style instead of `status 日本語`

### Additional Info

The community team will need let migrate users from the old channels to the new ones. Whilst this is annoying it is better for the community as they can share the channel as universal links.

status: ready <!-- Can be ready or wip -->

<img width="652" alt="screen shot 2018-10-10 at 9 07 19 am" src="https://user-images.githubusercontent.com/116099/46718592-f04dd600-cc6b-11e8-9905-55b2e53c616c.png">
