### PR TITLE
fix matching deps with only one dependency

### DIFF
--- a/nix/mobile/android/maven-and-npm-deps/maven/fetch-maven-deps.sh
+++ b/nix/mobile/android/maven-and-npm-deps/maven/fetch-maven-deps.sh
@@ -92,12 +92,12 @@ function runGradleDepsCommand() {
   echo "# $1"
 
   # Run the gradle command and:
-  # - remove lines that end with (*) or (n)
+  # - remove lines that end with (*) or (n) but don't start with (+)
   # - keep only lines that start with \--- or +---
   # - remove lines that refer to a project
   # - extract the package name and version, ignoring version range indications, such as in `com.google.android.gms:play-services-ads:[15.0.1,16.0.0) -> 15.0.1`
   gradle $1 $gradle_opts \
-    | grep --invert-match -E ".+ \([\*n]\)$" \
+    | grep --invert-match -E "^[^+].+ \([\*n]\)$" \
     | grep -e "[\\\+]---" \
     | grep --invert-match -e "--- project :" \
     | sed -E "s;.*[\\\+]--- ([^ ]+:)(.+ -> )?([^ ]+).*$;\1\3;"


### PR DESCRIPTION
This is a fix that came out of #9257. Essentially what the `fetch-maven-deps.sh` script does is it queries Gradle for all of its dependencies, and than watches as Gradle downloads them to assemble two files:

* `nix/mobile/android/maven-and-npm-deps/maven/maven-inputs.txt` - List dependency URLs
* `nix/mobile/android/maven-and-npm-deps/maven/maven-sources.nix` - Same but for Nix+hashes

Normally Gradle lists dependencies like this:
```
+--- project :react-native-webview-bridge
|    \--- com.facebook.react:react-native:+ -> 0.60.6 (*)
+--- project :react-native-image-resizer
|    \--- com.facebook.react:react-native:+ -> 0.60.6 (*)
```
But in case of a direct dependency with one sub-dependency it looks like this:
```
+--- com.android.support:support-compat:28.0.0 -> androidx.core:core:1.0.1 (*)
+--- com.android.support:appcompat-v7:28.0.0 -> androidx.appcompat:appcompat:1.0.2 (*)
```
The first regex - as the comment states - removes lines that end with `(*)` or `(n)`, which means:
```
(c) - dependency constraint
(*) - dependencies omitted (listed previously)
(n) - Not resolved (configuration is not meant to be resolved)
```
But in case of a single dependency with one sub-dependency that's not correct, because the first segment - in our case `com.android.support:support-compat:28.0.0` - should be included, but isn't due to it ending with `(*)` because of `androidx.core:core:1.0.1` being already listed before.