### PR TITLE
[TESTS/FIX] Changed a way to toggle airplane mode

### DIFF
--- a/test/appium/tests/atomic/chats/test_one_to_one.py
+++ b/test/appium/tests/atomic/chats/test_one_to_one.py
@@ -223,7 +223,7 @@ class TestMessagesOneToOneChatMultiple(MultipleDeviceTestCase):
     @marks.testrail_id(5326)
     @marks.critical
     def test_offline_status(self):
-        self.create_drivers(1, offline_mode=True)
+        self.create_drivers(1)
         sign_in = SignInView(self.drivers[0])
         home_view = sign_in.create_user()
 
@@ -232,7 +232,9 @@ class TestMessagesOneToOneChatMultiple(MultipleDeviceTestCase):
         wallet_view = home_view.wallet_button.click()
         wallet_view.home_button.click()
 
-        sign_in.driver.set_network_connection(1)  # airplane mode
+        sign_in.toggle_airplane_mode()
+        sign_in.accept_agreements()
+        home_view = sign_in.sign_in()
 
         chat = home_view.add_contact(transaction_senders['C']['public_key'])
         if chat.connection_status.text != 'Offline':


### PR DESCRIPTION
### Summary
Due to permissions restrictions the test permanently fails. 
Now we perform switching to airplane mode, not via API but simulating user actions.

The method is already being used successfully by another test **_test_offline_login_**.

```python
    def toggle_airplane_mode(self):
        # opening android settings
        self.driver.start_activity(app_package='com.android.settings', app_activity='.Settings')
        more_button = self.element_by_text('More')
        more_button.wait_for_visibility_of_element()
        more_button.click()
        airplane_toggle = self.element_by_xpath('//*[@resource-id="android:id/switch_widget"]')
        airplane_toggle.wait_for_visibility_of_element()
        airplane_toggle.click()
        # opening Status app
        self.driver.start_activity(app_package='im.status.ethereum', app_activity='.MainActivity')
```