### PR TITLE
[Feature] Fetch community info on handling community join link

### DIFF
--- a/src/status_im/chat/models/link_preview.cljs
+++ b/src/status_im/chat/models/link_preview.cljs
@@ -60,7 +60,7 @@
             (models.communities/handle-community community)))
 
 (rf/defn resolve-community-info
-  {:events [::resolve-community-info]}
+  {:events [:communities.ui/:resolve-community-info]}
   [{:keys [db]} community-id]
   {:db            (community-resolving db community-id)
    :json-rpc/call [{:method     "wakuext_requestCommunityInfoFromMailserver"

--- a/src/status_im/chat/models/link_preview.cljs
+++ b/src/status_im/chat/models/link_preview.cljs
@@ -60,7 +60,7 @@
             (models.communities/handle-community community)))
 
 (rf/defn resolve-community-info
-  {:events [:communities.ui/:resolve-community-info]}
+  {:events [:communities.ui/resolve-community-info]}
   [{:keys [db]} community-id]
   {:db            (community-resolving db community-id)
    :json-rpc/call [{:method     "wakuext_requestCommunityInfoFromMailserver"

--- a/src/status_im/ui/screens/communities/community.cljs
+++ b/src/status_im/ui/screens/communities/community.cljs
@@ -256,7 +256,7 @@
 (defn unknown-community
   [community-id]
   (let [fetching (rf/sub [:communities/fetching-community community-id])]
-    [:<> {:style {:flex 1}}
+    [:<>
      [topbar/topbar {:title (if fetching (i18n/label :t/fetching-community) (i18n/label :t/not-found))}]
      [rn/view
       {:style {:padding 16 :flex 1 :flex-direction :row :align-items :center :justify-content :center}}

--- a/src/status_im/utils/universal_links/core.cljs
+++ b/src/status_im/utils/universal_links/core.cljs
@@ -1,7 +1,6 @@
 (ns status-im.utils.universal-links.core
   (:require [clojure.string :as string]
             [goog.string :as gstring]
-            [i18n.i18n :as i18n]
             [re-frame.core :as re-frame]
             [status-im.add-new.db :as new-chat.db]
             [status-im.chat.models :as chat]
@@ -15,6 +14,7 @@
             [status-im.wallet.choose-recipient.core :as choose-recipient]
             [status-im2.navigation.events :as navigation]
             [taoensso.timbre :as log]
+            [utils.i18n :as i18n]
             [utils.re-frame :as rf]))
 
 ;; TODO(yenda) investigate why `handle-universal-link` event is

--- a/src/status_im/utils/universal_links/core.cljs
+++ b/src/status_im/utils/universal_links/core.cljs
@@ -1,21 +1,21 @@
 (ns status-im.utils.universal-links.core
   (:require [clojure.string :as string]
             [goog.string :as gstring]
+            [i18n.i18n :as i18n]
             [re-frame.core :as re-frame]
             [status-im.add-new.db :as new-chat.db]
             [status-im.chat.models :as chat]
             [status-im2.constants :as constants]
             [status-im.ethereum.core :as ethereum]
             [status-im.group-chats.core :as group-chats]
-            [utils.i18n :as i18n]
             [status-im.multiaccounts.model :as multiaccounts.model]
+            [status-im.native-module.core :as status]
             [status-im.router.core :as router]
             [status-im.ui.components.react :as react]
-            [utils.re-frame :as rf]
             [status-im.wallet.choose-recipient.core :as choose-recipient]
             [status-im2.navigation.events :as navigation]
             [taoensso.timbre :as log]
-            [status-im.native-module.core :as status]))
+            [utils.re-frame :as rf]))
 
 ;; TODO(yenda) investigate why `handle-universal-link` event is
 ;; dispatched 7 times for the same link
@@ -75,10 +75,12 @@
   (navigation/navigate-to-cofx cofx :community-requests-to-join {:community-id community-id}))
 
 (rf/defn handle-community
-  [cofx {:keys [community-id]}]
+  [{:keys [db] :as cofx} {:keys [community-id]}]
   (log/info "universal-links: handling community" community-id)
-  (navigation/navigate-to-cofx cofx :community {:community-id community-id}))
-
+  (rf/merge cofx
+            (when-not (get (:communities db) community-id)
+              {:dispatch [:communities.ui/:resolve-community-info community-id]})
+            (navigation/navigate-to-cofx :community {:community-id community-id})))
 
 (rf/defn handle-navigation-to-desktop-community-from-mobile
   {:events [:handle-navigation-to-desktop-community-from-mobile]}

--- a/src/status_im/utils/universal_links/core.cljs
+++ b/src/status_im/utils/universal_links/core.cljs
@@ -79,7 +79,7 @@
   (log/info "universal-links: handling community" community-id)
   (rf/merge cofx
             (when-not (get (:communities db) community-id)
-              {:dispatch [:communities.ui/:resolve-community-info community-id]})
+              {:dispatch [:communities.ui/resolve-community-info community-id]})
             (navigation/navigate-to-cofx :community {:community-id community-id})))
 
 (rf/defn handle-navigation-to-desktop-community-from-mobile


### PR DESCRIPTION


fixes #14705

### Summary

This PR attempts to improve the UX of joining NEW communities by fetching the community info (if not present in the app-dB) as soon as the user taps on the join community link without the need of tapping the `Fetch Community` button.

https://user-images.githubusercontent.com/19339952/213203166-bb36471e-f978-458c-921c-3dfaf1faa1b2.mov

#### Platforms

- Android
- iOS

#### Steps to test

- User `A` creates a community and shares the Community link with other contacts
- User `B` taps on the received community link and sees the community without the need of tapping the `Fetch Community` button

status: ready 
