### PR TITLE
Dont use github archive for desktop status-go version

### DIFF
--- a/modules/react-native-status/desktop/CMakeLists.txt
+++ b/modules/react-native-status/desktop/CMakeLists.txt
@@ -38,7 +38,7 @@ file (STRINGS "../../../STATUS_GO_VERSION" STATUS_GO_VERSION)
 ExternalProject_Add(StatusGo_ep
   PREFIX ${StatusGo_PREFIX}
   SOURCE_DIR ${StatusGo_SOURCE_DIR}
-  URL https://github.com/status-im/status-go/archive/v${STATUS_GO_VERSION}.zip
+  URL https://github.com/status-im/status-go/releases/download/v${STATUS_GO_VERSION}/status-go-desktop-${STATUS_GO_VERSION}.zip
   BUILD_BYPRODUCTS ${StatusGo_STATIC_LIB}
   CONFIGURE_COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/${CONFIGURE_SCRIPT} ${GO_ROOT_PATH} ${StatusGo_ROOT} ${StatusGo_SOURCE_DIR}
   BUILD_COMMAND ""


### PR DESCRIPTION
Fixes: #6564

I have changed the URL of github releases as `archive` is automatically generated by github and has the code at the time the release was created, which might not be the same as the one uploaded for android/ios.

From now on when releasing a new status-go version, the code needs to be explicitly uploaded by the user, so that the version is consistent with ios/android.

This manual step is prone to error, so I'll have a word with @jakubgs to automate this.

status: ready