### PR TITLE
chore: lint against re-frame dispatch/subscribe in quo components

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -287,6 +287,7 @@ endif
 
 lint: export TARGET := clojure
 lint: ##@test Run code style checks
+	sh scripts/lint-re-frame-in-quo-components.sh && \
 	clj-kondo --config .clj-kondo/config.edn --cache false --lint src && \
 	TARGETS=$$(git diff --diff-filter=d --cached --name-only src && echo src) && \
 	clojure -Scp "$$CLASS_PATH" -m cljfmt.main check --indents indentation.edn $$TARGETS

--- a/scripts/lint-re-frame-in-quo-components.sh
+++ b/scripts/lint-re-frame-in-quo-components.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+
+CHANGES=$(git diff --no-ext-diff --diff-filter=d --cached --unified=0 --no-prefix --minimal --exit-code src/quo src/quo2 | grep '^+' || echo '')
+
+INVALID_CHANGES=$(echo "$CHANGES" | grep -E '(re-frame/dispatch|rf/dispatch|re-frame/subscribe|rf/subscribe|rf/sub|<sub|>evt)')
+
+if test -n "$INVALID_CHANGES"; then
+    echo "re-frame dispatch/subscribe is not allowed in quo/quo2 components"
+    echo ''
+    echo "$INVALID_CHANGES"
+    exit 1
+fi


### PR DESCRIPTION
Add a script to lint against below strings in `src/quo` and `src/quo2`.

1. `re-frame/dispatch`
1. `re-frame/subscribe`
1. `rf/dispatch`
1. `rf/subscribe`
1. `>evt`
1. `<sub`

Script added into `make lint`


status: ready <!-- Can be ready or wip -->