### PR TITLE
Switched keychain to another tag

### DIFF
--- a/desktop_files/package.json.orig
+++ b/desktop_files/package.json.orig
@@ -67,7 +67,7 @@
     "react-native-image-crop-picker": "0.18.1",
     "react-native-image-resizer": "1.0.0",
     "react-native-invertible-scroll-view": "1.1.0",
-    "react-native-keychain": "git+https://github.com/status-im/react-native-keychain.git#v.3.0.0-status",
+    "react-native-keychain": "git+https://github.com/status-im/react-native-keychain.git#v.3.0.0-1-status",
     "react-native-level-fs": "3.0.0",
     "react-native-os": "1.1.0",
     "react-native-qrcode": "0.2.6",

--- a/desktop_files/yarn.lock
+++ b/desktop_files/yarn.lock
@@ -7222,9 +7222,9 @@ react-native-invertible-scroll-view@1.1.0:
     react-clone-referenced-element "^1.0.1"
     react-native-scrollable-mixin "^1.0.1"
 
-"react-native-keychain@git+https://github.com/status-im/react-native-keychain.git#v.3.0.0-status":
+"react-native-keychain@git+https://github.com/status-im/react-native-keychain.git#v.3.0.0-1-status":
   version "3.0.0-rc.3"
-  resolved "git+https://github.com/status-im/react-native-keychain.git#43e5512cabb8ee064fd9e503be943dcf2c7d7669"
+  resolved "git+https://github.com/status-im/react-native-keychain.git#33eb25baf359414f7a30a34a0298a6347f698138"
 
 react-native-level-fs@3.0.0:
   version "3.0.0"


### PR DESCRIPTION

fixes #7299 

### Summary:

Fixes desktop build problem. Keychain dependency changed to another tag.

#### Platforms (optional)
- macOS
- Linux
- Windows

<!-- (Specify if some specific areas has to be tested, for example 1-1 chats) -->
#### Areas that maybe impacted (optional)
**Functional**
- 1-1 chats
- public chats
- group chats
- wallet / transactions
- dapps / app browsing
- account recovery
- new account
- user profile updates
- networks
- mailservers
- fleet
- bootnodes

**Non-functional**
- battery performance
- CPU performance / speed of the app
- network consumption

<!-- (Specify exact steps to test if there are such) -->
### Steps to test:
- Open Status
- ...
- Step 3, etc.

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: read
