### PR TITLE
jenkins: allow combined jobs to copy artifacts

### DIFF
--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -13,6 +13,8 @@ pipeline {
       daysToKeepStr: '20',
       artifactNumToKeepStr: '10',
     ))
+    /* Allows combined build to copy */
+    copyArtifactPermission('/status-react/*')
   }
 
   parameters {

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -21,6 +21,8 @@ pipeline {
       daysToKeepStr: '20',
       artifactNumToKeepStr: '10',
     ))
+    /* Allows combined build to copy */
+    copyArtifactPermission('/status-react/*')
   }
 
   environment {

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -21,6 +21,8 @@ pipeline {
       daysToKeepStr: '20',
       artifactNumToKeepStr: '10',
     ))
+    /* Allows combined build to copy */
+    copyArtifactPermission('/status-react/*')
   }
 
   /**

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -21,6 +21,8 @@ pipeline {
       daysToKeepStr: '20',
       artifactNumToKeepStr: '10',
     ))
+    /* Allows combined build to copy */
+    copyArtifactPermission('/status-react/*')
   }
 
   environment {

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -21,6 +21,8 @@ pipeline {
       daysToKeepStr: '20',
       artifactNumToKeepStr: '10',
     ))
+    /* Allows combined build to copy */
+    copyArtifactPermission('/status-react/*')
   }
 
   /**


### PR DESCRIPTION
This is in order to enable `Production` permission checks when copying artifacts between builds.

![jenkins_copy_artifact_mode](https://user-images.githubusercontent.com/2212681/81544224-82055400-9377-11ea-966e-d7834a4c2039.png)

Related: https://issues.jenkins-ci.org/browse/JENKINS-40429