### PR TITLE
nix: add missing STATUS_GO_ANDROID_LIBDIR env variable

### DIFF
--- a/nix/mobile/android/default.nix
+++ b/nix/mobile/android/default.nix
@@ -45,6 +45,9 @@ in {
         export ANDROID_SDK_ROOT="${androidPkgs}"
         export ANDROID_NDK_ROOT="${androidPkgs}/ndk-bundle"
 
+        # required by some makefile targets
+        export STATUS_GO_ANDROID_LIBDIR=${status-go}
+
         # check if node modules changed and if so install them
         $STATUS_REACT_HOME/nix/mobile/reset-node_modules.sh \
           "${mavenAndNpmDeps.drv}/project"


### PR DESCRIPTION
This should fix the following from `make startdev-android-genymotion`:
```
A problem occurred configuring project ':app'.
> STATUS_GO_ANDROID_LIBDIR environment variable is not valid!
```
We stopped merging `status-go` shells in refactor done in #10464.