### PR TITLE
Fixes issue with launching of reportApp window on application crash event.

### DIFF
--- a/desktop/main.cpp
+++ b/desktop/main.cpp
@@ -46,12 +46,6 @@ QProcess *g_nodeJsServerProcess = nullptr;
 const int MAIN_WINDOW_WIDTH = 1024;
 const int MAIN_WINDOW_HEIGHT = 768;
 const QString CRASH_REPORT_EXECUTABLE = QStringLiteral("reportApp");
-const QString CRASH_REPORT_EXECUTABLE_RELATIVE_PATH =
-#ifdef Q_OS_WIN
-    QStringLiteral("");
-#else
-    QStringLiteral("/../reportApp");
-#endif
 
 const char *ENABLE_LOG_FILE_ENV_VAR_NAME = "STATUS_LOG_FILE_ENABLED";
 const char *LOG_FILE_PATH_ENV_VAR_NAME = "STATUS_LOG_PATH";
@@ -253,7 +247,6 @@ int main(int argc, char **argv) {
     killZombieJsServer();
   }
 #else
-  appPath.append(CRASH_REPORT_EXECUTABLE_RELATIVE_PATH);
   dataStoragePath = "";
 #endif
 

--- a/desktop/reportApp/main.qml
+++ b/desktop/reportApp/main.qml
@@ -28,7 +28,7 @@ Rectangle {
       Text {
         Layout.alignment: Qt.AlignCenter
         Layout.topMargin: 20
-        text: "Please report us crash log files to allow us fix the issue!"
+        text: "Please report us <b>crash.dmp</b> and <b>Status</b> executable files to allow us fix the issue!"
         font.bold: true
         font.pointSize: 20
       }
@@ -63,7 +63,8 @@ Rectangle {
               wrapMode: TextEdit.Wrap
               selectByMouse: true
               font.pointSize: 12
-              text: "Log files directory:\n" + reportPublisher.resolveDataStoragePath()
+              textFormat: TextEdit.RichText
+              text: "<div>Please upload both <b>crash.dmp</b> and <b>Status</b> executable files from the report directory:<br>" + reportPublisher.resolveDataStoragePath() + "</div>"
           }
 
           Button {

--- a/desktop/reportApp/reportpublisher.cpp
+++ b/desktop/reportApp/reportpublisher.cpp
@@ -36,17 +36,23 @@ void ReportPublisher::submit() {
 void ReportPublisher::restartAndQuit() {
   QString appPath = m_crashedExecutablePath;
 
-#ifdef Q_OS_MACOS
+#if defined(Q_OS_MACOS) || defined(Q_OS_LINUX)
   QFileInfo crashedExecutableFileInfo(m_crashedExecutablePath);
   QString fullPath = crashedExecutableFileInfo.dir().absolutePath();
+  #ifdef Q_OS_MACOS
   const QString bundleExtension = QStringLiteral(".app");
+  const QString cmdTemplate = QStringLiteral("open \"%1\"");
+  #else
+  const QString bundleExtension = QStringLiteral(".AppImage");
+  const QString cmdTemplate = QStringLiteral("\"%1\"");
+  #endif
   if (fullPath.contains(bundleExtension)) {
     appPath = fullPath.left(fullPath.indexOf(bundleExtension) +
                             bundleExtension.size());
   }
-  QString cmd = QString("open %1").arg(appPath);
+  QString cmd = QString(cmdTemplate).arg(appPath);
 #else
-  QString cmd = appPath;
+  QString cmd = QString("\"%1\"").arg(appPath);;
 #endif
 
   QProcess::startDetached(cmd);
@@ -61,8 +67,8 @@ void ReportPublisher::showDirectory() {
   if (!m_logFilesPrepared) {
     m_logFilesPrepared = prepareReportFiles(dataStoragePath);
   }
-  QDesktopServices::openUrl(
-      QUrl("file://" + dataStoragePath, QUrl::TolerantMode));
+
+  QDesktopServices::openUrl(QUrl::fromLocalFile(dataStoragePath));
 }
 
 bool ReportPublisher::prepareReportFiles(QString reportDirPath) {
@@ -101,5 +107,5 @@ QString ReportPublisher::resolveDataStoragePath() {
   if (!dir.exists()) {
     dir.mkpath(".");
   }
-  return dataStoragePath;
+  return dir.path();
 }

--- a/desktop_files/yarn.lock
+++ b/desktop_files/yarn.lock
@@ -4501,7 +4501,7 @@ glogg@^1.0.0:
 
 "google-breakpad@git+https://github.com/status-im/google-breakpad.git":
   version "1.0.0"
-  resolved "git+https://github.com/status-im/google-breakpad.git#9b6167b415d704c80a3303418a7c79d5ed0482ff"
+  resolved "git+https://github.com/status-im/google-breakpad.git#9fcfdc23010ce2b0742d276e2959ab13e7cf0dc7"
 
 got@^5.0.0, got@^5.2.0:
   version "5.7.1"


### PR DESCRIPTION
Signed-off-by: Max Risuhin <risuhin.max@gmail.com>

[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes #6656

### Summary:

Updates crash report Windows texts to ask user to attach crash .dmp file and Status executable file.
Crash handling on Windows (depends on PR https://github.com/status-im/google-breakpad/pull/1)
Fixes issue with launching of reportApp window on application crash event.

...

status: ready <!-- Can be ready or wip -->
