### PR TITLE
Fix running desktop in dev mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,6 @@ HOST_OS := $(shell uname | tr '[:upper:]' '[:lower:]')
 export NIX_CONF_DIR = $(PWD)/nix
 
 export REACT_SERVER_PORT ?= 5001 # any value different from default 5000 will work; this has to be specified for both the Node.JS server process and the Qt process
-export STATUS_NODE_PORT ?= 12345 # no need to specify this if just running dev instance alongside release build
-export STATUS_DATA_DIR ?= ~/status-files/data1 # this is where Realm data files, Geth node data, and logs will reside; also not strictly needed for dev alongside release
 
 # WARNING: This has to be located right before the targets
 ifdef IN_NIX_SHELL


### PR DESCRIPTION

fixes #7998

### Summary

Setting `STATUS_DATA_DIR` in Makefile caused the issue. It would be nice to have more deep investigation on why realm folder creation doesn't work well with custom `STATUS_DATA_DIR`. But as a quick solution to prevent blocking it just removed from Makefile for now.

### Testing notes
Shouldn't affect any functionality.

#### Platforms
- macOS
- Linux
- Windows

#### Areas that maybe impacted
- login

##### Functional
- account recovery
- new account

### Steps to test
- Open Status
- Make sure there is no error message "unable to decrypt database"

status: ready