### PR TITLE
Fix check for yarn

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,8 @@ clean: ##@prepare Remove all output folders
 	git clean -dxf -f -e android/local.properties
 
 setup: ##@prepare Install all the requirements for status-react
-	./scripts/setup
+	@./scripts/setup
+	@./scripts/run-pre-build-check.sh
 
 prepare-desktop: ##@prepare Install desktop platform dependencies and prepare workspace
 	scripts/prepare-for-platform.sh desktop

--- a/scripts/lib/setup/installers.sh
+++ b/scripts/lib/setup/installers.sh
@@ -211,15 +211,18 @@ function install_react_native_cli() {
 }
 
 function install_yarn() {
-  if ! program_exists "node"; then
-    npm install -g yarn@1.12.3 # Install the latest yarn
+  local expected_version="1.12.3"
+  if ! program_exists "yarn"; then
+    npm install -g yarn@$expected_version # Install the latest yarn
   else
     cecho "+ yarn already installed... skipping."
   fi
 
-  local yarn_version=$(yarn -v)
-  if [[ $yarn_version != "1.12.3" ]]; then
-    cecho "@b@red[[+ yarn version $yarn_version is installed. yarn version 1.12.3 is recommended.]]"
+  if program_exists "yarn"; then
+    local yarn_version=$(yarn -v)
+    if [[ $yarn_version != "$expected_version" ]]; then
+      cecho "@b@red[[+ yarn version $yarn_version is installed. yarn version $expected_version is recommended.]]"
+    fi
   fi
 }
 

--- a/scripts/run-pre-build-check.sh
+++ b/scripts/run-pre-build-check.sh
@@ -9,6 +9,11 @@ PLATFORM=""
 EXPECTED_NODE_VERSION="v9.3.0" # note the 'v' in front, that is how node does versioning
 EXPECTED_YARN_VERSION="1.12.3" # note the lack of 'v' in front. inconsistent. :(
 
+function program_exists() {
+  local program=$1
+  command -v "$program" >/dev/null 2>&1
+}
+
 #if no arguments passed, inform user about possible ones
 
 if [ $# -eq 0 ]; then
@@ -18,8 +23,14 @@ else
   PLATFORM=$1
 fi
 
-node_version=$(node -v)
+if ! program_exists node || ! program_exists yarn; then
+  echo -e "${YELLOW}********************************************************************************************"
+  echo -e "Please open another console to reload the environment, and then run make setup if necessary."
+  echo -e "********************************************************************************************${NC}"
+  exit 1
+fi
 
+node_version=$(node -v)
 if [[ $node_version != $EXPECTED_NODE_VERSION ]]; then
   echo -e "${YELLOW}+ node version $node_version is installed. node version $EXPECTED_NODE_VERSION is recommended.${NC}"
 fi


### PR DESCRIPTION
I've run into a funny issue when switching to `develop`. Even after fixing this typo, it would install `yarn` but not know about it after completing `make setup` because it would be on a bad selection in `nvm` (still pointing to 8.x.x). I had to manually do `nvm use status-im` for things to start working.