### PR TITLE
ci: lower App Store session duration to 500 seconds

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -103,7 +103,7 @@ def asc_api_key()
     key_id: ENV['FASTLANE_ASC_API_KEY_ID'],
     issuer_id: ENV['FASTLANE_ASC_API_ISSUER_ID'],
     key_filepath: ENV['FASTLANE_ASC_API_KEY_FILE_PATH'],
-    duration: 1200, # seconds, session length
+    duration: 500, # seconds, session length
     in_house: false,
   )
 end


### PR DESCRIPTION
Possible fix for iOS build authentication failures:
```
Authentication credentials are missing or invalid.
  - Provide a properly configured and signed bearer token, and make sure that it has not expired.
    Learn more about Generating Tokens for API Requests https://developer.apple.com/go/?id=api-generating-tokens
```
Resolves: https://github.com/status-im/status-react/issues/13352