### PR TITLE
Display contact verification requests and allow users to decline them

### DIFF
--- a/src/status_im/activity_center/core.cljs
+++ b/src/status_im/activity_center/core.cljs
@@ -43,6 +43,32 @@
     {:db (update-in db [:activity-center :notifications]
                     update-notifications new-notifications)}))
 
+;;;; Contact verification
+
+(fx/defn contact-verification-decline
+  {:events [:activity-center.contact-verification/decline]}
+  [_ contact-verification-id]
+  {::json-rpc/call [{:method     "wakuext_declineContactVerificationRequest"
+                     :params     [contact-verification-id]
+                     :on-success #(re-frame/dispatch [:activity-center.contact-verification/decline-success %])
+                     :on-error   #(re-frame/dispatch [:activity-center.contact-verification/decline-error contact-verification-id %])}]})
+
+(fx/defn contact-verification-decline-success
+  {:events [:activity-center.contact-verification/decline-success]}
+  [cofx response]
+  (->> response
+       :activityCenterNotifications
+       (map data-store.activities/<-rpc)
+       (notifications-reconcile cofx)))
+
+(fx/defn contact-verification-decline-error
+  {:events [:activity-center.contact-verification/decline-error]}
+  [_ contact-verification-id error]
+  (log/warn "Failed to decline contact verification"
+            {:contact-verification-id contact-verification-id
+             :error                   error})
+  nil)
+
 ;;;; Notifications fetching and pagination
 
 (def defaults

--- a/src/status_im/activity_center/core.cljs
+++ b/src/status_im/activity_center/core.cljs
@@ -1,6 +1,6 @@
 (ns status-im.activity-center.core
-  (:require [re-frame.core :as re-frame]
-            [status-im.constants :as constants]
+  (:require [re-frame.core :as rf]
+            [status-im.constants :as c]
             [status-im.data-store.activities :as data-store.activities]
             [status-im.ethereum.json-rpc :as json-rpc]
             [status-im.utils.fx :as fx]
@@ -29,12 +29,12 @@
               (as-> acc $
                 (update-in $ [type :read :data] remove-notification)
                 (update-in $ [type :unread :data] remove-notification)
-                (update-in $ [constants/activity-center-notification-type-no-type :read :data] remove-notification)
-                (update-in $ [constants/activity-center-notification-type-no-type :unread :data] remove-notification)
+                (update-in $ [c/activity-center-notification-type-no-type :read :data] remove-notification)
+                (update-in $ [c/activity-center-notification-type-no-type :unread :data] remove-notification)
                 (if (or (:dismissed notification) (:accepted notification))
                   $
                   (-> $ (update-in [type filter-status :data] insert-and-sort)
-                      (update-in [constants/activity-center-notification-type-no-type filter-status :data] insert-and-sort))))))
+                      (update-in [c/activity-center-notification-type-no-type filter-status :data] insert-and-sort))))))
           db-notifications
           new-notifications))
 
@@ -52,8 +52,8 @@
   [_ contact-verification-id]
   {::json-rpc/call [{:method     "wakuext_declineContactVerificationRequest"
                      :params     [contact-verification-id]
-                     :on-success #(re-frame/dispatch [:activity-center.contact-verification/decline-success %])
-                     :on-error   #(re-frame/dispatch [:activity-center.contact-verification/decline-error contact-verification-id %])}]})
+                     :on-success #(rf/dispatch [:activity-center.contact-verification/decline-success %])
+                     :on-error   #(rf/dispatch [:activity-center.contact-verification/decline-error contact-verification-id %])}]})
 
 (fx/defn contact-verification-decline-success
   {:events [:activity-center.contact-verification/decline-success]}
@@ -75,7 +75,7 @@
 
 (def defaults
   {:filter-status          :unread
-   :filter-type            constants/activity-center-notification-type-no-type
+   :filter-type            c/activity-center-notification-type-no-type
    :notifications-per-page 10})
 
 (def start-or-end-cursor
@@ -98,8 +98,8 @@
     {:db             (assoc-in db [:activity-center :notifications filter-type filter-status :loading?] true)
      ::json-rpc/call [{:method     (filter-status->rpc-method filter-status)
                        :params     [cursor (defaults :notifications-per-page) filter-type]
-                       :on-success #(re-frame/dispatch [:activity-center.notifications/fetch-success filter-type filter-status reset-data? %])
-                       :on-error   #(re-frame/dispatch [:activity-center.notifications/fetch-error filter-type filter-status %])}]}))
+                       :on-success #(rf/dispatch [:activity-center.notifications/fetch-success filter-type filter-status reset-data? %])
+                       :on-error   #(rf/dispatch [:activity-center.notifications/fetch-error filter-type filter-status %])}]}))
 
 (fx/defn notifications-fetch-first-page
   {:events [:activity-center.notifications/fetch-first-page]}

--- a/src/status_im/activity_center/core.cljs
+++ b/src/status_im/activity_center/core.cljs
@@ -1,6 +1,6 @@
 (ns status-im.activity-center.core
   (:require [re-frame.core :as rf]
-            [status-im.constants :as c]
+            [status-im.constants :as const]
             [status-im.data-store.activities :as data-store.activities]
             [status-im.ethereum.json-rpc :as json-rpc]
             [status-im.utils.fx :as fx]
@@ -29,12 +29,12 @@
               (as-> acc $
                 (update-in $ [type :read :data] remove-notification)
                 (update-in $ [type :unread :data] remove-notification)
-                (update-in $ [c/activity-center-notification-type-no-type :read :data] remove-notification)
-                (update-in $ [c/activity-center-notification-type-no-type :unread :data] remove-notification)
+                (update-in $ [const/activity-center-notification-type-no-type :read :data] remove-notification)
+                (update-in $ [const/activity-center-notification-type-no-type :unread :data] remove-notification)
                 (if (or (:dismissed notification) (:accepted notification))
                   $
                   (-> $ (update-in [type filter-status :data] insert-and-sort)
-                      (update-in [c/activity-center-notification-type-no-type filter-status :data] insert-and-sort))))))
+                      (update-in [const/activity-center-notification-type-no-type filter-status :data] insert-and-sort))))))
           db-notifications
           new-notifications))
 
@@ -75,7 +75,7 @@
 
 (def defaults
   {:filter-status          :unread
-   :filter-type            c/activity-center-notification-type-no-type
+   :filter-type            const/activity-center-notification-type-no-type
    :notifications-per-page 10})
 
 (def start-or-end-cursor

--- a/src/status_im/activity_center/core_test.cljs
+++ b/src/status_im/activity_center/core_test.cljs
@@ -83,7 +83,11 @@
                      :type     c/activity-center-notification-type-private-group-chat
                      :accepted true}]])
 
-     (is (= {c/activity-center-notification-type-one-to-one-chat
+     (is (= {c/activity-center-notification-type-no-type
+             {:read   {:data []}
+              :unread {:data []}}
+
+             c/activity-center-notification-type-one-to-one-chat
              {:read   {:cursor ""
                        :data   [{:id   "0x2"
                                  :read true
@@ -102,7 +106,19 @@
     (rf-test/run-test-sync
      (setup)
      (rf/dispatch [:test/assoc-in [:activity-center :notifications]
-                   {c/activity-center-notification-type-one-to-one-chat
+                   {c/activity-center-notification-type-no-type
+                    {:read   {:cursor ""
+                              :data   [{:id   "0x1"
+                                        :read true
+                                        :type c/activity-center-notification-type-one-to-one-chat}]}
+                     :unread {:cursor ""
+                              :data   [{:id   "0x4"
+                                        :read false
+                                        :type c/activity-center-notification-type-private-group-chat}
+                                       {:id   "0x6"
+                                        :read false
+                                        :type c/activity-center-notification-type-private-group-chat}]}}
+                    c/activity-center-notification-type-one-to-one-chat
                     {:read {:cursor ""
                             :data   [{:id   "0x1"
                                       :read true
@@ -129,7 +145,21 @@
                      :read false
                      :type c/activity-center-notification-type-private-group-chat}]])
 
-     (is (= {c/activity-center-notification-type-one-to-one-chat
+     (is (= {c/activity-center-notification-type-no-type
+             {:read   {:cursor ""
+                       :data   [{:id           "0x1"
+                                 :read         true
+                                 :type         c/activity-center-notification-type-one-to-one-chat
+                                 :last-message {}}]}
+              :unread {:cursor ""
+                       :data   [{:id   "0x6"
+                                 :read false
+                                 :type c/activity-center-notification-type-private-group-chat}
+                                {:id     "0x4"
+                                 :read   false
+                                 :type   c/activity-center-notification-type-private-group-chat
+                                 :author "0xabc"}]}}
+             c/activity-center-notification-type-one-to-one-chat
              {:read   {:cursor ""
                        :data   [{:id           "0x1"
                                  :read         true
@@ -163,7 +193,13 @@
                      :read false
                      :type c/activity-center-notification-type-one-to-one-chat}]])
 
-     (is (= {c/activity-center-notification-type-one-to-one-chat
+     (is (= {c/activity-center-notification-type-no-type
+             {:read   {:data []}
+              :unread {:data [{:id   "0x1"
+                               :read false
+                               :type c/activity-center-notification-type-one-to-one-chat}]}}
+
+             c/activity-center-notification-type-one-to-one-chat
              {:read   {:cursor ""
                        :data   []}
               :unread {:data [{:id   "0x1"
@@ -190,7 +226,18 @@
                    [{:id "0x1" :read true :type c/activity-center-notification-type-one-to-one-chat :timestamp 1 :last-message {}}
                     {:id "0x4" :read false :type c/activity-center-notification-type-one-to-one-chat :timestamp 100 :last-message {}}]])
 
-     (is (= {c/activity-center-notification-type-one-to-one-chat
+     (is (= {c/activity-center-notification-type-no-type
+             {:read   {:data   [{:id           "0x1"
+                                 :read         true
+                                 :type         c/activity-center-notification-type-one-to-one-chat
+                                 :timestamp    1
+                                 :last-message {}}]}
+              :unread {:data   [{:id           "0x4"
+                                 :read         false
+                                 :type         c/activity-center-notification-type-one-to-one-chat
+                                 :timestamp    100
+                                 :last-message {}}]}}
+             c/activity-center-notification-type-one-to-one-chat
              {:read   {:cursor ""
                        :data   [{:id        "0x2"
                                  :read      true

--- a/src/status_im/activity_center/core_test.cljs
+++ b/src/status_im/activity_center/core_test.cljs
@@ -11,15 +11,18 @@
   (h/register-helper-events)
   (rf/dispatch [:init/app-started]))
 
-(defn remove-color-key
-  "Remove `:color` key from notifications because they have random values that we
-  can't assert against."
-  [grouped-notifications {:keys [type status]}]
-  (update-in grouped-notifications
-             [type status :data]
-             (fn [old _]
-               (map #(dissoc % :color) old))
-             nil))
+;;;; Contact verification
+
+(deftest contact-verification-decline-test
+  (rf-test/run-test-sync
+   (setup)
+   (let [spy-queue               (atom [])
+         contact-verification-id 24]
+     (h/spy-fx spy-queue ::json-rpc/call)
+
+     (rf/dispatch [:activity-center.contact-verification/decline contact-verification-id]))))
+
+;;;; Notification reconciliation
 
 (deftest notifications-reconcile-test
   (testing "does nothing when there are no new notifications"
@@ -213,6 +216,18 @@
                                  :type      c/activity-center-notification-type-one-to-one-chat
                                  :timestamp 50}]}}}
             (get-in (h/db) [:activity-center :notifications]))))))
+
+;;;; Notifications fetching and pagination
+
+(defn remove-color-key
+  "Remove `:color` key from notifications because they have random values that we
+  can't assert against."
+  [grouped-notifications {:keys [type status]}]
+  (update-in grouped-notifications
+             [type status :data]
+             (fn [old _]
+               (map #(dissoc % :color) old))
+             nil))
 
 (deftest notifications-fetch-test
   (testing "fetches first page"

--- a/src/status_im/activity_center/core_test.cljs
+++ b/src/status_im/activity_center/core_test.cljs
@@ -2,7 +2,7 @@
   (:require [cljs.test :refer [deftest is testing]]
             [day8.re-frame.test :as rf-test]
             [re-frame.core :as rf]
-            [status-im.constants :as c]
+            [status-im.constants :as const]
             [status-im.ethereum.json-rpc :as json-rpc]
             status-im.events
             [status-im.test-helpers :as h]))
@@ -54,7 +54,7 @@
                                     :read                        true
                                     :reply-message               nil
                                     :timestamp                   1666647286000
-                                    :type                        6}]
+                                    :type                        const/activity-center-notification-type-contact-verification}]
        (h/stub-fx-with-callbacks
         ::json-rpc/call
         :on-success (constantly {:activityCenterNotifications
@@ -68,7 +68,7 @@
                                    :name                      "0x04d03f"
                                    :read                      true
                                    :timestamp                 1666647286000
-                                   :type                      c/activity-center-notification-type-contact-verification}]}))
+                                   :type                      const/activity-center-notification-type-contact-verification}]}))
 
        (h/spy-fx spy-queue ::json-rpc/call)
 
@@ -80,17 +80,17 @@
                   (get-in [0 :args 0])
                   (select-keys [:method :params]))))
 
-       (is (= {c/activity-center-notification-type-no-type
+       (is (= {const/activity-center-notification-type-no-type
                {:read   {:data [expected-notification]}
                 :unread {:data []}}
-               c/activity-center-notification-type-contact-verification
+               const/activity-center-notification-type-contact-verification
                {:read   {:data [expected-notification]}
                 :unread {:data []}}}
               (-> (h/db)
                   (get-in [:activity-center :notifications])
-                  (remove-color-key {:type   c/activity-center-notification-type-no-type
+                  (remove-color-key {:type   const/activity-center-notification-type-no-type
                                      :status :read})
-                  (remove-color-key {:type   c/activity-center-notification-type-contact-verification
+                  (remove-color-key {:type   const/activity-center-notification-type-contact-verification
                                      :status :read})))))))
 
   (testing "logs failure"
@@ -115,23 +115,23 @@
   (testing "does nothing when there are no new notifications"
     (rf-test/run-test-sync
      (setup)
-     (let [notifications {c/activity-center-notification-type-one-to-one-chat
+     (let [notifications {const/activity-center-notification-type-one-to-one-chat
                           {:read   {:cursor ""
                                     :data   [{:id   "0x1"
                                               :read true
-                                              :type c/activity-center-notification-type-one-to-one-chat}
+                                              :type const/activity-center-notification-type-one-to-one-chat}
                                              {:id   "0x2"
                                               :read true
-                                              :type c/activity-center-notification-type-one-to-one-chat}]}
+                                              :type const/activity-center-notification-type-one-to-one-chat}]}
                            :unread {:cursor ""
                                     :data   [{:id   "0x3"
                                               :read false
-                                              :type c/activity-center-notification-type-one-to-one-chat}]}}
-                          c/activity-center-notification-type-private-group-chat
+                                              :type const/activity-center-notification-type-one-to-one-chat}]}}
+                          const/activity-center-notification-type-private-group-chat
                           {:unread {:cursor ""
                                     :data   [{:id   "0x4"
                                               :read false
-                                              :type c/activity-center-notification-type-private-group-chat}]}}}]
+                                              :type const/activity-center-notification-type-private-group-chat}]}}}]
        (rf/dispatch [:test/assoc-in [:activity-center :notifications] notifications])
 
        (rf/dispatch [:activity-center.notifications/reconcile nil])
@@ -142,126 +142,127 @@
     (rf-test/run-test-sync
      (setup)
      (rf/dispatch [:test/assoc-in [:activity-center :notifications]
-                   {c/activity-center-notification-type-one-to-one-chat
+                   {const/activity-center-notification-type-one-to-one-chat
                     {:read   {:cursor ""
-                              :data   [{:id "0x1" :read true :type c/activity-center-notification-type-one-to-one-chat}
-                                       {:id "0x2" :read true :type c/activity-center-notification-type-one-to-one-chat}]}
+                              :data   [{:id "0x1" :read true :type const/activity-center-notification-type-one-to-one-chat}
+                                       {:id "0x2" :read true :type const/activity-center-notification-type-one-to-one-chat}]}
                      :unread {:cursor ""
-                              :data   [{:id "0x3" :read false :type c/activity-center-notification-type-one-to-one-chat}]}}
-                    2 {:unread {:cursor ""
-                                :data   [{:id "0x4" :read false :type 2}
-                                         {:id "0x6" :read false :type 2}]}}}])
+                              :data   [{:id "0x3" :read false :type const/activity-center-notification-type-one-to-one-chat}]}}
+                    const/activity-center-notification-type-private-group-chat
+                    {:unread {:cursor ""
+                              :data   [{:id "0x4" :read false :type const/activity-center-notification-type-private-group-chat}
+                                       {:id "0x6" :read false :type const/activity-center-notification-type-private-group-chat}]}}}])
 
      (rf/dispatch [:activity-center.notifications/reconcile
                    [{:id        "0x1"
                      :read      true
-                     :type      c/activity-center-notification-type-one-to-one-chat
+                     :type      const/activity-center-notification-type-one-to-one-chat
                      :dismissed true}
                     {:id       "0x3"
                      :read     false
-                     :type     c/activity-center-notification-type-one-to-one-chat
+                     :type     const/activity-center-notification-type-one-to-one-chat
                      :accepted true}
                     {:id        "0x4"
                      :read      false
-                     :type      c/activity-center-notification-type-private-group-chat
+                     :type      const/activity-center-notification-type-private-group-chat
                      :dismissed true}
                     {:id       "0x5"
                      :read     false
-                     :type     c/activity-center-notification-type-private-group-chat
+                     :type     const/activity-center-notification-type-private-group-chat
                      :accepted true}]])
 
-     (is (= {c/activity-center-notification-type-no-type
+     (is (= {const/activity-center-notification-type-no-type
              {:read   {:data []}
               :unread {:data []}}
 
-             c/activity-center-notification-type-one-to-one-chat
+             const/activity-center-notification-type-one-to-one-chat
              {:read   {:cursor ""
                        :data   [{:id   "0x2"
                                  :read true
-                                 :type c/activity-center-notification-type-one-to-one-chat}]}
+                                 :type const/activity-center-notification-type-one-to-one-chat}]}
               :unread {:cursor ""
                        :data   []}}
-             c/activity-center-notification-type-private-group-chat
+             const/activity-center-notification-type-private-group-chat
              {:read   {:data []}
               :unread {:cursor ""
                        :data   [{:id   "0x6"
                                  :read false
-                                 :type c/activity-center-notification-type-private-group-chat}]}}}
+                                 :type const/activity-center-notification-type-private-group-chat}]}}}
             (get-in (h/db) [:activity-center :notifications])))))
 
   (testing "replaces old notifications with newly arrived ones"
     (rf-test/run-test-sync
      (setup)
      (rf/dispatch [:test/assoc-in [:activity-center :notifications]
-                   {c/activity-center-notification-type-no-type
+                   {const/activity-center-notification-type-no-type
                     {:read   {:cursor ""
                               :data   [{:id   "0x1"
                                         :read true
-                                        :type c/activity-center-notification-type-one-to-one-chat}]}
+                                        :type const/activity-center-notification-type-one-to-one-chat}]}
                      :unread {:cursor ""
                               :data   [{:id   "0x4"
                                         :read false
-                                        :type c/activity-center-notification-type-private-group-chat}
+                                        :type const/activity-center-notification-type-private-group-chat}
                                        {:id   "0x6"
                                         :read false
-                                        :type c/activity-center-notification-type-private-group-chat}]}}
-                    c/activity-center-notification-type-one-to-one-chat
+                                        :type const/activity-center-notification-type-private-group-chat}]}}
+                    const/activity-center-notification-type-one-to-one-chat
                     {:read {:cursor ""
                             :data   [{:id   "0x1"
                                       :read true
-                                      :type c/activity-center-notification-type-one-to-one-chat}]}}
-                    c/activity-center-notification-type-private-group-chat
+                                      :type const/activity-center-notification-type-one-to-one-chat}]}}
+                    const/activity-center-notification-type-private-group-chat
                     {:unread {:cursor ""
                               :data   [{:id   "0x4"
                                         :read false
-                                        :type c/activity-center-notification-type-private-group-chat}
+                                        :type const/activity-center-notification-type-private-group-chat}
                                        {:id   "0x6"
                                         :read false
-                                        :type c/activity-center-notification-type-private-group-chat}]}}}])
+                                        :type const/activity-center-notification-type-private-group-chat}]}}}])
 
      (rf/dispatch [:activity-center.notifications/reconcile
                    [{:id           "0x1"
                      :read         true
-                     :type         c/activity-center-notification-type-one-to-one-chat
+                     :type         const/activity-center-notification-type-one-to-one-chat
                      :last-message {}}
                     {:id     "0x4"
                      :read   false
-                     :type   c/activity-center-notification-type-private-group-chat
+                     :type   const/activity-center-notification-type-private-group-chat
                      :author "0xabc"}
                     {:id   "0x6"
                      :read false
-                     :type c/activity-center-notification-type-private-group-chat}]])
+                     :type const/activity-center-notification-type-private-group-chat}]])
 
-     (is (= {c/activity-center-notification-type-no-type
+     (is (= {const/activity-center-notification-type-no-type
              {:read   {:cursor ""
                        :data   [{:id           "0x1"
                                  :read         true
-                                 :type         c/activity-center-notification-type-one-to-one-chat
+                                 :type         const/activity-center-notification-type-one-to-one-chat
                                  :last-message {}}]}
               :unread {:cursor ""
                        :data   [{:id   "0x6"
                                  :read false
-                                 :type c/activity-center-notification-type-private-group-chat}
+                                 :type const/activity-center-notification-type-private-group-chat}
                                 {:id     "0x4"
                                  :read   false
-                                 :type   c/activity-center-notification-type-private-group-chat
+                                 :type   const/activity-center-notification-type-private-group-chat
                                  :author "0xabc"}]}}
-             c/activity-center-notification-type-one-to-one-chat
+             const/activity-center-notification-type-one-to-one-chat
              {:read   {:cursor ""
                        :data   [{:id           "0x1"
                                  :read         true
-                                 :type         c/activity-center-notification-type-one-to-one-chat
+                                 :type         const/activity-center-notification-type-one-to-one-chat
                                  :last-message {}}]}
               :unread {:data []}}
-             c/activity-center-notification-type-private-group-chat
+             const/activity-center-notification-type-private-group-chat
              {:read   {:data []}
               :unread {:cursor ""
                        :data   [{:id   "0x6"
                                  :read false
-                                 :type c/activity-center-notification-type-private-group-chat}
+                                 :type const/activity-center-notification-type-private-group-chat}
                                 {:id     "0x4"
                                  :read   false
-                                 :type   c/activity-center-notification-type-private-group-chat
+                                 :type   const/activity-center-notification-type-private-group-chat
                                  :author "0xabc"}]}}}
             (get-in (h/db) [:activity-center :notifications])))))
 
@@ -269,29 +270,29 @@
     (rf-test/run-test-sync
      (setup)
      (rf/dispatch [:test/assoc-in [:activity-center :notifications]
-                   {c/activity-center-notification-type-one-to-one-chat
+                   {const/activity-center-notification-type-one-to-one-chat
                     {:read {:cursor ""
                             :data   [{:id   "0x1"
                                       :read true
-                                      :type c/activity-center-notification-type-one-to-one-chat}]}}}])
+                                      :type const/activity-center-notification-type-one-to-one-chat}]}}}])
 
      (rf/dispatch [:activity-center.notifications/reconcile
                    [{:id   "0x1"
                      :read false
-                     :type c/activity-center-notification-type-one-to-one-chat}]])
+                     :type const/activity-center-notification-type-one-to-one-chat}]])
 
-     (is (= {c/activity-center-notification-type-no-type
+     (is (= {const/activity-center-notification-type-no-type
              {:read   {:data []}
               :unread {:data [{:id   "0x1"
                                :read false
-                               :type c/activity-center-notification-type-one-to-one-chat}]}}
+                               :type const/activity-center-notification-type-one-to-one-chat}]}}
 
-             c/activity-center-notification-type-one-to-one-chat
+             const/activity-center-notification-type-one-to-one-chat
              {:read   {:cursor ""
                        :data   []}
               :unread {:data [{:id   "0x1"
                                :read false
-                               :type c/activity-center-notification-type-one-to-one-chat}]}}}
+                               :type const/activity-center-notification-type-one-to-one-chat}]}}}
             (get-in (h/db) [:activity-center :notifications])))))
 
   ;; Sorting by timestamp and ID is compatible with what the backend does when
@@ -300,54 +301,54 @@
     (rf-test/run-test-sync
      (setup)
      (rf/dispatch [:test/assoc-in [:activity-center :notifications]
-                   {c/activity-center-notification-type-one-to-one-chat
+                   {const/activity-center-notification-type-one-to-one-chat
                     {:read   {:cursor ""
-                              :data   [{:id "0x1" :read true :type c/activity-center-notification-type-one-to-one-chat :timestamp 1}
-                                       {:id "0x2" :read true :type c/activity-center-notification-type-one-to-one-chat :timestamp 1}]}
+                              :data   [{:id "0x1" :read true :type const/activity-center-notification-type-one-to-one-chat :timestamp 1}
+                                       {:id "0x2" :read true :type const/activity-center-notification-type-one-to-one-chat :timestamp 1}]}
                      :unread {:cursor ""
-                              :data   [{:id "0x3" :read false :type c/activity-center-notification-type-one-to-one-chat :timestamp 50}
-                                       {:id "0x4" :read false :type c/activity-center-notification-type-one-to-one-chat :timestamp 100}
-                                       {:id "0x5" :read false :type c/activity-center-notification-type-one-to-one-chat :timestamp 100}]}}}])
+                              :data   [{:id "0x3" :read false :type const/activity-center-notification-type-one-to-one-chat :timestamp 50}
+                                       {:id "0x4" :read false :type const/activity-center-notification-type-one-to-one-chat :timestamp 100}
+                                       {:id "0x5" :read false :type const/activity-center-notification-type-one-to-one-chat :timestamp 100}]}}}])
 
      (rf/dispatch [:activity-center.notifications/reconcile
-                   [{:id "0x1" :read true :type c/activity-center-notification-type-one-to-one-chat :timestamp 1 :last-message {}}
-                    {:id "0x4" :read false :type c/activity-center-notification-type-one-to-one-chat :timestamp 100 :last-message {}}]])
+                   [{:id "0x1" :read true :type const/activity-center-notification-type-one-to-one-chat :timestamp 1 :last-message {}}
+                    {:id "0x4" :read false :type const/activity-center-notification-type-one-to-one-chat :timestamp 100 :last-message {}}]])
 
-     (is (= {c/activity-center-notification-type-no-type
-             {:read   {:data   [{:id           "0x1"
-                                 :read         true
-                                 :type         c/activity-center-notification-type-one-to-one-chat
-                                 :timestamp    1
-                                 :last-message {}}]}
-              :unread {:data   [{:id           "0x4"
-                                 :read         false
-                                 :type         c/activity-center-notification-type-one-to-one-chat
-                                 :timestamp    100
-                                 :last-message {}}]}}
-             c/activity-center-notification-type-one-to-one-chat
+     (is (= {const/activity-center-notification-type-no-type
+             {:read   {:data [{:id           "0x1"
+                               :read         true
+                               :type         const/activity-center-notification-type-one-to-one-chat
+                               :timestamp    1
+                               :last-message {}}]}
+              :unread {:data [{:id           "0x4"
+                               :read         false
+                               :type         const/activity-center-notification-type-one-to-one-chat
+                               :timestamp    100
+                               :last-message {}}]}}
+             const/activity-center-notification-type-one-to-one-chat
              {:read   {:cursor ""
                        :data   [{:id        "0x2"
                                  :read      true
-                                 :type      c/activity-center-notification-type-one-to-one-chat
+                                 :type      const/activity-center-notification-type-one-to-one-chat
                                  :timestamp 1}
                                 {:id           "0x1"
                                  :read         true
-                                 :type         c/activity-center-notification-type-one-to-one-chat
+                                 :type         const/activity-center-notification-type-one-to-one-chat
                                  :timestamp    1
                                  :last-message {}}]}
               :unread {:cursor ""
                        :data   [{:id        "0x5"
                                  :read      false
-                                 :type      c/activity-center-notification-type-one-to-one-chat
+                                 :type      const/activity-center-notification-type-one-to-one-chat
                                  :timestamp 100}
                                 {:id           "0x4"
                                  :read         false
-                                 :type         c/activity-center-notification-type-one-to-one-chat
+                                 :type         const/activity-center-notification-type-one-to-one-chat
                                  :timestamp    100
                                  :last-message {}}
                                 {:id        "0x3"
                                  :read      false
-                                 :type      c/activity-center-notification-type-one-to-one-chat
+                                 :type      const/activity-center-notification-type-one-to-one-chat
                                  :timestamp 50}]}}}
             (get-in (h/db) [:activity-center :notifications]))))))
 
@@ -362,22 +363,22 @@
         ::json-rpc/call
         :on-success (constantly {:cursor        "10"
                                  :notifications [{:id     "0x1"
-                                                  :type   c/activity-center-notification-type-one-to-one-chat
+                                                  :type   const/activity-center-notification-type-one-to-one-chat
                                                   :read   false
                                                   :chatId "0x9"}]}))
        (h/spy-fx spy-queue ::json-rpc/call)
 
        (rf/dispatch [:activity-center.notifications/fetch-first-page
-                     {:filter-type c/activity-center-notification-type-one-to-one-chat}])
+                     {:filter-type const/activity-center-notification-type-one-to-one-chat}])
 
        (is (= :unread (get-in (h/db) [:activity-center :filter :status])))
        (is (= "" (get-in @spy-queue [0 :args 0 :params 0]))
            "Should be called with empty cursor when fetching first page")
-       (is (= {c/activity-center-notification-type-one-to-one-chat
+       (is (= {const/activity-center-notification-type-one-to-one-chat
                {:unread {:cursor "10"
                          :data   [{:chat-id       "0x9"
                                    :chat-name     nil
-                                   :chat-type     c/activity-center-notification-type-one-to-one-chat
+                                   :chat-type     const/activity-center-notification-type-one-to-one-chat
                                    :group-chat    false
                                    :id            "0x1"
                                    :public?       false
@@ -385,10 +386,10 @@
                                    :message       nil
                                    :read          false
                                    :reply-message nil
-                                   :type          c/activity-center-notification-type-one-to-one-chat}]}}}
+                                   :type          const/activity-center-notification-type-one-to-one-chat}]}}}
               (remove-color-key (get-in (h/db) [:activity-center :notifications])
                                 {:status :unread
-                                 :type   c/activity-center-notification-type-one-to-one-chat}))))))
+                                 :type   const/activity-center-notification-type-one-to-one-chat}))))))
 
   (testing "does not fetch next page when pagination cursor reached the end"
     (rf-test/run-test-sync
@@ -398,8 +399,8 @@
        (rf/dispatch [:test/assoc-in [:activity-center :filter :status]
                      :unread])
        (rf/dispatch [:test/assoc-in [:activity-center :filter :type]
-                     c/activity-center-notification-type-one-to-one-chat])
-       (rf/dispatch [:test/assoc-in [:activity-center :notifications c/activity-center-notification-type-one-to-one-chat :unread :cursor]
+                     const/activity-center-notification-type-one-to-one-chat])
+       (rf/dispatch [:test/assoc-in [:activity-center :notifications const/activity-center-notification-type-one-to-one-chat :unread :cursor]
                      ""])
 
        (rf/dispatch [:activity-center.notifications/fetch-next-page])
@@ -417,8 +418,8 @@
        (rf/dispatch [:test/assoc-in [:activity-center :filter :status]
                      :unread])
        (rf/dispatch [:test/assoc-in [:activity-center :filter :type]
-                     c/activity-center-notification-type-one-to-one-chat])
-       (rf/dispatch [:test/assoc-in [:activity-center :notifications c/activity-center-notification-type-one-to-one-chat :unread :cursor]
+                     const/activity-center-notification-type-one-to-one-chat])
+       (rf/dispatch [:test/assoc-in [:activity-center :notifications const/activity-center-notification-type-one-to-one-chat :unread :cursor]
                      nil])
 
        (rf/dispatch [:activity-center.notifications/fetch-next-page])
@@ -433,15 +434,15 @@
         ::json-rpc/call
         :on-success (constantly {:cursor        ""
                                  :notifications [{:id     "0x1"
-                                                  :type   c/activity-center-notification-type-mention
+                                                  :type   const/activity-center-notification-type-mention
                                                   :read   false
                                                   :chatId "0x9"}]}))
        (h/spy-fx spy-queue ::json-rpc/call)
        (rf/dispatch [:test/assoc-in [:activity-center :filter :status]
                      :unread])
        (rf/dispatch [:test/assoc-in [:activity-center :filter :type]
-                     c/activity-center-notification-type-mention])
-       (rf/dispatch [:test/assoc-in [:activity-center :notifications c/activity-center-notification-type-mention :unread :cursor]
+                     const/activity-center-notification-type-mention])
+       (rf/dispatch [:test/assoc-in [:activity-center :notifications const/activity-center-notification-type-mention :unread :cursor]
                      "10"])
 
        (rf/dispatch [:activity-center.notifications/fetch-next-page])
@@ -449,7 +450,7 @@
        (is (= "wakuext_unreadActivityCenterNotifications" (get-in @spy-queue [0 :args 0 :method])))
        (is (= "10" (get-in @spy-queue [0 :args 0 :params 0]))
            "Should be called with current cursor")
-       (is (= {c/activity-center-notification-type-mention
+       (is (= {const/activity-center-notification-type-mention
                {:unread {:cursor ""
                          :data   [{:chat-id       "0x9"
                                    :chat-name     nil
@@ -459,10 +460,10 @@
                                    :message       nil
                                    :read          false
                                    :reply-message nil
-                                   :type          c/activity-center-notification-type-mention}]}}}
+                                   :type          const/activity-center-notification-type-mention}]}}}
               (remove-color-key (get-in (h/db) [:activity-center :notifications])
                                 {:status :unread
-                                 :type   c/activity-center-notification-type-mention}))))))
+                                 :type   const/activity-center-notification-type-mention}))))))
 
   (testing "does not fetch next page while it is still loading"
     (rf-test/run-test-sync
@@ -472,10 +473,10 @@
        (rf/dispatch [:test/assoc-in [:activity-center :filter :status]
                      :read])
        (rf/dispatch [:test/assoc-in [:activity-center :filter :type]
-                     c/activity-center-notification-type-one-to-one-chat])
-       (rf/dispatch [:test/assoc-in [:activity-center :notifications c/activity-center-notification-type-one-to-one-chat :read :cursor]
+                     const/activity-center-notification-type-one-to-one-chat])
+       (rf/dispatch [:test/assoc-in [:activity-center :notifications const/activity-center-notification-type-one-to-one-chat :read :cursor]
                      "10"])
-       (rf/dispatch [:test/assoc-in [:activity-center :notifications c/activity-center-notification-type-one-to-one-chat :read :loading?]
+       (rf/dispatch [:test/assoc-in [:activity-center :notifications const/activity-center-notification-type-one-to-one-chat :read :loading?]
                      true])
 
        (rf/dispatch [:activity-center.notifications/fetch-next-page])
@@ -492,15 +493,15 @@
        (rf/dispatch [:test/assoc-in [:activity-center :filter :status]
                      :unread])
        (rf/dispatch [:test/assoc-in [:activity-center :filter :type]
-                     c/activity-center-notification-type-one-to-one-chat])
-       (rf/dispatch [:test/assoc-in [:activity-center :notifications c/activity-center-notification-type-one-to-one-chat :unread :cursor]
+                     const/activity-center-notification-type-one-to-one-chat])
+       (rf/dispatch [:test/assoc-in [:activity-center :notifications const/activity-center-notification-type-one-to-one-chat :unread :cursor]
                      ""])
 
        (rf/dispatch [:activity-center.notifications/fetch-first-page])
 
-       (is (nil? (get-in (h/db) [:activity-center :notifications c/activity-center-notification-type-one-to-one-chat :unread :loading?])))
+       (is (nil? (get-in (h/db) [:activity-center :notifications const/activity-center-notification-type-one-to-one-chat :unread :loading?])))
        (is (= [:activity-center.notifications/fetch-error
-               c/activity-center-notification-type-one-to-one-chat
+               const/activity-center-notification-type-one-to-one-chat
                :unread
                :fake-error]
               (:args (last @spy-queue))))))))

--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -22,6 +22,13 @@
 (def ^:const contact-request-state-received 3)
 (def ^:const contact-request-state-dismissed 4)
 
+(def ^:const contact-verification-state-unknown 0)
+(def ^:const contact-verification-state-pending 1)
+(def ^:const contact-verification-state-accepted 2)
+(def ^:const contact-verification-state-declined 3)
+(def ^:const contact-verification-state-cancelled 4)
+(def ^:const contact-verification-state-trusted 5)
+
 (def ^:const emoji-reaction-love 1)
 (def ^:const emoji-reaction-thumbs-up  2)
 (def ^:const emoji-reaction-thumbs-down  3)
@@ -183,11 +190,15 @@
 (def ^:const activity-center-notification-type-mention 3)
 (def ^:const activity-center-notification-type-reply 4)
 (def ^:const activity-center-notification-type-contact-request 5)
+(def ^:const activity-center-notification-type-contact-verification 6)
+
+;; TODO: Remove this constant once the old Notification Center code is removed.
+;; Its value clashes with the new constant `activity-center-notification-type-contact-verification`
+;; used in status-go.
 (def ^:const activity-center-notification-type-contact-request-retracted 6)
 
 ;; TODO: Replace with correct enum values once status-go implements them.
 (def ^:const activity-center-notification-type-admin 66610)
-(def ^:const activity-center-notification-type-identity-verification 66611)
 (def ^:const activity-center-notification-type-tx 66612)
 (def ^:const activity-center-notification-type-membership 66613)
 (def ^:const activity-center-notification-type-system 66614)

--- a/src/status_im/data_store/activities.cljs
+++ b/src/status_im/data_store/activities.cljs
@@ -1,44 +1,44 @@
 (ns status-im.data-store.activities
-  (:require [status-im.data-store.messages :as messages]
-            [status-im.constants :as constants]
+  (:require [clojure.set :as set]
             [quo.design-system.colors :as colors]
-            clojure.set))
+            [status-im.constants :as constants]
+            [status-im.data-store.messages :as messages]))
 
-(defn rpc->type [{:keys [type name] :as chat}]
-  (cond
-    (= constants/activity-center-notification-type-reply type)
+(defn- rpc->type [{:keys [type name] :as chat}]
+  (case type
+    constants/activity-center-notification-type-reply
     (assoc chat
            :chat-name name
            :chat-type constants/private-group-chat-type)
 
-    (= constants/activity-center-notification-type-mention type)
+    constants/activity-center-notification-type-mention
     (assoc chat
            :chat-type constants/private-group-chat-type
            :chat-name name)
 
-    (= constants/activity-center-notification-type-private-group-chat type)
+    constants/activity-center-notification-type-private-group-chat
     (assoc chat
            :chat-type constants/private-group-chat-type
            :chat-name name
            :public? false
            :group-chat true)
 
-    (= constants/activity-center-notification-type-one-to-one-chat type)
+    constants/activity-center-notification-type-one-to-one-chat
     (assoc chat
            :chat-type constants/one-to-one-chat-type
            :chat-name name
            :public? false
            :group-chat false)
 
-    :else
     chat))
 
 (defn <-rpc [item]
   (-> item
       rpc->type
-      (clojure.set/rename-keys {:lastMessage  :last-message
-                                :replyMessage :reply-message
-                                :chatId       :chat-id})
+      (set/rename-keys {:lastMessage               :last-message
+                        :replyMessage              :reply-message
+                        :chatId                    :chat-id
+                        :contactVerificationStatus :contact-verification-status})
       (assoc :color (rand-nth colors/chat-colors))
       (update :last-message #(when % (messages/<-rpc %)))
       (update :message #(when % (messages/<-rpc %)))

--- a/src/status_im/data_store/activities_test.cljs
+++ b/src/status_im/data_store/activities_test.cljs
@@ -4,11 +4,17 @@
             [status-im.constants :as constants]
             [status-im.data-store.activities :as store]))
 
+(def chat-id
+  "0x04c66155")
+
+(def chat-name
+  "0x04c661")
+
 (def raw-notification
-  {:chatId                    "0x04c66155"
+  {:chatId                    chat-id
    :contactVerificationStatus constants/contact-verification-state-pending
    :lastMessage               {}
-   :name                      "0x04c661"
+   :name                      chat-name
    :replyMessage              {}})
 
 (deftest <-rpc-test
@@ -16,8 +22,8 @@
     (is (contains? (set colors/chat-colors) (:color (store/<-rpc raw-notification)))))
 
   (testing "renames keys"
-    (is (= {:name                        "0x04c661"
-            :chat-id                     "0x04c66155"
+    (is (= {:name                        chat-name
+            :chat-id                     chat-id
             :contact-verification-status constants/contact-verification-state-pending}
            (-> raw-notification
                store/<-rpc
@@ -58,36 +64,36 @@
                (select-keys [:last-message :message :reply-message])))))
 
   (testing "augments notification based on its type"
-    (is (= {:chat-name "0x04c661"
+    (is (= {:chat-name chat-name
             :chat-type constants/private-group-chat-type
-            :name      "0x04c661"}
+            :name      chat-name}
            (-> raw-notification
                (assoc :type constants/activity-center-notification-type-reply)
                store/<-rpc
                (select-keys [:name :chat-type :chat-name :public? :group-chat]))))
 
-    (is (= {:chat-name "0x04c661"
+    (is (= {:chat-name chat-name
             :chat-type constants/private-group-chat-type
-            :name      "0x04c661"}
+            :name      chat-name}
            (-> raw-notification
                (assoc :type constants/activity-center-notification-type-mention)
                store/<-rpc
                (select-keys [:name :chat-type :chat-name :public? :group-chat]))))
 
-    (is (= {:chat-name  "0x04c661"
+    (is (= {:chat-name  chat-name
             :chat-type  constants/private-group-chat-type
             :group-chat true
-            :name       "0x04c661"
+            :name       chat-name
             :public?    false}
            (-> raw-notification
                (assoc :type constants/activity-center-notification-type-private-group-chat)
                store/<-rpc
                (select-keys [:name :chat-type :chat-name :public? :group-chat]))))
 
-    (is (= {:chat-name  "0x04c661"
+    (is (= {:chat-name  chat-name
             :chat-type  constants/one-to-one-chat-type
             :group-chat false
-            :name       "0x04c661"
+            :name       chat-name
             :public?    false}
            (-> raw-notification
                (assoc :type constants/activity-center-notification-type-one-to-one-chat)

--- a/src/status_im/data_store/activities_test.cljs
+++ b/src/status_im/data_store/activities_test.cljs
@@ -1,0 +1,95 @@
+(ns status-im.data-store.activities-test
+  (:require [cljs.test :refer [deftest is testing]]
+            [quo.design-system.colors :as colors]
+            [status-im.constants :as constants]
+            [status-im.data-store.activities :as store]))
+
+(def raw-notification
+  {:chatId                    "0x04c66155"
+   :contactVerificationStatus constants/contact-verification-state-pending
+   :lastMessage               {}
+   :name                      "0x04c661"
+   :replyMessage              {}})
+
+(deftest <-rpc-test
+  (testing "assocs random chat color"
+    (is (contains? (set colors/chat-colors) (:color (store/<-rpc raw-notification)))))
+
+  (testing "renames keys"
+    (is (= {:name                        "0x04c661"
+            :chat-id                     "0x04c66155"
+            :contact-verification-status constants/contact-verification-state-pending}
+           (-> raw-notification
+               store/<-rpc
+               (dissoc :color :last-message :message :reply-message)))))
+
+  (testing "transforms messages from RPC response"
+    (is (= {:last-message  {:quoted-message     nil
+                            :outgoing-status    nil
+                            :command-parameters nil
+                            :content            {:sticker     nil
+                                                 :rtl?        nil
+                                                 :ens-name    nil
+                                                 :parsed-text nil
+                                                 :response-to nil
+                                                 :chat-id     nil
+                                                 :image       nil
+                                                 :line-count  nil
+                                                 :links       nil
+                                                 :text        nil}
+                            :outgoing           false}
+            :message       nil
+            :reply-message {:quoted-message     nil
+                            :outgoing-status    nil
+                            :command-parameters nil
+                            :content            {:sticker     nil
+                                                 :rtl?        nil
+                                                 :ens-name    nil
+                                                 :parsed-text nil
+                                                 :response-to nil
+                                                 :chat-id     nil
+                                                 :image       nil
+                                                 :line-count  nil
+                                                 :links       nil
+                                                 :text        nil}
+                            :outgoing           false}}
+           (-> raw-notification
+               store/<-rpc
+               (select-keys [:last-message :message :reply-message])))))
+
+  (testing "augments notification based on its type"
+    (is (= {:chat-name "0x04c661"
+            :chat-type constants/private-group-chat-type
+            :name      "0x04c661"}
+           (-> raw-notification
+               (assoc :type constants/activity-center-notification-type-reply)
+               store/<-rpc
+               (select-keys [:name :chat-type :chat-name :public? :group-chat]))))
+
+    (is (= {:chat-name "0x04c661"
+            :chat-type constants/private-group-chat-type
+            :name      "0x04c661"}
+           (-> raw-notification
+               (assoc :type constants/activity-center-notification-type-mention)
+               store/<-rpc
+               (select-keys [:name :chat-type :chat-name :public? :group-chat]))))
+
+    (is (= {:chat-name  "0x04c661"
+            :chat-type  constants/private-group-chat-type
+            :group-chat true
+            :name       "0x04c661"
+            :public?    false}
+           (-> raw-notification
+               (assoc :type constants/activity-center-notification-type-private-group-chat)
+               store/<-rpc
+               (select-keys [:name :chat-type :chat-name :public? :group-chat]))))
+
+    (is (= {:chat-name  "0x04c661"
+            :chat-type  constants/one-to-one-chat-type
+            :group-chat false
+            :name       "0x04c661"
+            :public?    false}
+           (-> raw-notification
+               (assoc :type constants/activity-center-notification-type-one-to-one-chat)
+               store/<-rpc
+               (select-keys [:name :chat-type :chat-name :public? :group-chat]))))))

--- a/src/status_im/data_store/messages.cljs
+++ b/src/status_im/data_store/messages.cljs
@@ -20,6 +20,7 @@
       (clojure.set/rename-keys {:id :message-id
                                 :whisperTimestamp :whisper-timestamp
                                 :editedAt :edited-at
+                                :contactVerificationState :contact-verification-state
                                 :contactRequestState :contact-request-state
                                 :commandParameters :command-parameters
                                 :gapParameters :gap-parameters

--- a/src/status_im/data_store/messages_test.cljs
+++ b/src/status_im/data_store/messages_test.cljs
@@ -20,6 +20,8 @@
                                :response-to "a"
                                :links nil}
                      :whisper-timestamp 1
+                     :contact-verification-state 1
+                     :contact-request-state 2
                      :outgoing-status :sending
                      :command-parameters nil
                      :outgoing true
@@ -35,6 +37,8 @@
                    :whisperTimestamp 1
                    :parsedText "parsed-text"
                    :ensName "ens-name"
+                   :contactVerificationState 1
+                   :contactRequestState 2
                    :localChatId chat-id
                    :from from
                    :text "hta"

--- a/src/status_im/ui/screens/activity_center/views.cljs
+++ b/src/status_im/ui/screens/activity_center/views.cljs
@@ -68,7 +68,7 @@
                     {:button-1 {:label    (i18n/label :t/decline)
                                 :type     :danger
                                 :on-press #(>evt [:contact-requests.ui/decline-request id])}
-                     :button-2 {:label                     (i18n/label :t/reply)
+                     :button-2 {:label                     (i18n/label :t/message-reply)
                                 :type                      :success
                                 :override-background-color colors/success-60
                                 :on-press                  #(>evt [:contact-requests.ui/accept-request id])}}

--- a/src/status_im/ui/screens/activity_center/views.cljs
+++ b/src/status_im/ui/screens/activity_center/views.cljs
@@ -68,7 +68,7 @@
                     {:button-1 {:label    (i18n/label :t/decline)
                                 :type     :danger
                                 :on-press #(>evt [:contact-requests.ui/decline-request id])}
-                     :button-2 {:label                     (i18n/label :t/accept)
+                     :button-2 {:label                     (i18n/label :t/reply)
                                 :type                      :success
                                 :override-background-color colors/success-60
                                 :on-press                  #(>evt [:contact-requests.ui/accept-request id])}}

--- a/translations/en.json
+++ b/translations/en.json
@@ -1482,6 +1482,7 @@
     "add-nickname": "Add a nickname (optional)",
     "nickname-description": "Nicknames help you identify others in Status.\nOnly you can see the nicknames you’ve added",
     "accept": "Accept",
+    "reply": "Reply",
     "group-invite": "Group invite",
     "group-invite-link": "Group invite link",
     "pending-invitations": "Pending membership requests",

--- a/translations/en.json
+++ b/translations/en.json
@@ -1482,7 +1482,6 @@
     "add-nickname": "Add a nickname (optional)",
     "nickname-description": "Nicknames help you identify others in Status.\nOnly you can see the nicknames you’ve added",
     "accept": "Accept",
-    "reply": "Reply",
     "group-invite": "Group invite",
     "group-invite-link": "Group invite link",
     "pending-invitations": "Pending membership requests",

--- a/translations/en.json
+++ b/translations/en.json
@@ -1819,6 +1819,8 @@
     "admin": "Admin",
     "replies": "Replies",
     "identity-verification": "Identity verification",
+    "identity-verification-request": "Identity verification request",
+    "identity-verification-request-sent": "asked you",
     "membership": "Membership",
     "jump-to": "Jump to",
     "blank-messages-text": "Your messages will be here",


### PR DESCRIPTION
fixes #14171 

### Summary

Displays contact (identity) verification requests in the Activity Center and allows the receiver of such requests to decline them.

- [X] Fix reconciliation when notifications are also present in the "All" tab.
- [X] Introduces a new test helper to verify log messages. See `status-im.test-helpers/using-log-test-appender`.

<img alt="identity-verification-example" src="https://user-images.githubusercontent.com/46027/197662739-81b4190f-561e-4817-a518-4fbe78d9c514.png" height="600" />

### Review notes

- The new test utility `status-im.test-helpers/using-log-test-appender` is used in this PR to verify a dead end (a failure event handler without user feedback) at least logs critical information in case users need to report a bug.

- As new notification types are implemented, @smohamedjavid and I agreed to start taking advantage of multimethods to completely decouple different types of notifications. In the future we'll probably find new abstractions or ways to unify them.

- Status-go is under development to add support for notifications in the existing contact verification flows. The branch https://github.com/status-im/status-go/tree/feature/activity-center-read-unread is not yet merged and it's still prone to change before the final merge, but the implementation seems stable enough for us to move forward with the mobile implementation.

#### Platforms

- Android
- iOS

#### Areas that may be impacted

It's still completely isolated from the rest of the app and behind a feature toggle that's disabled by default.

### Steps to test

- Force mobile app to use compiled version from https://github.com/status-im/status-go/tree/feature/activity-center-read-unread.
- Enable `status-im.utils.config/new-activity-center-enabled?`
- Establish mutual contact approval between two contacts.
- Send contact verification from user A to B either by using a running REPL with the example code below, or using the Desktop client.
- Users can send as many contact verification requests as desired.
- Check that the user receiving such challenges can decline them.

```clojure
(rf/reg-event-fx
   :dev/send-contact-verification-request
   (fn [{:keys [_db]} [_ {:keys [contact-id challenge]}]]
     {::json-rpc/call [{:method     "wakuext_sendContactVerificationRequest"
                        :params     [contact-id challenge]
                        :on-success #(do
                                       (tap> {:success %})
                                       nil)
                        :on-error   #(do
                                       (tap> {:error %})
                                       nil)}]}))

(def alice-id "0x04d0")
(def carol-id  "0x0445")

;; Logged in as Alice, dispatch this event:
(rf/dispatch [:dev/send-contact-verification-request
                {:challenge  "Carol, who am I really?"
                 :contact-id carol-id}])
```

status: ready
