### PR TITLE
Chats improvements

### DIFF
--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -2,7 +2,7 @@
 {:source-paths ["src" "test/cljs"]
 
  :dependencies [[org.clojure/core.async "1.1.587"]
-                [reagent "0.10.0"]
+                [reagent "1.0.0"]
                 [re-frame "0.12.0"]
                 [binaryage/oops "0.7.0"]
                 [com.andrewmcveigh/cljs-time "0.5.2"]
@@ -16,7 +16,7 @@
                 [refactor-nrepl "2.5.0"]
                 [cider/cider-nrepl "0.25.3"]
                 [cider/piggieback "0.4.1"]
-                [re-frisk-remote "1.3.11"]
+                [re-frisk-remote "1.3.12"]
                 ;; routing
                 [bidi "2.1.6"]
                 ;; test dependencies

--- a/src/status_im/chat/models/loading.cljs
+++ b/src/status_im/chat/models/loading.cljs
@@ -1,27 +1,26 @@
 (ns status-im.chat.models.loading
   (:require [re-frame.core :as re-frame]
             [status-im.constants :as constants]
-            [status-im.ui.screens.chat.state :as chat.state]
             [status-im.data-store.chats :as data-store.chats]
             [status-im.data-store.messages :as data-store.messages]
-            [status-im.mailserver.core :as mailserver]
             [status-im.utils.fx :as fx]
-            [status-im.chat.models.reactions :as reactions]
             [status-im.chat.models.message-list :as message-list]
             [taoensso.timbre :as log]
-            [status-im.chat.models.message-seen :as message-seen]
-            [status-im.chat.models.mentions :as mentions]))
+            [status-im.ethereum.json-rpc :as json-rpc]
+            [clojure.string :as string]))
 
 (defn cursor->clock-value
   [^js cursor]
   (js/parseInt (.substring cursor 51 64)))
 
 (defn clock-value->cursor [clock-value]
-  (str "000000000000000000000000000000000000000000000000000" clock-value "0x0000000000000000000000000000000000000000000000000000000000000000"))
+  (str "000000000000000000000000000000000000000000000000000"
+       clock-value
+       "0x0000000000000000000000000000000000000000000000000000000000000000"))
 
 (fx/defn update-chats-in-app-db
   {:events [:chats-list/load-success]}
-  [{:keys [db] :as cofx} new-chats]
+  [{:keys [db]} new-chats]
   (let [old-chats (:chats db)
         chats (reduce (fn [acc {:keys [chat-id] :as chat}]
                         (assoc acc chat-id chat))
@@ -31,35 +30,13 @@
     {:db (assoc db :chats chats
                 :chats/loading? false)}))
 
-(fx/defn handle-chat-visibility-changed
-  {:events [:chat.ui/message-visibility-changed]}
-  [{:keys [db] :as cofx} ^js event]
-  (let [^js viewable-items (.-viewableItems event)
-        ^js last-element (aget viewable-items (dec (.-length viewable-items)))]
-    (when last-element
-      (let [last-element-clock-value (:clock-value (.-item last-element))
-            chat-id (:chat-id (.-item last-element))]
-        (when (and last-element-clock-value
-                   (get-in db [:pagination-info chat-id :messages-initialized?]))
-          (let [new-messages (reduce-kv (fn [acc message-id {:keys [clock-value] :as v}]
-                                          (if (<= last-element-clock-value clock-value)
-                                            (assoc acc message-id v)
-                                            acc))
-                                        {}
-                                        (get-in db [:messages chat-id]))]
-            {:db (-> db
-                     (assoc-in [:messages chat-id] new-messages)
-                     (assoc-in [:pagination-info chat-id] {:all-loaded? false
-                                                           :messages-initialized? true
-                                                           :cursor (clock-value->cursor last-element-clock-value)})
-                     (assoc-in [:message-lists chat-id] (message-list/add-many nil (vals new-messages))))}))))))
-
 (fx/defn initialize-chats
   "Initialize persisted chats on startup"
   [cofx]
   (data-store.chats/fetch-chats-rpc cofx {:on-success
                                           #(re-frame/dispatch
                                             [:chats-list/load-success %])}))
+
 (fx/defn handle-failed-loading-messages
   {:events [::failed-loading-messages]}
   [{:keys [db]} current-chat-id _ err]
@@ -67,104 +44,88 @@
   (when current-chat-id
     {:db (assoc-in db [:pagination-info current-chat-id :loading-messages?] false)}))
 
+(fx/defn handle-mark-all-read-successful
+  {:events [::mark-all-read-successful]}
+  [{:keys [db]} chat-id]
+  {:db (assoc-in db [:chats chat-id :unviewed-messages-count] 0)})
+
+(fx/defn handle-mark-all-read
+  {:events [:chat.ui/mark-all-read-pressed :chat/mark-all-as-read]}
+  [_ chat-id]
+  {::json-rpc/call [{:method     (json-rpc/call-ext-method "markAllRead")
+                     :params     [chat-id]
+                     :on-success #(re-frame/dispatch [::mark-all-read-successful chat-id])}]})
+
 (fx/defn messages-loaded
   "Loads more messages for current chat"
   {:events [::messages-loaded]}
-  [{{:keys [current-chat-id] :as db} :db :as cofx}
-   chat-id
-   session-id
-   {:keys [cursor messages]}]
-  (when-not (or (nil? current-chat-id)
-                (not= chat-id current-chat-id)
-                (and (get-in db [:pagination-info current-chat-id :messages-initialized?])
-                     (not= session-id
-                           (get-in db [:pagination-info current-chat-id :messages-initialized?]))))
-    (let [already-loaded-messages      (get-in db [:messages current-chat-id])
-          loaded-unviewed-messages-ids (get-in db [:chats current-chat-id :loaded-unviewed-messages-ids] #{})
-          users                        (get-in db [:chats current-chat-id :users] {})
+  [{db :db} chat-id session-id {:keys [cursor messages]}]
+  (when-not (and (get-in db [:pagination-info chat-id :messages-initialized?])
+                 (not= session-id
+                       (get-in db [:pagination-info chat-id :messages-initialized?])))
+    (let [already-loaded-messages (get-in db [:messages chat-id])
           ;; We remove those messages that are already loaded, as we might get some duplicates
-          {:keys [all-messages
-                  new-messages
-                  last-clock-value
-                  unviewed-message-ids
-                  users]}
-          (reduce (fn [{:keys [last-clock-value all-messages users] :as acc}
-                       {:keys [clock-value seen message-id alias name identicon from]
-                        :as message}]
-                    (let [nickname (get-in db [:contacts/contacts from :nickname])]
-                      (cond-> acc
-                        (and alias (not= alias ""))
-                        (update :users assoc from
-                                (mentions/add-searchable-phrases
-                                 {:alias      alias
-                                  :name       (or name alias)
-                                  :identicon  identicon
-                                  :public-key from
-                                  :nickname   nickname}))
-                        (or (nil? last-clock-value)
-                            (> last-clock-value clock-value))
-                        (assoc :last-clock-value clock-value)
+          {:keys [all-messages new-messages senders]}
+          (reduce (fn [{:keys [all-messages] :as acc}
+                       {:keys [message-id alias from]
+                        :as   message}]
+                    (cond-> acc
+                      (and (not (string/blank? alias))
+                           (not (get-in db [:chats chat-id :users from])))
+                      (update :senders assoc from message)
 
-                        (not seen)
-                        (update :unviewed-message-ids conj message-id)
+                      (nil? (get all-messages message-id))
+                      (update :new-messages conj message)
 
-                        (nil? (get all-messages message-id))
-                        (update :new-messages conj message)
+                      :always
+                      (update :all-messages assoc message-id message)))
+                  {:all-messages already-loaded-messages
+                   :senders      {}
+                   :new-messages []}
+                  messages)
+          current-clock-value (get-in db [:pagination-info chat-id :cursor-clock-value])
+          clock-value (when cursor (cursor->clock-value cursor))]
+      {:dispatch [:chat/add-senders-to-chat-users (vals senders)]
+       :db       (-> db
+                     (update-in [:pagination-info chat-id :cursor-clock-value]
+                                #(if (and (seq cursor) (or (not %) (< clock-value %)))
+                                   clock-value
+                                   %))
 
-                        :always
-                        (update :all-messages assoc message-id message))))
-                  {:all-messages         already-loaded-messages
-                   :unviewed-message-ids loaded-unviewed-messages-ids
-                   :users                users
-                   :new-messages         []}
-                  messages)]
-      (fx/merge cofx
-                {:db (-> db
-                         (assoc-in [:pagination-info current-chat-id :cursor-clock-value] (when (seq cursor) (cursor->clock-value cursor)))
-                         (assoc-in [:chats current-chat-id :loaded-unviewed-messages-ids] unviewed-message-ids)
-                         (assoc-in [:chats current-chat-id :users] users)
-                         (assoc-in [:pagination-info current-chat-id :loading-messages?] false)
-                         (assoc-in [:messages current-chat-id] all-messages)
-                         (update-in [:message-lists current-chat-id] message-list/add-many new-messages)
-                         (assoc-in [:pagination-info current-chat-id :cursor] cursor)
-                         (assoc-in [:pagination-info current-chat-id :all-loaded?]
-                                   (empty? cursor)))}
-                (message-seen/mark-messages-seen current-chat-id)))))
+                     (update-in [:pagination-info chat-id :cursor]
+                                #(if (or (empty? cursor) (not current-clock-value) (< clock-value current-clock-value))
+                                   cursor
+                                   %))
+                     (assoc-in [:pagination-info chat-id :loading-messages?] false)
+                     (assoc-in [:messages chat-id] all-messages)
+                     (update-in [:message-lists chat-id] message-list/add-many new-messages)
+                     (assoc-in [:pagination-info chat-id :all-loaded?]
+                               (empty? cursor)))})))
 
 (fx/defn load-more-messages
   {:events [:chat.ui/load-more-messages]}
-  [{:keys [db] :as cofx}]
-  (when-let [current-chat-id (:current-chat-id db)]
-    (when-let [session-id (get-in db [:pagination-info current-chat-id :messages-initialized?])]
-      (when-not (or (get-in db [:pagination-info current-chat-id :all-loaded?])
-                    (get-in db [:pagination-info current-chat-id :loading-messages?]))
-        (let [cursor (get-in db [:pagination-info current-chat-id :cursor])
-              load-messages-fx (data-store.messages/messages-by-chat-id-rpc
-                                current-chat-id
-                                cursor
-                                constants/default-number-of-messages
-                                #(re-frame/dispatch [::messages-loaded current-chat-id session-id %])
-                                #(re-frame/dispatch [::failed-loading-messages current-chat-id session-id %]))]
-          (fx/merge cofx
-                    load-messages-fx
-                    (reactions/load-more-reactions cursor)
-                    (mailserver/load-gaps-fx current-chat-id)))))))
+  [{:keys [db]} chat-id first-request]
+  (when-let [session-id (get-in db [:pagination-info chat-id :messages-initialized?])]
+    (when (and
+           (not (get-in db [:pagination-info chat-id :all-loaded?]))
+           (not (get-in db [:pagination-info chat-id :loading-messages?])))
+      (let [cursor (get-in db [:pagination-info chat-id :cursor])]
+        (when (or first-request cursor)
+          (merge
+           {:db (assoc-in db [:pagination-info chat-id :loading-messages?] true)}
+           {:utils/dispatch-later [{:ms 100 :dispatch [:load-more-reactions cursor chat-id]}
+                                   {:ms 100 :dispatch [:load-gaps chat-id]}]}
+           (data-store.messages/messages-by-chat-id-rpc
+            chat-id
+            cursor
+            constants/default-number-of-messages
+            #(re-frame/dispatch [::messages-loaded chat-id session-id %])
+            #(re-frame/dispatch [::failed-loading-messages chat-id session-id %]))))))))
 
 (fx/defn load-messages
-  {:events [:load-messages]}
-  [{:keys [db now] :as cofx}]
-  (when-let [current-chat-id (:current-chat-id db)]
-    (if-not (get-in db [:pagination-info current-chat-id :messages-initialized?])
-      (do
-       ; reset chat first-not-visible-items state
-        (chat.state/reset)
-        (fx/merge cofx
-                  {:db (-> db
-                          ;; We keep track of whether there's a loaded chat
-                          ;; which will be reset only if we hit home
-                           (assoc :loaded-chat-id current-chat-id)
-                           (assoc-in [:pagination-info current-chat-id :messages-initialized?] now))}
-                  (message-seen/mark-messages-seen current-chat-id)
-                  (load-more-messages)))
-      ;; We mark messages as seen in case we received them while on a different tab
-      (message-seen/mark-messages-seen cofx current-chat-id))))
+  [{:keys [db now] :as cofx} chat-id]
+  (when-not (get-in db [:pagination-info chat-id :messages-initialized?])
+    (fx/merge cofx
+              {:db (assoc-in db [:pagination-info chat-id :messages-initialized?] now)
+               :utils/dispatch-later [{:ms 500 :dispatch [:chat.ui/mark-all-read-pressed chat-id]}]}
+              (load-more-messages chat-id true))))

--- a/src/status_im/chat/models/message.cljs
+++ b/src/status_im/chat/models/message.cljs
@@ -1,214 +1,188 @@
 (ns status-im.chat.models.message
-  (:require [re-frame.core :as re-frame]
-            [status-im.chat.models :as chat-model]
-            [status-im.chat.models.loading :as chat-loading]
+  (:require [status-im.chat.models :as chat-model]
             [status-im.chat.models.message-list :as message-list]
             [status-im.constants :as constants]
             [status-im.data-store.messages :as data-store.messages]
             [status-im.ethereum.json-rpc :as json-rpc]
-            [status-im.multiaccounts.model :as multiaccounts.model]
             [status-im.transport.message.protocol :as protocol]
-            [status-im.ui.screens.chat.state :as view.state]
             [status-im.utils.fx :as fx]
             [taoensso.timbre :as log]
             [status-im.chat.models.mentions :as mentions]
-            [clojure.string :as string]))
+            [clojure.string :as string]
+            [status-im.contact.db :as contact.db]
+            [status-im.utils.types :as types]
+            [status-im.ui.screens.chat.state :as view.state]
+            [status-im.chat.models.loading :as chat.loading]
+            [status-im.utils.platform :as platform]))
 
-(defn- prepare-message
-  [message current-chat?]
-  (cond-> message
-    current-chat?
-    (assoc :seen true)))
+(defn- message-loaded?
+  [db chat-id message-id]
+  (get-in db [:messages chat-id message-id]))
 
+(defn- earlier-than-deleted-at?
+  [db chat-id clock-value]
+  (>= (get-in db [:chats chat-id :deleted-at-clock-value]) clock-value))
+
+(defn add-timeline-message [acc chat-id message-id message]
+  (-> acc
+      (update-in [:db :messages chat-id] assoc message-id message)
+      (update-in [:db :message-lists chat-id] message-list/add message)))
+
+;;TODO this is too expensive, probably we could mark message somehow and just hide it in the UI
 (fx/defn rebuild-message-list
   [{:keys [db]} chat-id]
   {:db (assoc-in db [:message-lists chat-id]
                  (message-list/add-many nil (vals (get-in db [:messages chat-id]))))})
 
-(fx/defn hidden-message-marked-as-seen
-  {:events [::hidden-message-marked-as-seen]}
-  [{:keys [db] :as cofx} chat-id _ hidden-message-count]
-  (when (= 1 hidden-message-count)
-    {:db (update-in db [:chats chat-id]
-                    update
-                    :unviewed-messages-count dec)}))
-(fx/defn hide-message
+(defn hide-message
   "Hide chat message, rebuild message-list"
-  [{:keys [db] :as cofx} chat-id {:keys [seen message-id]}]
-  (fx/merge cofx
-            {:db (update-in db [:messages chat-id] dissoc message-id)}
-            (data-store.messages/mark-messages-seen chat-id [message-id] #(re-frame/dispatch [::hidden-message-marked-as-seen %1 %2 %3]))
-            (rebuild-message-list chat-id)))
+  [{:keys [db]} chat-id message-id]
+  ;;TODO this is too expensive, probably we could mark message somehow and just hide it in the UI
+  (rebuild-message-list {:db (update-in db [:messages chat-id] dissoc message-id)} chat-id))
 
-(fx/defn add-message
-  [{:keys [db] :as cofx}
-   {{:keys [chat-id message-id replace timestamp from] :as message} :message
-    :keys [seen-by-user?]}]
-  (let [current-public-key (multiaccounts.model/current-public-key cofx)
-        message-to-be-removed (when replace
-                                (get-in db [:messages chat-id replace]))
-        prepared-message (prepare-message message seen-by-user?)]
-    (fx/merge cofx
-              (when message-to-be-removed
-                (hide-message chat-id message-to-be-removed))
-              (fn [{:keys [db]}]
-                {:db (cond-> (-> db
-                                 ;; We should not be always adding to the list, as it does not make sense
-                                 ;; if the chat has not been initialized, but run into
-                                 ;; some troubles disabling it, so next time
-                                 (update-in [:messages chat-id] assoc message-id prepared-message)
-                                 (update-in [:message-lists chat-id] message-list/add prepared-message))
-                       (and (not seen-by-user?)
-                            (not= from current-public-key)
-                            (not (get-in db [:chats chat-id :profile-public-key]))
-                            (not (get-in db [:chats chat-id :timeline?])))
-                       (update-in [:chats chat-id :loaded-unviewed-messages-ids]
-                                  (fnil conj #{}) message-id))}))))
+(fx/defn join-times-messages-checked
+  "The key :might-have-join-time-messages? in public chats signals that
+  the public chat is freshly (re)created and requests for messages to the
+  mailserver for the topic has not completed yet. Likewise, the key
+  :join-time-mail-request-id is associated a little bit after, to signal that
+  the request to mailserver was a success. When request is signalled complete
+  by mailserver, corresponding event :chat.ui/join-times-messages-checked
+  dissociates these two fileds via this function, thereby signalling that the
+  public chat is not fresh anymore."
+  {:events [:chat/join-times-messages-checked]}
+  [{:keys [db] :as cofx} chat-ids]
+  (reduce (fn [acc chat-id]
+            (cond-> acc
+              (:might-have-join-time-messages? (chat-model/get-chat cofx chat-id))
+              (update :db #(chat-model/dissoc-join-time-fields % chat-id))))
+          {:db db}
+          chat-ids))
 
-(fx/defn add-sender-to-chat-users
-  [{:keys [db]} {:keys [chat-id alias name identicon from]}]
-  (when (and alias (not= alias ""))
-    (let [nickname (get-in db [:contacts/contacts from :nickname])]
-      {:db (update-in db [:chats chat-id :users] assoc
-                      from
-                      (mentions/add-searchable-phrases
-                       {:alias      alias
-                        :name       (or name alias)
-                        :identicon  identicon
-                        :public-key from
-                        :nickname   nickname}))})))
+(fx/defn add-senders-to-chat-users
+  {:events [:chat/add-senders-to-chat-users]}
+  [{:keys [db]} messages]
+  (reduce (fn [acc {:keys [chat-id alias name identicon from]}]
+            (update-in acc [:db :chats chat-id :users] assoc
+                       from
+                       (mentions/add-searchable-phrases
+                        {:alias      alias
+                         :name       (or name alias)
+                         :identicon  identicon
+                         :public-key from
+                         :nickname   (get-in db [:contacts/contacts from :nickname])})))
+          {:db db}
+          messages))
 
-(fx/defn add-received-message
-  [{:keys [db] :as cofx}
-   {:keys [chat-id clock-value] :as message}]
-  (let [{:keys [loaded-chat-id view-id current-chat-id]} db
-        cursor-clock-value (get-in db [:chats current-chat-id :cursor-clock-value])
-        current-chat?      (= chat-id loaded-chat-id)]
-    (when current-chat?
-      (fx/merge
-       cofx
-       ;; If we don't have any hidden message or the hidden message is before
-       ;; this one, we add the message to the UI
-       (if (or (not @view.state/first-not-visible-item)
-               (<= (:clock-value @view.state/first-not-visible-item)
-                   clock-value))
-         (add-message {:message       message
-                       :seen-by-user? (and current-chat?
-                                           (= view-id :chat))})
-         ;; Not in the current view, set all-loaded to false
-         ;; and offload to db and update cursor if necessary
-         {:db (cond-> (assoc-in db [:chats chat-id :all-loaded?] false)
-                (>= clock-value cursor-clock-value)
-                (update-in [:chats chat-id] assoc
-                           :cursor (chat-loading/clock-value->cursor clock-value)
-                           :cursor-clock-value clock-value))})
-       (add-sender-to-chat-users message)))))
+(defn timeline-message? [db chat-id]
+  (and
+   (get-in db [:pagination-info constants/timeline-chat-id :messages-initialized?])
+   (or
+    (= chat-id (chat-model/my-profile-chat-topic db))
+    (when-let [pub-key (get-in db [:chats chat-id :profile-public-key])]
+      (contact.db/added? db pub-key)))))
 
-(defn- message-loaded?
-  [{:keys [db]} {:keys [chat-id message-id]}]
-  (get-in db [:messages chat-id message-id]))
+(defn get-timeline-message [db chat-id message-js]
+  (when (timeline-message? db chat-id)
+    (data-store.messages/<-rpc (types/js->clj message-js))))
 
-(defn- earlier-than-deleted-at?
-  [{:keys [db]} {:keys [chat-id clock-value]}]
-  (let [{:keys [deleted-at-clock-value]}
-        (get-in db [:chats chat-id])]
-    (>= deleted-at-clock-value clock-value)))
+(defn add-message [{:keys [db] :as acc} message-js chat-id message-id cursor-clock-value]
+  (let [{:keys [alias replace from clock-value] :as message}
+        (data-store.messages/<-rpc (types/js->clj message-js))]
+    (if (message-loaded? db chat-id message-id)
+      ;; If the message is already loaded, it means it's an update, that
+      ;; happens when a message that was missing a reply had the reply
+      ;; coming through, in which case we just insert the new message
+      (assoc-in acc [:db :messages chat-id message-id] message)
+      (cond-> acc
+        ;;add new message to db
+        :always
+        (update-in [:db :messages chat-id] assoc message-id message)
+        :always
+        (update-in [:db :message-lists chat-id] message-list/add message)
 
-(fx/defn update-unviewed-count
-  [{:keys [db] :as cofx} {:keys [chat-id from message-type message-id new?]}]
-  (when-not (= message-type constants/message-type-private-group-system-message)
-    (let [{:keys [current-chat-id view-id]} db
-          chat-view?         (= :chat view-id)
-          current-count (get-in db [:chats chat-id :unviewed-messages-count])]
-      (cond
-        (= from (multiaccounts.model/current-public-key cofx))
-       ;; nothing to do
-        nil
+        (or (not cursor-clock-value) (< clock-value cursor-clock-value))
+        (update-in [:db :pagination-info chat-id] assoc
+                   :cursor (chat.loading/clock-value->cursor clock-value)
+                   :cursor-clock-value clock-value)
 
-        (and chat-view? (= current-chat-id chat-id))
-        (fx/merge cofx
-                  (data-store.messages/mark-messages-seen current-chat-id [message-id] nil))
+        ;;conj sender for add-sender-to-chat-users
+        (and (not (string/blank? alias))
+             (not (get-in db [:chats chat-id :users from])))
+        (update :senders assoc from message)
 
-        new?
-        {:db (update-in db [:chats chat-id]
-                        assoc
-                        :unviewed-messages-count (inc current-count))}))))
+        (not (string/blank? replace))
+        ;;TODO this is expensive
+        (hide-message chat-id replace)))))
 
-(fx/defn check-for-incoming-tx
-  [cofx {{:keys [transaction-hash]} :command-parameters}]
-  (when (and transaction-hash
-             (not (string/blank? transaction-hash)))
-    ;; NOTE(rasom): dispatch later is needed because of circular dependency
-    {:dispatch-later
-     [{:dispatch [:watch-tx transaction-hash]
-       :ms       20}]}))
+(defn reduce-js-messages [{:keys [db] :as acc} ^js message-js]
+  (let [chat-id (.-localChatId message-js)
+        clock-value (.-clock message-js)
+        message-id (.-id message-js)
+        current-chat-id (:current-chat-id db)
+        cursor-clock-value (get-in db [:pagination-info current-chat-id :cursor-clock-value])]
+    ;;ignore not opened chats and earlier clock
+    (if (and (get-in db [:pagination-info chat-id :messages-initialized?])
+             ;;TODO why do we need this ?
+             (not (earlier-than-deleted-at? db chat-id clock-value)))
+      (if (or (not @view.state/first-not-visible-item)
+              (<= (:clock-value @view.state/first-not-visible-item)
+                  clock-value))
+        (add-message acc message-js chat-id message-id cursor-clock-value)
+        ;; Not in the current view, set all-loaded to false
+        ;; and offload to db and update cursor if necessary
+        ;;TODO if we'll offload messages , it will conflict with end reached, so probably if we reached the end of visible area,
+        ;; we need to drop other messages with (< clock-value cursor-clock-value) from response-js so we don't update
+        ;; :cursor-clock-value because it will be changed when we loadMore message
+        {:db (cond-> (assoc-in db [:pagination-info chat-id :all-loaded?] false)
+               (> clock-value cursor-clock-value)
+               ;;TODO cut older messages from messages-list
+               (update-in [:pagination-info chat-id] assoc
+                          :cursor (chat.loading/clock-value->cursor clock-value)
+                          :cursor-clock-value clock-value))})
+      acc)))
 
-(fx/defn receive-one
-  {:events [::receive-one]}
-  [{:keys [db] :as cofx} {:keys [message-id chat-id] :as message}]
-  (fx/merge cofx
-            ;;If its a profile updates we want to add this message to the timeline as well
-            #(when (get-in cofx [:db :chats chat-id :profile-public-key])
-               {:dispatch-n [[::receive-one (assoc message :chat-id chat-model/timeline-chat-id)]]})
-            #(when-not (earlier-than-deleted-at? cofx message)
-               (if (message-loaded? cofx message)
-                 ;; If the message is already loaded, it means it's an update, that
-                 ;; happens when a message that was missing a reply had the reply
-                 ;; coming through, in which case we just insert the new message
-                 {:db (assoc-in db [:messages chat-id message-id] message)}
-                 (fx/merge cofx
-                           (add-received-message message)
-                           (update-unviewed-count message)
-                           (chat-model/join-time-messages-checked chat-id)
-                           (check-for-incoming-tx message))))))
+(defn receive-many [{:keys [db]} ^js response-js]
+  (let [current-chat-id (:current-chat-id db)
+        messages-js ^js (.splice (.-messages response-js) 0 (if platform/low-device? 3 10))
+        {:keys [db chats senders]}
+        (reduce reduce-js-messages
+                {:db db :chats #{} :senders {} :transactions #{}}
+                messages-js)]
+    ;;we want to render new messages as soon as possible
+    ;;so we dispatch later all other events which can be handled async
+    {:db db
 
-;;TODO currently we process every message, we need to precess them by batches
-;;or better move processing to status-go
-#_((fx/defn add-received-messages
-     [{:keys [db] :as cofx} grouped-messages]
-     (when-let [messages (get grouped-messages (:loaded-chat-id db))]
-       (apply fx/merge cofx (map add-received-message messages))))
+     :utils/dispatch-later
+     (concat [{:ms 20 :dispatch [:process-response response-js]}]
+             (when (and current-chat-id
+                        (get chats current-chat-id)
+                        (not (chat-model/profile-chat? {:db db} current-chat-id)))
+               [{:ms 100 :dispatch [:chat/mark-all-as-read (:current-chat-id db)]}])
+             (when (seq senders)
+               [{:ms 100 :dispatch [:chat/add-senders-to-chat-users (vals senders)]}]))}))
 
-   (defn reduce-count-messages [me]
-     (fn [acc chat-id messages]
-       (assoc acc chat-id
-              (remove #(or
-                        (= (:message-type %)
-                           constants/message-type-private-group-system-message)
-                        (= (:from %) me))
-                      messages))))
+(defn reduce-js-statuses [db ^js message-js]
+  (let [chat-id (.-localChatId message-js)
+        profile-initialized (get-in db [:pagination-info chat-id :messages-initialized?])
+        timeline-message (timeline-message? db chat-id)]
+    (if (or profile-initialized timeline-message)
+      (let [{:keys [message-id] :as message} (data-store.messages/<-rpc (types/js->clj message-js))]
+        (cond-> db
+          profile-initialized
+          (update-in [:messages chat-id] assoc message-id message)
+          profile-initialized
+          (update-in [:message-lists chat-id] message-list/add message)
+          timeline-message
+          (update-in [:messages constants/timeline-chat-id] assoc message-id message)
+          timeline-message
+          (update-in [:message-lists constants/timeline-chat-id] message-list/add message)))
+      db)))
 
-   (defn reduce-chat-messages [chat-view? current-chat-id]
-     (fn [acc chat-id messages]
-       (if (and chat-view? (= current-chat-id chat-id))
-         (data-store.messages/mark-messages-seen acc current-chat-id (map :message-id messages) nil)
-         (update-in acc [:db :chats chat-id :unviewed-messages-count] + (count messages)))))
+(fx/defn process-statuses
+  {:events [:process-statuses]}
+  [{:keys [db]} statuses]
+  {:db (reduce reduce-js-statuses db statuses)})
 
-   (fx/defn update-unviewed-counts
-     [{:keys [db] :as cofx} grouped-messages]
-     (let [{:keys [current-chat-id view-id]} db
-           me (multiaccounts.model/current-public-key cofx)
-           messages (reduce-kv (reduce-count-messages me)
-                               {}
-                               grouped-messages)]
-       (when (seq messages)
-         (reduce-kv (reduce-chat-messages (= :chat view-id) current-chat-id) {:db db} messages))))
-
-   (fx/defn receive [cofx messages]
-     (when-let [grouped-messages
-                (->> (into []
-                           (comp
-                            (map #(assoc % :chat-id (extract-chat-id cofx %)))
-                            (remove #(earlier-than-deleted-at? cofx %)))
-                           messages)
-                     (group-by :chat-id))]
-       (when (seq grouped-messages)
-         (fx/merge cofx
-                   (add-received-messages grouped-messages)
-                   (update-unviewed-counts grouped-messages)
-                   (chat-model/join-time-messages-checked-for-chats (keys grouped-messages)))))))
-
-;;;; Send message
 (fx/defn update-db-message-status
   [{:keys [db] :as cofx} chat-id message-id status]
   (when (get-in db [:messages chat-id message-id])
@@ -242,13 +216,9 @@
             (rebuild-message-list chat-id)))
 
 (fx/defn send-message
-  [{:keys [db now] :as cofx} message]
+  [cofx message]
   (protocol/send-chat-messages cofx [message]))
 
 (fx/defn send-messages
-  [{:keys [db now] :as cofx} messages]
+  [cofx messages]
   (protocol/send-chat-messages cofx messages))
-
-(fx/defn toggle-expand-message
-  [{:keys [db]} chat-id message-id]
-  {:db (update-in db [:messages chat-id message-id :expanded?] not)})

--- a/src/status_im/chat/models/message_list.cljs
+++ b/src/status_im/chat/models/message_list.cljs
@@ -4,6 +4,7 @@
             ["functional-red-black-tree" :as rb-tree]))
 
 (defn- add-datemark [{:keys [whisper-timestamp] :as msg}]
+  ;;TODO this is slow
   (assoc msg :datemark (time/day-relative whisper-timestamp)))
 
 (defn- add-timestamp [{:keys [whisper-timestamp] :as msg}]
@@ -132,12 +133,10 @@
   (let [^js iter (.find tree message)
         ^js previous-message (when (.-hasPrev iter)
                                (get-prev-element iter))
-        ^js next-message     (when (.-hasNext iter)
-                               (get-next-element iter))
+        ^js next-message (when (.-hasNext iter)
+                           (get-next-element iter))
         ^js message-with-pos-data (add-group-info message previous-message next-message)]
-    (cond->
-     (.update iter message-with-pos-data)
-
+    (cond-> (.update iter message-with-pos-data)
       next-message
       (-> ^js (.find next-message)
           (.update (update-next-message message-with-pos-data next-message)))
@@ -170,8 +169,7 @@
     (update-message tree prepared-message)))
 
 (defn add [message-list message]
-  (insert-message (or message-list (rb-tree compare-fn))
-                  (prepare-message message)))
+  (insert-message (or message-list (rb-tree compare-fn)) (prepare-message message)))
 
 (defn add-many [message-list messages]
   (reduce add

--- a/src/status_im/chat/models/message_seen.cljs
+++ b/src/status_im/chat/models/message_seen.cljs
@@ -13,8 +13,7 @@
     {:db (update-in db [:chats chat-id] assoc
                     :unviewed-messages-count (subtract-seen-messages
                                               unviewed-messages-count
-                                              loaded-unviewed-messages-ids)
-                    :loaded-unviewed-messages-ids #{})}))
+                                              loaded-unviewed-messages-ids))}))
 
 (fx/defn mark-messages-seen
   "Marks all unviewed loaded messages as seen in particular chat"
@@ -29,10 +28,3 @@
                              loaded-unviewed-ids)}
                 (messages-store/mark-messages-seen chat-id loaded-unviewed-ids nil)
                 (update-chats-unviewed-messages-count {:chat-id chat-id})))))
-
-(fx/defn ui-mark-messages-seen
-  {:events [:chat.ui/mark-messages-seen]}
-  [{:keys [db] :as cofx} view-id]
-  (fx/merge cofx
-            {:db (assoc db :view-id view-id)}
-            (mark-messages-seen cofx (:current-chat-id db))))

--- a/src/status_im/chat/models/message_test.cljs
+++ b/src/status_im/chat/models/message_test.cljs
@@ -1,155 +1,135 @@
 (ns status-im.chat.models.message-test
   (:require [cljs.test :refer-macros [deftest is testing]]
-            [status-im.chat.models.loading :as chat-loading]
             [status-im.chat.models.message :as message]
             [status-im.chat.models.message-list :as models.message-list]
-            [status-im.ui.screens.chat.state :as view.state]
-            [status-im.utils.datetime :as time]))
+            [status-im.chat.models.loading :as loading]
+            [status-im.utils.datetime :as time]
+            [status-im.ui.screens.chat.state :as view.state]))
 
 (deftest add-received-message-test
-  (with-redefs [message/add-message (constantly :added)]
+  (with-redefs [message/add-message #(identity %1)]
     (let [chat-id "chat-id"
           clock-value 10
           cursor-clock-value (dec clock-value)
-          cursor (chat-loading/clock-value->cursor cursor-clock-value)
+          cursor (loading/clock-value->cursor cursor-clock-value)
           cofx {:now 0
-                :db {:loaded-chat-id chat-id
-                     :current-chat-id chat-id
-                     :all-loaded? true
-                     :chats {chat-id {:cursor cursor
-                                      :cursor-clock-value cursor-clock-value}}}}
-          message {:chat-id     chat-id
-                   :clock-value clock-value
-                   :alias       "alias"
-                   :name        "name"
-                   :identicon   "identicon"
-                   :from        "from"}]
-      (testing "not current-chat"
-        (is (nil? (message/add-received-message
-                   (update cofx :db dissoc :loaded-chat-id)
-                   message))))
+                :db {:current-chat-id chat-id
+                     :pagination-info {chat-id {:messages-initialized? true
+                                                :cursor cursor
+                                                :cursor-clock-value cursor-clock-value}}}}
+          message #js {:localChatId chat-id
+                       :clock       clock-value
+                       :alias       "alias"
+                       :name        "name"
+                       :identicon   "identicon"
+                       :from        "from"}]
       ;; <- cursor
       ;; <- message
       ;; <- top of the chat
       (testing "there's no hidden item"
         (with-redefs [view.state/first-not-visible-item (atom nil)]
-          (is (= {:db {:loaded-chat-id  "chat-id",
-                       :current-chat-id "chat-id",
-                       :all-loaded?     true,
-                       :chats
+          (is (= {:db {:current-chat-id "chat-id",
+                       :pagination-info
                        {"chat-id"
-                        {:cursor
+                        {:messages-initialized? true
+                         :cursor
                          "00000000000000000000000000000000000000000000000000090x0000000000000000000000000000000000000000000000000000000000000000",
-                         :cursor-clock-value 9,
-                         :users
-                         {"from" {:alias              "alias",
-                                  :name               "name",
-                                  :identicon          "identicon",
-                                  :public-key         "from"
-                                  :nickname           nil
-                                  :searchable-phrases ["alias" "name"]}}}}}}
-                 (message/add-received-message
-                  cofx
-                  message)))))
+                         :cursor-clock-value 9}}}}
+                 (dissoc (message/receive-many
+                          cofx
+                          #js {:messages (to-array [message])})
+                         :utils/dispatch-later)))))
       ;; <- cursor
       ;; <- first-hidden-item
       ;; <- message
       ;; <- top of the chat
       (testing "the hidden item has a clock value less than the current"
         (with-redefs [view.state/first-not-visible-item (atom {:clock-value (dec clock-value)})]
-          (is (= {:db {:loaded-chat-id  "chat-id",
-                       :current-chat-id "chat-id",
-                       :all-loaded?     true,
-                       :chats
+          (is (= {:db {:current-chat-id "chat-id",
+                       :pagination-info
                        {"chat-id"
-                        {:cursor
+                        {:messages-initialized? true
+                         :cursor
                          "00000000000000000000000000000000000000000000000000090x0000000000000000000000000000000000000000000000000000000000000000",
-                         :cursor-clock-value 9,
-                         :users
-                         {"from" {:alias              "alias",
-                                  :name               "name",
-                                  :identicon          "identicon",
-                                  :public-key         "from"
-                                  :nickname           nil
-                                  :searchable-phrases ["alias" "name"]}}}}}}
-                 (message/add-received-message
-                  cofx
-                  message)))))
+                         :cursor-clock-value 9}}}}
+                 (dissoc (message/receive-many
+                          cofx
+                          #js {:messages (to-array [message])})
+                         :utils/dispatch-later)))))
       ;; <- cursor
       ;; <- message
       ;; <- first-hidden-item
       ;; <- top of the chat
       (testing "the message falls between the first-hidden-item and cursor"
         (with-redefs [view.state/first-not-visible-item (atom {:clock-value (inc clock-value)})]
-          (let [result (message/add-received-message
-                        cofx
-                        message)]
+          (let [result (dissoc (message/receive-many
+                                cofx
+                                #js {:messages (to-array [message])})
+                               :utils/dispatch-later)]
             (testing "it sets all-loaded? to false"
-              (is (not (get-in result [:db :chats chat-id :all-loaded?]))))
+              (is (not (get-in result [:db :pagination-info chat-id :all-loaded?]))))
             (testing "it updates cursor-clock-value & cursor"
-              (is (= clock-value (get-in result [:db :chats chat-id :cursor-clock-value])))
-              (is (= (chat-loading/clock-value->cursor clock-value) (get-in result [:db :chats chat-id :cursor])))))))
+              (is (= clock-value (get-in result [:db :pagination-info chat-id :cursor-clock-value])))
+              (is (= (loading/clock-value->cursor clock-value) (get-in result [:db :pagination-info chat-id :cursor])))))))
       ;; <- message
       ;; <- first-hidden-item
       ;; <- top of the chat
       (testing "the message falls between the first-hidden-item and cursor is nil"
         (with-redefs [view.state/first-not-visible-item (atom {:clock-value (inc clock-value)})]
-          (let [result (message/add-received-message
-                        (update-in cofx [:db :chats chat-id] dissoc :cursor :cursor-clock-value)
-                        message)]
+          (let [result (dissoc (message/receive-many
+                                (update-in cofx [:db :pagination-info chat-id] dissoc :cursor :cursor-clock-value)
+                                #js {:messages (to-array [message])})
+                               :utils/dispatch-later)]
             (testing "it sets all-loaded? to false"
-              (is (not (get-in result [:db :chats chat-id :all-loaded?]))))
+              (is (not (get-in result [:db :pagination-info chat-id :all-loaded?]))))
             (testing "it updates cursor-clock-value & cursor"
-              (is (= clock-value (get-in result [:db :chats chat-id :cursor-clock-value])))
-              (is (= (chat-loading/clock-value->cursor clock-value) (get-in result [:db :chats chat-id :cursor])))))))
+              (is (= clock-value (get-in result [:db :pagination-info chat-id :cursor-clock-value])))
+              (is (= (loading/clock-value->cursor clock-value) (get-in result [:db :pagination-info chat-id :cursor])))))))
       ;; <- message
       ;; <- cursor
       ;; <- first-hidden-item
       ;; <- top of the chat
       (testing "the message falls before both the first-hidden-item and cursor"
         (with-redefs [view.state/first-not-visible-item (atom {:clock-value (inc clock-value)})]
-          (let [result (message/add-received-message
-                        cofx
-                        (update message :clock-value #(- % 2)))]
+          (let [message #js {:localChatId chat-id
+                             :clock       (- clock-value 2)
+                             :alias       "alias"
+                             :name        "name"
+                             :identicon   "identicon"
+                             :from        "from"}
+                result (dissoc (message/receive-many
+                                cofx
+                                #js {:messages (to-array [message])})
+                               :utils/dispatch-later)]
             (testing "it sets all-loaded? to false"
-              (is (not (get-in result [:db :chats chat-id :all-loaded?]))))
+              (is (not (get-in result [:db :pagination-info chat-id :all-loaded?]))))
             (testing "it does not update cursor-clock-value & cursor"
-              (is (= cursor-clock-value (get-in result [:db :chats chat-id :cursor-clock-value])))
-              (is (= cursor (get-in result [:db :chats chat-id :cursor]))))))))))
+              (is (= cursor-clock-value (get-in result [:db :pagination-info chat-id :cursor-clock-value])))
+              (is (= cursor (get-in result [:db :pagination-info chat-id :cursor]))))))))))
 
 (deftest message-loaded?
   (testing "it returns false when it's not in loaded message"
-    (is (not (#'status-im.chat.models.message/message-loaded? {:db {:chats {"a" {}}}}
-                                                              {:message-id "message-id"
-                                                               :from "a"
-                                                               :clock-value 1
-                                                               :chat-id "a"}))))
+    (is (not (#'status-im.chat.models.message/message-loaded? {:messages {"a" {}}} "a" "message-id"))))
   (testing "it returns true when it's already in the loaded message"
-    (is (#'status-im.chat.models.message/message-loaded? {:db
-                                                          {:messages {"a" {"message-id" {}}}}}
-                                                         {:message-id "message-id"
-                                                          :from "a"
-                                                          :clock-value 1
-                                                          :chat-id "a"}))))
+    (is (#'status-im.chat.models.message/message-loaded? {:messages {"a" {"message-id" {}}}} "a" "message-id"))))
+
 (deftest earlier-than-deleted-at?
   (testing "it returns true when the clock-value is the same as the deleted-clock-value in chat"
-    (is (#'status-im.chat.models.message/earlier-than-deleted-at? {:db {:chats {"a" {:deleted-at-clock-value 1}}}}
-                                                                  {:message-id "message-id"
-                                                                   :from "a"
-                                                                   :clock-value 1
-                                                                   :chat-id "a"})))
+    (is (#'status-im.chat.models.message/earlier-than-deleted-at?
+         {:chats {"a" {:deleted-at-clock-value 1}}}
+         "a"
+         1)))
   (testing "it returns false when the clock-value is greater than the deleted-clock-value in chat"
-    (is (not (#'status-im.chat.models.message/earlier-than-deleted-at? {:db {:chats {"a" {:deleted-at-clock-value 1}}}}
-                                                                       {:message-id "message-id"
-                                                                        :from "a"
-                                                                        :clock-value 2
-                                                                        :chat-id "a"}))))
+    (is (not (#'status-im.chat.models.message/earlier-than-deleted-at?
+              {:chats {"a" {:deleted-at-clock-value 1}}}
+              "a"
+              2))))
+
   (testing "it returns true when the clock-value is less than the deleted-clock-value in chat"
-    (is (#'status-im.chat.models.message/earlier-than-deleted-at? {:db {:chats {"a" {:deleted-at-clock-value 1}}}}
-                                                                  {:message-id "message-id"
-                                                                   :from "a"
-                                                                   :clock-value 0
-                                                                   :chat-id "a"}))))
+    (is (#'status-im.chat.models.message/earlier-than-deleted-at?
+         {:chats {"a" {:deleted-at-clock-value 1}}}
+         "a"
+         0))))
 
 (deftest delete-message
   (with-redefs [time/day-relative (constantly "day-relative")

--- a/src/status_im/chat/models/transport.cljs
+++ b/src/status_im/chat/models/transport.cljs
@@ -1,3 +1,4 @@
+;;this ns is needed because of cycled deps
 (ns status-im.chat.models.transport
   (:require [status-im.utils.fx :as fx]
             [status-im.transport.message.core :as transport.message]
@@ -9,5 +10,5 @@
   (let [message (get-in db [:messages chat-id message-id])]
     (fx/merge
      cofx
-     (transport.message/set-message-envelope-hash chat-id message-id (:message-type message) 1)
+     (transport.message/set-message-envelope-hash chat-id message-id (:message-type message))
      (chat.message/resend-message chat-id message-id))))

--- a/src/status_im/chat/models_test.cljs
+++ b/src/status_im/chat/models_test.cljs
@@ -151,7 +151,6 @@
 
    :messages {"status" {"4" {} "5" {} "6" {}}}
    :chats {"status" {:public? true
-                     :group-chat true
-                     :loaded-unviewed-messages-ids #{"6" "5" "4"}}
-           "opened" {:loaded-unviewed-messages-ids #{}}
-           "1-1"    {:loaded-unviewed-messages-ids #{"6" "5" "4"}}}})
+                     :group-chat true}
+           "opened" {}
+           "1-1"    {}}})

--- a/src/status_im/commands/core.cljs
+++ b/src/status_im/commands/core.cljs
@@ -24,18 +24,21 @@
   {:db (dissoc db :commands/select-account)
    ::json-rpc/call [{:method (json-rpc/call-ext-method "acceptRequestAddressForTransaction")
                      :params [message-id address]
-                     :on-success #(re-frame/dispatch [:transport/message-sent % 1])}]})
+                     :js-response true
+                     :on-success #(re-frame/dispatch [:transport/message-sent %])}]})
 
 (fx/defn handle-decline-request-address-for-transaction
   {:events [::decline-request-address-for-transaction]}
   [cofx message-id]
   {::json-rpc/call [{:method (json-rpc/call-ext-method "declineRequestAddressForTransaction")
                      :params [message-id]
-                     :on-success #(re-frame/dispatch [:transport/message-sent % 1])}]})
+                     :js-response true
+                     :on-success #(re-frame/dispatch [:transport/message-sent %])}]})
 
 (fx/defn handle-decline-request-transaction
   {:events [::decline-request-transaction]}
   [cofx message-id]
   {::json-rpc/call [{:method (json-rpc/call-ext-method "declineRequestTransaction")
                      :params [message-id]
-                     :on-success #(re-frame/dispatch [:transport/message-sent % 1])}]})
+                     :js-response true
+                     :on-success #(re-frame/dispatch [:transport/message-sent %])}]})

--- a/src/status_im/communities/core.cljs
+++ b/src/status_im/communities/core.cljs
@@ -175,8 +175,9 @@
                                    :text        "Upgrade here to see an invitation to community"
                                    :communityId community-id
                                    :contentType constants/content-type-community}]
+                     :js-response true
                      :on-success
-                     #(re-frame/dispatch [:transport/message-sent % 1])
+                     #(re-frame/dispatch [:transport/message-sent %])
                      :on-failure #(log/error "failed to send a message" %)}]})
 
 (fx/defn invite-users
@@ -242,7 +243,7 @@
   [{:keys [db]}]
   (let [{:keys [name description membership]} (get db :communities/create)
         my-public-key                         (get-in db [:multiaccount :public-key])]
-    (log/error "Edit community is not yet implemented")
+    (log/error "Edit community is not yet implemented")))
     ;; {::json-rpc/call [{:method     "wakuext_editCommunity"
     ;;                    :params     [{:identity    {:display_name name
     ;;                                                :description  description}
@@ -251,7 +252,7 @@
     ;;                    :on-error   #(do
     ;;                                   (log/error "failed to create community" %)
     ;;                                   (re-frame/dispatch [::failed-to-edit-community %]))}]}
-    ))
+
 
 (fx/defn create-channel
   {:events [::create-channel-confirmation-pressed]}

--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -132,3 +132,5 @@
 (def ^:const keycard-integration-link "https://status.im/keycard-integration")
 
 (def ^:const status-community-id "0x039b2da47552aa117a96ea8f1d4d108ba66637c7517a3c94a57b99dbb8a002eda2")
+
+(def ^:const timeline-chat-id "@timeline70bd746ddcc12beb96b2c9d572d0784ab137ffc774f5383e50585a932080b57cca0484b259e61cecbaa33a4c98a300a")

--- a/src/status_im/contact/block.cljs
+++ b/src/status_im/contact/block.cljs
@@ -43,7 +43,7 @@
                      public-key)
                     (assoc :last-updated now)
                     (update :system-tags (fnil conj #{}) :contact/blocked))
-        from-one-to-one-chat? (not (get-in db [:chats (:inactive-chat-id db) :group-chat]))]
+        from-one-to-one-chat? (not (get-in db [:chats (:current-chat-id db) :group-chat]))]
     (fx/merge cofx
               {:db (-> db
                        ;; add the contact to blocked contacts

--- a/src/status_im/contact/core.cljs
+++ b/src/status_im/contact/core.cljs
@@ -8,7 +8,8 @@
             [status-im.navigation :as navigation]
             [status-im.utils.fx :as fx]
             [taoensso.timbre :as log]
-            [clojure.string :as string]))
+            [clojure.string :as string]
+            [status-im.constants :as constants]))
 
 (fx/defn load-contacts
   {:events [::contacts-loaded]}
@@ -81,7 +82,8 @@
                             (fnil #(conj % :contact/added) #{})))]
       (fx/merge cofx
                 {:db (dissoc db :contacts/new-identity)
-                 :dispatch [:start-profile-chat public-key]}
+                 :dispatch-n [[:start-profile-chat public-key]
+                              [:offload-messages constants/timeline-chat-id]]}
                 (upsert-contact contact)
                 (send-contact-request contact)
                 (mailserver/process-next-messages-request)))))
@@ -95,7 +97,7 @@
                             (fnil #(disj % :contact/added) #{}))]
     (fx/merge cofx
               {:db (assoc-in db [:contacts/contacts public-key] new-contact)
-               :dispatch [:chat/remove-update-chat public-key]}
+               :dispatch [:offload-messages constants/timeline-chat-id]}
               (contacts-store/save-contact new-contact))))
 
 (fx/defn create-contact

--- a/src/status_im/data_store/chats.cljs
+++ b/src/status_im/data_store/chats.cljs
@@ -83,8 +83,7 @@
                                 :last-clock-value :lastClockValue
                                 :profile-public-key :profile})
       (dissoc :public? :group-chat :messages
-              :might-have-join-time-messages?
-              :loaded-unviewed-messages-ids :chat-type
+              :might-have-join-time-messages? :chat-type
               :contacts :admins :members-joined)))
 
 (defn <-rpc [chat]

--- a/src/status_im/data_store/chats_test.cljs
+++ b/src/status_im/data_store/chats_test.cljs
@@ -16,7 +16,6 @@
               :unviewed-messages-count 2
               :is-active true
               :chat-id "chat-id"
-              :loaded-unviewed-messages-ids []
               :timestamp 2}
         expected-chat {:id "chat-id"
                        :color "color"

--- a/src/status_im/data_store/messages.cljs
+++ b/src/status_im/data_store/messages.cljs
@@ -57,8 +57,8 @@
                                limit
                                on-success
                                on-failure]
-  {::json-rpc/call [{:method (json-rpc/call-ext-method "chatMessages")
-                     :params [chat-id cursor limit]
+  {::json-rpc/call [{:method     (json-rpc/call-ext-method "chatMessages")
+                     :params     [chat-id cursor limit]
                      :on-success (fn [result]
                                    (on-success (update result :messages #(map <-rpc %))))
                      :on-failure on-failure}]})

--- a/src/status_im/mailserver/core.cljs
+++ b/src/status_im/mailserver/core.cljs
@@ -1256,7 +1256,9 @@
                {})
               (dismiss-connection-error false))))
 
-(fx/defn load-gaps-fx [{:keys [db] :as cofx} chat-id]
+(fx/defn load-gaps-fx
+  {:events [:load-gaps]}
+  [{:keys [db] :as cofx} chat-id]
   (when-not (get-in db [:gaps-loaded? chat-id])
     (let [success-fn #(re-frame/dispatch [::gaps-loaded %1 %2])]
       (data-store.mailservers/load-gaps cofx chat-id success-fn))))

--- a/src/status_im/mailserver/topics.cljs
+++ b/src/status_im/mailserver/topics.cljs
@@ -169,9 +169,3 @@
   (extract-topics (:mailserver/topics db)
                   chat-id
                   (not (get-in (:chats db) [chat-id :public?]))))
-
-(defn topics-for-current-chat
-  "return a list of topics used by the current-chat, include discovery if
-  private group chat or one-to-one"
-  [{:keys [current-chat-id] :as db}]
-  (topics-for-chat db current-chat-id))

--- a/src/status_im/multiaccounts/login/core.cljs
+++ b/src/status_im/multiaccounts/login/core.cljs
@@ -32,7 +32,8 @@
             [status-im.data-store.invitations :as data-store.invitations]
             [status-im.chat.models.link-preview :as link-preview]
             [status-im.utils.mobile-sync :as utils.mobile-sync]
-            [status-im.async-storage.core :as async-storage]))
+            [status-im.async-storage.core :as async-storage]
+            [status-im.chat.models :as chat.models]))
 
 (re-frame/reg-fx
  ::login
@@ -317,6 +318,8 @@
               (finish-keycard-setup)
               (transport/start-messenger)
               (communities/fetch)
+              (chat.models/start-timeline-chat)
+              (chat.models/start-profile-chat (:public-key multiaccount))
               (multiaccounts/switch-preview-privacy-mode-flag)
               (link-preview/request-link-preview-whitelist)
               (logging/set-log-level (:log-level multiaccount)))))

--- a/src/status_im/notifications/local.cljs
+++ b/src/status_im/notifications/local.cljs
@@ -138,6 +138,7 @@
      {:keys [identicon]} :contact
      contact-id :contact-id}]
    (when (and chat-type chat-id)
+     ;;TODO : DON'T USE SUBS IN EVENTS
      (let [contact-name @(re-frame/subscribe
                           [:contacts/contact-name-by-identity contact-id])
            group-chat?  (not= chat-type constants/one-to-one-chat-type)

--- a/src/status_im/signals/core.cljs
+++ b/src/status_im/signals/core.cljs
@@ -55,7 +55,7 @@
       "node.login"         (status-node-started cofx (js->clj event-js :keywordize-keys true))
       "envelope.sent"      (transport.message/update-envelopes-status cofx (:ids (js->clj event-js :keywordize-keys true)) :sent)
       "envelope.expired"   (transport.message/update-envelopes-status cofx (:ids (js->clj event-js :keywordize-keys true)) :not-sent)
-      "message.delivered"  (let [{:keys [chatID messageID] :as event-cljs} (js->clj event-js :keywordize-keys true)]
+      "message.delivered"  (let [{:keys [chatID messageID]} (js->clj event-js :keywordize-keys true)]
                              (models.message/update-db-message-status cofx chatID messageID :delivered))
       "mailserver.request.completed" (mailserver/handle-request-completed cofx (js->clj event-js :keywordize-keys true))
       "mailserver.request.expired"   (when (multiaccounts.model/logged-in? cofx)
@@ -64,7 +64,7 @@
       "subscriptions.data" (ethereum.subscriptions/handle-signal cofx (js->clj event-js :keywordize-keys true))
       "subscriptions.error" (ethereum.subscriptions/handle-error cofx (js->clj event-js :keywordize-keys true))
       "whisper.filter.added" (transport.filters/handle-negotiated-filter cofx (js->clj event-js :keywordize-keys true))
-      "messages.new" (transport.message/process-response cofx event-js)
+      "messages.new" (transport.message/sanitize-messages-and-process-response cofx event-js)
       "wallet" (ethereum.subscriptions/new-wallet-event cofx (js->clj event-js :keywordize-keys true))
       "local-notifications" (local-notifications/process cofx (js->clj event-js :keywordize-keys true))
       (log/debug "Event " type " not handled"))))

--- a/src/status_im/signing/core.cljs
+++ b/src/status_im/signing/core.cljs
@@ -240,8 +240,9 @@
                      :params [chat-id (str value) contract transaction-hash
                               (or (:result (types/json->clj signature))
                                   (ethereum/normalized-hex signature))]
+                     :js-response true
                      :on-success
-                     #(re-frame/dispatch [:transport/message-sent % 1])}]})
+                     #(re-frame/dispatch [:transport/message-sent %])}]})
 
 (fx/defn send-accept-request-transaction-message
   {:events [:sign/send-accept-transaction-message]}
@@ -250,8 +251,9 @@
                      :params [transaction-hash message-id
                               (or (:result (types/json->clj signature))
                                   (ethereum/normalized-hex signature))]
+                     :js-response true
                      :on-success
-                     #(re-frame/dispatch [:transport/message-sent % 1])}]})
+                     #(re-frame/dispatch [:transport/message-sent %])}]})
 
 (fx/defn transaction-result
   [{:keys [db] :as cofx} result tx-obj]
@@ -429,7 +431,8 @@
                   amount
                   (when-not (= symbol :ETH)
                     address)]
-         :on-success #(re-frame/dispatch [:transport/message-sent % 1])}]})))
+         :js-response true
+         :on-success #(re-frame/dispatch [:transport/message-sent %])}]})))
 
 (fx/defn sign-transaction-button-clicked-from-request
   {:events  [:wallet.ui/sign-transaction-button-clicked-from-request]}

--- a/src/status_im/transport/message/protocol.cljs
+++ b/src/status_im/transport/message/protocol.cljs
@@ -26,26 +26,25 @@
    :sticker         sticker
    :contentType     content-type})
 
-(fx/defn send-chat-messages [cofx messages]
-  {::json-rpc/call
-   [{:method     (json-rpc/call-ext-method "sendChatMessages")
-     :params     [(mapv build-message messages)]
-     :on-success
-     #(re-frame/dispatch [:transport/message-sent % 1])
-     :on-failure #(log/error "failed to send a message" %)}]})
+(fx/defn send-chat-messages [_ messages]
+  {::json-rpc/call [{:method     (json-rpc/call-ext-method "sendChatMessages")
+                     :params     [(mapv build-message messages)]
+                     :js-response true
+                     :on-success #(re-frame/dispatch [:transport/message-sent %])
+                     :on-failure #(log/error "failed to send a message" %)}]})
 
-(fx/defn send-reaction [cofx {:keys [message-id chat-id emoji-id]}]
+(fx/defn send-reaction [_ {:keys [message-id chat-id emoji-id]}]
   {::json-rpc/call [{:method     (json-rpc/call-ext-method
                                   "sendEmojiReaction")
                      :params     [chat-id message-id emoji-id]
-                     :on-success
-                     #(re-frame/dispatch [:transport/reaction-sent %])
+                     :js-response true
+                     :on-success #(re-frame/dispatch [:sanitize-messages-and-process-response %])
                      :on-failure #(log/error "failed to send a reaction" %)}]})
 
-(fx/defn send-retract-reaction [cofx {:keys [emoji-reaction-id] :as reaction}]
+(fx/defn send-retract-reaction [_ {:keys [emoji-reaction-id] :as reaction}]
   {::json-rpc/call [{:method     (json-rpc/call-ext-method
                                   "sendEmojiReactionRetraction")
                      :params     [emoji-reaction-id]
-                     :on-success
-                     #(re-frame/dispatch [:transport/retraction-sent %])
+                     :js-response true
+                     :on-success #(re-frame/dispatch [:sanitize-messages-and-process-response %])
                      :on-failure #(log/error "failed to send a reaction retraction" %)}]})

--- a/src/status_im/ui/components/bottom_panel/views.cljs
+++ b/src/status_im/ui/components/bottom_panel/views.cljs
@@ -49,47 +49,47 @@
         update?           (atom nil)
         current-obj       (reagent/atom nil)]
     (reagent/create-class
-     {:component-will-mount  (fn [args]
-                               (let [[_ obj _ _] (.-argv (.-props args))]
-                                 (when @clear-timeout (js/clearTimeout @clear-timeout))
-                                 (when (or (not= obj @current-obj) @update?)
-                                   (cond
-                                     @update?
-                                     (do (reset! update? false)
-                                         (show-panel-anim bottom-anim-value alpha-value))
+     {:UNSAFE_componentWillMount  (fn [args]
+                                    (let [[_ obj _ _] (.-argv (.-props args))]
+                                      (when @clear-timeout (js/clearTimeout @clear-timeout))
+                                      (when (or (not= obj @current-obj) @update?)
+                                        (cond
+                                          @update?
+                                          (do (reset! update? false)
+                                              (show-panel-anim bottom-anim-value alpha-value))
 
-                                     (and @current-obj obj)
-                                     (do (reset! update? true)
-                                         (js/setTimeout #(reset! current-obj obj) 600)
-                                         (hide-panel-anim bottom-anim-value alpha-value (- window-height)))
+                                          (and @current-obj obj)
+                                          (do (reset! update? true)
+                                              (js/setTimeout #(reset! current-obj obj) 600)
+                                              (hide-panel-anim bottom-anim-value alpha-value (- window-height)))
 
-                                     obj
-                                     (do (reset! current-obj obj)
-                                         (show-panel-anim bottom-anim-value alpha-value))
+                                          obj
+                                          (do (reset! current-obj obj)
+                                              (show-panel-anim bottom-anim-value alpha-value))
 
-                                     :else
-                                     (do (reset! clear-timeout (js/setTimeout #(reset! current-obj nil) 600))
-                                         (hide-panel-anim bottom-anim-value alpha-value (- window-height)))))))
-      :component-will-update (fn [_ [_ obj _ _]]
-                               (when @clear-timeout (js/clearTimeout @clear-timeout))
-                               (when (or (not= obj @current-obj) @update?)
-                                 (cond
-                                   @update?
-                                   (do (reset! update? false)
-                                       (show-panel-anim bottom-anim-value alpha-value))
+                                          :else
+                                          (do (reset! clear-timeout (js/setTimeout #(reset! current-obj nil) 600))
+                                              (hide-panel-anim bottom-anim-value alpha-value (- window-height)))))))
+      :UNSAFE_componentWillUpdate (fn [_ [_ obj _ _]]
+                                    (when @clear-timeout (js/clearTimeout @clear-timeout))
+                                    (when (or (not= obj @current-obj) @update?)
+                                      (cond
+                                        @update?
+                                        (do (reset! update? false)
+                                            (show-panel-anim bottom-anim-value alpha-value))
 
-                                   (and @current-obj obj)
-                                   (do (reset! update? true)
-                                       (js/setTimeout #(reset! current-obj obj) 600)
-                                       (hide-panel-anim bottom-anim-value alpha-value (- window-height)))
+                                        (and @current-obj obj)
+                                        (do (reset! update? true)
+                                            (js/setTimeout #(reset! current-obj obj) 600)
+                                            (hide-panel-anim bottom-anim-value alpha-value (- window-height)))
 
-                                   obj
-                                   (do (reset! current-obj obj)
-                                       (show-panel-anim bottom-anim-value alpha-value))
+                                        obj
+                                        (do (reset! current-obj obj)
+                                            (show-panel-anim bottom-anim-value alpha-value))
 
-                                   :else
-                                   (do (reset! clear-timeout (js/setTimeout #(reset! current-obj nil) 600))
-                                       (hide-panel-anim bottom-anim-value alpha-value (- window-height))))))
+                                        :else
+                                        (do (reset! clear-timeout (js/setTimeout #(reset! current-obj nil) 600))
+                                            (hide-panel-anim bottom-anim-value alpha-value (- window-height))))))
       :reagent-render        (fn []
                                (when @current-obj
                                  [react/keyboard-avoiding-view {:style {:position :absolute :top 0 :bottom 0 :left 0 :right 0}}

--- a/src/status_im/ui/components/connectivity/view.cljs
+++ b/src/status_im/ui/components/connectivity/view.cljs
@@ -1,6 +1,5 @@
 (ns status-im.ui.components.connectivity.view
   (:require [re-frame.core :as re-frame]
-            [reagent.core :as reagent]
             [status-im.i18n.i18n :as i18n]
             [status-im.ui.components.animation :as animation]
             [status-im.ui.components.colors :as colors]
@@ -67,7 +66,7 @@
 
 (defview loading-indicator []
   (letsubs [ui-status-properties [:connectivity/ui-status-properties]
-            window-width (reagent/atom 0)]
+            window-width [:dimensions/window-width]]
     (when (:loading-indicator? ui-status-properties)
       [loading-indicator-anim @window-width])))
 

--- a/src/status_im/ui/components/tabbar/core.cljs
+++ b/src/status_im/ui/components/tabbar/core.cljs
@@ -79,7 +79,7 @@
 (def tabs
   (reagent/adapt-react-class
    (fn [props]
-     (let [{:keys [navigate index route state popToTop]} (bean props)
+     (let [{:keys [navigate index route popToTop]} (bean props)
            {:keys [keyboard-shown]
             :or   {keyboard-shown false}} (when platform/android? (rn/use-keyboard))
            {:keys [bottom]} (safe-area/use-safe-area)
@@ -105,10 +105,7 @@
               :label               title
               :on-press            #(if (= (str index) (str route-index))
                                       (popToTop)
-                                      (let [view-id (navigation/get-index-route-name route-index (bean state))]
-                                        (re-frame/dispatch-sync [:screens/tab-will-change view-id])
-                                        (reagent/flush)
-                                        (navigate (name nav-stack))))
+                                      (navigate (name nav-stack)))
               :accessibility-label accessibility-label
               :count-subscription  count-subscription
               :active?             (= (str index) (str route-index))

--- a/src/status_im/ui/screens/browser/permissions/views.cljs
+++ b/src/status_im/ui/screens/browser/permissions/views.cljs
@@ -40,41 +40,41 @@
                   alpha-value        (anim/create-value 0)
                   current-permission (reagent/atom nil)
                   update?            (reagent/atom nil)]
-    {:component-will-update (fn [_ [_ _ {:keys [requested-permission]}]]
-                              (cond
-                                @update?
-                                ;; the component has been updated with a new permission, we show the panel
-                                (do (reset! update? false)
-                                    (show-panel-anim bottom-anim-value alpha-value))
+    {:UNSAFE_componentWillUpdate (fn [_ [_ _ {:keys [requested-permission]}]]
+                                   (cond
+                                     @update?
+                                     ;; the component has been updated with a new permission, we show the panel
+                                     (do (reset! update? false)
+                                         (show-panel-anim bottom-anim-value alpha-value))
 
-                                (and @current-permission requested-permission)
-                                ;; a permission has been accepted/denied by the user, and there is
-                                ;; another permission that needs to be processed by the user
-                                ;; we hide the processed permission with an animation and update
-                                ;; `current-permission` with a delay so that the information is still
-                                ;; available during the animation
-                                (do (reset! update? true)
-                                    (js/setTimeout #(reset! current-permission
-                                                            (permission-details requested-permission))
-                                                   600)
-                                    (hide-panel-anim bottom-anim-value alpha-value))
+                                     (and @current-permission requested-permission)
+                                     ;; a permission has been accepted/denied by the user, and there is
+                                     ;; another permission that needs to be processed by the user
+                                     ;; we hide the processed permission with an animation and update
+                                     ;; `current-permission` with a delay so that the information is still
+                                     ;; available during the animation
+                                     (do (reset! update? true)
+                                         (js/setTimeout #(reset! current-permission
+                                                                 (permission-details requested-permission))
+                                                        600)
+                                         (hide-panel-anim bottom-anim-value alpha-value))
 
-                                requested-permission
-                                ;; the dapp is asking for a permission, we put it in current-permission
-                                ;; and start the show-animation
-                                (do (reset! current-permission
-                                            (get browser.permissions/supported-permissions
-                                                 requested-permission))
-                                    (show-panel-anim bottom-anim-value alpha-value))
+                                     requested-permission
+                                     ;; the dapp is asking for a permission, we put it in current-permission
+                                     ;; and start the show-animation
+                                     (do (reset! current-permission
+                                                 (get browser.permissions/supported-permissions
+                                                      requested-permission))
+                                         (show-panel-anim bottom-anim-value alpha-value))
 
-                                :else
-                                ;; a permission has been accepted/denied by the user, and there is
-                                ;; no other permission that needs to be processed by the user
-                                ;; we hide the processed permission with an animation and update
-                                ;; `current-permission` with a delay so that the information is still
-                                ;; available during the animation
-                                (do (js/setTimeout #(reset! current-permission nil) 500)
-                                    (hide-panel-anim bottom-anim-value alpha-value))))}
+                                     :else
+                                     ;; a permission has been accepted/denied by the user, and there is
+                                     ;; no other permission that needs to be processed by the user
+                                     ;; we hide the processed permission with an animation and update
+                                     ;; `current-permission` with a delay so that the information is still
+                                     ;; available during the animation
+                                     (do (js/setTimeout #(reset! current-permission nil) 500)
+                                         (hide-panel-anim bottom-anim-value alpha-value))))}
     (when @current-permission
       (let [{:keys [title description type icon]} @current-permission]
         [react/view styles/permissions-panel-container

--- a/src/status_im/ui/screens/chat/components/input.cljs
+++ b/src/status_im/ui/screens/chat/components/input.cljs
@@ -146,37 +146,36 @@
   (let [mentionable-users @(re-frame/subscribe [:chats/mentionable-users])
         timeout-id        (atom nil)
         last-text-change  (atom nil)]
-    [rn/view {:style (styles/text-input-wrapper)}
-     [rn/text-input
-      {:style                    (styles/text-input)
-       :ref                      text-input-ref
-       :max-font-size-multiplier 1
-       :accessibility-label      :chat-message-input
-       :text-align-vertical      :center
-       :multiline                true
-       :editable                 (not cooldown-enabled?)
-       :blur-on-submit           false
-       :auto-focus               false
-       :on-focus                 #(set-active-panel nil)
-       :max-length               chat.constants/max-text-size
-       :placeholder-text-color   (:text-02 @colors/theme)
-       :placeholder              (if cooldown-enabled?
-                                   (i18n/label :cooldown/text-input-disabled)
-                                   (i18n/label :t/type-a-message))
-       :underline-color-android  :transparent
-       :auto-capitalize          :sentences
-       :on-selection-change      (partial on-selection-change timeout-id last-text-change mentionable-users)
-       :on-change                (partial on-change
-                                          on-text-change last-text-change timeout-id mentionable-users)
-       :on-text-input            (partial on-text-input mentionable-users)}
-      (for [[idx [type text]] (map-indexed
-                               (fn [idx item]
-                                 [idx item])
-                               input-with-mentions)]
-        ^{:key (str idx "_" type "_" text)}
-        [rn/text (when (= type :mention)
-                   {:style {:color "#0DA4C9"}})
-         text])]]))
+    [rn/text-input
+     {:style                    (styles/text-input)
+      :ref                      text-input-ref
+      :max-font-size-multiplier 1
+      :accessibility-label      :chat-message-input
+      :text-align-vertical      :center
+      :multiline                true
+      :editable                 (not cooldown-enabled?)
+      :blur-on-submit           false
+      :auto-focus               false
+      :on-focus                 #(set-active-panel nil)
+      :max-length               chat.constants/max-text-size
+      :placeholder-text-color   (:text-02 @colors/theme)
+      :placeholder              (if cooldown-enabled?
+                                  (i18n/label :cooldown/text-input-disabled)
+                                  (i18n/label :t/type-a-message))
+      :underline-color-android  :transparent
+      :auto-capitalize          :sentences
+      :on-selection-change      (partial on-selection-change timeout-id last-text-change mentionable-users)
+      :on-change                (partial on-change
+                                         on-text-change last-text-change timeout-id mentionable-users)
+      :on-text-input            (partial on-text-input mentionable-users)}
+     (for [[idx [type text]] (map-indexed
+                              (fn [idx item]
+                                [idx item])
+                              input-with-mentions)]
+       ^{:key (str idx "_" type "_" text)}
+       [rn/text (when (= type :mention)
+                  {:style {:color "#0DA4C9"}})
+        text])]))
 
 (defn mention-item
   [[public-key {:keys [alias name nickname] :as user}] _ _ text-input-ref]

--- a/src/status_im/ui/screens/chat/components/style.cljs
+++ b/src/status_im/ui/screens/chat/components/style.cljs
@@ -38,6 +38,8 @@
   (merge typography/font-regular
          typography/base
          {:flex               1
+          :min-height         34
+          :max-height         144
           :margin             0
           :border-width       0
           :flex-shrink        1

--- a/src/status_im/ui/screens/chat/message/gap.cljs
+++ b/src/status_im/ui/screens/chat/message/gap.cljs
@@ -7,7 +7,7 @@
             [status-im.ui.screens.chat.styles.input.gap :as style]))
 
 (defn on-press
-  [ids first-gap? idx list-ref]
+  [ids first-gap? idx list-ref chat-id]
   (fn []
     (when (and list-ref @list-ref)
       (.scrollToIndex ^js @list-ref
@@ -15,24 +15,25 @@
                            :viewOffset   20
                            :viewPosition 0.5}))
     (if first-gap?
-      (re-frame/dispatch [:chat.ui/fetch-more])
-      (re-frame/dispatch [:chat.ui/fill-gaps ids]))))
+      (re-frame/dispatch [:chat.ui/fetch-more chat-id])
+      (re-frame/dispatch [:chat.ui/fill-gaps ids chat-id]))))
 
 (views/defview gap
-  [{:keys [gaps first-gap?]} idx list-ref timeline]
-  (views/letsubs [range [:chats/range]
-                  {:keys [might-have-join-time-messages?]} [:chats/current-raw-chat]
+  [{:keys [gaps first-gap?]} idx list-ref timeline chat-id]
+  (views/letsubs [range [:chats/range chat-id]
+                  {:keys [might-have-join-time-messages?]} [:chat-by-id chat-id]
                   in-progress? [:chats/fetching-gap-in-progress?
                                 (if first-gap?
                                   [:first-gap]
-                                  (:ids gaps))]
+                                  (:ids gaps))
+                                chat-id]
                   connected?   [:mailserver/connected?]]
     (let [ids            (:ids gaps)]
       (when-not (and first-gap? might-have-join-time-messages?)
         [react/view {:style style/gap-container}
          [react/touchable-highlight
           {:on-press (when (and connected? (not in-progress?))
-                       (on-press ids first-gap? idx list-ref))
+                       (on-press ids first-gap? idx list-ref chat-id))
            :style    style/touchable}
           [react/view {:style style/label-container}
            (if in-progress?

--- a/src/status_im/ui/screens/chat/message/message.cljs
+++ b/src/status_im/ui/screens/chat/message/message.cljs
@@ -120,7 +120,7 @@
                                     outgoing                                            colors/mention-outgoing
                                     :else                                               colors/mention-incoming)}
                 :on-press (when-not (= content-type constants/content-type-system-text)
-                            #(re-frame/dispatch [:chat.ui/show-profile-without-adding-contact literal]))}
+                            #(re-frame/dispatch [:chat.ui/show-profile literal]))}
                [mention-element literal]])
     "status-tag"
     (conj acc [react/text-class
@@ -286,17 +286,16 @@
       [react/view (style/message-author-userpic outgoing)
        (when first-in-group?
          [react/touchable-highlight {:on-press #(do (when modal (close-modal))
-                                                    (re-frame/dispatch [:chat.ui/show-profile-without-adding-contact from]))}
+                                                    (re-frame/dispatch [:chat.ui/show-profile from]))}
           [photos/member-photo from identicon]])])
     [react/view {:style (style/message-author-wrapper outgoing display-photo?)}
      (when display-username?
        [react/touchable-opacity {:style    style/message-author-touchable
                                  :on-press #(do (when modal (close-modal))
-                                                (re-frame/dispatch [:chat.ui/show-profile-without-adding-contact from]))}
+                                                (re-frame/dispatch [:chat.ui/show-profile from]))}
         [message-author-name from {:modal modal}]])
      ;;MESSAGE CONTENT
-     [react/view
-      content]
+     content
      [link-preview/link-preview-wrapper (:links (:content message)) outgoing false]]]
    ; delivery status
    [react/view (style/delivery-status outgoing)
@@ -475,7 +474,7 @@
                                                           (on-long-press
                                                            (when-not outgoing
                                                              [{:on-press #(when pack
-                                                                            (re-frame/dispatch [:chat.ui/show-profile-without-adding-contact from]))
+                                                                            (re-frame/dispatch [:chat.ui/show-profile from]))
                                                                :label    (i18n/label :t/view-details)}])))})
       [react/image {:style  {:margin 10 :width 140 :height 140}
                     ;;TODO (perf) move to event
@@ -512,7 +511,7 @@
 (defn chat-message [message space-keeper]
   [reactions/with-reaction-picker
    {:message         message
-    :reactions       @(re-frame/subscribe [:chats/message-reactions (:message-id message)])
+    :reactions       @(re-frame/subscribe [:chats/message-reactions (:message-id message) (:chat-id message)])
     :picker-on-open  (fn []
                        (space-keeper true))
     :picker-on-close (fn []

--- a/src/status_im/ui/screens/chat/message/reactions.cljs
+++ b/src/status_im/ui/screens/chat/message/reactions.cljs
@@ -62,35 +62,35 @@
                              (reset! position pos)
                              (reset! visible true))]
         [:<>
-         [animated/view {:style {:opacity (animated/mix animation 1 0)}}
-          [rn/view {:ref         ref
-                    :collapsable false}
-           [render message {:modal         false
-                            :on-long-press (fn [act]
-                                             (when (or (not outgoing)
-                                                       (and outgoing (= outgoing-status :sent)))
-                                               (reset! actions act)
-                                               (get-picker-position ref on-open)))}]]
+         [rn/view {:ref         ref
+                   :style       {:opacity (if @visible 0 1)}
+                   :collapsable false}
+          [render message {:modal         false
+                           :on-long-press (fn [act]
+                                            (when (or (not outgoing)
+                                                      (and outgoing (= outgoing-status :sent)))
+                                              (reset! actions act)
+                                              (get-picker-position ref on-open)))}]
           [reaction-row/message-reactions message reactions timeline]]
-         [rn/modal {:visible          @visible
-                    :on-request-close on-close
-                    :on-show          (fn []
-                                        (js/requestAnimationFrame
-                                         #(animated/set-value animated-state 1)))
-                    :transparent      true}
-          [reaction-picker/modal {:outgoing       (:outgoing message)
-                                  :display-photo  (:display-photo? message)
-                                  :animation      animation
-                                  :spring         spring-animation
-                                  :top            (:top @position)
-                                  :message-height (:height @position)
-                                  :on-close       on-close
-                                  :actions        @actions
-                                  :own-reactions  own-reactions
-                                  :timeline       timeline
-                                  :send-emoji     (fn [emoji]
-                                                    (on-close)
-                                                    (js/setTimeout #(on-emoji-press emoji)
-                                                                   reaction-picker/animation-duration))}
-           [render message {:modal       true
-                            :close-modal on-close}]]]]))))
+         (when @visible
+           [rn/modal {:on-request-close on-close
+                      :on-show          (fn []
+                                          (js/requestAnimationFrame
+                                           #(animated/set-value animated-state 1)))
+                      :transparent      true}
+            [reaction-picker/modal {:outgoing       (:outgoing message)
+                                    :display-photo  (:display-photo? message)
+                                    :animation      animation
+                                    :spring         spring-animation
+                                    :top            (:top @position)
+                                    :message-height (:height @position)
+                                    :on-close       on-close
+                                    :actions        @actions
+                                    :own-reactions  own-reactions
+                                    :timeline       timeline
+                                    :send-emoji     (fn [emoji]
+                                                      (on-close)
+                                                      (js/setTimeout #(on-emoji-press emoji)
+                                                                     reaction-picker/animation-duration))}
+             [render message {:modal       true
+                              :close-modal on-close}]]])]))))

--- a/src/status_im/ui/screens/chat/state.cljs
+++ b/src/status_im/ui/screens/chat/state.cljs
@@ -2,5 +2,7 @@
 
 (defonce first-not-visible-item (atom nil))
 
-(defn reset []
+(defonce scrolling (atom nil))
+
+(defn reset-visible-item []
   (reset! first-not-visible-item nil))

--- a/src/status_im/ui/screens/chat/stickers/views.cljs
+++ b/src/status_im/ui/screens/chat/stickers/views.cljs
@@ -82,8 +82,8 @@
 (defview stickers-paging-panel [installed-packs selected-pack]
   (letsubs [ref   (atom nil)
             width [:dimensions/window-width]]
-    {:component-will-update (fn [_ [_ installed-packs selected-pack]]
-                              (update-scroll-position @ref installed-packs selected-pack width true))
+    {:UNSAFE_componentWillUpdate (fn [_ [_ installed-packs selected-pack]]
+                                   (update-scroll-position @ref installed-packs selected-pack width true))
      :component-did-mount   #(update-scroll-position @ref installed-packs selected-pack width false)}
     [react/scroll-view {:style                             {:flex 1}
                         :horizontal                        true

--- a/src/status_im/ui/screens/chat/toolbar_content.cljs
+++ b/src/status_im/ui/screens/chat/toolbar_content.cljs
@@ -39,18 +39,19 @@
                                     chat-type
                                     chat-name
                                     public?]}]
-  [react/view {:style st/toolbar-container}
-   [react/view {:margin-right 10}
-    [chat-icon.screen/chat-icon-view-toolbar chat-id group-chat chat-name color]]
-   [react/view {:style st/chat-name-view}
-    (if group-chat
-      [react/text {:style               st/chat-name-text
-                   :number-of-lines     1
-                   :accessibility-label :chat-name-text}
-       chat-name]
-      [one-to-one-name chat-id])
-    (when-not group-chat
-      [contact-indicator chat-id])
-    (when (and group-chat (not invitation-admin) (not= chat-type constants/community-chat-type))
-      [group-last-activity {:contacts   contacts
-                            :public?    public?}])]])
+  (when chat-id
+    [react/view {:style st/toolbar-container}
+     [react/view {:margin-right 10}
+      [chat-icon.screen/chat-icon-view-toolbar chat-id group-chat chat-name color]]
+     [react/view {:style st/chat-name-view}
+      (if group-chat
+        [react/text {:style               st/chat-name-text
+                     :number-of-lines     1
+                     :accessibility-label :chat-name-text}
+         chat-name]
+        [one-to-one-name chat-id])
+      (when-not group-chat
+        [contact-indicator chat-id])
+      (when (and group-chat (not invitation-admin) (not= chat-type constants/community-chat-type))
+        [group-last-activity {:contacts   contacts
+                              :public?    public?}])]]))

--- a/src/status_im/ui/screens/home/views.cljs
+++ b/src/status_im/ui/screens/home/views.cljs
@@ -169,9 +169,8 @@
                  (when (or (seq items) @search-active? (seq search-filter))
                    [search-input-wrapper search-filter items])
                  [referral-item/list-item]
-                 (when
-                  (and (empty? items)
-                       (or @search-active? (seq search-filter)))
+                 (when (and (empty? items)
+                            (or @search-active? (seq search-filter)))
                    [start-suggestion search-filter])]
         :footer                       (if (and (not hide-home-tooltip?) (not @search-active?))
                                         [home-tooltip-view]
@@ -194,9 +193,9 @@
 
 (defn home []
   [react/keyboard-avoiding-view {:style styles/home-container}
-   [topbar/topbar {:title             (i18n/label :t/chat)
-                   :navigation        :none
-                   :right-component   [connectivity/connectivity-button]}]
+   [topbar/topbar {:title           (i18n/label :t/chat)
+                   :navigation      :none
+                   :right-component [connectivity/connectivity-button]}]
    [connectivity/loading-indicator]
    [chats-list]
    [plus-button]])

--- a/src/status_im/ui/screens/home/views/inner_item.cljs
+++ b/src/status_im/ui/screens/home/views/inner_item.cljs
@@ -174,13 +174,10 @@
                                    [message-content-text {:content      (:content last-message)
                                                           :content-type (:content-type last-message)}]]
                                   [unviewed-indicator home-item]]
-      :on-press                  #(do
-                                    (re-frame/dispatch [:dismiss-keyboard])
-                                    (re-frame/dispatch [:chat.ui/navigate-to-chat chat-id])
-                                    (re-frame/dispatch [:search/home-filter-changed nil])
-                                    (if public?
-                                      (re-frame/dispatch [:chat.ui/mark-public-all-read chat-id])
-                                      (re-frame/dispatch [:chat.ui/mark-messages-seen :chat])))
+      :on-press                  (fn []
+                                   (re-frame/dispatch [:dismiss-keyboard])
+                                   (re-frame/dispatch [:chat.ui/navigate-to-chat chat-id])
+                                   (re-frame/dispatch [:search/home-filter-changed nil]))
       :on-long-press             #(re-frame/dispatch [:bottom-sheet/show-sheet
                                                       {:content (fn []
                                                                   [sheets/actions home-item])}])}]))

--- a/src/status_im/ui/screens/popover/views.cljs
+++ b/src/status_im/ui/screens/popover/views.cljs
@@ -69,7 +69,7 @@
                                                     "hardwareBackPress"
                                                     request-close)))]
     (reagent/create-class
-     {:component-will-update
+     {:UNSAFE_componentWillUpdate
       (fn [_ [_ popover _]]
         (when @clear-timeout (js/clearTimeout @clear-timeout))
         (cond

--- a/src/status_im/ui/screens/routing/chat_stack.cljs
+++ b/src/status_im/ui/screens/routing/chat_stack.cljs
@@ -25,8 +25,8 @@
 (defonce communities-stack (navigation/create-stack))
 
 (defn chat-stack []
-  [stack {:initial-route-name :home
-          :header-mode        :none}
+  [stack {:initial-route-name    :home
+          :header-mode           :none}
    [{:name      :home
      :style     {:padding-bottom tabbar.styles/tabs-diff}
      :component home/home}

--- a/src/status_im/ui/screens/routing/status_stack.cljs
+++ b/src/status_im/ui/screens/routing/status_stack.cljs
@@ -9,6 +9,7 @@
   [stack {:initial-route-name :status
           :header-mode        :none}
    [{:name      :status
+     :on-focus  [:init-timeline-chat]
      :insets    {:top true}
      :style     {:padding-bottom tabbar.styles/tabs-diff}
      :component status.views/timeline}]])

--- a/src/status_im/ui/screens/status/new/views.cljs
+++ b/src/status_im/ui/screens/status/new/views.cljs
@@ -19,16 +19,16 @@
   [react/view styles/buttons
    [pressable/pressable {:type                :scale
                          :accessibility-label :take-picture
-                         :on-press  #(re-frame/dispatch [:chat.ui/show-image-picker-camera])}
+                         :on-press  #(re-frame/dispatch [:chat.ui/show-image-picker-camera-timeline])}
     [icons/icon :main-icons/camera]]
    [react/view {:style {:padding-top 8}}
-    [pressable/pressable {:on-press            #(re-frame/dispatch [:chat.ui/open-image-picker])
+    [pressable/pressable {:on-press            #(re-frame/dispatch [:chat.ui/open-image-picker-timeline])
                           :accessibility-label :open-gallery
                           :type                :scale}
      [icons/icon :main-icons/gallery]]]])
 
 (defn image-preview [uri]
-  [react/touchable-highlight {:on-press #(re-frame/dispatch [:chat.ui/camera-roll-pick uri])}
+  [react/touchable-highlight {:on-press #(re-frame/dispatch [:chat.ui/camera-roll-pick-timeline uri])}
    [react/image {:style  styles/image
                  :source {:uri uri}}]])
 
@@ -52,8 +52,8 @@
         scroll (reagent/atom nil)
         autoscroll? (reagent/atom false)
         scroll-height (reagent/atom nil)
-        input-text (re-frame/subscribe [:chats/current-chat-input-text])
-        sending-image (re-frame/subscribe [:chats/sending-image])]
+        input-text (re-frame/subscribe [:chats/timeline-chat-input-text])
+        sending-image (re-frame/subscribe [:chats/timeline-sending-image])]
     (fn []
       (let [{:keys [uri]} (first (vals @sending-image))]
         [kb-presentation/keyboard-avoiding-view {:style {:flex 1}}
@@ -83,7 +83,7 @@
                                                              @scroll-height
                                                              -40)]
                                           (.scrollTo @scroll #js {:y height :animated true})))
-             :on-change-text         #(re-frame/dispatch [:chat.ui/set-chat-input-text %])
+             :on-change-text         #(re-frame/dispatch [:chat.ui/set-timeline-input-text %])
              :default-value          @input-text
              :placeholder            (i18n/label :t/whats-on-your-mind)}]
            (when uri

--- a/src/status_im/utils/platform.cljs
+++ b/src/status_im/utils/platform.cljs
@@ -33,3 +33,5 @@
 
 (defn android-version>= [v]
   (and android? (>= version v)))
+
+(def low-device? (and android? (< version 29)))

--- a/src/status_im/utils/types.cljs
+++ b/src/status_im/utils/types.cljs
@@ -23,6 +23,13 @@
       (catch js/Error _
         (when (string? json) json)))))
 
+(defn json->js [json]
+  (when-not (= json "undefined")
+    (try
+      (.parse js/JSON json)
+      (catch js/Error _
+        (when (string? json) json)))))
+
 (def serialize clj->json)
 (defn deserialize [o] (try (json->clj o)
                            (catch :default _ nil)))

--- a/src/status_im/utils/utils.cljs
+++ b/src/status_im/utils/utils.cljs
@@ -98,7 +98,8 @@
  :utils/dispatch-later
  (fn [params]
    (doseq [{:keys [ms dispatch]} params]
-     (set-timeout #(re-frame/dispatch dispatch) ms))))
+     (when (and ms dispatch)
+       (set-timeout #(re-frame/dispatch dispatch) ms)))))
 
 (defn clear-timeout [id]
   (.clearTimeout background-timer id))

--- a/src/status_im/wallet/core.cljs
+++ b/src/status_im/wallet/core.cljs
@@ -383,7 +383,8 @@
                                           (when-not (= symbol :ETH)
                                             address)
                                           from-address]
-                                 :on-success #(re-frame/dispatch [:transport/message-sent % 1])}]})))
+                                 :js-response true
+                                 :on-success #(re-frame/dispatch [:transport/message-sent %])}]})))
 
 (fx/defn accept-request-transaction-button-clicked-from-command
   {:events  [:wallet.ui/accept-request-transaction-button-clicked-from-command]}


### PR DESCRIPTION
- Currently, we offload messages, so each time we open the profile we "reset" chat from which profile was opened (because we have status updates in profile), same for a timeline when we switch between timeline and chat, we don't offload messages in this PR for profiles and timeline
- we shouldn't use nested scrolls, so I've replaced the header component in the profile screen 
- Improved signal handler for messages, process 50 messages instead of 1 (it could be higher, but 50 should be enough because we show ~20 messages )

_Edited_: ok, reduced to 10 , because on slow devices it freezes 
_Edited_: actually, this is still bad on slow devices, why? 

js->clj for 20 messages is 25ms, 
preparing (adding timestamp) one message is 2-6 ms ( so if we receive 100 it will be 600ms)
rendering of 10 messages is 500ms
you can see the numbers on your phone in this build : 80c2468 | #27
just open any chat and press "..." and then "show perf log", times in ms
"enable perf" replaces item renderer on simplest one with text, for me, it reduces time from 500ms to 10-25ms

**further work in next PRs** so we need to improve our item rendered and reduce js->clj and preparing times


What's done in this PR:

1) separate subscriptions for profile and timeline streams, so we don't reset both chat and profile/timeline when we switch between them
2) sanitize messages on a signal, filter messages for a current chat, and sort them so we can process starting from the latest messages, also do js->clj as later as possible
3) process 10 messages (3 on low androids ) instead of 1
4) improve item renderer a little bit (it requires serious work to improve it significantly)
5) do not use an animated header in the profile because of nested scroll views
6) add loading indicator for messages


Why message offloading was disabled in this PR
1) it conflicts with endreached event, we offload messages and then endreached event fired and we load 20 messages again. This happens also when sending message, send message, then offload, readd all messages, then endreache, add 20 more, receiving each new messages or sending each new message cause this chain of events
2) re-adding all messages is really expensive , readding one messages is ±6ms so, if we offload 5 messages in the end of the list and we have 300 messages we just re-add 300 messages , ±1800 ms
Probably we still need to offload messages in one case, when we are in the chat for a long time and receive lots of new messages, we need to find a way how to pop messages from the arrray and do not re-add all messages in that case, but because messages will be offloaded when user switch a chat or just go back to chats list, i guess we can leave with it, and implement properly in another PR, test shows that adding messages time grows not so fast with having more messages, the only place where it grows is subscription, for 300 messages it might take up to 100-200ms on low end android device

https://github.com/status-im/status-react/issues/11846