### PR TITLE
[fix] don't lose big number precision above 53 bits in abi-spec

### DIFF
--- a/src/status_im/utils/ethereum/abi_spec.cljs
+++ b/src/status_im/utils/ethereum/abi_spec.cljs
@@ -41,7 +41,11 @@
 
 (defn hex-to-number [x]
   (when x
-    (.toNumber (dependencies/Web3.prototype.toBigNumber (str "0x" x) 16))))
+    (let [hex-x (str "0x" x)]
+      (try
+        (.hexToNumber utils hex-x)
+        (catch :default err
+          (.hexToNumberString utils hex-x))))))
 
 (defn sha3 [s]
   (.sha3 utils (str s)))

--- a/test/cljs/status_im/test/utils/ethereum/abi_spec.cljs
+++ b/test/cljs/status_im/test/utils/ethereum/abi_spec.cljs
@@ -2,6 +2,16 @@
   (:require [cljs.test :refer-macros [deftest is testing]]
             [status-im.utils.ethereum.abi-spec :as abi-spec]))
 
+(deftest hex-to-number
+  (testing "hex number is less than 53 bits, it returns a number")
+  (is (= (abi-spec/hex-to-number "9")
+         9))
+  (is (= (abi-spec/hex-to-number "99999999")
+         2576980377))
+  (testing "hex number is less than 53 bits, it returns a string")
+  (is (= (abi-spec/hex-to-number "9999999999999999")
+         "11068046444225730969")))
+
 (deftest enc
   (is (= "000000000000000000000000eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee" (abi-spec/enc {:type :address :value "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"}))))
 
@@ -33,9 +43,9 @@
            0
            0)))
 
-  (is (= (abi-spec/decode "0x0000000000000000000000000000000000000000000000000de0b6b3a76400000000000000000000000000000000000000000000000000000d7621dc58210000"
+  (is (= (abi-spec/decode "0x0000000000000000000000000000000000000000000000000de0b6b3a76400000000000000000000000000000000000000000000000000000d7621dc58210001"
                           ["uint256" "uint256"])
-         '(1000000000000000000 970000000000000000)))
+         '("1000000000000000000" "970000000000000001")))
 
   (is (= (abi-spec/decode "0x000000000000000000000000eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee000000000000000000000000eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee00000000000000000000000000000000000000000000000000000000000003e8"
                           ["address" "address" "uint256"])


### PR DESCRIPTION
- convert to string instead of numbers in hex-to-number
- remove usage of full web3 lib

status: ready <!-- Can be ready or wip -->