### PR TITLE
Split status-go Nix package per platform so rebuilds are faster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,6 @@ RED    := $(shell tput -Txterm setaf 1)
 WHITE  := $(shell tput -Txterm setaf 7)
 YELLOW := $(shell tput -Txterm setaf 3)
 RESET  := $(shell tput -Txterm sgr0)
-BOLD   := $(shell tput bold)
 HELP_FUN = \
 		   %help; \
 		   while(<>) { push @{$$help{$$2 // 'options'}}, [$$1, $$3] if /^([a-zA-Z\-]+)\s*:.*\#\#(?:@([a-zA-Z\-]+))?\s(.*)$$/ }; \

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -47,7 +47,7 @@ allprojects {
         jcenter()
         maven { url "$rootDir/../node_modules/react-native/android" }
         // for geth, function, and status-go
-        flatDir { dirs "libs", "${System.env.STATUS_GO_LIBDIR}/android" }
+        flatDir { dirs "libs", System.env.STATUS_GO_ANDROID_LIBDIR }
         maven { url "https://jitpack.io" }
     }
 }

--- a/derivation.nix
+++ b/derivation.nix
@@ -5,30 +5,13 @@
 
 with pkgs;
   let
-    sanitized-target-os = 
-      if (builtins.any (os: target-os == os) [ "linux" "android" "windows" "macos" "darwin" "ios" "all" ])
-      then target-os
-      else throw "Unknown value for target-os: '${target-os}'";
-    # based on the value passed in through target-os, check if we're targetting a desktop platform
-    targetDesktop = {
-      "linux" = true;
-      "windows" = true;
-      "macos" = true;
-      "darwin" = true;
-      "all" = true;
-    }.${sanitized-target-os} or false;
-    # based on the value passed in through target-os, check if we're targetting a mobile platform
-    targetMobile = {
-      "android" = true;
-      "ios" = true;
-      "all" = true;
-    }.${sanitized-target-os} or false;
+    platform = callPackage ./nix/platform.nix { inherit target-os; };
     # TODO: Try to use stdenv for iOS. The problem is with building iOS as the build is trying to pass parameters to Apple's ld that are meant for GNU's ld (e.g. -dynamiclib)
     _stdenv = stdenvNoCC;
     statusDesktop = callPackage ./nix/desktop { inherit target-os; stdenv = _stdenv; };
-    statusMobile = callPackage ./nix/mobile { inherit target-os config; status-go = status-go.package; stdenv = _stdenv; };
-    status-go = callPackage ./nix/status-go { inherit (xcodeenv) composeXcodeWrapper; inherit (statusMobile) xcodewrapperArgs; androidPkgs = statusMobile.androidComposition; };
-    nodejs' = pkgs.nodejs-10_x;
+    statusMobile = callPackage ./nix/mobile { inherit target-os config; stdenv = _stdenv; };
+    status-go = callPackage ./nix/status-go { inherit target-os; inherit (xcodeenv) composeXcodeWrapper; inherit (statusMobile) xcodewrapperArgs; androidPkgs = statusMobile.androidComposition; };
+    nodejs' = nodejs-10_x;
     yarn' = yarn.override { nodejs = nodejs'; };
     nodeInputs = import ./nix/global-node-packages/output {
       # The remaining dependencies come from Nixpkgs
@@ -49,16 +32,14 @@ with pkgs;
       leiningen
       maven
       watchman
-
-      status-go.package
-    ] ++ nodePkgBuildInputs
+    ] ++ status-go.packages
+      ++ nodePkgBuildInputs
       ++ lib.optional isDarwin cocoapods
       ++ lib.optional (!isDarwin) gcc7
-      ++ lib.optionals targetDesktop statusDesktop.buildInputs
-      ++ lib.optionals targetMobile statusMobile.buildInputs;
+      ++ lib.optionals platform.targetDesktop statusDesktop.buildInputs
+      ++ lib.optionals platform.targetMobile statusMobile.buildInputs;
     shellHook =
       status-go.shellHook +
-      lib.optionalString targetDesktop statusDesktop.shellHook +
-      lib.optionalString targetMobile statusMobile.shellHook;
-    hardeningDisable = status-go.hardeningDisable;
+      lib.optionalString platform.targetDesktop statusDesktop.shellHook +
+      lib.optionalString platform.targetMobile statusMobile.shellHook;
   }

--- a/modules/react-native-status/desktop/CMakeLists.txt
+++ b/modules/react-native-status/desktop/CMakeLists.txt
@@ -49,14 +49,14 @@ if (WIN32)
   set(REACT_NATIVE_DESKTOP_EXTERNAL_PROJECT_DEPS ${REACT_NATIVE_DESKTOP_EXTERNAL_PROJECT_DEPS} StatusGo_ep PARENT_SCOPE)
 else (WIN32)
   # For Linux and Darwin just use the Nix build of status-go
-  set(StatusGo_INCLUDE_DIR $ENV{STATUS_GO_INCLUDEDIR})
+  set(StatusGo_INCLUDE_DIR $ENV{STATUS_GO_DESKTOP_INCLUDEDIR})
   if (APPLE)
     set(StatusGo_PLATFORM "x86_64-darwin")
   else()
     set(StatusGo_PLATFORM "x86_64-linux")
   endif()
   set(StatusGo_STATIC_LIB
-      "$ENV{STATUS_GO_LIBDIR}/${StatusGo_PLATFORM}/${CMAKE_STATIC_LIBRARY_PREFIX}status${CMAKE_STATIC_LIBRARY_SUFFIX}")
+      "$ENV{STATUS_GO_DESKTOP_LIBDIR}/${StatusGo_PLATFORM}/${CMAKE_STATIC_LIBRARY_PREFIX}status${CMAKE_STATIC_LIBRARY_SUFFIX}")
 
   include_directories(${StatusGo_INCLUDE_DIR})
 

--- a/nix/desktop/default.nix
+++ b/nix/desktop/default.nix
@@ -4,19 +4,7 @@ with pkgs;
 with stdenv;
 
 let
-  targetLinux = {
-    "linux" = true;
-    "all" = isLinux;
-  }.${target-os} or false;
-  targetDarwin = {
-    "macos" = true;
-    "darwin" = true;
-    "all" = isDarwin;
-  }.${target-os} or false;
-  targetWindows = {
-    "windows" = true;
-    "all" = isLinux;
-  }.${target-os} or false;
+  platform = callPackage ../platform.nix { inherit target-os; };
   linuxPlatform = callPackage ./linux { };
   darwinPlatform = callPackage ./macos { };
   windowsPlatform = callPackage ./windows { };
@@ -27,18 +15,17 @@ in
       cmake
       extra-cmake-modules
       file
-    ] ++ lib.optionals targetLinux linuxPlatform.buildInputs
-      ++ lib.optionals targetDarwin darwinPlatform.buildInputs
-      ++ lib.optionals targetWindows windowsPlatform.buildInputs
-      ++ lib.optional (! targetWindows) qt5.full;
-    shellHook = (if target-os == "windows" then ''
-      unset QT_PATH
-    '' else ''
+    ] ++ lib.optionals platform.targetLinux linuxPlatform.buildInputs
+      ++ lib.optionals platform.targetDarwin darwinPlatform.buildInputs
+      ++ lib.optionals platform.targetWindows windowsPlatform.buildInputs
+      ++ lib.optional (! platform.targetWindows) qt5.full;
+    shellHook =
+    lib.optionalString (target-os != "windows") ''
       export QT_PATH="${qt5.full}"
       export QT_BASEBIN_PATH="${qt5.qtbase.bin}"
-      export PATH="${stdenv.lib.makeBinPath [ qt5.full ]}:$PATH"
-    '') +
-    lib.optionalString targetLinux linuxPlatform.shellHook +
-    lib.optionalString targetDarwin darwinPlatform.shellHook +
-    lib.optionalString targetWindows windowsPlatform.shellHook;
+      export PATH="${qt5.full}/bin:$PATH"
+    '' +
+    lib.optionalString platform.targetLinux linuxPlatform.shellHook +
+    lib.optionalString platform.targetDarwin darwinPlatform.shellHook +
+    lib.optionalString platform.targetWindows windowsPlatform.shellHook;
   }

--- a/nix/desktop/windows/default.nix
+++ b/nix/desktop/windows/default.nix
@@ -17,5 +17,6 @@ in
 
   shellHook = ''
     export STATUSREACT_WINDOWS_BASEIMAGE_PATH="${baseImage}/src"
+    unset QT_PATH
   '';
 }

--- a/nix/mobile/default.nix
+++ b/nix/mobile/default.nix
@@ -1,18 +1,11 @@
-{ config, stdenv, pkgs, target-os ? "all", status-go }:
+{ config, stdenv, pkgs, target-os ? "all" }:
 
 with pkgs;
 with stdenv;
 
 let
   gradle = gradle_4_10;
-  targetAndroid = {
-    "android" = true;
-    "all" = true;
-  }.${target-os} or false;
-  targetIOS = {
-    "ios" = true;
-    "all" = true;
-  }.${target-os} or false;
+  platform = pkgs.callPackage ../platform.nix { inherit target-os; };
   xcodewrapperArgs = {
     version = "10.1";
   };
@@ -25,11 +18,8 @@ in
     inherit xcodewrapperArgs;
 
     buildInputs =
-      lib.optional targetAndroid android.buildInputs ++
-      lib.optional (targetIOS && isDarwin) xcodeWrapper;
+      lib.optional platform.targetAndroid android.buildInputs ++
+      lib.optional (platform.targetIOS && isDarwin) xcodeWrapper;
     shellHook =
-      lib.optionalString targetIOS ''
-        export RCTSTATUS_FILEPATH=${status-go}/lib/ios/Statusgo.framework
-      '' +
-      lib.optionalString targetAndroid android.shellHook;
+      lib.optionalString platform.targetAndroid android.shellHook;
   }

--- a/nix/platform.nix
+++ b/nix/platform.nix
@@ -1,0 +1,48 @@
+{ target-os, stdenv }:
+
+with stdenv;
+
+assert lib.assertOneOf "target-os" target-os [ "linux" "android" "windows" "macos" "darwin" "ios" "all" ];
+
+let
+  # based on the value passed in through target-os, check if we're targetting a desktop platform
+  targetDesktop = {
+    "linux" = true;
+    "windows" = true;
+    "macos" = true;
+    "darwin" = true;
+    "all" = true;
+  }.${target-os} or false;
+  # based on the value passed in through target-os, check if we're targetting a mobile platform
+  targetMobile = {
+    "android" = true;
+    "ios" = true;
+    "all" = true;
+  }.${target-os} or false;
+  targetAndroid = {
+    "android" = true;
+    "all" = true;
+  }.${target-os} or false;
+  targetIOS = {
+    "ios" = true;
+    "all" = isDarwin;
+  }.${target-os} or false;
+  targetLinux = {
+    "linux" = true;
+    "all" = isLinux;
+  }.${target-os} or false;
+  targetDarwin = {
+    "macos" = true;
+    "darwin" = true;
+    "all" = isDarwin;
+  }.${target-os} or false;
+  targetWindows = {
+    "windows" = true;
+    "all" = isLinux;
+  }.${target-os} or false;
+
+in {
+  inherit targetDesktop targetMobile;
+  inherit targetAndroid targetIOS;
+  inherit targetLinux targetDarwin targetWindows;
+}

--- a/nix/status-go/build-desktop-status-go.nix
+++ b/nix/status-go/build-desktop-status-go.nix
@@ -1,0 +1,51 @@
+
+{ buildGoPackage, go, xcodeWrapper, pkgs, stdenv }:
+
+{ owner, repo, rev, version, goPackagePath, src, host,
+  goBuildFlags, goBuildLdFlags,
+  outputFileName,
+  hostSystem } @ args':
+
+with stdenv;
+
+let
+  args = removeAttrs args' [ "goBuildFlags" "goBuildLdFlags" "outputFileName" "hostSystem" ];
+  buildStatusGo = pkgs.callPackage ./build-status-go.nix { inherit buildGoPackage go xcodeWrapper; };
+
+  buildStatusGoDesktopLib = buildStatusGo (args // {
+    buildPhase = ''
+      runHook preBuild
+
+      runHook renameImports
+
+      pushd "$NIX_BUILD_TOP/go/src/${goPackagePath}" >/dev/null
+
+      echo
+      echo "Building desktop library"
+      echo
+      #GOOS=windows GOARCH=amd64 CGO_ENABLED=1 go build ${goBuildFlags} -buildmode=c-archive -o $out/${outputFileName} ./lib
+      go build -o $out/${outputFileName} ${goBuildFlags} -buildmode=c-archive ${goBuildLdFlags} ./lib
+
+      popd >/dev/null
+
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/lib/${hostSystem} $out/include
+      mv $out/${outputFileName} $out/lib/${hostSystem}
+      mv $out/libstatus.h $out/include
+
+      runHook postInstall
+    '';
+
+    outputs = [ "out" ];
+
+    meta = {
+      platforms = with lib.platforms; linux ++ darwin;
+    };
+  });
+
+in buildStatusGoDesktopLib

--- a/nix/status-go/build-mobile-status-go.nix
+++ b/nix/status-go/build-mobile-status-go.nix
@@ -1,0 +1,55 @@
+
+{ buildGoPackage, go, gomobile, openjdk, xcodeWrapper, pkgs, stdenv }:
+
+{ owner, repo, rev, version, goPackagePath, src, host,
+  goBuildFlags, goBuildLdFlags,
+  config } @ args':
+
+with stdenv;
+
+let
+  args = removeAttrs args' [ "config" "goBuildFlags" "goBuildLdFlags" ];
+  targetConfig = config;
+  buildStatusGo = pkgs.callPackage ./build-status-go.nix { inherit buildGoPackage go xcodeWrapper; };
+
+  buildStatusGoMobileLib = buildStatusGo (args // {
+    nativeBuildInputs = [ gomobile ] ++ lib.optional (targetConfig.name == "android") openjdk;
+
+    buildPhase = ''
+      runHook preBuild
+
+      runHook renameImports
+
+      # Build mobile libraries
+      # TODO: Manage to pass -s -w to -ldflags. Seems to only accept a single flag
+      echo
+      echo "Building mobile library for ${targetConfig.name}"
+      echo
+      GOPATH=${gomobile.dev}:$GOPATH \
+      PATH=${lib.makeBinPath [ gomobile.bin ]}:$PATH \
+      ${lib.concatStringsSep " " targetConfig.envVars} \
+      gomobile bind ${goBuildFlags} -target=${targetConfig.name} ${lib.concatStringsSep " " targetConfig.gomobileExtraFlags} \
+                    -o ${targetConfig.outputFileName} \
+                    ${goBuildLdFlags} \
+                    ${goPackagePath}/mobile
+
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/lib
+      mv ${targetConfig.outputFileName} $out/lib/
+
+      runHook postInstall
+    '';
+
+    outputs = [ "out" ];
+
+    meta = {
+      platforms = with lib.platforms; linux ++ darwin;
+    };
+  });
+
+in buildStatusGoMobileLib

--- a/nix/status-go/build-status-go.nix
+++ b/nix/status-go/build-status-go.nix
@@ -1,0 +1,65 @@
+{ buildGoPackage, go, xcodeWrapper, stdenv }:
+
+{ owner, repo, rev, version, goPackagePath, src, host,
+  nativeBuildInputs ? [],
+  buildPhase,
+  installPhase ? "",
+  postInstall ? "",
+  outputs, meta } @ args:
+
+with stdenv;
+
+let
+  removeReferences = [ go ];
+  removeExpr = refs: ''remove-references-to ${lib.concatMapStrings (ref: " -t ${ref}") refs}'';
+
+  buildStatusGo = buildGoPackage (args // {
+    name = "${repo}-${version}-${host}";
+
+    nativeBuildInputs = nativeBuildInputs ++ lib.optional isDarwin xcodeWrapper;
+
+    # Fixes Cgo related build failures (see https://github.com/NixOS/nixpkgs/issues/25959 )
+    hardeningDisable = [ "fortify" ];
+
+    # gomobile doesn't seem to be able to pass -ldflags with multiple values correctly to go build, so we just patch files here  
+    patchPhase = ''
+      date=$(date -u '+%Y-%m-%d.%H:%M:%S')
+
+      substituteInPlace cmd/statusd/main.go --replace \
+        "buildStamp = \"N/A\"" \
+        "buildStamp = \"$date\""
+      substituteInPlace params/version.go --replace \
+        "var Version string" \
+        "var Version string = \"${version}\""
+      substituteInPlace params/version.go --replace \
+        "var GitCommit string" \
+        "var GitCommit string = \"${rev}\""
+      substituteInPlace vendor/github.com/ethereum/go-ethereum/metrics/metrics.go --replace \
+        "var EnabledStr = \"false\"" \
+        "var EnabledStr = \"true\""
+    '';
+
+    # we print out the version so that we fail fast in case there's any problem running xcrun, instead of failing at the end of the build
+    preConfigure = lib.optionalString isDarwin ''
+      xcrun xcodebuild -version
+    '';
+
+    # remove hardcoded paths to go package in /nix/store, otherwise Nix will fail the build
+    preFixup = ''
+      find $out -type f -exec ${removeExpr removeReferences} '{}' + || true
+      return
+    '';
+
+    meta = {
+      # Add default meta information
+      inherit (meta) platforms;
+      description = meta.description or "The Status module that consumes go-ethereum.";
+      license = lib.licenses.mpl20;
+    } // meta // {
+      # add an extra maintainer to every package
+      maintainers = (meta.maintainers or []) ++
+                    [ lib.maintainers.pombeirp ];
+    };
+  });
+
+in buildStatusGo

--- a/nix/status-go/default.nix
+++ b/nix/status-go/default.nix
@@ -1,166 +1,96 @@
-{ stdenv, buildGoPackage, go, pkgs, fetchFromGitHub, openjdk, androidPkgs, composeXcodeWrapper, xcodewrapperArgs ? {} }:
+{ target-os, stdenv, buildGoPackage, go, pkgs, fetchFromGitHub, openjdk, androidPkgs, composeXcodeWrapper, xcodewrapperArgs ? {} }:
 
 with stdenv;
 
 let
-  extractStatusGoConfig = f: lib.last (lib.splitString "\n" (lib.fileContents f));
+  platform = pkgs.callPackage ../platform.nix { inherit target-os; };
   gomobile = pkgs.callPackage ./gomobile { inherit (androidPkgs) platform-tools; inherit composeXcodeWrapper xcodewrapperArgs; };
+  buildStatusGoDesktopLib = pkgs.callPackage ./build-desktop-status-go.nix { inherit buildGoPackage go pkgs xcodeWrapper; };
+  buildStatusGoMobileLib = pkgs.callPackage ./build-mobile-status-go.nix { inherit buildGoPackage go gomobile pkgs xcodeWrapper; };
+  extractStatusGoConfig = f: lib.last (lib.splitString "\n" (lib.fileContents f));
   owner = lib.fileContents ../../STATUS_GO_OWNER;
   version = extractStatusGoConfig ../../STATUS_GO_VERSION; # TODO: Simplify this path search with lib.locateDominatingFile
   sha256 = extractStatusGoConfig ../../STATUS_GO_SHA256;
   repo = "status-go";
   rev = version;
   goPackagePath = "github.com/${owner}/${repo}";
+  src = fetchFromGitHub { inherit rev owner repo sha256; };
+
   mobileConfigs = {
     android = {
       name = "android";
       outputFileName = "status-go-${version}.aar";
-      envVars = ''
-        ANDROID_HOME=${androidPkgs.androidsdk}/libexec/android-sdk \
-        ANDROID_NDK_HOME="${androidPkgs.ndk-bundle}/libexec/android-sdk/ndk-bundle" \
-      '';
-      gomobileExtraFlags = "";
+      envVars = [
+        "ANDROID_HOME=${androidPkgs.androidsdk}/libexec/android-sdk"
+        "ANDROID_NDK_HOME=${androidPkgs.ndk-bundle}/libexec/android-sdk/ndk-bundle"
+        "PATH=${lib.makeBinPath [ openjdk ]}:$PATH"
+      ];
+      gomobileExtraFlags = [];
     };
     ios = {
       name = "ios";
       outputFileName = "Statusgo.framework";
-      envVars = "";
-      gomobileExtraFlags = "-iosversion=8.0";
+      envVars = [];
+      gomobileExtraFlags = [ "-iosversion=8.0" ];
     };
   };
   hostConfigs = {
     darwin = {
-      mobileTargets = [ mobileConfigs.android mobileConfigs.ios ];
-      desktopOutputFileName = "libstatus.a";
+      name = "macos";
+      allTargets = [ status-go-packages.desktop status-go-packages.ios status-go-packages.android ];
     };
     linux = {
-      mobileTargets = [ mobileConfigs.android ];
-      desktopOutputFileName = "libstatus.a";
+      name = "linux";
+      allTargets = [ status-go-packages.desktop status-go-packages.android ];
     };
   };
   currentHostConfig = if isDarwin then hostConfigs.darwin else hostConfigs.linux;
-  currentHostMobileTargets = currentHostConfig.mobileTargets;
-  mobileBuildScript = lib.concatMapStrings (target: ''
-    echo
-    echo "Building mobile library for ${target.name}"
-    echo
-    GOPATH=${gomobile.dev}:$GOPATH \
-    PATH=${lib.makeBinPath [ gomobile.bin openjdk ]}:$PATH \
-    ${target.envVars} \
-    gomobile bind ${goBuildFlags} -target=${target.name} ${target.gomobileExtraFlags} \
-      -o ${target.outputFileName} \
-      ${goBuildLdFlags} \
-      ${goPackagePath}/mobile
-  '') currentHostMobileTargets;
-  mobileInstallScript = lib.concatMapStrings (target: ''
-    mkdir -p $out/lib/${target.name}
-    mv ${target.outputFileName} $out/lib/${target.name}/
-  '') currentHostMobileTargets;
-  desktopOutputFileName = currentHostConfig.desktopOutputFileName;
-  desktopSystem = hostPlatform.system;
-  removeReferences = [ go ];
-  removeExpr = refs: ''remove-references-to ${lib.concatMapStrings (ref: " -t ${ref}") refs}'';
+
   goBuildFlags = "-v";
   goBuildLdFlags = "-ldflags=-s";
+
   xcodeWrapper = composeXcodeWrapper xcodewrapperArgs;
-  status-go = buildGoPackage rec {
-    inherit goPackagePath version rev;
-    name = "${repo}-${version}";
 
-    src = pkgs.fetchFromGitHub { inherit rev owner repo sha256; };
+  statusGoArgs = { inherit owner repo rev version goPackagePath src goBuildFlags goBuildLdFlags; };
+  status-go-packages = {
+    desktop = buildStatusGoDesktopLib (statusGoArgs // {
+      outputFileName = "libstatus.a";
+      hostSystem = hostPlatform.system;
+      host = currentHostConfig.name;
+    });
 
-    nativeBuildInputs = [ gomobile openjdk ]
-      ++ lib.optional isDarwin xcodeWrapper;
+    android = buildStatusGoMobileLib (statusGoArgs // {
+      host = mobileConfigs.android.name;
+      config = mobileConfigs.android;
+    });
 
-    # Fixes Cgo related build failures (see https://github.com/NixOS/nixpkgs/issues/25959 )
-    hardeningDisable = [ "fortify" ];
-
-    # gomobile doesn't seem to be able to pass -ldflags with multiple values correctly to go build, so we just patch files here  
-    patchPhase = ''
-      date=$(date -u '+%Y-%m-%d.%H:%M:%S')
-
-      substituteInPlace cmd/statusd/main.go --replace \
-        "buildStamp = \"N/A\"" \
-        "buildStamp = \"$date\""
-      substituteInPlace params/version.go --replace \
-        "var Version string" \
-        "var Version string = \"${version}\""
-      substituteInPlace params/version.go --replace \
-        "var GitCommit string" \
-        "var GitCommit string = \"${rev}\""
-      substituteInPlace vendor/github.com/ethereum/go-ethereum/metrics/metrics.go --replace \
-        "var EnabledStr = \"false\"" \
-        "var EnabledStr = \"true\""
-    '';
-
-    # we print out the version so that we fail fast in case there's any problem running xcrun, instead of failing at the end of the build
-    preConfigure = lib.optionalString isDarwin ''
-      xcrun xcodebuild -version
-    '';
-
-    buildPhase = ''
-      runHook preBuild
-
-      runHook renameImports
-
-      pushd "$NIX_BUILD_TOP/go/src/${goPackagePath}" >/dev/null
-
-      echo
-      echo "Building desktop library"
-      echo
-      #GOOS=windows GOARCH=amd64 CGO_ENABLED=1 go build ${goBuildFlags} -buildmode=c-archive -o $out/${desktopOutputFileName} ./lib
-      go build -o $out/${desktopOutputFileName} ${goBuildFlags} -buildmode=c-archive ${goBuildLdFlags} ./lib
-
-      # Build command-line tools
-      for name in ./cmd/*; do
-        echo
-        echo "Building $name"
-        echo
-        go install ${goBuildFlags} $name
-      done
-
-      popd >/dev/null
-
-      # Build mobile libraries
-      # TODO: Manage to pass -s -w to -ldflags. Seems to only accept a single flag
-      ${mobileBuildScript}
-
-      runHook postBuild
-    '';
-
-    postInstall = ''
-      mkdir -p $bin
-      cp -r "$NIX_BUILD_TOP/go/bin/" $bin
-
-      ${mobileInstallScript}
-
-      mkdir -p $out/lib/${desktopSystem} $out/include
-      mv $out/${desktopOutputFileName} $out/lib/${desktopSystem}
-      mv $out/libstatus.h $out/include
-    '';
-
-    # remove hardcoded paths to go package in /nix/store, otherwise Nix will fail the build
-    preFixup = ''
-      find $out -type f -exec ${removeExpr removeReferences} '{}' + || true
-    '';
-
-    outputs = [ "out" "bin" ];
-
-    meta = {
-      description = "The Status module that consumes go-ethereum.";
-      license = lib.licenses.mpl20;
-      maintainers = with lib.maintainers; [ pombeirp ];
-      platforms = with lib.platforms; linux ++ darwin;
-    };
+    ios = buildStatusGoMobileLib (statusGoArgs // {
+      host = mobileConfigs.ios.name;
+      config = mobileConfigs.ios;
+    });
   };
 
+  packages = if target-os == "android" then [ status-go-packages.android ] else
+             if target-os == "ios" then [ status-go-packages.ios ] else
+             if target-os == "all" then currentHostConfig.allTargets else
+             if platform.targetDesktop then [ status-go-packages.desktop ] else
+             throw "Unexpected target platform ${target-os}";
+
 in {
-  package = status-go;
-  hardeningDisable = status-go.hardeningDisable;
+  inherit packages;
+
   shellHook =
-    ''
-      export STATUS_GO_INCLUDEDIR=${status-go}/include
-      export STATUS_GO_LIBDIR=${status-go}/lib
-      export STATUS_GO_BINDIR=${status-go.bin}/bin
+    lib.optionalString platform.targetIOS ''
+      # These variables are used by the iOS build preparation section in scripts/prepare-for-platform.sh
+      export RCTSTATUS_FILEPATH=${status-go-packages.ios}/lib/Statusgo.framework
+    '' +
+    lib.optionalString platform.targetAndroid ''
+      # These variables are used by the Status Android Gradle build script in android/build.gradle
+      export STATUS_GO_ANDROID_LIBDIR=${status-go-packages.android}/lib
+    '' +
+    lib.optionalString platform.targetDesktop ''
+      # These variables are used by the Status Desktop CMake build script in modules/react-native-status/desktop/CMakeLists.txt
+      export STATUS_GO_DESKTOP_INCLUDEDIR=${status-go-packages.desktop}/include
+      export STATUS_GO_DESKTOP_LIBDIR=${status-go-packages.desktop}/lib
     '';
 }


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

### Summary

[comment]: # (Summarise the problem and how the pull request solves it)
This PR:
- splits the status-go package into iOS, Android and Desktop sub-packages.
- doesn't build CLI tools anymore. We can bring them back once we have the need for them (maybe for shell.nix only).
- formalizes `target-os` processing into a separate file so that we avoid duplicate code.
- fixes an annoying warning in CI: `tput: No value for $TERM and no -T specified`.

This should make building and testing user branches much quicker compared with the existing way.

### Testing notes

No functional changes should happen as a result of this PR.

status: ready <!-- Can be ready or wip -->