### PR TITLE
Fix for group chat invites icon in activity center

### DIFF
--- a/src/status_im/ui/screens/notifications_center/views/notification.cljs
+++ b/src/status_im/ui/screens/notifications_center/views/notification.cljs
@@ -6,13 +6,13 @@
             [status-im.i18n.i18n :as i18n]
             [status-im.ui.screens.notifications-center.styles :as styles]
             [status-im.utils.handlers :refer [<sub]]
-            [status-im.ui.screens.chat.photos :as photos]
-            [status-im.multiaccounts.core :as multiaccounts]
             [status-im.ui.components.icons.icons :as icons]
             [status-im.utils.contenthash :as contenthash]
             [status-im.constants :as constants]
             [status-im.ui.components.colors :as colors]
-            [status-im.ui.screens.home.views.inner-item :as home-item]))
+            [status-im.ui.screens.home.views.inner-item :as home-item]
+            [status-im.ui.components.chat-icon.screen :as chat-icon.screen]
+            [status-im.ui.components.chat-icon.styles :as chat-icon.styles]))
 
 (defn mention-element [from]
   (let [contact-name @(re-frame/subscribe [:contacts/contact-name-by-identity from])]
@@ -113,19 +113,20 @@
      (render-message (:parsed-text content) max-notification-length max-number-of-lines style text-weight))])
 
 (defn activity-text-item [home-item opts]
-  (let [{:keys [chat-id chat-name message last-message reply-message muted read group-chat timestamp type]} home-item
+  (let [{:keys [chat-id chat-name message last-message reply-message muted read group-chat timestamp type color]} home-item
         message (or message last-message)
         {:keys [community-id]} (<sub [:chat-by-id chat-id])
         {:keys [name]} @(re-frame/subscribe [:communities/community community-id])
-        contact (when message @(re-frame/subscribe [:contacts/contact-by-identity (message :from)]))
         sender (when message (first @(re-frame/subscribe [:contacts/contact-two-names-by-identity (message :from)])))]
     [react/touchable-opacity (merge {:style (styles/notification-container read)} opts)
      [react/view {:style styles/notification-content-container}
-      [react/view {:style styles/photo-container}
-       [photos/photo
-        (multiaccounts/displayed-photo contact)
-        {:size 40
-         :accessibility-label :current-account-photo}]]
+      [chat-icon.screen/chat-icon-view chat-id group-chat chat-name
+       {:container              styles/photo-container
+        :size                   40
+        :chat-icon              chat-icon.styles/chat-icon-chat-list
+        :default-chat-icon      (chat-icon.styles/default-chat-icon-chat-list color)
+        :default-chat-icon-text (chat-icon.styles/default-chat-icon-text 40)
+        :accessibility-label    :current-account-photo}]
       [quo/text {:weight              :medium
                  :color               (when muted :secondary)
                  :accessibility-label :chat-name-or-sender-text

--- a/src/status_im/ui/screens/notifications_center/views/notification.cljs
+++ b/src/status_im/ui/screens/notifications_center/views/notification.cljs
@@ -6,6 +6,8 @@
             [status-im.i18n.i18n :as i18n]
             [status-im.ui.screens.notifications-center.styles :as styles]
             [status-im.utils.handlers :refer [<sub]]
+            [status-im.ui.screens.chat.photos :as photos]
+            [status-im.multiaccounts.core :as multiaccounts]
             [status-im.ui.components.icons.icons :as icons]
             [status-im.utils.contenthash :as contenthash]
             [status-im.constants :as constants]
@@ -117,16 +119,25 @@
         message (or message last-message)
         {:keys [community-id]} (<sub [:chat-by-id chat-id])
         {:keys [name]} @(re-frame/subscribe [:communities/community community-id])
+        contact (when message @(re-frame/subscribe [:contacts/contact-by-identity (message :from)]))
         sender (when message (first @(re-frame/subscribe [:contacts/contact-two-names-by-identity (message :from)])))]
     [react/touchable-opacity (merge {:style (styles/notification-container read)} opts)
      [react/view {:style styles/notification-content-container}
-      [chat-icon.screen/chat-icon-view chat-id group-chat chat-name
-       {:container              styles/photo-container
-        :size                   40
-        :chat-icon              chat-icon.styles/chat-icon-chat-list
-        :default-chat-icon      (chat-icon.styles/default-chat-icon-chat-list color)
-        :default-chat-icon-text (chat-icon.styles/default-chat-icon-text 40)
-        :accessibility-label    :current-account-photo}]
+      (if (or
+           (= type constants/activity-center-notification-type-mention)
+           (= type constants/activity-center-notification-type-reply))
+        [react/view {:style styles/photo-container}
+         [photos/photo
+          (multiaccounts/displayed-photo contact)
+          {:size 40
+           :accessibility-label :current-account-photo}]]
+        [chat-icon.screen/chat-icon-view chat-id group-chat chat-name
+         {:container              styles/photo-container
+          :size                   40
+          :chat-icon              chat-icon.styles/chat-icon-chat-list
+          :default-chat-icon      (chat-icon.styles/default-chat-icon-chat-list color)
+          :default-chat-icon-text (chat-icon.styles/default-chat-icon-text 40)
+          :accessibility-label    :current-account-photo}])
       [quo/text {:weight              :medium
                  :color               (when muted :secondary)
                  :accessibility-label :chat-name-or-sender-text


### PR DESCRIPTION
fixes #12304 

### Summary

This PR fixes group chat invites icon in activity center 

#### Screenshot

<img width="446" src="https://user-images.githubusercontent.com/18485527/127043799-1d6b17cb-9439-4a6b-93e3-f3974425e29e.png">

#### Platforms

- Android
- iOS

##### Functional

- activity center

### Steps to test

- Open Status in one device
- Invite to group chat to another user
- Open Status in another device logged with the invited user
- Verify icon in activity center notification

status: ready