### PR TITLE
fix Gradle permission errors during build

### DIFF
--- a/nix/mobile/android/targets/release-android.nix
+++ b/nix/mobile/android/targets/release-android.nix
@@ -120,6 +120,9 @@ in stdenv.mkDerivation {
     ${androidEnvShellHook}
     ${concatStrings (catAttrs "shellHook" [ mavenAndNpmDeps.shell status-go.shell ])}
 
+    # fix permissions so gradle can create directories
+    chmod -R +w $sourceRoot/android
+
     pushd $sourceRoot/android
     ${adhocEnvVars} ./gradlew -PversionCode=${assert build-number != ""; build-number} assemble${capitalizedBuildType} || exit
     popd > /dev/null


### PR DESCRIPTION
This is a fix for the failure of local builds due to:
```
Could not create service of type ScriptPluginFactory using BuildScopeServices.createScriptPluginFactory().
Could not create service of type FileHasher using BuildSessionScopeServices.createFileSnapshotter().
```
By adding `--stracktrace` to `gradle` in Nix you can see the actual error:
```
Caused by: org.gradle.api.UncheckedIOException:
  Failed to create parent directory '/build/project/android/.gradle/5.6.4'
  when creating directory '/build/project/android/.gradle/5.6.4/fileHashes'
```
Which is caused by lack of write permissions on `.gradle` folder in the build diretory.