### PR TITLE
[slow sign in] chats preloading

### DIFF
--- a/src/status_im/data_store/chats.cljs
+++ b/src/status_im/data_store/chats.cljs
@@ -60,11 +60,14 @@
 (re-frame/reg-cofx
  :data-store/all-chats
  (fn [cofx _]
-   (assoc cofx :all-stored-chats (map normalize-chat
-                                      (-> @core/account-realm
-                                          (core/get-all :chat)
-                                          (core/sorted :timestamp :desc)
-                                          (core/all-clj :chat))))))
+   (assoc cofx :get-all-stored-chats
+          (fn [from to]
+            (map normalize-chat
+                 (-> @core/account-realm
+                     (core/get-all :chat)
+                     (core/sorted :timestamp :desc)
+                     (core/page from to)
+                     (core/all-clj :chat)))))))
 
 (defn save-chat-tx
   "Returns tx function for saving chat"

--- a/src/status_im/data_store/realm/core.cljs
+++ b/src/status_im/data_store/realm/core.cljs
@@ -311,7 +311,7 @@
   (.sorted results (clj->js fields)))
 
 (defn page [results from to]
-  (js/Array.prototype.slice.call results from to))
+  (js/Array.prototype.slice.call results from (or to -1)))
 
 (defn filtered [results filter-query]
   (.filtered results filter-query))

--- a/src/status_im/transport/core.cljs
+++ b/src/status_im/transport/core.cljs
@@ -18,7 +18,6 @@
   - restoring existing symetric keys along with their unique filters
   - (optionally) initializing mailserver"
   [{:keys [db web3] :as cofx}]
-  (log/debug :init-whisper)
   (when-let [public-key (get-in db [:account/account :public-key])]
     (let [public-key-topics (keep (fn [[chat-id {:keys [topic sym-key]}]]
                                     (when (and (not sym-key)

--- a/src/status_im/transport/filters.cljs
+++ b/src/status_im/transport/filters.cljs
@@ -85,7 +85,6 @@
 (handlers/register-handler-fx
  :shh.callback/filter-added
  (fn [{:keys [db] :as cofx} [_ topic chat-id filter]]
-   (log/debug "PERF" :shh.callback/filter-added)
    (fx/merge cofx
              {:db (assoc-in db [:transport/filters chat-id] filter)}
              (mailserver/reset-request-to)

--- a/src/status_im/ui/screens/desktop/main/tabs/home/views.cljs
+++ b/src/status_im/ui/screens/desktop/main/tabs/home/views.cljs
@@ -147,7 +147,7 @@
      (fn [this]
        (let [[_ loading?] (.. this -props -argv)]
          (when loading?
-           (re-frame/dispatch [:init-chats]))))}
+           (re-frame/dispatch [:init-rest-of-chats]))))}
     [react/view {:style styles/chat-list-view}
      [react/view {:style styles/chat-list-header}
       [search-input search-filter]
@@ -155,16 +155,11 @@
        [react/touchable-highlight {:on-press #(re-frame/dispatch [:set-in [:desktop :popup] popup])}
         [react/view {:style styles/add-new}
          [icons/icon :icons/add {:style {:tint-color :white}}]]]]]
-     (if loading?
-       [react/view {:style {:flex            1
-                            :justify-content :center
-                            :align-items     :center}}
-        [components/activity-indicator {:animating true}]]
-       [react/scroll-view {:enableArrayScrollingOptimization true}
-        [react/view
-         (for [[index chat] (map-indexed vector filtered-home-items)]
-           ^{:key (first chat)}
-           [chat-list-item chat])]])]))
+     [react/scroll-view {:enableArrayScrollingOptimization true}
+      [react/view
+       (for [[index chat] (map-indexed vector filtered-home-items)]
+         ^{:key (first chat)}
+         [chat-list-item chat])]]]))
 
 (views/defview chat-list-view-wrapper []
   (views/letsubs [loading? [:get :chats/loading?]]

--- a/src/status_im/ui/screens/home/views.cljs
+++ b/src/status_im/ui/screens/home/views.cljs
@@ -99,17 +99,12 @@
        (let [[_ loading?] (.. this -props -argv)]
          (when loading?
            (utils/set-timeout
-            #(re-frame/dispatch [:init-chats])
+            #(re-frame/dispatch [:init-rest-of-chats])
             100))))}
     [react/view styles/container
      [toolbar show-welcome? (and network-initialized? (not rpc-network?)) sync-state latest-block-number]
      (cond show-welcome?
            [welcome view-id]
-           loading?
-           [react/view {:style {:flex            1
-                                :justify-content :center
-                                :align-items     :center}}
-            [components/activity-indicator {:animating true}]]
            :else
            [chats-list])
      (when platform/android?


### PR DESCRIPTION
10 last chats are loaded to `app-db` before showing `:home` screen, in
result a user will not see two consequent activity indicators. In this
case opening of `:home` screen is a bit slower but looks better from
UI/UX pov. As it is limited to 10 chats on initialization, the time
necessary for opening `:home` screen will not depend on a total number
of chats in `app-db` if an account contains 10+ chats.

status: ready <!-- Can be ready or wip -->
