### PR TITLE
disable playstore upload

### DIFF
--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -108,8 +108,6 @@ pipeline {
               }
               /* build type specific */
               switch (btype) {
-                case 'release':
-                  android.uploadToPlayStore(); break;
                 case 'nightly':
                   env.DIAWI_URL = android.uploadToDiawi(); break;
                 case 'e2e':


### PR DESCRIPTION
Disabled playstore uploads because the API key has been deleted and no longer works.