### PR TITLE
Fixed error on login with attempt to save wrong key into account

### DIFF
--- a/src/status_im/chat/models/link_preview.cljs
+++ b/src/status_im/chat/models/link_preview.cljs
@@ -63,8 +63,7 @@
 
 (fx/defn save-link-preview-whitelist
   {:events [::link-preview-whitelist-received]}
-  [cofx whitelist]
-  (fx/merge cofx
-            (multiaccounts.update/multiaccount-update
-             :link-previews-whitelist whitelist {})))
+  [{:keys [db]} whitelist]
+  {:db (assoc db :link-previews-whitelist
+              whitelist)})
 

--- a/src/status_im/db.cljs
+++ b/src/status_im/db.cljs
@@ -11,6 +11,7 @@
              :current-chat-id                    nil
              :selected-participants              #{}
              :sync-state                         :done
+             :link-previews-whitelist            []
              :app-state                          "active"
              :wallet                              wallet.db/default-wallet
              :wallet/all-tokens                  {}

--- a/src/status_im/subs.cljs
+++ b/src/status_im/subs.cljs
@@ -79,6 +79,7 @@
 (reg-root-key-sub :app-active-since :app-active-since)
 (reg-root-key-sub :connectivity/ui-status-properties :connectivity/ui-status-properties)
 (reg-root-key-sub :logged-in-since :logged-in-since)
+(reg-root-key-sub :link-previews-whitelist :link-previews-whitelist)
 
 ;;NOTE this one is not related to ethereum network
 ;; it is about cellular network/ wifi network
@@ -2544,14 +2545,6 @@
    (not-any? :error (vals manage))))
 
 ;; LINK PREVIEW ========================================================================================================
-
-(re-frame/reg-sub
- :link-preview/whitelist
- :<- [:multiaccount]
- (fn [multiaccount]
-   (filter (fn [{:keys [address]}]
-             (config/link-preview-enabled-site? address))
-           (get multiaccount :link-previews-whitelist))))
 
 (re-frame/reg-sub
  :link-preview/cache

--- a/src/status_im/ui/screens/chat/message/link_preview.cljs
+++ b/src/status_im/ui/screens/chat/message/link_preview.cljs
@@ -91,7 +91,7 @@
 (defview link-preview-wrapper [links outgoing timeline]
   (letsubs
     [ask-user? [:link-preview/link-preview-request-enabled]
-     whitelist [:link-preview/whitelist]
+     whitelist [:link-previews-whitelist]
      enabled-sites   [:link-preview/enabled-sites]]
     (when links
       (let [link-info (previewable-link links whitelist enabled-sites)

--- a/src/status_im/ui/screens/link_previews_settings/views.cljs
+++ b/src/status_im/ui/screens/link_previews_settings/views.cljs
@@ -22,7 +22,7 @@
                    [::link-preview/enable title ((complement boolean) enabled?)])})))
 
 (views/defview link-previews-settings []
-  (views/letsubs [link-previews-whitelist [:link-preview/whitelist]
+  (views/letsubs [link-previews-whitelist [:link-previews-whitelist]
                   link-previews-enabled-sites [:link-preview/enabled-sites]]
     (let [all-enabled (= (count link-previews-whitelist) (count link-previews-enabled-sites))]
       [react/view {:flex 1}


### PR DESCRIPTION

fixes #11461

### Summary
On app start `status-react` retrieves links whitelist form status-go and saves it locally in :link-previews-whitelist. But saving it under :multiaccount wasn't the best idea because that part of local memory always saves back to status-go as multiaccount setting. And since this is not valid key for settings, error happens.

Implementation changed to store :link-previews-whitelist not under :multiaccount

#### Platforms
- Android
- iOS

#### Areas that maybe impacted
links unfurling

### Steps to test
- Open Status
- Login into any account
- make sure there is no ` settings_saveSetting` error in logs

status: ready
