### PR TITLE
Increase community description character limit

### DIFF
--- a/src/status_im/ui/screens/communities/create.cljs
+++ b/src/status_im/ui/screens/communities/create.cljs
@@ -13,7 +13,7 @@
             [status-im.utils.debounce :as debounce]))
 
 (def max-name-length 30)
-(def max-description-length 140)
+(def max-description-length 600)
 
 (defn valid? [community-name community-description]
   (and (not (str/blank? community-name))


### PR DESCRIPTION
This increases the community character limit to 600 characters, allowing community owners to add rules, an explanation, or other information that require long-form text. 140 characters just isn't enough to say anything useful.