### PR TITLE
fix screen orientation on android

### DIFF
--- a/src/status_im/navigation/core.cljs
+++ b/src/status_im/navigation/core.cljs
@@ -26,6 +26,9 @@
 (defonce modals (atom []))
 (defonce dissmissing (atom false))
 
+(defonce set-navigation-default-options
+  (.setDefaultOptions Navigation (clj->js (roots/default-root))))
+
 ;; REGISTER COMPONENT (LAZY)
 (defn reg-comp [key]
   (log/debug "reg-comp" key)

--- a/src/status_im/navigation/core.cljs
+++ b/src/status_im/navigation/core.cljs
@@ -27,7 +27,7 @@
 (defonce dissmissing (atom false))
 
 (defonce set-navigation-default-options
-  (.setDefaultOptions Navigation (clj->js (roots/default-root))))
+  (.setDefaultOptions Navigation (clj->js {:layout {:orientation "portrait"}})))
 
 ;; REGISTER COMPONENT (LAZY)
 (defn reg-comp [key]


### PR DESCRIPTION
fixes https://github.com/status-im/status-react/issues/13214

## Summary
setting screen orientation using options while setting root is not working for bottom tabs due to RNN issue. [ref1](https://github.com/wix/react-native-navigation/issues/7462) [ref2](https://github.com/wix/react-native-navigation/issues/5276)

status: ready