### PR TITLE
nix: don't use gradle to patch node modules

### DIFF
--- a/nix/deps/nodejs-patched/default.nix
+++ b/nix/deps/nodejs-patched/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation {
         cp -r ${deps.nodejs}/node_modules/$moduleName ./node_modules/
         chmod u+w -R ./node_modules/$moduleName
       fi
-      ${patchMavenSources} $modBuildGradle '${deps.gradle}'
+      ${patchMavenSources} $modBuildGradle
     done
 
     patchShebangs ./node_modules

--- a/nix/mobile/android/release.nix
+++ b/nix/mobile/android/release.nix
@@ -105,7 +105,7 @@ in stdenv.mkDerivation rec {
     chmod +w -R ./node_modules
 
     # Patch build.gradle to use local repo
-    ${patchMavenSources} ./android/build.gradle ${deps.gradle}
+    ${patchMavenSources} ./android/build.gradle
   '';
   secretPhase = optionalString (secretsFile != "") ''
     source "${secretsFile}"

--- a/nix/pkgs/patch-maven-srcs/default.nix
+++ b/nix/pkgs/patch-maven-srcs/default.nix
@@ -14,13 +14,9 @@ writeScript "patch-maven-srcs" (''
   }
 
   gradleFile="$1"
-  derivation="$2"
 
   # Some of those find something, some don't, that's fine.
   patchMavenSource "$gradleFile" 'mavenCentral()' 'mavenLocal()'
   patchMavenSource "$gradleFile" 'google()'       'mavenLocal()'
   patchMavenSource "$gradleFile" 'jcenter()'      'mavenLocal()'
-  patchMavenSource "$gradleFile" 'https://maven.google.com' "$derivation"
-  patchMavenSource "$gradleFile" 'https://www.jitpack.io'   "$derivation"
-  patchMavenSource "$gradleFile" 'https://jitpack.io'       "$derivation"
 '')


### PR DESCRIPTION
Before in order to create `deps.nodejs-patched` the `deps.gradle` would also have to be downloaded in order to patch `build.gradle` files with path to the Gradle dependencies in Nix store.

It turns out just replacting lines referencing `mavenCentral()`, `google()`, and `jcenter()` in `repositories` block is enough to make Gradle properly fetch dependencies from repo provided via the command line `-Dmaven.repo.local='${deps.gradle}` option.

This should reduce the required size for shells that don't use Gradle.