### PR TITLE
New chat fix

### DIFF
--- a/src/status_im/ui/screens/home/sheet/views.cljs
+++ b/src/status_im/ui/screens/home/sheet/views.cljs
@@ -73,11 +73,13 @@
      :icon-color                 (colors/theme-colors colors/neutral-50 colors/neutral-40)
      :accessibility-label        :start-a-new-chat
      :icon                       :i/new-message
-     :on-press                   (fn [] ;; Note: currently the bottom button is overlapping with safe-area
+     :on-press                   (fn [] ;; Note: currently the bottom button is overlapping with
+                                        ;; safe-area
                                         ;; because it is using old bottom-sheet
                                    (rf/dispatch [:bottom-sheet/hide])
                                    ;; A one second delay is needed because there are 2 bottom-sheets here
-                                   ;; It would better to migrate contact-selection-list component to use a screen
+                                   ;; It would better to migrate contact-selection-list component to use
+                                   ;; a screen
                                    (js/setTimeout #(rf/dispatch [:bottom-sheet/show-sheet
                                                                  {:content
                                                                   new-chat-aio/contact-selection-list}])

--- a/src/status_im/ui/screens/home/sheet/views.cljs
+++ b/src/status_im/ui/screens/home/sheet/views.cljs
@@ -73,9 +73,11 @@
      :icon-color                 (colors/theme-colors colors/neutral-50 colors/neutral-40)
      :accessibility-label        :start-a-new-chat
      :icon                       :i/new-message
-     :on-press                   (fn [] ; Note: currently the bottom button is overlapping with safe-area
-                                        ; because it is using old bottom-sheet
+     :on-press                   (fn [] ;; Note: currently the bottom button is overlapping with safe-area
+                                        ;; because it is using old bottom-sheet
                                    (rf/dispatch [:bottom-sheet/hide])
+                                   ;; A one second delay is needed because there are 2 bottom-sheets here
+                                   ;; It would better to migrate contact-selection-list component to use a screen
                                    (js/setTimeout #(rf/dispatch [:bottom-sheet/show-sheet
                                                                  {:content
                                                                   new-chat-aio/contact-selection-list}])

--- a/src/status_im/ui/screens/home/sheet/views.cljs
+++ b/src/status_im/ui/screens/home/sheet/views.cljs
@@ -73,8 +73,14 @@
      :icon-color                 (colors/theme-colors colors/neutral-50 colors/neutral-40)
      :accessibility-label        :start-a-new-chat
      :icon                       :i/new-message
-     :on-press                   #(hide-sheet-and-dispatch [:bottom-sheet/show-sheet
-                                                            :start-a-new-chat])}]
+     :on-press                   (fn [] ; Note: currently the bottom button is overlapping with safe-area
+                                        ; because it is using old bottom-sheet
+                                   (rf/dispatch [:bottom-sheet/hide])
+                                   (js/setTimeout #(rf/dispatch [:bottom-sheet/show-sheet
+                                                                 {:content
+                                                                  new-chat-aio/contact-selection-list}])
+                                                  1000))
+    }]
    [quo2/menu-item
     {:theme                        :main
      :title                        (i18n/label :t/add-a-contact)

--- a/src/status_im/ui2/screens/chat/components/new_chat/view.cljs
+++ b/src/status_im/ui2/screens/chat/components/new_chat/view.cljs
@@ -60,7 +60,6 @@
   (let [contacts                                     (rf/sub
                                                       [:contacts/sorted-and-grouped-by-first-letter])
         selected-contacts-count                      (rf/sub [:selected-contacts-count])
-        window-height                                (rf/sub [:dimensions/window-height])
         one-contact-selected?                        (= selected-contacts-count 1)
         contacts-selected?                           (pos? selected-contacts-count)
         {:keys [names public-key]}                   (-> contacts first :data first)
@@ -68,7 +67,7 @@
         {:keys [nickname ens-name three-words-name]} names
         first-username                               (or ens-name nickname three-words-name)
         no-contacts?                                 (empty? contacts)]
-    [react/view {:style {:height (* window-height 0.95)}}
+    [react/view {:style {:flex 1}}
      [quo2/button
       {:type                      :grey
        :icon                      true

--- a/src/status_im/ui2/screens/chat/components/new_chat/view.cljs
+++ b/src/status_im/ui2/screens/chat/components/new_chat/view.cljs
@@ -58,7 +58,7 @@
 (defn contact-selection-list
   []
   (let [contacts                                     (rf/sub
-                                                      [:contacts/sorted-and-grouped-by-first-letter])
+                                                      [:contacts/grouped-by-first-letter])
         selected-contacts-count                      (rf/sub [:selected-contacts-count])
         one-contact-selected?                        (= selected-contacts-count 1)
         contacts-selected?                           (pos? selected-contacts-count)

--- a/src/status_im/ui2/screens/common/contact_list/view.cljs
+++ b/src/status_im/ui2/screens/common/contact_list/view.cljs
@@ -11,7 +11,7 @@
 (defn contact-list
   [data]
   (let [contacts (if (:group data)
-                   (rf/sub [:contacts/add-members-sections])
+                   (rf/sub [:contacts/sorted-and-grouped-by-first-letter])
                    (rf/sub [:contacts/filtered-active-sections]))]
     [rn/section-list
      {:key-fn                         :title

--- a/src/status_im/ui2/screens/common/contact_list/view.cljs
+++ b/src/status_im/ui2/screens/common/contact_list/view.cljs
@@ -11,7 +11,7 @@
 (defn contact-list
   [data]
   (let [contacts (if (:group data)
-                   (rf/sub [:contacts/sorted-and-grouped-by-first-letter])
+                   (rf/sub [:contacts/grouped-by-first-letter])
                    (rf/sub [:contacts/filtered-active-sections]))]
     [rn/section-list
      {:key-fn                         :title

--- a/src/status_im2/subs/contact.cljs
+++ b/src/status_im2/subs/contact.cljs
@@ -93,7 +93,7 @@
        vals)))
 
 (re-frame/reg-sub
- :contacts/add-members-sections
+ :contacts/sorted-and-grouped-by-first-letter
  :<- [:contacts/current-chat-contacts]
  :<- [:contacts/active]
  (fn [[members contacts]]

--- a/src/status_im2/subs/contact.cljs
+++ b/src/status_im2/subs/contact.cljs
@@ -93,7 +93,7 @@
        vals)))
 
 (re-frame/reg-sub
- :contacts/sorted-and-grouped-by-first-letter
+ :contacts/grouped-by-first-letter
  :<- [:contacts/current-chat-contacts]
  :<- [:contacts/active]
  (fn [[members contacts]]

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.117.3",
+    "version": "d40290a649133eb7b7f450b5c5b74eec28ba232d",
     "commit-sha1": "d40290a649133eb7b7f450b5c5b74eec28ba232d",
     "src-sha256": "140j0gbp8nxzncya9mcpvlxnax5ajfl8c32ih20b29n8j525gw66"
 }

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "d40290a649133eb7b7f450b5c5b74eec28ba232d",
+    "version": "v0.117.3",
     "commit-sha1": "d40290a649133eb7b7f450b5c5b74eec28ba232d",
     "src-sha256": "140j0gbp8nxzncya9mcpvlxnax5ajfl8c32ih20b29n8j525gw66"
 }


### PR DESCRIPTION
Fixes app crash when pressing new chat and bottom sheet not showing properly

### QA review notes:
1. Currently the bottom button is not positioned properly (overlapping with safe area) as we are currently using an old bottom sheet.
2. There is a 1 second delay when pressing "New chat". That's because it is trying to open a bottom sheet from inside a bottom sheet. We would have to migrate it to a screen component. Opened an issue https://github.com/status-im/status-mobile/issues/14741