### PR TITLE
upgrade Go: 1.11 > 1.12

### DIFF
--- a/nix/derivation.nix
+++ b/nix/derivation.nix
@@ -17,7 +17,7 @@ let
   # TODO: Try to use stdenv for iOS. The problem is with building iOS as the build is trying to pass parameters to Apple's ld that are meant for GNU's ld (e.g. -dynamiclib)
   stdenv = pkgs.stdenvNoCC;
   maven = pkgs.maven;
-  baseGo = pkgs.go_1_11;
+  baseGo = pkgs.go_1_12;
   go = pkgs.callPackage ./patched-go { inherit baseGo; };
   buildGoPackage = pkgs.buildGoPackage.override { inherit go; };
   desktop = pkgs.callPackage ./desktop { inherit target-os stdenv status-go pkgs go nodejs; inherit (pkgs) darwin; };

--- a/nix/nixpkgs-bootstrap.nix
+++ b/nix/nixpkgs-bootstrap.nix
@@ -1,11 +1,14 @@
 # This file controls the pinned version of nixpkgs we use for our Nix environment
 { config ? { android_sdk.accept_license = true; },
   pkgs ? (import ((import <nixpkgs> { }).fetchFromGitHub {
+    name = "nixpkgs-source";
     owner = "status-im";
     repo = "nixpkgs";
-    rev = "db492b61572251c2866f6b5e6e94e9d70e7d3021";
-    sha256 = "188r7gbcrxi20nj6xh9bmdf3lbjwb94v9s0wpacl7q39g1fca66h";
-    name = "nixpkgs-source";
+    rev = "f54e1c6441868450e947f6171b129dfb90a91653";
+    sha256 = "13cf3pi277ifg57l11kmjk08vrpv6km2jfxq7sp63zxw5bgkiqpd";
+    # To get the compressed Nix sha256, use:
+    # nix-prefetch-url --unpack https://github.com/${ORG}/nixpkgs/archive/${REV}.tar.gz
+    # The last line will be the hash.
   })) { inherit config; } }:
 
   {

--- a/nix/patched-go/default.nix
+++ b/nix/patched-go/default.nix
@@ -15,8 +15,6 @@ let
 		if tmp == "" {
 			tmp, err = ioutil.TempDir(os.Getenv("GOTMPDIR"), "go-build")
 		}'
-      # Disable chown tests, they fail with 'invalid argument'
-      rm src/os/os_unix_test.go
     '';
   });
 


### PR DESCRIPTION
As required by #9056 this is only the Go upgrade to 1.12 to avoid any other issues.