### PR TITLE
fix pairing for new cards

### DIFF
--- a/src/status_im/keycard/core.cljs
+++ b/src/status_im/keycard/core.cljs
@@ -70,7 +70,9 @@
                   (mnemonic/set-mnemonic))
                 (when (= flow :recovery)
                   (onboarding/proceed-with-generating-key)))
-      (recovery/load-pair-screen cofx))))
+      (if (get-in db [:keycard :secrets :password])
+        (onboarding/load-pairing-screen cofx)
+        (recovery/load-pair-screen cofx)))))
 
 (fx/defn navigate-to-keycard-settings
   {:events [:profile.ui/keycard-settings-button-pressed]}

--- a/src/status_im/keycard/onboarding.cljs
+++ b/src/status_im/keycard/onboarding.cljs
@@ -236,7 +236,10 @@
                        (assoc-in [:keycard :card-state] :init)
                        (assoc-in [:keycard :setup-step] :secret-keys)
                        (update-in [:keycard :secrets] merge secrets'))}
-              (load-pairing-screen))))
+              (common/show-connection-sheet
+               {:on-card-connected :keycard/get-application-info
+                :on-card-read      :keycard/check-card-state
+                :handler           (common/get-application-info :keycard/check-card-state)}))))
 
 (fx/defn on-install-applet-and-init-card-error
   {:events [:keycard.callback/on-install-applet-and-init-card-error


### PR DESCRIPTION
Closes #12876. 

This is a regression introduced by #12811 which in same case caused storing pairing without a instance-uid. When this happened, a second pairing was created on card at the end of the onboarding, so everything would actually work (the second pairing was not created on card, only on status-react side). When cancelling setup however, this would stop working until the app is restarted.