### PR TITLE
[Fixes: #11520] Rotate mailservers on error conditions

### DIFF
--- a/src/status_im/mailserver/constants.cljs
+++ b/src/status_im/mailserver/constants.cljs
@@ -11,6 +11,9 @@
 (def max-limit 1000)
 (def backoff-interval-ms 3000)
 (def default-limit max-limit)
+;; If a mailserver fails, how long before we should consider them again
+;; for selection, in ms
+(def cooloff-period 120000)
 (def connection-timeout
   "Time after which mailserver connection is considered to have failed"
   10000)

--- a/src/status_im/mailserver/core_test.cljs
+++ b/src/status_im/mailserver/core_test.cljs
@@ -879,3 +879,20 @@
               {:from 2
                :to   8}
               #{"chat1"}))))))
+
+(deftest sort-mailserver-test
+  (testing "it orders them by whether they have failed first and by rtts"
+    (let [now                 (inc constants/cooloff-period)
+          mailserver-failures {:a 1
+                               :b 0}
+          cofx {:now now
+                :db {:mailserver/failures mailserver-failures}}
+          mailserver-pings [{:address :a :rttMs 2}
+                            {:address :b :rttMs 3}
+                            {:address :d :rttMs 1}
+                            {:address :e :rttMs 4}]
+          expected-order  [{:address :d :rttMs 1}
+                           {:address :b :rttMs 3}
+                           {:address :e :rttMs 4}
+                           {:address :a :rttMs 2}]]
+      (is (= expected-order (mailserver/sort-mailservers cofx mailserver-pings))))))


### PR DESCRIPTION
Fixes: #11520

If a mailserver request is failing we disconnect at the 3rd attempt.

Though once we are disconnected, we connect again to the same mailserver
based on ping time.

This commit changes the behavior so that mailservers are penalized if
they are returning errors.

### Testing

Test mailservers , going offline/online etc

status: ready