### PR TITLE
Dont count 1-to-1 topics if not enabled

### DIFF
--- a/src/status_im/transport/db.cljs
+++ b/src/status_im/transport/db.cljs
@@ -3,6 +3,7 @@
   (:require [cljs.spec.alpha :as spec]
             [clojure.string :as s]
             status-im.contact.db
+            [status-im.utils.config :as config]
             [status-im.utils.clocks :as utils.clocks]
             [status-im.constants :as constants]))
 
@@ -127,7 +128,8 @@
         chats   (into #{:discovery-topic}
                       (keys (filter (fn [[chat-id {:keys [topic one-to-one]}]]
                                       (if one-to-one
-                                        chat-id
+                                        (and config/partitioned-topic-enabled?
+                                             chat-id)
                                         topic))
                                     (get db :transport/chats))))]
     (= chats filters)))

--- a/src/status_im/transport/message/core.cljs
+++ b/src/status_im/transport/message/core.cljs
@@ -43,8 +43,7 @@
                                      (receive-message now-in-s chat-id message))
                                    (js-array->seq js-messages))]
       (apply fx/merge cofx receive-message-fxs))
-    (do (log/error "Something went wrong" js-error js-messages)
-        cofx)))
+    (log/error "Something went wrong" js-error js-messages)))
 
 (fx/defn remove-hash
   [{:keys [db] :as cofx} envelope-hash]


### PR DESCRIPTION
We count 1-to-1 filters only if partitoned topic is enabled, otherwise no message is fetched when one-to-one are present, also fixes an issue with error handling, but does not fix the root cause (`Filter is nil`).

Current nightly does not fetch messages if a one-to-one chat is present.

status: ready