### PR TITLE
better protect transaction history polling from errors

### DIFF
--- a/test/cljs/status_im/test/wallet/transactions.cljs
+++ b/test/cljs/status_im/test/wallet/transactions.cljs
@@ -104,7 +104,7 @@
                    (swap! state inc)
                    (throw (ex-info "Throwing this on purpose in error-in-job test" {})))
                  10
-                 10))
+                 100))
         (async test-done
                (js/setTimeout
                 (fn []


### PR DESCRIPTION
### Summary:

Simple update to make sure the transaction history loop doesn't stop polling if an error is throw.

This PR is not in response to any reported problem its just something @cammellos pointed out to me when we were looking at the code.

### Review notes (optional):

Go blocks parse try catch blocks and turn them into event
dispatches. This captures the original intent of the code to catch
errors and terminate the current async worker execution.

status: ready
