### PR TITLE
don't use SHA1s as status-go version

### DIFF
--- a/ci/utils.groovy
+++ b/ci/utils.groovy
@@ -31,10 +31,11 @@ def gitCommit() {
   return GIT_COMMIT.take(6)
 }
 
-def pkgFilename(type, ext, arch="universal") {
+def pkgFilename(type, ext, arch=null) {
+  /* the grep removes the null arch */
   return [
     "StatusIm", timestamp(), gitCommit(), type, arch,
-  ].join('-') + ".${ext}"
+  ].grep().join('-') + ".${ext}"
 }
 
 def doGitRebase() {

--- a/nix/status-go/default.nix
+++ b/nix/status-go/default.nix
@@ -12,8 +12,8 @@ let
   gomobile = callPackage ./gomobile { inherit (androidPkgs) platform-tools; inherit target-os xcodeWrapper utils buildGoPackage; };
   buildStatusGoDesktopLib = callPackage ./build-desktop-status-go.nix { inherit buildGoPackage go xcodeWrapper utils; };
   buildStatusGoMobileLib = callPackage ./build-mobile-status-go.nix { inherit buildGoPackage go gomobile xcodeWrapper utils; };
-  extractStatusGoConfig = callPackage ./extract-status-go-config.nix { inherit (stdenv) lib; };
   versionJSON = importJSON ../../status-go-version.json; # TODO: Simplify this path search with lib.locateDominatingFile
+  versionRegex = "^v?[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+(-[[:alnum:].]+)$";
   owner = versionJSON.owner;
   repo = versionJSON.repo;
   version = versionJSON.version;
@@ -58,8 +58,10 @@ let
   goBuildFlags = "-v";
   # status-go params to be set at build time, important for About section and metrics
   goBuildParams = {
-    Version = removePrefix "v" version; # Geth forces a 'v' prefix
     GitCommit = rev;
+    Version = if (builtins.match versionRegex version) != null
+      then removePrefix "v" version # Geth forces a 'v' prefix
+      else "develop"; # to reduce metrics cardinality in Prometheus
   };
   # These are necessary for status-go to show correct version
   paramsLdFlags = attrValues (mapAttrs (name: value:

--- a/scripts/update-status-go.sh
+++ b/scripts/update-status-go.sh
@@ -37,7 +37,9 @@ STATUS_GO_COMMIT_SHA1=$(git ls-remote ${repoUrl} U ${STATUS_GO_VERSION} | cut -f
 
 if [[ -z "${STATUS_GO_COMMIT_SHA1}" ]]; then
     echo "Could not find SHA1 for rev ${STATUS_GO_VERSION}, assuming it's a commit."
+    echo "WARNING: Setting 'version' value to 'develop'"
     STATUS_GO_COMMIT_SHA1="${STATUS_GO_VERSION}"
+    STATUS_GO_VERSION="develop" # to reduce metrics cardinality in Prometheus
 fi
 
 STATUS_GO_SHA256=$(nix-prefetch-url --unpack ${repoUrl}/archive/${STATUS_GO_VERSION}.zip)


### PR DESCRIPTION
In order to avoid metrics that will contain commit SHA1s I'm enforcing use of `develop` as version when a commit SHA is used. This will lower the metric cardinality in Prometheus.

I also added a fix for CI to avoid appending `-universal` to all builds. It makes sense only for Android.