### PR TITLE
[#13968] Fetch and reconcile notifications by type and read status

### DIFF
--- a/src/quo2/components/tabs/tabs.cljs
+++ b/src/quo2/components/tabs/tabs.cljs
@@ -4,6 +4,7 @@
             [quo2.components.tabs.tab :as tab]
             [reagent.core :as reagent]
             [status-im.ui.components.react :as react]
+            [status-im.utils.core :as utils]
             [status-im.utils.number :as number-utils]))
 
 (def default-tab-size 32)
@@ -82,8 +83,8 @@
       (let [maybe-mask-wrapper (if fade-end?
                                  [react/masked-view
                                   {:mask-element (reagent/as-element
-                                                  [react/linear-gradient {:colors         ["black" "transparent"]
-                                                                          :locations      [(@fading :fade-end-percentage) 1]
+                                                  [react/linear-gradient {:colors         [:black :transparent]
+                                                                          :locations      [(get @fading :fade-end-percentage) 1]
                                                                           :start          {:x 0 :y 0}
                                                                           :end            {:x 1 :y 0}
                                                                           :pointer-events :none
@@ -99,7 +100,9 @@
                               :on-change
                               :scroll-on-press?
                               :size)
-                      {:ref                               (partial reset! flat-list-ref)
+                      (when scroll-on-press?
+                        {:initial-scroll-index (utils/first-index #(= @active-tab-id (:id %)) data)})
+                      {:ref                               #(reset! flat-list-ref %)
                        :extra-data                        (str @active-tab-id)
                        :horizontal                        true
                        :scroll-event-throttle             scroll-event-throttle
@@ -116,7 +119,7 @@
                                                                                                                    :layout-width        layout-width
                                                                                                                    :max-fade-percentage fade-end-percentage})]
                                                                 ;; Avoid unnecessary re-rendering.
-                                                                (when (not= new-percentage (@fading :fade-end-percentage))
+                                                                (when (not= new-percentage (get @fading :fade-end-percentage))
                                                                   (swap! fading assoc :fade-end-percentage new-percentage))))
                                                             (when on-scroll
                                                               (on-scroll e)))

--- a/src/status_im/activity_center/core.cljs
+++ b/src/status_im/activity_center/core.cljs
@@ -1,5 +1,6 @@
 (ns status-im.activity-center.core
   (:require [re-frame.core :as re-frame]
+            [status-im.constants :as constants]
             [status-im.data-store.activities :as data-store.activities]
             [status-im.ethereum.json-rpc :as json-rpc]
             [status-im.utils.fx :as fx]
@@ -8,90 +9,118 @@
 ;;;; Notification reconciliation
 
 (defn- update-notifications
-  [old new]
-  (let [ids-to-be-removed (->> new
-                               (filter #(or (:dismissed %) (:accepted %)))
-                               (map :id))
-        grouped-new       (apply dissoc (group-by :id new) ids-to-be-removed)
-        grouped-old       (apply dissoc (group-by :id old) ids-to-be-removed)]
-    (->> (merge grouped-old grouped-new)
-         vals
-         (map first))))
+  "Insert `new-notifications` in `db-notifications`.
+
+  Although correct, this is a naive implementation for reconciling notifications
+  because for every notification in `new-notifications`, linear scans will be
+  performed to remove it and sorting will be performed for every new insertion.
+  If the number of existing notifications cached in the app db becomes
+  ~excessively~ big, this implementation will probably need to be revisited."
+  [db-notifications new-notifications]
+  (reduce (fn [acc {:keys [id type read] :as notification}]
+            (let [filter-status (if read :read :unread)]
+              (cond-> (-> acc
+                          (update-in [type :read :data]
+                                     (fn [data]
+                                       (remove #(= id (:id %)) data)))
+                          (update-in [type :unread :data]
+                                     (fn [data]
+                                       (remove #(= id (:id %)) data))))
+                (not (or (:dismissed notification) (:accepted notification)))
+                (update-in [type filter-status :data]
+                           (fn [data]
+                             (->> notification
+                                  (conj data)
+                                  (sort-by (juxt :timestamp :id))
+                                  reverse))))))
+          db-notifications
+          new-notifications))
 
 (fx/defn notifications-reconcile
   {:events [:activity-center.notifications/reconcile]}
   [{:keys [db]} new-notifications]
-  (let [{read-new   true
-         unread-new false} (group-by :read new-notifications)
-        read-old           (get-in db [:activity-center :notifications-read :data])
-        unread-old         (get-in db [:activity-center :notifications-unread :data])]
-    {:db (-> db
-             (assoc-in [:activity-center :notifications-read :data]
-                       (update-notifications read-old read-new))
-             (assoc-in [:activity-center :notifications-unread :data]
-                       (update-notifications unread-old unread-new)))}))
+  (when (seq new-notifications)
+    {:db (update-in db [:activity-center :notifications]
+                    update-notifications new-notifications)}))
 
 ;;;; Notifications fetching and pagination
 
-(def notifications-per-page
-  20)
+(def defaults
+  {:filter-status          :unread
+   :filter-type            constants/activity-center-notification-type-no-type
+   :notifications-per-page 10})
 
 (def start-or-end-cursor
   "")
 
-(defn notifications-group->rpc-method
-  [notifications-group]
-  (if (= notifications-group :notifications-read)
+(defn- valid-cursor?
+  [cursor]
+  (and (some? cursor)
+       (not= cursor start-or-end-cursor)))
+
+(defn- filter-status->rpc-method
+  [filter-status]
+  (if (= filter-status :read)
     "wakuext_readActivityCenterNotifications"
     "wakuext_unreadActivityCenterNotifications"))
 
-(defn notifications-read-status->group
-  [status-filter]
-  (if (= status-filter :read)
-    :notifications-read
-    :notifications-unread))
-
 (fx/defn notifications-fetch
-  [{:keys [db]} cursor notifications-group]
-  (when-not (get-in db [:activity-center notifications-group :loading?])
-    {:db             (assoc-in db [:activity-center notifications-group :loading?] true)
-     ::json-rpc/call [{:method     (notifications-group->rpc-method notifications-group)
-                       :params     [cursor notifications-per-page]
-                       :on-success #(re-frame/dispatch [:activity-center.notifications/fetch-success notifications-group %])
-                       :on-error   #(re-frame/dispatch [:activity-center.notifications/fetch-error notifications-group %])}]}))
+  [{:keys [db]} {:keys [cursor filter-type filter-status reset-data?]}]
+  (when-not (get-in db [:activity-center :notifications filter-type filter-status :loading?])
+    {:db             (assoc-in db [:activity-center :notifications filter-type filter-status :loading?] true)
+     ::json-rpc/call [{:method     (filter-status->rpc-method filter-status)
+                       :params     [cursor (defaults :notifications-per-page) filter-type]
+                       :on-success #(re-frame/dispatch [:activity-center.notifications/fetch-success filter-type filter-status reset-data? %])
+                       :on-error   #(re-frame/dispatch [:activity-center.notifications/fetch-error filter-type filter-status %])}]}))
 
 (fx/defn notifications-fetch-first-page
   {:events [:activity-center.notifications/fetch-first-page]}
-  [{:keys [db] :as cofx} {:keys [status-filter] :or {status-filter :unread}}]
-  (let [notifications-group (notifications-read-status->group status-filter)]
+  [{:keys [db] :as cofx} {:keys [filter-type filter-status]}]
+  (let [filter-type   (or filter-type
+                          (get-in db [:activity-center :filter :type]
+                                  (defaults :filter-type)))
+        filter-status (or filter-status
+                          (get-in db [:activity-center :filter :status]
+                                  (defaults :filter-status)))]
     (fx/merge cofx
               {:db (-> db
-                       (assoc-in [:activity-center :current-status-filter] status-filter)
-                       (update-in [:activity-center notifications-group] dissoc :loading?)
-                       (update-in [:activity-center notifications-group] dissoc :data))}
-              (notifications-fetch start-or-end-cursor notifications-group))))
+                       (assoc-in [:activity-center :filter :type] filter-type)
+                       (assoc-in [:activity-center :filter :status] filter-status))}
+              (notifications-fetch {:cursor        start-or-end-cursor
+                                    :filter-type   filter-type
+                                    :filter-status filter-status
+                                    :reset-data?   true}))))
 
 (fx/defn notifications-fetch-next-page
   {:events [:activity-center.notifications/fetch-next-page]}
   [{:keys [db] :as cofx}]
-  (let [status-filter       (get-in db [:activity-center :current-status-filter])
-        notifications-group (notifications-read-status->group status-filter)
-        {:keys [cursor]}    (get-in db [:activity-center notifications-group])]
-    (when-not (= cursor start-or-end-cursor)
-      (notifications-fetch cofx cursor notifications-group))))
+  (let [{:keys [type status]} (get-in db [:activity-center :filter])
+        {:keys [cursor]}      (get-in db [:activity-center :notifications type status])]
+    (when (valid-cursor? cursor)
+      (notifications-fetch cofx {:cursor        cursor
+                                 :filter-type   type
+                                 :filter-status status
+                                 :reset-data?   false}))))
 
 (fx/defn notifications-fetch-success
-  {:events [:activity-center.notifications/fetch-success]}
-  [{:keys [db]} notifications-group {:keys [cursor notifications]}]
-  {:db (-> db
-           (update-in [:activity-center notifications-group] dissoc :loading?)
-           (assoc-in [:activity-center notifications-group :cursor] cursor)
-           (update-in [:activity-center notifications-group :data]
-                      concat
-                      (map data-store.activities/<-rpc notifications)))})
+  {:events       [:activity-center.notifications/fetch-success]
+   :interceptors [(re-frame/path [:activity-center :notifications])]}
+  [{:keys [db]}
+   filter-type
+   filter-status
+   reset-data?
+   {:keys [cursor notifications]}]
+  (let [processed (map data-store.activities/<-rpc notifications)]
+    {:db (-> db
+             (assoc-in [filter-type filter-status :cursor] cursor)
+             (update-in [filter-type filter-status] dissoc :loading?)
+             (update-in [filter-type filter-status :data]
+                        (if reset-data?
+                          (constantly processed)
+                          #(concat %1 processed))))}))
 
 (fx/defn notifications-fetch-error
   {:events [:activity-center.notifications/fetch-error]}
-  [{:keys [db]} notifications-group error]
+  [{:keys [db]} filter-type filter-status error]
   (log/warn "Failed to load Activity Center notifications" error)
-  {:db (update-in db [:activity-center notifications-group] dissoc :loading?)})
+  {:db (update-in db [:activity-center :notifications filter-type filter-status] dissoc :loading?)})

--- a/src/status_im/activity_center/core.cljs
+++ b/src/status_im/activity_center/core.cljs
@@ -103,8 +103,7 @@
                                  :reset-data?   false}))))
 
 (fx/defn notifications-fetch-success
-  {:events       [:activity-center.notifications/fetch-success]
-   :interceptors [(re-frame/path [:activity-center :notifications])]}
+  {:events [:activity-center.notifications/fetch-success]}
   [{:keys [db]}
    filter-type
    filter-status
@@ -112,9 +111,9 @@
    {:keys [cursor notifications]}]
   (let [processed (map data-store.activities/<-rpc notifications)]
     {:db (-> db
-             (assoc-in [filter-type filter-status :cursor] cursor)
-             (update-in [filter-type filter-status] dissoc :loading?)
-             (update-in [filter-type filter-status :data]
+             (assoc-in [:activity-center :notifications filter-type filter-status :cursor] cursor)
+             (update-in [:activity-center :notifications filter-type filter-status] dissoc :loading?)
+             (update-in [:activity-center :notifications filter-type filter-status :data]
                         (if reset-data?
                           (constantly processed)
                           #(concat %1 processed))))}))

--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -176,12 +176,20 @@
 (def ^:const docs-link "https://status.im/docs/")
 (def ^:const principles-link "https://our.status.im/our-principles/")
 
+(def ^:const activity-center-notification-type-no-type 0)
 (def ^:const activity-center-notification-type-one-to-one-chat 1)
 (def ^:const activity-center-notification-type-private-group-chat 2)
 (def ^:const activity-center-notification-type-mention 3)
 (def ^:const activity-center-notification-type-reply 4)
 (def ^:const activity-center-notification-type-contact-request 5)
 (def ^:const activity-center-notification-type-contact-request-retracted 6)
+
+;; TODO: Replace with correct enum values once status-go implements them.
+(def ^:const activity-center-notification-type-admin 66610)
+(def ^:const activity-center-notification-type-identity-verification 66611)
+(def ^:const activity-center-notification-type-tx 66612)
+(def ^:const activity-center-notification-type-membership 66613)
+(def ^:const activity-center-notification-type-system 66614)
 
 (def ^:const visibility-status-unknown 0)
 (def ^:const visibility-status-automatic 1)

--- a/src/status_im/subs/activity_center.cljs
+++ b/src/status_im/subs/activity_center.cljs
@@ -7,18 +7,21 @@
 
 (re-frame/reg-sub
  :activity-center/notifications
- (fn [db]
-   (get-in db [:activity-center :notifications])))
+ :<- [:activity-center]
+ (fn [activity-center]
+   (:notifications activity-center)))
 
 (re-frame/reg-sub
  :activity-center/filter-status
- (fn [db]
-   (get-in db [:activity-center :filter :status])))
+ :<- [:activity-center]
+ (fn [activity-center]
+   (get-in activity-center [:filter :status])))
 
 (re-frame/reg-sub
  :activity-center/filter-type
- (fn [db]
-   (get-in db [:activity-center :filter :type] constants/activity-center-notification-type-no-type)))
+ :<- [:activity-center]
+ (fn [activity-center]
+   (get-in activity-center [:filter :type] constants/activity-center-notification-type-no-type)))
 
 (re-frame/reg-sub
  :activity-center/filtered-notifications

--- a/src/status_im/subs/activity_center.cljs
+++ b/src/status_im/subs/activity_center.cljs
@@ -6,35 +6,33 @@
             [clojure.string :as string]))
 
 (re-frame/reg-sub
- :activity-center/notifications-read
+ :activity-center/notifications
  (fn [db]
-   (get-in db [:activity-center :notifications-read :data])))
+   (get-in db [:activity-center :notifications])))
 
 (re-frame/reg-sub
- :activity-center/notifications-unread
+ :activity-center/filter-status
  (fn [db]
-   (get-in db [:activity-center :notifications-unread :data])))
+   (get-in db [:activity-center :filter :status])))
 
 (re-frame/reg-sub
- :activity-center/current-status-filter
+ :activity-center/filter-type
  (fn [db]
-   (get-in db [:activity-center :current-status-filter])))
+   (get-in db [:activity-center :filter :type] constants/activity-center-notification-type-no-type)))
 
 (re-frame/reg-sub
- :activity-center/status-filter-unread-enabled?
- :<- [:activity-center/current-status-filter]
- (fn [current-status-filter]
-   (= :unread current-status-filter)))
+ :activity-center/filtered-notifications
+ :<- [:activity-center/filter-type]
+ :<- [:activity-center/filter-status]
+ :<- [:activity-center/notifications]
+ (fn [[filter-type filter-status notifications]]
+   (get-in notifications [filter-type filter-status :data])))
 
 (re-frame/reg-sub
- :activity-center/notifications-per-read-status
- :<- [:activity-center/notifications-read]
- :<- [:activity-center/notifications-unread]
- :<- [:activity-center/status-filter-unread-enabled?]
- (fn [[notifications-read notifications-unread unread-filter-enabled?]]
-   (if unread-filter-enabled?
-     notifications-unread
-     notifications-read)))
+ :activity-center/filter-status-unread-enabled?
+ :<- [:activity-center/filter-status]
+ (fn [filter-status]
+   (= :unread filter-status)))
 
 (defn- group-notifications-by-date
   [notifications]

--- a/src/status_im/subs/root.cljs
+++ b/src/status_im/subs/root.cljs
@@ -228,6 +228,7 @@
 
 (reg-root-key-sub :activity.center/notifications :activity.center/notifications)
 (reg-root-key-sub :activity.center/notifications-count :activity.center/notifications-count)
+(reg-root-key-sub :activity-center :activity-center)
 
 (reg-root-key-sub :bug-report/description-error :bug-report/description-error)
 (reg-root-key-sub :bug-report/details :bug-report/details)


### PR DESCRIPTION
fixes #13968

### Summary

This PR adds support for fetching notifications whenever the user switches tabs, based on the current read/unread filter and the type of notification. Reconciliation of new notifications pushed from `status-im.transport.message.core/process-response` now sort the data according to the same rules used by status-go.

### Demo

Please, ignore in the demo the incorrect toggle button icon and the non-green Accept button. These problems are being tracked already.

[PR.webm](https://user-images.githubusercontent.com/46027/194641364-125c2477-32a7-4450-bafe-ce618ba6c881.webm)

### Review notes

- Switching tabs never filter on the client-side, there's always a roundtrip to the backend.
- The app db structure changed to accommodate the fact that status-go uses a pagination cursor for every group of read/unread + type of notification.

**Extra goodies**:

- [x] Extract tabs component from the main screen component to reduce rendering cost when switching tabs.
- [x] Display empty state component when there are no notifications.
- [x] Fix screen flickering due to quickly flushing and filling the db state (a known problem in the production notification center).
- [x] Display top tab bar as a sticky header.
- [x] Namespace icon keywords.
- [x] Remove warning about children without unique key.

### For the curious

- This PR uses the [re-frame.core/path](https://day8.github.io/re-frame/api-re-frame.core/#path) standard interceptor. It's a useful way to narrow the scope of the app db, so that the event handler knows less about the "world".

- Cool fact about the test changes in this PR: although most of them changed, **their description did not**, because they communicate the overall behavior of the event handler, and that was kept mostly unchanged from previous PRs.

- When reading the tests, it's my hope that you can clearly see the 3 universal test sections `Arrange` `Act`, and `Assert`, and that they're understandable. In general, tests should be fairly easy (not just simple) to change, because they're often aggressively changed (more than the production code). If you have feedback, please do share so we can improve o/

#### Platforms

- Android
- iOS

### Steps to test

This PR relies on fixes that were pushed to a draft PR on status-go (https://github.com/status-im/status-go/pull/2831). Yes, it's getting old to mention this on every PR. It's time to get that PR reviewed! Hopefully soon, so everyone will be able to test more easily the new AC.

Therefore, to test, use the draft PR branch locally and point status-mobile to it and set `status-im.utils.config/new-activity-center-enabled?` to `true`.

status: ready
