### PR TITLE
node version bumped to 10.14.1 for desktop

### DIFF
--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -31,6 +31,7 @@ pipeline {
    * https://issues.jenkins-ci.org/browse/JENKINS-49076
    **/
   environment {
+    NODE_VERSION = 'v10.14.1'
     BUILD_PLATFORM = 'linux'
     LANG = 'en_US.UTF-8'
     LANGUAGE = 'en_US.UTF-8'
@@ -44,34 +45,34 @@ pipeline {
   stages {
     stage('Prep') {
       steps {
-        script {
+        script { nvm(env.NODE_VERSION) {
           /* Necessary to load methods */
           desktop = load 'ci/desktop.groovy'
           cmn     = load 'ci/common.groovy'
           sh 'env'
           desktop.prepDeps()
-        }
+        } }
       }
     }
     stage('Lint') {
-      steps {
+      steps { nvm(env.NODE_VERSION) {
         script { cmn.runLint() }
-      }
+      } }
     }
     stage('Tests') {
-      steps {
+      steps { nvm(env.NODE_VERSION) {
         script { cmn.runTests() }
-      }
+      } }
     }
     stage('Build') {
-      steps {
+      steps { nvm(env.NODE_VERSION) {
         script { desktop.buildClojureScript() }
-      }
+      } }
     }
     stage('Compile') {
-      steps {
+      steps { nvm(env.NODE_VERSION) {
         script { desktop.compile() }
-      }
+      } }
     }
     stage('Bundle') {
       steps {

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -3,7 +3,7 @@ pipeline {
     /* privileged mode is necessary for fuse */
     docker {
       label 'linux-new'
-      image 'statusteam/linux-desktop-ubuntu:qt-5.11.2'
+      image 'statusteam/linux-desktop-ubuntu:1.1.0'
       args (
         "--privileged "+
         "-v /dev/fuse:/dev/fuse "+

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -21,7 +21,6 @@ pipeline {
     LC_ALL = 'en_US.UTF-8'
     QT_PATH = '/usr/local/opt/qt'
     PATH = "/usr/local/opt/qt/bin:${env.PATH}"
-    MACDEPLOYQT = '/usr/local/opt/qt/bin/macdeployqt'
   }
 
   stages {

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -14,6 +14,7 @@ pipeline {
   }
 
   environment {
+    NODE_VERSION = 'v10.14.1'
     BUILD_PLATFORM = 'macos'
     LANG = 'en_US.UTF-8'
     LANGUAGE = 'en_US.UTF-8'
@@ -25,33 +26,33 @@ pipeline {
   stages {
     stage('Prep') {
       steps {
-        script {
+        script { nvm(env.NODE_VERSION) {
           /* Necessary to load methods */
           desktop = load 'ci/desktop.groovy'
           cmn     = load 'ci/common.groovy'
           desktop.prepDeps()
-        }
+        } }
       }
     }
     stage('Lint') {
-      steps {
+      steps { nvm(env.NODE_VERSION) {
         script { cmn.runLint() }
-      }
+      } }
     }
     stage('Tests') {
-      steps {
+      steps { nvm(env.NODE_VERSION) {
         script { cmn.runTests() }
-      }
+      } }
     }
     stage('Build') {
-      steps {
+      steps { nvm(env.NODE_VERSION) {
         script { desktop.buildClojureScript() }
-      }
+      } }
     }
     stage('Compile') {
-      steps {
+      steps { nvm(env.NODE_VERSION) {
         script { desktop.compile() }
-      }
+      } }
     }
     stage('Bundle') {
       steps {

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -51,14 +51,14 @@ pipeline {
       } }
     }
     stage('Compile') {
-      steps { nvm(env.NODE_VERSION) {
+      steps {
         script { desktop.compile() }
-      } }
+      }
     }
     stage('Bundle') {
-      steps {
+      steps { nvm(env.NODE_VERSION) {
         script { dmg = desktop.bundleMacOS(cmn.getBuildType()) }
-      }
+      } }
     }
     stage('Archive') {
       steps { archiveArtifacts dmg }

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -21,6 +21,7 @@ pipeline {
     LC_ALL = 'en_US.UTF-8'
     QT_PATH = '/usr/local/opt/qt'
     PATH = "/usr/local/opt/qt/bin:${env.PATH}"
+    MACDEPLOYQT = '/usr/local/opt/qt/bin/macdeployqt'
   }
 
   stages {

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -3,7 +3,7 @@ pipeline {
     /* privileged mode is necessary for fuse */
     docker {
       label 'linux-new'
-      image 'statusteam/windows-desktop-ubuntu:nsis-1.0.0'
+      image 'statusteam/windows-desktop-ubuntu:1.1.0'
       args (
         "--privileged "+
         "-v /dev/fuse:/dev/fuse "+

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -30,6 +30,7 @@ pipeline {
    * https://issues.jenkins-ci.org/browse/JENKINS-49076
    **/
   environment {
+    NODE_VERSION = 'v10.14.1'
     BUILD_PLATFORM = 'linux'
     LANG = 'en_US.UTF-8'
     LANGUAGE = 'en_US.UTF-8'
@@ -45,35 +46,35 @@ pipeline {
 
   stages {
     stage('Prep') {
-      steps {
+      script { nvm(env.NODE_VERSION) {
         script {
           /* Necessary to load methods */
           desktop = load 'ci/desktop.groovy'
           cmn     = load 'ci/common.groovy'
           sh 'env'
           desktop.prepDeps()
-        }
+        } }
       }
     }
     stage('Lint') {
-      steps {
+      steps { nvm(env.NODE_VERSION) {
         script { cmn.runLint() }
-      }
+      } }
     }
     stage('Tests') {
-      steps {
+      steps { nvm(env.NODE_VERSION) {
         script { cmn.runTests() }
-      }
+      } }
     }
     stage('Build') {
-      steps {
+      steps { nvm(env.NODE_VERSION) {
         script { desktop.buildClojureScript() }
-      }
+      } }
     }
     stage('Compile') {
-      steps {
+      steps { nvm(env.NODE_VERSION) {
         script { desktop.compile() }
-      }
+      } }
     }
     stage('Bundle') {
       steps {

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -46,7 +46,7 @@ pipeline {
 
   stages {
     stage('Prep') {
-      steps { nvm(env.NODE_VERSION) {
+      steps {
         script { nvm(env.NODE_VERSION) {
           /* Necessary to load methods */
           desktop = load 'ci/desktop.groovy'

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -46,8 +46,8 @@ pipeline {
 
   stages {
     stage('Prep') {
-      script { nvm(env.NODE_VERSION) {
-        script {
+      steps { nvm(env.NODE_VERSION) {
+        script { nvm(env.NODE_VERSION) {
           /* Necessary to load methods */
           desktop = load 'ci/desktop.groovy'
           cmn     = load 'ci/common.groovy'

--- a/ci/desktop.groovy
+++ b/ci/desktop.groovy
@@ -57,6 +57,10 @@ def prepDeps() {
 }
 
 def compile() {
+  /* since QT is in a custom path we need to add it to PATH */
+  if (env.QT_PATH) {
+    env.PATH = "${env.QT_PATH}:${env.PATH}"
+  }
   sh './scripts/build-desktop.sh compile'
 }
 

--- a/desktop/docker/linux/Dockerfile
+++ b/desktop/docker/linux/Dockerfile
@@ -40,7 +40,7 @@ ENV NPM_CONFIG_CACHE /var/tmp/npm
 ENV PATH /opt/qt/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 RUN apt-get update && apt-get -q -y --no-install-recommends install curl software-properties-common && \
-    curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
+    curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
     curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
     echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
     add-apt-repository -y ppa:longsleep/golang-backports && \
@@ -76,8 +76,10 @@ RUN cd /tmp && \
 RUN addgroup --gid 1002 jenkins && \
     adduser --shell /bin/bash \
       --disabled-password --gecos "" \
-      --uid 1001 --gid 1002 \
-      --home /var/tmp/jenkins jenkins
+      --uid 1001 --gid 1002 jenkins
+
+# Install NVM for Jenkins
+RUN su jenkins -c 'curl -s -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash'
 
 LABEL source="https://github.com/status-im/status-react/tree/develop/desktop/docker" \
       description="Image for building Linux Desktop version of Status app." \

--- a/desktop/docker/linux/Makefile
+++ b/desktop/docker/linux/Makefile
@@ -7,7 +7,8 @@ QT_ARCHIVE = qt-opensource-linux-x64-$(QT_VERSION).run
 QT_MD5SUM  = 974fda61267cfb6e45984ee5f0a285f8
 QT_URL = https://download.qt.io/archive/qt
 
-IMAGE_TAG = qt-$(QT_VERSION)
+# WARNING: Remember to change the tag when updating the image
+IMAGE_TAG = 1.1.0
 IMAGE_NAME = statusteam/linux-desktop-ubuntu:$(IMAGE_TAG)
 
 build: $(QT_ARCHIVE)

--- a/desktop/docker/windows/Dockerfile
+++ b/desktop/docker/windows/Dockerfile
@@ -10,7 +10,7 @@ ENV NPM_CONFIG_CACHE /var/tmp/npm
 ENV PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 RUN apt-get update && apt-get -q -y --no-install-recommends install curl software-properties-common && \
-    curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
+    curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
     curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
     echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
     add-apt-repository -y ppa:longsleep/golang-backports && \
@@ -48,8 +48,10 @@ RUN cd /tmp && \
 RUN addgroup --gid 1002 jenkins && \
     adduser --shell /bin/bash \
       --disabled-password --gecos "" \
-      --uid 1001 --gid 1002 \
-      --home /var/tmp/jenkins jenkins
+      --uid 1001 --gid 1002 jenkins
+
+# Install NVM for Jenkins
+RUN su jenkins -c 'curl -s -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash'
 
 LABEL source="https://github.com/status-im/status-react/tree/develop/desktop/windows/docker" \
       description="Image for building Windows Desktop version of Status app." \

--- a/desktop/docker/windows/Makefile
+++ b/desktop/docker/windows/Makefile
@@ -1,7 +1,8 @@
 GIT_COMMIT = $(shell git rev-parse --short HEAD)
 
-IMAGE_TAG = 1.0.0
-IMAGE_NAME = statusteam/windows-desktop-ubuntu:nsis-$(IMAGE_TAG)
+# WARNING: Remember to change the tag when updating the image
+IMAGE_TAG = 1.1.0
+IMAGE_NAME = statusteam/windows-desktop-ubuntu:$(IMAGE_TAG)
 
 build:
 	docker build \

--- a/modules/react-native-status/desktop/CMakeLists.txt
+++ b/modules/react-native-status/desktop/CMakeLists.txt
@@ -40,6 +40,7 @@ ExternalProject_Add(StatusGo_ep
   SOURCE_DIR ${StatusGo_SOURCE_DIR}
   GIT_REPOSITORY https://github.com/status-im/status-go.git
   GIT_TAG ${STATUS_GO_TAG}
+  GIT_SHALLOW true
   URL https://status-go.ams3.digitaloceanspaces.com/status-go-desktop-${STATUS_GO_VERSION}.zip
       https://github.com/status-im/status-go/archive/${STATUS_GO_VERSION}.zip
   BUILD_BYPRODUCTS ${StatusGo_STATIC_LIB}


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

If you submit PR for issue with bounty then write here Fixes #NN where NN is issue number

*otherwise*

fixes problem with macos builds

### Summary:

Desktop can't be built with node v9.3.0 used in recent Jenkins builds. So version changed.

### Review notes (optional):
<!-- (Specify if something in particular should be looked at, or ignored, during review) -->

### Testing notes (optional):
No functionality changed. Only node version.

#### Platforms (optional)
- macOS
- Linux
- Windows

<!-- (Specify if some specific areas has to be tested, for example 1-1 chats) -->
#### Areas that maybe impacted (optional)
**Functional**
- 1-1 chats
- public chats
- group chats
- wallet / transactions
- dapps / app browsing
- account recovery
- new account
- user profile updates
- networks
- mailservers
- fleet
- bootnodes

**Non-functional**
- battery performance
- CPU performance / speed of the app
- network consumption

<!-- (Specify exact steps to test if there are such) -->
### Steps to test:
- Open Status
- ...
- Step 3, etc.

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->
