### PR TITLE
ci: upgrade Node.js from 16.17.1 to 18.9.1

### DIFF
--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -46,8 +46,8 @@ in {
 
   # Package version adjustments
   gradle = super.gradle_5;
-  nodejs = super.nodejs-16_x;
-  yarn = super.yarn.override { nodejs = super.nodejs-16_x; };
+  nodejs = super.nodejs-18_x;
+  yarn = super.yarn.override { nodejs = super.nodejs-18_x; };
   openjdk = super.openjdk8_headless;
   xcodeWrapper = callPackage ./pkgs/xcodeenv/compose-xcodewrapper.nix { } {
     version = "13.3";


### PR DESCRIPTION
The End-of-Life for Node.js 16 is set to 11th of September 2023.

Lets see what happens.