### PR TITLE
feat: add repl support for cljs test

### DIFF
--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -70,17 +70,20 @@
           ;; produced by the target :mocks below and redefines node require
           ;; function to use the mocks instead of the rn libraries
           :test
-          {:output-to     "target/test/test.js"
-           :output-dir    "target/test"
-           :optimizations :simple
-           :target        :node-test
-           :closure-defines {status-im.utils.config/INFURA_TOKEN #shadow/env "INFURA_TOKEN"}
+          {:output-to        "target/test/test.js"
+           :output-dir       "target/test"
+           :optimizations    :simple
+           :target           :node-test
+           :main             status-im.test-runner/main
+           ;; set :ui-driven to true to let shadow-cljs inject node-repl
+           :ui-driven        true
+           :closure-defines  {status-im.utils.config/INFURA_TOKEN #shadow/env "INFURA_TOKEN"}
            :compiler-options {;; needed because we override require and it
                               ;; messes with source-map which reports callstack
                               ;; exceeded exceptions instead of real issues
-                              :source-map false
+                              :source-map    false
                               ;; needed because we use deref in tests
-                              :static-fns false
+                              :static-fns    false
                               :optimizations :simple}}
 
           ;; mock.js-dependencies is mocking the react-native libraries

--- a/src/status_im/integration_test.cljs
+++ b/src/status_im/integration_test.cljs
@@ -1,9 +1,9 @@
 (ns status-im.integration-test
-  (:require [day8.re-frame.test :as rf-test]
-            status-im.events
+  (:require [cljs.test :refer [deftest is run-tests]]
+            [day8.re-frame.test :as rf-test]
             [re-frame.core :as rf]
+            status-im.events
             [status-im.transport.core :as transport]
-            [cljs.test :refer [deftest is]]
             [status-im.utils.test :as utils.test]))
 
 (def password "testabc")
@@ -56,3 +56,6 @@
      (rf-test/wait-for ; wait for login
       [::transport/messenger-started]
       (assert-messenger-started))))))
+
+(comment
+  (run-tests))

--- a/src/status_im/test_runner.cljs
+++ b/src/status_im/test_runner.cljs
@@ -1,0 +1,104 @@
+(ns status-im.test-runner
+  {:dev/always true}
+  (:require
+   [cljs.test :as ct]
+   [clojure.string :as str]
+   [shadow.test :as st]
+   [shadow.test.env :as env]))
+
+(defonce repl? (atom false))
+
+(defmethod ct/report [::ct/default :end-run-tests] [m]
+  (when-not @repl?
+    (if (ct/successful? m)
+      (js/process.exit 0)
+      (js/process.exit 1))))
+
+;; get-test-data is a macro so this namespace REQUIRES :dev/always hint ns so that it is always recompiled
+(defn ^:dev/after-load reset-test-data! []
+  (-> (env/get-test-data)
+      (env/reset-test-data!)))
+
+(defn parse-args [args]
+  (reduce
+   (fn [opts arg]
+     (cond
+       (= "--help" arg)
+       (assoc opts :help true)
+
+       (= "--list" arg)
+       (assoc opts :list true)
+
+       (= "--repl" arg)
+       (assoc opts :repl true)
+
+       (str/starts-with? arg "--test=")
+       (let [test-arg (subs arg 7)
+             test-syms
+             (->> (str/split test-arg ",")
+                  (map symbol))]
+         (update opts :test-syms into test-syms))
+
+       :else
+       (do (println (str "Unknown arg: " arg))
+           opts)))
+   {:test-syms []}
+   args))
+
+(defn find-matching-test-vars [test-syms]
+  ;; FIXME: should have some kind of wildcard support
+  (let [test-namespaces
+        (->> test-syms (filter simple-symbol?) (set))
+        test-var-syms
+        (->> test-syms (filter qualified-symbol?) (set))]
+
+    (->> (env/get-test-vars)
+         (filter (fn [the-var]
+                   (let [{:keys [name ns]} (meta the-var)]
+                     (or (contains? test-namespaces ns)
+                         (contains? test-var-syms (symbol ns name)))))))))
+
+(defn execute-cli [{:keys [test-syms help list repl] :as _opts}]
+  (let [test-env
+        (-> (ct/empty-env)
+            ;; can't think of a proper way to let CLI specify custom reporter?
+            ;; :report-fn is mostly for UI purposes, CLI should be fine with default report
+            #_(assoc :report-fn
+                     (fn [m]
+                       (tap> [:test m (ct/get-current-env)])
+                       (prn m))))]
+
+    (cond
+      help
+      (do (println "Usage:")
+          (println "  --list (list known test names)")
+          (println "  --test=<ns-to-test>,<fqn-symbol-to-test> (run test for namespace or single var, separated by comma)")
+          (println "  --repl (start node without automatically running tests)"))
+
+      list
+      (doseq [[ns ns-info]
+              (->> (env/get-tests)
+                   (sort-by first))]
+        (println "Namespace:" ns)
+        (doseq [var (:vars ns-info)
+                :let [m (meta var)]]
+          (println (str "  " (:ns m) "/" (:name m))))
+        (println "---------------------------------"))
+
+      repl
+      (do
+        (reset! repl? true)
+        (js/process.on "SIGINT" #(js/process.exit 0)))
+
+      (seq test-syms)
+      (let [test-vars (find-matching-test-vars test-syms)]
+        (st/run-test-vars test-env test-vars))
+
+      :else
+      (st/run-all-tests test-env nil))))
+
+(defn ^:export main [& args]
+  (reset-test-data!)
+
+  (let [opts (parse-args args)]
+    (execute-cli opts)))


### PR DESCRIPTION
-------

### Summary

This add REPL support to cljs test

- run `make test` once
- run `yarn run shadow-cljs watch test`
- run `node --require ./test-resources/override.js target/test/test.js --repl` to get the running node process with shadow-cljs node repl
- run tests in REPL with cljs.test, for example [`cljs.test/run-tests`](https://cljs.github.io/api/cljs.test/#run-tests)

status: ready