### PR TITLE
Fix browser history sorting

### DIFF
--- a/src/status_im/subs.cljs
+++ b/src/status_im/subs.cljs
@@ -1433,7 +1433,7 @@
  :browser/browsers-vals
  :<- [:browser/browsers]
  (fn [browsers]
-   (vals browsers)))
+   (reverse (vals browsers))))
 
 (re-frame/reg-sub
  :get-current-browser


### PR DESCRIPTION
fixes #12094 

### Summary

Fixes browser history sorting

#### Platforms

- Android
- iOS

##### Functional

- dapps / app browsing

### Steps to test

- Open Status
- Open browser tabs and navigate through some websites 
- Verify browser history order is correct

status: ready