### PR TITLE
clear notifications on message read

### DIFF
--- a/modules/react-native-status/android/src/main/java/im/status/ethereum/pushnotifications/PushNotification.java
+++ b/modules/react-native-status/android/src/main/java/im/status/ethereum/pushnotifications/PushNotification.java
@@ -118,6 +118,13 @@ public class PushNotification extends ReactContextBaseJavaModule implements Acti
     }
 
     @ReactMethod
+    public void clearMessageNotifications(String conversationId) {
+        if (this.started) {
+            pushNotificationHelper.clearMessageNotifications(conversationId);
+        }
+    }
+
+    @ReactMethod
     public void enableNotifications() {
         this.started = true;
         this.pushNotificationHelper.start();

--- a/modules/react-native-status/android/src/main/java/im/status/ethereum/pushnotifications/PushNotificationHelper.java
+++ b/modules/react-native-status/android/src/main/java/im/status/ethereum/pushnotifications/PushNotificationHelper.java
@@ -119,13 +119,9 @@ public class PushNotificationHelper {
                         context.startActivity(getOpenAppIntent(deepLink));
                     }
                     if (groupId != null) {
-                      removeGroup(groupId);
-                      // clean up the group notifications when there is no
-                      // more unread chats
-                      if (messageGroups.size() == 0) {
-                          notificationManager.cancelAll();
-                      }}
+                        cleanGroup(groupId);
                     }
+                }
                 if (intent.getAction() == ACTION_TAP_STOP) {
                     stop();
                     System.exit(0);
@@ -188,6 +184,11 @@ public class PushNotificationHelper {
         } else {
             this.addStatusMessage(bundle);
         }
+    }
+
+    public void clearMessageNotifications(String conversationId) {
+        notificationManager.cancel(conversationId.hashCode());
+        cleanGroup(conversationId);
     }
 
     public void sendToNotificationCentreWithPicture(final Bundle bundle, Bitmap largeIconBitmap, Bitmap bigPictureBitmap) {
@@ -821,6 +822,13 @@ public class PushNotificationHelper {
 
     private void removeGroup(String groupId) {
         this.messageGroups.remove(groupId);
+    }
+
+    private void cleanGroup(String groupId) {
+        removeGroup(groupId);
+        if (messageGroups.size() == 0) {
+            notificationManager.cancelAll();
+        }
     }
 
     public void start() {

--- a/src/status_im/chat/models/loading.cljs
+++ b/src/status_im/chat/models/loading.cljs
@@ -65,7 +65,8 @@
 (fx/defn handle-mark-all-read
   {:events [:chat.ui/mark-all-read-pressed :chat/mark-all-as-read]}
   [_ chat-id]
-  {::json-rpc/call [{:method     (json-rpc/call-ext-method "markAllRead")
+  {:clear-message-notifications chat-id
+   ::json-rpc/call [{:method     (json-rpc/call-ext-method "markAllRead")
                      :params     [chat-id]
                      :on-success #(re-frame/dispatch [::mark-all-read-successful chat-id])}]})
 

--- a/src/status_im/chat/models/message.cljs
+++ b/src/status_im/chat/models/message.cljs
@@ -129,8 +129,8 @@
     {:db db
      :utils/dispatch-later
      (concat [{:ms 20 :dispatch [:process-response response-js]}]
-             (when-let [chat-id (:current-chat-id db)]
-               [{:ms 100 :dispatch [:chat/mark-all-as-read chat-id]}])
+             (when (and (:current-chat-id db) (= "active" (:app-state db)))
+               [{:ms 100 :dispatch [:chat/mark-all-as-read (:current-chat-id db)]}])
              (when (seq senders)
                [{:ms 100 :dispatch [:chat/add-senders-to-chat-users (vals senders)]}]))}))
 

--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -146,6 +146,8 @@
               (mailserver/process-next-messages-request)
               (wallet/restart-wallet-service-after-background app-in-background-since)
               (universal-links/process-stored-event)
+              #(when-let [chat-id (:current-chat-id db)]
+                 {:dispatch [:chat/mark-all-as-read chat-id]})
               #(when requires-bio-auth
                  (biometric/authenticate % on-biometric-auth-result authentication-options)))))
 

--- a/src/status_im/notifications/android.cljs
+++ b/src/status_im/notifications/android.cljs
@@ -10,6 +10,9 @@
 (defn present-local-notification [opts]
   (.presentLocalNotification ^js (pn-android) (clj->js opts)))
 
+(defn clear-message-notifications [chat-id]
+  (.clearMessageNotifications ^js (pn-android) chat-id))
+
 (defn create-channel [{:keys [channel-id channel-name]}]
   (.createChannel ^js (pn-android)
                   #js {:channelId   channel-id

--- a/src/status_im/notifications/core.cljs
+++ b/src/status_im/notifications/core.cljs
@@ -86,6 +86,12 @@
      (pn-android/disable-notifications)
      (.abandonPermissions ^js pn-ios))))
 
+(re-frame/reg-fx
+ :clear-message-notifications
+ (fn [chat-id]
+   (when platform/android?
+     (pn-android/clear-message-notifications chat-id))))
+
 (fx/defn handle-enable-notifications-event
   {:events [::registered-for-push-notifications]}
   [cofx token]


### PR DESCRIPTION
Fixes #11001. Also, now received messages are marked as read only when the app is in foreground or comes back from background with a chat open.