### PR TITLE
use nvm() wrapper in jenkins for android builds

### DIFF
--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -44,32 +44,36 @@ pipeline {
           mobile = load 'ci/mobile.groovy'
           cmn    = load 'ci/common.groovy'
           print "Running ${cmn.getBuildType()} build!"
-          /* Cleanup and Prep */
-          mobile.prep(cmn.getBuildType())
           /* Run at start to void mismatched numbers */
           cmn.buildNumber()
+          /* Read the valid NodeJS version */
+          env.NODE_VERSION = cmn.getToolVersion('node')
+          /* Cleanup and Prep */
+          nvm(env.NODE_VERSION) {
+            mobile.prep(cmn.getBuildType())
+          }
         }
       }
     }
     stage('Lint') {
-      steps {
+      steps { nvm(env.NODE_VERSION) {
         script { cmn.runLint() }
-      }
+      } }
     }
     stage('Tests') {
-      steps {
+      steps { nvm(env.NODE_VERSION) {
         script { cmn.runTests() }
-      }
+      } }
     }
     stage('Build') {
-      steps {
+      steps { nvm(env.NODE_VERSION) {
         script { mobile.leinBuild('android') }
-      }
+      } }
     }
     stage('Bundle') {
-      steps {
+      steps { nvm(env.NODE_VERSION) {
         script { apk = mobile.android.bundle(cmn.getBuildType()) }
-      }
+      } }
     }
     stage('Archive') {
       steps {

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -23,7 +23,6 @@ pipeline {
   }
 
   environment {
-    NODE_VERSION = 'v10.14.1'
     BUILD_PLATFORM = 'ios'
     LANG = 'en_US.UTF-8'
     LANGUAGE = 'en_US.UTF-8'
@@ -36,20 +35,24 @@ pipeline {
   stages {
     stage('Prep') {
       steps {
-        script { nvm(env.NODE_VERSION) {
+        script { 
           /* Necessary to load methods */
           mobile = load 'ci/mobile.groovy'
           cmn    = load 'ci/common.groovy'
           print "Running ${cmn.getBuildType()} build!"
-          /* Cleanup and Prep */
-          mobile.prep(cmn.getBuildType())
           /* Run at start to void mismatched numbers */
           cmn.buildNumber()
-        } }
+          /* Read the valid NodeJS version */
+          env.NODE_VERSION = cmn.getToolVersion('node')
+          /* Cleanup and Prep */
+          nvm(env.NODE_VERSION) {
+            mobile.prep(cmn.getBuildType())
+          }
+        }
       }
     }
     stage('Lint') {
-      steps { nvm(env.NODE_VERSION) {
+      steps {nvm(env.NODE_VERSION) {
         script { cmn.runLint() }
       } }
     }

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -40,7 +40,6 @@ pipeline {
    * https://issues.jenkins-ci.org/browse/JENKINS-49076
    **/
   environment {
-    NODE_VERSION = 'v10.14.1'
     BUILD_PLATFORM = 'linux'
     LANG = 'en_US.UTF-8'
     LANGUAGE = 'en_US.UTF-8'
@@ -55,13 +54,17 @@ pipeline {
   stages {
     stage('Prep') {
       steps {
-        script { nvm(env.NODE_VERSION) {
+        script {
           /* Necessary to load methods */
           desktop = load 'ci/desktop.groovy'
           cmn     = load 'ci/common.groovy'
-          sh 'env'
-          desktop.prepDeps()
-        } }
+          /* Read the valid NodeJS version */
+          env.NODE_VERSION = cmn.getToolVersion('node')
+          /* Cleanup and Prep */
+          nvm(env.NODE_VERSION) {
+            desktop.prepDeps()
+          }
+        }
       }
     }
     stage('Lint') {

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -23,7 +23,6 @@ pipeline {
   }
 
   environment {
-    NODE_VERSION = 'v10.14.1'
     BUILD_PLATFORM = 'macos'
     LANG = 'en_US.UTF-8'
     LANGUAGE = 'en_US.UTF-8'
@@ -37,12 +36,17 @@ pipeline {
   stages {
     stage('Prep') {
       steps {
-        script { nvm(env.NODE_VERSION) {
+        script {
           /* Necessary to load methods */
           desktop = load 'ci/desktop.groovy'
           cmn     = load 'ci/common.groovy'
-          desktop.prepDeps()
-        } }
+          /* Read the valid NodeJS version */
+          env.NODE_VERSION = cmn.getToolVersion('node')
+          /* Cleanup and Prep */
+          nvm(env.NODE_VERSION) {
+            desktop.prepDeps()
+          }
+        }
       }
     }
     stage('Lint') {

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -40,7 +40,6 @@ pipeline {
    * https://issues.jenkins-ci.org/browse/JENKINS-49076
    **/
   environment {
-    NODE_VERSION = 'v10.14.1'
     BUILD_PLATFORM = 'windows'
     LANG = 'en_US.UTF-8'
     LANGUAGE = 'en_US.UTF-8'
@@ -58,13 +57,17 @@ pipeline {
   stages {
     stage('Prep') {
       steps {
-        script { nvm(env.NODE_VERSION) {
+        script {
           /* Necessary to load methods */
           desktop = load 'ci/desktop.groovy'
           cmn     = load 'ci/common.groovy'
-          sh 'env'
-          desktop.prepDeps()
-        } }
+          /* Read the valid NodeJS version */
+          env.NODE_VERSION = cmn.getToolVersion('node')
+          /* Cleanup and Prep */
+          nvm(env.NODE_VERSION) {
+            desktop.prepDeps()
+          }
+        }
       }
     }
     stage('Lint') {

--- a/ci/common.groovy
+++ b/ci/common.groovy
@@ -4,6 +4,14 @@ def version() {
   return readFile("${env.WORKSPACE}/VERSION").trim()
 }
 
+def getToolVersion(name) {
+  def version = sh(
+    returnStdout: true,
+    script: "grep ${name} ${env.WORKSPACE}/.TOOLVERSIONS | cut -d'=' -f2-"
+  ).trim()
+  return version
+}
+
 def getBuildType() {
   def jobName = env.JOB_NAME
   if (jobName.contains('e2e')) {


### PR DESCRIPTION
Android builds seem to be the only ones not using this `nvm()` wrapper for correct NodeJS version.