### PR TITLE
Debug path

### DIFF
--- a/src/status_im/utils/test.cljs
+++ b/src/status_im/utils/test.cljs
@@ -3,7 +3,15 @@
 
 (def native-status (js/require "../../modules/react-native-status/nodejs/bindings"))
 
-(def test-dir "/tmp")
+(def fs (js/require "fs"))
+(def path (js/require "path"))
+(def os (js/require "os"))
+
+(def tmpdir (.tmpdir os))
+
+(def test-dir-prefix (.join path tmpdir "status-mobile-tests"))
+
+(def test-dir (.mkdtempSync fs test-dir-prefix))
 
 (defn signal-received-callback [a]
   (re-frame/dispatch [:signals/signal-received a]))


### PR DESCRIPTION
Before we were always using `/tmp` for the database directory for tests run.
This would create issues in test runs when the database was migrated.

This commit changes the behavior so that  a temporary directory is created each time the code is executed. Note this is only once per test run, not per test, tests will still use the same db, but it should not cause issues for now as there should not be any migration issue.