### PR TITLE
Fix e2e by rerun in a case of TLS failure in emulator

### DIFF
--- a/test/appium/support/api/network_api.py
+++ b/test/appium/support/api/network_api.py
@@ -23,7 +23,6 @@ class NetworkApi(object):
         self.api_key = environ.get('ETHERSCAN_API_KEY')
 
     def log(self, text: str):
-
         tests.test_suite_data.current_test.testruns[-1].steps.append(text)
         logging.info(text)
 
@@ -51,6 +50,7 @@ class NetworkApi(object):
             try:
                 return int(requests.request('GET', method, headers=self.headers).json()["result"])
             except ValueError:
+                time.sleep(5)
                 pass
 
     def get_latest_block_number(self) -> int:

--- a/test/appium/support/test_rerun.py
+++ b/test/appium/support/test_rerun.py
@@ -21,7 +21,8 @@ RERUN_ERRORS = [
     "[Errno 110] Connection timed out",
     "replacement transaction underpriced",
     "StaleElementReferenceException",
-    "No System TLS"
+    "'GetStartedButton' is not found on the screen",
+    "'AccessKeyButton' is not found on the screen"
 ]
 
 

--- a/test/appium/views/web_views/base_web_view.py
+++ b/test/appium/views/web_views/base_web_view.py
@@ -61,7 +61,7 @@ class WebViewMenuButton(BaseButton):
         self.locator = self.Locator.accessibility_id('chat-menu-button')
 
 
-class URLEditBoxLockIcon(BaseEditBox):
+class URLEditBoxLockIcon(BaseButton):
 
     def __init__(self, driver):
         super(URLEditBoxLockIcon, self).__init__(driver)


### PR DESCRIPTION
If test fails at start because emulator failed to launch Status we rerun such test (based on whether Get Started or Access Key button are visible). 