### PR TITLE
fastlane: disable oldest_build_allowed for TestFlight clean

### DIFF
--- a/ci/Jenkinsfile.fastlane.clean
+++ b/ci/Jenkinsfile.fastlane.clean
@@ -29,7 +29,7 @@ pipeline {
         nix = load('ci/nix.groovy')
         nix.shell(
           'bundle install --gemfile=fastlane/Gemfile',
-          attr: 'shells.fastlane'
+          attr: 'shells.fastlane',
         )
       } }
     }
@@ -44,7 +44,7 @@ pipeline {
         ]) {
           nix.shell(
             'bundle exec --gemfile=fastlane/Gemfile fastlane ios clean',
-            keep: ['FASTLANE_APPLE_ID', 'FASTLANE_PASSWORD']
+            keep: ['FASTLANE_APPLE_ID', 'FASTLANE_PASSWORD'],
             attr: 'shells.fastlane',
           )
         }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -222,9 +222,9 @@ platform :ios do
   lane :clean do
     clean_testflight_testers(
       username: ENV['FASTLANE_APPLE_ID'],
-      days_of_inactivity: 30,
-      oldest_build_allowed: 2_019_032_709
+      days_of_inactivity: 30
     )
+    # In the future we can try using 'oldest_build_allowed'
   end
 
   desc '`fastlane ios upload-diawi` - upload .ipa to diawi'


### PR DESCRIPTION
We've been seeing [the CI job](https://ci.status.im/job/status-tools/job/clean-testflight-users/) removing active users daily:
```
[02:04:15]: Fetching all TestFlight testers, this might take a few minutes, depending on the number of testers
[02:04:24]: Removing tester sergii@status.im due to inactivity from app ID 1178893006...
[02:04:25]: Removing tester ericmastro@status.im due to inactivity from app ID 1178893006...
[02:04:25]: Removing tester andrey@status.im due to inactivity from app ID 1178893006...
[02:04:27]: Removing tester dean.eigenmann@gmail.com due to inactivity from app ID 1178893006...
```
My suspicion is that it was caused by the value of `oldest_build_allowed` so I've removed it and for now replace it with `dry-run: true`. I've re-enabled the job on this branch, we'll see how it behaves in a few days.

State: Ready