### PR TITLE
fix emoji keyboard height for ios devices

### DIFF
--- a/src/status_im/ui/components/emoji_thumbnail/styles.cljs
+++ b/src/status_im/ui/components/emoji_thumbnail/styles.cljs
@@ -1,5 +1,6 @@
 (ns status-im.ui.components.emoji-thumbnail.styles
   (:require [quo.design-system.colors :as colors]
+            [status-im.utils.platform :as platform]
             [status-im.ui.components.emoji-thumbnail.utils :as emoji-utils]))
 
 (defn emoji-thumbnail-icon [color size]
@@ -24,7 +25,8 @@
 
 (def emoji-thumbnail-preview-size 60)
 
-(def emoji-picker-upper-components-size 350)
+(def emoji-picker-upper-components-size
+  (if platform/android? 350 405))
 
 (defn emoji-picker-gray-color []
   (if (colors/dark?) "#c3c3bc99" "#3C3C4399"))


### PR DESCRIPTION
### Summary
While creating a community channel android, shows an emoji categories option, but ios don't
<div align="center">
<img src="https://user-images.githubusercontent.com/17097240/139165241-4093f758-4b2a-4d8e-9536-5e6ab68701ec.png" alt="Screenshot" height="400"/>
<img src="https://user-images.githubusercontent.com/17097240/139164991-b0fd7d97-3796-42da-ba9d-09476d3d5045.PNG" alt="Screenshot" height="400"/>
</div>

But actually, the option is there, just need to scroll the page to access it.

<div align="center">
<img src="https://user-images.githubusercontent.com/17097240/139165422-9816c7a1-4f44-4d85-82f0-f251364abce2.png" alt="Screenshot" height="400"/>
</div>

But as the emoji keyboard itself is a scroll view, so that's why need to scroll from the top side. This is not obvious, so better to change emoji keyboard height.
