### PR TITLE
issue-13832: Implement account selector in manage app connection and persist when offline

### DIFF
--- a/src/status_im/network/net_info.cljs
+++ b/src/status_im/network/net_info.cljs
@@ -35,14 +35,14 @@
         connectivity-status (if isConnected :online :offline)
         status-changed?     (not= connectivity-status old-network-status)
         type-changed?       (= type old-network-type)
-        reconnected?        (when (and isInternetReachable
-                                       @app-went-offline?)
-                              (swap! app-went-offline? not)
-                              true)
         _                   (when (and (not isConnected)
                                        (not isInternetReachable)
                                        (not @app-went-offline?))
-                              (swap! app-went-offline? not))]
+                              (swap! app-went-offline? not))
+        reconnected?        (when (and isInternetReachable
+                                       @app-went-offline?)
+                              (swap! app-went-offline? not)
+                              true)]
     (log/debug "[net-info]"
                "old-network-status"  old-network-status
                "old-network-type"    old-network-type
@@ -50,7 +50,7 @@
                "type"                type
                "details"             details)
     (fx/merge cofx
-              (when status-changed?
+              (when (or status-changed? reconnected?)
                 (change-network-status isConnected reconnected?))
               (when-not type-changed?
                 (change-network-type old-network-type type (:is-connection-expensive details))))))

--- a/src/status_im/ui/screens/wallet/manage_connections/views.cljs
+++ b/src/status_im/ui/screens/wallet/manage_connections/views.cljs
@@ -6,17 +6,29 @@
             [quo.core :as quo]
             [quo.design-system.colors :as colors]
             [status-im.ui.components.icons.icons :as icons]
-            [status-im.utils.utils :as utils]))
+            [status-im.utils.utils :as utils]
+            [status-im.ui.screens.wallet-connect.session-proposal.views :refer [app-management-sheet-view]]
+            [status-im.ui.components.bottom-panel.views :as bottom-panel]
+            [status-im.utils.handlers :refer [<sub]]
+            [reagent.core :as reagent]))
 
-(defn print-session-info [session]
-  (let [peer-meta (get-in session [:params 0 :peerMeta])
-        peer-id (get-in session [:params 0 :peerId])
-        name (get peer-meta :name)
-        url (get peer-meta :url)
-        account (get-in session [:params 0  :accounts 0])
-        icons (get peer-meta :icons)
-        icon-uri (first (status-im.utils.utils/exclude-svg-resources icons))
-        visible-accounts @(re-frame/subscribe [:visible-accounts-without-watch-only])
+(defn account-selector-bottom-sheet [{:keys [session show-account-selector? idx]}]
+  (when @show-account-selector?
+    [rn/view {:style (cond-> {:height 50}
+                       (= idx 0) (assoc :margin-top 50))}
+     [bottom-panel/animated-bottom-panel
+      session
+      app-management-sheet-view
+      true]]))
+
+(defn print-session-info [{:keys [session visible-accounts show-account-selector?]}]
+  (let [peer-meta        (get-in session [:params 0 :peerMeta])
+        peer-id          (get-in session [:params 0 :peerId])
+        name             (get peer-meta :name)
+        url              (get peer-meta :url)
+        account          (get-in session [:params 0 :accounts 0])
+        icons            (get peer-meta :icons)
+        icon-uri         (first (status-im.utils.utils/exclude-svg-resources icons))
         selected-account (first (filter
                                  #(= account
                                      (:address %))
@@ -25,28 +37,51 @@
     [rn/view
      [:<>
       [rn/view {:style styles/app-row}
-       [react/image {:style styles/dapp-icon :source {:uri icon-uri}}]
+       [react/image {:style  styles/dapp-icon
+                     :source {:uri icon-uri}}]
        [rn/view {:style styles/app-column}
         [quo/text {:style styles/dapp-name} name]
         [quo/text {:style styles/dapp-url} url]]
 
        [rn/view {:flex-direction :row
-                 :position :absolute
-                 :right 10
-                 :align-items :center}
-        [rn/touchable-opacity {:style styles/delete-icon-container
+                 :position       :absolute
+                 :right          10
+                 :align-items    :center}
+        [rn/touchable-opacity {:style    styles/delete-icon-container
                                :on-press #(re-frame/dispatch [:wallet-connect-legacy/disconnect session])}
 
-         [icons/icon :icons/delete {:width 20
-                                    :height 20
+         [icons/icon :icons/delete {:width           20
+                                    :height          20
                                     :container-style {:elevation 3}
-                                    :color colors/red}]]
-
+                                    :color           colors/red}]]
         (when selected-account ;; The account might not be available in theory, if deleted
-          [rn/view {:style (styles/selected-account-container (:color selected-account))}
+          [rn/touchable-opacity {:style    (styles/selected-account-container (:color selected-account))
+                                 :on-press #(swap! show-account-selector? not)}
            [rn/text {:style styles/selected-account} (:name selected-account)]])]]]]))
 
+(defn list-item [{:keys [session visible-accounts show-account-selector?]} idx]
+  [rn/view
+   [print-session-info {:session session
+                        :visible-accounts visible-accounts
+                        :show-account-selector? show-account-selector?}]
+   [account-selector-bottom-sheet {:session                session
+                                   :show-account-selector? show-account-selector?
+                                   :idx                    idx}]])
+
+(defn list-comp [sessions visible-accounts]
+  (let [items (reagent/atom (doall (map (fn [session]
+                                          (let [show-account-selector? (reagent/atom false)]
+                                            {:visible-accounts       visible-accounts
+                                             :show-account-selector? show-account-selector?
+                                             :session                session}))
+                                        @sessions)))]
+    [rn/flat-list {:flex                      1
+                   :keyboardShouldPersistTaps :always
+                   :data                      @items
+                   :render-fn                 list-item
+                   :key-fn                    str}]))
+
 (defn views []
-  (let [legacy-sessions @(re-frame/subscribe [:wallet-connect-legacy/sessions])]
-    [rn/view {:margin-top 10}
-     (doall (map print-session-info legacy-sessions))]))
+  (let [sessions (reagent/atom (<sub [:wallet-connect-legacy/sessions]))
+        visible-accounts (<sub [:visible-accounts-without-watch-only])]
+    [list-comp sessions visible-accounts]))

--- a/src/status_im/wallet_connect_legacy/core.cljs
+++ b/src/status_im/wallet_connect_legacy/core.cljs
@@ -142,30 +142,40 @@
                     (:wallet-connect-legacy/sessions db))]
     {:wc-1-clean-up-sessions connectors}))
 
-(fx/defn session-connected
-  {:events [:wallet-connect-legacy/created]}
-  [{:keys [db]} session]
-  (let [connector (get db :wallet-connect-legacy/proposal-connector)
-        session (assoc (types/js->clj session)
-                       :wc-version constants/wallet-connect-version-1
-                       :connector connector)
-        info (.stringify js/JSON (.-session connector))
-        peer-id (get-in session [:params 0 :peerId])
-        dapp-name (get-in session [:params 0 :peerMeta :name])
-        dapp-url (get-in session [:params 0 :peerMeta :url])]
-    {:show-wallet-connect-success-sheet nil
-     :db (-> db
-             (assoc :wallet-connect/session-connected session)
-             (update :wallet-connect-legacy/sessions
-                     conj
-                     session))
-     ::json-rpc/call [{:method     "wakuext_addWalletConnectSession"
+(fx/defn save-session
+  {:events [:wallet-connect-legacy/save-session]}
+  [{:keys [db]} {:keys [peer-id dapp-name dapp-url connector]}]
+  (let [info (.stringify js/JSON (.-session connector))]
+    {::json-rpc/call [{:method     "wakuext_addWalletConnectSession"
                        :params     [{:id peer-id
                                      :info info
+                                    ;;  info will be the updated value
                                      :dappName dapp-name
                                      :dappUrl dapp-url}]
                        :on-success #(log/info "wakuext_addWalletConnectSession success call back , data =>" %)
                        :on-error   #(log/error "wakuext_addWalletConnectSession error call back , data =>" %)}]}))
+
+(fx/defn session-connected
+  {:events [:wallet-connect-legacy/created]}
+  [{:keys [db] :as cofx} session]
+  (let [connector (get db :wallet-connect-legacy/proposal-connector)
+        session (assoc (types/js->clj session)
+                       :wc-version constants/wallet-connect-version-1
+                       :connector connector)
+        peer-id (get-in session [:params 0 :peerId])
+        dapp-name (get-in session [:params 0 :peerMeta :name])
+        dapp-url (get-in session [:params 0 :peerMeta :url])]
+    (fx/merge cofx
+              {:db (-> db
+                       (assoc :wallet-connect/session-connected session)
+                       (update :wallet-connect-legacy/sessions
+                               conj
+                               session))
+               :show-wallet-connect-success-sheet nil}
+              (save-session {:peer-id peer-id
+                             :dapp-name dapp-name
+                             :dapp-url dapp-url
+                             :connector connector}))))
 
 (fx/defn manage-app
   {:events [:wallet-connect-legacy/manage-app]}
@@ -211,16 +221,20 @@
 
 (fx/defn change-session-account
   {:events [:wallet-connect-legacy/change-session-account]}
-  [{:keys [db]} session account]
-  (let [connector (:connector session)
-        address (:address account)
-        networks (get db :networks/networks)
+  [{:keys [db] :as cofx} session account]
+  (let [connector          (:connector session)
+        address            (:address account)
+        networks           (get db :networks/networks)
         current-network-id (get db :networks/current-network)
-        current-network (get networks current-network-id)
-        chain-id (get-in current-network [:config :NetworkId])]
-    {:hide-wallet-connect-app-management-sheet nil
-     :wc-1-update-session [connector chain-id address]
-     :db (assoc db :wallet-connect/showing-app-management-sheet? false)}))
+        current-network    (get networks current-network-id)
+        dapp-name          (get-in session [:params 0 :peerMeta :name])
+        dapp-url           (get-in session [:params 0 :peerMeta :url])
+        peer-id            (get-in session [:params 0 :peerId])
+        chain-id           (get-in current-network [:config :NetworkId])]
+    (fx/merge cofx
+              {:hide-wallet-connect-app-management-sheet nil
+               :wc-1-update-session                      [connector chain-id address]
+               :db                                       (assoc db :wallet-connect/showing-app-management-sheet? false)})))
 
 (fx/defn disconnect-by-peer-id
   {:events [:wallet-connect-legacy/disconnect-by-peer-id]}
@@ -268,10 +282,18 @@
   (let [sessions (get db :wallet-connect-legacy/sessions)
         accounts-new (:accounts (first (:params payload)))
         session (first (filter #(= (:connector %) connector) sessions))
-        updated-session (assoc-in session [:params 0 :accounts] accounts-new)]
-    {:db (-> db
-             (assoc :wallet-connect-legacy/sessions (conj (filter #(not= (:connector %) connector) sessions) updated-session))
-             (dissoc :wallet-connect/session-managed))}))
+        updated-session (assoc-in session [:params 0 :accounts] accounts-new)
+        peer-id (get-in updated-session [:params 0 :peerId])
+        dapp-name (get-in updated-session [:params 0 :peerMeta :name])
+        dapp-url (get-in updated-session [:params 0 :peerMeta :url])]
+    (fx/merge cofx
+              {:db (-> db
+                       (assoc :wallet-connect-legacy/sessions (conj (filter #(not= (:connector %) connector) sessions) updated-session))
+                       (dissoc :wallet-connect/session-managed))
+               :dispatch [:wallet-connect-legacy/save-session {:peer-id   peer-id
+                                                               :dapp-url  dapp-url
+                                                               :dapp-name dapp-name
+                                                               :connector connector}]})))
 
 (fx/defn wallet-connect-legacy-complete-transaction
   {:events [:wallet-connect-legacy.dapp/transaction-on-result]}
@@ -338,7 +360,8 @@
 (fx/defn sync-app-db-with-wc-sessions
   {:events [:sync-wallet-connect-app-sessions]}
   [{:keys [db]} session-data]
-  (let [chain-id (get-in db [:networks/networks (:networks/current-network db) :config :NetworkId])
+  (let [_        (log/debug "sync-app-db-with-wc-sessions")
+        chain-id (get-in db [:networks/networks (:networks/current-network db) :config :NetworkId])
         sessions (->> session-data
                       (map :info)
                       (map js/JSON.parse)
@@ -347,7 +370,7 @@
       {:initialize-wc-sessions [chain-id sessions]})))
 
 (fx/defn get-connector-session-from-db
-  {:events [:get-connector-session-from-db]}
+  {:events [:wallet-connect-legacy/get-connector-session-from-db]}
   [_]
   {::json-rpc/call [{:method     "wakuext_getWalletConnectSession"
                      :on-success #(re-frame/dispatch [:sync-wallet-connect-app-sessions %])


### PR DESCRIPTION
fixes #13832 

### Summary

- Android
- iOS

#### Areas that maybe impacted
Wallet connect

##### Functional

- wallet / transactions
- dapps / app browsing

### Steps to test

1. Add a dApp into the account
2. Go to Manage app connections
3. Press your account name and try to change it
4. test it offline with/without logging out


status: ready
