### PR TITLE
[#6867] Add on-send-sync to chat.command extension

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -11,7 +11,7 @@
          com.taoensso/timbre         {:mvn/version "4.10.0"}
          hickory                     {:mvn/version "0.7.1"}
          com.cognitect/transit-cljs  {:mvn/version "0.8.248"}
-         status-im/pluto             {:mvn/version "iteration-4-3"}
+         status-im/pluto             {:mvn/version "iteration-4-4"}
          mvxcvi/alphabase            {:mvn/version "1.0.0"}
          rasom/cljs-react-navigation {:mvn/version "0.1.4"}}
 

--- a/project.clj
+++ b/project.clj
@@ -11,7 +11,7 @@
                  [com.taoensso/timbre "4.10.0"]
                  [hickory "0.7.1"]
                  [com.cognitect/transit-cljs "0.8.248"]
-                 [status-im/pluto "iteration-4-3"]
+                 [status-im/pluto "iteration-4-4"]
                  [mvxcvi/alphabase "1.0.0"]
                  [rasom/cljs-react-navigation "0.1.4"]]
   :plugins [[lein-cljsbuild "1.1.7"]

--- a/src/status_im/chat/models/input.cljs
+++ b/src/status_im/chat/models/input.cljs
@@ -134,6 +134,15 @@
                 (set-chat-input-text nil)
                 (process-cooldown)))))
 
+(defn send-plain-text-message-fx
+  "no command detected, when not empty, proceed by sending text message without command processing"
+  [{:keys [db] :as cofx} message-text current-chat-id]
+  (when-not (string/blank? message-text)
+    (chat.message/send-message cofx {:chat-id      current-chat-id
+                                     :content-type constants/content-type-text
+                                     :content      (cond-> {:chat-id current-chat-id
+                                                            :text    message-text})})))
+
 (fx/defn send-current-message
   "Sends message from current chat input"
   [{{:keys [current-chat-id id->command access-scope->command-id] :as db} :db :as cofx}]

--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -699,6 +699,11 @@
                                            value))))
 
 (handlers/register-handler-fx
+ :chat/send-plain-text-message
+ (fn [{{:keys [current-chat-id]} :db :as cofx} [_ message-text]]
+   (chat.input/send-plain-text-message-fx cofx message-text current-chat-id)))
+
+(handlers/register-handler-fx
  :chat/disable-cooldown
  (fn [cofx _]
    (chat/disable-chat-cooldown cofx)))


### PR DESCRIPTION

fixes #6867

Requires https://github.com/status-im/pluto/pull/98

introduced `on-send-sync` property for  chat.command extension, and two new events 
`[chat.command/send {:params {}}]` and `[chat.command/send-plain-text-message {:value "message text"}]`

usage
https://status-im.github.io/pluto/try.html?hash=QmcfsYnFvKXApcFTCNttpQvQKYxiMCqVx5MvsocFyrr2KA

```
events/on-send-sync
 (let [{title :title text :text} properties]
   [chat.command/send {:params {:text text}}}])
 

 hooks/chat.command.principles
 {:description   "Status Principles"
  :on-send-sync  [on-send-sync]
``` 

<blockquote><img src="/pluto/img/favicon.png" width="48" align="right"><div><strong><a href="https://status-im.github.io/pluto/index.html">Pluto · A grammar for data manipulation</a></strong></div><div>A grammar for data manipulation</div></blockquote>