### PR TITLE
Ensure shell.nix uses same nixpkgs as the rest of the environment

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,16 +1,11 @@
 # target-os = [ 'windows' 'linux' 'macos' 'darwin' 'android' 'ios' 'all' ]
-{ config ? { android_sdk.accept_license = true; },
-  pkgs ? import ((import <nixpkgs> { }).fetchFromGitHub {
-    owner = "status-im";
-    repo = "nixpkgs";
-    rev = "db492b61572251c2866f6b5e6e94e9d70e7d3021";
-    sha256 = "188r7gbcrxi20nj6xh9bmdf3lbjwb94v9s0wpacl7q39g1fca66h";
-    name = "nixpkgs-source";
-  }) { inherit config; },
+{ config ? null,
+  nixpkgs-bootstrap ? import ./nix/nixpkgs-bootstrap.nix { inherit config; },
+  pkgs ? nixpkgs-bootstrap.pkgs,
   stdenv ? pkgs.stdenv,
   target-os ? "all" }:
 
-(pkgs.callPackage ./derivation.nix { inherit pkgs target-os config; }).overrideAttrs(_: {
+(pkgs.callPackage ./derivation.nix { inherit pkgs target-os; inherit (nixpkgs-bootstrap) config; }).overrideAttrs(_: {
   src = null;
   # TODO: Figure out if there's a better way to do this
   # NOTE: There's a weird difference in behavior between Linux and macOS: in Linux the packages will only be fetched by `nix build` if unpackPhase exists. In macOS it's the other way around :-/

--- a/nix/nixpkgs-bootstrap.nix
+++ b/nix/nixpkgs-bootstrap.nix
@@ -1,0 +1,13 @@
+# This file controls the pinned version of nixpkgs we use for our Nix environment
+{ config ? { android_sdk.accept_license = true; },
+  pkgs ? (import ((import <nixpkgs> { }).fetchFromGitHub {
+    owner = "status-im";
+    repo = "nixpkgs";
+    rev = "db492b61572251c2866f6b5e6e94e9d70e7d3021";
+    sha256 = "188r7gbcrxi20nj6xh9bmdf3lbjwb94v9s0wpacl7q39g1fca66h";
+    name = "nixpkgs-source";
+  })) { inherit config; } }:
+
+{
+  inherit pkgs config;
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,9 +1,10 @@
-{ pkgs ? import <nixpkgs> {},
+{ nixpkgs-bootstrap ? import ./nix/nixpkgs-bootstrap.nix { },
+  pkgs ? nixpkgs-bootstrap.pkgs,
   target-os ? "all" }:
 with pkgs;
 
 let
-  projectDeps = import ./default.nix { inherit target-os; };
+  projectDeps = import ./default.nix { inherit target-os; inherit (nixpkgs-bootstrap) config; };
   platform = callPackage ./nix/platform.nix { inherit target-os; };
   useFastlanePkg = (platform.targetAndroid && !stdenv'.isDarwin);
   # TODO: Try to use stdenv for iOS. The problem is with building iOS as the build is trying to pass parameters to Apple's ld that are meant for GNU's ld (e.g. -dynamiclib)


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes https://github.com/status-im/infra-ci/issues/6

### Summary

[comment]: # (Summarise the problem and how the pull request solves it)
This PR ensures a single source of truth for our pinned version of nixpkgs and ensures that shell.nix follows it.

status: ready <!-- Can be ready or wip -->