### PR TITLE
[Feature][#14352] Added mentions in Activity Center

### DIFF
--- a/src/quo2/core.cljs
+++ b/src/quo2/core.cljs
@@ -58,6 +58,7 @@
 (def tags quo2.components.tags.tags/tags)
 (def user-avatar-tag quo2.components.tags.context-tags/user-avatar-tag)
 (def context-tag quo2.components.tags.context-tags/context-tag)
+(def group-avatar-tag quo2.components.tags.context-tags/group-avatar-tag)
 (def tabs quo2.components.tabs.tabs/tabs)
 (def scrollable-tabs quo2.components.tabs.tabs/scrollable-tabs)
 (def account-selector quo2.components.tabs.account-selector/account-selector)

--- a/src/status_im/ui/screens/activity_center/notification/common/style.cljs
+++ b/src/status_im/ui/screens/activity_center/notification/common/style.cljs
@@ -1,0 +1,8 @@
+(ns status-im.ui.screens.activity-center.notification.common.style
+  (:require [quo2.foundations.colors :as colors]))
+
+(def user-avatar-tag
+  {:background-color colors/white-opa-10})
+
+(def user-avatar-tag-text
+  {:color colors/white})

--- a/src/status_im/ui/screens/activity_center/notification/common/view.cljs
+++ b/src/status_im/ui/screens/activity_center/notification/common/view.cljs
@@ -1,0 +1,17 @@
+(ns status-im.ui.screens.activity-center.notification.common.view
+  (:require [utils.re-frame :as rf]
+            [quo2.core :as quo2]
+            [status-im.multiaccounts.core :as multiaccounts]
+            [status-im.ui.screens.activity-center.notification.common.style :as style]
+            [status-im.ui.screens.activity-center.utils :as activity-center.utils]))
+
+(defn user-avatar-tag [user]
+  (let [contact (rf/sub [:contacts/contact-by-identity user])]
+    [quo2/user-avatar-tag
+     {:color          :purple
+      :override-theme :dark
+      :size           :small
+      :style          style/user-avatar-tag
+      :text-style     style/user-avatar-tag-text}
+     (activity-center.utils/contact-name contact)
+     (multiaccounts/displayed-photo contact)]))

--- a/src/status_im/ui/screens/activity_center/notification/mentions/style.cljs
+++ b/src/status_im/ui/screens/activity_center/notification/mentions/style.cljs
@@ -1,0 +1,14 @@
+(ns status-im.ui.screens.activity-center.notification.mentions.style
+  (:require [quo2.foundations.colors :as colors]))
+
+(def tag
+  {:background-color colors/white-opa-10})
+
+(def tag-text
+  {:color colors/white})
+
+(def mention-text
+  {:color              colors/white
+   :border-radius      6
+   :padding-horizontal 3
+   :background-color   colors/white-opa-10})

--- a/src/status_im/ui/screens/activity_center/notification/mentions/view.cljs
+++ b/src/status_im/ui/screens/activity_center/notification/mentions/view.cljs
@@ -11,7 +11,7 @@
             [clojure.string :as str]))
 
 (defn message-body [message]
-  (let [parsed-text (get-in message [:content :parsed-text])
+  (let [parsed-text          (get-in message [:content :parsed-text])
         parsed-text-children (:children (first parsed-text))]
     [quo2/text {:number-of-lines     2
                 :style               style/tag-text

--- a/src/status_im/ui/screens/activity_center/notification/mentions/view.cljs
+++ b/src/status_im/ui/screens/activity_center/notification/mentions/view.cljs
@@ -1,0 +1,55 @@
+(ns status-im.ui.screens.activity-center.notification.mentions.view
+  (:require [quo.components.animated.pressable :as animation]
+            [quo2.core :as quo2]
+            [quo2.components.markdown.text :as text]
+            [quo2.foundations.colors :as colors]
+            [status-im.i18n.i18n :as i18n]
+            [status-im.multiaccounts.core :as multiaccounts]
+            [status-im.ui.screens.activity-center.notification.mentions.style :as style]
+            [status-im.ui.screens.activity-center.utils :as activity-center.utils]
+            [status-im.utils.datetime :as datetime]
+            [utils.re-frame :as rf]
+            [clojure.string :as str]))
+
+(defn message-body [message]
+  (let [parsed-text (get-in message [:content :parsed-text])
+        parsed-text-children (:children (first parsed-text))]
+    [text/text {:number-of-lines     2
+                :style               style/tag-text
+                :accessibility-label :activity-message-body
+                :size                :paragraph-1}
+     (for [{:keys [type literal]} parsed-text-children]
+       (case type
+         "mention" [text/text {:style style/mention-text
+                               :size  :paragraph-1}
+                    (str "@" (rf/sub [:contacts/contact-name-by-identity literal]))]
+         literal))]))
+
+(defn view
+  [{:keys [author chat-name chat-id message] :as notification}]
+  (let [contact (rf/sub [:contacts/contact-by-identity author])]
+    [animation/pressable
+     {:on-press (fn []
+                  (rf/dispatch [:hide-popover])
+                  (rf/dispatch [:chat.ui/navigate-to-chat chat-id]))}
+     [quo2/activity-log
+      {:title     (i18n/label :t/mention)
+       :icon      :main-icons2/mention
+       :timestamp (datetime/timestamp->relative (:timestamp notification))
+       :unread?   (not (:read notification))
+       :context   [[quo2/user-avatar-tag
+                    {:color          :purple
+                     :override-theme :dark
+                     :size           :small
+                     :style          style/tag
+                     :text-style     style/tag-text}
+                    (activity-center.utils/contact-name contact)
+                    (multiaccounts/displayed-photo contact)]
+                   [quo2/text {:style style/tag-text} (str/lower-case (i18n/label :t/on))]
+                  ;;  TODO: The `group-avatar-tag` component does NOT support displaying channel name along with community/chat name. Need to update the component to support it. 
+                   [quo2/group-avatar-tag chat-name {:size           :small
+                                                     :override-theme :dark
+                                                     :color          colors/primary-50
+                                                     :style          style/tag
+                                                     :text-style     style/tag-text}]]
+       :message    {:body (message-body message)}}]]))

--- a/src/status_im/ui/screens/activity_center/notification/mentions/view.cljs
+++ b/src/status_im/ui/screens/activity_center/notification/mentions/view.cljs
@@ -1,7 +1,6 @@
 (ns status-im.ui.screens.activity-center.notification.mentions.view
   (:require [quo.components.animated.pressable :as animation]
             [quo2.core :as quo2]
-            [quo2.components.markdown.text :as text]
             [quo2.foundations.colors :as colors]
             [status-im.i18n.i18n :as i18n]
             [status-im.multiaccounts.core :as multiaccounts]
@@ -14,13 +13,13 @@
 (defn message-body [message]
   (let [parsed-text (get-in message [:content :parsed-text])
         parsed-text-children (:children (first parsed-text))]
-    [text/text {:number-of-lines     2
+    [quo2/text {:number-of-lines     2
                 :style               style/tag-text
                 :accessibility-label :activity-message-body
                 :size                :paragraph-1}
      (for [{:keys [type literal]} parsed-text-children]
        (case type
-         "mention" [text/text {:style style/mention-text
+         "mention" [quo2/text {:style style/mention-text
                                :size  :paragraph-1}
                     (str "@" (rf/sub [:contacts/contact-name-by-identity literal]))]
          literal))]))
@@ -34,7 +33,7 @@
                   (rf/dispatch [:chat.ui/navigate-to-chat chat-id]))}
      [quo2/activity-log
       {:title     (i18n/label :t/mention)
-       :icon      :main-icons2/mention
+       :icon      :i/mention
        :timestamp (datetime/timestamp->relative (:timestamp notification))
        :unread?   (not (:read notification))
        :context   [[quo2/user-avatar-tag

--- a/src/status_im/ui/screens/activity_center/notification/mentions/view.cljs
+++ b/src/status_im/ui/screens/activity_center/notification/mentions/view.cljs
@@ -3,9 +3,8 @@
             [quo2.core :as quo2]
             [quo2.foundations.colors :as colors]
             [status-im.i18n.i18n :as i18n]
-            [status-im.multiaccounts.core :as multiaccounts]
+            [status-im.ui.screens.activity-center.notification.common.view :as common]
             [status-im.ui.screens.activity-center.notification.mentions.style :as style]
-            [status-im.ui.screens.activity-center.utils :as activity-center.utils]
             [status-im.utils.datetime :as datetime]
             [utils.re-frame :as rf]
             [clojure.string :as str]))
@@ -13,42 +12,37 @@
 (defn message-body [message]
   (let [parsed-text          (get-in message [:content :parsed-text])
         parsed-text-children (:children (first parsed-text))]
-    [quo2/text {:number-of-lines     2
-                :style               style/tag-text
-                :accessibility-label :activity-message-body
-                :size                :paragraph-1}
-     (for [{:keys [type literal]} parsed-text-children]
-       (case type
-         "mention" [quo2/text {:style style/mention-text
-                               :size  :paragraph-1}
-                    (str "@" (rf/sub [:contacts/contact-name-by-identity literal]))]
-         literal))]))
+    (into [quo2/text {:number-of-lines     2
+                      :style               style/tag-text
+                      :accessibility-label :activity-message-body
+                      :size                :paragraph-1}]
+          (map-indexed (fn [index {:keys [type literal]}]
+                         ^{:key index}
+                         (case type
+                           "mention" [quo2/text  {:style style/mention-text
+                                                  :size  :paragraph-1}
+                                      (str "@" (rf/sub [:contacts/contact-name-by-identity literal]))]
+                           literal)) parsed-text-children))))
 
 (defn view
   [{:keys [author chat-name chat-id message] :as notification}]
-  (let [contact (rf/sub [:contacts/contact-by-identity author])]
-    [animation/pressable
-     {:on-press (fn []
-                  (rf/dispatch [:hide-popover])
-                  (rf/dispatch [:chat.ui/navigate-to-chat chat-id]))}
-     [quo2/activity-log
-      {:title     (i18n/label :t/mention)
-       :icon      :i/mention
-       :timestamp (datetime/timestamp->relative (:timestamp notification))
-       :unread?   (not (:read notification))
-       :context   [[quo2/user-avatar-tag
-                    {:color          :purple
-                     :override-theme :dark
-                     :size           :small
-                     :style          style/tag
-                     :text-style     style/tag-text}
-                    (activity-center.utils/contact-name contact)
-                    (multiaccounts/displayed-photo contact)]
-                   [quo2/text {:style style/tag-text} (str/lower-case (i18n/label :t/on))]
-                  ;;  TODO: The `group-avatar-tag` component does NOT support displaying channel name along with community/chat name. Need to update the component to support it. 
-                   [quo2/group-avatar-tag chat-name {:size           :small
-                                                     :override-theme :dark
-                                                     :color          colors/primary-50
-                                                     :style          style/tag
-                                                     :text-style     style/tag-text}]]
-       :message    {:body (message-body message)}}]]))
+  [animation/pressable
+   {:on-press (fn []
+                (rf/dispatch [:hide-popover])
+                (rf/dispatch [:chat.ui/navigate-to-chat chat-id]))}
+   [quo2/activity-log
+    {:title     (i18n/label :t/mention)
+     :icon      :i/mention
+     :timestamp (datetime/timestamp->relative (:timestamp notification))
+     :unread?   (not (:read notification))
+     :context   [[common/user-avatar-tag author]
+                 [quo2/text {:style style/tag-text} (str/lower-case (i18n/label :t/on))]
+                   ;; TODO (@smohamedjavid): The `group-avatar-tag` component 
+                   ;; does NOT support displaying channel name along with community/chat name.
+                   ;; Need to update the component to support it. 
+                 [quo2/group-avatar-tag chat-name {:size           :small
+                                                   :override-theme :dark
+                                                   :color          colors/primary-50
+                                                   :style          style/tag
+                                                   :text-style     style/tag-text}]]
+     :message    {:body (message-body message)}}]])

--- a/src/status_im/ui/screens/activity_center/views.cljs
+++ b/src/status_im/ui/screens/activity_center/views.cljs
@@ -8,6 +8,7 @@
             [status-im.i18n.i18n :as i18n]
             [status-im.ui.screens.activity-center.notification.contact-request.view :as contact-request]
             [status-im.ui.screens.activity-center.notification.contact-verification.view :as contact-verification]
+            [status-im.ui.screens.activity-center.notification.mentions.view :as mentions]
             [status-im.ui.screens.activity-center.style :as style]
             [utils.re-frame :as rf]))
 
@@ -111,6 +112,9 @@
 
      types/contact-request
      [contact-request/view notification]
+
+     types/mention
+     [mentions/view notification]
 
      nil)])
 

--- a/src/status_im/ui/screens/activity_center/views.cljs
+++ b/src/status_im/ui/screens/activity_center/views.cljs
@@ -128,8 +128,9 @@
        (react/effect! #(rf/dispatch [:activity-center.notifications/fetch-first-page]))
        [rn/view {:style (style/screen-container window-width top bottom)}
         [header]
-        [rn/flat-list {:data            notifications
-                       :empty-component [empty-tab]
-                       :key-fn          :id
-                       :on-end-reached  #(rf/dispatch [:activity-center.notifications/fetch-next-page])
-                       :render-fn       render-notification}]]))])
+        [rn/flat-list {:data                      notifications
+                       :empty-component           [empty-tab]
+                       :key-fn                    :id
+                       :on-scroll-to-index-failed identity
+                       :on-end-reached            #(rf/dispatch [:activity-center.notifications/fetch-next-page])
+                       :render-fn                 render-notification}]]))])

--- a/translations/en.json
+++ b/translations/en.json
@@ -1827,6 +1827,7 @@
     "share-image": "Share image",
     "see-sticker-set": "See the full sticker set",
     "mentions": "Mentions",
+    "mention": "Mention",
     "admin": "Admin",
     "replies": "Replies",
     "replied": "Replied",


### PR DESCRIPTION
Fixes #14352

### Summary

Implement Mentions in Activity Center 

<img width="359" alt="Mentions" src="https://user-images.githubusercontent.com/19339952/204331996-bc48de1d-55e9-4005-bbbc-ca942944c3f1.png">



**Design** 

([Figma Link](https://www.figma.com/file/eDfxTa9IoaCMUy5cLTp0ys/Shell-for-Mobile?node-id=639%3A21926))

#### Areas impacted

- Activity Center (Notifications Center)

**Platforms**

- Android
- iOS

**Platforms**

- 1-1 Chats
- Public Chats
- Group Chats

status: ready