### PR TITLE
don't use Jenkins master host for combined jobs

### DIFF
--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -1,5 +1,5 @@
 pipeline {
-  agent { label 'master' }
+  agent { label 'linux' }
 
   options {
     timestamps()


### PR DESCRIPTION
This lowers the risk of someone extracting sensitive data from master.

Once this is merged I will set the allowed limit of jobs on `master` host to `0`.