### PR TITLE
chore: fix can't remove node 0 error breaking react-devtools

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "app:packager": "react-native start --host 0.0.0.0 --port 8081",
     "app:android": "react-native run-android"
   },
+  "resolutions": {
+    "react-devtools-core": "^4.26.0"
+  },
   "dependencies": {
     "@babel/preset-typescript": "^7.17.12",
     "@react-native-async-storage/async-storage": "^1.17.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7877,10 +7877,10 @@ rc@^1.2.7, rc@^1.2.8:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-devtools-core@^4.6.0:
-  version "4.10.1"
-  resolved "https://registry.yarnpkg.com/react-devtools-core/-/react-devtools-core-4.10.1.tgz#6d57db291aeac9cc45ef9fb4636dd2ab97490daf"
-  integrity sha512-sXbBjGAWcf9HAblTP/zMtFhGHqxAfIR+GPxONZsSGN9FHnF4635dx1s2LdQWG9rJ+Ehr3nWg+BUAB6P78my5PA==
+react-devtools-core@^4.26.0, react-devtools-core@^4.6.0:
+  version "4.26.1"
+  resolved "https://registry.yarnpkg.com/react-devtools-core/-/react-devtools-core-4.26.1.tgz#2893fea58089be64c5356d5bd0eebda8d1bbf317"
+  integrity sha512-r1csa5n9nABVpSdAadwTG7K+SfgRJPc/Hdx89BkV5IlA1mEGgGi3ir630ST5D/xYlJQaY3VE75YGADgpNW7HIw==
   dependencies:
     shell-quote "^1.6.1"
     ws "^7"


### PR DESCRIPTION
You can now use the layout inspector in [flipper](https://fbflipper.com/docs/features/plugins/inspector/) now

Note: 
- this PR upgrade react-devtools-core from `4.6.0` to `4.26.1(^4.26.0)`, there're lots of changes.
- `yarn why react-devtools-core` indicating it's required by `react-native`
- the related fix might be https://github.com/facebook/react/pull/24510 which is released in react-devtools-core `4.24.6`

status: ready <!-- Can be ready or wip -->

![CleanShot 2022-11-10 at 15 47 40](https://user-images.githubusercontent.com/15090582/201032696-04bef558-dcc7-4ffe-9ef0-210e61f2772b.png)