### PR TITLE
[#6455]: Updated extension management

### DIFF
--- a/src/status_im/accounts/core.cljs
+++ b/src/status_im/accounts/core.cljs
@@ -63,10 +63,10 @@
   (let [extensions (-> account :extensions vals)]
     (if dev-mode?
       {:extensions/load {:extensions extensions
-                         :follow-up  :extensions/add}}
-      {:dispatch [:extensions/deactivate-all (filter :active? extensions)]})))
+                         :follow-up  :extensions/add-to-registry}}
+      {:dispatch [:extensions/update-hooks extensions]})))
 
-(fx/defn switch-dev-mode [{{:account/keys [account]} :db :as cofx} dev-mode?]
+(fx/defn switch-dev-mode [cofx dev-mode?]
   (fx/merge cofx
             (update-dev-server-state dev-mode?)
             (update-extensions-state dev-mode?)

--- a/src/status_im/chat/specs.cljs
+++ b/src/status_im/chat/specs.cljs
@@ -6,7 +6,7 @@
 (s/def :chat/current-chat-id (s/nilable string?))                 ; current or last opened chat-id
 (s/def :chat/chat-id (s/nilable string?))                         ; what is the difference ? ^
 (s/def :chat/new-chat-name (s/nilable string?))                   ; we have name in the new-chat why do we need this field
-(s/def :chat/chat-animations (s/nilable map?))                    ; {id (string) props (map)}
+(s/def :chat/animations (s/nilable map?))                         ; {id (string) props (map)}
 (s/def :chat/chat-ui-props (s/nilable map?))                      ; {id (string) props (map)}
 (s/def :chat/chat-list-ui-props (s/nilable map?))
 (s/def :chat/layout-height (s/nilable number?))                   ; height of chat's view layout 

--- a/src/status_im/chat/subs.cljs
+++ b/src/status_im/chat/subs.cljs
@@ -370,7 +370,7 @@
  :chat-animations
  (fn [db [_ key type]]
    (let [chat-id (subscribe [:get-current-chat-id])]
-     (get-in db [:chat-animations @chat-id key type]))))
+     (get-in db [:animations :chats @chat-id key type]))))
 
 (reg-sub
  :get-chats-unread-messages-number

--- a/src/status_im/data_store/accounts.cljs
+++ b/src/status_im/data_store/accounts.cljs
@@ -26,8 +26,8 @@
 
 (defn- deserialize-extensions [extensions]
   (reduce-kv
-   (fn [acc _ {:keys [id] :as extension}]
-     (assoc acc id extension))
+   (fn [acc _ {:keys [url] :as extension}]
+     (assoc acc url extension))
    {}
    extensions))
 

--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -18,6 +18,7 @@
             [status-im.contact.core :as contact]
             [status-im.data-store.core :as data-store]
             [status-im.extensions.core :as extensions]
+            [status-im.extensions.registry :as extensions.registry]
             [status-im.fleet.core :as fleet]
             [status-im.group-chats.core :as group-chats]
             [status-im.hardwallet.core :as hardwallet]
@@ -34,9 +35,7 @@
             [status-im.search.core :as search]
             [status-im.signals.core :as signals]
             [status-im.transport.message.core :as transport.message]
-            [status-im.ui.screens.currency-settings.models
-             :as
-             currency-settings.models]
+            [status-im.ui.screens.currency-settings.models :as currency-settings.models]
             [status-im.ui.screens.navigation :as navigation]
             [status-im.utils.fx :as fx]
             [status-im.utils.handlers :as handlers]
@@ -459,8 +458,13 @@
 
 (handlers/register-handler-fx
  :extensions.ui/add-extension-pressed
- (fn [cofx [_ id]]
-   (extensions/edit cofx id)))
+ (fn [cofx [_ extension-key]]
+   (extensions/edit cofx extension-key)))
+
+(handlers/register-handler-fx
+ :extensions.ui/uninstall-extension-pressed
+ (fn [cofx [_ extension-key]]
+   (extensions.registry/uninstall cofx extension-key)))
 
 (handlers/register-handler-fx
  :extensions.ui/input-changed
@@ -469,19 +473,19 @@
 
 (handlers/register-handler-fx
  :extensions.ui/activation-checkbox-pressed
- (fn [cofx [_ id state]]
-   (extensions/toggle-activation cofx id state)))
+ (fn [cofx [_ extension-key active?]]
+   (extensions.registry/change-state cofx extension-key active?)))
 
 (handlers/register-handler-fx
  :extensions.ui/show-button-pressed
  (fn [cofx [_ url]]
-   (extensions/load cofx url)))
+   (extensions.registry/load cofx url)))
 
 (handlers/register-handler-fx
  :extensions.ui/install-button-pressed
  [(re-frame/inject-cofx :random-id-generator)]
  (fn [cofx [_ data]]
-   (extensions/install cofx data)))
+   (extensions.registry/install cofx data)))
 
 ;; log-level module
 

--- a/src/status_im/extensions/core.cljs
+++ b/src/status_im/extensions/core.cljs
@@ -1,18 +1,15 @@
 (ns status-im.extensions.core
   (:refer-clojure :exclude [list])
   (:require [clojure.string :as string]
-            [pluto.reader :as reader]
-            [pluto.registry :as registry]
             [pluto.storages :as storages]
+            [pluto.reader :as reader]
             [re-frame.core :as re-frame]
-            [status-im.accounts.update.core :as accounts.update]
             [status-im.chat.commands.core :as commands]
             [status-im.chat.commands.impl.transactions :as transactions]
             [status-im.ui.components.button.view :as button]
             [status-im.ui.components.checkbox.view :as checkbox]
             [status-im.ui.components.list.views :as list]
             [status-im.ui.components.react :as react]
-            [status-im.i18n :as i18n]
             [status-im.ui.components.colors :as colors]
             [status-im.ui.screens.navigation :as navigation]
             [status-im.utils.handlers :as handlers]
@@ -324,64 +321,11 @@
   [{:keys [db]} input-key value]
   {:db (update db :extensions/manage assoc input-key {:value value})})
 
-(fx/defn fetch [cofx id]
-  (get-in cofx [:db :account/account :extensions id]))
+(fx/defn fetch [cofx ext-key]
+  (get-in cofx [:db :account/account :extensions ext-key]))
 
 (fx/defn edit
-  [cofx id]
-  (let [{:keys [url]} (fetch cofx id)]
+  [cofx extension-key]
+  (let [{:keys [url]} (fetch cofx extension-key)]
     (fx/merge (set-input cofx :url (str url))
               (navigation/navigate-to-cofx :edit-extension nil))))
-
-(fx/defn add
-  [cofx extension-data active?]
-  (let [extension-key  "extension"
-        extension-data (assoc-in extension-data ['meta :name] extension-key)]
-    (fx/merge cofx
-              #(registry/deactivate extension-key %)
-              #(registry/add extension-data %)
-              (when active?
-                #(registry/activate extension-key %)))))
-
-(fx/defn install
-  [{{:extensions/keys [manage] :account/keys [account] :as db} :db
-    random-id-generator :random-id-generator :as cofx}
-   extension-data]
-  (let [extension-key  (get-in extension-data ['meta :name])
-        {:keys [url id]} manage
-        extension      {:id      (or (:value id) "extension")
-                        :name    (str extension-key)
-                        :url     (:value url)
-                        :active? true}
-        new-extensions (assoc (:extensions account) (:id extension) extension)]
-    (fx/merge cofx
-              {:ui/show-confirmation {:title     (i18n/label :t/success)
-                                      :content   (i18n/label :t/extension-installed)
-                                      :on-accept #(re-frame/dispatch [:navigate-to-clean :my-profile])
-                                      :on-cancel nil}}
-              (accounts.update/account-update {:extensions new-extensions} {})
-              (add extension-data true))))
-
-(fx/defn toggle-activation
-  [cofx id state]
-  (let [toggle-fn      (get {true  registry/activate
-                             false registry/deactivate}
-                            state)
-        extensions     (get-in cofx [:db :account/account :extensions])
-        new-extensions (assoc-in extensions [id :active?] state)]
-    (fx/merge cofx
-              (accounts.update/account-update {:extensions new-extensions} {:success-event nil})
-              #(toggle-fn id %))))
-
-(fx/defn load
-  [_ url]
-  {:extensions/load {:extensions [{:url     (string/trim url)
-                                   :active? true}]
-                     :follow-up  :extensions/stage}})
-
-(fx/defn activate-extensions
-  [{{:account/keys [account]} :db}]
-  (let [{:keys [extensions dev-mode?]} account]
-    (when dev-mode?
-      {:extensions/load {:extensions (vals extensions)
-                         :follow-up  :extensions/add}})))

--- a/src/status_im/extensions/registry.cljs
+++ b/src/status_im/extensions/registry.cljs
@@ -1,0 +1,114 @@
+(ns status-im.extensions.registry
+  (:refer-clojure :exclude [list])
+  (:require [clojure.string :as string]
+            [pluto.utils :as utils]
+            [pluto.reader.hooks :as hooks]
+            [re-frame.core :as re-frame]
+            [status-im.accounts.update.core :as accounts.update]
+            [status-im.i18n :as i18n]
+            [status-im.utils.fx :as fx]
+            [clojure.set :as set]))
+
+(fx/defn update-hooks
+  [{:keys [db] :as cofx} hook-fn extension-key]
+  (let [account (get db :account/account)
+        hooks   (get-in account [:extensions extension-key :hooks])]
+    (apply utils/merge-fx cofx
+           (mapcat (fn [[_ extension-hooks]]
+                     (map (fn [[hook-id {:keys [hook-ref parsed]}]]
+                            (partial hook-fn (:hook hook-ref) hook-id parsed))
+                          extension-hooks))
+                   hooks))))
+
+(fx/defn add-to-registry
+  [{:keys [db] :as cofx} extension-key extension-data active?]
+  (let [{:keys [hooks]} extension-data
+        data {:hooks   hooks
+              :active? active?}]
+    (fx/merge cofx
+              {:db (update-in db [:account/account :extensions extension-key] merge data)}
+              (update-hooks hooks/hook-in extension-key))))
+
+(fx/defn remove-from-registry
+  [{:keys [db] :as cofx} extension-key]
+  (fx/merge cofx
+            (update-hooks hooks/unhook extension-key)
+            {:db (update-in db [:account/account :extensions] dissoc extension-key)}))
+
+(fx/defn change-state
+  [cofx extension-key active?]
+  (let [extensions     (get-in cofx [:db :account/account :extensions])
+        new-extensions (assoc-in extensions [extension-key :active?] active?)
+        hook-fn        (if active?
+                         hooks/hook-in
+                         hooks/unhook)]
+    (fx/merge cofx
+              (accounts.update/account-update {:extensions new-extensions} {:success-event nil})
+              (update-hooks hook-fn extension-key))))
+
+(fx/defn install
+  [{:keys [db random-id-generator] :as cofx} extension-data]
+  (let [{:extensions/keys [manage]
+         :account/keys    [account]} db
+        {:keys [id url]} manage
+        extension      {:id      (-> (:value id)
+                                     (or (random-id-generator))
+                                     (string/replace "-" ""))
+                        :name    (get-in extension-data ['meta :name])
+                        :url     (:value url)
+                        :active? true}
+        new-extensions (assoc (:extensions account) (:url extension) extension)]
+    (fx/merge cofx
+              {:ui/show-confirmation {:title     (i18n/label :t/success)
+                                      :content   (i18n/label :t/extension-installed)
+                                      :on-accept #(re-frame/dispatch [:navigate-to-clean :my-profile])
+                                      :on-cancel nil}}
+              (accounts.update/account-update {:extensions new-extensions} {})
+              (add-to-registry (:value url) extension-data true))))
+
+(fx/defn uninstall
+  [{:keys [db] :as cofx} extension-key]
+  (let [{:account/keys [account]} db
+        new-extensions (dissoc (:extensions account) extension-key)]
+    (fx/merge cofx
+              {:ui/show-confirmation {:title     (i18n/label :t/success)
+                                      :content   (i18n/label :t/extension-uninstalled)
+                                      :on-accept nil
+                                      :on-cancel nil}}
+              (remove-from-registry extension-key)
+              (accounts.update/account-update {:extensions new-extensions} {}))))
+
+(fx/defn load
+  [cofx url]
+  (if (get-in cofx [:db :account/account :extensions url])
+    {:utils/show-popup {:title   (i18n/label :t/error)
+                        :content (i18n/label :t/extension-is-already-added)}}
+    {:extensions/load {:extensions [{:url     (string/trim url)
+                                     :active? true}]
+                       :follow-up  :extensions/stage}}))
+
+(fx/defn initialize
+  [{{:account/keys [account]} :db}]
+  (let [{:keys [extensions dev-mode?]} account]
+    (when dev-mode?
+      {:extensions/load {:extensions (vals extensions)
+                         :follow-up  :extensions/add-to-registry}})))
+
+(defn existing-hooks-for
+  [type cofx extension-data]
+  (let [added-hooks (reduce (fn [acc [_ {:keys [hooks]}]]
+                              (->> (type hooks)
+                                   (keys)
+                                   (into acc)))
+                            #{}
+                            (get-in cofx [:db :account/account :extensions]))
+        hooks       (->> (get-in extension-data [:data :hooks type])
+                         (keys)
+                         (into #{}))]
+    (set/intersection added-hooks hooks)))
+
+(defn existing-hooks [cofx extension-data]
+  (->> (get-in extension-data [:data :hooks])
+       (keys)
+       (map #(existing-hooks-for % cofx extension-data))
+       (apply set/union)))

--- a/src/status_im/init/core.cljs
+++ b/src/status_im/init/core.cljs
@@ -7,7 +7,7 @@
             [status-im.constants :as constants]
             [status-im.data-store.core :as data-store]
             [status-im.data-store.realm.core :as realm]
-            [status-im.extensions.core :as extensions]
+            [status-im.extensions.registry :as extensions.registry]
             [status-im.i18n :as i18n]
             [status-im.browser.core :as browser]
             [status-im.contact.core :as contact]
@@ -218,7 +218,7 @@
             (chat-loading/initialize-pending-messages)
             (browser/initialize-browsers)
             (browser/initialize-dapp-permissions)
-            (extensions/activate-extensions)
+            (extensions.registry/initialize)
             #(when-not platform/desktop?
                (initialize-wallet %))
             (accounts.update/update-sign-in-time)

--- a/src/status_im/ui/components/list/styles.cljs
+++ b/src/status_im/ui/components/list/styles.cljs
@@ -120,3 +120,19 @@
 
 (def label
   {:color colors/gray})
+
+(def delete-button-width 100)
+
+(def delete-icon-highlight
+  {:position         :absolute
+   :top              0
+   :bottom           0
+   :right            -800
+   :width            800
+   :background-color colors/red-light})
+
+(def delete-icon-container
+  {:flex            1
+   :width           delete-button-width
+   :justify-content :center
+   :align-items     :center})

--- a/src/status_im/ui/components/list/views.cljs
+++ b/src/status_im/ui/components/list/views.cljs
@@ -18,13 +18,16 @@
 
   [section-list {:sections [{:title \"\" :key :unik :render-fn render :data {:title  \"\" :subtitle \"\"}}]}]
   "
+  (:require-macros [status-im.utils.views :as views])
   (:require [reagent.core :as reagent]
+            [status-im.ui.components.animation :as animation]
             [status-im.ui.components.checkbox.view :as checkbox]
             [status-im.ui.components.colors :as colors]
             [status-im.ui.components.icons.vector-icons :as vector-icons]
             [status-im.ui.components.list.styles :as styles]
             [status-im.ui.components.react :as react]
-            [status-im.utils.platform :as platform]))
+            [status-im.utils.platform :as platform]
+            [status-im.ui.screens.home.animations.responder :as responder]))
 
 (def flat-list-class (react/get-class "FlatList"))
 (def section-list-class (react/get-class "SectionList"))
@@ -219,3 +222,16 @@
    [react/text {:style styles/label}
     label]
    list])
+
+(views/defview deletable-list-item [{:keys [type id on-delete]} body]
+  (views/letsubs [swiped? [:delete-swipe-position type id]]
+    (let [offset-x            (animation/create-value (if swiped? styles/delete-button-width 0))
+          swipe-pan-responder (responder/swipe-pan-responder offset-x styles/delete-button-width id swiped?)
+          swipe-pan-handler   (responder/pan-handlers swipe-pan-responder)]
+      [react/view swipe-pan-handler
+       [react/animated-view {:style {:flex 1 :right offset-x}}
+        body
+        [react/touchable-highlight {:style    styles/delete-icon-highlight
+                                    :on-press on-delete}
+         [react/view {:style styles/delete-icon-container}
+          [vector-icons/icon :icons/delete {:color colors/red}]]]]])))

--- a/src/status_im/ui/screens/db.cljs
+++ b/src/status_im/ui/screens/db.cljs
@@ -4,7 +4,6 @@
             [status-im.utils.platform :as platform]
             [status-im.utils.dimensions :as dimensions]
             [status-im.fleet.core :as fleet]
-            pluto.registry
             status-im.transport.db
             status-im.accounts.db
             status-im.contact.db
@@ -274,7 +273,7 @@
                                    :chat/chat-id
                                    :chat/new-chat
                                    :chat/new-chat-name
-                                   :chat/chat-animations
+                                   :chat/animations
                                    :chat/chat-ui-props
                                    :chat/chat-list-ui-props
                                    :chat/layout-height

--- a/src/status_im/ui/screens/events.cljs
+++ b/src/status_im/ui/screens/events.cljs
@@ -141,8 +141,8 @@
 
 (handlers/register-handler-fx
  :set-swipe-position
- (fn [{:keys [db]} [_ item-id value]]
-   {:db (assoc-in db [:chat-animations item-id :delete-swiped] value)}))
+ (fn [{:keys [db]} [_ type item-id value]]
+   {:db (assoc-in db [:animations type item-id :delete-swiped] value)}))
 
 (handlers/register-handler-fx
  :show-tab-bar

--- a/src/status_im/ui/screens/extensions/add/events.cljs
+++ b/src/status_im/ui/screens/extensions/add/events.cljs
@@ -1,32 +1,40 @@
 (ns status-im.ui.screens.extensions.add.events
-  (:require [pluto.registry :as registry]
-            [re-frame.core :as re-frame]
+  (:require [re-frame.core :as re-frame]
             [status-im.extensions.core :as extensions]
+            [status-im.extensions.registry :as extensions.registry]
             [status-im.ui.screens.navigation :as navigation]
             [status-im.utils.handlers :as handlers]
-            [status-im.utils.fx :as fx]))
+            [status-im.utils.fx :as fx]
+            [status-im.i18n :as i18n]))
 
 (re-frame/reg-fx
  :extensions/load
  (fn [{:keys [extensions follow-up]}]
    (doseq [{:keys [url active?]} extensions]
-     (extensions/load-from url #(re-frame/dispatch [follow-up (extensions/parse-extension %) active?])))))
+     (extensions/load-from url #(re-frame/dispatch [follow-up url (extensions/parse-extension %) active?])))))
 
 (handlers/register-handler-fx
  :extensions/stage
- (fn [{:keys [db] :as cofx} [_ extension-data]]
-   (fx/merge cofx
-             {:db (assoc db :staged-extension extension-data)}
-             (navigation/navigate-to-cofx :show-extension nil))))
+ (fn [{:keys [db] :as cofx} [_ _ extension-data]]
+   (let [hooks (extensions.registry/existing-hooks cofx extension-data)]
+     (if (empty? hooks)
+       (fx/merge cofx
+                 {:db (assoc db :staged-extension extension-data)}
+                 (navigation/navigate-to-cofx :show-extension nil))
+       {:utils/show-popup {:title   (i18n/label :t/error)
+                           :content (i18n/label :t/extension-hooks-cannot-be-added
+                                                {:hooks (->> hooks
+                                                             (map name)
+                                                             (clojure.string/join ", "))})}}))))
 
 (handlers/register-handler-fx
- :extensions/add
- (fn [cofx [_ {:keys [data]} active?]]
-   (extensions/add cofx data active?)))
+ :extensions/add-to-registry
+ (fn [cofx [_ extension-key {:keys [data]} active?]]
+   (extensions.registry/add-to-registry cofx extension-key data active?)))
 
 (handlers/register-handler-fx
- :extensions/deactivate-all
+ :extensions/update-hooks
  (fn [cofx [_ extensions]]
-   (apply fx/merge cofx (map (fn [{:keys [id]}]
-                               (partial registry/deactivate id))
+   (apply fx/merge cofx (map (fn [{:keys [url]}]
+                               (extensions.registry/update-hooks cofx url))
                              extensions))))

--- a/src/status_im/ui/screens/extensions/db.cljs
+++ b/src/status_im/ui/screens/extensions/db.cljs
@@ -14,6 +14,7 @@
                                                    :extension/name
                                                    :extension/url
                                                    :extension/active?]
-                                          :opt-un [:extension/data]))
+                                          :opt-un [:extension/data
+                                                   :extension/hooks]))
 
 (spec/def :extensions/extensions (spec/nilable (spec/map-of :extension/id :extension/extension)))

--- a/src/status_im/ui/screens/extensions/views.cljs
+++ b/src/status_im/ui/screens/extensions/views.cljs
@@ -14,15 +14,20 @@
   [react/view (styles/mailserver-icon true)
    [vector-icons/icon :icons/mailserver {:color :white}]])
 
-(defn- render-extension [{:keys [id name url active?]}]
-  [list/list-item-with-checkbox
-   {:checked?        active?
-    :on-value-change #(re-frame/dispatch [:extensions.ui/activation-checkbox-pressed id %])}
-   [list/item
-    mailserver-icon
-    [list/item-content
-     [list/item-primary name]
-     [list/item-secondary url]]]])
+(defn- render-extension [{:keys [name url active?]}]
+  [list/deletable-list-item {:type      :extensions
+                             :id        url
+                             :on-delete #(do
+                                           (re-frame/dispatch [:set-swipe-position :extensions url false])
+                                           (re-frame/dispatch [:extensions.ui/uninstall-extension-pressed url]))}
+   [list/list-item-with-checkbox
+    {:checked?        active?
+     :on-value-change #(re-frame/dispatch [:extensions.ui/activation-checkbox-pressed url %])}
+    [list/item
+     mailserver-icon
+     [list/item-content
+      [list/item-primary name]
+      [list/item-secondary url]]]]])
 
 (views/defview extensions-settings []
   (views/letsubs [extensions [:extensions/all-extensions]]
@@ -38,6 +43,8 @@
                        :default-separator?      false
                        :key-fn                  :id
                        :render-fn               render-extension
-                       :content-container-style (merge (when (zero? (count extensions)) {:flex-grow 1}) {:justify-content :center})
+                       :content-container-style (merge (when (zero? (count extensions))
+                                                         {:flex-grow 1})
+                                                       {:justify-content :center})
                        :empty-component         [react/text {:style styles/empty-list}
                                                  (i18n/label :t/no-extension)]}]]]))

--- a/src/status_im/ui/screens/home/animations/responder.cljs
+++ b/src/status_im/ui/screens/home/animations/responder.cljs
@@ -20,7 +20,7 @@
     (let [updated-value (get-updated-value gesture end-offset-x swiped?)
           should-open?  (> updated-value (/ end-offset-x 2))
           to-value      (if should-open? end-offset-x 0)]
-      (re-frame/dispatch [:set-swipe-position chat-id should-open?])
+      (re-frame/dispatch [:set-swipe-position :chats chat-id should-open?])
       (animation/start (animation/spring animated-offset-x {:toValue to-value})))))
 
 (defn swipe-pan-responder [animated-offset-x end-offset-x chat-id swiped?]

--- a/src/status_im/ui/screens/home/styles.cljs
+++ b/src/status_im/ui/screens/home/styles.cljs
@@ -2,8 +2,6 @@
   (:require-macros [status-im.utils.styles :refer [defstyle defnstyle]])
   (:require [status-im.ui.components.colors :as colors]))
 
-(def delete-button-width 100)
-
 (defn toolbar []
   {:background-color colors/white})
 
@@ -171,20 +169,6 @@
   {:size      42
    :icon-size 17
    :shadow?   false})
-
-(def delete-icon-highlight
-  {:position         :absolute
-   :top              0
-   :bottom           0
-   :right            -800
-   :width            800
-   :background-color colors/red-light})
-
-(def delete-icon-container
-  {:flex            1
-   :width           delete-button-width
-   :justify-content :center
-   :align-items     :center})
 
 (def action-button-container
   {:position :absolute

--- a/src/status_im/ui/screens/home/views.cljs
+++ b/src/status_im/ui/screens/home/views.cljs
@@ -1,7 +1,6 @@
 (ns status-im.ui.screens.home.views
   (:require-macros [status-im.utils.views :as views])
   (:require [re-frame.core :as re-frame]
-            [status-im.ui.components.colors :as colors]
             [status-im.ui.components.list.views :as list]
             [status-im.ui.components.react :as react]
             [status-im.ui.components.toolbar.view :as toolbar]
@@ -9,13 +8,9 @@
             [status-im.ui.components.connectivity.view :as connectivity]
             [status-im.ui.screens.home.views.inner-item :as inner-item]
             [status-im.ui.screens.home.styles :as styles]
-            [status-im.ui.components.icons.vector-icons :as vector-icons]
-            [status-im.ui.components.animation :as animation]
-            [status-im.ui.screens.home.animations.responder :as responder]
             [status-im.utils.platform :as platform]
             [status-im.react-native.resources :as resources]
             [status-im.ui.components.common.common :as components.common]
-            [status-im.i18n :as i18n]
             [status-im.ui.components.icons.vector-icons :as icons]))
 
 (defn- toolbar [show-welcome?]
@@ -37,29 +32,22 @@
     [react/view styles/action-button
      [icons/icon :icons/add {:color :white}]]]])
 
-(views/defview home-list-item [[home-item-id home-item]]
-  (views/letsubs [swiped? [:delete-swipe-position home-item-id]]
-    (let [delete-action (if (:chat-id home-item)
+(defn home-list-item [[home-item-id home-item]]
+  (let [delete-action   (if (:chat-id home-item)
                           (if (and (:group-chat home-item)
                                    (not (:public? home-item)))
                             :group-chats.ui/remove-chat-pressed
                             :chat.ui/remove-chat)
                           :browser.ui/remove-browser-pressed)
-          inner-item-view (if (:chat-id home-item)
-                            inner-item/home-list-chat-item-inner-view
-                            inner-item/home-list-browser-item-inner-view)
-          offset-x (animation/create-value (if swiped? styles/delete-button-width 0))
-          swipe-pan-responder (responder/swipe-pan-responder offset-x styles/delete-button-width home-item-id swiped?)
-          swipe-pan-handler (responder/pan-handlers swipe-pan-responder)]
-      [react/view (assoc swipe-pan-handler :accessibility-label :chat-item)
-       [react/animated-view {:style {:flex 1 :right offset-x}}
-        [inner-item-view home-item]
-        [react/touchable-highlight {:style    styles/delete-icon-highlight
-                                    :on-press #(do
-                                                 (re-frame/dispatch [:set-swipe-position home-item-id false])
-                                                 (re-frame/dispatch [delete-action home-item-id]))}
-         [react/view {:style styles/delete-icon-container}
-          [vector-icons/icon :icons/delete {:color colors/red}]]]]])))
+        inner-item-view (if (:chat-id home-item)
+                          inner-item/home-list-chat-item-inner-view
+                          inner-item/home-list-browser-item-inner-view)]
+    [list/deletable-list-item {:type      :chats
+                               :id        home-item-id
+                               :on-delete #(do
+                                             (re-frame/dispatch [:set-swipe-position :chats home-item-id false])
+                                             (re-frame/dispatch [delete-action home-item-id]))}
+     [inner-item-view home-item]]))
 
 ;;do not remove view-id and will-update or will-unmount handlers, this is how it works
 (views/defview welcome [view-id]

--- a/src/status_im/ui/screens/subs.cljs
+++ b/src/status_im/ui/screens/subs.cljs
@@ -77,8 +77,8 @@
            (> (count (:navigation-stack db)) 1)))
 
 (reg-sub :delete-swipe-position
-         (fn [db [_ item-id]]
-           (let [item-animation (get-in db [:chat-animations item-id])]
+         (fn [db [_ type item-id]]
+           (let [item-animation (get-in db [:animations type item-id])]
              (if (some? item-animation) (:delete-swiped item-animation) nil))))
 
 (reg-sub :dimensions/window

--- a/src/status_im/utils/universal_links/core.cljs
+++ b/src/status_im/utils/universal_links/core.cljs
@@ -5,7 +5,7 @@
             [re-frame.core :as re-frame]
             [status-im.accounts.db :as accounts.db]
             [status-im.chat.models :as chat]
-            [status-im.extensions.core :as extensions]
+            [status-im.extensions.registry :as extensions.registry]
             [status-im.ui.components.list-selection :as list-selection]
             [status-im.ui.components.react :as react]
             [status-im.ui.screens.add-new.new-chat.db :as new-chat.db]
@@ -72,7 +72,7 @@
 
 (fx/defn handle-extension [cofx url]
   (log/info "universal-links: handling url profile" url)
-  (extensions/load cofx url))
+  (extensions.registry/load cofx url))
 
 (defn handle-not-found [full-url]
   (log/info "universal-links: no handler for " full-url))

--- a/translations/en.json
+++ b/translations/en.json
@@ -767,5 +767,7 @@
     "share-dapp-text": "Check out this DApp I'm using on Status: {{link}}",
     "network-invalid-url": "Network URL is invalid",
     "network-invalid-status-code": "Invalid status code: {{code}}",
-    "extension-is-already-added": "The extension is already added"
+    "extension-is-already-added": "The extension is already added",
+    "extension-uninstalled": "The extension was uninstalled",
+    "extension-hooks-cannot-be-added": "The following hooks from this extension cannot be added: {{hooks}}"
 }


### PR DESCRIPTION
Fixes #6455.
Also here: https://github.com/status-im/pluto/pull/88

This PR improves the extension management mechanism — allows to remove extensions and also moves registry from `pluto` to `status-react`.