### PR TITLE
fix empty community in the community list

### DIFF
--- a/src/status_im/chat/models/link_preview.cljs
+++ b/src/status_im/chat/models/link_preview.cljs
@@ -49,10 +49,10 @@
   {:events [::community-resolved]}
   [{:keys [db] :as cofx} community-id community]
   (fx/merge cofx
-            (merge
-             {:db (community-resolved db community-id)}
-             (when-not (nil? community)
-               {:dispatch [::cache-link-preview-data (community-link community-id) community]}))
+            (cond-> {:db (community-resolved db community-id)}
+              (some? community)
+              (assoc :dispatch [::cache-link-preview-data
+                                (community-link community-id) community]))
             (models.communities/handle-community community)))
 
 (fx/defn resolve-community-info

--- a/src/status_im/chat/models/link_preview.cljs
+++ b/src/status_im/chat/models/link_preview.cljs
@@ -49,8 +49,10 @@
   {:events [::community-resolved]}
   [{:keys [db] :as cofx} community-id community]
   (fx/merge cofx
-            {:db       (community-resolved db community-id)
-             :dispatch [::cache-link-preview-data (community-link community-id) community]}
+            (merge
+             {:db (community-resolved db community-id)}
+             (when-not (nil? community)
+               {:dispatch [::cache-link-preview-data (community-link community-id) community]}))
             (models.communities/handle-community community)))
 
 (fx/defn resolve-community-info

--- a/src/status_im/communities/core.cljs
+++ b/src/status_im/communities/core.cljs
@@ -84,7 +84,7 @@
 
 (fx/defn handle-community
   [{:keys [db]} {:keys [id] :as community}]
-  (when-not (nil? id)
+  (when id
     {:db (assoc-in db [:communities id] (<-rpc community))}))
 
 (fx/defn handle-communities

--- a/src/status_im/communities/core.cljs
+++ b/src/status_im/communities/core.cljs
@@ -84,7 +84,8 @@
 
 (fx/defn handle-community
   [{:keys [db]} {:keys [id] :as community}]
-  {:db (assoc-in db [:communities id] (<-rpc community))})
+  (when-not (nil? id)
+    {:db (assoc-in db [:communities id] (<-rpc community))}))
 
 (fx/defn handle-communities
   {:events [::fetched]}


### PR DESCRIPTION
fixes https://github.com/status-im/status-react/issues/13194

# Summary
PR fixes empty community in the community list

Earlier, we used to return community in response to the `resolve-community-info` call. 
Currently, we are using signals for returning the resolved community, and returning nil in an on-success event.