### PR TITLE
don't go into android dir, copy results if not linking

### DIFF
--- a/ci/android.groovy
+++ b/ci/android.groovy
@@ -20,42 +20,41 @@ def bundle() {
   }
 
   // The Nix script cannot access the user home directory, so best to copy the file to the Nix store and pass that to the Nix script
-  dir('android') {
-    withCredentials([
-      string(
-        credentialsId: 'android-keystore-pass',
-        variable: 'STATUS_RELEASE_STORE_PASSWORD'
-      ),
-      usernamePassword(
-        credentialsId: 'android-keystore-key-pass',
-        usernameVariable: 'STATUS_RELEASE_KEY_ALIAS',
-        passwordVariable: 'STATUS_RELEASE_KEY_PASSWORD'
-      )
-    ]) {
-      nix.build(
-        args: [
-          'gradle-opts': gradleOpt,
-          'build-number': utils.readBuildNumber(),
-          'build-type': btype
-        ],
-        safeEnv: [
-          'STATUS_RELEASE_KEY_ALIAS',
-          'STATUS_RELEASE_STORE_PASSWORD',
-          'STATUS_RELEASE_KEY_PASSWORD'
-        ],
-        keep: [
-          'REALM_DISABLE_ANALYTICS', 'NDK_ABI_FILTERS',
-          'STATUS_RELEASE_STORE_FILE'
-        ],
-        sbox: [
-          env.STATUS_RELEASE_STORE_FILE
-        ],
-        attr: "targets.mobile.android.release"
-      )
-    }
+  withCredentials([
+    string(
+      credentialsId: 'android-keystore-pass',
+      variable: 'STATUS_RELEASE_STORE_PASSWORD'
+    ),
+    usernamePassword(
+      credentialsId: 'android-keystore-key-pass',
+      usernameVariable: 'STATUS_RELEASE_KEY_ALIAS',
+      passwordVariable: 'STATUS_RELEASE_KEY_PASSWORD'
+    )
+  ]) {
+    nix.build(
+      args: [
+        'gradle-opts': gradleOpt,
+        'build-number': utils.readBuildNumber(),
+        'build-type': btype
+      ],
+      safeEnv: [
+        'STATUS_RELEASE_KEY_ALIAS',
+        'STATUS_RELEASE_STORE_PASSWORD',
+        'STATUS_RELEASE_KEY_PASSWORD'
+      ],
+      keep: [
+        'REALM_DISABLE_ANALYTICS', 'NDK_ABI_FILTERS',
+        'STATUS_RELEASE_STORE_FILE'
+      ],
+      sbox: [
+        env.STATUS_RELEASE_STORE_FILE
+      ],
+      attr: 'targets.mobile.android.release',
+      link: false
+    )
   }
   /* because nix-build was run in `android` dir that's where `result` is */
-  def outApk = "android/result/app.apk"
+  def outApk = "result/app.apk"
   def pkg = utils.pkgFilename(btype, 'apk')
   /* rename for upload */
   sh "cp ${outApk} ${pkg}"

--- a/ci/nix.groovy
+++ b/ci/nix.groovy
@@ -59,7 +59,7 @@ def build(Map opts = [:]) {
   opts.args = defaults.args + opts.args
   opts.keep = (opts.keep + defaults.keep).unique()
 
-  return sh(
+  def resultPath = sh(
     returnStdout: true,
     script: """
       set +x
@@ -68,6 +68,10 @@ def build(Map opts = [:]) {
       nix-build ${_getNixCommandArgs(opts, false)}
     """
   ).trim()
+  if (!opts.link) { /* if not linking, copy results */
+    sh "cp ${resultPath}/* ${env.WORKSPACE}/result/"
+  }
+  return resultPath
 }
 
 private makeNixBuildEnvFile(Map opts = [:]) {

--- a/nix/build.sh
+++ b/nix/build.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+gitRoot=$(cd "${BASH_SOURCE%/*}" && git rev-parse --show-toplevel)
+resultPath="${gitRoot}/result/"
+
 # cleanup for artifacts created during builds
 function cleanup() {
   # clear trapped signals
@@ -24,9 +27,9 @@ trap cleanup EXIT ERR INT QUIT
 function extractResults() {
   local nixResultPath="$1"
   echo "Saving build result: ${nixResultPath}"
-  mkdir -p result
-  cp -vfr ${nixResultPath}/* result/
-  chmod u+w -R result/
+  mkdir -p "${resultPath}"
+  cp -vfr ${nixResultPath}/* "${resultPath}"
+  chmod u+w -R "${resultPath}"
 }
 
 # Load Nix profile


### PR DESCRIPTION
Fix for wrong path of `result` folder when building inside of `android` directory.

Now it just fails when uploading due to lack of 64bit build:
```
Google Api Error: releaseValidationErrorKeyNotCompliantWith64BitRequirementError: Release is not compliant with the Play 64-bit requirement. - Release is not compliant with the Play 64-bit requirement.
```
https://ci.status.im/job/status-react/job/combined/job/mobile-android/11687/