### PR TITLE
[fix 5772] overlap in login screen on small screens

### DIFF
--- a/src/status_im/ui/screens/accounts/login/views.cljs
+++ b/src/status_im/ui/screens/accounts/login/views.cljs
@@ -64,7 +64,7 @@
      [status-bar/status-bar]
      [login-toolbar can-navigate-back?]
      [components.common/separator]
-     [react/view styles/login-view
+     [react/scroll-view styles/login-view
       [react/view styles/login-badge-container
        [account-login-badge photo-path name]
        [react/view {:style                       styles/password-container


### PR DESCRIPTION
Use a scroll view to avoid overlap and make whole screen accessible on small screens 

fix #5772

small screen
![screenshot_1550684317](https://user-images.githubusercontent.com/1181225/53112500-a93bef80-353f-11e9-9d83-5bb973adb7b7.png)
![screenshot_1550684320](https://user-images.githubusercontent.com/1181225/53112503-a93bef80-353f-11e9-927a-47a4f795891b.png)

big screen
![screenshot_1550684553](https://user-images.githubusercontent.com/1181225/53112507-ab05b300-353f-11e9-99a3-6e8f453e2443.png)

status: ready
