### PR TITLE
Improve makefile to only make Nix install the bare minimum for intended platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ HELP_FUN = \
 			   }; \
 			   print "\n"; \
 		   }
+HOST_OS := $(shell uname | tr '[:upper:]' '[:lower:]')
 
 export NIX_CONF_DIR = $(PWD)/nix
 
@@ -61,37 +62,45 @@ endif
 #----------------
 release: release-android release-ios ##@build build release for Android and iOS
 
+release-android: export TARGET_OS ?= android
 release-android: ##@build build release for Android
 	@$(MAKE) prod-build-android && \
 	react-native run-android --variant=release
 
+release-ios: export TARGET_OS ?= ios
 release-ios: ##@build build release for iOS release
 	# Open XCode inside the Nix context
 	@$(MAKE) prod-build-ios && \
-	@echo "Build in XCode, see https://status.im/build_status/ for instructions" && \
+	echo "Build in XCode, see https://status.im/build_status/ for instructions" && \
 	open ios/StatusIm.xcworkspace
 
+release-desktop: export TARGET_OS ?= $(HOST_OS)
 release-desktop: ##@build build release for desktop release
 	@$(MAKE) prod-build-desktop && \
 	scripts/build-desktop.sh
 
+release-windows-desktop: export TARGET_OS ?= windows
 release-windows-desktop: ##@build build release for desktop release
 	@$(MAKE) prod-build-desktop && \
 	TARGET_SYSTEM_NAME=Windows scripts/build-desktop.sh
 
+release-desktop: export TARGET_OS ?= $(HOST_OS)
 prod-build:
 	scripts/prepare-for-platform.sh android && \
 	scripts/prepare-for-platform.sh ios && \
 	lein prod-build
 
+prod-build-android: export TARGET_OS ?= android
 prod-build-android:
 	scripts/prepare-for-platform.sh android && \
 	lein prod-build-android
 
+prod-build-ios: export TARGET_OS ?= ios
 prod-build-ios:
 	scripts/prepare-for-platform.sh ios && \
 	lein prod-build-ios
 
+prod-build-android: export TARGET_OS ?= android
 prod-build-desktop:
 	git clean -qdxf -f ./index.desktop.js desktop/ && \
 	scripts/prepare-for-platform.sh desktop && \
@@ -107,20 +116,27 @@ _watch-%: ##@watch Start development for device
 	scripts/prepare-for-platform.sh $(SYSTEM)
 	clj -R:dev build.clj watch --platform $(SYSTEM) --$(SYSTEM)-device $(DEVICE)
 
+watch-ios-real: export TARGET_OS ?= ios
 watch-ios-real: _watch-ios-real ##@watch Start development for iOS real device
 
+watch-ios-simulator: export TARGET_OS ?= ios
 watch-ios-simulator: _watch-ios-simulator ##@watch Start development for iOS simulator
 
+watch-android-real: export TARGET_OS ?= android
 watch-android-real: _watch-android-real ##@watch Start development for Android real device
 
+watch-android-avd: export TARGET_OS ?= android
 watch-android-avd: _watch-android-avd ##@watch Start development for Android AVD
 
+watch-android-genymotion: export TARGET_OS ?= android
 watch-android-genymotion: _watch-android-genymotion ##@watch Start development for Android Genymotion
 
+watch-desktop: export TARGET_OS ?= $(HOST_OS)
 watch-desktop: ##@watch Start development for Desktop
 	@scripts/prepare-for-platform.sh desktop && \
 	clj -R:dev build.clj watch --platform desktop
 
+desktop-server: export TARGET_OS ?= $(HOST_OS)
 desktop-server:
 	@scripts/prepare-for-platform.sh desktop && \
 	node ubuntu-server.js
@@ -133,13 +149,16 @@ _run-%:
 	@scripts/prepare-for-platform.sh $(SYSTEM) && \
 	react-native run-$(SYSTEM)
 
+run-android: export TARGET_OS ?= android
 run-android: ##@run Run Android build
 	@scripts/prepare-for-platform.sh android && \
 	react-native run-android --appIdSuffix debug
 
+run-desktop: export TARGET_OS ?= $(HOST_OS)
 run-desktop: _run-desktop ##@run Run Desktop build
 
 SIMULATOR=
+run-ios: export TARGET_OS ?= ios
 run-ios: ##@run Run iOS build
 ifneq ("$(SIMULATOR)", "")
 	@scripts/prepare-for-platform.sh ios && \
@@ -162,19 +181,23 @@ test-auto: ##@test Run tests in interactive (auto) mode in NodeJS
 #--------------
 # Other
 #--------------
+run-desktop: export TARGET_OS ?= $(HOST_OS)
 react-native: ##@other Start react native packager
 	@scripts/start-react-native.sh
 
+geth-connect: export TARGET_OS ?= android
 geth-connect: ##@other Connect to Geth on the device
 	adb forward tcp:8545 tcp:8545 && \
 	build/bin/geth attach http://localhost:8545
 
+android-ports: export TARGET_OS ?= android
 android-ports: ##@other Add proxies to Android Device/Simulator
 	adb reverse tcp:8081 tcp:8081 && \
 	adb reverse tcp:3449 tcp:3449 && \
 	adb reverse tcp:4567 tcp:4567 && \
 	adb forward tcp:5561 tcp:5561
 
+android-logcat: export TARGET_OS ?= android
 android-logcat:
 	adb logcat | grep -e StatusModule -e ReactNativeJS -e StatusNativeLogs
 
@@ -184,23 +207,29 @@ _list:
 
 _unknown-startdev-target-%: SHELL := /bin/sh
 _unknown-startdev-target-%:
-	@ echo "Unknown target device '$*'. Supported targets:"
-	@ ${MAKE} _list | grep "watch-" | sed s/watch-/startdev-/
-	@ exit 1
+	@ echo "Unknown target device '$*'. Supported targets:"; \
+	${MAKE} _list | grep "watch-" | sed s/watch-/startdev-/; \
+	exit 1
 
 _startdev-%:
 	$(eval SYSTEM := $(word 2, $(subst -, , $@)))
 	$(eval DEVICE := $(word 3, $(subst -, , $@)))
-	scripts/prepare-for-platform.sh ${SYSTEM} || $(MAKE) _unknown-startdev-target-$@
+	scripts/prepare-for-platform.sh ${SYSTEM} || exit 1
 	@ if [ -z "$(DEVICE)" ]; then \
 		$(MAKE) watch-$(SYSTEM) || $(MAKE) _unknown-startdev-target-$@; \
 	else \
 		$(MAKE) watch-$(SYSTEM)-$(DEVICE) || $(MAKE) _unknown-startdev-target-$@; \
 	fi
 
+startdev-android-avd: export TARGET_OS ?= android
 startdev-android-avd: _startdev-android-avd
+startdev-android-genymotion: export TARGET_OS ?= android
 startdev-android-genymotion: _startdev-android-genymotion
+startdev-android-real: export TARGET_OS ?= android
 startdev-android-real: _startdev-android-real
+startdev-desktop: export TARGET_OS ?= $(HOST_OS)
 startdev-desktop: _startdev-desktop
+startdev-ios-real: export TARGET_OS ?= ios
 startdev-ios-real: _startdev-ios-real
+startdev-ios-simulator: export TARGET_OS ?= ios
 startdev-ios-simulator: _startdev-ios-simulator

--- a/ci/Jenkinsfile.nix.linux
+++ b/ci/Jenkinsfile.nix.linux
@@ -38,7 +38,7 @@ pipeline {
     stage('Build') {
       steps {
         sh """
-          nix build --no-link &&
+          nix build -v --no-link &&
           nix-shell --run echo
         """
       }

--- a/ci/Jenkinsfile.nix.macos
+++ b/ci/Jenkinsfile.nix.macos
@@ -39,7 +39,7 @@ pipeline {
       steps {
         sh """
           . ~/.nix-profile/etc/profile.d/nix.sh && \
-          nix build --no-link && \
+          nix build -v --no-link && \
           nix-shell --run echo
         """
       }

--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,4 @@
-# target-os = [ 'windows' 'linux' 'macos' 'android' 'ios' 'all' ]
+# target-os = [ 'windows' 'linux' 'macos' 'darwin' 'android' 'ios' 'all' ]
 { config ? { android_sdk.accept_license = true; },
   pkgs ? import ((import <nixpkgs> { }).fetchFromGitHub {
     owner = "status-im";

--- a/derivation.nix
+++ b/derivation.nix
@@ -1,4 +1,4 @@
-# target-os = [ 'windows' 'linux' 'macos' 'android' 'ios' ]
+# target-os = [ 'windows' 'linux' 'macos' 'darwin' 'android' 'ios' ]
 { system ? builtins.currentSystem
 , config ? {}, overlays ? []
 , pkgs ? (import <nixpkgs> { inherit system config overlays; })
@@ -7,15 +7,18 @@
 with pkgs;
   let
     sanitized-target-os = 
-      if (builtins.any (os: target-os == os) [ "linux" "android" "windows" "macos" "ios" "all" ])
+      if (builtins.any (os: target-os == os) [ "linux" "android" "windows" "macos" "darwin" "ios" "all" ])
       then target-os
       else throw "Unknown value for target-os: '${target-os}'";
+    # based on the value passed in through target-os, check if we're targetting a desktop platform
     targetDesktop = {
       "linux" = true;
       "windows" = true;
       "macos" = true;
+      "darwin" = true;
       "all" = true;
     }.${sanitized-target-os} or false;
+    # based on the value passed in through target-os, check if we're targetting a mobile platform
     targetMobile = {
       "android" = true;
       "ios" = true;

--- a/nix/desktop/default.nix
+++ b/nix/desktop/default.nix
@@ -10,6 +10,7 @@ let
   }.${target-os} or false;
   targetDarwin = {
     "macos" = true;
+    "darwin" = true;
     "all" = isDarwin;
   }.${target-os} or false;
   targetWindows = {

--- a/nix/shell.sh
+++ b/nix/shell.sh
@@ -20,10 +20,10 @@ if ! command -v "nix" >/dev/null 2>&1; then
 fi
 
 if command -v "nix" >/dev/null 2>&1; then
-  echo -e "${GREEN}Configuring Nix shell...${NC}";
+  echo -e "${GREEN}Configuring Nix shell for target '${TARGET_OS:=all}'...${NC}";
   if [[ $@ == "ENTER_NIX_SHELL" ]]; then
-    exec nix-shell --show-trace
+    exec nix-shell --show-trace --argstr target-os ${TARGET_OS}
   else
-    exec nix-shell --show-trace --run "$@"
+    exec nix-shell --show-trace --argstr target-os ${TARGET_OS} --run "$@"
   fi
 fi


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

### Summary

[comment]: # (Summarise the problem and how the pull request solves it)
This PR allows the Makefile to leverage the target-os argument to only install the packages that are required for what we're building. E.g. a new user that clones the repo on iOS and runs `make release-ios` won't see the Android SDK, NDK, gradle, etc being downloaded.

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->
