### PR TITLE
[#13895] Create new Activity Center screen

### DIFF
--- a/src/status_im/activity_center/core.cljs
+++ b/src/status_im/activity_center/core.cljs
@@ -1,0 +1,69 @@
+(ns status-im.activity-center.core
+  (:require [re-frame.core :as re-frame]
+            [status-im.data-store.activities :as data-store.activities]
+            [status-im.ethereum.json-rpc :as json-rpc]
+            [status-im.utils.fx :as fx]
+            [taoensso.timbre :as log]))
+
+(def notifications-per-page
+  20)
+
+(def start-or-end-cursor
+  "")
+
+(defn notifications-group->rpc-method
+  [notifications-group]
+  (if (= notifications-group :notifications-read)
+    "wakuext_readActivityCenterNotifications"
+    "wakuext_unreadActivityCenterNotifications"))
+
+(defn notifications-read-status->group
+  [status-filter]
+  (if (= status-filter :read)
+    :notifications-read
+    :notifications-unread))
+
+(fx/defn notifications-fetch
+  [{:keys [db]} cursor notifications-group]
+  (when-not (get-in db [:activity-center notifications-group :loading?])
+    {:db             (assoc-in db [:activity-center notifications-group :loading?] true)
+     ::json-rpc/call [{:method     (notifications-group->rpc-method notifications-group)
+                       :params     [cursor notifications-per-page]
+                       :on-success #(re-frame/dispatch [:activity-center/notifications:fetch:success notifications-group %])
+                       :on-error   #(re-frame/dispatch [:activity-center/notifications:fetch:error notifications-group %])}]}))
+
+(fx/defn notifications-fetch-first-page
+  {:events [:activity-center/notifications:fetch-first-page]}
+  [{:keys [db] :as cofx} {:keys [status-filter] :or {status-filter :unread}}]
+  (let [notifications-group (notifications-read-status->group status-filter)]
+    (fx/merge cofx
+              {:db (-> db
+                       (assoc-in [:activity-center :current-status-filter] status-filter)
+                       (update-in [:activity-center notifications-group] dissoc :loading?)
+                       (update-in [:activity-center notifications-group] dissoc :data))}
+              (notifications-fetch start-or-end-cursor notifications-group))))
+
+(fx/defn notifications-fetch-next-page
+  {:events [:activity-center/notifications:fetch-next-page]}
+  [{:keys [db] :as cofx}]
+  (let [status-filter       (get-in db [:activity-center :current-status-filter])
+        notifications-group (notifications-read-status->group status-filter)
+        {:keys [cursor]}    (get-in db [:activity-center notifications-group])]
+    (when-not (= cursor start-or-end-cursor)
+      (notifications-fetch cofx cursor notifications-group))))
+
+(fx/defn notifications-fetch-success
+  {:events [:activity-center/notifications:fetch:success]}
+  [{:keys [db]} notifications-group {:keys [cursor notifications]}]
+  {:db (-> db
+           (update-in [:activity-center notifications-group] dissoc :loading?)
+           (assoc-in [:activity-center notifications-group :cursor] cursor)
+           (update-in [:activity-center notifications-group :data]
+                      concat
+                      (map data-store.activities/<-rpc notifications)))})
+
+(fx/defn notifications-fetch-error
+  {:events [:activity-center/notifications:fetch:error]}
+  [{:keys [db]} notifications-group error]
+  (log/warn "Failed to load Activity Center notifications" error)
+  {:db (update-in db [:activity-center notifications-group] dissoc :loading?)})

--- a/src/status_im/activity_center/core.cljs
+++ b/src/status_im/activity_center/core.cljs
@@ -29,11 +29,11 @@
     {:db             (assoc-in db [:activity-center notifications-group :loading?] true)
      ::json-rpc/call [{:method     (notifications-group->rpc-method notifications-group)
                        :params     [cursor notifications-per-page]
-                       :on-success #(re-frame/dispatch [:activity-center/notifications:fetch:success notifications-group %])
-                       :on-error   #(re-frame/dispatch [:activity-center/notifications:fetch:error notifications-group %])}]}))
+                       :on-success #(re-frame/dispatch [:activity-center/notifications-fetch-success notifications-group %])
+                       :on-error   #(re-frame/dispatch [:activity-center/notifications-fetch-error notifications-group %])}]}))
 
 (fx/defn notifications-fetch-first-page
-  {:events [:activity-center/notifications:fetch-first-page]}
+  {:events [:activity-center/notifications-fetch-first-page]}
   [{:keys [db] :as cofx} {:keys [status-filter] :or {status-filter :unread}}]
   (let [notifications-group (notifications-read-status->group status-filter)]
     (fx/merge cofx
@@ -44,7 +44,7 @@
               (notifications-fetch start-or-end-cursor notifications-group))))
 
 (fx/defn notifications-fetch-next-page
-  {:events [:activity-center/notifications:fetch-next-page]}
+  {:events [:activity-center/notifications-fetch-next-page]}
   [{:keys [db] :as cofx}]
   (let [status-filter       (get-in db [:activity-center :current-status-filter])
         notifications-group (notifications-read-status->group status-filter)
@@ -53,7 +53,7 @@
       (notifications-fetch cofx cursor notifications-group))))
 
 (fx/defn notifications-fetch-success
-  {:events [:activity-center/notifications:fetch:success]}
+  {:events [:activity-center/notifications-fetch-success]}
   [{:keys [db]} notifications-group {:keys [cursor notifications]}]
   {:db (-> db
            (update-in [:activity-center notifications-group] dissoc :loading?)
@@ -63,7 +63,7 @@
                       (map data-store.activities/<-rpc notifications)))})
 
 (fx/defn notifications-fetch-error
-  {:events [:activity-center/notifications:fetch:error]}
+  {:events [:activity-center/notifications-fetch-error]}
   [{:keys [db]} notifications-group error]
   (log/warn "Failed to load Activity Center notifications" error)
   {:db (update-in db [:activity-center notifications-group] dissoc :loading?)})

--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -36,6 +36,7 @@
             [status-im.native-module.core :as status]
             [status-im.navigation :as navigation]
             status-im.notifications-center.core
+            status-im.activity-center.core
             status-im.pairing.core
             [status-im.popover.core :as popover]
             status-im.profile.core

--- a/src/status_im/subs.cljs
+++ b/src/status_im/subs.cljs
@@ -1935,6 +1935,31 @@
 
 ;;ACTIVITY CENTER NOTIFICATIONS ========================================================================================
 
+(re-frame/reg-sub
+ :activity-center/notifications-read
+ (fn [db]
+   (get-in db [:activity-center :notifications-read :data])))
+
+(re-frame/reg-sub
+ :activity-center/notifications-unread
+ (fn [db]
+   (get-in db [:activity-center :notifications-unread :data])))
+
+(re-frame/reg-sub
+ :activity-center/current-status-filter
+ (fn [db]
+   (get-in db [:activity-center :current-status-filter])))
+
+(re-frame/reg-sub
+ :activity-center/notifications-per-read-status
+ :<- [:activity-center/notifications-read]
+ :<- [:activity-center/notifications-unread]
+ :<- [:activity-center/current-status-filter]
+ (fn [[notifications-read notifications-unread status-filter]]
+   (if (= status-filter :unread)
+     notifications-unread
+     notifications-read)))
+
 (defn- group-notifications-by-date
   [notifications]
   (->> notifications

--- a/src/status_im/ui/screens/activity_center/views.cljs
+++ b/src/status_im/ui/screens/activity_center/views.cljs
@@ -32,12 +32,12 @@
     [rn/flat-list {:style          {:padding-horizontal 8}
                    :data           notifications
                    :key-fn         :id
-                   :on-end-reached #(>evt [:activity-center/notifications:fetch-next-page])
+                   :on-end-reached #(>evt [:activity-center/notifications-fetch-next-page])
                    :render-fn      render-notification}]))
 
 (defn activity-center []
   (reagent/create-class
-   {:component-did-mount #(>evt [:activity-center/notifications:fetch-first-page {:status-filter :unread}])
+   {:component-did-mount #(>evt [:activity-center/notifications-fetch-first-page {:status-filter :unread}])
     :reagent-render
     (fn []
       [:<>
@@ -45,8 +45,8 @@
                        :title      (i18n/label :t/activity)}]
        ;; TODO(ilmotta): Temporary solution to switch between read/unread
        ;; notifications while the Design team works on the mockups.
-       [button/button {:on-press #(>evt [:activity-center/notifications:fetch-first-page {:status-filter :unread}])}
+       [button/button {:on-press #(>evt [:activity-center/notifications-fetch-first-page {:status-filter :unread}])}
         "Unread"]
-       [button/button {:on-press #(>evt [:activity-center/notifications:fetch-first-page {:status-filter :read}])}
+       [button/button {:on-press #(>evt [:activity-center/notifications-fetch-first-page {:status-filter :read}])}
         "Read"]
        [notifications-list]])}))

--- a/src/status_im/ui/screens/activity_center/views.cljs
+++ b/src/status_im/ui/screens/activity_center/views.cljs
@@ -37,8 +37,7 @@
 
 (defn activity-center []
   (reagent/create-class
-   {:display-name        "activity-center"
-    :component-did-mount #(>evt [:activity-center/notifications:fetch-first-page {:status-filter :unread}])
+   {:component-did-mount #(>evt [:activity-center/notifications:fetch-first-page {:status-filter :unread}])
     :reagent-render
     (fn []
       [:<>

--- a/src/status_im/ui/screens/activity_center/views.cljs
+++ b/src/status_im/ui/screens/activity_center/views.cljs
@@ -35,7 +35,7 @@
                    :on-end-reached #(>evt [:activity-center/notifications:fetch-next-page])
                    :render-fn      render-notification}]))
 
-(defn center []
+(defn activity-center []
   (reagent/create-class
    {:display-name        "activity-center"
     :component-did-mount #(>evt [:activity-center/notifications:fetch-first-page {:status-filter :unread}])

--- a/src/status_im/ui/screens/activity_center/views.cljs
+++ b/src/status_im/ui/screens/activity_center/views.cljs
@@ -1,0 +1,53 @@
+(ns status-im.ui.screens.activity-center.views
+  (:require [quo.react-native :as rn]
+            [quo2.components.buttons.button :as button]
+            [quo2.components.notifications.activity-logs :as activity-logs]
+            [quo2.components.tags.context-tags :as context-tags]
+            [quo2.foundations.colors :as colors]
+            [reagent.core :as reagent]
+            [status-im.i18n.i18n :as i18n]
+            [status-im.ui.components.topbar :as topbar]
+            [status-im.utils.handlers :refer [<sub >evt]]))
+
+(defn render-notification
+  [notification index]
+  [rn/view {:flex           1
+            :flex-direction :column
+            :margin-top     (if (= 0 index) 0 4)}
+   [activity-logs/activity-log {:context   [[context-tags/group-avatar-tag "Name" {:color          :purple
+                                                                                   :override-theme :dark
+                                                                                   :size           :small
+                                                                                   :style          {:background-color colors/white-opa-10}
+                                                                                   :text-style     {:color colors/white}}]
+                                            [rn/text {:style {:color colors/white}} "did something here."]]
+                                :icon      :placeholder
+                                :message   {:body (get-in notification [:message :content :text])}
+                                :timestamp (:timestamp notification)
+                                :title     "Activity Title"
+                                :unread?   (not (:read notification))}]])
+
+(defn notifications-list
+  []
+  (let [notifications (<sub [:activity-center/notifications-per-read-status])]
+    [rn/flat-list {:style          {:padding-horizontal 8}
+                   :data           notifications
+                   :key-fn         :id
+                   :on-end-reached #(>evt [:activity-center/notifications:fetch-next-page])
+                   :render-fn      render-notification}]))
+
+(defn center []
+  (reagent/create-class
+   {:display-name        "activity-center"
+    :component-did-mount #(>evt [:activity-center/notifications:fetch-first-page {:status-filter :unread}])
+    :reagent-render
+    (fn []
+      [:<>
+       [topbar/topbar {:navigation {:on-press #(>evt [:navigate-back])}
+                       :title      (i18n/label :t/activity)}]
+       ;; TODO(ilmotta): Temporary solution to switch between read/unread
+       ;; notifications while the Design team works on the mockups.
+       [button/button {:on-press #(>evt [:activity-center/notifications:fetch-first-page {:status-filter :unread}])}
+        "Unread"]
+       [button/button {:on-press #(>evt [:activity-center/notifications:fetch-first-page {:status-filter :read}])}
+        "Read"]
+       [notifications-list]])}))

--- a/src/status_im/ui/screens/screens.cljs
+++ b/src/status_im/ui/screens/screens.cljs
@@ -135,7 +135,7 @@
 (defn screens []
   (concat [;;INTRO, ONBOARDING, LOGIN
 
-           ;Multiaccounts
+                                        ;Multiaccounts
            {:name          :multiaccounts
             :insets        {:bottom true}
             :options       {:topBar {:title        {:text (i18n/label :t/your-keys)}
@@ -143,7 +143,7 @@
             :right-handler multiaccounts/topbar-button
             :component     multiaccounts/multiaccounts}
 
-           ;Login
+                                        ;Login
            {:name          :login
             :insets        {:bottom true}
             :options       {:topBar {:rightButtons (right-button-options :login :more)}}
@@ -153,17 +153,17 @@
            {:name      :progress
             :component progress/progress}
 
-           ;[Onboarding]
+                                        ;[Onboarding]
            {:name      :intro
             :insets    {:bottom true}
             :component onboarding.intro/intro}
 
-           ;[Onboarding]
+                                        ;[Onboarding]
            {:name      :get-your-keys
             :insets    {:bottom true}
             :component onboarding.keys/get-your-keys}
 
-           ;[Onboarding]
+                                        ;[Onboarding]
            {:name      :choose-name
             :options   {:topBar             {:visible false}
                         :popGesture         false
@@ -172,7 +172,7 @@
             :insets    {:bottom true}
             :component onboarding.keys/choose-a-chat-name}
 
-           ;[Onboarding]
+                                        ;[Onboarding]
            {:name      :select-key-storage
             :insets    {:bottom true}
             :options   {:popGesture         false
@@ -180,7 +180,7 @@
                                              :popStackOnPress     false}}
             :component onboarding.storage/select-key-storage}
 
-           ;[Onboarding] Create Password
+                                        ;[Onboarding] Create Password
            {:name      :create-password
             :options   {:popGesture         false
                         :hardwareBackButton {:dismissModalOnPress false
@@ -188,7 +188,7 @@
             :insets    {:bottom true}
             :component onboarding.password/screen}
 
-           ;[Onboarding] Welcome
+                                        ;[Onboarding] Welcome
            {:name      :welcome
             :options   {:popGesture         false
                         :hardwareBackButton {:dismissModalOnPress false
@@ -196,7 +196,7 @@
             :insets    {:bottom true}
             :component onboarding.welcome/welcome}
 
-           ;[Onboarding] Notification
+                                        ;[Onboarding] Notification
            {:name      :onboarding-notification
             :options   {:popGesture         false
                         :hardwareBackButton {:dismissModalOnPress false
@@ -204,7 +204,7 @@
             :insets    {:bottom true}
             :component onboarding.notifications/notifications-onboarding}
 
-           ;[Onboarding] Recovery
+                                        ;[Onboarding] Recovery
            {:name      :recover-multiaccount-enter-phrase
             :insets    {:bottom true}
             :component onboarding.phrase/enter-phrase}
@@ -217,11 +217,11 @@
 
            ;;CHAT
 
-           ;Home
+                                        ;Home
            {:name      :home
             :component home/home-old}
 
-           ;Chat
+                                        ;Chat
            {:name          :chat
             :options       {:popGesture false
                             :hardwareBackButton {:dismissModalOnPress false
@@ -229,7 +229,7 @@
                             :topBar             {:visible false}}
             :component     chat/chat-old}
 
-           ;Pinned messages
+                                        ;Pinned messages
            {:name      :chat-pinned-messages
                                         ;TODO custom subtitle
             :options   {:topBar {:visible false}}
@@ -258,7 +258,7 @@
             :component notifications-center/center}
            {:name      :activity-center
             :options   {:topBar {:visible false}}
-            :component activity-center/center}
+            :component activity-center/activity-center}
            ;; Community
            {:name      :community
             ;;TODO custom
@@ -594,38 +594,38 @@
 
            ;;MODALS
 
-           ;[Chat] New Chat
+                                        ;[Chat] New Chat
            {:name      :new-chat
             :on-focus  [::new-chat.events/new-chat-focus]
             ;;TODO accessories
             :options   {:topBar {:visible false}}
             :component new-chat/new-chat}
 
-           ;[Chat] New Public chat
+                                        ;[Chat] New Public chat
            {:name      :new-public-chat
             :insets    {:bottom true}
             :options   {:topBar {:title {:text (i18n/label :t/new-public-group-chat)}}}
             :component new-public-chat/new-public-chat}
 
-           ;[Chat] Link preview settings
+                                        ;[Chat] Link preview settings
            {:name      :link-preview-settings
             :options   {:topBar {:title {:text (i18n/label :t/chat-link-previews)}}}
             :component link-previews-settings/link-previews-settings}
 
-           ;[Chat] Edit nickname
+                                        ;[Chat] Edit nickname
            {:name      :nickname
             :insets    {:bottom true}
             ;;TODO dyn subtitle
             :options   {:topBar {:visible false}}
             :component contact/nickname}
 
-           ;[Group chat] Edit group chat name
+                                        ;[Group chat] Edit group chat name
            {:name      :edit-group-chat-name
             :insets    {:bottom true}
             :options   {:topBar {:title {:text (i18n/label :t/edit-group)}}}
             :component group-chat/edit-group-chat-name}
 
-           ;[Group chat] Add participants
+                                        ;[Group chat] Add participants
            {:name      :add-participants-toggle-list
             :on-focus  [:group/add-participants-toggle-list]
             :insets    {:bottom true}
@@ -633,34 +633,34 @@
             :options   {:topBar {:visible false}}
             :component group-chat/add-participants-toggle-list}
 
-           ;[Communities] Invite people
+                                        ;[Communities] Invite people
            {:name      :invite-people-community
             ;;TODO dyn title
             :options   {:topBar {:visible false}}
             :component communities.invite/invite
             :insets    {:bottom true}}
 
-           ;New Contact
+                                        ;New Contact
            {:name      :new-contact
             :on-focus  [::new-chat.events/new-chat-focus]
             ;;TODO accessories
             :options   {:topBar {:visible false}}
             :component new-chat/new-contact}
 
-           ;[Wallet] Recipient
+                                        ;[Wallet] Recipient
            {:name      :recipient
             :insets    {:bottom true}
             ;;TODO accessories
             :options   {:topBar {:visible false}}
             :component recipient/recipient}
 
-           ;[Wallet] New favourite
+                                        ;[Wallet] New favourite
            {:name      :new-favourite
             :insets    {:bottom true}
             :options   {:topBar {:title {:text (i18n/label :t/new-favourite)}}}
             :component recipient/new-favourite}
 
-           ;QR Scanner
+                                        ;QR Scanner
            {:name      :qr-scanner
             :insets    {:top false :bottom false}
             ;;TODO custom topbar
@@ -671,7 +671,7 @@
             :component qr-scanner/qr-scanner}
 
            ;;TODO WHY MODAL?
-           ;[Profile] Notifications settings
+                                        ;[Profile] Notifications settings
            {:name      :notifications-settings
             :options   {:topBar             {:title {:text (i18n/label :t/notification-settings)}}
                         :popGesture         false
@@ -681,7 +681,7 @@
             :component notifications-settings/notifications-settings}
 
            ;;TODO WHY MODAL?
-           ;[Profile] Notifications Advanced settings
+                                        ;[Profile] Notifications Advanced settings
            {:name      :notifications-advanced-settings
             :options   {:topBar             {:title {:text (i18n/label :t/notification-settings)}}
                         :popGesture         false
@@ -690,7 +690,7 @@
             :insets    {:bottom true}
             :component notifications-settings/notifications-advanced-settings}
 
-           ;[Wallet] Prepare Transaction
+                                        ;[Wallet] Prepare Transaction
            {:name        :prepare-send-transaction
             :insets      {:bottom true}
             :on-dissmiss [:wallet/cancel-transaction-command]
@@ -699,7 +699,7 @@
                           :hardwareBackButton {:dismissModalOnPress false}}
             :component   wallet.send/prepare-send-transaction}
 
-           ;[Wallet] Request Transaction
+                                        ;[Wallet] Request Transaction
            {:name        :request-transaction
             :insets      {:bottom true}
             :on-dissmiss [:wallet/cancel-transaction-command]
@@ -708,12 +708,12 @@
                           :hardwareBackButton {:dismissModalOnPress false}}
             :component   wallet.send/request-transaction}
 
-           ;[Wallet] Buy crypto
+                                        ;[Wallet] Buy crypto
            {:name      :buy-crypto
             :insets    {:bottom true}
             :component wallet.buy-crypto/container}
 
-           ;[Wallet] Buy crypto website
+                                        ;[Wallet] Buy crypto website
            {:name      :buy-crypto-website
             :insets    {:bottom true}
             ;;TODO subtitle
@@ -726,27 +726,27 @@
             :options   {:topBar {:visible false}}
             :component wallet.collectibles/nft-details-modal}
 
-           ;My Status
+                                        ;My Status
            {:name      :my-status
             :insets    {:bottom true}
             :options   {:topBar {:title {:text (i18n/label :t/my-status)}}}
             :component status.new/my-status}
 
-           ;[Browser] New bookmark
+                                        ;[Browser] New bookmark
            {:name      :new-bookmark
             :insets    {:bottom true}
             ;;TODO dynamic title
             :options   {:topBar {:visible false}}
             :component bookmarks/new-bookmark}
 
-           ;Profile
+                                        ;Profile
            {:name      :profile
             :insets    {:bottom true}
             ;;TODO custom toolbar
             :options   {:topBar {:visible false}}
             :component contact/profile}
 
-           ;KEYCARD
+                                        ;KEYCARD
            {:name         :keycard-onboarding-intro
             :insets       {:bottom true}
             :back-handler keycard.core/onboarding-intro-back-handler

--- a/src/status_im/ui/screens/screens.cljs
+++ b/src/status_im/ui/screens/screens.cljs
@@ -80,6 +80,7 @@
             [status-im.ui.screens.network.network-details.views :as network-details]
             [status-im.ui.screens.network.views :as network]
             [status-im.ui.screens.notifications-center.views :as notifications-center]
+            [status-im.ui.screens.activity-center.views :as activity-center]
             [status-im.ui.screens.notifications-settings.views :as notifications-settings]
             [status-im.ui.screens.offline-messaging-settings.edit-mailserver.views
              :as
@@ -255,6 +256,9 @@
             ;;TODO custom nav
             :options   {:topBar {:visible false}}
             :component notifications-center/center}
+           {:name      :activity-center
+            :options   {:topBar {:visible false}}
+            :component activity-center/center}
            ;; Community
            {:name      :community
             ;;TODO custom


### PR DESCRIPTION
fixes #13895
Related to #13967  

### Summary

Create new Activity Center screen, roughly displaying read or unread notifications.

<table>
  <thead>
    <tr>
      <th>
        <img alt="Screenshot" src="https://user-images.githubusercontent.com/46027/189742659-db9c30e2-cb04-4238-a707-d98f7ea0a161.png" width="300"/>
        <p><strong>Unread notifications</strong></p>
      </th>
      <th>
        <img alt="Screenshot" src="https://user-images.githubusercontent.com/46027/189742755-675013ba-b594-4819-ae97-b4ac2277b235.png" width="300"/>
        <p><strong>Read notifications</strong></p>
      </th>
    </tr>
  </thead>
</table>

### Review notes

This PR should not affect production code. If you find anything, please let me know.

The design and app behavior in this PR should not be considered final, quite the contrary. Its goal is to **do the basic plumbing and reduce the amount of code to be reviewed in follow-up PRs**. Examples of things that will soon be addressed:

- The Design team is still working out how to better display read/unread notifications. They will probably be displayed as clickable filters, so in this PR I implemented something ugly, but which resembles the functionality.
- The activity logs have hardcoded and unformatted data.

For now, the Activity Center issues are being tracked with the label https://github.com/status-im/status-mobile/labels/Activity%20center.

### Testing notes

I decided to keep the new screen inaccessible from the UI, given how crude and non-functional it still is. Nonetheless, if you'd like to test it, you'll need to checkout the Status Go draft branch [activity-center-read-unread](https://github.com/status-im/status-go/tree/feature/activity-center-read-unread).

Remember to run `export STATUS_GO_SRC_OVERRIDE=$HOME/<path-to-your-status-go-repo>` before running targets such as `make run-android`.

Also apply the following diff to status-mobile:

```diff
modified   src/status_im/ui/screens/home/views.cljs
@@ -270,7 +270,7 @@
                           :accessibility-label :notifications-button
                           :on-press #(do
                                        (re-frame/dispatch [:mark-all-activity-center-notifications-as-read])
-                                       (re-frame/dispatch [:navigate-to :notifications-center]))}
+                                       (re-frame/dispatch [:navigate-to :activity-center]))}
       [icons/icon :main-icons/notification2 {:color (quo2.colors/theme-colors quo2.colors/black quo2.colors/white)}]]
      (when (pos? notif-count)
        [react/view {:style (merge (styles/counter-public-container) {:top 5 :right 5})
```

#### Platforms

- Android
- iOS

status: ready
