### PR TITLE
Prevent creating chats while status-go is not ready

### DIFF
--- a/src/status_im/accounts/login/core.cljs
+++ b/src/status_im/accounts/login/core.cljs
@@ -9,6 +9,7 @@
             [status-im.utils.keychain.core :as keychain]
             [status-im.utils.types :as types]
             [taoensso.timbre :as log]
+            [status-im.utils.universal-links.core :as universal-links]
             [status-im.utils.security :as security]
             [status-im.utils.platform :as platform]
             [status-im.protocol.core :as protocol]
@@ -96,6 +97,7 @@
            (when save-password?
              {:keychain/save-user-password [address password]}))
          (protocol/initialize-protocol)
+         (universal-links/process-stored-event)
          #(when-not platform/desktop?
             (initialize-wallet %)))
         (account-and-db-password-do-not-match cofx error)))))

--- a/src/status_im/init/core.cljs
+++ b/src/status_im/init/core.cljs
@@ -26,7 +26,6 @@
             [status-im.utils.ethereum.core :as ethereum]
             [status-im.utils.keychain.core :as keychain]
             [status-im.utils.platform :as platform]
-            [status-im.utils.universal-links.core :as universal-links]
             [status-im.utils.utils :as utils]
             [taoensso.timbre :as log]
             [status-im.utils.fx :as fx]
@@ -204,7 +203,6 @@
   (fx/merge cofx
             {:notifications/request-notifications-permissions nil}
             (navigation/navigate-to-cofx :home nil)
-            (universal-links/process-stored-event)
             (notifications/process-stored-event address stored-pns)
             (when platform/desktop?
               (chat-model/update-dock-badge-label))))

--- a/src/status_im/ui/screens/desktop/main/tabs/home/views.cljs
+++ b/src/status_im/ui/screens/desktop/main/tabs/home/views.cljs
@@ -142,6 +142,7 @@
 
 (views/defview chat-list-view [loading?]
   (views/letsubs [search-filter       [:search/filter]
+                  logging-in?          [:get :accounts/login]
                   filtered-home-items [:search/filtered-home-items]]
     {:component-did-mount
      (fn [this]
@@ -152,9 +153,11 @@
      [react/view {:style styles/chat-list-header}
       [search-input search-filter]
       [react/view
-       [react/touchable-highlight {:on-press #(re-frame/dispatch [:set-in [:desktop :popup] popup])}
+       [react/touchable-highlight {:on-press (when-not logging-in? #(re-frame/dispatch [:set-in [:desktop :popup] popup]))}
         [react/view {:style styles/add-new}
-         [icons/icon :icons/add {:style {:tint-color :white}}]]]]]
+         (if logging-in?
+           [components/activity-indicator {:animating true :color :white}]
+           [icons/icon :icons/add {:style {:tint-color :white}}])]]]]
      [react/scroll-view {:enableArrayScrollingOptimization true}
       [react/view
        (for [[index chat] (map-indexed vector filtered-home-items)]

--- a/src/status_im/ui/screens/home/styles.cljs
+++ b/src/status_im/ui/screens/home/styles.cljs
@@ -187,3 +187,6 @@
    :border-radius    28
    :align-items      :center
    :justify-content  :center})
+
+(def spinner-container
+  {:margin-right 10})

--- a/src/status_im/ui/screens/home/views.cljs
+++ b/src/status_im/ui/screens/home/views.cljs
@@ -6,6 +6,7 @@
             [status-im.ui.components.toolbar.view :as toolbar]
             [status-im.ui.components.toolbar.actions :as toolbar.actions]
             [status-im.ui.components.connectivity.view :as connectivity]
+            [status-im.ui.components.colors :as colors]
             [status-im.ui.screens.home.views.inner-item :as inner-item]
             [status-im.ui.screens.home.styles :as styles]
             [status-im.utils.platform :as platform]
@@ -16,7 +17,7 @@
             [status-im.ui.components.react :as components]
             [status-im.utils.utils :as utils]))
 
-(defn- toolbar [show-welcome? show-sync-state sync-state latest-block-number]
+(defn- toolbar [show-welcome? show-sync-state sync-state latest-block-number logged-in?]
   (when-not (and show-welcome?
                  platform/android?)
     [toolbar/toolbar nil nil
@@ -34,17 +35,27 @@
                    (str "not syncing")))]]]
          [toolbar/content-wrapper
           [components.common/logo styles/toolbar-logo]]))
-     [toolbar/actions
-      (when platform/ios?
+     (cond
+       (and platform/ios?
+            logged-in?)
+       [toolbar/actions
         [(-> (toolbar.actions/add true #(re-frame/dispatch [:navigate-to :new]))
-             (assoc-in [:icon-opts :accessibility-label] :new-chat-button))])]]))
+             (assoc-in [:icon-opts :accessibility-label] :new-chat-button))]]
+       platform/ios?
+       [react/view {:style styles/spinner-container}
+        [components/activity-indicator {:color colors/blue
+                                        :animating true}]])]))
 
-(defn- home-action-button []
+(defn- home-action-button [logged-in?]
   [react/view styles/action-button-container
    [react/touchable-highlight {:accessibility-label :new-chat-button
-                               :on-press            #(re-frame/dispatch [:navigate-to :new])}
+                               :on-press            (when logged-in? #(re-frame/dispatch [:navigate-to :new]))}
     [react/view styles/action-button
-     [icons/icon :icons/add {:color :white}]]]])
+
+     (if-not logged-in?
+       [components/activity-indicator {:color :white
+                                       :animating true}]
+       [icons/icon :icons/add {:color :white}])]]])
 
 (defn home-list-item [[home-item-id home-item]]
   (let [delete-action   (if (:chat-id home-item)
@@ -90,6 +101,7 @@
 (views/defview home [loading?]
   (views/letsubs [show-welcome? [:get-in [:accounts/create :show-welcome?]]
                   view-id [:get :view-id]
+                  logging-in? [:get :accounts/login]
                   sync-state [:chain-sync-state]
                   latest-block-number [:latest-block-number]
                   rpc-network? [:current-network-uses-rpc?]
@@ -102,7 +114,7 @@
             #(re-frame/dispatch [:init-rest-of-chats])
             100))))}
     [react/view styles/container
-     [toolbar show-welcome? (and network-initialized? (not rpc-network?)) sync-state latest-block-number]
+     [toolbar show-welcome? (and network-initialized? (not rpc-network?)) sync-state latest-block-number (not logging-in?)]
      (cond show-welcome?
            [welcome view-id]
            loading?
@@ -117,7 +129,7 @@
             [connectivity/connectivity-view]
             [chats-list]])
      (when platform/android?
-       [home-action-button])]))
+       [home-action-button (not logging-in?)])]))
 
 (views/defview home-wrapper []
   (views/letsubs [loading? [:get :chats/loading?]]


### PR DESCRIPTION
fixes: #7282 
Disable joining chats while the system is logging you in, otherwise the db gets into a inconsistent state.
status: ready