### PR TITLE
emit url event when recreating Activity with link

### DIFF
--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -17,6 +17,7 @@
             [status-im.utils.utils :as utils]
             [status-im.ethereum.json-rpc :as json-rpc]
             [status-im.anon-metrics.core :as anon-metrics]
+            [status-im.utils.universal-links.core :as universal-links]
             clojure.set
             status-im.currency.core
             status-im.navigation
@@ -144,6 +145,7 @@
                        (assoc :app-active-since now))}
               (mailserver/process-next-messages-request)
               (wallet/restart-wallet-service-after-background app-in-background-since)
+              (universal-links/process-stored-event)
               #(when requires-bio-auth
                  (biometric/authenticate % on-biometric-auth-result authentication-options)))))
 

--- a/src/status_im/utils/universal_links/core.cljs
+++ b/src/status_im/utils/universal_links/core.cljs
@@ -152,8 +152,8 @@
   "Store url in the database if the user is not logged in, to be processed
   on login, otherwise just handle it"
   {:events [:universal-links/handle-url]}
-  [cofx url]
-  (if (multiaccounts.model/logged-in? cofx)
+  [{:keys [db] :as cofx} url]
+  (if (and (multiaccounts.model/logged-in? cofx) (= (:app-state db) "active"))
     (route-url cofx url)
     (store-url-for-later cofx url)))
 

--- a/src/status_im/utils/universal_links/core_test.cljs
+++ b/src/status_im/utils/universal_links/core_test.cljs
@@ -14,7 +14,8 @@
         (is (= {:db {:universal-links/url "some-url"}}
                (links/handle-url {:db {}} "some-url")))))
     (testing "the user is logged in"
-      (let [db {:multiaccount      {:public-key "pk"}
+      (let [db {:multiaccount        {:public-key "pk"}
+                :app-state           "active"
                 :universal-links/url "some-url"}]
         (testing "it clears the url"
           (is (nil? (get-in (links/handle-url {:db db} "some-url")

--- a/test/appium/tests/atomic/chats/test_chats_management.py
+++ b/test/appium/tests/atomic/chats/test_chats_management.py
@@ -700,7 +700,7 @@ class TestChatManagementMultipleDevice(MultipleDeviceTestCase):
         device_1.open_notification_bar()
         if device_1.element_by_text_part(message_after_block_2).is_element_displayed():
             self.errors.append("Push notification is received from blocked user")
-        device_1.element_by_text_part("Background notification service").click()
+        device_1.element_by_text_part("Background service for notifications").click()
 
         if public_chat_after_block_1.chat_element_by_text(message_after_block_2).is_element_displayed():
             self.errors.append("Message from blocked user '%s' is received" % device_2.driver.number)

--- a/test/appium/tests/atomic/chats/test_commands.py
+++ b/test/appium/tests/atomic/chats/test_commands.py
@@ -199,6 +199,7 @@ class TestCommandsMultipleDevices(MultipleDeviceTestCase):
 
         home_1.just_fyi('Decline transaction request and check that state is changed')
         request_amount = chat_1.get_unique_amount()
+        chat_1.commands_button.click()
         request_transaction = chat_1.request_command.click()
         request_transaction.amount_edit_box.set_value(request_amount)
         request_transaction.confirm()

--- a/test/appium/tests/atomic/transactions/test_keycard_wallet.py
+++ b/test/appium/tests/atomic/transactions/test_keycard_wallet.py
@@ -31,6 +31,7 @@ class TestTransactionWalletSingleDevice(SingleDeviceTestCase):
 
     @marks.testrail_id(6290)
     @marks.high
+    @marks.flaky
     def test_keycard_fetching_balance_after_offline(self):
         sender = transaction_senders['F']
         sign_in = SignInView(self.driver)
@@ -42,7 +43,6 @@ class TestTransactionWalletSingleDevice(SingleDeviceTestCase):
         sign_in.just_fyi('Go back to online and check that balance is updated')
         sign_in.set_network_to_cellular_only()
         home.continue_syncing_button.wait_and_click()
-
         home.connection_offline_icon.wait_for_invisibility_of_element(100)
         wallet = home.wallet_button.click()
         wallet.wait_balance_is_changed('ETH')

--- a/test/appium/tests/atomic/transactions/test_wallet.py
+++ b/test/appium/tests/atomic/transactions/test_wallet.py
@@ -53,6 +53,7 @@ class TestTransactionWalletSingleDevice(SingleDeviceTestCase):
 
     @marks.testrail_id(6237)
     @marks.high
+    @marks.flaky
     def test_fetching_balance_after_offline(self):
         sender = wallet_users['E']
         sign_in = SignInView(self.driver)
@@ -61,13 +62,12 @@ class TestTransactionWalletSingleDevice(SingleDeviceTestCase):
         sign_in.set_device_to_offline()
         sign_in.recover_access(sender['passphrase'])
         home = sign_in.get_home_view()
-        wallet = home.wallet_button.click()
-        wallet.set_up_wallet()
 
         sign_in.just_fyi('Go back to online and check that balance is updated')
         sign_in.set_network_to_cellular_only()
         home.continue_syncing_button.wait_and_click()
         home.connection_offline_icon.wait_for_invisibility_of_element(100)
+        wallet = home.wallet_button.click()
         wallet.wait_balance_is_changed('ETH')
         wallet.scan_tokens('STT')
         initial_amount_STT = wallet.get_asset_amount_by_name('STT')


### PR DESCRIPTION
Fixes #12382.

the solution is a workaround to the fact that the linking module from react-native (at least in conjuction with react-native-navigation) does not emit the url event when the app is in background and the MainActivity has been destroyed (which happens, for example, when the app is removed from recent app list). The issue is also mentioned here: https://github.com/react-navigation/react-navigation/issues/9154.

Also as part of the fix, the link is stored until all events during the transition between background and active is completed. This is because otherwise it would sporadically (but quite often when recreating the Activity) fail because :chat-stack was not yet ready. This part of the fix should probably remain even if the workaround (the changes to MainActivity) becomes redundant