### PR TITLE
Handle Keycard timeout on iOS 15

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -611,7 +611,7 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   Keycard:
-    :commit: abf2be41c70846ab6f11c8bd445faf81b0befc1f
+    :commit: d5bb5d68dbac19a34945918b51873fbba2c18310
     :git: https://github.com/status-im/Keycard.swift.git
   secp256k1:
     :commit: 46a1fa30d9b8babeae85ff519050f42394ab5fcc

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "react-native-shake": "^3.3.1",
     "react-native-share": "^7.0.1",
     "react-native-splash-screen": "^3.2.0",
-    "react-native-status-keycard": "git+https://github.com/status-im/react-native-status-keycard.git#v2.5.36",
+    "react-native-status-keycard": "git+https://github.com/status-im/react-native-status-keycard.git#v2.5.37",
     "react-native-svg": "^9.8.4",
     "react-native-touch-id": "^4.4.1",
     "react-native-webview": "git+https://github.com/status-im/react-native-webview.git#v11.3.0-status",

--- a/src/status_im/keycard/core.cljs
+++ b/src/status_im/keycard/core.cljs
@@ -583,7 +583,7 @@
   {:db (-> db
            (assoc-in [:keycard :nfc-running?] false)
            (assoc-in [:keycard :card-connected?] false))
-   :keycard/start-nfc nil})
+   :dispatch-later [{:ms 500 :dispatch [:keycard.ui/start-nfc]}]})
 
 (fx/defn on-register-card-events
   {:events [:keycard.callback/on-register-card-events]}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6740,9 +6740,9 @@ react-native-splash-screen@^3.2.0:
   resolved "https://registry.yarnpkg.com/react-native-splash-screen/-/react-native-splash-screen-3.2.0.tgz#d47ec8557b1ba988ee3ea98d01463081b60fff45"
   integrity sha512-Ls9qiNZzW/OLFoI25wfjjAcrf2DZ975hn2vr6U9gyuxi2nooVbzQeFoQS5vQcbCt9QX5NY8ASEEAtlLdIa6KVg==
 
-"react-native-status-keycard@git+https://github.com/status-im/react-native-status-keycard.git#v2.5.36":
-  version "2.5.36"
-  resolved "git+https://github.com/status-im/react-native-status-keycard.git#7548329c597a6e1370010b8aa2d16a1d93610f11"
+"react-native-status-keycard@git+https://github.com/status-im/react-native-status-keycard.git#v2.5.37":
+  version "2.5.37"
+  resolved "git+https://github.com/status-im/react-native-status-keycard.git#af61b0213adbf4b5a6bae97c85496d95007d5acb"
 
 react-native-svg@^9.8.4:
   version "9.13.6"


### PR DESCRIPTION
Fixes #12762.

in IOS15 retrying to immediately reopen the NFC dialog after it has been closed for timeout results in an error. The new behaviour is to retry every 500ms until it succeeds. This will results in a small delay between the disappearance of the timed-out dialog and the appearance of the new one, but the application will work normally.