### PR TITLE
[TESTS] Fiat value is calculated on recipient side

### DIFF
--- a/test/appium/tests/users.py
+++ b/test/appium/tests/users.py
@@ -208,6 +208,13 @@ transaction_senders['X']['address'] = "0xc9cf2ff3ca98a91f2e3dfc35a13cf8425ecaf08
 transaction_senders['X']['public_key'] = "0x04a712634920a012cd45d63a23832d494518d992b77d3b8aa81131a302657193e2d174e3a" \
                                          "ffda80dad81bc3bf3edaf84334437cfecfb248f37fdcb1d882773cf08"
 
+transaction_senders['Y'] = dict()
+transaction_senders['Y']['passphrase'] = "slight thunder cup divorce hawk paper blush memory shaft extend laundry bone"
+transaction_senders['Y']['username'] = "Lighthearted Empty Longspur"
+transaction_senders['Y']['address'] = "0x2a5ed44a7092404ae08369ffde6e54ce47e3761c"
+transaction_senders['Y']['public_key'] = "0x04a6515d7f2a1659948429487ba3b747cc1860c29e304a5482492226ab65056c1c6ba6a" \
+                                         "5def258316d22882e43dd2b1b98b0f8d2488a7a5a967ac6d86c2a1088e2"
+
 transaction_recipients = dict()
 
 transaction_recipients['A'] = dict()
@@ -263,3 +270,10 @@ transaction_recipients['H']['username'] = "Glum Tricky Indianskimmer"
 transaction_recipients['H']['address'] = "0xe9676a57a28800d83301d9d3f9c77fd2e933609c"
 transaction_recipients['H']['public_key'] = "0x0400b4d2cb69c49d147af128a596a2160fb7ac1d2abc54156b26598feb5630e8e7529" \
                                             "f5a8363a73d6a9df86fdda87c095a9462aca8b4cbf1f331152a9a22cdb35d"
+
+transaction_recipients['I'] = dict()
+transaction_recipients['I']['passphrase'] = "engine equal wisdom saddle icon spring express limit surprise salute unique rose"
+transaction_recipients['I']['username'] = "Sharp Sour Greathornedowl"
+transaction_recipients['I']['address'] = "0x4e6c60f344b13d730682f0a6d8ae1255c75e730e"
+transaction_recipients['I']['public_key'] = "0x049d6fe0c874d11ddd92f72ac75659703a7b58211b934fc22f0c7eae835b71651c8" \
+                                            "3ae5e4fd688f1c898d39a657ea08a39d05d20a830bbf7eaffb6ccda9bef348f"

--- a/test/appium/views/wallet_view.py
+++ b/test/appium/views/wallet_view.py
@@ -278,7 +278,7 @@ class WalletView(BaseView):
     def send_transaction(self, **kwargs):
         send_transaction_view = self.send_transaction_button.click()
         send_transaction_view.select_asset_button.click()
-        asset_name = kwargs.get('asset_name', 'ETHro')
+        asset_name = kwargs.get('asset_name', 'ETHro').upper()
         asset_button = send_transaction_view.asset_by_name(asset_name)
         send_transaction_view.select_asset_button.click_until_presence_of_element(asset_button)
         asset_button.click()
@@ -308,7 +308,7 @@ class WalletView(BaseView):
         self.receive_transaction_button.click()
         send_transaction_view = self.send_transaction_request.click()
         send_transaction_view.select_asset_button.click()
-        asset_name = kwargs.get('asset_name', 'ETHro')
+        asset_name = kwargs.get('asset_name', 'ETHro').upper()
         asset_button = send_transaction_view.asset_by_name(asset_name)
         send_transaction_view.select_asset_button.click_until_presence_of_element(asset_button)
         asset_button.click()


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)
### Summary:

[comment]: # (Summarise the problem and how the pull request solves it)
Different users may want to use different currencies depending on their preferences.
When users set a preferred currency in Status mobile profile settings they should see all incoming/outgoing transactions fiat value in this currency.

The test verifies whether the above condition is met.  

### Review notes:
- changed existing test method conditions (`or` on `and`, i.e. both conditions must be satisfied) 
```python
if not request_message.is_element_displayed() and not request_message.contains_text(user_currency):
    {code goes here}
```
- wallet view fix: use `upper()` in order to find asset element by correct locator (`receive_transaction` and `send_transaction` methods)
<!-- (Specify if something in particular should be looked at, or ignored, during review) -->

<!-- (Specify exact steps to test if there are such) -->
### Steps to test:

1. Configure your currency to AUD for example and send some ETH to second device with currency in EUR in 1x1 chat. Expected outcome: both participants see transaction amount shown in selected currency
2. Configure your currency to AUD for example and send some ETH to second device with currency in EUR in wallet. Expected outcome: both participants see transaction amount shown in selected currency as a message in chat

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->
