### PR TITLE
hotfix realm migration

### DIFF
--- a/src/status_im/data_store/realm/schemas/account/migrations.cljs
+++ b/src/status_im/data_store/realm/schemas/account/migrations.cljs
@@ -108,7 +108,7 @@
   "reset last request to 1 to fetch 7 past days of history"
   [old-realm new-realm]
   (log/debug "migrating v18 account database")
-  (some-> old-realm
+  (some-> new-realm
           (.objects "transport-inbox-topic")
           (.map (fn [inbox-topic _ _]
                   (aset inbox-topic "last-request" 1)))))


### PR DESCRIPTION
Merge before nightly !

Fix migration failing in latest develop

`Could not change account Error: Cannot modify managed objects outside of a write transaction.`

The migration was trying to change a value in the old realm but it can only be done in the new one

status: ready
