### PR TITLE
added unread mentions counter

### DIFF
--- a/src/status_im2/subs/communities.cljs
+++ b/src/status_im2/subs/communities.cljs
@@ -224,16 +224,19 @@
  (fn [[{:keys [joined categories chats]} full-chats-data] [_ community-id]]
    (reduce
     (fn [acc [_ {:keys [name categoryID id emoji can-post?]}]]
-      (let [category                          (keyword (get-in categories
-                                                               [categoryID :name]
-                                                               (i18n/label :t/none)))
-            {:keys [unviewed-messages-count]} (get full-chats-data (str community-id id))]
+      (let [category                                                  (keyword
+                                                                       (get-in categories
+                                                                               [categoryID :name]
+                                                                               (i18n/label :t/none)))
+            {:keys [unviewed-messages-count unviewed-mentions-count]} (get full-chats-data
+                                                                           (str community-id id))]
         (update acc
                 category
                 #(vec (conj %1 %2))
                 {:name             name
                  :emoji            emoji
                  :unread-messages? (pos? unviewed-messages-count)
+                 :mentions-count   (or unviewed-mentions-count 0)
                  :locked?          (or (not joined) (not can-post?))
                  :id               id})))
     {}

--- a/src/status_im2/subs/communities_test.cljs
+++ b/src/status_im2/subs/communities_test.cljs
@@ -150,10 +150,13 @@
               :categories {1 {:id 1 :name "category1"}
                            2 {:id 2 :name "category2"}}
               :joined     true}})
-    (is (= {:category1 [{:name "chat1" :emoji nil :locked? false :id "0x1" :unread-messages? false}
-                        {:name "chat2" :emoji nil :locked? true :id "0x2" :unread-messages? false}]
-            :category2 [{:name "chat3" :emoji nil :locked? false :id "0x3" :unread-messages? false}]}
-           (rf/sub [sub-name "0x1"]))))
+    (is
+     (= {:category1
+         [{:name "chat1" :emoji nil :locked? false :id "0x1" :unread-messages? false :mentions-count 0}
+          {:name "chat2" :emoji nil :locked? true :id "0x2" :unread-messages? false :mentions-count 0}]
+         :category2
+         [{:name "chat3" :emoji nil :locked? false :id "0x3" :unread-messages? false :mentions-count 0}]}
+        (rf/sub [sub-name "0x1"]))))
   (testing "Channels without categories"
     (swap! rf-db/app-db assoc
       :communities/enabled? true
@@ -165,11 +168,13 @@
               :categories {1 {:id 1 :name "category1"}
                            2 {:id 2 :name "category2"}}
               :joined     true}})
-    (is (= {:category1 [{:name "chat1" :emoji nil :locked? false :id "0x1" :unread-messages? false}
-                        {:name "chat2" :emoji nil :locked? true :id "0x2" :unread-messages? false}]
-            (keyword (i18n/label :t/none))
-            [{:name "chat3" :emoji nil :locked? false :id "0x3" :unread-messages? false}]}
-           (rf/sub [sub-name "0x1"]))))
+    (is
+     (= {:category1
+         [{:name "chat1" :emoji nil :locked? false :id "0x1" :unread-messages? false :mentions-count 0}
+          {:name "chat2" :emoji nil :locked? true :id "0x2" :unread-messages? false :mentions-count 0}]
+         (keyword (i18n/label :t/none))
+         [{:name "chat3" :emoji nil :locked? false :id "0x3" :unread-messages? false :mentions-count 0}]}
+        (rf/sub [sub-name "0x1"]))))
   (testing "Unread messages"
     (swap! rf-db/app-db assoc
       :communities/enabled? true
@@ -180,8 +185,10 @@
               :categories {1 {:id 1 :name "category1"}}
               :joined     true}}
       :chats
-      {"0x10x1" {:unviewed-messages-count 1}
-       "0x10x2" {:unviewed-messages-count 0}})
-    (is (= {:category1 [{:name "chat1" :emoji nil :locked? false :id "0x1" :unread-messages? true}
-                        {:name "chat2" :emoji nil :locked? true :id "0x2" :unread-messages? false}]}
-           (rf/sub [sub-name "0x1"])))))
+      {"0x10x1" {:unviewed-messages-count 1 :unviewed-mentions-count 2}
+       "0x10x2" {:unviewed-messages-count 0 :unviewed-mentions-count 0}})
+    (is
+     (= {:category1
+         [{:name "chat1" :emoji nil :locked? false :id "0x1" :unread-messages? true :mentions-count 2}
+          {:name "chat2" :emoji nil :locked? true :id "0x2" :unread-messages? false :mentions-count 0}]}
+        (rf/sub [sub-name "0x1"])))))


### PR DESCRIPTION
fixes #14970

### Summary

The unread indicator is shown when the user has been mentioned in the channel.

<img width="340" alt="Screenshot 2023-02-03 at 18 21 02" src="https://user-images.githubusercontent.com/5786310/216679341-149793e7-e98b-4464-ade7-005a6518f070.png">


### Steps to test
Prerequisites:

User A and User B are members of the same community
User B sent one message in the community channel (this step is needed for the ability to create mentions)
Steps to reproduce:
User A: sends a message with mention of UserB to the community channel while User B is on the messages home screen
User B: check the count of unread mentions on a community page

Actual result
The unread indicator is shown

status: ready
