### PR TITLE
ENS names: starting chat, adding own ENS to profile

### DIFF
--- a/test/appium/tests/atomic/chats/test_one_to_one.py
+++ b/test/appium/tests/atomic/chats/test_one_to_one.py
@@ -9,7 +9,7 @@ from selenium.common.exceptions import TimeoutException
 
 from tests import marks, get_current_time
 from tests.base_test_case import MultipleDeviceTestCase, SingleDeviceTestCase
-from tests.users import transaction_senders, transaction_recipients, basic_user
+from tests.users import transaction_senders, transaction_recipients, basic_user, ens_user
 from views.sign_in_view import SignInView
 
 
@@ -716,3 +716,15 @@ class TestMessagesOneToOneChatSingle(SingleDeviceTestCase):
         chat.swipe_left()
         chat.sticker_icon.click()
         chat.chat_item.is_element_displayed()
+
+    @marks.testrail_id(5403)
+    @marks.critical
+    def test_start_chat_with_ens(self):
+        sign_in = SignInView(self.driver)
+        home = sign_in.create_user()
+        profile = home.profile_button.click()
+        profile.switch_network('Mainnet with upstream RPC')
+        chat = home.add_contact(ens_user['ens'])
+        if not chat.element_by_text(ens_user['username']).is_element_displayed():
+            self.driver.fail('Wrong user is resolved from username when starting 1-1 chat.')
+

--- a/test/appium/tests/users.py
+++ b/test/appium/tests/users.py
@@ -6,6 +6,13 @@ basic_user['public_key'] = "0x040d3400f0ba80b2f6017a9021a66e042abc33cf7051ddf98a
 basic_user['address'] = "f184747445c3B85CEb147DfB136067CB93d95F1D"
 basic_user['special_chars_password'] = " !\"#$Á%Ö&'()*+Í, -./:ä;<=>?@[\\]^_`{|}~ "
 
+ens_user = dict()
+ens_user['passphrase'] = "husband rough hotel obey annual you member reopen struggle air evoke taxi"
+ens_user['username'] = "Wan Sharp Bettong"
+ens_user['public_key'] = "0x042d693dc861dbd1da8542c9614dbea58a488dc3da822759a539279cdf9234de987342ca17009dcc97fbabf" \
+                         "00a606b770d92c3932e484a2b868eef2915982a24c6"
+ens_user['ens'] = 'autotester'
+
 wallet_users = dict()
 
 wallet_users['A'] = dict()

--- a/test/appium/views/dapps_view.py
+++ b/test/appium/views/dapps_view.py
@@ -30,6 +30,15 @@ class BrowserEntry(ChatElement):
         super(BrowserEntry, self).__init__(driver, name)
         self.locator = self.Locator.xpath_selector('//*[@text="%s"]/..' % name)
 
+class EnsName(BaseEditBox):
+    def __init__(self, driver):
+        super(EnsName, self).__init__(driver)
+        self.locator = self.Locator.xpath_selector('//android.widget.EditText')
+
+class EnsCheckName(BaseButton):
+        def __init__(self, driver):
+            super(EnsCheckName, self).__init__(driver)
+            self.locator = self.Locator.xpath_selector('//android.widget.EditText//following-sibling::android.view.ViewGroup[1]')
 
 class DappsView(BaseView):
 
@@ -39,6 +48,10 @@ class DappsView(BaseView):
         self.open_d_app_button = OpenDAppButton(self.driver)
         self.open_button = OpenButton(self.driver)
         self.enter_url_editbox = EnterUrlEditbox(self.driver)
+
+        #ens dapp
+        self.ens_name = EnsName(self.driver)
+        self.check_ens_name = EnsCheckName(self.driver)
 
     def open_url(self, url):
         self.enter_url_editbox.click()


### PR DESCRIPTION
1) https://ethstatus.testrail.net/index.php?/cases/view/5403 - can start to chat with ENS name
2) https://ethstatus.testrail.net/index.php?/cases/view/5502 - can register own username.
However, I think it should be split into 2 separate tests: 
- buy new ENS username (not sure if there is any sense to automate in on Ropsten)
- add already registered ENS username (made in this PR)

