### PR TITLE
Prevent incorrect usage of fx/defn inside fx/merge

### DIFF
--- a/src/status_im/utils/fx.clj
+++ b/src/status_im/utils/fx.clj
@@ -52,8 +52,18 @@
            ([cofx# ~@args]
             (if (and (map? cofx#)
                      (not (nil? (:db cofx#))))
-              (let [~cofx cofx#]
-                ~@fdecl)
+              (let [res# (let [~cofx cofx#] ~@fdecl)]
+                (when-not (nil? res#)
+                  (aset res#
+                        "cljs$core$ILookup$_lookup$arity$2"
+                        (fn [foo# k#]
+                          (clojure.core/this-as
+                           m#
+                           (when (and (map? k#)
+                                      (contains? k# :db))
+                             (throw (js/Error. (str "fx/defn's result is used as fx producing function in " ~name))))
+                           (get m# k# nil)))))
+                res#)
               (throw (js/Error. (str "fx/defn expects a map of cofx as first argument got " cofx# " in function " ~name))))))
          ~@(register-events events interceptors (with-meta name m) argsyms))
       (throw (Exception. (str "fx/defn expects a vector of keyword as value for :events key in attr-map in function " name))))))


### PR DESCRIPTION
For example we have some event handler:
```clojure
(fx/defn foobar
  [{:keys [db]}]
  {:db (assoc db :foo :bar)})
```

and we use it inside `fx/merge` like this
```clojure
(let [cofx {:db {}}]
  (fx/merge
   {:db {}}
   {:some-fx nil}
   (foobar cofx)))
```
Sometimes it happens that `cofx` is left as an explicit parameter for `foobar` and as a result this handler will be ignored at all. This periodically happens during different bug fixes/refactoring. Resulting fx map will looks as
```clojure
{:db      {}
 :some-fx nil}
```
because 
```clojure
((foobar cofx) cofx) => (get {:db {:foo :bar}} {:db {}, :some-fx nil}) => nil
```
but we expect it to be
```clojure
{:db      {:foo :bar}
 :some-fx nil}
```

To prevent this from happening map's lookup function is overwritten in the dumbest way possible and in case if cofx is passed as a key an exception is thrown.

status: wip