### PR TITLE
[wallet] Avoid requesting of token balances on account creation

### DIFF
--- a/src/status_im/ethereum/transactions/core.cljs
+++ b/src/status_im/ethereum/transactions/core.cljs
@@ -231,15 +231,15 @@
                            (wallet/stop-watching-tx hash))
                          transfers))
 
-                  true
+                  (and max-known-block
+                       (some #(> (:block %) max-known-block) transfers))
                   (conj (wallet/update-balances
-                         (into [] (reduce (fn [acc {:keys [address block]}]
-                                            (if (and max-known-block (> block max-known-block))
-                                              (conj acc address)
-                                              acc))
-                                          #{}
-                                          transfers))
+                         [address]
                          (zero? max-known-block)))
+
+                  (and (zero? max-known-block)
+                       (empty? transfers))
+                  (conj (wallet/set-zero-balances {:address address}))
 
                   (< (count transfers) limit)
                   (conj (tx-history-end-reached checksum)))]

--- a/src/status_im/wallet/accounts/core.cljs
+++ b/src/status_im/wallet/accounts/core.cljs
@@ -23,7 +23,8 @@
             [status-im.utils.hex :as hex]
             [status-im.ethereum.ens :as ens]
             [status-im.ens.core :as ens.core]
-            [status-im.ethereum.resolver :as resolver]))
+            [status-im.ethereum.resolver :as resolver]
+            [status-im.utils.mobile-sync :as utils.mobile-sync]))
 
 (fx/defn start-adding-new-account
   {:events [:wallet.accounts/start-adding-new-account]}
@@ -205,7 +206,9 @@
       (fx/merge cofx
                 {:db (update-in db [:add-account :account] merge account)}
                 (save-new-account)
-                (wallet/update-balances nil true)
+                (if (utils.mobile-sync/syncing-allowed? cofx)
+                  (wallet/set-max-block address 0)
+                  (wallet/update-balances nil true))
                 (prices/update-prices)
                 (navigation/navigate-back)))))
 


### PR DESCRIPTION
Currently app requests balances for all 160 tokens on a new wallet account generation, even if that account is empty. 
In this commit tx history is checked at first and if there are no incoming/outgoing transfers balances check is skipped. 

status: ready 