### PR TITLE
upload a latest.json to the nightlies bucket

### DIFF
--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -80,12 +80,14 @@ pipeline {
         ipaUrl = ios.getBuildVariables().get('DIAWI_URL')
         /* add URLs to the build description */
         cmn.setBuildDesc(
-          Apk: apkUrl,
-          e2e: e2eUrl,
-          iOS: ipaUrl,
-          App: appUrl,
-          Mac: dmgUrl
+          Apk: apkUrl, e2e: e2eUrl, iOS: ipaUrl, App: appUrl, Mac: dmgUrl,
         )
+        /* Create latest.json with newest nightly URLs */
+        if (btype == 'nightly') {
+          cmn.updateLatestNightlies(
+            APK: apkUrl, IOS: ipaUrl, APP: appUrl, MAC: dmgUrl
+          )
+        }
       } }
     }
     stage('Notify') {
@@ -108,7 +110,7 @@ pipeline {
                 [name: 'APK_URL', value: apkUrl, $class: 'StringParameterValue'],
                 [name: 'IOS_URL', value: ipaUrl, $class: 'StringParameterValue'],
                 [name: 'DMG_URL', value: dmgUrl, $class: 'StringParameterValue'],
-                [name: 'NIX_URL', value: appUrl, $class: 'StringParameterValue']
+                [name: 'NIX_URL', value: appUrl, $class: 'StringParameterValue'],
               ]
             ); break
           case 'release':

--- a/ci/common.groovy
+++ b/ci/common.groovy
@@ -1,3 +1,5 @@
+import groovy.json.JsonBuilder
+
 def version() {
   return readFile("${env.WORKSPACE}/VERSION").trim()
 }
@@ -179,6 +181,16 @@ def setBuildDesc(Map links) {
     }
   }
   currentBuild.description = desc
+}
+
+def updateLatestNightlies(Map links) {
+  def latestFile = pwd() + '/' + 'pkg/latest.json'
+  /* it might not exist */
+  sh 'mkdir -p pkg'
+  def latestJson = new JsonBuilder(links).toPrettyString()
+  println("latest.json:\n${latestJson}")
+  new File(latestFile).write(latestJson)
+  return uploadArtifact(latestFile)
 }
 
 def getParentRunEnv(name) {


### PR DESCRIPTION
This creates a `latest.json` file in the bucket containing nightlies which points to the URLs of the newest nightly archives.

We are doing this to provide an easy mechanism for repos like https://github.com/status-im/status.im to include newest nightly URLs whenever they are built.

<blockquote><img src="https://avatars3.githubusercontent.com/u/11767950?s=400&v=4" width="48" align="right"><div><img src="https://assets-cdn.github.com/favicon.ico" height="14"> GitHub</div><div><strong><a href="https://github.com/status-im/status.im">status-im/status.im</a></strong></div><div>Build a Better Web with Status. Contribute to status-im/status.im development by creating an account on GitHub.</div></blockquote>