### PR TITLE
status-go: share image/username on separate topic on a community

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.102.7",
-    "commit-sha1": "6df2033179083596447469f7e160a657de0020af",
-    "src-sha256": "17h6g0pjlynsr32dhiqaxyaybaqdbr4y9ivyjbdbwm0z5k1v82af"
+    "version": "02d5068af7e914a5ebe3cda0d04f21bed16c6096",
+    "commit-sha1": "02d5068af7e914a5ebe3cda0d04f21bed16c6096",
+    "src-sha256": "1q60j5vhaf3fwp70465fppi1jxr7vw09z430hfalwbacfqqxyyfp"
 }


### PR DESCRIPTION
https://github.com/status-im/status-go/compare/6df20331...02d5068a
status-go PR:  https://github.com/status-im/status-go/pull/2745

### Summary

Now when user joins a community it will notify other members about their profile picture, ens name, etc.

### Testing notes
<!-- (Optional) -->

##### Functional

- communities

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- create test community
- create new userA
- join with user A to community
- create new userB
- join with userB to community
- userB adds/modifies profile picture
- userA should see updated userB profile picture

_(it's important to create new users to ensure they haven't met each other on any public chat before)_

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->
