### PR TITLE
[#13433] Input field in chat view is not cleared after logging out

### DIFF
--- a/src/status_im/multiaccounts/logout/core.cljs
+++ b/src/status_im/multiaccounts/logout/core.cljs
@@ -15,6 +15,7 @@
   (let [key-uid              (get-in db [:multiaccount :key-uid])]
     (fx/merge cofx
               {:init-root-fx                         :progress
+               :chat.ui/clear-inputs                 nil
                :hide-popover                         nil
                ::logout                              nil
                ::multiaccounts/webview-debug-changed false

--- a/src/status_im/ui/screens/chat/components/input.cljs
+++ b/src/status_im/ui/screens/chat/components/input.cljs
@@ -114,6 +114,13 @@
 (defonce mentions-enabled (reagent/atom {}))
 (defonce chat-input-key (reagent/atom 1))
 
+(re-frame/reg-fx
+ :chat.ui/clear-inputs
+ (fn []
+   (reset! input-texts {})
+   (reset! mentions-enabled {})
+   (reset! chat-input-key 1)))
+
 (defn force-text-input-update!
   "force-text-input-update! forces the
   input to re-render, necessary when we are setting value"


### PR DESCRIPTION


fixes #13433
