### PR TITLE
Upgrade e2e

### DIFF
--- a/ci/tests/Jenkinsfile.e2e-upgrade
+++ b/ci/tests/Jenkinsfile.e2e-upgrade
@@ -5,12 +5,16 @@ pipeline {
   parameters {
     string(
       name: 'NETWORK',
-      description: 'Name of test network to use.',
+      description: 'Name of test network to use',
       defaultValue: 'ropsten',
     )
     string(
       name: 'APK_NAME',
-      description: 'Filename of APK uploaded to SauceLabs.',
+      description: 'Filename of APK uploaded to SauceLabs (base for upgrade, usually release build)',
+    )
+     string(
+      name: 'APK_NAME_UPGRADE',
+      description: 'Filename of APK of upgraded application (installed on top of base)',
     )
   }
 
@@ -47,12 +51,12 @@ pipeline {
         ]) {
           dir('test/appium/tests') {
             sh """
-              python3 -m pytest -m testrail_id \
-                -m "not upgrade" \
+              python3 -m pytest -m upgrade \
                 -n24 --rerun_count=2 \
                 --testrail_report=True \
                 --network=${params.NETWORK} \
-                --apk=${params.APK_NAME}
+                --apk=${params.APK_NAME} \
+                --apk_upgrade=${params.APK_NAME_UPGRADE}
             """
           }
         }

--- a/test/appium/tests/atomic/test_upgrade.py
+++ b/test/appium/tests/atomic/test_upgrade.py
@@ -1,33 +1,25 @@
-import pytest
-from tests import marks, pytest_config_global
+from tests import marks
 from tests.base_test_case import SingleDeviceTestCase
 from views.sign_in_view import SignInView
 
-
+@marks.all
+@marks.upgrade
 class TestUpgradeApplication(SingleDeviceTestCase):
 
-    def setup_method(self, method, **kwargs):
-        super(TestUpgradeApplication, self).setup_method(method, app='sauce-storage:app-release.apk')
-        self.apk_name = ([i for i in [i for i in pytest_config_global['apk'].split('/') if '.apk' in i]])[0]
-
-    @marks.testrail_id(5713)
-    @marks.upgrade
-    @marks.skip
-    # skipped as no support for upgrade now
+    @marks.testrail_id(6284)
     def test_apk_upgrade(self):
         sign_in = SignInView(self.driver)
         home = sign_in.create_user()
         profile = home.profile_button.click()
-        about = profile.about_button.click()
-        old_version = about.version.text
+        profile.about_button.click()
+        old_version = profile.app_version_text.text
+        profile.upgrade_app()
 
-        profile.driver.install_app('https://status-im.ams3.digitaloceanspaces.com/' +
-                                   self.apk_name, replace=True)
         sign_in.driver.launch_app()
         home = sign_in.sign_in()
 
         profile = home.profile_button.click()
-        about = profile.about_button.click()
-        new_version = about.version.text
-        print(new_version, old_version)
+        profile.about_button.click()
+        new_version = profile.app_version_text.text
+        print('Upgraded app version is %s vs base version is %s ' % (new_version, old_version))
         assert new_version != old_version

--- a/test/appium/tests/conftest.py
+++ b/test/appium/tests/conftest.py
@@ -67,6 +67,11 @@ def pytest_addoption(parser):
                      metavar="NAME",
                      default=None,
                      help="only run tests matching the environment NAME.")
+    parser.addoption("--apk_upgrade",
+                     action="store",
+                     metavar="NAME",
+                     default=None,
+                     help='Url or local path to apk for upgrade')
 
     # chat bot
 

--- a/test/appium/views/base_view.py
+++ b/test/appium/views/base_view.py
@@ -1,7 +1,6 @@
 import time
 
 import base64
-import pytest
 import random
 import re
 import string
@@ -14,7 +13,7 @@ from io import BytesIO
 from selenium.common.exceptions import NoSuchElementException, TimeoutException, StaleElementReferenceException
 
 from support.device_apps import start_web_browser
-from tests import common_password
+from tests import common_password, pytest_config_global
 from views.base_element import BaseButton, BaseElement, BaseEditBox, BaseText
 
 
@@ -687,6 +686,10 @@ class BaseView(object):
     def open_universal_web_link(self, deep_link):
         start_web_browser(self.driver)
         self.driver.get(deep_link)
+
+    def upgrade_app(self):
+        self.driver.install_app(pytest_config_global['apk_upgrade'], replace=True)
+        self.driver.info('Upgrading apk to apk_upgrade')
 
     # Method-helper
     def write_page_source_to_file(self, full_path_to_file):


### PR DESCRIPTION
POC for upgrade test.
Job: https://ci.status.im/job/end-to-end-tests/job/status-app-upgrade/
Currently test itself is located in `Upgrade` section in testrail, so wasn't captured in [test run](https://ethstatus.testrail.net/index.php?/runs/view/5214&group_by=cases:section_id&group_order=asc) (will decide later - move it to separate testrail suite or leave in existing)

- Added ci/tests/Jenkinsfile.e2e-upgrade to manage new job
- Edited /ci/tests/Jenkinsfile.e2e-nightly to exclude test cases with `upgrade` from nightly e2e builds
