### PR TITLE
Disable font scaling

### DIFF
--- a/components/src/status_im/ui/components/react.cljs
+++ b/components/src/status_im/ui/components/react.cljs
@@ -101,16 +101,19 @@
 
 (defn text
   ([t]
-   [text-class t])
+   [text-class {:allowFontScaling false} t])
   ([opts t & ts]
    (->> (conj ts t)
         (transform-to-uppercase opts)
-        (concat [text-class (add-font-style :style opts)])
+        (concat [text-class (add-font-style
+                             :style
+                             (assoc opts :allowFontScaling false))])
         (vec))))
 
 (defn text-input [{:keys [style] :as opts} text]
   [text-input-class (merge
                      {:underline-color-android :transparent
+                      :allowFontScaling        false
                       :placeholder-text-color  colors/text-gray
                       :placeholder             (i18n/label :t/type-a-message)
                       :value                   text}


### PR DESCRIPTION
fix #7215

Let's disable font scaling till we handle it properly. It looks off at the moment:

![screen shot 2019-03-01 at 09 16 51](https://user-images.githubusercontent.com/2364994/53623241-25e86100-3c05-11e9-89f1-d803746d1282.png)
![screen shot 2019-03-01 at 09 10 09](https://user-images.githubusercontent.com/2364994/53623242-25e86100-3c05-11e9-9de0-b1cafbf6cca7.png)