### PR TITLE
[#6643] Allow chat command suggestions to select parameter

### DIFF
--- a/src/status_im/chat/commands/core.cljs
+++ b/src/status_im/chat/commands/core.cljs
@@ -44,22 +44,6 @@
   [{:keys [type]} command-message]
   (protocol/preview type command-message))
 
-(defn- prepare-params
-  "Prepares parameters sequence of command by providing suggestion components with
-  selected-event injected with correct arg indexes and `last-arg?` flag."
-  [command]
-  (let [parameters     (protocol/parameters command)
-        last-param-idx (dec (count parameters))]
-    (into []
-          (map-indexed (fn [idx {:keys [suggestions] :as param}]
-                         (if suggestions
-                           (update param :suggestions partial
-                                   (fn [value]
-                                     [:chat.ui/set-command-parameter
-                                      (= idx last-param-idx) idx value]))
-                           param))
-                       parameters))))
-
 (defn- add-exclusive-choices [initial-scope exclusive-choices]
   (reduce (fn [scopes-set exclusive-choices]
             (reduce (fn [scopes-set scope]
@@ -83,7 +67,7 @@
   (let [id->command              (reduce (fn [acc command]
                                            (assoc acc (command-id command)
                                                   {:type   command
-                                                   :params (prepare-params command)}))
+                                                   :params (into [] (protocol/parameters command))}))
                                          {}
                                          commands)
         access-scope->command-id (reduce-kv (fn [acc command-id {:keys [type]}]

--- a/src/status_im/extensions/core.cljs
+++ b/src/status_im/extensions/core.cljs
@@ -134,6 +134,11 @@
                           (when timeout
                             {:timeout-ms timeout}))}))
 
+(handlers/register-handler-fx
+ :extensions.chat.command/set-parameter
+ (fn [_ [_ _ {:keys [value]}]]
+   {:dispatch [:chat.ui/set-command-parameter value]}))
+
 (defn operation->fn [k]
   (case k
     :plus   +
@@ -207,15 +212,17 @@
                 ;'list               {:value list :properties {:data :vector :item-view :view}}
                 'checkbox           {:value checkbox :properties {:on-change :event :checked :boolean}}
                 'nft-token-viewer   {:value transactions/nft-token :properties {:token :string}}
-                'transaction-status {:value transactions/transaction-status :properties {:outgoing :string :tx-hash :string}}
-                'asset-selector     {:value transactions/choose-nft-asset-suggestion}
-                'token-selector     {:value transactions/choose-nft-token-suggestion}}
+                'transaction-status {:value transactions/transaction-status :properties {:outgoing :string :tx-hash :string}}}
    :queries    {'identity            {:value :extensions/identity :arguments {:value :map}}
                 'store/get           {:value :store/get :arguments {:key :string}}
                 'wallet/collectibles {:value :get-collectible-token :arguments {:token :string :symbol :string}}}
    :events     {'alert
                 {:permissions [:read]
                  :value       :alert
+                 :arguments   {:value :string}}
+                'chat.command/set-parameter
+                {:permissions [:read]
+                 :value       :extensions.chat.command/set-parameter
                  :arguments   {:value :string}}
                 'log
                 {:permissions [:read]

--- a/test/cljs/status_im/test/chat/commands/core.cljs
+++ b/test/cljs/status_im/test/chat/commands/core.cljs
@@ -70,17 +70,6 @@
       (is (= TestCommandInstance
              (get-in fx [:db :id->command
                          (core/command-id TestCommandInstance) :type]))))
-    (testing "Suggestions for parameters are injected with correct selection events"
-      (is (= [:chat.ui/set-command-parameter false 0 "first-value"]
-             ((get-in fx [:db :id->command
-                          (core/command-id TestCommandInstance) :params
-                          0 :suggestions])
-              "first-value")))
-      (is (= [:chat.ui/set-command-parameter true 2 "last-value"]
-             ((get-in fx [:db :id->command
-                          (core/command-id TestCommandInstance) :params
-                          2 :suggestions])
-              "last-value"))))
     (testing "Access scope indexes are correctly created"
       (is (contains? (get-in fx [:db :access-scope->command-id #{:personal-chats}])
                      (core/command-id TestCommandInstance)))


### PR DESCRIPTION
fixes #6643

added new `chat.command/set-parameter` event

Usage in extension

```
 views/suggestion
 [view {:style {:flex-direction :row}
               :align-items    :flex-start}
  [button {:on-click [chat.command/set-parameter {:value "Yohoho"}]}]]
```
