### PR TITLE
Wakuv2

### DIFF
--- a/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusModule.java
+++ b/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusModule.java
@@ -1258,6 +1258,27 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
         StatusThreadPoolExecutor.getInstance().execute(r);
     }
 
+    @ReactMethod
+    public void getNodeConfig(final Callback callback) {
+        Log.d(TAG, "getNodeConfig");
+        if (!checkAvailability()) {
+            callback.invoke(false);
+            return;
+        }
+
+        Runnable r = new Runnable() {
+            @Override
+            public void run() {
+                String result = Statusgo.getNodeConfig();
+
+                callback.invoke(result);
+            }
+        };
+
+        StatusThreadPoolExecutor.getInstance().execute(r);
+    }
+
+
 
     @ReactMethod
     public void chaosModeUpdate(final boolean on, final Callback callback) {

--- a/modules/react-native-status/ios/RCTStatus/RCTStatus.m
+++ b/modules/react-native-status/ios/RCTStatus/RCTStatus.m
@@ -682,6 +682,18 @@ RCT_EXPORT_METHOD(extractGroupMembershipSignatures:(NSString *)content
 }
 
 ////////////////////////////////////////////////////////////////////
+#pragma mark - GetNodeConfig
+//////////////////////////////////////////////////////////////////// getNodeConfig
+RCT_EXPORT_METHOD(getNodeConfig:(RCTResponseSenderBlock)callback) {
+#if DEBUG
+    NSLog(@"GetNodeConfig() method called");
+#endif
+    NSString *result = StatusgoGetNodeConfig();
+    callback(@[result]);
+}
+
+
+////////////////////////////////////////////////////////////////////
 #pragma mark - only android methods
 ////////////////////////////////////////////////////////////////////
 RCT_EXPORT_METHOD(setAdjustResize) {

--- a/resources/config/fleets.json
+++ b/resources/config/fleets.json
@@ -72,9 +72,9 @@
                 "boot-01.gc-us-central1-a.eth.staging": "/ip4/35.238.97.234/tcp/30703/ethv4/16Uiu2HAm6G9sDMkrB4Xa5EH3Zx2dysCxFgBTSRzghic3Z9tRFRNE"
             },
             "whisper": {
-                "node-01.ac-cn-hongkong-c.eth.staging": "enode://00395686f5954662a3796e170b9e87bbaf68a050d57e9987b78a2292502dae44aae2b8803280a017ec9af9be0b3121db9d6b3693ab3a0451a866bcbedd58fdac@47.52.226.137:443",
+                "node-01.ac-cn-hongkong-c.eth.staging": "enode://088cf5a93c576fae52f6f075178467b8ff98bacf72f59e88efb16dfba5b30f80a4db78f8e3cb3d87f2f6521746ef4a8768465ef2896c6af24fd77a425e95b6dd@47.52.226.137:443",
                 "node-01.do-ams3.eth.staging": "enode://914c0b30f27bab30c1dfd31dad7652a46fda9370542aee1b062498b1345ee0913614b8b9e3e84622e84a7203c5858ae1d9819f63aece13ee668e4f6668063989@167.99.19.148:443",
-                "node-01.gc-us-central1-a.eth.staging": "enode://2d897c6e846949f9dcf10279f00e9b8325c18fe7fa52d658520ad7be9607c83008b42b06aefd97cfe1fdab571f33a2a9383ff97c5909ed51f63300834913237e@35.192.0.86:443"
+                "node-01.gc-us-central1-a.eth.staging": "enode://d3878441652f010326889f28360e69f2d09d06540f934fada0e17b374ce5319de64279aba3c44a5bf807d9967c6d705b3b4c6b03fa70763240e2ee6af01a539e@35.192.0.86:443"
             }
         },
         "eth.test": {
@@ -98,10 +98,34 @@
                 "node-01.do-ams3.eth.test": "enode://1d193635e015918fb85bbaf774863d12f65d70c6977506187ef04420d74ec06c9e8f0dcb57ea042f85df87433dab17a1260ed8dde1bdf9d6d5d2de4b7bf8e993@206.189.243.163:443",
                 "node-01.gc-us-central1-a.eth.test": "enode://f593a27731bc0f8eb088e2d39222c2d59dfb9bf0b3950d7a828d51e8ab9e08fffbd9916a82fd993c1a080c57c2bd70ed6c36f489a969de697aff93088dbee1a9@35.194.31.108:443"
             }
+        },
+        "wakuv2.prod": {
+            "waku": {
+                "node-01.ac-cn-hongkong-c.wakuv2.prod": "/ip4/8.210.222.231/tcp/30303/p2p/16Uiu2HAm4v86W3bmT1BiH6oSPzcsSr24iDQpSN5Qa992BCjjwgrD",
+                "node-01.do-ams3.wakuv2.prod": "/ip4/188.166.135.145/tcp/30303/p2p/16Uiu2HAmL5okWopX7NqZWBUKVqW8iUxCEmd5GMHLVPwCgzYzQv3e",
+                "node-01.gc-us-central1-a.wakuv2.prod": "/ip4/34.121.100.108/tcp/30303/p2p/16Uiu2HAmVkKntsECaYfefR1V2yCR79CegLATuTPE6B9TxgxBiiiA"
+            },
+            "waku-websocket": {
+                "node-01.ac-cn-hongkong-c.wakuv2.prod": "/dns4/node-01.ac-cn-hongkong-c.wakuv2.prod.statusim.net/tcp/443/wss/p2p/16Uiu2HAm4v86W3bmT1BiH6oSPzcsSr24iDQpSN5Qa992BCjjwgrD",
+                "node-01.do-ams3.wakuv2.prod": "/dns4/node-01.do-ams3.wakuv2.prod.statusim.net/tcp/443/wss/p2p/16Uiu2HAmL5okWopX7NqZWBUKVqW8iUxCEmd5GMHLVPwCgzYzQv3e",
+                "node-01.gc-us-central1-a.wakuv2.prod": "/dns4/node-01.gc-us-central1-a.wakuv2.prod.statusim.net/tcp/443/wss/p2p/16Uiu2HAmVkKntsECaYfefR1V2yCR79CegLATuTPE6B9TxgxBiiiA"
+            }
+        },
+        "wakuv2.test": {
+            "waku": {
+                "node-01.ac-cn-hongkong-c.wakuv2.test": "/ip4/47.242.210.73/tcp/30303/p2p/16Uiu2HAkvWiyFsgRhuJEb9JfjYxEkoHLgnUQmr1N5mKWnYjxYRVm",
+                "node-01.do-ams3.wakuv2.test": "/ip4/134.209.139.210/tcp/30303/p2p/16Uiu2HAmPLe7Mzm8TsYUubgCAW1aJoeFScxrLj8ppHFivPo97bUZ",
+                "node-01.gc-us-central1-a.wakuv2.test": "/ip4/104.154.239.128/tcp/30303/p2p/16Uiu2HAmJb2e28qLXxT5kZxVUUoJt72EMzNGXB47Rxx5hw3q4YjS"
+            },
+            "waku-websocket": {
+                "node-01.ac-cn-hongkong-c.wakuv2.test": "/dns4/node-01.ac-cn-hongkong-c.wakuv2.test.statusim.net/tcp/443/wss/p2p/16Uiu2HAkvWiyFsgRhuJEb9JfjYxEkoHLgnUQmr1N5mKWnYjxYRVm",
+                "node-01.do-ams3.wakuv2.test": "/dns4/node-01.do-ams3.wakuv2.test.statusim.net/tcp/443/wss/p2p/16Uiu2HAmPLe7Mzm8TsYUubgCAW1aJoeFScxrLj8ppHFivPo97bUZ",
+                "node-01.gc-us-central1-a.wakuv2.test": "/dns4/node-01.gc-us-central1-a.wakuv2.test.statusim.net/tcp/443/wss/p2p/16Uiu2HAmJb2e28qLXxT5kZxVUUoJt72EMzNGXB47Rxx5hw3q4YjS"
+            }
         }
     },
     "meta": {
-        "hostname": "bots-01.do-ams3.eth.staging",
-        "timestamp": "2020-02-17T16:44:07.570597"
+        "hostname": "node-01.do-ams3.proxy.misc",
+        "timestamp": "2021-06-07T00:00:09.836740"
     }
 }

--- a/src/status_im/multiaccounts/login/core.cljs
+++ b/src/status_im/multiaccounts/login/core.cljs
@@ -252,6 +252,16 @@
   [cofx]
   {::initialize-communities-enabled nil})
 
+(fx/defn get-node-config-callback
+  {:events [::get-node-config-callback]}
+  [{:keys [db] :as cofx} node-config]
+  {:db (assoc-in db [:multiaccount :wakuv2-config]
+                 (get (types/json->clj node-config) :WakuV2Config))})
+
+(fx/defn get-node-config
+  [_]
+  (status/get-node-config #(re-frame/dispatch [::get-node-config-callback %])))
+
 (fx/defn get-settings-callback
   {:events [::get-settings-callback]}
   [{:keys [db] :as cofx} settings]
@@ -279,6 +289,7 @@
               (initialize-communities-enabled)
               (check-network-version network-id)
               (chat.loading/initialize-chats)
+              (get-node-config)
               (communities/fetch)
               (contact/initialize-contacts)
               (stickers/init-stickers-packs)

--- a/src/status_im/native_module/core.cljs
+++ b/src/status_im/native_module/core.cljs
@@ -321,6 +321,10 @@
   (log/debug "[native-module] sign-group-membership")
   (.signGroupMembership ^js (status) content callback))
 
+(defn get-node-config [callback]
+  (log/debug "[native-module] get-node-config")
+  (.getNodeConfig ^js (status) callback))
+
 (defn update-mailservers
   [enodes on-result]
   (log/debug "[native-module] update-mailservers")

--- a/src/status_im/subs.cljs
+++ b/src/status_im/subs.cljs
@@ -445,8 +445,12 @@
 (re-frame/reg-sub
  :disconnected?
  :<- [:peers-count]
- (fn [peers-count]
-   (zero? peers-count)))
+ :<- [:waku/v2-flag]
+ (fn [peers-count wakuv2-flag]
+   ;; TODO Right now wakuv2 module in status-go
+   ;; does not report peer counts properly,
+   ;; so we always assume that we're connected
+   (if wakuv2-flag false (zero? peers-count))))
 
 (re-frame/reg-sub
  :offline?
@@ -633,6 +637,12 @@
  :<- [:multiaccount]
  (fn [multiaccount]
    (boolean (get multiaccount :waku-bloom-filter-mode))))
+
+(re-frame/reg-sub
+ :waku/v2-flag
+ :<- [:fleets/current-fleet]
+ (fn [fleet]
+   (string/starts-with? (name fleet) "wakuv2")))
 
 (re-frame/reg-sub
  :dapps-address

--- a/src/status_im/waku/core.cljs
+++ b/src/status_im/waku/core.cljs
@@ -13,4 +13,3 @@
              {})
             (node/prepare-new-config
              {:on-success #(re-frame/dispatch [:logout])})))
-


### PR DESCRIPTION
Add WakuV2 toggle under Advanced Settings.

Fleets were updated using `make update-fleets`.

`test` channel mobile screenshot: https://monosnap.com/file/clSlxxnCngGBVUTFinn59m5pu1xzou
`test` channel desktop screenshot: https://monosnap.com/file/0g4pfMyKL6z4hFJKOQKIAIbC5m8g68

How to test:

1. Profile->Advanced Settings now includes a WakuV2 toggle. This will switch to a wakuv2 fleet (test or prod, depending on whether eth.prod or eth.test fleet is selected)
2. Upon clicking the toggle, app will logout. Then upon relogin app should be connected to wakuv2 fleet.
3. One can test sending messages e.g. in some public channel between 2 mobile apps running this PR, or between mobile and desktop build from https://github.com/status-im/status-desktop/pull/2654. For desktop, in order to connect to wakuv2 fleet, one has to pick it in Advanced Settings. The UI is slightly different from mobile - there is no separate toggle, fleet selection does the trick.

For testing:
- messaging in public, 1-1 chats only
