### PR TITLE
After dismissing error, no redirect to home and new qr can be scanned.

### DIFF
--- a/src/status_im/contact/core.cljs
+++ b/src/status_im/contact/core.cljs
@@ -271,7 +271,7 @@
     (if (some? validation-result)
       {:utils/show-popup {:title (i18n/label :t/unable-to-read-this-code)
                           :content validation-result
-                          :on-dismiss #(re-frame/dispatch [:navigate-to-clean :home])}}
+                          :on-dismiss #(re-frame/dispatch [:qr-scanner.ui/qr-code-error-dismissed])}}
       (fx/merge cofx
                 fx
                 (if config/partitioned-topic-enabled?

--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -680,6 +680,11 @@
    (qr-scanner/scan-qr-code cofx identifier (merge {:handler handler} opts))))
 
 (handlers/register-handler-fx
+ :qr-scanner.ui/qr-code-error-dismissed
+ (fn [cofx [_ _]]
+   (qr-scanner/scan-qr-code-after-error-dismiss cofx)))
+
+(handlers/register-handler-fx
  :qr-scanner.callback/scan-qr-code-success
  (fn [cofx [_ context data]]
    (qr-scanner/set-qr-code cofx context data)))

--- a/src/status_im/qr_scanner/core.cljs
+++ b/src/status_im/qr_scanner/core.cljs
@@ -1,6 +1,7 @@
 (ns status-im.qr-scanner.core
   (:require [re-frame.core :as re-frame]
             [status-im.i18n :as i18n]
+            [status-im.ui.screens.navigation :as navigation]
             [status-im.utils.utils :as utils]
             [status-im.utils.fx :as fx]))
 
@@ -18,10 +19,16 @@
                                               50))
                                            #(re-frame/dispatch [deny-handler qr-codes]))}})
 
+(fx/defn scan-qr-code-after-error-dismiss
+  [{:keys [db]}]
+  (let [view-id (:view-id db)]
+    {:db (assoc-in db [:navigation/screen-params view-id :barcode-read?] false)}))
+
 (fx/defn set-qr-code
   [{:keys [db]} context data]
   (merge {:db (-> db
                   (update :qr-codes dissoc context)
+                  (update-in [:navigation/screen-params :qr-scanner] assoc :barcode-read? true)
                   (dissoc :current-qr-context))}
          (when-let [qr-codes (:qr-codes db)]
            {:dispatch [(:handler qr-codes) context data (dissoc qr-codes :handler)]})))

--- a/src/status_im/ui/screens/add_new/models.cljs
+++ b/src/status_im/ui/screens/add_new/models.cljs
@@ -6,17 +6,11 @@
             [status-im.utils.universal-links.core :as universal-links]
             [status-im.utils.fx :as fx]))
 
-(fx/defn process-qr-code
+(fx/defn handle-qr-code
   [cofx data]
   (if (spec/valid? :global/public-key data)
     (universal-links/handle-view-profile cofx data)
     (or (universal-links/handle-url cofx data)
-        {:utils/show-popup {:title      (i18n/label :t/unable-to-read-this-code)
-                            :content    (i18n/label :t/use-valid-qr-code {:data data})
-                            :on-dismiss #(re-frame/dispatch [:navigate-to-clean :home])}})))
-
-(fx/defn handle-qr-code
-  [cofx data]
-  (fx/merge cofx
-            (navigation/navigate-to-clean :home {})
-            (process-qr-code data)))
+        {:utils/show-popup {:title   (i18n/label :t/unable-to-read-this-code)
+                            :content (i18n/label :t/use-valid-qr-code {:data data})
+                            :on-dismiss #(re-frame/dispatch [:qr-scanner.ui/qr-code-error-dismissed])}})))

--- a/src/status_im/ui/screens/events.cljs
+++ b/src/status_im/ui/screens/events.cljs
@@ -178,7 +178,11 @@
  :screens/on-will-focus
  (fn [{:keys [db] :as cofx} [_ view-id]]
    (fx/merge cofx
-             {:db (assoc db :view-id view-id)}
+             (if (= view-id :qr-scanner)
+               {:db (-> db
+                        (assoc :view-id view-id)
+                        (assoc-in [:navigation/screen-params view-id :barcode-read?] false))}
+               {:db (assoc db :view-id view-id)})
              #(case view-id
                 :keycard-settings (hardwallet/settings-screen-did-load %)
                 :reset-card (hardwallet/reset-card-screen-did-load %)

--- a/src/status_im/ui/screens/qr_scanner/views.cljs
+++ b/src/status_im/ui/screens/qr_scanner/views.cljs
@@ -24,26 +24,26 @@
   (re-frame/dispatch [:qr-scanner.callback/scan-qr-code-success identifier (camera/get-qr-code-data data)]))
 
 (defview qr-scanner []
-  (letsubs [{identifier :current-qr-context} [:get-screen-params]
-            camera-initialized? (reagent/atom false)
-            barcode-read? (reagent/atom false)]
-    [react/view styles/barcode-scanner-container
-     [qr-scanner-toolbar (or (:toolbar-title identifier) (i18n/label :t/scan-qr)) identifier]
-     [camera/camera {:onBarCodeRead #(if (:multiple? identifier)
-                                       (on-barcode-read identifier %)
-                                       (when-not @barcode-read?
-                                         (do (reset! barcode-read? true)
-                                             (on-barcode-read identifier %))))
-                     :ref           #(reset! camera-initialized? true)
-                     :captureAudio  false
-                     :style         styles/barcode-scanner}]
-     [react/view styles/rectangle-container
-      [react/view styles/rectangle
-       [react/image {:source {:uri :corner_left_top}
-                     :style  styles/corner-left-top}]
-       [react/image {:source {:uri :corner_right_top}
-                     :style  styles/corner-right-top}]
-       [react/image {:source {:uri :corner_right_bottom}
-                     :style  styles/corner-right-bottom}]
-       [react/image {:source {:uri :corner_left_bottom}
-                     :style  styles/corner-left-bottom}]]]]))
+  (letsubs [{identifier :current-qr-context
+             barcode-read-sub? :barcode-read?} [:get-screen-params]
+            camera-initialized? (reagent/atom false)]
+    (let [barcode-read? barcode-read-sub?]
+      [react/view styles/barcode-scanner-container
+       [qr-scanner-toolbar (or (:toolbar-title identifier) (i18n/label :t/scan-qr)) identifier]
+       [camera/camera {:onBarCodeRead #(if (:multiple? identifier)
+                                         (on-barcode-read identifier %)
+                                         (when-not barcode-read?
+                                           (on-barcode-read identifier %)))
+                       :ref           #(reset! camera-initialized? true)
+                       :captureAudio  false
+                       :style         styles/barcode-scanner}]
+       [react/view styles/rectangle-container
+        [react/view styles/rectangle
+         [react/image {:source {:uri :corner_left_top}
+                       :style  styles/corner-left-top}]
+         [react/image {:source {:uri :corner_right_top}
+                       :style  styles/corner-right-top}]
+         [react/image {:source {:uri :corner_right_bottom}
+                       :style  styles/corner-right-bottom}]
+         [react/image {:source {:uri :corner_left_bottom}
+                       :style  styles/corner-left-bottom}]]]])))


### PR DESCRIPTION
WIP PR for https://github.com/status-im/status-react/issues/5287

@yenda So this maybe too hacky, and perhaps there is a more elegant solution, but I merge a navigate-clean and the navigate-to right back to qr-scanner. So after dismissing the error message when scanning an invalid qr code, navigating back works and the user can also scan another qr code. Currently, however, the navigation-stack is cluttered and was attempting to reset it to what it was before merge.

Let me know if merging navigate-clean then navigate-to qr-scanner is a step in the wrong direction, and I'll figure out another solution.

