### PR TITLE
Log db error

### DIFF
--- a/src/status_im/data_store/realm/core.cljs
+++ b/src/status_im/data_store/realm/core.cljs
@@ -202,8 +202,9 @@
          (encrypted-realm-version file-name new-key)
          (log/info "try to encrypt with password success")
          (on-success))
-       (catch :default _
+       (catch :default e
          (do
+           (log/warn "failed checking db encryption with" e)
            (log/info "try to encrypt with old key")
            (encrypted-realm-version file-name old-key)
            (log/info "try to encrypt with old key success")


### PR DESCRIPTION
Just add logging of db errors so we can address the problems on desktop when it asks to[ reset the database](https://github.com/status-im/status-react/issues/6112).
skips qa
status: ready
