### PR TITLE
nix: stop ndk-bundle from being cached

### DIFF
--- a/ci/Jenkinsfile.nix-cache
+++ b/ci/Jenkinsfile.nix-cache
@@ -87,7 +87,10 @@ pipeline {
         sshagent(credentials: ['nix-cache-ssh']) {
           nix.shell("""
               find /nix/store/ -mindepth 1 -maxdepth 1 -type d \
-                -not -name '*.links' -and -not -name '*-status-react-*' \
+                -not -name '*.links' -and \
+                -not -name '*-ndk-bundle-*' -and \
+                -not -name '*-status-react-*' \
+                | tee find.log \
                 | xargs nix-copy-closure -v --to ${NIX_CACHE_USER}@${NIX_CACHE_HOST}
             """,
             pure: false


### PR DESCRIPTION
This should in theory fix the issue with downloading the nkd-bundle from our own Nix cache:
```
copying path '/nix/store/64g5wharwjj040rg1v8jnc5qhv1hkgds-ndk-bundle-21.0.6113669' from 'https://nix-cache.status.im'...
warning: unable to download 'https://nix-cache.status.im/nar/64g5wharwjj040rg1v8jnc5qhv1hkgds.nar': HTTP error 200 (curl error: Stream error in the HTTP/2 framing layer); retrying in 314 ms
non-zero padding
```
The idea is to stop uploading Android NDK to our Nix cache and then purge it from the cache so that every time people have to download it they will get it directly from Google servers.

For more details see: https://github.com/status-im/infra-ci/issues/17