### PR TITLE
[fix] fetch wallet token transactions

### DIFF
--- a/src/status_im/ui/screens/wallet/events.cljs
+++ b/src/status_im/ui/screens/wallet/events.cljs
@@ -147,7 +147,8 @@
  :update-transactions
  (fn [{:keys [db]} _]
    {::wallet.transactions/sync-transactions-now
-    (select-keys db [:network-status :account/account :app-state :network :web3])}))
+    (select-keys db [:network-status :account/account :wallet/all-tokens
+                     :app-state :network :web3])}))
 
 (handlers/register-handler-fx
  :update-balance-success


### PR DESCRIPTION
- previously wallet transaction fetching was quite hazardous
- most of the time the `:wallet/all-tokens` map was nil so no token
was recognized
- the query for transfers was made accross 100000 blocks, now it
only checks that the first time, then from latest block checked minus
12 to follow progress of unconfirmed transactions

blocking tribute to talk

### Steps to test

send snt/stt to the account (no with another account which sends a message), unlike before the transaction should appear in transaction list

status: ready