### PR TITLE
feat: pinned messages new ui

### DIFF
--- a/src/status_im/chat/models/pin_message.cljs
+++ b/src/status_im/chat/models/pin_message.cljs
@@ -92,7 +92,6 @@
               (when pinned
                 (protocol/send-chat-messages [{:chat-id      (pin-message :chat-id)
                                                :content-type constants/content-type-pin
-                                               :text "This is a pin!"
                                                :response-to (pin-message :message-id)
                                                :ens-name preferred-name}])))))
 

--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -14,6 +14,7 @@
 (def ^:const content-type-community 9)
 (def ^:const content-type-gap 10)
 (def ^:const content-type-contact-request 11) ;; TODO: temp, will be removed
+(def ^:const content-type-pin 13)
 
 (def ^:const contact-request-state-none 0)
 (def ^:const contact-request-state-mutual 1)

--- a/src/status_im/ui/screens/chat/components/edit.cljs
+++ b/src/status_im/ui/screens/chat/components/edit.cljs
@@ -31,7 +31,7 @@
 
 (defn edit-message []
   [rn/view {:style {:flex-direction :row :height 24}}
-   [rn/view {:style (styles/reply-content)}
+   [rn/view {:style (styles/reply-content false)}
     [icons/icon :main-icons/edit-connector {:color (theme-colors quo2.colors/neutral-40 quo2.colors/neutral-60)
                                             :container-style {:position :absolute :left 10 :bottom -4 :width 16 :height 16}}]
     [rn/view {:style {:position :absolute :left 36 :right 54 :top 3 :flex-direction :row :align-items :center}}

--- a/src/status_im/ui/screens/chat/components/reply.cljs
+++ b/src/status_im/ui/screens/chat/components/reply.cljs
@@ -81,15 +81,16 @@
        [icons/icon :main-icons/close-circle {:container-style (styles/close-button)
                                              :color (:icon-02 @quo.colors/theme)}]]]]))
 
-(defn reply-message [{:keys [from identicon content-type contentType parsed-text content]} in-chat-input?]
+; This component is also used for quoted pinned message as the UI is very similar
+(defn reply-message [{:keys [from identicon content-type contentType parsed-text content]} in-chat-input? pin?]
   (let [contact-name       @(re-frame/subscribe [:contacts/contact-name-by-identity from])
         current-public-key @(re-frame/subscribe [:multiaccount/public-key])
         content-type       (or content-type contentType)]
-    [rn/view {:style {:flex-direction :row :height 24}}
-     [rn/view {:style (styles/reply-content)}
-      [icons/icon :main-icons/connector {:color (theme-colors quo2.colors/neutral-40 quo2.colors/neutral-60)
-                                         :container-style {:position :absolute :left 10 :bottom -4 :width 16 :height 16}}]
-      [rn/view {:style {:position :absolute :left 34 :top 3 :flex-direction :row :align-items :center :width "45%"}}
+    [rn/view {:style {:flex-direction :row :height (when-not pin? 24)}}
+     [rn/view {:style (styles/reply-content pin?)}
+      (when-not pin? [icons/icon :main-icons/connector {:color (theme-colors quo2.colors/neutral-40 quo2.colors/neutral-60)
+                                                        :container-style {:position :absolute :left 10 :bottom -4 :width 16 :height 16}}])
+      [rn/view {:style (styles/quoted-message pin?)}
        [photos/member-photo from identicon 16]
        [quo2.text/text {:weight          :semi-bold
                         :size            :paragraph-2
@@ -125,7 +126,7 @@
 (defn send-image [images]
   [rn/view {:style (styles/reply-container-image)}
    [rn/scroll-view {:horizontal true
-                    :style      (styles/reply-content)}
+                    :style      (styles/reply-content false)}
     (for [{:keys [uri]} (vals images)]
       ^{:key uri}
       [rn/image {:source {:uri uri}

--- a/src/status_im/ui/screens/chat/components/style.cljs
+++ b/src/status_im/ui/screens/chat/components/style.cljs
@@ -115,10 +115,10 @@
 
 (defn quoted-message [pin?]
   (merge {:flex-direction :row
-          :align-items :center}
+          :align-items :center
+          :width "45%"}
          (when-not pin? {:position :absolute
                          :left 34
-                         :right 54
                          :top 3})))
 
 (defn contact-request-content []

--- a/src/status_im/ui/screens/chat/components/style.cljs
+++ b/src/status_im/ui/screens/chat/components/style.cljs
@@ -108,10 +108,18 @@
    :padding-horizontal 10
    :flex               1})
 
-(defn reply-content []
-  {:padding-horizontal 10
+(defn reply-content [pin?]
+  {:padding-horizontal (when-not pin? 10)
    :flex               1
    :flex-direction     :row})
+
+(defn quoted-message [pin?]
+  (merge {:flex-direction :row
+          :align-items :center}
+         (when-not pin? {:position :absolute
+                         :left 34
+                         :right 54
+                         :top 3})))
 
 (defn contact-request-content []
   {:flex            1

--- a/src/status_im/ui/screens/chat/message/message.cljs
+++ b/src/status_im/ui/screens/chat/message/message.cljs
@@ -509,7 +509,7 @@
                                  :on-press #(do (when modal (close-modal))
                                                 (re-frame/dispatch [:chat.ui/show-profile from]))}
         [message-author-name from {:modal modal}]]
-       [react/text {:style {:font-size 13}} " pinned a message"]
+       [react/text {:style {:font-size 13}} (str " " (i18n/label :pinned-a-message))]
        [react/text
         {:style               (merge
                                {:padding-left 5

--- a/src/status_im/ui/screens/chat/message/message.cljs
+++ b/src/status_im/ui/screens/chat/message/message.cljs
@@ -99,6 +99,9 @@
   [react/view {:style (when-not pin? (style/quoted-message-container))}
    [components.reply/reply-message reply false pin?]])
 
+(defn system-text? [content-type]
+  (= content-type constants/content-type-system-text))
+
 (defn render-inline [message-text content-type acc {:keys [type literal destination]}]
   (case type
     ""
@@ -139,9 +142,9 @@
     (conj acc
           [react/view {:style {:background-color quo2.colors/primary-50-opa-10 :border-radius 6 :padding-horizontal 3}}
            [react/text-class
-            {:style    (merge {:color (if (= content-type constants/content-type-system-text) colors/black quo2.colors/primary-50)}
-                              (if (= content-type constants/content-type-system-text) typography/font-regular typography/font-medium))
-             :on-press (when-not (= content-type constants/content-type-system-text)
+            {:style    (merge {:color (if (system-text? content-type) colors/black quo2.colors/primary-50)}
+                              (if (system-text? content-type) typography/font-regular typography/font-medium))
+             :on-press (when-not (system-text? content-type)
                          #(>evt [:chat.ui/show-profile literal]))}
             [mention-element literal]]])
     "status-tag"

--- a/src/status_im/ui/screens/chat/message/message.cljs
+++ b/src/status_im/ui/screens/chat/message/message.cljs
@@ -138,7 +138,7 @@
     (conj acc
           [react/view {:style {:background-color quo2.colors/primary-50-opa-10 :border-radius 6 :padding-horizontal 3}}
            [react/text-class
-            {:style    (merge {:color (if (= content-type constants/content-type-system-text) colors/black (:text-04 @colors/theme))}
+            {:style    (merge {:color (if (= content-type constants/content-type-system-text) colors/black quo2.colors/primary-50)}
                               (if (= content-type constants/content-type-system-text) typography/font-regular typography/font-medium))
              :on-press (when-not (= content-type constants/content-type-system-text)
                          #(>evt [:chat.ui/show-profile literal]))}

--- a/src/status_im/ui/screens/chat/message/message.cljs
+++ b/src/status_im/ui/screens/chat/message/message.cljs
@@ -34,6 +34,7 @@
             [status-im.utils.security :as security]
             [quo2.foundations.typography :as typography]
             [quo2.foundations.colors :as quo2.colors])
+
   (:require-macros [status-im.utils.views :refer [defview letsubs]]))
 
 (defn message-timestamp-anim
@@ -490,13 +491,13 @@
 (defmethod ->message constants/content-type-pin [{:keys [from in-popover? timestamp-str] :as message} {:keys [modal close-modal]}]
   (let [response-to (:response-to (:content message))]
     [react/view {:style (merge {:flex-direction :row :margin-vertical 8} (style/message-wrapper message))}
-     [react/view {:style {:width photos.style/default-size
-                          :height photos.style/default-size
+     [react/view {:style {:width             photos.style/default-size
+                          :height            photos.style/default-size
                           :margin-horizontal 8
-                          :border-radius photos.style/default-size
-                          :justify-content :center
-                          :align-items :center
-                          :background-color quo2.colors/primary-50-opa-10}}
+                          :border-radius     photos.style/default-size
+                          :justify-content   :center
+                          :align-items       :center
+                          :background-color  quo2.colors/primary-50-opa-10}}
       [pin-icon]]
      [react/view
       [react/view {:style {:flex-direction :row :align-items :center}}

--- a/src/status_im/ui/screens/chat/message/message.cljs
+++ b/src/status_im/ui/screens/chat/message/message.cljs
@@ -12,9 +12,6 @@
             [status-im.react-native.resources :as resources]
             [status-im.ui.components.animation :as animation]
             [status-im.ui.components.fast-image :as fast-image]
-            [status-im.utils.handlers :refer [>evt]]
-            [quo2.foundations.colors :as quo2.colors]
-            [quo2.foundations.typography :as typography]
             [status-im.ui.components.icons.icons :as icons]
             [status-im.ui.components.react :as react]
             [status-im.ui.screens.chat.bottom-sheets.context-drawer :as message-context-drawer]
@@ -30,18 +27,13 @@
             [status-im.ui.screens.chat.sheets :as sheets]
             [status-im.ui.screens.chat.styles.message.message :as style]
             [status-im.ui.screens.chat.utils :as chat.utils]
-            [status-im.utils.security :as security]
-            [status-im.ui.screens.chat.message.reactions :as reactions]
-            [status-im.ui.screens.chat.image.preview.views :as preview]
             [status-im.ui.screens.chat.styles.photos :as photos.style]
-            [quo.core :as quo]
-            [status-im.utils.config :as config]
-            [reagent.core :as reagent]
-            [status-im.ui.screens.chat.components.reply :as components.reply]
-            [status-im.ui.screens.chat.message.link-preview :as link-preview]
             [status-im.ui.screens.communities.icon :as communities.icon]
+            [status-im.utils.handlers :refer [>evt]]
             [status-im.utils.config :as config]
-            [status-im.utils.security :as security])
+            [status-im.utils.security :as security]
+            [quo2.foundations.typography :as typography]
+            [quo2.foundations.colors :as quo2.colors])
   (:require-macros [status-im.utils.views :refer [defview letsubs]]))
 
 (defn message-timestamp-anim
@@ -504,7 +496,7 @@
                           :border-radius photos.style/default-size
                           :justify-content :center
                           :align-items :center
-                          :background-color "rgba(67,96,223,0.05)"}}
+                          :background-color quo2.colors/primary-50-opa-10}}
       [pin-icon]]
      [react/view
       [react/view {:style {:flex-direction :row :align-items :center}}
@@ -764,15 +756,16 @@
         on-open-drawer  (fn [actions]
                           (re-frame/dispatch [:bottom-sheet/show-sheet
                                               {:content (message-context-drawer/message-options
-                                                         actions
-                                                         (into #{} (js->clj own-reactions))
-                                                         #(on-emoji-press %))}]))
+                                                          actions
+                                                          (into #{} (js->clj own-reactions))
+                                                          #(on-emoji-press %))}]))
         on-long-press   (atom nil)]
-[react/view   {:style (merge (when mentioned {:background-color quo2.colors/primary-50-opa-5 :border-radius 16 :margin-bottom 4}) {:margin-horizontal 8})}
-  [->message message {:ref           on-long-press
+    [react/view   {:style (merge (when (or mentioned pinned) {:background-color quo2.colors/primary-50-opa-5 :border-radius 16 :margin-bottom 4}) {:margin-horizontal 8})}
+     (when pinned
+       [react/view {:style (style/pin-indicator-container)}
+        [pinned-by-indicator pinned-by]])
+     [->message message {:ref           on-long-press
                          :modal         false
                          :on-long-press on-open-drawer}]
      [reaction-row/message-reactions message reactions nil on-emoji-press on-long-press] ;; TODO: pass on-open-drawer function
- (when pinned
-   [react/view {:style (style/pin-indicator-container)}
-    [pinned-by-indicator pinned-by]])]))
+     ]))

--- a/src/status_im/ui/screens/chat/message/message.cljs
+++ b/src/status_im/ui/screens/chat/message/message.cljs
@@ -760,9 +760,9 @@
         on-open-drawer  (fn [actions]
                           (re-frame/dispatch [:bottom-sheet/show-sheet
                                               {:content (message-context-drawer/message-options
-                                                          actions
-                                                          (into #{} (js->clj own-reactions))
-                                                          #(on-emoji-press %))}]))
+                                                         actions
+                                                         (into #{} (js->clj own-reactions))
+                                                         #(on-emoji-press %))}]))
         on-long-press   (atom nil)]
     [react/view   {:style (merge (when (or mentioned pinned) {:background-color quo2.colors/primary-50-opa-5 :border-radius 16 :margin-bottom 4}) {:margin-horizontal 8})}
      (when pinned

--- a/src/status_im/ui/screens/chat/message/styles.cljs
+++ b/src/status_im/ui/screens/chat/message/styles.cljs
@@ -92,6 +92,7 @@
 (defn reactions-row [timeline margin-top]
   {:flex-direction  :row
    :padding-right   8
+   :padding-bottom   8
    :justify-content :flex-start
    :margin-top      margin-top
    :flex-wrap       :wrap

--- a/src/status_im/ui/screens/chat/styles/message/message.cljs
+++ b/src/status_im/ui/screens/chat/styles/message/message.cljs
@@ -3,7 +3,8 @@
             [quo.design-system.colors :as colors]
             [status-im.ui.components.react :as react]
             [status-im.ui.screens.chat.styles.photos :as photos]
-            [quo2.foundations.colors :as quo2.colors]))
+            [quo2.foundations.colors :as quo2.colors]
+            [quo2.foundations.typography :as typography]))
 
 (defn style-message-text
   []
@@ -93,9 +94,9 @@
    :margin-top     1})
 
 (defn pin-author-text []
-  {:color (:text-04 @colors/theme)
-   :font-weight "500"
-   :bottom 2})
+  (merge typography/font-medium
+         {:color quo2.colors/primary-50
+          :bottom 2}))
 
 (defn pinned-by-text []
   {:margin-left 5})

--- a/src/status_im/ui/screens/chat/styles/message/message.cljs
+++ b/src/status_im/ui/screens/chat/styles/message/message.cljs
@@ -152,10 +152,6 @@
    :flex-direction :row-reverse})
 
 (defn message-view
-<<<<<<< HEAD
-  [{:keys [content-type]}]
-  (merge
-=======
   [{:keys [content-type mentioned]}]
   (merge
    {:border-radius 10}
@@ -168,7 +164,6 @@
                                                           :padding-horizontal 12
                                                           :padding-top 6})
 
->>>>>>> 348a97211... feat: pinned messages new ui
    (when (= content-type constants/content-type-emoji)
      {:flex-direction :row})))
 

--- a/src/status_im/ui/screens/chat/styles/message/message.cljs
+++ b/src/status_im/ui/screens/chat/styles/message/message.cljs
@@ -71,30 +71,15 @@
   {:align-self    :flex-start
    :padding-left  8})
 
-(defn pin-indicator [display-photo?]
-  (merge
-   {:flex-direction             :row
-    :border-top-left-radius     4
-    :border-top-right-radius    12
-    :border-bottom-left-radius  12
-    :border-bottom-right-radius 12
-    :padding-left               8
-    :padding-right              10
-    :padding-vertical           5
-    :background-color           colors/gray-lighter
-    :justify-content            :center
-    :max-width                  "80%"
-    :align-self  :flex-start
-    :align-items :flex-start}
-   (when display-photo?
-     {:margin-left 44})))
+(defn pin-indicator []
+  (merge {:flex-direction :row}))
 
 (defn pin-indicator-container []
-  {:margin-top      2
+  {:margin-top      8
+   :margin-left 68
    :justify-content :center
    :align-self   :flex-start
-   :align-items  :flex-start
-   :padding-left 8})
+   :align-items  :flex-start})
 
 (defn pinned-by-text-icon-container []
   {:flex-direction :row
@@ -108,14 +93,9 @@
    :margin-top     1})
 
 (defn pin-author-text []
-  {:margin-left  2
-   :margin-right 12
-   :padding-right 0
-   :left         12
-   :flex-direction :row
-   :flex-shrink  1
-   :align-self   :flex-start
-   :overflow     :hidden})
+  {:color (:text-04 @colors/theme)
+   :font-weight "500"
+   :bottom 2})
 
 (defn pinned-by-text []
   {:margin-left 5})
@@ -171,8 +151,23 @@
    :flex-direction :row-reverse})
 
 (defn message-view
+<<<<<<< HEAD
   [{:keys [content-type]}]
   (merge
+=======
+  [{:keys [content-type mentioned]}]
+  (merge
+   {:border-radius 10}
+   (cond
+     (= content-type constants/content-type-system-text) nil
+     mentioned                                           {:background-color colors/mentioned-background
+                                                          :border-color colors/mentioned-border
+                                                          :border-width 1}
+     (= content-type constants/content-type-audio)       {:background-color colors/blue
+                                                          :padding-horizontal 12
+                                                          :padding-top 6})
+
+>>>>>>> 348a97211... feat: pinned messages new ui
    (when (= content-type constants/content-type-emoji)
      {:flex-direction :row})))
 


### PR DESCRIPTION
fixes #14022 

### Summary

This PR implements the [new UI ](https://www.figma.com/file/PPWkgOYlZZDxZv5SDGsZVV/Posts-%26-Attachments-for-Mobile?node-id=3425%3A413502) for pinned messages. It includes the new UI for a pinned message as well as the message that appears in the chat stating that a user has pinned a message. Showing a list of pinned messages, and unpinning messages are addressed in different issues (#14023 and #14024).

#### Platforms

- Android
- iOS

status: ready
