### PR TITLE
Fixes set-extension-url-from-qr: updates it for the new manage object

### DIFF
--- a/src/status_im/extensions/core.cljs
+++ b/src/status_im/extensions/core.cljs
@@ -246,7 +246,8 @@
 
 (fx/defn set-extension-url-from-qr
   [cofx url]
-  (fx/merge (assoc-in cofx [:db :extension-url] url)
+  (fx/merge (assoc-in cofx [:db :extensions/manage :url] {:value url
+                                                          :error false})
             (navigation/navigate-back)))
 
 (fx/defn set-input


### PR DESCRIPTION
Makes it possible to set extension url from QR code. 
It doesn't fix any problems with universal links — only makes it possible to use a QR scanner on add extension screen.