### PR TITLE
[#7667]Allow to add/remove custom network from an event

### DIFF
--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -506,7 +506,7 @@
 (handlers/register-handler-fx
  :network.ui/remove-network-confirmed
  (fn [cofx [_ network]]
-   (network/remove-network cofx network)))
+   (network/remove-network cofx network [:navigate-back])))
 
 (handlers/register-handler-fx
  :network.ui/connect-network-pressed

--- a/src/status_im/extensions/core.cljs
+++ b/src/status_im/extensions/core.cljs
@@ -23,6 +23,7 @@
             [status-im.utils.fx :as fx]
             status-im.extensions.ethereum
             status-im.extensions.camera
+            status-im.extensions.network
             [status-im.extensions.map :as map]
             [status-im.utils.ethereum.tokens :as tokens]
             [status-im.utils.ethereum.core :as ethereum]
@@ -549,7 +550,27 @@
                  :arguments   {:key :string}}
                 'store/clear-all
                 {:permissions [:read]
-                 :data        :store/clear-all}
+                 :data       :store/clear-all}
+                'network/add
+                {:permissions [:read]
+                 :data       :network/add
+                 :arguments   {:chain-id    :number
+                               :name        :string
+                               :url         :string
+                               :on-success? :event
+                               :on-failure? :event}}
+                'network/select
+                {:permissions [:read]
+                 :data       :network/select
+                 :arguments   {:chain-id    :number
+                               :on-success? :event
+                               :on-failure? :event}}
+                'network/remove
+                {:permissions [:read]
+                 :data       :network/remove
+                 :arguments   {:chain-id    :number
+                               :on-success? :event
+                               :on-failure? :event}}
                 'http/get
                 {:permissions [:read]
                  :data        :http/get

--- a/src/status_im/extensions/network.cljs
+++ b/src/status_im/extensions/network.cljs
@@ -1,0 +1,41 @@
+(ns status-im.extensions.network
+  (:require [status-im.utils.handlers :as handlers]
+            [status-im.i18n :as i18n]
+            [status-im.network.core :as network]))
+
+(handlers/register-handler-fx
+ :extensions/network-on-success
+ (fn [cofx [_ on-success result]]
+   (when on-success (on-success {:value result}))))
+
+(defn- network-id [extension-id chain-id]
+  (str extension-id "_" chain-id))
+
+(handlers/register-handler-fx
+ :network/select
+ (fn [cofx [_ _ {:keys [chain-id on-success on-failure]}]]
+   (if-let [network-id (network/get-network-id-for-chain-id cofx chain-id)]
+     (network/connect cofx {:network-id network-id
+                            :on-success (when on-success #(on-success {:value %}))
+                            :on-failure (when on-failure #(on-failure {:value %}))})
+     (when on-failure (on-failure {:value (i18n/label :t/extensions-network-not-found)})))))
+
+(handlers/register-handler-fx
+ :network/add
+ (fn [{:keys [db] :as cofx} [_ {extension-id :id} {:keys [chain-id name url on-success on-failure]}]]
+   (network/save cofx {:data {:name {:value name}
+                              :url {:value url}
+                              :network-id {:value chain-id}
+                              :chain {:value :custom}}
+                       :network-id  (network-id extension-id chain-id)
+                       :success-event (when on-success [:extensions/network-on-success on-success chain-id])
+                       :on-failure   (when on-failure #(on-failure {:value %}))
+                       :chain-id-unique? false})))
+
+(handlers/register-handler-fx
+ :network/remove
+ (fn [cofx [_ {extension-id :id} {:keys [chain-id on-success on-failure]}]]
+   (let [network-id (network-id extension-id chain-id)]
+     (if (network/get-network cofx network-id)
+       (network/remove-network cofx network-id (when on-success [:extensions/network-on-success on-success chain-id]))
+       (when on-failure (on-failure {:value (i18n/label :t/extensions-chain-id-not-found)}))))))

--- a/translations/en.json
+++ b/translations/en.json
@@ -960,6 +960,8 @@
     "dapps-permissions": "DApp permissions",
     "revoke-access": "Revoke access",
     "extensions-camera-send-picture": "Send picture",
+    "extensions-network-not-found": "network not found for the given chain-id",
+    "extensions-chain-id-not-found": "chain-id not found or was not created by this extension",
     "mobile-syncing-sheet-title": "Sync using Mobile data",
     "mobile-syncing-sheet-details": "Status tends to use a lot of data when syncing chats. You can choose not to sync when on mobile network",
     "mobile-network-continue-syncing": "Continue syncing",


### PR DESCRIPTION
fixes #7667

`network/add` is completed: it allows to create only chain-id not already defined.
`network/select` is completed: _can only be done on network definition created by the extension_ (❓) . it will require user to relogin.
`network/remove` is completed: removal can only be done on network definition done by the extension

status: DONE

[test extension](https://status.im/extensions/play.html?hash=QmWcCRTMm3corZpYAZWzrS6KwFtsTEcJZU2GEHwXBanbrT)