### PR TITLE
drop overriding .env values with CI parameters

### DIFF
--- a/ci/utils.groovy
+++ b/ci/utils.groovy
@@ -144,17 +144,6 @@ def updateEnv(type) {
     envFile = "${env.WORKSPACE}/.env.${type}"
   }
   sh "ln -sf ${envFile} .env"
-  /* find a list of .env settings to check for them in params */
-  def envContents = readFile(envFile)
-  def envLines = envContents.split()
-  def envVars = envLines.collect { it.split('=').first() }
-  /* for each var available in params modify the .env file */
-  envVars.each { var ->
-    if (params.get(var)) { /* var exists in params and is not empty */
-      println("Changing setting: ${var}=${params.get(var)}")
-      sh "sed -i'.bkp' 's/${var}=.*/${var}=${params.get(var)}/' ${envFile}"
-    }
-  }
   /* show contents for debugging purposes */
   sh "cat ${envFile}"
 }


### PR DESCRIPTION
As we found out today one of our Android jobs in CI had a leftover `FLEET` parameter set with a default value of `eth.beta` which caused some confusion. Dropping overriding of `.env` values with CI parameters to avoid this in the future.