### PR TITLE
GET /networks endpoint for development server

### DIFF
--- a/src/status_im/models/dev_server.cljs
+++ b/src/status_im/models/dev_server.cljs
@@ -50,6 +50,17 @@
                                              :network-id network-id
                                              :reason     reason}]})}))
 
+(defmethod process-request! [:GET "networks" nil]
+  [{:keys [cofx]}]
+  (let [{:keys [networks network]} (get-in cofx [:db :account/account])
+        networks (->> networks
+                      (map (fn [[id m]]
+                             [id (-> m
+                                     (select-keys [:id :name :config])
+                                     (assoc :active? (= id network)))]))
+                      (into {}))]
+    {:dev-server/respond [200 {:networks networks}]}))
+
 (defmethod process-request! [:DELETE "network" nil]
   [{:keys [cofx data]}]
   (network/delete


### PR DESCRIPTION
Adds GET /network to allow Embark developers to know what networks are added and which one is active.

Request/response example:
```
$ http -v --json GET localhost:5561/networks

GET /networks HTTP/1.1
Accept: application/json, */*
Accept-Encoding: gzip, deflate
Connection: keep-alive
Content-Type: application/json
Host: localhost:5561
User-Agent: HTTPie/0.9.9



HTTP/1.1 200 OK
Cache-Control: no-cache
Connection: Close
Content-Length: 1124
Content-Type: application/json
Date: Sun, 28 Oct 2018 13:48:36 GMT
Server: WGCDWebServer

{
    "networks": {
        "testnet": {
            "active?": false,
            "config": {
                "DataDir": "/ethereum/testnet",
                "LightEthConfig": {
                    "Enabled": true
                },
                "NetworkId": 3
            },
            "id": "testnet",
            "name": "Ropsten"
        },
        "testnet_rpc": {
            "active?": true,
            "config": {
                "DataDir": "/ethereum/testnet_rpc",
                "NetworkId": 3,
                "UpstreamConfig": {
                    "Enabled": true,
                    "URL": "https://ropsten.infura.io/z6GCTmjdP3FETEJmMBI4"
                }
            },
            "id": "testnet_rpc",
            "name": "Ropsten with upstream RPC"
        },
        ...
    }
}