### PR TITLE
[TESTS] E2E tests false failures fixes

### DIFF
--- a/test/appium/tests/atomic/account_management/test_profile.py
+++ b/test/appium/tests/atomic/account_management/test_profile.py
@@ -249,9 +249,8 @@ class TestProfileSingleDevice(SingleDeviceTestCase):
         profile = home_view.profile_button.click()
         profile.switch_network(network_name)
         profile = home_view.profile_button.click()
-        profile.network_settings_button.scroll_to_element()
         if not profile.current_active_network == network_name:
-             self.driver.fail('Oops! Wrong network selected!')
+            self.driver.fail('Oops! Wrong network selected!')
 
     @marks.testrail_id(5453)
     @marks.medium
@@ -283,7 +282,8 @@ class TestProfileSingleDevice(SingleDeviceTestCase):
         profile.logout()
         if signin_view.ok_button.is_element_displayed():
             signin_view.ok_button.click()
-        signin_view.other_multiaccounts_button.click()
+        signin_view.back_button.click()
+        signin_view.generate_new_key_button.click()
 
         if not signin_view.privacy_policy_link.is_element_displayed():
             self.driver.fail('{} Sign in view!'.format(no_link_found_error_msg))

--- a/test/appium/tests/atomic/chats/test_one_to_one.py
+++ b/test/appium/tests/atomic/chats/test_one_to_one.py
@@ -59,7 +59,7 @@ class TestMessagesOneToOneChatMultiple(MultipleDeviceTestCase):
 
         home_1.airplane_mode_button.click()  # turning on WiFi connection on primary device
 
-        home_1.connection_status.wait_for_invisibility_of_element(20)
+        home_1.connection_status.wait_for_invisibility_of_element(30)
         chat_element = home_1.get_chat_with_user(username_2)
         chat_element.wait_for_visibility_of_element(20)
         chat_1 = chat_element.click()
@@ -69,6 +69,7 @@ class TestMessagesOneToOneChatMultiple(MultipleDeviceTestCase):
         home_1.airplane_mode_button.click()  # airplane mode on primary device
 
         chat_2.element_by_text('Connecting to peers...').wait_for_invisibility_of_element(60)
+        chat_2.connection_status.wait_for_invisibility_of_element(30)
         message_2 = 'one more message'
         chat_2.chat_message_input.send_keys(message_2)
         chat_2.send_message_button.click()
@@ -242,13 +243,7 @@ class TestMessagesOneToOneChatMultiple(MultipleDeviceTestCase):
         sign_in = SignInView(self.drivers[0])
         home_view = sign_in.create_user()
 
-        # Dismiss "Welcome to Status" placeholder.
-        # When the placeholder is visible, the offline status bar does not appear
-        wallet_view = home_view.wallet_button.click()
-        wallet_view.home_button.click()
-        home_view.toggle_airplane_mode()
-        home_view.accept_agreements()
-        home_view = sign_in.sign_in()
+        home_view.airplane_mode_button.click()
 
         chat = home_view.add_contact(transaction_senders['C']['public_key'])
         if chat.connection_status.text != 'Offline':

--- a/test/appium/tests/atomic/transactions/test_daaps_transactions.py
+++ b/test/appium/tests/atomic/transactions/test_daaps_transactions.py
@@ -350,15 +350,13 @@ class TestTransactionDApp(SingleDeviceTestCase):
         send_transaction_view.sign_with_password.click()
         if send_transaction_view.enter_password_input.is_element_displayed():
             self.errors.append('sending all available ETH (no funds to pay gas)')
-        send_transaction_view.cancel_button.click()
-        send_transaction_view.amount_edit_box.clear()
 
         # Because tx gas price may change we calculate eth value according to current gas fee value
-        send_transaction_view.sign_transaction_button.click()
         transaction_fee_total = send_transaction_view.get_transaction_fee_total()
         eth_available_for_tx = str(Decimal('0.1') - Decimal(transaction_fee_total))
         wei = '0.000000000000000001'
         eth_value_plus_one_wei = ''.join([eth_available_for_tx, wei[len(eth_available_for_tx):]])
+        send_transaction_view.amount_edit_box.clear()
         send_transaction_view.amount_edit_box.set_value(eth_value_plus_one_wei)
         send_transaction_view.confirm()
 
@@ -371,6 +369,7 @@ class TestTransactionDApp(SingleDeviceTestCase):
         if send_transaction_view.enter_password_input.is_element_displayed():
             self.errors.append('sending big amount of ETH (no funds to pay gas)')
 
+        send_transaction_view.cancel_button.click()
         send_transaction_view.amount_edit_box.clear()
         send_transaction_view.amount_edit_box.set_value(eth_available_for_tx)
         send_transaction_view.confirm()
@@ -379,6 +378,7 @@ class TestTransactionDApp(SingleDeviceTestCase):
         if send_transaction_view.validation_warnings.not_enough_eth_for_gas.is_element_displayed():
             self.errors.append('"Not enough ETH for gas" warning appeared while sending normal amount of ETH')
 
+        send_transaction_view.sign_transaction_button.click()
         send_transaction_view.sign_transaction()
         if not wallet.send_transaction_button.is_element_displayed():
             self.errors.append('Could not sign the transaction!')

--- a/test/appium/views/home_view.py
+++ b/test/appium/views/home_view.py
@@ -167,7 +167,7 @@ class HomeView(BaseView):
         return ChatElement(self.driver, username[:25])
 
     def add_contact(self, public_key):
-        self.plus_button.click()
+        self.plus_button.click_until_presence_of_element(self.start_new_chat_button)
         contacts_view = self.start_new_chat_button.click()
         contacts_view.public_key_edit_box.click()
         contacts_view.public_key_edit_box.send_keys(public_key)


### PR DESCRIPTION
fixes #8667 

Updated tests:

- test_offline_messaging_1_1_chat
- test_offline_status (updated add_contact method)
- test_privacy_policy_is_accessible (will fail because Privacy Policy link is absent after logout)
- test_user_can_switch_network
- test_not_enough_eth_for_gas_validation_from_wallet

status: ready <!-- Can be ready or wip -->
