### PR TITLE
chore: get community img from real data

### DIFF
--- a/src/status_im2/contexts/communities/menus/leave/style.cljs
+++ b/src/status_im2/contexts/communities/menus/leave/style.cljs
@@ -1,8 +1,7 @@
 (ns status-im2.contexts.communities.menus.leave.style)
 
 (def button-container
-  {:margin-top      16
-   :margin-bottom   16
+  {:margin-top      20
    :flex            1
    :flex-direction  :row
    :align-items     :center
@@ -17,13 +16,13 @@
 (def text {:margin-top 16})
 
 (def container
-  {:height        160
+  {:height        180
    :margin-left   20
    :margin-right  20
    :margin-bottom 20})
 
 (def inner-container
-  {:flex            1
+  {:display         :flex
    :flex-direction  :row
    :align-items     :center
    :justify-content :space-between})

--- a/src/status_im2/contexts/communities/menus/leave/view.cljs
+++ b/src/status_im2/contexts/communities/menus/leave/view.cljs
@@ -12,32 +12,32 @@
 
 (defn leave-sheet
   [id]
-  [rn/view {:style style/container}
-   [rn/view {:style style/inner-container}
-    [quo/text
-     {:accessibility-label :communities-join-community
-      :weight              :semi-bold
-      :size                :heading-1}
-     (i18n/label :t/leave-community?)]]
-   ;; TODO get tag image from community data - https://github.com/status-im/status-mobile/issues/14740
-   #_[quo/context-tag
+  (let [{:keys [name images]} (rf/sub [:communities/community id])]
+    [rn/view {:style style/container}
+     [rn/view {:style style/inner-container}
+      [quo/text
+       {:accessibility-label :communities-join-community
+        :weight              :semi-bold
+        :size                :heading-1}
+       (i18n/label :t/leave-community?)]]
+     [quo/context-tag
       {:style
        {:margin-right :auto
         :margin-top   8}}
-      (resources/get-image :status-logo) (:name community)]
-   [quo/text
-    {:accessibility-label :communities-join-community
-     :size                :paragraph-1
-     :style               style/text}
-    (i18n/label :t/leave-community-message)]
-   [rn/view
-    {:style style/button-container}
-    [quo/button
-     {:on-press #(rf/dispatch [:bottom-sheet/hide])
-      :type     :grey
-      :style    style/cancel-button}
-     (i18n/label :t/cancel)]
-    [quo/button
-     {:on-press #(hide-sheet-and-dispatch [:communities/leave id])
-      :style    style/action-button}
-     (i18n/label :t/leave-community)]]])
+      (:thumbnail images) name]
+     [quo/text
+      {:accessibility-label :communities-join-community
+       :size                :paragraph-1
+       :style               style/text}
+      (i18n/label :t/leave-community-message)]
+     [rn/view
+      {:style style/button-container}
+      [quo/button
+       {:on-press #(rf/dispatch [:bottom-sheet/hide])
+        :type     :grey
+        :style    style/cancel-button}
+       (i18n/label :t/cancel)]
+      [quo/button
+       {:on-press #(hide-sheet-and-dispatch [:communities/leave id])
+        :style    style/action-button}
+       (i18n/label :t/leave-community)]]]))

--- a/src/status_im2/contexts/communities/menus/request_to_join/view.cljs
+++ b/src/status_im2/contexts/communities/menus/request_to_join/view.cljs
@@ -4,7 +4,6 @@
             [reagent.core :as reagent]
             [status-im.communities.core :as communities]
             [utils.i18n :as i18n]
-            [status-im.react-native.resources :as resources]
             [status-im2.contexts.communities.menus.request-to-join.style :as style]
             [utils.re-frame :as rf]
             [utils.requests :as requests]))
@@ -75,7 +74,7 @@
     :render-fn                         community-rule-item}])
 
 (defn request-to-join
-  [{:keys [permissions name id
+  [{:keys [permissions name id images
            can-join? can-request-access?
            requested-to-join-at]}]
   (let [agreed-to-rules? (reagent/atom false)
@@ -93,12 +92,11 @@
         [rn/view
          {:style style/request-icon}
          [quo/icon :i/info]]]
-       ;; TODO get tag image from community data
        [quo/context-tag
         {:style
          {:margin-right :auto
           :margin-top   8}}
-        (resources/get-image :status-logo) name]
+        (:thumbnail images) name]
        [quo/text
         {:style               {:margin-top 24}
          :accessibility-label :communities-rules-title

--- a/src/status_im2/contexts/communities/overview/view.cljs
+++ b/src/status_im2/contexts/communities/overview/view.cljs
@@ -312,9 +312,7 @@
         first-channel-height (reagent/atom 0)
         scroll-component     (scroll-page/scroll-page
                               {:uri (get-in images [:large :uri])}
-                              {:right-section-buttons [{:icon             :i/search
-                                                        :background-color (scroll-page/icon-color)}
-                                                       {:icon             :i/options
+                              {:right-section-buttons [{:icon             :i/options
                                                         :background-color (scroll-page/icon-color)
                                                         :on-press
                                                         #(rf/dispatch


### PR DESCRIPTION
fixes: https://github.com/status-im/status-mobile/issues/14740

join a community

then leave via the options on community overview page.

The icon should now be using the community icon rather than mock data img