### PR TITLE
Fix api request to etherscan

### DIFF
--- a/test/appium/support/api/network_api.py
+++ b/test/appium/support/api/network_api.py
@@ -13,25 +13,28 @@ class NetworkApi(object):
         self.network_url = 'http://api-%s.etherscan.io/api?' % pytest.config.getoption('network')
         self.faucet_url = 'https://faucet-ropsten.status.im/donate'
         self.faucet_backup_url = 'https://faucet.ropsten.be/donate'
+        self.headers = {
+        'User-Agent':"Mozilla\/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit\
+        /537.36 (KHTML, like Gecko) Chrome\/77.0.3865.90 Safari\/537.36", }
         self.chat_bot_url = 'http://offsite.chat:8099'
 
     def get_transactions(self, address: str) -> List[dict]:
         method = self.network_url + 'module=account&action=txlist&address=0x%s&sort=desc' % address
-        return requests.request('GET', url=method).json()['result']
+        return requests.request('GET', url=method, headers=self.headers).json()['result']
 
     def get_token_transactions(self, address: str) -> List[dict]:
         method = self.network_url + 'module=account&action=tokentx&address=0x%s&sort=desc' % address
-        return requests.request('GET', url=method).json()['result']
+        return requests.request('GET', url=method, headers=self.headers).json()['result']
 
     def is_transaction_successful(self, transaction_hash: str) -> int:
         method = self.network_url + 'module=transaction&action=getstatus&txhash=%s' % transaction_hash
-        return not int(requests.request('GET', url=method).json()['result']['isError'])
+        return not int(requests.request('GET', url=method, headers=self.headers).json()['result']['isError'])
 
     def get_balance(self, address):
         method = self.network_url + 'module=account&action=balance&address=0x%s&tag=latest' % address
         for i in range(5):
             try:
-                return int(requests.request('GET', method).json()["result"])
+                return int(requests.request('GET', method, headers=self.headers).json()["result"])
             except ValueError:
                 pass
 

--- a/test/appium/tests/atomic/transactions/test_wallet.py
+++ b/test/appium/tests/atomic/transactions/test_wallet.py
@@ -67,7 +67,7 @@ class TestTransactionWalletSingleDevice(SingleDeviceTestCase):
     @marks.testrail_id(5325)
     @marks.critical
     def test_send_stt_from_wallet(self):
-        recipient = basic_user
+        recipient = transaction_recipients['F']
         sender = transaction_senders['Q']
         sign_in_view = SignInView(self.driver)
         sign_in_view.recover_access(sender['passphrase'])
@@ -369,7 +369,7 @@ class TestTransactionWalletSingleDevice(SingleDeviceTestCase):
         send_transaction.sign_with_password.click_until_presence_of_element(send_transaction.enter_password_input)
         send_transaction.enter_password_input.send_keys(common_password)
         send_transaction.sign_button.click()
-        send_transaction.element_by_text('intrinsic gas too low', 'text').wait_for_visibility_of_element()
+        send_transaction.element_by_text('intrinsic gas too low', 'text').wait_for_visibility_of_element(20)
         send_transaction.ok_button.click()
 
         send_transaction.sign_transaction_button.click()


### PR DESCRIPTION
In some test for transactions we check eth/token balances per address in etherescan via their api. Recently api request start failing, but same GET requests were working fine in browser. So I added user-agent in api call as additional header. 
Transaction relates tests should work now.