### PR TITLE
fix maven deps shell by ajusting arguments

### DIFF
--- a/nix/mobile/android/maven-and-npm-deps/maven/shell.nix
+++ b/nix/mobile/android/maven-and-npm-deps/maven/shell.nix
@@ -1,8 +1,7 @@
-{ mergeSh, mkShell, curl, flock, git, gradle, jq, maven, nodejs,
-  projectNodePackage, androidShell, status-go }:
+{ lib, mkShell, pkgs, gradle, projectNodePackage, androidShell, status-go }:
 
-mergeSh (mkShell {
-  buildInputs = [
+lib.mergeSh (mkShell {
+  buildInputs = with pkgs; [
     curl flock # used in reset-node_modules.sh
     git gradle jq maven nodejs
     projectNodePackage


### PR DESCRIPTION
Fix for a bug introduced after refactor in #10437 that broke `make nix-update-gradle`:
```
error: while evaluating 'callPackageWith' at /nix/store/42pwzfd0bp194i2r48fqihwm6ifr4pp0-nixpkgs-source/lib/customisation.nix:117:35, called from /Users/ferossgp/code/status-react/nix/mobile/android/default.nix:26:39:
while evaluating 'makeOverridable' at /nix/store/42pwzfd0bp194i2r48fqihwm6ifr4pp0-nixpkgs-source/lib/customisation.nix:67:24, called from /nix/store/42pwzfd0bp194i2r48fqihwm6ifr4pp0-nixpkgs-source/lib/customisation.nix:121:8:
anonymous function at /Users/ferossgp/code/status-react/nix/mobile/android/maven-and-npm-deps/maven/shell.nix:1:1 called without required argument 'mergeSh', at /nix/store/42pwzfd0bp194i2r48fqihwm6ifr4pp0-nixpkgs-source/lib/customisation.nix:69:16
make: *** [nix-update-gradle] Error 1
```