### PR TITLE
Updated StatusImAppImage.zip URL to package with redundant files removed

### DIFF
--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -9,7 +9,7 @@ pipeline {
         "-v /dev/fuse:/dev/fuse "+
         "-v /var/tmp/lein:/var/tmp/lein:rw "+
         "-v /var/tmp/npm:/var/tmp/npm:rw "+
-        "-v /opt/StatusImAppImage_20181113.zip:/opt/StatusImAppImage.zip:ro"
+        "-v /opt/desktop-files:/opt/desktop-files:rw"
       )
     }
   }
@@ -39,7 +39,7 @@ pipeline {
     NPM_CONFIG_CACHE = '/var/tmp/npm'
     LEIN_HOME = '/var/tmp/lein'
     QT_PATH = '/opt/qt'
-    STATUSIM_APPIMAGE = '/opt/StatusImAppImage.zip'
+    STATUSIM_APPIMAGE_DIR = '/opt/desktop-files'
   }
 
   stages {

--- a/scripts/build-desktop.sh
+++ b/scripts/build-desktop.sh
@@ -73,6 +73,7 @@ STATUSREACTPATH="$(cd "$SCRIPTPATH" && cd '..' && pwd)"
 WORKFOLDER="$(joinExistingPath "$STATUSREACTPATH" 'StatusImPackage')"
 DEPLOYQT="$(joinPath . 'linuxdeployqt-continuous-x86_64.AppImage')"
 APPIMAGETOOL="$(joinPath . 'appimagetool-x86_64.AppImage')"
+STATUSIM_APPIMAGE_ARCHIVE="StatusImAppImage_20181208.zip"
 
 function init() {
   if [ -z $STATUSREACTPATH ]; then
@@ -270,14 +271,15 @@ function bundleLinux() {
 
   # invoke linuxdeployqt to create Status.AppImage
   echo "Creating AppImage..."
-
   pushd $WORKFOLDER
     rm -rf StatusImAppImage*
     # TODO this needs to be fixed: status-react/issues/5378
-    if [ -z $STATUSIM_APPIMAGE ]; then
-      STATUSIM_APPIMAGE=./StatusImAppImage.zip
-      [ -f $STATUSIM_APPIMAGE ] || wget https://desktop-app-files.ams3.digitaloceanspaces.com/StatusImAppImage_20181113.zip -O StatusImAppImage.zip
+    if [ -z $STATUSIM_APPIMAGE_DIR ]; then
+      STATUSIM_APPIMAGE="./${STATUSIM_APPIMAGE_ARCHIVE}"
+    else
+      STATUSIM_APPIMAGE="${STATUSIM_APPIMAGE_DIR}/${STATUSIM_APPIMAGE_ARCHIVE}"
     fi
+    [ -f $STATUSIM_APPIMAGE ] || wget "https://desktop-app-files.ams3.digitaloceanspaces.com/${STATUSIM_APPIMAGE_ARCHIVE}" -O $STATUSIM_APPIMAGE
     unzip "$STATUSIM_APPIMAGE" -d .
     rm -rf AppDir
     mkdir AppDir


### PR DESCRIPTION
fixes #7041

### Summary:

Prevents redundant files to be copied into AppImage bundle.

#### Platforms (optional)
- Linux

status: ready
