### PR TITLE
[refactor] differentiate private and public chat and contact subs

### DIFF
--- a/src/status_im/chat/commands/impl/transactions.cljs
+++ b/src/status_im/chat/commands/impl/transactions.cljs
@@ -105,7 +105,7 @@
     :placeholder (i18n/label :t/send-request-amount)}])
 
 (defview choose-nft-token [selected-event-creator]
-  (letsubs [{:keys [input-params]} [:selected-chat-command]
+  (letsubs [{:keys [input-params]} [:chats/selected-chat-command]
             collectibles           [:collectibles]]
     (let [collectible-tokens (get collectibles (keyword (:symbol input-params)))]
       [react/view {:flex-direction   :row
@@ -189,8 +189,8 @@
 ;; `/send` command
 
 (defview send-status [tx-hash outgoing]
-  (letsubs [confirmed? [:transaction-confirmed? tx-hash]
-            tx-exists? [:wallet-transaction-exists? tx-hash]]
+  (letsubs [confirmed? [:chats/transaction-confirmed? tx-hash]
+            tx-exists? [:chats/wallet-transaction-exists? tx-hash]]
     [react/touchable-highlight {:on-press #(when tx-exists?
                                              (re-frame/dispatch [:show-transaction-details tx-hash]))}
      [react/view transactions-styles/command-send-status-container
@@ -405,7 +405,7 @@
 
 (defview request-preview
   [{:keys [message-id content outgoing timestamp timestamp-str group-chat]}]
-  (letsubs [id->command         [:get-id->command]
+  (letsubs [id->command         [:chats/id->command]
             status-initialized? [:get :status-module-initialized?]
             network             [:network-name]
             prices              [:prices]]

--- a/src/status_im/chat/db.cljs
+++ b/src/status_im/chat/db.cljs
@@ -84,7 +84,7 @@
       (and (not outgoing)
            (not (= :user-message message-type)))))
 
-                                        ; any message that comes after this amount of ms will be grouped separately
+;; any message that comes after this amount of ms will be grouped separately
 (def ^:private group-ms 60000)
 
 (defn add-positional-metadata
@@ -93,18 +93,18 @@
   [{:keys [stream last-outgoing-seen]}
    {:keys [type message-type from datemark outgoing timestamp] :as message}]
   (let [previous-message         (peek stream)
-                                        ; Was the previous message from a different author or this message
-                                        ; comes after x ms
+        ;; Was the previous message from a different author or this message
+        ;; comes after x ms
         last-in-group?           (or (= :system-message message-type)
                                      (not= from (:from previous-message))
                                      (> (- (:timestamp previous-message) timestamp) group-ms))
         same-direction?          (= outgoing (:outgoing previous-message))
-                                        ; Have we seen an outgoing message already?
+        ;; Have we seen an outgoing message already?
         last-outgoing?           (and (not last-outgoing-seen)
                                       outgoing)
         datemark?                (= :datemark (:type message))
-                                        ; If this is a datemark or this is the last-message of a group,
-                                        ; then the previous message was the first
+        ;; If this is a datemark or this is the last-message of a group,
+        ;; then the previous message was the first
         previous-first-in-group? (or datemark?
                                      last-in-group?)
         new-message              (assoc message
@@ -114,12 +114,12 @@
                                         :last-outgoing?  last-outgoing?)]
     {:stream             (cond-> stream
                            previous-first-in-group?
-                                        ; update previuous message if necessary
+                           ;; update previous message if necessary
                            set-previous-message-info
 
                            :always
                            (conj new-message))
-                                        ; mark the last message sent by the user
+     ;; mark the last message sent by the user
      :last-outgoing-seen (or last-outgoing-seen last-outgoing?)}))
 
 (defn messages-stream

--- a/src/status_im/chat/subs.cljs
+++ b/src/status_im/chat/subs.cljs
@@ -8,51 +8,91 @@
             [status-im.models.transactions :as transactions]
             [status-im.utils.platform :as platform]))
 
-(re-frame/reg-sub :get-chats :chats)
-
-(re-frame/reg-sub :get-current-chat-id :current-chat-id)
-
-(re-frame/reg-sub :chat-ui-props :chat-ui-props)
-
-(re-frame/reg-sub :get-id->command :id->command)
-
-(re-frame/reg-sub :get-access-scope->command-id :access-scope->command-id)
+(re-frame/reg-sub ::chats :chats)
+(re-frame/reg-sub ::access-scope->command-id :access-scope->command-id)
+(re-frame/reg-sub ::chat-ui-props :chat-ui-props)
 
 (re-frame/reg-sub
- :get-current-chat-ui-props
- :<- [:chat-ui-props]
- :<- [:get-current-chat-id]
+ ::cooldown-enabled?
+ (fn [db]
+   (:chat/cooldown-enabled? db)))
+
+(re-frame/reg-sub
+ ::show-suggestions?
+ :<- [::show-suggestions-view?]
+ :<- [:chats/selected-chat-command]
+ (fn [[show-suggestions-box? selected-command]]
+   (and show-suggestions-box? (not selected-command))))
+
+(re-frame/reg-sub
+ ::show-suggestions-view?
+ :<- [:chats/current-chat-ui-prop :show-suggestions?]
+ :<- [:chats/current-chat]
+ :<- [:chats/all-available-commands]
+ (fn [[show-suggestions? {:keys [input-text]} commands]]
+   (and (or show-suggestions?
+            (commands.input/starts-as-command? (string/trim (or input-text ""))))
+        (seq commands))))
+
+(re-frame/reg-sub
+ ::get-commands-for-chat
+ :<- [:chats/id->command]
+ :<- [::access-scope->command-id]
+ :<- [:chats/current-chat]
+ (fn [[id->command access-scope->command-id chat]]
+   (commands/chat-commands id->command access-scope->command-id chat)))
+
+(re-frame/reg-sub :chats/id->command :id->command)
+(re-frame/reg-sub :chats/current-chat-id :current-chat-id)
+
+(re-frame/reg-sub
+ :chats/chat
+ :<- [:chats/active-chats]
+ (fn [chats [_ chat-id]]
+   (get chats chat-id)))
+
+(re-frame/reg-sub
+ :chats/current-chat-ui-props
+ :<- [::chat-ui-props]
+ :<- [:chats/current-chat-id]
  (fn [[chat-ui-props id]]
    (get chat-ui-props id)))
 
 (re-frame/reg-sub
- :get-current-chat-name
- :<- [:get-current-chat-contact]
- :<- [:get-current-chat]
+ :chats/current-chat-contact
+ :<- [:contacts/contacts]
+ :<- [:chats/current-chat-id]
+ (fn [[contacts chat-id]]
+   (get contacts chat-id)))
+
+(re-frame/reg-sub
+ :chats/current-chat-name
+ :<- [:chats/current-chat-contact]
+ :<- [:chats/current-chat]
  (fn [[contact chat]]
    (chat.db/chat-name chat contact)))
 
 (re-frame/reg-sub
- :get-chat-name
- :<- [:get-contacts]
- :<- [:get-chats]
+ :chats/chat-name
+ :<- [:contacts/contacts]
+ :<- [::chats]
  (fn [[contacts chats] [_ chat-id]]
    (chat.db/chat-name (get chats chat-id) (get contacts chat-id))))
 
 (re-frame/reg-sub
- :get-current-chat-ui-prop
- :<- [:get-current-chat-ui-props]
+ :chats/current-chat-ui-prop
+ :<- [:chats/current-chat-ui-props]
  (fn [ui-props [_ prop]]
    (get ui-props prop)))
 
 (re-frame/reg-sub
- :validation-messages
- :<- [:get-current-chat-ui-props]
+ :chats/validation-messages
+ :<- [:chats/current-chat-ui-props]
  (fn [ui-props]
    (some-> ui-props :validation-messages)))
 
 (re-frame/reg-sub
- :chat-input-margin
+ :chats/input-margin
  :<- [:get :keyboard-height]
  (fn [kb-height]
    (cond
@@ -61,118 +101,104 @@
      :default 0)))
 
 (re-frame/reg-sub
- :get-active-chats
- :<- [:get-contacts]
- :<- [:get-chats]
+ :chats/active-chats
+ :<- [:contacts/contacts]
+ :<- [::chats]
  :<- [:account/account]
  (fn [[contacts chats account]]
    (chat.db/active-chats contacts chats account)))
 
 (re-frame/reg-sub
- :get-chat
- :<- [:get-active-chats]
- (fn [chats [_ chat-id]]
-   (get chats chat-id)))
-
-(re-frame/reg-sub
- :get-current-chat
- :<- [:get-active-chats]
- :<- [:get-current-chat-id]
+ :chats/current-chat
+ :<- [:chats/active-chats]
+ :<- [:chats/current-chat-id]
  (fn [[chats current-chat-id]]
    (get chats current-chat-id)))
 
 (re-frame/reg-sub
- :get-current-chat-message
- :<- [:get-current-chat]
+ :chats/current-chat-message
+ :<- [:chats/current-chat]
  (fn [{:keys [messages]} [_ message-id]]
    (get messages message-id)))
 
 (re-frame/reg-sub
- :get-current-chat-messages
- :<- [:get-current-chat]
+ :chats/current-chat-messages
+ :<- [:chats/current-chat]
  (fn [{:keys [messages]}]
    (or messages {})))
 
 (re-frame/reg-sub
- :get-current-chat-message-groups
- :<- [:get-current-chat]
+ :chats/current-chat-message-groups
+ :<- [:chats/current-chat]
  (fn [{:keys [message-groups]}]
    (or message-groups {})))
 
 (re-frame/reg-sub
- :get-current-chat-message-statuses
- :<- [:get-current-chat]
+ :chats/current-chat-message-statuses
+ :<- [:chats/current-chat]
  (fn [{:keys [message-statuses]}]
    (or message-statuses {})))
 
 (re-frame/reg-sub
- :get-current-chat-referenced-messages
- :<- [:get-current-chat]
+ :chats/current-chat-referenced-messages
+ :<- [:chats/current-chat]
  (fn [{:keys [referenced-messages]}]
    (or referenced-messages {})))
 
 (re-frame/reg-sub
- :get-current-chat-messages-stream
- :<- [:get-current-chat-messages]
- :<- [:get-current-chat-message-groups]
- :<- [:get-current-chat-message-statuses]
- :<- [:get-current-chat-referenced-messages]
+ :chats/current-chat-messages-stream
+ :<- [:chats/current-chat-messages]
+ :<- [:chats/current-chat-message-groups]
+ :<- [:chats/current-chat-message-statuses]
+ :<- [:chats/current-chat-referenced-messages]
  (fn [[messages message-groups message-statuses referenced-messages]]
    (-> (chat.db/sort-message-groups message-groups messages)
        (chat.db/messages-with-datemarks-and-statuses messages message-statuses referenced-messages)
        chat.db/messages-stream)))
 
 (re-frame/reg-sub
- :get-commands-for-chat
- :<- [:get-id->command]
- :<- [:get-access-scope->command-id]
- :<- [:get-current-chat]
- (fn [[id->command access-scope->command-id chat]]
-   (commands/chat-commands id->command access-scope->command-id chat)))
-
-(re-frame/reg-sub
- :get-available-commands
- :<- [:get-commands-for-chat]
- :<- [:get-current-chat]
+ :chats/available-commands
+ :<- [::get-commands-for-chat]
+ :<- [:chats/current-chat]
  (fn [[commands chat]]
    (chat.db/available-commands commands chat)))
 
 (re-frame/reg-sub
- :get-all-available-commands
- :<- [:get-commands-for-chat]
+ :chats/all-available-commands
+ :<- [::get-commands-for-chat]
  (fn [commands]
    (chat.db/map->sorted-seq commands)))
 
 (re-frame/reg-sub
- :selected-chat-command
- :<- [:get-current-chat]
- :<- [:get-current-chat-ui-prop :selection]
- :<- [:get-commands-for-chat]
+ :chats/selected-chat-command
+ :<- [:chats/current-chat]
+ :<- [:chats/current-chat-ui-prop :selection]
+ :<- [::get-commands-for-chat]
  (fn [[{:keys [input-text]} selection commands]]
    (commands.input/selected-chat-command input-text selection commands)))
 
 (re-frame/reg-sub
- :chat-input-placeholder
- :<- [:get-current-chat]
- :<- [:selected-chat-command]
+ :chats/input-placeholder
+ :<- [:chats/current-chat]
+ :<- [:chats/selected-chat-command]
  (fn [[{:keys [input-text]} {:keys [params current-param-position]}]]
    (when (string/ends-with? (or input-text "") chat.constants/spacing-char)
      (get-in params [current-param-position :placeholder]))))
 
 (re-frame/reg-sub
- :chat-parameter-box
- :<- [:get-current-chat]
- :<- [:selected-chat-command]
+ :chats/parameter-box
+ :<- [:chats/current-chat]
+ :<- [:chats/selected-chat-command]
  (fn [[_ {:keys [current-param-position params]}]]
    (when (and params current-param-position)
      (get-in params [current-param-position :suggestions]))))
 
 (re-frame/reg-sub
- :show-parameter-box?
- :<- [:chat-parameter-box]
- :<- [:show-suggestions?]
- :<- [:validation-messages]
- :<- [:selected-chat-command]
+ :chats/show-parameter-box?
+ :<- [:chats/parameter-box]
+ :<- [::show-suggestions?]
+ :<- [:chats/validation-messages]
+ :<- [:chats/selected-chat-command]
  (fn [[chat-parameter-box show-suggestions? validation-messages {:keys [command-completion]}]]
    (and chat-parameter-box
         (not validation-messages)
@@ -180,32 +206,15 @@
         (not (= :complete command-completion)))))
 
 (re-frame/reg-sub
- :show-suggestions-view?
- :<- [:get-current-chat-ui-prop :show-suggestions?]
- :<- [:get-current-chat]
- :<- [:get-all-available-commands]
- (fn [[show-suggestions? {:keys [input-text]} commands]]
-   (and (or show-suggestions?
-            (commands.input/starts-as-command? (string/trim (or input-text ""))))
-        (seq commands))))
-
-(re-frame/reg-sub
- :show-suggestions?
- :<- [:show-suggestions-view?]
- :<- [:selected-chat-command]
- (fn [[show-suggestions-box? selected-command]]
-   (and show-suggestions-box? (not selected-command))))
-
-(re-frame/reg-sub
- :unviewed-messages-count
+ :chats/unviewed-messages-count
  (fn [[_ chat-id]]
-   (re-frame/subscribe [:get-chat chat-id]))
+   (re-frame/subscribe [:chats/chat chat-id]))
  (fn [{:keys [unviewed-messages]}]
    (count unviewed-messages)))
 
 (re-frame/reg-sub
- :get-photo-path
- :<- [:get-contacts]
+ :chats/photo-path
+ :<- [:contacts/contacts]
  :<- [:account/account]
  (fn [[contacts account] [_ id]]
    (or (:photo-path (contacts id))
@@ -213,9 +222,9 @@
          (:photo-path account)))))
 
 (re-frame/reg-sub
- :get-last-message
+ :chats/last-message
  (fn [[_ chat-id]]
-   (re-frame/subscribe [:get-chat chat-id]))
+   (re-frame/subscribe [:chats/chat chat-id]))
  (fn [{:keys [messages message-groups]}]
    (->> (chat.db/sort-message-groups message-groups messages)
         first
@@ -225,44 +234,33 @@
         (get messages))))
 
 (re-frame/reg-sub
- :chat-animations
- (fn [db [_ key type]]
-   (let [chat-id (re-frame/subscribe [:get-current-chat-id])]
-     (get-in db [:animations :chats @chat-id key type]))))
-
-(re-frame/reg-sub
- :get-chats-unread-messages-number
- :<- [:get-active-chats]
+ :chats/unread-messages-number
+ :<- [:chats/active-chats]
  (fn [chats _]
    (apply + (map (comp count :unviewed-messages) (vals chats)))))
 
 (re-frame/reg-sub
- :transaction-confirmed?
+ :chats/transaction-confirmed?
  (fn [db [_ tx-hash]]
    (-> (get-in db [:wallet :transactions tx-hash :confirmations] "0")
        (js/parseInt)
        (>= transactions/confirmations-count-threshold))))
 
 (re-frame/reg-sub
- :wallet-transaction-exists?
+ :chats/wallet-transaction-exists?
  (fn [db [_ tx-hash]]
    (not (nil? (get-in db [:wallet :transactions tx-hash])))))
 
 (re-frame/reg-sub
- :chat/cooldown-enabled?
- (fn [db]
-   (:chat/cooldown-enabled? db)))
-
-(re-frame/reg-sub
- :chat-cooldown-enabled?
- :<- [:get-current-chat]
- :<- [:chat/cooldown-enabled?]
+ :chats/cooldown-enabled?
+ :<- [:chats/current-chat]
+ :<- [::cooldown-enabled?]
  (fn [[{:keys [public?]} cooldown-enabled?]]
    (and public?
         cooldown-enabled?)))
 
 (re-frame/reg-sub
- :get-reply-message
- :<- [:get-current-chat]
+ :chats/reply-message
+ :<- [:chats/current-chat]
  (fn [{:keys [metadata messages]}]
    (get messages (:responding-to-message metadata))))

--- a/src/status_im/search/subs.cljs
+++ b/src/status_im/search/subs.cljs
@@ -23,7 +23,7 @@
 
 (re-frame/reg-sub
  :search/filtered-active-chats
- :<- [:get-active-chats]
+ :<- [:chats/active-chats]
  :<- [:search/filter]
  filter-chats)
 

--- a/src/status_im/ui/components/chat_icon/screen.cljs
+++ b/src/status_im/ui/components/chat_icon/screen.cljs
@@ -28,7 +28,7 @@
         [react/view pending-inner-circle]]])))
 
 (defview chat-icon-view [chat-id _group-chat name _online styles & [hide-dapp?]]
-  (letsubs [photo-path [:get-chat-photo chat-id]
+  (letsubs [photo-path [:contacts/chat-photo chat-id]
             dapp?      [:get-in [:contacts/contacts chat-id :dapp?]]]
     [react/view (:container styles)
      (if-not (string/blank? photo-path)

--- a/src/status_im/ui/components/connectivity/view.cljs
+++ b/src/status_im/ui/components/connectivity/view.cljs
@@ -29,7 +29,7 @@
             disconnected?        [:disconnected?]
             mailserver-error?    [:mailserver/error]
             mailserver-fetching? [:mailserver/fetching?]
-            current-chat-contact [:get-current-chat-contact]
+            current-chat-contact [:chats/current-chat-contact]
             view-id              [:get :view-id]
             window-width         [:dimensions/window-width]]
     (when-let [label (cond

--- a/src/status_im/ui/components/desktop/tabs.cljs
+++ b/src/status_im/ui/components/desktop/tabs.cljs
@@ -15,7 +15,7 @@
     :content {:title         "Home"
               :icon-inactive :icons/home
               :icon-active   :icons/home-active}
-    :count-subscription  :get-chats-unread-messages-number}
+    :count-subscription  :chats/unread-messages-number}
    #_{:view-id :wallet
       :content {:title         "Wallet"
                 :icon-inactive :icons/wallet

--- a/src/status_im/ui/components/toolbar/view.cljs
+++ b/src/status_im/ui/components/toolbar/view.cljs
@@ -31,7 +31,7 @@
                              icon-opts)]])
 
 (defview nav-button-with-count [props]
-  (letsubs [unread-messages-number [:get-chats-unread-messages-number]]
+  (letsubs [unread-messages-number [:chats/unread-messages-number]]
     (let [unread-messages? (pos? unread-messages-number)]
       [react/view {:flex-direction :row}
        [nav-button (assoc props :unread-messages? unread-messages?)]

--- a/src/status_im/ui/screens/add_new/new_chat/views.cljs
+++ b/src/status_im/ui/screens/add_new/new_chat/views.cljs
@@ -19,7 +19,7 @@
                               :show-forward? true}])
 
 (views/defview new-chat []
-  (views/letsubs [contacts      [:all-added-people-contacts]
+  (views/letsubs [contacts      [:contacts/all-added-people-contacts]
                   error-message [:new-identity-error]]
     [react/keyboard-avoiding-view open-dapp.styles/main-container
      [status-bar/status-bar]

--- a/src/status_im/ui/screens/add_new/open_dapp/views.cljs
+++ b/src/status_im/ui/screens/add_new/open_dapp/views.cljs
@@ -21,7 +21,7 @@
                               :accessibility-label :dapp-item}])
 
 (views/defview open-dapp []
-  (views/letsubs [dapps [:all-dapps]
+  (views/letsubs [dapps [:contacts/all-dapps]
                   url-text (atom nil)]
     [react/keyboard-avoiding-view styles/main-container
      [status-bar/status-bar]

--- a/src/status_im/ui/screens/chat/bottom_info.cljs
+++ b/src/status_im/ui/screens/chat/bottom_info.cljs
@@ -61,8 +61,8 @@
       [message-status-row contact row])))
 
 (defn bottom-info-view []
-  (let [bottom-info (re-frame/subscribe [:get-current-chat-ui-prop :bottom-info])
-        contacts    (re-frame/subscribe [:get-contacts])]
+  (let [bottom-info (re-frame/subscribe [:chats/current-chat-ui-prop :bottom-info])
+        contacts    (re-frame/subscribe [:contacts/contacts])]
     (reagent/create-class
      {:display-name "bottom-info-view"
       :reagent-render

--- a/src/status_im/ui/screens/chat/input/animations/expandable.cljs
+++ b/src/status_im/ui/screens/chat/input/animations/expandable.cljs
@@ -18,10 +18,10 @@
 
 (defview expandable-view [{:keys [key]} & elements]
   (letsubs [anim-value         (animation/create-value 0)
-            input-height       [:get-current-chat-ui-prop :input-height]
-            input-focused?     [:get-current-chat-ui-prop :input-focused?]
-            messages-focused?  [:get-current-chat-ui-prop :messages-focused?]
-            chat-input-margin  [:chat-input-margin]
+            input-height       [:chats/current-chat-ui-prop :input-height]
+            input-focused?     [:chats/current-chat-ui-prop :input-focused?]
+            messages-focused?  [:chats/current-chat-ui-prop :messages-focused?]
+            chat-input-margin  [:chats/input-margin]
             keyboard-height    [:get :keyboard-height]
             chat-layout-height [:get :layout-height]]
     (let [input-height (or input-height (+ input-style/padding-vertical

--- a/src/status_im/ui/screens/chat/input/input.cljs
+++ b/src/status_im/ui/screens/chat/input/input.cljs
@@ -21,8 +21,8 @@
             [status-im.utils.utils :as utils]))
 
 (defview basic-text-input [{:keys [set-container-width-fn height single-line-input?]}]
-  (letsubs [{:keys [input-text]} [:get-current-chat]
-            cooldown-enabled?    [:chat-cooldown-enabled?]]
+  (letsubs [{:keys [input-text]} [:chats/current-chat]
+            cooldown-enabled?    [:chats/cooldown-enabled?]]
     [react/text-input
      (merge
       {:ref                    #(when % (re-frame/dispatch [:chat.ui/set-chat-ui-props {:input-ref %}]))
@@ -49,7 +49,7 @@
         {:placeholder (i18n/label :cooldown/text-input-disabled)}))]))
 
 (defview invisible-input [{:keys [set-layout-width-fn value]}]
-  (letsubs [{:keys [input-text]} [:get-current-chat]]
+  (letsubs [{:keys [input-text]} [:chats/current-chat]]
     [react/text {:style     style/invisible-input-text
                  :on-layout #(let [w (-> (.-nativeEvent %)
                                          (.-layout)
@@ -65,7 +65,7 @@
                                         :duration 300})))))
 
 (defview input-helper [{:keys [width]}]
-  (letsubs [placeholder   [:chat-input-placeholder]
+  (letsubs [placeholder   [:chats/input-placeholder]
             opacity-value (animation/create-value 0)
             on-update     (input-helper-view-on-update {:opacity-value opacity-value
                                                         :placeholder   placeholder})]
@@ -82,7 +82,7 @@
     nil))
 
 (defview input-view [{:keys [single-line-input?]}]
-  (letsubs [command [:selected-chat-command]]
+  (letsubs [command [:chats/selected-chat-command]]
     (let [component              (reagent/current-component)
           set-layout-width-fn    #(reagent/set-state component {:width %})
           set-container-width-fn #(reagent/set-state component {:container-width %})
@@ -95,8 +95,8 @@
         [input-helper {:width width}]]])))
 
 (defview commands-button []
-  (letsubs [commands      [:get-all-available-commands]
-            reply-message [:get-reply-message]]
+  (letsubs [commands      [:chats/all-available-commands]
+            reply-message [:chats/reply-message]]
     (when (and (not reply-message) (seq commands))
       [react/touchable-highlight
        {:on-press            #(re-frame/dispatch [:chat.ui/set-command-prefix])
@@ -106,14 +106,14 @@
                                                   :color           :dark}]]])))
 
 (defview reply-message [from message-text]
-  (letsubs [username           [:get-contact-name-by-identity from]
+  (letsubs [username           [:contacts/contact-name-by-identity from]
             current-public-key [:account/public-key]]
     [react/view {:style style/reply-message-content}
      [react/text {:style style/reply-message-author} (chat-utils/format-reply-author from username current-public-key)]
      [react/text {:style (message-style/style-message-text false)} message-text]]))
 
 (defview reply-message-view []
-  (letsubs [{:keys [content from] :as message} [:get-reply-message]]
+  (letsubs [{:keys [content from] :as message} [:chats/reply-message]]
     (when message
       [react/view {:style style/reply-message-container}
        [react/view {:style style/reply-message}
@@ -128,9 +128,9 @@
                                           :color           colors/white}]]]])))
 
 (defview input-container []
-  (letsubs [margin               [:chat-input-margin]
-            {:keys [input-text]} [:get-current-chat]
-            result-box           [:get-current-chat-ui-prop :result-box]]
+  (letsubs [margin               [:chats/input-margin]
+            {:keys [input-text]} [:chats/current-chat]
+            result-box           [:chats/current-chat-ui-prop :result-box]]
     (let [single-line-input? (:singleLineInput result-box)]
       [react/view {:style     (style/root margin)
                    :on-layout #(let [h (-> (.-nativeEvent %)

--- a/src/status_im/ui/screens/chat/input/parameter_box.cljs
+++ b/src/status_im/ui/screens/chat/input/parameter_box.cljs
@@ -5,13 +5,13 @@
             [status-im.ui.components.react :as react]))
 
 (defview parameter-box-container []
-  (letsubs [parameter-box [:chat-parameter-box]]
+  (letsubs [parameter-box [:chats/parameter-box]]
     (when parameter-box
       [react/view style/root
        [parameter-box]])))
 
 (defview parameter-box-view []
-  (letsubs [show-box? [:show-parameter-box?]]
+  (letsubs [show-box? [:chats/show-parameter-box?]]
     (when show-box?
       [react/view]
       [expandable/expandable-view {:key :parameter-box}

--- a/src/status_im/ui/screens/chat/input/send_button.cljs
+++ b/src/status_im/ui/screens/chat/input/send_button.cljs
@@ -21,8 +21,8 @@
              (= :offline network-status)))))
 
 (defview send-button-view []
-  (letsubs [{:keys [command-completion]}            [:selected-chat-command]
-            {:keys [input-text seq-arg-input-text]} [:get-current-chat]
+  (letsubs [{:keys [command-completion]}            [:chats/selected-chat-command]
+            {:keys [input-text seq-arg-input-text]} [:chats/current-chat]
             network-status                          [:network-status]
             spin-value                              (animation/create-value 1)]
     {:component-did-update (send-button-view-on-update {:spin-value         spin-value

--- a/src/status_im/ui/screens/chat/input/suggestions.cljs
+++ b/src/status_im/ui/screens/chat/input/suggestions.cljs
@@ -17,7 +17,7 @@
      description]]])
 
 (defview suggestions-view []
-  (letsubs [available-commands [:get-available-commands]]
+  (letsubs [available-commands [:chats/available-commands]]
     [expandable/expandable-view {:key :suggestions}
      [react/view
       [react/scroll-view {:keyboard-should-persist-taps :always

--- a/src/status_im/ui/screens/chat/input/validation_messages.cljs
+++ b/src/status_im/ui/screens/chat/input/validation_messages.cljs
@@ -17,9 +17,9 @@
    markup])
 
 (defview validation-messages-view []
-  (letsubs [chat-input-margin [:chat-input-margin]
-            input-height      [:get-current-chat-ui-prop :input-height]
-            validation-result [:validation-messages]]
+  (letsubs [chat-input-margin [:chats/input-margin]
+            input-height      [:chats/current-chat-ui-prop :input-height]
+            validation-result [:chats/validation-messages]]
     (when validation-result
       (let [message (if (string? validation-result)
                       {:title       (i18n/label :t/error)

--- a/src/status_im/ui/screens/chat/message/message.cljs
+++ b/src/status_im/ui/screens/chat/message/message.cljs
@@ -24,7 +24,7 @@
 
 (defview message-content-command
   [command-message]
-  (letsubs [id->command [:get-id->command]]
+  (letsubs [id->command [:chats/id->command]]
     (if-let [command (commands-receiving/lookup-command-by-ref command-message id->command)]
       (commands/generate-preview command command-message)
       [react/text (str "Unhandled command: " (-> command-message :content :command-path first))])))
@@ -41,14 +41,15 @@
                                                                     (get content :command-ref))
     content]])
 
-; We can't use CSS as nested Text element don't accept margins nor padding
-; so we pad the invisible placeholder with some spaces to avoid having too
-; close to the text.
-(defn timestamp-with-padding [t]
+(defn timestamp-with-padding
+  "We can't use CSS as nested Text element don't accept margins nor padding
+  so we pad the invisible placeholder with some spaces to avoid having too
+  close to the text"
+  [t]
   (str "   " t))
 
 (defview quoted-message [{:keys [from text]} outgoing current-public-key]
-  (letsubs [username [:get-contact-name-by-identity from]]
+  (letsubs [username [:contacts/contact-name-by-identity from]]
     [react/view {:style (style/quoted-message-container outgoing)}
      [react/view {:style style/quoted-message-author-container}
       [vector-icons/icon :icons/reply {:color (if outgoing colors/wild-blue-yonder colors/gray)}]
@@ -131,8 +132,8 @@
     (i18n/message-status-label status)]])
 
 (defview group-message-delivery-status [{:keys [message-id current-public-key user-statuses] :as msg}]
-  (letsubs [{participants :contacts} [:get-current-chat]
-            contacts                 [:get-contacts]]
+  (letsubs [{participants :contacts} [:chats/current-chat]
+            contacts                 [:contacts/contacts]]
     (let [outgoing-status         (or (get-in user-statuses [current-public-key :status]) :sending)
           delivery-statuses       (dissoc user-statuses current-public-key)
           delivery-statuses-count (count delivery-statuses)
@@ -210,7 +211,7 @@
                 [text-status status]))))))))
 
 (defview message-author-name [from message-username]
-  (letsubs [username [:get-contact-name-by-identity from]]
+  (letsubs [username [:contacts/contact-name-by-identity from]]
     [react/text {:style style/message-author-name}
      (chat.utils/format-author from (or username message-username))]))
 

--- a/src/status_im/ui/screens/chat/message/options.cljs
+++ b/src/status_im/ui/screens/chat/message/options.cljs
@@ -18,7 +18,7 @@
                        :key     label}]]]])
 
 (defn view []
-  (let [{:keys [chat-id message-id]} @(re-frame/subscribe [:get-current-chat-ui-prop :message-options])
+  (let [{:keys [chat-id message-id]} @(re-frame/subscribe [:chats/current-chat-ui-prop :message-options])
         close-message-options-fn #(re-frame/dispatch [:chat.ui/set-chat-ui-props {:show-message-options? false}])]
     [bottom-info/overlay {:on-click-outside close-message-options-fn}
      [bottom-info/container (* styles/item-height 2)

--- a/src/status_im/ui/screens/chat/photos.cljs
+++ b/src/status_im/ui/screens/chat/photos.cljs
@@ -23,7 +23,7 @@
    [react/view {:style (style/photo-border size)}]])
 
 (defview member-photo [from]
-  (letsubs [photo-path [:get-photo-path from]]
+  (letsubs [photo-path [:chats/photo-path from]]
     (photo (if (string/blank? photo-path)
              (identicon/identicon from)
              photo-path)

--- a/src/status_im/ui/screens/chat/toolbar_content.cljs
+++ b/src/status_im/ui/screens/chat/toolbar_content.cljs
@@ -63,11 +63,11 @@
 
 (defview toolbar-content-view []
   (letsubs [{:keys [group-chat color online contacts
-                    public? chat-id] :as chat}    [:get-current-chat]
-            chat-name                             [:get-current-chat-name]
-            show-actions?                         [:get-current-chat-ui-prop :show-actions?]
+                    public? chat-id] :as chat}    [:chats/current-chat]
+            chat-name                             [:chats/current-chat-name]
+            show-actions?                         [:chats/current-chat-ui-prop :show-actions?]
             accounts                              [:accounts/accounts]
-            contact                               [:get-current-chat-contact]
+            contact                               [:chats/current-chat-contact]
             sync-state                            [:sync-state]]
     (let [has-subtitle? (or group-chat (not= :done sync-state))]
       [react/view {:style st/toolbar-container}

--- a/src/status_im/ui/screens/chat/views.cljs
+++ b/src/status_im/ui/screens/chat/views.cljs
@@ -26,7 +26,7 @@
             [status-im.ui.components.toolbar.actions :as toolbar.actions]))
 
 (defview add-contact-bar [contact-identity]
-  (letsubs [{:keys [hide-contact?] :as contact} [:get-contact-by-identity]]
+  (letsubs [{:keys [hide-contact?] :as contact} [:contacts/contact-by-identity]]
     (when (and (not hide-contact?)
                (models.contact/can-add-to-contacts? contact))
       [react/view style/add-contact
@@ -48,8 +48,8 @@
                         :options (actions/actions group-chat? chat-id public?)}))
 
 (defview chat-toolbar [public? modal?]
-  (letsubs [name                                  [:get-current-chat-name]
-            {:keys [group-chat chat-id contacts]} [:get-current-chat]]
+  (letsubs [name                                  [:chats/current-chat-name]
+            {:keys [group-chat chat-id contacts]} [:chats/current-chat]]
     [react/view
      [status-bar/status-bar (when modal? {:type :modal-white})]
      [toolbar/platform-agnostic-toolbar {}
@@ -101,7 +101,7 @@
        message-view]]]))
 
 (defview empty-chat-container [{:keys [group-chat chat-id]}]
-  (letsubs [contact [:get-contact-by-identity chat-id]]
+  (letsubs [contact [:contacts/contact-by-identity chat-id]]
     (let [one-to-one (and (not group-chat)
                           (not (:dapp? contact)))]
       [react/view style/empty-chat-container
@@ -115,8 +115,8 @@
           (i18n/label :t/empty-chat-description))]])))
 
 (defview messages-view [group-chat modal?]
-  (letsubs [messages           [:get-current-chat-messages-stream]
-            chat               [:get-current-chat]
+  (letsubs [messages           [:chats/current-chat-messages-stream]
+            chat               [:chats/current-chat]
             current-public-key [:account/public-key]]
     {:component-did-mount #(re-frame/dispatch [:chat.ui/set-chat-ui-props {:messages-focused? true
                                                                            :input-focused? false}])}
@@ -135,10 +135,10 @@
                        :keyboardShouldPersistTaps :handled}])))
 
 (defview chat-root [modal?]
-  (letsubs [{:keys [group-chat public?]} [:get-current-chat]
-            show-bottom-info? [:get-current-chat-ui-prop :show-bottom-info?]
-            show-message-options? [:get-current-chat-ui-prop :show-message-options?]
-            current-view      [:get :view-id]]
+  (letsubs [{:keys [group-chat public?]} [:chats/current-chat]
+            show-bottom-info?            [:chats/current-chat-ui-prop :show-bottom-info?]
+            show-message-options?        [:chats/current-chat-ui-prop :show-message-options?]
+            current-view                 [:get :view-id]]
     ;; this scroll-view is a hack that allows us to use on-blur and on-focus on Android
     ;; more details here: https://github.com/facebook/react-native/issues/11071
     [react/scroll-view {:scroll-enabled               false

--- a/src/status_im/ui/screens/desktop/main/add_new/views.cljs
+++ b/src/status_im/ui/screens/desktop/main/add_new/views.cljs
@@ -39,7 +39,7 @@
 
 (views/defview new-contact []
   (views/letsubs [new-contact-identity [:get :contacts/new-identity]
-                  contacts             [:all-added-people-contacts]
+                  contacts             [:contacts/all-added-people-contacts]
                   chat-error           [:new-identity-error]
                   topic                [:get :public-group-topic]
                   topic-error          [:public-chat.new/topic-error-message]]

--- a/src/status_im/ui/screens/desktop/main/chat/views.cljs
+++ b/src/status_im/ui/screens/desktop/main/chat/views.cljs
@@ -27,8 +27,8 @@
 
 (views/defview toolbar-chat-view [{:keys [chat-id color public-key public? group-chat]
                                    :as current-chat}]
-  (views/letsubs [chat-name         [:get-current-chat-name]
-                  {:keys [pending? public-key photo-path]} [:get-current-chat-contact]]
+  (views/letsubs [chat-name         [:chats/current-chat-name]
+                  {:keys [pending? public-key photo-path]} [:chats/current-chat-contact]]
     [react/view {:style styles/toolbar-chat-view}
      [react/view {:style {:flex-direction :row
                           :flex 1}}
@@ -69,14 +69,14 @@
        (i18n/label :t/delete-chat)]]]))
 
 (views/defview message-author-name [{:keys [from]}]
-  (views/letsubs [incoming-name   [:get-contact-name-by-identity from]]
+  (views/letsubs [incoming-name   [:contacts/contact-name-by-identity from]]
     (let [name (chat-utils/format-author from incoming-name)]
       [react/touchable-highlight {:on-press #(re-frame/dispatch [:show-contact-dialog from name (boolean incoming-name)])}
        [react/text {:style styles/author :font :medium} name]])))
 
 (views/defview member-photo [from]
   (views/letsubs [current-public-key [:account/public-key]
-                  photo-path [:get-photo-path from]]
+                  photo-path [:chats/photo-path from]]
     [react/view {:style {:width 40 :margin-horizontal 16}}
      [react/view {:style {:position :absolute}}
       [react/touchable-highlight {:on-press #(when-not (= current-public-key from)
@@ -88,7 +88,7 @@
                       :style  styles/photo-style}]]]]]))
 
 (views/defview quoted-message [{:keys [from text]} outgoing current-public-key]
-  (views/letsubs [username [:get-contact-name-by-identity from]]
+  (views/letsubs [username [:contacts/contact-name-by-identity from]]
     [react/view {:style styles/quoted-message-container}
      [react/view {:style styles/quoted-message-author-container}
       [icons/icon :icons/reply {:style           (styles/reply-icon outgoing)
@@ -175,12 +175,12 @@
 (defmethod message :default
   [text me? {:keys [message-id chat-id message-status user-statuses from
                     current-public-key content-type outgoing type value] :as message}]
-  (when (nil? message-id)
-    (log/debug "nil?" message))
   (if (= type :datemark)
     ^{:key (str "datemark" message-id)}
     [message.datemark/chat-datemark value]
     (when (contains? constants/desktop-content-types content-type)
+      (when (nil? message-id)
+        (log/debug "nil?" message))
       (reagent.core/create-class
        {:component-did-mount
         #(when (and message-id
@@ -206,7 +206,7 @@
     (reset! messages-to-load next-count)))
 
 (views/defview messages-view [{:keys [chat-id group-chat]}]
-  (views/letsubs [messages [:get-current-chat-messages-stream]
+  (views/letsubs [messages [:chats/current-chat-messages-stream]
                   current-public-key [:account/public-key]
                   messages-to-load (reagent/atom load-step)
                   chat-id* (reagent/atom nil)]
@@ -243,7 +243,7 @@
        [connectivity/error-view]])))
 
 (views/defview send-button [inp-ref network-status]
-  (views/letsubs [{:keys [input-text]} [:get-current-chat]]
+  (views/letsubs [{:keys [input-text]} [:chats/current-chat]]
     (let [empty? (= "" input-text)
           offline? (= :offline network-status)
           inactive? (or empty? offline?)]
@@ -258,7 +258,7 @@
         [icons/icon :icons/arrow-left {:style (styles/send-icon-arrow inactive?)}]]])))
 
 (views/defview reply-message [from message-text]
-  (views/letsubs [username           [:get-contact-name-by-identity from]
+  (views/letsubs [username           [:contacts/contact-name-by-identity from]
                   current-public-key [:account/public-key]]
     [react/view {:style styles/reply-content-container}
      [react/text {:style styles/reply-content-author}
@@ -266,14 +266,14 @@
      [react/text {:style styles/reply-content-message} message-text]]))
 
 (views/defview reply-member-photo [from]
-  (views/letsubs [photo-path [:get-photo-path from]]
+  (views/letsubs [photo-path [:chats/photo-path from]]
     [react/image {:source {:uri (if (string/blank? photo-path)
                                   (identicon/identicon from)
                                   photo-path)}
                   :style  styles/reply-photo-style}]))
 
 (views/defview reply-message-view []
-  (views/letsubs [{:keys [content from] :as message} [:get-reply-message]]
+  (views/letsubs [{:keys [content from] :as message} [:chats/reply-message]]
     (when message
       [react/view {:style styles/reply-wrapper}
        [react/view {:style styles/reply-container}
@@ -320,7 +320,7 @@
        [send-button inp-ref network-status]])))
 
 (views/defview chat-view []
-  (views/letsubs [{:keys [input-text chat-id] :as current-chat} [:get-current-chat]]
+  (views/letsubs [{:keys [input-text chat-id] :as current-chat} [:chats/current-chat]]
     [react/view {:style styles/chat-view}
      [toolbar-chat-view current-chat]
      [react/view {:style styles/separator}]
@@ -330,8 +330,8 @@
      [chat-text-input chat-id input-text]]))
 
 (views/defview chat-profile []
-  (views/letsubs [identity        [:get-current-contact-identity]
-                  maybe-contact   [:get-current-contact]]
+  (views/letsubs [identity        [:contacts/current-contact-identity]
+                  maybe-contact   [:contacts/current-contact]]
     (let [contact (or maybe-contact (contact.db/public-key->new-contact identity))
           {:keys [pending? public-key]} contact]
       [react/view {:style styles/chat-profile-body}

--- a/src/status_im/ui/screens/desktop/main/tabs/home/views.cljs
+++ b/src/status_im/ui/screens/desktop/main/tabs/home/views.cljs
@@ -13,18 +13,18 @@
             [status-im.constants :as constants]))
 
 (views/defview unviewed-indicator [chat-id]
-  (let [unviewed-messages-count (re-frame/subscribe [:unviewed-messages-count chat-id])]
+  (let [unviewed-messages-count (re-frame/subscribe [:chats/unviewed-messages-count chat-id])]
     (when (pos? @unviewed-messages-count)
       [react/view
        [react/text {:font  :medium}
         @unviewed-messages-count]])))
 
 (views/defview chat-list-item-inner-view [{:keys [chat-id name group-chat color public? public-key] :as chat-item}]
-  (letsubs [photo-path                         [:get-chat-photo chat-id]
-            unviewed-messages-count            [:unviewed-messages-count chat-id]
-            chat-name                          [:get-chat-name chat-id]
-            current-chat-id                    [:get-current-chat-id]
-            {:keys [content] :as last-message} [:get-last-message chat-id]]
+  (letsubs [photo-path                         [:contacts/chat-photo chat-id]
+            unviewed-messages-count            [:chats/unviewed-messages-count chat-id]
+            chat-name                          [:chats/chat-name chat-id]
+            current-chat-id                    [:chats/current-chat-id]
+            {:keys [content] :as last-message} [:chats/last-message chat-id]]
     (let [name (or chat-name
                    (gfycat/generate-gfy public-key))
           [unviewed-messages-label large?] (if (< 9 unviewed-messages-count)

--- a/src/status_im/ui/screens/group/add_contacts/views.cljs
+++ b/src/status_im/ui/screens/group/add_contacts/views.cljs
@@ -63,7 +63,7 @@
 
 ;; Start group chat
 (defview contact-toggle-list []
-  (letsubs [contacts                [:all-added-people-contacts]
+  (letsubs [contacts                [:contacts/all-added-people-contacts]
             selected-contacts-count [:selected-contacts-count]]
     [react/keyboard-avoiding-view {:style styles/group-container}
      [status-bar]
@@ -77,8 +77,8 @@
 
 ;; Add participants to existing group chat
 (defview add-participants-toggle-list []
-  (letsubs [contacts                [:get-all-contacts-not-in-current-chat]
-            {:keys [name]} [:get-current-chat]
+  (letsubs [contacts                [:contacts/all-contacts-not-in-current-chat]
+            {:keys [name]} [:chats/current-chat]
             selected-contacts-count [:selected-participants-count]]
     [react/keyboard-avoiding-view {:style styles/group-container}
      [status-bar]

--- a/src/status_im/ui/screens/group/subs.cljs
+++ b/src/status_im/ui/screens/group/subs.cljs
@@ -16,7 +16,7 @@
 (reg-sub
  :selected-contacts-count
  :<- [:get :group/selected-contacts]
- :<- [:get-contacts]
+ :<- [:contacts/contacts]
  (fn [[selected-contacts contacts]]
    (count (filter-selected-contacts selected-contacts contacts))))
 

--- a/src/status_im/ui/screens/home/subs.cljs
+++ b/src/status_im/ui/screens/home/subs.cljs
@@ -3,7 +3,7 @@
 
 (re-frame/reg-sub
  :home-items
- :<- [:get-active-chats]
+ :<- [:chats/active-chats]
  :<- [:browser/browsers]
  (fn [[chats browsers]]
    (sort-by #(-> % second :timestamp) > (merge chats browsers))))

--- a/src/status_im/ui/screens/home/views/inner_item.cljs
+++ b/src/status_im/ui/screens/home/views/inner_item.cljs
@@ -22,7 +22,7 @@
             [status-im.browser.core :as browser]))
 
 (defview command-short-preview [message]
-  (letsubs [id->command [:get-id->command]]
+  (letsubs [id->command [:chats/id->command]]
     (when-let [command (commands-receiving/lookup-command-by-ref message id->command)]
       (commands/generate-short-preview command message))))
 
@@ -63,7 +63,7 @@
      (time/to-short-str timestamp)]))
 
 (defview unviewed-indicator [chat-id]
-  (letsubs [unviewed-messages-count [:unviewed-messages-count chat-id]]
+  (letsubs [unviewed-messages-count [:chats/unviewed-messages-count chat-id]]
     (when (pos? unviewed-messages-count)
       [components.common/counter {:size                22
                                   :accessibility-label :unread-messages-count-text}
@@ -89,8 +89,8 @@
                                                  group-chat public?
                                                  public-key
                                                  timestamp]}]
-  (letsubs [last-message [:get-last-message chat-id]
-            chat-name    [:get-chat-name chat-id]]
+  (letsubs [last-message [:chats/last-message chat-id]
+            chat-name    [:chats/chat-name chat-id]]
     (let [truncated-chat-name (utils/truncate-str chat-name 30)]
       [react/touchable-highlight {:on-press #(re-frame/dispatch [:chat.ui/navigate-to-chat chat-id])}
        [react/view styles/chat-container

--- a/src/status_im/ui/screens/main_tabs/views.cljs
+++ b/src/status_im/ui/screens/main_tabs/views.cljs
@@ -17,7 +17,7 @@
     :content             {:title         (i18n/label :t/home)
                           :icon-inactive :icons/home
                           :icon-active   :icons/home-active}
-    :count-subscription  :get-chats-unread-messages-number
+    :count-subscription  :chats/unread-messages-number
     :accessibility-label :home-tab-button}
    {:view-id             :wallet
     :content             {:title         (i18n/label :t/wallet)

--- a/src/status_im/ui/screens/profile/contact/views.cljs
+++ b/src/status_im/ui/screens/profile/contact/views.cljs
@@ -62,8 +62,8 @@
    [profile-info-contact-code-item public-key]])
 
 (defview profile []
-  (letsubs [identity        [:get-current-contact-identity]
-            maybe-contact   [:get-current-contact]]
+  (letsubs [identity        [:contacts/current-contact-identity]
+            maybe-contact   [:contacts/current-contact]]
     (let [contact (or maybe-contact (contact.db/public-key->new-contact identity))]
       [react/view profile.components.styles/profile
        [status-bar/status-bar]

--- a/src/status_im/ui/screens/profile/group_chat/views.cljs
+++ b/src/status_im/ui/screens/profile/group_chat/views.cljs
@@ -72,7 +72,7 @@
                             #(re-frame/dispatch [(if platform/desktop? :show-profile-desktop :chat.ui/show-profile) public-key]))}]])
 
 (defview chat-group-members-view [chat-id admin? current-user-identity]
-  (letsubs [members [:get-current-chat-contacts]]
+  (letsubs [members [:contacts/current-chat-contacts]]
     (when (seq members)
       [react/view
        [list/flat-list {:data      members
@@ -86,7 +86,7 @@
    [chat-group-members-view chat-id admin? current-user-identity]])
 
 (defview group-chat-profile []
-  (letsubs [{:keys [admins chat-id] :as current-chat} [:get-current-chat]
+  (letsubs [{:keys [admins chat-id] :as current-chat} [:chats/current-chat]
             editing?     [:get :group-chat-profile/editing?]
             changed-chat [:get :group-chat-profile/profile]
             current-pk   [:account/public-key]]

--- a/src/status_im/ui/screens/wallet/components/views.cljs
+++ b/src/status_im/ui/screens/wallet/components/views.cljs
@@ -184,7 +184,7 @@
          (i18n/label :t/specify-recipient)))])
 
 (views/defview recipient-contact [address name request?]
-  (views/letsubs [contact [:get-contact-by-address address]]
+  (views/letsubs [contact [:contacts/contact-by-address address]]
     (let [address? (and (not (nil? address)) (not= address ""))]
       [react/view styles/recipient-container
        [react/view styles/recipient-icon
@@ -211,7 +211,7 @@
       (ethereum/normalized-address (:address contact))]]]])
 
 (views/defview recent-recipients []
-  (views/letsubs [contacts [:all-added-people-contacts]]
+  (views/letsubs [contacts [:contacts/all-added-people-contacts]]
     [simple-screen
      [toolbar (i18n/label :t/recipient)]
      [react/view styles/recent-recipients

--- a/src/status_im/ui/screens/wallet/transaction_sent/views.cljs
+++ b/src/status_im/ui/screens/wallet/transaction_sent/views.cljs
@@ -13,7 +13,7 @@
             [status-im.ui.components.colors :as colors]))
 
 (defview transaction-sent [& [modal?]]
-  (letsubs [chat-id [:get-current-chat-id]]
+  (letsubs [chat-id [:chats/current-chat-id]]
     [react/view wallet.styles/wallet-modal-container
      [status-bar/status-bar {:type (if modal? :modal-wallet :transparent)}]
      [react/view styles/transaction-sent-container

--- a/src/status_im/ui/screens/wallet/transactions/subs.cljs
+++ b/src/status_im/ui/screens/wallet/transactions/subs.cljs
@@ -27,7 +27,7 @@
 
 (reg-sub :wallet.transactions/transactions
          :<- [:wallet]
-         :<- [:get-contacts-by-address]
+         :<- [:contacts/contacts-by-address]
          (fn [[wallet contacts]]
            (reduce (fn [acc [hash transaction]]
                      (assoc acc hash (enrich-transaction transaction contacts)))


### PR DESCRIPTION
In order to make it easier to work with subscription and understand their scope, this PR does
the following for chat and contact subs:

- remove unused subscription
- aliased namespace keywords are used for local subs that used for caching
- synthetic :chat namespace is used for subs used elsewhere

This PR does not:

- remove subscriptions that don't make sense
- try to refactor subscriptions to make them less redundant

status: ready <!-- Can be ready or wip -->
