### PR TITLE
Add changelog from status-go on upgrade #13090

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: nix-add-gcroots clean nix-clean run-metro test release _list _fix-node-perms _tmpdir-mk _tmpdir-rm
+.PHONY: nix-add-gcroots clean nix-clean run-metro test release _list _fix-node-perms _tmpdir-mk _tmpdir-rm _install-hooks
 
 help: SHELL := /bin/sh
 help: ##@other Show this help
@@ -123,6 +123,11 @@ _tmpdir-mk: ##@prepare Create a TMPDIR for temporary files
 _tmpdir-rm: SHELL := /bin/sh
 _tmpdir-rm: ##@prepare Remove TMPDIR
 	rm -fr "$(TMPDIR)"
+
+_install-hooks: SHELL := /bin/sh
+_install-hooks: ##@prepare Create prepare-commit-msg git hook symlink
+	@ln -s ../../scripts/hooks/prepare-commit-msg .git/hooks
+-include _install-hooks
 
 # Remove directories and ignored files
 clean: SHELL := /bin/sh

--- a/scripts/hooks/prepare-commit-msg
+++ b/scripts/hooks/prepare-commit-msg
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z $(git diff --cached --name-only -r | grep status-go-version.json) ]]; then
+  exit 0 # No status-go-version.json changes found.
+fi
+
+MERGE_BASE=$(git merge-base -a develop "$(git rev-parse --abbrev-ref HEAD)" develop)
+GO_COMMIT_MERGE_BASE=$(git show "${MERGE_BASE}":status-go-version.json | jq -r '."commit-sha1"')
+GO_COMMIT_CURRENT=$(jq -r '."commit-sha1"' status-go-version.json)
+GITHUB_LINK_PREFIX="https://github.com/status-im/status-go/compare/"
+# Link to the current StatusGo changelog being updated.
+GITHUB_LINK="${GITHUB_LINK_PREFIX}${GO_COMMIT_MERGE_BASE}...${GO_COMMIT_CURRENT}"
+
+COMMIT_MSG_FILE=$1
+# Check if the commit message already contains the link (rebase) and update otherwise insert into line2
+if ! grep -qF "${GITHUB_LINK_PREFIX}" "${COMMIT_MSG_FILE}" >/dev/null; then
+  sed -in "2i${GITHUB_LINK}\n" "${COMMIT_MSG_FILE}"
+else
+  sed -in "s;^${GITHUB_LINK_PREFIX}.*$;${GITHUB_LINK};" "${COMMIT_MSG_FILE}"
+fi


### PR DESCRIPTION
fixes https://github.com/status-im/status-react/issues/13090
Summary

- If status-go is upgraded in status-react, add the link of changelog in to the next PR message.

Testing notes

 - Run scripts/update-status-go.sh "tag" and commit the changes. The PR message contains link to the changelog.
 - Also check a commit made using this hook `https://github.com/status-im/status-react/commit/f9f78e23d31db7f5eb31595b0b8fe645d6017dc7` the commit message contains link to the status-go changelog/

Platforms

   - command line

status: READY