### PR TITLE
[don't merge to develop]Changed build number to "release"

### DIFF
--- a/src/status_im/ui/screens/desktop/main/tabs/profile/views.cljs
+++ b/src/status_im/ui/screens/desktop/main/tabs/profile/views.cljs
@@ -249,7 +249,7 @@
         [react/view {:style (styles/profile-row false)}
          [react/touchable-highlight {:on-press #(re-frame/dispatch [:accounts.logout.ui/logout-confirmed])}
           [react/text {:style (styles/profile-row-text colors/red)} (i18n/label :t/logout)]]
-         [react/view [react/text {:style (styles/profile-row-text colors/gray)} "V" build/version " (" build/commit-sha ")"]]]]])))
+         [react/view [react/text {:style (styles/profile-row-text colors/gray)} "V" build/version " (" "release" ")"]]]]])))
 
 (views/defview profile-data []
   (views/letsubs


### PR DESCRIPTION
Temporarily overcomes #7159

### Summary:
Only for release branch we changing release version info to avoid issue #7159

#### Platforms (optional)
- macOS
- Linux
- Windows

<!-- (Specify if some specific areas has to be tested, for example 1-1 chats) -->
#### Areas that maybe impacted (optional)
**Functional**
- user profile updates
- networks


<!-- (Specify exact steps to test if there are such) -->
### Steps to test:
- Open Status
- Open settings
- Check that "release" said instead of hash in a version number

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready 
