### PR TITLE
fix replies compatibility

### DIFF
--- a/src/status_im/chat/db.cljs
+++ b/src/status_im/chat/db.cljs
@@ -60,10 +60,11 @@
                          :type  :datemark})
                   (map (fn [{:keys [message-id timestamp-str]}]
                          (let [{:keys [content] :as message} (get messages message-id)
-                               quote (some-> (:response-to content)
+                               {:keys [response-to response-to-v2]} content
+                               quote (some-> (or response-to-v2 response-to)
                                              (quoted-message-data messages referenced-messages))]
                            (cond-> (-> message
-                                       (update :content dissoc :response-to)
+                                       (update :content dissoc :response-to :response-to-v2)
                                        (assoc :datemark      datemark
                                               :timestamp-str timestamp-str
                                               :user-statuses (get message-statuses message-id)))

--- a/src/status_im/chat/models/input.cljs
+++ b/src/status_im/chat/models/input.cljs
@@ -87,10 +87,12 @@
 
 (fx/defn reply-to-message
   "Sets reference to previous chat message and focuses on input"
-  [{:keys [db] :as cofx} message-id]
+  [{:keys [db] :as cofx} message-id old-message-id]
   (let [current-chat-id (:current-chat-id db)]
     (fx/merge cofx
-              {:db (assoc-in db [:chats current-chat-id :metadata :responding-to-message] message-id)}
+              {:db (assoc-in db [:chats current-chat-id :metadata :responding-to-message]
+                             {:message-id     message-id
+                              :old-message-id old-message-id})}
               (chat-input-focus :input-ref))))
 
 (fx/defn cancel-message-reply
@@ -121,15 +123,17 @@
   "no command detected, when not empty, proceed by sending text message without command processing"
   [input-text current-chat-id {:keys [db] :as cofx}]
   (when-not (string/blank? input-text)
-    (let [reply-to-message (get-in db [:chats current-chat-id :metadata :responding-to-message])]
+    (let [{:keys [message-id old-message-id]}
+          (get-in db [:chats current-chat-id :metadata :responding-to-message])]
       (fx/merge cofx
                 {:db (assoc-in db [:chats current-chat-id :metadata :responding-to-message] nil)}
                 (chat.message/send-message {:chat-id      current-chat-id
                                             :content-type constants/content-type-text
                                             :content      (cond-> {:chat-id current-chat-id
                                                                    :text    input-text}
-                                                            reply-to-message
-                                                            (assoc :response-to reply-to-message))})
+                                                            message-id
+                                                            (assoc :response-to old-message-id
+                                                                   :response-to-v2 message-id))})
                 (commands.input/set-command-reference nil)
                 (set-chat-input-text nil)
                 (process-cooldown)))))

--- a/src/status_im/chat/subs.cljs
+++ b/src/status_im/chat/subs.cljs
@@ -263,4 +263,4 @@
  :chats/reply-message
  :<- [:chats/current-chat]
  (fn [{:keys [metadata messages]}]
-   (get messages (:responding-to-message metadata))))
+   (get messages (get-in metadata [:responding-to-message :message-id]))))

--- a/src/status_im/data_store/realm/schemas/account/core.cljs
+++ b/src/status_im/data_store/realm/schemas/account/core.cljs
@@ -278,6 +278,19 @@
           browser/v8
           dapp-permissions/v9])
 
+(def v27 [chat/v9
+          transport/v7
+          contact/v3
+          message/v8
+          mailserver/v11
+          mailserver-topic/v1
+          user-status/v2
+          membership-update/v1
+          installation/v2
+          local-storage/v1
+          browser/v8
+          dapp-permissions/v9])
+
 ;; put schemas ordered by version
 (def schemas [{:schema        v1
                :schemaVersion 1
@@ -356,4 +369,7 @@
                :migration     migrations/v25}
               {:schema        v26
                :schemaVersion 26
-               :migration     migrations/v26}])
+               :migration     migrations/v26}
+              {:schema        v27
+               :schemaVersion 27
+               :migration     migrations/v27}])

--- a/src/status_im/data_store/realm/schemas/account/message.cljs
+++ b/src/status_im/data_store/realm/schemas/account/message.cljs
@@ -51,3 +51,9 @@
                                          :default 0}
                       :show?            {:type    :bool
                                          :default true}}})
+
+(def v8
+  (-> v7
+      (assoc-in [:properties :old-message-id]
+                {:type    :string
+                 :indexed true})))

--- a/src/status_im/data_store/realm/schemas/account/migrations.cljs
+++ b/src/status_im/data_store/realm/schemas/account/migrations.cljs
@@ -3,6 +3,9 @@
             [cljs.reader :as reader]
             [status-im.chat.models.message-content :as message-content]
             [status-im.transport.utils :as transport.utils]
+            [cljs.tools.reader.edn :as edn]
+            [status-im.js-dependencies :as dependencies]
+            [clojure.string :as string]
             [cljs.tools.reader.edn :as edn]))
 
 (defn v1 [old-realm new-realm]
@@ -172,7 +175,7 @@
       (let [message (aget new-messages i)
             message-id (aget message "message-id")
             from (aget message "from")
-            chat-id (aget message "chat-id")
+            chat-id (:chat-id (edn/read-string (aget message "content")))
             clock-value (aget message "clock-value")
             new-message-id (transport.utils/message-id
                             {:from        from
@@ -240,3 +243,33 @@
                                                     "status = \"received\""))
                                     (.-length))]
         (aset chat "unviewed-messages-count" user-statuses-count)))))
+
+(defrecord Message [content content-type message-type clock-value timestamp])
+
+(defn sha3 [s]
+  (.sha3 dependencies/Web3.prototype s))
+
+(defn replace-ns [str-message]
+  (string/replace-first
+   str-message
+   "status-im.data-store.realm.schemas.account.migrations"
+   "status-im.transport.message.protocol"))
+
+(defn old-message-id
+  [message]
+  (sha3 (replace-ns (pr-str message))))
+
+(defn v27 [old-realm new-realm]
+  (let [messages (.objects new-realm "message")]
+    (dotimes [i (.-length messages)]
+      (let [js-message     (aget messages i)
+            message        {:content      (edn/read-string
+                                           (aget js-message "content"))
+                            :content-type (aget js-message "content-type")
+                            :message-type (keyword
+                                           (aget js-message "message-type"))
+                            :clock-value  (aget js-message "clock-value")
+                            :timestamp    (aget js-message "timestamp")}
+            message-record (map->Message message)
+            old-message-id (old-message-id message-record)]
+        (aset js-message "old-message-id" old-message-id)))))

--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -692,8 +692,8 @@
 
 (handlers/register-handler-fx
  :chat.ui/reply-to-message
- (fn [cofx [_ message-id]]
-   (chat.input/reply-to-message cofx message-id)))
+ (fn [cofx [_ message-id old-message-id]]
+   (chat.input/reply-to-message cofx message-id old-message-id)))
 
 (handlers/register-handler-fx
  :chat.ui/send-current-message

--- a/src/status_im/transport/db.cljs
+++ b/src/status_im/transport/db.cljs
@@ -58,6 +58,7 @@
 
 (spec/def :message.content/text (spec/and string? (complement s/blank?)))
 (spec/def :message.content/response-to string?)
+(spec/def :message.content/response-to-v2 string?)
 (spec/def :message.content/command-path (spec/tuple string? (spec/coll-of (spec/or :scope keyword? :chat-id string?) :kind set? :min-count 1)))
 (spec/def :message.content/params (spec/map-of keyword? any?))
 

--- a/src/status_im/transport/message/protocol.cljs
+++ b/src/status_im/transport/message/protocol.cljs
@@ -116,8 +116,9 @@
   (receive [this chat-id signature _ cofx]
     {:chat-received-message/add-fx
      [(assoc (into {} this)
+             :old-message-id (transport.utils/old-message-id this)
              :message-id (transport.utils/message-id
-                          {:chat-id     chat-id
+                          {:chat-id     (:chat-id content)
                            :from        signature
                            :clock-value clock-value})
              :chat-id chat-id

--- a/src/status_im/transport/utils.cljs
+++ b/src/status_im/transport/utils.cljs
@@ -17,11 +17,13 @@
 (defn sha3 [s]
   (.sha3 dependencies/Web3.prototype s))
 
+(defn old-message-id
+  [message]
+  (sha3 (pr-str message)))
+
 (defn message-id
   "Get a message-id"
   [{:keys [from chat-id clock-value] :as m}]
-  {:pre [(not (nil? from))
-         (not (nil? chat-id))]}
   (sha3 (str from chat-id clock-value)))
 
 (defn get-topic

--- a/src/status_im/ui/components/list_selection.cljs
+++ b/src/status_im/ui/components/list_selection.cljs
@@ -12,9 +12,9 @@
             (:url content))
     (.share react/sharing (clj->js content))))
 
-(defn- message-options [message-id text]
+(defn- message-options [message-id old-message-id text]
   [{:label  (i18n/label :t/message-reply)
-    :action #(re-frame/dispatch [:chat.ui/reply-to-message message-id])}
+    :action #(re-frame/dispatch [:chat.ui/reply-to-message message-id old-message-id])}
    {:label  (i18n/label :t/sharing-copy-to-clipboard)
     :action #(react/copy-to-clipboard text)}
    {:label  (i18n/label :t/sharing-share)
@@ -25,9 +25,9 @@
     (action-sheet/show options)
     (dialog/show options)))
 
-(defn chat-message [message-id text dialog-title]
+(defn chat-message [message-id old-message-id text dialog-title]
   (show {:title       dialog-title
-         :options     (message-options message-id text)
+         :options     (message-options message-id old-message-id text)
          :cancel-text (i18n/label :t/message-options-cancel)}))
 
 (defn browse [link]

--- a/src/status_im/ui/screens/chat/message/message.cljs
+++ b/src/status_im/ui/screens/chat/message/message.cljs
@@ -253,13 +253,13 @@
    [react/view (style/delivery-status outgoing)
     [message-delivery-status message]]])
 
-(defn chat-message [{:keys [message-id outgoing group-chat modal? current-public-key content-type content] :as message}]
+(defn chat-message [{:keys [message-id old-message-id outgoing group-chat modal? current-public-key content-type content] :as message}]
   [react/view
    [react/touchable-highlight {:on-press      (fn [_]
                                                 (re-frame/dispatch [:chat.ui/set-chat-ui-props {:messages-focused? true}])
                                                 (react/dismiss-keyboard!))
                                :on-long-press #(when (= content-type constants/content-type-text)
-                                                 (list-selection/chat-message message-id (:text content) (i18n/label :t/message)))}
+                                                 (list-selection/chat-message message-id old-message-id (:text content) (i18n/label :t/message)))}
     [react/view {:accessibility-label :chat-item}
      (let [incoming-group (and group-chat (not outgoing))]
        [message-content message-body (merge message

--- a/src/status_im/ui/screens/desktop/main/chat/views.cljs
+++ b/src/status_im/ui/screens/desktop/main/chat/views.cljs
@@ -98,7 +98,7 @@
   (not= (get-in user-statuses [current-public-key :status]) :not-sent))
 
 (views/defview message-without-timestamp
-  [text {:keys [message-id content current-public-key user-statuses] :as message} style]
+  [text {:keys [message-id old-message-id content current-public-key user-statuses] :as message} style]
   [react/view {:flex 1 :margin-vertical 5}
    [react/touchable-highlight {:on-press (fn [arg]
                                            (when (= "right" (.-button (.-nativeEvent arg)))
@@ -107,7 +107,7 @@
                                                 :on-select #(do (utils/show-popup "" "Message copied to clipboard") (react/copy-to-clipboard text))}
                                                {:text (i18n/label :t/message-reply)
                                                 :on-select #(when (message-sent? user-statuses current-public-key)
-                                                              (re-frame/dispatch [:chat.ui/reply-to-message message-id]))}])))}
+                                                              (re-frame/dispatch [:chat.ui/reply-to-message message-id old-message-id]))}])))}
     [react/view {:style styles/message-container}
      (when (:response-to content)
        [quoted-message (:response-to content) false current-public-key])


### PR DESCRIPTION
fix #6903 
1. `old-message-id` field (indexed) was introduced in `message` entity and is calculated as `message-id` was calculated in `0.9.31`
```clojure
(defn old-message-id
  [message]
  (sha3 (pr-str message)))
```
2. When a reply message is sent from the PR version of app both `response-to` and `response-to-new` (probably better to call it `v2/response-to`) fields are sent as a part of `message`'s `content` field, so that it can be recognized by `0.9.31`.
3. When PR version of app receives reply from `0.9.31` we check whether message's `content` contains `response-to` but doesn't contain `response-to-new`, and if so we check whether DB contains message with `old-message-id=response-to`. If such message has been found we assoc `response-to-new` to content.
4. If message from DB contains only `response-to` but not `response-to-new` attempt to fetch the message by `old-message-id` is done (can be also handled by migration)

status: ready
