### PR TITLE
e2e fixes: more time to wait

### DIFF
--- a/test/appium/tests/__init__.py
+++ b/test/appium/tests/__init__.py
@@ -36,6 +36,7 @@ mailserver_address = "enode://531e252ec966b7e83f5538c19bf1cde7381cc7949026a6e499
                      "fb7cefd31c3c88d600a775f14ed5781520a88ecd25da3c6:status-offline-inbox@35.225.227.79:30504"
 mailserver_central_2 = 'mail-02.gc-us-central1-a.eth.beta'
 mailserver_central_3 = 'mail-03.gc-us-central1-a.eth.beta'
+mailserver_ams_01 = 'mail-01.do-ams3.eth.beta'
 camera_access_error_text = "To grant the required camera permission, please go to your system settings " \
                            "and make sure that Status > Camera is selected."
 

--- a/test/appium/tests/atomic/account_management/test_profile.py
+++ b/test/appium/tests/atomic/account_management/test_profile.py
@@ -2,7 +2,8 @@ import pytest
 import re
 
 from tests import marks, bootnode_address, mailserver_address, camera_access_error_text, \
-    photos_access_error_text, test_dapp_url, test_dapp_name, mailserver_central_2, mailserver_central_3
+    photos_access_error_text, test_dapp_url, test_dapp_name, mailserver_central_2, mailserver_central_3, \
+    mailserver_ams_01
 from tests.base_test_case import SingleDeviceTestCase, MultipleDeviceTestCase
 from tests.users import transaction_senders, basic_user, ens_user
 from views.dapps_view import DappsView
@@ -488,7 +489,7 @@ class TestProfileSingleDevice(SingleDeviceTestCase):
         profile_view.just_fyi('pin mailserver')
         profile_view.sync_settings_button.click()
         # TODO: temporary to avoid issue 9269 - should be disabled after fix
-        mailserver = mailserver_central_2 if profile_view.element_by_text(mailserver_central_2).is_element_present() else mailserver_central_3
+        mailserver = mailserver_central_3 if profile_view.element_by_text(mailserver_central_2).is_element_present() else mailserver_central_2
         profile_view.mail_server_button.click()
         profile_view.mail_server_auto_selection_button.click()
         profile_view.element_by_text(mailserver).click()
@@ -578,8 +579,9 @@ class TestProfileMultipleDevice(MultipleDeviceTestCase):
         profile_1.sync_settings_button.click()
         profile_1.mail_server_button.click()
         # TODO: temporary pin mailserver to avoid issue 9269 - should be disabled after fix
+        mailserver = mailserver_ams_01 if profile_1.element_by_text(mailserver_central_2).is_element_present() else mailserver_central_2
         profile_1.mail_server_auto_selection_button.click()
-        profile_1.element_by_text(mailserver_central_2).click()
+        profile_1.element_by_text(mailserver).click()
         profile_1.confirm_button.click()
         profile_1.just_fyi('pin custom mailserver')
         profile_1.plus_button.click()

--- a/test/appium/tests/atomic/chats/test_one_to_one.py
+++ b/test/appium/tests/atomic/chats/test_one_to_one.py
@@ -245,6 +245,7 @@ class TestMessagesOneToOneChatMultiple(MultipleDeviceTestCase):
         home_view.airplane_mode_button.click()
 
         chat = home_view.add_contact(transaction_senders['C']['public_key'])
+        chat.element_by_text('Offline').wait_for_visibility_of_element(15)
         if chat.connection_status.text != 'Offline':
             self.errors.append('Offline status is not shown in 1-1 chat')
         chat.get_back_to_home_view()

--- a/test/appium/views/base_element.py
+++ b/test/appium/views/base_element.py
@@ -269,7 +269,7 @@ class BaseButton(BaseElement):
         self.driver.info('Tap on %s' % self.name)
         return self.navigate()
 
-    def click_until_presence_of_element(self, desired_element, attempts=3):
+    def click_until_presence_of_element(self, desired_element, attempts=4):
         counter = 0
         while not desired_element.is_element_present(1) and counter <= attempts:
             try:

--- a/test/appium/views/wallet_view.py
+++ b/test/appium/views/wallet_view.py
@@ -413,8 +413,7 @@ class WalletView(BaseView):
         counter = 0
         while True:
             if counter >= wait_time:
-                self.driver.info('Balance is not changed during %s seconds!' % wait_time)
-                return
+                self.driver.fail('Balance is not changed during %s seconds!' % wait_time)
             elif self.get_eth_value() != expected_balance:
                 counter += 10
                 time.sleep(10)


### PR DESCRIPTION
###  Summary

1. temporary workaround for issue 9269
2. added self.driver.fail in case when balance is not updated
3. added attempts to click_until_presence_of_element to prevent fails like https://ethstatus.testrail.net/index.php?/tests/view/937190


status: ready
