### PR TITLE
ci: re-add Play Store upload case for release

### DIFF
--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -100,6 +100,8 @@ pipeline {
               }
               /* build type specific */
               switch (btype) {
+                case 'release':
+                  android.uploadToPlayStore(); break;
                 case 'nightly':
                   env.DIAWI_URL = android.uploadToDiawi(); break;
                 case 'e2e':


### PR DESCRIPTION
We disabled it in #10130 because API account was disabled, but it was restored by Jarrad.