### PR TITLE
bug #5975 - navigating back to chat after /send command with onboarding

### DIFF
--- a/src/status_im/ui/screens/wallet/send/events.cljs
+++ b/src/status_im/ui/screens/wallet/send/events.cljs
@@ -165,7 +165,7 @@
      (fx/merge cofx
                #(when send-command?
                   (commands-sending/send % chat-id send-command? params))
-               (navigation/navigate-to-clean :wallet-transaction-sent {})))))
+               (navigation/navigate-to-clean :wallet-transaction-sent {:send-command? send-command?})))))
 
 (defn set-and-validate-amount-db [db amount symbol decimals]
   (let [{:keys [value error]} (wallet.db/parse-amount amount decimals)]
@@ -264,10 +264,15 @@
              cofx)
             :dispatch [:wallet/update-gas-price true]))))
 
+(fx/defn navigate-after-transaction [{:keys [db] :as cofx} send-command? chat-id]
+  (if (= :wallet-send-transaction-modal (second (:navigation-stack db)))
+    (chat.models/navigate-to-chat cofx chat-id {})
+    (navigation/navigate-back cofx)))
+
 (handlers/register-handler-fx
  :close-transaction-sent-screen
- (fn [cofx [_ chat-id]]
+ (fn [cofx [_ send-command? chat-id]]
    (fx/merge cofx
              {:dispatch-later [{:ms 400 :dispatch [:check-dapps-transactions-queue]}]}
-             (navigation/navigate-back))))
+             (navigate-after-transaction send-command? chat-id))))
 

--- a/src/status_im/ui/screens/wallet/transaction_sent/views.cljs
+++ b/src/status_im/ui/screens/wallet/transaction_sent/views.cljs
@@ -61,13 +61,14 @@
    (bottom-action-button on-next)])
 
 (defview transaction-sent []
-  (letsubs [chat-id [:chats/current-chat-id]]
+  (letsubs [chat-id                 [:chats/current-chat-id]
+            {:keys [send-command?]} [:get-screen-params :wallet-transaction-sent]]
     [react/view {:flex 1 :background-color colors/blue}
      [status-bar/status-bar {:type :transparent}]
-     (sent-screen {:on-next #(re-frame/dispatch [:close-transaction-sent-screen chat-id])})]))
+     (sent-screen {:on-next #(re-frame/dispatch [:close-transaction-sent-screen send-command? chat-id])})]))
 
 (defview transaction-sent-modal []
   (letsubs [chat-id [:chats/current-chat-id]]
     [react/view {:flex 1 :background-color colors/blue}
      [status-bar/status-bar {:type :modal-wallet}]
-     (sent-screen {:on-next #(re-frame/dispatch [:close-transaction-sent-screen chat-id])})]))
+     (sent-screen {:on-next #(re-frame/dispatch [:close-transaction-sent-screen false chat-id])})]))


### PR DESCRIPTION
fixes #5975

### Summary:

Navigates back to chat after /send command is done, even when the flow is intercepted by wallet onboarding. This bug fix also unblocks e2e tests.

### Testing notes (optional):

The previous attempt to quickfix this (PR #6113) introduced a regression (#6283). Please check for both problems in this PR.

### Steps to test:
see #5975 and #6283

status: ready