### PR TITLE
nix: fix conditional that selects .env.e2e for ABI=x86 builds

### DIFF
--- a/nix/mobile/android/release.nix
+++ b/nix/mobile/android/release.nix
@@ -32,9 +32,9 @@ let
   name = "status-react-build-${baseName}";
 
   envFileName = 
-    if (elem buildType ["release" "nightly"]) then ".env.${buildType}"
-    else if androidAbiInclude == "x86"        then ".env.e2e" 
-    else if (elem buildType ["pr" "manual"])  then ".env.jenkins"
+    if androidAbiInclude == "x86"                  then ".env.e2e" 
+    else if (elem buildType ["release" "nightly"]) then ".env.${buildType}"
+    else if (elem buildType ["pr" "manual"])       then ".env.jenkins"
     else ".env";
 
   # There are only two types of Gradle build targets: pr and release


### PR DESCRIPTION
This should fix an issue where `nightly` type builds for end-to-end tests don't use `.env.e2e`.
The order of the if's was incorrect. When ABI is set to only `x86` using the `.env.e2e` should override build type.