### PR TITLE
[#13357] 'Unknown Not a contact' screen with endless spinner when sta…

### DIFF
--- a/src/status_im/contact/chat.cljs
+++ b/src/status_im/contact/chat.cljs
@@ -11,9 +11,8 @@
    :interceptors [(re-frame/inject-cofx :random-id-generator)]}
   [cofx {:keys [public-key ens-name]}]
   (fx/merge cofx
-            {:dispatch-later [{:ms 1000 :dispatch [:chat.ui/start-chat public-key ens-name]}]}
-            (notification-center/accept-all-activity-center-notifications-from-chat public-key)
-            (navigation/pop-to-root-tab :chat-stack)))
+            (chat/start-chat public-key ens-name)
+            (notification-center/accept-all-activity-center-notifications-from-chat public-key)))
 
 (fx/defn contact-code-submitted
   {:events       [:contact.ui/contact-code-submitted]

--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -59,7 +59,7 @@
             [status-im.wallet.core :as wallet]
             status-im.wallet.custom-tokens.core
             [status-im.navigation.core :as navigation.core]
-            [status-im.multiaccounts.login.core :as login.core]
+            [status-im.navigation.state :as navigation.state]
             [status-im.signing.core :as signing]
             status-im.wallet-connect.core
             status-im.wallet-connect-legacy.core
@@ -123,7 +123,7 @@
         current-tab    (get db :current-tab :chat)
         view-id        (:view-id db)
         screen-params  (get-in db [:navigation/screen-params view-id])
-        root-id        @navigation.core/root-id
+        root-id        @navigation.state/root-id
         dispatch-later (cond-> []
                          (= view-id :chat)
                          (conj {:ms       1000

--- a/src/status_im/group_chats/core.cljs
+++ b/src/status_im/group_chats/core.cljs
@@ -15,9 +15,7 @@
   {:events [:navigate-chat-updated]}
   [cofx chat-id]
   (when (get-in cofx [:db :chats chat-id])
-    (fx/merge cofx
-              {:dispatch-later [{:ms 1000 :dispatch [:chat.ui/navigate-to-chat chat-id]}]}
-              (navigation/pop-to-root-tab :chat-stack))))
+    (models.chat/navigate-to-chat cofx chat-id)))
 
 (fx/defn handle-chat-removed
   {:events [:chat-removed]}

--- a/src/status_im/navigation/state.cljs
+++ b/src/status_im/navigation/state.cljs
@@ -1,0 +1,8 @@
+(ns status-im.navigation.state)
+
+(defonce root-comp-id (atom nil))
+(defonce root-id (atom nil))
+(defonce pushed-screen-id (atom nil))
+(defonce curr-modal (atom nil))
+(defonce modals (atom []))
+(defonce dissmissing (atom false))

--- a/src/status_im/qr_scanner/core.cljs
+++ b/src/status_im/qr_scanner/core.cljs
@@ -50,7 +50,7 @@
 
 (fx/defn handle-public-chat [cofx {:keys [topic]}]
   (when (seq topic)
-    (chat/start-public-chat cofx topic {})))
+    (chat/start-public-chat cofx topic)))
 
 (fx/defn handle-group-chat [cofx params]
   (group-chats/create-from-link cofx params))

--- a/src/status_im/ui/components/react.cljs
+++ b/src/status_im/ui/components/react.cljs
@@ -6,7 +6,7 @@
             [status-im.utils.platform :as platform]
             [status-im.utils.utils :as utils]
             ["react" :as reactjs]
-            ["react-native" :as react-native :refer (Keyboard)]
+            ["react-native" :as react-native :refer (Keyboard BackHandler)]
             ["react-native-image-crop-picker" :default image-picker]
             ["react-native-safe-area-context" :as safe-area-context
              :refer (SafeAreaProvider SafeAreaInsetsContext)]
@@ -270,3 +270,9 @@
 
 (def safe-area-provider (reagent/adapt-react-class SafeAreaProvider))
 (def safe-area-consumer (reagent/adapt-react-class (.-Consumer ^js SafeAreaInsetsContext)))
+
+(defn hw-back-add-listener [callback]
+  (.addEventListener BackHandler "hardwareBackPress" callback))
+
+(defn hw-back-remove-listener [callback]
+  (.removeEventListener BackHandler "hardwareBackPress" callback))

--- a/src/status_im/ui/screens/add_new/new_public_chat/view.cljs
+++ b/src/status_im/ui/screens/add_new/new_public_chat/view.cljs
@@ -12,7 +12,7 @@
   (:require-macros [status-im.utils.views :as views]))
 
 (defn- start-chat [topic]
-  (re-frame/dispatch [:chat.ui/start-public-chat topic {:navigation-reset? true}])
+  (re-frame/dispatch [:chat.ui/start-public-chat topic])
   (re-frame/dispatch [:set :public-group-topic nil]))
 
 (defn- hash-icon []

--- a/src/status_im/ui/screens/browser/options/views.cljs
+++ b/src/status_im/ui/screens/browser/options/views.cljs
@@ -86,10 +86,7 @@
             :accessibility-label :open-chat
             :title               (str "#" topic)
             :subtitle            (i18n/label :t/open-chat)
-            :on-press            #(do
-                                    (re-frame/dispatch [:navigate-change-tab :chat])
-                                    (re-frame/dispatch [:pop-to-root-tab :chat-stack])
-                                    (hide-sheet-and-dispatch [:chat.ui/start-public-chat topic {:navigation-reset? true}]))
+            :on-press            #(hide-sheet-and-dispatch [:chat.ui/start-public-chat topic])
             :chevron             true}]
           [components/separator]])
        (if connected?

--- a/src/status_im/ui/screens/chat/message/message.cljs
+++ b/src/status_im/ui/screens/chat/message/message.cljs
@@ -159,7 +159,7 @@
                         :text-decoration-line :underline}
                 :on-press
                 #(re-frame/dispatch
-                  [:chat.ui/start-public-chat literal {:navigation-reset? true}])}
+                  [:chat.ui/start-public-chat literal])}
                "#"
                literal])
 

--- a/src/status_im/ui/screens/help_center/views.cljs
+++ b/src/status_im/ui/screens/help_center/views.cljs
@@ -31,8 +31,7 @@
     :accessibility-label :request-a-feature-button
     :on-press
     #(re-frame/dispatch [:chat.ui/start-public-chat
-                         "support"
-                         {:navigation-reset? false}])
+                         "support"])
     :chevron             true}])
 
 (defn help-center []

--- a/src/status_im/ui/screens/home/views.cljs
+++ b/src/status_im/ui/screens/home/views.cljs
@@ -22,7 +22,6 @@
             [status-im.ui.components.plus-button :as components.plus-button]
             [status-im.ui.screens.chat.sheets :as sheets]
             [status-im.ui.components.tabbar.core :as tabbar]
-            ["react-native-navigation" :refer (Navigation)]
             [status-im.ui.components.invite.views :as invite]
             [status-im.utils.config :as config])
   (:require-macros [status-im.utils.views :as views]))
@@ -180,19 +179,13 @@
                      :accessibility-label :notifications-unread-badge}]])]))
 
 (defn home []
-  (reagent/create-class
-   {:component-did-mount #(set! (.-navigationEventListener %) (.bindComponent (.events Navigation) % "home"))
-    :componentWillAppear #(do (re-frame/dispatch-sync [:set :view-id :home])
-                              (re-frame/dispatch [:close-chat]))
-    :reagent-render
-    (fn []
-      [react/keyboard-avoiding-view {:style {:flex 1}
-                                     :ignore-offset true}
-       [topbar/topbar {:title           (i18n/label :t/chat)
-                       :navigation      :none
-                       :right-component [react/view {:flex-direction :row :margin-right 16}
-                                         [connectivity/connectivity-button]
-                                         [notifications-button]]}]
-       [chats-list]
-       [plus-button]
-       [tabbar/tabs-counts-subscriptions]])}))
+  [react/keyboard-avoiding-view {:style {:flex 1}
+                                 :ignore-offset true}
+   [topbar/topbar {:title           (i18n/label :t/chat)
+                   :navigation      :none
+                   :right-component [react/view {:flex-direction :row :margin-right 16}
+                                     [connectivity/connectivity-button]
+                                     [notifications-button]]}]
+   [chats-list]
+   [plus-button]
+   [tabbar/tabs-counts-subscriptions]])

--- a/src/status_im/ui/screens/screens.cljs
+++ b/src/status_im/ui/screens/screens.cljs
@@ -123,8 +123,7 @@
             ;[quo2.foundations.colors :as quo2.colors]))
 
 (def components
-  [{:name      :chat-toolbar
-    :component chat/topbar}])
+  [])
 
 (defn right-button-options [id icon]
   {:id   id
@@ -222,10 +221,9 @@
            ;Chat
            {:name          :chat
             :options       {:popGesture false
-                            :topBar     {:title        {:component {:name :chat-toolbar :id :chat-toolbar}
-                                                        :alignment :fill}
-                                         :rightButtons (right-button-options :chat :more)}}
-            :right-handler chat/topbar-button
+                            :hardwareBackButton {:dismissModalOnPress false
+                                                 :popStackOnPress     false}
+                            :topBar             {:visible false}}
             :component     chat/chat}
 
            ;Pinned messages

--- a/src/status_im/utils/universal_links/core.cljs
+++ b/src/status_im/utils/universal_links/core.cljs
@@ -76,7 +76,7 @@
 (fx/defn handle-public-chat [cofx {:keys [topic]}]
   (log/info "universal-links: handling public chat" topic)
   (when (seq topic)
-    (chat/start-public-chat cofx topic {})))
+    (chat/start-public-chat cofx topic)))
 
 (fx/defn handle-view-profile
   [{:keys [db] :as cofx} {:keys [public-key ens-name]}]

--- a/test/appium/views/base_view.py
+++ b/test/appium/views/base_view.py
@@ -15,7 +15,7 @@ from views.base_element import Button, BaseElement, EditBox, Text, CheckBox
 
 class BackButton(Button):
     def __init__(self, driver):
-        super().__init__(driver, accessibility_id="Navigate Up")
+        super().__init__(driver, accessibility_id="back-button")
 
     def click(self, times_to_click: int = 1):
         for _ in range(times_to_click):


### PR DESCRIPTION
It's an awful solution, but its the only way to fix it, the big problem with react-native-navigation, is because of its native nature, now we have two states, one state is visible on the screen in native, and one in js thread, so when we close the screen by native button we don't have information in js thread that screen is closed until it will be unmounted, but at that moment there might be another screen visible and active for some time, also there is no control on hardware back button, so its hard to sync states 

fixes: #13357
fixes: #12507