### PR TITLE
[#7917] fix - Contacts are not synced between 0.11.0 and current nightly

### DIFF
--- a/src/status_im/chat/models.cljs
+++ b/src/status_im/chat/models.cljs
@@ -66,11 +66,12 @@
   dissociates these two fileds via this function, thereby signalling that the
   public chat is not fresh anymore."
   [{:keys [chats] :as db} chat-id]
-  (if (:might-have-join-time-messages? (get chats chat-id))
-    (-> db
-        (update-in [:chats chat-id] dissoc :join-time-mail-request-id)
-        (update-in [:chats chat-id] dissoc :might-have-join-time-messages?))
-    db))
+  (when (:might-have-join-time-messages? (get chats chat-id))
+    {:db (update-in db
+                    [:chats chat-id]
+                    dissoc
+                    :join-time-mail-request-id
+                    :might-have-join-time-messages?)}))
 
 (defn- create-new-chat
   [chat-id {:keys [db now]}]

--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -734,7 +734,7 @@
 (handlers/register-handler-fx
  :chat.ui/join-time-messages-checked
  (fn [{:keys [db]} [_ chat-id]]
-   {:db (chat/join-time-messages-checked db chat-id)}))
+   (chat/join-time-messages-checked db chat-id)))
 
 (handlers/register-handler-fx
  :chat.ui/show-message-details


### PR DESCRIPTION
fixes #7917

### Summary:

A bug was introduced in #7663 that became apparent only after 7663 was merged

status: ready