### PR TITLE
Remove self-mentions

### DIFF
--- a/src/status_im/subs.cljs
+++ b/src/status_im/subs.cljs
@@ -1167,7 +1167,7 @@
                                    {:alias      name
                                     :name       (or preferred-name name)
                                     :public-key public-key})))
-            blocked))))
+            [blocked public-key]))))
 
 (re-frame/reg-sub
  :chat/mention-suggestions


### PR DESCRIPTION
fixes #11881 

### Summary

Remove self mentions from chats

#### Platforms

- Android
- iOS

##### Functional

- 1-1 chats
- public chats
- group chats

### Steps to test

- Open Status
- Open any chat
- Type @ to mention
- Verify that cannot self-mention

status: ready