### PR TITLE
[#6587] IPFS hosted apps should not share cookies/etc

### DIFF
--- a/clj-rn.conf.edn
+++ b/clj-rn.conf.edn
@@ -40,7 +40,8 @@
               "react-native-fetch-polyfill"
               "text-encoding"
               "js-sha3"
-              "react-navigation"]
+              "react-navigation"
+              "hi-base32"]
 
  ;; Desktop modules
  :desktop-modules ["realm"

--- a/mobile_files/package.json.orig
+++ b/mobile_files/package.json.orig
@@ -66,7 +66,8 @@
     "text-encoding": "^0.6.4",
     "url": "0.10.3",
     "web3": "git+https://github.com/status-im/web3.js.git#0.20.1-status",
-    "web3-utils": "1.0.0-beta.36"
+    "web3-utils": "1.0.0-beta.36",
+    "hi-base32": "0.5.0"
   },
   "devDependencies": {
     "@babel/core": "7.0.0-beta.47"

--- a/mobile_files/yarn.lock
+++ b/mobile_files/yarn.lock
@@ -3786,6 +3786,11 @@ hash.js@^1.0.0, hash.js@^1.0.3:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
 
+hi-base32@0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/hi-base32/-/hi-base32-0.5.0.tgz#61329f76a31f31008533f1c36f2473e259d64571"
+  integrity sha512-DDRmxSyoYuvjUb9EnXdoiMChBZ7ZcUVJsK5Frd3kqMhuBxvmZdnBeynAVfj7/ECbn++CekcoprvC/rprHPAtow==
+
 hmac-drbg@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"

--- a/src/status_im/js_dependencies.cljs
+++ b/src/status_im/js_dependencies.cljs
@@ -9,3 +9,4 @@
 (def text-encoding       (js/require "text-encoding"))
 (def js-sha3             (js/require "js-sha3"))
 (def web3-utils          (js/require "web3-utils"))
+(def hi-base32           (js/require "hi-base32"))


### PR DESCRIPTION
fixes #6587

encode ipfs hash in base32 and redirect to base32hash.infura.status.im

related changes in infra 
https://github.com/status-im/infra-misc/commit/5185fc87bc2878dd4f707408ea904a3827586d75
https://github.com/status-im/infra-misc/commit/348cf2441afa99aa6a9b5c23db63f414c0af6661
