### PR TITLE
Fix desktop release popup

### DIFF
--- a/src/status_im/accounts/core.cljs
+++ b/src/status_im/accounts/core.cljs
@@ -21,17 +21,6 @@
        (i18n/label :mainnet-is-default-alert-text)
        #(re-frame/dispatch [:accounts.ui/mainnet-warning-shown])))))
 
-(fx/defn show-desktop-alpha-release-warning [{:keys [db]}]
-  (let [enter-name-screen? (= :enter-name (get-in db [:accounts/create :step]))
-        shown? (get-in db [:account/account :desktop-alpha-release-warning-shown?])]
-    (when (and platform/desktop?
-               (not shown?)
-               (not enter-name-screen?))
-      (utils/show-popup
-       nil
-       (i18n/label :desktop-alpha-release-warning)
-       #(re-frame/dispatch [:accounts.ui/desktop-alpha-release-warning-shown])))))
-
 (defn- chat-send? [transaction]
   (and (seq transaction)
        (not (:in-progress? transaction))

--- a/src/status_im/accounts/create/core.cljs
+++ b/src/status_im/accounts/create/core.cljs
@@ -101,8 +101,7 @@
             {:db                                  (assoc db :accounts/create {:show-welcome? true})
              :notifications/request-notifications-permissions nil
              :dispatch                            [:navigate-to :home]}
-            (accounts.update/account-update {:name (:name create)} {})
-            (accounts.core/show-desktop-alpha-release-warning)))
+            (accounts.update/account-update {:name (:name create)} {})))
 
 (fx/defn next-step
   [{:keys [db] :as cofx} step password password-confirm]

--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -143,11 +143,6 @@
    (accounts.update/account-update cofx {:mainnet-warning-shown? true} {})))
 
 (handlers/register-handler-fx
- :accounts.ui/desktop-alpha-release-warning-shown
- (fn [cofx _]
-   (accounts.update/account-update cofx {:desktop-alpha-release-warning-shown? true} {})))
-
-(handlers/register-handler-fx
  :accounts.ui/dev-mode-switched
  (fn [cofx [_ dev-mode?]]
    (accounts/switch-dev-mode cofx dev-mode?)))

--- a/src/status_im/init/core.cljs
+++ b/src/status_im/init/core.cljs
@@ -198,8 +198,7 @@
             (universal-links/process-stored-event)
             (notifications/process-stored-event address)
             (when platform/desktop?
-              (chat-model/update-dock-badge-label))
-            (accounts.core/show-desktop-alpha-release-warning)))
+              (chat-model/update-dock-badge-label))))
 
 (defn dev-mode? [cofx]
   (get-in cofx [:db :account/account :dev-mode?]))

--- a/src/status_im/ui/screens/accounts/recover/styles.cljs
+++ b/src/status_im/ui/screens/accounts/recover/styles.cljs
@@ -28,6 +28,11 @@
    :font-size      13
    :color          colors/black})
 
+(def recover-release-warning
+  {:margin-top     16
+   :font-size      12
+   :color          colors/gray})
+
 (def recovery-phrase-input
   {:flex                1
    :text-align-vertical :top})

--- a/src/status_im/ui/screens/accounts/recover/views.cljs
+++ b/src/status_im/ui/screens/accounts/recover/views.cljs
@@ -13,7 +13,8 @@
             [status-im.utils.core :as utils.core]
             [status-im.react-native.js-dependencies :as js-dependencies]
             [status-im.ui.components.common.common :as components.common]
-            [status-im.utils.security :as security]))
+            [status-im.utils.security :as security]
+            [status-im.utils.platform :as platform]))
 
 (defview passphrase-input [passphrase error warning]
   (letsubs [input-ref (reagent/atom nil)]
@@ -61,7 +62,10 @@
        [components.common/separator]
        [react/view styles/inputs-container
         [passphrase-input (or passphrase "") passphrase-error passphrase-warning]
-        [password-input (or password "") password-error (when-not disabled? sign-in)]]
+        [password-input (or password "") password-error (when-not disabled? sign-in)]
+        (when platform/desktop?
+          [react/i18n-text {:style styles/recover-release-warning
+                            :key   :recover-account-warning}])]
        [react/view components.styles/flex]
        (if processing
          [react/view styles/processing-view

--- a/src/status_im/ui/screens/desktop/views.cljs
+++ b/src/status_im/ui/screens/desktop/views.cljs
@@ -10,12 +10,25 @@
             [status-im.ui.screens.accounts.create.views :as create.views]
             [status-im.ui.screens.accounts.login.views :as login.views]
             [status-im.ui.screens.accounts.recover.views :as recover.views]
-            [status-im.ui.screens.accounts.views :as accounts.views]))
+            [status-im.ui.screens.accounts.views :as accounts.views]
+            [status-im.utils.platform :as platform]
+            [status-im.i18n :as i18n]
+            [status-im.react-native.js-dependencies :as rn-dependencies]
+            [taoensso.timbre :as log]
+            [status-im.utils.utils :as utils]))
 
 (enable-console-print!)
 
 (views/defview main []
-  (views/letsubs [view-id [:get :view-id]]
+  (views/letsubs [view-id [:get :view-id]
+                  version [:get-app-version]]
+    {:component-did-mount
+     (fn []
+       (.getValue rn-dependencies/desktop-config "desktop-alpha-warning-shown-for-version"
+                  #(when-not (= %1 version)
+                     (.setValue rn-dependencies/desktop-config "desktop-alpha-warning-shown-for-version" version)
+                     (utils/show-popup nil (i18n/label :desktop-alpha-release-warning)))))}
+
     (let [component (case view-id
                       :intro intro.views/intro
                       :accounts accounts.views/accounts

--- a/translations/en.json
+++ b/translations/en.json
@@ -834,5 +834,6 @@
     "migrations-failed-content": "{{message}}\nschema version: initial {{initial-version}}, current {{current-version}}, last {{last-version}}\n\nPlease let us know about this problem at #status public chat. If you press \"Cancel\" button, nothing will happen. If you press \"{{erase-accounts-data-button-text}}\" button, account's db will be removed and you will be able to unlock account. All account's data will be lost.",
     "migrations-erase-accounts-data-button": "Erase account's db",
     "account-and-db-password-mismatch-title": "The problem occurred!",
-    "account-and-db-password-mismatch-content": "Account's and realm db passwords do not match."
+    "account-and-db-password-mismatch-content": "Account's and realm db passwords do not match.",
+    "recover-account-warning": "Your wallet information will be exposed by importing this account."
 }


### PR DESCRIPTION
Paritally fixes #7100

### Summary:
Warning message shown at first app launch, not after user logged in.
Added clarifying text to recover page


#### Platforms (optional)
- macOS
- Linux
- Windows

<!-- (Specify if some specific areas has to be tested, for example 1-1 chats) -->
#### Areas that maybe impacted (optional)
**Functional**
- account recovery
- new account

<!-- (Specify exact steps to test if there are such) -->
### Steps to test:
- Open Status
- Check that release warning message appeared
- Open recovery page, check that additional text present
- Close Status
- Open Status again and ensure warning message not shown

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready
