### PR TITLE
fix error when switching dark/light mode while splash screen is shown

### DIFF
--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -144,9 +144,8 @@
                          (conj {:ms 900 :dispatch
                                 [:navigate-to :create-community-channel
                                  (get-in db [:navigation/screen-params :create-community-channel])]}))]
-
-    (navigation.core/dismiss-all-modals)
-    (when (or (nil? cur-theme) (zero? cur-theme))
+    (when (and (some? root-id) (or (nil? cur-theme) (zero? cur-theme)))
+      (navigation.core/dismiss-all-modals)
       (fx/merge cofx
                 (merge
                  {::multiaccounts/switch-theme (if (= :dark theme) 2 1)}


### PR DESCRIPTION
partially fixes https://github.com/status-im/status-mobile/issues/13740

### Testing Note:
Not sure if the keycard issue is also fixed (if both are caused by the same bug), only tested 1st one.

status: ready