### PR TITLE
Fix/#11821 rpc finetuning

### DIFF
--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -54,7 +54,8 @@
             status-im.bootnodes.core
             status-im.browser.core
             status-im.browser.permissions
-            status-im.chat.models.transport))
+            status-im.chat.models.transport
+            [status-im.navigation :as navigation]))
 
 (re-frame/reg-fx
  :dismiss-keyboard
@@ -235,3 +236,11 @@
                      :params     []
                      :on-success (fn [on-ramps]
                                    (re-frame/dispatch [::crypto-loaded on-ramps]))}]})
+
+(fx/defn open-buy-crypto-screen
+  {:events [:buy-crypto.ui/open-screen]}
+  [cofx]
+  (fx/merge
+   cofx
+   (navigation/navigate-to :buy-crypto nil)
+   (wallet/keep-watching-history)))

--- a/src/status_im/ui/screens/wallet/account/views.cljs
+++ b/src/status_im/ui/screens/wallet/account/views.cljs
@@ -64,7 +64,7 @@
                                    :color       colors/white-transparent-70-persist}}
        (ethereum/normalized-hex address)]]
      [react/view {:position :absolute :top 12 :right 12}
-      [react/touchable-highlight {:on-press #(re-frame/dispatch [:show-popover {:view :share-account :address address}])}
+      [react/touchable-highlight {:on-press #(re-frame/dispatch [:wallet/share-popover address])}
        [icons/icon :main-icons/share {:color                      colors/white-persist
                                       :accessibility-label :share-wallet-address-icon}]]]
      [react/view {:height                     button-group-height :background-color          colors/black-transparent-20
@@ -83,7 +83,7 @@
        (i18n/label :t/receive)
        :main-icons/receive
        colors/white-persist
-       #(re-frame/dispatch [:show-popover {:view :share-account :address address}])]]]))
+       #(re-frame/dispatch [:wallet/share-popover address])]]]))
 
 (defn render-collectible [{:keys [name icon amount] :as collectible}]
   (let [items-number (money/to-fixed amount)]
@@ -170,7 +170,7 @@
     (i18n/label :t/receive)
     :main-icons/receive
     colors/blue-persist
-    #(re-frame/dispatch [:show-popover {:view :share-account :address address}])]])
+    #(re-frame/dispatch [:wallet/share-popover address])]])
 
 (defn anim-listener [anim-y scroll-y]
   (let [to-show (atom false)]

--- a/src/status_im/ui/screens/wallet/accounts/sheets.cljs
+++ b/src/status_im/ui/screens/wallet/accounts/sheets.cljs
@@ -64,8 +64,7 @@
      :icon                :main-icons/share
      :accessibility-label :share-account-button
      :on-press            #(hide-sheet-and-dispatch
-                            [:show-popover {:view    :share-account
-                                            :address (:address account)}])}]])
+                            [:wallet/share-popover (:address account)])}]])
 
 (defn add-account []
   (let [keycard? @(re-frame/subscribe [:keycard-multiaccount?])]

--- a/src/status_im/ui/screens/wallet/buy_crypto/views.cljs
+++ b/src/status_im/ui/screens/wallet/buy_crypto/views.cljs
@@ -15,7 +15,7 @@
 (def learn-more-url "")
 
 (defn on-buy-crypto-pressed []
-  (re-frame/dispatch [:navigate-to :buy-crypto]))
+  (re-frame/dispatch [:buy-crypto.ui/open-screen]))
 
 (defn render-on-ramp [{:keys [name fees logo-url description] :as on-ramp}]
   [react/touchable-highlight {:on-press #(re-frame/dispatch [:navigate-to :buy-crypto-website on-ramp])


### PR DESCRIPTION
fix #11821 

Transfer history checking is resumed for 30 mins for an empty account in case if 
- Users taps Share
- User taps Buy crypto
- User receives tx message

status: ready