### PR TITLE
Improve ubuntu-server and RCTStatus logging

### DIFF
--- a/modules/react-native-desktop-linking/desktop/desktoplinking.cpp
+++ b/modules/react-native-desktop-linking/desktop/desktoplinking.cpp
@@ -8,6 +8,8 @@
 #include <QUrl>
 #include <QFileOpenEvent>
 
+Q_LOGGING_CATEGORY(LINKING, "RCTLinking")
+
 namespace {
 struct RegisterQMLMetaType {
   RegisterQMLMetaType() { qRegisterMetaType<DesktopLinking *>(); }
@@ -44,7 +46,7 @@ QVariantMap DesktopLinking::constantsToExport() { return QVariantMap(); }
 
 void DesktopLinking::handleURL(const QString url) {
     Q_D(DesktopLinking);
-    qDebug() << "call of DesktopLinking::handleURL with param path: " << url;
+    qCDebug(LINKING) << "::handleURL - path:" << url;
     d->bridge->eventDispatcher()->sendDeviceEvent("urlOpened", QVariantMap{{"url", url}});
 }
 

--- a/modules/react-native-desktop-linking/desktop/desktoplinking.h
+++ b/modules/react-native-desktop-linking/desktop/desktoplinking.h
@@ -3,7 +3,10 @@
 
 #include "moduleinterface.h"
 
+#include <QLoggingCategory>
 #include <QVariantMap>
+
+Q_DECLARE_LOGGING_CATEGORY(LINKING)
 
 class DesktopLinkingPrivate;
 class DesktopLinking : public QObject, public ModuleInterface {

--- a/modules/react-native-desktop-notification/desktop/desktopnotification.cpp
+++ b/modules/react-native-desktop-notification/desktop/desktopnotification.cpp
@@ -22,6 +22,8 @@
 #include <QGuiApplication>
 #include <QDebug>
 
+Q_LOGGING_CATEGORY(NOTIFICATION, "RCTNotification")
+
 #ifdef Q_OS_LINUX
 namespace SnorePlugin {}
 
@@ -72,14 +74,14 @@ DesktopNotification::DesktopNotification(QObject *parent)
     Snore::SnoreCore::instance().loadPlugins(Snore::SnorePlugin::Backend);
   }
 
-  qDebug() << "DesktopNotification::DesktopNotification List of all loaded Snore plugins: "
-           << Snore::SnoreCore::instance().pluginNames();
+  qCDebug(NOTIFICATION) << "DesktopNotification::DesktopNotification List of all loaded Snore plugins:"
+                        << Snore::SnoreCore::instance().pluginNames();
 
   Snore::SnoreCore::instance().registerApplication(d_ptr->snoreApp);
   Snore::SnoreCore::instance().setDefaultApplication(d_ptr->snoreApp);
 
-  qDebug() << "DesktopNotification::DesktopNotification Current notification backend: "
-           << Snore::SnoreCore::instance().primaryNotificationBackend();
+  qCDebug(NOTIFICATION) << "DesktopNotification::DesktopNotification Current notification backend:"
+                        << Snore::SnoreCore::instance().primaryNotificationBackend();
 }
 
 DesktopNotification::~DesktopNotification() {
@@ -101,10 +103,10 @@ QVariantMap DesktopNotification::constantsToExport() { return QVariantMap(); }
 
 void DesktopNotification::sendNotification(QString text) {
   Q_D(DesktopNotification);
-  qDebug() << "call of DesktopNotification::sendNotification";
+  qCDebug(NOTIFICATION) << "::sendNotification";
 
   if (m_appHasFocus) {
-      qDebug() << "Don't send notification since some application window is active";
+      qCDebug(NOTIFICATION) << "Not sending notification since an application window is active";
       return;
   }
 

--- a/modules/react-native-desktop-notification/desktop/desktopnotification.h
+++ b/modules/react-native-desktop-notification/desktop/desktopnotification.h
@@ -13,7 +13,10 @@
 
 #include "moduleinterface.h"
 
+#include <QLoggingCategory>
 #include <QVariantMap>
+
+Q_DECLARE_LOGGING_CATEGORY(NOTIFICATION)
 
 class DesktopNotificationPrivate;
 class DesktopNotification : public QObject, public ModuleInterface {

--- a/modules/react-native-status/desktop/rctstatus.cpp
+++ b/modules/react-native-status/desktop/rctstatus.cpp
@@ -11,7 +11,6 @@
 #include "rctstatus.h"
 #include "bridge.h"
 #include "eventdispatcher.h"
-#include "logger.h"
 
 #include <QDebug>
 #include <QJsonDocument>
@@ -39,13 +38,13 @@ public:
 
 Bridge* RCTStatusPrivate::bridge = nullptr;
 RCTStatus* RCTStatusPrivate::rctStatus = nullptr;
-const QString RCTSTATUS = "RCTStatus";
+
+Q_LOGGING_CATEGORY(RCTSTATUS, "RCTStatus")
 
 RCTStatus::RCTStatus(QObject* parent) : QObject(parent), d_ptr(new RCTStatusPrivate) {
     RCTStatusPrivate::rctStatus = this;
     SetSignalEventCallback((void*)&RCTStatus::statusGoEventCallback);
     connect(this, &RCTStatus::statusGoEvent, this, &RCTStatus::onStatusGoEvent);
-    registerLogModule(RCTSTATUS);
 }
 
 RCTStatus::~RCTStatus() {}
@@ -69,7 +68,7 @@ QVariantMap RCTStatus::constantsToExport() {
 
 void RCTStatus::getDeviceUUID(double callbackId) {
   Q_D(RCTStatus);
-  rnLog(RCTSTATUS) << "::getDeviceUUID call";
+  qCDebug(RCTSTATUS) << "::getDeviceUUID call";
 
   d->bridge->invokePromiseCallback(callbackId, QVariantList{"com.status.StatusIm"});
 }
@@ -77,16 +76,16 @@ void RCTStatus::getDeviceUUID(double callbackId) {
 
 void RCTStatus::startNode(QString configString) {
     Q_D(RCTStatus);
-    rnLog(RCTSTATUS) << "::startNode call with param configString:" << configString;
+    qCDebug(RCTSTATUS) << "::startNode call - configString:" << configString;
 
     QJsonParseError jsonError;
     const QJsonDocument& jsonDoc = QJsonDocument::fromJson(configString.toUtf8(), &jsonError);
     if (jsonError.error != QJsonParseError::NoError){
-        rnLog(RCTSTATUS) << jsonError.errorString();
+        qCWarning(RCTSTATUS) << jsonError.errorString();
     }
 
     QVariantMap configJSON = jsonDoc.toVariant().toMap();
-    rnLog(RCTSTATUS) << "::startNode configString: " << configJSON;
+    qCDebug(RCTSTATUS) << "::startNode configString: " << configJSON;
 
     int networkId = configJSON["NetworkId"].toInt();
     QString relativeDataDirPath = configJSON["DataDir"].toString();
@@ -107,25 +106,25 @@ void RCTStatus::startNode(QString configString) {
     configJSON["LogFile"] = dataDir.absoluteFilePath("geth.log");
 
     const QJsonDocument& updatedJsonDoc = QJsonDocument::fromVariant(configJSON);
-    rnLog(RCTSTATUS) << "::startNode updated configString: " << updatedJsonDoc.toVariant().toMap();
+    qCInfo(RCTSTATUS) << "::startNode updated configString: " << updatedJsonDoc.toVariant().toMap();
     const char* result = StartNode(QString(updatedJsonDoc.toJson(QJsonDocument::Compact)).toUtf8().data());
-    rnLog(RCTSTATUS) << "::startNode StartNode result: " << statusGoResultError(result);
+    logStatusGoResult("::startNode StartNode", result);
 }
 
 
 void RCTStatus::stopNode() {
-    rnLog(RCTSTATUS) << "::stopNode call";
+    qCInfo(RCTSTATUS) << "::stopNode call";
     const char* result = StopNode();
-    rnLog(RCTSTATUS) << "::stopNode StopNode result: " << statusGoResultError(result);
+    logStatusGoResult("::stopNode StopNode", result);
 }
 
 
 void RCTStatus::createAccount(QString password, double callbackId) {
     Q_D(RCTStatus);
-    rnLog(RCTSTATUS) << "::createAccount call with param callbackId: " << callbackId;
+    qCInfo(RCTSTATUS) << "::createAccount call - callbackId:" << callbackId;
     QtConcurrent::run([&](QString password, double callbackId) {
             const char* result = CreateAccount(password.toUtf8().data());
-            rnLog(RCTSTATUS) << "::createAccount CreateAccount result: " << statusGoResultError(result);
+            logStatusGoResult("::createAccount CreateAccount", result);
             d->bridge->invokePromiseCallback(callbackId, QVariantList{result});
         }, password, callbackId);
 }
@@ -133,10 +132,10 @@ void RCTStatus::createAccount(QString password, double callbackId) {
 
 void RCTStatus::notifyUsers(QString token, QString payloadJSON, QString tokensJSON, double callbackId) {
     Q_D(RCTStatus);
-    rnLog(RCTSTATUS) << "::notifyUsers call with param callbackId: " << callbackId;
+    qCDebug(RCTSTATUS) << "::notifyUsers call - callbackId:" << callbackId;
     QtConcurrent::run([&](QString token, QString payloadJSON, QString tokensJSON, double callbackId) {
             const char* result = NotifyUsers(token.toUtf8().data(), payloadJSON.toUtf8().data(), tokensJSON.toUtf8().data());
-            rnLog(RCTSTATUS) << "::notifyUsers Notify result: " << statusGoResultError(result);
+            logStatusGoResult("::notifyUsers Notify", result);
             d->bridge->invokePromiseCallback(callbackId, QVariantList{result});
         }, token, payloadJSON, tokensJSON, callbackId);
 }
@@ -144,10 +143,10 @@ void RCTStatus::notifyUsers(QString token, QString payloadJSON, QString tokensJS
 
 void RCTStatus::addPeer(QString enode, double callbackId) {
     Q_D(RCTStatus);
-    rnLog(RCTSTATUS) << "::addPeer call with param callbackId: " << callbackId;
+    qCDebug(RCTSTATUS) << "::addPeer call - callbackId:" << callbackId;
     QtConcurrent::run([&](QString enode, double callbackId) {
             const char* result = AddPeer(enode.toUtf8().data());
-            rnLog(RCTSTATUS) << "::addPeer AddPeer result: " << statusGoResultError(result);
+            logStatusGoResult("::addPeer AddPeer", result);
             d->bridge->invokePromiseCallback(callbackId, QVariantList{result});
         }, enode, callbackId);
 }
@@ -155,10 +154,10 @@ void RCTStatus::addPeer(QString enode, double callbackId) {
 
 void RCTStatus::recoverAccount(QString passphrase, QString password, double callbackId) {
     Q_D(RCTStatus);
-    rnLog(RCTSTATUS) << "::recoverAccount call with param callbackId: " << callbackId;
+    qCInfo(RCTSTATUS) << "::recoverAccount call - callbackId:" << callbackId;
     QtConcurrent::run([&](QString passphrase, QString password, double callbackId) {
             const char* result = RecoverAccount(password.toUtf8().data(), passphrase.toUtf8().data());
-            rnLog(RCTSTATUS) << "::recoverAccount RecoverAccount result: " << statusGoResultError(result);
+            logStatusGoResult("::recoverAccount RecoverAccount", result);
             d->bridge->invokePromiseCallback(callbackId, QVariantList{result});
         }, passphrase, password, callbackId);
 }
@@ -166,10 +165,10 @@ void RCTStatus::recoverAccount(QString passphrase, QString password, double call
 
 void RCTStatus::login(QString address, QString password, double callbackId) {
     Q_D(RCTStatus);
-    rnLog(RCTSTATUS) << "::login call with param callbackId: " << callbackId;
+    qCInfo(RCTSTATUS) << "::login call - callbackId:" << callbackId;
     QtConcurrent::run([&](QString address, QString password, double callbackId) {
             const char* result = Login(address.toUtf8().data(), password.toUtf8().data());
-            rnLog(RCTSTATUS) << "::login Login result: " << statusGoResultError(result);
+            logStatusGoResult("::login Login", result);
             d->bridge->invokePromiseCallback(callbackId, QVariantList{result});
         }, address, password, callbackId);
 }
@@ -177,10 +176,10 @@ void RCTStatus::login(QString address, QString password, double callbackId) {
 
 void RCTStatus::sendTransaction(QString txArgsJSON, QString password, double callbackId) {
     Q_D(RCTStatus);
-    rnLog(RCTSTATUS) << "::sendTransaction call with param callbackId: " << callbackId;
+    qCDebug(RCTSTATUS) << "::sendTransaction call - callbackId:" << callbackId;
     QtConcurrent::run([&](QString txArgsJSON, QString password, double callbackId) {
             const char* result = SendTransaction(txArgsJSON.toUtf8().data(), password.toUtf8().data());
-            rnLog(RCTSTATUS) << "sendTransaction SendTransaction result: " << statusGoResultError(result);
+            logStatusGoResult("::sendTransaction SendTransaction", result);
             d->bridge->invokePromiseCallback(callbackId, QVariantList{result});
         }, txArgsJSON, password, callbackId);
 }
@@ -188,30 +187,30 @@ void RCTStatus::sendTransaction(QString txArgsJSON, QString password, double cal
 
 void RCTStatus::signMessage(QString rpcParams, double callbackId) {
     Q_D(RCTStatus);
-    rnLog(RCTSTATUS) << "::signMessage call with param callbackId: " << callbackId;
+    qCDebug(RCTSTATUS) << "::signMessage call - callbackId:" << callbackId;
     QtConcurrent::run([&](QString rpcParams, double callbackId) {
             const char* result = SignMessage(rpcParams.toUtf8().data());
-            rnLog(RCTSTATUS) << "::signMessage SignMessage result: " << statusGoResultError(result);
+            logStatusGoResult("::signMessage SignMessage", result);
             d->bridge->invokePromiseCallback(callbackId, QVariantList{result});
         }, rpcParams, callbackId);
 }
 
 void RCTStatus::signGroupMembership(QString content, double callbackId) {
     Q_D(RCTStatus);
-    qDebug() << "call of RCTStatus::signGroupMembership with param callbackId: " << callbackId;
+    qCDebug(RCTSTATUS) << "::signGroupMembership - callbackId:" << callbackId;
     QtConcurrent::run([&](QString content, double callbackId) {
             const char* result = SignGroupMembership(content.toUtf8().data());
-            qDebug() << "RCTStatus::signGroupMembership SignGroupMembership result: " << statusGoResultError(result);
+            logStatusGoResult("::signGroupMembership SignGroupMembership", result);
             d->bridge->invokePromiseCallback(callbackId, QVariantList{result});
         }, content, callbackId);
 }
 
 void RCTStatus::extractGroupMembershipSignatures(QString signatures, double callbackId) {
     Q_D(RCTStatus);
-    qDebug() << "call of RCTStatus::extractGroupMembershipSignatures with param callbackId: " << callbackId;
+    qCDebug(RCTSTATUS) << "::extractGroupMembershipSignatures - callbackId:" << callbackId;
     QtConcurrent::run([&](QString signatures, double callbackId) {
             const char* result = ExtractGroupMembershipSignatures(signatures.toUtf8().data());
-            qDebug() << "RCTStatus::extractGroupMembershipSignatures ExtractGroupMembershipSignatures result: " << statusGoResultError(result);
+            logStatusGoResult("::extractGroupMembershipSignatures ExtractGroupMembershipSignatures", result);
             d->bridge->invokePromiseCallback(callbackId, QVariantList{result});
         }, signatures, callbackId);
 }
@@ -239,20 +238,20 @@ void RCTStatus::clearStorageAPIs() {
 
 void RCTStatus::callRPC(QString payload, double callbackId) {
     Q_D(RCTStatus);
-    rnLog(RCTSTATUS) << "::callRPC call with param callbackId: " << callbackId;
+    qCDebug(RCTSTATUS) << "::callRPC call - payload:" << payload.left(128) << "callbackId:" << callbackId;
     QtConcurrent::run([&](QString payload, double callbackId) {
             const char* result = CallRPC(payload.toUtf8().data());
-            rnLog(RCTSTATUS) << "::callRPC CallRPC result: " << statusGoResultError(result);
+            logStatusGoResult("::callRPC CallRPC", result);
             d->bridge->invokePromiseCallback(callbackId, QVariantList{result});
         }, payload, callbackId);
 }
 
 void RCTStatus::callPrivateRPC(QString payload, double callbackId) {
     Q_D(RCTStatus);
-    rnLog(RCTSTATUS) << "::callPrivateRPC call with param callbackId: " << callbackId;
+    qCDebug(RCTSTATUS) << "::callPrivateRPC call - payload:" << payload.left(128) << "callbackId:" << callbackId;
     QtConcurrent::run([&](QString payload, double callbackId) {
             const char* result = CallPrivateRPC(payload.toUtf8().data());
-            rnLog(RCTSTATUS) << "::callPrivateRPC CallPrivateRPC result: " << statusGoResultError(result);
+            logStatusGoResult("::callPrivateRPC CallPrivateRPC", result);
             d->bridge->invokePromiseCallback(callbackId, QVariantList{result});
         }, payload, callbackId);
 }
@@ -261,33 +260,38 @@ void RCTStatus::closeApplication() {
 }
 
 bool RCTStatus::JSCEnabled() {
-    rnLog(RCTSTATUS) << "::JSCEnabled call";
+    qCDebug(RCTSTATUS) << "::JSCEnabled call";
     return false;
 }
 
 void RCTStatus::statusGoEventCallback(const char* event) {
-    rnLog(RCTSTATUS) << "::statusGoEventCallback call, ... event: " << event;
+    qCDebug(RCTSTATUS) << "::statusGoEventCallback call - event: " << event;
     RCTStatusPrivate::rctStatus->emitStatusGoEvent(event);
 }
 
 void RCTStatus::emitStatusGoEvent(QString event) {
-    rnLog(RCTSTATUS) << "::emitStatusGoEvent call, ... event: " << event;
+    qCDebug(RCTSTATUS) << "::emitStatusGoEvent call - event: " << event;
     Q_EMIT statusGoEvent(event);
 }
 
 void RCTStatus::onStatusGoEvent(QString event) {
-    rnLog(RCTSTATUS) << "::onStatusGoEvent call, ... event: " << event.toUtf8().data();
+    qCDebug(RCTSTATUS) << "::onStatusGoEvent call - event: " << event.toUtf8().data();
     RCTStatusPrivate::bridge->eventDispatcher()->sendDeviceEvent("gethEvent", QVariantMap{{"jsonEvent", event.toUtf8().data()}});
 }
 
-QString RCTStatus::statusGoResultError(const char* result)
+void RCTStatus::logStatusGoResult(const char* methodName, const char* result)
 {
     QJsonParseError jsonError;
     QJsonDocument jsonDoc = QJsonDocument::fromJson(QString(result).toUtf8(), &jsonError);
-    if (jsonError.error != QJsonParseError::NoError){
-        rnLog(RCTSTATUS) << jsonError.errorString();
-        return QString("");
+    if (jsonError.error != QJsonParseError::NoError) {
+        qCWarning(RCTSTATUS) << qUtf8Printable(jsonError.errorString());
+        return;
     }
 
-    return QString("Error: %1").arg(jsonDoc.toVariant().toMap().value("error").toString());
+    QString error = jsonDoc.toVariant().toMap().value("error").toString();
+    if (error.isEmpty()) {
+        qCDebug(RCTSTATUS) << methodName << "succeeded";
+    } else {
+        qCWarning(RCTSTATUS) << methodName << "- error:" << qUtf8Printable(error);
+    }
 }

--- a/modules/react-native-status/desktop/rctstatus.h
+++ b/modules/react-native-status/desktop/rctstatus.h
@@ -13,7 +13,10 @@
 
 #include "moduleinterface.h"
 
+#include <QLoggingCategory>
 #include <QVariantMap>
+
+Q_DECLARE_LOGGING_CATEGORY(RCTSTATUS)
 
 class RCTStatusPrivate;
 class RCTStatus : public QObject, public ModuleInterface {
@@ -67,7 +70,7 @@ private Q_SLOTS:
     void onStatusGoEvent(QString event);
 
 private:
-    QString statusGoResultError(const char *result);
+    void logStatusGoResult(const char* methodName, const char* result);
 
     QScopedPointer<RCTStatusPrivate> d_ptr;
 };


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

Part of #6593

### Summary:

[comment]: # (Summarise the problem and how the pull request solves it)
This PR is mostly to help with https://github.com/status-im/react-native-desktop/pull/382 so that we display the source category from Qt. I've taken the opportunity to handle some low hanging fruit from #6593 as I believe it will make a great impact on the readability of logs.

Before:
```
17:43:13.685 - D - ubuntu-server std:  "DEBUG [status-im.utils.handlers:36] - Handling re-frame event:  :chat.ui/send-current-message"
17:43:13.732 - D - "RCTStatus:" ::callPrivateRPC call with param callbackId:  30685
17:43:13.732 - D - "RCTStatus:" ::callPrivateRPC call with param callbackId:  30689
17:43:13.737 - D - "RCTStatus:" ::callPrivateRPC CallPrivateRPC result:  "Error: "
17:43:13.738 - D - "RCTStatus:" ::callPrivateRPC CallPrivateRPC result:  "Error: "
17:43:13.742 - D - ubuntu-server std:  "DEBUG [status-im.utils.handlers:36] - Handling re-frame event:  :transport/message-sent status-desktop"
17:43:13.793 - D - ubuntu-server std:  "DEBUG [status-im.ui.screens.desktop.main.chat.views:188] - nil? {:value \"today\", :type :datemark, :display-photo? true, :same-direction? false, :last-in-group? true, :last-outgoing? false, :group-chat true, :current-public-key \"0x04325367620ae20dd878dbb39f69f02c567d789dd21af8a88623dc5b529827c2812571c380a2cd8236a2851b8843d6486481166c39debf60a5d30b9099c66213e4\"}"
17:43:13.802 - W - QCoreApplication::postEvent: Unexpected null receiver
17:43:14.265 - D - "RCTStatus:" ::callPrivateRPC call with param callbackId:  30939
17:43:14.272 - D - "RCTStatus:" ::callPrivateRPC CallPrivateRPC result:  "Error: "
17:43:14.282 - D - ubuntu-server std:  "DEBUG [status-im.utils.handlers:36] - Handling re-frame event:  :transport/messages-received\nDEBUG [status-im.utils.handlers:36] - Handling re-frame event:  :message/add"
```

After:
```
16:30:36.587 - W - [Status] - QCoreApplication::postEvent: Unexpected null receiver
16:30:40.332 - D - [Status] - monitorNetworkAccess: setNetworkAccessible  old:  false new:  2
16:30:40.334 - D - [JSServer] - [status-im.utils.handlers:36] - Handling re-frame event:  :network/connection-status-changed true
16:30:40.335 - W - [JSServer] - [status-im.network.net-info:22] - isConnectionExpensive:  Error: Currently not supported on iOS
16:31:42.239 - D - [Status] - starting ubuntu server...
16:31:42.240 - D - [Status] - wait for started...
16:31:42.820 - D - [JSServer] - -- Server starting
16:31:42.820 - D - [Status] - waiting finished
16:31:43.127 - D - [Status] - DesktopNotification::DesktopNotification List of all loaded Snore plugins:  ("Freedesktop", "Snore")
16:31:43.127 - D - [Status] - DesktopNotification::DesktopNotification Current notification backend:  "Freedesktop"
```
### Testing notes (optional):
<!-- (Specify which platforms should be tested) -->
#### Platforms
- macOS
- Linux

status: ready <!-- Can be ready or wip -->
