### PR TITLE
different screen segments

### DIFF
--- a/src/status_im/ui/screens/communities/reorder_community_chats.cljs
+++ b/src/status_im/ui/screens/communities/reorder_community_chats.cljs
@@ -1,4 +1,4 @@
-(ns status-im.ui.screens.communities.reorder-categories
+(ns status-im.ui.screens.communities.reorder-community-chats
   (:require [quo.core :as quo]
             [clojure.walk :as walk]
             [quo.react-native :as rn]

--- a/src/status_im/ui/screens/screens.cljs
+++ b/src/status_im/ui/screens/screens.cljs
@@ -36,7 +36,7 @@
             [status-im.ui.screens.communities.members :as members]
             [status-im.ui.screens.communities.membership :as membership]
             [status-im.ui.screens.communities.profile :as community.profile]
-            [status-im.ui.screens.communities.reorder-categories :as reorder-categories]
+            [status-im.ui.screens.communities.reorder-community-chats :as reorder-community-chats]
             [status-im.ui.screens.communities.requests-to-join :as requests-to-join]
             [status-im.ui.screens.communities.select-category :as select-category]
             [status-im.ui.screens.communities.views :as communities]
@@ -294,7 +294,7 @@
            {:name      :community-reorder-categories
             :insets    {:top false}
             :options   {:topBar {:visible false}}
-            :component reorder-categories/view}
+            :component reorder-community-chats/view}
            {:name      :community-channel-details
             :insets    {:top false}
             ;;TODO custom


### PR DESCRIPTION
fixes https://github.com/status-im/status-react/issues/12954

### Summary

Add screens to edit chats and categories separately

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS
- macOS
- Linux
- Windows

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- 1-1 chats
- public chats
- group chats
- wallet / transactions
- dapps / app browsing
- account recovery
- new account
- user profile updates
- networks
- mailservers
- fleet
- bootnodes

##### Non-functional

- battery performance
- CPU performance / speed of the app
- network consumption

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open Status
- ...
- Step 3, etc.

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->
