### PR TITLE
Update bundle script

### DIFF
--- a/scripts/bundle-status-go.sh
+++ b/scripts/bundle-status-go.sh
@@ -16,7 +16,9 @@ fi
 set -euf
 
 # Ensure we start with a clean state, so as to e.g., not reuse old native status-go bindings 
-make clean
+if [ -z $DONT_CLEAN ] ; then
+  make clean
+fi
 
 for platform in "$@"; do
     case $platform in
@@ -75,7 +77,7 @@ for platform in "$@"; do
         target=$STATUS_REACT_HOME/modules/react-native-status/android/libs/status-im/status-go/local
         [ -d $target ] || mkdir -p $target
         # Copy over framework:
-        cp -R $STATUS_GO_HOME/build/bin/statusgo-android-16.aar $target/status-go-local.aar
+        cp -R $STATUS_GO_HOME/build/bin/statusgo.aar $target/status-go-local.aar
 
         # It might also be a good idea to print something custom so you can easily tell
         # the difference between an old and new version of status-go.


### PR DESCRIPTION
With the change in status-go mobile the name of the artifact as changed
and currently the script is looking at the wrong file.
I have also added an option to not clean the repo (only if specified),
as I rarely want to clean the repo myself, and I have always to comment
it out.

I have only updated it for linux/android, not sure about IOS.

status: ready