### PR TITLE
[Fixes: #10777] Always convert value to string

### DIFF
--- a/src/status_im/signing/core.cljs
+++ b/src/status_im/signing/core.cljs
@@ -232,7 +232,9 @@
   {:events [:sign/send-transaction-message]}
   [cofx chat-id value contract transaction-hash signature]
   {::json-rpc/call [{:method (json-rpc/call-ext-method "sendTransaction")
-                     :params [chat-id value contract transaction-hash
+                     ;; We make sure `value` is serialized as string, and not
+                     ;; as an integer or big-int
+                     :params [chat-id (str value) contract transaction-hash
                               (or (:result (types/json->clj signature))
                                   (ethereum/normalized-hex signature))]
                      :on-success


### PR DESCRIPTION
Fixes: https://github.com/status-im/status-react/issues/10777

When calling `SendTransaction` sometimes the value would be a string
(most cases), sometimes the value would instead big a `BigInt`, which
would be serialized to an integer, and status-go would be unable to
parse it as it expects values to be a string.
This commit makes sure that values are always serialized as string
before sending them over.

status: ready