### PR TITLE
e2e: nightly 12/08 fixes

### DIFF
--- a/test/appium/tests/critical/chats/test_1_1_public_chats.py
+++ b/test/appium/tests/critical/chats/test_1_1_public_chats.py
@@ -978,7 +978,10 @@ class TestEnsStickersMultipleDevicesMerged(MultipleSharedDeviceTestCase):
         self.home_2.add_contact(self.sender['public_key'])
         # To avoid activity centre for restored users
         [chat.send_message("hey!") for chat in (self.chat_1, self.chat_2)]
+
+        self.home_1.just_fyi("Close the ENS banner")
         [home.home_button.double_click() for home in (self.home_1, self.home_2)]
+        [home.ens_banner_close_button.click() for home in (self.home_1, self.home_2)]
 
     @marks.testrail_id(702152)
     def test_ens_purchased_in_profile(self):
@@ -1115,6 +1118,7 @@ class TestEnsStickersMultipleDevicesMerged(MultipleSharedDeviceTestCase):
         self.errors.verify_no_errors()
 
     @marks.testrail_id(702157)
+    @marks.xfail(reason='Failing due to the known IPFS issue', run=False)
     def test_sticker_1_1_public_chat_mainnet(self):
         self.home_2.status_in_background_button.click_if_shown()
         [home.home_button.double_click() for home in (self.home_1, self.home_2)]

--- a/test/appium/tests/critical/test_pairing_devices_sync.py
+++ b/test/appium/tests/critical/test_pairing_devices_sync.py
@@ -148,9 +148,13 @@ class TestPairingSyncMultipleDevicesMerged(MultipleSharedDeviceTestCase):
         dapp = self.home_1.dapp_tab_button.click()
         web_page = dapp.open_url('status.im')
         web_page.add_to_bookmarks()
-        self.home_1.profile_button.double_click()
+
+        self.home_1.just_fyi("Close the ENS banner")
+        [home.home_button.double_click() for home in (self.home_1, self.home_2)]
+        [home.ens_banner_close_button.click() for home in (self.home_1, self.home_2)]
 
         self.device_2.just_fyi('Pair main and secondary devices')
+        [device.profile_button.double_click() for device in (self.profile_1, self.profile_2)]
         self.profile_2.discover_and_advertise_device(self.name_2)
         self.profile_1.discover_and_advertise_device(self.name_1)
         self.profile_1.get_toggle_device_by_name(self.name_2).wait_and_click()

--- a/test/appium/tests/medium/test_browser_profile.py
+++ b/test/appium/tests/medium/test_browser_profile.py
@@ -74,7 +74,7 @@ class TestBrowserProfileOneDevice(MultipleSharedDeviceTestCase):
         self.home.just_fyi('Opening url containing ipns name')
         dapp = self.home.dapp_tab_button.click()
         web_page = dapp.open_url(ipns_url)
-        element_on_start_page = dapp.element_by_text('Select a token')
+        element_on_start_page = dapp.element_by_text('Select token')
         if not element_on_start_page.is_element_displayed(60):
             self.home.driver.fail('No start element is shown for dapp, so IPNS name is not resolved')
 

--- a/test/appium/tests/medium/test_deeplink_chat_share_profile.py
+++ b/test/appium/tests/medium/test_deeplink_chat_share_profile.py
@@ -31,6 +31,9 @@ class TestDeeplinkChatProfileOneDevice(MultipleSharedDeviceTestCase):
         self.public_chat = self.home.join_public_chat(self.public_chat_name)
         self.public_chat.get_back_to_home_view()
 
+        self.home.just_fyi("Close the ENS banner")
+        self.home.ens_banner_close_button.click()
+
     @marks.testrail_id(702244)
     def test_deep_link_with_invalid_user_public_key_own_profile_key(self):
         self.drivers[0].close_app()

--- a/test/appium/tests/medium/test_profile_m.py
+++ b/test/appium/tests/medium/test_profile_m.py
@@ -39,6 +39,10 @@ class TestProfileGapsCommunityMediumMultipleDevicesMerged(MultipleSharedDeviceTe
         self.public_chat_1, self.public_chat_2 = self.home_1.join_public_chat(
             self.public_chat_name), self.home_2.join_public_chat(self.public_chat_name)
 
+        self.home_1.just_fyi("Close the ENS banner")
+        [home.home_button.double_click() for home in (self.home_1, self.home_2)]
+        [home.ens_banner_close_button.click() for home in (self.home_1, self.home_2)]
+
     @marks.testrail_id(702281)
     def test_profile_show_profile_picture_and_online_indicator_settings(self):
         [home.home_button.double_click() for home in (self.home_1, self.home_2)]

--- a/test/appium/views/home_view.py
+++ b/test/appium/views/home_view.py
@@ -201,6 +201,7 @@ class HomeView(BaseView):
         self.my_profile_on_start_new_chat_button = Button(self.driver,
                                                           xpath="//*[@content-desc='current-account-photo']")
         self.communities_button = ChatButton(self.driver, accessibility_id="communities-button")
+        self.ens_banner_close_button = Button(self.driver, accessibility_id=":ens-banner-close-button")
 
         # Notification centre
         self.notifications_button = Button(self.driver, accessibility_id="notifications-button")


### PR DESCRIPTION
PR adds:
- closing the new ENS banner in several test groups
- `xfail` mark for a sticker test
- fix for the `Select token` button in Uniswap