### PR TITLE
Move to use Stale Probot instead of status-github-bot

### DIFF
--- a/.github/github-bot.yml
+++ b/.github/github-bot.yml
@@ -19,19 +19,3 @@ prchecklist:
   title: Pull Request Checklist
   checklist:
     - 'Have you updated the documentation, if impacted (e.g. [docs.status.im](https://docs.status.im/docs/build_status.html))?'
-
-stale:
-  daysUntilStale: 90
-  daysUntilPullRequestStale: 14
-  daysUntilClose: 7
-  exemptLabels:
-    - 'wall of shame'
-    - security
-  staleLabel: stale
-  markComment: >
-    This issue has been automatically marked as stale because it has not had
-    recent activity. It will be closed if no further activity occurs. Thank you
-    for your contributions.
-  closeComment: >
-    This issue has been automatically closed. Please re-open if this issue
-    is important to you.

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,16 @@
+daysUntilStale: 90
+daysUntilClose: 7
+exemptLabels:
+  - 'wall of shame'
+  - security
+staleLabel: stale
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+closeComment: >
+  This issue has been automatically closed. Please re-open if this issue
+  is important to you.
+
+pulls:
+  daysUntilStale: 14


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

### Summary
[comment]: # (Summarise the problem and how the pull request solves it)
According to syntax in https://github.com/probot/stale

status: ready <!-- Can be ready or wip -->

