### PR TITLE
Implement swipe-to-delete gesture in chat view

### DIFF
--- a/src/mocks/js_dependencies.cljs
+++ b/src/mocks/js_dependencies.cljs
@@ -180,6 +180,7 @@
                                        :FlatList                 #js {}
                                        :ScrollView               #js {}
                                        :TouchableOpacity         #js {}
+                                       :Swipeable                #js {}
                                        :createNativeWrapper      identity})
 
 (def react-native-redash #js {:clamp nil})

--- a/src/quo/gesture_handler.cljs
+++ b/src/quo/gesture_handler.cljs
@@ -8,13 +8,15 @@
                                        PureNativeButton TouchableWithoutFeedback TouchableOpacity
                                        TouchableHighlight
                                        createNativeWrapper State NativeViewGestureHandler
-                                       FlatList ScrollView)]))
+                                       FlatList ScrollView Swipeable)]))
 
 (def flat-list-raw FlatList)
 
 (def flat-list (reagent/adapt-react-class FlatList))
 
 (def scroll-view (reagent/adapt-react-class ScrollView))
+
+(def swipeable-raw (reagent/adapt-react-class Swipeable))
 
 (def tap-gesture-handler
   (reagent/adapt-react-class TapGestureHandler))
@@ -56,3 +58,12 @@
              :end          (oget State "END")
              :failed       (oget State "FAILED")
              :undetermined (oget State "UNDETERMINED")})
+
+(defn swipeable
+  [{:keys [ref friction right-threshold right-actions]
+    :or {ref nil friction 1.5 right-threshold 45}}]
+  (let [this (reagent/current-component) children (reagent/children this)]
+    (into [swipeable-raw {:ref (fn [item] (reset! ref item))
+                          :friction friction
+                          :right-threshold right-threshold
+                          :render-right-actions right-actions}] children)))

--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -245,3 +245,9 @@
    cofx
    (navigation/open-modal :buy-crypto nil)
    (wallet/keep-watching-history)))
+
+(fx/defn swipe-to-delete-chat
+  {:events [:home-list-swipe-to-delete-chat]}
+  [{:keys [db] :as cofx} chat-id]
+  (let [chats (:chats db)]
+    {:db (update db :chats #(dissoc chats chat-id))}))

--- a/src/status_im/ui/components/swipeable/style.cljs
+++ b/src/status_im/ui/components/swipeable/style.cljs
@@ -1,0 +1,9 @@
+(ns status-im.ui.components.swipeable.style
+  (:require [status-im.ui.components.colors :as colors]))
+
+(defn delete-action-container []
+  {:flex              0.3
+   :background-color  colors/red
+   :align-items       :flex-end
+   :justify-content   :center
+   :padding           16})

--- a/src/status_im/ui/components/swipeable/views.cljs
+++ b/src/status_im/ui/components/swipeable/views.cljs
@@ -1,0 +1,27 @@
+(ns status-im.ui.components.swipeable.views
+  (:require [status-im.ui.components.swipeable.style :as styles]
+            [status-im.i18n.i18n :as i18n]
+            [reagent.core :as reagent]
+            [quo.core :as quo]
+            [quo.gesture-handler :as gesture-handler]
+            [quo.react-native :as rn]))
+
+(defn- delete-action
+  [{:keys [on-press]}]
+  (reagent/as-element [rn/touchable-opacity {:style (styles/delete-action-container)
+                                            :on-press on-press}
+                                            [quo/text {:weight :bold
+                                                      :size :large
+                                                      :color :inverse} (i18n/label :t/delete)]]))
+
+(defn on-swipe-to-delete [on-delete swipeable-ref]
+  (let [close (goog.object/getValueByKeys swipeable-ref #js ["close"])]
+    (fn [] (close) (on-delete))))
+
+(defn swipe-to-delete
+  [{:keys [on-delete]}]
+  (let [this (reagent/current-component) children (reagent/children this) swipe-item (atom nil)]
+    (fn [{:keys [on-delete]}]
+      (into [gesture-handler/swipeable {:ref swipe-item
+                                        :right-actions #(delete-action {:on-press (on-swipe-to-delete on-delete @swipe-item)})}]
+                                        children))))

--- a/src/status_im/ui/components/swipeable/views.cljs
+++ b/src/status_im/ui/components/swipeable/views.cljs
@@ -1,27 +1,38 @@
 (ns status-im.ui.components.swipeable.views
   (:require [status-im.ui.components.swipeable.style :as styles]
             [status-im.i18n.i18n :as i18n]
+            [status-im.utils.utils :as utils]
             [reagent.core :as reagent]
             [quo.core :as quo]
             [quo.gesture-handler :as gesture-handler]
             [quo.react-native :as rn]))
 
+(defn- show-delete-confirmation [on-accept on-cancel]
+  (utils/show-confirmation {:title               (i18n/label :t/delete-chat)
+                            :content             (i18n/label :t/delete-chat-confirmation)
+                            :confirm-button-text (i18n/label :t/delete)
+                            :cancel-button-text  (i18n/label :t/cancel)
+                            :on-accept           on-accept
+                            :on-cancel           on-cancel}))
+
+(defn- on-swipe-to-delete [on-delete swipeable-ref]
+  (let [close (goog.object/getValueByKeys swipeable-ref #js ["close"])
+        dismiss-fn #(close)
+        accept-fn on-delete]
+    #(show-delete-confirmation accept-fn dismiss-fn)))
+
 (defn- delete-action
   [{:keys [on-press]}]
   (reagent/as-element [rn/touchable-opacity {:style (styles/delete-action-container)
-                                            :on-press on-press}
-                                            [quo/text {:weight :bold
-                                                      :size :large
-                                                      :color :inverse} (i18n/label :t/delete)]]))
-
-(defn on-swipe-to-delete [on-delete swipeable-ref]
-  (let [close (goog.object/getValueByKeys swipeable-ref #js ["close"])]
-    (fn [] (close) (on-delete))))
+                                             :on-press on-press}
+                       [quo/text {:weight :bold
+                                  :size :large
+                                  :color :inverse} (i18n/label :t/delete)]]))
 
 (defn swipe-to-delete
   [{:keys [on-delete]}]
   (let [this (reagent/current-component) children (reagent/children this) swipe-item (atom nil)]
-    (fn [{:keys [on-delete]}]
+    (fn [{:keys []}]
       (into [gesture-handler/swipeable {:ref swipe-item
                                         :right-actions #(delete-action {:on-press (on-swipe-to-delete on-delete @swipe-item)})}]
-                                        children))))
+            children))))

--- a/src/status_im/ui/screens/home/views/inner_item.cljs
+++ b/src/status_im/ui/screens/home/views/inner_item.cljs
@@ -7,6 +7,7 @@
             [status-im.ui.components.colors :as colors]
             [status-im.ui.components.chat-icon.screen :as chat-icon.screen]
             [quo.core :as quo]
+            [quo.react-native :as rn]
             [status-im.ui.components.react :as react]
             [status-im.ui.screens.home.styles :as styles]
             [status-im.ui.components.icons.icons :as icons]
@@ -170,23 +171,23 @@
 (defn home-list-item [home-item opts]
   (let [{:keys [chat-id chat-name color group-chat public? timestamp last-message muted]} home-item]
     [swipe-to-delete {:on-delete #(re-frame/dispatch [:home-list-swipe-to-delete-chat chat-id])}
-      [react/touchable-opacity (merge {:style {:height 64}} opts)
-      [:<>
-        [chat-item-icon muted (and group-chat (not public?)) (and group-chat public?)]
-        [chat-icon.screen/chat-icon-view chat-id group-chat chat-name
-        {:container              (assoc chat-icon.styles/container-chat-list
-                                        :top 12 :left 16 :position :absolute)
-          :size                   40
-          :chat-icon              chat-icon.styles/chat-icon-chat-list
-          :default-chat-icon      (chat-icon.styles/default-chat-icon-chat-list color)
-          :default-chat-icon-text (chat-icon.styles/default-chat-icon-text 40)}]
-        [chat-item-title chat-id muted group-chat chat-name]
-        [react/text {:style               styles/datetime-text
-                    :number-of-lines     1
-                    :accessibility-label :last-message-time-text}
+     [rn/view {:style {:background-color colors/white}} [react/touchable-opacity (merge {:style {:height 64}} opts)
+                                                         [:<>
+                                                          [chat-item-icon muted (and group-chat (not public?)) (and group-chat public?)]
+                                                          [chat-icon.screen/chat-icon-view chat-id group-chat chat-name
+                                                           {:container              (assoc chat-icon.styles/container-chat-list
+                                                                                           :top 12 :left 16 :position :absolute)
+                                                            :size                   40
+                                                            :chat-icon              chat-icon.styles/chat-icon-chat-list
+                                                            :default-chat-icon      (chat-icon.styles/default-chat-icon-chat-list color)
+                                                            :default-chat-icon-text (chat-icon.styles/default-chat-icon-text 40)}]
+                                                          [chat-item-title chat-id muted group-chat chat-name]
+                                                          [react/text {:style               styles/datetime-text
+                                                                       :number-of-lines     1
+                                                                       :accessibility-label :last-message-time-text}
         ;;TODO (perf) move to event
-        (memo-timestamp (if (pos? (:whisper-timestamp last-message))
-                          (:whisper-timestamp last-message)
-                          timestamp))]
-        [message-content-text (select-keys last-message [:content :content-type :community-id])]
-        [unviewed-indicator home-item]]]]))
+                                                           (memo-timestamp (if (pos? (:whisper-timestamp last-message))
+                                                                             (:whisper-timestamp last-message)
+                                                                             timestamp))]
+                                                          [message-content-text (select-keys last-message [:content :content-type :community-id])]
+                                                          [unviewed-indicator home-item]]]]]))

--- a/src/status_im/ui/screens/home/views/inner_item.cljs
+++ b/src/status_im/ui/screens/home/views/inner_item.cljs
@@ -13,7 +13,8 @@
             [status-im.utils.contenthash :as contenthash]
             [status-im.utils.core :as utils]
             [status-im.utils.datetime :as time]
-            [status-im.ui.components.chat-icon.styles :as chat-icon.styles]))
+            [status-im.ui.components.chat-icon.styles :as chat-icon.styles]
+            [status-im.ui.components.swipeable.views :refer [swipe-to-delete]]))
 
 (defn mention-element [from]
   @(re-frame/subscribe [:contacts/contact-name-by-identity from]))
@@ -168,23 +169,24 @@
 
 (defn home-list-item [home-item opts]
   (let [{:keys [chat-id chat-name color group-chat public? timestamp last-message muted]} home-item]
-    [react/touchable-opacity (merge {:style {:height 64}} opts)
-     [:<>
-      [chat-item-icon muted (and group-chat (not public?)) (and group-chat public?)]
-      [chat-icon.screen/chat-icon-view chat-id group-chat chat-name
-       {:container              (assoc chat-icon.styles/container-chat-list
-                                       :top 12 :left 16 :position :absolute)
-        :size                   40
-        :chat-icon              chat-icon.styles/chat-icon-chat-list
-        :default-chat-icon      (chat-icon.styles/default-chat-icon-chat-list color)
-        :default-chat-icon-text (chat-icon.styles/default-chat-icon-text 40)}]
-      [chat-item-title chat-id muted group-chat chat-name]
-      [react/text {:style               styles/datetime-text
-                   :number-of-lines     1
-                   :accessibility-label :last-message-time-text}
-       ;;TODO (perf) move to event
-       (memo-timestamp (if (pos? (:whisper-timestamp last-message))
-                         (:whisper-timestamp last-message)
-                         timestamp))]
-      [message-content-text (select-keys last-message [:content :content-type :community-id])]
-      [unviewed-indicator home-item]]]))
+    [swipe-to-delete {:on-delete #(re-frame/dispatch [:home-list-swipe-to-delete-chat chat-id])}
+      [react/touchable-opacity (merge {:style {:height 64}} opts)
+      [:<>
+        [chat-item-icon muted (and group-chat (not public?)) (and group-chat public?)]
+        [chat-icon.screen/chat-icon-view chat-id group-chat chat-name
+        {:container              (assoc chat-icon.styles/container-chat-list
+                                        :top 12 :left 16 :position :absolute)
+          :size                   40
+          :chat-icon              chat-icon.styles/chat-icon-chat-list
+          :default-chat-icon      (chat-icon.styles/default-chat-icon-chat-list color)
+          :default-chat-icon-text (chat-icon.styles/default-chat-icon-text 40)}]
+        [chat-item-title chat-id muted group-chat chat-name]
+        [react/text {:style               styles/datetime-text
+                    :number-of-lines     1
+                    :accessibility-label :last-message-time-text}
+        ;;TODO (perf) move to event
+        (memo-timestamp (if (pos? (:whisper-timestamp last-message))
+                          (:whisper-timestamp last-message)
+                          timestamp))]
+        [message-content-text (select-keys last-message [:content :content-type :community-id])]
+        [unviewed-indicator home-item]]]]))


### PR DESCRIPTION
fixes #11767
fixes: #12433

### Summary

[comment]: # (Summarise the problem and how the pull request solves it)
Implement swipe-to-delete gesture in chat view by creating a generic `swipeable` gesture handler component.

#### Platforms

- Android
- iOS

### Steps to test

- Open Status
- Sign in to your account
- Send a message in any of the chat channels
- In the home view, swipe (from the right) to remove a chat from the list

status: ready