### PR TITLE
[fix 5695] remove close icon in add to contacts bar

### DIFF
--- a/src/status_im/contact/core.cljs
+++ b/src/status_im/contact/core.cljs
@@ -75,8 +75,7 @@
   [{:keys [db] :as cofx} public-key]
   (when (not= (get-in db [:account/account :public-key]) public-key)
     (let [contact (-> (build-contact cofx public-key)
-                      (assoc :pending? false
-                             :hide-contact? false))]
+                      (assoc :pending? false))]
       (fx/merge cofx
                 {:db (assoc-in db [:contacts/new-identity] "")}
                 (upsert-contact contact)
@@ -264,11 +263,6 @@
   [cofx public-key]
   (fx/merge cofx
             (chat.models/start-chat public-key {:navigation-reset? true})))
-
-(fx/defn hide-contact
-  [{:keys [db]} public-key]
-  (when (get-in db [:contacts/contacts public-key])
-    {:db (assoc-in db [:contacts/contacts public-key :hide-contact?] true)}))
 
 (fx/defn handle-qr-code
   [{:keys [db] :as cofx} contact-identity]

--- a/src/status_im/contact/db.cljs
+++ b/src/status_im/contact/db.cljs
@@ -21,7 +21,6 @@
 (spec/def :contact/last-updated (spec/nilable int?))
 (spec/def :contact/last-online (spec/nilable int?))
 (spec/def :contact/pending? boolean?)
-(spec/def :contact/hide-contact? boolean?)
 (spec/def :contact/tags (spec/coll-of string? :kind set?))
 (spec/def :contact/blocked? boolean?)
 
@@ -33,7 +32,6 @@
                                                 :contact/last-updated
                                                 :contact/last-online
                                                 :contact/pending?
-                                                :contact/hide-contact?
                                                 :contact/fcm-token
                                                 :contact/description
                                                 :contact/blocked?
@@ -104,8 +102,8 @@
 (defn active
   [contacts]
   (->> contacts
-       (remove (fn [[_ {:keys [pending? hide-contact? blocked?]}]]
-                 (or pending? hide-contact? blocked?)))
+       (remove (fn [[_ {:keys [pending? blocked?]}]]
+                 (or pending? blocked?)))
        sort-contacts))
 
 (defn filter-dapps

--- a/src/status_im/data_store/realm/schemas/account/contact.cljs
+++ b/src/status_im/data_store/realm/schemas/account/contact.cljs
@@ -97,3 +97,20 @@
 (def v5 (assoc-in v4 [:properties :device-info]
                   {:type       :list
                    :objectType :contact-device-info}))
+
+(def v6 {:name       :contact
+         :primaryKey :public-key
+         :properties {:address          {:type :string :optional true}
+                      :name             {:type :string :optional true}
+                      :photo-path       {:type :string :optional true}
+                      :last-updated     {:type :int :default 0}
+                      :last-online      {:type :int :default 0}
+                      :blocked?         {:type :bool :default false}
+                      :pending?         {:type :bool :default false}
+                      :status           {:type :string :optional true}
+                      :fcm-token        {:type :string :optional true}
+                      :description      {:type :string :optional true}
+                      :public-key       :string
+                      :tags             {:type "string[]"}
+                      :device-info      {:type       :list
+                                         :objectType :contact-device-info}}})

--- a/src/status_im/data_store/realm/schemas/account/core.cljs
+++ b/src/status_im/data_store/realm/schemas/account/core.cljs
@@ -431,6 +431,21 @@
 
 (def v38 v37)
 
+(def v39 [chat/v14
+          transport/v8
+          contact/v6
+          message/v9
+          mailserver/v11
+          mailserver-topic/v1
+          user-status/v2
+          membership-update/v1
+          installation/v3
+          local-storage/v1
+          browser/v8
+          dapp-permissions/v9
+          contact-device-info/v1
+          contact-recovery/v1])
+
 ;; put schemas ordered by version
 (def schemas [{:schema        v1
                :schemaVersion 1
@@ -545,4 +560,7 @@
                :migration     (constantly nil)}
               {:schema        v38
                :schemaVersion 38
-               :migration     migrations/v38}])
+               :migration     migrations/v38}
+              {:schema        v39
+               :schemaVersion 39
+               :migration     (constantly nil)}])

--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -1588,11 +1588,6 @@
    (contact/unblock-contact cofx public-key)))
 
 (handlers/register-handler-fx
- :contact.ui/close-contact-pressed
- (fn [cofx [_ public-key]]
-   (contact/hide-contact cofx public-key)))
-
-(handlers/register-handler-fx
  :contact/qr-code-scanned
  [(re-frame/inject-cofx :random-id-generator)]
  (fn [cofx [_ _ contact-identity]]

--- a/src/status_im/ui/screens/chat/styles/main.cljs
+++ b/src/status_im/ui/screens/chat/styles/main.cljs
@@ -166,18 +166,12 @@
   {:flex-direction      :row
    :align-items         :center
    :height              36
-   :background-color    :white
    :border-bottom-width 1
-   :border-color        colors/gray-lighter
-   :justify-content     :space-between})
-
-(def add-contact-left
-  {:width       24
-   :margin-left 12})
+   :justify-content :center
+   :border-color        colors/gray-lighter})
 
 (def add-contact-center
-  {:flex-direction :row
-   :align-items    :center})
+  {:flex-direction :row})
 
 (def add-contact-text
   {:text-align          :center

--- a/src/status_im/ui/screens/chat/views.cljs
+++ b/src/status_im/ui/screens/chat/views.cljs
@@ -30,23 +30,15 @@
   (:require-macros [status-im.utils.views :refer [defview letsubs]]))
 
 (defn add-contact-bar [public-key]
-  [react/view style/add-contact
-   [react/view style/add-contact-left]
-   [react/touchable-highlight
-    {:on-press
-     #(re-frame/dispatch [:contact.ui/add-to-contact-pressed public-key])
-     :accessibility-label :add-to-contacts-button}
-    [react/view style/add-contact-center
-     [vector-icons/icon :main-icons/add
-      {:color colors/blue}]
-     [react/i18n-text {:style style/add-contact-text :key :add-to-contacts}]]]
-   [react/touchable-highlight
-    {:on-press
-     #(re-frame/dispatch [:contact.ui/close-contact-pressed public-key])
-     :accessibility-label :add-to-contacts-close-button}
-    [vector-icons/icon :main-icons/close
-     {:color           colors/black
-      :container-style style/add-contact-close-icon}]]])
+  [react/touchable-highlight
+   {:on-press
+    #(re-frame/dispatch [:contact.ui/add-to-contact-pressed public-key])
+    :accessibility-label :add-to-contacts-button
+    :style style/add-contact}
+   [react/view style/add-contact-center
+    [vector-icons/icon :main-icons/add
+     {:color colors/blue}]
+    [react/i18n-text {:style style/add-contact-text :key :add-to-contacts}]]])
 
 (defn- on-options [chat-id chat-name group-chat? public?]
   (list-selection/show {:title   chat-name

--- a/src/status_im/ui/screens/db.cljs
+++ b/src/status_im/ui/screens/db.cljs
@@ -30,10 +30,6 @@
              :chats                              {}
              :current-chat-id                    nil
              :selected-participants              #{}
-             :discoveries                        {}
-             :discover-search-tags               #{}
-             :discover-current-dapp              {}
-             :tags                               []
              :sync-state                         :done
              :app-state                          "active"
              :wallet.transactions                constants/default-wallet-transactions
@@ -329,12 +325,6 @@
                                    :chat/bot-db
                                    :chat/id->command
                                    :chat/access-scope->command-id
-                                   :discoveries/discoveries
-                                   :discoveries/discover-search-tags
-                                   :discoveries/discover-current-dapp
-                                   :discoveries/tags
-                                   :discoveries/current-tag
-                                   :discoveries/request-discoveries-timer
                                    :wallet/wallet
                                    :wallet/wallet.transactions
                                    :wallet/wallet-selected-asset

--- a/src/status_im/utils/logging/core.cljs
+++ b/src/status_im/utils/logging/core.cljs
@@ -9,9 +9,6 @@
   ;; TODO: Add message explaining db export
   (let [db-json (types/clj->json (select-keys db [:app-state
                                                   :current-chat-id
-                                                  :discover-current-dapp
-                                                  :discover-search-tags
-                                                  :discoveries
                                                   :initial-props
                                                   :keyboard-height
                                                   :keyboard-max-height

--- a/test/cljs/status_im/test/contacts/db.cljs
+++ b/test/cljs/status_im/test/contacts/db.cljs
@@ -14,7 +14,6 @@
             contacts         {"0x04985040682b77a32bb4bb58268a0719bd24ca4d07c255153fe1eb2ccd5883669627bd1a092d7cc76e8e4b9104327667b19dcda3ac469f572efabe588c38c1985f"
                               {:description   nil,
                                :last-updated  0,
-                               :hide-contact? false,
                                :address       "eca8218b5ebeb2c47ba94c1b6e0a779d78fff7bc",
                                :name          "User B",
                                :fcm-token     nil,
@@ -47,7 +46,6 @@
                  :public-key "0x048a2f8b80c60f89a91b4c1316e56f75b087f446e7b8701ceca06a40142d8efe1f5aa36bd0fee9e248060a8d5207b43ae98bef4617c18c71e66f920f324869c09f"}
                 {:description      nil
                  :last-updated     0
-                 :hide-contact?    false
                  :name             "User B"
                  :fcm-token        nil
                  :photo-path       "photo1"

--- a/test/cljs/status_im/test/sign_in/data.cljs
+++ b/test/cljs/status_im/test/sign_in/data.cljs
@@ -4,7 +4,6 @@
   [{:description   nil
     :last-updated  1547185503000
     :tags          #{}
-    :hide-contact? false
     :address       "2f88d65f3cb52605a54a833ae118fb1363acccd2"
     :name          "Darkviolet Lightgreen Halcyon"
     :fcm-token     "cwigXoAk9R4:APA91bFZOy8vsCj9I9t6PYZXropyYEqAhKaVD2GxrURwvxe_Ay3zLrtJxeirp69se_5EOjS5i4T9xQnoPWrFTLfU9U7AUBdjxZtq5cnlP005bOY05p-psxGsQThMKQMeP5DJC9uxN0Ei"
@@ -21,7 +20,6 @@
    {:description   nil
     :last-updated  1547271764000
     :tags          #{}
-    :hide-contact? false
     :address       "b267ff8336ac10b3a1986c04a70ff91fb03d0b78"
     :name          "rv"
     :fcm-token     "dpVPtMBLuv8:APA91bEU4YuSz9yrc-vsiSl-IjdLSR5UpHm7yffaFlWQs_fvsTiK18ZcdYUbzA8iUoNuMVRNF_ngU7JdQInwNpXdGtNv_qcAFt0jhXHqf7dWY-kGJUBw9Ma8G_2fa40JLJchGVrzUIen"


### PR DESCRIPTION
fix #5695 after discussing with @errorists it was concluded that there is no point fixing the close icon and that the best solution was to remove it. 

status: ready <!-- Can be ready or wip -->
