### PR TITLE
Send seen with pubkey

### DIFF
--- a/src/status_im/transport/message/protocol.cljs
+++ b/src/status_im/transport/message/protocol.cljs
@@ -130,8 +130,8 @@
                            chat-id
                            nil
                            this)
-      (send-with-sym-key cofx {:chat-id chat-id
-                               :payload this})))
+      (send-with-pubkey cofx {:chat-id chat-id
+                              :payload this})))
   (receive [this chat-id signature _ cofx]
     (chat/receive-seen cofx chat-id signature this))
   (validate [this]


### PR DESCRIPTION
fixes: #6320 

Seen messages were still sent with the sym-key, so sometimes after account recovery we would not have it in place yet, therefore clicking on chat would result in the error.
changes to send with pubkey.

### Areas that maybe impacted (optional)
**Functional**
- 1-1 chats seen messages

status: ready
