### PR TITLE
false faucet fixture autouse

### DIFF
--- a/test/appium/tests/conftest.py
+++ b/test/appium/tests/conftest.py
@@ -191,7 +191,7 @@ def pytest_runtest_protocol(item, nextitem):
             return True  # no need to rerun
 
 
-@pytest.fixture(scope="session", autouse=True)
+@pytest.fixture(scope="session", autouse=False)
 def faucet_for_senders():
     network_api = NetworkApi()
     for user in transaction_senders.values():


### PR DESCRIPTION
### Summary:

Set fixture calling faucet to false.
Reason: all production tests were failing due to unavailability of faucet donate service.