### PR TITLE
jenkins: build() doesn't like mixed arguments

### DIFF
--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -75,7 +75,7 @@ pipeline {
     stage('Publish') {
       steps { script {
         switch (btype) {
-          case 'nightly': build('misc/status.im', wait: false); break
+          case 'nightly': build(job: 'misc/status.im', wait: false); break
           case 'release': gh.publishReleaseMobile(); break
         }
       } }


### PR DESCRIPTION
The nightly builds are failing in `Publish` step due to change from #9994:
```
java.lang.IllegalArgumentException: Expected named arguments but got [{wait=false}, misc/status.im]
```
I guess it can't handle mixing positional and named arguments.