### PR TITLE
Ensure no ubuntu-server process is running at startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,6 +130,7 @@ CMakeCache.txt
 **/CMakeFiles/
 /StatusImPackage/*
 *.AppImage
+Status-Windows-x86_64.zip
 /desktop/bin/*
 /desktop/lib/*
 /desktop/modules/*

--- a/docker-build/README.md
+++ b/docker-build/README.md
@@ -1,6 +1,6 @@
 # Build
 
-```
+``` shell
 docker-compose -f docker-build/docker-compose.yml build
 ```
 
@@ -8,7 +8,7 @@ This will install all the required sdks, depending on the connection will take s
 
 # Run
 
-```
+``` shell
 docker-compose -f docker-build/docker-compose.yml up
 ```
 
@@ -18,7 +18,7 @@ You need to connect your device and accept the key.
 
 After the figwheel prompt you can install the application running:
 
-```
+``` shell
 docker-compose -f docker-build/docker-compose.yml exec adbd make run-android
 ```
 

--- a/scripts/build-desktop.sh
+++ b/scripts/build-desktop.sh
@@ -207,11 +207,12 @@ function compile() {
             -DJS_BUNDLE_PATH="$JS_BUNDLE_PATH" \
             -DCMAKE_CXX_FLAGS:='-DBUILD_FOR_BUNDLE=1' || exit 1
     fi
-    make -j5 || exit 1
+    make -S -j5 || exit 1
   popd
 }
 
 function bundleWindows() {
+  local buildType="$1"
   # TODO: Produce a setup program instead of a ZIP
   pushd $WORKFOLDER
     rm -rf Windows
@@ -227,9 +228,10 @@ function bundleWindows() {
     pushd Windows
       cp $STATUSREACTPATH/.env .
       mkdir -p assets/resources notifier
-      cp $STATUSREACTPATH/node_modules/node-notifier/vendor/snoreToast/SnoreToast.exe \
-         $STATUSREACTPATH/node_modules/node-notifier/vendor/notifu/*.exe \
+      cp $STATUSREACTPATH/node_modules/node-notifier/vendor/notifu/*.exe \
          notifier/
+      cp $STATUSREACTPATH/node_modules/node-notifier/vendor/snoreToast/SnoreToast.exe \
+         .
       cp -r $STATUSREACTPATH/resources/fonts \
             $STATUSREACTPATH/resources/icons \
             $STATUSREACTPATH/resources/images \
@@ -237,7 +239,14 @@ function bundleWindows() {
       local _bin=$STATUSREACTPATH/desktop/bin
       rm -rf $_bin/cmake_install.cmake $_bin/Makefile $_bin/CMakeFiles $_bin/Status_autogen && \
       cp -r $_bin/* .
-      zip -mr9 ../../Status-Windows-x86_64.zip .
+
+      local zipOptions="-mr9"
+      if [ -z $buildType ]; then
+        zipOptions="-mr1"
+      elif [ "$buildType" = "pr" ]; then
+        zipOptions="-mr2"
+      fi
+      zip $zipOptions ../../Status-Windows-x86_64.zip .
     popd
     rm -rf Windows
   popd


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

Fixes #6584

### Summary:

[comment]: # (Summarise the problem and how the pull request solves it)
Lots of users continue to be confused about the fact that the app sometimes doesn't show a UI, and having the instructions in the FAQ doesn't seem to be sufficient. This PR ensures that any rogue process is killed as the app is starting up.

### Review notes (optional):
<!-- (Specify if something in particular should be looked at, or ignored, during review) -->

### Testing notes:
<!-- (Specify which platforms should be tested) -->
#### Platforms
- macOS
- Linux
- Windows

<!-- (Specify exact steps to test if there are such) -->
### Steps to test:
- Ensure ubuntu-server is running in the background, but not Status
- Open Status
- App should start normally, whereas previously no UI would show up

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->
