### PR TITLE
bug #6768 - updating enabled tokens before navigation to wallet

### DIFF
--- a/src/status_im/ui/screens/wallet/navigation.cljs
+++ b/src/status_im/ui/screens/wallet/navigation.cljs
@@ -6,11 +6,15 @@
 
 (defmethod navigation/preload-data! :wallet
   [db _]
+  ;;TODO(goranjovic) - get rid of this preload hook completely
+  (re-frame/dispatch [:wallet.ui/pull-to-refresh])
   (re-frame/dispatch [:update-wallet])
   (assoc-in db [:wallet :current-tab] 0))
 
 (defmethod navigation/preload-data! :wallet-modal
   [db _]
+  ;;TODO(goranjovic) - get rid of this preload hook completely
+  (re-frame/dispatch [:wallet.ui/pull-to-refresh])
   (re-frame/dispatch [:update-wallet])
   (re-frame/dispatch [:update-transactions])
   (assoc-in db [:wallet :modal-history?] false))


### PR DESCRIPTION
fixes #6768

### Summary:

Fixes the issue with invisible tokens after upgrade by refreshing them before navigation to wallet.

### Steps to test:
see #6768 

status: ready 