### PR TITLE
Improve switcher cards lifecycle

### DIFF
--- a/src/react_native/reanimated.cljs
+++ b/src/react_native/reanimated.cljs
@@ -54,11 +54,13 @@
 ;; Helper functions
 (defn get-shared-value
   [anim]
-  (.-value anim))
+  (when anim
+    (.-value anim)))
 
 (defn set-shared-value
   [anim val]
-  (set! (.-value anim) val))
+  (when anim
+    (set! (.-value anim) val)))
 
 (defn kebab-case->camelCase
   [k]

--- a/src/status_im/communities/core.cljs
+++ b/src/status_im/communities/core.cljs
@@ -187,6 +187,7 @@
                                 (keys (get-in db [:communities community-id :chats])))]
     {:clear-message-notifications [community-chat-ids
                                    (get-in db [:multiaccount :remote-push-notifications-enabled?])]
+     :dispatch                    [:shell/close-switcher-card community-id]
      :json-rpc/call               [{:method      "wakuext_leaveCommunity"
                                     :params      [community-id]
                                     :js-response true

--- a/src/status_im/contact/block.cljs
+++ b/src/status_im/contact/block.cljs
@@ -47,6 +47,7 @@
                                              (update :chats dissoc public-key)
                                              (update :chats-home-list disj public-key)
                                              (assoc-in [:contacts/contacts public-key :added] false))
+            :dispatch                    [:shell/close-switcher-card public-key]
             :clear-message-notifications
             [[public-key] (get-in db [:multiaccount :remote-push-notifications-enabled?])]}
            (activity-center/notifications-fetch-unread-count)

--- a/src/status_im/group_chats/core.cljs
+++ b/src/status_im/group_chats/core.cljs
@@ -14,7 +14,7 @@
   {:events [:navigate-chat-updated]}
   [cofx chat-id]
   (when (get-in cofx [:db :chats chat-id])
-    (models.chat/navigate-to-chat cofx chat-id)))
+    (models.chat/navigate-to-chat-nav2 cofx chat-id nil)))
 
 (rf/defn handle-chat-removed
   {:events [:chat-removed]}

--- a/src/status_im/group_chats/core.cljs
+++ b/src/status_im/group_chats/core.cljs
@@ -71,7 +71,7 @@
 (rf/defn create-from-link
   [cofx {:keys [chat-id invitation-admin chat-name]}]
   (if (get-in cofx [:db :chats chat-id])
-    {:dispatch [:chat.ui/navigate-to-chat chat-id]}
+    {:dispatch [:chat.ui/navigate-to-chat-nav2 chat-id]}
     {:json-rpc/call [{:method      "wakuext_createGroupChatFromInvitation"
                       :params      [chat-name chat-id invitation-admin]
                       :js-response true

--- a/src/status_im/integration_test.cljs
+++ b/src/status_im/integration_test.cljs
@@ -251,7 +251,7 @@
          (rf/dispatch-sync [:chat.ui/start-chat chat-id]) ;; start a new chat
          (rf-test/wait-for
            [:status-im.chat.models/one-to-one-chat-created]
-           (rf/dispatch-sync [:chat.ui/navigate-to-chat chat-id])
+           (rf/dispatch-sync [:chat.ui/navigate-to-chat-nav2 chat-id])
            (is (= chat-id @(rf/subscribe [:chats/current-chat-id])))
            (logout!)
            (rf-test/wait-for [::logout/logout-method] ; we need to logout to make sure the node is not in
@@ -276,7 +276,7 @@
          (rf/dispatch-sync [:chat.ui/start-chat chat-id]) ;; start a new chat
          (rf-test/wait-for
            [:status-im.chat.models/one-to-one-chat-created]
-           (rf/dispatch-sync [:chat.ui/navigate-to-chat chat-id])
+           (rf/dispatch-sync [:chat.ui/navigate-to-chat-nav2 chat-id])
            (is (= chat-id @(rf/subscribe [:chats/current-chat-id])))
            (is @(rf/subscribe [:chats/chat chat-id]))
            (rf/dispatch-sync [:chat.ui/remove-chat-pressed chat-id])
@@ -307,7 +307,7 @@
          (rf/dispatch-sync [:chat.ui/start-chat chat-id]) ;; start a new chat
          (rf-test/wait-for
            [:status-im.chat.models/one-to-one-chat-created]
-           (rf/dispatch-sync [:chat.ui/navigate-to-chat chat-id])
+           (rf/dispatch-sync [:chat.ui/navigate-to-chat-nav2 chat-id])
            (is (= chat-id @(rf/subscribe [:chats/current-chat-id])))
            (is @(rf/subscribe [:chats/chat chat-id]))
            (rf/dispatch-sync [::chat.models/mute-chat-toggled chat-id true])

--- a/src/status_im/multiaccounts/login/core.cljs
+++ b/src/status_im/multiaccounts/login/core.cljs
@@ -424,7 +424,7 @@
          :key-uid
          (fn [stored-key-uid]
            (when (= stored-key-uid key-uid)
-             (re-frame/dispatch [:chat.ui/navigate-to-chat chat-id])))))))))
+             (re-frame/dispatch [:chat.ui/navigate-to-chat-nav2 chat-id])))))))))
 
 (rf/defn check-last-chat
   {:events [::check-last-chat]}

--- a/src/status_im/ui/screens/communities/views.cljs
+++ b/src/status_im/ui/screens/communities/views.cljs
@@ -48,7 +48,7 @@
     :on-press      (fn []
                      (rf/dispatch [:communities/load-category-states id])
                      (rf/dispatch [:dismiss-keyboard])
-                     (rf/dispatch [:navigate-to :community {:community-id id}]))
+                     (rf/dispatch [:navigate-to-nav2 :community {:community-id id}]))
     :on-long-press #(rf/dispatch [:bottom-sheet/show-sheet
                                   {:content (fn []
                                               [community/community-actions community])}])}
@@ -111,7 +111,7 @@
                                      (i18n/label :t/open-membership))]]
       :on-press                  #(do
                                     (rf/dispatch [:dismiss-keyboard])
-                                    (rf/dispatch [:navigate-to :community {:community-id id}]))}]))
+                                    (rf/dispatch [:navigate-to-nav2 :community {:community-id id}]))}]))
 
 (defn communities-actions
   []

--- a/src/status_im/ui/screens/home/views.cljs
+++ b/src/status_im/ui/screens/home/views.cljs
@@ -27,7 +27,6 @@
    [status-im.ui.screens.home.styles :as styles]
    [status-im.ui.screens.home.views.inner-item :as inner-item]
    [status-im.utils.utils :as utils]
-   [status-im2.setup.config :as config]
    [utils.debounce :as debounce])
   (:require-macros [status-im.utils.views :as views]))
 
@@ -152,9 +151,7 @@
      home-item
      {:on-press      (fn []
                        (re-frame/dispatch [:dismiss-keyboard])
-                       (if config/new-ui-enabled?
-                         (re-frame/dispatch [:chat.ui/navigate-to-chat-nav2 chat-id])
-                         (re-frame/dispatch [:chat.ui/navigate-to-chat chat-id]))
+                       (re-frame/dispatch [:chat.ui/navigate-to-chat-nav2 chat-id])
                        (re-frame/dispatch [:search/home-filter-changed nil]))
       :on-long-press #(re-frame/dispatch [:bottom-sheet/show-sheet
                                           {:content (fn []
@@ -169,9 +166,7 @@
      home-item
      {:on-press      (fn []
                        (re-frame/dispatch [:dismiss-keyboard])
-                       (if config/new-ui-enabled?
-                         (re-frame/dispatch [:chat.ui/navigate-to-chat-nav2 chat-id])
-                         (re-frame/dispatch [:chat.ui/navigate-to-chat chat-id]))
+                       (re-frame/dispatch [:chat.ui/navigate-to-chat-nav2 chat-id])
                        (re-frame/dispatch [:search/home-filter-changed nil]))
       :on-long-press #(re-frame/dispatch [:bottom-sheet/show-sheet
                                           {:content (fn []

--- a/src/status_im/utils/universal_links/core.cljs
+++ b/src/status_im/utils/universal_links/core.cljs
@@ -96,7 +96,7 @@
 (rf/defn handle-community-chat
   [cofx {:keys [chat-id]}]
   (log/info "universal-links: handling community chat" chat-id)
-  {:dispatch [:chat.ui/navigate-to-chat chat-id]})
+  {:dispatch [:chat.ui/navigate-to-chat-nav2 chat-id]})
 
 (rf/defn handle-public-chat
   [cofx {:keys [topic]}]

--- a/src/status_im2/contexts/activity_center/notification/mentions/view.cljs
+++ b/src/status_im2/contexts/activity_center/notification/mentions/view.cljs
@@ -46,7 +46,7 @@
     [rn/touchable-opacity
      {:on-press (fn []
                   (rf/dispatch [:hide-popover])
-                  (rf/dispatch [:chat.ui/navigate-to-chat chat-id]))}
+                  (rf/dispatch [:chat.ui/navigate-to-chat-nav2 chat-id]))}
      [quo/activity-log
       {:title     (i18n/label :t/mention)
        :icon      :i/mention

--- a/src/status_im2/contexts/activity_center/notification/reply/view.cljs
+++ b/src/status_im2/contexts/activity_center/notification/reply/view.cljs
@@ -38,7 +38,7 @@
     [rn/touchable-opacity
      {:on-press (fn []
                   (rf/dispatch [:hide-popover])
-                  (rf/dispatch [:chat.ui/navigate-to-chat chat-id]))}
+                  (rf/dispatch [:chat.ui/navigate-to-chat-nav2 chat-id]))}
      [quo/activity-log
       {:title     (i18n/label :t/message-reply)
        :icon      :i/reply

--- a/src/status_im2/contexts/chat/messages/list/view.cljs
+++ b/src/status_im2/contexts/chat/messages/list/view.cljs
@@ -181,7 +181,7 @@
      [quo/floating-shell-button
       (merge {:jump-to
               {:on-press #(do
-                            (rf/dispatch [:close-chat])
+                            (rf/dispatch [:close-chat true])
                             (rf/dispatch [:shell/navigate-to-jump-to]))
                :label    (i18n/label :t/jump-to)}}
              (when @show-floating-scroll-down-button

--- a/src/status_im2/contexts/chat/messages/view.cljs
+++ b/src/status_im2/contexts/chat/messages/view.cljs
@@ -19,7 +19,10 @@
   (when (and (not @navigation.state/curr-modal) (= (get @re-frame.db/app-db :view-id) :chat))
     (rn/hw-back-remove-listener navigate-back-handler)
     (rf/dispatch [:close-chat])
-    (rf/dispatch [:navigate-back])))
+    (rf/dispatch [:navigate-back])
+    ;; If true is not returned back button event will bubble up,
+    ;; and will call system back button action
+    true))
 
 (defn page-nav
   []

--- a/src/status_im2/subs/shell.cljs
+++ b/src/status_im2/subs/shell.cljs
@@ -102,7 +102,7 @@
    {:content  {:community-channel {:emoji        (:emoji channel)
                                    :channel-name (str "# " (:name channel))}}
     :on-press (fn []
-                (re-frame/dispatch [:navigate-to :community {:community-id community-id}])
+                (re-frame/dispatch [:navigate-to-nav2 :community {:community-id community-id}])
                 (js/setTimeout
                  #(re-frame/dispatch [:chat.ui/navigate-to-chat-nav2 channel-id true])
                  100))}))


### PR DESCRIPTION
### Changes/Fixes:
- Switcher card should be added/updated when chat screen or community screen is opened/created (from anywhere)
- Switcher card should be removed when chat deleted, community leaved, contact blocked etc.
(So basically switcher cards life-cycle should be as same as home screen chats/communities (addition/deletion))
- If user navigates back from channel to back to community, card should display community instead of channel
- Not related but fixed one another issue - Go back to community when android hardware back button is pressed in community chat

status: ready