### PR TITLE
fix community preview

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.97.0",
-    "commit-sha1": "9f7fc78def512929499bc2fa610f3b0e0ea1835b",
-    "src-sha256": "0glwvx166wkhy57ly1xwdx3657p13ckhq86zkaq0nn00wix35wqm"
+    "version": "v0.97.1",
+    "commit-sha1": "a3c60528ef6e077761a9beb7dd9c530123b7315f",
+    "src-sha256": "02a7xd5djf7ac32vmpmhwblpklhr5c6s4vbjrq68krla8h2rh78v"
 }


### PR DESCRIPTION
This commit makes community previews a bit more robust and fixes an issue with the signal not being sent. 
There's still some work to do to make it more reliable, and we should add caching, but that's outside the scope of this PR.
status:ready