### PR TITLE
nix: upgrade Nixpkgs, Go and Node.js

### DIFF
--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -33,9 +33,9 @@ in {
   gradlePropParser = callPackage ./tools/gradlePropParser.nix { };
 
   # Package version adjustments
-  go = super.pkgs.go_1_16;
+  go = super.pkgs.go_1_17;
   gradle = super.pkgs.gradle_5;
-  nodejs = super.pkgs.nodejs-12_x;
+  nodejs = super.pkgs.nodejs-16_x;
   openjdk = super.pkgs.openjdk8_headless;
   xcodeWrapper = callPackage ./pkgs/xcodeenv/compose-xcodewrapper.nix { } {
     version = "11.5";

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -13,8 +13,8 @@ let
     name = "nixpkgs-source";
     owner = "status-im";
     repo = "nixpkgs";
-    rev = "15111f8a9ad423d300886b537647691c2faa28cd";
-    sha256 = "05ny644x3dpxigljnb4rmams5vrs5gkbcyqjfamvlqm8rdmsi0kn";
+    rev = "4ba5f26780e7a27aa2e97676603cd9ef04f11e74";
+    sha256 = "sha256-ZpHXUuF9bvHooKwGuR1Mr/n2mE/LJ6/MCdCk2AfdD9M=";
     # To get the compressed Nix sha256, use:
     # nix-prefetch-url --unpack https://github.com/${ORG}/nixpkgs/archive/${REV}.tar.gz
   };


### PR DESCRIPTION
Notable software upgrades:

- Go `1.16.8` to `1.17.3`
- NodeJS `12.22.7` to `16.14.2`
- OpenJDK `8u272-b10` to `8u322-ga`
- Clojure `1.10.3.1029` to `1.11.1.1107`
- Git `2.33.1` to `2.35.1`
- CMake `3.18.1` to `3.22.3`
- Curl `7.79.1` to `7.82.0`
- GNU Awk `5.1.0` to `5.1.1`

The Go upgrade is done in advance of upgrade to `1.18.1`.
The Node.js upgrade is done since `12.x` security support [is over](https://endoflife.date/nodejs).