### PR TITLE
Fix Desktop build on macOS

### DIFF
--- a/desktop_files/package.json.orig
+++ b/desktop_files/package.json.orig
@@ -76,7 +76,7 @@
     "react-native-image-crop-picker": "0.18.1",
     "react-native-image-resizer": "1.0.0",
     "react-native-invertible-scroll-view": "1.1.0",
-    "react-native-keychain": "git+https://github.com/status-im/react-native-keychain.git#v.3.0.0-3-status",
+    "react-native-keychain": "git+https://github.com/status-im/react-native-keychain.git#v.3.0.0-4-status",
     "react-native-languages": "git+https://github.com/status-im/react-native-languages.git#v0.1.1-status",
     "react-native-navigation-twopane": "git+https://github.com/status-im/react-native-navigation-twopane.git#v0.0.2-status",
     "react-native-os": "1.1.0",

--- a/desktop_files/yarn.lock
+++ b/desktop_files/yarn.lock
@@ -6307,9 +6307,9 @@ react-native-invertible-scroll-view@1.1.0:
     react-clone-referenced-element "^1.0.1"
     react-native-scrollable-mixin "^1.0.1"
 
-"react-native-keychain@git+https://github.com/status-im/react-native-keychain.git#v.3.0.0-3-status":
+"react-native-keychain@git+https://github.com/status-im/react-native-keychain.git#v.3.0.0-4-status":
   version "3.0.0-rc.3"
-  resolved "git+https://github.com/status-im/react-native-keychain.git#25a76813def48ba9bf0fd1b3dd1e915d002b55dd"
+  resolved "git+https://github.com/status-im/react-native-keychain.git#5895bafa11e734325eaaffd56dda8ca50bfc5275"
 
 "react-native-languages@git+https://github.com/status-im/react-native-languages.git#v0.1.1-status":
   version "3.0.2"


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

### Summary

[comment]: # (Summarise the problem and how the pull request solves it)
Tiny PR to fix wrong target `react-native-keychain` version. This fixes desktop builds on macOS.

status: ready <!-- Can be ready or wip -->