### PR TITLE
Improve network info view

### DIFF
--- a/src/status_im/ui/screens/network_info/views.cljs
+++ b/src/status_im/ui/screens/network_info/views.cljs
@@ -9,7 +9,8 @@
             [quo.react-native :as rn]
             [quo.core :as quo]
             [quo.design-system.colors :as colors]
-            [status-im.i18n.i18n :as i18n]))
+            [status-im.i18n.i18n :as i18n]
+            [status-im.wallet.core :as wallet]))
 
 (defn get-block [block callback]
   (json-rpc/call
@@ -35,9 +36,10 @@
                              "latest"
                              (fn [res]
                                (reset! latest-block res)
+                               (when-not (last-loaded-block-number)
+                                 (re-frame/dispatch-sync [::wallet/request-current-block-update]))
                                (get-block
-                                (str "0x" (abi-spec/number-to-hex
-                                           (last-loaded-block-number)))
+                                (str "0x" (abi-spec/number-to-hex (last-loaded-block-number)))
                                 (fn [res]
                                   (reset! last-loaded-block res)
                                   (reset! refreshing? false))))))]

--- a/src/status_im/ui/screens/network_info/views.cljs
+++ b/src/status_im/ui/screens/network_info/views.cljs
@@ -8,7 +8,8 @@
             [status-im.utils.datetime :as time]
             [quo.react-native :as rn]
             [quo.core :as quo]
-            [quo.design-system.colors :as colors]))
+            [quo.design-system.colors :as colors]
+            [status-im.i18n.i18n :as i18n]))
 
 (defn get-block [block callback]
   (json-rpc/call
@@ -63,7 +64,7 @@
                                           :value last-loaded-block-number
                                           :ts    (to-date last-loaded-block-ts)
                                           :label "Last Loaded Block"}]
-               footer-text              (str "There is a lag of " blocks-diff " blocks with a time difference of " seconds-diff " seconds.")]
+               footer-text              (i18n/label :t/network-info-footer {:blocks-diff blocks-diff :seconds-diff seconds-diff})]
            (rn/flat-list {:data       data
                           :onRefresh  refresh
                           :refreshing @refreshing?

--- a/translations/en.json
+++ b/translations/en.json
@@ -1737,5 +1737,6 @@
     "current-average": "Current average",
     "current-base": "Current base",
     "maximum-fee-desc": "Maximum overall price for the transaction. If the current block base fee exceeds this, your transaction will be included in a following block with a lower base fee.",
-    "insufficient-balance-to-cover-fee": "not enough balance to cover transaction fee"
+    "insufficient-balance-to-cover-fee": "not enough balance to cover transaction fee",
+    "network-info-footer": "There is a lag of {{blocks-diff}} blocks with a time difference of {{seconds-diff}} seconds."
 }


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

Fixes #13087 

### Summary

[comment]: # (Summarise the problem and how the pull request solves it)
Improves the Network info view. The raw text is now a list view which describes the block number and its timestamp. The footer informs the lag in blocks and time in seconds. The user can pull to refresh the info. Also one had to press to refresh on initial load of the screen but now the data is fetched on initial load.

### Review notes
<!-- (Optional. Specify if something in particular should be looked at, or ignored, during review) -->

### Testing notes
<!-- (Optional) -->

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS


### Steps to test
1. Go to `Settings -> Advanced -> Network info` to see the updated screen.
<!-- (Specify exact steps to test if there are such) -->

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready
