### PR TITLE
ci: use full timestamp for iOS CFBundleVersion

### DIFF
--- a/ci/android.groovy
+++ b/ci/android.groovy
@@ -6,6 +6,8 @@ def bundle() {
   def btype = utils.getBuildType()
   /* Disable Gradle Daemon https://stackoverflow.com/questions/38710327/jenkins-builds-fail-using-the-gradle-daemon */
   def gradleOpt = "-PbuildUrl='${currentBuild.absoluteUrl}' --console plain "
+  /* Can't take more digits than unsigned int */
+  def buildNumber = utils.readBuildNumber().substring(0, 10)
   /* we don't need x86 for any builds except e2e */
   env.ANDROID_ABI_INCLUDE="armeabi-v7a;arm64-v8a"
   env.ANDROID_ABI_SPLIT="false"
@@ -40,7 +42,7 @@ def bundle() {
         'status-im.ci': '1',
         'status-im.build-type': btype,
         'status-im.status-react.gradle-opts': gradleOpt,
-        'status-im.status-react.build-number': utils.readBuildNumber(),
+        'status-im.status-react.build-number': buildNumber,
       ],
       safeEnv: [
         'STATUS_RELEASE_KEY_ALIAS',

--- a/ci/utils.groovy
+++ b/ci/utils.groovy
@@ -62,7 +62,7 @@ def readBuildNumber() {
   def number = sh(
     returnStdout: true,
     script: "${env.WORKSPACE}/scripts/version/build_no.sh"
-  ).trim().toInteger()
+  ).trim()
   return number
 }
 

--- a/scripts/version/gen_build_no.sh
+++ b/scripts/version/gen_build_no.sh
@@ -23,5 +23,5 @@ else
     # Format: Year(4 digit) + Month + Day + Hour
     # Example: 2018120118
     # We limited precision to hours to avoid of mismatched numbers.
-    date '+%Y%m%d%H' | tee "${BUILD_NUMBER_FILE}"
+    date '+%Y%m%d%H%M%S' | tee "${BUILD_NUMBER_FILE}"
 fi


### PR DESCRIPTION
And we have to trim the one used for Android.
For more details see:
>Warning: The greatest value Google Play allows for versionCode is 2100000000.
https://developer.android.com/studio/publish/versioning