### PR TITLE
[TESTS] Can complete txn to dapp after onboarding called from dapp is completed

### DIFF
--- a/test/appium/tests/atomic/transactions/test_daaps_transactions.py
+++ b/test/appium/tests/atomic/transactions/test_daaps_transactions.py
@@ -2,7 +2,7 @@ import pytest
 
 from tests import marks, unique_password
 from tests.base_test_case import SingleDeviceTestCase
-from tests.users import transaction_senders
+from tests.users import transaction_senders, transaction_recipients
 from views.sign_in_view import SignInView
 
 
@@ -142,3 +142,26 @@ class TestTransactionDApp(SingleDeviceTestCase):
 
         if not send_transaction_view.onboarding_message.is_element_displayed():
             self.driver.fail(onboarding_screen_error_msg)
+
+    @marks.testrail_id(5380)
+    @marks.high
+    def test_user_can_complete_tx_to_dapp_when_onboarding_via_dapp_completed(self):
+        user = transaction_recipients['G']
+        signin_view = SignInView(self.driver)
+        home_view = signin_view.recover_access(passphrase=user['passphrase'])
+        status_test_dapp = home_view.open_status_test_dapp()
+        status_test_dapp.wait_for_d_aap_to_load()
+        status_test_dapp.assets_button.click()
+
+        send_transaction_view = status_test_dapp.request_stt_button.click()
+        if not send_transaction_view.onboarding_message.is_element_displayed():
+            self.driver.fail('It seems onborading screen is not shown.')
+        send_transaction_view.complete_onboarding()
+
+        if not send_transaction_view.sign_transaction_button.is_element_displayed():
+            self.driver.fail('It seems transaction sign screen is not shown.')
+
+        send_transaction_view.sign_transaction()
+
+        if not status_test_dapp.assets_button.is_element_displayed():
+            self.driver.fail('It seems users was not redirected to Status DAPP screen.')

--- a/test/appium/tests/users.py
+++ b/test/appium/tests/users.py
@@ -230,3 +230,9 @@ transaction_recipients['F']['username'] = "Exhausted Yellowgreen Polecat"
 transaction_recipients['F']['address'] = "81e0b035fe73f4f1aefeb5c75537c7d9b423149f"
 transaction_recipients['F']['public_key'] = "0x04bf7da995d4e35a9fec3eec00f1b628d8c47fe931014111236cae617bd1dbd4743a49" \
                                             "684d083b4552d86a37380c8b0d49688e2026e2c801b4b503a9a8383c533d"
+transaction_recipients['G'] = dict()
+transaction_recipients['G']['passphrase'] = "spray tired dentist case please list occur envelope they across picture spatial"
+transaction_recipients['G']['username'] = "Amused Dazzling Badger"
+transaction_recipients['G']['address'] = "b1f8b0db0f12e45d7712625bc53535235d245a9f"
+transaction_recipients['G']['public_key'] = "0x04f08a05551c3704284ca03ea2ff7fe613a00e52be86d6b433f7e38fa31fd0741eebf" \
+                                            "4344ad8d1652896440dada4017665e9b16ae328cb829b9e647b65c7024df7"

--- a/test/appium/views/send_transaction_view.py
+++ b/test/appium/views/send_transaction_view.py
@@ -177,6 +177,13 @@ class SendTransactionView(BaseView):
 
         self.onboarding_message = OnboardingMessage(self.driver)
 
+    def complete_onboarding(self):
+        if self.onboarding_message.is_element_displayed():
+            from views.wallet_view import WalletView
+            wallet_view = WalletView(self.driver)
+            wallet_view.done_button.click()
+            self.yes_button.click()
+
     def sign_transaction(self, sender_password: str = common_password):
         self.sign_transaction_button.click_until_presence_of_element(self.enter_password_input)
         self.enter_password_input.send_keys(sender_password)

--- a/test/appium/views/web_views/status_test_dapp.py
+++ b/test/appium/views/web_views/status_test_dapp.py
@@ -81,3 +81,6 @@ class StatusTestDAppView(BaseWebView):
 
         self.status_api_button = StatusAPIButton(self.driver)
         self.request_contact_code_button = StatusAPIButton.RequestContactCodeButton(self.driver)
+
+    def wait_for_d_aap_to_load(self, wait_time=10):
+        self.assets_button.wait_for_visibility_of_element(seconds=wait_time)


### PR DESCRIPTION
### Steps to test:

1. Recover an account
2. Switch to ropsten
3. Open Status Test DApp -> Assets -> Request STT. Outcome: Onboarding screen appears.
4. Complete the onboarding. Outcome: Transaction sign in screen appears
5. Complete the transaction. Outome: User is being redirected back to Status Test DApp

status: ready <!-- Can be ready or wip -->
