### PR TITLE
[ANDROID #5793] enable saving password on android

### DIFF
--- a/android/app/src/main/java/im/status/ethereum/MainApplication.java
+++ b/android/app/src/main/java/im/status/ethereum/MainApplication.java
@@ -52,7 +52,7 @@ public class MainApplication extends MultiDexApplication implements ReactApplica
                 webViewDebugEnabled = true;
             }
 
-            StatusPackage statusPackage = new StatusPackage(BuildConfig.DEBUG, devCluster);
+            StatusPackage statusPackage = new StatusPackage(BuildConfig.DEBUG, devCluster, RootUtil.isDeviceRooted());
             Function<String, String> callRPC = statusPackage.getCallRPC();
             List<ReactPackage> packages = new ArrayList<ReactPackage>(Arrays.asList(
                     new MainReactPackage(),

--- a/env/dev/env/config.cljs
+++ b/env/dev/env/config.cljs
@@ -1,5 +1,6 @@
 (ns env.config)
 
-(def figwheel-urls {:android "ws://192.168.10.203:3449/figwheel-ws",
-                    :ios     "ws://localhost:3449/figwheel-ws",
-                    :desktop "ws://localhost:3449/figwheel-ws"})
+(def figwheel-urls {:android "ws://localhost:3449/figwheel-ws",
+ :ios "ws://192.168.0.9:3449/figwheel-ws",
+ :desktop "ws://localhost:3449/figwheel-ws"}
+)

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -68,7 +68,7 @@ PODS:
     - React
   - React/Core (0.56.0):
     - yoga (= 0.56.0.React)
-  - RNKeychain (3.0.0):
+  - RNKeychain (3.0.0-rc.3):
     - React
   - yoga (0.56.0.React)
 
@@ -123,4 +123,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 7636f960a0dbec2dd55b8b20e244befa3fdb4438
 
-COCOAPODS: 1.5.2
+COCOAPODS: 1.5.3

--- a/mobile_files/package.json.orig
+++ b/mobile_files/package.json.orig
@@ -47,7 +47,7 @@
     "react-native-image-crop-picker": "0.18.1",
     "react-native-image-resizer": "https://github.com/status-im/react-native-image-resizer.git#1.0.0-1",
     "react-native-invertible-scroll-view": "1.1.0",
-    "react-native-keychain": "3.0.0",
+    "react-native-keychain": "https://github.com/status-im/react-native-keychain#v.3.0.0-status",
     "react-native-level-fs": "3.0.1",
     "react-native-os": "https://github.com/status-im/react-native-os.git#1.1.0-1",
     "react-native-qrcode": "0.2.7",

--- a/mobile_files/yarn.lock
+++ b/mobile_files/yarn.lock
@@ -5936,10 +5936,9 @@ react-native-invertible-scroll-view@1.1.0:
     react-clone-referenced-element "^1.0.1"
     react-native-scrollable-mixin "^1.0.1"
 
-react-native-keychain@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/react-native-keychain/-/react-native-keychain-3.0.0.tgz#29da1dfa43c2581f76bf9420914fd38a1558cf18"
-  integrity sha512-0incABt1+aXsZvG34mDV57KKanSB+iMHmxvWv+N6lgpNLaSoqrCxazjbZdeqD4qJ7Z+Etp5CLf/4v1aI+sNLBw==
+"react-native-keychain@https://github.com/status-im/react-native-keychain#v.3.0.0-status":
+  version "3.0.0-rc.3"
+  resolved "https://github.com/status-im/react-native-keychain#43e5512cabb8ee064fd9e503be943dcf2c7d7669"
 
 react-native-level-fs@3.0.1:
   version "3.0.1"

--- a/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusModule.java
+++ b/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusModule.java
@@ -61,8 +61,9 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
     private boolean debug;
     private boolean devCluster;
     private ReactApplicationContext reactContext;
+    private boolean rootedDevice;
 
-    StatusModule(ReactApplicationContext reactContext, boolean debug, boolean devCluster) {
+    StatusModule(ReactApplicationContext reactContext, boolean debug, boolean devCluster, boolean rootedDevice) {
         super(reactContext);
         if (executor == null) {
             executor = Executors.newCachedThreadPool();
@@ -70,6 +71,7 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
         this.debug = debug;
         this.devCluster = devCluster;
         this.reactContext = reactContext;
+        this.rootedDevice = rootedDevice;
         reactContext.addLifecycleEventListener(this);
     }
 
@@ -857,7 +859,7 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
         Log.d(TAG, "AppStateChange: " + type);
         Statusgo.AppStateChange(type);
     }
-    
+
     private static String uniqueID = null;
     private static final String PREF_UNIQUE_ID = "PREF_UNIQUE_ID";
 
@@ -988,5 +990,10 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
 
     constants.put("is24Hour", this.is24Hour());
     return constants;
+  }
+
+  @ReactMethod
+  public void isDeviceRooted(final Callback callback) {
+    callback.invoke(rootedDevice);
   }
 }

--- a/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusPackage.java
+++ b/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusPackage.java
@@ -16,10 +16,12 @@ public class StatusPackage implements ReactPackage {
 
     private boolean debug;
     private boolean devCluster;
+    private boolean rootedDevice;
 
-    public StatusPackage (boolean debug, boolean devCluster) {
+    public StatusPackage (boolean debug, boolean devCluster, boolean rootedDevice) {
         this.debug = debug;
         this.devCluster = devCluster;
+        this.rootedDevice = rootedDevice;
     }
 
     @Override
@@ -27,7 +29,7 @@ public class StatusPackage implements ReactPackage {
         List<NativeModule> modules = new ArrayList<>();
         System.loadLibrary("statusgoraw");
         System.loadLibrary("statusgo");
-        modules.add(new StatusModule(reactContext, this.debug, this.devCluster));
+        modules.add(new StatusModule(reactContext, this.debug, this.devCluster, this.rootedDevice ));
 
         return modules;
     }

--- a/src/status_im/native_module/core.cljs
+++ b/src/status_im/native_module/core.cljs
@@ -84,3 +84,5 @@
 (def disable-installation native-module/disable-installation)
 
 (def update-mailservers native-module/update-mailservers)
+
+(def rooted-device? native-module/rooted-device?)

--- a/src/status_im/ui/screens/accounts/login/styles.cljs
+++ b/src/status_im/ui/screens/accounts/login/styles.cljs
@@ -52,3 +52,11 @@
    :text-align :center
    :flex-direction :row
    :align-items :center})
+
+(def save-password-unavailable-android
+  {:margin-top 8
+   :width "100%"
+   :color colors/text-gray
+   :text-align :center
+   :flex-direction :row
+   :align-items :center})

--- a/src/status_im/ui/screens/accounts/login/views.cljs
+++ b/src/status_im/ui/screens/accounts/login/views.cljs
@@ -18,7 +18,8 @@
             [cljs.spec.alpha :as spec]
             [status-im.utils.platform :as platform]
             [status-im.accounts.db :as db]
-            [status-im.utils.security :as security]))
+            [status-im.utils.security :as security]
+            [status-im.utils.keychain.core :as keychain]))
 
 (defn login-toolbar [can-navigate-back?]
   [toolbar/toolbar
@@ -81,15 +82,22 @@
                                 (re-frame/dispatch [:set-in [:accounts/login :error] ""]))
           :secure-text-entry true
           :error             (when (not-empty error) (i18n/label (error-key error)))}]]
-       (when platform/ios?
+
+       (when-not platform/desktop?
+         ;; saving passwords is unavailable on Desktop
          [react/view {:style styles/save-password-checkbox-container}
-          [profile.components/settings-switch-item
-           {:label-kw  (if can-save-password?
-                         :t/save-password
-                         :t/save-password-unavailable)
-            :active?   can-save-password?
-            :value     save-password?
-            :action-fn #(re-frame/dispatch [:set-in [:accounts/login :save-password?] %])}]])]]
+          (if (and platform/android? (not can-save-password?))
+            ;; on Android, there is much more reasons for the password save to be unavailable,
+            ;; so we don't show the checkbox whatsoever but put a label explaining why it happenned.
+            [react/i18n-text {:style styles/save-password-unavailable-android
+                              :key :save-password-unavailable-android}]
+            [profile.components/settings-switch-item
+             {:label-kw  (if can-save-password?
+                           :t/save-password
+                           :t/save-password-unavailable)
+              :active?   can-save-password?
+              :value     save-password?
+              :action-fn #(re-frame/dispatch [:set-in [:accounts/login :save-password?] %])}])])]]
      (when processing
        [react/view styles/processing-view
         [components/activity-indicator {:animating true}]

--- a/src/status_im/utils/platform.cljs
+++ b/src/status_im/utils/platform.cljs
@@ -36,3 +36,6 @@
     android? (str (.-DocumentDirectoryPath rn-dependencies/fs)
                   "/../no_backup")
     ios?          (.-LibraryDirectoryPath rn-dependencies/fs)))
+
+(defn android-version>= [v]
+  (and android? (>= version v)))

--- a/translations/en.json
+++ b/translations/en.json
@@ -136,6 +136,7 @@
     "twelve-words-in-correct-order": "12 words in correct order",
     "permissions": "Permissions",
     "save-password-unavailable": "Set device passcode to save password",
+    "save-password-unavailable-android": "Save password is unavailable: your device may be rooted or lacks necessary security features.",
     "currency-display-name-inr": "India Rupee",
     "transaction-moved-title": "Transaction moved",
     "counter-9-plus": "9+",


### PR DESCRIPTION
partially solves #5793

As was suggested by @mandrigin this feature is enabled only for Android 23+ because of security concerns https://github.com/oblador/react-native-keychain#security

uses our fork of react-native-keychain with minimum security guarantees for some operations

NOT hashes password (will be a follow-up PR)

status: ready
