### PR TITLE
Show schema version details on migrations failure

### DIFF
--- a/src/status_im/init/core.cljs
+++ b/src/status_im/init/core.cljs
@@ -108,7 +108,7 @@
 
 (fx/defn handle-change-account-error
   [{:keys [db]} error]
-  (let [{:keys [error message]}
+  (let [{:keys [error message details]}
         (if (map? error)
           error
           {:message (str error)})
@@ -120,8 +120,10 @@
        {:title               (i18n/label :migrations-failed-title)
         :content             (i18n/label
                               :migrations-failed-content
-                              {:message                         message
-                               :erase-accounts-data-button-text erase-button-text})
+                              (merge
+                               {:message                         message
+                                :erase-accounts-data-button-text erase-button-text}
+                               details))
         :confirm-button-text erase-button-text
         :on-cancel           #(re-frame/dispatch [:init.ui/data-reset-cancelled ""])
         :on-accept           #(re-frame/dispatch [:init.ui/account-data-reset-accepted address])}}

--- a/translations/en.json
+++ b/translations/en.json
@@ -790,6 +790,6 @@
     "to-see-this-message": "To see this message,",
     "install-the-extension": "install the extension",
     "migrations-failed-title": "Migration failed",
-    "migrations-failed-content": "{{message}}\n\nPlease let us know about this problem at #status public chat. If you press \"Cancel\" button, nothing will happen. If you press \"{{erase-accounts-data-button-text}}\" button, account's db will be removed and you will be able to unlock account. All account's data will be lost.",
+    "migrations-failed-content": "{{message}}\nschema version: initial {{initial-version}}, current {{current-version}}, last {{last-version}}\n\nPlease let us know about this problem at #status public chat. If you press \"Cancel\" button, nothing will happen. If you press \"{{erase-accounts-data-button-text}}\" button, account's db will be removed and you will be able to unlock account. All account's data will be lost.",
     "migrations-erase-accounts-data-button": "Erase account's db"
 }


### PR DESCRIPTION
Simplifies debugging of migration failures, specifically in cases when
more than one migration is applied.

status: ready <!-- Can be ready or wip -->
