### PR TITLE
Remove top nav search button and add bottom padding for home list

### DIFF
--- a/src/status_im2/contexts/chat/home/view.cljs
+++ b/src/status_im2/contexts/chat/home/view.cljs
@@ -40,7 +40,8 @@
         :on-end-reached               #(re-frame/dispatch [:chat/show-more-chats])
         :keyboard-should-persist-taps :always
         :data                         items
-        :render-fn                    chat-list-item/chat-list-item}])))
+        :render-fn                    chat-list-item/chat-list-item
+        :content-container-style      {:padding-bottom 30}}])))
 
 (defn welcome-blank-contacts
   []
@@ -93,7 +94,7 @@
 (defn home
   []
   [:<>
-   [common.home/top-nav {:type :default}]
+   [common.home/top-nav {:type :default :hide-search true}]
    [common.home/title-column
     {:label               (i18n/label :t/messages)
      :handler             #(rf/dispatch [:bottom-sheet/show-sheet :new-chat-bottom-sheet {}])

--- a/src/status_im2/contexts/communities/home/view.cljs
+++ b/src/status_im2/contexts/communities/home/view.cljs
@@ -48,7 +48,8 @@
     :keyboard-should-persist-taps      :always
     :shows-horizontal-scroll-indicator false
     :data                              community-ids
-    :render-fn                         render-fn}])
+    :render-fn                         render-fn
+    :content-container-style           {:padding-bottom 30}}])
 
 (defn segments-community-lists
   [selected-tab]

--- a/src/status_im2/contexts/shell/view.cljs
+++ b/src/status_im2/contexts/shell/view.cljs
@@ -109,9 +109,10 @@
         [jump-to-list switcher-cards shell-margin]
         [top-nav-blur-overlay (:top insets)]
         [common.home/top-nav
-         {:type  :shell
-          :style {:margin-top (:top insets)
-                  :z-index    2}}]])]))
+         {:type        :shell
+          :hide-search true
+          :style       {:margin-top (:top insets)
+                        :z-index    2}}]])]))
 
 (defn on-layout
   [evt]


### PR DESCRIPTION
### Summary
A small PR for removing the search button from the shell and chats screen so that they look the same as the communities screen. 
And also add bottom padding for the chats list, so that the last item doesn't get hidden behind the jump-to button.

status: ready