### PR TITLE
[fix] use cross platform shebangs in scripts

### DIFF
--- a/scripts/prepare-for-platform.sh
+++ b/scripts/prepare-for-platform.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/scripts/run-environment-check.sh
+++ b/scripts/run-environment-check.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'


### PR DESCRIPTION
### Summary:

On some linux distros the bash executeable isn't located in /bin/bash. This is the case for my distro, NixOs. By running the bash trough the current env, it would enable running shell scripts in all linux distros AFAIK.