### PR TITLE
Fix app version and deeplink tests

### DIFF
--- a/test/appium/tests/atomic/account_management/test_profile.py
+++ b/test/appium/tests/atomic/account_management/test_profile.py
@@ -347,17 +347,19 @@ class TestProfileSingleDevice(SingleDeviceTestCase):
         home_view = sign_in_view.create_user()
         profile_view = home_view.profile_button.click()
         profile_view.about_button.click()
-        version_text = profile_view.version_text.text
-        if not re.search("\d{1}[.]\d{1,2}[.]\d{1,2}\s[(]\d*[)];\sStatusIM\/android-\d{3}\/go\d{1}[.]\d{1,2}[.]\d{1,2}",
-                         version_text):
-            self.errors.append("Version %s didn't match expected format" % version_text)
-        profile_view.version_text.click()
+        app_version = profile_view.app_version_text.text
+        node_version = profile_view.node_version_text.text
+        if not re.search("\d{1}[.]\d{1,2}[.]\d{1,2}\s[(]\d*[)]", app_version):
+            self.errors.append("App version %s didn't match expected format" % app_version)
+        if not re.search("StatusIM\/android-\d{3}\/go\d{1}[.]\d{1,2}[.]\d{1,2}", node_version):
+            self.errors.append("Node version %s didn't match expected format" % node_version)
+        profile_view.app_version_text.click()
         profile_view.back_button.click()
         profile_view.home_button.click()
         chat = home_view.join_public_chat(home_view.get_public_chat_name())
         message_input = chat.chat_message_input
         message_input.paste_text_from_clipboard()
-        if message_input.text != version_text:
+        if message_input.text != app_version:
             self.errors.append('Version number was not copied to clipboard')
         self.verify_no_errors()
 

--- a/test/appium/tests/atomic/dapps_and_browsing/test_deep_links.py
+++ b/test/appium/tests/atomic/dapps_and_browsing/test_deep_links.py
@@ -63,7 +63,7 @@ class TestDeepLinks(SingleDeviceTestCase):
         profile_view = sign_in_view.get_profile_view()
         if profile_view.default_username_text.text != basic_user['username'] \
                 or not profile_view.contacts_button.is_element_displayed() \
-                or profile_view.share_my_profile_button.is_element_displayed():
+                or not profile_view.share_my_profile_button.is_element_displayed():
             self.driver.fail("Own profile screen is not opened!")
 
     @marks.testrail_id(5781)

--- a/test/appium/views/profile_view.py
+++ b/test/appium/views/profile_view.py
@@ -311,10 +311,16 @@ class FaqButton(BaseButton):
         return BaseWebView(self.driver)
 
 
-class VersionText(BaseText):
+class AppVersionText(BaseText):
     def __init__(self, driver):
-        super(VersionText, self).__init__(driver)
-        self.locator = self.Locator.xpath_selector("//*[@content-desc='version']//android.widget.TextView[2]")
+        super(AppVersionText, self).__init__(driver)
+        self.locator = self.Locator.xpath_selector("//*[@content-desc='app-version']//android.widget.TextView[2]")
+
+
+class NodeVersionText(BaseText):
+    def __init__(self, driver):
+        super(NodeVersionText, self).__init__(driver)
+        self.locator = self.Locator.xpath_selector("//*[@content-desc='node-version']//android.widget.TextView[2]")
 
 
 class BootnodesButton(BaseButton):
@@ -511,7 +517,8 @@ class ProfileView(BaseView):
         self.public_key_text = PublicKeyText(self.driver)
         self.profile_address_text = ProfileAddressText(self.driver)
         self.about_button = AboutButton(self.driver)
-        self.version_text = VersionText(self.driver)
+        self.app_version_text = AppVersionText(self.driver)
+        self.node_version_text = NodeVersionText(self.driver)
 
         self.network_settings_button = NetworkSettingsButton(self.driver)
         self.active_network_name = ActiveNetworkName(self.driver)


### PR DESCRIPTION
Fixed test_version_format test (now we have split app version and node version) and  test_open_own_user_profile_using_deep_link tests