### PR TITLE
[FIX #7344] Update args of eth_getLogs

### DIFF
--- a/src/status_im/extensions/ethereum.cljs
+++ b/src/status_im/extensions/ethereum.cljs
@@ -312,8 +312,8 @@
     :else block))
 
 (defn- execute-get-logs [_ {:keys [from to address topics block-hash] :as m}]
-  (let [params [{:from      (ensure-hex-bn from)
-                 :to        (ensure-hex-bn to)
+  (let [params [{:fromBlock      (ensure-hex-bn from)
+                 :toBlock        (ensure-hex-bn to)
                  :address   address
                  :topics    (generate-topic topics)
                  :blockhash block-hash}]]


### PR DESCRIPTION
fixes #7344 

### Summary:

[comment]: # (Summarise the problem and how the pull request solves it)
This PR updates execute-get-logs fn with right args for eth_getLogs

<!-- (Specify exact steps to test if there are such) -->
### Steps to test:
- Use ethereum/logs event in a custom extension with `to` and `from` args 

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->
