### PR TITLE
missing variable source

### DIFF
--- a/ci/android.groovy
+++ b/ci/android.groovy
@@ -40,7 +40,7 @@ def uploadToSauceLabs() {
   if (changeId != null) {
     env.SAUCE_LABS_NAME = "${changeId}.apk"
   } else {
-    def pkg = cmn.pkgFilename(type, 'apk')
+    def pkg = cmn.pkgFilename(cmn.getBuildType(), 'apk')
     env.SAUCE_LABS_NAME = "${pkg}"
   }
   withCredentials([


### PR DESCRIPTION
Tiny fix for nightly e2e builds.

Example:
```
[Pipeline] End of Pipeline
groovy.lang.MissingPropertyException: No such property: type for class: Script5
	at org.codehaus.groovy.runtime.ScriptBytecodeAdapter.unwrap(ScriptBytecodeAdapter.java:53)
	at org.codehaus.groovy.runtime.ScriptBytecodeAdapter.getProperty(ScriptBytecodeAdapter.java:458)
```
https://ci.status.im/job/status-react/job/combined/job/mobile-android-e2e/1/console