### PR TITLE
hide increase gas/cancel tx, temporary for 1.10

### DIFF
--- a/src/status_im/ui/screens/wallet/transactions/views.cljs
+++ b/src/status_im/ui/screens/wallet/transactions/views.cljs
@@ -76,7 +76,8 @@
                        :style     {:margin-top 10}
                        :icon-opts (merge styles/forward
                                          {:accessibility-label :show-transaction-button})}]]]]
-   (when (and (not keycard-account?)
+   (when (and false ;;TODO temporary disable for 1.10
+              (not keycard-account?)
               (= type :pending))
      [react/view {:flex-direction :row :padding 16 :justify-content :space-between}
       [quo/button


### PR DESCRIPTION
JohnLeaToday at 11:59 AM
 I was thinking that some design thought is required regarding the best way to communicate these scenarios to the user.  I wasn't thinking of these scenarios when I did the original design.
if we push this to the next release, we give ourselves the opportunity to work out the best design solution to correctly communicate these scenarios to the user
cammellosToday at 12:02 PM
ok, let s hide and re group for next release then