### PR TITLE
[wallet] Pull to refresh tx history

### DIFF
--- a/src/mocks/js_dependencies.cljs
+++ b/src/mocks/js_dependencies.cljs
@@ -22,6 +22,7 @@
                             :ReanimatedModule       {:configureProps (fn [])}}
 
             :View                     {}
+            :RefreshControl           {}
             :FlatList                 {}
             :Text                     {}
             :ProgressBarAndroid       {}

--- a/src/quo/react_native.cljs
+++ b/src/quo/react_native.cljs
@@ -17,6 +17,7 @@
 
 (def scroll-view (reagent/adapt-react-class (.-ScrollView ^js rn)))
 (def modal (reagent/adapt-react-class (.-Modal ^js rn)))
+(def refresh-control (reagent/adapt-react-class (.-RefreshControl ^js rn)))
 
 (def touchable-opacity (reagent/adapt-react-class (.-TouchableOpacity ^js rn)))
 (def touchable-highlight (reagent/adapt-react-class (.-TouchableHighlight ^js rn)))

--- a/src/status_im/ethereum/subscriptions.cljs
+++ b/src/status_im/ethereum/subscriptions.cljs
@@ -66,7 +66,8 @@
             (update-in [:wallet :accounts]
                        wallet/remove-transactions-since-block blockNumber)
             (transactions/update-fetching-status accounts :recent? false)
-            (dissoc :wallet/waiting-for-recent-history?))
+            (dissoc :wallet/waiting-for-recent-history?
+                    :wallet/refreshing-history?))
     :transactions/get-transfers
     {:chain-tokens (:wallet/all-tokens db)
      :addresses    (reduce
@@ -81,7 +82,7 @@
      :before-block blockNumber
      :limit        20
      :historical?  true}}
-   (wallet.core/restart-wallet-service false false)))
+   (wallet.core/restart-wallet-service-default)))
 
 (fx/defn new-wallet-event
   [cofx {:keys [type blockNumber accounts newTransactions] :as event}]

--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -1184,7 +1184,7 @@
                        (dissoc :app-in-background-since)
                        (assoc :app-active-since now))}
               (mailserver/process-next-messages-request)
-              (wallet/restart-wallet-service true false)
+              (wallet/restart-wallet-service {:force-start? true})
               #(when requires-bio-auth
                  (biometric/authenticate % on-biometric-auth-result authentication-options)))))
 

--- a/src/status_im/multiaccounts/login/core.cljs
+++ b/src/status_im/multiaccounts/login/core.cljs
@@ -318,7 +318,7 @@
               ;;FIXME
               (when nodes
                 (fleet/set-nodes :eth.contract nodes))
-              (wallet/restart-wallet-service true false)
+              (wallet/restart-wallet-service {:force-start? true})
               (if login-only?
                 (login-only-events key-uid password save-password?)
                 (create-only-events))

--- a/src/status_im/subs.cljs
+++ b/src/status_im/subs.cljs
@@ -169,6 +169,7 @@
 (reg-root-key-sub :wallet-service/state :wallet-service/state)
 (reg-root-key-sub :wallet/recipient :wallet/recipient)
 (reg-root-key-sub :wallet/favourites :wallet/favourites)
+(reg-root-key-sub :wallet/refreshing-history? :wallet/refreshing-history?)
 
 ;;commands
 (reg-root-key-sub :commands/select-account :commands/select-account)

--- a/src/status_im/ui/screens/mobile_network_settings/events.cljs
+++ b/src/status_im/ui/screens/mobile_network_settings/events.cljs
@@ -37,7 +37,7 @@
        logged-in?
        [(mailserver/process-next-messages-request)
         (bottom-sheet/hide-bottom-sheet)
-        (wallet/restart-wallet-service false false)]))))
+        (wallet/restart-wallet-service-default)]))))
 
 (defn apply-settings
   ([sync?] (apply-settings sync? :default))
@@ -62,7 +62,7 @@
         (bottom-sheet/hide-bottom-sheet)
         (when (and cellular? sync?)
           (mailserver/process-next-messages-request))
-        (wallet/restart-wallet-service false false))))))
+        (wallet/restart-wallet-service-default))))))
 
 (handlers/register-handler-fx
  :mobile-network/continue-syncing

--- a/src/status_im/ui/screens/wallet/transactions/views.cljs
+++ b/src/status_im/ui/screens/wallet/transactions/views.cljs
@@ -10,8 +10,7 @@
             [status-im.ui.components.topbar :as topbar]
             [status-im.ui.screens.wallet.transactions.styles :as styles]
             [quo.core :as quo]
-            [status-im.ui.components.toolbar :as toolbar]
-            [status-im.wallet.core :as wallet])
+            [status-im.ui.components.toolbar :as toolbar])
   (:require-macros [status-im.utils.views :refer [defview letsubs]]))
 
 (defn- transaction-icon
@@ -105,20 +104,6 @@
        {:style {:color colors/blue}}
        (i18n/label :t/check-on-etherscan)]]]))
 
-(defn refresh []
-  [react/touchable-highlight
-   {:on-press #(re-frame/dispatch [::wallet/restart])}
-   [react/view
-    {:style {:flex               1
-             :padding-horizontal 14
-             :flex-direction     :row
-             :align-items        :center
-             :background-color   colors/blue-light
-             :height             52}}
-    [react/text
-     {:style {:color colors/blue}}
-     (i18n/label :t/refresh)]]])
-
 (defn history-list
   [transactions-history-sections address]
   (let [fetching-recent-history? @(re-frame/subscribe [:wallet/fetching-recent-tx-history? address])
@@ -126,7 +111,6 @@
         all-fetched?             @(re-frame/subscribe [:wallet/tx-history-fetched? address])]
     [react/view components.styles/flex
      [etherscan-link address]
-     [refresh]
      (when fetching-recent-history?
        [react/view
         {:style {:flex            1
@@ -142,8 +126,7 @@
        [react/i18n-text {:style styles/empty-text
                          :key   (if (or fetching-recent-history? fetching-more-history?)
                                   :transactions-history-loading
-                                  :transactions-history-empty)}]
-       :refreshing false}]
+                                  :transactions-history-empty)}]}]
      (when (and (not fetching-recent-history?)
                 (not all-fetched?))
        (if fetching-more-history?


### PR DESCRIPTION
some details:
- "Refresh" button is removed
- there is a one minute cooldown period  just to make sure that history is not fetched too often 
- even if syncing is not allowed the history will be updated on pulling, I suppose that's expected

The rest of it should be pretty obvious.
 
status: ready