### PR TITLE
disable waiting for iOS build processing on upload

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -212,7 +212,8 @@ platform :ios do
       }
     )
     upload_to_testflight(
-      ipa: 'status_appstore/StatusIm.ipa'
+      ipa: 'status_appstore/StatusIm.ipa',
+      skip_waiting_for_build_processing: true
     )
   end
 


### PR DESCRIPTION
Waiting for `release` build to get uploaded to TestFlight takes far too long and makes builds time out:

```
21:25:19 [20:25:07]: Waiting for the build to show up in the build list - this may take a few minutes (check your email for processing issues if this continues)
21:25:38 [20:25:38]: Waiting for the build to show up in the build list - this may take a few minutes (check your email for processing issues if this continues)
21:26:11 [20:26:08]: Waiting for the build to show up in the build list - this may take a few minutes (check your email for processing issues if this continues)
```

https://ci.status.im/job/status-react/job/combined/job/mobile-ios/7411/console

So I'm setting `skip_waiting_for_build_processing` to `true`:
>If set to true, the distribute_external option won't work and no build will be distributed to testers. (You might want to use this option if you are using this action on CI and have to pay for 'minutes used' on your CI plan). If set to true and a changelog is provided, it will partially wait for the build to appear on AppStore Connect so the changelog can be set, and skip the remaining processing steps
https://docs.fastlane.tools/actions/upload_to_testflight/

