### PR TITLE
Whitelist link previews client side

### DIFF
--- a/src/status_im/subs.cljs
+++ b/src/status_im/subs.cljs
@@ -2474,7 +2474,9 @@
  :link-preview/whitelist
  :<- [:multiaccount]
  (fn [multiaccount]
-   (get multiaccount :link-previews-whitelist)))
+   (filter (fn [{:keys [address]}]
+             (config/link-preview-enabled-site? address))
+           (get multiaccount :link-previews-whitelist))))
 
 (re-frame/reg-sub
  :link-preview/cache

--- a/src/status_im/ui/screens/link_previews_settings/views.cljs
+++ b/src/status_im/ui/screens/link_previews_settings/views.cljs
@@ -22,7 +22,8 @@
                    [::link-preview/enable title ((complement boolean) enabled?)])})))
 
 (views/defview link-previews-settings []
-  (views/letsubs [{:keys [link-previews-whitelist link-previews-enabled-sites]} [:multiaccount]]
+  (views/letsubs [link-previews-whitelist [:link-preview/whitelist]
+                  link-previews-enabled-sites [:link-preview/enabled-sites]]
     [react/view {:flex 1}
      [topbar/topbar {:title (i18n/label :t/chat-link-previews)}]
      [react/image {:source      (resources/get-theme-image :unfurl)

--- a/src/status_im/utils/config.cljs
+++ b/src/status_im/utils/config.cljs
@@ -141,3 +141,5 @@
                [id network])
              default-networks)))
 
+(def link-preview-enabled-site?
+  #{"youtube.com" "youtu.be"})


### PR DESCRIPTION
whitelist links client side and allow only `youtube` for now.