### PR TITLE
disable play store release

### DIFF
--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -103,8 +103,6 @@ pipeline {
               }
               /* build type specific */
               switch (btype) {
-                case 'release':
-                  android.uploadToPlayStore(); break;
                 case 'nightly':
                   env.DIAWI_URL = android.uploadToDiawi(); break;
                 case 'e2e':


### PR DESCRIPTION
Because it apparently updated Play Store metadata in:
https://ci.status.im/job/status-react/job/combined/job/mobile-android/12834
Which caused a scheduled release to go into limbo.

I will try turning this back on after `1.4.0` is out and see if I can make it behave by using some or all of these: `release_status`, `skip_upload_metadata`, `skip_upload_changelogs`, `skip_upload_images`, or `skip_upload_screenshots`
https://docs.fastlane.tools/actions/upload_to_play_store/