### PR TITLE
Increase mailserver page size 10 times to make initial sync faster.

### DIFF
--- a/src/status_im/mailserver/core.cljs
+++ b/src/status_im/mailserver/core.cljs
@@ -236,7 +236,7 @@
         mailserver-removed?
         (connect-to-mailserver cofx)))))
 
-(def limit 200)
+(def limit 2000)
 
 (defn adjust-request-for-transit-time
   [from]


### PR DESCRIPTION
It should speed up the initial sync on empty accounts on slow networks.

status: ready <!-- Can be ready or wip -->
