### PR TITLE
status-go: extract node configuration to individual tables

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.92.6",
-    "commit-sha1": "36b4ecabbf76bf32397f4ccfe9a923967996b72d",
-    "src-sha256": "108hgl284q4n46bxklr8h2ijgmz76xrdmmsqb4l1nxblbajkm0bf"
+    "version": "feat/node-config",
+    "commit-sha1": "3daf1ea073fe1aa636a9d301a8e2a04acd7adbca",
+    "src-sha256": "1vc70av6jvsch12hyr32hsnh5yqsaavmhy32d20zx3nfb3kxgv12"
 }


### PR DESCRIPTION
### Summary
In this PR the status-go version is updated to use a version that extracts the node configuration from single blob value in the settings table to separate tables. Details for that PR can be seen here: https://github.com/status-im/status-go/pull/2470 . This should be transparent for the user, but just in case it is better to perform QA over this change

### Testing notes
We should test the following scenarios:
1. Having an account that was created in a version previous to this one,  update the status app, login, and guarantee that the account still works fine after migrations are executed
2. Creating a new account / restoring it should work fine

status: ready
