### PR TITLE
Stop sending seen messages

### DIFF
--- a/src/status_im/chat/models.cljs
+++ b/src/status_im/chat/models.cljs
@@ -209,7 +209,8 @@
                                         updated-statuses)
                  :data-store/tx [(user-statuses-store/save-statuses-tx updated-statuses)]}
                 (update-chats-unviewed-messages-count {:chat-id chat-id})
-                (send-messages-seen chat-id loaded-unviewed-ids)
+                ;;TODO(rasom): uncomment when seen messages will be revisited
+                #_(send-messages-seen chat-id loaded-unviewed-ids)
                 (when platform/desktop?
                   (update-dock-badge-label))))))
 

--- a/src/status_im/chat/models/message.cljs
+++ b/src/status_im/chat/models/message.cljs
@@ -198,10 +198,11 @@
                                                        current-chat? :seen
                                                        :else :received))
               (commands-receiving/receive message)
-              (send-message-seen chat-id message-id (and (not group-chat)
-                                                         current-chat?
-                                                         (not (= constants/system from))
-                                                         (not (:outgoing message)))))))
+              ;;TODO(rasom): uncomment when seen messages will be revisited
+              #_(send-message-seen chat-id message-id (and (not group-chat)
+                                                           current-chat?
+                                                           (not (= constants/system from))
+                                                           (not (:outgoing message)))))))
 
 (fx/defn update-group-messages [cofx chat->message chat-id]
   (fx/merge cofx

--- a/test/cljs/status_im/test/chat/models.cljs
+++ b/test/cljs/status_im/test/chat/models.cljs
@@ -245,10 +245,11 @@
   (testing "With empty unviewed set, no effects are produced"
     (is (= nil (chat/mark-messages-seen {:db test-db} "opened"))))
 
-  (testing "For 1-1 chat, we send seen messages confirmation to the recipient as well"
-    (is (= #{"4" "5" "6"}
-           (set (get-in (chat/mark-messages-seen {:db test-db} "1-1")
-                        [:shh/post 0 :message :payload :message-ids]))))))
+  #_(testing "For 1-1 chat, we send seen messages confirmation to the
+  recipient as well"
+      (is (= #{"4" "5" "6"}
+             (set (get-in (chat/mark-messages-seen {:db test-db} "1-1")
+                          [:shh/post 0 :message :payload :message-ids]))))))
 
 (deftest update-dock-badge-label
   (testing "When user has unseen private messages"

--- a/test/cljs/status_im/test/chat/models/message.cljs
+++ b/test/cljs/status_im/test/chat/models/message.cljs
@@ -162,10 +162,10 @@
                       :clock-value 1
                       :timestamp   0}
         extract-seen (comp :payload :message first :shh/post)]
-    (testing "it send a seen message when the chat is 1-to-1 and is open"
-      (is (instance? protocol/MessagesSeen
-                     (extract-seen (message/receive-many cofx [message]))))
-      (is (= #{"1"} (:message-ids (extract-seen (message/receive-many cofx [message]))))))
+    #_(testing "it sends a seen message when the chat is 1-to-1 and is open"
+        (is (instance? protocol/MessagesSeen
+                       (extract-seen (message/receive-many cofx [message]))))
+        (is (= #{"1"} (:message-ids (extract-seen (message/receive-many cofx [message]))))))
     (testing "it does not send any when the chat is a group-chat"
       (is (nil? (extract-seen
                  (message/receive-many


### PR DESCRIPTION
Currently, these messages are not used and should be properly revisited
later. It only generates extra traffic on discovery topic.

status: ready