### PR TITLE
feat: delete for me logic without UI

### DIFF
--- a/src/status_im/chat/models/delete_message_for_me.cljs
+++ b/src/status_im/chat/models/delete_message_for_me.cljs
@@ -1,0 +1,68 @@
+(ns status-im.chat.models.delete-message-for-me
+  (:require [re-frame.core :as re-frame]
+            [status-im.ethereum.json-rpc :as json-rpc]
+            [status-im.utils.datetime :as datetime]
+            [status-im.utils.fx :as fx]
+            [taoensso.timbre :as log]))
+
+(defn- update-db-clear-undo-timer
+  [db chat-id message-id]
+  (when (get-in db [:messages chat-id message-id])
+    (update-in db
+               [:messages chat-id message-id]
+               dissoc
+               :deleted-for-me-undoable-till)))
+
+(defn- update-db-delete-locally
+  "Delete message for me in re-frame db and set the undo timelimit"
+  [db chat-id message-id undo-time-limit-ms]
+  (when (get-in db [:messages chat-id message-id])
+    (update-in db
+               [:messages chat-id message-id]
+               assoc
+               :deleted-for-me? true
+               :deleted-for-me-undoable-till (+ (datetime/timestamp)
+                                                undo-time-limit-ms))))
+
+(defn- update-db-undo-locally
+  "Restore deleted-for-me message if called within timelimit"
+  [db chat-id message-id]
+  (let [{:keys [deleted-for-me? deleted-for-me-undoable-till]}
+        (get-in db [:messages chat-id message-id])]
+    (if (and deleted-for-me?
+             (> deleted-for-me-undoable-till (datetime/timestamp)))
+      (update-in db
+                 [:messages chat-id message-id]
+                 dissoc
+                 :deleted-for-me?
+                 :deleted-for-me-undoable-till)
+      (update-db-clear-undo-timer db chat-id message-id))))
+
+(fx/defn delete
+  "Delete message for me now locally and broadcast after undo time limit timeout"
+  {:events [:chat.ui/delete-message-for-me]}
+  [{:keys [db]} {:keys [chat-id message-id]} undo-time-limit-ms]
+  (when (get-in db [:messages chat-id message-id])
+    {:db (update-db-delete-locally db chat-id message-id undo-time-limit-ms)
+     :utils/dispatch-later [{:dispatch [:chat.ui/delete-message-for-me-and-sync
+                                        {:chat-id    chat-id
+                                         :message-id message-id}]
+                             :ms       undo-time-limit-ms}]}))
+
+(fx/defn undo
+  {:events [:chat.ui/undo-delete-message-for-me]}
+  [{:keys [db]} {:keys [chat-id message-id]}]
+  (when (get-in db [:messages chat-id message-id])
+    {:db (update-db-undo-locally db chat-id message-id)}))
+
+(fx/defn delete-and-sync
+  {:events [:chat.ui/delete-message-for-me-and-sync]}
+  [{:keys [db]} {:keys [message-id chat-id]}]
+  (when (get-in db [:messages chat-id message-id])
+    {:db             (update-db-clear-undo-timer db chat-id message-id)
+     ::json-rpc/call [{:method      "wakuext_deleteMessageForMeAndSync"
+                       :params      [chat-id message-id]
+                       :js-response true
+                       :on-error    #(log/error "failed to delete message for me " %)
+                       :on-success  #(re-frame/dispatch [:sanitize-messages-and-process-response
+                                                         %])}]}))

--- a/src/status_im/chat/models/delete_message_for_me_test.cljs
+++ b/src/status_im/chat/models/delete_message_for_me_test.cljs
@@ -1,0 +1,113 @@
+(ns status-im.chat.models.delete-message-for-me-test
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [status-im.chat.models.delete-message-for-me :as
+             delete-message-for-me]
+            [status-im.utils.datetime :as datetime]))
+
+(defonce mid "message-id")
+(defonce cid "chat-id")
+
+(deftest delete-for-me
+  (let [db      {:messages {cid {mid {:id mid}}}}
+        message {:message-id mid :chat-id cid}]
+    (testing "delete for me"
+      (let [expected {:db {:messages {"chat-id" {"message-id"
+                                                 {:id "message-id"
+                                                  :deleted-for-me? true
+                                                  :deleted-for-me-undoable-till
+                                                  (+ (datetime/timestamp)
+                                                     1000)}}}}
+                      :utils/dispatch-later
+                      [{:dispatch [:chat.ui/delete-message-for-me-and-sync
+                                   {:chat-id "chat-id" :message-id "message-id"}]
+                        :ms       1000}]}]
+        (is (= (delete-message-for-me/delete {:db db} message 1000) expected))))
+    (testing "should return nil if message in db"
+      (is (= (delete-message-for-me/delete {:db {:messages []}} message 1000)
+             nil)))))
+
+(deftest undo-delete-for-me
+  (let [db      {:messages {cid {mid {:id mid}}}}
+        message {:message-id mid :chat-id cid}]
+    (testing "undo delete for me in time"
+      (let [db       (update-in db
+                                [:messages cid mid]
+                                assoc
+                                :deleted-for-me? true
+                                :deleted-for-me-undoable-till
+                                (+ (datetime/timestamp) 1000))
+
+            expected {:db {:messages {"chat-id" {"message-id"
+                                                 {:id "message-id"}}}}}]
+        (is (= (delete-message-for-me/undo {:db db} message) expected))))
+    (testing "remain deleted for me when undo delete for me late"
+      (let [db       (update-in db
+                                [:messages cid mid]
+                                assoc
+                                :deleted-for-me? true
+                                :deleted-for-me-undoable-till
+                                (- (datetime/timestamp) 1000))
+
+            expected {:db {:messages {"chat-id" {"message-id" {:id "message-id"
+                                                               :deleted-for-me?
+                                                               true}}}}}]
+        (is (= (delete-message-for-me/undo {:db db} message) expected))))
+    (testing "remain deleted for me when undo delete for me late"
+      (let [db       (update-in db
+                                [:messages cid mid]
+                                assoc
+                                :deleted-for-me? true
+                                :deleted-for-me-undoable-till
+                                (- (datetime/timestamp) 1000))
+
+            expected {:db {:messages {"chat-id" {"message-id" {:id "message-id"
+                                                               :deleted-for-me?
+                                                               true}}}}}]
+        (is (= (delete-message-for-me/undo {:db db} message) expected))))
+    (testing "should return nil if message in db"
+      (is (= (delete-message-for-me/undo {:db {:messages []}} message)
+             nil)))))
+
+(deftest delete-for-me-and-sync
+  (let [db      {:messages {cid {mid {:id mid}}}}
+        message {:message-id mid :chat-id cid}]
+    (testing "delete for me and sync"
+      (let [expected-db {:messages {"chat-id" {"message-id" {:id "message-id"}}}}
+            effects     (delete-message-for-me/delete-and-sync {:db db} message)
+            result-db   (:db effects)
+            rpc-calls   (:status-im.ethereum.json-rpc/call effects)]
+        (is (= result-db expected-db))
+        (is (= (count rpc-calls) 1))
+        (is (= (-> rpc-calls
+                   first
+                   :method)
+               "wakuext_deleteMessageForMeAndSync"))
+        (is (= (-> rpc-calls
+                   first
+                   :params
+                   count)
+               2))
+        (is (= (-> rpc-calls
+                   first
+                   :params
+                   first)
+               cid))
+        (is (= (-> rpc-calls
+                   first
+                   :params
+                   second)
+               mid))))
+    (testing "delete for me and sync, should clean undo timer"
+      (let [expected-db {:messages {"chat-id" {"message-id" {:id "message-id"}}}}
+            effects     (delete-message-for-me/delete-and-sync
+                         {:db (update-in db
+                                         [:messages cid mid
+                                          :deleted-for-me-undoable-till]
+                                         (constantly (datetime/timestamp)))}
+                         message)
+            result-db   (:db effects)]
+        (is (= result-db expected-db))))
+    (testing "should return nil if message in db"
+      (is (= (delete-message-for-me/delete-and-sync {:db {:messages []}}
+                                                    message)
+             nil)))))

--- a/src/status_im/data_store/messages.cljs
+++ b/src/status_im/data_store/messages.cljs
@@ -31,6 +31,7 @@
                                 :quotedMessage :quoted-message
                                 :outgoingStatus :outgoing-status
                                 :audioDurationMs :audio-duration-ms
+                                :deletedForMe :deleted-for-me?
                                 :new :new?})
 
       (update :quoted-message clojure.set/rename-keys {:parsedText :parsed-text :communityId :community-id})

--- a/src/status_im/utils/config.cljs
+++ b/src/status_im/utils/config.cljs
@@ -182,3 +182,5 @@
 ;; usable enough to replace the old one **in the new UI**.
 (def new-activity-center-enabled?
   (atom false))
+
+(def delete-message-for-me-undo-time-limit-ms 4000)

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.110.3",
-    "commit-sha1": "506921509e477445a95e1961a2557ef584d7caec",
-    "src-sha256": "1xmngbfl67n031rxhhbs7m14gzmfhgr1d34szclf1a6qxb9kw946"
+    "version": "f47cb8572de921fb4cff5d0f8d87b7b92386a226",
+    "commit-sha1": "f47cb8572de921fb4cff5d0f8d87b7b92386a226",
+    "src-sha256": "0wbiwq6dh531crqsij836bdkggn8f1z9f121aqpyxwdgp1njzxjk"
 }

--- a/translations/en.json
+++ b/translations/en.json
@@ -418,6 +418,7 @@
     "delete-chat-confirmation": "Are you sure you want to delete this chat?",
     "delete-category-confirmation": "Are you sure you want to delete this category?",
     "delete-confirmation": "Delete?",
+    "delete-for-me": "Delete for me",
     "delete-mailserver": "Delete Status node",
     "delete-mailserver-are-you-sure": "Are you sure you want to delete this Status node?",
     "delete-mailserver-title": "Delete Status node",


### PR DESCRIPTION
related #13873

- [x] menu UI (will implement in a seperate PR)
- [ ] deleted message UI (will implement in a seperate PR)
- [ ] deleted for me notification with undo UI (will implement in a seperate PR)
- [x] delete/undo logic
- [x] status-go https://github.com/status-im/status-go/pull/2866 (version 0.111.1 already included in status-mobile)
- [x] temp UI indicating message deleted for me (deleted for me messages have a red border)

### Steps to test
- Open Status A with credential 1
- Open Status B with credential 1
- Open Status C with credential 2
- Pair A and B
- Switch A B C to the new UI
- Send message1 from 2 to 1
- (Press and hold message to get the `Delete for me` button)
- (Deleted for me message will have a red border around it)
- Delete message1 on A
	- message1 should be `deleted for me` on A, B but not C after 4+ seconds, showing
		- delete for me action has a 4 second (not the final number) delay before actually persist into db and synced to paired devices
		- delete for me can be applied to message send by others
		- delete for me only delete for **me**(for credential 1, which is status A and B)
		- delete for me message can be synced between paired devices

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready