### PR TITLE
workaround issue with building iOS release builds

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -217,6 +217,7 @@ platform :ios do
         clean: true,
         export_method: "app-store",
         output_directory: "status_appstore",
+        include_symbols: false,
         # Temporary fix for Xcode 10.1
         xcargs: "-UseModernBuildSystem=N",
         export_options: {


### PR DESCRIPTION
no app code is affected, and it solves "[Symbols tool failed](https://stackoverflow.com/questions/26882037/symbols-tool-failed-error-while-exporting-iphone-application-with-app-store-pr)" issue.

status: ready <!-- Can be ready or wip -->