### PR TITLE
[#11764] Data that was added before pairing devices is not synced any…

### DIFF
--- a/src/status_im/pairing/core.cljs
+++ b/src/status_im/pairing/core.cljs
@@ -180,7 +180,7 @@
  :pairing/get-our-installations
  get-our-installations)
 
-(defn send-installation-messages
+(fx/defn send-installation-messages
   {:events [:pairing.ui/synchronize-installation-pressed]}
   [{:keys [db]}]
   (let [multiaccount                             (:multiaccount db)


### PR DESCRIPTION

fixes #11764
