### PR TITLE
Load message on-component-did-mount

### DIFF
--- a/src/status_im/ui/screens/home/views.cljs
+++ b/src/status_im/ui/screens/home/views.cljs
@@ -213,7 +213,6 @@
                   :style {:margin-left 10}
                   :accessibility-label "notifications-button"
                   :on-press #(do
-                               (re-frame/dispatch [:get-activity-center-notifications])
                                (re-frame/dispatch [:mark-all-activity-center-notifications-as-read])
                                (re-frame/dispatch [:navigate-to :notifications-center]))
                   :theme    :icon}

--- a/src/status_im/ui/screens/notifications_center/views.cljs
+++ b/src/status_im/ui/screens/notifications_center/views.cljs
@@ -74,27 +74,31 @@
   (reset-state))
 
 (defn center []
-  (let [{:keys [notifications]} @(re-frame/subscribe [:activity.center/notifications])]
-    [react/keyboard-avoiding-view {:style {:flex 1}}
-     [topbar/topbar {:navigation {:on-press #(do
-                                               (reset-state)
-                                               (re-frame/dispatch [:close-notifications-center])
-                                               (re-frame/dispatch [:navigate-back]))}
-                     :title      (i18n/label :t/activity)}]
-     [filter-item]
-     [list/flat-list
-      {:key-fn                       #(or (:chat-id %) (:id %))
-       :on-end-reached               #(re-frame/dispatch [:get-activity-center-notifications])
-       :keyboard-should-persist-taps :always
-       :data                         notifications
-       :render-fn                    render-fn}]
-     (when (or @select-all (> (count @selected-items) 0))
-       [toolbar/toolbar
-        {:show-border? true
-         :left         [quo/button {:type     :secondary
-                                    :theme    :negative
-                                    :on-press #(toolbar-action false)}
-                        (i18n/label :t/reject-and-delete)]
-         :right        [quo/button {:type     :secondary
-                                    :on-press #(toolbar-action true)}
-                        (i18n/label :t/accept-and-add)]}])]))
+  (reagent/create-class
+   {:display-name "activity-center"
+    :component-did-mount #(re-frame/dispatch [:get-activity-center-notifications])
+    :reagent-render (fn []
+                      (let [{:keys [notifications]} @(re-frame/subscribe [:activity.center/notifications])]
+                        [react/keyboard-avoiding-view {:style {:flex 1}}
+                         [topbar/topbar {:navigation {:on-press #(do
+                                                                   (reset-state)
+                                                                   (re-frame/dispatch [:close-notifications-center])
+                                                                   (re-frame/dispatch [:navigate-back]))}
+                                         :title      (i18n/label :t/activity)}]
+                         [filter-item]
+                         [list/flat-list
+                          {:key-fn                       #(or (:chat-id %) (:id %))
+                           :on-end-reached               #(re-frame/dispatch [:load-more-activity-center-notifications])
+                           :keyboard-should-persist-taps :always
+                           :data                         notifications
+                           :render-fn                    render-fn}]
+                         (when (or @select-all (> (count @selected-items) 0))
+                           [toolbar/toolbar
+                            {:show-border? true
+                             :left         [quo/button {:type     :secondary
+                                                        :theme    :negative
+                                                        :on-press #(toolbar-action false)}
+                                            (i18n/label :t/reject-and-delete)]
+                             :right        [quo/button {:type     :secondary
+                                                        :on-press #(toolbar-action true)}
+                                            (i18n/label :t/accept-and-add)]}])]))}))


### PR DESCRIPTION
Fixes: https://github.com/status-im/status-react/issues/12006

I have changed the behavior of loading notifications:

Before it would always use the same function and check for `cursor !=
""`.
This worked on most cases, but sometimes the user would jump back to the
home view without doing any clean up, so cursor would be `""` and it
would not load any notification anymore.

Now the two functions are split in initial load, and load-more.

Initial load is called on component-did-mount so we don't have to worry
about where the user is coming from. We also avoid multiple firing of
the events by checking `loading?`, so it does not result in duplicated
notifications.

