### PR TITLE
avoid incosistent timestamps by using parent start time if available

### DIFF
--- a/ci/common.groovy
+++ b/ci/common.groovy
@@ -163,8 +163,15 @@ def uploadArtifact(path) {
   return "https://${bucket}.${domain}/${getFilename(path)}"
 }
 
+def parentOrCurrentBuild() {
+  def c = currentBuild.rawBuild.getCause(hudson.model.Cause$UpstreamCause)
+  if (c == null) { return currentBuild }
+  return c.getUpstreamRun()
+}
+
 def timestamp() {
-  def now = new Date(currentBuild.timeInMillis)
+  /* we use parent if available to make timestmaps consistent */
+  def now = new Date(parentOrCurrentBuild().timeInMillis)
   return now.format('yyMMdd-HHmmss', TimeZone.getTimeZone('UTC'))
 }
 


### PR DESCRIPTION
I've noticed that the `StatusIm-*.sha256' filename has different timestamps than build files, example:
```
StatusIm-190125-025916-d3f1b3-nightly.dmg
StatusIm-190125-025916-d3f1b3-nightly.exe
StatusIm-190125-025900-d3f1b3-nightly.sha256
```
This way if we use the parent job start time all timestmaps should be the same.

Status: READY