### PR TITLE
Update and migrate POA network URLs.

### DIFF
--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -62,7 +62,7 @@
                :config {:NetworkId      (ethereum/chain-keyword->chain-id :poa)
                         :DataDir        "/ethereum/poa_rpc"
                         :UpstreamConfig {:Enabled true
-                                         :URL     "https://poa.infura.io"}}}})
+                                         :URL     "https://core.poa.network"}}}})
 
 (def testnet-networks
   {"testnet"     {:id     "testnet",

--- a/src/status_im/data_store/realm/schemas/base/core.cljs
+++ b/src/status_im/data_store/realm/schemas/base/core.cljs
@@ -91,6 +91,8 @@
           extension/v12
           account/v19])
 
+(def v24 v23)
+
 ;; put schemas ordered by version
 (def schemas [{:schema        v1
                :schemaVersion 1
@@ -160,4 +162,7 @@
                :migration     (constantly nil)}
               {:schema        v23
                :schemaVersion 23
-               :migration     (constantly nil)}])
+               :migration     (constantly nil)}
+              {:schema        v24
+               :schemaVersion 24
+               :migration     migrations/v24}])


### PR DESCRIPTION
fixes #7411

### Summary

Update and migrate POA networks URL.

> Infura has disconnected the POA nodes, so Status needs to switch the RPC URL from the Infura one to https://core.poa.network .

(from https://github.com/status-im/status-react/issues/7411#issuecomment-460320937)

### Testing notes (optional):

Please, check the existing account upgrades!

#### Platforms (optional)
- Android
- iOS
- macOS
- Linux
- Windows

<!-- (Specify if some specific areas has to be tested, for example 1-1 chats) -->
#### Areas that maybe impacted (optional)
**Functional**
- 1-1 chats
- public chats
- group chats
- wallet / transactions
- dapps / app browsing
- account recovery
- new account
- user profile updates
- networks
- mailservers
- fleet
- bootnodes

**Non-functional**
- battery performance
- CPU performance / speed of the app
- network consumption

<!-- (Specify exact steps to test if there are such) -->
### Steps to test:
- Open Status
- ...
- Step 3, etc.

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->