### PR TITLE
Set new folder for codeowners in e2e

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -33,4 +33,4 @@ modules/react-native-desktop*/  @vkjr
 
 /deployment @vkjr @PombeirP
 
-/test    @antdanchenko @churik
+/test/appium/    @antdanchenko @churik


### PR DESCRIPTION
It is not needed for me to track all changes in `/tests` folder