### PR TITLE
Change behavior of all-filters-added

### DIFF
--- a/src/status_im/transport/db.cljs
+++ b/src/status_im/transport/db.cljs
@@ -2,6 +2,7 @@
  status-im.transport.db
   (:require [cljs.spec.alpha :as spec]
             [clojure.string :as s]
+            [clojure.set :as sets]
             status-im.contact.db
             [status-im.utils.config :as config]
             [status-im.utils.clocks :as utils.clocks]
@@ -132,4 +133,4 @@
                                              chat-id)
                                         topic))
                                     (get db :transport/chats))))]
-    (= chats filters)))
+    (empty? (sets/difference chats filters))))


### PR DESCRIPTION
Before we checked filters are exactly the same as the chats.
If there's any state mismatch, this will result in not fetching messages
from the mailserver.
This might not be necessarily what we want, we probably want to be
resilient to this case, as currently it's not fetching messages as I have more filter than I ought to (investigating the issue).

status: ready