### PR TITLE
Fix merging of :message/message-persisted event

### DIFF
--- a/src/status_im/chat/core.cljs
+++ b/src/status_im/chat/core.cljs
@@ -21,4 +21,4 @@
                               db
                               statuses)
        :data-store/tx [{:transaction (user-statuses-store/save-statuses-tx statuses)
-                        :success-event [:message/message-persisted js-obj]}]})))
+                        :success-event [:message/messages-persisted [js-obj]]}]})))

--- a/src/status_im/chat/models/message.cljs
+++ b/src/status_im/chat/models/message.cljs
@@ -139,7 +139,8 @@
                :data-store/tx [(merge
                                 {:transaction (messages-store/save-message-tx prepared-message)}
                                 (when raw-message
-                                  {:success-event [:message/message-persisted raw-message]}))]}
+                                  {:success-event
+                                   [:message/messages-persisted [raw-message]]}))]}
               (when (and platform/desktop?
                          (not batch?)
                          (not (system-message? prepared-message)))

--- a/src/status_im/data_store/core.cljs
+++ b/src/status_im/data_store/core.cljs
@@ -66,7 +66,7 @@
                              [merged-values]))]))))))
 
 (defn- merge-persistence-events [success-events]
-  (merge-events-of-type success-events :message/message-persisted))
+  (merge-events-of-type success-events :message/messages-persisted))
 
 (defn- perform-transactions [raw-transactions realm]
   (let [success-events (keep :success-event raw-transactions)

--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -791,9 +791,14 @@
    (chat.message/update-message-status cofx chat-id message-id status)))
 
 (handlers/register-handler-fx
- :message/message-persisted
- (fn [cofx [_ raw-message]]
-   (chat.message/confirm-message-processed cofx raw-message)))
+ :message/messages-persisted
+ (fn [cofx [_ raw-messages]]
+   (apply fx/merge
+          cofx
+          (map
+           (fn [raw-message]
+             (chat.message/confirm-message-processed raw-message))
+           raw-messages))))
 
 ;; signal module
 


### PR DESCRIPTION
Previously `:message/message-persisted` was dispatched for each incoming
message because its argument was not a vector. The event was renamed to
`:message/messages-persisted`.

status: ready