### PR TITLE
Feature/anon metrics

### DIFF
--- a/src/status_im/anon_metrics/interceptors.cljs
+++ b/src/status_im/anon_metrics/interceptors.cljs
@@ -1,0 +1,27 @@
+(ns status-im.anon-metrics.interceptors
+  (:require [status-im.ethereum.json-rpc :as json-rpc]
+            [taoensso.timbre :as log]
+            [re-frame.interceptor :refer [->interceptor]]
+            [status-im.utils.platform :as platform]
+            [status-im.utils.build :as build]
+            [status-im.anon-metrics.transformers :as txf]))
+
+(defn transform-and-log [context]
+  (log/info :catch-event-fn (get-in context [:coeffects :event]))
+  (when-let [transformed-payload (txf/transform context)]
+    (json-rpc/call {:method "appmetrics_saveAppMetrics"
+                    :params [[{:event (-> context :coeffects :event first)
+                               :value transformed-payload
+                               :app_version build/version
+                               :os platform/os}]]
+                    :on-failure log/error})))
+
+(defn catch-events-before [context]
+  (log/info "catch-events/interceptor fired")
+  (transform-and-log context)
+  context)
+
+(def catch-events
+  (->interceptor
+   :id     :catch-events
+   :before catch-events-before))

--- a/src/status_im/anon_metrics/transformers.cljs
+++ b/src/status_im/anon_metrics/transformers.cljs
@@ -1,0 +1,17 @@
+(ns status-im.anon-metrics.transformers
+  "`status-go` defines the shape of expected events so that we don't overcollect data (by mistake or intentionally).
+  `transformers` ns transform the event payload to match the expected shape on `status-go` side.")
+
+(defn navigate-to-txf [event]
+  {:view-id (second event)
+   :params (-> event
+               (nth 2)
+               (select-keys [:screen]))})
+
+(def transformations
+  {:navigate-to navigate-to-txf})
+
+(defn transform [ctx]
+  (let [event (-> ctx :coeffects :event)]
+    (when-let [txf (-> event first transformations)]
+      (txf event))))

--- a/src/status_im/ethereum/json_rpc.cljs
+++ b/src/status_im/ethereum/json_rpc.cljs
@@ -178,7 +178,8 @@
    "mailservers_addChatRequestRange" {}
    "mailservers_addChatRequestRanges" {}
    "mailservers_getChatRequestRanges" {}
-   "mailservers_deleteChatRequestRange" {}})
+   "mailservers_deleteChatRequestRange" {}
+   "appmetrics_saveAppMetrics" {}})
 
 (defn on-error-retry
   [call-method {:keys [method number-of-retries delay on-error] :as arg}]

--- a/src/status_im/navigation.cljs
+++ b/src/status_im/navigation.cljs
@@ -2,7 +2,8 @@
   (:require [re-frame.core :as re-frame]
             [status-im.ui.screens.routing.core :as navigation]
             [taoensso.timbre :as log]
-            [status-im.utils.fx :as fx]))
+            [status-im.utils.fx :as fx]
+            [status-im.anon-metrics.interceptors :as anon-metrics]))
 
 (re-frame/reg-fx
  ::navigate-to
@@ -44,7 +45,8 @@
    ::navigate-to [go-to-view-id screen-params]})
 
 (fx/defn navigate-to
-  {:events       [:navigate-to]}
+  {:events       [:navigate-to]
+   :interceptors [anon-metrics/catch-events]}
   [cofx go-to-view-id screen-params]
   (navigate-to-cofx cofx go-to-view-id screen-params))
 
@@ -59,7 +61,8 @@
   {::navigate-reset config})
 
 (fx/defn navigate-replace
-  {:events [:navigate-replace]}
+  {:events [:navigate-replace]
+   :interceptors [anon-metrics/catch-events]}
   [{:keys [db]} go-to-view-id screen-params]
   (let [db (cond-> (assoc db :view-id go-to-view-id)
              (seq screen-params)


### PR DESCRIPTION
## What's Changed?

Added an interceptor to catch the payloads of specific events and send the filtered data to `status-go` for further processing.

## Why Make the Change?

This functionality is the foundational change to `status-react` to compliment the functionality introduced to `status-go` in this PR https://github.com/status-im/status-go/pull/2170.

Effectively the interceptor's function is to relay event data about specific user actions to `status-go` ensuring that no sensitive data is collected by or even passed to `status-go`. The `status-go` side of this functionality also has a validation mechanism that explicitly rejects incoming data that does not adhere to the strict definition of what data is allowed.