### PR TITLE
e2e: removed xfail mark from sync/backup blocked contacts tests

### DIFF
--- a/test/appium/tests/critical/test_pairing_devices_sync.py
+++ b/test/appium/tests/critical/test_pairing_devices_sync.py
@@ -148,7 +148,6 @@ class TestPairingSyncMultipleDevicesMerged(MultipleSharedDeviceTestCase):
         [device.profile_button.double_click() for device in (self.profile_1, self.profile_2)]
 
     @marks.testrail_id(702194)
-    @marks.xfail(reason="failing due to issue #13635. Skipping until fix", run=False)
     def test_pairing_sync_initial_contacts_blocked_users(self):
         self.profile_2.contacts_button.scroll_to_element(9, 'up')
         self.profile_2.contacts_button.click()
@@ -172,7 +171,6 @@ class TestPairingSyncMultipleDevicesMerged(MultipleSharedDeviceTestCase):
         self.errors.verify_no_errors()
 
     @marks.testrail_id(702196)
-    @marks.xfail(reason="failing due to issue #13635. Skipping until fix", run=False)
     def test_pairing_sync_contacts_block_unblock(self):
         [device.profile_button.double_click() for device in (self.profile_1, self.profile_2)]
         new_user_for_block = transaction_senders['C']

--- a/test/appium/tests/medium/test_browser_profile.py
+++ b/test/appium/tests/medium/test_browser_profile.py
@@ -295,7 +295,6 @@ class TestBrowserProfileOneDevice(MultipleSharedDeviceTestCase):
         self.errors.verify_no_errors()
 
     @marks.testrail_id(702164)
-    @marks.xfail(reason="failing due to issue #13635. Skipping until fix", run=False)
     def test_profile_backup_of_contacts(self):
         self.home.get_back_to_home_view()
         self.home.just_fyi('Add user to contacts')
@@ -309,7 +308,7 @@ class TestBrowserProfileOneDevice(MultipleSharedDeviceTestCase):
         self.home.back_button.click()
 
         self.home.just_fyi('Add ENS-user to contacts')
-        user_ens = 'pavlotest.eth'
+        user_ens = 'ensmessenger'
         self.home.add_contact(user_ens)
         self.home.back_button.click()
 


### PR DESCRIPTION
Removed xfail mark from sync/backup blocked contacts tests to run tests for PR with fix https://github.com/status-im/status-mobile/pull/13701