### PR TITLE
[TESTS] Can open public chat using deep link

### DIFF
--- a/test/appium/tests/atomic/dapps_and_browsing/test_deep_links.py
+++ b/test/appium/tests/atomic/dapps_and_browsing/test_deep_links.py
@@ -19,7 +19,7 @@ class TestDeepLinks(SingleDeviceTestCase):
         chat_name = sign_in_view.get_public_chat_name()
         sign_in_view.send_as_keyevent('https://get.status.im/chat/public/%s' % chat_name)
         sign_in_view.confirm()
-        open_button = sign_in_view.element_by_text('Open in Status')
+        open_button = sign_in_view.element_by_xpath('//*[@text="Open in Status"] | //*[@content-desc="Open in Status"]')
         open_button.wait_for_visibility_of_element()
         open_button.click()
         sign_in_view.sign_in()


### PR DESCRIPTION
### Summary:
fix test for nightly im.status.ethereum-e2e-83a92a.apk

Changed element locator to work on both Saucelab and local environment.