### PR TITLE
add repo name to ghcmgr url

### DIFF
--- a/ci/ghcmgr.groovy
+++ b/ci/ghcmgr.groovy
@@ -43,7 +43,7 @@ def postBuild(success) {
       curl --silent --verbose -XPOST --data '${json}' \
         -u '${GHCMGR_USER}:${GHCMGR_PASS}' \
         -H "content-type: application/json" \
-        '${ghcmgrurl}/builds/${utils.changeId()}'
+        '${ghcmgrurl}/builds/status-react/${utils.changeId()}'
     """
   }
 }


### PR DESCRIPTION
Small fix to use the new URl for [`ghcmgr`](https://github.com/status-im/github-comment-manager) API which includes repo name, since now it supports multiple repos.