### PR TITLE
Add missing configuration for Windows desktop notifications

### DIFF
--- a/modules/react-native-desktop-notification/desktop/CMakeLists.txt
+++ b/modules/react-native-desktop-notification/desktop/CMakeLists.txt
@@ -10,7 +10,11 @@ include(${CMAKE_ROOT}/Modules/ExternalProject.cmake)
 
 set(SN_PREFIX ${CMAKE_CURRENT_BINARY_DIR}/SnoreNotify_ep-prefix/src/SnoreNotify_ep)
 if (WIN32)
-  set(SnoreNotify_CMAKE_ARGS -DMINGW=1 -DBUILD_osxnotificationcenter=OFF -DBUILD_sound=OFF -DBUILD_speech=OFF -DBUILD_toasty=OFF -DBUILD_snoretoast=OFF
+  set(SnoreNotifyWindowsToast_STATIC_LIB ${SN_PREFIX}/lib${SN_LIBPATHSUFFIX}/${CMAKE_STATIC_LIBRARY_PREFIX}snore_backend_windowstoast${CMAKE_STATIC_LIBRARY_SUFFIX})
+
+  set(SnoreNotify_LIBS ${SnoreNotifyWindowsToast_STATIC_LIB})
+
+  set(SnoreNotify_CMAKE_ARGS -DMINGW=1 -DBUILD_osxnotificationcenter=OFF -DBUILD_sound=OFF -DBUILD_speech=OFF -DBUILD_toasty=OFF
                              -DBUILD_freedesktop_backend=OFF -DBUILD_snarl=OFF -DBUILD_growl=OFF -DBUILD_trayicon=OFF -DBUILD_pushover_backend=OFF)
 endif()
 
@@ -66,7 +70,7 @@ ExternalProject_Add(SnoreNotify_ep
   GIT_REPOSITORY https://github.com/status-im/snorenotify.git
   CMAKE_ARGS ${SnoreNotify_CMAKE_ARGS}
   BUILD_BYPRODUCTS ${SnoreNotify_STATIC_LIB} ${SnoreNotify_LIBS} ${SnoreNotifyBackend_STATIC_LIB}
-                    ${SnoreNotifyBackendSettings_STATIC_LIB} ${SnoreNotifySettings_STATIC_LIB}
+                   ${SnoreNotifyBackendSettings_STATIC_LIB} ${SnoreNotifySettings_STATIC_LIB}
   LOG_DOWNLOAD 1
 )
 

--- a/modules/react-native-desktop-notification/desktop/desktopnotification.cpp
+++ b/modules/react-native-desktop-notification/desktop/desktopnotification.cpp
@@ -24,12 +24,16 @@
 
 Q_LOGGING_CATEGORY(NOTIFICATION, "RCTNotification")
 
-#ifdef Q_OS_LINUX
+#if defined(Q_OS_LINUX) || defined(Q_OS_WIN)
 namespace SnorePlugin {}
 
 
 using namespace SnorePlugin;
+#if defined(Q_OS_LINUX)
 Q_IMPORT_PLUGIN(Freedesktop)
+#elif defined(Q_OS_WIN)
+Q_IMPORT_PLUGIN(WindowsToast)
+#endif
 Q_IMPORT_PLUGIN(Snore)
 
 static void loadSnoreResources()
@@ -43,7 +47,7 @@ static void loadSnoreResources()
 }
 
 Q_COREAPP_STARTUP_FUNCTION(loadSnoreResources)
-#endif // Q_OS_LINUX
+#endif // defined(Q_OS_LINUX) || defined(Q_OS_WIN)
 
 namespace {
 struct RegisterQMLMetaType {
@@ -73,6 +77,7 @@ DesktopNotification::DesktopNotification(QObject *parent)
   if (Snore::SnoreCore::instance().pluginNames().isEmpty()) {
     Snore::SnoreCore::instance().loadPlugins(Snore::SnorePlugin::Backend);
   }
+  d_ptr->snoreApp.hints().setValue("windows-app-id", "StatusIm.Status.Desktop.1");
 
   qCDebug(NOTIFICATION) << "DesktopNotification::DesktopNotification List of all loaded Snore plugins:"
                         << Snore::SnoreCore::instance().pluginNames();

--- a/scripts/build-desktop.sh
+++ b/scripts/build-desktop.sh
@@ -207,7 +207,7 @@ function compile() {
             -DJS_BUNDLE_PATH="$JS_BUNDLE_PATH" \
             -DCMAKE_CXX_FLAGS:='-DBUILD_FOR_BUNDLE=1' || exit 1
     fi
-    make -j5 || exit 1
+    make -S -j5 || exit 1
   popd
 }
 
@@ -227,9 +227,8 @@ function bundleWindows() {
     pushd Windows
       cp $STATUSREACTPATH/.env .
       mkdir -p assets/resources notifier
-      cp $STATUSREACTPATH/node_modules/node-notifier/vendor/snoreToast/SnoreToast.exe \
-         $STATUSREACTPATH/node_modules/node-notifier/vendor/notifu/*.exe \
-         notifier/
+      cp $STATUSREACTPATH/node_modules/node-notifier/vendor/snoreToast/SnoreToast.exe .
+      cp $STATUSREACTPATH/node_modules/node-notifier/vendor/notifu/*.exe notifier/
       cp -r $STATUSREACTPATH/resources/fonts \
             $STATUSREACTPATH/resources/icons \
             $STATUSREACTPATH/resources/images \


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes #6728, integrated into https://github.com/status-im/status-react/pull/6586

### Summary:

[comment]: # (Summarise the problem and how the pull request solves it)
This PR enables building of the WindowsToast snore plugin and registers it. A commit was also done on the snorenotify repo to fix a build error on Windows.

This PR requires https://github.com/status-im/status-react/pull/6586 for the configuration (otherwise it must be done manually), so marking it WIP for the time being.

Sliding notification from the side:

![imagem](https://user-images.githubusercontent.com/138074/48548185-abe9d180-e8cc-11e8-997d-3377e58d58d1.png)

Notification center:

![imagem](https://user-images.githubusercontent.com/138074/48548379-18fd6700-e8cd-11e8-86bc-f269152c288a.png)

### Testing notes (optional):
<!-- (Specify which platforms should be tested) -->
#### Platforms (optional)
- Windows

<!-- (Specify if some specific areas has to be tested, for example 1-1 chats) -->
#### Areas that maybe impacted (optional)
**Functional**
- 1-1 chats
- public chats
- group chats

status: ready <!-- Can be ready or wip -->
