### PR TITLE
ci: do not upload release builds to Diawi

### DIFF
--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -76,7 +76,7 @@ pipeline {
           /* mobile */
           Apk: utils.pkgUrl(apk), Apke2e: utils.pkgUrl(apke2e),
           iOS: utils.pkgUrl(ios), /*iOSe2e: utils.pkgUrl(iose2e),*/
-          Diawi: utils.utils.getEnv(ios, 'DIAWI_URL'),
+          Diawi: utils.getEnv(ios, 'DIAWI_URL'),
           /* upload the sha256 checksums file too */
           SHA: s3.uploadArtifact(sha),
         ]

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -79,7 +79,7 @@ pipeline {
             /* e2e builds get tested in SauceLabs */
             if (utils.isE2EBuild()) {
               env.SAUCE_URL = ios.uploadToSauceLabs()
-            } else {
+            } else if (!utils.isReleaseBuild()) {
               env.DIAWI_URL = ios.uploadToDiawi()
             }
           } }


### PR DESCRIPTION
Otherwise the upload fails with `400 Bad Request` due to size:
```
bundler: failed to load command: fastlane (/Users/jenkins/.bundle/ruby/2.7.0/bin/fastlane)
/Users/jenkins/.bundle/ruby/2.7.0/gems/rest-client-2.1.0/lib/restclient/abstract_response.rb:249:in `exception_with_response': 400 Bad Request (RestClient::BadRequest)
```
Because release builds are over 100 MB:
```
 > ls -l StatusIm-Mobile-v1.20.0-59567a.ipa
-rw-r--r-- 1 jakubgs jakubgs 104M Sep  7 15:50 StatusIm-Mobile-v1.20.0-59567a.ip
```
And the Diawi free account limit is 75 MB: https://www.diawi.com/features-services