### PR TITLE
[#6294] add desktop alpha release warning

### DIFF
--- a/desktop_files/package-lock.json
+++ b/desktop_files/package-lock.json
@@ -11065,7 +11065,7 @@
       }
     },
     "react-native": {
-      "version": "git+https://github.com/status-im/react-native-desktop.git#master",
+      "version": "git+https://github.com/status-im/react-native-desktop.git#567ca5e9b53a91d55a2bc4e915bf4f5d2b6304c4",
       "requires": {
         "absolute-path": "0.0.0",
         "art": "0.10.3",

--- a/desktop_files/package.json
+++ b/desktop_files/package.json
@@ -55,7 +55,7 @@
     "querystring-es3": "0.2.1",
     "react": "16.4.1",
     "react-dom": "16.4.2",
-    "react-native": "git+https://github.com/status-im/react-native-desktop.git#master",
+    "react-native": "git+https://github.com/status-im/react-native-desktop.git#v0.56.1",
     "react-native-background-timer": "2.0.0",
     "react-native-camera": "0.10.0",
     "react-native-config": "git+https://github.com/status-im/react-native-config.git",

--- a/src/status_im/accounts/core.cljs
+++ b/src/status_im/accounts/core.cljs
@@ -21,6 +21,17 @@
        (i18n/label :mainnet-is-default-alert-text)
        #(re-frame/dispatch [:accounts.ui/mainnet-warning-shown])))))
 
+(fx/defn show-desktop-alpha-release-warning [{:keys [db]}]
+  (let [enter-name-screen? (= :enter-name (get-in db [:accounts/create :step]))
+        shown? (get-in db [:account/account :desktop-alpha-release-warning-shown?])]
+    (when (and platform/desktop?
+               (not shown?)
+               (not enter-name-screen?))
+      (utils/show-popup
+       nil
+       (i18n/label :desktop-alpha-release-warning)
+       #(re-frame/dispatch [:accounts.ui/desktop-alpha-release-warning-shown])))))
+
 (defn- chat-send? [transaction]
   (and (seq transaction)
        (not (:in-progress? transaction))

--- a/src/status_im/accounts/create/core.cljs
+++ b/src/status_im/accounts/create/core.cljs
@@ -1,6 +1,7 @@
 (ns status-im.accounts.create.core
   (:require [clojure.string :as string]
             [re-frame.core :as re-frame]
+            [status-im.accounts.core :as accounts.core]
             [status-im.accounts.login.core :as accounts.login]
             [status-im.accounts.statuses :as statuses]
             [status-im.accounts.update.core :as accounts.update]
@@ -93,7 +94,8 @@
             {:db                                  (assoc db :accounts/create {:show-welcome? true})
              :notifications/request-notifications-permissions nil
              :dispatch                            [:navigate-to :home]}
-            (accounts.update/account-update {:name (:name create)} {})))
+            (accounts.update/account-update {:name (:name create)} {})
+            (accounts.core/show-desktop-alpha-release-warning)))
 
 (fx/defn next-step
   [{:keys [db] :as cofx} step password password-confirm]

--- a/src/status_im/accounts/db.cljs
+++ b/src/status_im/accounts/db.cljs
@@ -52,6 +52,7 @@
 (spec/def :account/installation-id :global/not-empty-string)
 (spec/def :account/wallet-set-up-passed? (spec/nilable boolean?))
 (spec/def :account/mainnet-warning-shown? (spec/nilable boolean?))
+(spec/def :account/desktop-alpha-release-warning-shown? (spec/nilable boolean?))
 
 (spec/def :accounts/account (allowed-keys
                              :req-un [:account/name :account/address :account/public-key
@@ -64,7 +65,8 @@
                                       :account/seed-backed-up? :account/mnemonic :account/desktop-notifications?
                                       :account/wallet-set-up-passed? :account/last-request
                                       :account/bootnodes :account/extensions
-                                      :account/mainnet-warning-shown?]))
+                                      :account/mainnet-warning-shown?
+                                      :account/desktop-alpha-release-warning-shown?]))
 
 (spec/def :accounts/accounts (spec/nilable (spec/map-of :account/address :accounts/account)))
 

--- a/src/status_im/data_store/realm/schemas/base/account.cljs
+++ b/src/status_im/data_store/realm/schemas/base/account.cljs
@@ -207,3 +207,7 @@
 (def v13 (assoc-in v12
                    [:properties :desktop-notifications?]
                    {:type :bool :default false}))
+
+(def v14 (assoc-in v13
+                   [:properties :desktop-alpha-release-warning-shown?]
+                   {:type :bool :default false}))

--- a/src/status_im/data_store/realm/schemas/base/core.cljs
+++ b/src/status_im/data_store/realm/schemas/base/core.cljs
@@ -54,6 +54,11 @@
 
 (def v14 v13)
 
+(def v15 [network/v1
+          bootnode/v4
+          extension/v12
+          account/v14])
+
 ;; put schemas ordered by version
 (def schemas [{:schema        v1
                :schemaVersion 1
@@ -96,4 +101,7 @@
                :migration     migrations/v13}
               {:schema        v14
                :schemaVersion 14
-               :migration     migrations/v14}])
+               :migration     migrations/v14}
+              {:schema        v15
+               :schemaVersion 15
+               :migration     migrations/v15}])

--- a/src/status_im/data_store/realm/schemas/base/migrations.cljs
+++ b/src/status_im/data_store/realm/schemas/base/migrations.cljs
@@ -108,3 +108,6 @@
                                (assoc :mailserver wnode)))
             updated      (serialize new-settings)]
         (aset account "settings" updated)))))
+
+(defn v15 [old-realm new-realm]
+  (log/debug "migrating base database v15: " old-realm new-realm))

--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -122,6 +122,11 @@
    (accounts.update/account-update cofx {:mainnet-warning-shown? true} {})))
 
 (handlers/register-handler-fx
+ :accounts.ui/desktop-alpha-release-warning-shown
+ (fn [cofx _]
+   (accounts.update/account-update cofx {:desktop-alpha-release-warning-shown? true} {})))
+
+(handlers/register-handler-fx
  :accounts.ui/dev-mode-switched
  (fn [cofx [_ dev-mode?]]
    (accounts/switch-dev-mode cofx dev-mode?)))

--- a/src/status_im/init/core.cljs
+++ b/src/status_im/init/core.cljs
@@ -1,6 +1,7 @@
 (ns status-im.init.core
   (:require [re-frame.core :as re-frame]
             [status-im.chat.models.loading :as chat-loading]
+            [status-im.accounts.core :as accounts.core]
             [status-im.accounts.login.core :as accounts.login]
             [status-im.accounts.update.core :as accounts.update]
             [status-im.constants :as constants]
@@ -191,7 +192,8 @@
             (universal-links/process-stored-event)
             (notifications/process-stored-event address)
             (when platform/desktop?
-              (chat-model/update-dock-badge-label))))
+              (chat-model/update-dock-badge-label))
+            (accounts.core/show-desktop-alpha-release-warning)))
 
 (defn dev-mode? [cofx]
   (get-in cofx [:db :account/account :dev-mode?]))

--- a/translations/en.json
+++ b/translations/en.json
@@ -199,6 +199,7 @@
     "browsing-site-blocked-go-back": "Go back",
     "wallet-add-asset": "Add asset",
     "mainnet-is-default-alert-title": "Hello",
+    "desktop-alpha-release-warning": "Thanks for trying Status Desktop! This is an early alpha release focused on chat, and is missing several features found in the mobile client and may contain bugs and other issues. Please note that this is an alpha release and we advise you that using this app should be done for testing purposes only and you assume the full responsibility for all risks concerning your data and funds. Status makes no claims of security or integrity of funds in these builds.",
     "delete-message": "Delete message",
     "browser": "Browser",
     "sign-message": "Sign Message",


### PR DESCRIPTION
fixes #6294

### Summary:

* Show alpha release warning on desktop after login (show it only once)
* Update react-native-desktop to most recent version where Alert dialog layout is fixed.

status: ready

<img width="1136" alt="screenshot 2018-11-06 16 19 08" src="https://user-images.githubusercontent.com/23836/48067177-a6133280-e1e0-11e8-922f-4f5a9e43ff2d.png">

