### PR TITLE
Fix sed command to work on mac

### DIFF
--- a/scripts/hooks/prepare-commit-msg
+++ b/scripts/hooks/prepare-commit-msg
@@ -14,9 +14,9 @@ GITHUB_LINK="${GITHUB_LINK_PREFIX}${GO_COMMIT_MERGE_BASE}...${GO_COMMIT_CURRENT}
 
 COMMIT_MSG_FILE=$1
 # Check if the commit message already contains the link (rebase) and update otherwise insert into line2
-# temporary comment out because of the error on macos
-#if ! grep -qF "${GITHUB_LINK_PREFIX}" "${COMMIT_MSG_FILE}" >/dev/null; then
-#  sed -in "2i${GITHUB_LINK}\n" "${COMMIT_MSG_FILE}"
-#else
-#  sed -in "s;^${GITHUB_LINK_PREFIX}.*$;${GITHUB_LINK};" "${COMMIT_MSG_FILE}"
-#fi
+if ! grep -qF "${GITHUB_LINK_PREFIX}" "${COMMIT_MSG_FILE}" >/dev/null; then
+  sed -in'' -e "2i\\
+${GITHUB_LINK}\n" "${COMMIT_MSG_FILE}"
+else
+  sed -in'' -e "s;^${GITHUB_LINK_PREFIX}.*$;${GITHUB_LINK};" "${COMMIT_MSG_FILE}"
+fi


### PR DESCRIPTION
fixes #13090
### Summary
Fixes for sed command in MacOS

#### Platforms
- macOS
- Linux

### Steps to test
- Run scripts/update-status-go.sh "tag" and commit the changes. The PR message contains link to the changelog.
- Also check a commit made using this hook https://github.com/status-im/status-react/commit/f9f78e23d31db7f5eb31595b0b8fe645d6017dc7 the commit message contains link to the status-go changelog/
- Need to make sure that it works on GNU/Linux and on MacOS.

status: ready