### PR TITLE
Revert "Fixed incorrect parameters provided to Command#yield-control"

### DIFF
--- a/src/status_im/chat/commands/core.cljs
+++ b/src/status_im/chat/commands/core.cljs
@@ -6,7 +6,6 @@
             [status-im.chat.constants :as chat.constants]
             [status-im.chat.commands.protocol :as protocol]
             [status-im.chat.commands.impl.transactions :as transactions]
-            [status-im.contact.db :as db]
             [status-im.utils.handlers :as handlers]
             [status-im.utils.fx :as fx]))
 
@@ -35,16 +34,13 @@
   [type]
   (keyword (str (protocol/id type) "-button")))
 
-(defn- contact->address [contact]
-  (str "0x" (db/public-key->address contact)))
-
 (defn add-chat-contacts
   "Enrich command-message by adding contact list of the current private or group chat"
   [contacts {:keys [public? group-chat] :as command-message}]
   (cond
     public? command-message
-    group-chat (assoc command-message :contacts (map contact->address contacts))
-    :else (assoc command-message :contact (contact->address (first contacts)))))
+    group-chat (assoc command-message :contacts (map status-im.contact.db/public-key->address contacts))
+    :else (assoc command-message :contact (status-im.contact.db/public-key->address (first contacts)))))
 
 (defn enrich-command-message-for-events
   "adds new pairs to command-message to be consumed by extension events"

--- a/src/status_im/chat/commands/sending.cljs
+++ b/src/status_im/chat/commands/sending.cljs
@@ -31,13 +31,13 @@
       ;; errors during validation
       {:db (chat/set-chat-ui-props db {:validation-messages validation-error})}
       ;; no errors
-      (let [command-message (commands/enrich-command-message-for-events db (create-command-message chat-id type parameter-map cofx))]
-        (if (satisfies? protocol/Yielding type)
-          ;; yield control implemented, don't send the message
-          (protocol/yield-control type command-message cofx)
-          ;; no yield control, proceed with sending the command message
+      (if (satisfies? protocol/Yielding type)
+        ;; yield control implemented, don't send the message
+        (protocol/yield-control type parameter-map cofx)
+        ;; no yield control, proceed with sending the command message
+        (let [command-message (create-command-message chat-id type parameter-map cofx)]
           (fx/merge cofx
-                    #(protocol/on-send type command-message %)
+                    #(protocol/on-send type (commands/enrich-command-message-for-events db command-message) %)
                     (commands.input/set-command-reference nil)
                     (chat.message/send-message command-message)))))))
 

--- a/test/cljs/status_im/test/chat/commands/core.cljs
+++ b/test/cljs/status_im/test/chat/commands/core.cljs
@@ -111,9 +111,9 @@
                 "0x04b790f2c3f4079f35a1fa396465ceb243cc446c9af211d0a1774f869eb9632a67a6e664e24075ec5c5a8a95a509a2a8173dbfeb88af372e784a37fecc1b5c0ba5"
                 "0x04cc3cec3f88dc1a39e224388f0304023fc78c2a7d05e4ebd61638192cc592d2c13d8f081b5d9995dbfcbe45a4ca7eb80d5c505eee660e8fee0df2da222f047287"})
 
-(def contacts_addresses '("0x5adf1b9e1fa4bd4889fecd598b45079045d98f0e"
-                          "0x21631d18d9681d4ffdd460fc45fa52159fcd95c8"
-                          "0x5541e3be81b76d76cdbf968516caa5a5b773763b"))
+(def contacts_addresses '("5adf1b9e1fa4bd4889fecd598b45079045d98f0e"
+                          "21631d18d9681d4ffdd460fc45fa52159fcd95c8"
+                          "5541e3be81b76d76cdbf968516caa5a5b773763b"))
 
 (deftest enrich-command-message-for-events-test-public
   (let [db {:chats {"1" {:contacts nil :public? true :group-chat false}}}


### PR DESCRIPTION
This reverts commit ac1de8c690c26696965979ad5f7105dfac15726e because it causes a regression making sending any assets in a chat impossible.

status: ready <!-- Can be ready or wip -->
