### PR TITLE
feature #4959 - eip-55 in wallet send and request

### DIFF
--- a/src/status_im/ui/screens/wallet/choose_recipient/events.cljs
+++ b/src/status_im/ui/screens/wallet/choose_recipient/events.cljs
@@ -84,9 +84,7 @@
                           :ens-name recipient
                           :cb       #(re-frame/dispatch [:wallet.send/set-recipient %])}}
        (if (ethereum/address? recipient)
-         (if (-> recipient
-                 ethereum/address->checksum
-                 eip55/valid-address-checksum?)
+         (if (eip55/valid-address-checksum? recipient)
            {:db       (assoc-in db [:wallet :send-transaction :to] recipient)
             :dispatch [:navigate-back]}
            {:ui/show-error (i18n/label :t/wallet-invalid-address-checksum {:data recipient})})

--- a/src/status_im/ui/screens/wallet/components/views.cljs
+++ b/src/status_im/ui/screens/wallet/components/views.cljs
@@ -27,7 +27,8 @@
             [status-im.ui.components.toolbar.actions :as actions]
             [status-im.ui.components.toolbar.view :as toolbar]
             [status-im.ui.components.status-bar.view :as status-bar]
-            [status-im.ui.components.icons.vector-icons :as vector-icons]))
+            [status-im.ui.components.icons.vector-icons :as vector-icons]
+            [status-im.utils.ethereum.eip55 :as eip55]))
 
 ;; Wallet tab has a different coloring scheme (dark) that forces color changes (background, text)
 ;; It might be replaced by some theme mechanism
@@ -176,7 +177,7 @@
 (defn- recipient-address [address modal?]
   [react/text {:style               (merge styles/recipient-address (when-not address styles/recipient-no-address))
                :accessibility-label :recipient-address-text}
-   (or (ethereum/normalized-address address)
+   (or (eip55/address->checksum (ethereum/normalized-address address))
        (if modal?
          (i18n/label :t/new-contract)
          (i18n/label :t/specify-recipient)))])
@@ -195,7 +196,7 @@
          name]
         [react/text {:style               (styles/participant (and (not name) address?))
                      :accessibility-label (if request? :contact-address-text :recipient-address-text)}
-         (ethereum/normalized-address address)]]])))
+         (eip55/address->checksum (ethereum/normalized-address address))]]])))
 
 (defn render-contact [contact request?]
   [list/touchable-item #(re-frame/dispatch [:wallet/fill-request-from-contact contact request?])
@@ -206,7 +207,7 @@
       (:name contact)]
      [react/text {:style list.styles/secondary-text
                   :accessibility-label :contact-address-text}
-      (ethereum/normalized-address (:address contact))]]]])
+      (eip55/address->checksum (ethereum/normalized-address (:address contact)))]]]])
 
 (views/defview recent-recipients []
   (views/letsubs [contacts           [:contacts/active]

--- a/src/status_im/ui/screens/wallet/request/views.cljs
+++ b/src/status_im/ui/screens/wallet/request/views.cljs
@@ -23,7 +23,8 @@
             [status-im.utils.ethereum.tokens :as tokens]
             [status-im.ui.screens.wallet.utils :as wallet.utils]
             [status-im.ui.screens.chat.photos :as photos]
-            [status-im.ui.components.list.styles :as list.styles]))
+            [status-im.ui.components.list.styles :as list.styles]
+            [status-im.utils.ethereum.eip55 :as eip55]))
 
 ;; Request screen
 
@@ -94,4 +95,4 @@
         :footer-button send-transaction-request-button
         :value         (eip681/generate-uri address-hex {:chain-id chain-id})
         :hint          (i18n/label :t/request-qr-legend)
-        :legend        address-hex}]]]))
+        :legend        (eip55/address->checksum address-hex)}]]]))

--- a/src/status_im/utils/ethereum/core.cljs
+++ b/src/status_im/utils/ethereum/core.cljs
@@ -50,10 +50,6 @@
   (when s
     (.isAddress dependencies/Web3.prototype s)))
 
-(defn address->checksum [s]
-  (when s
-    (.toChecksumAddress dependencies/Web3.prototype s)))
-
 (defn network->chain-id [network]
   (get-in network [:config :NetworkId]))
 

--- a/src/status_im/utils/ethereum/eip55.cljs
+++ b/src/status_im/utils/ethereum/eip55.cljs
@@ -5,18 +5,17 @@
 
    e.g. 0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed"
   (:require [clojure.string :as string]
-            [status-im.utils.ethereum.core :as ethereum]))
+            [status-im.js-dependencies :as dependencies]))
 
-(defn valid-address-checksum? [address]
-  "verify address checksum according to EIP 55"
-  (let [adHash (ethereum/naked-address (ethereum/sha3
-                                        (string/lower-case (ethereum/naked-address address))))]
-    (every? true?
-            (map-indexed (fn [idx char]
-                           (if (> (compare char "9") 0)
-                             (if (>= (js/parseInt (nth adHash idx) 16) 8)
-                                ;  If true should be upper case
-                               (<= (compare char "Z") 0)
-                                ; If not should be lower case
-                               (> (compare char "Z") 0))
-                             true)) (ethereum/naked-address address)))))
+(def utils dependencies/web3-utils)
+
+(defn address->checksum
+  "Converts an arbitrary case address to one with correct checksum case."
+  [address]
+  (when address
+    (.toChecksumAddress utils address)))
+
+(defn valid-address-checksum?
+  "Checks address checksum validity."
+  [address]
+  (.checkAddressChecksum utils address))


### PR DESCRIPTION
fixes #4959

### Summary

This PR makes sure we consistently comply with EIP-55. Specifically:

- refactors EIP-55 validation and re-enables it
- formats the displayed address in Wallet > Receive in the EIP-55 compliant way

### Steps to test

Send:

- Wallet > Send > by address 
- paste a non-checksummed address - there should be validation error
- paste a checksummed address - it should pass

Receive:

- Wallet > Receive > long tap & copy address
- paste it in Wallet > Send > by address (same app version) - it should pass
- also verify that the address is checksummed and try it out in some other app that checks for checksummed addresses


status: ready