### PR TITLE
Fix crash on switching to Ropsten (dev mode)

### DIFF
--- a/src/status_im/subs.cljs
+++ b/src/status_im/subs.cljs
@@ -939,9 +939,10 @@
 (defn- get-balance-total-value [balance prices currency token->decimals]
   (reduce-kv (fn [acc symbol value]
                (if-let [price (get-in prices [symbol currency :price])]
-                 (+ acc (-> (money/internal->formatted value symbol (token->decimals symbol))
-                            (money/crypto->fiat price)
-                            .toNumber))
+                 (+ acc (or (some-> (money/internal->formatted value symbol (token->decimals symbol))
+                                    (money/crypto->fiat price)
+                                    .toNumber)
+                            0))
                  acc)) 0 balance))
 
 (re-frame/reg-sub


### PR DESCRIPTION
Can't be reproduced in nightly, but is a bit annoying during development.
Steps to reproduce:

1. log in
1. open wallet tab
1. switch to ropsten

<img width=280 src=https://user-images.githubusercontent.com/2364994/57183024-b36b5a00-6eaf-11e9-890f-dc035d02e02d.jpg />

status: ready

