### PR TITLE
Beta alert on upgrading

### DIFF
--- a/src/status_im/accounts/core.cljs
+++ b/src/status_im/accounts/core.cljs
@@ -8,7 +8,8 @@
             [status-im.utils.config :as config]
             [status-im.utils.utils :as utils]
             [status-im.utils.fx :as fx]
-            [status-im.utils.platform :as platform]))
+            [status-im.utils.platform :as platform]
+            [status-im.utils.build :as build]))
 
 (re-frame/reg-fx
  ::chaos-mode-changed
@@ -16,10 +17,11 @@
    (native-module/chaos-mode-update on (constantly nil))))
 
 (fx/defn show-mainnet-is-default-alert [{:keys [db]}]
-  (let [shown? (get-in db [:account/account :mainnet-warning-shown?])]
+  (let [shown-version (get-in db [:account/account :mainnet-warning-shown-version])
+        current-version build/version]
     (when (and platform/mobile?
                config/mainnet-warning-enabled?
-               (not shown?))
+               (not= shown-version current-version))
       (utils/show-popup
        (i18n/label :mainnet-is-default-alert-title)
        (i18n/label :mainnet-is-default-alert-text)

--- a/src/status_im/accounts/db.cljs
+++ b/src/status_im/accounts/db.cljs
@@ -55,7 +55,7 @@
 (spec/def :account/seed-backed-up? (spec/nilable boolean?))
 (spec/def :account/installation-id :global/not-empty-string)
 (spec/def :account/wallet-set-up-passed? (spec/nilable boolean?))
-(spec/def :account/mainnet-warning-shown? (spec/nilable boolean?))
+(spec/def :account/mainnet-warning-shown-version (spec/nilable string?))
 (spec/def :account/desktop-alpha-release-warning-shown? (spec/nilable boolean?))
 (spec/def :account/keycard-instance-uid (spec/nilable string?))
 (spec/def :account/keycard-pairing (spec/nilable string?))
@@ -71,7 +71,7 @@
                                                 :account/seed-backed-up? :account/mnemonic :account/desktop-notifications?
                                                 :account/wallet-set-up-passed? :account/last-request
                                                 :account/bootnodes :account/extensions
-                                                :account/mainnet-warning-shown?
+                                                :account/mainnet-warning-shown-version
                                                 :account/desktop-alpha-release-warning-shown?
                                                 :account/keycard-instance-uid
                                                 :account/keycard-pairing

--- a/src/status_im/data_store/realm/schemas/base/account.cljs
+++ b/src/status_im/data_store/realm/schemas/base/account.cljs
@@ -238,3 +238,7 @@
 (def v21 (update v20 :properties merge
                  {:syncing-on-mobile-network? {:type :bool :default false}
                   :remember-syncing-choice?   {:type :bool :default false}}))
+
+(def v22 (update (update v21 :properties dissoc :mainnet-warning-shown?)
+                 :properties merge
+                 {:mainnet-warning-shown-version {:type :string :optional true}}))

--- a/src/status_im/data_store/realm/schemas/base/core.cljs
+++ b/src/status_im/data_store/realm/schemas/base/core.cljs
@@ -103,6 +103,11 @@
           extension/v12
           account/v21])
 
+(def v27 [network/v1
+          bootnode/v4
+          extension/v12
+          account/v22])
+
 ;; put schemas ordered by version
 (def schemas [{:schema        v1
                :schemaVersion 1
@@ -181,4 +186,7 @@
                :migration     (constantly nil)}
               {:schema        v26
                :schemaVersion 26
+               :migration     (constantly nil)}
+              {:schema        v27
+               :schemaVersion 27
                :migration     (constantly nil)}])

--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -53,7 +53,8 @@
             [status-im.stickers.core :as stickers]
             [status-im.utils.config :as config]
             [status-im.ui.components.bottom-sheet.core :as bottom-sheet]
-            [status-im.ui.components.react :as react]))
+            [status-im.ui.components.react :as react]
+            [status-im.utils.build :as build]))
 
 ;; init module
 
@@ -155,7 +156,7 @@
 (handlers/register-handler-fx
  :accounts.ui/mainnet-warning-shown
  (fn [cofx _]
-   (accounts.update/account-update cofx {:mainnet-warning-shown? true} {})))
+   (accounts.update/account-update cofx {:mainnet-warning-shown-version build/version} {})))
 
 (handlers/register-handler-fx
  :accounts.update.callback/published


### PR DESCRIPTION
fixes #7598 

### Summary:

Shows the Beta Alert every time `status-react` is upgraded to a new version.

### Test suite:
* create account 1 -> show beta alert
* log out, log in account 1 -> no show
* log out, recover account 2 -> show beta alert
* log out, set autologin account 2, log in account 2 -> no show
* quit app
###### Change version number in `mobile_files/VERSION`
* autologin account 2 -> show beta alert
* log out, log in account 2 -> no show
* log out, log in account 1 -> show beta alert
* log out, log in account 1 -> no show

#### Areas that maybe impacted:
- account recovery
- new account

### Steps to test:
#### Note that simply upgrading to this PR won't show the beta alert as the version number won't have changed.
#### Option 1: build mode
- Merge this PR into your local rep
- Change version number in `mobile_files/VERSION`
- Build and install
- Log in to an existing account
- Beta alert should show up
- Log out, log in again
- Beta alert should not show up

#### Option 2: debug mode
- Run figwheel, re-frisk and metro
- Install app, wait for the figwheel prompt
- Create account, dismiss beta alert, log out
- Change version number in `mobile_files/VERSION`
- Wait for the changes to hot load
- Log in again
- Beta alert should show up
- Log out, log in again
- Beta alert should not show up

status: ready