### PR TITLE
[fix 6850] add to contact appears briefly when joining public chat

### DIFF
--- a/src/status_im/chat/subs.cljs
+++ b/src/status_im/chat/subs.cljs
@@ -59,27 +59,6 @@
    (get chat-ui-props id)))
 
 (re-frame/reg-sub
- :chats/current-chat-contact
- :<- [:contacts/contacts]
- :<- [:chats/current-chat-id]
- (fn [[contacts chat-id]]
-   (get contacts chat-id)))
-
-(re-frame/reg-sub
- :chats/current-chat-name
- :<- [:chats/current-chat-contact]
- :<- [:chats/current-chat]
- (fn [[contact chat]]
-   (chat.db/chat-name chat contact)))
-
-(re-frame/reg-sub
- :chats/chat-name
- :<- [:contacts/contacts]
- :<- [::chats]
- (fn [[contacts chats] [_ chat-id]]
-   (chat.db/chat-name (get chats chat-id) (get contacts chat-id))))
-
-(re-frame/reg-sub
  :chats/current-chat-ui-prop
  :<- [:chats/current-chat-ui-props]
  (fn [ui-props [_ prop]]

--- a/src/status_im/contact/subs.cljs
+++ b/src/status_im/contact/subs.cljs
@@ -69,16 +69,6 @@
         dapps)))
 
 (re-frame/reg-sub
- :contacts/contact-by-identity
- :<- [:contacts/contacts]
- :<- [:chats/current-chat]
- (fn [[all-contacts {:keys [contacts]}] [_ identity]]
-   (let [identity' (or identity (first contacts))]
-     (or
-      (get all-contacts identity')
-      (contact.db/public-key->new-contact identity')))))
-
-(re-frame/reg-sub
  :contacts/dapps-by-name
  :<- [:contacts/all-dapps]
  (fn [dapps]

--- a/src/status_im/group_chats/db.cljs
+++ b/src/status_im/group_chats/db.cljs
@@ -1,0 +1,46 @@
+(ns status-im.group-chats.db
+  (:require [status-im.chat.models :as models.chat]
+            [status-im.utils.gfycat.core :as gfycat]))
+
+(defn unwrap-events
+  "Flatten all events, denormalizing from field"
+  [all-updates]
+  (mapcat
+   (fn [{:keys [events from]}]
+     (map #(assoc % :from from) events))
+   all-updates))
+
+(defn joined-event?
+  [public-key {:keys [members-joined] :as chat}]
+  (contains? members-joined public-key))
+
+(defn joined?
+  [public-key {:keys [group-chat-local-version] :as chat}]
+  ;; We consider group chats with local version of 0 as joined for local events
+  (or (zero? group-chat-local-version)
+      (joined-event? public-key chat)))
+
+(defn invited?
+  [my-public-key {:keys [contacts]}]
+  (contains? contacts my-public-key))
+
+(defn get-inviter-pk
+  [my-public-key {:keys [membership-updates]}]
+  (->> membership-updates
+       unwrap-events
+       (keep (fn [{:keys [from type members]}]
+               (when (and (= type "members-added")
+                          ((set members) my-public-key))
+                 from)))
+       last))
+
+(defn get-pending-invite-inviter-name
+  "when the chat is a private group chat in which the user has been
+  invited and didn't accept the invitation yet, return inviter-name"
+  [contacts chat my-public-key]
+  (when (and (models.chat/group-chat? chat)
+             (invited? my-public-key chat)
+             (not (joined? my-public-key chat)))
+    (let [inviter-pk (get-inviter-pk my-public-key chat)]
+      (get-in contacts [inviter-pk :name]
+              (gfycat/generate-gfy inviter-pk)))))

--- a/src/status_im/ui/screens/chat/toolbar_content.cljs
+++ b/src/status_im/ui/screens/chat/toolbar_content.cljs
@@ -58,12 +58,10 @@
               (i18n/label-pluralize cnt :t/members-active))))]])))
 
 (defview toolbar-content-view []
-  (letsubs [{:keys [group-chat color online contacts
+  (letsubs [{:keys [group-chat color online contacts chat-name
                     public? chat-id] :as chat}    [:chats/current-chat]
-            chat-name                             [:chats/current-chat-name]
             show-actions?                         [:chats/current-chat-ui-prop :show-actions?]
             accounts                              [:accounts/accounts]
-            contact                               [:chats/current-chat-contact]
             sync-state                            [:sync-state]]
     (let [has-subtitle? (or group-chat (not= :done sync-state))]
       [react/view {:style st/toolbar-container}

--- a/src/status_im/ui/screens/chat/views.cljs
+++ b/src/status_im/ui/screens/chat/views.cljs
@@ -69,7 +69,7 @@
                                        :accessibility-label :chat-menu-button}
                            :handler   #(on-options chat-id name group-chat public?)}]])]
      [connectivity/connectivity-view]
-     (when-not (or public? group-chat)
+     (when (and (not group-chat) (first contacts))
        [add-contact-bar (first contacts)])]))
 
 (defmulti message-row (fn [{{:keys [type]} :row}] type))

--- a/src/status_im/ui/screens/desktop/main/chat/views.cljs
+++ b/src/status_im/ui/screens/desktop/main/chat/views.cljs
@@ -1,40 +1,35 @@
 (ns status-im.ui.screens.desktop.main.chat.views
-  (:require-macros [status-im.utils.views :as views])
-  (:require [re-frame.core :as re-frame]
-            [status-im.ui.components.icons.vector-icons :as icons]
-            [clojure.string :as string]
-            [status-im.ui.screens.chat.styles.message.message :as message.style]
-            [status-im.ui.screens.chat.message.message :as message]
-            [taoensso.timbre :as log]
+  (:require [clojure.string :as string]
+            [re-frame.core :as re-frame]
             [reagent.core :as reagent]
-            [status-im.chat.models :as models.chat]
-            [status-im.group-chats.core :as models.group-chats]
-            [status-im.ui.screens.chat.utils :as chat-utils]
-            [status-im.utils.gfycat.core :as gfycat]
             [status-im.constants :as constants]
-            [status-im.utils.identicon :as identicon]
-            [status-im.utils.datetime :as time]
-            [status-im.utils.core :as core-utils]
-            [status-im.utils.utils :as utils]
-            [status-im.ui.components.react :as react]
-            [status-im.ui.components.connectivity.view :as connectivity]
-            [status-im.ui.components.colors :as colors]
-            [status-im.ui.screens.chat.message.datemark :as message.datemark]
-            [status-im.ui.screens.desktop.main.tabs.profile.views :as profile.views]
-            [status-im.ui.components.icons.vector-icons :as vector-icons]
-            [status-im.ui.screens.desktop.main.chat.styles :as styles]
             [status-im.contact.db :as contact.db]
-            [status-im.ui.screens.chat.views :as views.chat]
-            [status-im.ui.components.popup-menu.views :refer [show-desktop-menu
-                                                              get-chat-menu-items]]
             [status-im.i18n :as i18n]
-            [status-im.ui.screens.desktop.main.chat.events :as chat.events]
-            [status-im.ui.screens.chat.message.message :as chat.message]))
+            [status-im.ui.components.colors :as colors]
+            [status-im.ui.components.connectivity.view :as connectivity]
+            [status-im.ui.components.icons.vector-icons :as vector-icons]
+            [status-im.ui.components.popup-menu.views
+             :refer
+             [get-chat-menu-items show-desktop-menu]]
+            [status-im.ui.components.react :as react]
+            [status-im.ui.screens.chat.message.datemark :as message.datemark]
+            [status-im.ui.screens.chat.message.message :as message]
+            [status-im.ui.screens.chat.styles.message.message :as message.style]
+            [status-im.ui.screens.chat.utils :as chat-utils]
+            [status-im.ui.screens.chat.views :as views.chat]
+            [status-im.ui.screens.desktop.main.chat.styles :as styles]
+            [status-im.ui.screens.desktop.main.tabs.profile.views :as profile.views]
+            [status-im.utils.core :as core-utils]
+            [status-im.utils.datetime :as time]
+            [status-im.utils.gfycat.core :as gfycat]
+            [status-im.utils.identicon :as identicon]
+            [status-im.utils.utils :as utils])
+  (:require-macros [status-im.utils.views :as views]))
 
-(views/defview toolbar-chat-view [{:keys [chat-id color public-key public? group-chat]
-                                   :as current-chat}]
-  (views/letsubs [chat-name         [:chats/current-chat-name]
-                  {:keys [pending? public-key photo-path]} [:chats/current-chat-contact]]
+(defn toolbar-chat-view
+  [{:keys [chat-id chat-name contact color public-key public? group-chat]
+    :as current-chat}]
+  (let [{:keys [pending? public-key photo-path]} contact]
     [react/view {:style styles/toolbar-chat-view}
      [react/view {:style {:flex-direction :row
                           :flex 1}}
@@ -88,10 +83,10 @@
   (views/letsubs [username [:contacts/contact-name-by-identity from]]
     [react/view {:style styles/quoted-message-container}
      [react/view {:style styles/quoted-message-author-container}
-      [icons/icon :tiny-icons/tiny-reply {:style           (styles/reply-icon outgoing)
-                                          :width           16
-                                          :height          16
-                                          :container-style (when outgoing {:opacity 0.4})}]
+      [vector-icons/icon :tiny-icons/tiny-reply {:style           (styles/reply-icon outgoing)
+                                                 :width           16
+                                                 :height          16
+                                                 :container-style (when outgoing {:opacity 0.4})}]
       (chat-utils/format-reply-author from username current-public-key (partial message.style/quoted-message-author outgoing))]
      [react/text {:style           (message.style/quoted-message-text outgoing)
                   :number-of-lines 5}
@@ -262,7 +257,7 @@
                                                 (.focus @inp-ref)
                                                 (re-frame/dispatch [:chat.ui/send-current-message])))}
        [react/view {:style (styles/send-icon inactive?)}
-        [icons/icon :main-icons/arrow-left {:style (styles/send-icon-arrow inactive?)}]]])))
+        [vector-icons/icon :main-icons/arrow-left {:style (styles/send-icon-arrow inactive?)}]]])))
 
 (views/defview reply-message [from message-text]
   (views/letsubs [username           [:contacts/contact-name-by-identity from]
@@ -290,7 +285,7 @@
          :on-press            #(re-frame/dispatch [:chat.ui/cancel-message-reply])
          :accessibility-label :cancel-message-reply}
         [react/view {}
-         [icons/icon :main-icons/close {:style styles/reply-close-icon}]]]])))
+         [vector-icons/icon :main-icons/close {:style styles/reply-close-icon}]]]])))
 
 (views/defview chat-text-input [chat-id input-text]
   (views/letsubs [inp-ref (atom nil)
@@ -325,19 +320,15 @@
                                                       (re-frame/dispatch [:chat.ui/set-chat-input-text text])))}]
        [send-button inp-ref disconnected?]])))
 
-(defn not-joined-group-chat? [chat current-public-key]
-  (and (models.chat/group-chat? chat)
-       (models.group-chats/invited? current-public-key chat)
-       (not (models.group-chats/joined? current-public-key chat))))
-
 (views/defview chat-view []
-  (views/letsubs [{:keys [input-text chat-id] :as current-chat} [:chats/current-chat]
+  (views/letsubs [{:keys [input-text chat-id pending-invite-inviter-name] :as current-chat}
+                  [:chats/current-chat]
                   current-public-key [:account/public-key]]
 
     [react/view {:style styles/chat-view}
      [toolbar-chat-view current-chat]
      [react/view {:style styles/separator}]
-     (if (not-joined-group-chat? current-chat current-public-key)
+     (if pending-invite-inviter-name
        [views.chat/group-chat-join-section current-public-key current-chat]
        [messages-view current-chat])
      [react/view {:style styles/separator}]

--- a/src/status_im/ui/screens/desktop/main/tabs/home/views.cljs
+++ b/src/status_im/ui/screens/desktop/main/tabs/home/views.cljs
@@ -19,15 +19,15 @@
             [status-im.ui.components.action-button.action-button :as action-button]
             [status-im.utils.config :as config]))
 
-(views/defview chat-list-item-inner-view [{:keys [chat-id name group-chat
-                                                  color public? public-key
-                                                  timestamp
-                                                  last-message-content
-                                                  last-message-content-type]
-                                           :as chat-item}]
+(views/defview chat-list-item-inner-view
+  [{:keys [chat-id name group-chat
+           color public? public-key
+           timestamp chat-name
+           last-message-content
+           last-message-content-type]
+    :as chat-item}]
   (views/letsubs [photo-path              [:contacts/chat-photo chat-id]
                   unviewed-messages-count [:chats/unviewed-messages-count chat-id]
-                  chat-name               [:chats/chat-name chat-id]
                   current-chat-id         [:chats/current-chat-id]]
     (let [last-message {:content      last-message-content
                         :timestamp    timestamp

--- a/src/status_im/ui/screens/home/views/inner_item.cljs
+++ b/src/status_im/ui/screens/home/views/inner_item.cljs
@@ -92,27 +92,28 @@
                    :accessibility-label :chat-name-text}
        chat-name]]]))
 
-(defview home-list-chat-item-inner-view [{:keys [chat-id name color online
-                                                 group-chat public?
-                                                 public-key
-                                                 timestamp
-                                                 last-message-content
-                                                 last-message-content-type]}]
-  (letsubs [chat-name    [:chats/chat-name chat-id]]
-    (let [truncated-chat-name (utils/truncate-str chat-name 30)]
-      [react/touchable-highlight {:on-press #(re-frame/dispatch [:chat.ui/navigate-to-chat chat-id])}
-       [react/view styles/chat-container
-        [react/view styles/chat-icon-container
-         [chat-icon.screen/chat-icon-view-chat-list chat-id group-chat truncated-chat-name color online false]]
-        [react/view styles/chat-info-container
-         [react/view styles/item-upper-container
-          [chat-list-item-name truncated-chat-name group-chat public? public-key]
-          [react/view styles/message-status-container
-           [message-timestamp timestamp]]]
-         [react/view styles/item-lower-container
-          [message-content-text {:content      last-message-content
-                                 :content-type last-message-content-type}]
-          [unviewed-indicator chat-id]]]]])))
+(defn home-list-chat-item-inner-view
+  [{:keys [chat-id chat-name
+           name color online
+           group-chat public?
+           public-key
+           timestamp
+           last-message-content
+           last-message-content-type]}]
+  (let [truncated-chat-name (utils/truncate-str chat-name 30)]
+    [react/touchable-highlight {:on-press #(re-frame/dispatch [:chat.ui/navigate-to-chat chat-id])}
+     [react/view styles/chat-container
+      [react/view styles/chat-icon-container
+       [chat-icon.screen/chat-icon-view-chat-list chat-id group-chat truncated-chat-name color online false]]
+      [react/view styles/chat-info-container
+       [react/view styles/item-upper-container
+        [chat-list-item-name truncated-chat-name group-chat public? public-key]
+        [react/view styles/message-status-container
+         [message-timestamp timestamp]]]
+       [react/view styles/item-lower-container
+        [message-content-text {:content      last-message-content
+                               :content-type last-message-content-type}]
+        [unviewed-indicator chat-id]]]]]))
 
 (defn home-list-browser-item-inner-view [{:keys [dapp url name browser-id] :as browser}]
   [react/touchable-highlight {:on-press #(re-frame/dispatch [:browser.ui/browser-item-selected browser-id])}

--- a/test/cljs/status_im/test/chat/db.cljs
+++ b/test/cljs/status_im/test/chat/db.cljs
@@ -127,6 +127,5 @@
                        2 active-chat-2
                        3 {:is-active false :chat-id 3}}]
     (testing "it returns only chats with is-active"
-      (is (= {1 active-chat-1
-              2 active-chat-2}
-             (s/active-chats {} chats {}))))))
+      (is (= #{1 2}
+             (set (keys (s/active-chats {} chats {}))))))))


### PR DESCRIPTION
- remove unnecessary subscriptions and logic from views, fix related circular dependencies
- make sure add-contact-bar appears only when required

fixes #6850

### Testing notes

#### Platforms
- Android
- iOS
- macOS
- Linux
- Windows

####
**Functional**
- 1-1 chats
- public chats
- group chats

### Steps to test:
- Open Status
- Open new public chat
- Add to contact bar shouldn't appear even for a split second

status: ready
