### PR TITLE
Add auto_assign and CODEOWNERS  config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,36 @@
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @global-owner1 and @global-owner2 will be requested for
+# review when someone opens a pull request.
+*       @status-im/status-core
+
+/ci                 @jakubgs
+/fastlane           @jakubgs
+/scripts            @jakubgs
+/.env*              @jakubgs
+/.TOOLVERSIONS      @jakubgs
+/STATUS_GO_*        @jakubgs
+
+# Order is important; the last matching pattern takes the most
+# precedence. When someone opens a pull request that only
+# modifies Nix files, only @js-owner and not the global
+# owner(s) will be requested for a review.
+*.nix       @PombeirP @jakubgs
+/nix        @PombeirP @jakubgs
+/.github/   @PombeirP @jakubgs
+
+/components @status-im/status-core-ui
+
+desktop/                        @vkjr
+/desktop_files                  @vkjr
+modules/react-native-desktop*/  @vkjr
+modules/react-native-desktop*/  @vkjr
+
+/doc        @oskarth @mandrigin @yenda @jeluard
+
+/deployment @vkjr @PombeirP
+
+/test    @antdanchenko @churik

--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,26 @@
+# Set to true to add reviewers to pull requests
+addReviewers: true
+
+# Set to true to add assignees to pull requests
+addAssignees: false
+
+# A list of reviewers to be added to pull requests (GitHub user name)
+reviewers:
+  - status-im/status-core
+
+# A number of reviewers added to the pull request
+# Set 0 to add all the reviewers (default: 0)
+numberOfReviewers: 0
+
+# A list of assignees, overrides reviewers if set
+# assignees:
+#   - status-im/status-core
+
+# A number of assignees to add to the pull request
+# Set to 0 to add all of the assignees.
+# Uses numberOfReviewers if unset.
+# numberOfAssignees: 2
+
+# A list of keywords to be skipped the process that add reviewers if pull requests include it
+skipKeywords:
+  - wip


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes #8074

### Summary

[comment]: # (Summarise the problem and how the pull request solves it)
This PR adds configuration for the auto_assign probot, as well as standard GH CODEOWNERS file to determine who to assign the review to based on file path.

status: ready <!-- Can be ready or wip -->