### PR TITLE
fix missing asset images

### DIFF
--- a/nix/mobile/android/jsbundle/default.nix
+++ b/nix/mobile/android/jsbundle/default.nix
@@ -30,11 +30,11 @@ in stdenv.mkDerivation {
             "status-modules/resources/.*"
             "build.clj" "externs.js"
             "project.clj" "prepare-modules.js"
-            "resources/js/.*"
-            "resources/config/.*"
+            # lein jsbundle stat's images to check if they exist
+            "resources/.*"
           ];
           exclude = [
-            "resources/images/.*"
+            "resources/fonts/.*"
           ];
           root = path;
         };

--- a/nix/mobile/android/targets/release-android.nix
+++ b/nix/mobile/android/targets/release-android.nix
@@ -46,7 +46,7 @@ in stdenv.mkDerivation {
         mkFilter {
           root = path;
           include = [
-            "mobile/js_files.*" "resources.*"
+            "mobile/js_files.*" "resources/.*"
             "modules/react-native-status/android.*"
             envFileName "VERSION" ".watchmanconfig"
             "status-go-version.json" "react-native.config.js"


### PR DESCRIPTION
Fixes: #10276

There were two bugs. The first one was not includeing `resources/images` in the `jsbundle` derivation. It requires it because it uses `stat` call to verify they exist during build. If it can't find them then the build succeeds but later when we run Gradle the images are not included.

The second bug was the syntax for this regex:
https://github.com/status-im/status-react/blob/e7a213fe95f24c18cffd6d13d08db6aa81b3a6b1/nix/mobile/android/targets/release-android.nix#L49
It should be `resources/.*`, otherwise the tokenizing logic doesn't work here:
https://github.com/status-im/status-react/blob/91431ca0c1bc4f001b0a452b5f329602a3e56c4c/nix/tools/mkFilter.nix#L25-L31
This bug was introduced by f75cb145880c8707dc117557af62ed8fea4652a4.