### PR TITLE
Fixed an issue with uninstalling non-active extensions

### DIFF
--- a/src/status_im/extensions/registry.cljs
+++ b/src/status_im/extensions/registry.cljs
@@ -29,10 +29,12 @@
               (update-hooks hooks/hook-in extension-key))))
 
 (fx/defn remove-from-registry
-  [{:keys [db] :as cofx} extension-key]
-  (fx/merge cofx
-            (update-hooks hooks/unhook extension-key)
-            {:db (update-in db [:account/account :extensions] dissoc extension-key)}))
+  [cofx extension-key]
+  (let [extensions (get-in cofx [:db :account/account :extensions])]
+    (fx/merge cofx
+              (when (get-in extensions [extension-key :active?])
+                (update-hooks hooks/unhook extension-key))
+              {:db (update-in cofx [:db :account/account :extensions] dissoc extension-key)})))
 
 (fx/defn change-state
   [cofx extension-key active?]


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

Fixes #6780 

### Summary:

Fixed an issue with uninstalling non-active extensions - The issue was that the non-active extensions were being attempted to be unhooked, but as they weren't active they had already been unhooked.

<!-- (Specify exact steps to test if there are such) -->
### Steps to test:
- Open Status
- Enable dev mode
- Go to extensions
- Install an extension
- Disable the extension
- Uninstall the extension and see that it is removed successfully

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->
