### PR TITLE
re-enable site updates on nightly builds

### DIFF
--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -69,14 +69,13 @@ pipeline {
         switch (btype) {
           /* legacy naming, should have named it nightly.json */
           case 'nightly': cmn.updateBucketJSON(urls, 'latest.json'); break
-          case 'release': cmn.updateBucketJSON(urls, 'release.json'); break
         }
       } }
     }
     stage('Publish') {
       steps { script {
         switch (btype) {
-          //case 'nightly': build('misc/status.im'); break
+          case 'nightly': build('misc/status.im', wait: false); break
           case 'release': gh.publishReleaseMobile(); break
         }
       } }


### PR DESCRIPTION
Since we are re-enabling nightly build updates in https://github.com/status-im/status.im/pull/458 we should also trigger site rebuilds on successful nightly builds.

This also adds `wait: false` so builds don't fail if there's issue with building the page.