### PR TITLE
Tx in Dapp multiaccount followup e2e fix

### DIFF
--- a/test/appium/tests/atomic/transactions/test_daaps_transactions.py
+++ b/test/appium/tests/atomic/transactions/test_daaps_transactions.py
@@ -45,8 +45,8 @@ class TestTransactionDApp(SingleDeviceTestCase):
         sender = transaction_senders['L']
         sign_in_view = SignInView(self.driver)
         home_view = sign_in_view.recover_access(sender['passphrase'])
-        wallet_view = home_view.wallet_button.click()
-        wallet_view.set_up_wallet()
+        # wallet_view = home_view.wallet_button.click()
+        # wallet_view.set_up_wallet()  ##  will be updated when 'View signing phrase' enabled
         status_test_dapp = home_view.open_status_test_dapp()
         status_test_dapp.wait_for_d_aap_to_load()
         status_test_dapp.transactions_button.click()
@@ -63,8 +63,8 @@ class TestTransactionDApp(SingleDeviceTestCase):
         sender = transaction_senders['W']
         sign_in_view = SignInView(self.driver)
         home_view = sign_in_view.recover_access(sender['passphrase'])
-        wallet_view = home_view.wallet_button.click()
-        wallet_view.set_up_wallet()
+        # wallet_view = home_view.wallet_button.click()
+        # wallet_view.set_up_wallet()  ##  will be updated when 'View signing phrase' enabled
         status_test_dapp = home_view.open_status_test_dapp()
         status_test_dapp.wait_for_d_aap_to_load()
         status_test_dapp.transactions_button.click()
@@ -80,8 +80,8 @@ class TestTransactionDApp(SingleDeviceTestCase):
         sender = transaction_senders['W']
         sign_in_view = SignInView(self.driver)
         home_view = sign_in_view.recover_access(sender['passphrase'])
-        wallet_view = home_view.wallet_button.click()
-        wallet_view.set_up_wallet()
+        # wallet_view = home_view.wallet_button.click()
+        # wallet_view.set_up_wallet()  ##  will be updated when 'View signing phrase' enabled
         status_test_dapp = home_view.open_status_test_dapp()
         status_test_dapp.wait_for_d_aap_to_load()
         status_test_dapp.transactions_button.click()
@@ -100,8 +100,8 @@ class TestTransactionDApp(SingleDeviceTestCase):
         sender = transaction_senders['Z']
         sign_in_view = SignInView(self.driver)
         home_view = sign_in_view.recover_access(sender['passphrase'])
-        wallet_view = home_view.wallet_button.click()
-        wallet_view.set_up_wallet()
+        # wallet_view = home_view.wallet_button.click()
+        # wallet_view.set_up_wallet()  ##  will be updated when 'View signing phrase' enabled
         status_test_dapp = home_view.open_status_test_dapp()
         status_test_dapp.wait_for_d_aap_to_load()
         status_test_dapp.transactions_button.click()
@@ -121,8 +121,8 @@ class TestTransactionDApp(SingleDeviceTestCase):
         sender = transaction_senders['M']
         sign_in_view = SignInView(self.driver)
         home_view = sign_in_view.recover_access(sender['passphrase'], unique_password)
-        wallet_view = home_view.wallet_button.click()
-        wallet_view.set_up_wallet()
+        # wallet_view = home_view.wallet_button.click()
+        # wallet_view.set_up_wallet()  ##  will be updated when 'View signing phrase' enabled
         status_test_dapp = home_view.open_status_test_dapp()
         status_test_dapp.wait_for_d_aap_to_load()
         status_test_dapp.assets_button.click()
@@ -159,11 +159,12 @@ class TestTransactionDApp(SingleDeviceTestCase):
         status_test_dapp.ok_button.click()
         status_test_dapp.cross_icon.click()
         wallet_view = sign_in_view.wallet_button.click()
-        wallet_view.set_up_wallet()
+        # wallet_view.set_up_wallet()  ##  will be updated when 'View signing phrase' enabled
         wallet_view.wait_balance_changed_on_wallet_screen()
 
     @marks.testrail_id(5355)
     @marks.medium
+    @marks.skip  # No onboarding for now. TO re-enable once wallet onboarding done
     def test_onboarding_screen_when_requesting_tokens_for_new_account(self):
         signin_view = SignInView(self.driver)
         home_view = signin_view.create_user()
@@ -176,6 +177,7 @@ class TestTransactionDApp(SingleDeviceTestCase):
 
     @marks.testrail_id(5677)
     @marks.high
+    @marks.skip  # No onboarding for now. TO re-enable once wallet onboarding done
     def test_onboarding_screen_when_requesting_tokens_for_recovered_account(self):
         signin_view = SignInView(self.driver)
         home_view = signin_view.recover_access(passphrase=transaction_senders['U']['passphrase'])
@@ -188,6 +190,7 @@ class TestTransactionDApp(SingleDeviceTestCase):
 
     @marks.testrail_id(5380)
     @marks.high
+    @marks.skip  # No onboarding for now. TO re-enable once wallet onboarding done
     def test_user_can_complete_tx_to_dapp_when_onboarding_via_dapp_completed(self):
         user = transaction_recipients['G']
         signin_view = SignInView(self.driver)


### PR DESCRIPTION
Quick fix for new wallet (multiaccount) e2e in daaps_transaction module: three tests were disabled because they have no sense to run without Onboarding. In the rest - commented wallet_set_up.
`wallet_button.click()` will be handled in separate PR (so I didn't touch `test_not_enough_eth_for_gas*` tests)