### PR TITLE
Watch-only accounts test and additional waiting when signing transaction

### DIFF
--- a/test/appium/tests/atomic/account_management/test_profile.py
+++ b/test/appium/tests/atomic/account_management/test_profile.py
@@ -140,7 +140,7 @@ class TestProfileSingleDevice(SingleDeviceTestCase):
             self.errors.append("Can't share public key")
         for _ in range(2):
             profile_view.click_system_back_button()
-        profile_view.close_share_chat_key_popup()
+        profile_view.close_share_popup()
         wallet = profile_view.wallet_button.click()
         wallet.set_up_wallet()
         wallet.accounts_status_account.click()
@@ -162,7 +162,7 @@ class TestProfileSingleDevice(SingleDeviceTestCase):
         public_key = profile_view.public_key_text.text
         profile_view.public_key_text.long_press_element()
         profile_view.copy_text()
-        profile_view.close_share_chat_key_popup()
+        profile_view.close_share_popup()
         home = profile_view.home_button.click()
         chat = home.add_contact(transaction_senders['M']['public_key'])
         chat.chat_message_input.click()

--- a/test/appium/tests/atomic/transactions/test_daaps_transactions.py
+++ b/test/appium/tests/atomic/transactions/test_daaps_transactions.py
@@ -1,4 +1,3 @@
-import pytest
 
 from tests import marks, unique_password, common_password
 from tests.base_test_case import SingleDeviceTestCase

--- a/test/appium/tests/atomic/transactions/test_wallet.py
+++ b/test/appium/tests/atomic/transactions/test_wallet.py
@@ -548,7 +548,7 @@ class TestTransactionWalletSingleDevice(SingleDeviceTestCase):
         wallet_view = sign_in_view.wallet_button.click()
         wallet_view.set_up_wallet()
         status_account_address = wallet_view.get_wallet_address()
-        wallet_view.account_options_button.click()
+        wallet_view.get_account_options_by_name().click()
 
         wallet_view.just_fyi('open Account Settings screen and check that all elements are shown')
         wallet_view.account_settings_button.click()

--- a/test/appium/views/base_view.py
+++ b/test/appium/views/base_view.py
@@ -584,7 +584,7 @@ class BaseView(object):
         sign_in_view = self.get_sign_in_view()
         sign_in_view.sign_in(password)
 
-    def close_share_chat_key_popup(self):
+    def close_share_popup(self):
         TouchAction(self.driver).tap(None, 255, 104, 1).perform()
 
     def get_public_key(self):
@@ -592,7 +592,7 @@ class BaseView(object):
         profile_view.share_my_profile_button.click()
         profile_view.public_key_text.wait_for_visibility_of_element()
         public_key = profile_view.public_key_text.text
-        self.close_share_chat_key_popup()
+        self.close_share_popup()
         return public_key
 
     def share_via_messenger(self):

--- a/test/appium/views/send_transaction_view.py
+++ b/test/appium/views/send_transaction_view.py
@@ -254,7 +254,8 @@ class SendTransactionView(BaseView):
     def sign_transaction(self, sender_password: str = common_password):
         self.sign_with_password.click_until_presence_of_element(self.enter_password_input)
         self.enter_password_input.send_keys(sender_password)
-        self.sign_button.click_until_presence_of_element(self.ok_button)
+        self.sign_button.click_until_absense_of_element(self.sign_button)
+        self.ok_button.wait_for_element(120)
         self.ok_button.click()
 
     def get_transaction_fee_total(self):

--- a/test/appium/views/wallet_view.py
+++ b/test/appium/views/wallet_view.py
@@ -273,6 +273,20 @@ class AddAnAccountButton(BaseButton):
         super(AddAnAccountButton, self).__init__(driver)
         self.locator = self.Locator.text_selector('Add an account')
 
+class AddAWatchOnlyAddressButton(BaseButton):
+    def __init__(self, driver):
+        super(AddAWatchOnlyAddressButton, self).__init__(driver)
+        self.locator = self.Locator.text_selector('Add a watch-only address')
+
+class EnterAddressInput(BaseEditBox):
+    def __init__(self, driver):
+        super(EnterAddressInput, self).__init__(driver)
+        self.locator = self.Locator.text_selector('Enter address')
+
+class DeleteAccountButton(BaseButton):
+    def __init__(self, driver):
+        super(DeleteAccountButton, self).__init__(driver)
+        self.locator = self.Locator.text_selector('Delete account')
 
 class GenerateNewAccountButton(BaseButton):
     def __init__(self, driver):
@@ -367,6 +381,9 @@ class WalletView(BaseView):
         self.set_currency_button = SetCurrencyButton(self.driver)
         self.add_account_button = AddAccountButton(self.driver)
         self.add_an_account_button = AddAnAccountButton(self.driver)
+        self.add_watch_only_address_button = AddAWatchOnlyAddressButton(self.driver)
+        self.enter_address_input = EnterAddressInput(self.driver)
+        self.delete_account_button = DeleteAccountButton(self.driver)
         self.generate_new_account_button = GenerateNewAccountButton(self.driver)
         self.enter_your_password_input = EnterYourPasswordInput(self.driver)
         self.generate_account_button = GenerateAccountButton(self.driver)
@@ -377,12 +394,13 @@ class WalletView(BaseView):
         # individual account settings
         self.account_settings_button = AccountSettingsButton(self.driver)
         self.apply_settings_button = ApplySettingsButton(self.driver)
-        self.account_options_button = AccountOptionsButton(self.driver, account_name='Status account')
 
     def get_usd_total_value(self):
         import re
         return float(re.sub('[~,]', '', self.usd_total_value.text))
 
+    def get_account_options_by_name(self, account_name='Status account'):
+        return AccountOptionsButton(self.driver, account_name)
 
 
     def get_asset_amount_by_name(self, asset: str):


### PR DESCRIPTION
1) added tests for adding and deleting watch-only account
2) changed waiting in sign_transaction in send_transaction_view.py - 2 mins should be enough for sure