### PR TITLE
Use QSettings in AppConfig

### DIFF
--- a/desktop/appconfig.cpp
+++ b/desktop/appconfig.cpp
@@ -2,6 +2,7 @@
 
 #include <QLoggingCategory>
 
+#include <QSettings>
 
 const QStringList loggingCategories = 
   {"UIManager", 
@@ -14,25 +15,50 @@ const QStringList loggingCategories =
     "RCTStatus",
     "jsserver",
     "status"};
+
+const QString SETTINGS_GROUP_NAME = "im/status";
+const QString AppConfig::LOGGING_ENABLED = "logging_enabled";
+
 Q_LOGGING_CATEGORY(APPCONFIG, "AppConfig")
 
 AppConfig AppConfig::appConfig;
 
-AppConfig::AppConfig() {
+AppConfig::AppConfig() 
+: settings("Status.im", "StatusDesktop") {
+  settings.beginGroup(SETTINGS_GROUP_NAME);
+
+  // Set default values
+  if (settings.value(LOGGING_ENABLED).isNull()) {
+    settings.setValue(LOGGING_ENABLED, false);
+  }
+
+  QStringList keys = settings.allKeys();
+  for (int i = 0; i < keys.size(); ++i) {
+    processFx(keys[i], settings.value(keys[i]));
+  }
 }
 
 AppConfig& AppConfig::inst() {
   return appConfig;
 }
 
-bool AppConfig::getLoggingEnabled() const {
-  return loggingEnabled;
+QVariant AppConfig::getValue(const QString& name) const {
+  return settings.value(name);
 }
 
-void AppConfig::setLoggingEnabled(bool enabled) {
-  //qCDebug(APPCONFIG) << "### appconfig setLoggingEnabled " << enabled;
-  QLoggingCategory::setFilterRules(getLoggingFilterRules(enabled));
-  this->loggingEnabled = enabled;
+void AppConfig::setValue(const QString& name, const QVariant& value) {
+  processFx(name, value);
+  settings.setValue(name, value);
+}
+
+// This fn is for processing side-effects of a particular value
+void AppConfig::processFx(const QString& name, const QVariant& value) const {
+  //qCDebug(APPCONFIG) << "### processFx group" << settings.group() << " " << name << ": " << value;
+  if (name == LOGGING_ENABLED) {
+    bool enabled = value.toBool();
+    //qCDebug(APPCONFIG) << "### processFx" << name << ": " << value << ": " << enabled;
+    QLoggingCategory::setFilterRules(getLoggingFilterRules(enabled));
+  }
 }
 
 QString AppConfig::getLoggingFilterRules(bool enabled) const {
@@ -47,3 +73,4 @@ QString AppConfig::getLoggingFilterRules(bool enabled) const {
      return filterRules;
    }
 }
+

--- a/desktop/appconfig.h
+++ b/desktop/appconfig.h
@@ -2,6 +2,8 @@
 #define APPCONFIG_H
 
 #include <QString>
+#include <QVariant>
+#include <QSettings>
 
 // This class is intended to store app configuration
 // modifiable from JS side
@@ -12,15 +14,18 @@ public:
 
   static AppConfig& inst();
 
-  bool getLoggingEnabled() const;
-  void setLoggingEnabled(bool enable);
+  QVariant getValue(const QString& name) const;
+  void setValue(const QString& name, const QVariant& value);
 
+  const static QString LOGGING_ENABLED;
 private:
   AppConfig();
 
-  bool loggingEnabled = false;
   static AppConfig appConfig;
+  QSettings settings;
 
   QString getLoggingFilterRules(bool enabled) const;
+  void processFx(const QString& name, const QVariant& value) const;
 };
 #endif // APPCONFIG_H
+

--- a/desktop/main.cpp
+++ b/desktop/main.cpp
@@ -1,4 +1,3 @@
-
 /**
  * Copyright (C) 2016, Canonical Ltd.
  * All rights reserved.
@@ -240,6 +239,9 @@ int main(int argc, char **argv) {
 
   QCoreApplication::setApplicationName("Status");
 
+  // Init AppConfig
+  AppConfig::inst().getValue(AppConfig::LOGGING_ENABLED);
+
   QString appPath = QCoreApplication::applicationDirPath();
   QString dataStoragePath = getDataStoragePath();
 #ifdef BUILD_FOR_BUNDLE
@@ -263,7 +265,6 @@ int main(int argc, char **argv) {
   }
 
   //qCDebug(STATUS) << "###STATUS_NO_LOGGING";
-  AppConfig::inst().setLoggingEnabled(false);
 
 
 #ifdef BUILD_FOR_BUNDLE
@@ -558,3 +559,4 @@ void saveMessage(QtMsgType type, const QMessageLogContext &context,
 }
 
 #include "main.moc"
+

--- a/modules/react-native-desktop-config/desktop/desktopconfig.cpp
+++ b/modules/react-native-desktop-config/desktop/desktopconfig.cpp
@@ -33,12 +33,14 @@ QList<ModuleMethod *> DesktopConfig::methodsToExport() {
 
 QVariantMap DesktopConfig::constantsToExport() { return QVariantMap(); }
 
-void DesktopConfig::getLoggingEnabled(double callback) {
-  bridge->invokePromiseCallback(callback, QVariantList{AppConfig::inst().getLoggingEnabled()});
+void DesktopConfig::getValue(const QString& name, double callback) {
+  //qCDebug(DESKTOPCONFIG) << "### getValue" << name;
+  bridge->invokePromiseCallback(callback, QVariantList{AppConfig::inst().getValue(name)});
 }
 
-void DesktopConfig::setLoggingEnabled(bool enable) {
-  //qCDebug(DESKTOPCONFIG) << "### setLoggingEnabled " << enable;
-  AppConfig::inst().setLoggingEnabled(enable);
+void DesktopConfig::setValue(const QString& name, const QVariant& value) {
+  //qCDebug(DESKTOPCONFIG) << "### setValue" << name << ": " << value;
+  AppConfig::inst().setValue(name, value);
 }
+
 

--- a/modules/react-native-desktop-config/desktop/desktopconfig.h
+++ b/modules/react-native-desktop-config/desktop/desktopconfig.h
@@ -2,7 +2,7 @@
 #define DESKTOPCONFIG_H
 
 #include "moduleinterface.h"
-
+#include <QVariant>
 #include <QLoggingCategory>
 
 Q_DECLARE_LOGGING_CATEGORY(CONFIG)
@@ -22,8 +22,8 @@ public:
     QList<ModuleMethod*> methodsToExport() override;
     QVariantMap constantsToExport() override;
 
-    Q_INVOKABLE void getLoggingEnabled(double callback);
-    Q_INVOKABLE void setLoggingEnabled(bool enable);
+    Q_INVOKABLE void getValue(const QString& name, double callback);
+    Q_INVOKABLE void setValue(const QString& name, const QVariant& value);
 
 private:
     Bridge* bridge = nullptr;

--- a/modules/react-native-desktop-config/index.js
+++ b/modules/react-native-desktop-config/index.js
@@ -4,15 +4,12 @@ const NativeModules = require('react-native').NativeModules;
 
 class DesktopConfig {
 
-  static getLoggingEnabled(callbackFn) {
-    NativeModules.DesktopConfigManager.getLoggingEnabled(
-      (enabled) => {
-        callbackFn(enabled);
-      });
+  static getValue(name, callbackFn) {
+    NativeModules.DesktopConfigManager.getValue(name, callbackFn);
   }
 
-  static setLoggingEnabled(enabled) {
-    NativeModules.DesktopConfigManager.setLoggingEnabled(enabled);
+  static setValue(name, value) {
+    NativeModules.DesktopConfigManager.setValue(name, value);
 
   }
 }

--- a/src/status_im/accounts/login/core.cljs
+++ b/src/status_im/accounts/login/core.cljs
@@ -102,10 +102,6 @@
                                      #(re-frame/dispatch
                                        [:web3/fetch-node-version-callback %])]}
          (protocol/initialize-protocol address)
-         #(when platform/desktop?
-            (let [logging-enabled (get-in db [:account/account :settings :logging-enabled])]
-              (log/debug "### user-login-callback .setLoggingEnabled" logging-enabled)
-              (.setLoggingEnabled rn-dependencies/desktop-config logging-enabled)))
          #(when-not platform/desktop?
             (initialize-wallet %)))
         (account-and-db-password-do-not-match cofx error)))))

--- a/src/status_im/log_level/core.cljs
+++ b/src/status_im/log_level/core.cljs
@@ -34,12 +34,10 @@
                           :on-cancel           nil}})
 
 (fx/defn save-logging-enabled
-  [{:keys [db now] :as cofx} enabled]
+  [{:keys [db] :as cofx}  enabled]
+  (.setValue rn-dependencies/desktop-config "logging_enabled" enabled)
   (let [settings (get-in db [:account/account :settings])]
-    (.setLoggingEnabled rn-dependencies/desktop-config enabled)
-    (accounts.update/update-settings cofx
-                                     (-> settings
-                                         (assoc :logging-enabled enabled)
-                                         (#(if enabled (assoc %1 :log-level "INFO") (dissoc %1 :log-level))))
+    (accounts.update/update-settings (assoc-in cofx [:db :desktop/desktop :logging-enabled] enabled)
+                                     (if enabled (assoc settings :log-level "INFO") (dissoc settings :log-level))
                                      {:success-event [:accounts.update.callback/save-settings-success]})))
 

--- a/src/status_im/ui/screens/desktop/main/tabs/profile/views.cljs
+++ b/src/status_im/ui/screens/desktop/main/tabs/profile/views.cljs
@@ -134,13 +134,10 @@
   (views/letsubs [logging-enabled [:settings/logging-enabled]]
     [react/view {:style (styles/profile-row false)}
      [react/text {:style (assoc (styles/profile-row-text colors/black)
-                                :font-size 14)} "Logging enabled?"]
-     (let [_ (log/debug "### logging-display" logging-enabled)]
-       [react/switch {:on-tint-color   colors/blue
-                      :value           logging-enabled
-                      :on-value-change #(do
-                                          (log/debug "### changelogging-enabled:" logging-enabled)
-                                          (re-frame/dispatch [:log-level.ui/logging-enabled (not logging-enabled)]))}])]))
+                                :font-size 14)} (i18n/label :t/logging-enabled)]
+     [react/switch {:on-tint-color   colors/blue
+                    :value           logging-enabled
+                    :on-value-change #(re-frame/dispatch [:log-level.ui/logging-enabled (not logging-enabled)])}]]))
 
 (views/defview advanced-settings []
   (views/letsubs [installations    [:pairing/installations]
@@ -180,7 +177,7 @@
          (installations-section installations))
 ;
        [react/view {:style styles/title-separator}]
-       [react/text {:style styles/adv-settings-subtitle} "Logging"]
+       [react/text {:style styles/adv-settings-subtitle} (i18n/label :t/logging)]
        [logging-display]])))
 
 (views/defview backup-recovery-phrase []

--- a/src/status_im/ui/screens/log_level_settings/subs.cljs
+++ b/src/status_im/ui/screens/log_level_settings/subs.cljs
@@ -11,4 +11,5 @@
 (re-frame/reg-sub
  :settings/logging-enabled
  (fn [db _]
-   (or (get-in db [:account/account :settings :logging-enabled]) false)))
+   (or (get-in db [:desktop/desktop :logging-enabled]) false)))
+

--- a/translations/en.json
+++ b/translations/en.json
@@ -564,6 +564,8 @@
     "transactions-sign-transaction": "Sign transaction",
     "wallet-backup-recovery-title": "Backup your recovery phrase",
     "change-log-level": "Change log level to {{log-level}}",
+    "logging": "Logging",
+    "logging-enabled": "Logging enabled?",
     "change-logging-enabled": "Are you sure you want to {{enable}} logging?",
     "enable": "enable",
     "disable": "disable",


### PR DESCRIPTION
Some app settings should be stored outside of Realm. This PR changes AppConfig class to use QSettings for logging-related settings storage. Other related settings can also be stored in a similar manner.

This allows to address a problem where logs are not being written yet because the `logging-enabled` hasn't been yet read from account data. Also, it might help with #7100 and #7140.

On macOS, relevant preferences file will be located under `~/Library/Preferences/im.status.StatusDesktop.plist`.

QA note: in order to circumvent macOS caching of plist files, run this command after deleting the plist file: `killall -u $USER cfprefsd`.

Fixes #7140 