### PR TITLE
[TESTS] Not enough eth for gas validation from DApp/wallet/chat

### DIFF
--- a/test/appium/tests/atomic/transactions/test_daaps_transactions.py
+++ b/test/appium/tests/atomic/transactions/test_daaps_transactions.py
@@ -2,7 +2,8 @@ import pytest
 
 from tests import marks, unique_password
 from tests.base_test_case import SingleDeviceTestCase
-from tests.users import transaction_senders, transaction_recipients
+from tests.users import transaction_senders, transaction_recipients, basic_user
+from views.send_transaction_view import SendTransactionView
 from views.sign_in_view import SignInView
 
 
@@ -154,3 +155,241 @@ class TestTransactionDApp(SingleDeviceTestCase):
 
         if not status_test_dapp.assets_button.is_element_displayed():
             self.driver.fail('It seems users was not redirected to Status DAPP screen.')
+
+    @marks.testrail_id(5685)
+    @marks.medium
+    def test_not_enough_eth_for_gas_validation_from_dapp(self):
+        singin_view = SignInView(self.driver)
+        home_view = singin_view.create_user()
+        wallet = home_view.wallet_button.click()
+        wallet.set_up_wallet()
+        wallet_address = wallet.get_wallet_address()
+        home_view = wallet.get_back_to_home_view()
+        status_test_dapp = home_view.open_status_test_dapp()
+        status_test_dapp.wait_for_d_aap_to_load()
+        status_test_dapp.transactions_button.click()
+        send_transaction_view = status_test_dapp.deploy_contract_button.click()
+
+        warning = 'No "Not enough ETH for gas" warning appeared while {}'
+        sign_button_warning = 'Signin transaction button is enabled while {}'
+
+        # Check whether deploying simple contract with an empty ETH balance triggers the warning
+        if not send_transaction_view.validation_warnings.not_enough_eth_for_gas.is_element_displayed():
+            self.errors.append(warning.format('deploying a contract with an empty ETH balance'))
+
+        # Check whether sign transaction button is disabled
+        send_transaction_view.sign_transaction_button.click()
+        if send_transaction_view.enter_password_input.is_element_displayed():
+            self.errors.append(sign_button_warning.format('deploying a contract with an empty ETH balance'))
+
+        # Requesting test ETH and waiting till the balance updates
+        send_transaction_view.cross_icon.click()
+        status_test_dapp.faucet_asset(asset='eth')
+        self.network_api.verify_balance_is_updated(initial_balance=0, recipient_address=wallet_address[2:])
+
+        status_test_dapp.transactions_button.click()
+        send_transaction_view = status_test_dapp.send_one_tx_in_batch_button.click()
+        send_transaction_view.advanced_button.click()
+        send_transaction_view.transaction_fee_button.click()
+        gas_limit = '100000'
+        send_transaction_view.gas_limit_input.clear()
+        send_transaction_view.gas_limit_input.set_value(gas_limit)
+        gas_price = '999.900000001'
+        send_transaction_view.gas_price_input.clear()
+        send_transaction_view.gas_price_input.set_value(gas_price)
+        send_transaction_view.total_fee_input.click()
+        send_transaction_view.done_button.click()
+
+        # Check whether sending a tx in batch with big gas limit and price triggers the warning and sign button is still
+        # disabled (no funds to pay gas)
+        if not send_transaction_view.validation_warnings.not_enough_eth_for_gas.is_element_displayed():
+            self.errors.append(warning.format('sending one transaction in batch with big gas '
+                                              'limit and price (no funds to pay gas)'))
+
+        # Check whether sign transaction button is disabled
+        send_transaction_view.sign_transaction_button.click()
+        if send_transaction_view.enter_password_input.is_element_displayed():
+            self.errors.append(sign_button_warning.
+                               format('sending one transaction in batch with big gas '
+                                      'limit and price (no funds to pay gas)'))
+
+        send_transaction_view.transaction_fee_button.click()
+        gas_price = '999.9'
+        send_transaction_view.gas_price_input.clear()
+        send_transaction_view.gas_price_input.set_value(gas_price)
+        send_transaction_view.total_fee_input.click()
+        send_transaction_view.done_button.click()
+
+        # Check whether sending a tx in batch with normal gas limit and price does not trigger the warning
+        # so the transaction can be signed
+        if send_transaction_view.validation_warnings.not_enough_eth_for_gas.is_element_displayed():
+            self.errors.append(warning.format('"Not enough ETH for gas" warning appeared while sending '
+                                              'one transaction in batch with normal gas limit and price'))
+
+        send_transaction_view.sign_transaction()
+        if not status_test_dapp.assets_button.is_element_displayed():
+            self.errors.append('Could not sing the transaction!')
+
+        self.verify_no_errors()
+
+    @marks.testrail_id(5686)
+    @marks.medium
+    def test_not_enough_eth_for_gas_validation_from_wallet(self):
+        singin_view = SignInView(self.driver)
+        home_view = singin_view.create_user()
+        wallet = home_view.wallet_button.click()
+        wallet.set_up_wallet()
+        wallet_address = wallet.get_wallet_address()
+        recipient = '0x' + basic_user['address']
+
+        wallet.send_transaction(asset_name='ethro', amount=0, recipient=recipient, sign_transaction=False)
+        send_transaction_view = SendTransactionView(self.driver)
+
+        warning = 'No "Not enough ETH for gas" warning appeared while {}'
+        sign_button_warning = 'Signin transaction button is enabled {}'
+
+        # Check whether sending 0 ETH with an empty ETH balance triggers the warning
+        if not send_transaction_view.validation_warnings.not_enough_eth_for_gas.is_element_displayed():
+            self.errors.append(warning.format('sending 0 ETH with an empty ETH balance'))
+
+        # Check whether sign transaction button is disabled
+        send_transaction_view.sign_transaction_button.click()
+        if send_transaction_view.enter_password_input.is_element_displayed():
+            self.errors.append(sign_button_warning.format('sending 0 ETH with an empty ETH balance'))
+
+        asset_button = send_transaction_view.asset_by_name('STT')
+        send_transaction_view.select_asset_button.click_until_presence_of_element(asset_button)
+        asset_button.click()
+        send_transaction_view.amount_edit_box.set_value('0')
+        send_transaction_view.confirm()
+
+        # Check whether sending 0 STT with an empty ETH balance triggers the warning
+        if not send_transaction_view.validation_warnings.not_enough_eth_for_gas.is_element_displayed():
+            self.errors.append(warning.format('sending 0 STT with an empty ETH balance'))
+
+        # Check whether sign transaction button is disabled
+        send_transaction_view.sign_transaction_button.click()
+        if send_transaction_view.enter_password_input.is_element_displayed():
+            self.errors.append(sign_button_warning.format('sending 0 STT with an empty ETH balance'))
+
+        home_view = send_transaction_view.get_back_to_home_view()
+        # Requesting test ETH and waiting till the balance updates
+        self.network_api.faucet(wallet_address[2:])
+        self.network_api.verify_balance_is_updated(initial_balance=0, recipient_address=wallet_address[2:])
+
+        wallet = home_view.wallet_button.click()
+        wallet.send_transaction(asset_name='ethro', amount=0.1, recipient=recipient, sign_transaction=False)
+
+        # Check whether sending all available ETH triggers the warning
+        if not send_transaction_view.validation_warnings.not_enough_eth_for_gas.is_element_displayed():
+            self.errors.append(warning.format('sending all available ETH (no funds to pay gas)'))
+
+        # Check whether sign transaction button is disabled
+        send_transaction_view.sign_transaction_button.click()
+        if send_transaction_view.enter_password_input.is_element_displayed():
+            self.errors.append('sending all available ETH (no funds to pay gas)')
+
+        send_transaction_view.amount_edit_box.clear()
+        send_transaction_view.amount_edit_box.set_value('0.099979000000000001')
+        send_transaction_view.confirm()
+
+        # Check whether sending big amount of ETH triggers the warning (no funds to pay gas)
+        if not send_transaction_view.validation_warnings.not_enough_eth_for_gas.is_element_displayed():
+            self.errors.append('sending big amount of ETH (no funds to pay gas)')
+
+        # Check whether sign transaction button is disabled
+        send_transaction_view.sign_transaction_button.click()
+        if send_transaction_view.enter_password_input.is_element_displayed():
+            self.errors.append('sending big amount of ETH (no funds to pay gas)')
+
+        send_transaction_view.amount_edit_box.clear()
+        send_transaction_view.amount_edit_box.set_value('0.099979')
+        send_transaction_view.confirm()
+
+        # Check whether sending normal amount of ETH does not trigger the warning
+        if send_transaction_view.validation_warnings.not_enough_eth_for_gas.is_element_displayed():
+            self.errors.append('"Not enough ETH for gas" warning appeared while sending normal amount of ETH')
+
+        send_transaction_view.sign_transaction()
+        if not wallet.send_transaction_button.is_element_displayed():
+            self.errors.append('Could not sing the transaction!')
+
+        self.verify_no_errors()
+
+    @marks.testrail_id(5687)
+    @marks.medium
+    @marks.skip
+    def test_not_enough_eth_for_gas_validation_from_chat(self):
+        signin_view = SignInView(self.driver)
+        home_view = signin_view.create_user()
+        recipient_public_key = basic_user['public_key']
+        wallet = home_view.wallet_button.click()
+        wallet.set_up_wallet()
+        wallet_address = wallet.get_wallet_address()
+        home_view = wallet.get_back_to_home_view()
+
+        chat = home_view.add_contact(recipient_public_key)
+        chat.send_transaction_in_1_1_chat(asset='ETHro', amount='0', wallet_set_up=False, sign_transaction=False)
+        send_transaction_view = SendTransactionView(self.driver)
+
+        warning = 'No "Not enough ETH for gas" warning appeared while {}'
+        sign_button_warning = 'Signin transaction button is enabled {}'
+
+        # Check whether sending 0 ETH with an empty ETH balance triggers the warning
+        if not send_transaction_view.validation_warnings.not_enough_eth_for_gas.is_element_displayed():
+            self.errors.append(warning.format('sending 0 ETH with an empty ETH balance'))
+
+        # Check whether sign transaction button is disabled
+        send_transaction_view.sign_transaction_button.click()
+        if send_transaction_view.enter_password_input.is_element_displayed():
+            self.errors.append(sign_button_warning.format('sending 0 ETH with an empty ETH balance'))
+
+        send_transaction_view.cross_icon.click()
+        chat.send_transaction_in_1_1_chat(asset='STT', amount='0', wallet_set_up=False, sign_transaction=False)
+
+        # Check whether sending 0 STT with an empty ETH balance triggers the warning
+        if not send_transaction_view.validation_warnings.not_enough_eth_for_gas.is_element_displayed():
+            self.errors.append(warning.format('sending 0 STT with an empty ETH balance'))
+
+        # Check whether sign transaction button is disabled
+        send_transaction_view.sign_transaction_button.click()
+        if send_transaction_view.enter_password_input.is_element_displayed():
+            self.errors.append(sign_button_warning.format('sending 0 STT with an empty ETH balance'))
+
+        send_transaction_view.cross_icon.click()
+        # Requesting test ETH and waiting till the balance updates
+        self.network_api.faucet(wallet_address[2:])
+        self.network_api.verify_balance_is_updated(initial_balance=0, recipient_address=wallet_address[2:])
+        chat.send_transaction_in_1_1_chat(asset='ETHro', amount='0.1', wallet_set_up=False, sign_transaction=False)
+
+        # Check whether sending all available ETH triggers the warning
+        if not send_transaction_view.validation_warnings.not_enough_eth_for_gas.is_element_displayed():
+            self.errors.append(warning.format('sending all available ETH'))
+
+        # Check whether sign transaction button is disabled
+        send_transaction_view.sign_transaction_button.click()
+        if send_transaction_view.enter_password_input.is_element_displayed():
+            self.errors.append(sign_button_warning.format('sending all available ETH'))
+
+        chat.send_transaction_in_1_1_chat(asset='ETHro', amount='0.099979000000000001',
+                                          wallet_set_up=False, sign_transaction=False)
+
+        # Check whether sending big amount of ETH triggers the warning (no funds to pay gas)
+        if not send_transaction_view.validation_warnings.not_enough_eth_for_gas.is_element_displayed():
+            self.errors.append('sending big amount of ETH (no funds to pay gas)')
+
+        # Check whether sign transaction button is disabled
+        send_transaction_view.sign_transaction_button.click()
+        if send_transaction_view.enter_password_input.is_element_displayed():
+            self.errors.append('sending big amount of ETH (no funds to pay gas)')
+
+        chat.send_transaction_in_1_1_chat(asset='ETHro', amount='0.099979', wallet_set_up=False, sign_transaction=False)
+        # Check whether sending normal amount of ETH does not trigger the warning
+        if send_transaction_view.validation_warnings.not_enough_eth_for_gas.is_element_displayed():
+            self.errors.append('"Not enough ETH for gas" warning appeared while sending normal amount of ETH')
+
+        send_transaction_view.sign_transaction()
+        if not wallet.send_transaction_button.is_element_displayed():
+            self.errors.append('Could not sing the transaction!')
+
+        self.verify_no_errors()

--- a/test/appium/views/chat_view.py
+++ b/test/appium/views/chat_view.py
@@ -357,7 +357,7 @@ class ChatView(BaseView):
         self.clear_history_button.click()
         self.clear_button.click()
 
-    def send_transaction_in_1_1_chat(self, asset, amount, password=common_password, wallet_set_up=False):
+    def send_transaction_in_1_1_chat(self, asset, amount, password=common_password, wallet_set_up=False, **kwargs):
         self.commands_button.click()
         self.send_command.click()
         self.asset_by_name(asset).click()
@@ -370,12 +370,13 @@ class ChatView(BaseView):
             wallet_view.yes_button.click()
         else:
             self.send_message_button.click_until_presence_of_element(send_transaction_view.sign_transaction_button)
-        send_transaction_view.sign_transaction(password)
-        chat_elem = self.chat_element_by_text(amount)
-        chat_elem.wait_for_visibility_of_element()
-        chat_elem.progress_bar.wait_for_invisibility_of_element(20)
-        if chat_elem.status.text not in ('Sent', 'Delivered', 'Seen'):
-            self.driver.fail('Sent transaction message was not sent')
+        if kwargs.get('sign_transaction', True):
+            send_transaction_view.sign_transaction(password)
+            chat_elem = self.chat_element_by_text(amount)
+            chat_elem.wait_for_visibility_of_element()
+            chat_elem.progress_bar.wait_for_invisibility_of_element(20)
+            if chat_elem.status.text not in ('Sent', 'Delivered', 'Seen'):
+                self.driver.fail('Sent transaction message was not sent')
 
     def send_transaction_in_group_chat(self, amount, password, recipient):
         self.commands_button.click()

--- a/test/appium/views/send_transaction_view.py
+++ b/test/appium/views/send_transaction_view.py
@@ -143,6 +143,17 @@ class OnboardingMessage(BaseElement):
         self.locator = self.Locator.text_selector('Set up your wallet')
 
 
+class NotEnoughEthForGas(BaseText):
+    def __init__(self, driver):
+        super().__init__(driver)
+        self.locator = self.Locator.text_selector('Not enough ETH for gas')
+
+
+class ValidationWarnings(object):
+    def __init__(self, driver):
+        self.not_enough_eth_for_gas = NotEnoughEthForGas(driver)
+
+
 class SendTransactionView(BaseView):
     def __init__(self, driver):
         super(SendTransactionView, self).__init__(driver)
@@ -176,6 +187,7 @@ class SendTransactionView(BaseView):
         self.progress_bar = ProgressBar(self.driver)
 
         self.onboarding_message = OnboardingMessage(self.driver)
+        self.validation_warnings = ValidationWarnings(self.driver)
 
     def complete_onboarding(self):
         if self.onboarding_message.is_element_displayed():

--- a/test/appium/views/wallet_view.py
+++ b/test/appium/views/wallet_view.py
@@ -284,8 +284,7 @@ class WalletView(BaseView):
         asset_button.click()
         send_transaction_view.amount_edit_box.click()
 
-        transaction_amount = str(kwargs.get('amount')) if kwargs.get('amount') else \
-            send_transaction_view.get_unique_amount()
+        transaction_amount = str(kwargs.get('amount', send_transaction_view.get_unique_amount()))
 
         send_transaction_view.amount_edit_box.set_value(transaction_amount)
         send_transaction_view.confirm()
@@ -302,7 +301,8 @@ class WalletView(BaseView):
             recent_recipient = send_transaction_view.element_by_text(recipient)
             send_transaction_view.recent_recipients_button.click_until_presence_of_element(recent_recipient)
             recent_recipient.click()
-        send_transaction_view.sign_transaction()
+        if kwargs.get('sign_transaction', True):
+            send_transaction_view.sign_transaction()
 
     def receive_transaction(self, **kwargs):
         self.receive_transaction_button.click()

--- a/test/appium/views/web_views/status_test_dapp.py
+++ b/test/appium/views/web_views/status_test_dapp.py
@@ -64,6 +64,16 @@ class StatusAPIButton(BaseButton):
             self.locator = self.Locator.text_part_selector('Request contact code')
 
 
+class SendOneTransactionInBatchButton(BaseButton):
+    def __init__(self, driver):
+        super().__init__(driver)
+        self.locator = self.Locator.text_selector('Send one Tx in batch')
+
+    def navigate(self):
+        from views.send_transaction_view import SendTransactionView
+        return SendTransactionView(self.driver)
+
+
 class StatusTestDAppView(BaseWebView):
 
     def __init__(self, driver):
@@ -77,6 +87,7 @@ class StatusTestDAppView(BaseWebView):
         self.transactions_button = TransactionsButton(self.driver)
         self.sign_message_button = TransactionsButton.SignMessageButton(self.driver)
         self.deploy_contract_button = TransactionsButton.DeployContractButton(self.driver)
+        self.send_one_tx_in_batch_button = SendOneTransactionInBatchButton(self.driver)
         self.test_filters_button = TransactionsButton.TestFiltersButton(self.driver)
 
         self.status_api_button = StatusAPIButton(self.driver)
@@ -84,3 +95,15 @@ class StatusTestDAppView(BaseWebView):
 
     def wait_for_d_aap_to_load(self, wait_time=10):
         self.assets_button.wait_for_visibility_of_element(seconds=wait_time)
+
+    def faucet_asset(self, asset='eth'):
+        self.wait_for_d_aap_to_load()
+        self.assets_button.click()
+        if asset == 'eth':
+            self.request_eth_button.click()
+            self.element_by_text('Faucet request recieved').wait_for_visibility_of_element()
+            self.ok_button.click()
+            self.element_by_text('Faucet request recieved').wait_for_invisibility_of_element()
+        elif asset == 'stt':
+            send_transaction_view = self.request_stt_button.click()
+            send_transaction_view.sign_transaction()


### PR DESCRIPTION
### Summary:
there are many use cases when a user cannot proceed with transaction due to not enough funds to pay gas although he/she has sufficient wallet balance.

The test verifies how the proper warning appears in these cases and checks whether the user can sign a transaction in such cases.

**Use cases:**

_DApp:_
- deploying simple contract with the empty wallet
- sending one tx in batch with a big amount of ETH (not enough funds to pay gas though)
- sending normal tx

_Wallet:_
- sending 0 ETH with the empty wallet
- sending 0 STT with the empty wallet
- sending all available ETH in the wallet
- sending a big amount of ETH (not enough funds to pay gas though)
- sending normal tx

_Chat:_
- sending 0 ETH with the empty wallet
- sending 0 STT with the empty wallet
- sending all available ETH in the wallet
- sending a big amount of ETH (not enough funds to pay gas though)
- sending normal tx


### Review notes:
- modified `send_transaction_in_1_1_chat()` method signature not to duplicate code-actions in the tests
- added new method `faucet_asset()` to `StatusTestDAppView` object
- skip mark test assigment due to the bug https://github.com/status-im/status-react/issues/6433


