### PR TITLE
nix: upgrade from 2.6.1 to 2.8.0

### DIFF
--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -1,7 +1,7 @@
 library 'status-jenkins-lib@v1.4.1'
 
 pipeline {
-  agent { label 'linux && x86_64 && nix-2.6' }
+  agent { label 'linux && x86_64 && nix-2.8' }
 
   options {
     timestamps()

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -1,7 +1,7 @@
 library 'status-jenkins-lib@v1.4.1'
 
 pipeline {
-  agent { label 'macos && x86_64 && nix-2.6 && xcode-13.3' }
+  agent { label 'macos && x86_64 && nix-2.8 && xcode-13.3' }
 
   parameters {
     string(

--- a/ci/Jenkinsfile.nix-cache
+++ b/ci/Jenkinsfile.nix-cache
@@ -98,8 +98,8 @@ pipeline {
           nix.shell("""
               find /nix/store/ -mindepth 1 -maxdepth 1 -type d \
                 -not -name '*.links' -and -not -name '*-status-react-*' \
-                | xargs nix-copy-closure -v \
-                  --to ${params.NIX_CACHE_USER}@${params.NIX_CACHE_HOST}
+                | xargs nix copy \
+                  --to ssh-ng://${params.NIX_CACHE_USER}@${params.NIX_CACHE_HOST}
             """,
             pure: false
           )

--- a/nix/nix.conf
+++ b/nix/nix.conf
@@ -11,3 +11,5 @@ keep-derivations = true
 keep-outputs = true
 # Extra isolation for network and filesystem, doesn't work on MacOS
 build-use-sandbox = false
+# Enable Nix v2 interface.
+experimental-features = nix-command

--- a/nix/scripts/setup.sh
+++ b/nix/scripts/setup.sh
@@ -6,9 +6,9 @@ GIT_ROOT=$(cd "${BASH_SOURCE%/*}" && git rev-parse --show-toplevel)
 source "${GIT_ROOT}/nix/scripts/lib.sh"
 source "${GIT_ROOT}/scripts/colors.sh"
 
-NIX_VERSION="2.6.1"
+NIX_VERSION="2.8.0"
 NIX_INSTALL_URL="https://nixos.org/releases/nix/nix-${NIX_VERSION}/install"
-NIX_INSTALL_SHA256="a63732b4f3628ce97e096dbda88e3cb9851ff6b4f94b5cd43feb257126437b9d"
+NIX_INSTALL_SHA256="f43bfedfca9151479462d8bc11f238615a2d52f19b14894d8e2b59980e75ef72"
 NIX_INSTALL_PATH="/tmp/nix-install-${NIX_VERSION}"
 
 install_nix() {


### PR DESCRIPTION
Minor upgrade done to match the version deployed in CI due to a bug with `nix-copy-closure` which broken Nix cache jobs:
https://github.com/status-im/infra-ci/issues/49

This will __not__ force upgrade on developes, nor require any `make nix-purge`. It is __optional__.
If however and upgrade is wanted it can be simply done with `nix upgrade-nix`.