### PR TITLE
🙅🏻 Add warning and disable option if no profile pic added

### DIFF
--- a/src/status_im/ui/screens/privacy_and_security_settings/views.cljs
+++ b/src/status_im/ui/screens/privacy_and_security_settings/views.cljs
@@ -30,6 +30,7 @@
                           webview-allow-permission-requests?
                           opensea-enabled?
                           profile-pictures-visibility]} [:multiaccount]
+                  has-picture              [:profile/has-picture]
                   supported-biometric-auth [:supported-biometric-auth]
                   keycard?                 [:keycard-multiaccount?]
                   auth-method              [:auth-method]
@@ -135,6 +136,7 @@
      [quo/list-item
       {:size                :small
        :title               (i18n/label :t/show-profile-pictures-to)
+       :disabled            (not has-picture)
        :accessibility-label :show-profile-pictures-to
        :accessory           :text
        :accessory-text      (get titles profile-pictures-show-to)


### PR DESCRIPTION
fixes #12751 

### Summary
- Add a sub title to the setting for "Show profile picture to"
- Disable this setting when no profile picture is applied

### Screenshots for nerds
| No picture 😞 | Yes picture 😊 |
|---|---|
| ![Simulator Screen Shot - iPhone 11 - 2021-10-27 at 15 19 29](https://user-images.githubusercontent.com/1925158/139043356-f706fbee-1f4e-4531-a8f8-ef02e3d0075c.png) | ![Simulator Screen Shot - iPhone 11 - 2021-10-27 at 15 20 03](https://user-images.githubusercontent.com/1925158/139043373-e8ac2bdc-e75d-4524-a2bb-6efcdf20be67.png) | 


status: ready 