### PR TITLE
[#6956] delete duplicates after iteration over messages/statuses

### DIFF
--- a/src/status_im/data_store/realm/schemas/account/migrations.cljs
+++ b/src/status_im/data_store/realm/schemas/account/migrations.cljs
@@ -246,7 +246,9 @@
 (defn v27 [old-ream new-realm]
   (let [messages (.objects new-realm "message")
         user-statuses (.objects new-realm "user-status")
-        old-ids->new-ids (volatile! {})]
+        old-ids->new-ids (volatile! {})
+        messages-to-be-deleted (volatile! [])
+        statuses-to-be-deleted (volatile! [])]
     (dotimes [i (.-length messages)]
       (let [message         (aget messages i)
             prev-message-id (aget message "message-id")
@@ -270,11 +272,14 @@
              new-realm
              "message"
              message-id)
-          (.delete new-realm message)
+          (vswap! messages-to-be-deleted conj message)
           (do
             (aset message "message-id" message-id)
             (aset message "raw-payload-hash" raw-payload-hash)
             (aset message "old-message-id" old-message-id)))))
+
+    (doseq [message @messages-to-be-deleted]
+      (.delete new-realm message))
 
     (dotimes [i (.-length user-statuses)]
       (let [user-status (aget user-statuses i)
@@ -286,7 +291,10 @@
              new-realm
              "user-status"
              new-status-id)
-          (.delete new-realm user-status)
+          (vswap! statuses-to-be-deleted conj user-status)
           (when (contains? @old-ids->new-ids message-id)
             (aset user-status "status-id" new-status-id)
-            (aset user-status "message-id" new-message-id)))))))
+            (aset user-status "message-id" new-message-id)))))
+
+    (doseq [status @statuses-to-be-deleted]
+      (.delete new-realm status))))


### PR DESCRIPTION
if an entity is deleted during iteration "index out of range"-like error happens
> I get `Cannot read property 'message-id' of undefined`

status: ready <!-- Can be ready or wip -->
