### PR TITLE
use a default pairing password Keycard

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "react-native-shake": "^3.3.1",
     "react-native-share": "^7.0.1",
     "react-native-splash-screen": "^3.2.0",
-    "react-native-status-keycard": "git+https://github.com/status-im/react-native-status-keycard.git#v2.5.35",
+    "react-native-status-keycard": "git+https://github.com/status-im/react-native-status-keycard.git#v2.5.36",
     "react-native-svg": "^9.8.4",
     "react-native-touch-id": "^4.4.1",
     "react-native-webview": "git+https://github.com/status-im/react-native-webview.git#v11.3.0-status",

--- a/src/status_im/keycard/onboarding.cljs
+++ b/src/status_im/keycard/onboarding.cljs
@@ -232,11 +232,10 @@
   [{:keys [db] :as cofx} secrets]
   (let [secrets' (js->clj secrets :keywordize-keys true)]
     (fx/merge cofx
-              {:keycard/get-application-info nil
-               :db                              (-> db
-                                                    (assoc-in [:keycard :card-state] :init)
-                                                    (assoc-in [:keycard :setup-step] :secret-keys)
-                                                    (update-in [:keycard :secrets] merge secrets'))}
+              {:db (-> db
+                       (assoc-in [:keycard :card-state] :init)
+                       (assoc-in [:keycard :setup-step] :secret-keys)
+                       (update-in [:keycard :secrets] merge secrets'))}
               (load-pairing-screen))))
 
 (fx/defn on-install-applet-and-init-card-error

--- a/yarn.lock
+++ b/yarn.lock
@@ -6735,9 +6735,9 @@ react-native-splash-screen@^3.2.0:
   resolved "https://registry.yarnpkg.com/react-native-splash-screen/-/react-native-splash-screen-3.2.0.tgz#d47ec8557b1ba988ee3ea98d01463081b60fff45"
   integrity sha512-Ls9qiNZzW/OLFoI25wfjjAcrf2DZ975hn2vr6U9gyuxi2nooVbzQeFoQS5vQcbCt9QX5NY8ASEEAtlLdIa6KVg==
 
-"react-native-status-keycard@git+https://github.com/status-im/react-native-status-keycard.git#v2.5.35":
-  version "2.5.35"
-  resolved "git+https://github.com/status-im/react-native-status-keycard.git#8cf7cbff803b080b2069202ea6179703b8c69d2e"
+"react-native-status-keycard@git+https://github.com/status-im/react-native-status-keycard.git#v2.5.36":
+  version "2.5.36"
+  resolved "git+https://github.com/status-im/react-native-status-keycard.git#7548329c597a6e1370010b8aa2d16a1d93610f11"
 
 react-native-svg@^9.8.4:
   version "9.13.6"


### PR DESCRIPTION
Closes #12685 

The new behaviour is:

1. when creating a new Keycard account with empty/factory reset card, the pairing password will be KeycardDefaultPairing
2. when recovering a Keycard account or restoring pairing in any way, the KeycardDefaultPairing password will be automatically tested before prompting the user for a pairing password. If it succeeds, the user skips the pairing step automatically, otherwise proceeds as before.
