### PR TITLE
[#11626] Group chat subtitle shows 'no members'

### DIFF
--- a/src/status_im/subs.cljs
+++ b/src/status_im/subs.cljs
@@ -774,6 +774,7 @@
  (fn [current-chat]
    (select-keys current-chat
                 [:community-id
+                 :contacts
                  :public?
                  :group-chat
                  :chat-type


### PR DESCRIPTION


fixes #11626