### PR TITLE
Use new user instead recovered because message may not be received quick

### DIFF
--- a/test/appium/tests/atomic/chats/test_commands.py
+++ b/test/appium/tests/atomic/chats/test_commands.py
@@ -60,28 +60,28 @@ class TestCommandsMultipleDevices(MultipleDeviceTestCase):
     @marks.testrail_id(6253)
     @marks.critical
     def test_send_eth_in_1_1_chat(self):
-        recipient = transaction_recipients['A']
         sender = transaction_senders['A']
         self.create_drivers(2)
         device_1, device_2 = SignInView(self.drivers[0]), SignInView(self.drivers[1])
         home_1 = device_1.recover_access(passphrase=sender['passphrase'])
-        home_2 = device_2.recover_access(passphrase=recipient['passphrase'])
+        home_2 = device_2.create_user()
+        recipient_public_key, recipient_username = home_2.get_public_key_and_username(return_username=True)
         wallet_1, wallet_2 = home_1.wallet_button.click(), home_2.wallet_button.click()
         for wallet in (wallet_1, wallet_2):
             wallet.set_up_wallet()
             wallet.home_button.click()
 
-        chat_1 = home_1.add_contact(recipient['public_key'])
+        chat_1 = home_1.add_contact(recipient_public_key)
         amount = chat_1.get_unique_amount()
 
         home_1.just_fyi('Send %s ETH in 1-1 chat and check it for sender and receiver: Address requested' % amount)
         chat_1.commands_button.click()
         send_transaction = chat_1.send_command.click()
-        if not send_transaction.get_username_in_transaction_bottom_sheet_button(recipient['username']).is_element_displayed():
-            self.driver.fail('%s is not shown in "Send Transaction" bottom sheet' % recipient['username'])
-        send_transaction.get_username_in_transaction_bottom_sheet_button(recipient['username']).click()
+        if not send_transaction.get_username_in_transaction_bottom_sheet_button(recipient_username).is_element_displayed():
+            self.driver.fail('%s is not shown in "Send Transaction" bottom sheet' % recipient_username)
+        send_transaction.get_username_in_transaction_bottom_sheet_button(recipient_username).click()
         if send_transaction.scan_qr_code_button.is_element_displayed():
-            self.driver.fail('Recipient is editable in bootom sheet when send ETH from 1-1 chat')
+            self.driver.fail('Recipient is editable in bottom sheet when send ETH from 1-1 chat')
         send_transaction.amount_edit_box.set_value(amount)
         send_transaction.confirm()
         send_transaction.sign_transaction_button.click()

--- a/test/appium/views/base_element.py
+++ b/test/appium/views/base_element.py
@@ -285,6 +285,8 @@ class BaseButton(BaseElement):
                 return self.navigate()
             except (NoSuchElementException, TimeoutException):
                 counter += 1
+        else:
+            self.driver.info("%s element not found" % desired_element.name)
 
     def click_until_absense_of_element(self, desired_element, attempts=3):
         counter = 0


### PR DESCRIPTION
Fix test_send_eth_in_1_1_chat test with using recipient as new user instead recovered because when recover same user many times during the day message sennt to him may not be received immediately (like with new user).