### PR TITLE
ci: fix GitHub upload by not changing dir when uploading

### DIFF
--- a/ci/github.groovy
+++ b/ci/github.groovy
@@ -131,17 +131,15 @@ def releaseDelete(Map args) {
 }
 
 def releaseUpload(Map args) {
-  dir(args.pkgDir) {
-    args.files.each {
-      sh """
-        github-release upload \
-          -u '${args.user}' \
-          -r '${args.repo}' \
-          -t '${args.version}' \
-          -n ${it} \
-          -f ${it}
-      """
-    }
+  args.files.each {
+    sh """
+      github-release upload \
+        -u '${args.user}' \
+        -r '${args.repo}' \
+        -t '${args.version}' \
+        -n ${it} \
+        -f ${it}
+    """
   }
 }
 
@@ -163,7 +161,6 @@ def publishRelease(Map args) {
     draft: true,
     user: 'status-im',
     repo: 'status-react',
-    pkgDir: args.pkgDir,
     files: args.files,
     version: args.version,
     branch: ghcmgr.utils.branchName(),
@@ -189,7 +186,6 @@ def publishReleaseMobile(path='pkg') {
   }
   publishRelease(
     version: ghcmgr.utils.getVersion(),
-    pkgDir: 'pkg',
     files: found.collect { it.path },
   )
 }


### PR DESCRIPTION
We got:
```
Error: open pkg/StatusIm-200121-092750-39b3aa-release-arm64-v8a.apk: no such file or directory
```
Because
```
10:44:24  Running in /var/jenkins_home/workspace/atus-react_release_release_1.0.x/pkg
```
Because I didn't drop the `dir()` call in #9859.