### PR TITLE
Add sender name in PNs (if db is unlocked)

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["components/src" "src" "react-native/src/cljsjs" "resources"]
- :deps  {org.clojure/clojure         {:mvn/version "1.9.0"}
+ :deps  {org.clojure/clojure         {:mvn/version "1.9.0"} ;; Keep in sync with .TOOLVERSIONS
          org.clojure/clojurescript   {:mvn/version "1.10.439"}
          org.clojure/core.async      {:mvn/version "0.4.474"}
          reagent                     {:mvn/version "0.7.0"

--- a/translations/en.json
+++ b/translations/en.json
@@ -450,7 +450,6 @@
         "other": "days"
     },
     "request-transaction": "Request transaction",
-    "notifications-new-message-title": "Status",
     "wallet-send": "Send",
     "wallet-deposit": "Deposit",
     "invalid-key-title": "We detected a problem with the encryption key",
@@ -742,7 +741,6 @@
     "view-profile": "View profile",
     "message": "Message",
     "here-is-your-passphrase": "Here is your passphrase, *write this down and keep this safe!* You will need it to recover your account.",
-    "add-mailserver": "Add Mailserver",
     "currency-display-name-ttd": "Trinidad and Tobago Dollar",
     "wallet-assets": "Assets",
     "are-you-sure-description": "You will not be able to see the whole recovery phrase again",

--- a/translations/es_419.json
+++ b/translations/es_419.json
@@ -422,7 +422,6 @@
     "not-specified": "No especificado",
     "notifications": "Notificaciones",
     "notifications-new-message-body": "Tienes un nuevo mensaje",
-    "notifications-new-message-title": "Status",
     "notifications-title": "Notificaciones y sonidos",
     "off": "Apagado",
     "offline": "Desconectado",

--- a/translations/fa.json
+++ b/translations/fa.json
@@ -423,7 +423,6 @@
     "not-specified": "مشخص نشده",
     "notifications": "اغلان ها",
     "notifications-new-message-body": "شما یک پیغام جدید دارید",
-    "notifications-new-message-title": "استتوس",
     "notifications-title": "اطلاعیه ها و صداها",
     "off": "خاموش",
     "offline": "آفلاین",

--- a/translations/ko.json
+++ b/translations/ko.json
@@ -450,7 +450,6 @@
     "not-specified": "지정되지 않음",
     "notifications": "알림",
     "notifications-new-message-body": "새로운 메세지가 있습니다",
-    "notifications-new-message-title": "스테이터스",
     "notifications-title": "알림 및 소리",
     "off": "끄기",
     "offline": "오프라인",

--- a/translations/ms.json
+++ b/translations/ms.json
@@ -450,7 +450,6 @@
     "not-specified": "Tidak diberikan",
     "notifications": "Pemberitahuan",
     "notifications-new-message-body": "Anda mempunyai mesej baru",
-    "notifications-new-message-title": "Status",
     "notifications-title": "Pemberitahuan dan bunyi",
     "off": "Tidak aktif",
     "offline": "Luar talian",

--- a/translations/ne.json
+++ b/translations/ne.json
@@ -433,7 +433,6 @@
     "not-specified": "नतोकिएको",
     "notifications": "Pemberitahuan",
     "notifications-new-message-body": "Anda mempunyai mesej baru",
-    "notifications-new-message-title": "Status",
     "notifications-title": "सूचना र ध्वनि",
     "off": "Tidak aktif",
     "offline": "अफलाइन",

--- a/translations/pl.json
+++ b/translations/pl.json
@@ -415,7 +415,6 @@
     "not-specified": "Nie określono",
     "notifications": "Powiadomienia",
     "notifications-new-message-body": "Masz nową wiadomość",
-    "notifications-new-message-title": "Status",
     "notifications-title": "Powiadomienia i dźwięki",
     "off": "Wył.",
     "offline": "Offline",

--- a/translations/ru.json
+++ b/translations/ru.json
@@ -432,7 +432,6 @@
     "not-specified": "Не указано",
     "notifications": "Уведомления",
     "notifications-new-message-body": "Вы получили новое сообщение",
-    "notifications-new-message-title": "Status",
     "notifications-title": "Уведомления и звуки",
     "off": "Выкл",
     "offline": "Оффлайн",

--- a/translations/zh_Hans_CN.json
+++ b/translations/zh_Hans_CN.json
@@ -450,7 +450,6 @@
     "not-specified": "未指定",
     "notifications": "通知",
     "notifications-new-message-body": "你有新信息",
-    "notifications-new-message-title": "Status",
     "notifications-title": "通知和声音",
     "off": "关闭",
     "offline": "离线",


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

Closes #7043 

### Summary:

[comment]: # (Summarise the problem and how the pull request solves it)

It is impossible to tell apart PNs, e.g. do they all come from a single sender, or are they all from different senders? This PR adds context by replacing the generic `Status` title (which was duplicate anyway)  with the contact name. If the db is unlocked, the actual contact name will be shown, otherwise, an anonymized short hash will be shown instead.

### Review notes (optional):
<!-- (Specify if something in particular should be looked at, or ignored, during review) -->

A follow-up PR would enable per-sender configuration of PNs (i.e. mute all notifications from a given sender), by creating a PN channel for each contact in the user's contact list.

![image](https://user-images.githubusercontent.com/138074/52003459-dc510d00-24c4-11e9-9c74-3cd2f42b86af.png)

### Testing notes (optional):
<!-- (Specify which platforms should be tested) -->
#### Platforms (optional)
- Android
- iOS

<!-- (Specify if some specific areas has to be tested, for example 1-1 chats) -->
#### Areas that maybe impacted (optional)
**Functional**
- 1-1 chats

<!-- (Specify exact steps to test if there are such) -->
### Steps to test:
- Create 3 accounts and add all contacts to the contact list among themselves
- Send messages to 1 contact from the other 2 contacts
- The name should be present in the PNs
- Sign out of the receiving account
- Send more messages
- The hash of the sender should be present in the PNs, since we can't access the db

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->
