### PR TITLE
(No code): Github issue simple template

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT_TEMPLATE.md
@@ -1,0 +1,51 @@
+---
+name: Full Bug Report
+about: Full bug report.
+---
+
+[comment]: # (Please replace ... with your information. Remove < and >)
+
+### User Story
+
+As a <user|developer|...>, I want to <task> so that <goal>.
+
+### Description
+
+[comment]: # (Feature or Bug? i.e Type: Bug)
+*Type*: <Bug|Feature>
+
+[comment]: # (Describe the feature you would like, or briefly summarise the bug and what you did, what you expected to happen, and what actually happens. Sections below)
+*Summary*: ...
+
+#### Expected behavior
+[comment]: # (Describe what you expected to happen.)
+
+#### Actual behavior
+[comment]: # (Describe what actually happened.)
+
+### Reproduction
+[comment]: # (Describe how we can replicate the bug step by step.)
+
+- Open Status
+- ...
+- Step 3, etc.
+
+### Solution
+[comment]: # (Please summarise the solution and provide a task list on what needs to be fixed.)
+*Summary*: 
+
+- [ ] ...
+- [ ] ...
+
+### Additional Information
+[comment]: # (Please do your best to fill this out.)
+* Status version: ...
+[comment]: # (Android or iOS.)
+* Operating System: <Android|iOS>
+
+#### Logs
+
+[comment]: # (if on Android please replicate bug whilst running adb logcat)
+```
+...
+```

--- a/.github/ISSUE_TEMPLATE/SIMPLE_ISSUE.md
+++ b/.github/ISSUE_TEMPLATE/SIMPLE_ISSUE.md
@@ -1,0 +1,26 @@
+---
+name: Simple Issue Report
+about: Simple issue report.
+---
+
+# Problem
+
+An overview of the background required to understand the problem.
+A problem description.
+
+# Implementation
+
+Known steps towards feature implementation.
+What needs further specifying and investigating.
+
+# Acceptance Criteria
+
+Rules for the future PR to be accepted.
+
+# Notes
+
+Random notes to keep in mind while implementing it. Mostly about related issues and future plans and thoughts.
+
+# Future Steps
+
+Steps which should be taken after this issue has been resolved.


### PR DESCRIPTION
Allows for a simple issue report that isn't as bloated. Both should show up as options in UI now, I believe.

No code changes, just GH UI config for issue templates.