### PR TITLE
Different screen segments

### DIFF
--- a/src/status_im/ui/components/tabs.cljs
+++ b/src/status_im/ui/components/tabs.cljs
@@ -13,3 +13,14 @@
       label]]]
    (when active?
      [react/view {:width 24 :height 3 :border-radius 4 :background-color colors/blue}])])
+
+(defn tab-button [state key label active?]
+  [react/view {:flex 1 :align-items :center :border-radius 8
+               :background-color (if active? colors/blue colors/blue-light)}
+   [react/touchable-highlight {:on-press            #(swap! state assoc :tab key)
+                               :accessibility-label (str label "-item-button")
+                               :style               {:border-radius 8}
+                               :flex                1}
+    [react/view {:padding-horizontal 12 :padding-vertical 8}
+     [react/text {:style {:font-weight "500" :color (if active? colors/white colors/blue) :line-height 22}}
+      label]]]])

--- a/src/status_im/ui/screens/communities/reorder_categories.cljs
+++ b/src/status_im/ui/screens/communities/reorder_categories.cljs
@@ -70,7 +70,7 @@
      [rn/view {:accessibility-label :category-item
                :style               (merge styles/category-item
                                            {:background-color background-color})}
-      (if-not (categories-tab?)
+      (if (not (categories-tab?))
         [icons/icon :main-icons/channel-category {:color colors/gray}]
         [rn/touchable-opacity
          {:accessibility-label :delete-category-button

--- a/translations/en.json
+++ b/translations/en.json
@@ -1691,6 +1691,7 @@
     "include": "Include",
     "category": "Category",
     "edit-chats": "Edit chats",
+    "edit-categories": "Edit Categories",
     "hide": "Hide",
     "account-is-used": "The account is being used with Dapps in the browser.",
     "normal": "Normal",


### PR DESCRIPTION

fixes  #12954

### Summary
Add screens to edit chats and categories separately

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS
- macOS
- Linux
- Windows

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- 1-1 chats
- public chats
- group chats
- wallet / transactions
- dapps / app browsing
- account recovery
- new account
- user profile updates
- networks
- mailservers
- fleet
- bootnodes

##### Non-functional

- battery performance
- CPU performance / speed of the app
- network consumption

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open Status
- ...
- Step 3, etc.

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->
