### PR TITLE
Show unread indicator on Activity Center tabs

### DIFF
--- a/src/mocks/js_dependencies.cljs
+++ b/src/mocks/js_dependencies.cljs
@@ -137,10 +137,13 @@ globalThis.__STATUS_MOBILE_JS_IDENTITY_PROXY__ = new Proxy({}, {get() { return (
 (def react-native-share #js {:default {}})
 (def react-native-svg
   #js
-   {:SvgUri  #js {:render identity}
-    :SvgXml  #js {:render identity}
-    :default #js {:render identity}
-    :Path    #js {:render identity}})
+   {:ClipPath #js {:render identity}
+    :Defs     #js {:render identity}
+    :Path     #js {:render identity}
+    :Rect     #js {:render identity}
+    :SvgUri   #js {:render identity}
+    :SvgXml   #js {:render identity}
+    :default  #js {:render identity}})
 (def react-native-webview #js {:default {}})
 (def react-native-audio-toolkit #js {:MediaStates {}})
 (def net-info #js {})

--- a/src/quo2/components/notifications/notification_dot.cljs
+++ b/src/quo2/components/notifications/notification_dot.cljs
@@ -2,13 +2,15 @@
   (:require [quo2.foundations.colors :as colors]
             [react-native.core :as rn]))
 
+(def ^:const size 8)
+
 (defn notification-dot
   [style]
   [rn/view
    {:style (merge {:background-color (colors/theme-colors colors/primary-50 colors/primary-60)
-                   :width            8
-                   :height           8
-                   :border-radius    4
+                   :width            size
+                   :height           size
+                   :border-radius    (/ size 2)
                    :position         :absolute
                    :z-index          1}
                   style)}])

--- a/src/quo2/components/notifications/notification_dot.cljs
+++ b/src/quo2/components/notifications/notification_dot.cljs
@@ -7,10 +7,12 @@
 (defn notification-dot
   [{:keys [style]}]
   [rn/view
-   {:style (merge {:background-color (colors/theme-colors colors/primary-50 colors/primary-60)
-                   :width            size
-                   :height           size
-                   :border-radius    (/ size 2)
-                   :position         :absolute
-                   :z-index          1}
-                  style)}])
+   {:accessibility-label :notification-dot
+    :style               (merge
+                          {:background-color (colors/theme-colors colors/primary-50 colors/primary-60)
+                           :width            size
+                           :height           size
+                           :border-radius    (/ size 2)
+                           :position         :absolute
+                           :z-index          1}
+                          style)}])

--- a/src/quo2/components/notifications/notification_dot.cljs
+++ b/src/quo2/components/notifications/notification_dot.cljs
@@ -5,7 +5,7 @@
 (def ^:const size 8)
 
 (defn notification-dot
-  [style]
+  [{:keys [style]}]
   [rn/view
    {:style (merge {:background-color (colors/theme-colors colors/primary-50 colors/primary-60)
                    :width            size

--- a/src/quo2/components/tabs/segmented_tab.cljs
+++ b/src/quo2/components/tabs/segmented_tab.cljs
@@ -1,5 +1,5 @@
 (ns quo2.components.tabs.segmented-tab
-  (:require [quo2.components.tabs.tab :as tab]
+  (:require [quo2.components.tabs.tab.view :as tab]
             [quo2.foundations.colors :as colors]
             [quo2.theme :as theme]
             [react-native.core :as rn]
@@ -28,7 +28,7 @@
            [rn/view
             {:margin-left (if (= 0 indx) 0 2)
              :flex        1}
-            [tab/tab
+            [tab/view
              {:id        id
               :segmented true
               :size      size

--- a/src/quo2/components/tabs/tab.cljs
+++ b/src/quo2/components/tabs/tab.cljs
@@ -55,13 +55,15 @@
                                 32 10
                                 28 8
                                 24 8
-                                20 6)
+                                20 6
+                                nil)
           :background-color   background-color
           :padding-horizontal (case size
                                 32 12
                                 28 12
                                 24 8
-                                20 8)}
+                                20 8
+                                nil)}
          (when disabled
            {:opacity 0.3})))
 

--- a/src/quo2/components/tabs/tab.cljs
+++ b/src/quo2/components/tabs/tab.cljs
@@ -1,9 +1,13 @@
 (ns quo2.components.tabs.tab
   (:require [quo2.components.icon :as icons]
             [quo2.components.markdown.text :as text]
+            [quo2.components.notifications.notification-dot :as notification-dot]
             [quo2.foundations.colors :as colors]
             [quo2.theme :as theme]
-            [react-native.core :as rn]))
+            [react-native.core :as rn]
+            [react-native.svg :as svg]))
+
+(def ^:const notification-dot-offset 2)
 
 (def themes
   {:light {:default  {:background-color colors/neutral-20
@@ -45,27 +49,59 @@
                       :icon-color       colors/neutral-40
                       :label            {:style {:color colors/white}}}}})
 
+(defn size->border-radius
+  [size]
+  (case size
+    32 10
+    28 8
+    24 8
+    20 6
+    nil))
+
+(defn size->padding-left
+  [size]
+  (case size
+    32 12
+    28 12
+    24 8
+    20 8
+    nil))
+
+(defn show-notification-dot?
+  [notification-dot? size]
+  (and notification-dot? (= size 32)))
+
 (defn style-container
-  [size disabled background-color]
-  (merge {:height             size
-          :align-items        :center
-          :justify-content    :center
-          :flex-direction     :row
-          :border-radius      (case size
-                                32 10
-                                28 8
-                                24 8
-                                20 6
-                                nil)
-          :background-color   background-color
-          :padding-horizontal (case size
-                                32 12
-                                28 12
-                                24 8
-                                20 8
-                                nil)}
-         (when disabled
-           {:opacity 0.3})))
+  [{:keys [size disabled background-color notification-dot?]}]
+  (let [border-radius (size->border-radius size)
+        padding       (size->padding-left size)]
+    (merge {:height                    size
+            :align-items               :center
+            :justify-content           :flex-end
+            :flex-direction            :row
+            :border-top-left-radius    border-radius
+            :border-bottom-left-radius border-radius
+            :background-color          background-color
+            :padding-left              padding}
+           (when-not (show-notification-dot? notification-dot? size)
+             {:padding-horizontal padding
+              :border-radius      border-radius})
+           (when disabled
+             {:opacity 0.3}))))
+
+(defn right-side-with-cutout
+  [{:keys [height width background-color]}]
+  [svg/svg
+   {:width    width
+    :height   height
+    :view-box (str "0 0 " width " " height)
+    :fill     :none}
+   [svg/path
+    {:fill-rule :evenodd
+     :clip-rule :evenodd
+     :fill      background-color
+     :d
+     "M11.4683 6.78094C11.004 6.92336 10.511 7 10 7C7.23858 7 5 4.76142 5 2C5 1.48904 5.07664 0.995988 5.21906 0.531702C4.68658 0.350857 4.13363 0.213283 3.56434 0.123117C2.78702 0 1.85801 0 0 0V32C1.85801 32 2.78702 32 3.56434 31.8769C7.84327 31.1992 11.1992 27.8433 11.8769 23.5643C12 22.787 12 21.858 12 20V12C12 10.142 12 9.21298 11.8769 8.43566C11.7867 7.86637 11.6491 7.31342 11.4683 6.78094Z"}]])
 
 (defn tab
   "[tab opts \"label\"]
@@ -76,9 +112,19 @@
     :before :icon-keyword
     :after :icon-keyword}"
   [_ _]
-  (fn [{:keys [id on-press disabled size before active accessibility-label blur? override-theme]
-        :or   {size 32}}
-       children]
+  (fn
+    [{:keys [accessibility-label
+             active
+             before
+             blur?
+             disabled
+             id
+             on-press
+             override-theme
+             size
+             notification-dot?]
+      :or   {size 32}}
+     children]
     (let [state                                       (cond disabled :disabled
                                                             active   :active
                                                             :else    :default)
@@ -91,21 +137,38 @@
               (when on-press
                 {:on-press (fn []
                              (on-press id))}))
-       [rn/view {:style (style-container size disabled background-color)}
-        (when before
+       [rn/view {:style {:flex-direction :row}}
+        (when (show-notification-dot? notification-dot? size)
           [rn/view
-           [icons/icon before {:color icon-color}]])
+           {:style {:position :absolute
+                    :z-index  1
+                    :right    (- notification-dot/size notification-dot-offset)
+                    :top      (- notification-dot-offset)}}
+           [notification-dot/notification-dot]])
         [rn/view
-         (cond
-           (string? children)
-           [text/text
-            (merge {:size            (case size
-                                       24 :paragraph-2
-                                       20 :label
-                                       nil)
-                    :weight          :medium
-                    :number-of-lines 1}
-                   label)
-            children]
-           (vector? children)
-           children)]]])))
+         {:style (style-container {:size              size
+                                   :disabled          disabled
+                                   :background-color  background-color
+                                   :notification-dot? notification-dot?})}
+         (when before
+           [rn/view
+            [icons/icon before {:color icon-color}]])
+         [rn/view
+          (cond
+            (string? children)
+            [text/text
+             (merge {:size            (case size
+                                        24 :paragraph-2
+                                        20 :label
+                                        nil)
+                     :weight          :medium
+                     :number-of-lines 1}
+                    label)
+             children]
+            (vector? children)
+            children)]]
+        (when (show-notification-dot? notification-dot? size)
+          [right-side-with-cutout
+           {:width            (size->padding-left size)
+            :height           size
+            :background-color background-color}])]])))

--- a/src/quo2/components/tabs/tab/style.cljs
+++ b/src/quo2/components/tabs/tab/style.cljs
@@ -2,8 +2,6 @@
   (:require [quo2.foundations.colors :as colors]
             [quo2.theme :as theme]))
 
-(def notification-dot-offset 2)
-
 (defn size->padding-left
   [size]
   (case size
@@ -22,12 +20,10 @@
     20 6
     nil))
 
-(defn notification-dot
-  [dot-size]
+(def notification-dot
   {:position :absolute
-   :z-index  1
-   :right    (- dot-size notification-dot-offset)
-   :top      (- notification-dot-offset)})
+   :top      -2
+   :right    -2})
 
 (def container
   {:flex-direction :row})

--- a/src/quo2/components/tabs/tab/style.cljs
+++ b/src/quo2/components/tabs/tab/style.cljs
@@ -2,6 +2,8 @@
   (:require [quo2.foundations.colors :as colors]
             [quo2.theme :as theme]))
 
+(def tab-background-opacity 0.3)
+
 (defn size->padding-left
   [size]
   (case size
@@ -34,17 +36,20 @@
         padding       (size->padding-left size)]
     (merge {:height                    size
             :align-items               :center
-            :justify-content           :flex-end
             :flex-direction            :row
             :border-top-left-radius    border-radius
             :border-bottom-left-radius border-radius
             :background-color          background-color
             :padding-left              padding}
-           (when-not show-notification-dot?
-             {:padding-horizontal padding
-              :border-radius      border-radius})
+           ;; The minimum padding right of 1 is a mandatory workaround. Without
+           ;; it, the SVG rendered besides the tab will have a 1px margin. This
+           ;; issue still exists in the latest react-native-svg versions.
+           (if show-notification-dot?
+             {:padding-right 1}
+             {:border-radius border-radius
+              :padding-right padding})
            (when disabled
-             {:opacity 0.3}))))
+             {:opacity tab-background-opacity}))))
 
 (def themes
   {:light {:default  {:background-color colors/neutral-20

--- a/src/quo2/components/tabs/tab/style.cljs
+++ b/src/quo2/components/tabs/tab/style.cljs
@@ -1,0 +1,100 @@
+(ns quo2.components.tabs.tab.style
+  (:require [quo2.foundations.colors :as colors]
+            [quo2.theme :as theme]))
+
+(def notification-dot-offset 2)
+
+(defn size->padding-left
+  [size]
+  (case size
+    32 12
+    28 12
+    24 8
+    20 8
+    nil))
+
+(defn size->border-radius
+  [size]
+  (case size
+    32 10
+    28 8
+    24 8
+    20 6
+    nil))
+
+(defn notification-dot
+  [dot-size]
+  {:position :absolute
+   :z-index  1
+   :right    (- dot-size notification-dot-offset)
+   :top      (- notification-dot-offset)})
+
+(def container
+  {:flex-direction :row})
+
+(defn tab
+  [{:keys [size disabled background-color show-notification-dot?]}]
+  (let [border-radius (size->border-radius size)
+        padding       (size->padding-left size)]
+    (merge {:height                    size
+            :align-items               :center
+            :justify-content           :flex-end
+            :flex-direction            :row
+            :border-top-left-radius    border-radius
+            :border-bottom-left-radius border-radius
+            :background-color          background-color
+            :padding-left              padding}
+           (when-not show-notification-dot?
+             {:padding-horizontal padding
+              :border-radius      border-radius})
+           (when disabled
+             {:opacity 0.3}))))
+
+(def themes
+  {:light {:default  {:background-color colors/neutral-20
+                      :icon-color       colors/neutral-50
+                      :label            {:style {:color colors/neutral-100}}}
+           :active   {:background-color colors/neutral-50
+                      :icon-color       colors/white
+                      :label            {:style {:color colors/white}}}
+           :disabled {:background-color colors/neutral-20
+                      :icon-color       colors/neutral-50
+                      :label            {:style {:color colors/neutral-100}}}}
+   :dark  {:default  {:background-color colors/neutral-80
+                      :icon-color       colors/neutral-40
+                      :label            {:style {:color colors/white}}}
+           :active   {:background-color colors/neutral-60
+                      :icon-color       colors/white
+                      :label            {:style {:color colors/white}}}
+           :disabled {:background-color colors/neutral-80
+                      :icon-color       colors/neutral-40
+                      :label            {:style {:color colors/white}}}}})
+
+(def themes-for-blur-background
+  {:light {:default  {:background-color colors/neutral-80-opa-5
+                      :icon-color       colors/neutral-80-opa-40
+                      :label            {:style {:color colors/neutral-100}}}
+           :active   {:background-color colors/neutral-80-opa-60
+                      :icon-color       colors/white
+                      :label            {:style {:color colors/white}}}
+           :disabled {:background-color colors/neutral-80-opa-5
+                      :icon-color       colors/neutral-80-opa-40
+                      :label            {:style {:color colors/neutral-100}}}}
+   :dark  {:default  {:background-color colors/white-opa-5
+                      :icon-color       colors/white
+                      :label            {:style {:color colors/white}}}
+           :active   {:background-color colors/white-opa-20
+                      :icon-color       colors/white
+                      :label            {:style {:color colors/white}}}
+           :disabled {:background-color colors/white-opa-5
+                      :icon-color       colors/neutral-40
+                      :label            {:style {:color colors/white}}}}})
+
+(defn by-theme
+  [{:keys [override-theme disabled active blur?]}]
+  (let [state (cond disabled :disabled
+                    active   :active
+                    :else    :default)
+        theme (or override-theme (theme/get-theme))]
+    (get-in (if blur? themes-for-blur-background themes)
+            [theme state])))

--- a/src/quo2/components/tabs/tab/view.cljs
+++ b/src/quo2/components/tabs/tab/view.cljs
@@ -1,4 +1,4 @@
-(ns quo2.components.tabs.tab
+(ns quo2.components.tabs.tab.view
   (:require [quo2.components.icon :as icons]
             [quo2.components.markdown.text :as text]
             [quo2.components.notifications.notification-dot :as notification-dot]
@@ -103,7 +103,7 @@
      :d
      "M11.4683 6.78094C11.004 6.92336 10.511 7 10 7C7.23858 7 5 4.76142 5 2C5 1.48904 5.07664 0.995988 5.21906 0.531702C4.68658 0.350857 4.13363 0.213283 3.56434 0.123117C2.78702 0 1.85801 0 0 0V32C1.85801 32 2.78702 32 3.56434 31.8769C7.84327 31.1992 11.1992 27.8433 11.8769 23.5643C12 22.787 12 21.858 12 20V12C12 10.142 12 9.21298 11.8769 8.43566C11.7867 7.86637 11.6491 7.31342 11.4683 6.78094Z"}]])
 
-(defn tab
+(defn view
   "[tab opts \"label\"]
    opts
    {:type :primary/:secondary/:grey/:outline/:ghost/:danger

--- a/src/quo2/components/tabs/tab/view.cljs
+++ b/src/quo2/components/tabs/tab/view.cljs
@@ -67,8 +67,8 @@
                            (on-press id))}))
      [rn/view {:style style/container}
       (when show-notification-dot?
-        [rn/view {:style (style/notification-dot notification-dot/size)}
-         [notification-dot/notification-dot]])
+        [notification-dot/notification-dot
+         {:style style/notification-dot}])
       [rn/view
        {:style (style/tab {:size                   size
                            :disabled               disabled

--- a/src/quo2/components/tabs/tab/view.cljs
+++ b/src/quo2/components/tabs/tab/view.cljs
@@ -1,95 +1,12 @@
 (ns quo2.components.tabs.tab.view
   (:require [quo2.components.icon :as icons]
             [quo2.components.markdown.text :as text]
+            [quo2.components.tabs.tab.style :as style]
             [quo2.components.notifications.notification-dot :as notification-dot]
-            [quo2.foundations.colors :as colors]
-            [quo2.theme :as theme]
             [react-native.core :as rn]
             [react-native.svg :as svg]))
 
-(def ^:const notification-dot-offset 2)
-
-(def themes
-  {:light {:default  {:background-color colors/neutral-20
-                      :icon-color       colors/neutral-50
-                      :label            {:style {:color colors/neutral-100}}}
-           :active   {:background-color colors/neutral-50
-                      :icon-color       colors/white
-                      :label            {:style {:color colors/white}}}
-           :disabled {:background-color colors/neutral-20
-                      :icon-color       colors/neutral-50
-                      :label            {:style {:color colors/neutral-100}}}}
-   :dark  {:default  {:background-color colors/neutral-80
-                      :icon-color       colors/neutral-40
-                      :label            {:style {:color colors/white}}}
-           :active   {:background-color colors/neutral-60
-                      :icon-color       colors/white
-                      :label            {:style {:color colors/white}}}
-           :disabled {:background-color colors/neutral-80
-                      :icon-color       colors/neutral-40
-                      :label            {:style {:color colors/white}}}}})
-
-(def themes-for-blur-background
-  {:light {:default  {:background-color colors/neutral-80-opa-5
-                      :icon-color       colors/neutral-80-opa-40
-                      :label            {:style {:color colors/neutral-100}}}
-           :active   {:background-color colors/neutral-80-opa-60
-                      :icon-color       colors/white
-                      :label            {:style {:color colors/white}}}
-           :disabled {:background-color colors/neutral-80-opa-5
-                      :icon-color       colors/neutral-80-opa-40
-                      :label            {:style {:color colors/neutral-100}}}}
-   :dark  {:default  {:background-color colors/white-opa-5
-                      :icon-color       colors/white
-                      :label            {:style {:color colors/white}}}
-           :active   {:background-color colors/white-opa-20
-                      :icon-color       colors/white
-                      :label            {:style {:color colors/white}}}
-           :disabled {:background-color colors/white-opa-5
-                      :icon-color       colors/neutral-40
-                      :label            {:style {:color colors/white}}}}})
-
-(defn size->border-radius
-  [size]
-  (case size
-    32 10
-    28 8
-    24 8
-    20 6
-    nil))
-
-(defn size->padding-left
-  [size]
-  (case size
-    32 12
-    28 12
-    24 8
-    20 8
-    nil))
-
-(defn show-notification-dot?
-  [notification-dot? size]
-  (and notification-dot? (= size 32)))
-
-(defn style-container
-  [{:keys [size disabled background-color notification-dot?]}]
-  (let [border-radius (size->border-radius size)
-        padding       (size->padding-left size)]
-    (merge {:height                    size
-            :align-items               :center
-            :justify-content           :flex-end
-            :flex-direction            :row
-            :border-top-left-radius    border-radius
-            :border-bottom-left-radius border-radius
-            :background-color          background-color
-            :padding-left              padding}
-           (when-not (show-notification-dot? notification-dot? size)
-             {:padding-horizontal padding
-              :border-radius      border-radius})
-           (when disabled
-             {:opacity 0.3}))))
-
-(defn right-side-with-cutout
+(defn- right-side-with-cutout
   [{:keys [height width background-color]}]
   [svg/svg
    {:width    width
@@ -103,72 +20,66 @@
      :d
      "M11.4683 6.78094C11.004 6.92336 10.511 7 10 7C7.23858 7 5 4.76142 5 2C5 1.48904 5.07664 0.995988 5.21906 0.531702C4.68658 0.350857 4.13363 0.213283 3.56434 0.123117C2.78702 0 1.85801 0 0 0V32C1.85801 32 2.78702 32 3.56434 31.8769C7.84327 31.1992 11.1992 27.8433 11.8769 23.5643C12 22.787 12 21.858 12 20V12C12 10.142 12 9.21298 11.8769 8.43566C11.7867 7.86637 11.6491 7.31342 11.4683 6.78094Z"}]])
 
+(defn- content
+  [{:keys [size label]} children]
+  [rn/view
+   (cond
+     (string? children)
+     [text/text
+      (merge {:size            (case size
+                                 24 :paragraph-2
+                                 20 :label
+                                 nil)
+              :weight          :medium
+              :number-of-lines 1}
+             label)
+      children]
+
+     (vector? children)
+     children)])
+
 (defn view
-  "[tab opts \"label\"]
-   opts
-   {:type :primary/:secondary/:grey/:outline/:ghost/:danger
-    :size 40/32/24
-    :icon true/false
-    :before :icon-keyword
-    :after :icon-keyword}"
-  [_ _]
-  (fn
-    [{:keys [accessibility-label
-             active
-             before
-             blur?
-             disabled
-             id
-             on-press
-             override-theme
-             size
-             notification-dot?]
-      :or   {size 32}}
-     children]
-    (let [state                                       (cond disabled :disabled
-                                                            active   :active
-                                                            :else    :default)
-          {:keys [icon-color background-color label]}
-          (get-in (if blur? themes-for-blur-background themes)
-                  [(or override-theme (theme/get-theme)) state])]
-      [rn/touchable-without-feedback
-       (merge {:disabled            disabled
-               :accessibility-label accessibility-label}
-              (when on-press
-                {:on-press (fn []
-                             (on-press id))}))
-       [rn/view {:style {:flex-direction :row}}
-        (when (show-notification-dot? notification-dot? size)
-          [rn/view
-           {:style {:position :absolute
-                    :z-index  1
-                    :right    (- notification-dot/size notification-dot-offset)
-                    :top      (- notification-dot-offset)}}
-           [notification-dot/notification-dot]])
-        [rn/view
-         {:style (style-container {:size              size
-                                   :disabled          disabled
-                                   :background-color  background-color
-                                   :notification-dot? notification-dot?})}
-         (when before
-           [rn/view
-            [icons/icon before {:color icon-color}]])
+  [{:keys [accessibility-label
+           active
+           before
+           blur?
+           disabled
+           id
+           on-press
+           override-theme
+           size
+           notification-dot?]
+    :or   {size 32}}
+   children]
+  (let [show-notification-dot? (and notification-dot? (= size 32))
+        {:keys [icon-color
+                background-color
+                label]}
+        (style/by-theme {:override-theme override-theme
+                         :blur?          blur?
+                         :disabled       disabled
+                         :active         active})]
+    [rn/touchable-without-feedback
+     (merge {:disabled            disabled
+             :accessibility-label accessibility-label}
+            (when on-press
+              {:on-press (fn []
+                           (on-press id))}))
+     [rn/view {:style style/container}
+      (when show-notification-dot?
+        [rn/view {:style (style/notification-dot notification-dot/size)}
+         [notification-dot/notification-dot]])
+      [rn/view
+       {:style (style/tab {:size                   size
+                           :disabled               disabled
+                           :background-color       background-color
+                           :show-notification-dot? show-notification-dot?})}
+       (when before
          [rn/view
-          (cond
-            (string? children)
-            [text/text
-             (merge {:size            (case size
-                                        24 :paragraph-2
-                                        20 :label
-                                        nil)
-                     :weight          :medium
-                     :number-of-lines 1}
-                    label)
-             children]
-            (vector? children)
-            children)]]
-        (when (show-notification-dot? notification-dot? size)
-          [right-side-with-cutout
-           {:width            (size->padding-left size)
-            :height           size
-            :background-color background-color}])]])))
+          [icons/icon before {:color icon-color}]])
+       [content {:size size :label label} children]]
+      (when show-notification-dot?
+        [right-side-with-cutout
+         {:width            (style/size->padding-left size)
+          :height           size
+          :background-color background-color}])]]))

--- a/src/quo2/components/tabs/tab/view.cljs
+++ b/src/quo2/components/tabs/tab/view.cljs
@@ -7,18 +7,26 @@
             [react-native.svg :as svg]))
 
 (defn- right-side-with-cutout
-  [{:keys [height width background-color]}]
+  "SVG exported from Figma."
+  [{:keys [height width background-color disabled]}]
+  ;; Do not add a view-box property, it'll cause an artifact where the SVG is
+  ;; rendered slightly smaller than the proper width and height.
   [svg/svg
-   {:width    width
-    :height   height
-    :view-box (str "0 0 " width " " height)
-    :fill     :none}
+   {:width        width
+    :height       height
+    :fill         background-color
+    :fill-opacity (when disabled style/tab-background-opacity)}
    [svg/path
-    {:fill-rule :evenodd
-     :clip-rule :evenodd
-     :fill      background-color
-     :d
-     "M11.4683 6.78094C11.004 6.92336 10.511 7 10 7C7.23858 7 5 4.76142 5 2C5 1.48904 5.07664 0.995988 5.21906 0.531702C4.68658 0.350857 4.13363 0.213283 3.56434 0.123117C2.78702 0 1.85801 0 0 0V32C1.85801 32 2.78702 32 3.56434 31.8769C7.84327 31.1992 11.1992 27.8433 11.8769 23.5643C12 22.787 12 21.858 12 20V12C12 10.142 12 9.21298 11.8769 8.43566C11.7867 7.86637 11.6491 7.31342 11.4683 6.78094Z"}]])
+    {:d
+     "M 11.468 6.781 C 11.004 6.923 10.511 7 10 7 C 7.239 7 5 4.761 5 2 C 5
+     1.489 5.077 0.996 5.219 0.532 C 4.687 0.351 4.134 0.213 3.564 0.123 C 2.787
+     0 1.858 0 0 0 L 0 32 C 1.858 32 2.787 32 3.564 31.877 C 7.843 31.199 11.199
+     27.843 11.877 23.564 C 12 22.787 12 21.858 12 20 L 12 12 C 12 10.142 12
+     9.213 11.877 8.436 C 11.787 7.866 11.649 7.313 11.468 6.781 Z"
+     :clip-path "url(#clip0_5514_84289)"}]
+   [svg/defs
+    [svg/clippath {:id "clip0_5514_84289"}
+     [svg/rect {:width width :height height :fill :none}]]]])
 
 (defn- content
   [{:keys [size label]} children]
@@ -82,4 +90,5 @@
         [right-side-with-cutout
          {:width            (style/size->padding-left size)
           :height           size
+          :disabled         disabled
           :background-color background-color}])]]))

--- a/src/quo2/components/tabs/tabs.cljs
+++ b/src/quo2/components/tabs/tabs.cljs
@@ -92,10 +92,9 @@
    {:style {:margin-right  (if (= size default-tab-size) 12 8)
             :padding-right (when (= index (dec number-of-items))
                              (:padding-left style))}}
-   (when notification-dot?
-     [indicator])
    [tab/tab
     {:id                  id
+     :notification-dot?   notification-dot?
      :accessibility-label accessibility-label
      :size                size
      :override-theme      override-theme

--- a/src/quo2/components/tabs/tabs.cljs
+++ b/src/quo2/components/tabs/tabs.cljs
@@ -95,7 +95,7 @@
     label]])
 
 (defn tabs
-  " Common options (both for scrollable and non-scrollable tabs):
+  " Common options (for scrollable and non-scrollable tabs):
 
   - `blur?` Boolean passed down to `quo2.components.tabs.tab/tab`.
   - `data` Vector of tab items.

--- a/src/quo2/components/tabs/tabs.cljs
+++ b/src/quo2/components/tabs/tabs.cljs
@@ -159,8 +159,8 @@
                scroll-on-press?      false
                size                  default-tab-size}
         :as   props}]
-      [rn/view {:style {:margin-top (- (dec unread-count-offset))}}
-       (if scrollable?
+      (if scrollable?
+        [rn/view {:style {:margin-top (- (dec unread-count-offset))}}
          [masked-view-wrapper {:fading fading :fade-end? fade-end?}
           [rn/flat-list
            (merge
@@ -202,17 +202,16 @@
                                                           :override-theme   override-theme
                                                           :scroll-on-press? scroll-on-press?
                                                           :size             size
-                                                          :style            style})})]]
-         [rn/view (merge style {:flex-direction :row})
-          (doall
-           (map-indexed (fn [index item]
-                          ^{:key (:id item)}
-                          [render-tab
-                           {:active-tab-id  active-tab-id
-                            :data           data
-                            :override-theme override-theme
-                            :size           size
-                            :style          style}
-                           item
-                           index])
-                        data))])])))
+                                                          :style            style})})]]]
+        [rn/view (merge style {:flex-direction :row})
+         (map-indexed (fn [index item]
+                        ^{:key (:id item)}
+                        [render-tab
+                         {:active-tab-id  active-tab-id
+                          :data           data
+                          :override-theme override-theme
+                          :size           size
+                          :style          style}
+                         item
+                         index])
+                      data)]))))

--- a/src/quo2/components/tabs/tabs.cljs
+++ b/src/quo2/components/tabs/tabs.cljs
@@ -44,7 +44,7 @@
     :component        tag/tab
     :size             32/24
     :on-press         fn
-    :blurred?         true/false 
+    :blurred?         true/false
     :labelled?        true/false
     :disabled?        true/false
     :scrollable?      false
@@ -55,7 +55,7 @@
     :data             [{:id :label \"\" :resource \"url\"}
                        {:id :label \"\" :resource \"url\"}]}
   Opts:
-   - `component` this is to determine which component is to be rendered since the 
+   - `component` this is to determine which component is to be rendered since the
                  logic in this view is shared between tab and tag component
    - `blurred`   boolean: use to determine border color if the background is blurred
    - `type`      can be icon or emoji with or without a tag label
@@ -153,7 +153,7 @@
                                                            new-percentage))))
                                                    (when on-scroll
                                                      (on-scroll e)))
-              :render-fn                         (fn [{:keys [id label]} index]
+              :render-fn                         (fn [{:keys [id label notification-dot?]} index]
                                                    [rn/view
                                                     {:style {:margin-right  (if (= size default-tab-size)
                                                                               12
@@ -163,6 +163,8 @@
                                                                               (get-in props
                                                                                       [:style
                                                                                        :padding-left]))}}
+                                                    (when notification-dot?
+                                                      [indicator])
                                                     [tab/tab
                                                      {:id             id
                                                       :size           size

--- a/src/quo2/components/tabs/tabs.cljs
+++ b/src/quo2/components/tabs/tabs.cljs
@@ -205,18 +205,14 @@
                                                           :style            style})})]]
          [rn/view (merge style {:flex-direction :row})
           (doall
-           (for [{:keys [label id notification-dot? accessibility-label]} data]
-             ^{:key id}
-             [rn/view {:style {:margin-right (if (= size default-tab-size) 12 8)}}
-              (when notification-dot?
-                [indicator])
-              [tab/tab
-               {:id                  id
-                :size                size
-                :accessibility-label accessibility-label
-                :active              (= id @active-tab-id)
-                :on-press            (fn []
-                                       (reset! active-tab-id id)
-                                       (when on-change
-                                         (on-change id)))}
-               label]]))])])))
+           (map-indexed (fn [index item]
+                          ^{:key (:id item)}
+                          [render-tab
+                           {:active-tab-id  active-tab-id
+                            :data           data
+                            :override-theme override-theme
+                            :size           size
+                            :style          style}
+                           item
+                           index])
+                        data))])])))

--- a/src/quo2/components/tabs/tabs.cljs
+++ b/src/quo2/components/tabs/tabs.cljs
@@ -78,7 +78,7 @@
 
 (defn- render-tab
   [{:keys [size data style override-theme blur? active-tab-id scroll-on-press? flat-list-ref on-change]}
-   {:keys [id label notification-dot?]}
+   {:keys [id label notification-dot? accessibility-label]}
    index]
   [rn/view
    {:style {:margin-right  (if (= size default-tab-size) 12 8)
@@ -87,21 +87,22 @@
    (when notification-dot?
      [indicator])
    [tab/tab
-    {:id             id
-     :size           size
-     :override-theme override-theme
-     :blur?          blur?
-     :active         (= id @active-tab-id)
-     :on-press       (fn [id]
-                       (reset! active-tab-id id)
-                       (when scroll-on-press?
-                         (.scrollToIndex ^js @flat-list-ref
-                                         #js
-                                          {:animated     true
-                                           :index        index
-                                           :viewPosition 0.5}))
-                       (when on-change
-                         (on-change id)))}
+    {:id                  id
+     :accessibility-label accessibility-label
+     :size                size
+     :override-theme      override-theme
+     :blur?               blur?
+     :active              (= id @active-tab-id)
+     :on-press            (fn [id]
+                            (reset! active-tab-id id)
+                            (when scroll-on-press?
+                              (.scrollToIndex ^js @flat-list-ref
+                                              #js
+                                               {:animated     true
+                                                :index        index
+                                                :viewPosition 0.5}))
+                            (when on-change
+                              (on-change id)))}
     label]])
 
 (defn tabs

--- a/src/quo2/components/tabs/tabs.cljs
+++ b/src/quo2/components/tabs/tabs.cljs
@@ -22,14 +22,14 @@
       (utils.number/naive-round fade-percentage 2))))
 
 (defn- masked-view-wrapper
-  [{:keys [fading fade-end?]} & children]
+  [{:keys [fade-end-percentage fade-end?]} & children]
   (if fade-end?
     (into [masked-view/masked-view
            {:mask-element
             (reagent/as-element
              [linear-gradient/linear-gradient
               {:colors         [:black :transparent]
-               :locations      [(get @fading :fade-end-percentage) 1]
+               :locations      [fade-end-percentage 1]
                :start          {:x 0 :y 0}
                :end            {:x 1 :y 0}
                :pointer-events :none
@@ -140,7 +140,8 @@
         :as   props}]
       (if scrollable?
         [rn/view {:style {:margin-top (- (dec unread-count-offset))}}
-         [masked-view-wrapper {:fading fading :fade-end? fade-end?}
+         [masked-view-wrapper
+          {:fade-end-percentage (get @fading :fade-end-percentage) :fade-end? fade-end?}
           [rn/flat-list
            (merge
             (dissoc props

--- a/src/quo2/components/tabs/tabs.cljs
+++ b/src/quo2/components/tabs/tabs.cljs
@@ -114,34 +114,26 @@
     label]])
 
 (defn tabs
-  "Usage:
-   {:type             :icon/:emoji/:label
-    :component        tag/tab
-    :size             32/24
-    :on-press         fn
-    :blurred?         true/false
-    :labelled?        true/false
-    :disabled?        true/false
-    :scrollable?      false
-    :scroll-on-press? true
-    :fade-end?        true
-    :on-change        fn
-    :default-active   tag-id
-    :data             [{:id :label \"\" :resource \"url\"}
-                       {:id :label \"\" :resource \"url\"}]}
-  Opts:
-   - `component` this is to determine which component is to be rendered since the
-                 logic in this view is shared between tab and tag component
-   - `blurred`   boolean: use to determine border color if the background is blurred
-   - `type`      can be icon or emoji with or without a tag label
-   - `labelled`  boolean: is true if tag has label else false
-   - `size` number
-   - `scroll-on-press?` When non-nil, clicking on a tag centers it the middle
-  (with animation enabled).
-   - `fade-end?` When non-nil, causes the end of the scrollable view to fade out.
-   - `fade-end-percentage` Percentage where fading starts relative to the total
-  layout width of the `flat-list` data."
+  " Common options (both for scrollable and non-scrollable tabs):
 
+  - `blur?` Boolean passed down to `quo2.components.tabs.tab/tab`.
+  - `data` Vector of tab items.
+  - `on-change` Callback called after a tab is selected.
+  - `override-theme` Passed down to `quo2.components.tabs.tab/tab`.
+  - `size` 32/24
+  - `style` Style map passed to View wrapping tabs or to the FlatList when tabs
+    are scrollable.
+
+  Options for scrollable tabs:
+  - `fade-end-percentage` Percentage where fading starts relative to the total
+    layout width of the `flat-list` data.
+  - `fade-end?` When non-nil, causes the end of the scrollable view to fade out.
+  - `on-scroll` Callback called on the on-scroll event of the FlatList. Only
+    used when `scrollable?` is non-nil.
+  - `scrollable?` When non-nil, use a scrollable flat-list to render tabs.
+  - `scroll-on-press?` When non-nil, clicking on a tag centers it the middle
+    (with animation enabled).
+  "
   [{:keys [default-active fade-end-percentage]
     :or   {fade-end-percentage 0.8}}]
   (let [active-tab-id (reagent/atom default-active)
@@ -153,19 +145,17 @@
                fade-end?
                on-change
                on-scroll
-               scroll-event-throttle
                scroll-on-press?
                scrollable?
                style
                size
                blur?
                override-theme]
-        :or   {fade-end-percentage   fade-end-percentage
-               fade-end?             false
-               scroll-event-throttle 64
-               scrollable?           false
-               scroll-on-press?      false
-               size                  default-tab-size}
+        :or   {fade-end-percentage fade-end-percentage
+               fade-end?           false
+               scrollable?         false
+               scroll-on-press?    false
+               size                default-tab-size}
         :as   props}]
       (if scrollable?
         [rn/view {:style {:margin-top (- (dec unread-count-offset))}}
@@ -191,7 +181,7 @@
              :content-container-style           {:padding-top (dec unread-count-offset)}
              :extra-data                        (str @active-tab-id)
              :horizontal                        true
-             :scroll-event-throttle             scroll-event-throttle
+             :scroll-event-throttle             64
              :shows-horizontal-scroll-indicator false
              :data                              data
              :key-fn                            (comp str :id)
@@ -216,7 +206,9 @@
                         ^{:key (:id item)}
                         [render-tab
                          {:active-tab-id   active-tab-id
+                          :blur?           blur?
                           :number-of-items (count data)
+                          :on-change       on-change
                           :override-theme  override-theme
                           :size            size
                           :style           style}

--- a/src/quo2/components/tabs/tabs.cljs
+++ b/src/quo2/components/tabs/tabs.cljs
@@ -1,8 +1,6 @@
 (ns quo2.components.tabs.tabs
   (:require [oops.core :refer [oget]]
-            [quo2.components.notifications.notification-dot :refer [notification-dot]]
             [quo2.components.tabs.tab :as tab]
-            [quo2.foundations.colors :as colors]
             [react-native.core :as rn]
             [react-native.linear-gradient :as linear-gradient]
             [react-native.masked-view :as masked-view]
@@ -12,22 +10,6 @@
 
 (def default-tab-size 32)
 (def unread-count-offset 3)
-
-(defn- indicator
-  []
-  [rn/view
-   {:accessibility-label :notification-dot
-    :style               {:position         :absolute
-                          :z-index          1
-                          :right            (- unread-count-offset)
-                          :top              (- unread-count-offset)
-                          :width            10
-                          :height           10
-                          :border-radius    5
-                          :justify-content  :center
-                          :align-items      :center
-                          :background-color (colors/theme-colors colors/neutral-5 colors/neutral-95)}}
-   [notification-dot]])
 
 (defn- calculate-fade-end-percentage
   [{:keys [offset-x content-width layout-width max-fade-percentage]}]

--- a/src/quo2/components/tabs/tabs.cljs
+++ b/src/quo2/components/tabs/tabs.cljs
@@ -1,6 +1,6 @@
 (ns quo2.components.tabs.tabs
   (:require [oops.core :refer [oget]]
-            [quo2.components.tabs.tab :as tab]
+            [quo2.components.tabs.tab.view :as tab]
             [react-native.core :as rn]
             [react-native.linear-gradient :as linear-gradient]
             [react-native.masked-view :as masked-view]
@@ -74,7 +74,7 @@
    {:style {:margin-right  (if (= size default-tab-size) 12 8)
             :padding-right (when (= index (dec number-of-items))
                              (:padding-left style))}}
-   [tab/tab
+   [tab/view
     {:id                  id
      :notification-dot?   notification-dot?
      :accessibility-label accessibility-label

--- a/src/quo2/components/tabs/tabs.cljs
+++ b/src/quo2/components/tabs/tabs.cljs
@@ -77,12 +77,20 @@
     (on-scroll e)))
 
 (defn- render-tab
-  [{:keys [size data style override-theme blur? active-tab-id scroll-on-press? flat-list-ref on-change]}
+  [{:keys [active-tab-id
+           blur?
+           flat-list-ref
+           number-of-items
+           on-change
+           override-theme
+           scroll-on-press?
+           size
+           style]}
    {:keys [id label notification-dot? accessibility-label]}
    index]
   [rn/view
    {:style {:margin-right  (if (= size default-tab-size) 12 8)
-            :padding-right (when (= index (dec (count data)))
+            :padding-right (when (= index (dec number-of-items))
                              (:padding-left style))}}
    (when notification-dot?
      [indicator])
@@ -95,7 +103,7 @@
      :active              (= id @active-tab-id)
      :on-press            (fn [id]
                             (reset! active-tab-id id)
-                            (when scroll-on-press?
+                            (when (and scroll-on-press? @flat-list-ref)
                               (.scrollToIndex ^js @flat-list-ref
                                               #js
                                                {:animated     true
@@ -196,8 +204,8 @@
              :render-fn                         (partial render-tab
                                                          {:active-tab-id    active-tab-id
                                                           :blur?            blur?
-                                                          :data             data
                                                           :flat-list-ref    flat-list-ref
+                                                          :number-of-items  (count data)
                                                           :on-change        on-change
                                                           :override-theme   override-theme
                                                           :scroll-on-press? scroll-on-press?
@@ -207,11 +215,11 @@
          (map-indexed (fn [index item]
                         ^{:key (:id item)}
                         [render-tab
-                         {:active-tab-id  active-tab-id
-                          :data           data
-                          :override-theme override-theme
-                          :size           size
-                          :style          style}
+                         {:active-tab-id   active-tab-id
+                          :number-of-items (count data)
+                          :override-theme  override-theme
+                          :size            size
+                          :style           style}
                          item
                          index])
                       data)]))))

--- a/src/react_native/svg.cljs
+++ b/src/react_native/svg.cljs
@@ -4,3 +4,6 @@
 
 (def svg (reagent/adapt-react-class Svg/default))
 (def path (reagent/adapt-react-class Svg/Path))
+(def rect (reagent/adapt-react-class Svg/Rect))
+(def clippath (reagent/adapt-react-class Svg/ClipPath))
+(def defs (reagent/adapt-react-class Svg/Defs))

--- a/src/status_im2/contexts/activity_center/view.cljs
+++ b/src/status_im2/contexts/activity_center/view.cljs
@@ -66,30 +66,39 @@
       :default-active      filter-type
       :data                [{:id    types/no-type
                              :label (i18n/label :t/all)}
-                            {:id                types/admin
-                             :label             (i18n/label :t/admin)
-                             :notification-dot? (contains? types-with-unread types/admin)}
-                            {:id                types/mention
-                             :label             (i18n/label :t/mentions)
-                             :notification-dot? (contains? types-with-unread types/mention)}
-                            {:id                types/reply
-                             :label             (i18n/label :t/replies)
-                             :notification-dot? (contains? types-with-unread types/reply)}
-                            {:id                types/contact-request
-                             :label             (i18n/label :t/contact-requests)
-                             :notification-dot? (contains? types-with-unread types/contact-request)}
-                            {:id                types/contact-verification
-                             :label             (i18n/label :t/identity-verification)
-                             :notification-dot? (contains? types-with-unread types/contact-verification)}
-                            {:id                types/tx
-                             :label             (i18n/label :t/transactions)
-                             :notification-dot? (contains? types-with-unread types/tx)}
-                            {:id                types/membership
-                             :label             (i18n/label :t/membership)
-                             :notification-dot? (contains? types-with-unread types/membership)}
-                            {:id                types/system
-                             :label             (i18n/label :t/system)
-                             :notification-dot? (contains? types-with-unread types/system)}]}]))
+                            {:id                  types/admin
+                             :label               (i18n/label :t/admin)
+                             :accessibility-label :tab-admin
+                             :notification-dot?   (contains? types-with-unread types/admin)}
+                            {:id                  types/mention
+                             :label               (i18n/label :t/mentions)
+                             :accessibility-label :tab-mention
+                             :notification-dot?   (contains? types-with-unread types/mention)}
+                            {:id                  types/reply
+                             :label               (i18n/label :t/replies)
+                             :accessibility-label :tab-reply
+                             :notification-dot?   (contains? types-with-unread types/reply)}
+                            {:id                  types/contact-request
+                             :label               (i18n/label :t/contact-requests)
+                             :accessibility-label :tab-contact-request
+                             :notification-dot?   (contains? types-with-unread types/contact-request)}
+                            {:id                  types/contact-verification
+                             :label               (i18n/label :t/identity-verification)
+                             :accessibility-label :tab-contact-verification
+                             :notification-dot?   (contains? types-with-unread
+                                                             types/contact-verification)}
+                            {:id                  types/tx
+                             :label               (i18n/label :t/transactions)
+                             :accessibility-label :tab-tx
+                             :notification-dot?   (contains? types-with-unread types/tx)}
+                            {:id                  types/membership
+                             :label               (i18n/label :t/membership)
+                             :accessibility-label :tab-membership
+                             :notification-dot?   (contains? types-with-unread types/membership)}
+                            {:id                  types/system
+                             :label               (i18n/label :t/system)
+                             :accessibility-label :tab-system
+                             :notification-dot?   (contains? types-with-unread types/system)}]}]))
 
 (defn header
   []

--- a/src/status_im2/contexts/activity_center/view.cljs
+++ b/src/status_im2/contexts/activity_center/view.cljs
@@ -50,7 +50,8 @@
 
 (defn tabs
   []
-  (let [filter-type (rf/sub [:activity-center/filter-type])]
+  (let [filter-type       (rf/sub [:activity-center/filter-type])
+        types-with-unread (rf/sub [:activity-center/notification-types-with-unread])]
     [quo/tabs
      {:size                32
       :scrollable?         true
@@ -65,22 +66,30 @@
       :default-active      filter-type
       :data                [{:id    types/no-type
                              :label (i18n/label :t/all)}
-                            {:id    types/admin
-                             :label (i18n/label :t/admin)}
-                            {:id    types/mention
-                             :label (i18n/label :t/mentions)}
-                            {:id    types/reply
-                             :label (i18n/label :t/replies)}
-                            {:id    types/contact-request
-                             :label (i18n/label :t/contact-requests)}
-                            {:id    types/contact-verification
-                             :label (i18n/label :t/identity-verification)}
-                            {:id    types/tx
-                             :label (i18n/label :t/transactions)}
-                            {:id    types/membership
-                             :label (i18n/label :t/membership)}
-                            {:id    types/system
-                             :label (i18n/label :t/system)}]}]))
+                            {:id                types/admin
+                             :label             (i18n/label :t/admin)
+                             :notification-dot? (contains? types-with-unread types/admin)}
+                            {:id                types/mention
+                             :label             (i18n/label :t/mentions)
+                             :notification-dot? (contains? types-with-unread types/mention)}
+                            {:id                types/reply
+                             :label             (i18n/label :t/replies)
+                             :notification-dot? (contains? types-with-unread types/reply)}
+                            {:id                types/contact-request
+                             :label             (i18n/label :t/contact-requests)
+                             :notification-dot? (contains? types-with-unread types/contact-request)}
+                            {:id                types/contact-verification
+                             :label             (i18n/label :t/identity-verification)
+                             :notification-dot? (contains? types-with-unread types/contact-verification)}
+                            {:id                types/tx
+                             :label             (i18n/label :t/transactions)
+                             :notification-dot? (contains? types-with-unread types/tx)}
+                            {:id                types/membership
+                             :label             (i18n/label :t/membership)
+                             :notification-dot? (contains? types-with-unread types/membership)}
+                            {:id                types/system
+                             :label             (i18n/label :t/system)
+                             :notification-dot? (contains? types-with-unread types/system)}]}]))
 
 (defn header
   []

--- a/src/status_im2/contexts/quo_preview/tabs/tabs.cljs
+++ b/src/status_im2/contexts/quo_preview/tabs/tabs.cljs
@@ -1,5 +1,5 @@
 (ns status-im2.contexts.quo-preview.tabs.tabs
-  (:require [quo2.components.tabs.tabs :as quo2]
+  (:require [quo2.core :as quo]
             [quo2.foundations.colors :as colors]
             [react-native.core :as rn]
             [reagent.core :as reagent]
@@ -17,6 +17,12 @@
     :key   :scrollable?
     :type  :boolean}])
 
+(defn generate-tabs-data
+  [length]
+  (for [index (range length)]
+    ^{:key index}
+    {:id index :label (str "Tab " (inc index))}))
+
 (defn cool-preview
   []
   (let [state (reagent/atom {:size        32
@@ -27,16 +33,16 @@
         [rn/view {:flex 1}
          [preview/customizer state descriptor]]
         [rn/view
-         {:padding-vertical 60
-          :flex-direction   :row
-          :justify-content  :center}
-         [quo2/tabs
+         {:padding-vertical   60
+          :padding-horizontal 20
+          :flex-direction     :row
+          :justify-content    :center}
+         [quo/tabs
           (merge @state
                  {:default-active 1
-                  :data           [{:id 1 :label "Tab 1"}
-                                   {:id 2 :label "Tab 2"}
-                                   {:id 3 :label "Tab 3"}
-                                   {:id 4 :label "Tab 4"}]
+                  :data           (if (:scrollable? @state)
+                                    (generate-tabs-data 15)
+                                    (generate-tabs-data 4))
                   :on-change      #(println "Active tab" %)}
                  (when (:scrollable? @state)
                    {:scroll-on-press?    true
@@ -49,7 +55,7 @@
    {:background-color (colors/theme-colors colors/white colors/neutral-90)
     :flex             1}
    [rn/flat-list
-    {:flex                      1
-     :keyboardShouldPersistTaps :always
-     :header                    [cool-preview]
-     :key-fn                    str}]])
+    {:flex                         1
+     :keyboard-should-persist-taps :always
+     :header                       [cool-preview]
+     :key-fn                       str}]])

--- a/src/status_im2/contexts/quo_preview/tabs/tabs.cljs
+++ b/src/status_im2/contexts/quo_preview/tabs/tabs.cljs
@@ -13,17 +13,20 @@
                :value "32"}
               {:key   24
                :value "24"}]}
+   {:label "Show unread indicators?"
+    :key   :unread-indicators?
+    :type  :boolean}
    {:label "Scrollable:"
     :key   :scrollable?
     :type  :boolean}])
 
 (defn generate-tab-items
-  [length]
+  [length unread-indicators?]
   (for [index (range length)]
     ^{:key index}
     {:id                index
      :label             (str "Tab " (inc index))
-     :notification-dot? (zero? (rem index 2))}))
+     :notification-dot? (and unread-indicators? (zero? (rem index 2)))}))
 
 (defn cool-preview
   []
@@ -42,9 +45,8 @@
          [quo/tabs
           (merge @state
                  {:default-active 1
-                  :data           (if (:scrollable? @state)
-                                    (generate-tab-items 15)
-                                    (generate-tab-items 4))
+                  :data           (generate-tab-items (if (:scrollable? @state) 15 4)
+                                                      (:unread-indicators? @state))
                   :on-change      #(println "Active tab" %)}
                  (when (:scrollable? @state)
                    {:scroll-on-press?    true

--- a/src/status_im2/contexts/quo_preview/tabs/tabs.cljs
+++ b/src/status_im2/contexts/quo_preview/tabs/tabs.cljs
@@ -21,7 +21,9 @@
   [length]
   (for [index (range length)]
     ^{:key index}
-    {:id index :label (str "Tab " (inc index))}))
+    {:id                index
+     :label             (str "Tab " (inc index))
+     :notification-dot? (zero? (rem index 2))}))
 
 (defn cool-preview
   []

--- a/src/status_im2/contexts/quo_preview/tabs/tabs.cljs
+++ b/src/status_im2/contexts/quo_preview/tabs/tabs.cljs
@@ -17,7 +17,7 @@
     :key   :scrollable?
     :type  :boolean}])
 
-(defn generate-tabs-data
+(defn generate-tab-items
   [length]
   (for [index (range length)]
     ^{:key index}
@@ -43,8 +43,8 @@
           (merge @state
                  {:default-active 1
                   :data           (if (:scrollable? @state)
-                                    (generate-tabs-data 15)
-                                    (generate-tabs-data 4))
+                                    (generate-tab-items 15)
+                                    (generate-tab-items 4))
                   :on-change      #(println "Active tab" %)}
                  (when (:scrollable? @state)
                    {:scroll-on-press?    true

--- a/src/status_im2/subs/activity_center.cljs
+++ b/src/status_im2/subs/activity_center.cljs
@@ -35,6 +35,19 @@
    (get-in notifications [filter-type filter-status :data])))
 
 (re-frame/reg-sub
+ :activity-center/notification-types-with-unread
+ :<- [:activity-center/notifications]
+ (fn [notifications]
+   (reduce-kv
+    (fn [acc notification-type {:keys [unread]}]
+      (if (and (not= notification-type types/no-type)
+               (seq (:data unread)))
+        (conj acc notification-type)
+        acc))
+    #{}
+    notifications)))
+
+(re-frame/reg-sub
  :activity-center/filter-status-unread-enabled?
  :<- [:activity-center/filter-status]
  (fn [filter-status]

--- a/src/status_im2/subs/activity_center_test.cljs
+++ b/src/status_im2/subs/activity_center_test.cljs
@@ -1,8 +1,9 @@
 (ns status-im2.subs.activity-center-test
   (:require [cljs.test :refer [is testing]]
             [re-frame.db :as rf-db]
-            [test-helpers.unit :as h]
+            [status-im2.contexts.activity-center.notification-types :as types]
             status-im2.subs.activity-center
+            [test-helpers.unit :as h]
             [utils.re-frame :as rf]))
 
 (h/deftest-sub :activity-center/filter-status-unread-enabled?
@@ -14,3 +15,40 @@
   (testing "returns false when filter status is not unread"
     (swap! rf-db/app-db assoc-in [:activity-center :filter :status] :all)
     (is (false? (rf/sub [sub-name])))))
+
+(h/deftest-sub :activity-center/notification-types-with-unread
+  [sub-name]
+  (testing "returns an empty set when no types have unread notifications"
+    (swap! rf-db/app-db assoc-in
+      [:activity-center :notifications]
+      {types/system  {:all {:data [{:id "0x1" :read true}]}}
+       types/mention {:all {:data [{:id "0x2" :read true}]}}})
+
+    (is (= #{}
+           (rf/sub [sub-name]))))
+
+  (testing "ignores the 'no-type'"
+    (swap! rf-db/app-db assoc-in
+      [:activity-center :notifications]
+      {types/no-type {:all {:data [{:id "0x1" :read false}
+                                   {:id "0x2" :read true}]}}})
+
+    (is (= #{}
+           (rf/sub [sub-name]))))
+
+  (testing "returns a set with all types containing unread notifications"
+    (swap! rf-db/app-db assoc-in
+      [:activity-center :notifications]
+      {types/reply   {:all    {:data []}
+                      :unread {:data []}}
+       types/system  {:all    {:data [{:id "0x1" :read true}
+                                      {:id "0x2" :read true}
+                                      {:id "0x3" :read false}]}
+                      :unread {:data [{:id "0x3" :read false}]}}
+       types/mention {:all    {:data [{:id "0x4" :read false}]}
+                      :unread {:data [{:id "0x5" :read false}]}}})
+
+    (let [actual (rf/sub [sub-name])]
+      (is (= #{types/system types/mention}
+             actual))
+      (is (set? actual)))))


### PR DESCRIPTION
Fixes https://github.com/status-im/status-mobile/issues/14852
Fixes https://github.com/status-im/status-mobile/issues/14882

### Summary

- [x] Fixes https://github.com/status-im/status-mobile/issues/14852
- [x] Fixes https://github.com/status-im/status-mobile/issues/14882
- [x] Refactors `tab` component to follow new guidelines.
- [x] Improves preview area for tabs to optionally show notification dots.
- [x] Refactors `tabs` component: break the component into smaller chunks; remove duplication between scrollable & non-scrollable tabs; update outdated docstring;
- [x] Adds accessibility labels to tabs.

<table>
  <thead>
    <tr>
      <th>Cutout with light theme on the background</th>
      <th>Cutout with dark theme on the background</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img alt="activity-center-light-theme" src="https://user-images.githubusercontent.com/46027/214553974-2b2e8c6e-71b8-46f3-ba75-a66cb4755490.png" width="400" /></td>
      <td><img alt="activity-center-dark-theme" src="https://user-images.githubusercontent.com/46027/214554602-d637d4d6-3b20-4aa8-a2ef-64836f4454bb.png" width="400" /></td>
    </tr>
  </tbody>
</table>

<table>
  <thead>
    <tr>
      <th>Cutout in non-scrollable tabs</th>
      <th>Notification dots in preview area</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img alt="messages-home-screen" src="https://user-images.githubusercontent.com/46027/214555646-bbb85546-20d9-48bb-8273-716564fb5e0f.png" width="400" /></td>
      <td><img alt="preview" src="https://user-images.githubusercontent.com/46027/214556532-10a044ae-9df5-4c86-be5f-447955276bfd.png" width="400" /></td>
    </tr>
  </tbody>
</table>

### Review notes

1. Figma specifies the notification dot should have a cutout on the corner of tabs. In ReactNative we can achieve the desired effect with an SVG because it doesn't support the CSS `clip-path` property.
2. I faced a dreadful, [known issue](https://github.com/facebook/react-native/issues/3121) in ReactNative, where `:overflow :visible` doesn't work on components inheriting from ScrollView (e.g. FlatList). Hence why this PR adds a slight padding to the top of scrollable tabs and then offset by a negative margin. It works pretty well in practice :) I tried all sorts of things to fix this, but none of them work in our ReactNative version.

#### Platforms

- Android
- iOS

status: ready
