### PR TITLE
Dont send unprocessed images

### DIFF
--- a/src/status_im/chat/models/images.cljs
+++ b/src/status_im/chat/models/images.cljs
@@ -141,12 +141,11 @@
   (let [current-chat-id (:current-chat-id db)
         images          (get-in db [:chats current-chat-id :metadata :sending-image])]
     (if (get-in db [:chats current-chat-id :timeline?])
-      {:db              (update-in db [:chats current-chat-id :metadata :sending-image] {uri {:uri uri}})
+      {:db              (assoc-in db [:chats current-chat-id :metadata :sending-image] {})
        ::image-selected uri}
       (when (and (< (count images) config/max-images-batch)
                  (not (get images uri)))
-        {:db              (update-in db [:chats current-chat-id :metadata :sending-image] assoc uri {:uri uri})
-         ::image-selected uri}))))
+        {::image-selected uri}))))
 
 (fx/defn save-image-to-gallery
   {:events [:chat.ui/save-image-to-gallery]}


### PR DESCRIPTION
Partially addresses: #11450

When selecting an image from camera roll we would immediately setting
the filepath with the raw image, process and later once it was processed
we would replace the file path.
On slow devices, the user might press send while the image is still
processing, causing the raw image to be sent, which might be discarded
as too large and never sent.

This commit changes the behavior so that we only set the uri once the
image is processed, it might add some delay, but the image should be
correctly sent.

status: ready