### PR TITLE
[#7890] handle wrong keycard when signing

### DIFF
--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -1417,6 +1417,16 @@
  (fn [cofx _]
    (hardwallet/sign cofx)))
 
+(handlers/register-handler-fx
+ :hardwallet/prepare-to-sign
+ (fn [cofx _]
+   (hardwallet/prepare-to-sign cofx)))
+
+(handlers/register-handler-fx
+ :hardwallet/unblock-pin
+ (fn [cofx _]
+   (hardwallet/unblock-pin cofx)))
+
 ;; browser module
 
 (handlers/register-handler-fx


### PR DESCRIPTION
fixes #7890 

### Summary

When wrong keycard is used for signing (not the one used for login), show user a warning.

status: ready