### PR TITLE
[Fixes: #10978] Endless loading public chat name

### DIFF
--- a/src/status_im/transport/utils.cljs
+++ b/src/status_im/transport/utils.cljs
@@ -1,12 +1,6 @@
 (ns ^{:doc "Utils for transport layer"}
  status-im.transport.utils
-  (:require [clojure.string :as string]
-            [status-im.ethereum.core :as ethereum]))
-
-(defn get-topic
-  "Get the topic of a group chat or public chat from the chat-id"
-  [chat-id]
-  (subs (ethereum/sha3 chat-id) 0 10))
+  (:require [clojure.string :as string]))
 
 (defn extract-enode-id [enode]
   (-> enode


### PR DESCRIPTION
fixes #10978 

### Summary

status-im.ethereum.core/sha3 will do something special with string start with '0x', which may cause function **get-topic** return wrong topic, status-go already calculated the right topic stored in db, so we could just find it there and use it instead.

#### Platforms

- Android
- iOS

#### Areas that maybe impacted

##### Functional

- mailservers

### Steps to test
pls refer #10978 


status: ready <!-- Can be ready or wip -->