### PR TITLE
[TESTS] Check that system replaces capital letters when typing passphrase

### DIFF
--- a/test/appium/tests/atomic/account_management/test_recover.py
+++ b/test/appium/tests/atomic/account_management/test_recover.py
@@ -147,3 +147,15 @@ class TestRecoverAccessFromSignInScreen(SingleDeviceTestCase):
 
         if not home_view.profile_button.is_element_displayed():
             self.driver.fail('Something went wrong. Probably, could not reach the home screen out.')
+
+    @marks.testrail_id(5394)
+    @marks.high
+    def test_uppercase_is_replaced_by_lowercase_automatically(self):
+        passphrase = transaction_senders['A']['passphrase']
+        capitalized_passphrase = passphrase.upper()
+        signin_view = SignInView(self.driver)
+        recover_access_view = signin_view.i_have_account_button.click()
+        recover_access_view.passphrase_input.click()
+        recover_access_view.send_as_keyevent(capitalized_passphrase)
+        if recover_access_view.passphrase_input.text != passphrase:
+            self.driver.fail('Upper case was not replaced by lower case!')

--- a/test/appium/views/base_view.py
+++ b/test/appium/views/base_view.py
@@ -347,7 +347,9 @@ class BaseView(object):
         time.sleep(3)
         self.driver.info("Enter '%s' using native keyboard" % string)
         for i in string:
-            if type(keys[i]) is list:
+            if i.isalpha() and i.isupper():
+                keycode, metastate = keys[i.lower()], 64  # META_SHIFT_LEFT_ON Constant Value: 64. Example: i='n' -> 'N'
+            elif type(keys[i]) is list:
                 keycode, metastate = keys[i][0], keys[i][1]
             else:
                 keycode, metastate = keys[i], None

--- a/test/appium/views/recover_access_view.py
+++ b/test/appium/views/recover_access_view.py
@@ -6,7 +6,7 @@ class PassphraseInput(BaseEditBox):
 
     def __init__(self, driver):
         super(PassphraseInput, self).__init__(driver)
-        self.locator = self.Locator.xpath_selector("//android.widget.EditText[contains(@text,'phrase')]")
+        self.locator = self.Locator.accessibility_id("enter-12-words")
 
 
 class ConfirmRecoverAccess(BaseButton):


### PR DESCRIPTION
### Summary
According to system design when a user is typing his/her passphrase (while recovering an account)
the mobile application should replace capital letters with small letters. Thus, the system prevents the user from CAPS mistyping.

This test exactly verifies the above case.

### Review notes:
`send_as_keyevent` was slightly changed. 
Now it operates on `keys` dictionary allowing to send a capital letter.

status: ready