### PR TITLE
Add pinned messages option in community channel info

### DIFF
--- a/src/status_im/ui/screens/chat/sheets.cljs
+++ b/src/status_im/ui/screens/chat/sheets.cljs
@@ -96,12 +96,6 @@
        :on-press            #(hide-sheet-and-dispatch [:navigate-to :community-channel-details {:chat-id chat-id}])}]
      [quo/list-item
       {:theme               :accent
-       :title               (i18n/label :t/pinned-messages)
-       :icon                :main-icons/pin
-       :accessory           :text
-       :on-press            #(hide-sheet-and-dispatch [:contact.ui/pinned-messages-pressed chat-id])}]
-     [quo/list-item
-      {:theme               :accent
        :title               (i18n/label :t/mark-all-read)
        :accessibility-label :mark-all-read-button
        :icon                :main-icons/check

--- a/src/status_im/ui/screens/communities/channel_details.cljs
+++ b/src/status_im/ui/screens/communities/channel_details.cljs
@@ -4,7 +4,8 @@
             [status-im.ui.components.profile-header.view :as profile-header]
             [status-im.i18n.i18n :as i18n]
             [clojure.string :as string]
-            [status-im.communities.core :as communities]))
+            [status-im.communities.core :as communities]
+            [re-frame.core :as re-frame]))
 
 (defn view []
   (let [{:keys [chat-id]} (<sub [:get-screen-params])]
@@ -12,7 +13,8 @@
       (let [current-chat (<sub [:chat-by-id chat-id])
             {:keys [chat-name color description community-id]} current-chat
             category (<sub [:chats/category-by-chat-id community-id chat-id])
-            {:keys [admin]} (<sub [:communities/community community-id])]
+            {:keys [admin]} (<sub [:communities/community community-id])
+            pinned-messages (<sub [:chats/pinned chat-id])]
         [quo/animated-header {:left-accessories  [{:icon                :main-icons/arrow-left
                                                    :accessibility-label :back-button
                                                    :on-press            #(>evt [:navigate-back])}]
@@ -42,4 +44,10 @@
                               :accessory      :text
                               :accessory-text (if category
                                                 (:name category)
-                                                (i18n/label :t/none))}])])]))))
+                                                (i18n/label :t/none))}])
+            [quo/list-item
+             {:title               (i18n/label :t/pinned-messages)
+              :accessory           :text
+              :accessory-text      (count pinned-messages)
+              :chevron             true
+              :on-press            #(re-frame/dispatch [:contact.ui/pinned-messages-pressed chat-id])}]])]))))


### PR DESCRIPTION
fixes #12283 

### Summary

Adding Pinned messages option to community channel info screen

#### Screenshots

<img width="446" src="https://user-images.githubusercontent.com/18485527/127374798-df1b6d88-0775-484c-a710-77a71b0cb5c7.png">

#### Platforms

- Android
- iOS

##### Functional

- community chats

### Steps to test

- Open Status
- Create a community
- Create a channel within the community
- Go to channel info
- Verify pinned messages option appears and works properly

status: ready
