### PR TITLE
Only create git hook whet it is absent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ _tmpdir-rm: ##@prepare Remove TMPDIR
 
 _install-hooks: SHELL := /bin/sh
 _install-hooks: ##@prepare Create prepare-commit-msg git hook symlink
-	@ln -s ../../scripts/hooks/prepare-commit-msg .git/hooks
+	@ln -s -f ../../scripts/hooks/prepare-commit-msg .git/hooks
 -include _install-hooks
 
 # Remove directories and ignored files


### PR DESCRIPTION
### Summary

Fix Makefile so it will not show this error "ln: failed to create symbolic link '.git/hooks/prepare-commit-msg': File exists" every time make target run.

#### Platforms
- command line build tools

##### Non-functional
- build scripts less noisy

### Steps to test
- run any make target
- see there is no error that symlink exists

status: ready