### PR TITLE
[fix] crash with creation and invitation to 1 letter group chat

### DIFF
--- a/src/status_im/ui/components/chat_icon/screen.cljs
+++ b/src/status_im/ui/components/chat_icon/screen.cljs
@@ -11,7 +11,15 @@
   (when-not (string/blank? name)
     [react/view (:default-chat-icon styles)
      [react/text {:style (:default-chat-icon-text styles)}
-      (string/capitalize (second name))]]))
+      ;; TODO: for now we check if the first letter is a #
+      ;; which means it is most likely a public chat and
+      ;; use the second letter if that is the case
+      ;; a broader refactoring should clean up upstream params
+      ;; for default-chat-icon
+      (string/capitalize (if (and (= "#" (first name))
+                                  (< 1 (count name)))
+                           (second name)
+                           (first name)))]]))
 
 (defn dapp-badge [{:keys [online-view-wrapper online-view online-dot-left online-dot-right]}]
   [react/view online-view-wrapper


### PR DESCRIPTION
fixes #7468

### Steps to test:
- Open Status
- Create private chat with only 1 char

status: ready
