### PR TITLE
Use dedup-id instead of raw-object

### DIFF
--- a/mobile_files/package.json.orig
+++ b/mobile_files/package.json.orig
@@ -66,7 +66,7 @@
     "string_decoder": "0.10.31",
     "text-encoding": "^0.6.4",
     "url": "0.10.3",
-    "web3": "git+https://github.com/status-im/web3.js.git#0.20.1-status",
+    "web3": "git+https://github.com/status-im/web3.js.git#0.20.2-status",
     "web3-utils": "1.0.0-beta.36",
     "hi-base32": "0.5.0"
   },

--- a/mobile_files/yarn.lock
+++ b/mobile_files/yarn.lock
@@ -6014,7 +6014,6 @@ react-native-splash-screen@3.1.1:
   version "2.3.4"
   resolved "git+https://github.com/status-im/react-native-status-keycard.git#04b0fb6fcbe588bd7fa076e1b0379e661bf1bddc"
 
-
 react-native-svg@6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/react-native-svg/-/react-native-svg-6.5.2.tgz#1105896b8873b0856821b18daa0c6898cea6c00c"
@@ -7423,9 +7422,9 @@ web3-utils@1.0.0-beta.36:
     underscore "1.8.3"
     utf8 "2.1.1"
 
-"web3@git+https://github.com/status-im/web3.js.git#0.20.1-status":
+"web3@git+https://github.com/status-im/web3.js.git#0.20.2-status":
   version "0.20.1"
-  resolved "git+https://github.com/status-im/web3.js.git#dad342dc95f7d5a888411ed57c9618937e2b6ebd"
+  resolved "git+https://github.com/status-im/web3.js.git#958dbabff2c77615e23f5de678a6fae0b0d70147"
   dependencies:
     bignumber.js "git+https://github.com/status-im/bignumber.js.git#v4.0.2-status"
     crypto-js "^3.1.4"

--- a/src/status_im/chat/core.cljs
+++ b/src/status_im/chat/core.cljs
@@ -4,7 +4,7 @@
 
 ;; Seen messages
 (fx/defn receive-seen
-  [{:keys [db js-obj]} chat-id sender {:keys [message-ids]}]
+  [{:keys [db js-obj dedup-id]} chat-id sender {:keys [message-ids]}]
   (when-let [seen-messages-ids (-> (get-in db [:chats chat-id :messages])
                                    (select-keys message-ids)
                                    keys)]
@@ -21,4 +21,4 @@
                               db
                               statuses)
        :data-store/tx [{:transaction (user-statuses-store/save-statuses-tx statuses)
-                        :success-event [:message/messages-persisted [js-obj]]}]})))
+                        :success-event [:message/messages-persisted [(or dedup-id js-obj)]]}]})))

--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -1463,8 +1463,8 @@
 
 (handlers/register-handler-fx
  :group-chats.callback/extract-signature-success
- (fn [cofx [_ group-update raw-payload sender-signature]]
-   (group-chats/handle-membership-update cofx group-update raw-payload sender-signature)))
+ (fn [cofx [_ group-update message-info sender-signature]]
+   (group-chats/handle-membership-update cofx group-update message-info sender-signature)))
 
 ;; profile module
 

--- a/src/status_im/transport/impl/receive.cljs
+++ b/src/status_im/transport/impl/receive.cljs
@@ -9,8 +9,9 @@
 
 (extend-type transport.group-chat/GroupMembershipUpdate
   protocol/StatusMessage
-  (receive [this _ signature _ {:keys [js-obj] :as cofx}]
-    (group-chats/handle-membership-update-received cofx this signature (.-payload js-obj))))
+  (receive [this _ signature _ {:keys [dedup-id js-obj] :as cofx}]
+    (group-chats/handle-membership-update-received cofx this signature {:dedup-id dedup-id
+                                                                        :raw-payload (.-payload js-obj)})))
 
 (extend-type transport.contact/ContactRequest
   protocol/StatusMessage

--- a/src/status_im/transport/message/protocol.cljs
+++ b/src/status_im/transport/message/protocol.cljs
@@ -118,6 +118,7 @@
              :raw-payload-hash (transport.utils/sha3
                                 (.-payload (:js-obj cofx)))
              :from signature
+             :dedup-id (:dedup-id cofx)
              :js-obj (:js-obj cofx))]})
   (validate [this]
     (if (spec/valid? :message/message this)


### PR DESCRIPTION

This is a backward/forward compatible change with status-go.
We are changing the way messages are confirmed from passing the
raw-object to status-go to a dedup-id instead, which needs to be sent
back.
Based on the response from statu-go we detect whether they are ids or
object and act accordingly.

status: ready