### PR TITLE
[#7002] Add a JS API allowing to install an extension

### DIFF
--- a/resources/js/web3_init.js
+++ b/resources/js/web3_init.js
@@ -14,6 +14,7 @@ function sendAPIrequest(permission, params) {
         type: 'api-request',
         permission: permission,
         messageId: messageId,
+        params: params,
         host: window.location.hostname
     });
 
@@ -77,6 +78,10 @@ var StatusAPI = function () {};
 
 StatusAPI.prototype.getContactCode = function () {
     return sendAPIrequest('contact-code');
+};
+
+StatusAPI.prototype.installExtension = function (uri) {
+    return sendAPIrequest('install-extension', {uri: uri});
 };
 
 var StatusHttpProvider = function () {};

--- a/resources/js/web3_opt_in.js
+++ b/resources/js/web3_opt_in.js
@@ -14,7 +14,8 @@ function sendAPIrequest(permission, params) {
     bridgeSend({
         type: 'api-request',
         permission: permission,
-        messageId: messageId
+        messageId: messageId,
+        params: params
     });
 
     return new Promise(function (resolve, reject) {
@@ -100,6 +101,10 @@ var StatusAPI = function () {};
 
 StatusAPI.prototype.getContactCode = function () {
     return sendAPIrequest('contact-code');
+};
+
+StatusAPI.prototype.installExtension = function (uri) {
+    return sendAPIrequest('install-extension', {uri: uri});
 };
 
 var ReadOnlyProvider = function () {};

--- a/src/status_im/browser/core.cljs
+++ b/src/status_im/browser/core.cljs
@@ -282,7 +282,7 @@
   (let [browser (get-current-browser db)
         url-original (get-current-url browser)
         data    (types/json->clj message)
-        {{:keys [url]} :navState :keys [type permission payload messageId]} data
+        {{:keys [url]} :navState :keys [type permission payload messageId params]} data
         {:keys [dapp? name]} browser
         dapp-name (if dapp? name (http/url-host url-original))]
     (cond
@@ -300,7 +300,7 @@
       (web3-send-async-read-only cofx dapp-name payload messageId)
 
       (= type constants/api-request)
-      (browser.permissions/process-permission cofx dapp-name permission messageId))))
+      (browser.permissions/process-permission cofx dapp-name permission messageId params))))
 
 (fx/defn handle-message-link
   [cofx link]

--- a/src/status_im/browser/permissions.cljs
+++ b/src/status_im/browser/permissions.cljs
@@ -4,21 +4,34 @@
             [status-im.i18n :as i18n]
             [status-im.utils.ethereum.core :as ethereum]
             [status-im.utils.fx :as fx]
-            [status-im.qr-scanner.core :as qr-scanner]))
+            [status-im.qr-scanner.core :as qr-scanner]
+            [status-im.extensions.registry :as extensions.registry]))
+
+(declare process-next-permission)
+(declare send-response-to-bridge)
 
 (def supported-permissions
-  {constants/dapp-permission-qr-code      {:yield-control? true
-                                           :allowed?       true}
-   constants/dapp-permission-contact-code {:title       (i18n/label :t/wants-to-access-profile)
-                                           :description (i18n/label :t/your-contact-code)
-                                           :icon        :icons/profile-active}
-   constants/dapp-permission-web3         {:title       (i18n/label :t/dapp-would-like-to-connect-wallet)
-                                           :description (i18n/label :t/allowing-authorizes-this-dapp)
-                                           :icon        :icons/wallet-active}})
+  {constants/dapp-permission-qr-code           {:yield-control? true
+                                                :allowed?       true}
+   constants/dapp-permission-install-extension {:yield-control? true
+                                                :allowed?       true}
+   constants/dapp-permission-contact-code      {:title       (i18n/label :t/wants-to-access-profile)
+                                                :description (i18n/label :t/your-contact-code)
+                                                :icon        :icons/profile-active}
+   constants/dapp-permission-web3              {:title       (i18n/label :t/dapp-would-like-to-connect-wallet)
+                                                :description (i18n/label :t/allowing-authorizes-this-dapp)
+                                                :icon        :icons/wallet-active}})
 
 (fx/defn permission-yield-control
-  [{:keys [db] :as cofx} dapp-name permission message-id]
+  [{:keys [db] :as cofx} dapp-name permission message-id params]
   (cond
+    (= permission constants/dapp-permission-install-extension)
+    (fx/merge cofx
+              {:db (assoc-in db [:extensions/manage :url :value] (:uri params))}
+              (extensions.registry/load (:uri params) true)
+              (send-response-to-bridge permission message-id true nil)
+              (process-next-permission dapp-name))
+
     (= permission constants/dapp-permission-qr-code)
     (fx/merge (assoc-in cofx [:db :browser/options :yielding-control?] true)
               (qr-scanner/scan-qr-code {:modal? false}
@@ -76,9 +89,9 @@
       (let [pending-permissions (get-in db [:browser/options :pending-permissions])
             next-permission     (last pending-permissions)
             new-cofx (update-in cofx [:db :browser/options :pending-permissions] butlast)]
-        (when-let [{:keys [yield-control? permission message-id allowed?]} next-permission]
+        (when-let [{:keys [yield-control? permission message-id allowed? params]} next-permission]
           (if (and yield-control? allowed?)
-            (permission-yield-control new-cofx dapp-name permission message-id)
+            (permission-yield-control new-cofx dapp-name permission message-id params)
             (permission-show-permission new-cofx dapp-name permission message-id yield-control?)))))))
 
 (fx/defn send-response-and-process-next-permission
@@ -93,12 +106,12 @@
 (fx/defn allow-permission
   "Add permission to set of allowed permission and process next permission"
   [{:keys [db] :as cofx}]
-  (let [{:keys [requested-permission message-id dapp-name yield-control?]}
+  (let [{:keys [requested-permission message-id dapp-name yield-control? params]}
         (get-in db [:browser/options :show-permission])]
     (fx/merge (assoc-in cofx [:db :browser/options :show-permission] nil)
               (update-dapp-permissions dapp-name requested-permission true)
               (if yield-control?
-                (permission-yield-control dapp-name requested-permission message-id)
+                (permission-yield-control dapp-name requested-permission message-id params)
                 (send-response-and-process-next-permission dapp-name requested-permission message-id)))))
 
 (fx/defn deny-permission
@@ -116,7 +129,7 @@
   "Process the permission requested by a dapp
   If supported permission is already granted, return the result immediatly to the bridge
   Otherwise process the first permission which will prompt user"
-  [cofx dapp-name permission message-id]
+  [cofx dapp-name permission message-id params]
   (let [allowed-permissions  (set (get-in cofx [:db :dapps/permissions dapp-name :permissions]))
         permission-allowed?  (boolean (allowed-permissions permission))
         supported-permission (get supported-permissions permission)]
@@ -133,5 +146,6 @@
                                                 :allowed?       (or permission-allowed?
                                                                     (:allowed? supported-permission))
                                                 :yield-control? (:yield-control? supported-permission)
+                                                :params         params
                                                 :message-id     message-id})
                                dapp-name))))

--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -220,6 +220,7 @@
 (def ^:const dapp-permission-contact-code "contact-code")
 (def ^:const dapp-permission-web3 "web3")
 (def ^:const dapp-permission-qr-code "qr-code")
+(def ^:const dapp-permission-install-extension "install-extension")
 (def ^:const api-response "api-response")
 (def ^:const api-request "api-request")
 (def ^:const history-state-changed "history-state-changed")


### PR DESCRIPTION

fixes #7002

QA: you can find "install extension" button in simple dapp fro testing