### PR TITLE
Add quick way to permanently hide android background service notification

### DIFF
--- a/modules/react-native-status/android/src/main/java/im/status/ethereum/pushnotifications/ForegroundService.java
+++ b/modules/react-native-status/android/src/main/java/im/status/ethereum/pushnotifications/ForegroundService.java
@@ -8,6 +8,7 @@ import android.app.Notification;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
+import android.provider.Settings;
 
 import androidx.core.app.NotificationCompat;
 import androidx.core.app.NotificationManagerCompat;
@@ -30,6 +31,10 @@ public class ForegroundService extends Service {
         Context context = getApplicationContext();
         // Create the NotificationChannel, but only on API 26+ because
         // the NotificationChannel class is new and not in the support library
+
+        Intent intent = null;
+        String notificationContentText = null;
+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             NotificationManager notificationManager =
                 context.getSystemService(NotificationManager.class);
@@ -38,31 +43,49 @@ public class ForegroundService extends Service {
                                                                   NotificationManager.IMPORTANCE_HIGH);
             channel.setShowBadge(false);
             notificationManager.createNotificationChannel(channel);
-        }
-        Class intentClass;
-        String packageName = context.getPackageName();
-        Intent launchIntent = context.getPackageManager().getLaunchIntentForPackage(packageName);
-        String className = launchIntent.getComponent().getClassName();
-        try {
-            intentClass =  Class.forName(className);
-        } catch (ClassNotFoundException e) {
-            e.printStackTrace();
-            return 0;
-        }
 
-        Intent intent = new Intent(context, intentClass);
-        intent.addCategory(Intent.CATEGORY_BROWSABLE);
-        intent.setAction(Intent.ACTION_VIEW);
-        intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
+            // Create intent that takes the user to the notification channel settings so they can hide it
+
+            intent = new Intent(Settings.ACTION_CHANNEL_NOTIFICATION_SETTINGS);
+            intent.putExtra(Settings.EXTRA_APP_PACKAGE, getPackageName());
+            intent.putExtra(Settings.EXTRA_CHANNEL_ID, CHANNEL_ID);
+
+            notificationContentText = context.getResources().getString(R.string.tap_to_hide_notification);
+            
+        } else {
+
+            // For older versions of android intent takes the user to the Status app
+
+            Class intentClass;
+            String packageName = context.getPackageName();
+            Intent launchIntent = context.getPackageManager().getLaunchIntentForPackage(packageName);
+            String className = launchIntent.getComponent().getClassName();
+            try {
+                intentClass =  Class.forName(className);
+            } catch (ClassNotFoundException e) {
+                e.printStackTrace();
+                return 0;
+            }
+            
+            intent = new Intent(context, intentClass);
+            intent.addCategory(Intent.CATEGORY_BROWSABLE);
+            intent.setAction(Intent.ACTION_VIEW);
+            intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
+
+            notificationContentText = context.getResources().getString(R.string.keep_status_running);
+
+        }
+        
+
+      
         PendingIntent pendingIntent = PendingIntent.getActivity(this, 0, intent, 0);
         Intent stopIntent = new Intent(PushNotificationHelper.ACTION_TAP_STOP);
         PendingIntent stopPendingIntent = PendingIntent.getBroadcast(context, 0, stopIntent, PendingIntent.FLAG_CANCEL_CURRENT);
 
-        String content = context.getResources().getString(R.string.keep_status_running);
         Notification notification = new NotificationCompat.Builder(context, CHANNEL_ID)
             .setSmallIcon(R.drawable.ic_stat_notify_status)
             .setContentTitle(context.getResources().getString(R.string.background_service_opened))
-            .setContentText(content)
+            .setContentText(notificationContentText)
             .setPriority(NotificationCompat.PRIORITY_HIGH)
             .setCategory(NotificationCompat.CATEGORY_MESSAGE)
             .setContentIntent(pendingIntent)

--- a/modules/react-native-status/android/src/main/res/values/strings.xml
+++ b/modules/react-native-status/android/src/main/res/values/strings.xml
@@ -1,8 +1,9 @@
 <resources>
-    <string name="status_service">Status Service</string>
+    <string name="status_service">Status Background Service</string>
     <string name="stop">STOP</string>
+    <string name="tap_to_hide_notification">Tap to hide this notification permanently</string>
     <string name="keep_status_running">Keep Status running to receive notifications</string>
-    <string name="background_service_opened">Background notification service opened</string>
+    <string name="background_service_opened">Background service for notifications is running</string>
     <string name="channel_description">Get notifications on new messages and mentions</string>
 </resources>
 


### PR DESCRIPTION
### Summary

As a user of status on android, I want to be able to receive notifications without having to constantly see the sticky notification for the background service. I'd like an easy way to hide this notification permanently.

Since Android 8.0 users can hide notifications for specific channels. A tap on the background service notification now takes the user to the background service notification channel settings so they can hide it permanently from there. Text in the notification also reflects what's going to happen when tapping it

<img width="488" alt="Screenshot 2021-07-31 at 12 54 17" src="https://user-images.githubusercontent.com/10310633/127737668-4a381725-d354-454d-bcd3-9a1a8c914f3c.png">

<img width="500" alt="Screenshot 2021-07-31 at 12 55 12" src="https://user-images.githubusercontent.com/10310633/127737693-27121a04-2c14-4429-9678-e4ec091239d0.png">


### Review notes

- Review the strings that have been modified in strings.xml

#### Platforms

- Android

#### Areas that maybe impacted

##### Functional

- 1-1 chats
- public chats
- group chats
- wallet / transactions
- account recovery
- new account
- user profile updates
- networks
- mailservers

##### Non-functional


### Steps to test

- Open Status on Android 8.0 or higher
- Tap on the Status Background service notification
- Disable channel notification
- Receive a message to check that notifications for that chat are still working

status: ready 
