### PR TITLE
[Fixed #7948] Do not navigate back to chat when in a DApp

### DIFF
--- a/src/status_im/ui/screens/routing/browser_stack.cljs
+++ b/src/status_im/ui/screens/routing/browser_stack.cljs
@@ -3,5 +3,6 @@
 (def browser-stack
   {:name       :browser-stack
    :screens    [:open-dapp
-                :browser]
+                :browser
+                :qr-scanner]
    :config     {:initialRouteName :open-dapp}})


### PR DESCRIPTION


fixes #7948

### Summary

Do not navigate back to chat when in a DApp

status: ready