### PR TITLE
PN and reactions for messages

### DIFF
--- a/src/status_im/ui/screens/chat/message/message.cljs
+++ b/src/status_im/ui/screens/chat/message/message.cljs
@@ -343,7 +343,7 @@
                                      :on-long-press on-long-press
                                      :disabled      in-popover?}
           [react/view {:style               (style/image-message style-opts)
-                       :accessibility-label :message-image}
+                       :accessibility-label :image-message}
            [react/image {:style       (dissoc style-opts :outgoing)
                          :resize-mode :cover
                          :source      {:uri uri}}

--- a/src/status_im/ui/screens/status/views.cljs
+++ b/src/status_im/ui/screens/status/views.cljs
@@ -48,7 +48,7 @@
                                          :overflow      :hidden
                                          :border-radius 16
                                          :margin-top    8}
-                   :accessibility-label :message-image}
+                   :accessibility-label :image-message}
        [react/image {:style       {:width  (first @dimensions)
                                    :height image-max-dimension}
                      :cache       :force-cache


### PR DESCRIPTION
New test to check PN received for stickers, audio, image and emoji. And also that emoji reactions can be set for each message.
+ updated accessibility for image message for easier implementation of e2e test

ChatElementByText customised a little for stickers, audio and image (these messages has separate accissibility-id which we can leverage in this class, but because there is not 'text' attribute I had to add separate locator there)
Also had to customise a little the set_reaction method: when we long-tap upon audio message it taps on audio-line and so long-tap doesn't work. And when it long-taps on emoji defined in ChatElement - it also taps somewhere outside the message but all fine if tap on emoji itself (element_by_text).

