### PR TITLE
Ubuntu-server rejects connections not from localhost

### DIFF
--- a/ubuntu-server.js
+++ b/ubuntu-server.js
@@ -114,6 +114,18 @@ function rnUbuntuServer(readable, writable) {
   });
 }
 
+var closeDangerousConnection = function(sock) {
+  var remoteAddress = sock.remoteAddress;
+  if(remoteAddress.indexOf("127.0.0.1") == -1) {
+    console.log("WARN: connection not from localhost, will be closed: ", remoteAddress);
+    sock.destroy();
+    return true;
+  } else {
+    console.log("Connection from: ", remoteAddress);
+    return false;
+  }
+}
+
 if (process.argv.indexOf('--pipe') != -1) {
   console.log = console.error
   rnUbuntuServer(process.stdin, process.stdout);
@@ -127,6 +139,7 @@ if (process.argv.indexOf('--pipe') != -1) {
 
   var server = net.createServer((sock) => {
     DEBUG && console.error("-- Connection from RN client");
-    rnUbuntuServer(sock, sock);
+    if(!closeDangerousConnection(sock))
+      rnUbuntuServer(sock, sock);
   }).listen(port, function() { console.error("-- Server starting") });
 }


### PR DESCRIPTION
Related to https://github.com/status-im/security-reports/issues/6

### Summary
This is a proposed fix to security issue in ubuntu-server.js.
We can check the address of socket connection and destroy it if it is not local.

**NOTE:** Commiting this file won't solve issue immediately, new binaries should be generated from updated `ubuntu-server.js` and used in all newly created packages

### Review notes
@corpetty, could you please take a look at proposed changes. If you think they will fix the problem, I'll commit the `ubuntu-server.js` in this PR and than generate new binaries for platforms to use them in installers.
I've checked with other laptop that when modified ubuntu-server.js runs it rejects incoming non-local connections and saves ability to accept local ones.

### Testing notes
Doesn't require testing until binaries updated

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

* macOS
* Linux
* Windows

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready

