### PR TITLE
nix: fix status-go source override

### DIFF
--- a/nix/scripts/clean.sh
+++ b/nix/scripts/clean.sh
@@ -89,7 +89,7 @@ if [[ -n "${nixResultPath}" ]]; then
     toDelete=$(findByResult "${nixResultPath}")
 else 
     # use regular expression that should match all status-react build artifacts
-    toDelete=$(findByRegex '.*-status-react-(shell|source|build|patched-npm-gradle-modules).*')
+    toDelete=$(findByRegex '.*-status-(react|go)-(shell|source|build|patched-npm-gradle-modules).*')
 fi
 
 # remove duplicates and return

--- a/nix/status-go/default.nix
+++ b/nix/status-go/default.nix
@@ -32,10 +32,13 @@ let
             filter =
               # Keep this filter as restrictive as possible in order to avoid unnecessary rebuilds and limit closure size
               mkFilter {
-                dirRootsToInclude = [];
-                dirsToExclude = [ ".git" ".svn" "CVS" ".hg" ".vscode" ".dependabot" ".github" ".ethereumtest" "build" ];
-                filesToInclude = [ "Makefile" "go.mod" "go.sum" "VERSION" ];
                 root = path;
+                include = [ ".*" ];
+                exclude = [
+                  ".*/[.]git.*" ".*[.]md" ".*[.]yml"
+                  ".*/.*_test.go$" "_assets/.*" "build/.*"
+                  ".*/.*LICENSE.*" ".*/CONTRIB.*" ".*/AUTHOR.*"
+                ];
               };
           };
     } else


### PR DESCRIPTION
Fixes custom source for `status-go` provided via `STATUS_GO_SRC_OVERRIDE` env variable.

I did not update the arguments when working on `mkFilter` function in: #10246

Status: __Ready__