### PR TITLE
fix typo in clj-rn conf

### DIFF
--- a/clj-rn.conf.edn
+++ b/clj-rn.conf.edn
@@ -88,7 +88,7 @@
 
  :builds [{:id           :desktop
            :source-paths ["react-native/src/desktop" "src" "env/dev"]
-           :compiler     {:output-to     "target/ios/desktop.js"
+           :compiler     {:output-to     "target/desktop/app.js"
                           :main          "env.desktop.main"
                           :output-dir    "target/desktop"
                           :npm-deps      false


### PR DESCRIPTION
### Summary:

Fix typo in clj-rn conf

status: ready