### PR TITLE
ci: fix GitHub release by using glob for all files

### DIFF
--- a/ci/ghcmgr.groovy
+++ b/ci/ghcmgr.groovy
@@ -11,7 +11,7 @@ utils = load 'ci/utils.groovy'
 def buildObj(success) {
   def pkg_url = env.PKG_URL
   /* a bare ipa file is not installable on iOS */
-  if (env.TARGET == 'ios') {
+  if (env.TARGET == 'ios' && env.DIAWI_URL != "") {
     pkg_url = env.DIAWI_URL 
   }
   /* assemble build object valid for ghcmgr */

--- a/ci/github.groovy
+++ b/ci/github.groovy
@@ -181,15 +181,16 @@ def publishRelease(Map args) {
   }
 }
 
-def publishReleaseMobile() {
+def publishReleaseMobile(path='pkg') {
+  def found = findFiles(glob: "${path}/*")
+  if (found.size() == 0) {
+    sh "ls ${path}"
+    error("No file to  release in ${path}")
+  }
   publishRelease(
-    version: ghcmgr.utils.getVersion()+'-mobile',
+    version: ghcmgr.utils.getVersion(),
     pkgDir: 'pkg',
-    files: [ /* upload only mobile release files */
-      ghcmgr.utils.pkgFilename(btype, 'ipa'),
-      ghcmgr.utils.pkgFilename(btype, 'apk'),
-      ghcmgr.utils.pkgFilename(btype, 'sha256'),
-    ]
+    files: found.collect { it.path },
   )
 }
 

--- a/ci/github.groovy
+++ b/ci/github.groovy
@@ -185,7 +185,7 @@ def publishReleaseMobile(path='pkg') {
   def found = findFiles(glob: "${path}/*")
   if (found.size() == 0) {
     sh "ls ${path}"
-    error("No file to  release in ${path}")
+    error("No file to release in ${path}")
   }
   publishRelease(
     version: ghcmgr.utils.getVersion(),

--- a/ci/ios.groovy
+++ b/ci/ios.groovy
@@ -63,6 +63,7 @@ def uploadToDiawi() {
   withCredentials([
     string(credentialsId: 'diawi-token', variable: 'DIAWI_TOKEN'),
   ]) {
+    /* This can silently fail with 'File is not processed.' */
     nix.shell(
       'bundle exec --gemfile=fastlane/Gemfile fastlane ios upload_diawi',
       keep: ['FASTLANE_DISABLE_COLORS', 'DIAWI_TOKEN'],


### PR DESCRIPTION
This should be much simpler than specifying filenames by using `pkgFilename()` generator.

This was done because we wanted to release just mobile versions on GitHub, but now we don't even build them so that's not necessary.

Also, adjusted `ghcmgr` POST to use `ipa` file if Diawi link is not available.