### PR TITLE
Feature/update links

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -8,10 +8,10 @@ These are just guidelines, not rules. Use your best judgment, and feel free to p
 
 #### What should I know before I get started?
 
-* [Mission and Core Values](https://wiki.status.im/Mission_and_Core_Values)
-* [Code of Conduct](https://wiki.status.im/Code_of_conduct)
-* [Read our FAQ](https://wiki.status.im/Frequently_Asked_Questions)
-* [Join our Riot](http://chat.status.im/) and chat in `#dev-status`
-* [Developer Introduction](https://wiki.status.im/Developer_Documentation#Getting_Started)
-* [How to Build Status](https://wiki.status.im/Building_Status)
-* [Finding issues to work on](https://wiki.status.im/Developer_Documentation)
+* [Mission and Core Values](https://status.im/contribute)
+* [Principles](https://status.im/contribute/our_principles.html)
+* [Read our FAQ](https://status.im/docs/FAQs.html)
+* [Join our Chat](http://get.status.im/chat/public/status-core-dev)
+* [Developer Introduction](https://status.im/developer_tools/)
+* [Build Status Yourself](https://status.im/build_status)
+* [Find issues to work on](https://github.com/status-im/)

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ release-android: prod-build-android ##@build build release for Android
 	react-native run-android --variant=release
 
 release-ios: prod-build-ios ##@build build release for iOS release
-	@echo "Build in XCode, see https://wiki.status.im/TBD for instructions"
+	@echo "Build in XCode, see https://status.im/build_status/ for instructions"
 
 release-desktop: prod-build-desktop ##@build build release for desktop release
 	scripts/build-desktop.sh

--- a/README.md
+++ b/README.md
@@ -17,38 +17,36 @@ If this interests you, **help us make Status a reality** - anyone can contribute
 
 ## How to Contribute?
 
-Go straight to the [docs](https://docs.status.im) or [join our Riot](http://chat.status.im/#/register) and choose what interests you:
+Go straight to the [docs](https://status.im/docs) or [join our chat](http://get.status.im/chat/public/status) and choose what interests you:
 
 - **Developer**
 Developers are the heart of software and to keep Status beating we need all the help we can get! If you're looking to code in ClojureScript or Golang then Status is the project for you! We use React Native and there is even some Java/Objective-C too!  
-Want to learn more about it? Start by reading our [Developer Introduction](https://docs.status.im/docs/) which guides you through the technology stack and start browsing [beginner issues](https://github.com/status-im/status-react/issues?utf8=%E2%9C%93&q=is%3Aopen%20is%3Aissue%20label%3A%22good%20first%20issue%22%20). Then you can read how to [Build Status](https://docs.status.im/docs/build_status.html), which talks about managing project dependencies, coding guidelines and testing procedures.
+Want to learn more about it? Start by reading our [Developer Introduction](https://status.im/developer_tools/) which guides you through the technology stack and start browsing [beginner issues](https://github.com/status-im/status-react/issues?utf8=%E2%9C%93&q=is%3Aopen%20is%3Aissue%20label%3A%22good%20first%20issue%22%20). Then you can read how to [Build Status](https://status.im/build_status/), which talks about managing project dependencies, coding guidelines and testing procedures.
 
 - **Community Management**  
-Metcalfe's law states that the value of a network is proportional to the square of the number of connected users of the system - without community Status is meaningless. We're looking to create a positive, fun environment to explore new ideas, experiment and grow the Status community. Building a community takes a lot of work but the people you'll meet and long lasting relationships you form will be well worth it, check out our [Community Principles](https://wiki.status.im/Read_Our_Principles)
+Metcalfe's law states that the value of a network is proportional to the square of the number of connected users of the system - without community Status is meaningless. We're looking to create a positive, fun environment to explore new ideas, experiment and grow the Status community. Building a community takes a lot of work but the people you'll meet and long lasting relationships you form will be well worth it, check out our [Community Principles](https://status.im/contribute/our_principles.html)
 
 - **Specification / Documentation**  
-John Dewey once said "Education is not preparation for life; education is life *itself* ". Developers & Designers need guidance and it all starts from documentation and specifications. Our software is only as good as its documentation, head over to our [docs](https://docs.status.im) and see how you can improve what we have.
+John Dewey once said "Education is not preparation for life; education is life *itself* ". Developers & Designers need guidance and it all starts from documentation and specifications. Our software is only as good as its documentation, head over to our [docs](https://status.im/docs) and see how you can improve what we have.
 
 - **Blog Writing**  
-Content is King, keeping our blog up to date and informing the community of news helps keep everyone on the same page. [Jump on our Riot](http://chat.status.im/#/register) and discuss with the team how you can contribute!
+Content is King, keeping our blog up to date and informing the community of news helps keep everyone on the same page. [Jump into our chat](http://get.status.im/chat/public/status) and discuss with the team how you can contribute!
 
 - **Testers**  
-It's bug hunting season! Status is currently in Alpha and there is sure to be a bunch of learning, [build status from scratch](https://docs.status.im/docs/build_status.html) or if an android user check out our [nightly builds](http://artifacts.status.im:8081/artifactory/nightlies-local/). You can shake your phone to submit bug reports, or start browsing our [Github Issues](http://github.com/status-im/status-react/issues). Every bug you find brings Status closer to stable, usable software for everyone to enjoy!
+It's bug hunting season! Status is currently in Alpha and there is sure to be a bunch of learning, [build status from scratch](https://status.im/build_status/) or if an android user check out our [nightly builds](https://status.im/nightly). You can shake your phone to submit bug reports, or start browsing our [Github Issues](http://github.com/status-im/status-react/issues). Every bug you find brings Status closer to stable, usable software for everyone to enjoy!
 
 - **Security**  
 Status is a visual interface to make permanent changes on the Blockchain, it handles crypto-tokens that have real value and allows 3rd party code execution. Security is paramount to its success. You are given permission to break Status as hard as you can, as long as you share your findings with the community!
 
 - **Evangelism**  
-Help us spread the word! Tell a friend *right now*, in fact tell **everyone** - yell from a mountain if you have to, every person counts! If you've got a great story to tell or have some interesting way you've spread the word about Status let us know about it in our [Riot](https://chat.status.im/#/register)
+Help us spread the word! Tell a friend *right now*, in fact tell **everyone** - yell from a mountain if you have to, every person counts! If you've got a great story to tell or have some interesting way you've spread the word about Status let us know about it in our [chat](https://get.status.im/chat/public/status)
 
 ## Status API 
-View our [API Docs](https://docs.status.im/docs/status_web_api.html) and learn how to integrate your DApp into Status. You can read more about how to add your DApp to Status [here](https://docs.status.im/docs/status_optimized.html)
+View our [API Docs](https://status.im/developer_tools/status_web_api.html) and learn how to integrate your DApp into Status. You can read more about how to add your DApp to Status [here](https://status.im/developer_tools/add_your_dapp.html).
 
 ## Give me Binaries!
 
-Currently the fastest way to get your hands on a binary is to join our Early Access by submitting your email on our [website](https://status.im) or by [building it yourself](https://docs.status.im/docs/build_status.html).
-
-Alternatively, if you’re on Android you can try one of our nightly APK builds from [here](http://artifacts.status.im:8081/artifactory/nightlies-local/)
+You can get our Beta builds for both Android and iOS on our [website](https://status.im), through our [nightly builds](https://status.im/nightly/) or by [building it yourself](https://status.im/build_status/).
 
 ## Core Contributors
 
@@ -59,7 +57,7 @@ Without the dedication of these outstanding individuals, Status would not exist.
 
 ## Contact us
 
-Feel free to email us at [support@status.im](mailto:support@status.im) or better yet, [join our Riot](http://chat.status.im/#/register).
+Feel free to email us at [support@status.im](mailto:support@status.im) or better yet, [join our chat](http://get.status.im/chat/public/status).
 
 ## License
 

--- a/scripts/lib/setup/platform.sh
+++ b/scripts/lib/setup/platform.sh
@@ -13,9 +13,9 @@ function is_linux() {
 function exit_unless_os_supported() {
   if ! is_macos && ! is_linux; then
     cecho "@red[[This install script currently supports Mac OS X and Linux \
-via apt. To manually install, please visit the wiki for more information:]]
+via apt. To manually install, please visit the docs for more information:]]
 
-    @blue[[https://wiki.status.im/Building_Status]]"
+    @blue[[https://status.im/build_status]]"
 
     echo
 

--- a/src/status_im/ui/screens/help_center/views.cljs
+++ b/src/status_im/ui/screens/help_center/views.cljs
@@ -18,7 +18,7 @@
      [profile.components/settings-item-separator]
      [profile.components/settings-item {:label-kw            :t/faq
                                         :accessibility-label :faq-button
-                                        :action-fn           #(.openURL react/linking "https://wiki.status.im/Questions_around_beta#firstHeading")}]
+                                        :action-fn           #(.openURL react/linking "https://status.im/docs/FAQs.html")}]
      [profile.components/settings-item-separator]
      [profile.components/settings-item {:label-kw            :t/ask-in-status
                                         :accessibility-label :submit-bug-button


### PR DESCRIPTION
Fixes #6740

### Summary:

The link to the FAQs in the app is broken. I did a find + replace for all the links I could get, but still haven't been able to find the guilty culprit. Maybe someone better at Clojure could help a brother out. 

#### Platforms (optional)
- Android
- iOS
- macOS
- Linux
- Windows

<!-- (Specify if some specific areas has to be tested, for example 1-1 chats) -->
#### Areas that maybe impacted (optional)
**Functional**
- account recovery
- new account
- user profile updates
- networks
- mailservers
- fleet
- bootnodes

<!-- (Specify exact steps to test if there are such) -->
### Steps to test:
- Open Status
- Check that the link under Profile > Need Help? > Frequently Asked Questions points to the right place, which is here: https://status.im/docs/FAQs.html

status: WIP


<blockquote><img src="/img/share.png" width="48" align="right"><div><strong><a href="https://status.im/docs/FAQs.html">Status, a Mobile Client for Ethereum 2.0</a></strong></div></blockquote>