### PR TITLE
[#7179] Fix command message preview in the list of chats

### DIFF
--- a/src/status_im/chat/models.cljs
+++ b/src/status_im/chat/models.cljs
@@ -100,12 +100,12 @@
                                      deleted-at-clock-value
                                      (utils.clocks/send 0))]
     {:db            (update-in db [:chats chat-id] merge
-                               {:messages                empty-message-map
-                                :message-groups          {}
-                                :last-message-content    nil
-                                :last-message-type       nil
-                                :unviewed-messages-count 0
-                                :deleted-at-clock-value  last-message-clock-value})
+                               {:messages                  empty-message-map
+                                :message-groups            {}
+                                :last-message-content      nil
+                                :last-message-content-type nil
+                                :unviewed-messages-count   0
+                                :deleted-at-clock-value    last-message-clock-value})
      :data-store/tx [(chats-store/clear-history-tx chat-id last-message-clock-value)
                      (messages-store/delete-messages-tx chat-id)]}))
 

--- a/src/status_im/chat/models/message.cljs
+++ b/src/status_im/chat/models/message.cljs
@@ -276,7 +276,7 @@
 (defn- update-last-message [all-chats chat-id]
   (let [{:keys [messages message-groups]}
         (get all-chats chat-id)
-        {:keys [content message-type clock-value]}
+        {:keys [content content-type clock-value]}
         (->> (chat.db/sort-message-groups message-groups messages)
              first
              second
@@ -284,10 +284,10 @@
              :message-id
              (get messages))]
     (chat-model/upsert-chat
-     {:chat-id              chat-id
-      :last-message-content content
-      :last-message-type    message-type
-      :last-clock-value     clock-value})))
+     {:chat-id                   chat-id
+      :last-message-content      content
+      :last-message-content-type content-type
+      :last-clock-value          clock-value})))
 
 (fx/defn update-last-messages
   [{:keys [db] :as cofx} chat-ids]
@@ -377,11 +377,11 @@
 
     (fx/merge cofx
               (chat-model/upsert-chat
-               {:chat-id              chat-id
-                :timestamp            now
-                :last-message-content (:content message)
-                :last-message-type    (:message-type message)
-                :last-clock-value     (:clock-value message)})
+               {:chat-id                   chat-id
+                :timestamp                 now
+                :last-message-content      (:content message)
+                :last-message-content-type (:content-type message)
+                :last-clock-value          (:clock-value message)})
               (add-message {:batch?           false
                             :message          message-with-id
                             :current-chat?    true

--- a/src/status_im/data_store/chats.cljs
+++ b/src/status_im/data_store/chats.cljs
@@ -54,7 +54,6 @@
       (update :tags #(into #{} %))
       (update :membership-updates  (partial unmarshal-membership-updates chat-id))
       (update :last-clock-value utils.clocks/safe-timestamp)
-      (update :last-message-type keyword)
       (update :last-message-content utils/safe-read-message-content)))
 
 (re-frame/reg-cofx
@@ -95,7 +94,7 @@
     (let [chat (get-chat-by-id chat-id realm)]
       (doto chat
         (aset "last-message-content" nil)
-        (aset "last-message-type" nil)
+        (aset "last-message-content-type" nil)
         (aset "deleted-at-clock-value" deleted-at-clock-value)))))
 
 (defn deactivate-chat-tx

--- a/src/status_im/data_store/realm/schemas/account/chat.cljs
+++ b/src/status_im/data_store/realm/schemas/account/chat.cljs
@@ -235,3 +235,11 @@
   (update v10 :properties merge
           {:last-clock-value {:type     :int
                               :optional true}}))
+
+(def v12
+  (-> v11
+      (update :properties merge
+              {:last-message-content-type
+               {:type     :string
+                :optional true}})
+      (update :properties dissoc :last-message-type)))

--- a/src/status_im/data_store/realm/schemas/account/core.cljs
+++ b/src/status_im/data_store/realm/schemas/account/core.cljs
@@ -317,6 +317,19 @@
           browser/v8
           dapp-permissions/v9])
 
+(def v30 [chat/v12
+          transport/v7
+          contact/v3
+          message/v9
+          mailserver/v11
+          mailserver-topic/v1
+          user-status/v2
+          membership-update/v1
+          installation/v2
+          local-storage/v1
+          browser/v8
+          dapp-permissions/v9])
+
 ;; put schemas ordered by version
 (def schemas [{:schema        v1
                :schemaVersion 1
@@ -404,4 +417,7 @@
                :migration     migrations/v28}
               {:schema        v29
                :schemaVersion 29
-               :migration     migrations/v29}])
+               :migration     migrations/v29}
+              {:schema        v30
+               :schemaVersion 30
+               :migration     migrations/v30}])

--- a/src/status_im/data_store/realm/schemas/account/migrations.cljs
+++ b/src/status_im/data_store/realm/schemas/account/migrations.cljs
@@ -307,16 +307,7 @@
    (.sorted "timestamp" true)
    (aget 0)))
 
-(defn v28 [old-realm new-realm]
-  (let [chats (.objects new-realm "chat")]
-    (dotimes [i (.-length chats)]
-      (let [chat (aget chats i)
-            chat-id (aget chat "chat-id")]
-        (when-let [last-message (get-last-message new-realm chat-id)]
-          (let [content (aget last-message "content")
-                message-type (aget last-message "message-type")]
-            (aset chat "last-message-content" content)
-            (aset chat "last-message-type" message-type)))))))
+(defn v28 [old-realm new-realm])
 
 (defn get-last-clock-value [realm chat-id]
   (if-let [last-message
@@ -337,3 +328,14 @@
             chat-id (aget chat "chat-id")]
         (when-let [last-clock-value (get-last-clock-value new-realm chat-id)]
           (aset chat "last-clock-value" last-clock-value))))))
+
+(defn v30 [old-realm new-realm]
+  (let [chats (.objects new-realm "chat")]
+    (dotimes [i (.-length chats)]
+      (let [chat (aget chats i)
+            chat-id (aget chat "chat-id")]
+        (when-let [last-message (get-last-message new-realm chat-id)]
+          (let [content (aget last-message "content")
+                content-type (aget last-message "content-type")]
+            (aset chat "last-message-content" content)
+            (aset chat "last-message-content-type" content-type)))))))

--- a/src/status_im/ui/screens/desktop/main/tabs/home/views.cljs
+++ b/src/status_im/ui/screens/desktop/main/tabs/home/views.cljs
@@ -23,7 +23,7 @@
                                                   color public? public-key
                                                   timestamp
                                                   last-message-content
-                                                  last-message-type]
+                                                  last-message-content-type]
                                            :as chat-item}]
   (views/letsubs [photo-path              [:contacts/chat-photo chat-id]
                   unviewed-messages-count [:chats/unviewed-messages-count chat-id]
@@ -31,7 +31,7 @@
                   current-chat-id         [:chats/current-chat-id]]
     (let [last-message {:content      last-message-content
                         :timestamp    timestamp
-                        :message-type last-message-type}
+                        :content-type last-message-content-type}
           name (or chat-name
                    (gfycat/generate-gfy public-key))
           [unviewed-messages-label large?] [(utils/unread-messages-count unviewed-messages-count) true]

--- a/src/status_im/ui/screens/home/views/inner_item.cljs
+++ b/src/status_im/ui/screens/home/views/inner_item.cljs
@@ -90,7 +90,7 @@
                                                  public-key
                                                  timestamp
                                                  last-message-content
-                                                 last-message-type]}]
+                                                 last-message-content-type]}]
   (letsubs [chat-name    [:chats/chat-name chat-id]]
     (let [truncated-chat-name (utils/truncate-str chat-name 30)]
       [react/touchable-highlight {:on-press #(re-frame/dispatch [:chat.ui/navigate-to-chat chat-id])}
@@ -104,7 +104,7 @@
            [message-timestamp timestamp]]]
          [react/view styles/item-lower-container
           [message-content-text {:content      last-message-content
-                                 :content-type last-message-type}]
+                                 :content-type last-message-content-type}]
           [unviewed-indicator chat-id]]]]])))
 
 (defn home-list-browser-item-inner-view [{:keys [dapp url name browser-id] :as browser}]

--- a/test/cljs/status_im/test/data_store/chats.cljs
+++ b/test/cljs/status_im/test/data_store/chats.cljs
@@ -5,17 +5,15 @@
 
 (deftest normalize-chat-test
   (testing "admins & contacts"
-    (is (= {:admins               #{4}
-            :contacts             #{2}
-            :tags                 #{}
-            :membership-updates   []
-            :last-message-type    :message-type
-            :last-message-content {:foo "bar"}
-            :last-clock-value     nil}
+    (is (= {:admins                    #{4}
+            :contacts                  #{2}
+            :tags                      #{}
+            :membership-updates        []
+            :last-message-content      {:foo "bar"}
+            :last-clock-value          nil}
            (chats/normalize-chat
-            {:admins               [4]
-             :contacts             [2]
-             :last-message-type    "message-type"
+            {:admins                    [4]
+             :contacts                  [2]
              :last-message-content "{:foo \"bar\"}"}))))
   (testing "membership-updates"
     (let [raw-events {"1" {:id "1" :type "members-added" :clock-value 10 :members [1 2] :signature "a" :from "id-1"}


### PR DESCRIPTION
fix #7179 

The bug was introduced in #7055.

`message-type` was stored and used instead of `content-type` which
caused incorrect displaying of the last message preview if the one was a
command.

status: ready 
