### PR TITLE
add swipe to reply feature

### DIFF
--- a/src/status_im/ui/screens/chat/components/accessory.cljs
+++ b/src/status_im/ui/screens/chat/components/accessory.cljs
@@ -46,6 +46,7 @@
                                                (animation/set-value translate-x (.-dx state))))
                       :onPanResponderRelease (fn [_ ^js state]
                                                (when (> (.-dx state) 100)
+                                              ;;  :dispatch-later [{:ms 25 :dispatch [:chat.ui/reply-to-message message]}]
                                                  (re-frame/dispatch [:chat.ui/reply-to-message message])
                                                  (animation/set-value pan-state 0))
                                                (js/setTimeout

--- a/src/status_im/ui/screens/chat/components/accessory.cljs
+++ b/src/status_im/ui/screens/chat/components/accessory.cljs
@@ -32,6 +32,27 @@
                                                     #(animated/set-value y 0)
                                                     100))})))))
 
+(defn swipe-pan-responder [translate-x pan-state message]
+  (js->clj (.-panHandlers
+            ^js (.create
+                 ^js rn/pan-responder
+                 #js {:onStartShouldSetPanResponder (fn [] true)
+                      :onPanResponderGrant (fn []
+                                             (animation/set-value pan-state 1))
+                      :onPanResponderMove  (fn [_ ^js state]
+                                             (when (> (.-dx state) 30)
+                                               (animation/set-value translate-x (.-dx state))))
+                      :onPanResponderRelease (fn [_ ^js state]
+                                               (when (> (.-dx state) 100)
+                                                 (re-frame/dispatch [:chat.ui/reply-to-message message])
+                                                 (animation/set-value pan-state 0))
+                                               (js/setTimeout
+                                                #(animation/set-value translate-x 0) 100))
+                      :onPanResponderTerminate (fn []
+                                                 (animation/set-value pan-state 0)
+                                                 (js/setTimeout
+                                                  #(animation/set-value translate-x 0) 100))}))))
+                                                  
 (def ios-view
   (reagent/adapt-react-class
    (react/memo

--- a/src/status_im/ui/screens/chat/components/accessory.cljs
+++ b/src/status_im/ui/screens/chat/components/accessory.cljs
@@ -7,6 +7,8 @@
             [quo.react :as react]
             [quo.platform :as platform]
             [quo.react-native :as rn]
+            [re-frame.core :as re-frame]
+            [status-im.ui.components.animation :as animation]
             [status-im.ui.components.tabbar.core :as tabbar]
             [quo.components.safe-area :refer [use-safe-area]]))
 

--- a/src/status_im/ui/screens/chat/components/accessory.cljs
+++ b/src/status_im/ui/screens/chat/components/accessory.cljs
@@ -54,7 +54,7 @@
                                                  (animation/set-value pan-state 0)
                                                  (js/setTimeout
                                                   #(animation/set-value translate-x 0) 100))}))))
-                                                  
+
 (def ios-view
   (reagent/adapt-react-class
    (react/memo

--- a/src/status_im/ui/screens/chat/components/accessory.cljs
+++ b/src/status_im/ui/screens/chat/components/accessory.cljs
@@ -42,7 +42,7 @@
                       :onPanResponderGrant (fn []
                                              (animation/set-value pan-state 1))
                       :onPanResponderMove  (fn [_ ^js state]
-                                             (when (> (.-dx state) 30)
+                                             (when (> (.-dx state) 0.1)
                                                (animation/set-value translate-x (.-dx state))))
                       :onPanResponderRelease (fn [_ ^js state]
                                                (when (> (.-dx state) 100)

--- a/src/status_im/ui/screens/chat/message/message.cljs
+++ b/src/status_im/ui/screens/chat/message/message.cljs
@@ -450,9 +450,8 @@
                      :flex-direction                   :row
                      :align-items                      :center}))
           ;;TODO: Add opacity animation on reply icon.
-           (when-not outgoing
            [react/view {:position :absolute :left -80}
-            [icons/icon :main-icons/reply {:color colors/blue}]])
+            [icons/icon :main-icons/reply {:color colors/blue}]]
 
            [react/view {:style (style/message-view message)}
             [react/view {:style      (style/message-view-content)

--- a/src/status_im/ui/screens/chat/message/message.cljs
+++ b/src/status_im/ui/screens/chat/message/message.cljs
@@ -454,7 +454,7 @@
                    :flex-direction                   :row
                    :align-items                      :center})
           ;;TODO: Add opacity animation on reply icon.
-           [react/view {:position :absolute :left (when-not outgoing -80)}
+           [react/view {:position :absolute :left (when-not outgoing -80) :bottom (when outgoing 0)}
             [icons/icon :main-icons/reply {:color colors/blue}]]
 
            [react/view {:style (style/message-view message)}

--- a/src/status_im/ui/screens/chat/message/message.cljs
+++ b/src/status_im/ui/screens/chat/message/message.cljs
@@ -4,7 +4,6 @@
             [status-im.i18n.i18n :as i18n]
             [status-im.react-native.resources :as resources]
             [quo.design-system.colors :as colors]
-            [quo.animated :as animated]
             [status-im.ui.components.icons.icons :as icons]
             [status-im.ui.components.react :as react]
             [status-im.ui.screens.chat.message.audio :as message.audio]
@@ -449,13 +448,13 @@
             :disabled         in-popover?})
          [react/view {:accessibility-label :swipe-to-reply}
           [react/animated-view
-           (when-not outgoing
-             (merge pan-responder
-                    {:style {:transform [{:translateX translate-x-anim-value}]}
-                     :flex-direction                   :row
-                     :align-items                      :center}))
+          ;;  (when-not outgoing
+           (merge pan-responder
+                  {:style {:transform [{:translateX translate-x-anim-value}]}
+                   :flex-direction                   :row
+                   :align-items                      :center})
           ;;TODO: Add opacity animation on reply icon.
-           [react/view {:position :absolute :left -80}
+           [react/view {:position :absolute :left (when-not outgoing -80)}
             [icons/icon :main-icons/reply {:color colors/blue}]]
 
            [react/view {:style (style/message-view message)}

--- a/src/status_im/ui/screens/chat/message/message.cljs
+++ b/src/status_im/ui/screens/chat/message/message.cljs
@@ -319,6 +319,11 @@
 (def image-max-width 260)
 (def image-max-height 192)
 
+;; start and end values of interpolation method
+(def start 0)
+(def end 1)
+(def outputEnd 0.5)
+
 (defn image-set-size [dimensions]
   (fn [width height]
     (when (< width height)
@@ -330,12 +335,12 @@
 (defn message-content-image
   [{:keys [content outgoing in-popover?] :as message}
    {:keys [on-long-press]}]
-  (let [dimensions (reagent/atom [image-max-width image-max-height])
+  (let [dimensions (reagent/atom [image-max-width image-max-height start end outputEnd])
         visible (reagent/atom false)
         uri (:image content)
         translate-x  (animation/create-value 0)
         pan-state    (animation/create-value 0)
-        translate-x-anim-value (animation/interpolate translate-x {:inputRange  [0 1] :outputRange [0 0.5]})
+        translate-x-anim-value (animation/interpolate translate-x {:inputRange  [start end] :outputRange [start outputEnd]})
         pan-responder (accessory/swipe-pan-responder translate-x pan-state message)]
     (react/image-get-size uri (image-set-size dimensions))
     (fn []
@@ -424,7 +429,7 @@
         collapsible? (reagent/atom false)
         translate-x  (animation/create-value 0)
         pan-state    (animation/create-value 0)
-        translate-x-anim-value (animation/interpolate translate-x {:inputRange  [0 1] :outputRange [0 0.5]})]
+        translate-x-anim-value (animation/interpolate translate-x {:inputRange  [start end] :outputRange [start outputEnd]})]
     (fn [{:keys [content outgoing current-public-key public? pinned in-popover?] :as message} on-long-press modal]
       (let [max-height (when-not (or outgoing modal)
                          (if @collapsible?
@@ -514,7 +519,7 @@
   (let [response-to (:response-to content)
         translate-x  (animation/create-value 0)
         pan-state    (animation/create-value 0)
-        translate-x-anim-value (animation/interpolate translate-x {:inputRange  [0 1] :outputRange [0 0.5]})
+        translate-x-anim-value (animation/interpolate translate-x {:inputRange  [start end] :outputRange [start outputEnd]})
         pan-responder (accessory/swipe-pan-responder translate-x pan-state message)]
     [message-content-wrapper message
      [react/touchable-highlight (when-not modal
@@ -556,7 +561,7 @@
   (let [pack (get-in content [:sticker :pack])
         translate-x  (animation/create-value 0)
         pan-state    (animation/create-value 0)
-        translate-x-anim-value (animation/interpolate translate-x {:inputRange  [0 1] :outputRange [0 0.5]})
+        translate-x-anim-value (animation/interpolate translate-x {:inputRange  [start end] :outputRange [start outputEnd]})
         pan-responder (accessory/swipe-pan-responder translate-x pan-state message)]
     [message-content-wrapper message
      [react/touchable-highlight (when-not modal

--- a/src/status_im/ui/screens/chat/message/message.cljs
+++ b/src/status_im/ui/screens/chat/message/message.cljs
@@ -352,17 +352,17 @@
                                                       (react/dismiss-keyboard!))
                                      :on-long-press on-long-press
                                      :disabled      in-popover?}
-         [react/view
-          [react/animated-view
-           (when-not outgoing
-             (merge pan-responder
-                    {:style {:transform [{:translateX translate-x-anim-value}]}}))
-          [react/view {:style               (style/image-message style-opts)
-                       :accessibility-label :image-message}
-           [react/image {:style       (dissoc style-opts :outgoing)
-                         :resize-mode :cover
-                         :source      {:uri uri}}
-          [react/view {:style (style/image-message-border style-opts)}]]]]]]]))))
+          [react/view
+           [react/animated-view
+            (when-not outgoing
+              (merge pan-responder
+                     {:style {:transform [{:translateX translate-x-anim-value}]}}))
+            [react/view {:style               (style/image-message style-opts)
+                         :accessibility-label :image-message}
+             [react/image {:style       (dissoc style-opts :outgoing)
+                           :resize-mode :cover
+                           :source      {:uri uri}}
+              [react/view {:style (style/image-message-border style-opts)}]]]]]]]))))
 
 (defmulti ->message :content-type)
 
@@ -442,51 +442,52 @@
                                       (js/setTimeout #(on-long-press-fn on-long-press message content) 200))
                                   (on-long-press-fn on-long-press message content)))
             :disabled         in-popover?})
-        [react/view {:accessibility-label :swipe-to-reply}
+         [react/view {:accessibility-label :swipe-to-reply}
           [react/animated-view
            (when-not outgoing
              (merge pan-responder
                     {:style {:transform [{:translateX translate-x-anim-value}]}
-                    :flex-direction                   :row
-                    :align-items                      :center}))
+                     :flex-direction                   :row
+                     :align-items                      :center}))
           ;;TODO: Add opacity animation on reply icon.
-          [react/view {:position :absolute :left -80 }
-            [icons/icon :main-icons/reply {:color colors/blue}]]
+           (when-not outgoing
+           [react/view {:position :absolute :left -80}
+            [icons/icon :main-icons/reply {:color colors/blue}]])
 
-         [react/view {:style (style/message-view message)}
-          [react/view {:style      (style/message-view-content)
-                       :max-height max-height}
-           (let [response-to (:response-to content)]
-             [react/view {:on-layout
-                          #(when (and (> (.-nativeEvent.layout.height ^js %) max-message-height-px)
-                                      (not @collapsible?)
-                                      (not outgoing)
-                                      (not modal))
-                             (reset! collapsed? true)
-                             (reset! collapsible? true))}
-              (when (and (seq response-to) (:quoted-message message))
-                [quoted-message response-to (:quoted-message message) outgoing current-public-key public? pinned])
-              [render-parsed-text-with-timestamp message (:parsed-text content)]])
-           (when-not @collapsed?
-             [message-timestamp message true])
-           (when (and @collapsible? (not modal))
-             (if @collapsed?
-               (let [color (if pinned colors/pin-background (if mentioned colors/mentioned-background colors/blue-light))]
-                 [react/touchable-highlight
-                  {:on-press #(swap! collapsed? not)
-                   :style    {:position :absolute :bottom 0 :left 0 :right 0 :height 72}}
-                  [react/linear-gradient {:colors [(str color "00") color]
-                                          :start  {:x 0 :y 0} :end {:x 0 :y 0.9}}
-                   [react/view {:height         72 :align-self :center :justify-content :flex-end
-                                :padding-bottom 10}
-                    [react/view (style/collapse-button)
-                     [icons/icon :main-icons/dropdown
-                      {:color colors/white}]]]]])
-               [react/touchable-highlight {:on-press #(swap! collapsed? not)
-                                           :style    {:align-self :center :margin 5}}
-                [react/view (style/collapse-button)
-                 [icons/icon :main-icons/dropdown-up
-                  {:color colors/white}]]]))]]]]]))))
+           [react/view {:style (style/message-view message)}
+            [react/view {:style      (style/message-view-content)
+                         :max-height max-height}
+             (let [response-to (:response-to content)]
+               [react/view {:on-layout
+                            #(when (and (> (.-nativeEvent.layout.height ^js %) max-message-height-px)
+                                        (not @collapsible?)
+                                        (not outgoing)
+                                        (not modal))
+                               (reset! collapsed? true)
+                               (reset! collapsible? true))}
+                (when (and (seq response-to) (:quoted-message message))
+                  [quoted-message response-to (:quoted-message message) outgoing current-public-key public? pinned])
+                [render-parsed-text-with-timestamp message (:parsed-text content)]])
+             (when-not @collapsed?
+               [message-timestamp message true])
+             (when (and @collapsible? (not modal))
+               (if @collapsed?
+                 (let [color (if pinned colors/pin-background (if mentioned colors/mentioned-background colors/blue-light))]
+                   [react/touchable-highlight
+                    {:on-press #(swap! collapsed? not)
+                     :style    {:position :absolute :bottom 0 :left 0 :right 0 :height 72}}
+                    [react/linear-gradient {:colors [(str color "00") color]
+                                            :start  {:x 0 :y 0} :end {:x 0 :y 0.9}}
+                     [react/view {:height         72 :align-self :center :justify-content :flex-end
+                                  :padding-bottom 10}
+                      [react/view (style/collapse-button)
+                       [icons/icon :main-icons/dropdown
+                        {:color colors/white}]]]]])
+                 [react/touchable-highlight {:on-press #(swap! collapsed? not)
+                                             :style    {:align-self :center :margin 5}}
+                  [react/view (style/collapse-button)
+                   [icons/icon :main-icons/dropdown-up
+                    {:color colors/white}]]]))]]]]]))))
 
 (defmethod ->message constants/content-type-text
   [message {:keys [on-long-press modal] :as reaction-picker}]
@@ -538,14 +539,14 @@
         (when-not outgoing
           (merge pan-responder
                  {:style {:transform [{:translateX translate-x-anim-value}]}}))
-      [react/view (style/message-view message)
-       [react/view {:style (style/message-view-content)}
-        [react/view {:style (style/style-message-text outgoing)}
-         (when (and (seq response-to) (:quoted-message message))
-           [quoted-message response-to (:quoted-message message) outgoing current-public-key public? pinned])
-         [react/text {:style (style/emoji-message message)}
-          (:text content)]]
-         [message-timestamp message]]]]]]
+        [react/view (style/message-view message)
+         [react/view {:style (style/message-view-content)}
+          [react/view {:style (style/style-message-text outgoing)}
+           (when (and (seq response-to) (:quoted-message message))
+             [quoted-message response-to (:quoted-message message) outgoing current-public-key public? pinned])
+           [react/text {:style (style/emoji-message message)}
+            (:text content)]]
+          [message-timestamp message]]]]]]
      reaction-picker]))
 
 (defmethod ->message constants/content-type-sticker
@@ -578,9 +579,9 @@
         (when-not outgoing
           (merge pan-responder
                  {:style {:transform [{:translateX translate-x-anim-value}]}}))
-      [react/image {:style  {:margin 10 :width 140 :height 140}
+        [react/image {:style  {:margin 10 :width 140 :height 140}
                     ;;TODO (perf) move to event
-                    :source {:uri (contenthash/url (-> content :sticker :hash))}}]]]]
+                      :source {:uri (contenthash/url (-> content :sticker :hash))}}]]]]
      reaction-picker]))
 
 (defmethod ->message constants/content-type-image [{:keys [content in-popover?] :as message} {:keys [on-long-press modal]

--- a/src/status_im/ui/screens/chat/message/message.cljs
+++ b/src/status_im/ui/screens/chat/message/message.cljs
@@ -4,6 +4,7 @@
             [status-im.i18n.i18n :as i18n]
             [status-im.react-native.resources :as resources]
             [quo.design-system.colors :as colors]
+            [quo.animated :as animated]
             [status-im.ui.components.icons.icons :as icons]
             [status-im.ui.components.react :as react]
             [status-im.ui.screens.chat.message.audio :as message.audio]
@@ -22,6 +23,8 @@
             [status-im.utils.config :as config]
             [reagent.core :as reagent]
             [status-im.ui.screens.chat.components.reply :as components.reply]
+            [status-im.ui.components.animation :as animation]
+            [status-im.ui.screens.chat.components.accessory :as accessory]
             [status-im.ui.screens.chat.message.link-preview :as link-preview]
             [status-im.ui.screens.communities.icon :as communities.icon]
             [status-im.chat.models.pin-message :as models.pin-message])
@@ -329,7 +332,11 @@
    {:keys [on-long-press]}]
   (let [dimensions (reagent/atom [image-max-width image-max-height])
         visible (reagent/atom false)
-        uri (:image content)]
+        uri (:image content)
+        translate-x  (animation/create-value 0)
+        pan-state    (animation/create-value 0)
+        translate-x-anim-value (animation/interpolate translate-x {:inputRange  [0 1] :outputRange [0 0.5]})
+        pan-responder (accessory/swipe-pan-responder translate-x pan-state message)]
     (react/image-get-size uri (image-set-size dimensions))
     (fn []
       (let [style-opts {:outgoing outgoing
@@ -345,12 +352,17 @@
                                                       (react/dismiss-keyboard!))
                                      :on-long-press on-long-press
                                      :disabled      in-popover?}
+         [react/view
+          [react/animated-view
+           (when-not outgoing
+             (merge pan-responder
+                    {:style {:transform [{:translateX translate-x-anim-value}]}}))
           [react/view {:style               (style/image-message style-opts)
                        :accessibility-label :image-message}
            [react/image {:style       (dissoc style-opts :outgoing)
                          :resize-mode :cover
                          :source      {:uri uri}}
-            [react/view {:style (style/image-message-border style-opts)}]]]]]))))
+          [react/view {:style (style/image-message-border style-opts)}]]]]]]]))))
 
 (defmulti ->message :content-type)
 
@@ -409,12 +421,16 @@
 
 (defn collapsible-text-message [{:keys [mentioned]} _]
   (let [collapsed?   (reagent/atom false)
-        collapsible? (reagent/atom false)]
+        collapsible? (reagent/atom false)
+        translate-x  (animation/create-value 0)
+        pan-state    (animation/create-value 0)
+        translate-x-anim-value (animation/interpolate translate-x {:inputRange  [0 1] :outputRange [0 0.5]})]
     (fn [{:keys [content outgoing current-public-key public? pinned in-popover?] :as message} on-long-press modal]
       (let [max-height (when-not (or outgoing modal)
                          (if @collapsible?
                            (if @collapsed? message-height-px nil)
-                           message-height-px))]
+                           message-height-px))
+            pan-responder (accessory/swipe-pan-responder translate-x pan-state message)]
         [react/touchable-highlight
          (when-not modal
            {:on-press         (fn [_]
@@ -426,6 +442,17 @@
                                       (js/setTimeout #(on-long-press-fn on-long-press message content) 200))
                                   (on-long-press-fn on-long-press message content)))
             :disabled         in-popover?})
+        [react/view {:accessibility-label :swipe-to-reply}
+          [react/animated-view
+           (when-not outgoing
+             (merge pan-responder
+                    {:style {:transform [{:translateX translate-x-anim-value}]}
+                    :flex-direction                   :row
+                    :align-items                      :center}))
+          ;;TODO: Add opacity animation on reply icon.
+          [react/view {:position :absolute :left -80 }
+            [icons/icon :main-icons/reply {:color colors/blue}]]
+
          [react/view {:style (style/message-view message)}
           [react/view {:style      (style/message-view-content)
                        :max-height max-height}
@@ -459,7 +486,7 @@
                                            :style    {:align-self :center :margin 5}}
                 [react/view (style/collapse-button)
                  [icons/icon :main-icons/dropdown-up
-                  {:color colors/white}]]]))]]]))))
+                  {:color colors/white}]]]))]]]]]))))
 
 (defmethod ->message constants/content-type-text
   [message {:keys [on-long-press modal] :as reaction-picker}]
@@ -484,7 +511,11 @@
 (defmethod ->message constants/content-type-emoji
   [{:keys [content current-public-key outgoing public? pinned in-popover? message-pin-enabled] :as message} {:keys [on-long-press modal]
                                                                                                              :as   reaction-picker}]
-  (let [response-to (:response-to content)]
+  (let [response-to (:response-to content)
+        translate-x  (animation/create-value 0)
+        pan-state    (animation/create-value 0)
+        translate-x-anim-value (animation/interpolate translate-x {:inputRange  [0 1] :outputRange [0 0.5]})
+        pan-responder (accessory/swipe-pan-responder translate-x pan-state message)]
     [message-content-wrapper message
      [react/touchable-highlight (when-not modal
                                   {:disabled      in-popover?
@@ -502,6 +533,11 @@
                                                         :label    (i18n/label :t/sharing-copy-to-clipboard)}]
                                                       (when message-pin-enabled [{:on-press #(pin-message message)
                                                                                   :label    (if pinned (i18n/label :t/unpin) (i18n/label :t/pin))}]))))})
+      [react/view
+       [react/animated-view
+        (when-not outgoing
+          (merge pan-responder
+                 {:style {:transform [{:translateX translate-x-anim-value}]}}))
       [react/view (style/message-view message)
        [react/view {:style (style/message-view-content)}
         [react/view {:style (style/style-message-text outgoing)}
@@ -509,7 +545,7 @@
            [quoted-message response-to (:quoted-message message) outgoing current-public-key public? pinned])
          [react/text {:style (style/emoji-message message)}
           (:text content)]]
-        [message-timestamp message]]]]
+         [message-timestamp message]]]]]]
      reaction-picker]))
 
 (defmethod ->message constants/content-type-sticker
@@ -517,7 +553,11 @@
     :as   message}
    {:keys [on-long-press modal]
     :as   reaction-picker}]
-  (let [pack (get-in content [:sticker :pack])]
+  (let [pack (get-in content [:sticker :pack])
+        translate-x  (animation/create-value 0)
+        pan-state    (animation/create-value 0)
+        translate-x-anim-value (animation/interpolate translate-x {:inputRange  [0 1] :outputRange [0 0.5]})
+        pan-responder (accessory/swipe-pan-responder translate-x pan-state message)]
     [message-content-wrapper message
      [react/touchable-highlight (when-not modal
                                   {:disabled            in-popover?
@@ -533,9 +573,14 @@
                                                              [{:on-press #(when pack
                                                                             (re-frame/dispatch [:chat.ui/show-profile from]))
                                                                :label    (i18n/label :t/view-details)}])))})
+      [react/view
+       [react/animated-view
+        (when-not outgoing
+          (merge pan-responder
+                 {:style {:transform [{:translateX translate-x-anim-value}]}}))
       [react/image {:style  {:margin 10 :width 140 :height 140}
                     ;;TODO (perf) move to event
-                    :source {:uri (contenthash/url (-> content :sticker :hash))}}]]
+                    :source {:uri (contenthash/url (-> content :sticker :hash))}}]]]]
      reaction-picker]))
 
 (defmethod ->message constants/content-type-image [{:keys [content in-popover?] :as message} {:keys [on-long-press modal]


### PR DESCRIPTION
[comment]: # This PR implements a "swipe to reply" feature on chat messages.

fixes #12361

### Summary

[comment]: # This PR implements swipe gesture replacing onLongPress to allow users reply a message with a better UX. 
...

#### Platforms

- Android
- iOS
- macOS
- Linux
- Windows

#### Areas that maybe impacted

##### Functional

- 1-1 chats
- public chats
- group chats

### Steps to test

- Step 1: Swipe a message to right
- Step 2: Reply a message

- Open Status
status: ready

https://user-images.githubusercontent.com/44679989/137039662-0664759b-a7bd-4d03-ad24-72767b5cca61.mp4


