### PR TITLE
add jenkins timeouts

### DIFF
--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -2,10 +2,13 @@ pipeline {
   agent { label 'linux' }
 
   options {
+    /* Prevent Jenkins jobs from running forever */
+    timeout(time: 25, unit: 'MINUTES')
+    /* Limit builds retained */
     buildDiscarder(logRotator(
-      numToKeepStr: '60',
+      numToKeepStr: '90',
       daysToKeepStr: '30',
-      artifactNumToKeepStr: '60',
+      artifactNumToKeepStr: '90',
     ))
   }
 

--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -3,6 +3,9 @@ pipeline {
 
   options {
     disableConcurrentBuilds()
+    /* Prevent Jenkins jobs from running forever */
+    timeout(time: 25, unit: 'MINUTES')
+    /* Limit builds retained */
     buildDiscarder(logRotator(
       numToKeepStr: '10',
       daysToKeepStr: '30',

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -2,10 +2,13 @@ pipeline {
   agent { label 'fastlane' }
 
   options {
+    /* Prevent Jenkins jobs from running forever */
+    timeout(time: 25, unit: 'MINUTES')
+    /* Limit builds retained */
     buildDiscarder(logRotator(
-      numToKeepStr: '30',
+      numToKeepStr: '60',
       daysToKeepStr: '30',
-      artifactNumToKeepStr: '30',
+      artifactNumToKeepStr: '60',
     ))
   }
 

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -15,10 +15,13 @@ pipeline {
   }
 
   options {
+    /* Prevent Jenkins jobs from running forever */
+    timeout(time: 25, unit: 'MINUTES')
+    /* Limit builds retained */
     buildDiscarder(logRotator(
-      numToKeepStr: '30',
+      numToKeepStr: '60',
       daysToKeepStr: '30',
-      artifactNumToKeepStr: '30',
+      artifactNumToKeepStr: '60',
     ))
   }
 

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -2,10 +2,13 @@ pipeline {
   agent { label 'macos' }
 
   options {
+    /* Prevent Jenkins jobs from running forever */
+    timeout(time: 25, unit: 'MINUTES')
+    /* Limit builds retained */
     buildDiscarder(logRotator(
-      numToKeepStr: '30',
+      numToKeepStr: '60',
       daysToKeepStr: '30',
-      artifactNumToKeepStr: '30',
+      artifactNumToKeepStr: '60',
     ))
   }
 


### PR DESCRIPTION
We've seen some Jenkins jobs running forever, usually due to Android builds. This at least should prevent our queue being clogged up by those builds.

Also bump number of archived builds for different platforms from 30 to 60.