### PR TITLE
fix #6440 increase width of mobile message bubbles on mobile

### DIFF
--- a/src/status_im/ui/screens/chat/styles/message/message.cljs
+++ b/src/status_im/ui/screens/chat/styles/message/message.cljs
@@ -77,9 +77,7 @@
   [outgoing message-type]
   (let [align (if outgoing :flex-end :flex-start)]
     {:flex-direction :column
-     :width          (if (= :system-message message-type)
-                       300
-                       230)
+     :width          320
      :padding-left   8
      :padding-right  8
      :align-items    align}))
@@ -211,4 +209,3 @@
 (defn extension-install [outgoing]
   {:font-size 12
    :color     (if outgoing colors/white colors/blue)})
-


### PR DESCRIPTION
fix #6440

![screenshot_1545125692](https://user-images.githubusercontent.com/1181225/50144908-96433f80-02b0-11e9-9ea3-d12cb718f6d2.png)
![screenshot_1545125659](https://user-images.githubusercontent.com/1181225/50144911-980d0300-02b0-11e9-8716-3801dfdc7164.png)

status: ready
