### PR TITLE
Add/Fix rebase overwritten event

### DIFF
--- a/src/status_im/communities/core.cljs
+++ b/src/status_im/communities/core.cljs
@@ -224,7 +224,7 @@
   (let [{:keys [name description membership image]} (get db :communities/create)]
     (let [params {:name name
                   :description description
-                  :membership (or membership constants/community-no-membership-access)
+                  :membership membership
                   :color (rand-nth colors/chat-colors)
                   :image (string/replace-first (str image) #"file://" "")
                   :imageAx 0

--- a/src/status_im/communities/core.cljs
+++ b/src/status_im/communities/core.cljs
@@ -221,12 +221,10 @@
 (fx/defn create
   {:events [::create-confirmation-pressed]}
   [{:keys [db]}]
-  (let [{:keys [name description image]} (get db :communities/create)]
-    ;; If access is ENS only, we set the access to require approval and set the rule
-    ;; of ens only
+  (let [{:keys [name description membership image]} (get db :communities/create)]
     (let [params {:name name
                   :description description
-                  :membership constants/community-on-request-access
+                  :membership (or membership constants/community-no-membership-access)
                   :color (rand-nth colors/chat-colors)
                   :image (string/replace-first (str image) #"file://" "")
                   :imageAx 0

--- a/src/status_im/ui/components/profile_header/view.cljs
+++ b/src/status_im/ui/components/profile_header/view.cljs
@@ -38,7 +38,7 @@
            {:padding-top    subtitle-margin})))
 
 (defn extended-header
-  [{:keys [title photo color subtitle subtitle-icon on-edit on-press monospace
+  [{:keys [title photo color membership subtitle subtitle-icon on-edit on-press monospace
            bottom-separator emoji public-key community?]
     :or   {bottom-separator true}}]
   (fn [{:keys [animation minimized]}]
@@ -70,6 +70,12 @@
                       :accessibility-role  :text
                       :accessibility-label :default-username}
             title]
+           (when membership [quo/text {:number-of-lines 1
+                         :ellipsize-mode  :middle
+                         :monospace       monospace
+                         :size            (if minimized :small :base)
+                         :color           :secondary}
+               membership])
            (when subtitle
              [animated/view {:style          (header-subtitle {:minimized minimized})
                              :pointer-events :box-none}

--- a/src/status_im/ui/components/profile_header/view.cljs
+++ b/src/status_im/ui/components/profile_header/view.cljs
@@ -71,11 +71,11 @@
                       :accessibility-label :default-username}
             title]
            (when membership [quo/text {:number-of-lines 1
-                         :ellipsize-mode  :middle
-                         :monospace       monospace
-                         :size            (if minimized :small :base)
-                         :color           :secondary}
-               membership])
+                                       :ellipsize-mode  :middle
+                                       :monospace       monospace
+                                       :size            (if minimized :small :base)
+                                       :color           :secondary}
+                             membership])
            (when subtitle
              [animated/view {:style          (header-subtitle {:minimized minimized})
                              :pointer-events :box-none}

--- a/src/status_im/ui/screens/communities/create.cljs
+++ b/src/status_im/ui/screens/communities/create.cljs
@@ -9,6 +9,7 @@
             [status-im.utils.image :as utils.image]
             [quo.design-system.colors :as colors]
             [status-im.ui.components.react :as react]
+            [status-im.ui.screens.communities.membership :as memberships]
             [status-im.ui.components.icons.icons :as icons]
             [status-im.utils.debounce :as debounce]))
 
@@ -128,7 +129,7 @@
     (str (count text) "/" max-length)]])
 
 (defn form []
-  (let [{:keys [name description]} (<sub [:communities/create])]
+  (let [{:keys [name description membership editing?]} (<sub [:communities/create])]
     [rn/scroll-view {:keyboard-should-persist-taps :handled
                      :style                   {:flex 1}
                      :content-container-style {:padding-vertical 16}}
@@ -156,7 +157,17 @@
         :on-change-text #(>evt [::communities/create-field :description %])}]]
      [quo/list-header {:color :main}
       (i18n/label :t/community-thumbnail-image)]
-     [photo-picker]]))
+     [photo-picker]
+     (when-not editing? [:<>
+                         [quo/separator {:style {:margin-vertical 10}}]
+                         [quo/list-item {:title          (i18n/label :t/membership-button)
+                                         :accessory-text (i18n/label (get-in memberships/options [membership :title] :t/membership-none))
+                                         :accessory      :text
+                                         :on-press       #(>evt [:navigate-to :community-membership])
+                                         :chevron        true
+                                         :size           :small}]
+                         [quo/list-footer
+                          (i18n/label (get-in memberships/options [membership :description] :t/membership-none-placeholder))]])]))
 
 (defn view []
   (let [{:keys [name description]} (<sub [:communities/create])]

--- a/src/status_im/ui/screens/communities/membership.cljs
+++ b/src/status_im/ui/screens/communities/membership.cljs
@@ -10,13 +10,6 @@
 (def options {constants/community-on-request-access
               {:title       :t/membership-approval
                :description :t/membership-approval-description}
-              constants/community-invitation-only-access
-              {:title       :t/membership-invite
-               :description :t/membership-invite-description}
-; disabled for now
-;              constants/community-rule-ens-only
-;              {:title       :t/membership-ens
-;               :description :t/membership-ens-description}
               constants/community-no-membership-access
               {:title       :t/membership-free
                :description :t/membership-free-description}})

--- a/src/status_im/ui/screens/communities/profile.cljs
+++ b/src/status_im/ui/screens/communities/profile.cljs
@@ -40,9 +40,8 @@
                                                                  (rn/resolve-asset-source
                                                                   (resources/get-image :status-logo)))
                                                                 (get-in community [:images :large :uri]))
-                                                    :membership #_{:clj-kondo/ignore [:missing-else-branch]}
-                                                    (if request-membership?
-                                                      (i18n/label :t/request-membership))
+                                                    :membership (when request-membership?
+                                                                  (i18n/label :t/request-membership))
                                                     :subtitle (if show-members-count?
                                                                 (i18n/label-pluralize members-count :t/community-members {:count members-count})
                                                                 (i18n/label :t/open-membership))

--- a/src/status_im/ui/screens/communities/profile.cljs
+++ b/src/status_im/ui/screens/communities/profile.cljs
@@ -41,8 +41,8 @@
                                                                   (resources/get-image :status-logo)))
                                                                 (get-in community [:images :large :uri]))
                                                     :membership #_{:clj-kondo/ignore [:missing-else-branch]}
-                                                                (if request-membership?
-                                                                  (i18n/label :t/request-membership))
+                                                    (if request-membership?
+                                                      (i18n/label :t/request-membership))
                                                     :subtitle (if show-members-count?
                                                                 (i18n/label-pluralize members-count :t/community-members {:count members-count})
                                                                 (i18n/label :t/open-membership))

--- a/src/status_im/ui/screens/communities/profile.cljs
+++ b/src/status_im/ui/screens/communities/profile.cljs
@@ -23,6 +23,7 @@
             roles                false
             notifications        false
             show-members-count?  (not= (:access permissions) constants/community-no-membership-access)
+            request-membership?  (= (:access permissions) constants/community-on-request-access)
             members-count        (count members)]
         [:<>
          [quo/animated-header {:left-accessories  [{:icon                :main-icons/arrow-left
@@ -39,6 +40,9 @@
                                                                  (rn/resolve-asset-source
                                                                   (resources/get-image :status-logo)))
                                                                 (get-in community [:images :large :uri]))
+                                                    :membership #_{:clj-kondo/ignore [:missing-else-branch]}
+                                                                (if request-membership?
+                                                                  (i18n/label :t/request-membership))
                                                     :subtitle (if show-members-count?
                                                                 (i18n/label-pluralize members-count :t/community-members {:count members-count})
                                                                 (i18n/label :t/open-membership))

--- a/src/status_im/ui/screens/communities/profile.cljs
+++ b/src/status_im/ui/screens/communities/profile.cljs
@@ -41,7 +41,7 @@
                                                                   (resources/get-image :status-logo)))
                                                                 (get-in community [:images :large :uri]))
                                                     :membership (when request-membership?
-                                                                  (i18n/label :t/request-membership))
+                                                                  (i18n/label :t/membership-approval))
                                                     :subtitle (if show-members-count?
                                                                 (i18n/label-pluralize members-count :t/community-members {:count members-count})
                                                                 (i18n/label :t/open-membership))

--- a/src/status_im/ui/screens/profile/contact/views.cljs
+++ b/src/status_im/ui/screens/profile/contact/views.cljs
@@ -205,6 +205,7 @@
                                         :title    first-name
                                         :photo    (multiaccounts/displayed-photo contact)
                                         :monospace (not ens-verified)
+                                        :access second-name
                                         :subtitle second-name
                                         :public-key public-key})]
                                      [react/view {:height 1 :background-color colors/gray-lighter :margin-top 8}]

--- a/src/status_im/ui/screens/profile/contact/views.cljs
+++ b/src/status_im/ui/screens/profile/contact/views.cljs
@@ -205,7 +205,6 @@
                                         :title    first-name
                                         :photo    (multiaccounts/displayed-photo contact)
                                         :monospace (not ens-verified)
-                                        :access second-name
                                         :subtitle second-name
                                         :public-key public-key})]
                                      [react/view {:height 1 :background-color colors/gray-lighter :margin-top 8}]


### PR DESCRIPTION
Re-enables community creation based on 2 types of membership:

- Require approval
- No requirement (Open Membership Community)

Fixes #12548 & Rebase problem based on the other PR 12883 mistakenly closed 

### Summary

This PR re-enables a feature which allows users to define three levels of community membership upon community creation. This feature was disabled by the issue #12147, and re-enabled now.
...

#### Platforms

- Android
- iOS

#### Areas that maybe impacted
- community creation

##### Functional
- community creation

### Steps to test
- Open the app
- Create a community & specify one of the levels of membership

Status: WIP

https://user-images.githubusercontent.com/44679989/147708328-e03e204b-f57d-4759-bdcf-bbef53c7ac69.mov


