### PR TITLE
Updated airswap dapp url

### DIFF
--- a/src/status_im/ui/screens/browser/default_dapps.cljs
+++ b/src/status_im/ui/screens/browser/default_dapps.cljs
@@ -5,7 +5,7 @@
 (def all
   [{:title (i18n/label :t/default-dapps-exchanges)
     :data  [{:name        "Airswap"
-             :dapp-url    "https://www.airswap.io/trade"
+             :dapp-url    "https://instant.airswap.io/"
              :photo-path  "contacts://airswap"
              :description "Meet the future of trading."}
             {:name        "Bancor"


### PR DESCRIPTION
Current Airswap url redirects to `https://instant.airswap.io/` and we show browser item not dapp item, updated url to fix that