### PR TITLE
status-go: group chat adjustments

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.108.3",
-    "commit-sha1": "0ecbb5e8d78749abeb9d7bb6dc4c3b4c18b683e5",
-    "src-sha256": "0shfklq1sisjnj008grcxwfam3j6psbis68r82nv38m8435z3g46"
+    "version": "1e4ac1c9edfabce3206c67f637d96c388778953b",
+    "commit-sha1": "1e4ac1c9edfabce3206c67f637d96c388778953b",
+    "src-sha256": "1x3456g2qwayjs1km8b82rkkq5zvks19wicpsxcbq9iz2pdxhfcm"
 }


### PR DESCRIPTION
https://github.com/status-im/status-go/compare/86054875...8c17c3af

status-go PR: https://github.com/status-im/status-go/pull/2828
status-desktop PR: https://github.com/status-im/status-desktop/pull/7188

### Summary

Now:

- only mutual contacts can be added to the group (either on group creation or later)
- any member has the ability to add its mutual contact to the group
- any member has the ability to change the name and color of the group

If in any doubts please refer to the specs: https://github.com/status-im/feature-specs/blob/3bcd4909d730bea213ad94412ed8e0077a32e7ba/content/raw/chat/group_chat.md

#### Areas that maybe impacted

- creating group chat
- adding/removing members to group chat
- changing group chat properties: name, ~~image~~(not implemented yet), color

##### Functional
- group chats

status: ready <!-- Can be ready or wip -->
