### PR TITLE
[Fix 6500 6501] fix search and chat order

### DIFF
--- a/src/status_im/chat/subs.cljs
+++ b/src/status_im/chat/subs.cljs
@@ -80,7 +80,10 @@
   (reduce (fn [acc [chat-id {:keys [is-active] :as chat}]]
             (if is-active
               (assoc acc chat-id (if-let [contact (get contacts chat-id)]
-                                   (update chat :tags clojure.set/union (:tags contact))
+                                   (-> chat
+                                       (assoc :name (:name contact))
+                                       (assoc :random-name (gfycat/generate-gfy (:whisper-identity contact)))
+                                       (update :tags clojure.set/union (:tags contact)))
                                    chat))
               acc))
           {}

--- a/src/status_im/search/subs.cljs
+++ b/src/status_im/search/subs.cljs
@@ -7,19 +7,25 @@
  (fn [db]
    (get-in db [:ui/search :filter] "")))
 
+(defn filter-chats
+  [[chats search-filter]]
+  (if (empty? search-filter)
+    chats
+    (let [search-filter (string/lower-case search-filter)]
+      (keep #(let [{:keys [name random-name tags]} (val %)]
+               (when (some (fn [s]
+                             (when s
+                               (string/includes? (string/lower-case s)
+                                                 search-filter)))
+                           (into [name random-name] tags))
+                 %))
+            chats))))
+
 (re-frame/reg-sub
  :search/filtered-active-chats
  :<- [:get-active-chats]
  :<- [:search/filter]
- (fn [[chats tag-filter]]
-   (if (empty? tag-filter)
-     chats
-     (keep #(when (some (fn [tag]
-                          (string/includes? (string/lower-case tag)
-                                            (string/lower-case tag-filter)))
-                        (into [(:name (val %))] (:tags (val %))))
-              %)
-           chats))))
+ filter-chats)
 
 (re-frame/reg-sub
  :search/filtered-home-items

--- a/src/status_im/search/subs.cljs
+++ b/src/status_im/search/subs.cljs
@@ -31,4 +31,4 @@
  :search/filtered-home-items
  :<- [:search/filtered-active-chats]
  (fn [active-chats]
-   active-chats))
+   (sort-by #(-> % second :timestamp) > active-chats)))

--- a/test/cljs/status_im/test/runner.cljs
+++ b/test/cljs/status_im/test/runner.cljs
@@ -17,6 +17,7 @@
             [status-im.test.models.contact]
             [status-im.test.models.network]
             [status-im.test.models.wallet]
+            [status-im.test.search.core]
             [status-im.test.transport.core]
             [status-im.test.transport.inbox]
             [status-im.test.chat.models]
@@ -96,6 +97,7 @@
  'status-im.test.chat.commands.input
  'status-im.test.chat.commands.impl.transactions
  'status-im.test.i18n
+ 'status-im.test.search.core
  'status-im.test.transport.core
  'status-im.test.transport.inbox
  'status-im.test.protocol.web3.inbox

--- a/test/cljs/status_im/test/search/core.cljs
+++ b/test/cljs/status_im/test/search/core.cljs
@@ -1,0 +1,29 @@
+(ns status-im.test.search.core
+  (:require [cljs.test :refer-macros [deftest testing is]]
+            [status-im.search.subs :as search.subs]))
+
+(deftest filter-chats
+  (let [chats {:chat-1 {:name "name1"
+                        :random-name "random-name1"
+                        :tags #{"tag1"}}
+               :chat-2 {:name "name2"
+                        :random-name "random-name2"
+                        :tags #{"tag2" "tag3"}}
+               :chat-3 {:name "name3"
+                        :random-name "random-name3"
+                        :tags #{}}
+               :chat-4 {:name "name4"
+                        :random-name "random-name4"
+                        :tags #{"tag4"}}}]
+    (testing "no search filter"
+      (is (= 4 (count (search.subs/filter-chats [chats ""])))))
+    (testing "searching for a specific tag"
+      (is (= 1 (count (search.subs/filter-chats [chats "tag2"])))))
+    (testing "searching for a partial tag"
+      (is (= 3 (count (search.subs/filter-chats [chats "tag"])))))
+    (testing "searching for a specific random-name"
+      (is (= 1 (count (search.subs/filter-chats [chats "random-name1"])))))
+    (testing "searching for a partial random-name"
+      (is (= 4 (count (search.subs/filter-chats [chats "random-name"])))))
+    (testing "searching for a specific chat name"
+      (is (= 1 (count (search.subs/filter-chats [chats "name4"])))))))


### PR DESCRIPTION
fixes #6500 #6501

### Summary:

- chat name is not consistent with contact name, if contact added user and was added back by user, chat name keeps the random name of the contact
- fixed by associng contact name and random name to chat in subscription
- order is fixed by sorting chats after filtering

#### Platforms
- macOS
- Linux

<!-- (Specify if some specific areas has to be tested, for example 1-1 chats) -->
#### Areas that maybe impacted
**Functional**
- chat list
- search

<!-- (Specify exact steps to test if there are such) -->
### Steps to test:
- Open Status on an account with many chats
- Check that contact can be found by username and random name
- Check that chats are ordered by last message received

status: ready
