### PR TITLE
Fix: unread messages counter when messages are deleted

### DIFF
--- a/src/status_im/chat/models.cljs
+++ b/src/status_im/chat/models.cljs
@@ -485,15 +485,3 @@
     :on-accept           #(do
                             (re-frame/dispatch [:bottom-sheet/hide])
                             (re-frame/dispatch [:chat.ui/remove-chat chat-id]))}})
-
-(fx/defn decrease-unviewed-count
-  {:events [:chat/decrease-unviewed-count]}
-  [{:keys [db]} chat-id {:keys [count countWithMentions]}]
-  {:db (-> db
-           ;; There might be some other requests being fired,
-           ;; so we need to make sure the count has not been set to
-           ;; 0 in the meantime
-           (update-in [:chats chat-id :unviewed-messages-count]
-                      #(max (- % count) 0))
-           (update-in [:chats chat-id :unviewed-mentions-count]
-                      #(max (- % countWithMentions) 0)))})

--- a/src/status_im/chat/models/message.cljs
+++ b/src/status_im/chat/models/message.cljs
@@ -1,6 +1,5 @@
 (ns status-im.chat.models.message
   (:require [status-im.chat.models :as chat-model]
-            [re-frame.core :as re-frame]
             [status-im.chat.models.message-list :as message-list]
             [status-im.constants :as constants]
             [status-im.data-store.messages :as data-store.messages]
@@ -201,19 +200,13 @@
 (fx/defn handle-removed-messages
   {:events [::handle-removed-messages]}
   [{:keys [db] :as cofx} removed-messages]
-  (let [mark-as-seen-fx (mapv (fn [removed-message]
-                                (let [chat-id (:chatId removed-message)
-                                      message-id (:messageId removed-message)]
-                                  (data-store.messages/mark-messages-seen chat-id
-                                                                          [message-id]
-                                                                          #(re-frame/dispatch [:chat/decrease-unviewed-count chat-id %3])))) removed-messages)
-        remove-messages-fx (fn [{:keys [db]}]
+  (let [remove-messages-fx (fn [{:keys [db]}]
                              {:db (reduce (fn [acc current]
                                             (update-in acc [:messages (:chatId current)] dissoc (:messageId current)))
                                           db removed-messages)
                               :dispatch-n [[:get-activity-center-notifications]
                                            [:get-activity-center-notifications-count]]})]
-    (apply fx/merge cofx (conj mark-as-seen-fx remove-messages-fx))))
+    (fx/merge cofx remove-messages-fx)))
 
 (comment
   (handle-removed-messages

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.108.3",
-    "commit-sha1": "0ecbb5e8d78749abeb9d7bb6dc4c3b4c18b683e5",
-    "src-sha256": "0shfklq1sisjnj008grcxwfam3j6psbis68r82nv38m8435z3g46"
+    "version": "unread-messages",
+    "commit-sha1": "0865dc182aa70b76a21aab06798bd2d6763d13ac",
+    "src-sha256": "0kpczsf5lzdaxm2m50g255f8bqqdyq3dp72x4s9qfc3m31jz4adc"
 }


### PR DESCRIPTION
fixes #13228

### Summary
This PR solves updating unread messages counter when messages are deleted while the recipient device is offline. It also updates the last preview message when the messages are deleted.
