### PR TITLE
upgrade requests for vuln report

### DIFF
--- a/test/appium/requirements.txt
+++ b/test/appium/requirements.txt
@@ -37,7 +37,7 @@ python-dateutil==2.7.3
 pytz==2018.4
 PyYAML==3.12
 repoze.lru==0.7
-requests==2.18.3
+requests==2.20.1
 rlp==1.0.1
 sauceclient==1.0.0
 scrypt==0.8.6

--- a/test/desktop_sikuli/requirements.txt
+++ b/test/desktop_sikuli/requirements.txt
@@ -10,7 +10,7 @@ pathlib2==2.3.2
 pluggy==0.7.1
 py==1.6.0
 pytest==2.7.2
-requests==2.19.1
+requests==2.20.1
 scandir==1.9.0
 six==1.11.0
 urllib3==1.23


### PR DESCRIPTION
fixes #6807 

### Summary:

GitHub gives vuln report of requests < 19.1.0

status: ready 
