### PR TITLE
fix user-statuses after migration from #6722

### DIFF
--- a/src/status_im/data_store/realm/schemas/account/core.cljs
+++ b/src/status_im/data_store/realm/schemas/account/core.cljs
@@ -340,4 +340,7 @@
                :migration     migrations/v24}
               {:schema        v25
                :schemaVersion 25
-               :migration     migrations/v25}])
+               :migration     migrations/v25}
+              {:schema        v25
+               :schemaVersion 26
+               :migration     migrations/v26}])


### PR DESCRIPTION
fix #6849

A wrong field was used in v25 migration (`whisper-id`) for `status-id` (which is `message-id + "-" + public-key`). This fix removes old `user-status` if a new one with the same id was created or changes `status-id` if this is still necessary. 

status: ready <!-- Can be ready or wip -->
