### PR TITLE
Migrate to nodejs v10.15.0

### DIFF
--- a/derivation.nix
+++ b/derivation.nix
@@ -26,14 +26,17 @@ with pkgs;
     statusDesktop = callPackage ./nix/desktop { inherit target-os; stdenv = _stdenv; };
     statusMobile = callPackage ./nix/mobile { inherit target-os status-go; androidPkgs = androidComposition; stdenv = _stdenv; };
     status-go = callPackage ./nix/status-go { inherit (xcodeenv) composeXcodeWrapper; inherit xcodewrapperArgs; androidPkgs = androidComposition; };
+    nodejs' = pkgs.nodejs-10_x;
+    yarn' = yarn.override { nodejs = nodejs'; };
     nodeInputs = import ./nix/global-node-packages/output {
       # The remaining dependencies come from Nixpkgs
-      inherit pkgs nodejs;
+      inherit pkgs;
+      nodejs = nodejs';
     };
-    nodePkgs = [
-      nodejs
+    nodePkgBuildInputs = [
+      nodejs'
       python27 # for e.g. gyp
-      yarn
+      yarn'
     ] ++ (map (x: nodeInputs."${x}") (builtins.attrNames nodeInputs));
     xcodewrapperArgs = {
       version = "10.1";
@@ -69,7 +72,7 @@ with pkgs;
       watchman
 
       status-go
-    ] ++ nodePkgs
+    ] ++ nodePkgBuildInputs
       ++ lib.optional isDarwin cocoapods
       ++ lib.optional (!isDarwin) gcc7
       ++ lib.optionals targetDesktop statusDesktop.buildInputs


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

### Summary
[comment]: # (Summarise the problem and how the pull request solves it)

Before the Nix migration, we used to be at Node 10. When migrating to Nix I wasn't yet aware of the syntax required to make yarn use our intended version of Node instead of its default of Node 8, so we just started with the default.

<!-- (PRs will only be accepted if squashed into single commit.) -->

Note: This PR is based on https://github.com/status-im/status-react/pull/7925, so you'll see a lot of unrelated changes. The PR itself is just a few lines change in `derivation.nix`.

status: ready <!-- Can be ready or wip -->

