### PR TITLE
[fix] remove mnemonic from current-account map

### DIFF
--- a/src/status_im/ui/screens/profile/user/views.cljs
+++ b/src/status_im/ui/screens/profile/user/views.cljs
@@ -267,7 +267,7 @@
         [react/view (merge action-button.styles/actions-list
                            styles/share-contact-code-container)
          [button/secondary-button {:on-press            #(re-frame/dispatch [:navigate-to :profile-qr-viewer
-                                                                             {:contact current-account
+                                                                             {:contact (dissoc current-account :mnemonic)
                                                                               :source  :public-key
                                                                               :value   public-key}])
                                    :style               styles/share-contact-code-button


### PR DESCRIPTION
current-account is duplicated in `:qr-modal` key when tapping on `share my profile` button in the Profile screen

this removes the mnemonic from the duplicated data so that it does persist there after user backed up his mnemonic

this was only happening until logging out/restarting the app

status: ready
