### PR TITLE
[Fixes: #11074] only validate whether group name is blank

### DIFF
--- a/src/status_im/group_chats/core.cljs
+++ b/src/status_im/group_chats/core.cljs
@@ -1,6 +1,7 @@
 (ns status-im.group-chats.core
   (:refer-clojure :exclude [remove])
   (:require [clojure.spec.alpha :as spec]
+            [clojure.string :as string]
             [re-frame.core :as re-frame]
             [status-im.chat.models :as models.chat]
             [status-im.chat.models.message :as models.message]
@@ -120,8 +121,11 @@
                                      nil)
             (navigation/navigate-to-cofx :home {})))
 
+(def not-blank?
+  (complement string/blank?))
+
 (defn- valid-name? [name]
-  (spec/valid? :profile/name name))
+  (spec/valid? not-blank? name))
 
 (fx/defn name-changed
   "Save chat from edited profile"


### PR DESCRIPTION
fixes #11074 

### Summary
problem: cannot rename group chat if name contains / 
solution: removed the validation of whether group name include command-char '/' , only validate if it is blank

#### Platforms
- Android
- iOS

#### Areas that maybe impacted
group chat

##### Functional
- group chats

### Steps to test
- case 1
  - Open Status
  - Navigate to group chat
  - Tap ... in top right of screen
  - Tap 'Group Info'
  - Tap edit icon top right of screen
  - Enter new name which contains command char '/', e.g. '/abc'
  - Able to press 'Done' 

- case 2
  - Open Status
  - Navigate to group chat
  - Tap ... in top right of screen
  - Tap 'Group Info'
  - Tap edit icon top right of screen
  - Enter new name which only contains blanks, e.g. '   '
  - Able to press 'Done' but nothing will happen

status: ready