### PR TITLE
Bug/fixed extensions installation issues

### DIFF
--- a/src/status_im/browser/permissions.cljs
+++ b/src/status_im/browser/permissions.cljs
@@ -27,7 +27,6 @@
   (cond
     (= permission constants/dapp-permission-install-extension)
     (fx/merge cofx
-              {:db (assoc-in db [:extensions/manage :url :value] (:uri params))}
               (extensions.registry/load (:uri params) true)
               (send-response-to-bridge permission message-id true nil)
               (process-next-permission dapp-name))

--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -510,21 +510,19 @@
    (extensions.registry/change-state cofx extension-key active?)))
 
 (handlers/register-handler-fx
- :extensions.ui/show-button-pressed
+ :extensions.ui/find-button-pressed
  (fn [cofx [_ url]]
    (extensions.registry/load cofx url false)))
 
 (handlers/register-handler-fx
  :extensions.ui/install-extension-button-pressed
- (fn [{:keys [db] :as cofx} [_ url]]
-   (fx/merge cofx
-             {:db (assoc-in db [:extensions/manage :url :value] url)}
-             (extensions.registry/load url true))))
+ (fn [cofx [_ url]]
+   (extensions.registry/load cofx url true)))
 
 (handlers/register-handler-fx
  :extensions.ui/install-button-pressed
- (fn [cofx [_ data modal?]]
-   (extensions.registry/install cofx data modal?)))
+ (fn [cofx [_ url data modal?]]
+   (extensions.registry/install cofx url data modal?)))
 
 ;; log-level module
 

--- a/src/status_im/extensions/registry.cljs
+++ b/src/status_im/extensions/registry.cljs
@@ -49,10 +49,8 @@
               (update-hooks hook-fn extension-key))))
 
 (fx/defn install
-  [{:keys [db] :as cofx} {:keys [hooks] :as extension-data} modal?]
-  (let [{:extensions/keys [manage]
-         :account/keys    [account]} db
-        url            (get-in manage [:url :value])
+  [{:keys [db] :as cofx} url {:keys [hooks] :as extension-data} modal?]
+  (let [{:account/keys    [account]} db
         extension      {:id      url
                         :name    (get-in extension-data ['meta :name])
                         :url     url
@@ -112,11 +110,12 @@
        (map #(existing-hooks-for % cofx extension-data))
        (apply set/union)))
 
-(fx/defn stage-extension [{:keys [db] :as cofx} extension-data modal?]
+(fx/defn stage-extension [{:keys [db] :as cofx} url extension-data modal?]
   (let [hooks (existing-hooks cofx extension-data)]
     (if (empty? hooks)
       (fx/merge cofx
-                {:db (assoc db :staged-extension extension-data)}
+                {:db (assoc db :extensions/staged-extension {:url            url
+                                                             :extension-data extension-data})}
                 (navigation/navigate-to-cofx (if modal? :show-extension-modal :show-extension) nil))
       {:utils/show-popup {:title   (i18n/label :t/error)
                           :content (i18n/label :t/extension-hooks-cannot-be-added

--- a/src/status_im/ui/screens/chat/message/message.cljs
+++ b/src/status_im/ui/screens/chat/message/message.cljs
@@ -16,7 +16,8 @@
             [status-im.i18n :as i18n]
             [status-im.ui.components.colors :as colors]
             [status-im.ui.components.icons.vector-icons :as icons]
-            [status-im.chat.commands.protocol :as protocol]))
+            [status-im.chat.commands.protocol :as protocol]
+            [status-im.extensions.core :as extensions]))
 
 (defn install-extension-message [extension-id outgoing]
   [react/touchable-highlight {:on-press #(re-frame/dispatch
@@ -33,8 +34,10 @@
   (letsubs [id->command [:chats/id->command]]
     (let [{:keys [type] :as command} (commands-receiving/lookup-command-by-ref command-message id->command)
           extension-id (get-in command-message [:content :params :extension-id])]
-      (if (and platform/mobile? extension-id (or (not type) (and type (satisfies? protocol/Extension type)
-                                                                 (not= extension-id (protocol/extension-id type)))))
+      (if (and platform/mobile? extension-id
+               (extensions/valid-uri? extension-id)
+               (or (not type) (and type (satisfies? protocol/Extension type)
+                                   (not= extension-id (protocol/extension-id type)))))
         ;; Show install message only for mobile and if message contains extension id and there is no extension installed
         ;; or installed extension has differen extension id
         [install-extension-message extension-id (:outgoing command-message)]

--- a/src/status_im/ui/screens/db.cljs
+++ b/src/status_im/ui/screens/db.cljs
@@ -164,7 +164,8 @@
 (spec/def ::collectibles (spec/nilable map?))
 
 (spec/def ::extension-url (spec/nilable string?))
-(spec/def ::staged-extension (spec/nilable any?))
+(spec/def :extensions/staged-extension (spec/nilable any?))
+(spec/def :extensions/manage (spec/nilable any?))
 (spec/def ::extensions-store (spec/nilable any?))
 
 ;;;;NODE
@@ -218,6 +219,7 @@
                                 :networks/networks
                                 :networks/manage
                                 :bootnodes/manage
+                                :extensions/staged-extension
                                 :extensions/manage
                                 :node/status
                                 :node/restart?
@@ -321,6 +323,5 @@
                                    ::device-UUID
                                    ::collectible
                                    ::collectibles
-                                   ::staged-extension
                                    ::extensions-store
                                    :registry/registry]))

--- a/src/status_im/ui/screens/extensions/add/events.cljs
+++ b/src/status_im/ui/screens/extensions/add/events.cljs
@@ -15,13 +15,13 @@
 
 (handlers/register-handler-fx
  :extensions/stage
- (fn [cofx [_ _ extension-data]]
-   (extensions.registry/stage-extension cofx extension-data false)))
+ (fn [cofx [_ url extension-data]]
+   (extensions.registry/stage-extension cofx url extension-data false)))
 
 (handlers/register-handler-fx
  :extensions/stage-modal
- (fn [cofx [_ _ extension-data]]
-   (extensions.registry/stage-extension cofx extension-data true)))
+ (fn [cofx [_ url extension-data]]
+   (extensions.registry/stage-extension cofx url extension-data true)))
 
 (handlers/register-handler-fx
  :extensions/add-to-registry

--- a/src/status_im/ui/screens/extensions/add/subs.cljs
+++ b/src/status_im/ui/screens/extensions/add/subs.cljs
@@ -9,4 +9,4 @@
 (re-frame/reg-sub
  :get-staged-extension
  (fn [db]
-   (:staged-extension db)))
+   (:extensions/staged-extension db)))

--- a/src/status_im/ui/screens/extensions/add/views.cljs
+++ b/src/status_im/ui/screens/extensions/add/views.cljs
@@ -31,54 +31,55 @@
           hooks))
 
 (views/defview show-extension-base [modal?]
-  (views/letsubs [{:keys [data errors]} [:get-staged-extension]]
-    (if data
-      [react/view styles/screen
-       [status-bar/status-bar]
-       [react/keyboard-avoiding-view components.styles/flex
-        [toolbar/simple-toolbar (i18n/label :t/extension) modal?]
-        [react/scroll-view {:keyboard-should-persist-taps :handled}
-         [react/view styles/wrapper
-          [react/view {:style {:border-radius 8 :margin 10 :padding 8 :background-color colors/red}}
-           [react/text {:style {:color colors/white}}
-            (i18n/label :t/extensions-disclaimer)]]
-          [cartouche {:header (i18n/label :t/identifier)}
-           [react/text {:style styles/text}
-            (str (get-in data ['meta :name]))]]
-          [cartouche {:header (i18n/label :t/name)}
-           [react/text {:style styles/text}
-            (str (get-in data ['meta :name]))]]
-          [cartouche {:header (i18n/label :t/description)}
-           [react/text {:style styles/text}
-            (str (get-in data ['meta :description]))]]
-          [cartouche {:header (i18n/label :t/hooks)}
-           (into [react/view] (for [hook (hooks data)]
-                                [react/text {:style styles/text}
-                                 (str hook)]))]
-          [cartouche {:header (i18n/label :t/permissions)}
-           [react/text {:style styles/text}
-            (i18n/label :t/none)]]
-          [cartouche {:header (i18n/label :t/errors)}
-           (if errors
-             (into [react/view] (for [error errors]
-                                  [react/text {:style styles/text}
-                                   (str (name (:pluto.reader.errors/type error)) " " (str (:pluto.reader.errors/value error)))]))
+  (views/letsubs [{:keys [extension-data url]} [:get-staged-extension]]
+    (let [{:keys [data errors]} extension-data]
+      (if data
+        [react/view styles/screen
+         [status-bar/status-bar]
+         [react/keyboard-avoiding-view components.styles/flex
+          [toolbar/simple-toolbar (i18n/label :t/extension) modal?]
+          [react/scroll-view {:keyboard-should-persist-taps :handled}
+           [react/view styles/wrapper
+            [react/view {:style {:border-radius 8 :margin 10 :padding 8 :background-color colors/red}}
+             [react/text {:style {:color colors/white}}
+              (i18n/label :t/extensions-disclaimer)]]
+            [cartouche {:header (i18n/label :t/identifier)}
              [react/text {:style styles/text}
-              (i18n/label :t/none)])]]]
-        [react/view styles/bottom-container
-         [react/view components.styles/flex]
-         [components.common/bottom-button
-          {:forward?  true
-           :label     (i18n/label :t/install)
-           :disabled? (not (empty? errors))
-           :on-press  #(re-frame/dispatch [:extensions.ui/install-button-pressed data modal?])}]]]]
-      [react/view styles/screen
-       [status-bar/status-bar]
-       [react/view {:flex 1}
-        [toolbar/simple-toolbar (i18n/label :t/extension)]
-        [react/view {:style {:flex 1 :justify-content :center :align-items :center}}
-         [react/text (i18n/label :t/invalid-extension)]
-         [react/text (str errors)]]]])))
+              (str (get-in data ['meta :name]))]]
+            [cartouche {:header (i18n/label :t/name)}
+             [react/text {:style styles/text}
+              (str (get-in data ['meta :name]))]]
+            [cartouche {:header (i18n/label :t/description)}
+             [react/text {:style styles/text}
+              (str (get-in data ['meta :description]))]]
+            [cartouche {:header (i18n/label :t/hooks)}
+             (into [react/view] (for [hook (hooks data)]
+                                  [react/text {:style styles/text}
+                                   (str hook)]))]
+            [cartouche {:header (i18n/label :t/permissions)}
+             [react/text {:style styles/text}
+              (i18n/label :t/none)]]
+            [cartouche {:header (i18n/label :t/errors)}
+             (if errors
+               (into [react/view] (for [error errors]
+                                    [react/text {:style styles/text}
+                                     (str (name (:pluto.reader.errors/type error)) " " (str (:pluto.reader.errors/value error)))]))
+               [react/text {:style styles/text}
+                (i18n/label :t/none)])]]]
+          [react/view styles/bottom-container
+           [react/view components.styles/flex]
+           [components.common/bottom-button
+            {:forward?  true
+             :label     (i18n/label :t/install)
+             :disabled? (not (empty? errors))
+             :on-press  #(re-frame/dispatch [:extensions.ui/install-button-pressed url data modal?])}]]]]
+        [react/view styles/screen
+         [status-bar/status-bar]
+         [react/view {:flex 1}
+          [toolbar/simple-toolbar (i18n/label :t/extension)]
+          [react/view {:style {:flex 1 :justify-content :center :align-items :center}}
+           [react/text (i18n/label :t/invalid-extension)]
+           [react/text (str errors)]]]]))))
 
 (views/defview show-extension []
   [show-extension-base false])
@@ -118,4 +119,4 @@
           {:forward?  true
            :label     (i18n/label :t/find)
            :disabled? (and (not @pressed) (not (extensions/valid-uri? url)))
-           :on-press  #(do (reset! pressed true) (re-frame/dispatch [:extensions.ui/show-button-pressed (string/trim url)]))}]]]])))
+           :on-press  #(do (reset! pressed true) (re-frame/dispatch [:extensions.ui/find-button-pressed (string/trim url)]))}]]]])))


### PR DESCRIPTION
 there are two issues with extensions installation
1) if someone sends a message with extensions which has been installed in "old" status client, they send wrong extension id, before we used a random number for id, in that case, nothing happens when you press install extension message
2) if you install an extension from the link, there was a bug, there is no id provided, and the extension installed wrong, without id, so next time you log in there is no extension