### PR TITLE
revert Replace react-navigation-stack with fork without default background color

### DIFF
--- a/mobile_files/package.json.orig
+++ b/mobile_files/package.json.orig
@@ -59,7 +59,6 @@
     "react-native-udp": "git+https://github.com/status-im/react-native-udp.git#2.3.1-1",
     "react-native-webview-bridge": "git+https://github.com/status-im/react-native-webview-bridge.git#v0.33.16-6",
     "react-navigation": "^2.12.1",
-    "react-navigation-stack": "git+https://github.com/status-im/react-navigation-stack.git#0.7.0",
     "realm": "2.21.0",
     "rn-snoopy": "git+https://github.com/status-im/rn-snoopy.git#v2.0.2-status",
     "string_decoder": "0.10.31",

--- a/mobile_files/yarn.lock
+++ b/mobile_files/yarn.lock
@@ -5970,9 +5970,10 @@ react-navigation-drawer@0.5.0:
   dependencies:
     react-native-drawer-layout-polyfill "^1.3.2"
 
-"react-navigation-stack@git+https://github.com/status-im/react-navigation-stack.git#0.7.0", react-navigation-stack@0.7.0:
+react-navigation-stack@0.7.0:
   version "0.7.0"
-  resolved "git+https://github.com/status-im/react-navigation-stack.git#0.7.0"
+  resolved "https://registry.yarnpkg.com/react-navigation-stack/-/react-navigation-stack-0.7.0.tgz#0b2f139ee1cba953037ef51353df992ec6c74fa2"
+  integrity sha512-3Tbb/SsustBrM9R/qaI6XuOfyqYMVbwkeHFC8NbU890vB0aKZvjAtioWLZ18e/4LgbiOCmoTdp37z3gkGDyNDQ==
 
 react-navigation-tabs@0.8.4:
   version "0.8.4"


### PR DESCRIPTION
It seems that our fork introduced some regression and nav transitions on iOS become slow. 