### PR TITLE
erase only account's db when it can't be encrypted

### DIFF
--- a/src/status_im/accounts/login/core.cljs
+++ b/src/status_im/accounts/login/core.cljs
@@ -33,7 +33,7 @@
       (catch (fn [error]
                (log/warn "Could not change account" error)
                ;; If all else fails we fallback to showing initial error
-               (re-frame/dispatch [:init.callback/account-change-error (str error)])))))
+               (re-frame/dispatch [:init.callback/account-change-error error])))))
 
 ;;;; Handlers
 (fx/defn login [cofx]

--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -55,6 +55,11 @@
    {:init/reset-data nil}))
 
 (handlers/register-handler-fx
+ :init.ui/account-data-reset-accepted
+ (fn [_ [_ address]]
+   {:init/reset-account-data address}))
+
+(handlers/register-handler-fx
  :init.ui/data-reset-cancelled
  (fn [cofx [_ encryption-key]]
    (init/initialize-app cofx encryption-key)))
@@ -127,6 +132,11 @@
  :init.callback/keychain-reset
  (fn [cofx _]
    (init/initialize-keychain cofx)))
+
+(handlers/register-handler-fx
+ :init.callback/account-db-removed
+ (fn [{:keys [db]} _]
+   {:db (assoc-in db [:accounts/login :processing] false)}))
 
 ;; home screen
 

--- a/translations/en.json
+++ b/translations/en.json
@@ -380,7 +380,7 @@
     "recover-access": "Recover access",
     "currency-display-name-ron": "Romania Leu",
     "log-level-settings": "Log level settings",
-    "invalid-key-content": "To protect yourself, you need to create new account and erase your old data by tapping “Apply”. If you have an existing account and would like to save your recovery phrase then choose “Cancel”, back it up, and restart the app. We strongly recommend creating new account because the old one is stored unencrypted.",
+    "invalid-key-content": "{{message}}\n\nAccount's database can't be encrypted because file is corrupted. There is no way to restore it. If you press \"Cancel\" button, nothing will happen. If you press \"{{erase-accounts-data-button-text}}\" button, account's db will be removed and you will be able to unlock account. All account's data will be lost.",
     "advanced-settings": "Advanced settings",
     "group-info": "Group info",
     "currency-display-name-nio": "Nicaragua Cordoba",
@@ -782,5 +782,8 @@
     "network-invalid-status-code": "Invalid status code: {{code}}",
     "extension-is-already-added": "The extension is already added",
     "extension-uninstalled": "The extension was uninstalled",
-    "extension-hooks-cannot-be-added": "The following hooks from this extension cannot be added: {{hooks}}"
+    "extension-hooks-cannot-be-added": "The following hooks from this extension cannot be added: {{hooks}}",
+    "migrations-failed-title": "Migration failed",
+    "migrations-failed-content": "{{message}}\n\nPlease let us know about this problem at #status public chat. If you press \"Cancel\" button, nothing will happen. If you press \"{{erase-accounts-data-button-text}}\" button, account's db will be removed and you will be able to unlock account. All account's data will be lost.",
+    "migrations-erase-accounts-data-button": "Erase account's db"
 }


### PR DESCRIPTION
https://discuss.status.im/t/problem-with-encryption-key/809

Currently, if account's db can't be encrypted the whole `realm` dir is removed and keychain is purged. This causes situation when other perfectly working accounts are purged without reason (we state that only current account will be removed in confirmation window), along with broken UI state when a user can't log into any account after such error.

That's what we show user in such situation:
> To protect yourself, you need to create new account and erase your old data by tapping “Apply”. If you have an existing account and would like to save your recovery phrase then choose “Cancel”, back it up, and restart the app. We strongly recommend creating new account because the old one is stored unencrypted.

With this change, only account's db will be removed in case if it can't be encrypted. 
In case of migration failure different message is shown to the user.

status: ready
