### PR TITLE
Added BrowserStack logo to README.md on the main page

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,7 @@ Feel free to email us at [support@status.im](mailto:support@status.im) or better
 ## License
 
 Licensed under the [Mozilla Public License v2.0](https://github.com/status-im/status-react/blob/develop/LICENSE.md)
+
+## Testing Supported by
+
+<img width="160" src="http://foundation.zurb.com/sites/docs/assets/img/logos/browser-stack.svg" alt="BrowserStack"/>


### PR DESCRIPTION
- The logo is added in order to apply for open source [plan](https://www.browserstack.com/open-source?ref=pricing)
- BrowserStack is a solution fro running e2e tests against iOS
- The platform provides real devices instead of emulators on SauceLabs
- Also would be a good improvement for Android e2e tests in future, if the platform is stable