### PR TITLE
run checks and build steps in parallel

### DIFF
--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -52,24 +52,32 @@ pipeline {
         }
       }
     }
-    stage('Lint') {
-      steps {
-        script { cmn.nix.shell('lein cljfmt check') }
-      }
-    }
-    stage('Tests') {
-      steps {
-        script { cmn.nix.shell('lein test-cljs') }
-      }
-    }
-    stage('Build') {
-      steps {
-        script { cmn.nix.shell('make prod-build-android')}
-      }
-    }
-    stage('Bundle') {
-      steps {
-        script { apk = android.bundle() }
+    stage('Parallel') {
+      parallel {
+        stage('Checks') { stages {
+          stage('Lint') {
+            steps {
+              script { cmn.nix.shell('lein cljfmt check') }
+            }
+          }
+          stage('Tests') {
+            steps {
+              script { cmn.nix.shell('lein test-cljs') }
+            }
+          }
+        } }
+        stage('Build') { stages {
+          stage('Clojure') {
+            steps {
+              script { cmn.nix.shell('make prod-build-android')}
+            }
+          }
+          stage('Bundle') {
+            steps {
+              script { apk = android.bundle() }
+            }
+          }
+        } }
       }
     }
     stage('Archive') {

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -51,24 +51,32 @@ pipeline {
         }
       }
     }
-    stage('Lint') {
-      steps {
-        script { cmn.nix.shell('lein cljfmt check') }
-      }
-    }
-    stage('Tests') {
-      steps {
-        script { cmn.nix.shell('lein test-cljs') }
-      }
-    }
-    stage('Build') {
-      steps {
-        script { cmn.nix.shell('make prod-build-ios') }
-      }
-    }
-    stage('Bundle') {
-      steps {
-        script { api = ios.bundle() }
+    stage('Parallel') {
+      parallel {
+        stage('Checks') { stages {
+          stage('Lint') {
+            steps {
+              script { cmn.nix.shell('lein cljfmt check') }
+            }
+          }
+          stage('Tests') {
+            steps {
+              script { cmn.nix.shell('lein test-cljs') }
+            }
+          }
+        } }
+        stage('Build') { stages {
+          stage('Clojure') {
+            steps {
+              script { cmn.nix.shell('make prod-build-ios') }
+            }
+          }
+          stage('Bundle') {
+            steps {
+              script { api = ios.bundle() }
+            }
+          }
+        } }
       }
     }
     stage('Archive') {

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -53,29 +53,37 @@ pipeline {
         }
       }
     }
-    stage('Lint') {
-      steps {
-        script { cmn.nix.shell('lein cljfmt check') }
-      }
-    }
-    stage('Tests') {
-      steps {
-        script { cmn.nix.shell('lein test-cljs') }
-      }
-    }
-    stage('Build') {
-      steps {
-        script { desktop.buildClojureScript() }
-      }
-    }
-    stage('Compile') {
-      steps {
-        script { desktop.compile() }
-      }
-    }
-    stage('Bundle') {
-      steps {
-        script { app = desktop.bundleLinux(btype) }
+    stage('Parallel') {
+      parallel {
+        stage('Checks') { stages {
+          stage('Lint') {
+            steps {
+              script { cmn.nix.shell('lein cljfmt check') }
+            }
+          }
+          stage('Tests') {
+            steps {
+              script { cmn.nix.shell('lein test-cljs') }
+            }
+          }
+        } }
+        stage('Build') { stages {
+          stage('Clojure') {
+            steps {
+              script { desktop.buildClojureScript() }
+            }
+          }
+          stage('Compile') {
+            steps {
+              script { desktop.compile() }
+            }
+          }
+          stage('Bundle') {
+            steps {
+              script { app = desktop.bundleLinux(btype) }
+            }
+          }
+        } }
       }
     }
     stage('Archive') {

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -49,29 +49,37 @@ pipeline {
         }
       }
     }
-    stage('Lint') {
-      steps {
-        script { cmn.nix.shell('lein cljfmt check') }
-      }
-    }
-    stage('Tests') {
-      steps {
-        script { cmn.nix.shell('lein test-cljs') }
-      }
-    }
-    stage('Build') {
-      steps {
-        script { desktop.buildClojureScript() }
-      }
-    }
-    stage('Compile') {
-      steps {
-        script { desktop.compile() }
-      }
-    }
-    stage('Bundle') {
-      steps {
-        script { dmg = desktop.bundleMacOS(btype) }
+    stage('Parallel') {
+      parallel {
+        stage('Checks') { stages {
+          stage('Lint') {
+            steps {
+              script { cmn.nix.shell('lein cljfmt check') }
+            }
+          }
+          stage('Tests') {
+            steps {
+              script { cmn.nix.shell('lein test-cljs') }
+            }
+          }
+        } }
+        stage('Build') { stages {
+          stage('Clojure') {
+            steps {
+              script { desktop.buildClojureScript() }
+            }
+          }
+          stage('Compile') {
+            steps {
+              script { desktop.compile() }
+            }
+          }
+          stage('Bundle') {
+            steps {
+              script { dmg = desktop.bundleMacOS(btype) }
+            }
+          }
+        } }
       }
     }
     stage('Archive') {

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -57,29 +57,37 @@ pipeline {
         }
       }
     }
-    stage('Lint') {
-      steps {
-        script { cmn.nix.shell('lein cljfmt check') }
-      }
-    }
-    stage('Tests') {
-      steps {
-        script { cmn.nix.shell('lein test-cljs') }
-      }
-    }
-    stage('Build') {
-      steps {
-        script { desktop.buildClojureScript() }
-      }
-    }
-    stage('Compile') {
-      steps {
-        script { desktop.compile() }
-      }
-    }
-    stage('Bundle') {
-      steps {
-        script { app = desktop.bundleWindows(btype) }
+    stage('Parallel') {
+      parallel {
+        stage('Checks') { stages {
+          stage('Lint') {
+            steps {
+              script { cmn.nix.shell('lein cljfmt check') }
+            }
+          }
+          stage('Tests') {
+            steps {
+              script { cmn.nix.shell('lein test-cljs') }
+            }
+          }
+        } }
+        stage('Build') { stages {
+          stage('Clojure') {
+            steps {
+              script { desktop.buildClojureScript() }
+            }
+          }
+          stage('Compile') {
+            steps {
+              script { desktop.compile() }
+            }
+          }
+          stage('Bundle') {
+            steps {
+              script { app = desktop.bundleWindows(btype) }
+            }
+          }
+        } }
       }
     }
     stage('Archive') {


### PR DESCRIPTION
By running Lint and Test stages in parallel to build stages we lose ~4 min on ever build.

Full manual build in 17 min, compared to usual ~24 of a nightly:
https://ci.status.im/job/status-react/job/manual/354/