### PR TITLE
Allow running multiple Desktop instances on the same machine

### DIFF
--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -9,7 +9,7 @@ pipeline {
         "-v /dev/fuse:/dev/fuse "+
         "-v /var/tmp/lein:/var/tmp/lein:rw "+
         "-v /var/tmp/npm:/var/tmp/npm:rw "+
-        "-v /opt/StatusImAppImage.zip:/opt/StatusImAppImage.zip:ro"
+        "-v /opt/StatusImAppImage_20181113.zip:/opt/StatusImAppImage.zip:ro"
       )
     }
   }

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -9,7 +9,7 @@ pipeline {
         "-v /dev/fuse:/dev/fuse "+
         "-v /var/tmp/lein:/var/tmp/lein:rw "+
         "-v /var/tmp/npm:/var/tmp/npm:rw "+
-        "-v /opt/StatusIm-Windows-base-image.zip:/opt/StatusIm-Windows-base-image.zip:ro"
+        "-v /opt/StatusIm-Windows-base-image_20181113.zip:/opt/StatusIm-Windows-base-image.zip:ro"
       )
     }
   }

--- a/env/dev/env/android/main.cljs
+++ b/env/dev/env/android/main.cljs
@@ -13,10 +13,10 @@
 (assert (exists? core/app-root) "Fatal Error - Your core.cljs file doesn't define an 'app-root' function!!! - Perhaps there was a compilation failure?")
 
 (def cnt (r/atom 0))
-(defn reloader [] @cnt [core/app-root])
+(defn reloader [props] @cnt [core/app-root props])
 
 ;; Do not delete, root-el is used by the figwheel-bridge.js
-(def root-el (r/as-element [reloader]))
+(def root-el (r/reactify-component reloader))
 
 (figwheel/start {:websocket-url    (:android conf/figwheel-urls)
                  :heads-up-display false

--- a/env/dev/env/desktop/main.cljs
+++ b/env/dev/env/desktop/main.cljs
@@ -13,10 +13,10 @@
 (assert (exists? core/app-root) "Fatal Error - Your core.cljs file doesn't define an 'app-root' function!!! - Perhaps there was a compilation failure?")
 
 (def cnt (r/atom 0))
-(defn reloader [] @cnt [core/app-root])
+(defn reloader [props] @cnt [core/app-root props])
 
 ;; Do not delete, root-el is used by the figwheel-bridge.js
-(def root-el (r/as-element [reloader]))
+(def root-el (r/reactify-component reloader))
 
 (figwheel/start {:websocket-url    (:desktop conf/figwheel-urls)
                  :heads-up-display false

--- a/env/dev/env/ios/main.cljs
+++ b/env/dev/env/ios/main.cljs
@@ -13,10 +13,10 @@
 (assert (exists? core/app-root) "Fatal Error - Your core.cljs file doesn't define an 'app-root' function!!! - Perhaps there was a compilation failure?")
 
 (def cnt (r/atom 0))
-(defn reloader [] @cnt [core/app-root])
+(defn reloader [props] @cnt [core/app-root props])
 
 ;; Do not delete, root-el is used by the figwheel-bridge.js
-(def root-el (r/as-element [reloader]))
+(def root-el (r/reactify-component reloader))
 
 (figwheel/start {:websocket-url    (:ios conf/figwheel-urls)
                  :heads-up-display false

--- a/figwheel-bridge.js
+++ b/figwheel-bridge.js
@@ -78,7 +78,7 @@ var figwheelApp = function (platform, devHost) {
                     </ReactNative.View>
                 );
             }
-            return this.state.root;
+            return React.createElement(this.state.root, this.props);
         },
 
         componentDidMount: function () {

--- a/modules/react-native-status/desktop/rctstatus.cpp
+++ b/modules/react-native-status/desktop/rctstatus.cpp
@@ -92,7 +92,15 @@ void RCTStatus::startNode(QString configString) {
     if (!relativeDataDirPath.startsWith("/"))
         relativeDataDirPath.prepend("/");
 
-    QString rootDirPath = QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation);
+    QString statusDataDir = qgetenv("STATUS_DATA_DIR");
+    QString rootDirPath;
+    if (!statusDataDir.isEmpty()) {
+      rootDirPath = statusDataDir;
+    }
+    else {
+      rootDirPath = QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation);
+    }
+
     QDir rootDir(rootDirPath);
     QString absDataDirPath = rootDirPath + relativeDataDirPath;
     QDir dataDir(absDataDirPath);

--- a/scripts/build-desktop.sh
+++ b/scripts/build-desktop.sh
@@ -227,7 +227,7 @@ function bundleWindows() {
 
     if [ -z $STATUSIM_WINDOWS_BASEIMAGE_ZIP ]; then
       STATUSIM_WINDOWS_BASEIMAGE_ZIP=./StatusIm-Windows-base-image.zip
-      [ -f $STATUSIM_WINDOWS_BASEIMAGE_ZIP ] || wget https://desktop-app-files.ams3.digitaloceanspaces.com/StatusIm-Windows-base-image.zip
+      [ -f $STATUSIM_WINDOWS_BASEIMAGE_ZIP ] || wget https://desktop-app-files.ams3.digitaloceanspaces.com/StatusIm-Windows-base-image_20181113.zip -O StatusIm-Windows-base-image.zip
     fi
     unzip "$STATUSIM_WINDOWS_BASEIMAGE_ZIP" -d Windows/
 
@@ -271,11 +271,11 @@ function bundleLinux() {
   echo "Creating AppImage..."
 
   pushd $WORKFOLDER
-    rm -rf StatusImAppImage
+    rm -rf StatusImAppImage*
     # TODO this needs to be fixed: status-react/issues/5378
     if [ -z $STATUSIM_APPIMAGE ]; then
       STATUSIM_APPIMAGE=./StatusImAppImage.zip
-      [ -f $STATUSIM_APPIMAGE ] || wget https://desktop-app-files.ams3.digitaloceanspaces.com/StatusImAppImage.zip
+      [ -f $STATUSIM_APPIMAGE ] || wget https://desktop-app-files.ams3.digitaloceanspaces.com/StatusImAppImage_20181113.zip -O StatusImAppImage.zip
     fi
     unzip "$STATUSIM_APPIMAGE" -d .
     rm -rf AppDir
@@ -351,7 +351,7 @@ function bundleMacOS() {
   pushd $WORKFOLDER
     rm -rf Status.app
     # TODO this needs to be fixed: status-react/issues/5378
-    [ -f ./Status.app.zip ] || curl -L -o Status.app.zip https://desktop-app-files.ams3.digitaloceanspaces.com/Status.app.zip
+    [ -f ./Status.app.zip ] || curl -L -o Status.app.zip https://desktop-app-files.ams3.digitaloceanspaces.com/Status_20181113.app.zip
     echo -e "${GREEN}Downloading done.${NC}"
     echo ""
     unzip ./Status.app.zip

--- a/src/status_im/android/core.cljs
+++ b/src/status_im/android/core.cljs
@@ -17,7 +17,7 @@
 (defn app-state-change-handler [state]
   (dispatch [:app-state-change state]))
 
-(defn app-root []
+(defn app-root [props]
   (let [keyboard-height (subscribe [:get :keyboard-height])]
     (reagent/create-class
      {:component-will-mount
@@ -39,7 +39,8 @@
         (.hide react/splash-screen)
         (.addEventListener react/app-state "change" app-state-change-handler))
       :component-did-mount
-      (fn []
+      (fn [this]
+        (dispatch [:set-initial-props (reagent/props this)])
          ;; TODO(oskarth): Background click_action handler
         (notifications/init))
       :component-will-unmount

--- a/src/status_im/desktop/core.cljs
+++ b/src/status_im/desktop/core.cljs
@@ -1,18 +1,23 @@
 (ns status-im.desktop.core
   (:require [reagent.core :as reagent]
+            [re-frame.core :as re-frame]
             status-im.utils.db
             status-im.ui.screens.db
             status-im.ui.screens.events
             status-im.ui.screens.subs
             status-im.data-store.core
+            [reagent.impl.component :as reagent.component]
             [status-im.ui.screens.desktop.views :as views]
             [status-im.core :as core]
             [status-im.desktop.deep-links :as deep-links]))
 
-(defn app-root []
+(defn app-root [props]
   (reagent/create-class
-   {:component-did-mount deep-links/add-event-listener
-    :reagent-render      views/main}))
+   {:component-did-mount (fn [this]
+                           (re-frame/dispatch [:set-initial-props (reagent/props this)])
+                           (deep-links/add-event-listener))
+    :reagent-render      (fn [props]
+                           views/main)}))
 
 (defn init []
   (core/init app-root))

--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -1170,6 +1170,11 @@
    (pairing/send-installation-messages cofx)))
 
 (handlers/register-handler-fx
+ :set-initial-props
+ (fn [cofx [_ initial-props]]
+   {:db (assoc (:db cofx) :initial-props initial-props)}))
+
+(handlers/register-handler-fx
  :pairing.ui/enable-installation-pressed
  (fn [cofx [_ installation-id]]
    (pairing/enable-fx cofx installation-id)))

--- a/src/status_im/init/core.cljs
+++ b/src/status_im/init/core.cljs
@@ -78,11 +78,13 @@
 (fx/defn initialize-app-db
   "Initialize db to initial state"
   [{{:keys [status-module-initialized? view-id hardwallet
+            initial-props
             network-status network peers-count peers-summary device-UUID]
      :node/keys [status]
      :or   {network (get app-db :network)}} :db}]
   {:db (assoc app-db
               :contacts/contacts {}
+              :initial-props initial-props
               :network-status network-status
               :peers-count (or peers-count 0)
               :peers-summary (or peers-summary [])

--- a/src/status_im/ios/core.cljs
+++ b/src/status_im/ios/core.cljs
@@ -15,7 +15,7 @@
 (defn app-state-change-handler [state]
   (dispatch [:app-state-change state]))
 
-(defn app-root []
+(defn app-root [props]
   (let [keyboard-height (subscribe [:get :keyboard-height])]
     (reagent/create-class
      {:component-will-mount
@@ -34,7 +34,8 @@
         (.hide react/splash-screen)
         (.addEventListener react/app-state "change" app-state-change-handler))
       :component-did-mount
-      (fn []
+      (fn [this]
+        (dispatch [:set-initial-props (reagent/props this)])
         (notifications/init))
       :component-will-unmount
       (fn []

--- a/src/status_im/node/core.cljs
+++ b/src/status_im/node/core.cljs
@@ -54,12 +54,16 @@
   (get-in db [:accounts/accounts address :network]))
 
 (defn- get-base-node-config [config]
-  (cond-> (assoc config
-                 :Name "StatusIM"
-                 :BackupDisabledDataDir (utils.platform/no-backup-directory))
-    config/dev-build?
-    (assoc :ListenAddr ":30304"
-           :DataDir (str (:DataDir config) "_dev"))))
+  (let [initial-props @(re-frame/subscribe [:initial-props])
+        status-node-port (get initial-props :STATUS_NODE_PORT)]
+    (cond-> (assoc config
+                   :Name "StatusIM"
+                   :BackupDisabledDataDir (utils.platform/no-backup-directory))
+      config/dev-build?
+      (assoc :ListenAddr ":30304"
+             :DataDir (str (:DataDir config) "_dev"))
+      status-node-port
+      (assoc :ListenAddr (str ":" status-node-port)))))
 
 (defn- pick-nodes
   "Picks `limit` different nodes randomly from the list of nodes

--- a/src/status_im/ui/screens/db.cljs
+++ b/src/status_im/ui/screens/db.cljs
@@ -57,6 +57,7 @@
              :chat/last-outgoing-message-sent-at 0
              :chat/spam-messages-frequency       0
              :tooltips                           {}
+             :initial-props                      {}
              :desktop/desktop                    {:tab-view-id :home}
              :dimensions/window                  (dimensions/window)
              :push-notifications/stored          {}
@@ -148,6 +149,7 @@
 
 (spec/def :desktop/desktop (spec/nilable any?))
 (spec/def ::tooltips (spec/nilable any?))
+(spec/def ::initial-props (spec/nilable any?))
 
 ;;;;NETWORK
 
@@ -254,6 +256,7 @@
                                    ::was-modal?
                                    ::rpc-url
                                    ::tooltips
+                                   ::initial-props
                                    ::web3
                                    ::web3-node-version
                                    ::webview-bridge

--- a/src/status_im/ui/screens/subs.cljs
+++ b/src/status_im/ui/screens/subs.cljs
@@ -91,3 +91,7 @@
 (reg-sub :dimensions/window-width
          :<- [:dimensions/window]
          :width)
+
+(reg-sub :initial-props
+         (fn [db _]
+           (get db :initial-props)))

--- a/ubuntu-server.js
+++ b/ubuntu-server.js
@@ -119,9 +119,9 @@ if (process.argv.indexOf('--pipe') != -1) {
   rnUbuntuServer(process.stdin, process.stdout);
 } else {
   var port = process.env['REACT_SERVER_PORT'] || 5000;
-  process.argv.forEach((val) => {
-    if (val.indexOf('--port') != -1) {
-      port = val.substring(7);
+  process.argv.forEach((val, index) => {
+    if (val == '--port') {
+      port = process.argv[++index];
     }
   });
 


### PR DESCRIPTION
Fixes #6213 

Depends on https://github.com/status-im/react-native-desktop/pull/387

Following changes are introduced:

1. Value of `REACT_SERVER_PORT` env variable is passed via `--port` param to the `ubuntu-server` subprocess that is launched inside a bundle.
2. Values of `STATUS_NODE_PORT`, `STATUS_DATA_DIR` env variables are passed to RN root component via initialProps (
https://facebook.github.io/react-native/docs/communication-ios#passing-properties-from-native-to-react-native) and afterwards used for base node configuration.
3. In order to make item 2 work in dev environment, figwheel bridge had to be modified so that to use React Component as a `root_el`, instead of React Element. This is necessary to pass initialProps to `app-root`, as figwheel wraps `app-root` in its own `reloader`.

**QA notes:**
Set `REACT_SERVER_PORT`, `STATUS_NODE_PORT`, `STATUS_DATA_DIR` env variable values prior to running each instance of Status.app from terminal, e.g.:
```
export REACT_SERVER_PORT=5001
export STATUS_NODE_PORT=10001
export STATUS_DATA_DIR=~/status-data/instance1 # Note the absolute path here
open Status.app
```