### PR TITLE
Decline pending group invites from user, when user is blocked

### DIFF
--- a/src/status_im/data_store/contacts.cljs
+++ b/src/status_im/data_store/contacts.cljs
@@ -45,6 +45,7 @@
 (fx/defn block [_ contact-id on-success]
   {::json-rpc/call [{:method (json-rpc/call-ext-method "blockContact")
                      :params [contact-id]
+                     :js-response true
                      :on-success on-success
                      :on-failure #(log/error "failed to block contact" % contact-id)}]})
 

--- a/src/status_im/transport/message/core.cljs
+++ b/src/status_im/transport/message/core.cljs
@@ -81,9 +81,7 @@
         (fx/merge cofx
                   (process-next response-js sync-handler)
                   (models.contact/ensure-contacts
-                   (map data-store.contacts/<-rpc contacts-clj)
-                   (when chats
-                     (map data-store.chats/<-rpc (types/js->clj chats))))))
+                   (map data-store.contacts/<-rpc contacts-clj) chats)))
 
       (seq communities)
       (let [communities-clj (types/js->clj communities)]

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.91.15",
-    "commit-sha1": "258cbb694f040007d3b360638c9390885dcad8ff",
-    "src-sha256": "1rc6pq8js477cxxph25ahzyyga9ygf7cr1gwmayfa9z89mhjqcva"
+    "version": "v0.92.0",
+    "commit-sha1": "83c384989967131afcb47d7f4df673725adf6a71",
+    "src-sha256": "0djagpalbpi4zi54raa28m8vnp0gajpm8fb76wm4mc5rz8542an3"
 }


### PR DESCRIPTION
fixes https://github.com/status-im/status-react/issues/12839

leftover from https://github.com/status-im/status-react/pull/12835

### Summary
PR implements a feature, which auto declines pending group invites from a user when he/she is blocked. Group invites on the home screen and also in the activity center will be declined.

#### status-go PR:
https://github.com/status-im/status-go/pull/2455