### PR TITLE
upgrade ruby to 2.5

### DIFF
--- a/.TOOLVERSIONS
+++ b/.TOOLVERSIONS
@@ -2,6 +2,7 @@ android-ndk;r10e;070be287539e3e7706f8dabfb6bf9879
 android-sdk-build-tools;28.0.1;
 android-sdk-platform;android-27;
 android-sdk;4333796;aa190cfd7299cd6a1c687355bb2764e4
+bundler;1.17.2;bundler 
 clojure_cli;1.9.0.381;
 cmake;3.12.2;
 conan;1.9.0;

--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -3,7 +3,7 @@ pipeline {
     docker {
       label 'linux'
       /* WARNING: remember to keep this up-to-date with the value in docker/android/Makefile */
-      image 'statusteam/status-build-android:1.1.1-cd1596b3'
+      image 'statusteam/status-build-android:1.1.2-9ea4e0f4'
       args (
         "-v /home/jenkins/tmp:/var/tmp:rw "+
         "-v /home/jenkins/status-im.keystore:/tmp/status-im.keystore:ro"
@@ -44,11 +44,6 @@ pipeline {
     ANDROID_SDK_ROOT  = '/usr/lib/android-sdk'
     ANDROID_NDK       = '/usr/lib/android-ndk'
     ANDROID_NDK_HOME  = '/usr/lib/android-ndk'
-    /* We use EXECUTOR_NUMBER to avoid multiple instances clashing */
-    LEIN_HOME         = "/var/tmp/lein-${EXECUTOR_NUMBER}"
-    YARN_CACHE_FOLDER = "/var/tmp/yarn-${EXECUTOR_NUMBER}"
-    BUNDLE_PATH       = "/var/tmp/bundle-${EXECUTOR_NUMBER}"
-    GRADLE_USER_HOME  = "/var/tmp/gradle-${EXECUTOR_NUMBER}"
   }
 
   stages {

--- a/ci/android.groovy
+++ b/ci/android.groovy
@@ -31,7 +31,6 @@ def bundle(type = 'nightly') {
 def uploadToPlayStore(type = 'nightly') {
   withCredentials([
     string(credentialsId: "SUPPLY_JSON_KEY_DATA", variable: 'GOOGLE_PLAY_JSON_KEY'),
-    string(credentialsId: "SLACK_URL", variable: 'SLACK_URL')
   ]) {
     sh "bundle exec fastlane android ${type}"
   }

--- a/ci/ios.groovy
+++ b/ci/ios.groovy
@@ -23,7 +23,6 @@ def bundle(type) {
   sh 'mkdir -p status-e2e'
   /* build the actual app */
   withCredentials([
-    string(credentialsId: 'SLACK_URL', variable: 'SLACK_URL'),
     string(credentialsId: "slave-pass-${env.NODE_NAME}", variable: 'KEYCHAIN_PASSWORD'),
     string(credentialsId: 'FASTLANE_PASSWORD', variable: 'FASTLANE_PASSWORD'),
     string(credentialsId: 'APPLE_ID', variable: 'APPLE_ID'),

--- a/docker/android/Dockerfile
+++ b/docker/android/Dockerfile
@@ -42,6 +42,7 @@ RUN cd /usr/lib/android-ndk && rm -fr docs tests samples \
 ################################################################################
 FROM statusteam/status-build-base:${BASE_IMAGE_TAG}
 
+ARG BUNDLER_VERSION
 ARG ANDROID_NDK_VERSION
 ARG ANDROID_SDK_VERSION
 
@@ -54,18 +55,21 @@ ENV GRADLE_USER_HOME=/var/tmp/gradle \
     ANDROID_NDK=/usr/lib/android-ndk \
     ANDROID_NDK_HOME=/usr/lib/android-ndk
 
-RUN add-apt-repository -y ppa:cwchien/gradle \
- && apt-get update \
- && DEBIAN_FRONTEND=noninteractive \
-      apt-get -q -y --no-install-recommends install \
-        gradle ruby ruby-dev ruby-bundler \
- && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/man \
- && gem install cocoapods bundler fastlane fastlane-plugin-diawi fastlane-plugin-clean_testflight_testers CFPropertyList
-
 # Install Android SDK & NDK
 COPY --from=sdk_and_ndk /usr/lib/android-sdk /usr/lib/android-sdk 
 COPY --from=sdk_and_ndk /usr/lib/android-ndk /usr/lib/android-ndk 
 RUN chmod o+w /usr/lib/android-sdk /usr/lib/android-ndk
+
+RUN add-apt-repository -y ppa:cwchien/gradle \
+ && apt-add-repository -y ppa:brightbox/ruby-ng \
+ && apt-get update \
+ && DEBIAN_FRONTEND=noninteractive \
+      apt-get -q -y --no-install-recommends install \
+        gradle ruby2.5 ruby2.5-dev \
+ && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/man
+
+RUN gem install bundler -v ${BUNDLER_VERSION} \
+ && gem install json cocoapods CFPropertyList
 
 LABEL source="https://github.com/status-im/status-react/tree/develop/docker/android" \
       description="Image for building Android version of Status app." \

--- a/docker/android/Makefile
+++ b/docker/android/Makefile
@@ -13,22 +13,25 @@ ANDROID_SDK_CHECKSUM = $(call  __toolversion, -c android-sdk)
 ANDROID_SDK_URL = https://dl.google.com/android/repository/sdk-tools-linux-$(ANDROID_SDK_VERSION).zip
 ANDROID_SDK_ARCHIVE = sdk-tools-linux-$(ANDROID_SDK_VERSION).zip
 
+BUNDLER_VERSION=$(call  __toolversion, bundler)
 SDK_PLATFORM_VERSION=$(call  __toolversion, android-sdk-platform)
 SDK_BUILD_TOOLS_VERSION=$(call  __toolversion, android-sdk-build-tools)
 
 # WARNING: Remember to change the tag when updating the image
 BASE_IMAGE_TAG = $(shell cd $(GIT_ROOT)/docker/base && make get-image-tag)
 DEPS_HASH = $(shell $(GIT_ROOT)/scripts/gen-deps-hash.sh -b $(BASE_IMAGE_TAG) \
+					-d bundler \
 					-d android-ndk \
 					-d android-sdk \
 					-d android-sdk-platform \
 					-d android-sdk-build-tools)
-IMAGE_TAG = 1.1.1-$(DEPS_HASH)
+IMAGE_TAG = 1.1.2-$(DEPS_HASH)
 IMAGE_NAME = statusteam/status-build-android:$(IMAGE_TAG)
 
 build: $(ANDROID_NDK_ARCHIVE) $(ANDROID_SDK_ARCHIVE)
 	docker build \
 		--build-arg="BASE_IMAGE_TAG=$(BASE_IMAGE_TAG)" \
+		--build-arg="BUNDLER_VERSION=$(BUNDLER_VERSION)" \
 		--build-arg="ANDROID_NDK_VERSION=$(ANDROID_NDK_VERSION)" \
 		--build-arg="ANDROID_SDK_VERSION=$(ANDROID_SDK_VERSION)" \
 		--build-arg="SDK_BUILD_TOOLS_VERSION=$(SDK_BUILD_TOOLS_VERSION)" \


### PR DESCRIPTION
This might fix these errors:
```
 bundler: failed to load command: fastlane (/var/tmp/bundle-1/bin/fastlane)
 MultiJson::AdapterError: [!] Did not recognize your adapter specification (libruby.so.2.5: cannot open shared object file: No such file or directory - /var/tmp/bundle-1/gems/json-2.2.0/lib/json/ext/parser.so).
   /var/tmp/bundle-1/gems/json-2.2.0/lib/json/ext.rb:7:in `require'
   /var/tmp/bundle-1/gems/json-2.2.0/lib/json/ext.rb:7:in `<module:Ext>'
   /var/tmp/bundle-1/gems/json-2.2.0/lib/json/ext.rb:6:in `<module:JSON>'
   /var/tmp/bundle-1/gems/json-2.2.0/lib/json/ext.rb:3:in `<top (required)>'
...
```
Which show up in Android builds when running in `release` mode when Fastlane is used for uploading to PlayStore.