### PR TITLE
UI Component - Account

### DIFF
--- a/src/quo2/components/avatars/account_avatar.cljs
+++ b/src/quo2/components/avatars/account_avatar.cljs
@@ -24,7 +24,7 @@
 (defn account-avatar
   [{:keys [size icon color]
     :or   {size  80
-           icon  :main-icons/placeholder
+           icon  :i/placeholder
            color :purple}}]
   (let [icon-color           (colors/custom-color-by-theme color 50 60)
         avatar-border-radius (get-border-radius size)

--- a/src/quo2/components/avatars/account_avatar.cljs
+++ b/src/quo2/components/avatars/account_avatar.cljs
@@ -1,12 +1,7 @@
 (ns quo2.components.avatars.account-avatar
   (:require [quo2.components.icon :as icons]
             [quo2.foundations.colors :as colors]
-            [quo2.theme :as theme]
             [react-native.core :as rn]))
-
-(def icon-color-value
-  {:dark  (get-in colors/customization [:dark :purple])
-   :light (get-in colors/customization [:light :purple])})
 
 (defn get-border-radius
   [size]
@@ -27,12 +22,11 @@
     20 11))
 
 (defn account-avatar
-  [{:keys [size icon]
-    :or   {size 80
-           icon :main-icons/placeholder}}]
-  (let [icon-color           (if (theme/dark?)
-                               (:dark icon-color-value)
-                               (:light icon-color-value))
+  [{:keys [size icon color]
+    :or   {size  80
+           icon  :main-icons/placeholder
+           color :purple}}]
+  (let [icon-color           (colors/custom-color-by-theme color 50 60)
         avatar-border-radius (get-border-radius size)
         inner-icon-size      (get-inner-icon-sizes size)]
     [rn/view

--- a/src/quo2/components/settings/accounts/style.cljs
+++ b/src/quo2/components/settings/accounts/style.cljs
@@ -1,13 +1,15 @@
 (ns quo2.components.settings.accounts.style
   (:require [quo2.foundations.colors :as colors]))
 
-(def card {:position      :relative
-           :padding       8
-           :border-radius 16
-           :height        160
-           :width         160})
+(def card
+  {:position      :relative
+   :padding       8
+   :border-radius 16
+   :height        160
+   :width         160})
 
-(defn background-top [custom-color]
+(defn background-top
+  [custom-color]
   {:position                :absolute
    :top                     0
    :border-top-left-radius  16
@@ -18,7 +20,8 @@
                                 (get-in [custom-color 50])
                                 (colors/alpha 0.2))})
 
-(defn background-bottom []
+(defn background-bottom
+  []
   {:position         :absolute
    :top              40
    :border-radius    16
@@ -28,7 +31,8 @@
                       colors/white
                       colors/neutral-90)})
 
-(defn avatar-border []
+(defn avatar-border
+  []
   {:margin          2
    :justify-content :center
    :align-items     :center
@@ -40,23 +44,28 @@
                      colors/white
                      colors/neutral-90)})
 
-(def menu-button-container {:justify-content :center
-                            :align-items     :center
-                            :align-self      :flex-start})
-(defn menu-button-color []
+(def menu-button-container
+  {:justify-content :center
+   :align-items     :center
+   :align-self      :flex-start})
+(defn menu-button-color
+  []
   {:background-color (colors/theme-colors
                       colors/white-opa-40
                       colors/neutral-80-opa-40)})
 
-(defn address-text []
+(defn address-text
+  []
   {:color (colors/theme-colors
            colors/neutral-50
            colors/neutral-40)})
 
-(def card-top {:flex-direction  :row
-               :align-items     :center
-               :justify-content :space-between})
+(def card-top
+  {:flex-direction  :row
+   :align-items     :center
+   :justify-content :space-between})
 
-(def card-bottom {:flex              1
-                  :margin-horizontal 4
-                  :margin-top        4})
+(def card-bottom
+  {:flex              1
+   :margin-horizontal 4
+   :margin-top        4})

--- a/src/quo2/components/settings/accounts/style.cljs
+++ b/src/quo2/components/settings/accounts/style.cljs
@@ -1,0 +1,67 @@
+(ns quo2.components.settings.accounts.style
+  (:require [quo2.foundations.colors :as colors]))
+
+(def card {:position      :relative
+           :padding       8
+           :border-radius 16
+           :height        160
+           :width         160})
+
+;; Card Background
+(defn background-top [custom-color]
+  {:position                :absolute
+   :top                     0
+   :border-top-left-radius  16
+   :border-top-right-radius 16
+   :width                   160
+   :height                  64
+   :background-color        (-> colors/customization
+                                (get-in [custom-color 50])
+                                (colors/alpha 0.2))})
+
+(defn background-bottom []
+  {:position         :absolute
+   :top              40
+   :border-radius    16
+   :width            160
+   :height           120
+   :background-color (colors/theme-colors
+                      colors/white
+                      colors/neutral-90)})
+
+;; Avatar
+(defn avatar-border []
+  {:margin          2
+   :justify-content :center
+   :align-items     :center
+   :width           52
+   :height          52
+   :border-radius   14
+   :border-width    2
+   :border-color    (colors/theme-colors
+                     colors/white
+                     colors/neutral-90)})
+
+;; Menu button
+(def menu-button-container {:justify-content :center
+                            :align-items     :center
+                            :align-self      :flex-start})
+(defn menu-button-color []
+  {:background-color (colors/theme-colors
+                      colors/white-opa-40
+                      colors/neutral-80-opa-40)})
+;; Address text
+(defn address-text []
+  {:color (colors/theme-colors
+           colors/neutral-50
+           colors/neutral-40)})
+
+;; Top content
+(def card-top {:flex-direction  :row
+               :align-items     :center
+               :justify-content :space-between})
+
+;; Bottom content
+(def card-bottom {:flex              1
+                  :margin-horizontal 4
+                  :margin-top        4})

--- a/src/quo2/components/settings/accounts/style.cljs
+++ b/src/quo2/components/settings/accounts/style.cljs
@@ -7,7 +7,6 @@
            :height        160
            :width         160})
 
-;; Card Background
 (defn background-top [custom-color]
   {:position                :absolute
    :top                     0
@@ -29,7 +28,6 @@
                       colors/white
                       colors/neutral-90)})
 
-;; Avatar
 (defn avatar-border []
   {:margin          2
    :justify-content :center
@@ -42,7 +40,6 @@
                      colors/white
                      colors/neutral-90)})
 
-;; Menu button
 (def menu-button-container {:justify-content :center
                             :align-items     :center
                             :align-self      :flex-start})
@@ -50,18 +47,16 @@
   {:background-color (colors/theme-colors
                       colors/white-opa-40
                       colors/neutral-80-opa-40)})
-;; Address text
+
 (defn address-text []
   {:color (colors/theme-colors
            colors/neutral-50
            colors/neutral-40)})
 
-;; Top content
 (def card-top {:flex-direction  :row
                :align-items     :center
                :justify-content :space-between})
 
-;; Bottom content
 (def card-bottom {:flex              1
                   :margin-horizontal 4
                   :margin-top        4})

--- a/src/quo2/components/settings/accounts/view.cljs
+++ b/src/quo2/components/settings/accounts/view.cljs
@@ -28,17 +28,12 @@
   [rn/view {:style style/card}
    [card-background {:custom-color custom-color}]
    [rn/view {:style style/card-top}
-    ;; Avatar
     [avatar {:color custom-color
              :icon  avatar-icon}]
-    ;; Menu buttom
     [menu-button {:on-press on-press-menu}]]
-
    [rn/view {:style style/card-bottom}
-    ;; Account name
     [text/text {:size :paragraph-1, :weight :semi-bold}
      account-name]
-    ;; Account address
     [text/text {:style (style/address-text)
                 :size   :paragraph-2
                 :weight :medium}

--- a/src/quo2/components/settings/accounts/view.cljs
+++ b/src/quo2/components/settings/accounts/view.cljs
@@ -32,9 +32,9 @@
              :icon  avatar-icon}]
     [menu-button {:on-press on-press-menu}]]
    [rn/view {:style style/card-bottom}
-    [text/text {:size :paragraph-1, :weight :semi-bold}
+    [text/text {:size :paragraph-1 :weight :semi-bold}
      account-name]
-    [text/text {:style (style/address-text)
+    [text/text {:style  (style/address-text)
                 :size   :paragraph-2
                 :weight :medium}
      account-address]]])

--- a/src/quo2/components/settings/accounts/view.cljs
+++ b/src/quo2/components/settings/accounts/view.cljs
@@ -1,9 +1,9 @@
 (ns quo2.components.settings.accounts.view
-  (:require [quo.react-native :as rn]
-            [quo2.components.avatars.account-avatar :as av]
+  (:require [quo2.components.avatars.account-avatar :as account-avatar]
             [quo2.components.buttons.button :as button]
             [quo2.components.markdown.text :as text]
-            [quo2.components.settings.accounts.style :as style]))
+            [quo2.components.settings.accounts.style :as style]
+            [react-native.core :as rn]))
 
 (defn card-background
   [{:keys [custom-color]}]
@@ -14,7 +14,7 @@
 (defn avatar
   [avatar-props]
   [rn/view {:style (style/avatar-border)}
-   [av/account-avatar (assoc avatar-props :size 48)]])
+   [account-avatar/account-avatar (assoc avatar-props :size 48)]])
 
 (defn menu-button
   [{:keys [on-press]}]

--- a/src/quo2/components/settings/accounts/view.cljs
+++ b/src/quo2/components/settings/accounts/view.cljs
@@ -10,7 +10,7 @@
    [rn/view {:style (style/background-top custom-color)}]
    [rn/view {:style (style/background-bottom)}]])
 
-(defn avatar [{:keys [_color _icon] :as avatar-props}]
+(defn avatar [avatar-props]
   [rn/view {:style (style/avatar-border)}
    [av/account-avatar (assoc avatar-props :size 48)]])
 

--- a/src/quo2/components/settings/accounts/view.cljs
+++ b/src/quo2/components/settings/accounts/view.cljs
@@ -1,0 +1,45 @@
+(ns quo2.components.settings.accounts.view
+  (:require [quo.react-native :as rn]
+            [quo2.components.avatars.account-avatar :as av]
+            [quo2.components.buttons.button :as button]
+            [quo2.components.markdown.text :as text]
+            [quo2.components.settings.accounts.style :as style]))
+
+(defn card-background [{:keys [custom-color]}]
+  [:<>
+   [rn/view {:style (style/background-top custom-color)}]
+   [rn/view {:style (style/background-bottom)}]])
+
+(defn avatar [{:keys [_color _icon] :as avatar-props}]
+  [rn/view {:style (style/avatar-border)}
+   [av/account-avatar (assoc avatar-props :size 48)]])
+
+(defn menu-button [{:keys [on-press]}]
+  [rn/view {:style style/menu-button-container}
+   [button/button {:style    (style/menu-button-color)
+                   :type     :gray
+                   :icon     true
+                   :size     24
+                   :on-press on-press}
+    :i/more]])
+
+(defn account
+  [{:keys [account-name account-address avatar-icon custom-color on-press-menu]}]
+  [rn/view {:style style/card}
+   [card-background {:custom-color custom-color}]
+   [rn/view {:style style/card-top}
+    ;; Avatar
+    [avatar {:color custom-color
+             :icon  avatar-icon}]
+    ;; Menu buttom
+    [menu-button {:on-press on-press-menu}]]
+
+   [rn/view {:style style/card-bottom}
+    ;; Account name
+    [text/text {:size :paragraph-1, :weight :semi-bold}
+     account-name]
+    ;; Account address
+    [text/text {:style (style/address-text)
+                :size   :paragraph-2
+                :weight :medium}
+     account-address]]])

--- a/src/quo2/components/settings/accounts/view.cljs
+++ b/src/quo2/components/settings/accounts/view.cljs
@@ -5,22 +5,26 @@
             [quo2.components.markdown.text :as text]
             [quo2.components.settings.accounts.style :as style]))
 
-(defn card-background [{:keys [custom-color]}]
+(defn card-background
+  [{:keys [custom-color]}]
   [:<>
    [rn/view {:style (style/background-top custom-color)}]
    [rn/view {:style (style/background-bottom)}]])
 
-(defn avatar [avatar-props]
+(defn avatar
+  [avatar-props]
   [rn/view {:style (style/avatar-border)}
    [av/account-avatar (assoc avatar-props :size 48)]])
 
-(defn menu-button [{:keys [on-press]}]
+(defn menu-button
+  [{:keys [on-press]}]
   [rn/view {:style style/menu-button-container}
-   [button/button {:style    (style/menu-button-color)
-                   :type     :gray
-                   :icon     true
-                   :size     24
-                   :on-press on-press}
+   [button/button
+    {:style    (style/menu-button-color)
+     :type     :gray
+     :icon     true
+     :size     24
+     :on-press on-press}
     :i/more]])
 
 (defn account
@@ -28,13 +32,15 @@
   [rn/view {:style style/card}
    [card-background {:custom-color custom-color}]
    [rn/view {:style style/card-top}
-    [avatar {:color custom-color
-             :icon  avatar-icon}]
+    [avatar
+     {:color custom-color
+      :icon  avatar-icon}]
     [menu-button {:on-press on-press-menu}]]
    [rn/view {:style style/card-bottom}
     [text/text {:size :paragraph-1 :weight :semi-bold}
      account-name]
-    [text/text {:style  (style/address-text)
-                :size   :paragraph-2
-                :weight :medium}
+    [text/text
+     {:style  (style/address-text)
+      :size   :paragraph-2
+      :weight :medium}
      account-address]]])

--- a/src/quo2/core.cljs
+++ b/src/quo2/core.cljs
@@ -46,6 +46,7 @@
    quo2.components.selectors.filter.view
    quo2.components.selectors.selectors
    quo2.components.separator
+   quo2.components.settings.accounts.view
    quo2.components.settings.privacy-option
    quo2.components.tabs.account-selector
    quo2.components.tabs.tabs
@@ -128,3 +129,4 @@
 
 ;;;; SETTINGS
 (def privacy-option quo2.components.settings.privacy-option/card)
+(def account quo2.components.settings.accounts.view/account)

--- a/src/status_im2/contexts/quo_preview/main.cljs
+++ b/src/status_im2/contexts/quo_preview/main.cljs
@@ -63,6 +63,7 @@
    [status-im2.contexts.quo-preview.wallet.lowest-price :as lowest-price]
    [status-im2.contexts.quo-preview.wallet.network-amount :as network-amount]
    [status-im2.contexts.quo-preview.wallet.network-breakdown :as network-breakdown]
+   [status-im2.contexts.quo-preview.settings.accounts :as accounts]
    [status-im2.contexts.quo-preview.wallet.token-overview :as token-overview]))
 
 (def screens-categories
@@ -194,7 +195,10 @@
                             :component selectors/preview-selectors}]
    :settings              [{:name      :privacy-option
                             :insets    {:top false}
-                            :component privacy-option/preview-options}]
+                            :component privacy-option/preview-options}
+                           {:name      :accounts
+                            :insets    {:top false}
+                            :component accounts/preview-accounts}]
    :tabs                  [{:name      :segmented
                             :insets    {:top false}
                             :component segmented/preview-segmented}

--- a/src/status_im2/contexts/quo_preview/settings/accounts.cljs
+++ b/src/status_im2/contexts/quo_preview/settings/accounts.cljs
@@ -3,7 +3,7 @@
             [quo2.components.settings.accounts.view :as quo]
             [quo2.foundations.colors :as colors]
             [react-native.core :as rn]
-            [reagent.core :as r]
+            [reagent.core :as reagent]
             [status-im2.contexts.quo-preview.preview :as preview]))
 
 (def descriptor
@@ -22,12 +22,12 @@
 
 (defn cool-preview
   []
-  (let [state (r/atom {:custom-color    :blue
-                       :account-name    "Booze for Dubai"
-                       :account-address "0x21a ... 49e"
-                       :avatar-icon     :i/placeholder
-                       :on-press-menu   (fn []
-                                          (js/alert "Menu button pressed"))})]
+  (let [state (reagent/atom {:custom-color    :blue
+                             :account-name    "Booze for Dubai"
+                             :account-address "0x21a ... 49e"
+                             :avatar-icon     :i/placeholder
+                             :on-press-menu   (fn []
+                                                (js/alert "Menu button pressed"))})]
     (fn []
       [rn/view
        {:margin-bottom 50

--- a/src/status_im2/contexts/quo_preview/settings/accounts.cljs
+++ b/src/status_im2/contexts/quo_preview/settings/accounts.cljs
@@ -20,7 +20,8 @@
     :key   :account-address
     :type  :text}])
 
-(defn cool-preview []
+(defn cool-preview
+  []
   (let [state (r/atom {:custom-color    :blue
                        :account-name    "Booze for Dubai"
                        :account-address "0x21a ... 49e"
@@ -28,17 +29,20 @@
                        :on-press-menu   (fn []
                                           (js/alert "Menu button pressed"))})]
     (fn []
-      [rn/view {:margin-bottom 50
-                :padding       16}
+      [rn/view
+       {:margin-bottom 50
+        :padding       16}
        [preview/customizer state descriptor]
-       [rn/view {:padding-vertical 100
-                 :align-items      :center
-                 :background-color (colors/theme-colors
-                                    colors/neutral-30
-                                    colors/neutral-95)}
+       [rn/view
+        {:padding-vertical 100
+         :align-items      :center
+         :background-color (colors/theme-colors
+                            colors/neutral-30
+                            colors/neutral-95)}
         [quo/account @state]]])))
 
-(defn preview-accounts []
+(defn preview-accounts
+  []
   [rn/view {:style {:flex 1}}
    [rn/flat-list
     {:flex                      1

--- a/src/status_im2/contexts/quo_preview/settings/accounts.cljs
+++ b/src/status_im2/contexts/quo_preview/settings/accounts.cljs
@@ -24,7 +24,6 @@
   (let [state (r/atom {:custom-color    :blue
                        :account-name    "Booze for Dubai"
                        :account-address "0x21a ... 49e"
-                       ;; Fixed parameters:
                        :avatar-icon     :i/placeholder
                        :on-press-menu   (fn []
                                           (js/alert "Menu button pressed"))})]

--- a/src/status_im2/contexts/quo_preview/settings/accounts.cljs
+++ b/src/status_im2/contexts/quo_preview/settings/accounts.cljs
@@ -10,9 +10,9 @@
   [{:label   "Custom color"
     :key     :custom-color
     :type    :select
-    :options (mapv (fn [[k _]]
-                     {:key k, :value (string/capitalize (name k))})
-                   colors/customization)}
+    :options (map (fn [[k _]]
+                    {:key k, :value (string/capitalize (name k))})
+                  colors/customization)}
    {:label "Account name"
     :key   :account-name
     :type  :text}

--- a/src/status_im2/contexts/quo_preview/settings/accounts.cljs
+++ b/src/status_im2/contexts/quo_preview/settings/accounts.cljs
@@ -11,7 +11,7 @@
     :key     :custom-color
     :type    :select
     :options (map (fn [[k _]]
-                    {:key k, :value (string/capitalize (name k))})
+                    {:key k :value (string/capitalize (name k))})
                   colors/customization)}
    {:label "Account name"
     :key   :account-name

--- a/src/status_im2/contexts/quo_preview/settings/accounts.cljs
+++ b/src/status_im2/contexts/quo_preview/settings/accounts.cljs
@@ -1,0 +1,48 @@
+(ns status-im2.contexts.quo-preview.settings.accounts
+  (:require [clojure.string :as string]
+            [quo2.components.settings.accounts.view :as quo2]
+            [quo2.foundations.colors :as colors]
+            [react-native.core :as rn]
+            [reagent.core :as r]
+            [status-im2.contexts.quo-preview.preview :as preview]))
+
+(def descriptor
+  [{:label   "Custom color"
+    :key     :custom-color
+    :type    :select
+    :options (mapv (fn [[k _]]
+                     {:key k, :value (string/capitalize (name k))})
+                   colors/customization)}
+   {:label "Account name"
+    :key   :account-name
+    :type  :text}
+   {:label "Account address"
+    :key   :account-address
+    :type  :text}])
+
+(defn cool-preview []
+  (let [state (r/atom {:custom-color    :blue
+                       :account-name    "Booze for Dubai"
+                       :account-address "0x21a ... 49e"
+                       ;; Fixed parameters:
+                       :avatar-icon     :main-icons/placeholder
+                       :on-press-menu   (fn []
+                                          (prn "menu pressed"))})]
+    (fn []
+      [rn/view {:margin-bottom 50
+                :padding       16}
+       [preview/customizer state descriptor]
+       [rn/view {:padding-vertical 100
+                 :align-items      :center
+                 :background-color (colors/theme-colors
+                                    colors/neutral-30
+                                    colors/neutral-95)}
+        [quo2/account @state]]])))
+
+(defn preview-accounts []
+  [rn/view {:style {:flex 1}}
+   [rn/flat-list
+    {:flex                      1
+     :keyboardShouldPersistTaps :always
+     :header                    [cool-preview]
+     :key-fn                    str}]])

--- a/src/status_im2/contexts/quo_preview/settings/accounts.cljs
+++ b/src/status_im2/contexts/quo_preview/settings/accounts.cljs
@@ -1,6 +1,6 @@
 (ns status-im2.contexts.quo-preview.settings.accounts
   (:require [clojure.string :as string]
-            [quo2.components.settings.accounts.view :as quo2]
+            [quo2.components.settings.accounts.view :as quo]
             [quo2.foundations.colors :as colors]
             [react-native.core :as rn]
             [reagent.core :as r]
@@ -36,7 +36,7 @@
                  :background-color (colors/theme-colors
                                     colors/neutral-30
                                     colors/neutral-95)}
-        [quo2/account @state]]])))
+        [quo/account @state]]])))
 
 (defn preview-accounts []
   [rn/view {:style {:flex 1}}

--- a/src/status_im2/contexts/quo_preview/settings/accounts.cljs
+++ b/src/status_im2/contexts/quo_preview/settings/accounts.cljs
@@ -27,7 +27,7 @@
                        ;; Fixed parameters:
                        :avatar-icon     :i/placeholder
                        :on-press-menu   (fn []
-                                          (prn "menu pressed"))})]
+                                          (js/alert "Menu button pressed"))})]
     (fn []
       [rn/view {:margin-bottom 50
                 :padding       16}

--- a/src/status_im2/contexts/quo_preview/settings/accounts.cljs
+++ b/src/status_im2/contexts/quo_preview/settings/accounts.cljs
@@ -25,7 +25,7 @@
                        :account-name    "Booze for Dubai"
                        :account-address "0x21a ... 49e"
                        ;; Fixed parameters:
-                       :avatar-icon     :main-icons/placeholder
+                       :avatar-icon     :i/placeholder
                        :on-press-menu   (fn []
                                           (prn "menu pressed"))})]
     (fn []


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

Fixes #14603

### Summary

[comment]: # (Summarise the problem and how the pull request solves it)

It implements the [Accounts Component](https://www.figma.com/file/WQZcp6S0EnzxdTL4taoKDv/Design-System?node-id=2051%3A32614&t=5QOzYVaAMhY5MSPN-0) for both dark & white themes.

It solves it by adding the following namespaces:
- Styles: `quo2.components.settings.accounts.style`.
- Hiccup structure: `quo2.components.settings.accounts.view`.
- Preview-screen: `status-im2.contexts.quo-preview.settings.accounts`.

Additionally, 
- Adds the new component to `status-im2.contexts.quo-preview.main`.
- Solves an issue of the `account-avatar` component (in `quo2.components.avatars.account-avatar`) since this issue required it.

### Review notes
I splitted the code in three commits in order to make the code review easier, these commits do the following:

####  a0d0c5c02621b598a749453641df4fa0c73c4d5c  Fix account-avatar color & allow color customization 
The avatar component preview isn't working in the develop branch, it's due to wrongly extracting the `:purple` theme color from `quo2.foundations.colors/customization`, I fixed it by using `custom-color-by-theme`

Additionally, the avatar color was fixed to be `:purple`, but in this issue I needed to put it in different colors, so now `account-avatar` receives a `:color` key which defaults to `:purple` if not given.

#### a43794ba3f444f00fa7ea83776c992929632a0de Implement accounts component
Implements the Accounts component and adds it to `quo2.core`.

#### 4f1afcb86288c9fe1ec6ee2168532db9ed79a725 Create account-component preview
Creates a preview in the Settings section to test it.

### Testing notes
Navigate to `Profile -> Quo2.0 Preview -> Settings -> Accounts` in the app, switch the theme to test if the implementation meet the design.

- The menu button can be pressed, it prints in the terminal a string.
- A custom color, account name & account address can be set in the preview screen.

#### Platforms
- Android
- iOS

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional
None, since it is only in a preview screen.

### Steps to test
Compile & run the app, login and naviage to  `Profile -> Quo2.0 Preview -> Settings -> Accounts`

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: waiting for review.