### PR TITLE
use the proper source of publish method

### DIFF
--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -75,7 +75,7 @@ pipeline {
       steps { script {
         switch (btype) {
           case 'nightly': build(job: 'misc/status.im', wait: false); break
-          case 'release': gh.publishReleaseMobile(); break
+          case 'release': github.publishReleaseMobile(); break
         }
       } }
     }


### PR DESCRIPTION
Small fix for GitHub release. Using wrong var name, `gh` instead of `github`.