### PR TITLE
Allow Chinese characters as ENS names

### DIFF
--- a/src/status_im/ens/core.cljs
+++ b/src/status_im/ens/core.cljs
@@ -179,7 +179,7 @@
 (defn- state [custom-domain? username usernames]
   (cond
     (or (string/blank? username)
-        (> 4 (count username))) :too-short
+        (> 1 (count username))) :too-short
     (valid-username? custom-domain? username)
     (if (usernames (fullname custom-domain? username))
       :already-added

--- a/src/status_im/ethereum/stateofus.cljs
+++ b/src/status_im/ethereum/stateofus.cljs
@@ -55,7 +55,7 @@
 (defn valid-username? [username]
   (boolean
    (and (lower-case? username)
-        (re-find #"^[a-z0-9]+$" username))))
+        (re-find #"^[a-z0-9\u4e00-\u9eff]+$" username))))
 
 (defn ens-name-parse [contact-identity]
   (when (string? contact-identity)


### PR DESCRIPTION
This PR lowers the minimum stateofus.eth username requirement to one character to allow usernames like @1 and adds RegEx to support Chinese characters, to allow usernames like @中国

### Why?
Lots of users in China want to use Chinese characters in their names, and over a dozen people have suggested this feature to me.
There's a huge amount of unused address space on stateofus.eth, and this PR seeks to open that up.

### Why not also emojis?
From my testing, emojis have rendering issues, but Chinese hanzi and short usernames do not.