### PR TITLE
Mark CTA notifications as read

### DIFF
--- a/src/status_im/ui/screens/activity_center/notification/contact_request/view.cljs
+++ b/src/status_im/ui/screens/activity_center/notification/contact_request/view.cljs
@@ -51,9 +51,13 @@
                     {:button-1 {:label               (i18n/label :t/decline)
                                 :accessibility-label :decline-contact-request
                                 :type                :danger
-                                :on-press            #(rf/dispatch [:contact-requests.ui/decline-request id])}
+                                :on-press            (fn []
+                                                       (rf/dispatch [:contact-requests.ui/decline-request id])
+                                                       (rf/dispatch [:activity-center.notifications/mark-as-read id]))}
                      :button-2 {:label               (i18n/label :t/accept)
                                 :accessibility-label :accept-contact-request
                                 :type                :positive
-                                :on-press            #(rf/dispatch [:contact-requests.ui/accept-request id])}}
+                                :on-press            (fn []
+                                                       (rf/dispatch [:contact-requests.ui/accept-request id])
+                                                       (rf/dispatch [:activity-center.notifications/mark-as-read id]))}}
                     nil))])))

--- a/src/status_im/ui/screens/activity_center/notification/contact_verification/view.cljs
+++ b/src/status_im/ui/screens/activity_center/notification/contact_verification/view.cljs
@@ -85,21 +85,29 @@
                       {:button-1 {:label               (i18n/label :t/untrustworthy)
                                   :accessibility-label :mark-contact-verification-as-untrustworthy
                                   :type                :danger
-                                  :on-press            #(rf/dispatch [:activity-center.contact-verification/mark-as-untrustworthy id])}
+                                  :on-press            (fn []
+                                                         (rf/dispatch [:activity-center.contact-verification/mark-as-untrustworthy id])
+                                                         (rf/dispatch [:activity-center.notifications/mark-as-read id]))}
                        :button-2 {:label               (i18n/label :t/accept)
                                   :accessibility-label :mark-contact-verification-as-trusted
                                   :type                :positive
-                                  :on-press            #(rf/dispatch [:activity-center.contact-verification/mark-as-trusted id])}})
+                                  :on-press            (fn []
+                                                         (rf/dispatch [:activity-center.contact-verification/mark-as-trusted id])
+                                                         (rf/dispatch [:activity-center.notifications/mark-as-read id]))}})
                     (when (= contact-verification-status constants/contact-verification-status-pending)
                       {:button-1 {:label               (i18n/label :t/decline)
                                   :accessibility-label :decline-contact-verification
                                   :type                :danger
-                                  :on-press            #(hide-bottom-sheet-and-dispatch [:activity-center.contact-verification/decline id])}
+                                  :on-press            (fn []
+                                                         (hide-bottom-sheet-and-dispatch [:activity-center.contact-verification/decline id])
+                                                         (rf/dispatch [:activity-center.notifications/mark-as-read id]))}
                        :button-2 (if replying?
                                    {:label               (i18n/label :t/send-reply)
                                     :accessibility-label :reply-to-contact-verification
                                     :type                :primary
-                                    :on-press            #(hide-bottom-sheet-and-dispatch [:activity-center.contact-verification/reply id @reply])}
+                                    :on-press            (fn []
+                                                           (hide-bottom-sheet-and-dispatch [:activity-center.contact-verification/reply id @reply])
+                                                           (rf/dispatch [:activity-center.notifications/mark-as-read id]))}
                                    {:label               (i18n/label :t/message-reply)
                                     :accessibility-label :send-reply-to-contact-verification
                                     :type                :primary

--- a/src/status_im/ui/screens/home/views.cljs
+++ b/src/status_im/ui/screens/home/views.cljs
@@ -256,11 +256,11 @@
                           :width 32
                           :style {:margin-left 12}
                           :accessibility-label :notifications-button
-                          :on-press #(do
-                                       (re-frame/dispatch [:mark-all-activity-center-notifications-as-read])
-                                       (if config/new-activity-center-enabled?
-                                         (re-frame/dispatch [:activity-center/open])
-                                         (re-frame/dispatch [:navigate-to :notifications-center])))}
+                          :on-press #(do (if config/new-activity-center-enabled?
+                                           (re-frame/dispatch [:activity-center/open])
+                                           (do
+                                             (re-frame/dispatch [:mark-all-activity-center-notifications-as-read])
+                                             (re-frame/dispatch [:navigate-to :notifications-center]))))}
       [icons/icon :main-icons/notification2 {:color (quo2.colors/theme-colors quo2.colors/neutral-100 quo2.colors/white)}]]
      (when (pos? notif-count)
        [react/view {:style (merge (styles/counter-public-container) {:top 5 :right 5})

--- a/src/status_im2/common/home/view.cljs
+++ b/src/status_im2/common/home/view.cljs
@@ -9,10 +9,10 @@
             [utils.re-frame :as rf]))
 
 (defn navigate-to-activity-center []
-  (rf/dispatch [:mark-all-activity-center-notifications-as-read])
   (if config/new-activity-center-enabled?
     (rf/dispatch [:activity-center/open])
-    (rf/dispatch [:navigate-to :notifications-center])))
+    (do (rf/dispatch [:mark-all-activity-center-notifications-as-read])
+        (rf/dispatch [:navigate-to :notifications-center]))))
 
 (defn title-column [{:keys [label handler accessibility-label]}]
   [rn/view style/title-column

--- a/src/status_im2/contexts/chat/home/contact_request/view.cljs
+++ b/src/status_im2/contexts/chat/home/contact_request/view.cljs
@@ -1,5 +1,6 @@
 (ns status-im2.contexts.chat.home.contact-request.view
   (:require [react-native.core :as rn]
+            [status-im2.setup.config :as config]
             [quo2.core :as quo]
             [i18n.i18n :as i18n]
             [utils.re-frame :as rf]
@@ -58,7 +59,8 @@
     :on-press       #(do
                        (rf/dispatch [:bottom-sheet/show-sheet
                                      {:content (fn [] [contact-requests-sheet requests])}])
-                       (rf/dispatch [:mark-all-activity-center-notifications-as-read]))
+                       (when-not config/new-activity-center-enabled?
+                         (rf/dispatch [:mark-all-activity-center-notifications-as-read])))
     :style          style/contact-requests}
    [rn/view {:style (style/contact-requests-icon)}
     [quo/icon :i/pending-user {:color (colors/theme-colors colors/neutral-50 colors/neutral-40)}]]


### PR DESCRIPTION
Partially implements https://github.com/status-im/status-mobile/issues/14415

### Summary

This PR implements the new app behavior to mark notifications with CTA (call to action) in the Activity Center as `read`. CTA notifications are only ever marked as read if the user first interacts with them, therefore, leaving/entering the Activity Center has no side-effect.

[untitled.webm](https://user-images.githubusercontent.com/46027/203836793-4d92d379-e40c-4eb0-8a0c-2cdeb9b6a3c7.webm)

### Out of scope

- Changing the structure of the files according to new guidelines.
- Marking non-CTA notifications as `read` is more complex according to new UX and will be left for another PR.
- Sorting unread notifications at the top requires changes in status-go as well, so it is also going to be implemented in a separate PR.

status: ready
