### PR TITLE
increase request timeout

### DIFF
--- a/src/status_im/transport/inbox.cljs
+++ b/src/status_im/transport/inbox.cljs
@@ -28,11 +28,12 @@
 
 (def one-day (* 24 3600))
 (def seven-days (* 7 one-day))
-(def maximum-number-of-attemps 3)
+(def maximum-number-of-attemps 2)
+(def request-timeout 30)
 
 (def connection-timeout
   "Time after which mailserver connection is considered to have failed"
-  5000)
+  10000)
 
 (defn- parse-json
   ;; NOTE(dmitryn) Expects JSON response like:
@@ -178,6 +179,7 @@
                     (clj->js {:topic          topic
                               :mailServerPeer address
                               :symKeyID       sym-key-id
+                              :timeout        request-timeout
                               :from           from
                               :to             to})
                     (fn [error request-id]
@@ -370,8 +372,8 @@
 
 (fx/defn resend-request
   [{:keys [db] :as cofx} {:keys [request-id]}]
-  (if (>= maximum-number-of-attemps
-          (get-in [:transport.inbox/current-request :attemps] db))
+  (if (<= maximum-number-of-attemps
+          (get-in db [:transport.inbox/current-request :attemps]))
     (fx/merge cofx
               {:db (update db :transport.inbox/current-request dissoc :attemps)}
               (change-mailserver))


### PR DESCRIPTION
Merge before nightly

Seems like it is common for requests to timeout after 10 sec so 

- give more time for requests to complete
- change mailserver everytime a request time out


status: ready <!-- Can be ready or wip -->
