### PR TITLE
add alternative nix-cache in China

### DIFF
--- a/nix/README.md
+++ b/nix/README.md
@@ -1,0 +1,16 @@
+# Description
+
+This folder contains configuration for [Nix](https://nixos.org/), a purely functional package manager used by the Status app for its build process.
+
+# Configuration
+
+The main config file is [`nix/nix.conf`](/nix/nix.conf) and its main purpose is defining the [binary caches](https://nixos.org/nix/manual/#ch-basic-package-mgmt) which allow download of packages to avoid having to compile them yourself locally.
+
+__NOTE:__ If you are in Asia you might want to move the `nix-cache-cn` to be first in order of `extra-substituters`. Removing `cache.nixos.org` could also help.
+
+# Shell
+
+In order to access an interactive Nix shell a user should run `make shell`.
+
+The Nix shell is started in this repo via the [`nix/shell.sh`](/nix/shell.sh) script, which is a wrapper around the `nix-shell` command and is intended for use with our main [`Makefile`](/Makefile). This allows for an implicit use of `nix-shell` as the default shell in the `Makefile`.
+

--- a/nix/nix.conf
+++ b/nix/nix.conf
@@ -1,3 +1,4 @@
-extra-substituters = https://nix-cache.status.im/
-trusted-public-keys = nix-cache.status.im-1:x/93lOfLU+duPplwMSBR+OlY4+mo+dCN7n0mr4oPwgY= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+# NOTE: If you are in Asia you might want to move the nix-cache-cn to be first in order.
+substituters = https://nix-cache.status.im/ https://cache.nixos.org https://nix-cache-cn.status.im/
+trusted-public-keys = nix-cache.status.im-1:x/93lOfLU+duPplwMSBR+OlY4+mo+dCN7n0mr4oPwgY= nix-cache-cn.status.im:WUiOoTQQurm+rEL/yuAuU/a3TViDtMM9DCMgMx/KkOw= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
 connect-timeout = 10


### PR DESCRIPTION
Since some users commented on [issues using our Nix cache from China]() I've created a mirror of our cache under https://nix-cache-cn.status.im/. By adding it to `extra-substituters` as the second option I make it a fallback, and by default Nix should use https://nix-cache.status.im/ first, and if that fails try the Chinese one second.

