### PR TITLE
Synchronise Sticker Pack setting fields

### DIFF
--- a/src/status_im/multiaccounts/update/core.cljs
+++ b/src/status_im/multiaccounts/update/core.cljs
@@ -2,6 +2,7 @@
   (:require [status-im.constants :as constants]
             [status-im.ethereum.json-rpc :as json-rpc]
             [status-im.utils.fx :as fx]
+            [status-im.utils.types :as types]
             [taoensso.timbre :as log]))
 
 (fx/defn send-multiaccount-update [{:keys [db] :as cofx}]
@@ -41,17 +42,35 @@
                        :mnemonic nil
                        {}))
 
+(defn augment-synchronized-recent-stickers
+  "Add 'url' parameter to stickers that are synchronized from other devices.
+   It is not sent from aanother devices but we have it in our db."
+  [synced-stickers stickers-from-db]
+  (mapv #(assoc % :url (->> (get stickers-from-db (:packID %))
+                            (:stickers)
+                            (filter (fn [sticker-db] (= (:hash sticker-db) (:hash %))))
+                            (first)
+                            (:url)))
+        synced-stickers))
+
 (fx/defn optimistic
   [{:keys [db] :as cofx} setting setting-value]
   (let [current-multiaccount (:multiaccount db)
         setting-value (if (= :currency setting)
                         (keyword setting-value)
                         setting-value)
-        db (if (= :stickers/packs-installed setting)
-             ;;updating :stickers/packs for installed stickers
-             (let [packs-installed-keys (keys (js->clj setting-value))]
-               (reduce #(assoc-in %1 [:stickers/packs %2 :status] constants/sticker-pack-status-installed) db packs-installed-keys))
-             db)]
+        db  (case setting
+              :stickers/packs-pending
+              (let [packs-pending (keys (js->clj setting-value))]
+                (update db :stickers/packs-pending conj packs-pending))
+              :stickers/packs-installed
+              (let [packs-installed-keys (keys (js->clj setting-value))]
+                (reduce #(assoc-in %1 [:stickers/packs %2 :status] constants/sticker-pack-status-installed) db packs-installed-keys))
+              :stickers/recent-stickers
+              (let [recent-stickers-from-remote (augment-synchronized-recent-stickers (types/js->clj setting-value) (:stickers/packs db))
+                    merged (into recent-stickers-from-remote (:stickers/recent-stickers db))]
+                (assoc db :stickers/recent-stickers recent-stickers-from-remote))
+              db)]
     {:db (if setting-value
            (assoc-in db [:multiaccount setting] setting-value)
            (update db :multiaccount dissoc setting))}))

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.101.1",
-    "commit-sha1": "cc80f5753baf4701cfabcde8d01c2e8b9deebd6f",
-    "src-sha256": "1sc4a8qnmb64dn0x9s4r1m42dwzr70jh2mzgyhn2mavx33abr8kn"
+    "version": "develop",
+    "commit-sha1": "efa14805bd3a87f7e87f2655dd651dc4d9c18e6d",
+    "src-sha256": "0xa2d3w7caxnd89gbbg3n7y2r8mk1ljaygknxliaizpyp473zkh4"
 }


### PR DESCRIPTION
Synchronize Sticker Pack setting fields
fixes #13193

### Summary
Implement functionality that handles the syncing of the stickers/recent-stickers settings

#### Platforms
- Android
- iOS

##### Functional
- 1-1 chat
- public chats
- group chats

### Steps to test
Enable synchronization as described in this comment:
https://github.com/status-im/status-react/pull/13053#issuecomment-1065179963

Open Status
Send stickers and see them added to recent stickers and synchronized in another device with the same account.

status: ready