### PR TITLE
chore: tweak zprint conf

### DIFF
--- a/.zprintrc
+++ b/.zprintrc
@@ -8,6 +8,8 @@
              ;; no comma in map
              :no-comma
 
+             :how-to-ns
+
              :custom-justify
 
              ;; respect all newlines
@@ -26,9 +28,6 @@
   "deftest-sub"     :arg1-body
   "wait-for"        :arg1-body
   "with-deps-check" :arg1-body
-  "ns"              [:arg1-body
-                     {:list   {:respect-nl? false}
-                      :vector {:respect-nl? false}}]
   "->"              [:noarg1-body
                      {:list               {:constant-pair? false :force-nl? false}
                       :next-inner-restore [[:list :constant-pair?]]}]

--- a/.zprintrc
+++ b/.zprintrc
@@ -40,7 +40,6 @@
  :remove    {:fn-force-nl #{:noarg1-body}}
  :style-map
  {:no-comma       {:map {:comma? false}}
-  :rj-var         {:pair {:justify {:max-variance 1000}}}
   :custom-justify
   {:doc     "Justify everything using pre-1.1.2 approach"
    :binding {:justify? true :justify {:max-variance 1000}}

--- a/.zprintrc
+++ b/.zprintrc
@@ -8,8 +8,6 @@
              ;; no comma in map
              :no-comma
 
-             :how-to-ns
-
              :custom-justify
 
              ;; respect all newlines

--- a/Makefile
+++ b/Makefile
@@ -294,10 +294,10 @@ lint: ##@test Run code style checks
 
 lint-fix: export TARGET := default
 lint-fix: ##@test Run code style checks and fix issues
-	TARGETS=$$(git diff --diff-filter=d --cached --name-only | grep -e \.clj$$ -e \.cljs$$ -e \.cljc$$ -e \.edn$$ || echo shadow-cljs.edn) && \
-	clojure-lsp clean-ns --filenames $$(echo $$TARGETS | xargs | sed -e 's/ /,/g') && \
-	zprint '{:search-config? true}' -fw $$TARGETS && \
-	zprint '{:search-config? true}' -fw $$TARGETS
+	ALL_CLOJURE_FILE=$$(git ls-files | grep -e \.clj$$ -e \.cljs$$ -e \.cljc$$ -e \.edn$$) && \
+	clojure-lsp clean-ns && \
+	zprint '{:search-config? true}' -sw $$ALL_CLOJURE_FILE && \
+	zprint '{:search-config? true}' -sw $$ALL_CLOJURE_FILE
 
 
 shadow-server: export TARGET := clojure

--- a/Makefile
+++ b/Makefile
@@ -295,7 +295,6 @@ lint: ##@test Run code style checks
 lint-fix: export TARGET := default
 lint-fix: ##@test Run code style checks and fix issues
 	ALL_CLOJURE_FILE=$$(git ls-files | grep -e \.clj$$ -e \.cljs$$ -e \.cljc$$ -e \.edn$$) && \
-	clojure-lsp clean-ns && \
 	zprint '{:search-config? true}' -sw $$ALL_CLOJURE_FILE && \
 	zprint '{:search-config? true}' -sw $$ALL_CLOJURE_FILE
 

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -18,7 +18,7 @@ in mkShell {
     # build specific utilities
     clojure maven watchman
     # lint specific utilities
-    clj-kondo zprint clojure-lsp
+    clj-kondo zprint
     # other nice to have stuff
     yarn nodejs python27
   ] # and some special cases


### PR DESCRIPTION
1. prev ns rule is not following community rule's `better` option, fix it by using builtin `:how-to-ns` rule, https://stuartsierra.com/2016/clojure-how-to-ns.html
1. remove unused rule `:rj-var`
1. `make lint-fix` will format all files tracked by git, instead of only staged files
1. [ ] try to solve https://github.com/orgs/status-im/teams/mobile-devs/discussions/1?from_comment=1 https://github.com/kkinnear/zprint/issues/282 (in seperate PR)

~**NOTE**: this requires another reformat, will change all `(ns ...)`~

status: ready <!-- Can be ready or wip -->