### PR TITLE
[slow sign in] adding symkeys and filters in batch 

### DIFF
--- a/src/status_im/accounts/login/core.cljs
+++ b/src/status_im/accounts/login/core.cljs
@@ -101,7 +101,7 @@
           :web3/fetch-node-version  [web3
                                      #(re-frame/dispatch
                                        [:web3/fetch-node-version-callback %])]}
-         (protocol/initialize-protocol address)
+         (protocol/initialize-protocol)
          #(when-not platform/desktop?
             (initialize-wallet %)))
         (account-and-db-password-do-not-match cofx error)))))

--- a/src/status_im/protocol/core.cljs
+++ b/src/status_im/protocol/core.cljs
@@ -47,7 +47,7 @@
 
 (fx/defn initialize-protocol
   [{:data-store/keys [transport mailserver-topics mailservers]
-    :keys [db web3] :as cofx} address]
+    :keys [db web3] :as cofx}]
   (let [network (get-in db [:account/account :network])
         network-id (str (get-in db [:account/account :networks network :config :NetworkId]))]
     (fx/merge cofx
@@ -59,7 +59,7 @@
                                                  :network-id network-id}}
               (start-check-sync-state)
               (mailserver/initialize-mailserver mailservers)
-              (transport/init-whisper address))))
+              (transport/init-whisper))))
 
 (fx/defn handle-close-app-confirmed
   [_]

--- a/src/status_im/transport/filters.cljs
+++ b/src/status_im/transport/filters.cljs
@@ -18,7 +18,7 @@
   (log/debug :stop-watching filter))
 
 (defn add-filter!
-  [web3 {:keys [topics to] :as options} callback chat-id]
+  [web3 {:keys [topics] :as options} callback chat-id]
   (let [options  (assoc options :allowP2P true)]
     (log/debug :add-filter options)
     (when-let [filter (.newMessageFilter (utils/shh web3)
@@ -26,6 +26,24 @@
                                          callback
                                          #(log/warn :add-filter-error (.stringify js/JSON (clj->js options)) %))]
       (re-frame/dispatch [:shh.callback/filter-added (first topics) chat-id filter]))))
+
+(defn add-filters!
+  [web3 filters]
+  (log/debug "PERF" :add-filters (first filters))
+  (re-frame/dispatch
+   [:shh.callback/filters-added
+    (keep
+     (fn [{:keys [options callback chat-id]}]
+       (when-let [filter (.newMessageFilter
+                          (utils/shh web3)
+                          (clj->js (assoc options :allowP2P true))
+                          callback
+                          #(log/warn :add-filter-error
+                                     (.stringify js/JSON (clj->js options)) %))]
+         {:topic   (first (:topics options))
+          :chat-id chat-id
+          :filter  filter}))
+     filters)]))
 
 (re-frame/reg-fx
  :shh/add-filter
@@ -35,6 +53,24 @@
          callback (fn [js-error js-message]
                     (re-frame/dispatch [:transport/messages-received js-error js-message chat-id]))]
      (add-filter! web3 params callback chat-id))))
+
+(re-frame/reg-fx
+ :shh/add-filters
+ (fn [{:keys [web3 filters]}]
+   (log/debug "PERF" :shh/add-filters)
+   (let [filters
+         (reduce
+          (fn [acc {:keys [sym-key-id topic chat-id]}]
+            (conj acc
+                  {:options  {:topics   [topic]
+                              :symKeyID sym-key-id}
+                   :callback (fn [js-error js-message]
+                               (re-frame/dispatch [:transport/messages-received
+                                                   js-error js-message chat-id]))
+                   :chat-id  chat-id}))
+          []
+          filters)]
+     (add-filters! web3 filters))))
 
 (re-frame/reg-fx
  :shh/add-discovery-filter
@@ -55,12 +91,34 @@
 (handlers/register-handler-fx
  :shh.callback/filter-added
  (fn [{:keys [db] :as cofx} [_ topic chat-id filter]]
+   (log/debug "PERF" :shh.callback/filter-added)
    (fx/merge cofx
              {:db (assoc-in db [:transport/filters chat-id] filter)}
              (mailserver/reset-request-to)
              (mailserver/upsert-mailserver-topic {:topic topic
                                                   :chat-id chat-id})
              (mailserver/process-next-messages-request))))
+
+(fx/defn add-filter
+  [{:keys [db]} chat-id filter]
+  {:db (assoc-in db [:transport/filters chat-id] filter)})
+
+(handlers/register-handler-fx
+ :shh.callback/filters-added
+ (fn [cofx [_ filters]]
+   (log/debug "PERF" :shh.callback/filters-added)
+   (let [filters-fx-fns
+         (mapcat
+          (fn [{:keys [topic chat-id filter]}]
+            [(add-filter chat-id filter)
+             (mailserver/upsert-mailserver-topic {:topic   topic
+                                                  :chat-id chat-id})])
+          filters)]
+     (apply fx/merge cofx
+            (mailserver/reset-request-to)
+            (concat
+             filters-fx-fns
+             [(mailserver/process-next-messages-request)])))))
 
 (handlers/register-handler-fx
  :shh.callback/filter-removed

--- a/test/cljs/status_im/test/transport/core.cljs
+++ b/test/cljs/status_im/test/transport/core.cljs
@@ -6,16 +6,19 @@
 
 (deftest init-whisper
   (let [cofx {:db {:account/account {:public-key "1"}
-                   :transport/chats {"1" {:topic "topic-1"}
+                   :transport/chats {"1" {:topic   "topic-1"
+                                          :sym-key "sk1"}
                                      "2" {}
-                                     "3" {:topic "topic-3"}}
-                   :semaphores #{}}}]
+                                     "3" {:topic   "topic-3"
+                                          :sym-key "sk3"}}
+                   :semaphores      #{}}}]
     (testing "it adds the discover filter"
       (is (= {:web3 nil :private-key-id "1" :topic "0xf8946aac"}
-             (:shh/add-discovery-filter (transport/init-whisper cofx "user-address")))))
+             (:shh/add-discovery-filter (transport/init-whisper cofx)))))
     (testing "it restores the sym-keys"
-      (is (= [["1" {:topic "topic-1"}] ["3" {:topic "topic-3"}]]
-             (-> (transport/init-whisper cofx  "user-address") :shh/restore-sym-keys :transport))))
+      (is (= [{:topic "topic-1", :sym-key "sk1", :chat-id "1"}
+              {:topic "topic-3", :sym-key "sk3", :chat-id "3"}]
+             (-> (transport/init-whisper cofx) :shh/restore-sym-keys-batch :transport))))
     (testing "custom mailservers"
       (let [ms-1            {:id "1"
                              :fleet :eth.beta
@@ -48,7 +51,7 @@
                                     ms-3])]
         (is (= expected-mailservers
                (-> (get-in
-                    (protocol/initialize-protocol cofx-with-ms "user-address")
+                    (protocol/initialize-protocol cofx-with-ms)
                     [:db :mailserver/mailservers])
                    (update-in [:eth.beta "1"] dissoc :generating-sym-key?)
                    (update-in [:eth.beta "2"] dissoc :generating-sym-key?)


### PR DESCRIPTION
Chat's symmetric keys should be restored after signing in in order to be
used during filters creation. Currently, if there are **N** chats we restore
**N** keys one by one:
1. `ssh.addSymKey` is called
2. `:status-im.transport.core/sym-key-added` event is dispatched
   on success
3. filter is created via `ssh.newMessageFilter`
4. `:shh.callback/filter-added` event is dispatched if filter was
   successfully created

In result we have **2N** `re-frame` events which is expensive in case if we have
a lot of chats.

This PR changes the way keys are restored:
1. batch of `ssh.addSymKey` requests for all sym keys is sent at once
2. `:status-im.transport.core/sym-keys-added` event is dispatched with results
   of all successful `ssh.addSymKey` calls
3. filter is created via `ssh.newMessageFilter`
4. `:shh.callback/filters-added` event is dispatched with all added filters
   as a parameter
5. profit

In ideal case only 2 `re-frame` events are dispatched.

**Possible cons:**
Batch size is not limited atm, probably better to split it into smaller 
chunks if there are, let's say, 1000+ chats. 

**Results**
adding filters on galaxy s9(`develop vs PR`):
100 chats: 3.3s vs 0.5s
200 chats: 6s vs 0.6s

on a slower android device:
50 chats: 5.62s vs 1.07s

status: ready <!-- Can be ready or wip -->
