### PR TITLE
Fix yarn install issue with rn-emoji-keyboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "react-native-svg": "^9.8.4",
     "react-native-touch-id": "^4.4.1",
     "react-native-webview": "git+https://github.com/status-im/react-native-webview.git#refs/tags/v11.16.0-status",
-    "rn-emoji-keyboard": "git+https://github.com/status-im/rn-emoji-keyboard.git#refs/tags/v0.4.2",
+    "rn-emoji-keyboard": "git+https://github.com/status-im/rn-emoji-keyboard.git#refs/tags/v0.4.3",
     "tdigest": "^0.1.1",
     "web3-utils": "^1.2.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7860,9 +7860,9 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
-"rn-emoji-keyboard@git+https://github.com/status-im/rn-emoji-keyboard.git#refs/tags/v0.4.2":
-  version "0.4.2"
-  resolved "git+https://github.com/status-im/rn-emoji-keyboard.git#969814269cc51fae2c1fd0375e8509fa066cdc7f"
+"rn-emoji-keyboard@git+https://github.com/status-im/rn-emoji-keyboard.git#refs/tags/v0.4.3":
+  version "0.4.3"
+  resolved "git+https://github.com/status-im/rn-emoji-keyboard.git#577f672c15c683eab721cefcf7f5031efd07fda3"
 
 "rn-snoopy@git+https://github.com/status-im/rn-snoopy.git#refs/tags/v2.0.2-status":
   version "2.0.2"


### PR DESCRIPTION
fixes https://github.com/status-im/status-react/issues/13269

## QA test request
PR targets upgrading of `react-native-svg` of `rn-emoji-keyboard` which we use for creating community channel thumbnails.
And also in the process removed some unnecessary changes in the fork. Please let me know if the emoji keyboard is not working as expected after the upgrade.

status: ready