### PR TITLE
[#5179] show fiat value in transaction details

### DIFF
--- a/src/status_im/ui/screens/wallet/transactions/views.cljs
+++ b/src/status_im/ui/screens/wallet/transactions/views.cljs
@@ -163,7 +163,7 @@
       (-> amount (money/token->unit (:decimals token)) money/to-fixed str))
     "..."))
 
-(defn details-header [network {:keys [value date type symbol token]}]
+(defn details-header [network {:keys [date type symbol symbol-fiat token type value value-fiat]}]
   (let [asset (tokens/asset-for (ethereum/network->chain-keyword network) symbol)]
     [react/view {:style styles/details-header}
      [react/view {:style styles/details-header-icon}
@@ -174,7 +174,14 @@
         (pretty-print-asset symbol value token)]
        " "
        [react/text {:accessibility-label :currency-text}
-        (wallet.utils/display-symbol asset)]]
+        (wallet.utils/display-symbol asset)]
+       " ("
+       [react/text {:accessibility-label :amount-text}
+        (str value-fiat)]
+       " "
+       [react/text {:accessibility-label :currency-text}
+        (clojure.string/upper-case (name symbol-fiat))]
+       ")"]
       [react/text {:style styles/details-header-date} date]]]))
 
 (defn progress-bar [progress failed?]
@@ -214,7 +221,7 @@
 (defn details-list [{:keys [block hash
                             from from-wallet from-contact
                             to to-wallet to-contact
-                            gas-limit gas-price-gwei gas-price-eth gas-used cost nonce data]}]
+                            gas-limit gas-price-gwei gas-price-eth gas-used cost cost-fiat nonce data]}]
   [react/view {:style styles/details-block}
    [details-list-row :t/block block]
    [details-list-row :t/hash hash]
@@ -233,7 +240,7 @@
    [details-list-row :t/gas-limit gas-limit]
    [details-list-row :t/gas-price gas-price-gwei gas-price-eth]
    [details-list-row :t/gas-used gas-used]
-   [details-list-row :t/cost-fee cost]
+   [details-list-row :t/cost-fee cost cost-fiat]
    [details-list-row :t/nonce nonce]
    [details-list-row :t/data data]])
 


### PR DESCRIPTION
Fixes #5179

### Summary:

This patch uses the user current currency to show the value of a transaction in that currency. Transaction cost/fee is also shown in this format.

![ss](https://user-images.githubusercontent.com/44213672/47117397-841f3380-d264-11e8-9352-b4a503277fc9.jpg)

### Review notes:

I decided to show these amounts by appending the symbol name. I did not find any way to render currency based on locale. If there is a method to render currency based on the locale that supports crypto too, then I should use that method. If not, this implementation is good enough for now, IMHO.

Note also that this always shows the current fiat at the current exchange prices. If there is a way to get the price given a timestamp that will very useful here.

#### Platforms
- Android
- iOS

#### Areas that maybe impacted
**Functional**
- 1-1 chats
- wallet / transactions

### Steps to test:
- Open Status
- Send or receive a transaction
- Open Transaction Details from Wallet

status: ready