### PR TITLE
Add e2e test for PN

### DIFF
--- a/test/appium/views/base_view.py
+++ b/test/appium/views/base_view.py
@@ -476,6 +476,10 @@ class BaseView(object):
         for _ in range(times):
             self.driver.press_keycode(4)
 
+    def click_system_home_button(self):
+        self.driver.info('Press system Home button')
+        self.driver.press_keycode(3)
+
     def cut_text(self):
         self.driver.info('Cut text')
         self.driver.press_keycode(277)
@@ -666,6 +670,10 @@ class BaseView(object):
         self.send_as_keyevent('+0100100101')
         self.confirm()
 
+    def click_upon_push_notification_by_text(self, text):
+        self.element_by_text_part(text).click()
+        return self.get_chat_view()
+
     def reconnect(self):
         connect_status = self.connection_status
         for i in range(3):
@@ -692,6 +700,11 @@ class BaseView(object):
 
     def asset_by_name(self, asset_name):
         return AssetButton(self.driver, asset_name)
+
+    def open_notification_bar(self):
+        action = TouchAction(self.driver)
+        for i in range(2):
+            action.press(None, 100, 10).move_to(None, 100, 600).perform()
 
     def toggle_airplane_mode(self):
         self.airplane_mode_button.click()

--- a/test/appium/views/profile_view.py
+++ b/test/appium/views/profile_view.py
@@ -458,6 +458,12 @@ class AboutButton(BaseButton):
         return self.navigate()
 
 
+class PrifileNotificationsButton(BaseButton):
+    def __init__(self, driver):
+        super().__init__(driver)
+        self.locator = self.Locator.accessibility_id("notifications-button")
+
+
 class RemovePictureButton(BaseButton):
     def __init__(self, driver):
         super().__init__(driver)
@@ -606,6 +612,7 @@ class ProfileView(BaseView):
         self.remove_picture_button = RemovePictureButton(self.driver)
         self.confirm_edit_button = ConfirmEditButton(self.driver)
         self.cross_icon = CrossIcon(self.driver)
+        self.profile_notifications_button = PrifileNotificationsButton(self.driver)
         self.advanced_button = AdvancedButton(self.driver)
         self.log_level_setting = LogLevelSetting(self.driver)
         self.debug_mode_toggle = DebugModeToggle(self.driver)

--- a/test/appium/views/sign_in_view.py
+++ b/test/appium/views/sign_in_view.py
@@ -165,6 +165,12 @@ class MaybeLaterButton(BaseButton):
         self.locator = self.Locator.accessibility_id("maybe-later")
 
 
+class EnableNotificationsButton(BaseButton):
+    def __init__(self, driver):
+        super(EnableNotificationsButton, self).__init__(driver)
+        self.locator = self.Locator.accessibility_id("enable-notifications")
+
+
 class AddExistingMultiaccountButton(RecoverAccessButton):
     def __init__(self, driver):
         super(AddExistingMultiaccountButton, self).__init__(driver)
@@ -236,6 +242,7 @@ class SignInView(BaseView):
         self.confirm_password_input = ConfirmPasswordInput(self.driver)
         self.create_password_input = CreatePasswordInput(self.driver)
         self.confirm_your_password_input = ConfirmYourPasswordInput(self.driver)
+        self.enable_notifications_button = EnableNotificationsButton(self.driver)
         self.maybe_later_button = MaybeLaterButton(self.driver)
         self.name_input = NameInput(self.driver)
         self.other_multiaccounts_button = OtherMultiAccountsButton(self.driver)
@@ -252,7 +259,7 @@ class SignInView(BaseView):
         self.pair_to_this_device_button = PairToThisDeviceButton(self.driver)
 
 
-    def create_user(self, password=common_password, keycard=False):
+    def create_user(self, password=common_password, keycard=False, enable_notifications=False):
         self.get_started_button.click()
         self.generate_key_button.click()
         self.next_button.click()
@@ -266,7 +273,10 @@ class SignInView(BaseView):
             self.confirm_your_password_input.set_value(password)
             self.next_button.click()
         self.maybe_later_button.wait_for_visibility_of_element(30)
-        self.maybe_later_button.click_until_presence_of_element(self.lets_go_button)
+        if enable_notifications:
+            self.enable_notifications_button.click()
+        else:
+            self.maybe_later_button.click_until_presence_of_element(self.lets_go_button)
         self.lets_go_button.click_until_absense_of_element(self.lets_go_button)
         self.profile_button.wait_for_visibility_of_element(30)
         return self.get_home_view()


### PR DESCRIPTION
Add e2e test to check PN received. 

Test case (and the test script here) covers:
a) PNs are present if Notifications enabled during onboarding
b) PN is present if Notifications enabled from Profile
c) PN for text message
d) PN for emoji message

Negative cases (when PN have not to appear like for blocked users) and PN for commands/image/sticker/reply message will be done later in next PRs.