### PR TITLE
fix ios keycard recovery pin error

### DIFF
--- a/src/status_im/keycard/common.cljs
+++ b/src/status_im/keycard/common.cljs
@@ -403,9 +403,7 @@
                              :import-multiaccount []
                              :error-label         :t/pin-mismatch))}
          (hide-connection-sheet)
-         (when (zero? pin-retries-count) (frozen-keycard-popup))
-         (when (= flow :import)
-           (navigation/navigate-to-cofx :keycard-recovery-pin nil)))
+         (when (zero? pin-retries-count) (frozen-keycard-popup)))
         (show-wrong-keycard-alert)))))
 
 (fx/defn factory-reset

--- a/src/status_im/ui/screens/keycard/pin/views.cljs
+++ b/src/status_im/ui/screens/keycard/pin/views.cljs
@@ -152,8 +152,8 @@
   [{:keys [retry-counter]}]
   (let [error-y-translation (animation/create-value -8)
         error-opacity (animation/create-value 0)
-        retries-y-translation (animation/create-value (if retry-counter 8 0))
-        retries-opacity (animation/create-value (if retry-counter 0 1))
+        retries-y-translation (animation/create-value (if retry-counter 0 -8))
+        retries-opacity (animation/create-value (if retry-counter 1 0))
         !error? (reagent/atom false)]
     (reagent/create-class
      {:component-did-update


### PR DESCRIPTION
fixes: https://github.com/status-im/status-mobile/issues/13917

### Summary
Two bugs stopped the ios form from showing pin error and counter

1. Pin view had default value in reverse order, so even if it had counter value at the time of rendering it hid the counter label.

2. We were already on the `:keycard-recovery-pin` screen and still navigated again. For some reason, it didn't affect the android, but for ios, it overlapped the old screen with the new one.
Visibility for the counter still updated on the original screen, but now  it was overlapped with the new screen (which ignored the passed counter value due to 1st bug)

status: ready