### PR TITLE
fix missing cmn. prefix

### DIFF
--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -76,7 +76,7 @@ pipeline {
           /* mobile */
           Apk: cmn.pkgUrl(apk), Apke2e: cmn.pkgUrl(apke2e),
           iOS: cmn.pkgUrl(ios), /*iOSe2e: cmn.pkgUrl(iose2e),*/
-          Diawi: getEnv(ios, 'DIAWI_URL'),
+          Diawi: cmn.getEnv(ios, 'DIAWI_URL'),
           /* desktop */
           App: cmn.pkgUrl(nix), Mac: cmn.pkgUrl(osx), Win: cmn.pkgUrl(win),
           /* upload the sha256 checksums file too */


### PR DESCRIPTION
Fix for Nightly build:
https://ci.status.im/job/status-react/job/nightly/975/console
Missing `cmn` prefix.