### PR TITLE
E2E Fixes

### DIFF
--- a/test/appium/tests/atomic/account_management/test_create_account.py
+++ b/test/appium/tests/atomic/account_management/test_create_account.py
@@ -15,6 +15,8 @@ class TestCreateAccount(SingleDeviceTestCase):
     @marks.critical
     @marks.battery_consumption
     @marks.skip
+    # skipped because it is a part of other tests
+    # obsolate
     def test_create_account(self):
         sign_in = SignInView(self.driver, skip_popups=False)
         sign_in.accept_agreements()
@@ -53,7 +55,7 @@ class TestCreateAccount(SingleDeviceTestCase):
         sign_in.next_button.click()
 
         if sign_in.get_public_key() == public_key:
-            pytest.fail('New account was not created')
+            self.driver.fail('New account was not created')
 
     @marks.testrail_id(5379)
     @marks.high

--- a/test/appium/tests/atomic/account_management/test_recover.py
+++ b/test/appium/tests/atomic/account_management/test_recover.py
@@ -29,6 +29,8 @@ class TestRecoverAccountSingleDevice(SingleDeviceTestCase):
 
     @marks.skip
     @marks.testrail_id(845)
+    # test doesn't exist in TestRail
+    # obsolate
     def test_recover_account_with_incorrect_passphrase(self):
         sign_in = SignInView(self.driver)
         sign_in.create_user()
@@ -42,7 +44,7 @@ class TestRecoverAccountSingleDevice(SingleDeviceTestCase):
         sign_in.accept_agreements()
         sign_in.recover_access(passphrase=' '.join(list(recovery_phrase.values())[::-1]))
         if sign_in.get_public_key() == public_key:
-            pytest.fail('The same account is recovered with reversed passphrase')
+            self.driver.fail('The same account is recovered with reversed passphrase')
 
     @marks.logcat
     @marks.testrail_id(5366)

--- a/test/appium/tests/atomic/account_management/test_sign_in.py
+++ b/test/appium/tests/atomic/account_management/test_sign_in.py
@@ -27,6 +27,8 @@ class TestSignIn(SingleDeviceTestCase):
 
     @marks.testrail_id(5463)
     @marks.medium
+    @marks.skip
+    # TODO: e2e blocker: 8567 (should be enabled after fix)
     def test_login_with_incorrect_password(self):
         sign_in = SignInView(self.driver)
         sign_in.create_user()
@@ -64,4 +66,4 @@ class TestSignIn(SingleDeviceTestCase):
         home.home_button.wait_for_visibility_of_element()
         connection_text = sign_in.connection_status.text
         if connection_text != 'Offline':
-            pytest.fail("Connection status text '%s' doesn't match expected 'Offline'" % connection_text)
+            self.driver.fail("Connection status text '%s' doesn't match expected 'Offline'" % connection_text)

--- a/test/appium/tests/atomic/account_management/test_wallet_management.py
+++ b/test/appium/tests/atomic/account_management/test_wallet_management.py
@@ -89,7 +89,7 @@ class TestWalletManagement(SingleDeviceTestCase):
         public_chat = home_view.join_public_chat('testchat')
         public_chat.chat_message_input.paste_text_from_clipboard()
         if public_chat.chat_message_input.text != transaction_hash:
-            pytest.fail('Transaction hash was not copied')
+            self.driver.fail('Transaction hash was not copied')
 
     @marks.testrail_id(5341)
     @marks.critical
@@ -115,16 +115,8 @@ class TestWalletManagement(SingleDeviceTestCase):
         sign_in.create_user()
         wallet = sign_in.wallet_button.click()
         wallet.set_up_wallet()
-        # if wallet.backup_recovery_phrase.is_element_present():
-        #     pytest.fail("'Backup your Recovery phrase' option is shown on Wallet for an account with no funds")
-        # wallet.receive_transaction_button.click()
-        # address = wallet.address_text.text[2:]
-        # wallet.get_back_to_home_view()
-        # home = wallet.home_button.click()
-        # self.network_api.get_donate(address)
-        # home.wallet_button.click()
         if not wallet.backup_recovery_phrase_warning_text.is_element_present():
-            pytest.fail("'Back up your seed phrase' warning is not shown on Wallet")
+            self.driver.fail("'Back up your seed phrase' warning is not shown on Wallet")
         wallet.multiaccount_more_options.click_until_presence_of_element(wallet.backup_recovery_phrase)
         wallet.backup_recovery_phrase.click()
         profile = wallet.get_profile_view()
@@ -145,7 +137,7 @@ class TestWalletManagement(SingleDeviceTestCase):
         send_transaction = wallet.send_transaction_button.click()
         send_transaction.select_asset_button.click()
         if send_transaction.asset_by_name(asset_name).is_element_displayed():
-            pytest.fail('Collectibles can be sent from wallet')
+            self.driver.fail('Collectibles can be sent from wallet')
 
     @marks.testrail_id(5467)
     @marks.medium
@@ -168,6 +160,7 @@ class TestWalletManagement(SingleDeviceTestCase):
     @marks.testrail_id(5435)
     @marks.medium
     @marks.skip
+    # TODO: e2e blocker: 9225 (should be updated and enabled)
     def test_filter_transactions_history(self):
         user = wallet_users['C']
         sign_in_view = SignInView(self.driver)
@@ -184,7 +177,7 @@ class TestWalletManagement(SingleDeviceTestCase):
             details = transaction_history.transactions_table.transaction_by_index(i).click()
             if details.get_recipient_address() != '0x' + user['address'] \
                     or details.element_by_text('Failed').is_element_displayed():
-                pytest.fail('Incoming transactions are not filtered')
+                self.driver.fail('Incoming transactions are not filtered')
             details.back_button.click()
 
         transaction_history.filters_button.click()
@@ -195,7 +188,7 @@ class TestWalletManagement(SingleDeviceTestCase):
             details = transaction_history.transactions_table.transaction_by_index(i).click()
             if details.get_sender_address() != '0x' + user['address'] \
                     or details.element_by_text('Failed').is_element_displayed():
-                pytest.fail('Outgoing transactions are not filtered')
+                self.driver.fail('Outgoing transactions are not filtered')
             details.back_button.click()
 
         transaction_history.filters_button.click()
@@ -205,7 +198,7 @@ class TestWalletManagement(SingleDeviceTestCase):
         for i in range(transaction_history.transactions_table.get_transactions_number()):
             details = transaction_history.transactions_table.transaction_by_index(i).click()
             if not details.element_by_text('Failed').is_element_displayed():
-                pytest.fail('Failed transactions are not filtered')
+                self.driver.fail('Failed transactions are not filtered')
             details.back_button.click()
         self.verify_no_errors()
 

--- a/test/appium/tests/atomic/chats/test_chats_management.py
+++ b/test/appium/tests/atomic/chats/test_chats_management.py
@@ -21,11 +21,11 @@ class TestChatManagement(SingleDeviceTestCase):
             chat_view.send_message_button.click()
         chat_view.clear_history()
         if not chat_view.no_messages_in_chat.is_element_present():
-            pytest.fail('Message history is shown')
+            self.driver.fail('Message history is shown')
         home_view.relogin()
         home_view.get_chat_with_user(basic_user['username']).click()
         if not chat_view.no_messages_in_chat.is_element_present():
-            pytest.fail('Message history is shown after re-login')
+            self.driver.fail('Message history is shown after re-login')
 
     @marks.testrail_id(5319)
     @marks.critical
@@ -42,7 +42,7 @@ class TestChatManagement(SingleDeviceTestCase):
         sign_in.accept_agreements()
         sign_in.sign_in()
         if home.get_chat_with_user(basic_user['username']).is_element_displayed():
-            pytest.fail('Deleted 1-1 chat is present after relaunch app')
+            self.driver.fail('Deleted 1-1 chat is present after relaunch app')
 
     @marks.testrail_id(5343)
     @marks.critical
@@ -84,11 +84,11 @@ class TestChatManagement(SingleDeviceTestCase):
         contacts_view = home.start_new_chat_button.click()
         contacts_view.public_key_edit_box.paste_text_from_clipboard()
         if contacts_view.public_key_edit_box.text != public_key:
-            pytest.fail('Public key is not pasted from clipboard')
+            self.driver.fail('Public key is not pasted from clipboard')
         contacts_view.confirm()
         contacts_view.get_back_to_home_view()
         if not home.get_chat_with_user(basic_user['username']).is_element_present():
-            pytest.fail("No chat open in home view")
+            self.driver.fail("No chat open in home view")
 
     @marks.testrail_id(5387)
     @marks.high
@@ -135,7 +135,7 @@ class TestChatManagement(SingleDeviceTestCase):
         contacts_view.confirm()
         warning_text = contacts_view.element_by_text('Please enter or scan a valid chat key or username')
         if not warning_text.is_element_displayed():
-            pytest.fail('Error is not shown for invalid public key')
+            self.driver.fail('Error is not shown for invalid public key')
 
     @marks.testrail_id(5466)
     @marks.medium
@@ -217,7 +217,7 @@ class TestChatManagementMultipleDevice(MultipleDeviceTestCase):
                         chat_1.element_by_text(username, 'text'),
                         chat_1.add_to_contacts,
                         chat_1.profile_send_message,
-                        # temporary skipped due to 8601
+                        # TODO: temporary skipped due to 8601
                         # chat_1.profile_send_transaction,
                         chat_1.profile_address_text]:
             if not element.scroll_to_element():

--- a/test/appium/tests/atomic/chats/test_commands.py
+++ b/test/appium/tests/atomic/chats/test_commands.py
@@ -16,7 +16,7 @@ class TestCommandsMultipleDevices(MultipleDeviceTestCase):
     @marks.testrail_id(5334)
     @marks.critical
     @marks.skip
-    # temporary skipped due to 8601
+    # TODO: temporary skipped due to 8601
     def test_network_mismatch_for_send_request_commands(self):
         sender = transaction_senders['D']
         self.create_drivers(2)
@@ -78,7 +78,7 @@ class TestCommandsMultipleDevices(MultipleDeviceTestCase):
     @marks.testrail_id(5306)
     @marks.critical
     @marks.skip
-    # temporary skipped due to 8601
+    # TODO: temporary skipped due to 8601
     def test_send_eth_in_1_1_chat(self):
         recipient = transaction_recipients['A']
         sender = transaction_senders['A']
@@ -132,7 +132,7 @@ class TestCommandsMultipleDevices(MultipleDeviceTestCase):
     @marks.testrail_id(5318)
     @marks.critical
     @marks.skip
-    # temporary skipped due to 8601
+    # TODO: temporary skipped due to 8601
     def test_request_and_receive_eth_in_1_1_chat(self):
         recipient = transaction_recipients['B']
         sender = transaction_senders['J']
@@ -171,7 +171,7 @@ class TestCommandsMultipleDevices(MultipleDeviceTestCase):
     @marks.testrail_id(5324)
     @marks.critical
     @marks.skip
-    # temporary skipped due to 8601
+    # TODO: temporary skipped due to 8601
     def test_request_eth_in_wallet(self):
         self.create_drivers(2)
         device_1, device_2 = SignInView(self.drivers[0]), SignInView(self.drivers[1])
@@ -217,7 +217,7 @@ class TestCommandsMultipleDevices(MultipleDeviceTestCase):
     @marks.testrail_id(5383)
     @marks.high
     @marks.skip
-    # temporary skipped due to 8601
+    # TODO: temporary skipped due to 8601
     def test_contact_profile_send_transaction(self):
         self.create_drivers(1)
         recipient = basic_user
@@ -248,7 +248,7 @@ class TestCommandsMultipleDevices(MultipleDeviceTestCase):
     @marks.testrail_id(5348)
     @marks.critical
     @marks.skip
-    # temporary skipped due to 8601
+    # TODO: temporary skipped due to 8601
     def test_send_tokens_in_1_1_chat(self):
         recipient = transaction_recipients['C']
         sender = transaction_senders['C']
@@ -281,7 +281,7 @@ class TestCommandsMultipleDevices(MultipleDeviceTestCase):
     @marks.testrail_id(5352)
     @marks.critical
     @marks.skip
-    # temporary skipped due to 8601
+    # TODO: temporary skipped due to 8601
     def test_request_and_receive_tokens_in_1_1_chat(self):
         recipient = transaction_recipients['D']
         sender = transaction_senders['B']
@@ -318,7 +318,7 @@ class TestCommandsMultipleDevices(MultipleDeviceTestCase):
     @marks.testrail_id(5376)
     @marks.high
     @marks.skip
-    # temporary skipped due to 8601
+    # TODO: temporary skipped due to 8601
     def test_transaction_confirmed_on_recipient_side(self):
         recipient = transaction_recipients['E']
         sender = transaction_senders['E']
@@ -347,7 +347,7 @@ class TestCommandsSingleDevices(SingleDeviceTestCase):
     @marks.testrail_id(5349)
     @marks.high
     @marks.skip
-    # temporary skipped due to 8601
+    # TODO: temporary skipped due to 8601
     def test_send_request_not_enabled_tokens(self):
         sign_in = SignInView(self.driver)
         home = sign_in.create_user()
@@ -367,7 +367,7 @@ class TestCommandsSingleDevices(SingleDeviceTestCase):
     @marks.testrail_id(5417)
     @marks.critical
     @marks.skip
-    # temporary skipped due to 8601
+    # TODO: temporary skipped due to 8601
     def test_logcat_send_transaction_in_1_1_chat(self):
         sender = transaction_senders['F']
         sign_in = SignInView(self.driver)
@@ -385,7 +385,7 @@ class TestCommandsSingleDevices(SingleDeviceTestCase):
     @marks.testrail_id(5347)
     @marks.high
     @marks.skip
-    # temporary skipped due to 8601
+    # TODO: temporary skipped due to 8601
     def test_send_transaction_details_in_1_1_chat(self):
         recipient = basic_user
         sender = transaction_senders['G']
@@ -415,7 +415,7 @@ class TestCommandsSingleDevices(SingleDeviceTestCase):
     @marks.testrail_id(5377)
     @marks.high
     @marks.skip
-    # temporary skipped due to 8601
+    # TODO: temporary skipped due to 8601
     def test_transaction_confirmed_on_sender_side(self):
         sender = transaction_senders['H']
         sign_in = SignInView(self.driver)
@@ -428,12 +428,12 @@ class TestCommandsSingleDevices(SingleDeviceTestCase):
         chat.send_transaction_in_1_1_chat('ETHro', amount)
         self.network_api.wait_for_confirmation_of_transaction(sender['address'], amount)
         if not chat.chat_element_by_text(amount).contains_text('Confirmed', wait_time=90):
-            pytest.fail('Status "Confirmed" is not shown under transaction for the sender')
+            self.driver.fail('Status "Confirmed" is not shown under transaction for the sender')
 
     @marks.testrail_id(5410)
     @marks.high
     @marks.skip
-    # temporary skipped due to 8601
+    # TODO: temporary skipped due to 8601
     def test_insufficient_funds_1_1_chat_0_balance(self):
         sign_in_view = SignInView(self.driver)
         sign_in_view.create_user()
@@ -469,7 +469,7 @@ class TestCommandsSingleDevices(SingleDeviceTestCase):
     @marks.testrail_id(5473)
     @marks.medium
     @marks.skip
-    # temporary skipped due to 8601
+    # TODO: temporary skipped due to 8601
     def test_insufficient_funds_1_1_chat_positive_balance(self):
         sender = transaction_senders['I']
         sign_in_view = SignInView(self.driver)
@@ -480,7 +480,7 @@ class TestCommandsSingleDevices(SingleDeviceTestCase):
         eth_value = wallet_view.get_eth_value()
         stt_value = wallet_view.get_stt_value()
         if eth_value == 0 or stt_value == 0:
-            pytest.fail('No funds!')
+            self.driver.fail('No funds!')
         home_view = wallet_view.home_button.click()
         chat_view = home_view.add_contact(basic_user['public_key'])
         chat_view.commands_button.click()

--- a/test/appium/tests/atomic/chats/test_one_to_one.py
+++ b/test/appium/tests/atomic/chats/test_one_to_one.py
@@ -308,6 +308,8 @@ class TestMessagesOneToOneChatMultiple(MultipleDeviceTestCase):
 
     @marks.testrail_id(5425)
     @marks.medium
+    @marks.skip
+    # TODO: e2e blocker: 8995 (should be enabled after fix)
     def test_bold_and_italic_text_in_messages(self):
         self.create_drivers(2)
         sign_in_1, sign_in_2 = SignInView(self.drivers[0]), SignInView(self.drivers[1])
@@ -368,6 +370,7 @@ class TestMessagesOneToOneChatMultiple(MultipleDeviceTestCase):
     @marks.skip
     @marks.testrail_id(5385)
     @marks.high
+    # TODO: update with correct time - doesn't work for now
     def test_timestamp_in_chats(self):
         self.create_drivers(2)
         sign_in_1, sign_in_2 = SignInView(self.drivers[0]), SignInView(self.drivers[1])
@@ -417,7 +420,7 @@ class TestMessagesOneToOneChatMultiple(MultipleDeviceTestCase):
     @marks.testrail_id(5405)
     @marks.high
     @marks.skip
-    # temporary skipped due to 8601
+    # TODO: temporary skipped due to 8601
     def test_fiat_value_is_correctly_calculated_on_recipient_side(self):
         sender = transaction_senders['Y']
         recipient = transaction_recipients['I']
@@ -534,7 +537,7 @@ class TestMessagesOneToOneChatSingle(SingleDeviceTestCase):
         message_input.delete_last_symbols(2)
         current_text = message_input.text
         if current_text != message_text[:-2]:
-            pytest.fail("Message input text '%s' doesn't match expected '%s'" % (current_text, message_text[:-2]))
+            self.driver.fail("Message input text '%s' doesn't match expected '%s'" % (current_text, message_text[:-2]))
 
         message_input.cut_text()
 
@@ -572,7 +575,7 @@ class TestMessagesOneToOneChatSingle(SingleDeviceTestCase):
     @marks.testrail_id(5393)
     @marks.high
     @marks.skip
-    # temporary skipped due to 8601
+    # TODO: temporary skipped due to 8601
     def test_that_fiat_value_is_correct_for_token_transactions(self):
         sender_passphrase = transaction_senders['X']['passphrase']
         recipient_public_key = transaction_recipients['H']['public_key']

--- a/test/appium/tests/atomic/chats/test_public.py
+++ b/test/appium/tests/atomic/chats/test_public.py
@@ -156,6 +156,7 @@ class TestPublicChatSingleDevice(SingleDeviceTestCase):
     @marks.skip
     @marks.testrail_id(5392)
     @marks.high
+    # TODO: update to use korean keyboard
     def test_send_korean_characters(self):
         sign_in = SignInView(self.driver)
         home = sign_in.create_user()
@@ -173,6 +174,7 @@ class TestPublicChatSingleDevice(SingleDeviceTestCase):
     @marks.skip
     @marks.testrail_id(5336)
     @marks.medium
+    # skipped as it is a part of other tests
     def test_user_can_interact_with_public_chat(self):
         signin = SignInView(self.driver)
         home_view = signin.create_user()

--- a/test/appium/tests/atomic/dapps_and_browsing/test_browsing.py
+++ b/test/appium/tests/atomic/dapps_and_browsing/test_browsing.py
@@ -29,7 +29,7 @@ class TestBrowsing(SingleDeviceTestCase):
         browsing_view.find_text_part('Unable to load page')
         browsing_view.cross_icon.click()
         if home_view.element_by_text('Browser').is_element_displayed():
-            pytest.fail('Browser entity is shown for an invalid link')
+            self.driver.fail('Browser entity is shown for an invalid link')
 
     @marks.testrail_id(6210)
     @marks.high
@@ -99,6 +99,7 @@ class TestBrowsing(SingleDeviceTestCase):
     @marks.testrail_id(5321)
     @marks.skip
     @marks.critical
+    # TODO: update to use some static website
     def test_back_forward_buttons_browsing_website(self):
         sign_in = SignInView(self.driver)
         home = sign_in.create_user()

--- a/test/appium/tests/atomic/test_translations.py
+++ b/test/appium/tests/atomic/test_translations.py
@@ -3,7 +3,6 @@ from itertools import chain
 import json
 import os
 import pytest
-
 from tests import marks
 from tests.base_test_case import NoDeviceTestCase
 
@@ -14,6 +13,7 @@ class TestTranslations(NoDeviceTestCase):
 
     @marks.testrail_id(6223)
     @marks.skip
+    # skipped: no need to launch it on daily basis
     def test_find_unused_translations(self):
         directory = os.sep.join(__file__.split(os.sep)[:-5])
         with open(os.path.join(directory, 'translations/en.json'), 'r') as f:

--- a/test/appium/tests/atomic/test_upgrade.py
+++ b/test/appium/tests/atomic/test_upgrade.py
@@ -13,6 +13,7 @@ class TestUpgradeApplication(SingleDeviceTestCase):
     @marks.testrail_id(5713)
     @marks.upgrade
     @marks.skip
+    # skipped as no support for upgrade now
     def test_apk_upgrade(self):
         sign_in = SignInView(self.driver)
         home = sign_in.create_user()

--- a/test/appium/tests/atomic/transactions/test_daaps_transactions.py
+++ b/test/appium/tests/atomic/transactions/test_daaps_transactions.py
@@ -59,7 +59,7 @@ class TestTransactionDApp(SingleDeviceTestCase):
         for text in 'Contract deployed at: ', 'Call contract get function', \
                     'Call contract set function', 'Call function 2 times in a row':
             if not status_test_dapp.element_by_text(text).is_element_displayed(120):
-                pytest.fail('Contract was not created')
+                self.driver.fail('Contract was not created')
 
     @marks.testrail_id(5784)
     @marks.critical
@@ -94,7 +94,7 @@ class TestTransactionDApp(SingleDeviceTestCase):
 
         # Check that second 'Send transaction' screen appears
         if not send_transaction_view.element_by_text('Sign with password').is_element_displayed(10):
-            pytest.fail('Second send transaction screen did not appear!')
+            self.driver.fail('Second send transaction screen did not appear!')
 
         send_transaction_view.sign_transaction()
 
@@ -114,7 +114,7 @@ class TestTransactionDApp(SingleDeviceTestCase):
 
         # Check that second 'Send transaction' screen appears
         if not send_transaction_view.element_by_text('Sign with password').is_element_displayed(20):
-            pytest.fail('Second send transaction screen did not appear!')
+            self.driver.fail('Second send transaction screen did not appear!')
 
         send_transaction_view.sign_transaction()
 
@@ -295,6 +295,8 @@ class TestTransactionDApp(SingleDeviceTestCase):
 
     @marks.testrail_id(5686)
     @marks.medium
+    @marks.skip
+    # TODO: e2e blocker: 8567 (should be enabled after fix)
     def test_not_enough_eth_for_gas_validation_from_wallet(self):
         singin_view = SignInView(self.driver)
         home_view = singin_view.create_user()
@@ -393,6 +395,7 @@ class TestTransactionDApp(SingleDeviceTestCase):
     @marks.testrail_id(5687)
     @marks.medium
     @marks.skip
+    # TODO: e2e blocker: 8601 (should be enabled after fix)
     def test_not_enough_eth_for_gas_validation_from_chat(self):
         signin_view = SignInView(self.driver)
         home_view = signin_view.create_user()

--- a/test/appium/tests/atomic/transactions/test_wallet.py
+++ b/test/appium/tests/atomic/transactions/test_wallet.py
@@ -14,7 +14,7 @@ class TestTransactionWalletSingleDevice(SingleDeviceTestCase):
     @marks.testrail_id(5307)
     @marks.critical
     @marks.skip
-    # temporary skipped due to 8601
+    # TODO: temporary skipped due to 8601
     def test_send_eth_from_wallet_to_contact(self):
         recipient = basic_user
         sender = transaction_senders['N']
@@ -320,7 +320,7 @@ class TestTransactionWalletSingleDevice(SingleDeviceTestCase):
         eth_value = wallet_view.get_eth_value()
         stt_value = wallet_view.get_stt_value()
         if eth_value == 0 or stt_value == 0:
-            pytest.fail('No funds!')
+            self.driver.fail('No funds!')
         wallet_view.accounts_status_account.click()
         send_transaction = wallet_view.send_transaction_button.click()
         send_transaction.amount_edit_box.set_value(round(eth_value + 1))
@@ -526,6 +526,7 @@ class TestTransactionWalletMultipleDevice(MultipleDeviceTestCase):
     @marks.testrail_id(5378)
     @marks.skip
     @marks.high
+    # TODO: temporary skipped due to 8601
     def test_transaction_message_sending_from_wallet(self):
         recipient = transaction_recipients['E']
         sender = transaction_senders['V']

--- a/test/appium/views/dapps_view.py
+++ b/test/appium/views/dapps_view.py
@@ -64,6 +64,17 @@ class SelectAccountRadioButton(BaseButton):
         self.locator = self.Locator.xpath_selector("//*[@text='%s']/../../android.view.ViewGroup/android.view.ViewGroup[2]" % account_name)
 
 
+class AlwaysAllowRadioButton(BaseButton):
+    def __init__(self, driver):
+        super(AlwaysAllowRadioButton, self).__init__(driver)
+        self.locator = self.Locator.xpath_selector("//*[@text='Always allow']/../android.view.ViewGroup")
+
+
+class CrossCloseWeb3PermissionButton(BaseButton):
+    def __init__(self, driver):
+        super(CrossCloseWeb3PermissionButton, self).__init__(driver)
+        self.locator = self.Locator.xpath_selector(
+            '//*[contains(@text,"ÐApps can access")]/../android.view.ViewGroup[1]/android.view.ViewGroup')
 
 class DappsView(BaseView):
 
@@ -85,6 +96,9 @@ class DappsView(BaseView):
         self.select_account_button = SelectAccountButton(self.driver)
         self.select_account_radio_button = SelectAccountRadioButton(self.driver,
                                                                     account_name='Status account')
+        #permissions window
+        self.always_allow_radio_button = AlwaysAllowRadioButton(self.driver)
+        self.close_web3_permissions_window_button = CrossCloseWeb3PermissionButton(self.driver)
 
 
     def open_url(self, url):


### PR DESCRIPTION
1. new e2e `test_always_allow_web3_permissions`
2. fixed test [5436](https://ethstatus.testrail.net/index.php?/cases/view/5436)
3. replaced pytest.fail to self.driver.fail
4. skipped several failed e2e due to non-high-prio blockers
5. added comments to all skipped e2e with reason