### PR TITLE
Tell user to run `nvm use` in terminal if needed

### DIFF
--- a/scripts/run-environment-check.sh
+++ b/scripts/run-environment-check.sh
@@ -25,7 +25,16 @@ fi
 
 if ! program_exists node || ! program_exists yarn; then
   echo -e "${YELLOW}********************************************************************************************"
-  echo -e "Please open another console to reload the environment, and then run make setup if necessary."
+
+  nvmrc="./.nvmrc"
+  if [ -e "$nvmrc" ]; then
+    node_version=$(node -v)
+    version_alias=$(cat "$nvmrc")
+    echo -e "Please run 'nvm use $version_alias' in the terminal and try again."
+  else
+    echo -e "Please open another console to reload the environment, and then run make setup if necessary."
+  fi
+
   echo -e "********************************************************************************************${NC}"
   exit 1
 fi


### PR DESCRIPTION
This PR addresses the fact that calling `nvm use` in the setup script only works inside that script (the `NVM_DIR` env var is not exported in the parent process, so if the user didn't have `status-im` active going in, it's not going to be active anyway after running `make setup`, therefore we need to instruct him to do so manually).

status: ready <!-- Can be ready or wip -->
