### PR TITLE
[TESTS] User can see own collectibles after recovering the account

### DIFF
--- a/test/appium/tests/atomic/account_management/test_wallet_management.py
+++ b/test/appium/tests/atomic/account_management/test_wallet_management.py
@@ -199,9 +199,8 @@ class TestWalletManagement(SingleDeviceTestCase):
 
     @marks.testrail_id(5381)
     @marks.high
-    @marks.skip
     def test_user_can_see_all_own_assets_after_account_recovering(self):
-        passphrase = wallet_users['D']['passphrase']
+        passphrase = wallet_users['E']['passphrase']
         signin_view = SignInView(self.driver)
         home_view = signin_view.recover_access(passphrase=passphrase)
         profile = home_view.profile_button.click()

--- a/test/appium/tests/users.py
+++ b/test/appium/tests/users.py
@@ -35,7 +35,7 @@ wallet_users['D']['address'] = "80b663e82657caf5657ce79b11aeaeda02c6cd92"
 wallet_users['D']['public_key'] = "0x048d9ee2acb99b0c9fef98665f8287d99fc365c5e827fc2541ffdce4cb87a9480bbea8" \
                                   "324968b9bb1ae6c2eca37cf0ab4aba9d85755e3a532431b9edc189f23c7c"
 wallet_users['E'] = dict()
-wallet_users['E']['passpharse'] = "record sphere illegal section blame swing wreck estate celery same excite summer"
+wallet_users['E']['passphrase'] = "record sphere illegal section blame swing wreck estate celery same excite summer"
 wallet_users['E']['username'] = "Homely Untimely Grasshopper"
 wallet_users['E']['address'] = "0x3e2e4077753d3c229a9ae332b9ca46958945e2f6"
 wallet_users['E']['public_key'] = "0x04a30d58c2c65c654a521455dabc139a9c26be7ca565f152a8182376150c1e12fe362c017a21b0e" \

--- a/test/appium/views/wallet_view.py
+++ b/test/appium/views/wallet_view.py
@@ -330,4 +330,5 @@ class WalletView(BaseView):
 
     def collectible_amount_by_name(self, name):
         elm = CollectibleTextElement(self.driver, name)
+        elm.scroll_to_element()
         return elm.text


### PR DESCRIPTION
### Review notes:

- removed `skip` mark. reason: account has KudosToken collectible now and the test works as designed
- small fixes for the test

Related to https://github.com/status-im/status-react/pull/6745

Status: ready

