### PR TITLE
Fix show/hide password on Android

### DIFF
--- a/src/status_im/ui/screens/multiaccounts/views.cljs
+++ b/src/status_im/ui/screens/multiaccounts/views.cljs
@@ -64,6 +64,7 @@
    [quo/text-input
     {:show-cancel         false
      :auto-correct        false
+     :keyboard-type       :visible-password
      :placeholder         (i18n/label :t/seed-phrase-placeholder)
      :monospace           true
      :multiline           true

--- a/src/status_im/ui/screens/onboarding/phrase/view.cljs
+++ b/src/status_im/ui/screens/onboarding/phrase/view.cljs
@@ -94,6 +94,7 @@
              :bottom-value        40
              :multiline           true
              :auto-correct        false
+             :keyboard-type       :visible-password
              :monospace           true}]
            [react/view {:align-items :flex-end}
             [react/view {:flex-direction   :row

--- a/src/status_im/ui/screens/profile/seed/views.cljs
+++ b/src/status_im/ui/screens/profile/seed/views.cljs
@@ -104,7 +104,7 @@
                            (i18n/label :t/word-n {:number (inc idx)})]]
       :auto-focus        true
       :auto-correct      false
-      :keyboard-type     "visible-password"
+      :keyboard-type     :visible-password
       :monospace         true
       :on-change-text    #(re-frame/dispatch [:set-in [:my-profile/seed :word] %])
       :on-submit-editing next-handler

--- a/src/status_im/ui/screens/wallet/add_new/views.cljs
+++ b/src/status_im/ui/screens/wallet/add_new/views.cljs
@@ -87,7 +87,7 @@
         :auto-focus          false
         :placeholder         (i18n/label :t/multiaccounts-recover-enter-phrase-title)
         :auto-correct        false
-        :keyboard-type       "visible-password"
+        :keyboard-type       :visible-password
         :multiline           true
         :height              95
         :error               account-error
@@ -104,7 +104,7 @@
         :auto-focus          false
         :placeholder         (i18n/label :t/enter-a-private-key)
         :auto-correct        false
-        :keyboard-type       "visible-password"
+        :keyboard-type       :visible-password
         :error               account-error
         :secure-text-entry   true
         :accessibility-label :add-account-enter-private-key


### PR DESCRIPTION
Fixes #11955.

This PR actually has three parts

- [x] Make the seed phrase entry "visibile-password" on Android, otherwise SwiftKey and similar would record the seed phrase
- [x] Make the password hide/show button work in both directions.
- [x] When the text is password/visibile-password make sure auto correct and autocomplete is disabled

As a side effect of point 2, when the password is shown, the "suggestions" from SwiftKey and probably other keyboard as activated. This is because I had to make a sort of workaround until https://github.com/facebook/react-native/issues/27946 is fixed. Point 3 seems to at least (from my limited testing) avoid that the password is stored by the keyboard.