### PR TITLE
Adjust from value to accomodate for late-comers

### DIFF
--- a/src/status_im/transport/message/protocol.cljs
+++ b/src/status_im/transport/message/protocol.cljs
@@ -16,10 +16,13 @@
   (receive [this chat-id signature timestamp cofx] "Method producing all effects necessary for receiving the message record")
   (validate [this] "Method returning the message if it is valid or nil if it is not"))
 
-(def ^:private whisper-opts
-  {:ttl       10 ;; ttl of 10 sec
-   :powTarget config/pow-target
-   :powTime   config/pow-time})
+(def whisper-opts
+  {;; time drift that is tolerated by whisper, in seconds
+   :whisper-drift-tolerance 10
+   ;; ttl of 10 sec
+   :ttl                     10
+   :powTarget               config/pow-target
+   :powTime                 config/pow-time})
 
 (fx/defn init-chat
   "Initialises chat on protocol layer.


### PR DESCRIPTION
We add a bunch of seconds to the `from` field when requesting from the mailserver to accomodate for late-comers. We still cap to one day max to avoid errors from mailserver.


same as https://github.com/status-im/status-react/pull/6988 but had to re-create as I forced pushed :(

fixes: #6814

status: ready