### PR TITLE
make sourcing nix quiet

### DIFF
--- a/ci/utils.groovy
+++ b/ci/utils.groovy
@@ -17,8 +17,11 @@ def getToolVersion(name) {
 
 def nix_sh(cmd) {
   sh """
-    . ~/.nix-profile/etc/profile.d/nix.sh && \\
-      nix-shell \'${env.WORKSPACE}/default.nix\' --argstr target-os \'${env.TARGET_PLATFORM}\' \\
+    set +x
+    . ~/.nix-profile/etc/profile.d/nix.sh
+    set -x
+    nix-shell \'${env.WORKSPACE}/default.nix\' \\
+        --argstr target-os \'${env.TARGET_PLATFORM}\' \\
         --run \'${cmd}\'
   """
 }


### PR DESCRIPTION
Attempt at avoiding `echo`ing the sourcing of `~/.nix-profile/etc/profile.d/nix.sh` every time we source it in `nix_sh`.

See: https://stackoverflow.com/a/26803326