### PR TITLE
Build Linux with --pure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ release-desktop: ##@build build release for desktop release
 release-windows-desktop: export TARGET_OS ?= windows
 release-windows-desktop: ##@build build release for desktop release
 	@$(MAKE) prod-build-desktop && \
-	TARGET_SYSTEM_NAME=Windows scripts/build-desktop.sh
+	scripts/build-desktop.sh
 
 release-desktop: export TARGET_OS ?= $(HOST_OS)
 prod-build:

--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -31,7 +31,7 @@ pipeline {
   }
 
   environment {
-    TARGET_PLATFORM = 'android'
+    TARGET_OS = 'android'
     LANG     = 'en_US.UTF-8'
     LANGUAGE = 'en_US.UTF-8'
     LC_ALL   = 'en_US.UTF-8'

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -22,7 +22,7 @@ pipeline {
   }
 
   environment {
-    TARGET_PLATFORM = 'ios'
+    TARGET_OS = 'ios'
     CI_ENVIRONMENT = 'jenkins'
     LANG = 'en_US.UTF-8'
     LANGUAGE = 'en_US.UTF-8'

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -36,7 +36,7 @@ pipeline {
    * https://issues.jenkins-ci.org/browse/JENKINS-49076
    **/
   environment {
-    TARGET_PLATFORM = 'linux'
+    TARGET_OS = 'linux'
     LANG = 'en_US.UTF-8'
     LANGUAGE = 'en_US.UTF-8'
     LC_ALL = 'en_US.UTF-8'

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -22,7 +22,7 @@ pipeline {
   }
 
   environment {
-    TARGET_PLATFORM = 'macos'
+    TARGET_OS = 'macos'
     CI_ENVIRONMENT = 'jenkins'
     LANG = 'en_US.UTF-8'
     LANGUAGE = 'en_US.UTF-8'

--- a/ci/Jenkinsfile.nix.linux
+++ b/ci/Jenkinsfile.nix.linux
@@ -39,7 +39,7 @@ pipeline {
       steps {
         sh """
           nix build -v --no-link &&
-          nix-shell --run echo
+          nix-shell --pure --run echo
         """
       }
     }

--- a/ci/Jenkinsfile.nix.macos
+++ b/ci/Jenkinsfile.nix.macos
@@ -40,7 +40,7 @@ pipeline {
         sh """
           . ~/.nix-profile/etc/profile.d/nix.sh && \
           nix build -v --no-link && \
-          nix-shell --run echo
+          nix-shell --pure --run echo
         """
       }
     }

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -35,7 +35,7 @@ pipeline {
    * https://issues.jenkins-ci.org/browse/JENKINS-49076
    **/
   environment {
-    TARGET_PLATFORM = 'windows'
+    TARGET_OS = 'windows'
     CI_ENVIRONMENT = 'jenkins'
     LANG = 'en_US.UTF-8'
     LANGUAGE = 'en_US.UTF-8'
@@ -43,7 +43,6 @@ pipeline {
     NPM_CONFIG_CACHE = '/var/tmp/npm'
     LEIN_HOME = '/var/tmp/lein'
     NIX_CONF_DIR = "${env.WORKSPACE}/nix"
-    TARGET_SYSTEM_NAME = 'Windows'
     CONAN_PRINT_RUN_COMMANDS = '1'
     CONAN_SYSREQUIRES_MODE = 'disabled'
     CONAN_SYSREQUIRES_SUDO = '0'

--- a/ci/common.groovy
+++ b/ci/common.groovy
@@ -43,7 +43,7 @@ def notifyPR(success) {
 }
 
 def prepNixEnvironment() {
-  if (env.TARGET_PLATFORM == 'linux' || env.TARGET_PLATFORM == 'windows' || env.TARGET_PLATFORM == 'android') {
+  if (env.TARGET_OS == 'linux' || env.TARGET_OS == 'windows' || env.TARGET_OS == 'android') {
     def glibcLocales = sh(
       returnStdout: true,
       script: ". ~/.nix-profile/etc/profile.d/nix.sh && nix-build --no-out-link '<nixpkgs>' -A glibcLocales"
@@ -62,15 +62,15 @@ def prep(type = 'nightly') {
   /* pick right .env and update from params */
   utils.updateEnv(type)
 
-  if (env.TARGET_PLATFORM == 'android' || env.TARGET_PLATFORM == 'ios') {
+  if (env.TARGET_OS == 'android' || env.TARGET_OS == 'ios') {
     /* Run at start to void mismatched numbers */
     utils.genBuildNumber()
     /* install ruby dependencies */
     utils.nix_sh 'bundle install --quiet'
   }
 
-  def prepareTarget=env.TARGET_PLATFORM
-  if (env.TARGET_PLATFORM == 'macos' || env.TARGET_PLATFORM == 'linux' || env.TARGET_PLATFORM == 'windows') {
+  def prepareTarget=env.TARGET_OS
+  if (env.TARGET_OS == 'macos' || env.TARGET_OS == 'linux' || env.TARGET_OS == 'windows') {
     prepareTarget='desktop'
   }
   /* node deps, pods, and status-go download */

--- a/ci/docker/nix/Dockerfile
+++ b/ci/docker/nix/Dockerfile
@@ -88,7 +88,7 @@ RUN export USER=jenkins \
  && /tmp/nix-install.sh \
  && . ~/.nix-profile/etc/profile.d/nix.sh \
  && nix-build --no-out-link https://github.com/status-im/status-react/tarball/${GIT_COMMIT} \
- && nix-shell --run 'echo' https://github.com/status-im/status-react/tarball/${GIT_COMMIT}
+ && nix-shell --pure --run 'echo' https://github.com/status-im/status-react/tarball/${GIT_COMMIT}
 
 # hack to avoid calling login
 ENV USER=jenkins

--- a/ci/ghcmgr.groovy
+++ b/ci/ghcmgr.groovy
@@ -11,7 +11,7 @@ utils = load 'ci/utils.groovy'
 def buildObj(success) {
   def pkg_url = env.PKG_URL
   /* a bare ipa file is not installable on iOS */
-  if (env.TARGET_PLATFORM == 'ios') {
+  if (env.TARGET_OS == 'ios') {
     pkg_url = env.DIAWI_URL 
   }
   /* assemble build object valid for ghcmgr */
@@ -19,7 +19,7 @@ def buildObj(success) {
     id: env.BUILD_DISPLAY_NAME,
     commit: GIT_COMMIT.take(8),
     success: success != null ? success : true,
-    platform: env.TARGET_PLATFORM + (utils.getBuildType() == 'e2e' ? '-e2e' : ''),
+    platform: env.TARGET_OS + (utils.getBuildType() == 'e2e' ? '-e2e' : ''),
     duration: utils.buildDuration(),
     url: currentBuild.absoluteUrl,
     pkg_url: pkg_url,

--- a/ci/github.groovy
+++ b/ci/github.groovy
@@ -62,7 +62,7 @@ def notifyPRSuccess() {
   def type = utils.getBuildType() == 'e2e' ? ' e2e' : ''
   msg += "[${env.JOB_NAME}${currentBuild.displayName}](${currentBuild.absoluteUrl}) ${d} "
   msg += "${utils.buildDuration()} ${d} ${GIT_COMMIT.take(8)} ${d} "
-  msg += "[:package: ${env.TARGET_PLATFORM}${type} package](${env.PKG_URL})"
+  msg += "[:package: ${env.TARGET_OS}${type} package](${env.PKG_URL})"
   notify(msg)
 }
 

--- a/ci/utils.groovy
+++ b/ci/utils.groovy
@@ -16,12 +16,15 @@ def getToolVersion(name) {
 }
 
 def nix_sh(cmd) {
+  def isPure = env.TARGET_PLATFORM == 'linux'
+  def pureFlag = isPure ? '--pure' : ''
+
   sh """
     set +x
     . ~/.nix-profile/etc/profile.d/nix.sh
     set -x
     nix-shell --argstr target-os \'${env.TARGET_PLATFORM}\' \\
-              --run \'${cmd}\' \\
+              ${pureFlag} --run \'${cmd}\' \\
               \'${env.WORKSPACE}/shell.nix\'
   """
 }

--- a/ci/utils.groovy
+++ b/ci/utils.groovy
@@ -16,14 +16,14 @@ def getToolVersion(name) {
 }
 
 def nix_sh(cmd) {
-  def isPure = env.TARGET_PLATFORM == 'linux'
+  def isPure = env.TARGET_OS == 'linux'
   def pureFlag = isPure ? '--pure' : ''
 
   sh """
     set +x
     . ~/.nix-profile/etc/profile.d/nix.sh
     set -x
-    nix-shell --argstr target-os \'${env.TARGET_PLATFORM}\' \\
+    nix-shell --argstr target-os \'${env.TARGET_OS}\' \\
               ${pureFlag} --run \'${cmd}\' \\
               \'${env.WORKSPACE}/shell.nix\'
   """

--- a/nix/shell.sh
+++ b/nix/shell.sh
@@ -22,10 +22,12 @@ if ! command -v "nix" >/dev/null 2>&1; then
 fi
 
 if command -v "nix" >/dev/null 2>&1; then
-  echo -e "${GREEN}Configuring Nix shell for target '${TARGET_OS:=all}'...${NC}";
+  echo -e "${GREEN}Configuring Nix shell for target '${TARGET_OS:=all}'...${NC}"
   if [[ $@ == "ENTER_NIX_SHELL" ]]; then
     exec nix-shell --show-trace --argstr target-os ${TARGET_OS}
   else
-    exec nix-shell --show-trace --argstr target-os ${TARGET_OS} --run "$@"
+    is_pure=''
+    [ "${TARGET_OS}" == 'linux' ] && is_pure='--pure'
+    exec nix-shell ${is_pure} --show-trace --argstr target-os ${TARGET_OS} --run "$@"
   fi
 fi

--- a/scripts/build-desktop.sh
+++ b/scripts/build-desktop.sh
@@ -10,8 +10,8 @@ YELLOW='\033[1;33m'
 NC='\033[0m'
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 OS=$(uname -s)
-if [ -z $TARGET_SYSTEM_NAME ]; then
-  TARGET_SYSTEM_NAME=$OS
+if [ -z "$TARGET_OS" ]; then
+  TARGET_OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 fi
 WINDOWS_CROSSTOOLCHAIN_PKG_NAME='mxetoolchain-x86_64-w64-mingw32'
 
@@ -51,7 +51,7 @@ function is_linux() {
 }
 
 function is_windows_target() {
-  [[ "$TARGET_SYSTEM_NAME" =~ Windows ]]
+  [[ "$TARGET_OS" =~ windows ]]
 }
 
 function joinPath() {

--- a/shell.nix
+++ b/shell.nix
@@ -27,6 +27,7 @@ in _mkShell {
     wget
   ] ++ lib.optionals targetMobile [ bundler ruby ]; # bundler/ruby used for fastlane
   inputsFrom = [ projectDeps ];
+  TARGET_OS=target-os;
   shellHook =
     ''
       set -e


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

### Summary
[comment]: # (Summarise the problem and how the pull request solves it)
This PR adds support for building on Linux with `--pure` flag (more platforms to follow, in baby steps), so that we have more guarantees that we're not using something from the host environment and contaminating our build.
The nix cache builds are also run with `--pure` (Linux and macOS).

### Review notes
I've consolidated 3 environment variables which served the same purpose into `TARGET_OS`. This variable is now defined in the Makefile and also [made into an environment variable](https://github.com/status-im/status-react/pull/7971/files#diff-5204cbe23b218cae9de0b1aedd4edcd2R30
) in shell.nix. Therefore there's no longer a need to define `TARGET_SYSTEM_NAME=Windows` before invoking `build-desktop.sh`.

status: ready <!-- Can be ready or wip -->

