### PR TITLE
[#4158] Fix New messages counter being shown for already seen messages

### DIFF
--- a/src/status_im/chat/models.cljs
+++ b/src/status_im/chat/models.cljs
@@ -246,7 +246,8 @@
               {:db (-> (assoc db :current-chat-id chat-id)
                        (set-chat-ui-props {:validation-messages nil}))}
               (contact-code/listen-to-chat chat-id)
-              (mark-messages-seen chat-id))))
+              (when platform/desktop?
+                (mark-messages-seen chat-id)))))
 
 (fx/defn navigate-to-chat
   "Takes coeffects map and chat-id, returns effects necessary for navigation and preloading data"

--- a/src/status_im/ui/screens/events.cljs
+++ b/src/status_im/ui/screens/events.cljs
@@ -25,6 +25,7 @@
             status-im.utils.keychain.events
             [re-frame.core :as re-frame]
             [status-im.hardwallet.core :as hardwallet]
+            [status-im.chat.models :as chat]
             [status-im.native-module.core :as status]
             [status-im.mailserver.core :as mailserver]
             [status-im.ui.components.permissions :as permissions]
@@ -72,6 +73,11 @@
 (re-frame/reg-fx
  :http-post
  http-post)
+
+(defn- mark-messages-seen
+  [{:keys [db] :as cofx}]
+  (let [{:keys [current-chat-id]} db]
+    (chat/mark-messages-seen cofx current-chat-id)))
 
 (defn- http-raw-post [{:keys [url body response-validator success-event-creator failure-event-creator timeout-ms opts]}]
   (let [on-success #(re-frame/dispatch (success-event-creator %))
@@ -190,4 +196,5 @@
                 :hardwallet-connect (hardwallet/hardwallet-connect-screen-did-load %)
                 :hardwallet-authentication-method (hardwallet/authentication-method-screen-did-load %)
                 :accounts (hardwallet/accounts-screen-did-load %)
+                :chat (mark-messages-seen %)
                 nil))))


### PR DESCRIPTION
Fixes #4158 
(New messages counter is shown for already seen messages)

### Summary:
Solved the problem by marking as seen new messages when view-id of on-will-focus event is :chat

### Notes:


* Tested on iOS simulator and Android AVD
* This PR only focuses on mobile platforms
* Related Desktop issues(for example https://github.com/status-im/status-react/issues/6812) can be worked on if needed. However, because of on-going work on porting mobile UI to desktop, sounded like it might not be necessary.

status: ready

