### PR TITLE
[#14381] Wrap texts with view to ensure separate accessibility labels

### DIFF
--- a/src/quo2/components/avatars/user_avatar.cljs
+++ b/src/quo2/components/avatars/user_avatar.cljs
@@ -122,9 +122,10 @@
                                  first-initial-letter
                                  initials)
                                "")]
-    [rn/view {:style {:width         outer-dimensions
-                      :height        outer-dimensions
-                      :border-radius outer-dimensions}}
+    [rn/view {:accessibility-label :user-avatar
+              :style               {:width         outer-dimensions
+                                    :height        outer-dimensions
+                                    :border-radius outer-dimensions}}
      (when (and ring? identicon?)
        [icons/icon :i/identicon-ring {:size     outer-dimensions
                                       :no-color true}])

--- a/src/status_im/ui/screens/communities/invite.cljs
+++ b/src/status_im/ui/screens/communities/invite.cljs
@@ -73,6 +73,7 @@
            :center
            [quo/button {:disabled (and (str/blank? @user-pk)
                                        (zero? (count selected)))
+                        :accessibility-label :share-community-link
                         :type     :secondary
                         :on-press #(>evt-once
                                     [(if can-invite?

--- a/src/status_im/ui2/screens/chat/messages/message.cljs
+++ b/src/status_im/ui2/screens/chat/messages/message.cljs
@@ -290,8 +290,9 @@
    (when show-key?
      (let [props {:size  :label
                   :style {:color (colors/theme-colors colors/neutral-50 colors/neutral-40)}}]
-       [text/text {:style {:margin-left 8
-                           :margin-top  2}}
+       [rn/view {:style {:margin-left    8
+                         :margin-top     2
+                         :flex-direction :row}}
         [text/text
          (assoc props :accessibility-label :message-chat-key)
          (utils/get-shortened-address (:public-key contact))]


### PR DESCRIPTION
First attempt did not work because `text`s would be merged into a single node on Android if they have another `text` as parent. 

fix #14381 