### PR TITLE
Fixes #12192 -- Disable fetching more messages when status nodes are …

### DIFF
--- a/.calva/output-window/output.calva-repl
+++ b/.calva/output-window/output.calva-repl
@@ -1,8 +1,0 @@
-; This is the Calva evaluation results output window.
-; TIPS: The keyboard shortcut `ctrl+alt+o o` shows and focuses this window
-;   when connected to a REPL session.
-; Please see https://calva.io/output/ for more info.
-; Happy coding! ♥️
-
-; Connecting ...
-; No nrepl port file found.

--- a/.calva/output-window/output.calva-repl
+++ b/.calva/output-window/output.calva-repl
@@ -1,0 +1,8 @@
+; This is the Calva evaluation results output window.
+; TIPS: The keyboard shortcut `ctrl+alt+o o` shows and focuses this window
+;   when connected to a REPL session.
+; Please see https://calva.io/output/ for more info.
+; Happy coding! ♥️
+
+; Connecting ...
+; No nrepl port file found.

--- a/src/status_im/subs.cljs
+++ b/src/status_im/subs.cljs
@@ -13,6 +13,7 @@
             [status-im.ethereum.tokens :as tokens]
             [status-im.ethereum.transactions.core :as transactions]
             [status-im.fleet.core :as fleet]
+            [status-im.mailserver.core :as mailserver]
             [status-im.group-chats.db :as group-chats.db]
             [status-im.communities.core :as communities]
             [status-im.group-chats.core :as group-chat]
@@ -2481,6 +2482,11 @@
  (fn [[mailserver current-mailserver-id]]
    (= (get-in mailserver [:id :value])
       current-mailserver-id)))
+
+(re-frame/reg-sub
+ :mailserver/use-status-nodes?
+ (fn [db _]
+   (boolean (mailserver/fetch-use-mailservers? {:db db}))))
 
 (re-frame/reg-sub
  :mailserver.edit/validation-errors

--- a/src/status_im/ui/screens/chat/message/gap.cljs
+++ b/src/status_im/ui/screens/chat/message/gap.cljs
@@ -22,7 +22,7 @@
     (when (or (not first-gap?) public? community?)
       [react/view {:style (style/gap-container)}
        [react/touchable-highlight
-        {:on-press (when (and connected? (and (not in-progress?) use-status-nodes?))
+        {:on-press (when (and (not in-progress?) use-status-nodes? connected?)
                      (on-press chat-id gap-ids))
          :style    style/touchable}
         [react/view {:style style/label-container}

--- a/src/status_im/ui/screens/chat/message/gap.cljs
+++ b/src/status_im/ui/screens/chat/message/gap.cljs
@@ -17,18 +17,19 @@
                                 gap-ids
                                 chat-id]
                   connected?   [:mailserver/connected?]
+                  use-status-nodes? [:mailserver/use-status-nodes?]
                   first-gap?   (= gap-ids #{:first-gap})]
     (when (or (not first-gap?) public? community?)
       [react/view {:style (style/gap-container)}
        [react/touchable-highlight
-        {:on-press (when (and connected? (not in-progress?))
+        {:on-press (when (and connected? (and (not in-progress?) use-status-nodes?))
                      (on-press chat-id gap-ids))
          :style    style/touchable}
         [react/view {:style style/label-container}
          (if in-progress?
            [react/activity-indicator]
            [react/nested-text
-            {:style (style/gap-text connected?)}
+            {:style (style/gap-text (and connected? use-status-nodes?))}
             (i18n/label (if first-gap? :t/load-more-messages :t/fetch-messages))
             (when first-gap?
               [{:style style/date}


### PR DESCRIPTION
…disabled

[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

Fixes #12192

### Summary

Added a boolean to check if status nodes are enabled or not and if they're disabled we disable the functionality of fetch more messages button

The issue didn't state to hide the fetch more messages button or to disable it
So I disabled it.

#### Platforms to test
- iOS
- macOS
- Linux
- Windows

#### Areas that maybe impacted

##### Functional

- 1-1 chats
- public chats
- group chats

### Steps to test
Go to settings -> sync settings and disable status nodes and then try to fetch more messages.
It won't work
