### PR TITLE
[#7917] fix - Contacts are not synced between 0.11.0 and current nightly

### DIFF
--- a/src/status_im/contact/db.cljs
+++ b/src/status_im/contact/db.cljs
@@ -148,6 +148,17 @@
   ([db public-key]
    (pending? (get-in db [:contacts/contacts public-key]))))
 
+(defn legacy-pending?
+  "Would the :pending? field be true? for contacts sync payload sent to devices
+  running 0.11.0 or older?"
+  ([{:keys [system-tags] :as contact}]
+   (let [request-received? (contains? system-tags :contact/request-received)
+         added? (added? contact)]
+     (and request-received?
+          (not added?))))
+  ([db public-key]
+   (pending? (get-in db [:contacts/contacts public-key]))))
+
 (defn active?
   "Checks that the user is added to the contact and not blocked"
   ([contact]

--- a/src/status_im/pairing/core.cljs
+++ b/src/status_im/pairing/core.cljs
@@ -134,7 +134,7 @@
                                      (update :system-tags disj :contact/blocked))
                            ;; for compatibility with version < contact.v7
                            (contact.db/added? contact) (assoc :pending? false)
-                           (contact.db/pending? contact) (assoc :pending? true))))
+                           (contact.db/legacy-pending? contact) (assoc :pending? true))))
                 {}
                 batch)]
     (transport.pairing/SyncInstallation. contacts-to-sync {} {})))
@@ -235,7 +235,7 @@
                       {public-key (cond-> contact
                                     ;; for compatibility with version < contact.v7
                                     (contact.db/added? contact) (assoc :pending? false)
-                                    (contact.db/pending? contact) (assoc :pending? true))}
+                                    (contact.db/legacy-pending? contact) (assoc :pending? true))}
                       {} {})]
     (send-installation-message-fx cofx sync-message)))
 
@@ -259,12 +259,31 @@
              {}
              contacts))
 
+(defn ensure-system-tags
+  "Make sure system tags is there"
+  [contacts]
+  (reduce-kv (fn [acc k {:keys [system-tags] :as v}]
+               (assoc acc k
+                      (assoc
+                       v
+                       :system-tags
+                       (if system-tags
+                         system-tags
+                         (if (and (contains? v :pending?) (not (:pending? v)))
+                           #{:contact/added}
+                           #{:contact/request-received})))))
+             {}
+             contacts))
+
 (defn handle-sync-installation [{:keys [db] :as cofx} {:keys [contacts account chat]} sender]
   (if (= sender (accounts.db/current-public-key cofx))
     (let [success-event [:message/messages-persisted [(or (:dedup-id cofx) (:js-obj cofx))]]
-          new-contacts  (vals (merge-contacts (:contacts/contacts db) (ensure-photo-path contacts)))
+          new-contacts  (when (seq contacts)
+                          (vals (merge-contacts (:contacts/contacts db)
+                                                ((comp ensure-photo-path
+                                                       ensure-system-tags) contacts))))
           new-account   (merge-account (:account/account db) account)
-          contacts-fx   (mapv contact/upsert-contact new-contacts)]
+          contacts-fx   (when new-contacts (mapv contact/upsert-contact new-contacts))]
       (apply fx/merge
              cofx
              (concat

--- a/src/status_im/transport/db.cljs
+++ b/src/status_im/transport/db.cljs
@@ -28,9 +28,9 @@
 (spec/def :pairing/pending? boolean?)
 (spec/def :pairing/contact (spec/keys  :req-un [:contact/public-key
                                                 :contact/name
-                                                :contact/address
-                                                :contact/system-tags]
-                                       :opt-un [:contact/last-updated
+                                                :contact/address]
+                                       :opt-un [:contact/system-tags
+                                                :contact/last-updated
                                                 :contact/last-online
                                                 :contact/fcm-token
                                                 :pairing/pending?


### PR DESCRIPTION
fixes #7917 

- tested with android-real with 0.11.0 as device A and iOS simulator as device B
- tested adding a single contact from user profile
- tested pressing "Sync all devices" in Profile -> Devices

status: ready