### PR TITLE
[TESTS] e2e false failures fixes

### DIFF
--- a/test/appium/tests/atomic/account_management/test_profile.py
+++ b/test/appium/tests/atomic/account_management/test_profile.py
@@ -365,15 +365,11 @@ class TestProfileSingleDevice(SingleDeviceTestCase):
         sign_in_view = SignInView(self.driver)
         home = sign_in_view.create_user()
         home.invite_friends_button.click()
-        # TODO: referrals temporal flow
-        home.element_by_text('Invite').click()
         home.share_via_messenger()
         home.find_text_part("Hey join me on Status: https://join.status.im/u/0x")
-        home.click_system_back_button(2)
+        home.click_system_back_button()
         home.plus_button.click()
         home.chats_menu_invite_friends_button.click()
-        # TODO: referrals temporal flow
-        home.element_by_text('Invite').click()
         home.share_via_messenger()
         home.find_text_part("Hey join me on Status: https://join.status.im/u/0x")
 
@@ -1098,8 +1094,9 @@ class TestProfileMultipleDevice(MultipleDeviceTestCase):
         dapp_view_1.element_by_text('Get started').click()
         dapp_view_1.ens_name.set_value(ens_user['ens'])
         expected_text = 'This user name is owned by you and connected with your chat key.'
-        if not dapp_view_1.wait_for_element_starts_with_text(expected_text):
-            sign_in_1.driver.fail("No %s is shown" % expected_text)
+        if not dapp_view_1.element_by_text_part(expected_text).is_element_displayed():
+            dapp_view_1.click_system_back_button()
+            dapp_view_1.wait_for_element_starts_with_text(expected_text)
         dapp_view_1.check_ens_name.click_until_presence_of_element(dapp_view_1.element_by_text('Ok, got it'))
         dapp_view_1.element_by_text('Ok, got it').click()
 

--- a/test/appium/tests/atomic/dapps_and_browsing/test_browsing.py
+++ b/test/appium/tests/atomic/dapps_and_browsing/test_browsing.py
@@ -132,8 +132,7 @@ class TestBrowsing(SingleDeviceTestCase):
         home_view = sign_in.create_user()
         daap_view = home_view.dapp_tab_button.click()
         browsing_view = daap_view.open_url('http://www.dvwa.co.uk')
-        browsing_view.url_edit_box_lock_icon.click()
-        browsing_view.find_full_text(connection_not_secure_text)
+        browsing_view.url_edit_box_lock_icon.click_until_presence_of_element(browsing_view.element_by_text(connection_not_secure_text))
 
     @marks.testrail_id(5402)
     @marks.high
@@ -143,14 +142,12 @@ class TestBrowsing(SingleDeviceTestCase):
         daap_view = home_view.dapp_tab_button.click()
         browsing_view = daap_view.open_url('https://www.bbc.com')
         browsing_view.wait_for_d_aap_to_load()
-        browsing_view.url_edit_box_lock_icon.click()
-        browsing_view.find_full_text(connection_is_secure_text)
+        browsing_view.url_edit_box_lock_icon.click_until_presence_of_element(browsing_view.element_by_text(connection_is_secure_text))
         browsing_view.cross_icon.click()
 
         browsing_view = daap_view.open_url('https://instant.airswap.io')
         browsing_view.wait_for_d_aap_to_load()
-        browsing_view.url_edit_box_lock_icon.click()
-        browsing_view.find_full_text(connection_is_secure_text)
+        browsing_view.url_edit_box_lock_icon.click_until_presence_of_element(browsing_view.element_by_text(connection_is_secure_text))
 
     @marks.testrail_id(5390)
     @marks.high

--- a/test/appium/views/base_view.py
+++ b/test/appium/views/base_view.py
@@ -702,9 +702,7 @@ class BaseView(object):
         return AssetButton(self.driver, asset_name)
 
     def open_notification_bar(self):
-        action = TouchAction(self.driver)
-        for i in range(2):
-            action.press(None, 100, 10).move_to(None, 100, 600).perform()
+        self.driver.open_notifications()
 
     def toggle_airplane_mode(self):
         self.airplane_mode_button.click()


### PR DESCRIPTION
- updated tests that checked tooltips on browser view (sometimes they do not appear after first tap) 
- updated open notifications bar with appium built-in method, as touch action in a lot of cases didn't work a expected
- updated ENS name check, as sometimes text is overlapped with keyboard
- updated Inivite friends flow (no referral on Ropsten)