### PR TITLE
fix success value of build objects sent to ghcmgr

### DIFF
--- a/ci/common.groovy
+++ b/ci/common.groovy
@@ -160,7 +160,7 @@ def ghcmgrBuildObj(success) {
   return [
     id: env.BUILD_DISPLAY_NAME,
     commit: GIT_COMMIT.take(8),
-    success: success ? success : true,
+    success: success != null ? success : true,
     platform: env.BUILD_PLATFORM + (getBuildType() == 'e2e' ? '-e2e' : ''),
     duration: buildDuration(),
     url: currentBuild.absoluteUrl,


### PR DESCRIPTION
Right now we always say `true` for `success` because of this bug.

Right all builds show up as successful.