### PR TITLE
Maintain scroll position after fetching gap

### DIFF
--- a/src/status_im/chat/db.cljs
+++ b/src/status_im/chat/db.cljs
@@ -112,13 +112,18 @@
                                    (- next-whisper-timestamp next-timestamp))
                                   120)]
     (reduce
-     (fn [acc {:keys [from id]}]
+     (fn [acc {:keys [from to id]}]
        (if (and next-message
                 (not ignore-next-message?)
                 (or
                  (and (nil? previous-timestamp)
                       (< from next-whisper-timestamp))
-                 (< previous-timestamp from next-whisper-timestamp)))
+                 (and
+                  (< previous-timestamp from)
+                  (< to next-whisper-timestamp))
+                 (and
+                  (< from previous-timestamp)
+                  (< to next-whisper-timestamp))))
          (-> acc
              (update :gaps-number inc)
              (update-in [:gap :ids] conj id))

--- a/src/status_im/ui/screens/chat/actions.cljs
+++ b/src/status_im/ui/screens/chat/actions.cljs
@@ -45,24 +45,24 @@
   [(view-profile chat-id)
    (clear-history)
    (fetch-history chat-id)
-   #_(fetch-history48-60 chat-id)
-   #_(fetch-history84-96 chat-id)
+   (fetch-history48-60 chat-id)
+   (fetch-history84-96 chat-id)
    (delete-chat chat-id false)])
 
 (defn- group-chat-actions [chat-id]
   [(group-info chat-id)
    (clear-history)
    (fetch-history chat-id)
-   #_(fetch-history48-60 chat-id)
-   #_(fetch-history84-96 chat-id)
+   (fetch-history48-60 chat-id)
+   (fetch-history84-96 chat-id)
    (delete-chat chat-id true)])
 
 (defn- public-chat-actions [chat-id]
   [(share-chat chat-id)
    (clear-history)
    (fetch-history chat-id)
-   #_(fetch-history48-60 chat-id)
-   #_(fetch-history84-96 chat-id)
+   (fetch-history48-60 chat-id)
+   (fetch-history84-96 chat-id)
    (delete-chat chat-id false)])
 
 (defn actions [group-chat? chat-id public?]

--- a/test/cljs/status_im/test/chat/db.cljs
+++ b/test/cljs/status_im/test/chat/db.cljs
@@ -207,6 +207,9 @@
             :timestamp-str     "14:00"
             :user-statuses     nil
             :datemark          "today"}
+           {:type  :gap
+            :value ":gapid1"
+            :gaps  {:ids [:gapid1]}}
            {:whisper-timestamp 30
             :timestamp         30
             :content           nil
@@ -217,9 +220,6 @@
             :type              :datemark
             :whisper-timestamp 30
             :timestamp         30}
-           {:type  :gap
-            :value ":gapid1"
-            :gaps  {:ids [:gapid1]}}
            {:whisper-timestamp 20
             :timestamp         20
             :content           nil


### PR DESCRIPTION
1. previously the gap was shown before the first message which has `timestamp` higher than gap's `from`; in this PR the gap is shown after all messages which `timestamp` is lower than gap, also after messages which are inside the gap and before the first message which `timestamp` is higher than gap's `to`. 
    before:
    ```
    message A (T=10)
    gap (20-30)
    message B (25)
    message C (35)
    ```

    after:
    ```
    message A (T=10)
    message B (25)
    gap (20-30)
    message C (35)
    ```

    This minimizes chances that requested messages will be rendered between messages B and C instead of rendering between gap and C. In result, we can scroll to message C before loading and bottom side of the chat will maintain the same position after fetching messages (no guaranty but higher chances).

2. Before fetching the gap, the list is scrolled so that the next message after the gap (message C in the example above) is placed in the center of the screen. In this case, after rendering of the newly fetched messages, the user will still be able to see older, already seen messages along with new rendered messages which will replace gap above that "message C"

In some cases the app will behave properly without these changes, it depends on a number of referenced messages which are fetched and have to be rendered in responses. Also, messages like `B` might not be present in the chat's history.

status: ready