### PR TITLE
Online Status Indicator

### DIFF
--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -162,3 +162,8 @@
 (def ^:const activity-center-notification-type-private-group-chat 2)
 (def ^:const activity-center-notification-type-mention 3)
 (def ^:const activity-center-notification-type-reply 4)
+
+(def ^:const visibility-status-unknown 0)
+(def ^:const visibility-status-online 1)
+(def ^:const visibility-status-dnd 2)
+(def ^:const visibility-status-invisible 3)

--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -164,6 +164,7 @@
 (def ^:const activity-center-notification-type-reply 4)
 
 (def ^:const visibility-status-unknown 0)
-(def ^:const visibility-status-online 1)
+(def ^:const visibility-status-automatic 1)
 (def ^:const visibility-status-dnd 2)
-(def ^:const visibility-status-invisible 3)
+(def ^:const visibility-status-always-online 3)
+(def ^:const visibility-status-inactive 4)

--- a/src/status_im/data_store/settings.cljs
+++ b/src/status_im/data_store/settings.cljs
@@ -1,7 +1,8 @@
 (ns status-im.data-store.settings
   (:require
    [status-im.utils.config :as config]
-   [status-im.ethereum.eip55 :as eip55]))
+   [status-im.ethereum.eip55 :as eip55]
+   [status-im.data-store.status-updates :as status-updates]))
 
 (defn rpc->networks [networks]
   (reduce (fn [acc {:keys [id] :as network}]
@@ -50,4 +51,5 @@
       (update :link-previews-enabled-sites set)
       (update :custom-bootnodes rpc->custom-bootnodes)
       (update :custom-bootnodes-enabled? rpc->custom-bootnodes)
-      (update :currency keyword)))
+      (update :currency keyword)
+      (update :current-user-status status-updates/<-rpc)))

--- a/src/status_im/data_store/status_updates.cljs
+++ b/src/status_im/data_store/status_updates.cljs
@@ -1,0 +1,16 @@
+(ns status-im.data-store.status-updates
+  (:require [clojure.set :as clojure.set]
+            [status-im.ethereum.json-rpc :as json-rpc]
+            [status-im.utils.fx :as fx]
+            [taoensso.timbre :as log]))
+
+(defn <-rpc [status-update]
+  (clojure.set/rename-keys status-update {:publicKey  :public-key
+                                          :statusType :status-type}))
+
+(fx/defn fetch-status-updates-rpc
+  [_ on-success]
+  {::json-rpc/call [{:method     "wakuext_statusUpdates"
+                     :params     []
+                     :on-success #(on-success (:statusUpdates ^js %))
+                     :on-failure #(log/error "failed to fetch status-updates" %)}]})

--- a/src/status_im/db.cljs
+++ b/src/status_im/db.cljs
@@ -32,6 +32,7 @@
              :tooltips                           {}
              :dimensions/window                  (dimensions/window)
              :registry                           {}
+             :status-updates                     {}
              :stickers/packs-owned               #{}
              :stickers/packs-pending             #{}
              :keycard                            {:nfc-enabled?   false

--- a/src/status_im/ethereum/json_rpc.cljs
+++ b/src/status_im/ethereum/json_rpc.cljs
@@ -131,6 +131,8 @@
    "wakuext_enablePushNotificationsBlockMentions" {}
    "wakuext_disablePushNotificationsBlockMentions" {}
    "wakuext_unreadActivityCenterNotificationsCount" {}
+   "wakuext_setUserStatus" {}
+   "wakuext_statusUpdates" {}
    "multiaccounts_getIdentityImages" {}
    "multiaccounts_getIdentityImage" {}
    "multiaccounts_storeIdentityImage" {}

--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -27,6 +27,8 @@
             status-im.wallet.choose-recipient.core
             status-im.wallet.accounts.core
             status-im.popover.core
+            status-im.visibility-status-popover.core
+            status-im.status-updates.core
             status-im.bottom-sheet.core
             status-im.add-new.core
             status-im.search.core

--- a/src/status_im/multiaccounts/login/core.cljs
+++ b/src/status_im/multiaccounts/login/core.cljs
@@ -37,7 +37,8 @@
             [status-im.notifications-center.core :as notifications-center]
             [status-im.navigation :as navigation]
             [status-im.signing.eip1559 :as eip1559]
-            [status-im.data-store.chats :as data-store.chats]))
+            [status-im.data-store.chats :as data-store.chats]
+            [status-im.status-updates.core :as status-updates]))
 
 (re-frame/reg-fx
  ::initialize-communities-enabled
@@ -338,7 +339,8 @@
               (get-group-chat-invitations)
               (multiaccounts/get-profile-picture)
               (multiaccounts/switch-preview-privacy-mode-flag)
-              (link-preview/request-link-preview-whitelist))))
+              (link-preview/request-link-preview-whitelist)
+              (status-updates/initialize-status-updates))))
 
 (defn get-new-auth-method [auth-method save-password?]
   (when save-password?

--- a/src/status_im/navigation/core.cljs
+++ b/src/status_im/navigation/core.cljs
@@ -136,7 +136,7 @@
    (fn [^js evn]
      (let [view-id (keyword (.-componentName evn))]
        (when (get views/screens view-id)
-         (when (and (not= view-id :bottom-sheet) (not= view-id :popover))
+         (when (and (not= view-id :bottom-sheet) (not= view-id :popover) (not= view-id :visibility-status-popover))
            (set-view-id view-id)
            (when-not @curr-modal
              (reset! pushed-screen-id view-id))))))))
@@ -146,7 +146,7 @@
   (.registerComponentDidDisappearListener
    (.events Navigation)
    (fn [^js evn]
-     (when-not (#{"popover" "bottom-sheet" "signing-sheet"} (.-componentName evn))
+     (when-not (#{"popover" "bottom-sheet" "signing-sheet" "visibility-status-popover"} (.-componentName evn))
        (doseq [[_ {:keys [ref value]}] @quo.text-input/text-input-refs]
          (.setNativeProps ^js ref (clj->js {:text value})))
        (doseq [[^js text-input default-value] @react/text-input-refs]
@@ -289,6 +289,16 @@
 
 (re-frame/reg-fx :show-popover (fn [] (show-overlay "popover")))
 (re-frame/reg-fx :hide-popover (fn [] (dissmiss-overlay "popover")))
+
+;; VISIBILITY STATUS POPOVER
+(defonce visibility-status-popover-reg
+  (.registerComponent Navigation
+                      "visibility-status-popover"
+                      (fn [] (gestureHandlerRootHOC views/visibility-status-popover-comp))
+                      (fn [] views/visibility-status-popover-comp)))
+
+(re-frame/reg-fx :show-visibility-status-popover (fn [] (show-overlay "visibility-status-popover")))
+(re-frame/reg-fx :hide-visibility-status-popover (fn [] (dissmiss-overlay "visibility-status-popover")))
 
 ;; BOTTOM SHEETS
 (defonce bottom-sheet-reg

--- a/src/status_im/status_updates/core.cljs
+++ b/src/status_im/status_updates/core.cljs
@@ -1,0 +1,82 @@
+(ns status-im.status-updates.core
+  (:require [re-frame.core :as re-frame]
+            [status-im.data-store.status-updates :as status-updates-store]
+            [status-im.ethereum.json-rpc :as json-rpc]
+            [status-im.utils.fx :as fx]
+            [status-im.constants :as constants]
+            [status-im.multiaccounts.update.core :as multiaccounts.update]))
+
+(fx/defn load-status-updates
+  {:events [::status-updates-loaded]}
+  [{:keys [db]} status-updates-loaded]
+  (let [{:keys [status-updates]}
+        (reduce (fn [prev-map status-update-loaded]
+                  (let [{:keys [public-key] :as status-update} (status-updates-store/<-rpc status-update-loaded)]
+                    (assoc-in prev-map [:status-updates public-key] status-update)))
+                {:status-updates {}}
+                status-updates-loaded)]
+    {:db (assoc db :status-updates status-updates)}))
+
+(fx/defn handle-status-updates
+  [{:keys [db]} status-updates-received]
+  (let [status-updates-old (if (nil? (:status-updates db)) {} (:status-updates db))
+        {:keys [status-updates]}
+        (reduce (fn [prev-map status-update-received]
+                  (let [{:keys [public-key clock] :as status-update} (status-updates-store/<-rpc status-update-received)
+                        status-update-old (get-in prev-map [:status-updates public-key])]
+                    (when (or
+                           (nil? status-update-old)
+                           (> clock (:clock status-update-old)))
+                      (assoc-in prev-map [:status-updates public-key] status-update))))
+                {:status-updates status-updates-old}
+                status-updates-received)]
+    {:db (update-in db [:status-updates] merge status-updates)}))
+
+(fx/defn initialize-status-updates [cofx]
+  (status-updates-store/fetch-status-updates-rpc cofx #(re-frame/dispatch [::status-updates-loaded %])))
+
+(fx/defn visibility-status-option-pressed
+  {:events [:status-updates/visibility-status-option-pressed]}
+  [_ status-type]
+  (let [events-to-dispatch-later (atom [])]
+    (swap! events-to-dispatch-later conj {:ms 10 :dispatch [:status-updates/update-visibility-status status-type]})
+    (when
+     (not= status-type constants/visibility-status-online)
+      ;; Disable broadcasting further updates
+      (swap! events-to-dispatch-later conj {:ms 1000 :dispatch [:status-updates/send-status-updates? false]}))
+    {:dispatch        [:status-updates/send-status-updates? true] ;; Enable broadcasting for current update
+     :dispatch-later  @events-to-dispatch-later}))
+
+(fx/defn update-visibility-status
+  {:events [:status-updates/update-visibility-status]}
+  [{:keys [db] :as cofx} status-type]
+  {:db (update-in db [:multiaccount :current-user-status] merge {:statusType status-type})
+   ::json-rpc/call [{:method     "wakuext_setUserStatus"
+                     :params     [status-type ""]
+                     :on-success #()}]})
+
+(fx/defn send-status-updates?
+  {:events [:status-updates/send-status-updates?]}
+  [cofx val]
+  (multiaccounts.update/multiaccount-update cofx
+                                            :send-status-updates? val
+                                            {}))
+
+(fx/defn timeout-user-online-status
+  {:events [:status-updates/timeout-user-online-status]}
+  [{:keys [db]} public-key clock]
+  (let [current-clock (get-in db [:status-updates public-key :clock] 0)]
+    (when (= current-clock clock)
+      {:db (update-in db [:status-updates public-key] merge {:status-type constants/visibility-status-invisible})})))
+
+(fx/defn countdown-for-online-user
+  {:events [:status-updates/countdown-for-online-user]}
+  [{:keys [db]} public-key clock ms]
+  {:dispatch-later [{:ms ms
+                     :dispatch [:status-updates/timeout-user-online-status public-key clock]}]})
+
+(fx/defn delayed-visibility-status-update
+  {:events [:status-updates/delayed-visibility-status-update]}
+  [{:keys [db]} status-type]
+  {:dispatch-later [{:ms 200
+                     :dispatch [:status-updates/visibility-status-option-pressed status-type]}]})

--- a/src/status_im/status_updates/core.cljs
+++ b/src/status_im/status_updates/core.cljs
@@ -41,7 +41,7 @@
   (let [events-to-dispatch-later (atom [])]
     (swap! events-to-dispatch-later conj {:ms 10 :dispatch [:status-updates/update-visibility-status status-type]})
     (when
-     (not= status-type constants/visibility-status-online)
+     (= status-type constants/visibility-status-inactive)
       ;; Disable broadcasting further updates
       (swap! events-to-dispatch-later conj {:ms 1000 :dispatch [:status-updates/send-status-updates? false]}))
     {:dispatch        [:status-updates/send-status-updates? true] ;; Enable broadcasting for current update
@@ -67,7 +67,7 @@
   [{:keys [db]} public-key clock]
   (let [current-clock (get-in db [:status-updates public-key :clock] 0)]
     (when (= current-clock clock)
-      {:db (update-in db [:status-updates public-key] merge {:status-type constants/visibility-status-invisible})})))
+      {:db (update-in db [:status-updates public-key] merge {:status-type constants/visibility-status-inactive})})))
 
 (fx/defn countdown-for-online-user
   {:events [:status-updates/countdown-for-online-user]}

--- a/src/status_im/subs.cljs
+++ b/src/status_im/subs.cljs
@@ -86,6 +86,7 @@
 (reg-root-key-sub :app-state :app-state)
 (reg-root-key-sub :home-items-show-number :home-items-show-number)
 (reg-root-key-sub :waku/v2-peer-stats :peer-stats)
+(reg-root-key-sub :status-updates :status-updates)
 
 ;;NOTE this one is not related to ethereum network
 ;; it is about cellular network/ wifi network
@@ -200,6 +201,7 @@
 (reg-root-key-sub :intro-wizard-state :intro-wizard)
 
 (reg-root-key-sub :popover/popover :popover/popover)
+(reg-root-key-sub :visibility-status-popover/popover :visibility-status-popover/popover)
 (reg-root-key-sub :add-account :add-account)
 
 (reg-root-key-sub :keycard :keycard)
@@ -355,6 +357,11 @@
 
 ;;GENERAL ==============================================================================================================
 
+(re-frame/reg-sub
+ :status-updates/status-update
+ :<- [:status-updates]
+ (fn [status-updates [_ public-key]]
+   (get status-updates public-key)))
 
 (re-frame/reg-sub
  :multiaccount/logged-in?
@@ -783,6 +790,12 @@
          :seed
          (string/blank? (security/safe-unmask-data seed))
          false))))
+
+(re-frame/reg-sub
+ :multiaccount/current-user-status
+ :<- [:multiaccount]
+ (fn [{:keys [current-user-status]}]
+   current-user-status))
 
 ;;CHAT ==============================================================================================================
 

--- a/src/status_im/transport/message/core.cljs
+++ b/src/status_im/transport/message/core.cljs
@@ -19,6 +19,7 @@
             [status-im.constants :as constants]
             [status-im.multiaccounts.model :as multiaccounts.model]
             [status-im.notifications-center.core :as notifications-center]
+            [status-im.status-updates.core :as models.status-updates]
             [clojure.string :as string]))
 
 (fx/defn process-next
@@ -42,6 +43,7 @@
         ^js activity-notifications     (.-activityCenterNotifications response-js)
         ^js pin-messages               (.-pinMessages response-js)
         ^js removed-messages           (.-removedMessages response-js)
+        ^js status-updates             (.-statusUpdates response-js)
         sync-handler                   (when-not process-async process-response)]
     (cond
 
@@ -149,7 +151,14 @@
         (js-delete response-js "removedMessages")
         (fx/merge cofx
                   (process-next response-js sync-handler)
-                  (models.message/handle-removed-messages removed-messages-clj))))))
+                  (models.message/handle-removed-messages removed-messages-clj)))
+
+      (seq status-updates)
+      (let [status-updates-clj (types/js->clj status-updates)]
+        (js-delete response-js "statusUpdates")
+        (fx/merge cofx
+                  (process-next response-js sync-handler)
+                  (models.status-updates/handle-status-updates status-updates-clj))))))
 
 (defn group-by-and-update-unviewed-counts
   "group messages by current chat, profile updates, transactions and update unviewed counters in db for not curent chats"

--- a/src/status_im/ui/components/chat_icon/styles.cljs
+++ b/src/status_im/ui/components/chat_icon/styles.cljs
@@ -70,51 +70,6 @@
           :height        64
           :border-radius 32}))
 
-(def online-view-wrapper
-  {:position         :absolute
-   :bottom           -2
-   :right            -2
-   :width            17
-   :height           17
-   :border-radius    11
-   :background-color colors/white})
-
-(def online-view
-  {:position         :absolute
-   :bottom           2
-   :right            2
-   :width            13
-   :height           13
-   :border-radius    9
-   :background-color colors/blue})
-
-(def online-view-profile
-  (merge online-view
-         {:width         24
-          :height        24
-          :border-radius 12}))
-
-(def online-dot
-  {:position         :absolute
-   :top              5
-   :width            3
-   :height           3
-   :border-radius    2
-   :background-color colors/white})
-(def online-dot-left (merge online-dot {:left 2.8}))
-(def online-dot-right (merge online-dot {:left 7.2}))
-
-(def online-dot-profile
-  (merge online-dot
-         {:top    8
-          :width  4
-          :height 4}))
-
-(def online-dot-left-profile
-  (merge online-dot-profile {:left 5}))
-(def online-dot-right-profile
-  (merge online-dot-profile {:left 11}))
-
 (def container-chat-list
   {:width  40
    :height 40})

--- a/src/status_im/ui/components/profile_header/view.cljs
+++ b/src/status_im/ui/components/profile_header/view.cljs
@@ -37,7 +37,7 @@
          (when-not minimized
            {:padding-top    subtitle-margin})))
 
-(defn extended-header [{:keys [title photo color subtitle subtitle-icon on-edit on-press monospace bottom-separator emoji]
+(defn extended-header [{:keys [title photo color subtitle subtitle-icon on-edit on-press monospace bottom-separator emoji public-key]
                         :or   {bottom-separator true}}]
   (fn [{:keys [animation minimized]}]
     (let [wrapper  (if on-press
@@ -57,7 +57,7 @@
                   [chat-icon.screen/profile-icon-view
                    photo title color emoji (and (not minimized) on-edit)
                    (if minimized avatar-minimized-size avatar-extended-size)
-                   nil]]])
+                   nil public-key]]])
           [animated/view {:style          (header-text)
                           :pointer-events :box-none}
            [quo/text {:animated?           true

--- a/src/status_im/ui/screens/communities/members.cljs
+++ b/src/status_im/ui/screens/communities/members.cljs
@@ -51,8 +51,9 @@
      {:title               first-name
       :subtitle            second-name
       :accessibility-label :member-item
-      :icon                [chat-icon/contact-icon-contacts-tab
-                            (multiaccounts/displayed-photo member)]
+      :icon                 [chat-icon/profile-photo-plus-dot-view
+                             {:public-key public-key
+                              :photo-path (multiaccounts/displayed-photo member)}]
       :accessory           (when (not= public-key my-public-key)
                              [quo/button {:on-press
                                           #(>evt [:bottom-sheet/show-sheet
@@ -94,7 +95,6 @@
                     can-manage-users?]} (<sub [:communities/community community-id])]
         [:<>
          [topbar/topbar {:title    (i18n/label :t/community-members-title)
-
                          :subtitle (str (count members))}]
          [header community-id]
          (when (and can-manage-users? (= constants/community-on-request-access (:access permissions)))

--- a/src/status_im/ui/screens/contacts_list/views.cljs
+++ b/src/status_im/ui/screens/contacts_list/views.cljs
@@ -15,8 +15,9 @@
     [quo/list-item
      {:title    first-name
       :subtitle second-name
-      :icon     [chat-icon.screen/contact-icon-contacts-tab
-                 (multiaccounts/displayed-photo contact)]
+      :icon     [chat-icon.screen/profile-photo-plus-dot-view
+                 {:public-key public-key
+                  :photo-path (multiaccounts/displayed-photo contact)}]
       :chevron  true
       :on-press #(re-frame/dispatch [:chat.ui/show-profile public-key])}]))
 

--- a/src/status_im/ui/screens/profile/contact/views.cljs
+++ b/src/status_im/ui/screens/profile/contact/views.cljs
@@ -205,7 +205,8 @@
                                         :title    first-name
                                         :photo    (multiaccounts/displayed-photo contact)
                                         :monospace (not ens-verified)
-                                        :subtitle second-name})]
+                                        :subtitle second-name
+                                        :public-key public-key})]
                                      [react/view {:height 1 :background-color colors/gray-lighter :margin-top 8}]
                                      [nickname-settings contact]
                                      [pin-settings public-key (count pinned-messages)]

--- a/src/status_im/ui/screens/profile/user/views.cljs
+++ b/src/status_im/ui/screens/profile/user/views.cljs
@@ -17,7 +17,9 @@
             [status-im.ui.components.profile-header.view :as profile-header]
             [status-im.ui.screens.profile.user.edit-picture :as edit]
             [status-im.utils.utils :as utils]
-            [status-im.ethereum.stateofus :as stateofus])
+            [status-im.ethereum.stateofus :as stateofus]
+            [quo.design-system.spacing :as spacing]
+            [status-im.ui.screens.profile.visibility-status.views :as visibility-status])
   (:require-macros [status-im.utils.views :as views]))
 
 (views/defview share-chat-key []
@@ -64,6 +66,8 @@
         chain @(re-frame/subscribe [:chain-keyword])
         registrar (stateofus/get-cached-registrar chain)]
     [:<>
+     [visibility-status/visibility-status-button visibility-status/calculate-button-height-and-dispatch-popover]
+     [quo/separator {:style {:margin-top  (:tiny spacing/spacing)}}]
      [quo/list-item
       (cond-> {:title                (or (when registrar preferred-name)
                                          (i18n/label :t/ens-usernames))

--- a/src/status_im/ui/screens/profile/visibility_status/styles.cljs
+++ b/src/status_im/ui/screens/profile/visibility_status/styles.cljs
@@ -1,0 +1,66 @@
+(ns status-im.ui.screens.profile.visibility-status.styles
+  (:require [quo.design-system.colors :as colors]))
+
+(def color-error "#FA6565")
+(def color-online "#7CDA00")
+(def color-dnd "#FA6565")
+(def color-invisible "#FFFFFF")
+
+(defn visibility-status-button-container []
+  {:background-color       (:interactive-02 @colors/theme)
+   :margin-left            16
+   :border-radius          16
+   :border-top-left-radius 4
+   :align-self             "flex-start"
+   :flex-direction         "row"
+   :align-items            "center"
+   :padding                6
+   :padding-right          12})
+
+(defn color-invisible? [dot-color]
+  (= dot-color color-invisible))
+
+(defn visibility-status-dot [dot-color size]
+  {:background-color dot-color
+   :width            size
+   :height           size
+   :border-radius    (/ size 2)
+   :border-width     1
+   :border-color     (if (color-invisible? dot-color) "rgba(0,0,0,0.1)" "#FFFFFF")})
+
+(defn visiblity-status-profile-dot [color]
+  (merge (visibility-status-dot color 10) {:margin 6
+                                           :border-width (if (color-invisible? color) 1 0)}))
+
+(defn visibility-status-text []
+  {:color      (:text-01 @colors/theme)
+   :font-size  16
+   :weight     700
+   :text-align "center"})
+
+(defn visibility-status-subtitle []
+  {:color        (:text-02 @colors/theme)
+   :font-size    16
+   :margin-left  22
+   :margin-right 6
+   :weight       600})
+
+(defn visibility-status-options [scale position]
+  {:background-color       (:ui-background @colors/theme)
+   :border-radius          16
+   :border-top-left-radius 4
+   :justify-content        "center"
+   :align-self             "flex-start"
+   :left                    16
+   :top                    -76
+   :padding-top             6
+   :padding-bottom          6
+   :transform               [{:scaleY scale}
+                             {:translateY position}]})
+
+(def visibility-status-popover-view
+  {:position :absolute
+   :top      0
+   :bottom   0
+   :left     0
+   :right    0})

--- a/src/status_im/ui/screens/profile/visibility_status/styles.cljs
+++ b/src/status_im/ui/screens/profile/visibility_status/styles.cljs
@@ -4,7 +4,7 @@
 (def color-error "#FA6565")
 (def color-online "#7CDA00")
 (def color-dnd "#FA6565")
-(def color-invisible "#FFFFFF")
+(def color-inactive "#939BA1")
 
 (defn visibility-status-button-container []
   {:background-color       (:interactive-02 @colors/theme)
@@ -14,11 +14,9 @@
    :align-self             "flex-start"
    :flex-direction         "row"
    :align-items            "center"
+   :justify-content        "center"
    :padding                6
    :padding-right          12})
-
-(defn color-invisible? [dot-color]
-  (= dot-color color-invisible))
 
 (defn visibility-status-dot [dot-color size]
   {:background-color dot-color
@@ -26,11 +24,13 @@
    :height           size
    :border-radius    (/ size 2)
    :border-width     1
-   :border-color     (if (color-invisible? dot-color) "rgba(0,0,0,0.1)" "#FFFFFF")})
+   :border-color     "#FFFFFF"})
 
-(defn visiblity-status-profile-dot [color]
-  (merge (visibility-status-dot color 10) {:margin 6
-                                           :border-width (if (color-invisible? color) 1 0)}))
+(defn visibility-status-profile-dot [color size border-width margin-left]
+  (merge (visibility-status-dot color size)
+         {:margin-right 6
+          :margin-left  margin-left
+          :border-width border-width}))
 
 (defn visibility-status-text []
   {:color      (:text-01 @colors/theme)
@@ -45,6 +45,10 @@
    :margin-right 6
    :weight       600})
 
+(defn visibility-status-option []
+  {:flex-direction  "row"
+   :align-items "center"})
+
 (defn visibility-status-options [scale position]
   {:background-color       (:ui-background @colors/theme)
    :border-radius          16
@@ -53,8 +57,8 @@
    :align-self             "flex-start"
    :left                    16
    :top                    -76
-   :padding-top             6
    :padding-bottom          6
+   :padding-top             8
    :transform               [{:scaleY scale}
                              {:translateY position}]})
 

--- a/src/status_im/ui/screens/profile/visibility_status/utils.cljs
+++ b/src/status_im/ui/screens/profile/visibility_status/utils.cljs
@@ -1,0 +1,44 @@
+(ns status-im.ui.screens.profile.visibility-status.utils
+  (:require [status-im.constants :as constants]
+            [status-im.i18n.i18n :as i18n]
+            [status-im.ui.screens.profile.visibility-status.styles :as styles]
+            [re-frame.core :as re-frame]
+            [status-im.utils.datetime :as datetime]))
+
+(def visibility-status-type-data
+  {constants/visibility-status-unknown   {:color    styles/color-error
+                                          :title    (i18n/label :t/error)}
+   constants/visibility-status-online    {:color    styles/color-online
+                                          :title    (i18n/label :t/status-online)}
+   constants/visibility-status-dnd       {:color    styles/color-dnd
+                                          :title    (i18n/label :t/status-dnd)
+                                          :subtitle (i18n/label :t/subtitle-dnd)}
+   constants/visibility-status-invisible {:color    styles/color-invisible
+                                          :title    (i18n/label :t/status-invisible)
+                                          :subtitle (i18n/label :t/subtitle-invisible)}})
+
+;; Currently, Another user is broadcasting their status updates at the rate of 5 minutes.
+;; So, we need to show that user online a little extra than that time. (broadcast receiving delay)
+(defn dot-color [{:keys [public-key status-type clock]}]
+  (let [status-lifespan    (datetime/minutes 5.1)
+        status-expire-time (+ (datetime/to-mills clock) status-lifespan)
+        time-left          (-  status-expire-time (datetime/timestamp))
+        status-type        (if (or (nil? status-type)
+                                   (and
+                                    (= status-type constants/visibility-status-online)
+                                    (neg? time-left)))
+                             constants/visibility-status-invisible
+                             status-type)]
+    (when (= status-type constants/visibility-status-online)
+      (re-frame/dispatch [:status-updates/countdown-for-online-user public-key clock time-left]))
+    (:color (get visibility-status-type-data status-type))))
+
+(defn icon-visibility-status-dot [public-key container-size identicon?]
+  (let [status-update @(re-frame/subscribe [:status-updates/status-update public-key])
+        size          (/ container-size 4)
+        margin        (if identicon? (/ size 6) (/ size 7))
+        dot-color     (dot-color status-update)]
+    (merge (styles/visibility-status-dot dot-color size)
+           {:bottom           margin
+            :right            margin
+            :position         :absolute})))

--- a/src/status_im/ui/screens/profile/visibility_status/views.cljs
+++ b/src/status_im/ui/screens/profile/visibility_status/views.cljs
@@ -38,11 +38,11 @@
      [rn/view {:style (styles/visibility-status-profile-dot color size border-width margin-left)}]]))
 
 (defn visibility-status-button [on-press props]
-  (let [{:keys [statusType]}        (<sub [:multiaccount/current-user-status])
-        status-type                 (if (nil? statusType)
+  (let [{:keys [status-type]}       (<sub [:multiaccount/current-user-status])
+        status-type                 (if (nil? status-type)
                                       (do
                                         (dispatch-status-update constants/visibility-status-automatic)
-                                        constants/visibility-status-automatic) statusType)
+                                        constants/visibility-status-automatic) status-type)
         {:keys [color alias title]} (get utils/visibility-status-type-data status-type)
         title                       (if (nil? alias) title alias)]
     [rn/touchable-opacity

--- a/src/status_im/ui/screens/views.cljs
+++ b/src/status_im/ui/screens/views.cljs
@@ -5,6 +5,7 @@
             [status-im.ui.screens.screens :as screens]
             [oops.core :refer [oget]]
             [status-im.ui.screens.popover.views :as popover]
+            [status-im.ui.screens.profile.visibility-status.views :as visibility-status-views]
             [status-im.ui.screens.bottom-sheets.views :as bottom-sheets]
             [status-im.ui.screens.signing.views :as signing]
             [status-im.ui.screens.wallet.send.views :as wallet.send.views]
@@ -83,6 +84,16 @@
      [react/safe-area-provider
       [inactive]
       [popover/popover]
+      (when js/goog.DEBUG
+        [reloader/reload-view])])))
+
+(def visibility-status-popover-comp
+  (reagent/reactify-component
+   (fn []
+     ^{:key (str "visibility-status-popover" @reloader/cnt)}
+     [react/safe-area-provider
+      [inactive]
+      [visibility-status-views/visibility-status-popover]
       (when js/goog.DEBUG
         [reloader/reload-view])])))
 

--- a/src/status_im/utils/datetime.cljs
+++ b/src/status_im/utils/datetime.cljs
@@ -20,6 +20,8 @@
 (def hour (* 60 minute))
 (def day (* 24 hour))
 (def week (* 7 day))
+(defn weeks [w]
+  (* w week))
 (def units [{:name :t/datetime-second-short :limit 60 :in-second 1}
             {:name :t/datetime-minute-short :limit 3600 :in-second 60}
             {:name :t/datetime-hour-short :limit 86400 :in-second 3600}

--- a/src/status_im/utils/datetime.cljs
+++ b/src/status_im/utils/datetime.cljs
@@ -167,3 +167,6 @@
     (str day (or (s (mod (- m 20) 10))
                  (s m)
                  (s 0)))))
+
+(defn to-mills [sec]
+  (* 1000 sec))

--- a/src/status_im/visibility_status_popover/core.cljs
+++ b/src/status_im/visibility_status_popover/core.cljs
@@ -1,0 +1,20 @@
+(ns status-im.visibility-status-popover.core
+  (:require [status-im.utils.fx :as fx]))
+
+(fx/defn show-visibility-status-popover
+  {:events [:show-visibility-status-popover]}
+  [_ value]
+  {:show-visibility-status-popover nil
+   :dispatch-later                 [{:ms 250 :dispatch [:show-visibility-status-popover-db value]}]
+   :dismiss-keyboard               nil})
+
+(fx/defn show-visibility-status-popover-db
+  {:events [:show-visibility-status-popover-db]}
+  [{:keys [db]} value]
+  {:db (assoc db :visibility-status-popover/popover value)})
+
+(fx/defn hide-visibility-status-popover
+  {:events [:hide-visibility-status-popover]}
+  [{:keys [db]}]
+  {:db (dissoc db :visibility-status-popover/popover)
+   :hide-visibility-status-popover nil})

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.89.11",
-    "commit-sha1": "23308d7e8c4b7f5c85bffe870ba92010a3784dcb",
-    "src-sha256": "0zlbzys7g1v3sr67l7fq85mhsk58gkplx8ci7lr5imk9cbciarlx"
+    "version": "feature/online-status-indicator",
+    "commit-sha1": "a6625311a8a188a63f5a2105479f55b80a70fdde",
+    "src-sha256": "1v6gpfcb57xi4hjd1iv1q997yjbk7nvpa0ky7gdrpyla3q0qpp66"
 }

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -4,6 +4,6 @@
     "owner": "status-im",
     "repo": "status-go",
     "version": "feature/online-status-indicator",
-    "commit-sha1": "a6625311a8a188a63f5a2105479f55b80a70fdde",
-    "src-sha256": "1v6gpfcb57xi4hjd1iv1q997yjbk7nvpa0ky7gdrpyla3q0qpp66"
+    "commit-sha1": "2cf515e6a0c9f4b25266d0505f162773589a1f40",
+    "src-sha256": "181bdj73gkcb14ja3x5wf7ifwsx7n8m08j1v7cx64zvx309jn815"
 }

--- a/translations/en.json
+++ b/translations/en.json
@@ -1675,9 +1675,12 @@
     "use-as-profile-picture": "Use as profile picture",
     "view-on-opensea": "View on OpenSea",
     "profile-picture-updated": "Profile picture updated",
-    "status-online": "Online",
+    "status-automatic": "Automatic",
+    "status-automatic-subtitle": "Set status automatically",
     "status-dnd": "Do not disturb",
-    "status-invisible": "Invisible",
-    "subtitle-dnd": "Mutes all notifications",
-    "subtitle-invisible": "Hides your online status"
+    "status-dnd-subtitle": "Mutes all notifications",
+    "status-always-online": "Always Online",
+    "status-always-online-alias": "Online",
+    "status-inactive": "Inactive",
+    "status-inactive-subtitle": "Hides your online status"
 }

--- a/translations/en.json
+++ b/translations/en.json
@@ -1674,5 +1674,10 @@
     "disable-later-in-settings": "You can disable this later in Settings",
     "use-as-profile-picture": "Use as profile picture",
     "view-on-opensea": "View on OpenSea",
-    "profile-picture-updated": "Profile picture updated"
+    "profile-picture-updated": "Profile picture updated",
+    "status-online": "Online",
+    "status-dnd": "Do not disturb",
+    "status-invisible": "Invisible",
+    "subtitle-dnd": "Mutes all notifications",
+    "subtitle-invisible": "Hides your online status"
 }


### PR DESCRIPTION
fixes #12547

### Summary
PR implements Online Status Indicator
<div align="center">
<img src="https://user-images.githubusercontent.com/17097240/137238899-27f531a4-f463-4029-b526-8c906cb7d02f.png" alt="Screenshot" height="400"/>
<img src="https://user-images.githubusercontent.com/17097240/137241282-d597c429-8d44-406e-b178-651982c0aa5e.gif" alt="Screenshot" height="400"/>
<img src="https://user-images.githubusercontent.com/17097240/137238905-4bca1567-61f6-40c0-9e2e-d6456f6c4e23.png" alt="Screenshot" height="400"/>
</div>

PR follows these design guidelines: [Designs](https://www.figma.com/file/TNCyHKtR3sx5EL6YznFWUa4O/Profile?node-id=7253%3A27195)

#### Design Input Required
- Offline white circle looks a little weird above chat icon. Should circle only be visible for online & DND and no circle for offline?
- Options to keep? (online, offline, DND)

#### TODO
Currently, DND is working as an invisible/offline, and the real invisible button don't do anything. This will start working once status-go will include this option.

#### Code
There were some residue code in [styles.cljs](https://github.com/status-im/status-react/pull/12706/files#diff-f54bb761ef81cb3f9f1af35f7080f4edc667f1e88fb816755a5d14d7d442992d) file from 2016 implementation of online status indicator. Currently, it is not used anywhere, so removed to avoid confusion between styles.

Thanks