### PR TITLE
[#11743] Fix crash on network change

### DIFF
--- a/src/status_im/ui/screens/network/network_details/views.cljs
+++ b/src/status_im/ui/screens/network/network_details/views.cljs
@@ -6,7 +6,8 @@
             [status-im.ui.screens.network.styles :as st]
             [status-im.ui.screens.network.views :as network-settings]
             [status-im.ui.components.react :as react]
-            [status-im.ui.components.topbar :as topbar])
+            [status-im.ui.components.topbar :as topbar]
+            [status-im.utils.debounce :refer [dispatch-and-chill]])
   (:require-macros [status-im.utils.views :as views]))
 
 (views/defview network-details []
@@ -24,7 +25,7 @@
           {:name       name
            :connected? connected?}]
          (when-not connected?
-           [react/touchable-highlight {:on-press #(re-frame/dispatch [::network/connect-network-pressed id])}
+           [react/touchable-highlight {:on-press #(dispatch-and-chill [::network/connect-network-pressed id] 1000)}
             [react/view st/connect-button-container
              [react/view {:style               st/connect-button
                           :accessibility-label :network-connect-button}


### PR DESCRIPTION
fixes #11743 

### Summary

As the issue mentions, when changing network and tapping twice on the Connect button, the app crashes. Changed `reframe/dispatch` to `dispatch-and-chill` on the Button `on-press` callback with a timeout of 1000 miliseconds (should work with less but 1 second should do the trick and won't affect user experience at all).

![Fix demo](https://user-images.githubusercontent.com/18485527/108141061-c9a4d300-70a1-11eb-8294-ac10bb24062a.gif)

##### Functional

- user profile updates
- networks

### Steps to test

- Open Status
- Sign In
- Go to Profile > Advanced > Network
- Select a new network
- Tap very quickly two (or more) times on the Connect button
- Verify that only opens one confirmation popup
- Confirm and verify that the app does not crash anymore

status: ready