### PR TITLE
[Fixes: #12140] Don't show gap after 30 days and allow user to set ms

### DIFF
--- a/src/status_im/chat/db.cljs
+++ b/src/status_im/chat/db.cljs
@@ -61,7 +61,7 @@
   "collapse-gaps will take an array of messages and collapse any gap next to
   each other in a single gap.
   It will also append one last gap if the last message is a non-gap"
-  [messages chat-id synced-from chat-type joined loading-messages?]
+  [messages chat-id synced-from now chat-type joined loading-messages?]
   (let [messages-with-gaps (reduce
                             (fn [acc {:keys [gap-parameters message-id] :as message}]
                               (let [last-element (peek acc)]
@@ -85,6 +85,8 @@
             (nil? synced-from) ; it's still syncing
             (= constants/timeline-chat-type chat-type) ; it's a timeline chat
             (= constants/profile-chat-type chat-type) ; it's a profile chat
+            (and (not (nil? synced-from)) ; it's not more than a month
+                 (<= synced-from (- (quot now 1000) constants/one-month)))
             (and (= constants/private-group-chat-type chat-type) ; it's a private group chat
                  (or (not (pos? joined)) ; we haven't joined
                      (>= (quot joined 1000) synced-from))) ; the history goes before we joined

--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -140,3 +140,8 @@
 (def ^:const status-community-id "0x039b2da47552aa117a96ea8f1d4d108ba66637c7517a3c94a57b99dbb8a002eda2")
 
 (def ^:const timeline-chat-id "@timeline70bd746ddcc12beb96b2c9d572d0784ab137ffc774f5383e50585a932080b57cca0484b259e61cecbaa33a4c98a300a")
+
+(def ^:const one-day (* 60 60 24))
+(def ^:const three-days (* one-day 3))
+(def ^:const one-week (* one-day 7))
+(def ^:const one-month (* one-day 31))

--- a/src/status_im/multiaccounts/core.cljs
+++ b/src/status_im/multiaccounts/core.cljs
@@ -130,6 +130,14 @@
    :webview-allow-permission-requests? (boolean enabled?)
    {}))
 
+(fx/defn switch-default-sync-period
+  {:events [:multiaccounts.ui/default-sync-period-switched]}
+  [cofx value]
+  (multiaccounts.update/multiaccount-update
+   cofx
+   :default-sync-period value
+   {}))
+
 (fx/defn switch-preview-privacy-mode-flag
   [{:keys [db]}]
   (let [private? (get-in db [:multiaccount :preview-privacy?])]

--- a/src/status_im/subs.cljs
+++ b/src/status_im/subs.cljs
@@ -975,7 +975,7 @@
        (-> message-list-seq
            (chat.db/add-datemarks)
            (hydrate-messages messages)
-           (chat.db/collapse-gaps chat-id synced-from chat-type joined loading-messages?))))))
+           (chat.db/collapse-gaps chat-id synced-from (datetime/timestamp) chat-type joined loading-messages?))))))
 
 ;;we want to keep data unchanged so react doesn't change component when we leave screen
 (def memo-chat-messages-stream (atom nil))

--- a/src/status_im/ui/screens/default_sync_period_settings/view.cljs
+++ b/src/status_im/ui/screens/default_sync_period_settings/view.cljs
@@ -1,0 +1,30 @@
+(ns status-im.ui.screens.default-sync-period-settings.view
+  (:require-macros [status-im.utils.views :as views])
+  (:require [status-im.ui.components.react :as react]
+            [status-im.i18n.i18n :as i18n]
+            [status-im.constants :as constants]
+            [quo.core :as quo]
+            [re-frame.core :as re-frame]
+            [status-im.ui.components.topbar :as topbar]))
+
+(def titles {constants/one-day (i18n/label :t/one-day)
+             constants/three-days (i18n/label :t/three-days)
+             constants/one-week (i18n/label :t/one-week)
+             constants/one-month (i18n/label :t/one-month)})
+
+(defn radio-item [id value]
+  [quo/list-item
+   {:active    (= value id)
+    :accessory :radio
+    :title     (get titles id)
+    :on-press  #(re-frame/dispatch [:multiaccounts.ui/default-sync-period-switched id])}])
+
+(views/defview default-sync-period-settings []
+  (views/letsubs [{:keys [default-sync-period]} [:multiaccount]]
+    [react/view {:flex 1}
+     [topbar/topbar {:title (i18n/label :t/default-sync-period)}]
+     [react/view {:margin-top 8}
+      [radio-item constants/one-day default-sync-period]
+      [radio-item constants/three-days default-sync-period]
+      [radio-item constants/one-week default-sync-period]
+      [radio-item constants/one-month default-sync-period]]]))

--- a/src/status_im/ui/screens/routing/profile_stack.cljs
+++ b/src/status_im/ui/screens/routing/profile_stack.cljs
@@ -25,6 +25,9 @@
             [status-im.ui.screens.mobile-network-settings.view
              :as
              mobile-network-settings]
+            [status-im.ui.screens.default-sync-period-settings.view
+             :as
+             default-sync-period-settings]
             [status-im.ui.screens.network.edit-network.views :as edit-network]
             [status-im.ui.screens.network.views :as network]
             [status-im.ui.screens.network.network-details.views :as network-details]
@@ -121,6 +124,8 @@
      :component fleet-settings/fleet-settings}
     {:name      :mobile-network-settings
      :component mobile-network-settings/mobile-network-settings}
+    {:name      :default-sync-period-settings
+     :component default-sync-period-settings/default-sync-period-settings}
     {:name      :backup-seed
      :component profile.seed/backup-seed}
     {:name       :delete-profile

--- a/src/status_im/ui/screens/sync_settings/views.cljs
+++ b/src/status_im/ui/screens/sync_settings/views.cljs
@@ -3,12 +3,14 @@
   (:require [re-frame.core :as re-frame]
             [quo.core :as quo]
             [status-im.i18n.i18n :as i18n]
+            [status-im.constants :as constants]
             [status-im.ui.components.colors :as colors]
             [status-im.ui.components.react :as react]
             [status-im.ui.components.topbar :as topbar]))
 
 (views/defview sync-settings []
   (views/letsubs [{:keys [syncing-on-mobile-network?
+                          default-sync-period
                           use-mailservers?]}          [:multiaccount]
                   current-mailserver-name             [:mailserver/current-name]]
     [react/view {:style {:flex 1 :background-color colors/white}}
@@ -25,6 +27,21 @@
                       :accessory-text      (if syncing-on-mobile-network?
                                              (i18n/label :t/mobile-network-use-mobile)
                                              (i18n/label :t/mobile-network-use-wifi))}]
+      [quo/list-item {:size                :small
+                      :title               (i18n/label :t/default-sync-period)
+                      :accessibility-label :default-sync-period-button
+                      :on-press            #(re-frame/dispatch [:navigate-to :default-sync-period-settings])
+                      :chevron             true
+                      :accessory           :text
+                      :accessory-text      (cond
+                                             (= default-sync-period constants/one-day)
+                                             (i18n/label :t/one-day)
+                                             (= default-sync-period constants/three-days)
+                                             (i18n/label :t/three-days)
+                                             (= default-sync-period constants/one-week)
+                                             (i18n/label :t/one-week)
+                                             (= default-sync-period constants/one-month)
+                                             (i18n/label :t/one-month))}]
       [quo/list-item {:size                :small
                       :accessibility-label :offline-messages-settings-button
                       :title               (i18n/label :t/history-nodes)

--- a/translations/en.json
+++ b/translations/en.json
@@ -1527,6 +1527,11 @@
     "activity": "Activity",
     "reject-and-delete": "Reject and delete",
     "accept-and-add": "Accept and add",
+    "one-day": "One day",
+    "three-days": "Three days",
+    "one-week": "One week",
+    "one-month": "One month",
     "my-profile": "My profile",
+    "default-sync-period": "Sync history for",
     "bip39-password-placeholder": "BIP39 password"
 }


### PR DESCRIPTION
This commit adds a setting in sync section so that user can select the
amount of days the can sync.

