### PR TITLE
Paginate using clock-value & message-id instead of skip/limit

### DIFF
--- a/src/status_im/chat/models/loading.cljs
+++ b/src/status_im/chat/models/loading.cljs
@@ -111,9 +111,10 @@
     get-stored-user-statuses :get-stored-user-statuses
     get-referenced-messages :get-referenced-messages :as cofx}]
   (when-not (get-in db [:chats current-chat-id :all-loaded?])
-    (let [loaded-count               (count (get-in db [:chats current-chat-id :messages]))
+    (let [previous-pagination-info   (get-in db [:chats current-chat-id :pagination-info])
           {:keys [messages
-                  all-loaded?]}      (get-stored-messages current-chat-id loaded-count)
+                  pagination-info
+                  all-loaded?]}      (get-stored-messages current-chat-id previous-pagination-info)
           already-loaded-messages    (get-in db [:chats current-chat-id :messages])
           ;; We remove those messages that are already loaded, as we might get some duplicates
           new-messages               (remove (comp already-loaded-messages :message-id)
@@ -132,6 +133,7 @@
                          (update-in [:chats current-chat-id :message-statuses] merge new-statuses)
                          (update-in [:chats current-chat-id :referenced-messages]
                                     #(into (apply dissoc % new-message-ids) referenced-messages))
+                         (assoc-in [:chats current-chat-id :pagination-info] pagination-info)
                          (assoc-in [:chats current-chat-id :all-loaded?]
                                    all-loaded?))}
                 (chat-model/update-chats-unviewed-messages-count

--- a/src/status_im/data_store/realm/core.cljs
+++ b/src/status_im/data_store/realm/core.cljs
@@ -307,6 +307,9 @@
                                        false
                                        true)))
 
+(defn multi-field-sorted [results fields]
+  (.sorted results (clj->js fields)))
+
 (defn page [results from to]
   (js/Array.prototype.slice.call results from to))
 


### PR DESCRIPTION
Fixes: #7097 

Paginating using the count of loaded messages might result in some
messages being skipped and not being loaded in the database, in case of
out-of-order messages received.

This commit changes the behavior to sort by `clock-value` and
`message-id`, which gives a consistent sorting.

The initial idea was to use a cursor `clock-value-message-id` and
iterate on that, but realm does not support filtering on string (</>),
so instead we keep track of messages with identical clock-value and
exclude those in the next page query.

The change might result in pages that have duplicates (so messages needs
to be deduped), but won't result in skipped messages.

For a good description of the issue: https://coderwall.com/p/lkcaag/pagination-you-re-probably-doing-it-wrong

This is also using `clock-value` instead of `timestamp`, as that's the one true order, although messages gets grouped by timestamp and then sorted by clock-value.

### Testing

1) Create 0..100 messages in chat A
2) Logout
3) Set you phone date to yesterday
4) Login again, open that chat, don't scroll
5) Publish a few messages
6) Scroll up, check 0..100 are all there

In develop you will see some gaps
In this PR there should not be any 

status: ready
