### PR TITLE
nix: move jetify-ing Java files to patchNodeModules

### DIFF
--- a/nix/mobile/android/release.nix
+++ b/nix/mobile/android/release.nix
@@ -107,9 +107,6 @@ in stdenv.mkDerivation rec {
 
     # Patch build.gradle to use local repo
     ${patchMavenSources} ./android/build.gradle ${deps.gradle}
-
-    # Patch dependencies which are not yet ported to AndroidX
-    ${nodejs}/bin/node ./node_modules/jetifier/bin/jetify
   '';
   secretPhase = optionalString (secretsFile != "") ''
     source "${secretsFile}"

--- a/nix/tools/patchNodeModules.nix
+++ b/nix/tools/patchNodeModules.nix
@@ -2,7 +2,7 @@
 # result of yarn2nix and symlinking what is fine, and 
 # copying and modifying what needs to be adjusted.
 
-{ stdenv, lib, pkgs, patchMavenSources, coreutils }:
+{ stdenv, patchMavenSources, nodejs }:
 
 nodePkgs: mavenPkgs:
 
@@ -31,8 +31,8 @@ stdenv.mkDerivation {
       if [[ -L ./node_modules/$moduleName ]]; then
         unlink ./node_modules/$moduleName
         cp -r ${nodePkgs}/node_modules/$moduleName ./node_modules/
+        chmod u+w -R ./node_modules/$moduleName
       fi
-      chmod +w -R ./node_modules/$relativeToNode
       ${patchMavenSources} $modBuildGradle '${mavenPkgs}'
     done
 
@@ -50,6 +50,9 @@ stdenv.mkDerivation {
     substituteInPlace ./node_modules/react-native/react.gradle --replace \
         'targetName.toLowerCase().contains("release")' \
         '!targetName.toLowerCase().contains("debug")'
+
+    # Patch Java files in modules which are not yet ported to AndroidX
+    ${nodejs}/bin/node ./node_modules/jetifier/bin/jetify
   '';
 
   installPhase = ''


### PR DESCRIPTION
This fixes the frequent re-copying of `node_modules` due to Metro running [jetifier](https://github.com/mikehardy/jetifier) to patch Java files in `node_modules` that haven't been ported to import from new Androidx path.

This should limit this happening:
```
Modifications detected in 16 files:
- node_modules/react-native-status-keycard/android/src/main/java/im/status/ethereum/keycard/SmartCard.java
- node_modules/react-native-status-keycard/android/src/main/java/im/status/ethereum/keycard/SmartCardSecrets.java
- node_modules/react-native-keychain/android/src/main/java/com/oblador/keychain/PrefsStorage.java
- node_modules/react-native-keychain/android/src/main/java/com/oblador/keychain/KeychainModule.java
- node_modules/react-native-keychain/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageKeystoreAESCBC.java
- node_modules/react-native-keychain/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorage.java
- node_modules/react-native-keychain/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageFacebookConceal.java
```