### PR TITLE
Add loading indicator when community is fetching

### DIFF
--- a/src/status_im/communities/core.cljs
+++ b/src/status_im/communities/core.cljs
@@ -81,6 +81,10 @@
                db
                chat-ids)})
 
+(fx/defn handle-community
+  [{:keys [db]} {:keys [id] :as community}]
+  {:db (assoc-in db [:communities id] (<-rpc community))})
+
 (fx/defn handle-communities
   {:events [::fetched]}
   [{:keys [db]} communities]

--- a/src/status_im/subs.cljs
+++ b/src/status_im/subs.cljs
@@ -238,6 +238,7 @@
 (reg-root-key-sub :communities/requests-to-join :communities/requests-to-join)
 (reg-root-key-sub :communities/community-id-input :communities/community-id-input)
 (reg-root-key-sub :communities/enabled? :communities/enabled?)
+(reg-root-key-sub :communities/resolve-community-info :communities/resolve-community-info)
 
 (reg-root-key-sub :activity.center/notifications :activity.center/notifications)
 (reg-root-key-sub :activity.center/notifications-count :activity.center/notifications-count)
@@ -259,6 +260,12 @@
    (if communities-enabled?
      raw-communities
      [])))
+
+(re-frame/reg-sub
+ :communities/fetching-community
+ :<- [:communities/resolve-community-info]
+ (fn [info [_ id]]
+   (get info id)))
 
 (re-frame/reg-sub
  :communities/section-list

--- a/src/status_im/ui/screens/communities/community.cljs
+++ b/src/status_im/ui/screens/communities/community.cljs
@@ -4,11 +4,13 @@
             [status-im.ui.components.toolbar :as toolbar]
             [quo.core :as quo]
             [status-im.constants :as constants]
+            [status-im.chat.models.link-preview :as link-preview]
             [status-im.utils.handlers :refer [>evt <sub]]
             [status-im.i18n.i18n :as i18n]
             [status-im.utils.datetime :as datetime]
             [status-im.communities.core :as communities]
             [status-im.ui.components.list.views :as list]
+            [status-im.ui.components.react :as components.react]
             [status-im.ui.screens.home.views.inner-item :as inner-item]
             [status-im.ui.screens.chat.photos :as photos]
             [status-im.react-native.resources :as resources]
@@ -240,10 +242,18 @@
       :data                         chats
       :render-fn                    channel-preview-item}]))
 
-(defn unknown-community []
-  [rn/view {:style {:flex 1}}
-   [topbar/topbar {:title  (i18n/label :t/not-found)}]
-   [blank-page (i18n/label :t/community-info-not-found)]])
+(defn unknown-community [community-id]
+  (let [fetching (<sub [:communities/fetching-community community-id])]
+    [:<> {:style {:flex 1}}
+     [topbar/topbar {:title  (if fetching (i18n/label :t/fetching-community) (i18n/label :t/not-found))}]
+     [rn/view {:style {:padding 16 :flex 1 :flex-direction :row :align-items :center :justify-content :center}}
+
+      [quo/button {:on-press (when-not fetching #(>evt [::link-preview/resolve-community-info community-id]))
+                   :disabled fetching
+                   :color :secondary}
+       (if fetching
+         [components.react/small-loading-indicator]
+         (i18n/label :t/fetch-community))]]]))
 
 (defn community-edit []
   (let [{:keys [community-id]} (<sub [:get-screen-params])]
@@ -319,4 +329,4 @@
                  :center       [quo/button {:on-press #(>evt [::communities/join id])
                                             :type     :secondary}
                                 (i18n/label :t/follow)]}]))]
-          [unknown-community])))))
+          [unknown-community community-id])))))

--- a/translations/en.json
+++ b/translations/en.json
@@ -1325,6 +1325,8 @@
     "welcome-blank-message": "Your chats will appear here. To start new chats press the ⊕ button",
     "welcome-community-blank-message": "Your chats will appear here. To start new chats click on the 3 dots above and select \"Create a channel\"",
     "welcome-blank-community-message": "Your communities will appear here.",
+    "fetch-community": "Fetch community",
+    "fetching-community": "Fetching community...",
     "seed-phrase-placeholder": "Seed phrase...",
     "word-count": "Word count",
     "word-n": "Word #{{number}}",


### PR DESCRIPTION
This commit adds a loading indicator to communities when is being fetched from the mailserver, also allows a user to fetch a community if for any reason it failed.

### Testing

As soon as you receive a community link, you can click on it, and you end on a page where it should show that is loading. Eventually it will be replaced by either the community, if fetching was successful or the button will be clickable and you will be able to fetch the community again.

For testing the happy path:

1) Post a link to a community in a public chat
2) With a different device, open the chat, as soon as you see the link click on it
3) You should see "Fetching community page..." and eventually it should be replaced by the community preview

For testing fetching a community through the button:
1) Post a link to a community in a public chat
2) With a different device, open the chat, as soon as you see the link, disconnect internet so that it's unable to fetch it
3) Click on the link
4) You should see "Fetching community page..." and eventually the button should become enabled, you can click on it, and the process should restart. Once you go online and you click, you should be able to fetch community info.

status: ready
 