### PR TITLE
Allow disabling Hermes engine by passing flag while building app

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -76,13 +76,22 @@ import com.sun.org.apache.xalan.internal.xsltc.compiler.Copy
  *   extraPackagerArgs: []
  * ]
  */
+
+/*
+ Enabling Hermes on x86 devices is crashing the app after a few reloads,
+ this flag can be used to disable Hermes while building app.
+ https://github.com/status-im/status-mobile/issues/14031
+ */
+
+def disableHermes = new Boolean(System.getenv('DISABLE_HERMES') ?: false)
+
 project.ext.react = [
     nodeExecutableAndArgs: ["node", "--max-old-space-size=16384"],
     entryFile: "index.js",
     /* NOTE: Hermes engine is required for Android 64-bit builds running on 64 devices,
      *       to guard against a hang in the UI thread after invoking status-go.
      * Also a clean and rebuild is required when changing this. */
-    enableHermes: true,
+    enableHermes: !disableHermes,
     /* Disable 'The first definition was here.' warnings */
     hermesFlagsRelease: ["-w"],
     bundleInPr: true,

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -83,7 +83,7 @@ import com.sun.org.apache.xalan.internal.xsltc.compiler.Copy
  https://github.com/status-im/status-mobile/issues/14031
  */
 
-def disableHermes = new Boolean(System.getenv('DISABLE_HERMES') ?: false)
+def disableHermes = System.getenv('DISABLE_HERMES') == 'true'
 
 project.ext.react = [
     nodeExecutableAndArgs: ["node", "--max-old-space-size=16384"],

--- a/doc/TROUBLESHOOTING.md
+++ b/doc/TROUBLESHOOTING.md
@@ -97,3 +97,32 @@ System's local adb and Nix's adb differ. As adb include of server/client process
 Always use respective `make` commands, e.g. `make android-ports`, `make android-devices`, etc.
 
 Alternatively, run adb commands only from `make shell TARGET=android` shell. Don't forget the `TARGET=android` env var setting - otherwise `adb` will still be selected from the system's default location. You can double-check this by running `which adb`.
+
+# Hot Reloading Crashes
+## APP Crashes on reloading changes
+
+### Cause
+Status-mobile uses watchman for monitoring changes and uses its own [reloader](https://github.com/status-im/status-mobile/blob/develop/src/status_im/reloader.cljs) for updating the running app. If react-native's fast refresh is also enabled then it creates conflicts and crashes the app.
+
+### Solution
+Open react native's [In-App Developer Menu](https://reactnative.dev/docs/debugging#accessing-the-in-app-developer-menu) and press "Disable Fast Refresh" or "Disable Hot Reloading"
+
+## App Crashes after few reloads
+
+### Cause
+For x86 CPU architecture Android Devices, Hermes is creating the issue and the app crashes after a few reloads.
+([Original Issue](https://github.com/status-im/status-mobile/issues/14031))
+
+<details>
+  <summary>How to Find CPU architecture</summary>
+
+  CPU architecture of android device can be found using
+  - `adb shell uname -m` or
+  - `adb shell getprop ro.product.cpu.abilist`
+
+</details>
+
+### Solution
+Disable Hermes while building the app
+
+`make run-android DISABLE_HERMES=true`

--- a/doc/TROUBLESHOOTING.md
+++ b/doc/TROUBLESHOOTING.md
@@ -102,7 +102,7 @@ Alternatively, run adb commands only from `make shell TARGET=android` shell. Don
 ## APP Crashes on reloading changes
 
 ### Cause
-Status-mobile uses watchman for monitoring changes and uses its own [reloader](https://github.com/status-im/status-mobile/blob/develop/src/status_im/reloader.cljs) for updating the running app. If react-native's fast refresh is also enabled then it creates conflicts and crashes the app.
+Status-mobile uses `shadow-cljs` for hot reloading changes and uses its own [reloader](https://github.com/status-im/status-mobile/blob/develop/src/status_im/reloader.cljs) for updating them in the running app. If react-native's fast refresh is also enabled then it creates conflicts and crashes the app.
 
 ### Solution
 Open react native's [In-App Developer Menu](https://reactnative.dev/docs/debugging#accessing-the-in-app-developer-menu) and press "Disable Fast Refresh" or "Disable Hot Reloading"


### PR DESCRIPTION
fixes: https://github.com/status-im/status-mobile/issues/14031

### Summary
Hermes is introduced in https://github.com/status-im/status-mobile/pull/8943 PR for performance improvements and also to fix [app freezes](https://github.com/status-im/status-mobile/issues/8665) in arm64 android devices.
For arm64 devices it is working great, but for x86 devices it is crashing debug app after reloading it a few times. It is a probably library bug, but we can't upgrade to newer versions because it depends on the react-native version.

So this PR allows passing the flag `DISABLE_HERMES` for disabling Hermes while building the app for those devices.

### Testing
- apart from simple testing like printing groovy variables, I also checked the availability of Hermes using
```(.-HermesInternal ^js js/global)``` inside Clojure code. It returns `nil` when Hermes is disabled and `#js {}` when enabled.
- fix also tested by @ilmotta, ([ref](https://github.com/status-im/status-mobile/issues/14031#issuecomment-1252324850))

_**PS:** Beside 10 MB size difference, I didn't faced any performance issues even after disabling hermes_

status: ready