### PR TITLE
fastlane: disable default_keychain to avoid race condition

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -91,8 +91,8 @@ class Keychain
       unlock: true,
       # Lock it up after 25 minutes just in case we don't delete it.
       timeout: 1500,
-      # To make Fastlane import WWDR certificate into it.
-      default_keychain: true,
+      # Setting a default can cause a race condition with parallel jobs.
+      default_keychain: false,
     )
   end
 


### PR DESCRIPTION
If we run parallel job and a job sets a temporary keychain into a default than another job can assume that is the user default.

The result is that one of the jobs will attempt to set a non-existent temporary keychain into the default keychain.

This happens when we call `Fastlane::Actions::DeleteKeychainAction`:
https://github.com/fastlane/fastlane/blob/2.164.0/fastlane/lib/fastlane/actions/delete_keychain.rb#L21

Example: https://ci.status.im/job/status-react/job/prs/job/ios/job/PR-11341/20/