### PR TITLE
fix: No "Delete" option for a group chat from the home screen if user…

### DIFF
--- a/src/status_im/ui/screens/chat/sheets.cljs
+++ b/src/status_im/ui/screens/chat/sheets.cljs
@@ -102,7 +102,8 @@
 
 (defn group-chat-accents []
   (fn [{:keys [chat-id group-chat chat-name color invitation-admin]}]
-    (let [{:keys [joined?]} @(re-frame/subscribe [:group-chat/inviter-info chat-id])]
+    (let [{:keys [joined?]} @(re-frame/subscribe [:group-chat/inviter-info chat-id])
+          removed? @(re-frame/subscribe [:group-chat/removed-from-current-chat?])]
       (if invitation-admin
         [quo/list-item
          {:theme               :accent
@@ -137,7 +138,14 @@
              :title               (i18n/label :t/leave-chat)
              :accessibility-label :leave-chat-button
              :icon                :main-icons/arrow-left
-             :on-press            #(re-frame/dispatch [:group-chats.ui/leave-chat-pressed chat-id])}])]))))
+             :on-press            #(re-frame/dispatch [:group-chats.ui/leave-chat-pressed chat-id])}])
+         (when removed?
+           [quo/list-item
+            {:theme               :accent
+             :title               (i18n/label :t/remove)
+             :accessibility-label :remove-group-chat
+             :icon                :main-icons/delete
+             :on-press            #(hide-sheet-and-dispatch [:group-chats.ui/remove-chat-confirmed chat-id])}])]))))
 
 (defn actions [{:keys [chat-type]
                 :as current-chat}]


### PR DESCRIPTION
fixes #11488 

### Summary

We should check if the user has been removed by admin in private group chat when the user trying pop up the option menu list via long pressing private group chat within **home** screen.

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

status: ready <!-- Can be ready or wip -->