### PR TITLE
fix: switching to light / dark mode makes the app reset to the old ui when new ui toggle is activated

### DIFF
--- a/src/status_im/navigation2.cljs
+++ b/src/status_im/navigation2.cljs
@@ -16,6 +16,13 @@
    :dispatch                 [:init-root (if @config/new-ui-enabled? :home-stack :chat-stack)]
    ::async-storage/set!      {:new-ui-enabled? @config/new-ui-enabled?}})
 
+(fx/defn reload-new-ui
+  {:events [:reload-new-ui]}
+  [_]
+  (reloader/reload)
+  {:new-ui/reset-bottom-tabs nil
+   :dispatch                 [:init-root :home-stack]})
+
 (fx/defn init-root-nav2
   {:events [:init-root-nav2]}
   [_ root-id]

--- a/src/status_im/ui/screens/appearance/views.cljs
+++ b/src/status_im/ui/screens/appearance/views.cljs
@@ -5,13 +5,14 @@
             [status-im.react-native.resources :as resources]
             [quo.core :as quo]
             [quo.design-system.colors :as colors]
-            [status-im.i18n.i18n :as i18n]))
+            [status-im.i18n.i18n :as i18n]
+            [status-im.utils.config :as config]))
 
 (defn button [label icon theme selected?]
   [react/touchable-highlight
    {:on-press (fn []
                 (re-frame/dispatch [:multiaccounts.ui/appearance-switched theme])
-                (re-frame/dispatch [:init-root :chat-stack])
+                (re-frame/dispatch (if @config/new-ui-enabled? [:reload-new-ui] [:init-root :chat-stack]))
                 (re-frame/dispatch [:navigate-change-tab :profile])
                 (js/setTimeout #(re-frame/dispatch [:navigate-to :appearance]) 1000))}
    [react/view (merge {:align-items :center :padding 8 :border-radius 20}


### PR DESCRIPTION
### Summary

Currently, if the user activates the New UI and then changes the app appearance (dark mode to light mode or vice versa), the app changes the appearance but it resets to the old UI. This PR fixes this.

#### Platforms

- Android
- iOS

##### Functional

- settings

### Steps to test

- Open Status
- Go to Settings > Advanced
- Activate New UI toggle
- Go to Settings > Appearance
- Toggle appearance to dark mode or light mode
- Verify that the app is still on the New UI and the theme properly changes

status: ready