### PR TITLE
[Fixes: #14623] Enable mutual contacts by default and show banner

### DIFF
--- a/src/quo2/components/drawers/permission_context/__tests__/permission_context_component_spec.cljs
+++ b/src/quo2/components/drawers/permission_context/__tests__/permission_context_component_spec.cljs
@@ -1,0 +1,13 @@
+(ns quo2.components.drawers.permission-context.--tests--.permission-context-component-spec
+  (:require [quo2.components.drawers.permission-context.view :as permission-context]
+            [react-native.core :as rn]
+            [test-helpers.component :as h]))
+
+(h/describe "permission context"
+  (h/test
+    (h/render [permission-context/view
+               [rn/text
+                {:accessibility-label :accessibility-id}
+                "a sample label"]])
+    (-> (js/expect (h/get-by-label-text :accessibility-id))
+        (.toBeTruthy))))

--- a/src/quo2/components/drawers/permission_context/style.cljs
+++ b/src/quo2/components/drawers/permission_context/style.cljs
@@ -1,0 +1,16 @@
+(ns quo2.components.drawers.permission-context.style
+  (:require [quo2.foundations.colors :as colors]))
+
+(def radius 20)
+(def container
+  {:padding-top             16
+   :padding-bottom          48
+   :padding-horizontal      20
+   :shadow-offset           {:width  0
+                             :height 2}
+   :shadow-radius           radius
+   :border-top-left-radius  radius
+   :border-top-right-radius radius
+   :elevation               2
+   :shadow-opacity          1
+   :shadow-color            colors/shadow})

--- a/src/quo2/components/drawers/permission_context/view.cljs
+++ b/src/quo2/components/drawers/permission_context/view.cljs
@@ -1,0 +1,8 @@
+(ns quo2.components.drawers.permission-context.view
+  (:require [react-native.core :as rn]
+            [quo2.components.drawers.permission-context.style :as style]))
+
+(defn view
+  [children]
+  [rn/view {:style style/container}
+   children])

--- a/src/quo2/core_spec.cljs
+++ b/src/quo2/core_spec.cljs
@@ -4,6 +4,7 @@
             [quo2.components.counter.--tests--.counter-component-spec]
             [quo2.components.dividers.--tests--.divider-label-component-spec]
             [quo2.components.drawers.--tests--.action-drawers-component-spec]
+            [quo2.components.drawers.permission-context.--tests--.permission-context-component-spec]
             [quo2.components.markdown.--tests--.text-component-spec]
             [quo2.components.selectors.--tests--.selectors-component-spec]
             [quo2.components.selectors.filter.component-spec]))

--- a/src/status_im/contact/core.cljs
+++ b/src/status_im/contact/core.cljs
@@ -4,7 +4,6 @@
             [status-im.contact.block :as contact.block]
             [status-im.contact.db :as contact.db]
             [status-im.data-store.contacts :as contacts-store]
-            [status-im.multiaccounts.update.core :as multiaccounts.update]
             [utils.re-frame :as rf]
             [status-im2.navigation.events :as navigation]
             [taoensso.timbre :as log]))
@@ -150,15 +149,6 @@
              nickname
              #(re-frame/dispatch [:sanitize-messages-and-process-response %]))
             (navigation/navigate-back)))
-
-(rf/defn switch-mutual-contact-requests-enabled
-  {:events [:multiaccounts.ui/switch-mutual-contact-requests-enabled]}
-  [cofx enabled?]
-  (multiaccounts.update/multiaccount-update
-   cofx
-   :mutual-contact-enabled?
-   enabled?
-   nil))
 
 (rf/defn set-search-query
   {:events [:contacts/set-search-query]}

--- a/src/status_im/ui/screens/advanced_settings/views.cljs
+++ b/src/status_im/ui/screens/advanced_settings/views.cljs
@@ -14,8 +14,7 @@
            transactions-management-enabled?
            wakuv2-flag
            current-fleet
-           webview-debug
-           mutual-contact-requests-enabled?]}]
+           webview-debug]}]
   (keep
    identity
    [{:size                 :small
@@ -115,17 +114,7 @@
      #(re-frame/dispatch
        [:multiaccounts.ui/waku-bloom-filter-mode-switched (not waku-bloom-filter-mode)])
      :accessory               :switch
-     :active                  waku-bloom-filter-mode}
-    {:size                    :small
-     :title                   (i18n/label :t/mutual-contact-requests)
-     :accessibility-label     :mutual-contact-requests-switch
-     :container-margin-bottom 8
-     :on-press
-     #(re-frame/dispatch
-       [:multiaccounts.ui/switch-mutual-contact-requests-enabled
-        (not mutual-contact-requests-enabled?)])
-     :accessory               :switch
-     :active                  mutual-contact-requests-enabled?}]))
+     :active                  waku-bloom-filter-mode}]))
 
 (defn- flat-list-data
   [options]
@@ -146,8 +135,7 @@
                   communities-enabled?             [:communities/enabled?]
                   transactions-management-enabled? [:wallet/transactions-management-enabled?]
                   current-log-level                [:log-level/current-log-level]
-                  current-fleet                    [:fleets/current-fleet]
-                  mutual-contact-requests-enabled? [:mutual-contact-requests/enabled?]]
+                  current-fleet                    [:fleets/current-fleet]]
     [list/flat-list
      {:data      (flat-list-data
                   {:network-name                     network-name
@@ -158,7 +146,6 @@
                    :dev-mode?                        false
                    :wakuv2-flag                      wakuv2-flag
                    :waku-bloom-filter-mode           waku-bloom-filter-mode
-                   :webview-debug                    webview-debug
-                   :mutual-contact-requests-enabled? mutual-contact-requests-enabled?})
+                   :webview-debug                    webview-debug})
       :key-fn    (fn [_ i] (str i))
       :render-fn render-item}]))

--- a/src/status_im2/contexts/chat/messages/contact_requests/bottom_drawer.cljs
+++ b/src/status_im2/contexts/chat/messages/contact_requests/bottom_drawer.cljs
@@ -1,0 +1,26 @@
+(ns status-im2.contexts.chat.messages.contact-requests.bottom-drawer
+  (:require
+   [i18n.i18n :as i18n]
+   [utils.re-frame :as rf]
+   [quo2.core :as quo]
+   [quo2.components.drawers.permission-context.view :as permission-context]
+   [status-im2.common.constants :as constants]))
+
+(defn view
+  [contact-id contact-request-state]
+  (let [names (rf/sub [:contacts/contact-two-names-by-identity contact-id])]
+    [permission-context/view
+     [quo/button
+      {:type     :ghost
+       :on-press #(rf/dispatch [:chat.ui/show-profile contact-id])
+       :before   :i/communities}
+      (cond
+        (or (= contact-request-state
+               constants/contact-request-state-none)
+            (= contact-request-state
+               constants/contact-request-state-received))
+        (i18n/label :t/contact-request-chat-add {:name (first names)})
+        (= contact-request-state
+           constants/contact-request-state-sent)
+
+        (i18n/label :t/contact-request-chat-pending))]]))

--- a/src/status_im2/contexts/chat/messages/list/view.cljs
+++ b/src/status_im2/contexts/chat/messages/list/view.cljs
@@ -131,17 +131,10 @@
   [{:keys [chat
            pan-responder
            show-input?]}]
-  (let [{:keys [group-chat chat-type chat-id public? community-id admins]} chat
-        mutual-contact-requests-enabled? (rf/sub [:mutual-contact-requests/enabled?])
-        messages (rf/sub [:chats/raw-chat-messages-stream chat-id])
-        one-to-one? (= chat-type constants/one-to-one-chat-type)
-        contact-added? (when one-to-one? (rf/sub [:contacts/contact-added? chat-id]))
-        should-send-contact-request?
-        (and
-         mutual-contact-requests-enabled?
-         one-to-one?
-         (not contact-added?))
-        bottom-space 15]
+  (let [{:keys [group-chat chat-id public? community-id admins]} chat
+        messages                                                 (rf/sub [:chats/raw-chat-messages-stream
+                                                                          chat-id])
+        bottom-space                                             15]
     [rn/view
      {:style {:flex 1}}
      ;;DO NOT use anonymous functions for handlers
@@ -152,7 +145,7 @@
         :ref                          list-ref
         :header                       [list-header chat]
         :footer                       [list-footer chat]
-        :data                         (when-not should-send-contact-request? messages)
+        :data                         messages
         :render-data                  (get-render-data {:group-chat      group-chat
                                                         :chat-id         chat-id
                                                         :public?         public?

--- a/src/status_im2/contexts/chat/messages/view.cljs
+++ b/src/status_im2/contexts/chat/messages/view.cljs
@@ -7,6 +7,8 @@
             [status-im.ui2.screens.chat.pin-limit-popover.view :as pin-limit-popover]
             [status-im2.common.constants :as constants]
             [status-im2.contexts.chat.messages.list.view :as messages.list]
+            [status-im2.contexts.chat.messages.contact-requests.bottom-drawer :as
+             contact-requests.bottom-drawer]
             [status-im2.contexts.chat.messages.pin.banner.view :as pin.banner] ;;TODO move to status-im2
             [status-im2.navigation.state :as navigation.state]
             [utils.debounce :as debounce]
@@ -62,8 +64,11 @@
 
 (defn chat-render
   []
-  (let [;;NOTE: we want to react only on these fields, do not use full chat map here
-        {:keys [chat-id show-input?] :as chat} (rf/sub [:chats/current-chat-chat-view])]
+  (let [{:keys [chat-id
+                contact-request-state
+                show-input?]
+         :as   chat}
+        (rf/sub [:chats/current-chat-chat-view])]
     [rn/keyboard-avoiding-view {:style {:position :relative :flex 1}}
      [rn/view
       {:style {:position         :absolute
@@ -74,14 +79,15 @@
 
       [pin.banner/banner chat-id]
       [not-implemented/not-implemented
-       [pin-limit-popover/pin-limit-popover chat-id]]
-     ]
+       [pin-limit-popover/pin-limit-popover chat-id]]]
      [page-nav]
-
-
      [messages.list/messages-list {:chat chat :show-input? show-input?}]
-     (when show-input?
-       [composer/composer chat-id])]))
+     (cond (and (not show-input?)
+                contact-request-state)
+           [contact-requests.bottom-drawer/view chat-id contact-request-state]
+
+           show-input?
+           [composer/composer chat-id])]))
 
 (defn chat
   []

--- a/src/status_im2/subs/chat/chats_test.cljs
+++ b/src/status_im2/subs/chat/chats_test.cljs
@@ -1,0 +1,57 @@
+(ns status-im2.subs.chat.chats-test
+  (:require [cljs.test :refer [is testing]]
+            [re-frame.db :as rf-db]
+            [test-helpers.unit :as h]
+            [status-im2.common.constants :as constants]
+            [utils.re-frame :as rf]))
+
+(def public-key "0xpk")
+(def multiaccount {:public-key public-key})
+(def chat-id "1")
+(def chat {:chat-id chat-id})
+
+(def private-group-chat
+  (assoc
+   chat
+   :members    #{{:id public-key}}
+   :group-chat true
+   :chat-type  constants/private-group-chat-type))
+
+(def one-to-one-chat
+  (assoc
+   chat
+   :chat-type
+   constants/one-to-one-chat-type))
+
+(h/deftest-sub :chats/current-chat
+  [sub-name]
+  (testing "private group chat, user is a member"
+    (let [chats {chat-id private-group-chat}]
+      (swap! rf-db/app-db assoc
+        :multiaccount    multiaccount
+        :current-chat-id chat-id
+        :chats           chats)
+      (is (true? (:show-input? (rf/sub [sub-name]))))))
+  (testing "private group chat, user is not member"
+    (let [chats {chat-id (dissoc private-group-chat :members)}]
+      (swap! rf-db/app-db assoc
+        :multiaccount    multiaccount
+        :current-chat-id chat-id
+        :chats           chats)
+      (is (not (:show-input? (rf/sub [sub-name]))))))
+  (testing "one to one chat, mutual contacts"
+    (let [chats {chat-id one-to-one-chat}]
+      (swap! rf-db/app-db assoc
+        :contacts/contacts {chat-id {:contact-request-state constants/contact-request-state-mutual}}
+        :multiaccount      multiaccount
+        :current-chat-id   chat-id
+        :chats             chats)
+      (is (:show-input? (rf/sub [sub-name])))))
+  (testing "one to one chat, not a contact"
+    (let [chats {chat-id one-to-one-chat}]
+      (swap! rf-db/app-db assoc
+        :contacts/contacts {chat-id {:contact-request-state constants/contact-request-state-sent}}
+        :multiaccount      multiaccount
+        :current-chat-id   chat-id
+        :chats             chats)
+      (is (not (:show-input? (rf/sub [sub-name])))))))

--- a/src/status_im2/subs/contact.cljs
+++ b/src/status_im2/subs/contact.cljs
@@ -24,12 +24,6 @@
    (get multiaccount :profile-pictures-show-to)))
 
 (re-frame/reg-sub
- :mutual-contact-requests/enabled?
- :<- [:multiaccount]
- (fn [settings]
-   (boolean (:mutual-contact-enabled? settings))))
-
-(re-frame/reg-sub
  ::profile-pictures-visibility
  :<- [:multiaccount]
  (fn [multiaccount]

--- a/translations/en.json
+++ b/translations/en.json
@@ -1935,5 +1935,7 @@
     "who-are-you-looking-for": "Who are you looking for ?",
     "close-contact-search": "Close contact search",
     "selected-count-from-max": "{{selected}}/{{max}}",
-    "online": "Online"
+    "online": "Online",
+    "contact-request-chat-pending": "Your contact request is pending",
+    "contact-request-chat-add": "Add {{name}} to send a message"
 }


### PR DESCRIPTION
This commit enables mutual contact requests by default, and fixes an issue whereby old messages would not be displayed if the users stopped being in contacts.

It also partially implements the permission context component, tracked https://github.com/status-im/status-mobile/issues/14746 

but most likely it needs some polishing, but I'd rather do that on a separate PR since I have to jump on a different task.

https://www.figma.com/file/7KIYbhoqNGAIFonE0w9TDz/Messages-for-Mobile?node-id=5611%3A457496&t=kMVt8MCJburJSglp-1


Let me know if that's the approach you'd like me to take (namespaces, how components are split, names etc).

