### PR TITLE
Fix issues found when running `make setup` on clean MacOS/Linux systems

### DIFF
--- a/ci/common.groovy
+++ b/ci/common.groovy
@@ -93,7 +93,6 @@ def installJSDeps(platform) {
   def maxAttempts = 10
   def installed = false
   /* prepare environment for specific platform build */
-  sh "scripts/run-environment-check.sh ${platform}"
   sh "scripts/prepare-for-platform.sh ${platform}"
   while (!installed && attempt <= maxAttempts) {
     println "#${attempt} attempt to install npm deps"

--- a/docker/android/Makefile
+++ b/docker/android/Makefile
@@ -24,13 +24,12 @@ IMAGE_NAME = statusteam/status-build-android:$(IMAGE_TAG)
 
 build: $(ANDROID_NDK_ARCHIVE) $(ANDROID_SDK_ARCHIVE)
 	docker build \
-        --build-arg="BASE_IMAGE_TAG=$(BASE_IMAGE_TAG)" \
-        --build-arg="ANDROID_NDK_VERSION=$(ANDROID_NDK_VERSION)" \
-        --build-arg="ANDROID_SDK_VERSION=$(ANDROID_SDK_VERSION)" \
-        --build-arg="SDK_PLATFORM_VERSION=$(SDK_PLATFORM_VERSION)" \
-        --build-arg="SDK_BUILD_TOOLS_VERSION=$(SDK_BUILD_TOOLS_VERSION)" \
-        --label="commit=$(GIT_COMMIT)" \
-        -t $(IMAGE_NAME) .
+		--build-arg="ANDROID_NDK_VERSION=$(ANDROID_NDK_VERSION)" \
+		--build-arg="ANDROID_SDK_VERSION=$(ANDROID_SDK_VERSION)" \
+		--build-arg="SDK_PLATFORM_VERSION=$(SDK_PLATFORM_VERSION)" \
+		--build-arg="SDK_BUILD_TOOLS_VERSION=$(SDK_BUILD_TOOLS_VERSION)" \
+		--label="commit=$(GIT_COMMIT)" \
+		-t $(IMAGE_NAME) .
 
 $(ANDROID_NDK_ARCHIVE):
 	wget -q "$(ANDROID_NDK_URL)" -O "$(ANDROID_NDK_ARCHIVE)"
@@ -42,11 +41,11 @@ $(ANDROID_SDK_ARCHIVE):
 
 test: ## Run build inside the image as a test
 	docker run -u $(shell id -u):$(shell id -g) \
-        --name android-test --rm \
-        --tmpfs /var/tmp:rw,size=1G,exec,mode=1777 \
-        -v $(GIT_ROOT):/repo:rw \
-        -w /repo $(IMAGE_NAME) \
-        docker/android/build.sh
+		--name android-test --rm \
+		--tmpfs /var/tmp:rw,size=1G,exec,mode=1777 \
+		-v $(GIT_ROOT):/repo:rw \
+		-w /repo $(IMAGE_NAME) \
+		docker/android/build.sh
 
 push: build
 	docker push $(IMAGE_NAME)

--- a/scripts/generate-keystore.sh
+++ b/scripts/generate-keystore.sh
@@ -17,5 +17,7 @@ STATUS_RELEASE_KEY_PASSWORD=$(property_gradle 'STATUS_RELEASE_KEY_PASSWORD')
 [[ -e "${STORE_FILE/#\~/$HOME}" ]] && echo "Keystore $STORE_FILE already exists, please manually remove it if you want to regenerate." && exit 0
 
 echo "Generating keystore $STORE_FILE"
+keydirname="$( dirname "$STORE_FILE" )"
+[ -d $keydirname ] || mkdir -p $keydirname
 keytool -genkey -v -keystore ${STORE_FILE}  -keyalg RSA -keysize 2048 -validity 10000 -alias ${STATUS_RELEASE_KEY_ALIAS} \
         -storepass ${STATUS_RELEASE_STORE_PASSWORD} -keypass ${STATUS_RELEASE_KEY_PASSWORD} -dname "CN=, OU=, O=, L=, S=, C="

--- a/scripts/lib/setup/packages.sh
+++ b/scripts/lib/setup/packages.sh
@@ -202,9 +202,10 @@ function load_rvm_if_available() {
 ###############
 
 function load_nvm_if_available() {
-  [ -f ~/.nvm/nvm.sh ] && source ~/.nvm/nvm.sh
+  local nvm_path=${NVM_DIR:-~/.nvm}
+  [ -f ${nvm_path}/nvm.sh ] && chmod +x ${nvm_path}/nvm.sh && source ${nvm_path}/nvm.sh
 }
 
 function nvm_installed() {
-  program_exists "nvm"
+  declare -F nvm &>/dev/null
 }

--- a/scripts/prepare-for-platform.sh
+++ b/scripts/prepare-for-platform.sh
@@ -31,7 +31,7 @@ fi
 
 scripts/run-environment-check.sh $1
 
-echo "Creating link: package.json -> ${PLATFORM_FOLDER}/package.json.orig "
+echo "Creating link: package.json -> ${PLATFORM_FOLDER}/package.json.orig"
 ln -sf ${PLATFORM_FOLDER}/package.json.orig package.json
 
 echo "Creating link: yarn.lock -> ${PLATFORM_FOLDER}/yarn.lock"

--- a/scripts/run-environment-check.sh
+++ b/scripts/run-environment-check.sh
@@ -14,8 +14,7 @@ source_lib "packages.sh"
 EXPECTED_NODE_VERSION="v$(toolversion node)" # note the 'v' in front, that is how node does versioning
 EXPECTED_YARN_VERSION="$(toolversion yarn)" # note the lack of 'v' in front. inconsistent. :(
 
-#if no arguments passed, inform user about possible ones
-
+# if no arguments passed, inform user about possible ones
 if [ $# -eq 0 ]; then
   echo -e "${GREEN}This script should be invoked with platform argument: 'android', 'ios' or 'desktop'${NC}"
   exit 1
@@ -23,12 +22,13 @@ else
   PLATFORM=$1
 fi
 
-if ! program_version_exists node $EXPECTED_NODE_VERSION || ! program_exists yarn $EXPECTED_YARN_VERSION; then
-  echo -e "${YELLOW}**********************************************************************************************"
+load_nvm_if_available
+
+if ! program_exists node || ! program_exists yarn; then
+  echo -e "${YELLOW}********************************************************************************************"
 
   nvmrc="./.nvmrc"
-  if [ -e "$nvmrc" ]; then
-    node_version=$(node -v)
+  if [ -e "$nvmrc" ] && nvm_installed; then
     version_alias=$(cat "$nvmrc")
     echo -e "Please run 'nvm use $version_alias' in the terminal and try again."
   else
@@ -56,7 +56,7 @@ fi
 
 if [[ $PLATFORM == 'android' ]]; then
   _localPropertiesPath=./android/local.properties
-  if ! grep -Fq "ndk.dir" $_localPropertiesPath > /dev/null; then
+  if [ ! -f $_localPropertiesPath ] || ! grep -Fq "ndk.dir" $_localPropertiesPath > /dev/null; then
     if [ -z $ANDROID_NDK_HOME ]; then
       echo -e "${GREEN}NDK directory not configured, please run 'make setup' or add the line to ${_localPropertiesPath}!${NC}"
       exit 1
@@ -64,4 +64,8 @@ if [[ $PLATFORM == 'android' ]]; then
   fi
 fi
 
-echo -e "${GREEN}Finished!${NC}"
+if [[ $PLATFORM == 'setup' ]]; then
+  echo -e "${YELLOW}Finished! Please close your terminal, and reopen a new one before building Status.${NC}"
+else
+  echo -e "${GREEN}Finished!${NC}"
+fi

--- a/scripts/toolversion
+++ b/scripts/toolversion
@@ -33,9 +33,9 @@ if [[ -z "${1}" ]]; then usage; fi
 NAME=${1}
 
 getColumn () {
-    local out=$(awk -F';' "/^${NAME};/{print \$${1}}" "${TOOL_VERSIONS_FILE}")
-    [ -z "$out" ] && exit 1
-    echo "$out"
+    local value=$(awk -F';' "/^${NAME};/{print \$${1}}" "${TOOL_VERSIONS_FILE}")
+    [ -z "$value" ] && echo "\nUnexpected missing value for ${NAME} in ${TOOL_VERSIONS_FILE}" && exit 1
+    echo $value
 }
 
 if [[ $CHECKSUM ]]; then


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

### Summary:

[comment]: # (Summarise the problem and how the pull request solves it)
This PR fixes multiple issues that I found while setting up status-react on clean MacOS and Linux machines. The goal is for `make setup` to do everything required to get the environment ready for e.g. `make release-android` without any errors. At most, it can ask for password or license agreement confirmations. Currently on Android the user still needs to manually install `git` and `make` before he can clone and set up his environment.

### Review notes (optional):
<!-- (Specify if something in particular should be looked at, or ignored, during review) -->

Significant changes:
- keystore file will be created if not present already instead of failing setup;
- ask to agree to Android SDK licenses instead of failing setup;
- Linux:
  - if `ANDROID_SDK_ROOT` is not defined, the script will download and install Android SDK (without Android Studio);
  - Some missing packages added;
- Mac:
  - ensure we have a `~/.bash_profile` file, otherwise NVM will not create it and won't be available later on;
  - write Android SDK paths to `~/.bash_profile`

status: ready <!-- Can be ready or wip -->
