### PR TITLE
Remove automatic sending of contact request

### DIFF
--- a/src/status_im/chat/commands/impl/transactions.cljs
+++ b/src/status_im/chat/commands/impl/transactions.cljs
@@ -14,6 +14,7 @@
             [status-im.ui.components.animation :as animation]
             [status-im.ui.components.svgimage :as svgimage]
             [status-im.i18n :as i18n]
+            [status-im.contact.db :as db.contact]
             [status-im.constants :as constants]
             [status-im.utils.ethereum.core :as ethereum]
             [status-im.utils.ethereum.tokens :as tokens]
@@ -296,7 +297,10 @@
   protocol/Yielding
   (yield-control [_ {{{amount :amount asset :asset} :params} :content} {:keys [db] :as cofx}]
     ;; Prefill wallet and navigate there
-    (let [recipient-contact     (get-in db [:contacts/contacts (:current-chat-id db)])
+    (let [recipient-contact     (or
+                                 (get-in db [:contacts/contacts (:current-chat-id db)])
+                                 (db.contact/public-key->new-contact (:current-chat-id db)))
+
           sender-account        (:account/account db)
           chain                 (keyword (:chain db))
           symbol-param          (keyword asset)

--- a/src/status_im/contact/core.cljs
+++ b/src/status_im/contact/core.cljs
@@ -260,10 +260,9 @@
 (def receive-contact-request-confirmation handle-contact-update)
 (def receive-contact-update handle-contact-update)
 
-(fx/defn add-contact-and-open-chat
+(fx/defn open-chat
   [cofx public-key]
   (fx/merge cofx
-            (add-contact public-key)
             (chat.models/start-chat public-key {:navigation-reset? true})))
 
 (fx/defn hide-contact
@@ -283,8 +282,8 @@
       (fx/merge cofx
                 fx
                 (if config/partitioned-topic-enabled?
-                  (add-contacts-filter contact-identity :add-contact-and-open-chat)
-                  (add-contact-and-open-chat contact-identity))))))
+                  (add-contacts-filter contact-identity :open-chat)
+                  (open-chat contact-identity))))))
 
 (fx/defn open-contact-toggle-list
   [{:keys [db :as cofx]}]
@@ -297,4 +296,4 @@
 (fx/defn add-new-identity-to-contacts
   [{{:contacts/keys [new-identity]} :db :as cofx}]
   (when (seq new-identity)
-    (add-contact-and-open-chat cofx new-identity)))
+    (open-chat cofx new-identity)))

--- a/src/status_im/contact/db.cljs
+++ b/src/status_im/contact/db.cljs
@@ -63,17 +63,6 @@
 (spec/def :contact/new-tag string?)
 (spec/def :ui/contact (spec/keys :opt [:contact/new-tag]))
 
-(defn public-key->new-contact [public-key]
-  {:name       (gfycat/generate-gfy public-key)
-   :photo-path (identicon/identicon public-key)
-   :public-key public-key})
-
-(defn public-key->contact
-  [contacts public-key]
-  (when public-key
-    (get contacts public-key
-         (public-key->new-contact public-key))))
-
 (defn public-key->address [public-key]
   (let [length (count public-key)
         normalized-key (case length
@@ -83,6 +72,18 @@
                          nil)]
     (when normalized-key
       (subs (.sha3 js-dependencies/Web3.prototype normalized-key #js {:encoding "hex"}) 26))))
+
+(defn public-key->new-contact [public-key]
+  {:name       (gfycat/generate-gfy public-key)
+   :address    (public-key->address public-key)
+   :photo-path (identicon/identicon public-key)
+   :public-key public-key})
+
+(defn public-key->contact
+  [contacts public-key]
+  (when public-key
+    (get contacts public-key
+         (public-key->new-contact public-key))))
 
 (defn- contact-by-address [[_ contact] address]
   (when (ethereum/address= (:address contact) address)

--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -1542,7 +1542,7 @@
 (handlers/register-handler-fx
  :contact/filters-added
  (fn [cofx [_ contact-identity]]
-   (contact/add-contact-and-open-chat cofx contact-identity)))
+   (contact/open-chat cofx contact-identity)))
 
 (handlers/register-handler-fx
  :contact.ui/start-group-chat-pressed
@@ -1553,7 +1553,7 @@
  :contact.ui/send-message-pressed
  [(re-frame/inject-cofx :random-id-generator)]
  (fn [cofx [_ {:keys [public-key]}]]
-   (contact/add-contact-and-open-chat cofx public-key)))
+   (contact/open-chat cofx public-key)))
 
 (handlers/register-handler-fx
  :contact.ui/contact-code-submitted

--- a/src/status_im/transport/filters.cljs
+++ b/src/status_im/transport/filters.cljs
@@ -96,8 +96,8 @@
                   :add-contact
                   (contact/add-contact public-key)
 
-                  :add-contact-and-open-chat
-                  (contact/add-contact-and-open-chat public-key)))]
+                  :open-chat
+                  (contact/open-chat public-key)))]
              filters-fx-fns
              [(mailserver/process-next-messages-request)])))))
 

--- a/src/status_im/ui/screens/chat/views.cljs
+++ b/src/status_im/ui/screens/chat/views.cljs
@@ -67,9 +67,9 @@
                                        :accessibility-label :chat-menu-button}
                            :handler   #(on-options chat-id chat-name group-chat public?)}]])]
      [connectivity/connectivity-view]
-     (when (and contact
+     (when (and (not group-chat)
                 (models.contact/can-add-to-contacts? contact))
-       [add-contact-bar (:public-key contact)])]))
+       [add-contact-bar chat-id])]))
 
 (defmulti message-row (fn [{{:keys [type]} :row}] type))
 

--- a/test/appium/requirements.txt
+++ b/test/appium/requirements.txt
@@ -17,14 +17,14 @@ execnet==1.4.1
 future==0.16.0
 idna==2.5
 kiwisolver==1.0.1
-lxml==3.8.0
+lxml==4.3.1
 matplotlib==2.2.2
 multidict==3.1.3
 namedlist==1.7
 numpy==1.14.4
 pbkdf2==1.3
 Pillow==5.1.0
-py==1.4.34
+py==1.5.1
 py-ecc==1.4.2
 pycryptodome==3.6.1
 pyethash==0.1.27
@@ -35,7 +35,7 @@ pytest-forked==0.2
 pytest-xdist==1.22.2
 python-dateutil==2.7.3
 pytz==2018.4
-PyYAML==4.1
+PyYAML==4.2b4
 repoze.lru==0.7
 requests==2.20.1
 rlp==1.0.1

--- a/test/appium/tests/atomic/chats/test_chats_management.py
+++ b/test/appium/tests/atomic/chats/test_chats_management.py
@@ -68,7 +68,7 @@ class TestChatManagement(SingleDeviceTestCase):
 
     @marks.testrail_id(5304)
     @marks.critical
-    def test_add_contact_by_pasting_public_key(self):
+    def test_open_chat_by_pasting_public_key(self):
         sign_in = SignInView(self.driver)
         home = sign_in.create_user()
         public_key = basic_user['public_key']
@@ -87,10 +87,8 @@ class TestChatManagement(SingleDeviceTestCase):
             pytest.fail('Public key is not pasted from clipboard')
         start_new_chat.confirm()
         start_new_chat.get_back_to_home_view()
-        home.plus_button.click()
-        start_new_chat.start_new_chat_button.click()
-        if not start_new_chat.element_by_text(basic_user['username']).is_element_displayed():
-            pytest.fail("List of contacts doesn't contain added user")
+        if not home.get_chat_with_user(basic_user['username']).is_element_present():
+            pytest.fail("No chat open in home view")
 
     @marks.testrail_id(5387)
     @marks.high

--- a/test/appium/views/home_view.py
+++ b/test/appium/views/home_view.py
@@ -125,6 +125,7 @@ class HomeView(BaseView):
         start_new_chat.public_key_edit_box.send_keys(public_key)
         one_to_one_chat = self.get_chat_view()
         start_new_chat.confirm_until_presence_of_element(one_to_one_chat.chat_message_input)
+        one_to_one_chat.add_to_contacts.click()
         return one_to_one_chat
 
     def start_1_1_chat(self, username):

--- a/test/cljs/status_im/test/contacts/db.cljs
+++ b/test/cljs/status_im/test/contacts/db.cljs
@@ -40,17 +40,18 @@
                [{:name             "Snappy Impressive Leonberger"
                  :photo-path       "generated"
                  :admin?           true
-                 :public-key "0x04fcf40c526b09ff9fb22f4a5dbd08490ef9b64af700870f8a0ba2133f4251d5607ed83cd9047b8c2796576bc83fa0de23a13a4dced07654b8ff137fe744047917"}
+                 :address          "71adb0644e2b590e37dafdfea8bd58f0c7668c7f"
+                 :public-key       "0x04fcf40c526b09ff9fb22f4a5dbd08490ef9b64af700870f8a0ba2133f4251d5607ed83cd9047b8c2796576bc83fa0de23a13a4dced07654b8ff137fe744047917"}
                 {:name             "User A"
                  :photo-path       "photo2"
                  :public-key "0x048a2f8b80c60f89a91b4c1316e56f75b087f446e7b8701ceca06a40142d8efe1f5aa36bd0fee9e248060a8d5207b43ae98bef4617c18c71e66f920f324869c09f"}
                 {:description      nil
                  :last-updated     0
                  :hide-contact?    false
-                 :address          "eca8218b5ebeb2c47ba94c1b6e0a779d78fff7bc"
                  :name             "User B"
                  :fcm-token        nil
                  :photo-path       "photo1"
+                 :address          "eca8218b5ebeb2c47ba94c1b6e0a779d78fff7bc"
                  :status           nil
                  :blocked?         false
                  :pending?         true


### PR DESCRIPTION
Fixes: #7401 
Fixes: #7500 
Removes sending automatically a contact request on "Send message" or "Start new chat".

Also allows to send transactions to non-contacts.
cc @goranjovic , the change is pretty small (we just build the contact if it's not in our list), but maybe you would like to have a quick look at it.

### Testing
- Send message should not add a user a contact
- Start new chat -> QR CODE / Public Key should not add a user as a contact

status: ready