### PR TITLE
[fix 7332] error pop-up when sending tx from wallet

### DIFF
--- a/src/status_im/chat/models/message.cljs
+++ b/src/status_im/chat/models/message.cljs
@@ -382,12 +382,12 @@
               (add-own-status chat-id message-id :sending)
               (send chat-id message-id wrapped-record))))
 
-(fx/defn send-push-notification [cofx message-id fcm-token status]
+(fx/defn send-push-notification [cofx chat-id message-id fcm-token status]
   (log/debug "#6772 - send-push-notification" message-id fcm-token)
   (when (and fcm-token (= status :sent))
     (let [payload {:from (accounts.db/current-public-key cofx)
-                   :to   (get-in cofx [:db :current-chat-id])
-                   :id   message-id}]
+                   :to chat-id
+                   :id message-id}]
       {:send-notification {:data-payload (notifications/encode-notification-payload payload)
                            :tokens       [fcm-token]}})))
 

--- a/src/status_im/transport/message/core.cljs
+++ b/src/status_im/transport/message/core.cljs
@@ -87,7 +87,7 @@
           (fx/merge cofx
                     (remove-hash envelope-hash)
                     (check-confirmations status chat-id message-id)
-                    (models.message/send-push-notification message-id fcm-token status)))))))
+                    (models.message/send-push-notification chat-id message-id fcm-token status)))))))
 
 (fx/defn set-contact-message-envelope-hash
   [{:keys [db] :as cofx} chat-id envelope-hash]


### PR DESCRIPTION
when the last used chat was a public chat, the public-key of
the recipient to populate the `:to` key in the notification data
was taken from `:current-chat-id`in app-db.

this fix ensures that the right chat-id (the actual public-key of
the contact) is used instead of current-chat-id by changing the arity
of `send-push-notification`

fixes #7332 

status: ready
