### PR TITLE
fix community channel back button

### DIFF
--- a/src/status_im/chat/models.cljs
+++ b/src/status_im/chat/models.cljs
@@ -252,7 +252,8 @@
   (fx/merge cofx
             {:dispatch [:navigate-to :chat]}
             (navigation/change-tab :chat)
-            (navigation/pop-to-root-tab :chat-stack)
+            (when-not (= (:view-id db) :community)
+              (navigation/pop-to-root-tab :chat-stack))
             (close-chat)
             (force-close-chat chat-id)
             (fn [{:keys [db]}]


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/14338

### Summary
Don't remove community stack while opening community channel

status: ready