### PR TITLE
add OpenJDK toleiningen shell, necessary for generate-keystore.sh

### DIFF
--- a/nix/derivation.nix
+++ b/nix/derivation.nix
@@ -37,7 +37,7 @@ let
 
   # TARGETS
   leiningen-shell = mkShell {
-    buildInputs = with pkgs; [ clojure leiningen maven nodejs ];
+    buildInputs = with pkgs; [ clojure leiningen maven nodejs pkgs.openjdk ];
     shellHook =
       if target-os == "android" then mobile.android.shellHook else
       if target-os == "ios" then mobile.ios.shellHook else "";


### PR DESCRIPTION
Fix for:
```
scripts/generate-keystore.sh: line 22: keytool: command not found
```
Since when using `--pure` then `keytool` is not available in the shell.