### PR TITLE
always start PIN/PUK/Pairing change with PIN prompt

### DIFF
--- a/src/status_im/keycard/change_pin.cljs
+++ b/src/status_im/keycard/change_pin.cljs
@@ -5,32 +5,27 @@
             [status-im.utils.fx :as fx]
             [taoensso.timbre :as log]
             [status-im.keycard.common :as common]
-            [status-im.utils.security :as security]
-            [status-im.keycard.login :as keycard.login]))
+            [status-im.utils.security :as security]))
 
 (fx/defn change-credentials-pressed
   {:events [:keycard-settings.ui/change-credentials-pressed]}
   [{:keys [db] :as cofx} changing]
-  (let [pin-retry-counter (get-in db [:keycard :application-info :pin-retry-counter])
-        enter-step (if (zero? pin-retry-counter) :puk :current)]
-    (if (= enter-step :puk)
-      (keycard.login/reset-pin cofx)
-      (fx/merge cofx
-                {:db
-                 (assoc-in db [:keycard :pin] {:enter-step       enter-step
-                                               :current          []
-                                               :puk              []
-                                               :original         []
-                                               :confirmation     []
-                                               :puk-original     []
-                                               :puk-confirmation []
-                                               :status           nil
-                                               :error-label      nil
-                                               :on-verified      (case changing
-                                                                   :pin     :keycard/proceed-to-change-pin
-                                                                   :puk     :keycard/proceed-to-change-puk
-                                                                   :pairing :keycard/proceed-to-change-pairing)})}
-                (common/navigate-to-enter-pin-screen)))))
+  (fx/merge cofx
+            {:db
+             (assoc-in db [:keycard :pin] {:enter-step       :current
+                                           :current          []
+                                           :puk              []
+                                           :original         []
+                                           :confirmation     []
+                                           :puk-original     []
+                                           :puk-confirmation []
+                                           :status           nil
+                                           :error-label      nil
+                                           :on-verified      (case changing
+                                                               :pin     :keycard/proceed-to-change-pin
+                                                               :puk     :keycard/proceed-to-change-puk
+                                                               :pairing :keycard/proceed-to-change-pairing)})}
+            (common/navigate-to-enter-pin-screen)))
 
 (fx/defn proceed-to-change-pin
   {:events [:keycard/proceed-to-change-pin]}

--- a/src/status_im/keycard/delete_key.cljs
+++ b/src/status_im/keycard/delete_key.cljs
@@ -31,16 +31,14 @@
 (fx/defn proceed-to-reset-card
   {:events [:keycard/proceed-to-reset-card]}
   [{:keys [db] :as cofx} keep-keys-on-keycard?]
-  (let [pin-retry-counter (get-in db [:keycard :application-info :pin-retry-counter])
-        enter-step (if (zero? pin-retry-counter) :puk :current)]
-    (fx/merge cofx
-              {:db (assoc-in db [:keycard :pin] {:enter-step  enter-step
-                                                 :current     []
-                                                 :puk         []
-                                                 :status      nil
-                                                 :error-label nil
-                                                 :on-verified (if keep-keys-on-keycard?
-                                                                :keycard/unpair-and-delete
-                                                                :keycard/remove-key-with-unpair)})}
-              (common/set-on-card-connected :keycard/navigate-to-enter-pin-screen)
-              (common/navigate-to-enter-pin-screen))))
+  (fx/merge cofx
+            {:db (assoc-in db [:keycard :pin] {:enter-step  :current
+                                               :current     []
+                                               :puk         []
+                                               :status      nil
+                                               :error-label nil
+                                               :on-verified (if keep-keys-on-keycard?
+                                                              :keycard/unpair-and-delete
+                                                              :keycard/remove-key-with-unpair)})}
+            (common/set-on-card-connected :keycard/navigate-to-enter-pin-screen)
+            (common/navigate-to-enter-pin-screen)))

--- a/src/status_im/keycard/unpair.cljs
+++ b/src/status_im/keycard/unpair.cljs
@@ -21,16 +21,14 @@
 (fx/defn unpair-card-confirmed
   {:events [:keycard-settings.ui/unpair-card-confirmed]}
   [{:keys [db] :as cofx}]
-  (let [pin-retry-counter (get-in db [:keycard :application-info :pin-retry-counter])
-        enter-step (if (zero? pin-retry-counter) :puk :current)]
-    (fx/merge cofx
-              {:db (assoc-in db [:keycard :pin] {:enter-step  enter-step
-                                                 :current     []
-                                                 :puk         []
-                                                 :status      nil
-                                                 :error-label nil
-                                                 :on-verified :keycard/unpair})}
-              (common/navigate-to-enter-pin-screen))))
+  (fx/merge cofx
+            {:db (assoc-in db [:keycard :pin] {:enter-step  :current
+                                               :current     []
+                                               :puk         []
+                                               :status      nil
+                                               :error-label nil
+                                               :on-verified :keycard/unpair})}
+            (common/navigate-to-enter-pin-screen)))
 
 (fx/defn unpair
   {:events [:keycard/unpair]}

--- a/src/status_im/ui/screens/keycard/pin/views.cljs
+++ b/src/status_im/ui/screens/keycard/pin/views.cljs
@@ -242,33 +242,29 @@
           ;; properly rewritten so that different instances of pin-view do not
           ;; mess with state unrelated to them.
           step (or step :current)]
-      (if (zero? pin-retry-counter)
-        [pin-view {:pin               pin
-                   :retry-counter     (when (< puk-retry-counter puk-retries) puk-retry-counter)
-                   :title-label       :t/enter-puk-code
-                   :description-label :t/enter-puk-code-description
-                   :step              step
-                   :status            status
-                   :error-label       error-label}]
-        [pin-view {:pin               pin
-                   :retry-counter     (when (< pin-retry-counter pin-retries) pin-retry-counter)
-                   :title-label       (case step
-                                        :current             :t/current-pin
-                                        :login               :t/current-pin
-                                        :import-multiaccount :t/current-pin
-                                        :original            :t/create-a-pin
-                                        :confirmation        :t/repeat-pin
-                                        :puk-original        :t/create-a-puk
-                                        :puk-confirmation    :t/repeat-puk
-                                        :t/current-pin)
-                   :description-label (case step
-                                        :current             :t/current-pin-description
-                                        :sign                :t/current-pin-description
-                                        :import-multiaccount :t/current-pin-description
-                                        :login               :t/login-pin-description
-                                        :puk-original        :t/new-puk-description
-                                        :puk-confirmation    :t/new-puk-description
-                                        :t/new-pin-description)
-                   :step              step
-                   :status            status
-                   :error-label       error-label}]))))
+      [pin-view {:pin               pin
+                 :retry-counter     (if (= step :puk)
+                                      (when (< puk-retry-counter puk-retries) puk-retry-counter)
+                                      (when (< pin-retry-counter pin-retries) pin-retry-counter))
+                 :title-label       (case step
+                                      :current             :t/current-pin
+                                      :login               :t/current-pin
+                                      :import-multiaccount :t/current-pin
+                                      :original            :t/create-a-pin
+                                      :confirmation        :t/repeat-pin
+                                      :puk                 :t/enter-puk-code
+                                      :puk-original        :t/create-a-puk
+                                      :puk-confirmation    :t/repeat-puk
+                                      :t/current-pin)
+                 :description-label (case step
+                                      :current             :t/current-pin-description
+                                      :sign                :t/current-pin-description
+                                      :import-multiaccount :t/current-pin-description
+                                      :login               :t/login-pin-description
+                                      :puk                 :t/enter-puk-code-description
+                                      :puk-original        :t/new-puk-description
+                                      :puk-confirmation    :t/new-puk-description
+                                      :t/new-pin-description)
+                 :step              step
+                 :status            status
+                 :error-label       error-label}])))


### PR DESCRIPTION
Fixes #12328.

when opening the change PIN/PUK/Pairing screen you should always get prompted for the current PIN, since we don't know if the card you will tap is blocked or not (we have backup cards so the previously tapped card state is not enough info).