### PR TITLE
move gh notification to post, add check for CHANGE_ID

### DIFF
--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -92,11 +92,6 @@ pipeline {
         }
       }
     }
-    stage('Notify') {
-      steps {
-        script { cmn.notifyPRSuccess() }
-      }
-    }
     stage('Cleanup') {
       steps {
         script { cmn.clean() }
@@ -105,5 +100,6 @@ pipeline {
   }
   post {
     failure { script { load('ci/common.groovy').notifyPRFailure() } }
+    success { script { load('ci/common.groovy').notifyPRSuccess() } }
   }
 }

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -86,11 +86,6 @@ pipeline {
         }
       }
     }
-    stage('Notify') {
-      steps {
-        script { cmn.notifyPRSuccess() }
-      }
-    }
     stage('Cleanup') {
       steps {
         script { cmn.clean() }
@@ -99,5 +94,6 @@ pipeline {
   }
   post {
     failure { script { load('ci/common.groovy').notifyPRFailure() } }
+    success { script { load('ci/common.groovy').notifyPRSuccess() } }
   }
 }

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -99,11 +99,6 @@ pipeline {
         script { env.PKG_URL = cmn.uploadArtifact(app) }
       }
     }
-    stage('Notify') {
-      steps {
-        script { cmn.notifyPRSuccess() }
-      }
-    }
     stage('Cleanup') {
       steps {
         script { cmn.clean() }
@@ -112,5 +107,6 @@ pipeline {
   }
   post {
     failure { script { load('ci/common.groovy').notifyPRFailure() } }
+    success { script { load('ci/common.groovy').notifyPRSuccess() } }
   }
 }

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -80,11 +80,6 @@ pipeline {
         script { env.PKG_URL = cmn.uploadArtifact(dmg) }
       }
     }
-    stage('Notify') {
-      steps {
-        script { cmn.notifyPRSuccess() }
-      }
-    }
     stage('Cleanup') {
       steps {
         script { cmn.clean() }
@@ -93,5 +88,6 @@ pipeline {
   }
   post {
     failure { script { load('ci/common.groovy').notifyPRFailure() } }
+    success { script { load('ci/common.groovy').notifyPRSuccess() } }
   }
 }

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -102,11 +102,6 @@ pipeline {
         script { env.PKG_URL = cmn.uploadArtifact(app) }
       }
     }
-    stage('Notify') {
-      steps {
-        script { cmn.notifyPRSuccess() }
-      }
-    }
     stage('Cleanup') {
       steps {
         script { cmn.clean() }
@@ -115,5 +110,6 @@ pipeline {
   }
   post {
     failure { script { load('ci/common.groovy').notifyPRFailure() } }
+    success { script { load('ci/common.groovy').notifyPRSuccess() } }
   }
 }


### PR DESCRIPTION
This fixes the issue of GitHub Comment Manager throwing an error for notification on release builds, since `CHANGE_ID` is missing, which is present in PR builds:
https://ci.status.im/job/status-react/job/combined/job/mobile-android/10188/console
```
+ curl --silent --verbose -XPOST --data {
    "id": "#10188",
    "commit": "b56fd2e2",
    "success": true,
    "platform": "android",
    "duration": "~18 min",
    "url": "https://ci.status.im/job/status-react/job/combined/job/mobile-android/10188/",
    "pkg_url": "https://status-im.ams3.digitaloceanspaces.com/StatusIm-190109-095716-b56fd2-release.apk"
} -u ****:**** -H content-type: application/json https://ghcmgr.status.im/builds/null
```
```
{
   "name": "HttpError",
   "status": 400,
   "message": "Invalid value for parameter 'number': \"null\" is NaN",
   "stack": "HttpError: Invalid value for parameter 'number': \"null\" is NaN\n    at values.forEach (/app/node_modules/@octokit/rest/plugins/validate/validate.js:73:17)\n    at Array.forEach (<anonymous>)\n    at Object.keys.forEach.parameterName (/app/node_modules/@octokit/rest/plugins/validate/validate.js:38:12)\n    at Array.forEach (<anonymous>)\n    at validate (/app/node_modules/@octokit/rest/plugins/validate/validate.js:16:23)\n    at process._tickCallback (internal/process/next_tick.js:68:7)"
```

<blockquote><img src="/static/04e18fb5/favicon.ico" width="48" align="right"><div><strong><a href="https://ci.status.im/job/status-react/job/combined/job/mobile-android/10188/console">status-react » combined » mobile-android #10188 Console [Jenkins]</a></strong></div></blockquote>