### PR TITLE
Android Mute notifications

### DIFF
--- a/src/status_im/ui/screens/profile/contact/views.cljs
+++ b/src/status_im/ui/screens/profile/contact/views.cljs
@@ -15,7 +15,6 @@
             [quo.design-system.colors :as colors]
             [status-im.ui.components.toolbar :as toolbar]
             [status-im.ui.components.keyboard-avoid-presentation :as kb-presentation]
-            [status-im.utils.platform :as platform]
             [reagent.core :as reagent]
             [clojure.string :as string]
             [quo.components.list.item :as list-item]

--- a/src/status_im/ui/screens/profile/contact/views.cljs
+++ b/src/status_im/ui/screens/profile/contact/views.cljs
@@ -39,14 +39,13 @@
               :icon                :main-icons/add-contact
               :accessibility-label :add-to-contacts-button
               :action              #(re-frame/dispatch [:contact.ui/add-to-contact-pressed public-key])}])
-          (when platform/ios?
-            [{:label               (i18n/label (if (or muted? blocked?) :t/unmute :t/mute))
-              :icon                :main-icons/notification
-              :accessibility-label :mute-chat
-              :selected            muted?
-              :disabled            blocked?
-              :action              (when-not blocked?
-                                     #(re-frame/dispatch [::chat.models/mute-chat-toggled public-key (not muted?)]))}])
+          [{:label               (i18n/label (if (or muted? blocked?) :t/unmute :t/mute))
+            :icon                :main-icons/notification
+            :accessibility-label :mute-chat
+            :selected            muted?
+            :disabled            blocked?
+            :action              (when-not blocked?
+                                   #(re-frame/dispatch [::chat.models/mute-chat-toggled public-key (not muted?)]))}]
           [{:label               (i18n/label (if blocked? :t/unblock :t/block))
             :negative            true
             :selected            blocked?

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.92.7",
-    "commit-sha1": "f1569e4bde50e993611288a59b7a415a010cbfa8",
-    "src-sha256": "12qj6p5m25z7ypgm9yxrg98lcc096sl2pwdks2iwlip585xsrc0h"
+    "version": "mute-notifications",
+    "commit-sha1": "6fb1b06394dc303878c95c5ffd5e93e471ec7a49",
+    "src-sha256": "1il056viy8p74hhbjal0hsbmg25v0m5pv37zmnilbxsdp3icw25a"
 }


### PR DESCRIPTION
Fixes https://github.com/status-im/status-react/issues/12890

### Summary
When a user mutes a particular one on one chat, the user will not receive notifications for new chat messages

### Testing notes
Mute a chat between your User (A) and User B
Send a message to User B from User A
Notice that User B does not receive notifications for new chat messages
Unmute User B from User A
Notice that user B now receives notifications for new chat messages

<!-- (Optional, remove if no changes to documentation) -->
Documentation change PR (review please): https://github.com/status-im/status.im/pull/xxx

### Review notes
<!-- (Optional. Specify if something in particular should be looked at, or ignored, during review) -->

### Testing notes
<!-- (Optional) -->

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS
- macOS
- Linux
- Windows

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- 1-1 chats
- public chats
- group chats
- wallet / transactions
- dapps / app browsing
- account recovery
- new account
- user profile updates
- networks
- mailservers
- fleet
- bootnodes

##### Non-functional

- battery performance
- CPU performance / speed of the app
- network consumption

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open Status
- ...
- Step 3, etc.

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->
