### PR TITLE
add support for 120Hz animations

### DIFF
--- a/ios/StatusIm/Info.plist
+++ b/ios/StatusIm/Info.plist
@@ -140,5 +140,6 @@
 	</array>
 	<key>NFCReaderUsageDescription</key>
 	<string>Enable Keycard</string>
+	<key>CADisableMinimumFrameDurationOnPhone</key><true/>
 </dict>
 </plist>

--- a/ios/StatusImPR/Info.plist
+++ b/ios/StatusImPR/Info.plist
@@ -144,5 +144,6 @@
 	</array>
 	<key>NFCReaderUsageDescription</key>
 	<string>Enable Keycard</string>
+	<key>CADisableMinimumFrameDurationOnPhone</key><true/>
 </dict>
 </plist>


### PR DESCRIPTION
Fixes: https://github.com/status-im/status-mobile/issues/14904

I did some tests to see of react-native-reanimated does support 120hz animations, and it does. 
Just this entry `<key>CADisableMinimumFrameDurationOnPhone</key><true/>` needs to be added in info.plist file, and animations frame will refresh every 8.3ms instead of 16.6ms (on supporting devices).