### PR TITLE
Sort pinned messages by time of pinning

### DIFF
--- a/src/status_im/subs.cljs
+++ b/src/status_im/subs.cljs
@@ -993,6 +993,15 @@
    (get pin-messages chat-id {})))
 
 (re-frame/reg-sub
+ :chats/pinned-sorted-list
+ :<- [::pin-messages]
+ (fn [pin-messages [_ chat-id]]
+   (->>
+    (get pin-messages chat-id {})
+    vals
+    (sort-by :pinned-at <))))
+
+(re-frame/reg-sub
  :chats/message-reactions
  :<- [:multiaccount/public-key]
  :<- [::reactions]

--- a/src/status_im/ui/screens/chat/message/pinned_message.cljs
+++ b/src/status_im/ui/screens/chat/message/pinned_message.cljs
@@ -44,10 +44,10 @@
 (def list-key-fn #(or (:message-id %) (:value %)))
 
 (defn pinned-messages-limit-list [chat-id]
-  (let [pinned-messages @(re-frame/subscribe [:chats/pinned chat-id])]
+  (let [pinned-messages @(re-frame/subscribe [:chats/pinned-sorted-list chat-id])]
     [list/flat-list
      {:key-fn                       list-key-fn
-      :data                         (reverse (vals pinned-messages))
+      :data                         (reverse pinned-messages)
       :render-data                  {:chat-id chat-id}
       :render-fn                    render-pin-fn
       :on-scroll-to-index-failed    identity


### PR DESCRIPTION
fixes #12290

### Summary

This PR adds sorting pinned messages by time of pinning and also removes separation of pinned messages in timeframes

#### Screenshots

<img width="446" src="https://user-images.githubusercontent.com/18485527/127712448-c879e998-2a17-4566-ae14-11c04ee93476.png">

#### Platforms

- Android
- iOS

##### Functional

- 1-1 chats
- group chats

### Steps to test

- Open Status
- Pin some messages
- Open pinned messages screen
- Verify that pinned messages are sorted by time of pinning

status: ready