### PR TITLE
don't use sandbox for Nix Cache builds

### DIFF
--- a/ci/Jenkinsfile.nix-cache
+++ b/ci/Jenkinsfile.nix-cache
@@ -46,6 +46,7 @@ pipeline {
         platforms.each { os ->
           nix.build(
             attr: "targets.status-go.${os}.buildInputs",
+            sandbox: false,
             link: false
           )
         }
@@ -57,6 +58,7 @@ pipeline {
          * (e.g. maven and node repos) */
         nix.build(
           attr: 'targets.mobile.android.jsbundle',
+          sandbox: false,
           pure: false,
           link: false
         )
@@ -67,6 +69,7 @@ pipeline {
         /* build/fetch things required to build jsbundle and android */
         nix.build(
           attr: 'targets.mobile.android.buildInputs',
+          sandbox: false,
           pure: false,
           link: false
         )
@@ -77,6 +80,7 @@ pipeline {
         /* build/fetch things required to instantiate shell.nix for TARGET=all */
         nix.build(
           attr: 'shells.default.buildInputs',
+          sandbox: false,
           link: false
         )
       } }


### PR DESCRIPTION
Fix for failing Nix Cache builds due to `sandbox: true` being the default:
```
sandbox-exec: execvp() of '/nix/store/mg4y1vjgvz508n4qrhcilz52j0iil1f2-bash-4.4-p23/bin/bash'
  failed: Operation not permitted
```
https://ci.status.im/job/status-react/job/nix-cache/job/macos/690/console