### PR TITLE
[fix 7617] search bar glitch

### DIFF
--- a/src/status_im/ui/screens/home/views.cljs
+++ b/src/status_im/ui/screens/home/views.cljs
@@ -156,12 +156,22 @@
                       :easing   (.in (animation/easing)
                                      (.-quad (animation/easing)))})))
 
+(defn set-search-state-visible!
+  [visible?]
+  (swap! search-input-state assoc :show? visible?)
+  (animation/set-value (:height @search-input-state)
+                       (if visible?
+                         styles/search-input-height
+                         0)))
+
 (defn animated-search-input
   [search-filter]
   (reagent/create-class
    {:component-will-unmount
-    #(do (swap! search-input-state assoc :show? false)
-         (animation/set-value (:height @search-input-state) 0))
+    #(set-search-state-visible! false)
+    :component-did-mount
+    #(when search-filter
+       (set-search-state-visible! true))
     :reagent-render
     (fn [search-filter]
       (let [{:keys [show? height]} @search-input-state]


### PR DESCRIPTION
fixes #7617

Tested on Android emulator

![screenshot_1551707024](https://user-images.githubusercontent.com/1181225/53737260-55f56580-3e8c-11e9-980a-e90bbb56dba5.png)

State of the search bar was cleaned when component is unmounted, so that it wouldn't stay up when user logs out and logs in again. However it appears that the component is unmounted as well in some scenarios. This PR adds a check when the component is mounted so that it shows the search-bar properly if there is a search-filter.

status: ready
