### PR TITLE
Remove reliance on .nvmrc file and enforce node version check

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -46,7 +46,6 @@ local.properties
 #
 node_modules/
 npm-debug.log
-.nvmrc
 
 # BUCK
 buck-out/

--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,6 @@ local.properties
 #
 node_modules/
 npm-debug.log
-.nvmrc
 .babelrc
 yarn-error.log
 default.realm/

--- a/scripts/lib/setup/installers.sh
+++ b/scripts/lib/setup/installers.sh
@@ -309,29 +309,25 @@ function install_nvm() {
 }
 
 function install_node_via_nvm() {
-  local nvmrc="$(repo_path)/.nvmrc"
   local required_version=$(toolversion node)
 
   cd "$(repo_path)"
 
-  if [ ! -e "$nvmrc" -o "$(nvm version v""$required_version"")" = "N/A" ]; then
+  if [ "$(nvm version v""$required_version"")" = "N/A" ]; then
     cecho "@b@blue[[+ Installing Node $required_version]]"
 
     nvm install $required_version
     nvm alias status-im $required_version
-    echo status-im > "$nvmrc"
-
     nvm use status-im
 
   else
-    local version_alias=$(cat "$nvmrc")
     if [ "$(nvm version status-im)" != "v$required_version" ]; then
       nvm alias status-im $required_version
     fi
-    nvm use $version_alias
+    nvm use status-im
 
     local version=$(node -v)
-    cecho "+ Node already installed ($version_alias $version via NVM)... skipping."
+    cecho "+ Node already installed (status-im $version via NVM)... skipping."
   fi
 }
 

--- a/scripts/run-environment-check.sh
+++ b/scripts/run-environment-check.sh
@@ -22,36 +22,27 @@ else
   PLATFORM=$1
 fi
 
-load_nvm_if_available
+if [[ $PLATFORM == 'setup' ]]; then
+  load_nvm_if_available
+fi
 
-if ! program_exists node || ! program_exists yarn; then
+if ! program_version_exists node $EXPECTED_NODE_VERSION || ! program_version_exists yarn $EXPECTED_YARN_VERSION; then
   echo -e "${YELLOW}********************************************************************************************"
 
-  nvmrc="./.nvmrc"
-  if [ -e "$nvmrc" ] && nvm_installed; then
-    version_alias=$(cat "$nvmrc")
-    echo -e "Please run 'nvm use $version_alias' in the terminal and try again."
-  else
-    echo -e "The current environment doesn't contain the expected versions of node and/or yarn"
-    echo -e "  - node:\texpected\t${EXPECTED_NODE_VERSION}"
-    echo -e "  \t\tfound\t\t$(node -v) ($(which node))"
-    echo -e "  - yarn:\texpected\t${EXPECTED_YARN_VERSION}"
-    echo -e "  \t\tfound\t\t$(yarn -v) ($(which yarn))"
-    echo -e "Please open another console to reload the environment, and then run 'make setup' if necessary."
+  echo -e "The current environment doesn't contain the expected versions of node and/or yarn"
+  echo -e "  - node:\texpected\t${EXPECTED_NODE_VERSION}"
+  echo -e "  \t\tfound\t\t$(node -v) ($(which node))"
+  echo -e "  - yarn:\texpected\t${EXPECTED_YARN_VERSION}"
+  echo -e "  \t\tfound\t\t$(yarn -v) ($(which yarn))"
+  echo -e "Please open another console to reload the environment, and then run 'make setup' if necessary."
+
+  load_nvm_if_available
+  if nvm_installed; then
+    echo -e "Afterwards, run 'nvm use status-im' in the terminal and try again."
   fi
 
   echo -e "**********************************************************************************************${NC}"
   exit 1
-fi
-
-node_version=$(node -v)
-if [[ $node_version != $EXPECTED_NODE_VERSION ]]; then
-  echo -e "${YELLOW}+ node version $node_version is installed. node version $EXPECTED_NODE_VERSION is recommended.${NC}"
-fi
-
-yarn_version=$(yarn -v)
-if [[ $yarn_version != $EXPECTED_YARN_VERSION ]]; then
-  echo -e "${YELLOW}+ yarn version $yarn_version is installed. yarn version $EXPECTED_YARN_VERSION is recommended.${NC}"
 fi
 
 if [[ $PLATFORM == 'android' ]]; then


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

### Summary:

[comment]: # (Summarise the problem and how the pull request solves it)
This PR enforces checks on node and yarn versions. This has allowed us to e.g. learn that macOS/iOS build agents were using a more recent version of node than we stipulate on `.TOOLVERSIONS`.
It also removes the file `.nvmrc` which was being created in `make setup` and didn't seem to serve any practical purpose, especially since we started taking control over which versions of tools we sanction.

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->
