### PR TITLE
[#13965 #13966 #13969] Implement accept/decline/open chat for contact requests

### DIFF
--- a/src/quo2/components/notifications/activity_logs.cljs
+++ b/src/quo2/components/notifications/activity_logs.cljs
@@ -94,6 +94,7 @@
             :align-items :flex-start
             :flex        1}
    [status-tags/status-tag {:size   :small
+                            :label  (:label status)
                             :status status}]])
 
 (defn- activity-title

--- a/src/status_im/activity_center/core.cljs
+++ b/src/status_im/activity_center/core.cljs
@@ -5,6 +5,34 @@
             [status-im.utils.fx :as fx]
             [taoensso.timbre :as log]))
 
+;;;; Notification reconciliation
+
+(defn- update-notifications
+  [old new]
+  (let [ids-to-be-removed (->> new
+                               (filter #(or (:dismissed %) (:accepted %)))
+                               (map :id))
+        grouped-new       (apply dissoc (group-by :id new) ids-to-be-removed)
+        grouped-old       (apply dissoc (group-by :id old) ids-to-be-removed)]
+    (->> (merge grouped-old grouped-new)
+         vals
+         (map first))))
+
+(fx/defn notifications-reconcile
+  {:events [:activity-center.notifications/reconcile]}
+  [{:keys [db]} new-notifications]
+  (let [{read-new   true
+         unread-new false} (group-by :read new-notifications)
+        read-old           (get-in db [:activity-center :notifications-read :data])
+        unread-old         (get-in db [:activity-center :notifications-unread :data])]
+    {:db (-> db
+             (assoc-in [:activity-center :notifications-read :data]
+                       (update-notifications read-old read-new))
+             (assoc-in [:activity-center :notifications-unread :data]
+                       (update-notifications unread-old unread-new)))}))
+
+;;;; Notifications fetching and pagination
+
 (def notifications-per-page
   20)
 
@@ -29,11 +57,11 @@
     {:db             (assoc-in db [:activity-center notifications-group :loading?] true)
      ::json-rpc/call [{:method     (notifications-group->rpc-method notifications-group)
                        :params     [cursor notifications-per-page]
-                       :on-success #(re-frame/dispatch [:activity-center/notifications-fetch-success notifications-group %])
-                       :on-error   #(re-frame/dispatch [:activity-center/notifications-fetch-error notifications-group %])}]}))
+                       :on-success #(re-frame/dispatch [:activity-center.notifications/fetch-success notifications-group %])
+                       :on-error   #(re-frame/dispatch [:activity-center.notifications/fetch-error notifications-group %])}]}))
 
 (fx/defn notifications-fetch-first-page
-  {:events [:activity-center/notifications-fetch-first-page]}
+  {:events [:activity-center.notifications/fetch-first-page]}
   [{:keys [db] :as cofx} {:keys [status-filter] :or {status-filter :unread}}]
   (let [notifications-group (notifications-read-status->group status-filter)]
     (fx/merge cofx
@@ -44,7 +72,7 @@
               (notifications-fetch start-or-end-cursor notifications-group))))
 
 (fx/defn notifications-fetch-next-page
-  {:events [:activity-center/notifications-fetch-next-page]}
+  {:events [:activity-center.notifications/fetch-next-page]}
   [{:keys [db] :as cofx}]
   (let [status-filter       (get-in db [:activity-center :current-status-filter])
         notifications-group (notifications-read-status->group status-filter)
@@ -53,7 +81,7 @@
       (notifications-fetch cofx cursor notifications-group))))
 
 (fx/defn notifications-fetch-success
-  {:events [:activity-center/notifications-fetch-success]}
+  {:events [:activity-center.notifications/fetch-success]}
   [{:keys [db]} notifications-group {:keys [cursor notifications]}]
   {:db (-> db
            (update-in [:activity-center notifications-group] dissoc :loading?)
@@ -63,7 +91,7 @@
                       (map data-store.activities/<-rpc notifications)))})
 
 (fx/defn notifications-fetch-error
-  {:events [:activity-center/notifications-fetch-error]}
+  {:events [:activity-center.notifications/fetch-error]}
   [{:keys [db]} notifications-group error]
   (log/warn "Failed to load Activity Center notifications" error)
   {:db (update-in db [:activity-center notifications-group] dissoc :loading?)})

--- a/src/status_im/activity_center/core_test.cljs
+++ b/src/status_im/activity_center/core_test.cljs
@@ -1,0 +1,152 @@
+(ns status-im.activity-center.core-test
+  (:require [cljs.test :refer [deftest is testing]]
+            [day8.re-frame.test :as rf-test]
+            [re-frame.core :as rf]
+            [status-im.ethereum.json-rpc :as json-rpc]
+            [status-im.test-helpers :as h]
+            status-im.events))
+
+(defn setup []
+  (h/register-helper-events)
+  (rf/dispatch [:init/app-started]))
+
+(deftest notifications-reconcile-test
+  (testing "does nothing when there are no new notifications"
+    (rf-test/run-test-sync
+     (setup)
+     (let [read   [{:id "0x1" :read true}]
+           unread [{:id "0x4" :read false}]]
+       (rf/dispatch [:test/assoc-in [:activity-center :notifications-read :data] read])
+       (rf/dispatch [:test/assoc-in [:activity-center :notifications-unread :data] unread])
+
+       (rf/dispatch [:activity-center.notifications/reconcile nil])
+
+       (is (= read (get-in (h/db) [:activity-center :notifications-read :data])))
+       (is (= unread (get-in (h/db) [:activity-center :notifications-unread :data]))))))
+
+  (testing "removes dismissed or accepted notifications"
+    (rf-test/run-test-sync
+     (setup)
+     (rf/dispatch [:test/assoc-in [:activity-center :notifications-read :data]
+                   [{:id "0x1" :read true}
+                    {:id "0x2" :read true}
+                    {:id "0x3" :read true}]])
+     (rf/dispatch [:test/assoc-in [:activity-center :notifications-unread :data]
+                   [{:id "0x4" :read false}
+                    {:id "0x5" :read false}
+                    {:id "0x6" :read false}]])
+
+     (rf/dispatch [:activity-center.notifications/reconcile
+                   [{:id "0x1" :read true :dismissed true}
+                    {:id "0x3" :read true :accepted true}
+                    {:id "0x4" :read false :dismissed true}
+                    {:id "0x5" :read false :accepted true}]])
+
+     (is (= [{:id "0x2" :read true}]
+            (get-in (h/db) [:activity-center :notifications-read :data])))
+     (is (= [{:id "0x6" :read false}]
+            (get-in (h/db) [:activity-center :notifications-unread :data])))))
+
+  (testing "replaces old notifications with newly arrived ones"
+    (rf-test/run-test-sync
+     (setup)
+     (rf/dispatch [:test/assoc-in [:activity-center :notifications-read :data]
+                   [{:id "0x1" :read true}
+                    {:id "0x2" :read true}]])
+     (rf/dispatch [:test/assoc-in [:activity-center :notifications-unread :data]
+                   [{:id "0x3" :read false}
+                    {:id "0x4" :read false}]])
+
+     (rf/dispatch [:activity-center.notifications/reconcile
+                   [{:id "0x1" :read true :name "ABC"}
+                    {:id "0x3" :read false :name "XYZ"}]])
+
+     (is (= [{:id "0x1" :read true :name "ABC"}
+             {:id "0x2" :read true}]
+            (get-in (h/db) [:activity-center :notifications-read :data])))
+     (is (= [{:id "0x3" :read false :name "XYZ"}
+             {:id "0x4" :read false}]
+            (get-in (h/db) [:activity-center :notifications-unread :data]))))))
+
+(deftest notifications-fetch-test
+  (testing "fetches first page"
+    (rf-test/run-test-sync
+     (setup)
+     (let [spy-queue (atom [])]
+       (h/stub-fx-with-callbacks ::json-rpc/call
+                                 :on-success (constantly {:cursor        "10"
+                                                          :notifications [{:chatId "0x1"}]}))
+       (h/spy-fx spy-queue ::json-rpc/call)
+
+       (rf/dispatch [:activity-center.notifications/fetch-first-page])
+
+       (is (= :unread (get-in (h/db) [:activity-center :current-status-filter])))
+       (is (nil? (get-in (h/db) [:activity-center :notifications-unread :loading?])))
+       (is (= "10" (get-in (h/db) [:activity-center :notifications-unread :cursor])))
+       (is (= "" (get-in @spy-queue [0 :args 0 :params 0])))
+       (is (= [{:chat-id "0x1"}]
+              (->> (get-in (h/db) [:activity-center :notifications-unread :data])
+                   (map #(select-keys % [:chat-id]))))))))
+
+  (testing "does not fetch next page when pagination cursor reached the end"
+    (rf-test/run-test-sync
+     (setup)
+     (let [spy-queue (atom [])]
+       (h/spy-fx spy-queue ::json-rpc/call)
+       (rf/dispatch [:test/assoc-in [:activity-center :current-status-filter] :unread])
+       (rf/dispatch [:test/assoc-in [:activity-center :notifications-unread :cursor] ""])
+
+       (rf/dispatch [:activity-center.notifications/fetch-next-page])
+
+       (is (= [] @spy-queue)))))
+
+  (testing "fetches next page when pagination cursor is not empty"
+    (rf-test/run-test-sync
+     (setup)
+     (let [spy-queue (atom [])]
+       (h/stub-fx-with-callbacks ::json-rpc/call
+                                 :on-success (constantly {:cursor        ""
+                                                          :notifications [{:chatId "0x1"}]}))
+       (h/spy-fx spy-queue ::json-rpc/call)
+       (rf/dispatch [:test/assoc-in [:activity-center :current-status-filter] :unread])
+       (rf/dispatch [:test/assoc-in [:activity-center :notifications-unread :cursor] "10"])
+
+       (rf/dispatch [:activity-center.notifications/fetch-next-page])
+
+       (is (= "wakuext_unreadActivityCenterNotifications" (get-in @spy-queue [0 :args 0 :method])))
+       (is (= "10" (get-in @spy-queue [0 :args 0 :params 0])))
+       (is (= "" (get-in (h/db) [:activity-center :notifications-unread :cursor])))
+       (is (= [{:chat-id "0x1"}]
+              (->> (get-in (h/db) [:activity-center :notifications-unread :data])
+                   (map #(select-keys % [:chat-id]))))))))
+
+  (testing "does not fetch next page while it is still loading"
+    (rf-test/run-test-sync
+     (setup)
+     (let [spy-queue (atom [])]
+       (h/spy-fx spy-queue ::json-rpc/call)
+       (rf/dispatch [:test/assoc-in [:activity-center :current-status-filter] :read])
+       (rf/dispatch [:test/assoc-in [:activity-center :notifications-read :cursor] "10"])
+       (rf/dispatch [:test/assoc-in [:activity-center :notifications-read :loading?] true])
+
+       (rf/dispatch [:activity-center.notifications/fetch-next-page])
+
+       (is (= [] @spy-queue)))))
+
+  (testing "resets loading flag after an error"
+    (rf-test/run-test-sync
+     (setup)
+     (let [spy-queue (atom [])]
+       (h/stub-fx-with-callbacks ::json-rpc/call :on-error (constantly :fake-error))
+       (h/spy-event-fx spy-queue :activity-center.notifications/fetch-error)
+       (h/spy-fx spy-queue ::json-rpc/call)
+       (rf/dispatch [:test/assoc-in [:activity-center :current-status-filter] :unread])
+       (rf/dispatch [:test/assoc-in [:activity-center :notifications-unread :cursor] ""])
+
+       (rf/dispatch [:activity-center.notifications/fetch-first-page])
+
+       (is (nil? (get-in (h/db) [:activity-center :notifications-unread :loading?])))
+       (is (= [:activity-center.notifications/fetch-error
+               :notifications-unread
+               :fake-error]
+              (:args (last @spy-queue))))))))

--- a/src/status_im/test_helpers.cljs
+++ b/src/status_im/test_helpers.cljs
@@ -1,0 +1,87 @@
+(ns status-im.test-helpers
+  "Utilities for simplifying the process of writing tests and improving test
+  readability.
+
+  Avoid coupling this namespace with particularities of the Status' domain, thus
+  prefer to use it for more general purpose concepts, such as the re-frame event
+  layer."
+  (:require [re-frame.core :as rf]
+            [re-frame.registrar :as rf-registrar]
+            [re-frame.events :as rf-events]
+            [re-frame.db :as rf-db]))
+
+(defn db
+  "A simple wrapper to get the latest value from the app db."
+  []
+  @rf-db/app-db)
+
+(defn register-helper-events
+  "Register utility events for testing.
+
+  Note that re-frame-test removes such events if they're declared in the scope
+  of the macro `day8.re-frame.test/run-test-sync` (or the async variant)."
+  []
+  (rf/reg-event-db
+   :test/assoc-in
+   (fn [db [_ keys value]]
+     (assoc-in db keys value))))
+
+(defn spy-event-fx
+  "Re-register event effect using id `id`, but conj to `state` the event
+  arguments before calling the original handler.
+
+  Callers of this function can later on deref `state` to make assertions.
+
+  It's recommended to run this function in the scope of the macro
+  `day8.re-frame.test/run-test-sync` (or the async variant) as they
+  automatically clean up effects."
+  [state id]
+  (let [interceptors (get-in @rf-registrar/kind->id->handler [:event id])]
+    (rf-events/register
+     id
+     (concat (butlast interceptors)
+             (list {:id     :test/spy-event-fx
+                    :before (fn [context]
+                              (swap! state conj {:id id :args (get-in context [:coeffects :event])})
+                              context)}
+                   (last interceptors))))))
+
+(defn spy-fx
+  "Re-register effect using id `id`, but conj to `state` the effect arguments
+  before calling the original effect handler.
+
+  Callers of this function can later on inspect `state` to make assertions.
+
+  It's recommended to run this function in the scope of the macro
+  `day8.re-frame.test/run-test-sync` (or the async variant) as they
+  automatically clean up effects."
+  [state id]
+  (let [original-fn (get-in @rf-registrar/kind->id->handler [:fx id])]
+    (rf/reg-fx
+     id
+     (fn [fx-args]
+       (swap! state conj {:id id :args fx-args})
+       (original-fn fx-args)))))
+
+(defn stub-fx-with-callbacks
+  "Re-register effect using id `id` with a no-op version.
+
+  This function is useful to redefine effects that expect callbacks, usually to
+  pass downstream dummy data to successful/failure events. In re-frame parlance,
+  such effects accept on-success and on-error keywords.
+
+  The original effect handler for `id` is expected to receive a single map as
+  argument with either :on-success or :on-error keywords.
+
+  This function expects to receive either `on-success` or `on-error`, but not
+  both. If both are passed, `on-error` will be preferred."
+  [id & {:keys [on-success on-error]}]
+  (rf/reg-fx
+   id
+   (fn [[fx-map]]
+     (let [original-on-error   (:on-error fx-map)
+           original-on-success (:on-success fx-map)]
+       (cond (and original-on-error on-error)
+             (original-on-error (on-error fx-map))
+             (and original-on-success on-success)
+             (original-on-success (on-success fx-map)))))))

--- a/src/status_im/ui/components/topnav.cljs
+++ b/src/status_im/ui/components/topnav.cljs
@@ -1,12 +1,12 @@
 (ns status-im.ui.components.topnav
-  (:require
-   [re-frame.core :as re-frame]
-   [quo2.components.buttons.button :as quo2.button]
-   [status-im.qr-scanner.core :as qr-scanner]
-   [status-im.utils.handlers :refer [<sub]]
-   [status-im.i18n.i18n :as i18n]
-   [status-im.ui.screens.home.styles :as styles]
-   [status-im.ui.components.react :as react]))
+  (:require [quo2.components.buttons.button :as quo2.button]
+            [re-frame.core :as re-frame]
+            [status-im.i18n.i18n :as i18n]
+            [status-im.qr-scanner.core :as qr-scanner]
+            [status-im.ui.components.react :as react]
+            [status-im.ui.screens.home.styles :as styles]
+            [status-im.utils.config :as config]
+            [status-im.utils.handlers :refer [<sub]]))
 
 (defn qr-scanner []
   [quo2.button/button
@@ -39,7 +39,9 @@
                           :accessibility-label :notifications-button
                           :on-press #(do
                                        (re-frame/dispatch [:mark-all-activity-center-notifications-as-read])
-                                       (re-frame/dispatch [:navigate-to :notifications-center]))}
+                                       (if (and @config/new-ui-enabled? @config/new-activity-center-enabled?)
+                                         (re-frame/dispatch [:navigate-to :activity-center])
+                                         (re-frame/dispatch [:navigate-to :notifications-center])))}
       :main-icons2/notifications]
      (when (pos? notif-count)
        [react/view {:style (merge (styles/counter-public-container) {:top 5 :right 5})

--- a/src/status_im/ui/screens/home/views.cljs
+++ b/src/status_im/ui/screens/home/views.cljs
@@ -274,7 +274,9 @@
                           :accessibility-label :notifications-button
                           :on-press #(do
                                        (re-frame/dispatch [:mark-all-activity-center-notifications-as-read])
-                                       (re-frame/dispatch [:navigate-to :notifications-center]))}
+                                       (if (and @config/new-ui-enabled? @config/new-activity-center-enabled?)
+                                         (re-frame/dispatch [:navigate-to :activity-center])
+                                         (re-frame/dispatch [:navigate-to :notifications-center])))}
       [icons/icon :main-icons/notification2 {:color (quo2.colors/theme-colors quo2.colors/black quo2.colors/white)}]]
      (when (pos? notif-count)
        [react/view {:style (merge (styles/counter-public-container) {:top 5 :right 5})

--- a/src/status_im/utils/config.cljs
+++ b/src/status_im/utils/config.cljs
@@ -177,3 +177,8 @@
 (def wallet-connect-project-id "87815d72a81d739d2a7ce15c2cfdefb3")
 
 (def new-ui-enabled? (atom false))
+
+;; TODO: Remove this (highly) temporary flag once the new Activity Center is
+;; usable enough to replace the old one **in the new UI**.
+(def new-activity-center-enabled?
+  (atom false))


### PR DESCRIPTION
fixes #13965
fixes #13966
fixes #13969

## Summary

This PR makes *contact requests* in the new Activity Center interactive, and it implements the logic to reconcile/sync new notifications signaled from the backend to the app db. As usual with the new Activity Center, this PR should have no impact for production users.

### Review notes

Notification reconciliation is now implemented for the new Activity Center, which means new notifications are "merged" with existing app db notifications. The original implementation isn't compatible with the way notifications are fetched by read/unread status from the backend.

The most interesting and challenging part of this PR was to write unit tests for the event handlers defined in `status_im/activity_center/core.cljs`. Thankfully :heart:, we already had integration tests with examples and the [https://github.com/day8/re-frame-test](re-frame-test) dependency, as well as a recently merged [PR](https://github.com/status-im/status-mobile/pull/13754) adding REPL support for CLJS. 

As the re-frame documentation [clearly points out](https://github.com/day8/re-frame/blob/master/docs/Testing.md#what-to-test), the majority of the test focus should be put on event handlers, because that's where most of the logic lives. It's also the layer that's responsible for getting data in/out of the application. I felt the need to test the reconciliation of new notifications, as well as the pagination.

Even though most of Status' event handlers are pure functions returning data, many can have side-effects when dispatched, and many effects further dispatch success/failure events. This means to write unit tests for them, it's desirable to have a way to stub and spy on effects, etc. IMO, it's also desirable to be able to clearly identify the `Arrange`, `Act`, and `Assert` sections. You'll find these utility functions in the new namespace `status-im.test-helpers`. To grab another quote from re-frame:

>The interesting part is the unit test "setup" where we need to establish an initial value for db.
>
>https://github.com/day8/re-frame/blob/master/docs/Testing.md#event-handlers---setup---part-3

I believe the more we start to test this critical layer, the better we'll get, and along with this more useful test facilities will emerge.

#### Platforms

- Android
- iOS

### Steps to test

Please, use these user stories as a guide if you'd like to manually test the app, but first off do the following:

1. Checkout status-go branch `feature/activity-center-read-unread`.
2. Run `export STATUS_GO_SRC_OVERRIDE=$HOME/<path-to-your-status-go-repo>` before running targets such as `make run-android`.
3. Set the flag `status-im.utils.config/new-activity-center-enabled?` to true and enable the new UI.

>Given that Alice and Carol are not friends,
>And given that Alice has her Notification Center already open,
>When Carol sends a Contact Request to Alice,
>Then Alice sees a new notification without refreshing the Activity Center screen.

>Given that Alice and Carol are not friends,
>And given that Carol sent a Contact Request to Alice,
>When Alice sees the new notification,
>Then she can Accept the Contact Request directly from the new activity,
>And she can immediately see the activity status change to Accepted.

>Given that Carol and Alice are not friends,
>And given that Carol sent a Contact Request to Alice,
>When Alice sees the new notification,
>Then she can Decline the Contact Request directly from the new activity,
>And she can immediately see the activity status change to Declined.

>Given that Alice has accepted a Contact Request from Carol,
>When Alice presses the new activity,
>Then she is redirected to the chat screen with Carol.

status: ready
