### PR TITLE
Created a new event which allows extensions to send chat messages.

### DIFF
--- a/src/status_im/extensions/core.cljs
+++ b/src/status_im/extensions/core.cljs
@@ -35,6 +35,11 @@
  (fn [_ [_ _ m]]
    {::identity-event m}))
 
+(re-frame/reg-event-fx
+ :chat/send-message
+ (fn [cofx [_ message-text {:keys [to value] :as arguments}]]
+   (chat.input/send-plain-text-message-fx (assoc cofx :now (datetime/timestamp)) value to)))
+
 (re-frame/reg-fx
  ::alert
  (fn [value] (js/alert value)))
@@ -474,6 +479,10 @@
                 {:permissions [:read]
                  :value       :extensions.chat.command/send-message
                  :arguments   {:params :map}}
+                'chat/send-message
+                {:permissions [:read]
+                 :value       :chat/send-message
+                 :arguments   {:to :string :value :string}}
                 'log
                 {:permissions [:read]
                  :value       :log

--- a/src/status_im/extensions/core.cljs
+++ b/src/status_im/extensions/core.cljs
@@ -37,7 +37,7 @@
 
 (re-frame/reg-event-fx
  :chat/send-message
- (fn [cofx [_ message-text {:keys [to value] :as arguments}]]
+ (fn [cofx [_ _ {:keys [to value]}]]
    (chat.input/send-plain-text-message-fx (assoc cofx :now (datetime/timestamp)) value to)))
 
 (re-frame/reg-fx

--- a/src/status_im/extensions/core.cljs
+++ b/src/status_im/extensions/core.cljs
@@ -479,10 +479,12 @@
                 {:permissions [:read]
                  :value       :extensions.chat.command/send-message
                  :arguments   {:params :map}}
-                'chat/send-message
-                {:permissions [:read]
-                 :value       :chat/send-message
-                 :arguments   {:to :string :value :string}}
+                
+                ;; TODO: figure out better security model
+;;                 'chat/send-message
+;;                 {:permissions [:read]
+;;                  :value       :chat/send-message
+;;                  :arguments   {:to :string :value :string}}
                 'log
                 {:permissions [:read]
                  :value       :log


### PR DESCRIPTION
Fixes #7354 

You can use this event from an extension like this:

```
[chat/send-message {:to "0xSomeProfileAddress or NameOfAPublicChannelWithout#" :value "Chat Message"}]
```