### PR TITLE
Don't show lock icon on error

### DIFF
--- a/src/status_im/ui/screens/browser/views.cljs
+++ b/src/status_im/ui/screens/browser/views.cljs
@@ -186,12 +186,11 @@
         :bounces                                    false
         :local-storage-enabled                      true
         :render-error                               web-view-error
-        :on-navigation-state-change                 #(do
+        :on-load-start                              #(do
                                                        (re-frame/dispatch [:set-in [:ens/registration :state] :searching])
                                                        (debounce/debounce-and-dispatch
-                                                        [:browser/navigation-state-changed % error?]
+                                                        [:browser/navigation-state-changed (.-nativeEvent %) error?]
                                                         500))
-
         :on-permission-request                      #(if resources-permission?
                                                        (request-resources-access-for-page (-> ^js % .-nativeEvent .-resources) url @webview-ref/webview-ref)
                                                        (block-resources-access-and-notify-user url))
@@ -226,7 +225,7 @@
           can-go-forward? (browser/can-go-forward? browser)
           url-original    (browser/get-current-url browser)]
       [react/view {:style styles/browser}
-       [toolbar-content url url-original secure? url-editing? unsafe?]
+       [toolbar-content url url-original (and (not error?) secure?) url-editing? unsafe?]
        [components/separator-dark]
        [react/view
         (when loading?


### PR DESCRIPTION


### Summary

[comment]: # (Summarise the problem and how the pull request solves it)
...

<!-- (Optional, remove if no changes to documentation) -->
Documentation change PR (review please): https://github.com/status-im/status.im/pull/xxx

### Review notes
<!-- (Optional. Specify if something in particular should be looked at, or ignored, during review) -->

### Testing notes
<!-- (Optional) -->

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS
- macOS
- Linux
- Windows

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- 1-1 chats
- public chats
- group chats
- wallet / transactions
- dapps / app browsing
- account recovery
- new account
- user profile updates
- networks
- mailservers
- fleet
- bootnodes

##### Non-functional

- battery performance
- CPU performance / speed of the app
- network consumption

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open Status
- ...
- Step 3, etc.

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->
