### PR TITLE
🧴Mentions hygiene

### DIFF
--- a/src/status_im/chat/models/mentions_test.cljs
+++ b/src/status_im/chat/models/mentions_test.cljs
@@ -4,19 +4,18 @@
             [cljs.test :as test :include-macros true]))
 
 (test/deftest test-replace-mentions
-  (let [users (fn []
-                {"User Number One"
-                 {:name       "User Number One"
-                  :alias      "User Number One"
-                  :public-key "0xpk1"}
-                 "User Number Two"
-                 {:name       "user2"
-                  :alias      "User Number Two"
-                  :public-key "0xpk2"}
-                 "User Number Three"
-                 {:name       "user3"
-                  :alias      "User Number Three"
-                  :public-key "0xpk3"}})]
+  (let [users {"User Number One"
+               {:name       "User Number One"
+                :alias      "User Number One"
+                :public-key "0xpk1"}
+               "User Number Two"
+               {:name       "user2"
+                :alias      "User Number Two"
+                :public-key "0xpk2"}
+               "User Number Three"
+               {:name       "user3"
+                :alias      "User Number Three"
+                :public-key "0xpk3"}}]
     (test/testing "empty string"
       (let [text   ""
             result (mentions/replace-mentions text users)]


### PR DESCRIPTION
# Summary
- Remove redundant call to `users-fn` and pass `mentionable-users` directly
- Rename `get-suggestions` to `get-user-suggestions`, will be helpful when the `get-channel-suggestions` function is implemented
- Extract inline function props to text input as a namespaced function. Now they won't get redefined at every key-press and are slightly easier to read and reason for

These changes were made while working on # autocomplete feature for chat text-input (which is not completed yet).

### Testing notes
- Check if autocomplete mention works fine

#### Platforms
- Android
- iOS

#### Areas that maybe impacted
- All types of chat

##### Non-functional
- CPU performance / speed of the app

status: ready