### PR TITLE
Share image message

### DIFF
--- a/src/status_im/chat/models/message.cljs
+++ b/src/status_im/chat/models/message.cljs
@@ -6,6 +6,8 @@
             [status-im.data-store.messages :as data-store.messages]
             [status-im.ethereum.json-rpc :as json-rpc]
             [status-im.transport.message.protocol :as protocol]
+            [status-im.bottom-sheet.core :as bottom-sheet]
+            [status-im.navigation :as navigation]
             [status-im.utils.fx :as fx]
             [taoensso.timbre :as log]
             [status-im.chat.models.mentions :as mentions]
@@ -196,6 +198,13 @@
                          :on-error   #(do
                                         (log/error "failed to share image message" %)
                                         (re-frame/dispatch [::failed-to-share-image %]))}]})))
+
+(fx/defn share-to-contacts-pressed
+  {:events [::share-to-contacts-pressed]}
+  [cofx message]
+  (fx/merge cofx
+            (bottom-sheet/hide-bottom-sheet)
+            (navigation/open-modal :share-to-contacts {:message message})))
 
 
 (fx/defn delete-message

--- a/src/status_im/chat/models/message.cljs
+++ b/src/status_im/chat/models/message.cljs
@@ -185,11 +185,11 @@
 (fx/defn share-to-contacts-pressed
   {:events [::share-to-contacts-pressed]}
   [{:keys [db] :as cofx}
-  {:keys [message-id content-type] :as message}]
+   {:keys [message-id content-type] :as message}]
   (fx/merge cofx
-            (navigation/open-modal 
-              :share-to-contacts {:message-id message-id
-                                  :content-type content-type})))
+            (navigation/open-modal
+             :share-to-contacts {:message-id message-id
+                                 :content-type content-type})))
 
 
 (fx/defn delete-message

--- a/src/status_im/chat/models/message.cljs
+++ b/src/status_im/chat/models/message.cljs
@@ -182,33 +182,15 @@
                                :on-error #(log/error "failed to re-send message" %)}]}
             (update-message-status chat-id message-id :sending)))
 
-(fx/defn share-image-to-contacts-pressed
-  {:events [::share-image-to-contacts-pressed]}
-  [cofx user-pk contacts message-id]
-  (let [pks (if (seq user-pk)
-              (conj contacts user-pk)
-              contacts)]
-    (when (seq pks)
-      {::json-rpc/call [{:method     "wakuext_shareImageMessage"
-                         :params     [{:id message-id
-                                       :users pks}]
-                         :js-response true
-                         :on-success #(re-frame/dispatch [::home %])
-                         :on-error   #(do
-                                        (log/error "failed to share image message" %)
-                                        (re-frame/dispatch [::failed-to-share-image %]))}]})))
-
 (fx/defn share-to-contacts-pressed
   {:events [::share-to-contacts-pressed]}
-  [{:keys [db] :as cofx} chat-id message-id]
+  [{:keys [db] :as cofx}
+  {:keys [message-id content-type] :as message}]
   (fx/merge cofx
-            (navigation/open-modal :share-to-contacts {:chat-id chat-id :message-id message-id})))
+            (navigation/open-modal 
+              :share-to-contacts {:message-id message-id
+                                  :content-type content-type})))
 
-;;(fx/defn reset-image-id-input [{:keys [db]} id]
-;;{:db (assoc db :messages/messages-input-id id)})
-
-;;(defn fetch-image-id-input [{:keys [db]}]
-;;(:messages/messages-input-id db))
 
 (fx/defn delete-message
   "Deletes chat message, rebuild message-list"

--- a/src/status_im/chat/models/message.cljs
+++ b/src/status_im/chat/models/message.cljs
@@ -181,6 +181,23 @@
                                :on-error #(log/error "failed to re-send message" %)}]}
             (update-message-status chat-id message-id :sending)))
 
+(fx/defn share-image-message
+  {:events [::share-community-confirmation-pressed]}
+  [cofx user-pk contacts message-id]
+  (let [pks (if (seq user-pk)
+              (conj contacts user-pk)
+              contacts)]
+    (when (seq pks)
+      {::json-rpc/call [{:method     "wakuext_shareImageMessage"
+                         :params     [{:id message-id
+                                       :users pks}]
+                         :js-response true
+                         :on-success #(re-frame/dispatch [::people-shared-to %])
+                         :on-error   #(do
+                                        (log/error "failed to share image message" %)
+                                        (re-frame/dispatch [::failed-to-share-image %]))}]})))
+
+
 (fx/defn delete-message
   "Deletes chat message, rebuild message-list"
   {:events [:chat.ui/delete-message]}

--- a/src/status_im/chat/models/message.cljs
+++ b/src/status_im/chat/models/message.cljs
@@ -6,7 +6,6 @@
             [status-im.data-store.messages :as data-store.messages]
             [status-im.ethereum.json-rpc :as json-rpc]
             [status-im.transport.message.protocol :as protocol]
-            [status-im.bottom-sheet.core :as bottom-sheet]
             [status-im.navigation :as navigation]
             [status-im.utils.fx :as fx]
             [taoensso.timbre :as log]
@@ -202,7 +201,7 @@
 (fx/defn share-to-contacts-pressed
   {:events [::share-to-contacts-pressed]}
   [{:keys [db] :as cofx} chat-id message-id]
-  (fx/merge cofx 
+  (fx/merge cofx
             (navigation/open-modal :share-to-contacts {:chat-id chat-id :message-id message-id})))
 
 ;;(fx/defn reset-image-id-input [{:keys [db]} id]

--- a/src/status_im/chat/models/message.cljs
+++ b/src/status_im/chat/models/message.cljs
@@ -183,8 +183,8 @@
                                :on-error #(log/error "failed to re-send message" %)}]}
             (update-message-status chat-id message-id :sending)))
 
-(fx/defn share-image-message
-  {:events [::share-community-confirmation-pressed]}
+(fx/defn share-image-to-contacts-pressed
+  {:events [::share-image-to-contacts-pressed]}
   [cofx user-pk contacts message-id]
   (let [pks (if (seq user-pk)
               (conj contacts user-pk)
@@ -194,18 +194,22 @@
                          :params     [{:id message-id
                                        :users pks}]
                          :js-response true
-                         :on-success #(re-frame/dispatch [::people-shared-to %])
+                         :on-success #(re-frame/dispatch [::home %])
                          :on-error   #(do
                                         (log/error "failed to share image message" %)
                                         (re-frame/dispatch [::failed-to-share-image %]))}]})))
 
 (fx/defn share-to-contacts-pressed
   {:events [::share-to-contacts-pressed]}
-  [cofx message]
-  (fx/merge cofx
-            (bottom-sheet/hide-bottom-sheet)
-            (navigation/open-modal :share-to-contacts {:message message})))
+  [{:keys [db] :as cofx} chat-id message-id]
+  (fx/merge cofx 
+            (navigation/open-modal :share-to-contacts {:chat-id chat-id :message-id message-id})))
 
+;;(fx/defn reset-image-id-input [{:keys [db]} id]
+;;{:db (assoc db :messages/messages-input-id id)})
+
+;;(defn fetch-image-id-input [{:keys [db]}]
+;;(:messages/messages-input-id db))
 
 (fx/defn delete-message
   "Deletes chat message, rebuild message-list"

--- a/src/status_im/ethereum/json_rpc.cljs
+++ b/src/status_im/ethereum/json_rpc.cljs
@@ -66,6 +66,7 @@
    "wakuext_createGroupChatWithMembers" {}
    "wakuext_createGroupChatFromInvitation" {}
    "wakuext_reSendChatMessage" {}
+   "wakuext_shareImageMessage" {}
    "wakuext_getOurInstallations" {}
    "wakuext_setInstallationMetadata" {}
    "wakuext_loadFilters" {}

--- a/src/status_im/subs.cljs
+++ b/src/status_im/subs.cljs
@@ -222,6 +222,7 @@
 (reg-root-key-sub ::pagination-info :pagination-info)
 (reg-root-key-sub ::pin-message-lists :pin-message-lists)
 (reg-root-key-sub ::pin-messages :pin-messages)
+(reg-root-key-sub :messages/messages-input-id :messages/messages-input-id)
 
 (reg-root-key-sub :tos-accept-next-root :tos-accept-next-root)
 

--- a/src/status_im/transport/message/protocol.cljs
+++ b/src/status_im/transport/message/protocol.cljs
@@ -38,7 +38,7 @@
                                        :id message-id
                                        :contentType content-type}]
                          :js-response true
-                         :on-success #(re-frame/dispatch [:transport/message-sent %])
+                         :on-success #(re-frame/dispatch [:navigate-back])
                          :on-error   #(do
                                         (log/error "failed to share image message" %)
                                         (re-frame/dispatch [::failed-to-share-image %]))}]})))   

--- a/src/status_im/transport/message/protocol.cljs
+++ b/src/status_im/transport/message/protocol.cljs
@@ -26,6 +26,23 @@
    :sticker         sticker
    :contentType     content-type})
 
+(fx/defn share-image-to-contacts-pressed
+  {:events [::share-image-to-contacts-pressed]}
+  [cofx user-pk contacts message-id content-type]
+  (let [pks (if (seq user-pk)
+              (conj contacts user-pk)
+              contacts)]
+    (when (seq pks)
+      {::json-rpc/call [{:method     "wakuext_shareImageMessage"
+                         :params     [{:users pks
+                                       :id message-id
+                                       :contentType content-type}]
+                         :js-response true
+                         :on-success #(re-frame/dispatch [:transport/message-sent %])
+                         :on-error   #(do
+                                        (log/error "failed to share image message" %)
+                                        (re-frame/dispatch [::failed-to-share-image %]))}]})))   
+
 (fx/defn send-chat-messages [_ messages]
   {::json-rpc/call [{:method     (json-rpc/call-ext-method "sendChatMessages")
                      :params     [(mapv build-message messages)]

--- a/src/status_im/ui/screens/chat/invite.cljs
+++ b/src/status_im/ui/screens/chat/invite.cljs
@@ -5,10 +5,10 @@
             [status-im.i18n.i18n :as i18n]
             [status-im.ui.components.toolbar :as toolbar]
             [status-im.utils.handlers :refer [<sub >evt-once]]
-            [status-im.contact.chat :as chat]
+            [status-im.chat.models.message :as chat-model]
             [status-im.ui.components.topbar :as topbar]
             [status-im.ui.components.chat-icon.screen :as chat-icon.screen]
-            [status-im.multiaccounts.core :as multiaccounts]
+            [status-im.multiaccounts.core :as multiaccounts]            
             [clojure.string :as str]))
 
 (defn header [user-pk]
@@ -41,7 +41,7 @@
 (defn invite []
   (let [user-pk           (reagent/atom "")
         contacts-selected (reagent/atom #{})
-        {:keys [message]} (<sub [:get-screen-params])]
+        {:keys [message-id]} (<sub [:get-screen-params])]
     (fn []
       (let [contacts-data               (<sub [:contacts/active])
             selected                    @contacts-selected
@@ -65,5 +65,6 @@
            [quo/button {:disabled (and (str/blank? @user-pk)
                                        (zero? (count selected)))
                         :type     :secondary
-                        :on-press #(>evt-once [::chat/share-image-to-contacts-pressed @user-pk selected message])}
+                        :on-press #(>evt-once [::chat-model/share-image-to-contacts-pressed
+                                               @user-pk selected message-id])}
             (i18n/label :t/share)]}]]))))

--- a/src/status_im/ui/screens/chat/invite.cljs
+++ b/src/status_im/ui/screens/chat/invite.cljs
@@ -8,7 +8,7 @@
             [status-im.chat.models.message :as chat-model]
             [status-im.ui.components.topbar :as topbar]
             [status-im.ui.components.chat-icon.screen :as chat-icon.screen]
-            [status-im.multiaccounts.core :as multiaccounts]            
+            [status-im.multiaccounts.core :as multiaccounts]
             [clojure.string :as str]))
 
 (defn header [user-pk]

--- a/src/status_im/ui/screens/chat/invite.cljs
+++ b/src/status_im/ui/screens/chat/invite.cljs
@@ -1,0 +1,69 @@
+(ns status-im.ui.screens.chat.invite
+  (:require [reagent.core :as reagent]
+            [quo.react-native :as rn]
+            [quo.core :as quo]
+            [status-im.i18n.i18n :as i18n]
+            [status-im.ui.components.toolbar :as toolbar]
+            [status-im.utils.handlers :refer [<sub >evt-once]]
+            [status-im.contact.chat :as chat]
+            [status-im.ui.components.topbar :as topbar]
+            [status-im.ui.components.chat-icon.screen :as chat-icon.screen]
+            [status-im.multiaccounts.core :as multiaccounts]
+            [clojure.string :as str]))
+
+(defn header [user-pk]
+  [:<>
+   [rn/view {:style {:padding-horizontal 16
+                     :padding-vertical   8}}
+    [quo/text-input
+     {:label          (i18n/label :t/enter-user-pk)
+      :placeholder    (i18n/label :t/enter-user-pk)
+      :on-change-text #(reset! user-pk %)
+      :default-value  @user-pk
+      :auto-focus     true}]]
+   [quo/separator {:style {:margin-vertical 8}}]
+   [quo/list-header (i18n/label :t/contacts)]])
+
+(defn contacts-list-item [{:keys [public-key active] :as contact} _ _ {:keys [selected]}]
+  (let [[first-name second-name] (multiaccounts/contact-two-names contact true)]
+    [quo/list-item
+     {:title     first-name
+      :subtitle  second-name
+      :icon      [chat-icon.screen/contact-icon-contacts-tab
+                  (multiaccounts/displayed-photo contact)]
+      :accessory :checkbox
+      :active    active
+      :on-press  (fn []
+                   (if active
+                     (swap! selected disj public-key)
+                     (swap! selected conj public-key)))}]))
+
+(defn invite []
+  (let [user-pk           (reagent/atom "")
+        contacts-selected (reagent/atom #{})
+        {:keys [message]} (<sub [:get-screen-params])]
+    (fn []
+      (let [contacts-data               (<sub [:contacts/active])
+            selected                    @contacts-selected
+            contacts                    (map (fn [{:keys [public-key] :as contact}]
+                                               (assoc contact :active (contains? selected public-key)))
+                                             contacts-data)]
+        [:<>
+         [topbar/topbar {:title (i18n/label :t/community-share-title)
+                         :modal? true}]
+         [rn/flat-list {:style                   {:flex 1}
+                        :content-container-style {:padding-vertical 16}
+                          ;:header                  [header user-pk]
+                        :render-data             {:selected contacts-selected}
+                        :render-fn               contacts-list-item
+                        :key-fn                  (fn [{:keys [active public-key]}]
+                                                   (str public-key active))
+                        :data                    contacts}]
+         [toolbar/toolbar
+          {:show-border? true
+           :center
+           [quo/button {:disabled (and (str/blank? @user-pk)
+                                       (zero? (count selected)))
+                        :type     :secondary
+                        :on-press #(>evt-once [::chat/share-image-to-contacts-pressed @user-pk selected message])}
+            (i18n/label :t/share)]}]]))))

--- a/src/status_im/ui/screens/chat/message/message.cljs
+++ b/src/status_im/ui/screens/chat/message/message.cljs
@@ -50,7 +50,7 @@
 
 (defview mention-element [from]
   (letsubs [contact-name [:contacts/contact-name-by-identity from]]
-           contact-name))
+    contact-name))
 
 (def edited-at-text (str " ⌫ " (i18n/label :t/edited)))
 
@@ -90,25 +90,25 @@
 (defview quoted-message
   [_ {:keys [from parsed-text image]} outgoing current-public-key public? pinned]
   (letsubs [contact-name [:contacts/contact-name-by-identity from]]
-           [react/view {:style (style/quoted-message-container (and outgoing (not pinned)))}
-            [react/view {:style style/quoted-message-author-container}
-             [chat.utils/format-reply-author
-              from
-              contact-name
-              current-public-key
-              (partial style/quoted-message-author (and outgoing (not pinned)))
-              (and outgoing (not pinned))]]
-            (if (and image
+    [react/view {:style (style/quoted-message-container (and outgoing (not pinned)))}
+     [react/view {:style style/quoted-message-author-container}
+      [chat.utils/format-reply-author
+       from
+       contact-name
+       current-public-key
+       (partial style/quoted-message-author (and outgoing (not pinned)))
+       (and outgoing (not pinned))]]
+     (if (and image
               ;; Disabling images for public-chats
-                     (not public?))
-              [react/image {:style  {:width            56
-                                     :height           56
-                                     :background-color :black
-                                     :border-radius    4}
-                            :source {:uri image}}]
-              [react/text {:style           (style/quoted-message-text (and outgoing (not pinned)))
-                           :number-of-lines 5}
-               (components.reply/get-quoted-text-with-mentions parsed-text)])]))
+              (not public?))
+       [react/image {:style  {:width            56
+                              :height           56
+                              :background-color :black
+                              :border-radius    4}
+                     :source {:uri image}}]
+       [react/text {:style           (style/quoted-message-text (and outgoing (not pinned)))
+                    :number-of-lines 5}
+        (components.reply/get-quoted-text-with-mentions parsed-text)])]))
 
 (defn render-inline [message-text outgoing pinned content-type acc {:keys [type literal destination]}]
   (case type
@@ -271,42 +271,42 @@
 
 (defview message-author-name [from opts]
   (letsubs [contact-with-names [:contacts/contact-by-identity from]]
-           (chat.utils/format-author contact-with-names opts)))
+    (chat.utils/format-author contact-with-names opts)))
 
 (defview message-my-name [opts]
   (letsubs [contact-with-names [:multiaccount/contact]]
-           (chat.utils/format-author contact-with-names opts)))
+    (chat.utils/format-author contact-with-names opts)))
 
 (defview community-content [{:keys [community-id] :as message}]
   (letsubs [{:keys [name description verified] :as community} [:communities/community community-id]
             communities-enabled? [:communities/enabled?]]
-           (when (and communities-enabled? community)
-             [react/view {:style (assoc (style/message-wrapper message)
-                                        :margin-vertical 10
-                                        :margin-left 8
-                                        :width 271)}
-              (when verified
-                [react/view (style/community-verified)
-                 [react/text {:style {:font-size 13
-                                      :color colors/blue}} (i18n/label :t/communities-verified)]])
-              [react/view (style/community-message verified)
-               [react/view {:width 62
-                            :padding-left 14}
-                (if (= community-id constants/status-community-id)
-                  [react/image {:source (resources/get-image :status-logo)
-                                :style {:width 40
-                                        :height 40}}]
-                  [communities.icon/community-icon community])]
-               [react/view {:padding-right 14 :flex 1}
-                [react/text {:style {:font-weight "700" :font-size 17}}
-                 name]
-                [react/text description]]]
-              [react/view (style/community-view-button)
-               [react/touchable-highlight {:on-press #(re-frame/dispatch [:navigate-to
-                                                                          :community
-                                                                          {:community-id (:id community)}])}
-                [react/text {:style {:text-align :center
-                                     :color colors/blue}} (i18n/label :t/view)]]]])))
+    (when (and communities-enabled? community)
+      [react/view {:style (assoc (style/message-wrapper message)
+                                 :margin-vertical 10
+                                 :margin-left 8
+                                 :width 271)}
+       (when verified
+         [react/view (style/community-verified)
+          [react/text {:style {:font-size 13
+                               :color colors/blue}} (i18n/label :t/communities-verified)]])
+       [react/view (style/community-message verified)
+        [react/view {:width 62
+                     :padding-left 14}
+         (if (= community-id constants/status-community-id)
+           [react/image {:source (resources/get-image :status-logo)
+                         :style {:width 40
+                                 :height 40}}]
+           [communities.icon/community-icon community])]
+        [react/view {:padding-right 14 :flex 1}
+         [react/text {:style {:font-weight "700" :font-size 17}}
+          name]
+         [react/text description]]]
+       [react/view (style/community-view-button)
+        [react/touchable-highlight {:on-press #(re-frame/dispatch [:navigate-to
+                                                                   :community
+                                                                   {:community-id (:id community)}])}
+         [react/text {:style {:text-align :center
+                              :color colors/blue}} (i18n/label :t/view)]]]])))
 
 (defn message-content-wrapper
   "Author, userpic and delivery wrapper"

--- a/src/status_im/ui/screens/chat/message/message.cljs
+++ b/src/status_im/ui/screens/chat/message/message.cljs
@@ -571,9 +571,10 @@
                          :source {:uri (contenthash/url (-> content :sticker :hash))}}]]
      reaction-picker]))
 
-(defmethod ->message constants/content-type-image [{:keys [content in-popover?] :as message} {:keys [on-long-press modal]
-                                                                                              :as   reaction-picker}]
-  [message-content-wrapper message
+(defmethod ->message constants/content-type-image 
+[{:keys [content in-popover?] :as message}
+ {:keys [on-long-press modal] :as   reaction-picker}]
+   [message-content-wrapper message
    [message-content-image message {:modal         modal
                                    :disabled      in-popover?
                                    :delay-long-press 100

--- a/src/status_im/ui/screens/chat/message/message.cljs
+++ b/src/status_im/ui/screens/chat/message/message.cljs
@@ -24,7 +24,7 @@
             [status-im.ui.screens.chat.components.reply :as components.reply]
             [status-im.ui.screens.chat.message.link-preview :as link-preview]
             [status-im.ui.screens.communities.icon :as communities.icon]
-            [status-im.communities.core :as communities]
+            [status-im.chat.models.message :as message]
             [status-im.utils.handlers :refer [>evt]]
             [status-im.ui.components.animation :as animation]
             [status-im.chat.models.pin-message :as models.pin-message])
@@ -582,7 +582,7 @@
                                                      [{:on-press #(re-frame/dispatch [:chat.ui/reply-to-message message])
                                                        :id       :reply
                                                        :label    (i18n/label :t/message-reply)}
-                                                      {:on-press            #(>evt [::communities/share-to-contacts-pressed message])
+                                                      {:on-press            #(>evt [::message/share-to-contacts-pressed message])
                                                        :id                :share
                                                        :label               (i18n/label :t/share)}
                                                       {:on-press #(re-frame/dispatch [:chat.ui/save-image-to-gallery (:image content)])

--- a/src/status_im/ui/screens/chat/share.cljs
+++ b/src/status_im/ui/screens/chat/share.cljs
@@ -1,11 +1,11 @@
-(ns status-im.ui.screens.chat.invite
+(ns status-im.ui.screens.chat.share
   (:require [reagent.core :as reagent]
             [quo.react-native :as rn]
             [quo.core :as quo]
             [status-im.i18n.i18n :as i18n]
             [status-im.ui.components.toolbar :as toolbar]
             [status-im.utils.handlers :refer [<sub >evt-once]]
-            [status-im.chat.models.message :as chat-model]
+            [ status-im.transport.message.protocol :as protocol]
             [status-im.ui.components.topbar :as topbar]
             [status-im.ui.components.chat-icon.screen :as chat-icon.screen]
             [status-im.multiaccounts.core :as multiaccounts]
@@ -38,10 +38,11 @@
                      (swap! selected disj public-key)
                      (swap! selected conj public-key)))}]))
 
-(defn invite []
+(defn share []
   (let [user-pk           (reagent/atom "")
         contacts-selected (reagent/atom #{})
-        {:keys [message-id]} (<sub [:get-screen-params])]
+        {:keys [message-id]} (<sub [:get-screen-params])      
+        {:keys [content-type]} (<sub [:get-screen-params])]
     (fn []
       (let [contacts-data               (<sub [:contacts/active])
             selected                    @contacts-selected
@@ -65,6 +66,6 @@
            [quo/button {:disabled (and (str/blank? @user-pk)
                                        (zero? (count selected)))
                         :type     :secondary
-                        :on-press #(>evt-once [::chat-model/share-image-to-contacts-pressed
-                                               @user-pk selected message-id])}
+                        :on-press #(>evt-once [::protocol/share-image-to-contacts-pressed
+                                               @user-pk selected message-id content-type])}
             (i18n/label :t/share)]}]]))))

--- a/src/status_im/ui/screens/chat/share.cljs
+++ b/src/status_im/ui/screens/chat/share.cljs
@@ -41,7 +41,7 @@
 (defn share []
   (let [user-pk           (reagent/atom "")
         contacts-selected (reagent/atom #{})
-        {:keys [message-id]} (<sub [:get-screen-params])      
+        {:keys [message-id]} (<sub [:get-screen-params])
         {:keys [content-type]} (<sub [:get-screen-params])]
     (fn []
       (let [contacts-data               (<sub [:contacts/active])

--- a/src/status_im/ui/screens/screens.cljs
+++ b/src/status_im/ui/screens/screens.cljs
@@ -621,6 +621,8 @@
 
 
            ;[Chat] Link preview settings
+
+
            {:name      :link-preview-settings
             :options   {:topBar {:title {:text (i18n/label :t/chat-link-previews)}}}
             :component link-previews-settings/link-previews-settings}

--- a/src/status_im/ui/screens/screens.cljs
+++ b/src/status_im/ui/screens/screens.cljs
@@ -23,7 +23,7 @@
             [status-im.ui.screens.bug-report :as bug-report]
             [status-im.ui.screens.chat.pinned-messages :as pin-messages]
             [status-im.ui.screens.chat.views :as chat]
-            [status-im.ui.screens.chat.invite :as chat.invite]
+            [status-im.ui.screens.chat.share :as chat.share]
             [status-im.ui.screens.communities.channel-details :as communities.channel-details]
             [status-im.ui.screens.communities.community :as community]
             [status-im.ui.screens.communities.community-emoji-thumbnail-picker :as community-emoji-thumbnail-picker]
@@ -616,7 +616,7 @@
            {:name      :share-to-contacts
             :options   {:topBar {:visible false}
                         :cofx :cofx}
-            :component chat.invite/invite
+            :component chat.share/share
             :insets    {:bottom true}}
 
 

--- a/src/status_im/ui/screens/screens.cljs
+++ b/src/status_im/ui/screens/screens.cljs
@@ -23,6 +23,7 @@
             [status-im.ui.screens.bug-report :as bug-report]
             [status-im.ui.screens.chat.pinned-messages :as pin-messages]
             [status-im.ui.screens.chat.views :as chat]
+            [status-im.ui.screens.chat.invite :as chat.invite]
             [status-im.ui.screens.communities.channel-details :as communities.channel-details]
             [status-im.ui.screens.communities.community :as community]
             [status-im.ui.screens.communities.community-emoji-thumbnail-picker :as community-emoji-thumbnail-picker]
@@ -610,6 +611,14 @@
             :insets    {:bottom true}
             :options   {:topBar {:title {:text (i18n/label :t/new-public-group-chat)}}}
             :component new-public-chat/new-public-chat}
+
+           ;[Chat] Share Images message
+           {:name      :share-to-contacts
+            :options   {:topBar {:visible false}
+                        :cofx :cofx}
+            :component chat.invite/invite
+            :insets    {:bottom true}}
+
 
            ;[Chat] Link preview settings
            {:name      :link-preview-settings

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "share-image",
-    "commit-sha1": "b9a981b451f70fae4b702e324fc92d24585b6d8b",
-    "src-sha256": "1n4j3vn90wmjwx9276zchbzg820q0ymzvvy6myvhbg6a08ac8xj8"
+    "version": "v0.94.0",
+    "commit-sha1": "5925b3b7cca127805c200a631e9b88d4ce5d31d5",
+    "src-sha256": "0wzlvap62m85rqn69vy7a3ny1kjcaxfhrzcjsx2p16xwjmi0i1rm"
 }

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.92.7",
-    "commit-sha1": "f1569e4bde50e993611288a59b7a415a010cbfa8",
-    "src-sha256": "12qj6p5m25z7ypgm9yxrg98lcc096sl2pwdks2iwlip585xsrc0h"
+    "version": "share-image",
+    "commit-sha1": "b9a981b451f70fae4b702e324fc92d24585b6d8b",
+    "src-sha256": "1n4j3vn90wmjwx9276zchbzg820q0ymzvvy6myvhbg6a08ac8xj8"
 }

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.94.0",
-    "commit-sha1": "5925b3b7cca127805c200a631e9b88d4ce5d31d5",
-    "src-sha256": "0wzlvap62m85rqn69vy7a3ny1kjcaxfhrzcjsx2p16xwjmi0i1rm"
+    "version": "share-image",
+    "commit-sha1": "d6995083836876f482392e8901f6e1904d0f2cb1",
+    "src-sha256": "0v6amrjxywi15qncm3m3xgh94249scrgfjyvbdwzrah71xyqw4h8"
 }


### PR DESCRIPTION
This PR adds the option and the fronted functionality to share image messages to multiple selected contacts 

fixes #12480 

### Testing notes
Long press on an image
Click share option
Select contacts to share to

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS
- macOS
- Linux
- Windows

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- 1-1 chats
- public chats
- group chats
- wallet / transactions
- dapps / app browsing
- account recovery
- new account
- user profile updates
- networks
- mailservers
- fleet
- bootnodes

##### Non-functional

- battery performance
- CPU performance / speed of the app
- network consumption

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open Status
- ...
- Step 3, etc.

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->
