### PR TITLE
Fix various Activity Log layout issues

### DIFF
--- a/src/quo2/components/notifications/activity_log/style.cljs
+++ b/src/quo2/components/notifications/activity_log/style.cljs
@@ -3,7 +3,7 @@
 
 (def container
   {:flex-direction     :row
-   :flex               1
+   :flex-grow          1
    :align-items        :flex-start
    :padding-top        8
    :padding-horizontal 12
@@ -67,12 +67,10 @@
 
 (def context-container
   {:flex-direction  :row
-   :flex            1
    :align-items     :center
    :justify-content :flex-start
    :flex-wrap       :wrap})
 
 (def top-section-container
   {:align-items    :center
-   :flex           1
    :flex-direction :row})

--- a/src/quo2/components/notifications/activity_log/style.cljs
+++ b/src/quo2/components/notifications/activity_log/style.cljs
@@ -1,0 +1,78 @@
+(ns quo2.components.notifications.activity-log.style
+  (:require [quo2.foundations.colors :as colors]))
+
+(def container
+  {:flex-direction     :row
+   :flex               1
+   :align-items        :flex-start
+   :padding-top        8
+   :padding-horizontal 12
+   :padding-bottom     12})
+
+(def icon
+  {:height          32
+   :width           32
+   :border-radius   100
+   :margin-top      10
+   :border-width    1
+   :border-color    colors/white-opa-5
+   :align-items     :center
+   :justify-content :center})
+
+(def message-title
+  {:color         colors/white-opa-40
+   :margin-bottom 2})
+
+(def message-body
+  {:color colors/white})
+
+(def message-container
+  {:border-radius      12
+   :margin-top         12
+   :padding-horizontal 12
+   :padding-vertical   8
+   :background-color   colors/white-opa-5})
+
+(def buttons-container
+  {:margin-top     12
+   :flex-direction :row
+   :align-items    :flex-start})
+
+(def status
+  {:margin-top  12
+   :align-items :flex-start
+   :flex        1})
+
+(defn title [replying?]
+  {:color       colors/white
+   :flex-shrink 1
+   :max-width   (when-not replying? "60%")})
+
+(def timestamp
+  {:text-transform :none
+   :flex-grow      1
+   :margin-left    8
+   :color          colors/neutral-40})
+
+(def unread-dot
+  {:background-color colors/primary-50
+   :border-radius    4
+   :width            8
+   :height           8})
+
+(def unread-dot-container
+  {:margin-left        8
+   :padding-horizontal 12
+   :padding-vertical   7})
+
+(def context-container
+  {:flex-direction  :row
+   :flex            1
+   :align-items     :center
+   :justify-content :flex-start
+   :flex-wrap       :wrap})
+
+(def top-section-container
+  {:align-items    :center
+   :flex           1
+   :flex-direction :row})

--- a/src/quo2/components/notifications/activity_log/view.cljs
+++ b/src/quo2/components/notifications/activity_log/view.cljs
@@ -1,4 +1,4 @@
-(ns quo2.components.notifications.activity-logs
+(ns quo2.components.notifications.activity-log.view
   (:require [clojure.string :as string]
             [quo.core :as quo]
             [quo2.components.buttons.button :as button]
@@ -6,6 +6,7 @@
             [quo2.components.markdown.text :as text]
             [quo2.components.tags.status-tags :as status-tags]
             [quo2.foundations.colors :as colors]
+            [quo2.components.notifications.activity-log.style :as style]
             [react-native.core :as rn]
             [reagent.core :as reagent]
             [status-im.i18n.i18n :as i18n]))
@@ -49,26 +50,14 @@
 
 (defn- activity-icon
   [icon]
-  [rn/view {:height          32
-            :width           32
-            :border-radius   100
-            :margin-top      10
-            :border-width    1
-            :border-color    colors/white-opa-5
-            :align-items     :center
-            :justify-content :center}
+  [rn/view {:style style/icon}
    [icon/icon icon {:color colors/white}]])
 
 (defn- activity-context
   [context replying?]
   (let [first-line-offset (if replying? 4 0)
         gap-between-lines 4]
-    (into [rn/view {:style {:flex-direction  :row
-                            :flex            1
-                            :align-items     :center
-                            :justify-content :flex-start
-                            :flex-wrap       :wrap
-                            :margin-top      first-line-offset}}]
+    (into [rn/view {:style (assoc style/context-container :margin-top first-line-offset)}]
           (mapcat (fn [detail]
                     ^{:key (hash detail)}
                     (if (string? detail)
@@ -86,19 +75,14 @@
 
 (defn- activity-message
   [{:keys [title body]}]
-  [rn/view {:border-radius      12
-            :margin-top         12
-            :padding-horizontal 12
-            :padding-vertical   8
-            :background-color   colors/white-opa-5}
+  [rn/view {:style style/message-container}
    (when title
      [text/text {:size                :paragraph-2
                  :accessibility-label :activity-message-title
-                 :style               {:color         colors/white-opa-40
-                                       :margin-bottom 2}}
+                 :style               style/message-title}
       title])
    (if (string? body)
-     [text/text {:style               {:color colors/white}
+     [text/text {:style               style/message-body
                  :accessibility-label :activity-message-body
                  :size                :paragraph-1}
       body]
@@ -111,9 +95,7 @@
                        {:padding-vertical 9
                         :flex-grow        1
                         :flex-basis       0})]
-    [rn/view {:margin-top     12
-              :flex-direction :row
-              :align-items    :flex-start}
+    [rn/view style/buttons-container
      (when button-1
        [button/button (-> button-1
                           (assoc :size size)
@@ -128,9 +110,7 @@
 
 (defn- activity-status
   [status]
-  [rn/view {:style               {:margin-top  12
-                                  :align-items :flex-start
-                                  :flex        1}
+  [rn/view {:style               style/status
             :accessibility-label :activity-status}
    [status-tags/status-tag {:size   :small
                             :label  (:label status)
@@ -140,9 +120,7 @@
   [title replying?]
   [text/text {:weight              :semi-bold
               :accessibility-label :activity-title
-              :style               {:color       colors/white
-                                    :flex-shrink 1
-                                    :max-width   (when-not replying? "60%")}
+              :style               (style/title replying?)
               :size                (if replying? :heading-2 :paragraph-1)}
    title])
 
@@ -150,22 +128,14 @@
   [timestamp]
   [text/text {:size                :label
               :accessibility-label :activity-timestamp
-              :style               {:text-transform :none
-                                    :flex-grow      1
-                                    :margin-left    8
-                                    :color          colors/neutral-40}}
+              :style               style/timestamp}
    timestamp])
 
 (defn- activity-unread-dot
   []
   [rn/view {:accessibility-label :activity-unread-indicator
-            :style               {:margin-left        8
-                                  :padding-horizontal 12
-                                  :padding-vertical   7}}
-   [rn/view {:style {:background-color colors/primary-50
-                     :border-radius    4
-                     :width            8
-                     :height           8}}]])
+            :style               style/unread-dot-container}
+   [rn/view {:style style/unread-dot}]])
 
 (defn- footer
   [_]
@@ -180,7 +150,7 @@
              (or button-1 button-2)
              [activity-buttons button-1 button-2 replying? reply-input])])))
 
-(defn activity-log
+(defn view
   [{:keys [icon
            message
            context
@@ -190,20 +160,13 @@
            unread?]
     :as   props}]
   [rn/view {:accessibility-label :activity
-            :style               {:flex-direction     :row
-                                  :flex               1
-                                  :align-items        :flex-start
-                                  :padding-top        8
-                                  :padding-horizontal 12
-                                  :padding-bottom     12}}
+            :style               style/container}
    (when-not replying?
      [activity-icon icon])
    [rn/view {:style {:padding-left (when-not replying? 8)
                      :flex         1}}
     [rn/view
-     [rn/view {:style {:align-items    :center
-                       :flex           1
-                       :flex-direction :row}}
+     [rn/view {:style style/top-section-container}
       [activity-title title replying?]
       (when-not replying?
         [activity-timestamp timestamp])

--- a/src/quo2/components/notifications/activity_log/view.cljs
+++ b/src/quo2/components/notifications/activity_log/view.cljs
@@ -61,13 +61,12 @@
           (mapcat (fn [detail]
                     ^{:key (hash detail)}
                     (if (string? detail)
-                      (map-indexed (fn [index s]
-                                     ^{:key index}
-                                     [rn/view {:style {:margin-right 4
-                                                       :margin-top   0}}
-                                      [text/text {:size :paragraph-2}
-                                       s]])
-                                   (string/split detail #"\s+"))
+                      (map (fn [s]
+                             [rn/view {:style {:margin-right 4
+                                               :margin-top   0}}
+                              [text/text {:size :paragraph-2}
+                               s]])
+                           (string/split detail #"\s+"))
                       [[rn/view {:margin-right 4
                                  :margin-top   gap-between-lines}
                         detail]]))

--- a/src/quo2/components/notifications/activity_logs.cljs
+++ b/src/quo2/components/notifications/activity_logs.cljs
@@ -92,13 +92,15 @@
             :padding-vertical   8
             :background-color   colors/white-opa-5}
    (when title
-     [text/text {:size  :paragraph-2
-                 :style {:color         colors/white-opa-40
-                         :margin-bottom 2}}
+     [text/text {:size                :paragraph-2
+                 :accessibility-label :activity-message-title
+                 :style               {:color         colors/white-opa-40
+                                       :margin-bottom 2}}
       title])
    (if (string? body)
-     [text/text {:style {:color colors/white}
-                 :size  :paragraph-1}
+     [text/text {:style               {:color colors/white}
+                 :accessibility-label :activity-message-body
+                 :size                :paragraph-1}
       body]
      body)])
 
@@ -126,36 +128,40 @@
 
 (defn- activity-status
   [status]
-  [rn/view {:margin-top  12
-            :align-items :flex-start
-            :flex        1}
+  [rn/view {:style               {:margin-top  12
+                                  :align-items :flex-start
+                                  :flex        1}
+            :accessibility-label :activity-status}
    [status-tags/status-tag {:size   :small
                             :label  (:label status)
                             :status status}]])
 
 (defn- activity-title
   [title replying?]
-  [text/text {:weight :semi-bold
-              :style  {:color       colors/white
-                       :flex-shrink 1
-                       :max-width   (when-not replying? "60%")}
-              :size   (if replying? :heading-2 :paragraph-1)}
+  [text/text {:weight              :semi-bold
+              :accessibility-label :activity-title
+              :style               {:color       colors/white
+                                    :flex-shrink 1
+                                    :max-width   (when-not replying? "60%")}
+              :size                (if replying? :heading-2 :paragraph-1)}
    title])
 
 (defn- activity-timestamp
   [timestamp]
-  [text/text {:size  :label
-              :style {:text-transform :none
-                      :flex-grow      1
-                      :margin-left    8
-                      :color          colors/neutral-40}}
+  [text/text {:size                :label
+              :accessibility-label :activity-timestamp
+              :style               {:text-transform :none
+                                    :flex-grow      1
+                                    :margin-left    8
+                                    :color          colors/neutral-40}}
    timestamp])
 
 (defn- activity-unread-dot
   []
-  [rn/view {:style {:margin-left        8
-                    :padding-horizontal 12
-                    :padding-vertical   7}}
+  [rn/view {:accessibility-label :activity-unread-indicator
+            :style               {:margin-left        8
+                                  :padding-horizontal 12
+                                  :padding-vertical   7}}
    [rn/view {:style {:background-color colors/primary-50
                      :border-radius    4
                      :width            8
@@ -183,12 +189,13 @@
            replying?
            unread?]
     :as   props}]
-  [rn/view {:style {:flex-direction     :row
-                    :flex               1
-                    :align-items        :flex-start
-                    :padding-top        8
-                    :padding-horizontal 12
-                    :padding-bottom     12}}
+  [rn/view {:accessibility-label :activity
+            :style               {:flex-direction     :row
+                                  :flex               1
+                                  :align-items        :flex-start
+                                  :padding-top        8
+                                  :padding-horizontal 12
+                                  :padding-bottom     12}}
    (when-not replying?
      [activity-icon icon])
    [rn/view {:style {:padding-left (when-not replying? 8)

--- a/src/quo2/components/notifications/activity_logs.cljs
+++ b/src/quo2/components/notifications/activity_logs.cljs
@@ -1,5 +1,5 @@
 (ns quo2.components.notifications.activity-logs
-  (:require [clojure.string :as str]
+  (:require [clojure.string :as string]
             [quo.core :as quo]
             [quo2.components.buttons.button :as button]
             [quo2.components.icon :as icon]
@@ -78,7 +78,7 @@
                                                        :margin-top   0}}
                                       [text/text {:size :paragraph-2}
                                        s]])
-                                   (str/split detail #"\s+"))
+                                   (string/split detail #"\s+"))
                       [[rn/view {:margin-right 4
                                  :margin-top   gap-between-lines}
                         detail]]))

--- a/src/quo2/core.cljs
+++ b/src/quo2/core.cljs
@@ -28,7 +28,7 @@
             quo2.components.messages.gap
             quo2.components.messages.system-message
             quo2.components.reactions.reaction
-            quo2.components.notifications.activity-logs
+            quo2.components.notifications.activity-log.view
             quo2.components.notifications.info-count
             quo2.components.notifications.notification-dot
             quo2.components.tags.tags
@@ -58,6 +58,7 @@
 (def tags quo2.components.tags.tags/tags)
 (def user-avatar-tag quo2.components.tags.context-tags/user-avatar-tag)
 (def context-tag quo2.components.tags.context-tags/context-tag)
+(def group-avatar-tag quo2.components.tags.context-tags/group-avatar-tag)
 (def tabs quo2.components.tabs.tabs/tabs)
 (def scrollable-tabs quo2.components.tabs.tabs/scrollable-tabs)
 (def account-selector quo2.components.tabs.account-selector/account-selector)
@@ -96,6 +97,6 @@
 (def preview-list quo2.components.list-items.preview-list/preview-list)
 
 ;;;; NOTIFICATIONS
-(def activity-log quo2.components.notifications.activity-logs/activity-log)
+(def activity-log quo2.components.notifications.activity-log.view/view)
 (def info-count quo2.components.notifications.info-count/info-count)
 (def notification-dot quo2.components.notifications.notification-dot/notification-dot)

--- a/src/quo2/core.cljs
+++ b/src/quo2/core.cljs
@@ -58,7 +58,6 @@
 (def tags quo2.components.tags.tags/tags)
 (def user-avatar-tag quo2.components.tags.context-tags/user-avatar-tag)
 (def context-tag quo2.components.tags.context-tags/context-tag)
-(def group-avatar-tag quo2.components.tags.context-tags/group-avatar-tag)
 (def tabs quo2.components.tabs.tabs/tabs)
 (def scrollable-tabs quo2.components.tabs.tabs/scrollable-tabs)
 (def account-selector quo2.components.tabs.account-selector/account-selector)

--- a/src/status_im/ui/screens/activity_center/notification/contact_request/view.cljs
+++ b/src/status_im/ui/screens/activity_center/notification/contact_request/view.cljs
@@ -38,8 +38,7 @@
                                  :text-style     style/user-avatar-tag-text}
                                 (activity-center.utils/contact-name contact)
                                 (multiaccounts/displayed-photo contact)]
-                               [quo2/text {:style style/context-tag-text}
-                                (i18n/label :t/contact-request-sent)]]
+                               (i18n/label :t/contact-request-sent)]
                    :message   {:body (get-in message [:content :text])}
                    :status    (case (:contact-request-state message)
                                 constants/contact-request-message-state-accepted

--- a/src/status_im/ui/screens/activity_center/notification/contact_request/view.cljs
+++ b/src/status_im/ui/screens/activity_center/notification/contact_request/view.cljs
@@ -48,10 +48,12 @@
                                 nil)}
                   (case (:contact-request-state message)
                     constants/contact-request-state-mutual
-                    {:button-1 {:label    (i18n/label :t/decline)
-                                :type     :danger
-                                :on-press #(rf/dispatch [:contact-requests.ui/decline-request id])}
-                     :button-2 {:label    (i18n/label :t/accept)
-                                :type     :positive
-                                :on-press #(rf/dispatch [:contact-requests.ui/accept-request id])}}
+                    {:button-1 {:label               (i18n/label :t/decline)
+                                :accessibility-label :decline-contact-request
+                                :type                :danger
+                                :on-press            #(rf/dispatch [:contact-requests.ui/decline-request id])}
+                     :button-2 {:label               (i18n/label :t/accept)
+                                :accessibility-label :accept-contact-request
+                                :type                :positive
+                                :on-press            #(rf/dispatch [:contact-requests.ui/accept-request id])}}
                     nil))])))

--- a/src/status_im/ui/screens/activity_center/notification/contact_verification/view.cljs
+++ b/src/status_im/ui/screens/activity_center/notification/contact_verification/view.cljs
@@ -82,23 +82,28 @@
                    :status          (activity-status challenger? contact-verification-status)}
                   (if challenger?
                     (cond (= contact-verification-status constants/contact-verification-status-accepted)
-                          {:button-1 {:label    (i18n/label :t/untrustworthy)
-                                      :type     :danger
-                                      :on-press #(rf/dispatch [:activity-center.contact-verification/mark-as-untrustworthy id])}
-                           :button-2 {:label    (i18n/label :t/accept)
-                                      :type     :positive
-                                      :on-press #(rf/dispatch [:activity-center.contact-verification/mark-as-trusted id])}})
+                          {:button-1 {:label               (i18n/label :t/untrustworthy)
+                                      :accessibility-label :mark-contact-verification-as-untrustworthy
+                                      :type                :danger
+                                      :on-press            #(rf/dispatch [:activity-center.contact-verification/mark-as-untrustworthy id])}
+                           :button-2 {:label               (i18n/label :t/accept)
+                                      :accessibility-label :mark-contact-verification-as-trusted
+                                      :type                :positive
+                                      :on-press            #(rf/dispatch [:activity-center.contact-verification/mark-as-trusted id])}})
                     (cond (= contact-verification-status constants/contact-verification-status-pending)
-                          {:button-1 {:label    (i18n/label :t/decline)
-                                      :type     :danger
-                                      :on-press #(hide-bottom-sheet-and-dispatch [:activity-center.contact-verification/decline id])}
+                          {:button-1 {:label               (i18n/label :t/decline)
+                                      :accessibility-label :decline-contact-verification
+                                      :type                :danger
+                                      :on-press            #(hide-bottom-sheet-and-dispatch [:activity-center.contact-verification/decline id])}
                            :button-2 (if replying?
-                                       {:label    (i18n/label :t/send-reply)
-                                        :type     :primary
-                                        :on-press #(hide-bottom-sheet-and-dispatch [:activity-center.contact-verification/reply id @reply])}
-                                       {:label    (i18n/label :t/message-reply)
-                                        :type     :primary
-                                        :on-press #(rf/dispatch [:bottom-sheet/show-sheet
-                                                                 :activity-center.contact-verification/reply
-                                                                 {:notification notification
-                                                                  :replying?    true}])})})))])))))
+                                       {:label               (i18n/label :t/send-reply)
+                                        :accessibility-label :reply-to-contact-verification
+                                        :type                :primary
+                                        :on-press            #(hide-bottom-sheet-and-dispatch [:activity-center.contact-verification/reply id @reply])}
+                                       {:label               (i18n/label :t/message-reply)
+                                        :accessibility-label :send-reply-to-contact-verification
+                                        :type                :primary
+                                        :on-press            #(rf/dispatch [:bottom-sheet/show-sheet
+                                                                            :activity-center.contact-verification/reply
+                                                                            {:notification notification
+                                                                             :replying?    true}])})})))])))))

--- a/src/status_im/ui/screens/activity_center/notification/contact_verification/view.cljs
+++ b/src/status_im/ui/screens/activity_center/notification/contact_verification/view.cljs
@@ -26,16 +26,15 @@
        :text-style     style/user-avatar-tag-text}
       (activity-center.utils/contact-name contact)
       (multiaccounts/displayed-photo contact)]
-     [quo2/text {:style style/context-tag-text}
-      (if challenger?
-        (cond (or (= contact-verification-status constants/contact-verification-status-accepted)
-                  (= contact-verification-status constants/contact-verification-status-trusted)
-                  (= contact-verification-status constants/contact-verification-status-untrustworthy))
-              (str (str/lower-case (i18n/label :t/replied)) ":"))
-        (cond (or (= contact-verification-status constants/contact-verification-status-accepted)
-                  (= contact-verification-status constants/contact-verification-status-pending)
-                  (= contact-verification-status constants/contact-verification-status-declined))
-              (str (i18n/label :t/identity-verification-request-sent) ":")))]]))
+     (if challenger?
+       (cond (or (= contact-verification-status constants/contact-verification-status-accepted)
+                 (= contact-verification-status constants/contact-verification-status-trusted)
+                 (= contact-verification-status constants/contact-verification-status-untrustworthy))
+             (str (str/lower-case (i18n/label :t/replied)) ":"))
+       (cond (or (= contact-verification-status constants/contact-verification-status-accepted)
+                 (= contact-verification-status constants/contact-verification-status-pending)
+                 (= contact-verification-status constants/contact-verification-status-declined))
+             (str (i18n/label :t/identity-verification-request-sent) ":")))]))
 
 (defn- activity-message
   [challenger? {:keys [contact-verification-status message reply-message]}]

--- a/src/status_im/ui/screens/activity_center/notification/contact_verification/view.cljs
+++ b/src/status_im/ui/screens/activity_center/notification/contact_verification/view.cljs
@@ -27,27 +27,27 @@
       (activity-center.utils/contact-name contact)
       (multiaccounts/displayed-photo contact)]
      (if challenger?
-       (cond (or (= contact-verification-status constants/contact-verification-status-accepted)
+       (when (or (= contact-verification-status constants/contact-verification-status-accepted)
                  (= contact-verification-status constants/contact-verification-status-trusted)
                  (= contact-verification-status constants/contact-verification-status-untrustworthy))
-             (str (str/lower-case (i18n/label :t/replied)) ":"))
-       (cond (or (= contact-verification-status constants/contact-verification-status-accepted)
+         (str (str/lower-case (i18n/label :t/replied)) ":"))
+       (when (or (= contact-verification-status constants/contact-verification-status-accepted)
                  (= contact-verification-status constants/contact-verification-status-pending)
                  (= contact-verification-status constants/contact-verification-status-declined))
-             (str (i18n/label :t/identity-verification-request-sent) ":")))]))
+         (str (i18n/label :t/identity-verification-request-sent) ":")))]))
 
 (defn- activity-message
   [challenger? {:keys [contact-verification-status message reply-message]}]
   (if challenger?
-    (cond (or (= contact-verification-status constants/contact-verification-status-accepted)
+    (when (or (= contact-verification-status constants/contact-verification-status-accepted)
               (= contact-verification-status constants/contact-verification-status-trusted)
               (= contact-verification-status constants/contact-verification-status-untrustworthy))
-          {:title (get-in message [:content :text])
-           :body  (get-in reply-message [:content :text])})
-    (cond (or (= contact-verification-status constants/contact-verification-status-accepted)
+      {:title (get-in message [:content :text])
+       :body  (get-in reply-message [:content :text])})
+    (when (or (= contact-verification-status constants/contact-verification-status-accepted)
               (= contact-verification-status constants/contact-verification-status-pending)
               (= contact-verification-status constants/contact-verification-status-declined))
-          {:body (get-in message [:content :text])})))
+      {:body (get-in message [:content :text])})))
 
 (defn- activity-status
   [challenger? contact-verification-status]
@@ -81,29 +81,29 @@
                    :message         (activity-message challenger? notification)
                    :status          (activity-status challenger? contact-verification-status)}
                   (if challenger?
-                    (cond (= contact-verification-status constants/contact-verification-status-accepted)
-                          {:button-1 {:label               (i18n/label :t/untrustworthy)
-                                      :accessibility-label :mark-contact-verification-as-untrustworthy
-                                      :type                :danger
-                                      :on-press            #(rf/dispatch [:activity-center.contact-verification/mark-as-untrustworthy id])}
-                           :button-2 {:label               (i18n/label :t/accept)
-                                      :accessibility-label :mark-contact-verification-as-trusted
-                                      :type                :positive
-                                      :on-press            #(rf/dispatch [:activity-center.contact-verification/mark-as-trusted id])}})
-                    (cond (= contact-verification-status constants/contact-verification-status-pending)
-                          {:button-1 {:label               (i18n/label :t/decline)
-                                      :accessibility-label :decline-contact-verification
-                                      :type                :danger
-                                      :on-press            #(hide-bottom-sheet-and-dispatch [:activity-center.contact-verification/decline id])}
-                           :button-2 (if replying?
-                                       {:label               (i18n/label :t/send-reply)
-                                        :accessibility-label :reply-to-contact-verification
-                                        :type                :primary
-                                        :on-press            #(hide-bottom-sheet-and-dispatch [:activity-center.contact-verification/reply id @reply])}
-                                       {:label               (i18n/label :t/message-reply)
-                                        :accessibility-label :send-reply-to-contact-verification
-                                        :type                :primary
-                                        :on-press            #(rf/dispatch [:bottom-sheet/show-sheet
-                                                                            :activity-center.contact-verification/reply
-                                                                            {:notification notification
-                                                                             :replying?    true}])})})))])))))
+                    (when (= contact-verification-status constants/contact-verification-status-accepted)
+                      {:button-1 {:label               (i18n/label :t/untrustworthy)
+                                  :accessibility-label :mark-contact-verification-as-untrustworthy
+                                  :type                :danger
+                                  :on-press            #(rf/dispatch [:activity-center.contact-verification/mark-as-untrustworthy id])}
+                       :button-2 {:label               (i18n/label :t/accept)
+                                  :accessibility-label :mark-contact-verification-as-trusted
+                                  :type                :positive
+                                  :on-press            #(rf/dispatch [:activity-center.contact-verification/mark-as-trusted id])}})
+                    (when (= contact-verification-status constants/contact-verification-status-pending)
+                      {:button-1 {:label               (i18n/label :t/decline)
+                                  :accessibility-label :decline-contact-verification
+                                  :type                :danger
+                                  :on-press            #(hide-bottom-sheet-and-dispatch [:activity-center.contact-verification/decline id])}
+                       :button-2 (if replying?
+                                   {:label               (i18n/label :t/send-reply)
+                                    :accessibility-label :reply-to-contact-verification
+                                    :type                :primary
+                                    :on-press            #(hide-bottom-sheet-and-dispatch [:activity-center.contact-verification/reply id @reply])}
+                                   {:label               (i18n/label :t/message-reply)
+                                    :accessibility-label :send-reply-to-contact-verification
+                                    :type                :primary
+                                    :on-press            #(rf/dispatch [:bottom-sheet/show-sheet
+                                                                        :activity-center.contact-verification/reply
+                                                                        {:notification notification
+                                                                         :replying?    true}])})})))])))))

--- a/src/status_im/ui/screens/activity_center/style.cljs
+++ b/src/status_im/ui/screens/activity_center/style.cljs
@@ -19,13 +19,10 @@
    :padding-top    (if (pos? top) (+ top 12) 12)
    :padding-bottom bottom})
 
-(def notifications-container
-  {:flex-grow 1})
-
 (defn notification-container
   [index]
   {:margin-top         (if (zero? index) 0 4)
-   :padding-horizontal screen-padding})
+   :padding-horizontal 8})
 
 (def tabs
   {:padding-left screen-padding})

--- a/src/status_im/ui/screens/activity_center/views.cljs
+++ b/src/status_im/ui/screens/activity_center/views.cljs
@@ -124,9 +124,8 @@
        (react/effect! #(rf/dispatch [:activity-center.notifications/fetch-first-page]))
        [rn/view {:style (style/screen-container window-width top bottom)}
         [header]
-        [rn/flat-list {:content-container-style style/notifications-container
-                       :data                    notifications
-                       :empty-component         [empty-tab]
-                       :key-fn                  :id
-                       :on-end-reached          #(rf/dispatch [:activity-center.notifications/fetch-next-page])
-                       :render-fn               render-notification}]]))])
+        [rn/flat-list {:data            notifications
+                       :empty-component [empty-tab]
+                       :key-fn          :id
+                       :on-end-reached  #(rf/dispatch [:activity-center.notifications/fetch-next-page])
+                       :render-fn       render-notification}]]))])

--- a/src/status_im2/contexts/quo_preview/notifications/activity_logs.cljs
+++ b/src/status_im2/contexts/quo_preview/notifications/activity_logs.cljs
@@ -1,12 +1,10 @@
 (ns status-im2.contexts.quo-preview.notifications.activity-logs
-  (:require [status-im2.contexts.quo-preview.preview :as preview]
-            [react-native.core :as rn]
-            [quo2.components.markdown.text :as text]
-            [quo2.components.notifications.activity-logs :as activity-logs]
-            [quo2.components.tags.context-tags :as context-tags]
+  (:require [quo2.core :as quo2]
             [quo2.foundations.colors :as colors]
-            [status-im2.contexts.quo-preview.tags.status-tags :as status-tags]
-            [reagent.core :as reagent]))
+            [react-native.core :as rn]
+            [reagent.core :as reagent]
+            [status-im2.contexts.quo-preview.preview :as preview]
+            [status-im2.contexts.quo-preview.tags.status-tags :as status-tags]))
 
 (def descriptor [{:label "Unread?"
                   :key   :unread?
@@ -68,12 +66,12 @@
                  status-tags/status-tags-options])
 
 (def basic-user-action
-  [[context-tags/group-avatar-tag "Name" {:color          :purple
-                                          :override-theme :dark
-                                          :size           :small
-                                          :style          {:background-color colors/white-opa-10}
-                                          :text-style     {:color colors/white}}]
-   [rn/text {:style {:color colors/white}} "did something here."]])
+  [[quo2/group-avatar-tag "Name" {:color          :purple
+                                  :override-theme :dark
+                                  :size           :small
+                                  :style          {:background-color colors/white-opa-10}
+                                  :text-style     {:color colors/white}}]
+   [quo2/text {:style {:color colors/white}} "did something here."]])
 
 (def complex-user-action
   (let [tag-props {:color          :purple
@@ -81,28 +79,28 @@
                    :size           :small
                    :style          {:background-color colors/white-opa-10}
                    :text-style     {:color colors/white}}]
-    [[context-tags/group-avatar-tag "250,000 SNT" tag-props]
-     [rn/text {:style {:color colors/white}} "from"]
-     [context-tags/group-avatar-tag "Mainnet" tag-props]
-     [rn/text {:style {:color colors/white}} "to"]
-     [context-tags/group-avatar-tag "Optimism" tag-props]
-     [rn/text {:style {:color colors/white}} "on"]
-     [context-tags/group-avatar-tag "My savings" tag-props]]))
+    [[quo2/group-avatar-tag "250,000 SNT" tag-props]
+     [quo2/text {:style {:color colors/white}} "from"]
+     [quo2/group-avatar-tag "Mainnet" tag-props]
+     [quo2/text {:style {:color colors/white}} "to"]
+     [quo2/group-avatar-tag "Optimism" tag-props]
+     [quo2/text {:style {:color colors/white}} "on"]
+     [quo2/group-avatar-tag "My savings" tag-props]]))
 
 (def message-with-mention
   (let [common-text-style {:style {:color colors/white}
                            :size  :paragraph-1}]
     {:body [rn/view {:flex           1
                      :flex-direction :row}
-            [text/text common-text-style "Hello"]
-            [text/text {:style {:background-color   colors/primary-50-opa-10
+            [quo2/text common-text-style "Hello"]
+            [quo2/text {:style {:background-color   colors/primary-50-opa-10
                                 :border-radius      6
                                 :color              colors/primary-50
                                 :margin-horizontal  3
                                 :padding-horizontal 3
                                 :size               :paragraph-1}}
              "@name"]
-            [text/text common-text-style "! How are you feeling?"]]}))
+            [quo2/text common-text-style "! How are you feeling?"]]}))
 
 (def message-with-title
   {:body  "Your favorite color is Turquoise."
@@ -161,7 +159,7 @@
                    :flex-direction   :row
                    :justify-content  :center
                    :padding-vertical 60}
-          [activity-logs/activity-log props]]]))))
+          [quo2/activity-log props]]]))))
 
 (defn preview-activity-logs []
   [rn/view {:flex 1}

--- a/src/status_im2/contexts/quo_preview/notifications/activity_logs.cljs
+++ b/src/status_im2/contexts/quo_preview/notifications/activity_logs.cljs
@@ -66,12 +66,14 @@
                  status-tags/status-tags-options])
 
 (def basic-user-action
-  [[quo2/group-avatar-tag "Name" {:color          :purple
-                                  :override-theme :dark
-                                  :size           :small
-                                  :style          {:background-color colors/white-opa-10}
-                                  :text-style     {:color colors/white}}]
-   [quo2/text {:style {:color colors/white}} "did something here."]])
+  [[quo2/user-avatar-tag
+    {:color          :purple
+     :override-theme :dark
+     :size           :small
+     :style          {:background-color colors/white-opa-10}
+     :text-style     {:color colors/white}}
+    "Name"]
+   "did something here."])
 
 (def complex-user-action
   (let [tag-props {:color          :purple
@@ -79,13 +81,13 @@
                    :size           :small
                    :style          {:background-color colors/white-opa-10}
                    :text-style     {:color colors/white}}]
-    [[quo2/group-avatar-tag "250,000 SNT" tag-props]
-     [quo2/text {:style {:color colors/white}} "from"]
-     [quo2/group-avatar-tag "Mainnet" tag-props]
-     [quo2/text {:style {:color colors/white}} "to"]
-     [quo2/group-avatar-tag "Optimism" tag-props]
-     [quo2/text {:style {:color colors/white}} "on"]
-     [quo2/group-avatar-tag "My savings" tag-props]]))
+    [[quo2/user-avatar-tag tag-props "Alice"]
+     "from"
+     [quo2/user-avatar-tag tag-props "Mainnet"]
+     "to"
+     [quo2/user-avatar-tag tag-props "Optimism"]
+     "on"
+     [quo2/user-avatar-tag tag-props "My savings"]]))
 
 (def message-with-mention
   (let [common-text-style {:style {:color colors/white}


### PR DESCRIPTION
fixes #14102 

### Summary

Apart from fixing #14102, this PR also fixes other outstanding problems.

- [x] Fix incorrect display of long notification titles.
- [x] Add more accessibility labels
- [x] Add missing margin below the notification title.
- [x] Removed blue background from notification to match what's in Figma.

<table>
  <thead>
    <tr>
      <th>BEFORE</th>
      <th>FIXED</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img alt="before" src="https://user-images.githubusercontent.com/46027/202776394-54cde967-3e7a-4ffc-8ed8-460e69b650cb.png" width="300" /></td>
      <td><img alt="fixed" src="https://user-images.githubusercontent.com/46027/202776377-3342abb9-0cbd-4033-a7a6-e2029e10651d.png" width="300" /></td>
    </tr>
  </tbody>
</table>

<table>
  <thead>
    <tr>
      <th>BEFORE</th>
      <th>FIXED</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>
        <img alt="before" src="https://user-images.githubusercontent.com/46027/193580174-f3cbf42a-a69c-43d6-941f-fa3175d8e944.png" width="300" />
      </td>
      <td>
        <img alt="fixed" src="https://user-images.githubusercontent.com/46027/202780028-cf36016e-f689-430d-9817-5eeffe6a5b60.png" width="300" />
      </td>
    </tr>
  </tbody>
</table>


status: ready
