### PR TITLE
Introduce subscription tests

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -10,6 +10,8 @@
            status-im.test-helpers/deftest-sub clojure.core/defn
            taoensso.tufte/defnp               clojure.core/defn}
  :linters {:invalid-arity     {:skip-args [status-im.utils.fx/defn utils.re-frame/defn]}
-           ;;TODO remove number when this is fixed
-           ;;https://github.com/borkdude/clj-kondo/issues/867
-           :unresolved-symbol {:exclude [PersistentPriorityMap.EMPTY number]}}}
+           ;; TODO remove number when this is fixed
+           ;; https://github.com/borkdude/clj-kondo/issues/867
+           :unresolved-symbol {:exclude [PersistentPriorityMap.EMPTY
+                                         number
+                                         status-im.test-helpers/restore-app-db]}}}

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,13 +1,14 @@
-{:lint-as {status-im.utils.views/defview  clojure.core/defn
-           status-im.utils.views/letsubs  clojure.core/let
-           reagent.core/with-let          clojure.core/let
-           status-im.utils.fx/defn        clj-kondo.lint-as/def-catch-all
-           utils.re-frame/defn            clj-kondo.lint-as/def-catch-all
-           quo.react/with-deps-check      clojure.core/fn
-           quo.previews.preview/list-comp clojure.core/for
-           status-im.utils.styles/def     clojure.core/def
-           status-im.utils.styles/defn    clojure.core/defn
-           taoensso.tufte/defnp           clojure.core/defn}
+{:lint-as {status-im.utils.views/defview      clojure.core/defn
+           status-im.utils.views/letsubs      clojure.core/let
+           reagent.core/with-let              clojure.core/let
+           status-im.utils.fx/defn            clj-kondo.lint-as/def-catch-all
+           utils.re-frame/defn                clj-kondo.lint-as/def-catch-all
+           quo.react/with-deps-check          clojure.core/fn
+           quo.previews.preview/list-comp     clojure.core/for
+           status-im.utils.styles/def         clojure.core/def
+           status-im.utils.styles/defn        clojure.core/defn
+           status-im.test-helpers/deftest-sub clojure.core/defn
+           taoensso.tufte/defnp               clojure.core/defn}
  :linters {:invalid-arity     {:skip-args [status-im.utils.fx/defn utils.re-frame/defn]}
            ;;TODO remove number when this is fixed
            ;;https://github.com/borkdude/clj-kondo/issues/867

--- a/doc/new-guidelines.md
+++ b/doc/new-guidelines.md
@@ -346,6 +346,53 @@ keywords and concatenating them into a single string.
 (i18n/label :t/biometric-auth-error {:code error-code})
 ```
 
+### Tests
+#### Subscription tests
+
+Test [layer-3 subscriptions](https://day8.github.io/re-frame/subscriptions/) by
+actually subscribing to them, so reframe's signal graph gets validated too.
+
+```clojure
+;; bad
+(defn user-recipes
+  [[current-user all-recipes location]]
+  ...)
+
+(re-frame/reg-sub
+ :user/recipes
+ :<- [:current-user]
+ :<- [:all-recipes]
+ :<- [:location]
+ user-recipes)
+
+(deftest user-recipes-test
+  (testing "builds list of recipes"
+    (let [current-user {...}
+          all-recipes  {...}
+          location     [...]]
+      (is (= expected (recipes [current-user all-recipes location]))))))
+
+;; good
+(require '[status-im.test-helpers :as h])
+
+(re-frame/reg-sub
+ :user/recipes
+ :<- [:current-user]
+ :<- [:all-recipes]
+ :<- [:location]
+ (fn [[current-user all-recipes location]]
+   ...))
+
+(h/deftest-sub :user/recipes
+  [sub-name]
+  (testing "builds list of recipes"
+    (swap! rf-db/app-db assoc
+           :current-user {...}
+           :all-recipes {...}
+           :location [...])
+    (is (= expected (rf/sub [sub-name])))))
+```
+
 ## Project Structure
 
 First, the bird's-eye view with some example ClojureScript files:

--- a/src/status_im/test_helpers.clj
+++ b/src/status_im/test_helpers.clj
@@ -1,0 +1,67 @@
+(ns status-im.test-helpers
+  (:require [clojure.spec.alpha :as s]
+            [clojure.string :as string]
+            [clojure.walk :as walk]))
+
+(defn- subscription-name->test-name
+  [sub-name]
+  (->> [(namespace sub-name)
+        (name sub-name)
+        "test"]
+       (remove nil?)
+       (map #(string/replace % #"\." "-"))
+       (string/join "-")))
+
+(defmacro ^:private restore-app-db
+  "Saves app db, executes `body` and restores to original app-db.
+
+  Also clears the subscription cache for good measure."
+  [& body]
+  `(do (re-frame.subs/clear-subscription-cache!)
+       (let [original-db# (deref re-frame.db/app-db)]
+         (try
+           ~@body
+           (finally
+             (reset! re-frame.db/app-db original-db#))))))
+
+(defmacro ^:private testing-subscription
+  [description & body]
+  `(cljs.test/testing ~description
+     (restore-app-db ~@body)))
+
+(s/fdef deftest-sub
+  :args (s/cat :sub-name keyword?
+               :args (s/coll-of symbol? :count 1)
+               :body (s/* any?)))
+(defmacro deftest-sub
+  "Defines a test based on `sub-name`, executes `body` and restores the app db.
+
+  Any usage of the `cljs.test/testing` macro inside `body` will be modified to
+  also make sure the app db is restored and the subscription cache is reset.
+
+  Expressions in `body` will have access to `sub-name`, which should be used to
+  avoid needlessly repeating the subscription name.
+
+  Example:
+
+  ```clojure
+  (require '[status-im.test-helpers :as h])
+
+  (h/deftest-sub :wallet/sorted-tokens
+    [sub-name]
+    (testing \"sorts tokens by name, lowercased\"
+      ;; Arrange
+      (swap! rf-db/app-db assoc-in [<db-path>] <value>)
+
+      ;; Act and Assert
+      (is (= <expected> (rf/sub [sub-name])))))
+  ```"
+  [sub-name args & body]
+  `(let [sub-name# ~sub-name]
+     (cljs.test/deftest ~(symbol (subscription-name->test-name sub-name))
+       (restore-app-db
+        (let [~args [sub-name#]]
+          ~@(clojure.walk/postwalk-replace
+             {'cljs.test/testing `testing-subscription
+              'testing           `testing-subscription}
+             body))))))

--- a/src/status_im/test_helpers.clj
+++ b/src/status_im/test_helpers.clj
@@ -33,6 +33,7 @@
   :args (s/cat :sub-name keyword?
                :args (s/coll-of symbol? :count 1)
                :body (s/* any?)))
+
 (defmacro deftest-sub
   "Defines a test based on `sub-name`, executes `body` and restores the app db.
 

--- a/src/status_im/test_helpers.cljs
+++ b/src/status_im/test_helpers.cljs
@@ -10,6 +10,7 @@
             [re-frame.db :as rf-db]
             [re-frame.events :as rf-events]
             [re-frame.registrar :as rf-registrar]
+            [re-frame.subs :as rf-subs]
             [taoensso.timbre :as log]))
 
 (defn db
@@ -101,3 +102,15 @@
                                       :fn       (fn [{:keys [vargs level]}]
                                                   (swap! logs conj {:args vargs :level level}))})]
       (f logs))))
+
+(defn restore-app-db
+  "Saves current app DB, calls `f` and restores the original app DB.
+
+  Always clears the subscription cache after calling `f`."
+  [f]
+  (rf-subs/clear-subscription-cache!)
+  (let [original-db @rf-db/app-db]
+    (try
+      (f)
+      (finally
+        (reset! rf-db/app-db original-db)))))

--- a/src/status_im/test_helpers.cljs
+++ b/src/status_im/test_helpers.cljs
@@ -5,6 +5,7 @@
   Avoid coupling this namespace with particularities of the Status' domain, thus
   prefer to use it for more general purpose concepts, such as the re-frame event
   layer."
+  (:require-macros status-im.test-helpers)
   (:require [re-frame.core :as rf]
             [re-frame.db :as rf-db]
             [re-frame.events :as rf-events]

--- a/src/status_im2/subs/activity_center_test.cljs
+++ b/src/status_im2/subs/activity_center_test.cljs
@@ -1,0 +1,16 @@
+(ns status-im2.subs.activity-center-test
+  (:require [cljs.test :refer [is testing]]
+            [re-frame.db :as rf-db]
+            [status-im.test-helpers :as h]
+            status-im2.subs.activity-center
+            [utils.re-frame :as rf]))
+
+(h/deftest-sub :activity-center/filter-status-unread-enabled?
+  [sub-name]
+  (testing "returns true when filter status is unread"
+    (swap! rf-db/app-db assoc-in [:activity-center :filter :status] :unread)
+    (is (true? (rf/sub [sub-name]))))
+
+  (testing "returns false when filter status is not unread"
+    (swap! rf-db/app-db assoc-in [:activity-center :filter :status] :all)
+    (is (false? (rf/sub [sub-name])))))

--- a/src/status_im2/subs/subs_test.cljs
+++ b/src/status_im2/subs/subs_test.cljs
@@ -1,9 +1,7 @@
 (ns status-im2.subs.subs-test
   (:require [cljs.test :refer [deftest is testing]]
             [status-im2.subs.wallet.transactions :as wallet.transactions]
-            [status-im2.subs.onboarding :as onboarding]
-            [status-im.utils.money :as money]
-            [status-im2.subs.wallet.wallet :as wallet]))
+            [status-im2.subs.onboarding :as onboarding]))
 
 (def transactions [{:timestamp "1505912551000"}
                    {:timestamp "1505764322000"}
@@ -40,17 +38,3 @@
                 {"0x1" {:keycard-pairing "keycard-pairing-code"}}}
                {})]
       (is (= res "keycard-pairing-code")))))
-
-(deftest test-balance-total-value
-  (is (= (wallet/get-balance-total-value
-          {:ETH (money/bignumber 1000000000000000000)
-           :SNT (money/bignumber 100000000000000000000)
-           :AST (money/bignumber 10000)}
-          {:ETH {:USD {:from "ETH", :to "USD", :price 677.91, :last-day 658.688}}
-           :SNT {:USD {:from "SNT", :to "USD", :price 0.1562, :last-day 0.15}}
-           :AST {:USD {:from "AST", :to "USD", :price 4,      :last-day 3}}}
-          :USD
-          {:ETH 18
-           :SNT 18
-           :AST 4})
-         697.53)))

--- a/src/status_im2/subs/wallet/wallet_test.cljs
+++ b/src/status_im2/subs/wallet/wallet_test.cljs
@@ -1,0 +1,133 @@
+(ns status-im2.subs.wallet.wallet-test
+  (:require [cljs.test :refer [deftest is testing]]
+            [re-frame.db :as rf-db]
+            [status-im.test-helpers :as h]
+            [status-im.utils.money :as money]
+            [status-im2.subs.wallet.wallet :as wallet]
+            [utils.re-frame :as rf]))
+
+(def money-zero (money/bignumber 0))
+(def money-eth (money/bignumber 8000000000000000000))
+(def money-snt (money/bignumber 756000000000000000000))
+(def main-account-id "0x0Fbd")
+
+(def accounts
+  [{:address    "0x0Fbd"
+    :name       "Main account"
+    :hidden     false
+    :removed    false}
+   {:address    "0x5B03"
+    :name       "Secondary account"
+    :hidden     false
+    :removed    false}])
+
+(def wallet
+  {:accounts {main-account-id
+              {:balance      {:ETH money-eth :SNT money-snt}
+               :transactions {}
+               :max-block    0}
+              "0x5B03"
+              {:balance      {:ETH money-eth :SNT money-snt}
+               :transactions {}
+               :max-block    10}}})
+
+(def prices
+  {:ETH {:USD {:from  "ETH"
+               :to    "USD"
+               :price 1282.23}}
+   :SNT {:USD {:from  "SNT"
+               :to    "USD"
+               :price 0.0232}}})
+
+(def tokens
+  {"0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+   {:address  "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+    :name     "Ether"
+    :symbol   :ETH
+    :decimals 18
+    :chainId  1}
+   "0x744d70fdbe2ba4cf95131626614a1763df805b9e"
+   {:address  "0x744d70fdbe2ba4cf95131626614a1763df805b9e"
+    :name     "Status Network Token"
+    :symbol   :SNT
+    :decimals 18
+    :chainId  1}})
+
+(h/deftest-sub :balances
+  [sub-name]
+  (swap! rf-db/app-db assoc
+         :multiaccount/accounts accounts
+         :wallet wallet)
+  (is (= [{:ETH money-eth
+           :SNT money-snt}
+          {:ETH money-eth
+           :SNT money-snt}]
+         (rf/sub [sub-name]))))
+
+(h/deftest-sub :wallet/token->decimals
+  [sub-name]
+  (swap! rf-db/app-db assoc :wallet/all-tokens tokens)
+  (is (= {:SNT 18 :ETH 18}
+         (rf/sub [sub-name]))))
+
+(deftest get-balance-total-value-test
+  (is (= 697.53
+         (wallet/get-balance-total-value
+          {:ETH (money/bignumber 1000000000000000000)
+           :SNT (money/bignumber 100000000000000000000)
+           :AST (money/bignumber 10000)}
+          {:ETH {:USD {:from "ETH" :to "USD" :price 677.91 :last-day 658.688}}
+           :SNT {:USD {:from "SNT" :to "USD" :price 0.1562 :last-day 0.15}}
+           :AST {:USD {:from "AST" :to "USD" :price 4 :last-day 3}}}
+          :USD
+          {:ETH 18
+           :SNT 18
+           :AST 4}))))
+
+(h/deftest-sub :portfolio-value
+  [sub-name]
+  (testing "returns fallback value when balances and prices are not available"
+    (is (= "..." (rf/sub [sub-name]))))
+
+  (testing "returns zero when balance is not positive"
+    (let [empty-wallet {:accounts {main-account-id
+                                   {:balance {:ETH money-zero
+                                              :SNT money-zero}}}}]
+      (swap! rf-db/app-db assoc
+             :multiaccount/accounts accounts
+             :prices prices
+             :wallet empty-wallet
+             :wallet/all-tokens tokens)
+      (is (= "0" (rf/sub [sub-name])))))
+
+  (testing "returns formatted value in the default USD currency"
+    (swap! rf-db/app-db assoc
+           :multiaccount/accounts accounts
+           :prices prices
+           :wallet wallet
+           :wallet/all-tokens tokens)
+    (is (= "20,550.76" (rf/sub [sub-name])))))
+
+(h/deftest-sub :account-portfolio-value
+  [sub-name]
+  (testing "returns fallback value when balances and prices are not available"
+    (is (= "..." (rf/sub [sub-name]))))
+
+  (testing "returns zero when balance is not positive"
+    (let [empty-wallet {:accounts {main-account-id
+                                   {:balance {:ETH money-zero
+                                              :SNT money-zero}}}}]
+      (swap! rf-db/app-db assoc
+             :multiaccount/accounts accounts
+             :prices prices
+             :wallet empty-wallet
+             :wallet/all-tokens tokens)
+      (is (= "0" (rf/sub [sub-name main-account-id])))))
+
+  (testing "returns formatted value in the default USD currency"
+    (swap! rf-db/app-db assoc
+           :multiaccount/accounts accounts
+           :prices prices
+           :wallet wallet
+           :wallet/all-tokens tokens)
+    (is (= "10,275.38" (rf/sub [sub-name main-account-id])))))


### PR DESCRIPTION
### Summary

This PR brings to every contributor's reach the capability to easily test subscriptions in a way that also make sure re-frame's *signal graph* is validated. It also adds tests to more complex subscriptions to show how well the proposed solution scales to any subscription.

There's a long rationale about why this PR is doing what it's doing, and I hope the explanations that follow can help us get on the same page.

I'm assuming not everyone is familiar with some of the concepts I mention here, and because of that I prefer to more thoroughly explain them. I'm sorry if sometimes this feels pedantic to you.

### Motivation

1. Just a handful of layer-3 subscriptions have tests, and the ones that do are incomplete.

2. The team is not aligned on how to design layer-3 subscription tests and the perils lurking in the dark mysteries of re-frame. We can see this in some PR threads.

3. **Make more layers of the architecture testable**, so that we can start to actually increase the quality of the app over time. In my opinion, at the speed the mobile codebase is growing/churning and the amount of contributors coming in, we need to aggressively improve our testing story.

Quality assurance is not just trusting end-of-the-line QA processes (e.g. manual tests, PR reviews and e2e tests) and expecting engineers to write great code (whatever that means). **Quality should be embedded in everything we do.**

Subscriptions (layer-3), events, effects and interceptors should be tested and there's nothing preventing us from doing so. They are the underlying structures that make the app work, and if we don't test them we put too much burden on the last layer (view), which is the most complicated to test.

**Why should we care?** Software engineers test so that systems can **evolve with confidence from one snapshot to another**, often in highly collaborative environments. Layer-3 subs are one piece of this puzzle.

### Main problem

What's all the fuss about testing subscription handlers? After all, they're pure functions.

If you're not yet familiar with or need a refresh on **re-frame's signal graph**, I highly recommend first reading https://day8.github.io/re-frame/subscriptions/.

According to [reframe's testing doc](https://github.com/day8/re-frame/blob/master/docs/Testing.md), only layer-3 subscriptions should be tested. I completely agree with that because testing *extractors* (layer-2) is almost pointless given their simplicity (there's no real logic). Therefore, **this PR is only concerned with layer-3 subs**.

Re-frame suggests testing subscriptions by *extracting anonymous subscription handlers to named functions*. This works, but in practice, testing like that has important limitations for subscriptions because it's easy to make tests pass, when **in reality the signal graph could be broken** :boom:

### Example problem

Here's a relatively complicated layer-3 subscription:

```clojure
(re-frame/reg-sub
 :portfolio-value
 :<- [:balances]
 :<- [:prices]
 :<- [:wallet/currency]
 :<- [:wallet/token->decimals]
 (fn [[balances prices currency token->decimals]]
   (if (and balances prices)
     (let [currency-key        (-> currency :code keyword)
           balance-total-value (apply + (map #(get-balance-total-value % prices currency-key token->decimals) balances))]
       (if (pos? balance-total-value)
         (-> balance-total-value
             (money/with-precision 2)
             str
             (i18n/format-currency (:code currency)))
         "0"))
     "...")))
```

If we follow re-frame's recommendation to test this subscription, then we should extract the anonymous function, like so.

```clojure
(defn portfolio-value
  [[balances prices currency token->decimals]]
  (if (and balances prices)
    (let [currency-key        (-> currency :code keyword)
          balance-total-value (apply + (map #(get-balance-total-value % prices currency-key token->decimals) balances))]
      (if (pos? balance-total-value)
        (-> balance-total-value
            (money/with-precision 2)
            str
            (i18n/format-currency (:code currency)))
        "0"))
    "..."))

(re-frame/reg-sub
 :portfolio-value
 :<- [:balances]
 :<- [:prices]
 :<- [:wallet/currency]
 :<- [:wallet/token->decimals]
 portfolio-value)
```

At this point, the extracted public function is testable, but notice we lose the ability to actually verify the subscription is receiving the correct *inputs*.

Let's say requirements change, and `:wallet/currency` returns a different map structure. Well then, instead of breaking, tests would still pass. Now imagine the entire system's subscriptions are tested like this. In that case, **every single change to a subscription would require manually hunting its usages and checking if tests need to be updated**, otherwise **there's no guarantee a regression in the signal graph was not introduced**. This is a lot of work many contributors won't do (including myself).

### A little bit better, but with issues

The solution I found to be the most valuable from previous experiences is to not ignore the subscription inputs, i.e. subscribe to the real subscription and let re-frame do its work.

```clojure
(deftest portfolio-value-test
  (testing "returns zero when balance is not positive"
    ;; Important in REPL sessions
    (rf-subs/clear-subscription-cache!)
    (let [original-db  @rf-db/app-db
          empty-wallet {:accounts {main-account-id
                                   {:balance {:ETH money-zero
                                              :SNT money-zero}}}}]
      ;; Arrange section
      (swap! rf-db/app-db assoc
             :multiaccount/accounts accounts
             :prices prices
             :wallet empty-wallet
             :wallet/all-tokens tokens)

      ;; Act, assert and clean-up.
      (try
        (is (= "0" (rf/sub [:portfolio-value])))
        (finally
          (reset! rf-db/app-db original-db))))))
```

So as you can see, now the problem is that the test is mixed up with boring stuff to arrange and clean-up state. You could use `cljs.test/use-fixtures`, but it has a limitation that it only works for top-level tests, not for individual `cljs.test/testing` sections, so you'd end up having to define multiple `deftest`s repeating long subscription names. Or you'd need to copy & paste setup/teardown code inside `testing` macros. No fun, and again, easy to miss and end-up with flaky tests (no no no...)

### Even better solution

Clojure gives us the power of macros to abstract all that plumbing. So here's the final solution, using `test-helpers/deftest-sub`. The actual implementation of the macro is quite interesting, see the *For the Curious* section for more details.

```clojure
(deftest-sub :portfolio-value
  [sub-name]
  (testing "returns zero when balance is not positive"
    (let [empty-wallet {:accounts {main-account-id
                                   {:balance {:ETH money-zero
                                              :SNT money-zero}}}}]
      (swap! rf-db/app-db assoc
             :multiaccount/accounts accounts
             :prices prices
             :wallet empty-wallet
             :wallet/all-tokens tokens)
      (is (= "0" (rf/sub [sub-name]))))))
```

Important things:

- The name of test is derived from the actual name of the subscription. This means if the production code renames the subscription, then tests will fail.
- It's just as fast as any other simple unit test.
- The macro works as expected with clj-kondo.
- There's zero need to worry about messing up the app DB state and affecting or being affected by other tests.
- It works just fine for REPL-Drive Development. In fact, all tests in this PR were implemented using the test REPL.
- We can use multiple and nested calls to the `testing` macro, and they'll be correctly augmented by the `deftest-sub` macro to reset the subscription cache and restore the app DB state.

### For the curious

#### The `deftest-sub` Macro

If you'd like to learn more about macros, specifically Deep Code Walking Macros (DCWM), check out this excellent blog post https://blog.fogus.me/2013/07/17/an-introduction-to-deep-code-walking-macros-with-clojure. If, on the other hand, you have no idea how macros work, the Clojure for the Brave and True book [section on macros](https://www.braveclojure.com/writing-macros/) is a very good starting point.

Now, if you try to call the `deftest-sub` macro with invalid arguments, you get a *beatiful* error generated by [expound](https://github.com/bhb/expound). This works because I've defined a `clojure.spec.alpha/fdef` for the macro. This is what Clojure core does for many macros, and it greatly improves DX.

See, I'm not suggesting using clojure.spec everywhere, but using it for macros with instrumentation enabled is definitely a win. `fdef` has zero impact in production performance with instrumentation disabled, and besides this macro is only for testing, so no impact whatsoever.

```
------ REPL Error while processing ---------------------------------------------
(deftest-sub "some-subscription-name"
  [query-id]
  (do-something))
Syntax error macroexpanding status-im.test-helpers/deftest-sub.
Call to status-im.test-helpers/deftest-sub did not conform to spec.
-- Spec failed --------------------

("some-subscription-name" ... ...)
^^^^^^^^^^^^^^^^^^^^^^^^

should satisfy

keyword?

-------------------------
Detected 1 error
```

### What about the guidelines?

This is an introductory PR to the subject of testing subscriptions, and it's my hope that PRs from now on will be able to be opened with subscription tests whenever needed. I think we can update the guidelines once more people write subscription tests and we get practical feedback.

### More references

- https://github.com/day8/re-frame/blob/master/docs/FAQs/Why-Clear-Sub-Cache.md
- https://blog.klipse.tech/clojure/2016/10/10/defn-args.html
- https://cljdoc.org/d/expectations/clojure-test/1.2.1/doc/fixtures-focused-execution

status: ready
