### PR TITLE
fix: channel list mute icon now showing

### DIFF
--- a/src/quo2/components/list_items/channel.cljs
+++ b/src/quo2/components/list_items/channel.cljs
@@ -40,7 +40,7 @@
    [rn/view {:style {:height 20}}
     (when (and (not locked?)
                muted?)
-      [quo2.icons/icon :main-icons2/muted?
+      [quo2.icons/icon :main-icons2/muted
        {:size     20
         :no-color true}])
     (when (and (not locked?)


### PR DESCRIPTION
had a typo in the icon name.

Fixed now:

<img width="345" alt="Screenshot 2022-09-28 at 09 36 43" src="https://user-images.githubusercontent.com/22799766/192731334-fcdd38a6-00cd-480f-90f8-8467e552be2d.png">
