### PR TITLE
add diawi upload retries

### DIFF
--- a/ci/common.groovy
+++ b/ci/common.groovy
@@ -36,8 +36,8 @@ def notifyPR(success) {
   } catch (ex) { /* fallback to posting directly to GitHub */
     println "Failed to use GHCMGR: ${ex}"
     switch (success) {
-      case true:  gh.NotifyPRSuccess(); break
-      case false: gh.NotifyPRFailure(); break
+      case true:  gh.notifyPRSuccess(); break
+      case false: gh.notifyPRFailure(); break
     }
   }
 }

--- a/ci/github.groovy
+++ b/ci/github.groovy
@@ -10,7 +10,7 @@ utils = load 'ci/utils.groovy'
 
 def notify(message) {
   def githubIssuesUrl = 'https://api.github.com/repos/status-im/status-react/issues'
-  def changeId = changeId() 
+  def changeId = utils.changeId() 
   if (changeId == null) { return }
   def msgObj = [body: message]
   def msgJson = new JsonBuilder(msgObj).toPrettyString()

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -161,10 +161,11 @@ end
 
 def upload_to_diawi(source)
     diawi(
-        token: ENV["DIAWI_TOKEN"],
-        file: source
+        file: source,
+        last_hope_attempts_count: 3,
+        token: ENV["DIAWI_TOKEN"]
     )
-
+    # save the URL to a file for use in CI
     File.write("diawi.out", lane_context[SharedValues::UPLOADED_FILE_LINK_TO_DIAWI])
 end
 


### PR DESCRIPTION
This is in response to a weird case where Diawi upload silently failed:

```log
[13:46:17]: Start uploading file to diawi. Please, be patient. This could take some time.
[13:46:20]: Processing file...
[13:46:22]: Processing file...
[13:46:24]: File is not processed.
[13:46:24]: Try to upload file by yourself: StatusIm-190424-122020-0e4704-pr.ipa
```

https://ci.status.im/job/status-react/job/prs/job/ios/job/PR-8029/1/console

I opened an issue but this could also help: https://github.com/pacification/fastlane-plugin-diawi/issues/10

I also added checking of response from `ghcmgr` to mark `Post` stage as failed without having to use teh `--fail` flag which hides response to the request.

