### PR TITLE
[extensions] ethereum events

### DIFF
--- a/src/status_im/chat/commands/core.cljs
+++ b/src/status_im/chat/commands/core.cljs
@@ -139,7 +139,7 @@
     :parameters    [{:id           :keyword
                      :type         {:one-of #{:text :phone :password :number}}
                      :placeholder  :string
-                     :suggestions  :view}]}
+                     :suggestions? :view}]}
    :hook
    (reify hooks/Hook
      (hook-in [_ id {:keys [description scope parameters preview short-preview on-send on-receive]} cofx]

--- a/src/status_im/extensions/core.cljs
+++ b/src/status_im/extensions/core.cljs
@@ -16,13 +16,14 @@
             [status-im.ui.components.colors :as colors]
             [status-im.ui.screens.navigation :as navigation]
             [status-im.utils.handlers :as handlers]
-            [status-im.utils.fx :as fx]))
+            [status-im.utils.fx :as fx]
+            status-im.extensions.ethereum))
 
 (re-frame/reg-fx
  ::alert
  (fn [value] (js/alert value)))
 
-(re-frame/reg-event-fx
+(handlers/register-handler-fx
  :alert
  (fn [_ [_ {:keys [value]}]]
    {::alert value}))
@@ -31,7 +32,7 @@
  ::log
  (fn [value] (js/console.log value)))
 
-(re-frame/reg-event-fx
+(handlers/register-handler-fx
  :log
  (fn [_ [_ {:keys [value]}]]
    {::log value}))
@@ -148,7 +149,7 @@
                 'transaction-status {:value transactions/transaction-status :properties {:outgoing :string :tx-hash :string}}
                 'asset-selector     {:value transactions/choose-nft-asset-suggestion}
                 'token-selector     {:value transactions/choose-nft-token-suggestion}}
-   :queries    {'store/get {:value :store/get :arguments {:key :string}}
+   :queries    {'store/get           {:value :store/get :arguments {:key :string}}
                 'wallet/collectibles {:value :get-collectible-token :arguments {:token :string :symbol :string}}}
    :events     {'alert
                 {:permissions [:read]
@@ -191,30 +192,25 @@
                  :arguments   {:hash        :string
                                :on-success  :event
                                :on-failure? :event}}
-                'ethereum/sign
-                {:arguments
-                 {:account   :string
-                  :message   :string
-                  :on-result :event}}
                 'ethereum/send-transaction
-                {:arguments
-                 {:from       :string
-                  :to         :string
-                  :gas?       :string
-                  :gas-price? :string
-                  :value?     :string
-                  :data?      :string
-                  :nonce?     :string}}
+                {:permissions [:read]
+                 :value       :extensions/ethereum-send-transaction
+                 :arguments   {:to         :string
+                               :gas?       :string
+                               :gas-price? :string
+                               :value?     :string
+                               :method?    :string
+                               :params?    :vector
+                               :nonce?     :string
+                               :on-result? :event}}
                 'ethereum/call
-                {:arguments
-                 {:from?      :string
-                  :to         :string
-                  :gas?       :string
-                  :gas-price? :string
-                  :value?     :string
-                  :data?      :string
-                  :block      :string}}}
-   :hooks {:commands commands/command-hook}})
+                {:permissions [:read]
+                 :value       :extensions/ethereum-call
+                 :arguments   {:to         :string
+                               :method     :string
+                               :params?    :vector
+                               :on-result? :event}}}
+   :hooks      {:commands commands/command-hook}})
 
 (defn read-extension [{:keys [value]}]
   (when (seq value)

--- a/src/status_im/extensions/ethereum.cljs
+++ b/src/status_im/extensions/ethereum.cljs
@@ -1,0 +1,39 @@
+(ns status-im.extensions.ethereum
+  (:require [status-im.utils.handlers :as handlers]
+            [re-frame.core :as re-frame]
+            [status-im.models.wallet :as models.wallet]
+            [status-im.utils.ethereum.abi-spec :as abi-spec]
+            [status-im.utils.fx :as fx]
+            [status-im.ui.screens.navigation :as navigation]))
+
+(handlers/register-handler-fx
+ :extensions/transaction-on-result
+ (fn [cofx [_ on-result id result method]]
+   (fx/merge cofx
+             (when on-result
+               {:dispatch (on-result {:error nil :result result})})
+             (navigation/navigate-to-clean :wallet-transaction-sent nil))))
+
+(handlers/register-handler-fx
+ :extensions/transaction-on-error
+ (fn [{db :db} [_ on-result message]]
+   (when on-result {:dispatch (on-result {:error message :result nil})})))
+
+(handlers/register-handler-fx
+ :extensions/ethereum-send-transaction
+ (fn [{db :db} [_ {:keys [method params on-result] :as arguments}]]
+   (let [tx-object (assoc (select-keys arguments [:to :gas :gas-price :value :nonce])
+                          :data (when (and method params) (abi-spec/encode method params)))
+         transaction (models.wallet/prepare-extension-transaction tx-object (:contacts/contacts db) on-result)]
+     (models.wallet/open-modal-wallet-for-transaction db transaction tx-object))))
+
+(handlers/register-handler-fx
+ :extensions/ethereum-call
+ (fn [_ [_ {:keys [to method params on-result]}]]
+   (let [tx-object {:to to :data (when method (abi-spec/encode method params))}]
+     {:browser/call-rpc [{"jsonrpc" "2.0"
+                          "method"  "eth_call"
+                          "params"  [tx-object "latest"]}
+                         #(when on-result
+                            (re-frame/dispatch (on-result {:error %1 :result (when %2
+                                                                               (get (js->clj %2) "result"))})))]})))

--- a/src/status_im/ui/screens/wallet/send/db.cljs
+++ b/src/status_im/ui/screens/wallet/send/db.cljs
@@ -32,11 +32,12 @@
 (spec/def ::whisper-identity (spec/nilable string?))
 (spec/def ::method (spec/nilable string?))
 (spec/def ::tx-hash (spec/nilable string?))
-(spec/def ::dapp-transaction (spec/nilable any?))
+(spec/def ::on-result (spec/nilable any?))
+(spec/def ::on-error (spec/nilable any?))
 
 (spec/def :wallet/send-transaction (allowed-keys
                                     :opt-un [::amount ::to ::to-name ::amount-error ::asset-error ::amount-text
                                              ::password ::show-password-input? ::id ::from ::data ::nonce
-                                             ::camera-flashlight ::in-progress? ::dapp-transaction
+                                             ::camera-flashlight ::in-progress? ::on-result ::on-error
                                              ::wrong-password? ::from-chat? ::symbol ::advanced?
                                              ::gas ::gas-price ::whisper-identity ::method ::tx-hash]))


### PR DESCRIPTION
`ethereum/send-transaction` and `ethereum/call` events support

```
[button {:label "send value transaction" :on-click [ethereum/send-transaction {:to "0xdfb0c49664b4e5e14d9c54d563d8f8c9add7d4a3" :value val :on-result [tx-result]}]}]
    [button {:label "send data transaction" :on-click [ethereum/send-transaction {:to "0xc032537f648a7359076aad96b115c232530c2ff6" :method "set(uint256)" :params [20] :on-result [tx-result]}]}]
    [button {:label "call get" :on-click [ethereum/call {:to "0xc032537f648a7359076aad96b115c232530c2ff6" :method "get()" :on-result [tx-result]}]}]])
```

Example extension: https://get.status.im/extension/ipfs@QmVkdXbeXaidjc15mhT36vj6DD1qDkghATcy3QtGnxZGQ2



<blockquote></blockquote>


For QA: transactions from dapps should be tested