### PR TITLE
Lint namespace aliases

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -9,7 +9,10 @@
            status-im.utils.styles/defn        clojure.core/defn
            status-im.test-helpers/deftest-sub clojure.core/defn
            taoensso.tufte/defnp               clojure.core/defn}
- :linters {:invalid-arity     {:skip-args [status-im.utils.fx/defn utils.re-frame/defn]}
+ :linters {:consistent-alias  {:level   :error
+                               :aliases {clojure.string  string
+                                         taoensso.timbre log}}
+           :invalid-arity     {:skip-args [status-im.utils.fx/defn utils.re-frame/defn]}
            ;; TODO remove number when this is fixed
            ;; https://github.com/borkdude/clj-kondo/issues/867
            :unresolved-symbol {:exclude [PersistentPriorityMap.EMPTY

--- a/doc/new-guidelines.md
+++ b/doc/new-guidelines.md
@@ -274,15 +274,6 @@ test macros `deftest` and `is`, which are ubiquitous in the Clojure community.
   (:require [cljs-time.coerce :as time.coerce]))
 ```
 
-### Namespace aliases
-
-Prefer the following namespace aliases:
-
-```clojure
-[clojure.string :as string]
-[taoensso.timbre :as log]
-```
-
 ### Javascript interop
 
 Use [binaryage/oops](https://github.com/binaryage/cljs-oops) macros instead of

--- a/src/quo2/components/avatars/wallet_user_avatar.cljs
+++ b/src/quo2/components/avatars/wallet_user_avatar.cljs
@@ -2,7 +2,7 @@
   (:require [react-native.core :as rn]
             [quo2.foundations.colors :as colors]
             [quo2.components.markdown.text :as text]
-            [clojure.string :as clojure-string]))
+            [clojure.string :as string]))
 
 (def circle-sizes {:small 20
                    :medium 32
@@ -29,10 +29,10 @@
   (let [circle-size    (size circle-sizes)
         small?         (= size :small)
         f-name-initial (-> f-name
-                           clojure-string/upper-case
+                           string/upper-case
                            (subs 0 1))
         l-name-initial (-> l-name
-                           clojure-string/upper-case
+                           string/upper-case
                            (subs 0 1))
         circle-color   (colors/custom-color color 50 20)
         text-color     (colors/custom-color-by-theme color 50 60)]

--- a/src/quo2/components/code/snippet.cljs
+++ b/src/quo2/components/code/snippet.cljs
@@ -1,7 +1,7 @@
 (ns quo2.components.code.snippet
   (:require ["react-native" :as react-native]
             [cljs-bean.core :as bean]
-            [clojure.string :as str]
+            [clojure.string :as string]
             [oops.core :as oops]
             [react-native.core :as rn]
             [quo2.theme :as theme]
@@ -52,7 +52,7 @@
                              :style (text-style (get-in node [:properties :className]))}]
                  (render-nodes children))
            ;; Remove newlines as we already render each line separately.
-           (-> value str/trim-newline)))
+           (-> value string/trim-newline)))
        nodes))
 
 (defn- code-block [{:keys [rows line-number-width]}]

--- a/src/quo2/components/icons/icons.clj
+++ b/src/quo2/components/icons/icons.clj
@@ -1,6 +1,6 @@
 (ns quo2.components.icons.icons
   (:require [clojure.java.io :as io]
-            [clojure.string :as cstr]))
+            [clojure.string :as string]))
 
 (def icon-path "./resources/images/icons2/")
 
@@ -13,17 +13,17 @@
   (fn [el]
     (let [s (combine-path path el)
           k (-> el
-                (cstr/replace "_" "-")
-                (cstr/replace " " "-")
-                (cstr/lower-case)
+                (string/replace "_" "-")
+                (string/replace " " "-")
+                (string/lower-case)
                 (str size))]
       [k `(js/require ~s)])))
 
 (defn get-files [path]
   (->> (io/file path)
        file-seq
-       (filter #(cstr/ends-with? % "png"))
-       (map #(first (cstr/split (.getName %) #"@")))
+       (filter #(string/ends-with? % "png"))
+       (map #(first (string/split (.getName %) #"@")))
        distinct))
 
 (defn get-icons [size]

--- a/src/status_im/async_storage/transit.cljs
+++ b/src/status_im/async_storage/transit.cljs
@@ -1,6 +1,6 @@
 (ns status-im.async-storage.transit
   (:require [cognitect.transit :as transit]
-            [taoensso.timbre :as timbre]))
+            [taoensso.timbre :as log]))
 
 (def reader (transit/reader :json))
 (def writer (transit/writer :json))
@@ -8,4 +8,4 @@
 (defn clj->transit [o] (transit/write writer o))
 (defn transit->clj [o] (try (transit/read reader o)
                             (catch :default e
-                              (timbre/error e))))
+                              (log/error e))))

--- a/src/status_im/contact/db.cljs
+++ b/src/status_im/contact/db.cljs
@@ -1,6 +1,6 @@
 (ns status-im.contact.db
   (:require [clojure.set :as clojure.set]
-            [clojure.string :as clojure.string]
+            [clojure.string :as string]
             [status-im.ethereum.core :as ethereum]
             [status-im.utils.gfycat.core :as gfycat]
             [status-im.utils.identicon :as identicon]
@@ -40,8 +40,8 @@
   (sort (fn [c1 c2]
           (let [name1 (or (:name c1) (:address c1) (:public-key c1))
                 name2 (or (:name c2) (:address c2) (:public-key c2))]
-            (compare (clojure.string/lower-case name1)
-                     (clojure.string/lower-case name2))))
+            (compare (string/lower-case name1)
+                     (string/lower-case name2))))
         (vals contacts)))
 
 (defn filter-dapps
@@ -71,7 +71,7 @@
     (->> members
          (map #(or (get all-contacts %)
                    (public-key->new-contact %)))
-         (sort-by (comp clojure.string/lower-case #(or (:name %) (:alias %))))
+         (sort-by (comp string/lower-case #(or (:name %) (:alias %))))
          (map #(if (get admins (:public-key %))
                  (assoc % :admin? true)
                  %)))))

--- a/src/status_im/ethereum/macros.clj
+++ b/src/status_im/ethereum/macros.clj
@@ -1,10 +1,10 @@
 (ns status-im.ethereum.macros
   (:require [clojure.java.io :as io]
-            [clojure.string :as cstr]))
+            [clojure.string :as string]))
 
 (defn token-icon-path [path]
   (fn [el]
-    (let [el    (cstr/replace el ".png" "")
+    (let [el    (string/replace el ".png" "")
           s     (str path el ".png")
           s-js  (str "." s)]
       (when (.exists (io/file s))
@@ -17,8 +17,8 @@
   (let [path (str "./resources/images/tokens/" (name network) "/")
         files (->> (io/file path)
                    file-seq
-                   (filter #(cstr/ends-with? % "png"))
-                   (map #(first (cstr/split (.getName %) #"@")))
+                   (filter #(string/ends-with? % "png"))
+                   (map #(first (string/split (.getName %) #"@")))
                    distinct)]
     (into {} (map (token-icon-path path) files))))
 

--- a/src/status_im/keycard/sign.cljs
+++ b/src/status_im/keycard/sign.cljs
@@ -7,7 +7,7 @@
             [status-im.utils.types :as types]
             [taoensso.timbre :as log]
             [status-im.keycard.common :as common]
-            [clojure.string :as clojure.string]))
+            [clojure.string :as string]))
 
 (fx/defn sign
   {:events [:keycard/sign]}
@@ -50,8 +50,8 @@
 
 (defn normalize-signature [signature]
   (-> signature
-      (clojure.string/replace-first #"00$", "1b")
-      (clojure.string/replace-first #"01$", "1c")
+      (string/replace-first #"00$", "1b")
+      (string/replace-first #"01$", "1c")
       ethereum/normalized-hex))
 
 (fx/defn sign-message

--- a/src/status_im/notifications/local.cljs
+++ b/src/status_im/notifications/local.cljs
@@ -12,7 +12,7 @@
             [quo.platform :as platform]
             [re-frame.core :as re-frame]
             [cljs-bean.core :as bean]
-            [clojure.string :as clojure.string]
+            [clojure.string :as string]
             [status-im.chat.models :as chat.models]
             [status-im.utils.react-native :as react-native-utils]))
 
@@ -65,7 +65,7 @@
     :as notification}]
   (let [token       (if erc20
                       (get-in db
-                              [:wallet/all-tokens (clojure.string/lower-case contract)]
+                              [:wallet/all-tokens (string/lower-case contract)]
                               default-erc20-token)
                       (tokens/native-currency network))
         amount      (money/wei->ether (decode/uint value))

--- a/src/status_im/test_runner.cljs
+++ b/src/status_im/test_runner.cljs
@@ -2,7 +2,7 @@
   {:dev/always true}
   (:require
    [cljs.test :as ct]
-   [clojure.string :as str]
+   [clojure.string :as string]
    [shadow.test :as st]
    [shadow.test.env :as env]))
 
@@ -32,10 +32,10 @@
        (= "--repl" arg)
        (assoc opts :repl true)
 
-       (str/starts-with? arg "--test=")
+       (string/starts-with? arg "--test=")
        (let [test-arg (subs arg 7)
              test-syms
-             (->> (str/split test-arg ",")
+             (->> (string/split test-arg ",")
                   (map symbol))]
          (update opts :test-syms into test-syms))
 

--- a/src/status_im/ui/components/icons/icons.clj
+++ b/src/status_im/ui/components/icons/icons.clj
@@ -1,18 +1,18 @@
 (ns status-im.ui.components.icons.icons
   (:require [clojure.java.io :as io]
-            [clojure.string :as cstr]))
+            [clojure.string :as string]))
 
 (def icon-path "./resources/images/icons/")
 
 (defn require-icon [el]
   (let [s (str "../resources/images/icons/" el ".png")
-        k (cstr/replace el "_" "-")]
+        k (string/replace el "_" "-")]
     [k `(js/require ~s)]))
 
 (defmacro resolve-icons []
   (let [files (->> (io/file icon-path)
                    file-seq
-                   (filter #(cstr/ends-with? % "png"))
-                   (map #(first (cstr/split (.getName %) #"@")))
+                   (filter #(string/ends-with? % "png"))
+                   (map #(first (string/split (.getName %) #"@")))
                    distinct)]
     (into {} (map require-icon files))))

--- a/src/status_im/ui/screens/activity_center/notification/contact_verification/view.cljs
+++ b/src/status_im/ui/screens/activity_center/notification/contact_verification/view.cljs
@@ -1,5 +1,5 @@
 (ns status-im.ui.screens.activity-center.notification.contact-verification.view
-  (:require [clojure.string :as str]
+  (:require [clojure.string :as string]
             [quo2.core :as quo2]
             [status-im.constants :as constants]
             [status-im.i18n.i18n :as i18n]
@@ -20,7 +20,7 @@
      (when (or (= contact-verification-status constants/contact-verification-status-accepted)
                (= contact-verification-status constants/contact-verification-status-trusted)
                (= contact-verification-status constants/contact-verification-status-untrustworthy))
-       (str (str/lower-case (i18n/label :t/replied)) ":"))
+       (str (string/lower-case (i18n/label :t/replied)) ":"))
      (when (or (= contact-verification-status constants/contact-verification-status-accepted)
                (= contact-verification-status constants/contact-verification-status-pending)
                (= contact-verification-status constants/contact-verification-status-declined))

--- a/src/status_im/ui/screens/activity_center/notification/mentions/view.cljs
+++ b/src/status_im/ui/screens/activity_center/notification/mentions/view.cljs
@@ -7,7 +7,7 @@
             [status-im.ui.screens.activity-center.notification.mentions.style :as style]
             [status-im.utils.datetime :as datetime]
             [utils.re-frame :as rf]
-            [clojure.string :as str]))
+            [clojure.string :as string]))
 
 (defn message-body [message]
   (let [parsed-text          (get-in message [:content :parsed-text])
@@ -36,10 +36,10 @@
      :timestamp (datetime/timestamp->relative (:timestamp notification))
      :unread?   (not (:read notification))
      :context   [[common/user-avatar-tag author]
-                 [quo2/text {:style style/tag-text} (str/lower-case (i18n/label :t/on))]
-                 ;; TODO (@smohamedjavid): The `group-avatar-tag` component 
+                 [quo2/text {:style style/tag-text} (string/lower-case (i18n/label :t/on))]
+                 ;; TODO (@smohamedjavid): The `group-avatar-tag` component
                  ;; does NOT support displaying channel name along with community/chat name.
-                 ;; Need to update the component to support it. 
+                 ;; Need to update the component to support it.
                  [quo2/group-avatar-tag chat-name {:size           :small
                                                    :override-theme :dark
                                                    :color          colors/primary-50

--- a/src/status_im/ui/screens/communities/community_emoji_thumbnail_picker.cljs
+++ b/src/status_im/ui/screens/communities/community_emoji_thumbnail_picker.cljs
@@ -1,7 +1,7 @@
 (ns status-im.ui.screens.communities.community-emoji-thumbnail-picker
   (:require [quo.react-native :as rn]
             [quo.core :as quo]
-            [clojure.string :as str]
+            [clojure.string :as string]
             [status-im.ui.components.react :as react]
             [status-im.utils.handlers :refer [>evt <sub]]
             [status-im.communities.core :as communities]
@@ -21,7 +21,7 @@
   (let [{:keys [color]} (<sub [:communities/create-channel])
         item-color (:color item)
         key (:key key)
-        color-selected?  (= (str/lower-case item-color) (str/lower-case color))]
+        color-selected?  (= (string/lower-case item-color) (string/lower-case color))]
     [react/touchable-opacity {:key                 key
                               :accessibility-label :color-circle
                               :on-press            #(>evt  [::communities/create-channel-field :color item-color])}
@@ -29,7 +29,7 @@
       [rn/view {:style (styles/emoji-picker-color item-color)}]]]))
 
 (defn update-emoji [emoji]
-  (when-not (str/blank? emoji)
+  (when-not (string/blank? emoji)
     (>evt [::communities/create-channel-field :emoji emoji])))
 
 (defn emoji-keyboard-section []
@@ -45,4 +45,3 @@
     [thumbnail-preview-section]
     [color-picker/color-picker-section color-circle]
     [emoji-keyboard-section]]])
-

--- a/src/status_im/ui/screens/communities/create.cljs
+++ b/src/status_im/ui/screens/communities/create.cljs
@@ -2,7 +2,7 @@
   (:require [quo.react-native :as rn]
             [status-im.i18n.i18n :as i18n]
             [quo.core :as quo]
-            [clojure.string :as str]
+            [clojure.string :as string]
             [status-im.utils.handlers :refer [>evt <sub]]
             [status-im.communities.core :as communities]
             [status-im.ui.components.toolbar :as toolbar]
@@ -17,8 +17,8 @@
 (def max-description-length 140)
 
 (defn valid? [community-name community-description]
-  (and (not (str/blank? community-name))
-       (not (str/blank? community-description))
+  (and (not (string/blank? community-name))
+       (not (string/blank? community-description))
        (<= (count community-name) max-name-length)
        (<= (count community-description) max-description-length)))
 

--- a/src/status_im/ui/screens/communities/create_category.cljs
+++ b/src/status_im/ui/screens/communities/create_category.cljs
@@ -6,14 +6,14 @@
             [quo.core :as quo]
             [utils.debounce :as debounce]
             [status-im.i18n.i18n :as i18n]
-            [clojure.string :as str]
+            [clojure.string :as string]
             [status-im.ui.components.list.views :as list]
             [status-im.ui.screens.home.views.inner-item :as inner-item]
             [status-im.communities.core :as communities]
             [reagent.core :as reagent]))
 
 (defn valid? [category-name]
-  (and (not (str/blank? category-name))
+  (and (not (string/blank? category-name))
        (<= (count category-name) 30)))
 
 (def selected-items (reagent/atom #{}))

--- a/src/status_im/ui/screens/communities/create_channel.cljs
+++ b/src/status_im/ui/screens/communities/create_channel.cljs
@@ -1,5 +1,5 @@
 (ns status-im.ui.screens.communities.create-channel
-  (:require [clojure.string :as str]
+  (:require [clojure.string :as string]
             [quo.react-native :as rn]
             [quo.core :as quo]
             [status-im.i18n.i18n :as i18n]
@@ -13,8 +13,8 @@
             [status-im.ui.components.emoji-thumbnail.preview :as emoji-thumbnail-preview]))
 
 (defn valid? [channel-name channel-description]
-  (and (not (str/blank? channel-name))
-       (not (str/blank? channel-description))
+  (and (not (string/blank? channel-name))
+       (not (string/blank? channel-description))
        (<= (count channel-name) create/max-name-length)
        (<= (count channel-description) create/max-description-length)))
 

--- a/src/status_im/ui/screens/communities/edit_channel.cljs
+++ b/src/status_im/ui/screens/communities/edit_channel.cljs
@@ -1,5 +1,5 @@
 (ns status-im.ui.screens.communities.edit-channel
-  (:require [clojure.string :as str]
+  (:require [clojure.string :as string]
             [quo.core :as quo]
             [status-im.i18n.i18n :as i18n]
             [status-im.ui.components.toolbar :as toolbar]
@@ -9,7 +9,7 @@
             [status-im.ui.screens.communities.create-channel :as create-channel]))
 
 (defn valid? [community-name]
-  (not (str/blank? community-name)))
+  (not (string/blank? community-name)))
 
 (defn view []
   (let [{:keys [name]} (<sub [:communities/create-channel])]

--- a/src/status_im/ui/screens/communities/invite.cljs
+++ b/src/status_im/ui/screens/communities/invite.cljs
@@ -10,7 +10,7 @@
             [status-im.ui.components.topbar :as topbar]
             [status-im.ui.components.chat-icon.screen :as chat-icon.screen]
             [status-im.multiaccounts.core :as multiaccounts]
-            [clojure.string :as str]))
+            [clojure.string :as string]))
 
 (defn header [user-pk]
   [:<>
@@ -71,7 +71,7 @@
          [toolbar/toolbar
           {:show-border? true
            :center
-           [quo/button {:disabled (and (str/blank? @user-pk)
+           [quo/button {:disabled (and (string/blank? @user-pk)
                                        (zero? (count selected)))
                         :accessibility-label :share-community-link
                         :type     :secondary

--- a/src/status_im/ui/screens/privacy_and_security_settings/events.cljs
+++ b/src/status_im/ui/screens/privacy_and_security_settings/events.cljs
@@ -6,12 +6,12 @@
             [status-im.ethereum.core :as ethereum]
             [status-im.utils.types :as types]
             [taoensso.timbre :as log]
-            [clojure.string :as clojure.string]
+            [clojure.string :as string]
             [status-im.i18n.i18n :as i18n]))
 
 (defn safe-blank? [s]
   (or (not s)
-      (clojure.string/blank? s)))
+      (string/blank? s)))
 
 (re-frame/reg-fx
  ::delete-profile

--- a/src/status_im/ui/screens/signing/sheets.cljs
+++ b/src/status_im/ui/screens/signing/sheets.cljs
@@ -7,7 +7,7 @@
             [quo.design-system.colors :as colors]
             [status-im.utils.money :as money]
             [status-im.ui.components.icons.icons :as icons]
-            [clojure.string :as clojure.string]
+            [clojure.string :as string]
             [status-im.signing.gas :as gas]
             [reagent.core :as reagent]))
 
@@ -211,7 +211,7 @@
       [react/text {:style {:margin-top 12}
                    :accessibility-label :slow-fee
                    :on-press #(re-frame/dispatch [:signing.edit-fee.ui/set-option :slow])}
-       (clojure.string/join
+       (string/join
         " "
         [(str (i18n/label :t/slow) ":")
          (str (:base-fee slow) " gwei")
@@ -221,7 +221,7 @@
       [react/text {:style {:margin-top 12}
                    :accessibility-label :normal-fee
                    :on-press #(re-frame/dispatch [:signing.edit-fee.ui/set-option :normal])}
-       (clojure.string/join
+       (string/join
         " "
         [(str (i18n/label :t/normal) ":")
          (str (:base-fee normal) " gwei")
@@ -232,7 +232,7 @@
       [react/text {:style {:margin-top 12}
                    :accessibility-label :fast-fee
                    :on-press #(re-frame/dispatch [:signing.edit-fee.ui/set-option :fast])}
-       (clojure.string/join
+       (string/join
         " "
         [(str (i18n/label :t/fast) ":")
          (str (:base-fee fast) " gwei")
@@ -241,7 +241,7 @@
            "<- selected")])]
       (when (= :custom option)
         [react/text {:style {:margin-top 12}}
-         (clojure.string/join
+         (string/join
           " "
           [(str (i18n/label :t/custom) ":")
            (str (-> fee-edit

--- a/src/status_im/ui/screens/wallet/collectibles/views.cljs
+++ b/src/status_im/ui/screens/wallet/collectibles/views.cljs
@@ -1,6 +1,6 @@
 (ns status-im.ui.screens.wallet.collectibles.views
   (:require [re-frame.core :as re-frame]
-            [clojure.string :as str]
+            [clojure.string :as string]
             [status-im.ui.components.react :as react]
             [quo.core :as quo]
             [status-im.utils.handlers :refer [<sub]]
@@ -22,12 +22,12 @@
 
 (defn is-image? [nft]
   (and (seq (:image_url nft))
-       (not (str/ends-with? (:image_url nft) ".svg"))
-       (not (str/ends-with? (:image_url nft) ".mp4"))))
+       (not (string/ends-with? (:image_url nft) ".svg"))
+       (not (string/ends-with? (:image_url nft) ".mp4"))))
 
 (defn is-vector? [nft]
   (and (seq (:image_url nft))
-       (str/ends-with? (:image_url nft) ".svg")))
+       (string/ends-with? (:image_url nft) ".svg")))
 
 (defn missing-image-placeholder []
   [react/view {:style {:width            "100%"

--- a/src/status_im/ui/screens/wallet/swap/views.cljs
+++ b/src/status_im/ui/screens/wallet/swap/views.cljs
@@ -18,7 +18,7 @@
             [status-im.ui.screens.wallet.components.views :as wallet.components]
             [status-im.utils.handlers :refer [<sub]]
             [status-im.wallet.utils :as wallet.utils]
-            [clojure.string :as str]))
+            [clojure.string :as string]))
 
 (defn render-asset [{{:keys
                       [icon decimals amount color value]
@@ -378,7 +378,7 @@
                                              :ignore-offset true}
      [topbar/topbar
       {:title    name
-       :subtitle (str/upper-case (i18n/label :t/powered-by-paraswap))
+       :subtitle (string/upper-case (i18n/label :t/powered-by-paraswap))
        :modal?   true}]
 
      [react/view (merge {:padding-horizontal 16
@@ -430,4 +430,3 @@
       {:show-border? true
        :right        [quo/button {:theme :accent}
                       (i18n/label :t/swap)]}]]))
-

--- a/src/status_im/ui2/screens/chat/components/received_cr_item.cljs
+++ b/src/status_im/ui2/screens/chat/components/received_cr_item.cljs
@@ -4,14 +4,14 @@
             [status-im.utils.handlers :refer [<sub >evt]]
             [quo2.components.avatars.user-avatar :as user-avatar]
             [quo2.foundations.typography :as typography]
-            [clojure.string :as str]
+            [clojure.string :as string]
             [status-im.utils.utils :as utils.utils]
             [status-im.utils.datetime :as time]
             [status-im.i18n.i18n :as i18n]
             [quo2.components.notifications.notification-dot :refer [notification-dot]]))
 
 (defn received-cr-item [{:keys [chat-id message timestamp read]}]
-  (let [no-ens-name  (str/blank? (get-in message [:content :ens-name]))
+  (let [no-ens-name  (string/blank? (get-in message [:content :ens-name]))
         display-name (first (<sub [:contacts/contact-two-names-by-identity chat-id]))]
     [rn/view {:style {:flex-direction :row
                       :padding-top    8
@@ -73,5 +73,3 @@
                                                     :padding-horizontal 8
                                                     :margin-left        8}}
         [rn/text {:style (merge typography/font-medium typography/paragraph-2 {:color colors/white})} (i18n/label :t/accept)]]]]]))
-
-

--- a/src/status_im/utils/datetime.cljs
+++ b/src/status_im/utils/datetime.cljs
@@ -7,7 +7,7 @@
                                       unparse]]
             [status-im.i18n.i18n :refer [label label-pluralize]]
             [status-im.native-module.core :as status]
-            [clojure.string :as s]
+            [clojure.string :as string]
             [status-im.goog.i18n :as goog.18n]))
 
 ;;;; Datetime constants
@@ -36,7 +36,7 @@
 (defn- is24Hour-locsym
   "Detects if given locale symbols timeformat generates AM/PM ('a')."
   [^js locsym]
-  (not (s/includes?
+  (not (string/includes?
         (nth (.-TIMEFORMATS locsym) 2)
         "a")))
 
@@ -151,7 +151,7 @@
       (.format ^js (time-fmt) datetime)
 
       (within-last-n-days? datetime 1)
-      (str (s/capitalize (label :t/datetime-yesterday))
+      (str (string/capitalize (label :t/datetime-yesterday))
            " "
            (.format ^js (time-fmt) datetime))
 

--- a/src/status_im/utils/name.cljs
+++ b/src/status_im/utils/name.cljs
@@ -1,17 +1,17 @@
 (ns status-im.utils.name
-  (:require [clojure.string :as str]))
+  (:require [clojure.string :as string]))
 
 (defn too-long? [name max-len]
   (> (count name) max-len))
 
 (defn max-name
   [name max-len]
-  (let [names (str/split name " ")]
+  (let [names (string/split name " ")]
     (first
      (reduce (fn [[name done] next-name]
                (if done
                  name
-                 (let [new-name (str/join " " [name next-name])]
+                 (let [new-name (string/join " " [name next-name])]
                    (if (too-long? new-name max-len)
                      (let [new-name' (str name " " (first next-name) ".")]
                        (if (too-long? new-name' max-len)
@@ -25,6 +25,6 @@
   (if (> (count name) max-len)
     (let [name' (max-name name max-len)]
       (if (too-long? name' max-len)
-        (str (str/trim (subs name 0 max-len)) "...")
+        (str (string/trim (subs name 0 max-len)) "...")
         name'))
     name))

--- a/src/status_im/utils/snoopy.cljs
+++ b/src/status_im/utils/snoopy.cljs
@@ -1,5 +1,5 @@
 (ns status-im.utils.snoopy
-  (:require [clojure.string :as clojure.string]
+  (:require [clojure.string :as string]
             [status-im.utils.config :as config]
             ["react-native/Libraries/vendor/emitter/EventEmitter" :refer [EventEmitter]]
             ["rn-snoopy" :default snoopy]
@@ -25,7 +25,7 @@
            (= first-arg "gethEvent"))
       (and
        (string? method)
-       (clojure.string/starts-with? method "<callback for Status."))))
+       (string/starts-with? method "<callback for Status."))))
 
 (defn timer-filter [{:keys [method]}]
   (contains? #{"callTimers" "createTimer"} method))
@@ -46,7 +46,7 @@
   (or (= module "NativeAnimatedModule")
       (and
        (string? method)
-       (clojure.string/starts-with? method "<callback for NativeAnimatedModule."))))
+       (string/starts-with? method "<callback for NativeAnimatedModule."))))
 
 (defn keyboard-observer-filter [{:keys [module]}]
   ;; mostly all calls to KeyboardObserver are done by FlatList


### PR DESCRIPTION
### Summary

This PR does one straightforward thing: it enables the clj-kondo linter `:consistent-alias` and lint the aliases that were previously documented in the [New guidelines > Namespace Aliases](https://github.com/status-im/status-mobile/blob/develop/doc/new-guidelines.md#namespace-aliases).

#### Notes

From now on, devs can easily add new namespace alias checks instead of relying on convention.

status: ready
