### PR TITLE
enable desktop builds for releases

### DIFF
--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -26,16 +26,13 @@ pipeline {
     }
     stage('Build') {
       parallel {
-        stage('MacOS') { when { expression { btype != 'release' } }
-        steps { script {
+        stage('MacOS') { steps { script {
           osx = cmn.buildBranch('status-react/combined/desktop-macos')
         } } }
-        stage('Linux') { when { expression { btype != 'release' } }
-        steps { script {
+        stage('Linux') { steps { script {
           nix = cmn.buildBranch('status-react/combined/desktop-linux')
         } } }
-        stage('Windows') { when { expression { btype != 'release' } }
-        steps { script {
+        stage('Windows') { steps { script {
           win = cmn.buildBranch('status-react/combined/desktop-windows')
         } } }
         stage('iOS') { steps { script {


### PR DESCRIPTION
Fixes https://github.com/status-im/status-react/issues/7001

Dropping the `when` clauses to enable desktop builds for release.