### PR TITLE
[TESTS] Removed skip mark for a test

### DIFF
--- a/test/appium/tests/atomic/chats/test_public.py
+++ b/test/appium/tests/atomic/chats/test_public.py
@@ -110,7 +110,6 @@ class TestPublicChatMultipleDevice(MultipleDeviceTestCase):
 @marks.chat
 class TestPublicChatSingleDevice(SingleDeviceTestCase):
 
-    @marks.skip
     @marks.testrail_id(5392)
     @marks.high
     def test_send_korean_characters(self):


### PR DESCRIPTION
### Summary 
the test under the PR had been marked with 'skip' flag since June. 
The related bug was fixed https://github.com/status-im/status-react/issues/4829, so I removed the mark. 

