### PR TITLE
store :raw-payload-hash in message

### DIFF
--- a/src/status_im/chat/models/message.cljs
+++ b/src/status_im/chat/models/message.cljs
@@ -307,7 +307,8 @@
                  :content-type constants/content-type-status}]
     (assoc message
            :message-id (transport.utils/system-message-id message)
-           :old-message-id "system")))
+           :old-message-id "system"
+           :raw-payload-hash "system")))
 
 (defn group-message? [{:keys [message-type]}]
   (#{:group-user-message :public-group-user-message} message-type))
@@ -342,7 +343,8 @@
         message-id      (transport.utils/message-id from raw-payload)
         message-with-id (assoc message
                                :message-id message-id
-                               :old-message-id old-message-id)]
+                               :old-message-id old-message-id
+                               :raw-payload-hash (transport.utils/sha3 raw-payload))]
 
     (fx/merge cofx
               (chat-model/upsert-chat {:chat-id chat-id

--- a/src/status_im/data_store/realm/schemas/account/core.cljs
+++ b/src/status_im/data_store/realm/schemas/account/core.cljs
@@ -281,7 +281,7 @@
 (def v27 [chat/v9
           transport/v7
           contact/v3
-          message/v8
+          message/v9
           mailserver/v11
           mailserver-topic/v1
           user-status/v2

--- a/src/status_im/data_store/realm/schemas/account/message.cljs
+++ b/src/status_im/data_store/realm/schemas/account/message.cljs
@@ -57,3 +57,8 @@
       (assoc-in [:properties :old-message-id]
                 {:type    :string
                  :indexed true})))
+
+(def v9
+  (-> v8
+      (assoc-in [:properties :raw-payload-hash]
+                {:type :string})))

--- a/src/status_im/data_store/realm/schemas/account/migrations.cljs
+++ b/src/status_im/data_store/realm/schemas/account/migrations.cljs
@@ -263,9 +263,11 @@
                                       clock-value timestamp)
             old-message-id  (old-message-id message-record)
             raw-payload     (raw-payload message-record)
-            message-id      (transport.utils/message-id from raw-payload)]
+            message-id      (transport.utils/message-id from raw-payload)
+            raw-payload-hash (transport.utils/sha3 raw-payload)]
         (vswap! old-ids->new-ids assoc prev-message-id message-id)
         (aset message "message-id" message-id)
+        (aset message "raw-payload-hash" raw-payload-hash)
         (aset message "old-message-id" old-message-id)))
 
     (dotimes [i (.-length user-statuses)]

--- a/src/status_im/transport/message/protocol.cljs
+++ b/src/status_im/transport/message/protocol.cljs
@@ -118,6 +118,8 @@
                           signature
                           (.-payload (:js-obj cofx)))
              :chat-id chat-id
+             :raw-payload-hash (transport.utils/sha3
+                                (.-payload (:js-obj cofx)))
              :from signature
              :js-obj (:js-obj cofx))]})
   (validate [this]

--- a/src/status_im/transport/utils.cljs
+++ b/src/status_im/transport/utils.cljs
@@ -28,7 +28,7 @@
 (defn message-id
   "Get a message-id"
   [from raw-payload]
-  (sha3 (str from raw-payload)))
+  (sha3 (str from (sha3 raw-payload))))
 
 (defn get-topic
   "Get the topic of a group chat or public chat from the chat-id"


### PR DESCRIPTION
Currently, we calculate `message-id` as `sha3(from + raw_payload)`, but we do not store `raw_payload` and it might be problematic to restore it from DB because:
1) `content` field might be changed and so `Message` record will differ from the original one
2) it is even more problematic for `GroupMembershipUpdate` message because we don't save it in DB

In order to handle this, we can store `sha3(raw_payload)` as `raw-payload-hash` prop of `message` entity and use it in case of emergency :) 

`message-id` will be calculated as `sha3(from + sha3(raw_payload))`

status: ready <!-- Can be ready or wip -->
