### PR TITLE
[#6517] Fix bugged quantity on chat command preview (iOS)

### DIFF
--- a/src/status_im/i18n.cljs
+++ b/src/status_im/i18n.cljs
@@ -260,8 +260,7 @@
   ([path] (label path {}))
   ([path options]
    (if (exists? rn-dependencies/i18n.t)
-     (let [options (update options :amount label-number)]
-       (.t rn-dependencies/i18n (name path) (clj->js (label-options options))))
+     (.t rn-dependencies/i18n (name path) (clj->js (label-options options)))
      (name path))))
 
 (defn label-pluralize [count path & options]


### PR DESCRIPTION
Fixes #6517 

### Summary:
Fixes bug causing values over 1000 to be truncated on chat command short preview on iOS

### Steps to test:
- Start new chat, send /request (token) 10000
- Return to home screen
- Short preview correctly display 10,000 instead of 10

status: ready <!-- Can be ready or wip -->
