### PR TITLE
use auto@status.im Apple account for signing app

### DIFF
--- a/ci/Jenkinsfile.fastlane.clean
+++ b/ci/Jenkinsfile.fastlane.clean
@@ -1,33 +1,39 @@
-env.LANG="en_US.UTF-8"
-env.LANGUAGE="en_US.UTF-8"
-env.LC_ALL="en_US.UTF-8"
-env.FASTLANE_DISABLE_COLORS=1
-env.REALM_DISABLE_ANALYTICS=1
+pipeline {
+  agent { label 'macos' }
 
-timeout(120) {
-  node ('macos') {
-    stage('Git Checkout'){
-      checkout([
-        $class: 'GitSCM',
-        branches: [[name: 'develop']],
-        doGenerateSubmoduleConfigurations: false,
-        extensions: [[$class: 'CleanBeforeCheckout']],
-        submoduleCfg: [],
-        userRemoteConfigs: [[url: 'https://github.com/status-im/status-react.git']]
-      ])
-    }
+  environment {
+    LANG = "en_US.UTF-8"
+    LANGUAGE = "en_US.UTF-8"
+    LC_ALL = "en_US.UTF-8"
+    FASTLANE_DISABLE_COLORS = 1
+    REALM_DISABLE_ANALYTICS = 1
+  }
 
+  options {
+    timestamps()
+    /* Prevent Jenkins jobs from running forever */
+    timeout(time: 45, unit: 'MINUTES')
+    buildDiscarder(logRotator(numToKeepStr: '100'))
+  }
+
+  stages {
     stage('Install Deps'){
-      sh ('bundle install')
+      steps {
+        sh ('bundle install')
+      }
     }
 
     stage('Clean Users'){
-      withCredentials([
-        string(credentialsId: 'FASTLANE_PASSWORD', variable: 'FASTLANE_PASSWORD'),
-        string(credentialsId: 'APPLE_ID', variable: 'APPLE_ID')]
-      ) {
-        sh ('bundle install')
-        sh ('bundle exec fastlane ios clean')
+      steps {
+        withCredentials([
+          usernamePassword(
+            credentialsId:  'fastlane-match-apple-id',
+            usernameVariable: 'FASTLANE_APPLE_ID',
+            passwordVariable: 'FASTLANE_PASSWORD'
+          ),
+        ]) {
+          sh ('bundle exec fastlane ios clean')
+        }
       }
     }
   }

--- a/ci/ios.groovy
+++ b/ci/ios.groovy
@@ -24,9 +24,12 @@ def bundle(type) {
   /* build the actual app */
   withCredentials([
     string(credentialsId: "slave-pass-${env.NODE_NAME}", variable: 'KEYCHAIN_PASSWORD'),
-    string(credentialsId: 'FASTLANE_PASSWORD', variable: 'FASTLANE_PASSWORD'),
-    string(credentialsId: 'APPLE_ID', variable: 'APPLE_ID'),
-    string(credentialsId: 'fastlane-match-password', variable:'MATCH_PASSWORD')
+    string(credentialsId: 'fastlane-match-password', variable: 'MATCH_PASSWORD'),
+    usernamePassword(
+      credentialsId:  'fastlane-match-apple-id',
+      usernameVariable: 'FASTLANE_APPLE_ID',
+      passwordVariable: 'FASTLANE_PASSWORD'
+    ),
   ]) {
     utils.nix_sh "bundle exec fastlane ios ${target}"
   }

--- a/fastlane/Appfile
+++ b/fastlane/Appfile
@@ -1,7 +1,7 @@
 # iOS
 
 app_identifier("im.status.ethereum") # The bundle identifier of your app
-apple_id(ENV["APPLE_ID"]) # Your Apple email address
+apple_id(ENV["FASTLANE_APPLE_ID"]) # Your Apple email address
 itc_team_id("118430139") # iTunes Connect Team ID
 
 # Android

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -186,16 +186,14 @@ platform :ios do
   desc "This lane builds a new adhoc build and leaves an .ipa that is ad-hoc signed (can be uploaded to diawi)"
   lane :pr do
     unlock_keychain_if_needed
-    # TODO: fixme when 2FA is setup
-    build_ios_adhoc(true)
+    build_ios_adhoc(false)
   end
 
   desc "`fastlane ios nightly` - makes a new nightly"
   desc "This lane builds a new nightly and leaves an .ipa that is ad-hoc signed (can be uploaded to diawi)"
   lane :nightly do
     unlock_keychain_if_needed
-    # TODO: fixme when 2FA is setup
-    build_ios_adhoc(true)
+    build_ios_adhoc(false)
   end
 
   desc "`fastlane ios release` builds a release & uploads it to TestFlight"
@@ -231,7 +229,7 @@ platform :ios do
   desc "uses custom plugin, installed via"
   desc "`sudo get install fastlane-plugin-clean_testflight_testers`"
   lane :clean do
-    clean_testflight_testers
+    clean_testflight_testers(username: ENV["FASTLANE_APPLE_ID"])
   end
 
   desc "`fastlane ios upload-diawi` - upload .ipa to diawi"

--- a/fastlane/Matchfile
+++ b/fastlane/Matchfile
@@ -3,7 +3,7 @@ git_url("git@github.com:status-im/ios-certificates.git")
 type("development") # The default type, can be: appstore, adhoc, enterprise or development
 
 # app_identifier(["tools.fastlane.app", "tools.fastlane.app2"])
-username("support@status.im") # Your Apple Developer Portal username
+username(ENV["FASTLANE_APPLE_ID"]) # Your Apple Developer Portal username
 
 # For all available options run `fastlane match --help`
 # Remove the # in the beginning of the line to enable the other options


### PR DESCRIPTION
Changing to a different Apple account to avoid the Two-Factor Auth mess that Apple made mandatory for all "Holder" accounts like our support@status.im.