### PR TITLE
[fix] contract call effect should destructure keys not vector

### DIFF
--- a/src/status_im/utils/ethereum/abi_spec.cljs
+++ b/src/status_im/utils/ethereum/abi_spec.cljs
@@ -390,4 +390,5 @@
     (let [bytes (subs bytes 2)]
       (when-not (empty? bytes)
         (let [offsets (get-offsets types)]
-          (map (dec-type bytes) offsets types))))))
+          (map #(when-not (= "0x" %) %)
+               (map (dec-type bytes) offsets types)))))))

--- a/src/status_im/utils/ethereum/contracts.cljs
+++ b/src/status_im/utils/ethereum/contracts.cljs
@@ -34,7 +34,7 @@
 
 (re-frame/reg-fx
  ::call
- (fn [[address data callback]]
+ (fn [{:keys [address data callback]}]
    (ethereum/call {:to address
                    :data data}
                   callback)))
@@ -60,4 +60,6 @@
             :on-result on-result})
           {::call {:address  contract-address
                    :data     data
-                   :callback #(callback (abi-spec/decode % return-params))}})))))
+                   :callback #(callback (if (empty? return-params)
+                                          %
+                                          (abi-spec/decode % return-params)))}})))))


### PR DESCRIPTION
- fix destructuring in `::call` fx
- return params decoding should return nil and not "0x"

# testing

- only the stickers are using this for now


status: ready