### PR TITLE
[fix 6508] user own picture should be unclickable in chats

### DIFF
--- a/src/status_im/ui/screens/desktop/main/chat/views.cljs
+++ b/src/status_im/ui/screens/desktop/main/chat/views.cljs
@@ -75,24 +75,17 @@
        [react/text {:style styles/author :font :medium} name]])))
 
 (views/defview member-photo [from]
-  (views/letsubs [photo-path [:get-photo-path from]]
+  (views/letsubs [current-public-key [:get-current-public-key]
+                  photo-path [:get-photo-path from]]
     [react/view {:style {:width 40 :margin-horizontal 16}}
      [react/view {:style {:position :absolute}}
-      [react/touchable-highlight {:on-press #(re-frame/dispatch [:show-profile-desktop from])}
+      [react/touchable-highlight {:on-press #(when-not (= current-public-key from)
+                                               (re-frame/dispatch [:show-profile-desktop from]))}
        [react/view {:style styles/member-photo-container}
         [react/image {:source {:uri (if (string/blank? photo-path)
                                       (identicon/identicon from)
                                       photo-path)}
                       :style  styles/photo-style}]]]]]))
-
-(views/defview my-photo [from]
-  (views/letsubs [account [:get-current-account]]
-    (let [{:keys [photo-path]} account]
-      [react/view
-       [react/image {:source {:uri (if (string/blank? photo-path)
-                                     (identicon/identicon from)
-                                     photo-path)}
-                     :style  styles/photo-style}]])))
 
 (views/defview quoted-message [{:keys [from text]} outgoing current-public-key]
   (views/letsubs [username [:get-contact-name-by-identity from]]


### PR DESCRIPTION
fixes #6508 

### Summary:

Make own user picture unclickable in chats

#### Platforms

- macOS
- Linux

<!-- (Specify if some specific areas has to be tested, for example 1-1 chats) -->
#### Areas that maybe impacted
**Functional**
- 1-1 chats
- public chats
- group chats

<!-- (Specify exact steps to test if there are such) -->
### Steps to test:
- Open Status
- Join a public and 1-1 chat
- Own user picture shouldn't be clickable

status: ready
