### PR TITLE
Convert address to checksum address before testing for eip55

### DIFF
--- a/src/status_im/ui/screens/wallet/choose_recipient/events.cljs
+++ b/src/status_im/ui/screens/wallet/choose_recipient/events.cljs
@@ -82,7 +82,9 @@
                           :ens-name recipient
                           :cb       #(re-frame/dispatch [:wallet.send/set-recipient %])}}
        (if (ethereum/address? recipient)
-         (if (eip55/valid-address-checksum? recipient)
+         (if (-> recipient
+                 ethereum/address->checksum
+                 eip55/valid-address-checksum?)
            {:db       (assoc-in db [:wallet :send-transaction :to] recipient)
             :dispatch [:navigate-back]}
            {:ui/show-error (i18n/label :t/wallet-invalid-address-checksum {:data recipient})})

--- a/src/status_im/utils/ethereum/core.cljs
+++ b/src/status_im/utils/ethereum/core.cljs
@@ -48,6 +48,10 @@
   (when s
     (.isAddress dependencies/Web3.prototype s)))
 
+(defn address->checksum [s]
+  (when s
+    (.toChecksumAddress dependencies/Web3.prototype s)))
+
 (defn network->chain-id [network]
   (get-in network [:config :NetworkId]))
 


### PR DESCRIPTION
The address was not in checksum format before being tested for eip55. 

Fixes #7541 

@goranjovic please have a look, as I am a wallet n00b

status: ready
