### PR TITLE
Generate the  build number at the beginning of the build

### DIFF
--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -35,7 +35,10 @@ pipeline {
           /* Necessary to load methods */
           mobile = load 'ci/mobile.groovy'
           cmn    = load 'ci/common.groovy'
+          /* Cleanup and Prep */
           mobile.prep(cmn.getBuildType())
+          /* Run at start to void mismatched numbers */
+          cmn.buildNumber()
         }
       }
     }

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -31,7 +31,10 @@ pipeline {
           /* Necessary to load methods */
           mobile = load 'ci/mobile.groovy'
           cmn    = load 'ci/common.groovy'
+          /* Cleanup and Prep */
           mobile.prep(cmn.getBuildType())
+          /* Run at start to void mismatched numbers */
+          cmn.buildNumber()
         }
       }
     }

--- a/ci/android.groovy
+++ b/ci/android.groovy
@@ -1,8 +1,7 @@
 common = load 'ci/common.groovy'
 
 def compile(type = 'nightly') {
-  common.buildNumber()
-  // Disable Gradle Daemon https://stackoverflow.com/questions/38710327/jenkins-builds-fail-using-the-gradle-daemon
+  /* Disable Gradle Daemon https://stackoverflow.com/questions/38710327/jenkins-builds-fail-using-the-gradle-daemon */
   def gradleOpt = "-PbuildUrl='${currentBuild.absoluteUrl}' -Dorg.gradle.daemon=false "
   if (type == 'release') {
     gradleOpt += "-PreleaseVersion='${common.version()}'"

--- a/scripts/gen_build_no.sh
+++ b/scripts/gen_build_no.sh
@@ -20,7 +20,8 @@ BUILD_NUMBER_FILE="${GIT_ROOT}/BUILD_NUMBER"
 if [[ -f "${BUILD_NUMBER_FILE}" ]]; then
     cat "${BUILD_NUMBER_FILE}"
 else
-    # Format: Year(2 digit) + Month + Day + Hour + Minutes
-    # Example: 1812011805
-    date '+%y%m%d%H%M' | tee "${BUILD_NUMBER_FILE}"
+    # Format: Year(4 digit) + Month + Day + Hour
+    # Example: 2018120118
+    # We limited precision to hours to avoid of mismatched numbers.
+    date '+%Y%m%d%H' | tee "${BUILD_NUMBER_FILE}"
 fi


### PR DESCRIPTION
Generate the build number at the beginning of the build to avoid mismatched numbers.

Resolves. https://github.com/status-im/status-react/issues/6881