### PR TITLE
add NIX_KEEP to add --keep to pyre nix shell

### DIFF
--- a/nix/shell.sh
+++ b/nix/shell.sh
@@ -32,11 +32,17 @@ if command -v "nix" >/dev/null 2>&1; then
     exec nix-shell --show-trace --argstr target-os ${TARGET_OS}
   else
     is_pure=''
-    if [ "${TARGET_OS}" != 'all' ] && [ "${TARGET_OS}" != 'ios' ] && [ "${TARGET_OS}" != 'windows' ]; then
+    if [[ "${TARGET_OS}" != 'all' ]] && [[ "${TARGET_OS}" != 'ios' ]] && [[ "${TARGET_OS}" != 'windows' ]]; then
       is_pure='--pure'
       pure_desc='pure '
     fi
+    # This variable allows specifying which env vars to keep for Nix pure shell
+    # The separator is a semicolon
+    keep_opts=''
+    if [[ -n "${NIX_KEEP}" ]]; then
+      keep_opts="--keep ${NIX_KEEP//;/ --keep }"
+    fi
     echo -e "${GREEN}Configuring ${pure_desc}Nix shell for target '${TARGET_OS}'...${NC}"
-    exec nix-shell ${is_pure} --show-trace --argstr target-os ${TARGET_OS} --run "$@"
+    exec nix-shell ${is_pure} ${keep_opts} --show-trace --argstr target-os ${TARGET_OS} --run "$@"
   fi
 fi


### PR DESCRIPTION
It's not pretty but it's simple. This should help with for what @rasom is trying to do in #8360.

Now we can do something like:

```Makefile
export NIX_KEEP ?= 'BUILD_ENV;WHATEVER_ELSE'

prod-build-android: export TARGET_OS ?= android
prod-build-android: export BUILD_ENV ?= prod
prod-build-android:
lein prod-build-android && \
node prepare-modules.js
```

