### PR TITLE
Tracing of nested fx handlers on :trace logging level

### DIFF
--- a/src/status_im/utils/fx.cljs
+++ b/src/status_im/utils/fx.cljs
@@ -2,7 +2,7 @@
   (:require-macros status-im.utils.fx)
   (:require [status-im.ethereum.json-rpc :as json-rpc]
             [taoensso.timbre :as log]
-            status-im.utils.handlers)
+            [status-im.utils.handlers :as handlers])
   (:refer-clojure :exclude [merge reduce]))
 
 (defn- update-db [cofx fx]
@@ -47,6 +47,8 @@
   :data-source/tx and effects are handled specially and their results
   (list of transactions) are compacted to one transactions list (for each effect). "
   [{:keys [db] :as cofx} & args]
+  (when js/goog.DEBUG
+    (swap! handlers/handler-nesting-level inc))
   (let [[first-arg & rest-args] args
         initial-fxs? (map? first-arg)
         fx-fns (if initial-fxs? rest-args args)]

--- a/src/status_im/utils/handlers.cljs
+++ b/src/status_im/utils/handlers.cljs
@@ -36,12 +36,16 @@
   (let [[first _] (get-coeffect ctx :event)]
     first))
 
+(def handler-nesting-level (atom 0))
+
 (def debug-handlers-names
   "Interceptor which logs debug information to js/console for each event."
   (->interceptor
    :id     :debug-handlers-names
    :before (fn debug-handlers-names-before
              [context]
+             (when js/goog.DEBUG
+               (reset! handler-nesting-level 0))
              (log/debug "Handling re-frame event: " (pretty-print-event context))
              context)))
 


### PR DESCRIPTION
Example:
```
INFO [status-im.transport.core:63] - Messenger started
│  ├─ fetch-node-info-fx status-im.transport.core
│  ├─ init status-im.pairing.core
│  ├─ start-fx status-im.utils.publisher
│  ├─ initialize-mailserver status-im.mailserver.core
│  │  ├─ set-current-mailserver status-im.mailserver.core
│  │  ├─ get-mailservers-latency status-im.mailserver.core
│  │  ├─ process-next-messages-request status-im.mailserver.core
│  │  ├─ process-stored-event status-im.utils.universal-links.core
```

```
DEBUG [status-im.utils.handlers:49] - Handling re-frame event:  :status-im.ethereum.transactions.core/new-transfers
├─ new-transfers status-im.ethereum.transactions.core
│  ├─ handle-new-transfer status-im.ethereum.transactions.core
DEBUG [status-im.ethereum.transactions.core:233] - [transfers] new-transfers address 0xda5df240d5264ed5270dfb4a3b03
│  │  ├─ tx-fetching-ended status-im.ethereum.transactions.core
│  │  ├─ set-max-block-with-transfers status-im.wallet.core
│  │  ├─ set-max-block status-im.wallet.core
DEBUG [status-im.wallet.core:873] - set-max-block address 0xda5Df240d5264ED5270DFb4A3b03438439e5a417 block 0
│  │  ├─ set-zero-balances status-im.wallet.core
│  │  │  ├─ update-balance status-im.wallet.core
│  │  │  ├─ update-tokens-balances status-im.wallet.core
│  │  │  ├─ tx-history-end-reached status-im.ethereum.transactions.core
│  │  │  ├─ stop-fetching-on-empty-tx-history status-im.wallet.core
│  │  │  │  ├─ clear-timeouts status-im.wallet.core
INFO [status-im.wallet.core:754] - [wallet] clear-timeouts
│  │  │  │  ├─ check-ens-transactions status-im.ethereum.transactions.core
```
status: ready