### PR TITLE
[#13791] Extend integration tests to create a new wallet account

### DIFF
--- a/src/status_im/integration_test.cljs
+++ b/src/status_im/integration_test.cljs
@@ -5,12 +5,15 @@
             status-im.events
             [status-im.multiaccounts.logout.core :as logout]
             [status-im.transport.core :as transport]
-            ;; status-im.subs ;;so integration tests can run independently
+            status-im.subs ;;so integration tests can run independently
+            [status-im.ethereum.core :as ethereum]
             [status-im.utils.test :as utils.test]))
 
 (def password "testabc")
 
 (def community {:membership 1 :name "foo" :description "bar"})
+
+(def account-name "account-abc")
 
 (utils.test/init!)
 
@@ -54,6 +57,15 @@
 (defn assert-community-created []
   (is (= @(rf/subscribe [:communities/create]) community)))
 
+(defn create-new-account! []
+  (rf/dispatch-sync [:wallet.accounts/start-adding-new-account {:type :generate}])
+  (rf/dispatch-sync [:set-in [:add-account :account :name] account-name])
+  (rf/dispatch [:wallet.accounts/add-new-account (ethereum/sha3 password)]))
+
+(defn assert-new-account-created []
+  (is (true? (some #(= (:name %) account-name)
+                   @(rf/subscribe [:multiaccount/accounts])))))
+
 (defn logout! []
   (rf/dispatch [:logout]))
 
@@ -96,6 +108,27 @@
        (assert-community-created)
        (logout!)
        (rf-test/wait-for [::logout/logout-method]
+                         (assert-logout))))))))
+
+(deftest create-wallet-account-test
+  (rf-test/run-test-async
+   (initialize-app!) ; initialize app
+   (rf-test/wait-for
+    [:status-im.init.core/initialize-multiaccounts]
+    (generate-and-derive-addresses!) ; generate 5 new keys
+    (rf-test/wait-for
+     [:multiaccount-generate-and-derive-addresses-success]
+     (assert-multiaccount-loaded) ; assert keys are generated
+     (create-multiaccount!) ; create a multiaccount
+     (rf-test/wait-for ; wait for login
+      [::transport/messenger-started]
+      (assert-messenger-started)
+      (create-new-account!) ; create a new account
+      (rf-test/wait-for
+       [:wallet.accounts/account-stored]
+       (assert-new-account-created) ; assert account was created
+       (logout!)
+       (rf-test/wait-for [::logout/logout-method] ; we need to logout to make sure the node is not in an inconsistent state between tests
                          (assert-logout))))))))
 
 (comment

--- a/src/status_im/utils/test.cljs
+++ b/src/status_im/utils/test.cljs
@@ -52,6 +52,16 @@
                                                        (.multiAccountGenerateAndDeriveAddresses
                                                         native-status
                                                         json)))
+            :multiAccountLoadAccount (fn [json callback]
+                                       (callback
+                                        (.multiAccountLoadAccount
+                                         native-status
+                                         json)))
+            :multiAccountDeriveAddresses (fn [json callback]
+                                       (callback
+                                        (.multiAccountDeriveAddresses
+                                         native-status
+                                         json)))
             :initKeystore (fn [key-uid callback]
                             (callback
                              (.initKeystore


### PR DESCRIPTION
fixes #13791

### Testing notes
- Can skip manual QA
- Can skip e2e tests

status: ready