### PR TITLE
remove mounting of /dev/fuse for linux builds

### DIFF
--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -6,8 +6,6 @@ pipeline {
       /* WARNING: remember to keep this up-to-date with the value in docker/linux/Makefile */
       image 'statusteam/status-build-linux:1.1.0-2a35dcde'
       args (
-        "--privileged "+
-        "-v /dev/fuse:/dev/fuse "+
         "-v /var/tmp/lein:/var/tmp/lein:rw "+
         "-v /var/tmp/npm:/var/tmp/npm:rw "+
         "-v /opt/desktop-files:/opt/desktop-files:rw"

--- a/scripts/build-desktop.sh
+++ b/scripts/build-desktop.sh
@@ -79,10 +79,16 @@ function joinExistingPath() {
 STATUSREACTPATH="$(cd "$SCRIPTPATH" && cd '..' && pwd)"
 WORKFOLDER="$(joinExistingPath "$STATUSREACTPATH" 'StatusImPackage')"
 DEPLOYQTFNAME='linuxdeployqt-continuous-x86_64_20181215.AppImage'
-APPIMAGETOOLFNAME='appimagetool-x86_64_20181109.AppImage'
+APPIMAGETOOLFNAME='appimagetool-x86_64_20190221.AppImage'
 DEPLOYQT=$(joinPath . "$DEPLOYQTFNAME")
 APPIMAGETOOL=$(joinPath . "$APPIMAGETOOLFNAME")
 STATUSIM_APPIMAGE_ARCHIVE="StatusImAppImage_20181208.zip"
+
+APPIMAGE_OPTIONS=""
+if [[ ! -c /dev/fuse ]]; then # doesn't exist when run under docker
+    # We extract it to avoid having to use fuse and privileged mode in docker
+    APPIMAGE_OPTIONS="--appimage-extract-and-run"
+fi
 
 function init() {
   if [ -z $STATUSREACTPATH ]; then
@@ -311,7 +317,7 @@ function bundleLinux() {
     rm -f $usrBinPath/Status.AppImage
   popd
 
-  $DEPLOYQT \
+  $DEPLOYQT $APPIMAGE_OPTIONS \
     $desktopFilePath \
     -verbose=$VERBOSE_LEVEL -always-overwrite -no-strip \
     -no-translations -bundle-non-qt-libs \
@@ -324,7 +330,7 @@ function bundleLinux() {
 
   pushd $WORKFOLDER
     rm -f $usrBinPath/Status.AppImage
-    $APPIMAGETOOL ./AppDir
+    $APPIMAGETOOL $APPIMAGE_OPTIONS ./AppDir
     [ $VERBOSE_LEVEL -ge 1 ] && ldd $usrBinPath/Status
     rm -rf Status.AppImage
   popd


### PR DESCRIPTION
We can't use `--privileged` because:

1. It's horrible practice security wise.
2. It stops use from using [user namespaces](https://docs.docker.com/engine/security/userns-remap/) with docker.

I'm updating `appimagetool` because the current one doesn't support `--appimage-extract-and-run`.

State: READY