### PR TITLE
Update SimplDapp in e2e to use github url

### DIFF
--- a/test/appium/tests/atomic/dapps_and_browsing/test_deep_links.py
+++ b/test/appium/tests/atomic/dapps_and_browsing/test_deep_links.py
@@ -44,7 +44,7 @@ class TestDeepLinks(SingleDeviceTestCase):
         sign_in_view = SignInView(self.driver)
         sign_in_view.create_user()
         self.driver.close_app()
-        dapp_name = 'simpledapp.eth'
+        dapp_name = 'status-im.github.io/dapp'
         dapp_deep_link = 'https://get.status.im/browse/%s' % dapp_name
         sign_in_view.open_weblink_and_login(dapp_deep_link)
         web_view = sign_in_view.get_chat_view()

--- a/test/appium/views/home_view.py
+++ b/test/appium/views/home_view.py
@@ -200,7 +200,7 @@ class HomeView(BaseView):
 
     def open_status_test_dapp(self, allow_all=True):
         dapp_view = self.dapp_tab_button.click()
-        dapp_view.open_url('simpledapp.eth')
+        dapp_view.open_url('status-im.github.io/dapp')
         status_test_dapp = dapp_view.get_status_test_dapp_view()
         for _ in range(2):
             if allow_all:


### PR DESCRIPTION
Updated test dapp to use`status-im.github.io/dapp` link from `sipledapp.eth` (`sipledapp.eth` leads to infura which may be unstable. We'll have separate test for verification of `sipledapp.eth`)