### PR TITLE
Fix wrong greater than sign on mailserver connection

### DIFF
--- a/src/status_im/mailserver/core.cljs
+++ b/src/status_im/mailserver/core.cljs
@@ -614,7 +614,7 @@
                  ;; We either never tried to connect to this peer
                  (or (nil? last-connection-attempt)
                      ;; Or 30 seconds have passed and no luck
-                     (<= (- now last-connection-attempt) (* constants/connection-timeout 3))))
+                     (>= (- now last-connection-attempt) (* constants/connection-timeout 3))))
         ;; Then we change mailserver
         (change-mailserver cofx)))))
 


### PR DESCRIPTION
The wrong condition was used, and had the opposite effect, so that if it would not connect in less than 30 seconds, it would not connect at all :facepalm: 
fixes the issue.