### PR TITLE
fix error: package com.facebook.react.bridge does not exist while bui…

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -42,6 +42,8 @@ subprojects {
     }
 }
 
+def REACT_NATIVE_VERSION = new File(['node', '--print',"JSON.parse(require('fs').readFileSync(require.resolve('react-native/package.json'), 'utf-8')).version"].execute(null, rootDir).text.trim())
+
 allprojects {
     beforeEvaluate {
         if (System.env.STATUS_GO_ANDROID_LIBDIR == null || System.env.STATUS_GO_ANDROID_LIBDIR == "") {
@@ -62,5 +64,12 @@ allprojects {
         jcenter() // Required for @react-native-community/blur:3.6.1, can be removed after updating to 3.6.1+
         mavenCentral()
         maven { url "https://www.jitpack.io" }
+    }
+
+    configurations.all {
+        resolutionStrategy {
+            // reference https://stackoverflow.com/questions/74345114/error-package-com-facebook-react-bridge-does-not-exist-while-building-react-nat
+            force "com.facebook.react:react-native:" + REACT_NATIVE_VERSION
+        }
     }
 }


### PR DESCRIPTION
sometimes `make run-android` may result in following error, this pr fixed this error, reference is [here](https://stackoverflow.com/questions/74345114/error-package-com-facebook-react-bridge-does-not-exist-while-building-react-nat)
```
/Users/mac/status-react/node_modules/@react-native-async-storage/async-storage/android/src/main/java/com/reactnativecommunity/asyncstorage/AsyncLocalStorageUtil.java:10: error: package javax.annotation does not exist
import javax.annotation.Nullable;
                       ^
/Users/mac/status-react/node_modules/@react-native-async-storage/async-storage/android/src/main/java/com/reactnativecommunity/asyncstorage/AsyncLocalStorageUtil.java:21: error: package com.facebook.react.bridge does not exist
import com.facebook.react.bridge.ReadableArray;
                                ^
/Users/mac/status-react/node_modules/@react-native-async-storage/async-storage/android/src/main/java/com/reactnativecommunity/asyncstorage/ReactDatabaseSupplier.java:14: error: package com.facebook.common.logging does not exist
import com.facebook.common.logging.FLog;
                                  ^
...
```
https://gist.github.com/jakubgs/d06afd176bcec79b8c410446a1715ea6