### PR TITLE
nix: Add add-gcroots target to Makefile to avoid garbage collection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,4 @@ conan.cmake
 
 # nix
 /.ran-setup
+/.nix-gcroots/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean clean-nix react-native-android react-native-ios react-native-desktop test release _list
+.PHONY: add-gcroots clean clean-nix react-native-android react-native-ios react-native-desktop test release _list
 
 help: ##@other Show this help
 	@perl -e '$(HELP_FUN)' $(MAKEFILE_LIST)
@@ -45,7 +45,10 @@ clean: ##@prepare Remove all output folders
 
 clean-nix: SHELL := /bin/sh
 clean-nix: ##@prepare Remove complete nix setup
-	sudo rm -rf /nix ~/.nix-profile ~/.nix-defexpr ~/.nix-channels ~/.cache/nix ~/.status
+	sudo rm -rf /nix ~/.nix-profile ~/.nix-defexpr ~/.nix-channels ~/.cache/nix ~/.status .nix-gcroots
+
+add-gcroots: ##@prepare Add Nix GC roots to avoid status-react expressions being garbage collected
+	scripts/add-gcroots.sh
 
 shell: ##@prepare Enter into a pre-configured shell
 ifndef IN_NIX_SHELL

--- a/nix/shell.sh
+++ b/nix/shell.sh
@@ -32,7 +32,7 @@ if command -v "nix" >/dev/null 2>&1; then
     exec nix-shell --show-trace --argstr target-os ${TARGET_OS}
   else
     is_pure=''
-    if [ "${TARGET_OS}" != 'ios' ] && [ "${TARGET_OS}" != 'windows' ]; then
+    if [ "${TARGET_OS}" != 'all' ] && [ "${TARGET_OS}" != 'ios' ] && [ "${TARGET_OS}" != 'windows' ]; then
       is_pure='--pure'
       pure_desc='pure '
     fi

--- a/scripts/add-gcroots.sh
+++ b/scripts/add-gcroots.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+GIT_ROOT=$(git rev-parse --show-toplevel)
+
+rm -rf .nix-gcroots
+mkdir .nix-gcroots
+
+drv=$(nix-instantiate shell.nix)
+refs=$(nix-store --query --references $drv)
+nix-store -r $refs --indirect --add-root $GIT_ROOT/.nix-gcroots/shell.dep

--- a/scripts/lib/setup/platform.sh
+++ b/scripts/lib/setup/platform.sh
@@ -16,7 +16,7 @@ function is_nixos() {
 
 function exit_unless_os_supported() {
   if [ "$IN_NIX_SHELL" == 'pure' ]; then
-    cecho "@red[[This install script is not supported in a pure Nix shell]]
+    cecho "@red[[This install script is not supported in a pure Nix shell]]"
 
     echo
 


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

### Summary

[comment]: # (Summarise the problem and how the pull request solves it)

This PR adds a Makefile target to pin the status-react dependencies so that a garbage collection doesn't delete the downloaded/built dependencies. This is important for people who use Nix for other projects other than status-react and need to run GC regularly.

status: ready <!-- Can be ready or wip -->