### PR TITLE
Fix unique :key warning on add pubchat screen

### DIFF
--- a/src/status_im/ui/screens/add_new/new_public_chat/view.cljs
+++ b/src/status_im/ui/screens/add_new/new_public_chat/view.cljs
@@ -103,4 +103,5 @@
                              (conj chats lang-topic)
                              chats)]
             (for [chat chats]
-              (render-topic chat)))]])]]))
+              ^{:key chat}
+              [render-topic chat]))]])]]))


### PR DESCRIPTION
It is a bit annoying.

status: ready