### PR TITLE
fix use of toolversion by using absolute GIT_ROOT

### DIFF
--- a/docker/base/Makefile
+++ b/docker/base/Makefile
@@ -1,12 +1,11 @@
 GIT_COMMIT = $(shell git rev-parse --short HEAD)
+GIT_ROOT = $(shell git rev-parse --show-toplevel)
 
 # Software Versions, URLs, and Checksums
 NVM_VERSION = v0.33.11
 NVM_INSTALL_SCRIPT = nvm_$(NVM_VERSION)_install.sh
 NVM_NODE_VERSION = v10.14.0
 LEIN_VERSION = stable
-
-GIT_ROOT = $(shell git rev-parse --show-toplevel)
 
 # WARNING: Remember to change the tag when updating the image
 IMAGE_TAG = 1.0.0

--- a/docker/linux/Makefile
+++ b/docker/linux/Makefile
@@ -1,6 +1,7 @@
 __toolversion = $(shell $(GIT_ROOT)/scripts/toolversion $(1))
 
 GIT_COMMIT = $(shell git rev-parse --short HEAD)
+GIT_ROOT = $(shell git rev-parse --show-toplevel)
 
 # WARNING: Change version in Dockerfile too
 QT_VERSION = 5.11.2

--- a/docker/windows/Makefile
+++ b/docker/windows/Makefile
@@ -1,6 +1,7 @@
 __toolversion = $(shell $(GIT_ROOT)/scripts/toolversion $(1))
 
 GIT_COMMIT = $(shell git rev-parse --short HEAD)
+GIT_ROOT = $(shell git rev-parse --show-toplevel)
 
 # WARNING: Remember to change the tag when updating the image
 IMAGE_TAG = 1.1.1

--- a/scripts/lib/setup/packages.sh
+++ b/scripts/lib/setup/packages.sh
@@ -4,6 +4,8 @@
 # Install checks
 ########
 
+GIT_ROOT=$(git rev-parse --show-toplevel)
+
 function program_exists() {
   local program=$1
   command -v "$program" >/dev/null 2>&1
@@ -25,7 +27,7 @@ function program_version_exists() {
 }
 
 function toolversion() {
-  ./toolversion "${1}"
+  ${GIT_ROOT}/scripts/toolversion "${1}"
 }
 
 ########


### PR DESCRIPTION
Fix for:
```
00:00:24.972 /Users/jenkins/workspace/status-react_prs_ios-e2e_PR-7313/scripts/lib/setup/packages.sh: line 28: ./toolversion: No such file or directory
00:00:24.972 /Users/jenkins/workspace/status-react_prs_ios-e2e_PR-7313/scripts/lib/setup/packages.sh: line 28: ./toolversion: No such file or directory
00:00:24.972 [1;33m+ node version v10.12.0 is installed. node version v is recommended.[0m
00:00:25.278 [1;33m+ yarn version 1.13.0 is installed. yarn version  is recommended.[0m
```
https://ci.status.im/job/status-react/job/prs/job/ios-e2e/job/PR-7313/2/consoleFull