### PR TITLE
[#7892] generate keycard mnemonic offline

### DIFF
--- a/mobile_files/package.json.orig
+++ b/mobile_files/package.json.orig
@@ -54,7 +54,7 @@
     "react-native-safe-area-view": "0.9.0",
     "react-native-securerandom": "git+https://github.com/status-im/react-native-securerandom.git#0.1.1-2",
     "react-native-splash-screen": "3.1.1",
-    "react-native-status-keycard": "git+https://github.com/status-im/react-native-status-keycard.git#v2.4.0",
+    "react-native-status-keycard": "git+https://github.com/status-im/react-native-status-keycard.git#v2.5.0",
     "react-native-svg": "^9.2.4",
     "react-native-svg-transformer": "^0.12.1",
     "react-native-tcp": "git+https://github.com/status-im/react-native-tcp.git#v3.3.0-1-status",

--- a/mobile_files/yarn.lock
+++ b/mobile_files/yarn.lock
@@ -5355,9 +5355,9 @@ react-native-splash-screen@3.1.1:
   resolved "https://registry.yarnpkg.com/react-native-splash-screen/-/react-native-splash-screen-3.1.1.tgz#1a4e46c9fdce53ff52af2a2cb4181788c4e30b30"
   integrity sha512-PU2YocOSGbLjL9Vgcq/cwMNuHHKNjjuPpa1IPMuWo+6EB/fSZ5VOmxSa7+eucQe3631s3NhGuk3eHKahU03a4Q==
 
-"react-native-status-keycard@git+https://github.com/status-im/react-native-status-keycard.git#v2.4.0":
-  version "2.4.0"
-  resolved "git+https://github.com/status-im/react-native-status-keycard.git#b9a66144b3942e40ffb30cb27fa01202b0d11061"
+"react-native-status-keycard@git+https://github.com/status-im/react-native-status-keycard.git#v2.5.0":
+  version "2.5.0"
+  resolved "git+https://github.com/status-im/react-native-status-keycard.git#d9ccdd6a7db0ae6c3d52b8c998529ac5a21ca029"
 
 react-native-svg-transformer@^0.12.1:
   version "0.12.1"

--- a/src/status_im/hardwallet/card.cljs
+++ b/src/status_im/hardwallet/card.cljs
@@ -86,10 +86,10 @@
         (catch #(re-frame/dispatch [:hardwallet.callback/on-pairing-error (error-object->map %)])))))
 
 (defn generate-mnemonic
-  [{:keys [pairing]}]
+  [{:keys [pairing words]}]
   (when pairing
     (.. keycard
-        (generateMnemonic pairing)
+        (generateMnemonic pairing words)
         (then #(re-frame/dispatch [:hardwallet.callback/on-generate-mnemonic-success %]))
         (catch #(re-frame/dispatch [:hardwallet.callback/on-generate-mnemonic-error (error-object->map %)])))))
 

--- a/src/status_im/hardwallet/core.cljs
+++ b/src/status_im/hardwallet/core.cljs
@@ -16,7 +16,8 @@
             [clojure.string :as string]
             [status-im.accounts.login.core :as accounts.login]
             [status-im.accounts.recover.core :as accounts.recover]
-            [status-im.models.wallet :as models.wallet]))
+            [status-im.models.wallet :as models.wallet]
+            [status-im.utils.ethereum.mnemonic :as mnemonic]))
 
 (def default-pin "000000")
 
@@ -823,7 +824,8 @@
 (fx/defn generate-mnemonic
   [cofx]
   (let [{:keys [pairing]} (get-in cofx [:db :hardwallet :secrets])]
-    {:hardwallet/generate-mnemonic {:pairing pairing}}))
+    {:hardwallet/generate-mnemonic {:pairing pairing
+                                    :words   (string/join "\n" mnemonic/dictionary)}}))
 
 (fx/defn on-card-connected
   [{:keys [db] :as cofx} _]

--- a/src/status_im/ui/screens/profile/user/views.cljs
+++ b/src/status_im/ui/screens/profile/user/views.cljs
@@ -116,7 +116,8 @@
                                         :action-fn           #(re-frame/dispatch [:navigate-to :currency-settings])
                                         :accessibility-label :currency-button}]
      [profile.components/settings-item-separator]
-     (when config/hardwallet-enabled?
+     (when (and config/hardwallet-enabled?
+                platform/android?)
        [profile.components/settings-item {:label-kw            :t/status-keycard
                                           :accessibility-label :keycard-button
                                           :action-fn           #(re-frame/dispatch [:profile.ui/keycard-settings-button-pressed])}])


### PR DESCRIPTION
fixes #7892 

### Summary:

Pass bip39 words list to keycard sdk, instead of fetch it from github. Allows generating mnemonic and passing keycard installation offline.

status: ready
