### PR TITLE
Add LES nodes back into list of static nodes

### DIFF
--- a/src/status_im/node/core.cljs
+++ b/src/status_im/node/core.cljs
@@ -92,7 +92,7 @@
                              :Fleet              (name current-fleet-key)
                              :BootNodes          (pick-nodes 4 (vals (:boot current-fleet)))
                              :TrustedMailServers (pick-nodes 6 (vals (:mail current-fleet)))
-                             :StaticNodes        (pick-nodes 2 (vals (:whisper current-fleet)))
+                             :StaticNodes        (into (pick-nodes 2 (vals (:whisper current-fleet))) (vals (:static current-fleet)))
                              :RendezvousNodes    rendezvous-nodes})
 
       :always


### PR DESCRIPTION
Background: fixing a bad rebase that made it into `develop` and now LES doesn't work.

closes: https://github.com/status-im/status-react/issues/6844