### PR TITLE
disable different ID for PR builds on iOS

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -197,7 +197,8 @@ platform :ios do
   desc 'This lane builds a new adhoc build and leaves an .ipa that is ad-hoc signed (can be uploaded to diawi)'
   lane :pr do
     unlock_keychain_if_needed
-    build_ios_adhoc(pr_build: true)
+    # Temporarily switched to not build PR builds since they don't start
+    build_ios_adhoc(pr_build: false)
   end
 
   desc '`fastlane ios nightly` - makes a new nightly'


### PR DESCRIPTION
This was introduced in d91675116015abd0d168d8602ad24b0599c4290f and seems broken on some iOS devices. Fails with: `Unable to install "Status PR"`
![photo_2020-07-02_13 41 03](https://user-images.githubusercontent.com/2212681/86361836-af35fa80-bc74-11ea-95ea-3c4c9f63cee4.jpeg)
So I'm temporarily making PR builds use the same ID as release builds, as it was before.