### PR TITLE
fix screen opens twice on app reopening in ios

### DIFF
--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -38,7 +38,7 @@
             [status-im.navigation :as navigation]
             status-im.notifications-center.core
             status-im.pairing.core
-            status-im.popover.core
+            [status-im.popover.core :as popover]
             status-im.profile.core
             status-im.search.core
             status-im.signals.core
@@ -52,7 +52,7 @@
             status-im.utils.logging.core
             [status-im.utils.universal-links.core :as universal-links]
             [status-im.utils.utils :as utils]
-            status-im.visibility-status-popover.core
+            [status-im.visibility-status-popover.core :as visibility-status-popover]
             status-im.visibility-status-updates.core
             status-im.waku.core
             status-im.wallet.accounts.core
@@ -60,7 +60,8 @@
             [status-im.wallet.core :as wallet]
             status-im.wallet.custom-tokens.core
             [status-im.navigation.core :as navigation.core]
-            [status-im.multiaccounts.login.core :as login.core]))
+            [status-im.multiaccounts.login.core :as login.core]
+            [status-im.signing.core :as signing]))
 
 (re-frame/reg-fx
  :dismiss-keyboard
@@ -148,7 +149,14 @@
                  {::multiaccounts/switch-theme (if (= :dark theme) 2 1)}
                  (when (seq dispatch-later)
                    {:utils/dispatch-later dispatch-later}))
-                (bottom-sheet/hide-bottom-sheet)
+                (when (get-in db [:bottom-sheet/show?])
+                  (bottom-sheet/hide-bottom-sheet))
+                (when (get-in db [:popover/popover])
+                  (popover/hide-popover))
+                (when (get-in db [:visibility-status-popover/popover])
+                  (visibility-status-popover/hide-visibility-status-popover))
+                (when (get-in db [:signing/tx])
+                  (signing/discard))
                 (navigation/init-root root-id)
                 (when (= root-id :chat-stack)
                   (navigation/change-tab current-tab))))))

--- a/src/status_im/navigation/core.cljs
+++ b/src/status_im/navigation/core.cljs
@@ -390,7 +390,9 @@
                          :create-community-channel
                          :community-emoji-thumbnail-picker
                          :create-community-category
-                         :community-edit-chats))
+                         :community-edit-chats
+                         :community-edit
+                         :community-reorder-categories))
 
 ;; change view-id if it is still same after component is disappeared
 ;; https://github.com/wix/react-native-navigation/issues/5744#issuecomment-563226820

--- a/src/status_im/utils/theme.cljs
+++ b/src/status_im/utils/theme.cljs
@@ -1,11 +1,13 @@
 (ns status-im.utils.theme
   (:require ["react-native" :refer (Appearance)]
-            [oops.core :refer [oget ocall]]))
+            [oops.core :refer [ocall]]))
 
 (def initial-mode (atom (ocall Appearance "getColorScheme")))
 
+;; Note - don't use value returned by change listener
+;; https://github.com/facebook/react-native/issues/28525
 (defn add-mode-change-listener [callback]
-  (ocall Appearance "addChangeListener" #(let [mode (oget % "colorScheme")]
+  (ocall Appearance "addChangeListener" #(let [mode (ocall Appearance "getColorScheme")]
                                            (when-not (= mode @initial-mode)
                                              (reset! initial-mode mode)
                                              (callback (keyword mode))))))


### PR DESCRIPTION
fixes https://github.com/status-im/status-react/issues/13153

### Summary (Fixes):
- [Appearance module](https://reactnative.dev/docs/appearance) of react-native has a [bug](https://github.com/facebook/react-native/issues/28525#issuecomment-666244448), it fires system theme change events `(with wrong value)` when the ios app comes back from the background. So now instead of relying on the value provided by the event, we are requesting it manually.
- Back button was shown because we were calling `:navigate-to` event, even for the views on the home screen. `(for some reason, this also affected ios only)`

### QA test request:
Thanks @qoqobolo for finding this great issue. Fix might have affected system theme changes for android, Please let me know if it is not working as expected

status: ready