### PR TITLE
Add nix purge command and change the behavior of nix clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,9 +127,16 @@ _tmpdir-rm: SHELL := /bin/sh
 _tmpdir-rm: ##@prepare Remove TMPDIR
 	rm -fr "$(TMPDIR)"
 
+# Remove directories and ignored files
 clean: SHELL := /bin/sh
 clean: _fix-node-perms _tmpdir-rm ##@prepare Remove all output folders
+	git clean -dXf
+
+# Remove directories, ignored and non-ignored files
+purge: SHELL := /bin/sh
+purge: _fix-node-perms _tmpdir-rm ##@prepare Remove all output folders
 	git clean -dxf
+
 
 watchman-clean: export TARGET := watchman
 watchman-clean: ##@prepare Delete repo directory from watchman

--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -116,7 +116,7 @@ pipeline {
     }
     stage('Cleanup') {
       steps {
-        sh 'make clean'
+        sh 'make purge'
       }
     }
   }

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -114,7 +114,7 @@ pipeline {
     stage('Cleanup') {
       steps {
         sh 'make watchman-clean'
-        sh 'make clean'
+        sh 'make purge'
       }
     }
   }


### PR DESCRIPTION
This commit changes the behavior of `make clean` so that untracked files are not removed.
It adds a `make purge` command with the old behavior of `make clean` and it uses that in ci.