### PR TITLE
WIP feature #6297 - wallet on desktop

### DIFF
--- a/src/status_im/init/core.cljs
+++ b/src/status_im/init/core.cljs
@@ -178,7 +178,7 @@
            (= view-id :create-account)
            (assoc-in [:accounts/create :step] :enter-name))}))
 
-(defn initialize-wallet [cofx]
+(fx/defn initialize-wallet [cofx]
   (fx/merge cofx
             (models.wallet/initialize-tokens)
             (models.wallet/update-wallet)
@@ -216,8 +216,7 @@
             (browser/initialize-browsers)
             (browser/initialize-dapp-permissions)
             (extensions.registry/initialize)
-            #(when-not platform/desktop?
-               (initialize-wallet %))
+            (initialize-wallet)
             (accounts.update/update-sign-in-time)
             #(when-not (creating-account? %)
                (login-only-events % address))))

--- a/src/status_im/ui/components/checkbox/styles.cljs
+++ b/src/status_im/ui/components/checkbox/styles.cljs
@@ -1,4 +1,5 @@
 (ns status-im.ui.components.checkbox.styles
+  (:require-macros [status-im.utils.styles :refer [defstyle]])
   (:require [status-im.ui.components.colors :as colors]))
 
 (def wrapper
@@ -18,9 +19,11 @@
           :width         26
           :height        26}))
 
-(def check-icon
-  {:width  12
-   :height 12})
+(defstyle check-icon
+  {:width   12
+   :height  12
+   ;;TODO(goranjovic) - this is a quickfix because checkboxes are invisible on desktop
+   :desktop {:background-color colors/blue}})
 
 (def plain-check-icon
   (merge check-icon

--- a/src/status_im/ui/components/desktop/events.cljs
+++ b/src/status_im/ui/components/desktop/events.cljs
@@ -11,9 +11,9 @@
 (fx/defn navigate-to
   [{:keys [db] :as cofx} tab-name]
   (navigation/navigate-to-cofx cofx
-                               (if (and (= tab-name :home) (:current-chat-id db))
-                                 :chat
-                                 :home)
+                               (cond (and (= tab-name :home) (:current-chat-id db)) :chat
+                                     (= tab-name :wallet) :wallet
+                                     :else :home)
                                nil))
 
 (fx/defn fetch-desktop-version

--- a/src/status_im/ui/components/desktop/tabs.cljs
+++ b/src/status_im/ui/components/desktop/tabs.cljs
@@ -16,10 +16,11 @@
               :icon-inactive :icons/home
               :icon-active   :icons/home-active}
     :count-subscription  :chats/unread-messages-number}
-   #_{:view-id :wallet
-      :content {:title         "Wallet"
-                :icon-inactive :icons/wallet
-                :icon-active   :icons/wallet-active}}
+   {:view-id            :wallet
+    :content            {:title         "Wallet"
+                         :icon-inactive :icons/wallet
+                         :icon-active   :icons/wallet-active}
+    :count-subscription :get-wallet-unread-messages-number}
    {:view-id :profile
     :content {:title         "Profile"
               :icon-inactive :icons/profile

--- a/src/status_im/ui/components/list/styles.cljs
+++ b/src/status_im/ui/components/list/styles.cljs
@@ -3,7 +3,8 @@
   (:require [status-im.ui.components.colors :as colors]))
 
 (def item
-  {:flex-direction     :row
+  {:flex               1
+   :flex-direction     :row
    :justify-content    :center
    :padding-horizontal 16})
 

--- a/src/status_im/ui/components/list_selection.cljs
+++ b/src/status_im/ui/components/list_selection.cljs
@@ -5,7 +5,8 @@
             [status-im.ui.components.dialog :as dialog]
             [status-im.ui.components.react :as react]
             [status-im.utils.platform :as platform]
-            [status-im.utils.http :as http]))
+            [status-im.utils.http :as http]
+            [status-im.utils.utils :as utils]))
 
 (defn open-share [content]
   (when (or (:message content)
@@ -21,9 +22,9 @@
     :action #(open-share {:message text})}])
 
 (defn show [options]
-  (if platform/ios?
-    (action-sheet/show options)
-    (dialog/show options)))
+  (cond platform/ios? (action-sheet/show options)
+        platform/android? (dialog/show options)
+        :else (utils/show-options-dialog options)))
 
 (defn chat-message [message-id text dialog-title]
   (show {:title       dialog-title

--- a/src/status_im/ui/components/toolbar/styles.cljs
+++ b/src/status_im/ui/components/toolbar/styles.cljs
@@ -16,6 +16,7 @@
    :justify-content  :space-between
    :background-color (or background-color toolbar-background)
    :elevation        (if flat? 0 2)
+   :desktop          {:height 55}
    :android          {:height 55}
    :ios              {:height 56}})
 
@@ -68,7 +69,8 @@
 (defstyle item
   {:ios     {:padding-horizontal 12
              :padding-vertical   16}
-   :android {:padding 16}})
+   :android {:padding 16}
+   :desktop {:padding 16}})
 
 (def item-text
   {:color     colors/blue
@@ -85,9 +87,20 @@
 
 (def item-text-white-background {:color colors/blue})
 
-;;TODO(goranjovic) - Breaks the toolbar title into new line on smaller screens
-;;e.g. see Discover > Popular hashtags on iPhone 5s
-(def ios-content-item {:position :absolute :right 40 :left 40})
+;;TODO(goranjovic) - This doesn't work at all on desktop. Review why we even need absolute position hacks
+;; hiding it as a temporary fix.
+(defstyle ios-content-item
+  {:desktop {:position :absolute
+             :right    40
+             :left     40
+             :width    0
+             :height   0}
+   :android {:position :absolute
+             :right    40
+             :left     40}
+   :ios     {:position :absolute
+             :right    40
+             :left     40}})
 
 (def counter-container
   {:top 3})

--- a/src/status_im/ui/screens/desktop/main/tabs/home/views.cljs
+++ b/src/status_im/ui/screens/desktop/main/tabs/home/views.cljs
@@ -22,11 +22,11 @@
         @unviewed-messages-count]])))
 
 (views/defview chat-list-item-inner-view [{:keys [chat-id name group-chat color public? public-key] :as chat-item}]
-  (letsubs [photo-path                         [:contacts/chat-photo chat-id]
-            unviewed-messages-count            [:chats/unviewed-messages-count chat-id]
-            chat-name                          [:chats/chat-name chat-id]
-            current-chat-id                    [:chats/current-chat-id]
-            {:keys [content] :as last-message} [:chats/last-message chat-id]]
+  (views/letsubs [photo-path                         [:contacts/chat-photo chat-id]
+                  unviewed-messages-count            [:chats/unviewed-messages-count chat-id]
+                  chat-name                          [:chats/chat-name chat-id]
+                  current-chat-id                    [:chats/current-chat-id]
+                  {:keys [content] :as last-message} [:chats/last-message chat-id]]
     (let [name (or chat-name
                    (gfycat/generate-gfy public-key))
           [unviewed-messages-label large?] (if (< 9 unviewed-messages-count)

--- a/src/status_im/ui/screens/desktop/main/views.cljs
+++ b/src/status_im/ui/screens/desktop/main/views.cljs
@@ -5,8 +5,19 @@
             [status-im.ui.screens.desktop.main.styles :as styles]
             [status-im.ui.screens.desktop.main.chat.views :as chat.views]
             [status-im.ui.screens.desktop.main.add-new.views :as add-new.views]
+            [status-im.ui.screens.wallet.main.views :as wallet.main]
             [status-im.ui.components.desktop.tabs :as tabs]
-            [status-im.ui.components.react :as react]))
+            [status-im.ui.components.react :as react]
+            [re-frame.core :as re-frame]
+            [status-im.ui.screens.wallet.onboarding.setup.views :as wallet.onboarding.setup]
+            [status-im.ui.screens.wallet.send.views :as wallet.send]
+            [status-im.ui.screens.wallet.request.views :as wallet.request]
+            [status-im.ui.screens.wallet.transactions.views :as wallet.transactions]
+            [status-im.ui.screens.wallet.components.views :as wallet.components]
+            [status-im.ui.screens.wallet.transaction-sent.views :as wallet.transaction-sent]
+            [status-im.ui.screens.wallet.transaction-fee.views :as wallet.transaction-fee]
+            [status-im.ui.components.colors :as colors]
+            [status-im.ui.screens.wallet.settings.views :as wallet-settings]))
 
 (views/defview status-view []
   [react/view {:style {:flex 1 :background-color "#eef2f5" :align-items :center :justify-content :center}}
@@ -18,6 +29,7 @@
     (let [component (case tab
                       :profile profile.views/profile-data
                       :home home.views/chat-list-view-wrapper
+                      :wallet react/view
                       react/view)]
       [react/view {:style {:flex 1}}
        [component]])))
@@ -25,12 +37,26 @@
 (views/defview main-view []
   (views/letsubs [view-id [:get :view-id]]
     (let [component (case view-id
-                      :chat         chat.views/chat-view
-                      :new-contact  add-new.views/new-contact
-                      :qr-code      profile.views/qr-code
+                      :chat chat.views/chat-view
+                      :new-contact add-new.views/new-contact
+                      :qr-code profile.views/qr-code
                       :advanced-settings profile.views/advanced-settings
                       :chat-profile chat.views/chat-profile
                       :backup-recovery-phrase profile.views/backup-recovery-phrase
+                      :wallet wallet.main/wallet
+                      :wallet-settings-assets wallet-settings/manage-assets
+                      :wallet-onboarding-setup wallet.onboarding.setup/screen
+                      :wallet-send-transaction wallet.send/send-transaction
+                      :recent-recipients       wallet.components/recent-recipients
+                      :contact-code                 wallet.components/contact-code
+                      :wallet-send-assets wallet.components/send-assets
+                      :wallet-transaction-fee wallet.transaction-fee/transaction-fee
+                      :wallet-transaction-sent wallet.transaction-sent/transaction-sent
+                      :wallet-request-transaction wallet.request/request-transaction
+                      :wallet-request-assets wallet.components/request-assets
+                      :wallet-send-transaction-request wallet.request/send-transaction-request
+                      :transactions-history wallet.transactions/transactions
+                      :wallet-transaction-details   wallet.transactions/transaction-details
                       status-view)]
       [react/view {:style {:flex 1}}
        [component]])))

--- a/src/status_im/ui/screens/desktop/views.cljs
+++ b/src/status_im/ui/screens/desktop/views.cljs
@@ -3,7 +3,7 @@
   (:require [status-im.ui.screens.desktop.main.views :as main.views]
             [status-im.ui.components.react :as react]
             [status-im.ui.screens.intro.views :as intro.views]
-            [status-im.ui.screens.group.add-contacts.views :refer [contact-toggle-list]]
+            [status-im.ui.screens.group.add-contacts.views :as add-contacts.views]
             [status-im.ui.screens.group.views :refer [new-group]]
             [status-im.ui.screens.profile.group-chat.views :refer [group-chat-profile]]
             [status-im.ui.screens.group.add-contacts.views :refer [add-participants-toggle-list]]
@@ -22,7 +22,7 @@
                       :recover recover.views/recover
                       :create-account create.views/create-account
                       :new-group  new-group
-                      :contact-toggle-list contact-toggle-list
+                      :contact-toggle-list add-contacts.views/contact-toggle-list
                       :group-chat-profile group-chat-profile
                       :add-participants-toggle-list add-participants-toggle-list
 
@@ -32,7 +32,21 @@
                        :home
                        :qr-code
                        :chat-profile
-                       :backup-recovery-phrase) main.views/main-views
+                       :backup-recovery-phrase
+                       :wallet
+                       :wallet-settings-assets
+                       :wallet-onboarding-setup
+                       :wallet-send-transaction
+                       :recent-recipients
+                       :contact-code
+                       :wallet-transaction-sent
+                       :wallet-transaction-details
+                       :wallet-send-assets
+                       :wallet-transaction-fee
+                       :wallet-request-transaction
+                       :wallet-send-transaction-request
+                       :wallet-request-assets
+                       :transactions-history) main.views/main-views
                       :login login.views/login
                       react/view)]
       [react/view {:style {:flex 1}}

--- a/src/status_im/ui/screens/wallet/components/views.cljs
+++ b/src/status_im/ui/screens/wallet/components/views.cljs
@@ -64,7 +64,7 @@
 (defn simple-screen
   ([toolbar content] (simple-screen nil toolbar content))
   ([{:keys [avoid-keyboard? status-bar-type]} toolbar content]
-   [(top-view avoid-keyboard?) {:flex 1 :background-color colors/blue}
+   [(top-view avoid-keyboard?) {:style {:flex 1 :background-color colors/blue}}
     [status-bar/status-bar {:type (or status-bar-type :wallet)}]
     toolbar
     content]))
@@ -254,14 +254,15 @@
 
 (defn- on-choose-recipient [contact-only?]
   (list-selection/show {:title   (i18n/label :t/wallet-choose-recipient)
-                        :options (concat
-                                  [{:label  (i18n/label :t/recent-recipients)
-                                    :action #(re-frame/dispatch [:navigate-to :recent-recipients])}]
+                        :options (vector
+                                  {:label  (i18n/label :t/recent-recipients)
+                                   :action #(re-frame/dispatch [:navigate-to :recent-recipients])}
+                                  (when-not (or contact-only? platform/desktop?)
+                                    {:label  (i18n/label :t/scan-qr)
+                                     :action request-camera-permissions})
                                   (when-not contact-only?
-                                    [{:label  (i18n/label :t/scan-qr)
-                                      :action request-camera-permissions}
-                                     {:label  (i18n/label :t/recipient-code)
-                                      :action #(re-frame/dispatch [:navigate-to :contact-code])}]))}))
+                                    {:label  (i18n/label :t/recipient-code)
+                                     :action #(re-frame/dispatch [:navigate-to :contact-code])}))}))
 
 (defn recipient-selector [{:keys [name address disabled? contact-only? request? modal?]}]
   [cartouche {:on-press  #(on-choose-recipient contact-only?)

--- a/src/status_im/ui/screens/wallet/main/styles.cljs
+++ b/src/status_im/ui/screens/wallet/main/styles.cljs
@@ -7,7 +7,8 @@
 (defstyle main-section
   {:flex    1
    :android {:background-color colors/white}
-   :ios     {:background-color colors/blue}})
+   :ios     {:background-color colors/blue}
+   :desktop {:background-color colors/blue}})
 
 (defstyle scroll-bottom
   {:background-color colors/white
@@ -15,6 +16,7 @@
    :position         :absolute
    :left             0
    :right            0
+   :desktop          {}
    :android          {:height 0}
    :ios              {:height 9999}})
 
@@ -127,7 +129,8 @@
    :color     colors/black})
 
 (def asset-item-currency
-  {:font-size   16
+  {:flex 1
+   :font-size   16
    :color       colors/gray
    :margin-left 6})
 

--- a/src/status_im/ui/screens/wallet/main/views.cljs
+++ b/src/status_im/ui/screens/wallet/main/views.cljs
@@ -129,7 +129,7 @@
 
 (defn- asset-section [assets currency address-hex modal?]
   (let [{:keys [tokens nfts]} (group-assets assets)]
-    [react/view styles/asset-section
+    [react/view {:style styles/asset-section}
      [list/section-list
       {:scroll-enabled     false
        :key-fn             (comp str :symbol)
@@ -159,12 +159,12 @@
                   {:keys [seed-backed-up?]} [:account/account]
                   error-message   [:wallet/error-message]
                   address-hex     [:account/hex-address]]
-    [react/view styles/main-section
+    [react/view {:style styles/main-section}
      (if modal?
        [toolbar-modal modal-history?]
        [settings/toolbar-view])
      (if (and modal? modal-history?)
-       [react/view styles/modal-history
+       [react/view {:style styles/modal-history}
         [transactions.views/history-list true]]
        [react/scroll-view {:refresh-control
                            (reagent/as-element
@@ -181,7 +181,7 @@
                          assets))
           [backup-seed-phrase])
         (if modal?
-          [react/view styles/address-section
+          [react/view {:style styles/address-section}
            [react/text {:style               styles/wallet-address
                         :accessibility-label :address-text
                         :selectable          true}

--- a/src/status_im/ui/screens/wallet/onboarding/views.cljs
+++ b/src/status_im/ui/screens/wallet/onboarding/views.cljs
@@ -119,7 +119,7 @@
        (partial display-confirmation #(re-frame/dispatch [:accounts.ui/wallet-set-up-confirmed true])))]]))
 
 (defn onboarding []
-  [react/view styles/root
+  [react/view {:style styles/root}
    [react/view {:style styles/onboarding-image-container}
     [react/image {:source (:wallet-welcome resources/ui)
                   :style  styles/onboarding-image}]]

--- a/src/status_im/ui/screens/wallet/request/views.cljs
+++ b/src/status_im/ui/screens/wallet/request/views.cljs
@@ -21,7 +21,8 @@
             [status-im.utils.ethereum.eip681 :as eip681]
             [status-im.utils.utils :as utils]
             [status-im.utils.ethereum.tokens :as tokens]
-            [status-im.ui.screens.wallet.utils :as wallet.utils]))
+            [status-im.ui.screens.wallet.utils :as wallet.utils]
+            [status-im.utils.platform :as platform]))
 
 ;; Request screen
 
@@ -68,10 +69,12 @@
 ;; Main screen
 
 (defn send-transaction-request-button [value]
-  [button/primary-button {:on-press            #(re-frame/dispatch [:navigate-to :wallet-send-transaction-request])
-                          :style               styles/send-request
-                          :accessibility-label :sent-transaction-request-button}
-   (i18n/label :t/send-transaction-request)])
+  (if platform/desktop?
+    [react/view]
+    [button/primary-button {:on-press            #(re-frame/dispatch [:navigate-to :wallet-send-transaction-request])
+                            :style               styles/send-request
+                            :accessibility-label :sent-transaction-request-button}
+     (i18n/label :t/send-transaction-request)]))
 
 (views/defview request-transaction []
   (views/letsubs [address-hex [:account/hex-address]

--- a/src/status_im/ui/screens/wallet/send/events.cljs
+++ b/src/status_im/ui/screens/wallet/send/events.cljs
@@ -18,7 +18,8 @@
             [status-im.utils.money :as money]
             [status-im.utils.security :as security]
             [status-im.utils.types :as types]
-            [status-im.utils.utils :as utils]))
+            [status-im.utils.utils :as utils]
+            [status-im.utils.platform :as platform]))
 
 ;;;; FX
 
@@ -264,10 +265,15 @@
              cofx)
             :dispatch [:wallet/update-gas-price true]))))
 
+(fx/defn navigate-after-transaction [{:keys [db] :as cofx}]
+  (if platform/desktop?
+    (navigation/navigate-to-cofx cofx :wallet {})
+    (navigation/navigate-back cofx)))
+
 (handlers/register-handler-fx
  :close-transaction-sent-screen
  (fn [cofx [_ chat-id]]
    (fx/merge cofx
              {:dispatch-later [{:ms 400 :dispatch [:check-dapps-transactions-queue]}]}
-             (navigation/navigate-back))))
+             (navigate-after-transaction))))
 

--- a/src/status_im/ui/screens/wallet/send/subs.cljs
+++ b/src/status_im/ui/screens/wallet/send/subs.cljs
@@ -4,6 +4,10 @@
             [status-im.models.wallet :as models.wallet]))
 
 (re-frame/reg-sub
+ :get-wallet-unread-messages-number
+ (constantly 0))
+
+(re-frame/reg-sub
  ::send-transaction
  :<- [:wallet]
  (fn [wallet]

--- a/src/status_im/ui/screens/wallet/send/views.cljs
+++ b/src/status_im/ui/screens/wallet/send/views.cljs
@@ -29,6 +29,7 @@
             [taoensso.timbre :as log]
             [reagent.core :as reagent]
             [status-im.ui.components.colors :as colors]
+            [status-im.utils.platform :as platform]
             [status-im.ui.screens.wallet.utils :as wallet.utils]))
 
 (defn- toolbar [modal? title]
@@ -144,7 +145,8 @@
         chain                        (ethereum/network->chain-keyword network)
         native-currency              (tokens/native-currency chain)
         {:keys [decimals] :as token} (tokens/asset-for all-tokens chain symbol)
-        online? (= :online network-status)]
+        ;; TODO(goranjovic): offline status detection doesn't work on desktop yet
+        online? (or platform/desktop? (= :online network-status))]
     [wallet.components/simple-screen {:avoid-keyboard? (not modal?)
                                       :status-bar-type (if modal? :modal-wallet :wallet)}
      [toolbar modal? (i18n/label :t/send-transaction)]

--- a/src/status_im/ui/screens/wallet/settings/views.cljs
+++ b/src/status_im/ui/screens/wallet/settings/views.cljs
@@ -11,7 +11,8 @@
             [status-im.ui.components.status-bar.view :as status-bar]
             [status-im.ui.screens.wallet.styles :as wallet.styles]
             [status-im.utils.ethereum.core :as ethereum]
-            [status-im.utils.ethereum.tokens :as tokens]))
+            [status-im.utils.ethereum.tokens :as tokens]
+            [status-im.ui.components.colors :as colors]))
 
 (def hook
   "Hook for extensions"
@@ -40,7 +41,7 @@
   (letsubs [network        [:network]
             visible-tokens [:wallet/visible-tokens-symbols]
             all-tokens     [:wallet/all-tokens]]
-    [react/view (merge components.styles/flex {:background-color :white})
+    [react/view {:style {:flex 1 :background-color colors/white}}
      [status-bar/status-bar {:type :modal-wallet}]
      [toolbar/toolbar {:style wallet.styles/toolbar}
       [toolbar/nav-text {:handler             #(do (re-frame/dispatch [:update-wallet])

--- a/src/status_im/ui/screens/wallet/transaction_sent/views.cljs
+++ b/src/status_im/ui/screens/wallet/transaction_sent/views.cljs
@@ -11,26 +11,26 @@
             [status-im.ui.components.colors :as colors]))
 
 (defn- ok-circle []
-  [react/view {:background-color colors/black-transparent
-               :width            160
-               :height           160
-               :border-radius    81
-               :align-items      :center
-               :justify-content  :center}
-   [react/view {:background-color colors/white
-                :width            80
-                :height           80
-                :border-radius    41
-                :shadow-radius    4
-                :shadow-offset    {:width 0 :height 2}
-                :shadow-opacity   0.8
-                :shadow-color     "rgba(43, 59, 71, 0.12)"
-                :align-items      :center
-                :justify-content  :center}
+  [react/view {:style {:background-color colors/black-transparent
+                       :width            160
+                       :height           160
+                       :border-radius    81
+                       :align-items      :center
+                       :justify-content  :center}}
+   [react/view {:style {:background-color colors/white
+                        :width            80
+                        :height           80
+                        :border-radius    41
+                        :shadow-radius    4
+                        :shadow-offset    {:width 0 :height 2}
+                        :shadow-opacity   0.8
+                        :shadow-color     "rgba(43, 59, 71, 0.12)"
+                        :align-items      :center
+                        :justify-content  :center}
     [vi/icon :icons/tiny-check {:color colors/blue}]]])
 
 (defn- transaction-sent-message []
-  [react/view {:align-items :center}
+  [react/view {:style {:align-items :center}}
    [react/text {:style               styles/transaction-sent
                 :font                (if platform/android? :medium :default)
                 :accessibility-label :transaction-sent-text}
@@ -43,8 +43,8 @@
                               :style {:border-top-width 1
                                       :border-color     colors/white-light-transparent}
                               :accessibility-label :got-it-button}
-   [react/view {:align-items      :center
-                :padding-vertical 18}
+   [react/view {:style {:align-items      :center
+                        :padding-vertical 18}}
     [react/text {:style      {:color     colors/white
                               :font-size 15}
                  :font       (if platform/android? :medium :default)
@@ -53,21 +53,21 @@
 
 (defn- sent-screen [{:keys [on-next]}]
   {:pre [(fn? on-next)]}
-  [react/view {:flex 1}
-   [react/view {:flex 0.7}] ;; spacer
-   [react/view {:align-items :center} (ok-circle)]
-   [react/view {:flex 1}]   ;; spacer
+  [react/view {:style {:flex 1}}
+   [react/view {:style {:flex 0.7}}] ;; spacer
+   [react/view {:style {:align-items :center}} (ok-circle)]
+   [react/view {:style {:flex 1}}]   ;; spacer
    (transaction-sent-message)
    (bottom-action-button on-next)])
 
 (defview transaction-sent []
   (letsubs [chat-id [:chats/current-chat-id]]
-    [react/view {:flex 1 :background-color colors/blue}
+    [react/view {:style {:flex 1 :background-color colors/blue}}
      [status-bar/status-bar {:type :transparent}]
      (sent-screen {:on-next #(re-frame/dispatch [:close-transaction-sent-screen chat-id])})]))
 
 (defview transaction-sent-modal []
   (letsubs [chat-id [:chats/current-chat-id]]
-    [react/view {:flex 1 :background-color colors/blue}
+    [react/view {:style {:flex 1 :background-color colors/blue}}
      [status-bar/status-bar {:type :modal-wallet}]
      (sent-screen {:on-next #(re-frame/dispatch [:close-transaction-sent-screen chat-id])})]))

--- a/src/status_im/utils/utils.cljs
+++ b/src/status_im/utils/utils.cljs
@@ -1,13 +1,17 @@
 (ns status-im.utils.utils
   (:require [status-im.i18n :as i18n]
-            [status-im.react-native.js-dependencies :as rn-dependencies]
-            [re-frame.core :as re-frame]))
+            [status-im.react-native.js-dependencies :as js-dependencies]
+            [re-frame.core :as re-frame]
+            [taoensso.timbre :as log]
+            [clojure.set :as set]))
+
+(def alert (.-Alert js-dependencies/react-native))
 
 (defn show-popup
   ([title content]
    (show-popup title content nil))
   ([title content on-dismiss]
-   (.alert (.-Alert rn-dependencies/react-native)
+   (.alert alert
            title
            content
            (clj->js
@@ -25,7 +29,7 @@
 
 (defn show-confirmation
   [{:keys [title content confirm-button-text on-accept on-cancel cancel-button-text]}]
-  (.alert (.-Alert rn-dependencies/react-native)
+  (.alert alert
           title
           content
           ;; Styles are only relevant on iOS. On Android first button is 'neutral' and second is 'positive'
@@ -44,7 +48,7 @@
   ([title content on-accept]
    (show-question title content on-accept nil))
   ([title content on-accept on-cancel]
-   (.alert (.-Alert rn-dependencies/react-native)
+   (.alert alert
            title
            content
            (clj->js
@@ -55,10 +59,18 @@
                      :onPress             on-accept
                      :accessibility-label :yes-button})))))
 
+(defn show-options-dialog
+  [{:keys [title options]}]
+  (.alert alert
+          title
+          ""
+          (clj->js
+           (vec (map #(set/rename-keys % {:label :text, :action :onPress}) options)))))
+
 ;; background-timer
 
 (defn set-timeout [cb ms]
-  (.setTimeout rn-dependencies/background-timer cb ms))
+  (.setTimeout js-dependencies/background-timer cb ms))
 
 ;; same as re-frame dispatch-later but using background timer for long
 ;; running timeouts
@@ -69,10 +81,10 @@
      (set-timeout #(re-frame/dispatch dispatch) ms))))
 
 (defn clear-timeout [id]
-  (.clearTimeout rn-dependencies/background-timer id))
+  (.clearTimeout js-dependencies/background-timer id))
 
 (defn set-interval [cb ms]
-  (.setInterval rn-dependencies/background-timer cb ms))
+  (.setInterval js-dependencies/background-timer cb ms))
 
 (defn clear-interval [id]
-  (.clearInterval rn-dependencies/background-timer id))
+  (.clearInterval js-dependencies/background-timer id))


### PR DESCRIPTION
fixes #6297

### Summary:

Wallet on Desktop. Added a tab, which displays main wallet screen in main area. Sidebar is empty.
Basic wallet functionality is also there, with some noted exceptions.

What works:
- signing phrase onboarding
- display of balance and tokens in main wallet screen
- adding/removing enabled tokens
- send transaction to contact or by address
- show own address qr in receive transaction
- set custom gas settings

What does not work:
- send a transaction request (we have no chat commands on desktop yet)
- transaction history (http calls don't work on desktop, at least not on linux) - status-im/react-native-desktop#373
- set recipient by scanning qr (camera on desktop not supported)
- generally this PR does only main Wallet tab, not chat commands and not dapp transactions.
- network switching, only mainnet
- offline detection - always says it's offline on linux, so it's being ignored by wallet when on desktop

Notable responsiveness issues:
- missing title in Assets selection screen (the one where you enable/disable tokens)
- blue area below token list in main wallet screen
- missing component that displays menu popups - using dialog as a short term solution
- checkbox component is weird on desktop

## Testing notes (optional):

All platforms should be tested - shared code was affected.

#### Platforms (optional)
- Android
- iOS
- macOS
- Linux

#### Areas that maybe impacted (optional)
**Functional**
- wallet / transactions

status: ready 