### PR TITLE
Fix error when opening 1-1 chat in activity center for blocked user

### DIFF
--- a/src/status_im/subs.cljs
+++ b/src/status_im/subs.cljs
@@ -1802,12 +1802,15 @@
 (re-frame/reg-sub
  :activity.center/notifications-grouped-by-date
  :<- [:activity.center/notifications]
- (fn [{:keys [notifications]}]
-   (let [supported-notifications (filter (fn [{:keys [type]}]
-                                           (or (= constants/activity-center-notification-type-mention type)
-                                               (= constants/activity-center-notification-type-one-to-one-chat type)
-                                               (= constants/activity-center-notification-type-private-group-chat type)
-                                               (= constants/activity-center-notification-type-reply type))) notifications)]
+ :<- [::chats]
+ (fn [[{:keys [notifications]} chats]]
+   (let [supported-notifications (filter (fn [{:keys [type chat-id]}]
+                                           (and
+                                            (or (= constants/activity-center-notification-type-mention type)
+                                                (= constants/activity-center-notification-type-one-to-one-chat type)
+                                                (= constants/activity-center-notification-type-private-group-chat type)
+                                                (= constants/activity-center-notification-type-reply type))
+                                            (get chats chat-id))) notifications)]
      (group-notifications-by-date (map #(assoc % :timestamp (or (:timestamp %) (:timestamp (or (:message %) (:last-message %))))) supported-notifications)))))
 
 ;;WALLET TRANSACTIONS ==================================================================================================


### PR DESCRIPTION
fixes #12333

### Summary

This PR aims to fix an error when opening 1-1 chat in activity center with a previously blocked user. The proposed solution is to avoid showing that notifications as it makes no sense, so we filter it.

#### Platforms

- Android
- iOS

##### Functional

- activity center

### Steps to test

User A:
- Join a public chat
- Send a message
- Send a message in 1-1 chat with User B

User B:
- Join the same public chat
- Tap User's A name in chat view > Open profile > Block
- Open Activity center
- Verify there's no notification in activity center for a 1-to-1 chat 

status: ready