### PR TITLE
Bug/discovery topic filter

### DIFF
--- a/src/status_im/transport/db.cljs
+++ b/src/status_im/transport/db.cljs
@@ -3,6 +3,7 @@
   (:require [cljs.spec.alpha :as spec]
             [clojure.string :as s]
             status-im.contact.db
+            [status-im.utils.config :as config]
             [status-im.utils.clocks :as utils.clocks]
             [status-im.constants :as constants]))
 
@@ -127,7 +128,8 @@
         chats   (into #{:discovery-topic}
                       (keys (filter (fn [[chat-id {:keys [topic one-to-one]}]]
                                       (if one-to-one
-                                        chat-id
+                                        (and config/partitioned-topic-enabled?
+                                             chat-id)
                                         topic))
                                     (get db :transport/chats))))]
     (= chats filters)))

--- a/src/status_im/transport/filters.cljs
+++ b/src/status_im/transport/filters.cljs
@@ -66,7 +66,9 @@
              {:options  (cond-> (assoc params :topics [topic])
                           minPow
                           (assoc :minPow minPow))
-              :callback (or callback (partial receive-message chat-id))
+              ;; We don't pass a chat id on discovery-filters as we might receive
+              ;; messages for multiple chats
+              :callback (or callback (partial receive-message nil))
               :chat-id  chat-id}) topics)))))
 
 (fx/defn add-filter

--- a/src/status_im/transport/message/core.cljs
+++ b/src/status_im/transport/message/core.cljs
@@ -43,8 +43,7 @@
                                      (receive-message now-in-s chat-id message))
                                    (js-array->seq js-messages))]
       (apply fx/merge cofx receive-message-fxs))
-    (do (log/error "Something went wrong" js-error js-messages)
-        cofx)))
+    (log/error "Something went wrong" js-error js-messages)))
 
 (fx/defn remove-hash
   [{:keys [db] :as cofx} envelope-hash]


### PR DESCRIPTION
Fixes #7410 
This restore the previous behavior, for 1-to-1 messages we don't set a chat-id in the filter, as multiple chats are listening to the filter. It is only an issue on messages sent through pairing, as otherwise we just use the signature of the user.

status: ready
