### PR TITLE
Simplify Linux bundle building

### DIFF
--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -49,6 +49,7 @@ pipeline {
     LEIN_HOME = '/var/tmp/lein'
     QT_PATH = '/opt/qt'
     STATUSIM_APPIMAGE_DIR = '/opt/desktop-files'
+    VERBOSE_LEVEL = '3'
   }
 
   stages {

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -31,6 +31,7 @@ pipeline {
     QT_PATH = '/usr/local/opt/qt'
     PATH = "/usr/local/opt/qt/bin:${env.PATH}"
     MACDEPLOYQT = '/usr/local/opt/qt/bin/macdeployqt'
+    VERBOSE_LEVEL = '3'
   }
 
   stages {

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -52,6 +52,7 @@ pipeline {
     CONAN_SYSREQUIRES_MODE = 'disabled'
     CONAN_SYSREQUIRES_SUDO = '0'
     STATUSIM_WINDOWS_BASEIMAGE_ZIP = '/opt/StatusIm-Windows-base-image.zip'
+    VERBOSE_LEVEL = '3'
   }
 
   stages {

--- a/desktop/main.cpp
+++ b/desktop/main.cpp
@@ -208,8 +208,7 @@ QString getDataStoragePath() {
   QString dataStoragePath;
   if (!statusDataDir.isEmpty()) {
     dataStoragePath = statusDataDir;
-  }
-  else {
+  } else {
     dataStoragePath = QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation);
   }
   QDir dir(dataStoragePath);


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

### Summary:

After examining the [source code](https://github.com/probonopd/linuxdeployqt/blob/master/tools/linuxdeployqt/main.cpp) for `linuxdeployqt`, I realized that our usage is a bit naive and can be simplified. This PR reduces the number of calls to `linuxdeployqt` from 3 to a single call in the bundle phase of the Linux build, making bundling faster (prev: 5m30s, now: 2m30s) and easier to reason about.

I confirmed that the bundle contents are the same before and after, so no QA is needed. The only exception is that we now really don't include the Qt translations, as the stated intention in the script:

![image](https://user-images.githubusercontent.com/138074/50349252-7f644d80-053b-11e9-9c16-0318193a224b.png)

status: ready <!-- Can be ready or wip -->
