### PR TITLE
Decline pending group invitations from user, when user is banned

### DIFF
--- a/src/status_im/chat/models.cljs
+++ b/src/status_im/chat/models.cljs
@@ -129,11 +129,13 @@
                 (map (map-chats cofx) chats))]
     (fx/merge
      cofx
-     {:db (-> db
-              (update :chats merge all-chats)
-              (update :chats-home-list set/union chats-home-list)
-              (update :chats #(apply dissoc % removed-chats))
-              (update :chats-home-list set/difference removed-chats))}
+     (merge {:db (-> db
+                     (update :chats merge all-chats)
+                     (update :chats-home-list set/union chats-home-list)
+                     (update :chats #(apply dissoc % removed-chats))
+                     (update :chats-home-list set/difference removed-chats))}
+            (when (not-empty removed-chats)
+              {:clear-multiple-message-notifications removed-chats}))
      leave-removed-chat)))
 
 (fx/defn clear-history

--- a/src/status_im/communities/core.cljs
+++ b/src/status_im/communities/core.cljs
@@ -14,7 +14,8 @@
    [quo.design-system.colors :as colors]
    [status-im.navigation :as navigation]
    [status-im.utils.handlers :refer [>evt]]
-   [status-im.ui.components.emoji-thumbnail.styles :as emoji-thumbnail-styles]))
+   [status-im.ui.components.emoji-thumbnail.styles :as emoji-thumbnail-styles]
+   [status-im.notifications-center.core :as notification-center]))
 
 (def crop-size 1000)
 
@@ -447,7 +448,8 @@
   [cofx response-js]
   (fx/merge cofx
             (bottom-sheet/hide-bottom-sheet)
-            (handle-response response-js)))
+            (handle-response response-js)
+            (notification-center/get-activity-center-notifications-count)))
 
 (fx/defn member-ban
   {:events [::member-ban]}

--- a/src/status_im/notifications/core.cljs
+++ b/src/status_im/notifications/core.cljs
@@ -92,6 +92,13 @@
    (when platform/android?
      (pn-android/clear-message-notifications chat-id))))
 
+(re-frame/reg-fx
+ :clear-multiple-message-notifications
+ (fn [chat-ids]
+   (when platform/android?
+     (doseq [chat-id chat-ids]
+       (pn-android/clear-message-notifications chat-id)))))
+
 (fx/defn handle-enable-notifications-event
   {:events [::registered-for-push-notifications]}
   [cofx token]

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.91.5",
-    "commit-sha1": "1d752c087f34f44bb8ad5dd477e398567d991be8",
-    "src-sha256": "18rfvsfg5hl326rcdwigdx7ssaq57d8ajgjjgsk214b1wbxaa26v"
+    "version": "v0.91.8",
+    "commit-sha1": "a65c873b8f2633c05a0f108a84ccbc3b8456378a",
+    "src-sha256": "16c8nphz7jkfsgcp2gcv91lhky2ykkz0mrazg03pqdrcnjb2y774"
 }


### PR DESCRIPTION
fixes https://github.com/status-im/status-react/issues/12108

### Summary
PR implements a feature, which auto declines pending group invites from a user when he/she is banned from a community. Group invites on the home screen and also in the activity center will be declined.

<div align="center">
<img src="https://user-images.githubusercontent.com/17097240/142915106-58b62a0c-a1d2-4a49-a162-c334375bf24a.gif" alt="Screenshot" height="400"/>
</div>

#### status-go PR:
https://github.com/status-im/status-go/pull/2437

#### Other features:
- Push notifications from declined invites also will be removed
- Declined invites chats also gets removed from the synced device

#### Known Issue:
- Push notifications from declined invites will be removed only from android devices
- Group invites on the home screen of all synced devices will be removed. 
But as the activity center is not currently synced, invites from the activity center will only be removed from the device banning the user.

#### Todo:
It will be good to auto decline pending group invitations also when the user is blocked 🤔. Will implement this feature in a separate PR. https://github.com/status-im/status-react/issues/12839

status: ready