### PR TITLE
Forward image message to selected contacts

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -648,7 +648,7 @@ SPEC CHECKSUMS:
   FBLazyVector: 3bb422f41b18121b71783a905c10e58606f7dc3e
   FBReactNativeSpec: f2c97f2529dd79c083355182cc158c9f98f4bd6e
   Folly: b73c3869541e86821df3c387eb0af5f65addfab4
-  glog: 61334f8bdb4deea07543d4fbac3fb5948e78a7a5
+  glog: 2d7c14bbcd0c3139c6258f813895cb61d7860fcc
   HMSegmentedControl: 34c1f54d822d8308e7b24f5d901ec674dfa31352
   Keycard: 07f1b4d4fadcf1218084cb3e1bb3a8bac3870c5a
   libwebp: 98a37e597e40bfdb4c911fc98f2c53d0b12d05fc

--- a/src/status_im/ui/screens/chat/message/message.cljs
+++ b/src/status_im/ui/screens/chat/message/message.cljs
@@ -24,6 +24,7 @@
             [status-im.ui.screens.chat.message.link-preview :as link-preview]
             [status-im.ui.screens.communities.icon :as communities.icon]
             [status-im.ui.components.animation :as animation]
+            [status-im.chat.models.message :as message]
             [status-im.chat.models.pin-message :as models.pin-message])
   (:require-macros [status-im.utils.views :refer [defview letsubs]]))
 
@@ -586,7 +587,10 @@
                                  :label    (i18n/label :t/message-reply)}
                                 {:on-press #(re-frame/dispatch [:chat.ui/save-image-to-gallery (:image content)])
                                  :id       :save
-                                 :label    (i18n/label :t/save)}]
+                                 :label    (i18n/label :t/save)}
+                                {:on-press #(re-frame/dispatch [::message/share-to-contacts-pressed message])
+                                 :id       :share
+                                 :label    (i18n/label :t/share)}]
                                (when (and outgoing config/delete-message-enabled?)
                                  [{:on-press #(re-frame/dispatch [:chat.ui/soft-delete-message message])
                                    :label    (i18n/label :t/delete)

--- a/src/status_im/ui/screens/chat/share.cljs
+++ b/src/status_im/ui/screens/chat/share.cljs
@@ -1,0 +1,61 @@
+(ns status-im.ui.screens.chat.share
+  (:require [reagent.core :as reagent]
+            [quo.react-native :as rn]
+            [quo.core :as quo]
+            [status-im.i18n.i18n :as i18n]
+            [status-im.ui.components.toolbar :as toolbar]
+            [status-im.utils.handlers :refer [<sub >evt-once]]
+            [status-im.ui.components.chat-icon.screen :as chat-icon.screen]
+            [status-im.chat.models.message :as message]
+            [status-im.multiaccounts.core :as multiaccounts]
+            [clojure.string :as str]))
+
+(defn blank-page [text]
+  [rn/view {:style {:padding 16 :flex 1 :flex-direction :row :align-items :center :justify-content :center}}
+   [quo/text {:align :center
+              :color :secondary}
+    text]])
+
+(defn contacts-list-item [{:keys [public-key active] :as contact} _ _ {:keys [selected]}]
+  (let [[first-name second-name] (multiaccounts/contact-two-names contact true)]
+    [quo/list-item
+     {:title     first-name
+      :subtitle  second-name
+      :icon      [chat-icon.screen/contact-icon-contacts-tab
+                  (multiaccounts/displayed-photo contact)]
+      :accessory :checkbox
+      :active    active
+      :on-press  (fn []
+                   (if active
+                     (swap! selected disj public-key)
+                     (swap! selected conj public-key)))}]))
+
+(defn share []
+  (let [user-pk           (reagent/atom "")
+        contacts-selected (reagent/atom #{})
+        {:keys [message-id]} (<sub [:get-screen-params])]
+    (fn []
+      (let [contacts-data               (<sub [:contacts/active])
+            selected                    @contacts-selected
+            contacts                    (map (fn [{:keys [public-key] :as contact}]
+                                               (assoc contact :active (contains? selected public-key)))
+                                             contacts-data)]
+        [:<>
+         (if (empty? contacts)
+           [blank-page (i18n/label :t/share-images-with-your-contacts)]
+           [rn/flat-list {:style                   {:flex 1}
+                          :content-container-style {:padding-vertical 16}
+                          :render-data             {:selected contacts-selected}
+                          :render-fn               contacts-list-item
+                          :key-fn                  (fn [{:keys [active public-key]}]
+                                                     (str public-key active))
+                          :data                    contacts}])
+         [toolbar/toolbar
+          {:show-border? true
+           :center
+           [quo/button {:disabled (and (str/blank? @user-pk)
+                                       (zero? (count selected)))
+                        :type     :secondary
+                        :on-press #(>evt-once [::message/share-image-to-contacts-pressed
+                                               @user-pk selected message-id])}
+            (i18n/label :t/share)]}]]))))

--- a/src/status_im/ui/screens/screens.cljs
+++ b/src/status_im/ui/screens/screens.cljs
@@ -23,6 +23,7 @@
             [status-im.ui.screens.bug-report :as bug-report]
             [status-im.ui.screens.chat.pinned-messages :as pin-messages]
             [status-im.ui.screens.chat.views :as chat]
+            [status-im.ui.screens.chat.share :as chat.share]
             [status-im.ui.screens.communities.channel-details :as communities.channel-details]
             [status-im.ui.screens.communities.community :as community]
             [status-im.ui.screens.communities.community-emoji-thumbnail-picker :as community-emoji-thumbnail-picker]
@@ -618,6 +619,12 @@
             :insets    {:bottom true}
             :options   {:topBar {:title {:text (i18n/label :t/new-public-group-chat)}}}
             :component new-public-chat/new-public-chat}
+
+            ;[Chat] Share Images message
+           {:name      :share-to-contacts
+            :options   {:topBar {:title {:text (i18n/label :t/community-share-title)}}}
+            :component chat.share/share
+            :insets    {:bottom true}}
 
            ;[Chat] Link preview settings
            {:name      :link-preview-settings

--- a/translations/en.json
+++ b/translations/en.json
@@ -1354,6 +1354,7 @@
     "welcome-community-blank-message": "Your channels will appear here. To create a new channel, click on the ⊕ button and select \"Create a channel\"",
     "welcome-community-blank-message-edit-chats": "Your channels will appear here. To create a new channel, go back to the community screen, click on the ⊕ button and select \"Create a channel\"",
     "welcome-blank-community-message": "Your communities will appear here.",
+    "share-images-with-your-contacts": "Your contacts will appear here. To share an image with you contacts, add some contacts in your profile, share your images with your contacts.",
     "fetch-community": "Fetch community",
     "fetching-community": "Fetching community...",
     "seed-phrase-placeholder": "Seed phrase...",


### PR DESCRIPTION
This PR adds the option and the fronted functionality to share image messages to multiple selected contacts


### Summary

[comment]: # (Summarise the problem and how the pull request solves it)


<!-- (Optional, remove if no changes to documentation) -->
Documentation change PR (review please): https://github.com/status-im/status.im/pull/xxx

### Review notes
<!-- (Optional. Specify if something in particular should be looked at, or ignored, during review) -->

### Testing notes
<!-- (Optional) -->

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS
- macOS
- Linux
- Windows

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- 1-1 chats
- public chats
- group chats
- wallet / transactions
- dapps / app browsing
- account recovery
- new account
- user profile updates
- networks
- mailservers
- fleet
- bootnodes

##### Non-functional

- battery performance
- CPU performance / speed of the app
- network consumption

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open Status
- ...
- Step 3, etc.

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->
