### PR TITLE
Add desktop chunks hack

### DIFF
--- a/src/status_im/ui/screens/chat/utils.cljs
+++ b/src/status_im/ui/screens/chat/utils.cljs
@@ -3,6 +3,7 @@
             [status-im.utils.gfycat.core :as gfycat]
             [status-im.utils.platform :as platform]
             [status-im.i18n :as i18n]
+            [status-im.constants :as constants]
             [status-im.ui.components.react :as react]
             [status-im.ui.components.colors :as colors]
             [status-im.utils.http :as http]))
@@ -49,3 +50,19 @@
                    [react/text (into {:key idx} (lookup-props text-chunk message kind))
                     text-chunk]))
                render-recipe))
+
+(defn render-chunks-desktop [render-recipe message]
+  "This fn is only need as a temporary hack
+   until rn-desktop supports text/number-of-lines property"
+  (seq (second
+        (reduce (fn [[total-length acc] [idx [text-chunk kind]]]
+                  (if (< constants/chars-collapse-threshold total-length)
+                    (reduced [total-length acc])
+                    [(+ total-length (count text-chunk))
+                     (conj acc
+                           (if (= :text kind)
+                             text-chunk
+                             [react/text (into {:key idx} (lookup-props text-chunk message kind))
+                              text-chunk]))]))
+                [0 []]
+                (map vector (range) render-recipe)))))

--- a/src/status_im/ui/screens/desktop/main/chat/views.cljs
+++ b/src/status_im/ui/screens/desktop/main/chat/views.cljs
@@ -119,7 +119,13 @@
        [react/text {:style           (styles/message-text collapsible? false)
                     :selectable      true
                     :selection-color colors/blue-light}
-        message-text]
+        (if-let [render-recipe (:render-recipe content)]
+          (apply
+           (if (and collapsible? (not expanded?))
+             chat-utils/render-chunks-desktop
+             chat-utils/render-chunks)
+           render-recipe message-text)
+          message-text)]
        (when collapsible?
          [message/expand-button expanded? chat-id message-id])])]])
 


### PR DESCRIPTION
I was dumb and deleted a render-recipes logic for Desktop msg rendering in https://github.com/status-im/status-react/pull/7152. However, it takes care of link rendering, among other things. While rn-desktop does not support number-of-lines property yet, this hack is added to properly cut off long messages that have URLs in them.