### PR TITLE
chore: update nix config to reference babel.config.js file

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,8 +1,0 @@
-{
-  "presets": [
-    "module:metro-react-native-babel-preset"
-  ],
-  "plugins": [
-    "react-native-reanimated/plugin"
-  ]
-}

--- a/Makefile
+++ b/Makefile
@@ -322,8 +322,8 @@ run-visual-test-ios: ##@test Run tests once in NodeJS
 	detox test --configuration ios.sim.debug 
 
 component-test-watch: export TARGET := clojure
-component-test: export COMPONENT_TEST := true
-component-test: export BABEL_ENV := test
+component-test-watch: export COMPONENT_TEST := true
+component-test-watch: export BABEL_ENV := test
 component-test-watch: ##@ Watch tests and re-run no changes to cljs files
 	yarn install
 	nodemon --exec 'yarn shadow-cljs compile component-test && jest --config=test/jest/jest.config.js' -e cljs

--- a/nix/mobile/android/release.nix
+++ b/nix/mobile/android/release.nix
@@ -45,7 +45,7 @@ in stdenv.mkDerivation rec {
     filter = lib.mkFilter {
       root = path;
       include = [
-        "package.json" "yarn.lock" "metro.config.js" ".babelrc"
+        "package.json" "yarn.lock" "metro.config.js" "babel.config.js"
         "resources/.*" "translations/.*" "src/js/worklet_factory.js"
         "modules/react-native-status/android.*" "android/.*"
         envFileName "VERSION" "status-go-version.json" "react-native.config.js"


### PR DESCRIPTION
Fixes https://github.com/status-im/status-mobile/issues/14433

We want keep babel.rc file deleted and now use babel.config.js which needed an updated reference in the nix config files.