### PR TITLE
[#7374] stickers polishing

### DIFF
--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -1652,7 +1652,7 @@
                                                           [:stickers/load-sticker-pack-success o])
                                  :failure-event-creator (fn [o] nil)})
                       ;;TODO for testing ONLY
-                      ["https://ipfs.infura.io/ipfs/QmbgsCFEz4ubLFzF3SFfCxDEeXeMxe4yypxC3W1Ro9rLXS/"])}))
+                      ["https://ipfs.infura.io/ipfs/QmRKmQjXyqpfznQ9Y9dTnKePJnQxoJATivPbGcCAKRsZJq/"])}))
 
 (handlers/register-handler-fx
  :stickers/select-pack

--- a/src/status_im/ui/screens/chat/input/input.cljs
+++ b/src/status_im/ui/screens/chat/input/input.cljs
@@ -106,7 +106,7 @@
         :accessibility-label :chat-commands-button}
        [react/view
         [vector-icons/icon :main-icons/commands {:container-style style/input-commands-icon
-                                                 :color           :dark}]]])))
+                                                 :color           colors/gray}]]])))
 
 (defview reply-message [from message-text]
   (letsubs [username           [:contacts/contact-name-by-identity from]

--- a/src/status_im/ui/screens/chat/stickers/styles.cljs
+++ b/src/status_im/ui/screens/chat/stickers/styles.cljs
@@ -1,4 +1,5 @@
-(ns status-im.ui.screens.chat.stickers.styles)
+(ns status-im.ui.screens.chat.stickers.styles
+  (:require [status-im.utils.platform :as platform]))
 
 (def stickers-panel {:flex 1 :margin 5 :flex-direction :row :justify-content :flex-start :flex-wrap :wrap})
 
@@ -11,3 +12,9 @@
    :border-radius     (/ icon-size 2)
    :align-items       :center
    :justify-content   :center})
+
+(defn stickers-panel-height []
+  (cond
+    platform/iphone-x? 299
+    platform/ios? 258
+    :else 272))

--- a/src/status_im/ui/screens/stickers/subs.cljs
+++ b/src/status_im/ui/screens/stickers/subs.cljs
@@ -25,6 +25,13 @@
    (map #(if (get installed (:id %)) (assoc % :installed true) %) (vals packs))))
 
 (re-frame/reg-sub
+ :stickers/get-current-pack
+ :<- [:get-screen-params]
+ :<- [:stickers/all-packs]
+ (fn [[{:keys [id]} packs]]
+   (first (filter #(= (:id %) id) packs))))
+
+(re-frame/reg-sub
  :stickers/recent
  :<- [:account/account]
  (fn [{:keys [recent-stickers]}]

--- a/src/status_im/ui/screens/stickers/views.cljs
+++ b/src/status_im/ui/screens/stickers/views.cljs
@@ -11,10 +11,8 @@
             [status-im.ui.components.icons.vector-icons :as icons]
             [status-im.utils.money :as money]))
 
-(def thumbnail-icon-size 40)
-
-(defn- thumbnail-icon [uri]
-  [react/image {:style  {:width thumbnail-icon-size :height thumbnail-icon-size :border-radius (/ thumbnail-icon-size 2)}
+(defn- thumbnail-icon [uri size]
+  [react/image {:style  {:width size :height size :border-radius (/ size 2)}
                 :source {:uri uri}}])
 
 (defn- installed-icon []
@@ -39,17 +37,17 @@
                (str price))]]])))
 
 (defn pack-badge [{:keys [name author price thumbnail preview id installed] :as pack}]
-  [react/view {:margin-bottom 27}
-   [react/touchable-highlight {:on-press #(re-frame/dispatch [:navigate-to :stickers-pack pack])}
-    [react/image {:style {:height 200 :border-radius 20} :source {:uri preview}}]]
-   [react/view {:height 64 :align-items :center :flex-direction :row}
-    [thumbnail-icon thumbnail]
-    [react/view {:padding-horizontal 16 :flex 1}
-     [react/text {:style {:font-size 15}} name]
-     [react/text {:style {:font-size 15 :color colors/gray :margin-top 6}} author]]
-    (if installed
-      [installed-icon]
-      [price-badge price id])]])
+  [react/touchable-highlight {:on-press #(re-frame/dispatch [:navigate-to :stickers-pack pack])}
+   [react/view {:margin-bottom 27}
+    [react/image {:style {:height 200 :border-radius 20} :source {:uri preview}}]
+    [react/view {:height 64 :align-items :center :flex-direction :row}
+     [thumbnail-icon thumbnail 40]
+     [react/view {:padding-horizontal 16 :flex 1}
+      [react/text {:style {:font-size 15}} name]
+      [react/text {:style {:font-size 15 :color colors/gray :margin-top 6}} author]]
+     (if installed
+       [installed-icon]
+       [price-badge price id])]]])
 
 (defview packs []
   (letsubs [packs [:stickers/all-packs]]
@@ -67,13 +65,13 @@
 (def sticker-icon-size 60)
 
 (defview pack []
-  (letsubs [{:keys [id name author price thumbnail stickers installed]} [:get-screen-params]]
+  (letsubs [{:keys [id name author price thumbnail stickers installed]} [:stickers/get-current-pack]]
     [react/view styles/screen
      [status-bar/status-bar]
      [react/keyboard-avoiding-view components.styles/flex
       [toolbar/simple-toolbar]
-      [react/view {:height 94 :align-items :center :flex-direction :row :padding-horizontal 16}
-       [thumbnail-icon thumbnail]
+      [react/view {:height 74 :align-items :center :flex-direction :row :padding-horizontal 16}
+       [thumbnail-icon thumbnail 64]
        [react/view {:padding-horizontal 16 :flex 1}
         [react/text {:style {:font-size 22 :font-weight :bold}} name]
         [react/text {:style {:font-size 15 :color colors/gray :margin-top 6}} author]]

--- a/src/status_im/utils/navigation.cljs
+++ b/src/status_im/utils/navigation.cljs
@@ -1,16 +1,17 @@
 (ns status-im.utils.navigation
-  (:require [status-im.react-native.js-dependencies :as js-dependencies]))
+  (:require [status-im.react-native.js-dependencies :as js-dependencies]
+            [status-im.utils.platform :as platform]))
 
 (def navigation-actions
-  (when (not status-im.utils.platform/desktop?)
+  (when (not platform/desktop?)
     (.-NavigationActions js-dependencies/react-navigation)))
 
 (def navigation-events
-  (when (not status-im.utils.platform/desktop?)
+  (when (not platform/desktop?)
     (.-NavigationEvents js-dependencies/react-navigation)))
 
 (def stack-actions
-  (when (not status-im.utils.platform/desktop?)
+  (when (not platform/desktop?)
     (.-StackActions js-dependencies/react-navigation)))
 
 (def navigator-ref (atom nil))
@@ -20,7 +21,7 @@
 
 (defn can-be-called? []
   (and @navigator-ref
-       (not status-im.utils.platform/desktop?)))
+       (not platform/desktop?)))
 
 (defn navigate-to [route]
   (when (can-be-called?)


### PR DESCRIPTION

fixes #7374


**Polish**
- [x] the icon for Commands is black, should be Grey (common, not related to stickers)
- [x] like [I've mentioned before](https://github.com/status-im/status-react/pull/7210#issuecomment-451949739), the Sticker Menu should grab its height from the system keyboard
- [x] The 'Get stickers' button doesn't have touch feedback, it should be a Touchable with Opacity
- [x] Sticker Market, tapping on the smaller sticker thumbnail, title or artist name should also lead you to sticker details, the only area that's outside of that is the install button.
- [x] Sticker Pack Details, the thumbnail should be a 64 by 64
- [x] Sticker Pack Details, the entire top toolbar is too high, should be a 188 instead of 202px
- [x] the underline under selected sticker pack should have a 1px border radius. We're designers, we round everything ;) 
- [x] a non-issue yet since we won't have many packs at launch but the sticker pack selection menu should be horizontally scrollable

**Separate issues**
- a beautiful thing that would make me cry is if the menu wouldn't 'jump' on opening but animate instead. But this is a larger problem as the text input also has this wonky issue where only the keyboard animates smoothly and the input just teleports into position. [Issue required]
