### PR TITLE
Deduplication-ids

### DIFF
--- a/src/status_im/chat/models/loading.cljs
+++ b/src/status_im/chat/models/loading.cljs
@@ -79,7 +79,8 @@
 (fx/defn initialize-chats
   "Initialize all persisted chats on startup"
   [{:keys [db default-dapps all-stored-chats get-stored-messages get-stored-user-statuses
-           get-stored-unviewed-messages get-referenced-messages stored-message-ids] :as cofx}]
+           get-stored-unviewed-messages get-referenced-messages stored-message-ids
+           stored-deduplication-ids] :as cofx}]
   (let [stored-unviewed-messages (get-stored-unviewed-messages (:current-public-key db))
         chats (reduce (fn [acc {:keys [chat-id] :as chat}]
                         (let [chat-messages (index-messages (get-stored-messages chat-id))
@@ -90,6 +91,7 @@
                                         :unviewed-messages unviewed-ids
                                         :messages chat-messages
                                         :message-statuses (get-stored-user-statuses chat-id message-ids)
+                                        :deduplication-ids (get stored-deduplication-ids chat-id)
                                         :not-loaded-message-ids (set/difference (get stored-message-ids chat-id)
                                                                                 (set message-ids))
                                         :referenced-messages (index-messages

--- a/src/status_im/chat/models/message.cljs
+++ b/src/status_im/chat/models/message.cljs
@@ -152,14 +152,13 @@
             (chat-loading/group-chat-messages chat-id (get chat->message chat-id))))
 
 (defn- add-to-chat?
-  [{:keys [db]} {:keys [chat-id clock-value message-id message-id-old-format] :as message}]
-  (let [{:keys [deleted-at-clock-value messages not-loaded-message-ids]}
+  [{:keys [db]} {:keys [chat-id clock-value message-id from] :as message}]
+  (let [deduplication-id (messages-store/deduplication-id from chat-id clock-value)
+        {:keys [deleted-at-clock-value messages not-loaded-message-ids deduplication-ids]}
         (get-in db [:chats chat-id])]
     (not (or (get messages message-id)
-             ;; TODO(rasom): remove this condition
-             ;; on when 0.9.29 will not be available for users
-             (and message-id-old-format (get messages message-id-old-format))
              (get not-loaded-message-ids message-id)
+             (get deduplication-ids deduplication-id)
              (>= deleted-at-clock-value clock-value)))))
 
 (defn- filter-messages [cofx messages]

--- a/src/status_im/chat/specs.cljs
+++ b/src/status_im/chat/specs.cljs
@@ -18,6 +18,7 @@
 (s/def :chat/message-statuses (s/nilable map?))                   ; message/user statuses indexed by two level index
 (s/def :chat/not-loaded-message-ids (s/nilable set?))             ; set of message-ids not yet fully loaded from persisted state
 (s/def :chat/referenced-messages (s/nilable map?))                ; map of messages indexed by message-id which are not displayed directly, but referenced by other messages
+(s/def :chat/deduplication-ids (s/nilable set?))                  ; set of helper deduplication ids
 (s/def :chat/last-clock-value (s/nilable number?))                ; last logical clock value of messages in chat
 (s/def :chat/loaded-chats (s/nilable seq?))
 (s/def :chat/bot-db (s/nilable map?))

--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -92,6 +92,7 @@
   (re-frame/inject-cofx :data-store/get-unviewed-messages)
   (re-frame/inject-cofx :data-store/get-referenced-messages)
   (re-frame/inject-cofx :data-store/message-ids)
+  (re-frame/inject-cofx :data-store/deduplication-ids)
   (re-frame/inject-cofx :data-store/get-local-storage-data)
   (re-frame/inject-cofx :data-store/get-all-contacts)
   (re-frame/inject-cofx :data-store/get-all-mailservers)

--- a/src/status_im/transport/message/protocol.cljs
+++ b/src/status_im/transport/message/protocol.cljs
@@ -105,18 +105,13 @@
            this)
           (send-with-pubkey cofx params)))))
   (receive [this chat-id signature _ cofx]
-    (let [old-message (Message. (:text content) content-type message-type
-                                clock-value timestamp)]
-      {:chat-received-message/add-fx
-       [(assoc (into {} this)
-               :message-id (transport.utils/message-id this)
-               ;; TODO(rasom): remove this condition
-               ;; on when 0.9.29 will not be available for users
-               :message-id-old-format (transport.utils/message-id-old-format old-message)
-               :show? true
-               :chat-id chat-id
-               :from signature
-               :js-obj (:js-obj cofx))]}))
+    {:chat-received-message/add-fx
+     [(assoc (into {} this)
+             :message-id (transport.utils/message-id this)
+             :show? true
+             :chat-id chat-id
+             :from signature
+             :js-obj (:js-obj cofx))]})
   (validate [this]
     (if (spec/valid? :message/message this)
       this

--- a/src/status_im/transport/utils.cljs
+++ b/src/status_im/transport/utils.cljs
@@ -22,15 +22,6 @@
   [message]
   (sha3 (pr-str message)))
 
-(defn message-id-old-format
-  "Get an old format message-id.
-   To be removed on 8th day after 0.9.30"
-  [message]
-  (-> message
-      pr-str
-      (clojure.string/replace "message.protocol" "message.v1.protocol")
-      sha3))
-
 (defn get-topic
   "Get the topic of a group chat or public chat from the chat-id"
   [chat-id]

--- a/src/status_im/ui/screens/db.cljs
+++ b/src/status_im/ui/screens/db.cljs
@@ -296,6 +296,7 @@
                  :chat/message-groups
                  :chat/message-statuses
                  :chat/not-loaded-message-ids
+                 :chat/deduplication-ids
                  :chat/referenced-messages
                  :chat/last-clock-value
                  :chat/loaded-chats


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes #6460 and #6438 by maintaining a set of de-duplication ids computed from all messages persisted on device and always comparing de-duplication id of newly arrived message with this set.
Deduplication id is `sha(sender-pk, chat-id, clock-value)`.
This solution should be fairly robust, although little bit performance & memory consuming, we will kick it out once we implement sane message ids and safe period of 7days (are whatever will be fetched into history) after sane message ids are implemented will pass.

status: ready
