### PR TITLE
[Fix][#14890] Added support for pinned message notification in reply notification

### DIFF
--- a/src/status_im2/contexts/activity_center/notification/reply/view.cljs
+++ b/src/status_im2/contexts/activity_center/notification/reply/view.cljs
@@ -3,6 +3,7 @@
             [quo2.foundations.colors :as colors]
             [react-native.core :as rn]
             [status-im.ui2.screens.chat.messages.message :as old-message]
+            [status-im2.common.not-implemented :as not-implemented]
             [status-im2.constants :as constants]
             [status-im2.contexts.activity-center.notification.common.view :as common]
             [status-im2.contexts.activity-center.notification.reply.style :as style]
@@ -21,11 +22,19 @@
 (defn get-message-content
   [{:keys [content-type] :as message}]
   (case content-type
-    constants/content-type-text    (get-in message [:content :text])
+    constants/content-type-text        (get-in message [:content :text])
 
-    constants/content-type-image   [old-message/message-content-image message]
+    constants/content-type-image       [old-message/message-content-image message]
 
-    constants/content-type-sticker [old-message/sticker message]))
+    constants/content-type-sticker     [old-message/sticker message]
+
+    ;; NOTE: The following type (system-text) doesn't have a design yet.
+    ;; https://github.com/status-im/status-mobile/issues/14915
+    constants/content-type-system-text [not-implemented/not-implemented
+                                        [quo/text {:style style/tag-text}
+                                         (get-in message [:content :text])]]
+
+    nil))
 
 (defn view
   [{:keys [author chat-name chat-id message read timestamp]}]


### PR DESCRIPTION
fixes #14890 

### Summary

This fix adds support for the pinned message notifications in the Reply type to prevent the crashing of the Activity Center. Currently, we don't have a design for pinned message notifications; hence, the red border.

![Simulator Screen Shot - iPhone 14 - 2023-01-26 at 17 01 51](https://user-images.githubusercontent.com/19339952/214834179-4833423b-2c0e-419a-9c98-3d7066aaf5a3.png)

### Steps to reproduce

**Preconditions:** `User A` and `User B` are mutual contacts

1. User A creates a community and shares it with User B
2. User B join the community and send a message
3. User B moves to the home screen
4. User A pins the message sent by User B to the channel
5. User B receives an unread indicator in the AC and tries to open it


status: ready 
