### PR TITLE
ci: parametrize publishing, make BUILD_TYPE a choice

### DIFF
--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -1,4 +1,4 @@
-library 'status-react-jenkins@v1.2.8'
+library 'status-react-jenkins@v1.2.9'
 
 pipeline {
   agent { label 'linux' }

--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -1,4 +1,4 @@
-library 'status-react-jenkins@v1.2.8'
+library 'status-react-jenkins@v1.2.9'
 
 pipeline {
   agent { label 'linux' }
@@ -14,6 +14,20 @@ pipeline {
       daysToKeepStr: '30',
       artifactNumToKeepStr: '10',
     ))
+  }
+
+  /* WARNING: Defining parameters here with the ?: trick causes them to remember last value. */
+  parameters { 
+    choice(
+      name: 'BUILD_TYPE',
+      description: 'Makefile target to build. Optional Parameter.',
+      choices: genChoices(params.BUILD_TYPE, ['manual', 'nightly', 'release', 'pr', 'e2e']),
+    )
+    booleanParam(
+      name: 'PUBLISH',
+      description: 'Trigger publishing of build results for nightly or release.',
+      defaultValue: params.PUBLISH ?: false,
+    )
   }
 
   stages {
@@ -65,18 +79,20 @@ pipeline {
         ]
         /* add URLs to the build description */
         jenkins.setBuildDesc(urls)
-        /* Create JSON file with newest build URLs */
-        switch (btype) {
-          /* legacy naming, should have named it nightly.json */
-          case 'nightly': s3.updateBucketJSON(urls, 'latest.json'); break
-        }
       } }
     }
     stage('Publish') {
+      when { expression { params.PUBLISH } }
       steps { script {
         switch (btype) {
-          case 'nightly': build(job: 'misc/status.im', wait: false); break
-          case 'release': github.publishReleaseMobile(); break
+          case 'nightly':
+            /* Create JSON file with newest build URLs */
+            s3.updateBucketJSON(urls, 'latest.json');
+            build(job: 'misc/status.im', wait: false);
+            break;
+          case 'release':
+            github.publishReleaseMobile();
+            break;
         }
       } }
     }
@@ -92,4 +108,15 @@ pipeline {
       } }
     }
   }
+}
+
+/* Helper that generates list of available choices for a parameter
+ * but re-orders them based on the currently set value. First is default. */
+def List genChoices(String previousChoice, List defaultChoices) {
+  if (previousChoice == null) {
+     return defaultChoices
+  }
+  choices = defaultChoices.minus(previousChoice)
+  choices.add(0, previousChoice)
+  return choices
 }

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -1,4 +1,4 @@
-library 'status-react-jenkins@v1.2.8'
+library 'status-react-jenkins@v1.2.9'
 
 pipeline {
   agent { label 'macos-xcode-11.5' }

--- a/ci/Jenkinsfile.nix-cache
+++ b/ci/Jenkinsfile.nix-cache
@@ -1,4 +1,4 @@
-library 'status-react-jenkins@v1.2.8'
+library 'status-react-jenkins@v1.2.9'
 
 pipeline {
   agent { label params.AGENT_LABEL }

--- a/ci/tools/Jenkinsfile.fastlane-clean
+++ b/ci/tools/Jenkinsfile.fastlane-clean
@@ -1,4 +1,4 @@
-library 'status-react-jenkins@v1.2.8'
+library 'status-react-jenkins@v1.2.9'
 
 pipeline {
   agent { label 'macos' }

--- a/ci/tools/Jenkinsfile.playstore-meta
+++ b/ci/tools/Jenkinsfile.playstore-meta
@@ -1,4 +1,4 @@
-library 'status-react-jenkins@v1.2.8'
+library 'status-react-jenkins@v1.2.9'
 
 pipeline {
   agent { label 'linux' }


### PR DESCRIPTION
ci: parametrize publishing, make BUILD_TYPE a choice

This changes the behavior of mobile combined builds to not publish the results of `nightly` or `release` builds unless `PUBLISH` parameter is set to `true`.

It also makes the `BUILD_TYPE` into a dropdown choice field with pre-defined values, like `manual` or `e2e`.

Changes:
- Add parameter definitions for `BUILD_TYPE` and `PUBLISH`
- Move uploading of `latest.json` to `Publish` stage
- Make `Publish` stage optional based on the `PUBLISH` parameter

Requires: https://github.com/status-im/status-react-jenkins/pull/21

Example: https://ci.status.im/job/status-react/job/manual/64/

Result:
![image](https://user-images.githubusercontent.com/2212681/103887541-7ecb8f00-50e3-11eb-9a34-fea39595e2c1.png)