### PR TITLE
nix: allow XCode versions 11.5 and higher

### DIFF
--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -32,9 +32,12 @@ in {
   gradlePropParser = callPackage ./tools/gradlePropParser.nix { };
 
   # Package version adjustments
-  xcodeWrapper = super.xcodeenv.composeXcodeWrapper { version = "11.5"; };
-  openjdk = super.pkgs.openjdk8_headless;
   nodejs = super.pkgs.nodejs-12_x;
+  openjdk = super.pkgs.openjdk8_headless;
+  xcodeWrapper = callPackage ./pkgs/xcodeenv/compose-xcodewrapper.nix { } {
+    version = "11.5";
+    allowHigher = true;
+  };
 
   # Android environement
   androidEnvCustom = callPackage ./pkgs/android-sdk { };

--- a/nix/pkgs/xcodeenv/compose-xcodewrapper.nix
+++ b/nix/pkgs/xcodeenv/compose-xcodewrapper.nix
@@ -1,0 +1,41 @@
+{ stdenv }:
+
+{ version ? "11.1"
+, allowHigher ? false
+, xcodeBaseDir ? "/Applications/Xcode.app" }:
+
+assert stdenv.isDarwin;
+
+stdenv.mkDerivation {
+  name = "xcode-wrapper-${version}${if allowHigher then "-plus" else ""}";
+  buildCommand = ''
+    mkdir -p $out/bin
+    cd $out/bin
+    ln -s /usr/bin/xcode-select
+    ln -s /usr/bin/security
+    ln -s /usr/bin/codesign
+    ln -s /usr/bin/xcrun
+    ln -s /usr/bin/plutil
+    ln -s /usr/bin/clang
+    ln -s /usr/bin/lipo
+    ln -s /usr/bin/file
+    ln -s /usr/bin/rev
+    ln -s "${xcodeBaseDir}/Contents/Developer/usr/bin/xcodebuild"
+    ln -s "${xcodeBaseDir}/Contents/Developer/Applications/Simulator.app/Contents/MacOS/Simulator"
+
+    cd ..
+    ln -s "${xcodeBaseDir}/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs"
+
+    # Check if we have the xcodebuild version that we want
+    currVer=$($out/bin/xcodebuild -version)
+    ${if allowHigher then ''
+    if [ -z "$(printf '%s\n' "${version}" "$currVer" | sort -V | head -n1)""" != "${version}" ]
+    '' else ''
+    if [ -z "$(echo $currVer | grep -x 'Xcode ${version}')" ]
+    ''}
+    then
+        echo "We require xcodebuild version${if allowHigher then " or higher" else ""}: ${version}"
+        exit 1
+    fi
+  '';
+}

--- a/nix/tools/utils.nix
+++ b/nix/tools/utils.nix
@@ -13,7 +13,7 @@ let
     xcode=0
     iPhoneSDK=0
     export PATH=${xcodeWrapper}/bin:$PATH
-    [[ "$(xcrun xcodebuild -version)" == "Xcode ${_xcodeVersion}"* ]] && xcode=1
+    xcrun xcodebuild -version && xcode=1
     [ $xcode -eq 1 ] && xcrun --sdk iphoneos --show-sdk-version > /dev/null && iPhoneSDK=1
   '';
   _xcodeToolReportScript = tool-name: ''[ $SELECTED -eq 0 ] && echo -e "${NC}- ${RED}[ ] ${tool-name}" || echo -e "${NC}- ${GREEN}[√] ${tool-name}${RED}"'';


### PR DESCRIPTION
This is kinda hacky, but is simple enough since the version check uses grep.

For details see:
https://github.com/status-im/nixpkgs/blob/status-mods/pkgs/development/mobile/xcodeenv/compose-xcodewrapper.nix