### PR TITLE
[fix] ipfs CID

### DIFF
--- a/src/status_im/ipfs/core.cljs
+++ b/src/status_im/ipfs/core.cljs
@@ -4,7 +4,7 @@
 
 ;; we currently use an ipfs gateway but this detail is not relevant
 ;; outside of this namespace
-(def ^:const ipfs-add-url "https://ipfs.infura.io:5001/api/v0/add")
+(def ^:const ipfs-add-url "https://ipfs.infura.io:5001/api/v0/add?cid-version=1")
 (def ^:const ipfs-cat-url "https://ipfs.infura.io/ipfs/")
 
 (fx/defn cat
@@ -30,10 +30,11 @@
        :size Size})))
 
 (fx/defn add
+  "Add `value` on ipfs, and returns its b58 encoded CID"
   [cofx {:keys [value on-success on-failure]}]
   (let [formdata (doto (js/FormData.)
                    ;; the key is ignored so there is no need to provide one
-                   (.append nil value))]
+                   (.append "file" value))]
     {:http-raw-post (cond-> {:url  ipfs-add-url
                              :body formdata
                              :timeout-ms 5000

--- a/test/cljs/status_im/test/utils/contenthash.cljs
+++ b/test/cljs/status_im/test/utils/contenthash.cljs
@@ -23,6 +23,11 @@
             {:namespace :ipfs
              :hash "QmRAQB6YaCyidP37UdDnjFY5vQuiBrcqdyoW1CuDgwxkD4"})
            "0xe301122029f2d17be6139079dc48696d1f582a8530eb9805b561eda517e22a892c7e3f1f")))
+  (testing "encoding a valid ipfs cid"
+    (is (= (contenthash/encode
+            {:namespace :ipfs
+             :hash "zb2rhZfjRh2FHHB2RkHVEvL2vJnCTcu7kwRqgVsf9gpkLgteo"})
+           "0xe301015512202cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824")))
   (testing "encoding an invalid ipfs hash"
     (is (nil? (contenthash/encode {:namespace :ipfs
                                    :hash "0xe301122029f2d17be6139079dc48696d1f582a8530eb9805b561eda517e2"}))))


### PR DESCRIPTION
# summary
the `add` post method on infura gateway allows a cid-version argument that I added which returns a CID instead of a simple hash. That way it is clear which content-id the ipfs object has. 

should fix tribute to talk once the ttt PR is rebased

# testing
I added a unit test:
this is the base58 encoded CID from ipfs
https://cid.ipfs.io/#zb2rhZfjRh2FHHB2RkHVEvL2vJnCTcu7kwRqgVsf9gpkLgteo
this is the conversion to hex
https://cid.ipfs.io/#f015512202cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824 (removed contenthash prefix and added f which means hex in multibase format)

both have the same BASE32 CIDV1

isn't used anywhere except in tribute-to-talk, so doesn't require testing yet

status: ready

