### PR TITLE
Allow multiple push notifications

### DIFF
--- a/src/status_im/accounts/update/core.cljs
+++ b/src/status_im/accounts/update/core.cljs
@@ -1,15 +1,23 @@
 (ns status-im.accounts.update.core
-  (:require [status-im.data-store.accounts :as accounts-store]
-            [status-im.transport.message.protocol :as protocol]
-            [status-im.data-store.transport :as transport-store]
-            [status-im.transport.message.contact :as message.contact]
-            [status-im.utils.fx :as fx]))
+  (:require
+   [status-im.contact.device-info :as device-info]
+   [status-im.data-store.accounts :as accounts-store]
+   [status-im.data-store.transport :as transport-store]
+   [status-im.transport.message.protocol :as protocol]
+   [status-im.transport.message.contact :as message.contact]
+   [status-im.utils.fx :as fx]))
 
-(fx/defn account-update-message [{:keys [db]}]
+(fx/defn account-update-message [{:keys [db] :as cofx}]
   (let [account (:account/account db)
         fcm-token (get-in db [:notifications :fcm-token])
         {:keys [name photo-path address]} account]
-    (message.contact/ContactUpdate. name photo-path address fcm-token)))
+    (message.contact/ContactUpdate. name photo-path address fcm-token (device-info/all cofx))))
+
+(fx/defn send-account-update [cofx]
+  (protocol/send
+   (account-update-message cofx)
+   nil
+   cofx))
 
 (fx/defn send-contact-update-fx
   [{:keys [db] :as cofx} chat-id payload]
@@ -47,7 +55,6 @@
   [{:keys [db] :as cofx} new-account-fields {:keys [success-event]}]
   (let [current-account (:account/account db)
         new-account     (merge current-account new-account-fields)
-        fcm-token       (get-in db [:notifications :fcm-token])
         fx              {:db                 (assoc db :account/account new-account)
                          :data-store/base-tx [{:transaction (accounts-store/save-account-tx new-account)
                                                :success-event success-event}]}
@@ -55,7 +62,7 @@
     (if (or (:name new-account-fields) (:photo-path new-account-fields))
       (fx/merge cofx
                 fx
-                #(protocol/send (account-update-message %) nil %))
+                #(send-account-update %))
       fx)))
 
 (fx/defn clean-seed-phrase

--- a/src/status_im/chat/models/message.cljs
+++ b/src/status_im/chat/models/message.cljs
@@ -382,14 +382,14 @@
               (add-own-status chat-id message-id :sending)
               (send chat-id message-id wrapped-record))))
 
-(fx/defn send-push-notification [cofx chat-id message-id fcm-token status]
-  (log/debug "#6772 - send-push-notification" message-id fcm-token)
-  (when (and fcm-token (= status :sent))
+(fx/defn send-push-notification [cofx chat-id message-id fcm-tokens status]
+  (log/debug "#6772 - send-push-notification" message-id fcm-tokens)
+  (when (and (seq fcm-tokens) (= status :sent))
     (let [payload {:from (accounts.db/current-public-key cofx)
                    :to chat-id
                    :id message-id}]
       {:send-notification {:data-payload (notifications/encode-notification-payload payload)
-                           :tokens       [fcm-token]}})))
+                           :tokens       fcm-tokens}})))
 
 (fx/defn update-message-status [{:keys [db]} chat-id message-id status]
   (let [from           (get-in db [:chats chat-id :messages message-id :from])

--- a/src/status_im/contact/core.cljs
+++ b/src/status_im/contact/core.cljs
@@ -2,7 +2,9 @@
   (:require [re-frame.core :as re-frame]
             [status-im.accounts.db :as accounts.db]
             [status-im.chat.models :as chat.models]
+            [clojure.set :as clojure.set]
             [status-im.contact.db :as contact.db]
+            [status-im.contact.device-info :as device-info]
             [status-im.data-store.contacts :as contacts-store]
             [status-im.data-store.messages :as data-store.messages]
             [status-im.data-store.chats :as data-store.chats]
@@ -48,6 +50,7 @@
     {:name          name
      :profile-image photo-path
      :address       address
+     :device-info   (device-info/all {:db db})
      :fcm-token     fcm-token}))
 
 (fx/defn upsert-contact [{:keys [db] :as cofx}
@@ -218,7 +221,7 @@
 (defn handle-contact-update
   [public-key
    timestamp
-   {:keys [name profile-image address fcm-token] :as m}
+   {:keys [name profile-image address fcm-token device-info] :as m}
    {{:contacts/keys [contacts] :as db} :db :as cofx}]
   ;; We need to convert to timestamp ms as before we were using now in ms to
   ;; set last updated
@@ -243,15 +246,15 @@
                                :address      (or address
                                                  (:address contact)
                                                  (contact.db/public-key->address public-key))
+                               :device-info  (device-info/merge-info
+                                              timestamp
+                                              (:device-info contact)
+                                              device-info)
                                :last-updated timestamp-ms
-                                  ;;NOTE (yenda) in case of concurrent contact request
+                                ;;NOTE (yenda) in case of concurrent contact request
                                :pending?     (get contact :pending? true)}
                                fcm-token (assoc :fcm-token fcm-token))]
-        ;;NOTE (yenda) only update if there is changes to the contact
-        (when-not (= contact-props
-                     (select-keys contact [:public-key :address :photo-path
-                                           :name :fcm-token :pending?]))
-          (upsert-contact cofx contact-props))))))
+        (upsert-contact cofx contact-props)))))
 
 (def receive-contact-request handle-contact-update)
 (def receive-contact-request-confirmation handle-contact-update)

--- a/src/status_im/contact/device_info.cljs
+++ b/src/status_im/contact/device_info.cljs
@@ -1,0 +1,26 @@
+(ns status-im.contact.device-info
+  (:require [status-im.utils.config :as config]))
+
+(defn all [{:keys [db]}]
+  (filter
+   :fcm-token
+   (conj
+    (->> (:pairing/installations db)
+         (vals)
+         (filter :enabled?)
+         (filter :fcm-token)
+         (take config/max-installations)
+         (map #(hash-map :id (:installation-id %)
+                         :fcm-token (:fcm-token %))))
+    {:id (get-in db [:account/account :installation-id])
+     :fcm-token (get-in db [:notifications :fcm-token])})))
+
+(defn merge-info [timestamp previous-devices new-devices]
+  (reduce (fn [acc {:keys [id] :as new-device}]
+            (if (:fcm-token new-device)
+              (assoc acc
+                     id
+                     (assoc new-device :timestamp timestamp))
+              acc))
+          previous-devices
+          new-devices))

--- a/src/status_im/data_store/contacts.cljs
+++ b/src/status_im/data_store/contacts.cljs
@@ -8,6 +8,9 @@
   (-> contact
       (update :tags #(into #{} %))))
 
+(defn- serialize-contact [contact]
+  (update contact :device-info #(or (vals %) [])))
+
 (re-frame/reg-cofx
  :data-store/get-all-contacts
  (fn [coeffects _]
@@ -22,7 +25,7 @@
   (fn [realm]
     (core/create realm
                  :contact
-                 contact
+                 (serialize-contact contact)
                  true)))
 
 (defn save-contacts-tx

--- a/src/status_im/data_store/realm/schemas/account/contact.cljs
+++ b/src/status_im/data_store/realm/schemas/account/contact.cljs
@@ -93,3 +93,7 @@
                       :description      {:type :string :optional true}
                       :public-key       :string
                       :tags             {:type     "string[]"}}})
+
+(def v5 (assoc-in v4 [:properties :device-info]
+                  {:type       :list
+                   :objectType :contact-device-info}))

--- a/src/status_im/data_store/realm/schemas/account/contact_device_info.cljs
+++ b/src/status_im/data_store/realm/schemas/account/contact_device_info.cljs
@@ -1,0 +1,7 @@
+(ns status-im.data-store.realm.schemas.account.contact-device-info)
+
+(def v1 {:name :contact-device-info
+         :primaryKey :id
+         :properties {:id :string
+                      :timestamp :int
+                      :fcm-token :string}})

--- a/src/status_im/data_store/realm/schemas/account/core.cljs
+++ b/src/status_im/data_store/realm/schemas/account/core.cljs
@@ -6,6 +6,7 @@
             [status-im.data-store.realm.schemas.account.contact :as contact]
             [status-im.data-store.realm.schemas.account.message :as message]
             [status-im.data-store.realm.schemas.account.user-status :as user-status]
+            [status-im.data-store.realm.schemas.account.contact-device-info :as contact-device-info]
             [status-im.data-store.realm.schemas.account.local-storage :as local-storage]
             [status-im.data-store.realm.schemas.account.mailserver :as mailserver]
             [status-im.data-store.realm.schemas.account.browser :as browser]
@@ -413,6 +414,21 @@
           dapp-permissions/v9
           contact-recovery/v1])
 
+(def v37 [chat/v14
+          transport/v8
+          contact/v5
+          message/v9
+          mailserver/v11
+          mailserver-topic/v1
+          user-status/v2
+          membership-update/v1
+          installation/v3
+          local-storage/v1
+          browser/v8
+          dapp-permissions/v9
+          contact-device-info/v1
+          contact-recovery/v1])
+
 ;; put schemas ordered by version
 (def schemas [{:schema        v1
                :schemaVersion 1
@@ -521,4 +537,7 @@
                :migration     migrations/v35}
               {:schema        v36
                :schemaVersion 36
+               :migration     (constantly nil)}
+              {:schema        v37
+               :schemaVersion 37
                :migration     (constantly nil)}])

--- a/src/status_im/data_store/realm/schemas/account/installation.cljs
+++ b/src/status_im/data_store/realm/schemas/account/installation.cljs
@@ -21,3 +21,6 @@
 
 (def v3 (assoc-in v2 [:properties :name] {:type     :string
                                           :optional true}))
+
+(def v4 (assoc-in v3 [:properties :fcm-token] {:type     :string
+                                               :optional true}))

--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -1633,12 +1633,16 @@
 (handlers/register-handler-fx
  :pairing.callback/enable-installation-success
  (fn [cofx [_ installation-id]]
-   (pairing/enable cofx installation-id)))
+   (fx/merge cofx
+             (pairing/enable installation-id)
+             (accounts.update/send-account-update))))
 
 (handlers/register-handler-fx
  :pairing.callback/disable-installation-success
  (fn [cofx [_ installation-id]]
-   (pairing/disable cofx installation-id)))
+   (fx/merge cofx
+             (pairing/disable installation-id)
+             (accounts.update/send-account-update))))
 
 ;; Contact recovery module
 

--- a/src/status_im/pairing/core.cljs
+++ b/src/status_im/pairing/core.cljs
@@ -3,6 +3,7 @@
             [clojure.string :as string]
             [status-im.i18n :as i18n]
             [status-im.utils.fx :as fx]
+            [status-im.contact.device-info :as device-info]
             [status-im.ui.screens.navigation :as navigation]
             [status-im.utils.config :as config]
             [status-im.utils.platform :as utils.platform]
@@ -21,7 +22,6 @@
             [status-im.transport.message.pairing :as transport.pairing]))
 
 (def contact-batch-n 4)
-(def max-installations 2)
 
 (defn- parse-response [response-js]
   (-> response-js
@@ -29,10 +29,11 @@
       (js->clj :keywordize-keys true)))
 
 (defn pair-installation [cofx]
-  (let [installation-name (get-in cofx [:db :account/account :installation-name])
+  (let [fcm-token         (get-in cofx [:db :notifications :fcm-token])
+        installation-name (get-in cofx [:db :account/account :installation-name])
         installation-id (get-in cofx [:db :account/account :installation-id])
         device-type     utils.platform/os]
-    (protocol/send (transport.pairing/PairInstallation. installation-id device-type installation-name) nil cofx)))
+    (protocol/send (transport.pairing/PairInstallation. installation-id device-type installation-name fcm-token) nil cofx)))
 
 (defn has-paired-installations? [cofx]
   (->>
@@ -51,6 +52,9 @@
   (let [[old-contact new-contact] (sort-by :last-updated [remote local])]
     (-> local
         (merge new-contact)
+        (assoc :device-info (device-info/merge-info (:last-updated new-contact)
+                                                    (:device-info old-contact)
+                                                    (vals (:device-info new-contact))))
         (assoc :pending? (boolean
                           (and (:pending? local true)
                                (:pending? remote true)))))))
@@ -137,13 +141,13 @@
             [(sync-installation-account-message cofx)]
             (chats->sync-installation-messages cofx))))
 
-(defn enable [{:keys [db]} installation-id]
+(fx/defn enable [{:keys [db]} installation-id]
   {:db (assoc-in db
                  [:pairing/installations installation-id :enabled?]
                  true)
    :data-store/tx [(data-store.installations/enable installation-id)]})
 
-(defn disable [{:keys [db]} installation-id]
+(fx/defn disable [{:keys [db]} installation-id]
   {:db (assoc-in db
                  [:pairing/installations installation-id :enabled?]
                  false)
@@ -174,7 +178,7 @@
                                       (partial handle-disable-installation-response installation-id)))
 
 (defn enable-fx [cofx installation-id]
-  (if (< (count (filter :enabled? (get-in cofx [:db :pairing/installations]))) max-installations)
+  (if (< (count (filter :enabled? (get-in cofx [:db :pairing/installations]))) config/max-installations)
     {:pairing/enable-installation installation-id}
     {:utils/show-popup {:title (i18n/label :t/pairing-maximum-number-reached-title)
 
@@ -243,11 +247,15 @@
                   (models.chat/start-public-chat % (:chat-id chat) {:dont-navigate? true}))]
               contacts-fx)))))
 
-(defn handle-pair-installation [{:keys [db] :as cofx} {:keys [name installation-id device-type]} timestamp sender]
+(defn handle-pair-installation [{:keys [db] :as cofx} {:keys [name
+                                                              fcm-token
+                                                              installation-id
+                                                              device-type]} timestamp sender]
   (when (and (= sender (accounts.db/current-public-key cofx))
              (not= (get-in db [:account/account :installation-id]) installation-id))
     (let [installation {:installation-id   installation-id
                         :name              name
+                        :fcm-token         fcm-token
                         :device-type       device-type
                         :last-paired       timestamp}]
       (upsert-installation cofx installation))))

--- a/src/status_im/transport/message/contact.cljs
+++ b/src/status_im/transport/message/contact.cljs
@@ -4,19 +4,19 @@
             [status-im.transport.message.protocol :as protocol]
             [status-im.utils.fx :as fx]))
 
-(defrecord ContactRequest [name profile-image address fcm-token]
+(defrecord ContactRequest [name profile-image address fcm-token device-info]
   protocol/StatusMessage
   (validate [this]
     (when (spec/valid? :message/contact-request this)
       this)))
 
-(defrecord ContactRequestConfirmed [name profile-image address fcm-token]
+(defrecord ContactRequestConfirmed [name profile-image address fcm-token device-info]
   protocol/StatusMessage
   (validate [this]
     (when (spec/valid? :message/contact-request-confirmed this)
       this)))
 
-(defrecord ContactUpdate [name profile-image address fcm-token]
+(defrecord ContactUpdate [name profile-image address fcm-token device-info]
   protocol/StatusMessage
   (validate [this]
     (when (spec/valid? :message/contact-update this)

--- a/src/status_im/transport/message/pairing.cljs
+++ b/src/status_im/transport/message/pairing.cljs
@@ -4,7 +4,7 @@
             [taoensso.timbre :as log]))
 
 (defrecord PairInstallation
-           [installation-id device-type name]
+           [installation-id device-type name fcm-token]
   protocol/StatusMessage
   (validate [this]
     (if (spec/valid? :message/pair-installation this)

--- a/src/status_im/utils/config.cljs
+++ b/src/status_im/utils/config.cljs
@@ -47,3 +47,4 @@
 (def pow-target (js/parseFloat (get-config :POW_TARGET "0.002")))
 (def pow-time (js/parseInt (get-config :POW_TIME "1")))
 (def use-sym-key (enabled? (get-config :USE_SYM_KEY 0)))
+(def max-installations 2)

--- a/test/cljs/status_im/test/contacts/device_info.cljs
+++ b/test/cljs/status_im/test/contacts/device_info.cljs
@@ -1,0 +1,34 @@
+(ns status-im.test.contacts.device-info
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [status-im.contact.device-info :as device-info]))
+
+(def device-list
+  {"2" {:installation-id "2"
+        :fcm-token "token-2"
+        :enabled? true}
+   "3" {:installation-id "3"
+        :fcm-token "token-3"
+        :enabled? false}
+   "4" {:installation-id "4"
+        :enabled? true}
+   "5" {:installation-id "5"
+        :fcm-token "token-5"
+        :enabled? true}})
+
+(deftest device-info-all
+  (testing "no devices"
+    (is (= [{:id "1"
+             :fcm-token "token-1"}]
+           (device-info/all {:db {:account/account {:installation-id "1"}
+                                  :notifications   {:fcm-token "token-1"}}})))
+
+    (testing "some devices"
+      (is (= [{:id "1"
+               :fcm-token "token-1"}
+              {:id "2"
+               :fcm-token "token-2"}
+              {:id "5"
+               :fcm-token "token-5"}]
+             (device-info/all {:db {:account/account {:installation-id "1"}
+                                    :pairing/installations device-list
+                                    :notifications   {:fcm-token "token-1"}}}))))))

--- a/test/cljs/status_im/test/models/contact.cljs
+++ b/test/cljs/status_im/test/models/contact.cljs
@@ -28,6 +28,8 @@
                   {:name "name"
                    :profile-image "image"
                    :address "address"
+                   :device-info [{:id "1"
+                                  :fcm-token "token-1"}]
                    :fcm-token "token"}
                   {:db {}})
           contact (get-in actual [:db :contacts/contacts public-key])]
@@ -39,6 +41,9 @@
                  :name             "name"
                  :last-updated     1000
                  :pending?         true
+                 :device-info      {"1" {:id "1"
+                                         :timestamp 1
+                                         :fcm-token "token-1"}}
                  :fcm-token        "token"
                  :address          "address"} contact)))))
   (testing "the contact is already in contacts"
@@ -48,6 +53,10 @@
                     1
                     {:name "new-name"
                      :profile-image "new-image"
+                     :device-info [{:id "2"
+                                    :fcm-token "token-2"}
+                                   {:id "3"
+                                    :fcm-token "token-3"}]
                      :address "new-address"
                      :fcm-token "new-token"}
                     {:db {:contacts/contacts
@@ -55,6 +64,12 @@
                                        :photo-path       "old-image"
                                        :name             "old-name"
                                        :last-updated     0
+                                       :device-info      {"1" {:id "1"
+                                                               :timestamp 0
+                                                               :fcm-token "token-1"}
+                                                          "2" {:id "2"
+                                                               :timestamp 0
+                                                               :fcm-token "token-2"}}
                                        :pending?         false
                                        :fcm-token        "old-token"
                                        :address          "old-address"}}}})
@@ -66,6 +81,15 @@
                    :photo-path       "new-image"
                    :name             "new-name"
                    :last-updated     1000
+                   :device-info      {"1" {:id "1"
+                                           :fcm-token "token-1"
+                                           :timestamp 0}
+                                      "2" {:id "2"
+                                           :fcm-token "token-2"
+                                           :timestamp 1}
+                                      "3" {:id "3"
+                                           :fcm-token "token-3"
+                                           :timestamp 1}}
                    :pending?         false
                    :fcm-token        "new-token"
                    :address          "new-address"} contact)))))
@@ -116,6 +140,8 @@
                   {:db {:contacts/contacts
                         {public-key {:public-key       public-key
                                      :photo-path       "old-image"
+                                     :device-info      {"1" {:id "1"
+                                                             :fcm-token "token-1"}}
                                      :name             "old-name"
                                      :last-updated     0
                                      :pending?         false}}}})
@@ -126,6 +152,8 @@
         (is (=  {:public-key       public-key
                  :photo-path       "new-image"
                  :name             "new-name"
+                 :device-info      {"1" {:id "1"
+                                         :fcm-token "token-1"}}
                  :last-updated     1000
                  :pending?         false
                  :address          address} contact)))))

--- a/test/cljs/status_im/test/pairing/core.cljs
+++ b/test/cljs/status_im/test/pairing/core.cljs
@@ -19,6 +19,7 @@
           expected  {:pending? false
                      :this-should-be-kept true
                      :last-updated 2
+                     :device-info nil
                      :name "name-v2"
                      :photo-path "photo-v2"}]
       (is (= expected (pairing/merge-contact contact-1 contact-2)))))
@@ -32,6 +33,7 @@
                      :photo-path "photo-v2"}
           expected  {:pending? false
                      :last-updated 2
+                     :device-info nil
                      :name "name-v2"
                      :photo-path "photo-v2"}]
       (is (= expected (pairing/merge-contact contact-1 contact-2)))))
@@ -43,6 +45,7 @@
                      :photo-path "photo-v2"}
           expected  {:pending? false
                      :last-updated 2
+                     :device-info nil
                      :name "name-v2"
                      :photo-path "photo-v2"}]
       (is (= expected (pairing/merge-contact contact-1 contact-2)))))
@@ -57,6 +60,7 @@
                      :photo-path "photo-v2"}
           expected  {:pending? false
                      :last-updated 2
+                     :device-info nil
                      :name "name-v2"
                      :photo-path "photo-v2"}]
       (is (= expected (pairing/merge-contact contact-1 contact-2)))))
@@ -68,13 +72,48 @@
                      :photo-path "photo-v2"}
           expected  {:pending? true
                      :last-updated 2
+                     :device-info nil
+                     :name "name-v2"
+                     :photo-path "photo-v2"}]
+      (is (= expected (pairing/merge-contact contact-1 contact-2)))))
+  (testing "device-info"
+    (let [contact-1 {:pending? false
+                     :last-updated 1
+                     :name "name-v1"
+                     :device-info {"1" {:timestamp 1
+                                        :fcm-token "token-1"
+                                        :id "1"}
+                                   "2" {:timestamp 1
+                                        :fcm-token "token-2"
+                                        :id "2"}}
+                     :photo-path "photo-v1"}
+          contact-2 {:pending? false
+                     :last-updated 2
+                     :name "name-v2"
+                     :device-info {"2" {:timestamp 2
+                                        :fcm-token "token-2"
+                                        :id "2"}
+                                   "3" {:timestamp 2
+                                        :fcm-token "token-3"
+                                        :id "3"}}
+                     :photo-path "photo-v2"}
+          expected  {:pending? false
+                     :last-updated 2
+                     :device-info {"1" {:timestamp 1
+                                        :fcm-token "token-1"
+                                        :id "1"}
+                                   "2" {:timestamp 2
+                                        :fcm-token "token-2"
+                                        :id "2"}
+                                   "3" {:timestamp 2
+                                        :fcm-token "token-3"
+                                        :id "3"}}
                      :name "name-v2"
                      :photo-path "photo-v2"}]
       (is (= expected (pairing/merge-contact contact-1 contact-2))))))
 
 (deftest handle-sync-installation-test
   (with-redefs [identicon/identicon (constantly "generated")]
-
     (testing "syncing contacts"
       (let [old-contact-1   {:name "old-contact-one"
                              :public-key "contact-1"
@@ -122,12 +161,12 @@
                                      "contact-2" old-contact-2
                                      "contact-4" contact-4
                                      "contact-5" remote-contact-5}}
-            expected {"contact-1" new-contact-1
-                      "contact-2" new-contact-2
+            expected {"contact-1" (assoc new-contact-1 :device-info nil)
+                      "contact-2" (assoc new-contact-2 :device-info nil)
                       "contact-3" contact-3
                       "contact-4" (assoc contact-4
                                          :photo-path "generated")
-                      "contact-5" local-contact-5}]
+                      "contact-5" (assoc local-contact-5 :device-info nil)}]
         (testing "not coming from us"
           (is (not (pairing/handle-sync-installation cofx sync-message "not-us"))))
         (testing "coming from us"
@@ -169,6 +208,7 @@
                                            "2" {:has-bundle? false
                                                 :installation-id "2"}}}}
         pair-message {:device-type "ios"
+                      :fcm-token "fcm-token"
                       :name "name"
                       :installation-id "1"}]
     (testing "not coming from us"
@@ -176,6 +216,7 @@
     (testing "coming from us"
       (is (= {"1" {:has-bundle? true
                    :installation-id "1"
+                   :fcm-token "fcm-token"
                    :name "name"
                    :last-paired 1
                    :device-type "ios"}

--- a/test/cljs/status_im/test/runner.cljs
+++ b/test/cljs/status_im/test/runner.cljs
@@ -1,6 +1,7 @@
 (ns status-im.test.runner
   (:require [doo.runner :refer-macros [doo-tests]]
             [status-im.test.contacts.db]
+            [status-im.test.contacts.device-info]
             [status-im.test.data-store.chats]
             [status-im.test.data-store.core]
             [status-im.test.data-store.realm.core]
@@ -76,6 +77,7 @@
  'status-im.test.utils.async
  'status-im.test.chat.db
  'status-im.test.contacts.db
+ 'status-im.test.contacts.device-info
  'status-im.test.chat.models
  'status-im.test.init.core
  'status-im.test.data-store.chats


### PR DESCRIPTION
We keep tokens synchronized across devices, so that the user can notify
us on any paired device.
Currently we record the installation id associated to the fcm-token even
though is not necessary, but it will be once we send device-to-device
messages, in which case we want to notify only those devices.

## How does it work?

A device advertise their own token on contact request/updates etc (same as before)
In addition to advertising their own token, they advertise the token of each enabled paired device.

When sending a message, a peer will take the last 3 fcm-token (3 is the maximum number of paired devices), and send a push notifications to those devices. It will be forgiving meaning that it will not use pairing info to exclude devices.

## Testing

### Normal flow

1) Create device A1 & A2 and B1
2) Pair device A1 & A2
3) Add B1 to contacts
4) Send a message from B to A, both A1 & A2 should get a notification

### Pairing flow

1) Follow normal flow
2) Create device B2 and pair B1
3) Sync all from B1 to B2
4) Send a message from B2 to A, both A1 & A2 should get a notification


### Non-paired flow

1) Create device A1 & A2 and B1
2) Add B1 to contacts from A1
3) Add B1 to contacts from A2
4) Send a message from B to A, both A1 & A2 should get notifications

### Too many devices

1) Create device A1 & A2 & A3 and B1
2) Pair device A1 & A2 & A3
3) Add B1 to contacts
4) Send a message from B to A, both A1 & A2 & A3 should get notifications
5) create device A4
6) Add B to contacts on A4
7) Send a message from B to A, only 3 devices should get notifications (A4 included, one of A1/A2/A3 should be missing)

status: ready