### PR TITLE
feat: Added Dividers Date Component  to quo2

### DIFF
--- a/src/quo2/components/dividers/date.cljs
+++ b/src/quo2/components/dividers/date.cljs
@@ -1,17 +1,18 @@
 (ns quo2.components.dividers.date
   (:require [react-native.core :as rn]
-            [clojure.string :as string]
             [quo2.components.separator :as separator]
             [quo2.components.markdown.text :as text]
             [quo2.foundations.colors :as colors]))
 
 (defn date [value]
   [rn/view {:margin-vertical 16
-            :padding-left 52}
+            :padding-right 8
+            :padding-left 62}
    [text/text {:weight              :medium
-               :accessibility-label :message-datemark-text
+               :accessibility-label :divider-date-text
                :size :label
                :style {:color (colors/theme-colors colors/neutral-50 colors/neutral-40)
+                       :text-transform :capitalize
                        :margin-bottom 4}}
-    (string/capitalize value)]
+    value]
    [separator/separator]])

--- a/src/quo2/components/dividers/date.cljs
+++ b/src/quo2/components/dividers/date.cljs
@@ -1,6 +1,7 @@
 (ns quo2.components.dividers.date
   (:require [react-native.core :as rn]
             [clojure.string :as string]
+            [quo2.components.separator :as separator]
             [quo2.components.markdown.text :as text]
             [quo2.foundations.colors :as colors]))
 
@@ -10,9 +11,7 @@
    [text/text {:weight              :medium
                :accessibility-label :message-datemark-text
                :size :label
-               :style {:color (colors/theme-colors colors/neutral-50 colors/neutral-40)}}
+               :style {:color (colors/theme-colors colors/neutral-50 colors/neutral-40)
+                       :margin-bottom 4}}
     (string/capitalize value)]
-   [rn/view {:width "100%"
-             :height 1
-             :background-color (colors/theme-colors colors/neutral-10 colors/neutral-90)
-             :margin-top 4}]])
+   [separator/separator]])

--- a/src/quo2/components/dividers/date.cljs
+++ b/src/quo2/components/dividers/date.cljs
@@ -1,20 +1,18 @@
 (ns quo2.components.dividers.date
   (:require [react-native.core :as rn]
             [clojure.string :as string]
-            [quo2.components.markdown.text :as quo2.text]
-            [quo2.foundations.colors :as quo2.colors]))
+            [quo2.components.markdown.text :as text]
+            [quo2.foundations.colors :as colors]))
 
 (defn date [value]
-  [rn/touchable-without-feedback
-   {:on-press #(rn/dismiss-keyboard!)}
-   [rn/view {:margin-vertical 16
-             :padding-left 52}
-    [quo2.text/text {:weight              :medium
-                     :accessibility-label :message-datemark-text
-                     :size :label
-                     :style {:color (quo2.colors/theme-colors quo2.colors/neutral-50 quo2.colors/neutral-40)}}
-     (string/capitalize value)]
-    [rn/view {:width "100%"
-              :height 1
-              :background-color (quo2.colors/theme-colors quo2.colors/neutral-10 quo2.colors/neutral-90)
-              :margin-top 4}]]])
+  [rn/view {:margin-vertical 16
+            :padding-left 52}
+   [text/text {:weight              :medium
+               :accessibility-label :message-datemark-text
+               :size :label
+               :style {:color (colors/theme-colors colors/neutral-50 colors/neutral-40)}}
+    (string/capitalize value)]
+   [rn/view {:width "100%"
+             :height 1
+             :background-color (colors/theme-colors colors/neutral-10 colors/neutral-90)
+             :margin-top 4}]])

--- a/src/quo2/components/dividers/date.cljs
+++ b/src/quo2/components/dividers/date.cljs
@@ -1,0 +1,20 @@
+(ns quo2.components.dividers.date
+  (:require [react-native.core :as rn]
+            [clojure.string :as string]
+            [quo2.components.markdown.text :as quo2.text]
+            [quo2.foundations.colors :as quo2.colors]))
+
+(defn date [value]
+  [rn/touchable-without-feedback
+   {:on-press #(rn/dismiss-keyboard!)}
+   [rn/view {:margin-vertical 16
+             :padding-left 52}
+    [quo2.text/text {:weight              :medium
+                     :accessibility-label :message-datemark-text
+                     :size :label
+                     :style {:color (quo2.colors/theme-colors quo2.colors/neutral-50 quo2.colors/neutral-40)}}
+     (string/capitalize value)]
+    [rn/view {:width "100%"
+              :height 1
+              :background-color (quo2.colors/theme-colors quo2.colors/neutral-10 quo2.colors/neutral-90)
+              :margin-top 4}]]])

--- a/src/quo2/core.cljs
+++ b/src/quo2/core.cljs
@@ -18,6 +18,7 @@
             quo2.components.community.token-gating
             quo2.components.counter.counter
             quo2.components.dividers.divider-label
+            quo2.components.dividers.date
             quo2.components.dividers.new-messages
             quo2.components.drawers.action-drawers
             quo2.components.dropdowns.dropdown
@@ -94,6 +95,7 @@
 ;;;; DIVIDERS
 (def divider-label quo2.components.dividers.divider-label/divider-label)
 (def new-messages quo2.components.dividers.new-messages/new-messages)
+(def divider-date quo2.components.dividers.date/date)
 
 ;;;; LIST ITEMS
 (def channel-list-item quo2.components.list-items.channel/list-item)

--- a/src/status_im2/contexts/chat/messages/list/view.cljs
+++ b/src/status_im2/contexts/chat/messages/list/view.cljs
@@ -120,7 +120,9 @@
                          chat-id show-input? message-pin-enabled edit-enabled in-pinned-view? can-delete-message-for-everyone?]}]
   [rn/view {:style (when (and platform/android? (not in-pinned-view?)) {:scaleY -1})}
    (if (= type :datemark)
-     [quo/divider-date (:value message)]
+     [rn/touchable-without-feedback
+      {:on-press #(rn/dismiss-keyboard!)}
+      [quo/divider-date (:value message)]]
      (if (= type :gap)
        ;; TODO (flexsurfer) new gap functionality is not implemented yet
        [gap/gap message idx messages-list-ref false chat-id]

--- a/src/status_im2/contexts/chat/messages/list/view.cljs
+++ b/src/status_im2/contexts/chat/messages/list/view.cljs
@@ -8,7 +8,6 @@
             [oops.core :as oops]
             [react-native.background-timer :as background-timer]
             [status-im2.common.constants :as constants]
-            [quo2.components.dividers.date :as divider-date]
 
             ;;TODO move to status-im2
             [status-im.ui2.screens.chat.messages.message :as message]
@@ -121,7 +120,7 @@
                          chat-id show-input? message-pin-enabled edit-enabled in-pinned-view? can-delete-message-for-everyone?]}]
   [rn/view {:style (when (and platform/android? (not in-pinned-view?)) {:scaleY -1})}
    (if (= type :datemark)
-     [divider-date/date (:value message)]
+     [quo/divider-date (:value message)]
      (if (= type :gap)
        ;; TODO (flexsurfer) new gap functionality is not implemented yet
        [gap/gap message idx messages-list-ref false chat-id]

--- a/src/status_im2/contexts/chat/messages/list/view.cljs
+++ b/src/status_im2/contexts/chat/messages/list/view.cljs
@@ -121,7 +121,7 @@
   [rn/view {:style (when (and platform/android? (not in-pinned-view?)) {:scaleY -1})}
    (if (= type :datemark)
      [rn/touchable-without-feedback
-      {:on-press #(rn/dismiss-keyboard!)}
+      {:on-press rn/dismiss-keyboard!}
       [quo/divider-date (:value message)]]
      (if (= type :gap)
        ;; TODO (flexsurfer) new gap functionality is not implemented yet

--- a/src/status_im2/contexts/chat/messages/list/view.cljs
+++ b/src/status_im2/contexts/chat/messages/list/view.cljs
@@ -8,11 +8,11 @@
             [oops.core :as oops]
             [react-native.background-timer :as background-timer]
             [status-im2.common.constants :as constants]
+            [quo2.components.dividers.date :as divider-date]
 
             ;;TODO move to status-im2
             [status-im.ui2.screens.chat.messages.message :as message]
             [status-im.ui.screens.chat.group :as chat.group]
-            [status-im.ui.screens.chat.message.datemark :as message-datemark]
             [status-im.ui.screens.chat.message.gap :as gap]
             [status-im.ui.screens.chat.state :as state]
             [quo.react-native :as quo.react]))
@@ -121,8 +121,7 @@
                          chat-id show-input? message-pin-enabled edit-enabled in-pinned-view? can-delete-message-for-everyone?]}]
   [rn/view {:style (when (and platform/android? (not in-pinned-view?)) {:scaleY -1})}
    (if (= type :datemark)
-     ;; TODO (flexsurfer) implement and use date divider component https://github.com/status-im/status-mobile/issues/14523
-     [message-datemark/chat-datemark (:value message)]
+     [divider-date/date (:value message)]
      (if (= type :gap)
        ;; TODO (flexsurfer) new gap functionality is not implemented yet
        [gap/gap message idx messages-list-ref false chat-id]

--- a/src/status_im2/contexts/chat/messages/list/view.cljs
+++ b/src/status_im2/contexts/chat/messages/list/view.cljs
@@ -120,9 +120,7 @@
                          chat-id show-input? message-pin-enabled edit-enabled in-pinned-view? can-delete-message-for-everyone?]}]
   [rn/view {:style (when (and platform/android? (not in-pinned-view?)) {:scaleY -1})}
    (if (= type :datemark)
-     [rn/touchable-without-feedback
-      {:on-press rn/dismiss-keyboard!}
-      [quo/divider-date (:value message)]]
+     [quo/divider-date (:value message)]
      (if (= type :gap)
        ;; TODO (flexsurfer) new gap functionality is not implemented yet
        [gap/gap message idx messages-list-ref false chat-id]

--- a/src/status_im2/contexts/quo_preview/dividers/date.cljs
+++ b/src/status_im2/contexts/quo_preview/dividers/date.cljs
@@ -1,0 +1,28 @@
+(ns status-im2.contexts.quo-preview.dividers.date
+  (:require [react-native.core :as rn]
+            [reagent.core :as reagent]
+            [status-im2.contexts.quo-preview.preview :as preview]
+            [quo2.foundations.colors :as colors]
+            [quo2.core :as quo]))
+
+(def descriptor [{:label   "Value"
+                  :key     :label
+                  :type    :text}])
+(defn cool-preview []
+  (let [state     (reagent/atom {:label "Today"})]
+    (fn []
+      [rn/touchable-without-feedback {:on-press rn/dismiss-keyboard!}
+       [rn/view {:padding-bottom 150}
+        [preview/customizer state descriptor]
+        [rn/view {:padding-vertical 60}
+         [quo/divider-date (@state :label)]]]])))
+
+(defn preview-divider-date []
+  [rn/view  {:background-color (colors/theme-colors
+                                colors/white
+                                colors/neutral-95)
+             :flex             1}
+   [rn/flat-list {:flex                      1
+                  :keyboardShouldPersistTaps :always
+                  :header                    [cool-preview]
+                  :key-fn                    str}]])

--- a/src/status_im2/contexts/quo_preview/main.cljs
+++ b/src/status_im2/contexts/quo_preview/main.cljs
@@ -19,6 +19,7 @@
             [status-im2.contexts.quo-preview.community.community-membership-list-view :as community-membership-list-view]
             [status-im2.contexts.quo-preview.community.discover-card :as discover-card]
             [status-im2.contexts.quo-preview.dividers.divider-label :as divider-label]
+            [status-im2.contexts.quo-preview.dividers.date :as divider-date]
             [status-im2.contexts.quo-preview.dividers.new-messages :as new-messages]
             [status-im2.contexts.quo-preview.drawers.action-drawers :as drawers]
             [status-im2.contexts.quo-preview.dropdowns.dropdown :as dropdown]
@@ -107,7 +108,10 @@
                :component divider-label/preview-divider-label}
               {:name      :new-messages
                :insets    {:top false}
-               :component new-messages/preview-new-messages}]
+               :component new-messages/preview-new-messages}
+              {:name      :divider-date
+               :insets    {:top false}
+               :component divider-date/preview-divider-date}]
    :drawers [{:name      :action-drawers
               :insets    {:top false}
               :component drawers/preview-action-drawers}]


### PR DESCRIPTION
Fixes #14523 

### Summary
Added Divider Date Component to quo2.

#### Results
Light Mode:
<img src="https://user-images.githubusercontent.com/19279756/207720693-c97fe1fb-e75c-4b20-b172-189d656d167a.png" width="400"/>
<img src="https://user-images.githubusercontent.com/19279756/207720708-de3bc00c-4cdf-4b52-a493-e3edd0c39bf7.png" width="400"/>

Dark Mode:
<img src="https://user-images.githubusercontent.com/19279756/207720746-30ecefd7-f0d9-4143-adb8-4dc24e30f5c5.png" width="400"/>
<img src="https://user-images.githubusercontent.com/19279756/207720751-deb10656-17e3-4b39-9b56-4abb497d9506.png" width="400"/>

### Review notes
- Please check the file structure/naming(I'm following Figma structure).

### Testing notes
- Test in both Light & Dark modes.

#### Platforms
- Android
- iOS

#### Areas that may be impacted
- Chats

##### Functional
- 1-1 chats
- public chats
- group chats


### Steps to test
- Open Status.
- Open any chat.
- Check the date divider style.
- Clicking on the date divider should close Keyboard.

status: ready
