### PR TITLE
fix availability of INFURA_TOKEN for Android build

### DIFF
--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -1,4 +1,4 @@
-library 'status-react-jenkins@v1.2.4'
+library 'status-react-jenkins@v1.2.5'
 
 pipeline {
   agent { label 'linux' }

--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -1,4 +1,4 @@
-library 'status-react-jenkins@v1.2.4'
+library 'status-react-jenkins@v1.2.5'
 
 pipeline {
   agent { label 'linux' }

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -1,4 +1,4 @@
-library 'status-react-jenkins@v1.2.4'
+library 'status-react-jenkins@v1.2.5'
 
 pipeline {
   agent { label 'macos-xcode-11.5' }

--- a/ci/Jenkinsfile.nix-cache
+++ b/ci/Jenkinsfile.nix-cache
@@ -1,4 +1,4 @@
-library 'status-react-jenkins@v1.2.4'
+library 'status-react-jenkins@v1.2.5'
 
 pipeline {
   agent { label params.AGENT_LABEL }

--- a/ci/tools/Jenkinsfile.fastlane-clean
+++ b/ci/tools/Jenkinsfile.fastlane-clean
@@ -1,4 +1,4 @@
-library 'status-react-jenkins@v1.2.4'
+library 'status-react-jenkins@v1.2.5'
 
 pipeline {
   agent { label 'macos' }

--- a/ci/tools/Jenkinsfile.playstore-meta
+++ b/ci/tools/Jenkinsfile.playstore-meta
@@ -1,4 +1,4 @@
-library 'status-react-jenkins@v1.2.4'
+library 'status-react-jenkins@v1.2.5'
 
 pipeline {
   agent { label 'linux' }

--- a/nix/mobile/android/release.nix
+++ b/nix/mobile/android/release.nix
@@ -19,6 +19,9 @@ let
     toLower optionalString stringLength assertMsg
     getConfig makeLibraryPath assertEnvVarSet elem;
 
+  # Pass secretsFile for INFURA_TOKEN to jsbundle build
+  builtJsBundle = jsbundle { inherit secretsFile; };
+
   buildType = getConfig "build-type" "release";
   buildNumber = getConfig "build-number" 9999;
   gradleOpts = getConfig "android.gradle-opts" null;
@@ -98,7 +101,7 @@ in stdenv.mkDerivation rec {
     cp -bf ./${envFileName} ./.env
 
     # Copy index.js and app/ input files
-    cp -ra --no-preserve=ownership ${jsbundle}/* ./
+    cp -ra --no-preserve=ownership ${builtJsBundle}/* ./
 
     # Copy android/ directory
     mkdir -p ./android/build


### PR DESCRIPTION
The env variable `INFURA_TOKEN` is used at build time of JS bundle, not the final APK file.
We never passed the `secretsFile` to the derivation for JS bundle so it never saw the `INFURA_TOKEN`.

Depends on: https://github.com/status-im/status-react-jenkins/pull/16