### PR TITLE
skip uploading on release since bundle stage already does that

### DIFF
--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -74,6 +74,7 @@ pipeline {
       }
     }
     stage('Upload') {
+      when { expression { cmn.getBuildType() != 'release' } }
       steps {
         script {
           /* e2e builds get tested in SauceLabs */


### PR DESCRIPTION
Right now the __Bundle__ stage runs `bundle exec fastlane ios release` which also calls `upload_to_testflight`, so the upload is already included in that stage. We should probably split this later, but for now I'm just going to disable the __Upload__ stage for release builds.