### PR TITLE
updating dev dependencies

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -21,16 +21,16 @@
                  :sha "144eeecfb389edd9b5d4d94507acf828c5265b97"}
 
          ;; Figwheel ClojureScript REPL
-         cider/piggieback        {:mvn/version "0.3.9"
+         cider/piggieback        {:mvn/version "0.4.0"
                                   :exclusions  [com.google.javascript/closure-compiler]}
-         figwheel-sidecar        {:mvn/version "0.5.18-SNAPSHOT"}
+         figwheel-sidecar        {:mvn/version "0.5.18"}
          re-frisk-remote         {:mvn/version "0.5.5"}
          re-frisk-sidecar        {:mvn/version "0.5.7"}
          hawk                    {:mvn/version "0.2.11"}
          day8.re-frame/tracing   {:mvn/version "0.5.0"}
 
          ;; CIDER compatible nREPL
-         cider/cider-nrepl       {:mvn/version "0.18.0"}
+         cider/cider-nrepl       {:mvn/version "0.21.1"}
          refactor-nrepl          {:mvn/version "2.4.0"}}}
   :test {:extra-deps {day8.re-frame/test {:mvn/version "0.1.5"}
                       doo                {:mvn/version "0.1.9"}}}}}

--- a/project.clj
+++ b/project.clj
@@ -40,7 +40,7 @@
             "test-cljs"          ["with-profile" "test" "doo" "node" "test" "once"]
             "test-protocol"      ["with-profile" "test" "doo" "node" "protocol" "once"]
             "test-env-dev-utils" ["with-profile" "test" "doo" "node" "env-dev-utils" "once"]}
-  :profiles {:dev      {:dependencies [[cider/piggieback "0.3.9"]]
+  :profiles {:dev      {:dependencies [[cider/piggieback "0.4.0"]]
                         :cljsbuild    {:builds
                                        {:ios
                                         {:source-paths ["components/src" "react-native/src/cljsjs" "react-native/src/mobile" "src"]
@@ -64,7 +64,7 @@
                         :repl-options {:nrepl-middleware [cider.piggieback/wrap-cljs-repl]
                                        :timeout          240000}}
              :figwheel [:dev
-                        {:dependencies [[figwheel-sidecar "0.5.18-SNAPSHOT"]
+                        {:dependencies [[figwheel-sidecar "0.5.18"]
                                         [re-frisk-remote "0.5.5"]
                                         [re-frisk-sidecar "0.5.7"]
                                         [day8.re-frame/tracing "0.5.0"]


### PR DESCRIPTION
update cider and figwheel (more importantly use release of figwheel instead of snapshot)

status: ready