### PR TITLE
[TESTS] User can send/read messages in public chat

### DIFF
--- a/test/appium/support/utilities.py
+++ b/test/appium/support/utilities.py
@@ -1,5 +1,6 @@
 from operator import itemgetter
 from typing import List
+from datetime import datetime
 
 
 def fill_string_with_char(string: str, fillchar: str, amount: int, start: bool = False, end: bool = False) -> str:
@@ -38,3 +39,7 @@ def get_merged_txs_list(normal_txs_list, token_events_list) -> List[dict]:
     res.extend(normal_txs_list)
     res.extend(token_events_list)
     return sorted(res, key=itemgetter('timeStamp'), reverse=True)
+
+
+def generate_timestamp():
+    return datetime.strftime(datetime.now(), '%F %H:%M:%S')

--- a/test/appium/tests/atomic/chats/test_public.py
+++ b/test/appium/tests/atomic/chats/test_public.py
@@ -1,3 +1,4 @@
+from support.utilities import generate_timestamp
 from tests import marks
 from tests.base_test_case import MultipleDeviceTestCase, SingleDeviceTestCase
 from views.sign_in_view import SignInView
@@ -126,3 +127,31 @@ class TestPublicChatSingleDevice(SingleDeviceTestCase):
         if not public_chat.chat_element_by_text(message).is_element_displayed():
             self.errors.append('Message with korean characters is not shown')
         self.verify_no_errors()
+
+    @marks.testrail_id(5336)
+    @marks.high
+    def test_user_can_interact_with_public_chat(self):
+        signin = SignInView(self.driver)
+        home_view = signin.create_user()
+        chat = home_view.join_public_chat('evripidis-middellijn')
+
+        if chat.empty_public_chat_message.is_element_displayed():
+            self.driver.fail('Empty chat: history is not fetched!')
+
+        # just to generate random text to be sent
+        text = generate_timestamp()
+        chat.send_message(text)
+
+        if not chat.chat_element_by_text(text).is_element_displayed():
+            self.errors.append('User sent message but it did not appear in chat!')
+
+        chat.move_to_messages_by_time_marker('Today')
+        if len(chat.chat_item.find_elements()) <= 1:
+            self.errors.append('There were no history messages fetched!')
+
+        chat.move_to_messages_by_time_marker('Yesterday')
+        if len(chat.chat_item.find_elements()) <= 1:
+            self.errors.append('There were no history messages fetched!')
+
+        self.verify_no_errors()
+

--- a/test/appium/views/base_element.py
+++ b/test/appium/views/base_element.py
@@ -110,13 +110,16 @@ class BaseElement(object):
             raise TimeoutException("Device %s: '%s' is still visible on the screen after %s seconds" % (
                 self.driver.number, self.name, seconds)) from None
 
-    def scroll_to_element(self):
-        for _ in range(9):
+    def scroll_to_element(self, depth: int = 9, direction='down'):
+        for _ in range(depth):
             try:
                 return self.find_element()
             except NoSuchElementException:
                 self.driver.info('Scrolling down to %s' % self.name)
-                self.driver.swipe(500, 1000, 500, 500)
+                if direction == 'down':
+                    self.driver.swipe(500, 1000, 500, 500)
+                else:
+                    self.driver.swipe(500, 500, 500, 1000)
 
     def is_element_present(self, sec=5):
         try:

--- a/test/appium/views/chat_view.py
+++ b/test/appium/views/chat_view.py
@@ -3,7 +3,7 @@ import time
 from selenium.common.exceptions import TimeoutException, NoSuchElementException
 
 from tests import common_password
-from views.base_element import BaseButton, BaseEditBox, BaseText
+from views.base_element import BaseButton, BaseEditBox, BaseText, BaseElement
 from views.base_view import BaseView, ProgressBar
 from views.profile_view import ProfilePictureElement, ProfileAddressText
 
@@ -244,6 +244,24 @@ class ChatElementByText(BaseText):
         return element.is_element_displayed(wait_time)
 
 
+class EmptyPublicChatMessage(BaseText):
+    def __init__(self, driver):
+        super().__init__(driver)
+        self.locator = self.Locator.text_part_selector("There are no messages")
+
+
+class ChatItem(BaseElement):
+    def __init__(self, driver):
+        super().__init__(driver)
+        self.locator = self.Locator.xpath_selector('//*[@content-desc="chat-item"]')
+
+
+class HistoryTimeMarker(BaseText):
+    def __init__(self, driver, marker='Today'):
+        super().__init__(driver)
+        self.locator = self.Locator.xpath_selector('//*[@text="%s"]' % marker)
+
+
 class ChatView(BaseView):
     def __init__(self, driver):
         super(ChatView, self).__init__(driver)
@@ -252,6 +270,8 @@ class ChatView(BaseView):
         self.add_to_contacts = AddToContacts(self.driver)
         self.user_name_text = UserNameText(self.driver)
         self.no_messages_in_chat = NoMessagesInChatText(self.driver)
+        self.empty_public_chat_message = EmptyPublicChatMessage(self.driver)
+        self.chat_item = ChatItem(self.driver)
 
         self.commands_button = CommandsButton(self.driver)
         self.send_command = SendCommand(self.driver)
@@ -390,3 +410,11 @@ class ChatView(BaseView):
         today_height = today_text_element.size['height']
         if message_location < today_location + today_height:
             errors.append("Message '%s' is not under 'Today' text" % text)
+
+    def send_message(self, message: str = 'test message'):
+        self.chat_message_input.send_keys(message)
+        self.send_message_button.click()
+
+    def move_to_messages_by_time_marker(self, marker='Today'):
+        self.driver.info("Moving to messages by time marker: '%s'" % marker)
+        HistoryTimeMarker(self.driver, marker).scroll_to_element(depth=50, direction='up')


### PR DESCRIPTION
### Summary:

[comment]: # (Summarise the problem and how the pull request solves it)
Mobile app shows last 24h history for users who joined a public chat. 
Test verifies whether a user can send a message and view 24h history fetched when joining a public chat.

### Review notes:
modified `scroll_to_element` base method to use bidirectional scrolling (up/down).
<!-- (Specify if something in particular should be looked at, or ignored, during review) -->

### Testing notes:
Of course, we cannot check every message in a public chat. But we can check few message items when scrolling up.


### Steps to test:

1. Join public chat #status
2. Send message and check it appears in chat
3. Scroll the chat history up till 'Yesterday' placeholder and ensure you see message items in chat

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->
