### PR TITLE
Update logcat tests and disable upgrade-app test

### DIFF
--- a/test/appium/tests/atomic/account_management/test_create_account.py
+++ b/test/appium/tests/atomic/account_management/test_create_account.py
@@ -113,7 +113,9 @@ class TestCreateAccount(SingleDeviceTestCase):
     def test_password_in_logcat_creating_account(self):
         sign_in = SignInView(self.driver)
         sign_in.create_user(password=unique_password)
-        sign_in.check_no_values_in_logcat(password=unique_password)
+        values_in_logcat = sign_in.find_values_in_logcat(password=unique_password)
+        if values_in_logcat:
+            self.driver.fail(values_in_logcat)
 
     @marks.testrail_id(5718)
     @marks.medium

--- a/test/appium/tests/atomic/account_management/test_profile.py
+++ b/test/appium/tests/atomic/account_management/test_profile.py
@@ -194,6 +194,7 @@ class TestProfileSingleDevice(SingleDeviceTestCase):
         profile_view.find_text_part('custom_ropsten')
 
     @marks.logcat
+    @marks.critical
     @marks.testrail_id(5419)
     def test_logcat_backup_recovery_phrase(self):
         sign_in_view = SignInView(self.driver)
@@ -211,8 +212,10 @@ class TestProfileSingleDevice(SingleDeviceTestCase):
         profile_view.recovery_phrase_word_input.set_value(recovery_phrase[word_number_1])
         profile_view.done_button.click()
         profile_view.yes_button.click()
-        profile_view.check_no_values_in_logcat(passphrase1=recovery_phrase[word_number],
+        values_in_logcat = profile_view.find_values_in_logcat(passphrase1=recovery_phrase[word_number],
                                                passphrase2=recovery_phrase[word_number_1])
+        if len(values_in_logcat) == 2:
+            self.driver.fail(values_in_logcat)
 
     @marks.testrail_id(5391)
     @marks.high

--- a/test/appium/tests/atomic/account_management/test_recover.py
+++ b/test/appium/tests/atomic/account_management/test_recover.py
@@ -64,7 +64,9 @@ class TestRecoverAccountSingleDevice(SingleDeviceTestCase):
     def test_logcat_recovering_account(self):
         sign_in = SignInView(self.driver)
         sign_in.recover_access(passphrase=basic_user['passphrase'], password=unique_password)
-        sign_in.check_no_values_in_logcat(passphrase=basic_user['passphrase'], password=unique_password)
+        values_in_logcat = sign_in.find_values_in_logcat(passphrase=basic_user['passphrase'], password=unique_password)
+        if values_in_logcat:
+            self.driver.fail(values_in_logcat)
 
 
 class TestRecoverAccessFromSignInScreen(SingleDeviceTestCase):

--- a/test/appium/tests/atomic/account_management/test_sign_in.py
+++ b/test/appium/tests/atomic/account_management/test_sign_in.py
@@ -47,7 +47,9 @@ class TestSignIn(SingleDeviceTestCase):
         profile = sign_in.profile_button.click()
         profile.logout()
         sign_in.sign_in()
-        sign_in.check_no_values_in_logcat(password=unique_password)
+        values_in_logcat = sign_in.find_values_in_logcat(password=unique_password)
+        if values_in_logcat:
+            self.driver.fail(values_in_logcat)
 
 
 @marks.all

--- a/test/appium/tests/atomic/chats/test_commands.py
+++ b/test/appium/tests/atomic/chats/test_commands.py
@@ -378,7 +378,9 @@ class TestCommandsSingleDevices(SingleDeviceTestCase):
         chat = home.add_contact(basic_user['public_key'])
         amount = chat.get_unique_amount()
         chat.send_transaction_in_1_1_chat('ETHro', amount, unique_password)
-        chat.check_no_values_in_logcat(password=unique_password)
+        values_in_logcat = chat.find_values_in_logcat(password=unique_password)
+        if values_in_logcat:
+            self.driver.fail(values_in_logcat)
 
     @marks.testrail_id(5347)
     @marks.high

--- a/test/appium/tests/atomic/test_upgrade.py
+++ b/test/appium/tests/atomic/test_upgrade.py
@@ -12,6 +12,7 @@ class TestUpgradeApplication(SingleDeviceTestCase):
 
     @marks.testrail_id(5713)
     @marks.upgrade
+    @marks.skip
     def test_apk_upgrade(self):
         sign_in = SignInView(self.driver)
         home = sign_in.create_user()

--- a/test/appium/tests/atomic/transactions/test_daaps_transactions.py
+++ b/test/appium/tests/atomic/transactions/test_daaps_transactions.py
@@ -132,7 +132,10 @@ class TestTransactionDApp(SingleDeviceTestCase):
         status_test_dapp.assets_button.click()
         send_transaction_view = status_test_dapp.request_stt_button.click()
         send_transaction_view.sign_transaction(unique_password)
-        send_transaction_view.check_no_values_in_logcat(password=unique_password)
+        values_in_logcat = send_transaction_view.find_values_in_logcat(password=unique_password)
+        if values_in_logcat:
+            self.driver.fail(values_in_logcat)
+
 
     @marks.logcat
     @marks.testrail_id(5420)
@@ -148,7 +151,9 @@ class TestTransactionDApp(SingleDeviceTestCase):
             send_transaction_view.enter_password_input)
         send_transaction_view.enter_password_input.send_keys(unique_password)
         send_transaction_view.sign_button.click()
-        send_transaction_view.check_no_values_in_logcat(password=unique_password)
+        values_in_logcat = send_transaction_view.find_values_in_logcat(password=unique_password)
+        if values_in_logcat:
+            self.driver.fail(values_in_logcat)
 
     @marks.testrail_id(5372)
     @marks.high

--- a/test/appium/tests/atomic/transactions/test_wallet.py
+++ b/test/appium/tests/atomic/transactions/test_wallet.py
@@ -122,6 +122,7 @@ class TestTransactionWalletSingleDevice(SingleDeviceTestCase):
             self.driver.fail('Transaction was sent with a wrong password')
 
     @marks.testrail_id(1452)
+
     def test_transaction_appears_in_history(self):
         recipient = basic_user
         sign_in_view = SignInView(self.driver)
@@ -169,7 +170,9 @@ class TestTransactionWalletSingleDevice(SingleDeviceTestCase):
         send_transaction.enter_recipient_address_button.click()
         send_transaction.enter_recipient_address_input.set_value(recipient['public_key'])
         send_transaction.done_button.click()
-        send_transaction.find_text_part('Invalid address:', 20)
+        if not send_transaction.find_text_part('Invalid address'):
+            self.driver.fail("Invalid address accepted for input as recipient!")
+        send_transaction.ok_button.click()
 
     @marks.logcat
     @marks.testrail_id(5416)
@@ -194,7 +197,9 @@ class TestTransactionWalletSingleDevice(SingleDeviceTestCase):
         send_transaction.done_button.click()
         send_transaction.sign_transaction_button.click()
         send_transaction.sign_transaction(unique_password)
-        send_transaction.check_no_values_in_logcat(password=unique_password)
+        values_in_logcat = send_transaction.find_values_in_logcat(password=unique_password)
+        if values_in_logcat:
+            self.driver.fail(values_in_logcat)
 
     @marks.testrail_id(5350)
     @marks.critical

--- a/test/appium/views/base_view.py
+++ b/test/appium/views/base_view.py
@@ -592,11 +592,13 @@ class BaseView(object):
                             e.msg = "Device %s: Can't reconnect to mail server after 3 attempts" % self.driver.number
                             raise e
 
-    def check_no_values_in_logcat(self, **kwargs):
+    def find_values_in_logcat(self, **kwargs):
         logcat = self.logcat
+        items_in_logcat = list()
         for key, value in kwargs.items():
             if re.findall('\W%s$|\W%s\W' % (value, value), logcat):
-                pytest.fail('%s in logcat!!!' % key.capitalize(), pytrace=False)
+                items_in_logcat.append('%s in logcat!!!' % key.capitalize())
+        return items_in_logcat
 
     def asset_by_name(self, asset_name):
         return AssetButton(self.driver, asset_name)


### PR DESCRIPTION
- we had often false failing test_logcat_backup_recovery_phrase test. It was checking whether any of two words, used as confirmation to back up seed phrase, are present in logcat. If any of two is present test fails. Issue is that in dictionary for seed-phrases there are many words which are used as normal log items: for example "talk" or "list" or "icon" and many more. So we modified the test to check whether both words are in logcat
- test_send_eth_from_wallet_incorrect_address updated so no ERROR in Jenkins. 
- upgrade_app test disabled (no upgrade support for now anyway)