### PR TITLE
re-add custom cache folders in /var/tmp

### DIFF
--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -44,6 +44,12 @@ pipeline {
     ANDROID_SDK_ROOT  = '/usr/lib/android-sdk'
     ANDROID_NDK       = '/usr/lib/android-ndk'
     ANDROID_NDK_HOME  = '/usr/lib/android-ndk'
+    /* bundle cache is sensitive to being used by differnt ruby versions */
+    BUNDLE_PATH       = "/tmp/bundle"
+    /* We use EXECUTOR_NUMBER to avoid multiple instances clashing */
+    LEIN_HOME         = "/var/tmp/lein-${EXECUTOR_NUMBER}"
+    YARN_CACHE_FOLDER = "/var/tmp/yarn-${EXECUTOR_NUMBER}"
+    GRADLE_USER_HOME  = "/var/tmp/gradle-${EXECUTOR_NUMBER}"
   }
 
   stages {


### PR DESCRIPTION
Removed in #7777, but apparently this is still an issue for Gradle.

I'm also putting `bundler` cache path in `/tmp/bundle` because otherwise it fails due to clashing ruby versions:
```
jenkins@de7ef417c83c:mobile-android$ export BUNDLE_PATH=/var/tmp/bundle-0
jenkins@de7ef417c83c:mobile-android$ bundle exec fastlane android nightly
/usr/bin/env: ‘ruby2.3’: No such file or directory
```
My best guess is that this was caused by the `nix` branch(#7506) which is already using Ruby `2.5`, while `develop` is still using `2.3`.