### PR TITLE
Pass cofx as first parameter when deleting bootnodes

### DIFF
--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -551,8 +551,8 @@
 
 (handlers/register-handler-fx
  :bootnodes.ui/delete-pressed
- (fn [_ [_ id]]
-   (bootnodes/show-delete-bootnode-confirmation _ id)))
+ (fn [cofx [_ id]]
+   (bootnodes/show-delete-bootnode-confirmation cofx id)))
 
 (handlers/register-handler-fx
  :bootnodes.ui/delete-confirmed


### PR DESCRIPTION
Fixes:#7553

Cofx was not passed as first parameter as not used, and validations would fail, other then that the rest is working. 

status: ready