### PR TITLE
don't raise exception on testrail api errors

### DIFF
--- a/test/appium/support/testrail_report.py
+++ b/test/appium/support/testrail_report.py
@@ -1,5 +1,6 @@
 import json
 import requests
+import logging
 import emoji
 import base64
 from os import environ
@@ -33,7 +34,7 @@ class TestrailReport(BaseTestReport):
     def get(self, method):
         rval = requests.get(self.api_url + method, headers=self.headers).json()
         if 'error' in rval:
-            raise Exception('Failed request: %s' % rval['error'])
+            logging.error("Failed TestRail request: %s" % rval['error'])
         return rval
 
     def post(self, method, data):


### PR DESCRIPTION
Looks like raising an error here makes the PR end-to-end tests fail:
```
...
  File "/home/jenkins/workspace/end-to-end-tests/status-app-end-to-end-tests/test/appium/support/github_report.py", line 29, in build_html_report
    passed_tests_html = self.build_tests_table_html(passed_tests, run_id, failed_tests=False)
  File "/home/jenkins/workspace/end-to-end-tests/status-app-end-to-end-tests/test/appium/support/github_report.py", line 49, in build_tests_table_html
    html += self.build_test_row_html(i, test, run_id)
  File "/home/jenkins/workspace/end-to-end-tests/status-app-end-to-end-tests/test/appium/support/github_report.py", line 56, in build_test_row_html
    test_rail_link = TestrailReport().get_test_result_link(run_id, test.testrail_case_id)
  File "/home/jenkins/workspace/end-to-end-tests/status-app-end-to-end-tests/test/appium/support/testrail_report.py", line 120, in get_test_result_link
    test_id = self.get('get_results_for_case/%s/%s' % (test_run_id, test_case_id))[0]['test_id']
  File "/home/jenkins/workspace/end-to-end-tests/status-app-end-to-end-tests/test/appium/support/testrail_report.py", line 36, in get
    raise Exception('Failed request: %s' % rval['error'])
Exception: Failed request: No (active) test found for the run/case combination.
```
https://ci.status.im/job/end-to-end-tests/job/status-app-end-to-end-tests/3095/console