### PR TITLE
Allow slashes in status-go branch names

### DIFF
--- a/nix/status-go/build-mobile-status-go.nix
+++ b/nix/status-go/build-mobile-status-go.nix
@@ -2,7 +2,7 @@
 { stdenv, utils, callPackage,
   buildGoPackage, go, gomobile, openjdk, xcodeWrapper }:
 
-{ owner, repo, rev, version, goPackagePath, src, host,
+{ owner, repo, rev, version, sanitizedVersion, goPackagePath, src, host,
 
   # mobile-only arguments
   goBuildFlags, goBuildLdFlags,

--- a/nix/status-go/build-status-go.nix
+++ b/nix/status-go/build-status-go.nix
@@ -1,6 +1,6 @@
 { buildGoPackage, go, xcodeWrapper, stdenv, utils }:
 
-{ owner, repo, rev, version, goPackagePath, src, host,
+{ owner, repo, rev, version, sanitizedVersion, goPackagePath, src, host,
   nativeBuildInputs ? [],
   buildPhase, buildMessage,
   installPhase ? "",
@@ -19,7 +19,7 @@ let
   args = removeAttrs args' [ "buildMessage" ]; # Remove our arguments from args before passing them on to buildGoPackage
   buildStatusGo = buildGoPackage (args // {
     pname = repo;
-    version = "${version}-${strings.substring 0 7 rev}-${host}";
+    version = "${sanitizedVersion}-${strings.substring 0 7 rev}-${host}";
 
     nativeBuildInputs =
       nativeBuildInputs ++
@@ -58,7 +58,7 @@ let
       return # make sure we stop fixup so as to not allow the host preFixup script to proceed
     '';
 
-    passthru = { inherit owner version rev; };
+    passthru = { inherit owner repo version rev; };
 
     meta = {
       # Add default meta information


### PR DESCRIPTION
This PR renames the version used in the Nix path so that it doesn't contain forward slashes.