### PR TITLE
Nix/reduce store size

### DIFF
--- a/nix/mobile/android/maven-and-npm-deps/maven/default.nix
+++ b/nix/mobile/android/maven-and-npm-deps/maven/default.nix
@@ -9,10 +9,9 @@ let
   mavenSourceFiles =
     let
       srcs = import ./maven-sources.nix { };
-      system = if stdenv.isDarwin then "osx" else "linux";
       # Warning: This must be the same as gradlePluginVersion android/gradle.properties
       version = "3.5.3-5435860";
-      aapt2NativePkg = "https://dl.google.com/dl/android/maven2/com/android/tools/build/aapt2/${version}/aapt2-${version}-${system}";
+      aapt2NativePkg = "https://dl.google.com/dl/android/maven2/com/android/tools/build/aapt2/${version}/aapt2-${version}-linux";
     in srcs // (if !stdenv.isLinux then { } else {
       # On Linux, we need to patch the interpreter in Java packages that contain native executables to use Nix's interpreter instead
       "${aapt2NativePkg}" = srcs."${aapt2NativePkg}" // {

--- a/nix/mobile/node-package.nix
+++ b/nix/mobile/node-package.nix
@@ -1,46 +1,15 @@
-{ lib, fetchFromGitHub, pkgs, nodejs, yarn }:
+{ lib, fetchFromGitHub
+, nodejs, yarn2nix-moretea }:
 
 let
-  yarn2nix = import (fetchFromGitHub {
-    name = "yarn2nix-source";
-    owner = "moretea";
-    repo = "yarn2nix";
-    rev = "3cc020e384ce2a439813adb7a0cc772a034d90bb";
-    sha256 = "0h2kzdfiw43rbiiffpqq9lkhvdv8mgzz2w29pzrxgv8d39x67vr9";
-  }) { inherit pkgs nodejs yarn; };
+  version = lib.fileContents ../../VERSION;
   yarnLock = ../../mobile/js_files/yarn.lock;
   packageJSON = ../../mobile/js_files/package.json;
   packageJSONContent = lib.importJSON packageJSON;
-
-  # Create a yarn package for our project that contains all the dependecies, so that we have a
-  # known good node_modules folder that we can use later on
-  projectNodePackage = yarn2nix.mkYarnModules rec {
-    name = "${pname}-${version}";
-    pname = packageJSONContent.name;
-    version = packageJSONContent.version;
-    inherit packageJSON yarnLock;
-    # Replace symlink to deps with copy of real dependencies
-    postBuild = ''
-      # Fixup symlinks in folder we'll be moving.
-      # Basically transform a symlink pointing to ../../../../../../a into ../../../../a 
-      symlinks=( $(find $out/deps/${pname}/node_modules/ -lname '../../../../../..*') )
-      for sl in ''${symlinks[@]}; do
-        newTarget=$(readlink "$sl" | sed -E "s|(\.\./){2}(.*)|\2|")
-        ln -snf "$newTarget" "$sl"
-      done
-      unset sl
-      unset symlinks
-
-      # Merge deps with node_modules
-      cp -R --no-clobber $out/deps/${pname}/node_modules/. $out/node_modules/
-      # Get rid of deps
-      rm -rf $out/deps/
-      # Get rid of symlink to deps
-      rm $out/node_modules/${pname}
-
-      # Ensure the we copied expected dependencies from $out/deps
-      [ -d $out/node_modules/react-native-fs ] || exit 1
-    '';
-  };
-
-in projectNodePackage
+in
+  # Create a yarn package for our project that contains all the dependecies.
+  yarn2nix-moretea.mkYarnModules rec {
+    pname = "status-react";
+    name = "${pname}-node-deps-${version}";
+    inherit version packageJSON yarnLock;
+  }

--- a/nix/tools/maven/maven-repo-builder.nix
+++ b/nix/tools/maven/maven-repo-builder.nix
@@ -40,13 +40,13 @@ let
         mkdir -p ${directory}
 
         ${optionalString (pom-download != "") ''
-        cp -f "${pom-download}" "${getPOM dep.path}"
+        ln -s "${pom-download}" "${getPOM dep.path}"
         ''}
         ${optionalString (pom.sha1 != "") ''
         echo "${pom.sha1}" > "${getPOM dep.path}.sha1"
         ''}
         ${optionalString (jar-download != "") ''
-        cp -f "${jar-download}" "${dep.path}.${dep.type}"
+        ln -s "${jar-download}" "${dep.path}.${dep.type}"
         ''}
         ${optionalString (jar.sha1 != "") ''
         echo "${jar.sha1}" > "${dep.path}.${dep.type}.sha1"
@@ -54,6 +54,9 @@ let
         
         ${if dep.postCopy != "" then ''
           depPath="$PWD/${dep.path}"
+          # postCopy can't modify the jar if it's a symlink
+          rm "${dep.path}.${dep.type}"
+          cp "${jar-download}" "${dep.path}.${dep.type}"
           ${dep.postCopy}
           unset depPath
         '' else ""


### PR DESCRIPTION
First attempt at fixing #10563 by reducing the size of the derivation for Gradle and Node modules.

I've managed to go down from `725 MB` to `32 MB` for `.m2` Maven cache folder. This reduces the size of the `status-react-patched-npm-gradle-modules` by ~53%. And considering that's the one we rebuild the most it should lessen the storage burden on developers machines.