### PR TITLE
[desktop] Add search feature for chat list

### DIFF
--- a/src/status_im/contact/core.cljs
+++ b/src/status_im/contact/core.cljs
@@ -67,14 +67,16 @@
               (add-new-contact contact)
               (send-contact-request contact))))
 
-(fx/defn add-contact-tag
+(fx/defn add-tag
   "add a tag to the contact"
-  [{:keys [db] :as cofx} whisper-id tag]
-  (let [tags (conj (get-in db [:contacts/contacts whisper-id :tags] #{}) tag)]
+  [{:keys [db] :as cofx}]
+  (let [tag (get-in db [:ui/contact :contact/new-tag])
+        whisper-id (get-in db [:current-chat-id])
+        tags (conj (get-in db [:contacts/contacts whisper-id :tags] #{}) tag)]
     {:db (assoc-in db [:contacts/contacts whisper-id :tags] tags)
      :data-store/tx [(contacts-store/add-contact-tag-tx whisper-id tag)]}))
 
-(fx/defn remove-contact-tag
+(fx/defn remove-tag
   "remove a tag from the contact"
   [{:keys [db] :as cofx} whisper-id tag]
   (let [tags (disj (get-in db [:contacts/contacts whisper-id :tags] #{}) tag)]

--- a/src/status_im/contact/db.cljs
+++ b/src/status_im/contact/db.cljs
@@ -36,32 +36,30 @@
 (spec/def :contact/debug? boolean?)
 (spec/def :contact/tags (spec/coll-of string? :kind set?))
 
-(spec/def :contact/contact
-  (allowed-keys
-   :req-un [:contact/name]
-   :opt-un [:contact/whisper-identity
-            :contact/address
-            :contact/public-key
-            :contact/photo-path
-            :contact/status
-            :contact/last-updated
-            :contact/last-online
-            :contact/pending?
-            :contact/hide-contact?
-            :contact/unremovable?
-            :contact/dapp?
-            :contact/dapp-url
-            :contact/dapp-hash
-            :contact/bot-url
-            :contact/jail-loaded?
-            :contact/jail-loaded-events
-            :contact/command
-            :contact/response
-            :contact/debug?
-            :contact/subscriptions
-            :contact/fcm-token
-            :contact/description
-            :contact/tags]))
+(spec/def :contact/contact (spec/keys  :req-un [:contact/name]
+                                       :opt-un [:contact/whisper-identity
+                                                :contact/address
+                                                :contact/public-key
+                                                :contact/photo-path
+                                                :contact/status
+                                                :contact/last-updated
+                                                :contact/last-online
+                                                :contact/pending?
+                                                :contact/hide-contact?
+                                                :contact/unremovable?
+                                                :contact/dapp?
+                                                :contact/dapp-url
+                                                :contact/dapp-hash
+                                                :contact/bot-url
+                                                :contact/jail-loaded?
+                                                :contact/jail-loaded-events
+                                                :contact/command
+                                                :contact/response
+                                                :contact/debug?
+                                                :contact/subscriptions
+                                                :contact/fcm-token
+                                                :contact/description
+                                                :contact/tags]))
 
 ;;Contact list ui props
 (spec/def :contact-list-ui/edit? boolean?)
@@ -83,3 +81,6 @@
 (spec/def :contacts/click-action (spec/nilable #{:send :request}))
 ;;used in modal list (for example for wallet)
 (spec/def :contacts/click-params (spec/nilable map?))
+
+(spec/def :contact/new-tag string?)
+(spec/def :ui/contact (spec/keys :opt [:contact/new-tag]))

--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -30,6 +30,7 @@
             [status-im.privacy-policy.core :as privacy-policy]
             [status-im.protocol.core :as protocol]
             [status-im.qr-scanner.core :as qr-scanner]
+            [status-im.search.core :as search]
             [status-im.signals.core :as signals]
             [status-im.transport.inbox :as inbox]
             [status-im.transport.message.core :as transport.message]
@@ -1073,3 +1074,20 @@
  [(re-frame/inject-cofx :random-id-generator)]
  (fn [cofx _]
    (contact/add-new-identity-to-contacts cofx)))
+
+(handlers/register-handler-fx
+ :contact.ui/add-tag
+ (fn [cofx _]
+   (contact/add-tag cofx)))
+
+(handlers/register-handler-fx
+ :contact.ui/set-tag-input-field
+ (fn [cofx [_ text]]
+   {:db (assoc-in (:db cofx) [:ui/contact :contact/new-tag] text)}))
+
+;; search module
+
+(handlers/register-handler-fx
+ :search/filter-changed
+ (fn [cofx [_ search-filter]]
+   (search/filter-changed cofx search-filter)))

--- a/src/status_im/search/core.cljs
+++ b/src/status_im/search/core.cljs
@@ -1,0 +1,5 @@
+(ns status-im.search.core
+  (:require [status-im.utils.fx :as fx]))
+
+(fx/defn filter-changed [cofx search-filter]
+  {:db (assoc-in (:db cofx) [:ui/search :filter] search-filter)})

--- a/src/status_im/search/subs.cljs
+++ b/src/status_im/search/subs.cljs
@@ -1,0 +1,28 @@
+(ns status-im.search.subs
+  (:require [clojure.string :as string]
+            [re-frame.core :as re-frame]))
+
+(re-frame/reg-sub
+ :search/filter
+ (fn [db]
+   (get-in db [:ui/search :filter] "")))
+
+(re-frame/reg-sub
+ :search/filtered-active-chats
+ :<- [:get-active-chats]
+ :<- [:search/filter]
+ (fn [[chats tag-filter]]
+   (if (empty? tag-filter)
+     chats
+     (keep #(when (some (fn [tag]
+                          (string/includes? (string/lower-case tag)
+                                            (string/lower-case tag-filter)))
+                        (into [(:name (val %))] (:tags (val %))))
+              %)
+           chats))))
+
+(re-frame/reg-sub
+ :search/filtered-home-items
+ :<- [:search/filtered-active-chats]
+ (fn [active-chats]
+   active-chats))

--- a/src/status_im/ui/screens/db.cljs
+++ b/src/status_im/ui/screens/db.cljs
@@ -243,8 +243,10 @@
                  :transport.inbox/request-to
                  :desktop/desktop
                  :dimensions/window
-                 :dapps/permissions]
-
+                 :dapps/permissions
+                 :ui/contact
+                 :ui/search
+                 :ui/chat]
                 :opt-un
                 [::current-public-key
                  ::modal

--- a/src/status_im/ui/screens/subs.cljs
+++ b/src/status_im/ui/screens/subs.cljs
@@ -3,6 +3,7 @@
             [status-im.utils.ethereum.core :as ethereum]
             status-im.chat.subs
             status-im.contact.subs
+            status-im.search.subs
             status-im.ui.screens.accounts.subs
             status-im.ui.screens.extensions.subs
             status-im.ui.screens.home.subs

--- a/src/status_im/utils/db.cljs
+++ b/src/status_im/utils/db.cljs
@@ -10,3 +10,7 @@
 (spec/def :global/not-empty-string (spec/and string? not-empty))
 (spec/def :global/public-key (spec/and :global/not-empty-string valid-public-key?))
 (spec/def :global/address ethereum/address?)
+
+(spec/def :status/tag (spec/and :global/not-empty-string
+                                (partial re-matches #"[a-z0-9\-]+")))
+(spec/def :status/tags (spec/coll-of :status/tag :kind set?))

--- a/test/cljs/status_im/test/chat/subs.cljs
+++ b/test/cljs/status_im/test/chat/subs.cljs
@@ -118,4 +118,4 @@
     (testing "it returns only chats with is-active"
       (is (= {1 active-chat-1
               2 active-chat-2}
-             (s/active-chats chats))))))
+             (s/active-chats [{} chats]))))))


### PR DESCRIPTION
Fixes #6429

### Summary:

Add search feature for chat list

#### Platforms (optional)
- macOS
- Linux

### Steps to test:
- Open an account that has a lot of chats
- On top of chat list type something in the search field
- Only chats that match the search should be displayed

status: ready


![screenshot from 2018-10-19 16-29-34](https://user-images.githubusercontent.com/1181225/47224668-5b11b680-d3bc-11e8-9913-9b66b034c589.png)
![screenshot from 2018-10-19 16-29-48](https://user-images.githubusercontent.com/1181225/47224669-5b11b680-d3bc-11e8-92b7-798caefca3b2.png)
