### PR TITLE
fixed various styling issues

### DIFF
--- a/src/quo/components/list/item.cljs
+++ b/src/quo/components/list/item.cljs
@@ -157,7 +157,7 @@
    [icon-column props]
    [title-column props]])
 
-(defn right-side [{:keys [chevron active accessory accessory-text animated-accessory?]}]
+(defn right-side [{:keys [chevron active disabled accessory accessory-text animated-accessory?]}]
   (when (or chevron accessory)
     [rn/view {:style {:align-items     :center
                       :justify-content :flex-end
@@ -171,12 +171,12 @@
                       :flex-basis      80}}
      [rn/view {:style (:tiny spacing/padding-horizontal)}
       (case accessory
-        :radio    [controls/radio {:value active}]
+        :radio    [controls/radio {:value active :disabled disabled}]
         :checkbox [(if animated-accessory?
                      controls/animated-checkbox
                      controls/checkbox)
-                   {:value active}]
-        :switch   [controls/switch {:value active}]
+                   {:value active :disabled disabled}]
+        :switch   [controls/switch {:value active :disabled disabled}]
         :text     [text/text {:color           :secondary
                               :ellipsize-mode  :middle
                               :number-of-lines 1}
@@ -250,6 +250,7 @@
                    :right-side-present?       (or accessory chevron)}]
        [right-side {:chevron             chevron
                     :active              active
+                    :disabled            disabled
                     :on-press            on-press
                     :accessory-text      accessory-text
                     :animated-accessory? animated-accessory?

--- a/src/status_im/ui/screens/intro/styles.cljs
+++ b/src/status_im/ui/screens/intro/styles.cljs
@@ -33,6 +33,7 @@
 
 (def wizard-title
   {:margin-bottom 16
+   :typography    :header
    :text-align    :center})
 
 (def wizard-text

--- a/src/status_im/ui/screens/keycard/frozen_card/view.cljs
+++ b/src/status_im/ui/screens/keycard/frozen_card/view.cljs
@@ -43,6 +43,6 @@
     (when show-dismiss-button?
       [react/view {:margin-top 24}
        [quo/button
-        {:on-press    #(re-frame/dispatch [::login/frozen-keycard-popover-dismissed])
-         :background? false}
+        {:on-press #(re-frame/dispatch [::login/frozen-keycard-popover-dismissed])
+         :type     :secondary}
         (i18n/label :t/dismiss)]])]])

--- a/src/status_im/ui/screens/keycard/views.cljs
+++ b/src/status_im/ui/screens/keycard/views.cljs
@@ -267,10 +267,10 @@
       [react/view styles/container
        [topbar/topbar
         (merge
-         {:right-accessories [(when-not hide-login-actions?
-                                {:icon     :main-icons/more
-                                 :on-press #(re-frame/dispatch [:keycard.login.pin.ui/more-icon-pressed])})]
-          :title             (cond
+         (when-not hide-login-actions?
+           {:right-accessories [{:icon     :main-icons/more
+                                 :on-press #(re-frame/dispatch [:keycard.login.pin.ui/more-icon-pressed])}]})
+         {:title             (cond
                                (#{:reset :reset-confirmation} enter-step)
                                (i18n/label :t/keycard-reset-passcode)
 
@@ -351,7 +351,9 @@
             :save-password-checkbox? (not (contains?
                                            #{:reset :reset-confirmation :puk}
                                            enter-step))}])
-        (when-not hide-login-actions?
+        (if hide-login-actions?
+          [react/view {:flex-direction :row
+                       :height         32}]
           [toolbar/toolbar
            {:center [quo/button
                      {:on-press #(re-frame/dispatch [:multiaccounts.recover.ui/recover-multiaccount-button-pressed])


### PR DESCRIPTION
Fixes #10991.
Fixes #11839.
Fixes #12106.

Fixing #11839 involved a small change in Quo's ``list-item``. The change propagates the ``:disabled`` attribute to the right accessory (if it is one of ``:checkbox``, ``:radio``, ``:switch``). I don't think this should cause problems (seems a reasonable behaviour to me) but since the components are used everywhere some testing is needed.