### PR TITLE
Added "Search with DuckDuckGo"

### DIFF
--- a/src/status_im/ui/screens/home/views.cljs
+++ b/src/status_im/ui/screens/home/views.cljs
@@ -107,6 +107,9 @@
                          :on-press (fn []
                                      (debounce/dispatch-and-chill [:contact.ui/contact-code-submitted false] 3000)
                                      (re-frame/dispatch [:search/home-filter-changed nil]))}])
+       
+       ;; Open public chat
+       
        (when valid-public?
          [quo/list-item {:theme    :accent
                          :icon     :main-icons/public-chat
@@ -115,7 +118,27 @@
                          :on-press (fn []
                                      (re-frame/dispatch [:chat.ui/start-public-chat search-value])
                                      (re-frame/dispatch [:set :public-group-topic nil])
-                                     (re-frame/dispatch [:search/home-filter-changed nil]))}])])))
+                                     (re-frame/dispatch [:search/home-filter-changed nil]))}])
+       
+       ;; Search DuckDuckGo
+
+       [quo/list-item {:theme    :accent
+                         :icon     :main-icons/private-chat
+                         :title    search-value
+                         :subtitle (str "Search DuckDuckGo") ;; Needs translation
+                         :on-press (fn []
+                                     (re-frame/dispatch [:browser.ui/open-url (str "https://duckduckgo.com/?q="search-value)])
+                                     (re-frame/dispatch [:search/home-filter-changed nil]))}]
+       
+       ;; Go to URL
+
+       [quo/list-item {:theme    :accent
+                       :icon     :main-icons/private-chat
+                       :title    (str search-value ".com")
+                       :subtitle (str "Go to URL") ;; Needs translation
+                       :on-press (fn []
+                                   (re-frame/dispatch [:browser.ui/open-url (str search-value ".com")])
+                                   (re-frame/dispatch [:search/home-filter-changed nil]))}]])))
 
 (defn render-fn [{:keys [chat-id] :as home-item}]
   ;; We use `chat-id` to distinguish communities from chats


### PR DESCRIPTION
### Summary

This adds the option to do a search on DuckDuckGo or open a tab in the browser directly from the search box on the chat page if no other results are found. This speeds up the searching process and integrates the browser deeper into the app.

### Review notes
This is a work in progress. Help with translations and icons would be much appreciated :)

#### Platforms
- Android
- iOS

### Steps to test
- Open Status
- Type a word that isn't in any of your chats (such as "netflix")
- Check to make sure that that your query can be searched on DuckDuckGo and the URL can be opened

status: wip

https://user-images.githubusercontent.com/65834069/142092208-39973b42-9ab4-4307-81ae-c4e56206b9a4.mp4
