### PR TITLE
Fetch missed range of messages

### DIFF
--- a/src/status_im/chat/models/loading.cljs
+++ b/src/status_im/chat/models/loading.cljs
@@ -27,9 +27,11 @@
                  (update-in db [:chats chat-id :message-groups datemark]
                             (fn [message-references]
                               (->> grouped-messages
-                                   (map (fn [{:keys [message-id timestamp]}]
-                                          {:message-id    message-id
-                                           :timestamp-str (time/timestamp->time timestamp)}))
+                                   (map (fn [{:keys [message-id timestamp whisper-timestamp]}]
+                                          {:message-id        message-id
+                                           :timestamp-str     (time/timestamp->time timestamp)
+                                           :timestamp         timestamp
+                                           :whisper-timestamp whisper-timestamp}))
                                    (into (or message-references '()))
                                    (sort-references (get-in db [:chats chat-id :messages]))))))
                db

--- a/src/status_im/chat/models/message.cljs
+++ b/src/status_im/chat/models/message.cljs
@@ -273,7 +273,7 @@
         (get all-chats chat-id)
         {:keys [content content-type clock-value]}
         (->> (chat.db/sort-message-groups message-groups messages)
-             first
+             last
              second
              last
              :message-id

--- a/src/status_im/data_store/realm/schemas/account/core.cljs
+++ b/src/status_im/data_store/realm/schemas/account/core.cljs
@@ -461,6 +461,21 @@
           contact-device-info/v1
           contact-recovery/v1])
 
+(def v41 [chat/v14
+          transport/v8
+          contact/v7
+          message/v10
+          mailserver/v11
+          mailserver-topic/v2
+          user-status/v2
+          membership-update/v1
+          installation/v3
+          local-storage/v1
+          browser/v8
+          dapp-permissions/v9
+          contact-device-info/v1
+          contact-recovery/v1])
+
 ;; put schemas ordered by version
 (def schemas [{:schema        v1
                :schemaVersion 1
@@ -581,4 +596,7 @@
                :migration     (constantly nil)}
               {:schema        v40
                :schemaVersion 40
-               :migration     migrations/v40}])
+               :migration     migrations/v40}
+              {:schema        v41
+               :schemaVersion 41
+               :migration     (constantly nil)}])

--- a/src/status_im/data_store/realm/schemas/account/mailserver_topic.cljs
+++ b/src/status_im/data_store/realm/schemas/account/mailserver_topic.cljs
@@ -5,3 +5,14 @@
          :properties {:topic        :string
                       :chat-ids     :string
                       :last-request {:type :int :default 1}}})
+
+(def v2
+  (-> v1
+      (assoc-in
+       [:properties :gap-from]
+       {:type     :int
+        :optional true})
+      (assoc-in
+       [:properties :gap-to]
+       {:type     :int
+        :optional true})))

--- a/src/status_im/data_store/realm/schemas/account/message.cljs
+++ b/src/status_im/data_store/realm/schemas/account/message.cljs
@@ -62,3 +62,9 @@
   (-> v8
       (assoc-in [:properties :raw-payload-hash]
                 {:type :string})))
+
+(def v10
+  (-> v9
+      (assoc-in [:properties :whisper-timestamp]
+                {:type :int
+                 :optional true})))

--- a/src/status_im/data_store/realm/schemas/account/transport_inbox_topic.cljs
+++ b/src/status_im/data_store/realm/schemas/account/transport_inbox_topic.cljs
@@ -1,3 +1,4 @@
+; This entity is not used in the newer version of schema
 (ns status-im.data-store.realm.schemas.account.transport-inbox-topic)
 
 (def v1 {:name       :transport-inbox-topic

--- a/src/status_im/mailserver/subs.cljs
+++ b/src/status_im/mailserver/subs.cljs
@@ -44,6 +44,13 @@
         (not (or connecting? connection-error? request-error?)))))
 
 (re-frame/reg-sub
+ :mailserver/connected?
+ (fn [db]
+   (let [connected? (= :connected (:mailserver/state db))
+         online?    (= :online (:network-status db))]
+     (and connected? online?))))
+
+(re-frame/reg-sub
  :mailserver/current-id
  (fn [db]
    (:mailserver/current-id db)))

--- a/src/status_im/transport/message/protocol.cljs
+++ b/src/status_im/transport/message/protocol.cljs
@@ -113,7 +113,7 @@
         (fx/merge cofx
                   (send-direct-message current-public-key nil this)
                   (send-with-pubkey params)))))
-  (receive [this chat-id signature _ cofx]
+  (receive [this chat-id signature timestamp cofx]
     {:chat-received-message/add-fx
      [(assoc (into {} this)
              :old-message-id (transport.utils/old-message-id this)
@@ -121,6 +121,7 @@
                           signature
                           (.-payload (:js-obj cofx)))
              :chat-id chat-id
+             :whisper-timestamp timestamp
              :raw-payload-hash (transport.utils/sha3
                                 (.-payload (:js-obj cofx)))
              :from signature

--- a/src/status_im/ui/screens/chat/views.cljs
+++ b/src/status_im/ui/screens/chat/views.cljs
@@ -70,6 +70,37 @@
   [{{:keys [value]} :row}]
   [message-datemark/chat-datemark-mobile value])
 
+(defview gap []
+  (letsubs [in-progress? [:chats/fetching-gap-in-progress?]
+            connected?   [:mailserver/connected?]]
+    [react/view {:align-self          :stretch
+                 :margin-top          24
+                 :margin-bottom       24
+                 :height              48
+                 :align-items         :center
+                 :justify-content     :center
+                 :border-color        colors/gray-light
+                 :border-top-width    1
+                 :border-bottom-width 1
+                 :background-color    :white}
+     [react/touchable-highlight
+      {:on-press (when (and connected? (not in-progress?))
+                   #(re-frame/dispatch [:chat.ui/fill-the-gap]))}
+      [react/view {:flex            1
+                   :align-items     :center
+                   :justify-content :center}
+       (if in-progress?
+         [react/activity-indicator]
+         [react/text
+          {:style {:color (if connected?
+                            colors/blue
+                            colors/gray)}}
+          (i18n/label :t/fetch-messages)])]]]))
+
+(defmethod message-row :gap
+  [_]
+  [gap])
+
 (defmethod message-row :default
   [{:keys [group-chat current-public-key modal? row]}]
   [message/chat-message (assoc row

--- a/test/cljs/status_im/test/chat/db.cljs
+++ b/test/cljs/status_im/test/chat/db.cljs
@@ -1,35 +1,35 @@
 (ns status-im.test.chat.db
   (:require [cljs.test :refer-macros [deftest is testing]]
-            [status-im.chat.db :as s]))
+            [status-im.chat.db :as db]))
 
 (deftest group-chat-name
   (testing "it prepends # if it's a public chat"
-    (is (= "#withhash" (s/group-chat-name {:group-chat true
-                                           :chat-id "1"
-                                           :public? true
-                                           :name "withhash"}))))
+    (is (= "#withhash" (db/group-chat-name {:group-chat true
+                                            :chat-id    "1"
+                                            :public?    true
+                                            :name       "withhash"}))))
   (testing "it leaves the name unchanged if it's a group chat"
-    (is (= "unchanged" (s/group-chat-name {:group-chat true
-                                           :chat-id "1"
-                                           :name "unchanged"})))))
+    (is (= "unchanged" (db/group-chat-name {:group-chat true
+                                            :chat-id    "1"
+                                            :name       "unchanged"})))))
 
 (deftest message-stream-tests
   (testing "messages with no interspersed datemarks"
-    (let [m1 {:from "1"
-              :datemark "a"
-              :outgoing false}
-          m2   {:from "2"
-                :datemark "a"
-                :outgoing true}
-          m3    {:from "2"
-                 :datemark "a"
-                 :outgoing true}
-          dm1  {:type :datemark
-                :value "a"}
+    (let [m1       {:from     "1"
+                    :datemark "a"
+                    :outgoing false}
+          m2       {:from     "2"
+                    :datemark "a"
+                    :outgoing true}
+          m3       {:from     "2"
+                    :datemark "a"
+                    :outgoing true}
+          dm1      {:type  :datemark
+                    :value "a"}
           messages [m1 m2 m3 dm1]
           [actual-m1
            actual-m2
-           actual-m3] (s/messages-stream messages)]
+           actual-m3] (db/messages-stream messages)]
       (testing "it marks only the first message as :last?"
         (is (:last? actual-m1))
         (is (not (:last? actual-m2)))
@@ -59,29 +59,29 @@
         (is (:last-in-group? actual-m2))
         (is (not (:last-in-group? actual-m3))))))
   (testing "messages with interspersed datemarks"
-    (let [m1 {:from "2"          ; first & last in group
-              :timestamp 63000
-              :outgoing true}
-          dm1 {:type :datemark
-               :value "a"}
-          m2  {:from "2"         ; first & last in group as more than 1 minute after previous message
-               :timestamp 62000
-               :outgoing false}
-          m3  {:from "2"         ; last in group
-               :timestamp 1
-               :outgoing false}
-          m4  {:from "2"         ; first in group
-               :timestamp 0
-               :outgoing false}
-          dm2 {:type :datemark
-               :value "b"}
+    (let [m1       {:from      "2"                          ; first & last in group
+                    :timestamp 63000
+                    :outgoing  true}
+          dm1      {:type  :datemark
+                    :value "a"}
+          m2       {:from      "2"                          ; first & last in group as more than 1 minute after previous message
+                    :timestamp 62000
+                    :outgoing  false}
+          m3       {:from      "2"                          ; last in group
+                    :timestamp 1
+                    :outgoing  false}
+          m4       {:from      "2"                          ; first in group
+                    :timestamp 0
+                    :outgoing  false}
+          dm2      {:type  :datemark
+                    :value "b"}
           messages [m1 dm1 m2 m3 m4 dm2]
           [actual-m1
            _
            actual-m2
            actual-m3
            actual-m4
-           _] (s/messages-stream messages)]
+           _] (db/messages-stream messages)]
       (testing "it marks the first outgoing message as :last-outgoing?"
         (is (:last-outgoing? actual-m1))
         (is (not (:last-outgoing? actual-m2)))
@@ -103,12 +103,12 @@
         (is (:last-in-group? actual-m3))
         (is (not (:last-in-group? actual-m4))))))
   (testing "system-messages"
-    (let [m1 {:from "system"
-              :message-type :system-message
-              :datemark "a"
-              :outgoing false}
+    (let [m1       {:from         "system"
+                    :message-type :system-message
+                    :datemark     "a"
+                    :outgoing     false}
           messages [m1]
-          [actual-m1] (s/messages-stream messages)]
+          [actual-m1] (db/messages-stream messages)]
       (testing "it does display the photo"
         (is (:display-photo? actual-m1))
         (testing "it does not display the username"
@@ -122,4 +122,218 @@
                        "3" {:is-active false :chat-id "3"}}]
     (testing "it returns only chats with is-active"
       (is (= #{"1" "2"}
-             (set (keys (s/active-chats {} chats {}))))))))
+             (set (keys (db/active-chats {} chats {}))))))))
+
+(deftest messages-with-datemarks-and-statuses
+  (testing "empty state"
+    (is (empty?
+         (db/messages-with-datemarks-and-statuses
+          nil
+          nil
+          nil
+          nil
+          nil))))
+  (testing "simple case"
+    (is (=
+         '({:whisper-timestamp 40
+            :timestamp         40
+            :content           nil
+            :timestamp-str     "14:00"
+            :user-statuses     nil
+            :datemark          "today"}
+           {:whisper-timestamp 30
+            :timestamp         30
+            :content           nil
+            :timestamp-str     "13:00"
+            :user-statuses     nil
+            :datemark          "today"}
+           {:value             "today"
+            :type              :datemark
+            :whisper-timestamp 30
+            :timestamp         30}
+           {:whisper-timestamp 20
+            :timestamp         20
+            :content           nil
+            :timestamp-str     "12:00"
+            :user-statuses     nil
+            :datemark          "yesterday"}
+           {:whisper-timestamp 10
+            :timestamp         10
+            :content           nil
+            :timestamp-str     "11:00"
+            :user-statuses     nil
+            :datemark          "yesterday"}
+           {:value             "yesterday"
+            :type              :datemark
+            :whisper-timestamp 10
+            :timestamp         10})
+         (db/messages-with-datemarks-and-statuses
+          {"yesterday"
+           (list
+            {:message-id        :m1
+             :timestamp-str     "11:00"
+             :whisper-timestamp 10
+             :timestamp         10}
+            {:message-id        :m2
+             :timestamp-str     "12:00"
+             :whisper-timestamp 20
+             :timestamp         20})
+           "today"
+           (list
+            {:message-id        :m3
+             :timestamp-str     "13:00"
+             :whisper-timestamp 30
+             :timestamp         30}
+            {:message-id        :m4
+             :timestamp-str     "14:00"
+             :whisper-timestamp 40
+             :timestamp         40})}
+          {:m1 {:whisper-timestamp 10
+                :timestamp         10}
+           :m2 {:whisper-timestamp 20
+                :timestamp         20}
+           :m3 {:whisper-timestamp 30
+                :timestamp         30}
+           :m4 {:whisper-timestamp 40
+                :timestamp         40}}
+          nil
+          nil
+          nil))))
+  (testing "simple case with gap"
+    (is (=
+         '({:whisper-timestamp 40
+            :timestamp         40
+            :content           nil
+            :timestamp-str     "14:00"
+            :user-statuses     nil
+            :datemark          "today"}
+           {:whisper-timestamp 30
+            :timestamp         30
+            :content           nil
+            :timestamp-str     "13:00"
+            :user-statuses     nil
+            :datemark          "today"}
+           {:value             "today"
+            :type              :datemark
+            :whisper-timestamp 30
+            :timestamp         30}
+           {:type              :gap
+            :value             "25"}
+           {:whisper-timestamp 20
+            :timestamp         20
+            :content           nil
+            :timestamp-str     "12:00"
+            :user-statuses     nil
+            :datemark          "yesterday"}
+           {:whisper-timestamp 10
+            :timestamp         10
+            :content           nil
+            :timestamp-str     "11:00"
+            :user-statuses     nil
+            :datemark          "yesterday"}
+           {:value             "yesterday"
+            :type              :datemark
+            :whisper-timestamp 10
+            :timestamp         10})
+         (db/messages-with-datemarks-and-statuses
+          {"yesterday"
+           (list
+            {:message-id        :m1
+             :timestamp-str     "11:00"
+             :whisper-timestamp 10
+             :timestamp         10}
+            {:message-id        :m2
+             :timestamp-str     "12:00"
+             :whisper-timestamp 20
+             :timestamp         20})
+           "today"
+           (list
+            {:message-id        :m3
+             :timestamp-str     "13:00"
+             :whisper-timestamp 30
+             :timestamp         30}
+            {:message-id        :m4
+             :timestamp-str     "14:00"
+             :whisper-timestamp 40
+             :timestamp         40})}
+          {:m1 {:whisper-timestamp 10
+                :timestamp         10}
+           :m2 {:whisper-timestamp 20
+                :timestamp         20}
+           :m3 {:whisper-timestamp 30
+                :timestamp         30}
+           :m4 {:whisper-timestamp 40
+                :timestamp         40}}
+          nil
+          nil
+          {:from    25
+           :exists? true}))))
+  (testing "simple case with gap after all messages"
+    (is (=
+         '({:type  :gap
+            :value "100"}
+           {:whisper-timestamp 40
+            :timestamp         40
+            :content           nil
+            :timestamp-str     "14:00"
+            :user-statuses     nil
+            :datemark          "today"}
+           {:whisper-timestamp 30
+            :timestamp         30
+            :content           nil
+            :timestamp-str     "13:00"
+            :user-statuses     nil
+            :datemark          "today"}
+           {:value             "today"
+            :type              :datemark
+            :whisper-timestamp 30
+            :timestamp         30}
+           {:whisper-timestamp 20
+            :timestamp         20
+            :content           nil
+            :timestamp-str     "12:00"
+            :user-statuses     nil
+            :datemark          "yesterday"}
+           {:whisper-timestamp 10
+            :timestamp         10
+            :content           nil
+            :timestamp-str     "11:00"
+            :user-statuses     nil
+            :datemark          "yesterday"}
+           {:value             "yesterday"
+            :type              :datemark
+            :whisper-timestamp 10
+            :timestamp         10})
+         (db/messages-with-datemarks-and-statuses
+          {"yesterday"
+           (list
+            {:message-id        :m1
+             :timestamp-str     "11:00"
+             :whisper-timestamp 10
+             :timestamp         10}
+            {:message-id        :m2
+             :timestamp-str     "12:00"
+             :whisper-timestamp 20
+             :timestamp         20})
+           "today"
+           (list
+            {:message-id        :m3
+             :timestamp-str     "13:00"
+             :whisper-timestamp 30
+             :timestamp         30}
+            {:message-id        :m4
+             :timestamp-str     "14:00"
+             :whisper-timestamp 40
+             :timestamp         40})}
+          {:m1 {:whisper-timestamp 10
+                :timestamp         10}
+           :m2 {:whisper-timestamp 20
+                :timestamp         20}
+           :m3 {:whisper-timestamp 30
+                :timestamp         30}
+           :m4 {:whisper-timestamp 40
+                :timestamp         40}}
+          nil
+          nil
+          {:from    100
+           :exists? true})))))

--- a/test/cljs/status_im/test/mailserver/core.cljs
+++ b/test/cljs/status_im/test/mailserver/core.cljs
@@ -627,3 +627,187 @@
         (is (not (-> (mailserver/connect-to-mailserver {:db mailserver-with-sym-key-db})
                      :shh/generate-sym-key-from-password
                      first)))))))
+
+(deftest calculate-gap
+  (testing "new topic"
+    (is (= {:gap-from     10
+            :gap-to       10
+            :last-request 10}
+
+           (mailserver/calculate-gap
+            {:gap-from     nil
+             :gap-to       nil
+             :last-request nil}
+            {:request-from 5
+             :request-to   10}))))
+  (testing "calculate-gap#1"
+    (is (= {:gap-from     3
+            :gap-to       4
+            :last-request 5}
+
+           (mailserver/calculate-gap
+            {:gap-from     1
+             :gap-to       2
+             :last-request 3}
+            {:request-from 4
+             :request-to   5}))))
+  (testing "calculate-gap#2"
+    (is (= {:gap-from     1
+            :gap-to       2
+            :last-request 5}
+           (mailserver/calculate-gap
+            {:gap-from     1
+             :gap-to       2
+             :last-request 4}
+            {:request-from 3
+             :request-to   5}))))
+  (testing "calculate-gap#2-1"
+    (is (= {:gap-from     1
+            :gap-to       2
+            :last-request 4}
+           (mailserver/calculate-gap
+            {:gap-from     1
+             :gap-to       2
+             :last-request 3}
+            {:request-from 3
+             :request-to   4}))))
+  (testing "calculate-gap#3"
+    (is (= {:gap-from     1
+            :gap-to       2
+            :last-request 5}
+           (mailserver/calculate-gap
+            {:gap-from     1
+             :gap-to       2
+             :last-request 5}
+            {:request-from 3
+             :request-to   4}))))
+  (testing "calculate-gap#3-1"
+    (is (= {:gap-from     1
+            :gap-to       2
+            :last-request 3}
+           (mailserver/calculate-gap
+            {:gap-from     1
+             :gap-to       2
+             :last-request 3}
+            {:request-from 2
+             :request-to   3}))))
+  (testing "calculate-gap#4"
+    (is (= {:gap-from     1
+            :gap-to       2
+            :last-request 5}
+           (mailserver/calculate-gap
+            {:gap-from     1
+             :gap-to       2
+             :last-request 5}
+            {:request-from 3
+             :request-to   4}))))
+  (testing "calculate-gap#5"
+    (is (= {:gap-from     1
+            :gap-to       4
+            :last-request 5}
+           (mailserver/calculate-gap
+            {:gap-from     1
+             :gap-to       4
+             :last-request 5}
+            {:request-from 2
+             :request-to   3}))))
+  (testing "calculate-gap#6"
+    (is (= {:gap-from     2
+            :gap-to       3
+            :last-request 4}
+           (mailserver/calculate-gap
+            {:gap-from     2
+             :gap-to       3
+             :last-request 4}
+            {:request-from 1
+             :request-to   2}))))
+  (testing "calculate-gap#6-1"
+    (is (= {:gap-from     1
+            :gap-to       4
+            :last-request 5}
+           (mailserver/calculate-gap
+            {:gap-from     1
+             :gap-to       4
+             :last-request 5}
+            {:request-from 2
+             :request-to   3}))))
+  (testing "calculate-gap#0"
+    (is (= {:gap-from     2
+            :gap-to       3
+            :last-request 3}
+           (mailserver/calculate-gap
+            {:gap-from     3
+             :gap-to       3
+             :last-request 3}
+            {:request-from 1
+             :request-to   2}))))
+  (testing "calculate-gap#7"
+    (is (= {:gap-from     3
+            :gap-to       4
+            :last-request 5}
+           (mailserver/calculate-gap
+            {:gap-from     3
+             :gap-to       4
+             :last-request 5}
+            {:request-from 1
+             :request-to   2}))))
+  (testing "calculate-gap#8"
+    (is (= {:gap-from     5
+            :gap-to       5
+            :last-request 5}
+           (mailserver/calculate-gap
+            {:gap-from     2
+             :gap-to       3
+             :last-request 5}
+            {:request-from 1
+             :request-to   4}))))
+  (testing "calculate-gap#8-1"
+    (is (= {:gap-from     3
+            :gap-to       3
+            :last-request 3}
+           (mailserver/calculate-gap
+            {:gap-from     1
+             :gap-to       2
+             :last-request 3}
+            {:request-from 1
+             :request-to   2}))))
+  (testing "calculate-gap#9"
+    (is (= {:gap-from     5
+            :gap-to       5
+            :last-request 5}
+           (mailserver/calculate-gap
+            {:gap-from     2
+             :gap-to       3
+             :last-request 4}
+            {:request-from 1
+             :request-to   5}))))
+  (testing "calculate-gap#9-1"
+    (is (= {:gap-from     3
+            :gap-to       3
+            :last-request 3}
+           (mailserver/calculate-gap
+            {:gap-from     1
+             :gap-to       2
+             :last-request 3}
+            {:request-from 1
+             :request-to   3}))))
+  (testing "calculate-gap#10"
+    (is (= {:gap-from     1
+            :gap-to       2
+            :last-request 5}
+           (mailserver/calculate-gap
+            {:gap-from     1
+             :gap-to       3
+             :last-request 4}
+            {:request-from 2
+             :request-to   5}))))
+  (testing "calculate-gap#10-1"
+    (is (= {:gap-from     1
+            :gap-to       2
+            :last-request 3}
+           (mailserver/calculate-gap
+            {:gap-from     1
+             :gap-to       2
+             :last-request 3}
+            {:request-from 2
+             :request-to   3})))))

--- a/translations/en.json
+++ b/translations/en.json
@@ -997,5 +997,6 @@
     "chaos-unicorn-day-details": "\uD83E\uDD84\uD83E\uDD84\uD83E\uDD84\uD83E\uDD84\uD83E\uDD84\uD83E\uDD84\uD83E\uDD84\uD83D\uDE80!",
     "invalid-format": "Invalid format\nMust be {{format}}",
     "mailserver-format": "enode://{enode-id}:{password}@{ip-address}:{port}",
-    "bootnode-format": "enode://{enode-id}@{ip-address}:{port}"
+    "bootnode-format": "enode://{enode-id}@{ip-address}:{port}",
+    "fetch-messages": "↓ Fetch messages"
 }


### PR DESCRIPTION
The goal of this PR is to show to a user that some messages might be out of range of the last request to mailserver. In this case user can request to "fill that gap" and receive missed messages (if such exist).
- only the last "gap" is shown in UI, the user will not be informed about previous gaps in requests
- the range of the gap is not limited at the moment, i.e. if user missed 5 days of history they will be proposed to request the whole range of messages 

testing notes:
- only 60s of history is fetched by default in the latest build of this PR; it will allow to test functionality without waiting 24h
- if 24h of history is necessary for testing it can be loaded via "Fetch last 24 hours" option in chat's menu

status: ready  