### PR TITLE
Ensure keycard has applet installed before starting setup

### DIFF
--- a/src/status_im/ui/screens/hardwallet/success/styles.cljs
+++ b/src/status_im/ui/screens/hardwallet/success/styles.cljs
@@ -59,7 +59,7 @@
    :margin-bottom    40})
 
 (def bottom-action-text
-  {:typography     :main
+  {:typography     :main-medium
    :color          colors/blue
    :text-transform :uppercase})
 

--- a/translations/en.json
+++ b/translations/en.json
@@ -819,6 +819,7 @@
     "card-setup-prepare-text": "The whole process will take a few minutes.",
     "card-is-paired": "Card is paired",
     "no-keycard-applet-on-card": "No Keycard applet on card",
+    "keycard-applet-install-instructions": "To install the applet please follow the instructions on https://github.com/status-im/keycard-cli#keycard-applet-installation",
     "keycard-applet-will-be-installed": "Keycard applet will automatically be installed",
     "begin-set-up": "Begin setup",
     "maintain-card-to-phone-contact": "Maintain card-to-phone contact during process.",


### PR DESCRIPTION
### Summary:
Show warning with applet install instructions if keycard has no applet installed. Doesn't allow to proceed with installation for such cards. Keycards coming from factory has applet already installed.

### Testing notes (optional):
To install applet with CLI follow the instructions https://github.com/status-im/keycard-cli#keycard-applet-installation

status: ready

