### PR TITLE
Include share action on longpress image menu

### DIFF
--- a/src/status_im/ui/screens/chat/message/message.cljs
+++ b/src/status_im/ui/screens/chat/message/message.cljs
@@ -24,6 +24,7 @@
             [status-im.ui.screens.chat.message.link-preview :as link-preview]
             [status-im.ui.screens.communities.icon :as communities.icon]
             [status-im.ui.components.animation :as animation]
+            [status-im.chat.models.images :as images]
             [status-im.chat.models.pin-message :as models.pin-message])
   (:require-macros [status-im.utils.views :refer [defview letsubs]]))
 
@@ -586,7 +587,11 @@
                                  :label    (i18n/label :t/message-reply)}
                                 {:on-press #(re-frame/dispatch [:chat.ui/save-image-to-gallery (:image content)])
                                  :id       :save
-                                 :label    (i18n/label :t/save)}]
+                                 :label    (i18n/label :t/save)}
+                                {:on-press #(images/download-image-http
+                                             (get-in message [:content :image]) preview/share)
+                                 :id       :share
+                                 :label    (i18n/label :t/share)}]
                                (when (and outgoing config/delete-message-enabled?)
                                  [{:on-press #(re-frame/dispatch [:chat.ui/soft-delete-message message])
                                    :label    (i18n/label :t/delete)

--- a/src/status_im/ui/screens/chat/message/reactions_picker.cljs
+++ b/src/status_im/ui/screens/chat/message/reactions_picker.cljs
@@ -25,6 +25,8 @@
    "unpin"  :main-icons/pin
    "copy"   :main-icons/copy
    "reply"  :main-icons/reply
+   "save"  :main-icons/download
+   "share"  :main-icons/share-default
    "delete" :main-icons/delete})
 
 (defn picker [{:keys [outgoing actions own-reactions on-close send-emoji timeline]}]


### PR DESCRIPTION
This PR adds share image messages functionality on long-press image menu

fixes #12480

