### PR TITLE
[#13690] Fix visibility status color

### DIFF
--- a/src/status_im/db.cljs
+++ b/src/status_im/db.cljs
@@ -13,7 +13,7 @@
              :sync-state                         :done
              :link-previews-whitelist            []
              :app-state                          "active"
-             :wallet                              wallet.db/default-wallet
+             :wallet                             wallet.db/default-wallet
              :wallet/all-tokens                  {}
              :peers-count                        0
              :node-info                          {}
@@ -34,9 +34,9 @@
              :registry                           {}
              :visibility-status-updates          {}
              :stickers/packs-pending             #{}
-             :keycard                            {:nfc-enabled?   false
-                                                  :pin            {:original     []
-                                                                   :confirmation []
-                                                                   :current      []
-                                                                   :puk          []
-                                                                   :enter-step   :original}}})
+             :keycard                            {:nfc-enabled? false
+                                                  :pin          {:original     []
+                                                                 :confirmation []
+                                                                 :current      []
+                                                                 :puk          []
+                                                                 :enter-step   :original}}})

--- a/src/status_im/ui/components/chat_icon/screen.cljs
+++ b/src/status_im/ui/components/chat_icon/screen.cljs
@@ -63,25 +63,6 @@
        [react/view {:style               dot-styles
                     :accessibility-label dot-accessibility-label}])]))
 
-(defn profile-photo-plus-dot-view-old
-  [{:keys [public-key photo-container photo-path community?]}]
-  (let [photo-path             (if (nil? photo-path)
-                                 @(re-frame.core/subscribe [:chats/photo-path public-key])
-                                 photo-path)
-        photo-container        (if (nil? photo-container)
-                                 styles/container-chat-list photo-container)
-        size                    (:width photo-container)
-        identicon?              (when photo-path (profile.db/base64-png? photo-path))
-        dot-styles              (visibility-status-utils/icon-visibility-status-dot-old
-                                 public-key size identicon?)
-        dot-accessibility-label (:accessibility-label dot-styles)]
-    [react/view {:style               photo-container
-                 :accessibility-label :profile-photo}
-     [photos/photo photo-path {:size size}]
-     (when-not community?
-       [react/view {:style               dot-styles
-                    :accessibility-label dot-accessibility-label}])]))
-
 (defn emoji-chat-icon-view
   [chat-id group-chat name emoji styles]
   [react/view (:container styles)
@@ -91,16 +72,6 @@
        [emoji-chat-icon emoji styles])
      [profile-photo-plus-dot-view {:public-key      chat-id
                                    :photo-container (:default-chat-icon styles)}])])
-
-(defn emoji-chat-icon-view-old
-  [chat-id group-chat name emoji styles]
-  [react/view (:container styles)
-   (if group-chat
-     (if (string/blank? emoji)
-       [default-chat-icon name styles]
-       [emoji-chat-icon emoji styles])
-     [profile-photo-plus-dot-view-old {:public-key      chat-id
-                                       :photo-container (:default-chat-icon styles)}])])
 
 (defn chat-icon-view-toolbar
   [chat-id group-chat name color emoji]
@@ -169,7 +140,7 @@
   (if group-chat
     [default-chat-icon icon-text styles]
     (let [photo-path @(re-frame.core/subscribe [:chats/photo-path chat-id])]
-      (if-not (string/blank? photo-path)
+      (when-not (string/blank? photo-path)
         [photos/photo photo-path styles]))))
 
 (defn emoji-chat-intro-icon-view [icon-text chat-id group-chat emoji styles]
@@ -178,7 +149,7 @@
       [default-chat-icon icon-text styles]
       [emoji-chat-icon emoji styles])
     (let [photo-path @(re-frame.core/subscribe [:chats/photo-path chat-id])]
-      (if-not (string/blank? photo-path)
+      (when-not (string/blank? photo-path)
         [photos/photo photo-path styles]))))
 
 (defn profile-icon-view
@@ -192,10 +163,10 @@
                                                  (styles/emoji-chat-icon-text size))} override-styles)]
     [react/view (:container styles)
      (if (and photo-path (seq photo-path))
-       [profile-photo-plus-dot-view-old {:photo-path      photo-path
-                                         :public-key      public-key
-                                         :photo-container (:container styles)
-                                         :community?      community?}]
+       [profile-photo-plus-dot-view {:photo-path      photo-path
+                                     :public-key      public-key
+                                     :photo-container (:container styles)
+                                     :community?      community?}]
        (if (string/blank? emoji)
          [default-chat-icon name styles]
          [emoji-chat-icon emoji styles]))

--- a/src/status_im/ui/screens/communities/members.cljs
+++ b/src/status_im/ui/screens/communities/members.cljs
@@ -45,15 +45,15 @@
                                             my-public-key
                                             can-manage-users?
                                             can-kick-users?]}]
-  (let [member (<sub [:contacts/contact-by-identity public-key])
+  (let [member                   (<sub [:contacts/contact-by-identity public-key])
         [first-name second-name] (<sub [:contacts/contact-two-names-by-identity public-key])]
     [quo/list-item
      {:title               first-name
       :subtitle            second-name
       :accessibility-label :member-item
-      :icon                 [chat-icon/profile-photo-plus-dot-view-old
-                             {:public-key public-key
-                              :photo-path (multiaccounts/displayed-photo member)}]
+      :icon                [chat-icon/profile-photo-plus-dot-view
+                            {:public-key public-key
+                             :photo-path (multiaccounts/displayed-photo member)}]
       :accessory           (when (not= public-key my-public-key)
                              [quo/button {:on-press
                                           #(>evt [:bottom-sheet/show-sheet

--- a/src/status_im/ui/screens/contacts_list/views.cljs
+++ b/src/status_im/ui/screens/contacts_list/views.cljs
@@ -15,7 +15,7 @@
     [quo/list-item
      {:title    first-name
       :subtitle second-name
-      :icon     [chat-icon.screen/profile-photo-plus-dot-view-old
+      :icon     [chat-icon.screen/profile-photo-plus-dot-view
                  {:public-key public-key
                   :photo-path (multiaccounts/displayed-photo contact)}]
       :chevron  true

--- a/src/status_im/ui/screens/home/views/inner_item.cljs
+++ b/src/status_im/ui/screens/home/views/inner_item.cljs
@@ -259,7 +259,7 @@
     [react/touchable-opacity (merge {:style {:height 64 :background-color background-color}} opts)
      [:<>
       [chat-item-icon muted (and group-chat (not public?)) (and group-chat public?)]
-      [chat-icon.screen/emoji-chat-icon-view-old chat-id group-chat chat-name emoji
+      [chat-icon.screen/emoji-chat-icon-view chat-id group-chat chat-name emoji
        {:container              (assoc chat-icon.styles/container-chat-list
                                        :top 12 :left 16 :position :absolute)
         :size                   40

--- a/src/status_im/ui/screens/profile/visibility_status/styles.cljs
+++ b/src/status_im/ui/screens/profile/visibility_status/styles.cljs
@@ -15,15 +15,15 @@
    :padding-right          12})
 
 (defn visibility-status-dot
-  [{:keys [dot-color size new-ui?]}]
+  [{:keys [color size new-ui?]}]
   (if new-ui?
-    {:background-color dot-color
+    {:background-color color
      :width            size
      :height           size
      :border-radius    (/ size 2)
      :border-width     3.5
      :border-color     (quo2.colors/theme-colors quo2.colors/white quo2.colors/neutral-90)}
-    {:background-color dot-color
+    {:background-color color
      :width            size
      :height           size
      :border-radius    (/ size 2)

--- a/src/status_im/ui/screens/profile/visibility_status/styles.cljs
+++ b/src/status_im/ui/screens/profile/visibility_status/styles.cljs
@@ -14,24 +14,27 @@
    :padding                6
    :padding-right          12})
 
-(defn visibility-status-dot [dot-color size]
-  {:background-color dot-color
-   :width            size
-   :height           size
-   :border-radius    (/ size 2)
-   :border-width     3.5
-   :border-color     (quo2.colors/theme-colors quo2.colors/white quo2.colors/neutral-90)})
+(defn visibility-status-dot
+  [{:keys [dot-color size new-ui?]}]
+  (if new-ui?
+    {:background-color dot-color
+     :width            size
+     :height           size
+     :border-radius    (/ size 2)
+     :border-width     3.5
+     :border-color     (quo2.colors/theme-colors quo2.colors/white quo2.colors/neutral-90)}
+    {:background-color dot-color
+     :width            size
+     :height           size
+     :border-radius    (/ size 2)
+     :border-width     1
+     :border-color     colors/white}))
 
-(defn visibility-status-dot-old [dot-color size]
-  {:background-color dot-color
-   :width            size
-   :height           size
-   :border-radius    (/ size 2)
-   :border-width     1
-   :border-color     colors/white})
-
-(defn visibility-status-profile-dot-old [color size border-width margin-left]
-  (merge (visibility-status-dot-old color size)
+(defn visibility-status-profile-dot
+  [{:keys [color size border-width margin-left new-ui?]}]
+  (merge (visibility-status-dot {:color   color
+                                 :size    size
+                                 :new-ui? new-ui?})
          {:margin-right 6
           :margin-left  margin-left
           :border-width border-width}))

--- a/src/status_im/ui/screens/profile/visibility_status/utils.cljs
+++ b/src/status_im/ui/screens/profile/visibility_status/utils.cljs
@@ -1,12 +1,13 @@
 (ns status-im.ui.screens.profile.visibility-status.utils
-  (:require [status-im.constants :as constants]
+  (:require [clojure.string :as string]
+            [quo.design-system.colors :as colors]
+            [quo2.foundations.colors :as quo2.colors]
+            [status-im.constants :as constants]
             [status-im.i18n.i18n :as i18n]
             [status-im.ui.screens.profile.visibility-status.styles :as styles]
-            [status-im.utils.handlers :refer [<sub]]
+            [status-im.utils.config :as config]
             [status-im.utils.datetime :as datetime]
-            [quo.design-system.colors :as colors]
-            [clojure.string :as string]
-            [quo2.foundations.colors :as quo2.colors]))
+            [status-im.utils.handlers :refer [<sub]]))
 
 ;; Specs:
 ;; :visibility-status-automatic
@@ -73,53 +74,63 @@
       constants/visibility-status-inactive
       status-type)))
 
-(defn dot-color [{:keys [status-type] :or {status-type constants/visibility-status-inactive}}]
-  (:color (get visibility-status-type-data status-type)))
-
-(defn dot-color-old [{:keys [status-type] :or {status-type constants/visibility-status-inactive}}]
-  (:color (get visibility-status-type-data-old status-type)))
+(defn icon-dot-color [{:keys [status-type] :or {status-type constants/visibility-status-inactive}}]
+  (if @config/new-ui-enabled?
+    (:color (get visibility-status-type-data status-type))
+    (:color (get visibility-status-type-data-old status-type))))
 
 (defn my-icon? [public-key]
   (or (string/blank? public-key)
       (= public-key (<sub [:multiaccount/public-key]))))
 
-(defn visibility-status-update [public-key my-icon?]
+(defn visibility-status-update
+  [public-key my-icon?]
   (if my-icon?
     (<sub [:multiaccount/current-user-visibility-status])
     (<sub [:visibility-status-updates/visibility-status-update public-key])))
 
-(defn icon-visibility-status-dot [public-key container-size _]
-  (let [my-icon?                 (my-icon? public-key)
-        visibility-status-update (visibility-status-update public-key my-icon?)
-        size                     (/ container-size 2.4)
-        margin                   -2
-        dot-color                (dot-color visibility-status-update)
-        accessibility-label      (if (= dot-color quo2.colors/color-online)
-                                   :online-profile-photo-dot
-                                   :offline-profile-photo-dot)]
-    (merge (styles/visibility-status-dot dot-color size)
-           {:bottom              margin
-            :right               margin
-            :position            :absolute
-            :accessibility-label accessibility-label})))
+(defn icon-dot-accessibility-label
+  [dot-color]
+  (if @config/new-ui-enabled?
+    (if (= dot-color quo2.colors/color-online)
+      :online-profile-photo-dot
+      :offline-profile-photo-dot)
+    (if (= dot-color colors/color-online)
+      :online-profile-photo-dot
+      :offline-profile-photo-dot)))
 
-(defn icon-visibility-status-dot-old [public-key container-size identicon?]
+(defn icon-dot-margin
+  [size identicon?]
+  (if @config/new-ui-enabled?
+    -2
+    (if identicon?
+      (/ size 6)
+      (/ size 7))))
+
+(defn icon-dot-size
+  [container-size]
+  (if @config/new-ui-enabled?
+    (/ container-size 2.4)
+    (/ container-size 4)))
+
+(defn icon-visibility-status-dot
+  [public-key container-size identicon?]
   (let [my-icon?                 (my-icon? public-key)
         visibility-status-update (visibility-status-update public-key my-icon?)
-        size                     (/ container-size 4)
-        margin                   (if identicon? (/ size 6) (/ size 7))
-        dot-color                (dot-color-old visibility-status-update)
-        accessibility-label      (if (= dot-color colors/color-online)
-                                   :online-profile-photo-dot
-                                   :offline-profile-photo-dot)]
-    (merge (styles/visibility-status-dot-old dot-color size)
+        size                     (icon-dot-size container-size)
+        margin                   (icon-dot-margin size identicon?)
+        dot-color                (icon-dot-color visibility-status-update)
+        new-ui?                  @config/new-ui-enabled?]
+    (merge (styles/visibility-status-dot {:dot-color dot-color
+                                          :size      size
+                                          :new-ui?   new-ui?})
            {:bottom              margin
             :right               margin
             :position            :absolute
-            :accessibility-label accessibility-label})))
+            :accessibility-label (icon-dot-accessibility-label dot-color)})))
 
 (defn visibility-status-order [public-key]
   (let [my-icon?                 (my-icon? public-key)
         visibility-status-update (visibility-status-update public-key my-icon?)
-        dot-color                (dot-color visibility-status-update)]
+        dot-color                (icon-dot-color visibility-status-update)]
     (if (= dot-color colors/color-online) 0 1)))

--- a/src/status_im/ui/screens/profile/visibility_status/utils.cljs
+++ b/src/status_im/ui/screens/profile/visibility_status/utils.cljs
@@ -121,9 +121,9 @@
         margin                   (icon-dot-margin size identicon?)
         dot-color                (icon-dot-color visibility-status-update)
         new-ui?                  @config/new-ui-enabled?]
-    (merge (styles/visibility-status-dot {:dot-color dot-color
-                                          :size      size
-                                          :new-ui?   new-ui?})
+    (merge (styles/visibility-status-dot {:color   dot-color
+                                          :size    size
+                                          :new-ui? new-ui?})
            {:bottom              margin
             :right               margin
             :position            :absolute

--- a/src/status_im/ui/screens/profile/visibility_status/views.cljs
+++ b/src/status_im/ui/screens/profile/visibility_status/views.cljs
@@ -6,13 +6,14 @@
             [quo.react-native :as rn]
             [re-frame.core :as re-frame]
             [reagent.core :as reagent]
+            [status-im.constants :as constants]
             [status-im.ui.components.animation :as anim]
             [status-im.ui.components.react :as react]
-            [status-im.utils.platform :as platform]
-            [status-im.utils.handlers :refer [<sub]]
-            [status-im.constants :as constants]
             [status-im.ui.screens.profile.visibility-status.styles :as styles]
-            [status-im.ui.screens.profile.visibility-status.utils :as utils]))
+            [status-im.ui.screens.profile.visibility-status.utils :as utils]
+            [status-im.utils.config :as config]
+            [status-im.utils.handlers :refer [<sub]]
+            [status-im.utils.platform :as platform]))
 
 ;; === Code Related to visibility-status-button ===
 
@@ -33,13 +34,22 @@
 (defn profile-visibility-status-dot [status-type color]
   (let [automatic?                      (= status-type
                                            constants/visibility-status-automatic)
-        [border-width margin-left size] (if automatic? [1 -10 12] [0 6 10])]
+        [border-width margin-left size] (if automatic? [1 -10 12] [0 6 10])
+        new-ui?                         @config/new-ui-enabled?]
     [:<>
      (when automatic?
-       [rn/view {:style (styles/visibility-status-profile-dot-old
-                         colors/color-inactive size border-width 6)}])
-     [rn/view {:style (styles/visibility-status-profile-dot-old
-                       color size border-width margin-left)}]]))
+       [rn/view {:style (styles/visibility-status-profile-dot
+                         {:color        colors/color-inactive
+                          :size         size
+                          :border-width border-width
+                          :margin-left  6
+                          :new-ui?      new-ui?})}])
+     [rn/view {:style (styles/visibility-status-profile-dot
+                       {:color        color
+                        :size         size
+                        :border-width border-width
+                        :margin-left  margin-left
+                        :new-ui?      new-ui?})}]]))
 
 (defn visibility-status-button [on-press props]
   (let [logged-in?            (<sub [:multiaccount/logged-in?])


### PR DESCRIPTION
Fixes #13690

### Summary

This PR fixes the visibility status color of the dot icon.

### Review notes

This PR fixes the issue by introducing a new state called `:ui/old?` (true by default). Components that are _directly_ impacted by the redesign can simply subscribe to the new state and react accordingly. **Edit**: thanks to reviewers, I could replace the new state with the existing atom `utils.config.new-ui-enabled?`.

AFAIU, the current approach to redesign on top of the existing design is to duplicate functions, using the suffix `*-old`. This seems to divert from re-frame's recommendation to derive the UI from the app db and also causes an explosion of duplicated functions throughout the codebase.

The duplicate+suffix strategy also leads to unnecessary changes to the call tree. For instance, some functions are duplicated because their downstream functions return a different color, but in reality, these parent functions have the exact same behavior. A concrete example, the parent component `emoji-chat-icon-view` depends on `profile-photo-plus-dot-view`, but it doesn't care what the inner component returns, so why should it change in a breaking way (var rename)? Of course, there are cases where it might be better duplicating a function, but most of the `*-old` ones I've seen could avoid such in-place changes.

If this new approach seems reasonable to y'all, perhaps future PRs could use the new subscription, which could help reduce the number of regressions while the redesign isn't finished.

### Testing notes

For manually testing between the old/new design, you can dispatch the event below in a REPL:

```clojure
(comment
  (re-frame.core/reg-event-fx
   :ui/toggle-old
   (fn [{:keys [db]}]
     {:db (update db :ui/old? not)}))

  (re-frame.core/dispatch [:ui/toggle-old]))
```

**Edit**: Use the existing effect to toggle the new UI.

```clojure
(comment
  (re-frame.core/dispatch [:toggle-new-ui]))
```

The video below demonstrates the app already fixed, with the toggle on/off and how it affects the visibility status icon.

https://user-images.githubusercontent.com/46027/182368085-ac5e033b-4bd6-4466-924a-2eb1ef46475c.mp4

#### Platforms

- Android
- iOS

### Steps to test

To reproduce the bug:

The issue https://github.com/status-im/status-mobile/issues/13690 describes the steps to reproduce, but to summarize:

1. Open Status.
2. Open the chat with someone who's currently active and visible to you.
3. Notice the _slight_ difference between the green colors in the visibility status _dot_ icon.

For QA purposes:

1. Open Status with the fix from this PR.
2. Open the chat with someone who's currently active and visible to you.
3. Toggle between the new/old design and notice the visibility status icon is displayed with the expected green color.

Status: ready
