### PR TITLE
set BUILD_TYPE to pr as default

### DIFF
--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -13,6 +13,14 @@ pipeline {
     ))
   }
 
+  parameters {
+    booleanParam(
+      name: 'BUILD_TYPE',
+      description: 'Specify build type. Values: pr / nightly / release',
+      defaultValue: 'pr',
+    )
+  }
+
   environment {
     BUILD_PLATFORM = 'android'
     LANG = 'en_US.UTF-8'

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -1,6 +1,14 @@
 pipeline {
   agent { label 'macos' }
 
+  parameters {
+    booleanParam(
+      name: 'BUILD_TYPE',
+      description: 'Specify build type. Values: pr / nightly / release',
+      defaultValue: 'pr',
+    )
+  }
+
   options {
     timestamps()
     /* Prevent Jenkins jobs from running forever */

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -14,6 +14,14 @@ pipeline {
     }
   }
 
+  parameters {
+    booleanParam(
+      name: 'BUILD_TYPE',
+      description: 'Specify build type. Values: pr / nightly / release',
+      defaultValue: 'pr',
+    )
+  }
+
   options {
     timestamps()
     /* Prevent Jenkins jobs from running forever */

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -1,6 +1,14 @@
 pipeline {
   agent { label 'macos' }
 
+  parameters {
+    booleanParam(
+      name: 'BUILD_TYPE',
+      description: 'Specify build type. Values: pr / nightly / release',
+      defaultValue: 'pr',
+    )
+  }
+
   options {
     timestamps()
     /* Prevent Jenkins jobs from running forever */

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -14,6 +14,14 @@ pipeline {
     }
   }
 
+  parameters {
+    booleanParam(
+      name: 'BUILD_TYPE',
+      description: 'Specify build type. Values: pr / nightly / release',
+      defaultValue: 'pr',
+    )
+  }
+
   options {
     /* Prevent Jenkins jobs from running forever */
     timeout(time: 45, unit: 'MINUTES')


### PR DESCRIPTION
This is in order to make possible running separate platforms as separate PR builds for GitHub.
Otherwise we get:
```
java.lang.IllegalArgumentException: Null value not allowed as an environment variable: BUILD_TYPE
```