### PR TITLE
move google repo before jcenter for maven

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,12 +18,12 @@ buildscript {
 allprojects {
     repositories {
         mavenLocal()
+        google()
         jcenter()
         maven { url "$rootDir/../node_modules/react-native/android" }
         maven { url "$rootDir/../modules/react-native-status/android/libs" }
         // for geth, function, and status-go
         flatDir { dirs "libs", "${rootDir}/app/libs" }
         maven { url "https://jitpack.io" }
-        google()
     }
 }


### PR DESCRIPTION
I'm not sure but this might fix the issues with Android builds failing due to:
```
Could not resolve all files for configuration ':react-native-camera:releaseCompileClasspath'.
> Could not find play-services-basement.aar (com.google.android.gms:play-services-basement:15.0.1).
  Searched in the following locations:
      https://jcenter.bintray.com/com/google/android/gms/play-services-basement/15.0.1/play-services-basement-15.0.1.aar
```