### PR TITLE
nix: make status-go version regex even more lax

### DIFF
--- a/nix/tools/utils.nix
+++ b/nix/tools/utils.nix
@@ -49,7 +49,7 @@ let
   # paths don't like slashes in them
   dropSlashes = builtins.replaceStrings [ "/" ] [ "_" ];
   # if version doesn't match this it's probably a commit, it's lax semver
-  versionRegex = "^v?[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+[[:alnum:]_.-]*$";
+  versionRegex = "^v?[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+[[:alnum:]+_.-]*$";
   sanitizeVersion = version:
     if (builtins.match versionRegex version) != null
     # Geth forces a 'v' prefix for all versions


### PR DESCRIPTION
In release `1.7.0` we had an issue with `status-go` version `v0.62.3.hotfix.3` ~~not matching [Semantic Versioning](https://semver.org/#spec-item-11)~~ so a fix was introduced in https://github.com/status-im/status-react/pull/11331 that made the regex a bit more lax.

__EDIT__: Apparently `hotfix.X` should be treated as metadata, which does allow use of `+` in semver.

Again in `1.9.0` we had the same issue and the release not appears as `develop` instead of the actual `status-go` version, which this time was `0.63.8+hotfix.2`. Notice the `+` instead of `-` or `.` before `hotfix.2`.

I've added `+` to allowed characters after the 3 digit standard version format.