### PR TITLE
Skip fetching 24h of discovery topics on a new account

### DIFF
--- a/src/status_im/accounts/create/core.cljs
+++ b/src/status_im/accounts/create/core.cljs
@@ -66,7 +66,7 @@
    {:keys [pubkey address mnemonic installation-id
            keycard-instance-uid keycard-pairing keycard-paired-on]}
    password
-   {:keys [seed-backed-up? login?] :or {login? true}}]
+   {:keys [seed-backed-up? login? new-account?] :or {login? true}}]
   (let [normalized-address (utils.hex/normalize-hex address)
         account            {:public-key             pubkey
                             :installation-id        (or installation-id (get-in db [:accounts/new-installation-id]))
@@ -84,7 +84,8 @@
                             :keycard-paired-on      keycard-paired-on
                             :settings               (constants/default-account-settings)
                             :syncing-on-mobile-network? false
-                            :remember-syncing-choice? false}]
+                            :remember-syncing-choice? false
+                            :new-account?           new-account?}]
     (log/debug "account-created")
     (when-not (string/blank? pubkey)
       (fx/merge cofx

--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -240,7 +240,8 @@
   (re-frame/inject-cofx :accounts.create/get-signing-phrase)
   (re-frame/inject-cofx :accounts.create/get-status)]
  (fn [cofx [_ result password]]
-   (accounts.create/on-account-created cofx result password {:seed-backed-up? false})))
+   (accounts.create/on-account-created cofx result password {:seed-backed-up? false
+                                                             :new-account?    true})))
 
 (handlers/register-handler-fx
  :accounts.create.ui/create-new-account-button-pressed


### PR DESCRIPTION
Please review only the last commit.

It makes onboarding a bit faster, also probably reduces traffic from mailservers (I can't live a day without creating 5-15 new accounts).

status: ready