### PR TITLE
Fix sync of blocked contacts

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.103.2",
-    "commit-sha1": "3a46b051149e567e2be48bd9eb8e6703b01ae86f",
-    "src-sha256": "1vbd71crazy4jq7pvwiv0vzw3nfa8wl22k88vga5ppz0nz196cm7"
+    "version": "13635-currently-blocked-users-are-not-syncing",
+    "commit-sha1": "bc4a3be31f82d516950c55dab734a2c2959751d1",
+    "src-sha256": "1fxny5lkvvcl5r2n80ya1x47syly69nqz7dfzpb2x0dycqhz4c0x"
 }


### PR DESCRIPTION
https://github.com/status-im/status-go/compare/3a46b051...bc4a3be3
fixes #13635

### Summary
Fix sync of blocked contacts. Receiving device was dropping requests if blocked contact is also removed.

#### Platforms
- Android
- iOS

##### Functional
- 1-1 chats
- public chats
- account recovery

### Steps to test
Please see: [here](https://github.com/status-im/status-mobile/issues/13635)

status: ready