### PR TITLE
nix: upgrade xcode 11.4.1 to 11.5

### DIFF
--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -1,7 +1,7 @@
 library 'status-react-jenkins@v1.1.7'
 
 pipeline {
-  agent { label 'macos-xcode-11.4.1' }
+  agent { label 'macos-xcode-11.5' }
 
   parameters {
     string(

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -1,7 +1,7 @@
 library 'status-react-jenkins@v1.1.7'
 
 pipeline {
-  agent { label 'macos-xcode-11.4.1' }
+  agent { label 'macos-xcode-11.5' }
 
   parameters {
     string(

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -32,7 +32,7 @@ in {
   gradlePropParser = callPackage ./tools/gradlePropParser.nix { };
 
   # Package version adjustments
-  xcodeWrapper = super.xcodeenv.composeXcodeWrapper { version = "11.4.1"; };
+  xcodeWrapper = super.xcodeenv.composeXcodeWrapper { version = "11.5"; };
   openjdk = super.pkgs.openjdk8_headless;
   nodejs = super.pkgs.nodejs-12_x;
 


### PR DESCRIPTION
XCode `11.5` has been out for over a month so it's probably unlikely we'll get `11.5.1`. It's about time.

Related: https://github.com/status-im/infra-ci/issues/20

Also checking if this might help me with MacOS signing issues I'm having in https://github.com/status-im/nim-status-client/issues/335.