### PR TITLE
[#14385] Comment out background which overlaps chat screen

### DIFF
--- a/src/status_im/ui2/screens/chat/composer/view.cljs
+++ b/src/status_im/ui2/screens/chat/composer/view.cljs
@@ -188,7 +188,7 @@
                                                        (re-frame/dispatch [:chat.ui/send-current-message]))}
                     :i/arrow-up]]])
                ;black background
-               [reanimated/view {:style (reanimated/apply-animations-to-style
-                                         {:opacity bg-opacity}
-                                         (styles/bottom-sheet-background window-height))}]
+               #_[reanimated/view {:style (reanimated/apply-animations-to-style
+                                           {:opacity bg-opacity}
+                                           (styles/bottom-sheet-background window-height))}]
                [mentions/autocomplete-mentions suggestions]]))])))])


### PR DESCRIPTION
Sometimes that background overlaps content of chat screen. If it is is non-functional then no point in fixing it for now.


status: ready ?