### PR TITLE
make sure nodejs uses a fixed timezone

### DIFF
--- a/test-resources/override.js
+++ b/test-resources/override.js
@@ -1,6 +1,6 @@
 var Mocks = require('../target/mocks/mocks.js');
 var Module = require('module');
-process.env.TZ = 'Etc/Universal'
+process.env.TZ = 'Etc/UTC'
 
 const originalLoader = Module._load;
 

--- a/test-resources/override.js
+++ b/test-resources/override.js
@@ -1,5 +1,6 @@
 var Mocks = require('../target/mocks/mocks.js');
 var Module = require('module');
+process.env.TZ = 'Europe/Amsterdam'
 
 const originalLoader = Module._load;
 

--- a/test-resources/override.js
+++ b/test-resources/override.js
@@ -1,6 +1,6 @@
 var Mocks = require('../target/mocks/mocks.js');
 var Module = require('module');
-process.env.TZ = 'Europe/Amsterdam'
+process.env.TZ = 'Etc/Universal'
 
 const originalLoader = Module._load;
 


### PR DESCRIPTION
we had a _timebomb_ tests in the codebase that would break on some environments and work on other environments. Making sure nodejs specifies a timezone fixes them.

fixes #14742

status: ready
