### PR TITLE
move pairing handling to native module

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "react-native-screens": "^2.10.1",
     "react-native-shake": "^3.3.1",
     "react-native-splash-screen": "^3.2.0",
-    "react-native-status-keycard": "git+https://github.com/status-im/react-native-status-keycard.git#v2.5.32",
+    "react-native-status-keycard": "git+https://github.com/status-im/react-native-status-keycard.git#v2.5.33",
     "react-native-svg": "^9.8.4",
     "react-native-touch-id": "^4.4.1",
     "react-native-webview": "git+https://github.com/status-im/react-native-webview.git#v10.9.2",

--- a/src/status_im/keycard/card.cljs
+++ b/src/status_im/keycard/card.cljs
@@ -76,6 +76,10 @@
   {:code  (.-code object)
    :error (.-message object)})
 
+(defn set-pairings [pairings]
+  (log/debug "[keycard] open-nfc-settings")
+  (keycard/set-pairings card {:pairings pairings}))
+
 (defn get-application-info [{:keys [on-success] :as args}]
   (log/debug "[keycard] get-application-info")
   (keycard/get-application-info

--- a/src/status_im/keycard/change_pin.cljs
+++ b/src/status_im/keycard/change_pin.cljs
@@ -59,8 +59,7 @@
         :on-card-connected :keycard/change-pin
         :handler
         (fn [{:keys [db] :as cofx}]
-          (let [pairing     (common/get-pairing db)
-                new-pin     (common/vector->string
+          (let [new-pin     (common/vector->string
                              (get-in db [:keycard :pin :original]))
                 current-pin (common/vector->string
                              (get-in db [:keycard :pin :current]))]
@@ -70,8 +69,7 @@
 
               :keycard/change-pin
               {:new-pin     new-pin
-               :current-pin current-pin
-               :pairing     pairing}})))}))))
+               :current-pin current-pin}})))}))))
 
 (fx/defn on-change-pin-success
   {:events [:keycard.callback/on-change-pin-success]}
@@ -97,7 +95,6 @@
   [{:keys [db] :as cofx} error]
   (log/debug "[keycard] change pin error" error)
   (let [tag-was-lost? (common/tag-lost? (:error error))
-        pairing       (common/get-pairing db)
         pin-retries (common/pin-retries (:error error))]
     (fx/merge cofx
               (if tag-was-lost?

--- a/src/status_im/keycard/keycard.cljs
+++ b/src/status_im/keycard/keycard.cljs
@@ -8,6 +8,7 @@
   (check-nfc-enabled [this args])
   (open-nfc-settings [this])
   (register-card-events [this args])
+  (set-pairings [this args])
   (on-card-disconnected [this callback])
   (on-card-connected [this callback])
   (remove-event-listener [this event])

--- a/src/status_im/keycard/login.cljs
+++ b/src/status_im/keycard/login.cljs
@@ -90,16 +90,16 @@
         (get-in db [:keycard :application-info])
 
         key-uid                (get-in db [:keycard :application-info :key-uid])
+        paired?                (get-in db [:keycard :application-info :paired?])
         multiaccount           (get-in db [:multiaccounts/multiaccounts (get-in db [:multiaccounts/login :key-uid])])
         multiaccount-key-uid   (get multiaccount :key-uid)
         multiaccount-mismatch? (or (nil? multiaccount)
-                                   (not= multiaccount-key-uid key-uid))
-        pairing                (:keycard-pairing multiaccount)]
+                                   (not= multiaccount-key-uid key-uid))]
     (log/debug "[keycard] login-with-keycard"
                "empty application info" (empty? application-info)
                "no key-uid" (empty? key-uid)
                "multiaccount-mismatch?" multiaccount-mismatch?
-               "no pairing" (empty? pairing))
+               "no pairing" paired?)
     (cond
       (empty? application-info)
       (fx/merge cofx
@@ -116,7 +116,7 @@
                 (common/hide-connection-sheet)
                 (navigation/navigate-to-cofx :keycard-wrong nil))
 
-      (empty? pairing)
+      (not paired?)
       (fx/merge cofx
                 (common/hide-connection-sheet)
                 (navigation/navigate-to-cofx :keycard-unpaired nil))
@@ -138,7 +138,7 @@
    {:sheet-options     {:on-cancel [::common/cancel-sheet-confirm]}
     :on-card-connected :keycard/get-application-info
     :on-card-read      :keycard/login-with-keycard
-    :handler           (common/get-application-info nil :keycard/login-with-keycard)}))
+    :handler           (common/get-application-info :keycard/login-with-keycard)}))
 
 (fx/defn on-keycard-keychain-keys
   {:events [:multiaccounts.login.callback/get-keycard-keys-success]}

--- a/src/status_im/keycard/onboarding.cljs
+++ b/src/status_im/keycard/onboarding.cljs
@@ -253,7 +253,7 @@
 (fx/defn generate-and-load-key
   {:events [:keycard/generate-and-load-key]}
   [{:keys [db] :as cofx}]
-  (let [{:keys [pairing pin]}
+  (let [{:keys [pin]}
         (get-in db [:keycard :secrets])
 
         {:keys [selected-id multiaccounts]}
@@ -272,7 +272,6 @@
     (fx/merge cofx
               {:keycard/generate-and-load-key
                {:mnemonic     mnemonic
-                :pairing      pairing
                 :pin          pin'}})))
 
 (fx/defn begin-setup-pressed
@@ -290,7 +289,7 @@
    (common/show-connection-sheet
     {:on-card-connected :keycard/get-application-info
      :on-card-read      :keycard/check-card-state
-     :handler           (common/get-application-info nil :keycard/check-card-state)})))
+     :handler           (common/get-application-info :keycard/check-card-state)})))
 
 (fx/defn cancel-confirm
   {:events [::cancel-confirm]}

--- a/src/status_im/keycard/recovery.cljs
+++ b/src/status_im/keycard/recovery.cljs
@@ -115,7 +115,7 @@
     {:on-card-connected :keycard/get-application-info
      :on-card-read      :keycard/check-card-state
      :sheet-options     {:on-cancel [::cancel-pressed]}
-     :handler           (common/get-application-info nil :keycard/check-card-state)})))
+     :handler           (common/get-application-info :keycard/check-card-state)})))
 
 (fx/defn recovery-success-finish-pressed
   {:events [:keycard.recovery.success/finish-pressed]}
@@ -253,8 +253,7 @@
                                         (assoc-in [:keycard :pin :status] :verifying)
                                         (assoc-in [:keycard :secrets] {:pairing   pairing'
                                                                        :paired-on (utils.datetime/timestamp)}))
-               :keycard/import-keys {:pairing    pairing'
-                                     :pin        pin
+               :keycard/import-keys {:pin        pin
                                      :on-success :keycard.callback/on-generate-and-load-key-success}})))
 
 (fx/defn load-recovering-key-screen

--- a/src/status_im/keycard/unpair.cljs
+++ b/src/status_im/keycard/unpair.cljs
@@ -37,10 +37,8 @@
 (fx/defn unpair
   {:events [:keycard/unpair]}
   [{:keys [db]}]
-  (let [pin     (common/vector->string (get-in db [:keycard :pin :current]))
-        pairing (common/get-pairing db)]
-    {:keycard/unpair {:pin     pin
-                      :pairing pairing}}))
+  (let [pin     (common/vector->string (get-in db [:keycard :pin :current]))]
+    {:keycard/unpair {:pin pin}}))
 
 (fx/defn unpair-and-delete
   {:events [:keycard/unpair-and-delete]}
@@ -50,11 +48,9 @@
    {:on-card-connected :keycard/unpair-and-delete
     :handler
     (fn [{:keys [db]}]
-      (let [pin     (common/vector->string (get-in db [:keycard :pin :current]))
-            pairing (common/get-pairing db)]
+      (let [pin     (common/vector->string (get-in db [:keycard :pin :current]))]
         {:keycard/unpair-and-delete
-         {:pin     pin
-          :pairing pairing}}))}))
+         {:pin pin}}))}))
 
 (fx/defn remove-pairing-from-multiaccount
   [cofx {:keys [remove-instance-uid?]}]
@@ -108,11 +104,9 @@
    {:on-card-connected :keycard/remove-key-with-unpair
     :handler
     (fn [{:keys [db]}]
-      (let [pin     (common/vector->string (get-in db [:keycard :pin :current]))
-            pairing (common/get-pairing db)]
+      (let [pin     (common/vector->string (get-in db [:keycard :pin :current]))]
         {:keycard/remove-key-with-unpair
-         {:pin     pin
-          :pairing pairing}}))}))
+         {:pin pin}}))}))
 
 (defn handle-account-removal [{:keys [db] :as cofx} keys-removed-from-card?]
   (let [key-uid (get-in db [:multiaccount :key-uid])

--- a/src/status_im/keycard/wallet.cljs
+++ b/src/status_im/keycard/wallet.cljs
@@ -19,7 +19,7 @@
 (fx/defn verify-pin-with-delay
   [cofx]
   {:utils/dispatch-later
-   ;; We need to give previous sheet some time to be fully hidden 
+   ;; We need to give previous sheet some time to be fully hidden
    [{:ms 200
      :dispatch [:wallet.accounts/verify-pin]}]})
 
@@ -33,8 +33,7 @@
   [{:keys [db]}]
   (let [path-num (inc (get-in db [:multiaccount :latest-derived-path]))
         path     (str constants/path-wallet-root "/" path-num)
-        pin      (common/vector->string (get-in db [:keycard :pin :export-key]))
-        pairing  (common/get-pairing db)]
+        pin      (common/vector->string (get-in db [:keycard :pin :export-key]))]
     {:db
      (assoc-in
       db [:keycard :on-export-success]
@@ -48,7 +47,7 @@
                   :public-key (str "0x" public-key)
                   :path       path})))
 
-     :keycard/export-key {:pin pin :pairing pairing :path path}}))
+     :keycard/export-key {:pin pin :path path}}))
 
 (fx/defn verify-pin
   {:events [:wallet.accounts/verify-pin]}

--- a/src/status_im/multiaccounts/login/core.cljs
+++ b/src/status_im/multiaccounts/login/core.cljs
@@ -438,7 +438,7 @@
         (get-credentials % key-uid)
         (and keycard-multiaccount?
              (get-in db [:keycard :card-connected?]))
-        (keycard.common/get-application-info % nil nil))
+        (keycard.common/get-application-info % nil))
      (open-login-callback nil))))
 
 (fx/defn biometric-auth-done

--- a/src/status_im/ui/screens/keycard/views.cljs
+++ b/src/status_im/ui/screens/keycard/views.cljs
@@ -116,7 +116,7 @@
       (i18n/label :t/pair-this-card)]
      [react/view {:margin-top 27}
       [quo/button {:type     :secondary
-                   :on-press #(re-frame/dispatch [:keycard.login.ui/dismiss-pressed])}
+                   :on-press #(re-frame/dispatch [:navigate-back])}
        (i18n/label :t/dismiss)]]]]])
 
 ;; NOTE(Ferossgp): Seems like it should be in popover

--- a/yarn.lock
+++ b/yarn.lock
@@ -6751,9 +6751,9 @@ react-native-splash-screen@^3.2.0:
   resolved "https://registry.yarnpkg.com/react-native-splash-screen/-/react-native-splash-screen-3.2.0.tgz#d47ec8557b1ba988ee3ea98d01463081b60fff45"
   integrity sha512-Ls9qiNZzW/OLFoI25wfjjAcrf2DZ975hn2vr6U9gyuxi2nooVbzQeFoQS5vQcbCt9QX5NY8ASEEAtlLdIa6KVg==
 
-"react-native-status-keycard@git+https://github.com/status-im/react-native-status-keycard.git#v2.5.32":
-  version "2.5.32"
-  resolved "git+https://github.com/status-im/react-native-status-keycard.git#f602fadf800937fc1de92aa18c2e58c372eb1bed"
+"react-native-status-keycard@git+https://github.com/status-im/react-native-status-keycard.git#v2.5.33":
+  version "2.5.33"
+  resolved "git+https://github.com/status-im/react-native-status-keycard.git#d1098e969a1007919134e210781bdc57222bf8d3"
 
 react-native-svg@^9.8.4:
   version "9.13.6"


### PR DESCRIPTION
Moves pairing handling to the native module, allowing to select the correct pairing after the card has been tapped and thus decoupling the account from pairing altogether.

Closes #11389 and #11387. Allows implementing card backup and using multiple cards with the same account

status: ready
