### PR TITLE
Add configurable e2e tests kickoff project board column name

### DIFF
--- a/.github/github-bot.yml
+++ b/.github/github-bot.yml
@@ -10,6 +10,7 @@ project-board:
 automated-tests:
   repo-full-name: 'status-im/status-react'
   job-full-name: 'end-to-end-tests/status-app-end-to-end-tests'
+  kickoff-column-name: 'REVIEW'
 
 github-team:
   slug: 'clojure'


### PR DESCRIPTION
This PR adds `automated-tests/kickoff-column-name` to `.github/github-bot.yml` so we can configure how e2e tests get started.

status: ready <!-- Can be ready or wip -->
