### PR TITLE
[#4181] use react/text to show sign message text

### DIFF
--- a/src/status_im/ui/screens/wallet/send/styles.cljs
+++ b/src/status_im/ui/screens/wallet/send/styles.cljs
@@ -139,6 +139,11 @@
    :selection-color        colors/white
    :style                  wallet.components.styles/text-input})
 
+(def sign-message-text
+  {:color            colors/white
+   :font-size        14
+   :padding-vertical 8})
+
 (def sign-buttons
   {:background-color colors/blue
    :padding-vertical 8})

--- a/src/status_im/ui/screens/wallet/send/views.cljs
+++ b/src/status_im/ui/screens/wallet/send/views.cljs
@@ -245,12 +245,10 @@
        [react/view styles/send-transaction-form
         [wallet.components/cartouche {:disabled? true}
          (i18n/label :t/message)
-         [components/amount-input
-          {:disabled?     true
-           :input-options {:multiline true
-                           :height    100}
-           :amount-text   data}
-          nil]]]]
+         [react/text
+          {:style styles/sign-message-text
+           :selectable true}
+          data]]]]
       [enter-password-buttons false
        #(re-frame/dispatch [:wallet/discard-transaction-navigate-back])
        #(re-frame/dispatch [:wallet/sign-message])


### PR DESCRIPTION
Fixes #4181

### Summary:

Right now the sign message text is shown using the `amount-input` component.
This component uses a multi-line `react/input-text` to show the message, but the
input is always disabled and the text is [shown unmodified](https://github.com/status-im/status-react/blob/develop/src/status_im/ui/screens/wallet/components/views.cljs#L289).  Multi-line input-texts do not expand their height based on the content, so the message is cut off when displayed.

This commit replaces the use of the `amount-input` component by a simple
`react/text` with `selectable` property set to true. The behavior should be
almost the same than before, but now the all the content is visible.
(NOTE that the text is already under a scroll view).

![after](https://user-images.githubusercontent.com/44213672/47052139-748de500-d1a7-11e8-85e6-a2d78cc0f264.jpg)

#### Platforms
- Android
- iOS

#### Areas that maybe impacted

**Functional**
- dapps / app browsing

### Steps to test:
- Open Opensea
- Explore the sea
- Buy an item
- Sign transaction
- Enter email address and name
- Submit to load "Sign message" screen (now should be all text readable)

status: ready