### PR TITLE
Fix broken contact syncing

### DIFF
--- a/src/status_im/transport/impl/send.cljs
+++ b/src/status_im/transport/impl/send.cljs
@@ -29,9 +29,8 @@
   protocol/StatusMessage
   (send [this chat-id cofx]
     (let [sync-message (transport.pairing/SyncInstallation.
-                        (select-keys
-                         (get-in cofx [:db :contacts/contacts])
-                         [chat-id])
+                        {chat-id (pairing/contact->pairing
+                                  (get-in cofx [:db :contacts/contacts chat-id]))}
                         nil
                         nil)]
       (fx/merge cofx

--- a/translations/en.json
+++ b/translations/en.json
@@ -194,7 +194,7 @@
     "devices": "Devices",
     "learn-more": "Learn more",
     "pair": "Pair devices",
-    "pair-this-device": "Pair this device",
+    "pair-this-device": "Advertise device",
     "pair-this-device-description": "Pair your devices to sync contacts and chats between them",
     "you": "you",
     "syncing-enabled": "Syncing enabled",


### PR DESCRIPTION
Fixes: #8030 
Contact syncing between 0.11 & 0.12 was not working properly as we were not setting the `pending?` flag in some cases.
Changes the copy from `Pair this device` to `Advertise device`, as it better captures the action.

status: ready