### PR TITLE
To isolate soft error handling per test

### DIFF
--- a/test/appium/tests/atomic/account_management/test_create_account.py
+++ b/test/appium/tests/atomic/account_management/test_create_account.py
@@ -32,7 +32,7 @@ class TestCreateAccount(SingleDeviceTestCase):
         sign_in.name_input.send_keys('user_%s' % get_current_time())
 
         sign_in.next_button.click()
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
     @marks.testrail_id(5356)
     @marks.critical
@@ -81,7 +81,7 @@ class TestCreateAccount(SingleDeviceTestCase):
         shown_username = profile_view.default_username_text.text
         if shown_username != username:
             self.errors.append("Default username '%s' doesn't match '%s'" % (shown_username, username))
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
     @marks.testrail_id(5460)
     @marks.medium
@@ -106,7 +106,7 @@ class TestCreateAccount(SingleDeviceTestCase):
 
         if not sign_in.find_text_part(mismatch_error):
             self.errors.append("'%s' is not shown")
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
     @marks.testrail_id(5414)
     @marks.critical

--- a/test/appium/tests/atomic/account_management/test_profile.py
+++ b/test/appium/tests/atomic/account_management/test_profile.py
@@ -54,7 +54,7 @@ class TestProfileSingleDevice(SingleDeviceTestCase):
         chat.send_message_button.click()
         if not chat.chat_element_by_text(message).is_element_displayed():
             self.errors.append("Message was not sent!")
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
     @marks.testrail_id(6228)
     @marks.high
@@ -106,7 +106,7 @@ class TestProfileSingleDevice(SingleDeviceTestCase):
             self.errors.append("Mobile data is enabled by default")
         if not profile_view.ask_me_when_on_mobile_network.attribute_value("checked"):
             self.errors.append("'Ask me when on mobile network' is not enabled by default")
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
 
     @marks.testrail_id(5454)
@@ -148,7 +148,7 @@ class TestProfileSingleDevice(SingleDeviceTestCase):
         wallet.share_via_messenger()
         if not wallet.element_by_text_part(address).is_element_present():
             self.errors.append("Can't share address")
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
     @marks.testrail_id(5375)
     @marks.high
@@ -186,7 +186,7 @@ class TestProfileSingleDevice(SingleDeviceTestCase):
         chat.paste_text()
         if chat.chat_message_input.text != address:
             self.errors.append('Wallet address was not copied')
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
     @marks.testrail_id(5502)
     @marks.critical
@@ -219,7 +219,7 @@ class TestProfileSingleDevice(SingleDeviceTestCase):
             self.errors.append('No ENS name is shown in own profile after adding')
         if not dapp_view.element_by_text('%s.stateofus.eth' % ens_user['ens']).is_element_displayed():
             self.errors.append('No ENS name is shown in own profile after adding')
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
     @marks.testrail_id(5475)
     @marks.low
@@ -255,7 +255,7 @@ class TestProfileSingleDevice(SingleDeviceTestCase):
         profile_view.backup_recovery_phrase_button.click()
         if not profile_view.backup_recovery_phrase_button.is_element_displayed():
             self.errors.append('Back up seed phrase option is available after seed phrase backed up!')
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
     @marks.testrail_id(5433)
     @marks.medium
@@ -332,7 +332,7 @@ class TestProfileSingleDevice(SingleDeviceTestCase):
         for text in basic_user['username'], 'Remove from contacts', 'Send message', 'Block this user':
             if not chat_view.element_by_text(text).scroll_to_element():
                 self.errors.append('%s is not visible' % text)
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
     @marks.testrail_id(5368)
     @marks.high
@@ -351,7 +351,7 @@ class TestProfileSingleDevice(SingleDeviceTestCase):
             for text in 'INFO', 'eth.beta':
                 if not profile_view.element_by_text(text).is_element_displayed():
                     self.errors.append('%s is not selected by default' % text)
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
 
     @marks.testrail_id(5468)
@@ -421,7 +421,7 @@ class TestProfileSingleDevice(SingleDeviceTestCase):
         if not base_web_view.policy_summary.is_element_displayed():
             self.errors.append('{} Profile about view!'.format(no_link_open_error_msg))
 
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
     @marks.testrail_id(5738)
     @marks.high
@@ -453,7 +453,7 @@ class TestProfileSingleDevice(SingleDeviceTestCase):
             dapp_view.allow_button.click(times_to_click=1)
         if not dapp_view.element_by_text_part('to your profile').is_element_displayed():
             self.errors.append('Profile permission is not asked')
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
     @marks.testrail_id(5428)
     @marks.low
@@ -476,7 +476,7 @@ class TestProfileSingleDevice(SingleDeviceTestCase):
         message_input.paste_text_from_clipboard()
         if message_input.text != app_version:
             self.errors.append('Version number was not copied to clipboard')
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
     @marks.testrail_id(5766)
     @marks.medium
@@ -512,7 +512,7 @@ class TestProfileSingleDevice(SingleDeviceTestCase):
         if profile_view.confirm_button.is_element_displayed():
             self.errors.append('can select mailserver with "Autoselection" switched on')
 
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
 
 @marks.all
@@ -663,7 +663,7 @@ class TestProfileMultipleDevice(MultipleDeviceTestCase):
         if not public_chat_1.chat_element_by_text(message).is_element_displayed(30):
             self.errors.append("Chat history wasn't fetched")
 
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
     @marks.testrail_id(5762)
     @marks.high
@@ -725,7 +725,7 @@ class TestProfileMultipleDevice(MultipleDeviceTestCase):
         if not chat.chat_element_by_text(message_after_sync).is_element_displayed():
             self.errors.append('"%s" message in 1-1 is not synced' % message_after_sync)
 
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
     @marks.testrail_id(5680)
     @marks.high
@@ -807,7 +807,7 @@ class TestProfileMultipleDevice(MultipleDeviceTestCase):
         if not device_2_profile.profile_picture.is_element_image_equals_template('sauce_logo_red_profile.png'):
             self.errors.append('Profile picture was not updated after changing when devices are paired')
 
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
     @marks.testrail_id(6226)
     @marks.critical
@@ -857,4 +857,4 @@ class TestProfileMultipleDevice(MultipleDeviceTestCase):
         if chat_2.chat_element_by_text(message_text_2).username.text.lower() != '@' + user_1['ens']:
             self.errors.append('ENS username is not shown in public chat')
 
-        self.verify_no_errors()
+        self.errors.verify_no_errors()

--- a/test/appium/tests/atomic/account_management/test_recover.py
+++ b/test/appium/tests/atomic/account_management/test_recover.py
@@ -25,7 +25,7 @@ class TestRecoverAccountSingleDevice(SingleDeviceTestCase):
         profile_view.backup_recovery_phrase_button.click()
         if not profile_view.backup_recovery_phrase_button.is_element_displayed():
             self.errors.append('Back up seed phrase option is active for recovered account!')
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
     @marks.skip
     @marks.testrail_id(845)
@@ -147,7 +147,7 @@ class TestRecoverAccessFromSignInScreen(SingleDeviceTestCase):
             else:
                 recover_access_view.click_system_back_button()
 
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
     @marks.testrail_id(5499)
     @marks.medium
@@ -194,4 +194,4 @@ class TestRecoverAccessFromSignInScreen(SingleDeviceTestCase):
                 self.errors.append('Restored wallet address "%s" does not match expected "%s"' % (address, account))
             profile_view = home_view.profile_button.click()
             profile_view.logout()
-        self.verify_no_errors()
+        self.errors.verify_no_errors()

--- a/test/appium/tests/atomic/account_management/test_wallet_management.py
+++ b/test/appium/tests/atomic/account_management/test_wallet_management.py
@@ -50,7 +50,7 @@ class TestWalletManagement(SingleDeviceTestCase):
             if wallet.element_by_text_part(text).is_element_displayed():
                 self.errors.append('Signing phrase pop up appears after wallet set up')
                 break
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
     @marks.testrail_id(5384)
     @marks.critical
@@ -106,7 +106,7 @@ class TestWalletManagement(SingleDeviceTestCase):
         wallet.select_asset(asset)
         if wallet.asset_by_name(asset).is_element_displayed():
             self.errors.append('%s asset is shown in wallet but was deselected' % asset)
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
     @marks.testrail_id(5358)
     @marks.medium
@@ -204,7 +204,7 @@ class TestWalletManagement(SingleDeviceTestCase):
             if not details.element_by_text('Failed').is_element_displayed():
                 self.driver.fail('Failed transactions are not filtered')
             details.back_button.click()
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
     @marks.testrail_id(5381)
     @marks.high
@@ -275,7 +275,7 @@ class TestWalletManagement(SingleDeviceTestCase):
         send_transaction.select_asset_button.click_until_presence_of_element(token_element)
         if not token_element.is_element_displayed():
             self.errors.append('Custom token is not shown on Send Transaction view')
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
     @marks.testrail_id(6224)
     @marks.critical
@@ -338,4 +338,4 @@ class TestWalletManagement(SingleDeviceTestCase):
         if send_transaction.enter_recipient_address_text.text != ens_user_other_domain['address']:
             self.errors.append('ENS address on another domain is not resolved as recipient')
 
-        self.verify_no_errors()
+        self.errors.verify_no_errors()

--- a/test/appium/tests/atomic/chats/test_chats_management.py
+++ b/test/appium/tests/atomic/chats/test_chats_management.py
@@ -64,7 +64,7 @@ class TestChatManagement(SingleDeviceTestCase):
         home.join_public_chat(chat_name)
         if chat.chat_element_by_text(message).is_element_displayed():
             self.errors.append('Chat history is shown')
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
     @marks.testrail_id(5304)
     @marks.high
@@ -105,7 +105,7 @@ class TestChatManagement(SingleDeviceTestCase):
         home.relogin()
         if home.get_chat_with_user(basic_user['username']).is_element_present(10):
             self.errors.append("One-to-one' chat is shown after re-login, but the chat has been deleted")
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
     @marks.testrail_id(5388)
     @marks.high
@@ -122,7 +122,7 @@ class TestChatManagement(SingleDeviceTestCase):
         home.relogin()
         if home.element_by_text(chat_name).is_element_present(5):
             self.errors.append("Public chat '%s' is shown after re-login, but the chat has been deleted" % chat_name)
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
     @marks.testrail_id(5464)
     @marks.medium
@@ -178,7 +178,7 @@ class TestChatManagement(SingleDeviceTestCase):
                     self.errors.append("'%s' is shown on the home screen after searching by '%s' keyword" %
                                        (element.text, keyword))
             home.search_chat_input.clear()
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
     @marks.testrail_id(6221)
     @marks.medium
@@ -252,7 +252,7 @@ class TestChatManagementMultipleDevice(MultipleDeviceTestCase):
         if not contacts_1.element_by_text(username).is_element_displayed():
             self.errors.append("List of contacts doesn't contain added user")
 
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
     @marks.testrail_id(5786)
     @marks.critical
@@ -396,4 +396,4 @@ class TestChatManagementMultipleDevice(MultipleDeviceTestCase):
                 "Message from blocked user '%s' is received after fetching new messages from offline"
                 % device_2.driver.number)
 
-        self.verify_no_errors()
+        self.errors.verify_no_errors()

--- a/test/appium/tests/atomic/chats/test_commands.py
+++ b/test/appium/tests/atomic/chats/test_commands.py
@@ -73,7 +73,7 @@ class TestCommandsMultipleDevices(MultipleDeviceTestCase):
                 self.errors.append("Request funds message doesn't contain text 'Transaction Request'")
         except TimeoutException:
             self.errors.append('Request funds message was not received')
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
     @marks.testrail_id(5306)
     @marks.critical
@@ -127,7 +127,7 @@ class TestCommandsMultipleDevices(MultipleDeviceTestCase):
             self.network_api.find_transaction_by_unique_amount(recipient['address'], amount)
         except Failed as e:
             self.errors.append(e.msg)
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
     @marks.testrail_id(5318)
     @marks.critical
@@ -166,7 +166,7 @@ class TestCommandsMultipleDevices(MultipleDeviceTestCase):
             self.network_api.find_transaction_by_unique_amount(recipient['address'], amount)
         except Failed as e:
             self.errors.append(e.msg)
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
     @marks.testrail_id(5324)
     @marks.critical
@@ -212,7 +212,7 @@ class TestCommandsMultipleDevices(MultipleDeviceTestCase):
                 self.errors.append("Request funds message doesn't contain 'Send' button")
         except TimeoutException:
             self.errors.append('Request funds message was not received')
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
     @marks.testrail_id(5383)
     @marks.high
@@ -276,7 +276,7 @@ class TestCommandsMultipleDevices(MultipleDeviceTestCase):
             self.network_api.find_transaction_by_unique_amount(recipient['address'], amount, token=True)
         except Failed as e:
             self.errors.append(e.msg)
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
     @marks.testrail_id(5352)
     @marks.critical
@@ -313,7 +313,7 @@ class TestCommandsMultipleDevices(MultipleDeviceTestCase):
             self.network_api.find_transaction_by_unique_amount(recipient['address'], amount, token=True)
         except Failed as e:
             self.errors.append(e.msg)
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
     @marks.testrail_id(5376)
     @marks.high
@@ -361,7 +361,7 @@ class TestCommandsSingleDevices(SingleDeviceTestCase):
         chat.request_command.click()
         if chat.asset_by_name('MDS').is_element_displayed():
             self.errors.append('Token which is not enabled in wallet can be requested in 1-1 chat')
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
     @marks.logcat
     @marks.testrail_id(5417)
@@ -410,7 +410,7 @@ class TestCommandsSingleDevices(SingleDeviceTestCase):
             self.errors.append("Asset field doesn't contain 'ETHro' text")
         if not send_transaction_view.element_by_text_part(amount).is_element_displayed():
             self.errors.append('Amount is not visible')
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
     @marks.testrail_id(5377)
     @marks.high
@@ -464,7 +464,7 @@ class TestCommandsSingleDevices(SingleDeviceTestCase):
         chat_view.send_message_button.click()
         if not error_text.is_element_displayed():
             self.errors.append("'Insufficient funds' error is now shown when sending 1 STT from chat with balance 0")
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
     @marks.testrail_id(5473)
     @marks.medium
@@ -505,4 +505,4 @@ class TestCommandsSingleDevices(SingleDeviceTestCase):
             self.errors.append(
                 "'Insufficient funds' error is now shown when sending %s STT from chat with balance %s" % (
                     round(stt_value + 1), stt_value))
-        self.verify_no_errors()
+        self.errors.verify_no_errors()

--- a/test/appium/tests/atomic/chats/test_group_chat.py
+++ b/test/appium/tests/atomic/chats/test_group_chat.py
@@ -79,7 +79,7 @@ class TestGroupChatMultipleDevice(MultipleDeviceTestCase):
             if chat.user_name_text.text != chat_name:
                 self.errors.append('Oops! Chat screen does not match the entered chat name %s' % chat_name)
 
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
     @marks.testrail_id(3993)
     @marks.critical
@@ -99,7 +99,7 @@ class TestGroupChatMultipleDevice(MultipleDeviceTestCase):
                         "Message from device: %s" % chat_driver.driver.number).is_element_displayed():
                     self.errors.append("Message from device '%s' was not received" % chat_driver.driver.number)
 
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
     @marks.testrail_id(5674)
     @marks.high
@@ -128,7 +128,7 @@ class TestGroupChatMultipleDevice(MultipleDeviceTestCase):
             if not device_1_chat.chat_element_by_text(message).is_element_displayed():
                 self.errors.append("Message with test '%s' was not received" % message)
 
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
     @marks.testrail_id(3997)
     @marks.high
@@ -152,7 +152,7 @@ class TestGroupChatMultipleDevice(MultipleDeviceTestCase):
         if device_1_home.element_by_text(chat_name).is_element_displayed():
             self.errors.append("Group chat '%s' is shown, but the chat has been deleted" % chat_name)
 
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
     @marks.testrail_id(3998)
     @marks.high
@@ -191,7 +191,7 @@ class TestGroupChatMultipleDevice(MultipleDeviceTestCase):
 
         if not device_2_chat.chat_element_by_text(message_for_device_2).is_element_displayed(30):
             self.errors.append('Message that was sent after device 2 has joined is not visible')
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
     @marks.testrail_id(5756)
     @marks.high
@@ -220,7 +220,7 @@ class TestGroupChatMultipleDevice(MultipleDeviceTestCase):
             # device 2: check that chat doesn't reappear
             if device_2_home.element_by_text(chat_name).is_element_displayed():
                 self.errors.append("Group chat '%s' is shown, but the chat has been deleted" % chat_name)
-            self.verify_no_errors()
+            self.errors.verify_no_errors()
 
     @marks.testrail_id(4001)
     @marks.high
@@ -255,7 +255,7 @@ class TestGroupChatMultipleDevice(MultipleDeviceTestCase):
         if device_2_chat.chat_element_by_text(message_for_device_2).is_element_displayed():
             self.errors.append("Message with text '%s' was received" % message_for_device_2)
 
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
     @marks.testrail_id(5694)
     @marks.high
@@ -287,7 +287,7 @@ class TestGroupChatMultipleDevice(MultipleDeviceTestCase):
         # device 2: check that as admin can add new members to group chat
         device_2_chat.add_members_to_group_chat([chat_member['username']])
 
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
     @marks.testrail_id(5681)
     @marks.high
@@ -323,4 +323,4 @@ class TestGroupChatMultipleDevice(MultipleDeviceTestCase):
                 device_1_chat.driver.fail(
                     "Message '%s' is shown after re-login, but group chat history has been cleared" % message)
 
-        self.verify_no_errors()
+        self.errors.verify_no_errors()

--- a/test/appium/tests/atomic/chats/test_one_to_one.py
+++ b/test/appium/tests/atomic/chats/test_one_to_one.py
@@ -146,7 +146,7 @@ class TestMessagesOneToOneChatMultiple(MultipleDeviceTestCase):
         device_2_chat.view_profile_button.click()
         if not device_2_chat.contact_profile_picture.is_element_image_equals_template('sauce_logo.png'):
             self.errors.append("Updated profile picture is not shown in one-to-one chat")
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
     @marks.testrail_id(5316)
     @marks.critical
@@ -191,7 +191,7 @@ class TestMessagesOneToOneChatMultiple(MultipleDeviceTestCase):
         device_1_chat.view_profile_button.click()
         if not device_1_chat.contact_profile_picture.is_element_image_equals_template(file_name):
             self.errors.append("Updated profile picture is not shown in one-to-one chat")
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
     @marks.testrail_id(5373)
     @marks.high
@@ -233,7 +233,7 @@ class TestMessagesOneToOneChatMultiple(MultipleDeviceTestCase):
             web_view.find_full_text('Private, Secure Communication')
         except TimeoutException:
             self.errors.append('Device 1: URL was not opened from 1-1 chat')
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
     @marks.testrail_id(5326)
     @marks.critical
@@ -255,7 +255,7 @@ class TestMessagesOneToOneChatMultiple(MultipleDeviceTestCase):
         public_chat = home_view.join_public_chat(home_view.get_public_chat_name())
         if public_chat.connection_status.text != 'Offline':
             self.errors.append('Offline status is not shown in a public chat')
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
     @marks.testrail_id(5374)
     @marks.high
@@ -269,7 +269,7 @@ class TestMessagesOneToOneChatMultiple(MultipleDeviceTestCase):
         chat_view.send_message_button.click()
         if chat_view.chat_element_by_text(message).status.text != 'Sent':
             self.errors.append("'Sent' status is not shown under the sent text message")
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
     @marks.testrail_id(5362)
     @marks.critical
@@ -304,7 +304,7 @@ class TestMessagesOneToOneChatMultiple(MultipleDeviceTestCase):
 
         if chat_element.new_messages_counter.is_element_displayed():
             self.errors.append('New messages counter is shown on chat element for already seen message')
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
     @marks.testrail_id(5425)
     @marks.medium
@@ -365,7 +365,7 @@ class TestMessagesOneToOneChatMultiple(MultipleDeviceTestCase):
         if not device_1_chat.chat_element_by_text(italic_text_expected).is_element_displayed():
             self.errors.append('Italic text is not displayed in 1-1 chat for the recipient')
 
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
     @marks.skip
     @marks.testrail_id(5385)
@@ -415,7 +415,7 @@ class TestMessagesOneToOneChatMultiple(MultipleDeviceTestCase):
         if not device_1_chat.chat_element_by_text(message).member_photo.is_element_displayed():
             self.errors.append('Member photo is not displayed in 1-1 chat for the recipient')
 
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
     @marks.testrail_id(5405)
     @marks.high
@@ -483,7 +483,7 @@ class TestMessagesOneToOneChatMultiple(MultipleDeviceTestCase):
         # if not received_message.is_element_displayed() and not sent_message.contains_text(device2['currency']):
         #     self.errors.append('Wrong currency fiat value while receiving ETH sent via wallet.')
 
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
 
 @marks.all
@@ -521,7 +521,7 @@ class TestMessagesOneToOneChatSingle(SingleDeviceTestCase):
         message_input.paste_text_from_clipboard()
         if message_input.text != message_text:
             self.errors.append('Message text was not copied in 1-1 chat')
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
     @marks.testrail_id(5322)
     @marks.medium
@@ -570,7 +570,7 @@ class TestMessagesOneToOneChatSingle(SingleDeviceTestCase):
 
         if not chat.chat_element_by_text(emoji_unicode).is_element_displayed():
             self.errors.append('Message with emoji was not sent in 1-1 chat')
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
     @marks.testrail_id(5393)
     @marks.high
@@ -661,7 +661,7 @@ class TestMessagesOneToOneChatSingle(SingleDeviceTestCase):
         # if not request_message.is_element_displayed() and not request_message.contains_text(user_currency):
         #     self.errors.append('Wrong fiat value while requesting assets from wallet with user selected currency.')
 
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
     @marks.testrail_id(5782)
     @marks.critical
@@ -695,7 +695,7 @@ class TestMessagesOneToOneChatSingle(SingleDeviceTestCase):
         chat.swipe_right()
         if not chat.sticker_icon.is_element_displayed():
             self.errors.append('Sticker is not shown in recently used list')
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
     @marks.testrail_id(5783)
     @marks.critical

--- a/test/appium/tests/atomic/chats/test_public.py
+++ b/test/appium/tests/atomic/chats/test_public.py
@@ -45,7 +45,7 @@ class TestPublicChatMultipleDevice(MultipleDeviceTestCase):
         # if chat_1.element_by_text_part(username_1).is_element_displayed():
         #     self.errors.append("Username '%s' is shown for the sender" % username_1)
 
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
     @marks.testrail_id(5386)
     @marks.high
@@ -112,7 +112,7 @@ class TestPublicChatMultipleDevice(MultipleDeviceTestCase):
 
         if chat_element.new_messages_counter.is_element_displayed():
             self.errors.append('New messages counter is shown on chat element for already seen message')
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
     @marks.testrail_id(6202)
     @marks.low
@@ -147,7 +147,7 @@ class TestPublicChatMultipleDevice(MultipleDeviceTestCase):
         chat_element_1 = chat_1.chat_element_by_text(message_text)
         if not chat_element_1.is_element_displayed(sec=10) or chat_element_1.replied_message_text != emoji_unicode:
             self.errors.append('Reply message was not received by the sender')
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
 
 @marks.chat
@@ -169,7 +169,7 @@ class TestPublicChatSingleDevice(SingleDeviceTestCase):
         public_chat.send_message_button.click()
         if not public_chat.chat_element_by_text(message).is_element_displayed():
             self.errors.append('Message with korean characters is not shown')
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
     @marks.skip
     @marks.testrail_id(5336)
@@ -204,7 +204,7 @@ class TestPublicChatSingleDevice(SingleDeviceTestCase):
         if len(chat.chat_item.find_elements()) <= 1:
             self.errors.append('No messages fetched for yesterday!')
 
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
     @marks.testrail_id(5675)
     @marks.high
@@ -240,4 +240,4 @@ class TestPublicChatSingleDevice(SingleDeviceTestCase):
         for message in (before_yesterday, quiet_time_before_yesterday):
             if not chat.element_by_text_part(message).is_element_displayed():
                 self.driver.fail('"%s" is not shown' % message)
-        self.verify_no_errors()
+        self.errors.verify_no_errors()

--- a/test/appium/tests/atomic/dapps_and_browsing/test_dapps.py
+++ b/test/appium/tests/atomic/dapps_and_browsing/test_dapps.py
@@ -64,7 +64,7 @@ class TestDApps(SingleDeviceTestCase):
         dapp_view.open_url(test_dapp_url)
         if status_test_dapp.allow_button.is_element_displayed():
             self.driver.append('DApp is asking permissions after relogin (Always allow is enabled)')
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
 
     @marks.testrail_id(6232)
@@ -121,7 +121,7 @@ class TestDApps(SingleDeviceTestCase):
         if not send_transaction_view.element_by_text(address).is_element_displayed():
             self.errors.append("Wallet address %s in not shown in 'From' on Send Transaction screen" % address)
 
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
     @marks.testrail_id(5654)
     @marks.low

--- a/test/appium/tests/atomic/transactions/test_daaps_transactions.py
+++ b/test/appium/tests/atomic/transactions/test_daaps_transactions.py
@@ -291,7 +291,7 @@ class TestTransactionDApp(SingleDeviceTestCase):
         if not status_test_dapp.assets_button.is_element_displayed():
             self.errors.append('Could not sing the transaction!')
 
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
     @marks.testrail_id(5686)
     @marks.medium
@@ -390,7 +390,7 @@ class TestTransactionDApp(SingleDeviceTestCase):
         if not wallet.send_transaction_button.is_element_displayed():
             self.errors.append('Could not sign the transaction!')
 
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
     @marks.testrail_id(5687)
     @marks.medium
@@ -469,4 +469,4 @@ class TestTransactionDApp(SingleDeviceTestCase):
         if not wallet.send_transaction_button.is_element_displayed():
             self.errors.append('Could not sing the transaction!')
 
-        self.verify_no_errors()
+        self.errors.verify_no_errors()

--- a/test/appium/tests/atomic/transactions/test_wallet.py
+++ b/test/appium/tests/atomic/transactions/test_wallet.py
@@ -245,7 +245,7 @@ class TestTransactionWalletSingleDevice(SingleDeviceTestCase):
         # error_text = 'Amount is too precise. Max number of decimals is 7.'
         # if not send_transaction.element_by_text(error_text).is_element_displayed():
         #     self.errors.append('Warning about too precise amount is not shown when requesting a transaction')
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
     @marks.testrail_id(5423)
     @marks.medium
@@ -294,7 +294,7 @@ class TestTransactionWalletSingleDevice(SingleDeviceTestCase):
         send_transaction.amount_edit_box.set_value(1)
         if not error_text.is_element_displayed():
             self.errors.append("'Insufficient funds' error is now shown when sending 1 STT from wallet with balance 0")
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
     @marks.testrail_id(5412)
     @marks.high
@@ -324,7 +324,7 @@ class TestTransactionWalletSingleDevice(SingleDeviceTestCase):
             self.errors.append(
                 "'Insufficient funds' error is now shown when sending %s STT from wallet with balance %s" % (
                     round(stt_value + 1), stt_value))
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
     @marks.testrail_id(5359)
     @marks.critical
@@ -400,7 +400,7 @@ class TestTransactionWalletSingleDevice(SingleDeviceTestCase):
                 self.errors.append('Transactions recipients do not match!')
             transactions_details.back_button.click()
 
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
     @marks.testrail_id(5429)
     @marks.medium
@@ -536,7 +536,7 @@ class TestTransactionWalletSingleDevice(SingleDeviceTestCase):
         if not account_button.color_matches('multi_account_color.png'):
             self.driver.fail('Account color does not match expected')
 
-        self.verify_no_errors()
+        self.errors.verify_no_errors()
 
 
 @marks.transaction
@@ -578,4 +578,4 @@ class TestTransactionWalletMultipleDevice(MultipleDeviceTestCase):
         chat_2 = home_2.get_chat_with_user(sender['username']).click()
         if not chat_2.chat_element_by_text(amount).is_element_displayed():
             self.errors.append('Transaction message is not shown in 1-1 chat for the recipient')
-        self.verify_no_errors()
+        self.errors.verify_no_errors()

--- a/test/appium/tests/test_performance.py
+++ b/test/appium/tests/test_performance.py
@@ -63,4 +63,4 @@ class TestPerformance(SingleDeviceTestCase):
             self.errors.append(
                 "time between submitting a password and successful login is '%s' seconds, while baseline is '%s'!"
                 % (time_to_login, baseline_login))
-        self.verify_no_errors()
+        self.errors.verify_no_errors()


### PR DESCRIPTION
Fixes #8784 

List of soft errors we collected was in AbstractTestCase. When two of more tests shared the same thread this list shared between them. In that case, when first test appended error but later this test failed during it's execution we had soft error list still keeping the record. Then even the second test may pass we had self.verify_no_errors() which failing the test with the error from the first test (because list of errors not cleared).

This PR fixes it by isolating errors on a per-test level (not per driver). Each time test starts we create new list for soft errors. And