### PR TITLE
don't pass any arguments to getVersion

### DIFF
--- a/ci/android.groovy
+++ b/ci/android.groovy
@@ -16,7 +16,7 @@ def bundle() {
       target = 'pr';
       env.NDK_ABI_FILTERS="x86"; break
     case 'release':
-      gradleOpt += "-PreleaseVersion='${utils.getVersion('mobile_files')}'"
+      gradleOpt += "-PreleaseVersion='${utils.getVersion()}'"
   }
 
   dir('android') {


### PR DESCRIPTION
The ab11a67c96 change removed the only argument from the `getVersion()` method but didn't clean a call to it in `android.groovy`, which causes this error in release builds:
```
java.lang.NoSuchMethodError: No such DSL method 'getVersion' found among steps ...
```