### PR TITLE
[fix] add missing account schema in base schemas

### DIFF
--- a/src/status_im/data_store/realm/schemas/base/core.cljs
+++ b/src/status_im/data_store/realm/schemas/base/core.cljs
@@ -44,7 +44,8 @@
 
 (def v12 [network/v1
           bootnode/v4
-          extension/v12])
+          extension/v12
+          account/v12])
 
 (def v13 [network/v1
           bootnode/v4


### PR DESCRIPTION
### Review notes
The account schema is missing in v12

#### Areas that maybe impacted
**Functional**
- upgrade

<!-- (Specify exact steps to test if there are such) -->
### Steps to test:
- Upgrade from previous release with multiple accounts
- Accounts should still be there


status: ready
