### PR TITLE
❌ Disable Medium.com unfurling

### DIFF
--- a/src/status_im/utils/config.cljs
+++ b/src/status_im/utils/config.cljs
@@ -146,7 +146,6 @@
   #{"youtube.com"
     "youtu.be"
     "our.status.im"
-    "medium.com"
     "github.com"
     "giphy.com"
     "gph.is"


### PR DESCRIPTION
### Summary
Temporary measure to disable Medium.com, because their links are not resolving correctly:
- Issue: https://github.com/status-im/status-go/issues/2192
- Companion Go PR: https://github.com/status-im/status-go/pull/2193


#### Platforms
- Android
- iOS


### Steps to test
- Send Medium Link in chat, it should not unfurl
- There should be no option to allow Medium.com in settings

status: ready