### PR TITLE
🧽 🚿 Add missing seed phrase sanitation to key storage flow 

### DIFF
--- a/src/status_im/multiaccounts/key_storage/core.cljs
+++ b/src/status_im/multiaccounts/key_storage/core.cljs
@@ -66,7 +66,8 @@
   "Check if the key-uid was generated with the given seed-phrase"
   [{:keys [import-mnemonic-fn on-success on-error]} {:keys [seed-phrase key-uid]}]
   (import-mnemonic-fn
-   seed-phrase nil
+   (mnemonic/sanitize-passphrase seed-phrase)
+   nil
    (fn [result]
      (let [{:keys [keyUid]} (types/json->clj result)]
        ;; if the key-uid from app-db is same as the one returned by multiaccount import,


### PR DESCRIPTION
### Summary

In key management section, the mnemonic was not being trimmed, which lead to issues. The issue was pointed out by @Serhy in https://github.com/status-im/status-react/issues/11735#issuecomment-782066601 .

This PR adds the missing seed sanitation.

#### Platforms
- Android
- iOS


#### Areas that maybe impacted
- Key transfer to Keycard

### Steps to test
- Open Status
- Click on an on-device multi account
- Click on the context menu (three dots on the right-top)
- Chose "Manage keys and storage"
- Check "Move keystore file"
- Click "Enter seed phrase"
- Enter seed phrase of the selected account with extra spaces at the end / in between words
- You should be able to proceed as long as the words are correct


status: ready
