### PR TITLE
[TESTS] Can proceed using dapp after transacting tokens

### DIFF
--- a/test/appium/tests/atomic/dapps_and_browsing/test_dapps.py
+++ b/test/appium/tests/atomic/dapps_and_browsing/test_dapps.py
@@ -38,3 +38,25 @@ class TestDApps(SingleDeviceTestCase):
         status_test_dapp.allow_button.click()
         if not status_test_dapp.element_by_text(user['public_key']).is_element_displayed():
             pytest.fail('Public key is not returned')
+
+    @marks.testrail_id(5654)
+    @marks.low
+    def test_can_proceed_dapp_usage_after_transacting_it(self):
+        user = basic_user
+        sign_in_view = SignInView(self.driver)
+        home_view = sign_in_view.recover_access(passphrase=user['passphrase'])
+        chat = home_view.join_public_chat(home_view.get_public_chat_name())
+        chat.back_button.click()
+        status_test_dapp = home_view.open_status_test_dapp()
+        status_test_dapp.wait_for_d_aap_to_load()
+        status_test_dapp.assets_button.click()
+        send_transaction_view = status_test_dapp.request_stt_button.click()
+        wallet_view = send_transaction_view.get_wallet_view()
+        wallet_view.done_button.click()
+        wallet_view.yes_button.click()
+        send_transaction_view.advanced_button.click()
+        send_transaction_view.transaction_fee_button.click()
+        send_transaction_view.done_button.click()
+        send_transaction_view.sign_transaction()
+        if not status_test_dapp.assets_button.is_element_displayed():
+            self.driver.fail('Oops! Cannot proceed to use Status Test Dapp.')

--- a/test/appium/views/base_element.py
+++ b/test/appium/views/base_element.py
@@ -41,6 +41,11 @@ class BaseElement(object):
         def id(locator, value):
             return locator(MobileBy.ID, value)
 
+        @classmethod
+        def webview_selector(cls, value):
+            xpath_expression = '//*[@text="{0}"] | //*[@content-desc="{desc}"]'.format(value, desc=value)
+            return cls(MobileBy.XPATH, xpath_expression)
+
         def __str__(self, *args, **kwargs):
             return "%s:%s" % (self.by, self.value)
 

--- a/test/appium/views/web_views/status_test_dapp.py
+++ b/test/appium/views/web_views/status_test_dapp.py
@@ -5,24 +5,21 @@ class AssetsButton(BaseButton):
 
     def __init__(self, driver):
         super(AssetsButton, self).__init__(driver)
-        self.locator = self.Locator.text_selector('Assets')
+        self.locator = self.Locator.webview_selector('Assets')
 
     class RequestETHButton(BaseButton):
         def __init__(self, driver):
             super(AssetsButton.RequestETHButton, self).__init__(driver)
-            self.locator = self.Locator.text_selector('Request Ropsten ETH')
+            self.locator = self.Locator.webview_selector('Ropsten ETH')
 
     class RequestSTTButton(BaseButton):
         def __init__(self, driver):
             super(AssetsButton.RequestSTTButton, self).__init__(driver)
-            self.locator = self.Locator.text_selector('Request STT')
+            self.locator = self.Locator.webview_selector('Request STT')
 
         def navigate(self):
             from views.send_transaction_view import SendTransactionView
             return SendTransactionView(self.driver)
-
-    def click(self):
-        self.click_until_presence_of_element(self.RequestSTTButton(self.driver))
 
 
 class TransactionsButton(BaseButton):


### PR DESCRIPTION
### Summary:
The test is checking whether a user stays on Dapp screen after transaction is signed in Dapp.

In brief, the problem was that after transacting user was redirected to chat screen. 
Navigation occurred to the most recent chat visited before transacting in the Dapp. In a case, there were no chats prior Dapp TX at all - 'Unknown' chat created.
See origin https://github.com/status-im/status-react/issues/6283

**Steps:**

1. Recover an account with ETH > 0
2. Join random public chat
3. Navigate to SimpleTestDapp -> Assets
4. Tap Request STT. Finish Wallet Set Up.
5. Advanced -> Transaction Fee -> Tap Done button
6. Sign transaction