### PR TITLE
Don't show the LES debug label if the network wasn't initialized just yet

### DIFF
--- a/src/status_im/ui/screens/home/subs.cljs
+++ b/src/status_im/ui/screens/home/subs.cljs
@@ -13,6 +13,12 @@
  (fn [{:node/keys [chain-sync-state]} _] chain-sync-state))
 
 (re-frame/reg-sub
+ :current-network-initialized?
+ (fn [db _]
+   (let [network (get-in db [:account/account :networks (:network db)])]
+     (boolean network))))
+
+(re-frame/reg-sub
  :current-network-uses-rpc?
  (fn [db _]
    (let [network (get-in db [:account/account :networks (:network db)])]

--- a/src/status_im/ui/screens/home/views.cljs
+++ b/src/status_im/ui/screens/home/views.cljs
@@ -92,7 +92,8 @@
                   view-id [:get :view-id]
                   sync-state [:chain-sync-state]
                   latest-block-number [:latest-block-number]
-                  rpc-network? [:current-network-uses-rpc?]]
+                  rpc-network? [:current-network-uses-rpc?]
+                  network-initialized? [:current-network-initialized?]]
     {:component-did-mount
      (fn [this]
        (let [[_ loading?] (.. this -props -argv)]
@@ -108,7 +109,7 @@
                     (true? old-loading?))
            (re-frame/dispatch [:load-chats-messages]))))}
     [react/view styles/container
-     [toolbar show-welcome? (not rpc-network?) sync-state latest-block-number]
+     [toolbar show-welcome? (and network-initialized? (not rpc-network?)) sync-state latest-block-number]
      (cond show-welcome?
            [welcome view-id]
            loading?


### PR DESCRIPTION


fixes #6823

### Testing notes (optional):
<!-- (Specify which platforms should be tested) -->
#### Platforms (optional)
- Android
- iOS

<!-- (Specify exact steps to test if there are such) -->
### Steps to test:
- Open Status (a clean account, an RPC network)
- Sign-in
- LES label shouldn't be visible at any point anymore, even for a split second.

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->