### PR TITLE
ci: upgarde to Xcode 13.3.1

### DIFF
--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -1,7 +1,7 @@
 library 'status-jenkins-lib@v1.4.1'
 
 pipeline {
-  agent { label 'macos && x86_64 && nix-2.6 && xcode-12.5' }
+  agent { label 'macos && x86_64 && nix-2.6 && xcode-13.3' }
 
   parameters {
     string(

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -38,7 +38,7 @@ in {
   nodejs = super.pkgs.nodejs-16_x;
   openjdk = super.pkgs.openjdk8_headless;
   xcodeWrapper = callPackage ./pkgs/xcodeenv/compose-xcodewrapper.nix { } {
-    version = "11.5";
+    version = "13.3";
     allowHigher = true;
   };
   gomobile = super.gomobile.override {


### PR DESCRIPTION
App store now requires all applications to be built with XCode 13: https://developer.apple.com/news/?id=2t1chhp3

Related: https://github.com/status-im/infra-ci/issues/48