### PR TITLE
fix which APK is published for e2e builds

### DIFF
--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -106,7 +106,11 @@ pipeline {
         script {
           def urls = apks.collect { cmn.utils.uploadArtifact(it) }
           /* return only the universal APK */
-          env.PKG_URL = urls.find { it.contains('universal') }
+          if (urls.size() > 1) { 
+            env.PKG_URL = urls.find { it.contains('universal') }
+          } else { /* if no universal is available pick first */
+            env.PKG_URL = urls.first()
+          }
           /* build type specific */
           switch (btype) {
             case 'release':
@@ -114,7 +118,7 @@ pipeline {
             case 'nightly':
               env.DIAWI_URL = android.uploadToDiawi(); break;
             case 'e2e':
-              env.SAUCE_URL = android.uploadToSauceLabs()
+              env.SAUCE_URL = android.uploadToSauceLabs(); break;
           }
         }
       }

--- a/ci/android.groovy
+++ b/ci/android.groovy
@@ -14,9 +14,11 @@ def bundle() {
   switch (btype) {
     case 'e2e':
       env.ANDROID_ABI_INCLUDE="x86" /* e2e builds are used with simulators */
+      break
     case 'release':
       env.ANDROID_ABI_SPLIT="true"
       gradleOpt += "-PreleaseVersion='${utils.getVersion()}'"
+      break
   }
 
   /* credentials necessary to open the keystore and sign the APK */
@@ -69,6 +71,9 @@ def extractArchFromAPK(name) {
   if (matches.size() > 0) {
     return matches[0][1]
   }
+  if (utils.getBuildType() == 'e2e') {
+    return 'x86'
+  }
   /* non-release builds make universal APKs */
   return 'universal'
 }
@@ -82,7 +87,7 @@ def renameAPKs() {
   def apkGlob = 'result/*.apk'
   def found = findFiles(glob: apkGlob)
   if (found.size() == 0) {
-    error("APKs not found via glob: ${apkGlob}")
+    throw "APKs not found via glob: ${apkGlob}"
   }
   def renamed = []
   /* rename each for upload & archiving */
@@ -113,7 +118,7 @@ def uploadToSauceLabs() {
   if (changeId != null) {
     env.SAUCE_LABS_NAME = "${changeId}.apk"
   } else {
-    def pkg = utils.pkgFilename(utils.getBuildType(), 'apk')
+    def pkg = utils.pkgFilename(utils.getBuildType(), 'apk', 'x86')
     env.SAUCE_LABS_NAME = "${pkg}"
   }
   withCredentials([

--- a/ci/ghcmgr.groovy
+++ b/ci/ghcmgr.groovy
@@ -55,7 +55,7 @@ def postBuild(success) {
   /* We're not using --fail because it suppresses server response */
   if (!stdout.contains('HTTP_CODE:201')) {
     println("STDOUT:\n${stdout}")
-    error("Notifying GHCMGR failed with: TODO")
+    error("Notifying GHCMGR failed")
   }
 }
 


### PR DESCRIPTION
Due to small bug introduced in #9038 `e2e` builds post the `universal` APK instead of `x86` one.