### PR TITLE
nix: Use mkFilter in local status-go source

### DIFF
--- a/fastlane/Gemfile
+++ b/fastlane/Gemfile
@@ -2,10 +2,6 @@ source 'https://rubygems.org'
 
 gem 'fastlane', '>= 2.131.0'
 
-plugins_path = ENV['FASTLANE_PLUGINFILE_PATH']
-
-if plugins_path == nil
-    plugins_path = File.join(__dir__, 'Pluginfile')
-end
-
+plugins_path = ENV['FASTLANE_PLUGINFILE_PATH'] ||
+               File.join(__dir__, 'Pluginfile')
 eval_gemfile(plugins_path) if plugins_path

--- a/nix/derivation.nix
+++ b/nix/derivation.nix
@@ -22,7 +22,7 @@ let
   buildGoPackage = pkgs.buildGoPackage.override { inherit go; };
   desktop = pkgs.callPackage ./desktop { inherit target-os stdenv status-go pkgs go nodejs; inherit (pkgs) darwin; };
   mobile = pkgs.callPackage ./mobile { inherit target-os config stdenv pkgs mkShell nodejs yarn status-go maven localMavenRepoBuilder mkFilter; inherit (pkgs.xcodeenv) composeXcodeWrapper; };
-  status-go = pkgs.callPackage ./status-go { inherit target-os config go buildGoPackage; inherit (mobile.ios) xcodeWrapper; androidPkgs = mobile.android.androidComposition; };
+  status-go = pkgs.callPackage ./status-go { inherit target-os config go buildGoPackage mkFilter; inherit (mobile.ios) xcodeWrapper; androidPkgs = mobile.android.androidComposition; };
   # mkFilter is a function that allows filtering a directory structure (used for filtering source files being captured in a closure)
   mkFilter = import ./tools/mkFilter.nix { inherit (stdenv) lib; };
   localMavenRepoBuilder =


### PR DESCRIPTION
This PR improves the filtering of status-go Nix closure so that it doesn't capture folders such as `.ethereumtest`, `protocol` or `eth-node`.

status: ready <!-- Can be ready or wip -->