### PR TITLE
[Fixes: #11452] Don't allow more than x pictures if taken from camera

### DIFF
--- a/src/status_im/chat/models/images.cljs
+++ b/src/status_im/chat/models/images.cljs
@@ -54,6 +54,12 @@
          #(log/error "could not resize image" %)))))))
 
 (re-frame/reg-fx
+ ::chat-open-image-picker-camera
+ (fn []
+   (react/show-image-picker-camera
+    #(re-frame/dispatch [:chat.ui/image-captured (.-path %)]) {})))
+
+(re-frame/reg-fx
  ::chat-open-image-picker
  (fn []
    (react/show-image-picker
@@ -91,8 +97,12 @@
 
 (fx/defn image-captured
   {:events [:chat.ui/image-captured]}
-  [_ uri]
-  {::image-selected uri})
+  [{:keys [db]} uri]
+  (let [current-chat-id (:current-chat-id db)
+        images          (get-in db [:chats current-chat-id :metadata :sending-image])]
+    (when (and (< (count images) config/max-images-batch)
+               (not (get images uri)))
+      {::image-selected uri})))
 
 (fx/defn camera-roll-get-photos
   {:events [:chat.ui/camera-roll-get-photos]}
@@ -134,6 +144,14 @@
         images          (get-in db [:chats current-chat-id :metadata :sending-image])]
     (when (< (count images) config/max-images-batch)
       {::chat-open-image-picker nil})))
+
+(fx/defn chat-show-image-picker-camera
+  {:events [:chat.ui/show-image-picker-camera]}
+  [{:keys [db]}]
+  (let [current-chat-id (:current-chat-id db)
+        images          (get-in db [:chats current-chat-id :metadata :sending-image])]
+    (when (< (count images) config/max-images-batch)
+      {::chat-open-image-picker-camera nil})))
 
 (fx/defn camera-roll-pick
   {:events [:chat.ui/camera-roll-pick]}

--- a/src/status_im/ui/screens/chat/image/views.cljs
+++ b/src/status_im/ui/screens/chat/image/views.cljs
@@ -15,9 +15,7 @@
 (defn take-picture []
   (permissions/request-permissions
    {:permissions [:camera]
-    :on-allowed  (fn []
-                   (react/show-image-picker-camera
-                    #(re-frame/dispatch [:chat.ui/image-captured (.-path %)]) {}))
+    :on-allowed  #(re-frame/dispatch [:chat.ui/show-image-picker-camera])
     :on-denied   (fn []
                    (utils/set-timeout
                     #(utils/show-popup (i18n/label :t/error)

--- a/src/status_im/ui/screens/status/new/views.cljs
+++ b/src/status_im/ui/screens/status/new/views.cljs
@@ -15,14 +15,11 @@
             [status-im.ui.screens.status.views :as status.views]
             [status-im.ui.screens.status.new.styles :as styles]))
 
-(defn take-picture []
-  (react/show-image-picker-camera #(re-frame/dispatch [:chat.ui/image-captured (.-path %)]) {}))
-
 (defn buttons []
   [react/view styles/buttons
    [pressable/pressable {:type                :scale
                          :accessibility-label :take-picture
-                         :on-press            take-picture}
+                         :on-press  #(re-frame/dispatch [:chat.ui/show-image-picker-camera])}
     [icons/icon :main-icons/camera]]
    [react/view {:style {:padding-top 8}}
     [pressable/pressable {:on-press            #(re-frame/dispatch [:chat.ui/open-image-picker])


### PR DESCRIPTION
This commit fixes an issue with taking pictures from camera, where
the check for image count was not checked.

status: ready