### PR TITLE
always checkout to status-react folder

### DIFF
--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -5,6 +5,8 @@ pipeline {
     timestamps()
     /* Prevent Jenkins jobs from running forever */
     timeout(time: 45, unit: 'MINUTES')
+    /* make project dir the same for consisten nix src */
+    checkoutToSubdirectory('status-react')
     /* Limit builds retained */
     buildDiscarder(logRotator(
       numToKeepStr: '10',
@@ -22,11 +24,14 @@ pipeline {
   }
 
   environment {
+    /* change workspace to keep it consistent for nix src */
+    SRC = "${WORKSPACE}/status-react"
+    /* locale */
     LANG     = "en_US.UTF-8"
     LC_ALL   = "en_US.UTF-8"
     LANGUAGE = "en_US.UTF-8"
     TARGET_OS = 'android'
-    NIX_CONF_DIR = "${env.WORKSPACE}/nix"
+    NIX_CONF_DIR = "${SRC}/nix"
     FASTLANE_DISABLE_COLORS = 1
     REALM_DISABLE_ANALYTICS = 1
     /* since we are mounting it we need to specify location */
@@ -39,46 +44,46 @@ pipeline {
 
   stages {
     stage('Prep') {
-      steps {
+      steps { dir(SRC) {
         script {
           /* Necessary to load methods */
-          mobile = load 'ci/mobile.groovy'
-          cmn    = load 'ci/common.groovy'
+          mobile = load('ci/mobile.groovy')
+          cmn    = load('ci/common.groovy')
           btype  = cmn.utils.getBuildType()
           print "Running ${btype} build!"
           cmn.ci.abortPreviousRunningBuilds()
           /* Cleanup and Prep */
           cmn.prep(btype)
         }
-      }
+      } }
     }
     stage('Lint') {
-      steps {
+      steps { dir(SRC) {
         script { cmn.nix.shell('lein cljfmt check') }
-      }
+      } }
     }
     stage('Tests') {
-      steps {
+      steps { dir(SRC) {
         script { cmn.nix.shell('lein test-cljs') }
-      }
+      } }
     }
     stage('Build') {
-      steps {
+      steps { dir(SRC) {
         script { cmn.nix.shell('lein prod-build-android')}
-      }
+      } }
     }
     stage('Bundle') {
-      steps {
+      steps { dir(SRC) {
         script { apk = mobile.android.bundle() }
-      }
+      } }
     }
     stage('Archive') {
-      steps {
+      steps { dir(SRC) {
         archiveArtifacts apk
-      }
+      } }
     }
     stage('Upload') {
-      steps {
+      steps { dir(SRC) {
         script {
           env.PKG_URL = cmn.utils.uploadArtifact(apk)
           /* build type specific */
@@ -91,16 +96,20 @@ pipeline {
               env.SAUCE_URL = mobile.android.uploadToSauceLabs()
           }
         }
-      }
+      } }
     }
     stage('Cleanup') {
-      steps {
+      steps { dir(SRC) {
         sh 'make clean'
-      }
+      } }
     }
   }
   post {
-    success { script { load('ci/common.groovy').notifyPR(true) } }
-    failure { script { load('ci/common.groovy').notifyPR(false) } }
+    success { dir(SRC) { script {
+      load('ci/common.groovy').notifyPR(true)
+    } } }
+    failure { dir(SRC) { script {
+      load('ci/common.groovy').notifyPR(false)
+    } } }
   }
 }

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -13,6 +13,8 @@ pipeline {
     timestamps()
     /* Prevent Jenkins jobs from running forever */
     timeout(time: 45, unit: 'MINUTES')
+    /* make project dir the same for consisten nix src */
+    checkoutToSubdirectory('status-react')
     /* Limit builds retained */
     buildDiscarder(logRotator(
       numToKeepStr: '10',
@@ -22,11 +24,14 @@ pipeline {
   }
 
   environment {
+    /* change workspace to keep it consistent for nix src */
+    SRC = "${WORKSPACE}/status-react"
+    /* locale */
     LANG     = "en_US.UTF-8"
     LC_ALL   = "en_US.UTF-8"
     LANGUAGE = "en_US.UTF-8"
     TARGET_OS = 'ios'
-    NIX_CONF_DIR = "${env.WORKSPACE}/nix"
+    NIX_CONF_DIR = "${SRC}/nix"
     FASTLANE_DISABLE_COLORS = 1
     REALM_DISABLE_ANALYTICS = 1
     BUNDLE_PATH = "${HOME}/.bundle"
@@ -38,46 +43,46 @@ pipeline {
 
   stages {
     stage('Prep') {
-      steps {
+      steps { dir(SRC) {
         script {
           /* Necessary to load methods */
-          mobile = load 'ci/mobile.groovy'
-          cmn    = load 'ci/common.groovy'
+          mobile = load("${SRC}/ci/mobile.groovy")
+          cmn    = load("${SRC}/ci/common.groovy")
           btype  = cmn.utils.getBuildType()
           print "Running ${btype} build!"
           cmn.ci.abortPreviousRunningBuilds()
           /* Cleanup and Prep */
           cmn.prep(btype)
         }
-      }
+      } }
     }
     stage('Lint') {
-      steps {
+      steps { dir(SRC) {
         script { cmn.nix.shell('lein cljfmt check') }
-      }
+      } }
     }
     stage('Tests') {
-      steps {
+      steps { dir(SRC) {
         script { cmn.nix.shell('lein test-cljs') }
-      }
+      } }
     }
     stage('Build') {
-      steps {
+      steps { dir(SRC) {
         script { cmn.nix.shell('lein prod-build-ios') }
-      }
+      } }
     }
     stage('Bundle') {
-      steps {
+      steps { dir(SRC) {
         script { api = mobile.ios.bundle() }
-      }
+      } }
     }
     stage('Archive') {
-      steps {
+      steps { dir(SRC) {
         archiveArtifacts api
-      }
+      } }
     }
     stage('Upload') {
-      steps {
+      steps { dir(SRC) {
         script {
           env.PKG_URL = cmn.utils.uploadArtifact(api)
           /* e2e builds get tested in SauceLabs */
@@ -87,16 +92,20 @@ pipeline {
             env.DIAWI_URL = mobile.ios.uploadToDiawi()
           }
         }
-      }
+      } }
     }
     stage('Cleanup') {
-      steps {
+      steps { dir(SRC) {
         sh 'make clean'
-      }
+      } }
     }
   }
   post {
-    success { script { load('ci/common.groovy').notifyPR(true) } }
-    failure { script { load('ci/common.groovy').notifyPR(false) } }
+    success { dir(SRC) { script {
+      load('ci/common.groovy').notifyPR(true)
+    } } }
+    failure { dir(SRC) { script {
+      load('ci/common.groovy').notifyPR(false)
+    } } }
   }
 }

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -13,6 +13,8 @@ pipeline {
     timestamps()
     /* Prevent Jenkins jobs from running forever */
     timeout(time: 40, unit: 'MINUTES')
+    /* make project dir the same for consisten nix src */
+    checkoutToSubdirectory('status-react')
     /* Limit builds retained */
     buildDiscarder(logRotator(
       numToKeepStr: '10',
@@ -26,11 +28,14 @@ pipeline {
    * https://issues.jenkins-ci.org/browse/JENKINS-49076
    **/
   environment {
+    /* change workspace to keep it consistent for nix src */
+    SRC = "${WORKSPACE}/status-react"
+    /* locale */
     LANG     = "en_US.UTF-8"
     LC_ALL   = "en_US.UTF-8"
     LANGUAGE = "en_US.UTF-8"
     TARGET_OS = 'linux'
-    NIX_CONF_DIR = "${env.WORKSPACE}/nix"
+    NIX_CONF_DIR = "${SRC}/nix"
     VERBOSE_LEVEL = '3'
     /* We use EXECUTOR_NUMBER to avoid multiple instances clashing */
     LEIN_HOME         = "/var/tmp/lein-${EXECUTOR_NUMBER}"
@@ -40,62 +45,66 @@ pipeline {
 
   stages {
     stage('Prep') {
-      steps {
+      steps { dir(SRC) {
         script {
           /* Necessary to load methods */
-          desktop = load 'ci/desktop.groovy'
-          cmn     = load 'ci/common.groovy'
+          desktop = load("${SRC}/ci/desktop.groovy")
+          cmn     = load("${SRC}/ci/common.groovy")
           btype   = cmn.utils.getBuildType()
           print "Running ${btype} build!"
           cmn.ci.abortPreviousRunningBuilds()
           /* Cleanup and Prep */
           cmn.prep(btype)
         }
-      }
+      } }
     }
     stage('Lint') {
-      steps {
+      steps { dir(SRC) {
         script { cmn.nix.shell('lein cljfmt check') }
-      }
+      } }
     }
     stage('Tests') {
-      steps {
+      steps { dir(SRC) {
         script { cmn.nix.shell('lein test-cljs') }
-      }
+      } }
     }
     stage('Build') {
-      steps {
+      steps { dir(SRC) {
         script { desktop.buildClojureScript() }
-      }
+      } }
     }
     stage('Compile') {
-      steps {
+      steps { dir(SRC) {
         script { desktop.compile() }
-      }
+      } }
     }
     stage('Bundle') {
-      steps {
+      steps { dir(SRC) {
         script { app = desktop.bundleLinux(btype) }
-      }
+      } }
     }
     stage('Archive') {
-      steps {
+      steps { dir(SRC) {
         archiveArtifacts app
-      }
+      } }
     }
     stage('Upload') {
-      steps {
+      steps { dir(SRC) {
         script { env.PKG_URL = cmn.utils.uploadArtifact(app) }
-      }
+      } }
     }
     stage('Cleanup') {
-      steps {
+      steps { dir(SRC) {
         sh 'make clean'
-      }
+      } }
     }
   }
   post {
-    success { script { load('ci/common.groovy').notifyPR(true) } }
-    failure { script { load('ci/common.groovy').notifyPR(false) } }
+    success { dir(SRC) { script {
+      load('ci/common.groovy').notifyPR(true)
+    } } }
+    failure { dir(SRC) { script {
+      load('ci/common.groovy').notifyPR(false)
+    } } }
   }
 }

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -13,6 +13,8 @@ pipeline {
     timestamps()
     /* Prevent Jenkins jobs from running forever */
     timeout(time: 25, unit: 'MINUTES')
+    /* make project dir the same for consisten nix src */
+    checkoutToSubdirectory('status-react')
     /* Limit builds retained */
     buildDiscarder(logRotator(
       numToKeepStr: '10',
@@ -22,11 +24,14 @@ pipeline {
   }
 
   environment {
+    /* change workspace to keep it consistent for nix src */
+    SRC = "${WORKSPACE}/status-react"
+    /* locale */
     LANG     = "en_US.UTF-8"
     LC_ALL   = "en_US.UTF-8"
     LANGUAGE = "en_US.UTF-8"
     TARGET_OS = 'macos'
-    NIX_CONF_DIR = "${env.WORKSPACE}/nix"
+    NIX_CONF_DIR = "${SRC}/nix"
     VERBOSE_LEVEL = '3'
     /* We use EXECUTOR_NUMBER to avoid multiple instances clashing */
     LEIN_HOME         = "/var/tmp/lein-${EXECUTOR_NUMBER}"
@@ -36,62 +41,66 @@ pipeline {
 
   stages {
     stage('Prep') {
-      steps {
+      steps { dir(SRC) {
         script {
           /* Necessary to load methods */
-          desktop = load 'ci/desktop.groovy'
-          cmn     = load 'ci/common.groovy'
+          desktop = load("${SRC}/ci/desktop.groovy")
+          cmn     = load("${SRC}/ci/common.groovy")
           btype   = cmn.utils.getBuildType()
           print "Running ${btype} build!"
           cmn.ci.abortPreviousRunningBuilds()
           /* Cleanup and Prep */
           cmn.prep(btype)
         }
-      }
+      } }
     }
     stage('Lint') {
-      steps {
+      steps { dir(SRC) {
         script { cmn.nix.shell('lein cljfmt check') }
-      }
+      } }
     }
     stage('Tests') {
-      steps {
+      steps { dir(SRC) {
         script { cmn.nix.shell('lein test-cljs') }
-      }
+      } }
     }
     stage('Build') {
-      steps {
+      steps { dir(SRC) {
         script { desktop.buildClojureScript() }
-      }
+      } }
     }
     stage('Compile') {
-      steps {
+      steps { dir(SRC) {
         script { desktop.compile() }
-      }
+      } }
     }
     stage('Bundle') {
-      steps {
+      steps { dir(SRC) {
         script { dmg = desktop.bundleMacOS(btype) }
-      }
+      } }
     }
     stage('Archive') {
-      steps {
+      steps { dir(SRC) {
         archiveArtifacts dmg
-      }
+      } }
     }
     stage('Upload') {
-      steps {
+      steps { dir(SRC) {
         script { env.PKG_URL = cmn.utils.uploadArtifact(dmg) }
-      }
+      } }
     }
     stage('Cleanup') {
-      steps {
+      steps { dir(SRC) {
         sh 'make clean'
-      }
+      } }
     }
   }
   post {
-    success { script { load('ci/common.groovy').notifyPR(true) } }
-    failure { script { load('ci/common.groovy').notifyPR(false) } }
+    success { dir(SRC) { script {
+      load('ci/common.groovy').notifyPR(true)
+    } } }
+    failure { dir(SRC) { script {
+      load('ci/common.groovy').notifyPR(false)
+    } } }
   }
 }

--- a/ci/Jenkinsfile.nix-cache
+++ b/ci/Jenkinsfile.nix-cache
@@ -1,20 +1,13 @@
 pipeline {
   agent { label params.AGENT_LABEL }
 
-  environment {
-    /* we source .bash_profile to be able to use nix-store */
-    NIX_SSHOPTS = "-o StrictHostKeyChecking=no source .bash_profile;"
-    /* where our /nix/store is hosted */
-    NIX_CACHE_USER = 'nix-cache'
-    NIX_CACHE_HOST = 'master-01.do-ams3.ci.misc.statusim.net'
-    NIX_CONF_DIR = "${env.WORKSPACE}/nix"
-  }
-
   options {
     timestamps()
     disableConcurrentBuilds()
     /* Prevent Jenkins jobs from running forever */
     timeout(time: 300, unit: 'MINUTES')
+    /* make project dir the same for consisten nix src */
+    checkoutToSubdirectory('status-react')
     /* Limit builds retained */
     buildDiscarder(logRotator(
       numToKeepStr: '20',
@@ -22,27 +15,38 @@ pipeline {
     ))
   }
 
+  environment {
+    /* change workspace to keep it consistent for nix src */
+    SRC = "${WORKSPACE}/status-react"
+    /* we source .bash_profile to be able to use nix-store */
+    NIX_SSHOPTS = "-o StrictHostKeyChecking=no source .bash_profile;"
+    /* where our /nix/store is hosted */
+    NIX_CACHE_USER = 'nix-cache'
+    NIX_CACHE_HOST = 'master-01.do-ams3.ci.misc.statusim.net'
+    NIX_CONF_DIR = "${SRC}/nix"
+  }
+
   stages {
     stage('Setup') {
-      steps {
+      steps { dir(SRC) {
         sh 'scripts/setup'
         sh """
           . ~/.nix-profile/etc/profile.d/nix.sh && \
           nix-env -i openssh
         """
-      }
+      } }
     }
     stage('Build') {
-      steps {
+      steps { dir(SRC) {
         sh """
           . ~/.nix-profile/etc/profile.d/nix.sh && \
           nix build -v --no-link && \
           nix-shell --pure --run echo
         """
-      }
+      } }
     }
     stage('Upload') {
-      steps {
+      steps { dir(SRC) {
         sshagent(credentials: ['nix-cache-ssh']) {
           sh """
             . ~/.nix-profile/etc/profile.d/nix.sh && \
@@ -50,7 +54,7 @@ pipeline {
               xargs nix-copy-closure -v --to ${NIX_CACHE_USER}@${NIX_CACHE_HOST}
           """
         }
-      }
+      } }
     }
   }
 }

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -13,6 +13,8 @@ pipeline {
     timestamps()
     /* Prevent Jenkins jobs from running forever */
     timeout(time: 45, unit: 'MINUTES')
+    /* make project dir the same for consisten nix src */
+    checkoutToSubdirectory('status-react')
     /* Limit builds retained */
     buildDiscarder(logRotator(
       numToKeepStr: '10',
@@ -26,11 +28,14 @@ pipeline {
    * https://issues.jenkins-ci.org/browse/JENKINS-49076
    **/
   environment {
+    /* change workspace to keep it consistent for nix src */
+    SRC = "${WORKSPACE}/status-react"
+    /* locale */
     LANG     = "en_US.UTF-8"
     LC_ALL   = "en_US.UTF-8"
     LANGUAGE = "en_US.UTF-8"
     TARGET_OS = 'windows'
-    NIX_CONF_DIR = "${env.WORKSPACE}/nix"
+    NIX_CONF_DIR = "${SRC}/nix"
     VERBOSE_LEVEL = '3'
     /* Conan settings */
     CONAN_PRINT_RUN_COMMANDS = '1'
@@ -44,62 +49,66 @@ pipeline {
 
   stages {
     stage('Prep') {
-      steps {
+      steps { dir(SRC) {
         script {
           /* Necessary to load methods */
-          desktop = load 'ci/desktop.groovy'
-          cmn     = load 'ci/common.groovy'
+          desktop = load("${SRC}/ci/desktop.groovy")
+          cmn     = load("${SRC}/ci/common.groovy")
           btype   = cmn.utils.getBuildType()
           print "Running ${btype} build!"
           cmn.ci.abortPreviousRunningBuilds()
           /* Cleanup and Prep */
           cmn.prep(btype)
         }
-      }
+      } }
     }
     stage('Lint') {
-      steps {
+      steps { dir(SRC) {
         script { cmn.nix.shell('lein cljfmt check') }
-      }
+      } }
     }
     stage('Tests') {
-      steps {
+      steps { dir(SRC) {
         script { cmn.nix.shell('lein test-cljs') }
-      }
+      } }
     }
     stage('Build') {
-      steps {
+      steps { dir(SRC) {
         script { desktop.buildClojureScript() }
-      }
+      } }
     }
     stage('Compile') {
-      steps {
+      steps { dir(SRC) {
         script { desktop.compile() }
-      }
+      } }
     }
     stage('Bundle') {
-      steps {
+      steps { dir(SRC) {
         script { app = desktop.bundleWindows(btype) }
-      }
+      } }
     }
     stage('Archive') {
-      steps {
+      steps { dir(SRC) {
         archiveArtifacts app
-      }
+      } }
     }
     stage('Upload') {
-      steps {
+      steps { dir(SRC) {
         script { env.PKG_URL = cmn.utils.uploadArtifact(app) }
-      }
+      } }
     }
     stage('Cleanup') {
-      steps {
+      steps { dir(SRC) {
         sh 'make clean'
-      }
+      } }
     }
   }
   post {
-    success { script { load('ci/common.groovy').notifyPR(true) } }
-    failure { script { load('ci/common.groovy').notifyPR(false) } }
+    success { dir(SRC) { script {
+      load('ci/common.groovy').notifyPR(true)
+    } } }
+    failure { dir(SRC) { script {
+      load('ci/common.groovy').notifyPR(false)
+    } } }
   }
 }

--- a/ci/android.groovy
+++ b/ci/android.groovy
@@ -89,7 +89,7 @@ def uploadToDiawi() {
       keep: ['FASTLANE_DISABLE_COLORS', 'APK_PATH', 'DIAWI_TOKEN']
     )
   }
-  diawiUrl = readFile "${env.WORKSPACE}/fastlane/diawi.out"
+  diawiUrl = readFile "${SRC}/fastlane/diawi.out"
   return diawiUrl
 }
 

--- a/ci/ios.groovy
+++ b/ci/ios.groovy
@@ -69,7 +69,7 @@ def uploadToDiawi() {
       keep: ['FASTLANE_DISABLE_COLORS', 'DIAWI_TOKEN']
     )
   }
-  diawiUrl = readFile "${env.WORKSPACE}/fastlane/diawi.out"
+  diawiUrl = readFile "${SRC}/fastlane/diawi.out"
   return diawiUrl
 }
 

--- a/ci/nix.groovy
+++ b/ci/nix.groovy
@@ -27,7 +27,7 @@ def shell(Map opts = [:], String cmd) {
         ${keepFlags.join(" ")} \\
         ${argsFlags.join(" ")} \\
         --run \'${cmd}\' \\
-        \'${env.WORKSPACE}/shell.nix\'
+        \'${SRC}/shell.nix\'
   """
 }
 

--- a/ci/utils.groovy
+++ b/ci/utils.groovy
@@ -2,9 +2,9 @@ nix = load 'ci/nix.groovy'
 
 def getVersion(type = null) {
   /* if type is undefined we get VERSION from repo root */
-  def path = "${env.WORKSPACE}/VERSION"
+  def path = "${SRC}/VERSION"
   if (type != null) {
-    path = "${env.WORKSPACE}/${type}/VERSION"
+    path = "${SRC}/${type}/VERSION"
   }
   return readFile(path).trim()
 }
@@ -12,7 +12,7 @@ def getVersion(type = null) {
 def getToolVersion(name) {
   def version = sh(
     returnStdout: true,
-    script: "${env.WORKSPACE}/scripts/toolversion ${name}"
+    script: "${SRC}/scripts/toolversion ${name}"
   ).trim()
   return version
 }
@@ -185,7 +185,7 @@ def changeId() {
 }
 
 def updateEnv(type) {
-  def envFile = "${env.WORKSPACE}/.env"
+  def envFile = "${SRC}/.env"
   /* select .env based on type of build */
   def selectedEnv = '.env.jenkins'
   switch (type) {


### PR DESCRIPTION
This is a possible solution for Pedros issues with changing checkout folder for `status-react`.

It's really ugly, but I can't use [`customWorkspace`](https://jenkins.io/doc/book/pipeline/syntax/#common-options) because the context doesn't have access to `EXECUTOR_NUMBER` variable([JENKINS-50907](https://issues.jenkins-ci.org/browse/JENKINS-50907)). Because of that we can only set a static path, and that would cause clashes when more than 1 job of the same type is running on the same host.

Context: https://discourse.nixos.org/t/path-for-src-in-derivation-file-is-created-with-captured-directory-name-as-suffix/3102