### PR TITLE
add cleanup steps and reduce number of builds to keep

### DIFF
--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -8,9 +8,9 @@ pipeline {
     timeout(time: 35, unit: 'MINUTES')
     /* Limit builds retained */
     buildDiscarder(logRotator(
-      numToKeepStr: '90',
-      daysToKeepStr: '30',
-      artifactNumToKeepStr: '90',
+      numToKeepStr: '10',
+      daysToKeepStr: '20',
+      artifactNumToKeepStr: '10',
     ))
   }
 
@@ -95,6 +95,11 @@ pipeline {
     stage('Notify') {
       steps {
         script { cmn.gitHubNotifyPRSuccess() }
+      }
+    }
+    stage('Cleanup') {
+      steps {
+        script { cmn.clean() }
       }
     }
   }

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -16,9 +16,9 @@ pipeline {
     timeout(time: 35, unit: 'MINUTES')
     /* Limit builds retained */
     buildDiscarder(logRotator(
-      numToKeepStr: '90',
-      daysToKeepStr: '60',
-      artifactNumToKeepStr: '60',
+      numToKeepStr: '10',
+      daysToKeepStr: '20',
+      artifactNumToKeepStr: '10',
     ))
   }
 
@@ -88,6 +88,11 @@ pipeline {
     stage('Notify') {
       steps {
         script { cmn.gitHubNotifyPRSuccess() }
+      }
+    }
+    stage('Cleanup') {
+      steps {
+        script { cmn.clean() }
       }
     }
   }

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -29,9 +29,9 @@ pipeline {
     timeout(time: 35, unit: 'MINUTES')
     /* Limit builds retained */
     buildDiscarder(logRotator(
-      numToKeepStr: '60',
-      daysToKeepStr: '30',
-      artifactNumToKeepStr: '60',
+      numToKeepStr: '10',
+      daysToKeepStr: '20',
+      artifactNumToKeepStr: '10',
     ))
   }
 
@@ -101,6 +101,11 @@ pipeline {
     stage('Notify') {
       steps {
         script { cmn.gitHubNotifyPRSuccess() }
+      }
+    }
+    stage('Cleanup') {
+      steps {
+        script { cmn.clean() }
       }
     }
   }

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -16,9 +16,9 @@ pipeline {
     timeout(time: 25, unit: 'MINUTES')
     /* Limit builds retained */
     buildDiscarder(logRotator(
-      numToKeepStr: '60',
-      daysToKeepStr: '30',
-      artifactNumToKeepStr: '60',
+      numToKeepStr: '10',
+      daysToKeepStr: '20',
+      artifactNumToKeepStr: '10',
     ))
   }
 
@@ -82,6 +82,11 @@ pipeline {
     stage('Notify') {
       steps {
         script { cmn.gitHubNotifyPRSuccess() }
+      }
+    }
+    stage('Cleanup') {
+      steps {
+        script { cmn.clean() }
       }
     }
   }

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -29,9 +29,9 @@ pipeline {
     timeout(time: 45, unit: 'MINUTES')
     /* Limit builds retained */
     buildDiscarder(logRotator(
-      numToKeepStr: '60',
-      daysToKeepStr: '30',
-      artifactNumToKeepStr: '60',
+      numToKeepStr: '10',
+      daysToKeepStr: '20',
+      artifactNumToKeepStr: '10',
     ))
   }
 
@@ -104,6 +104,11 @@ pipeline {
     stage('Notify') {
       steps {
         script { cmn.gitHubNotifyPRSuccess() }
+      }
+    }
+    stage('Cleanup') {
+      steps {
+        script { cmn.clean() }
       }
     }
   }

--- a/ci/desktop.groovy
+++ b/ci/desktop.groovy
@@ -2,12 +2,8 @@ cmn = load 'ci/common.groovy'
 
 packageFolder = './StatusImPackage'
 
-def cleanupBuild() {
-  sh 'make clean'
-}
-
 def cleanupAndDeps() {
-  cleanupBuild()
+  cmn.clean()
   sh 'cp .env.jenkins .env'
   sh 'lein deps'
   cmn.installJSDeps('desktop')

--- a/ci/mobile.groovy
+++ b/ci/mobile.groovy
@@ -36,7 +36,7 @@ def podUpdate() {
 def prep(type = 'nightly') {
   cmn.doGitRebase()
   /* ensure that we start from a known state */
-  sh 'make clean'
+  cmn.clean()
   /* select type of build */
   switch (type) {
     case 'nightly':


### PR DESCRIPTION
Attempt to fix issues with disc space on Jenkins slaves.

Before we used to run platform builds from the `combined` folder:
https://ci.status.im/job/status-react/job/combined/
Which meant that every paltform build had at most two folders per host, which wasn't that much space.
Now that we run PR builds per platform per PR we create that many folders on each host:
https://ci.status.im/job/status-react/job/prs/
Which means for MacOS hosts there 2 platforms - iOS, iOS e2e and MacOS - and each of those can have 2 builds running at the same time. There are currently roughly ~30 PRs active.
That gives us 30\*2\*3 = 180 build folders, multiply that by ~1.5GB and you get 270GB of space taken by PR builds on each MacOS host.

To avoid this we need to clean up stuff after builds. I might even have to remove the `node_modules` folder to avoid space issues.

<blockquote><img src="/static/43054e8a/favicon.ico" width="48" align="right"><div><strong><a href="https://ci.status.im/job/status-react/job/combined/">All [status-react » combined] [Jenkins]</a></strong></div></blockquote>
<blockquote><img src="/static/43054e8a/favicon.ico" width="48" align="right"><div><strong><a href="https://ci.status.im/job/status-react/job/prs/">All [status-react » prs] [Jenkins]</a></strong></div></blockquote>