### PR TITLE
Fix clojure.set and clojure.walk inconsistent namespace aliases

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -11,6 +11,8 @@
                 taoensso.tufte/defnp               clojure.core/defn}
  :linters      {:consistent-alias  {:level   :error
                                     :aliases {clojure.string  string
+                                              clojure.set     set
+                                              clojure.walk    walk
                                               taoensso.timbre log}}
                 :invalid-arity     {:skip-args [status-im.utils.fx/defn utils.re-frame/defn]}
                 ;; TODO remove number when this is fixed

--- a/src/status_im/communities/core.cljs
+++ b/src/status_im/communities/core.cljs
@@ -1,5 +1,5 @@
 (ns status-im.communities.core
-  (:require [clojure.set :as clojure.set]
+  (:require [clojure.set :as set]
             [clojure.string :as string]
             [clojure.walk :as walk]
             [quo.design-system.colors :as colors]
@@ -28,10 +28,10 @@
 
 (defn <-request-to-join-community-rpc
   [r]
-  (clojure.set/rename-keys r
-                           {:communityId :community-id
-                            :publicKey   :public-key
-                            :chatId      :chat-id}))
+  (set/rename-keys r
+                   {:communityId :community-id
+                    :publicKey   :public-key
+                    :chatId      :chat-id}))
 
 (defn <-requests-to-join-community-rpc
   [requests]
@@ -64,12 +64,12 @@
 (defn <-rpc
   [c]
   (-> c
-      (clojure.set/rename-keys {:canRequestAccess            :can-request-access?
-                                :canManageUsers              :can-manage-users?
-                                :canDeleteMessageForEveryone :can-delete-message-for-everyone?
-                                :canJoin                     :can-join?
-                                :requestedToJoinAt           :requested-to-join-at
-                                :isMember                    :is-member?})
+      (set/rename-keys {:canRequestAccess            :can-request-access?
+                        :canManageUsers              :can-manage-users?
+                        :canDeleteMessageForEveryone :can-delete-message-for-everyone?
+                        :canJoin                     :can-join?
+                        :requestedToJoinAt           :requested-to-join-at
+                        :isMember                    :is-member?})
       (update :members walk/stringify-keys)
       (update :chats <-chats-rpc)
       (update :categories <-categories-rpc)))

--- a/src/status_im/contact/db.cljs
+++ b/src/status_im/contact/db.cljs
@@ -1,5 +1,5 @@
 (ns status-im.contact.db
-  (:require [clojure.set :as clojure.set]
+  (:require [clojure.set :as set]
             [clojure.string :as string]
             [status-im.constants :as constants]
             [status-im.ethereum.core :as ethereum]
@@ -68,8 +68,8 @@
   (let [current-contact (some->
                          current-account
                          (select-keys [:name :preferred-name :public-key :identicon :images])
-                         (clojure.set/rename-keys {:name           :alias
-                                                   :preferred-name :name}))
+                         (set/rename-keys {:name           :alias
+                                           :preferred-name :name}))
         all-contacts    (cond-> contacts
                           current-contact
                           (assoc public-key current-contact))]

--- a/src/status_im/data_store/chats.cljs
+++ b/src/status_im/data_store/chats.cljs
@@ -1,5 +1,5 @@
 (ns status-im.data-store.chats
-  (:require [clojure.set :as clojure.set]
+  (:require [clojure.set :as set]
             [status-im.constants :as constants]
             [status-im.data-store.messages :as messages]
             [utils.re-frame :as rf]
@@ -58,19 +58,19 @@
 (defn <-rpc
   [chat]
   (-> chat
-      (clojure.set/rename-keys {:id                     :chat-id
-                                :communityId            :community-id
-                                :syncedFrom             :synced-from
-                                :syncedTo               :synced-to
-                                :membershipUpdateEvents :membership-update-events
-                                :deletedAtClockValue    :deleted-at-clock-value
-                                :chatType               :chat-type
-                                :unviewedMessagesCount  :unviewed-messages-count
-                                :unviewedMentionsCount  :unviewed-mentions-count
-                                :lastMessage            :last-message
-                                :lastClockValue         :last-clock-value
-                                :invitationAdmin        :invitation-admin
-                                :profile                :profile-public-key})
+      (set/rename-keys {:id                     :chat-id
+                        :communityId            :community-id
+                        :syncedFrom             :synced-from
+                        :syncedTo               :synced-to
+                        :membershipUpdateEvents :membership-update-events
+                        :deletedAtClockValue    :deleted-at-clock-value
+                        :chatType               :chat-type
+                        :unviewedMessagesCount  :unviewed-messages-count
+                        :unviewedMentionsCount  :unviewed-mentions-count
+                        :lastMessage            :last-message
+                        :lastClockValue         :last-clock-value
+                        :invitationAdmin        :invitation-admin
+                        :profile                :profile-public-key})
       rpc->type
       unmarshal-members
       (update :last-message #(when % (messages/<-rpc %)))

--- a/src/status_im/data_store/contacts.cljs
+++ b/src/status_im/data_store/contacts.cljs
@@ -1,12 +1,12 @@
 (ns status-im.data-store.contacts
-  (:require [clojure.set :as clojure.set]
+  (:require [clojure.set :as set]
             [utils.re-frame :as rf]
             [taoensso.timbre :as log]))
 
 (defn <-rpc
   [contact]
   (-> contact
-      (clojure.set/rename-keys
+      (set/rename-keys
        {:id                     :public-key
         :ensVerifiedAt          :ens-verified-at
         :displayName            :display-name

--- a/src/status_im/data_store/messages.cljs
+++ b/src/status_im/data_store/messages.cljs
@@ -1,5 +1,5 @@
 (ns status-im.data-store.messages
-  (:require [clojure.set :as clojure.set]
+  (:require [clojure.set :as set]
             [utils.re-frame :as rf]
             [taoensso.timbre :as log]))
 
@@ -10,40 +10,40 @@
     (assoc :text    (:text content)
            :sticker (:sticker content))
     :always
-    (clojure.set/rename-keys {:chat-id           :chat_id
-                              :whisper-timestamp :whisperTimestamp
-                              :community-id      :communityId
-                              :clock-value       :clock})))
+    (set/rename-keys {:chat-id           :chat_id
+                      :whisper-timestamp :whisperTimestamp
+                      :community-id      :communityId
+                      :clock-value       :clock})))
 
 (defn <-rpc
   [message]
   (-> message
-      (clojure.set/rename-keys {:id                       :message-id
-                                :whisperTimestamp         :whisper-timestamp
-                                :editedAt                 :edited-at
-                                :contactVerificationState :contact-verification-state
-                                :contactRequestState      :contact-request-state
-                                :commandParameters        :command-parameters
-                                :gapParameters            :gap-parameters
-                                :messageType              :message-type
-                                :localChatId              :chat-id
-                                :communityId              :community-id
-                                :contentType              :content-type
-                                :clock                    :clock-value
-                                :quotedMessage            :quoted-message
-                                :outgoingStatus           :outgoing-status
-                                :audioDurationMs          :audio-duration-ms
-                                :deleted                  :deleted?
-                                :deletedForMe             :deleted-for-me?
-                                :albumId                  :album-id
-                                :new                      :new?})
+      (set/rename-keys {:id                       :message-id
+                        :whisperTimestamp         :whisper-timestamp
+                        :editedAt                 :edited-at
+                        :contactVerificationState :contact-verification-state
+                        :contactRequestState      :contact-request-state
+                        :commandParameters        :command-parameters
+                        :gapParameters            :gap-parameters
+                        :messageType              :message-type
+                        :localChatId              :chat-id
+                        :communityId              :community-id
+                        :contentType              :content-type
+                        :clock                    :clock-value
+                        :quotedMessage            :quoted-message
+                        :outgoingStatus           :outgoing-status
+                        :audioDurationMs          :audio-duration-ms
+                        :deleted                  :deleted?
+                        :deletedForMe             :deleted-for-me?
+                        :albumId                  :album-id
+                        :new                      :new?})
 
       (update :quoted-message
-              clojure.set/rename-keys
+              set/rename-keys
               {:parsedText :parsed-text :communityId :community-id})
       (update :outgoing-status keyword)
       (update :command-parameters
-              clojure.set/rename-keys
+              set/rename-keys
               {:transactionHash :transaction-hash
                :commandState    :command-state})
       (assoc :content  {:chat-id     (:chatId message)

--- a/src/status_im/data_store/pin_messages.cljs
+++ b/src/status_im/data_store/pin_messages.cljs
@@ -1,5 +1,5 @@
 (ns status-im.data-store.pin-messages
-  (:require [clojure.set :as clojure.set]
+  (:require [clojure.set :as set]
             [status-im.data-store.messages :as messages]
             [utils.re-frame :as rf]
             [taoensso.timbre :as log]))
@@ -8,8 +8,8 @@
   [message]
   (-> message
       (merge (messages/<-rpc (message :message)))
-      (clojure.set/rename-keys {:pinnedAt :pinned-at
-                                :pinnedBy :pinned-by})
+      (set/rename-keys {:pinnedAt :pinned-at
+                        :pinnedBy :pinned-by})
       (dissoc :message)))
 
 (defn pinned-message-by-chat-id-rpc
@@ -21,9 +21,9 @@
   {:json-rpc/call [{:method     "wakuext_chatPinnedMessages"
                     :params     [chat-id cursor limit]
                     :on-success (fn [result]
-                                  (let [result (clojure.set/rename-keys result
-                                                                        {:pinnedMessages
-                                                                         :pinned-messages})]
+                                  (let [result (set/rename-keys result
+                                                                {:pinnedMessages
+                                                                 :pinned-messages})]
                                     (on-success (update result :pinned-messages #(map <-rpc %)))))
                     :on-error   on-error}]})
 

--- a/src/status_im/data_store/reactions.cljs
+++ b/src/status_im/data_store/reactions.cljs
@@ -1,24 +1,24 @@
 (ns status-im.data-store.reactions
-  (:require [clojure.set :as clojure.set]))
+  (:require [clojure.set :as set]))
 
 (defn ->rpc
   [message]
   (-> message
-      (clojure.set/rename-keys {:message-id        :messageId
-                                :emoji-id          :emojiId
-                                :chat-id           :localChatId
-                                :message-type      :messageType
-                                :emoji-reaction-id :id})))
+      (set/rename-keys {:message-id        :messageId
+                        :emoji-id          :emojiId
+                        :chat-id           :localChatId
+                        :message-type      :messageType
+                        :emoji-reaction-id :id})))
 
 (defn <-rpc
   [message]
   (-> message
       (dissoc :chat_id)
-      (clojure.set/rename-keys {:messageId   :message-id
-                                :localChatId :chat-id
-                                :emojiId     :emoji-id
-                                :messageType :message-type
-                                :id          :emoji-reaction-id})))
+      (set/rename-keys {:messageId   :message-id
+                        :localChatId :chat-id
+                        :emojiId     :emoji-id
+                        :messageType :message-type
+                        :id          :emoji-reaction-id})))
 
 (defn reactions-by-chat-id-rpc
   [chat-id

--- a/src/status_im/data_store/visibility_status_updates.cljs
+++ b/src/status_im/data_store/visibility_status_updates.cljs
@@ -1,18 +1,18 @@
 (ns status-im.data-store.visibility-status-updates
-  (:require [clojure.set :as clojure.set]
+  (:require [clojure.set :as set]
             [re-frame.core :as re-frame]
             [utils.re-frame :as rf]
             [taoensso.timbre :as log]))
 
 (defn <-rpc
   [visibility-status-update]
-  (clojure.set/rename-keys visibility-status-update
-                           {:publicKey  :public-key
-                            :statusType :status-type}))
+  (set/rename-keys visibility-status-update
+                   {:publicKey  :public-key
+                    :statusType :status-type}))
 (defn <-rpc-settings
   [settings]
   (-> settings
-      (clojure.set/rename-keys
+      (set/rename-keys
        {:current-user-status :current-user-visibility-status})
       (update :current-user-visibility-status <-rpc)))
 

--- a/src/status_im/navigation/core.cljs
+++ b/src/status_im/navigation/core.cljs
@@ -2,7 +2,7 @@
   (:require ["react-native" :as rn]
             ["react-native-gesture-handler" :refer (gestureHandlerRootHOC)]
             ["react-native-navigation" :refer (Navigation)]
-            [clojure.set :as clojure.set]
+            [clojure.set :as set]
             [quo.components.text-input :as quo.text-input]
             [quo.design-system.colors :as quo.colors]
             [re-frame.core :as re-frame]
@@ -299,7 +299,7 @@
           (fn [^js evn]
             (let [selected-tab-index (.-selectedTabIndex evn)
                   comp               (get tab-root-ids selected-tab-index)
-                  tab-key            (get (clojure.set/map-invert tab-key-idx) selected-tab-index)]
+                  tab-key            (get (set/map-invert tab-key-idx) selected-tab-index)]
               (re-frame/dispatch [:set :current-tab tab-key])
               (when (= @state/root-comp-id comp)
                 (when (= :chat tab-key)

--- a/src/status_im/signing/core.cljs
+++ b/src/status_im/signing/core.cljs
@@ -1,5 +1,5 @@
 (ns status-im.signing.core
-  (:require [clojure.set :as clojure.set]
+  (:require [clojure.set :as set]
             [clojure.string :as string]
             [re-frame.core :as re-frame]
             [status-im.constants :as constants]
@@ -596,4 +596,4 @@
     (sign cofx
           {:tx-obj (-> tx
                        (select-keys [:from :to :value :input :gas :nonce :hash])
-                       (clojure.set/rename-keys {:input :data}))})))
+                       (set/rename-keys {:input :data}))})))

--- a/src/status_im/ui/screens/communities/reorder_categories.cljs
+++ b/src/status_im/ui/screens/communities/reorder_categories.cljs
@@ -1,5 +1,5 @@
 (ns status-im.ui.screens.communities.reorder-categories
-  (:require [clojure.set :as clojure.set]
+  (:require [clojure.set :as set]
             [clojure.string :as string]
             [clojure.walk :as walk]
             [quo.core :as quo]
@@ -48,7 +48,7 @@
   [{:keys [id community-id] :as home-item} is-active? drag]
   (let [chat-id          (string/replace id community-id "")
         background-color (if is-active? colors/gray-lighter colors/white)
-        home-item        (clojure.set/rename-keys home-item {:id :chat-id})]
+        home-item        (set/rename-keys home-item {:id :chat-id})]
     [rn/view
      {:accessibility-label :chat-item
       :style               (merge styles/category-item

--- a/src/status_im/utils/views.clj
+++ b/src/status_im/utils/views.clj
@@ -1,5 +1,5 @@
 (ns status-im.utils.views
-  (:require [clojure.walk :as w]))
+  (:require [clojure.walk :as walk]))
 
 (defn atom?
   [sub]
@@ -9,9 +9,9 @@
 (defn walk-sub
   [sub form->sym]
   (if (coll? sub)
-    (w/postwalk (fn [f]
-                  (or (form->sym f) f))
-                sub)
+    (walk/postwalk (fn [f]
+                     (or (form->sym f) f))
+                   sub)
     (or (form->sym sub) sub)))
 
 (defn prepare-subs

--- a/src/status_im/wallet/core.cljs
+++ b/src/status_im/wallet/core.cljs
@@ -1,6 +1,6 @@
 (ns status-im.wallet.core
   (:require
-   [clojure.set :as clojure.set]
+   [clojure.set :as set]
    [clojure.string :as string]
    [re-frame.core :as re-frame]
    [status-im.async-storage.core :as async-storage]
@@ -360,7 +360,7 @@
     (rf/merge cofx
               (multiaccounts.update/multiaccount-update
                :wallet/visible-tokens
-               (update visible-tokens chain clojure.set/union chain-visible-tokens)
+               (update visible-tokens chain set/union chain-visible-tokens)
                {})
               (update-tokens-balances balances)
               (prices/update-prices))))

--- a/src/status_im2/subs/multiaccount.cljs
+++ b/src/status_im2/subs/multiaccount.cljs
@@ -1,6 +1,6 @@
 (ns status-im2.subs.multiaccount
   (:require [cljs.spec.alpha :as spec]
-            [clojure.set :as clojure.set]
+            [clojure.set :as set]
             [clojure.string :as string]
             [re-frame.core :as re-frame]
             [status-im.ethereum.core :as ethereum]
@@ -23,7 +23,7 @@
    (some->
     current-account
     (select-keys [:name :preferred-name :public-key :identicon :image :images])
-    (clojure.set/rename-keys {:name :alias})
+    (set/rename-keys {:name :alias})
     (multiaccounts/contact-with-names))))
 
 (re-frame/reg-sub


### PR DESCRIPTION
### Summary

Quick and simple PR: add two new rules for idiomatic namespace aliases, following the Clojure Style Guide https://guide.clojure.style/#use-idiomatic-namespace-aliases

- [x] Fix all `clojure.set` aliases
- [x] Fix one (the only one) inconsistent `clojure.walk` alias.

status: ready
