### PR TITLE
[#14713] Show Admin Notifications in Activity Center

### DIFF
--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -29,10 +29,6 @@
 (def ^:const contact-verification-status-trusted 5)
 (def ^:const contact-verification-status-untrustworthy 6)
 
-(def ^:const membership-status-pending 1)
-(def ^:const membership-status-accepted 2)
-(def ^:const membership-status-declined 3)
-
 (def ^:const emoji-reaction-love 1)
 (def ^:const emoji-reaction-thumbs-up 2)
 (def ^:const emoji-reaction-thumbs-down 3)

--- a/src/status_im/constants.cljs
+++ b/src/status_im/constants.cljs
@@ -29,6 +29,10 @@
 (def ^:const contact-verification-status-trusted 5)
 (def ^:const contact-verification-status-untrustworthy 6)
 
+(def ^:const membership-status-pending 1)
+(def ^:const membership-status-accepted 2)
+(def ^:const membership-status-declined 3)
+
 (def ^:const emoji-reaction-love 1)
 (def ^:const emoji-reaction-thumbs-up 2)
 (def ^:const emoji-reaction-thumbs-down 3)

--- a/src/status_im/data_store/activities.cljs
+++ b/src/status_im/data_store/activities.cljs
@@ -40,7 +40,9 @@
       (set/rename-keys {:lastMessage               :last-message
                         :replyMessage              :reply-message
                         :chatId                    :chat-id
-                        :contactVerificationStatus :contact-verification-status})
+                        :contactVerificationStatus :contact-verification-status
+                        :communityId               :community-id
+                        :membershipStatus          :membership-status})
       (update :last-message #(when % (messages/<-rpc %)))
       (update :message #(when % (messages/<-rpc %)))
       (update :reply-message #(when % (messages/<-rpc %)))

--- a/src/status_im2/common/constants.cljs
+++ b/src/status_im2/common/constants.cljs
@@ -31,9 +31,10 @@
 (def ^:const contact-verification-status-trusted 5)
 (def ^:const contact-verification-status-untrustworthy 6)
 
-(def ^:const community-membership-status-pending 1)
-(def ^:const community-membership-status-accepted 2)
-(def ^:const community-membership-status-declined 3)
+(def ^:const activity-center-membership-status-idle 0)
+(def ^:const activity-center-membership-status-pending 1)
+(def ^:const activity-center-membership-status-accepted 2)
+(def ^:const activity-center-membership-status-declined 3)
 
 (def ^:const emoji-reaction-love 1)
 (def ^:const emoji-reaction-thumbs-up 2)

--- a/src/status_im2/common/constants.cljs
+++ b/src/status_im2/common/constants.cljs
@@ -31,6 +31,10 @@
 (def ^:const contact-verification-status-trusted 5)
 (def ^:const contact-verification-status-untrustworthy 6)
 
+(def ^:const community-membership-status-pending 1)
+(def ^:const community-membership-status-accepted 2)
+(def ^:const community-membership-status-declined 3)
+
 (def ^:const emoji-reaction-love 1)
 (def ^:const emoji-reaction-thumbs-up 2)
 (def ^:const emoji-reaction-thumbs-down 3)

--- a/src/status_im2/contexts/activity_center/notification/admin/view.cljs
+++ b/src/status_im2/contexts/activity_center/notification/admin/view.cljs
@@ -1,0 +1,51 @@
+(ns status-im2.contexts.activity-center.notification.admin.view
+  (:require [i18n.i18n :as i18n]
+            [quo2.core :as quo]
+            [quo2.foundations.colors :as colors]
+            [status-im.constants :as constants]
+            [status-im2.contexts.activity-center.notification.common.view :as common]
+            [status-im2.contexts.activity-center.notification.reply.style :as style]
+            [utils.datetime :as datetime]
+            [utils.re-frame :as rf]))
+
+(defn view
+  [{:keys [author communityId id membershipStatus read timestamp]}]
+  (let [community               (rf/sub [:communities/community communityId])
+        community-name          (:name community)
+        community-image         (get-in community [:images :thumbnail :uri])]
+     [quo/activity-log
+      (merge 
+       {:title     (i18n/label :t/join-request)
+       :icon      :i/add-user
+       :timestamp (datetime/timestamp->relative timestamp)
+       :unread?   (not read)
+       :context   [[common/user-avatar-tag author]
+                   [quo/text {:style style/lowercase-text} (i18n/label :t/wants-to-join)]
+                   [quo/context-tag
+                    {:size           :small
+                     :override-theme :dark
+                     :color          colors/primary-50
+                     :style          style/tag
+                     :text-style     style/tag-text}
+                    {:uri community-image} community-name]]
+        :status    (case membershipStatus
+                    constants/membership-status-accepted
+                     {:type :positive :label (i18n/label :t/accepted)}
+                     constants/membership-status-declined
+                     {:type :negative :label (i18n/label :t/declined)}
+                     nil)}
+       (case membershipStatus
+          constants/membership-status-pending
+          {:button-1 {:label               (i18n/label :t/decline)
+                      :accessibility-label :decline-contact-request
+                      :type                :danger
+                      :on-press            (fn []
+                                             (rf/dispatch [:communities.ui/decline-request-to-join-pressed communityId id])
+                                             (rf/dispatch [:activity-center.notifications/mark-as-read id]))}
+           :button-2 {:label               (i18n/label :t/accept)
+                      :accessibility-label :accept-contact-request
+                      :type                :positive
+                      :on-press            (fn []
+                                             (rf/dispatch [:communities.ui/accept-request-to-join-pressed communityId id])
+                                             (rf/dispatch [:activity-center.notifications/mark-as-read id]))}}
+          nil))]))

--- a/src/status_im2/contexts/activity_center/notification/admin/view.cljs
+++ b/src/status_im2/contexts/activity_center/notification/admin/view.cljs
@@ -29,13 +29,13 @@
                      :text-style     style/user-avatar-tag-text}
                     {:uri community-image} community-name]]
        :status    (case membership-status
-                    constants/community-membership-status-accepted
+                    constants/activity-center-membership-status-accepted
                     {:type :positive :label (i18n/label :t/accepted)}
-                    constants/community-membership-status-declined
+                    constants/activity-center-membership-status-declined
                     {:type :negative :label (i18n/label :t/declined)}
                     nil)}
       (case membership-status
-        constants/community-membership-status-pending
+        constants/activity-center-membership-status-pending
         {:button-1 {:label               (i18n/label :t/decline)
                     :accessibility-label :decline-contact-request
                     :type                :danger

--- a/src/status_im2/contexts/activity_center/notification/admin/view.cljs
+++ b/src/status_im2/contexts/activity_center/notification/admin/view.cljs
@@ -37,7 +37,7 @@
       (case membership-status
         constants/activity-center-membership-status-pending
         {:button-1 {:label               (i18n/label :t/decline)
-                    :accessibility-label :decline-contact-request
+                    :accessibility-label :decline-join-request
                     :type                :danger
                     :on-press            (fn []
                                            (rf/dispatch [:communities.ui/decline-request-to-join-pressed
@@ -45,7 +45,7 @@
                                            (rf/dispatch [:activity-center.notifications/mark-as-read
                                                          id]))}
          :button-2 {:label               (i18n/label :t/accept)
-                    :accessibility-label :accept-contact-request
+                    :accessibility-label :accept-join-request
                     :type                :positive
                     :on-press            (fn []
                                            (rf/dispatch [:communities.ui/accept-request-to-join-pressed

--- a/src/status_im2/contexts/activity_center/notification/admin/view.cljs
+++ b/src/status_im2/contexts/activity_center/notification/admin/view.cljs
@@ -2,15 +2,15 @@
   (:require [i18n.i18n :as i18n]
             [quo2.core :as quo]
             [quo2.foundations.colors :as colors]
-            [status-im.constants :as constants]
+            [status-im2.common.constants :as constants]
             [status-im2.contexts.activity-center.notification.common.style :as style]
             [status-im2.contexts.activity-center.notification.common.view :as common]
             [utils.datetime :as datetime]
             [utils.re-frame :as rf]))
 
 (defn view
-  [{:keys [author communityId id membershipStatus read timestamp]}]
-  (let [community       (rf/sub [:communities/community communityId])
+  [{:keys [author community-id id membership-status read timestamp]}]
+  (let [community       (rf/sub [:communities/community community-id])
         community-name  (:name community)
         community-image (get-in community [:images :thumbnail :uri])]
     [quo/activity-log
@@ -28,20 +28,20 @@
                      :style          style/user-avatar-tag
                      :text-style     style/user-avatar-tag-text}
                     {:uri community-image} community-name]]
-       :status    (case membershipStatus
-                    constants/membership-status-accepted
+       :status    (case membership-status
+                    constants/community-membership-status-accepted
                     {:type :positive :label (i18n/label :t/accepted)}
-                    constants/membership-status-declined
+                    constants/community-membership-status-declined
                     {:type :negative :label (i18n/label :t/declined)}
                     nil)}
-      (case membershipStatus
-        constants/membership-status-pending
+      (case membership-status
+        constants/community-membership-status-pending
         {:button-1 {:label               (i18n/label :t/decline)
                     :accessibility-label :decline-contact-request
                     :type                :danger
                     :on-press            (fn []
                                            (rf/dispatch [:communities.ui/decline-request-to-join-pressed
-                                                         communityId id])
+                                                         community-id id])
                                            (rf/dispatch [:activity-center.notifications/mark-as-read
                                                          id]))}
          :button-2 {:label               (i18n/label :t/accept)
@@ -49,7 +49,7 @@
                     :type                :positive
                     :on-press            (fn []
                                            (rf/dispatch [:communities.ui/accept-request-to-join-pressed
-                                                         communityId id])
+                                                         community-id id])
                                            (rf/dispatch [:activity-center.notifications/mark-as-read
                                                          id]))}}
         nil))]))

--- a/src/status_im2/contexts/activity_center/notification/admin/view.cljs
+++ b/src/status_im2/contexts/activity_center/notification/admin/view.cljs
@@ -3,49 +3,53 @@
             [quo2.core :as quo]
             [quo2.foundations.colors :as colors]
             [status-im.constants :as constants]
+            [status-im2.contexts.activity-center.notification.common.style :as style]
             [status-im2.contexts.activity-center.notification.common.view :as common]
-            [status-im2.contexts.activity-center.notification.reply.style :as style]
             [utils.datetime :as datetime]
             [utils.re-frame :as rf]))
 
 (defn view
   [{:keys [author communityId id membershipStatus read timestamp]}]
-  (let [community               (rf/sub [:communities/community communityId])
-        community-name          (:name community)
-        community-image         (get-in community [:images :thumbnail :uri])]
-     [quo/activity-log
-      (merge 
-       {:title     (i18n/label :t/join-request)
+  (let [community       (rf/sub [:communities/community communityId])
+        community-name  (:name community)
+        community-image (get-in community [:images :thumbnail :uri])]
+    [quo/activity-log
+     (merge
+      {:title     (i18n/label :t/join-request)
        :icon      :i/add-user
        :timestamp (datetime/timestamp->relative timestamp)
        :unread?   (not read)
        :context   [[common/user-avatar-tag author]
-                   [quo/text {:style style/lowercase-text} (i18n/label :t/wants-to-join)]
+                   (i18n/label :t/wants-to-join)
                    [quo/context-tag
                     {:size           :small
                      :override-theme :dark
                      :color          colors/primary-50
-                     :style          style/tag
-                     :text-style     style/tag-text}
+                     :style          style/user-avatar-tag
+                     :text-style     style/user-avatar-tag-text}
                     {:uri community-image} community-name]]
-        :status    (case membershipStatus
+       :status    (case membershipStatus
                     constants/membership-status-accepted
-                     {:type :positive :label (i18n/label :t/accepted)}
-                     constants/membership-status-declined
-                     {:type :negative :label (i18n/label :t/declined)}
-                     nil)}
-       (case membershipStatus
-          constants/membership-status-pending
-          {:button-1 {:label               (i18n/label :t/decline)
-                      :accessibility-label :decline-contact-request
-                      :type                :danger
-                      :on-press            (fn []
-                                             (rf/dispatch [:communities.ui/decline-request-to-join-pressed communityId id])
-                                             (rf/dispatch [:activity-center.notifications/mark-as-read id]))}
-           :button-2 {:label               (i18n/label :t/accept)
-                      :accessibility-label :accept-contact-request
-                      :type                :positive
-                      :on-press            (fn []
-                                             (rf/dispatch [:communities.ui/accept-request-to-join-pressed communityId id])
-                                             (rf/dispatch [:activity-center.notifications/mark-as-read id]))}}
-          nil))]))
+                    {:type :positive :label (i18n/label :t/accepted)}
+                    constants/membership-status-declined
+                    {:type :negative :label (i18n/label :t/declined)}
+                    nil)}
+      (case membershipStatus
+        constants/membership-status-pending
+        {:button-1 {:label               (i18n/label :t/decline)
+                    :accessibility-label :decline-contact-request
+                    :type                :danger
+                    :on-press            (fn []
+                                           (rf/dispatch [:communities.ui/decline-request-to-join-pressed
+                                                         communityId id])
+                                           (rf/dispatch [:activity-center.notifications/mark-as-read
+                                                         id]))}
+         :button-2 {:label               (i18n/label :t/accept)
+                    :accessibility-label :accept-contact-request
+                    :type                :positive
+                    :on-press            (fn []
+                                           (rf/dispatch [:communities.ui/accept-request-to-join-pressed
+                                                         communityId id])
+                                           (rf/dispatch [:activity-center.notifications/mark-as-read
+                                                         id]))}}
+        nil))]))

--- a/src/status_im2/contexts/activity_center/notification_types.cljs
+++ b/src/status_im2/contexts/activity_center/notification_types.cljs
@@ -6,10 +6,10 @@
 (def ^:const mention 3)
 (def ^:const reply 4)
 (def ^:const contact-request 5)
+(def ^:const admin 8)
 (def ^:const contact-verification 10)
 
 ;; TODO: Replace with correct enum values once status-go implements them.
-(def ^:const admin 66610)
 (def ^:const tx 66612)
 (def ^:const membership 66613)
 (def ^:const system 66614)

--- a/src/status_im2/contexts/activity_center/view.cljs
+++ b/src/status_im2/contexts/activity_center/view.cljs
@@ -5,6 +5,7 @@
             [react-native.core :as rn]
             [react-native.safe-area :as safe-area]
             [status-im2.contexts.activity-center.notification-types :as types]
+            [status-im2.contexts.activity-center.notification.admin.view :as admin]
             [status-im2.contexts.activity-center.notification.contact-request.view :as contact-request]
             [status-im2.contexts.activity-center.notification.contact-verification.view :as
              contact-verification]
@@ -111,6 +112,9 @@
 
      types/reply
      [reply/view notification]
+
+     types/admin
+     [admin/view notification]
 
      nil)])
 

--- a/translations/en.json
+++ b/translations/en.json
@@ -1939,5 +1939,7 @@
     "selected-count-from-max": "{{selected}}/{{max}}",
     "online": "Online",
     "contact-request-chat-pending": "Your contact request is pending",
-    "contact-request-chat-add": "Add {{name}} to send a message"
+    "contact-request-chat-add": "Add {{name}} to send a message",
+    "join-request": "Join request",
+    "wants-to-join": "want to join"
 }

--- a/translations/en.json
+++ b/translations/en.json
@@ -1941,5 +1941,5 @@
     "contact-request-chat-pending": "Your contact request is pending",
     "contact-request-chat-add": "Add {{name}} to send a message",
     "join-request": "Join request",
-    "wants-to-join": "want to join"
+    "wants-to-join": "wants to join"
 }


### PR DESCRIPTION
fixes #14713

### Summary

Implement [Admin Notifications](https://www.figma.com/file/eDfxTa9IoaCMUy5cLTp0ys/Shell-for-Mobile?node-id=3804%3A787601&t=DFDzGj4GThvYiKUp-0) in Activity Center.

![Screenshot 2023-01-10 at 6 19 39 PM](https://user-images.githubusercontent.com/19339952/211619677-9dc3d53d-d8d2-4dd7-b2f1-e15a05302e69.png)



#### Areas impacted

- Activity Center (Notifications Center)

#### Platforms

- Android
- iOS

#### Functional

- Communities

#### Steps to test

1. Create a Community with a `require approval` membership (User A)
2. Send the Community link (not inviting them) to other contacts (User B, User C,...etc)
3. Let the other users `Request access` to the community you have shared
4. Open Activity Center to see the admin (Join request) notifications (User A)

status: ready