### PR TITLE
[TESTS] User can remove profile picture

### DIFF
--- a/test/appium/tests/atomic/account_management/test_profile.py
+++ b/test/appium/tests/atomic/account_management/test_profile.py
@@ -24,6 +24,22 @@ class TestProfileSingleDevice(SingleDeviceTestCase):
         if not profile_view.profile_picture.is_element_image_equals_template():
             pytest.fail('Profile picture was not updated')
 
+    @marks.testrail_id(5454)
+    @marks.critical
+    def test_user_can_remove_profile_picture(self):
+        signin_view = SignInView(self.driver)
+        home_view = signin_view.create_user()
+        profile_view = home_view.profile_button.click()
+        profile_view.edit_profile_picture('sauce_logo.png')
+        profile_view.swipe_down()
+        if not profile_view.profile_picture.is_element_image_equals_template():
+            self.driver.fail('Profile picture was not updated')
+
+        profile_view.remove_profile_picture()
+        profile_view.swipe_down()
+        if profile_view.profile_picture.is_element_image_equals_template():
+            self.driver.fail('Profile picture was not deleted')
+
     @marks.testrail_id(5323)
     @marks.critical
     def test_share_contact_code_and_wallet_address(self):

--- a/test/appium/views/profile_view.py
+++ b/test/appium/views/profile_view.py
@@ -394,6 +394,12 @@ class AboutButton(BaseButton):
         return self.navigate()
 
 
+class RemovePictureButton(BaseButton):
+    def __init__(self, driver):
+        super().__init__(driver)
+        self.locator = self.Locator.text_selector('Remove current photo')
+
+
 class ProfileView(BaseView):
 
     def __init__(self, driver):
@@ -427,6 +433,7 @@ class ProfileView(BaseView):
         self.edit_button = EditButton(self.driver)
         self.profile_picture = ProfilePictureElement(self.driver)
         self.edit_picture_button = EditPictureButton(self.driver)
+        self.remove_picture_button = RemovePictureButton(self.driver)
         self.confirm_edit_button = ConfirmEditButton(self.driver)
         self.cross_icon = CrossIcon(self.driver)
         self.share_button = ShareButton(self.driver)
@@ -505,10 +512,10 @@ class ProfileView(BaseView):
     def edit_profile_picture(self, file_name: str):
         if not AbstractTestCase().environment == 'sauce':
             raise NotImplementedError('Test case is implemented to run on SauceLabs only')
-        self.profile_picture.template = file_name
         self.edit_button.click()
         self.swipe_down()
         self.edit_picture_button.click()
+        self.profile_picture.template = file_name
         self.select_from_gallery_button.click()
         if self.allow_button.is_element_displayed(sec=10):
             self.allow_button.click()
@@ -517,6 +524,15 @@ class ProfileView(BaseView):
             for element_text in 'Images', 'DCIM':
                 self.element_by_text(element_text).click()
         picture.click()
+        self.confirm_edit_button.click()
+
+    def remove_profile_picture(self):
+        if not AbstractTestCase().environment == 'sauce':
+            raise NotImplementedError('Test case is implemented to run on SauceLabs only')
+        self.edit_button.click()
+        self.swipe_down()
+        self.edit_picture_button.click()
+        self.remove_picture_button.click()
         self.confirm_edit_button.click()
 
     def logout(self):


### PR DESCRIPTION
### Summary:
Verify that user can remove the profile avatar.

### Review notes:
modified a bit `edit_profile_picture()` method signature to perform two types of actions: deleting and editing

### Steps to test:

1. Open Status app
2. Go to profile and remove profile picture
3. Set profile picture from gallery
4. Refresh screen 
5. Remove profile picture
6. Refresh screen and check the profile picture

**Expected result:**
it is removed

