### PR TITLE
Persist switcher cards

### DIFF
--- a/src/status_im/data_store/switcher_cards.cljs
+++ b/src/status_im/data_store/switcher_cards.cljs
@@ -1,0 +1,41 @@
+(ns status-im.data-store.switcher-cards
+  (:require [clojure.set :as set]
+            [clojure.walk :as walk]
+            [utils.re-frame :as rf]
+            [taoensso.timbre :as log]))
+
+(defn <-rpc
+  [switcher-cards]
+  (walk/postwalk-replace
+   {:cardId   :card-id
+    :screenId :screen-id}
+   switcher-cards))
+
+(defn rpc->
+  [switcher-card]
+  (set/rename-keys switcher-card
+                   {:card-id   :cardId
+                    :screen-id :screenId}))
+
+(rf/defn upsert-switcher-card-rpc
+  [_ switcher-card]
+  {:json-rpc/call [{:method     "wakuext_upsertSwitcherCard"
+                    :params     [(rpc-> switcher-card)]
+                    :on-success #()
+                    :on-error   #()}]})
+
+(rf/defn delete-switcher-card-rpc
+  [_ card-id]
+  {:json-rpc/call [{:method     "wakuext_deleteSwitcherCard"
+                    :params     [card-id]
+                    :on-success #()
+                    :on-error   #()}]})
+
+(rf/defn fetch-switcher-cards-rpc
+  [_]
+  {:json-rpc/call [{:method     "wakuext_switcherCards"
+                    :params     []
+                    :on-success #(rf/dispatch
+                                  [:shell/switcher-cards-loaded
+                                   (:switcherCards ^js %)])
+                    :on-error   #(log/error "Failed to fetch switcher cards" %)}]})

--- a/src/status_im/multiaccounts/login/core.cljs
+++ b/src/status_im/multiaccounts/login/core.cljs
@@ -9,6 +9,7 @@
    [status-im.data-store.chats :as data-store.chats]
    [status-im.data-store.invitations :as data-store.invitations]
    [status-im.data-store.settings :as data-store.settings]
+   [status-im.data-store.switcher-cards :as switcher-cards-store]
    [status-im.data-store.visibility-status-updates :as visibility-status-updates-store]
    [status-im.ethereum.core :as ethereum]
    [status-im.ethereum.eip55 :as eip55]
@@ -473,7 +474,8 @@
               (multiaccounts/get-profile-picture)
               (multiaccounts/switch-preview-privacy-mode-flag)
               (link-preview/request-link-preview-whitelist)
-              (visibility-status-updates-store/fetch-visibility-status-updates-rpc))))
+              (visibility-status-updates-store/fetch-visibility-status-updates-rpc)
+              (switcher-cards-store/fetch-switcher-cards-rpc))))
 
 (defn get-new-auth-method
   [auth-method save-password?]

--- a/src/status_im2/contexts/shell/view.cljs
+++ b/src/status_im2/contexts/shell/view.cljs
@@ -47,19 +47,19 @@
    (i18n/label :t/jump-to)])
 
 (defn render-card
-  [{:keys [id type channel-id] :as card}]
+  [{:keys [type screen-id] :as card}]
   (let [card-data (case type
                     shell.constants/one-to-one-chat-card
-                    (rf/sub [:shell/one-to-one-chat-card id])
+                    (rf/sub [:shell/one-to-one-chat-card screen-id])
 
                     shell.constants/private-group-chat-card
-                    (rf/sub [:shell/private-group-chat-card id])
+                    (rf/sub [:shell/private-group-chat-card screen-id])
 
                     shell.constants/community-card
-                    (rf/sub [:shell/community-card id])
+                    (rf/sub [:shell/community-card screen-id])
 
                     shell.constants/community-channel-card
-                    (rf/sub [:shell/community-channel-card channel-id])
+                    (rf/sub [:shell/community-channel-card screen-id])
 
                     nil)]
     [switcher-cards/card (merge card card-data)]))

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "d43e06f4c27a900641cd55c2a46002e6f0909c95",
-    "commit-sha1": "d43e06f4c27a900641cd55c2a46002e6f0909c95",
-    "src-sha256": "18n5h3yx6wxb5l1nvra868dhnyl732zvpdn3mqg4zfsjxmx82np7"
+    "version": "v0.117.3",
+    "commit-sha1": "d40290a649133eb7b7f450b5c5b74eec28ba232d",
+    "src-sha256": "140j0gbp8nxzncya9mcpvlxnax5ajfl8c32ih20b29n8j525gw66"
 }


### PR DESCRIPTION
status-go PR: https://github.com/status-im/status-go/pull/3049

### Testing:
PR handles storing the card when opening chat, community, etc. And deleting the card by pressing the close button.
Removing the card when deleting chat, blocking user, etc. will be implemented later. 

status : ready