### PR TITLE
Remove old coverage status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,5 +69,3 @@ Licensed under the [Mozilla Public License v2.0](https://github.com/status-im/st
 ## Testing Supported by
 
 [![BrowserStack Status](https://www.browserstack.com/automate/badge.svg?badge_key=SFBWQ3k5R2tnT2t6UGsxU1h1U0g3VFlCNnoxVTRHYWNoTDhsb1laaTJZWT0tLUZMUm5sSVFBSU9qSWM1RUJvK1I3Z3c9PQ==--ad15ae7992b432b33743749d40318952415bd98f)](https://www.browserstack.com/automate/public-build/SFBWQ3k5R2tnT2t6UGsxU1h1U0g3VFlCNnoxVTRHYWNoTDhsb1laaTJZWT0tLUZMUm5sSVFBSU9qSWM1RUJvK1I3Z3c9PQ==--ad15ae7992b432b33743749d40318952415bd98f)
-
-[![Coverage Status](https://coveralls.io/repos/github/status-im/status-react/badge.svg?)](https://coveralls.io/github/status-im/status-react)


### PR DESCRIPTION
### Summary
Removes old coverage status badges. They are broken. https://coveralls.io/github/status-im/status-react this one ran 3 years ago.

status: ready