### PR TITLE
Edit basic community info

### DIFF
--- a/src/status_im/ethereum/json_rpc.cljs
+++ b/src/status_im/ethereum/json_rpc.cljs
@@ -128,6 +128,7 @@
    "multiaccounts_storeIdentityImage" {}
    "multiaccounts_deleteIdentityImage" {}
    "wakuext_createCommunity" {}
+   "wakuext_editCommunity" {}
    "wakuext_createCommunityChat" {}
    "wakuext_inviteUsersToCommunity" {}
    "wakuext_shareCommunity" {}

--- a/src/status_im/ui/screens/communities/profile.cljs
+++ b/src/status_im/ui/screens/communities/profile.cljs
@@ -67,8 +67,7 @@
                          :icon    :main-icons/notification}])
        (when (or show-members-count? notifications (and admin roles))
          [quo/separator {:style {:margin-vertical 8}}])
-       ;; Disable as not implemented yet
-       (when false
+       (when admin
          [quo/list-item {:theme    :accent
                          :icon     :main-icons/edit
                          :title    (i18n/label :t/edit-community)

--- a/translations/en.json
+++ b/translations/en.json
@@ -191,6 +191,7 @@
     "community-image-take": "Take a photo",
     "community-image-pick": "Pick an image",
     "community-image-delete": "",
+    "community-image-remove": "Remove",
     "community-color": "Community colour",
     "community-color-placeholder": "Pick a colour",
     "membership-button": "Membership requirement",


### PR DESCRIPTION
fixes #12018

### Summary

Editing community: name, description, permissions, thumbnail image

![Screenshot 2021-05-17 at 14 29 01](https://user-images.githubusercontent.com/5786310/118482417-60267600-b71d-11eb-915b-1fe9b7cd9bf8.png)


### Review notes
corresponding [status-go pr](https://github.com/status-im/status-go/pull/2229)

#### Platforms
- Android
- iOS

### Steps to test
- Open Status
- Open community profile
- Make sure that `Edit Community` option is available if you are an admin
- change something
- make sure community changes are in place


status: ready
