### PR TITLE
Replace 'make prepare' with implicit behavior

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,17 +3,6 @@
 help: ##@other Show this help
 	@perl -e '$(HELP_FUN)' $(MAKEFILE_LIST)
 
-DO_SPACE_URL = https://status-go.ams3.digitaloceanspaces.com
-GITHUB_URL = https://github.com/status-im/status-go/releases
-RCTSTATUS_DIR = modules/react-native-status/ios/RCTStatus
-ANDROID_LIBS_DIR = android/app/libs
-STATUS_GO_VER = $(shell cat STATUS_GO_VERSION)
-
-STATUS_GO_IOS_ARCH = $(RCTSTATUS_DIR)/status-go-ios-$(STATUS_GO_VER).zip
-STATUS_GO_DRO_ARCH = $(ANDROID_LIBS_DIR)/status-go-$(STATUS_GO_VER).aar
-
-OS := $(shell uname)
-
 # This is a code for automatic help generator.
 # It supports ANSI colors and categories.
 # To add new item into help output, simply add comments
@@ -71,65 +60,6 @@ else
 	@echo "Nix shell is already active"
 endif
 
-prepare-desktop: _ensure-in-nix-shell ##@prepare Install desktop platform dependencies and prepare workspace
-	scripts/prepare-for-platform.sh desktop
-	yarn install --frozen-lockfile
-
-$(STATUS_GO_IOS_ARCH):
-	@echo "Downloading status-go artifact from DigitalOcean Bucket"; \
-	curl --fail --silent --location \
-		"${DO_SPACE_URL}/status-go-ios-$(STATUS_GO_VER).zip" \
-		--output "$(STATUS_GO_IOS_ARCH)"; \
-	if [ $$? -ne 0 ]; then \
-		echo "Failed to download from DigitalOcean Bucket, checking GitHub..."; \
-		curl --fail --silent --location \
-			"$(GITHUB_URL)/download/$(STATUS_GO_VER)/status-go-ios.zip" \
-			--output "$(STATUS_GO_IOS_ARCH)"; \
-		if [ $$? -ne 0 ]; then \
-			echo "Failed to download from GitHub!"; \
-			echo "Please check the contents of your STATUS_GO_VERSION are correct."; \
-			echo "Verify the version has been uploaded:"; \
-			echo " * $(DO_SPACE_URL)/index.html"; \
-			echo " * $(GITHUB_URL)"; \
-			exit 1; \
-		fi \
-	fi
-
-$(STATUS_GO_DRO_ARCH):
-	mkdir -p $(ANDROID_LIBS_DIR)
-	@echo "Downloading status-go artifact from DigitalOcean Bucket"; \
-	curl --fail --silent --location \
-		"${DO_SPACE_URL}/status-go-android-$(STATUS_GO_VER).aar" \
-		--output "$(STATUS_GO_DRO_ARCH)"; \
-	if [ $$? -ne 0 ]; then \
-		echo "Failed to download from DigitalOcean Bucket, checking GitHub..."; \
-		curl --fail --silent --location \
-			"$(GITHUB_URL)/download/$(STATUS_GO_VER)/status-go-android.aar" \
-			--output "$(STATUS_GO_DRO_ARCH)"; \
-		if [ $$? -ne 0 ]; then \
-			echo "Failed to download from GitHub!"; \
-		fi \
-	fi
-
-prepare-ios: _ensure-in-nix-shell $(STATUS_GO_IOS_ARCH) ##@prepare Install and prepare iOS-specific dependencies
-	scripts/prepare-for-platform.sh ios
-	yarn install --frozen-lockfile
-	unzip -q -o "$(STATUS_GO_IOS_ARCH)" -d "$(RCTSTATUS_DIR)"
-ifeq ($(OS),Darwin)
-	# TODO: remove this patch when we upgrade to RN 0.57+
-	git apply --check ios/patches/ios-legacy-build-system.patch 2> /dev/null && git apply ios/patches/ios-legacy-build-system.patch || echo "Patch already applied"
-	# CocoaPods are trash and can't handle other pod instances running at the same time
-	./scripts/wait-for.sh pod 240
-	cd ios && pod install
-endif
-
-prepare-android: _ensure-in-nix-shell $(STATUS_GO_DRO_ARCH) ##@prepare Install and prepare Android-specific dependencies
-	scripts/prepare-for-platform.sh android
-	yarn install --frozen-lockfile
-	cd android && ./gradlew react-native-android:installArchives
-
-prepare-mobile: prepare-android prepare-ios ##@prepare Install and prepare mobile platform specific dependencies
-
 #----------------
 # Release builds
 #----------------
@@ -158,18 +88,18 @@ ifdef IN_NIX_SHELL
 endif
 
 prod-build: _ensure-in-nix-shell
-	scripts/run-environment-check.sh android
-	scripts/run-environment-check.sh ios
+	scripts/prepare-for-platform.sh android
+	scripts/prepare-for-platform.sh ios
 	lein prod-build
 
 prod-build-android: _ensure-in-nix-shell
 	rm ./modules/react-native-status/android/libs/status-im/status-go/local/status-go-local.aar 2> /dev/null || true
-	scripts/run-environment-check.sh android
+	scripts/prepare-for-platform.sh android
 	lein prod-build-android
 
 prod-build-ios: _ensure-in-nix-shell
 	rm -r ./modules/react-native-status/ios/RCTStatus/Statusgo.framework/ 2> /dev/null || true
-	scripts/run-environment-check.sh ios
+	scripts/prepare-for-platform.sh ios
 	lein prod-build-ios
 
 full-prod-build: _ensure-in-nix-shell ##@build build prod for both Android and iOS
@@ -180,7 +110,7 @@ full-prod-build: _ensure-in-nix-shell ##@build build prod for both Android and i
 
 prod-build-desktop: _ensure-in-nix-shell
 	git clean -qdxf -f ./index.desktop.js desktop/
-	scripts/run-environment-check.sh desktop
+	scripts/prepare-for-platform.sh desktop
 	lein prod-build-desktop
 
 #--------------
@@ -190,7 +120,7 @@ prod-build-desktop: _ensure-in-nix-shell
 _watch-%: _ensure-in-nix-shell ##@watch Start development for device
 	$(eval SYSTEM := $(word 2, $(subst -, , $@)))
 	$(eval DEVICE := $(word 3, $(subst -, , $@)))
-	scripts/run-environment-check.sh $(SYSTEM)
+	scripts/prepare-for-platform.sh $(SYSTEM)
 	clj -R:dev build.clj watch --platform $(SYSTEM) --$(SYSTEM)-device $(DEVICE)
 
 watch-ios-real: _watch-ios-real ##@watch Start development for iOS real device
@@ -204,7 +134,7 @@ watch-android-avd: _watch-android-avd ##@watch Start development for Android AVD
 watch-android-genymotion: _watch-android-genymotion ##@watch Start development for Android Genymotion
 
 watch-desktop: ##@watch Start development for Desktop
-	scripts/run-environment-check.sh desktop
+	scripts/prepare-for-platform.sh desktop
 	clj -R:dev build.clj watch --platform desktop
 
 #--------------
@@ -212,18 +142,18 @@ watch-desktop: ##@watch Start development for Desktop
 # -------------
 _run-%: _ensure-in-nix-shell
 	$(eval SYSTEM := $(word 2, $(subst -, , $@)))
-	scripts/run-environment-check.sh $(SYSTEM)
+	scripts/prepare-for-platform.sh $(SYSTEM)
 	react-native run-$(SYSTEM)
 
 run-android: _ensure-in-nix-shell ##@run Run Android build
-	scripts/run-environment-check.sh android
+	scripts/prepare-for-platform.sh android
 	react-native run-android --appIdSuffix debug
 
 run-desktop: _run-desktop ##@run Run Desktop build
 
 SIMULATOR=
 run-ios: _ensure-in-nix-shell ##@run Run iOS build
-	scripts/run-environment-check.sh ios
+	scripts/prepare-for-platform.sh ios
 ifneq ("$(SIMULATOR)", "")
 	react-native run-ios --simulator="$(SIMULATOR)"
 else

--- a/ci/common.groovy
+++ b/ci/common.groovy
@@ -81,7 +81,7 @@ def prep(type = 'nightly') {
     prepareTarget='desktop'
   }
   /* node deps, pods, and status-go download */
-  utils.nix_sh "make prepare-${prepareTarget}"
+  utils.nix_sh "scripts/prepare-for-platform.sh ${prepareTarget}"
 }
 
 return this

--- a/scripts/bundle-status-go.sh
+++ b/scripts/bundle-status-go.sh
@@ -43,7 +43,7 @@ for platform in "$@"; do
         # ./build/bin/statusgo-ios-9.3-framework/Statusgo.framework
         #
         # You can get this by running:
-        # make prepare-{ios,android}
+        # scripts/prepare-for-platform.sh {ios|android}
         #
         # Locally you can see it here:
         # > (cd status-react && find . -iname "Statusgo.framework")

--- a/scripts/lib/setup/output.sh
+++ b/scripts/lib/setup/output.sh
@@ -71,12 +71,7 @@ There are a few @b[[manual steps]] you might want to do:
 
 3. Add your SSH public key to Github if it isn't already in there.
 
-To build the app, please run one of the following commands, depending on the desired target:
-
-- @b[[make prepare-mobile]]
-- @b[[make prepare-desktop]]
-
-followed by one of the @b[[make release-*]] commands.
+To build the app, please run one of the @b[[make release-*]] commands.
 "
 
   echo

--- a/scripts/prepare-for-platform.sh
+++ b/scripts/prepare-for-platform.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+GIT_ROOT=$(git rev-parse --show-toplevel)
+
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
@@ -9,12 +11,22 @@ NC='\033[0m'
 PLATFORM=""
 PLATFORM_FOLDER=""
 
+DO_SPACE_URL=https://status-go.ams3.digitaloceanspaces.com
+GITHUB_URL=https://github.com/status-im/status-go/releases
+STATUS_GO_VER="$(cat STATUS_GO_VERSION)"
+
+ANDROID_LIBS_DIR="$GIT_ROOT/android/app/libs"
+STATUS_GO_DRO_ARCH="${ANDROID_LIBS_DIR}/status-go-${STATUS_GO_VER}.aar"
+
+RCTSTATUS_DIR="$GIT_ROOT/modules/react-native-status/ios/RCTStatus"
+STATUS_GO_IOS_ARCH="${RCTSTATUS_DIR}/status-go-ios-${STATUS_GO_VER}.zip"
+
 #if no arguments passed, inform user about possible ones
 
 if [ $# -eq 0 ]; then
-  echo -e "${GREEN}This script should be invoked with platform argument: 'android', 'ios' or 'desktop'${NC}"
-  echo "If invoked with 'mobile' argument it will link: "
-  echo "package.json.mobile -> package.json"
+  echo -e "${GREEN}This script should be invoked with platform argument: 'android', 'ios', or 'desktop'${NC}"
+  echo "If invoked with 'android' argument it will link: "
+  echo "mobile_files/package.json.orig -> package.json"
   echo "etc.."
   exit 1
 else
@@ -29,19 +41,85 @@ else
   PLATFORM_FOLDER="${PLATFORM}_files"
 fi
 
-scripts/run-environment-check.sh $1
+$GIT_ROOT/scripts/run-environment-check.sh $1
 
-echo "Creating link: package.json -> ${PLATFORM_FOLDER}/package.json.orig"
-ln -sf ${PLATFORM_FOLDER}/package.json.orig package.json
+if [ ! -f .babelrc ] || [ $(readlink .babelrc) != "${PLATFORM_FOLDER}/.babelrc" ]; then
+  echo "Creating link: package.json -> ${PLATFORM_FOLDER}/package.json.orig"
+  ln -sf ${PLATFORM_FOLDER}/package.json.orig package.json
 
-echo "Creating link: yarn.lock -> ${PLATFORM_FOLDER}/yarn.lock"
-ln -sf ${PLATFORM_FOLDER}/yarn.lock yarn.lock
+  echo "Creating link: yarn.lock -> ${PLATFORM_FOLDER}/yarn.lock"
+  ln -sf ${PLATFORM_FOLDER}/yarn.lock yarn.lock
 
-echo "Creating link: VERSION -> ${PLATFORM_FOLDER}/VERSION"
-ln -sf ${PLATFORM_FOLDER}/VERSION VERSION
+  echo "Creating link: VERSION -> ${PLATFORM_FOLDER}/VERSION"
+  ln -sf ${PLATFORM_FOLDER}/VERSION VERSION
 
-echo "Creating link: .babelrc -> ${PLATFORM_FOLDER}/.babelrc"
-ln -sf ${PLATFORM_FOLDER}/.babelrc .babelrc
+  echo "Creating link: .babelrc -> ${PLATFORM_FOLDER}/.babelrc"
+  ln -sf ${PLATFORM_FOLDER}/.babelrc .babelrc
+fi
 
+yarn install --frozen-lockfile
+
+if [ "$PLATFORM" == 'mobile' ]; then
+  if [ "$1" == 'android' ]; then
+    outputPath=$STATUS_GO_DRO_ARCH
+    ext='.aar'
+  else
+    outputPath=$STATUS_GO_IOS_ARCH
+    ext='.zip'
+  fi
+
+  statusGoSentinelFile="$(dirname $outputPath)/.download.log"
+  if [ -f "$statusGoSentinelFile" ] && [ "$(cat $statusGoSentinelFile)" == "$STATUS_GO_VER" ]; then
+	  echo "status-go artifact already downloaded!"
+  else
+    echo "Downloading status-go artifact from DigitalOcean Bucket to $outputPath"
+
+    set +e
+    curl --fail --silent --location \
+      "${DO_SPACE_URL}/status-go-$1-${STATUS_GO_VER}${ext}" \
+      --output "$outputPath"
+    set -e
+    if [ $? -ne 0 ]; then
+      echo "Failed to download from DigitalOcean Bucket, checking GitHub..."
+      set +e
+      curl --fail --silent --location \
+        "${GITHUB_URL}/download/${STATUS_GO_VER}/status-go-$1.zip" \
+        --output "$outputPath"
+      set -e
+      if [ $? -ne 0 ]; then
+        echo "Failed to download from GitHub!"
+        echo "Please check the contents of your STATUS_GO_VERSION are correct."
+        echo "Verify the version has been uploaded:"
+        echo " * ${DO_SPACE_URL}/index.html"
+        echo " * $GITHUB_URL"
+        exit 1
+      fi
+    fi
+    echo "$STATUS_GO_VER" > $statusGoSentinelFile
+  fi
+fi
+
+case $1 in
+  android)
+    set -e
+    if [ ! -d $GIT_ROOT/node_modules/react-native/android/com/facebook/react/react-native/ ]; then
+      cd $GIT_ROOT/android && ./gradlew react-native-android:installArchives
+    fi
+    ;;
+  ios)
+    if [ ! -d "$RCTSTATUS_DIR/Statusgo.framework" ]; then
+      unzip -q -o "$STATUS_GO_IOS_ARCH" -d "$RCTSTATUS_DIR" && rm $STATUS_GO_IOS_ARCH
+      if [ "$(uname)" == 'Darwin' ]; then
+        # TODO: remove this patch when we upgrade to RN 0.57+
+        git apply --check $GIT_ROOT/ios/patches/ios-legacy-build-system.patch 2> /dev/null && \
+          git apply $GIT_ROOT/ios/patches/ios-legacy-build-system.patch || \
+          echo "Patch already applied"
+        # CocoaPods are trash and can't handle other pod instances running at the same time
+        $GIT_ROOT/scripts/wait-for.sh pod 240
+        pushd $GIT_ROOT/ios && pod install; popd
+      fi
+    fi
+    ;;
+esac
 
 echo -e "${GREEN}Finished!${NC}"


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

### Summary:

[comment]: # (Summarise the problem and how the pull request solves it)

This PR replaces the `make prepare-*` targets with smarter implicit behavior. If you had previously run `make release-android` and you now do `make release-desktop`, the script will detect that the symlinks do not point to the correct platform and will recreate them. It'll also call `yarn install` and download any necessary status-go artifacts (soon this should be replaced with Nix).

### Review notes (optional):
<!-- (Specify if something in particular should be looked at, or ignored, during review) -->

The main gist of this PR is to move the status-go artifact download from the Makefile to `prepare-for-platform.sh` so that we can check on whether it already exists before trying to download it again. The same thing is done for things like the node symlinks.

Documentation PR to get rid of mentions to `make prepare-*`: https://github.com/status-im/status.im/pull/256

### Testing notes (optional):
<!-- (Specify which platforms should be tested) -->

This does not affect app functionality, only command line build behavior.

status: ready <!-- Can be ready or wip -->
