### PR TITLE
Only scale if width/height is positive

### DIFF
--- a/src/status_im/ui/screens/chat/message/styles.cljs
+++ b/src/status_im/ui/screens/chat/message/styles.cljs
@@ -130,7 +130,8 @@
        :height (* aspect-ratio max-width)})))
 
 (defn link-preview-image [outgoing {:keys [height width] :as dimensions}]
-  (merge (if (and height width)
+  (merge (if (and (pos? height)
+                  (pos? width))
            (scale-dimensions dimensions)
            {:height 170})
          {:overflow                   :hidden


### PR DESCRIPTION
image width/height is returned as 0,0 from status-go, we should likely `omitempty` there, but also we should make sure they are both positive.