### PR TITLE
call the correct job for updating nightlies page

### DIFF
--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -104,22 +104,16 @@ pipeline {
       steps { script {
         switch (btype) {
           case 'nightly':
-            build(
-              job: 'misc/status-im.github.io-update_env',
-              parameters: [
-                [name: 'APK_URL', value: apkUrl, $class: 'StringParameterValue'],
-                [name: 'IOS_URL', value: ipaUrl, $class: 'StringParameterValue'],
-                [name: 'DMG_URL', value: dmgUrl, $class: 'StringParameterValue'],
-                [name: 'NIX_URL', value: appUrl, $class: 'StringParameterValue'],
-              ]
-            ); break
+            build('misc/status.im')
+            break
           case 'release':
             build(
               job: 'misc/cn.status.im',
               parameters: [
                 [name: 'APK_URL', value: apkUrl, $class: 'StringParameterValue'],
               ]
-            ); break
+            )
+            break
         }
       } }
     }


### PR DESCRIPTION
Fixes which job is run to update the nightlies links.

The `misc/status-im.github.io-update_env` job is now obsolete.