### PR TITLE
Implicit make shell

### DIFF
--- a/nix/shell.sh
+++ b/nix/shell.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+export TERM=xterm # fix for colors
+shift # we remove the first -c from arguments
+if ! command -v "nix" >/dev/null 2>&1; then
+  echo -e "${GREEN}Setting up environment...${NC}"
+  ./scripts/setup
+fi
+if command -v "nix" >/dev/null 2>&1 || [ -f ~/.nix-profile/etc/profile.d/nix.sh ]; then
+  echo -e "${GREEN}Configuring Nix shell...${NC}";
+  if [[ $@ == "ENTER_NIX_SHELL" ]]; then
+    . ~/.nix-profile/etc/profile.d/nix.sh && exec nix-shell
+  else
+    . ~/.nix-profile/etc/profile.d/nix.sh && exec nix-shell --run "$@"
+  fi
+fi

--- a/scripts/lib/setup/installers.sh
+++ b/scripts/lib/setup/installers.sh
@@ -23,16 +23,9 @@ function install_nix() {
         echo "if [ -e ${HOME}/.nix-profile/etc/profile.d/nix.sh ]; then . ${HOME}/.nix-profile/etc/profile.d/nix.sh; fi # added by make setup Status script" >> ~/.bashrc
       fi
 
-      local buildFlags=''
-      [ -n "$CI_ENVIRONMENT" ] && buildFlags='-v'
-      . ${HOME}/.nix-profile/etc/profile.d/nix.sh && \
-      NIX_CONF_DIR=$(cd "${BASH_SOURCE%/*}" && pwd)/nix \
-        nix build --no-link ${buildFlags} -f ${GIT_ROOT}/default.nix
-
       if [ $? -eq 0 ]; then
         echo -e "${YELLOW}**********************************************************************************************************"
-        echo "The Nix package manager was successfully installed. Please run \`make shell\` to initialize the Nix environment."
-        echo "If this doesn't work, you might have to sign out and back in, in order for the environment to be reloaded."
+        echo "The Nix package manager was successfully installed."
         echo -e "**********************************************************************************************************${NC}"
       fi
     else

--- a/scripts/run-environment-check.sh
+++ b/scripts/run-environment-check.sh
@@ -38,7 +38,7 @@ if [ -z "$IN_NIX_SHELL" ]; then
   fi
 fi
 
-if [[ $PLATFORM == 'android' ]]; then
+if [ "$PLATFORM" == 'android' ]; then
   if [ ! -d $ANDROID_SDK_ROOT ]; then
     echo -e "${GREEN}NDK setup not complete, please run 'make setup'!${NC}"
     exit 1
@@ -47,6 +47,9 @@ if [[ $PLATFORM == 'android' ]]; then
     echo -e "${GREEN}NDK setup not complete, please run 'make setup'!${NC}"
     exit 1
   fi
+elif [ "$PLATFORM" == 'ios' ] && [ "$(uname)" != "Darwin" ]; then
+  echo -e "${RED}iOS builds are only possible on macOS hosts${NC}"
+  exit 1
 fi
 
 if [[ $PLATFORM == 'setup' ]]; then

--- a/scripts/setup
+++ b/scripts/setup
@@ -2,13 +2,10 @@
 
 ########################################################################
 # This install script will setup your development dependencies on OS X
-# or Ubuntu. Ubuntu 16.04 is the only tested version.
+# or Ubuntu. Ubuntu 18.04 is the only tested version.
 #
 # Usage: scripts/setup
 ########################################################################
-
-YELLOW='\033[1;33m'
-NC='\033[0m'
 
 _current_dir=$(cd "${BASH_SOURCE%/*}" && pwd)
 source "$_current_dir/lib/setup/path-support.sh"


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

### Summary:

[comment]: # (Summarise the problem and how the pull request solves it)
This PR aims to simplify things for developers by getting rid of the pre-requisite of starting a Nix shell. The makefile is now smart enough to detect if a Nix shell is needed and start one if required.

This PR also adds a `desktop-server` target to make it easier to start a ubuntu-server in the context of Nix, along with the default variables needed to run a debug Desktop app alongside with the release one.

The PR depends on the nix-status-go PR, so it currently includes its commits (will rebase once that one is merged).

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->