### PR TITLE
[TESTS] Performance: time to load sign in screen (no save password)

### DIFF
--- a/test/appium/tests/base_test_case.py
+++ b/test/appium/tests/base_test_case.py
@@ -123,7 +123,7 @@ class AbstractTestCase:
 
     def verify_no_errors(self):
         if self.errors:
-            pytest.fail('. '.join([self.errors.pop(0) for _ in range(len(self.errors))]))
+            pytest.fail('\n '.join([self.errors.pop(0) for _ in range(len(self.errors))]))
 
     def is_alert_present(self, driver):
         try:
@@ -136,7 +136,7 @@ class AbstractTestCase:
 
     def add_alert_text_to_report(self, driver):
         if self.is_alert_present(driver):
-            test_suite_data.current_test.testruns[-1].error += ", also Unexpected Alert is shown: '%s'" \
+            test_suite_data.current_test.testruns[-1].error += "; also Unexpected Alert is shown: '%s'" \
                                                                        % self.get_alert_text(driver)
 
 

--- a/test/appium/tests/marks.py
+++ b/test/appium/tests/marks.py
@@ -21,6 +21,7 @@ wallet = pytest.mark.wallet
 sign_in = pytest.mark.sign_in
 skip = pytest.mark.skip
 logcat = pytest.mark.logcat
+performance = pytest.mark.performance
 
 
 battery_consumption = pytest.mark.battery_consumption

--- a/test/appium/tests/test_performance.py
+++ b/test/appium/tests/test_performance.py
@@ -1,0 +1,65 @@
+from tests import marks
+from tests.base_test_case import SingleDeviceTestCase
+from views.sign_in_view import SignInView
+from datetime import datetime
+import time
+
+
+class TestPerformance(SingleDeviceTestCase):
+
+    def get_timestamps_by_event(self, *args):
+        # earlier event will be overwritten by latest in case of multiple events in a logcat!
+
+        timestamps_by_event = dict()
+        logcat = self.driver.get_log('logcat')
+        for event in args:
+            for line in logcat:
+                if event in line['message']:
+                    timestamps_by_event[event] = line['timestamp']
+        return timestamps_by_event
+
+    @marks.testrail_id(6216)
+    @marks.high
+    @marks.performance
+    def test_time_to_load_sign_in_screen(self):
+
+        app_started = ':init/app-started'
+        login_shown = ':on-will-focus :login'
+        password_submitted = ':accounts.login.ui/password-input-submitted'
+        login_success = ':accounts.login.callback/login-success'
+
+        sign_in = SignInView(self.driver)
+        sign_in.create_user()
+        profile = sign_in.profile_button.click()
+        profile.logout()
+        home = sign_in.sign_in()
+        home.plus_button.click()
+        self.driver.info("Close app")
+        self.driver.close_app()
+        self.driver.info("Launch app")
+        self.driver.launch_app()
+        time.sleep(5)
+
+        timestamps_by_event = self.get_timestamps_by_event(app_started, login_shown, password_submitted, login_success)
+        for event in app_started, login_shown, password_submitted, login_success:
+            self.driver.info("event: '%s' | timestamp: '%s' | time: '%s'" % (event, timestamps_by_event[event],
+                             datetime.utcfromtimestamp(timestamps_by_event[event] / 1000)))
+
+        time_to_login= (timestamps_by_event[login_success] - timestamps_by_event[password_submitted]) / 1000
+        self.driver.info("Time to login is '%s'" % time_to_login)
+
+        time_to_start_app = (timestamps_by_event[login_shown] - timestamps_by_event[app_started]) / 1000
+        self.driver.info("Time to start the app is '%s'" % time_to_start_app)
+
+        baseline_start_app = 0.8
+        baseline_login = 1.2
+
+        if time_to_start_app > baseline_start_app:
+            self.errors.append(
+                "time between starting the app and login screen is '%s' seconds, while baseline is '%s'!"
+                % (time_to_start_app, baseline_start_app))
+        if time_to_login > baseline_login:
+            self.errors.append(
+                "time between submitting a password and successful login is '%s' seconds, while baseline is '%s'!"
+                % (time_to_login, baseline_login))
+        self.verify_no_errors()


### PR DESCRIPTION
Get time to show sign in screen:
1) Launch Status app and check time for this event in logcat :init/app-started'
2) check time in logcat for ':on-will-focus :login' when Sign in screen with Password field is shown 
3) find the diff between time2 and time1
Get time between submitting password and Chats tab shown (no fetching, no chats)
4) type the valid password and tap on Sign in button, check in logcat for time3 of ':accounts.login.ui/password-input-submitted'
5) check time4 when Chats tab is shown, in logcat it's ':accounts.login.callback/login-success'
6) find diff between time4 and time3
7) repeat steps above to get 10 measurements and find average values

check that average is not more than x sec:
- time to show sign in screen
- time between submitting password and Chats tab shown