### PR TITLE
remove wallet address auto generation

### DIFF
--- a/src/status_im/chat/commands/core.cljs
+++ b/src/status_im/chat/commands/core.cljs
@@ -35,22 +35,23 @@
   [type]
   (keyword (str (protocol/id type) "-button")))
 
-(defn- contact->address [contact]
-  (str "0x" (db/public-key->address contact)))
+(defn- contact->address [all-contacts pub-key]
+  (get-in all-contacts [pub-key :address]))
 
 (defn add-chat-contacts
   "Enrich command-message by adding contact list of the current private or group chat"
-  [contacts {:keys [public? group-chat] :as command-message}]
+  [all-contacts contacts {:keys [public? group-chat] :as command-message}]
   (cond
     public? command-message
-    group-chat (assoc command-message :contacts (map contact->address contacts))
-    :else (assoc command-message :contact (contact->address (first contacts)))))
+    group-chat (assoc command-message :contacts (map #(contact->address all-contacts %) contacts))
+    :else (assoc command-message :contact (contact->address all-contacts (first contacts)))))
 
 (defn enrich-command-message-for-events
   "adds new pairs to command-message to be consumed by extension events"
   [db {:keys [chat-id] :as command-message}]
-  (let [{:keys [contacts public? group-chat]} (get-in db [:chats chat-id])]
-    (add-chat-contacts contacts (assoc command-message :public? public? :group-chat group-chat))))
+  (let [{:keys [contacts public? group-chat]} (get-in db [:chats chat-id])
+        all-contacts (get db :contacts/contacts)]
+    (add-chat-contacts all-contacts contacts (assoc command-message :public? public? :group-chat group-chat))))
 
 (defn generate-short-preview
   "Returns short preview for command"

--- a/src/status_im/contact/core.cljs
+++ b/src/status_im/contact/core.cljs
@@ -28,10 +28,8 @@
 
 (defn build-contact [{{:keys [chats] :account/keys [account]
                        :contacts/keys [contacts]} :db} public-key]
-  (cond-> (assoc (or (get contacts public-key)
-                     (contact.db/public-key->new-contact public-key))
-                 :address (contact.db/public-key->address public-key))
-
+  (cond-> (or (get contacts public-key)
+              (contact.db/public-key->new-contact public-key))
     (= public-key (:public-key account)) (assoc :name (:name account))))
 
 (defn- own-info [db]
@@ -126,9 +124,7 @@
                               {:public-key   public-key
                                :photo-path   profile-image
                                :name         name
-                               :address      (or address
-                                                 (:address contact)
-                                                 (contact.db/public-key->address public-key))
+                               :address      (or address (:address contact))
                                :last-updated timestamp-ms
                                   ;;NOTE (yenda) in case of concurrent contact request
                                :pending?     (get contact :pending? true)}

--- a/src/status_im/contact/db.cljs
+++ b/src/status_im/contact/db.cljs
@@ -87,16 +87,6 @@
    :photo-path (identicon/identicon public-key)
    :public-key public-key})
 
-(defn public-key->address [public-key]
-  (let [length (count public-key)
-        normalized-key (case length
-                         132 (subs public-key 4)
-                         130 (subs public-key 2)
-                         128 public-key
-                         nil)]
-    (when normalized-key
-      (subs (.sha3 js-dependencies/Web3.prototype normalized-key #js {:encoding "hex"}) 26))))
-
 (defn- contact-by-address [[_ contact] address]
   (when (ethereum/address= (:address contact) address)
     contact))

--- a/src/status_im/contact/subs.cljs
+++ b/src/status_im/contact/subs.cljs
@@ -1,5 +1,6 @@
 (ns status-im.contact.subs
   (:require [re-frame.core :as re-frame]
+            [clojure.string :as str]
             [status-im.utils.identicon :as identicon]
             [status-im.contact.db :as contact.db]))
 
@@ -46,6 +47,12 @@
  :<- [::all-added-contacts]
  (fn [contacts]
    (remove :dapp? contacts)))
+
+(re-frame/reg-sub
+ :contacts/all-added-people-contacts-with-address
+ :<- [:contacts/all-added-people-contacts]
+ (fn [contacts]
+   (remove #(-> % :address (str/blank?)) contacts)))
 
 (re-frame/reg-sub
  :contacts/all-dapps

--- a/src/status_im/ui/screens/chat/message/message.cljs
+++ b/src/status_im/ui/screens/chat/message/message.cljs
@@ -33,6 +33,7 @@
 (defview message-content-command
   [command-message]
   (letsubs [id->command [:chats/id->command]
+            all-contacts [:contacts/contacts]
             {:keys [contacts]} [:chats/current-chat]]
     (let [{:keys [type] :as command} (commands-receiving/lookup-command-by-ref command-message id->command)
           extension-id (get-in command-message [:content :params :extension-id])]
@@ -44,7 +45,7 @@
         ;; or installed extension has differen extension id
         [install-extension-message extension-id (:outgoing command-message)]
         (if command
-          (commands/generate-preview command (commands/add-chat-contacts contacts command-message))
+          (commands/generate-preview command (commands/add-chat-contacts all-contacts contacts command-message))
           [react/text (str "Unhandled command: " (-> command-message :content :command-path first))])))))
 
 (defview message-timestamp [t justify-timestamp? outgoing command? content]

--- a/src/status_im/ui/screens/home/views/inner_item.cljs
+++ b/src/status_im/ui/screens/home/views/inner_item.cljs
@@ -23,9 +23,10 @@
 
 (defview command-short-preview [message]
   (letsubs [id->command [:chats/id->command]
+            all-contacts [:contacts/contacts]
             {:keys [contacts]} [:chats/current-chat]]
     (when-let [command (commands-receiving/lookup-command-by-ref message id->command)]
-      (commands/generate-short-preview command (commands/add-chat-contacts contacts message)))))
+      (commands/generate-short-preview command (commands/add-chat-contacts all-contacts contacts message)))))
 
 (defn message-content-text [{:keys [content content-type] :as message}]
   [react/view styles/last-message-container

--- a/src/status_im/ui/screens/profile/contact/views.cljs
+++ b/src/status_im/ui/screens/profile/contact/views.cljs
@@ -1,5 +1,6 @@
 (ns status-im.ui.screens.profile.contact.views
   (:require [re-frame.core :as re-frame]
+            [clojure.string :as str]
             [status-im.contact.db :as contact.db]
             [status-im.i18n :as i18n]
             [status-im.ui.components.list.views :as list]
@@ -16,7 +17,7 @@
    toolbar/default-nav-back
    [toolbar/content-title ""]])
 
-(defn actions [{:keys [pending? public-key dapp?]}]
+(defn actions [{:keys [pending? public-key dapp? address]}]
   (concat (if (or (nil? pending?) pending?)
             [{:label               (i18n/label :t/add-to-contacts)
               :icon                :icons/add-contact
@@ -34,6 +35,7 @@
             [{:label               (i18n/label :t/send-transaction)
               :icon                :icons/arrow-right
               :action              #(re-frame/dispatch [:profile/send-transaction public-key])
+              :disabled?           (str/blank? address)
               :accessibility-label :send-transaction-button}])
           [{:label               (i18n/label :t/share-profile-link)
             :icon                :icons/share

--- a/src/status_im/ui/screens/wallet/components/views.cljs
+++ b/src/status_im/ui/screens/wallet/components/views.cljs
@@ -211,7 +211,7 @@
       (ethereum/normalized-address (:address contact))]]]])
 
 (views/defview recent-recipients []
-  (views/letsubs [contacts [:contacts/all-added-people-contacts]]
+  (views/letsubs [contacts [:contacts/all-added-people-contacts-with-address]]
     [simple-screen
      [toolbar (i18n/label :t/recipient)]
      [react/view styles/recent-recipients

--- a/test/cljs/status_im/test/chat/commands/core.cljs
+++ b/test/cljs/status_im/test/chat/commands/core.cljs
@@ -115,6 +115,11 @@
                           "0x21631d18d9681d4ffdd460fc45fa52159fcd95c8"
                           "0x5541e3be81b76d76cdbf968516caa5a5b773763b"))
 
+(def contacts-list
+  (let [pairs (zipmap contacts contacts_addresses)]
+    (reduce (fn [acc [pub addr]]
+              (assoc acc pub {:address addr})) {} pairs)))
+
 (deftest enrich-command-message-for-events-test-public
   (let [db {:chats {"1" {:contacts nil :public? true :group-chat false}}}
         msg {:chat-id "1"}
@@ -124,7 +129,8 @@
              (assoc msg :public? true :group-chat false))))))
 
 (deftest enrich-command-message-for-events-test-groupchat
-  (let [db {:chats {"1" {:contacts contacts :public? false :group-chat true}}}
+  (let [db {:contacts/contacts contacts-list
+            :chats {"1" {:contacts contacts :public? false :group-chat true}}}
         msg {:chat-id "1"}
         enriched-msg (core/enrich-command-message-for-events db msg)]
     (testing "command-message correctly enriched - group chat"
@@ -132,7 +138,8 @@
              (assoc msg :public? false :group-chat true :contacts contacts_addresses))))))
 
 (deftest enrich-command-message-for-events-test-1on1-chat
-  (let [db {:chats {"1" {:contacts contacts :public? false :group-chat false}}}
+  (let [db {:contacts/contacts contacts-list
+            :chats {"1" {:contacts contacts :public? false :group-chat false}}}
         msg {:chat-id "1"}
         enriched-msg (core/enrich-command-message-for-events db msg)]
     (testing "command-message correctly enriched - 1on1 chat"

--- a/test/cljs/status_im/test/models/contact.cljs
+++ b/test/cljs/status_im/test/models/contact.cljs
@@ -118,7 +118,8 @@
                                      :photo-path       "old-image"
                                      :name             "old-name"
                                      :last-updated     0
-                                     :pending?         false}}}})
+                                     :pending?         false
+                                     :address          address}}}})
           contact (get-in actual [:db :contacts/contacts public-key])]
       (testing "it stores the contact in the database"
         (is (:data-store/tx actual)))


### PR DESCRIPTION
In this PR we are removing the automatic derivation of the wallet address from the whisper public key, so that a user can send a different wallet address that is not derived from the same key used for chat.
This change is needed to interact with keycard accounts and in the future for accounts with chat and wallet keys decoupled. 

In the current app we create contacts in 2 ways:

1 - When Bob adds Alice, Alice receive Bob's contacts info with name, wallet address, etc.. and creates a new entry in her contact list.

2 - When Bob adds Alice, Bob creates a new entry in the contact list with data derived from Alice's public key.

If Alice is using a keycard account, Bob will end up generating a new contact entry with the wallet address derived from Alice's public key, which would be the wrong address. 
Alice is instead using a whisper key derived at `m/43'/60'/ 1581'/0/0` as described in (EIP1581)[https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1581.md], and a wallet key using the standard BIP44 path.

For this reasons, we are removing the automatic derivation of the wallet address and instead using only the address received from the other contact.

After this changes, transactions will be available only to contact that contains a wallet address.

#### Areas that maybe impacted (optional)
**Functional**
- in-chat transactions 1-1 chats
- wallet / transactions