### PR TITLE
e2e: fix handling of GitHub token

### DIFF
--- a/ci/tests/Jenkinsfile.e2e-prs
+++ b/ci/tests/Jenkinsfile.e2e-prs
@@ -61,9 +61,10 @@ pipeline {
         }
 
         withCredentials([
-          string(
+          usernamePassword(
             credentialsId: 'status-im-auto-token',
-            variable: 'GIT_HUB_TOKEN'
+            usernameVariable: 'GIT_HUB_USER', /* ignored */
+            passwordVariable: 'GIT_HUB_TOKEN'
           ),
           usernamePassword(
             credentialsId:  'test-rail-api',


### PR DESCRIPTION
Fix for end-to-end test errors:
```
ERROR: Credentials 'status-im-auto-token' is of type 'Username with password' where 'org.jenkinsci.plugins.plaincredentials.StringCredentials' was expected
```
https://ci.status.im/job/end-to-end-tests/job/status-app-prs/437/console