### PR TITLE
Load 7 days history by default from non-discovery topics

### DIFF
--- a/src/status_im/data_store/realm/schemas/account/mailserver_requests_gap.cljs
+++ b/src/status_im/data_store/realm/schemas/account/mailserver_requests_gap.cljs
@@ -1,0 +1,8 @@
+(ns status-im.data-store.realm.schemas.account.mailserver-requests-gap)
+
+(def v1 {:name       :mailserver-requests-gap
+         :properties {:chat-id {:type    :bool
+                                :indexed true}
+                      :from    {:type    :integer
+                                :indexed true}
+                      :to      :integer}})

--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -724,7 +724,7 @@
  :chat.ui/fetch-history-pressed
  (fn [{:keys [now] :as cofx} [_ chat-id]]
    (mailserver/fetch-history cofx chat-id
-                             {:from (- (quot now 1000) (* 24 3600))})))
+                             {:from (- (quot now 1000) mailserver/one-day)})))
 
 (handlers/register-handler-fx
  :chat.ui/fill-the-gap

--- a/src/status_im/mailserver/core.cljs
+++ b/src/status_im/mailserver/core.cljs
@@ -39,7 +39,7 @@
 (def max-discovery-request-range one-day)
 (def maximum-number-of-attempts 2)
 (def request-timeout 30)
-(def min-limit 100)
+(def min-limit 50)
 (def max-limit 2000)
 (def backoff-interval-ms 3000)
 (def default-limit max-limit)
@@ -364,10 +364,11 @@
           {:topic     topic
            :from      from
            :to        to
+           :limit     (when-not discovery? 100)
            :force-to? (not (nil? force-request-to))})))))
 
 (defn aggregate-requests
-  [acc {:keys [topic from to force-to?]}]
+  [acc {:keys [topic from to force-to? limit]}]
   (update acc [from to force-to?]
           (fn [{:keys [topics]}]
             {:topics    ((fnil conj #{}) topics topic)
@@ -375,7 +376,8 @@
              :to        to
              ;; To is sent to the mailserver only when force-to? is true,
              ;; also we use to calculate when the last-request was sent.
-             :force-to? force-to?})))
+             :force-to? force-to?
+             :limit     limit})))
 
 (defn prepare-messages-requests
   [{{:keys [:mailserver/requests-from

--- a/src/status_im/mailserver/core.cljs
+++ b/src/status_im/mailserver/core.cljs
@@ -309,6 +309,7 @@
               " from " actual-from
               " force-to? " force-to?
               " to " to
+              " range " (- to from)
               " cursor " cursor
               " limit " actual-limit)
     (.requestMessages (transport.utils/shh web3)
@@ -733,7 +734,7 @@
       (let [mailserver-topic
             (-> current-mailserver-topic
                 (assoc :last-request (- (quot now 1000)
-                                        (if (= topic :discovery-topic)
+                                        (if (= topic transport.topic/discovery-topic-hash)
                                           max-discovery-request-range
                                           max-request-range)))
                 (update :chat-ids conj chat-id))]

--- a/src/status_im/transport/partitioned_topic.cljs
+++ b/src/status_im/transport/partitioned_topic.cljs
@@ -53,7 +53,11 @@
     discovery-topic-hash))
 
 (defn discovery-topics [public-key]
-  [(partitioned-topic-hash public-key) discovery-topic-hash])
+  [;; TODO(rasom):
+   ;; can be uncommented when proper deruvation will be implemented,
+   ;; useless at the moment
+   #_(partitioned-topic-hash public-key)
+   discovery-topic-hash])
 
 (defn contains-topic?
   [available-topics topic]

--- a/test/cljs/status_im/test/transport/core.cljs
+++ b/test/cljs/status_im/test/transport/core.cljs
@@ -17,8 +17,8 @@
     (testing "it adds the discover filters"
       (is (= {:web3 nil :private-key-id "1" :topics '({:topic   "topic-4"
                                                        :chat-id "4"}
-                                                      {:topic   "0x2af2e6e7"
-                                                       :chat-id :discovery-topic}
+                                                      #_{:topic   "0x2af2e6e7"
+                                                         :chat-id :discovery-topic}
                                                       {:topic   "0xf8946aac"
                                                        :chat-id :discovery-topic})}
              (:shh/add-discovery-filters (transport/init-whisper cofx)))))


### PR DESCRIPTION
In most cases it is acceptable to load 7 days (instead of 1) of public chat history.
Discovery topic is still a bit "overloaded", that's why only 1 day is requested.  

status: ready