### PR TITLE
[fix] icon and text alignment for group and public chat on home

### DIFF
--- a/src/status_im/ui/screens/home/styles.cljs
+++ b/src/status_im/ui/screens/home/styles.cljs
@@ -75,13 +75,13 @@
              :height    26}})
 
 (defstyle private-group-icon-container
-  {:width        20
-   :height       12
+  {:align-items :center
+   :justify-content :center
    :margin-right 6})
 
 (defstyle public-group-icon-container
-  {:width        20
-   :height       12
+  {:align-items :center
+   :justify-content :center
    :margin-right 6})
 
 (def last-message-container

--- a/src/status_im/ui/screens/home/views/inner_item.cljs
+++ b/src/status_im/ui/screens/home/views/inner_item.cljs
@@ -84,7 +84,9 @@
      (when private-group?
        [react/view styles/private-group-icon-container
         [vector-icons/icon :tiny-icons/tiny-group {:color colors/gray}]])
-     [react/view {:flex-shrink 1}
+     [react/view {:flex-shrink 1
+                  :align-items :center
+                  :justify-content :center}
       [react/text {:style               styles/name-text
                    :number-of-lines     1
                    :accessibility-label :chat-name-text}


### PR DESCRIPTION

![screenshot_1549989249](https://user-images.githubusercontent.com/1181225/52651562-afe9b780-2eec-11e9-9b56-7bec05c72772.png)


status: ready
