### PR TITLE
disable pipefail for update-status-go.sh

### DIFF
--- a/scripts/update-status-go.sh
+++ b/scripts/update-status-go.sh
@@ -5,7 +5,7 @@ if [[ ! -x "$(command -v nix-prefetch-url)" ]] && [[ -z "${IN_NIX_SHELL}" ]]; th
     exit 1
 fi
 
-set -eof pipefail
+set -ef
 
 GIT_ROOT="$(cd "${BASH_SOURCE%/*}" && git rev-parse --show-toplevel)"
 VERSION_FILE="${GIT_ROOT}/status-go-version.json"


### PR DESCRIPTION
This caused a silent failure due to usage of grep matching.

```
 > scripts/update-status-go.sh debug/env-variables
 > echo $?
1
```

Totally my fault. Didn't check all the cases.