### PR TITLE
Fix for 2 failed e2e

### DIFF
--- a/test/appium/support/api/network_api.py
+++ b/test/appium/support/api/network_api.py
@@ -5,6 +5,7 @@ import pytest
 import requests
 import time
 from json import JSONDecodeError
+from decimal import Decimal
 
 
 class NetworkApi(object):
@@ -130,3 +131,10 @@ class NetworkApi(object):
         url = '%s/ping/%s?count=%s&interval=%s' % (self.chat_bot_url, chat_name, messages_number, interval)
         text = requests.request('GET', url).text
         return [i.split(maxsplit=5)[-1].strip('*') for i in text.splitlines()]
+
+    def get_rounded_balance(self, fetched_balance, actual_balance):
+        fetched_balance, actual_balance = str(fetched_balance), str(actual_balance)
+        # get actual number of decimals on account balance
+        decimals = abs(Decimal(fetched_balance).as_tuple().exponent)
+        rounded_balance = round(float(actual_balance), decimals)
+        return rounded_balance

--- a/test/appium/tests/atomic/dapps_and_browsing/test_dapps.py
+++ b/test/appium/tests/atomic/dapps_and_browsing/test_dapps.py
@@ -28,12 +28,12 @@ class TestDApps(SingleDeviceTestCase):
         sign_in_view = SignInView(self.driver)
         home_view = sign_in_view.recover_access(passphrase=user['passphrase'])
         status_test_dapp = home_view.open_status_test_dapp(allow_all=False)
-        status_test_dapp.status_api_button.click()
-        status_test_dapp.request_contact_code_button.click()
+        status_test_dapp.status_api_button.click_until_presence_of_element(status_test_dapp.request_contact_code_button)
+        status_test_dapp.request_contact_code_button.click_until_presence_of_element(status_test_dapp.deny_button)
         status_test_dapp.deny_button.click()
         if status_test_dapp.element_by_text(user['public_key']).is_element_displayed():
             pytest.fail('Public key is returned but access was not allowed')
-        status_test_dapp.request_contact_code_button.click()
+        status_test_dapp.request_contact_code_button.click_until_presence_of_element(status_test_dapp.deny_button)
         status_test_dapp.allow_button.click()
         if not status_test_dapp.element_by_text(user['public_key']).is_element_displayed():
             pytest.fail('Public key is not returned')

--- a/test/appium/views/base_view.py
+++ b/test/appium/views/base_view.py
@@ -386,6 +386,7 @@ class BaseView(object):
                 counter += 1
 
     def just_fyi(self, string):
+        self.driver.info('=========================================================================')
         self.driver.info(string)
 
     def click_system_back_button(self):


### PR DESCRIPTION
* Can request contact public key in Status test Dapp - failed because too fast tried to tap "status_api_button"

* test_send_funds_between_accounts_in_multiaccount_instance - failed because of 2 reasons:
1) account balance was fetched too fast (added waiting for confirmations of the last transaction)
2) adding two floats in Python wasn't equal to the actual balance on the wallet.
So special method `get_rounded_balance` was added to handle this case.
* reworked tests for blocked users to use new accounts instead of predefined.
