### PR TITLE
use the currently selected account for signing messages/typed data

### DIFF
--- a/src/status_im/keycard/sign.cljs
+++ b/src/status_im/keycard/sign.cljs
@@ -21,7 +21,7 @@
         data                 (get-in db [:keycard :data])
         typed?               (get-in db [:keycard :typed?])
         pin                  (common/vector->string (get-in db [:keycard :pin :sign]))
-        from                 (get-in db [:signing/tx :from :address])
+        from                 (or (get-in db [:signing/tx :from :address]) (get-in db [:signing/tx :message :from]) (ethereum/default-address db))
         path                 (reduce
                               (fn [_ {:keys [address path]}]
                                 (when (= from address)


### PR DESCRIPTION
Fixes #11759 by searching the "from" field not only in the transaction but also in the message map. If no "from" field is specified, the default account is used as a fallback.

status: ready