### PR TITLE
narrow match with UID, print persistent matching processes

### DIFF
--- a/nix/mobile/ios/install-pods-and-status-go.sh
+++ b/nix/mobile/ios/install-pods-and-status-go.sh
@@ -24,7 +24,7 @@ else
   fi
   if [ "$(uname)" == 'Darwin' ]; then
     # CocoaPods are trash and can't handle other pod instances running at the same time
-    $STATUS_REACT_HOME/scripts/wait-for.sh 240 -f 'pod'
+    $STATUS_REACT_HOME/scripts/wait-for.sh 240 'pod install'
     pushd $STATUS_REACT_HOME/ios && pod install; popd
   fi
 fi

--- a/scripts/wait-for.sh
+++ b/scripts/wait-for.sh
@@ -4,25 +4,30 @@ set -e
 
 TIMEOUT=${1}
 shift
-PGREP_OPTS=${@}
+PGREP_FILTER=${@}
 SLEEP_SEC=5
 STEPS=$((TIMEOUT / SLEEP_SEC))
+# use UID to restrict search
+PGREP_OPTS="-U ${UID} -f"
 
 if [[ -z ${PGREP_OPTS} ]]; then
     echo "No pgrep options name specified!" >&2
     exit 1
 fi
 
-echo "Checking for process: '${PGREP_OPTS}'"
+echo "Checking for process: '${PGREP_FILTER}'"
 for ((i = 0; i < ${STEPS}; i += 1)); do
-    if pgrep ${PGREP_OPTS} > /dev/null; then
+    if pgrep ${PGREP_OPTS} "${PGREP_FILTER}" > /dev/null; then
         echo "Process found. Sleeping ${SLEEP_SEC}..." >&2
         sleep ${SLEEP_SEC}
     else
-        echo "Process '${PGREP_OPTS}' gone." >&2
+        echo "Process '${PGREP_FILTER}' gone." >&2
         exit 0
     fi
 done
 
 echo "Timeout reached! (${TIMEOUT}s) Process still up: ${PGREP_OPTS}" >&2
+echo "Following processes matched:"
+# show what is still up
+ps u $(pgrep -l ${PGREP_OPTS} "${PGREP_FILTER}" | cut -d' ' -f1 | xargs -I{} echo -n "-p {} ")
 exit 1


### PR DESCRIPTION
Small improvement to the `scripts/wait-for.sh` which we use to avoid running two instanced of `pod`.

The issue is sometimes it times out but we don't know because of which process, this:

* Makes second argument to `scripts/wait-for.sh` only the filter
* Narrows down the search by using the `-U` flag and user `UID`
* Prints the matching processes if the timeout is reached for debugging