### PR TITLE
fix bundle install by disabling Nix sandbox

### DIFF
--- a/ci/common.groovy
+++ b/ci/common.groovy
@@ -54,7 +54,9 @@ def prep(type = 'nightly') {
     /* install ruby dependencies */
     nix.shell(
       'bundle install --gemfile=fastlane/Gemfile --quiet',
-      attr: 'shells.fastlane')
+      attr: 'shells.fastlane',
+      sandbox: false
+    )
   }
 
   if (['macos', 'linux', 'windows'].contains(env.TARGET)) {
@@ -62,7 +64,11 @@ def prep(type = 'nightly') {
     nix.shell('scripts/prepare-for-desktop-platform.sh', pure: false)
   }
   /* run script in the nix shell so that node_modules gets instantiated before attempting the copies */
-  nix.shell('scripts/copy-translations.sh chmod', attr: "shells.${env.TARGET}")
+  nix.shell(
+    'scripts/copy-translations.sh chmod',
+    attr: "shells.${env.TARGET}",
+    sandbox: false
+  )
 }
 
 def uploadArtifact(path) {


### PR DESCRIPTION
This fixes the following error:
```log
sandbox-exec: execvp() of '/nix/store/mg4y1vjgvz508n4qrhcilz52j0iil1f2-bash-4.4-p23/bin/bash' failed: Operation not permitted
```
When running:
https://github.com/status-im/status-react/blob/9b1150df2947e491ffd5dcd477ed14d457762ef8/ci/common.groovy#L55-L56
or
https://github.com/status-im/status-react/blob/9b1150df2947e491ffd5dcd477ed14d457762ef8/ci/common.groovy#L65