### PR TITLE
Fix sticker pack synchronization

### DIFF
--- a/src/status_im/multiaccounts/update/core.cljs
+++ b/src/status_im/multiaccounts/update/core.cljs
@@ -42,6 +42,7 @@
 
 (fx/defn optimistic
   [{:keys [db] :as cofx} setting setting-value]
+         (prn "---------- " setting setting-value)
   (let [current-multiaccount (:multiaccount db)]
     {:db (if setting-value
            (assoc-in db [:multiaccount setting] setting-value)

--- a/src/status_im/stickers/core.cljs
+++ b/src/status_im/stickers/core.cljs
@@ -108,8 +108,11 @@
      {:db (-> db
               (assoc-in [:stickers/packs-installed id] pack))}
      ;;(assoc :stickers/selected-pack id))} TODO it doesn't scroll to selected pack on Android
+     
      (multiaccounts.update/multiaccount-update
       :stickers/packs-installed
+
+    
       (assoc (:stickers/packs-installed multiaccount) id pack)
       {}))))
 

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.98.1",
-    "commit-sha1": "3050106595104c16083a8a155d7b2167e7fda798",
-    "src-sha256": "0dab072wmajdnp3hiyycxg1wn14a7l142z3768vwc2mz13nnld2r"
+    "version": "122cbb18e5aa52563427c48fa09eacd6bae489a6",
+    "commit-sha1": "122cbb18e5aa52563427c48fa09eacd6bae489a6",
+    "src-sha256": "0f0z144gzg1lnyf7x0m78j3pmx1hkrfv18byjbd0s7nqsk2x9sbp"
 }


### PR DESCRIPTION
fixes #12889

### Summary
Fixed sticker pack synchronisation within the same account.

### Review notes
<!-- (Optional. Specify if something in particular should be looked at, or ignored, during review) -->

### Testing notes
<!-- (Optional) -->

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS
- macOS
- Linux
- Windows

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- 1-1 chats
- public chats
- group chats
- wallet / transactions
- dapps / app browsing
- account recovery
- new account
- user profile updates
- networks
- mailservers
- fleet
- bootnodes

##### Non-functional

- battery performance
- CPU performance / speed of the app
- network consumption

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open Status
- ...
- Step 3, etc.

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: wip
