### PR TITLE
status-go: leave community

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.105.1",
-    "commit-sha1": "924820c14af829a941744c0de9658485a8599a17",
-    "src-sha256": "1hqdil8bi3ziky9n1aqkcdl1pgis1yknzs8zlpww89xadh39dfxa"
+    "version": "388d6d6d9a80a33ca3f33edd3fbbef55e9e59918",
+    "commit-sha1": "388d6d6d9a80a33ca3f33edd3fbbef55e9e59918",
+    "src-sha256": "1v98zf93m50af6fjz9zcyam1isj7rja15fyhflbi9mgx64pc6x7c"
 }


### PR DESCRIPTION
https://github.com/status-im/status-go/compare/924820c1...388d6d6d

status-go PR: https://github.com/status-im/status-go/pull/2813
status-desktop PR: https://github.com/status-im/status-desktop/pull/7122

origin task: https://github.com/status-im/status-go/issues/2812

### Summary

Before, leaving the community was only local to the user. Now, users advertise they are leaving community, other members should update their members list accordingly.

See [status-desktop PR](https://github.com/status-im/status-desktop/pull/7122) description video for details.

### Testing notes
All changes to the community will be reflected only when admin processes community requests, that implies the admin has to be online in order to see members list update by others.

- admin can only leave the community locally (other members are not informed)

#### Areas that maybe impacted
Joining and leaving communities

##### Example scenarios to test

A) 
--admin is online--
1) user A leaves the community
2) user A joins the community (aka rejoin)

B)
--admin is offline--

1) user A leaves the community
2) user A joins the community (aka rejoin)

--admin is online--

##### Functional

- communities

status: ready <!-- Can be ready or wip -->
