### PR TITLE
don't rebase on canary-branch

### DIFF
--- a/ci/utils.groovy
+++ b/ci/utils.groovy
@@ -69,6 +69,10 @@ def pkgFilename(type, ext) {
 
 def doGitRebase() {
   /* rebasing on relases defeats the point of having a release branch */
+  if (branchName() == 'canary-branch') {
+    println 'Skipping rebase for canary build...'
+    return
+  }
   if (params.BUILD_TYPE == 'release') {
     println 'Skipping rebase due to release build...'
     return


### PR DESCRIPTION
Disables rebasing of `canary-branch` which is used for our canary builds:
https://ci.status.im/job/status-react/job/canary/
Location of some files changed and this caused builds to start failing.

