### PR TITLE
Retry mailserver request when initial request fails

### DIFF
--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -372,6 +372,11 @@
    (mailserver/set-url-from-qr cofx url)))
 
 (handlers/register-handler-fx
+ :mailserver.callback/resend-request
+ (fn [cofx [_ request]]
+   (mailserver/resend-request cofx request)))
+
+(handlers/register-handler-fx
  :mailserver.ui/connect-pressed
  (fn [cofx [_  mailserver-id]]
    (mailserver/show-connection-confirmation cofx mailserver-id)))


### PR DESCRIPTION
If the initial request fails we immediately show the error pop-up. This
PR changes the behavior so that it is retried just like any other
request. If 3 requests in a row fail, we show the error pop up if the
user has specifically set a mailserver, otherwise is changed
automatically.

status: ready
