### PR TITLE
Remove explicit join from group chats

### DIFF
--- a/src/status_im/group_chats/db.cljs
+++ b/src/status_im/group_chats/db.cljs
@@ -2,9 +2,9 @@
 
 (def members-added-type 3)
 
-(defn joined?
-  [public-key {:keys [members-joined]}]
-  (contains? members-joined public-key))
+(defn member?
+  [public-key {:keys [contacts]}]
+  (contains? contacts public-key))
 
 (defn invited?
   [my-public-key {:keys [contacts]}]

--- a/src/status_im/subs.cljs
+++ b/src/status_im/subs.cljs
@@ -1053,9 +1053,9 @@
        (assoc :show-input? true)
 
        (and (chat.models/group-chat? current-chat)
-            (group-chats.db/joined? my-public-key current-chat))
+            (group-chats.db/member? my-public-key current-chat))
        (assoc :show-input? true
-              :joined? true)
+              :member? true)
 
        (and (chat.models/community-chat? current-chat)
             (communities/can-post? community my-public-key (:chat-id current-chat)))
@@ -1413,7 +1413,7 @@
    [(re-frame/subscribe [:chat-by-id chat-id])
     (re-frame/subscribe [:multiaccount/public-key])])
  (fn [[chat my-public-key]]
-   {:joined? (group-chats.db/joined? my-public-key chat)
+   {:member? (group-chats.db/member? my-public-key chat)
     :inviter-pk (group-chats.db/get-inviter-pk my-public-key chat)}))
 
 (re-frame/reg-sub

--- a/src/status_im/ui/screens/chat/group.cljs
+++ b/src/status_im/ui/screens/chat/group.cljs
@@ -12,13 +12,6 @@
             [status-im.utils.platform :as platform])
   (:require-macros [status-im.utils.views :refer [defview letsubs]]))
 
-(defn join-chat-button [chat-id]
-  [quo/button
-   {:type                :secondary
-    :accessibility-label :join-chat-button
-    :on-press            #(debounce/dispatch-and-chill [:group-chats.ui/join-pressed chat-id] 2000)}
-   (i18n/label :t/join-group-chat)])
-
 (defn decline-chat [chat-id]
   [quo/button
    {:type                :secondary
@@ -69,16 +62,9 @@
 
 (defview group-chat-footer
   [chat-id invitation-admin]
-  (letsubs [{:keys [joined?]} [:group-chat/inviter-info chat-id]
-            removed? [:group-chat/removed-from-current-chat?]
-            invitations [:group-chat/invitations-by-chat-id chat-id]]
-    (if invitation-admin
-      [request-membership (first invitations)]
-      (when (and (not joined?) (not removed?))
-        [react/view {:style style/group-chat-join-footer}
-         [react/view {:style style/group-chat-join-container}
-          [join-chat-button chat-id]
-          [decline-chat chat-id]]]))))
+  (letsubs [invitations [:group-chat/invitations-by-chat-id chat-id]]
+    (when invitation-admin
+      [request-membership (first invitations)])))
 
 (def group-chat-description-loading
   [react/view {:style (merge style/intro-header-description-container
@@ -153,10 +139,10 @@
                {:group-name chat-name})])
 
 (defview group-chat-inviter-description-container [chat-id chat-name]
-  (letsubs [{:keys [joined? inviter-pk]}
+  (letsubs [{:keys [member? inviter-pk]}
             [:group-chat/inviter-info chat-id]]
     (cond
-      (not joined?)
+      (not member?)
       [pending-invitation-description inviter-pk chat-name]
       inviter-pk
       [joined-group-chat-description inviter-pk chat-name]

--- a/src/status_im/ui/screens/chat/sheets.cljs
+++ b/src/status_im/ui/screens/chat/sheets.cljs
@@ -99,7 +99,7 @@
 
 (defn group-chat-accents []
   (fn [{:keys [chat-id group-chat chat-name color invitation-admin]}]
-    (let [{:keys [joined?]} @(re-frame/subscribe [:group-chat/inviter-info chat-id])
+    (let [{:keys [member?]} @(re-frame/subscribe [:group-chat/inviter-info chat-id])
           removed? @(re-frame/subscribe [:group-chat/removed-from-current-chat?])]
       (if invitation-admin
         [quo/list-item
@@ -125,7 +125,7 @@
            :accessibility-label :mark-all-read-button
            :icon                :main-icons/check
            :on-press            #(hide-sheet-and-dispatch [:chat.ui/mark-all-read-pressed chat-id])}]
-         (when joined?
+         (when member?
            [quo/list-item
             {:theme               :negative
              :title               (i18n/label :t/leave-chat)

--- a/src/status_im/ui/screens/profile/group_chat/views.cljs
+++ b/src/status_im/ui/screens/profile/group_chat/views.cljs
@@ -157,13 +157,13 @@
             (i18n/label :t/empty-pending-invitations-descr)])]]])))
 
 (defview group-chat-profile []
-  (letsubs [{:keys [admins chat-id joined? chat-name color contacts] :as current-chat} [:chats/current-chat]
+  (letsubs [{:keys [admins chat-id member? chat-name color contacts] :as current-chat} [:chats/current-chat]
             members         [:contacts/current-chat-contacts]
             current-pk      [:multiaccount/public-key]
             pinned-messages [:chats/pinned chat-id]]
     (when current-chat
       (let [admin?                (get admins current-pk)
-            allow-adding-members? (and admin? joined?
+            allow-adding-members? (and admin? member?
                                        (< (count members) constants/max-group-chat-participants))]
         [react/view profile.components.styles/profile
          [quo/animated-header
@@ -171,7 +171,7 @@
            :left-accessories  [{:icon                :main-icons/arrow-left
                                 :accessibility-label :back-button
                                 :on-press            #(re-frame/dispatch [:navigate-back])}]
-           :right-accessories (when (and admin? joined?)
+           :right-accessories (when (and admin? member?)
                                 [{:icon                :icons/edit
                                   :accessibility-label :edit-button
                                   :on-press            #(re-frame/dispatch [:open-modal :edit-group-chat-name])}])
@@ -200,7 +200,7 @@
              :accessory-text      (count pinned-messages)
              :chevron             true
              :on-press            #(re-frame/dispatch [:contact.ui/pinned-messages-pressed chat-id])}]
-           (when joined?
+           (when member?
              [quo/list-item
               {:theme               :negative
                :title               (i18n/label :t/leave-chat)

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.100.2",
-    "commit-sha1": "ed67cc2a6cffc8312c784f6a77170a80be96fa54",
-    "src-sha256": "0crafxj747ddsjkkwdrdnijj22vknyzwrgakbn83fszxb1babj0z"
+    "version": "v0.101.0",
+    "commit-sha1": "09ba88c19dc36c88d22e880d6568e4fe4861ddc3",
+    "src-sha256": "178p268kj5n0qzsw8i20zgip34q1rrxa7l7j3gib6ai3a30p6zif"
 }


### PR DESCRIPTION
## Testing

e2e will likely need changing, as now chats are not explicitly joined by the users. cc @churik 

We should test compatibility between this version and release, as behind the scene a chat is autojoined when accepted from the activity center.



status: ready