### PR TITLE
leave group chat fix

### DIFF
--- a/src/status_im/group_chats/core.cljs
+++ b/src/status_im/group_chats/core.cljs
@@ -21,7 +21,8 @@
   {:events [:chat-removed]}
   [cofx response]
   (fx/merge cofx
-            {:dispatch-n [[:sanitize-messages-and-process-response response]
+            {:db (dissoc (:db cofx) :current-chat-id)
+             :dispatch-n [[:sanitize-messages-and-process-response response]
                           [:pop-to-root-tab :chat-stack]]}
             (notification-center/get-activity-center-notifications-count)))
 


### PR DESCRIPTION
1) A adds B to group chat
2) B accepts group chat and enters group chat
3) B leaves group chat (now B is home)
4) A re-adds B
B sees the notification flashing, but it's accepted immediately,