### PR TITLE
Disable chat input for chats with a blocked user

### DIFF
--- a/src/status_im/subs.cljs
+++ b/src/status_im/subs.cljs
@@ -1033,9 +1033,8 @@
  :<- [:chats/current-raw-chat]
  :<- [:multiaccount/public-key]
  :<- [:communities/current-community]
- (fn [[{:keys [group-chat] :as current-chat}
-       my-public-key
-       community]]
+ :<- [:contacts/blocked-set]
+ (fn [[{:keys [group-chat chat-id] :as current-chat} my-public-key community blocked-users-set]]
    (when current-chat
      (cond-> current-chat
        (chat.models/public-chat? current-chat)
@@ -1051,7 +1050,7 @@
        (assoc :show-input? true)
 
        (not group-chat)
-       (assoc :show-input? true)))))
+       (assoc :show-input? (not (contains? blocked-users-set chat-id)))))))
 
 (re-frame/reg-sub
  :chats/current-chat-chat-view


### PR DESCRIPTION
fixes #13115

### Summary

[comment]: # User can send messages to blocked contact so this commit disables chat input for chats with a blocked user.

#### Platforms
- Android
- iOS

#### Areas that maybe impacted
1-1 chats

##### Functional
- 1-1 chats

##### Non-functional
- user experience

### Steps to test
- chat with user user
- block them
- navigate to chat with them (user icon -> contacts -> blocked users)
- observe chat input field is hidden

status: ready
