### PR TITLE
e2e: new ui 1-1

### DIFF
--- a/test/appium/tests/__init__.py
+++ b/test/appium/tests/__init__.py
@@ -74,7 +74,7 @@ test_dapp_web_url = "status-im.github.io/dapp"
 test_dapp_url = 'https://simpledapp.status.im/'
 test_dapp_name = 'simpledapp.status.im'
 
-emojis = {'thumbs-up': 5, 'thumbs-down': 6, 'love': 1, 'laugh': 4, 'angry': 2, 'sad': 3}
+emojis = {'thumbs-up': 2, 'thumbs-down': 3, 'love': 1, 'laugh': 4, 'angry': 6, 'sad': 5}
 
 
 with open(os.sep.join(__file__.split(os.sep)[:-1]) + '/../../../translations/en.json') as json_file:

--- a/test/appium/views/base_view.py
+++ b/test/appium/views/base_view.py
@@ -378,6 +378,9 @@ class BaseView(object):
         counter = 0
         if element == 'home':
             element = self.chats_tab
+        elif element == 'chat':
+            chat = self.get_chat_view()
+            element = chat.chat_message_input
             # Old UI
             # element = self.home_button
         while not element.is_element_displayed(1) and counter <= attempts:

--- a/test/appium/views/chat_view.py
+++ b/test/appium/views/chat_view.py
@@ -191,9 +191,12 @@ class ChatElementByText(Text):
 
     @property
     def status(self) -> str:
-        sent = Text(self.driver, prefix=self.locator, xpath="//*[@content-desc='sent']")
-        delivered = Text(self.driver, prefix=self.locator, xpath="//*[@content-desc='delivered']")
+        sending = Text(self.driver, prefix=self.locator, xpath="//*[contains(@text, ':sending')]")
+        sent = Text(self.driver, prefix=self.locator, xpath="//*[contains(@text, ':sent')]")
+        delivered = Text(self.driver, prefix=self.locator, xpath="//*[contains(@text, ':delivered')]")
         status = ''
+        if sending.is_element_displayed(10, ignored_exceptions=NoSuchElementException):
+            status = 'sending'
         if sent.is_element_displayed(10, ignored_exceptions=NoSuchElementException):
             status = 'sent'
         if delivered.is_element_displayed(30, ignored_exceptions=NoSuchElementException):
@@ -638,9 +641,9 @@ class ChatView(BaseView):
 
         # Chat input
         self.chat_message_input = EditBox(self.driver, accessibility_id="chat-message-input")
+        self.cancel_reply_button = Button(self.driver, accessibility_id="reply-cancel-button")
         self.quote_username_in_message_input = EditBox(self.driver,
-                                                       xpath="//android.view.ViewGroup[@content-desc='cancel-message-reply']/..//android.widget.TextView[1]")
-        self.cancel_reply_button = Button(self.driver, accessibility_id="cancel-message-reply")
+                                                       xpath="//*[@content-desc='reply-cancel-button']/preceding::android.widget.TextView[2]")
         self.chat_item = Button(self.driver, xpath="(//*[@content-desc='chat-item'])[1]")
         self.chat_name_editbox = EditBox(self.driver, accessibility_id="chat-name-input")
         self.commands_button = CommandsButton(self.driver)
@@ -921,6 +924,12 @@ class ChatView(BaseView):
         element = Button(self.driver, accessibility_id='emoji-picker-%s' % key)
         element.click()
         element.wait_for_invisibility_of_element()
+
+    def add_remove_same_reaction(self, message: str, emoji: str = 'thumbs-up'):
+        self.driver.info("Adding one more '%s' reaction or removing an added one" % emoji)
+        key = emojis[emoji]
+        element = Button(self.driver, accessibility_id='emoji-reaction-%s' % key)
+        element.click()
 
     def view_profile_long_press(self, message=str):
         self.chat_element_by_text(message).long_press_element()

--- a/test/appium/views/home_view.py
+++ b/test/appium/views/home_view.py
@@ -293,7 +293,7 @@ class HomeView(BaseView):
 
         # Options on long tap
         self.chats_menu_invite_friends_button = Button(self.driver, accessibility_id="chats-menu-invite-friends-button")
-        self.delete_chat_button = Button(self.driver, accessibility_id="delete-chat-button")
+        self.delete_chat_button = Button(self.driver, translation_id="delete-chat")
         self.clear_history_button = Button(self.driver, accessibility_id="clear-history-button")
         self.mark_all_messages_as_read_button = Button(self.driver, accessibility_id="mark-all-read-button")
 
@@ -468,7 +468,7 @@ class HomeView(BaseView):
         self.driver.info("Deleting chat '%s' by long press" % username)
         self.get_chat(username).long_press_element()
         self.delete_chat_button.click()
-        self.delete_button.click()
+        self.delete_chat_button.click()
 
     def leave_chat_long_press(self, username):
         self.driver.info("Leaving chat '%s' by long press" % username)


### PR DESCRIPTION
Updated tests for 1-1 chat:
- 702782 `test_1_1_chat_emoji_send_reply_and_open_link`
- 702813 `test_1_1_chat_push_emoji`
- 702733 `test_1_1_chat_text_message_edit_delete_push_disappear`
- 702784 `test_1_1_chat_delete_via_long_press_relogin`