### PR TITLE
[feature] [#13099] Automatic RPC usage refresh

### DIFF
--- a/src/status_im/ui/screens/rpc_usage_info.cljs
+++ b/src/status_im/ui/screens/rpc_usage_info.cljs
@@ -95,9 +95,9 @@
        ^{:key (str k v)}
        [quo.react-native/view
         {:style {:flex-direction :row
-                 :justify-content :space-between}}
-        [quo.core/text k]
-        [quo.core/text v]]))])
+                 :align-items     :center}}
+        [quo.core/text {:style {:flex 1}} k]
+        [quo.core/text  {:style {:margin-left 16}} v]]))])
 
 (defn prepare-stats [{:keys [stats]}]
   (clojure.string/join
@@ -106,7 +106,7 @@
           (str k " " v))
         stats)))
 
-(defn usage-info []
+(defn usage-info-render []
   (let [stats @(re-frame/subscribe [:rpc-usage/data])
         methods-filter @(re-frame/subscribe [:rpc-usage/filter])]
     [react/view {:flex 1
@@ -133,10 +133,10 @@
        :auto-focus      false}]
      [stats-table stats]]))
 
-(defn usage-info-container []
+(defn usage-info []
   (reagent/create-class {:component-did-mount (fn []
                                                 (reset! rpc-refresh-interval (utils/set-interval #(re-frame/dispatch [::get-stats]) rpc-usage-refresh-interval-ms)))
                          :component-will-unmount (fn []
                                                    (utils/clear-interval @rpc-refresh-interval)
                                                    (reset! rpc-refresh-interval nil))
-                         :reagent-render usage-info}))
+                         :reagent-render usage-info-render}))

--- a/src/status_im/ui/screens/screens.cljs
+++ b/src/status_im/ui/screens/screens.cljs
@@ -565,7 +565,7 @@
             :component network-info/network-info}
            {:name      :rpc-usage-info
             :options   {:topBar {:title {:text (i18n/label :t/rpc-usage-info)}}}
-            :component rpc-usage-info/usage-info-container}
+            :component rpc-usage-info/usage-info}
            {:name      :edit-network
             :options   {:topBar {:title {:text (i18n/label :t/add-network)}}}
             :component edit-network/edit-network}

--- a/src/status_im/ui/screens/screens.cljs
+++ b/src/status_im/ui/screens/screens.cljs
@@ -565,7 +565,7 @@
             :component network-info/network-info}
            {:name      :rpc-usage-info
             :options   {:topBar {:title {:text (i18n/label :t/rpc-usage-info)}}}
-            :component rpc-usage-info/usage-info}
+            :component rpc-usage-info/usage-info-container}
            {:name      :edit-network
             :options   {:topBar {:title {:text (i18n/label :t/add-network)}}}
             :component edit-network/edit-network}


### PR DESCRIPTION
Fixes https://github.com/status-im/status-react/issues/13099

### Summary
In this PR, I have added an automatic refresh of RPC usage under **_RPC usage stats_** screen without the user's need to interact with the app.
This is achieved by calling the _get-stats_ method every 2 seconds with the help of the _set-interval_ method from _utils_.

I have removed the _**Refresh**_ button from the UI as it no longer serves the purpose and kept the **_Reset_** and **_Copy_** buttons intact.

#### Areas that maybe impacted
 - RPC Usage Stats

### Steps to test

- Open Status
- Navigate to **Profile** Tab
- Open **Advanced Settings**
- Open **RPC Usage Stats**

status: ready 