### PR TITLE
[Fixes: #11545] Don't update browser if nil

### DIFF
--- a/src/status_im/browser/core.cljs
+++ b/src/status_im/browser/core.cljs
@@ -189,12 +189,13 @@
   [cofx browser url]
   (let [history-index (:history-index browser)
         history       (:history browser)]
-    (let [new-history (conj (subvec history 0 (inc history-index)) url)
-          new-index   (dec (count new-history))]
-      (update-browser cofx
-                      (assoc browser
-                             :history new-history
-                             :history-index new-index)))))
+    (when history
+      (let [new-history (conj (subvec history 0 (inc history-index)) url)
+            new-index   (dec (count new-history))]
+        (update-browser cofx
+                        (assoc browser
+                               :history new-history
+                               :history-index new-index))))))
 
 (defmulti storage-gateway :namespace)
 
@@ -251,7 +252,7 @@
   (let [browser (get-current-browser (:db cofx))
         options (get-in cofx [:db :browser/options])
         current-url (:url options)]
-    (when (and (not (string/blank? url)) (not= "about:blank" url) (not= current-url url) (not= (str current-url "/") url))
+    (when (and browser (not (string/blank? url)) (not= "about:blank" url) (not= current-url url) (not= (str current-url "/") url))
       (let [resolved-ens (first (filter (fn [v]
                                           (not= (.indexOf ^js url (second v)) -1))
                                         (:resolved-ens options)))
@@ -266,7 +267,7 @@
 (fx/defn update-browser-name
   [cofx title]
   (let [browser (get-current-browser (:db cofx))]
-    (when (and (not (:dapp? browser)) title (not (string/blank? title)))
+    (when (and browser (not (:dapp? browser)) title (not (string/blank? title)))
       (update-browser cofx (assoc browser :name title)))))
 
 (fx/defn navigation-state-changed


### PR DESCRIPTION
Fixes: #11545
Fixes: #11544

The two issues were caused by the same bug, essentially if
`navigation-state-changed` event was fired (it's debounced) when the tab
had been closed, the browser would be updated with a `nil` id, causing
all sort of issues as it had not history etc.

This commit ensures that no changes are made if the browser is nil.

### Testing

Tabs usage, I have little context on the feature, so I just verified it works more or less as it did before.

status: ready