### PR TITLE
nix: fix ios sim builds, build for amd64 instead 386

### DIFF
--- a/nix/status-go/mobile/default.nix
+++ b/nix/status-go/mobile/default.nix
@@ -6,6 +6,7 @@
 {
   android = callPackage ./build.nix {
     platform = "android";
+    # 386 is for android simulator
     architectures = [ "arm" "arm64" "386" ];
     outputFileName = "status-go-${source.shortRev}.aar";
     inherit meta source goBuildFlags goBuildLdFlags;
@@ -13,7 +14,8 @@
 
   ios = callPackage ./build.nix {
     platform = "ios";
-    architectures = [ "arm" "arm64" "386" ];
+    # amd64 is for ios simulator
+    architectures = [ "arm" "arm64" "amd64" ];
     outputFileName = "Statusgo.framework";
     inherit meta source goBuildFlags goBuildLdFlags;
   };


### PR DESCRIPTION
Should fix this error:
```
Undefined symbols for architecture x86_64:
  "_StatusgoAddPeer", referenced from:
      -[Status addPeer:callback:] in libRCTStatus.a(RCTStatus.o)
```