### PR TITLE
[fix 8054] network in app-db is not always correct

### DIFF
--- a/src/status_im/init/core.cljs
+++ b/src/status_im/init/core.cljs
@@ -188,7 +188,7 @@
                         :accounts/accounts accounts
                         :mailserver/mailservers mailservers
                         :network-status network-status
-                        :network network
+                        :network account-network
                         :network/type (:network/type db)
                         :chain (ethereum/network->chain-name account-network)
                         :universal-links/url url
@@ -270,4 +270,3 @@
 (re-frame/reg-fx
  :init/reset-account-data
  reset-account-data!)
-


### PR DESCRIPTION
- when login in after a different account using a different network
the new account inherited the network from the previous one
- this fixes it by using the account network when initializing app-db
instead of reusing current network


status: ready