### PR TITLE
React Native HTTP Bridge 0.6.1 update: ability to handle simultaneous HTTP requests properly

### DIFF
--- a/desktop_files/package.json
+++ b/desktop_files/package.json
@@ -64,7 +64,7 @@
     "react-native-fetch-polyfill": "1.1.2",
     "react-native-fs": "git+https://github.com/status-im/react-native-fs.git",
     "react-native-http": "github:tradle/react-native-http#834492d",
-    "react-native-http-bridge": "git+https://github.com/status-im/react-native-http-bridge.git#desktop",
+    "react-native-http-bridge": "0.6.1",
     "react-native-i18n": "git+https://github.com/status-im/react-native-i18n.git#version_0.0.8_desktop",
     "react-native-image-crop-picker": "0.18.1",
     "react-native-image-resizer": "1.0.0",

--- a/mobile_files/package.json
+++ b/mobile_files/package.json
@@ -42,7 +42,7 @@
     "react-native-fetch-polyfill": "1.1.2",
     "react-native-firebase": "https://github.com/status-im/react-native-firebase#5.0.0-rc1",
     "react-native-fs": "2.11.15",
-    "react-native-http-bridge": "https://github.com/status-im/react-native-http-bridge.git#0.5.2-1",
+    "react-native-http-bridge": "0.6.1",
     "react-native-i18n": "2.0.15",
     "react-native-image-crop-picker": "0.18.1",
     "react-native-image-resizer": "https://github.com/status-im/react-native-image-resizer.git#1.0.0-1",

--- a/src/status_im/dev_server/core.cljs
+++ b/src/status_im/dev_server/core.cljs
@@ -10,8 +10,9 @@
                        "Status iOS"
                        "Status Android"))
 
-(defn respond! [status-code data]
+(defn respond! [request-id status-code data]
   (.respond react/http-bridge
+            request-id
             status-code
             "application/json"
             (types/clj->json data)))
@@ -22,12 +23,12 @@
           server-name
           (fn [req]
             (try
-              (let [{:keys [url type postData]} (js->clj req :keywordize-keys true)
+              (let [{:keys [requestId url type postData]} (js->clj req :keywordize-keys true)
                     data (if (string? postData)
                            (-> (.parse js/JSON postData)
                                (js->clj :keywordize-keys true))
                            postData)]
-                (re-frame/dispatch [:process-http-request url type data]))
+                (re-frame/dispatch [:process-http-request requestId url type data]))
               (catch js/Error e
                 (log/debug "Error: " e))))))
 

--- a/src/status_im/dev_server/events.cljs
+++ b/src/status_im/dev_server/events.cljs
@@ -19,19 +19,20 @@
 
 (re-frame/reg-fx
  :dev-server/respond
- (fn [[status-code data]]
-   (dev-server.core/respond! status-code data)))
+ (fn [[request-id status-code data]]
+   (dev-server.core/respond! request-id status-code data)))
 
 ;; Handlers
 
 (handlers/register-handler-fx
  :process-http-request
  [(re-frame/inject-cofx :random-id-generator)]
- (fn [cofx [_ url type data]]
+ (fn [cofx [_ request-id url type data]]
    (try
-     (models.dev-server/process-request! {:cofx cofx
-                                          :url  (rest (string/split url "/"))
-                                          :type (keyword type)
-                                          :data data})
+     (models.dev-server/process-request! {:cofx       cofx
+                                          :request-id request-id
+                                          :url        (rest (string/split url "/"))
+                                          :type       (keyword type)
+                                          :data       data})
      (catch js/Error e
-       {:dev-server/respond [400 {:message (str "Unsupported operation: " e)}]}))))
+       {:dev-server/respond [request-id 400 {:message (str "Unsupported operation: " e)}]}))))

--- a/src/status_im/models/dev_server.cljs
+++ b/src/status_im/models/dev_server.cljs
@@ -13,17 +13,17 @@
 (defmulti process-request! (fn [{:keys [url type]}] [type (first url) (second url)]))
 
 (defmethod process-request! [:POST "ping" nil]
-  [_]
-  {:dev-server/respond [200 {:message "Pong!"}]})
+  [{:keys [request-id]}]
+  {:dev-server/respond [request-id 200 {:message "Pong!"}]})
 
 (defmethod process-request! [:POST "dapp" "open"]
-  [{{:keys [url]} :data cofx :cofx}]
+  [{{:keys [request-id url]} :data cofx :cofx}]
   (fx/merge cofx
-            {:dev-server/respond [200 {:message "URL has been opened."}]}
+            {:dev-server/respond [request-id 200 {:message "URL has been opened."}]}
             (browser/open-url url)))
 
 (defmethod process-request! [:POST "network" nil]
-  [{:keys [cofx data]}]
+  [{:keys [cofx request-id data]}]
   (let [data (->> data
                   (map (fn [[k v]] [k {:value v}]))
                   (into {}))]
@@ -31,27 +31,31 @@
      cofx
      {:data       data
       :on-success (fn [network _]
-                    {:dev-server/respond [200 {:message    "Network has been added."
-                                               :network-id network}]})
+                    {:dev-server/respond
+                     [request-id 200 {:message    "Network has been added."
+                                      :network-id network}]})
       :on-failure (fn [_ _]
-                    {:dev-server/respond [400 {:message "Please, check the validity of network information."}]})})))
+                    {:dev-server/respond
+                     [request-id 400 {:message "Please, check the validity of network information."}]})})))
 
 (defmethod process-request! [:POST "network" "connect"]
-  [{:keys [cofx data]}]
+  [{:keys [cofx request-id data]}]
   (network/connect
    cofx
    {:network-id (:id data)
     :on-success (fn [{:keys [network-id client-version]} _]
-                  {:dev-server/respond [200 {:message        "Network has been connected."
-                                             :network-id     network-id
-                                             :client-version client-version}]})
+                  {:dev-server/respond
+                   [request-id 200 {:message        "Network has been connected."
+                                    :network-id     network-id
+                                    :client-version client-version}]})
     :on-failure (fn [{:keys [network-id reason]} _]
-                  {:dev-server/respond [400 {:message    "Cannot connect the network."
-                                             :network-id network-id
-                                             :reason     reason}]})}))
+                  {:dev-server/respond
+                   [request-id 400 {:message    "Cannot connect the network."
+                                    :network-id network-id
+                                    :reason     reason}]})}))
 
 (defmethod process-request! [:GET "networks" nil]
-  [{:keys [cofx]}]
+  [{:keys [cofx request-id]}]
   (let [{:keys [networks network]} (get-in cofx [:db :account/account])
         networks (->> networks
                       (map (fn [[id m]]
@@ -59,19 +63,19 @@
                                      (select-keys [:id :name :config])
                                      (assoc :active? (= id network)))]))
                       (into {}))]
-    {:dev-server/respond [200 {:networks networks}]}))
+    {:dev-server/respond [request-id 200 {:networks networks}]}))
 
 (defmethod process-request! [:DELETE "network" nil]
-  [{:keys [cofx data]}]
+  [{:keys [cofx request-id data]}]
   (network/delete
    cofx
    {:network    (:id data)
     :on-success (fn [network _]
-                  {:dev-server/respond [200 {:message    "Network has been deleted."
-                                             :network-id network}]})
+                  {:dev-server/respond [request-id 200 {:message    "Network has been deleted."
+                                                        :network-id network}]})
     :on-failure (fn [_ _]
-                  {:dev-server/respond [400 {:message "Cannot delete the provided network."}]})}))
+                  {:dev-server/respond [request-id 400 {:message "Cannot delete the provided network."}]})}))
 
 (defmethod process-request! :default
-  [{:keys [type url]}]
-  {:dev-server/respond [404 {:message (str "Not found (" (name type) " " (string/join "/" url) ")")}]})
+  [{:keys [request-id type url]}]
+  {:dev-server/respond [request-id 404 {:message (str "Not found (" (name type) " " (string/join "/" url) ")")}]})


### PR DESCRIPTION
Status: ready.

During the hackathon, there was a problem found in the way we handle and process requests in `react-native-http-bridge`. Previous versions of this library were relatively simple, and there was no tracking of incoming requests bundled to it. It led to a stupid bug — it was possible to send several simultaneous HTTP requests to debug server, and after some time server started to respond with incorrect responses.

The problem is fixed here:  https://github.com/alwx/react-native-http-bridge/commit/f3381bb5a24ff11cd02db7ed929ba78ce4f6406b. The new version of `react-native-http-bridged` is published in `npm` already.
This PR is needed to pass the new required parameter called `requestId` properly.