### PR TITLE
upgrade Xcode to 11.4.1

### DIFF
--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -1,7 +1,7 @@
 library 'status-react-jenkins@master'
 
 pipeline {
-  agent { label 'macos-xcode-11.4' }
+  agent { label 'macos-xcode-11.4.1' }
 
   parameters {
     string(

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -1,7 +1,7 @@
 library 'status-react-jenkins@master'
 
 pipeline {
-  agent { label 'macos-xcode-11.4' }
+  agent { label 'macos-xcode-11.4.1' }
 
   parameters {
     string(

--- a/nix/mobile/default.nix
+++ b/nix/mobile/default.nix
@@ -5,7 +5,7 @@ let
   inherit (lib) catAttrs concatStrings optional unique;
 
   xcodewrapperArgs = {
-    version = "11.4";
+    version = "11.4.1";
   };
   xcodeWrapper = composeXcodeWrapper xcodewrapperArgs;
   fastlane = callPackage ./fastlane { };


### PR DESCRIPTION
Because of-fucking-course `11.4.1` came out [LITERALLY HOURS](https://developer.apple.com/documentation/xcode_release_notes/xcode_11_4_1_release_notes) after I upgraded to `11.4`...