### PR TITLE
Fetch new version of base images with fixed ubuntu-server

### DIFF
--- a/nix/desktop/linux/base-image/default.nix
+++ b/nix/desktop/linux/base-image/default.nix
@@ -5,13 +5,13 @@ with pkgs;
 let
   package = stdenv.mkDerivation rec {
     name = "StatusImAppImage";
-    version = "20181208";
+    version = "20190515";
 
     src =
       if stdenv.hostPlatform.system == "x86_64-linux" then
         fetchurl {
           url = "https://desktop-app-files.ams3.digitaloceanspaces.com/${name}_${version}.zip";
-          sha256 = "15c6p5v6325kj2whc298dn1dyigi0yzk2nzh1y10d03aqr4j8mp5";
+          sha256 = "0g7qa97cr0f9807sfd3khxiqz575i9kxi6lfda350ilaw8lnnfv2";
         }
       else throw "${name} is not supported on ${stdenv.hostPlatform.system}";
 

--- a/nix/desktop/macos/base-image/default.nix
+++ b/nix/desktop/macos/base-image/default.nix
@@ -5,13 +5,13 @@ with pkgs;
 let
     package = stdenv.mkDerivation rec {
     name = "StatusImAppBundle";
-    version = "20181113";
+    version = "20190515";
 
     src =
       if stdenv.hostPlatform.system == "x86_64-darwin" then
         fetchurl {
           url = "https://desktop-app-files.ams3.digitaloceanspaces.com/Status_${version}.app.zip";
-          sha256 = "0n8n6p60dwsr4q5v4vq8fffcy5qmqhp03yy95k66q4yic72r0hhz";
+          sha256 = "1255jgdp0apqh7qfp752nww91iq39x5mm7rf0wazq2vjahfr4pc5";
         }
       else throw "${name} is not supported on ${stdenv.hostPlatform.system}";
 

--- a/nix/desktop/windows/base-image/default.nix
+++ b/nix/desktop/windows/base-image/default.nix
@@ -7,13 +7,13 @@ assert stdenv.isLinux;
 let
   package = stdenv.mkDerivation rec {
     name = "StatusIm-Windows-base-image";
-    version = "20181113";
+    version = "20190515";
 
     src =
       if stdenv.hostPlatform.system == "x86_64-linux" then
         fetchurl {
           url = "https://desktop-app-files.ams3.digitaloceanspaces.com/${name}_${version}.zip";
-          sha256 = "1wrxcss63zlwspmw76k549z72hcycxzd9iw4cdh98l4hs2ayzsk3";
+          sha256 = "0wkq0khllms2hnbznb1j8l8yfw6z7phzrdg4ndyik20jkl0faj8f";
         }
       else throw "${name} is not supported on ${stdenv.hostPlatform.system}";
 


### PR DESCRIPTION
Related to status-im/security-reports#6

### Summary

New binaries of `ubuntu-server` with security fix were generated for all platforms and uploaded to digitaloceanspaces
Nix files were updated to use fixed binaries

### Review notes
ubuntu-server binaries uploaded, nix files changed to download new versions

### Testing notes
Replacing ubuntu-server won't affect app logic but can affect app startup. So if it starts and able to login then `ubuntu-server` works fine with `react-native-desktop` and `realm.

#### Platforms
- macOS
- Linux
- Windows

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional
- new account
- user profile updates

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open Status
- Ensure it runs
- Ensure you are able to login

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready