### PR TITLE
fix: quo haptic impact light key

### DIFF
--- a/src/quo/haptic.cljs
+++ b/src/quo/haptic.cljs
@@ -3,7 +3,7 @@
 
 (def haptic-methods
   {:selection            "selection"
-   :impacet-light        "impactLight"
+   :impact-light         "impactLight"
    :impact-medium        "impactMedium"
    :impact-heavy         "impactHeavy"
    :notification-success "notificationSuccess"


### PR DESCRIPTION
### Summary

This key did not match the medium and heavy variants.
