### PR TITLE
use the new pr commenting service (ghcmgr)

### DIFF
--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -94,7 +94,7 @@ pipeline {
     }
     stage('Notify') {
       steps {
-        script { cmn.gitHubNotifyPRSuccess() }
+        script { cmn.notifyPRSuccess() }
       }
     }
     stage('Cleanup') {
@@ -104,6 +104,6 @@ pipeline {
     }
   }
   post {
-    failure { script { load('ci/common.groovy').gitHubNotifyPRFail() } }
+    failure { script { load('ci/common.groovy').notifyPRFailure() } }
   }
 }

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -79,6 +79,7 @@ pipeline {
           /* e2e builds get tested in SauceLabs */
           if (cmn.getBuildType() == 'e2e') {
             env.SAUCE_URL = mobile.ios.uploadToSauceLabs()
+            env.PKG_URL = cmn.uploadArtifact(api)
           } else {
             env.PKG_URL = mobile.ios.uploadToDiawi()
           }
@@ -87,7 +88,7 @@ pipeline {
     }
     stage('Notify') {
       steps {
-        script { cmn.gitHubNotifyPRSuccess() }
+        script { cmn.notifyPRSuccess() }
       }
     }
     stage('Cleanup') {
@@ -97,6 +98,6 @@ pipeline {
     }
   }
   post {
-    failure { script { load('ci/common.groovy').gitHubNotifyPRFail() } }
+    failure { script { load('ci/common.groovy').notifyPRFailure() } }
   }
 }

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -100,7 +100,7 @@ pipeline {
     }
     stage('Notify') {
       steps {
-        script { cmn.gitHubNotifyPRSuccess() }
+        script { cmn.notifyPRSuccess() }
       }
     }
     stage('Cleanup') {
@@ -110,6 +110,6 @@ pipeline {
     }
   }
   post {
-    failure { script { load('ci/common.groovy').gitHubNotifyPRFail() } }
+    failure { script { load('ci/common.groovy').notifyPRFailure() } }
   }
 }

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -81,7 +81,7 @@ pipeline {
     }
     stage('Notify') {
       steps {
-        script { cmn.gitHubNotifyPRSuccess() }
+        script { cmn.notifyPRSuccess() }
       }
     }
     stage('Cleanup') {
@@ -91,6 +91,6 @@ pipeline {
     }
   }
   post {
-    failure { script { load('ci/common.groovy').gitHubNotifyPRFail() } }
+    failure { script { load('ci/common.groovy').notifyPRFailure() } }
   }
 }

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -103,7 +103,7 @@ pipeline {
     }
     stage('Notify') {
       steps {
-        script { cmn.gitHubNotifyPRSuccess() }
+        script { cmn.notifyPRSuccess() }
       }
     }
     stage('Cleanup') {
@@ -113,6 +113,6 @@ pipeline {
     }
   }
   post {
-    failure { script { load('ci/common.groovy').gitHubNotifyPRFail() } }
+    failure { script { load('ci/common.groovy').notifyPRFailure() } }
   }
 }


### PR DESCRIPTION
This is a fix for spamming comment sections with builds for different platforms.

It uses a very simple service I've created:
https://github.com/status-im/github-comment-manager

Which essentially stores builds CI posts to it and posts or updates a single comment with all the builds it knows for that PR.

Deployed with:
https://github.com/status-im/infra-misc/tree/master/ansible/roles/github-comment-manager

<blockquote><img src="https://avatars3.githubusercontent.com/u/11767950?s=400&v=4" width="48" align="right"><div><img src="https://github.githubassets.com/favicon.ico" height="14"> GitHub</div><div><strong><a href="https://github.com/status-im/github-comment-manager">status-im/github-comment-manager</a></strong></div><div>Service for managing comments on GitHub. Contribute to status-im/github-comment-manager development by creating an account on GitHub.</div></blockquote>
<blockquote><div><strong><a href="https://github.com/status-im/infra-misc/tree/master/ansible/roles/github-comment-manager">Page not found · GitHub</a></strong></div></blockquote>