### PR TITLE
"Fetch more history" and fixes for e2e

### DIFF
--- a/test/appium/tests/atomic/account_management/test_profile.py
+++ b/test/appium/tests/atomic/account_management/test_profile.py
@@ -164,6 +164,7 @@ class TestProfileSingleDevice(SingleDeviceTestCase):
         sign_in_view.sign_in()
         profile_view = sign_in_view.profile_button.click()
         profile_view.advanced_button.click()
+        profile_view.network_settings_button.scroll_to_element(10, 'up')
         profile_view.find_text_part('custom_ropsten')
 
     @marks.logcat
@@ -258,8 +259,9 @@ class TestProfileSingleDevice(SingleDeviceTestCase):
         profile = home_view.profile_button.click()
         profile.switch_network(network_name)
         profile = home_view.profile_button.click()
+        profile.network_settings_button.scroll_to_element()
         if not profile.current_active_network == network_name:
-            self.driver.fail('Oops! Wrong network selected!')
+             self.driver.fail('Oops! Wrong network selected!')
 
     @marks.testrail_id(5453)
     @marks.medium

--- a/test/appium/views/profile_view.py
+++ b/test/appium/views/profile_view.py
@@ -533,7 +533,7 @@ class ProfileView(BaseView):
     def switch_network(self, network):
         self.advanced_button.click()
         self.debug_mode_toggle.click()
-        self.network_settings_button.scroll_to_element()
+        self.network_settings_button.scroll_to_element(10, 'up')
         self.network_settings_button.click()
         network_button = NetworkSettingsButton.NetworkButton(self.driver, network)
         network_button.click()
@@ -649,5 +649,5 @@ class ProfileView(BaseView):
     @property
     def current_active_network(self):
         self.advanced_button.click()
-        self.active_network_name.scroll_to_element()
+        self.active_network_name.scroll_to_element(10, 'up')
         return self.active_network_name.text


### PR DESCRIPTION
1) `test_fetch_more_history_in_empty_chat `
 Tested in empty chat that label with the date on "Fetch more messages" button is changed after clicking to fetch earlier history. 
Also checked that label "it is quite here" is changed accordingly.

2) Added scrolling for elements in profile, which fixes `test_user_can_switch_network` and `test_add_custom_network`
