### PR TITLE
Handle mailserver request error

### DIFF
--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -424,6 +424,11 @@
    (log/error "Error on mark-trusted-peer: " error)
    (mailserver/check-connection cofx)))
 
+(handlers/register-handler-fx
+ :mailserver.callback/request-error
+ (fn [cofx [_ error]]
+   (mailserver/handle-request-error cofx error)))
+
 ;; network module
 
 (handlers/register-handler-fx

--- a/src/status_im/mailserver/core.cljs
+++ b/src/status_im/mailserver/core.cljs
@@ -288,7 +288,9 @@
                       (fn [error request-id]
                         (if-not error
                           (log/info "mailserver: messages request success for topic " topics "from" from "to" to)
-                          (log/error "mailserver: messages request error for topic " topics ": " error))))))
+                          (do
+                            (log/error "mailserver: messages request error for topic " topics ": " error)
+                            (re-frame/dispatch [:mailserver.callback/request-error (i18n/label :t/mailserver-request-error-title)])))))))
 
 (re-frame/reg-fx
  :mailserver/request-messages


### PR DESCRIPTION
potentially fixes #7520 

I could not replicate consistently, the two cases that I have seen is when the request failed because of the 3s limit, but we never received an expired event. So this tentatively fixes the issue, but difficult to make sure it does not happen again as can't replicate consistently.

status: ready
