### PR TITLE
Changed 2-button confirmations to 1-button popups for installing and uninstalling extensions

### DIFF
--- a/src/status_im/extensions/registry.cljs
+++ b/src/status_im/extensions/registry.cljs
@@ -56,10 +56,9 @@
                         :active? true}
         new-extensions (assoc (:extensions account) (:url extension) extension)]
     (fx/merge cofx
-              {:ui/show-confirmation {:title     (i18n/label :t/success)
-                                      :content   (i18n/label :t/extension-installed)
-                                      :on-accept #(re-frame/dispatch [:navigate-to-clean :my-profile])
-                                      :on-cancel nil}}
+              {:utils/show-popup {:title     (i18n/label :t/success)
+                                  :content   (i18n/label :t/extension-installed)
+                                  :on-dismiss #(re-frame/dispatch [:navigate-to-clean :my-profile])}}
               (accounts.update/account-update {:extensions new-extensions} {})
               (add-to-registry (:value url) extension-data true))))
 
@@ -68,10 +67,8 @@
   (let [{:account/keys [account]} db
         new-extensions (dissoc (:extensions account) extension-key)]
     (fx/merge cofx
-              {:ui/show-confirmation {:title     (i18n/label :t/success)
-                                      :content   (i18n/label :t/extension-uninstalled)
-                                      :on-accept nil
-                                      :on-cancel nil}}
+              {:utils/show-popup {:title     (i18n/label :t/success)
+                                  :content   (i18n/label :t/extension-uninstalled)}}
               (remove-from-registry extension-key)
               (accounts.update/account-update {:extensions new-extensions} {}))))
 


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

Fixes #6353

### Summary:

[comment]: # (Summarise the problem and how the pull request solves it)

Changed the 2-button dialogs to 1-button popups - thereby making it a simple "OK" box instead of "Cancel / OK".

<!-- (Specify exact steps to test if there are such) -->
### Steps to test:
- Open Status
- Enable dev mode
- Go to extensions
- Install or uninstall an extension and see the dialog/popup

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->
