### PR TITLE
rebase only PR builds

### DIFF
--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -42,9 +42,9 @@ pipeline {
       steps {
         script {
           /* Necessary to load methods */
-          mobile = load 'ci/mobile.groovy'
-          cmn    = load 'ci/common.groovy'
-          btype  = cmn.utils.getBuildType()
+          android = load 'ci/android.groovy'
+          cmn     = load 'ci/common.groovy'
+          btype   = cmn.utils.getBuildType()
           print "Running ${btype} build!"
           cmn.ci.abortPreviousRunningBuilds()
           /* Cleanup and Prep */
@@ -69,7 +69,7 @@ pipeline {
     }
     stage('Bundle') {
       steps {
-        script { apk = mobile.android.bundle() }
+        script { apk = android.bundle() }
       }
     }
     stage('Archive') {
@@ -84,11 +84,11 @@ pipeline {
           /* build type specific */
           switch (btype) {
             case 'release':
-              mobile.android.uploadToPlayStore(); break;
+              android.uploadToPlayStore(); break;
             case 'nightly':
-              env.DIAWI_URL = mobile.android.uploadToDiawi(); break;
+              env.DIAWI_URL = android.uploadToDiawi(); break;
             case 'e2e':
-              env.SAUCE_URL = mobile.android.uploadToSauceLabs()
+              env.SAUCE_URL = android.uploadToSauceLabs()
           }
         }
       }
@@ -100,7 +100,7 @@ pipeline {
     }
   }
   post {
-    success { script { load('ci/common.groovy').notifyPR(true) } }
-    failure { script { load('ci/common.groovy').notifyPR(false) } }
+    success { script { load('ci/github.groovy').notifyPR(true) } }
+    failure { script { load('ci/github.groovy').notifyPR(false) } }
   }
 }

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -41,9 +41,9 @@ pipeline {
       steps {
         script {
           /* Necessary to load methods */
-          mobile = load 'ci/mobile.groovy'
-          cmn    = load 'ci/common.groovy'
-          btype  = cmn.utils.getBuildType()
+          ios   = load 'ci/ios.groovy'
+          cmn   = load 'ci/common.groovy'
+          btype = cmn.utils.getBuildType()
           print "Running ${btype} build!"
           cmn.ci.abortPreviousRunningBuilds()
           /* Cleanup and Prep */
@@ -68,7 +68,7 @@ pipeline {
     }
     stage('Bundle') {
       steps {
-        script { api = mobile.ios.bundle() }
+        script { api = ios.bundle() }
       }
     }
     stage('Archive') {
@@ -82,9 +82,9 @@ pipeline {
           env.PKG_URL = cmn.utils.uploadArtifact(api)
           /* e2e builds get tested in SauceLabs */
           if (btype == 'e2e') {
-            env.SAUCE_URL = mobile.ios.uploadToSauceLabs()
+            env.SAUCE_URL = ios.uploadToSauceLabs()
           } else {
-            env.DIAWI_URL = mobile.ios.uploadToDiawi()
+            env.DIAWI_URL = ios.uploadToDiawi()
           }
         }
       }
@@ -96,7 +96,7 @@ pipeline {
     }
   }
   post {
-    success { script { load('ci/common.groovy').notifyPR(true) } }
-    failure { script { load('ci/common.groovy').notifyPR(false) } }
+    success { script { load('ci/github.groovy').notifyPR(true) } }
+    failure { script { load('ci/github.groovy').notifyPR(false) } }
   }
 }

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -95,7 +95,7 @@ pipeline {
     }
   }
   post {
-    success { script { load('ci/common.groovy').notifyPR(true) } }
-    failure { script { load('ci/common.groovy').notifyPR(false) } }
+    success { script { load('ci/github.groovy').notifyPR(true) } }
+    failure { script { load('ci/github.groovy').notifyPR(false) } }
   }
 }

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -91,7 +91,7 @@ pipeline {
     }
   }
   post {
-    success { script { load('ci/common.groovy').notifyPR(true) } }
-    failure { script { load('ci/common.groovy').notifyPR(false) } }
+    success { script { load('ci/github.groovy').notifyPR(true) } }
+    failure { script { load('ci/github.groovy').notifyPR(false) } }
   }
 }

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -99,7 +99,7 @@ pipeline {
     }
   }
   post {
-    success { script { load('ci/common.groovy').notifyPR(true) } }
-    failure { script { load('ci/common.groovy').notifyPR(false) } }
+    success { script { load('ci/github.groovy').notifyPR(true) } }
+    failure { script { load('ci/github.groovy').notifyPR(false) } }
   }
 }

--- a/ci/common.groovy
+++ b/ci/common.groovy
@@ -2,12 +2,9 @@ import groovy.json.JsonBuilder
 
 /* Libraries -----------------------------------------------------------------*/
 
-gh = load 'ci/github.groovy'
 ci = load 'ci/jenkins.groovy'
-gh = load 'ci/github.groovy'
 nix = load 'ci/nix.groovy'
 utils = load 'ci/utils.groovy'
-ghcmgr = load 'ci/ghcmgr.groovy'
 
 /* Small Helpers -------------------------------------------------------------*/
 
@@ -30,19 +27,6 @@ def updateBucketJSON(urls, fileName) {
   println "${fileName}:\n${contentJson}"
   new File(filePath).write(contentJson)
   return utils.uploadArtifact(filePath)
-}
-
-def notifyPR(success) {
-  if (utils.changeId() == null) { return }
-  try {
-    ghcmgr.postBuild(success)
-  } catch (ex) { /* fallback to posting directly to GitHub */
-    println "Failed to use GHCMGR: ${ex}"
-    switch (success) {
-      case true:  gh.notifyPRSuccess(); break
-      case false: gh.notifyPRFailure(); break
-    }
-  }
 }
 
 def prep(type = 'nightly') {

--- a/ci/desktop.groovy
+++ b/ci/desktop.groovy
@@ -1,14 +1,27 @@
 nix = load 'ci/nix.groovy'
-cmn = load 'ci/common.groovy'
 utils = load 'ci/utils.groovy'
 
 packageFolder = './StatusImPackage'
+
+def installJSDeps(platform) {
+  def attempt = 1
+  def maxAttempts = 10
+  def installed = false
+  /* prepare environment for specific platform build */
+  nix.shell "scripts/prepare-for-platform.sh ${platform}"
+  while (!installed && attempt <= maxAttempts) {
+    println "#${attempt} attempt to install npm deps"
+    nix.shell 'yarn install --frozen-lockfile'
+    installed = fileExists('node_modules/web3/index.js')
+    attemp = attempt + 1
+  }
+}
 
 def cleanupAndDeps() {
   sh 'make clean'
   sh 'cp .env.jenkins .env'
   nix.shell 'lein deps'
-  utils.installJSDeps('desktop')
+  installJSDeps('desktop')
 }
 
 def buildClojureScript() {

--- a/ci/github.groovy
+++ b/ci/github.groovy
@@ -1,6 +1,7 @@
 import groovy.json.JsonBuilder
 
-utils = load 'ci/utils.groovy'
+/* I'm using utils from ghcmgr to avoid another load */
+ghcmgr = load 'ci/ghcmgr.groovy'
 
 /**
  * Methods for interacting with GitHub API and related tools.
@@ -10,7 +11,7 @@ utils = load 'ci/utils.groovy'
 
 def notify(message) {
   def githubIssuesUrl = 'https://api.github.com/repos/status-im/status-react/issues'
-  def changeId = utils.changeId() 
+  def changeId = ghcmgr.utils.changeId() 
   if (changeId == null) { return }
   def msgObj = [body: message]
   def msgJson = new JsonBuilder(msgObj).toPrettyString()
@@ -32,7 +33,7 @@ def notify(message) {
 def notifyFull(urls) {
   def msg = "#### :white_check_mark: "
   msg += "[${env.JOB_NAME}${currentBuild.displayName}](${currentBuild.absoluteUrl}) "
-  msg += "CI BUILD SUCCESSFUL in ${utils.buildDuration()} (${GIT_COMMIT.take(8)})\n"
+  msg += "CI BUILD SUCCESSFUL in ${ghcmgr.utils.buildDuration()} (${GIT_COMMIT.take(8)})\n"
   msg += '| | | | | |\n'
   msg += '|-|-|-|-|-|\n'
   msg += "| [Android](${urls.Apk}) ([e2e](${urls.Apke2e})) "
@@ -49,7 +50,7 @@ def notifyPRFailure() {
   def d = ":small_orange_diamond:"
   def msg = "#### :x: "
   msg += "[${env.JOB_NAME}${currentBuild.displayName}](${currentBuild.absoluteUrl}) ${d} "
-  msg += "${utils.buildDuration()} ${d} ${GIT_COMMIT.take(8)} ${d} "
+  msg += "${ghcmgr.utils.buildDuration()} ${d} ${GIT_COMMIT.take(8)} ${d} "
   msg += "[:page_facing_up: build log](${currentBuild.absoluteUrl}/consoleText)"
   //msg += "Failed in stage: ${env.STAGE_NAME}\n"
   //msg += "```${currentBuild.rawBuild.getLog(5)}```"
@@ -59,9 +60,9 @@ def notifyPRFailure() {
 def notifyPRSuccess() {
   def d = ":small_blue_diamond:"
   def msg = "#### :heavy_check_mark: "
-  def type = utils.getBuildType() == 'e2e' ? ' e2e' : ''
+  def type = ghcmgr.utils.getBuildType() == 'e2e' ? ' e2e' : ''
   msg += "[${env.JOB_NAME}${currentBuild.displayName}](${currentBuild.absoluteUrl}) ${d} "
-  msg += "${utils.buildDuration()} ${d} ${GIT_COMMIT.take(8)} ${d} "
+  msg += "${ghcmgr.utils.buildDuration()} ${d} ${GIT_COMMIT.take(8)} ${d} "
   msg += "[:package: ${env.TARGET_OS}${type} package](${env.PKG_URL})"
   notify(msg)
 }
@@ -81,7 +82,7 @@ def getDiffUrl(prev, current) {
 
 def getReleaseChanges() {
   def prevRelease = getPrevRelease()
-  def curRelease = utils.branchName()
+  def curRelease = ghcmgr.utils.branchName()
   def changes = ''
   try {
     changes = sh(returnStdout: true,
@@ -165,7 +166,7 @@ def publishRelease(Map args) {
     pkgDir: args.pkgDir,
     files: args.files,
     version: args.version,
-    branch: utils.branchName(),
+    branch: ghcmgr.utils.branchName(),
     desc: getReleaseChanges(),
   ]
   /* we release only for mobile right now */
@@ -182,14 +183,26 @@ def publishRelease(Map args) {
 
 def publishReleaseMobile() {
   publishRelease(
-    version: utils.getVersion()+'-mobile',
+    version: ghcmgr.utils.getVersion()+'-mobile',
     pkgDir: 'pkg',
     files: [ /* upload only mobile release files */
-      utils.pkgFilename(btype, 'ipa'),
-      utils.pkgFilename(btype, 'apk'),
-      utils.pkgFilename(btype, 'sha256'),
+      ghcmgr.utils.pkgFilename(btype, 'ipa'),
+      ghcmgr.utils.pkgFilename(btype, 'apk'),
+      ghcmgr.utils.pkgFilename(btype, 'sha256'),
     ]
   )
+}
+
+def notifyPR(success) {
+  if (ghcmgr.utils.changeId() == null) { return }
+  try {
+    ghcmgr.postBuild(success)
+  } catch (ex) { /* fallback to posting directly to GitHub */
+    println "Failed to use GHCMGR: ${ex}"
+    switch (success) {
+      case true:  notifyPRSuccess(); break
+    }
+  }
 }
 
 return this

--- a/ci/mobile.groovy
+++ b/ci/mobile.groovy
@@ -1,4 +1,0 @@
-ios = load 'ci/ios.groovy'
-android = load 'ci/android.groovy'
-
-return this


### PR DESCRIPTION
Changes:
* Reversing the logic. Only PR builds should be rebased
* Remove unnecessary `load` calls for `nix.groovy` and other libraries to reduce groovy load time
  - cuts down initial Groovy scripts load from ~25 to 10 seconds for all builds
* Moved `notifyPR` to `github.groovy` to avoid loading all of `common.groovy` at the end of every build
  - cuts down fGroovy load from ~25 to 4 sec of off all builds
  - Thanks for catching that @PombeirP!