### PR TITLE
desktop builds need GnuPG, also s3cmd

### DIFF
--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -104,7 +104,7 @@ pipeline {
     stage('Upload') {
       steps {
         script {
-          def urls = apks.collect { cmn.utils.uploadArtifact(it) }
+          def urls = apks.collect { cmn.uploadArtifact(it) }
           /* return only the universal APK */
           if (urls.size() > 1) { 
             env.PKG_URL = urls.find { it.contains('universal') }

--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -80,7 +80,7 @@ pipeline {
           /* desktop */
           App: cmn.pkgUrl(nix), Mac: cmn.pkgUrl(osx), Win: cmn.pkgUrl(win),
           /* upload the sha256 checksums file too */
-          SHA: cmn.utils.uploadArtifact(cmn.utils.pkgFind('sha256')),
+          SHA: cmn.uploadArtifact(cmn.utils.pkgFind('sha256')),
         ]
         /* add URLs to the build description */
         cmn.ci.setBuildDesc(urls)

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -85,7 +85,7 @@ pipeline {
     stage('Upload') {
       steps {
         script {
-          env.PKG_URL = cmn.utils.uploadArtifact(api)
+          env.PKG_URL = cmn.uploadArtifact(api)
           /* e2e builds get tested in SauceLabs */
           if (btype == 'e2e') {
             env.SAUCE_URL = ios.uploadToSauceLabs()

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -93,7 +93,7 @@ pipeline {
     }
     stage('Upload') {
       steps {
-        script { env.PKG_URL = cmn.utils.uploadArtifact(app) }
+        script { env.PKG_URL = cmn.uploadArtifact(app) }
       }
     }
     stage('Cleanup') {

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -90,7 +90,7 @@ pipeline {
     }
     stage('Upload') {
       steps {
-        script { env.PKG_URL = cmn.utils.uploadArtifact(dmg) }
+        script { env.PKG_URL = cmn.uploadArtifact(dmg) }
       }
     }
     stage('Cleanup') {

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -96,7 +96,7 @@ pipeline {
     }
     stage('Upload') {
       steps {
-        script { env.PKG_URL = cmn.utils.uploadArtifact(app) }
+        script { env.PKG_URL = cmn.uploadArtifact(app) }
       }
     }
     stage('Cleanup') {

--- a/ci/nix.groovy
+++ b/ci/nix.groovy
@@ -12,9 +12,9 @@ def shell(Map opts = [:], String cmd) {
   ]
   /* merge defaults with received opts */
   opts = defaults + opts
-  /* Previous merge overwrites the array */
+  /* previous merge overwrites the array */
   opts.keep = (opts.keep + defaults.keep).unique()
-
+  /* not all targets can use a pure build */
   if (env.TARGET_OS in ['windows', 'ios']) {
     opts.pure = false
   }

--- a/ci/utils.groovy
+++ b/ci/utils.groovy
@@ -100,39 +100,6 @@ def pkgFind(glob) {
   return found[0].path
 }
 
-def uploadArtifact(path) {
-  /* defaults for upload */
-  def domain = 'ams3.digitaloceanspaces.com'
-  def bucket = 'status-im'
-  /* There's so many PR builds we need a separate bucket */
-  if (getBuildType() == 'pr') {
-    bucket = 'status-im-prs'
-  }
-  /* WARNING: s3cmd can't guess APK MIME content-type */
-  def customOpts = ''
-  if (path.endsWith('apk')) {
-    customOpts += "--mime-type='application/vnd.android.package-archive'"
-  }
-  /* We also need credentials for the upload */
-  withCredentials([usernamePassword(
-    credentialsId: 'digital-ocean-access-keys',
-    usernameVariable: 'DO_ACCESS_KEY',
-    passwordVariable: 'DO_SECRET_KEY'
-  )]) {
-    sh """
-      s3cmd \\
-        --acl-public \\
-        ${customOpts} \\
-        --host='${domain}' \\
-        --host-bucket='%(bucket)s.${domain}' \\
-        --access_key=${DO_ACCESS_KEY} \\
-        --secret_key=${DO_SECRET_KEY} \\
-        put ${path} s3://${bucket}/
-    """
-  }
-  return "https://${bucket}.${domain}/${getFilename(path)}"
-}
-
 def getBuildType() {
   def jobName = env.JOB_NAME
   if (jobName.contains('e2e')) {

--- a/nix/desktop/default.nix
+++ b/nix/desktop/default.nix
@@ -8,7 +8,7 @@ let
   platform = callPackage ../platform.nix { inherit target-os; };
   baseImageFactory = callPackage ./base-image { inherit stdenv; };
   linuxPlatform = callPackage ./linux { inherit stdenv status-go baseImageFactory; };
-  darwinPlatform = callPackage ./macos { inherit stdenv status-go darwin baseImageFactory; };
+  darwinPlatform = callPackage ./macos { inherit stdenv status-go darwin baseImageFactory pkgs; };
   windowsPlatform = callPackage ./windows { inherit stdenv go baseImageFactory; };
   snoreNotifySources = callPackage ./cmake/snorenotify { };
   qtkeychainSources = callPackage ./cmake/qtkeychain { };

--- a/nix/desktop/macos/default.nix
+++ b/nix/desktop/macos/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, callPackage,
+{ stdenv, callPackage, pkgs,
   darwin, qt5, status-go, baseImageFactory }:
 
 with darwin.apple_sdk.frameworks;
@@ -11,6 +11,7 @@ let
 
 in {
   buildInputs = [
+    pkgs.gnupg22
     baseImage
     qt5.full
     AppKit

--- a/shell.nix
+++ b/shell.nix
@@ -25,6 +25,7 @@ let
     gnumake
     jq
     wget
+    s3cmd
   ];
 
 in mkShell {


### PR DESCRIPTION
Due to default shell changing to `zsh` in MacOS `10.15` the `PATH` has been affected and is causing failures due to missing tools like `s3cmd` and `gpg`, so I've just pulled those in via Nix.

After this one is merged `macos-01` and `macos-03` and be put back online in Jenkins.