### PR TITLE
[slow sign in] fix slow sign in (first iteration)

### DIFF
--- a/src/status_im/accounts/login/core.cljs
+++ b/src/status_im/accounts/login/core.cljs
@@ -33,7 +33,7 @@
       (catch (fn [error]
                (log/warn "Could not change account" error)
                ;; If all else fails we fallback to showing initial error
-               (re-frame/dispatch [:init.callback/account-change-error])))))
+               (re-frame/dispatch [:init.callback/account-change-error (str error)])))))
 
 ;;;; Handlers
 (fx/defn login [cofx]

--- a/src/status_im/chat/models/loading.cljs
+++ b/src/status_im/chat/models/loading.cljs
@@ -52,35 +52,48 @@
               (filter #(not (contains? message-id->messages %))))
         (vals message-id->messages)))
 
+(fx/defn load-chats-messages
+  [{:keys [db get-stored-messages get-stored-user-statuses
+           get-referenced-messages get-stored-unviewed-messages]
+    :as cofx}]
+  (let [chats (:chats db)]
+    (fx/merge
+     cofx
+     {:db (assoc
+           db :chats
+           (reduce
+            (fn [chats chat-id]
+              (let [stored-unviewed-messages (get-stored-unviewed-messages (accounts.db/current-public-key cofx))
+                    chat-messages (index-messages (get-stored-messages chat-id))
+                    message-ids   (keys chat-messages)]
+                (update
+                 chats
+                 chat-id
+                 assoc
+
+                 :messages chat-messages
+                 :message-statuses (get-stored-user-statuses chat-id message-ids)
+                 :unviewed-messages (get stored-unviewed-messages chat-id)
+                 :referenced-messages (into {}
+                                            (map (juxt :message-id identity)
+                                                 (get-referenced-messages
+                                                  (get-referenced-ids chat-messages)))))))
+            chats
+            (keys chats)))}
+     (group-messages))))
+
 (fx/defn initialize-chats
   "Initialize all persisted chats on startup"
-  [{:keys [db default-dapps all-stored-chats get-stored-messages get-stored-user-statuses
-           get-stored-unviewed-messages get-referenced-messages stored-message-ids
-           stored-deduplication-ids] :as cofx}]
-  (let [stored-unviewed-messages (get-stored-unviewed-messages (accounts.db/current-public-key cofx))
-        chats (reduce (fn [acc {:keys [chat-id] :as chat}]
-                        (let [chat-messages (index-messages (get-stored-messages chat-id))
-                              message-ids   (keys chat-messages)
-                              unviewed-ids  (get stored-unviewed-messages chat-id)]
-                          (assoc acc chat-id
-                                 (assoc chat
-                                        :unviewed-messages unviewed-ids
-                                        :messages chat-messages
-                                        :message-statuses (get-stored-user-statuses chat-id message-ids)
-                                        :deduplication-ids (get stored-deduplication-ids chat-id)
-                                        :not-loaded-message-ids (set/difference (get stored-message-ids chat-id)
-                                                                                (set message-ids))
-                                        :referenced-messages (into {}
-                                                                   (map (juxt :message-id identity)
-                                                                        (get-referenced-messages
-                                                                         (get-referenced-ids chat-messages))))))))
+  [{:keys [db default-dapps all-stored-chats] :as cofx}]
+  (let [chats (reduce (fn [acc {:keys [chat-id] :as chat}]
+                        (assoc acc chat-id
+                               (assoc chat :not-loaded-message-ids #{})))
                       {}
                       all-stored-chats)]
     (fx/merge cofx
               {:db (assoc db
-                          :chats          chats
+                          :chats chats
                           :contacts/dapps default-dapps)}
-              (group-messages)
               (commands/load-commands commands/register))))
 
 (fx/defn initialize-pending-messages

--- a/src/status_im/chat/specs.cljs
+++ b/src/status_im/chat/specs.cljs
@@ -9,7 +9,7 @@
 (s/def :chat/animations (s/nilable map?))                         ; {id (string) props (map)}
 (s/def :chat/chat-ui-props (s/nilable map?))                      ; {id (string) props (map)}
 (s/def :chat/chat-list-ui-props (s/nilable map?))
-(s/def :chat/layout-height (s/nilable number?))                   ; height of chat's view layout 
+(s/def :chat/layout-height (s/nilable number?))                   ; height of chat's view layout
 (s/def :chat/selected-participants (s/nilable set?))
 (s/def :chat/public-group-topic (s/nilable string?))
 (s/def :chat/public-group-topic-error (s/nilable string?))
@@ -18,7 +18,6 @@
 (s/def :chat/message-statuses (s/nilable map?))                   ; message/user statuses indexed by two level index
 (s/def :chat/not-loaded-message-ids (s/nilable set?))             ; set of message-ids not yet fully loaded from persisted state
 (s/def :chat/referenced-messages (s/nilable map?))                ; map of messages indexed by message-id which are not displayed directly, but referenced by other messages
-(s/def :chat/deduplication-ids (s/nilable set?))                  ; set of helper deduplication ids
 (s/def :chat/last-clock-value (s/nilable number?))                ; last logical clock value of messages in chat
 (s/def :chat/loaded-chats (s/nilable seq?))
 (s/def :chat/bot-db (s/nilable map?))
@@ -26,3 +25,4 @@
 (s/def :chat/cooldown-enabled? (s/nilable boolean?))
 (s/def :chat/last-outgoing-message-sent-at (s/nilable number?))
 (s/def :chat/spam-messages-frequency (s/nilable number?))         ; number of consecutive spam messages sent
+(s/def :chats/loading? (s/nilable boolean?))

--- a/src/status_im/data_store/messages.cljs
+++ b/src/status_im/data_store/messages.cljs
@@ -39,46 +39,8 @@
  (fn [cofx _]
    (assoc cofx :get-stored-messages get-by-chat-id)))
 
-(re-frame/reg-cofx
- :data-store/message-ids
- (fn [cofx _]
-   (assoc cofx :stored-message-ids (let [chat-id->message-id (volatile! {})]
-                                     (-> @core/account-realm
-                                         (.objects "message")
-                                         (.map (fn [msg _ _]
-                                                 (vswap! chat-id->message-id
-                                                         #(update %
-                                                                  (aget msg "chat-id")
-                                                                  (fnil conj #{})
-                                                                  (aget msg "message-id"))))))
-                                     @chat-id->message-id))))
-
 (defn- sha3 [s]
   (.sha3 dependencies/Web3.prototype s))
-
-(defn deduplication-id
-  "Computes deduplication id from message sender-pk, chat-id and clock-value"
-  [sender-pk chat-id clock-value]
-  (sha3 (str sender-pk chat-id clock-value)))
-
-(re-frame/reg-cofx
- :data-store/deduplication-ids
- (fn [cofx _]
-   (assoc cofx :stored-deduplication-ids (let [chat-id->message-id (volatile! {})]
-                                           (-> @core/account-realm
-                                               (.objects "message")
-                                               (.map (fn [msg _ _]
-                                                       (let [chat-id     (aget msg "chat-id")
-                                                             sender-pk   (aget msg "from")
-                                                             clock-value (aget msg "clock-value")]
-                                                         (vswap! chat-id->message-id
-                                                                 #(update %
-                                                                          (aget msg "chat-id")
-                                                                          (fnil conj #{})
-                                                                          (deduplication-id sender-pk
-                                                                                            chat-id
-                                                                                            clock-value)))))))
-                                           @chat-id->message-id))))
 
 (defn- get-unviewed-messages
   [public-key]
@@ -136,3 +98,8 @@
   (fn [realm]
     (core/delete realm (core/get-by-field realm :message :chat-id chat-id))
     (core/delete realm (core/get-by-field realm :user-status :chat-id chat-id))))
+
+(defn message-exists? [message-id]
+  (if @core/account-realm
+    (not (nil? (.objectForPrimaryKey @core/account-realm "message" message-id)))
+    false))

--- a/src/status_im/data_store/realm/schemas/account/core.cljs
+++ b/src/status_im/data_store/realm/schemas/account/core.cljs
@@ -252,6 +252,19 @@
           browser/v8
           dapp-permissions/v9])
 
+(def v25 [chat/v8
+          transport/v7
+          contact/v3
+          message/v7
+          mailserver/v11
+          mailserver-topic/v1
+          user-status/v2
+          membership-update/v1
+          installation/v2
+          local-storage/v1
+          browser/v8
+          dapp-permissions/v9])
+
 ;; put schemas ordered by version
 (def schemas [{:schema        v1
                :schemaVersion 1
@@ -324,4 +337,7 @@
                :migration     migrations/v23}
               {:schema        v24
                :schemaVersion 24
-               :migration     migrations/v24}])
+               :migration     migrations/v24}
+              {:schema        v25
+               :schemaVersion 25
+               :migration     migrations/v25}])

--- a/src/status_im/group_chats/core.cljs
+++ b/src/status_im/group_chats/core.cljs
@@ -115,7 +115,11 @@
                                 :dsts          members
                                 :success-event [:transport/message-sent
                                                 chat-id
-                                                (transport.utils/message-id (:message payload))
+                                                (transport.utils/message-id
+                                                 ;; NOTE: There is no clock-value here.
+                                                 ;; Will we have collision?
+                                                 {:from current-public-key
+                                                  :chat-id chat-id})
                                                 :group-user-message]
                                 :payload       payload}}))))
 

--- a/src/status_im/init/core.cljs
+++ b/src/status_im/init/core.cljs
@@ -98,10 +98,10 @@
   {:db (assoc db :device-UUID device-uuid)})
 
 (fx/defn handle-change-account-error
-  [cofx]
+  [cofx error]
   {:ui/show-confirmation
    {:title               (i18n/label :invalid-key-title)
-    :content             (i18n/label :invalid-key-content)
+    :content             (str error "\n" (i18n/label :invalid-key-content))
     :confirm-button-text (i18n/label :invalid-key-confirm)
     ;; On cancel we initialize the app with the invalid key, to allow the user
     ;; to recover the seed phrase
@@ -209,13 +209,10 @@
                                              [:web3/fetch-node-version-callback %])]
              :notifications/get-fcm-token nil}
             (initialize-account-db address)
-            (protocol/initialize-protocol address)
             (contact/load-contacts)
             (pairing/load-installations)
             #(when (dev-mode? %)
                (models.dev-server/start))
-            (chat-loading/initialize-chats)
-            (chat-loading/initialize-pending-messages)
             (browser/initialize-browsers)
             (browser/initialize-dapp-permissions)
             (extensions.registry/initialize)

--- a/src/status_im/transport/message/protocol.cljs
+++ b/src/status_im/transport/message/protocol.cljs
@@ -87,7 +87,10 @@
                               :payload       this
                               :success-event [:transport/message-sent
                                               chat-id
-                                              (transport.utils/message-id this)
+                                              (transport.utils/message-id
+                                               {:from        current-public-key
+                                                :chat-id     chat-id
+                                                :clock-value clock-value})
                                               message-type]}]
       (case message-type
         :public-group-user-message
@@ -113,7 +116,10 @@
   (receive [this chat-id signature _ cofx]
     {:chat-received-message/add-fx
      [(assoc (into {} this)
-             :message-id (transport.utils/message-id this)
+             :message-id (transport.utils/message-id
+                          {:chat-id     chat-id
+                           :from        signature
+                           :clock-value clock-value})
              :chat-id chat-id
              :from signature
              :js-obj (:js-obj cofx))]})

--- a/src/status_im/transport/utils.cljs
+++ b/src/status_im/transport/utils.cljs
@@ -19,8 +19,10 @@
 
 (defn message-id
   "Get a message-id"
-  [message]
-  (sha3 (pr-str message)))
+  [{:keys [from chat-id clock-value] :as m}]
+  {:pre [(not (nil? from))
+         (not (nil? chat-id))]}
+  (sha3 (str from chat-id clock-value)))
 
 (defn get-topic
   "Get the topic of a group chat or public chat from the chat-id"

--- a/src/status_im/ui/screens/db.cljs
+++ b/src/status_im/ui/screens/db.cljs
@@ -65,7 +65,8 @@
                                                   :nfc-enabled?   false
                                                   :pin            {:original     []
                                                                    :confirmation []
-                                                                   :enter-step   :original}}})
+                                                                   :enter-step   :original}}
+             :chats/loading?                     true})
 
 ;;;;GLOBAL
 
@@ -247,7 +248,8 @@
                                 :wallet/all-tokens
                                 :ui/contact
                                 :ui/search
-                                :ui/chat]
+                                :ui/chat
+                                :chats/loading?]
                           :opt-un [::modal
                                    ::was-modal?
                                    ::rpc-url
@@ -294,7 +296,6 @@
                                    :chat/message-groups
                                    :chat/message-statuses
                                    :chat/not-loaded-message-ids
-                                   :chat/deduplication-ids
                                    :chat/referenced-messages
                                    :chat/last-clock-value
                                    :chat/loaded-chats

--- a/src/status_im/ui/screens/desktop/main/views.cljs
+++ b/src/status_im/ui/screens/desktop/main/views.cljs
@@ -17,7 +17,7 @@
   (views/letsubs [tab [:get-in [:desktop/desktop :tab-view-id]]]
     (let [component (case tab
                       :profile profile.views/profile-data
-                      :home home.views/chat-list-view
+                      :home home.views/chat-list-view-wrapper
                       react/view)]
       [react/view {:style {:flex 1}}
        [component]])))

--- a/src/status_im/ui/screens/main_tabs/views.cljs
+++ b/src/status_im/ui/screens/main_tabs/views.cljs
@@ -76,7 +76,7 @@
        (contains? #{:home :wallet :my-profile} new-view-id))}
     [react/view common.styles/main-container
      (case view-id
-       :home [home/home]
+       :home [home/home-wrapper]
        :wallet [wallet.main/wallet]
        :my-profile [profile.user/my-profile]
        nil)


### PR DESCRIPTION
### Summary:

[comment]: # (Summarise the problem and how the pull request solves it)
Signing in is slow for account with tons of messages. This is caused by many reasons ([see this note](https://notes.status.im/VxmgW_rJQkqHsPoqGiMGxQ)), this PR fixes some of them:
> - Remove necessity in the usage of `deduplication-ids` set (part of **A**). In order to tackle deduplication problem proper `message-id` (which will be calculated the same way regardless by which version of the app it has been received) can be calculated ([this function was suggested](https://github.com/status-im/status-react/blob/26ec3f8cd7906a0a80cd75a937e8c8028a358fa9/src/status_im/data_store/messages.cljs#L59)) and updated in all existing messages via db migration. This is done in https://github.com/status-im/status-react/pull/6722
> - Remove necessity in the loading of all `message-ids` (another part of **A**). We can check if the message has been already received by making a direct query to db. While query which is done using [`.objects()`](https://realm.io/docs/javascript/latest/api/Realm.html#objects) with `message-id=...` condition is quite slow, [`objectForPrimaryKey`](https://realm.io/docs/javascript/latest/api/Realm.html#objectForPrimaryKey) works acceptably faster (~50ms fro 1000 queries). Implemented in https://github.com/status-im/status-react/pull/6722. Other suggestions on this are welcome.
> - Load part of data necessary for `:home` screen asynchronously. In this case we can go to **7** without doing **8**. That's the only way to guaranty that `sign in` will have some likely constant regardless of db size. Done in https://github.com/status-im/status-react/pull/6722 (probably touches **E** as no need to calculate it before rendering screen)

### Review notes (optional):
<!-- (Specify if something in particular should be looked at, or ignored, during review) -->
- `message-id` is calculated as `sha3(from + chat-id + clock-value)` for each message
- [`objectForPrimaryKey`](https://realm.io/docs/javascript/latest/api/Realm.html#objectForPrimaryKey) is used to check if `message-id` already exists in DB
- `:init-chats` event is dispatched 100ms after `:home`'s `componentDidMount` on mobile. The reason for this is that otherwise on Android event will handled before `:home` is actually rendered and it will be shown only after `:init-chats`. 
- migration resets `messages-id` in `message` (`:messages-id`, `:reference-id` in `:content`), `messages-status` (`:status-id`, `:messages-id`) entities, let me now if any other reference was missed
- during transition period we will lost all refernces to messages which are done on older clients (as there is no way to calculate new `message-id` from the old one directly, without the message)

### Testing notes (optional):
<!-- (Specify which platforms should be tested) -->
#### Platforms (optional)
- All platforms

<!-- (Specify if some specific areas has to be tested, for example 1-1 chats) -->
#### Areas that maybe impacted (optional)
**Functional**
- signing in 
- 1-1 chats
- public chats
- group chats

<!-- (Specify exact steps to test if there are such) -->
### Steps to test:
- Open Status
- create a n account
- join several pub chats
- send ~10000 messages in these pubchats (also it is slower if all these messages are unread)
- logout
- sign in back and check how fast it happens

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->