### PR TITLE
ignore nix/clean.sh failures when in CI

### DIFF
--- a/nix/build.sh
+++ b/nix/build.sh
@@ -6,8 +6,16 @@ set -e
 function cleanup() {
   # clear trapped signals
   trap - EXIT ERR INT QUIT
-  # do the actual cleanup
-  ./nix/clean.sh "${nixResultPath}"
+  # do the actual cleanup, ignore failure 
+  if ./nix/clean.sh "${nixResultPath}"; then
+    echo "Successful cleanup!"
+  elif [[ -n "${JENKINS_URL}" ]]; then
+    # in CI removing some paths can fail due to parallel builds
+    echo "Ignoring cleanup failure in CI."
+  else
+    echo "Failed cleanup!"
+    exit 1
+  fi
 }
 
 trap cleanup EXIT ERR INT QUIT


### PR DESCRIPTION
Looks like fix merged in #8788 reduced frequency of `alive` errors when cleaning Nix store but it still happens. For that reason I'm just going to ignore those failures in CI.

This should be fine as other parallel jobs that use the same hash should remove it once they finish.

Fixes: #8757