### PR TITLE
nix: add support for INFURA_TOKEN var for Android build

### DIFF
--- a/nix/lib/checkEnvVarSet.nix
+++ b/nix/lib/checkEnvVarSet.nix
@@ -1,7 +1,6 @@
 # Helper for verifying an environment variable is set
 name: ''
   if [[ -z ''$${name} ]]; then 
-    echo 'Not env var set: ${name}' >&2
-    exit 1
+    echo 'WARNING! Env var not set: ${name}' >&2
   fi
 ''

--- a/nix/lib/default.nix
+++ b/nix/lib/default.nix
@@ -4,5 +4,5 @@
   getConfig = import ./getConfig.nix { inherit lib config; };
   mkFilter = import ./mkFilter.nix { inherit lib; };
   mergeSh = import ./mergeSh.nix { inherit lib; };
-  assertEnvVarSet = import ./assertEnvVarSet.nix;
+  checkEnvVarSet = import ./checkEnvVarSet.nix;
 }

--- a/nix/mobile/android/jsbundle/default.nix
+++ b/nix/mobile/android/jsbundle/default.nix
@@ -47,6 +47,7 @@ stdenv.mkDerivation {
   # For optional INFURA_TOKEN variable
   secretsPhase = if (secretsFile != "") then ''
     source "${secretsFile}"
+    ${lib.checkEnvVarSet "INFURA_TOKEN"}
   '' else ''
     echo "No secrets provided!"
   '';


### PR DESCRIPTION
Without this running something like:
```sh
make release-android INFURA_TOKEN=whatever
```
Would have no effect due to not being included in the secrets file.