### PR TITLE
[#2884] added name lookup for recipient after qr code scanning

### DIFF
--- a/src/status_im/contact/subs.cljs
+++ b/src/status_im/contact/subs.cljs
@@ -1,7 +1,6 @@
 (ns status-im.contact.subs
   (:require [re-frame.core :refer [reg-sub subscribe]]
             [status-im.utils.contacts :as utils.contacts]
-            [status-im.utils.ethereum.core :as ethereum]
             [status-im.utils.identicon :as identicon]))
 
 (reg-sub :get-current-contact-identity :contacts/identity)
@@ -149,19 +148,10 @@
                :else
                (identicon/identicon chat-id)))))
 
-(defn- address= [{:keys [address] :as contact} s]
-  (when (and address (= (ethereum/normalized-address s)
-                        (ethereum/normalized-address address)))
-    contact))
-
-(defn- contact-by-address [[_ contact] s]
-  (when (address= contact s)
-    contact))
-
 (reg-sub :get-contact-by-address
          :<- [:get-contacts]
          (fn [contacts [_ address]]
-           (some #(contact-by-address % address) contacts)))
+           (utils.contacts/find-contact-by-address contacts address)))
 
 (reg-sub :get-contacts-by-address
          :<- [:get-contacts]

--- a/src/status_im/ui/screens/wallet/choose_recipient/events.cljs
+++ b/src/status_im/ui/screens/wallet/choose_recipient/events.cljs
@@ -6,7 +6,8 @@
             [status-im.utils.handlers :as handlers]
             [status-im.utils.money :as money]
             [status-im.utils.ethereum.ens :as ens]
-            [re-frame.core :as re-frame]))
+            [re-frame.core :as re-frame]
+            [status-im.utils.contacts :as utils.contacts]))
 
 (handlers/register-handler-fx
  :wallet/toggle-flashlight
@@ -15,21 +16,25 @@
          toggled-state (if (= :on flashlight-state) :off :on)]
      {:db (assoc-in db [:wallet :send-transaction :camera-flashlight] toggled-state)})))
 
+(defn- find-address-name [db address]
+  (:name (utils.contacts/find-contact-by-address (:contacts/contacts db) address)))
+
 (defn- fill-request-details [db {:keys [address name value symbol gas gasPrice whisper-identity from-chat?]}]
   {:pre [(not (nil? address))]}
-  (update-in
-   db [:wallet :send-transaction]
-   (fn [{old-symbol :symbol :as old-transaction}]
-     (let [symbol-changed? (not= old-symbol symbol)]
-       (cond-> (assoc old-transaction :to address :to-name name :whisper-identity whisper-identity)
-         value (assoc :amount value)
-         symbol (assoc :symbol symbol)
-         (and gas symbol-changed?) (assoc :gas (money/bignumber gas))
-         from-chat? (assoc :from-chat? from-chat?)
-         (and gasPrice symbol-changed?)
-         (assoc :gas-price (money/bignumber gasPrice))
-         (and symbol (not gasPrice) symbol-changed?)
-         (assoc :gas-price (ethereum/estimate-gas symbol)))))))
+  (let [name (or name (find-address-name db address))]
+    (update-in
+     db [:wallet :send-transaction]
+     (fn [{old-symbol :symbol :as old-transaction}]
+       (let [symbol-changed? (not= old-symbol symbol)]
+         (cond-> (assoc old-transaction :to address :to-name name :whisper-identity whisper-identity)
+           value (assoc :amount value)
+           symbol (assoc :symbol symbol)
+           (and gas symbol-changed?) (assoc :gas (money/bignumber gas))
+           from-chat? (assoc :from-chat? from-chat?)
+           (and gasPrice symbol-changed?)
+           (assoc :gas-price (money/bignumber gasPrice))
+           (and symbol (not gasPrice) symbol-changed?)
+           (assoc :gas-price (ethereum/estimate-gas symbol))))))))
 
 (defn- extract-details
   "First try to parse as EIP681 URI, if not assume this is an address directly.

--- a/src/status_im/utils/contacts.cljs
+++ b/src/status_im/utils/contacts.cljs
@@ -1,7 +1,8 @@
 (ns status-im.utils.contacts
   (:require [status-im.js-dependencies :as js-dependencies]
             [status-im.utils.identicon :as identicon]
-            [status-im.utils.gfycat.core :as gfycat]))
+            [status-im.utils.gfycat.core :as gfycat]
+            [status-im.utils.ethereum.core :as ethereum]))
 
 (defn whisper-id->new-contact [whisper-id]
   {:name             (gfycat/generate-gfy whisper-id)
@@ -17,3 +18,10 @@
                          nil)]
     (when normalized-key
       (subs (.sha3 js-dependencies/Web3.prototype normalized-key #js {:encoding "hex"}) 26))))
+
+(defn- contact-by-address [[_ contact] address]
+  (when (ethereum/address= (:address contact) address)
+    contact))
+
+(defn find-contact-by-address [contacts address]
+  (some #(contact-by-address % address) contacts))

--- a/src/status_im/utils/ethereum/core.cljs
+++ b/src/status_im/utils/ethereum/core.cljs
@@ -171,3 +171,8 @@
                                                 (if-not error
                                                   (cb (js->clj result :keywordize-keys true))
                                                   (handle-error error)))))
+
+(defn address= [address1 address2]
+  (and address1 address2
+       (= (normalized-address address1)
+          (normalized-address address2))))


### PR DESCRIPTION
Fixes #2884.

Should now display contact name beside address when QR code is scanned.

I have tried to make scope of changes as small as possible, but address comparison function was private in contact/subs so I moved it to utils.contacts without changing any logic.

It seems that the same problem is present when entering address manually (name is not displayed even when contact address is entered) and I think that it could be solved in a similar manner.
