### PR TITLE
[#12898] Fix endless loading in pubchats

### DIFF
--- a/src/status_im/mailserver/core.cljs
+++ b/src/status_im/mailserver/core.cljs
@@ -184,8 +184,9 @@
 
 (fx/defn handle-successful-request
   {:events [::request-success]}
-  [{:keys [db]} response-js]
-  {:db (dissoc db :mailserver/current-request)})
+  [{:keys [db] :as cofx} response-js]
+  {:db       (dissoc db :mailserver/current-request)
+   :dispatch [:sanitize-messages-and-process-response response-js]})
 
 (fx/defn process-next-messages-request
   {:events [::request-messages]}


### PR DESCRIPTION
fix (partially) #12898

In case if a new pubchat was created while offline, `syncedTo`/`syncedFrom` props of the chat wouldn't be updated until after the first successful request to mailserver which means that values would be updated only on the next re-login even if the device is back online. 

status: ready  