### PR TITLE
bug #5899 - restored missing transaction error messages

### DIFF
--- a/src/status_im/models/wallet.cljs
+++ b/src/status_im/models/wallet.cljs
@@ -167,16 +167,13 @@
       {:db (-> db
                (assoc-in [:wallet :send-transaction :wrong-password?] true))}
 
-      (merge (let [cofx {:db
-                         (-> db
-                             (assoc-in [:wallet :transactions-queue] nil)
-                             (assoc-in [:wallet :send-transaction] {}))
-                         :wallet/show-transaction-error
-                         message}]
-               (navigation/navigate-back cofx))
-
-             (when on-error
-               {:dispatch (conj on-error message)})))))
+      (fx/merge {:db (-> db
+                         (assoc-in [:wallet :transactions-queue] nil)
+                         (assoc-in [:wallet :send-transaction] {}))}
+                {:wallet/show-transaction-error message}
+                (navigation/navigate-back)
+                (when on-error
+                  {:dispatch (conj on-error message)})))))
 
 (defn transform-data-for-message [{:keys [method] :as transaction}]
   (cond-> transaction


### PR DESCRIPTION
### Summary:

Send transaction errors were not displayed anymore after events refactor. This PR brings error messages back.

<!-- (Specify exact steps to test if there are such) -->
### Steps to test:
see #5899 

status: ready 