### PR TITLE
avoid closing/opening NFC dialog in rapid sequence

### DIFF
--- a/src/status_im/keycard/core.cljs
+++ b/src/status_im/keycard/core.cljs
@@ -525,14 +525,14 @@
     (fx/merge cofx
               {:db (assoc-in db [:keycard :card-state] card-state)}
               (set-setup-step card-state)
-              (common/hide-connection-sheet)
 
               (when paired?
                 (load-pairing))
 
-              (when (and flow
-                         (= card-state :init))
-                (proceed-setup-with-initialized-card flow instance-uid paired?))
+              (if (and flow
+                       (= card-state :init))
+                (proceed-setup-with-initialized-card flow instance-uid paired?)
+                (common/hide-connection-sheet))
 
               (when (= card-state :pre-init)
                 (if (= flow :import)

--- a/src/status_im/keycard/mnemonic.cljs
+++ b/src/status_im/keycard/mnemonic.cljs
@@ -21,6 +21,7 @@
               (assoc-in [:keycard :setup-step] :recovery-phrase)
               (assoc-in [:keycard :secrets :mnemonic] mnemonic))}
      (common/clear-on-card-connected)
+     (common/hide-connection-sheet)
      (navigation/navigate-replace :keycard-onboarding-recovery-phrase nil))))
 
 (fx/defn load-loading-keys-screen


### PR DESCRIPTION
Fixes #12910.

on iOS15 opening/reopening the NFC dialog too fast can cause an error. This error is actually handled correctly and opening is retried, which is why the bug is hard to reproduce (I still didn't manage to reproduce it) but maybe on some specific model/os combination unexpected conditions might happen.

This fix avoids closing/reopening the NFC dialog in rapid sequence, which happened when recovering from mnemonic between the pairing step and key loading step. This has the added advantage of saving about 1-2 seconds (on iOS, on Android it makes no difference).