### PR TITLE
Block user from 1-1 chat header

### DIFF
--- a/test/appium/tests/atomic/chats/test_chats_management.py
+++ b/test/appium/tests/atomic/chats/test_chats_management.py
@@ -1,7 +1,7 @@
 import pytest
 import time
 
-from tests import marks, camera_access_error_text
+from tests import marks, camera_access_error_text, get_current_time
 from tests.users import basic_user
 from tests.base_test_case import SingleDeviceTestCase, MultipleDeviceTestCase
 from views.sign_in_view import SignInView
@@ -219,5 +219,151 @@ class TestChatManagementMultipleDevice(MultipleDeviceTestCase):
         contacts_1 = home_1.start_new_chat_button.click()
         if not contacts_1.element_by_text(username).is_element_displayed():
             self.errors.append("List of contacts doesn't contain added user")
+
+        self.verify_no_errors()
+
+    @marks.testrail_id(5786)
+    @marks.critical
+    def test_block_user_from_public_chat(self):
+        self.create_drivers(2)
+        device_1, device_2 = SignInView(self.drivers[0]), SignInView(self.drivers[1])
+        username_1 = 'user_%s' % get_current_time()
+        message_before_block_1, message_before_block_2 = "Before block from %s" % device_1.driver.number, "Before block from %s" % device_2.driver.number
+        message_after_block_2 = "After block from %s" % device_2.driver.number
+        home_1, home_2 = device_1.create_user(username=username_1), device_2.recover_access(basic_user['passphrase'])
+
+        # device 1, device 2: join to public chat and send several messages
+        chat_name = device_1.get_public_chat_name()
+        for home in home_1, home_2:
+            home.join_public_chat(chat_name)
+        chat_public_1, chat_public_2 = home_1.get_chat_view(), home_2.get_chat_view()
+        for chat in chat_public_1, chat_public_2:
+            chat.chat_message_input.send_keys("Before block from %s" % chat.driver.number)
+            chat.send_message_button.click()
+
+        # device 1: block user from public chat
+        chat_element = chat_public_1.chat_element_by_text(message_before_block_2)
+        chat_element.find_element()
+        chat_element.member_photo.click()
+        chat_public_1.profile_block_contact.click()
+        chat_public_1.block_button.click()
+
+        # device 1: check that messages from blocked user are hidden in public chat
+        if chat_public_1.chat_element_by_text(message_before_block_2).is_element_displayed():
+            self.errors.append(
+                "Messages from blocked user %s are not cleared in public chat '%s'" % (device_2.driver.number, chat_name))
+
+        # device 1: close app
+        self.drivers[0].close_app()
+
+        # device 2: send message to public chat while device 1 is offline
+        chat_public_2.chat_message_input.send_keys(message_after_block_2)
+        chat_public_2.send_message_button.click()
+
+        # device 1: check that new messages from blocked user are not delivered
+        self.drivers[0].launch_app()
+        device_1.accept_agreements()
+        device_1.sign_in()
+        home_1.join_public_chat(chat_name)
+        for message in message_before_block_2, message_after_block_2:
+            if chat_public_1.chat_element_by_text(message).is_element_displayed():
+                self.errors.append(
+                    "'%s' from blocked user %s are shown in public chat" % (message, device_2.driver.number))
+
+    @marks.testrail_id(5763)
+    @marks.high
+    def test_block_user_from_one_to_one_header(self):
+
+        self.create_drivers(2)
+        device_1, device_2 = SignInView(self.drivers[0]), SignInView(self.drivers[1])
+        username_1 = 'user_%s' % get_current_time()
+        message_before_block_1, message_before_block_2 = "Before block from %s" % device_1.driver.number, "Before block from %s" % device_2.driver.number
+        message_after_block_2 = "After block from %s" % device_2.driver.number
+        home_1, home_2 = device_1.create_user(username=username_1), device_2.recover_access(basic_user['passphrase'])
+
+        # device 1, device 2: join to public chat and send several messages
+        chat_name = device_1.get_public_chat_name()
+        for home in home_1, home_2:
+            home.join_public_chat(chat_name)
+        chat_public_1, chat_public_2 = home_1.get_chat_view(), home_2.get_chat_view()
+        for chat in chat_public_1, chat_public_2:
+            chat.chat_message_input.send_keys("Before block from %s" % chat.driver.number)
+            chat.send_message_button.click()
+
+        home_1, home_2 = chat_public_1.get_back_to_home_view(), chat_public_2.get_back_to_home_view()
+
+        #  device 1, device 2: create 1-1 chat and send there several messages
+        chat_1 = home_1.add_contact(basic_user['public_key'])
+        for _ in range(2):
+            chat_1.chat_message_input.send_keys(message_before_block_1)
+            chat_1.send_message_button.click()
+
+        chat_2 = home_2.get_chat_with_user(username_1).click()
+        for _ in range(2):
+            chat_2.chat_message_input.send_keys(message_before_block_2)
+            chat_2.send_message_button.click()
+
+        #  device 1: block user from chat header
+        chat_1.chat_options.click()
+        chat_1.view_profile_button.click()
+        chat_1.profile_block_contact.click()
+        chat_1.block_button.click()
+
+        # device 1: check that chat with blocked user was deleted and messages from blocked user are hidden in public chat
+        if home_1.get_chat_with_user(basic_user['username']).is_element_displayed():
+            pytest.fail("Chat with blocked user '%s' is not deleted" % device_2.driver.number)
+
+        public_chat_after_block = home_1.join_public_chat(chat_name)
+        if public_chat_after_block.chat_element_by_text(message_before_block_2).is_element_displayed():
+            self.errors.append(
+                "Messages from blocked user '%s' are not cleared in public chat '%s'" % (device_2.driver.number,
+                chat_name))
+
+        # device 2: send messages to 1-1 and public chat
+        for _ in range(2):
+            chat_2.chat_message_input.send_keys(message_after_block_2)
+            chat_2.send_message_button.click()
+        home_2 = chat_2.get_back_to_home_view()
+        home_2.join_public_chat(chat_name)
+        chat_public_2 = home_2.get_chat_view()
+
+        for _ in range(2):
+            chat_public_2.chat_message_input.send_keys(message_after_block_2)
+            chat_public_2.send_message_button.click()
+
+        # device 1: check that new messages sent from device 2 are not shown
+        if public_chat_after_block.chat_element_by_text(message_after_block_2).is_element_displayed():
+            self.errors.append("Message from blocked user '%s' is received" % device_2.driver.number)
+        home_1 = public_chat_after_block.get_back_to_home_view()
+
+        if home_1.get_chat_with_user(basic_user['username']).is_element_displayed():
+            pytest.fail(
+                "Chat with blocked user '%s' is reappeared after receiving new messages" % device_2.driver.number)
+
+        # device 1: close app
+        self.drivers[0].close_app()
+
+        # device 2: send message to 1-1 and public chat while device 1 is offline
+        for _ in range(2):
+            chat_public_2.chat_message_input.send_keys(message_after_block_2)
+            chat_public_2.send_message_button.click()
+        home_2 = chat_public_2.get_back_to_home_view()
+        chat_2 = home_2.get_chat_with_user(username_1).click()
+        for _ in range(2):
+            chat_2.chat_message_input.send_keys(message_after_block_2)
+            chat_2.send_message_button.click()
+
+        # device 1: check that messages from blocked user are not fetched from offline
+        self.drivers[0].launch_app()
+        device_1.accept_agreements()
+        device_1.sign_in()
+        if home_1.get_chat_with_user(basic_user['username']).is_element_displayed():
+            pytest.fail(
+                "Chat with blocked user '%s' is reappeared after fetching new messages from offline" % device_2.driver.number)
+        home_1.join_public_chat(chat_name)
+        chat_public_1 = home_1.get_chat_view()
+        if chat_public_1.chat_element_by_text(message_after_block_2).is_element_displayed():
+            self.errors.append(
+                "Message from blocked user '%s' is received after fetching new messages from offline" % device_2.driver.number)
 
         self.verify_no_errors()

--- a/test/appium/views/chat_view.py
+++ b/test/appium/views/chat_view.py
@@ -121,6 +121,12 @@ class ClearButton(BaseButton):
         super(ClearButton, self).__init__(driver)
         self.locator = self.Locator.xpath_selector('//*[@text="CLEAR"]')
 
+class BlockButton(BaseButton):
+
+    def __init__(self, driver):
+        super(BlockButton, self).__init__(driver)
+        self.locator = self.Locator.xpath_selector('//*[@text="BLOCK"]')
+
 
 class LeaveButton(BaseButton):
 
@@ -199,6 +205,10 @@ class ProfileSendTransactionButton(BaseButton):
         super(ProfileSendTransactionButton, self).__init__(driver)
         self.locator = self.Locator.accessibility_id('send-transaction-button')
 
+class ProfileBlockContactButton(BaseButton):
+    def __init__(self, driver):
+        super(ProfileBlockContactButton, self).__init__(driver)
+        self.locator = self.Locator.accessibility_id('block-contact')
 
 class JoinChatButton(BaseButton):
     def __init__(self, driver):
@@ -341,6 +351,7 @@ class ChatView(BaseView):
         self.delete_chat_button = DeleteChatButton(self.driver)
         self.clear_history_button = ClearHistoryButton(self.driver)
         self.clear_button = ClearButton(self.driver)
+        self.block_button = BlockButton(self.driver)
 
         # Group chats
         self.group_info = GroupInfoButton(self.driver)
@@ -366,6 +377,7 @@ class ChatView(BaseView):
         self.profile_send_message = ProfileSendMessageButton(self.driver)
         self.profile_send_transaction = ProfileSendTransactionButton(self.driver)
         self.profile_address_text = ProfileAddressText(self.driver)
+        self.profile_block_contact = ProfileBlockContactButton(self.driver)
 
     def wait_for_syncing_complete(self):
         self.driver.info('Waiting for syncing complete:')


### PR DESCRIPTION
Tests a bit complicated, but I don't see any reason to split it, because we need to check that messages from blocked user are deleted from public and 1-1 chat and are not reappered. 

I decided that deleting user messages after blocking from group chat can be separate test with high priority, so modified https://ethstatus.testrail.net/index.php?/cases/view/5763  (to avoid overcomplicating this test, which is already too big)