### PR TITLE
Fix connection stats display

### DIFF
--- a/src/status_im/ui/screens/desktop/main/tabs/profile/views.cljs
+++ b/src/status_im/ui/screens/desktop/main/tabs/profile/views.cljs
@@ -115,9 +115,9 @@
     [react/text {:style styles/connection-stats-title}
      "Mailserver requests"]
     [react/text {:style styles/connection-stats-entry}
-     (str "errors " p2p-inbound-traffic)]
+     (str "errors " mailserver-request-errors)]
     [react/text {:style styles/connection-stats-entry}
-     (str "process time " p2p-outbound-traffic)]]
+     (str "process time " mailserver-request-process-time)]]
    [react/view
     [react/text {:style styles/connection-stats-title}
      "p2p traffic"]


### PR DESCRIPTION
Note: for some reason values in Mailserver and LES columns are zero, but that's what we get from status-go side.

Mailserver data set:
```
{:requestValidationErrors {:Overall 0}, :archivedEnvelopes {:AvgRate01Min 0, :AvgRate05Min 0, :AvgRate15Min 0, :MeanRate 0, :Overall 0
}, :archivedEnvelopesSize {:AvgRate01Min 0, :AvgRate05Min 0, :AvgRate15Min 0, :MeanRate 0, :Overall 0}, :sentEnvelopes {:AvgRate01Min 0, :AvgRate05Min 0, :AvgRate15Min 0, :MeanRate 0, :Overall 0}, :reques
tProcessNetTime {:AvgRate01Min 0, :AvgRate05Min 0, :AvgRate15Min 0, :MeanRate 0, :Overall 0, :Percentiles {:5 0, :20 0, :50 0, :80 0, :95 0}}, :requests {:AvgRate01Min 0, :AvgRate05Min 0, :AvgRate15Min 0,
 :MeanRate 0, :Overall 0}, :syncRequests {:AvgRate01Min 0, :AvgRate05Min 0, :AvgRate15Min 0, :MeanRate 0, :Overall 0}, :requestsBatched {:Overall 0}, :processRequestErrors {:Overall 0}, :requestProcessTim
e {:AvgRate01Min 0, :AvgRate05Min 0, :AvgRate15Min 0, :MeanRate 0, :Overall 0, :Percentiles {:5 0, :20 0, :50 0, :80 0, :95 0}}, :historicResponseErrors {:Overall 0}, :sentEnvelopesSize {:AvgRate01Min 0,
:AvgRate05Min 0, :AvgRate15Min 0, :MeanRate 0, :Overall 0}, :requestErrors {:Overall 0}, :archiveErrors {:Overall 0}}
```

LES data set:
```
{:misc {:in {:packets {:AvgRate01Min 0, :AvgRate05Min 0, :AvgRate15Min 0, :MeanRate 0, :Overall 0}, :traffic {:AvgRate01Min 0, :AvgRate05Min 0, :AvgRate15Min 0, :MeanRate 0, :Overall 0}}, :out {:packets {:AvgRate01Min 0, :AvgRate05Min 0, :AvgRate15Min 0, :MeanRate 0, :Overall 0}, :traffic {:AvgRate01Min 0, :AvgRate05Min 0, :AvgRate15Min 0, :MeanRate 0, :Overall 0}}}}
```