### PR TITLE
Keycard transacting e2e

### DIFF
--- a/test/appium/tests/__init__.py
+++ b/test/appium/tests/__init__.py
@@ -29,6 +29,9 @@ appium_container = AppiumContainer()
 
 common_password = 'qwerty'
 unique_password = 'unique' + get_current_time()
+pin = '121212'
+puk = '000000000000'
+pair_code= '000000'
 
 bootnode_address = "enode://a8a97f126f5e3a340cb4db28a1187c325290ec08b2c9a6b1f19845ac86c46f9fac2ba13328822590" \
                    "fd3de3acb09cc38b5a05272e583a2365ad1fa67f66c55b34@167.99.210.203:30404"

--- a/test/appium/tests/atomic/chats/test_keycard_commands.py
+++ b/test/appium/tests/atomic/chats/test_keycard_commands.py
@@ -1,0 +1,205 @@
+from _pytest.outcomes import Failed
+import time
+
+from tests import marks
+from tests.users import transaction_senders, transaction_recipients
+from tests.base_test_case import MultipleDeviceTestCase, SingleDeviceTestCase
+from views.sign_in_view import SignInView
+
+
+@marks.chat
+@marks.transaction
+@marks.skip
+## TODO: uncomment and check when commands in 1-1 chat will be ready in kk framework
+class TestCommandsMultipleDevices(MultipleDeviceTestCase):
+
+    @marks.testrail_id(6293)
+    @marks.critical
+    def test_keycard_send_eth_in_1_1_chat(self):
+        recipient = transaction_recipients['A']
+        sender = transaction_senders['A']
+        self.create_drivers(2)
+        device_1, device_2 = SignInView(self.drivers[0]), SignInView(self.drivers[1])
+        home_1 = device_1.recover_access(passphrase=sender['passphrase'], keycard=True)
+        home_2 = device_2.recover_access(passphrase=recipient['passphrase'], keycard=True)
+        wallet_1, wallet_2 = home_1.wallet_button.click(), home_2.wallet_button.click()
+        for wallet in (wallet_1, wallet_2):
+            wallet.set_up_wallet()
+            wallet.home_button.click()
+
+        chat_1 = home_1.add_contact(recipient['public_key'])
+        amount = chat_1.get_unique_amount()
+
+        home_1.just_fyi('Send %s ETH in 1-1 chat and check it for sender and receiver: Address requested' % amount)
+        chat_1.commands_button.click()
+        send_transaction = chat_1.send_command.click()
+        if not send_transaction.get_username_in_transaction_bottom_sheet_button(recipient['username']).is_element_displayed():
+            self.driver.fail('%s is not shown in "Send Transaction" bottom sheet' % recipient['username'])
+        send_transaction.get_username_in_transaction_bottom_sheet_button(recipient['username']).click()
+        if send_transaction.scan_qr_code_button.is_element_displayed():
+            self.driver.fail('Recipient is editable in bootom sheet when send ETH from 1-1 chat')
+        send_transaction.amount_edit_box.set_value(amount)
+        send_transaction.confirm()
+        send_transaction.sign_transaction_button.click()
+        chat_1_sender_message = chat_1.chat_element_by_text('↑ Outgoing transaction')
+        if not chat_1_sender_message.is_element_displayed():
+            self.driver.fail('No message is shown after sending ETH in 1-1 chat for sender')
+        if chat_1_sender_message.transaction_status.text != 'Address requested':
+            self.errors.append('Wrong state is shown for outgoing transaction: "Address requested" is expected, in fact'
+                               ' %s ' % chat_1_sender_message.transaction_status.text)
+
+        chat_2 = home_2.get_chat(sender['username']).click()
+        chat_2_receiver_message = chat_2.chat_element_by_text('↓ Incoming transaction')
+        timestamp_sender = chat_1_sender_message.timestamp_message.text
+        if not chat_2_receiver_message.is_element_displayed():
+            self.driver.fail('No message about incoming transaction in 1-1 chat is shown for receiver')
+        if chat_2_receiver_message.transaction_status.text != 'Address requested':
+            self.errors.append('Wrong state is shown for incoming transaction: "Address requested" is expected, in fact'
+                               ' %s' % chat_2_receiver_message.transaction_status.text)
+
+        home_2.just_fyi('Accept and share address for sender and receiver')
+        for text in ('Accept and share address', 'Decline'):
+            if not chat_2_receiver_message.contains_text(text):
+                self.driver.fail("Transaction message doesn't contain required option %s" % text)
+        select_account_bottom_sheet = chat_2_receiver_message.accept_and_share_address.click()
+        if not select_account_bottom_sheet.get_account_in_select_account_bottom_sheet_button('Status').is_element_displayed():
+            self.errors.append('Not expected value in "From" in "Select account": "Status" is expected')
+        select_account_bottom_sheet.select_button.click()
+        if chat_2_receiver_message.transaction_status.text != "Shared 'Status account'":
+            self.errors.append('Wrong state is shown for incoming transaction: "Shared \'Status account\' is expected, '
+                               'in fact  %s ' %  chat_2_receiver_message.transaction_status.text)
+        if chat_1_sender_message.transaction_status.text != 'Address request accepted':
+            self.errors.append('Wrong state is shown for outgoing transaction: "Address request accepted" is expected, '
+                               'in fact %s ' % chat_1_sender_message.transaction_status.text)
+
+        home_1.just_fyi("Sign and send transaction and check that timestamp on message is updated")
+        time.sleep(40)
+        send_message = chat_1_sender_message.sign_and_send.click()
+        send_message.next_button.click()
+        send_message.sign_transaction(keycard=True)
+        if chat_1_sender_message.transaction_status.text != 'Pending':
+            self.errors.append('Wrong state is shown for outgoing transaction: "Pending" is expected, in fact'
+                               ' %s ' % chat_1_sender_message.transaction_status.text)
+        updated_timestamp_sender = chat_1_sender_message.timestamp_message.text
+        if updated_timestamp_sender == timestamp_sender:
+            self.errors.append("Timestamp of message is not updated after signing transaction")
+
+        chat_1.wallet_button.click()
+        wallet_1.accounts_status_account.click()
+        transactions_view = wallet_1.transaction_history_button.click()
+        transactions_view.transactions_table.find_transaction(amount=amount)
+        self.network_api.wait_for_confirmation_of_transaction(sender['address'], amount)
+        wallet_1.home_button.click()
+
+        home_1.just_fyi("Check 'Confirmed' state for sender")
+        if chat_1_sender_message.transaction_status.text != 'Confirmed':
+            self.errors.append('Wrong state is shown for outgoing transaction: "Confirmed" is expected, in fact'
+                               ' %s ' % chat_1_sender_message.transaction_status.text)
+        self.errors.verify_no_errors()
+
+    @marks.testrail_id(6294)
+    @marks.critical
+    def test_keycard_request_and_receive_stt_in_1_1_chat_offline(self):
+        sender = transaction_senders['C']
+        self.create_drivers(2)
+        device_1, device_2 = SignInView(self.drivers[0]), SignInView(self.drivers[1])
+
+        device_1.just_fyi('Grab user data for transactions and public chat, set up wallets')
+        home_1 = device_1.create_user(keycard=True)
+        recipient_public_key, recipient_username = home_1.get_public_key_and_username(return_username=True)
+        wallet_1 = home_1.wallet_button.click()
+        wallet_1.set_up_wallet()
+        recipient_address = wallet_1.get_wallet_address()
+        wallet_1.back_button.click()
+        wallet_1.select_asset('STT')
+        wallet_1.home_button.click()
+
+        home_2 = device_2.recover_access(passphrase=sender['passphrase'], keycard=True)
+        wallet_2 = home_2.wallet_button.click()
+        wallet_2.set_up_wallet()
+        wallet_2.home_button.click()
+
+        device_2.just_fyi('Add recipient to contact and send 1 message')
+        chat_2 = home_2.add_contact(recipient_public_key)
+        chat_2.send_message("Hey there!")
+        amount = chat_2.get_unique_amount()
+        asset_name = 'STT'
+        profile_2 = wallet_2.profile_button.click()
+        profile_2.logout()
+        chat_element = home_1.get_chat(sender['username'])
+        chat_element.wait_for_visibility_of_element(30)
+        chat_1 = chat_element.click()
+
+        home_1.just_fyi('Request %s STT in 1-1 chat and check it is visible for sender and receiver' % amount)
+        chat_1.commands_button.click()
+        request_transaction = chat_1.request_command.click()
+        request_transaction.amount_edit_box.set_value(amount)
+        request_transaction.confirm()
+        asset_button = request_transaction.asset_by_name(asset_name)
+        request_transaction.select_asset_button.click_until_presence_of_element(asset_button)
+        asset_button.click()
+        request_transaction.request_transaction_button.click()
+        chat_1_request_message = chat_1.chat_element_by_text('↓ Incoming transaction')
+        if not chat_1_request_message.is_element_displayed():
+            self.driver.fail('No incoming transaction in 1-1 chat is shown for recipient after requesting STT')
+
+        home_2.just_fyi('Check that transaction message is fetched from offline and sign transaction')
+        device_2.sign_in()
+        home_2.connection_status.wait_for_invisibility_of_element(30)
+        home_2.get_chat(recipient_username).click()
+        chat_2_sender_message = chat_2.chat_element_by_text('↑ Outgoing transaction')
+        if not chat_2_sender_message.is_element_displayed():
+                self.driver.fail('No outgoing transaction in 1-1 chat is shown for sender after requesting STT')
+        if chat_2_sender_message.transaction_status.text != 'Address received':
+            self.errors.append('Wrong state is shown for outgoing transaction: "Address request accepted" is expected, '
+                               'in fact %s ' % chat_2_sender_message.transaction_status.text)
+        send_message = chat_2_sender_message.sign_and_send.click()
+        send_message.next_button.click()
+        send_message.sign_transaction(keycard=True)
+
+        home_2.just_fyi('Check that transaction message is updated with new status after offline')
+        chat_2.toggle_airplane_mode()
+        self.network_api.wait_for_confirmation_of_transaction(sender['address'], amount, confirmations=15, token=True)
+        chat_2.toggle_airplane_mode()
+        chat_2.connection_status.wait_for_invisibility_of_element(30)
+        if chat_2_sender_message.transaction_status.text != 'Confirmed':
+            self.errors.append('Wrong state is shown for outgoing transaction: "Confirmed" is expected, in fact'
+                               ' %s ' % chat_2_sender_message.transaction_status.text)
+        try:
+            self.network_api.find_transaction_by_unique_amount(recipient_address[2:], amount, token=True)
+        except Failed as e:
+            self.errors.append(e.msg)
+        self.errors.verify_no_errors()
+
+
+@marks.chat
+@marks.transaction
+@marks.skip
+## TODO: uncomment and check when commands in 1-1 chat will be ready in kk framework
+class TestCommandsSingleDevices(SingleDeviceTestCase):
+
+    @marks.testrail_id(6295)
+    @marks.high
+    def test_keycard_send_eth_to_ens(self):
+        sign_in = SignInView(self.driver)
+        sender = transaction_senders['E']
+        home = sign_in.recover_access(sender['passphrase'], keycard=True)
+        chat = home.add_contact('nastya')
+        chat.commands_button.click()
+        amount = chat.get_unique_amount()
+
+        send_message = chat.send_command.click()
+        send_message.amount_edit_box.set_value(amount)
+        send_message.confirm()
+        send_message.next_button.click()
+
+        from views.send_transaction_view import SendTransactionView
+        send_transaction = SendTransactionView(self.driver)
+        send_transaction.sign_transaction(keycard=True)
+        chat_sender_message = chat.chat_element_by_text('↑ Outgoing transaction')
+        self.network_api.wait_for_confirmation_of_transaction(sender['address'], amount, confirmations=15)
+        if chat_sender_message.transaction_status.text != 'Confirmed':
+            self.errors.append('Wrong state is shown for outgoing transaction to ENS: "Confirmed" is expected, '
+                               'in fact %s ' % chat_sender_message.transaction_status.text)
+
+        self.errors.verify_no_errors()

--- a/test/appium/tests/atomic/transactions/test_keycard_dapps_transactions.py
+++ b/test/appium/tests/atomic/transactions/test_keycard_dapps_transactions.py
@@ -1,0 +1,139 @@
+from tests import marks, pin, puk, pair_code
+from tests.base_test_case import SingleDeviceTestCase
+from tests.users import transaction_senders
+from views.sign_in_view import SignInView
+
+
+class TestTransactionDApp(SingleDeviceTestCase):
+
+    @marks.testrail_id(6249)
+    @marks.critical
+    def test_keycard_send_transaction_from_daap(self):
+        sender = transaction_senders['K']
+        sign_in_view = SignInView(self.driver)
+        home_view = sign_in_view.recover_access(sender['passphrase'], keycard=True)
+        address = sender['address']
+        initial_balance = self.network_api.get_balance(address)
+        wallet_view = home_view.wallet_button.click()
+        wallet_view.set_up_wallet()
+        initial_amount_STT = wallet_view.get_asset_amount_by_name('STT')
+        status_test_dapp = home_view.open_status_test_dapp()
+        status_test_dapp.wait_for_d_aap_to_load()
+        status_test_dapp.assets_button.click()
+        send_transaction_view = status_test_dapp.request_stt_button.click()
+        send_transaction_view.sign_transaction(keycard=True)
+        self.network_api.verify_balance_is_updated(initial_balance, address)
+        status_test_dapp.wallet_button.click()
+
+        send_transaction_view.just_fyi('Verify that wallet balance is updated')
+        wallet_view.wait_balance_is_changed('STT', initial_amount_STT)
+
+        send_transaction_view.just_fyi('Check logcat for sensitive data')
+        values_in_logcat = send_transaction_view.find_values_in_logcat(mnemonic=sender['passphrase'],
+                                                                       pin=pin,
+                                                                       puk=puk,
+                                                                       password=pair_code)
+        if values_in_logcat:
+            self.driver.fail(values_in_logcat)
+
+    @marks.testrail_id(6251)
+    @marks.critical
+    def test_keycard_sign_message_from_daap(self):
+        sign_in_view = SignInView(self.driver)
+        home_view = sign_in_view.create_user(keycard=True)
+        wallet_view = home_view.wallet_button.click()
+        wallet_view.set_up_wallet()
+        status_test_dapp = home_view.open_status_test_dapp()
+        status_test_dapp.wait_for_d_aap_to_load()
+        status_test_dapp.transactions_button.click()
+        send_transaction_view = status_test_dapp.sign_message_button.click()
+        send_transaction_view.find_full_text('Test message')
+        keycard_view = send_transaction_view.sign_with_keycard_button.click()
+        keycard_view.enter_default_pin()
+        if not keycard_view.element_by_text_part('Signed message').is_element_displayed():
+            self.driver.fail('Message was not signed')
+
+        keycard_view.just_fyi('Check logcat for sensitive data')
+        values_in_logcat = send_transaction_view.find_values_in_logcat(pin=pin,
+                                                                       puk=puk,
+                                                                       password=pair_code)
+        if values_in_logcat:
+            self.driver.fail(values_in_logcat)
+
+    @marks.testrail_id(5333)
+    @marks.medium
+    def test_keycard_deploy_contract_from_daap(self):
+        sender = transaction_senders['L']
+        sign_in_view = SignInView(self.driver)
+        home_view = sign_in_view.recover_access(sender['passphrase'], keycard=True)
+        wallet_view = home_view.wallet_button.click()
+        wallet_view.set_up_wallet()
+        status_test_dapp = home_view.open_status_test_dapp()
+        status_test_dapp.wait_for_d_aap_to_load()
+        status_test_dapp.transactions_button.click()
+        send_transaction_view = status_test_dapp.deploy_contract_button.click()
+        send_transaction_view.sign_transaction(keycard=True)
+        for text in 'Contract deployed at: ', 'Call contract get function', \
+                    'Call contract set function', 'Call function 2 times in a row':
+            if not status_test_dapp.element_by_text(text).is_element_displayed(180):
+                self.driver.fail('Contract was not created')
+
+    @marks.testrail_id(5784)
+    @marks.medium
+    def test_keycard_sign_typed_message(self):
+        sender = transaction_senders['W']
+        sign_in_view = SignInView(self.driver)
+        home_view = sign_in_view.recover_access(sender['passphrase'], keycard=True)
+        wallet_view = home_view.wallet_button.click()
+        wallet_view.set_up_wallet()
+        status_test_dapp = home_view.open_status_test_dapp()
+        status_test_dapp.wait_for_d_aap_to_load()
+        status_test_dapp.transactions_button.click_until_presence_of_element(status_test_dapp.sign_typed_message_button)
+        send_transaction_view = status_test_dapp.sign_typed_message_button.click()
+        send_transaction_view.sign_with_keycard_button.click()
+        keycard_view = send_transaction_view.sign_with_keycard_button.click()
+        keycard_view.enter_default_pin()
+        if not keycard_view.element_by_text('0x123').is_element_displayed():
+            self.driver.fail('Typed message was not signed')
+
+    @marks.testrail_id(6287)
+    @marks.high
+    def test_keycard_send_two_transactions_in_batch_in_dapp(self):
+        sender = transaction_senders['W']
+        sign_in_view = SignInView(self.driver)
+        home_view = sign_in_view.recover_access(sender['passphrase'], keycard=True)
+        wallet_view = home_view.wallet_button.click()
+        wallet_view.set_up_wallet()
+        status_test_dapp = home_view.open_status_test_dapp()
+        status_test_dapp.wait_for_d_aap_to_load()
+        status_test_dapp.transactions_button.click_until_presence_of_element(status_test_dapp.send_two_tx_in_batch_button)
+        send_transaction_view = status_test_dapp.send_two_tx_in_batch_button.click()
+        send_transaction_view.sign_transaction(keycard=True)
+
+        wallet_view.just_fyi('Check that second "Send transaction" screen appears')
+        if not send_transaction_view.sign_with_keycard_button.is_element_displayed(10):
+            self.driver.fail('Second send transaction screen did not appear!')
+
+        send_transaction_view.sign_transaction(keycard=True)
+
+    @marks.testrail_id(5744)
+    @marks.critical
+    def test_keycard_send_two_transactions_one_after_another_in_dapp(self):
+        sender = transaction_senders['Z']
+        sign_in_view = SignInView(self.driver)
+        home_view = sign_in_view.recover_access(sender['passphrase'], keycard=True)
+        wallet_view = home_view.wallet_button.click()
+        wallet_view.set_up_wallet()
+        status_test_dapp = home_view.open_status_test_dapp()
+        status_test_dapp.wait_for_d_aap_to_load()
+        status_test_dapp.transactions_button.click()
+        send_transaction_view = status_test_dapp.send_two_tx_one_by_one_button.click()
+        send_transaction_view.sign_transaction(keycard=True)
+
+        wallet_view.just_fyi('Check that second "Send transaction" screen appears')
+        if not send_transaction_view.sign_with_keycard_button.is_element_displayed(20):
+            self.driver.fail('Second send transaction screen did not appear!')
+
+        send_transaction_view.sign_transaction(keycard=True)
+
+

--- a/test/appium/tests/atomic/transactions/test_keycard_wallet.py
+++ b/test/appium/tests/atomic/transactions/test_keycard_wallet.py
@@ -1,0 +1,188 @@
+from support.utilities import get_merged_txs_list
+from tests import marks, pin, puk, pair_code
+from tests.base_test_case import SingleDeviceTestCase
+from tests.users import transaction_senders, basic_user, wallet_users
+from views.sign_in_view import SignInView
+
+
+@marks.transaction
+class TestTransactionWalletSingleDevice(SingleDeviceTestCase):
+
+    @marks.testrail_id(6289)
+    @marks.critical
+    def test_keycard_send_eth_from_wallet_to_address(self):
+        recipient = basic_user
+        sender = transaction_senders['P']
+        sign_in_view = SignInView(self.driver)
+        home_view = sign_in_view.recover_access(sender['passphrase'], keycard=True)
+        wallet_view = home_view.wallet_button.click()
+        wallet_view.set_up_wallet()
+        wallet_view.accounts_status_account.click()
+        send_transaction = wallet_view.send_transaction_button.click()
+        send_transaction.amount_edit_box.click()
+        transaction_amount = send_transaction.get_unique_amount()
+        send_transaction.amount_edit_box.set_value(transaction_amount)
+        send_transaction.confirm()
+        send_transaction.chose_recipient_button.click()
+        send_transaction.enter_recipient_address_button.click()
+
+        send_transaction.just_fyi('Send transaction')
+        send_transaction.enter_recipient_address_input.set_value(recipient['address'])
+        send_transaction.done_button.click()
+        send_transaction.sign_transaction_button.click()
+        send_transaction.sign_transaction(keycard=True)
+        self.network_api.find_transaction_by_unique_amount(sender['address'], transaction_amount)
+
+        send_transaction.just_fyi('Check that transaction is appeared in transaction history')
+        transactions_view = wallet_view.transaction_history_button.click()
+        transactions_view.transactions_table.find_transaction(amount=transaction_amount)
+
+        transactions_view.just_fyi('Check logcat for sensitive data')
+        values_in_logcat = send_transaction.find_values_in_logcat(pin=pin, puk=puk, password=pair_code)
+        if values_in_logcat:
+            self.driver.fail(values_in_logcat)
+
+
+    @marks.testrail_id(6290)
+    @marks.high
+    def test_keycard_fetching_balance_after_offline(self):
+        sender = wallet_users['A']
+        sign_in_view = SignInView(self.driver)
+
+        sign_in_view.just_fyi('Restore account with funds offline')
+        sign_in_view.toggle_airplane_mode()
+        sign_in_view.recover_access(sender['passphrase'], keycard=True)
+        home_view = sign_in_view.get_home_view()
+        wallet_view = home_view.wallet_button.click()
+        wallet_view.set_up_wallet()
+
+        sign_in_view.just_fyi('Go back to online and check that balance is updated')
+        sign_in_view.toggle_airplane_mode()
+        wallet_view.wait_balance_is_changed('ETHro')
+        wallet_view.wait_balance_is_changed('STT')
+
+        sign_in_view.just_fyi('Send some tokens to other account')
+        recipient = "0x" + basic_user['address']
+        sending_amount = wallet_view.get_unique_amount()
+        asset = 'STT'
+        wallet_view.accounts_status_account.click_until_presence_of_element(wallet_view.send_transaction_button)
+        wallet_view.send_transaction(asset_name=asset, amount=sending_amount, recipient=recipient,
+                                     sign_transaction=True, keycard=True)
+        sign_in_view.toggle_airplane_mode()
+        self.network_api.wait_for_confirmation_of_transaction(basic_user['address'], sending_amount, confirmations=6, token=True)
+
+        sign_in_view.just_fyi('Change that balance is updated and transaction is appeared in history')
+        initial_amount_STT = wallet_view.get_asset_amount_by_name('STT')
+        sign_in_view.toggle_airplane_mode()
+        wallet_view.wait_balance_is_changed('STT', initial_amount_STT)
+        transactions_view = wallet_view.transaction_history_button.click()
+        transactions_view.transactions_table.find_transaction(amount=sending_amount, asset='STT')
+
+    @marks.testrail_id(6291)
+    @marks.critical
+    def test_keycard_can_see_all_transactions_in_history(self):
+        address = wallet_users['D']['address']
+        passphrase = wallet_users['D']['passphrase']
+
+        ropsten_txs = self.network_api.get_transactions(address)
+        ropsten_tokens = self.network_api.get_token_transactions(address)
+        expected_txs_list = get_merged_txs_list(ropsten_txs, ropsten_tokens)
+        signin_view = SignInView(self.driver)
+        home_view = signin_view.recover_access(passphrase=passphrase, keycard=True)
+        wallet_view = home_view.wallet_button.click()
+        wallet_view.set_up_wallet()
+        wallet_view.accounts_status_account.click()
+        transaction_view = wallet_view.transaction_history_button.click()
+
+        status_tx_number = transaction_view.transactions_table.get_transactions_number()
+        if status_tx_number < 1:
+            self.driver.fail('No transactions found')
+
+        for n in range(status_tx_number):
+            transactions_details = transaction_view.transactions_table.transaction_by_index(n).click()
+            tx_hash = transactions_details.get_transaction_hash()
+            tx_from = transactions_details.get_sender_address()
+            tx_to = transactions_details.get_recipient_address()
+            if tx_from != expected_txs_list[tx_hash]['from']:
+                self.errors.append('Transactions senders do not match!')
+            if tx_to != expected_txs_list[tx_hash]['to']:
+                self.errors.append('Transactions recipients do not match!')
+            transactions_details.back_button.click()
+
+        self.errors.verify_no_errors()
+
+    @marks.testrail_id(6292)
+    @marks.medium
+    def test_keycard_send_funds_between_accounts_in_multiaccount_instance(self):
+        sign_in_view = SignInView(self.driver)
+        sign_in_view.create_user(keycard=True)
+        wallet_view = sign_in_view.wallet_button.click()
+        wallet_view.set_up_wallet()
+        status_account_address = wallet_view.get_wallet_address()[2:]
+        wallet_view.back_button.click()
+        self.network_api.get_donate(status_account_address)
+        wallet_view.wait_balance_is_changed()
+        account_name = 'subaccount'
+        wallet_view.add_account(account_name, keycard=True)
+
+        wallet_view.just_fyi("Send transaction to new account")
+        wallet_view.accounts_status_account.click()
+        send_transaction = wallet_view.send_transaction_button.click()
+        send_transaction.amount_edit_box.click()
+        transaction_amount = send_transaction.get_unique_amount()
+        send_transaction.amount_edit_box.set_value(transaction_amount)
+        send_transaction.confirm()
+        send_transaction.chose_recipient_button.click()
+        send_transaction.accounts_button.click()
+        send_transaction.element_by_text(account_name).click()
+        send_transaction.sign_transaction_button.click()
+        send_transaction.sign_transaction(keycard=True)
+        self.network_api.wait_for_confirmation_of_transaction(status_account_address, transaction_amount)
+        self.network_api.verify_balance_is_updated('0.1', status_account_address)
+
+        wallet_view.just_fyi("Verifying previously sent transaction in new account")
+        wallet_view.back_button.click()
+        wallet_view.get_account_by_name(account_name).click()
+        wallet_view.send_transaction_button.click()
+        wallet_view.back_button.click()
+        balance_after_receiving_tx = float(wallet_view.get_asset_amount_by_name('ETHro'))
+        expected_balance = self.network_api.get_rounded_balance(balance_after_receiving_tx, transaction_amount)
+        if balance_after_receiving_tx != expected_balance:
+            self.driver.fail('New account balance %s does not match expected %s after receiving a transaction' % (
+                balance_after_receiving_tx, transaction_amount))
+
+        wallet_view.just_fyi("Sending eth from new account to main account")
+        updated_balance = self.network_api.get_balance(status_account_address)
+        wallet_view.send_transaction_button.click()
+        send_transaction.amount_edit_box.click()
+        transaction_amount_1 = round(float(transaction_amount) * 0.05, 11)
+        send_transaction.amount_edit_box.set_value(str(transaction_amount_1))
+        send_transaction.confirm()
+        send_transaction.chose_recipient_button.click()
+        send_transaction.accounts_button.click()
+        send_transaction.element_by_text('Status account').click()
+        send_transaction.sign_transaction_button.click()
+        send_transaction.sign_transaction(keycard=True)
+        send_transaction.back_button.click()
+        sub_account_address = wallet_view.get_wallet_address(account_name)[2:]
+        self.network_api.wait_for_confirmation_of_transaction(sub_account_address, transaction_amount_1)
+        transactions_view = wallet_view.transaction_history_button.click()
+
+        wallet_view.just_fyi("Check transactions on subaccount")
+        transactions_view.transactions_table.find_transaction(amount=transaction_amount)
+        transactions_view.transactions_table.find_transaction(amount=format(float(transaction_amount_1),'.11f').rstrip('0'))
+        self.network_api.verify_balance_is_updated(updated_balance, status_account_address)
+
+        wallet_view.just_fyi("Verify total ETH on main wallet view")
+        self.network_api.wait_for_confirmation_of_transaction(status_account_address, transaction_amount_1, 3)
+        self.network_api.verify_balance_is_updated((updated_balance + transaction_amount_1), status_account_address)
+        send_transaction.back_button.click()
+        balance_of_sub_account = float(self.network_api.get_balance(sub_account_address)) / 1000000000000000000
+        balance_of_status_account = float(self.network_api.get_balance(status_account_address)) / 1000000000000000000
+        total_eth_from_two_accounts = float(wallet_view.get_asset_amount_by_name('ETHro'))
+        expected_balance = self.network_api.get_rounded_balance(total_eth_from_two_accounts,
+                                                                (balance_of_status_account + balance_of_sub_account))
+
+        if total_eth_from_two_accounts != expected_balance:
+            self.driver.fail('Total wallet balance %s != of Status account (%s) + SubAccount (%s)' % (
+                total_eth_from_two_accounts, balance_of_status_account, balance_of_sub_account))

--- a/test/appium/views/keycard_view.py
+++ b/test/appium/views/keycard_view.py
@@ -1,4 +1,4 @@
-from views.base_element import BaseButton, BaseText, BaseElement, BaseEditBox
+from views.base_element import BaseButton, BaseText, BaseEditBox
 from views.base_view import BaseView
 
 

--- a/test/appium/views/transactions_view.py
+++ b/test/appium/views/transactions_view.py
@@ -32,10 +32,10 @@ class TransactionTable(BaseElement):
             super(TransactionTable.TransactionElement, self).__init__(driver)
 
         @staticmethod
-        def by_amount(driver, amount: str):
+        def by_amount(driver, amount: str, asset):
             element = TransactionTable.TransactionElement(driver)
             element.locator = element.Locator.xpath_selector(
-                "(//android.widget.TextView[contains(@text,'%s ETH')])" % amount)
+                "(//android.widget.TextView[contains(@text,'%s %s')])" % (amount, asset))
             return element
 
         @staticmethod
@@ -84,11 +84,11 @@ class TransactionTable(BaseElement):
     def transaction_by_index(self, index: int):
         return self.TransactionElement.by_index(self.driver, index=index)
 
-    def transaction_by_amount(self, amount: str):
-        return self.TransactionElement.by_amount(self.driver, amount=amount.replace(',', '.'))
+    def transaction_by_amount(self, amount: str, asset):
+        return self.TransactionElement.by_amount(self.driver, amount=amount.replace(',', '.'), asset=asset)
 
-    def find_transaction(self, amount: str) -> TransactionElement:
-        element = self.transaction_by_amount(amount=amount)
+    def find_transaction(self, amount: str, asset='ETH') -> TransactionElement:
+        element = self.transaction_by_amount(amount=amount, asset=asset)
         for i in range(9):
             try:
                 element.find_element()
@@ -96,7 +96,7 @@ class TransactionTable(BaseElement):
             except NoSuchElementException:
                 time.sleep(5)
                 self.refresh_transactions()
-        self.driver.fail('Transaction was not found on Wallet/Transaction screen')
+        self.driver.fail('Transaction %s %s was not found on Wallet/Transaction screen' %(amount, asset))
 
     def refresh_transactions(self):
         self.driver.swipe(500, 500, 500, 1000)

--- a/test/appium/views/wallet_view.py
+++ b/test/appium/views/wallet_view.py
@@ -154,7 +154,7 @@ class AssetCheckBox(BaseButton):
         self.locator = self.Locator.xpath_selector("//*[@text='%s']" % self.asset_name)
 
     def click(self):
-        self.scroll_to_element().click()
+        self.scroll_to_element(12).click()
         self.driver.info('Click %s asset checkbox' % self.asset_name)
 
 
@@ -542,7 +542,10 @@ class WalletView(BaseView):
             recent_recipient.click()
         if kwargs.get('sign_transaction', True):
             send_transaction_view.sign_transaction_button.click()
-            send_transaction_view.sign_transaction()
+            if kwargs.get('keycard', False):
+                send_transaction_view.sign_transaction(keycard=True)
+            else:
+                send_transaction_view.sign_transaction()
 
     def receive_transaction(self, **kwargs):
         self.receive_transaction_button.click()
@@ -586,9 +589,15 @@ class WalletView(BaseView):
     def get_account_by_name(self, account_name: str):
         return AccountElementButton(self.driver, account_name)
 
-    def add_account(self, account_name: str, password: str = common_password):
+    def add_account(self, account_name: str, password: str = common_password, keycard=False):
         self.add_account_button.click()
         self.generate_an_account_button.click()
-        self.enter_your_password_input.send_keys(password)
         self.account_name_input.send_keys(account_name)
-        self.add_account_generate_account_button.click()
+        if keycard:
+            from views.keycard_view import KeycardView
+            keycard_view = KeycardView(self.driver)
+            self.add_account_button.click()
+            keycard_view.enter_default_pin()
+        else:
+            self.enter_your_password_input.send_keys(password)
+            self.add_account_generate_account_button.click()

--- a/test/appium/views/web_views/status_test_dapp.py
+++ b/test/appium/views/web_views/status_test_dapp.py
@@ -34,6 +34,11 @@ class TransactionsButton(BaseButton):
             super(TransactionsButton.SignMessageButton, self).__init__(driver)
             self.locator = self.Locator.text_selector('Sign message')
 
+        def click(self):
+            from views.send_transaction_view import SigningPhraseText
+            self.click_until_presence_of_element(SigningPhraseText(self.driver))
+            return self.navigate()
+
         def navigate(self):
             from views.send_transaction_view import SendTransactionView
             return SendTransactionView(self.driver)
@@ -42,6 +47,11 @@ class TransactionsButton(BaseButton):
         def __init__(self, driver):
             super(TransactionsButton.SignTypedMessageButton, self).__init__(driver)
             self.locator = self.Locator.text_selector('Sign Typed Message')
+
+        def click(self):
+            from views.send_transaction_view import SigningPhraseText
+            self.click_until_presence_of_element(SigningPhraseText(self.driver))
+            return self.navigate()
 
         def navigate(self):
             from views.send_transaction_view import SendTransactionView


### PR DESCRIPTION
Based on https://github.com/status-im/status-react/pull/10606

- made test/appium/tests/atomic/chats/test_keycard_commands.py - 3 e2e (skipped due to #10632), test/appium/tests/atomic/transactions/test_keycard_dapps_transactions.py - 5 e2e, test/appium/tests/atomic/transactions/test_keycard_wallet.py - 4 e2e 

- updated testcases in test_dapps_transactions.py, test_wallet.py - include checks for transactions in transaction history, deleted tests C5420, C5418, C6236, C5416, C5325 as they are parts of existing tests now

- added checking of token transaction in transaction history

- edited corresponding testcases in testrail