### PR TITLE
Make Probot move reviewed PRs to E2E Tests column

### DIFF
--- a/.github/github-bot.yml
+++ b/.github/github-bot.yml
@@ -5,7 +5,7 @@ project-board:
   tested-pr-label-name: 'Tested - Issues'
   contributor-column-name: 'CONTRIBUTOR'
   review-column-name: 'REVIEW'
-  test-column-name: 'TO TEST'
+  test-column-name: 'E2E Tests'
 
 automated-tests:
   repo-full-name: 'status-im/status-react'


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

### Summary

[comment]: # (Summarise the problem and how the pull request solves it)
This tiny PR makes Probot move the reviewed PRs to `E2E Tests` instead of `TO TEST`.

status: ready <!-- Can be ready or wip -->