### PR TITLE
use separate jobs for e2e builds, disable aborting for non-pr builds

### DIFF
--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -40,13 +40,13 @@ pipeline {
           ios = cmn.buildBranch('status-react/combined/mobile-ios')
         } } }
         stage('iOS e2e') { steps { script {
-          iose2e = cmn.buildBranch('status-react/combined/mobile-ios', 'e2e')
+          iose2e = cmn.buildBranch('status-react/combined/mobile-ios-e2e')
         } } }
         stage('Android') { steps { script {
           apk = cmn.buildBranch('status-react/combined/mobile-android')
         } } }
         stage('Android e2e') { steps { script {
-          apke2e = cmn.buildBranch('status-react/combined/mobile-android', 'e2e')
+          apke2e = cmn.buildBranch('status-react/combined/mobile-android-e2e')
         } } }
       }
     }

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -25,7 +25,7 @@ pipeline {
   options {
     timestamps()
     /* Prevent Jenkins jobs from running forever */
-    timeout(time: 35, unit: 'MINUTES')
+    timeout(time: 40, unit: 'MINUTES')
     /* Limit builds retained */
     buildDiscarder(logRotator(
       numToKeepStr: '10',

--- a/ci/common.groovy
+++ b/ci/common.groovy
@@ -34,13 +34,18 @@ def getBuildType() {
 
 @NonCPS
 def abortPreviousRunningBuilds() {
+  /* Aborting makes sense only for PR builds, since devs start so many of them */
+  if (!env.JOB_NAME.contains('status-react/prs')) {
+    println ">> Not aborting any previous jobs. Not a PR build."
+    return
+  }
   Run previousBuild = currentBuild.rawBuild.getPreviousBuildInProgress()
 
   while (previousBuild != null) {
     if (previousBuild.isInProgress()) {
       def executor = previousBuild.getExecutor()
       if (executor != null) {
-        echo ">> Aborting older build #${previousBuild.number}"
+        println ">> Aborting older build #${previousBuild.number}"
         executor.interrupt(Result.ABORTED, new UserInterruption(
           "newer build #${currentBuild.number}"
         ))


### PR DESCRIPTION
Our most recent Nightly builds started failing due to a recent change that aborts previously running jobs.
https://github.com/status-im/status-react/pull/7317
Example: https://ci.status.im/job/status-react/job/combined/job/mobile-ios/5615/console
```
Aborted by unknown
00:00:20.416 Sending interrupt signal to process
```
This was intended only for PRs, but nightly builds use the same Jenkins jobs for regular and e2e builds, which causes one to abort the other.

This is a two-fold fix:
* Added separate Jobs for nightlies with `-e2e` suffix to make it clearer which one is which
* Added an `if` statement to avoid abording when build is not a PR build.