### PR TITLE
Feat/wallet sync

### DIFF
--- a/src/status_im/multiaccounts/login/core.cljs
+++ b/src/status_im/multiaccounts/login/core.cljs
@@ -419,6 +419,17 @@
   [{:keys [db]}]
   {::open-last-chat (get-in db [:multiaccount :key-uid])})
 
+(fx/defn update-wallet-accounts
+  [{:keys [db]} accounts]
+  (let [existing-accounts (into {} (map #(vector (:address %1) %1) (:multiaccount/accounts db)))
+        reduce-fn (fn [existing-accs new-acc]
+                    (let [address (:address new-acc)]
+                      (if (:removed new-acc)
+                        (dissoc existing-accs address)
+                        (assoc existing-accs address new-acc))))
+        new-accounts (reduce reduce-fn existing-accounts (rpc->accounts accounts))]
+    {:db (assoc db :multiaccount/accounts (vals new-accounts))}))
+
 (fx/defn get-chats-callback
   {:events [::get-chats-callback]}
   [{:keys [db] :as cofx}]

--- a/src/status_im/transport/message/core.cljs
+++ b/src/status_im/transport/message/core.cljs
@@ -19,6 +19,7 @@
             [status-im.utils.types :as types]
             [status-im.constants :as constants]
             [status-im.multiaccounts.model :as multiaccounts.model]
+            [status-im.multiaccounts.login.core :as multiaccounts.login]
             [status-im.notifications-center.core :as notifications-center]
             [status-im.visibility-status-updates.core :as models.visibility-status-updates]
             [status-im.browser.core :as browser]
@@ -51,6 +52,7 @@
         ^js settings                   (.-settings response-js)
         ^js cleared-histories          (.-clearedHistories response-js)
         ^js identity-images            (.-identityImages response-js)
+        ^js accounts                   (.-accounts response-js)
         sync-handler                   (when-not process-async process-response)]
     (cond
 
@@ -158,6 +160,13 @@
                   (process-next response-js sync-handler)
                   (models.visibility-status-updates/handle-visibility-status-updates
                    visibility-status-updates-clj)))
+
+      (seq accounts)
+      (do
+        (js-delete response-js "accounts")
+        (fx/merge cofx
+                  (process-next response-js sync-handler)
+                  (multiaccounts.login/update-wallet-accounts (types/js->clj accounts))))
 
       (seq settings)
       (do


### PR DESCRIPTION
Depends on https://github.com/status-im/status-go/pull/2607.

This works for watch-only accounts only (sync for all types of wallet accounts will be implemented separately).

Also fixes an issue introduced by https://github.com/status-im/status-react/pull/13315 (watch-only wallet accounts could not be deleted).

Steps that were taken to verify the PR:
1. Create wallet account on Device 1 (running develop, not this PR)
2. Install this PR on Device 1 so that account DB is migrated. Confirm wallet account is visible.
3. Install this PR on Device 2 and sync them (via `Sync All Devices` button on Device 1). Confirm wallet account appears on Device 2.
4. Add another wallet account on Device 2. Confirm it appears on Device 1.
5. Remove first wallet account on Device 1. Confirm it is removed on Device 2.