### PR TITLE
fix to #5699 : 'Reset to default' from transaction fee screen resets gas limit to 21000 always sending tx from Dapp

### DIFF
--- a/src/status_im/models/wallet.cljs
+++ b/src/status_im/models/wallet.cljs
@@ -223,7 +223,9 @@
 (defn open-modal-wallet-for-transaction [db transaction tx-object]
   (let [{:keys [gas gas-price]} transaction
         {:keys [wallet-set-up-passed?]} (:account/account db)]
-    {:db         (assoc-in db [:wallet :send-transaction] transaction)
+    {:db         (-> db
+                     (assoc-in [:wallet :send-transaction] transaction)
+                     (assoc-in [:wallet :send-transaction :original-gas] gas))
      :dispatch-n [[:update-wallet]
                   (when-not gas
                     [:wallet/update-estimated-gas tx-object])

--- a/src/status_im/ui/screens/wallet/events.cljs
+++ b/src/status_im/ui/screens/wallet/events.cljs
@@ -238,7 +238,11 @@
  :wallet/update-estimated-gas-success
  (fn [{:keys [db]} [_ gas]]
    (when gas
-     {:db (assoc-in db [:wallet :send-transaction :gas] (money/bignumber (int (* gas 1.2))))})))
+     (let [adjusted-gas (money/bignumber (int (* gas 1.2)))
+           db-with-adjusted-gas (assoc-in db [:wallet :send-transaction :gas] adjusted-gas)]
+       {:db (if (some? (-> db :wallet :send-transaction :original-gas))
+              db-with-adjusted-gas
+              (assoc-in db-with-adjusted-gas [:wallet :send-transaction :original-gas] adjusted-gas))}))))
 
 (handlers/register-handler-fx
  :wallet-setup-navigate-back

--- a/src/status_im/ui/screens/wallet/send/db.cljs
+++ b/src/status_im/ui/screens/wallet/send/db.cljs
@@ -8,6 +8,7 @@
 (spec/def ::to (spec/nilable string?))
 (spec/def ::amount (spec/nilable money/valid?))
 (spec/def ::gas (spec/nilable money/valid?))
+(spec/def ::original-gas (spec/nilable money/valid?))
 (spec/def ::gas-price (spec/nilable money/valid?))
 ; dapp transaction
 (spec/def ::data (spec/nilable string?))
@@ -38,4 +39,4 @@
                                                        ::password ::show-password-input? ::id ::from ::data ::nonce
                                                        ::camera-flashlight ::in-progress? ::on-result ::on-error
                                                        ::wrong-password? ::from-chat? ::symbol ::advanced?
-                                                       ::gas ::gas-price ::public-key ::method ::tx-hash]))
+                                                       ::gas ::gas-price ::original-gas ::public-key ::method ::tx-hash]))

--- a/src/status_im/ui/screens/wallet/send/events.cljs
+++ b/src/status_im/ui/screens/wallet/send/events.cljs
@@ -251,12 +251,14 @@
 (handlers/register-handler-fx
  :wallet.send/reset-gas-default
  (fn [{:keys [db] :as cofx}]
-   (let [gas-estimate (money/to-fixed
-                       (ethereum/estimate-gas
-                        (-> db :wallet :send-transaction :symbol)))]
+   (let [gas-default (if-some [original-gas (-> db :wallet :send-transaction :original-gas)]
+                       (money/to-fixed original-gas)
+                       (money/to-fixed
+                        (ethereum/estimate-gas
+                         (-> db :wallet :send-transaction :symbol))))]
      (assoc (models.wallet/edit-value
              :gas
-             gas-estimate
+             gas-default
              cofx)
             :dispatch [:wallet/update-gas-price true]))))
 


### PR DESCRIPTION
fixes #5699

Assuming that the dapp can calculate gas by itself (not sure about it), the idea is to store the original gas in the db (a new field `:original-gas` in `:send-transaction`).
When "Reset to default" is pressed, the handler checks if there is an origina-gas. if present it is used to reset the gas, if not present, gas estimation is used.