### PR TITLE
Fix typo (replace backtick with apostrophe)

### DIFF
--- a/translations/en.json
+++ b/translations/en.json
@@ -1576,7 +1576,7 @@
     "master-account": "Master account",
     "back-up": "Back up",
     "key-on-device": "Private key is saved on this device",
-    "whats-trending": "See what`s trending",
+    "whats-trending": "See what's trending",
     "seed-key-uid-mismatch": "Seed doesn't match",
     "seed-key-uid-mismatch-desc-1": "The seed phrase you entered does not match {{multiaccount-name}}",
     "seed-key-uid-mismatch-desc-2": "To manage keys for this account verify your seed phrase and try again.",


### PR DESCRIPTION
Fixes: https://github.com/status-im/status-mobile/pull/14018#issuecomment-1258753608

I replaced the backtick with an apostrophe in the English translation file, to match the rest of the text, and maintain proper punctuation.