### PR TITLE
[#13046] No value in 'Gas amount limit' field in NFT dapps by default

### DIFF
--- a/src/status_im/signing/gas.cljs
+++ b/src/status_im/signing/gas.cljs
@@ -387,10 +387,7 @@
 (re-frame/reg-fx
  :signing/update-estimated-gas
  (fn [{:keys [obj success-event error-event]}]
-   (let [value (:value obj)]
-     (json-rpc/call {:method     "eth_estimateGas"
-                     :params     [(if value
-                                    (assoc obj :value "0x0")
-                                    obj)]
-                     :on-success #(re-frame/dispatch [success-event %])
-                     :on-error   #(re-frame/dispatch [error-event %])}))))
+   (json-rpc/call {:method     "eth_estimateGas"
+                   :params     [obj]
+                   :on-success #(re-frame/dispatch [success-event %])
+                   :on-error   #(re-frame/dispatch [error-event %])})))

--- a/src/status_im/wallet/core.cljs
+++ b/src/status_im/wallet/core.cljs
@@ -472,7 +472,11 @@
                         (str (wallet.utils/format-amount (.minus amount fee) decimals)))
                       (str (wallet.utils/format-amount amount decimals)))]
     (when amount-text
-      {:db (assoc-in db [:wallet/prepare-transaction :amount-text] amount-text)})))
+      {:db (cond-> db
+             :always
+             (assoc-in [:wallet/prepare-transaction :amount-text] amount-text)
+             (= :ETH symbol)
+             (assoc-in [:wallet/prepare-transaction :gas] gas))})))
 
 (fx/defn set-and-validate-request-amount
   {:events [:wallet.request/set-amount-text]}


### PR DESCRIPTION

fixes #13046
