### PR TITLE
[#4650] changed return-key-type to Done while setting user name

### DIFF
--- a/src/status_im/ui/screens/accounts/create/views.cljs
+++ b/src/status_im/ui/screens/accounts/create/views.cljs
@@ -27,14 +27,15 @@
                       :input-placeholder (i18n/label :t/name-placeholder)
                       :input-description (i18n/label :t/name-description)}})
 
-(defview input [next-enabled? {:keys [step error password password-confirm]}]
+(defview input [next-enabled? {:keys [step error password password-confirm return-key-type] :or {return-key-type :default}}]
   [text-input/text-input-with-label
    (cond-> {:label             (get-in steps [step :input-label])
             :placeholder       (get-in steps [step :input-placeholder])
             :on-change-text    #(re-frame/dispatch [:accounts.create.ui/input-text-changed (get-in steps [step :input-key]) %])
             :secure-text-entry (boolean (#{:enter-password :confirm-password} step))
             :auto-focus        true
-            :error             error}
+            :error             error
+            :return-key-type   return-key-type}
      next-enabled? (assoc :on-submit-editing #(re-frame/dispatch [:accounts.create.ui/next-step-pressed step password password-confirm])))])
 
 (defview create-account []
@@ -64,10 +65,12 @@
          [react/view {:style                       styles/input-container
                       :important-for-accessibility :no-hide-descendants}
           [input next-enabled?
-           {:step             step
-            :error            error
-            :password         password
-            :password-confirm password-confirm}]
+           (merge {:step             step
+                   :error            error
+                   :password         password
+                   :password-confirm password-confirm}
+                  (when (= step :enter-name)
+                    {:return-key-type :done}))]
           [react/text {:style styles/input-description}
            (get-in steps [step :input-description])]]
          [react/view {:style components.styles/flex}]


### PR DESCRIPTION
Fixes #4650.

Added optional return-key-type parameter to input that defaults to :default, but for enter-name step is set to :done.