### PR TITLE
always upload iOS builds to Diawi

### DIFF
--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -67,11 +67,11 @@ pipeline {
     stage('Upload') {
       steps {
         script {
-          switch (cmn.getBuildType()) {
-            case 'nightly':
-              env.DIAWI_URL = mobile.ios.uploadToDiawi(); break;
-            case 'e2e':
-              env.SAUCE_URL = mobile.ios.uploadToSauceLabs(); break;
+          /* e2e builds get tested in SauceLabs */
+          if (params.BUILD_TYPE == 'e2e') {
+            env.SAUCE_URL = mobile.ios.uploadToSauceLabs()
+          } else {
+            env.DIAWI_URL = mobile.ios.uploadToDiawi()
           }
         }
       }


### PR DESCRIPTION
Looks like we are not uploading to Diawi when we should, which is always.
Fixes missing  iOS URL in GitHub posts.