### PR TITLE
📐 Fix the top margin on keystorage views

### DIFF
--- a/src/status_im/ui/screens/multiaccounts/key_storage/views.cljs
+++ b/src/status_im/ui/screens/multiaccounts/key_storage/views.cljs
@@ -104,7 +104,7 @@
 (defview seed-phrase []
   (letsubs
     [{:keys [seed-word-count seed-shape-invalid?]} [:multiaccounts/key-storage]]
-    [react/keyboard-avoiding-view {:style {:display :flex :flex 1 :flex-direction :column}}
+    [react/keyboard-avoiding-view {:flex 1}
      [local-topbar (i18n/label :t/enter-seed-phrase)]
      [multiaccounts.views/seed-phrase-input
       {:on-change-event     [::multiaccounts.key-storage/seed-phrase-input-changed]
@@ -115,15 +115,14 @@
                           :margin-bottom 8
                           :text-align    :center}}
       (i18n/label :t/multiaccounts-recover-enter-phrase-text)]
-     [react/keyboard-avoiding-view {:style {:flex 1}}
-      [toolbar/toolbar {:show-border? true
-                        :right        [quo/button
-                                       {:type     :secondary
-                                        :disabled (or seed-shape-invalid?
-                                                      (nil? seed-shape-invalid?))
-                                        :on-press #(re-frame/dispatch [::multiaccounts.key-storage/choose-storage-pressed])
-                                        :after    :main-icons/next}
-                                       (i18n/label :t/choose-storage)]}]]]))
+     [toolbar/toolbar {:show-border? true
+                       :right        [quo/button
+                                      {:type     :secondary
+                                       :disabled (or seed-shape-invalid?
+                                                     (nil? seed-shape-invalid?))
+                                       :on-press #(re-frame/dispatch [::multiaccounts.key-storage/choose-storage-pressed])
+                                       :after    :main-icons/next}
+                                      (i18n/label :t/choose-storage)]}]]))
 
 (defn keycard-subtitle []
   [react/view
@@ -316,10 +315,7 @@
     ;; Delete multiaccount and init keycard onboarding
     (re-frame/dispatch [::multiaccounts.key-storage/delete-multiaccount-and-init-keycard-onboarding]))
 
-
   ;; Show error popup
-
-
   (re-frame/dispatch [::multiaccounts.key-storage/show-seed-key-uid-mismatch-error-popup])
   (re-frame/dispatch [::multiaccounts.key-storage/show-transfer-warning-popup])
   (re-frame/dispatch [::multiaccounts.key-storage/delete-multiaccount-error])

--- a/src/status_im/ui/screens/routing/intro_login_stack.cljs
+++ b/src/status_im/ui/screens/routing/intro_login_stack.cljs
@@ -5,6 +5,7 @@
             [status-im.ui.screens.multiaccounts.views :as multiaccounts]
             [status-im.ui.screens.intro.views :as intro]
             [status-im.keycard.core :as keycard.core]
+            [status-im.ui.screens.routing.key-storage-stack :as key-storage-stack]
             [status-im.ui.screens.keycard.onboarding.views :as keycard.onboarding]
             [status-im.ui.screens.keycard.recovery.views :as keycard.recovery]
             [status-im.ui.screens.keycard.views :as keycard]
@@ -104,4 +105,7 @@
       {:name      :keycard-unpaired
        :component keycard/unpaired}
       {:name      :not-keycard
-       :component keycard/not-keycard}]]))
+       :component keycard/not-keycard}
+      {:name      :key-storage-stack
+       :insets    {:top false}
+       :component key-storage-stack/key-storage-stack}]]))

--- a/src/status_im/ui/screens/routing/main.cljs
+++ b/src/status_im/ui/screens/routing/main.cljs
@@ -11,7 +11,6 @@
             [status-im.ui.screens.routing.chat-stack :as chat-stack]
             [status-im.ui.screens.routing.wallet-stack :as wallet-stack]
             [status-im.ui.screens.wallet.buy-crypto.views :as wallet.buy-crypto]
-            [status-im.ui.screens.routing.key-storage-stack :as key-storage-stack]
             [status-im.ui.screens.group.views :as group-chat]
             [status-im.ui.screens.routing.profile-stack :as profile-stack]
             [status-im.ui.screens.routing.browser-stack :as browser-stack]
@@ -162,9 +161,7 @@
        {:name       :buy-crypto-website
         :transition :presentation-ios
         :insets     {:bottom true}
-        :component  wallet.buy-crypto/website}
-       {:name      :key-storage-stack
-        :component key-storage-stack/key-storage-stack}]
+        :component  wallet.buy-crypto/website}]
 
       (when config/quo-preview-enabled?
         [{:name      :quo-preview


### PR DESCRIPTION

fixes #11765 

### Summary
The views in KeyStorage stack had a top margin because they were being rendered as modals. This PR moves that stack inside the intro stack, hence removing the top-margin. 

This PR also fixes the incorrect usage of `keyboard-avoiding-view` component, that led to distorted alignment of the seed phrase entry screen.

### Testing notes
- Please check that the seed phrase screen looks okay on both ios and android, without and without the keyboard (focus on the text box for the keyboard to appear)

#### Platform
- Android
- iOS

#### Areas that maybe impacted
- Key Storage and management

status: ready 
