### PR TITLE
Add back missing `arm` status-go target

### DIFF
--- a/nix/status-go/default.nix
+++ b/nix/status-go/default.nix
@@ -70,6 +70,12 @@ let
           gomobileTarget = "${name}/arm64";
           outputFileName = "status-go-${srcData.shortRev}-arm64.aar";
         };
+        arm = {
+          linkNimbus = enableNimbus;
+          nimbus = assert enableNimbus; nimbus.wrappers-android.arm;
+          gomobileTarget = "${name}/arm";
+          outputFileName = "status-go-${srcData.shortRev}-arm.aar";
+        };
         x86 = {
           linkNimbus = enableNimbus;
           nimbus = assert enableNimbus; nimbus.wrappers-android.x86;


### PR DESCRIPTION
This PR fixes a bug introduced in the Nimbus PR due to the fact that we now explicitly generate each target platform instead of allowing gomobile to generate all of them. `arm` was missing as a target platform for Android.

Fixes https://github.com/status-im/status-react/issues/9879