### PR TITLE
Selecting users when creating group chat e2e tests fix

### DIFF
--- a/test/appium/views/start_new_chat_view.py
+++ b/test/appium/views/start_new_chat_view.py
@@ -63,7 +63,7 @@ class EnterUrlEditbox(BaseEditBox):
 class UsernameCheckbox(BaseButton):
     def __init__(self, driver, username):
         super(UsernameCheckbox, self).__init__(driver)
-        self.locator = self.Locator.xpath_selector("//*[@text='%s']/../../android.widget.CheckBox" % username)
+        self.locator = self.Locator.xpath_selector("//*[@text='%s']" % username)
 
 
 class InviteFriendsButton(BaseButton):


### PR DESCRIPTION
Update tests related to group chat creation after changes to the checkboxes made in #7481
(now test clicks upon username)