### PR TITLE
Publish contact updates & contact code periodically

### DIFF
--- a/src/status_im/accounts/create/core.cljs
+++ b/src/status_im/accounts/create/core.cljs
@@ -102,12 +102,15 @@
   [{db :db} input-key text]
   {:db (update db :accounts/create merge {input-key text :error nil})})
 
-(defn account-set-name [{{:accounts/keys [create] :as db} :db :as cofx}]
+(defn account-set-name [{{:accounts/keys [create] :as db} :db now :now :as cofx}]
   (fx/merge cofx
             {:db                                  (assoc db :accounts/create {:show-welcome? true})
              :notifications/request-notifications-permissions nil
              :dispatch                            [:navigate-to :home]}
-            (accounts.update/account-update {:name (:name create)} {})))
+            ;; We set last updated as we are actually changing a field,
+            ;; unlike on recovery where the name is not set
+            (accounts.update/account-update {:last-updated now
+                                             :name (:name create)} {})))
 
 (fx/defn next-step
   [{:keys [db] :as cofx} step password password-confirm]

--- a/src/status_im/accounts/update/publisher.cljs
+++ b/src/status_im/accounts/update/publisher.cljs
@@ -1,0 +1,43 @@
+(ns status-im.accounts.update.publisher
+  (:require [status-im.constants :as constants]
+            [status-im.accounts.update.core :as accounts]
+            [status-im.pairing.core :as pairing]
+            [status-im.data-store.accounts :as accounts-store]
+            [status-im.transport.shh :as shh]
+            [status-im.utils.fx :as fx]))
+
+;; Publish updates every 48 hours
+(def publish-updates-interval (* 48 60 60 1000))
+
+(defn publish-update! [{:keys [db now web3]}]
+  (let [my-public-key (get-in db [:account/account :public-key])
+        peers-count (:peers-count db)
+        last-updated (get-in
+                      db
+                      [:account/account :last-updated])]
+    (when (and (pos? peers-count)
+               (pos? last-updated)
+               (< publish-updates-interval
+                  (- now last-updated)))
+      (let [public-keys  (accounts/contact-public-keys {:db db})
+            payload      (accounts/account-update-message {:db db})
+            sync-message (pairing/sync-installation-account-message {:db db})]
+        (doseq [pk public-keys]
+          (shh/send-direct-message!
+           web3
+           {:pubKey pk
+            :sig my-public-key
+            :chat constants/contact-discovery
+            :payload payload}
+           [:accounts.update.callback/published]
+           [:accounts.update.callback/failed-to-publish]
+           1))
+        (shh/send-direct-message!
+         web3
+         {:pubKey my-public-key
+          :sig my-public-key
+          :chat constants/contact-discovery
+          :payload sync-message}
+         [:accounts.update.callback/published]
+         [:accounts.update.callback/failed-to-publish]
+         1)))))

--- a/src/status_im/chat/models.cljs
+++ b/src/status_im/chat/models.cljs
@@ -4,8 +4,10 @@
             [status-im.data-store.chats :as chats-store]
             [status-im.data-store.messages :as messages-store]
             [status-im.data-store.user-statuses :as user-statuses-store]
+            [status-im.contact-code.core :as contact-code]
             [status-im.i18n :as i18n]
             [status-im.transport.chat.core :as transport.chat]
+            [status-im.transport.utils :as transport.utils]
             [status-im.transport.message.protocol :as protocol]
             [status-im.transport.message.public-chat :as public-chat]
             [status-im.ui.components.colors :as colors]
@@ -27,6 +29,9 @@
    (:group-chat chat))
   ([cofx chat-id]
    (multi-user-chat? (get-chat cofx chat-id))))
+
+(def one-to-one-chat?
+  (complement multi-user-chat?))
 
 (defn public-chat?
   ([chat]
@@ -142,6 +147,8 @@
                (transport.chat/unsubscribe-from-chat % chat-id))
             (deactivate-chat chat-id)
             (clear-history chat-id)
+            #(when (one-to-one-chat? % chat-id)
+               (contact-code/stop-listening % chat-id))
             (navigation/navigate-to-cofx :home {})))
 
 (fx/defn send-messages-seen
@@ -217,10 +224,12 @@
 (fx/defn preload-chat-data
   "Takes chat-id and coeffects map, returns effects necessary when navigating to chat"
   [{:keys [db] :as cofx} chat-id]
-  (fx/merge cofx
-            {:db (-> (assoc db :current-chat-id chat-id)
-                     (set-chat-ui-props {:validation-messages nil}))}
-            (mark-messages-seen chat-id)))
+  (let [chat (get-in db [:chats chat-id])]
+    (fx/merge cofx
+              {:db (-> (assoc db :current-chat-id chat-id)
+                       (set-chat-ui-props {:validation-messages nil}))}
+              (contact-code/listen-to-chat chat-id)
+              (mark-messages-seen chat-id))))
 
 (fx/defn navigate-to-chat
   "Takes coeffects map and chat-id, returns effects necessary for navigation and preloading data"

--- a/src/status_im/contact/core.cljs
+++ b/src/status_im/contact/core.cljs
@@ -7,8 +7,11 @@
             [status-im.data-store.messages :as data-store.messages]
             [status-im.data-store.chats :as data-store.chats]
             [status-im.i18n :as i18n]
+            [status-im.transport.utils :as transport.utils]
             [status-im.transport.message.contact :as message.contact]
+            [status-im.transport.message.public-chat :as transport.public-chat]
             [status-im.transport.message.protocol :as protocol]
+            [status-im.contact-code.core :as contact-code]
             [status-im.ui.screens.add-new.new-chat.db :as new-chat.db]
             [status-im.ui.screens.navigation :as navigation]
             [status-im.utils.fx :as fx]
@@ -47,16 +50,15 @@
      :address       address
      :fcm-token     fcm-token}))
 
-(fx/defn add-new-contact [{:keys [db]} {:keys [public-key] :as contact}]
-  (let [new-contact (assoc contact
-                           :pending? false
-                           :hide-contact? false
-                           :public-key public-key)]
-    {:db            (-> db
-                        (update-in [:contacts/contacts public-key]
-                                   merge new-contact)
-                        (assoc-in [:contacts/new-identity] ""))
-     :data-store/tx [(contacts-store/save-contact-tx new-contact)]}))
+(fx/defn upsert-contact [{:keys [db] :as cofx}
+                         {:keys [pending?
+                                 public-key] :as contact}]
+  (fx/merge cofx
+            {:db            (-> db
+                                (update-in [:contacts/contacts public-key] merge contact))
+             :data-store/tx [(contacts-store/save-contact-tx contact)]}
+            #(when-not pending?
+               (contact-code/listen-to-chat % public-key))))
 
 (fx/defn send-contact-request
   [{:keys [db] :as cofx} {:keys [public-key pending? dapp?] :as contact}]
@@ -65,11 +67,16 @@
       (protocol/send (message.contact/map->ContactRequestConfirmed (own-info db)) public-key cofx)
       (protocol/send (message.contact/map->ContactRequest (own-info db)) public-key cofx))))
 
-(fx/defn add-contact [{:keys [db] :as cofx} public-key]
+(fx/defn add-contact
+  "Add a contact and set pending to false"
+  [{:keys [db] :as cofx} public-key]
   (when (not= (get-in db [:account/account :public-key]) public-key)
-    (let [contact (build-contact cofx public-key)]
+    (let [contact (-> (build-contact cofx public-key)
+                      (assoc :pending? false
+                             :hide-contact? false))]
       (fx/merge cofx
-                (add-new-contact contact)
+                {:db (assoc-in db [:contacts/new-identity] "")}
+                (upsert-contact contact)
                 (send-contact-request contact)))))
 
 (fx/defn add-contacts-filter [{:keys [db]} public-key action]
@@ -244,10 +251,7 @@
         (when-not (= contact-props
                      (select-keys contact [:public-key :address :photo-path
                                            :name :fcm-token :pending?]))
-          {:db            (update-in db [:contacts/contacts public-key]
-                                     merge contact-props)
-           :data-store/tx [(contacts-store/save-contact-tx
-                            contact-props)]})))))
+          (upsert-contact cofx contact-props))))))
 
 (def receive-contact-request handle-contact-update)
 (def receive-contact-request-confirmation handle-contact-update)

--- a/src/status_im/contact_code/core.cljs
+++ b/src/status_im/contact_code/core.cljs
@@ -1,0 +1,94 @@
+(ns status-im.contact-code.core
+  "This namespace is used to listen for and publish contact-codes. We want to listen
+  to contact codes once we engage in the conversation with someone, or once someone is
+  in our contacts."
+  (:require
+   [taoensso.timbre :as log]
+   [status-im.utils.fx :as fx]
+   [status-im.transport.shh :as shh]
+   [status-im.transport.message.public-chat :as transport.public-chat]
+   [status-im.data-store.accounts :as data-store.accounts]
+   [status-im.transport.chat.core :as transport.chat]
+   [status-im.accounts.db :as accounts.db]))
+
+(defn topic [pk]
+  (str pk "-contact-code"))
+
+(fx/defn listen [cofx chat-id]
+  (transport.public-chat/join-public-chat
+   cofx
+   (topic chat-id)))
+
+(fx/defn listen-to-chat
+  "For a one-to-one chat, listen to the pk of the user, for a group chat
+  listen for any member"
+  [cofx chat-id]
+  (let [{:keys [members
+                public?
+                is-active
+                group-chat]} (get-in cofx [:db :chats chat-id])]
+    (when is-active
+      (cond
+        (and group-chat
+             (not public?))
+        (apply fx/merge cofx
+               (map listen members))
+        (not public?)
+        (listen cofx chat-id)))))
+
+(fx/defn stop-listening
+  "We can stop listening to contact codes when we don't have any active chat
+  with the user (one-to-one or group-chat), and it is not in our contacts"
+  [{:keys [db] :as cofx} their-public-key]
+  (let [my-public-key (accounts.db/current-public-key cofx)
+        active-group-chats (filter (fn [{:keys [is-active members members-joined]}]
+                                     (and is-active
+                                          (contains? members-joined my-public-key)
+                                          (contains? members their-public-key)))
+                                   (vals (:chats db)))]
+    (when (and (not= false (get-in db [:contacts/contacts their-public-key :pending?]))
+               (not= my-public-key their-public-key)
+               (not (get-in db [:chats their-public-key :is-active]))
+               (empty? active-group-chats))
+
+      (fx/merge
+       cofx
+       (transport.chat/unsubscribe-from-chat (topic their-public-key))))))
+
+;; Publish contact code every 12hrs
+(def publish-contact-code-interval (* 12 60 60 1000))
+
+(fx/defn init [cofx]
+  (log/debug "initializing contact-code")
+  (let [current-public-key (accounts.db/current-public-key cofx)]
+    (listen cofx current-public-key)))
+
+(defn publish! [{:keys [web3 now] :as cofx}]
+  (let [current-public-key (accounts.db/current-public-key cofx)
+        chat-id (topic current-public-key)
+        peers-count (:peers-count @re-frame.db/app-db)
+        last-published (get-in
+                        @re-frame.db/app-db
+                        [:account/account :last-published-contact-code])]
+    (when (and (pos? peers-count)
+               (< publish-contact-code-interval
+                  (- now last-published)))
+
+      (let [message {:chat chat-id
+                     :sig  current-public-key
+                     :payload ""}]
+        (shh/send-public-message!
+         web3
+         message
+         [:contact-code.callback/contact-code-published]
+         :contact-code.callback/contact-code-publishing-failed)))))
+
+(fx/defn published [{:keys [now db] :as cofx}]
+  (let [new-account (assoc (:account/account db)
+                           :last-published-contact-code
+                           now)]
+    {:db (assoc db :account/account new-account)
+     :data-store/base-tx [(data-store.accounts/save-account-tx new-account)]}))
+
+(fx/defn publishing-failed [cofx]
+  (log/warn "failed to publish contact-code"))

--- a/src/status_im/data_store/realm/schemas/base/account.cljs
+++ b/src/status_im/data_store/realm/schemas/base/account.cljs
@@ -230,3 +230,6 @@
                                         {:type "string[]" :optional true}
                                         :recent-stickers
                                         {:type "string[]" :optional true}}))
+(def v20 (assoc-in v19
+                   [:properties :last-published-contact-code]
+                   {:type :int :default 0}))

--- a/src/status_im/data_store/realm/schemas/base/core.cljs
+++ b/src/status_im/data_store/realm/schemas/base/core.cljs
@@ -93,6 +93,11 @@
 
 (def v24 v23)
 
+(def v25 [network/v1
+          bootnode/v4
+          extension/v12
+          account/v20])
+
 ;; put schemas ordered by version
 (def schemas [{:schema        v1
                :schemaVersion 1
@@ -165,4 +170,7 @@
                :migration     (constantly nil)}
               {:schema        v24
                :schemaVersion 24
-               :migration     migrations/v24}])
+               :migration     migrations/v24}
+              {:schema        v25
+               :schemaVersion 25
+               :migration     (constantly nil)}])

--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -31,6 +31,7 @@
             [status-im.network.core :as network]
             [status-im.notifications.core :as notifications]
             [status-im.pairing.core :as pairing]
+            [status-im.contact-code.core :as contact-code]
             [status-im.privacy-policy.core :as privacy-policy]
             [status-im.protocol.core :as protocol]
             [status-im.qr-scanner.core :as qr-scanner]
@@ -153,6 +154,17 @@
  :accounts.ui/mainnet-warning-shown
  (fn [cofx _]
    (accounts.update/account-update cofx {:mainnet-warning-shown? true} {})))
+
+(handlers/register-handler-fx
+ :accounts.update.callback/published
+ (fn [{:keys [now] :as cofx} _]
+   (accounts.update/account-update cofx {:last-updated now} {})))
+
+(handlers/register-handler-fx
+ :accounts.update.callback/failed-to-publish
+ (fn [{:keys [now] :as cofx} [_ message]]
+   (log/warn "failed to publish account update" message)
+   (accounts.update/account-update cofx {:last-updated now} {})))
 
 (handlers/register-handler-fx
  :accounts.ui/dev-mode-switched
@@ -1582,6 +1594,16 @@
  :set-initial-props
  (fn [cofx [_ initial-props]]
    {:db (assoc (:db cofx) :initial-props initial-props)}))
+
+(handlers/register-handler-fx
+ :contact-code.callback/contact-code-published
+ (fn [cofx arg]
+   (contact-code/published cofx)))
+
+(handlers/register-handler-fx
+ :contact-code.callback/contact-code-publishing-failed
+ (fn [cofx _]
+   (contact-code/publishing-failed cofx)))
 
 (handlers/register-handler-fx
  :pairing.ui/enable-installation-pressed

--- a/src/status_im/transport/filters.cljs
+++ b/src/status_im/transport/filters.cljs
@@ -108,8 +108,9 @@
 
 (re-frame/reg-fx
  :shh/remove-filter
- (fn [{:keys [filter] :as params}]
-   (when filter (remove-filter! params))))
+ (fn [filters]
+   (doseq [{:keys [filter] :as params} filters]
+     (when filter (remove-filter! params)))))
 
 (re-frame/reg-fx
  :shh/remove-filters

--- a/src/status_im/utils/async.cljs
+++ b/src/status_im/utils/async.cljs
@@ -50,3 +50,53 @@
       (run-task task-fn)
       (recur (async/<! task-queue)))
     task-queue))
+
+;; ---------------------------------------------------------------------------
+;; Periodic background job
+;; ---------------------------------------------------------------------------
+
+(defn async-periodic-run!
+  ([async-periodic-chan]
+   (async-periodic-run! async-periodic-chan true))
+  ([async-periodic-chan worker-fn]
+   (async/put! async-periodic-chan worker-fn)))
+
+(defn async-periodic-stop! [async-periodic-chan]
+  (async/close! async-periodic-chan))
+
+(defn async-periodic-exec
+  "Periodically execute an function.
+
+  Takes a work-fn of one argument `finished-fn -> any` this function
+  is passed a finished-fn that must be called to signal that the work
+  being performed in the work-fn is finished.
+
+  Returns a go channel that represents a way to control the looping process.
+
+  Stop the polling loop with `async-periodic-stop!`
+
+  The work-fn can be forced to run immediately with `async-periodic-run!`
+
+  Or you can queue up another fn `finished-fn -> any` to execute on
+  the queue with `async-periodic-run!`."
+  [work-fn interval-ms timeout-ms]
+  {:pre [(fn? work-fn) (integer? interval-ms) (integer? timeout-ms)]}
+  (let [do-now-chan (async/chan (async/sliding-buffer 1))
+        try-it (fn [exec-fn catch-fn] (try (exec-fn) (catch :default e (catch-fn e))))]
+    (async/go-loop []
+      (let [timeout-chan (timeout interval-ms)
+            finished-chan (async/promise-chan)
+            [v ch] (async/alts! [do-now-chan timeout-chan])
+            worker (if (and (= ch do-now-chan) (fn? v))
+                     v work-fn)]
+        (when-not (and (= ch do-now-chan) (nil? v))
+          ;; don't let try catch be parsed by go-block
+          (try-it #(worker (fn [] (async/put! finished-chan true)))
+                  (fn [e]
+                    (log/error "failed to run job" e)
+                    ;; if an error occurs in work-fn log it and consider it done
+                    (async/put! finished-chan true)))
+          ;; sanity timeout for work-fn
+          (async/alts! [finished-chan (timeout timeout-ms)])
+          (recur))))
+    do-now-chan))

--- a/src/status_im/utils/fx.cljs
+++ b/src/status_im/utils/fx.cljs
@@ -12,7 +12,7 @@
 (def ^:private mergable-keys
   #{:data-store/tx :data-store/base-tx :chat-received-message/add-fx
     :shh/add-new-sym-keys :shh/get-new-sym-keys :shh/post
-    :shh/send-direct-message
+    :shh/send-direct-message :shh/remove-filter
     :shh/generate-sym-key-from-password  :transport/confirm-messages-processed
     :group-chats/extract-membership-signature :utils/dispatch-later})
 

--- a/src/status_im/utils/publisher.cljs
+++ b/src/status_im/utils/publisher.cljs
@@ -1,0 +1,42 @@
+(ns status-im.utils.publisher
+  (:require [re-frame.core :as re-frame]
+            [re-frame.db]
+            [status-im.accounts.update.publisher :as accounts]
+            [status-im.contact-code.core :as contact-code]
+            [status-im.utils.async :as async-util]
+            [status-im.utils.datetime :as datetime]
+            [status-im.utils.fx :as fx]))
+
+(defonce polling-executor (atom nil))
+(def sync-interval-ms 120000)
+(def sync-timeout-ms  20000)
+
+(defn- start-publisher! [web3]
+  (when @polling-executor
+    (async-util/async-periodic-stop! @polling-executor))
+  (reset! polling-executor
+          (async-util/async-periodic-exec
+           (fn [done-fn]
+             (let [cofx {:web3 web3
+                         :now  (datetime/timestamp)
+                         :db   @re-frame.db/app-db}]
+               (accounts/publish-update! cofx)
+               (contact-code/publish! cofx)
+               (done-fn)))
+           sync-interval-ms
+           sync-timeout-ms)))
+
+(re-frame/reg-fx
+ ::start-publisher
+ #(start-publisher! %))
+
+(re-frame/reg-fx
+ ::stop-publisher
+ #(when @polling-executor
+    (async-util/async-periodic-stop! @polling-executor)))
+
+(fx/defn start-fx [{:keys [web3]}]
+  {::start-publisher web3})
+
+(fx/defn stop-fx [cofx]
+  {::stop-publisher []})

--- a/test/cljs/status_im/test/chat/models.cljs
+++ b/test/cljs/status_im/test/chat/models.cljs
@@ -168,7 +168,7 @@
     (testing "it adds the relevant transactions for realm"
       (let [actual (chat/remove-chat cofx chat-id)]
         (is (:data-store/tx actual))
-        (is (= 3 (count (:data-store/tx actual))))))))
+        (is (= 5 (count (:data-store/tx actual))))))))
 
 (deftest multi-user-chat?
   (let [chat-id "1"]

--- a/test/cljs/status_im/test/contact_code/core.cljs
+++ b/test/cljs/status_im/test/contact_code/core.cljs
@@ -1,0 +1,78 @@
+(ns status-im.test.contact-code.core
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [status-im.contact-code.core :as contact-code]))
+
+(def me "me")
+(def member-1 "member-1")
+(def member-1-topic "member-1-contact-code")
+(def member-2 "member-2")
+(def member-2-topic "member-2-contact-code")
+(def chat-id "chat-id")
+(def chat-id-topic "chat-id-contact-code")
+
+(deftest listen-to-chat
+  (testing "an inactive chat"
+    (testing "it does nothing"
+      (is (not (contact-code/listen-to-chat {:db {}} chat-id)))))
+  (testing "an active 1-to-1 chat"
+    (testing "it listen to the topic"
+      (is (get-in
+           (contact-code/listen-to-chat {:db {:chats {chat-id {:is-active true}}}}
+                                        chat-id)
+           [:db :transport/chats chat-id-topic]))))
+  (testing "an active group chat"
+    (testing "it listen to any member"
+      (let [transport (get-in
+                       (contact-code/listen-to-chat {:db {:chats {chat-id
+                                                                  {:is-active true
+                                                                   :group-chat true
+                                                                   :members #{member-1
+                                                                              member-2}}}}}
+                                                    chat-id)
+                       [:db :transport/chats])]
+        (is (not (get transport chat-id-topic)))
+        (is (get transport member-1-topic))
+        (is (get transport member-2-topic))))))
+
+(deftest stop-listening
+  (testing "the user is in our contacts"
+    (testing "it does not remove transport"
+      (is (not (contact-code/stop-listening {:db {:contacts/contacts
+                                                  {chat-id {:pending? false}}}}
+                                            chat-id)))))
+  (testing "the user is not in our contacts"
+    (testing "the user is not in any group chats or 1-to1-"
+      (testing "it removes the transport"
+        (let [transport (contact-code/stop-listening {:db {:transport/chats
+                                                           {chat-id-topic {}}}}
+                                                     chat-id)]
+          (is transport)
+          (is (not (get transport chat-id-topic))))))
+    (testing "the user is still in some group chats"
+      (testing "we joined, and group chat is active it does not remove transport"
+        (let [transport (contact-code/stop-listening {:db {:account/account {:public-key me}
+                                                           :chats
+                                                           {chat-id {:is-active true
+                                                                     :members-joined #{me}
+                                                                     :members #{member-1}}}
+                                                           :transport/chats
+                                                           {member-1-topic {}}}}
+                                                     member-1)]
+          (is (not transport))))
+      (testing "we didn't join, it removes transport"
+        (let [transport (contact-code/stop-listening {:db {:account/account {:public-key me}
+                                                           :chats
+                                                           {chat-id {:is-active true
+                                                                     :members-joined #{member-1}
+                                                                     :members #{member-1}}}
+                                                           :transport/chats
+                                                           {member-1-topic {}}}}
+                                                     member-1)]
+          (is transport)
+          (is (not (get transport member-1-topic))))))
+    (testing "we have a 1-to-1 chat with the user"
+      (testing "it does not remove transport"
+        (let [transport (contact-code/stop-listening {:db {:chats
+                                                           {member-1 {:is-active true}}}}
+                                                     member-1)]
+          (is (not transport)))))))

--- a/test/cljs/status_im/test/models/contact.cljs
+++ b/test/cljs/status_im/test/models/contact.cljs
@@ -29,7 +29,7 @@
                    :profile-image "image"
                    :address "address"
                    :fcm-token "token"}
-                  {})
+                  {:db {}})
           contact (get-in actual [:db :contacts/contacts public-key])]
       (testing "it stores the contact in the database"
         (is (:data-store/tx actual)))

--- a/test/cljs/status_im/test/runner.cljs
+++ b/test/cljs/status_im/test/runner.cljs
@@ -59,6 +59,7 @@
             [status-im.test.accounts.recover.core]
             [status-im.test.hardwallet.core]
             [status-im.test.contact-recovery.core]
+            [status-im.test.contact-code.core]
             [status-im.test.ui.screens.currency-settings.models]
             [status-im.test.ui.screens.wallet.db]
             [status-im.test.sign-in.flow]))
@@ -131,6 +132,7 @@
  'status-im.test.ui.screens.wallet.db
  'status-im.test.browser.core
  'status-im.test.contact-recovery.core
+ 'status-im.test.contact-code.core
  'status-im.test.extensions.ethereum
  'status-im.test.browser.permissions
  'status-im.test.sign-in.flow)


### PR DESCRIPTION
## Contact updates
Currently it's very easy for contact details to get out of sync, the
simplest example is:
A & B are contacts.
A changes name.
B receives the updated name.
B re-install the app.
Until A changes name again, B will not see their name, picture and won't
be able to send push notifications.

This PR changes the behavior to publish account informations to contacts
every 48 hrs, to add some redundancy in this cases.

## Contact code

This PR also publishes contact codes periodically to a public channel, once every 12hrs.
This allow other peers to fetch our information so that they can contact securely using PFS and include all our devices.
This change leaks some metadata, namely if you have been online in the past 12 hours, but it's the same as publishing on swarm/ipfs, we are trading off some darkness for stronger encryption and usability.

### Testing

It's a bit hard to test as the problem only shows after the contact request is not on the mailserver anymore.
Theoretically it goes like this:

1) Create account A
2) Create account B
3) Add B to contacts from A
4) You should now see contact details of A on B
5) Change clock on B to +2 days
6) Unistall/Reinstall  the app on B
7) Login, make sure you are connected, wait until messages are fetched on the mailserver. Check that A is not in your contacts (any message should not have their name). Make sure you can receive messages.
8) Change clock on A +2 days, make sure you are online and connected.
9) Wait a few minutes (+/- 5 mins).

You should see contact information of A on B eventually.

Mind that any time you change the clock, things might get a bit weird (you might go offline/online/offline etc). Generally login/logout fixes it.

status: ready