### PR TITLE
Move react-native-status module to a local CocoaPods dependency

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -20,6 +20,7 @@ abstract_target 'Status' do
   pod 'Permission-Camera', :path => "#{permissions_path}/Camera.podspec"
 
   pod "react-native-status-keycard", path: "../node_modules/react-native-status-keycard"
+  pod "react-native-status", path: "../modules/react-native-status"
   pod "Keycard", git: "https://github.com/status-im/Keycard.swift.git"
   pod 'secp256k1', git: "https://github.com/status-im/secp256k1.swift.git", submodules: true
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -25,7 +25,7 @@ PODS:
     - OpenSSL-Universal (= 1.1.180)
   - Flipper-Glog (0.3.6)
   - Flipper-PeerTalk (0.0.4)
-  - Flipper-RSocket (1.3.0):
+  - Flipper-RSocket (1.3.1):
     - Flipper-Folly (~> 2.5)
   - FlipperKit (0.74.0):
     - FlipperKit/Core (= 0.74.0)
@@ -268,7 +268,9 @@ PODS:
     - React
   - react-native-splash-screen (3.2.0):
     - React
-  - react-native-status-keycard (2.5.32):
+  - react-native-status (1.0.0):
+    - React
+  - react-native-status-keycard (2.5.33):
     - Keycard
     - React
   - react-native-webview (10.9.2):
@@ -440,6 +442,7 @@ DEPENDENCIES:
   - react-native-shake (from `../node_modules/react-native-shake`)
   - "react-native-slider (from `../node_modules/@react-native-community/slider`)"
   - react-native-splash-screen (from `../node_modules/react-native-splash-screen`)
+  - react-native-status (from `../modules/react-native-status`)
   - react-native-status-keycard (from `../node_modules/react-native-status-keycard`)
   - react-native-webview (from `../node_modules/react-native-webview`)
   - React-RCTActionSheet (from `../node_modules/react-native/Libraries/ActionSheetIOS`)
@@ -555,6 +558,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@react-native-community/slider"
   react-native-splash-screen:
     :path: "../node_modules/react-native-splash-screen"
+  react-native-status:
+    :path: "../modules/react-native-status"
   react-native-status-keycard:
     :path: "../node_modules/react-native-status-keycard"
   react-native-webview:
@@ -643,7 +648,7 @@ SPEC CHECKSUMS:
   Flipper-Folly: f7a3caafbd74bda4827954fd7a6e000e36355489
   Flipper-Glog: 1dfd6abf1e922806c52ceb8701a3599a79a200a6
   Flipper-PeerTalk: 116d8f857dc6ef55c7a5a75ea3ceaafe878aadc9
-  Flipper-RSocket: 602921fee03edacf18f5d6f3d3594ba477f456e5
+  Flipper-RSocket: 127954abe8b162fcaf68d2134d34dc2bd7076154
   FlipperKit: f42987ea58737ac0fb3fbc38f8e703452ba56940
   Folly: b73c3869541e86821df3c387eb0af5f65addfab4
   glog: cee4319f395bad5865ef3f32466c2e0ae677432c
@@ -673,7 +678,8 @@ SPEC CHECKSUMS:
   react-native-shake: de052eaa3eadc4a326b8ddd7ac80c06e8d84528c
   react-native-slider: 12bd76d3d568c9c5500825db54123d44b48e4ad4
   react-native-splash-screen: 200d11d188e2e78cea3ad319964f6142b6384865
-  react-native-status-keycard: f846d457fc2b964d327f86c345936477004a8a60
+  react-native-status: 45dbf1302ce3c258b459dfab137cd1c2c68c295d
+  react-native-status-keycard: dac854029a37eabf04a8ede091ddeee71ab049b9
   react-native-webview: 4e96d493f9f90ba4f03b28933f30b2964df07e39
   React-RCTActionSheet: 89a0ca9f4a06c1f93c26067af074ccdce0f40336
   React-RCTAnimation: 1bde3ecc0c104c55df246eda516e0deb03c4e49b
@@ -710,6 +716,6 @@ SPEC CHECKSUMS:
   Yoga: 4bd86afe9883422a7c4028c00e34790f560923d6
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: 2dcfb8f3d85214711628bc8909bfe647a800507a
+PODFILE CHECKSUM: c1c8d3ccfd58edcd7388c38b7b0a24d729b2be80
 
 COCOAPODS: 1.10.0

--- a/ios/StatusIm.xcodeproj/project.pbxproj
+++ b/ios/StatusIm.xcodeproj/project.pbxproj
@@ -10,7 +10,6 @@
 		00E356F31AD99517003FC87E /* StatusImTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 00E356F21AD99517003FC87E /* StatusImTests.m */; };
 		13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.m */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
-		20AB9EC61D47CC0300E7FD9C /* libRCTStatus.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 201067C41D4789F700FA83B6 /* libRCTStatus.a */; };
 		25DC9C9DC25846BD8D084888 /* libc++.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B9A886A2CB448B1ABA0EB62 /* libc++.tbd */; };
 		3870E1E692E24133A80B07DE /* Inter-SemiBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 693A62DB37BC4CD5A30E5C96 /* Inter-SemiBold.otf */; };
 		393D26E3080B443A998F4A2F /* Inter-Italic.otf in Resources */ = {isa = PBXBuildFile; fileRef = B07176ACDAA1422E8F0A3D6B /* Inter-Italic.otf */; };
@@ -22,7 +21,6 @@
 		3AAD2AC024A3A60E0075D594 /* MessageUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B24FC7FE1DE7195F00D694FF /* MessageUI.framework */; };
 		3AAD2AC124A3A60E0075D594 /* Social.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B24FC7FC1DE7195700D694FF /* Social.framework */; };
 		3AAD2AC224A3A60E0075D594 /* Statusgo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE4E31B21D8695250033ED64 /* Statusgo.framework */; };
-		3AAD2AC324A3A60E0075D594 /* libRCTStatus.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 201067C41D4789F700FA83B6 /* libRCTStatus.a */; };
 		3AAD2AC524A3A60E0075D594 /* libc++.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B9A886A2CB448B1ABA0EB62 /* libc++.tbd */; };
 		3AAD2AC624A3A60E0075D594 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 4E586E1B0E544F64AA9F5BD1 /* libz.tbd */; };
 		3AAD2ACA24A3A60E0075D594 /* launch-image-universal.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 74B758FB20D7C00B003343C3 /* launch-image-universal.storyboard */; };
@@ -64,13 +62,6 @@
 			proxyType = 1;
 			remoteGlobalIDString = 13B07F861A680F5B00A75B9A;
 			remoteInfo = StatusIm;
-		};
-		201067C31D4789F700FA83B6 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 439B6B4B407A4E2AACAFE5BE /* RCTStatus.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 206C9F3A1D474E910063E3E6;
-			remoteInfo = RCTStatus;
 		};
 		9EC013781E06FB1900155B5C /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -123,7 +114,6 @@
 		3AAD2ADC24A3A60E0075D594 /* Status PR.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Status PR.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3AB1C3AD245C043900098F67 /* StatusIm-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "StatusIm-Bridging-Header.h"; sourceTree = "<group>"; };
 		3F224519278D376B19F4CA2B /* Pods-Status-StatusIm-StatusImTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Status-StatusIm-StatusImTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-Status-StatusIm-StatusImTests/Pods-Status-StatusIm-StatusImTests.release.xcconfig"; sourceTree = "<group>"; };
-		439B6B4B407A4E2AACAFE5BE /* RCTStatus.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RCTStatus.xcodeproj; path = "../modules/react-native-status/ios/RCTStatus/RCTStatus.xcodeproj"; sourceTree = "<group>"; };
 		4C16DE0B1F89508700AA10DB /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 		4E586E1B0E544F64AA9F5BD1 /* libz.tbd */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
 		5D4CB5416994C913628B8754 /* libPods-Status-StatusImPR.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Status-StatusImPR.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -170,7 +160,6 @@
 				B24FC7FF1DE7195F00D694FF /* MessageUI.framework in Frameworks */,
 				B24FC7FD1DE7195700D694FF /* Social.framework in Frameworks */,
 				CE4E31B31D8695250033ED64 /* Statusgo.framework in Frameworks */,
-				20AB9EC61D47CC0300E7FD9C /* libRCTStatus.a in Frameworks */,
 				25DC9C9DC25846BD8D084888 /* libc++.tbd in Frameworks */,
 				BA68A2377A20496EA737000D /* libz.tbd in Frameworks */,
 				68E19BBDF749E72ED1F9DEF5 /* libPods-Status-StatusIm.a in Frameworks */,
@@ -185,7 +174,6 @@
 				3AAD2AC024A3A60E0075D594 /* MessageUI.framework in Frameworks */,
 				3AAD2AC124A3A60E0075D594 /* Social.framework in Frameworks */,
 				3AAD2AC224A3A60E0075D594 /* Statusgo.framework in Frameworks */,
-				3AAD2AC324A3A60E0075D594 /* libRCTStatus.a in Frameworks */,
 				3AAD2AC524A3A60E0075D594 /* libc++.tbd in Frameworks */,
 				3AAD2AC624A3A60E0075D594 /* libz.tbd in Frameworks */,
 				6C137817D5298C82BC79177C /* libPods-Status-StatusImPR.a in Frameworks */,
@@ -245,14 +233,6 @@
 			name = Resources;
 			sourceTree = "<group>";
 		};
-		201067BA1D4789F700FA83B6 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				201067C41D4789F700FA83B6 /* libRCTStatus.a */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
 		3AAD2AB624A3A5F10075D594 /* StatusImPR */ = {
 			isa = PBXGroup;
 			children = (
@@ -278,7 +258,6 @@
 			isa = PBXGroup;
 			children = (
 				9EC0135C1E06FB1900155B5C /* RCTWKWebView.xcodeproj */,
-				439B6B4B407A4E2AACAFE5BE /* RCTStatus.xcodeproj */,
 			);
 			name = Libraries;
 			sourceTree = "<group>";
@@ -462,10 +441,6 @@
 			projectDirPath = "";
 			projectReferences = (
 				{
-					ProductGroup = 201067BA1D4789F700FA83B6 /* Products */;
-					ProjectRef = 439B6B4B407A4E2AACAFE5BE /* RCTStatus.xcodeproj */;
-				},
-				{
 					ProductGroup = 9EC0135D1E06FB1900155B5C /* Products */;
 					ProjectRef = 9EC0135C1E06FB1900155B5C /* RCTWKWebView.xcodeproj */;
 				},
@@ -480,13 +455,6 @@
 /* End PBXProject section */
 
 /* Begin PBXReferenceProxy section */
-		201067C41D4789F700FA83B6 /* libRCTStatus.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libRCTStatus.a;
-			remoteRef = 201067C31D4789F700FA83B6 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
 		9EC013791E06FB1900155B5C /* libRCTWKWebView.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;

--- a/modules/react-native-status/ios/RCTStatus/RCTStatus.h
+++ b/modules/react-native-status/ios/RCTStatus/RCTStatus.h
@@ -1,7 +1,7 @@
 #import <sys/utsname.h>
 #import <Foundation/Foundation.h>
 #import <React/RCTBridgeModule.h>
-#import "Statusgo/Statusgo.h"
+#import "Statusgo.h"
 #import "RCTLog.h"
 
 @interface Status : NSObject <RCTBridgeModule, StatusgoSignalHandler>

--- a/modules/react-native-status/ios/RCTStatus/RCTStatus.m
+++ b/modules/react-native-status/ios/RCTStatus/RCTStatus.m
@@ -2,8 +2,8 @@
 #import "ReactNativeConfig.h"
 #import "React/RCTBridge.h"
 #import "React/RCTEventDispatcher.h"
-#import "Statusgo/Statusgo.h"
-#import <SSZipArchive.h>
+#import "Statusgo.h"
+#import "SSZipArchive.h"
 
 @interface NSDictionary (BVJSONString)
 -(NSString*) bv_jsonStringWithPrettyPrint:(BOOL) prettyPrint;

--- a/modules/react-native-status/react-native-status.podspec
+++ b/modules/react-native-status/react-native-status.podspec
@@ -1,0 +1,22 @@
+require "json"
+
+package = JSON.parse(File.read(File.join(__dir__, "package.json")))
+
+Pod::Spec.new do |s|
+  s.name         = "react-native-status"
+  s.version      = package["version"]
+  s.summary      = package["description"]
+  s.homepage     = package["homepage"]
+  s.license      = package["license"]
+  s.authors      = package["author"]
+
+  s.platforms    = { :ios => "10.0" }
+  s.source       = { :git => "https://github.com/status-im/react-native-status.git", :tag => "#{s.version}" }
+
+
+  s.source_files = "ios/**/*.{h,m,mm,swift}"
+
+
+  s.dependency "React"
+  s.vendored_frameworks = "Statusgo.framework"
+end


### PR DESCRIPTION
### Summary

I had some problems with `react-native-status` module linking on Xcode 12 / M1 Macbook / macOS Big Sur. It compiled but the NativeModule was not recognized on the React Native side, making the app to crash as soon as it started. Moving `react-native-status` from Manual Linking to a pod dependency solved the problem, and I thought it might be better for building and compatibility to let CocoaPods manage the library linking, so pushing this PR as a proposal to move it to a pod dependency.

### Review notes

- Check if package versions modifications in `Podfile.lock` file are OK 
- Check iOS compiling, probably by checking out the code and manually trying it

### Testing notes

- A smoke testing should be fine as nothing logic-related was changed.

#### Platforms

- iOS

status: ready
