### PR TITLE
Keep message list rendered while switching between tabs

### DIFF
--- a/src/status_im/ui/screens/chat/views.cljs
+++ b/src/status_im/ui/screens/chat/views.cljs
@@ -198,8 +198,7 @@
             my-public-key                      [:account/public-key]
             show-bottom-info?                  [:chats/current-chat-ui-prop :show-bottom-info?]
             show-message-options?              [:chats/current-chat-ui-prop :show-message-options?]
-            show-stickers?                     [:chats/current-chat-ui-prop :show-stickers?]
-            current-view                       [:get :view-id]]
+            show-stickers?                     [:chats/current-chat-ui-prop :show-stickers?]]
     ;; this scroll-view is a hack that allows us to use on-blur and on-focus on Android
     ;; more details here: https://github.com/facebook/react-native/issues/11071
     [react/scroll-view {:scroll-enabled               false
@@ -210,10 +209,8 @@
                   :on-layout (fn [e]
                                (re-frame/dispatch [:set :layout-height (-> e .-nativeEvent .-layout .-height)]))}
       [chat-toolbar public? modal?]
-      (if (or (= :chat current-view) modal?)
-        [messages-view-animation
-         [messages-view-wrapper modal?]]
-        [react/view style/message-view-preview])
+      [messages-view-animation
+       [messages-view-wrapper modal?]]
       (when (show-input-container? my-public-key current-chat)
         [input/container])
       (when show-stickers?


### PR DESCRIPTION
It partially solves the issue with keeping chat at the same position when switching tabs and also removes unnecessary animation.

![m](https://user-images.githubusercontent.com/2364994/53328998-d7308380-38f3-11e9-84a7-cbde1a2d4175.gif)
