### PR TITLE
Upgrade Xcode to 11.2.1

### DIFF
--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -1,5 +1,5 @@
 pipeline {
-  agent { label 'macos-xcode-11.1' }
+  agent { label 'macos-xcode-11.2.1' }
 
   parameters {
     string(

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -1,5 +1,5 @@
 pipeline {
-  agent { label 'macos-xcode-11.1' }
+  agent { label 'macos-xcode-11.2.1' }
 
   parameters {
     string(

--- a/nix/mobile/default.nix
+++ b/nix/mobile/default.nix
@@ -6,7 +6,7 @@ let
 
   platform = callPackage ../platform.nix { inherit target-os; };
   xcodewrapperArgs = {
-    version = "11.1";
+    version = "11.2.1";
   };
   xcodeWrapper = composeXcodeWrapper xcodewrapperArgs;
   androidPlatform = callPackage ./android { inherit config target-os mkShell mkFilter nodejs maven localMavenRepoBuilder projectNodePackage jsbundle; status-go = status-go.android; };

--- a/nix/mobile/default.nix
+++ b/nix/mobile/default.nix
@@ -10,7 +10,7 @@ let
   };
   xcodeWrapper = composeXcodeWrapper xcodewrapperArgs;
   androidPlatform = callPackage ./android { inherit config target-os mkShell mkFilter nodejs maven localMavenRepoBuilder projectNodePackage jsbundle; status-go = status-go.android; };
-  iosPlatform = callPackage ./ios { inherit config mkFilter mkShell xcodeWrapper projectNodePackage; status-go = status-go.ios; };
+  iosPlatform = callPackage ./ios { inherit config mkFilter mkShell xcodeWrapper projectNodePackage fastlane; status-go = status-go.ios; };
   fastlane = callPackage ./fastlane { inherit stdenv target-os mkShell; };
   selectedSources = [
       fastlane

--- a/nix/mobile/fastlane/default.nix
+++ b/nix/mobile/fastlane/default.nix
@@ -27,6 +27,7 @@ let
 in {
   # We only include bundler in regular shell if targetting iOS, because that's how the CI builds the whole project
   buildInputs = unique (optionals platform.targetIOS bundlerDeps);
+  drv = fastlane;
   inherit shellHook;
 
   # TARGETS

--- a/nix/mobile/ios/default.nix
+++ b/nix/mobile/ios/default.nix
@@ -1,4 +1,4 @@
-{ config, stdenv, stdenvNoCC, callPackage, mkShell,
+{ config, stdenv, stdenvNoCC, callPackage, mkShell, fastlane, cocoapods,
   xcodeWrapper, mkFilter, fetchurl, flock, nodejs, bash, zlib, procps,
   status-go, projectNodePackage }:
 
@@ -27,23 +27,19 @@ let
         };
     };
 
-  selectedSources = [ status-go ];
-
-  # TARGETS
-  shell = mkShell {
-    buildInputs = [ xcodeWrapper ];
-  };
-
-in {
-  inherit xcodeWrapper;
+  selectedSources = [ fastlane status-go ];
 
   buildInputs = unique ([
+    cocoapods
+    fastlane.drv
     xcodeWrapper
     flock # used in reset-node_modules.sh
     procps
   ] ++ catAttrs "buildInputs" selectedSources);
+
   shellHook = ''
     ${status-go.shellHook}
+    ${fastlane.shellHook}
 
     ${createMobileFilesSymlinks "$STATUS_REACT_HOME"}
 
@@ -52,6 +48,11 @@ in {
     exit
   '';
 
+in {
+  inherit xcodeWrapper shellHook buildInputs;
+
   # TARGETS
-  inherit shell;
+  shell = mkShell {
+    inherit buildInputs shellHook;
+  };
 }


### PR DESCRIPTION
One of the CI hosts - `macos-03` - has been upgraded to OSX 10.15.1 and Xcode to `11.2.1`.

To accommodate this upgrade this PR updates the host labels used by CI jobs, and also adds `fastlane` binary to the Nix shell for building the iOS app.

Once this is merged I will upgrade the other two MacOS hosts to Xcode `11.2.1`.