### PR TITLE
fix renaming iOS release builds

### DIFF
--- a/ci/ios.groovy
+++ b/ci/ios.groovy
@@ -33,7 +33,10 @@ def bundle(type) {
   }
   /* rename built file for uploads and archivization */
   def pkg = ''
-  if (type == 'e2e') {
+  if (type == 'release') {
+    pkg = cmn.pkgFilename('release', 'ipa')
+    sh "cp status_appstore/StatusIm.ipa ${pkg}"
+  } else if (type == 'e2e') {
     pkg = cmn.pkgFilename('e2e', 'app.zip')
     sh "cp status-e2e/StatusIm.app.zip ${pkg}"
   } else if (type != 'testflight') {


### PR DESCRIPTION
This should fix issue with failing to rename iOS release builds.
https://ci.status.im/job/status-react/job/combined/job/mobile-ios/5563/consoleFull
```log
00:25:10.265 + cp status-adhoc/StatusIm.ipa StatusIm-190109-131303-9f1c3d-release.ipa
00:25:10.265 cp: status-adhoc/StatusIm.ipa: No such file or directory
```

<blockquote><img src="/static/04e18fb5/favicon.ico" width="48" align="right"><div><strong><a href="https://ci.status.im/job/status-react/job/combined/job/mobile-ios/5563/consoleFull">status-react » combined » mobile-ios #5563 Console [Jenkins]</a></strong></div></blockquote>