### PR TITLE
Fix `scripts/start-react-native.sh` so it can handle killing multiple processes listening on port 8081

### DIFF
--- a/scripts/start-react-native.sh
+++ b/scripts/start-react-native.sh
@@ -6,11 +6,11 @@ YELLOW='\033[1;33m'
 NC='\033[0m'
 
 METRO_PORT=8081
-METRO_PID="$(lsof -i :${METRO_PORT} | awk 'NR!=1 {print $2}')"
-if [ ! -z $METRO_PID ]; then
-  echo -e "${YELLOW}TCP port ${METRO_PORT} is required by the Metro packager.\nThe following process currently has the port open, preventing Metro from starting:${NC}"
+METRO_PID="$(lsof -i :${METRO_PORT} | awk 'NR!=1 {print $2}' | sort -u | tr '\r\n' ' ')"
+if [ ! -z "$METRO_PID" ]; then
+  echo -e "${YELLOW}TCP port ${METRO_PORT} is required by the Metro packager.\nThe following processes currently have the port open, preventing Metro from starting:${NC}"
   ps -fp $METRO_PID
-  echo -e "${YELLOW}Do you want to terminate it (y/n)?${NC}"
+  echo -e "${YELLOW}Do you want to terminate them (y/n)?${NC}"
   read -n 1 term
   [[ $term == 'y' ]] && kill $METRO_PID
 fi


### PR DESCRIPTION
status: ready <!-- Can be ready or wip -->
