### PR TITLE
ULC mode for Ropsten

### DIFF
--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -70,6 +70,11 @@
                   :config {:NetworkId      (ethereum/chain-keyword->chain-id :testnet)
                            :DataDir        "/ethereum/testnet"
                            :LightEthConfig {:Enabled true}}}
+   "testnet_ulc" {:id     "testnet_ulc",
+                  :name   "Ropsten ULC",
+                  :config {:NetworkId      (ethereum/chain-keyword->chain-id :testnet)
+                           :DataDir        "/ethereum/testnet_ulc"
+                           :LightEthConfig {:Enabled true :ULC true}}}
    "testnet_rpc" {:id     "testnet_rpc",
                   :name   "Ropsten with upstream RPC",
                   :config {:NetworkId      (ethereum/chain-keyword->chain-id :testnet)

--- a/src/status_im/node/core.cljs
+++ b/src/status_im/node/core.cljs
@@ -77,6 +77,16 @@
       (if utils.platform/desktop? ""
           config/log-level-status-go)))
 
+(defn- ulc-network? [config]
+  (get-in config [:LightEthConfig :ULC] false))
+
+(defn- add-ulc-trusted-nodes [config trusted-nodes]
+  (if (ulc-network? config)
+    (-> config
+        (assoc-in [:LightEthConfig :TrustedNodes] trusted-nodes)
+        (assoc-in [:LightEthConfig :MinTrustedFraction] 50))
+    config))
+
 (defn- get-account-node-config [db address]
   (let [accounts (get db :accounts/accounts)
         current-fleet-key (fleet/current-fleet db address)
@@ -120,6 +130,9 @@
        config/bootnodes-settings-enabled?
        use-custom-bootnodes)
       (add-custom-bootnodes network bootnodes)
+
+      :always
+      (add-ulc-trusted-nodes (vals (:static current-fleet)))
 
       :always
       (add-log-level log-level))))


### PR DESCRIPTION
UPD (2019-02-19):

This commit adds necessary configuration tweaks and additional to use ULC (instead of LES) on Ropsten. The LES/ULC functionality is untested and might not work, but the configuration entries are there for when we pick it back up.

---

This commit enables ULC mode on Ropsten, by adding an additional network.

It also upgrades status-go to 0.16.7, a version that supports ULC (contains the ULC patch).

---

part of #6476

#### TODO
- [x] Merge #6325
- [x] Upgrade status-go

status: ready <!-- Can be ready or wip -->
