### PR TITLE
update react-native-webview for better SSL handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "react-native-status-keycard": "git+https://github.com/status-im/react-native-status-keycard.git#v2.5.35",
     "react-native-svg": "^9.8.4",
     "react-native-touch-id": "^4.4.1",
-    "react-native-webview": "git+https://github.com/status-im/react-native-webview.git#v10.9.2",
+    "react-native-webview": "git+https://github.com/status-im/react-native-webview.git#v11.3.0-status",
     "tdigest": "^0.1.1",
     "web3-utils": "^1.2.1"
   },

--- a/src/status_im/ui/screens/browser/views.cljs
+++ b/src/status_im/ui/screens/browser/views.cljs
@@ -186,6 +186,7 @@
         :java-script-enabled                        true
         :bounces                                    false
         :local-storage-enabled                      true
+        :set-support-multiple-windows               false
         :render-error                               web-view-error
         :on-navigation-state-change                 #(do
                                                        (re-frame/dispatch [:set-in [:ens/registration :state] :searching])

--- a/yarn.lock
+++ b/yarn.lock
@@ -6748,9 +6748,9 @@ react-native-touch-id@^4.4.1:
   resolved "https://registry.yarnpkg.com/react-native-touch-id/-/react-native-touch-id-4.4.1.tgz#8b1bb2d04c30bac36bb9696d2d723e719c4a8b08"
   integrity sha512-1jTl8fC+0fxvqegy/XXTyo6vMvPhjzkoDdaqoYZx0OH8AT250NuXnNPyKktvigIcys3+2acciqOeaCall7lrvg==
 
-"react-native-webview@git+https://github.com/status-im/react-native-webview.git#v10.9.2":
-  version "10.9.2"
-  resolved "git+https://github.com/status-im/react-native-webview.git#e2cf5fdc76d73f84ac2f60ca5d5ad4af3ac0730a"
+"react-native-webview@git+https://github.com/status-im/react-native-webview.git#v11.3.0-status":
+  version "11.3.0"
+  resolved "git+https://github.com/status-im/react-native-webview.git#aafe232857d5c278d7ab43826e8b79a523121073"
   dependencies:
     escape-string-regexp "2.0.0"
     invariant "2.2.4"


### PR DESCRIPTION
Fixes #12073.

update react-native-webview to release v11.3.0 + permission handling patch. This is the last release where our patch applies cleanly and seems to work fine. The improvements to permission handling introduced by newer versions of react-native-webview are not a replacement for our patch, so should we have a reason for futher upgrades additional work will be needed.

when testing please check carefully for regressions in the browser since a core component has been upgraded. Note that entering https://cryptokitties.co does not work with this version either. It doesn't work in any other browser I tested as well so something is definitely misconfigured on their side.

However, http://cryptokitties.co and https://www.cryptokitties.co both work fine. Also accessing from dap.ps is OK.