### PR TITLE
Fix ios simulator error when notifications enabled

### DIFF
--- a/src/status_im/notifications/core.cljs
+++ b/src/status_im/notifications/core.cljs
@@ -143,8 +143,7 @@
   {:events [:notifications/switch-error]}
   [cofx enabled?]
   (multiaccounts.update/multiaccount-update
-   :remote-push-notifications-enabled? (not enabled?)
-   {}))
+   cofx :remote-push-notifications-enabled? (not enabled?) {}))
 
 (fx/defn notification-switch
   {:events [::switch]}


### PR DESCRIPTION
## Summary:
PR fixes ios simulator error when enabling notifications

### Error cause:
Remote notifications are not supported in the ios simulator and that's why when the simulator tried to register for push notifications, it fired event `:notifications/switch-error`, which called `multiaccounts.update/multiaccount-update` function with one less variable (cofx) than expected and caused the error

Thank you very much @msuess and @Samyoul for finding this issue.

status: ready