### PR TITLE
Dont change mailserver if no network

### DIFF
--- a/src/status_im/mailserver/core.cljs
+++ b/src/status_im/mailserver/core.cljs
@@ -383,27 +383,28 @@
   "mark mailserver status as `:error` if custom mailserver is used
   otherwise try to reconnect to another mailserver"
   [{:keys [db] :as cofx}]
-  (if-let [preferred-mailserver (preferred-mailserver-id cofx)]
-    (let [current-fleet (fleet/current-fleet db)]
-      {:db
-       (update-mailserver-state db :error)
-       :ui/show-confirmation
-       {:title               (i18n/label :t/mailserver-error-title)
-        :content             (i18n/label :t/mailserver-error-content)
-        :confirm-button-text (i18n/label :t/mailserver-pick-another)
-        :on-accept           #(re-frame/dispatch
-                               [:navigate-to :offline-messaging-settings])
-        :extra-options       [{:text    (i18n/label :t/mailserver-retry)
-                               :onPress #(re-frame/dispatch
-                                          [:mailserver.ui/connect-confirmed
-                                           current-fleet
-                                           preferred-mailserver])
-                               :style   "default"}]}})
-    (let [{:keys [address]} (fetch-current cofx)]
-      (fx/merge cofx
-                {:mailserver/remove-peer address}
-                (set-current-mailserver)
-                (connect-to-mailserver)))))
+  (when-not (zero? (:peers-count db))
+    (if-let [preferred-mailserver (preferred-mailserver-id cofx)]
+      (let [current-fleet (fleet/current-fleet db)]
+        {:db
+         (update-mailserver-state db :error)
+         :ui/show-confirmation
+         {:title               (i18n/label :t/mailserver-error-title)
+          :content             (i18n/label :t/mailserver-error-content)
+          :confirm-button-text (i18n/label :t/mailserver-pick-another)
+          :on-accept           #(re-frame/dispatch
+                                 [:navigate-to :offline-messaging-settings])
+          :extra-options       [{:text    (i18n/label :t/mailserver-retry)
+                                 :onPress #(re-frame/dispatch
+                                            [:mailserver.ui/connect-confirmed
+                                             current-fleet
+                                             preferred-mailserver])
+                                 :style   "default"}]}})
+      (let [{:keys [address]} (fetch-current cofx)]
+        (fx/merge cofx
+                  {:mailserver/remove-peer address}
+                  (set-current-mailserver)
+                  (connect-to-mailserver))))))
 
 (fx/defn check-connection
   "connection-checks counter is used to prevent changing

--- a/test/cljs/status_im/test/mailserver/core.cljs
+++ b/test/cljs/status_im/test/mailserver/core.cljs
@@ -28,6 +28,32 @@
     :enode "enode://0f7c65277f916ff4379fe520b875082a56e587eb3ce1c1567d9ff94206bdb05ba167c52272f20f634cd1ebdec5d9dfeb393018bfde1595d8e64a717c8b46692f@203.136.241.111:40404"
     :name "Geth/v1.7.2-stable/linux-amd64/go1.9.1"}])
 
+(deftest change-mailserver
+  (testing "we are offline"
+    (testing "it does not change mailserver"
+      (is (not (mailserver/change-mailserver {:db {:peers-count 0}})))))
+  (testing "we are online"
+    (testing "there's a preferred mailserver"
+      (testing "it shows the popup"
+        (is (:ui/show-confirmation (mailserver/change-mailserver
+                                    {:db {:account/account {:settings
+                                                            {:fleet :beta
+                                                             :mailserver {:beta "id"}}}
+                                          :peers-count 1}})))))
+    (testing "there's not a preferred mailserver"
+      (testing "it changes the mailserver"
+        (is (= :a
+               (get-in
+                (mailserver/change-mailserver
+                 {:db {:mailserver/mailservers {:beta {:a "b"}}
+                       :account/account {:settings
+                                         {:fleet :beta}}
+                       :peers-count 1}})
+                [:db :mailserver/current-id]))))
+      (testing "it does not show the popup"
+        (is (not (:ui/show-confirmation (mailserver/change-mailserver
+                                         {:db {:peers-count 1}}))))))))
+
 (deftest test-registered-peer?
   (testing "Peer is registered"
     (is (mailserver/registered-peer? peers enode)))


### PR DESCRIPTION
When we are offline, we don't try to change mailserver, and we don't
show a pop up to the user, as it is not that the mailserver is not
working, we are just offline.

### Testing

1) Login, wait for all the mailserver stuff to be finished
2) Select one mailserver in settings
3) Turn on airplane mode, wait until Offline is displayed
4) Open a chat
5) Fetch 24 hours
6) Wait 20s
7) Turn off airplane mode

On develop it will show a popup on 6
On this PR it should not

Everything else should work the same after 7

I would add to release if works.

status: ready
