### PR TITLE
[TESTS]reduce number of parallel sessions

### DIFF
--- a/ci/tests/Jenkinsfile.e2e-nightly
+++ b/ci/tests/Jenkinsfile.e2e-nightly
@@ -48,7 +48,7 @@ pipeline {
           dir('test/appium/tests') {
             sh """
               python3 -m pytest \
-                --numprocesses 16 \
+                --numprocesses 15 \
                 --rerun_count=2 \
                 --testrail_report=True \
                 -m testrail_id \

--- a/ci/tests/Jenkinsfile.e2e-prs
+++ b/ci/tests/Jenkinsfile.e2e-prs
@@ -84,7 +84,7 @@ pipeline {
           dir('test/appium/tests') {
             sh """
               python3 -m pytest \
-                --numprocesses 16 \
+                --numprocesses 15 \
                 --rerun_count=2 \
                 --testrail_report=True \
                 -m "${params.TEST_MARKERS}" \

--- a/ci/tests/Jenkinsfile.e2e-upgrade
+++ b/ci/tests/Jenkinsfile.e2e-upgrade
@@ -53,7 +53,7 @@ pipeline {
             sh """
               python3 -m pytest \
                 -m upgrade \
-                --numprocesses 16 \
+                --numprocesses 15 \
                 --rerun_count=2 \
                 --testrail_report=True \
                 --network=${params.NETWORK} \


### PR DESCRIPTION
As some tests failed due to error 'no host specified' on re-run, it is an attempt to reduce this likelihood by reserving one "dedicated" host because we have a lot of 2-driver e2e, and some 3-driver e2e.