### PR TITLE
Move unit test helper namespaces to `src/test_helpers/`

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,14 +1,14 @@
-{:lint-as      {status-im.utils.views/defview      clojure.core/defn
-                status-im.utils.views/letsubs      clojure.core/let
-                reagent.core/with-let              clojure.core/let
-                status-im.utils.fx/defn            clj-kondo.lint-as/def-catch-all
-                utils.re-frame/defn                clj-kondo.lint-as/def-catch-all
-                quo.react/with-deps-check          clojure.core/fn
-                quo.previews.preview/list-comp     clojure.core/for
-                status-im.utils.styles/def         clojure.core/def
-                status-im.utils.styles/defn        clojure.core/defn
-                status-im.test-helpers/deftest-sub clojure.core/defn
-                taoensso.tufte/defnp               clojure.core/defn}
+{:lint-as      {status-im.utils.views/defview  clojure.core/defn
+                status-im.utils.views/letsubs  clojure.core/let
+                reagent.core/with-let          clojure.core/let
+                status-im.utils.fx/defn        clj-kondo.lint-as/def-catch-all
+                utils.re-frame/defn            clj-kondo.lint-as/def-catch-all
+                quo.react/with-deps-check      clojure.core/fn
+                quo.previews.preview/list-comp clojure.core/for
+                status-im.utils.styles/def     clojure.core/def
+                status-im.utils.styles/defn    clojure.core/defn
+                test-helpers.unit/deftest-sub  clojure.core/defn
+                taoensso.tufte/defnp           clojure.core/defn}
  :linters      {:consistent-alias  {:level   :error
                                     :aliases {clojure.string  string
                                               clojure.set     set

--- a/doc/new-guidelines.md
+++ b/doc/new-guidelines.md
@@ -364,7 +364,7 @@ actually subscribing to them, so reframe's signal graph gets validated too.
       (is (= expected (recipes [current-user all-recipes location]))))))
 
 ;; good
-(require '[status-im.test-helpers :as h])
+(require '[test-helpers.unit :as h])
 
 (re-frame/reg-sub
  :user/recipes

--- a/src/status_im2/contexts/activity_center/events_test.cljs
+++ b/src/status_im2/contexts/activity_center/events_test.cljs
@@ -2,7 +2,7 @@
   (:require [cljs.test :refer [deftest is testing]]
             [status-im.constants :as constants]
             status-im.events
-            [status-im.test-helpers :as h]
+            [test-helpers.unit :as h]
             [status-im2.contexts.activity-center.events :as activity-center]
             [status-im2.contexts.activity-center.notification-types :as types]
             [utils.re-frame :as rf]))

--- a/src/status_im2/subs/activity_center_test.cljs
+++ b/src/status_im2/subs/activity_center_test.cljs
@@ -1,7 +1,7 @@
 (ns status-im2.subs.activity-center-test
   (:require [cljs.test :refer [is testing]]
             [re-frame.db :as rf-db]
-            [status-im.test-helpers :as h]
+            [test-helpers.unit :as h]
             status-im2.subs.activity-center
             [utils.re-frame :as rf]))
 

--- a/src/status_im2/subs/communities_test.cljs
+++ b/src/status_im2/subs/communities_test.cljs
@@ -1,7 +1,7 @@
 (ns status-im2.subs.communities-test
   (:require [cljs.test :refer [is testing use-fixtures]]
             [re-frame.db :as rf-db]
-            [status-im.test-helpers :as h]
+            [test-helpers.unit :as h]
             status-im2.subs.communities
             [utils.re-frame :as rf]))
 
@@ -135,4 +135,3 @@
             {:id "0x1" :name "Civilized monkeys"}
             {:id "0x2" :name "Civilized rats"}]
            (rf/sub [sub-name])))))
-

--- a/src/status_im2/subs/wallet/wallet_test.cljs
+++ b/src/status_im2/subs/wallet/wallet_test.cljs
@@ -1,7 +1,7 @@
 (ns status-im2.subs.wallet.wallet-test
   (:require [cljs.test :refer [deftest is testing]]
             [re-frame.db :as rf-db]
-            [status-im.test-helpers :as h]
+            [test-helpers.unit :as h]
             [status-im.utils.money :as money]
             [status-im2.subs.wallet.wallet :as wallet]
             [utils.re-frame :as rf]))

--- a/src/test_helpers/unit.clj
+++ b/src/test_helpers/unit.clj
@@ -1,4 +1,4 @@
-(ns status-im.test-helpers
+(ns test-helpers.unit
   (:require [clojure.spec.alpha :as s]
             [clojure.string :as string]
             [clojure.walk :as walk]))
@@ -34,7 +34,7 @@
   Example:
 
   ```clojure
-  (require '[status-im.test-helpers :as h])
+  (require '[test-helpers.unit :as h])
 
   (h/deftest-sub :wallet/sorted-tokens
     [sub-name]
@@ -60,7 +60,7 @@
   "Register log fixture which allows inspecting all calls to `taoensso.timbre/log`.
 
   Usage: Simply call this macro once per test namespace, and use the
-  `status-im.test-helpers/logs` atom to deref the collection of all logs for the
+  `test-helpers.unit/logs` atom to deref the collection of all logs for the
   test under execution.
 
   In Clojure(Script), we can rely on fixtures for each `cljs.deftest`, but not
@@ -69,8 +69,8 @@
   []
   `(cljs.test/use-fixtures
     :each
-    {:before status-im.test-helpers/log-fixture-before
-     :after  status-im.test-helpers/log-fixture-after}))
+    {:before test-helpers.unit/log-fixture-before
+     :after  test-helpers.unit/log-fixture-after}))
 
 (defmacro run-test-sync
   "Wrap around `re-frame.test/run-test-sync` to make it work with our aliased

--- a/src/test_helpers/unit.cljs
+++ b/src/test_helpers/unit.cljs
@@ -1,11 +1,11 @@
-(ns status-im.test-helpers
+(ns test-helpers.unit
   "Utilities for simplifying the process of writing tests and improving test
   readability.
 
   Avoid coupling this namespace with particularities of the Status' domain, thus
   prefer to use it for more general purpose concepts, such as the re-frame event
   layer."
-  (:require-macros status-im.test-helpers)
+  (:require-macros test-helpers.unit)
   (:require [re-frame.core :as rf]
             [re-frame.db :as rf-db]
             [re-frame.events :as rf-events]


### PR DESCRIPTION
### Summary

Quick one, move the *unit test helper namespaces* (clj and cljs) to `src/test_helpers/`, to be consistent with where the component test helpers live.

status: ready
