### PR TITLE
Fix base image path import in Windows setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,6 +148,7 @@ Status-Windows-x86_64.exe
 /desktop/lib/*
 /desktop/modules/*
 /desktop/Makefile
+/desktop/graph_info.json
 /desktop/run-app.bat
 /desktop/run-app.sh
 /desktop/CMakeFiles/

--- a/scripts/build-desktop.sh
+++ b/scripts/build-desktop.sh
@@ -206,7 +206,7 @@ function bundleWindows() {
   fi
 
   # TODO this needs to be fixed: status-react/issues/5378
-  local windowsBaseImagePath="$(nix show-derivation -r -f $STATUSREACTPATH | jq -r '.[] | select(.env.name=="StatusIm-Windows-base-image") | .outputs.out.path')/src"
+  local windowsBaseImagePath="$(nix show-derivation -r -f $STATUSREACTPATH | jq -r '.[] | select(.env.name=="StatusIm-Windows-base-image") | .outputs.out.path')/src/"
 
   local top_srcdir=$(joinExistingPath "$STATUSREACTPATH" '.')
   VERSION_MAJOR="$(cut -d'.' -f1 <<<"$VERSION")"


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes #7826 

### Summary:

[comment]: # (Summarise the problem and how the pull request solves it)
...

### Review notes (optional):
<!-- (Specify if something in particular should be looked at, or ignored, during review) -->

This PR adds a missing slash to the path. Without it, the `src/` folder was being copied to the installer, instead of its contents. Not sure how this worked before...

### Testing notes (optional):
<!-- (Specify which platforms should be tested) -->
#### Platforms (optional)
- Windows

status: ready <!-- Can be ready or wip -->
