### PR TITLE
android: don't crash on invalid URLs

### DIFF
--- a/mobile_files/package.json.orig
+++ b/mobile_files/package.json.orig
@@ -59,7 +59,7 @@
     "react-native-svg": "6.5.2",
     "react-native-tcp": "git+https://github.com/status-im/react-native-tcp.git#v3.3.0-1-status",
     "react-native-udp": "git+https://github.com/status-im/react-native-udp.git#2.3.1-1",
-    "react-native-webview-bridge": "git+https://github.com/status-im/react-native-webview-bridge.git#0.33.16-4",
+    "react-native-webview-bridge": "git+https://github.com/status-im/react-native-webview-bridge.git#v0.33.16-6",
     "react-navigation": "^2.12.1",
     "react-navigation-stack": "git+https://github.com/status-im/react-navigation-stack.git#0.7.0",
     "realm": "2.21.0",

--- a/mobile_files/yarn.lock
+++ b/mobile_files/yarn.lock
@@ -6058,9 +6058,9 @@ react-native-tab-view@^1.0.0:
     ip-regex "^1.0.3"
     util "^0.10.3"
 
-"react-native-webview-bridge@git+https://github.com/status-im/react-native-webview-bridge.git#0.33.16-4":
+"react-native-webview-bridge@git+https://github.com/status-im/react-native-webview-bridge.git#v0.33.16-6":
   version "0.33.16"
-  resolved "git+https://github.com/status-im/react-native-webview-bridge.git#db39ab2719dd0e0d33324643820619f3e75960b4"
+  resolved "git+https://github.com/status-im/react-native-webview-bridge.git#4d9a7e7fd5319c3c2b494426c4ede3ac94135a87"
   dependencies:
     invariant "2.2.0"
     keymirror "0.1.1"


### PR DESCRIPTION
actual fix: https://github.com/status-im/react-native-webview-bridge/commit/d5a9ad652ea2618b6987dd6fffa8b549d24c95b2

also, use a tag so it helps with reproducible builds

tested on Android 8.0 in genymotion.
url: `http://a bc.com`
no crash

<img width="342" alt="gm" src="https://user-images.githubusercontent.com/466427/53433817-77220600-39f5-11e9-90eb-06c220661ce5.png">



fixes #4205

status: ready <!-- Can be ready or wip -->