### PR TITLE
desktop wrong data dir

### DIFF
--- a/modules/react-native-status/desktop/rctstatus.cpp
+++ b/modules/react-native-status/desktop/rctstatus.cpp
@@ -111,7 +111,8 @@ void RCTStatus::startNode(QString configString) {
     configJSON["KeyStoreDir"] = rootDir.absoluteFilePath("keystore");
     configJSON["LogFile"] = d_gethLogFilePath;
 
-    shhextConfig["BackupDisabledDataDir"] = absDataDirPath;
+    shhextConfig["BackupDisabledDataDir"] = rootDirPath;
+
     configJSON["ShhExtConfig"] = shhextConfig;
 
     const QJsonDocument& updatedJsonDoc = QJsonDocument::fromVariant(configJSON);


### PR DESCRIPTION
Desktop was using a network dependent data dir to store dbs, this changes the behavior so that it is not stored in a network dependend directory.

### Testing

Pair your devices pre-upgrade, make sure they are still paired after.

status: ready
