### PR TITLE
Added junitxml report back

### DIFF
--- a/test/appium/pytest.ini
+++ b/test/appium/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
 norecursedirs = .git views
-addopts = -s -v --tb=line
+addopts = -s -v --tb=line --junitxml=result.xml


### PR DESCRIPTION
It was removed in https://github.com/status-im/status-react/commit/b16c224fd5602330e76db0952cdeb7a08e8f0ba4#diff-d847c682a6cd2f8c4d1f9eddd37f9481 (probably accidentally), but required in 
https://github.com/status-im/status-react/blob/develop/ci/tests/Jenkinsfile.e2e-nightly in success stage at least.
