### PR TITLE
don't update cn.status.im on every release build

### DIFF
--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -95,20 +95,9 @@ pipeline {
       } }
     }
     stage('Publish') {
+      when { expression { btype == 'nightly' } }
       steps { script {
-        switch (btype) {
-          case 'nightly':
-            build('misc/status.im')
-            break
-          case 'release':
-            build(
-              job: 'misc/cn.status.im',
-              parameters: [
-                [name: 'APK_URL', value: urls.Apk, $class: 'StringParameterValue'],
-              ]
-            )
-            break
-        }
+        build('misc/status.im')
       } }
     }
     stage('Run e2e') {


### PR DESCRIPTION
Stops the release jobs from updating the APK url on https://cn.status.im/ on every build.

<blockquote><div><strong><a href="https://cn.status.im/">Status, a Mobile Ethereum OS</a></strong></div><div>Status is an interface to access Ethereum, built for Android & iOS. Enjoy encrypted messaging, a cryptocurrency wallet, and seamless access to DApps.</div></blockquote>