### PR TITLE
upload release.json for release builds

### DIFF
--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -76,6 +76,7 @@ pipeline {
           /* mobile */
           Apk: cmn.pkgUrl(apk), Apke2e: cmn.pkgUrl(apke2e),
           iOS: cmn.pkgUrl(ios), /*iOSe2e: cmn.pkgUrl(iose2e),*/
+          Diawi: getEnv(ios, 'DIAWI_URL'),
           /* desktop */
           App: cmn.pkgUrl(nix), Mac: cmn.pkgUrl(osx), Win: cmn.pkgUrl(win),
           /* upload the sha256 checksums file too */
@@ -83,15 +84,12 @@ pipeline {
         ]
         /* add URLs to the build description */
         cmn.setBuildDesc(urls)
-        /* Create latest.json with newest nightly URLs */
-        if (btype == 'nightly') {
-          cmn.updateLatestNightlies(urls)
+        /* Create JSON file with newest build URLs */
+        switch (btype) {
+          /* legacy naming, should have named it nightly.json */
+          case 'nightly': cmn.updateBucketJSON(urls, 'latest.json'); break
+          case 'release': cmn.updateBucketJSON(urls, 'release.json'); break
         }
-      } }
-    }
-    stage('Notify') { when { expression { env.CHANGE_ID != null } }
-      steps { script {
-        cmn.gitHubNotifyFull(urls)
       } }
     }
     stage('Publish') {

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -78,12 +78,12 @@ pipeline {
       when { expression { cmn.getBuildType() != 'release' } }
       steps {
         script {
+          env.PKG_URL = cmn.uploadArtifact(api)
           /* e2e builds get tested in SauceLabs */
           if (cmn.getBuildType() == 'e2e') {
             env.SAUCE_URL = mobile.ios.uploadToSauceLabs()
-            env.PKG_URL = cmn.uploadArtifact(api)
           } else {
-            env.PKG_URL = mobile.ios.uploadToDiawi()
+            env.DIAWI_URL = mobile.ios.uploadToDiawi()
           }
         }
       }

--- a/ci/common.groovy
+++ b/ci/common.groovy
@@ -258,22 +258,6 @@ def gitHubNotify(message) {
   }
 }
 
-def gitHubNotifyFull(urls) {
-  def msg = "#### :white_check_mark: "
-  msg += "[${env.JOB_NAME}${currentBuild.displayName}](${currentBuild.absoluteUrl}) "
-  msg += "CI BUILD SUCCESSFUL in ${buildDuration()} (${GIT_COMMIT.take(8)})\n"
-  msg += '| | | | | |\n'
-  msg += '|-|-|-|-|-|\n'
-  msg += "| [Android](${urls.Apk}) ([e2e](${urls.Apke2e})) "
-  msg += "| [iOS](${urls.iOS}) ([e2e](${urls.iOSe2e})) |"
-  if (urls.Mac != null) {
-    msg += " [MacOS](${urls.Mac}) | [AppImage](${urls.App}) | [Windows](${urls.Win}) |"
-  } else {
-    msg += " ~~MacOS~~ | ~~AppImage~~ | ~~Windows~~~ |"
-  }
-  gitHubNotify(msg)
-}
-
 def gitHubNotifyPRFailure() {
   def d = ":small_orange_diamond:"
   def msg = "#### :x: "
@@ -343,20 +327,21 @@ def setBuildDesc(Map links) {
   currentBuild.description = desc
 }
 
-def updateLatestNightlies(urls) {
+def updateBucketJSON(urls, fileName) {
   /* latest.json has slightly different key names */
-  def latest = [
+  def content = [
+    DIAWI: urls.Diawi,
     APK: urls.Apk, IOS: urls.iOS,
     APP: urls.App, MAC: urls.Mac,
     WIN: urls.Win, SHA: urls.SHA
   ]
-  def latestFile = pwd() + '/' + 'pkg/latest.json'
+  def filePath = "${pwd()}/pkg/${fileName}"
   /* it might not exist */
   sh 'mkdir -p pkg'
-  def latestJson = new JsonBuilder(latest).toPrettyString()
-  println "latest.json:\n${latestJson}"
-  new File(latestFile).write(latestJson)
-  return uploadArtifact(latestFile)
+  def contentJson = new JsonBuilder(content).toPrettyString()
+  println "${fileName}:\n${contentJson}"
+  new File(filePath).write(contentJson)
+  return uploadArtifact(filePath)
 }
 
 def getParentRunEnv(name) {


### PR DESCRIPTION
In order to create https://status.im/stable/ as an equivalent of https://status.im/nightly/ but for releases I've made the following changes:

* Always upload the results `ipa` file for iOS to our DO Bucket
  - This will be also useful when we start diffing packages.
* Store the URL to the `ipa` file in `PKG_URL`
* Store the Diawi link under `DIAWI_URL` instead
* Get rid of useless __Notify__ stage. It makes sense only in PR builds.
* Get rid of unused `gitHubNotifyFull()` method

This is a corresponding change in `status.im` repo that adds uploading of `release.json`:
https://github.com/status-im/status.im/pull/247