### PR TITLE
Attempt to fix too long prefix for notification types

### DIFF
--- a/src/status_im/activity_center/core.cljs
+++ b/src/status_im/activity_center/core.cljs
@@ -1,6 +1,6 @@
 (ns status-im.activity-center.core
   (:require [re-frame.core :as rf]
-            [status-im.constants :as const]
+            [status-im.activity-center.notification-types :as types]
             [status-im.data-store.activities :as data-store.activities]
             [status-im.ethereum.json-rpc :as json-rpc]
             [status-im.utils.fx :as fx]
@@ -29,12 +29,12 @@
               (as-> acc $
                 (update-in $ [type :read :data] remove-notification)
                 (update-in $ [type :unread :data] remove-notification)
-                (update-in $ [const/activity-center-notification-type-no-type :read :data] remove-notification)
-                (update-in $ [const/activity-center-notification-type-no-type :unread :data] remove-notification)
+                (update-in $ [types/no-type :read :data] remove-notification)
+                (update-in $ [types/no-type :unread :data] remove-notification)
                 (if (or (:dismissed notification) (:accepted notification))
                   $
                   (-> $ (update-in [type filter-status :data] insert-and-sort)
-                      (update-in [const/activity-center-notification-type-no-type filter-status :data] insert-and-sort))))))
+                      (update-in [types/no-type filter-status :data] insert-and-sort))))))
           db-notifications
           new-notifications))
 
@@ -75,7 +75,7 @@
 
 (def defaults
   {:filter-status          :unread
-   :filter-type            const/activity-center-notification-type-no-type
+   :filter-type            types/no-type
    :notifications-per-page 10})
 
 (def start-or-end-cursor

--- a/src/status_im/activity_center/core_test.cljs
+++ b/src/status_im/activity_center/core_test.cljs
@@ -2,7 +2,7 @@
   (:require [cljs.test :refer [deftest is testing]]
             [day8.re-frame.test :as rf-test]
             [re-frame.core :as rf]
-            [status-im.constants :as const]
+            [status-im.activity-center.notification-types :as types]
             [status-im.ethereum.json-rpc :as json-rpc]
             status-im.events
             [status-im.test-helpers :as h]
@@ -46,7 +46,7 @@
                                       :read                        true
                                       :reply-message               nil
                                       :timestamp                   1666647286000
-                                      :type                        const/activity-center-notification-type-contact-verification}]
+                                      :type                        types/contact-verification}]
          (h/stub-fx-with-callbacks
           ::json-rpc/call
           :on-success (constantly {:activityCenterNotifications
@@ -60,7 +60,7 @@
                                      :name                      "0x04d03f"
                                      :read                      true
                                      :timestamp                 1666647286000
-                                     :type                      const/activity-center-notification-type-contact-verification}]}))
+                                     :type                      types/contact-verification}]}))
 
          (h/spy-fx spy-queue ::json-rpc/call)
 
@@ -72,10 +72,10 @@
                     (get-in [0 :args 0])
                     (select-keys [:method :params]))))
 
-         (is (= {const/activity-center-notification-type-no-type
+         (is (= {types/no-type
                  {:read   {:data [expected-notification]}
                   :unread {:data []}}
-                 const/activity-center-notification-type-contact-verification
+                 types/contact-verification
                  {:read   {:data [expected-notification]}
                   :unread {:data []}}}
                 (get-in (h/db) [:activity-center :notifications]))))))
@@ -103,23 +103,23 @@
     (testing "does nothing when there are no new notifications"
       (rf-test/run-test-sync
        (setup)
-       (let [notifications {const/activity-center-notification-type-one-to-one-chat
+       (let [notifications {types/one-to-one-chat
                             {:read   {:cursor ""
                                       :data   [{:id   "0x1"
                                                 :read true
-                                                :type const/activity-center-notification-type-one-to-one-chat}
+                                                :type types/one-to-one-chat}
                                                {:id   "0x2"
                                                 :read true
-                                                :type const/activity-center-notification-type-one-to-one-chat}]}
+                                                :type types/one-to-one-chat}]}
                              :unread {:cursor ""
                                       :data   [{:id   "0x3"
                                                 :read false
-                                                :type const/activity-center-notification-type-one-to-one-chat}]}}
-                            const/activity-center-notification-type-private-group-chat
+                                                :type types/one-to-one-chat}]}}
+                            types/private-group-chat
                             {:unread {:cursor ""
                                       :data   [{:id   "0x4"
                                                 :read false
-                                                :type const/activity-center-notification-type-private-group-chat}]}}}]
+                                                :type types/private-group-chat}]}}}]
          (rf/dispatch [:test/assoc-in [:activity-center :notifications] notifications])
 
          (rf/dispatch [:activity-center.notifications/reconcile nil])
@@ -130,127 +130,127 @@
       (rf-test/run-test-sync
        (setup)
        (rf/dispatch [:test/assoc-in [:activity-center :notifications]
-                     {const/activity-center-notification-type-one-to-one-chat
+                     {types/one-to-one-chat
                       {:read   {:cursor ""
-                                :data   [{:id "0x1" :read true :type const/activity-center-notification-type-one-to-one-chat}
-                                         {:id "0x2" :read true :type const/activity-center-notification-type-one-to-one-chat}]}
+                                :data   [{:id "0x1" :read true :type types/one-to-one-chat}
+                                         {:id "0x2" :read true :type types/one-to-one-chat}]}
                        :unread {:cursor ""
-                                :data   [{:id "0x3" :read false :type const/activity-center-notification-type-one-to-one-chat}]}}
-                      const/activity-center-notification-type-private-group-chat
+                                :data   [{:id "0x3" :read false :type types/one-to-one-chat}]}}
+                      types/private-group-chat
                       {:unread {:cursor ""
-                                :data   [{:id "0x4" :read false :type const/activity-center-notification-type-private-group-chat}
-                                         {:id "0x6" :read false :type const/activity-center-notification-type-private-group-chat}]}}}])
+                                :data   [{:id "0x4" :read false :type types/private-group-chat}
+                                         {:id "0x6" :read false :type types/private-group-chat}]}}}])
 
        (rf/dispatch [:activity-center.notifications/reconcile
                      [{:id        "0x1"
                        :read      true
-                       :type      const/activity-center-notification-type-one-to-one-chat
+                       :type      types/one-to-one-chat
                        :dismissed true}
                       {:id       "0x3"
                        :read     false
-                       :type     const/activity-center-notification-type-one-to-one-chat
+                       :type     types/one-to-one-chat
                        :accepted true}
                       {:id        "0x4"
                        :read      false
-                       :type      const/activity-center-notification-type-private-group-chat
+                       :type      types/private-group-chat
                        :dismissed true}
                       {:id       "0x5"
                        :read     false
-                       :type     const/activity-center-notification-type-private-group-chat
+                       :type     types/private-group-chat
                        :accepted true}]])
 
-       (is (= {const/activity-center-notification-type-no-type
+       (is (= {types/no-type
                {:read   {:data []}
                 :unread {:data []}}
 
-               const/activity-center-notification-type-one-to-one-chat
+               types/one-to-one-chat
                {:read   {:cursor ""
                          :data   [{:id   "0x2"
                                    :read true
-                                   :type const/activity-center-notification-type-one-to-one-chat}]}
+                                   :type types/one-to-one-chat}]}
                 :unread {:cursor ""
                          :data   []}}
-               const/activity-center-notification-type-private-group-chat
+               types/private-group-chat
                {:read   {:data []}
                 :unread {:cursor ""
                          :data   [{:id   "0x6"
                                    :read false
-                                   :type const/activity-center-notification-type-private-group-chat}]}}}
+                                   :type types/private-group-chat}]}}}
               (get-in (h/db) [:activity-center :notifications])))))
 
     (testing "replaces old notifications with newly arrived ones"
       (rf-test/run-test-sync
        (setup)
        (rf/dispatch [:test/assoc-in [:activity-center :notifications]
-                     {const/activity-center-notification-type-no-type
+                     {types/no-type
                       {:read   {:cursor ""
                                 :data   [{:id   "0x1"
                                           :read true
-                                          :type const/activity-center-notification-type-one-to-one-chat}]}
+                                          :type types/one-to-one-chat}]}
                        :unread {:cursor ""
                                 :data   [{:id   "0x4"
                                           :read false
-                                          :type const/activity-center-notification-type-private-group-chat}
+                                          :type types/private-group-chat}
                                          {:id   "0x6"
                                           :read false
-                                          :type const/activity-center-notification-type-private-group-chat}]}}
-                      const/activity-center-notification-type-one-to-one-chat
+                                          :type types/private-group-chat}]}}
+                      types/one-to-one-chat
                       {:read {:cursor ""
                               :data   [{:id   "0x1"
                                         :read true
-                                        :type const/activity-center-notification-type-one-to-one-chat}]}}
-                      const/activity-center-notification-type-private-group-chat
+                                        :type types/one-to-one-chat}]}}
+                      types/private-group-chat
                       {:unread {:cursor ""
                                 :data   [{:id   "0x4"
                                           :read false
-                                          :type const/activity-center-notification-type-private-group-chat}
+                                          :type types/private-group-chat}
                                          {:id   "0x6"
                                           :read false
-                                          :type const/activity-center-notification-type-private-group-chat}]}}}])
+                                          :type types/private-group-chat}]}}}])
 
        (rf/dispatch [:activity-center.notifications/reconcile
                      [{:id           "0x1"
                        :read         true
-                       :type         const/activity-center-notification-type-one-to-one-chat
+                       :type         types/one-to-one-chat
                        :last-message {}}
                       {:id     "0x4"
                        :read   false
-                       :type   const/activity-center-notification-type-private-group-chat
+                       :type   types/private-group-chat
                        :author "0xabc"}
                       {:id   "0x6"
                        :read false
-                       :type const/activity-center-notification-type-private-group-chat}]])
+                       :type types/private-group-chat}]])
 
-       (is (= {const/activity-center-notification-type-no-type
+       (is (= {types/no-type
                {:read   {:cursor ""
                          :data   [{:id           "0x1"
                                    :read         true
-                                   :type         const/activity-center-notification-type-one-to-one-chat
+                                   :type         types/one-to-one-chat
                                    :last-message {}}]}
                 :unread {:cursor ""
                          :data   [{:id   "0x6"
                                    :read false
-                                   :type const/activity-center-notification-type-private-group-chat}
+                                   :type types/private-group-chat}
                                   {:id     "0x4"
                                    :read   false
-                                   :type   const/activity-center-notification-type-private-group-chat
+                                   :type   types/private-group-chat
                                    :author "0xabc"}]}}
-               const/activity-center-notification-type-one-to-one-chat
+               types/one-to-one-chat
                {:read   {:cursor ""
                          :data   [{:id           "0x1"
                                    :read         true
-                                   :type         const/activity-center-notification-type-one-to-one-chat
+                                   :type         types/one-to-one-chat
                                    :last-message {}}]}
                 :unread {:data []}}
-               const/activity-center-notification-type-private-group-chat
+               types/private-group-chat
                {:read   {:data []}
                 :unread {:cursor ""
                          :data   [{:id   "0x6"
                                    :read false
-                                   :type const/activity-center-notification-type-private-group-chat}
+                                   :type types/private-group-chat}
                                   {:id     "0x4"
                                    :read   false
-                                   :type   const/activity-center-notification-type-private-group-chat
+                                   :type   types/private-group-chat
                                    :author "0xabc"}]}}}
               (get-in (h/db) [:activity-center :notifications])))))
 
@@ -258,29 +258,29 @@
       (rf-test/run-test-sync
        (setup)
        (rf/dispatch [:test/assoc-in [:activity-center :notifications]
-                     {const/activity-center-notification-type-one-to-one-chat
+                     {types/one-to-one-chat
                       {:read {:cursor ""
                               :data   [{:id   "0x1"
                                         :read true
-                                        :type const/activity-center-notification-type-one-to-one-chat}]}}}])
+                                        :type types/one-to-one-chat}]}}}])
 
        (rf/dispatch [:activity-center.notifications/reconcile
                      [{:id   "0x1"
                        :read false
-                       :type const/activity-center-notification-type-one-to-one-chat}]])
+                       :type types/one-to-one-chat}]])
 
-       (is (= {const/activity-center-notification-type-no-type
+       (is (= {types/no-type
                {:read   {:data []}
                 :unread {:data [{:id   "0x1"
                                  :read false
-                                 :type const/activity-center-notification-type-one-to-one-chat}]}}
+                                 :type types/one-to-one-chat}]}}
 
-               const/activity-center-notification-type-one-to-one-chat
+               types/one-to-one-chat
                {:read   {:cursor ""
                          :data   []}
                 :unread {:data [{:id   "0x1"
                                  :read false
-                                 :type const/activity-center-notification-type-one-to-one-chat}]}}}
+                                 :type types/one-to-one-chat}]}}}
               (get-in (h/db) [:activity-center :notifications])))))
 
     ;; Sorting by timestamp and ID is compatible with what the backend does when
@@ -289,54 +289,54 @@
       (rf-test/run-test-sync
        (setup)
        (rf/dispatch [:test/assoc-in [:activity-center :notifications]
-                     {const/activity-center-notification-type-one-to-one-chat
+                     {types/one-to-one-chat
                       {:read   {:cursor ""
-                                :data   [{:id "0x1" :read true :type const/activity-center-notification-type-one-to-one-chat :timestamp 1}
-                                         {:id "0x2" :read true :type const/activity-center-notification-type-one-to-one-chat :timestamp 1}]}
+                                :data   [{:id "0x1" :read true :type types/one-to-one-chat :timestamp 1}
+                                         {:id "0x2" :read true :type types/one-to-one-chat :timestamp 1}]}
                        :unread {:cursor ""
-                                :data   [{:id "0x3" :read false :type const/activity-center-notification-type-one-to-one-chat :timestamp 50}
-                                         {:id "0x4" :read false :type const/activity-center-notification-type-one-to-one-chat :timestamp 100}
-                                         {:id "0x5" :read false :type const/activity-center-notification-type-one-to-one-chat :timestamp 100}]}}}])
+                                :data   [{:id "0x3" :read false :type types/one-to-one-chat :timestamp 50}
+                                         {:id "0x4" :read false :type types/one-to-one-chat :timestamp 100}
+                                         {:id "0x5" :read false :type types/one-to-one-chat :timestamp 100}]}}}])
 
        (rf/dispatch [:activity-center.notifications/reconcile
-                     [{:id "0x1" :read true :type const/activity-center-notification-type-one-to-one-chat :timestamp 1 :last-message {}}
-                      {:id "0x4" :read false :type const/activity-center-notification-type-one-to-one-chat :timestamp 100 :last-message {}}]])
+                     [{:id "0x1" :read true :type types/one-to-one-chat :timestamp 1 :last-message {}}
+                      {:id "0x4" :read false :type types/one-to-one-chat :timestamp 100 :last-message {}}]])
 
-       (is (= {const/activity-center-notification-type-no-type
+       (is (= {types/no-type
                {:read   {:data [{:id           "0x1"
                                  :read         true
-                                 :type         const/activity-center-notification-type-one-to-one-chat
+                                 :type         types/one-to-one-chat
                                  :timestamp    1
                                  :last-message {}}]}
                 :unread {:data [{:id           "0x4"
                                  :read         false
-                                 :type         const/activity-center-notification-type-one-to-one-chat
+                                 :type         types/one-to-one-chat
                                  :timestamp    100
                                  :last-message {}}]}}
-               const/activity-center-notification-type-one-to-one-chat
+               types/one-to-one-chat
                {:read   {:cursor ""
                          :data   [{:id        "0x2"
                                    :read      true
-                                   :type      const/activity-center-notification-type-one-to-one-chat
+                                   :type      types/one-to-one-chat
                                    :timestamp 1}
                                   {:id           "0x1"
                                    :read         true
-                                   :type         const/activity-center-notification-type-one-to-one-chat
+                                   :type         types/one-to-one-chat
                                    :timestamp    1
                                    :last-message {}}]}
                 :unread {:cursor ""
                          :data   [{:id        "0x5"
                                    :read      false
-                                   :type      const/activity-center-notification-type-one-to-one-chat
+                                   :type      types/one-to-one-chat
                                    :timestamp 100}
                                   {:id           "0x4"
                                    :read         false
-                                   :type         const/activity-center-notification-type-one-to-one-chat
+                                   :type         types/one-to-one-chat
                                    :timestamp    100
                                    :last-message {}}
                                   {:id        "0x3"
                                    :read      false
-                                   :type      const/activity-center-notification-type-one-to-one-chat
+                                   :type      types/one-to-one-chat
                                    :timestamp 50}]}}}
               (get-in (h/db) [:activity-center :notifications])))))))
 
@@ -352,22 +352,22 @@
           ::json-rpc/call
           :on-success (constantly {:cursor        "10"
                                    :notifications [{:id     "0x1"
-                                                    :type   const/activity-center-notification-type-one-to-one-chat
+                                                    :type   types/one-to-one-chat
                                                     :read   false
                                                     :chatId "0x9"}]}))
          (h/spy-fx spy-queue ::json-rpc/call)
 
          (rf/dispatch [:activity-center.notifications/fetch-first-page
-                       {:filter-type const/activity-center-notification-type-one-to-one-chat}])
+                       {:filter-type types/one-to-one-chat}])
 
          (is (= :unread (get-in (h/db) [:activity-center :filter :status])))
          (is (= "" (get-in @spy-queue [0 :args 0 :params 0]))
              "Should be called with empty cursor when fetching first page")
-         (is (= {const/activity-center-notification-type-one-to-one-chat
+         (is (= {types/one-to-one-chat
                  {:unread {:cursor "10"
                            :data   [{:chat-id       "0x9"
                                      :chat-name     nil
-                                     :chat-type     const/activity-center-notification-type-one-to-one-chat
+                                     :chat-type     types/one-to-one-chat
                                      :group-chat    false
                                      :id            "0x1"
                                      :public?       false
@@ -375,7 +375,7 @@
                                      :message       nil
                                      :read          false
                                      :reply-message nil
-                                     :type          const/activity-center-notification-type-one-to-one-chat}]}}}
+                                     :type          types/one-to-one-chat}]}}}
                 (get-in (h/db) [:activity-center :notifications]))))))
 
     (testing "does not fetch next page when pagination cursor reached the end"
@@ -386,8 +386,8 @@
          (rf/dispatch [:test/assoc-in [:activity-center :filter :status]
                        :unread])
          (rf/dispatch [:test/assoc-in [:activity-center :filter :type]
-                       const/activity-center-notification-type-one-to-one-chat])
-         (rf/dispatch [:test/assoc-in [:activity-center :notifications const/activity-center-notification-type-one-to-one-chat :unread :cursor]
+                       types/one-to-one-chat])
+         (rf/dispatch [:test/assoc-in [:activity-center :notifications types/one-to-one-chat :unread :cursor]
                        ""])
 
          (rf/dispatch [:activity-center.notifications/fetch-next-page])
@@ -405,8 +405,8 @@
          (rf/dispatch [:test/assoc-in [:activity-center :filter :status]
                        :unread])
          (rf/dispatch [:test/assoc-in [:activity-center :filter :type]
-                       const/activity-center-notification-type-one-to-one-chat])
-         (rf/dispatch [:test/assoc-in [:activity-center :notifications const/activity-center-notification-type-one-to-one-chat :unread :cursor]
+                       types/one-to-one-chat])
+         (rf/dispatch [:test/assoc-in [:activity-center :notifications types/one-to-one-chat :unread :cursor]
                        nil])
 
          (rf/dispatch [:activity-center.notifications/fetch-next-page])
@@ -421,15 +421,15 @@
           ::json-rpc/call
           :on-success (constantly {:cursor        ""
                                    :notifications [{:id     "0x1"
-                                                    :type   const/activity-center-notification-type-mention
+                                                    :type   types/mention
                                                     :read   false
                                                     :chatId "0x9"}]}))
          (h/spy-fx spy-queue ::json-rpc/call)
          (rf/dispatch [:test/assoc-in [:activity-center :filter :status]
                        :unread])
          (rf/dispatch [:test/assoc-in [:activity-center :filter :type]
-                       const/activity-center-notification-type-mention])
-         (rf/dispatch [:test/assoc-in [:activity-center :notifications const/activity-center-notification-type-mention :unread :cursor]
+                       types/mention])
+         (rf/dispatch [:test/assoc-in [:activity-center :notifications types/mention :unread :cursor]
                        "10"])
 
          (rf/dispatch [:activity-center.notifications/fetch-next-page])
@@ -437,7 +437,7 @@
          (is (= "wakuext_unreadActivityCenterNotifications" (get-in @spy-queue [0 :args 0 :method])))
          (is (= "10" (get-in @spy-queue [0 :args 0 :params 0]))
              "Should be called with current cursor")
-         (is (= {const/activity-center-notification-type-mention
+         (is (= {types/mention
                  {:unread {:cursor ""
                            :data   [{:chat-id       "0x9"
                                      :chat-name     nil
@@ -447,7 +447,7 @@
                                      :message       nil
                                      :read          false
                                      :reply-message nil
-                                     :type          const/activity-center-notification-type-mention}]}}}
+                                     :type          types/mention}]}}}
                 (get-in (h/db) [:activity-center :notifications]))))))
 
     (testing "does not fetch next page while it is still loading"
@@ -458,10 +458,10 @@
          (rf/dispatch [:test/assoc-in [:activity-center :filter :status]
                        :read])
          (rf/dispatch [:test/assoc-in [:activity-center :filter :type]
-                       const/activity-center-notification-type-one-to-one-chat])
-         (rf/dispatch [:test/assoc-in [:activity-center :notifications const/activity-center-notification-type-one-to-one-chat :read :cursor]
+                       types/one-to-one-chat])
+         (rf/dispatch [:test/assoc-in [:activity-center :notifications types/one-to-one-chat :read :cursor]
                        "10"])
-         (rf/dispatch [:test/assoc-in [:activity-center :notifications const/activity-center-notification-type-one-to-one-chat :read :loading?]
+         (rf/dispatch [:test/assoc-in [:activity-center :notifications types/one-to-one-chat :read :loading?]
                        true])
 
          (rf/dispatch [:activity-center.notifications/fetch-next-page])
@@ -478,15 +478,15 @@
          (rf/dispatch [:test/assoc-in [:activity-center :filter :status]
                        :unread])
          (rf/dispatch [:test/assoc-in [:activity-center :filter :type]
-                       const/activity-center-notification-type-one-to-one-chat])
-         (rf/dispatch [:test/assoc-in [:activity-center :notifications const/activity-center-notification-type-one-to-one-chat :unread :cursor]
+                       types/one-to-one-chat])
+         (rf/dispatch [:test/assoc-in [:activity-center :notifications types/one-to-one-chat :unread :cursor]
                        ""])
 
          (rf/dispatch [:activity-center.notifications/fetch-first-page])
 
-         (is (nil? (get-in (h/db) [:activity-center :notifications const/activity-center-notification-type-one-to-one-chat :unread :loading?])))
+         (is (nil? (get-in (h/db) [:activity-center :notifications types/one-to-one-chat :unread :loading?])))
          (is (= [:activity-center.notifications/fetch-error
-                 const/activity-center-notification-type-one-to-one-chat
+                 types/one-to-one-chat
                  :unread
                  :fake-error]
                 (:args (last @spy-queue)))))))))

--- a/src/status_im/activity_center/notification_types.cljs
+++ b/src/status_im/activity_center/notification_types.cljs
@@ -1,0 +1,20 @@
+(ns status-im.activity-center.notification-types)
+
+(def ^:const no-type 0)
+(def ^:const one-to-one-chat 1)
+(def ^:const private-group-chat 2)
+(def ^:const mention 3)
+(def ^:const reply 4)
+(def ^:const contact-request 5)
+(def ^:const contact-verification 6)
+
+;; TODO: Remove this constant once the old Notification Center code is removed.
+;; Its value clashes with the new constant `-contact-verification`
+;; used in status-go.
+(def ^:const contact-request-retracted 6)
+
+;; TODO: Replace with correct enum values once status-go implements them.
+(def ^:const admin 66610)
+(def ^:const tx 66612)
+(def ^:const membership 66613)
+(def ^:const system 66614)

--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -183,25 +183,6 @@
 (def ^:const docs-link "https://status.im/docs/")
 (def ^:const principles-link "https://our.status.im/our-principles/")
 
-(def ^:const activity-center-notification-type-no-type 0)
-(def ^:const activity-center-notification-type-one-to-one-chat 1)
-(def ^:const activity-center-notification-type-private-group-chat 2)
-(def ^:const activity-center-notification-type-mention 3)
-(def ^:const activity-center-notification-type-reply 4)
-(def ^:const activity-center-notification-type-contact-request 5)
-(def ^:const activity-center-notification-type-contact-verification 6)
-
-;; TODO: Remove this constant once the old Notification Center code is removed.
-;; Its value clashes with the new constant `activity-center-notification-type-contact-verification`
-;; used in status-go.
-(def ^:const activity-center-notification-type-contact-request-retracted 6)
-
-;; TODO: Replace with correct enum values once status-go implements them.
-(def ^:const activity-center-notification-type-admin 66610)
-(def ^:const activity-center-notification-type-tx 66612)
-(def ^:const activity-center-notification-type-membership 66613)
-(def ^:const activity-center-notification-type-system 66614)
-
 (def ^:const visibility-status-unknown 0)
 (def ^:const visibility-status-automatic 1)
 (def ^:const visibility-status-dnd 2)

--- a/src/status_im/data_store/activities.cljs
+++ b/src/status_im/data_store/activities.cljs
@@ -2,29 +2,30 @@
   (:require [clojure.set :as set]
             [quo.design-system.colors :as colors]
             [status-im.constants :as constants]
+            [status-im.activity-center.notification-types :as notification-types]
             [status-im.data-store.messages :as messages]
             [status-im.utils.config :as config]))
 
 (defn- rpc->type [{:keys [type name] :as chat}]
   (case type
-    constants/activity-center-notification-type-reply
+    notification-types/reply
     (assoc chat
            :chat-name name
            :chat-type constants/private-group-chat-type)
 
-    constants/activity-center-notification-type-mention
+    notification-types/mention
     (assoc chat
            :chat-type constants/private-group-chat-type
            :chat-name name)
 
-    constants/activity-center-notification-type-private-group-chat
+    notification-types/private-group-chat
     (assoc chat
            :chat-type constants/private-group-chat-type
            :chat-name name
            :public? false
            :group-chat true)
 
-    constants/activity-center-notification-type-one-to-one-chat
+    notification-types/one-to-one-chat
     (assoc chat
            :chat-type constants/one-to-one-chat-type
            :chat-name name

--- a/src/status_im/data_store/activities_test.cljs
+++ b/src/status_im/data_store/activities_test.cljs
@@ -1,6 +1,7 @@
 (ns status-im.data-store.activities-test
   (:require [cljs.test :refer [deftest is testing]]
             [status-im.constants :as constants]
+            [status-im.activity-center.notification-types :as notification-types]
             [status-im.data-store.activities :as store]
             [status-im.utils.config :as config]))
 
@@ -66,7 +67,7 @@
               :chat-type constants/private-group-chat-type
               :name      chat-name}
              (-> raw-notification
-                 (assoc :type constants/activity-center-notification-type-reply)
+                 (assoc :type notification-types/reply)
                  store/<-rpc
                  (select-keys [:name :chat-type :chat-name :public? :group-chat]))))
 
@@ -74,7 +75,7 @@
               :chat-type constants/private-group-chat-type
               :name      chat-name}
              (-> raw-notification
-                 (assoc :type constants/activity-center-notification-type-mention)
+                 (assoc :type notification-types/mention)
                  store/<-rpc
                  (select-keys [:name :chat-type :chat-name :public? :group-chat]))))
 
@@ -84,7 +85,7 @@
               :name       chat-name
               :public?    false}
              (-> raw-notification
-                 (assoc :type constants/activity-center-notification-type-private-group-chat)
+                 (assoc :type notification-types/private-group-chat)
                  store/<-rpc
                  (select-keys [:name :chat-type :chat-name :public? :group-chat]))))
 
@@ -94,6 +95,6 @@
               :name       chat-name
               :public?    false}
              (-> raw-notification
-                 (assoc :type constants/activity-center-notification-type-one-to-one-chat)
+                 (assoc :type notification-types/one-to-one-chat)
                  store/<-rpc
                  (select-keys [:name :chat-type :chat-name :public? :group-chat])))))))

--- a/src/status_im/notifications_center/core.cljs
+++ b/src/status_im/notifications_center/core.cljs
@@ -1,14 +1,14 @@
 (ns status-im.notifications-center.core
   (:require [status-im.utils.fx :as fx]
             [status-im.ethereum.json-rpc :as json-rpc]
-            [status-im.constants :as constants]
+            [status-im.activity-center.notification-types :as types]
             [taoensso.timbre :as log]
             [re-frame.core :as re-frame]
             [status-im.data-store.activities :as data-store.activities]))
 
 (def non-dismissable-notifications
-  #{constants/activity-center-notification-type-contact-request
-    constants/activity-center-notification-type-contact-request-retracted})
+  #{types/contact-request
+    types/contact-request-retracted})
 
 (fx/defn handle-activities [{:keys [db]} activities]
   (let [{:keys [unread-count notifications]}

--- a/src/status_im/subs/activity_center.cljs
+++ b/src/status_im/subs/activity_center.cljs
@@ -3,6 +3,7 @@
             [status-im.utils.datetime :as datetime]
             [status-im.multiaccounts.core :as multiaccounts]
             [status-im.constants :as constants]
+            [status-im.activity-center.notification-types :as types]
             [clojure.string :as string]))
 
 (re-frame/reg-sub
@@ -21,7 +22,7 @@
  :activity-center/filter-type
  :<- [:activity-center]
  (fn [activity-center]
-   (get-in activity-center [:filter :type] constants/activity-center-notification-type-no-type)))
+   (get-in activity-center [:filter :type] types/no-type)))
 
 (re-frame/reg-sub
  :activity-center/filtered-notifications
@@ -55,17 +56,17 @@
  (fn [[{:keys [notifications]} contacts]]
    (let [supported-notifications
          (filter (fn [{:keys [type last-message message]}]
-                   (or (and (= constants/activity-center-notification-type-one-to-one-chat type)
+                   (or (and (= types/one-to-one-chat type)
                             (not (nil? last-message)))
-                       (and (= constants/activity-center-notification-type-contact-request type)
+                       (and (= types/contact-request type)
                             (not= constants/contact-request-message-state-none
                                   (-> contacts
                                       (multiaccounts/contact-by-identity (:from message))
                                       :contact-request-state)))
-                       (= constants/activity-center-notification-type-contact-request-retracted type)
-                       (= constants/activity-center-notification-type-private-group-chat type)
-                       (= constants/activity-center-notification-type-reply type)
-                       (= constants/activity-center-notification-type-mention type)))
+                       (= types/contact-request-retracted type)
+                       (= types/private-group-chat type)
+                       (= types/reply type)
+                       (= types/mention type)))
                  notifications)]
      (group-notifications-by-date
       (map #(assoc %

--- a/src/status_im/ui/screens/activity_center/views.cljs
+++ b/src/status_im/ui/screens/activity_center/views.cljs
@@ -9,6 +9,7 @@
             [quo2.components.tags.context-tags :as context-tags]
             [quo2.foundations.colors :as colors]
             [status-im.constants :as constants]
+            [status-im.activity-center.notification-types :as types]
             [status-im.i18n.i18n :as i18n]
             [status-im.multiaccounts.core :as multiaccounts]
             [status-im.utils.datetime :as datetime]
@@ -26,7 +27,7 @@
 
 ;;;; Contact request notifications
 
-(defmethod notification-component constants/activity-center-notification-type-contact-request
+(defmethod notification-component types/contact-request
   [{:keys [id] :as notification}]
   (let [message   (or (:message notification) (:last-message notification))
         contact   (<sub [:contacts/contact-by-identity (:author notification)])
@@ -76,7 +77,7 @@
 
 ;;;; Contact verification notifications
 
-(defmethod notification-component constants/activity-center-notification-type-contact-verification
+(defmethod notification-component types/contact-verification
   [{:keys [id contact-verification-status] :as notification}]
   (let [message (or (:message notification) (:last-notification notification))
         contact (<sub [:contacts/contact-by-identity (:author notification)])]
@@ -170,23 +171,23 @@
                            :fade-end?           true
                            :on-change           #(>evt [:activity-center.notifications/fetch-first-page {:filter-type %}])
                            :default-active      filter-type
-                           :data                [{:id    constants/activity-center-notification-type-no-type
+                           :data                [{:id    types/no-type
                                                   :label (i18n/label :t/all)}
-                                                 {:id    constants/activity-center-notification-type-admin
+                                                 {:id    types/admin
                                                   :label (i18n/label :t/admin)}
-                                                 {:id    constants/activity-center-notification-type-mention
+                                                 {:id    types/mention
                                                   :label (i18n/label :t/mentions)}
-                                                 {:id    constants/activity-center-notification-type-reply
+                                                 {:id    types/reply
                                                   :label (i18n/label :t/replies)}
-                                                 {:id    constants/activity-center-notification-type-contact-request
+                                                 {:id    types/contact-request
                                                   :label (i18n/label :t/contact-requests)}
-                                                 {:id    constants/activity-center-notification-type-contact-verification
+                                                 {:id    types/contact-verification
                                                   :label (i18n/label :t/identity-verification)}
-                                                 {:id    constants/activity-center-notification-type-tx
+                                                 {:id    types/tx
                                                   :label (i18n/label :t/transactions)}
-                                                 {:id    constants/activity-center-notification-type-membership
+                                                 {:id    types/membership
                                                   :label (i18n/label :t/membership)}
-                                                 {:id    constants/activity-center-notification-type-system
+                                                 {:id    types/system
                                                   :label (i18n/label :t/system)}]}]))
 
 (defn header

--- a/src/status_im/ui/screens/notifications_center/views.cljs
+++ b/src/status_im/ui/screens/notifications_center/views.cljs
@@ -10,6 +10,7 @@
             [status-im.ui.components.toolbar :as toolbar]
             [clojure.string :as string]
             [status-im.constants :as constants]
+            [status-im.activity-center.notification-types :as types]
             [status-im.ui.screens.notifications-center.views.notification :as notification]))
 
 (def selecting (reagent/atom nil))
@@ -20,9 +21,9 @@
   (when id
     (let [selected (get @selected-items id)
           on-change (fn []
-                      (when-not (= type constants/activity-center-notification-type-mention) (swap! selected-items #(if selected (disj % id) (conj % id)))))]
+                      (when-not (= type types/mention) (swap! selected-items #(if selected (disj % id) (conj % id)))))]
       [react/view {:flex-direction :row :flex 1 :align-items :center}
-       (when (and @selecting (not (= type constants/activity-center-notification-type-mention)))
+       (when (and @selecting (not (= type types/mention)))
          [react/view {:padding-left 16}
           [quo/checkbox {:value     (or @select-all selected)
                          :disabled  @select-all
@@ -35,11 +36,11 @@
                              (on-change)
                              ;; We don't dispatch on contact requests unless
                              ;; accepted
-                             (when (or (not= type constants/activity-center-notification-type-contact-request)
+                             (when (or (not= type types/contact-request)
                                        (= constants/contact-request-message-state-accepted (get-in home-item [:message :contact-request-state])))
                                (re-frame/dispatch [:accept-activity-center-notification-and-open-chat id]))))
           :on-long-press #(do (reset! selecting true)
-                              (when-not (= type constants/activity-center-notification-type-mention) (swap! selected-items conj id)))}]]])))
+                              (when-not (= type types/mention) (swap! selected-items conj id)))}]]])))
 (defn filter-item []
   [react/view {:padding-vertical 8 :border-bottom-width 1 :border-bottom-color colors/gray-lighter}
    [react/view {:align-items :center :justify-content :space-between :padding-horizontal 16 :flex-direction :row}

--- a/src/status_im/ui/screens/notifications_center/views/notification.cljs
+++ b/src/status_im/ui/screens/notifications_center/views/notification.cljs
@@ -10,6 +10,7 @@
             [status-im.multiaccounts.core :as multiaccounts]
             [status-im.ui.components.icons.icons :as icons]
             [status-im.constants :as constants]
+            [status-im.activity-center.notification-types :as types]
             [quo.design-system.colors :as colors]
             [status-im.ui.screens.home.views.inner-item :as home-item]
             [status-im.ui.components.chat-icon.screen :as chat-icon.screen]
@@ -41,19 +42,19 @@
      [react/touchable-opacity (merge {:style (styles/notification-container read)} opts)
       [react/view {:style {:flex 1}}
        (when (or
-              (= type constants/activity-center-notification-type-contact-request)
-              (= type constants/activity-center-notification-type-contact-request-retracted))
+              (= type types/contact-request)
+              (= type types/contact-request-retracted))
          [react/view {:style {:padding-horizontal 20}}
           [quo/text {:weight :bold}
            (if
-            (= type constants/activity-center-notification-type-contact-request)
+            (= type types/contact-request)
              (i18n/label :t/contact-request)
              (i18n/label :t/removed-from-contacts))]])
        (if (or
-            (= type constants/activity-center-notification-type-mention)
-            (= type constants/activity-center-notification-type-contact-request)
-            (= type constants/activity-center-notification-type-reply))
-         [react/view {:style (styles/photo-container (= type constants/activity-center-notification-type-contact-request))}
+            (= type types/mention)
+            (= type types/contact-request)
+            (= type types/reply))
+         [react/view {:style (styles/photo-container (= type types/contact-request))}
 
           [photos/photo
            (multiaccounts/displayed-photo contact)
@@ -73,10 +74,10 @@
                   :number-of-lines     1
                   :style               (styles/title-text title-text-width)}
         (if (or
-             (= type constants/activity-center-notification-type-mention)
-             (= type constants/activity-center-notification-type-contact-request)
-             (= type constants/activity-center-notification-type-contact-request-retracted)
-             (= type constants/activity-center-notification-type-reply))
+             (= type types/mention)
+             (= type types/contact-request)
+             (= type types/contact-request-retracted)
+             (= type types/reply))
           sender
           [home-item/chat-item-title chat-id muted group-chat chat-name])]
        [react/text {:style               styles/datetime-text
@@ -85,9 +86,9 @@
        ;;TODO (perf) move to event
         (home-item/memo-timestamp timestamp)]
        [react/view {:style styles/notification-message-container}
-        (when-not (= type constants/activity-center-notification-type-contact-request-retracted)
+        (when-not (= type types/contact-request-retracted)
           [home-item/message-content-text (select-keys message [:content :content-type :community-id]) false])
-        (cond (= type constants/activity-center-notification-type-mention)
+        (cond (= type types/mention)
               [react/view {:style styles/group-info-container
                            :accessibility-label :chat-name-container}
                [icons/icon
@@ -112,7 +113,7 @@
                           :size :small}
                 (str (when community-id "#") chat-name)]]
 
-              (= type constants/activity-center-notification-type-reply)
+              (= type types/reply)
               [react/view {:style styles/reply-message-container
                            :accessibility-label :reply-message-container}
                [icons/icon
@@ -122,7 +123,7 @@
                  :height 18
                  :container-style styles/reply-icon}]
                [home-item/message-content-text (select-keys reply-message [:content :content-type :community-id]) false]])]]]
-     (when (= type constants/activity-center-notification-type-contact-request)
+     (when (= type types/contact-request)
        [react/view {:style {:margin-right 20
                             :margin-top 10
                             :align-self :flex-end}}


### PR DESCRIPTION
Just a renaming of `constant/activity-center-notification-type...` prefix which is too long.  

Please let me know if we have some agreement that we actually have to name constants like this.

status: ready



 