### PR TITLE
E2e test. Fetch tx from etherscan starting from last 5000 blocks

### DIFF
--- a/test/appium/support/api/network_api.py
+++ b/test/appium/support/api/network_api.py
@@ -16,6 +16,7 @@ class NetworkApi(object):
         self.network_url = 'http://api-%s.etherscan.io/api?' % tests.pytest_config_global['network']
         self.faucet_url = 'https://faucet-ropsten.status.im/donate'
         self.faucet_backup_address = w3.account_address
+        self.start_block_number = self.get_start_block_number()
         self.headers = {
         'User-Agent':"Mozilla\\5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit\\537.36 (KHTML, like Gecko) Chrome\\7"
                      "7.0.3865.90 Safari\\537.36", }
@@ -27,7 +28,7 @@ class NetworkApi(object):
         logging.info(text)
 
     def get_transactions(self, address: str) -> List[dict]:
-        method = self.network_url + 'module=account&action=txlist&address=0x%s&sort=desc&apikey=%s' % (address, self.api_key)
+        method = self.network_url + 'module=account&action=txlist&address=0x%s&startblock=%s&endblock=99999999&sort=desc&apikey=%s' % (address, self.start_block_number, self.api_key)
         try:
             transactions_response = requests.request('GET', url=method, headers=self.headers).json()
             if transactions_response:
@@ -39,7 +40,7 @@ class NetworkApi(object):
             pass
 
     def get_token_transactions(self, address: str) -> List[dict]:
-        method = self.network_url + 'module=account&action=tokentx&address=0x%s&sort=desc&apikey=%s' % (address, self.api_key)
+        method = self.network_url + 'module=account&action=tokentx&address=0x%s&startblock=%s&endblock=99999999&sort=desc&apikey=%s' % (address, self.start_block_number, self.api_key)
         try:
             transactions_response = requests.request('GET', url=method, headers=self.headers).json()
             if transactions_response:
@@ -60,9 +61,10 @@ class NetworkApi(object):
         self.log('Balance is %s Gwei' % balance)
         return int(balance)
 
-    def get_latest_block_number(self) -> int:
-        method = self.network_url + 'module=proxy&action=eth_blockNumber'
-        return int(requests.request('GET', url=method).json()['result'], 0)
+    def get_start_block_number(self) -> str:
+        current_block = w3.current_block_number()
+        start_from = int(current_block) - 5000
+        return str(start_from)
 
     def find_transaction_by_hash(self,transaction_hash: str):
         transaction = w3.transaction_status(transaction_hash)

--- a/test/appium/support/api/web3_api.py
+++ b/test/appium/support/api/web3_api.py
@@ -73,8 +73,10 @@ def balance_of_address(address):
     else:
         return w3.eth.getBalance(to_checksum_address(address))
 
+
 def transaction_status(hash):
     return w3.eth.getTransaction(hash)
+
 
 def to_checksumed_address(address):
     return to_checksum_address(address)
@@ -82,6 +84,10 @@ def to_checksumed_address(address):
 
 def current_gas_price():
     return str(w3.eth.gasPrice / 1000000000)
+
+
+def current_block_number():
+    return w3.eth.blockNumber
 
 
 def sign_transaction(tx_data, pk):


### PR DESCRIPTION
In order to not grab all transactions per account from ethercan when needed we fetch only those included in last 5000 blocks