### PR TITLE
Don't rely on contacst for one-to-one mentions, and remove cursor

### DIFF
--- a/src/status_im/chat/models/mentions.cljs
+++ b/src/status_im/chat/models/mentions.cljs
@@ -195,6 +195,10 @@
                        :name       name}))
              {}
              group-contacts))
+          (= chat-type constants/one-to-one-chat-type)
+          (assoc users
+                 current-chat-id
+                 (contact.db/public-key->contact contacts current-chat-id))
 
           :else users)
         {:keys [name preferred-name public-key]}

--- a/src/status_im/contact/db.cljs
+++ b/src/status_im/contact/db.cljs
@@ -18,8 +18,8 @@
 (defn public-key->contact
   [contacts public-key]
   (when public-key
-    (get contacts public-key
-         (public-key->new-contact public-key))))
+    (or (get contacts public-key)
+        (public-key->new-contact public-key))))
 
 (defn- contact-by-address [[addr contact] address]
   (when (ethereum/address= addr address)


### PR DESCRIPTION
[Fixes: #11670]
[Fixes: #11671]

This commit fixes 2 issues.

One issue was due to removing tribute to talk, which added in the
`contacts` map any user you open a chat with, and some code relied on
this behavior.

The second issue was likely due to a react native upgrade which might
have fixed a bug but caused a different issue, which resulted in the
text disappearing when cursor was set.

I have removed that (it was only used on android) and everything seems
to be working correctly, but not so sure about this one.

### Testing

Mentions on android/ios in one-to-one chats/group chats etc

cc @rasom I could not replicate the bug on android with cursor, but maybe I am just not looking in the right place.
I also see the text flickering, not sure if it's develop that is slow though.