### PR TITLE
nix: always use patched node_modules in shells

### DIFF
--- a/nix/mobile/android/default.nix
+++ b/nix/mobile/android/default.nix
@@ -1,5 +1,5 @@
 { lib, pkgs, deps, callPackage, mkShell
-, status-go, androidPkgs, androidShell, patchNodeModules }:
+, status-go, androidPkgs, androidShell }:
 
 let
   # Import a jsbundle compiled out of clojure codebase
@@ -8,18 +8,14 @@ let
   # Import a patched version of watchman (important for sandboxed builds on macOS)
   watchmanFactory = callPackage ./watchman.nix { };
 
-  # Some node_modules have build.gradle files that reference remote repos.
-  # This patches them to reference local repos only
-  nodeJsModules = patchNodeModules deps.nodejs deps.gradle;
-
   # TARGETS
   release = callPackage ./release.nix {
-    inherit jsbundle status-go watchmanFactory nodeJsModules;
+    inherit jsbundle status-go watchmanFactory;
   };
 
 in {
   # TARGETS
-  inherit release jsbundle nodeJsModules;
+  inherit release jsbundle;
 
   shell = mkShell {
     buildInputs = with pkgs; [
@@ -50,7 +46,7 @@ in {
         ln -sf ./mobile/js_files/* ./
 
         # check if node modules changed and if so install them
-        $STATUS_REACT_HOME/nix/scripts/node_modules.sh ${nodeJsModules}
+        $STATUS_REACT_HOME/nix/scripts/node_modules.sh ${deps.nodejs-patched}
       }
     '';
   };

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -24,6 +24,7 @@ in {
     clojure = callPackage ./deps/clojure { };
     gradle = callPackage ./deps/gradle { };
     nodejs = callPackage ./deps/nodejs { };
+    nodejs-patched = callPackage ./deps/nodejs-patched { };
     react-native = callPackage ./deps/react-native { };
   };
 

--- a/nix/shells.nix
+++ b/nix/shells.nix
@@ -49,7 +49,7 @@ let
     buildInputs = [ pkgs.androidPkgs ];
     shellHook = ''
       export STATUS_REACT_HOME=$(git rev-parse --show-toplevel)
-      $STATUS_REACT_HOME/nix/scripts/node_modules.sh ${pkgs.deps.nodejs}
+      $STATUS_REACT_HOME/nix/scripts/node_modules.sh ${pkgs.deps.nodejs-patched}
     '';
   };
 


### PR DESCRIPTION
Becuase `clojure` shell used unpatched `node_modules` while the `android` shell used the patched version when starting these shells the `node_modules` would keep being switched between them wasting time:
```
 > make shell TARGET=android
Configuring Nix shell for target 'android'...
Yarn modules changed, copying new version over
Copying node_modules from Nix store:
 - /nix/store/29hr20vcd7alkyb0hxrknrrd26121x8h-status-react-node-deps-0.14.0-patched
```
and:
```
 > make shell TARGET=clojure
Configuring Nix shell for target 'clojure'...
Yarn modules changed, copying new version over
Copying node_modules from Nix store:
 - /nix/store/3kzlca8gqgk0ii662mxf09c10hbl77sv-status-react-node-deps-0.14.0
```

Changes:
- Move `nix/tools/patchNodeModules.nix` to `nix/deps/nodejs-patched`
- Make `nix/deps/nodejs-patched` a normal derivation without extra arguments
- Use `deps.nodejs-patched` in `nix/mobile/android` shell
- Use `deps.nodejs-patched` in `nix/shells.nix` node shell
- Use `with pkgs` to reduce arguments in `nix/mobile/android/release.nix`