### PR TITLE
[fix] usernames in bold on Linux

### DIFF
--- a/src/status_im/ui/screens/desktop/main/chat/styles.cljs
+++ b/src/status_im/ui/screens/desktop/main/chat/styles.cljs
@@ -38,7 +38,8 @@
 
 (def author
   {:color         colors/black
-   :font-size     14})
+   :font-size     14
+   :font-weight   :bold})
 
 (defn chat-box [height]
   {:height            (+ height (* 2 chat-vertical-padding))


### PR DESCRIPTION
Show usernames in bold on Linux

# Steps to test
- check that usernames in chat are bold on Linux

status: ready <!-- Can be ready or wip -->
