### PR TITLE
Connection status info

### DIFF
--- a/src/status_im/ui/screens/desktop/main/tabs/profile/styles.cljs
+++ b/src/status_im/ui/screens/desktop/main/tabs/profile/styles.cljs
@@ -163,6 +163,10 @@
   {:margin        24
    :font-size     20})
 
+(def connection-message-text
+  {:margin-left   24
+   :margin-bottom 10})
+
 (def title-separator
   {:height            1
    :background-color  colors/gray-light})

--- a/src/status_im/ui/screens/desktop/main/tabs/profile/views.cljs
+++ b/src/status_im/ui/screens/desktop/main/tabs/profile/views.cljs
@@ -84,7 +84,6 @@
    [pairing.views/sync-devices]
    [pairing.views/installations-list installations]])
 
-
 (defn connection-status
   "generates a composite message of the current connection state given peer and mailserver statuses"
   [peers-count node-status mailserver-state peers-disconnected?]
@@ -115,7 +114,7 @@
                     :font  :medium}
         (i18n/label :advanced-settings)]
        [react/view
-        [react/text connection-message]]
+        [react/text {:style styles/connection-message-text} connection-message]]
        [react/view {:style styles/title-separator}]
        [react/text {:style styles/mailserver-title} (i18n/label :offline-messaging)]
        [react/view

--- a/src/status_im/ui/screens/desktop/main/tabs/profile/views.cljs
+++ b/src/status_im/ui/screens/desktop/main/tabs/profile/views.cljs
@@ -89,15 +89,18 @@
                   current-mailserver-id [:mailserver/current-id]
                   mailservers           [:mailserver/fleet-mailservers]
                   mailserver-state      [:mailserver/state]
+                  node-status           [:node-status]
                   peers-count           [:peers-count]]
     (let [render-fn (offline-messaging.views/render-row current-mailserver-id)
-          connected-peers-message      (str "Connected to " peers-count " peers")]
+          connected-peers-message      (str "Connected to " peers-count " peers")
+          node-status-message          (str "The node is currently " node-status)]
       [react/scroll-view
        [react/text {:style styles/advanced-settings-title
                     :font  :medium}
         (i18n/label :advanced-settings)]
        [react/view
         [react/text connected-peers-message]
+        [react/text node-status-message]
         [react/text (str mailserver-state)]]
        [react/view {:style styles/title-separator}]
        [react/text {:style styles/mailserver-title} (i18n/label :offline-messaging)]

--- a/src/status_im/ui/screens/desktop/main/tabs/profile/views.cljs
+++ b/src/status_im/ui/screens/desktop/main/tabs/profile/views.cljs
@@ -87,12 +87,18 @@
 (views/defview advanced-settings []
   (views/letsubs [installations    [:pairing/installations]
                   current-mailserver-id [:mailserver/current-id]
-                  mailservers           [:mailserver/fleet-mailservers]]
-    (let [render-fn (offline-messaging.views/render-row current-mailserver-id)]
+                  mailservers           [:mailserver/fleet-mailservers]
+                  mailserver-state      [:mailserver/state]
+                  peers-count           [:peers-count]]
+    (let [render-fn (offline-messaging.views/render-row current-mailserver-id)
+          connected-peers-message      (str "Connected to " peers-count " peers")]
       [react/scroll-view
        [react/text {:style styles/advanced-settings-title
                     :font  :medium}
         (i18n/label :advanced-settings)]
+       [react/view
+        [react/text connected-peers-message]
+        [react/text (str mailserver-state)]]
        [react/view {:style styles/title-separator}]
        [react/text {:style styles/mailserver-title} (i18n/label :offline-messaging)]
        [react/view

--- a/src/status_im/ui/screens/subs.cljs
+++ b/src/status_im/ui/screens/subs.cljs
@@ -47,6 +47,7 @@
 (reg-sub :sync-state :sync-state)
 (reg-sub :network-status :network-status)
 (reg-sub :peers-count :peers-count)
+(reg-sub :node-status :node/status)
 
 (reg-sub :offline?
          :<- [:network-status]


### PR DESCRIPTION
fixes #6567 

## Summary

This is a basic port of the criteria laid out by @adambabik during our time in Prague and detailed in the above-linked issue "Show connection status within the app". 

My first question for the clj folks is whether the various states of `:node/status`, which is already in app-db, can be a reasonable proxy for `discovery.started` and `discovery.stopped`. 

If not, I'd be curious about current examples within re-frame around how we can use json-rpc to get these values? I'm still ramping on the inner workings of *chat* but the principle form of message communication seems to be waiting for gethEvents via the signal-received event handler, and I wasn't sure how to go about querying values from the status-go side without merely waiting for these events. 

One other question had to do with whether the whisper min and max here should both be set to 2, and what that means currently? https://github.com/status-im/status-react/blob/develop/src/status_im/node/core.cljs#L50 While this PR is pretty simple, we talked about a visual indicator something akin to a traffic light, and I'm thinking the whisper min and max will come into play here for "yellow", though of course it would be good to discuss this with those who have been around the part of the code base for a while already.

I chose the "advanced settings" tab for this PR because we are already displaying mailserver information there. It seems like a more visual indicator could be planned as a follow up to this in collaboration with @EugeOrtiz for design input. (as has been mentioned on the issue)

## Testing instructions
1. navigate to *advanced settings* of desktop app
2. look for section near the top of the chat screen with connection info. (screenshot attached on #6567)
3. disconnect app from internet to verify "disconnected" state and then watch as peers are added once the network is re-enabled. 
