### PR TITLE
Swipe to reply gesture

### DIFF
--- a/src/status_im/ui/screens/chat/components/accessory.cljs
+++ b/src/status_im/ui/screens/chat/components/accessory.cljs
@@ -7,6 +7,8 @@
             [quo.react :as react]
             [quo.platform :as platform]
             [quo.react-native :as rn]
+            [re-frame.core :as re-frame]
+            [status-im.ui.components.animation :as animation]
             [status-im.ui.components.tabbar.core :as tabbar]
             [quo.components.safe-area :refer [use-safe-area]]))
 
@@ -31,6 +33,27 @@
                                                    (js/setTimeout
                                                     #(animated/set-value y 0)
                                                     100))})))))
+
+(defn swipe-pan-responder [translate-x pan-state message]
+  (js->clj (.-panHandlers
+            ^js (.create
+                 ^js rn/pan-responder
+                 #js {:onStartShouldSetPanResponder (fn [] true)
+                      :onPanResponderGrant (fn []
+                                             (animation/set-value pan-state 1))
+                      :onPanResponderMove  (fn [_ ^js state]
+                                             (when (> (.-dx state) 30)
+                                               (animation/set-value translate-x (.-dx state))))
+                      :onPanResponderRelease (fn [_ ^js state]
+                                               (when (> (.-dx state) 100)
+                                                 (re-frame/dispatch [:chat.ui/reply-to-message message])
+                                                 (animation/set-value pan-state 0))
+                                               (js/setTimeout
+                                                #(animation/set-value translate-x 0) 100))
+                      :onPanResponderTerminate (fn []
+                                                 (animation/set-value pan-state 0)
+                                                 (js/setTimeout
+                                                  #(animation/set-value translate-x 0) 100))}))))
 
 (def ios-view
   (reagent/adapt-react-class


### PR DESCRIPTION
[Fixes #12361 ] Swipe-to-reply gesture

### Summary

When a user swipes on a chat message, the reply input will be launched and populated with the message being replied to. 

### Review notes
The animation takes in the following variable translate-x  {:inputRange  [0 1] :outputRange [0 0.5]}  for interpolation along x

To make the difference between just  a simple tap on a chat message and swiping, the distance of the swipe gesture will have to be greater than 30 after which the view is translated along x

The reply-to-message component launches if the distance of x is greater than 100

### Testing notes
This functionality is only on textual chat message. I didn't find images on public chats to test the feature on images.
Testing notes

    Click on any public chat
    Swipe on a text message
    See that the reply input has been populated and the swiped message has a spring animation for visual feedback upon swiping

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS
- macOS
- Linux
- Windows

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- 1-1 chats
- public chats
- group chats
- wallet / transactions
- dapps / app browsing
- account recovery
- new account
- user profile updates
- networks
- mailservers
- fleet
- bootnodes

##### Non-functional

- battery performance
- CPU performance / speed of the app
- network consumption

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open Status
- ...
- Step 3, etc.

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->
