### PR TITLE
Renamed hook name

### DIFF
--- a/src/status_im/extensions/core.cljs
+++ b/src/status_im/extensions/core.cljs
@@ -289,7 +289,7 @@
                                :params?    :vector
                                :outputs?   :vector
                                :on-result  :event}}}
-   :hooks      {:command         commands/command-hook
+   :hooks      {:chat.command    commands/command-hook
                 :wallet.settings settings/hook}})
 
 (defn parse [{:keys [data]} id]


### PR DESCRIPTION


### Summary:

Properly rename command hook (wrong merge)

status: ready