### PR TITLE
Typo in "new message" notification fixed

### DIFF
--- a/translations/en.json
+++ b/translations/en.json
@@ -675,7 +675,7 @@
     "currency-display-name-ttd": "Trinidad and Tobago Dollar",
     "wallet-assets": "Assets",
     "are-you-sure-description": "You will not be able to see the whole recovery phrase again",
-    "notifications-new-message-body": "You have new message",
+    "notifications-new-message-body": "You have a new message",
     "currency-display-name-php": "Philippines Peso",
     "image-source-title": "Edit picture",
     "leave-confirmation": "Leave?",


### PR DESCRIPTION
There's a typo in the new message notification, it's missing an article.