### PR TITLE
Increase group size to 50 members

### DIFF
--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -68,7 +68,7 @@
 (def ^:const profile-pictures-visibility-none 3)
 
 (def ^:const min-password-length 6)
-(def ^:const max-group-chat-participants 20)
+(def ^:const max-group-chat-participants 50)
 (def ^:const default-number-of-messages 20)
 (def ^:const default-number-of-pin-messages 3)
 


### PR DESCRIPTION
This PR increases the group chat size to 50 members. Increased group sizes are a highly requested feature, especially since Communities aren't rolled out officially.
I have tested this with over 100 real people in a group, and it was also functioning normally with 50.

status: ready
