### PR TITLE
Fix unread indicator in activity center when delete message

### DIFF
--- a/src/status_im/chat/models/message.cljs
+++ b/src/status_im/chat/models/message.cljs
@@ -209,7 +209,8 @@
                              {:db (reduce (fn [acc current]
                                             (update-in acc [:messages (:chatId current)] dissoc (:messageId current)))
                                           db removed-messages)
-                              :dispatch [:get-activity-center-notifications]})]
+                              :dispatch-n [[:get-activity-center-notifications]
+                                           [:get-activity-center-notifications-count]]})]
     (apply fx/merge cofx (conj mark-as-seen-fx remove-messages-fx))))
 
 (comment


### PR DESCRIPTION
fixes #12493

### Summary

Fix unread indicator in activity center when deleting a message previously notified to the user

#### Platforms

- Android
- iOS

##### Functional

- activity center

### Steps to test

- Open Status
- Create group with user A and B
- Mention user B in chat
- Delete message
- Verify unread notification is gone

status: ready