### PR TITLE
remove cancel warning on Keycard onboarding

### DIFF
--- a/src/status_im/keycard/onboarding.cljs
+++ b/src/status_im/keycard/onboarding.cljs
@@ -315,19 +315,9 @@
   [{:keys [db] :as cofx}]
   {:db (update db :keycard dissoc :factory-reset-card?)})
 
-(fx/defn cancel-confirm
-  {:events [::cancel-confirm]}
+(fx/defn cancel-pressed
+  {:events [::cancel-pressed]}
   [cofx]
   (fx/merge cofx
             (navigation/navigate-back)
             (common/cancel-sheet-confirm)))
-
-(fx/defn cancel-pressed
-  {:events [::cancel-pressed]}
-  [_]
-  {:ui/show-confirmation {:title               (i18n/label :t/keycard-cancel-setup-title)
-                          :content             (i18n/label :t/keycard-cancel-setup-text)
-                          :confirm-button-text (i18n/label :t/yes)
-                          :cancel-button-text  (i18n/label :t/no)
-                          :on-accept           #(re-frame/dispatch [::cancel-confirm])
-                          :on-cancel           #()}})

--- a/src/status_im/keycard/recovery.cljs
+++ b/src/status_im/keycard/recovery.cljs
@@ -83,22 +83,12 @@
              :keycard/check-nfc-enabled nil}
             (navigation/navigate-to-cofx :keycard-onboarding-intro nil)))
 
-(fx/defn cancel-confirm
-  {:events [::cancel-confirm]}
-  [{:keys [db] :as cofx}]
+(fx/defn cancel-pressed
+  {:events [::cancel-pressed]}
+  [cofx]
   (fx/merge cofx
             (common/cancel-sheet-confirm)
             (navigation/navigate-back)))
-
-(fx/defn cancel-pressed
-  {:events [::cancel-pressed]}
-  [_]
-  {:ui/show-confirmation {:title               (i18n/label :t/keycard-cancel-setup-title)
-                          :content             (i18n/label :t/keycard-cancel-setup-text)
-                          :confirm-button-text (i18n/label :t/yes)
-                          :cancel-button-text  (i18n/label :t/no)
-                          :on-accept           #(re-frame/dispatch [::cancel-confirm])
-                          :on-cancel           #()}})
 
 (fx/defn begin-setup-pressed
   {:events [:keycard.recovery.intro.ui/begin-recovery-pressed]}

--- a/test/appium/tests/atomic/account_management/test_keycard.py
+++ b/test/appium/tests/atomic/account_management/test_keycard.py
@@ -149,9 +149,6 @@ class TestCreateAccount(SingleDeviceTestCase):
         keycard_flow.connect_card_button.click()
         keycard_flow.enter_another_pin()
         keycard_flow.cancel_button.click()
-        if not keycard_flow.element_by_translation_id("keycard-cancel-setup-title").is_element_displayed():
-            self.driver.fail('No Dangerous operation popup is shown on canceling operation from PIN code stage')
-        keycard_flow.yes_button.click()
 
         sign_in.just_fyi('Cancel from Confirm seed phrase: initialized + 1 pairing slot is used')
         keycard_flow.begin_setup_button.click()
@@ -161,15 +158,11 @@ class TestCreateAccount(SingleDeviceTestCase):
         keycard_flow.confirm_button.click()
         keycard_flow.yes_button.click()
         keycard_flow.cancel_button.click()
-        if not keycard_flow.element_by_translation_id("keycard-cancel-setup-title").is_element_displayed():
-            self.driver.fail('No Dangerous operation popup is shown on canceling operation during Backup seed phrase stage')
-        keycard_flow.yes_button.click()
         if not keycard_flow.element_by_text_part('Back up seed phrase').is_element_displayed():
             self.driver.fail('On canceling setup from Confirm seed phrase was not redirected to expected screen')
 
         sign_in.just_fyi('Cancel from Back Up seed phrase: initialized + 1 pairing slot is used')
         keycard_flow.cancel_button.click()
-        keycard_flow.yes_button.click()
         keycard_flow.begin_setup_button.click()
         keycard_flow.element_by_translation_id("back-up-seed-phrase").wait_for_element(10)
         new_seed_phrase = keycard_flow.get_seed_phrase()
@@ -214,9 +207,6 @@ class TestCreateAccount(SingleDeviceTestCase):
         keycard_flow.connect_card_button.click()
         keycard_flow.enter_another_pin()
         keycard_flow.cancel_button.click()
-        if not keycard_flow.element_by_translation_id("keycard-cancel-setup-title").is_element_displayed():
-            self.driver.fail('No Dangerous operation popup is shown on canceling operation from PIN code stage')
-        keycard_flow.yes_button.click()
 
         sign_in.just_fyi('Finish setup and relogin')
         keycard_flow.begin_setup_button.click()


### PR DESCRIPTION
Fixes #10032. This warning is not necessary anymore since you can resume the onboarding from any step and even easily reset the card if needed.