### PR TITLE
Custom network and seen status autotests fix

### DIFF
--- a/test/appium/tests/atomic/chats/test_one_to_one.py
+++ b/test/appium/tests/atomic/chats/test_one_to_one.py
@@ -5,7 +5,7 @@ import emoji
 from datetime import datetime
 from selenium.common.exceptions import TimeoutException
 from tests import marks, get_current_time
-from tests.users import transaction_senders, transaction_recipients
+from tests.users import transaction_senders, transaction_recipients, basic_user
 from tests.base_test_case import MultipleDeviceTestCase, SingleDeviceTestCase
 from views.sign_in_view import SignInView
 
@@ -251,27 +251,16 @@ class TestMessagesOneToOneChatMultiple(MultipleDeviceTestCase):
 
     @marks.testrail_id(5374)
     @marks.high
-    def test_message_marked_as_sent_and_seen_1_1_chat(self):
-        self.create_drivers(2)
-        device_1, device_2 = SignInView(self.drivers[0]), SignInView(self.drivers[1])
-        username_1 = 'user_%s' % get_current_time()
-        device_1_home, device_2_home = device_1.create_user(username=username_1), device_2.create_user()
-        device_2_public_key = device_2_home.get_public_key()
-        device_2_home.home_button.click()
-
-        device_1_chat = device_1_home.add_contact(device_2_public_key)
-
+    def test_message_marked_as_sent_in_1_1_chat(self):
+        self.create_drivers(1)
+        sign_in_view = SignInView(self.drivers[0])
+        home_view = sign_in_view.create_user()
+        chat_view = home_view.add_contact(basic_user['public_key'])
         message = 'test message'
-        device_1_chat.chat_message_input.send_keys(message)
-        device_1_chat.send_message_button.click()
-        if device_1_chat.chat_element_by_text(message).status.text != 'Sent':
+        chat_view.chat_message_input.send_keys(message)
+        chat_view.send_message_button.click()
+        if chat_view.chat_element_by_text(message).status.text != 'Sent':
             self.errors.append("'Sent' status is not shown under the sent text message")
-
-        device_2_chat = device_2_home.get_chat_with_user(username_1).click()
-        device_2_chat.chat_element_by_text(message).wait_for_visibility_of_element()
-
-        if device_1_chat.chat_element_by_text(message).status.text != 'Seen':
-            self.errors.append("'Seen' status is not shown under the text message which was read by a receiver")
         self.verify_no_errors()
 
     @marks.testrail_id(5362)

--- a/test/appium/tests/atomic/transactions/test_daaps_transactions.py
+++ b/test/appium/tests/atomic/transactions/test_daaps_transactions.py
@@ -288,9 +288,15 @@ class TestTransactionDApp(SingleDeviceTestCase):
         send_transaction_view.sign_transaction_button.click()
         if send_transaction_view.enter_password_input.is_element_displayed():
             self.errors.append('sending all available ETH (no funds to pay gas)')
-
         send_transaction_view.amount_edit_box.clear()
-        send_transaction_view.amount_edit_box.set_value('0.099979000000000001')
+
+        # Because tx gas price may change we calculate eth value according to current gas fee value
+        send_transaction_view.advanced_button.click()
+        transaction_fee_total = send_transaction_view.get_transaction_fee_total()
+        eth_available_for_tx = str(0.1 - transaction_fee_total)
+        wei = '0.000000000000000001'
+        eth_value_plus_one_wei = ''.join([eth_available_for_tx, wei[len(eth_available_for_tx):]])
+        send_transaction_view.amount_edit_box.set_value(eth_value_plus_one_wei)
         send_transaction_view.confirm()
 
         # Check whether sending big amount of ETH triggers the warning (no funds to pay gas)
@@ -303,7 +309,7 @@ class TestTransactionDApp(SingleDeviceTestCase):
             self.errors.append('sending big amount of ETH (no funds to pay gas)')
 
         send_transaction_view.amount_edit_box.clear()
-        send_transaction_view.amount_edit_box.set_value('0.099979')
+        send_transaction_view.amount_edit_box.set_value(eth_available_for_tx)
         send_transaction_view.confirm()
 
         # Check whether sending normal amount of ETH does not trigger the warning

--- a/test/appium/views/profile_view.py
+++ b/test/appium/views/profile_view.py
@@ -271,8 +271,7 @@ class RopstenChainButton(BaseButton):
 
     def __init__(self, driver):
         super(RopstenChainButton, self).__init__(driver)
-        self.locator = self.Locator.xpath_selector(
-            "//*[contains(@text,'Ropsten test network')]/following-sibling::android.widget.CheckBox[1]")
+        self.locator = self.Locator.xpath_selector("//*[contains(@text,'Ropsten test network')]")
 
 
 class SpecifyNameInput(BaseEditBox):

--- a/test/appium/views/send_transaction_view.py
+++ b/test/appium/views/send_transaction_view.py
@@ -112,6 +112,13 @@ class TransactionFeeButton(BaseButton):
         self.locator = self.Locator.accessibility_id('transaction-fee-button')
 
 
+class TransactionFeeTotalValue(BaseButton):
+    def __init__(self, driver):
+        super(TransactionFeeTotalValue, self).__init__(driver)
+        self.locator = self.Locator.xpath_selector("//*[@content-desc='transaction-fee-button']"
+                                                   "/android.widget.TextView[1]")
+
+
 class GasLimitInput(BaseEditBox):
     def __init__(self, driver):
         super(GasLimitInput, self).__init__(driver)
@@ -168,6 +175,7 @@ class SendTransactionView(BaseView):
 
         self.advanced_button = AdvancedButton(self.driver)
         self.transaction_fee_button = TransactionFeeButton(self.driver)
+        self.transaction_fee_total_value = TransactionFeeTotalValue(self.driver)
         self.gas_limit_input = GasLimitInput(self.driver)
         self.gas_price_input = GasPriceInput(self.driver)
         self.total_fee_input = TotalFeeInput(self.driver)
@@ -202,3 +210,7 @@ class SendTransactionView(BaseView):
         self.sign_transaction_button.click_until_presence_of_element(self.progress_bar)
         self.progress_bar.wait_for_invisibility_of_element(60)
         self.got_it_button.click()
+
+    def get_transaction_fee_total(self):
+        return float(self.transaction_fee_total_value.text.split()[0])
+


### PR DESCRIPTION
* When creating custom network updated network chain locator
* No 'Seen' message status under messages. Updated test to check that 'Sent' status is displayed only
* We hardcoded ETH value for boundary case in the past. Updated test to calculate ETH value depending of the transaction fee amount. 