### PR TITLE
add a fix for APK content type (#6271)

### DIFF
--- a/ci/common.groovy
+++ b/ci/common.groovy
@@ -101,6 +101,12 @@ def uploadArtifact(path) {
   if (getBuildType() == 'pr') {
     bucket = 'status-im-prs'
   }
+  /* WARNING: s3cmd can't guess APK MIME content-type */
+  def customOpts = ''
+  if (path.endsWith('apk')) {
+    customOpts += "--mime-type='application/vnd.android.package-archive'"
+  }
+  /* We also need credentials for the upload */
   withCredentials([usernamePassword(
     credentialsId: 'digital-ocean-access-keys',
     usernameVariable: 'DO_ACCESS_KEY',
@@ -109,6 +115,7 @@ def uploadArtifact(path) {
     sh """
       s3cmd \\
         --acl-public \\
+        ${customOpts} \\
         --host='${domain}' \\
         --host-bucket='%(bucket)s.${domain}' \\
         --access_key=${DO_ACCESS_KEY} \\


### PR DESCRIPTION
This fixes the issue where the `*.apk` files would be treated as `*.zip` files by Android due to what kind of `Content-Type` would be returned while downloding it from our Digital Ocean Space.

Example:
```bash
 % curl -skv https://status-im.ams3.digitaloceanspaces.com/StatusIm-181012-025922-02cb5d-nightly.apk
...
< HTTP/1.1 200 OK
< Content-Type: application/zip
...
```
This is due to the [`s3cmd`](https://github.com/s3tools/s3cmd) utility we are using for uploading not detecting the MIME type correctly. To fix that the MIME type has to be specified explicity when uploading using the `--mime-type=` argument.