### PR TITLE
Retry mailserver request with cursor

### DIFF
--- a/src/status_im/mailserver/core.cljs
+++ b/src/status_im/mailserver/core.cljs
@@ -461,9 +461,11 @@
         (if (seq cursor)
           (when-let [mailserver (get-mailserver-when-ready cofx)]
 
-            {:mailserver/request-messages {:web3 (:web3 db)
-                                           :mailserver    mailserver
-                                           :request (assoc request :cursor cursor)}})
+            (let [request-with-cursor (assoc request :cursor cursor)]
+              {:db (assoc db :mailserver/current-request request-with-cursor)
+               :mailserver/request-messages {:web3 (:web3 db)
+                                             :mailserver    mailserver
+                                             :request request-with-cursor}}))
           (fx/merge cofx
                     {:db (-> db
                              (dissoc :mailserver/current-request)
@@ -552,9 +554,9 @@
               {:db (update db :mailserver/current-request dissoc :attemps)}
               (change-mailserver))
     (when-let [mailserver (get-mailserver-when-ready cofx)]
-      (let [{:keys [topics from to] :as request} (get db :mailserver/current-request)
+      (let [{:keys [topics from to cursor] :as request} (get db :mailserver/current-request)
             web3 (:web3 db)]
-        (log/info "mailserver: message request " request-id "expired for mailserver topic" topics "from" from "to" to)
+        (log/info "mailserver: message request " request-id "expired for mailserver topic" topics "from" from "to" to "cursor" cursor)
         {:db (update-in db [:mailserver/current-request :attemps] inc)
          :mailserver/request-messages {:web3    web3
                                        :mailserver   mailserver


### PR DESCRIPTION
### Testing
Testing is quite difficult, as certain conditions needs to be replicated.

The easiest way to confirm is working is to check status logs.

Use fetch 24 hours on a 1-to-1 chat, and it should start fetching from the mailserver.
If any of the request times out (you should see a line in the logs with `mailserver.request.expired`), the next request should have a `cursor` (the logs will show the cursor), as long as the initial request had a cursor (in most cases).

In general this should help with constant fetching, as before if any of the requests was failing it would start from scratch.

status: ready
