### PR TITLE
Fetch unread notification count only for supported notification types

### DIFF
--- a/src/status_im2/contexts/activity_center/events.cljs
+++ b/src/status_im2/contexts/activity_center/events.cljs
@@ -366,7 +366,7 @@
   {:events [:activity-center.notifications/fetch-unread-count]}
   [_]
   {:json-rpc/call [{:method     "wakuext_unreadAndAcceptedActivityCenterNotificationsCount"
-                    :params     []
+                    :params     [types/all-supported]
                     :on-success #(rf/dispatch [:activity-center.notifications/fetch-unread-count-success
                                                %])
                     :on-error   #()}]})

--- a/src/status_im2/contexts/activity_center/notification_types.cljs
+++ b/src/status_im2/contexts/activity_center/notification_types.cljs
@@ -10,13 +10,13 @@
 (def ^:const contact-verification 10)
 
 (def ^:const all-supported
-  [one-to-one-chat
-   private-group-chat
-   mention
-   reply
-   contact-request
-   admin
-   contact-verification])
+  #{one-to-one-chat
+    private-group-chat
+    mention
+    reply
+    contact-request
+    admin
+    contact-verification})
 
 ;; TODO: Replace with correct enum values once status-go implements them.
 (def ^:const tx 66612)

--- a/src/status_im2/contexts/activity_center/notification_types.cljs
+++ b/src/status_im2/contexts/activity_center/notification_types.cljs
@@ -9,6 +9,14 @@
 (def ^:const admin 8)
 (def ^:const contact-verification 10)
 
+(def ^:const all-supported [one-to-one-chat
+                            private-group-chat
+                            mention
+                            reply
+                            contact-request
+                            admin
+                            contact-verification])
+
 ;; TODO: Replace with correct enum values once status-go implements them.
 (def ^:const tx 66612)
 (def ^:const system 66614)

--- a/src/status_im2/contexts/activity_center/notification_types.cljs
+++ b/src/status_im2/contexts/activity_center/notification_types.cljs
@@ -9,13 +9,14 @@
 (def ^:const admin 8)
 (def ^:const contact-verification 10)
 
-(def ^:const all-supported [one-to-one-chat
-                            private-group-chat
-                            mention
-                            reply
-                            contact-request
-                            admin
-                            contact-verification])
+(def ^:const all-supported
+  [one-to-one-chat
+   private-group-chat
+   mention
+   reply
+   contact-request
+   admin
+   contact-verification])
 
 ;; TODO: Replace with correct enum values once status-go implements them.
 (def ^:const tx 66612)


### PR DESCRIPTION
Fixes #14872
Requires https://github.com/status-im/status-go/pull/3141

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

Status: ready <!-- Can be ready or wip -->
