### PR TITLE
sync leftovers

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.92.1",
-    "commit-sha1": "3564630c3317f564e4aa10a461448fe2b5a7c54c",
-    "src-sha256": "0rrrydwr7yc9nf9rfpl1vx8ngpkw00q1zdfjw0by9xi49l8lkvf3"
+    "version": "v0.92.2",
+    "commit-sha1": "9feea4fe253d63b84fe7dfa4d3f1fda1a640375a",
+    "src-sha256": "1y70bwphdhaf0h8r4ycg9xiq2md1z61hdj16pky45prz2h1cwc6c"
 }


### PR DESCRIPTION
Close #12875 

Pressing the sync all devices button causes (among other things) the active/inactive state of the device where is pressed to sync to all other devices. This fix avoids syncing chat removals for chats which are inactive but have pending notifications (not accepted/not dismissed).

For issue 3, this means that if the sync button is pressed on the device where the group has not yet been joined the group will remain in the notification area of that phone but going to the notification works correctly. On the device where the group was already active, it will remain active.

To meet the expected behaviour described in the issue completely, we would need the Sync all devices to bidirectionally sync devices and somehow handle eventual conflicts