### PR TITLE
[#7898] remove pin from alert message

### DIFF
--- a/src/status_im/hardwallet/core.cljs
+++ b/src/status_im/hardwallet/core.cljs
@@ -17,7 +17,8 @@
             [status-im.accounts.login.core :as accounts.login]
             [status-im.accounts.recover.core :as accounts.recover]
             [status-im.models.wallet :as models.wallet]
-            [status-im.utils.ethereum.mnemonic :as mnemonic]))
+            [status-im.utils.ethereum.mnemonic :as mnemonic]
+            [status-im.accounts.logout.core :as accounts.logout]))
 
 (def default-pin "000000")
 
@@ -653,8 +654,8 @@
                                      (assoc-in [:hardwallet :pin] {:status      nil
                                                                    :error-label nil}))
                :utils/show-popup {:title   ""
-                                  :content (i18n/label :t/pin-changed {:pin pin})}}
-              (navigation/navigate-back))))
+                                  :content (i18n/label :t/pin-changed)}}
+              (accounts.logout/logout))))
 
 (fx/defn on-change-pin-error
   [{:keys [db]} error]

--- a/translations/en.json
+++ b/translations/en.json
@@ -876,7 +876,7 @@
     "pin-mismatch": "PIN does not match",
     "tag-was-lost": "Tag was lost",
     "cannot-use-default-pin": "PIN 000000 is not allowed.\nPlease use another number",
-    "pin-changed": "PIN has been changed to {{pin}}",
+    "pin-changed": "PIN has been changed",
     "pin-retries-left": "You have {{number}} retries left",
     "keycard-blocked": "Keycard has been blocked.\nYou need to reset card to continue using it.",
     "reset-card": "Reset card",


### PR DESCRIPTION
fixes #7898

### Summary

Remove pin from alert message to improve security.

status: ready