### PR TITLE
Make keycard login faster

### DIFF
--- a/mobile_files/package.json.orig
+++ b/mobile_files/package.json.orig
@@ -54,7 +54,7 @@
     "react-native-safe-area-view": "0.9.0",
     "react-native-securerandom": "git+https://github.com/status-im/react-native-securerandom.git#0.1.1-2",
     "react-native-splash-screen": "3.1.1",
-    "react-native-status-keycard": "git+https://github.com/status-im/react-native-status-keycard.git#v2.3.9",
+    "react-native-status-keycard": "git+https://github.com/status-im/react-native-status-keycard.git#v2.3.10",
     "react-native-svg": "6.5.2",
     "react-native-tcp": "git+https://github.com/status-im/react-native-tcp.git#v3.3.0-1-status",
     "react-native-udp": "git+https://github.com/status-im/react-native-udp.git#2.3.1-1",

--- a/mobile_files/yarn.lock
+++ b/mobile_files/yarn.lock
@@ -5845,9 +5845,9 @@ react-native-splash-screen@3.1.1:
   resolved "https://registry.yarnpkg.com/react-native-splash-screen/-/react-native-splash-screen-3.1.1.tgz#1a4e46c9fdce53ff52af2a2cb4181788c4e30b30"
   integrity sha512-PU2YocOSGbLjL9Vgcq/cwMNuHHKNjjuPpa1IPMuWo+6EB/fSZ5VOmxSa7+eucQe3631s3NhGuk3eHKahU03a4Q==
 
-"react-native-status-keycard@git+https://github.com/status-im/react-native-status-keycard.git#v2.3.9":
-  version "2.3.9"
-  resolved "git+https://github.com/status-im/react-native-status-keycard.git#d6378e434fcf06ca23f8c373a4d44d5a69c23db5"
+"react-native-status-keycard@git+https://github.com/status-im/react-native-status-keycard.git#v2.3.10":
+  version "2.3.10"
+  resolved "git+https://github.com/status-im/react-native-status-keycard.git#a6da0a7889fdbc8cdf61771cf1b989c5cfb14b08"
 
 react-native-svg@6.5.2:
   version "6.5.2"

--- a/src/status_im/hardwallet/core.cljs
+++ b/src/status_im/hardwallet/core.cljs
@@ -701,10 +701,13 @@
 
 (fx/defn wait-for-card-tap
   [{:keys [db] :as cofx}]
-  (fx/merge cofx
-            {:db (-> db
-                     (assoc-in [:hardwallet :on-card-read] :hardwallet/login-with-keycard))}
-            (navigation/navigate-to-cofx :hardwallet-connect nil)))
+  (let [card-connected? (get-in db [:hardwallet :card-connected?])]
+    (if card-connected?
+      (login-with-keycard cofx false)
+      (fx/merge cofx
+                {:db (-> db
+                         (assoc-in [:hardwallet :on-card-read] :hardwallet/login-with-keycard))}
+                (navigation/navigate-to-cofx :hardwallet-connect nil)))))
 
 ; PIN enter steps:
 ; login - PIN is used to login


### PR DESCRIPTION
### Summary:

Optimize keycard login speed by using `exportKey()` SDK methods.

`getKeys()` method now takes ~3.3 seconds instead of ~5 seconds 
https://github.com/status-im/react-native-status-keycard/blob/master/android/src/main/java/im/status/ethereum/keycard/SmartCard.java#L288

Also
* don't ask to tap card if it's already has connection.
* update cap file keycard_v2.1.cap

#### Platforms (optional)
- Android

status: ready
