### PR TITLE
Handle confirmations from mailservers

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.91.3",
-    "commit-sha1": "478eb435b19a3ca1c7893259a96b35f81ae3b67f",
-    "src-sha256": "0sp1bcz1vlyvgf2x2ihgp93f14zpmw80x6j76ivk2d3wygmqkh5s"
+    "version": "v0.91.5",
+    "commit-sha1": "1d752c087f34f44bb8ad5dd477e398567d991be8",
+    "src-sha256": "18rfvsfg5hl326rcdwigdx7ssaq57d8ajgjjgsk214b1wbxaa26v"
 }


### PR DESCRIPTION
Makes confirmations a bit more robust.

It should fix an issue with being offline and having your messages confirmed.

On develop currently the behavior is:

1) Have app open and ready on a chat
2) Cut off wifi and immediately after send a message 
Expected:
Message not confirmed
Actual:
Message is confirmed

After this change it will not mark the message as confirmed.

### Testing

This PR will work just as in develop against prod & staging fleet (so it will result in the `Actual` behavior from above). 
The `Expected` behavior needs to be tested against the test fleet.

It should though not have any issue (other than the above) when testing with prod/staging.

Develop though won't work with the test fleet, messages won't get confirmed, that's know, as it's a breaking change.



status: ready