### PR TITLE
Implement pure macOS build environment

### DIFF
--- a/ci/common.groovy
+++ b/ci/common.groovy
@@ -77,7 +77,7 @@ def prep(type = 'nightly') {
     prepareTarget='desktop'
   }
   /* node deps, pods, and status-go download */
-  utils.nix_sh "scripts/prepare-for-platform.sh ${prepareTarget}"
+  utils.nix_impure_sh "scripts/prepare-for-platform.sh ${prepareTarget}"
 }
 
 return this

--- a/ci/desktop.groovy
+++ b/ci/desktop.groovy
@@ -84,7 +84,7 @@ def bundleMacOS(type = 'nightly') {
       string(credentialsId: 'desktop-gpg-inner-pass', variable: 'GPG_PASS_INNER'),
       string(credentialsId: 'desktop-keychain-pass', variable: 'KEYCHAIN_PASS')
     ]) {
-      utils.nix_sh """
+      utils.nix_impure_sh """
         ../scripts/sign-macos-pkg.sh Status.app ../deployment/macos/macos-developer-id.keychain-db.gpg && \
         ../node_modules/appdmg/bin/appdmg.js ../deployment/macos/status-dmg.json ${pkg} && \
         ../scripts/sign-macos-pkg.sh ${pkg} ../deployment/macos/macos-developer-id.keychain-db.gpg

--- a/ci/utils.groovy
+++ b/ci/utils.groovy
@@ -15,8 +15,16 @@ def getToolVersion(name) {
   return version
 }
 
+def nix_impure_sh(cmd) {
+  _nix_sh(cmd, true)
+}
+
 def nix_sh(cmd) {
-  def isPure = env.TARGET_OS != 'windows' && env.TARGET_OS != 'ios' && !cmd.contains('prepare-for-platform.sh')
+  _nix_sh(cmd, false)
+}
+
+def _nix_sh(cmd, forceImpure) {
+  def isPure = !forceImpure && env.TARGET_OS != 'windows' && env.TARGET_OS != 'ios'
   def pureFlag = isPure ? '--pure --keep LOCALE_ARCHIVE_2_27 --keep REALM_DISABLE_ANALYTICS --keep STATUS_RELEASE_STORE_FILE --keep STATUS_RELEASE_STORE_PASSWORD --keep STATUS_RELEASE_KEY_ALIAS --keep STATUS_RELEASE_KEY_PASSWORD --keep GPG_PASS_OUTER --keep GPG_PASS_INNER --keep KEYCHAIN_PASS --keep VERBOSE_LEVEL' : ''
 
   sh """

--- a/ci/utils.groovy
+++ b/ci/utils.groovy
@@ -16,8 +16,8 @@ def getToolVersion(name) {
 }
 
 def nix_sh(cmd) {
-  def isPure = env.TARGET_OS == 'linux' || env.TARGET_OS == 'android'
-  def pureFlag = isPure ? '--pure --keep LOCALE_ARCHIVE_2_27 --keep REALM_DISABLE_ANALYTICS --keep STATUS_RELEASE_STORE_FILE --keep STATUS_RELEASE_STORE_PASSWORD --keep STATUS_RELEASE_KEY_ALIAS --keep STATUS_RELEASE_KEY_PASSWORD --keep VERBOSE_LEVEL' : ''
+  def isPure = env.TARGET_OS != 'windows' && env.TARGET_OS != 'ios' && !cmd.contains('prepare-for-platform.sh')
+  def pureFlag = isPure ? '--pure --keep LOCALE_ARCHIVE_2_27 --keep REALM_DISABLE_ANALYTICS --keep STATUS_RELEASE_STORE_FILE --keep STATUS_RELEASE_STORE_PASSWORD --keep STATUS_RELEASE_KEY_ALIAS --keep STATUS_RELEASE_KEY_PASSWORD --keep GPG_PASS_OUTER --keep GPG_PASS_INNER --keep KEYCHAIN_PASS --keep VERBOSE_LEVEL' : ''
 
   sh """
     set +x
@@ -30,7 +30,7 @@ def nix_sh(cmd) {
 }
 
 def nix_fastlane_sh(cmd) {
-  def isPure = env.TARGET_OS == 'android'
+  def isPure = env.TARGET_OS != 'ios'
   def pureFlag = isPure ? '--pure --keep LANG --keep LANGUAGE --keep LC_ALL --keep DIAWI_TOKEN --keep DIAWI_IPA --keep APK_PATH --keep GOOGLE_PLAY_JSON_KEY --keep SAUCE_LABS_NAME --keep SAUCE_USERNAME --keep SAUCE_ACCESS_KEY --keep FASTLANE_DISABLE_COLORS --keep FASTLANE_APPLE_ID --keep FASTLANE_PASSWORD --keep KEYCHAIN_PASSWORD --keep MATCH_PASSWORD --keep REALM_DISABLE_ANALYTICS --keep STATUS_RELEASE_STORE_FILE --keep GRADLE_USER_HOME' : ''
 
   sh """

--- a/default.nix
+++ b/default.nix
@@ -5,6 +5,7 @@
     repo = "nixpkgs";
     rev = "db492b61572251c2866f6b5e6e94e9d70e7d3021";
     sha256 = "188r7gbcrxi20nj6xh9bmdf3lbjwb94v9s0wpacl7q39g1fca66h";
+    name = "nixpkgs-source";
   }) { inherit config; },
   stdenv ? pkgs.stdenv,
   target-os ? "all" }:

--- a/derivation.nix
+++ b/derivation.nix
@@ -35,6 +35,7 @@ with pkgs;
     ] ++ status-go.packages
       ++ nodePkgBuildInputs
       ++ lib.optional isDarwin cocoapods
+      ++ lib.optional (isDarwin && !platform.targetIOS) clang
       ++ lib.optional (!isDarwin) gcc7
       ++ lib.optionals platform.targetDesktop statusDesktop.buildInputs
       ++ lib.optionals platform.targetMobile statusMobile.buildInputs;

--- a/desktop/CMakeLists.txt
+++ b/desktop/CMakeLists.txt
@@ -6,7 +6,7 @@
 # LICENSE file in the root directory of this source tree. An additional grant
 # of patent rights can be found in the PATENTS file in the same directory.
 
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12.1)
 
 set(APP_NAME Status)
 set(JS_APP_NAME StatusIm)
@@ -19,8 +19,6 @@ endif()
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DUNICODE -std=c11")
 set(CMAKE_INSTALL_PREFIX bin)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_PREFIX}" CACHE PATH "Where to place compiled executables.")
-
-set(CMAKE_OSX_DEPLOYMENT_TARGET "10.9")
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/CMakeModules/")
 
@@ -80,6 +78,11 @@ if (Qt5_POSITION_INDEPENDENT_CODE)
   SET(CMAKE_POSITION_INDEPENDENT_CODE ON)
 endif(Qt5_POSITION_INDEPENDENT_CODE)
 
+target_sources(${APP_NAME} 
+  PRIVATE
+    "${CMAKE_CURRENT_LIST_DIR}/appconfig.h"
+    "${CMAKE_CURRENT_LIST_DIR}/appconfig.cpp")
+
 #set(SOURCE_ROOT ${CMAKE_SOURCE_DIR})
 include(CompleteBundle)
 
@@ -88,12 +91,6 @@ if (WIN32)
 else()
   set(RUN_SCRIPT_FILE_NAME "run-app.sh")
 endif()
-
-
-target_sources(${APP_NAME} 
-  PRIVATE
-    "${CMAKE_CURRENT_LIST_DIR}/appconfig.h"
-    "${CMAKE_CURRENT_LIST_DIR}/appconfig.cpp")
 
 configure_file(
   ${RUN_SCRIPT_FILE_NAME}.in

--- a/desktop/CMakeModules/CompleteBundleWin.cmake.in
+++ b/desktop/CMakeModules/CompleteBundleWin.cmake.in
@@ -14,7 +14,8 @@ if(USE_QTWEBKIT)
   add_custom_command(TARGET @APP_NAME@ POST_BUILD
       COMMAND ${CMAKE_COMMAND} -E copy_if_different
           "@CONAN_BIN_DIRS_QT5-MXE@/QtWebProcess.exe"
-          ${TARGET_DIR})
+          ${TARGET_DIR}
+          BYPRODUCTS ${TARGET_DIR}/QtWebProcess.exe)
 endif()
 foreach(qtmodule ${qtmodules})
   message(STATUS "Copying ${qtmodule} module to ${TARGET_DIR}")

--- a/desktop/Toolchain-Ubuntu-mingw64.cmake
+++ b/desktop/Toolchain-Ubuntu-mingw64.cmake
@@ -11,7 +11,7 @@ if(NOT "${CMAKE_HOST_SYSTEM_NAME}" STREQUAL "Linux")
   message(FATAL_ERROR "Can only cross-compile to Windows from Linux")
 endif()
 
-set(USE_QTWEBKIT ON)
+set(USE_QTWEBKIT OFF)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/toolchain/")
 include(conanbuildinfo)

--- a/desktop_files/yarn.lock
+++ b/desktop_files/yarn.lock
@@ -7139,8 +7139,8 @@ react-native-invertible-scroll-view@1.1.0:
     react-native-scrollable-mixin "^1.0.1"
 
 "react-native-keychain@git+https://github.com/status-im/react-native-keychain.git#v.3.0.0-3-status":
-  version "3.0.0-rc.3"
-  resolved "git+https://github.com/status-im/react-native-keychain.git#25a76813def48ba9bf0fd1b3dd1e915d002b55dd"
+  version "3.0.0-rc.4"
+  resolved "git+https://github.com/status-im/react-native-keychain.git#5895bafa11e734325eaaffd56dda8ca50bfc5275"
 
 "react-native-languages@git+https://github.com/status-im/react-native-languages.git#v0.1.1-status":
   version "3.0.2"

--- a/modules/react-native-desktop-notification/desktop/CMakeLists.txt
+++ b/modules/react-native-desktop-notification/desktop/CMakeLists.txt
@@ -69,13 +69,10 @@ if (CMAKE_CROSSCOMPILING)
 endif()
 
 ExternalProject_Add(SnoreNotify_ep
-  GIT_REPOSITORY https://github.com/status-im/snorenotify.git
-  GIT_TAG 9d54904e4896ab6c3c3a52f97381e5948b455970
-  GIT_SHALLOW TRUE
+  URL $ENV{SNORENOTIFY_SOURCES} # The source is defined in /nix/desktop/macos/snorenotify/default.nix
   CMAKE_ARGS ${SnoreNotify_CMAKE_ARGS}
   BUILD_BYPRODUCTS ${SnoreNotify_STATIC_LIB} ${SnoreNotify_LIBS} ${SnoreNotifyBackend_STATIC_LIB}
                    ${SnoreNotifyBackendSettings_STATIC_LIB} ${SnoreNotifySettings_STATIC_LIB}
-  LOG_DOWNLOAD 1
 )
 
 set(REACT_NATIVE_DESKTOP_EXTERNAL_PROJECT_DEPS ${REACT_NATIVE_DESKTOP_EXTERNAL_PROJECT_DEPS} SnoreNotify_ep PARENT_SCOPE)

--- a/nix/desktop/cmake/qtkeychain/default.nix
+++ b/nix/desktop/cmake/qtkeychain/default.nix
@@ -1,0 +1,45 @@
+{ pkgs, stdenv, fetchFromGitHub }:
+
+with pkgs;
+
+let
+  version = "0.8.90";
+  rev = "d3c606c55adf8c2c2747556055652b3469f6c4c2"; # This revision will get used in https://github.com/status-im/react-native-keychain/blob/master/desktop/CMakeLists.txt#L45
+  sha256 = "1gqw3g0j46aswncm8fgy419lp1fp2y2nild82hs18xra5albvf3i";
+  package = stdenv.mkDerivation {
+    name = "qtkeychain-patched-source";
+    version = "${version}-${lib.strings.substring 0 7 rev}";
+
+    src = fetchFromGitHub {
+      inherit rev sha256;
+      owner = "status-im";
+      repo = "qtkeychain";
+      name = "qtkeychain-source-${version}";
+    };
+
+    phases = [ "unpackPhase" ];
+    unpackPhase = ''
+      mkdir -p $out/src
+      cp -r $src/* $out/src/
+      substituteInPlace $out/src/CMakeLists.txt \
+        --replace "cmake_minimum_required(VERSION 2.8.11)" "cmake_minimum_required(VERSION 3.12.1)" \
+        --replace "project(qtkeychain)" "project(qtkeychain VERSION ${version})" \
+        --replace "set(QTKEYCHAIN_VERSION 0.8.90)" "set(QTKEYCHAIN_VERSION ${version})" \
+        --replace "{QTKEYCHAIN_VERSION}\" VARIABLE_PREFIX SNORE" "QTKEYCHAIN_VERSION VARIABLE_PREFIX SNORE" \
+        --replace "\"\$QTKEYCHAIN_VERSION" qtkeychain
+    '';
+
+    meta = {
+      description = "Patched sources for qtkeychain, a platform-independent Qt API for storing passwords securely";
+      homepage = https://github.com/status-im/qtkeychain;
+      license = stdenv.lib.licenses.bsd3;
+      maintainers = [ stdenv.lib.maintainers.pombeirp ];
+      platforms = with stdenv.lib.platforms; darwin ++ linux;
+    };
+  };
+
+in package // {
+  shellHook = ''
+    export QTKEYCHAIN_SOURCES="${package}/src"
+  '';
+}

--- a/nix/desktop/cmake/snorenotify/default.nix
+++ b/nix/desktop/cmake/snorenotify/default.nix
@@ -1,0 +1,51 @@
+{ pkgs, stdenv, fetchFromGitHub }:
+
+with pkgs;
+
+let
+  version = "0.7.1";
+  rev = "9d54904e4896ab6c3c3a52f97381e5948b455970"; # This revision will get used in modules/react-native-desktop-notification/desktop/CMakeLists.txt#L71
+  sha256 = "0ix1qgx877nw9mlbbqsgkis4phkkf4ax2ambziy2w48hg6ai0x4d";
+  package = stdenv.mkDerivation {
+    name = "snorenotify-patched-source";
+    version = "${version}-${lib.strings.substring 0 7 rev}";
+
+    src = fetchFromGitHub {
+      inherit rev sha256;
+      owner = "status-im";
+      repo = "snorenotify";
+      name = "snorenotify-source-${version}";
+    };
+
+    phases = [ "unpackPhase" ];
+    unpackPhase = ''
+      mkdir -p $out/src
+      cp -r $src/* $out/src/
+      substituteInPlace $out/src/CMakeLists.txt \
+          --replace "cmake_minimum_required( VERSION 2.8.12 )" "" \
+          --replace "project( SnoreNotify )" "cmake_minimum_required( VERSION 3.12.1 )
+project( SnoreNotify VERSION ${version} )" \
+          --replace "set(SNORE_VERSION_MAJOR 0)" "set(SNORE_VERSION_MAJOR ${lib.versions.major version} )" \
+          --replace "set(SNORE_VERSION_MINOR 7)" "set(SNORE_VERSION_MINOR ${lib.versions.minor version} )" \
+          --replace "set(SNORE_VERSION_PATCH 1)" "set(SNORE_VERSION_PATCH ${lib.versions.patch version} )"
+      substituteInPlace $out/src/src/libsnore/CMakeLists.txt \
+        --replace "{SNORE_VERSION_MAJOR}" "SNORE_VERSION_MAJOR" \
+        --replace "{SNORE_VERSION_MINOR}" "SNORE_VERSION_MINOR" \
+        --replace "{SNORE_VERSION_PATCH}" "SNORE_VERSION_PATCH" \
+        --replace "ecm_setup_version(\"\$SNORE_VERSION_MAJOR.\$SNORE_VERSION_MINOR.\$SNORE_VERSION_PATCH\"" "ecm_setup_version(SnoreNotify"
+    '';
+
+    meta = {
+      description = "Patched sources for Snorenotify, a multi platform Qt notification framework. Using a plugin system it is possible to create notifications with many different notification systems on Windows, Mac OS and Unix and mobile Devices";
+      homepage = https://github.com/status-im/snorenotify;
+      license = stdenv.lib.licenses.lgpl3;
+      maintainers = [ stdenv.lib.maintainers.pombeirp ];
+      platforms = with stdenv.lib.platforms; darwin ++ linux;
+    };
+  };
+
+in package // {
+  shellHook = ''
+    export SNORENOTIFY_SOURCES="${package}/src"
+  '';
+}

--- a/nix/desktop/default.nix
+++ b/nix/desktop/default.nix
@@ -8,6 +8,8 @@ let
   linuxPlatform = callPackage ./linux { };
   darwinPlatform = callPackage ./macos { };
   windowsPlatform = callPackage ./windows { };
+  snoreNotifySources = callPackage ./cmake/snorenotify { };
+  qtkeychainSources = callPackage ./cmake/qtkeychain { };
 
 in
   {
@@ -15,17 +17,21 @@ in
       cmake
       extra-cmake-modules
       file
+      snoreNotifySources
+      qtkeychainSources
     ] ++ lib.optionals platform.targetLinux linuxPlatform.buildInputs
       ++ lib.optionals platform.targetDarwin darwinPlatform.buildInputs
       ++ lib.optionals platform.targetWindows windowsPlatform.buildInputs
       ++ lib.optional (! platform.targetWindows) qt5.full;
-    shellHook =
-    lib.optionalString (target-os != "windows") ''
-      export QT_PATH="${qt5.full}"
-      export QT_BASEBIN_PATH="${qt5.qtbase.bin}"
-      export PATH="${qt5.full}/bin:$PATH"
-    '' +
-    lib.optionalString platform.targetLinux linuxPlatform.shellHook +
-    lib.optionalString platform.targetDarwin darwinPlatform.shellHook +
-    lib.optionalString platform.targetWindows windowsPlatform.shellHook;
+    shellHook = 
+      snoreNotifySources.shellHook +
+      qtkeychainSources.shellHook +
+      lib.optionalString (target-os != "windows") ''
+        export QT_PATH="${qt5.full}"
+        export QT_BASEBIN_PATH="${qt5.qtbase.bin}"
+        export PATH="${qt5.full}/bin:$PATH"
+      '' +
+      lib.optionalString platform.targetLinux linuxPlatform.shellHook +
+      lib.optionalString platform.targetDarwin darwinPlatform.shellHook +
+      lib.optionalString platform.targetWindows windowsPlatform.shellHook;
   }

--- a/nix/desktop/linux/appimagekit/default.nix
+++ b/nix/desktop/linux/appimagekit/default.nix
@@ -9,6 +9,7 @@
 let
 
   appimagekit_src = fetchFromGitHub {
+    name = "AppImageKit-source";
     owner = "AppImage";
     repo = "AppImageKit";
     rev = "b0859501df61cde198b54a317c03b41dbafc98b1";
@@ -21,6 +22,7 @@ let
     version = "20161009";
 
     src = fetchFromGitHub {
+      name = "squashfuse-source";
       owner = "vasi";
       repo  = "squashfuse";
       rev   = "1f980303b89c779eabfd0a0fdd36d6a7a311bf92";

--- a/nix/desktop/linux/base-image/default.nix
+++ b/nix/desktop/linux/base-image/default.nix
@@ -2,31 +2,38 @@
 
 with pkgs;
 
-stdenv.mkDerivation rec {
-  name = "StatusImAppImage";
-  version = "20181208";
+let
+  package = stdenv.mkDerivation rec {
+    name = "StatusImAppImage";
+    version = "20181208";
 
-  src =
-    if stdenv.hostPlatform.system == "x86_64-linux" then
-      fetchurl {
-        url = "https://desktop-app-files.ams3.digitaloceanspaces.com/${name}_${version}.zip";
-        sha256 = "15c6p5v6325kj2whc298dn1dyigi0yzk2nzh1y10d03aqr4j8mp5";
-      }
-    else throw "${name} is not supported on ${stdenv.hostPlatform.system}";
+    src =
+      if stdenv.hostPlatform.system == "x86_64-linux" then
+        fetchurl {
+          url = "https://desktop-app-files.ams3.digitaloceanspaces.com/${name}_${version}.zip";
+          sha256 = "15c6p5v6325kj2whc298dn1dyigi0yzk2nzh1y10d03aqr4j8mp5";
+        }
+      else throw "${name} is not supported on ${stdenv.hostPlatform.system}";
 
-  nativeBuildInputs = [ unzip ];
+    nativeBuildInputs = [ unzip ];
 
-  phases = [ "unpackPhase" ];
-  unpackPhase = ''
-    mkdir -p $out/src
-    unzip $src -d $out/src
-  '';
+    phases = [ "unpackPhase" ];
+    unpackPhase = ''
+      mkdir -p $out/src
+      unzip $src -d $out/src
+    '';
 
-  meta = {
-    description = "A base image for Linux Status Desktop release distributions";
-    homepage = https://desktop-app-files.ams3.digitaloceanspaces.com/;
-    license = stdenv.lib.licenses.gpl3;
-    maintainers = [ stdenv.lib.maintainers.pombeirp ];
-    platforms = stdenv.lib.platforms.linux;
+    meta = {
+      description = "A base image for Linux Status Desktop release distributions";
+      homepage = https://desktop-app-files.ams3.digitaloceanspaces.com/;
+      license = stdenv.lib.licenses.gpl3;
+      maintainers = [ stdenv.lib.maintainers.pombeirp ];
+      platforms = stdenv.lib.platforms.linux;
+    };
   };
+
+in package // {
+  shellHook = ''
+    export STATUSREACT_LINUX_BASEIMAGE_PATH="${package}/src"
+  '';
 }

--- a/nix/desktop/linux/default.nix
+++ b/nix/desktop/linux/default.nix
@@ -3,6 +3,8 @@
 with pkgs;
 with stdenv;
 
+assert isLinux;
+
 let
   baseImage = callPackage ./base-image { };
   appimagekit = callPackage ./appimagekit { };

--- a/nix/desktop/linux/default.nix
+++ b/nix/desktop/linux/default.nix
@@ -10,11 +10,8 @@ let
   appimagekit = callPackage ./appimagekit { };
   linuxdeployqt = callPackage ./linuxdeployqt { inherit appimagekit; };
 
-in
-{
+in {
   buildInputs = [ appimagekit linuxdeployqt patchelf baseImage ];
 
-  shellHook = ''
-    export STATUSREACT_LINUX_BASEIMAGE_PATH="${baseImage}/src"
-  '';
+  inherit (baseImage) shellHook;
 }

--- a/nix/desktop/linux/linuxdeployqt/default.nix
+++ b/nix/desktop/linux/linuxdeployqt/default.nix
@@ -9,6 +9,7 @@ stdenv.mkDerivation rec {
   src =
     if stdenv.hostPlatform.system == "x86_64-linux" then
       fetchFromGitHub {
+        name = "${name}-source";
         owner = "probonopd";
         repo = "linuxdeployqt";
         rev = "600fc20ea73ee937a402a2bb6b3663d93fcc1d4b";

--- a/nix/desktop/macos/base-image/default.nix
+++ b/nix/desktop/macos/base-image/default.nix
@@ -2,31 +2,38 @@
 
 with pkgs;
 
-stdenv.mkDerivation rec {
-  name = "StatusImAppBundle";
-  version = "20181113";
+let
+    package = stdenv.mkDerivation rec {
+    name = "StatusImAppBundle";
+    version = "20181113";
 
-  src =
-    if stdenv.hostPlatform.system == "x86_64-darwin" then
-      fetchurl {
-        url = "https://desktop-app-files.ams3.digitaloceanspaces.com/Status_${version}.app.zip";
-        sha256 = "0n8n6p60dwsr4q5v4vq8fffcy5qmqhp03yy95k66q4yic72r0hhz";
-      }
-    else throw "${name} is not supported on ${stdenv.hostPlatform.system}";
+    src =
+      if stdenv.hostPlatform.system == "x86_64-darwin" then
+        fetchurl {
+          url = "https://desktop-app-files.ams3.digitaloceanspaces.com/Status_${version}.app.zip";
+          sha256 = "0n8n6p60dwsr4q5v4vq8fffcy5qmqhp03yy95k66q4yic72r0hhz";
+        }
+      else throw "${name} is not supported on ${stdenv.hostPlatform.system}";
 
-  nativeBuildInputs = [ unzip ];
+    nativeBuildInputs = [ unzip ];
 
-  phases = [ "unpackPhase" ];
-  unpackPhase = ''
-    mkdir -p $out/src
-    unzip $src -d $out/src
-  '';
+    phases = [ "unpackPhase" ];
+    unpackPhase = ''
+      mkdir -p $out/src
+      unzip $src -d $out/src
+    '';
 
-  meta = {
-    description = "A base image for macOS Status Desktop release distributions";
-    homepage = https://desktop-app-files.ams3.digitaloceanspaces.com/;
-    license = stdenv.lib.licenses.gpl3;
-    maintainers = [ stdenv.lib.maintainers.pombeirp ];
-    platforms = stdenv.lib.platforms.darwin;
+    meta = {
+      description = "A base image for macOS Status Desktop release distributions";
+      homepage = https://desktop-app-files.ams3.digitaloceanspaces.com/;
+      license = stdenv.lib.licenses.gpl3;
+      maintainers = [ stdenv.lib.maintainers.pombeirp ];
+      platforms = stdenv.lib.platforms.darwin;
+    };
   };
+
+in package // {
+  shellHook = ''
+    export STATUSREACT_MACOS_BASEIMAGE_PATH="${package}/src"
+  '';
 }

--- a/nix/desktop/macos/default.nix
+++ b/nix/desktop/macos/default.nix
@@ -2,15 +2,20 @@
 
 with pkgs;
 with stdenv;
+with darwin.apple_sdk.frameworks;
+
+assert isDarwin;
 
 let
   baseImage = callPackage ./base-image { };
 
 in
 {
-  buildInputs = [ baseImage ];
+  buildInputs = [ baseImage ] ++
+    [ AppKit Cocoa darwin.cf-private Foundation OpenGL ];
 
   shellHook = ''
-    export STATUSREACT_MACOS_BASEIMAGE_PATH="${baseImage}/src"
+    ${baseImage.shellHook}
+    export NIX_TARGET_LDFLAGS="-F${CoreFoundation}/Library/Frameworks -framework CoreFoundation $NIX_TARGET_LDFLAGS"
   '';
 }

--- a/nix/desktop/windows/base-image/default.nix
+++ b/nix/desktop/windows/base-image/default.nix
@@ -2,6 +2,8 @@
 
 with pkgs;
 
+assert stdenv.isLinux;
+
 stdenv.mkDerivation rec {
   name = "StatusIm-Windows-base-image";
   version = "20181113";

--- a/nix/desktop/windows/base-image/default.nix
+++ b/nix/desktop/windows/base-image/default.nix
@@ -4,39 +4,46 @@ with pkgs;
 
 assert stdenv.isLinux;
 
-stdenv.mkDerivation rec {
-  name = "StatusIm-Windows-base-image";
-  version = "20181113";
+let
+  package = stdenv.mkDerivation rec {
+    name = "StatusIm-Windows-base-image";
+    version = "20181113";
 
-  src =
-    if stdenv.hostPlatform.system == "x86_64-linux" then
-      fetchurl {
-        url = "https://desktop-app-files.ams3.digitaloceanspaces.com/${name}_${version}.zip";
-        sha256 = "1wrxcss63zlwspmw76k549z72hcycxzd9iw4cdh98l4hs2ayzsk3";
-      }
-    else throw "${name} is not supported on ${stdenv.hostPlatform.system}";
+    src =
+      if stdenv.hostPlatform.system == "x86_64-linux" then
+        fetchurl {
+          url = "https://desktop-app-files.ams3.digitaloceanspaces.com/${name}_${version}.zip";
+          sha256 = "1wrxcss63zlwspmw76k549z72hcycxzd9iw4cdh98l4hs2ayzsk3";
+        }
+      else throw "${name} is not supported on ${stdenv.hostPlatform.system}";
 
-  nativeBuildInputs = [ unzip ];
+    nativeBuildInputs = [ unzip ];
 
-  phases = [ "unpackPhase" "installPhase" ];
-  unpackPhase = ''
-    mkdir -p $out/src
-    unzip $src -d $out/src
-  '';
-  installPhase = ''
-    runHook preInstall
+    phases = [ "unpackPhase" "installPhase" ];
+    unpackPhase = ''
+      mkdir -p $out/src
+      unzip $src -d $out/src
+    '';
+    installPhase = ''
+      runHook preInstall
 
-    echo $out
-    ls $out -al
+      echo $out
+      ls $out -al
 
-    runHook postInstall
-  '';
+      runHook postInstall
+    '';
 
-  meta = {
-    description = "A base image for Windows Status Desktop release distributions";
-    homepage = https://desktop-app-files.ams3.digitaloceanspaces.com/;
-    license = stdenv.lib.licenses.gpl3;
-    maintainers = [ stdenv.lib.maintainers.pombeirp ];
-    platforms = stdenv.lib.platforms.linux;
+    meta = {
+      description = "A base image for Windows Status Desktop release distributions";
+      homepage = https://desktop-app-files.ams3.digitaloceanspaces.com/;
+      license = stdenv.lib.licenses.gpl3;
+      maintainers = [ stdenv.lib.maintainers.pombeirp ];
+      platforms = stdenv.lib.platforms.linux;
+    };
   };
+
+in package // {
+  shellHook = ''
+    export STATUSREACT_WINDOWS_BASEIMAGE_PATH="${package}/src"
+  '';
 }

--- a/nix/desktop/windows/default.nix
+++ b/nix/desktop/windows/default.nix
@@ -18,7 +18,7 @@ in
   ];
 
   shellHook = ''
-    export STATUSREACT_WINDOWS_BASEIMAGE_PATH="${baseImage}/src"
+    ${baseImage.shellHook}
     unset QT_PATH
   '';
 }

--- a/nix/desktop/windows/default.nix
+++ b/nix/desktop/windows/default.nix
@@ -3,6 +3,8 @@
 with pkgs;
 with stdenv;
 
+assert isLinux;
+
 let
   baseImage = callPackage ./base-image { };
 

--- a/nix/shell.sh
+++ b/nix/shell.sh
@@ -13,7 +13,7 @@ shift # we remove the first -c from arguments
 if ! command -v "nix" >/dev/null 2>&1; then
   if [ -f ~/.nix-profile/etc/profile.d/nix.sh ]; then
     . ~/.nix-profile/etc/profile.d/nix.sh
-  else
+  elif [ "$IN_NIX_SHELL" != 'pure' ]; then
     echo -e "${GREEN}Setting up environment...${NC}"
     ./scripts/setup
 
@@ -22,8 +22,13 @@ if ! command -v "nix" >/dev/null 2>&1; then
 fi
 
 if command -v "nix" >/dev/null 2>&1; then
+  platform=${TARGET_OS:=all}
+  if [ "$platform" != 'all' ]; then
+    # This is a dirty workaround to the fact that 'yarn install' is an impure operation, so we need to call it from an impure shell. Hopefull we'll be able to fix this later on with something like yarn2nix
+    nix-shell --show-trace --argstr target-os ${TARGET_OS} --run "scripts/prepare-for-platform.sh $platform"
+  fi
   if [[ $@ == "ENTER_NIX_SHELL" ]]; then
-    echo -e "${GREEN}Configuring Nix shell for target '${TARGET_OS:=all}'...${NC}"
+    echo -e "${GREEN}Configuring Nix shell for target '${TARGET_OS}'...${NC}"
     exec nix-shell --show-trace --argstr target-os ${TARGET_OS}
   else
     is_pure=''
@@ -31,7 +36,7 @@ if command -v "nix" >/dev/null 2>&1; then
       is_pure='--pure'
       pure_desc='pure '
     fi
-    echo -e "${GREEN}Configuring ${pure_desc}Nix shell for target '${TARGET_OS:=all}'...${NC}"
+    echo -e "${GREEN}Configuring ${pure_desc}Nix shell for target '${TARGET_OS}'...${NC}"
     exec nix-shell ${is_pure} --show-trace --argstr target-os ${TARGET_OS} --run "$@"
   fi
 fi

--- a/nix/shell.sh
+++ b/nix/shell.sh
@@ -27,7 +27,7 @@ if command -v "nix" >/dev/null 2>&1; then
     exec nix-shell --show-trace --argstr target-os ${TARGET_OS}
   else
     is_pure=''
-    if [ "${TARGET_OS}" == 'linux' ] || [ "${TARGET_OS}" == 'android' ]; then
+    if [ "${TARGET_OS}" != 'ios' ] && [ "${TARGET_OS}" != 'windows' ]; then
       is_pure='--pure'
       pure_desc='pure '
     fi

--- a/nix/status-go/default.nix
+++ b/nix/status-go/default.nix
@@ -14,7 +14,7 @@ let
   repo = "status-go";
   rev = version;
   goPackagePath = "github.com/${owner}/${repo}";
-  src = fetchFromGitHub { inherit rev owner repo sha256; };
+  src = fetchFromGitHub { inherit rev owner repo sha256; name = "${repo}-source"; };
 
   mobileConfigs = {
     android = {

--- a/scripts/build-desktop.sh
+++ b/scripts/build-desktop.sh
@@ -79,9 +79,6 @@ if is_windows_target; then
   CMAKE_EXTRA_FLAGS="$CMAKE_EXTRA_FLAGS -DCMAKE_C_COMPILER='x86_64-w64-mingw32.shared-gcc'"
   CMAKE_EXTRA_FLAGS="$CMAKE_EXTRA_FLAGS -DCMAKE_CXX_COMPILER='x86_64-w64-mingw32.shared-g++'"
   CMAKE_EXTRA_FLAGS="$CMAKE_EXTRA_FLAGS -DCMAKE_RC_COMPILER='x86_64-w64-mingw32.shared-windres'"
-elif is_macos; then
-  CMAKE_EXTRA_FLAGS="$CMAKE_EXTRA_FLAGS -DCMAKE_C_COMPILER='gcc'"
-  CMAKE_EXTRA_FLAGS="$CMAKE_EXTRA_FLAGS -DCMAKE_CXX_COMPILER='g++'"
 fi
 
 STATUSREACTPATH="$(cd "$SCRIPTPATH" && cd '..' && pwd)"
@@ -448,7 +445,7 @@ function bundleMacOS() {
 
     local qtbaseplugins=(bearer platforms printsupport styles)
     local qtfullplugins=(iconengines imageformats webview)
-    if program_exists nix && [ -n "$IN_NIX_SHELL" ]; then
+    if [ -n "$IN_NIX_SHELL" ]; then
       # Since in the Nix qt.full package the different Qt modules are spread across several directories,
       # macdeployqt cannot find some qtbase plugins, so we copy them in its place
       mkdir -p "$contentsPath/PlugIns"

--- a/scripts/lib/setup/platform.sh
+++ b/scripts/lib/setup/platform.sh
@@ -15,6 +15,14 @@ function is_nixos() {
 }
 
 function exit_unless_os_supported() {
+  if [ "$IN_NIX_SHELL" == 'pure' ]; then
+    cecho "@red[[This install script is not supported in a pure Nix shell]]
+
+    echo
+
+    exit 1
+  fi
+
   if ! is_macos && ! is_linux; then
     cecho "@red[[This install script currently supports Mac OS X and Linux \
 via apt. To manually install, please visit the docs for more information:]]

--- a/scripts/prepare-for-platform.sh
+++ b/scripts/prepare-for-platform.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+###################################################################################################
+#
+# Impure setup (any setup here should be minimized and instead be moved to Nix for a pure setup)
+#
+###################################################################################################
+
 set -e
 
 GIT_ROOT=$(git rev-parse --show-toplevel)
@@ -16,7 +22,7 @@ RCTSTATUS_DIR="$GIT_ROOT/modules/react-native-status/ios/RCTStatus"
 #if no arguments passed, inform user about possible ones
 
 if [ $# -eq 0 ]; then
-  echo -e "${GREEN}This script should be invoked with platform argument: 'android', 'ios', or 'desktop'${NC}"
+  echo -e "${GREEN}This script should be invoked with platform argument: 'android', 'ios', 'desktop', 'windows', 'linux', 'macos' or 'darwin'${NC}"
   echo "If invoked with 'android' argument it will link: "
   echo "mobile_files/package.json.orig -> package.json"
   echo "etc.."
@@ -25,6 +31,9 @@ else
   case $1 in
     android | ios)
       PLATFORM='mobile'
+      ;;
+    windows | linux | macos | darwin)
+      PLATFORM='desktop'
       ;;
     *)
       PLATFORM=$1

--- a/scripts/setup
+++ b/scripts/setup
@@ -3,6 +3,7 @@
 ########################################################################
 # This install script will setup your development dependencies on OS X
 # or Ubuntu. Ubuntu 18.04 is the only tested version.
+# It is not required or supported in NixOS.
 #
 # Usage: scripts/setup
 ########################################################################

--- a/shell.nix
+++ b/shell.nix
@@ -43,7 +43,7 @@ in mkShell' {
       ${projectDeps.shellHook}
       ${lib.optionalString useFastlanePkg fastlane'.shellHook}
 
-      if [ ! -f $STATUS_REACT_HOME/.ran-setup ]; then
+      if [ "$IN_NIX_SHELL" != 'pure' ] && [ ! -f $STATUS_REACT_HOME/.ran-setup ]; then
         $STATUS_REACT_HOME/scripts/setup
         touch $STATUS_REACT_HOME/.ran-setup
       fi


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

### Summary

[comment]: # (Summarise the problem and how the pull request solves it)
This PR implements the necessary changes to rely only on Nix-packaged dependencies for macOS builds.

### Review notes
<!-- (Optional. Specify if something in particular should be looked at, or ignored, during review) -->

The invocation of `prepare-for-platform.sh` was moved to `shell.sh` because it needs to run in an impure environment (e.g. downloading npm dependencies before setting up the pure shell).

The CMake minimum version was raised to the version we install, otherwise, it would complain that it couldn't detect the capabilities of the custom clang provided by Nix.

I turned off `USE_QTWEBKIT` because it would require some lengthy refactoring of `desktop/CMakeModules/CompleteBundleWin.cmake.in`, and I don't believe we're using it at the moment anyway.

I checked in the changes that appeared locally for `ios/Podfile.lock`(I think the existing one in `develop` is wrong and was merged from an external contributor PR).

Finally, I created Nix packages that package the sources of `qtkeychain` and `SnoreNotify` because in a pure environment CMake is not able to download the sources. Therefore we store the path to the Nix store in environment variables that can be accessed by the CMake script.

### Testing notes
<!-- (Optional) -->

We should check that macOS and Windows builds don't introduce any obvious bugs. Only light testing is required.

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- iOS
- macOS
- Windows

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- wallet / transactions
- dapps / app browsing
- new account

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->