### PR TITLE
upgrade android ndk to r17c

### DIFF
--- a/.TOOLVERSIONS
+++ b/.TOOLVERSIONS
@@ -1,4 +1,4 @@
-android-ndk;r10e;070be287539e3e7706f8dabfb6bf9879
+android-ndk;r17c;a4b6b8281e7d101efd994d31e64af746
 android-sdk-build-tools;28.0.1;
 android-sdk-platform;android-27;
 android-sdk;4333796;aa190cfd7299cd6a1c687355bb2764e4

--- a/.TOOLVERSIONS
+++ b/.TOOLVERSIONS
@@ -1,6 +1,6 @@
 android-ndk;r17c;a4b6b8281e7d101efd994d31e64af746
-android-sdk-build-tools;28.0.1;
-android-sdk-platform;android-27;
+android-sdk-build-tools;28.0.3;
+android-sdk-platform;android-28;
 android-sdk;4333796;aa190cfd7299cd6a1c687355bb2764e4
 clojure_cli;1.9.0.381;
 cmake;3.12.2;

--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -3,7 +3,7 @@ pipeline {
     docker {
       label 'linux'
       /* WARNING: remember to keep this up-to-date with the value in docker/android/Makefile */
-      image 'statusteam/status-build-android:1.1.1-d3611a31'
+      image 'statusteam/status-build-android:1.1.1-481a7564'
       args (
         "-v /home/jenkins/tmp:/var/tmp:rw "+
         "-v /home/jenkins/status-im.keystore:/tmp/status-im.keystore:ro"

--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -3,7 +3,7 @@ pipeline {
     docker {
       label 'linux'
       /* WARNING: remember to keep this up-to-date with the value in docker/android/Makefile */
-      image 'statusteam/status-build-android:1.1.1-cd1596b3'
+      image 'statusteam/status-build-android:1.1.1-d3611a31'
       args (
         "-v /home/jenkins/tmp:/var/tmp:rw "+
         "-v /home/jenkins/status-im.keystore:/tmp/status-im.keystore:ro"

--- a/docker/android/Makefile
+++ b/docker/android/Makefile
@@ -17,7 +17,7 @@ SDK_PLATFORM_VERSION=$(call  __toolversion, android-sdk-platform)
 SDK_BUILD_TOOLS_VERSION=$(call  __toolversion, android-sdk-build-tools)
 
 # WARNING: Remember to change the tag when updating the image
-BASE_IMAGE_TAG = $(shell cd $(GIT_ROOT)/docker/base && make get-image-tag)
+BASE_IMAGE_TAG = $(shell cd $(GIT_ROOT)/docker/base && $(MAKE) get-image-tag --no-print-directory)
 DEPS_HASH = $(shell $(GIT_ROOT)/scripts/gen-deps-hash.sh -b $(BASE_IMAGE_TAG) \
 					-d android-ndk \
 					-d android-sdk \

--- a/docker/base/Makefile
+++ b/docker/base/Makefile
@@ -1,3 +1,6 @@
+.PHONY:get-image-tag
+.SILENT:get-image-tag
+
 __toolversion = $(shell $(GIT_ROOT)/scripts/toolversion $(1))
 
 GIT_COMMIT = $(shell git rev-parse --short HEAD)


### PR DESCRIPTION
Required by #7666
I've pushed the image and it's already up:
https://cloud.docker.com/u/statusteam/repository/docker/statusteam/status-build-android/tags