### PR TITLE
Dont setup topic as it resets the discovery filter

### DIFF
--- a/src/status_im/group_chats/core.cljs
+++ b/src/status_im/group_chats/core.cljs
@@ -522,7 +522,9 @@
                                             :members-joined           (:members-joined new-group)
                                             :contacts                 (:contacts new-group)})
                   (add-system-messages chat-id previous-chat new-group)
-                  (set-up-topic chat-id previous-chat)
+
+                  (when config/group-chats-publish-to-topic?
+                    (set-up-topic chat-id previous-chat))
                   #(when (and message
                               ;; don't allow anything but group messages
                               (instance? protocol/Message message)

--- a/test/cljs/status_im/test/group_chats/core.cljs
+++ b/test/cljs/status_im/test/group_chats/core.cljs
@@ -170,33 +170,34 @@
                    (map (comp :text :content) (sort-by :clock-value (vals (:messages actual-chat))))))))))))
 
 (deftest set-up-topic
-  (let [cofx {:now 0 :db {:account/account {:public-key admin}}}]
-    (testing "a brand new chat"
-      (let [actual (group-chats/handle-membership-update cofx initial-message "payload" admin)]
-        (testing "it sets up a topic"
-          (is (:shh/add-discovery-filters actual)))))
-    (testing "an existing chat"
-      (let [cofx  (assoc cofx
-                         :db
-                         (:db (group-chats/handle-membership-update cofx initial-message "payload" admin)))
-            new-message {:chat-id chat-id
-                         :membership-updates [{:from member-1
-                                               :events [{:type "chat-created"
-                                                         :clock-value 1
-                                                         :name "group-name"}
-                                                        {:type "admins-added"
-                                                         :clock-value 10
-                                                         :members [member-2]}
-                                                        {:type "admin-removed"
-                                                         :clock-value 11
-                                                         :member member-1}]}
-                                              {:from member-1
-                                               :events [{:type "member-removed"
-                                                         :clock-value 12
-                                                         :member member-1}]}]}
-            actual (group-chats/handle-membership-update cofx new-message "payload" admin)]
-        (testing "it removes the topic"
-          (is (:shh/remove-filters actual)))))))
+  (with-redefs [config/group-chats-publish-to-topic? true]
+    (let [cofx {:now 0 :db {:account/account {:public-key admin}}}]
+      (testing "a brand new chat"
+        (let [actual (group-chats/handle-membership-update cofx initial-message "payload" admin)]
+          (testing "it sets up a topic"
+            (is (:shh/add-discovery-filters actual)))))
+      (testing "an existing chat"
+        (let [cofx  (assoc cofx
+                           :db
+                           (:db (group-chats/handle-membership-update cofx initial-message "payload" admin)))
+              new-message {:chat-id chat-id
+                           :membership-updates [{:from member-1
+                                                 :events [{:type "chat-created"
+                                                           :clock-value 1
+                                                           :name "group-name"}
+                                                          {:type "admins-added"
+                                                           :clock-value 10
+                                                           :members [member-2]}
+                                                          {:type "admin-removed"
+                                                           :clock-value 11
+                                                           :member member-1}]}
+                                                {:from member-1
+                                                 :events [{:type "member-removed"
+                                                           :clock-value 12
+                                                           :member member-1}]}]}
+              actual (group-chats/handle-membership-update cofx new-message "payload" admin)]
+          (testing "it removes the topic"
+            (is (:shh/remove-filters actual))))))))
 
 (deftest build-group-test
   (testing "only adds"


### PR DESCRIPTION
disabling for now as it causes to re-fetch the discovery topic on login when a group chat is created.
status: ready