### PR TITLE
Fix make startdev-desktop target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -213,4 +213,8 @@ startdev-%:
 	$(eval SYSTEM := $(word 2, $(subst -, , $@)))
 	$(eval DEVICE := $(word 3, $(subst -, , $@)))
 	${MAKE} prepare-${SYSTEM}
-	${MAKE} watch-$(SYSTEM)-$(DEVICE)
+	if [ -z "$(DEVICE)" ]; then \
+		${MAKE} watch-$(SYSTEM); \
+	else \
+		${MAKE} watch-$(SYSTEM)-$(DEVICE); \
+	fi


### PR DESCRIPTION
It was invoking `watch-desktop-` target

status: ready <!-- Can be ready or wip -->
