### PR TITLE
Fixed e2e: return boolean instead of string

### DIFF
--- a/test/appium/tests/atomic/account_management/test_profile.py
+++ b/test/appium/tests/atomic/account_management/test_profile.py
@@ -109,7 +109,7 @@ class TestProfileSingleDevice(SingleDeviceTestCase):
         self.verify_no_errors()
 
 
-    @marks.testrail_id(6229)
+    @marks.testrail_id(5454)
     @marks.critical
     def test_user_can_remove_profile_picture(self):
         signin_view = SignInView(self.driver)
@@ -535,7 +535,7 @@ class TestProfileMultipleDevice(MultipleDeviceTestCase):
 @marks.account
 class TestProfileMultipleDevice(MultipleDeviceTestCase):
 
-    @marks.testrail_id(6835)
+    @marks.testrail_id(5762)
     @marks.high
     def test_pair_devices_sync_one_to_one_contacts(self):
         self.create_drivers(2)

--- a/test/appium/views/base_element.py
+++ b/test/appium/views/base_element.py
@@ -158,7 +158,13 @@ class BaseElement(object):
         return Image.open(BytesIO(base64.b64decode(self.find_element().screenshot_as_base64)))
 
     def attribute_value(self, value):
-        return self.find_element().get_attribute(value)
+        attribute_value = self.find_element().get_attribute(value)
+        if attribute_value == 'true' or 'True':
+            return True
+        elif attribute_value == 'false' or 'False':
+            return False
+        else:
+            return attribute_value
 
     def is_element_image_equals_template(self, file_name: str = ''):
         if file_name:


### PR DESCRIPTION
Sometimes test `test_mobile_data_usage_settings` failed because of wrong comparison of grabbed attributes.
Replaced with explicit comparison - checked 5 times locally, test is passed.

UPD: added retirn of boolean instead of string for cases 'true', 'True', 'false', 'False'