### PR TITLE
moving security from status-im namespace to root level utils directory

### DIFF
--- a/doc/decisions/0007-masking-sensitive-data.md
+++ b/doc/decisions/0007-masking-sensitive-data.md
@@ -20,6 +20,8 @@ printed out by mistake in a log entry (see https://github.com/status-im/status-m
 To minimize the risk of leaking passwords through logs, we should not pass
 passwords as strings in our codebase. We introduced a new type `MaskedData` in
 `status-im.utils.security`.
+update (16-Dec-2022) `status-im.utils.security` is now moved over to `utils.security.core` 
+
 We use `(security/mask-data <data to hide>` to wrap sensitive data into this
 type and then use `(security/unmask <masked-data>)` to get the plaintext back.
 

--- a/src/status_im/integration_test.cljs
+++ b/src/status_im/integration_test.cljs
@@ -6,7 +6,7 @@
             status-im.events
             status-im2.navigation.core
             [status-im.chat.models :as chat.models]
-            [status-im.utils.security :as security]
+            [utils.security.core :as security]
             [status-im.multiaccounts.logout.core :as logout]
             [status-im.transport.core :as transport]
             status-im2.subs.root ;;so integration tests can run independently
@@ -103,7 +103,7 @@
    (initialize-app!) ; initialize app
    (rf-test/wait-for
     [:setup/initialize-view]
-    (generate-and-derive-addresses!) ; generate 5 new keys      
+    (generate-and-derive-addresses!) ; generate 5 new keys
     (rf-test/wait-for
      [:multiaccount-generate-and-derive-addresses-success]
      (assert-multiaccount-loaded) ; assert keys are generated

--- a/src/status_im/keycard/change_pin.cljs
+++ b/src/status_im/keycard/change_pin.cljs
@@ -5,7 +5,7 @@
             [status-im.utils.fx :as fx]
             [taoensso.timbre :as log]
             [status-im.keycard.common :as common]
-            [status-im.utils.security :as security]))
+            [utils.security.core :as security]))
 
 (fx/defn change-credentials-pressed
   {:events [:keycard-settings.ui/change-credentials-pressed]}

--- a/src/status_im/keycard/recovery.cljs
+++ b/src/status_im/keycard/recovery.cljs
@@ -17,7 +17,7 @@
             [status-im.native-module.core :as status]
             [status-im.popover.core :as popover]
             [status-im.utils.types :as types]
-            [status-im.utils.security :as security]
+            [utils.security.core :as security]
             [status-im.utils.keychain.core :as keychain]
             [status-im.utils.platform :as platform]))
 

--- a/src/status_im/multiaccounts/create/core.cljs
+++ b/src/status_im/multiaccounts/create/core.cljs
@@ -10,7 +10,7 @@
             [quo.design-system.colors :as colors]
             [status-im.utils.config :as config]
             [status-im.utils.fx :as fx]
-            [status-im.utils.security :as security]
+            [utils.security.core :as security]
             [status-im.utils.signing-phrase.core :as signing-phrase]
             [status-im.utils.types :as types]))
 

--- a/src/status_im/multiaccounts/key_storage/core.cljs
+++ b/src/status_im/multiaccounts/key_storage/core.cljs
@@ -11,7 +11,7 @@
             [status-im2.navigation.events :as navigation]
             [status-im.popover.core :as popover]
             [status-im.utils.fx :as fx]
-            [status-im.utils.security :as security]
+            [utils.security.core :as security]
             [status-im.ethereum.core :as ethereum]
             [status-im.i18n.i18n :as i18n]
             [status-im.utils.types :as types]

--- a/src/status_im/multiaccounts/key_storage/core_test.cljs
+++ b/src/status_im/multiaccounts/key_storage/core_test.cljs
@@ -2,7 +2,7 @@
   (:require [cljs.test :refer-macros [deftest is testing]]
             [clojure.string :as string]
             [status-im.multiaccounts.key-storage.core :as models]
-            [status-im.utils.security :as security]))
+            [utils.security.core :as security]))
 
 (deftest move-keystore-checked
   (testing "Checks checkbox on-press"

--- a/src/status_im/multiaccounts/login/core.cljs
+++ b/src/status_im/multiaccounts/login/core.cljs
@@ -21,7 +21,7 @@
             [status-im.utils.fx :as fx]
             [status-im.utils.keychain.core :as keychain]
             [status-im2.setup.log :as logging]
-            [status-im.utils.security :as security]
+            [utils.security.core :as security]
             [status-im.utils.types :as types]
             [status-im.utils.utils :as utils]
             [status-im.wallet.core :as wallet]

--- a/src/status_im/multiaccounts/recover/core.cljs
+++ b/src/status_im/multiaccounts/recover/core.cljs
@@ -12,7 +12,7 @@
             [status-im.popover.core :as popover]
             [status-im2.navigation.events :as navigation]
             [status-im.utils.fx :as fx]
-            [status-im.utils.security :as security]
+            [utils.security.core :as security]
             [status-im.utils.types :as types]
             [status-im.utils.utils :as utils]
             [status-im.bottom-sheet.core :as bottom-sheet]

--- a/src/status_im/multiaccounts/recover/core_test.cljs
+++ b/src/status_im/multiaccounts/recover/core_test.cljs
@@ -2,7 +2,7 @@
   (:require [cljs.test :refer-macros [deftest is testing]]
             [status-im.multiaccounts.recover.core :as models]
             [status-im.multiaccounts.create.core :as multiaccounts.create]
-            [status-im.utils.security :as security]))
+            [utils.security.core :as security]))
 
 ;;;; helpers
 

--- a/src/status_im/multiaccounts/reset_password/core.cljs
+++ b/src/status_im/multiaccounts/reset_password/core.cljs
@@ -3,7 +3,7 @@
             [status-im.utils.fx :as fx]
             [status-im.utils.types :as types]
             [clojure.string :as string]
-            [status-im.utils.security :as security]
+            [utils.security.core :as security]
             [status-im.utils.keychain.core :as keychain]
             [status-im.popover.core :as popover]
             [status-im.native-module.core :as status]

--- a/src/status_im/router/core.cljs
+++ b/src/status_im/router/core.cljs
@@ -10,7 +10,7 @@
             [status-im.ethereum.stateofus :as stateofus]
             [status-im.utils.db :as utils.db]
             [status-im.utils.http :as http]
-            [status-im.utils.security :as security]
+            [utils.security.core :as security]
             [status-im.utils.wallet-connect :as wallet-connect]
             [status-im.constants :as constants]
             [taoensso.timbre :as log]))

--- a/src/status_im/signing/core.cljs
+++ b/src/status_im/signing/core.cljs
@@ -14,7 +14,7 @@
             [status-im.utils.fx :as fx]
             [status-im.utils.hex :as utils.hex]
             [status-im.utils.money :as money]
-            [status-im.utils.security :as security]
+            [utils.security.core :as security]
             [status-im.utils.types :as types]
             [status-im.utils.utils :as utils]
             [status-im.wallet.prices :as prices]

--- a/src/status_im/ui/screens/chat/message/link_preview.cljs
+++ b/src/status_im/ui/screens/chat/message/link_preview.cljs
@@ -3,7 +3,7 @@
             [quo.core :as quo]
             [re-frame.core :as re-frame]
             [status-im.ui.components.react :as react]
-            [status-im.utils.security :as security]
+            [utils.security.core :as security]
             [status-im.i18n.i18n :as i18n]
             [status-im.ui.screens.chat.message.styles :as styles]
             [status-im.react-native.resources :as resources]

--- a/src/status_im/ui/screens/chat/message/message.cljs
+++ b/src/status_im/ui/screens/chat/message/message.cljs
@@ -14,7 +14,7 @@
             [status-im.ui.screens.chat.message.gap :as message.gap]
             [status-im.ui.screens.chat.styles.message.message-old :as style]
             [status-im.ui.screens.chat.utils :as chat.utils]
-            [status-im.utils.security :as security]
+            [utils.security.core :as security]
             [status-im.ui.screens.chat.message.reactions-old :as reactions]
             [status-im.ui.screens.chat.image.preview.views :as preview]
             [quo.core :as quo]

--- a/src/status_im/ui/screens/keycard/pairing/views.cljs
+++ b/src/status_im/ui/screens/keycard/pairing/views.cljs
@@ -3,7 +3,7 @@
             [reagent.core :as reagent]
             [status-im.ui.components.toolbar :as toolbar]
             [status-im.i18n.i18n :as i18n]
-            [status-im.utils.security :as security]
+            [utils.security.core :as security]
             [quo.react-native :as rn]
             [quo.core :as quo]))
 

--- a/src/status_im/ui/screens/multiaccounts/key_storage/views.cljs
+++ b/src/status_im/ui/screens/multiaccounts/key_storage/views.cljs
@@ -16,7 +16,7 @@
             [status-im.ui.components.accordion :as accordion]
             [status-im.ui.screens.multiaccounts.views :as multiaccounts.views]
             [status-im.ui.screens.multiaccounts.key-storage.styles :as styles]
-            [status-im.utils.security]))
+            [utils.security.core]))
 
 (defn local-topbar [subtitle action]
   [topbar/topbar (merge {:title   (i18n/label :t/key-managment)
@@ -214,7 +214,7 @@
       [quo/text-input
        {:secure-text-entry   true
         :placeholder         (i18n/label :t/current-password)
-        :on-change-text      #(re-frame/dispatch [::multiaccounts.key-storage/password-changed (status-im.utils.security/mask-data %)])
+        :on-change-text      #(re-frame/dispatch [::multiaccounts.key-storage/password-changed (utils.security.core/mask-data %)])
         :accessibility-label :enter-password-input
         :auto-capitalize     :none
         :error               migration-password-error
@@ -325,20 +325,20 @@
     ;; Enter seed phrase
 
     ;; invalid seed shape
-    #_(re-frame/dispatch [::multiaccounts.key-storage/seed-phrase-input-changed (status-im.utils.security/mask-data "h h h h h h h h h h h h")])
+    #_(re-frame/dispatch [::multiaccounts.key-storage/seed-phrase-input-changed (utils.security.core/mask-data "h h h h h h h h h h h h")])
 
     ;; valid seed for Trusty Candid Bighornedsheep
     ;; If you try to select Dim Venerated Yaffle, but use this seed instead, validate-seed-against-key-uid will fail miserably
     #_(re-frame/dispatch [::multiaccounts.key-storage/seed-phrase-input-changed
-                          (status-im.utils.security/mask-data "disease behave roof exile ghost head carry item tumble census rocket champion")])
+                          (utils.security.core/mask-data "disease behave roof exile ghost head carry item tumble census rocket champion")])
 
     ;; valid seed for Swiffy Warlike Seagull
     #_(re-frame/dispatch [::multiaccounts.key-storage/seed-phrase-input-changed
-                          (status-im.utils.security/mask-data "dirt agent garlic merge tuna leaf congress hedgehog absent dish pizza scrap")])
+                          (utils.security.core/mask-data "dirt agent garlic merge tuna leaf congress hedgehog absent dish pizza scrap")])
 
     ;; valid seed for Dim Venerated Yaffle (this is just a test account, okay to leak seed)
     (re-frame/dispatch [::multiaccounts.key-storage/seed-phrase-input-changed
-                        (status-im.utils.security/mask-data "rocket mixed rebel affair umbrella legal resemble scene virus park deposit cargo")])
+                        (utils.security.core/mask-data "rocket mixed rebel affair umbrella legal resemble scene virus park deposit cargo")])
 
     ;; Click choose storage
     (re-frame/dispatch [::multiaccounts.key-storage/choose-storage-pressed])

--- a/src/status_im/ui/screens/multiaccounts/login/views.cljs
+++ b/src/status_im/ui/screens/multiaccounts/login/views.cljs
@@ -8,7 +8,7 @@
             [status-im.ui.screens.multiaccounts.login.styles :as styles]
             [status-im.ui.screens.multiaccounts.styles :as ast]
             [status-im.utils.platform :as platform]
-            [status-im.utils.security :as security]
+            [utils.security.core :as security]
             [status-im.utils.utils :as utils]
             [quo.core :as quo]
             [status-im.ui.components.icons.icons :as icons]

--- a/src/status_im/ui/screens/multiaccounts/recover/views.cljs
+++ b/src/status_im/ui/screens/multiaccounts/recover/views.cljs
@@ -7,7 +7,7 @@
             [status-im.keycard.recovery :as keycard]
             [status-im.i18n.i18n :as i18n]
             [status-im2.setup.config :as config]
-            [status-im.utils.security]
+            [utils.security.core]
             [quo.design-system.colors :as colors]
             [quo.core :as quo]
             [status-im.qr-scanner.core :as qr-scanner]
@@ -114,7 +114,7 @@
 
     ;; Enter seed phrase for Dim Venerated Yaffle
     (re-frame/dispatch [:multiaccounts.recover/enter-phrase-input-changed
-                        (status-im.utils.security/mask-data "rocket mixed rebel affair umbrella legal resemble scene virus park deposit cargo")])
+                        (utils.security.core/mask-data "rocket mixed rebel affair umbrella legal resemble scene virus park deposit cargo")])
 
     ;; Recover multiaccount
     (re-frame/dispatch [:multiaccounts.recover/enter-phrase-next-pressed])

--- a/src/status_im/ui/screens/multiaccounts/views.cljs
+++ b/src/status_im/ui/screens/multiaccounts/views.cljs
@@ -6,7 +6,7 @@
             [status-im.ui.screens.multiaccounts.styles :as styles]
             [status-im.ui.components.list.views :as list]
             [status-im.ui.components.react :as react]
-            [status-im.utils.security :as security]
+            [utils.security.core :as security]
             [status-im.i18n.i18n :as i18n]
             [quo.design-system.colors :as colors]
             [status-im.ui.components.toolbar :as toolbar]

--- a/src/status_im/ui/screens/onboarding/password/views.cljs
+++ b/src/status_im/ui/screens/onboarding/password/views.cljs
@@ -4,7 +4,7 @@
             [status-im.ui.components.toolbar :as toolbar]
             [status-im.i18n.i18n :as i18n]
             [status-im.constants :as const]
-            [status-im.utils.security :as security]
+            [utils.security.core :as security]
             [quo.react-native :as rn]
             [quo.core :as quo]))
 

--- a/src/status_im/ui/screens/onboarding/phrase/view.cljs
+++ b/src/status_im/ui/screens/onboarding/phrase/view.cljs
@@ -4,7 +4,7 @@
             [quo.design-system.colors :as colors]
             [status-im.i18n.i18n :as i18n]
             [re-frame.core :as re-frame]
-            [status-im.utils.security :as security]
+            [utils.security.core :as security]
             [quo.core :as quo]
             [status-im.utils.datetime :as datetime]
             [status-im.ui.screens.onboarding.views :as ui]

--- a/src/status_im/ui/screens/privacy_and_security_settings/delete_profile.cljs
+++ b/src/status_im/ui/screens/privacy_and_security_settings/delete_profile.cljs
@@ -6,7 +6,7 @@
             [re-frame.core :as re-frame]
             [status-im.i18n.i18n :as i18n]
             [reagent.core :as reagent]
-            [status-im.utils.security :as security]
+            [utils.security.core :as security]
             [status-im.ui.screens.privacy-and-security-settings.events :as delete-profile]
             status-im.keycard.delete-key))
 

--- a/src/status_im/ui/screens/privacy_and_security_settings/events.cljs
+++ b/src/status_im/ui/screens/privacy_and_security_settings/events.cljs
@@ -1,7 +1,7 @@
 (ns status-im.ui.screens.privacy-and-security-settings.events
   (:require [status-im.utils.fx :as fx]
             [re-frame.core :as re-frame]
-            [status-im.utils.security :as security]
+            [utils.security.core :as security]
             [status-im.native-module.core :as status]
             [status-im.ethereum.core :as ethereum]
             [status-im.utils.types :as types]

--- a/src/status_im/ui/screens/reset_password/views.cljs
+++ b/src/status_im/ui/screens/reset_password/views.cljs
@@ -6,7 +6,7 @@
             [quo.design-system.colors :as colors]
             [status-im.ui.components.icons.icons :as icons]
             [status-im.multiaccounts.reset-password.core :as reset-password]
-            [status-im.utils.security :as security]
+            [utils.security.core :as security]
             [status-im.ui.components.toolbar :as toolbar])
   (:require-macros [status-im.utils.views :refer [defview letsubs]]))
 

--- a/src/status_im/ui/screens/signing/views.cljs
+++ b/src/status_im/ui/screens/signing/views.cljs
@@ -23,7 +23,7 @@
             [status-im.ui.screens.signing.styles :as styles]
             [status-im.ui.screens.wallet.components.views :as wallet.components]
             [status-im.utils.platform :as platform]
-            [status-im.utils.security :as security]
+            [utils.security.core :as security]
             [status-im.utils.types :as types]
             [status-im.utils.utils :as utils]
             [status-im.wallet.utils :as wallet.utils]))

--- a/src/status_im/ui/screens/wallet/account_settings/views.cljs
+++ b/src/status_im/ui/screens/wallet/account_settings/views.cljs
@@ -10,7 +10,7 @@
             [reagent.core :as reagent]
             [quo.core :as quo]
             [status-im.ui.components.topbar :as topbar]
-            [status-im.utils.security :as security]))
+            [utils.security.core :as security]))
 
 (defn not-valid-password? [password]
   (< (count (security/safe-unmask-data password)) 6))

--- a/src/status_im/ui/screens/wallet/add_new/views.cljs
+++ b/src/status_im/ui/screens/wallet/add_new/views.cljs
@@ -13,7 +13,7 @@
             [status-im.ui.components.icons.icons :as icons]
             [status-im.ui.screens.wallet.account-settings.views :as account-settings]
             [status-im.ethereum.core :as ethereum]
-            [status-im.utils.security :as security]
+            [utils.security.core :as security]
             [clojure.string :as string]
             [quo.core :as quo]))
 

--- a/src/status_im/ui/screens/wallet_connect/session_proposal/views.cljs
+++ b/src/status_im/ui/screens/wallet_connect/session_proposal/views.cljs
@@ -4,7 +4,7 @@
             [status-im.ui.components.react :as react]
             [status-im.i18n.i18n :as i18n]
             [status-im.utils.utils :as status.utils]
-            [status-im.utils.security]
+            [utils.security.core]
             [quo.design-system.colors :as colors]
             [quo.core :as quo]
             [status-im.ui.components.icons.icons :as icons]

--- a/src/status_im/ui2/screens/chat/messages/message.cljs
+++ b/src/status_im/ui2/screens/chat/messages/message.cljs
@@ -36,7 +36,7 @@
             [status-im.ui2.screens.chat.components.reply :as components.reply]
             [status-im.utils.config :as config]
             [status-im.utils.datetime :as time]
-            [status-im.utils.security :as security]
+            [utils.security.core :as security]
             [status-im.utils.utils :as utils]
             [status-im2.contexts.chat.home.chat-list-item.view :as home.chat-list-item]
             [utils.re-frame :as rf])

--- a/src/status_im/utils/keychain/core.cljs
+++ b/src/status_im/utils/keychain/core.cljs
@@ -2,7 +2,7 @@
   (:require [re-frame.core :as re-frame]
             [taoensso.timbre :as log]
             [status-im.utils.platform :as platform]
-            [status-im.utils.security :as security]
+            [utils.security.core :as security]
             [status-im.native-module.core :as status]
             [status-im.utils.fx :as fx]
             [clojure.string :as string]

--- a/src/status_im/wallet/accounts/core.cljs
+++ b/src/status_im/wallet/accounts/core.cljs
@@ -15,7 +15,7 @@
             [status-im.utils.types :as types]
             [status-im.wallet.core :as wallet]
             [clojure.string :as string]
-            [status-im.utils.security :as security]
+            [utils.security.core :as security]
             [status-im.multiaccounts.core :as multiaccounts]
             [status-im.ethereum.mnemonic :as mnemonic]
             [taoensso.timbre :as log]

--- a/src/status_im2/contexts/syncing/events.cljs
+++ b/src/status_im2/contexts/syncing/events.cljs
@@ -1,6 +1,6 @@
 (ns status-im2.contexts.syncing.events
   (:require [utils.re-frame :as rf]
-            [status-im.utils.security :as security]
+            [utils.security.core :as security]
             [taoensso.timbre :as log]
             [status-im.native-module.core :as status]
             [status-im2.contexts.syncing.sheets.enter-password.view :as sheet]))

--- a/src/status_im2/subs/multiaccount.cljs
+++ b/src/status_im2/subs/multiaccount.cljs
@@ -2,7 +2,7 @@
   (:require [re-frame.core :as re-frame]
             [status-im.multiaccounts.core :as multiaccounts]
             [status-im.ethereum.core :as ethereum]
-            [status-im.utils.security :as security]
+            [utils.security.core :as security]
             [cljs.spec.alpha :as spec]
             [status-im.fleet.core :as fleet]
             [clojure.string :as string]

--- a/src/utils/security/core.cljs
+++ b/src/utils/security/core.cljs
@@ -1,5 +1,5 @@
-(ns status-im.utils.security
-  (:require [status-im.utils.security-html :as h]))
+(ns utils.security.core
+  (:require [utils.security.security-html :as h]))
 
 (defprotocol Unmaskable
   ;; Retrieve the stored value.

--- a/src/utils/security/security_html.cljs
+++ b/src/utils/security/security_html.cljs
@@ -1,4 +1,4 @@
-(ns status-im.utils.security-html
+(ns utils.security.security-html
   (:require [clojure.string :as string]))
 
 ; Taken from https://github.com/sindresorhus/is-html

--- a/src/utils/security/security_html_test.cljs
+++ b/src/utils/security/security_html_test.cljs
@@ -1,6 +1,6 @@
-(ns status-im.utils.security-html-test
+(ns utils.security.security-html-test
   (:require [cljs.test :refer-macros [deftest is testing]]
-            [status-im.utils.security-html :as s]))
+            [utils.security.security-html :as s]))
 
 (deftest with-doctype
   (is (s/is-html? "<!doctype html>"))

--- a/src/utils/security/security_test.cljs
+++ b/src/utils/security/security_test.cljs
@@ -1,6 +1,6 @@
-(ns status-im.utils.security-test
+(ns utils.security.security-test
   (:require [cljs.test :refer-macros [deftest is testing]]
-            [status-im.utils.security :as security]))
+            [utils.security.core :as security]))
 
 (def rtlo-link "‮http://google.com")
 (def rtlo-link-text "blah blah ‮  some other blah blah http://google.com blah bash")


### PR DESCRIPTION
security related files below are moved from : 

`src/status_im/utils/security.cljs` to `src/utils/security/core.cljs`
`src/status_im/utils/security_html.cljs` to `src/utils/security/security_html.cljs`
`src/status_im/utils/security_html_test.cljs` to `src/utils/security/security_html_test.cljs`
`src/status_im/utils/security_test.cljs` to `src/utils/security/security_test.cljs`

I have updated all usage of security from old namespace to the new one.

fixes #14551

status: ready 
