### PR TITLE
[Fixes: #8280] Remove unused transport security entries

### DIFF
--- a/ios/StatusIm/Info.plist
+++ b/ios/StatusIm/Info.plist
@@ -63,11 +63,6 @@
 		<true/>
 		<key>NSExceptionDomains</key>
 		<dict>
-			<key>api.status.im</key>
-			<dict>
-				<key>NSTemporaryExceptionAllowsInsecureHTTPLoads</key>
-				<true/>
-			</dict>
 			<key>localhost</key>
 			<dict>
 				<key>NSTemporaryExceptionAllowsInsecureHTTPLoads</key>


### PR DESCRIPTION
Removes not user security transport entries from ios

### Testing

IOS dapps/browser