### PR TITLE
[#6307] fix each message sent before upgrade is shown twice after 0.9.29

### DIFF
--- a/src/status_im/chat/models/message.cljs
+++ b/src/status_im/chat/models/message.cljs
@@ -145,10 +145,13 @@
             (chat-loading/group-chat-messages chat-id (get chat->message chat-id))))
 
 (defn- add-to-chat?
-  [{:keys [db]} {:keys [chat-id clock-value message-id] :as message}]
+  [{:keys [db]} {:keys [chat-id clock-value message-id message-id-old-format] :as message}]
   (let [{:keys [deleted-at-clock-value messages not-loaded-message-ids]}
         (get-in db [:chats chat-id])]
     (not (or (get messages message-id)
+             ;; TODO(rasom): remove this condition
+             ;; on when 0.9.29 will not be available for users
+             (and message-id-old-format (get messages message-id-old-format))
              (get not-loaded-message-ids message-id)
              (>= deleted-at-clock-value clock-value)))))
 

--- a/src/status_im/transport/message/protocol.cljs
+++ b/src/status_im/transport/message/protocol.cljs
@@ -105,13 +105,18 @@
            this)
           (send-with-pubkey cofx params)))))
   (receive [this chat-id signature _ cofx]
-    {:chat-received-message/add-fx
-     [(assoc (into {} this)
-             :message-id (transport.utils/message-id this)
-             :show?      true
-             :chat-id    chat-id
-             :from       signature
-             :js-obj     (:js-obj cofx))]})
+    (let [old-message (Message. (:text content) content-type message-type
+                                clock-value timestamp)]
+      {:chat-received-message/add-fx
+       [(assoc (into {} this)
+               :message-id (transport.utils/message-id this)
+               ;; TODO(rasom): remove this condition
+               ;; on when 0.9.29 will not be available for users
+               :message-id-old-format (transport.utils/message-id-old-format old-message)
+               :show? true
+               :chat-id chat-id
+               :from signature
+               :js-obj (:js-obj cofx))]}))
   (validate [this]
     (if (spec/valid? :message/message this)
       this

--- a/src/status_im/transport/utils.cljs
+++ b/src/status_im/transport/utils.cljs
@@ -22,6 +22,15 @@
   [message]
   (sha3 (pr-str message)))
 
+(defn message-id-old-format
+  "Get an old format message-id.
+   To be removed on 8th day after 0.9.30"
+  [message]
+  (-> message
+      pr-str
+      (clojure.string/replace "message.protocol" "message.v1.protocol")
+      sha3))
+
 (defn get-topic
   "Get the topic of a group chat or public chat from the chat-id"
   [chat-id]


### PR DESCRIPTION
fix #6307

status: ready <!-- Can be ready or wip -->
