### PR TITLE
Request messages from mailserver taking TTL into account

### DIFF
--- a/modules/react-native-status/desktop/CMakeLists.txt
+++ b/modules/react-native-status/desktop/CMakeLists.txt
@@ -38,9 +38,6 @@ endif()
 ExternalProject_Add(StatusGo_ep
   PREFIX ${StatusGo_PREFIX}
   SOURCE_DIR ${StatusGo_SOURCE_DIR}
-  GIT_REPOSITORY https://github.com/status-im/status-go.git
-  GIT_TAG ${STATUS_GO_TAG}
-  GIT_SHALLOW true
   URL https://status-go.ams3.digitaloceanspaces.com/status-go-desktop-${STATUS_GO_VERSION}.zip
       https://github.com/status-im/status-go/archive/${STATUS_GO_VERSION}.zip
   BUILD_BYPRODUCTS ${StatusGo_STATIC_LIB}

--- a/src/status_im/transport/message/protocol.cljs
+++ b/src/status_im/transport/message/protocol.cljs
@@ -16,10 +16,13 @@
   (receive [this chat-id signature timestamp cofx] "Method producing all effects necessary for receiving the message record")
   (validate [this] "Method returning the message if it is valid or nil if it is not"))
 
-(def ^:private whisper-opts
-  {:ttl       10 ;; ttl of 10 sec
-   :powTarget config/pow-target
-   :powTime   config/pow-time})
+(def whisper-opts
+  {;; time drift that is tolerated by whisper, in seconds
+   :whisper-drift-tolerance 10
+   ;; ttl of 10 sec
+   :ttl                     10
+   :powTarget               config/pow-target
+   :powTime                 config/pow-time})
 
 (fx/defn init-chat
   "Initialises chat on protocol layer.


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes #6814

### Summary:

[comment]: # (Summarise the problem and how the pull request solves it)
This PR makes a slight change to the logic that requests messages from mailserver, so that the `from` value is adapted to take into account the message TTL and the max time drift allowed by a node, so `from` encompasses a bit more in the past.

### Review notes (optional):
<!-- (Specify if something in particular should be looked at, or ignored, during review) -->

I'm not sure if it's OK to expose `protocol/whisper-opts`, so would appreciate feedback on that. And of course, checking whether the logic was added to the most correct place.

status: ready <!-- Can be ready or wip -->
