### PR TITLE
[fix 6410] error when fetching history on certain accounts

### DIFF
--- a/src/status_im/transport/core.cljs
+++ b/src/status_im/transport/core.cljs
@@ -31,7 +31,7 @@
                                             :private-key-id public-key
                                             :topic topic}
                  :shh/restore-sym-keys {:web3       web3
-                                        :transport  (:transport/chats db)
+                                        :transport  (filter (comp :topic second) (:transport/chats db))
                                         :on-success sym-key-added-callback}}
                 (inbox/connect-to-mailserver)
                 (message/resend-contact-messages [])))))

--- a/test/cljs/status_im/test/transport/core.cljs
+++ b/test/cljs/status_im/test/transport/core.cljs
@@ -1,15 +1,21 @@
 (ns status-im.test.transport.core
   (:require [cljs.test :refer-macros [deftest is testing]]
             [status-im.protocol.core :as protocol]
+            [status-im.transport.core :as transport]
             [status-im.transport.message.core :as message]))
 
 (deftest init-whisper
   (let [cofx {:db {:account/account {:public-key "1"}
+                   :transport/chats {"1" {:topic "topic-1"}
+                                     "2" {}
+                                     "3" {:topic "topic-3"}}
                    :semaphores #{}}}]
     (testing "it adds the discover filter"
-      (is (= (:shh/add-discovery-filter (protocol/initialize-protocol cofx "user-address")))))
+      (is (= {:web3 nil :private-key-id "1" :topic "0xf8946aac"}
+             (:shh/add-discovery-filter (transport/init-whisper cofx "user-address")))))
     (testing "it restores the sym-keys"
-      (is (= (:shh/restore-sym-keys (protocol/initialize-protocol cofx  "user-address")))))
+      (is (= [["1" {:topic "topic-1"}] ["3" {:topic "topic-3"}]]
+             (-> (transport/init-whisper cofx  "user-address") :shh/restore-sym-keys :transport))))
     (testing "custom mailservers"
       (let [ms-1            {:id "1"
                              :fleet :eth.beta


### PR DESCRIPTION
fixes #6410

### Summary:
- 1-1 chats don't have a topic anymore because they only use the
discovery topic so topic is nil for these chat
- this was causing an error when initializing whisper because the app
was trying to start a filter for each of the chat including the 1-1 with
no topic
- we now filter the transport/chats to only recover sym-key and start filter
for those with a topic

#### Platforms
- Android
- iOS
- macOS
- Linux

#### Areas that maybe impacted
**Functional**
- 1-1 chats
- public chats
- group chats
- mailservers

### Steps to test:
- Open Status with affected account
- should now recover history

status: ready