### PR TITLE
Support of java 8+ versions

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -23,7 +23,7 @@
          ;; Figwheel ClojureScript REPL
          cider/piggieback        {:mvn/version "0.3.9"
                                   :exclusions  [com.google.javascript/closure-compiler]}
-         figwheel-sidecar        {:mvn/version "0.5.16"
+         figwheel-sidecar        {:mvn/version "0.5.17"
                                   :exclusions  [com.google.javascript/closure-compiler]}
          re-frisk-remote         {:mvn/version "0.5.5"}
          re-frisk-sidecar        {:mvn/version "0.5.7"}

--- a/project.clj
+++ b/project.clj
@@ -64,7 +64,7 @@
                         :repl-options {:nrepl-middleware [cider.piggieback/wrap-cljs-repl]
                                        :timeout          240000}}
              :figwheel [:dev
-                        {:dependencies [[figwheel-sidecar "0.5.16-SNAPSHOT"]
+                        {:dependencies [[figwheel-sidecar "0.5.17"]
                                         [re-frisk-remote "0.5.5"]
                                         [re-frisk-sidecar "0.5.7"]
                                         [day8.re-frame/tracing "0.5.0"]


### PR DESCRIPTION
Running `lein` build commands with openjdk `10.0.2` installed failures with output similar to:
```
Exception in thread "main" java.lang.ClassNotFoundException: javax.xml.bind.DatatypeConverter, compiling:(org/httpkit/server.clj:1:1)
...
Caused by: java.lang.ClassNotFoundException: javax.xml.bind.DatatypeConverter
``` 
Updating of figwheel-sidecar to 0.5.17 resolves above issue