### PR TITLE
[#7135] Fix wrong password handling

### DIFF
--- a/src/status_im/init/core.cljs
+++ b/src/status_im/init/core.cljs
@@ -150,7 +150,7 @@
          :keys [accounts/accounts accounts/create networks/networks network
                 network-status peers-count peers-summary view-id navigation-stack
                 status-module-initialized? device-UUID semaphores accounts/login]
-         :node/keys [status]
+         :node/keys [status on-ready]
          :or   {network (get app-db :network)}} db
         current-account (get accounts address)
         account-network-id (get current-account :network network)
@@ -160,6 +160,7 @@
                         :navigation-stack navigation-stack
                         :status-module-initialized? (or platform/ios? js/goog.DEBUG status-module-initialized?)
                         :node/status status
+                        :node/on-ready on-ready
                         :accounts/create create
                         :networks/networks networks
                         :account/account current-account

--- a/src/status_im/ui/screens/accounts/subs.cljs
+++ b/src/status_im/ui/screens/accounts/subs.cljs
@@ -2,7 +2,8 @@
   (:require [re-frame.core :as re-frame]
             [status-im.accounts.db :as db]
             [status-im.utils.ethereum.core :as ethereum]
-            [cljs.spec.alpha :as spec]))
+            [cljs.spec.alpha :as spec]
+            [status-im.utils.security :as security]))
 
 (re-frame/reg-sub
  :accounts/accounts
@@ -40,3 +41,12 @@
  :get-recover-account
  (fn [db]
    (:accounts/recover db)))
+
+(re-frame/reg-sub
+ :sign-in-enabled?
+ :<- [:get :accounts/login]
+ :<- [:get :node/status]
+ (fn [[{:keys [password]} status]]
+   (and (or (nil? status) (= status :stopped))
+        (spec/valid? ::db/password
+                     (security/safe-unmask-data password)))))


### PR DESCRIPTION
fix #7135 

Leftover after #7032. The node hasn't been started if the user entered a
wrong password, that's why `Statusgo.Verify` call has failed (it works
properly only with running node atm).

Implementation:
- the node is started with "dummy" configs if it's necessary to call
  `Statusgo.Verify` method
- on `Statusgo.Verify` callback node is stopped so that it can be
  started with proper configs on the next sign in attempt.

status: ready <!-- Can be ready or wip -->
