### PR TITLE
fastlane: debug failed Diawi uploads

### DIFF
--- a/ci/ios.groovy
+++ b/ci/ios.groovy
@@ -65,7 +65,7 @@ def uploadToDiawi() {
   ]) {
     /* This can silently fail with 'File is not processed.' */
     nix.shell(
-      'bundle exec --gemfile=fastlane/Gemfile fastlane ios upload_diawi',
+      'bundle exec --verbose --gemfile=fastlane/Gemfile fastlane ios upload_diawi',
       keep: ['FASTLANE_DISABLE_COLORS', 'DIAWI_TOKEN'],
       attr: 'shells.fastlane'
     )

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -150,7 +150,8 @@ end
 def upload_to_diawi(source)
   diawi(
     file: source,
-    last_hope_attempts_count: 3,
+    last_hope_attempts_count: 5,
+    last_hope_attempts_backoff: 5,
     token: ENV['DIAWI_TOKEN']
   )
   # save the URL to a file for use in CI

--- a/fastlane/Gemfile.lock
+++ b/fastlane/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/status-im/fastlane-plugin-diawi
+  revision: 5a4394e311c59672608f0d72530134d08a1b0670
+  branch: v1.3.1
+  specs:
+    fastlane-plugin-diawi (1.3.0)
+      rest-client (>= 2.0.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -27,7 +35,7 @@ GEM
     faraday_middleware (0.13.1)
       faraday (>= 0.7.4, < 1.0)
     fastimage (2.1.7)
-    fastlane (2.139.0)
+    fastlane (2.140.0)
       CFPropertyList (>= 2.3, < 4.0.0)
       addressable (>= 2.3, < 3.0.0)
       babosa (>= 1.0.2, < 2.0.0)
@@ -65,8 +73,6 @@ GEM
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3)
     fastlane-plugin-clean_testflight_testers (0.3.0)
-    fastlane-plugin-diawi (1.3.0)
-      rest-client (>= 2.0.0)
     gh_inspector (1.1.3)
     google-api-client (0.36.4)
       addressable (~> 2.5, >= 2.5.1)
@@ -76,10 +82,12 @@ GEM
       representable (~> 3.0)
       retriable (>= 2.0, < 4.0)
       signet (~> 0.12)
-    google-cloud-core (1.4.1)
+    google-cloud-core (1.5.0)
       google-cloud-env (~> 1.0)
+      google-cloud-errors (~> 1.0)
     google-cloud-env (1.3.0)
       faraday (~> 0.11)
+    google-cloud-errors (1.0.0)
     google-cloud-storage (1.25.1)
       addressable (~> 2.5)
       digest-crc (~> 0.4)
@@ -149,7 +157,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.6)
-    unicode-display_width (1.6.0)
+    unicode-display_width (1.6.1)
     word_wrap (1.0.0)
     xcodeproj (1.14.0)
       CFPropertyList (>= 2.3.3, < 4.0)
@@ -168,7 +176,7 @@ PLATFORMS
 DEPENDENCIES
   fastlane (>= 2.131.0)
   fastlane-plugin-clean_testflight_testers
-  fastlane-plugin-diawi
+  fastlane-plugin-diawi!
 
 BUNDLED WITH
    1.17.3

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -3,4 +3,4 @@
 # Ensure this file is checked in to source control!
 
 gem 'fastlane-plugin-clean_testflight_testers'
-gem 'fastlane-plugin-diawi'
+gem 'fastlane-plugin-diawi', git: 'https://github.com/status-im/fastlane-plugin-diawi', branch: 'v1.3.1'

--- a/fastlane/gemset.nix
+++ b/fastlane/gemset.nix
@@ -201,10 +201,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "10chm11gr9ykh89yzxs016j96xib42hbpp3pw1al89rvrcjjh5dc";
+      sha256 = "1lz3kq21zy2pcrmq5r65x5im21f51nxyh9zmkcyafvsaqib8y775";
       type = "gem";
     };
-    version = "2.139.0";
+    version = "2.140.0";
   };
   fastlane-plugin-clean_testflight_testers = {
     groups = ["default"];
@@ -221,9 +221,11 @@
     groups = ["default"];
     platforms = [];
     source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "01zaq5ykpn8j04pfyd4p3p0dnlil3cbbzcw5hayc70dpak09cr6x";
-      type = "gem";
+      fetchSubmodules = false;
+      rev = "5a4394e311c59672608f0d72530134d08a1b0670";
+      sha256 = "0ls2wqaigk8dwjs8v4sbxih3r4wbjwyhq2hnlhbyh1kv4q05x9sh";
+      type = "git";
+      url = "https://github.com/status-im/fastlane-plugin-diawi";
     };
     version = "1.3.0";
   };
@@ -249,15 +251,15 @@
     version = "0.36.4";
   };
   google-cloud-core = {
-    dependencies = ["google-cloud-env"];
+    dependencies = ["google-cloud-env" "google-cloud-errors"];
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1kw0ql11avvjbrlhclli5ffls12ch4q2bgb30gvg5nxy0wfpj5j8";
+      sha256 = "1qjn7vs8f85vxi1nkikbjfja6bv9snrj26vzscjii0cm8n4dy0i1";
       type = "gem";
     };
-    version = "1.4.1";
+    version = "1.5.0";
   };
   google-cloud-env = {
     dependencies = ["faraday"];
@@ -269,6 +271,16 @@
       type = "gem";
     };
     version = "1.3.0";
+  };
+  google-cloud-errors = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0nl08lhgjvz3g7nsarn9nnsck0k3dg8mwg4awcnklnzpvs62b4ih";
+      type = "gem";
+    };
+    version = "1.0.0";
   };
   google-cloud-storage = {
     dependencies = ["addressable" "digest-crc" "google-api-client" "google-cloud-core" "googleauth" "mini_mime"];
@@ -676,10 +688,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "08kfiniak1pvg3gn5k6snpigzvhvhyg7slmm0s2qx5zkj62c1z2w";
+      sha256 = "1pppclzq4qb26g321553nm9xqca3zgllvpwb2kqxsdadwj51s09x";
       type = "gem";
     };
-    version = "1.6.0";
+    version = "1.6.1";
   };
   word_wrap = {
     groups = ["default"];


### PR DESCRIPTION
We've been having more and more failed Diawi uploads:
```
[10:16:00]: Start uploading file to diawi. Please, be patient. This could take some time.
[10:16:04]: Processing file...
[10:16:06]: Processing file...
[10:16:08]: Processing file...
[10:16:10]: Processing file...
[10:16:12]: Processing file...
[10:16:14]: File is not processed.
[10:16:14]: Try to upload file by yourself: StatusIm-200121-100440-39b3aa-release.ipa
```
~~In order to debug this I'm enabling `callback_emails` for [`fastlane-plugin-diawi`](https://github.com/pacification/fastlane-plugin-diawi) and adding the `--verbose` flag to Fastlane call in hope that we can get a reason for these issues.~~

Changes:
* Use our fork of [fastlane-plugin-diawi](https://github.com/status-im/fastlane-plugin-diawi/tree/add-timeout-option)
* Use the newly added `last_hope_attempts_backoff` to 5 seconds
* Set the `last_hope_attempts_count` to 5