### PR TITLE
[fix] public chat icon when following link from private chat

### DIFF
--- a/src/status_im/ui/components/chat_icon/screen.cljs
+++ b/src/status_im/ui/components/chat_icon/screen.cljs
@@ -1,10 +1,11 @@
 (ns status-im.ui.components.chat-icon.screen
-  (:require-macros [status-im.utils.views :refer [defview letsubs]])
   (:require [clojure.string :as string]
-            [status-im.ui.components.react :as react]
+            [re-frame.core :as re-frame.core]
             [status-im.ui.components.chat-icon.styles :as styles]
-            [status-im.ui.screens.chat.photos :as photos]
-            [status-im.ui.components.colors :as colors]))
+            [status-im.ui.components.colors :as colors]
+            [status-im.ui.components.react :as react]
+            [status-im.ui.screens.chat.photos :as photos])
+  (:require-macros [status-im.utils.views :refer [defview letsubs]]))
 
 (defn default-chat-icon [name styles]
   (when-not (string/blank? name)
@@ -27,14 +28,15 @@
        [react/view pending-outer-circle
         [react/view pending-inner-circle]]])))
 
-(defview chat-icon-view [chat-id _group-chat name _online styles & [hide-dapp?]]
-  (letsubs [photo-path [:contacts/chat-photo chat-id]
-            dapp?      [:get-in [:contacts/contacts chat-id :dapp?]]]
+(defn chat-icon-view
+  [chat-id _group-chat name _online styles & [hide-dapp?]]
+  (let [photo-path (re-frame.core/subscribe [:contacts/chat-photo chat-id])
+        dapp?      (re-frame.core/subscribe [:get-in [:contacts/contacts chat-id :dapp?]])]
     [react/view (:container styles)
-     (if-not (string/blank? photo-path)
-       [photos/photo photo-path styles]
+     (if-not (string/blank? @photo-path)
+       [photos/photo @photo-path styles]
        [default-chat-icon name styles])
-     (when (and dapp? (not hide-dapp?))
+     (when (and @dapp? (not hide-dapp?))
        [dapp-badge styles])
      [pending-contact-badge chat-id styles]]))
 

--- a/src/status_im/ui/screens/chat/toolbar_content.cljs
+++ b/src/status_im/ui/screens/chat/toolbar_content.cljs
@@ -1,15 +1,11 @@
 (ns status-im.ui.screens.chat.toolbar-content
-  (:require-macros [status-im.utils.views :refer [defview letsubs]])
-  (:require [clojure.string :as string]
-            [cljs-time.core :as t]
-            [status-im.ui.components.react :as react]
+  (:require [cljs-time.core :as t]
             [status-im.i18n :as i18n]
-            [status-im.ui.screens.chat.photos :as photos]
-            [status-im.ui.screens.chat.styles.main :as st]
-            [status-im.utils.datetime :as time]
             [status-im.ui.components.chat-icon.screen :as chat-icon.screen]
-            [status-im.ui.components.common.common :as components.common]
-            [status-im.ui.components.styles :as common.styles]))
+            [status-im.ui.components.react :as react]
+            [status-im.ui.screens.chat.styles.main :as st]
+            [status-im.utils.datetime :as time])
+  (:require-macros [status-im.utils.views :refer [defview letsubs]]))
 
 (defn- online-text [contact chat-id]
   (if contact


### PR DESCRIPTION
- when following a link from a private chat, the public chat icons
was staying the same

#### Platforms
- Android
- iOS

**Functional**
- 1-1 chats
- public chats

<!-- (Specify exact steps to test if there are such) -->
### Steps to test:
- Open Status
- Open a 1-1 chat with a message containing `#status` and tap on the link
- #status public chat should open with the right icon

status: ready <!-- Can be ready or wip -->
