### PR TITLE
[#10734] Show message timestamps on tap, remove from bubbles 🕙

### DIFF
--- a/src/status_im/ui/screens/chat/message/audio.cljs
+++ b/src/status_im/ui/screens/chat/message/audio.cljs
@@ -181,7 +181,7 @@
                    :message-id @current-player-message-id}))
   nil)
 
-(defview message-content [{:keys [audio audio-duration-ms message-id outgoing]} timestamp-view]
+(defview message-content [{:keys [audio audio-duration-ms message-id outgoing]}]
   (letsubs [state        (reagent/atom nil)
             progress     (reagent/atom 0)
             progress-anim (anim/create-value 0)
@@ -223,5 +223,4 @@
                         (#{:playing :paused :seeking}  (:general @state)) @progress
                         :else (:duration @state))
                  s (quot time 1000)]
-             (gstring/format "%02d:%02d" (quot s 60) (mod s 60)))]
-          timestamp-view]]))))
+             (gstring/format "%02d:%02d" (quot s 60) (mod s 60)))]]]))))

--- a/src/status_im/ui/screens/chat/styles/message/audio.cljs
+++ b/src/status_im/ui/screens/chat/styles/message/audio.cljs
@@ -43,5 +43,5 @@
    :justify-content :space-between})
 
 (defn timestamp [outgoing]
-  (merge (message.style/message-timestamp-text outgoing)
+  (merge (message.style/audio-message-timestamp-text outgoing)
          {:margin-left 40}))

--- a/src/status_im/ui/screens/chat/styles/message/message.cljs
+++ b/src/status_im/ui/screens/chat/styles/message/message.cljs
@@ -29,11 +29,33 @@
 (def message-timestamp
   {:font-size  10})
 
-(defn message-timestamp-placeholder
+(defn message-status-placeholder
   []
   (merge message-timestamp {:opacity 0 :color "rgba(0,0,0,0)"}))
 
-(defn message-timestamp-text
+(defn message-timestamp-wrapper [{:keys [last-in-group? outgoing group-chat]}]
+  {:justify-content :center
+   (if outgoing :margin-right :margin-left) 12 ;; horizontal margin is only required at the adjust side of the message.
+   :margin-top (if (and last-in-group?
+                        (or outgoing
+                            (not group-chat)))
+                 16
+                 0) ;; Add gap between message groups
+   :opacity 0})
+
+(defn message-timestamp-text []
+  (merge message-timestamp
+         {:color       colors/gray
+          :text-align :center}))
+
+(defn message-status-text [outgoing]
+  {:font-size 10
+   :line-height 10
+   :color       (if outgoing
+                  colors/white-transparent-70-persist
+                  colors/gray)})
+
+(defn audio-message-timestamp-text
   [outgoing]
   (merge message-timestamp
          {:line-height 10
@@ -44,7 +66,7 @@
 (defn message-wrapper [{:keys [outgoing in-popover?]}]
   (if (and outgoing (not in-popover?))
     {:margin-left 96}
-    {:margin-right 52}))
+    {:margin-right 96}))
 
 (defn message-author-wrapper
   [outgoing display-photo? in-popover?]
@@ -156,10 +178,10 @@
    :padding-left 3})
 
 (defn emoji-message
-  [{:keys [incoming-group]}]
+  [{:keys [incoming-group outgoing]}]
   {:font-size    28
    :line-height  34                     ;TODO: Smaller crops the icon on the top
-   :margin-right 12
+   :margin-right (if outgoing 18 0) ;; Margin to display outgoing message status
    :margin-top   (if incoming-group 4 0)})
 
 (defn collapse-button []
@@ -170,6 +192,10 @@
    :shadow-radius  16
    :shadow-color   (:shadow-01 @colors/theme)
    :shadow-offset  {:width 0 :height 4}})
+
+(defn message-view-wrapper [outgoing]
+  {:align-self :flex-end
+   :flex-direction (if outgoing :row :row-reverse)})
 
 (defn message-view
   [{:keys [content-type outgoing group-chat last-in-group? mentioned pinned]}]


### PR DESCRIPTION
Fixes #10734 

### Summary
Visible timestamps on all bubbles clutter up the chat and add noise when they're not needed. This PR removes the timestamp from the message bubble. Users can tap on a message and the timestamp will fade in on the longer margin side of the message.

<img src="https://user-images.githubusercontent.com/19279756/146177546-80b98c09-2b71-4245-9272-90c48bea86cd.gif" width="400"/>

#### UI Changes
- Message timestamp is removed from the message bubble.
- Tap on a message and the timestamp will fade in on the longer margin side of the message. 
<img width="215" alt="time-stamp-show-hide" src="https://user-images.githubusercontent.com/19279756/146177831-66805c01-f639-44ac-a760-977f40772925.png">


#### Platforms
- Android
- iOS

#### Areas that maybe impacted
##### Functional
- 1-1 chats
- public chats
- group chats

### Steps to test
- Open Status
- Go to 1-1 chat/public chat/group chat.
- Verify: message timestamps are hidden.
- Tap on a message to view the timestamp.
- Verify: timestamp fades in, then fades out after 2seconds).

status: ready
