### PR TITLE
nix: bump stalled-download-timeout to 10 minutes

### DIFF
--- a/nix/README.md
+++ b/nix/README.md
@@ -94,3 +94,10 @@ export NIX_IGNORE_SYMLINK_STORE=1
 Add it to your `.bashrc` or any other shell config file.
 
 __NOTE__: Your old `/nix` directory will end up in `/Users/Shared/Relocated Items/Security/nix` after OS upgrade.
+
+### Cache Downloads Timing Out
+
+If copying from Nix Cache times out you can adjust the timeout by changing [`nix/nix.conf`](/nix/nix.conf):
+```conf
+stalled-download-timeout = 9001
+```

--- a/nix/nix.conf
+++ b/nix/nix.conf
@@ -1,5 +1,7 @@
 # NOTE: If you are in Asia you might want to add https://nix-cache-cn.status.im/ to substituters
 substituters = https://nix-cache.status.im/ https://cache.nixos.org/
 trusted-public-keys = nix-cache.status.im-1:x/93lOfLU+duPplwMSBR+OlY4+mo+dCN7n0mr4oPwgY= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= nix-cache-cn.status.im:WUiOoTQQurm+rEL/yuAuU/a3TViDtMM9DCMgMx/KkOw= 
+# Some downloads are multiple GB, default is 5 minutes
+stalled-download-timeout = 600
 connect-timeout = 10
 max-jobs = auto


### PR DESCRIPTION
@siphiuel had some issues with Nix cache download timing out:

```
copying path '/nix/store/qwmjkll2i1agmaq8xm4p0c99ngf3z0h1-ndk-bundle-21.0.5935234' from 'https://nix-cache.status.im'...
```

Which makes sense since it's pretty big:

```
admin@master-01.do-ams3.ci.misc:~ % du -hs /nix/store/qwmjkll2i1agmaq8xm4p0c99ngf3z0h1-ndk-bundle-21.0.5935234
3.4G /nix/store/qwmjkll2i1agmaq8xm4p0c99ngf3z0h1-ndk-bundle-21.0.5935234
```

This should double the time before a cache download times out.

