### PR TITLE
Disable send button when no peers are connected.

### DIFF
--- a/src/status_im/ui/screens/chat/input/send_button.cljs
+++ b/src/status_im/ui/screens/chat/input/send_button.cljs
@@ -14,20 +14,20 @@
        (animation/timing spin-value {:toValue  to-spin-value
                                      :duration 300})))))
 
-(defn sendable? [input-text network-status]
+(defn sendable? [input-text offline?]
   (let [trimmed (string/trim input-text)]
     (not (or (string/blank? trimmed)
              (= trimmed "/")
-             (= :offline network-status)))))
+             offline?))))
 
 (defview send-button-view []
   (letsubs [{:keys [command-completion]}            [:chats/selected-chat-command]
             {:keys [input-text seq-arg-input-text]} [:chats/current-chat]
-            network-status                          [:network-status]
+            offline?                                [:offline?]
             spin-value                              (animation/create-value 1)]
     {:component-did-update (send-button-view-on-update {:spin-value         spin-value
                                                         :command-completion command-completion})}
-    (when (and (sendable? input-text network-status)
+    (when (and (sendable? input-text offline?)
                (or (not command-completion)
                    (#{:complete :less-than-needed} command-completion)))
       [react/touchable-highlight {:on-press #(re-frame/dispatch [:chat.ui/send-current-message])}

--- a/src/status_im/ui/screens/subs.cljs
+++ b/src/status_im/ui/screens/subs.cljs
@@ -48,17 +48,19 @@
 (reg-sub :network-status :network-status)
 (reg-sub :peers-count :peers-count)
 
-(reg-sub :offline?
-         :<- [:network-status]
-         :<- [:sync-state]
-         (fn [[network-status sync-state]]
-           (or (= network-status :offline)
-               (= sync-state :offline))))
-
 (reg-sub :disconnected?
          :<- [:peers-count]
          (fn [peers-count]
            (zero? peers-count)))
+
+(reg-sub :offline?
+         :<- [:network-status]
+         :<- [:sync-state]
+         :<- [:disconnected?]
+         (fn [[network-status sync-state disconnected?]]
+           (or disconnected?
+               (= network-status :offline)
+               (= sync-state :offline))))
 
 (reg-sub :syncing?
          :<- [:sync-state]


### PR DESCRIPTION
Previously we were only checking whether `network-status` is equal to
`:offline`, therefore allowing the user to send messages even when no
peers are connected (i.e. the app is displaying Connecting to peers..).

Another potential issue (need to verify still though), is that we always check `network-status` against `:offline`, but it is initialized to `nil`. So if you start the app when you are offline, it will not report the network status correctly, until there's a network change. need to verify this though.

### Testing

When you see Offline or Connecting to peers, the send button in chats should be disabled.

status: ready