### PR TITLE
check parameter, e2e builds can be release builds too

### DIFF
--- a/ci/utils.groovy
+++ b/ci/utils.groovy
@@ -118,7 +118,7 @@ def uploadArtifact(path) {
   def domain = 'ams3.digitaloceanspaces.com'
   def bucket = 'status-im'
   /* There's so many PR builds we need a separate bucket */
-  if (getBuildType() == 'pr') {
+  if (params.BUILD_TYPE == 'pr') {
     bucket = 'status-im-prs'
   }
   /* WARNING: s3cmd can't guess APK MIME content-type */


### PR DESCRIPTION
Checking result of `getBuildType()` doesn't work because in case of `e2e` builds even release builds will return `e2e`, and hence will be rebased.