### PR TITLE
 Fixes: #10065 fix mailserver popup showing after canceling it

### DIFF
--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -221,6 +221,11 @@
    (mailserver/save-settings cofx current-fleet mailserver-id)))
 
 (handlers/register-handler-fx
+ :mailserver.ui/dismiss-connection-error
+ (fn [cofx [_ new-state]]
+   (mailserver/dismiss-connection-error cofx new-state)))
+
+(handlers/register-handler-fx
  :mailserver.ui/unpin-pressed
  (fn [cofx _]
    (mailserver/unpin cofx)))

--- a/src/status_im/mailserver/core.cljs
+++ b/src/status_im/mailserver/core.cljs
@@ -529,13 +529,13 @@
              ;; instead of using pos?
              (not (zero? (:peers-count db))))
     (if-let [preferred-mailserver (preferred-mailserver-id db)]
-      (let [error-dismissed (connection-error-dismissed db)
+      (let [error-dismissed? (connection-error-dismissed db)
             current-fleet (node/current-fleet-key db)]
         ;; Error connecting to the mail server
         {:db
          (update-mailserver-state db :error)
          :ui/show-confirmation
-         (when-not error-dismissed
+         (when-not error-dismissed?
            {:title               (i18n/label :t/mailserver-error-title)
             :content             (i18n/label :t/mailserver-error-content)
             :confirm-button-text (i18n/label :t/mailserver-pick-another)
@@ -1179,12 +1179,12 @@
         mailserver-id (:mailserver/current-id db)
         pinned-mailservers (get-in db [:multiaccount :pinned-mailservers])]
     (fx/merge cofx
-      (multiaccounts.update/multiaccount-update
-        :pinned-mailservers (assoc pinned-mailservers
-                              current-fleet
-                              mailserver-id)
-        {})
-      (dismiss-connection-error false))))
+              (multiaccounts.update/multiaccount-update
+               :pinned-mailservers (assoc pinned-mailservers
+                                          current-fleet
+                                          mailserver-id)
+               {})
+              (dismiss-connection-error false))))
 
 (fx/defn load-gaps-fx [{:keys [db] :as cofx} chat-id]
   (when-not (get-in db [:gaps-loaded? chat-id])

--- a/src/status_im/ui/screens/offline_messaging_settings/views.cljs
+++ b/src/status_im/ui/screens/offline_messaging_settings/views.cljs
@@ -53,6 +53,8 @@
     [react/view {:style styles/wrapper}
      [topbar/topbar
       {:title (i18n/label :t/history-nodes)
+       ;; Navigate to profile as we might be coming from home to this view
+       :navigation {:on-press #(re-frame/dispatch [:navigate-to :profile-stack {:screen :sync-settings}])}
        :right-accessories
        [{:icon    :main-icons/add-circle
          :on-press #(re-frame/dispatch [:mailserver.ui/add-pressed])}]}]

--- a/src/status_im/ui/screens/sync_settings/views.cljs
+++ b/src/status_im/ui/screens/sync_settings/views.cljs
@@ -14,7 +14,8 @@
                   current-fleet                       [:fleets/current-fleet]
                   mailservers                         [:mailserver/mailservers]]
     [react/view {:style {:flex 1 :background-color colors/white}}
-     [topbar/topbar {:title (i18n/label :t/sync-settings)}]
+     [topbar/topbar {:title (i18n/label :t/sync-settings)
+                     :navigation {:on-press #(re-frame/dispatch [:navigate-to :profile-stack {:screen :my-profile}])}}]
      [react/scroll-view
       [quo/list-header (i18n/label :t/data-syncing)]
       [quo/list-item {:size                :small


### PR DESCRIPTION
Reopening this as it's still a valid issue, for example if the mailserver was initially online but later it went offline, the popup interferes with the user being able to change settings or ignore the warning.
 Original PR

https://github.com/status-im/status-react/pull/10342
### Summary

Fixes #10065 by setting a `dismissed` flag on Cancel, so the popup will not appear again.
Selecting a new mail server sets `dismissed` as false, so the error can appear again

#### Platforms

Tested Android simulator

### Steps to test

See issue above to see reproduction steps