### PR TITLE
[13587] Change text of group invitation push notification

### DIFF
--- a/test/appium/views/chat_view.py
+++ b/test/appium/views/chat_view.py
@@ -1039,4 +1039,4 @@ class ChatView(BaseView):
 
     @staticmethod
     def pn_wants_you_to_join_to_group_chat(admin, chat_name):
-        return '%s wants you to join group %s' % (admin, chat_name)
+        return '%s added you to group %s' % (admin, chat_name)


### PR DESCRIPTION

Fixes #13587 

### Summary
Change text of group invitation push notification 

#### Platforms
- Android

##### Functional
- group chats


### Steps to test
In the ticket


status: ready
