### PR TITLE
Use new Infura API.

### DIFF
--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -47,7 +47,7 @@
                   :config {:NetworkId      (ethereum/chain-keyword->chain-id :mainnet)
                            :DataDir        "/ethereum/mainnet_rpc"
                            :UpstreamConfig {:Enabled true
-                                            :URL     "https://mainnet.infura.io/z6GCTmjdP3FETEJmMBI4"}}}})
+                                            :URL     "https://mainnet.infura.io/v3/f315575765b14720b32382a61a89341a"}}}})
 
 (def sidechain-networks
   {"xdai_rpc" {:id     "xdai_rpc",
@@ -74,7 +74,7 @@
                   :config {:NetworkId      (ethereum/chain-keyword->chain-id :testnet)
                            :DataDir        "/ethereum/testnet_rpc"
                            :UpstreamConfig {:Enabled true
-                                            :URL     "https://ropsten.infura.io/z6GCTmjdP3FETEJmMBI4"}}}
+                                            :URL     "https://ropsten.infura.io/v3/f315575765b14720b32382a61a89341a"}}}
    "rinkeby"     {:id     "rinkeby",
                   :name   "Rinkeby",
                   :config {:NetworkId      (ethereum/chain-keyword->chain-id :rinkeby)
@@ -85,7 +85,7 @@
                   :config {:NetworkId      (ethereum/chain-keyword->chain-id :rinkeby)
                            :DataDir        "/ethereum/rinkeby_rpc"
                            :UpstreamConfig {:Enabled true
-                                            :URL     "https://rinkeby.infura.io/z6GCTmjdP3FETEJmMBI4"}}}})
+                                            :URL     "https://rinkeby.infura.io/v3/f315575765b14720b32382a61a89341a"}}}})
 
 (defn network-enabled? [network]
   (let [rpc-network? (get-in (val network) [:config :UpstreamConfig :Enabled])

--- a/test/appium/views/profile_view.py
+++ b/test/appium/views/profile_view.py
@@ -491,7 +491,7 @@ class ProfileView(BaseView):
         self.network_settings_button.click()
         self.plus_button.click_until_presence_of_element(self.ropsten_chain_button)
         self.ropsten_chain_button.click()
-        self.custom_network_url.send_keys('https://ropsten.infura.io/iMko0kJNQUdhbCSaJcox')
+        self.custom_network_url.send_keys('https://ropsten.infura.io/v3/f315575765b14720b32382a61a89341a')
         self.specify_name_input.send_keys('custom_ropsten')
         self.save_button.click()
         self.element_by_text_part('custom_ropsten').click_until_presence_of_element(self.connect_button)

--- a/test/cljs/status_im/test/models/network.cljs
+++ b/test/cljs/status_im/test/models/network.cljs
@@ -20,7 +20,7 @@
   (testing "an https url"
     (is (model/valid-rpc-url? "https://valid.something.else")))
   (testing "a fully qualified url"
-    (is (model/valid-rpc-url? "https://mainnet.infura.io:6523/z6GCTmjdP3FETEJmMBI4")))
+    (is (model/valid-rpc-url? "https://mainnet.infura.io:6523/v3/f315575765b14720b32382a61a89341a")))
   (testing "an ip address"
     (is (model/valid-rpc-url? "https://192.168.1.1")))
   (testing "localhost"


### PR DESCRIPTION
As per announcement, we need to switch our Infura project IDs.

> As previously announced, accessing Infura will begin requiring a Project ID generated from the new Infura Dashboard. If you are using Infura and have not yet migrated your project, please take the time to do so now. The first milestone in this transition will be activated next week on January 23, 2019 at 20:00 UTC.

https://blog.infura.io/infura-dashboard-transition-update-c670945a922a

The new project is created with ID `f315575765b14720b32382a61a89341a`
and the API keys are updated.

#### Steps to do before merging:
- [x] get a reply from Infura if we need an upgrade;
- [x] test this PR.

status: ready <!-- Can be ready or wip -->
