### PR TITLE
always use english for fallback text

### DIFF
--- a/src/status_im/chat/models/input.cljs
+++ b/src/status_im/chat/models/input.cljs
@@ -174,7 +174,7 @@
             {:chat-id      chat-id
              :content-type constants/content-type-image
              :image-path   (utils/safe-replace uri #"file://" "")
-             :text         (i18n/label :t/update-to-see-image)})
+             :text         (i18n/label :t/update-to-see-image {"locale" "en"})})
           images)))
 
 (fx/defn clean-input [{:keys [db] :as cofx} current-chat-id]
@@ -227,7 +227,7 @@
                                      :content-type      constants/content-type-audio
                                      :audio-path        audio-path
                                      :audio-duration-ms duration
-                                     :text              (i18n/label :t/update-to-listen-audio)})))
+                                     :text              (i18n/label :t/update-to-listen-audio {"locale" "en"})})))
 
 (fx/defn send-sticker-message
   [cofx {:keys [hash pack]} current-chat-id]
@@ -236,7 +236,7 @@
                                      :content-type constants/content-type-sticker
                                      :sticker {:hash hash
                                                :pack pack}
-                                     :text    (i18n/label :t/update-to-see-sticker)})))
+                                     :text    (i18n/label :t/update-to-see-sticker {"locale" "en"})})))
 
 (fx/defn send-edited-message [{:keys [db] :as cofx} text {:keys [message-id]}]
   (fx/merge


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

Fixes #12995 

### Summary

[comment]: # (Summarise the problem and how the pull request solves it)

Always uses English fallback texts for stickers, images and audio.

#### Areas that maybe impacted
- sticker messages
- audio messages
- image messages

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- set simulator/system language to something other than English
- Open Status
- run re-frisk
- send sticker, audio and image messages
- make sure that the fallback text is in English in the debugger

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready
