### PR TITLE
[fix] show first letter of public chat name in icon instead of #

### DIFF
--- a/src/status_im/ui/components/chat_icon/screen.cljs
+++ b/src/status_im/ui/components/chat_icon/screen.cljs
@@ -11,7 +11,7 @@
   (when-not (string/blank? name)
     [react/view (:default-chat-icon styles)
      [react/text {:style (:default-chat-icon-text styles)}
-      (string/capitalize (first name))]]))
+      (string/capitalize (second name))]]))
 
 (defn dapp-badge [{:keys [online-view-wrapper online-view online-dot-left online-dot-right]}]
   [react/view online-view-wrapper


### PR DESCRIPTION
### Testing notes

#### Platforms
- Android
- iOS

#### Areas that maybe impacted 
**Functional**
- public chats
- group chats

### Steps to test:
- Open Status
- Add public chats and group chats
- Icons should contain the first letter not #

status: ready