### PR TITLE
Safe deserialization of the last message's content

### DIFF
--- a/src/status_im/data_store/chats.cljs
+++ b/src/status_im/data_store/chats.cljs
@@ -55,7 +55,7 @@
       (update :membership-updates  (partial unmarshal-membership-updates chat-id))
       (update :last-clock-value utils.clocks/safe-timestamp)
       (update :last-message-type keyword)
-      (update :last-message-content edn/read-string)))
+      (update :last-message-content utils/safe-read-message-content)))
 
 (re-frame/reg-cofx
  :data-store/all-chats

--- a/src/status_im/data_store/messages.cljs
+++ b/src/status_im/data_store/messages.cljs
@@ -1,19 +1,15 @@
 (ns status-im.data-store.messages
-  (:require [cljs.tools.reader.edn :as edn]
-            [taoensso.timbre :as log]
-            [re-frame.core :as re-frame]
+  (:require [re-frame.core :as re-frame]
             [status-im.constants :as constants]
             [status-im.data-store.realm.core :as core]
             [status-im.utils.core :as utils]
             [status-im.js-dependencies :as dependencies]))
 
-(defn- transform-message [message]
-  (try
+(defn- transform-message [{:keys [content] :as message}]
+  (when-let [parsed-content (utils/safe-read-message-content content)]
     (-> message
         (update :message-type keyword)
-        (update :content edn/read-string))
-    (catch :default e
-      (log/warn "failed to transform message with " e))))
+        (assoc :content parsed-content))))
 
 (defn- get-by-chat-id
   ([chat-id]

--- a/src/status_im/utils/core.cljc
+++ b/src/status_im/utils/core.cljc
@@ -1,5 +1,7 @@
 (ns status-im.utils.core
-  (:require [clojure.string :as str]))
+  (:require [clojure.string :as str]
+            [cljs.tools.reader.edn :as edn]
+            [taoensso.timbre :as log]))
 
 (defn truncate-str
   "Given string and max threshold, trims the string to threshold length with `...`
@@ -63,3 +65,9 @@
   Similar to group-by except that the map values are single objects (depends on key uniqueness)."
   [key coll]
   (into {} (map #(vector (key %) %) coll)))
+
+(defn safe-read-message-content [content]
+  (try
+    (edn/read-string content)
+    (catch :default e
+      (log/warn "failed to transform message with " e))))


### PR DESCRIPTION
The issue was fixed in #7085 but reintroduced in #7055.

status: ready <!-- Can be ready or wip -->
