### PR TITLE
Flaky tests plugin and another capability

### DIFF
--- a/test/appium/requirements.txt
+++ b/test/appium/requirements.txt
@@ -14,6 +14,7 @@ eth-utils==1.0.3
 ethereum==2.3.0
 execnet==1.4.1
 future==0.16.0
+flaky
 idna==2.5
 kiwisolver==1.0.1
 lxml==4.3.1

--- a/test/appium/requirements.txt
+++ b/test/appium/requirements.txt
@@ -43,7 +43,7 @@ scrypt==0.8.6
 selenium==3.14.1
 six==1.10.0
 toolz==0.9.0
-urllib3==1.24.2
+urllib3==1.24.3
 yarl==0.12.0
 zbarlight==2.3
 docker

--- a/test/appium/support/test_rerun.py
+++ b/test/appium/support/test_rerun.py
@@ -9,7 +9,7 @@ RERUN_ERRORS = [
     'Unexpected server error',
     '504 Gateway Time-out',
     'Internal Server Error',
-    'Invalid message: ERROR Internal Server Error',
+    'failed to start the browser or device',
     'ERROR The test with session id'
     "Message: 'CreateMultiaccountButton' is not found on screen",
     "503 Service Unavailable",

--- a/test/appium/tests/atomic/account_management/test_profile.py
+++ b/test/appium/tests/atomic/account_management/test_profile.py
@@ -6,7 +6,6 @@ from tests import marks, bootnode_address, mailserver_address, camera_access_err
 from tests.base_test_case import SingleDeviceTestCase, MultipleDeviceTestCase
 from tests.users import transaction_senders, basic_user, ens_user
 from views.sign_in_view import SignInView
-from tests import pytest_config_global
 
 
 @marks.all
@@ -538,6 +537,7 @@ class TestProfileSingleDevice(SingleDeviceTestCase):
 
     @marks.testrail_id(5766)
     @marks.medium
+    @marks.flaky
     def test_use_pinned_mailserver(self):
         sign_in_view = SignInView(self.driver)
         home_view = sign_in_view.create_user()
@@ -664,6 +664,7 @@ class TestProfileMultipleDevice(MultipleDeviceTestCase):
 
     @marks.testrail_id(5436)
     @marks.medium
+    @marks.flaky
     def test_add_switch_delete_custom_mailserver(self):
         self.create_drivers(2)
         sign_in_1, sign_in_2 = SignInView(self.drivers[0]), SignInView(self.drivers[1])
@@ -743,6 +744,7 @@ class TestProfileMultipleDevice(MultipleDeviceTestCase):
 
     @marks.testrail_id(5767)
     @marks.medium
+    @marks.flaky
     def test_can_not_connect_to_mailserver(self):
         self.create_drivers(2)
         sign_in_1, sign_in_2 = SignInView(self.drivers[0]), SignInView(self.drivers[1])

--- a/test/appium/tests/base_test_case.py
+++ b/test/appium/tests/base_test_case.py
@@ -66,6 +66,7 @@ class AbstractTestCase:
         desired_caps['commandTimeout'] = 600
         desired_caps['idleTimeout'] = 1000
         desired_caps['unicodeKeyboard'] = True
+        desired_caps['resetKeyboard'] = True
         desired_caps['automationName'] = 'UiAutomator2'
         desired_caps['setWebContentDebuggingEnabled'] = True
         desired_caps['ignoreUnimportantViews'] = False
@@ -94,6 +95,7 @@ class AbstractTestCase:
         desired_caps['newCommandTimeout'] = 600
         desired_caps['fullReset'] = False
         desired_caps['unicodeKeyboard'] = True
+        desired_caps['resetKeyboard'] = True
         desired_caps['automationName'] = 'UiAutomator2'
         desired_caps['setWebContentDebuggingEnabled'] = True
         return desired_caps

--- a/test/appium/tests/marks.py
+++ b/test/appium/tests/marks.py
@@ -9,6 +9,7 @@ low = pytest.mark.low
 
 account = pytest.mark.account
 upgrade = pytest.mark.upgrade
+flaky = pytest.mark.flaky
 api = pytest.mark.api
 all = pytest.mark.all
 chat = pytest.mark.chat

--- a/test/appium/views/base_view.py
+++ b/test/appium/views/base_view.py
@@ -641,6 +641,7 @@ class BaseView(object):
         return user_data
 
     def share_via_messenger(self):
+        self.element_by_text_part("Direct share").wait_for_element()
         self.element_by_text('Messages').click()
         self.element_by_text('New message').click()
         self.send_as_keyevent('+0100100101')

--- a/test/appium/views/profile_view.py
+++ b/test/appium/views/profile_view.py
@@ -674,6 +674,7 @@ class ProfileView(BaseView):
         self.plus_button.click_until_presence_of_element(self.ropsten_chain_button)
         self.custom_network_url.send_keys('https://ropsten.infura.io/v3/f315575765b14720b32382a61a89341a')
         self.specify_name_input.send_keys('custom_ropsten')
+        self.ropsten_chain_button.scroll_to_element()
         self.ropsten_chain_button.click()
         self.ropsten_chain_button.click()
         self.save_button.click()


### PR DESCRIPTION
* Added pytest plugin for fluky tests. From doc: "Ideally, tests reliably pass or fail, but sometimes test fixtures must rely on components that aren't 100% reliable. With flaky, instead of removing those tests or marking them to @skip, they can be automatically retried." Which is our case in some tests which may fail due to emulator side unexpected behavior. By default retry happens one time (if not specified in max_runs=[int] attribute) on test marked as @marks.flaky. 
Report is not affected. If test marked as flaky and it fails with persistent error from rerun_errors then test will run 2^2 times
* Added new capability "resetKeyboard" which supposedly have to disable keyboard (which may appear in like 2 of 100 test runs)