### PR TITLE
[#6952] fix odd app behavior after quick logout

### DIFF
--- a/src/status_im/accounts/logout/core.cljs
+++ b/src/status_im/accounts/logout/core.cljs
@@ -2,20 +2,21 @@
   (:require [re-frame.core :as re-frame]
             [status-im.i18n :as i18n]
             [status-im.transport.core :as transport]
-            [status-im.ui.screens.navigation :as navigation]
             [status-im.utils.fx :as fx]
-            [status-im.models.transactions :as transactions]))
+            [status-im.models.transactions :as transactions]
+            [status-im.node.core :as node]
+            [status-im.init.core :as init]))
 
 (fx/defn logout
   [{:keys [db] :as cofx}]
-  (let [{:transport/keys [chats]} db]
-    (fx/merge cofx
-              {:keychain/clear-user-password (get-in db [:account/account :address])
-               :dev-server/stop              nil
-               :keychain/get-encryption-key [:init.callback/get-encryption-key-success]}
-              (transactions/stop-sync)
-              (navigation/navigate-to-clean :login {})
-              (transport/stop-whisper))))
+  (fx/merge cofx
+            {:keychain/clear-user-password (get-in db [:account/account :address])
+             :dev-server/stop              nil}
+            (transactions/stop-sync)
+            (transport/stop-whisper)
+            (init/initialize-app-db)
+            (init/load-accounts-and-initialize-views)
+            (node/stop)))
 
 (fx/defn show-logout-confirmation [_]
   {:ui/show-confirmation

--- a/src/status_im/accounts/recover/core.cljs
+++ b/src/status_im/accounts/recover/core.cljs
@@ -10,7 +10,8 @@
             [status-im.utils.identicon :as identicon]
             [status-im.utils.security :as security]
             [status-im.utils.types :as types]
-            [status-im.utils.fx :as fx]))
+            [status-im.utils.fx :as fx]
+            [status-im.node.core :as node]))
 
 (defn check-password-errors [password]
   (cond (string/blank? password) :required-field
@@ -80,10 +81,15 @@
               {:db (dissoc db :accounts/recover)}
               (validate-recover-result data password))))
 
-(fx/defn recover-account [{:keys [db]}]
-  (let [{:keys [password passphrase]} (:accounts/recover db)]
-    {:db (assoc-in db [:accounts/recover :processing?] true)
-     :accounts.recover/recover-account [(security/mask-data passphrase) password]}))
+(fx/defn recover-account
+  [{:keys [db random-guid-generator] :as cofx}]
+  (fx/merge
+   cofx
+   {:db (-> db
+            (assoc-in [:accounts/recover :processing?] true)
+            (assoc :node/on-ready :recover-account)
+            (assoc :accounts/new-installation-id (random-guid-generator)))}
+   (node/initialize nil)))
 
 (fx/defn recover-account-with-checks [{:keys [db] :as cofx}]
   (let [{:keys [passphrase processing?]} (:accounts/recover db)]

--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -118,10 +118,13 @@
   (re-frame/inject-cofx :data-store/all-browsers)
   (re-frame/inject-cofx :data-store/all-dapp-permissions)]
  (fn [{:keys [db] :as cofx} [_ address]]
-   (fx/merge
-    cofx
-    (node/initialize (get-in db [:accounts/login :address]))
-    (init/initialize-account address))))
+   (let [{:node/keys [status]} db]
+     (fx/merge
+      cofx
+      (if (= status :started)
+        (accounts.login/login)
+        (node/initialize (get-in db [:accounts/login :address])))
+      (init/initialize-account address)))))
 
 (handlers/register-handler-fx
  :init.callback/keychain-reset
@@ -176,6 +179,7 @@
 
 (handlers/register-handler-fx
  :accounts.create.ui/next-step-pressed
+ [(re-frame/inject-cofx :random-guid-generator)]
  (fn [cofx [_ step password password-confirm]]
    (accounts.create/next-step cofx step password password-confirm)))
 
@@ -231,11 +235,13 @@
 
 (handlers/register-handler-fx
  :accounts.recover.ui/sign-in-button-pressed
+ [(re-frame/inject-cofx :random-guid-generator)]
  (fn [cofx _]
    (accounts.recover/recover-account-with-checks cofx)))
 
 (handlers/register-handler-fx
  :accounts.recover.ui/recover-account-confirmed
+ [(re-frame/inject-cofx :random-guid-generator)]
  (fn [cofx _]
    (accounts.recover/recover-account cofx)))
 
@@ -252,7 +258,7 @@
 (handlers/register-handler-fx
  :accounts.login.ui/password-input-submitted
  (fn [cofx _]
-   (accounts.login/user-login cofx)))
+   (accounts.login/user-login cofx false)))
 
 (handlers/register-handler-fx
  :accounts.login.callback/login-success
@@ -293,6 +299,7 @@
 
 (handlers/register-handler-fx
  :accounts.logout.ui/logout-confirmed
+ [(re-frame/inject-cofx :data-store/get-all-accounts)]
  (fn [cofx _]
    (accounts.logout/logout cofx)))
 
@@ -300,6 +307,7 @@
 
 (handlers/register-handler-fx
  :accounts.update.callback/save-settings-success
+ [(re-frame/inject-cofx :data-store/get-all-accounts)]
  (fn [cofx _]
    (accounts.logout/logout cofx)))
 

--- a/src/status_im/init/core.cljs
+++ b/src/status_im/init/core.cljs
@@ -99,8 +99,7 @@
   [cofx encryption-key]
   (fx/merge cofx
             {:init/init-store encryption-key}
-            (initialize-app-db)
-            (node/initialize nil)))
+            (initialize-app-db)))
 
 (fx/defn set-device-uuid
   [{:keys [db]} device-uuid]

--- a/test/cljs/status_im/test/accounts/recover/core.cljs
+++ b/test/cljs/status_im/test/accounts/recover/core.cljs
@@ -95,29 +95,24 @@
          (models/validate-password {:db {:accounts/recover {:password "thisisapaswoord"}}}))))
 
 (deftest recover-account
-  (let [new-cofx (models/recover-account {:db {:accounts/recover
+  (let [new-cofx (models/recover-account {:random-guid-generator (constantly "random")
+                                          :db {:accounts/recover
                                                {:passphrase "game buzz method pretty zeus fat quit display velvet unveil marine crater"
                                                 :password   "thisisapaswoord"}}})]
-    (is (= {:accounts/recover {:passphrase  "game buzz method pretty zeus fat quit display velvet unveil marine crater"
-                               :password    "thisisapaswoord"
-                               :processing? true}}
-           (:db new-cofx)))
-    (is (= security/MaskedData
-           (-> new-cofx :accounts.recover/recover-account first type)))
-    (is (= "thisisapaswoord" (-> new-cofx :accounts.recover/recover-account second)))))
+    (is (contains? new-cofx :node/start))
+    (is (= "random" (get-in new-cofx [:db :accounts/new-installation-id])))
+    (is (= :recover-account (get-in new-cofx [:db :node/on-ready])))))
 
 (deftest recover-account-with-checks
-  (let [new-cofx (models/recover-account-with-checks {:db {:accounts/recover
+  (let [new-cofx (models/recover-account-with-checks {:random-guid-generator (constantly "random")
+                                                      :db {:accounts/recover
                                                            {:passphrase "game buzz method pretty olympic fat quit display velvet unveil marine crater"
                                                             :password   "thisisapaswoord"}}})]
-    (is (= {:accounts/recover {:passphrase  "game buzz method pretty olympic fat quit display velvet unveil marine crater"
-                               :password    "thisisapaswoord"
-                               :processing? true}}
-           (:db new-cofx)))
-    (is (= security/MaskedData
-           (-> new-cofx :accounts.recover/recover-account first type)))
-    (is (= "thisisapaswoord" (-> new-cofx :accounts.recover/recover-account second))))
-  (let [new-cofx (models/recover-account-with-checks {:db {:accounts/recover
+    (is (contains? new-cofx :node/start))
+    (is (= "random" (get-in new-cofx [:db :accounts/new-installation-id])))
+    (is (= :recover-account (get-in new-cofx [:db :node/on-ready]))))
+  (let [new-cofx (models/recover-account-with-checks {:random-guid-generator (constantly "random")
+                                                      :db {:accounts/recover
                                                            {:passphrase "game buzz method pretty zeus fat quit display velvet unveil marine crater"
                                                             :password   "thisisapaswoord"}}})]
     (is (= (i18n/label :recovery-typo-dialog-title) (-> new-cofx :ui/show-confirmation :title)))

--- a/test/cljs/status_im/test/node/core.cljs
+++ b/test/cljs/status_im/test/node/core.cljs
@@ -13,34 +13,18 @@
   (let [address "a"
         cofx {:db {:accounts/accounts {address {:installation-id "id"}}}}]
     (testing "installation-id"
-      (testing "the user is not logged in"
-        (let [actual (parse-node-config (node/start cofx nil))]
-          (is (not (:InstallationID actual)))))
-      (testing "the user is logged in"
-        (let [actual (parse-node-config (node/start cofx address))]
-          (is (= "id" (:InstallationID actual))))))
+      (let [actual (parse-node-config (node/start cofx address))]
+        (is (= "id" (:InstallationID actual)))))
     (testing "pfs & group chats disabled"
       (with-redefs [config/pfs-encryption-enabled? false
                     config/group-chats-enabled? false]
-        (testing "the user is not logged in"
-          (let [actual (parse-node-config (node/start cofx nil))]
-            (is (not (:PFSEnabled actual)))))
-        (testing "the user is logged in"
-          (let [actual (parse-node-config (node/start cofx address))]
-            (is (not (:PFSEnabled actual))))))
+        (let [actual (parse-node-config (node/start cofx address))]
+          (is (not (:PFSEnabled actual)))))
       (testing "pfs is enabled"
         (with-redefs [config/pfs-encryption-enabled? true]
-          (testing "the user is not logged in"
-            (let [actual (parse-node-config (node/start cofx nil))]
-              (is (not (:PFSEnabled actual)))))
-          (testing "the user is logged in"
-            (let [actual (parse-node-config (node/start cofx address))]
-              (is (:PFSEnabled actual))))))
+          (let [actual (parse-node-config (node/start cofx address))]
+            (is (:PFSEnabled actual)))))
       (testing "group chats is enabled"
         (with-redefs [config/group-chats-enabled? true]
-          (testing "the user is not logged in"
-            (let [actual (parse-node-config (node/start cofx nil))]
-              (is (not (:PFSEnabled actual)))))
-          (testing "the user is logged in"
-            (let [actual (parse-node-config (node/start cofx address))]
-              (is (:PFSEnabled actual)))))))))
+          (let [actual (parse-node-config (node/start cofx address))]
+            (is (:PFSEnabled actual))))))))


### PR DESCRIPTION
fix #6952 

## Node instance management ##

Currently the node instance with "dummy" configs is used to allow 
`CreateAccount` and `RecoverAccount` calls, but there is no point in doing this 
as node can be started right before these calls. Also we restart node on logging
out which causes weird behaviour like described here #6952.

**How it worked in `develop` before this PR**:
1. `node` is started on application startup.
   `PFSEnabled=false,NoDiscovery=true` are used, so it is started only to make
   possible `CreateAccount` and `RecoverAccount` calls, because they require
   running node atm.
2. When the user **presses "Sign in" button**, the node is stopped, then started
   with user specific configs (`InstallationID`, custom bootnodes, etc), and
   only after that `Login` call is performed.
3. When the user **creates** a new account, at first `CreateAccount` call happens,
   and after that node is stopped and started as in **1.**.
4. When the user **restores** their account, at first `RecoverAccount` call happens,
   and after that node is stopped and started as in **1.**.
5. When the user **logs out** the node is stopped and started again as in **1.** to
   make possible CreateAccount`,`RecoverAccount` calls.

**How it works in this PR**:
1. `node` is not started on the app startup
2. When the user **presses "Sign in" button** the node is started
   with user specific configs (`InstallationID`, custom bootnodes, etc), and
   only after that `Login` call is performed.
3. When the user **creates** a new account, at first the node is started with
   default params (the same as would be used when user signs into the app after
   account creation whithout changing any setting), then `CreateAccount` call
   happens, then `Login`.
4. When the user **restores** their account, the flow is the same as **3.** but
   with `RecoverAccount` instead of `CreateAccount`
5. When the user **logs out** the node is stopped. That's it.

status: ready <!-- Can be ready or wip -->
