### PR TITLE
[perf] small perf improvement for nested-text

### DIFF
--- a/components/src/status_im/ui/components/react.cljs
+++ b/components/src/status_im/ui/components/react.cljs
@@ -128,9 +128,12 @@
 
                        (vector? text-element)
                        (let [[options nested-text-elements] text-element]
-                         [nested-text (prepare-text-props
-                                       (utils.core/deep-merge options-with-style
-                                                              options))
+                         [(if (string? nested-text-elements)
+                            text-class
+                            nested-text)
+                          (prepare-text-props
+                           (utils.core/deep-merge options-with-style
+                                                  options))
                           nested-text-elements]))))
              [text-class options-with-style]
              nested-text-elements))))


### PR DESCRIPTION
A simple optim that seems to bring about 30% speedup improvement to compute `nested-text` elements

## Measurements

384 ms with no optim average 40 runs of 10k calls
269 ms with simple element for non nested text on average of 40 runs of 10k calls

```clojure
(def a (atom 0))
(defn nested-text
  ([options & nested-text-elements]
   (let [start (status-im.utils.datetime/timestamp)
         options-with-style (prepare-text-props options)
         elements
         (reduce (fn [acc text-element]
                   (conj acc
                         (cond
                           (string? text-element)
                           [text-class options-with-style text-element]

                           (vector? text-element)
                           (let [[{:keys [style] :as options} nested-text-elements]
                                 text-element]
                             [(if (string? nested-text-elements)
                                text-class
                                nested-text) (prepare-text-props
                                              (-> options-with-style
                                                  (merge (dissoc options style))
                                                  (update :style merge style)))
                              nested-text-elements]))))
                 [text-class options-with-style]
                 nested-text-elements)
         end  (status-im.utils.datetime/timestamp)]
     (swap! a #(+ % (- end start)))
     elements
     nil)))
```

```clojure
(def b (let [{:keys [content] :as message} (get-in @re-frame.db/app-db [:chats "test" :messages "0xd5c4ff6f2f705560211caee516b5e0e655edb6323e3ad5c9aaf3284d4c6266e2"])] (status-im.ui.screens.chat.utils/render-chunks (:render-recipe content) message)))
(dotimes [y 10] (reset! a 0) (dotimes [x 10000] (apply nested-text {} (conj b (str x)))) (println @a))
```

### Steps to test

- check rendering speed of #test public channel which is full of nested-text messages

status: ready