### PR TITLE
fix edge case where PR e2e builds are not rebased

### DIFF
--- a/ci/android.groovy
+++ b/ci/android.groovy
@@ -71,7 +71,7 @@ def extractArchFromAPK(name) {
   if (matches.size() > 0) {
     return matches[0][1]
   }
-  if (utils.getBuildType() == 'e2e') {
+  if (utils.isE2EBuild()) {
     return 'x86'
   }
   /* non-release builds make universal APKs */

--- a/ci/common.groovy
+++ b/ci/common.groovy
@@ -70,7 +70,7 @@ def uploadArtifact(path) {
   def domain = 'ams3.digitaloceanspaces.com'
   def bucket = 'status-im'
   /* There's so many PR builds we need a separate bucket */
-  if (utils.getBuildType() == 'pr') {
+  if (utils.isPRBuild()) {
     bucket = 'status-im-prs'
   }
   /* WARNING: s3cmd can't guess APK MIME content-type */

--- a/ci/ghcmgr.groovy
+++ b/ci/ghcmgr.groovy
@@ -19,7 +19,7 @@ def buildObj(success) {
     id: env.BUILD_DISPLAY_NAME,
     commit: GIT_COMMIT.take(8),
     success: success != null ? success : true,
-    platform: env.TARGET + (utils.getBuildType() == 'e2e' ? '-e2e' : ''),
+    platform: env.TARGET + (utils.isE2EBuild() ? '-e2e' : ''),
     duration: utils.buildDuration(),
     url: currentBuild.absoluteUrl,
     pkg_url: pkg_url,

--- a/ci/github.groovy
+++ b/ci/github.groovy
@@ -60,7 +60,7 @@ def notifyPRFailure() {
 def notifyPRSuccess() {
   def d = ":small_blue_diamond:"
   def msg = "#### :heavy_check_mark: "
-  def type = ghcmgr.utils.getBuildType() == 'e2e' ? ' e2e' : ''
+  def type = ghcmgr.utils.isE2EBuild() ? ' e2e' : ''
   msg += "[${env.JOB_NAME}${currentBuild.displayName}](${currentBuild.absoluteUrl}) ${d} "
   msg += "${ghcmgr.utils.buildDuration()} ${d} ${GIT_COMMIT.take(8)} ${d} "
   msg += "[:package: ${env.TARGET}${type} package](${env.PKG_URL})"

--- a/ci/utils.groovy
+++ b/ci/utils.groovy
@@ -31,7 +31,7 @@ def pkgFilename(type, ext, arch=null) {
 }
 
 def doGitRebase() {
-  if (getBuildType() != 'pr') {
+  if (!isPRBuild()) {
     println 'Skipping rebase due for non-PR build...'
     return
   }
@@ -93,12 +93,20 @@ def pkgFind(glob) {
   return found[0].path
 }
 
+def isPRBuild() {
+  return env.JOB_NAME.startsWith('status-react/prs')
+}
+
+def isE2EBuild() {
+  return env.JOB_NAME.contains('e2e')
+}
+
 def getBuildType() {
   def jobName = env.JOB_NAME
-  if (jobName.contains('e2e')) {
+  if (isE2EBuild()) {
       return 'e2e'
   }
-  if (jobName.startsWith('status-react/prs')) {
+  if (isPRBuild()) {
       return 'pr'
   }
   if (jobName.startsWith('status-react/nightly')) {


### PR DESCRIPTION
An issue was found in #9568 where `e2e` build had older translations due to lack of rebase.

This lack of rebase happens because we rebase only PR builds:
https://github.com/status-im/status-react/blob/ee52ceffa3d42ea8cbeb518d3d47bbf44f796f81/ci/utils.groovy#L33-L37
BUT `e2e` builds don't show up as `pr` builds in that if:
https://github.com/status-im/status-react/blob/ee52ceffa3d42ea8cbeb518d3d47bbf44f796f81/ci/utils.groovy#L96-L103
Because `e2e` type has precedence over `pr`.