### PR TITLE
nix: Remove need to pass default values in `--arg config`

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,5 @@
 # target-os = [ 'windows' 'linux' 'macos' 'darwin' 'android' 'ios' 'all' ]
-{ config ? { android_sdk.accept_license = true; },
+{ config ? { },
   nixpkgs-bootstrap ? import ./nix/nixpkgs-bootstrap.nix { inherit config; },
   pkgs ? nixpkgs-bootstrap.pkgs,
   stdenv ? pkgs.stdenv,

--- a/nix/nixpkgs-bootstrap.nix
+++ b/nix/nixpkgs-bootstrap.nix
@@ -1,6 +1,8 @@
 # This file controls the pinned version of nixpkgs we use for our Nix environment
-{ config ? { android_sdk.accept_license = true; },
-  pkgs ? (import ((import <nixpkgs> { }).fetchFromGitHub {
+let
+  inherit (import <nixpkgs> { }) fetchFromGitHub;
+  defaultConfig = { android_sdk.accept_license = true; };
+  nixpkgsSrc = {
     name = "nixpkgs-source";
     owner = "status-im";
     repo = "nixpkgs";
@@ -9,8 +11,15 @@
     # To get the compressed Nix sha256, use:
     # nix-prefetch-url --unpack https://github.com/${ORG}/nixpkgs/archive/${REV}.tar.gz
     # The last line will be the hash.
-  })) { inherit config; } }:
+  };
 
-  {
-    inherit pkgs config;
-  }
+in {
+  config ? { },
+  config' ? defaultConfig // config,
+  pkgs ? (import (fetchFromGitHub nixpkgsSrc)) { config = config'; }
+}:
+
+{
+  inherit pkgs;
+  config = config';
+}

--- a/nix/shell.sh
+++ b/nix/shell.sh
@@ -52,7 +52,7 @@ if [[ "$TARGET_OS" =~ (linux|windows|darwin|macos) ]]; then
 fi
 
 if [ -n "${STATUS_GO_SRC_OVERRIDE}" ]; then
-  shellArgs+=("--arg config {android_sdk.accept_license=true;status_go.src_override=\"${STATUS_GO_SRC_OVERRIDE}\";}")
+  shellArgs+=("--arg config {status_go.src_override=\"${STATUS_GO_SRC_OVERRIDE}\";}")
 fi
 
 # if _NIX_ATTR is specified we shouldn't use shell.nix, the path will be different

--- a/scripts/release-android.sh
+++ b/scripts/release-android.sh
@@ -7,7 +7,7 @@ source "$_current_dir/lib/setup/path-support.sh"
 source_lib "platform.sh"
 
 nixOpts=(
-  "--arg config {android_sdk.accept_license=true;status_go.src_override=\"${STATUS_GO_SRC_OVERRIDE}\";}"
+  "--arg config {status_go.src_override=\"${STATUS_GO_SRC_OVERRIDE}\";}"
   "--arg env {BUILD_ENV=\"${BUILD_ENV}\";ANDROID_ABI_SPLIT=\"${ANDROID_ABI_SPLIT}\";ANDROID_ABI_INCLUDE=\"${ANDROID_ABI_INCLUDE}\";}"
   "--argstr build-type ${BUILD_TYPE}"
   "--argstr build-number ${BUILD_NUMBER}"

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,4 @@
-{ config ? { android_sdk.accept_license = true; },
+{ config ? { },
   nixpkgs-bootstrap ? import ./nix/nixpkgs-bootstrap.nix { inherit config; },
   pkgs ? nixpkgs-bootstrap.pkgs,
   target-os ? "none" }:


### PR DESCRIPTION
This PR refactors the Nix bootstrapping so that invokations don't need to pass default `config` fields (such as `android_sdk.accept_license = true;`), but can still override them if needed.