### PR TITLE
Add missing nix shell ios

### DIFF
--- a/ci/ios.groovy
+++ b/ci/ios.groovy
@@ -28,7 +28,7 @@ def bundle(type) {
     string(credentialsId: 'APPLE_ID', variable: 'APPLE_ID'),
     string(credentialsId: 'fastlane-match-password', variable:'MATCH_PASSWORD')
   ]) {
-    sh "bundle exec fastlane ios ${target}"
+    utils.nix_sh "bundle exec fastlane ios ${target}"
   }
   /* rename built file for uploads and archivization */
   def pkg = ''


### PR DESCRIPTION
Apparently we missed this line in the huge Nix PR so I'm fixing it.