### PR TITLE
nix: use android-sdk shell for fdroid-pr target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ fdroid-fix-tmp: ##@prepare Fix TMPDIR permissions so Vagrant user is the owner
 
 fdroid-build-env: fdroid-max-watches fdroid-nix-dir fdroid-fix-tmp ##@prepare Setup build environment for F-Droud build
 
-fdroid-pr: export TARGET := android
+fdroid-pr: export TARGET := android-sdk
 fdroid-pr: ##@prepare Create F-Droid release PR
 ifndef APK
 	$(error APK env var not defined)
@@ -314,7 +314,7 @@ test: ##@test Run tests once in NodeJS
 # Other
 #--------------
 
-geth-connect: export TARGET := android-env
+geth-connect: export TARGET := android-sdk
 geth-connect: ##@other Connect to Geth on the device
 	adb forward tcp:8545 tcp:8545 && \
 	build/bin/geth attach http://localhost:8545
@@ -324,22 +324,22 @@ android-clean: ##@prepare Clean Gradle state
 	git clean -dxf -f ./android/app/build; \
 	[[ -d android/.gradle ]] && cd android && ./gradlew clean
 
-android-ports: export TARGET := android-env
+android-ports: export TARGET := android-sdk
 android-ports: ##@other Add proxies to Android Device/Simulator
 	adb reverse tcp:8081 tcp:8081 && \
 	adb reverse tcp:3449 tcp:3449 && \
 	adb reverse tcp:4567 tcp:4567 && \
 	adb forward tcp:5561 tcp:5561
 
-android-devices: export TARGET := android-env
+android-devices: export TARGET := android-sdk
 android-devices: ##@other Invoke adb devices
 	adb devices
 
-android-logcat: export TARGET := android-env
+android-logcat: export TARGET := android-sdk
 android-logcat: ##@other Read status-mobile logs from Android phone using adb
 	adb logcat | grep -e RNBootstrap -e ReactNativeJS -e ReactNative -e StatusModule -e StatusNativeLogs -e 'F DEBUG   :' -e 'Go      :' -e 'GoLog   :' -e 'libc    :'
 
-android-install: export TARGET := android-env
+android-install: export TARGET := android-sdk
 android-install: export BUILD_TYPE ?= release
 android-install: ##@other Install APK on device using adb
 	adb install result/app-$(BUILD_TYPE).apk

--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.5.5'
+library 'status-jenkins-lib@v1.5.7'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.5.5'
+library 'status-jenkins-lib@v1.5.7'
 
 pipeline {
   agent { label 'linux' }

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.5.5'
+library 'status-jenkins-lib@v1.5.7'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.nix-cache
+++ b/ci/Jenkinsfile.nix-cache
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.5.5'
+library 'status-jenkins-lib@v1.5.7'
 
 pipeline {
   agent { label params.AGENT_LABEL }

--- a/ci/Jenkinsfile.tests
+++ b/ci/Jenkinsfile.tests
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.5.5'
+library 'status-jenkins-lib@v1.5.7'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/tests/Jenkinsfile.e2e-prs
+++ b/ci/tests/Jenkinsfile.e2e-prs
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.5.5'
+library 'status-jenkins-lib@v1.5.7'
 
 pipeline {
 

--- a/ci/tools/Jenkinsfile.fastlane-clean
+++ b/ci/tools/Jenkinsfile.fastlane-clean
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.5.5'
+library 'status-jenkins-lib@v1.5.7'
 
 pipeline {
   agent { label 'macos' }

--- a/ci/tools/Jenkinsfile.playstore-meta
+++ b/ci/tools/Jenkinsfile.playstore-meta
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.5.5'
+library 'status-jenkins-lib@v1.5.7'
 
 pipeline {
   agent { label 'linux' }

--- a/nix/pkgs/android-sdk/shell.nix
+++ b/nix/pkgs/android-sdk/shell.nix
@@ -1,7 +1,7 @@
 { mkShell, openjdk, androidPkgs }:
 
 mkShell {
-  name = "android-env-shell";
+  name = "android-sdk-shell";
   shellHook = ''
     export JAVA_HOME="${openjdk}"
 

--- a/nix/shells.nix
+++ b/nix/shells.nix
@@ -56,8 +56,8 @@ let
       buildInputs = with pkgs; [ openjdk8 apksigner ];
     };
 
-    # for targets that need 'adb' and other SDK/NDK tools
-    android-env = pkgs.androidShell;
+    # for targets needing 'adb', 'apkanalyzer' and other SDK/NDK tools
+    android-sdk = pkgs.androidShell;
 
     # helpers for use with target argument
     ios = targets.mobile.ios.shell;

--- a/scripts/fdroid-pr.sh
+++ b/scripts/fdroid-pr.sh
@@ -43,7 +43,7 @@ fi
 
 VERSION_NAME=$(apkanalyzer manifest print "${APK_FILE}" | awk -F'"' '/android:versionName/{print $2}')
 if [[ -n "${VERSION_NAME}" ]]; then
-    log_data "Version Code: ${VERSION_NAME}"
+    log_data "Version Name: ${VERSION_NAME}"
 else
     log_warning "Failed to find version name." >&2; exit 1
 fi


### PR DESCRIPTION
Also renamed `android-env` shell to `android-sdk` to be more descriptive.