### PR TITLE
modify .env settings using Jenkins params

### DIFF
--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -80,7 +80,7 @@ pipeline {
     }
     stage('Bundle') {
       steps {
-        script { apk = mobile.android.bundle(btype) }
+        script { apk = mobile.android.bundle() }
       }
     }
     stage('Archive') {

--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -14,7 +14,6 @@ pipeline {
     ))
   }
 
-
   stages {
     stage('Prep') {
       steps { script {

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -65,7 +65,7 @@ pipeline {
     }
     stage('Bundle') {
       steps {
-        script { api = mobile.ios.bundle(btype) }
+        script { api = mobile.ios.bundle() }
       }
     }
     stage('Archive') {

--- a/ci/android.groovy
+++ b/ci/android.groovy
@@ -1,14 +1,15 @@
 utils = load 'ci/utils.groovy'
 
-def bundle(type = 'nightly') {
+def bundle() {
+  def btype = utils.getBuildType()
   /* Disable Gradle Daemon https://stackoverflow.com/questions/38710327/jenkins-builds-fail-using-the-gradle-daemon */
   def gradleOpt = "-PbuildUrl='${currentBuild.absoluteUrl}' -Dorg.gradle.daemon=false "
   def target = "release"
 
-  if (type in ['pr', 'e2e']) {
+  if (btype in ['pr', 'e2e']) {
     /* PR builds shouldn't replace normal releases */
     target = 'pr'
-  } else if (type == 'release') {
+  } else if (btype == 'release') {
     gradleOpt += "-PreleaseVersion='${utils.getVersion('mobile_files')}'"
   }
   dir('android') {
@@ -28,7 +29,7 @@ def bundle(type = 'nightly') {
   }
   sh 'find android/app/build/outputs/apk'
   def outApk = "android/app/build/outputs/apk/${target}/app-${target}.apk"
-  def pkg = utils.pkgFilename(type, 'apk')
+  def pkg = utils.pkgFilename(btype, 'apk')
   /* rename for upload */
   sh "cp ${outApk} ${pkg}"
   /* necessary for Fastlane */

--- a/ci/common.groovy
+++ b/ci/common.groovy
@@ -53,22 +53,15 @@ def prepNixEnvironment() {
 }
 
 def prep(type = 'nightly') {
+  /* build/downloads all nix deps in advance */
   prepNixEnvironment()
-
+  /* rebase unless this is a release build */
   utils.doGitRebase()
   /* ensure that we start from a known state */
   sh 'make clean'
-  /* select type of build */
-  switch (type) {
-    case 'nightly':
-      sh 'cp .env.nightly .env'; break
-    case 'release':
-      sh 'cp .env.prod .env'; break
-    case 'e2e':
-      sh 'cp .env.e2e .env'; break
-    default:
-      sh 'cp .env.jenkins .env'; break
-  }
+  /* pick right .env and update from params */
+  utils.updateEnv(type)
+
   if (env.TARGET_PLATFORM == 'android' || env.TARGET_PLATFORM == 'ios') {
     /* Run at start to void mismatched numbers */
     utils.genBuildNumber()

--- a/ci/ios.groovy
+++ b/ci/ios.groovy
@@ -6,12 +6,10 @@ def plutil(name, value) {
 """
 }
 
-def bundle(type) {
-  if (!type) {
-    type = utils.getBuildType()
-  }
+def bundle() {
+  def btype = utils.getBuildType()
   def target
-  switch (type) {
+  switch (btype) {
     case 'release':     target = 'release'; break;
     case 'testflight':  target = 'release'; break;
     case 'e2e':         target = 'e2e';     break;
@@ -39,14 +37,14 @@ def bundle(type) {
   }
   /* rename built file for uploads and archivization */
   def pkg = ''
-  if (type == 'release') {
+  if (btype == 'release') {
     pkg = utils.pkgFilename('release', 'ipa')
     sh "cp status_appstore/StatusIm.ipa ${pkg}"
-  } else if (type == 'e2e') {
+  } else if (btype == 'e2e') {
     pkg = utils.pkgFilename('e2e', 'app.zip')
     sh "cp status-e2e/StatusIm.app.zip ${pkg}"
-  } else if (type != 'testflight') {
-    pkg = utils.pkgFilename(type, 'ipa')
+  } else if (btype != 'testflight') {
+    pkg = utils.pkgFilename(btype, 'ipa')
     sh "cp status-adhoc/StatusIm.ipa ${pkg}"
   }
   /* necessary for Diawi upload */


### PR DESCRIPTION
Now we can specify ANY setting that exists in the `.env` file and modify it before build. It just has to be added as parameter in Jenkins job configuration.

This was done mostly so testers can make manual builds with changed `FLEET`.

Successful manual build with `eth.staging` passed as `FLEET` parameter:
https://ci.status.im/job/status-react/job/manual/269/

