### PR TITLE
[slow sign in] denormalize last-clock-value

### DIFF
--- a/src/status_im/data_store/chats.cljs
+++ b/src/status_im/data_store/chats.cljs
@@ -47,22 +47,13 @@
                :signature signature
                :chat-id chat-id}))))
 
-(defn- get-last-clock-value [chat-id]
-  (-> (core/get-by-field @core/account-realm
-                         :message :chat-id chat-id)
-      (core/sorted :clock-value :desc)
-      (core/single-clj :message)
-      :clock-value
-      (utils.clocks/safe-timestamp)))
-
 (defn- normalize-chat [{:keys [chat-id] :as chat}]
   (-> chat
       (update :admins   #(into #{} %))
       (update :contacts #(into #{} %))
       (update :tags #(into #{} %))
       (update :membership-updates  (partial unmarshal-membership-updates chat-id))
-      ;; We cap the clock value to a safe value in case the db has been polluted
-      (assoc :last-clock-value (get-last-clock-value chat-id))
+      (update :last-clock-value utils.clocks/safe-timestamp)
       (update :last-message-type keyword)
       (update :last-message-content edn/read-string)))
 

--- a/src/status_im/data_store/realm/core.cljs
+++ b/src/status_im/data_store/realm/core.cljs
@@ -149,7 +149,7 @@
   (when (pos? current-version)
     (doseq [schema schemas
             :when (> (:schemaVersion schema) current-version)]
-      (migration-log :current-version current-version)
+      (migration-log :current-version (:schemaVersion schema))
       (let [migrated-realm (open-realm schema file-name encryption-key)]
         (close migrated-realm))))
   (open-realm (last schemas) file-name encryption-key))

--- a/src/status_im/data_store/realm/schemas/account/chat.cljs
+++ b/src/status_im/data_store/realm/schemas/account/chat.cljs
@@ -230,3 +230,8 @@
                                   :optional true}
            :last-message-type    {:type     :string
                                   :optional true}}))
+
+(def v11
+  (update v10 :properties merge
+          {:last-clock-value {:type     :int
+                              :optional true}}))

--- a/src/status_im/data_store/realm/schemas/account/core.cljs
+++ b/src/status_im/data_store/realm/schemas/account/core.cljs
@@ -304,6 +304,19 @@
           browser/v8
           dapp-permissions/v9])
 
+(def v29 [chat/v11
+          transport/v7
+          contact/v3
+          message/v9
+          mailserver/v11
+          mailserver-topic/v1
+          user-status/v2
+          membership-update/v1
+          installation/v2
+          local-storage/v1
+          browser/v8
+          dapp-permissions/v9])
+
 ;; put schemas ordered by version
 (def schemas [{:schema        v1
                :schemaVersion 1
@@ -388,4 +401,7 @@
                :migration     migrations/v27}
               {:schema        v28
                :schemaVersion 28
-               :migration     migrations/v28}])
+               :migration     migrations/v28}
+              {:schema        v29
+               :schemaVersion 29
+               :migration     migrations/v29}])

--- a/test/cljs/status_im/test/data_store/chats.cljs
+++ b/test/cljs/status_im/test/data_store/chats.cljs
@@ -5,39 +5,37 @@
 
 (deftest normalize-chat-test
   (testing "admins & contacts"
-    (with-redefs [chats/get-last-clock-value (constantly 42)]
-      (is (= {:last-clock-value 42
-              :admins #{4}
-              :contacts #{2}
-              :tags #{}
-              :membership-updates []
-              :last-message-type :message-type
-              :last-message-content {:foo "bar"}}
-             (chats/normalize-chat
-              {:admins            [4]
-               :contacts          [2]
-               :last-message-type "message-type"
-               :last-message-content "{:foo \"bar\"}"})))))
+    (is (= {:admins               #{4}
+            :contacts             #{2}
+            :tags                 #{}
+            :membership-updates   []
+            :last-message-type    :message-type
+            :last-message-content {:foo "bar"}
+            :last-clock-value     nil}
+           (chats/normalize-chat
+            {:admins               [4]
+             :contacts             [2]
+             :last-message-type    "message-type"
+             :last-message-content "{:foo \"bar\"}"}))))
   (testing "membership-updates"
-    (with-redefs [chats/get-last-clock-value (constantly 42)]
-      (let [raw-events {"1" {:id "1" :type "members-added" :clock-value 10 :members [1 2] :signature "a" :from "id-1"}
-                        "2" {:id "2" :type "member-removed" :clock-value 11 :member 1 :signature "a" :from "id-1"}
-                        "3" {:id "3" :type "chat-created" :clock-value 0 :name "blah" :signature "b" :from "id-2"}}
-            expected    #{{:chat-id "chat-id"
-                           :from "id-2"
-                           :signature "b"
-                           :events [{:type "chat-created" :clock-value 0 :name "blah"}]}
-                          {:chat-id "chat-id"
-                           :signature "a"
-                           :from "id-1"
-                           :events [{:type "members-added" :clock-value 10 :members [1 2]}
+    (let [raw-events {"1" {:id "1" :type "members-added" :clock-value 10 :members [1 2] :signature "a" :from "id-1"}
+                      "2" {:id "2" :type "member-removed" :clock-value 11 :member 1 :signature "a" :from "id-1"}
+                      "3" {:id "3" :type "chat-created" :clock-value 0 :name "blah" :signature "b" :from "id-2"}}
+          expected   #{{:chat-id   "chat-id"
+                        :from      "id-2"
+                        :signature "b"
+                        :events    [{:type "chat-created" :clock-value 0 :name "blah"}]}
+                       {:chat-id   "chat-id"
+                        :signature "a"
+                        :from      "id-1"
+                        :events    [{:type "members-added" :clock-value 10 :members [1 2]}
                                     {:type "member-removed" :clock-value 11 :member 1}]}}
-            actual      (->> (chats/normalize-chat {:chat-id "chat-id"
-                                                    :membership-updates raw-events})
-                             :membership-updates
-                             (into #{}))]
-        (is (= expected
-               actual))))))
+          actual     (->> (chats/normalize-chat {:chat-id            "chat-id"
+                                                 :membership-updates raw-events})
+                          :membership-updates
+                          (into #{}))]
+      (is (= expected
+             actual)))))
 
 (deftest marshal-membership-updates-test
   (let [raw-updates [{:chat-id "chat-id"


### PR DESCRIPTION
In order to get `:last-clock-value` one extra query was executed for
each chat during initialization.

Implementation:
- `:last-clock-value` field was added to `chat` entity
- this field is updated when the message is sent/received
- an extra query was removed

status: ready 
