### PR TITLE
bug #6261 - removed blue dot from outgoing payment messages

### DIFF
--- a/src/status_im/chat/commands/impl/transactions/styles.cljs
+++ b/src/status_im/chat/commands/impl/transactions/styles.cljs
@@ -80,7 +80,7 @@
 
 (defn command-amount-currency-separator [outgoing]
   {:opacity 0
-   :color   colors/white})
+   :color   (if outgoing colors/blue colors/white)})
 
 (defn command-send-currency-text [outgoing]
   {:font-size      22


### PR DESCRIPTION
fixes #6261

### Summary:

Removes the blue dot from payment messages.

### Testing notes (optional):

#### Platforms (optional)
- Android
- iOS
- macOS
- Linux

#### Areas that maybe impacted (optional)
**Functional**
- 1-1 chats


<!-- (Specify exact steps to test if there are such) -->
### Steps to test:
- Send/receive a transaction and a request
- Neither incoming nor outgoing payment messages should contain a visible blue dot between amount and symbol

status: ready
