### PR TITLE
Several small improvements to the build scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ watch-desktop: ##@watch Start development for Desktop
 run-android: ##@run Run Android build
 	react-native run-android --appIdSuffix debug
 
-run-desktop: ##@run Run Android build
+run-desktop: ##@run Run Desktop build
 	react-native run-desktop
 
 SIMULATOR=

--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,7 @@ test-auto: ##@test Run tests in interactive (auto) mode in NodeJS
 # Other
 #--------------
 react-native: ##@other Start react native packager
-	react-native start
+	@scripts/start-react-native.sh
 
 geth-connect: ##@other Connect to Geth on the device
 	adb forward tcp:8545 tcp:8545

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -25,10 +25,7 @@ STATUS_RELEASE_STORE_PASSWORD=password
 STATUS_RELEASE_KEY_ALIAS=status
 STATUS_RELEASE_KEY_PASSWORD=password
 
-# Workaround for issue https://github.com/facebook/react-native/issues/16906
+# Workaround for issue https://github.com/facebook/react-native/issues/16906 (TODO: fixed in 0.57.3, remove once we upgrade react-native)
 android.enableAapt2=false
-
-# Disable Gradle Daemon https://stackoverflow.com/questions/38710327/jenkins-builds-fail-using-the-gradle-daemon
-org.gradle.daemon=false
 
 org.gradle.jvmargs=-Xmx4608M

--- a/ci/android.groovy
+++ b/ci/android.groovy
@@ -2,7 +2,8 @@ common = load 'ci/common.groovy'
 
 def compile(type = 'nightly') {
   common.buildNumber()
-  def gradleOpt = "-PbuildUrl='${currentBuild.absoluteUrl}' "
+  // Disable Gradle Daemon https://stackoverflow.com/questions/38710327/jenkins-builds-fail-using-the-gradle-daemon
+  def gradleOpt = "-PbuildUrl='${currentBuild.absoluteUrl}' -Dorg.gradle.daemon=false "
   if (type == 'release') {
     gradleOpt += "-PreleaseVersion='${common.version()}'"
   }

--- a/modules/react-native-status/android/build.gradle
+++ b/modules/react-native-status/android/build.gradle
@@ -27,8 +27,10 @@ dependencies {
 
     // Check if the local status-go jar exists, and compile against that if it does
     final String localStatusLibOutputDir = "${rootDir}/../modules/react-native-status/android/libs", localVersion = 'local'
-    if ( new File("${localStatusLibOutputDir}/${statusGoGroup}/${statusGoName}/${localVersion}/${statusGoName}-${localVersion}.aar").exists() ) {
+    final File localFile = new File("${localStatusLibOutputDir}/${statusGoGroup}/${statusGoName}/${localVersion}/${statusGoName}-${localVersion}.aar")
+    if ( localFile.exists() ) {
         // Use the local version
+        logger.warn("Using local build of Android status-go library ${localFile.absolutePath}.")
         statusGoVersion = localVersion
     }
 

--- a/scripts/lib/setup/installers.sh
+++ b/scripts/lib/setup/installers.sh
@@ -216,19 +216,25 @@ function install_node_via_nvm() {
   cd "$(repo_path)"
 
   if [ ! -e "$nvmrc" ]; then
-    cecho "@b@blue[[+ Installing Node 9 (Node 10 is not supported by Realm)]]"
+    cecho "@b@blue[[+ Installing Node 8 (Node 10 is not supported by Realm and Node 9 doesn't support npm 5.5.1)]]"
 
-    nvm install 9
-    nvm alias status-im 9
+    nvm install 8.9.4
+    nvm alias status-im 8.9.4
     echo status-im > "$nvmrc"
 
     nvm use status-im
+    npm install -g npm@5.5.1 # Explicitly downgrade to v5.5.1 of npm, since Status Desktop builds require it (npm install hangs with version higher than 5.5.1). We could maintain two versions of npm (5.5.1 for Desktop and a more recent on for mobile) but that can be confusing and lead to inconsistent environments
   else
     local version_alias=$(cat "$nvmrc")
     nvm use $version_alias
 
     local version=$(node -v)
     cecho "+ Node already installed ($version_alias $version via NVM)... skipping."
+  fi
+
+  local npm_version=$(npm -v)
+  if [[ $npm_version != "5.5.1" ]]; then
+    cecho "@b@red[[+ npm version $npm_version is installed. npm version 5.5.1 is recommended.]]"
   fi
 }
 

--- a/scripts/lib/setup/installers.sh
+++ b/scripts/lib/setup/installers.sh
@@ -354,7 +354,7 @@ function install_android_ndk() {
       cecho "@cyan[[Extracting Android NDK to $_ndkParentDir.]]" && \
       unzip -q -o ./android-ndk.zip -d "$_ndkParentDir" && \
       rm -f ./android-ndk.zip && \
-      _ndkTargetDir="$_ndkParentDir/$(ls $_ndkParentDir | head -n 1)" && \
+      _ndkTargetDir="$_ndkParentDir/$(ls $_ndkParentDir | grep ndk)" && \
       echo "ndk.dir=$_ndkTargetDir" | tee -a $_localPropertiesPath && \
       cecho "@blue[[Android NDK installation completed in $_ndkTargetDir.]]"
   fi

--- a/scripts/prepare-for-platform.sh
+++ b/scripts/prepare-for-platform.sh
@@ -9,19 +9,25 @@ PLATFORM_FOLDER=""
 
 #if no arguments passed, inform user about possible ones
 
-if [ $# -eq 0 ]
-  then
-    echo -e "${GREEN}This script should be invoked with platform argument: 'mobile' or 'desktop'${NC}"
-    echo "When called it links"
-    # echo "If invoked with 'mobile' argument it will make a copying: "
-    # echo "package.json.mobile -> package.json"
-    # echo "etc.."
-    exit 1
-  else
-    PLATFORM=$1
-    PLATFORM_FOLDER="${PLATFORM}_files"
+if [ $# -eq 0 ]; then
+  echo -e "${GREEN}This script should be invoked with platform argument: 'android', 'ios' or 'desktop'${NC}"
+  echo "If invoked with 'mobile' argument it will link: "
+  echo "package.json.mobile -> package.json"
+  echo "etc.."
+  exit 1
+else
+  case $1 in
+    android | ios)
+      PLATFORM='mobile'
+      ;;
+    *)
+      PLATFORM=$1
+      ;;
+  esac
+  PLATFORM_FOLDER="${PLATFORM}_files"
 fi
 
+scripts/run-pre-build-check.sh $1
 
 echo "Creating link: package.json -> ${PLATFORM_FOLDER}/package.json "
 ln -sf  ${PLATFORM_FOLDER}/package.json package.json

--- a/scripts/run-pre-build-check.sh
+++ b/scripts/run-pre-build-check.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+PLATFORM=""
+
+#if no arguments passed, inform user about possible ones
+
+if [ $# -eq 0 ]; then
+  echo -e "${GREEN}This script should be invoked with platform argument: 'android', 'ios' or 'desktop'${NC}"
+  exit 1
+else
+  PLATFORM=$1
+fi
+
+npm_version=$(npm -v)
+if [[ $npm_version != "5.5.1" ]]; then
+  echo -e "${YELLOW}+ npm version $npm_version is installed. npm version 5.5.1 is recommended.${NC}"
+fi
+
+if [[ $PLATFORM == 'android' ]]; then
+  _localPropertiesPath=./android/local.properties
+  if ! grep -Fq "ndk.dir" $_localPropertiesPath; then
+    if [ -z $ANDROID_NDK_HOME ]; then
+      echo -e "${GREEN}NDK directory not configured, please run 'make setup' or add the line to ${_localPropertiesPath}!${NC}"
+      exit 1
+    fi
+  fi
+fi
+
+echo -e "${GREEN}Finished!${NC}"

--- a/scripts/start-react-native.sh
+++ b/scripts/start-react-native.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+METRO_PORT=8081
+METRO_PID="$(lsof -i :${METRO_PORT} | awk 'NR!=1 {print $2}')"
+if [ ! -z $METRO_PID ]; then
+  echo -e "${YELLOW}TCP port ${METRO_PORT} is required by the Metro packager.\nThe following process currently has the port open, preventing Metro from starting:${NC}"
+  ps -fp $METRO_PID
+  echo -e "${YELLOW}Do you want to terminate it (y/n)?${NC}"
+  read -n 1 term
+  [[ $term == 'y' ]] && kill $METRO_PID
+fi
+
+react-native start

--- a/scripts/update-status-go.sh
+++ b/scripts/update-status-go.sh
@@ -26,6 +26,6 @@ if [ $# -eq 0 ]; then
 fi
 
 STATUSGO_VERSION=$1
+STATUSGO_VERSION=${STATUSGO_VERSION#"v"}
 
-sedi "s/\([[:blank:]]\{28,\}<version>\).*\(<\/version>\)/\1$STATUSGO_VERSION\2/" modules/react-native-status/ios/RCTStatus/pom.xml
-sedi "s/\(statusGoVersion = '\).*\('\)/\1$STATUSGO_VERSION\2/" modules/react-native-status/android/build.gradle
+echo $STATUSGO_VERSION > STATUS_GO_VERSION


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

This PR serves to capture some commits that I needed to do while working on another longer-lived branch.

### Summary:

[comment]: # (Summarise the problem and how the pull request solves it)
This PR does the following:
- Installs the Node/npm versions which are actually recommended in docs.status.im (I don't see the logic in installing Node 9/npm 6.x when our documentation asks for a lower version);
- Improves local build performance by allowing gradle to use a daemon and only disabling that where it supposedly causes issues (Jenkins);
- Avoids repeated downloads of Android NDK by avoiding resetting of `android/local.properties` file;
- Takes proactive measure of warning user if NDK is not configured at the beginning of the build instead of letting the user deal with cryptic message at the end of build;
- Updates `scripts/update-status-go.sh` so that the right files are updated, and any `v` prefix is ignored. 
- Adds the convenience of offering to terminate a process that is keeping port 8081 open and preventing Metro from starting (`make react-native`)

status: ready <!-- Can be ready or wip -->
