### PR TITLE
download from DigitalOcean first since it's faster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 help: ##@other Show this help
 	@perl -e '$(HELP_FUN)' $(MAKEFILE_LIST)
 
-DO_SPACE_URL = https://status-go.ams3.digitaloceanspaces.com/
+DO_SPACE_URL = https://status-go.ams3.digitaloceanspaces.com
 GITHUB_URL = https://github.com/status-im/status-go/releases/download
 RCTSTATUS_DIR = modules/react-native-status/ios/RCTStatus
 ANDROID_LIBS_DIR = android/app/libs
@@ -49,30 +49,30 @@ prepare-desktop: ##@prepare Install desktop platform dependencies and prepare wo
 
 $(STATUS_GO_IOS_ARCH):
 	curl --fail --silent --location \
-		"$(GITHUB_URL)/$(STATUS_GO_VER)/status-go-ios.zip" \
+		"${DO_SPACE_URL}/status-go-ios-$(STATUS_GO_VER).zip" \
 		--output "$(STATUS_GO_IOS_ARCH)"; \
 	if [ $$? -ne 0 ]; then \
-		echo "Failed to download from GitHub, checking DigitalOcean Bucket..."; \
+		echo "Failed to download from DigitalOcean Bucket, checking GitHub..."; \
 		curl --fail --silent --location \
-			"${DO_SPACE_URL}/status-go-ios-$(STATUS_GO_VER).zip" \
+			"$(GITHUB_URL)/$(STATUS_GO_VER)/status-go-ios.zip" \
 			--output "$(STATUS_GO_IOS_ARCH)"; \
 		if [ $$? -ne 0 ]; then \
-			echo "Failed to download from DigitalOcean Spaces!"; \
+			echo "Failed to download from GitHub!"; \
 		fi \
 	fi
 
 $(STATUS_GO_DRO_ARCH):
 	mkdir -p $(ANDROID_LIBS_DIR)
 	curl --fail --silent --location \
-		"$(GITHUB_URL)/$(STATUS_GO_VER)/status-go-android.aar" \
+		"${DO_SPACE_URL}/status-go-android-$(STATUS_GO_VER).aar" \
 		--output "$(STATUS_GO_DRO_ARCH)"; \
 	if [ $$? -ne 0 ]; then \
-		echo "Failed to download from GitHub, checking DigitalOcean Bucket..."; \
+		echo "Failed to download from DigitalOcean Bucket, checking GitHub..."; \
 		curl --fail --silent --location \
-			"${DO_SPACE_URL}/status-go-android-$(STATUS_GO_VER).aar" \
+			"$(GITHUB_URL)/$(STATUS_GO_VER)/status-go-android.aar" \
 			--output "$(STATUS_GO_DRO_ARCH)"; \
 		if [ $$? -ne 0 ]; then \
-			echo "Failed to download from DigitalOcean Spaces!"; \
+			echo "Failed to download from GitHub!"; \
 		fi \
 	fi
 


### PR DESCRIPTION
Since downloads of `status-go-ios.zip` are abysmally slow form GitHub and slowing down the Prep step on Jenkins I'm switching around the download steps to first try DigitalOcean.

This is how it looks right now on Jenkins...
![slow_ios](https://user-images.githubusercontent.com/2212681/49080715-d7fa4080-f244-11e8-89c1-69adf5ac30fc.png)
Related: https://github.com/status-im/status-go/pull/1292