### PR TITLE
Back / dismiss gestures on Android

### DIFF
--- a/src/status_im/ui/screens/routing/main.cljs
+++ b/src/status_im/ui/screens/routing/main.cljs
@@ -82,48 +82,48 @@
         :component    home/welcome}
        {:name       :new-chat
         :on-focus   [::new-chat.events/new-chat-focus]
-        :transition :presentation-ios
+        :transition :presentation-modal
         :component  new-chat/new-chat}
        {:name       :new-contact
         :on-focus   [::new-chat.events/new-chat-focus]
-        :transition :presentation-ios
+        :transition :presentation-modal
         :component  new-chat/new-contact}
        {:name       :link-preview-settings
-        :transition :presentation-ios
+        :transition :presentation-modal
         :component  link-previews/link-previews-settings}
        {:name       :new-public-chat
-        :transition :presentation-ios
+        :transition :presentation-modal
         :insets     {:bottom true}
         :component  new-public-chat/new-public-chat}
        {:name       :nickname
-        :transition :presentation-ios
+        :transition :presentation-modal
         :insets     {:bottom true}
         :component  contact/nickname}
        {:name       :edit-group-chat-name
-        :transition :presentation-ios
+        :transition :presentation-modal
         :insets     {:bottom true}
         :component  group-chat/edit-group-chat-name}
        {:name       :create-group-chat
-        :transition :presentation-ios
+        :transition :presentation-modal
         :component  chat-stack/new-group-chat}
        {:name       :communities
-        :transition :presentation-ios
+        :transition :presentation-modal
         :component  chat-stack/communities}
        {:name       :referral-invite
-        :transition :presentation-ios
+        :transition :presentation-modal
         :insets     {:bottom true}
         :component  invite/referral-invite}
        {:name       :add-participants-toggle-list
         :on-focus   [:group/add-participants-toggle-list]
-        :transition :presentation-ios
+        :transition :presentation-modal
         :insets     {:bottom true}
         :component  group-chat/add-participants-toggle-list}
        {:name       :recipient
-        :transition :presentation-ios
+        :transition :presentation-modal
         :insets     {:bottom true}
         :component  recipient/recipient}
        {:name       :new-favourite
-        :transition :presentation-ios
+        :transition :presentation-modal
         :insets     {:bottom true}
         :component  recipient/new-favourite}
        {:name      :qr-scanner
@@ -142,31 +142,31 @@
         :insets       {:bottom true}
         :component    notifications-settings/notifications-onboarding}
        {:name       :prepare-send-transaction
-        :transition :presentation-ios
+        :transition :presentation-modal
         :insets     {:bottom true}
         :component  wallet/prepare-send-transaction}
        {:name       :request-transaction
-        :transition :presentation-ios
+        :transition :presentation-modal
         :insets     {:bottom true}
         :component  wallet/request-transaction}
        {:name       :my-status
-        :transition :presentation-ios
+        :transition :presentation-modal
         :insets     {:bottom true}
         :component  status.new/my-status}
        {:name       :new-bookmark
-        :transition :presentation-ios
+        :transition :presentation-modal
         :insets     {:bottom true}
         :component  bookmarks/new-bookmark}
        {:name       :profile
-        :transition :presentation-ios
+        :transition :presentation-modal
         :insets     {:bottom true}
         :component  contact/profile}
        {:name       :buy-crypto
-        :transition :presentation-ios
+        :transition :presentation-modal
         :insets     {:bottom true}
         :component wallet.buy-crypto/container}
        {:name       :buy-crypto-website
-        :transition :presentation-ios
+        :transition :presentation-modal
         :insets     {:bottom true}
         :component  wallet.buy-crypto/website}
        {:name      :invite-people-community

--- a/src/status_im/ui/screens/routing/profile_stack.cljs
+++ b/src/status_im/ui/screens/routing/profile_stack.cljs
@@ -120,7 +120,7 @@
     {:name      :backup-seed
      :component profile.seed/backup-seed}
     {:name       :delete-profile
-     :transition :presentation-ios
+     :transition :presentation-modal
      :insets     {:bottom true}
      :component  delete-profile/delete-profile}
     ;; {:name:my-profile-ext-settings


### PR DESCRIPTION
fixes #11913 

### Summary

We need to enable navigation gestures on Android. In this PR i'm doing a refactor on the routing core functions where `gestureEnabled` is set to true by default on all screens on Android, which is enabling swipe gestures for navigating back and therefore that comes with animated transitions. Also we are applying different transition animations for modal presentations (default is an horizontal transition from left to right, and for modal presentation is a vertical transition from bottom to top). I set some arbitrary `gestureResponseDistance` values for enabling the swipe gesture, but can be adjusted. Finally, refactored `:presentation-ios` to `:presentation-modal` because we are enabling modal presentation for both OS.

![navigation-gestures-android](https://user-images.githubusercontent.com/18485527/114076288-e1682e80-987c-11eb-9f75-55ac0e343eff.gif)

### Testing notes

Be sure that no screen was broken.

#### Platforms

- Android
- iOS (changes impact on Android but doing some smoke testing on iOS is recommended)

#### Areas that maybe impacted
General navigation

##### Non-functional

- Navigation transitions and gestures

### Steps to test

- Open Status
- Navigate through screens
- Swipe horizontally to go back, or swipe vertically to dismiss a modal

status: ready