### PR TITLE
Envelope marked as sent even if it was expired

### DIFF
--- a/src/status_im/signals/core.cljs
+++ b/src/status_im/signals/core.cljs
@@ -55,7 +55,7 @@
       "node.stopped"       (status-node-stopped cofx)
       "module.initialized" (status-module-initialized cofx)
       "envelope.sent"      (transport.message/update-envelope-status cofx (:hash event) :sent)
-      "envelope.expired"   (transport.message/update-envelope-status cofx (:hash event) :sent)
+      "envelope.expired"   (transport.message/update-envelope-status cofx (:hash event) :not-sent)
       "bundles.added"      (pairing/handle-bundles-added cofx event)
       "mailserver.request.completed" (when (accounts.db/logged-in? cofx)
                                        (mailserver/update-mailserver-topics cofx {:request-id (:requestID event)


### PR DESCRIPTION
At some point it definitely worked right, i noticed this problem while testing confirmations. And app clearly shows every message as sent, even if i send it into the void.