### PR TITLE
support style in link and map-link components in extensions

### DIFF
--- a/src/status_im/extensions/map.cljs
+++ b/src/status_im/extensions/map.cljs
@@ -8,7 +8,6 @@
             [status-im.utils.platform :as platform]
             [status-im.utils.types :as types]
             [status-im.ui.components.react :as react]
-            [status-im.ui.components.colors :as colors]
             [status-im.ui.screens.browser.styles :as styles]
             [status-im.react-native.js-dependencies :as js-dependencies]))
 
@@ -80,16 +79,3 @@
                                                   (str "update(" (types/clj->json (assoc marker :fly fly? :interactive interactive?)) ");")
                                                   (str "init(" (types/clj->json {:interactive interactive?}) ");")))}
      webview]))
-
-(defn map-link
-  "create a link-view which opens native map/navigation app with marker and label"
-  [{:keys [text lat lng]}]
-  (let [uri (cond
-              platform/ios? (str "http://maps.apple.com/?q=" (js/encodeURIComponent text) "&ll=" lat "," lng)
-              platform/android? (str "geo:0,0?q=" lat "," lng "(" (js/encodeURIComponent text) ")")
-              :else (str "http://www.openstreetmap.org/?mlat=" lat "&mlon=" lng))]
-    [react/text
-     {:style    {:color                colors/white
-                 :text-decoration-line :underline}
-      :on-press #(.openURL react/linking uri)}
-     text]))


### PR DESCRIPTION
@jeluard @flexsurfer 

as discussed here: https://github.com/status-im/status-react/pull/7404#issuecomment-470143806

I implemented the ability to override the standard style for links.
I also added some new features to the link component:

`link  {:value link :properties {:uri :string :text? :string :open-in? {:one-of #{:device :status}}}}`

link definition now supports:
- displaying a `text` different from the `uri`
- with `open-in` you can choose to open the link on the device or in status browser. if you don't specify, dialog is shown to the user who choose how to open it.

extension example is here: https://get.status.im/extension/ipfs@QmXv1ZzHbJYiA7n8TM8aUaAQsW5Cm8jHj3MBmshVNP59qW


![image](https://user-images.githubusercontent.com/15999009/54025976-8e52b780-419c-11e9-85bd-8569f68e540c.png)
