### PR TITLE
avoid building jsbundle twice, drop jsbundle stage

### DIFF
--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -73,13 +73,6 @@ pipeline {
           }
         } }
         stage('Build') { stages {
-          stage('JSBundle') {
-            steps {
-              script {
-                nix.shell('make jsbundle-android', pure: false)
-              }
-            }
-          }
           stage('Bundle') {
             steps {
               script { apks = android.bundle() }


### PR DESCRIPTION
Because we run `nix/scripts/clean.sh` after building `JSBundle` it is
removed from Nix store and can't be reused in the `Bundle` stage.

This should lower the wait time for Android builds.