### PR TITLE
add timestamps to all commands

### DIFF
--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -2,6 +2,7 @@ pipeline {
   agent { label 'linux' }
 
   options {
+    timestamps()
     /* Prevent Jenkins jobs from running forever */
     timeout(time: 25, unit: 'MINUTES')
     /* Limit builds retained */

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -2,6 +2,7 @@ pipeline {
   agent { label 'fastlane' }
 
   options {
+    timestamps()
     /* Prevent Jenkins jobs from running forever */
     timeout(time: 35, unit: 'MINUTES')
     /* Limit builds retained */

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -15,6 +15,7 @@ pipeline {
   }
 
   options {
+    timestamps()
     /* Prevent Jenkins jobs from running forever */
     timeout(time: 25, unit: 'MINUTES')
     /* Limit builds retained */

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -2,6 +2,7 @@ pipeline {
   agent { label 'macos' }
 
   options {
+    timestamps()
     /* Prevent Jenkins jobs from running forever */
     timeout(time: 25, unit: 'MINUTES')
     /* Limit builds retained */


### PR DESCRIPTION
This will help us identify which steps take too long in builds.