### PR TITLE
update-status-go: fix case where two matching refs exist

### DIFF
--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -101,11 +101,13 @@ pipeline {
               } else { /* if no universal is available pick first */
                 env.PKG_URL = urls.first()
               }
-              if (utils.isNightlyBuild()) {
-                env.DIAWI_URL = android.uploadToDiawi()
-              }
+              jenkins.setBuildDesc(APK: env.PKG_URL)
+              /* e2e builds get tested in SauceLabs */
               if (utils.isE2EBuild()) {
                 env.SAUCE_URL = android.uploadToSauceLabs()
+              }
+              if (utils.isNightlyBuild()) {
+                env.DIAWI_URL = android.uploadToDiawi()
               }
             }
           }

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -99,8 +99,9 @@ pipeline {
           steps {
             script {
               env.PKG_URL = s3.uploadArtifact(api)
+              jenkins.setBuildDesc(IPA: env.PKG_URL)
               /* e2e builds get tested in SauceLabs */
-              if (btype == 'e2e') {
+              if (utils.isE2EBuild()) {
                 env.SAUCE_URL = ios.uploadToSauceLabs()
               } else {
                 env.DIAWI_URL = ios.uploadToDiawi()


### PR DESCRIPTION
Before it was possible to break the format of `status-go-version.json`:
```
 > git ls-remote https://github.com/status-im/status-go v0.62.3.hotfix.3
59e6602405bfbcf8446d26aca9b8087e84529f8e    refs/heads/release/v0.62.3.hotfix.3
59e6602405bfbcf8446d26aca9b8087e84529f8e    refs/tags/v0.62.3.hotfix.3
```
Which would result in `commit-sha1` key being set to two commits insted of one.

Issue originally found in #11253.