### PR TITLE
Fetch messages from mailserver upon PN if db is unlocked. Part of #3451

### DIFF
--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -404,6 +404,11 @@
    (mailserver/check-connection cofx)))
 
 (handlers/register-handler-fx
+ :mailserver/fetch-history
+ (fn [cofx [_ chat-id from-timestamp]]
+   (mailserver/fetch-history cofx chat-id from-timestamp)))
+
+(handlers/register-handler-fx
  :mailserver.callback/generate-mailserver-symkey-success
  (fn [cofx [_ mailserver sym-key-id]]
    (mailserver/add-mailserver-sym-key cofx mailserver sym-key-id)))
@@ -658,7 +663,7 @@
 (handlers/register-handler-fx
  :chat.ui/fetch-history-pressed
  (fn [cofx [_ chat-id]]
-   (mailserver/fetch-history cofx chat-id)))
+   (mailserver/fetch-history cofx chat-id 1)))
 
 (handlers/register-handler-fx
  :chat.ui/remove-chat-pressed


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

### Summary:

[comment]: # (Summarise the problem and how the pull request solves it)
This PR improves delivery of messages by triggering a request to the mailserver every time a push notification arrives (therefore there is less risk that a message won't arrive because the user didn't open the app in the last 24 hours). It does so for the target chat ID and only for the last 15 minutes (this can be observed on the logs by filtering for `fetch-history`).

### Testing notes (optional):
<!-- (Specify which platforms should be tested) -->
#### Platforms (optional)
- Android
- iOS

<!-- (Specify if some specific areas has to be tested, for example 1-1 chats) -->
#### Areas that maybe impacted (optional)
**Functional**
- 1-1 chats

<!-- (Specify exact steps to test if there are such) -->
### Steps to test:
- Open Status
- Put the app in the background
- Send a message from another client to this account
- Wait for the PN to arrive
- Put the phone in airplane mode
- Tap the notification
- Check that the message has arrived even though the phone is in airplane mode

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->
