### PR TITLE
[TESTS] fix 22.07.20 nightly failures

### DIFF
--- a/test/appium/support/api/network_api.py
+++ b/test/appium/support/api/network_api.py
@@ -106,7 +106,7 @@ class NetworkApi(object):
             if int(transaction['confirmations']) >= confirmations:
                 return
             time.sleep(10)
-        pytest.fail('Transaction with amount %s was not confirmed, address is %s' % (amount, address))
+        pytest.fail('Transaction with amount %s was not confirmed, address is %s, still has %s confirmations' % (amount, address, int(transaction['confirmations'])))
 
     def verify_balance_is_updated(self, initial_balance, recipient_address, wait_time=360):
         counter = 0

--- a/test/appium/tests/atomic/account_management/test_create_account.py
+++ b/test/appium/tests/atomic/account_management/test_create_account.py
@@ -90,21 +90,34 @@ class TestCreateAccount(SingleDeviceTestCase):
         sign_in.generate_key_button.click()
         sign_in.next_button.click()
         sign_in.next_button.click()
-        sign_in.create_password_input.set_value('12345')
-
         mismatch_error = "Passwords don't match"
+        cases = ['password is not confirmed', 'password is too short', "passwords don't match"]
+        error = "Can create multiaccount when"
 
+        sign_in.just_fyi('Checking case when %s' % cases[0])
+        sign_in.create_password_input.send_keys('123456')
         sign_in.next_button.click()
-        if sign_in.confirm_your_password_input.is_element_displayed():
-            self.errors.append('Next button is clickable when password is less then 6 symbols')
+        if sign_in.maybe_later_button.is_element_displayed(10):
+            self.driver.fail('%s  %s' % (error, cases[0]))
 
-        sign_in.create_password_input.set_value('123456')
+        sign_in.just_fyi('Checking case when %s'% cases[1])
+        sign_in.create_password_input.send_keys('123456')
+        [field.send_keys('123456') for field in (sign_in.create_password_input, sign_in.confirm_your_password_input)]
+        sign_in.confirm_your_password_input.delete_last_symbols(1)
+        sign_in.create_password_input.delete_last_symbols(1)
         sign_in.next_button.click()
-        sign_in.confirm_your_password_input.set_value('1234567')
-        sign_in.next_button.click()
+        if sign_in.maybe_later_button.is_element_displayed(10):
+            self.driver.fail('%s  %s' % (error, cases[1]))
 
+        sign_in.just_fyi("Checking case %s" % cases[2])
+        sign_in.create_password_input.send_keys('1234565')
+        sign_in.confirm_your_password_input.send_keys('1234567')
         if not sign_in.find_text_part(mismatch_error):
-            self.errors.append("'%s' is not shown")
+            self.errors.append("'%s' is not shown" % mismatch_error)
+        sign_in.next_button.click()
+        if sign_in.maybe_later_button.is_element_displayed(10):
+            self.driver.fail('%s  %s' % (error, cases[2]))
+
         self.errors.verify_no_errors()
 
     @marks.testrail_id(5414)

--- a/test/appium/tests/atomic/account_management/test_wallet_management.py
+++ b/test/appium/tests/atomic/account_management/test_wallet_management.py
@@ -143,7 +143,7 @@ class TestWalletManagement(SingleDeviceTestCase):
         assets = ['CryptoKitties', 'CryptoStrikers']
         for asset in assets:
             wallet.select_asset(asset)
-        wallet.accounts_status_account.click()
+        wallet.accounts_status_account.click_until_presence_of_element(wallet.collectibles_button)
         wallet.collectibles_button.click()
         for asset in assets:
             if not wallet.element_by_text(asset).is_element_displayed():

--- a/test/appium/tests/atomic/chats/test_commands.py
+++ b/test/appium/tests/atomic/chats/test_commands.py
@@ -120,7 +120,7 @@ class TestCommandsMultipleDevices(MultipleDeviceTestCase):
         time.sleep(40)
         send_message = chat_1_sender_message.sign_and_send.click()
         send_message.next_button.click()
-        send_message.sign_transaction()
+        send_message.sign_transaction(default_gas_price=False)
         updated_timestamp_sender = chat_1_sender_message.timestamp_message.text
         if updated_timestamp_sender == timestamp_sender:
             self.errors.append("Timestamp of message is not updated after signing transaction")
@@ -245,7 +245,6 @@ class TestCommandsMultipleDevices(MultipleDeviceTestCase):
                                    'sharing address')
 
         home_1.just_fyi('Decline transaction request and check that state is changed')
-        chat_1.commands_button.click()
         request_amount = chat_1.get_unique_amount()
         request_transaction = chat_1.request_command.click()
         request_transaction.amount_edit_box.set_value(request_amount)

--- a/test/appium/tests/atomic/chats/test_keycard_commands.py
+++ b/test/appium/tests/atomic/chats/test_keycard_commands.py
@@ -14,7 +14,7 @@ class TestCommandsMultipleDevices(MultipleDeviceTestCase):
     @marks.testrail_id(6293)
     @marks.critical
     def test_keycard_send_eth_in_1_1_chat(self):
-        sender = transaction_senders['A']
+        sender = transaction_senders['E']
         self.create_drivers(2)
         device_1, device_2 = SignInView(self.drivers[0]), SignInView(self.drivers[1])
         home_1 = device_1.recover_access(passphrase=sender['passphrase'], keycard=True)
@@ -74,7 +74,7 @@ class TestCommandsMultipleDevices(MultipleDeviceTestCase):
         time.sleep(40)
         send_message = chat_1_sender_message.sign_and_send.click()
         send_message.next_button.click()
-        send_message.sign_transaction(keycard=True)
+        send_message.sign_transaction(keycard=True, default_gas_price=False)
         if chat_1_sender_message.transaction_status.text != 'Pending':
             self.errors.append('Wrong state is shown for outgoing transaction: "Pending" is expected, in fact'
                                ' %s ' % chat_1_sender_message.transaction_status.text)
@@ -98,7 +98,7 @@ class TestCommandsMultipleDevices(MultipleDeviceTestCase):
     @marks.testrail_id(6294)
     @marks.critical
     def test_keycard_request_and_receive_stt_in_1_1_chat_offline(self):
-        sender = transaction_senders['C']
+        sender = transaction_senders['D']
         self.create_drivers(2)
         device_1, device_2 = SignInView(self.drivers[0]), SignInView(self.drivers[1])
 
@@ -154,11 +154,11 @@ class TestCommandsMultipleDevices(MultipleDeviceTestCase):
                                'in fact %s ' % chat_2_sender_message.transaction_status.text)
         send_message = chat_2_sender_message.sign_and_send.click()
         send_message.next_button.click()
-        send_message.sign_transaction(keycard=True)
+        send_message.sign_transaction(keycard=True, default_gas_price=False)
 
         home_2.just_fyi('Check that transaction message is updated with new status after offline')
         chat_2.toggle_airplane_mode()
-        self.network_api.wait_for_confirmation_of_transaction(sender['address'], amount, confirmations=15, token=True)
+        self.network_api.wait_for_confirmation_of_transaction(sender['address'], amount, token=True)
         chat_2.toggle_airplane_mode()
         chat_2.connection_status.wait_for_invisibility_of_element(60)
         if chat_2_sender_message.transaction_status.text != 'Confirmed':

--- a/test/appium/tests/atomic/transactions/test_wallet.py
+++ b/test/appium/tests/atomic/transactions/test_wallet.py
@@ -78,7 +78,7 @@ class TestTransactionWalletSingleDevice(SingleDeviceTestCase):
     @marks.testrail_id(6237)
     @marks.high
     def test_fetching_balance_after_offline(self):
-        sender = wallet_users['A']
+        sender = wallet_users['E']
         sign_in_view = SignInView(self.driver)
 
         sign_in_view.just_fyi('Restore account with funds offline')

--- a/test/appium/views/sign_in_view.py
+++ b/test/appium/views/sign_in_view.py
@@ -261,7 +261,7 @@ class SignInView(BaseView):
 
     def create_user(self, password=common_password, keycard=False, enable_notifications=False):
         self.get_started_button.click()
-        self.generate_key_button.click()
+        self.generate_key_button.click_until_presence_of_element(self.next_button)
         self.next_button.click()
         if keycard:
             keycard_flow = self.keycard_storage_button.click()

--- a/test/appium/views/wallet_view.py
+++ b/test/appium/views/wallet_view.py
@@ -544,22 +544,13 @@ class WalletView(BaseView):
         send_transaction_view.chose_recipient_button.click()
 
         recipient = kwargs.get('recipient')
-
-        if '0x' in recipient:
-            send_transaction_view.enter_recipient_address_button.click()
-            send_transaction_view.enter_recipient_address_input.set_value(recipient)
-            send_transaction_view.done_button.click()
-        else:
-            send_transaction_view.recent_recipients_button.click()
-            recent_recipient = send_transaction_view.element_by_text(recipient)
-            send_transaction_view.recent_recipients_button.click_until_presence_of_element(recent_recipient)
-            recent_recipient.click()
+        send_transaction_view.enter_recipient_address_button.click()
+        send_transaction_view.enter_recipient_address_input.set_value(recipient)
+        send_transaction_view.done_button.click()
         if kwargs.get('sign_transaction', True):
             send_transaction_view.sign_transaction_button.click()
-            if kwargs.get('keycard', False):
-                send_transaction_view.sign_transaction(keycard=True)
-            else:
-                send_transaction_view.sign_transaction()
+            send_transaction_view.sign_transaction(keycard=kwargs.get('keycard', False), default_gas_price=kwargs.get('default_gas_price', False))
+
 
     def receive_transaction(self, **kwargs):
         self.receive_transaction_button.click()


### PR DESCRIPTION
- changed transaction users for several tests
- rewrite send_transaction to use custom transaction by default
- added additional logging to method for getting transaction confirmations
- rewrite test for validation password
- several other minor fixes