### PR TITLE
upgrade XCode to 11.3.1

### DIFF
--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -1,5 +1,5 @@
 pipeline {
-  agent { label 'macos-xcode-11.2.1' }
+  agent { label 'macos-xcode-11.3.1' }
 
   parameters {
     string(

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -1,5 +1,5 @@
 pipeline {
-  agent { label 'macos-xcode-11.2.1' }
+  agent { label 'macos-xcode-11.3.1' }
 
   parameters {
     string(

--- a/nix/mobile/default.nix
+++ b/nix/mobile/default.nix
@@ -5,7 +5,7 @@ let
   inherit (lib) catAttrs concatStrings optional unique;
 
   xcodewrapperArgs = {
-    version = "11.2.1";
+    version = "11.3.1";
   };
   xcodeWrapper = composeXcodeWrapper xcodewrapperArgs;
   fastlane = callPackage ./fastlane { };


### PR DESCRIPTION
The `macos-03` host has already been upgraded to XCode 11.3 in https://github.com/status-im/infra-ci/issues/14.

Before this is merged I'll upgrade another host, probably `macos-02`, and leave `macos-01` for a bit.