### PR TITLE
Identify New Chats

### DIFF
--- a/src/status_im/chat/models/loading.cljs
+++ b/src/status_im/chat/models/loading.cljs
@@ -61,7 +61,8 @@
   [db chat-id]
   (update-in db [:chats chat-id] assoc
              :unviewed-messages-count 0
-             :unviewed-mentions-count 0))
+             :unviewed-mentions-count 0
+             :highlight false))
 
 (fx/defn handle-mark-all-read-successful
   {:events [::mark-all-read-successful]}

--- a/src/status_im/data_store/chats.cljs
+++ b/src/status_im/data_store/chats.cljs
@@ -93,9 +93,11 @@
        :unviewed-mentions-count (.-unviewedMentionsCount chat)
        :last-message            {:content      {:text        (.-text chat)
                                                 :parsed-text (types/js->clj (.-parsedText chat))}
-                                 :content-type (.-contentType chat)}
+                                 :content-type (.-contentType chat)
+                                 :community-id (.-contentCommunityId chat)}
        :last-clock-value        (.-lastClockValue chat)
-       :profile-public-key      (.-profile chat)}
+       :profile-public-key      (.-profile chat)
+       :highlight               (.-highlight chat)}
       rpc->type
       unmarshal-members))
 

--- a/src/status_im/ui/screens/communities/community.cljs
+++ b/src/status_im/ui/screens/communities/community.cljs
@@ -162,7 +162,7 @@
                                                     [sheets/actions home-item])}])}])
 
 (defn categories-accordion [community-id chats categories edit data]
-  [rn/view {:padding-bottom 8}
+  [:<>
    (for [{:keys [name id]} (vals categories)]
      ^{:key (str "cat" name id)}
      [:<>

--- a/src/status_im/ui/screens/home/views/inner_item.cljs
+++ b/src/status_im/ui/screens/home/views/inner_item.cljs
@@ -14,10 +14,11 @@
             [status-im.utils.datetime :as time]
             [status-im.ui.components.chat-icon.styles :as chat-icon.styles]))
 
-(defn preview-label [label-key]
+(defn preview-label [label-key label-fn]
   [react/text {:style               styles/last-message-text
-               :accessibility-label :no-messages-text}
-   (i18n/label label-key)])
+               :accessibility-label :no-messages-text
+               :number-of-lines     1}
+   (i18n/label label-key label-fn)])
 
 (def max-subheader-length 100)
 
@@ -70,7 +71,11 @@
          parsed-text)]
     (:components result)))
 
-(defn message-content-text [{:keys [content content-type]} absolute]
+(defn content-type-community-invite? [content-type community-id]
+  (and (= constants/content-type-community content-type)
+       (not (string/blank? community-id))))
+
+(defn message-content-text [{:keys [content content-type community-id]} absolute]
   [react/view (when absolute {:position :absolute :left 72 :top 32 :right 80})
    (cond
      (not (and content content-type))
@@ -95,7 +100,12 @@
      [preview-label :t/image]
 
      (= constants/content-type-audio content-type)
-     [preview-label :t/audio])])
+     [preview-label :t/audio]
+
+     (content-type-community-invite? content-type community-id)
+     (let [{:keys [name]}
+           @(re-frame/subscribe [:communities/community community-id])]
+       [preview-label :t/community-message-preview {:community-name name}]))])
 
 (def memo-timestamp
   (memoize
@@ -154,8 +164,9 @@
      (first @(re-frame/subscribe [:contacts/contact-two-names-by-identity chat-id])))])
 
 (defn home-list-item [home-item opts]
-  (let [{:keys [chat-id chat-name color group-chat public? timestamp last-message muted emoji]} home-item]
-    [react/touchable-opacity (merge {:style {:height 64}} opts)
+  (let [{:keys [chat-id chat-name color group-chat public? timestamp last-message muted emoji highlight]} home-item
+        background-color (when highlight (colors/get-color :interactive-02))]
+    [react/touchable-opacity (merge {:style {:height 64 :background-color background-color}} opts)
      [:<>
       [chat-item-icon muted (and group-chat (not public?)) (and group-chat public?)]
       [chat-icon.screen/emoji-chat-icon-view chat-id group-chat chat-name emoji
@@ -175,5 +186,5 @@
        (memo-timestamp (if (pos? (:whisper-timestamp last-message))
                          (:whisper-timestamp last-message)
                          timestamp))]
-      [message-content-text (select-keys last-message [:content :content-type]) true]
+      [message-content-text (select-keys last-message [:content :content-type :community-id]) true]
       [unviewed-indicator home-item]]]))

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.89.13",
-    "commit-sha1": "b79d68c69684f754ea705469c552485905f58e32",
-    "src-sha256": "10h2y9kyahpfns4kfjqzayqfb7fwq94lmncp47snbcrwj03vaanq"
+    "version": "v0.89.14",
+    "commit-sha1": "c20e8ebdeffd14a881d8092ee64e5180ad53449e",
+    "src-sha256": "0jbmgj0m1hv1nx3frbzs7lsn8nqspsir5kpzn8lldfgkfgpv96h7"
 }


### PR DESCRIPTION
fixes #10087
fixes #12650

### Summary
PR implements a feature to identify new chats in the list and also fixes some small design issues
<div align="center">
<img src="https://user-images.githubusercontent.com/17097240/134817218-d784eace-073e-430d-a76a-725ecb19b11e.png" alt="Screenshot" height="400"/>
<img src="https://user-images.githubusercontent.com/17097240/134817227-dd8145d2-84de-420d-a0fe-27635f920ac7.png" alt="Screenshot" height="400"/>
</div>

## status-go PR:
https://github.com/status-im/status-go/pull/2384

## Highlighted Chats: 
* Group Invites
* Community Invites
* New Chat from a contact

## Fixed Issues
This PR also fixes some other issues, which are required for the completion of the feature.
* **Last message overflow**
<img src="https://user-images.githubusercontent.com/17097240/134817488-6cf3a796-ffcd-459c-8142-cc7bfbbb8f4c.png" alt="Screenshot" height="150"/>

* **Gap over community Channels**
This gap is very small usually not much visible. But with highlighted chat, this gap becomes very clear.
<img src="https://user-images.githubusercontent.com/17097240/134817576-735f946d-209c-45df-b6e6-cb4c95d54917.png" alt="Screenshot" height="150"/>

## Design Test Request: 
1. Please don't forget to save contact before testing highlighting for new chat and group invites.
2. Issue: There is a rare case where chat shouldn't be highlighted.
_Step 1._ Chat is old
_Step 2._ The sender sends a community invite
_Step 3._ The receiver **receives** the invite
_Step 4._ The sender deletes the invite
Now highlighting should be removed, but then this will create an issue for new chats. Or we store another variable to store the previous state of highlight variable, which is not worth for this rare case and small issue 🤔

Thanks 🙏