### PR TITLE
bump ios timeout to 35 min because prep stage can take long

### DIFF
--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -3,7 +3,7 @@ pipeline {
 
   options {
     /* Prevent Jenkins jobs from running forever */
-    timeout(time: 25, unit: 'MINUTES')
+    timeout(time: 35, unit: 'MINUTES')
     /* Limit builds retained */
     buildDiscarder(logRotator(
       numToKeepStr: '60',


### PR DESCRIPTION
This is a temporary fix. I'm thinking of how to reduce the time prep sometimes takes.