### PR TITLE
[fix] resurrect cljs-react-navigation

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -12,7 +12,8 @@
          hickory                     {:mvn/version "0.7.1"}
          com.cognitect/transit-cljs  {:mvn/version "0.8.248"}
          status-im/pluto             {:mvn/version "iteration-4-1"}
-         mvxcvi/alphabase            {:mvn/version "1.0.0"}}
+         mvxcvi/alphabase            {:mvn/version "1.0.0"}
+         rasom/cljs-react-navigation {:mvn/version "0.1.4"}}
 
  :aliases
  {:dev {:extra-deps


### PR DESCRIPTION
update to cljs compiler accidently removed dep which wasn't caught by CI because it still uses lein

status: ready <!-- Can be ready or wip -->
