### PR TITLE
Communities encryption integration

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.101.0",
-    "commit-sha1": "09ba88c19dc36c88d22e880d6568e4fe4861ddc3",
-    "src-sha256": "178p268kj5n0qzsw8i20zgip34q1rrxa7l7j3gib6ai3a30p6zif"
+    "version": "feat/communities-encryption-integration",
+    "commit-sha1": "a0c4392ca9f69cb4ce038c767524f22df7a27e6a",
+    "src-sha256": "1svgjjqxphys352g8xfyna8gh5hw1aisghbaf1pikk1kl8bsjvca"
 }


### PR DESCRIPTION
This is PR is here to verify that merging https://github.com/status-im/status-go/pull/2534 will not break anything.

The status-go PR provides encryption feature for communities in some basic form. It is set to Off by default, so, once merged, the PR initially should have no effect.