### PR TITLE
add missing android sdk license acceptance in nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,5 @@
 # target-os = [ 'windows' 'linux' 'macos' 'darwin' 'android' 'ios' 'all' ]
-{ config ? null,
+{ config ? { android_sdk.accept_license = true; },
   nixpkgs-bootstrap ? import ./nix/nixpkgs-bootstrap.nix { inherit config; },
   pkgs ? nixpkgs-bootstrap.pkgs,
   stdenv ? pkgs.stdenv,


### PR DESCRIPTION
Tiny fix for Linux Nix Cache builds failing with:
```
 + nix build -v --no-link
error: value is null while a set was expected, at /nix/store/q9i5qy8xbp0jy3k34dh794pc8n766nnm-nixpkgs-source/pkgs/top-level/default.nix:63:5
```
https://ci.status.im/job/status-react/job/nix-cache/job/linux/338/