### PR TITLE
[TESTS] Dockerize appium and track battery and network consumption on real devices 

### DIFF
--- a/test/appium/docker/Dockerfile
+++ b/test/appium/docker/Dockerfile
@@ -1,0 +1,110 @@
+FROM ubuntu:16.04
+
+LABEL maintainer "Lukasz Fryc <lukasz@status.im>"
+
+WORKDIR /root
+
+#==================
+# General Packages
+#------------------
+# openjdk-8-jdk
+#   Java
+# ca-certificates
+#   SSL client
+# tzdata
+#   Timezone
+# zip
+#   Make a zip file
+# unzip
+#   Unzip zip file
+# curl
+#   Transfer data from or to a server
+# wget
+#   Network downloader
+# libqt5webkit5
+#   Web content engine (Fix issue in Android)
+# libgconf-2-4
+#   Required package for chrome and chromedriver to run on Linux
+# xvfb
+#   X virtual framebuffer
+#==================
+RUN apt-get -qqy update && \
+    apt-get -qqy --no-install-recommends install \
+    openjdk-8-jdk \
+    ca-certificates \
+    tzdata \
+    zip \
+    unzip \
+    curl \
+    wget \
+    libqt5webkit5 \
+    libgconf-2-4 \
+    xvfb \
+    build-essential \
+  && rm -rf /var/lib/apt/lists/*
+
+#===============
+# Set JAVA_HOME
+#===============
+ENV JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64/jre" \
+    PATH=$PATH:$JAVA_HOME/bin
+
+#=====================
+# Install Android SDK
+#=====================
+ARG SDK_VERSION=sdk-tools-linux-4333796
+ARG ANDROID_BUILD_TOOLS_VERSION=28.0.1
+ARG ANDROID_PLATFORM_VERSION="android-27"
+
+ENV SDK_VERSION=$SDK_VERSION \
+    ANDROID_BUILD_TOOLS_VERSION=$ANDROID_BUILD_TOOLS_VERSION \
+    ANDROID_HOME=/root
+
+RUN wget -O tools.zip https://dl.google.com/android/repository/${SDK_VERSION}.zip && \
+    unzip tools.zip && rm tools.zip && \
+    chmod a+x -R $ANDROID_HOME && \
+    chown -R root:root $ANDROID_HOME
+
+ENV PATH=$PATH:$ANDROID_HOME/tools:$ANDROID_HOME/tools/bin
+
+# https://askubuntu.com/questions/885658/android-sdk-repositories-cfg-could-not-be-loaded
+RUN mkdir -p ~/.android && \
+    touch ~/.android/repositories.cfg && \
+    echo y | sdkmanager "platform-tools" && \
+    echo y | sdkmanager "build-tools;$ANDROID_BUILD_TOOLS_VERSION" && \
+    echo y | sdkmanager "platforms;$ANDROID_PLATFORM_VERSION"
+
+ENV PATH=$PATH:$ANDROID_HOME/platform-tools:$ANDROID_HOME/build-tools
+
+#====================================
+# Install latest nodejs, npm, appiuma
+#====================================
+# ARG APPIUM_VERSION=1.7.2
+# ENV APPIUM_VERSION=$APPIUM_VERSION
+
+RUN curl -sL https://deb.nodesource.com/setup_9.x | bash -
+RUN apt-get -qqy install nodejs
+RUN npm set maxsockets 3 && \
+    npm install -g appium@1.7.2 --unsafe-perm=true --allow-root
+RUN apt-get remove --purge -y npm && \
+    apt-get autoremove --purge -y && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+    apt-get clean
+
+#==================================
+# Fix Issue with timezone mismatch
+#==================================
+# ENV TZ="US/Pacific"
+# RUN echo "${TZ}" > /etc/timezone
+
+#===============
+# Expose Ports
+#---------------
+# 4723
+#   Appium port
+#===============
+EXPOSE 4723
+
+COPY entry_point.sh /root/
+RUN chmod +x /root/entry_point.sh
+ENTRYPOINT /root/entry_point.sh

--- a/test/appium/docker/HOWTO.md
+++ b/test/appium/docker/HOWTO.md
@@ -1,0 +1,66 @@
+## Instructions
+
+Use device with Android 7.1 or newer.
+
+1. Install needed tools
+
+    - Install Docker https://docs.docker.com/install/
+    - Install Python 3
+
+    Go to https://realpython.com/installing-python and follow the instructions. For macOS with Homebrew, you can run `brew install python3` to install it. 
+
+2. Build Appium docker image
+
+    - Make sure Docker app is running
+    - Build Appium image to have environment in which tests will be executed
+
+    ```
+    $ cd appium/docker
+    $ docker build -t "appium/appium:local" .
+    ```
+
+    Make sure all build steps were successful. You should see:
+    ```
+    Successfully tagged appium/appium:local
+    ```
+
+3. Find out IP address of the device
+
+    On device, open wifi settings and click on the current network. Write down the IP address as it will be needed for running the battery test wirelessly.
+
+4. Run the battery test
+
+    - Make sure the device is sufficiently charged
+    - Disconnect the device USB cable
+    - Create a directory that will be shared with the docker container. E.g. `mkdir /Users/lukas/Desktop/shared`
+    - Put .apk to test into the shared directory. E.g. `mv StatusIm-181109-092655-009d97-e2e.apk /Users/lukas/Desktop/shared`  
+    - Run a test with using appium container
+        - `--device_ip` - IP address of the device (see 3.)
+        - `--apk=StatusIm-181109-092655-009d97-e2e.apk` - name of the apk file
+        - `--docker=True` - run the tests using appium docker container
+        - `--docker_shared_volume=/Users/lukas/Desktop/shared` - path to the shared directory
+        - `--bugreport=True` - generate bugreport file
+        
+        ```
+        $ cd status-react/test/appium
+        $ python3 -m pytest --apk=StatusIm-181109-092655-009d97-e2e.apk --device_ip=192.168.0.104 --bugreport=True --docker=true --docker_shared_volume=/Users/lukas/Desktop/shared tests/atomic/transactions/test_wallet.py::TestTransactionWalletSingleDevice::test_send_eth_from_wallet_to_contact
+        ```
+    - Follow the instructions shown in the command line
+
+    **In case of issues:**
+    
+    Find out the Appium container id: `docker ps` and get the latest logs: `docker logs ebdf1761f51f` where `ebdf1761f51f` is the container id.
+    
+5. Analyse test results
+
+    The test generates Android bugreport that is saved in shared directory. It contains data about battery, cpu, memory, network usage, and more. See [energy-efficient-bok](https://github.com/status-im/energy-efficient-bok/blob/master/QA_Android.md) or [Battery Historian](https://developer.android.com/studio/profile/battery-historian) to learn how to analyse it.
+
+
+## Issues with adb connect
+
+To run the battery test without charging the device, adb needs to connect to it wirelessly. To avoid wifi connection issues, you can connect to the device via bluetooth.
+
+macOS instructions:
+- On device, enable bluetooth on your device in Android settings -> connections -> bluetooth
+- On device, go to mobile hotspots and tethering and enable bluetooth tethering
+- On macOS, go to the bluetooth settings and connect with the device (click "Connect to Network")

--- a/test/appium/docker/entry_point.sh
+++ b/test/appium/docker/entry_point.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+APPIUM_LOG="/var/log/appium.log"
+CMD="appium --log $APPIUM_LOG"
+
+$CMD

--- a/test/appium/requirements.txt
+++ b/test/appium/requirements.txt
@@ -47,3 +47,5 @@ toolz==0.9.0
 urllib3==1.22
 yarl==0.12.0
 zbarlight==1.2
+docker
+influxdb

--- a/test/appium/support/appium_container.py
+++ b/test/appium/support/appium_container.py
@@ -1,0 +1,111 @@
+import datetime
+import logging
+import re
+import subprocess
+import time
+
+import docker
+from docker.errors import NotFound
+
+
+DOCKER_SHARED_VOLUME_PATH = '/root/shared_volume'
+
+
+class DeviceStats(object):
+
+    def __init__(self):
+        self.total_battery_capacity_mah = None
+        # Est power used (mAh) by the app
+        self.estimated_power_usage_mah = None
+
+
+class AppiumContainer:
+
+    def start_appium_container(self, shared_volume):
+        docker_client = docker.from_env()
+        try:
+            self.container = docker_client.containers.get("appium")
+            self.container.restart()
+        except NotFound:
+            self.container = docker_client.containers.run("appium/appium:local", detach=True, name="appium",
+                                                          ports={'4723/tcp': 4723},
+                                                          volumes={shared_volume: {
+                                                              'bind': DOCKER_SHARED_VOLUME_PATH, 'mode': 'rw'}})
+        logging.info("Running Appium container. ID: %s" % self.container.short_id)
+
+    def exec_run(self, cmd):
+        return self.container.exec_run(cmd, stdout=True, stderr=True, stdin=True)
+
+    def connect_device(self, device_ip):
+        device_address = device_ip + ':5555'
+        connected_state = "connected to %s" % device_address
+
+        cmd = self.exec_run(['adb', 'connect', device_address])
+        if connected_state in cmd.output.decode("utf-8"):
+            logging.info("adb is already connected with the device")
+        else:
+            logging.info("Connecting the device with adb..")
+            # Restart adb on host machine
+            subprocess.call(['adb', 'kill-server'])
+            input("Connect USB cable to the device and press ENTER..")
+            # Reset USB on host machine
+            subprocess.call(['adb', 'usb'])
+            time.sleep(5)  # wait until adb usb is restarted
+            # Set the target device to listen for a TCP/IP connection on port 5555 on host machine
+            subprocess.call(['adb', 'tcpip', '5555'])
+            # restarting in TCP mode port: 5555
+            input("Now, disconnect the USB cable and press ENTER..")
+            # Connect to the device in docker container
+            self.exec_run(['adb', 'connect', device_address])
+            input("Please check your device and allow for USB debugging if necessary. Then press ENTER to continue "
+                  "the test..\n")
+
+    def reset_battery_stats(self):
+        logging.info("Resetting device stats..")
+        self.exec_run(['adb', 'shell', 'dumpsys', 'batterystats', '--reset'])
+
+    def generate_bugreport(self, report_name):
+        now = datetime.datetime.now()
+        bugreport_name = "bugreport_%s_%s" % (report_name, now.strftime("%Y-%m-%d_%H-%M-%S"))
+
+        print("\nGenerating device report from the test..")
+        self.exec_run(['adb', 'bugreport', "/%s/%s" % (DOCKER_SHARED_VOLUME_PATH, bugreport_name)])
+        print("Device report saved in the shared volume as %s.zip" % bugreport_name)
+
+    def get_device_stats(self):
+        stats = DeviceStats()
+
+        # Find process uid
+        uid_line = self.exec_run(['adb', 'shell', 'ps', '|', 'grep', 'im.status.ethereum']).output \
+            .decode('utf-8')
+        # Match first word which is the uid
+        match = re.match(r'(?:^|(?:[.!?]\s))(\w+)', uid_line, re.M | re.I)
+        uid = match.group(1).replace('_', '')
+
+        # Battery stats
+        batterystats = self.exec_run(['adb', 'shell', 'dumpsys', 'batterystats', 'im.status.ethereum']).output \
+            .decode('utf-8').splitlines()
+        battery_usage_line = [s for s in batterystats if "Uid %s" % uid in s][0]
+        match = re.match(r'.* Uid %s: ([^\s]+)' % uid, battery_usage_line, re.M | re.I)
+        stats.estimated_power_usage_mah = float(match.group(1))
+        capacity_line = [s for s in batterystats if "Capacity" in s][0]
+        match = re.match(r'.* Capacity: (.*), Computed drain: (.*), .*', capacity_line, re.M | re.I)
+        stats.total_battery_capacity_mah = float(match.group(1))
+        stats.total_computed_drain_mah = float(match.group(2))
+
+        # Wi-Fi stats
+        wifi_stats = self.exec_run(['adb', 'shell', 'dumpsys', 'batterystats', 'im.status.ethereum', '|', 'grep',
+                                'Wi-Fi\ total']).output.decode('utf-8')
+        stats.wifi_received = wifi_stats.split()[3].replace(',', '')
+        stats.wifi_sent = wifi_stats.split()[5]
+
+        # OS stats
+        stats.os_version = self.exec_run(['adb', 'shell', 'getprop', 'ro.build.version.release'])\
+            .output.decode('utf-8').rstrip("\n")
+        stats.device_model = self.exec_run(['adb', 'shell', 'getprop', 'ro.product.model'])\
+            .output.decode('utf-8').rstrip("\n")
+
+        return stats
+
+    def stop_container(self):
+        self.container.stop()

--- a/test/appium/support/device_stats_db.py
+++ b/test/appium/support/device_stats_db.py
@@ -1,0 +1,39 @@
+import datetime
+
+from influxdb import InfluxDBClient
+
+
+def convert_to_mb(value):
+    number = float(value[:-2])
+    unit = value[-2:]
+    if unit == 'KB':
+        number = number / 1000
+    return number
+
+
+class DeviceStatsDB:
+
+    def __init__(self, host, port, username, password, database):
+        self.client = InfluxDBClient(host, port, username, password, database)
+
+    def save_stats(self, build_name, test_name, test_group, test_passed, device_stats):
+        json_body = [
+            {
+                "measurement": "device",
+                "time": datetime.datetime.utcnow().isoformat(),
+                "fields": {
+                    "battery_used_mah": device_stats.estimated_power_usage_mah,
+                    "wifi_sent": convert_to_mb(device_stats.wifi_sent),
+                    "wifi_received": convert_to_mb(device_stats.wifi_received),
+                },
+                "tags": {
+                    "test_name": test_name,
+                    "test_group": test_group,
+                    "build_name": build_name,
+                    "device_model": device_stats.device_model,
+                    "device_os_version": device_stats.os_version,
+                    "test_passed": test_passed
+                }
+            }
+        ]
+        self.client.write_points(json_body)

--- a/test/appium/tests/__init__.py
+++ b/test/appium/tests/__init__.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 from datetime import datetime
 
+from support.appium_container import AppiumContainer
 from support.test_data import TestSuiteData
 
 
@@ -24,6 +25,7 @@ def debug(text: str):
 
 
 test_suite_data = TestSuiteData()
+appium_container = AppiumContainer()
 
 common_password = 'qwerty'
 unique_password = 'unique' + get_current_time()

--- a/test/appium/tests/atomic/account_management/test_create_account.py
+++ b/test/appium/tests/atomic/account_management/test_create_account.py
@@ -10,6 +10,7 @@ class TestCreateAccount(SingleDeviceTestCase):
 
     @marks.testrail_id(5300)
     @marks.critical
+    @marks.battery_consumption
     def test_create_account(self):
         sign_in = SignInView(self.driver, skip_popups=False)
         sign_in.accept_agreements()

--- a/test/appium/tests/atomic/account_management/test_profile.py
+++ b/test/appium/tests/atomic/account_management/test_profile.py
@@ -201,6 +201,7 @@ class TestProfileSingleDevice(SingleDeviceTestCase):
 
     @marks.testrail_id(5382)
     @marks.high
+    @marks.battery_consumption
     def test_contact_profile_view(self):
         sign_in_view = SignInView(self.driver)
         sign_in_view.create_user()

--- a/test/appium/tests/atomic/account_management/test_recover.py
+++ b/test/appium/tests/atomic/account_management/test_recover.py
@@ -13,6 +13,7 @@ class TestRecoverAccountSingleDevice(SingleDeviceTestCase):
 
     @marks.testrail_id(5301)
     @marks.critical
+    @marks.battery_consumption
     def test_recover_account(self):
         sign_in = SignInView(self.driver)
         home = sign_in.create_user()

--- a/test/appium/tests/atomic/chats/test_one_to_one.py
+++ b/test/appium/tests/atomic/chats/test_one_to_one.py
@@ -474,6 +474,7 @@ class TestMessagesOneToOneChatSingle(SingleDeviceTestCase):
 
     @marks.testrail_id(5328)
     @marks.critical
+    @marks.battery_consumption
     def test_send_emoji(self):
         sign_in = SignInView(self.driver)
         home = sign_in.create_user()

--- a/test/appium/tests/marks.py
+++ b/test/appium/tests/marks.py
@@ -21,3 +21,5 @@ wallet_modal = pytest.mark.wallet_modal
 sign_in = pytest.mark.sign_in
 skip = pytest.mark.skip
 logcat = pytest.mark.logcat
+
+battery_consumption = pytest.mark.battery_consumption


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)

### Problem

Currently, we measure Status battery consumption manually. It takes a lot of time and is prone to errors. We need to have a way to reliably measure battery and data consumption as often as we want. Ideally for each PR or at least nightly build.     

### Solution

There are couple of possible solutions. One is to use external provider like BitBar to provide us with real devices and device metrics. It seems like a good approach but usually those providers do not have stats we are interested in (battery, network usage) or are unreliable. They are also really expensive to use. Another solution is to use our own test devices and have a small device farm. In this PR, I will focus on the latter.

#### An easy way to run our appium tests locally

Setting up appium to run E2E test takes time. That's why I put appium and adb in a docker image. Now, it only takes a one step to run a test. 

To run a test with appium as docker conainer add following parameters to `pytest`:
```
--docker=true --docker_shared_volume=/Users/lukas/Desktop/shared --device_ip=192.168.0.104
```

Dockerizing our E2E environment also allows us to better maintain all dependencies.

#### Tracking battery and network consumption for existing E2E tests 

To measure battery, the device can't be connected via USB cable. Otherwise, the device is charged when battery consumption is being tracked. It spoils the results. To solve that, adb needs to connect to the device wirelessly.

Now, when tests are run with `--docker=true --device_ip=192.168.0.104 --docker_shared_volume=/Users/lukas/Desktop/shared` the adb connects to the device wirelessly and tracks battery and network consumption for every test. Adding `--bugreport=True` will generate Android bugreport after each test and save it in `docker_shared_volume`. The bugreport contains all possible stats about the device for later analysis. Learn how to analyse it [here](https://github.com/status-im/energy-efficient-bok/blob/master/QA_Android.md). 

Note: each existing test can be run this way.

#### Analysing the results

Analysing bugreport using [Battery Historian](https://developer.android.com/studio/profile/battery-historian#BatteryHistorianCharts) is time consuming. Also, we do not really need all the stats the bugreport contains. What we care about is battery and network consumption. At least for now. 

What's more important, we need a lot of measurements / tests to come up with a correct (average) battery consumption. I decided to use InfluxDB time series db to store the measurements and Grafana to visualise them. 

**Battery usage per test**
 
It shows how much battery was used (mAh) for each test running on a build. On screenshot below, you can see how battery usage for `test_resover_account` has changed since `9a088f` (blue line) to `44aef6` (purple).

<img width="1346" alt="screenshot 2018-11-12 at 12 07 16" src="https://user-images.githubusercontent.com/7532782/48346698-44d5de00-e67c-11e8-90cb-93a53ff0ad50.png">

**Average battery usage per build**

This graph shows how much battery was used on average when running a set of tests. Currently, the set of tests for nightly builds consists of 4 tests. This set can be extended to include other tests that we think can be helpful in measuring Status battery/wifi consumption. The tests are marked as `@marks.device_nightly`.
 
<img width="1345" alt="screenshot 2018-11-12 at 12 06 33" src="https://user-images.githubusercontent.com/7532782/48346752-6636ca00-e67c-11e8-9860-e544278d7e2a.png">

Note: each test is executed couple of times (at least 2) to calculate average battery consumption. Then the averages are summed up to provide total battery consumption for set of tests.

**Details of measurements**

There are also tables with details all measurements done so far as well as averages.

<img width="1329" alt="screenshot 2018-11-12 at 12 06 53" src="https://user-images.githubusercontent.com/7532782/48346694-3edffd00-e67c-11e8-87a4-0ca10fb35a33.png">

<img width="1338" alt="screenshot 2018-11-12 at 12 06 45" src="https://user-images.githubusercontent.com/7532782/48346764-6df66e80-e67c-11e8-9dc9-6316462200ca.png">

#### How you can run it locally?

https://github.com/status-im/status-react/blob/4a49e46a00cb1f731867fd89eb19f55714eeac83/test/appium/docker/HOWTO.md

----

### Next things

1. I will continue measuring battery and network consumption for each nightly. If I notice any increase/decrease, I will let you know.

2. I will ask @jakubgs to deploy my Influx database and Grafana so everyone could access it and see the results. When it's done, everyone will be able to run the test locally and publish the results from her/his Android device.
 
3. Grafana dashboards for network consumption and other device stats.

4. Setting up small device farm to run more measurements.