### PR TITLE
Issue template: create simple.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/simple.md
+++ b/.github/ISSUE_TEMPLATE/simple.md
@@ -1,0 +1,27 @@
+---
+name: Simple
+about: Simple issue report.
+
+---
+
+# Problem
+
+An overview of the background required to understand the problem.
+A problem description.
+
+# Implementation
+
+Known steps towards feature implementation.
+What needs further specifying and investigating.
+
+# Acceptance Criteria
+
+Rules for the future PR to be accepted.
+
+# Notes
+
+Random notes to keep in mind while implementing it. Mostly about related issues and future plans and thoughts.
+
+# Future Steps
+
+Steps which should be taken after this issue has been resolved.


### PR DESCRIPTION
Simple issue reporter based on status-go. The current one is too bloated for most issues and only applicable for some bug reports. We can create multiple ones like this: https://help.github.com/articles/manually-creating-a-single-issue-template-for-your-repository.

<blockquote><div><strong><a href="https://help.github.com/articles/manually-creating-a-single-issue-template-for-your-repository">Manually creating a single issue template for your repository - User Documentation</a></strong></div><div>When you add a manually-created issue template to your repository, project contributors will automatically see the template's contents in the issue body.
…</div></blockquote>