### PR TITLE
Make nix-clean also delete `android-gradle-and-npm-modules` derivations

### DIFF
--- a/nix/clean.sh
+++ b/nix/clean.sh
@@ -80,3 +80,6 @@ toDelete=$(printf '%s\n' "${toDelete[@]}" | sort | uniq)
 
 log "Deleting..."
 nix-store --ignore-liveness --delete ${toDelete[@]}
+
+log "Deleting dead Android Gradle and NPM derivations..."
+nix-store --gc --print-dead | grep -E 'android-gradle-and-npm-modules(\.drv)?$' | xargs nix-store --delete


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

### Summary

[comment]: # (Summarise the problem and how the pull request solves it)
This PR makes `make nix-clean` also take care of Android Gradle and NPM Nix expressions, so disk usage doesn't grow indefinitely.

status: ready <!-- Can be ready or wip -->