### PR TITLE
fix: remove annoying deref in lazy seq warning

### DIFF
--- a/src/status_im/ui/screens/chat/message/reactions_picker.cljs
+++ b/src/status_im/ui/screens/chat/message/reactions_picker.cljs
@@ -1,14 +1,14 @@
 (ns status-im.ui.screens.chat.message.reactions-picker
   (:require [cljs-bean.core :as bean]
-            [status-im.ui.screens.chat.message.styles :as styles]
-            [status-im.ui.components.icons.icons :as icons]
-            [status-im.constants :as constants]
-            [reagent.core :as reagent]
-            [quo.react-native :as rn]
-            [quo.react :as react]
             [quo.animated :as animated]
             [quo.components.safe-area :as safe-area]
-            [quo.core :as quo]))
+            [quo.core :as quo]
+            [quo.react :as react]
+            [quo.react-native :as rn]
+            [reagent.core :as reagent]
+            [status-im.constants :as constants]
+            [status-im.ui.components.icons.icons :as icons]
+            [status-im.ui.screens.chat.message.styles :as styles]))
 
 (def tabbar-height 36)
 (def text-input-height 54)
@@ -44,18 +44,19 @@
                              :width  32}}]]]))]
    (when (seq actions)
      [rn/view {:style (styles/quick-actions-container)}
-      (for [action actions
-            :let   [{:keys [id label on-press]} (bean/bean action)]]
-        ^{:key id}
-        [rn/touchable-opacity {:on-press (fn []
-                                           (on-close)
-                                           (js/setTimeout on-press animation-duration))}
-         [rn/view {:style (styles/quick-actions-row)}
-          [quo/text {:color  (if (= id "delete") :negative :link)
-                     :weight :medium} label]
-          (when-let [icon (get id-icon id)]
-            [icons/icon icon
-             {:color (if (= id "delete") :red :blue)}])]])])])
+      (doall
+       (for [action actions
+             :let   [{:keys [id label on-press]} (bean/bean action)]]
+         ^{:key id}
+         [rn/touchable-opacity {:on-press (fn []
+                                            (on-close)
+                                            (js/setTimeout on-press animation-duration))}
+          [rn/view {:style (styles/quick-actions-row)}
+           [quo/text {:color  (if (= id "delete") :negative :link)
+                      :weight :medium} label]
+           (when-let [icon (get id-icon id)]
+             [icons/icon icon
+              {:color (if (= id "delete") :red :blue)}])]]))])])
 
 (def modal
   (reagent/adapt-react-class


### PR DESCRIPTION
the warning
```
[Mon Sep 19 2022 15:34:13.404]  WARN     Warning: Reactive deref not supported in lazy seq, it should be wrapped in doall: ([#object[reagent.impl.template.NativeWrapper] {:on-press #obje
ct[Function]} [#object[reagent.impl.template.NativeWrapper] {:style {:flex-direction :row, :padding-horizontal 16, :padding-vertical 12, :justify-content :space-between, :border-top-widt
h 1, :border-top-color "rgba(238,242,245,1)"}} [quo.components.text.text {:color :link, :weight :medium} "Reply"] [G__38721 :main-icons/reply {:color :blue}]]] [#object[reagent.impl.temp
late.NativeWrapper] {:on-press #object[Function]} [#object[reagent.impl.template.NativeWrapper] {:style {:flex-direction :row, :padding-horizontal 16, :padding-vertical 12, :justify-cont
ent :space-between, :border-top-width 1, :border-top-color "rgba(238,242,245,1)"}} [quo.components.text.text {:color :link, :weight :medium} "Copy"] [G__38721 :main-icons/copy {:color :b
lue}]]] [#object[reagent.impl.template.NativeWrapper] {:on-press #object[Function]} [#object[reagent.impl.template.NativeWrapper] {:style {:flex-direction :row, :padding-horizontal 16, :
padding-vertical 12, :justify-content :space-between, :border-top-width 1, :border-top-color "rgba(238,242,245,1)"}} [quo.components.text.text {:color :link, :weight :medium} "Pin"] [G__
38721 :main-icons/pin {:color :blue}]]] [#object[reagent.impl.template.NativeWrapper] {:on-press #object[Function]} [#object[reagent.impl.template.NativeWrapper] {:style {:flex-direction
 :row, :padding-horizontal 16, :padding-vertical 12, :justify-content :space-between, :border-top-width 1, :border-top-color "rgba(238,242,245,1)"}} [quo.components.text.text {:color :li
nk, :weight :medium} "Delete for me"] nil]])
 (in status_im.ui.screens.chat.message.reactions_picker.picker)
status_im.ui.screens.chat.message.reactions_picker.picker@
```
status: ready <!-- Can be ready or wip -->