### PR TITLE
nix: fix ios shell to use patched nodejs modules

### DIFF
--- a/nix/mobile/ios/default.nix
+++ b/nix/mobile/ios/default.nix
@@ -30,7 +30,7 @@ in {
         ln -sf ./mobile/js_files/* ./
 
         # check if node modules changed and if so install them
-        ./nix/scripts/node_modules.sh "${deps.nodejs}"
+        ./nix/scripts/node_modules.sh "${deps.nodejs-patched}"
       }
     '';
   };


### PR DESCRIPTION
This was missed in #10671 (604362958b5aa8d8ffdda0a0d8356d6b4b0d513f).