### PR TITLE
[TESTS] Fix group and browser tests

### DIFF
--- a/test/appium/tests/atomic/chats/test_group_chat.py
+++ b/test/appium/tests/atomic/chats/test_group_chat.py
@@ -27,6 +27,7 @@ def create_and_join_group_chat(device_1_home, device_2_home, chat_name):
 
     # device 2: open group chat
     device_2_chat = device_2_home.get_chat_with_user(chat_name).click()
+    device_2_home.element_by_text_part('JOIN CHAT').click()
 
     return device_1_chat, device_2_chat
 

--- a/test/appium/tests/atomic/chats/test_public.py
+++ b/test/appium/tests/atomic/chats/test_public.py
@@ -1,5 +1,5 @@
+import time
 from selenium.common.exceptions import TimeoutException
-
 from support.utilities import generate_timestamp
 from tests import marks
 from tests.base_test_case import MultipleDeviceTestCase, SingleDeviceTestCase
@@ -173,12 +173,9 @@ class TestPublicChatSingleDevice(SingleDeviceTestCase):
         tag_message = '#spectentur'
         chat.send_message(tag_message)
         chat.element_starts_with_text(tag_message).click()
-        chat.empty_public_chat_message.wait_for_visibility_of_element()
-
+        time.sleep(4)
         if not chat.user_name_text.text == tag_message:
             self.driver.fail('Could not redirect a user to a public chat tapping the tag message.')
-
         home = chat.get_back_to_home_view()
-
         if not home.chat_name_text.text == tag_message:
             self.driver.fail('Could not find the public chat in user chat list.')

--- a/test/appium/tests/atomic/dapps_and_browsing/test_browsing.py
+++ b/test/appium/tests/atomic/dapps_and_browsing/test_browsing.py
@@ -65,10 +65,11 @@ class TestBrowsing(SingleDeviceTestCase):
         start_new_chat = home_view.plus_button.click()
         browsing_view = start_new_chat.open_url('google.com')
         browsing_view.cross_icon.click()
-        home_view.get_chat_with_user('Browser').swipe_and_delete()
+        browser_entry = home_view.get_chat_with_user('Google')
+        browser_entry.swipe_and_delete()
         home_view.relogin()
-        if home_view.get_chat_with_user('Browser').is_element_present(20):
-            pytest.fail('The browser entry is present after re-login')
+        if browser_entry.is_element_present(20):
+            self.driver.fail('The browser entry is present after re-login')
 
     @marks.testrail_id(5320)
     @marks.critical

--- a/test/appium/tests/atomic/dapps_and_browsing/test_dapps.py
+++ b/test/appium/tests/atomic/dapps_and_browsing/test_dapps.py
@@ -27,8 +27,7 @@ class TestDApps(SingleDeviceTestCase):
         user = basic_user
         sign_in_view = SignInView(self.driver)
         home_view = sign_in_view.recover_access(passphrase=user['passphrase'])
-        status_test_dapp = home_view.open_status_test_dapp()
-        status_test_dapp.wait_for_d_aap_to_load()
+        status_test_dapp = home_view.open_status_test_dapp(allow_all=False)
         status_test_dapp.status_api_button.click()
         status_test_dapp.request_contact_code_button.click()
         status_test_dapp.deny_button.click()

--- a/test/appium/views/home_view.py
+++ b/test/appium/views/home_view.py
@@ -157,7 +157,7 @@ class HomeView(BaseView):
         start_new_chat.confirm_until_presence_of_element(chat_view.chat_message_input)
         return chat_view
 
-    def open_status_test_dapp(self):
+    def open_status_test_dapp(self, allow_all=True):
         profile_view = self.profile_button.click()
         profile_view.advanced_button.click()
         profile_view.debug_mode_toggle.click()
@@ -168,5 +168,8 @@ class HomeView(BaseView):
         status_test_dapp = start_new_chat_view.status_test_dapp_button.click()
         start_new_chat_view.open_button.click()
         for _ in range(2):
-            status_test_dapp.allow_button.click()
+            if allow_all:
+                status_test_dapp.allow_button.click()
+            else:
+                status_test_dapp.deny_button.click()
         return status_test_dapp


### PR DESCRIPTION
* added click on new `JOIN CHAT` button on joining a group chat 
* changed `test_delete_browser_entry`  to search the entry by site name instead of `Browser` caption
* added deny/allow permissions switch in order to fix `Can request contact public key in Status test Dapp` test