### PR TITLE
Quick fix: Replace usage of `make setup` on macOS cache builds

### DIFF
--- a/ci/Jenkinsfile.nix.macos
+++ b/ci/Jenkinsfile.nix.macos
@@ -28,7 +28,7 @@ pipeline {
   stages {
     stage('Setup') {
       steps {
-        sh 'make setup'
+        sh 'scripts/setup'
         sh """
           . ~/.nix-profile/etc/profile.d/nix.sh && \
           nix-env -i openssh

--- a/default.nix
+++ b/default.nix
@@ -95,7 +95,7 @@ with pkgs;
       lib.optionalString targetMobile statusMobile.shellHook +
       ''
         if [ -n "$ANDROID_SDK_ROOT" ] && [ ! -d "$ANDROID_SDK_ROOT" ]; then
-          ./scripts/setup # we assume that if the Android SDK dir does not exist, make setup needs to be run
+          ./scripts/setup # we assume that if the Android SDK dir does not exist, setup script needs to be run
         fi
         set +e
       '';

--- a/scripts/lib/setup/installers.sh
+++ b/scripts/lib/setup/installers.sh
@@ -20,7 +20,7 @@ function install_nix() {
       if is_linux && [ -f ~/.bashrc ] && ! grep -qF ".nix-profile/etc/profile.d/nix.sh" ~/.bashrc; then
         # For some reason, new terminals are not started as login shells, so .profile and .bash_profile are not sourced.
         # To get around it, we add Nix initialization to .bashrc as well, if it exists
-        echo "if [ -e ${HOME}/.nix-profile/etc/profile.d/nix.sh ]; then . ${HOME}/.nix-profile/etc/profile.d/nix.sh; fi # added by make setup Status script" >> ~/.bashrc
+        echo "if [ -e ${HOME}/.nix-profile/etc/profile.d/nix.sh ]; then . ${HOME}/.nix-profile/etc/profile.d/nix.sh; fi # added by Status' setup script" >> ~/.bashrc
       fi
 
       if [ $? -eq 0 ]; then

--- a/scripts/run-environment-check.sh
+++ b/scripts/run-environment-check.sh
@@ -31,7 +31,7 @@ if [ -z "$IN_NIX_SHELL" ]; then
     echo -e "  \t\tfound\t\t$(node -v) ($(which node))"
     echo -e "  - yarn:\texpected\t${EXPECTED_YARN_VERSION}"
     echo -e "  \t\tfound\t\t$(yarn -v) ($(which yarn))"
-    echo -e "Please open another console to reload the environment, and then run 'make setup' if necessary."
+    echo -e "Please open another console to reload the environment."
 
     echo -e "**********************************************************************************************${NC}"
     exit 1
@@ -40,11 +40,11 @@ fi
 
 if [ "$PLATFORM" == 'android' ]; then
   if [ ! -d $ANDROID_SDK_ROOT ]; then
-    echo -e "${GREEN}NDK setup not complete, please run 'make setup'!${NC}"
+    echo -e "${GREEN}NDK setup not complete, please run 'scripts/setup'!${NC}"
     exit 1
   fi
   if [ ! -d $ANDROID_NDK_ROOT ]; then
-    echo -e "${GREEN}NDK setup not complete, please run 'make setup'!${NC}"
+    echo -e "${GREEN}NDK setup not complete, please run 'scripts/setup'!${NC}"
     exit 1
   fi
 elif [ "$PLATFORM" == 'ios' ] && [ "$(uname)" != "Darwin" ]; then


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

### Summary:

[comment]: # (Summarise the problem and how the pull request solves it)
This PR fixes broken Nix macOS cache CI build pipeline, because `make setup` has been deprecated.

status: ready <!-- Can be ready or wip -->