### PR TITLE
use nix shell for running fastlane ios clean

### DIFF
--- a/ci/Jenkinsfile.fastlane.clean
+++ b/ci/Jenkinsfile.fastlane.clean
@@ -2,28 +2,32 @@ pipeline {
   agent { label 'macos' }
 
   environment {
-    LANG = "en_US.UTF-8"
-    LANGUAGE = "en_US.UTF-8"
-    LC_ALL = "en_US.UTF-8"
+    LANG      = 'en_US.UTF-8'
+    LANGUAGE  = 'en_US.UTF-8'
+    LC_ALL    = 'en_US.UTF-8'
+    TARGET_OS = 'ios'
     FASTLANE_DISABLE_COLORS = 1
   }
 
   options {
     timestamps()
+    /* Disable concurrent jobs */
+    disableConcurrentBuilds()
     /* Prevent Jenkins jobs from running forever */
     timeout(time: 45, unit: 'MINUTES')
-    buildDiscarder(logRotator(numToKeepStr: '100'))
+    /* Don't keep more than 50 builds */
+    buildDiscarder(logRotator(numToKeepStr: '50'))
   }
 
   stages {
-    stage('Install Deps'){
-      steps {
-        sh ('bundle install --gemfile=fastlane/Gemfile')
-      }
+    stage('Prep') {
+      steps { script {
+        nix = load('ci/nix.groovy')
+        nix.shell('bundle install --gemfile=fastlane/Gemfile')
+      } }
     }
-
     stage('Clean Users'){
-      steps {
+      steps { script {
         withCredentials([
           usernamePassword(
             credentialsId:  'fastlane-match-apple-id',
@@ -31,9 +35,12 @@ pipeline {
             passwordVariable: 'FASTLANE_PASSWORD'
           ),
         ]) {
-          sh ('bundle exec --gemfile=fastlane/Gemfile fastlane ios clean')
+          nix.shell(
+            'bundle exec --gemfile=fastlane/Gemfile fastlane ios clean',
+            keep: ['FASTLANE_APPLE_ID', 'FASTLANE_PASSWORD']
+          )
         }
-      }
+      } }
     }
   }
 }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -234,10 +234,12 @@ platform :ios do
   end
 
   desc "`fastlane ios clean` - remove inactive TestFlight users"
-  desc "uses custom plugin, installed via"
-  desc "`sudo get install fastlane-plugin-clean_testflight_testers`"
   lane :clean do
-    clean_testflight_testers(username: ENV["FASTLANE_APPLE_ID"])
+    clean_testflight_testers(
+      username: ENV["FASTLANE_APPLE_ID"],
+      days_of_inactivity: 30,
+      oldest_build_allowed: 2019032709
+    )
   end
 
   desc "`fastlane ios upload-diawi` - upload .ipa to diawi"


### PR DESCRIPTION
This is a fix that uses Nix to resolve issues for the CI job that cleans up inactive TestFlight users:
https://ci.status.im/job/status-tools/job/clean-testflight-users