### PR TITLE
Update saucelabs endpoint

### DIFF
--- a/test/appium/requirements.txt
+++ b/test/appium/requirements.txt
@@ -39,8 +39,8 @@ PyYAML==5.3.1
 repoze.lru==0.7
 requests==2.25.0
 rlp==1.2.0
-sauceclient==1.0.0
 scrypt==0.8.17
+sauceclient==1.0.0
 selenium==3.14.1
 six==1.10.0
 urllib3==1.25.9

--- a/test/appium/tests/base_test_case.py
+++ b/test/appium/tests/base_test_case.py
@@ -30,7 +30,7 @@ class AbstractTestCase:
 
     @property
     def executor_sauce_lab(self):
-        return 'http://%s:%s@ondemand.saucelabs.com:80/wd/hub' % (self.sauce_username, self.sauce_access_key)
+        return 'https://%s:%s@ondemand.eu-central-1.saucelabs.com:443/wd/hub' % (self.sauce_username, self.sauce_access_key)
 
     @property
     def executor_local(self):
@@ -59,7 +59,6 @@ class AbstractTestCase:
     def capabilities_sauce_lab(self):
         desired_caps = dict()
         desired_caps['app'] = 'sauce-storage:' + test_suite_data.apk_name
-
         desired_caps['build'] = pytest_config_global['build']
         desired_caps['name'] = test_suite_data.current_test.name
         desired_caps['platformName'] = 'Android'

--- a/test/appium/tests/cloudbase_test_api.py
+++ b/test/appium/tests/cloudbase_test_api.py
@@ -1,0 +1,48 @@
+from os import environ
+import json
+import requests
+from io import BytesIO
+
+from sauceclient import SauceClient, SauceException
+
+try:
+    import http.client as http_client
+    from urllib.parse import urlencode
+except ImportError:
+    import httplib as http_client
+    from urllib import urlencode
+
+
+sauce_username = environ.get('SAUCE_USERNAME')
+sauce_access_key = environ.get('SAUCE_ACCESS_KEY')
+
+sauce = SauceClient(sauce_username, sauce_access_key)
+apibase = 'eu-central-1.saucelabs.com'
+
+
+def request(method, url, body=None, content_type='application/json'):
+    """This is to monkey patch further this method in order to use apibase"""
+    headers = sauce.make_auth_headers(content_type)
+    connection = http_client.HTTPSConnection(apibase)
+    connection.request(method, url, body, headers=headers)
+    response = connection.getresponse()
+    data = response.read()
+    connection.close()
+    if response.status not in [200, 201]:
+        raise SauceException('{}: {}.\nSauce Status NOT OK'.format(
+            response.status, response.reason), response=response)
+    return json.loads(data.decode('utf-8'))
+
+sauce.request = request
+
+def upload_from_url(apk_path = str()):
+    response = requests.get(apk_path, stream=True)
+    response.raise_for_status()
+    apk_name = apk_path.split("/")[-1]
+    file = BytesIO(response.content)
+    del response
+    requests.post('https://eu-central-1.saucelabs.com/rest/v1/storage/'
+                  + sauce_username + '/' + apk_name + '?overwrite=true',
+                  auth=(sauce_username, sauce_access_key),
+                  data=file,
+                  headers={'Content-Type': 'application/octet-stream'})


### PR DESCRIPTION
We migrated to EU datacenter in saucelabs and needed to make some changes in code.
Sorry for awkward package in requirements, as a quick fix it should be OK. There is just no updated version on sauceclient package in PyPI yet which has support of different endpoints.