### PR TITLE
[temporary workaround] ci: don't check certificates in AppStoreConnect when building iOS

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -151,14 +151,16 @@ platform :ios do
   desc "This lane builds a new adhoc build and leaves an .ipa that is ad-hoc signed (can be uploaded to diawi)"
   lane :pr do
     unlock_keychain_if_needed
-    build_ios_adhoc(false)
+    # TODO: fixme when 2FA is setup
+    build_ios_adhoc(true)
   end
 
   desc "`fastlane ios nightly` - makes a new nightly"
   desc "This lane builds a new nightly and leaves an .ipa that is ad-hoc signed (can be uploaded to diawi)"
   lane :nightly do
     unlock_keychain_if_needed
-    build_ios_adhoc(false)
+    # TODO: fixme when 2FA is setup
+    build_ios_adhoc(true)
   end
 
   desc "`fastlane ios release` builds a release & uploads it to TestFlight"


### PR DESCRIPTION
⚠️⚠️ ⚠️ it will break adding new devices ⚠️⚠️⚠️
but will help workaround the isssue that we don't have 2FA installed on our Apple ID
(essentially, our iOS apps will build again)

to be reverted when we setup a proper 2FA on our main AppStoreConnect account

status: ready <!-- Can be ready or wip -->