### PR TITLE
Add tests create acc with special chars pass

### DIFF
--- a/test/appium/tests/atomic/account_management/test_create_account.py
+++ b/test/appium/tests/atomic/account_management/test_create_account.py
@@ -2,6 +2,7 @@ import pytest
 from tests import marks, common_password, get_current_time, unique_password
 from tests.base_test_case import SingleDeviceTestCase
 from views.sign_in_view import SignInView
+from tests.users import basic_user
 
 
 @marks.all
@@ -90,3 +91,10 @@ class TestCreateAccount(SingleDeviceTestCase):
         sign_in = SignInView(self.driver)
         sign_in.create_user(password=unique_password)
         sign_in.check_no_values_in_logcat(password=unique_password)
+
+    @marks.testrail_id(5718)
+    @marks.medium
+    def test_special_characters_in_password_when_creating_new_account(self):
+        sign_in = SignInView(self.driver)
+        sign_in.create_user(password=basic_user['special_chars_password'])
+        sign_in.relogin(password=basic_user['special_chars_password'])

--- a/test/appium/tests/atomic/account_management/test_recover.py
+++ b/test/appium/tests/atomic/account_management/test_recover.py
@@ -158,3 +158,10 @@ class TestRecoverAccessFromSignInScreen(SingleDeviceTestCase):
         recover_access_view.send_as_keyevent(capitalized_passphrase)
         if recover_access_view.passphrase_input.text != passphrase:
             self.driver.fail('Upper case was not replaced by lower case!')
+
+    @marks.testrail_id(5719)
+    @marks.medium
+    def test_special_characters_in_password_when_recover_account(self):
+        sign_in = SignInView(self.driver)
+        sign_in.recover_access(passphrase=basic_user['passphrase'], password=basic_user['special_chars_password'])
+        sign_in.relogin(password=basic_user['special_chars_password'])

--- a/test/appium/tests/users.py
+++ b/test/appium/tests/users.py
@@ -4,6 +4,7 @@ basic_user['username'] = "Little Weighty Iberianmole"
 basic_user['public_key'] = "0x040d3400f0ba80b2f6017a9021a66e042abc33cf7051ddf98a24a815c93d6c052ce2b7873d799f096325" \
                            "9f41c5a1bf08133dd4f3fe63ea1cceaa1e86ebc4bc42c9"
 basic_user['address'] = "f184747445c3B85CEb147DfB136067CB93d95F1D"
+basic_user['special_chars_password'] = " !\"#$Á%Ö&'()*+Í, -./:ä;<=>?@[\\]^_`{|}~ "
 
 wallet_users = dict()
 

--- a/test/appium/views/sign_in_view.py
+++ b/test/appium/views/sign_in_view.py
@@ -134,9 +134,9 @@ class SignInView(BaseView):
         else:
             recover_access_view = self.i_have_account_button.click()
         recover_access_view.passphrase_input.click()
-        recover_access_view.send_as_keyevent(passphrase)
+        recover_access_view.passphrase_input.set_value(passphrase)
         recover_access_view.password_input.click()
-        recover_access_view.send_as_keyevent(password)
+        recover_access_view.password_input.set_value(password)
         recover_access_view.sign_in_button.click_until_presence_of_element(recover_access_view.home_button)
         return self.get_home_view()
 


### PR DESCRIPTION
* Added tests to create and recover an account having special characters in the password
* Along with set_value for password (when recover account) updated the way to input passphrase: if it works - autotests set execution should be faster (will update with numbers after e2e against this PR finished)
**Upd**: https://ci.status.im/job/end-to-end-tests/job/status-app-nightly/742/ - nightly scope ran from this branch. All fine but I don't see any change in time of job ran (~48 min as before)
