### PR TITLE
refactor #7571 - decoupled request transaction from send transaction …

### DIFF
--- a/src/status_im/chat/commands/impl/transactions.cljs
+++ b/src/status_im/chat/commands/impl/transactions.cljs
@@ -318,7 +318,7 @@
                                     :amount-text amount
                                     :amount-error error)
                          (choose-recipient.events/fill-request-details
-                          (transaction-details recipient-contact symbol))
+                          (transaction-details recipient-contact symbol) false)
                          (update-in [:wallet :send-transaction]
                                     dissoc :id :password :wrong-password?))
                  ;; TODO(janherich) - refactor wallet send events, updating gas price

--- a/src/status_im/ui/screens/wallet/choose_recipient/events.cljs
+++ b/src/status_im/ui/screens/wallet/choose_recipient/events.cljs
@@ -20,22 +20,24 @@
 (defn- find-address-name [db address]
   (:name (contact.db/find-contact-by-address (:contacts/contacts db) address)))
 
-(defn- fill-request-details [db {:keys [address name value symbol gas gasPrice public-key from-chat?]}]
+(defn- fill-request-details [db {:keys [address name value symbol gas gasPrice public-key from-chat?]} request?]
   {:pre [(not (nil? address))]}
-  (let [name (or name (find-address-name db address))]
-    (update-in
-     db [:wallet :send-transaction]
-     (fn [{old-symbol :symbol :as old-transaction}]
-       (let [symbol-changed? (not= old-symbol symbol)]
-         (cond-> (assoc old-transaction :to address :to-name name :public-key public-key)
-           value (assoc :amount value)
-           symbol (assoc :symbol symbol)
-           (and gas symbol-changed?) (assoc :gas (money/bignumber gas))
-           from-chat? (assoc :from-chat? from-chat?)
-           (and gasPrice symbol-changed?)
-           (assoc :gas-price (money/bignumber gasPrice))
-           (and symbol (not gasPrice) symbol-changed?)
-           (assoc :gas-price (ethereum/estimate-gas symbol))))))))
+  (let [name (or name (find-address-name db address))
+        data-path (if request?
+                    [:wallet :request-transaction]
+                    [:wallet :send-transaction])]
+    (update-in db data-path
+               (fn [{old-symbol :symbol :as old-transaction}]
+                 (let [symbol-changed? (not= old-symbol symbol)]
+                   (cond-> (assoc old-transaction :to address :to-name name :public-key public-key)
+                     value (assoc :amount value)
+                     symbol (assoc :symbol symbol)
+                     (and gas symbol-changed?) (assoc :gas (money/bignumber gas))
+                     from-chat? (assoc :from-chat? from-chat?)
+                     (and gasPrice symbol-changed?)
+                     (assoc :gas-price (money/bignumber gasPrice))
+                     (and symbol (not gasPrice) symbol-changed?)
+                     (assoc :gas-price (ethereum/estimate-gas symbol))))))))
 
 (defn- extract-details
   "First try to parse as EIP681 URI, if not assume this is an address directly.
@@ -105,7 +107,7 @@
          symbol-changed?                        (and old-symbol new-symbol (not= old-symbol new-symbol))]
      (cond-> {:db         db
               :dispatch   [:navigate-back]}
-       (and address valid-network?) (update :db #(fill-request-details % details))
+       (and address valid-network?) (update :db #(fill-request-details % details false))
        symbol-changed? (changed-asset old-symbol new-symbol)
        (and old-amount new-amount (not= old-amount new-amount)) (changed-amount-warning old-amount new-amount)
         ;; NOTE(goranjovic) - the next line is there is because QR code scanning switches the amount to ETH
@@ -119,6 +121,6 @@
 
 (handlers/register-handler-fx
  :wallet/fill-request-from-contact
- (fn [{db :db} [_ {:keys [address name public-key]}]]
-   {:db         (fill-request-details db {:address address :name name :public-key public-key})
+ (fn [{db :db} [_ {:keys [address name public-key]} request?]]
+   {:db         (fill-request-details db {:address address :name name :public-key public-key} request?)
     :dispatch   [:navigate-back]}))

--- a/src/status_im/ui/screens/wallet/request/views.cljs
+++ b/src/status_im/ui/screens/wallet/request/views.cljs
@@ -21,7 +21,9 @@
             [status-im.utils.ethereum.eip681 :as eip681]
             [status-im.utils.utils :as utils]
             [status-im.utils.ethereum.tokens :as tokens]
-            [status-im.ui.screens.wallet.utils :as wallet.utils]))
+            [status-im.ui.screens.wallet.utils :as wallet.utils]
+            [status-im.ui.screens.chat.photos :as photos]
+            [status-im.ui.components.list.styles :as list.styles]))
 
 ;; Request screen
 
@@ -29,7 +31,8 @@
   ;; TODO(jeluard) both send and request flows should be merged
   (views/letsubs [network                                           [:account/network]
                   {:keys [to to-name public-key]}                   [:wallet.send/transaction]
-                  {:keys [amount amount-error amount-text symbol]}  [:wallet.request/transaction]
+                  {:keys [amount amount-error amount-text symbol
+                          to to-name public-key]}                   [:wallet.request/transaction]
                   network-status                                    [:network-status]
                   all-tokens                                        [:wallet/all-tokens]
                   scroll                                            (atom nil)]
@@ -43,8 +46,7 @@
           [components/recipient-selector {:contact-only? true
                                           :address       to
                                           :name          to-name
-                                          :request?      true
-                                          :modal?        false}]
+                                          :request?      true}]
           [components/asset-selector {:disabled? false
                                       :type      :request
                                       :symbol    symbol}]


### PR DESCRIPTION
fixes #7571
partially addresses  #7263

### Problem

Request transaction flow was tightly coupled with Send transaction flow, so it was rather difficult to prevent PR scope creep. This PR addresses the issue by decoupling the two flows.

The purpose of this PR is to gradually prepare develop branch for the changes intended in #7263

### Testing notes (optional):

Request transaction and Send transaction should work as before. No behavior changes

status: ready 
