### PR TITLE
ci: make e2e stage depends on publish param

### DIFF
--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -97,7 +97,7 @@ pipeline {
       } }
     }
     stage('Run e2e') {
-      when { expression { btype == 'nightly' } }
+      when { expression { btype == 'nightly' && params.PUBLISH } }
       steps { script {
         e2eApk = utils.getEnv(apke2e, 'SAUCE_URL')
         build(


### PR DESCRIPTION
Changing behavior of triggering `end-to-end-tests/job/status-app-nightly/` - it will be triggered only when PUBLISH parameter is enabled (by default only for `nightly`, but not for `manual` job)