### PR TITLE
[Fixes: #13416] resize image in status-go as well, alert user if fails

### DIFF
--- a/src/status_im/chat/models/loading.cljs
+++ b/src/status_im/chat/models/loading.cljs
@@ -49,7 +49,7 @@
   {::json-rpc/call [{:method "wakuext_chat"
                      :params [chat-id]
                      :on-success #(re-frame/dispatch [:chats-list/load-chat-success %])
-                     :on-failure #(log/error "failed to fetch chats" 0 -1 %)}]})
+                     :on-error #(log/error "failed to fetch chats" 0 -1 %)}]})
 
 (fx/defn handle-failed-loading-messages
   {:events [::failed-loading-messages]}

--- a/src/status_im/communities/core.cljs
+++ b/src/status_im/communities/core.cljs
@@ -189,7 +189,8 @@
                      :js-response true
                      :on-success
                      #(re-frame/dispatch [:transport/message-sent %])
-                     :on-failure #(log/error "failed to send a message" %)}]})
+                     :on-error
+                     #(log/error "failed to send a message" %)}]})
 
 (fx/defn invite-users
   {:events [::invite-people-confirmation-pressed]}

--- a/src/status_im/data_store/chats.cljs
+++ b/src/status_im/data_store/chats.cljs
@@ -107,4 +107,4 @@
                      :params []
                      :js-response true
                      :on-success #(on-success ^js %)
-                     :on-failure #(log/error "failed to fetch chats" 0 -1 %)}]})
+                     :on-error #(log/error "failed to fetch chats" 0 -1 %)}]})

--- a/src/status_im/data_store/contacts.cljs
+++ b/src/status_im/data_store/contacts.cljs
@@ -23,7 +23,7 @@
   {::json-rpc/call [{:method "wakuext_contacts"
                      :params []
                      :on-success #(on-success (map <-rpc %))
-                     :on-failure #(log/error "failed to fetch contacts" %)}]})
+                     :on-error #(log/error "failed to fetch contacts" %)}]})
 
 (fx/defn add
   [_ public-key nickname ens-name on-success]
@@ -34,7 +34,7 @@
                                     (log/info "saved contact" public-key "successfuly")
                                     (when on-success
                                       (on-success %)))
-                     :on-failure #(log/error "failed to add contact" public-key %)}]})
+                     :on-error #(log/error "failed to add contact" public-key %)}]})
 
 (fx/defn set-nickname
   [_ public-key nickname on-success]
@@ -45,18 +45,18 @@
                                     (log/debug "set contact nickname" public-key "successfuly" nickname)
                                     (when on-success
                                       (on-success %)))
-                     :on-failure #(log/error "failed to set contact nickname " public-key nickname %)}]})
+                     :on-error #(log/error "failed to set contact nickname " public-key nickname %)}]})
 
 (fx/defn block [_ contact-id on-success]
   {::json-rpc/call [{:method "wakuext_blockContact"
                      :params [contact-id]
                      :js-response true
                      :on-success on-success
-                     :on-failure #(log/error "failed to block contact" % contact-id)}]})
+                     :on-error #(log/error "failed to block contact" % contact-id)}]})
 
 (fx/defn unblock [_ contact-id on-success]
   {::json-rpc/call [{:method "wakuext_unblockContact"
                      :params [contact-id]
                      :on-success on-success
                      :js-response true
-                     :on-failure #(log/error "failed to unblock contact" % contact-id)}]})
+                     :on-error #(log/error "failed to unblock contact" % contact-id)}]})

--- a/src/status_im/data_store/messages.cljs
+++ b/src/status_im/data_store/messages.cljs
@@ -54,12 +54,12 @@
                                cursor
                                limit
                                on-success
-                               on-failure]
+                               on-error]
   {::json-rpc/call [{:method     "wakuext_chatMessages"
                      :params     [chat-id cursor limit]
                      :on-success (fn [result]
                                    (on-success (update result :messages #(map <-rpc %))))
-                     :on-failure on-failure}]})
+                     :on-error on-error}]})
 
 (defn mark-seen-rpc [chat-id ids on-success]
   {::json-rpc/call [{:method "wakuext_markMessagesSeen"
@@ -67,25 +67,25 @@
                      :on-success #(do
                                     (log/debug "successfully marked as seen" %)
                                     (when on-success (on-success chat-id ids %)))
-                     :on-failure #(log/error "failed to get messages" %)}]})
+                     :on-error #(log/error "failed to get messages" %)}]})
 
 (defn delete-message-rpc [id]
   {::json-rpc/call [{:method "wakuext_deleteMessage"
                      :params [id]
                      :on-success #(log/debug "successfully deleted message" id)
-                     :on-failure #(log/error "failed to delete message" % id)}]})
+                     :on-error #(log/error "failed to delete message" % id)}]})
 
 (defn delete-messages-from-rpc [author]
   {::json-rpc/call [{:method "wakuext_deleteMessagesFrom"
                      :params [author]
                      :on-success #(log/debug "successfully deleted messages from" author)
-                     :on-failure #(log/error "failed to delete messages from" % author)}]})
+                     :on-error #(log/error "failed to delete messages from" % author)}]})
 
 (defn delete-messages-by-chat-id-rpc [chat-id]
   {::json-rpc/call [{:method "wakuext_deleteMessagesByChatID"
                      :params [chat-id]
                      :on-success #(log/debug "successfully deleted messages by chat-id" chat-id)
-                     :on-failure #(log/error "failed to delete messages by chat-id" % chat-id)}]})
+                     :on-error #(log/error "failed to delete messages by chat-id" % chat-id)}]})
 
 (fx/defn delete-message [cofx id]
   (delete-message-rpc id))

--- a/src/status_im/data_store/pin_messages.cljs
+++ b/src/status_im/data_store/pin_messages.cljs
@@ -16,16 +16,16 @@
                                      cursor
                                      limit
                                      on-success
-                                     on-failure]
+                                     on-error]
   {::json-rpc/call [{:method     "wakuext_chatPinnedMessages"
                      :params     [chat-id cursor limit]
                      :on-success (fn [result]
                                    (let [result (clojure.set/rename-keys result {:pinnedMessages :pinned-messages})]
                                      (on-success (update result :pinned-messages #(map <-rpc %)))))
-                     :on-failure on-failure}]})
+                     :on-error on-error}]})
 
 (fx/defn send-pin-message [cofx pin-message]
   {::json-rpc/call [{:method "wakuext_sendPinMessage"
                      :params [(messages/->rpc pin-message)]
                      :on-success #(log/debug "successfully pinned message" pin-message)
-                     :on-failure #(log/error "failed to pin message" % pin-message)}]})
+                     :on-error #(log/error "failed to pin message" % pin-message)}]})

--- a/src/status_im/data_store/reactions.cljs
+++ b/src/status_im/data_store/reactions.cljs
@@ -23,9 +23,9 @@
                                 cursor
                                 limit
                                 on-success
-                                on-failure]
+                                on-error]
   {::json-rpc/call [{:method     "wakuext_emojiReactionsByChatID"
                      :params     [chat-id cursor limit]
                      :on-success (fn [result]
                                    (on-success (map <-rpc result)))
-                     :on-failure on-failure}]})
+                     :on-error on-error}]})

--- a/src/status_im/data_store/visibility_status_updates.cljs
+++ b/src/status_im/data_store/visibility_status_updates.cljs
@@ -20,5 +20,5 @@
                      :on-success #(re-frame/dispatch
                                    [:visibility-status-updates/visibility-status-updates-loaded
                                     (:statusUpdates ^js %)])
-                     :on-failure #(log/error
-                                   "failed to fetch visibility-status-updates" %)}]})
+                     :on-error #(log/error
+                                 "failed to fetch visibility-status-updates" %)}]})

--- a/src/status_im/pairing/core.cljs
+++ b/src/status_im/pairing/core.cljs
@@ -9,29 +9,29 @@
             [taoensso.timbre :as log]
             [status-im.multiaccounts.update.core :as multiaccounts.update]))
 
-(defn enable-installation-rpc [installation-id on-success on-failure]
+(defn enable-installation-rpc [installation-id on-success on-error]
   (json-rpc/call {:method     "wakuext_enableInstallation"
                   :params     [installation-id]
                   :on-success on-success
-                  :on-failure on-failure}))
+                  :on-error on-error}))
 
-(defn disable-installation-rpc [installation-id on-success on-failure]
+(defn disable-installation-rpc [installation-id on-success on-error]
   (json-rpc/call {:method     "wakuext_disableInstallation"
                   :params     [installation-id]
                   :on-success on-success
-                  :on-failure on-failure}))
+                  :on-error on-error}))
 
-(defn set-installation-metadata-rpc [installation-id metadata on-success on-failure]
+(defn set-installation-metadata-rpc [installation-id metadata on-success on-error]
   (json-rpc/call {:method     "wakuext_setInstallationMetadata"
                   :params     [installation-id metadata]
                   :on-success on-success
-                  :on-failure on-failure}))
+                  :on-error on-error}))
 
-(defn get-our-installations-rpc [on-success on-failure]
+(defn get-our-installations-rpc [on-success on-error]
   (json-rpc/call {:method     "wakuext_getOurInstallations"
                   :params     []
                   :on-success on-success
-                  :on-failure on-failure}))
+                  :on-error on-error}))
 
 (defn compare-installation
   "Sort installations, first by our installation-id, then on whether is

--- a/src/status_im/signing/core.cljs
+++ b/src/status_im/signing/core.cljs
@@ -159,7 +159,7 @@
                                                 :gasLimit (money/to-fixed (money/bignumber gas)))
                                          clj->js)]
                        :on-success #(log/info "pending transfer is saved")
-                       :on-failure #(log/info "pending transfer was not saved" %)}]}))
+                       :on-error #(log/info "pending transfer was not saved" %)}]}))
 
 (defn get-method-type [data]
   (cond

--- a/src/status_im/transport/core.cljs
+++ b/src/status_im/transport/core.cljs
@@ -40,7 +40,7 @@
   [_]
   {::json-rpc/call [{:method "wakuext_startMessenger"
                      :on-success #(re-frame/dispatch [::messenger-started %])
-                     :on-failure #(log/error "failed to start messenger")}]})
+                     :on-error #(log/error "failed to start messenger")}]})
 
 (fx/defn messenger-started
   {:events [::messenger-started]}

--- a/src/status_im/transport/message/protocol.cljs
+++ b/src/status_im/transport/message/protocol.cljs
@@ -31,18 +31,20 @@
                      :params     [(mapv build-message messages)]
                      :js-response true
                      :on-success #(re-frame/dispatch [:transport/message-sent %])
-                     :on-failure #(log/error "failed to send a message" %)}]})
+                     :on-error #(do
+                                  (log/warn "failed to send a message" %)
+                                  (js/alert (str "failed to send a message: " %)))}]})
 
 (fx/defn send-reaction [_ {:keys [message-id chat-id emoji-id]}]
   {::json-rpc/call [{:method     "wakuext_sendEmojiReaction"
                      :params     [chat-id message-id emoji-id]
                      :js-response true
                      :on-success #(re-frame/dispatch [:sanitize-messages-and-process-response %])
-                     :on-failure #(log/error "failed to send a reaction" %)}]})
+                     :on-error #(log/error "failed to send a reaction" %)}]})
 
 (fx/defn send-retract-reaction [_ {:keys [emoji-reaction-id]}]
   {::json-rpc/call [{:method     "wakuext_sendEmojiReactionRetraction"
                      :params     [emoji-reaction-id]
                      :js-response true
                      :on-success #(re-frame/dispatch [:sanitize-messages-and-process-response %])
-                     :on-failure #(log/error "failed to send a reaction retraction" %)}]})
+                     :on-error #(log/error "failed to send a reaction retraction" %)}]})

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.100.1",
-    "commit-sha1": "869942c05e04fa6e5d5105d3f5642f6a5ff28fcb",
-    "src-sha256": "0krig4rggbd6aryczig4r70fcn8fmfki52s931zyn3nqmjr386xh"
+    "version": "v0.100.2",
+    "commit-sha1": "ed67cc2a6cffc8312c784f6a77170a80be96fa54",
+    "src-sha256": "0crafxj747ddsjkkwdrdnijj22vknyzwrgakbn83fszxb1babj0z"
 }


### PR DESCRIPTION
Cap size of images, resize them in status-go, and refuses to send images > 500KB, in case we can't achieve the desired compression.

I could not replicate the issue using the current code, I will have to push out a special build disabling compression so you can see the error message.


### Testing

Since we can't replicate the issue, but we think the reason is that some images are not compressed enough, the best bet is to try to send very large images (15M/20M). 
If that does not work I can disable client-side compression, and you should be hitting the limit (status-go compression is more forgiving, also slower, so best to keep both).
