### PR TITLE
nix: fix nix-cache builds using wrong status-go targets

### DIFF
--- a/ci/Jenkinsfile.nix-cache
+++ b/ci/Jenkinsfile.nix-cache
@@ -36,7 +36,7 @@ pipeline {
     }
     stage('Build status-go') {
       steps { script {
-        def platforms = ['android', 'desktop', 'ios']
+        def platforms = ['mobile.android', 'mobile.ios', 'desktop']
         if (uname != "Darwin") {
           platforms.removeAll { it == "ios" }
         }
@@ -65,7 +65,7 @@ pipeline {
       steps { script {
         /* build/fetch things required to build jsbundle and android */
         nix.build(
-          attr: 'targets.mobile.android.buildInputs',
+          attr: 'targets.mobile.android.release.buildInputs',
           sandbox: false,
           pure: false,
           link: false


### PR DESCRIPTION
Due to all the Nix refactors I've done `nix-cache` builds have been fucked.

Builds:
* https://ci.status.im/job/status-react/job/nix-cache/job/linux/
* https://ci.status.im/job/status-react/job/nix-cache/job/macos/