### PR TITLE
[Fix] Back button behaviour when Photo Selector is open

### DIFF
--- a/src/status_im2/contexts/chat/messages/view.cljs
+++ b/src/status_im2/contexts/chat/messages/view.cljs
@@ -17,9 +17,12 @@
 (defn navigate-back-handler
   []
   (when (and (not @navigation.state/curr-modal) (= (get @re-frame.db/app-db :view-id) :chat))
-    (rn/hw-back-remove-listener navigate-back-handler)
-    (rf/dispatch [:chat/close])
-    (rf/dispatch [:navigate-back])
+    (if (get @re-frame.db/app-db :bottom-sheet/show?)
+      (rf/dispatch [:bottom-sheet/hide])
+      (do
+        (rn/hw-back-remove-listener navigate-back-handler)
+        (rf/dispatch [:chat/close])
+        (rf/dispatch [:navigate-back])))
     ;; If true is not returned back button event will bubble up,
     ;; and will call system back button action
     true))


### PR DESCRIPTION
fixes #14788 

### Summary

This PR fixes Issue 1 of #14788 where the user is not navigated back to opened chat after the `back` device's button is tapped.

Issue 2 is fixed as part of PR #14791.

#### Platforms

- Android

#### Areas impacted

- 1-1 chats
- Public chats
- Group chats
- Communities chats

### Steps to reproduce 

- Open Status
- Open any Chat
- Open the Image Selector
- Press the `back` button on the device


status: ready
