### PR TITLE
Fix iOS status-go build error

### DIFF
--- a/nix/mobile/reset-node_modules.sh
+++ b/nix/mobile/reset-node_modules.sh
@@ -27,7 +27,12 @@ needCopyModules=1
 if [ -d "$nodeModulesDir" ]; then
   if [ -f "$nodeModulesDir/.copied~" ]; then
     echo "Checking for modifications in node_modules..."
-    modifiedFiles=( $(find $nodeModulesDir -writable -type f -newer $nodeModulesDir/.copied~ -not \( -path "$nodeModulesDir/react-native/third-party/*" -prune -o -path './resources/icons/*' -prune \) -print) )
+    modifiedFiles=( $(find $nodeModulesDir -writable -type f -newer $nodeModulesDir/.copied~ \
+      -not \( -path "$nodeModulesDir/react-native/third-party/*" -prune \
+           -o -path "$nodeModulesDir/react-native/ReactAndroid/build/*" -prune \
+           -o -path "$nodeModulesDir/*/android/build/*" -prune \
+           -o -path "$nodeModulesDir/realm/src/*" -prune \
+           -o -path './resources/icons/*' -prune \) -print) )
     if [ ${#modifiedFiles[@]} -eq 0 ]; then
       needCopyModules=0
       echo "No modifications detected."

--- a/nix/status-go/build-mobile-status-go.nix
+++ b/nix/status-go/build-mobile-status-go.nix
@@ -20,19 +20,22 @@ let
 
     buildMessage = "Building mobile library for ${targetConfig.name}";
     # Build mobile libraries
-    buildPhase = ''
-      mkdir $NIX_BUILD_TOP/go-build
+    buildPhase =
+      let
+        NIX_GOWORKDIR = "$NIX_BUILD_TOP/go-build";
+      in ''
+      mkdir ${NIX_GOWORKDIR}
 
       GOPATH=${gomobile.dev}:$GOPATH \
       PATH=${makeBinPath [ gomobile.bin ]}:$PATH \
+      NIX_GOWORKDIR=${NIX_GOWORKDIR} \
       ${concatStringsSep " " targetConfig.envVars} \
-      NIX_GOWORKDIR=$NIX_BUILD_TOP/go-build \
       gomobile bind ${goBuildFlags} -target=${targetConfig.name} ${concatStringsSep " " targetConfig.gomobileExtraFlags} \
                     -o ${targetConfig.outputFileName} \
                     ${goBuildLdFlags} \
                     ${goPackagePath}/mobile
 
-      rm -rf $NIX_BUILD_TOP/go-build
+      rm -rf ${NIX_GOWORKDIR}
     '';
 
     installPhase = ''


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

### Summary

[comment]: # (Summarise the problem and how the pull request solves it)
This PR patches an additional location in gomobile sources for determinism and fixes an error in the iOS status-go build that may happen on some machines: https://gist.github.com/flexsurfer/aceace6f115ea13f48ee83de50e01328#file-gistfile1-txt-L15

It also relaxes the filter of the files that cause node_modules to be recopied from the Nix Store, so that caching can occur for Realm and ReactAndroid builds.

status: ready <!-- Can be ready or wip -->