### PR TITLE
[#12783] Improve order of mailserver requests

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -4,6 +4,6 @@
     "owner": "status-im",
     "repo": "status-go",
     "version": "v0.93.3",
-    "commit-sha1": "2e8007c12de237542f7b29da17122ff60a30ff0d",
-    "src-sha256": "0gw6qkx5v3bf8hlkdw4f02qfvgs5x9h8sc491yxyw11gjjm94gim"
+    "commit-sha1": "c0c90947abf88202465eb66979584cc5e7905b7d",
+    "src-sha256": "160wk6d8xg1fhg4s5s6hf0grxv3z911xy2vwvx1nbvp6y9p60lzm"
 }


### PR DESCRIPTION
fixes (partially) #12783 

Topics are ordered by `chat.ReadMessagesAtClockValue`, which means that chats which were opened recently will have higher priority. That should make receiving updates in the last opened chats faster. The way to test it is to create an acc with 20-30 spam chats and compare how fast messages are received in the last chat (better to use a chat without spam for this) after 2-3h offline.

status: ready