### PR TITLE
more reliable address comparison

### DIFF
--- a/src/status_im/ethereum/core.cljs
+++ b/src/status_im/ethereum/core.cljs
@@ -153,8 +153,8 @@
 
 (defn address= [address1 address2]
   (and address1 address2
-       (= (normalized-hex address1)
-          (normalized-hex address2))))
+       (= (string/lower-case (normalized-hex address1))
+          (string/lower-case (normalized-hex address2)))))
 
 (defn public-key->address [public-key]
   (let [length (count public-key)

--- a/src/status_im/keycard/sign.cljs
+++ b/src/status_im/keycard/sign.cljs
@@ -24,7 +24,7 @@
         from                 (or (get-in db [:signing/tx :from :address]) (get-in db [:signing/tx :message :from]) (ethereum/default-address db))
         path                 (reduce
                               (fn [_ {:keys [address path]}]
-                                (when (= from address)
+                                (when (ethereum/address= from address)
                                   (reduced path)))
                               nil
                               (:multiaccount/accounts db))]


### PR DESCRIPTION
Fixes #13615.

During keycard signing, there was an address comparison which simply used the = operator. We should instead normalize and lowercase the addresses to compare to avoid any possible format differences