### PR TITLE
Increase build timeout as it is failing intermittently now

### DIFF
--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -4,7 +4,7 @@ pipeline {
   options {
     disableConcurrentBuilds()
     /* Prevent Jenkins jobs from running forever */
-    timeout(time: 25, unit: 'MINUTES')
+    timeout(time: 30, unit: 'MINUTES')
     /* Limit builds retained */
     buildDiscarder(logRotator(
       numToKeepStr: '10',


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

Tiny PR to increase Jenkins build timeout from 25 minutes to 30, as the latest nightly went slightly over 25 minutes.

status: ready <!-- Can be ready or wip -->
