### PR TITLE
[TESTS] False failed tests fixed - chat, browsing, deeps links, transactions

### DIFF
--- a/test/appium/support/utilities.py
+++ b/test/appium/support/utilities.py
@@ -1,6 +1,6 @@
-from operator import itemgetter
-from typing import List
 from datetime import datetime
+from operator import itemgetter
+from typing import Dict
 
 
 def fill_string_with_char(string: str, fillchar: str, amount: int, start: bool = False, end: bool = False) -> str:
@@ -30,7 +30,7 @@ def fill_string_with_char(string: str, fillchar: str, amount: int, start: bool =
     return string_revised
 
 
-def get_merged_txs_list(normal_txs_list, token_events_list) -> List[dict]:
+def get_merged_txs_list(normal_txs_list, token_events_list) -> Dict[str, Dict[str, str]]:
     res = []
     for i in normal_txs_list:
         for j in token_events_list:
@@ -38,7 +38,8 @@ def get_merged_txs_list(normal_txs_list, token_events_list) -> List[dict]:
                 normal_txs_list.remove(i)
     res.extend(normal_txs_list)
     res.extend(token_events_list)
-    return sorted(res, key=itemgetter('timeStamp'), reverse=True)
+    txs_list = sorted(res, key=itemgetter('timeStamp'), reverse=True)
+    return dict((item['hash'], item) for item in txs_list)
 
 
 def generate_timestamp():

--- a/test/appium/tests/atomic/chats/test_one_to_one.py
+++ b/test/appium/tests/atomic/chats/test_one_to_one.py
@@ -694,7 +694,7 @@ class TestMessagesOneToOneChatSingle(SingleDeviceTestCase):
         home_view = sign_in_view.create_user()
 
         wallet_view = home_view.wallet_button.click()
-        # wallet_view.set_up_wallet()
+        wallet_view.set_up_wallet()
         wallet_address = wallet_view.get_wallet_address()
         home_view = wallet_view.get_back_to_home_view()
 

--- a/test/appium/tests/atomic/dapps_and_browsing/test_browsing.py
+++ b/test/appium/tests/atomic/dapps_and_browsing/test_browsing.py
@@ -70,7 +70,8 @@ class TestBrowsing(SingleDeviceTestCase):
         daap_view = home_view.dapp_tab_button.click()
         browsing_view = daap_view.open_url('google.com')
         browsing_view.cross_icon.click()
-        browser_entry = daap_view.get_browser_entry('Google').scroll_to_element()
+        browser_entry = daap_view.get_browser_entry('Google')
+        browser_entry.scroll_to_element()
         browser_entry.swipe_and_delete()
         home_view.relogin()
         if browser_entry.is_element_present(20):

--- a/test/appium/tests/atomic/dapps_and_browsing/test_deep_links.py
+++ b/test/appium/tests/atomic/dapps_and_browsing/test_deep_links.py
@@ -74,9 +74,7 @@ class TestDeepLinks(SingleDeviceTestCase):
         self.driver.close_app()
         deep_link = 'https://get.status.im/user/%s' % basic_user['public_key'][:-10]
         sign_in_view.open_weblink_and_login(deep_link)
-        chat_view = sign_in_view.get_home_view()
-        chat_view.plus_button.click()
-        try:
-            assert chat_view.start_new_chat_button.is_element_present()
-        except (AssertionError, NoSuchElementException):
+        home_view = sign_in_view.get_home_view()
+        home_view.plus_button.click_until_presence_of_element(home_view.start_new_chat_button)
+        if not home_view.start_new_chat_button.is_element_present():
             pytest.fail("Can't navigate to start new chat after app opened from deep link with invalid public key")

--- a/test/appium/tests/atomic/transactions/test_daaps_transactions.py
+++ b/test/appium/tests/atomic/transactions/test_daaps_transactions.py
@@ -274,7 +274,7 @@ class TestTransactionDApp(SingleDeviceTestCase):
         send_transaction_view.gas_price_input.clear()
         send_transaction_view.gas_price_input.set_value(gas_price)
         send_transaction_view.update_fee_button.click()
-        send_transaction_view.done_button.click()
+        # send_transaction_view.done_button.click()
 
         # Check whether sending a tx in batch with normal gas limit and price does not trigger the warning
         # so the transaction can be signed
@@ -338,6 +338,7 @@ class TestTransactionDApp(SingleDeviceTestCase):
         self.network_api.verify_balance_is_updated(initial_balance=0, recipient_address=wallet_address[2:])
 
         wallet = home_view.wallet_button.click()
+        wallet.accounts_status_account.click()
         wallet.send_transaction(asset_name='ETHro', amount=0.1, recipient=recipient, sign_transaction=False)
 
         # Check whether sending all available ETH triggers the warning

--- a/test/appium/tests/atomic/transactions/test_wallet.py
+++ b/test/appium/tests/atomic/transactions/test_wallet.py
@@ -391,27 +391,19 @@ class TestTransactionWalletSingleDevice(SingleDeviceTestCase):
         transaction_view = wallet_view.transaction_history_button.click()
 
         status_tx_number = transaction_view.transactions_table.get_transactions_number()
-        actual_txs_list = []
+        if status_tx_number < 1:
+            self.driver.fail('No transactions found')
 
         for n in range(status_tx_number):
             transactions_details = transaction_view.transactions_table.transaction_by_index(n).click()
-
-            status_tx = {
-                'hash': transactions_details.get_transaction_hash(),
-                'from': transactions_details.get_sender_address(),
-                'to': transactions_details.get_recipient_address(),
-            }
-            actual_txs_list.append(status_tx)
-            transactions_details.back_button.click()
-
-            if [tx['hash'] for tx in actual_txs_list] != [tx['hash'] for tx in expected_txs_list]:
-                self.errors.append('Transactions hashes do not match!')
-
-            if [tx['from'] for tx in actual_txs_list] != [tx['from'] for tx in expected_txs_list]:
+            tx_hash = transactions_details.get_transaction_hash()
+            tx_from = transactions_details.get_sender_address()
+            tx_to = transactions_details.get_recipient_address()
+            if tx_from != expected_txs_list[tx_hash]['from']:
                 self.errors.append('Transactions senders do not match!')
-
-            if [tx['to'] for tx in actual_txs_list] != [tx['to'] for tx in expected_txs_list]:
+            if tx_to != expected_txs_list[tx_hash]['to']:
                 self.errors.append('Transactions recipients do not match!')
+            transactions_details.back_button.click()
 
         self.verify_no_errors()
 

--- a/test/appium/views/home_view.py
+++ b/test/appium/views/home_view.py
@@ -106,6 +106,8 @@ class ChatElement(BaseButton):
                 break
             time.sleep(3)
             counter += 1
+        else:
+            raise NoSuchElementException('Unable to swipe and delete - Delete button is not found') from None
         self.swipe_delete_button.click()
 
     @property


### PR DESCRIPTION
fixes #8633 

Updated tests:

- test_can_see_all_transactions_in_history
- test_purchase_pack_and_send_sticker
- test_not_enough_eth_for_gas_validation_from_wallet
- test_not_enough_eth_for_gas_validation_from_dapp
- test_deep_link_with_invalid_user_public_key

status: ready <!-- Can be ready or wip -->
