### PR TITLE
upgradable message-id

### DIFF
--- a/src/status_im/chat/db.cljs
+++ b/src/status_im/chat/db.cljs
@@ -60,10 +60,11 @@
                          :type  :datemark})
                   (map (fn [{:keys [message-id timestamp-str]}]
                          (let [{:keys [content] :as message} (get messages message-id)
-                               quote (some-> (:response-to content)
+                               {:keys [response-to response-to-v2]} content
+                               quote (some-> (or response-to-v2 response-to)
                                              (quoted-message-data messages referenced-messages))]
                            (cond-> (-> message
-                                       (update :content dissoc :response-to)
+                                       (update :content dissoc :response-to :response-to-v2)
                                        (assoc :datemark      datemark
                                               :timestamp-str timestamp-str
                                               :user-statuses (get message-statuses message-id)))

--- a/src/status_im/chat/models/input.cljs
+++ b/src/status_im/chat/models/input.cljs
@@ -87,10 +87,12 @@
 
 (fx/defn reply-to-message
   "Sets reference to previous chat message and focuses on input"
-  [{:keys [db] :as cofx} message-id]
+  [{:keys [db] :as cofx} message-id old-message-id]
   (let [current-chat-id (:current-chat-id db)]
     (fx/merge cofx
-              {:db (assoc-in db [:chats current-chat-id :metadata :responding-to-message] message-id)}
+              {:db (assoc-in db [:chats current-chat-id :metadata :responding-to-message]
+                             {:message-id     message-id
+                              :old-message-id old-message-id})}
               (chat-input-focus :input-ref))))
 
 (fx/defn cancel-message-reply
@@ -121,15 +123,17 @@
   "no command detected, when not empty, proceed by sending text message without command processing"
   [input-text current-chat-id {:keys [db] :as cofx}]
   (when-not (string/blank? input-text)
-    (let [reply-to-message (get-in db [:chats current-chat-id :metadata :responding-to-message])]
+    (let [{:keys [message-id old-message-id]}
+          (get-in db [:chats current-chat-id :metadata :responding-to-message])]
       (fx/merge cofx
                 {:db (assoc-in db [:chats current-chat-id :metadata :responding-to-message] nil)}
                 (chat.message/send-message {:chat-id      current-chat-id
                                             :content-type constants/content-type-text
                                             :content      (cond-> {:chat-id current-chat-id
                                                                    :text    input-text}
-                                                            reply-to-message
-                                                            (assoc :response-to reply-to-message))})
+                                                            message-id
+                                                            (assoc :response-to old-message-id
+                                                                   :response-to-v2 message-id))})
                 (commands.input/set-command-reference nil)
                 (set-chat-input-text nil)
                 (process-cooldown)))))

--- a/src/status_im/chat/subs.cljs
+++ b/src/status_im/chat/subs.cljs
@@ -263,4 +263,4 @@
  :chats/reply-message
  :<- [:chats/current-chat]
  (fn [{:keys [metadata messages]}]
-   (get messages (:responding-to-message metadata))))
+   (get messages (get-in metadata [:responding-to-message :message-id]))))

--- a/src/status_im/data_store/realm/schemas/account/core.cljs
+++ b/src/status_im/data_store/realm/schemas/account/core.cljs
@@ -278,6 +278,19 @@
           browser/v8
           dapp-permissions/v9])
 
+(def v27 [chat/v9
+          transport/v7
+          contact/v3
+          message/v8
+          mailserver/v11
+          mailserver-topic/v1
+          user-status/v2
+          membership-update/v1
+          installation/v2
+          local-storage/v1
+          browser/v8
+          dapp-permissions/v9])
+
 ;; put schemas ordered by version
 (def schemas [{:schema        v1
                :schemaVersion 1
@@ -356,4 +369,7 @@
                :migration     migrations/v25}
               {:schema        v26
                :schemaVersion 26
-               :migration     migrations/v26}])
+               :migration     migrations/v26}
+              {:schema        v27
+               :schemaVersion 27
+               :migration     migrations/v27}])

--- a/src/status_im/data_store/realm/schemas/account/message.cljs
+++ b/src/status_im/data_store/realm/schemas/account/message.cljs
@@ -51,3 +51,9 @@
                                          :default 0}
                       :show?            {:type    :bool
                                          :default true}}})
+
+(def v8
+  (-> v7
+      (assoc-in [:properties :old-message-id]
+                {:type    :string
+                 :indexed true})))

--- a/src/status_im/data_store/realm/schemas/account/migrations.cljs
+++ b/src/status_im/data_store/realm/schemas/account/migrations.cljs
@@ -3,6 +3,9 @@
             [cljs.reader :as reader]
             [status-im.chat.models.message-content :as message-content]
             [status-im.transport.utils :as transport.utils]
+            [cljs.tools.reader.edn :as edn]
+            [status-im.js-dependencies :as dependencies]
+            [clojure.string :as string]
             [cljs.tools.reader.edn :as edn]))
 
 (defn v1 [old-realm new-realm]
@@ -172,7 +175,7 @@
       (let [message (aget new-messages i)
             message-id (aget message "message-id")
             from (aget message "from")
-            chat-id (aget message "chat-id")
+            chat-id (:chat-id (edn/read-string (aget message "content")))
             clock-value (aget message "clock-value")
             new-message-id (transport.utils/message-id
                             {:from        from
@@ -240,3 +243,33 @@
                                                     "status = \"received\""))
                                     (.-length))]
         (aset chat "unviewed-messages-count" user-statuses-count)))))
+
+(defrecord Message [content content-type message-type clock-value timestamp])
+
+(defn sha3 [s]
+  (.sha3 dependencies/Web3.prototype s))
+
+(defn replace-ns [str-message]
+  (string/replace-first
+   str-message
+   "status-im.data-store.realm.schemas.account.migrations"
+   "status-im.transport.message.protocol"))
+
+(defn old-message-id
+  [message]
+  (sha3 (replace-ns (pr-str message))))
+
+(defn v27 [old-realm new-realm]
+  (let [messages (.objects new-realm "message")]
+    (dotimes [i (.-length messages)]
+      (let [js-message     (aget messages i)
+            message        {:content      (edn/read-string
+                                           (aget js-message "content"))
+                            :content-type (aget js-message "content-type")
+                            :message-type (keyword
+                                           (aget js-message "message-type"))
+                            :clock-value  (aget js-message "clock-value")
+                            :timestamp    (aget js-message "timestamp")}
+            message-record (map->Message message)
+            old-message-id (old-message-id message-record)]
+        (aset js-message "old-message-id" old-message-id)))))

--- a/src/status_im/data_store/realm/schemas/account/migrations.cljs
+++ b/src/status_im/data_store/realm/schemas/account/migrations.cljs
@@ -4,9 +4,10 @@
             [status-im.chat.models.message-content :as message-content]
             [status-im.transport.utils :as transport.utils]
             [cljs.tools.reader.edn :as edn]
-            [status-im.js-dependencies :as dependencies]
             [clojure.string :as string]
-            [cljs.tools.reader.edn :as edn]))
+            [status-im.constants :as constants]
+            [cognitect.transit :as transit]
+            [status-im.js-dependencies :as dependencies]))
 
 (defn v1 [old-realm new-realm]
   (log/debug "migrating v1 account database: " old-realm new-realm))
@@ -162,77 +163,9 @@
 (defn v24 [old-realm new-realm]
   (log/debug "migrating v24 account database"))
 
-(defn v25 [old-realm new-realm]
-  (log/debug "migrating v25 account database")
-  (let [new-messages (.objects new-realm "message")
-        user-statuses (.objects new-realm "user-status")
-        old-ids->new-ids (volatile! {})
-        updated-messages-ids (volatile! #{})
-        updated-message-statuses-ids (volatile! #{})
-        messages-to-be-deleted (volatile! [])
-        statuses-to-be-deleted (volatile! [])]
-    (dotimes [i (.-length new-messages)]
-      (let [message (aget new-messages i)
-            message-id (aget message "message-id")
-            from (aget message "from")
-            chat-id (:chat-id (edn/read-string (aget message "content")))
-            clock-value (aget message "clock-value")
-            new-message-id (transport.utils/message-id
-                            {:from        from
-                             :chat-id     chat-id
-                             :clock-value clock-value})]
-        (vswap! old-ids->new-ids assoc message-id new-message-id)))
-
-    (dotimes [i (.-length new-messages)]
-      (let [message (aget new-messages i)
-            old-message-id (aget message "message-id")
-            content (edn/read-string (aget message "content"))
-            response-to (:response-to content)
-            new-message-id (get @old-ids->new-ids old-message-id)]
-        (if (contains? @updated-messages-ids new-message-id)
-          (vswap! messages-to-be-deleted conj message)
-          (do
-            (vswap! updated-messages-ids conj new-message-id)
-            (aset message "message-id" new-message-id)
-            (when (and response-to (get @old-ids->new-ids response-to))
-              (let [new-content (assoc content :response-to
-                                       (get @old-ids->new-ids response-to))]
-                (aset message "content" (prn-str new-content))))))))
-
-    (doseq [message @messages-to-be-deleted]
-      (.delete new-realm message))
-
-    (dotimes [i (.-length user-statuses)]
-      (let [user-status (aget user-statuses i)
-            message-id     (aget user-status "message-id")
-            new-message-id (get @old-ids->new-ids message-id)
-            public-key     (aget user-status "public-key")
-            new-status-id (str new-message-id "-" public-key)]
-        (if (contains? @updated-message-statuses-ids new-status-id)
-          (vswap! statuses-to-be-deleted conj user-status)
-          (do
-            (vswap! updated-message-statuses-ids conj new-status-id)
-            (aset user-status "status-id" new-status-id)
-            (aset user-status "message-id" new-message-id)))))
-
-    (doseq [status @statuses-to-be-deleted]
-      (.delete new-realm status))))
+(defn v25 [old-realm new-realm])
 
 (defn v26 [old-realm new-realm]
-  (let [user-statuses (.objects new-realm "user-status")]
-    (dotimes [i (.-length user-statuses)]
-      (let [user-status   (aget user-statuses i)
-            status-id     (aget user-status "message-id")
-            message-id    (aget user-status "message-id")
-            public-key    (aget user-status "public-key")
-            new-status-id (str message-id "-" public-key)]
-        (when (and (= "-" (last status-id)))
-          (if (.objectForPrimaryKey
-               new-realm
-               "user-status"
-               new-status-id)
-            (.delete new-realm user-status)
-            (aset user-status "status-id" new-status-id))))))
   (let [chats (.objects new-realm "chat")]
     (dotimes [i (.-length chats)]
       (let [chat                (aget chats i)
@@ -244,10 +177,11 @@
                                     (.-length))]
         (aset chat "unviewed-messages-count" user-statuses-count)))))
 
+;; Message record's interface was
+;; copied from status-im.transport.message.protocol
+;; to ensure that any further changes to this record will not
+;; affect migrations
 (defrecord Message [content content-type message-type clock-value timestamp])
-
-(defn sha3 [s]
-  (.sha3 dependencies/Web3.prototype s))
 
 (defn replace-ns [str-message]
   (string/replace-first
@@ -255,21 +189,91 @@
    "status-im.data-store.realm.schemas.account.migrations"
    "status-im.transport.message.protocol"))
 
+(defn sha3 [s]
+  (.sha3 dependencies/Web3.prototype s))
+
 (defn old-message-id
+  "Calculates the same `message-id` as was used in `0.9.31`"
   [message]
   (sha3 (replace-ns (pr-str message))))
 
-(defn v27 [old-realm new-realm]
-  (let [messages (.objects new-realm "message")]
+;; The code below copied from status-im.transport.message.transit
+;; in order to make sure that future changes will not have any impact
+;; on migrations
+(defn- new->legacy-command-data [{:keys [command-path params] :as content}]
+  (get {["send" #{:personal-chats}]    [{:command-ref ["transactor" :command 83 "send"]
+                                         :command "send"
+                                         :bot "transactor"
+                                         :command-scope-bitmask 83}
+                                        constants/content-type-command]
+        ["request" #{:personal-chats}] [{:command-ref ["transactor" :command 83 "request"]
+                                         :request-command-ref ["transactor" :command 83 "send"]
+                                         :command "request"
+                                         :request-command "send"
+                                         :bot "transactor"
+                                         :command-scope-bitmask 83
+                                         :prefill [(get params :asset)
+                                                   (get params :amount)]}
+                                        constants/content-type-command-request]}
+       command-path))
+
+(deftype MessageHandler []
+  Object
+  (tag [this v] "c4")
+  (rep [this {:keys [content content-type message-type clock-value timestamp]}]
+    (condp = content-type
+      constants/content-type-text ;; append new content add the end, still pass content the old way at the old index
+      #js [(:text content) content-type message-type clock-value timestamp content]
+      constants/content-type-command ;; handle command compatibility issues
+      (let [[legacy-content legacy-content-type] (new->legacy-command-data content)]
+        #js [(merge content legacy-content) (or legacy-content-type content-type) message-type clock-value timestamp])
+      ;; no need for legacy conversions for rest of the content types
+      #js [content content-type message-type clock-value timestamp])))
+
+(def writer (transit/writer :json
+                            {:handlers
+                             {Message (MessageHandler.)}}))
+
+(defn serialize
+  "Serializes a record implementing the StatusMessage protocol using the custom writers"
+  [o]
+  (transit/write writer o))
+
+(defn raw-payload
+  [message]
+  (transport.utils/from-utf8 (serialize message)))
+
+(defn v27 [old-ream new-realm]
+  (let [messages (.objects new-realm "message")
+        user-statuses (.objects new-realm "user-status")
+        old-ids->new-ids (volatile! {})]
     (dotimes [i (.-length messages)]
-      (let [js-message     (aget messages i)
-            message        {:content      (edn/read-string
-                                           (aget js-message "content"))
-                            :content-type (aget js-message "content-type")
-                            :message-type (keyword
-                                           (aget js-message "message-type"))
-                            :clock-value  (aget js-message "clock-value")
-                            :timestamp    (aget js-message "timestamp")}
-            message-record (map->Message message)
-            old-message-id (old-message-id message-record)]
-        (aset js-message "old-message-id" old-message-id)))))
+      (let [message         (aget messages i)
+            prev-message-id (aget message "message-id")
+            content         (-> (aget message "content")
+                                edn/read-string
+                                (dissoc :should-collapse? :metadata :render-recipe))
+            content-type    (aget message "content-type")
+            message-type    (keyword
+                             (aget message "message-type"))
+            clock-value     (aget message "clock-value")
+            from            (aget message "from")
+            timestamp       (aget message "timestamp")
+            message-record  (Message. content content-type message-type
+                                      clock-value timestamp)
+            old-message-id  (old-message-id message-record)
+            raw-payload     (raw-payload message-record)
+            message-id      (transport.utils/message-id from raw-payload)]
+        (vswap! old-ids->new-ids assoc prev-message-id message-id)
+        (aset message "message-id" message-id)
+        (aset message "old-message-id" old-message-id)))
+
+    (dotimes [i (.-length user-statuses)]
+      (let [user-status (aget user-statuses i)
+            message-id     (aget user-status "message-id")
+            new-message-id (get @old-ids->new-ids message-id)
+            public-key     (aget user-status "public-key")
+            new-status-id (str new-message-id "-" public-key)]
+        (when (contains? @old-ids->new-ids message-id)
+          (aset user-status "status-id" new-status-id)
+          (aset user-status "message-id" new-message-id))))))

--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -692,8 +692,8 @@
 
 (handlers/register-handler-fx
  :chat.ui/reply-to-message
- (fn [cofx [_ message-id]]
-   (chat.input/reply-to-message cofx message-id)))
+ (fn [cofx [_ message-id old-message-id]]
+   (chat.input/reply-to-message cofx message-id old-message-id)))
 
 (handlers/register-handler-fx
  :chat.ui/send-current-message

--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -1082,8 +1082,8 @@
 
 (handlers/register-handler-fx
  :group-chats.callback/extract-signature-success
- (fn [cofx [_ group-update sender-signature]]
-   (group-chats/handle-membership-update cofx group-update sender-signature)))
+ (fn [cofx [_ group-update raw-payload sender-signature]]
+   (group-chats/handle-membership-update cofx group-update raw-payload sender-signature)))
 
 ;; profile module
 

--- a/src/status_im/transport/db.cljs
+++ b/src/status_im/transport/db.cljs
@@ -58,6 +58,7 @@
 
 (spec/def :message.content/text (spec/and string? (complement s/blank?)))
 (spec/def :message.content/response-to string?)
+(spec/def :message.content/response-to-v2 string?)
 (spec/def :message.content/command-path (spec/tuple string? (spec/coll-of (spec/or :scope keyword? :chat-id string?) :kind set? :min-count 1)))
 (spec/def :message.content/params (spec/map-of keyword? any?))
 

--- a/src/status_im/transport/impl/receive.cljs
+++ b/src/status_im/transport/impl/receive.cljs
@@ -9,8 +9,8 @@
 
 (extend-type transport.group-chat/GroupMembershipUpdate
   protocol/StatusMessage
-  (receive [this _ signature _ cofx]
-    (group-chats/handle-membership-update-received cofx this signature)))
+  (receive [this _ signature _ {:keys [js-obj] :as cofx}]
+    (group-chats/handle-membership-update-received cofx this signature (.-payload js-obj))))
 
 (extend-type transport.contact/ContactRequest
   protocol/StatusMessage

--- a/src/status_im/transport/message/contact.cljs
+++ b/src/status_im/transport/message/contact.cljs
@@ -1,8 +1,6 @@
 (ns ^{:doc "Contact request and update API"}
  status-im.transport.message.contact
   (:require [cljs.spec.alpha :as spec]
-            [status-im.data-store.transport :as transport-store]
-            [status-im.transport.db :as transport.db]
             [status-im.transport.message.protocol :as protocol]
             [status-im.utils.fx :as fx]))
 

--- a/src/status_im/transport/message/protocol.cljs
+++ b/src/status_im/transport/message/protocol.cljs
@@ -80,17 +80,14 @@
 
 (defrecord Message [content content-type message-type clock-value timestamp]
   StatusMessage
-  (send [this chat-id cofx]
+  (send [this chat-id {:keys [message-id] :as cofx}]
     (let [dev-mode?          (get-in cofx [:db :account/account :dev-mode?])
           current-public-key (accounts.db/current-public-key cofx)
           params             {:chat-id       chat-id
                               :payload       this
                               :success-event [:transport/message-sent
                                               chat-id
-                                              (transport.utils/message-id
-                                               {:from        current-public-key
-                                                :chat-id     chat-id
-                                                :clock-value clock-value})
+                                              message-id
                                               message-type]}]
       (case message-type
         :public-group-user-message
@@ -118,9 +115,8 @@
      [(assoc (into {} this)
              :old-message-id (transport.utils/old-message-id this)
              :message-id (transport.utils/message-id
-                          {:chat-id     (:chat-id content)
-                           :from        signature
-                           :clock-value clock-value})
+                          signature
+                          (.-payload (:js-obj cofx)))
              :chat-id chat-id
              :from signature
              :js-obj (:js-obj cofx))]})

--- a/src/status_im/transport/message/protocol.cljs
+++ b/src/status_im/transport/message/protocol.cljs
@@ -116,8 +116,9 @@
   (receive [this chat-id signature _ cofx]
     {:chat-received-message/add-fx
      [(assoc (into {} this)
+             :old-message-id (transport.utils/old-message-id this)
              :message-id (transport.utils/message-id
-                          {:chat-id     chat-id
+                          {:chat-id     (:chat-id content)
                            :from        signature
                            :clock-value clock-value})
              :chat-id chat-id

--- a/src/status_im/transport/utils.cljs
+++ b/src/status_im/transport/utils.cljs
@@ -17,11 +17,13 @@
 (defn sha3 [s]
   (.sha3 dependencies/Web3.prototype s))
 
+(defn old-message-id
+  [message]
+  (sha3 (pr-str message)))
+
 (defn message-id
   "Get a message-id"
   [{:keys [from chat-id clock-value] :as m}]
-  {:pre [(not (nil? from))
-         (not (nil? chat-id))]}
   (sha3 (str from chat-id clock-value)))
 
 (defn get-topic

--- a/src/status_im/transport/utils.cljs
+++ b/src/status_im/transport/utils.cljs
@@ -21,10 +21,14 @@
   [message]
   (sha3 (pr-str message)))
 
+(defn system-message-id
+  [{:keys [from chat-id clock-value]}]
+  (sha3 (str from chat-id clock-value)))
+
 (defn message-id
   "Get a message-id"
-  [{:keys [from chat-id clock-value] :as m}]
-  (sha3 (str from chat-id clock-value)))
+  [from raw-payload]
+  (sha3 (str from raw-payload)))
 
 (defn get-topic
   "Get the topic of a group chat or public chat from the chat-id"

--- a/src/status_im/ui/components/list_selection.cljs
+++ b/src/status_im/ui/components/list_selection.cljs
@@ -12,9 +12,9 @@
             (:url content))
     (.share react/sharing (clj->js content))))
 
-(defn- message-options [message-id text]
+(defn- message-options [message-id old-message-id text]
   [{:label  (i18n/label :t/message-reply)
-    :action #(re-frame/dispatch [:chat.ui/reply-to-message message-id])}
+    :action #(re-frame/dispatch [:chat.ui/reply-to-message message-id old-message-id])}
    {:label  (i18n/label :t/sharing-copy-to-clipboard)
     :action #(react/copy-to-clipboard text)}
    {:label  (i18n/label :t/sharing-share)
@@ -25,9 +25,9 @@
     (action-sheet/show options)
     (dialog/show options)))
 
-(defn chat-message [message-id text dialog-title]
+(defn chat-message [message-id old-message-id text dialog-title]
   (show {:title       dialog-title
-         :options     (message-options message-id text)
+         :options     (message-options message-id old-message-id text)
          :cancel-text (i18n/label :t/message-options-cancel)}))
 
 (defn browse [link]

--- a/src/status_im/ui/screens/chat/message/message.cljs
+++ b/src/status_im/ui/screens/chat/message/message.cljs
@@ -253,13 +253,13 @@
    [react/view (style/delivery-status outgoing)
     [message-delivery-status message]]])
 
-(defn chat-message [{:keys [message-id outgoing group-chat modal? current-public-key content-type content] :as message}]
+(defn chat-message [{:keys [message-id old-message-id outgoing group-chat modal? current-public-key content-type content] :as message}]
   [react/view
    [react/touchable-highlight {:on-press      (fn [_]
                                                 (re-frame/dispatch [:chat.ui/set-chat-ui-props {:messages-focused? true}])
                                                 (react/dismiss-keyboard!))
                                :on-long-press #(when (= content-type constants/content-type-text)
-                                                 (list-selection/chat-message message-id (:text content) (i18n/label :t/message)))}
+                                                 (list-selection/chat-message message-id old-message-id (:text content) (i18n/label :t/message)))}
     [react/view {:accessibility-label :chat-item}
      (let [incoming-group (and group-chat (not outgoing))]
        [message-content message-body (merge message

--- a/src/status_im/ui/screens/desktop/main/chat/views.cljs
+++ b/src/status_im/ui/screens/desktop/main/chat/views.cljs
@@ -98,7 +98,7 @@
   (not= (get-in user-statuses [current-public-key :status]) :not-sent))
 
 (views/defview message-without-timestamp
-  [text {:keys [message-id content current-public-key user-statuses] :as message} style]
+  [text {:keys [message-id old-message-id content current-public-key user-statuses] :as message} style]
   [react/view {:flex 1 :margin-vertical 5}
    [react/touchable-highlight {:on-press (fn [arg]
                                            (when (= "right" (.-button (.-nativeEvent arg)))
@@ -107,7 +107,7 @@
                                                 :on-select #(do (utils/show-popup "" "Message copied to clipboard") (react/copy-to-clipboard text))}
                                                {:text (i18n/label :t/message-reply)
                                                 :on-select #(when (message-sent? user-statuses current-public-key)
-                                                              (re-frame/dispatch [:chat.ui/reply-to-message message-id]))}])))}
+                                                              (re-frame/dispatch [:chat.ui/reply-to-message message-id old-message-id]))}])))}
     [react/view {:style styles/message-container}
      (when (:response-to content)
        [quoted-message (:response-to content) false current-public-key])

--- a/test/cljs/status_im/test/group_chats/core.cljs
+++ b/test/cljs/status_im/test/group_chats/core.cljs
@@ -32,7 +32,7 @@
   (with-redefs [config/group-chats-enabled? true]
     (testing "a brand new chat"
       (let [actual   (->
-                      (group-chats/handle-membership-update {:now 0 :db {}} initial-message admin)
+                      (group-chats/handle-membership-update {:now 0 :db {}} initial-message "payload" admin)
                       :db
                       :chats
                       (get chat-id))]
@@ -66,6 +66,7 @@
                          (group-chats/handle-membership-update
                           {:now 0 :db {}}
                           (assoc initial-message :chat-id bad-chat-id)
+                          "payload"
                           admin)
                          :db
                          :chats
@@ -74,10 +75,10 @@
           (is (not actual)))))
     (testing "an already existing chat"
       (let [cofx (assoc
-                  (group-chats/handle-membership-update {:now 0 :db {}} initial-message admin)
+                  (group-chats/handle-membership-update {:now 0 :db {}} initial-message "payload" admin)
                   :now 0)]
         (testing "the message has already been received"
-          (let [actual (group-chats/handle-membership-update cofx initial-message admin)]
+          (let [actual (group-chats/handle-membership-update cofx initial-message "payload" admin)]
             (testing "it noops"
               (is (=
                    (get-in cofx [:db :chats chat-id])
@@ -105,6 +106,7 @@
                                                                                              {:type "name-changed"
                                                                                               :clock-value 13
                                                                                               :name "new-name"}]}]}
+                                                             "payload"
                                                              member-3)
                 actual-chat (get-in actual [:db :chats chat-id])]
             (testing "the chat is updated"


### PR DESCRIPTION
fix #6956
fix #6903

- `transport.utils/message-id` function is called only in three places now and accepts `from` and  `raw_payload` as parameters. ID is calculated as `sha3(from + raw_payload)`.
- This means that for wrapped private group chat message the raw payload of `GroupMembershipUpdate` is used.
- tested on pub chats, 1-1 chats, private chats on sent/received messages
- db migrations, since `0.9.31` are merged where possible so that they will take the minimum necessary time to be executed and also compatible with nightlies builds (to not break desktop version)

status: ready 
