### PR TITLE
fix navigation default options overwrite

### DIFF
--- a/src/status_im/navigation2/core.cljs
+++ b/src/status_im/navigation2/core.cljs
@@ -11,8 +11,8 @@
                   :wallet      2
                   :browser     3})
 
-(defonce set-navigation-default-options
-  (.setDefaultOptions Navigation (clj->js {:options {:topBar {:visible false}}})))
+;; (defonce set-navigation-default-options
+;;   (.setDefaultOptions Navigation (clj->js {:options {:topBar {:visible false}}})))
 
 ;; TODO (parvesh) - improve open-modal and close-modal
 (defn open-modal [comp]


### PR DESCRIPTION
fixes: https://github.com/status-im/status-react/issues/13377

## Summary

As [set-navigation-default-options](https://github.com/status-im/status-react/blob/d31fca96a93e4c09594f0c0862ffc619191e528d/src/status_im/navigation2/core.cljs#L14) method is declared as `defonce` in [navigation2.cljs](https://github.com/status-im/status-react/blob/develop/src/status_im/navigation2/core.cljs), it is overwriting already present navigation default options in [navigation.cljs](https://github.com/status-im/status-react/blob/develop/src/status_im/navigation/core.cljs).

status: ready