### PR TITLE
nix: pass OPENSEA_API_KEY via saveAccountAndLogin

### DIFF
--- a/nix/mobile/android/default.nix
+++ b/nix/mobile/android/default.nix
@@ -37,7 +37,7 @@ in {
       export STATUS_NIX_MAVEN_REPO="${deps.gradle}"
 
       # required by some makefile targets
-      export STATUS_GO_ANDROID_LIBDIR=${status-go {}}
+      export STATUS_GO_ANDROID_LIBDIR=${status-go}
 
       # check if node modules changed and if so install them
       $STATUS_MOBILE_HOME/nix/scripts/node_modules.sh ${deps.nodejs-patched}

--- a/nix/mobile/android/release.nix
+++ b/nix/mobile/android/release.nix
@@ -77,7 +77,7 @@ in stdenv.mkDerivation rec {
   ANDROID_NDK_ROOT = "${androidPkgs.ndk}";
 
   # Used by the Android Gradle build script in android/build.gradle
-  STATUS_GO_ANDROID_LIBDIR = status-go { inherit secretsFile; };
+  STATUS_GO_ANDROID_LIBDIR = status-go;
 
   phases = [
     "unpackPhase" "secretsPhase" "buildPhase" "checkPhase" "installPhase"

--- a/nix/mobile/ios/status-go-shell.nix
+++ b/nix/mobile/ios/status-go-shell.nix
@@ -7,7 +7,7 @@
 
 mkShell {
   shellHook = ''
-    export STATUS_GO_IOS_LIBDIR=${status-go {}}/Statusgo.xcframework
+    export STATUS_GO_IOS_LIBDIR=${status-go}/Statusgo.xcframework
 
     RCTSTATUS_DIR="$STATUS_MOBILE_HOME/modules/react-native-status/ios/RCTStatus"
     targetBasename='Statusgo.xcframework'

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -43,7 +43,9 @@
            :dev {:devtools {:after-load status-im.reloader/reload
                             :build-notify status-im.reloader/build-notify
                             :preloads [re-frisk-remote.preload]}
-                 :closure-defines {status-im.utils.config/INFURA_TOKEN #shadow/env "INFURA_TOKEN"}
+                 :closure-defines
+                 {status-im.utils.config/INFURA_TOKEN #shadow/env "INFURA_TOKEN"
+                  status-im.utils.config/OPENSEA_API_KEY #shadow/env "OPENSEA_API_KEY"}
                  :compiler-options {:output-feature-set :es5
                                     :closure-defines
                                     {re-frame.trace/trace-enabled? true}
@@ -55,7 +57,10 @@
                  :local-ip #shadow/env "SHADOW_HOST"}
            :chunks {:fleets status-im.fleet.default-fleet/default-fleets
                     :chats status-im.chat.default-chats/default-chats}
-           :release {:closure-defines {status-im.utils.config/INFURA_TOKEN #shadow/env "INFURA_TOKEN"}
+           :release
+           {:closure-defines
+            {status-im.utils.config/INFURA_TOKEN #shadow/env "INFURA_TOKEN"
+             status-im.utils.config/OPENSEA_API_KEY #shadow/env "OPENSEA_API_KEY"}
                      :compiler-options {:output-feature-set :es6
                                         ;;disable for android build as there
                                         ;;is an intermittent warning with deftype
@@ -77,7 +82,9 @@
            :main             status-im.test-runner/main
            ;; set :ui-driven to true to let shadow-cljs inject node-repl
            :ui-driven        true
-           :closure-defines  {status-im.utils.config/INFURA_TOKEN #shadow/env "INFURA_TOKEN"}
+           :closure-defines
+           {status-im.utils.config/INFURA_TOKEN #shadow/env "INFURA_TOKEN"
+            status-im.utils.config/OPENSEA_API_KEY #shadow/env "OPENSEA_API_KEY"}
            :compiler-options {;; needed because we override require and it
                               ;; messes with source-map which reports callstack
                               ;; exceeded exceptions instead of real issues

--- a/src/status_im/keycard/simulated_keycard.cljs
+++ b/src/status_im/keycard/simulated_keycard.cljs
@@ -10,7 +10,8 @@
             [status-im.i18n.i18n :as i18n]
             [clojure.string :as string]
             [taoensso.timbre :as log]
-            [status-im.multiaccounts.create.core :as multiaccounts.create]))
+            [status-im.multiaccounts.create.core :as multiaccounts.create]
+            [status-im.node.core :as node]))
 
 (def kk1-password "000000")
 (def default-pin "111111")
@@ -432,7 +433,7 @@
    (types/clj->json accounts-data)))
 
 (defn login [{:keys [key-uid multiaccount-data password]}]
-  (status/login-with-config key-uid multiaccount-data password nil))
+  (status/login-with-config key-uid multiaccount-data password node/login-node-config))
 
 (defn send-transaction-with-signature
   [{:keys [transaction on-completed]}]

--- a/src/status_im/multiaccounts/login/core.cljs
+++ b/src/status_im/multiaccounts/login/core.cljs
@@ -40,7 +40,8 @@
             [status-im.utils.platform :as platform]
             [status-im.ethereum.tokens :as tokens]
             [clojure.string :as string]
-            [status-im.utils.wallet-connect :as wallet-connect]))
+            [status-im.utils.wallet-connect :as wallet-connect]
+            [status-im.node.core :as node]))
 
 (re-frame/reg-fx
  ::initialize-communities-enabled
@@ -63,7 +64,7 @@
 (re-frame/reg-fx
  ::login
  (fn [[key-uid account-data hashed-password]]
-   (status/login-with-config key-uid account-data hashed-password nil)))
+   (status/login-with-config key-uid account-data hashed-password node/login-node-config)))
 
 (re-frame/reg-fx
  ::export-db

--- a/src/status_im/node/core.cljs
+++ b/src/status_im/node/core.cljs
@@ -60,6 +60,14 @@
     (assoc :ListenAddr ":30304"
            :DataDir (str (:DataDir config) "_dev"))))
 
+(def login-node-config
+  {:WalletConfig (cond-> {:Enabled true}
+                   (not= config/opensea-api-key "")
+                   (assoc :OpenseaAPIKey config/opensea-api-key))})
+
+(defn- get-login-node-config [config]
+  (merge config login-node-config))
+
 (defn- pick-nodes
   "Picks `limit` different nodes randomly from the list of nodes
   if there is more than `limit` nodes in the list, otherwise return the list
@@ -99,6 +107,9 @@
       :always
       (get-base-node-config)
 
+      :always
+      (get-login-node-config)
+
       current-fleet
       (assoc :NoDiscovery   wakuv2-enabled
              :Rendezvous    (if wakuv2-enabled false (boolean (seq rendezvous-nodes)))
@@ -118,8 +129,7 @@
                              :RendezvousNodes    (if wakuv2-enabled [] rendezvous-nodes)})
 
       :always
-      (assoc :WalletConfig {:Enabled true}
-             :LocalNotificationsConfig {:Enabled true}
+      (assoc :LocalNotificationsConfig {:Enabled true}
              :BrowsersConfig {:Enabled true}
              :PermissionsConfig {:Enabled true}
              :MailserversConfig {:Enabled true}

--- a/src/status_im/utils/config.cljs
+++ b/src/status_im/utils/config.cljs
@@ -20,10 +20,12 @@
 ;; flags stay up to date and are removed once behavior introduced is stable.
 
 (goog-define INFURA_TOKEN "800c641949d64d768a5070a1b0511938")
+(goog-define OPENSEA_API_KEY "")
 
 (def mainnet-rpc-url (str "https://mainnet.infura.io/v3/" INFURA_TOKEN))
 (def testnet-rpc-url (str "https://ropsten.infura.io/v3/" INFURA_TOKEN))
 (def goerli-rpc-url  (str "https://goerli.infura.io/v3/" INFURA_TOKEN))
+(def opensea-api-key OPENSEA_API_KEY)
 (def bootnodes-settings-enabled? (enabled? (get-config :BOOTNODES_SETTINGS_ENABLED "1")))
 (def rpc-networks-only? (enabled? (get-config :RPC_NETWORKS_ONLY "1")))
 (def mailserver-confirmations-enabled? (enabled? (get-config :MAILSERVER_CONFIRMATIONS_ENABLED)))


### PR DESCRIPTION
Here the injection of OpenSea API key was done at compile time: https://github.com/status-im/status-mobile/commit/aa72ac57

But this makes `status-go` builds impure, and also prevents them from being extracted from `status-mobile` into `status-go` repo.

Instead we pass the `OPENSEA_API_KEY` env variable to JS bundle at build time, which is then passed to `status-go` via the `Statusgo.saveAccountAndLogin` call in `saveAccountAndLogin`:
https://github.com/status-im/status-mobile/blob/51174f848899360482b7ac55e2407b7cff76ab9e/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusModule.java#L323-L327

Which sends `NodeConfig` that also contains `WalletConfig` which can include `OpenseaAPIKey`:
```go
type WalletConfig struct {
    Enabled       bool
    OpenseaAPIKey string `json:"OpenseaAPIKey"`
}
```
https://github.com/status-im/status-go/blob/0135cc15/params/config.go#L510-L514