### PR TITLE
Fix leftover from make prepare-* which went unnoticed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,7 +200,7 @@ _unknown-startdev-target-%:
 _startdev-%: _ensure-in-nix-shell
 	$(eval SYSTEM := $(word 2, $(subst -, , $@)))
 	$(eval DEVICE := $(word 3, $(subst -, , $@)))
-	$(MAKE) prepare-${SYSTEM} || $(MAKE) _unknown-startdev-target-$@
+	scripts/prepare-for-platform.sh ${SYSTEM} || $(MAKE) _unknown-startdev-target-$@
 	@ if [ -z "$(DEVICE)" ]; then \
 		$(MAKE) watch-$(SYSTEM) || $(MAKE) _unknown-startdev-target-$@; \
 	else \


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

This tiny PR fixes a remaining call to `make prepare-*` target that went unnoticed in the main PR.

status: ready <!-- Can be ready or wip -->
