### PR TITLE
[#6642] Feature/chat command extra key

### DIFF
--- a/src/status_im/chat/commands/impl/transactions.cljs
+++ b/src/status_im/chat/commands/impl/transactions.cljs
@@ -91,9 +91,6 @@
   [{:id          :asset
     :type        :text
     :placeholder (i18n/label :t/send-request-currency)
-    ;; Suggestion components should be structured in such way that they will just take
-    ;; one argument, event-creator fn used to construct event to fire whenever something
-    ;; is selected.
     :suggestions choose-asset-suggestion}
    {:id          :amount
     :type        :number

--- a/src/status_im/chat/commands/sending.cljs
+++ b/src/status_im/chat/commands/sending.cljs
@@ -21,12 +21,12 @@
 
 (fx/defn validate-and-send
   "Validates and sends command in current chat"
-  [{:keys [db now] :as cofx} input-text {:keys [type params] :as command}]
+  [{:keys [db] :as cofx} input-text {:keys [type params]} custom-params]
   (let [chat-id       (:current-chat-id db)
-        parameter-map (commands.input/parse-parameters params input-text)]
+        parameter-map (merge (commands.input/parse-parameters params input-text) custom-params)]
     (if-let [validation-error (protocol/validate type parameter-map cofx)]
       ;; errors during validation
-      {:db (chat/set-chat-ui-props db {:validation-messages  validation-error})}
+      {:db (chat/set-chat-ui-props db {:validation-messages validation-error})}
       ;; no errors
       (if (satisfies? protocol/Yielding type)
         ;; yield control implemented, don't send the message

--- a/src/status_im/chat/models/input.cljs
+++ b/src/status_im/chat/models/input.cljs
@@ -103,9 +103,9 @@
 
 (defn command-complete-fx
   "command is complete, proceed with command processing"
-  [input-text command {:keys [db now] :as cofx}]
+  [cofx input-text command custom-params]
   (fx/merge cofx
-            (commands.sending/validate-and-send input-text command)
+            (commands.sending/validate-and-send input-text command custom-params)
             (set-chat-input-text nil)
             (process-cooldown)))
 
@@ -137,7 +137,7 @@
 (fx/defn send-current-message
   "Sends message from current chat input"
   [{{:keys [current-chat-id id->command access-scope->command-id] :as db} :db :as cofx}]
-  (let [input-text   (get-in db [:chats current-chat-id :input-text])
+  (let [{:keys [input-text custom-params]} (get-in db [:chats current-chat-id])
         command      (commands.input/selected-chat-command
                       input-text nil (commands/chat-commands id->command
                                                              access-scope->command-id
@@ -145,7 +145,7 @@
     (if command
       ;; Returns true if current input contains command
       (if (= :complete (:command-completion command))
-        (command-complete-fx input-text command cofx)
+        (command-complete-fx cofx input-text command custom-params)
         (command-not-complete-fx input-text current-chat-id cofx))
       (plain-text-message-fx input-text current-chat-id cofx))))
 

--- a/src/status_im/extensions/core.cljs
+++ b/src/status_im/extensions/core.cljs
@@ -139,6 +139,17 @@
  (fn [_ [_ _ {:keys [value]}]]
    {:dispatch [:chat.ui/set-command-parameter value]}))
 
+(handlers/register-handler-fx
+ :extensions.chat.command/set-custom-parameter
+ (fn [{{:keys [current-chat-id] :as db} :db} [_ _ {:keys [key value]}]]
+   {:db (assoc-in db [:chats current-chat-id :custom-params key] value)}))
+
+(handlers/register-handler-fx
+ :extensions.chat.command/set-parameter-with-custom-params
+ (fn [{{:keys [current-chat-id] :as db} :db} [_ _ {:keys [value params]}]]
+   {:db (update-in db [:chats current-chat-id :custom-params] merge params)
+    :dispatch [:chat.ui/set-command-parameter value]}))
+
 (defn operation->fn [k]
   (case k
     :plus   +
@@ -223,7 +234,15 @@
                 'chat.command/set-parameter
                 {:permissions [:read]
                  :value       :extensions.chat.command/set-parameter
-                 :arguments   {:value :string}}
+                 :arguments   {:value :any}}
+                'chat.command/set-custom-parameter
+                {:permissions [:read]
+                 :value       :extensions.chat.command/set-custom-parameter
+                 :arguments   {:key :keyword :value :any}}
+                'chat.command/set-parameter-with-custom-params
+                {:permissions [:read]
+                 :value       :extensions.chat.command/set-parameter-with-custom-params
+                 :arguments   {:value :string :params :map}}
                 'log
                 {:permissions [:read]
                  :value       :log


### PR DESCRIPTION
fixes #6642

Introduced two new events

```
[chat.command/set-parameter-with-custom-params {:value "Yohoho" :params {:param1 "value1"}}]

[chat.command/set-custom-parameter {:key :param1 :value "value1"}]

```

usage

```
views/suggetsion
 [view {:style {:flex-direction :row
                :align-items    :flex-start}}
  [button {:on-click [chat.command/set-parameter-with-custom-params {:value "Yohoho" :params {:param1 "Test"}}]}]]
 
```