### PR TITLE
Adjusted border color on outline button

### DIFF
--- a/src/quo2/components/buttons/button.cljs
+++ b/src/quo2/components/buttons/button.cljs
@@ -32,9 +32,9 @@
            :outline         {:icon-color           colors/neutral-50
                              :icon-secondary-color colors/neutral-50
                              :label-color          colors/neutral-100
-                             :border-color         {:default  colors/neutral-20
+                             :border-color         {:default  colors/neutral-30
                                                     :pressed  colors/neutral-40
-                                                    :disabled colors/neutral-20}}
+                                                    :disabled colors/neutral-30}}
            :ghost           {:icon-color           colors/neutral-50
                              :icon-secondary-color colors/neutral-50
                              :label-color          colors/neutral-100


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/14699

### Summary

[comment]: # (Summarise the problem and how the pull request solves it)

Updates border colors for outline buttons in the light theme (it's already fine and set properly for dark theme).
Dropdown component is basically a button with an icon so it covers this case as well.

### Testing notes
<!-- (Optional) -->

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

status: ready <!-- Can be ready or wip -->
