### PR TITLE
Fix deep links tests

### DIFF
--- a/test/appium/tests/atomic/dapps_and_browsing/test_deep_links.py
+++ b/test/appium/tests/atomic/dapps_and_browsing/test_deep_links.py
@@ -37,7 +37,6 @@ class TestDeepLinks(SingleDeviceTestCase):
             if not chat_view.element_by_text(text).scroll_to_element(10):
                 pytest.fail("User profile screen is not opened")
 
-
     @marks.testrail_id(5442)
     @marks.medium
     def test_open_dapp_using_deep_link(self):

--- a/test/appium/views/base_element.py
+++ b/test/appium/views/base_element.py
@@ -159,12 +159,18 @@ class BaseElement(object):
             self.template = file_name
         return not ImageChops.difference(self.image, self.template).getbbox()
 
-    def swipe_element(self):
+    def swipe_left_on_element(self):
         element = self.find_element()
         location, size = element.location, element.size
         x, y = location['x'], location['y']
         width, height = size['width'], size['height']
         self.driver.swipe(start_x=x + width * 0.75, start_y=y + height / 2, end_x=x, end_y=y + height / 2)
+
+    def swipe_to_web_element(self):
+        element = self.find_element()
+        location = element.location
+        x, y = location['x'], location['y']
+        self.driver.swipe(start_x=x, start_y=y, end_x=x, end_y=400)
 
     def long_press_element(self):
         element = self.find_element()

--- a/test/appium/views/base_view.py
+++ b/test/appium/views/base_view.py
@@ -279,10 +279,7 @@ class OpenInStatusButton(BaseButton):
 
     def click(self):
         self.wait_for_visibility_of_element()
-
-        # 'Open in Status' button already in DOM but need to scroll down so that click action works
-        self.driver.swipe(500, 500, 500, 200)
-        self.driver.info('Tap on %s' % self.name)
+        self.swipe_to_web_element()
         self.wait_for_element().click()
 
 

--- a/test/appium/views/home_view.py
+++ b/test/appium/views/home_view.py
@@ -96,7 +96,7 @@ class ChatElement(BaseButton):
     def swipe_and_delete(self):
         counter = 0
         while counter < 3:
-            self.swipe_element()
+            self.swipe_left_on_element()
             if self.swipe_delete_button.is_element_present():
                 break
             time.sleep(3)

--- a/test/appium/views/sign_in_view.py
+++ b/test/appium/views/sign_in_view.py
@@ -141,8 +141,7 @@ class SignInView(BaseView):
         return self.get_home_view()
 
     def sign_in(self, password=common_password):
-        if self.ok_button.is_element_displayed():
-            self.ok_button.click()
+        self.accept_agreements()
         self.password_input.set_value(password)
         return self.sign_in_button.click()
 

--- a/test/appium/views/web_views/status_test_dapp.py
+++ b/test/appium/views/web_views/status_test_dapp.py
@@ -1,4 +1,5 @@
 from views.web_views.base_web_view import BaseWebView, BaseButton
+import time
 
 
 class AssetsButton(BaseButton):
@@ -65,7 +66,8 @@ class TransactionsButton(BaseButton):
             return SendTransactionView(self.driver)
 
         def click(self):
-            self.driver.swipe(500, 1000, 500, 800)
+            self.swipe_to_web_element()
+            time.sleep(2)
             self.wait_for_visibility_of_element().click()
             return self.navigate()
 


### PR DESCRIPTION
- for web views (app browsing and android chromium browsing) added method to swipe page so that element is visible to user
- sign_in method updated to accept all agreements (it was failing sometimes on pop-up about ROOTED device)