### PR TITLE
Removed react-native-webview from clj-rn.conf.edn

### DIFF
--- a/clj-rn.conf.edn
+++ b/clj-rn.conf.edn
@@ -60,7 +60,6 @@
                    "react-native-image-crop-picker"
                    "react-native-securerandom"
                    "react-native-webview-bridge"
-                   "react-native-webview"
                    "homoglyph-finder"
                    "web3"
                    "chance"


### PR DESCRIPTION

fixes #7735

### Summary:

`react-native-webview` removed from status desktop, but not yet from clj-rn.conf.edn. That leads to error on loading `index.desktop.js`

### Review notes (optional):


### Testing notes (optional):
Shouln't really affect production build.

#### Platforms (optional)
- macOS
- Linux
- Windows

<!-- (Specify if some specific areas has to be tested, for example 1-1 chats) -->
#### Areas that maybe impacted (optional)
**Functional**
- 1-1 chats
- public chats
- group chats
- wallet / transactions
- dapps / app browsing
- account recovery
- new account
- user profile updates
- networks
- mailservers
- fleet
- bootnodes

**Non-functional**
- battery performance
- CPU performance / speed of the app
- network consumption

<!-- (Specify exact steps to test if there are such) -->
### Steps to test:
(applicable only for dev mode)
- run `npm start`
- run `react-native run-desktop`
- Check that app starts correctly

status: ready
