### PR TITLE
Changed common_password to qwerty1234

### DIFF
--- a/test/appium/tests/__init__.py
+++ b/test/appium/tests/__init__.py
@@ -18,7 +18,7 @@ async def start_threads(quantity: int, func: type, returns: dict, *args):
 def get_current_time():
     return datetime.now().strftime('%-m%-d%-H%-M%-S')
 
-git
+
 def debug(text: str):
     logging.debug(text)
 

--- a/test/appium/tests/__init__.py
+++ b/test/appium/tests/__init__.py
@@ -18,7 +18,7 @@ async def start_threads(quantity: int, func: type, returns: dict, *args):
 def get_current_time():
     return datetime.now().strftime('%-m%-d%-H%-M%-S')
 
-
+git
 def debug(text: str):
     logging.debug(text)
 
@@ -28,7 +28,7 @@ pytest_config_global = dict()
 test_suite_data = TestSuiteData()
 appium_container = AppiumContainer()
 
-common_password = 'qwerty'
+common_password = 'qwerty1234'
 unique_password = 'unique' + get_current_time()
 pin = '121212'
 puk = '000000000000'

--- a/test/appium/tests/atomic/account_management/test_create_restore_account.py
+++ b/test/appium/tests/atomic/account_management/test_create_restore_account.py
@@ -193,8 +193,8 @@ class TestOnboardingOneDeviceMerged(MultipleSharedDeviceTestCase):
             self.driver.fail('%s  %s' % (error, cases[0]))
 
         self.sign_in.just_fyi('Checking case when %s' % cases[1])
-        self.sign_in.create_password_input.send_keys('123456')
-        [field.send_keys('123456') for field in (self.sign_in.create_password_input, self.sign_in.confirm_your_password_input)]
+        self.sign_in.create_password_input.send_keys('12345678')
+        [field.send_keys('12345678') for field in (self.sign_in.create_password_input, self.sign_in.confirm_your_password_input)]
         self.sign_in.confirm_your_password_input.delete_last_symbols(1)
         self.sign_in.create_password_input.delete_last_symbols(1)
         self.sign_in.next_button.click()
@@ -202,8 +202,8 @@ class TestOnboardingOneDeviceMerged(MultipleSharedDeviceTestCase):
             self.driver.fail('%s  %s' % (error, cases[1]))
 
         self.sign_in.just_fyi("Checking case %s" % cases[2])
-        self.sign_in.create_password_input.send_keys('1234565')
-        self.sign_in.confirm_your_password_input.send_keys('1234567')
+        self.sign_in.create_password_input.send_keys('12345654')
+        self.sign_in.confirm_your_password_input.send_keys('12345678')
         if not self.sign_in.element_by_translation_id("password_error1").is_element_displayed():
             self.errors.append("'%s' is not shown" % self.sign_in.get_translation_by_key("password_error1"))
         self.sign_in.create_password_input.set_value(common_password)

--- a/test/appium/tests/atomic/account_management/test_create_restore_account.py
+++ b/test/appium/tests/atomic/account_management/test_create_restore_account.py
@@ -193,8 +193,8 @@ class TestOnboardingOneDeviceMerged(MultipleSharedDeviceTestCase):
             self.driver.fail('%s  %s' % (error, cases[0]))
 
         self.sign_in.just_fyi('Checking case when %s' % cases[1])
-        self.sign_in.create_password_input.send_keys('12345678')
-        [field.send_keys('12345678') for field in (self.sign_in.create_password_input, self.sign_in.confirm_your_password_input)]
+        self.sign_in.create_password_input.send_keys('12345677')
+        [field.send_keys('12345677') for field in (self.sign_in.create_password_input, self.sign_in.confirm_your_password_input)]
         self.sign_in.confirm_your_password_input.delete_last_symbols(1)
         self.sign_in.create_password_input.delete_last_symbols(1)
         self.sign_in.next_button.click()

--- a/test/appium/tests/atomic/account_management/test_create_restore_account.py
+++ b/test/appium/tests/atomic/account_management/test_create_restore_account.py
@@ -193,8 +193,8 @@ class TestOnboardingOneDeviceMerged(MultipleSharedDeviceTestCase):
             self.driver.fail('%s  %s' % (error, cases[0]))
 
         self.sign_in.just_fyi('Checking case when %s' % cases[1])
-        self.sign_in.create_password_input.send_keys('1234566')
-        [field.send_keys('1234566') for field in (self.sign_in.create_password_input, self.sign_in.confirm_your_password_input)]
+        self.sign_in.create_password_input.send_keys('12345677')
+        [field.send_keys('12345677') for field in (self.sign_in.create_password_input, self.sign_in.confirm_your_password_input)]
         self.sign_in.confirm_your_password_input.delete_last_symbols(1)
         self.sign_in.create_password_input.delete_last_symbols(1)
         self.sign_in.next_button.click()

--- a/test/appium/tests/atomic/account_management/test_create_restore_account.py
+++ b/test/appium/tests/atomic/account_management/test_create_restore_account.py
@@ -187,7 +187,7 @@ class TestOnboardingOneDeviceMerged(MultipleSharedDeviceTestCase):
         error = "Can create multiaccount when"
 
         self.sign_in.just_fyi('Checking case when %s' % cases[0])
-        self.sign_in.create_password_input.send_keys('123456')
+        self.sign_in.create_password_input.send_keys('12345678')
         self.sign_in.next_button.click()
         if self.sign_in.maybe_later_button.is_element_displayed(10):
             self.driver.fail('%s  %s' % (error, cases[0]))

--- a/test/appium/tests/atomic/account_management/test_create_restore_account.py
+++ b/test/appium/tests/atomic/account_management/test_create_restore_account.py
@@ -187,14 +187,14 @@ class TestOnboardingOneDeviceMerged(MultipleSharedDeviceTestCase):
         error = "Can create multiaccount when"
 
         self.sign_in.just_fyi('Checking case when %s' % cases[0])
-        self.sign_in.create_password_input.send_keys('12345678')
+        self.sign_in.create_password_input.send_keys('12345677')
         self.sign_in.next_button.click()
         if self.sign_in.maybe_later_button.is_element_displayed(10):
             self.driver.fail('%s  %s' % (error, cases[0]))
 
         self.sign_in.just_fyi('Checking case when %s' % cases[1])
-        self.sign_in.create_password_input.send_keys('12345677')
-        [field.send_keys('12345677') for field in (self.sign_in.create_password_input, self.sign_in.confirm_your_password_input)]
+        self.sign_in.create_password_input.send_keys('1234566')
+        [field.send_keys('1234566') for field in (self.sign_in.create_password_input, self.sign_in.confirm_your_password_input)]
         self.sign_in.confirm_your_password_input.delete_last_symbols(1)
         self.sign_in.create_password_input.delete_last_symbols(1)
         self.sign_in.next_button.click()
@@ -203,7 +203,7 @@ class TestOnboardingOneDeviceMerged(MultipleSharedDeviceTestCase):
 
         self.sign_in.just_fyi("Checking case %s" % cases[2])
         self.sign_in.create_password_input.send_keys('12345654')
-        self.sign_in.confirm_your_password_input.send_keys('12345678')
+        self.sign_in.confirm_your_password_input.send_keys('12345677')
         if not self.sign_in.element_by_translation_id("password_error1").is_element_displayed():
             self.errors.append("'%s' is not shown" % self.sign_in.get_translation_by_key("password_error1"))
         self.sign_in.create_password_input.set_value(common_password)

--- a/test/appium/tests/atomic/account_management/test_wallet_management.py
+++ b/test/appium/tests/atomic/account_management/test_wallet_management.py
@@ -94,7 +94,7 @@ class TestWalletManagementDeviceMerged(MultipleSharedDeviceTestCase):
         self.wallet.just_fyi("Checking basic validation when adding multiaccount")
         if self.wallet.get_account_by_name(account_name).is_element_displayed():
             self.drivers[0].fail('Account is added without password')
-        self.wallet.enter_your_password_input.send_keys('000000')
+        self.wallet.enter_your_password_input.send_keys('00000000')
         self.wallet.add_account_generate_account_button.click()
         if not self.wallet.element_by_text_part('Password seems to be incorrect').is_element_displayed():
             self.drivers[0].fail("Incorrect password validation is not performed")


### PR DESCRIPTION
For running e2e in https://github.com/status-im/status-react/pull/13150 common_password value was changed to qwerty1234 in order to meet new password reqs implemented by the PR. 
