### PR TITLE
Wait until activity is ready

### DIFF
--- a/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusModule.java
+++ b/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusModule.java
@@ -90,12 +90,25 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
     }
 
     private boolean checkAvailability() {
+      // We wait at least 10s for getCurrentActivity to return a value,
+      // otherwise we give up
+      for (int attempts = 0; attempts < 100; attempts++) {
         if (getCurrentActivity() != null) {
-            return true;
+          return true;
         }
+        try {
+          Thread.sleep(100);
+        } catch (InterruptedException ex) {
+          if (getCurrentActivity() != null) {
+            return true;
+          }
+          Log.d(TAG, "Activity doesn't exist");
+          return false;
+        }
+      }
 
-        Log.d(TAG, "Activity doesn't exist");
-        return false;
+      Log.d(TAG, "Activity doesn't exist");
+      return false;
 
     }
 
@@ -342,6 +355,7 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
         Log.d(TAG, "startNode");
         if (!checkAvailability()) {
             Log.e(TAG, "[startNode] Activity doesn't exist, cannot start node");
+            System.exit(0);
             return;
         }
 


### PR DESCRIPTION
Fixes: #7579 

When resuming from a push notification sometimes `ReactInstanceManager.attachRootViewToInstance()` would be called after the db is initialized, resulting in the node not being started as `getCurrentActivity` would return `null` and we give up trying.

This PR changes the behavior so that we wait very inelegantly for it to return a value, and we give up after (roughly) 10 seconds.

### Testing

- Login/logout
- Create a new account
- Resuming from background
- Push notifications 

status: ready