### PR TITLE
Include a 'My Profile' button in the Start New Chat dialogue

### DIFF
--- a/translations/en.json
+++ b/translations/en.json
@@ -1515,5 +1515,6 @@
     "not-found": "Not found",
     "activity": "Activity",
     "reject-and-delete": "Reject and delete",
-    "accept-and-add": "Accept and add"
+    "accept-and-add": "Accept and add",
+    "my-profile": "My profile"
 }


### PR DESCRIPTION
fixes #11990 

### Summary

Include a 'My Profile' button in the Start New Chat dialogue

#### Demo

##### iOS

![my-profile-demo-ios](https://user-images.githubusercontent.com/18485527/116147271-e2d78a80-a6b5-11eb-8096-d8418c2c90db.gif)

##### Android

![my-profile-demo-android](https://user-images.githubusercontent.com/18485527/116147292-ea972f00-a6b5-11eb-865d-eb23e88663cd.gif)

#### Platforms

- Android
- iOS

#### Areas that maybe impacted

##### Functional

- 1-1 chats

### Steps to test

- Open Status
- Go to Chat tab
- Tap on + button
- Tap on "Start new chat"
- Interact with "My Profile" button

status: ready