### PR TITLE
Communities now correctly listed in pending/joined sections.

### DIFF
--- a/src/status_im2/contexts/communities/home/view.cljs
+++ b/src/status_im2/contexts/communities/home/view.cljs
@@ -46,20 +46,25 @@
     :render-fn                         render-fn}])
 
 (defn segments-community-lists [selected-tab]
-  (let [communities (rf/sub [:communities/community-ids])
+  (let [ids-by-user-involvement (rf/sub [:communities/community-ids-by-user-involvement])
         tab @selected-tab]
     [rn/view {:style {:padding-left     20
                       :padding-right    8
                       :padding-vertical 12}}
      (case tab
        :joined
-       [communities-list communities]
+       [communities-list (:joined ids-by-user-involvement)]
 
        :pending
-       [communities-list communities]
+       [communities-list (:pending ids-by-user-involvement)]
 
        :opened
-       [communities-list communities])]))
+       [communities-list (:opened ids-by-user-involvement)]
+
+       [quo/information-box
+        {:type :error
+         :icon :i/info}
+        (i18n/label :t/error)])]))
 
 (defn home []
   (let [selected-tab (reagent/atom :joined)]

--- a/src/status_im2/contexts/communities/overview/style.cljs
+++ b/src/status_im2/contexts/communities/overview/style.cljs
@@ -1,17 +1,20 @@
 (ns status-im2.contexts.communities.overview.style
-  (:require [react-native.platform :as platform]
-            [quo2.foundations.colors :as colors]))
+  (:require [react-native.platform :as platform]))
 
 (def preview-user
   {:flex-direction :row
    :align-items    :center
    :margin-top     20})
 
-(def blur-channel-header {:blur-amount 32
-                          :blur-type :xlight
-                          :overlay-color (if platform/ios? colors/white-opa-70 :transparent)
-                          :style {:position :absolute
-                                  :top (if platform/ios? 56 60)
-                                  :height 34
-                                  :width "100%"
-                                  :flex 1}})
+(def blur-channel-header
+  {:position :absolute
+   :top (if platform/ios? 56 60)
+   :height 34
+   :width "100%"
+   :flex 1})
+
+(def join-button
+  {:width "100%"
+   :margin-top 20
+   :margin-left :auto
+   :margin-right :auto})

--- a/src/status_im2/contexts/communities/overview/view.cljs
+++ b/src/status_im2/contexts/communities/overview/view.cljs
@@ -44,38 +44,38 @@
   #(rf/dispatch
     [:bottom-sheet/show-sheet
      {:content
-      (constantly [quo/token-gating
-                   {:channel {:name name
-                              :community-color (colors/custom-color :pink 50)
-                              :emoji emoji
-                              :emoji-background-color channel-color
-                              :on-enter-channel (fn [] (utils/show-popup "Entered channel" "Wuhuu!! You successfully entered the channel :)"))
-                              :gates {:read [{:token "KNC"
-                                              :token-img-src knc-token-img
-                                              :amount 200
-                                              :is-sufficient? true}
-                                             {:token "MANA"
-                                              :token-img-src mana-token-img
-                                              :amount 10
-                                              :is-sufficient? false
-                                              :is-purchasable true}
-                                             {:token "RARE"
-                                              :token-img-src rare-token-img
-                                              :amount 10
-                                              :is-sufficient? false}]
-                                      :write [{:token "KNC"
-                                               :token-img-src knc-token-img
-                                               :amount 200
-                                               :is-sufficient? true}
-                                              {:token "DAI"
-                                               :token-img-src dai-token-img
-                                               :amount 20
-                                               :is-purchasable true
-                                               :is-sufficient? false}
-                                              {:token "ETH"
-                                               :token-img-src eth-token-img
-                                               :amount 0.5
-                                               :is-sufficient? false}]}}}])
+      (fn [] [quo/token-gating
+              {:channel {:name name
+                         :community-color (colors/custom-color :pink 50)
+                         :emoji emoji
+                         :emoji-background-color channel-color
+                         :on-enter-channel (fn [] (utils/show-popup "Entered channel" "Wuhuu!! You successfully entered the channel :)"))
+                         :gates {:read [{:token "KNC"
+                                         :token-img-src knc-token-img
+                                         :amount 200
+                                         :is-sufficient? true}
+                                        {:token "MANA"
+                                         :token-img-src mana-token-img
+                                         :amount 10
+                                         :is-sufficient? false
+                                         :is-purchasable true}
+                                        {:token "RARE"
+                                         :token-img-src rare-token-img
+                                         :amount 10
+                                         :is-sufficient? false}]
+                                 :write [{:token "KNC"
+                                          :token-img-src knc-token-img
+                                          :amount 200
+                                          :is-sufficient? true}
+                                         {:token "DAI"
+                                          :token-img-src dai-token-img
+                                          :amount 20
+                                          :is-purchasable true
+                                          :is-sufficient? false}
+                                         {:token "ETH"
+                                          :token-img-src eth-token-img
+                                          :amount 0.5
+                                          :is-sufficient? false}]}}}])
       :content-height 210}]))
 
 (def mock-list-of-channels {:Welcome [{:name "welcome"
@@ -159,8 +159,27 @@
 
 (def channel-list-component (memoize channel-list-component-fn))
 
+(defn join-community [{:keys [joined can-join? requested-to-join-at community-color] :as community}]
+  (let [node-offline? (and can-join? (not joined) (pos? requested-to-join-at))]
+    [:<>
+     (when-not joined
+       [quo/button
+        {:on-press  #(rf/dispatch [:bottom-sheet/show-sheet
+                                   {:content (fn [] [requests.actions/request-to-join community])
+                                    :content-height 300}])
+         :override-background-color community-color
+         :style style/join-button
+         :before :i/communities}
+        (i18n/label :t/join-open-community)])
+     (when node-offline?
+       [quo/information-box
+        {:type :informative
+         :icon :i/info
+         :style {:margin-top 12}}
+        (i18n/label :t/request-processed-after-node-online)])]))
+
 (defn render-page-content [{:keys [name description locked joined id images
-                                   status tokens tags community-color]
+                                   status tokens tags]
                             :as   community}
                            channel-heights first-channel-height]
   (let [thumbnail-image (get-in images [:thumbnail])]
@@ -192,27 +211,27 @@
                              [:bottom-sheet/show-sheet
                               {:content-height 210
                                :content
-                               (constantly [quo/token-gating
-                                            {:community {:name name
-                                                         :community-color colors/primary-50
-                                                         :community-avatar (cond
-                                                                             (= id constants/status-community-id)
-                                                                             (resources/get-image :status-logo)
-                                                                             (seq thumbnail-image)
-                                                                             thumbnail-image)
-                                                         :gates {:join [{:token "KNC"
-                                                                         :token-img-src knc-token-img
-                                                                         :amount 200
-                                                                         :is-sufficient? true}
-                                                                        {:token "MANA"
-                                                                         :token-img-src mana-token-img
-                                                                         :amount 10
-                                                                         :is-sufficient? false
-                                                                         :is-purchasable true}
-                                                                        {:token "RARE"
-                                                                         :token-img-src rare-token-img
-                                                                         :amount 10
-                                                                         :is-sufficient? false}]}}}])}])}]])
+                               (fn [] [quo/token-gating
+                                       {:community {:name name
+                                                    :community-color colors/primary-50
+                                                    :community-avatar (cond
+                                                                        (= id constants/status-community-id)
+                                                                        (resources/get-image :status-logo)
+                                                                        (seq thumbnail-image)
+                                                                        thumbnail-image)
+                                                    :gates {:join [{:token "KNC"
+                                                                    :token-img-src knc-token-img
+                                                                    :amount 200
+                                                                    :is-sufficient? true}
+                                                                   {:token "MANA"
+                                                                    :token-img-src mana-token-img
+                                                                    :amount 10
+                                                                    :is-sufficient? false
+                                                                    :is-purchasable true}
+                                                                   {:token "RARE"
+                                                                    :token-img-src rare-token-img
+                                                                    :amount 10
+                                                                    :is-sufficient? false}]}}}])}])}]])
         (when joined
           [rn/view {:position         :absolute
                     :top              12
@@ -238,25 +257,17 @@
         [rn/view {:margin-top 12}]
         [quo/community-tags tags]
         [preview-user-list]
-        (when-not joined
-          [quo/button
-           {:on-press  #(rf/dispatch [:bottom-sheet/show-sheet
-                                      {:content (constantly [requests.actions/request-to-join community])
-                                       :content-height 300}])
-            :override-background-color community-color
-            :style
-            {:width "100%"
-             :margin-top 20
-             :margin-left :auto
-             :margin-right :auto}
-            :before :i/communities}
-           (i18n/label :t/join-open-community)])]
+        [join-community community]]
        [channel-list-component channel-heights first-channel-height]])))
 
 (defn render-sticky-header [channel-heights first-channel-height]
   (fn [scroll-height]
     (when (> scroll-height @first-channel-height)
-      [rn/blur-view style/blur-channel-header
+      [rn/blur-view
+       {:blur-amount 32
+        :blur-type :xlight
+        :overlay-color (if platform/ios? colors/white-opa-70 :transparent)
+        :style style/blur-channel-header}
        [quo/divider-label
         {:label (:label (last (filter (fn [{:keys [height]}]
                                         (>= scroll-height (+ height @first-channel-height)))
@@ -274,7 +285,7 @@
                                                     {:icon :i/options
                                                      :background-color (scroll-page/icon-color)
                                                      :on-press #(rf/dispatch [:bottom-sheet/show-sheet
-                                                                              {:content (constantly [home.actions/actions community])
+                                                                              {:content (fn [] [home.actions/actions community])
                                                                                :content-height 400}])}]}
                            name)]
     (fn []
@@ -288,7 +299,6 @@
 (defn overview []
   (let [community-mock (rf/sub [:get-screen-params :community-overview]) ;TODO stop using mock data and only pass community id
         community (rf/sub [:communities/community (:id community-mock)])]
-
     [rn/view {:style
               {:position :absolute
                :top (if platform/ios? 0 44)

--- a/src/status_im2/subs/communities_test.cljs
+++ b/src/status_im2/subs/communities_test.cljs
@@ -74,3 +74,38 @@
     (is (= {:unviewed-messages-count 0
             :unviewed-mentions-count 0}
            (rf/sub [sub-name community-id])))))
+
+(h/deftest-sub :communities/community-ids-by-user-involvement
+  [sub-name]
+  (testing "Empty communities list"
+    (swap! rf-db/app-db assoc :communities
+           {})
+    (is (= {:joined [], :pending [], :opened []}
+           (rf/sub [sub-name]))))
+  (testing "Only opened communities"
+    (swap! rf-db/app-db assoc
+           :communities/enabled? true
+           :communities
+           {"0x1" {:id "0x1" :name "civilized monkeys"}
+            "0x2" {:id "0x2" :name "Civilized rats"}
+            "0x3" {:id "0x3" :name "Civilized dolphins"}})
+    (is (= {:joined [], :pending [], :opened ["0x1" "0x2" "0x3"]}
+           (rf/sub [sub-name]))))
+  (testing "One joined community and two opened ones"
+    (swap! rf-db/app-db assoc
+           :communities/enabled? true
+           :communities
+           {"0x1" {:id "0x1" :name "civilized monkeys" :joined true}
+            "0x2" {:id "0x2" :name "Civilized rats"}
+            "0x3" {:id "0x3" :name "Civilized dolphins"}})
+    (is (= {:joined ["0x1"], :pending [], :opened ["0x2" "0x3"]}
+           (rf/sub [sub-name]))))
+  (testing "One joined community, one open and one pending"
+    (swap! rf-db/app-db assoc
+           :communities/enabled? true
+           :communities
+           {"0x1" {:id "0x1" :name "civilized monkeys" :joined true}
+            "0x2" {:id "0x2" :name "Civilized rats" :requested-to-join-at 1000}
+            "0x3" {:id "0x3" :name "Civilized dolphins"}})
+    (is (= {:joined ["0x1"], :pending ["0x2"], :opened ["0x3"]}
+           (rf/sub [sub-name])))))

--- a/translations/en.json
+++ b/translations/en.json
@@ -1123,6 +1123,7 @@
     "repeat-pin": "Repeat new 6-digit passcode",
     "repeat-puk": "Repeat new 12-digit PUK",
     "report-bug-email-template": "1. Issue Description\n{{description}}\n\n\n2. Steps to reproduce\n{{steps}}\n\n\n3. Attach screenshots that can demo the problem, please\n",
+    "request-processed-after-node-online": "Your request will be processed once the community owner node is back online.",
     "request-transaction": "Request transaction",
     "required-field": "Required field",
     "resend-message": "Resend",


### PR DESCRIPTION
### Summary
- all communities are visible now, not only Status
- fixed tabs pending/joined/opened to correctly show communities
- added "node offline" information box from #14456
  
  
### Review notes
The behavior of added information box was not really defined (agreed to wait for John on the design meeting), so its adding doesn't really close an issue. Moreover, you won't see it in UI because currently, when you join an open community, it is treated as fully joined even if the user didn't have a network connection at the moment of joining. Not sure if this behavior is correct. @churik, maybe you know. If not, we can probably open a bug.


#### Platforms
- Android
- iOS



status: ready
