### PR TITLE
Report messages as "processed" to status-go only after they were stored in Realm

### DIFF
--- a/src/status_im/data_store/core.cljs
+++ b/src/status_im/data_store/core.cljs
@@ -46,14 +46,37 @@
    (then
     #(data-source/open-account address password encryption-key))))
 
+(defn merge-events-of-type [success-events event-type]
+  ;; merges data value of events of specified type together
+  ;; keeps the other events intact
+  ;; [[:e1 [:d1]] [:e1 [:d2]]] => [[:e1 [:d1 :d2]]]
+  (let [event-to-merge? (fn [event]
+                          (and (vector? event)
+                               (= (first event) event-type)
+                               (vector? (second event))))
+        unmergeable-events (filter (complement event-to-merge?) success-events)
+        mergeable-events (filter event-to-merge? success-events)]
+    (into []
+          (into unmergeable-events
+                (when-not (empty? mergeable-events)
+                  (let [merged-values (reduce into
+                                              (map second mergeable-events))]
+                    [(into [event-type]
+                           (when merged-values
+                             [merged-values]))]))))))
+
+(defn- merge-persistence-events [success-events]
+  (merge-events-of-type success-events :message/message-persisted))
+
 (defn- perform-transactions [raw-transactions realm]
   (let [success-events (keep :success-event raw-transactions)
         transactions   (map (fn [{:keys [transaction] :as f}]
                               (or transaction f)) raw-transactions)]
     (data-source/write realm #(doseq [transaction transactions]
                                 (transaction realm)))
-    (doseq [event success-events]
-      (re-frame/dispatch event))))
+    (let [optimized-events (merge-persistence-events success-events)]
+      (doseq [event optimized-events]
+        (re-frame/dispatch event)))))
 
 (re-frame/reg-fx
  :data-store/base-tx

--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -788,6 +788,11 @@
  (fn [cofx [_ chat-id message-id status]]
    (chat.message/update-message-status cofx chat-id message-id status)))
 
+(handlers/register-handler-fx
+ :message/message-persisted
+ (fn [cofx [_ raw-message]]
+   (chat.message/confirm-message-processed cofx raw-message)))
+
 ;; signal module
 
 (handlers/register-handler-fx

--- a/src/status_im/transport/message/core.cljs
+++ b/src/status_im/transport/message/core.cljs
@@ -150,7 +150,6 @@
       (apply fx/merge cofx resend-contact-message-fxs))))
 
 (re-frame/reg-fx
- ;; TODO(janherich): this should be called after `:data-store/tx` actually
  :transport/confirm-messages-processed
  (fn [messages]
    (let [{:keys [web3]} (first messages)

--- a/test/cljs/status_im/test/chat/models/message.cljs
+++ b/test/cljs/status_im/test/chat/models/message.cljs
@@ -56,8 +56,6 @@
           (is message))
         (testing "it marks the message as outgoing"
           (is (= true (:outgoing message))))
-        (testing "it confirm the message as processed"
-          (is (:transport/confirm-messages-processed actual)))
         (testing "it stores the message"
           (is (:data-store/tx actual)))
         (testing "it does not send a seen confirmation"

--- a/test/cljs/status_im/test/data_store/core.cljs
+++ b/test/cljs/status_im/test/data_store/core.cljs
@@ -1,0 +1,49 @@
+(ns status-im.test.data-store.core
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [status-im.utils.utils :as utils]
+            [clojure.string :as string]
+            [status-im.data-store.core :as core]))
+
+(deftest merge-events-of-type
+  (def events-test [[:event1 [:data1]] [:event1 [:data2]]
+                    [:event2 [:data3]] [:event2 [:data4]]
+                    [:event3 [:data5]]
+                    [:event4 :data6]
+                    [:event5]])
+  (testing "merging-events-with-data"
+    (is (= (core/merge-events-of-type events-test :event1)
+           [[:event1 [:data1 :data2]]
+            [:event2 [:data3]] [:event2 [:data4]]
+            [:event3 [:data5]]
+            [:event4 :data6]
+            [:event5]]))
+
+    (is (= (core/merge-events-of-type events-test :event2)
+           [[:event2 [:data3 :data4]]
+            [:event1 [:data1]] [:event1 [:data2]]
+            [:event3 [:data5]]
+            [:event4 :data6]
+            [:event5]]))
+
+    (is (= (core/merge-events-of-type events-test :event3)
+           [[:event3 [:data5]]
+            [:event1 [:data1]] [:event1 [:data2]]
+            [:event2 [:data3]] [:event2 [:data4]]
+            [:event4 :data6]
+            [:event5]]))
+
+    ;; we can't group non-vector event data
+    (is (= (core/merge-events-of-type events-test :event4)
+           [[:event1 [:data1]] [:event1 [:data2]]
+            [:event2 [:data3]] [:event2 [:data4]]
+            [:event3 [:data5]]
+            [:event4 :data6]
+            [:event5]]))
+
+    ;; we can't group non-vector event data
+    (is (= (core/merge-events-of-type events-test :event5)
+           [[:event1 [:data1]] [:event1 [:data2]]
+            [:event2 [:data3]] [:event2 [:data4]]
+            [:event3 [:data5]]
+            [:event4 :data6]
+            [:event5]]))))

--- a/test/cljs/status_im/test/runner.cljs
+++ b/test/cljs/status_im/test/runner.cljs
@@ -2,6 +2,7 @@
   (:require [doo.runner :refer-macros [doo-tests]]
             [status-im.test.contacts.db]
             [status-im.test.data-store.chats]
+            [status-im.test.data-store.core]
             [status-im.test.data-store.realm.core]
             [status-im.test.extensions.core]
             [status-im.test.extensions.ethereum]
@@ -75,6 +76,7 @@
  'status-im.test.chat.models
  'status-im.test.init.core
  'status-im.test.data-store.chats
+ 'status-im.test.data-store.core
  'status-im.test.data-store.realm.core
  'status-im.test.extensions.core
  'status-im.test.mailserver.core


### PR DESCRIPTION
fixes: https://www.pivotaltracker.com/story/show/162661405

### Summary

This suppose to fix the potential issue I was able to reproduce with chats being different on Desktop and mobile. The working theory was that these messages were reported as "confirmed" to status-go side (deduplication) but were never added to the DB.

In this PR, messages actually reported as "confirmed" if and only if they were successfully stored in Realm. This adds an additional event to `re-frame`, but this makes the code to handle errors correctly.

#### Platforms (optional)
- Android
- iOS
- macOS
- Linux
- Windows

<!-- (Specify if some specific areas has to be tested, for example 1-1 chats) -->
#### Areas that maybe impacted (optional)
**Functional**
- 1-1 chats
- public chats
- group chats

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->

<blockquote><div><strong><a href="https://www.pivotaltracker.com/story/show/162661405">As a user, I want consistent message history between desktop and mobile.  - Pivotal Tracker</a></strong></div></blockquote>