### PR TITLE
Migrate old Infura RPC URLs to the new ones for existing accounts.

### DIFF
--- a/src/status_im/data_store/realm/schemas/base/core.cljs
+++ b/src/status_im/data_store/realm/schemas/base/core.cljs
@@ -66,10 +66,15 @@
 
 (def v17 v16)
 
-(def v18 [network/v1
+;; should go through migration of Infura project IDs from old format to new
+(def v18 v17)
+
+(def v19 [network/v1
           bootnode/v4
           extension/v12
           account/v16])
+
+(def v20 v19)
 
 ;; put schemas ordered by version
 (def schemas [{:schema        v1
@@ -125,4 +130,10 @@
                :migration     migrations/v17}
               {:schema        v18
                :schemaVersion 18
-               :migration     migrations/v18}])
+               :migration     migrations/v18}
+              {:schema        v19
+               :schemaVersion 19
+               :migration     migrations/v19}
+              {:schema        v20
+               :schemaVersion 20
+               :migration     migrations/v20}])

--- a/src/status_im/data_store/realm/schemas/base/migrations.cljs
+++ b/src/status_im/data_store/realm/schemas/base/migrations.cljs
@@ -3,6 +3,7 @@
             [cognitect.transit :as transit]
             [clojure.set :as set]
             [clojure.string :as string]
+            [status-im.constants :as constants]
             [status-im.utils.random :as random]))
 
 (def reader (transit/reader :json))
@@ -128,5 +129,70 @@
             updated      (serialize new-settings)]
         (aset account "settings" updated)))))
 
+;; transform inactive legacy network values into the current ones
+(defn transition-rpc-url [rpc-url]
+  (case rpc-url
+    "https://mainnet.infura.io/z6GCTmjdP3FETEJmMBI4"
+    (get-in constants/mainnet-networks ["mainnet_rpc" :config :UpstreamConfig :URL])
+    "https://ropsten.infura.io/z6GCTmjdP3FETEJmMBI4"
+    (get-in constants/testnet-networks ["testnet_rpc" :config :UpstreamConfig :URL])
+    "https://rinkeby.infura.io/z6GCTmjdP3FETEJmMBI4"
+    (get-in constants/testnet-networks ["rinkeby_rpc" :config :UpstreamConfig :URL])
+    rpc-url))
+
+(defn- update-infura-project-id! [network-js]
+  (let [old-config (js->clj
+                    (.parse js/JSON
+                            (aget network-js "config")))]
+    ;; we only transition rpc networks
+    (when (get-in old-config ["UpstreamConfig" "Enabled"])
+      (let [new-config (update-in
+                        old-config
+                        ["UpstreamConfig" "URL"]
+                        transition-rpc-url)]
+        (aset network-js
+              "config"
+              (.stringify js/JSON (clj->js new-config)))))))
+
+(defn- update-infura-project-ids! [networks-js]
+  (dotimes [i (.-length networks-js)]
+    (let [network-js (aget networks-js i)]
+      (update-infura-project-id! network-js))))
+
+(defn- migrate-infura-project-ids! [realm-js]
+  (let [accounts (.objects realm-js "account")]
+    (dotimes [i (.-length accounts)]
+      (let [account  (aget accounts i)
+            networks (aget account "networks")]
+        (update-infura-project-ids! networks)
+        (aset account "networks" networks)))))
+
 (defn v18 [old-realm new-realm]
-  (log/debug "migrating base database v18: " old-realm new-realm))
+  (log/debug "migrating accounts database v18: " old-realm new-realm)
+  (migrate-infura-project-ids! new-realm))
+
+;; used to be v18 migration
+(defn v19 [old-realm new-realm]
+  (log/debug "migrating base database v19: " old-realm new-realm))
+
+(defn v20 [old-realm new-realm]
+  (log/debug "migrating accounts database v20: " old-realm new-realm)
+  ;; Why is this function called twice?
+  ;; We had to release a hotfix that didn't have v18 migration while we had nightlies
+  ;; that already have it. so this `migrate-infura-project-ids!` went as
+  ;; migration no. 18 in the release.
+  ;;
+  ;; Hence, we ended up with 2 branches where migration v18 meant different things:
+  ;; - release 0.9.32-infura-hotfix: v18 means migration of Infura project IDs
+  ;; - nightlies: v18 means empty migration but schema change
+  ;;
+  ;; To be able to migrate from both of these, we
+  ;; (1) swapped migration v18 and v19 in the nigtlies (`develop` branch).
+  ;; (2) create a migration v20 that applies Infura migration again.
+  ;;
+  ;; That way we can upgrade both of the paths:
+  ;; - 0.9.32 that had v18 with Infura transition will apply both v19 and v20, where
+  ;;    v20 will be a no-op.
+  ;; - nightlies that had v18 as an empty transition will apply the empty transition
+  ;;    v19 again, and migrate Infura IDs as v20.
+  (migrate-infura-project-ids! new-realm))


### PR DESCRIPTION
This PR makes a DB migration that transforms old Infura project URLs to the new ones (follow-up to https://github.com/status-im/status-react/pull/7313)

<!-- (Specify if some specific areas has to be tested, for example 1-1 chats) -->
#### Areas that maybe impacted (optional)
**Functional**
- upgrades

<!-- (Specify exact steps to test if there are such) -->
### Steps to test:
- Upgrade Status from previous version
- Login to existing accounts
- Old Infura URLs shouldn't be in the logs.

fixes: #7323

status: ready <!-- Can be ready or wip -->