### PR TITLE
Feature/#14131 blur activity center background

### DIFF
--- a/src/quo2/components/tabs/tab.cljs
+++ b/src/quo2/components/tabs/tab.cljs
@@ -24,6 +24,25 @@
                                 :icon-color       colors/neutral-40
                                 :label            {:style {:color colors/white}}}}})
 
+(def themes-for-blur-background {:light {:default  {:background-color colors/neutral-80-opa-5
+                                                    :icon-color       colors/neutral-80-opa-40
+                                                    :label            {:style {:color colors/neutral-100}}}
+                                         :active   {:background-color colors/neutral-80-opa-60
+                                                    :icon-color       colors/white
+                                                    :label            {:style {:color colors/white}}}
+                                         :disabled {:background-color colors/neutral-80-opa-5
+                                                    :icon-color       colors/neutral-80-opa-40
+                                                    :label            {:style {:color colors/neutral-100}}}}
+                                 :dark  {:default  {:background-color colors/white-opa-5
+                                                    :icon-color       colors/white
+                                                    :label            {:style {:color colors/white}}}
+                                         :active   {:background-color colors/white-opa-20
+                                                    :icon-color       colors/white
+                                                    :label            {:style {:color colors/white}}}
+                                         :disabled {:background-color colors/white-opa-5
+                                                    :icon-color       colors/neutral-40
+                                                    :label            {:style {:color colors/white}}}}})
+
 (defn style-container [size disabled background-color]
   (merge {:height             size
           :align-items        :center
@@ -48,12 +67,12 @@
     :before :icon-keyword
     :after :icon-keyword}"
   [_ _]
-  (fn [{:keys [id on-press disabled size before active accessibility-label]
+  (fn [{:keys [id on-press disabled size before active accessibility-label blur? override-theme]
         :or   {size 32}}
        children]
     (let [state (cond disabled :disabled active :active :else :default)
           {:keys [icon-color background-color label]}
-          (get-in themes [(theme/get-theme) state])]
+          (get-in (if blur? themes-for-blur-background themes) [(or override-theme  (theme/get-theme))  state])]
       [rn/touchable-without-feedback (merge {:disabled            disabled
                                              :accessibility-label accessibility-label}
                                             (when on-press

--- a/src/quo2/components/tabs/tabs.cljs
+++ b/src/quo2/components/tabs/tabs.cljs
@@ -73,7 +73,9 @@
                  on-scroll
                  scroll-event-throttle
                  scroll-on-press?
-                 size]
+                 size
+                 blur?
+                 override-theme]
           :or   {fade-end-percentage   fade-end-percentage
                  fade-end?             false
                  scroll-event-throttle 64
@@ -127,16 +129,18 @@
                                                             [rn/view {:style {:margin-right  (if (= size default-tab-size) 12 8)
                                                                               :padding-right (when (= index (dec (count data)))
                                                                                                (get-in props [:style :padding-left]))}}
-                                                             [tab/tab {:id       id
-                                                                       :size     size
-                                                                       :active   (= id @active-tab-id)
-                                                                       :on-press (fn [id]
-                                                                                   (reset! active-tab-id id)
-                                                                                   (when scroll-on-press?
-                                                                                     (.scrollToIndex @flat-list-ref
-                                                                                                     #js {:animated     true
-                                                                                                          :index        index
-                                                                                                          :viewPosition 0.5}))
-                                                                                   (when on-change
-                                                                                     (on-change id)))}
+                                                             [tab/tab {:id             id
+                                                                       :size           size
+                                                                       :override-theme override-theme
+                                                                       :blur?           blur?
+                                                                       :active          (= id @active-tab-id)
+                                                                       :on-press        (fn [id]
+                                                                                          (reset! active-tab-id id)
+                                                                                          (when scroll-on-press?
+                                                                                            (.scrollToIndex @flat-list-ref
+                                                                                                            #js {:animated     true
+                                                                                                                 :index        index
+                                                                                                                 :viewPosition 0.5}))
+                                                                                          (when on-change
+                                                                                            (on-change id)))}
                                                               label]])})])))))

--- a/src/quo2/components/tags/context_tags.cljs
+++ b/src/quo2/components/tags/context_tags.cljs
@@ -48,15 +48,18 @@
       (trim-public-key public-key)]]))
 
 (defn context-tag [params photo name]
-  [base-tag (assoc-in params [:style :padding-left] 3)
-   [rn/image {:style {:width 20
-                      :border-radius 10
-                      :background-color :white
-                      :height 20}
-              :source photo}]
-   [text/text {:weight :medium
-               :size :paragraph-2}
-    (str " " name)]])
+  (let [text-style (params :text-style)]
+    [base-tag (assoc-in params [:style :padding-left] 3)
+     [rn/image {:style {:width 20
+                        :border-radius 10
+                        :background-color :white
+                        :height 20}
+                :source photo}]
+     [text/text
+      (merge {:weight :medium
+              :size :paragraph-2}
+             {:style text-style})
+      (str " " name)]]))
 
 (defn user-avatar-tag []
   (fn [params username photo]

--- a/src/status_im/ui/components/topnav.cljs
+++ b/src/status_im/ui/components/topnav.cljs
@@ -44,9 +44,8 @@
                                          (re-frame/dispatch [:show-popover {:view                        :activity-center
                                                                             :disable-touchable-overlay?  true
                                                                             :blur-view?                  true
-                                                                            :blur-view-props             {:blurAmount 20
-                                                                                                          :overlay-color  colors/neutral-80-opa-80
-                                                                                                          :blurType :dark}}])
+                                                                            :blur-view-props             {:blur-amount 20
+                                                                                                          :blur-type :dark}}])
                                          (re-frame/dispatch [:navigate-to :notifications-center])))}
       :main-icons2/notifications]
      (when (pos? notif-count)

--- a/src/status_im/ui/components/topnav.cljs
+++ b/src/status_im/ui/components/topnav.cljs
@@ -41,11 +41,12 @@
                           :on-press #(do
                                        (re-frame/dispatch [:mark-all-activity-center-notifications-as-read])
                                        (if config/new-activity-center-enabled?
-                                         (re-frame/dispatch [:show-popover {:view            :activity-center
-                                                                            :blur-view?      true
-                                                                            :blur-view-props {:blurAmount 20
-                                                                                              :overlay-color  colors/neutral-80-opa-80
-                                                                                              :blurType :dark}}])
+                                         (re-frame/dispatch [:show-popover {:view                        :activity-center
+                                                                            :disable-touchable-overlay?  true
+                                                                            :blur-view?                  true
+                                                                            :blur-view-props             {:blurAmount 20
+                                                                                                          :overlay-color  colors/neutral-80-opa-80
+                                                                                                          :blurType :dark}}])
                                          (re-frame/dispatch [:navigate-to :notifications-center])))}
       :main-icons2/notifications]
      (when (pos? notif-count)

--- a/src/status_im/ui/components/topnav.cljs
+++ b/src/status_im/ui/components/topnav.cljs
@@ -44,7 +44,7 @@
                                                                             :disable-touchable-overlay?  true
                                                                             :blur-view?                  true
                                                                             :blur-view-props             {:blur-amount 20
-                                                                                                          :blur-type :dark}}])
+                                                                                                          :blur-type   :dark}}])
                                          (re-frame/dispatch [:navigate-to :notifications-center])))}
       :main-icons2/notifications]
      (when (pos? notif-count)

--- a/src/status_im/ui/components/topnav.cljs
+++ b/src/status_im/ui/components/topnav.cljs
@@ -1,5 +1,6 @@
 (ns status-im.ui.components.topnav
   (:require [quo2.components.buttons.button :as quo2.button]
+            [quo2.foundations.colors :as colors]
             [re-frame.core :as re-frame]
             [status-im.i18n.i18n :as i18n]
             [status-im.qr-scanner.core :as qr-scanner]
@@ -40,7 +41,11 @@
                           :on-press #(do
                                        (re-frame/dispatch [:mark-all-activity-center-notifications-as-read])
                                        (if config/new-activity-center-enabled?
-                                         (re-frame/dispatch [:navigate-to :activity-center])
+                                         (re-frame/dispatch [:show-popover {:view            :activity-center
+                                                                            :blur-view?      true
+                                                                            :blur-view-props {:blurAmount 20
+                                                                                              :overlay-color  colors/neutral-80-opa-80
+                                                                                              :blurType :dark}}])
                                          (re-frame/dispatch [:navigate-to :notifications-center])))}
       :main-icons2/notifications]
      (when (pos? notif-count)

--- a/src/status_im/ui/components/topnav.cljs
+++ b/src/status_im/ui/components/topnav.cljs
@@ -1,6 +1,5 @@
 (ns status-im.ui.components.topnav
   (:require [quo2.components.buttons.button :as quo2.button]
-            [quo2.foundations.colors :as colors]
             [re-frame.core :as re-frame]
             [status-im.i18n.i18n :as i18n]
             [status-im.qr-scanner.core :as qr-scanner]

--- a/src/status_im/ui/screens/activity_center/views.cljs
+++ b/src/status_im/ui/screens/activity_center/views.cljs
@@ -116,13 +116,14 @@
   []
   (let [unread-filter-enabled? (<sub [:activity-center/filter-status-unread-enabled?])]
     ;; TODO: Replace the button by a Filter Selector component once available for use.
-    [button/button {:icon     true
-                    :type     (if unread-filter-enabled? :primary :outline)
-                    :size     32
-                    :on-press #(>evt [:activity-center.notifications/fetch-first-page
-                                      {:filter-status (if unread-filter-enabled?
-                                                        :read
-                                                        :unread)}])}
+    [button/button {:icon             true
+                    :type             (if unread-filter-enabled? :primary :blur-bg-outline)
+                    :size             32
+                    :override-theme   :dark
+                    :on-press         #(>evt [:activity-center.notifications/fetch-first-page
+                                              {:filter-status (if unread-filter-enabled?
+                                                                :read
+                                                                :unread)}])}
      :main-icons2/unread]))
 
 ;; TODO(2022-10-07): The empty state is still under design analysis, so we
@@ -149,6 +150,8 @@
   []
   (let [filter-type (<sub [:activity-center/filter-type])]
     [tabs/scrollable-tabs {:size                32
+                           :blur?               true
+                           :override-theme      :dark
                            :style               {:padding-left 20}
                            :fade-end-percentage 0.79
                            :scroll-on-press?    true
@@ -179,10 +182,11 @@
   (let [screen-padding 20]
     [rn/view
      [button/button {:icon     true
-                     :type     :grey
+                     :type     :blur-bg
                      :size     32
-                     :style    {:margin-vertical 12
-                                :margin-left     screen-padding}
+                     :override-theme :dark
+                     :style    {:margin-vertical  12
+                                :margin-left      screen-padding}
                      :on-press #(>evt [:hide-popover])}
       :main-icons2/close]
      [text/text {:size   :heading-1

--- a/src/status_im/ui/screens/activity_center/views.cljs
+++ b/src/status_im/ui/screens/activity_center/views.cljs
@@ -40,21 +40,16 @@
           contact     (<sub [:contacts/contact-by-identity (:from message)])
           sender-name (or (get-in contact [:names :nickname])
                           (get-in contact [:names :three-words-name]))]
-      [[rn/view
-        {:style {:flex-direction :row
-                 :flex 1
-                 :align-items :center}}
-        [context-tags/user-avatar-tag
-         {:color          :purple
-          :override-theme :dark
-          :size           :small
-          :style          {:background-color colors/white-opa-10}
-          :text-style     {:color colors/white}}
-         sender-name
-         (multiaccounts/displayed-photo contact)]
-        [rn/view {:style {:width 4}}]
-        [rn/text {:style {:color colors/white}}
-         (i18n/label :t/contact-request-sent)]]])
+      [[context-tags/user-avatar-tag
+        {:color          :purple
+         :override-theme :dark
+         :size           :small
+         :style          {:background-color colors/white-opa-10}
+         :text-style     {:color colors/white}}
+        sender-name
+        (multiaccounts/displayed-photo contact)]
+       [rn/text {:style {:color colors/white}}
+        (i18n/label :t/contact-request-sent)]])
     nil))
 
 (defn activity-message

--- a/src/status_im/ui/screens/activity_center/views.cljs
+++ b/src/status_im/ui/screens/activity_center/views.cljs
@@ -12,7 +12,8 @@
             [status-im.i18n.i18n :as i18n]
             [status-im.multiaccounts.core :as multiaccounts]
             [status-im.utils.datetime :as datetime]
-            [status-im.utils.handlers :refer [<sub >evt]]))
+            [status-im.utils.handlers :refer [<sub >evt]]
+            [quo.components.safe-area :as safe-area]))
 
 (defn activity-title
   [{:keys [type]}]
@@ -72,10 +73,10 @@
     {:button-1 {:label    (i18n/label :t/decline)
                 :type     :danger
                 :on-press #(>evt [:contact-requests.ui/decline-request id])}
-     :button-2 {:label    (i18n/label :t/accept)
-                :type     :success
+     :button-2 {:label                     (i18n/label :t/accept)
+                :type                      :success
                 :override-background-color colors/success-60
-                :on-press #(>evt [:contact-requests.ui/accept-request id])}}
+                :on-press                  #(>evt [:contact-requests.ui/accept-request id])}}
     nil))
 
 (defn activity-pressable
@@ -176,13 +177,13 @@
   []
   (let [screen-padding 20]
     [rn/view
-     [button/button {:icon     true
-                     :type     :blur-bg
-                     :size     32
+     [button/button {:icon           true
+                     :type           :blur-bg
+                     :size           32
                      :override-theme :dark
-                     :style    {:margin-vertical  12
-                                :margin-left      screen-padding}
-                     :on-press #(>evt [:hide-popover])}
+                     :style          {:margin-vertical  12
+                                      :margin-left      screen-padding}
+                     :on-press       #(>evt [:hide-popover])}
       :main-icons2/close]
      [text/text {:size   :heading-1
                  :weight :semi-bold
@@ -207,16 +208,14 @@
     :reagent-render
     (fn []
       (let [notifications (<sub [:activity-center/filtered-notifications])
-            window-height (<sub [:dimensions/window-height])
             window-width  (<sub [:dimensions/window-width])]
-        [rn/view {:style {:background-color :transparent
-                          :height           window-height
-                          :width            window-width}}
-         [rn/flat-list {:content-container-style {:flex-grow 1}
-                        :data                    notifications
-                        :empty-component         [empty-tab]
-                        :header                  [header]
-                        :key-fn                  :id
-                        :on-end-reached          #(>evt [:activity-center.notifications/fetch-next-page])
-                        :render-fn               render-notification
-                        :sticky-header-indices   [0]}]]))}))
+        [safe-area/view {:style {:flex 1}}
+         [rn/view {:style {:width window-width
+                           :flex  1}}
+          [header]
+          [rn/flat-list {:content-container-style {:flex-grow 1}
+                         :data                    notifications
+                         :empty-component         [empty-tab]
+                         :key-fn                  :id
+                         :on-end-reached          #(>evt [:activity-center.notifications/fetch-next-page])
+                         :render-fn               render-notification}]]]))}))

--- a/src/status_im/ui/screens/home/views.cljs
+++ b/src/status_im/ui/screens/home/views.cljs
@@ -260,9 +260,8 @@
                                          (re-frame/dispatch [:show-popover {:view                        :activity-center
                                                                             :disable-touchable-overlay?  true
                                                                             :blur-view?                  true
-                                                                            :blur-view-props             {:blurAmount 20
-                                                                                                          :overlay-color  quo2.colors/neutral-80-opa-80
-                                                                                                          :blurType :dark}}])
+                                                                            :blur-view-props             {:blur-amount 20
+                                                                                                          :blur-type :dark}}])
                                          (re-frame/dispatch [:navigate-to :notifications-center])))}
       [icons/icon :main-icons/notification2 {:color (quo2.colors/theme-colors quo2.colors/neutral-100 quo2.colors/white)}]]
      (when (pos? notif-count)

--- a/src/status_im/ui/screens/home/views.cljs
+++ b/src/status_im/ui/screens/home/views.cljs
@@ -261,7 +261,7 @@
                                                                             :disable-touchable-overlay?  true
                                                                             :blur-view?                  true
                                                                             :blur-view-props             {:blur-amount 20
-                                                                                                          :blur-type :dark}}])
+                                                                                                          :blur-type   :dark}}])
                                          (re-frame/dispatch [:navigate-to :notifications-center])))}
       [icons/icon :main-icons/notification2 {:color (quo2.colors/theme-colors quo2.colors/neutral-100 quo2.colors/white)}]]
      (when (pos? notif-count)

--- a/src/status_im/ui/screens/home/views.cljs
+++ b/src/status_im/ui/screens/home/views.cljs
@@ -257,11 +257,12 @@
                           :on-press #(do
                                        (re-frame/dispatch [:mark-all-activity-center-notifications-as-read])
                                        (if config/new-activity-center-enabled?
-                                         (re-frame/dispatch [:show-popover {:view            :activity-center
-                                                                            :blur-view?      true
-                                                                            :blur-view-props {:blurAmount 20
-                                                                                              :overlay-color  quo2.colors/neutral-80-opa-80
-                                                                                              :blurType :dark}}])
+                                         (re-frame/dispatch [:show-popover {:view                        :activity-center
+                                                                            :disable-touchable-overlay?  true
+                                                                            :blur-view?                  true
+                                                                            :blur-view-props             {:blurAmount 20
+                                                                                                          :overlay-color  quo2.colors/neutral-80-opa-80
+                                                                                                          :blurType :dark}}])
                                          (re-frame/dispatch [:navigate-to :notifications-center])))}
       [icons/icon :main-icons/notification2 {:color (quo2.colors/theme-colors quo2.colors/neutral-100 quo2.colors/white)}]]
      (when (pos? notif-count)

--- a/src/status_im/ui/screens/home/views.cljs
+++ b/src/status_im/ui/screens/home/views.cljs
@@ -257,7 +257,11 @@
                           :on-press #(do
                                        (re-frame/dispatch [:mark-all-activity-center-notifications-as-read])
                                        (if config/new-activity-center-enabled?
-                                         (re-frame/dispatch [:navigate-to :activity-center])
+                                         (re-frame/dispatch [:show-popover {:view            :activity-center
+                                                                            :blur-view?      true
+                                                                            :blur-view-props {:blurAmount 20
+                                                                                              :overlay-color  quo2.colors/neutral-80-opa-80
+                                                                                              :blurType :dark}}])
                                          (re-frame/dispatch [:navigate-to :notifications-center])))}
       [icons/icon :main-icons/notification2 {:color (quo2.colors/theme-colors quo2.colors/neutral-100 quo2.colors/white)}]]
      (when (pos? notif-count)

--- a/src/status_im/ui/screens/popover/views.cljs
+++ b/src/status_im/ui/screens/popover/views.cljs
@@ -97,9 +97,9 @@
       (fn []
         (when @current-popover
           (let [{:keys [view style disable-touchable-overlay? blur-view? blur-view-props]} @current-popover
-                comp (if blur-view? react/blur-view react/view)
-                overlay-comp (if disable-touchable-overlay? react/view react/touchable-highlight)]
-            [comp (merge  {:style {:position :absolute :top 0 :bottom 0 :left 0 :right 0}} blur-view-props)
+                component (if blur-view? react/blur-view react/view)
+                overlay-component (if disable-touchable-overlay? react/view react/touchable-highlight)]
+            [component (merge  {:style {:position :absolute :top 0 :bottom 0 :left 0 :right 0}} blur-view-props)
              (when platform/ios?
                [react/animated-view
                 {:style {:flex 1 :background-color colors/black-persist :opacity alpha-value}}])
@@ -109,7 +109,7 @@
                                     :left      0
                                     :right     0
                                     :transform [{:translateY bottom-anim-value}]}}
-              [overlay-comp
+              [overlay-component
                {:style    {:flex 1 :align-items :center :justify-content :center}
                 :on-press request-close}
                [react/view (merge {:background-color (if blur-view? :transparent colors/white)

--- a/src/status_im/ui/screens/popover/views.cljs
+++ b/src/status_im/ui/screens/popover/views.cljs
@@ -19,7 +19,8 @@
             [status-im.ui.screens.keycard.views :as keycard.views]
             [status-im.ui.screens.keycard.frozen-card.view :as frozen-card]
             [status-im.ui.screens.chat.message.pinned-message :as pinned-message]
-            [status-im.ui.screens.signing.sheets :as signing-sheets]))
+            [status-im.ui.screens.signing.sheets :as signing-sheets]
+            [status-im.ui.screens.activity-center.views :as activity-center]))
 
 (defn hide-panel-anim
   [bottom-anim-value alpha-value window-height]
@@ -95,8 +96,9 @@
       :reagent-render
       (fn []
         (when @current-popover
-          (let [{:keys [view style]} @current-popover]
-            [react/view {:position :absolute :top 0 :bottom 0 :left 0 :right 0}
+          (let [{:keys [view style blur-view? blur-view-props]} @current-popover
+                comp (if blur-view? react/blur-view react/view)]
+            [comp (merge  {:style {:position :absolute :top 0 :bottom 0 :left 0 :right 0}} blur-view-props)
              (when platform/ios?
                [react/animated-view
                 {:style {:flex 1 :background-color colors/black-persist :opacity alpha-value}}])
@@ -109,7 +111,7 @@
               [react/touchable-highlight
                {:style    {:flex 1 :align-items :center :justify-content :center}
                 :on-press request-close}
-               [react/view (merge {:background-color colors/white
+               [react/view (merge {:background-color (if blur-view? :transparent colors/white)
                                    :border-radius    16
                                    :margin           32
                                    :shadow-offset    {:width 0 :height 2}
@@ -172,6 +174,9 @@
 
                    (= :fees-warning view)
                    [signing-sheets/fees-warning]
+
+                   (= :activity-center view)
+                   [activity-center/activity-center]
 
                    :else
                    [view])]]]]])))})))

--- a/src/status_im/ui/screens/popover/views.cljs
+++ b/src/status_im/ui/screens/popover/views.cljs
@@ -96,8 +96,9 @@
       :reagent-render
       (fn []
         (when @current-popover
-          (let [{:keys [view style blur-view? blur-view-props]} @current-popover
-                comp (if blur-view? react/blur-view react/view)]
+          (let [{:keys [view style disable-touchable-overlay? blur-view? blur-view-props]} @current-popover
+                comp (if blur-view? react/blur-view react/view)
+                overlay-comp (if disable-touchable-overlay? react/view react/touchable-highlight)]
             [comp (merge  {:style {:position :absolute :top 0 :bottom 0 :left 0 :right 0}} blur-view-props)
              (when platform/ios?
                [react/animated-view
@@ -108,7 +109,7 @@
                                     :left      0
                                     :right     0
                                     :transform [{:translateY bottom-anim-value}]}}
-              [react/touchable-highlight
+              [overlay-comp
                {:style    {:flex 1 :align-items :center :justify-content :center}
                 :on-press request-close}
                [react/view (merge {:background-color (if blur-view? :transparent colors/white)
@@ -119,67 +120,66 @@
                                    :shadow-opacity   1
                                    :shadow-color     "rgba(0, 9, 26, 0.12)"}
                                   style)
-                [react/touchable-opacity {:active-opacity 1}
-                 (cond
-                   (vector? view)
-                   view
+                (cond
+                  (vector? view)
+                  view
 
-                   (= :signing-phrase view)
-                   [signing-phrase/signing-phrase]
+                  (= :signing-phrase view)
+                  [signing-phrase/signing-phrase]
 
-                   (= :share-account view)
-                   [request/share-address]
+                  (= :share-account view)
+                  [request/share-address]
 
-                   (= :share-chat-key view)
-                   [profile.user/share-chat-key]
+                  (= :share-chat-key view)
+                  [profile.user/share-chat-key]
 
-                   (= :custom-seed-phrase view)
-                   [multiaccounts.recover/custom-seed-phrase]
+                  (= :custom-seed-phrase view)
+                  [multiaccounts.recover/custom-seed-phrase]
 
-                   (= :enable-biometric view)
-                   [biometric/enable-biometric-popover]
+                  (= :enable-biometric view)
+                  [biometric/enable-biometric-popover]
 
-                   (= :secure-with-biometric view)
-                   [biometric/secure-with-biometric-popover]
+                  (= :secure-with-biometric view)
+                  [biometric/secure-with-biometric-popover]
 
-                   (= :disable-password-saving view)
-                   [biometric/disable-password-saving-popover]
+                  (= :disable-password-saving view)
+                  [biometric/disable-password-saving-popover]
 
-                   (= :transaction-data view)
-                   [signing/transaction-data]
+                  (= :transaction-data view)
+                  [signing/transaction-data]
 
-                   (= :frozen-card view)
-                   [frozen-card/frozen-card]
+                  (= :frozen-card view)
+                  [frozen-card/frozen-card]
 
-                   (= :blocked-card view)
-                   [keycard.views/blocked-card-popover]
+                  (= :blocked-card view)
+                  [keycard.views/blocked-card-popover]
 
-                   (= :export-community view)
-                   [communities/export-community]
+                  (= :export-community view)
+                  [communities/export-community]
 
-                   (= :seed-key-uid-mismatch view)
-                   [multiaccounts.key-storage/seed-key-uid-mismatch-popover]
+                  (= :seed-key-uid-mismatch view)
+                  [multiaccounts.key-storage/seed-key-uid-mismatch-popover]
 
-                   (= :transfer-multiaccount-to-keycard-warning view)
-                   [multiaccounts.key-storage/transfer-multiaccount-warning-popover]
+                  (= :transfer-multiaccount-to-keycard-warning view)
+                  [multiaccounts.key-storage/transfer-multiaccount-warning-popover]
 
-                   (= :transfer-multiaccount-unknown-error view)
-                   [multiaccounts.key-storage/unknown-error-popover]
+                  (= :transfer-multiaccount-unknown-error view)
+                  [multiaccounts.key-storage/unknown-error-popover]
 
-                   (= :password-reset-popover view)
-                   [reset-password.views/reset-password-popover]
+                  (= :password-reset-popover view)
+                  [reset-password.views/reset-password-popover]
 
-                   (= :pin-limit view)
-                   [pinned-message/pin-limit-popover]
+                  (= :pin-limit view)
+                  [pinned-message/pin-limit-popover]
 
-                   (= :fees-warning view)
-                   [signing-sheets/fees-warning]
+                  (= :fees-warning view)
+                  [signing-sheets/fees-warning]
 
-                   (= :activity-center view)
-                   [activity-center/activity-center]
+                  (= :activity-center view)
+                  [activity-center/activity-center]
 
-                   :else
-                   [view])]]]]])))})))
+                  :else
+                  [view])]]]])))})))
 
 (views/defview popover []
   (views/letsubs [popover [:popover/popover]


### PR DESCRIPTION
Fixes #14131, #14133 and #14134

### Summary

Implement Blur Background and force dark mode for Activity Center in the new UI. 

![Screenshot 2022-10-17 at 2 39 53 PM](https://user-images.githubusercontent.com/19339952/196137903-bbcc0f0e-a44d-4bad-8479-355a8d638e7b.png)


**Design** 

([Figma Link](https://www.figma.com/file/eDfxTa9IoaCMUy5cLTp0ys/Shell-for-Mobile?node-id=3806%3A586138))

#### Areas impacted

- Activity Center (Notifications Center)

**Platforms**

- Android
- iOS

**Steps to test**

1. Open the `Status` application
2. Navigate to the `Profile` tab
3. Navigate to `Advanced` and enable the `New UI`
4. Navigate to the `Communities` or `Messages` tab
5. Open  `Activity Center`

status: ready