### PR TITLE
feat: support deleted by xxx

### DIFF
--- a/src/quo2/components/messages/system_message.cljs
+++ b/src/quo2/components/messages/system_message.cljs
@@ -64,7 +64,7 @@
 (defmulti sm-render :type)
 
 (defmethod sm-render :deleted
-  [{:keys [label timestamp-str labels]}]
+  [{:keys [label timestamp-str labels child]}]
   [rn/view
    {:align-items     :center
     :justify-content :space-between
@@ -77,11 +77,13 @@
      {:icon    :main-icons/delete
       :color   :danger
       :opacity 5}]
-    [text/text
-     {:size  :paragraph-2
-      :style {:color        (get-color :text)
-              :margin-right 5}}
-     (or (get labels label) label (:message-deleted labels))]
+    (if child
+      child
+      [text/text
+       {:size  :paragraph-2
+        :style {:color        (get-color :text)
+                :margin-right 5}}
+       (or (get labels label) label (:message-deleted labels))])
     [sm-timestamp timestamp-str]]])
 
 (defmethod sm-render :added
@@ -185,9 +187,7 @@
           1000))
        [reanimated/touchable-opacity
         {:on-press #(when-not non-pressable?
-                      (reanimated/set-shared-value
-                       sv-color
-                       (get-color :bg :pressed type)))
+                      (reanimated/set-shared-value sv-color (get-color :bg :pressed type)))
          :style    (reanimated/apply-animations-to-style
                     {:background-color sv-color}
                     (merge

--- a/src/quo2/core.cljs
+++ b/src/quo2/core.cljs
@@ -88,6 +88,7 @@
 (def filter quo2.components.selectors.filter.view/view)
 (def skeleton quo2.components.loaders.skeleton/skeleton)
 (def author quo2.components.messages.author.view/author)
+(def display-name quo2.components.messages.author.view/display-name)
 
 ;;;; AVATAR
 (def account-avatar quo2.components.avatars.account-avatar/account-avatar)

--- a/src/status_im/chat/models/message.cljs
+++ b/src/status_im/chat/models/message.cljs
@@ -3,16 +3,16 @@
             [re-frame.core :as re-frame]
             [status-im.chat.models.loading :as chat.loading]
             [status-im.chat.models.mentions :as mentions]
-            [status-im2.contexts.chat.messages.list.events :as message-list]
             [status-im.data-store.messages :as data-store.messages]
             [status-im.transport.message.protocol :as protocol]
-            [status-im2.contexts.chat.messages.list.state :as view.state]
-            [utils.re-frame :as rf]
             [status-im.utils.gfycat.core :as gfycat]
             [status-im.utils.platform :as platform]
             [status-im.utils.types :as types]
             [status-im2.contexts.chat.messages.delete-message.events :as delete-message]
-            [taoensso.timbre :as log]))
+            [status-im2.contexts.chat.messages.list.events :as message-list]
+            [status-im2.contexts.chat.messages.list.state :as view.state]
+            [taoensso.timbre :as log]
+            [utils.re-frame :as rf]))
 
 (defn- message-loaded?
   [db chat-id message-id]
@@ -166,7 +166,9 @@
   {:events [::handle-removed-messages]}
   [{:keys [db] :as cofx} removed-messages]
   (let [mark-as-deleted-fx (->> removed-messages
-                                (map #(assoc % :message-id (:messageId %)))
+                                (map #(assoc %
+                                             :message-id (:messageId %)
+                                             :deleted-by (:deletedBy %)))
                                 (group-by :chatId)
                                 (mapv (fn [[chat-id messages]]
                                         (delete-message/delete-messages-localy messages chat-id))))

--- a/src/status_im/data_store/messages.cljs
+++ b/src/status_im/data_store/messages.cljs
@@ -36,6 +36,7 @@
                         :audioDurationMs          :audio-duration-ms
                         :deleted                  :deleted?
                         :deletedForMe             :deleted-for-me?
+                        :deletedBy                :deleted-by
                         :albumId                  :album-id
                         :imageWidth               :image-width
                         :imageHeight              :image-height

--- a/src/status_im2/contexts/chat/messages/content/deleted/view.cljs
+++ b/src/status_im2/contexts/chat/messages/content/deleted/view.cljs
@@ -1,16 +1,20 @@
 (ns status-im2.contexts.chat.messages.content.deleted.view
-  (:require [utils.i18n :as i18n]
-            [quo2.core :as quo]))
+  (:require [quo2.core :as quo]
+            [react-native.core :as rn]
+            [utils.i18n :as i18n]))
 
 (defn deleted-message
-  [{:keys [deleted? deleted-undoable-till timestamp-str deleted-for-me-undoable-till]}]
-  [quo/system-message
-   {:type             :deleted
-    :label            (if deleted? :message-deleted :message-deleted-for-you)
-    :labels           {:pinned-a-message        (i18n/label :t/pinned-a-message)
-                       :message-deleted         (i18n/label :t/message-deleted-for-everyone)
-                       :message-deleted-for-you (i18n/label :t/message-deleted-for-you)
-                       :added                   (i18n/label :t/added)}
-    :timestamp-str    timestamp-str
-    :non-pressable?   true
-    :animate-landing? (or deleted-undoable-till deleted-for-me-undoable-till)}])
+  [{:keys [deleted? deleted-by deleted-undoable-till timestamp-str deleted-for-me-undoable-till]}]
+  (let [msg [quo/system-message
+             {:type             :deleted
+              :label            (if deleted? :message-deleted :message-deleted-for-you)
+              :labels           {:pinned-a-message        (i18n/label :t/pinned-a-message)
+                                 :message-deleted         (i18n/label :t/message-deleted-for-everyone)
+                                 :message-deleted-for-you (i18n/label :t/message-deleted-for-you)
+                                 :added                   (i18n/label :t/added)}
+              :timestamp-str    timestamp-str
+              :non-pressable?   true
+              :animate-landing? (or deleted-undoable-till deleted-for-me-undoable-till)}]]
+    (if deleted-by
+      [rn/view {:style {:border-width 1 :border-color :blue}} msg]
+      msg)))

--- a/src/status_im2/contexts/chat/messages/content/deleted/view.cljs
+++ b/src/status_im2/contexts/chat/messages/content/deleted/view.cljs
@@ -1,20 +1,52 @@
 (ns status-im2.contexts.chat.messages.content.deleted.view
   (:require [quo2.core :as quo]
             [react-native.core :as rn]
-            [utils.i18n :as i18n]))
+            [utils.i18n :as i18n]
+            [utils.re-frame :as rf]))
+
+(defn user-xxx-deleted-this-message
+  [{:keys [display-name profile-picture]}]
+  [rn/view {:style {:flex-direction :row :align-items :center}}
+   [rn/view {:style {:margin-right 4}}
+    [quo/user-avatar
+     {:full-name         display-name
+      :profile-picture   profile-picture
+      :status-indicator? false
+      :ring?             false
+      :size              :xxxs}]]
+   [quo/display-name
+    {:profile-name display-name
+     :text-style   {}}]
+   [quo/text {:style {:margin-left 4} :size :paragraph-2}
+    (i18n/label :t/deleted-this-message)]])
+
+(defn deleted-by-message
+  [{:keys [deleted-by deleted-undoable-till timestamp-str deleted-for-me-undoable-till from]}]
+  (let [;; deleted message with nil deleted-by is deleted by (:from message)
+        display-name (first (rf/sub [:contacts/contact-two-names-by-identity (or deleted-by from)]))
+        contact      (rf/sub [:contacts/contact-by-address (or deleted-by from)])
+        photo-path   (when-not (empty? (:images contact))
+                       (rf/sub [:chats/photo-path (or deleted-by from)]))]
+    [quo/system-message
+     {:type             :deleted
+      :timestamp-str    timestamp-str
+      :child            [user-xxx-deleted-this-message
+                         {:display-name display-name :profile-picture photo-path}]
+      :non-pressable?   true
+      :animate-landing? (or deleted-undoable-till deleted-for-me-undoable-till)}]))
 
 (defn deleted-message
-  [{:keys [deleted? deleted-by deleted-undoable-till timestamp-str deleted-for-me-undoable-till]}]
-  (let [msg [quo/system-message
-             {:type             :deleted
-              :label            (if deleted? :message-deleted :message-deleted-for-you)
-              :labels           {:pinned-a-message        (i18n/label :t/pinned-a-message)
-                                 :message-deleted         (i18n/label :t/message-deleted-for-everyone)
-                                 :message-deleted-for-you (i18n/label :t/message-deleted-for-you)
-                                 :added                   (i18n/label :t/added)}
-              :timestamp-str    timestamp-str
-              :non-pressable?   true
-              :animate-landing? (or deleted-undoable-till deleted-for-me-undoable-till)}]]
-    (if deleted-by
-      [rn/view {:style {:border-width 1 :border-color :blue}} msg]
-      msg)))
+  [{:keys [deleted? deleted-by deleted-undoable-till timestamp-str deleted-for-me-undoable-till from]
+    :as   message}]
+  (let [pub-key        (rf/sub [:multiaccount/public-key])
+        deleted-by-me? (= (or deleted-by from) pub-key)]
+    (if (not deleted-by-me?)
+      [deleted-by-message message]
+      [quo/system-message
+       {:type             :deleted
+        :label            (if deleted? :message-deleted :message-deleted-for-you)
+        :labels           {:message-deleted         (i18n/label :t/message-deleted-for-everyone)
+                           :message-deleted-for-you (i18n/label :t/message-deleted-for-you)}
+        :timestamp-str    timestamp-str
+        :non-pressable?   true
+        :animate-landing? (or deleted-undoable-till deleted-for-me-undoable-till)}])))

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.126.0",
-    "commit-sha1": "cefa0089dcf24e2f91ebc133ec4994c1f2e128ce",
-    "src-sha256": "00zy4k1200da67dg23r0hvl3dfd9b4pfzsv238islp8pqa869sfi"
+    "version": "v0.126.1",
+    "commit-sha1": "cb624b0cc14d95e46754210c9153f8a0444d2845",
+    "src-sha256": "1wrjlzwqj7qzsvh2aba4fjfp29ckx416lkxsk3c7las88ji93wzn"
 }

--- a/translations/en.json
+++ b/translations/en.json
@@ -448,6 +448,7 @@
     "delete-profile": "Delete profile",
     "delete-my-profile": "Delete my profile",
     "delete-profile-warning": "Warning: If you don’t have your seed phrase written down, you will lose access to your funds after you delete your profile",
+    "deleted-this-message": "deleted this message",
     "enter-channel": "Enter channel",
     "profile-deleted-title": "Profile deleted",
     "profile-deleted-content": "Your profile was successfully deleted",


### PR DESCRIPTION
Resolve #14489
Resolve #14826
Resolve #14509


### Summary

the UI will only show up for messages that not deleted for everyone by current user

![CleanShot 2023-01-12 at 21 04 01](https://user-images.githubusercontent.com/15090582/212073749-79552095-7548-4a28-968a-c61a319fb4bf.png)

### Testing notes

the xxx deleted this message UI might not fit in the screen if user display name too long (indicated in above screenshot)
will fix with separate PR


#### Areas that maybe impacted
- delete message for everyone

status: ready <!-- Can be ready or wip -->