### PR TITLE
renamed deposit to receive on main wallet screen

### DIFF
--- a/src/status_im/ui/screens/wallet/main/views.cljs
+++ b/src/status_im/ui/screens/wallet/main/views.cljs
@@ -67,7 +67,7 @@
     :accessibility-label :send-transaction-button
     :icon                :main-icons/send
     :action              #(re-frame/dispatch [:navigate-to :wallet-send-transaction])}
-   {:label               (i18n/label :t/wallet-deposit)
+   {:label               (i18n/label :t/receive)
     :accessibility-label :receive-transaction-button
     :icon                :main-icons/receive
     :action              #(re-frame/dispatch [:navigate-to :wallet-request-transaction])}


### PR DESCRIPTION
fixes #7487

### Summary:

Per popular demand, we're renaming Deposit action back to Receive on main wallet screen.

### Testing notes (optional):

Automated tests only, just changing a label, see screenshot.


status: ready 