### PR TITLE
status timeline: set image max width to avoid overflow of horizontally long images

### DIFF
--- a/src/status_im/ui/screens/status/views.cljs
+++ b/src/status_im/ui/screens/status/views.cljs
@@ -33,7 +33,9 @@
   (let [width (reagent/atom nil)]
     (fn [uri show-close?]
       [react/view {:style               {:width         @width
+                                         :align-items   :center
                                          :height        image-max-dimension
+                                         :max-width     :100%
                                          :overflow      :hidden
                                          :opacity       (if @width 1 0)
                                          :border-radius 16


### PR DESCRIPTION
[comment]: Fixes https://github.com/status-im/status-react/issues/13149

Platforms
Android
iOS
status: ready
