### PR TITLE
[#11760] Allow copying and pasting of images in chat's input

### DIFF
--- a/android/app/src/main/java/im/status/ethereum/MainApplication.java
+++ b/android/app/src/main/java/im/status/ethereum/MainApplication.java
@@ -21,6 +21,7 @@ import java.util.List;
 import im.status.ethereum.keycard.RNStatusKeycardPackage;
 import im.status.ethereum.module.StatusPackage;
 import im.status.ethereum.pushnotifications.PushNotificationPackage;
+import im.status.ethereum.rnclipboard.ClipboardAndroidPackage;
 
 public class MainApplication extends NavigationApplication {
 
@@ -39,6 +40,7 @@ public class MainApplication extends NavigationApplication {
             packages.add(new ReactNativeDialogsPackage());
             packages.add(new RNStatusKeycardPackage());
             packages.add(new PushNotificationPackage());
+            packages.add(new ClipboardAndroidPackage());
             return packages;
         }
 
@@ -90,4 +92,6 @@ public class MainApplication extends NavigationApplication {
             }
         }
     }
+
+    
 }

--- a/android/app/src/main/java/im/status/ethereum/rnclipboard/ClipboardAndroid.java
+++ b/android/app/src/main/java/im/status/ethereum/rnclipboard/ClipboardAndroid.java
@@ -1,0 +1,112 @@
+package im.status.ethereum.rnclipboard;
+import android.content.ClipData;
+import android.content.ClipDescription;
+import android.content.ClipboardManager;
+import android.content.ContentResolver;
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.net.Uri;
+import android.provider.MediaStore;
+import android.util.Base64;
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.Callback;
+
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+
+public class ClipboardAndroid extends ReactContextBaseJavaModule {
+    ReactApplicationContext mContext;
+    private ContentResolver cr;
+
+    ClipboardAndroid(ReactApplicationContext context){
+            super(context);
+            this.mContext = context;
+            this.cr = context.getContentResolver();
+    }
+
+    
+    /*
+    * Get clipboard objects and pass data to javascript callback to be called in React Native
+    */
+    @ReactMethod
+    public void pasteEvent(Callback cb){
+        ClipboardManager clipboardManager = (ClipboardManager) mContext.getSystemService(Context.CLIPBOARD_SERVICE);
+        if (!(clipboardManager.hasPrimaryClip())){
+            cb.invoke(null);
+        }
+        else if (clipboardManager.getPrimaryClipDescription().hasMimeType(ClipDescription.MIMETYPE_TEXT_PLAIN)){
+            pasteString(clipboardManager.getPrimaryClip().getItemAt(0), cb);
+        }
+        else {
+            pasteImage(clipboardManager.getPrimaryClip(), cb);
+        }
+    }
+
+    @ReactMethod
+    public void copyText(String copyString){
+        ClipboardManager clipboard = (ClipboardManager)
+                mContext.getSystemService(Context.CLIPBOARD_SERVICE);
+        ClipData clip = ClipData.newPlainText("simple text", copyString);
+        clipboard.setPrimaryClip(clip);
+    }
+
+    private void pasteString(ClipData.Item dataItem, Callback dataCall){
+        String pasteString = (String) dataItem.getText();
+        if (pasteString != null){
+            dataCall.invoke(pasteString);
+        }
+    }
+
+    private void pasteImage(ClipData clipData, Callback cb){
+        Log.i(mContext.getApplicationInfo().packageName, "the paste is called");
+        if(clipData != null){
+            ClipData.Item item = clipData.getItemAt(0);
+            Uri pasteUri = item.getUri();
+            if (pasteUri != null){
+                String mimeType = cr.getType(pasteUri);
+                if (mimeType != null){
+                    Log.i(mContext.getApplicationInfo().packageName, "mimetype is " + mimeType);
+                    if (mimeType.equals("image/jpeg") || mimeType.equals("image/png") || mimeType.equals("image/jpg")){
+                        String imgPath = pasteUri.getPath();
+                        try {
+                            Bitmap bitmap = MediaStore.Images.Media.getBitmap(cr, pasteUri);
+                            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+                            if (mimeType.equals("image/jpeg") || mimeType.equals("image/jpg")){
+                                bitmap.compress(Bitmap.CompressFormat.JPEG, 100, outputStream);
+                            }
+                            if (mimeType.equals("image/png")){
+                                bitmap.compress(Bitmap.CompressFormat.PNG, 100, outputStream);
+                            }
+                            byte[] byteArray = outputStream.toByteArray();
+                            String encodedString = Base64.encodeToString(byteArray, Base64.DEFAULT);
+                            StringBuilder builder = new StringBuilder("data:" + mimeType + ";base64,").append(encodedString);
+                            cb.invoke(builder.toString());
+                            Log.i(mContext.getApplicationInfo().packageName, "the image string " + encodedString);
+                        } catch (IOException e) {
+                            e.printStackTrace();
+                            Log.e(mContext.getApplicationInfo().packageName, e.getLocalizedMessage());
+                        }
+                        Log.i(mContext.getApplicationInfo().packageName, "the paste is path " + imgPath);
+                    }
+
+                }
+            }
+        }
+    }
+
+    @NonNull
+    @Override
+    public String getName() {
+        return "ClipboardAndroid";
+    }
+}

--- a/android/app/src/main/java/im/status/ethereum/rnclipboard/ClipboardAndroidPackage.java
+++ b/android/app/src/main/java/im/status/ethereum/rnclipboard/ClipboardAndroidPackage.java
@@ -1,0 +1,29 @@
+package im.status.ethereum.rnclipboard;
+
+import androidx.annotation.NonNull;
+
+import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.uimanager.ViewManager;
+
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class ClipboardAndroidPackage implements ReactPackage {
+    @NonNull
+    @Override
+    public List<NativeModule> createNativeModules(@NonNull ReactApplicationContext reactContext) {
+        List<NativeModule> modules = new ArrayList<>();
+        modules.add(new ClipboardAndroid(reactContext));
+        return modules;
+    }
+
+    @NonNull
+    @Override
+    public List<ViewManager> createViewManagers(@NonNull ReactApplicationContext reactContext) {
+        return Collections.emptyList();
+    }
+}

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -205,6 +205,8 @@ PODS:
     - react-native-config/App (= 1.4.2)
   - react-native-config/App (1.4.2):
     - React-Core
+  - react-native-context-menu-view (1.2.1):
+    - React
   - react-native-image-resizer (1.2.3):
     - React
   - react-native-mail (4.0.0):
@@ -301,8 +303,8 @@ PODS:
     - React-RCTText
   - RNCAsyncStorage (1.11.0):
     - React
-  - RNCClipboard (1.2.2):
-    - React
+  - RNCClipboard (1.8.4):
+    - React-Core
   - RNCMaskedView (0.1.9):
     - React
   - RNCPushNotificationIOS (1.4.1):
@@ -401,6 +403,7 @@ DEPENDENCIES:
   - react-native-camera-kit (from `../node_modules/react-native-camera-kit`)
   - "react-native-cameraroll (from `../node_modules/@react-native-community/cameraroll`)"
   - react-native-config (from `../node_modules/react-native-config`)
+  - react-native-context-menu-view (from `../node_modules/react-native-context-menu-view`)
   - react-native-image-resizer (from `../node_modules/react-native-image-resizer`)
   - react-native-mail (from `../node_modules/react-native-mail`)
   - "react-native-netinfo (from `../node_modules/@react-native-community/netinfo`)"
@@ -425,7 +428,7 @@ DEPENDENCIES:
   - ReactNativeDarkMode (from `../node_modules/react-native-dark-mode`)
   - ReactNativeNavigation (from `../node_modules/react-native-navigation`)
   - "RNCAsyncStorage (from `../node_modules/@react-native-community/async-storage`)"
-  - "RNCClipboard (from `../node_modules/@react-native-community/clipboard`)"
+  - "RNCClipboard (from `../node_modules/@react-native-clipboard/clipboard`)"
   - "RNCMaskedView (from `../node_modules/@react-native-community/masked-view`)"
   - "RNCPushNotificationIOS (from `../node_modules/@react-native-community/push-notification-ios`)"
   - RNDeviceInfo (from `../node_modules/react-native-device-info`)
@@ -500,6 +503,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@react-native-community/cameraroll"
   react-native-config:
     :path: "../node_modules/react-native-config"
+  react-native-context-menu-view:
+    :path: "../node_modules/react-native-context-menu-view"
   react-native-image-resizer:
     :path: "../node_modules/react-native-image-resizer"
   react-native-mail:
@@ -549,7 +554,7 @@ EXTERNAL SOURCES:
   RNCAsyncStorage:
     :path: "../node_modules/@react-native-community/async-storage"
   RNCClipboard:
-    :path: "../node_modules/@react-native-community/clipboard"
+    :path: "../node_modules/@react-native-clipboard/clipboard"
   RNCMaskedView:
     :path: "../node_modules/@react-native-community/masked-view"
   RNCPushNotificationIOS:
@@ -619,6 +624,7 @@ SPEC CHECKSUMS:
   react-native-camera-kit: 498a6d111a904834e0824e9073cfadef7303235f
   react-native-cameraroll: ac69828fc43b9dbf92149714fd739577d38e4448
   react-native-config: c98128a72bc2c3a1ca72caec0b021f0fa944aa29
+  react-native-context-menu-view: 314d901eb8d8b3d32c2bcc5c5288045c539fe345
   react-native-image-resizer: 2f1577efa3bc762597681f530c8e8d05ce0ceeb3
   react-native-mail: 7e37dfbe93ff0d4c7df346b738854dbed533e86f
   react-native-netinfo: ddaca8bbb9e6e914b1a23787ccb879bc642931c9
@@ -643,7 +649,7 @@ SPEC CHECKSUMS:
   ReactNativeDarkMode: 0178ffca3b10f6a7c9f49d6f9810232b328fa949
   ReactNativeNavigation: 4c4ca87edc0da4ee818158a62cb6188088454e5c
   RNCAsyncStorage: d059c3ee71738c39834a627476322a5a8cd5bf36
-  RNCClipboard: 8148e21ac347c51fd6cd4b683389094c216bb543
+  RNCClipboard: ddd4d291537f1667209c9c405aaa4307297e252e
   RNCMaskedView: 71fc32d971f03b7f03d6ab6b86b730c4ee64f5b6
   RNCPushNotificationIOS: c145c6253ea016e5efeff604f2720736b4a596f7
   RNDeviceInfo: 9538a884f862fe4aa0d7cead9f34e292d41ba8f6

--- a/nix/nix.conf
+++ b/nix/nix.conf
@@ -1,5 +1,5 @@
 # NOTE: If you are in Asia you might want to add https://nix-cache-cn.status.im/ to extra-substituters
-extra-substituters = https://nix-cache.status.im/
+#extra-substituters = https://nix-cache.status.im/
 substituters = https://cache.nixos.org/
 trusted-public-keys = nix-cache.status.im-1:x/93lOfLU+duPplwMSBR+OlY4+mo+dCN7n0mr4oPwgY= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
 # Some downloads are multiple GB, default is 5 minutes

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "app:android": "react-native run-android"
   },
   "dependencies": {
+    "@react-native-clipboard/clipboard": "^1.8.4",
     "@react-native-community/async-storage": "^1.11.0",
     "@react-native-community/audio-toolkit": "git+https://github.com/tbenr/react-native-audio-toolkit.git#v2.0.3-status-v6",
     "@react-native-community/cameraroll": "git+https://github.com/status-im/react-native-cameraroll.git#v4.0.4-status.0",
@@ -36,6 +37,7 @@
     "react-native-background-timer": "^2.1.1",
     "react-native-camera-kit": "^8.0.4",
     "react-native-config": "git+https://github.com/status-im/react-native-config.git#v1.4.2-status",
+    "react-native-context-menu-view": "^1.2.1",
     "react-native-dark-mode": "^0.2.2",
     "react-native-device-info": "^7.4.0",
     "react-native-dialogs": "^1.0.4",

--- a/src/status_im/ui/components/react.cljs
+++ b/src/status_im/ui/components/react.cljs
@@ -19,6 +19,9 @@
 (def native-modules (.-NativeModules react-native))
 (def clipboard-android (.-ClipboardAndroid native-modules))
 (def device-event-emitter (.-DeviceEventEmitter react-native))
+(def dimens  (.-Dimensions react-native))
+(def screen-width (.(. dimens get "window") -width))
+(def screen-height (.(. dimens get "window") -height))
 
 ;; React Components
 

--- a/src/status_im/ui/screens/chat/components/input.cljs
+++ b/src/status_im/ui/screens/chat/components/input.cljs
@@ -230,9 +230,9 @@
     (when platform/android?
       (re-frame/dispatch [::mentions/calculate-suggestions mentionable-users]))))
 
+;custom context menu
 (defn context-press [event]
   ;(println "wahala-event" (.. event -nativeEvent -name) (.. event -nativeEvent -index))
-  ;;TODO dispatch functions according to event types
   (if (= 0 (.. event -nativeEvent -index))
     (if platform/ios? (react-comps/paste-image-ios) (react-comps/paste-image-and-text-clipboard))
       nil))

--- a/src/status_im/ui/screens/chat/components/style.cljs
+++ b/src/status_im/ui/screens/chat/components/style.cljs
@@ -23,12 +23,11 @@
 (def input-row
   {:flex-direction :row
    :overflow       :hidden
-   :justify-content :space-between
+   :justify-content  :space-between
    :align-items    :flex-end})
 
 (defn text-input-wrapper []
-  (merge {
-          :flex-direction :row
+  (merge {:flex-direction :row
           :align-items    :flex-start
           :flex           1
           :min-height     34
@@ -53,11 +52,11 @@
 
 (defn actions-wrapper [show-send]
   (merge
-   (when show-send
-     {:width 0 :left -88})
-   {:flex-direction :row
-    :padding-left   4
-    :min-height     34}))
+    (when show-send
+      {:width 0 :left -88})
+    {:flex-direction :row
+     :padding-left   4
+     :min-height     34}))
 
 (defn touchable-icon []
   {:padding-horizontal 10

--- a/src/status_im/ui/screens/chat/components/style.cljs
+++ b/src/status_im/ui/screens/chat/components/style.cljs
@@ -23,10 +23,12 @@
 (def input-row
   {:flex-direction :row
    :overflow       :hidden
+   :justify-content :space-between
    :align-items    :flex-end})
 
 (defn text-input-wrapper []
-  (merge {:flex-direction :row
+  (merge {
+          :flex-direction :row
           :align-items    :flex-start
           :flex           1
           :min-height     34

--- a/src/status_im/ui/screens/chat/image/views.cljs
+++ b/src/status_im/ui/screens/chat/image/views.cljs
@@ -93,7 +93,8 @@
           (when first-img
             [image-preview first-img selected true height])
           (when second-img
-            [image-preview second-img selected false height])]))]))
+            [image-preview second-img selected false height])
+          ]))]))
 
 (defview image-view []
   {:component-did-mount

--- a/yarn.lock
+++ b/yarn.lock
@@ -1375,6 +1375,11 @@
     sudo-prompt "^9.0.0"
     wcwidth "^1.0.1"
 
+"@react-native-community/clipboard@^1.2.2":
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/@react-native-community/clipboard/-/clipboard-1.5.1.tgz#32abb3ea2eb91ee3f9c5fb1d32d5783253c9fabe"
+  integrity sha512-AHAmrkLEH5UtPaDiRqoULERHh3oNv7Dgs0bTC0hO5Z2GdNokAMPT5w8ci8aMcRemcwbtdHjxChgtjbeA38GBdA==
+
 "@react-native-community/hooks@^2.5.1":
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/@react-native-community/hooks/-/hooks-2.5.1.tgz#545c76d1a6203532a8e776578bbaaa64bb754cf6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1231,6 +1231,11 @@
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
 
+"@react-native-clipboard/clipboard@^1.8.4":
+  version "1.8.4"
+  resolved "https://registry.yarnpkg.com/@react-native-clipboard/clipboard/-/clipboard-1.8.4.tgz#4bc1fb00643688e489d8220cd635844ab5c066f9"
+  integrity sha512-poFq3RvXzkbXcqoQNssbZ+aNbCRzBFAWkR9QL7u9xNMgsyWZtk7d16JQoaBo8D2E+kKi+/9JOiVQzA5w+9N67w==
+
 "@react-native-community/async-storage@^1.11.0":
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/@react-native-community/async-storage/-/async-storage-1.11.0.tgz#bf81b8813080846f150c67f531987c429b442166"
@@ -1369,11 +1374,6 @@
     strip-ansi "^5.2.0"
     sudo-prompt "^9.0.0"
     wcwidth "^1.0.1"
-
-"@react-native-community/clipboard@^1.2.2":
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/@react-native-community/clipboard/-/clipboard-1.2.2.tgz#956b29df141199fd9ed47e820baf9693f9f50b55"
-  integrity sha512-WJkJSWA/fhuBhHL3rh6UDdB8+AZNMvAHoyo/ERnNxl9KZqruq7K+AIaQQlggEAsIVBIhjKt65fT+Zynj7gF8Cg==
 
 "@react-native-community/hooks@^2.5.1":
   version "2.5.1"
@@ -6596,6 +6596,11 @@ react-native-camera-kit@^8.0.4:
 "react-native-config@git+https://github.com/status-im/react-native-config.git#v1.4.2-status":
   version "1.4.2"
   resolved "git+https://github.com/status-im/react-native-config.git#c3e58d76fed923aaf88eadc5073099fab5ecb346"
+
+react-native-context-menu-view@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/react-native-context-menu-view/-/react-native-context-menu-view-1.2.1.tgz#0faf79127c5242fb852d4ce5cb3c6660c19291db"
+  integrity sha512-p6aslD1mTftJG57RRP2qVHHD/37A6oRN5H90n5UY151cWNfhYx5uCfD6B6Uou0MGuOStMKEWZ6h739AO/pPOOg==
 
 react-native-dark-mode@^0.2.2:
   version "0.2.2"


### PR DESCRIPTION

Feature implementation for #11760 

### Summary

[comment]: # (Summarise the problem and how the pull request solves it)
...


### Review notes
<!-- (Optional. Specify if something in particular should be looked at, or ignored, during review) -->
- A native module to accomplish the feature was written in java(android) in addition to react-native-clipboard's(formerly react-native-community/clipboard) ios paste image features, these functions pass images from the clipboard as base64 strings.
- implementations/styles of the text input are still quite unclear to me so these base64 strings aren't being passed to any functions or components, I have reached out to @cammellos concerning this, hopefully I get a response soon
- a context menu component is wrapped around text-input to provide the text-input options to "paste" image which is quite different from native tooltips/context-menus. Although this custom context-menu is fired on long press of component. Plugging in to native events from actions on native tooltips is still quite unclear on respective iOS and android platforms. Looks like [extending ReactNative's native implementations of the these components is the only way to go to achieve pasting from native tooltips/context-menu. Here's a npm package that successfully extended native implementations to create native tooltips and context menus](https://github.com/Astrocoders/react-native-selectable-text) ,e.g. I tried implementing a subclass for React Native's ReactTextInputManager.java, I was able to implement native context menus but couldn't get the text input view to focus on interactions. There's a [stackoverflow question](https://stackoverflow.com/questions/68794869/how-to-maintain-focus-in-custom-textinput-component-in-react-native-android) I opened concerning that. 
- code written by a newbie to clojure 🙂🙂🙂

### Testing notes
<!-- (Optional) -->

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- 1-1 chats
- public chats
- group chats


### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Copy photo to clipboard 
- Open Status
- Proceed to initiate chat
- Long press on text input and press "paste" button on context menu
- base64 string logged on metro console

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: wip <!-- Can be ready or wip -->
