### PR TITLE
status-go: add intro/outro message to communities

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "a244d776571cc73ea34d7a700cc5db36166ce832",
-    "commit-sha1": "a244d776571cc73ea34d7a700cc5db36166ce832",
-    "src-sha256": "1v057jy565y9178ja8j9j6sg04z83y7a0bnry6ziy9zf2zda7nkg"
+    "version": "dbb8e14d84b46eb1370a0e7ca99f3a9d932ebe87",
+    "commit-sha1": "dbb8e14d84b46eb1370a0e7ca99f3a9d932ebe87",
+    "src-sha256": "1dmrl2ikj26kwa3i9wkwrgvvv9512lq567ppi6v73j6wq24nglfc"
 }


### PR DESCRIPTION
Added intro/outro messages to communities. These parameters are optional so no changes should be required by Mobile.

introduced in: https://github.com/status-im/status-go/pull/2688
used in: https://github.com/status-im/status-desktop/pull/5882

### Testing notes
<!-- (Optional) -->

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- communities

Mobile should not be affected by these changes, intro/outro messages are optional, and there is no requirement to accept intro messages from a backend perspective.

### Steps to test
<!-- (Specify exact steps to test if there are such) -->
Scenario A:
- create community

Scenario B:
- edit community

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->
