### PR TITLE
Parse translations + fix e2e

### DIFF
--- a/test/appium/tests/__init__.py
+++ b/test/appium/tests/__init__.py
@@ -1,7 +1,8 @@
 import asyncio
 import logging
 from datetime import datetime
-
+import os
+import json
 from support.appium_container import AppiumContainer
 from support.test_data import TestSuiteData
 
@@ -64,5 +65,8 @@ test_dapp_web_url = "status-im.github.io/dapp"
 test_dapp_url = 'simpledapp.eth'
 test_dapp_name = 'simpledapp.eth'
 
-emojis =  {'thumbs-up': 2, 'thumbs-down': 3, 'love': 1, 'laugh': 4, 'angry': 6, 'sad': 5}
+emojis = {'thumbs-up': 2, 'thumbs-down': 3, 'love': 1, 'laugh': 4, 'angry': 6, 'sad': 5}
 
+
+with open(os.sep.join(__file__.split(os.sep)[:-1]) + '/../../../translations/en.json') as json_file:
+    transl = json.load(json_file)

--- a/test/appium/tests/atomic/account_management/test_profile.py
+++ b/test/appium/tests/atomic/account_management/test_profile.py
@@ -617,7 +617,7 @@ class TestProfileSingleDevice(SingleDeviceTestCase):
     def test_dapps_permissions(self):
         sign_in_view = SignInView(self.driver)
         home_view = sign_in_view.create_user()
-        account_name = 'Status account'
+        account_name = home_view.status_account_name
 
         home_view.just_fyi('open Status Test Dapp, allow all and check permissions in Profile')
         home_view.open_status_test_dapp()

--- a/test/appium/tests/atomic/chats/test_commands.py
+++ b/test/appium/tests/atomic/chats/test_commands.py
@@ -98,7 +98,8 @@ class TestCommandsMultipleDevices(MultipleDeviceTestCase):
         if not select_account_bottom_sheet.get_account_in_select_account_bottom_sheet_button('Status').is_element_displayed():
             self.errors.append('Not expected value in "From" in "Select account": "Status" is expected')
         select_account_bottom_sheet.select_button.click()
-        chat_2_receiver_message.transaction_status.wait_for_element_text("Shared 'Status account'")
+        chat_2_receiver_message.transaction_status.wait_for_element_text("Shared '%s'" %
+                                                                         home_1.status_account_name)
         chat_1_sender_message.transaction_status.wait_for_element_text('Address request accepted')
 
         home_1.just_fyi("Sign and send transaction and check that timestamp on message is updated")

--- a/test/appium/tests/atomic/chats/test_keycard_commands.py
+++ b/test/appium/tests/atomic/chats/test_keycard_commands.py
@@ -56,7 +56,7 @@ class TestCommandsMultipleDevices(MultipleDeviceTestCase):
         if not select_account_bottom_sheet.get_account_in_select_account_bottom_sheet_button('Status').is_element_displayed():
             self.errors.append('Not expected value in "From" in "Select account": "Status" is expected')
         select_account_bottom_sheet.select_button.click()
-        chat_2_receiver_message.transaction_status.wait_for_element_text("Shared 'Status account'")
+        chat_2_receiver_message.transaction_status.wait_for_element_text("Shared '%s'" % home_1.status_account_name)
         chat_1_sender_message.transaction_status.wait_for_element_text('Address request accepted')
 
         home_1.just_fyi("Sign and send transaction and check that timestamp on message is updated")

--- a/test/appium/tests/atomic/dapps_and_browsing/test_browsing.py
+++ b/test/appium/tests/atomic/dapps_and_browsing/test_browsing.py
@@ -1,4 +1,4 @@
-from tests import marks, connection_not_secure_text, connection_is_secure_text, test_dapp_url
+from tests import marks, connection_not_secure_text, connection_is_secure_text
 from tests.base_test_case import SingleDeviceTestCase
 from views.sign_in_view import SignInView
 from views.dapps_view import DappsView

--- a/test/appium/tests/atomic/dapps_and_browsing/test_dapps.py
+++ b/test/appium/tests/atomic/dapps_and_browsing/test_dapps.py
@@ -62,7 +62,7 @@ class TestDApps(SingleDeviceTestCase):
 
         wallet_view.just_fyi('create new account in multiaccount')
         wallet_view.set_up_wallet()
-        status_account = 'Status account'
+        status_account = home_view.status_account_name
         account_name = 'Subaccount'
         wallet_view.add_account(account_name)
         address = wallet_view.get_wallet_address(account_name)

--- a/test/appium/tests/atomic/transactions/test_keycard_wallet.py
+++ b/test/appium/tests/atomic/transactions/test_keycard_wallet.py
@@ -141,7 +141,7 @@ class TestTransactionWalletSingleDevice(SingleDeviceTestCase):
         updated_balance = self.network_api.get_balance(status_account_address)
         transaction_amount_1 = round(float(transaction_amount) * 0.1, 11)
         wallet_view.wait_balance_is_changed()
-        send_transaction = wallet_view.send_transaction(account_name='Status account',
+        send_transaction = wallet_view.send_transaction(account_name=wallet_view.status_account_name,
                                                         amount=transaction_amount_1,
                                                         keycard=True)
         send_transaction.back_button.click()
@@ -178,7 +178,7 @@ class TestTransactionWalletSingleDevice(SingleDeviceTestCase):
         send_transaction.confirm()
         send_transaction.chose_recipient_button.click()
         send_transaction.accounts_button.click()
-        send_transaction.element_by_text('Status account').click()
+        send_transaction.element_by_text(wallet_view.status_account_name).click()
         send_transaction.sign_transaction_button.click()
         send_transaction.sign_transaction(keycard=True)
         wallet_view.element_by_text('Assets').click()

--- a/test/appium/tests/atomic/transactions/test_wallet.py
+++ b/test/appium/tests/atomic/transactions/test_wallet.py
@@ -274,7 +274,7 @@ class TestTransactionWalletSingleDevice(SingleDeviceTestCase):
         wallet_view.just_fyi("Sending eth from new account to main account")
         updated_balance = self.network_api.get_balance(status_account_address)
         transaction_amount_1 = round(float(transaction_amount) * 0.1, 12)
-        send_transaction = wallet_view.send_transaction(account_name='Status account',
+        send_transaction = wallet_view.send_transaction(account_name=wallet_view.status_account_name,
                                                         amount=transaction_amount_1)
         send_transaction.back_button.click()
         sub_account_address = wallet_view.get_wallet_address(account_name)[2:]

--- a/test/appium/tests/base_test_case.py
+++ b/test/appium/tests/base_test_case.py
@@ -11,6 +11,7 @@ from appium import webdriver
 from appium.webdriver.common.mobileby import MobileBy
 from selenium.common.exceptions import NoSuchElementException
 from selenium.common.exceptions import WebDriverException
+from tests import transl
 
 from support.api.network_api import NetworkApi
 from support.github_report import GithubHtmlReport
@@ -39,6 +40,9 @@ class AbstractTestCase:
         sys.stdout = sys.stderr
         print("SauceOnDemandSessionID=%s job-name=%s" % (driver.session_id,
                                                          pytest_config_global['build']))
+
+    def get_translation_by_key(self, key):
+        return transl[key]
 
     def add_local_devices_to_capabilities(self):
         updated_capabilities = list()

--- a/test/appium/views/base_element.py
+++ b/test/appium/views/base_element.py
@@ -12,6 +12,7 @@ from selenium.common.exceptions import NoSuchElementException
 from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.support import expected_conditions
+from tests import transl
 
 
 class BaseElement(object):
@@ -45,6 +46,11 @@ class BaseElement(object):
         def webview_selector(cls, value):
             xpath_expression = '//*[@text="{0}"] | //*[@content-desc="{desc}"]'.format(value, desc=value)
             return cls(MobileBy.XPATH, xpath_expression)
+
+        @classmethod
+        def translation_id_selector(cls, id):
+            text = transl[id]
+            return BaseElement.Locator.xpath_selector('//*[@text="' + text + '"]')
 
         def __str__(self, *args, **kwargs):
             return "%s:%s" % (self.by, self.value)

--- a/test/appium/views/base_view.py
+++ b/test/appium/views/base_view.py
@@ -13,7 +13,7 @@ from io import BytesIO
 from selenium.common.exceptions import NoSuchElementException, TimeoutException, StaleElementReferenceException
 
 from support.device_apps import start_web_browser
-from tests import common_password, pytest_config_global, geth_log_emulator_path
+from tests import common_password, pytest_config_global, geth_log_emulator_path, transl
 from views.base_element import BaseButton, BaseElement, BaseEditBox, BaseText
 
 
@@ -430,6 +430,10 @@ class BaseView(object):
             'text': BaseText
         }
 
+    @property
+    def status_account_name(self):
+        return self.get_translation_by_key('ethereum-account')
+
     def accept_agreements(self):
         iterations = int()
         self.close_native_device_dialog("Messages has stopped")
@@ -443,6 +447,9 @@ class BaseView(object):
                 except (NoSuchElementException, TimeoutException):
                     pass
             iterations += 1
+
+    def get_translation_by_key(self, id):
+        return transl[id]
 
     def rooted_device_continue(self):
         try:
@@ -557,6 +564,12 @@ class BaseView(object):
         self.driver.info("Looking for full text: '%s'" % text)
         element = self.element_types[element_type](self.driver)
         element.locator = element.Locator.xpath_selector("//*[starts-with(@text,'%s')]" % text)
+        return element
+
+    def find_element_by_translation_id(self, id, element_type='base'):
+        self.driver.info("Looking element by id: '%s'" % id)
+        element = self.element_types[element_type](self.driver)
+        element.locator = element.Locator.translation_id_selector(id)
         return element
 
     def wait_for_element_starts_with_text(self, text, wait_time=60):

--- a/test/appium/views/dapps_view.py
+++ b/test/appium/views/dapps_view.py
@@ -2,7 +2,6 @@ from views.base_element import BaseButton, BaseEditBox, BaseElement
 from views.base_view import BaseView
 from views.home_view import ChatElement
 
-
 class DiscoverDappsButton(BaseButton):
     def __init__(self, driver):
         super(DiscoverDappsButton, self).__init__(driver)
@@ -118,7 +117,7 @@ class DappsView(BaseView):
         #select account
         self.select_account_button = SelectAccountButton(self.driver)
         self.select_account_radio_button = SelectAccountRadioButton(self.driver,
-                                                                    account_name='Status account')
+                                                                    account_name=self.status_account_name)
         #permissions window
         self.always_allow_radio_button = AlwaysAllowRadioButton(self.driver)
         self.close_web3_permissions_window_button = CrossCloseWeb3PermissionButton(self.driver)
@@ -140,7 +139,8 @@ class DappsView(BaseView):
         self.clear_all_d_app_button if clear_all else self.remove_d_app_button.click()
         return entry
 
-    def select_account_by_name(self, account_name='Status account'):
+    def select_account_by_name(self, account_name=''):
+        account_name = self.status_account_name if not account_name else account_name
         return SelectAccountRadioButton(self.driver, account_name)
 
     def set_primary_ens_username(self, ens_name):

--- a/test/appium/views/wallet_view.py
+++ b/test/appium/views/wallet_view.py
@@ -420,7 +420,7 @@ class WalletView(BaseView):
 
         # elements for multiaccount
         self.multiaccount_more_options = MultiaccountMoreOptions(self.driver)
-        self.accounts_status_account = AccountElementButton(self.driver, account_name="Status account")
+        self.accounts_status_account = AccountElementButton(self.driver, account_name=self.status_account_name)
         self.collectibles_button = CollectiblesButton(self.driver)
         self.cryptokitties_in_collectibles_number = NumberInCollectiblesButton(self.driver, 'CryptoKitties')
         self.view_in_cryptokitties_button = ViewInCryptoKittiesButton(self.driver)
@@ -449,7 +449,8 @@ class WalletView(BaseView):
         import re
         return float(re.sub('[~,]', '', self.usd_total_value.text))
 
-    def get_account_options_by_name(self, account_name='Status account'):
+    def get_account_options_by_name(self, account_name=''):
+        account_name = self.status_account_name if not account_name else account_name
         return AccountOptionsButton(self.driver, account_name)
 
     def get_asset_amount_by_name(self, asset: str):
@@ -513,7 +514,8 @@ class WalletView(BaseView):
         self.ok_got_it_button.click()
         return phrase
 
-    def get_wallet_address(self, account_name="Status account"):
+    def get_wallet_address(self, account_name=''):
+        account_name = self.status_account_name if not account_name else account_name
         self.wallet_account_by_name(account_name).click()
         self.receive_transaction_button.click_until_presence_of_element(self.qr_code_image)
         address = self.address_text.text


### PR DESCRIPTION
- added parsing of en.json, so in future instead of element_by_text,  element_by_text
_part  `translation_id_selector`  should be used
- replaced 'Status account' str to str from translation by key 'ethereum-account' 