### PR TITLE
new ghcmgr API requries repo name in path

### DIFF
--- a/ci/common.groovy
+++ b/ci/common.groovy
@@ -232,7 +232,7 @@ def ghcmgrPostBuild(success) {
       curl --silent --verbose -XPOST --data '${json}' \
         -u '${GHCMGR_USER}:${GHCMGR_PASS}' \
         -H "content-type: application/json" \
-        '${ghcmgrurl}/builds/${changeId}'
+        '${ghcmgrurl}/builds/status-react/${changeId}'
     """
   }
 }


### PR DESCRIPTION
I've implemented multi-repo comment management in `ghcmgr`.
Change: https://github.com/status-im/github-comment-manager/commit/303079ea7d2dc68c3849299db366a3b39d38396b
Now the API path requires repo name.

NOTE: I've kept the previous API path for transition time:
https://github.com/status-im/github-comment-manager/blob/master/src/app.js#L27