### PR TITLE
Enable asset in Wallet before usage

### DIFF
--- a/test/appium/tests/atomic/account_management/test_wallet_management.py
+++ b/test/appium/tests/atomic/account_management/test_wallet_management.py
@@ -84,18 +84,14 @@ class TestWalletManagement(SingleDeviceTestCase):
         sign_in.create_user()
         wallet = sign_in.wallet_button.click()
         wallet.set_up_wallet()
-        wallet.options_button.click()
-        wallet.manage_assets_button.click()
-        select_asset = 'MDS'
-        deselect_asset = 'STT'
-        wallet.asset_checkbox_by_name(select_asset).click()
-        wallet.asset_checkbox_by_name(deselect_asset).click()
-        wallet.cross_icon.click()
-        wallet.asset_by_name(select_asset).scroll_to_element()
-        if not wallet.asset_by_name(select_asset).is_element_displayed():
-            self.errors.append('%s asset is not shown in wallet' % select_asset)
-        if wallet.asset_by_name(deselect_asset).is_element_displayed():
-            self.errors.append('%s asset is shown in wallet but was deselected' % deselect_asset)
+        asset = "MDS"
+        wallet.select_asset(asset)
+        wallet.asset_by_name(asset).scroll_to_element()
+        if not wallet.asset_by_name(asset).is_element_displayed():
+            self.errors.append('%s asset is not shown in wallet' % asset)
+        wallet.select_asset(asset)
+        if wallet.asset_by_name(asset).is_element_displayed():
+            self.errors.append('%s asset is shown in wallet but was deselected' % asset)
         self.verify_no_errors()
 
     @marks.testrail_id(5358)
@@ -127,11 +123,8 @@ class TestWalletManagement(SingleDeviceTestCase):
         profile.switch_network('Mainnet with upstream RPC')
         wallet = sign_in.wallet_button.click()
         wallet.set_up_wallet()
-        wallet.options_button.click()
-        wallet.manage_assets_button.click()
         asset_name = 'CryptoKitties'
-        wallet.asset_checkbox_by_name(asset_name).click()
-        wallet.cross_icon.click()
+        wallet.select_asset(asset_name)
         send_transaction = wallet.send_transaction_button.click()
         send_transaction.select_asset_button.click()
         if send_transaction.asset_by_name(asset_name).is_element_displayed():

--- a/test/appium/tests/atomic/chats/test_commands.py
+++ b/test/appium/tests/atomic/chats/test_commands.py
@@ -438,6 +438,12 @@ class TestCommandsSingleDevices(SingleDeviceTestCase):
             self.errors.append("'Insufficient funds' error is now shown when sending 1 ETH from chat with balance 0")
         send_transaction.cross_icon.click()
         chat_view.commands_button.click()
+
+        # enable STT in wallet
+        chat_view.wallet_button.click()
+        wallet_view.select_asset("STT")
+        wallet_view.home_button.click()
+
         chat_view.send_command.click()
         chat_view.asset_by_name('STT').click()
         chat_view.send_as_keyevent('1')

--- a/test/appium/tests/atomic/transactions/test_daaps_transactions.py
+++ b/test/appium/tests/atomic/transactions/test_daaps_transactions.py
@@ -297,6 +297,7 @@ class TestTransactionDApp(SingleDeviceTestCase):
         home_view = singin_view.create_user()
         wallet = home_view.wallet_button.click()
         wallet.set_up_wallet()
+        wallet.select_asset("STT")
         wallet_address = wallet.get_wallet_address()
         recipient = '0x' + basic_user['address']
 

--- a/test/appium/tests/atomic/transactions/test_wallet.py
+++ b/test/appium/tests/atomic/transactions/test_wallet.py
@@ -270,6 +270,7 @@ class TestTransactionWalletSingleDevice(SingleDeviceTestCase):
         sign_in_view.create_user()
         wallet_view = sign_in_view.wallet_button.click()
         wallet_view.set_up_wallet()
+        wallet_view.select_asset("STT")
         send_transaction = wallet_view.send_transaction_button.click()
         send_transaction.amount_edit_box.set_value(1)
         error_text = send_transaction.element_by_text('Insufficient funds')

--- a/test/appium/views/base_view.py
+++ b/test/appium/views/base_view.py
@@ -484,7 +484,7 @@ class BaseView(object):
 
     @staticmethod
     def get_unique_amount():
-        return '0.0%s' % datetime.now().strftime('%-m%-d%-H%-M%-S').strip('0')
+        return '0.00%s' % datetime.now().strftime('%-d%-H%-M%-S').strip('0')
 
     @staticmethod
     def get_public_chat_name():

--- a/test/appium/views/wallet_view.py
+++ b/test/appium/views/wallet_view.py
@@ -268,6 +268,13 @@ class WalletView(BaseView):
     def asset_checkbox_by_name(self, asset_name):
         return AssetCheckBox(self.driver, asset_name)
 
+    def select_asset(self, *args):
+        self.options_button.click()
+        self.manage_assets_button.click()
+        for asset in args:
+            self.asset_checkbox_by_name(asset).click()
+        self.cross_icon.click()
+
     def send_transaction(self, **kwargs):
         send_transaction_view = self.send_transaction_button.click()
         send_transaction_view.select_asset_button.click()


### PR DESCRIPTION
- assets in Wallet changed behaviour: no more assets set by default if amount = 0. So we have to enable/disable tokens manually for new users before use them in tests
- updated get_unique_amount so that transaction amount be 10 times less