### PR TITLE
Feature/extensions selection component

### DIFF
--- a/src/status_im/ui/screens/db.cljs
+++ b/src/status_im/ui/screens/db.cljs
@@ -136,6 +136,7 @@
 (spec/def :navigation.screen-params/collectibles-list map?)
 
 (spec/def :navigation.screen-params/show-extension map?)
+(spec/def :navigation.screen-params/selection-modal-screen map?)
 
 (spec/def :navigation/screen-params (spec/nilable (spec/keys :opt-un [:navigation.screen-params/network-details
                                                                       :navigation.screen-params/browser
@@ -145,7 +146,8 @@
                                                                       :navigation.screen-params/edit-contact-group
                                                                       :navigation.screen-params/dapp-description
                                                                       :navigation.screen-params/collectibles-list
-                                                                      :navigation.screen-params/show-extension])))
+                                                                      :navigation.screen-params/show-extension
+                                                                      :navigation.screen-params/selection-modal-screen])))
 
 (spec/def :desktop/desktop (spec/nilable any?))
 (spec/def ::tooltips (spec/nilable any?))

--- a/src/status_im/ui/screens/extensions/views.cljs
+++ b/src/status_im/ui/screens/extensions/views.cljs
@@ -48,3 +48,24 @@
                                                        {:justify-content :center})
                        :empty-component         [react/text {:style styles/empty-list}
                                                  (i18n/label :t/no-extension)]}]]]))
+
+(defn- render-selection-item [render on-select]
+  (fn [item]
+    [react/touchable-highlight {:on-press #(on-select item)}
+     [render item]]))
+
+(views/defview selection-modal-screen []
+  (views/letsubs [{:keys [items render title extractor-key on-select]} [:get-screen-params :selection-modal-screen]]
+    [react/view {:flex 1}
+     [status-bar/status-bar]
+     [toolbar/toolbar {}
+      toolbar/default-nav-close
+      [toolbar/content-title title]]
+     [react/view styles/wrapper
+      [list/flat-list {:data                    items
+                       :default-separator?      false
+                       :key-fn                  extractor-key
+                       :render-fn               (render-selection-item render on-select)
+                       :content-container-style {:justify-content :center}
+                       :empty-component         [react/text {:style styles/empty-list}
+                                                 "No items"]}]]]))

--- a/src/status_im/ui/screens/views.cljs
+++ b/src/status_im/ui/screens/views.cljs
@@ -42,7 +42,7 @@
             [status-im.ui.screens.network-settings.views :refer [network-settings]]
             [status-im.ui.screens.network-settings.network-details.views :refer [network-details]]
             [status-im.ui.screens.network-settings.edit-network.views :refer [edit-network]]
-            [status-im.ui.screens.extensions.views :refer [extensions-settings]]
+            [status-im.ui.screens.extensions.views :refer [extensions-settings selection-modal-screen]]
             [status-im.ui.screens.log-level-settings.views :refer [log-level-settings]]
             [status-im.ui.screens.fleet-settings.views :refer [fleet-settings]]
             [status-im.ui.screens.offline-messaging-settings.views :refer [offline-messaging-settings]]
@@ -247,6 +247,10 @@
            :wallet-settings-hook         wallet-settings/settings-hook})
          {:headerMode       "none"
           :initialRouteName "wallet"})}
+
+       :selection-modal-screen
+       {:screen (nav-reagent/stack-screen
+                 (wrap-modal :selection-modal-screen selection-modal-screen))}
 
        :wallet-send-modal-stack
        {:screen


### PR DESCRIPTION

fixes #6931

Introduced new extensions event `selection-screen`

Usage https://status-im.github.io/pluto/try.html?hash=Qma3CLom6sg55YPteKmRH6xUbpeJ4JVVeCeDp3ZP8XfHg6
```

views/render
 (let [{name :name} properties]
   [view {:style {:height 64 :margin-horizontal 16}}
    [text {:style {:font-size 16 :color :black}} name]])


[touchable-opacity {:on-press [selection-screen {:title "Choose asset" :items tokens :on-select [select] :render [render] :extractor-key :name}]}
     
```

<blockquote><img src="/pluto/img/favicon.png" width="48" align="right"><div><strong><a href="https://status-im.github.io/pluto/index.html">Pluto · A grammar for data manipulation</a></strong></div><div>A grammar for data manipulation</div></blockquote>