### PR TITLE
[Fixes: #12393] Allow to enable transaction management

### DIFF
--- a/src/status_im/multiaccounts/login/core.cljs
+++ b/src/status_im/multiaccounts/login/core.cljs
@@ -50,6 +50,14 @@
         callback)))))
 
 (re-frame/reg-fx
+ ::initialize-transactions-management-enabled
+ (fn []
+   (let [callback #(re-frame/dispatch [:multiaccounts.ui/switch-transactions-management-enabled %])]
+     (async-storage/get-item
+      :transactions-management-enabled?
+      callback))))
+
+(re-frame/reg-fx
  ::login
  (fn [[key-uid account-data hashed-password]]
    (status/login key-uid account-data hashed-password)))
@@ -253,6 +261,10 @@
   [cofx]
   {::initialize-communities-enabled nil})
 
+(fx/defn initialize-transactions-management-enabled
+  [cofx]
+  {::initialize-transactions-management-enabled nil})
+
 (fx/defn get-node-config-callback
   {:events [::get-node-config-callback]}
   [{:keys [db] :as cofx} node-config]
@@ -292,6 +304,7 @@
               (initialize-appearance)
               (transport/start-messenger)
               (initialize-communities-enabled)
+              (initialize-transactions-management-enabled)
               (check-network-version network-id)
               (chat.loading/initialize-chats)
               (get-node-config)

--- a/src/status_im/subs.cljs
+++ b/src/status_im/subs.cljs
@@ -167,6 +167,7 @@
 (reg-root-key-sub :wallet/non-archival-node :wallet/non-archival-node)
 (reg-root-key-sub :wallet/latest-base-fee :wallet/latest-base-fee)
 (reg-root-key-sub :wallet/latest-priority-fee :wallet/latest-priority-fee)
+(reg-root-key-sub :wallet/transactions-management-enabled? :wallet/transactions-management-enabled?)
 ;;commands
 (reg-root-key-sub :commands/select-account :commands/select-account)
 

--- a/src/status_im/ui/screens/advanced_settings/views.cljs
+++ b/src/status_im/ui/screens/advanced_settings/views.cljs
@@ -11,6 +11,7 @@
                                           current-log-level
                                           waku-bloom-filter-mode
                                           communities-enabled?
+                                          transactions-management-enabled?
                                           current-fleet
                                           webview-debug]}]
   (keep
@@ -79,6 +80,15 @@
        :accessory               :switch
        :active                  communities-enabled?})
     {:size                   :small
+     :title                   (i18n/label :t/transactions-management-enabled)
+     :accessibility-label     :transactions-management-enabled
+     :container-margin-bottom 8
+     :on-press
+     #(re-frame/dispatch
+       [:multiaccounts.ui/switch-transactions-management-enabled (not transactions-management-enabled?)])
+     :accessory               :switch
+     :active                  transactions-management-enabled?}
+    {:size                   :small
      :title                   "Webview debug"
      :accessibility-label     :webview-debug-switch
      :container-margin-bottom 8
@@ -106,20 +116,22 @@
     [quo/list-item props]))
 
 (views/defview advanced-settings []
-  (views/letsubs [{:keys [webview-debug]} [:multiaccount]
-                  network-name             [:network-name]
-                  waku-bloom-filter-mode   [:waku/bloom-filter-mode]
-                  communities-enabled?     [:communities/enabled?]
-                  current-log-level        [:log-level/current-log-level]
-                  current-fleet            [:fleets/current-fleet]]
+  (views/letsubs [{:keys [webview-debug]}          [:multiaccount]
+                  network-name                     [:network-name]
+                  waku-bloom-filter-mode           [:waku/bloom-filter-mode]
+                  communities-enabled?             [:communities/enabled?]
+                  transactions-management-enabled? [:wallet/transactions-management-enabled?]
+                  current-log-level                [:log-level/current-log-level]
+                  current-fleet                    [:fleets/current-fleet]]
     [list/flat-list
      {:data      (flat-list-data
-                  {:network-name           network-name
-                   :current-log-level      current-log-level
-                   :communities-enabled?   communities-enabled?
-                   :current-fleet          current-fleet
-                   :dev-mode?              false
-                   :waku-bloom-filter-mode waku-bloom-filter-mode
-                   :webview-debug          webview-debug})
+                  {:network-name                     network-name
+                   :current-log-level                current-log-level
+                   :communities-enabled?             communities-enabled?
+                   :transactions-management-enabled? transactions-management-enabled?
+                   :current-fleet                    current-fleet
+                   :dev-mode?                        false
+                   :waku-bloom-filter-mode           waku-bloom-filter-mode
+                   :webview-debug                    webview-debug})
       :key-fn    (fn [_ i] (str i))
       :render-fn render-item}]))

--- a/src/status_im/ui/screens/wallet/transactions/views.cljs
+++ b/src/status_im/ui/screens/wallet/transactions/views.cljs
@@ -38,7 +38,7 @@
   [{:keys [label contact address contact-accessibility-label
            address-accessibility-label currency-text amount-text
            time-formatted on-touch-fn type hash]}
-   _ _ {:keys [keycard-account?]}]
+   _ _ {:keys [keycard-account? transactions-management-enabled?]}]
   [react/view
    [list/touchable-item on-touch-fn
     [react/view {:accessibility-label :transaction-item}
@@ -75,7 +75,7 @@
                        :style     {:margin-top 10}
                        :icon-opts (merge styles/forward
                                          {:accessibility-label :show-transaction-button})}]]]]
-   (when (and false ;;TODO temporary disable for 1.10
+   (when (and transactions-management-enabled?
               (not keycard-account?)
               (= type :pending))
      [react/view {:flex-direction :row :padding 16 :justify-content :space-between}
@@ -132,13 +132,14 @@
 
 (defn history-list
   [{:keys [transaction-history-sections total]} address]
-  (let [fetching-recent-history? @(re-frame/subscribe [:wallet/fetching-recent-tx-history? address])
-        fetching-more-history?   @(re-frame/subscribe [:wallet/fetching-tx-history? address])
-        keycard-account?         @(re-frame/subscribe [:multiaccounts/keycard-account?])
-        custom-rpc-node?         @(re-frame/subscribe [:custom-rpc-node])
-        non-archival-rpc-node?   @(re-frame/subscribe [:wallet/non-archival-node])
-        all-fetched?             @(re-frame/subscribe [:wallet/tx-history-fetched? address])
-        syncing-allowed?         @(re-frame/subscribe [:mobile-network/syncing-allowed?])]
+  (let [fetching-recent-history?         @(re-frame/subscribe [:wallet/fetching-recent-tx-history? address])
+        fetching-more-history?           @(re-frame/subscribe [:wallet/fetching-tx-history? address])
+        keycard-account?                 @(re-frame/subscribe [:multiaccounts/keycard-account?])
+        transactions-management-enabled? @(re-frame/subscribe [:wallet/transactions-management-enabled?])
+        custom-rpc-node?                 @(re-frame/subscribe [:custom-rpc-node])
+        non-archival-rpc-node?           @(re-frame/subscribe [:wallet/non-archival-node])
+        all-fetched?                     @(re-frame/subscribe [:wallet/tx-history-fetched? address])
+        syncing-allowed?                 @(re-frame/subscribe [:mobile-network/syncing-allowed?])]
     [react/view {:flex 1}
      [etherscan-link address]
      (cond non-archival-rpc-node?
@@ -155,7 +156,8 @@
      [list/section-list
       {:sections   transaction-history-sections
        :key-fn     :hash
-       :render-data {:keycard-account? keycard-account?}
+       :render-data {:keycard-account? keycard-account?
+                     :transactions-management-enabled? transactions-management-enabled?}
        :render-fn  render-transaction
        :empty-component
        [react/i18n-text {:style styles/empty-text

--- a/src/status_im/wallet/core.cljs
+++ b/src/status_im/wallet/core.cljs
@@ -962,3 +962,9 @@
       {:method     "wallet_deletePendingTransaction"
        :params     [hash]
        :on-success #(log/info "[wallet] pending transaction deleted" hash)}))))
+
+(fx/defn switch-transactions-management-enabled
+  {:events [:multiaccounts.ui/switch-transactions-management-enabled]}
+  [{:keys [db]} enabled?]
+  {::async-storage/set! {:transactions-management-enabled? enabled?}
+   :db (assoc db :wallet/transactions-management-enabled? enabled?)})

--- a/translations/en.json
+++ b/translations/en.json
@@ -1188,6 +1188,7 @@
     "transaction": "Transaction",
     "transaction-data": "Transaction data",
     "transaction-declined": "Transaction declined",
+    "transactions-management-enabled": "Transaction management (alpha)",
     "transaction-description": "Consider it complete after 12 confirmations on the network.",
     "transaction-details": "Transaction details",
     "transaction-failed": "Transaction failed",


### PR DESCRIPTION
Fixes: #12393 

Adds a setting to enable management transactions, as it was before. I have briefly checked it works the cancel/increase gas, but this only makes sure that there's a setting.

The setting is per installation, not per account.

status: ready