### PR TITLE
use a table to post links to build artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,11 +51,11 @@ _prepare-mobile: ##@prepare Install mobile platform dependencies and prepare wor
 	npm install
 
 $(STATUS_GO_IOS_ARCH):
-	cd $(RCTSTATUS_DIR) && curl -OL "$(GITHUB_URL)/$(STATUS_GO_VER)/status-go-ios.zip"
+	cd $(RCTSTATUS_DIR) && curl -s -OL "$(GITHUB_URL)/$(STATUS_GO_VER)/status-go-ios.zip"
 
 $(STATUS_GO_DRO_ARCH):
 	mkdir -p $(ANDROID_LIBS_DIR)
-	cd $(ANDROID_LIBS_DIR) && curl -o status-go-$(STATUS_GO_VER).aar -OL "$(GITHUB_URL)/$(STATUS_GO_VER)/status-go-android.aar"
+	cd $(ANDROID_LIBS_DIR) && curl -s -o status-go-$(STATUS_GO_VER).aar -OL "$(GITHUB_URL)/$(STATUS_GO_VER)/status-go-android.aar"
 
 prepare-ios: $(STATUS_GO_IOS_ARCH) _prepare-mobile ##@prepare Install and prepare iOS-specific dependencies
 	cd $(RCTSTATUS_DIR) && unzip -q -o status-go-ios.zip

--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -74,7 +74,6 @@ pipeline {
       steps { script {
         e2eUrl = cmn.uploadArtifact(cmn.pkgFind('e2e.apk'))
         apkUrl = cmn.uploadArtifact(cmn.pkgFind("${btype}.apk"))
-
         if (btype != 'release') {
           dmgUrl = cmn.uploadArtifact(cmn.pkgFind('dmg'))
           appUrl = cmn.uploadArtifact(cmn.pkgFind('AppImage'))
@@ -102,8 +101,7 @@ pipeline {
       steps { script {
         if (env.CHANGE_ID != null) {
           cmn.githubNotify(
-            apkUrl, e2eUrl, ipaUrl, dmgUrl, appUrl, zipUrl,
-            env.CHANGE_ID
+            apk: apkUrl, e2e: e2eUrl, ipa: ipaUrl, app: appUrl, dmg: dmgUrl, win: zipUrl,
           )
         }
       } }
@@ -129,10 +127,10 @@ pipeline {
       when { expression { btype == 'nightly' } }
       steps { script {
         e2eApk = e2e.getBuildVariables().get('SAUCE_URL')
-          build(
-            job: 'end-to-end-tests/status-app-nightly', wait: false,
-            parameters: [string(name: 'apk', value: "--apk=${e2eApk}")]
-          )
+        build(
+          job: 'end-to-end-tests/status-app-nightly', wait: false,
+          parameters: [string(name: 'apk', value: "--apk=${e2eApk}")]
+        )
       } }
     }
   }

--- a/ci/Jenkinsfile.fastlane.clean
+++ b/ci/Jenkinsfile.fastlane.clean
@@ -4,23 +4,31 @@ env.LC_ALL="en_US.UTF-8"
 env.FASTLANE_DISABLE_COLORS=1
 env.REALM_DISABLE_ANALYTICS=1
 
-timeout(90) {
-    node ('fastlane'){
-
-    stage('Git & Dependencies'){
-
-      checkout([$class: 'GitSCM', branches: [[name: 'develop']],
-      doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'CleanBeforeCheckout']],
-      submoduleCfg: [], userRemoteConfigs: [[url: 'https://github.com/status-im/status-react.git']]])
-
-      load "$HOME/env.groovy"
+timeout(120) {
+  node ('macos') {
+    stage('Git Checkout'){
+      checkout([
+        $class: 'GitSCM',
+        branches: [[name: 'develop']],
+        doGenerateSubmoduleConfigurations: false,
+        extensions: [[$class: 'CleanBeforeCheckout']],
+        submoduleCfg: [],
+        userRemoteConfigs: [[url: 'https://github.com/status-im/status-react.git']]
+      ])
     }
 
-    stage('Clean Testflight Users'){
+    stage('Install Deps'){
+      sh ('bundle install')
+    }
 
-      withCredentials([string(credentialsId: 'FASTLANE_PASSWORD', variable: 'FASTLANE_PASSWORD'),
-      string(credentialsId: 'APPLE_ID', variable: 'APPLE_ID')]) {
+    stage('Clean Users'){
+      withCredentials([
+        string(credentialsId: 'FASTLANE_PASSWORD', variable: 'FASTLANE_PASSWORD'),
+        string(credentialsId: 'APPLE_ID', variable: 'APPLE_ID')]
+      ) {
         sh ('bundle install')
-        sh ('bundle exec fastlane ios clean')}}
+        sh ('bundle exec fastlane ios clean')
+      }
     }
+  }
 }


### PR DESCRIPTION
Changes:
* The Jenkins build posts take up a lot of vertical space, made them a bit slimmer with a table.
* Cleans up ` ci/Jenkinsfile.fastlane.clean` and bumps it's timeout to 120 minutes.
* Adds `--silent` to `curl` calls in the `Makefile`.
* General formatting cleanup
