### PR TITLE
remove "react-native/src/mobile" from deps.edn paths

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,4 +1,4 @@
-{:paths ["components/src" "src" "react-native/src/cljsjs" "react-native/src/mobile" "resources"]
+{:paths ["components/src" "src" "react-native/src/cljsjs" "resources"]
  :deps  {org.clojure/clojure         {:mvn/version "1.9.0"}
          org.clojure/clojurescript   {:mvn/version "1.10.238"}
          org.clojure/core.async      {:mvn/version "0.4.474"}


### PR DESCRIPTION
### Summary:

Now that desktop is also built with clj-rn this was causing js-dependencies for mobile to be added into the desktop files causing errors when building from scratch

status: ready
