### PR TITLE
Fix reconciliation of notifications for new filter type :all

### DIFF
--- a/src/status_im/data_store/activities.cljs
+++ b/src/status_im/data_store/activities.cljs
@@ -4,7 +4,7 @@
             [status-im.constants :as constants]
             [status-im.activity-center.notification-types :as notification-types]
             [status-im.data-store.messages :as messages]
-            [status-im.utils.config :as config]))
+            [status-im2.setup.config :as config]))
 
 (defn- rpc->type [{:keys [type name] :as chat}]
   (case type

--- a/src/status_im/data_store/activities_test.cljs
+++ b/src/status_im/data_store/activities_test.cljs
@@ -3,7 +3,7 @@
             [status-im.constants :as constants]
             [status-im.activity-center.notification-types :as notification-types]
             [status-im.data-store.activities :as store]
-            [status-im.utils.config :as config]))
+            [status-im2.setup.config :as config]))
 
 (def chat-id
   "0x04c66155")

--- a/src/status_im/transport/message/core.cljs
+++ b/src/status_im/transport/message/core.cljs
@@ -5,7 +5,7 @@
             [status-im.chat.models.pin-message :as models.pin-message]
             [status-im.chat.models :as models.chat]
             [status-im.chat.models.reactions :as models.reactions]
-            [status-im.utils.config :as config]
+            [status-im2.setup.config :as config]
             [status-im.contact.core :as models.contact]
             [status-im.communities.core :as models.communities]
             [status-im.pairing.core :as models.pairing]

--- a/src/status_im/ui/screens/home/views.cljs
+++ b/src/status_im/ui/screens/home/views.cljs
@@ -22,7 +22,7 @@
             [status-im.ui.components.plus-button :as components.plus-button]
             [status-im.ui.screens.chat.sheets :as sheets]
             [status-im.ui.components.invite.views :as invite]
-            [status-im.utils.config :as config]
+            [status-im2.setup.config :as config]
             [quo2.components.markdown.text :as quo2.text]
             [status-im.qr-scanner.core :as qr-scanner]
             [status-im.ui.components.chat-icon.screen :as chat-icon.screen]

--- a/src/status_im/utils/config.cljs
+++ b/src/status_im/utils/config.cljs
@@ -145,7 +145,3 @@
 
 ;;TODO for development only should be removed in status 2.0
 (def new-ui-enabled? true)
-
-;; TODO: Remove this (highly) temporary flag once the new Activity Center is
-;; usable enough to replace the old one **in the new UI**.
-(def new-activity-center-enabled? false)


### PR DESCRIPTION
fixes #14400 

### Summary

See issue for details about the bug.

#### Notes

Fixed inconsistent usage of the feature flag `new-activity-center-enabled?`. Due to the duplication of certain namespaces during the ongoing project restructure, some parts of the app were pointing to the new (duplicated) flag, while others were pointing to the old one.

status: ready
