### PR TITLE
Update pods only if installation fails.

### DIFF
--- a/ci/mobile.groovy
+++ b/ci/mobile.groovy
@@ -57,8 +57,14 @@ def prep(type = 'nightly') {
   /* generate ios/StatusIm.xcworkspace */
   if (env.BUILD_PLATFORM == 'ios') {
     dir('ios') {
-      podUpdate()
-      sh 'pod install --silent'
+      try {
+         sh 'pod install --silent'
+      } catch (Exception ex) {
+         println "pod installation failed, trying to upgrade the repo"
+         /* only if pod install fails, we try to upgrade the repo */
+         podUpdate()
+         sh 'pod install --silent'
+      }
     }
   }
 }


### PR DESCRIPTION
Updating pods was a way to mitigate one of the issues we had in the past. It's not necessary right now if pods are installing just fine.

This PR only calls this command if `pod install` fails.

status: ready <!-- Can be ready or wip -->