### PR TITLE
[DESKTOP] Add mailserver and bootnodes settings

### DIFF
--- a/src/status_im/mailserver/core.cljs
+++ b/src/status_im/mailserver/core.cljs
@@ -5,6 +5,7 @@
             [status-im.data-store.core :as data-store]
             [status-im.fleet.core :as fleet]
             [status-im.native-module.core :as status]
+            [status-im.utils.platform :as platform]
             [status-im.transport.utils :as transport.utils]
             [status-im.utils.fx :as fx]
             [status-im.constants :as constants]
@@ -401,7 +402,9 @@
           :content             (i18n/label :t/mailserver-error-content)
           :confirm-button-text (i18n/label :t/mailserver-pick-another)
           :on-accept           #(re-frame/dispatch
-                                 [:navigate-to :offline-messaging-settings])
+                                 [:navigate-to (if platform/desktop?
+                                                 :advanced-settings
+                                                 :offline-messaging-settings)])
           :extra-options       [{:text    (i18n/label :t/mailserver-retry)
                                  :onPress #(re-frame/dispatch
                                             [:mailserver.ui/connect-confirmed

--- a/src/status_im/ui/components/checkbox/view.cljs
+++ b/src/status_im/ui/components/checkbox/view.cljs
@@ -2,8 +2,7 @@
   (:require [status-im.ui.components.checkbox.styles :as styles]
             [status-im.ui.components.colors :as colors]
             [status-im.ui.components.icons.vector-icons :as icons]
-            [status-im.ui.components.react :as react]
-            [status-im.utils.platform :as platform]))
+            [status-im.ui.components.react :as react]))
 
 (defn checkbox
   "react/check-box is currently not available on iOS,
@@ -18,9 +17,11 @@
            :accessibility-label accessibility-label}
           (when on-value-change
             {:on-press #(on-value-change (not checked?))}))
-   [react/view (styles/icon-check-container checked?)
-    (when checked?
-      [icons/icon :tiny-icons/tiny-check {:color colors/white}])]])
+   (if checked?
+     [icons/icon
+      :tiny-icons/tiny-check {:container-style (styles/icon-check-container true)
+                              :color colors/white}]
+     [react/view {:style  (styles/icon-check-container false)}])])
 
 (defn radio-button
   [{:keys [on-value-change checked? accessibility-label

--- a/src/status_im/ui/screens/desktop/main/tabs/profile/views.cljs
+++ b/src/status_im/ui/screens/desktop/main/tabs/profile/views.cljs
@@ -183,11 +183,32 @@
        [react/view {:style styles/title-separator}]
        [react/text {:style styles/adv-settings-subtitle} (i18n/label :offline-messaging)]
        [offline-messaging.views/pinned-state preferred-mailserver-id]
+       [react/touchable-highlight {:on-press #(re-frame/dispatch [:navigate-to :edit-mailserver])}
+        [react/view {:style {:border-radius 8
+                             :flex 1
+                             :margin-left 24
+                             :width 90
+                             :padding 4
+                             :background-color colors/blue}}
+         [react/text {:style {:color colors/white}}
+          "Add mailserver"]]]
        [react/view
         (for [mailserver (vals mailservers)]
           ^{:key (:id mailserver)}
           [react/view {:style {:margin-vertical 8}}
            [render-fn mailserver]])]
+       [react/view {:style styles/title-separator}]
+       [react/text {:style styles/adv-settings-subtitle} (i18n/label :bootnodes)]
+       [react/touchable-highlight {:on-press #(re-frame/dispatch [:navigate-to :bootnodes-settings])}
+        [react/view {:style {:border-radius 8
+                             :flex 1
+                             :margin-left 24
+                             :width 90
+                             :padding 4
+                             :background-color colors/blue}}
+         [react/text {:style {:color colors/white}}
+          "Bootnodes settings"]]]
+
        [react/view {:style styles/title-separator}]
        [react/text {:style styles/adv-settings-subtitle} (i18n/label :t/logging)]
        [logging-display]

--- a/src/status_im/ui/screens/desktop/main/views.cljs
+++ b/src/status_im/ui/screens/desktop/main/views.cljs
@@ -5,10 +5,13 @@
             [status-im.ui.screens.desktop.main.styles :as styles]
             [status-im.ui.screens.desktop.main.chat.views :as chat.views]
             [status-im.ui.screens.desktop.main.add-new.views :as add-new.views]
+            [status-im.ui.screens.bootnodes-settings.edit-bootnode.views :as edit-bootnode]
             [status-im.ui.screens.about-app.views :as about-app.views]
             [status-im.ui.screens.help-center.views :as help-center.views]
+            [status-im.ui.screens.bootnodes-settings.views :as bootnodes]
             [status-im.ui.components.desktop.tabs :as tabs]
             [status-im.ui.components.react :as react]
+            [status-im.ui.screens.offline-messaging-settings.edit-mailserver.views :as edit-mailserver]
             [re-frame.core :as re-frame]))
 
 (views/defview status-view []
@@ -44,6 +47,9 @@
                       :desktop/new-group-chat add-new.views/new-group-chat
                       :qr-code profile.views/qr-code
                       :advanced-settings profile.views/advanced-settings
+                      :edit-mailserver edit-mailserver/edit-mailserver
+                      :bootnodes-settings bootnodes/bootnodes-settings
+                      :edit-bootnode edit-bootnode/edit-bootnode
                       :about-app about-app.views/about-app
                       :help-center help-center.views/help-center
                       :installations profile.views/installations

--- a/src/status_im/ui/screens/desktop/views.cljs
+++ b/src/status_im/ui/screens/desktop/views.cljs
@@ -43,6 +43,9 @@
                        :desktop/new-group-chat
                        :desktop/new-public-chat
                        :advanced-settings
+                       :edit-mailserver
+                       :bootnodes-settings
+                       :edit-bootnode
                        :about-app
                        :help-center
                        :installations


### PR DESCRIPTION
Adds `Add mailserver` and `Bootnodes settings` buttons to Desktop's `Advanced settings` screen

Fixes #7430