### PR TITLE
[Fixes: #11579] Add only certain fields to multiaccount on login

### DIFF
--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -139,13 +139,17 @@
 (handlers/register-handler-fx
  :multiaccounts.login.ui/multiaccount-selected
  (fn [{:keys [db] :as cofx} [_ key-uid]]
-   (let [multiaccount (get-in db [:multiaccounts/multiaccounts key-uid])]
+   ;; We specifically pass a bunch of fields instead of the whole multiaccount
+   ;; as we want store some fields in multiaccount that are not here
+   (let [multiaccount
+         (get-in db [:multiaccounts/multiaccounts key-uid])]
      (fx/merge
       cofx
       {:db (-> db
                (dissoc :intro-wizard)
                (update :keycard dissoc :application-info))}
-      (multiaccounts.login/open-login multiaccount)))))
+      (multiaccounts.login/open-login
+       (select-keys multiaccount [:key-uid :name :public-key :identicon :images]))))))
 
 (handlers/register-handler-fx
  :login/filters-initialized

--- a/src/status_im/init/core.cljs
+++ b/src/status_im/init/core.cljs
@@ -27,8 +27,13 @@
   [cofx {:keys [logout?]}]
   (let [{{:multiaccounts/keys [multiaccounts]} :db} cofx]
     (when (and (seq multiaccounts) (not logout?))
+      ;; We specifically pass a bunch of fields instead of the whole multiaccount
+      ;; as we want store some fields in multiaccount that are not here
       (let [multiaccount (first (sort-by :timestamp > (vals multiaccounts)))]
-        (multiaccounts.login/open-login cofx multiaccount)))))
+        (multiaccounts.login/open-login cofx
+                                        (select-keys
+                                         multiaccount
+                                         [:key-uid :name :public-key :identicon :images]))))))
 
 (fx/defn initialize-multiaccounts
   {:events [::initialize-multiaccounts]}


### PR DESCRIPTION
`multiaccounts` has some fields that should not be overriden
(`save-password`), so we expliciltly `assoc` only certain fields.

status: ready