### PR TITLE
[6454] dont clear chat history on deletion

### DIFF
--- a/src/status_im/chat/models.cljs
+++ b/src/status_im/chat/models.cljs
@@ -122,7 +122,6 @@
             #(when (public-chat? % chat-id)
                (transport.chat/unsubscribe-from-chat % chat-id))
             (deactivate-chat chat-id)
-            (clear-history chat-id)
             (navigation/navigate-to-cofx :home {})))
 
 (fx/defn send-messages-seen


### PR DESCRIPTION
fixes #6454  

### Summary:

Summary:

If a public chat is removed from the chat list and then reopened again, its content is empty. There is "Fetching messages" but the old messages (before removing the chat) do not appear. I think it's counter-intuitive and the app should display old messages when public chat is re-opened.
I'd say old messages should be displayed even though the user has cleared the chat before removing it. So basically joining/re-opening a public chat should fetch all messages.

Reproduction
Join public chat with some messages
Remove it
Join the same public chat again
User should see historical messages (currently 7 days of history) which is not the case

### Review notes (optional):
This is my first PR on a issue on status-react. So I'm not familiar with all the ramifications here but this appears to solve it. 

It seems like `clear-history` is miss-used here.

status: ready 
