### PR TITLE
Resolve username to ENS after 1-1 chat opened by ENS search

### DIFF
--- a/src/status_im/ui/screens/add_new/new_chat/views.cljs
+++ b/src/status_im/ui/screens/add_new/new_chat/views.cljs
@@ -191,7 +191,9 @@
                :subtitle (if ens-name (gfycat/generate-gfy public-key) (utils/get-shortened-address public-key))
                :icon     [chat-icon/contact-icon-contacts-tab
                           (identicon/identicon public-key)]
-               :on-press #(re-frame/dispatch [:chat.ui/start-chat public-key])}
+               :on-press #(do
+                            (debounce/dispatch-and-chill [:contact.ui/contact-code-submitted false] 3000)
+                            (re-frame/dispatch [:search/home-filter-changed nil]))}
               (when ens-name {:subtitle-secondary public-key}))]
             [quo/text {:style {:margin-horizontal 16}
                        :size  :base


### PR DESCRIPTION
fixes #12027 

### Summary

We need to resolve username to ENS after 1-1 chat opened by ENS search. This PR approach is to get the ens name from `contacts/new-identity` db key if exists, and include it in `contacts/contact-two-names-by-identity` returning contact. Also include ens-name as default nickname if adding to contacts from the chat.

#### Platforms

- Android
- iOS

#### Areas that maybe impacted

##### Functional

- 1-1 chats

### Steps to test

- Open Status
- Tap on +
- Start new chat
- Search user by ENS
- Start chat with ENS user

status: ready
