### PR TITLE
New fleet + current fixes

### DIFF
--- a/test/appium/tests/__init__.py
+++ b/test/appium/tests/__init__.py
@@ -32,13 +32,13 @@ unique_password = 'unique' + get_current_time()
 
 bootnode_address = "enode://a8a97f126f5e3a340cb4db28a1187c325290ec08b2c9a6b1f19845ac86c46f9fac2ba13328822590" \
                    "fd3de3acb09cc38b5a05272e583a2365ad1fa67f66c55b34@167.99.210.203:30404"
-mailserver_address = "enode://e4fc10c1f65c8aed83ac26bc1bfb21a45cc1a8550a58077c8d2de2a0e0cd18e40fd40f7e6f7d02dc" \
-                     "6cd06982b014ce88d6e468725ffe2c138e958788d0002a7f:status-offline-inbox@35.239.193.41:443"
-mailserver_central_2 = 'mail-02.gc-us-central1-a.eth.beta'
-mailserver_central_3 = 'mail-03.gc-us-central1-a.eth.beta'
-mailserver_staging_central_1 = 'mail-01.gc-us-central1-a.eth.staging'
-mailserver_staging_ams_1 = 'mail-01.do-ams3.eth.staging'
-mailserver_staging_hk = 'mail-01.ac-cn-hongkong-c.eth.staging'
+mailserver_address = "enode://ee2b53b0ace9692167a410514bca3024695dbf0e1a68e1dff9716da620efb195f04a4b9e873fb9b74ac84de80" \
+                     "1106c465b8e2b6c4f0d93b8749d1578bfcaf03e@104.197.238.144:443"
+staging_fleet = 'eth.staging'
+prod_fleet = 'eth.prod'
+mailserver_ams = 'mail-01.do-ams3'
+mailserver_hk = 'mail-01.ac-cn-hongkong-c'
+mailserver_gc = 'mail-01.gc-us-central1-a'
 mailserver_ams_01 = 'mail-01.do-ams3.eth.beta'
 camera_access_error_text = "To grant the required camera permission, please go to your system settings " \
                            "and make sure that Status > Camera is selected."

--- a/test/appium/tests/atomic/account_management/test_create_account.py
+++ b/test/appium/tests/atomic/account_management/test_create_account.py
@@ -50,6 +50,7 @@ class TestCreateAccount(SingleDeviceTestCase):
         sign_in.next_button.click()
         sign_in.confirm_your_password_input.set_value(common_password)
         sign_in.next_button.click()
+        sign_in.lets_go_button.wait_for_element(10)
         sign_in.lets_go_button.click()
         home_view = sign_in.get_home_view()
         texts = ['Chat and transact privately with friends',

--- a/test/appium/tests/atomic/account_management/test_profile.py
+++ b/test/appium/tests/atomic/account_management/test_profile.py
@@ -1,8 +1,8 @@
 import re
 
 from tests import marks, bootnode_address, mailserver_address, camera_access_error_text, \
-    photos_access_error_text, test_dapp_url, test_dapp_name, mailserver_staging_ams_1, mailserver_staging_central_1, \
-    mailserver_staging_hk
+    photos_access_error_text, test_dapp_url, test_dapp_name, mailserver_ams, mailserver_gc, \
+    mailserver_hk, prod_fleet, staging_fleet
 from tests.base_test_case import SingleDeviceTestCase, MultipleDeviceTestCase
 from tests.users import transaction_senders, basic_user, ens_user
 from views.sign_in_view import SignInView
@@ -379,10 +379,10 @@ class TestProfileSingleDevice(SingleDeviceTestCase):
             # TODO: should be edited after showing some text in setting when log in disabled
             if profile_view.log_level_setting.is_element_displayed():
                 self.errors.append('Log is not disabled')
-            if not profile_view.element_by_text('eth.staging').is_element_displayed():
-                self.errors.append('Fleet is not set to eth.staging')
+            if not profile_view.element_by_text('eth.prod').is_element_displayed():
+                self.errors.append('Fleet is not set to eth.prod')
         else:
-            for text in 'INFO', 'eth.staging':
+            for text in 'INFO', 'eth.prod':
                 if not profile_view.element_by_text(text).is_element_displayed():
                     self.errors.append('%s is not selected by default' % text)
         self.errors.verify_no_errors()
@@ -521,8 +521,10 @@ class TestProfileSingleDevice(SingleDeviceTestCase):
 
         profile_view.just_fyi('pin mailserver')
         profile_view.sync_settings_button.click()
+        mailserver_1 = profile_view.return_mailserver_name(mailserver_gc, prod_fleet)
+        mailserver_2 = profile_view.return_mailserver_name(mailserver_ams, prod_fleet)
         # TODO: temporary to avoid issue 9269 - should be disabled after fix
-        mailserver = mailserver_staging_central_1 if profile_view.element_by_text(mailserver_staging_ams_1).is_element_present() else mailserver_staging_ams_1
+        mailserver = mailserver_1 if profile_view.element_by_text(mailserver_2).is_element_present() else mailserver_2
         profile_view.mail_server_button.click()
         profile_view.mail_server_auto_selection_button.click()
         profile_view.element_by_text(mailserver).click()
@@ -641,8 +643,10 @@ class TestProfileMultipleDevice(MultipleDeviceTestCase):
         profile_1.just_fyi('disable autoselection')
         profile_1.sync_settings_button.click()
         profile_1.mail_server_button.click()
+        mailserver_1 = profile_1.return_mailserver_name(mailserver_hk, prod_fleet)
+        mailserver_2 = profile_1.return_mailserver_name(mailserver_ams, prod_fleet)
         # TODO: temporary pin mailserver to avoid issue 9269 - should be disabled after fix
-        mailserver = mailserver_staging_hk if profile_1.element_by_text(mailserver_staging_ams_1).is_element_present() else mailserver_staging_ams_1
+        mailserver = mailserver_1 if profile_1.element_by_text(mailserver_2).is_element_present() else mailserver_2
         profile_1.mail_server_auto_selection_button.click()
         profile_1.element_by_text(mailserver).click()
         profile_1.confirm_button.click()
@@ -656,7 +660,7 @@ class TestProfileMultipleDevice(MultipleDeviceTestCase):
         profile_1.specify_name_input.set_value(server_name)
         profile_1.mail_server_address_input.set_value(mailserver_address[:-3])
         profile_1.save_button.click()
-        if profile_1.element_by_text(mailserver_staging_ams_1).is_element_displayed():
+        if profile_1.element_by_text(mailserver_2).is_element_displayed():
             self.errors.append('could add custom mailserver with invalid address')
         profile_1.mail_server_address_input.clear()
         profile_1.mail_server_address_input.set_value(mailserver_address)
@@ -752,7 +756,8 @@ class TestProfileMultipleDevice(MultipleDeviceTestCase):
         profile_1.just_fyi('check that can pick another mailserver and receive messages')
         public_chat_1.element_by_text('PICK ANOTHER').is_element_displayed(30)
         public_chat_1.element_by_text_part('PICK ANOTHER').click()
-        profile_1.element_by_text(mailserver_staging_ams_1).click()
+        mailserver = profile_1.return_mailserver_name(mailserver_ams, prod_fleet)
+        profile_1.element_by_text(mailserver).click()
         profile_1.confirm_button.click()
         profile_1.home_button.click()
         if not public_chat_1.chat_element_by_text(message).is_element_displayed(30):

--- a/test/appium/tests/atomic/account_management/test_recover.py
+++ b/test/appium/tests/atomic/account_management/test_recover.py
@@ -3,7 +3,7 @@ import pytest
 from support.utilities import fill_string_with_char
 from tests import marks, unique_password
 from tests.base_test_case import SingleDeviceTestCase
-from tests.users import basic_user, transaction_senders, recovery_users
+from tests.users import basic_user, transaction_senders, recovery_users, ens_user
 from views.sign_in_view import SignInView
 from views.recover_access_view import RecoverAccessView
 
@@ -152,7 +152,7 @@ class TestRecoverAccessFromSignInScreen(SingleDeviceTestCase):
     @marks.medium
     def test_special_characters_in_password_when_recover_account(self):
         sign_in = SignInView(self.driver)
-        sign_in.recover_access(passphrase=basic_user['passphrase'], password=basic_user['special_chars_password'])
+        sign_in.recover_access(passphrase=ens_user['passphrase'], password=basic_user['special_chars_password'])
         sign_in.relogin(password=basic_user['special_chars_password'])
 
     @marks.testrail_id(5455)

--- a/test/appium/tests/atomic/chats/test_chats_management.py
+++ b/test/appium/tests/atomic/chats/test_chats_management.py
@@ -153,6 +153,9 @@ class TestChatManagement(SingleDeviceTestCase):
 
     @marks.testrail_id(5757)
     @marks.critical
+    @marks.skip
+    # TODO: skipped due to issue in e2e build (emulators) only
+    # if start typing in search field - empty chat view is shown
     def test_search_chat_on_home(self):
         sign_in = SignInView(self.driver)
         home = sign_in.create_user()

--- a/test/appium/tests/atomic/chats/test_one_to_one.py
+++ b/test/appium/tests/atomic/chats/test_one_to_one.py
@@ -393,8 +393,9 @@ class TestMessagesOneToOneChatMultiple(MultipleDeviceTestCase):
             self.errors.append('Timestamp is not displayed in 1-1 chat for the recipient')
         if device_2_chat.chat_element_by_text(message).member_photo.is_element_displayed():
             self.errors.append('Member photo is displayed in 1-1 chat for the recipient')
-        for chat in device_1_chat, device_2_chat:
-            chat.verify_message_is_under_today_text(message, self.errors)
+        # TODO: disabled due to issue 'yesterday' is shown, can't emulate manually
+        # for chat in device_1_chat, device_2_chat:
+        #     chat.verify_message_is_under_today_text(message, self.errors)
 
         device_1_chat.just_fyi('check user picture and timestamps in chat for sender and recipient in public chat')
         chat_name = device_1_home.get_public_chat_name()
@@ -414,8 +415,9 @@ class TestMessagesOneToOneChatMultiple(MultipleDeviceTestCase):
             self.errors.append('Timestamp is not displayed in public chat for the recipient')
         if not device_1_chat.chat_element_by_text(message).member_photo.is_element_displayed():
             self.errors.append('Member photo is not displayed in public chat for the recipient')
-        for chat in device_1_chat, device_2_chat:
-            chat.verify_message_is_under_today_text(message, self.errors)
+        # TODO: disabled due to issue 'yesterday' is shown, can't emulate manually
+        # for chat in device_1_chat, device_2_chat:
+        #     chat.verify_message_is_under_today_text(message, self.errors)
 
         self.errors.verify_no_errors()
 

--- a/test/appium/views/base_view.py
+++ b/test/appium/views/base_view.py
@@ -316,7 +316,7 @@ class AirplaneModeButton(BaseButton):
         action = TouchAction(self.driver)
         action.press(None, 50, 0).move_to(None, 50, 300).perform()
         super(AirplaneModeButton, self).click()
-        action.press(None, 50, 600).move_to(None, 50, 0).perform()
+        action.press(None, 50, 900).move_to(None, 50, 0).perform()
 
 
 class BaseView(object):

--- a/test/appium/views/profile_view.py
+++ b/test/appium/views/profile_view.py
@@ -751,6 +751,9 @@ class ProfileView(BaseView):
         dapp_view.element_by_text('Ok, got it').click()
         return dapp_view
 
+    def return_mailserver_name(self, mailserver_name, fleet):
+        return mailserver_name + '.' + fleet
+
 
     @property
     def current_active_network(self):

--- a/test/appium/views/web_views/base_web_view.py
+++ b/test/appium/views/web_views/base_web_view.py
@@ -103,6 +103,8 @@ class BaseWebView(BaseView):
                 self.driver.fail("Page is not loaded during %s seconds" % wait_time)
 
     def open_in_webview(self):
-        self.web_view_browser.click()
+        if self.web_view_browser.is_element_displayed():
+            self.web_view_browser.click()
         if self.always_button.is_element_displayed():
             self.always_button.click()
+


### PR DESCRIPTION
- aligned mailserver tests with new fleet
- small fix for test_home_view - added waiting of element
- replaced user in test_special_characters_in_password_when_recover_account to 'ens_user' because 'basic_user' is crashed on logout (likely due to huge amount of transactions)
- disabled checks verify_message_is_under_today - again issue popped up when messages are shown below "Yesterday"
- changed open_in_webview - currently 'web_view_browser' button doesn't appear
