### PR TITLE
fix failure due to superfluous slashes in path

### DIFF
--- a/nix/tools/mkFilter.nix
+++ b/nix/tools/mkFilter.nix
@@ -24,11 +24,13 @@ let
     root }:
     let
       allPathRootsAllowed = (length dirRootsToInclude) == 0;
+      # this removes superfluous slashes from the path
+      cleanRoot = "${toString (/. + root)}/";
     in
       path: type:
       let
         baseName = baseNameOf (toString path);
-        subpath = elemAt (splitString "${toString root}/" path) 1;
+        subpath = elemAt (splitString cleanRoot path) 1;
         spdir = elemAt (splitString "/" subpath) 0;
 
       in lib.cleanSourceFilter path type && (


### PR DESCRIPTION
Small fix for issue found by @flexsurfer when he did:
```
make run-ios STATUS_GO_SRC_OVERRIDE=/Users/Andrey/go//src/github.com/status-im/status-go
npx react-native run-ios
Configuring default Nix shell for target 'ios'...
trace: Using local status-go sources from /Users/Andrey/go//src/github.com/status-im/status-go

error: while evaluating the attribute 'buildInputs' of the derivation 'status-react-shell' at /Users/andrey/Status/status-react/shell.nix:24:3:
while evaluating the attribute 'src' of the derivation 'status-go-develop-unknown-ios' at /nix/store/id4y2z7gvdb17nhmalqaf4ib11x34nfm-nixpkgs-source/pkgs/stdenv/generic/make-derivation.nix:191:11:
while evaluating the attribute 'src' at /Users/andrey/Status/status-react/nix/status-go/default.nix:27:9:
while evaluating anonymous function at /Users/andrey/Status/status-react/nix/tools/mkFilter.nix:28:13, called from undefined position:
while evaluating 'splitString' at /nix/store/id4y2z7gvdb17nhmalqaf4ib11x34nfm-nixpkgs-source/lib/strings.nix:382:23, called from /Users/andrey/Status/status-react/nix/tools/mkFilter.nix:32:25:
while evaluating 'recurse' at /nix/store/id4y2z7gvdb17nhmalqaf4ib11x34nfm-nixpkgs-source/lib/strings.nix:392:24, called from /nix/store/id4y2z7gvdb17nhmalqaf4ib11x34nfm-nixpkgs-source/lib/strings.nix:403:7:
while evaluating 'addContextFrom' at /nix/store/id4y2z7gvdb17nhmalqaf4ib11x34nfm-nixpkgs-source/lib/strings.nix:369:23, called from /nix/store/id4y2z7gvdb17nhmalqaf4ib11x34nfm-nixpkgs-source/lib/strings.nix:385:11:
list index 1 is out of bounds, at /Users/andrey/Status/status-react/nix/tools/mkFilter.nix:31:19
make: *** [run-ios] Error 1
```
This was caused by the double slash in the path.

The `/. + path` construction is a special syntax for fixing paths in Nix.
See section about `builtins.toPath` in Nix manual:
https://nixos.org/nix/manual/#ssec-builtins

REPL example:
```
nix-repl> "${toString (/. + "/home//user////go")}/"
"/home/sochan/go/"
```