### PR TITLE
Add changelog from status-go on upgrade

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: nix-add-gcroots clean nix-clean run-metro test release _list _fix-node-perms _tmpdir-mk _tmpdir-rm
+.PHONY: nix-add-gcroots clean nix-clean run-metro test release _list _fix-node-perms _tmpdir-mk _tmpdir-rm _install-hooks
 
 help: SHELL := /bin/sh
 help: ##@other Show this help
@@ -123,6 +123,11 @@ _tmpdir-mk: ##@prepare Create a TMPDIR for temporary files
 _tmpdir-rm: SHELL := /bin/sh
 _tmpdir-rm: ##@prepare Remove TMPDIR
 	rm -fr "$(TMPDIR)"
+
+_install-hooks: SHELL := /bin/sh
+_install-hooks: ##@prepare Create prepare-commit-msg git hook symlink
+	@ln -s ../../scripts/hooks/prepare-commit-msg .git/hooks
+-include _install-hooks
 
 # Remove directories and ignored files
 clean: SHELL := /bin/sh

--- a/scripts/hooks/prepare-commit-msg
+++ b/scripts/hooks/prepare-commit-msg
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z $(git diff --cached --name-only -r | grep status-go-version.json) ]]; then
+  exit 0 # No status-go-version.json changes found.
+fi
+
+MERGE_BASE=$(git merge-base -a develop "$(git rev-parse --abbrev-ref HEAD)" develop)
+GO_COMMIT_MERGE_BASE=$(git show "${MERGE_BASE}":status-go-version.json | jq -r '."commit-sha1"')
+GO_COMMIT_CURRENT=$(jq -r '."commit-sha1"' status-go-version.json)
+
+GITHUB_LINK="https://github.com/status-im/status-go/compare/${GO_COMMIT_MERGE_BASE}...${GO_COMMIT_CURRENT}"
+
+COMMIT_MSG_FILE=$1
+#todo for now instead of sed I use this just to have it all working. Later will implement sed solution
+if [[ -f "${COMMIT_MSG_FILE}" ]]; then
+  if [ -f temp_file ] ; then
+          rm temp_file
+  fi
+  while IFS= read -r line; do
+    if [[ "$line" == *"https://github.com/status-im/status-go/compare"* ]]; then
+      echo "${GITHUB_LINK}" >>temp_file
+    else
+      echo "${line}" >>temp_file
+    fi
+  done <"${COMMIT_MSG_FILE}"
+
+  if ! grep -q "https://github.com/status-im/status-go/compare" temp_file; then
+    echo "${GITHUB_LINK}" >>temp_file
+  fi
+
+  cat temp_file >"${COMMIT_MSG_FILE}"
+fi


### PR DESCRIPTION
fixes #13090

### Summary

If status-go is upgraded in status-react, add the commit the the last PR description of status-go

### Review notes
I use Github API to get the info.

### Testing notes
Run `scripts/update-status-go.sh "tag"` and observe status-go-version.json is updated with last PR message (along of other changes)

#### Platforms
- command line scripting

### Steps to test

- cd status-react
- scripts/update-status-go.sh v0.94.9
- cat status-go-version.json
- observe last PR message added to status-go information

status: WIP