### PR TITLE
[Update][#14555] Channel name update in Context Tag

### DIFF
--- a/src/quo2/components/tags/context_tags.cljs
+++ b/src/quo2/components/tags/context_tags.cljs
@@ -60,11 +60,11 @@
 (defn context-tag
   [_ _]
   (fn [params photo name channel-name]
-    (let [text-style  (params :text-style)
+    (let [text-style  (:text-style params)
           text-params {:weight :medium
                        :size   :paragraph-2
                        :style  (assoc text-style :justify-content :center)}
-          icon-color   (colors/theme-colors colors/neutral-50 colors/neutral-40)]
+          icon-color  (colors/theme-colors colors/neutral-50 colors/neutral-40)]
       [base-tag (assoc-in params [:style :padding-left] 3)
        [rn/image
         {:style {:width 20

--- a/src/quo2/components/tags/context_tags.cljs
+++ b/src/quo2/components/tags/context_tags.cljs
@@ -1,5 +1,6 @@
 (ns quo2.components.tags.context-tags
   (:require [quo2.components.avatars.group-avatar :as group-avatar]
+            [quo2.components.icon :as icons]
             [quo2.components.markdown.text :as text]
             [quo2.foundations.colors :as colors]
             [quo2.theme :as quo2.theme]
@@ -57,20 +58,31 @@
       (trim-public-key public-key)]]))
 
 (defn context-tag
-  [params photo name]
-  (let [text-style (params :text-style)]
+  [params photo name channel-name]
+  (let [text-style (params :text-style)
+        text-params (merge {:weight :medium
+                            :size :paragraph-2}
+                           {:style (merge text-style {:justify-content :center})})
+        icon-color (colors/theme-colors colors/neutral-50 colors/neutral-40)]
     [base-tag (assoc-in params [:style :padding-left] 3)
      [rn/image
-      {:style  {:width            20
-                :border-radius    10
-                :background-color :white
-                :height           20}
+      {:style {:width 20
+               :border-radius 10
+               :background-color :white
+               :height 20}
        :source photo}]
-     [text/text
-      (merge {:weight :medium
-              :size   :paragraph-2}
-             {:style text-style})
-      (str " " name)]]))
+     [rn/view
+      {:style {:align-items :center
+               :flex-direction :row}}
+      [text/text text-params (str " " name)]
+      (when channel-name
+        [:<>
+         [icons/icon
+          :main-icons/chevron-right
+          {:color  icon-color
+           :width  16
+           :height 16}]
+         [text/text text-params (str "#" " " channel-name)]])]]))
 
 (defn user-avatar-tag
   []

--- a/src/quo2/components/tags/context_tags.cljs
+++ b/src/quo2/components/tags/context_tags.cljs
@@ -58,31 +58,31 @@
       (trim-public-key public-key)]]))
 
 (defn context-tag
-  [params photo name channel-name]
-  (let [text-style (params :text-style)
-        text-params (merge {:weight :medium
-                            :size :paragraph-2}
-                           {:style (merge text-style {:justify-content :center})})
-        icon-color (colors/theme-colors colors/neutral-50 colors/neutral-40)]
-    [base-tag (assoc-in params [:style :padding-left] 3)
-     [rn/image
-      {:style {:width 20
-               :border-radius 10
-               :background-color :white
-               :height 20}
-       :source photo}]
-     [rn/view
-      {:style {:align-items :center
-               :flex-direction :row}}
-      [text/text text-params (str " " name)]
-      (when channel-name
-        [:<>
-         [icons/icon
-          :main-icons/chevron-right
-          {:color  icon-color
-           :width  16
-           :height 16}]
-         [text/text text-params (str "#" " " channel-name)]])]]))
+  [_ _]
+  (fn [params photo name channel-name]
+    (let [text-style  (params :text-style)
+          text-params {:weight :medium
+                       :size   :paragraph-2
+                       :style  (assoc text-style :justify-content :center)}
+          icon-color   (colors/theme-colors colors/neutral-50 colors/neutral-40)]
+      [base-tag (assoc-in params [:style :padding-left] 3)
+       [rn/image
+        {:style {:width 20
+                 :border-radius 10
+                 :background-color :white
+                 :height 20}
+         :source photo}]
+       [rn/view
+        {:style {:align-items :center
+                 :flex-direction :row}}
+        [text/text text-params (str " " name)]
+        (when channel-name
+          [:<>
+           [icons/icon
+            :i/chevron-right
+            {:color icon-color
+             :size  16}]
+           [text/text text-params (str "# " channel-name)]])]])))
 
 (defn user-avatar-tag
   []

--- a/src/status_im2/contexts/quo_preview/tags/context_tags.cljs
+++ b/src/status_im2/contexts/quo_preview/tags/context_tags.cljs
@@ -28,11 +28,22 @@
               {:key   :avatar
                :value "Avatar"}
               {:key   :group-avatar
-               :value "Group avatar"}]}])
+               :value "Group avatar"}
+              {:key   :context-tag
+               :value "Context tag"}]}])
+
+(def context-tag-descriptor
+  [{:label "Label"
+    :key   :label
+    :type  :text}
+   {:label "Channel Name"
+    :key   :channel-name
+    :type  :text}])
 
 (defn cool-preview
   []
   (let [state (reagent/atom {:label "Name"
+                             :channel-name "Channel"
                              :type  :group-avatar})]
     (fn []
       (let [contacts             {example-pk  {:public-key example-pk
@@ -56,6 +67,7 @@
                                    "Please select a user")
             descriptor
             (cond
+              (= (:type @state) :context-tag)  (into main-descriptor context-tag-descriptor)
               (= (:type @state) :group-avatar) (conj main-descriptor
                                                      {:label "Label"
                                                       :key   :label
@@ -80,6 +92,8 @@
             :flex-direction   :row
             :justify-content  :center}
            (case (:type @state)
+             :context-tag
+             [quo2/context-tag group-avatar-default-params {:uri example-photo2}  (:label @state) (:channel-name @state)]
              :group-avatar
              [quo2/group-avatar-tag (:label @state) group-avatar-default-params]
              :public-key


### PR DESCRIPTION
fixes #14555

### Summary

A minor UI update on the `Context Tag` component to support channel name as this component is extensively used on Activity Center.


#### Platforms

- Android
- iOS

### Steps to test

- Open Status
- Navigate to `Quo2 Preview`
- Open `Context-Tag` under the `tags` section

status: ready
