### PR TITLE
don't rebase desktop builds on release either

### DIFF
--- a/ci/mobile.groovy
+++ b/ci/mobile.groovy
@@ -3,9 +3,7 @@ utils = load 'ci/utils.groovy'
 android = load 'ci/android.groovy'
 
 def prep(type = 'nightly') {
-  if (type != 'release') {
-    utils.doGitRebase()
-  }
+  utils.doGitRebase()
   /* ensure that we start from a known state */
   sh 'make clean'
   /* Run at start to void mismatched numbers */

--- a/ci/utils.groovy
+++ b/ci/utils.groovy
@@ -48,6 +48,11 @@ def pkgFilename(type, ext) {
 }
 
 def doGitRebase() {
+  /* rebasing on relases defeats the point of having a release branch */
+  if (getBuildType() == 'release') {
+    println 'Skipping rebase due to release build...'
+    return
+  }
   sh 'git status'
   sh 'git fetch --force origin develop:develop'
   try {


### PR DESCRIPTION
Since nix branch was merged we noticed that desktop builds do the rebase, while mobile don't. None should during release.
https://github.com/status-im/status-react/blob/774ad652291e48c25e329a83a8360a36b54e73d5/ci/desktop.groovy#L45-L48