### PR TITLE
Fix blank screen

### DIFF
--- a/desktop_files/package.json.orig
+++ b/desktop_files/package.json.orig
@@ -67,7 +67,7 @@
     "react-native-image-crop-picker": "0.18.1",
     "react-native-image-resizer": "1.0.0",
     "react-native-invertible-scroll-view": "1.1.0",
-    "react-native-keychain": "git+https://github.com/status-im/react-native-keychain.git#v.3.0.0-1-status",
+    "react-native-keychain": "git+https://github.com/status-im/react-native-keychain.git#v.3.0.0-2-status",
     "react-native-level-fs": "3.0.0",
     "react-native-os": "1.1.0",
     "react-native-qrcode": "0.2.6",

--- a/desktop_files/yarn.lock
+++ b/desktop_files/yarn.lock
@@ -7222,9 +7222,9 @@ react-native-invertible-scroll-view@1.1.0:
     react-clone-referenced-element "^1.0.1"
     react-native-scrollable-mixin "^1.0.1"
 
-"react-native-keychain@git+https://github.com/status-im/react-native-keychain.git#v.3.0.0-1-status":
+"react-native-keychain@git+https://github.com/status-im/react-native-keychain.git#v.3.0.0-2-status":
   version "3.0.0-rc.3"
-  resolved "git+https://github.com/status-im/react-native-keychain.git#33eb25baf359414f7a30a34a0298a6347f698138"
+  resolved "git+https://github.com/status-im/react-native-keychain.git#ce6cec62222713f2cec7798b69c4fae6b493832f"
 
 react-native-level-fs@3.0.0:
   version "3.0.0"


### PR DESCRIPTION
fixes #7348

### Summary:

New users had a problem with fresh releases of Status desktop because `react-native-keychain` contained error and they couldn't store anything in keychain. So keychain fix pushed and status desktop switched to corrected version

### Review notes (optional):
Changes in `react-native-keychain` - https://github.com/status-im/react-native-keychain/pull/8

### Testing notes (optional):
<!-- (Specify which platforms should be tested) -->
#### Platforms (optional)
- macOS
- Linux
- Windows

<!-- (Specify if some specific areas has to be tested, for example 1-1 chats) -->
#### Areas that maybe impacted (optional)
**Functional**
- account recovery
- new account

<!-- (Specify exact steps to test if there are such) -->
### Steps to test:
- Open Status on a clean machine
- Ensure UI is visible and you are able to create/recover account

status: ready
