### PR TITLE
Fix mentions on edited message

### DIFF
--- a/src/status_im/multiaccounts/core.cljs
+++ b/src/status_im/multiaccounts/core.cljs
@@ -54,13 +54,11 @@
 
 (defn displayed-name
   "Use preferred name, name or alias in that order"
-  [{:keys [name preferred-name alias public-key ens-verified]}]
-  (let [ens-name (or preferred-name
-                     name)]
-    ;; Preferred name is our own otherwise we make sure it's verified
-    (if (or preferred-name (and ens-verified name))
+  [{:keys [name preferred-name alias public-key]}]
+  (let [ens-name (or preferred-name name)]
+    (if (or preferred-name name)
       (let [username (stateofus/username ens-name)]
-        (str "@" (or username ens-name)))
+        (or username ens-name))
       (or alias (gfycat/generate-gfy public-key)))))
 
 (defn contact-by-identity [contacts identity]

--- a/src/status_im/ui/screens/chat/components/input.cljs
+++ b/src/status_im/ui/screens/chat/components/input.cljs
@@ -12,6 +12,7 @@
             [status-im.multiaccounts.core :as multiaccounts]
             [status-im.chat.constants :as chat.constants]
             [status-im.utils.utils :as utils.utils]
+            [status-im.subs.chat.chats :as chats.subs]
             [quo.components.animated.pressable :as pressable]
             [re-frame.core :as re-frame]
             [status-im.i18n.i18n :as i18n]
@@ -217,11 +218,16 @@
   {:events [:chat.ui.input/set-chat-input-text]}
   [{:keys [db] :as cofx} text chat-id]
   (let [text-with-mentions (mentions/->input-field text)
+        current-chat (get (:chats db) chat-id)
+        all-contacts (:contacts/contacts db)
         contacts (:contacts db)
+        current-multiaccount (:multiaccount db)
+        mentionable-users (chats.subs/compute-mentionable-users current-chat nil all-contacts current-multiaccount)
         hydrated-mentions (map (fn [[t mention :as e]]
                                  (if (= t :mention)
                                    [:mention (str "@" (multiaccounts/displayed-name
                                                        (or (get contacts mention)
+                                                           (get mentionable-users mention)
                                                            {:public-key mention})))]
                                    e)) text-with-mentions)
         info (mentions/->info hydrated-mentions)]


### PR DESCRIPTION
fixes #14051

### Summary
Fixes edited messages mentions

#### Platforms
- Android
- iOS

##### Functional
- 1-1 chat
- public chats
- group chats
- account recovery
- new account
- user profile updates

### Steps to test
- Open Status
- Send messages that mention other users (with and without ENS usernames)
- Edit those messages
- See if edited messages with ENS name are displayed correctly
- Also check if anywhere username is mentioned is displayed correctly
- Have a nice day

status: WIP 