### PR TITLE
[feature] add ipfs module to add and cat content on ipfs

### DIFF
--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -266,9 +266,5 @@
 (def ^:const scan-qr-code-callback "scan-qr-code-callback")
 
 ;;ipfs
-(def ^:const ipfs-add-url "https://ipfs.infura.io:5001/api/v0/add")
-(def ^:const ipfs-add-param-name "extension.event.edn")
-(def ^:const ipfs-cat-url "https://ipfs.infura.io/ipfs/")
-
 (def ^:const ipfs-proto-code "e3")
 (def ^:const swarm-proto-code "e4")

--- a/src/status_im/extensions/core.cljs
+++ b/src/status_im/extensions/core.cljs
@@ -14,6 +14,7 @@
             [status-im.ui.components.react :as react]
             [status-im.ui.screens.wallet.settings.views :as settings]
             [status-im.i18n :as i18n]
+            [status-im.ipfs.core :as ipfs]
             [status-im.utils.money :as money]
             [status-im.constants :as constants]
             [status-im.ui.components.colors :as colors]
@@ -224,40 +225,13 @@
 
 (re-frame/reg-event-fx
  :ipfs/cat
- (fn [_ [_ _ {:keys [hash on-success on-failure]}]]
-   {:http-raw-get (merge {:url (str constants/ipfs-cat-url hash)
-                          :success-event-creator
-                          (fn [{:keys [status body]}]
-                            (if (= 200 status)
-                              (on-success {:value body})
-                              (when on-failure
-                                (on-failure {:value status}))))}
-                         (when on-failure
-                           {:failure-event-creator on-failure})
-                         {:timeout-ms 5000})}))
-
-(defn- parse-ipfs-add-response [res]
-  (let [{:keys [Name Hash Size]} (parse-json res)]
-    {:name Name
-     :hash Hash
-     :size Size}))
+ (fn [cofx [_ _ args]]
+   (ipfs/cat cofx args)))
 
 (re-frame/reg-event-fx
  :ipfs/add
- (fn [_ [_ _ {:keys [value on-success on-failure]}]]
-   (let [formdata (doto (js/FormData.)
-                    (.append constants/ipfs-add-param-name value))]
-     {:http-raw-post (merge {:url  constants/ipfs-add-url
-                             :body formdata
-                             :success-event-creator
-                             (fn [{:keys [status body]}]
-                               (if (= 200 status)
-                                 (on-success {:value (parse-ipfs-add-response body)})
-                                 (when on-failure
-                                   (on-failure {:value status}))))}
-                            (when on-failure
-                              {:failure-event-creator on-failure})
-                            {:timeout-ms 5000})})))
+ (fn [cofx [_ _ args]]
+   (ipfs/add cofx args)))
 
 (re-frame/reg-event-fx
  :http/post

--- a/src/status_im/ipfs/core.cljs
+++ b/src/status_im/ipfs/core.cljs
@@ -1,0 +1,47 @@
+(ns status-im.ipfs.core
+  (:refer-clojure :exclude [cat])
+  (:require [status-im.utils.fx :as fx]))
+
+;; we currently use an ipfs gateway but this detail is not relevant
+;; outside of this namespace
+(def ^:const ipfs-add-url "https://ipfs.infura.io:5001/api/v0/add")
+(def ^:const ipfs-cat-url "https://ipfs.infura.io/ipfs/")
+
+(fx/defn cat
+  [cofx {:keys [hash on-success on-failure]}]
+  {:http-raw-get (cond-> {:url (str ipfs-cat-url hash)
+                          :timeout-ms 5000
+                          :success-event-creator
+                          (fn [{:keys [status body]}]
+                            (if (= 200 status)
+                              (on-success {:value body})
+                              (when on-failure
+                                (on-failure {:value status}))))}
+                   on-failure
+                   (assoc :failure-event-creator on-failure))})
+
+(defn- parse-ipfs-add-response
+  [response]
+  (when response
+    (let [{:keys [Name Hash Size]} (js->clj (js/JSON.parse response)
+                                            :keywordize-keys true)]
+      {:name Name
+       :hash Hash
+       :size Size})))
+
+(fx/defn add
+  [cofx {:keys [value on-success on-failure]}]
+  (let [formdata (doto (js/FormData.)
+                   ;; the key is ignored so there is no need to provide one
+                   (.append nil value))]
+    {:http-raw-post (cond-> {:url  ipfs-add-url
+                             :body formdata
+                             :timeout-ms 5000
+                             :success-event-creator
+                             (fn [{:keys [status body]}]
+                               (if (= 200 status)
+                                 (on-success {:value (parse-ipfs-add-response body)})
+                                 (when on-failure
+                                   (on-failure {:value status}))))}
+                      on-failure
+                      (assoc :failure-event-creator on-failure))}))


### PR DESCRIPTION
ipfs  is needed for tribute to talk and probably other applications in the future, this PR moves ipfs add and cat support into a separate module so that it can be used outside of extensions

status: ready <!-- Can be ready or wip -->
