### PR TITLE
fix pgrep by using --full for checking whole command line for name

### DIFF
--- a/scripts/wait-for.sh
+++ b/scripts/wait-for.sh
@@ -13,7 +13,7 @@ if [[ -z ${PROC_NAME} ]]; then
 fi
 
 for ((i = 0; i < ${STEPS}; i += 1)); do
-    if pgrep ${PROC_NAME} > /dev/null; then
+    if pgrep -f ${PROC_NAME} > /dev/null; then
         echo "Process found. Sleeping ${SLEEP_SEC}..." >&2
         sleep ${SLEEP_SEC}
     else


### PR DESCRIPTION
It appears the `pod` processes are still clashing. `pgrep` is not finding them properly withou `-f`:
```
 -f, --full
   The pattern is normally only matched against the process name.  When -f is set, the full command line is used.
```