### PR TITLE
Fix null is not an object error for invalid URLs

### DIFF
--- a/src/status_im/browser/core.cljs
+++ b/src/status_im/browser/core.cljs
@@ -80,7 +80,10 @@
 
 (defn check-if-phishing-url [{:keys [history history-index] :as browser}]
   (let [history-host (http/url-host (try (nth history history-index) (catch js/Error _)))]
-    (assoc browser :unsafe? (dependencies/phishing-detect history-host))))
+    (if history-host
+      (assoc browser :unsafe? (dependencies/phishing-detect history-host))
+      (assoc browser :web-view-error? true)
+      )))
 
 (def ipfs-proto-code "e3")
 (def swarm-proto-code "e4")


### PR DESCRIPTION
fixes #6291 

### Summary:
The null is not an object error occurred in the `check-if-phishing-url` function that's called whenever a new URL is opened, because the `http/url-host` function would return null when the URL entered was invalid. This null (history-host) was then passed to `dependencies/phishing-detect`, which is a JS library, which has a `str.split` to split a URL into its constituent parts. This `.split` being called on `null` caused the application to error out. I fixed it by adding a check to see if `history-host` is not null. 

### Review notes (optional):
I don't want to admit how long this took me to figure out a fix for, as I'd never used Clojure or functional programming before. I hope this helps. 

#### Platforms (optional)
- Android
- iOS

### Steps to test:
- Open Status
- Open Status Browser, for example from Profile -> ENS Names page
- Type in invalid URL like http:/ojkdkllkjasjd.com
- You should see ERR_NAME_NOT_RESOLVED instead of the previous null is not an object error

status: ready
