### PR TITLE
[slow sign in] faster unviewed messages

### DIFF
--- a/src/status_im/chat/models.cljs
+++ b/src/status_im/chat/models.cljs
@@ -67,12 +67,14 @@
   "Adds new public group chat to db & realm"
   [cofx topic]
   (upsert-chat cofx
-               {:chat-id          topic
-                :is-active        true
-                :name             topic
-                :group-chat       true
-                :contacts         #{}
-                :public?          true}))
+               {:chat-id                      topic
+                :is-active                    true
+                :name                         topic
+                :group-chat                   true
+                :contacts                     #{}
+                :public?                      true
+                :unviewed-messages-count      0
+                :loaded-unviewed-messages-ids #{}}))
 
 (fx/defn add-group-chat
   "Adds new private group chat to db & realm"
@@ -100,8 +102,7 @@
     {:db            (update-in db [:chats chat-id] merge
                                {:messages           empty-message-map
                                 :message-groups         {}
-                                :unviewed-messages      #{}
-                                :not-loaded-message-ids #{}
+                                :unviewed-messages-count 0
                                 :deleted-at-clock-value last-message-clock-value})
      :data-store/tx [(chats-store/clear-history-tx chat-id last-message-clock-value)
                      (messages-store/delete-messages-tx chat-id)]}))
@@ -135,7 +136,7 @@
     (protocol/send (protocol/map->MessagesSeen {:message-ids message-ids}) chat-id cofx)))
 
 (defn- unread-messages-number [chats]
-  (apply + (map (comp count :unviewed-messages) chats)))
+  (apply + (map :unviewed-messages-count chats)))
 
 (fx/defn update-dock-badge-label
   [cofx]
@@ -151,33 +152,52 @@
                 :else nil)]
     {:set-dock-badge-label label}))
 
+(defn subtract-seen-messages
+  [old-count new-seen-messages-ids]
+  (max 0 (- old-count (count new-seen-messages-ids))))
+
+(fx/defn update-chats-unviewed-messages-count
+  [{:keys [db] :as cofx} {:keys [chat-id new-loaded-unviewed-messages-ids]}]
+  (let [{:keys [loaded-unviewed-messages-ids unviewed-messages-count]}
+        (get-in db [:chats chat-id])
+
+        unviewed-messages-ids (if (seq new-loaded-unviewed-messages-ids)
+                                new-loaded-unviewed-messages-ids
+                                loaded-unviewed-messages-ids)]
+    (upsert-chat
+     cofx
+     {:chat-id                      chat-id
+      :unviewed-messages-count      (subtract-seen-messages
+                                     unviewed-messages-count
+                                     unviewed-messages-ids)
+      :loaded-unviewed-messages-ids #{}})))
+
 ;; TODO (janherich) - ressurect `constants/system` messages for group chats in the future
 (fx/defn mark-messages-seen
   "Marks all unviewed loaded messages as seen in particular chat"
   [{:keys [db] :as cofx} chat-id]
-  (when-let [all-unviewed-ids (seq (get-in db [:chats chat-id :unviewed-messages]))]
-    (let [me                  (accounts.db/current-public-key cofx)
-          updated-statuses    (keep (fn [message-id]
-                                      (some-> db
-                                              (get-in [:chats chat-id :message-statuses
-                                                       message-id me])
-                                              (assoc :status :seen)))
-                                    all-unviewed-ids)
-          loaded-unviewed-ids (map :message-id updated-statuses)]
-      (when (seq loaded-unviewed-ids)
-        (fx/merge cofx
-                  {:db (-> (reduce (fn [acc {:keys [message-id status]}]
-                                     (assoc-in acc [:chats chat-id :message-statuses
-                                                    message-id me :status]
-                                               status))
-                                   db
-                                   updated-statuses)
-                           (update-in [:chats chat-id :unviewed-messages]
-                                      #(apply disj % loaded-unviewed-ids)))
-                   :data-store/tx [(user-statuses-store/save-statuses-tx updated-statuses)]}
-                  (send-messages-seen chat-id loaded-unviewed-ids)
-                  (when platform/desktop?
-                    (update-dock-badge-label)))))))
+  (let [public-key          (accounts.db/current-public-key cofx)
+        loaded-unviewed-ids (get-in db [:chats chat-id :loaded-unviewed-messages-ids])
+        updated-statuses    (map (fn [message-id]
+                                   {:chat-id    chat-id
+                                    :message-id message-id
+                                    :status-id  (str chat-id "-" message-id)
+                                    :public-key public-key
+                                    :status     :seen})
+                                 loaded-unviewed-ids)]
+    (when (seq loaded-unviewed-ids)
+      (fx/merge cofx
+                {:db            (reduce (fn [acc {:keys [message-id status]}]
+                                          (assoc-in acc [:chats chat-id :message-statuses
+                                                         message-id public-key :status]
+                                                    status))
+                                        db
+                                        updated-statuses)
+                 :data-store/tx [(user-statuses-store/save-statuses-tx updated-statuses)]}
+                (update-chats-unviewed-messages-count {:chat-id chat-id})
+                (send-messages-seen chat-id loaded-unviewed-ids)
+                (when platform/desktop?
+                  (update-dock-badge-label))))))
 
 (fx/defn preload-chat-data
   "Takes chat-id and coeffects map, returns effects necessary when navigating to chat"

--- a/src/status_im/chat/specs.cljs
+++ b/src/status_im/chat/specs.cljs
@@ -16,7 +16,6 @@
 (s/def :chat/messages (s/nilable map?))                           ; messages indexed by message-id
 (s/def :chat/message-groups (s/nilable map?))                     ; grouped/sorted messages
 (s/def :chat/message-statuses (s/nilable map?))                   ; message/user statuses indexed by two level index
-(s/def :chat/not-loaded-message-ids (s/nilable set?))             ; set of message-ids not yet fully loaded from persisted state
 (s/def :chat/referenced-messages (s/nilable map?))                ; map of messages indexed by message-id which are not displayed directly, but referenced by other messages
 (s/def :chat/last-clock-value (s/nilable number?))                ; last logical clock value of messages in chat
 (s/def :chat/loaded-chats (s/nilable seq?))

--- a/src/status_im/chat/subs.cljs
+++ b/src/status_im/chat/subs.cljs
@@ -209,8 +209,8 @@
  :chats/unviewed-messages-count
  (fn [[_ chat-id]]
    (re-frame/subscribe [:chats/chat chat-id]))
- (fn [{:keys [unviewed-messages]}]
-   (count unviewed-messages)))
+ (fn [{:keys [unviewed-messages-count]}]
+   unviewed-messages-count))
 
 (re-frame/reg-sub
  :chats/photo-path
@@ -237,7 +237,7 @@
  :chats/unread-messages-number
  :<- [:chats/active-chats]
  (fn [chats _]
-   (apply + (map (comp count :unviewed-messages) (vals chats)))))
+   (apply + (map :unviewed-messages-count (vals chats)))))
 
 (re-frame/reg-sub
  :chats/transaction-confirmed?

--- a/src/status_im/data_store/messages.cljs
+++ b/src/status_im/data_store/messages.cljs
@@ -42,24 +42,6 @@
 (defn- sha3 [s]
   (.sha3 dependencies/Web3.prototype s))
 
-(defn- get-unviewed-messages
-  [public-key]
-  (-> @core/account-realm
-      (core/get-by-fields
-       :user-status
-       :and {:public-key public-key
-             :status     "received"})
-      (.reduce (fn [acc msg _ _]
-                 (let [chat-id (aget msg "chat-id")
-                       message-id (aget msg "message-id")]
-                   (update acc chat-id (fnil conj #{}) message-id)))
-               {})))
-
-(re-frame/reg-cofx
- :data-store/get-unviewed-messages
- (fn [cofx _]
-   (assoc cofx :get-stored-unviewed-messages get-unviewed-messages)))
-
 (re-frame/reg-cofx
  :data-store/get-referenced-messages
  (fn [cofx _]

--- a/src/status_im/data_store/realm/schemas/account/chat.cljs
+++ b/src/status_im/data_store/realm/schemas/account/chat.cljs
@@ -189,3 +189,37 @@
                       :public?                {:type    :bool
                                                :default false}
                       :tags                   {:type     "string[]"}}})
+
+(def v9 {:name       :chat
+         :primaryKey :chat-id
+         :properties {:chat-id                 :string
+                      :name                    :string
+                      :color                   {:type    :string
+                                                :default colors/default-chat-color}
+                      :group-chat              {:type    :bool
+                                                :indexed true}
+                      :is-active               :bool
+                      :timestamp               :int
+                      :contacts                {:type "string[]"}
+                      :admins                  {:type "string[]"}
+                      :membership-updates      {:type       :list
+                                                :objectType :membership-update}
+                      :removed-at              {:type     :int
+                                                :optional true}
+                      :removed-from-at         {:type     :int
+                                                :optional true}
+                      :deleted-at-clock-value  {:type     :int
+                                                :optional true}
+                      :added-to-at             {:type     :int
+                                                :optional true}
+                      :updated-at              {:type     :int
+                                                :optional true}
+                      :message-overhead        {:type    :int
+                                                :default 0}
+                      :debug?                  {:type    :bool
+                                                :default false}
+                      :public?                 {:type    :bool
+                                                :default false}
+                      :tags                    {:type "string[]"}
+                      :unviewed-messages-count {:type    :int
+                                                :default 0}}})

--- a/src/status_im/data_store/realm/schemas/account/core.cljs
+++ b/src/status_im/data_store/realm/schemas/account/core.cljs
@@ -265,6 +265,19 @@
           browser/v8
           dapp-permissions/v9])
 
+(def v26 [chat/v9
+          transport/v7
+          contact/v3
+          message/v7
+          mailserver/v11
+          mailserver-topic/v1
+          user-status/v2
+          membership-update/v1
+          installation/v2
+          local-storage/v1
+          browser/v8
+          dapp-permissions/v9])
+
 ;; put schemas ordered by version
 (def schemas [{:schema        v1
                :schemaVersion 1
@@ -341,6 +354,6 @@
               {:schema        v25
                :schemaVersion 25
                :migration     migrations/v25}
-              {:schema        v25
+              {:schema        v26
                :schemaVersion 26
                :migration     migrations/v26}])

--- a/src/status_im/data_store/realm/schemas/account/migrations.cljs
+++ b/src/status_im/data_store/realm/schemas/account/migrations.cljs
@@ -229,4 +229,14 @@
                "user-status"
                new-status-id)
             (.delete new-realm user-status)
-            (aset user-status "status-id" new-status-id)))))))
+            (aset user-status "status-id" new-status-id))))))
+  (let [chats (.objects new-realm "chat")]
+    (dotimes [i (.-length chats)]
+      (let [chat                (aget chats i)
+            chat-id             (aget chat "chat-id")
+            user-statuses-count (-> (.objects new-realm "user-status")
+                                    (.filtered (str "chat-id=\"" chat-id "\""
+                                                    " and "
+                                                    "status = \"received\""))
+                                    (.-length))]
+        (aset chat "unviewed-messages-count" user-statuses-count)))))

--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -87,8 +87,7 @@
 
 (handlers/register-handler-fx
  :load-chats-messages
- [(re-frame/inject-cofx :data-store/get-unviewed-messages)
-  (re-frame/inject-cofx :data-store/get-messages)
+ [(re-frame/inject-cofx :data-store/get-messages)
   (re-frame/inject-cofx :data-store/get-referenced-messages)
   (re-frame/inject-cofx :data-store/get-user-statuses)]
  (fn [cofx]

--- a/src/status_im/ui/screens/db.cljs
+++ b/src/status_im/ui/screens/db.cljs
@@ -295,7 +295,6 @@
                                    :chat/messages
                                    :chat/message-groups
                                    :chat/message-statuses
-                                   :chat/not-loaded-message-ids
                                    :chat/referenced-messages
                                    :chat/last-clock-value
                                    :chat/loaded-chats

--- a/src/status_im/ui/screens/desktop/main/tabs/home/views.cljs
+++ b/src/status_im/ui/screens/desktop/main/tabs/home/views.cljs
@@ -14,19 +14,12 @@
             [status-im.utils.utils :as utils]
             [status-im.ui.components.react :as components]))
 
-(views/defview unviewed-indicator [chat-id]
-  (let [unviewed-messages-count (re-frame/subscribe [:chats/unviewed-messages-count chat-id])]
-    (when (pos? @unviewed-messages-count)
-      [react/view
-       [react/text {:font  :medium}
-        @unviewed-messages-count]])))
-
 (views/defview chat-list-item-inner-view [{:keys [chat-id name group-chat color public? public-key] :as chat-item}]
-  (letsubs [photo-path                         [:contacts/chat-photo chat-id]
-            unviewed-messages-count            [:chats/unviewed-messages-count chat-id]
-            chat-name                          [:chats/chat-name chat-id]
-            current-chat-id                    [:chats/current-chat-id]
-            {:keys [content] :as last-message} [:chats/last-message chat-id]]
+  (views/letsubs [photo-path              [:contacts/chat-photo chat-id]
+                  unviewed-messages-count [:chats/unviewed-messages-count chat-id]
+                  chat-name               [:chats/chat-name chat-id]
+                  current-chat-id         [:chats/current-chat-id]
+                  {:keys [content] :as last-message} [:chats/last-message chat-id]]
     (let [name (or chat-name
                    (gfycat/generate-gfy public-key))
           [unviewed-messages-label large?] (if (< 9 unviewed-messages-count)

--- a/test/cljs/status_im/test/chat/models/message.cljs
+++ b/test/cljs/status_im/test/chat/models/message.cljs
@@ -17,12 +17,6 @@
                                     :from "a"
                                     :clock-value 1
                                     :chat-id "a"}))))
-  (testing "it returns false when it's already in the not-loaded-message-ids"
-    (is (not (message/add-to-chat? {:db {:chats {"a" {:not-loaded-message-ids #{"message-id"}}}}}
-                                   {:message-id "message-id"
-                                    :from "a"
-                                    :clock-value 1
-                                    :chat-id "a"}))))
   (testing "it returns false when the clock-value is the same as the deleted-clock-value in chat"
     (is (not (message/add-to-chat? {:db {:chats {"a" {:deleted-at-clock-value 1}}}}
                                    {:message-id "message-id"


### PR DESCRIPTION
fixes
> B: all messages-statuses for unviewed messages are fetched/iterated. This data is used for “unviewed messages” counters.

> Denormalize unviewed message counter, store it along with chat. B

from https://notes.status.im/VxmgW_rJQkqHsPoqGiMGxQ

# What's the difference?
- How it worked.
  We fetched ALL `user-statuses` with `status=received` (which mean that message hasn't been seen), iterated them, grouped by chat and then stored `message-ids` of these `user-statuses` in chat's `:unviewed-messages` key.
  
 - How it works now.
 `:unviewed-messages-count` (probably should be `counter`) was added to chat entity. That means that we don't need to iterate over `user-statuses` in order to get this data. In the rest of it the difference is only that we need to update chat's db record each time when uviewed messages are seen.

status: ready <!-- Can be ready or wip -->
