### PR TITLE
🔄 Pull to refresh on wallet screen

### DIFF
--- a/src/quo/components/animated_header.cljs
+++ b/src/quo/components/animated_header.cljs
@@ -44,7 +44,7 @@
         offset          (reagent/atom 0)
         on-layout       (fn [evt]
                           (reset! offset (oget evt "nativeEvent" "layout" "height")))]
-    (fn [{:keys [extended-header] :as props} children]
+    (fn [{:keys [extended-header refresh-control] :as props} children]
       [animated/view {:flex           1
                       :pointer-events :box-none}
        [animated/code {:key  (str @offset)
@@ -68,7 +68,8 @@
                         (dissoc props :extended-header))]]
        (into [animated/scroll-view {:on-scroll           on-scroll
                                     :style               {:z-index 1}
-                                    :scrollEventThrottle 16}
+                                    :scrollEventThrottle 16
+                                    :refreshControl      refresh-control}
               [animated/view {:pointer-events :box-none}
                [animated/view {:pointer-events :box-none
                                :on-layout      on-layout}

--- a/src/status_im/ui/screens/multiaccounts/login/views.cljs
+++ b/src/status_im/ui/screens/multiaccounts/login/views.cljs
@@ -107,3 +107,10 @@
          {:disabled (or (not sign-in-enabled?) processing)
           :on-press #(login-multiaccount @password-text-input)}
          (i18n/label :t/sign-in)]]}]]))
+
+(comment
+  ;; fill password and login
+  (do
+    (re-frame/dispatch [:set-in [:multiaccounts/login :password]
+                        (security/mask-data "111111")])
+    (re-frame/dispatch [:multiaccounts.login.ui/password-input-submitted])))

--- a/src/status_im/ui/screens/wallet/account/views.cljs
+++ b/src/status_im/ui/screens/wallet/account/views.cljs
@@ -180,7 +180,8 @@
 
 (views/defview account []
   (views/letsubs [{:keys [name address] :as account} [:multiaccount/current-account]
-                  fetching-error [:wallet/fetching-error]]
+                  fetching-error [:wallet/fetching-error]
+                  refreshing-history? [:wallet/refreshing-history?]]
     (let [anim-y (animation/create-value button-group-height)
           scroll-y (animation/create-value 0)]
       (anim-listener anim-y scroll-y)
@@ -201,7 +202,7 @@
          :refreshControl        (accounts/refresh-control
                                  (and
                                   @accounts/updates-counter
-                                  @(re-frame/subscribe [:wallet/refreshing-history?])))}
+                                  refreshing-history?))}
         (when fetching-error
           [react/view {:style {:flex 1
                                :align-items :center

--- a/src/status_im/ui/screens/wallet/accounts/views.cljs
+++ b/src/status_im/ui/screens/wallet/accounts/views.cljs
@@ -222,7 +222,8 @@
      [quo/animated-header
       {:extended-header   total-value
        :use-insets        true
-       :refresh-control   (refresh-control (and @updates-counter refreshing-history?))
+       :refresh-control   (refresh-control
+                           (and @updates-counter refreshing-history?))
        :right-accessories [{:on-press            #(re-frame/dispatch
                                                    [::qr-scanner/scan-code
                                                     {:handler :wallet.send/qr-scanner-result}])

--- a/src/status_im/ui/screens/wallet/accounts/views.cljs
+++ b/src/status_im/ui/screens/wallet/accounts/views.cljs
@@ -199,11 +199,11 @@
 
 (defn schedule-counter-reset []
   (utils.utils/set-timeout
-    (fn []
-      (swap! updates-counter inc)
-      (when @(re-frame/subscribe [:wallet/refreshing-history?])
-        (schedule-counter-reset)))
-    1000))
+   (fn []
+     (swap! updates-counter inc)
+     (when @(re-frame/subscribe [:wallet/refreshing-history?])
+       (schedule-counter-reset)))
+   1000))
 
 (defn refresh-action []
   (schedule-counter-reset)

--- a/src/status_im/wallet/core.cljs
+++ b/src/status_im/wallet/core.cljs
@@ -709,6 +709,7 @@
    cofx
    {:force-restart? force-restart?}))
 
+;; cooldown time in milliseconds
 (def pull-to-refresh-cooldown-period (* 1 60 1000))
 
 (fx/defn restart-on-pull


### PR DESCRIPTION
fixes #11849

### Summary
In the current implementation, we have pull-to-refresh action on individual accounts page. This action restarts the wallet service.

This PR replicates the same action on the accounts overview screen.

### Testing notes
Pull-to-refresh is known to behave differently on Android on Ios. We should test both to be sure.

#### Platforms
- Android
- iOS

#### Areas that maybe impacted
- Wallet

##### Functional
- wallet / transactions

### Steps to test
- Goto wallet screen, pull down to refresh, all account balances should update
- The same should happen if you are on a specific account screen and you pull-to-refresh

status: ready
