### PR TITLE
[slow sign in] denormalize last message

### DIFF
--- a/src/status_im/chat/subs.cljs
+++ b/src/status_im/chat/subs.cljs
@@ -222,18 +222,6 @@
          (:photo-path account)))))
 
 (re-frame/reg-sub
- :chats/last-message
- (fn [[_ chat-id]]
-   (re-frame/subscribe [:chats/chat chat-id]))
- (fn [{:keys [messages message-groups]}]
-   (->> (chat.db/sort-message-groups message-groups messages)
-        first
-        second
-        last
-        :message-id
-        (get messages))))
-
-(re-frame/reg-sub
  :chats/unread-messages-number
  :<- [:chats/active-chats]
  (fn [chats _]

--- a/src/status_im/data_store/messages.cljs
+++ b/src/status_im/data_store/messages.cljs
@@ -66,7 +66,7 @@
  (fn [cofx _]
    (assoc cofx :get-referenced-messages get-references-by-ids)))
 
-(defn- prepare-content [content]
+(defn prepare-content [content]
   (if (string? content)
     content
     (pr-str content)))

--- a/src/status_im/data_store/realm/schemas/account/chat.cljs
+++ b/src/status_im/data_store/realm/schemas/account/chat.cljs
@@ -223,3 +223,10 @@
                       :tags                    {:type "string[]"}
                       :unviewed-messages-count {:type    :int
                                                 :default 0}}})
+
+(def v10
+  (update v9 :properties merge
+          {:last-message-content {:type     :string
+                                  :optional true}
+           :last-message-type    {:type     :string
+                                  :optional true}}))

--- a/src/status_im/data_store/realm/schemas/account/core.cljs
+++ b/src/status_im/data_store/realm/schemas/account/core.cljs
@@ -291,6 +291,19 @@
           browser/v8
           dapp-permissions/v9])
 
+(def v28 [chat/v10
+          transport/v7
+          contact/v3
+          message/v9
+          mailserver/v11
+          mailserver-topic/v1
+          user-status/v2
+          membership-update/v1
+          installation/v2
+          local-storage/v1
+          browser/v8
+          dapp-permissions/v9])
+
 ;; put schemas ordered by version
 (def schemas [{:schema        v1
                :schemaVersion 1
@@ -372,4 +385,7 @@
                :migration     migrations/v26}
               {:schema        v27
                :schemaVersion 27
-               :migration     migrations/v27}])
+               :migration     migrations/v27}
+              {:schema        v28
+               :schemaVersion 28
+               :migration     migrations/v28}])

--- a/src/status_im/data_store/realm/schemas/account/migrations.cljs
+++ b/src/status_im/data_store/realm/schemas/account/migrations.cljs
@@ -298,3 +298,21 @@
 
     (doseq [status @statuses-to-be-deleted]
       (.delete new-realm status))))
+
+(defn get-last-message [realm chat-id]
+  (->
+   (.objects realm "message")
+   (.filtered (str "chat-id=\"" chat-id "\""))
+   (.sorted "timestamp" true)
+   (aget 0)))
+
+(defn v28 [old-realm new-realm]
+  (let [chats (.objects new-realm "chat")]
+    (dotimes [i (.-length chats)]
+      (let [chat (aget chats i)
+            chat-id (aget chat "chat-id")]
+        (when-let [last-message (get-last-message new-realm chat-id)]
+          (let [content (aget last-message "content")
+                message-type (aget last-message "message-type")]
+            (aset chat "last-message-content" content)
+            (aset chat "last-message-type" message-type)))))))

--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -92,14 +92,6 @@
    (init/handle-init-store-error cofx encryption-key)))
 
 (handlers/register-handler-fx
- :load-chats-messages
- [(re-frame/inject-cofx :data-store/get-messages)
-  (re-frame/inject-cofx :data-store/get-referenced-messages)
-  (re-frame/inject-cofx :data-store/get-user-statuses)]
- (fn [cofx]
-   (chat-loading/load-chats-messages cofx)))
-
-(handlers/register-handler-fx
  :init-chats
  [(re-frame/inject-cofx :web3/get-web3)
   (re-frame/inject-cofx :get-default-dapps)

--- a/src/status_im/ui/screens/desktop/main/tabs/home/views.cljs
+++ b/src/status_im/ui/screens/desktop/main/tabs/home/views.cljs
@@ -19,13 +19,18 @@
             [status-im.ui.components.action-button.action-button :as action-button]
             [status-im.utils.config :as config]))
 
-(views/defview chat-list-item-inner-view [{:keys [chat-id name group-chat color public? public-key] :as chat-item}]
+(views/defview chat-list-item-inner-view [{:keys [chat-id name group-chat
+                                                  color public? public-key
+                                                  last-message-content
+                                                  last-message-type]
+                                           :as chat-item}]
   (views/letsubs [photo-path              [:contacts/chat-photo chat-id]
                   unviewed-messages-count [:chats/unviewed-messages-count chat-id]
                   chat-name               [:chats/chat-name chat-id]
-                  current-chat-id         [:chats/current-chat-id]
-                  {:keys [content] :as last-message} [:chats/last-message chat-id]]
-    (let [name (or chat-name
+                  current-chat-id         [:chats/current-chat-id]]
+    (let [last-message {:content      last-message-content
+                        :message-type last-message-type}
+          name (or chat-name
                    (gfycat/generate-gfy public-key))
           [unviewed-messages-label large?] [(utils/unread-messages-count unviewed-messages-count) true]
           current? (= current-chat-id chat-id)]
@@ -52,7 +57,7 @@
                      :style           styles/chat-last-message}
          (if (= constants/content-type-command (:content-type last-message))
            [chat-item/command-short-preview last-message]
-           (or (:text content)
+           (or (:text last-message-content)
                (i18n/label :no-messages-yet)))]]
        [react/view {:style styles/timestamp}
         [chat-item/message-timestamp (:timestamp last-message)]
@@ -140,14 +145,7 @@
      (fn [this]
        (let [[_ loading?] (.. this -props -argv)]
          (when loading?
-           (re-frame/dispatch [:init-chats]))))
-
-     :component-did-update
-     (fn [this [_ old-loading?]]
-       (let [[_ loading?] (.. this -props -argv)]
-         (when (and (false? loading?)
-                    (true? old-loading?))
-           (re-frame/dispatch [:load-chats-messages]))))}
+           (re-frame/dispatch [:init-chats]))))}
     [react/view {:style styles/chat-list-view}
      [react/view {:style styles/chat-list-header}
       [search-input search-filter]

--- a/src/status_im/ui/screens/home/views.cljs
+++ b/src/status_im/ui/screens/home/views.cljs
@@ -100,14 +100,7 @@
          (when loading?
            (utils/set-timeout
             #(re-frame/dispatch [:init-chats])
-            100))))
-
-     :component-did-update
-     (fn [this [_ old-loading?]]
-       (let [[_ loading?] (.. this -props -argv)]
-         (when (and (false? loading?)
-                    (true? old-loading?))
-           (re-frame/dispatch [:load-chats-messages]))))}
+            100))))}
     [react/view styles/container
      [toolbar show-welcome? (and network-initialized? (not rpc-network?)) sync-state latest-block-number]
      (cond show-welcome?

--- a/src/status_im/ui/screens/home/views/inner_item.cljs
+++ b/src/status_im/ui/screens/home/views/inner_item.cljs
@@ -88,9 +88,10 @@
 (defview home-list-chat-item-inner-view [{:keys [chat-id name color online
                                                  group-chat public?
                                                  public-key
-                                                 timestamp]}]
-  (letsubs [last-message [:chats/last-message chat-id]
-            chat-name    [:chats/chat-name chat-id]]
+                                                 timestamp
+                                                 last-message-content
+                                                 last-message-type]}]
+  (letsubs [chat-name    [:chats/chat-name chat-id]]
     (let [truncated-chat-name (utils/truncate-str chat-name 30)]
       [react/touchable-highlight {:on-press #(re-frame/dispatch [:chat.ui/navigate-to-chat chat-id])}
        [react/view styles/chat-container
@@ -100,10 +101,10 @@
          [react/view styles/item-upper-container
           [chat-list-item-name truncated-chat-name group-chat public? public-key]
           [react/view styles/message-status-container
-           [message-timestamp (or (:timestamp last-message)
-                                  timestamp)]]]
+           [message-timestamp timestamp]]]
          [react/view styles/item-lower-container
-          [message-content-text last-message]
+          [message-content-text {:content      last-message-content
+                                 :content-type last-message-type}]
           [unviewed-indicator chat-id]]]]])))
 
 (defn home-list-browser-item-inner-view [{:keys [dapp url name browser-id] :as browser}]

--- a/test/cljs/status_im/test/data_store/chats.cljs
+++ b/test/cljs/status_im/test/data_store/chats.cljs
@@ -10,9 +10,14 @@
               :admins #{4}
               :contacts #{2}
               :tags #{}
-              :membership-updates []}
-             (chats/normalize-chat {:admins [4]
-                                    :contacts [2]})))))
+              :membership-updates []
+              :last-message-type :message-type
+              :last-message-content {:foo "bar"}}
+             (chats/normalize-chat
+              {:admins            [4]
+               :contacts          [2]
+               :last-message-type "message-type"
+               :last-message-content "{:foo \"bar\"}"})))))
   (testing "membership-updates"
     (with-redefs [chats/get-last-clock-value (constantly 42)]
       (let [raw-events {"1" {:id "1" :type "members-added" :clock-value 10 :members [1 2] :signature "a" :from "id-1"}


### PR DESCRIPTION
implements 
> - Store the latest message (or part of it which is shown in chat list) along with chat. In this case no need to make extra query in order to show chats list properly. **C**

from https://notes.status.im/VxmgW_rJQkqHsPoqGiMGxQ

status: ready <!-- Can be ready or wip -->
