### PR TITLE
Fix pinned edited messages not updating in communities

### DIFF
--- a/src/status_im/ui/screens/chat/sheets.cljs
+++ b/src/status_im/ui/screens/chat/sheets.cljs
@@ -87,7 +87,9 @@
        :subtitle            (i18n/label :t/view-details)
        :chevron             true
        :accessibility-label :view-community-channel-details
-       :on-press            #(hide-sheet-and-dispatch [:navigate-to :community-channel-details {:chat-id chat-id}])}]
+       :on-press            #(do
+                               (hide-sheet-and-dispatch [:navigate-to :community-channel-details {:chat-id chat-id}])
+                               (re-frame/dispatch [::models.pin-message/load-pin-messages chat-id]))}]
      [quo/list-item
       {:theme               :accent
        :title               (i18n/label :t/mark-all-read)


### PR DESCRIPTION
fixes #12396 

### Summary

Fixes pinned edited messages not updating in communities

#### Platforms

- Android
- iOS

##### Functional

- communities
- pinned messages

### Steps to test

- Open Status
- Open a community where you are admin
- Open a chat from the community
- Pin some message
- Edit pinned message
- Go to see pinned messages
- Verify pinned message is showing the latest edited message

status: ready