### PR TITLE
Remove contact request notification from activity center when request is canceled

### DIFF
--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -35,6 +35,7 @@
 (def ^:const timeline-chat-type 5)
 (def ^:const community-chat-type 6)
 
+(def ^:const contact-request-message-state-none 0)
 (def ^:const contact-request-message-state-pending 1)
 (def ^:const contact-request-message-state-accepted 2)
 (def ^:const contact-request-message-state-declined 3)

--- a/src/status_im/subs.cljs
+++ b/src/status_im/subs.cljs
@@ -1928,19 +1928,25 @@
 (re-frame/reg-sub
  :activity.center/notifications-grouped-by-date
  :<- [:activity.center/notifications]
- (fn [{:keys [notifications]}]
+ :<- [:contacts/contacts]
+ (fn [[{:keys [notifications]} contacts]]
    (let [supported-notifications
-         (filter (fn [{:keys [type last-message]}]
+         (filter (fn [{:keys [type last-message message]}]
                    (or (and (= constants/activity-center-notification-type-one-to-one-chat type)
                             (not (nil? last-message)))
-                       (= constants/activity-center-notification-type-contact-request type)
+                       (and (= constants/activity-center-notification-type-contact-request type)
+                            (not= constants/contact-request-message-state-none
+                                  (-> contacts
+                                      (multiaccounts/contact-by-identity (:from message))
+                                      :contact-request-state)))
                        (= constants/activity-center-notification-type-contact-request-retracted type)
                        (= constants/activity-center-notification-type-private-group-chat type)
                        (= constants/activity-center-notification-type-reply type)
                        (= constants/activity-center-notification-type-mention type)))
                  notifications)]
      (group-notifications-by-date
-      (map #(assoc % :timestamp (or (:timestamp %) (:timestamp (or (:message %) (:last-message %)))))
+      (map #(assoc % :timestamp (or (:timestamp %) (:timestamp (or (:message %) (:last-message %))))
+                   :contact (multiaccounts/contact-by-identity contacts (get-in % [:message :from])))
            supported-notifications)))))
 
 ;;WALLET TRANSACTIONS ==================================================================================================

--- a/src/status_im/ui/screens/notifications_center/views/notification.cljs
+++ b/src/status_im/ui/screens/notifications_center/views/notification.cljs
@@ -132,4 +132,5 @@
           constants/contact-request-message-state-declined
           [quo/text {:style {:color colors/red}} (i18n/label :t/declined)]
           constants/contact-request-message-state-pending
-          [contact-request-actions (:message-id message)])])]))
+          [contact-request-actions (:message-id message)]
+          nil)])]))


### PR DESCRIPTION
Currently if request is canceled on sender's side and on receiver's side the activity screen is opened the notification about request would stay on the screen.

status: ready