### PR TITLE
Save diawi link in the build description for easy access

### DIFF
--- a/ci/ios.groovy
+++ b/ci/ios.groovy
@@ -69,6 +69,8 @@ def uploadToDiawi() {
     )
   }
   diawiUrl = readFile "${env.WORKSPACE}/fastlane/diawi.out"
+  /* Save the URL in the build description */
+  currentBuild.description = "<a href=\"${diawiUrl}\">Diawi Link</a>"
   return diawiUrl
 }
 

--- a/ci/nix.groovy
+++ b/ci/nix.groovy
@@ -18,17 +18,13 @@ def shell(Map opts = [:], String cmd) {
   if (env.TARGET_OS in ['windows', 'ios']) {
     opts.pure = false
   }
-  def stdOut = sh(
-    script: """
+  sh("""
       set +x
       . ~/.nix-profile/etc/profile.d/nix.sh
       set -x
       IN_CI_ENVIRONMENT=1 \\
       nix-shell --run \'${cmd}\' ${_getNixCommandArgs(opts, true)}
-    """,
-    returnStdout: true
-  )
-  return stdOut.trim()
+  """)
 }
 
 /**


### PR DESCRIPTION
Makes it easier to access the build, also saves it for when build logs are gone.

Also dropped saving output of `nix-shell` commands since it makes them not visible in logs.