### PR TITLE
Fix play store upload

### DIFF
--- a/ci/android.groovy
+++ b/ci/android.groovy
@@ -109,7 +109,8 @@ def uploadToPlayStore(type = 'nightly') {
     nix.shell(
       "fastlane android ${type}",
       keep: ['FASTLANE_DISABLE_COLORS', 'APK_PATHS', 'GOOGLE_PLAY_JSON_KEY'],
-      attr: 'shells.fastlane'
+      attr: 'shells.fastlane',
+      pure: false
     )
   }
 }

--- a/scripts/setup
+++ b/scripts/setup
@@ -35,7 +35,7 @@ $GIT_ROOT/scripts/inotify_fix.sh
 setup_header "Installing requirements..."
 
 if [ "$IN_NIX_SHELL" != 'pure' ] && ! is_nixos && ! program_exists nix; then
-  required_version="2.3.1"
+  required_version="2.3.2"
   NIX_INSTALLER_NO_MODIFY_PROFILE=1 NIX_IGNORE_SYMLINK_STORE=1 bash <(curl https://nixos.org/releases/nix/nix-${required_version}/install) --no-daemon
   if [ $? -eq 0 ]; then
     echo -e "${YELLOW}**********************************************************************************************************"


### PR DESCRIPTION
Use of `--pure` for Play Store upload cause this error:
```
SSL_connect returned=1 errno=0 state=error: certificate verify failed (unable to get local issuer certificate)
```