### PR TITLE
ci: use more buckets for different builds

### DIFF
--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -1,4 +1,4 @@
-library 'status-react-jenkins@v1.2.3'
+library 'status-react-jenkins@v1.2.4'
 
 pipeline {
   agent { label 'linux' }

--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -1,4 +1,4 @@
-library 'status-react-jenkins@v1.2.3'
+library 'status-react-jenkins@v1.2.4'
 
 pipeline {
   agent { label 'linux' }

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -1,4 +1,4 @@
-library 'status-react-jenkins@v1.2.3'
+library 'status-react-jenkins@v1.2.4'
 
 pipeline {
   agent { label 'macos-xcode-11.5' }

--- a/ci/Jenkinsfile.nix-cache
+++ b/ci/Jenkinsfile.nix-cache
@@ -1,4 +1,4 @@
-library 'status-react-jenkins@v1.2.3'
+library 'status-react-jenkins@v1.2.4'
 
 pipeline {
   agent { label params.AGENT_LABEL }

--- a/ci/tools/Jenkinsfile.fastlane-clean
+++ b/ci/tools/Jenkinsfile.fastlane-clean
@@ -1,4 +1,4 @@
-library 'status-react-jenkins@v1.2.3'
+library 'status-react-jenkins@v1.2.4'
 
 pipeline {
   agent { label 'macos' }

--- a/ci/tools/Jenkinsfile.playstore-meta
+++ b/ci/tools/Jenkinsfile.playstore-meta
@@ -1,4 +1,4 @@
-library 'status-react-jenkins@v1.2.3'
+library 'status-react-jenkins@v1.2.4'
 
 pipeline {
   agent { label 'linux' }


### PR DESCRIPTION
More fine-grained split between where different builds go:

* `status-im-releases` for release builds
* `status-im-nightlies` for nightlies

I want to reserve the `status-im` bucket for use with the site.

Related PR: https://github.com/status-im/status-react-jenkins/pull/15