### PR TITLE
Fix android minify and macos debug

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -204,8 +204,8 @@ android {
     buildTypes {
         debug {
             applicationIdSuffix ".debug"
-            debuggable        true
-            versionNameSuffix "-SNAPSHOT"
+            debuggable          true
+            versionNameSuffix   "-SNAPSHOT"
             resValue "string", "build_config_package", "im.status.ethereum"
         }
         release {
@@ -216,8 +216,8 @@ android {
         pr {
             initWith release
             applicationIdSuffix ".pr"
-            versionNameSuffix ".pr"
-            debuggable        true
+            versionNameSuffix   ".pr"
+            debuggable          true
             matchingFallbacks = ["release"]
             // necessary to make react-native-config's code generation work
             resValue "string", "build_config_package", "im.status.ethereum"
@@ -235,6 +235,11 @@ android {
                         versionCodes.get(abi) * 1048576 + defaultConfig.versionCode
             }
         }
+    }
+
+    aaptOptions {
+        // disable PNG optimization as for some reason it cannot be trusted to provide deterministic output (see https://f-droid.org/en/docs/Reproducible_Builds/)
+        cruncherEnabled = false
     }
 
     sourceSets {

--- a/desktop/build.sh
+++ b/desktop/build.sh
@@ -38,8 +38,6 @@ cmake -DCMAKE_BUILD_TYPE=Debug \
       -DEXTERNAL_MODULES_DIR="$ExternalModulesPaths" \
       -DJS_BUNDLE_PATH="$JsBundlePath" \
       -DDESKTOP_FONTS="$desktopFonts" \
-      -DCMAKE_C_COMPILER='gcc'\
-      -DCMAKE_CXX_COMPILER='g++' \
       -DCMAKE_INSTALL_COMPONENT='' \
       . && \
 make


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

### Summary

[comment]: # (Summarise the problem and how the pull request solves it)
This PR fixes a couple of issues I came across today, namely Android CI builds not being minified, and macOS debug builds still looking for gcc instead of clang (should have been done in fca01891baae35146216e3f9e0aaa90341ad2dad).

status: ready <!-- Can be ready or wip -->