### PR TITLE
Fix getRoots typo in nix/clean.sh

### DIFF
--- a/nix/clean.sh
+++ b/nix/clean.sh
@@ -9,7 +9,7 @@ function getSources()   { nix-store --query --binding src "${1}"; }
 function getOutputs()   { nix-store --query --outputs "${1}"; }
 function getDrvFiles()  { nix-store --query --deriver "${1}"; }
 function getReferrers() { nix-store --query --referrers "${1}"; }
-function getRoots()     { nix-store --query --roots ${1} }
+function getRoots()     { nix-store --query --roots "${1}"; }
 
 function findRelated() {
     path="${1}"


### PR DESCRIPTION
Fixes a bug introduced in commit 5ea8040c5658ada9202e3fd1930a0f85c1b7bb96 where a typo in getRoots causes the script to break.