### PR TITLE
[#12297] Fix error for replies activity center while not implemented in status-react

### DIFF
--- a/src/status_im/subs.cljs
+++ b/src/status_im/subs.cljs
@@ -1753,7 +1753,11 @@
  :activity.center/notifications-grouped-by-date
  :<- [:activity.center/notifications]
  (fn [{:keys [notifications]}]
-   (group-notifications-by-date (map #(assoc % :timestamp (or (:timestamp %) (:timestamp (or (:message %) (:last-message %))))) notifications))))
+   (let [supported-notifications (filter (fn [{:keys [type]}]
+                                           (or (= constants/activity-center-notification-type-mention type)
+                                               (= constants/activity-center-notification-type-one-to-one-chat type)
+                                               (= constants/activity-center-notification-type-private-group-chat type))) notifications)]
+     (group-notifications-by-date (map #(assoc % :timestamp (or (:timestamp %) (:timestamp (or (:message %) (:last-message %))))) supported-notifications)))))
 
 ;;WALLET TRANSACTIONS ==================================================================================================
 


### PR DESCRIPTION
fixes #12297

### Summary

Temporary fix for unblock 1.15 release, while complete implementation should come with #12266. Also this will prevent this error to happen for future new type of notifications that are implemented in status-go but not in status-react.

#### Platforms

- Android
- iOS

##### Functional

- activity-center

### Steps to test

- Open Status
- Reply to message from logged user in a group from another device
- Verify Activity Center can be opened

status: ready