### PR TITLE
Don't provide --apk=, it's already there

### DIFF
--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -106,7 +106,7 @@ pipeline {
         e2eApk = cmn.utils.getEnv(apke2e, 'SAUCE_URL')
         build(
           job: 'end-to-end-tests/status-app-nightly', wait: false,
-          parameters: [string(name: 'apk', value: "--apk=${e2eApk}")]
+          parameters: [string(name: 'APK_NAME', value: e2eApk)]
         )
       } }
     }

--- a/ci/Jenkinsfile.nightly-end-to-end
+++ b/ci/Jenkinsfile.nightly-end-to-end
@@ -51,9 +51,13 @@ pipeline {
   post {
     always {
       script {
-        sauce('12e007ad-48cf-4c20-92f3-b923bb5641bd') {
+        sauce('sauce-labs-cred') {
           saucePublisher()
         }
+      }
+    }
+    success {
+      script {
         junit(
           testDataPublishers: [[$class: 'SauceOnDemandReportPublisher', jobVisibility: 'public']],
           testResults: 'test/appium/tests/*.xml'

--- a/ci/android.groovy
+++ b/ci/android.groovy
@@ -71,8 +71,11 @@ def uploadToSauceLabs() {
     env.SAUCE_LABS_NAME = "${pkg}"
   }
   withCredentials([
-    string(credentialsId: 'SAUCE_ACCESS_KEY', variable: 'SAUCE_ACCESS_KEY'),
-    string(credentialsId: 'SAUCE_USERNAME', variable: 'SAUCE_USERNAME'),
+    usernamePassword(
+      credentialsId:  'sauce-labs-api',
+      usernameVariable: 'SAUCE_USERNAME',
+      passwordVariable: 'SAUCE_ACCESS_KEY'
+    ),
   ]) {
     nix.shell(
       'fastlane android saucelabs',

--- a/ci/ios.groovy
+++ b/ci/ios.groovy
@@ -81,8 +81,11 @@ def uploadToSauceLabs() {
     env.SAUCE_LABS_NAME = "im.status.ethereum-e2e-${utils.gitCommit()}.app.zip"
   }
   withCredentials([
-    string(credentialsId: 'SAUCE_ACCESS_KEY', variable: 'SAUCE_ACCESS_KEY'),
-    string(credentialsId: 'SAUCE_USERNAME', variable: 'SAUCE_USERNAME'),
+    usernamePassword(
+      credentialsId:  'sauce-labs-api',
+      usernameVariable: 'SAUCE_USERNAME',
+      passwordVariable: 'SAUCE_ACCESS_KEY'
+    ),
   ]) {
     nix.shell(
       'bundle exec --gemfile=fastlane/Gemfile fastlane ios saucelabs',


### PR DESCRIPTION
Tiny fix for how Nightly builds trigger e2e tests by passing the filename of the APK to test.

Also updated the name of the SauceLabs credential in Jenkins.

Related to: #8451