### PR TITLE
[14703] Remove using function as children warning from android text input

### DIFF
--- a/src/status_im/chat/models/input.cljs
+++ b/src/status_im/chat/models/input.cljs
@@ -49,9 +49,9 @@
         cursor      (+ at-sign-idx (count name) 2)]
     (rf/merge
      cofx
-     {:db                   (-> db
-                                (assoc-in [:chats/cursor chat-id] cursor)
-                                (assoc-in [:chats/mention-suggestions chat-id] nil))}
+     {:db (-> db
+              (assoc-in [:chats/cursor chat-id] cursor)
+              (assoc-in [:chats/mention-suggestions chat-id] nil))}
      (set-chat-input-text new-text chat-id)
      ;; NOTE(rasom): Some keyboards do not react on selection property passed to
      ;; text input (specifically Samsung keyboard with predictive text set on).

--- a/src/status_im/chat/models/input.cljs
+++ b/src/status_im/chat/models/input.cljs
@@ -51,8 +51,7 @@
      cofx
      {:db                   (-> db
                                 (assoc-in [:chats/cursor chat-id] cursor)
-                                (assoc-in [:chats/mention-suggestions chat-id] nil))
-      :set-text-input-value [chat-id new-text text-input-ref]}
+                                (assoc-in [:chats/mention-suggestions chat-id] nil))}
      (set-chat-input-text new-text chat-id)
      ;; NOTE(rasom): Some keyboards do not react on selection property passed to
      ;; text input (specifically Samsung keyboard with predictive text set on).

--- a/src/status_im/ui2/screens/chat/composer/input.cljs
+++ b/src/status_im/ui2/screens/chat/composer/input.cljs
@@ -175,7 +175,6 @@
          :editable                 (not cooldown-enabled?)
          :blur-on-submit           false
          :auto-focus               false
-         :default-value            initial-value
          :on-focus                 #(set-active-panel nil)
          :max-length               chat.constants/max-text-size
          :placeholder-text-color   (:text-02 @quo.colors/theme)
@@ -195,22 +194,21 @@
          (partial on-change last-text-change timeout-id mentionable-users refs chat-id sending-image)
          :on-text-input            (partial on-text-input mentionable-users chat-id)}
         input-with-mentions (rf/sub [:chat/input-with-mentions])
-        children            (fn []
-                              (if mentions-enabled?
-                                (map-indexed
-                                 (fn [index [_ text]]
-                                   ^{:key (str index "_" type "_" text)}
-                                   [rn/text (when (= type :mention) {:style {:color colors/primary-50}})
-                                    text])
-                                 input-with-mentions)
-                                (get @input-texts chat-id)))]
+        children (if mentions-enabled?
+                   (map-indexed
+                    (fn [index [type text]]
+                      ^{:key (str index "_" type "_" text)}
+                      [rn/text (when (= type :mention) {:style {:color colors/primary-50}})
+                       text])
+                    input-with-mentions)
+                   (get @input-texts chat-id))]
     (reset! text-input-ref (:text-input-ref refs))
     ;when ios implementation for selectable-text-input is ready, we need remove this condition and use
     ;selectable-text-input directly.
     (if platform/android?
       [selectable-text-input chat-id props children]
       [rn/text-input props
-       [children]])))
+       children])))
 
 (defn selectable-text-input-manager
   []

--- a/src/status_im/ui2/screens/chat/composer/input.cljs
+++ b/src/status_im/ui2/screens/chat/composer/input.cljs
@@ -380,4 +380,4 @@
                                           :on-selection        on-selection})]
           [rn-selectable-text-input {:menuItems @menu-items :style style}
            [rn/text-input props
-            children]]))})))
+            [children]]]))})))

--- a/src/status_im/ui2/screens/chat/composer/input.cljs
+++ b/src/status_im/ui2/screens/chat/composer/input.cljs
@@ -16,9 +16,7 @@
             [utils.re-frame :as rf]
             [status-im.utils.platform :as platform]
             [status-im.utils.utils :as utils.utils]
-            [utils.transforms :as transforms]
-            [quo.previews.text-input :as text-input]
-            [status-im2.contexts.quo-preview.markdown.text :as text]))
+            [utils.transforms :as transforms]))
 
 (defonce input-texts (atom {}))
 (defonce mentions-enabled? (reagent/atom {}))

--- a/src/status_im/ui2/screens/chat/composer/input.cljs
+++ b/src/status_im/ui2/screens/chat/composer/input.cljs
@@ -221,7 +221,7 @@
 (declare first-level-menu-items second-level-menu-items)
 
 (defn update-input-text
-  [{:keys [chat-id]} text]
+  [{:keys [text-input chat-id]} text]
   (on-text-change text chat-id))
 
 (re-frame/reg-fx

--- a/src/status_im/ui2/screens/chat/composer/input.cljs
+++ b/src/status_im/ui2/screens/chat/composer/input.cljs
@@ -210,7 +210,7 @@
     (if platform/android?
       [selectable-text-input chat-id props children]
       [rn/text-input props
-       children])))
+       [children]])))
 
 (defn selectable-text-input-manager
   []


### PR DESCRIPTION
fixes #14703
status: ready
