### PR TITLE
Check if package-lock.json was changed and fail the build (Mobile only)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ setup: ##@prepare Install all the requirements for status-react
 
 prepare-desktop: ##@prepare Install desktop platform dependencies and prepare workspace
 	scripts/prepare-for-platform.sh desktop
-	npm install
+	scripts/locked-npm-install.sh
 
 $(STATUS_GO_IOS_ARCH):
 	curl --fail --silent --location \
@@ -78,7 +78,7 @@ $(STATUS_GO_DRO_ARCH):
 
 prepare-ios: $(STATUS_GO_IOS_ARCH) ##@prepare Install and prepare iOS-specific dependencies
 	scripts/prepare-for-platform.sh ios
-	npm install
+	scripts/locked-npm-install.sh
 	unzip -q -o "$(STATUS_GO_IOS_ARCH)" -d "$(RCTSTATUS_DIR)"
 ifeq ($(OS),Darwin)
 	cd ios && pod install
@@ -86,7 +86,7 @@ endif
 
 prepare-android: $(STATUS_GO_DRO_ARCH) ##@prepare Install and prepare Android-specific dependencies
 	scripts/prepare-for-platform.sh android
-	npm install
+	scripts/locked-npm-install.sh
 	cd android && ./gradlew react-native-android:installArchives
 
 prepare-mobile: prepare-android prepare-ios ##@prepare Install and prepare mobile platform specific dependencies

--- a/ci/common.groovy
+++ b/ci/common.groovy
@@ -53,19 +53,27 @@ def installJSDeps(platform) {
   def attempt = 1
   def maxAttempts = 10
   def installed = false
-  def errroCode = 0
+  def errorCode = 0
+  def errorLog = ""
   /* prepare environment for specific platform build */
   sh "scripts/prepare-for-platform.sh ${platform}"
   while (!installed && attempt <= maxAttempts) {
     println("#${attempt} attempt to install npm deps")
 
-    errorCode = sh('scripts/locked-npm-install.sh', returnStatus: true)
+    try {
+      errorLog = sh(
+        returnStdout: true, 
+        script: 'scripts/locked-npm-install.sh'
+      )
+    } catch (exc) {
+        errorCode = 1
+    }
     installed = fileExists('node_modules/web3/index.js')
     attemp = attempt + 1
   }
 
   if(!installed || errorCode != 0) {
-    error "node dependencies installation failed (installed: ${installed}, errorCode: ${errorCode})"
+    error "node dependencies installation failed (installed: ${installed}, errorCode: ${errorCode}, errorLog: ${errorLog})"
   }
 }
 

--- a/ci/common.groovy
+++ b/ci/common.groovy
@@ -53,13 +53,19 @@ def installJSDeps(platform) {
   def attempt = 1
   def maxAttempts = 10
   def installed = false
+  def errroCode = 0
   /* prepare environment for specific platform build */
   sh "scripts/prepare-for-platform.sh ${platform}"
   while (!installed && attempt <= maxAttempts) {
     println("#${attempt} attempt to install npm deps")
-    sh 'npm install'
+
+    errorCode = sh('scripts/locked-npm-install.sh', returnStatus: true)
     installed = fileExists('node_modules/web3/index.js')
     attemp = attempt + 1
+  }
+
+  if(!installed || errorCode != 0) {
+    error "node dependencies installation failed (installed: ${installed}, errorCode: ${errorCode})"
   }
 }
 

--- a/docker-build/Dockerfile
+++ b/docker-build/Dockerfile
@@ -80,7 +80,9 @@ ADD ./project.clj ./
 
 ADD ./package.json package-lock.json ./
 
-RUN npm install
+ADD ./scripts ./
+
+RUN scripts/locked-npm-install.sh
 
 ADD . ./
 

--- a/mobile_files/package-lock.json
+++ b/mobile_files/package-lock.json
@@ -8649,7 +8649,7 @@
         },
         "core-js": {
           "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
           "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
         },
         "create-react-class": {
@@ -8791,7 +8791,9 @@
       }
     },
     "react-native-http-bridge": {
-      "version": "git+https://github.com/status-im/react-native-http-bridge.git#214301a806743d0ce04f4559c3d55b3e8ff95f5d"
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/react-native-http-bridge/-/react-native-http-bridge-0.6.1.tgz",
+      "integrity": "sha512-XnPVdaYkKIC8bRGmADVLhgDO0Evnya3rOExVEzxk6pBJjNUewWljkGHt//OTpb4t7Te6oDqQAwa+gfVtzhRU1A=="
     },
     "react-native-i18n": {
       "version": "2.0.15",

--- a/scripts/build-android.sh
+++ b/scripts/build-android.sh
@@ -14,7 +14,7 @@ echo
 
 GRADLE_PROPERTIES="--daemon --parallel -q -b android/build.gradle"
 
-npm install
+scripts/locked-npm-install.sh
 
 case $TARGET in
   debug)

--- a/scripts/locked-npm-install.sh
+++ b/scripts/locked-npm-install.sh
@@ -23,7 +23,9 @@ fi
 
 EXIT_CODE=0
 
-for LOCK_FILE in "mobile_files/package-lock.json" "desktop_files/package-lock.json"
+                                                  # TODO: Re-enable when Desktop's package-lock is fixed.
+                                                  # 
+for LOCK_FILE in "mobile_files/package-lock.json" #"desktop_files/package-lock.json"
 do
     echo "VERIFYING LOCK FILE: $LOCK_FILE"
 

--- a/scripts/locked-npm-install.sh
+++ b/scripts/locked-npm-install.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+# This script should be used instead of `npm install` in the project for security reasons.
+# The script checks if `npm install` changed the package-lock.json file, this way
+# it verifies that all the downloaded dependencies are of the versions we expect they have.
+#
+# Usage:
+#
+# From the root project directory call `scripts/locked-npm-install.sh`
+#
+# Return value:
+# 
+# Script returns 0 if all lock files are up to date, 1 otherwise.
+
+npm install
+
+EXIT_CODE=0
+
+for LOCK_FILE in "mobile_files/package-lock.json" "desktop_files/package-lock.json"
+do
+    echo "VERIFYING LOCK FILE: $LOCK_FILE"
+
+    git diff-index --quiet HEAD $LOCK_FILE
+    DIFF_RESULT=$?
+
+    if [ $DIFF_RESULT -ne 0 ]; then
+        echo "!!! $LOCK_FILE is OUTDATED !!!"
+        echo "if that is expected, please, commit your changes to the package-lock.json"
+        echo "if that is unexpected, please, verify the new dependencies or report to security@status.im"
+
+        echo "DIFF of $LOCK_FILE"
+        git --no-pager diff $LOCK_FILE
+        EXIT_CODE=1
+    else
+        echo "$LOCK_FILE is up-to-date"
+    fi
+    echo ""
+    echo ""
+done
+
+exit $EXIT_CODE

--- a/scripts/locked-npm-install.sh
+++ b/scripts/locked-npm-install.sh
@@ -14,6 +14,13 @@
 
 npm install
 
+NPM_EXIT_CODE=$?
+
+if [ $NPM_EXIT_CODE -ne 0 ]; then
+    echo "Error while running npm install"
+    exit $NPM_EXIT_CODE
+fi
+
 EXIT_CODE=0
 
 for LOCK_FILE in "mobile_files/package-lock.json" "desktop_files/package-lock.json"
@@ -27,9 +34,19 @@ do
         echo "!!! $LOCK_FILE is OUTDATED !!!"
         echo "if that is expected, please, commit your changes to the package-lock.json"
         echo "if that is unexpected, please, verify the new dependencies or report to security@status.im"
-
+        echo ""
+        echo "*************************"
         echo "DIFF of $LOCK_FILE"
+        echo "if the only difference in the diff is https -> http, try doing"
+        echo "+------------------------------+"
+        echo "| > rm -rf node_modules/       |"
+        echo "| > npm cache clean --force    |"
+        echo "+------------------------------+"
+        echo "and run this script again"
+        echo "-> https://npm.community/t/npm-install-downgrading-resolved-packages-from-https-to-http-registry-in-package-lock-json/1818/7"
+        echo "-> https://npm.community/t/some-packages-have-dist-tarball-as-http-and-not-https/285/9"
         git --no-pager diff $LOCK_FILE
+
         EXIT_CODE=1
     else
         echo "$LOCK_FILE is up-to-date"

--- a/scripts/run-osx
+++ b/scripts/run-osx
@@ -61,7 +61,7 @@ open -a /Applications/Genymotion.app/Contents/MacOS/player.app --args --vm-name 
 fi
 
 # Install deps
-npm install
+scripts/locked-npm-install.sh
 
 cd android && ./gradlew react-native-android:installArchives && cd ../
 


### PR DESCRIPTION
Due to vulnerabilities, like the one found in [event-stream](https://snyk.io/blog/malicious-code-found-in-npm-package-event-stream), we can't trust npm even when locking the version numbers.
Hence, we are trying to mitigate similar issues by checking if `package-lock.json` was updated after `npm install` and failing the build if it was.
The lock file contains a checksum of the minified package, so if someone updates it but keeps the same version, this script should detect it.

- [x] Write the script
- [x] Update the `package-lock.json` content
- [x] Plug in the new script instead of `npm install`
- [x] Ensure the deps versions in the `package.json` are locked
- [x] (Temporarily) Disable Desktop and add a follow-up PR. (https://github.com/status-im/status-react/pull/6918)

fixes #6906

status: ready <!-- Can be ready or wip -->