### PR TITLE
Remove separate topic in group chats

### DIFF
--- a/src/status_im/transport/message/public_chat.cljs
+++ b/src/status_im/transport/message/public_chat.cljs
@@ -10,23 +10,6 @@
 (defn- has-already-joined? [{:keys [db]} chat-id]
   (get-in db [:transport/chats chat-id]))
 
-(fx/defn join-group-chat
-  "Function producing all protocol level effects necessary for a group chat identified by chat-id"
-  [{:keys [db] :as cofx} chat-id]
-  (when-not (has-already-joined? cofx chat-id)
-    (let [public-key (get-in db [:account/account :public-key])
-          topic (transport.utils/get-topic chat-id)]
-      (fx/merge cofx
-                {:shh/add-discovery-filters {:web3 (:web3 db)
-                                             :private-key-id public-key
-                                             :topics [{:topic topic
-                                                       :chat-id chat-id}]}}
-                (protocol/init-chat {:chat-id chat-id
-                                     :topic   topic})
-                #(hash-map :data-store/tx  [(transport-store/save-transport-tx
-                                             {:chat-id chat-id
-                                              :chat    (get-in % [:db :transport/chats chat-id])})])))))
-
 (fx/defn join-public-chat
   "Function producing all protocol level effects necessary for joining public chat identified by chat-id"
   [{:keys [db] :as cofx} chat-id]

--- a/src/status_im/utils/config.cljs
+++ b/src/status_im/utils/config.cljs
@@ -17,7 +17,6 @@
 
 (def bootnodes-settings-enabled? (enabled? (get-config :BOOTNODES_SETTINGS_ENABLED "1")))
 (def rpc-networks-only? (enabled? (get-config :RPC_NETWORKS_ONLY "1")))
-(def group-chats-publish-to-topic? (enabled? (get-config :GROUP_CHATS_PUBLISH_TO_TOPIC "0")))
 (def show-contact-recovery-pop-up? (enabled? (get-config :SHOW_CONTACT_RECOVERY_POPUP)))
 (def mailserver-confirmations-enabled? (enabled? (get-config :MAILSERVER_CONFIRMATIONS_ENABLED)))
 (def mainnet-warning-enabled? (enabled? (get-config :MAINNET_WARNING_ENABLED 0)))

--- a/test/cljs/status_im/test/group_chats/core.cljs
+++ b/test/cljs/status_im/test/group_chats/core.cljs
@@ -169,36 +169,6 @@
                     "group-chat-name-changed"]
                    (map (comp :text :content) (sort-by :clock-value (vals (:messages actual-chat))))))))))))
 
-(deftest set-up-topic
-  (with-redefs [config/group-chats-publish-to-topic? true]
-    (let [cofx {:now 0 :db {:account/account {:public-key admin}}}]
-      (testing "a brand new chat"
-        (let [actual (group-chats/handle-membership-update cofx initial-message "payload" admin)]
-          (testing "it sets up a topic"
-            (is (:shh/add-discovery-filters actual)))))
-      (testing "an existing chat"
-        (let [cofx  (assoc cofx
-                           :db
-                           (:db (group-chats/handle-membership-update cofx initial-message "payload" admin)))
-              new-message {:chat-id chat-id
-                           :membership-updates [{:from member-1
-                                                 :events [{:type "chat-created"
-                                                           :clock-value 1
-                                                           :name "group-name"}
-                                                          {:type "admins-added"
-                                                           :clock-value 10
-                                                           :members [member-2]}
-                                                          {:type "admin-removed"
-                                                           :clock-value 11
-                                                           :member member-1}]}
-                                                {:from member-1
-                                                 :events [{:type "member-removed"
-                                                           :clock-value 12
-                                                           :member member-1}]}]}
-              actual (group-chats/handle-membership-update cofx new-message "payload" admin)]
-          (testing "it removes the topic"
-            (is (:shh/remove-filters actual))))))))
-
 (deftest build-group-test
   (testing "only adds"
     (let [events [{:type    "chat-created"


### PR DESCRIPTION
   Currently the separate topic was not used, as it's a bit tricky to
    coordinate when multiple devices from different versions are present,
    with the partitioned topic, probably this optimisation is not necessary
    anymore, so removing this for now.
status: ready