### PR TITLE
settings: fix a typo in dapps permissions label

### DIFF
--- a/translations/en.json
+++ b/translations/en.json
@@ -929,7 +929,7 @@
     "mailserver-pick-another": "Pick another mailserver",
     "mailserver-error-title": "Error connecting to mailserver",
     "mailserver-error-content": "The mailserver you selected couldn't be reached.",
-    "dapps-permissions": "Dapps permissions",
+    "dapps-permissions": "DApp permissions",
     "revoke-access": "Revoke access",
     "extensions-camera-send-picture": "Send picture",
     "mobile-syncing-sheet-title": "Sync using the mobile network",


### PR DESCRIPTION
`Dapp` -> `DApp`

fixes #7599


⚠️⚠️  NB! this change is already in the release branch ⚠️ ⚠️ 


status: ready <!-- Can be ready or wip -->