### PR TITLE
add retries to SauceLabs upload

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -31,13 +31,23 @@ def upload_to_saucelabs(file)
     username = ENV["SAUCE_USERNAME"]
     unique_name = ENV["SAUCE_LABS_NAME"]
 
-    url = "https://saucelabs.com/rest/v1/storage/" + username + '/' + unique_name + "?overwrite=true"
+    url = "https://saucelabs.com/rest/v1/storage/#{username}/#{unique_name}?overwrite=true"
+    # retry settings
+    conn_timeout = "5"
+    upload_timeout = "60"
+    upload_retries = "3"
 
     upload_result = sh(
         "curl",
         "-u", username + ':' + key,
         "-X", "POST",
         "-H", "Content-Type: application/octet-stream",
+        # we retry few times if upload doesn't succeed in sensible time
+        "--connect-timeout", conn_timeout,  # max time in sec. for establishing connection 
+        "--max-time", upload_timeout,       # max time in sec. for whole transfer to take
+        "--retry", upload_retries,          # number of retries to attempt
+        "--retry-max-time", upload_timeout, # same as --max-time but for retries
+        "--retry-delay", "0",               # an exponential backoff algorithm in sec.
         url,
         # this command has `status-react/fastlane` as cwd
         # so we need to jump outside this folder to get a file
@@ -46,7 +56,7 @@ def upload_to_saucelabs(file)
 
     # fail the lane if upload fails
     UI.user_error!(
-        "failed to upload file to saucelabs: " + upload_result
+        "failed to upload file to saucelabs despite #{upload_retries} retries: #{upload_result}"
     ) unless upload_result.include? "filename"
 end
 


### PR DESCRIPTION
Sometimes upload to SauceLabs fails:
```log
00:17:13.066  [03:16:26]: $ curl -u ****:**** -X POST -H Content-Type:\ application/octet-stream https://saucelabs.com/rest/v1/storage/****/StatusIm-190307-025900-382eea-e2e.apk\?overwrite\=true --data-binary @../android/app/build/outputs/apk/release/app-release.apk
00:17:13.066  [03:16:26]: ▸ % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
00:17:13.066  [03:16:26]: ▸ Dload  Upload   Total   Spent    Left  Speed
00:35:11.335  Cancelling nested steps due to timeout
00:35:11.339  Sending interrupt signal to process
```
https://ci.status.im/job/status-react/job/combined/job/mobile-android-e2e/186/console

In this case it took around ~18 minutes without any timeout, and failed due to Jenkins job timeout and subsequent abort.

I'm adding curl options to retry upload 3 times if the connection isn't established in under 5 seconds or it doesn't succeed in under 60 seconds. Looking at the e2e job the upload stage usually hovers around ~20 seconds.
https://ci.status.im/job/status-react/job/combined/job/mobile-android-e2e/