### PR TITLE
fix link used for Macs

### DIFF
--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -77,7 +77,7 @@ pipeline {
           Apk: cmn.pkgUrl(apk), Apke2e: cmn.pkgUrl(apke2e),
           iOS: cmn.pkgUrl(ios), iOSe2e: cmn.pkgUrl(iose2e),
           /* desktop */
-          App: cmn.pkgUrl(nix), Mac: cmn.pkgUrl(ios), Win: cmn.pkgUrl(win),
+          App: cmn.pkgUrl(nix), Mac: cmn.pkgUrl(osx), Win: cmn.pkgUrl(win),
           /* upload the sha256 checksums file too */
           SHA: cmn.uploadArtifact(cmn.pkgFind('sha256')),
         ]


### PR DESCRIPTION
Fixes issue with Mac nightly link on our page: https://status.im/nightly/

<blockquote><img src="/img/share.png" width="48" align="right"><div><strong><a href="https://status.im/nightly/">Status, a Mobile Client for Ethereum 2.0</a></strong></div></blockquote>