### PR TITLE
trigger migration to Keycard from logged in state

### DIFF
--- a/src/status_im/init/core.cljs
+++ b/src/status_im/init/core.cljs
@@ -14,7 +14,7 @@
 
 (fx/defn initialize-app-db
   "Initialize db to initial state"
-  [{{:keys [keycard supported-biometric-auth app-active-since]
+  [{{:keys [keycard supported-biometric-auth app-active-since goto-key-storage?]
      :network/keys [type] :keycard/keys [banner-hidden]} :db
     now :now}]
   {:db (assoc app-db
@@ -23,6 +23,7 @@
               :keycard (dissoc keycard :secrets)
               :supported-biometric-auth supported-biometric-auth
               :app-active-since (or app-active-since now)
+              :goto-key-storage? goto-key-storage?
               :multiaccounts/loading true)})
 
 (fx/defn initialize-views

--- a/src/status_im/multiaccounts/key_storage/core.cljs
+++ b/src/status_im/multiaccounts/key_storage/core.cljs
@@ -5,6 +5,7 @@
             [status-im.multiaccounts.core :as multiaccounts]
             [status-im.multiaccounts.recover.core :as multiaccounts.recover]
             [status-im.multiaccounts.model :as multiaccounts.model]
+            [status-im.multiaccounts.logout.core :as multiaccounts.logout]
             [status-im.native-module.core :as native-module]
             [status-im.navigation :as navigation]
             [status-im.popover.core :as popover]
@@ -239,6 +240,23 @@ We don't need to take the exact steps, just set the required state and redirect 
   (fx/merge cofx
             (popover/hide-popover)
             (navigation/navigate-to-cofx :multiaccounts nil)))
+
+(fx/defn confirm-logout-and-goto-key-storage
+  {:events [::confirm-logout-and-goto-key-storage]}
+  [{:keys [db] :as cofx}]
+  (fx/merge cofx
+            {:db (assoc db :goto-key-storage? true)}
+            (multiaccounts.logout/logout)))
+
+(fx/defn logout-and-goto-key-storage
+  {:events [::logout-and-goto-key-storage]}
+  [_]
+  {:ui/show-confirmation
+   {:title               (i18n/label :t/logout-title)
+    :content             (i18n/label :t/logout-key-management)
+    :confirm-button-text (i18n/label :t/logout)
+    :on-accept           #(re-frame/dispatch [::confirm-logout-and-goto-key-storage])
+    :on-cancel           nil}})
 
 (comment
   ;; check import mnemonic output

--- a/src/status_im/ui/screens/privacy_and_security_settings/views.cljs
+++ b/src/status_im/ui/screens/privacy_and_security_settings/views.cljs
@@ -3,6 +3,7 @@
             [status-im.i18n.i18n :as i18n]
             [quo.core :as quo]
             [status-im.multiaccounts.reset-password.core :as reset-password]
+            [status-im.multiaccounts.key-storage.core :as key-storage]
             [status-im.ui.components.common.common :as components.common]
             [status-im.ui.components.react :as react]
             [status-im.utils.config :as config]
@@ -95,6 +96,12 @@
                        :on-press           #(re-frame/dispatch
                                              [:multiaccounts.ui/webview-permission-requests-switched
                                               ((complement boolean) webview-allow-permission-requests?)])}])
+     (when (not keycard?)
+       [quo/list-item {:size                :small
+                       :title               (i18n/label :t/manage-keys-and-storage)
+                       :chevron             true
+                       :on-press            #(re-frame/dispatch [::key-storage/logout-and-goto-key-storage])
+                       :accessibility-label :key-managment}])
      [separator]
      [quo/list-item
       {:size                :small

--- a/translations/en.json
+++ b/translations/en.json
@@ -796,6 +796,7 @@
     "logout-app-content": "The account will be logged out. When you unlock it again, the selected network will be used",
     "logout-are-you-sure": "Are you sure you want\nto log out?",
     "logout-title": "Log out?",
+    "logout-key-management": "You need to log out to access key management.",
     "looking-for-cards": "Looking for cards...",
     "lost-connection": "Lost connection",
     "mailserver-address": "Status node address",


### PR DESCRIPTION
Closes #11778. It logs you out and redirects to the key management UI since it is the safest way to actually perform the migration.

The entry point is from Profile -> Privacy and Settings -> Manage Keys and Storage.

When we do #12336 the menu label will be renamed to whatever we decide it should be called (Migrate account to Keycard I guess)