### PR TITLE
e2e: fix for nightly 16/06

### DIFF
--- a/test/appium/tests/atomic/account_management/test_profile.py
+++ b/test/appium/tests/atomic/account_management/test_profile.py
@@ -63,7 +63,7 @@ class TestProfileSingleDevice(SingleDeviceTestCase):
     def test_mobile_data_usage_popup_stop_syncing(self):
         sign_in_view = SignInView(self.driver)
         sign_in_view.create_user()
-        offline_banner_text = "Offline, waiting for Wi-Fi"
+        offline_banner_text = "No Wi-fi, message syncing disabled."
 
         sign_in_view.just_fyi("Enable mobile network to see popup and stop syncing")
         sign_in_view.toggle_mobile_data()
@@ -71,7 +71,7 @@ class TestProfileSingleDevice(SingleDeviceTestCase):
         if not sign_in_view.wait_for_element_starts_with_text(offline_banner_text, 60):
             self.driver.fail('No popup about offline history is shown')
         sign_in_view.element_by_text_part(offline_banner_text).click()
-        for item in "Offline, waiting for Wi-Fi", "Start syncing", "Go to settings":
+        for item in offline_banner_text, "Start syncing", "Go to settings":
             if not sign_in_view.element_by_text(item).is_element_displayed():
                 self.driver.fail("%s is not shown" % item)
 

--- a/test/appium/tests/atomic/chats/test_chats_management.py
+++ b/test/appium/tests/atomic/chats/test_chats_management.py
@@ -355,8 +355,12 @@ class TestChatManagement(SingleDeviceTestCase):
         browsing_view = daap_view.open_url('dap.ps')
         browsing_view.share_url_button.click()
         browsing_view.share_via_messenger()
-        if not chat_view.element_by_text_part('https://join.status.im/b/https://dap.ps').is_element_present():
-             self.errors.append("Can't share link to URL")
+        expeceted_text_1 = 'https://join.status.im/b/https://dap.ps'
+        expeceted_text_2 = 'https://join.status.im/b/http://dap.ps'
+
+        if not (chat_view.element_by_text_part(expeceted_text_1).is_element_present() or
+                chat_view.element_by_text_part(expeceted_text_2).is_element_present()):
+            self.errors.append("Can't share link to URL")
 
         self.errors.verify_no_errors()
 

--- a/test/appium/tests/atomic/chats/test_commands.py
+++ b/test/appium/tests/atomic/chats/test_commands.py
@@ -239,12 +239,9 @@ class TestCommandsMultipleDevices(MultipleDeviceTestCase):
         chat_2 = home_2.get_chat(sender['username']).click()
         chat_2_receiver_message = chat_2.chat_element_by_text('↓ Incoming transaction')
         chat_2_receiver_message.decline_transaction.click()
-        chat_1.element_by_text_part('Transaction declined').wait_for_element(20)
-        for status in chat_2_receiver_message.transaction_status.text, chat_1_sender_message.transaction_status.text:
-            if status != 'Transaction declined':
-                self.errors.append('Wrong state is shown: "Transaction declined" is expected, in fact'
-                                   ' %s ' % status)
-
+        for message in chat_1_sender_message, chat_2_receiver_message:
+            if not message.contains_text('Transaction declined' ,20):
+                self.errors.append('Message status is not updated to  "Transaction declined"')
         home_1.just_fyi('Decline transaction request and check that state is changed')
         chat_1.commands_button.click()
         request_amount = chat_1.get_unique_amount()

--- a/test/appium/tests/atomic/transactions/test_wallet.py
+++ b/test/appium/tests/atomic/transactions/test_wallet.py
@@ -484,6 +484,7 @@ class TestTransactionWalletSingleDevice(SingleDeviceTestCase):
 
         wallet_view.just_fyi('change account name/color and verified applied changes')
         account_name = ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(10))
+        wallet_view.account_name_input.clear()
         wallet_view.account_name_input.send_keys(account_name)
         wallet_view.account_color_button.select_color_by_position(1)
         wallet_view.apply_settings_button.click()
@@ -629,7 +630,7 @@ class TestTransactionWalletSingleDevice(SingleDeviceTestCase):
         send_transaction.select_asset_button.click_until_presence_of_element(token_element)
         if not token_element.is_element_displayed():
             self.errors.append('Custom token is not shown on Send Transaction view')
-        send_transaction.cancel_button.click()
+        send_transaction.cancel_button.click_until_absense_of_element(token_element)
 
         #TODO: workaroud for issue 10699
         profile = wallet_view.profile_button.click()


### PR DESCRIPTION
- added two possible URLs for `test_share_user_profile_url_public_chat` (HTTP and HTTPS)
- added separate waiting for transaction status change in `test_decline_transactions_in_1_1_chat `
- added clearing of text input in `test_can_change_account_settings `
- replaced click to click_until_absense_of_element in `test_can_change_account_settings` (sometimes doesn't work from 1 time)