### PR TITLE
chats list performance

### DIFF
--- a/src/status_im/chat/models_test.cljs
+++ b/src/status_im/chat/models_test.cljs
@@ -50,10 +50,7 @@
         (is (= nil (get-in actual [:db :messages chat-id])))))
     (testing "it sets a deleted-at-clock-value equal to the last message clock-value"
       (let [actual (chat/remove-chat cofx chat-id)]
-        (is (= 10 (get-in actual [:db :chats chat-id :deleted-at-clock-value])))))
-    (testing "it sets the chat as inactive"
-      (let [actual (chat/remove-chat cofx chat-id)]
-        (is (= false (get-in actual [:db :chats chat-id :is-active])))))))
+        (is (= 10 (get-in actual [:db :chats chat-id :deleted-at-clock-value])))))))
 
 (deftest multi-user-chat?
   (let [chat-id "1"]

--- a/src/status_im/data_store/chats.cljs
+++ b/src/status_im/data_store/chats.cljs
@@ -6,43 +6,45 @@
             [status-im.utils.fx :as fx]
             [taoensso.timbre :as log]))
 
-(defn rpc->type [{:keys [chatType name] :as chat}]
+(defn rpc->type [{:keys [chat-type name] :as chat}]
   (cond
-    (or (= constants/public-chat-type chatType)
-        (= constants/profile-chat-type chatType)
-        (= constants/timeline-chat-type chatType)) (assoc chat
-                                                          :chat-name (str "#" name)
-                                                          :public? true
-                                                          :group-chat true
-                                                          :timeline? (= constants/timeline-chat-type chatType))
-    (= constants/community-chat-type chatType) (assoc chat
-                                                      :chat-name name
-                                                      :group-chat true)
-    (= constants/private-group-chat-type chatType) (assoc chat
-                                                          :chat-name name
-                                                          :public? false
-                                                          :group-chat true)
+    (or (= constants/public-chat-type chat-type)
+        (= constants/profile-chat-type chat-type)
+        (= constants/timeline-chat-type chat-type)) (assoc chat
+                                                           :chat-name (str "#" name)
+                                                           :public? true
+                                                           :group-chat true
+                                                           :timeline? (= constants/timeline-chat-type chat-type))
+    (= constants/community-chat-type chat-type) (assoc chat
+                                                       :chat-name name
+                                                       :group-chat true)
+    (= constants/private-group-chat-type chat-type) (assoc chat
+                                                           :chat-name name
+                                                           :public? false
+                                                           :group-chat true)
     :else (assoc chat :public? false :group-chat false)))
 
-(defn- unmarshal-members [{:keys [members chatType] :as chat}]
+(defn members-reducer [acc member]
+  (cond-> acc
+    (:admin member)
+    (update :admins conj (:id member))
+    (:joined member)
+    (update :members-joined conj (:id member))
+    :always
+    (update :contacts conj (:id member))))
+
+(defn- unmarshal-members [{:keys [members chat-type] :as chat}]
   (cond
-    (= constants/public-chat-type chatType) (assoc chat
-                                                   :contacts #{}
-                                                   :admins #{}
-                                                   :members-joined #{})
-    (= constants/private-group-chat-type chatType) (merge chat
-                                                          (reduce (fn [acc member]
-                                                                    (cond-> acc
-                                                                      (:admin member)
-                                                                      (update :admins conj (:id member))
-                                                                      (:joined member)
-                                                                      (update :members-joined conj (:id member))
-                                                                      :always
-                                                                      (update :contacts conj (:id member))))
-                                                                  {:admins #{}
-                                                                   :members-joined #{}
-                                                                   :contacts #{}}
-                                                                  members))
+    (= constants/public-chat-type chat-type) (assoc chat
+                                                    :contacts #{}
+                                                    :admins #{}
+                                                    :members-joined #{})
+    (= constants/private-group-chat-type chat-type) (merge chat
+                                                           (reduce members-reducer
+                                                                   {:admins #{}
+                                                                    :members-joined #{}
+                                                                    :contacts #{}}
+                                                                   members))
     :else
     (assoc chat
            :contacts #{(:id chat)}
@@ -51,8 +53,6 @@
 
 (defn <-rpc [chat]
   (-> chat
-      rpc->type
-      unmarshal-members
       (clojure.set/rename-keys {:id :chat-id
                                 :communityId :community-id
                                 :syncedFrom :synced-from
@@ -63,15 +63,42 @@
                                 :unviewedMessagesCount :unviewed-messages-count
                                 :unviewedMentionsCount :unviewed-mentions-count
                                 :lastMessage :last-message
-                                :active :is-active
                                 :lastClockValue :last-clock-value
                                 :invitationAdmin :invitation-admin
                                 :profile :profile-public-key})
+      rpc->type
+      unmarshal-members
       (update :last-message #(when % (messages/<-rpc %)))
       (dissoc :members)))
 
-(fx/defn fetch-chats-rpc [cofx {:keys [on-success]}]
-  {::json-rpc/call [{:method (json-rpc/call-ext-method "chats")
+(defn <-rpc-js [^js chat]
+  (-> {:name (.-name chat)
+       :description (.-description chat)
+       :color (.-color chat)
+       :timestamp (.-timestamp chat)
+       :alias (.-alias chat)
+       :identicon (.-identicon chat)
+       :muted (.-muted chat)
+       :joined (.-joined chat)
+
+       :chat-id (.-id chat)
+       :community-id (.-communityId chat)
+       :synced-from (.-syncedFrom chat)
+       :synced-to (.-syncedTo chat)
+       :deleted-at-clock-value (.-deletedAtClockValue chat)
+       :chat-type (.-chatType chat)
+       :unviewed-messages-count (.-unviewedMessagesCount chat)
+       :unviewed-mentions-count (.-unviewedMentionsCount chat)
+       :last-message {:content {:text (.-text chat)}
+                      :content-type (.-contentType chat)}
+       :last-clock-value (.-lastClockValue chat)
+       :profile-public-key (.-profile chat)}
+      rpc->type
+      unmarshal-members))
+
+(fx/defn fetch-chats-rpc [_ {:keys [on-success]}]
+  {::json-rpc/call [{:method (json-rpc/call-ext-method "chatsPreview")
                      :params []
-                     :on-success #(on-success (map <-rpc %))
+                     :js-response true
+                     :on-success #(on-success ^js %)
                      :on-failure #(log/error "failed to fetch chats" 0 -1 %)}]})

--- a/src/status_im/data_store/chats_test.cljs
+++ b/src/status_im/data_store/chats_test.cljs
@@ -22,7 +22,6 @@
               :lastClockValue 10
               :membershipUpdateEvents :events
               :unviewedMessagesCount 2
-              :active true
               :timestamp 2}
         expected-chat {:public? false
                        :group-chat true
@@ -37,7 +36,6 @@
                        :name "name"
                        :membership-update-events :events
                        :unviewed-messages-count 2
-                       :is-active true
                        :chat-id "chat-id"
                        :timestamp 2}]
     (testing "from-rpc"

--- a/src/status_im/data_store/contacts.cljs
+++ b/src/status_im/data_store/contacts.cljs
@@ -33,14 +33,14 @@
                                 :nickname :localNickname})))
 
 (fx/defn fetch-contacts-rpc
-  [cofx on-success]
+  [_ on-success]
   {::json-rpc/call [{:method (json-rpc/call-ext-method "contacts")
                      :params []
                      :on-success #(on-success (map <-rpc %))
                      :on-failure #(log/error "failed to fetch contacts" %)}]})
 
 (fx/defn save-contact
-  [cofx {:keys [public-key] :as contact} on-success]
+  [_ {:keys [public-key] :as contact} on-success]
   {::json-rpc/call [{:method (json-rpc/call-ext-method "saveContact")
                      :params [(->rpc contact)]
                      :on-success #(do
@@ -49,7 +49,7 @@
                                       (on-success)))
                      :on-failure #(log/error "failed to save contact" public-key %)}]})
 
-(fx/defn block [cofx contact on-success]
+(fx/defn block [_ contact on-success]
   {::json-rpc/call [{:method (json-rpc/call-ext-method "blockContact")
                      :params [(->rpc contact)]
                      :on-success on-success

--- a/src/status_im/db.cljs
+++ b/src/status_im/db.cljs
@@ -27,6 +27,8 @@
              :chat/cooldown-enabled?             false
              :chat/last-outgoing-message-sent-at 0
              :chat/spam-messages-frequency       0
+             :chats-home-list                    #{}
+             :home-items-show-number             20
              :tooltips                           {}
              :dimensions/window                  (dimensions/window)
              :registry                           {}

--- a/src/status_im/ethereum/json_rpc.cljs
+++ b/src/status_im/ethereum/json_rpc.cljs
@@ -72,8 +72,9 @@
    "wakuext_removeFilters" {}
    "wakuext_sendContactUpdate" {}
    "wakuext_sendContactUpdates" {}
-   "wakuext_chats" {}
+   "wakuext_chatsPreview" {}
    "wakuext_activeChats" {}
+   "wakuext_chat" {}
    "wakuext_addSystemMessages" {}
    "wakuext_deleteMessagesFrom" {}
    "wakuext_deleteMessagesByChatID" {}

--- a/src/status_im/group_chats/core.cljs
+++ b/src/status_im/group_chats/core.cljs
@@ -13,7 +13,7 @@
 (fx/defn navigate-chat-updated
   {:events [:navigate-chat-updated]}
   [cofx chat-id]
-  (when (get-in cofx [:db :chats chat-id :is-active])
+  (when (get-in cofx [:db :chats chat-id])
     (fx/merge cofx
               {:dispatch-later [{:ms 1000 :dispatch [:chat.ui/navigate-to-chat chat-id]}]}
               (navigation/pop-to-root-tab :chat-stack))))
@@ -59,7 +59,7 @@
 
 (fx/defn create-from-link
   [cofx {:keys [chat-id invitation-admin chat-name]}]
-  (if (get-in cofx [:db :chats chat-id :is-active])
+  (if (get-in cofx [:db :chats chat-id])
     {:dispatch-n [[:accept-all-activity-center-notifications-from-chat chat-id]
                   [:chat.ui/navigate-to-chat chat-id false]]}
     {::json-rpc/call [{:method     (json-rpc/call-ext-method "createGroupChatFromInvitation")

--- a/src/status_im/multiaccounts/login/core.cljs
+++ b/src/status_im/multiaccounts/login/core.cljs
@@ -1,7 +1,6 @@
 (ns status-im.multiaccounts.login.core
   (:require [re-frame.core :as re-frame]
             [status-im.anon-metrics.core :as anon-metrics]
-            [status-im.chat.models.loading :as chat.loading]
             [status-im.contact.core :as contact]
             [status-im.utils.config :as config]
             [status-im.data-store.settings :as data-store.settings]
@@ -37,7 +36,8 @@
             [status-im.async-storage.core :as async-storage]
             [status-im.notifications-center.core :as notifications-center]
             [status-im.navigation :as navigation]
-            [status-im.signing.eip1559 :as eip1559]))
+            [status-im.signing.eip1559 :as eip1559]
+            [status-im.data-store.chats :as data-store.chats]))
 
 (re-frame/reg-fx
  ::initialize-communities-enabled
@@ -250,10 +250,19 @@
        (.catch (fn [_]
                  (log/error "Failed to initialize wallet"))))))
 
+(fx/defn initialize-browser [_]
+  {::json-rpc/call
+   [{:method     "browsers_getBrowsers"
+     :on-success #(re-frame/dispatch [::initialize-browsers %])}
+    {:method     "browsers_getBookmarks"
+     :on-success #(re-frame/dispatch [::initialize-bookmarks %])}
+    {:method     "permissions_getDappPermissions"
+     :on-success #(re-frame/dispatch [::initialize-dapp-permissions %])}]})
+
 (fx/defn initialize-appearance [cofx]
   {::multiaccounts/switch-theme (get-in cofx [:db :multiaccount :appearance])})
 
-(fx/defn get-group-chat-invitations [cofx]
+(fx/defn get-group-chat-invitations [_]
   {::json-rpc/call
    [{:method     (json-rpc/call-ext-method "getGroupChatInvitations")
      :on-success #(re-frame/dispatch [::initialize-invitations %])}]})
@@ -279,19 +288,36 @@
 (fx/defn get-settings-callback
   {:events [::get-settings-callback]}
   [{:keys [db] :as cofx} settings]
-  (let [{:keys          [notifications-enabled?]
-         :networks/keys [current-network networks]
+  (let [{:networks/keys [current-network networks]
          :as            settings}
         (data-store.settings/rpc->settings settings)
-        multiaccount (dissoc settings :networks/current-network :networks/networks)
+        multiaccount (dissoc settings :networks/current-network :networks/networks)]
+    (fx/merge cofx
+              {:db (-> db
+                       (dissoc :multiaccounts/login)
+                       (assoc :networks/current-network current-network
+                              :networks/networks networks
+                              :multiaccount multiaccount))}
+              (data-store.chats/fetch-chats-rpc
+               {:on-success
+                #(do (re-frame/dispatch [:chats-list/load-success %])
+                     (re-frame/dispatch [::get-chats-callback settings]))})
+              (acquisition/login)
+              (initialize-appearance)
+              (initialize-communities-enabled)
+              (get-node-config)
+              (communities/fetch)
+              (logging/set-log-level (:log-level multiaccount))
+              (notifications-center/get-activity-center-notifications-count))))
+
+(fx/defn get-chats-callback
+  {:events [::get-chats-callback]}
+  [{:keys [db] :as cofx} settings]
+  (let [{:keys          [notifications-enabled?]
+         :networks/keys [current-network networks]} settings
         network-id   (str (get-in networks [current-network :config :NetworkId]))]
     (fx/merge cofx
-              (cond-> {:db (-> db
-                               (dissoc :multiaccounts/login)
-                               (assoc :networks/current-network current-network
-                                      :networks/networks networks
-                                      :multiaccount multiaccount))
-                       ::eip1559/check-eip1559-activation
+              (cond-> {::eip1559/check-eip1559-activation
                        {:network-id  network-id
                         :on-enabled  #(log/info "eip1550 is activated")
                         :on-disabled #(log/info "eip1559 is not activated")}
@@ -301,24 +327,17 @@
                                              accounts custom-tokens favourites]))}
                 notifications-enabled?
                 (assoc ::notifications/enable nil))
-              (acquisition/login)
-              (initialize-appearance)
               (transport/start-messenger)
-              (initialize-communities-enabled)
               (initialize-transactions-management-enabled)
               (check-network-version network-id)
-              (chat.loading/initialize-chats)
-              (get-node-config)
-              (communities/fetch)
               (contact/initialize-contacts)
               (stickers/init-stickers-packs)
+              (initialize-browser)
               (mobile-network/on-network-status-change)
               (get-group-chat-invitations)
-              (logging/set-log-level (:log-level multiaccount))
               (multiaccounts/get-profile-picture)
               (multiaccounts/switch-preview-privacy-mode-flag)
-              (link-preview/request-link-preview-whitelist)
-              (notifications-center/get-activity-center-notifications-count))))
+              (link-preview/request-link-preview-whitelist))))
 
 (defn get-new-auth-method [auth-method save-password?]
   (when save-password?
@@ -358,13 +377,7 @@
     (fx/merge cofx
               {:db (assoc db :chats/loading? true)
                ::json-rpc/call
-               [{:method     "browsers_getBrowsers"
-                 :on-success #(re-frame/dispatch [::initialize-browsers %])}
-                {:method     "browsers_getBookmarks"
-                 :on-success #(re-frame/dispatch [::initialize-bookmarks %])}
-                {:method     "permissions_getDappPermissions"
-                 :on-success #(re-frame/dispatch [::initialize-dapp-permissions %])}
-                {:method     "settings_getSettings"
+               [{:method     "settings_getSettings"
                  :on-success #(do (re-frame/dispatch [::get-settings-callback %])
                                   (redirect-to-root db))}]}
               (notifications/load-notification-preferences)
@@ -384,7 +397,7 @@
     (fx/merge cofx
               {:db             (-> db
                                    (dissoc :multiaccounts/login)
-                                   (assoc :tos/next-root :onboarding-notification)
+                                   (assoc :tos/next-root :onboarding-notification :chats/loading? false)
                                    (assoc-in [:multiaccount :multiaccounts/first-account] first-account?))
                :dispatch-later [{:ms 2000 :dispatch [::initialize-wallet
                                                      accounts nil nil
@@ -392,8 +405,9 @@
                                                      true]}]}
               (finish-keycard-setup)
               (transport/start-messenger)
-              (chat.loading/initialize-chats)
               (communities/fetch)
+              (data-store.chats/fetch-chats-rpc
+               {:on-success #(re-frame/dispatch [:chats-list/load-success %])})
               (initialize-communities-enabled)
               (multiaccounts/switch-preview-privacy-mode-flag)
               (link-preview/request-link-preview-whitelist)
@@ -406,6 +420,22 @@
 
 (defn- keycard-setup? [cofx]
   (boolean (get-in cofx [:db :keycard :flow])))
+
+(defn on-login-update-db [db login-only? now]
+  (-> db
+      (dissoc :connectivity/ui-status-properties)
+      (update :keycard dissoc :from-key-storage-and-migration?)
+      (update :keycard dissoc
+              :on-card-read
+              :card-read-in-progress?
+              :pin
+              :multiaccount)
+      (assoc :tos-accept-next-root
+             (if login-only?
+               :chat-stack
+               :onboarding-notification))
+      (assoc :logged-in-since now)
+      (assoc :view-id :home)))
 
 (fx/defn multiaccount-login-success
   [{:keys [db now] :as cofx}]
@@ -424,20 +454,7 @@
                "login-only?" login-only?
                "recovered-account?" recovered-account?)
     (fx/merge cofx
-              {:db (-> db
-                       (dissoc :connectivity/ui-status-properties)
-                       (update :keycard dissoc :from-key-storage-and-migration?)
-                       (update :keycard dissoc
-                               :on-card-read
-                               :card-read-in-progress?
-                               :pin
-                               :multiaccount)
-                       (assoc :tos-accept-next-root
-                              (if login-only?
-                                :chat-stack
-                                :onboarding-notification))
-                       (assoc :logged-in-since now)
-                       (assoc :view-id :home))
+              {:db (on-login-update-db db login-only? now)
                ::json-rpc/call
                [{:method     "web3_clientVersion"
                  :on-success #(re-frame/dispatch [::initialize-web3-client-version %])}]}

--- a/src/status_im/multiaccounts/login/data_test.cljs
+++ b/src/status_im/multiaccounts/login/data_test.cljs
@@ -29,7 +29,6 @@
     :membership-updates        ()
     :unviewed-messages-count   0
     :last-message-content-type "text/plain"
-    :is-active                 true
     :last-message-content      {:chat-id "status" :text "darn typos...! "}
     :debug?                    false
     :group-chat                true
@@ -48,7 +47,6 @@
     :membership-updates        ()
     :unviewed-messages-count   0
     :last-message-content-type "text/plain"
-    :is-active                 true
     :last-message-content      {:chat-id "0x04173f7cdea0076a7998abb674cc79fe61337c42db77043c01d5b0f3e3ac1e5a45bca0c93bb9f3c3d38b7cc9a7337cd64f9f9b2114fe4bbdfe1ae2633ba14d8c9c"
                                 :text    "Hey"}
     :debug?                    false
@@ -68,7 +66,6 @@
     :membership-updates        ()
     :unviewed-messages-count   0
     :last-message-content-type "text/plain"
-    :is-active                 true
     :last-message-content      {:chat-id "0x04173f7cdea0076a7998abb674cc79fe61337c42db77043c01d5b0f3e3ac1e5a45bca0c93bb9f3c3d38b7cc9a7337cd64f9f9b2114fe4bbdfe1ae2633ba14d8c9c"
                                 :text    "Djndjd"}
     :debug?                    false

--- a/src/status_im/navigation/roots.cljs
+++ b/src/status_im/navigation/roots.cljs
@@ -68,6 +68,7 @@
      {:id       :tabs-stack
       :options  (merge (default-root)
                        {:bottomTabs {:titleDisplayMode :alwaysHide
+                                     :tabsAttachMode :onSwitchToTab
                                      :backgroundColor  colors/white}})
       :children [;CHAT STACK
                  {:stack {:id       :chat-stack

--- a/src/status_im/ui/components/invite/views.cljs
+++ b/src/status_im/ui/components/invite/views.cljs
@@ -235,11 +235,9 @@
 
 (defn button []
   (if-not @(re-frame/subscribe [::invite.events/enabled])
-    [rn/view {:style {:align-items :center}}
-     [rn/view {:style (:tiny spacing/padding-vertical)}
-      [quo/button {:on-press            #(re-frame/dispatch [::invite.events/share-link nil])
-                   :accessibility-label :invite-friends-button}
-       (i18n/label :t/invite-friends)]]]
+    [quo/button {:on-press            #(re-frame/dispatch [::invite.events/share-link nil])
+                 :accessibility-label :invite-friends-button}
+     (i18n/label :t/invite-friends)]
     (let [pack   @(re-frame/subscribe [::invite.events/default-reward])
           tokens (transform-tokens pack)]
       [rn/view {:style {:align-items        :center

--- a/src/status_im/ui/screens/add_new/new_public_chat/view.cljs
+++ b/src/status_im/ui/screens/add_new/new_public_chat/view.cljs
@@ -35,12 +35,12 @@
     :error               error}])
 
 (defn render-topic [topic]
-  ^{:key topic}
   [react/touchable-highlight {:on-press            #(start-chat topic)
                               :accessibility-label :chat-item}
-   [react/view {:padding-right 8 :padding-vertical 8}
-    [react/view {:border-color colors/gray-lighter :border-radius 36 :border-width 1 :padding-horizontal 8 :padding-vertical 5}
-     [react/text {:style {:color colors/blue :typography :main-medium}} (str "#" topic)]]]])
+   [react/view {:border-color colors/gray-lighter :border-radius 36 :border-width 1 :padding-horizontal 8
+                :padding-vertical 5 :margin-right 8 :margin-vertical 8}
+    [react/text {:style {:color colors/blue :typography :main-medium}}
+     (str "#" topic)]]])
 
 (def lang-names {"es" "status-espanol"
                  "pt" "statusbrasil"

--- a/src/status_im/ui/screens/home/styles.cljs
+++ b/src/status_im/ui/screens/home/styles.cljs
@@ -36,6 +36,7 @@
 
 (def no-chats-text
   {:margin-top        50
+   :margin-bottom     8
    :margin-horizontal 16
    :line-height       22
    :text-align        :center})

--- a/src/status_im/ui/screens/home/views.cljs
+++ b/src/status_im/ui/screens/home/views.cljs
@@ -29,42 +29,40 @@
 
 (defn home-tooltip-view []
   [react/view (styles/chat-tooltip)
-   [react/view {:style {:flex-direction :row}}
-    [react/view {:flex 1}
-     [react/view {:style styles/empty-chats-header-container}
-      [react/view {:style {:width       66 :position :absolute :top -6 :background-color colors/white
-                           :align-items :center}}
-       [react/image {:source (resources/get-image :empty-chats-header)
-                     :style  {:width 50 :height 50}}]]]
-     [react/touchable-highlight
-      {:style               {:position :absolute :right  0  :top         0
-                             :width    44        :height 44 :align-items :center :justify-content :center}
-       :on-press            #(re-frame/dispatch [:multiaccounts.ui/hide-home-tooltip])
-       :accessibility-label :hide-home-button}
-      [icons/icon :main-icons/close-circle {:color colors/gray}]]]]
-   [react/view
-    [react/i18n-text {:style styles/no-chats-text :key :chat-and-transact}]]
+   [react/view {:style {:width       66 :position :absolute :top -6 :background-color colors/white
+                        :align-items :center}}
+    [react/image {:source (resources/get-image :empty-chats-header)
+                  :style  {:width 50 :height 50}}]]
+   [react/touchable-highlight
+    {:style               {:position :absolute :right  0  :top         0
+                           :width    44        :height 44 :align-items :center :justify-content :center}
+     :on-press            #(re-frame/dispatch [:multiaccounts.ui/hide-home-tooltip])
+     :accessibility-label :hide-home-button}
+    [icons/icon :main-icons/close-circle {:color colors/gray}]]
+   [react/i18n-text {:style styles/no-chats-text :key :chat-and-transact}]
    [invite/button]
-   [react/view {:align-items :center}
+   [react/view {:align-items :center :margin-bottom 16}
     [react/view {:style (styles/hr-wrapper)}]
     [react/i18n-text {:style (styles/or-text) :key :or}]]
-   [react/view {:margin-top 16}
-    [react/i18n-text {:style {:margin-horizontal 16
-                              :text-align        :center}
-                      :key   :follow-your-interests}]
-    [react/view {:style styles/tags-wrapper}
-     [react/view {:flex-direction :row :flex-wrap :wrap :justify-content :center}
-      (for [chat (new-public-chat/featured-public-chats)]
-        (new-public-chat/render-topic chat))]]
-    (when @(re-frame/subscribe [:communities/enabled?])
-      [react/view
-       [react/i18n-text {:style {:margin-horizontal 16
-                                 :text-align        :center}
-                         :key   :join-a-community}]
-       [react/view {:style styles/tags-wrapper}
-        [react/view {:flex-direction :row :flex-wrap :wrap :justify-content :center}
-         (for [community communities/featured]
-           (communities.views/render-featured-community community))]]])]])
+   [react/i18n-text {:style {:margin-horizontal 16
+                             :text-align        :center}
+                     :key   :follow-your-interests}]
+   [react/view {:flex-direction :row :flex-wrap :wrap :justify-content :center
+                :margin-top      10
+                :margin-bottom   18}
+    (for [chat (new-public-chat/featured-public-chats)]
+      ^{:key chat}
+      [new-public-chat/render-topic chat])]
+   (when @(re-frame/subscribe [:communities/enabled?])
+     [:<>
+      [react/i18n-text {:style {:margin-horizontal 16
+                                :text-align        :center}
+                        :key   :join-a-community}]
+      [react/view {:flex-direction :row :flex-wrap :wrap :justify-content :center
+                   :margin-top      10
+                   :margin-bottom   18}
+       (for [community communities/featured]
+         [communities.views/render-featured-community community])]])])
 
 (defn welcome-blank-page []
   [react/view {:style {:flex 1 :flex-direction :row :align-items :center :justify-content :center}}
@@ -150,7 +148,7 @@
       [list/flat-list
        {:key-fn                       chat-list-key-fn
         :getItemLayout                get-item-layout
-        :initialNumToRender           5
+        :on-end-reached               #(re-frame/dispatch [:chat.ui/show-more-chats])
         :keyboard-should-persist-taps :always
         :data                         items
         :render-fn                    render-fn

--- a/src/status_im/ui/screens/notifications_center/views.cljs
+++ b/src/status_im/ui/screens/notifications_center/views.cljs
@@ -78,43 +78,44 @@
   (reagent/create-class
    {:display-name "activity-center"
     :component-did-mount #(re-frame/dispatch [:get-activity-center-notifications])
-    :reagent-render (fn []
-                      (let [notifications @(re-frame/subscribe [:activity.center/notifications-grouped-by-date])]
-                        [react/keyboard-avoiding-view {:style {:flex 1}
-                                                       :ignore-offset true}
-                         [topbar/topbar {:navigation {:on-press #(do
-                                                                   (reset-state)
-                                                                   (re-frame/dispatch [:navigate-back]))}
-                                         :title      (i18n/label :t/activity)}]
-                         (if (= (count notifications) 0)
-                           [react/view {:style {:flex 1
-                                                :justify-content :center
-                                                :align-items :center}}
-                            [quo/text {:color :secondary
-                                       :size :large
-                                       :align :center}
-                             (i18n/label :t/empty-activity-center)]]
-                           [:<>
-                            [filter-item]
-                            [list/section-list
-                             {:key-fn                       #(str (:timestamp %) (or (:chat-id %) (:id %)))
-                              :on-end-reached               #(re-frame/dispatch [:load-more-activity-center-notifications])
-                              :keyboard-should-persist-taps :always
-                              :sections                     notifications
-                              :render-fn                    render-fn
-                              :stickySectionHeadersEnabled false
-                              :render-section-header-fn
-                              (fn [{:keys [title]}]
-                                [quo/list-header title])}]
-                            (when (or @select-all (> (count @selected-items) 0))
-                              [toolbar/toolbar
-                               {:show-border? true
-                                :left         [quo/button {:type     :secondary
-                                                           :theme    :negative
-                                                           :accessibility-label :reject-and-delete-activity-center
-                                                           :on-press #(toolbar-action false)}
-                                               (i18n/label :t/reject-and-delete)]
-                                :right        [quo/button {:type     :secondary
-                                                           :accessibility-label :accept-and-add-activity-center
-                                                           :on-press #(toolbar-action true)}
-                                               (i18n/label :t/accept-and-add)]}])])]))}))
+    :reagent-render
+    (fn []
+      (let [notifications @(re-frame/subscribe [:activity.center/notifications-grouped-by-date])]
+        [react/keyboard-avoiding-view {:style {:flex 1}
+                                       :ignore-offset true}
+         [topbar/topbar {:navigation {:on-press #(do
+                                                   (reset-state)
+                                                   (re-frame/dispatch [:navigate-back]))}
+                         :title      (i18n/label :t/activity)}]
+         (if (= (count notifications) 0)
+           [react/view {:style {:flex 1
+                                :justify-content :center
+                                :align-items :center}}
+            [quo/text {:color :secondary
+                       :size :large
+                       :align :center}
+             (i18n/label :t/empty-activity-center)]]
+           [:<>
+            [filter-item]
+            [list/section-list
+             {:key-fn                       #(str (:timestamp %) (or (:chat-id %) (:id %)))
+              :on-end-reached               #(re-frame/dispatch [:load-more-activity-center-notifications])
+              :keyboard-should-persist-taps :always
+              :sections                     notifications
+              :render-fn                    render-fn
+              :stickySectionHeadersEnabled false
+              :render-section-header-fn
+              (fn [{:keys [title]}]
+                [quo/list-header title])}]
+            (when (or @select-all (> (count @selected-items) 0))
+              [toolbar/toolbar
+               {:show-border? true
+                :left         [quo/button {:type     :secondary
+                                           :theme    :negative
+                                           :accessibility-label :reject-and-delete-activity-center
+                                           :on-press #(toolbar-action false)}
+                               (i18n/label :t/reject-and-delete)]
+                :right        [quo/button {:type     :secondary
+                                           :accessibility-label :accept-and-add-activity-center
+                                           :on-press #(toolbar-action true)}
+                               (i18n/label :t/accept-and-add)]}])])]))}))

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.87.0",
-    "commit-sha1": "fb218761d9d1620916ae7e8b19b9b4a03f92c767",
-    "src-sha256": "073qgjfn2cn1li6g4r38xizkifsl4xd1sm51784jmy7kq6gqs1gr"
+    "version": "v0.87.1",
+    "commit-sha1": "59eeed94368c1f0ee9d603e313a13f178e644514",
+    "src-sha256": "1pnyb4vw88nx5b8np0ajhfyjblfkxr8bl40vhilz5gpz1g1a9l3c"
 }

--- a/translations/en.json
+++ b/translations/en.json
@@ -1157,6 +1157,7 @@
     "status-not-sent-click": "Not confirmed. Click for options",
     "step-i-of-n": "Step {{step}} of {{number}}",
     "sticker-market": "Sticker market",
+    "sticker": "Sticker",
     "submit": "Submit",
     "submit-bug": "Submit a bug",
     "success": "Success",


### PR DESCRIPTION
chats list performance

currently, it took 7s to show 1000 chats
1)json is huge
2)json->js is slow (~200ms)
3)js->cljs is slow (~2s)
4)subscriptions are slow, because we reduce all chats few times
5)flatlist is slow 

it's still slow for 1000 chats, but much better
what have been done:
1)decreased json size, by removing group chats data and lastMessage data on go side
2)js->cljs replaced by manually creating of data structures
3)subscriptions improved
4)rendering improved

in this PR it takes ~1-2s to show 1000 chats, which is fine, because it's really rare case, further improvements can be done with JSI