### PR TITLE
Update interceptors.cljs

### DIFF
--- a/src/status_im/anon_metrics/interceptors.cljs
+++ b/src/status_im/anon_metrics/interceptors.cljs
@@ -14,7 +14,7 @@
                                :value transformed-payload
                                :app_version build/version
                                :os platform/os}]]
-                    :on-failure log/error})))
+                    :on-failure prn})))
 
 (defn catch-events-before [context]
   (log/info "catch-events/interceptor fired")

--- a/src/status_im/anon_metrics/interceptors.cljs
+++ b/src/status_im/anon_metrics/interceptors.cljs
@@ -14,7 +14,7 @@
                                :value transformed-payload
                                :app_version build/version
                                :os platform/os}]]
-                    :on-failure prn})))
+                    :on-failure #(log/error)})))
 
 (defn catch-events-before [context]
   (log/info "catch-events/interceptor fired")


### PR DESCRIPTION
Quick patch to remove log macro call in an inaccessible place

Currently getting the following warning error.

```shell
------ WARNING #1 - :undeclared-var --------------------------------------------
 File: /Users/samuel/Documents/dev/status-im/status-react/src/status_im/anon_metrics/interceptors.cljs:17:33
--------------------------------------------------------------------------------
  14 |                                :value transformed-payload
  15 |                                :app_version build/version
  16 |                                :os platform/os}]]
  17 |                     :on-failure log/error})))
---------------------------------------^----------------------------------------
 Can't take value of macro taoensso.timbre/error
--------------------------------------------------------------------------------
  18 | 
  19 | (defn catch-events-before [context]
  20 |   (log/info "catch-events/interceptor fired")
  21 |   (transform-and-log context)
--------------------------------------------------------------------------------
```