### PR TITLE
dont delete public chat history in app-db

### DIFF
--- a/src/status_im/chat/models.cljs
+++ b/src/status_im/chat/models.cljs
@@ -122,7 +122,9 @@
             #(when (public-chat? % chat-id)
                (transport.chat/unsubscribe-from-chat % chat-id))
             (deactivate-chat chat-id)
-            (clear-history chat-id)
+            #(if-not (public-chat? % chat-id)
+               (clear-history % chat-id)
+               {:data-store/tx [(messages-store/delete-messages-tx chat-id)]})
             (navigation/navigate-to-cofx :home {})))
 
 (fx/defn send-messages-seen

--- a/src/status_im/data_store/chats.cljs
+++ b/src/status_im/data_store/chats.cljs
@@ -81,12 +81,11 @@
      (update chat :membership-updates marshal-membership-updates)
      true)))
 
-;; Only used in debug mode
 (defn delete-chat-tx
   "Returns tx function for hard deleting the chat"
   [chat-id]
   (fn [realm]
-    (core/delete realm (core/get-by-field realm :chat :chat chat-id))))
+    (core/delete realm (core/get-by-field realm :chat :chat-id chat-id))))
 
 (defn- get-chat-by-id [chat-id realm]
   (core/single (core/get-by-field realm :chat :chat-id chat-id)))


### PR DESCRIPTION
fixes #6454 

### Summary:

**From issue**
If a public chat is removed from the chat list and then reopened again, its content is empty. There is "Fetching messages" but the old messages (before removing the chat) do not appear. I think it's counter-intuitive and the app should display old messages when public chat is re-opened.
I'd say old messages should be displayed even though the user has cleared the chat before removing it. So basically joining/re-opening a public chat should fetch all messages.

**This PR stops treating public and non public chats the same**, when you delete a public chat it doesn't clear the history.  It does delete the public chat messages from the local persistent store as an added layer of security.

The result is a balance of security and you get the needed behavior that if you delete a public chat and rejoin you are not presented with an empty chat window.

#### Areas that maybe impacted (optional)
**Functional**
- 1-1 chats
- public chats
- group chats

### Steps to test:
- Open Status

Public chats
* Join public chat with some messages
* hit delete chat
* Join the same public chat again
* User should see historical messages (currently 7 days of history) which is not the case

1-1 chats
* initiate a 1-1 chat
* type a few messages
* hit delete chat
* initiate the same 1-1 chat with the same person
* the previous messages should not be seen

status: ready
