### PR TITLE
[#7189] Proper handling of restoring existing account with wrong password

### DIFF
--- a/src/status_im/accounts/recover/core.cljs
+++ b/src/status_im/accounts/recover/core.cljs
@@ -71,15 +71,21 @@
                    :address    address
                    :photo-path (identicon/identicon pubkey)
                    :mnemonic   ""}]
-      (accounts.create/on-account-created cofx account password {:seed-backed-up? true}))
-    {:db (assoc-in db [:accounts/recover :password-error] :recover-password-invalid)}))
+      (accounts.create/on-account-created
+       cofx account password {:seed-backed-up? true}))
+    {:db        (-> db
+                    (update :accounts/recover assoc
+                            :processing? false
+                            :password ""
+                            :password-error :recover-password-invalid)
+                    (update :accounts/recover dissoc
+                            :password-valid?))
+     :node/stop nil}))
 
 (fx/defn on-account-recovered
-  [{:keys [db] :as cofx} result password]
+  [cofx result password]
   (let [data (types/json->clj result)]
-    (fx/merge cofx
-              {:db (dissoc db :accounts/recover)}
-              (validate-recover-result data password))))
+    (validate-recover-result cofx data password)))
 
 (fx/defn recover-account
   [{:keys [db random-guid-generator] :as cofx}]

--- a/src/status_im/ui/screens/accounts/recover/views.cljs
+++ b/src/status_im/ui/screens/accounts/recover/views.cljs
@@ -1,5 +1,6 @@
 (ns status-im.ui.screens.accounts.recover.views
-  (:require-macros [status-im.utils.views :refer [defview letsubs]])
+  (:require-macros [status-im.utils.views :refer [defview letsubs]
+                    :as views])
   (:require [re-frame.core :as re-frame]
             [reagent.core :as reagent]
             [status-im.ui.components.text-input.view :as text-input]
@@ -14,7 +15,8 @@
             [status-im.react-native.js-dependencies :as js-dependencies]
             [status-im.ui.components.common.common :as components.common]
             [status-im.utils.security :as security]
-            [status-im.utils.platform :as platform]))
+            [status-im.utils.platform :as platform]
+            [clojure.string :as string]))
 
 (defview passphrase-input [passphrase error warning]
   (letsubs [input-ref (reagent/atom nil)]
@@ -34,26 +36,40 @@
                                  warning (i18n/label warning))}]))
 
 (defview password-input [password error on-submit-editing]
-  [react/view {:style                       styles/password-input
-               :important-for-accessibility :no-hide-descendants}
-   [text-input/text-input-with-label
-    {:label             (i18n/label :t/password)
-     :accessibility-label :enter-password
-     :placeholder       (i18n/label :t/enter-password)
-     :default-value     password
-     :auto-focus        false
-     :on-change-text    #(re-frame/dispatch [:accounts.recover.ui/password-input-changed (security/mask-data %)])
-     :on-blur           #(re-frame/dispatch [:accounts.recover.ui/password-input-blured])
-     :secure-text-entry true
-     :error             (when error (i18n/label error))
-     :on-submit-editing on-submit-editing}]])
+  (views/letsubs [inp-ref (atom nil)]
+    {:component-will-update
+     (fn [_ [_ new-password]]
+       (when (and (string? new-password)
+                  (string/blank? new-password)
+                  @inp-ref)
+         (.clear @inp-ref)))}
+    [react/view {:style                       styles/password-input
+                 :important-for-accessibility :no-hide-descendants}
+     [text-input/text-input-with-label
+      {:label               (i18n/label :t/password)
+       :accessibility-label :enter-password
+       :placeholder         (i18n/label :t/enter-password)
+       :default-value       password
+       :auto-focus          false
+       :on-change-text      #(re-frame/dispatch [:accounts.recover.ui/password-input-changed (security/mask-data %)])
+       :on-blur             #(re-frame/dispatch [:accounts.recover.ui/password-input-blured])
+       :secure-text-entry   true
+       :error               (when error (i18n/label error))
+       :on-submit-editing   on-submit-editing
+       :ref                 #(reset! inp-ref %)}]]))
 
 (defview recover []
-  (letsubs [recovered-account [:get-recover-account]]
-    (let [{:keys [passphrase password processing passphrase-valid? password-valid?
+  (letsubs [recovered-account [:get-recover-account]
+            node-status? [:get :node/status]]
+    (let [{:keys [passphrase password passphrase-valid? password-valid?
                   password-error passphrase-error passphrase-warning processing?]} recovered-account
+          node-stopped? (or (nil? node-status?)
+                            (= :stopped node-status?))
           valid-form? (and password-valid? passphrase-valid?)
-          disabled?   (or (not recovered-account) processing? (not valid-form?))
+          disabled?   (or (not recovered-account)
+                          processing?
+                          (not valid-form?)
+                          (not node-stopped?))
           sign-in     #(re-frame/dispatch [:accounts.recover.ui/sign-in-button-pressed])]
       [react/keyboard-avoiding-view {:style styles/screen-container}
        [status-bar/status-bar]
@@ -67,7 +83,7 @@
           [react/i18n-text {:style styles/recover-release-warning
                             :key   :recover-account-warning}])]
        [react/view components.styles/flex]
-       (if processing
+       (if processing?
          [react/view styles/processing-view
           [react/activity-indicator {:animating true}]
           [react/i18n-text {:style styles/sign-you-in


### PR DESCRIPTION
fix #7189 

On restoring existing password with a wrong password:
- the password is cleared from the input
- the node is stopped
- the user can proceed with another attempt or log into another account

Besides that activity indicator wasn't working during restoring, that's fixed now.

status: ready
