### PR TITLE
bump linux timeout to 35 minutes

### DIFF
--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -17,7 +17,7 @@ pipeline {
   options {
     timestamps()
     /* Prevent Jenkins jobs from running forever */
-    timeout(time: 25, unit: 'MINUTES')
+    timeout(time: 35, unit: 'MINUTES')
     /* Limit builds retained */
     buildDiscarder(logRotator(
       numToKeepStr: '60',


### PR DESCRIPTION
The average is too close to 25 minutes, which is the current timeout:
https://ci.status.im/job/status-react/job/combined/job/desktop-linux/

<blockquote><img src="/static/e7749a62/favicon.ico" width="48" align="right"><div><strong><a href="https://ci.status.im/job/status-react/job/combined/job/desktop-linux/">desktop-linux [status-react » combined] [Jenkins]</a></strong></div></blockquote>