### PR TITLE
Include UI toggle for all builds

### DIFF
--- a/src/quo/react_native.cljs
+++ b/src/quo/react_native.cljs
@@ -108,7 +108,7 @@
                                                               :property (:opacity layout-animation-properties)}}})
 
 (defonce enable-layout-animations
-  (when (and platform/android? config/quo-preview-enabled?)
+  (when platform/android?
     (.setLayoutAnimationEnabledExperimental ^js ui-manager true)))
 
 (def activity-indicator (reagent/adapt-react-class (.-ActivityIndicator ^js rn)))

--- a/src/quo/react_native.cljs
+++ b/src/quo/react_native.cljs
@@ -6,8 +6,7 @@
             ["@react-native-community/hooks" :as hooks]
             ["react-native-navigation" :refer (Navigation)]
             ["rn-emoji-keyboard" :refer (EmojiKeyboard)]
-            ["react-native-draggable-flatlist" :default DraggableFlatList]
-            [status-im.utils.config :as config]))
+            ["react-native-draggable-flatlist" :default DraggableFlatList]))
 
 (def rn-draggable-flatlist (reagent/adapt-react-class DraggableFlatList))
 

--- a/src/status_im/core.cljs
+++ b/src/status_im/core.cljs
@@ -40,8 +40,7 @@
 
   (utils.universal-links/initialize)
 
-  (when config/quo-preview-enabled?
-    (async-storage/get-item :new-ui-enabled? #(reset! config/new-ui-enabled? %)))
+  (async-storage/get-item :new-ui-enabled? #(reset! config/new-ui-enabled? %))
 
   ;;DEV
   (snoopy/subscribe!)

--- a/src/status_im/ui/screens/advanced_settings/views.cljs
+++ b/src/status_im/ui/screens/advanced_settings/views.cljs
@@ -127,14 +127,13 @@
        [:multiaccounts.ui/switch-wallet-connect-enabled (not wallet-connect-enabled?)])
      :accessory               :switch
      :active                  wallet-connect-enabled?}
-    (when config/quo-preview-enabled?
-      {:size                    :small
-       :title                   (i18n/label :t/new-ui)
-       :accessibility-label     :new-ui-toggle
-       :container-margin-bottom 8
-       :on-press                #(re-frame/dispatch [:toggle-new-ui])
-       :accessory               :switch
-       :active                  new-ui-enabled?})]))
+    {:size                    :small
+     :title                   (i18n/label :t/new-ui)
+     :accessibility-label     :new-ui-toggle
+     :container-margin-bottom 8
+     :on-press                #(re-frame/dispatch [:toggle-new-ui])
+     :accessory               :switch
+     :active                  new-ui-enabled?}]))
 
 (defn- flat-list-data [options]
   (normal-mode-settings-data options))

--- a/src/status_im/ui/screens/screens.cljs
+++ b/src/status_im/ui/screens/screens.cljs
@@ -885,14 +885,13 @@
             :options   {:topBar {:visible false}}
             :component bug-report/bug-report}]
 
+          navigation2.screens/screens
           (when config/quo-preview-enabled?
             quo.preview/screens)
           (when config/quo-preview-enabled?
             quo.preview/main-screens)
           (when config/quo-preview-enabled?
             quo2.preview/screens)
-          (when config/quo-preview-enabled?
-            navigation2.screens/screens)
           (when @config/new-ui-enabled?
             navigation2.screens/screen-overwrites)
           (when config/quo-preview-enabled?


### PR DESCRIPTION
## Summary:

We are also going to include UI toggle in release. So this PR removes `quo-preview-enabled?` flag and makes sure UI  toggle is available for all builds

## Testing
Please test for any regressions.

status: ready