### PR TITLE
abstract running code in separate thread for native java modules

### DIFF
--- a/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusModule.java
+++ b/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusModule.java
@@ -138,7 +138,7 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
     }
 
 
-    private void runFunctionInSeparateThread(Supplier<String[]> func, Callback callback) {
+    private void runStatusGoMethodInSeparateThread(Supplier<String[]> func, Callback callback) {
        if (!checkAvailability()) {
           callback.invoke(false);
           return;
@@ -545,32 +545,32 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
         StatusThreadPoolExecutor.getInstance().execute(r);
     }
 
-   private void executeRunnableStatusGoMethod(final String methodName, final Callback callback, final Object... args) {
-       if (!checkAvailability()) {
-           callback.invoke(false);
-           return;
-       }
-
-       Runnable runnableTask = new Runnable() {
-           @Override
-           public void run() {
-               String res = "";
-               try {
-                   Method method = Statusgo.class.getMethod(methodName);
-                   if (args.length > 0) {
-                       res = (String) method.invoke(null, args);
-                   } else {
-                       res = (String) method.invoke(null);
-                   }
-               } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
-                   e.printStackTrace();
-               }
-               callback.invoke(res);
-           }
-       };
-
-       StatusThreadPoolExecutor.getInstance().execute(runnableTask);
-   }
+//    private void executeRunnableStatusGoMethod(final String methodName, final Callback callback, final Object... args) {
+//        if (!checkAvailability()) {
+//            callback.invoke(false);
+//            return;
+//        }
+//
+//        Runnable runnableTask = new Runnable() {
+//            @Override
+//            public void run() {
+//                String res = "";
+//                try {
+//                    Method method = Statusgo.class.getMethod(methodName);
+//                    if (args.length > 0) {
+//                        res = (String) method.invoke(null, args);
+//                    } else {
+//                        res = (String) method.invoke(null);
+//                    }
+//                } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+//                    e.printStackTrace();
+//                }
+//                callback.invoke(res);
+//            }
+//        };
+//
+//        StatusThreadPoolExecutor.getInstance().execute(runnableTask);
+//    }
 
     @ReactMethod
     public void verify(final String address, final String password, final Callback callback) {
@@ -579,12 +579,12 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
         final String absRootDirPath = this.getNoBackupDirectory();
         final String newKeystoreDir = pathCombine(absRootDirPath, "keystore");
 
-        executeRunnableStatusGoMethod("verify", callback, "");
+        runStatusGoMethodInSeparateThread(() -> Statusgo.verify(), callback);
     }
 
     @ReactMethod
     public void verifyDatabasePassword(final String keyUID, final String password, final Callback callback) {
-        executeRunnableStatusGoMethod("verifyDatabasePassword", callback, keyUID, password);
+        runStatusGoMethodInSeparateThread(() -> Statusgo.verifyDatabasePassword(keyUID, password), callback);
     }
 
     public String getKeyStorePath(String keyUID) {
@@ -755,57 +755,58 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
 
     @ReactMethod
     public void addPeer(final String enode, final Callback callback) {
-        executeRunnableStatusGoMethod("addPeer", callback, enode);
+        runStatusGoMethodInSeparateThread(() -> Statusgo.addPeer(enode), callback);
     }
 
     @ReactMethod
     public void multiAccountStoreAccount(final String json, final Callback callback) {
-        executeRunnableStatusGoMethod("multiAccountStoreAccount", callback, json);
+        runStatusGoMethodInSeparateThread(() -> Statusgo.multiAccountStoreAccount(json), callback);
     }
 
     @ReactMethod
     public void multiAccountLoadAccount(final String json, final Callback callback) {
-        executeRunnableStatusGoMethod("multiAccountLoadAccount", callback, json);
+        runStatusGoMethodInSeparateThread(() -> Statusgo.multiAccountLoadAccount(json), callback);
     }
 
     @ReactMethod
     public void multiAccountReset(final Callback callback) {
-        executeRunnableStatusGoMethod("multiAccountReset", callback, "");
+        runStatusGoMethodInSeparateThread(() -> Statusgo.multiAccountReset(), callback);
+
     }
 
     @ReactMethod
     public void multiAccountDeriveAddresses(final String json, final Callback callback) {
-        executeRunnableStatusGoMethod("multiAccountDeriveAddresses", callback, json);
+        runStatusGoMethodInSeparateThread(() -> Statusgo.multiAccountDeriveAddresses(json), callback);
     }
 
     @ReactMethod
     public void multiAccountGenerateAndDeriveAddresses(final String json, final Callback callback) {
-        executeRunnableStatusGoMethod("multiAccountGenerateAndDeriveAddresses", callback, json);
+        runStatusGoMethodInSeparateThread(() -> Statusgo.multiAccountGenerateAndDeriveAddresses(json), callback);
     }
 
     @ReactMethod
     public void multiAccountStoreDerived(final String json, final Callback callback) {
-        executeRunnableStatusGoMethod("multiAccountStoreDerivedAccounts", callback, json);
+        runStatusGoMethodInSeparateThread(() -> Statusgo.multiAccountStoreDerivedAccounts(json), callback);
     }
 
     @ReactMethod
     public void multiAccountImportMnemonic(final String json, final Callback callback) {
-        executeRunnableStatusGoMethod("multiAccountImportMnemonic", callback, json);
+        runStatusGoMethodInSeparateThread(() -> Statusgo.multiAccountImportMnemonic(json), callback);
     }
 
     @ReactMethod
     public void multiAccountImportPrivateKey(final String json, final Callback callback) {
-        executeRunnableStatusGoMethod("multiAccountImportPrivateKey", callback, json);
+        runStatusGoMethodInSeparateThread(() -> Statusgo.multiAccountImportPrivateKey(json), callback);
     }
 
     @ReactMethod
     public void hashTransaction(final String txArgsJSON, final Callback callback) {
-        executeRunnableStatusGoMethod("hashTransaction", callback, txArgsJSON);
+        runStatusGoMethodInSeparateThread(() -> Statusgo.hashTransaction(txArgsJSON), callback);
     }
 
     @ReactMethod
     public void hashMessage(final String message, final Callback callback) {
-        executeRunnableStatusGoMethod("hashMessage", callback, message);
+        runStatusGoMethodInSeparateThread(() -> Statusgo.hashMessage(message), callback);
     }
 
     @ReactMethod
@@ -815,7 +816,7 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
          final String keyStorePath = this.getKeyStorePath(keyUID);
          jsonConfig.put("keystorePath", keyStorePath);
 
-        executeRunnableStatusGoMethod("getConnectionStringForBootstrappingAnotherDevice", callback, jsonConfig.toString());
+        runStatusGoMethodInSeparateThread(() -> Statusgo.getConnectionStringForBootstrappingAnotherDevice(jsonConfig.toString()), callback);
     }
 
     @ReactMethod
@@ -824,7 +825,7 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
          final String keyStorePath = pathCombine(this.getNoBackupDirectory(), "/keystore");
          jsonConfig.put("keystorePath", keyStorePath);
 
-        executeRunnableStatusGoMethod("inputConnectionStringForBootstrapping", callback, connectionString, jsonConfig.toString());
+        runStatusGoMethodInSeparateThread(() -> Statusgo.inputConnectionStringForBootstrapping(connectionString, jsonConfig.toString()), callback);
     }
 
     @ReactMethod
@@ -919,42 +920,42 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
 
     @ReactMethod
     public void hashTypedData(final String data, final Callback callback) {
-        executeRunnableStatusGoMethod("hashTypedData", callback, data);
+        runStatusGoMethodInSeparateThread(() -> Statusgo.hashTypedData(data), callback);
     }
 
     @ReactMethod
     public void hashTypedDataV4(final String data, final Callback callback) {
-        executeRunnableStatusGoMethod("hashTypedDataV4", callback, data);
+        runStatusGoMethodInSeparateThread(() -> Statusgo.hashTypedDataV4(data), callback);
     }
 
     @ReactMethod
     public void sendTransactionWithSignature(final String txArgsJSON, final String signature, final Callback callback) {
-        executeRunnableStatusGoMethod("sendTransactionWithSignature", callback, txArgsJSON, signature);
+        runStatusGoMethodInSeparateThread(() -> Statusgo.sendTransactionWithSignature(txArgsJSON, signature), callback);
     }
 
     @ReactMethod
     public void sendTransaction(final String txArgsJSON, final String password, final Callback callback) {
-        executeRunnableStatusGoMethod("sendTransaction", callback, txArgsJSON, password);
+        runStatusGoMethodInSeparateThread(() -> Statusgo.sendTransaction(txArgsJSON, password), callback);
     }
 
     @ReactMethod
     public void signMessage(final String rpcParams, final Callback callback) {
-        executeRunnableStatusGoMethod("signMessage", callback, rpcParams);
+        runStatusGoMethodInSeparateThread(() -> Statusgo.signMessage(rpcParams), callback);
     }
 
     @ReactMethod
     public void recover(final String rpcParams, final Callback callback) {
-        executeRunnableStatusGoMethod("recover", callback, rpcParams);
+        runStatusGoMethodInSeparateThread(() -> Statusgo.recover(rpcParams), callback);
     }
 
     @ReactMethod
     public void signTypedData(final String data, final String account, final String password, final Callback callback) {
-        executeRunnableStatusGoMethod("signTypedData", callback, data, account, password);
+        runStatusGoMethodInSeparateThread(() -> Statusgo.signTypedData(data, account, password), callback);
     }
 
     @ReactMethod
     public void signTypedDataV4(final String data, final String account, final String password, final Callback callback) {
-        executeRunnableStatusGoMethod("signTypedDataV4", callback, data, account, password);
+        runStatusGoMethodInSeparateThread(() -> Statusgo.signTypedDataV4(data, account, password), callback);
 
     }
 
@@ -1061,12 +1062,12 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
 
     @ReactMethod
     public void callRPC(final String payload, final Callback callback) {
-        executeRunnableStatusGoMethod("callRPC", callback, payload);
+        runStatusGoMethodInSeparateThread(() -> Statusgo.callRPC(payload), callback);
     }
 
     @ReactMethod
     public void callPrivateRPC(final String payload, final Callback callback) {
-        executeRunnableStatusGoMethod("callPrivateRPC", callback, payload);
+        runStatusGoMethodInSeparateThread(() -> Statusgo.callPrivateRPC(payload), callback);
     }
 
     @ReactMethod
@@ -1130,29 +1131,29 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
 
     @ReactMethod
     public void extractGroupMembershipSignatures(final String signaturePairs, final Callback callback) {
-        executeRunnableStatusGoMethod("extractGroupMembershipSignatures", callback, signaturePairs);
+        runStatusGoMethodInSeparateThread(() -> Statusgo.extractGroupMembershipSignatures(signaturePairs), callback);
     }
 
     @ReactMethod
     public void signGroupMembership(final String content, final Callback callback) {
-        executeRunnableStatusGoMethod("signGroupMembership", callback, content);
+        runStatusGoMethodInSeparateThread(() -> Statusgo.signGroupMembership(content), callback);
     }
 
     @ReactMethod
     public void getNodeConfig(final Callback callback) {
-         executeRunnableStatusGoMethod("getNodeConfig", callback, "");
+         runStatusGoMethodInSeparateThread(() -> Statusgo.getNodeConfig(), callback);
     }
 
     @ReactMethod
     public void deleteMultiaccount(final String keyUID, final Callback callback) {
         final String keyStoreDir = this.getKeyStorePath(keyUID);
-        executeRunnableStatusGoMethod("deleteMultiaccount", callback, keyUID, keyStoreDir);
+        runStatusGoMethodInSeparateThread(() -> Statusgo.deleteMultiaccount(keyUID, keyStoreDir), callback);
     }
 
     @ReactMethod
     public void deleteImportedKey(final String keyUID, final String address, final String password, final Callback callback) {
         final String keyStoreDir = this.getKeyStorePath(keyUID);
-        executeRunnableStatusGoMethod("deleteImportedKey", callback, address, password, keyStoreDir);
+        runStatusGoMethodInSeparateThread(() -> Statusgo.deleteImportedKey(address, password, keyStoreDir), callback);
     }
 
     @ReactMethod(isBlockingSynchronousMethod = true)
@@ -1162,7 +1163,7 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
 
     @ReactMethod
     public void generateAliasAsync(final String seed, final Callback callback) {
-        executeRunnableStatusGoMethod("generateAlias", callback, seed);
+        runStatusGoMethodInSeparateThread(() -> Statusgo.generateAlias(seed), callback);
     }
 
     @ReactMethod(isBlockingSynchronousMethod = true)
@@ -1227,31 +1228,13 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
 
     @ReactMethod
     public void identiconAsync(final String seed, final Callback callback) {
-        executeRunnableStatusGoMethod("identicon", callback, seed);
+        runStatusGoMethodInSeparateThread(() -> Statusgo.identicon(seed), callback);
     }
 
     @ReactMethod
     public void generateAliasAndIdenticonAsync(final String seed, final Callback callback) {
-//         Log.d(TAG, "generateAliasAndIdenticonAsync");
-//         if (!checkAvailability()) {
-//             callback.invoke(false);
-//             return;
-//         }
-//
-//         Runnable r = new Runnable() {
-//             @Override
-//             public void run() {
-//                 String resIdenticon = Statusgo.identicon(seed);
-//                 String resAlias = Statusgo.generateAlias(seed);
-//
-//                 Log.d(TAG, resIdenticon);
-//                 Log.d(TAG, resAlias);
-//                 callback.invoke(resAlias, resIdenticon);
-//             }
-//         };
-//
-//         StatusThreadPoolExecutor.getInstance().execute(r);
-             runFunctionInSeparateThread(() -> {
+
+             runStatusGoMethodInSeparateThread(() -> {
                 String resIdenticon = Statusgo.identicon(seed);
                 String resAlias = Statusgo.generateAlias(seed);
                 return new String[]{resAlias, resIdenticon};
@@ -1279,7 +1262,7 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
 
     @ReactMethod
     public void validateMnemonic(final String seed, final Callback callback) {
-        executeRunnableStatusGoMethod("validateMnemonic", callback, seed);
+        runStatusGoMethodInSeparateThread(() -> Statusgo.validateMnemonic(seed), callback);
     }
 
     @ReactMethod
@@ -1348,7 +1331,7 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
     @ReactMethod
     public void convertToKeycardAccount(final String keyUID, final String accountData, final String options, final String password, final String newPassword, final Callback callback) {
         final String keyStoreDir = this.getKeyStorePath(keyUID);
-        executeRunnableStatusGoMethod("validateMnemonic", callback, keyStoreDir, accountData, options, password, newPassword);
+         runStatusGoMethodInSeparateThread(() -> Statusgo.validateMnemonic(keyStoreDir, accountData, options, password, newPassword), callback);
     }
 
 }

--- a/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusModule.java
+++ b/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusModule.java
@@ -63,6 +63,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.InvocationTargetException;
 import java.text.SimpleDateFormat;
 import java.util.HashMap;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.Map;
 import java.util.Stack;
@@ -138,18 +139,23 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
     }
 
 
-    private void runStatusGoMethodInSeparateThread(Supplier<String[]> func, Callback callback) {
-       if (!checkAvailability()) {
-          callback.invoke(false);
-          return;
-       }
+    private void runStatusGoMethodInSeparateThread(Object func, Callback callback) {
+        if (!checkAvailability()) {
+            callback.invoke(false);
+            return;
+        }
 
-       Runnable r = () -> {
-          String[] res = func.get();
-          callback.invoke(res);
-       };
+        Runnable r = () -> {
+            Object res = null;
+            if (func instanceof Function) {
+                res = ((Function) func).apply(null);
+            } else if (func instanceof Supplier) {
+                res = ((Supplier) func).get();
+            }
+            callback.invoke(res);
+        };
 
-       StatusThreadPoolExecutor.getInstance().execute(r);
+        StatusThreadPoolExecutor.getInstance().execute(r);
     }
 
     public String getNoBackupDirectory() {

--- a/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusModule.java
+++ b/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusModule.java
@@ -138,26 +138,6 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
 
     }
 
-
-    private void runStatusGoMethodInSeparateThread(Object func, Callback callback) {
-        if (!checkAvailability()) {
-            callback.invoke(false);
-            return;
-        }
-
-        Runnable r = () -> {
-            Object res = null;
-            if (func instanceof Function) {
-                res = ((Function) func).apply(null);
-            } else if (func instanceof Supplier) {
-                res = ((Supplier) func).get();
-            }
-            callback.invoke(res);
-        };
-
-        StatusThreadPoolExecutor.getInstance().execute(r);
-    }
-
     public String getNoBackupDirectory() {
         return this.getReactApplicationContext().getNoBackupFilesDir().getAbsolutePath();
     }
@@ -551,46 +531,33 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
         StatusThreadPoolExecutor.getInstance().execute(r);
     }
 
-//    private void executeRunnableStatusGoMethod(final String methodName, final Callback callback, final Object... args) {
-//        if (!checkAvailability()) {
-//            callback.invoke(false);
-//            return;
-//        }
-//
-//        Runnable runnableTask = new Runnable() {
-//            @Override
-//            public void run() {
-//                String res = "";
-//                try {
-//                    Method method = Statusgo.class.getMethod(methodName);
-//                    if (args.length > 0) {
-//                        res = (String) method.invoke(null, args);
-//                    } else {
-//                        res = (String) method.invoke(null);
-//                    }
-//                } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
-//                    e.printStackTrace();
-//                }
-//                callback.invoke(res);
-//            }
-//        };
-//
-//        StatusThreadPoolExecutor.getInstance().execute(runnableTask);
-//    }
+    private void executeRunnableStatusGoMethod(Supplier<String> method, Callback callback) throws JSONException {
+        if (!checkAvailability()) {
+            callback.invoke(false);
+            return;
+        }
+
+        Runnable runnableTask = () -> {
+            String res = method.get();
+            callback.invoke(res);
+        };
+
+        StatusThreadPoolExecutor.getInstance().execute(runnableTask);
+    }
 
     @ReactMethod
-    public void verify(final String address, final String password, final Callback callback) {
+    public void verify(final String address, final String password, final Callback callback) throws JSONException {
         Activity currentActivity = getCurrentActivity();
 
         final String absRootDirPath = this.getNoBackupDirectory();
         final String newKeystoreDir = pathCombine(absRootDirPath, "keystore");
 
-        runStatusGoMethodInSeparateThread(() -> Statusgo.verify(), callback);
+        executeRunnableStatusGoMethod(() -> Statusgo.verifyAccountPassword(newKeystoreDir, address, password), callback);
     }
 
     @ReactMethod
-    public void verifyDatabasePassword(final String keyUID, final String password, final Callback callback) {
-        runStatusGoMethodInSeparateThread(() -> Statusgo.verifyDatabasePassword(keyUID, password), callback);
+    public void verifyDatabasePassword(final String keyUID, final String password, final Callback callback) throws JSONException {
+        executeRunnableStatusGoMethod(() -> Statusgo.verifyDatabasePassword(keyUID, password), callback);
     }
 
     public String getKeyStorePath(String keyUID) {
@@ -760,59 +727,59 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
     }
 
     @ReactMethod
-    public void addPeer(final String enode, final Callback callback) {
-        runStatusGoMethodInSeparateThread(() -> Statusgo.addPeer(enode), callback);
+    public void addPeer(final String enode, final Callback callback) throws JSONException {
+        executeRunnableStatusGoMethod(() -> Statusgo.addPeer(enode), callback);
     }
 
     @ReactMethod
-    public void multiAccountStoreAccount(final String json, final Callback callback) {
-        runStatusGoMethodInSeparateThread(() -> Statusgo.multiAccountStoreAccount(json), callback);
+    public void multiAccountStoreAccount(final String json, final Callback callback) throws JSONException {
+        executeRunnableStatusGoMethod(() -> Statusgo.multiAccountStoreAccount(json), callback);
     }
 
     @ReactMethod
-    public void multiAccountLoadAccount(final String json, final Callback callback) {
-        runStatusGoMethodInSeparateThread(() -> Statusgo.multiAccountLoadAccount(json), callback);
+    public void multiAccountLoadAccount(final String json, final Callback callback) throws JSONException {
+        executeRunnableStatusGoMethod(() -> Statusgo.multiAccountLoadAccount(json), callback);
     }
 
     @ReactMethod
-    public void multiAccountReset(final Callback callback) {
-        runStatusGoMethodInSeparateThread(() -> Statusgo.multiAccountReset(), callback);
+    public void multiAccountReset(final Callback callback) throws JSONException {
+        executeRunnableStatusGoMethod(() -> Statusgo.multiAccountReset(), callback);
 
     }
 
     @ReactMethod
-    public void multiAccountDeriveAddresses(final String json, final Callback callback) {
-        runStatusGoMethodInSeparateThread(() -> Statusgo.multiAccountDeriveAddresses(json), callback);
+    public void multiAccountDeriveAddresses(final String json, final Callback callback) throws JSONException {
+        executeRunnableStatusGoMethod(() -> Statusgo.multiAccountDeriveAddresses(json), callback);
     }
 
     @ReactMethod
-    public void multiAccountGenerateAndDeriveAddresses(final String json, final Callback callback) {
-        runStatusGoMethodInSeparateThread(() -> Statusgo.multiAccountGenerateAndDeriveAddresses(json), callback);
+    public void multiAccountGenerateAndDeriveAddresses(final String json, final Callback callback) throws JSONException {
+        executeRunnableStatusGoMethod(() -> Statusgo.multiAccountGenerateAndDeriveAddresses(json), callback);
     }
 
     @ReactMethod
-    public void multiAccountStoreDerived(final String json, final Callback callback) {
-        runStatusGoMethodInSeparateThread(() -> Statusgo.multiAccountStoreDerivedAccounts(json), callback);
+    public void multiAccountStoreDerived(final String json, final Callback callback) throws JSONException {
+        executeRunnableStatusGoMethod(() -> Statusgo.multiAccountStoreDerivedAccounts(json), callback);
     }
 
     @ReactMethod
-    public void multiAccountImportMnemonic(final String json, final Callback callback) {
-        runStatusGoMethodInSeparateThread(() -> Statusgo.multiAccountImportMnemonic(json), callback);
+    public void multiAccountImportMnemonic(final String json, final Callback callback) throws JSONException {
+        executeRunnableStatusGoMethod(() -> Statusgo.multiAccountImportMnemonic(json), callback);
     }
 
     @ReactMethod
-    public void multiAccountImportPrivateKey(final String json, final Callback callback) {
-        runStatusGoMethodInSeparateThread(() -> Statusgo.multiAccountImportPrivateKey(json), callback);
+    public void multiAccountImportPrivateKey(final String json, final Callback callback) throws JSONException {
+        executeRunnableStatusGoMethod(() -> Statusgo.multiAccountImportPrivateKey(json), callback);
     }
 
     @ReactMethod
-    public void hashTransaction(final String txArgsJSON, final Callback callback) {
-        runStatusGoMethodInSeparateThread(() -> Statusgo.hashTransaction(txArgsJSON), callback);
+    public void hashTransaction(final String txArgsJSON, final Callback callback) throws JSONException {
+        executeRunnableStatusGoMethod(() -> Statusgo.hashTransaction(txArgsJSON), callback);
     }
 
     @ReactMethod
-    public void hashMessage(final String message, final Callback callback) {
-        runStatusGoMethodInSeparateThread(() -> Statusgo.hashMessage(message), callback);
+    public void hashMessage(final String message, final Callback callback) throws JSONException {
+        executeRunnableStatusGoMethod(() -> Statusgo.hashMessage(message), callback);
     }
 
     @ReactMethod
@@ -822,7 +789,7 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
          final String keyStorePath = this.getKeyStorePath(keyUID);
          jsonConfig.put("keystorePath", keyStorePath);
 
-        runStatusGoMethodInSeparateThread(() -> Statusgo.getConnectionStringForBootstrappingAnotherDevice(jsonConfig.toString()), callback);
+        executeRunnableStatusGoMethod(() -> Statusgo.getConnectionStringForBootstrappingAnotherDevice(jsonConfig.toString()), callback);
     }
 
     @ReactMethod
@@ -831,7 +798,7 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
          final String keyStorePath = pathCombine(this.getNoBackupDirectory(), "/keystore");
          jsonConfig.put("keystorePath", keyStorePath);
 
-        runStatusGoMethodInSeparateThread(() -> Statusgo.inputConnectionStringForBootstrapping(connectionString, jsonConfig.toString()), callback);
+        executeRunnableStatusGoMethod(() -> Statusgo.inputConnectionStringForBootstrapping(connectionString, jsonConfig.toString()), callback);
     }
 
     @ReactMethod
@@ -925,43 +892,43 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
     }
 
     @ReactMethod
-    public void hashTypedData(final String data, final Callback callback) {
-        runStatusGoMethodInSeparateThread(() -> Statusgo.hashTypedData(data), callback);
+    public void hashTypedData(final String data, final Callback callback) throws JSONException {
+        executeRunnableStatusGoMethod(() -> Statusgo.hashTypedData(data), callback);
     }
 
     @ReactMethod
-    public void hashTypedDataV4(final String data, final Callback callback) {
-        runStatusGoMethodInSeparateThread(() -> Statusgo.hashTypedDataV4(data), callback);
+    public void hashTypedDataV4(final String data, final Callback callback) throws JSONException {
+        executeRunnableStatusGoMethod(() -> Statusgo.hashTypedDataV4(data), callback);
     }
 
     @ReactMethod
-    public void sendTransactionWithSignature(final String txArgsJSON, final String signature, final Callback callback) {
-        runStatusGoMethodInSeparateThread(() -> Statusgo.sendTransactionWithSignature(txArgsJSON, signature), callback);
+    public void sendTransactionWithSignature(final String txArgsJSON, final String signature, final Callback callback) throws JSONException {
+        executeRunnableStatusGoMethod(() -> Statusgo.sendTransactionWithSignature(txArgsJSON, signature), callback);
     }
 
     @ReactMethod
-    public void sendTransaction(final String txArgsJSON, final String password, final Callback callback) {
-        runStatusGoMethodInSeparateThread(() -> Statusgo.sendTransaction(txArgsJSON, password), callback);
+    public void sendTransaction(final String txArgsJSON, final String password, final Callback callback) throws JSONException {
+        executeRunnableStatusGoMethod(() -> Statusgo.sendTransaction(txArgsJSON, password), callback);
     }
 
     @ReactMethod
-    public void signMessage(final String rpcParams, final Callback callback) {
-        runStatusGoMethodInSeparateThread(() -> Statusgo.signMessage(rpcParams), callback);
+    public void signMessage(final String rpcParams, final Callback callback) throws JSONException {
+        executeRunnableStatusGoMethod(() -> Statusgo.signMessage(rpcParams), callback);
     }
 
     @ReactMethod
-    public void recover(final String rpcParams, final Callback callback) {
-        runStatusGoMethodInSeparateThread(() -> Statusgo.recover(rpcParams), callback);
+    public void recover(final String rpcParams, final Callback callback) throws JSONException {
+        executeRunnableStatusGoMethod(() -> Statusgo.recover(rpcParams), callback);
     }
 
     @ReactMethod
-    public void signTypedData(final String data, final String account, final String password, final Callback callback) {
-        runStatusGoMethodInSeparateThread(() -> Statusgo.signTypedData(data, account, password), callback);
+    public void signTypedData(final String data, final String account, final String password, final Callback callback) throws JSONException {
+        executeRunnableStatusGoMethod(() -> Statusgo.signTypedData(data, account, password), callback);
     }
 
     @ReactMethod
-    public void signTypedDataV4(final String data, final String account, final String password, final Callback callback) {
-        runStatusGoMethodInSeparateThread(() -> Statusgo.signTypedDataV4(data, account, password), callback);
+    public void signTypedDataV4(final String data, final String account, final String password, final Callback callback) throws JSONException {
+        executeRunnableStatusGoMethod(() -> Statusgo.signTypedDataV4(data, account, password), callback);
 
     }
 
@@ -1067,13 +1034,13 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
     }
 
     @ReactMethod
-    public void callRPC(final String payload, final Callback callback) {
-        runStatusGoMethodInSeparateThread(() -> Statusgo.callRPC(payload), callback);
+    public void callRPC(final String payload, final Callback callback) throws JSONException {
+        executeRunnableStatusGoMethod(() -> Statusgo.callRPC(payload), callback);
     }
 
     @ReactMethod
-    public void callPrivateRPC(final String payload, final Callback callback) {
-        runStatusGoMethodInSeparateThread(() -> Statusgo.callPrivateRPC(payload), callback);
+    public void callPrivateRPC(final String payload, final Callback callback) throws JSONException {
+        executeRunnableStatusGoMethod(() -> Statusgo.callPrivateRPC(payload), callback);
     }
 
     @ReactMethod
@@ -1136,30 +1103,30 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
     }
 
     @ReactMethod
-    public void extractGroupMembershipSignatures(final String signaturePairs, final Callback callback) {
-        runStatusGoMethodInSeparateThread(() -> Statusgo.extractGroupMembershipSignatures(signaturePairs), callback);
+    public void extractGroupMembershipSignatures(final String signaturePairs, final Callback callback) throws JSONException {
+        executeRunnableStatusGoMethod(() -> Statusgo.extractGroupMembershipSignatures(signaturePairs), callback);
     }
 
     @ReactMethod
-    public void signGroupMembership(final String content, final Callback callback) {
-        runStatusGoMethodInSeparateThread(() -> Statusgo.signGroupMembership(content), callback);
+    public void signGroupMembership(final String content, final Callback callback) throws JSONException {
+        executeRunnableStatusGoMethod(() -> Statusgo.signGroupMembership(content), callback);
     }
 
     @ReactMethod
-    public void getNodeConfig(final Callback callback) {
-         runStatusGoMethodInSeparateThread(() -> Statusgo.getNodeConfig(), callback);
+    public void getNodeConfig(final Callback callback) throws JSONException {
+         executeRunnableStatusGoMethod(() -> Statusgo.getNodeConfig(), callback);
     }
 
     @ReactMethod
-    public void deleteMultiaccount(final String keyUID, final Callback callback) {
+    public void deleteMultiaccount(final String keyUID, final Callback callback) throws JSONException {
         final String keyStoreDir = this.getKeyStorePath(keyUID);
-        runStatusGoMethodInSeparateThread(() -> Statusgo.deleteMultiaccount(keyUID, keyStoreDir), callback);
+        executeRunnableStatusGoMethod(() -> Statusgo.deleteMultiaccount(keyUID, keyStoreDir), callback);
     }
 
     @ReactMethod
-    public void deleteImportedKey(final String keyUID, final String address, final String password, final Callback callback) {
+    public void deleteImportedKey(final String keyUID, final String address, final String password, final Callback callback) throws JSONException {
         final String keyStoreDir = this.getKeyStorePath(keyUID);
-        runStatusGoMethodInSeparateThread(() -> Statusgo.deleteImportedKey(address, password, keyStoreDir), callback);
+        executeRunnableStatusGoMethod(() -> Statusgo.deleteImportedKey(address, password, keyStoreDir), callback);
     }
 
     @ReactMethod(isBlockingSynchronousMethod = true)
@@ -1168,8 +1135,8 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
     }
 
     @ReactMethod
-    public void generateAliasAsync(final String seed, final Callback callback) {
-        runStatusGoMethodInSeparateThread(() -> Statusgo.generateAlias(seed), callback);
+    public void generateAliasAsync(final String seed, final Callback callback) throws JSONException {
+        executeRunnableStatusGoMethod(() -> Statusgo.generateAlias(seed), callback);
     }
 
     @ReactMethod(isBlockingSynchronousMethod = true)
@@ -1233,18 +1200,32 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
     }
 
     @ReactMethod
-    public void identiconAsync(final String seed, final Callback callback) {
-        runStatusGoMethodInSeparateThread(() -> Statusgo.identicon(seed), callback);
+    public void identiconAsync(final String seed, final Callback callback) throws JSONException {
+        executeRunnableStatusGoMethod(() -> Statusgo.identicon(seed), callback);
     }
 
     @ReactMethod
     public void generateAliasAndIdenticonAsync(final String seed, final Callback callback) {
 
-             runStatusGoMethodInSeparateThread(() -> {
-                String resIdenticon = Statusgo.identicon(seed);
-                String resAlias = Statusgo.generateAlias(seed);
-                return new String[]{resAlias, resIdenticon};
-            }, callback);
+         Log.d(TAG, "generateAliasAndIdenticonAsync");
+                if (!checkAvailability()) {
+                    callback.invoke(false);
+                    return;
+                }
+
+                Runnable r = new Runnable() {
+                    @Override
+                    public void run() {
+                        String resIdenticon = Statusgo.identicon(seed);
+                        String resAlias = Statusgo.generateAlias(seed);
+
+                        Log.d(TAG, resIdenticon);
+                        Log.d(TAG, resAlias);
+                        callback.invoke(resAlias, resIdenticon);
+                    }
+                };
+
+                StatusThreadPoolExecutor.getInstance().execute(r);
 
     }
 
@@ -1267,8 +1248,8 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
     }
 
     @ReactMethod
-    public void validateMnemonic(final String seed, final Callback callback) {
-        runStatusGoMethodInSeparateThread(() -> Statusgo.validateMnemonic(seed), callback);
+    public void validateMnemonic(final String seed, final Callback callback) throws JSONException {
+        executeRunnableStatusGoMethod(() -> Statusgo.validateMnemonic(seed), callback);
     }
 
     @ReactMethod
@@ -1319,25 +1300,14 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
     }
 
     @ReactMethod
-    public void reEncryptDbAndKeystore(final String keyUID, final String password, final String newPassword, final Callback callback) {
-        Log.d(TAG, "reEncryptDbAndKeyStore");
-
-        Runnable r = new Runnable() {
-            @Override
-            public void run() {
-		// changes db password and re-encrypts keystore
-                String result = Statusgo.changeDatabasePassword(keyUID, password, newPassword);
-                callback.invoke(result);
-            }
-        };
-
-        StatusThreadPoolExecutor.getInstance().execute(r);
+    public void reEncryptDbAndKeystore(final String keyUID, final String password, final String newPassword, final Callback callback) throws JSONException {
+        executeRunnableStatusGoMethod(() -> Statusgo.changeDatabasePassword(keyUID, password, newPassword), callback);
     }
 
     @ReactMethod
-    public void convertToKeycardAccount(final String keyUID, final String accountData, final String options, final String password, final String newPassword, final Callback callback) {
+    public void convertToKeycardAccount(final String keyUID, final String accountData, final String options, final String password, final String newPassword, final Callback callback) throws JSONException {
         final String keyStoreDir = this.getKeyStorePath(keyUID);
-         runStatusGoMethodInSeparateThread(() -> Statusgo.validateMnemonic(keyStoreDir, accountData, options, password, newPassword), callback);
+        executeRunnableStatusGoMethod(() -> Statusgo.convertToKeycardAccount(keyStoreDir, accountData, options, password, newPassword), callback);
     }
 
 }

--- a/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusModule.java
+++ b/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusModule.java
@@ -59,6 +59,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
+import java.lang.reflect.Method;
+import java.lang.reflect.InvocationTargetException;
 import java.text.SimpleDateFormat;
 import java.util.HashMap;
 import java.util.Map;
@@ -527,45 +529,46 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
         StatusThreadPoolExecutor.getInstance().execute(r);
     }
 
+   private void executeRunnableStatusGoMethod(final String methodName, final Callback callback, final Object... args) {
+       if (!checkAvailability()) {
+           callback.invoke(false);
+           return;
+       }
+
+       Runnable runnableTask = new Runnable() {
+           @Override
+           public void run() {
+               String res = "";
+               try {
+                   Method method = Statusgo.class.getMethod(methodName);
+                   if (args.length > 0) {
+                       res = (String) method.invoke(null, args);
+                   } else {
+                       res = (String) method.invoke(null);
+                   }
+               } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+                   e.printStackTrace();
+               }
+               callback.invoke(res);
+           }
+       };
+
+       StatusThreadPoolExecutor.getInstance().execute(runnableTask);
+   }
+
     @ReactMethod
     public void verify(final String address, final String password, final Callback callback) {
-        Log.d(TAG, "verify");
-        if (!checkAvailability()) {
-            callback.invoke(false);
-            return;
-        }
-
         Activity currentActivity = getCurrentActivity();
 
         final String absRootDirPath = this.getNoBackupDirectory();
         final String newKeystoreDir = pathCombine(absRootDirPath, "keystore");
 
-        Runnable r = new Runnable() {
-            @Override
-            public void run() {
-                String result = Statusgo.verifyAccountPassword(newKeystoreDir, address, password);
-
-                callback.invoke(result);
-            }
-        };
-
-        StatusThreadPoolExecutor.getInstance().execute(r);
+        executeRunnableStatusGoMethod("verify", callback, "");
     }
 
     @ReactMethod
     public void verifyDatabasePassword(final String keyUID, final String password, final Callback callback) {
-        Log.d(TAG, "verifyDatabasePassword");
-
-        Runnable r = new Runnable() {
-            @Override
-            public void run() {
-                String result = Statusgo.verifyDatabasePassword(keyUID, password);
-
-                callback.invoke(result);
-            }
-        };
-
-        StatusThreadPoolExecutor.getInstance().execute(r);
+        executeRunnableStatusGoMethod("verifyDatabasePassword", callback, keyUID, password);
     }
 
     public String getKeyStorePath(String keyUID) {
@@ -736,208 +739,57 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
 
     @ReactMethod
     public void addPeer(final String enode, final Callback callback) {
-        Log.d(TAG, "addPeer");
-        if (!checkAvailability()) {
-            callback.invoke(false);
-            return;
-        }
-
-        Runnable r = new Runnable() {
-            @Override
-            public void run() {
-                String res = Statusgo.addPeer(enode);
-
-                callback.invoke(res);
-            }
-        };
-
-        StatusThreadPoolExecutor.getInstance().execute(r);
+        executeRunnableStatusGoMethod("addPeer", callback, enode);
     }
 
     @ReactMethod
     public void multiAccountStoreAccount(final String json, final Callback callback) {
-        Log.d(TAG, "multiAccountStoreAccount");
-        if (!checkAvailability()) {
-            callback.invoke(false);
-            return;
-        }
-        Runnable r = new Runnable() {
-            @Override
-            public void run() {
-                String res = Statusgo.multiAccountStoreAccount(json);
-
-                callback.invoke(res);
-            }
-        };
-
-        StatusThreadPoolExecutor.getInstance().execute(r);
+        executeRunnableStatusGoMethod("multiAccountStoreAccount", callback, json);
     }
 
     @ReactMethod
     public void multiAccountLoadAccount(final String json, final Callback callback) {
-        Log.d(TAG, "multiAccountLoadAccount");
-        if (!checkAvailability()) {
-            callback.invoke(false);
-            return;
-        }
-        Runnable r = new Runnable() {
-            @Override
-            public void run() {
-                String res = Statusgo.multiAccountLoadAccount(json);
-
-                callback.invoke(res);
-            }
-        };
-
-        StatusThreadPoolExecutor.getInstance().execute(r);
+        executeRunnableStatusGoMethod("multiAccountLoadAccount", callback, json);
     }
 
     @ReactMethod
     public void multiAccountReset(final Callback callback) {
-        Log.d(TAG, "multiAccountReset");
-        if (!checkAvailability()) {
-            callback.invoke(false);
-            return;
-        }
-        Runnable r = new Runnable() {
-            @Override
-            public void run() {
-                String res = Statusgo.multiAccountReset();
-
-                callback.invoke(res);
-            }
-        };
-
-        StatusThreadPoolExecutor.getInstance().execute(r);
+        executeRunnableStatusGoMethod("multiAccountReset", callback, "");
     }
 
     @ReactMethod
     public void multiAccountDeriveAddresses(final String json, final Callback callback) {
-        Log.d(TAG, "multiAccountDeriveAddresses");
-        if (!checkAvailability()) {
-            callback.invoke(false);
-            return;
-        }
-        Runnable r = new Runnable() {
-            @Override
-            public void run() {
-                String res = Statusgo.multiAccountDeriveAddresses(json);
-
-                callback.invoke(res);
-            }
-        };
-
-        StatusThreadPoolExecutor.getInstance().execute(r);
+        executeRunnableStatusGoMethod("multiAccountDeriveAddresses", callback, json);
     }
 
     @ReactMethod
     public void multiAccountGenerateAndDeriveAddresses(final String json, final Callback callback) {
-        Log.d(TAG, "multiAccountGenerateAndDeriveAddresses");
-        if (!checkAvailability()) {
-            callback.invoke(false);
-            return;
-        }
-        Runnable r = new Runnable() {
-            @Override
-            public void run() {
-                String res = Statusgo.multiAccountGenerateAndDeriveAddresses(json);
-
-                callback.invoke(res);
-            }
-        };
-
-        StatusThreadPoolExecutor.getInstance().execute(r);
+        executeRunnableStatusGoMethod("multiAccountGenerateAndDeriveAddresses", callback, json);
     }
 
     @ReactMethod
     public void multiAccountStoreDerived(final String json, final Callback callback) {
-        Log.d(TAG, "multiAccountStoreDerived");
-        if (!checkAvailability()) {
-            callback.invoke(false);
-            return;
-        }
-        Runnable r = new Runnable() {
-            @Override
-            public void run() {
-                String res = Statusgo.multiAccountStoreDerivedAccounts(json);
-
-                callback.invoke(res);
-            }
-        };
-
-        StatusThreadPoolExecutor.getInstance().execute(r);
+        executeRunnableStatusGoMethod("multiAccountStoreDerivedAccounts", callback, json);
     }
 
     @ReactMethod
     public void multiAccountImportMnemonic(final String json, final Callback callback) {
-        Log.d(TAG, "multiAccountImportMnemonic");
-        if (!checkAvailability()) {
-            callback.invoke(false);
-            return;
-        }
-        Runnable r = new Runnable() {
-            @Override
-            public void run() {
-                String res = Statusgo.multiAccountImportMnemonic(json);
-                callback.invoke(res);
-            }
-        };
-        StatusThreadPoolExecutor.getInstance().execute(r);
+        executeRunnableStatusGoMethod("multiAccountImportMnemonic", callback, json);
     }
 
     @ReactMethod
     public void multiAccountImportPrivateKey(final String json, final Callback callback) {
-        Log.d(TAG, "multiAccountImportPrivateKey");
-        if (!checkAvailability()) {
-            callback.invoke(false);
-            return;
-        }
-        Runnable r = new Runnable() {
-            @Override
-            public void run() {
-                String res = Statusgo.multiAccountImportPrivateKey(json);
-                callback.invoke(res);
-            }
-        };
-        StatusThreadPoolExecutor.getInstance().execute(r);
+        executeRunnableStatusGoMethod("multiAccountImportPrivateKey", callback, json);
     }
 
     @ReactMethod
     public void hashTransaction(final String txArgsJSON, final Callback callback) {
-        Log.d(TAG, "hashTransaction");
-        if (!checkAvailability()) {
-            callback.invoke(false);
-            return;
-        }
-
-        Runnable r = new Runnable() {
-            @Override
-            public void run() {
-                String res = Statusgo.hashTransaction(txArgsJSON);
-                callback.invoke(res);
-            }
-        };
-
-        StatusThreadPoolExecutor.getInstance().execute(r);
+        executeRunnableStatusGoMethod("hashTransaction", callback, txArgsJSON);
     }
 
     @ReactMethod
     public void hashMessage(final String message, final Callback callback) {
-        Log.d(TAG, "hashMessage");
-        if (!checkAvailability()) {
-            callback.invoke(false);
-            return;
-        }
-
-        Runnable r = new Runnable() {
-            @Override
-            public void run() {
-                String res = Statusgo.hashMessage(message);
-                callback.invoke(res);
-            }
-        };
-
-        StatusThreadPoolExecutor.getInstance().execute(r);
+        executeRunnableStatusGoMethod("hashMessage", callback, message);
     }
 
     @ReactMethod
@@ -947,20 +799,7 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
          final String keyStorePath = this.getKeyStorePath(keyUID);
          jsonConfig.put("keystorePath", keyStorePath);
 
-        if (!checkAvailability()) {
-            callback.invoke(false);
-            return;
-        }
-
-        Runnable runnableTask = new Runnable() {
-            @Override
-            public void run() {
-                String res = Statusgo.getConnectionStringForBootstrappingAnotherDevice(jsonConfig.toString());
-                callback.invoke(res);
-            }
-        };
-
-        StatusThreadPoolExecutor.getInstance().execute(runnableTask);
+        executeRunnableStatusGoMethod("getConnectionStringForBootstrappingAnotherDevice", callback, jsonConfig.toString());
     }
 
     @ReactMethod
@@ -969,20 +808,7 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
          final String keyStorePath = pathCombine(this.getNoBackupDirectory(), "/keystore");
          jsonConfig.put("keystorePath", keyStorePath);
 
-        if (!checkAvailability()) {
-            callback.invoke(false);
-            return;
-        }
-
-        Runnable runnableTask = new Runnable() {
-            @Override
-            public void run() {
-                String res = Statusgo.inputConnectionStringForBootstrapping(connectionString,jsonConfig.toString());
-                callback.invoke(res);
-            }
-        };
-
-        StatusThreadPoolExecutor.getInstance().execute(runnableTask);
+        executeRunnableStatusGoMethod("inputConnectionStringForBootstrapping", callback, connectionString, jsonConfig.toString());
     }
 
     @ReactMethod
@@ -1077,154 +903,43 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
 
     @ReactMethod
     public void hashTypedData(final String data, final Callback callback) {
-        Log.d(TAG, "hashTypedData");
-        if (!checkAvailability()) {
-            callback.invoke(false);
-            return;
-        }
-
-        Runnable r = new Runnable() {
-            @Override
-            public void run() {
-                String res = Statusgo.hashTypedData(data);
-                callback.invoke(res);
-            }
-        };
-
-        StatusThreadPoolExecutor.getInstance().execute(r);
+        executeRunnableStatusGoMethod("hashTypedData", callback, data);
     }
 
     @ReactMethod
     public void hashTypedDataV4(final String data, final Callback callback) {
-        Log.d(TAG, "hashTypedDataV4");
-        if (!checkAvailability()) {
-            callback.invoke(false);
-            return;
-        }
-
-        Runnable r = new Runnable() {
-            @Override
-            public void run() {
-                String res = Statusgo.hashTypedDataV4(data);
-                callback.invoke(res);
-            }
-        };
-
-        StatusThreadPoolExecutor.getInstance().execute(r);
+        executeRunnableStatusGoMethod("hashTypedDataV4", callback, data);
     }
 
     @ReactMethod
     public void sendTransactionWithSignature(final String txArgsJSON, final String signature, final Callback callback) {
-        Log.d(TAG, "sendTransactionWithSignature");
-        if (!checkAvailability()) {
-            callback.invoke(false);
-            return;
-        }
-
-        Runnable r = new Runnable() {
-            @Override
-            public void run() {
-                String res = Statusgo.sendTransactionWithSignature(txArgsJSON, signature);
-                callback.invoke(res);
-            }
-        };
-
-        StatusThreadPoolExecutor.getInstance().execute(r);
+        executeRunnableStatusGoMethod("sendTransactionWithSignature", callback, txArgsJSON, signature);
     }
 
     @ReactMethod
     public void sendTransaction(final String txArgsJSON, final String password, final Callback callback) {
-        Log.d(TAG, "sendTransaction");
-        if (!checkAvailability()) {
-            callback.invoke(false);
-            return;
-        }
-
-        Runnable r = new Runnable() {
-            @Override
-            public void run() {
-                String res = Statusgo.sendTransaction(txArgsJSON, password);
-                callback.invoke(res);
-            }
-        };
-
-        StatusThreadPoolExecutor.getInstance().execute(r);
+        executeRunnableStatusGoMethod("sendTransaction", callback, txArgsJSON, password);
     }
 
     @ReactMethod
     public void signMessage(final String rpcParams, final Callback callback) {
-        Log.d(TAG, "signMessage");
-        if (!checkAvailability()) {
-            callback.invoke(false);
-            return;
-        }
-
-        Runnable r = new Runnable() {
-            @Override
-            public void run() {
-                String res = Statusgo.signMessage(rpcParams);
-                callback.invoke(res);
-            }
-        };
-
-        StatusThreadPoolExecutor.getInstance().execute(r);
+        executeRunnableStatusGoMethod("signMessage", callback, rpcParams);
     }
 
     @ReactMethod
     public void recover(final String rpcParams, final Callback callback) {
-        Log.d(TAG, "recover");
-        if (!checkAvailability()) {
-            callback.invoke(false);
-            return;
-        }
-
-        Runnable r = new Runnable() {
-            @Override
-            public void run() {
-                String res = Statusgo.recover(rpcParams);
-                callback.invoke(res);
-            }
-        };
-
-        StatusThreadPoolExecutor.getInstance().execute(r);
+        executeRunnableStatusGoMethod("recover", callback, rpcParams);
     }
 
     @ReactMethod
     public void signTypedData(final String data, final String account, final String password, final Callback callback) {
-        Log.d(TAG, "signTypedData");
-        if (!checkAvailability()) {
-            callback.invoke(false);
-            return;
-        }
-
-        Runnable r = new Runnable() {
-            @Override
-            public void run() {
-                String res = Statusgo.signTypedData(data, account, password);
-                callback.invoke(res);
-            }
-        };
-
-        StatusThreadPoolExecutor.getInstance().execute(r);
+        executeRunnableStatusGoMethod("signTypedData", callback, data, account, password);
     }
 
     @ReactMethod
     public void signTypedDataV4(final String data, final String account, final String password, final Callback callback) {
-        Log.d(TAG, "signTypedDataV4");
-        if (!checkAvailability()) {
-            callback.invoke(false);
-            return;
-        }
+        executeRunnableStatusGoMethod("signTypedDataV4", callback, data, account, password);
 
-        Runnable r = new Runnable() {
-            @Override
-            public void run() {
-                String res = Statusgo.signTypedDataV4(data, account, password);
-                callback.invoke(res);
-            }
-        };
-
-        StatusThreadPoolExecutor.getInstance().execute(r);
     }
 
     @ReactMethod
@@ -1330,28 +1045,12 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
 
     @ReactMethod
     public void callRPC(final String payload, final Callback callback) {
-        Runnable r = new Runnable() {
-            @Override
-            public void run() {
-                String res = Statusgo.callRPC(payload);
-                callback.invoke(res);
-            }
-        };
-
-        StatusThreadPoolExecutor.getInstance().execute(r);
+        executeRunnableStatusGoMethod("callRPC", callback, payload);
     }
 
     @ReactMethod
     public void callPrivateRPC(final String payload, final Callback callback) {
-        Runnable r = new Runnable() {
-            @Override
-            public void run() {
-                String res = Statusgo.callPrivateRPC(payload);
-                callback.invoke(res);
-            }
-        };
-
-        StatusThreadPoolExecutor.getInstance().execute(r);
+        executeRunnableStatusGoMethod("callPrivateRPC", callback, payload);
     }
 
     @ReactMethod
@@ -1415,104 +1114,29 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
 
     @ReactMethod
     public void extractGroupMembershipSignatures(final String signaturePairs, final Callback callback) {
-        Log.d(TAG, "extractGroupMembershipSignatures");
-        if (!checkAvailability()) {
-            callback.invoke(false);
-            return;
-        }
-
-        Runnable r = new Runnable() {
-            @Override
-            public void run() {
-                String result = Statusgo.extractGroupMembershipSignatures(signaturePairs);
-
-                callback.invoke(result);
-            }
-        };
-
-        StatusThreadPoolExecutor.getInstance().execute(r);
+        executeRunnableStatusGoMethod("extractGroupMembershipSignatures", callback, signaturePairs);
     }
 
     @ReactMethod
     public void signGroupMembership(final String content, final Callback callback) {
-        Log.d(TAG, "signGroupMembership");
-        if (!checkAvailability()) {
-            callback.invoke(false);
-            return;
-        }
-
-        Runnable r = new Runnable() {
-            @Override
-            public void run() {
-                String result = Statusgo.signGroupMembership(content);
-
-                callback.invoke(result);
-            }
-        };
-
-        StatusThreadPoolExecutor.getInstance().execute(r);
+        executeRunnableStatusGoMethod("signGroupMembership", callback, content);
     }
 
     @ReactMethod
     public void getNodeConfig(final Callback callback) {
-        Log.d(TAG, "getNodeConfig");
-        if (!checkAvailability()) {
-            callback.invoke(false);
-            return;
-        }
-
-        Runnable r = new Runnable() {
-            @Override
-            public void run() {
-                String result = Statusgo.getNodeConfig();
-
-                callback.invoke(result);
-            }
-        };
-
-        StatusThreadPoolExecutor.getInstance().execute(r);
+         executeRunnableStatusGoMethod("getNodeConfig", callback, "");
     }
 
     @ReactMethod
     public void deleteMultiaccount(final String keyUID, final Callback callback) {
-        Log.d(TAG, "deleteMultiaccount");
-        if (!checkAvailability()) {
-            callback.invoke(false);
-            return;
-        }
-
         final String keyStoreDir = this.getKeyStorePath(keyUID);
-        Runnable r = new Runnable() {
-            @Override
-            public void run() {
-                String res = Statusgo.deleteMultiaccount(keyUID, keyStoreDir);
-
-                callback.invoke(res);
-            }
-        };
-
-        StatusThreadPoolExecutor.getInstance().execute(r);
+        executeRunnableStatusGoMethod("deleteMultiaccount", callback, keyUID, keyStoreDir);
     }
 
     @ReactMethod
     public void deleteImportedKey(final String keyUID, final String address, final String password, final Callback callback) {
-        Log.d(TAG, "deleteImportedKey");
-        if (!checkAvailability()) {
-            callback.invoke(false);
-            return;
-        }
-
         final String keyStoreDir = this.getKeyStorePath(keyUID);
-        Runnable r = new Runnable() {
-            @Override
-            public void run() {
-                String res = Statusgo.deleteImportedKey(address, password, keyStoreDir);
-
-                callback.invoke(res);
-            }
-        };
-
-        StatusThreadPoolExecutor.getInstance().execute(r);
+        executeRunnableStatusGoMethod("deleteImportedKey", callback, address, password, keyStoreDir);
     }
 
     @ReactMethod(isBlockingSynchronousMethod = true)
@@ -1522,23 +1146,7 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
 
     @ReactMethod
     public void generateAliasAsync(final String seed, final Callback callback) {
-        Log.d(TAG, "generateAliasAsync");
-        if (!checkAvailability()) {
-            callback.invoke(false);
-            return;
-        }
-
-        Runnable r = new Runnable() {
-            @Override
-            public void run() {
-                String res = Statusgo.generateAlias(seed);
-
-                Log.d(TAG, res);
-                callback.invoke(res);
-            }
-        };
-
-        StatusThreadPoolExecutor.getInstance().execute(r);
+        executeRunnableStatusGoMethod("generateAlias", callback, seed);
     }
 
     @ReactMethod(isBlockingSynchronousMethod = true)
@@ -1603,23 +1211,7 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
 
     @ReactMethod
     public void identiconAsync(final String seed, final Callback callback) {
-        Log.d(TAG, "identiconAsync");
-        if (!checkAvailability()) {
-            callback.invoke(false);
-            return;
-        }
-
-        Runnable r = new Runnable() {
-            @Override
-            public void run() {
-                String res = Statusgo.identicon(seed);
-
-                Log.d(TAG, res);
-                callback.invoke(res);
-            }
-        };
-
-        StatusThreadPoolExecutor.getInstance().execute(r);
+        executeRunnableStatusGoMethod("identicon", callback, seed);
     }
 
     @ReactMethod
@@ -1665,23 +1257,7 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
 
     @ReactMethod
     public void validateMnemonic(final String seed, final Callback callback) {
-        Log.d(TAG, "validateMnemonic");
-        if (!checkAvailability()) {
-            callback.invoke(false);
-            return;
-        }
-
-        Runnable r = new Runnable() {
-            @Override
-            public void run() {
-                String resValidateMnemonic = Statusgo.validateMnemonic(seed);
-
-                Log.d(TAG, resValidateMnemonic);
-                callback.invoke(resValidateMnemonic);
-            }
-        };
-
-        StatusThreadPoolExecutor.getInstance().execute(r);
+        executeRunnableStatusGoMethod("validateMnemonic", callback, seed);
     }
 
     @ReactMethod
@@ -1749,18 +1325,8 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
 
     @ReactMethod
     public void convertToKeycardAccount(final String keyUID, final String accountData, final String options, final String password, final String newPassword, final Callback callback) {
-        Log.d(TAG, "convertToKeycardAccount");
-
         final String keyStoreDir = this.getKeyStorePath(keyUID);
-        Runnable r = new Runnable() {
-            @Override
-            public void run() {
-                String result = Statusgo.convertToKeycardAccount(keyStoreDir, accountData, options, password, newPassword);
-                callback.invoke(result);
-            }
-        };
-
-        StatusThreadPoolExecutor.getInstance().execute(r);
+        executeRunnableStatusGoMethod("validateMnemonic", callback, keyStoreDir, accountData, options, password, newPassword);
     }
 
 }

--- a/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusModule.java
+++ b/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusModule.java
@@ -63,7 +63,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.InvocationTargetException;
 import java.text.SimpleDateFormat;
 import java.util.HashMap;
-import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.Map;
 import java.util.Stack;
 import java.util.zip.ZipEntry;
@@ -138,18 +138,18 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
     }
 
 
-    private void runFunctionInSeparateThread(Function<Void, String[]> func, Callback callback) {
-        if (!checkAvailability()) {
-            callback.invoke(false);
-            return;
-        }
+    private void runFunctionInSeparateThread(Supplier<String[]> func, Callback callback) {
+       if (!checkAvailability()) {
+          callback.invoke(false);
+          return;
+       }
 
-        Runnable r = () -> {
-            String[] res = func.apply(null);
-            callback.invoke(res);
-        };
+       Runnable r = () -> {
+          String[] res = func.get();
+          callback.invoke(res);
+       };
 
-        StatusThreadPoolExecutor.getInstance().execute(r);
+       StatusThreadPoolExecutor.getInstance().execute(r);
     }
 
     public String getNoBackupDirectory() {


### PR DESCRIPTION
This commit adds a method `executeRunnableStatusGoMethod ` which abstracts common logic out of several methods in  `StatusModule.java`

fixes #14687

#### Platforms
- Android

#### Areas that maybe impacted
Any and everything where the app uses status-go

### Steps to test
please test everything

status: ready
