### PR TITLE
[Fixes #6825] Do not open settings as a modal

### DIFF
--- a/src/status_im/ui/screens/wallet/settings/views.cljs
+++ b/src/status_im/ui/screens/wallet/settings/views.cljs
@@ -86,5 +86,5 @@
         :icon-opts {:color               colors/white
                     :accessibility-label :options-menu-button}
         :options   (into [{:label  (i18n/label :t/wallet-manage-assets)
-                           :action #(re-frame/dispatch [:navigate-to-modal :wallet-settings-assets])}]
+                           :action #(re-frame/dispatch [:navigate-to :wallet-settings-assets])}]
                          (map setting->action settings))}]]]))


### PR DESCRIPTION
fixes #6825

### Summary:

### Steps to test:
- Open Status
- Open wallet / settings / manage assets

status: ready 
