### PR TITLE
[Mobile] Show status-go version on separate line in About.

### DIFF
--- a/src/status_im/ui/screens/about_app/views.cljs
+++ b/src/status_im/ui/screens/about_app/views.cljs
@@ -8,7 +8,8 @@
             [re-frame.core :as re-frame]))
 
 (views/defview about-app []
-  (views/letsubs [version [:get-app-version]]
+  (views/letsubs [app-version [:get-app-short-version]
+                  node-version [:get-app-node-version]]
     [react/view {:flex 1}
      [status-bar/status-bar]
      [toolbar/simple-toolbar (i18n/label :t/about-app)]
@@ -22,6 +23,12 @@
        (when status-im.utils.platform/ios?
          [profile.components/settings-item-separator])
        [profile.components/settings-item
-        {:item-text           (i18n/label :t/version {:version version})
+        {:item-text           (i18n/label :t/version {:version app-version})
+         :accessibility-label :version
+         :hide-arrow?         true}]
+       (when status-im.utils.platform/ios?
+         [profile.components/settings-item-separator])
+       [profile.components/settings-item
+        {:item-text           node-version
          :accessibility-label :version
          :hide-arrow?         true}]]]]))

--- a/src/status_im/ui/screens/profile/subs.cljs
+++ b/src/status_im/ui/screens/profile/subs.cljs
@@ -4,6 +4,13 @@
             [status-im.utils.build :as build]
             [status-im.utils.platform :as platform]))
 
+(defn- node-version [{:keys [web3-node-version]}]
+  (str "status-go v" (or web3-node-version "N/A") ""))
+
+(def app-short-version
+  (let [version (if platform/desktop? build/version build/build-no)]
+    (str build/version " (" version ")")))
+
 (re-frame/reg-sub
  :get-profile-unread-messages-number
  :<- [:account/account]
@@ -12,9 +19,16 @@
 
 (re-frame/reg-sub
  :get-app-version
- (fn [{:keys [web3-node-version]}]
-   (let [version (if platform/desktop? build/version build/build-no)]
-     (str build/version " (" version "); node " (or web3-node-version "N/A") ""))))
+ (fn [db]
+   (str app-short-version "; " (node-version db))))
+
+(re-frame/reg-sub
+ :get-app-short-version
+ (fn [db] app-short-version))
+
+(re-frame/reg-sub
+ :get-app-node-version
+ node-version)
 
 (re-frame/reg-sub
  :get-device-UUID


### PR DESCRIPTION
fixes #7231

### New look (iPhone 5s):
<img width="252" alt="iphone se - 12 1 2019-01-09 16-41-59" src="https://user-images.githubusercontent.com/466427/50910146-7f19ec80-142d-11e9-9ee2-b34dae4caf43.png">


#### Platforms (optional)
- Android
- iOS
- macOS
- Linux
- Windows

<!-- (Specify if some specific areas has to be tested, for example 1-1 chats) -->
#### Areas that maybe impacted (optional)
**Functional**
- about

status: ready <!-- Can be ready or wip -->