### PR TITLE
Upgrade SQLCipher: ~>3.0 -> ~>4.0

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -17,7 +17,7 @@ target 'StatusIm' do
   pod 'react-native-background-timer', :path => '../node_modules/react-native-background-timer'
   pod 'RNKeychain', :path => '../node_modules/react-native-keychain'
   pod 'react-native-camera', path: '../node_modules/react-native-camera'
-  pod 'SQLCipher', '~>3.0'
+  pod 'SQLCipher', '~>4.0'
 
   target 'StatusImTests' do
     inherit! :search_paths

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -70,10 +70,10 @@ PODS:
     - yoga (= 0.56.0.React)
   - RNKeychain (3.0.0-rc.3):
     - React
-  - SQLCipher (3.4.2):
-    - SQLCipher/standard (= 3.4.2)
-  - SQLCipher/common (3.4.2)
-  - SQLCipher/standard (3.4.2):
+  - SQLCipher (4.0.1):
+    - SQLCipher/standard (= 4.0.1)
+  - SQLCipher/common (4.0.1)
+  - SQLCipher/standard (4.0.1):
     - SQLCipher/common
   - yoga (0.56.0.React)
 
@@ -84,7 +84,7 @@ DEPENDENCIES:
   - react-native-background-timer (from `../node_modules/react-native-background-timer`)
   - react-native-camera (from `../node_modules/react-native-camera`)
   - RNKeychain (from `../node_modules/react-native-keychain`)
-  - SQLCipher (~> 3.0)
+  - SQLCipher (~> 4.0)
   - yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
@@ -126,9 +126,9 @@ SPEC CHECKSUMS:
   react-native-background-timer: bb7a98c8e97fc7c290de2d423dd09ddb73dcbcbb
   react-native-camera: 68ad5143d2d0636236d46c7de8d2a6455ca52a36
   RNKeychain: 627c6095cef215dd3d9804a9a9cf45ab96aa3997
-  SQLCipher: f9fcf29b2e59ced7defc2a2bdd0ebe79b40d4990
+  SQLCipher: 4636a257060f6f1b4e143a143028b61a2b462d0d
   yoga: b1ce48b6cf950b98deae82838f5173ea7cf89e85
 
-PODFILE CHECKSUM: 7a7b07318fa8b5a77d7f71190a3536cf574273ed
+PODFILE CHECKSUM: 48bbd1245b59112b9600de92c43aa1faaf417db9
 
 COCOAPODS: 1.5.3


### PR DESCRIPTION
Upgrade of SQLCipher pod due to various build/installation failures seen in:
https://github.com/status-im/status-react/pull/7243
https://ci.status.im/job/status-react/job/prs/job/ios-e2e/job/PR-7243/3/consoleText