### PR TITLE
Add icons & mentions/unread counts to community list

### DIFF
--- a/src/status_im/ui2/screens/quo2_preview/community/community_membership_list_view.cljs
+++ b/src/status_im/ui2/screens/quo2_preview/community/community_membership_list_view.cljs
@@ -1,10 +1,10 @@
-(ns status-im.ui2.screens.quo2-preview.community.community-list-view
+(ns status-im.ui2.screens.quo2-preview.community.community-membership-list-view
   (:require [quo.react-native :as rn]
             [quo.previews.preview :as preview]
             [reagent.core :as reagent]
             [quo2.foundations.colors :as colors]
-            [quo2.components.community.community-list-view :as community-list-view]
-            [status-im.ui2.screens.quo2-preview.community.data :as data]))
+            [status-im.ui2.screens.quo2-preview.community.data :as data]
+            [quo2.components.community.community-list-view :as community-list-view]))
 
 (def descriptor [{:label   "Notifications:"
                   :key     :notifications
@@ -41,15 +41,15 @@
          [preview/customizer state descriptor]]
         [rn/view {:padding-vertical 60
                   :justify-content  :center}
-         [community-list-view/communities-list-view-item {} (cond-> (merge @state data/community)
-                                                              (= :muted (:notifications @state))
-                                                              (assoc :muted? true)
+         [community-list-view/communities-membership-list-item {} (cond-> (merge @state data/community)
+                                                                    (= :muted (:notifications @state))
+                                                                    (assoc :muted? true)
 
-                                                              (= :unread-mentions-count (:notifications @state))
-                                                              (assoc :unread-mentions-count 5)
+                                                                    (= :unread-mentions-count (:notifications @state))
+                                                                    (assoc :unread-mentions-count 5)
 
-                                                              (= :unread-messages-count (:notifications @state))
-                                                              (assoc :unread-messages? true))]]]])))
+                                                                    (= :unread-messages-count (:notifications @state))
+                                                                    (assoc :unread-messages? true))]]]])))
 
 (defn preview-community-list-view []
   [rn/view {:background-color (colors/theme-colors colors/neutral-5

--- a/src/status_im/ui2/screens/quo2_preview/community/data.cljs
+++ b/src/status_im/ui2/screens/quo2_preview/community/data.cljs
@@ -1,0 +1,18 @@
+(ns status-im.ui2.screens.quo2-preview.community.data
+  (:require
+   [quo.design-system.colors :as quo.colors]
+   [status-im.i18n.i18n :as i18n]
+   [status-im.react-native.resources :as resources]))
+
+(def thumbnail "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII")
+
+(def community
+  {:id             "0xsomeid"
+   :name           "Status"
+   :description    "Status is a secure messaging app, crypto wallet and web3 browser built with the state of the art technology"
+   :community-icon thumbnail
+   :color          (rand-nth quo.colors/chat-colors)
+   :tokens         [{:id 1 :group [{:id 1 :token-icon (resources/get-image :status-logo)}]}]
+   :tags           [{:id 1 :tag-label (i18n/label :t/music) :resource (resources/get-image :music)}
+                    {:id 2 :tag-label (i18n/label :t/lifestyle) :resource (resources/get-image :lifestyle)}
+                    {:id 3 :tag-label (i18n/label :t/podcasts) :resource (resources/get-image :podcasts)}]})

--- a/src/status_im/ui2/screens/quo2_preview/main.cljs
+++ b/src/status_im/ui2/screens/quo2_preview/main.cljs
@@ -16,6 +16,7 @@
             [status-im.ui2.screens.quo2-preview.counter.counter :as counter]
             [status-im.ui2.screens.quo2-preview.community.community-card-view :as community-card]
             [status-im.ui2.screens.quo2-preview.community.community-list-view :as community-list-view]
+            [status-im.ui2.screens.quo2-preview.community.community-membership-list-view :as community-membership-list-view]
             [status-im.ui2.screens.quo2-preview.community.discover-card :as discover-card]
             [status-im.ui2.screens.quo2-preview.dividers.divider-label :as divider-label]
             [status-im.ui2.screens.quo2-preview.dividers.new-messages :as new-messages]
@@ -86,6 +87,9 @@
                {:name      :community-list-view
                 :insets    {:top false}
                 :component community-list-view/preview-community-list-view}
+               {:name      :community-membership-list-view
+                :insets    {:top false}
+                :component community-membership-list-view/preview-community-list-view}
                {:name      :discover-card
                 :insets    {:top false}
                 :component discover-card/preview-discoverd-card}]

--- a/src/status_im2/subs/communities_test.cljs
+++ b/src/status_im2/subs/communities_test.cljs
@@ -1,0 +1,40 @@
+(ns status-im2.subs.communities-test
+  (:require [cljs.test :refer [deftest is testing]]
+            [status-im2.subs.communities :as subs]))
+
+(deftest community->home-item-test
+  (testing "has unread messages"
+    (is (= {:name                  "name-1"
+            :muted?                true
+            :unread-messages?      true
+            :unread-mentions-count 5
+            :community-icon        "icon-1"}
+           (subs/community->home-item
+            {:name "name-1"
+             :muted true
+             :images {:thumbnail {:uri "icon-1"}}}
+            {:unviewed-messages-count 1
+             :unviewed-mentions-count 5}))))
+  (testing "no unread messages"
+    (is (= {:name                  "name-2"
+            :muted?                false
+            :unread-messages?      false
+            :unread-mentions-count 5
+            :community-icon        "icon-2"}
+           (subs/community->home-item
+            {:name "name-2"
+             :muted false
+             :images {:thumbnail {:uri "icon-2"}}}
+            {:unviewed-messages-count 0
+             :unviewed-mentions-count 5})))))
+
+(deftest calculate-unviewed-counts-test
+  (let [chats [{:unviewed-messages-count 1
+                :unviewed-mentions-count 2}
+               {:unviewed-messages-count 3
+                :unviewed-mentions-count 0}
+               {:unviewed-messages-count 2
+                :unviewed-mentions-count 1}]]
+    (is (= {:unviewed-messages-count 6
+            :unviewed-mentions-count 3}
+           (subs/calculate-unviewed-counts chats)))))


### PR DESCRIPTION
Add icons, unread counters to community list

Icon currently has no fallback, previously we fell back on the name of the community as an icon, but I have asked an it is/will be a compulsory field, so not sure it's worth it.

With regards of subscriptions, the strategy I have followed is:

1) Flat list subscribes to the ids of the joined communities.
So the whole list should only re-render when a user leaves/joins a community. (https://github.com/day8/re-frame/blob/master/docs/Performance-Problems.md).
2) Each community component is passed only an id as prop, and subscribes to the community data, only the values that are strictly needed to display the row. Only changes to relevant fields should trigger a re-render.

One thing that is not very efficient, is that if for example the unread mentions count changes (i.e any chat within a community has a mention), the whole row re-renders. This is due to the fact that the "unread" counter is not a "connected" componet, i.e, does not subscribe to anything.
That makes the `quo2` component pure, but I believe it's not optimal in terms of performance, so that's something to watch out for. 
Redux solution to this is to wrap pure components, into "connected" components, and pass the props along.
That's something worth considering if performance are an issue imo.

