### PR TITLE
contenthash utility namespace

### DIFF
--- a/src/status_im/utils/contenthash.cljs
+++ b/src/status_im/utils/contenthash.cljs
@@ -1,0 +1,34 @@
+(ns status-im.utils.contenthash
+  "TODO: currently we only support encoding/decoding ipfs contenthash
+  implementing swarm and other protocols will come later"
+  (:refer-clojure :exclude [cat])
+  (:require [alphabase.base58 :as b58]
+            [alphabase.hex :as hex]
+            [clojure.string :as string]
+            [status-im.ipfs.core :as ipfs]
+            [status-im.utils.fx :as fx]))
+
+(defn encode [{:keys [hash namespace ipld]}]
+  (when (and hash
+             (= namespace :ipfs)
+             (= 46 (count hash))
+             (nil? ipld))
+    (str "0xe301" (hex/encode (b58/decode hash)))))
+
+(defn decode [contenthash]
+  (when (and contenthash
+             (string/starts-with? contenthash "0xe3011220")
+             (= 74 (count contenthash)))
+    {:namespace :ipfs
+     :hash (-> contenthash
+               (subs 6)
+               hex/decode
+               b58/encode)}))
+
+(fx/defn cat
+  [cofx {:keys [contenthash on-success on-failure]}]
+  (let [{:keys [namespace hash]} (decode contenthash)]
+    (when (= namespace :ipfs)
+      (ipfs/cat {:hash hash
+                 :on-success on-success
+                 :on-failure on-failure}))))

--- a/test/cljs/status_im/test/runner.cljs
+++ b/test/cljs/status_im/test/runner.cljs
@@ -38,6 +38,7 @@
             [status-im.test.utils.utils]
             [status-im.test.utils.money]
             [status-im.test.utils.clocks]
+            [status-im.test.utils.contenthash]
             [status-im.test.utils.ethereum.eip55]
             [status-im.test.utils.ethereum.eip681]
             [status-im.test.utils.ethereum.core]
@@ -111,6 +112,7 @@
  'status-im.test.utils.utils
  'status-im.test.utils.money
  'status-im.test.utils.clocks
+ 'status-im.test.utils.contenthash
  'status-im.test.utils.ethereum.eip55
  'status-im.test.utils.ethereum.eip681
  'status-im.test.utils.ethereum.core

--- a/test/cljs/status_im/test/utils/contenthash.cljs
+++ b/test/cljs/status_im/test/utils/contenthash.cljs
@@ -1,0 +1,33 @@
+(ns status-im.test.utils.contenthash
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [status-im.utils.contenthash :as contenthash]))
+
+;; we reuse the exemple from EIP-1577 but omit content type: dag-pb (0x70)
+;; in the contenthash as we do not support it yet
+
+(deftest contenthash-decode
+  (testing "decoding a valid ipfs hash"
+    (is (= (contenthash/decode "0xe301122029f2d17be6139079dc48696d1f582a8530eb9805b561eda517e22a892c7e3f1f")
+           {:namespace :ipfs
+            :hash "QmRAQB6YaCyidP37UdDnjFY5vQuiBrcqdyoW1CuDgwxkD4"})))
+  (testing "decoding an invalid ipfs hash"
+    (is (nil? (contenthash/decode "0xe301122029f2d17be6139079dc48696d1f582a8530eb9805b561eda517e2"))))
+  (testing "decoding random garbage"
+    (is (nil? (contenthash/decode "0xabcdef1234567890"))))
+  (testing "decoding nil"
+    (is (nil? (contenthash/decode nil)))))
+
+(deftest contenthash-encode
+  (testing "encoding a valid ipfs hash"
+    (is (= (contenthash/encode
+            {:namespace :ipfs
+             :hash "QmRAQB6YaCyidP37UdDnjFY5vQuiBrcqdyoW1CuDgwxkD4"})
+           "0xe301122029f2d17be6139079dc48696d1f582a8530eb9805b561eda517e22a892c7e3f1f")))
+  (testing "encoding an invalid ipfs hash"
+    (is (nil? (contenthash/encode {:namespace :ipfs
+                                   :hash "0xe301122029f2d17be6139079dc48696d1f582a8530eb9805b561eda517e2"}))))
+  (testing "encoding random garbage"
+    (is (nil? (contenthash/encode {:namespace :ipfs
+                                   :hash "0xabcdef1234567890"}))))
+  (testing "encoding random garbage"
+    (is (nil? (contenthash/encode nil)))))


### PR DESCRIPTION
reviewers: only check last commit

- support for ipfs only
- provides fns to encode and decode contenthashes as defined in EIP1577
- provides cat fx to retrieve contenthash

status: ready <!-- Can be ready or wip -->
