### PR TITLE
Set Activity Center as the new default

### DIFF
--- a/src/quo2/components/notifications/activity_log/view.cljs
+++ b/src/quo2/components/notifications/activity_log/view.cljs
@@ -64,7 +64,8 @@
                       (map (fn [s]
                              [rn/view {:style {:margin-right 4
                                                :margin-top   0}}
-                              [text/text {:size :paragraph-2}
+                              [text/text {:size  :paragraph-2
+                                          :style {:color colors/white}}
                                s]])
                            (string/split detail #"\s+"))
                       [[rn/view {:margin-right 4

--- a/src/quo2/components/tabs/tabs.cljs
+++ b/src/quo2/components/tabs/tabs.cljs
@@ -158,7 +158,7 @@
                                                                        :on-press       (fn [id]
                                                                                          (reset! active-tab-id id)
                                                                                          (when scroll-on-press?
-                                                                                           (.scrollToIndex @flat-list-ref
+                                                                                           (.scrollToIndex ^js @flat-list-ref
                                                                                                            #js {:animated     true
                                                                                                                 :index        index
                                                                                                                 :viewPosition 0.5}))

--- a/src/status_im/ui/screens/activity_center/views.cljs
+++ b/src/status_im/ui/screens/activity_center/views.cljs
@@ -82,12 +82,13 @@
   []
   (let [screen-padding 20]
     [rn/view
-     [quo2/button {:icon           true
-                   :type           :blur-bg
-                   :size           32
-                   :override-theme :dark
-                   :style          style/header-button
-                   :on-press       #(rf/dispatch [:hide-popover])}
+     [quo2/button {:icon                true
+                   :type                :blur-bg
+                   :size                32
+                   :accessibility-label :close-activity-center
+                   :override-theme      :dark
+                   :style               style/header-button
+                   :on-press            #(rf/dispatch [:hide-popover])}
       :i/close]
      [quo2/text {:size   :heading-1
                  :weight :semi-bold

--- a/src/status_im2/setup/config.cljs
+++ b/src/status_im2/setup/config.cljs
@@ -141,4 +141,4 @@
 
 ;; TODO: Remove this (highly) temporary flag once the new Activity Center is
 ;; usable enough to replace the old one **in the new UI**.
-(def new-activity-center-enabled? false)
+(def new-activity-center-enabled? true)


### PR DESCRIPTION
Partially implements https://github.com/status-im/status-mobile/issues/14490

### Summary

This tiny little PR simply enables the new Activity Center (AC) by default. A follow up PR will then remove the old Notification Center code and the flag. The goal is for the AC to be usable in the next release, so we can dogfood the redesigned mobile app.

**Types of notifications supported by the new AC as of 2022-12-06**

- Mentions
- Contact requests
- Identity verification requests (apparently will be deprecated in the MVP).

#### Why?

This PR is needed because I want to be sure the new AC won't disrupt the QA team in the first place. Also because I want the next PR (not yet created) that will remove the old Notification Center to be merged as fast as possible, in order to avoid code conflicts. Hence why enabling the flag is coming before code deletion.

#### Platforms

- Android
- iOS

### Steps to test

The most important case to test IMO is the Contact Request flow, because it's a requirement to chat with other users. To test the Activity Center, simply click on the bell icon in the home screen.

There are many issues already created mapping the work left to be done for the AC. You can check them out here https://github.com/status-im/status-mobile/labels/Activity%20center.

**Figma flows**: https://www.figma.com/file/eDfxTa9IoaCMUy5cLTp0ys/Shell-for-Mobile?node-id=451%3A18681&t=gIS1Vt4Ucc2gSrlr-0

### Note for QA review

- There's an open issue I'm working on right now #14495 

status: ready
