### PR TITLE
Fix: share images bug that freezes app

### DIFF
--- a/src/status_im/ui/screens/chat/message/reactions.cljs
+++ b/src/status_im/ui/screens/chat/message/reactions.cljs
@@ -55,8 +55,7 @@
                               (fn []
                                 (reset! actions nil)
                                 (reset! visible false)
-                                (picker-on-close))
-                              reaction-picker/animation-duration))
+                                (picker-on-close))))
             on-open        (fn [pos]
                              (picker-on-open)
                              (reset! position pos)


### PR DESCRIPTION
fixes #13381

### Summary
The issue seems to resolve after removing reaction picker animation-duration
