### PR TITLE
Show loading until all messages are processed

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.91.10",
-    "commit-sha1": "7ef2efaabd643a476699d545d22faf36ba066b08",
-    "src-sha256": "0rwpbkqwzk772advqs6g98bqrbcvhs25xwwnfci04pqycklh11zb"
+    "version": "v0.91.12",
+    "commit-sha1": "f60cf5cd47c9f50f1bfb8e01aa5f49802d5220c5",
+    "src-sha256": "10dwxrav77v7xvbzy9camacdflsvpyjnwry638jhgrd4i32x745f"
 }


### PR DESCRIPTION
This build fixes an issue with receiving messages.

Before we would stop showing loading and mark a request as completed as soon as the messages made it to our device, but not necessarily processed.
This caused 2 issues:
1) If the device would be killed while it was processing messages, all those messages would be lost.
2) The "loading..." indicator was not accurate, it would stop showing even though messages were not in the chat.

### Testing

It's hard to replicate in real scenario, so I prepared a couple of builds that intentionally slow down the processing of messages.

One is faulty (old behavior), while the other one includes the fix.

Test faulty behavior:

1) Install build `#4` (https://status-im-prs.ams3.cdn.digitaloceanspaces.com/StatusIm-Mobile-211126-101731-c1102f-pr12834-universal.apk).
2) Join a chat with a known amount of messages (at least 30)
3) Wait 3,4 seconds
4) Kill the app
5) Re-open the app
6) Look at the chat and wait 60 seconds

Expected:
messages are retrieved
Actual:
messages are not retrieved

Also notice that on 3, the "loading..." spinner is gone in the chat, while messages are not there.

To test the fixed behavior, follow the same steps, but use build 5.
The chat should still show "loading..." in step 3, and on reopening the app. 
Messages should be eventually retrieved in step 6.
