### PR TITLE
Fix: refactored token token to fix a bug

### DIFF
--- a/src/quo2/components/tags/token_tag.cljs
+++ b/src/quo2/components/tags/token_tag.cljs
@@ -3,8 +3,7 @@
             [quo.react-native :as rn]
             [quo.theme :as theme]
             [quo2.components.markdown.text :as text]
-            [status-im.ui.components.icons.icons :as icons]
-            [quo2.components.tags.tag :as tag]))
+            [status-im.ui.components.icons.icons :as icons]))
 
 (def themes {:light {:background-color colors/neutral-20}
              :dark {:background-color colors/neutral-80}})
@@ -77,23 +76,23 @@
         :or
         {size :small border-color (colors/custom-color-by-theme :purple 50 60)}}]
 
-    [tag/tag {:size size
-              :token-img-src token-img-src
-              :border-color (when is-required border-color)
-              :overlay
-              (when (or is-required is-purchasable)
-                [rn/view
-                 {:style (merge icon-container-styles
-                                {:width 15.5
-                                 :height 15.5
-                                 :background-color border-color
-                                 :border-color (if (=  (theme/get-theme) :dark) colors/neutral-100 colors/white)
-                                 :border-width 1
-                                 :right  (get-value-from-size size -3.75 -5.75)
-                                 :bottom (get-value-from-size size (- 32 7.75 4) (- 24 7.75 2)) ; (- height (icon-height/2) spacing)
-                                 })}
-                 [icons/icon (if is-required :main-icons2/required-checkmark12 :main-icons2/purchasable12)
-                  {:no-color true
-                   :width 13.5
-                   :height 13.5}]])}
+    [tag {:size size
+          :token-img-src token-img-src
+          :border-color (when is-required border-color)
+          :overlay
+          (when (or is-required is-purchasable)
+            [rn/view
+             {:style (merge icon-container-styles
+                            {:width 15.5
+                             :height 15.5
+                             :background-color border-color
+                             :border-color (if (=  (theme/get-theme) :dark) colors/neutral-100 colors/white)
+                             :border-width 1
+                             :right  (get-value-from-size size -3.75 -5.75)
+                             :bottom (get-value-from-size size (- 32 7.75 4) (- 24 7.75 2)) ; (- height (icon-height/2) spacing)
+                             })}
+             [icons/icon (if is-required :main-icons2/required-checkmark12 :main-icons2/purchasable12)
+              {:no-color true
+               :width 13.5
+               :height 13.5}]])}
      (str value " " token)]))

--- a/src/quo2/screens/tags/permission_tag.cljs
+++ b/src/quo2/screens/tags/permission_tag.cljs
@@ -145,6 +145,7 @@
         [rn/view {:flex 1}
          [preview/customizer state descriptor]]
         [rn/view {:padding-vertical 60
+                  :align-self       :center
                   :justify-content  :center}
          (when @state
            (for [{:keys [tokens]} community-tokens]


### PR DESCRIPTION
fixes #14151

### Summary
App does not crash when user navigates to view token-tag

The error was because token-tag was referencing tag component in quo2 instead of calling tag function in token-tag ns. Refactoring that seems to have solved the problem

