### PR TITLE
fetch emoji hash for profile

### DIFF
--- a/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusModule.java
+++ b/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusModule.java
@@ -1139,6 +1139,11 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
         executeRunnableStatusGoMethod(() -> Statusgo.generateAlias(seed), callback);
     }
 
+    @ReactMethod
+    public void emojiHash(final String publicKey, final Callback callback) throws JSONException {
+        executeRunnableStatusGoMethod(() -> Statusgo.emojiHash(publicKey), callback);
+    }
+
     @ReactMethod(isBlockingSynchronousMethod = true)
     public String identicon(final String seed) {
         return Statusgo.identicon(seed);

--- a/modules/react-native-status/ios/RCTStatus/RCTStatus.m
+++ b/modules/react-native-status/ios/RCTStatus/RCTStatus.m
@@ -865,6 +865,12 @@ RCT_EXPORT_METHOD(generateAliasAsync:(NSString *)publicKey
     callback(@[result]);
 }
 
+RCT_EXPORT_METHOD(emojiHash:(NSString *)publicKey
+                  callback:(RCTResponseSenderBlock)callback) {
+    NSString *result = StatusgoEmojiHash(publicKey);
+    callback(@[result]);
+}
+
 RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(identicon:(NSString *)publicKey) {
   return StatusgoIdenticon(publicKey);
 }

--- a/src/status_im/multiaccounts/login/core.cljs
+++ b/src/status_im/multiaccounts/login/core.cljs
@@ -44,7 +44,8 @@
    [status-im2.navigation.events :as navigation]
    [status-im2.common.log :as logging]
    [taoensso.timbre :as log]
-   [utils.security.core :as security]))
+   [utils.security.core :as security]
+   [status-im2.contexts.emoji-hash.events :as emoji-hash]))
 
 (re-frame/reg-fx
  ::initialize-communities-enabled
@@ -473,6 +474,7 @@
               (get-group-chat-invitations)
               (multiaccounts/get-profile-picture)
               (multiaccounts/switch-preview-privacy-mode-flag)
+              (emoji-hash/fetch-for-current-public-key)
               (link-preview/request-link-preview-whitelist)
               (visibility-status-updates-store/fetch-visibility-status-updates-rpc)
               (switcher-cards-store/fetch-switcher-cards-rpc))))

--- a/src/status_im/native_module/core.cljs
+++ b/src/status_im/native_module/core.cljs
@@ -481,6 +481,12 @@
   (when (validators/valid-public-key? public-key)
     (.generateAliasAsync ^js (status) public-key callback)))
 
+(defn public-key->emoji-hash
+  "Generate an emoji has from the multiaccount public key"
+  [public-key callback]
+  (when (validators/valid-public-key? public-key)
+    (.emojiHash ^js (status) public-key callback)))
+
 (defn identicon
   "Generate a icon based on a string, synchronously"
   [seed]

--- a/src/status_im/native_module/core.cljs
+++ b/src/status_im/native_module/core.cljs
@@ -482,7 +482,7 @@
     (.generateAliasAsync ^js (status) public-key callback)))
 
 (defn public-key->emoji-hash
-  "Generate an emoji has from the multiaccount public key"
+  "Generate an emoji hash from the multiaccount public key"
   [public-key callback]
   (when (validators/valid-public-key? public-key)
     (.emojiHash ^js (status) public-key callback)))

--- a/src/status_im2/contexts/emoji_hash/events.cljs
+++ b/src/status_im2/contexts/emoji_hash/events.cljs
@@ -1,0 +1,20 @@
+(ns status-im2.contexts.emoji-hash.events
+  (:require [utils.re-frame :as rf]
+            [status-im.native-module.core :as native-module]
+            [utils.transforms :as transform]))
+
+(defn fetch-for-current-public-key
+  []
+  (let [public-key (rf/sub [:multiaccount/public-key])]
+    (native-module/public-key->emoji-hash
+     public-key
+     (fn [response]
+       (let [response-clj (transform/json->clj response)
+             emoji-hash   (get response-clj :result)]
+         (rf/dispatch [:emoji-hash/add-to-multiaccount emoji-hash])
+       )))))
+
+(rf/defn add-emoji-hash-to-multiaccount
+  {:events [:emoji-hash/add-to-multiaccount]}
+  [{:keys [db]} emoji-hash]
+  {:db (assoc db :multiaccount/emoji-hash emoji-hash)})

--- a/src/status_im2/contexts/emoji_hash/events.cljs
+++ b/src/status_im2/contexts/emoji_hash/events.cljs
@@ -11,8 +11,7 @@
      (fn [response]
        (let [response-clj (transform/json->clj response)
              emoji-hash   (get response-clj :result)]
-         (rf/dispatch [:emoji-hash/add-to-multiaccount emoji-hash])
-       )))))
+         (rf/dispatch [:emoji-hash/add-to-multiaccount emoji-hash]))))))
 
 (rf/defn add-emoji-hash-to-multiaccount
   {:events [:emoji-hash/add-to-multiaccount]}


### PR DESCRIPTION
### Summary

This PR introduces emoji hash in status-mobile.

What happens here : 

- after a user logs in we pass their public key to status-go and in return we get the emoji hash from status-go
- we then store this emoji hash in app-db under `:multiaccount/emoji-hash`

This functionality is required in shell share tab view.

#### Platforms
- Android
- iOS

status: ready
