### PR TITLE
Fixed incorrect on-send / on-receive handling

### DIFF
--- a/src/status_im/chat/commands/core.cljs
+++ b/src/status_im/chat/commands/core.cljs
@@ -149,8 +149,8 @@
                            (description [_] description)
                            (parameters [_] parameters)
                            (validate [_ _ _])
-                           (on-send [_ _ _] (when on-send {:dispatch on-send}))
-                           (on-receive [_ _ _] (when on-receive {:dispatch on-receive}))
+                           (on-send [_ command-message _] (when on-send {:dispatch (on-send {:value command-message})}))
+                           (on-receive [_ command-message _] (when on-receive {:dispatch (on-receive {:value command-message})}))
                            (short-preview [_ props] (short-preview props))
                            (preview [_ props] (preview props)))]
          (load-commands cofx [new-command])))


### PR DESCRIPTION
### Summary:

Fixed bug when defining `on-send` and `on-receive` chat command hook.