### PR TITLE
ci: fetch E2E APK from android-e2e jobs

### DIFF
--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -105,7 +105,7 @@ pipeline {
         e2eApk = utils.getEnv(apke2e, 'SAUCE_URL')
         build(
           job: 'status-mobile/e2e/status-app-nightly',
-          parameters: [string(name: 'APK_NAME', value: e2eApk)],
+          parameters: [string(name: 'APK_URL', value: e2eApk)],
           wait: false
         )
       } }

--- a/ci/tests/Jenkinsfile.e2e-nightly
+++ b/ci/tests/Jenkinsfile.e2e-nightly
@@ -4,8 +4,8 @@ pipeline {
 
   parameters {
     string(
-      name: 'APK_NAME',
-      description: 'Filename of APK uploaded to SauceLabs.',
+      name: 'APK_URL',
+      description: 'URL of APK uploaded to SauceLabs.',
     )
     string(
       name: 'KEYWORD_EXPRESSION',
@@ -20,6 +20,14 @@ pipeline {
 
 
   stages {
+    stage('Prep') {
+      steps { script {
+        if (params.PR_ID == null) {
+          error("PR_ID parameter not set!")
+        }
+      } }
+    }
+
     stage('Setup') {
       steps { script {
         dir('test/appium') {
@@ -27,6 +35,7 @@ pipeline {
         }
       } }
     }
+
     stage('Test') {
       steps {
         withCredentials([

--- a/ci/tests/Jenkinsfile.e2e-prs
+++ b/ci/tests/Jenkinsfile.e2e-prs
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.6.3'
+library 'status-jenkins-lib@v1.6.5'
 
 pipeline {
 
@@ -9,16 +9,6 @@ pipeline {
       name: 'BRANCH_NAME',
       description: 'Name of the branch to checkout and build.',
       defaultValue: 'develop',
-    )
-/* Commented to use TEST_MARKERS values from job params
-    string(
-      name: 'TEST_MARKERS',
-      description: 'Marker expression for matching tests to run.',
-      defaultValue: 'new_ui_critical',
-    ) */
-    string(
-      name: 'APK_NAME',
-      description: 'Filename of APK uploaded to SauceLabs, path, or URL.',
     )
     string(
       name: 'PR_ID',
@@ -34,6 +24,19 @@ pipeline {
       description: 'IDs of the TestRail case, separated by a comma (Optional)',
       defaultValue: '',
     )
+    /* FIXME: Remove this no longer relevant argument */
+    string(
+      name: 'APK_NAME',
+      description: 'OBSOLETE ARGUMENT TO BE REMOVED',
+      defaultValue: 'DUMMY',
+    )
+    /* Commented to use TEST_MARKERS values from job params
+    string(
+      name: 'TEST_MARKERS',
+      description: 'Marker expression for matching tests to run.',
+      defaultValue: 'new_ui_critical',
+    )
+    */
   }
 
   options {
@@ -41,12 +44,25 @@ pipeline {
   }
 
   stages {
-    stage('Checks') {
+    stage('Prep') {
       steps { script {
-        if (params.APK_NAME == null) { error("APK_NAME parameter not set!") }
-        if (params.PR_ID == null) { error("PR_ID parameter not set!") }
+        currentBuild.displayName = "PR-${params.PR_ID}"
+        if (params.PR_ID == null) {
+          error("PR_ID parameter not set!")
+        }
       } }
     }
+
+    stage('Fetch') {
+      steps { script { /* WARNING: This copies the latest available artifact. */
+        copyArtifacts(
+          projectName: "status-mobile/prs/android-e2e/PR-${params.PR_ID}",
+          selector: lastWithArtifacts(),
+        )
+        apk_path = "${env.PWD}/${utils.findFile('result/*.apk')}"
+      } }
+    }
+
     stage('Setup') {
       steps { script {
         dir('test/appium') {
@@ -54,9 +70,9 @@ pipeline {
         }
       } }
     }
+
     stage('Test') {
       steps { script {
-        currentBuild.displayName = "PR-${params.PR_ID}"
         /* for managing optional arguments */
         def extraPytestOpts = ''
         if (params.TR_CASE_IDS != '') {
@@ -103,7 +119,7 @@ pipeline {
                 --rerun_count=2 \
                 --testrail_report=True \
                 -k \"${params.KEYWORD_EXPRESSION}\" \
-                --apk=${params.APK_NAME} \
+                --apk=${apk_path} \
                 --build=PR-${params.PR_ID}-${utils.timestamp()} \
                 --pr_number=${params.PR_ID} \
                 ${extraPytestOpts}

--- a/ci/tests/Jenkinsfile.e2e-upgrade
+++ b/ci/tests/Jenkinsfile.e2e-upgrade
@@ -4,12 +4,12 @@ pipeline {
 
   parameters {
     string(
-      name: 'APK_NAME',
-      description: 'Filename of APK uploaded to SauceLabs (base for upgrade, usually release build)',
+      name: 'APK_URL',
+      description: 'URL of APK to be tested(base for upgrade, usually release build)',
     )
      string(
-      name: 'APK_NAME_UPGRADE',
-      description: 'Filename of APK of upgraded application (installed on top of base)',
+      name: 'APK_URL_UPGRADE',
+      description: 'URL of APK of upgraded application (installed on top of base)',
     )
      string(
       name: 'KEYWORD_EXPRESSION',
@@ -29,6 +29,17 @@ pipeline {
 
 
   stages {
+    stage('Prep') {
+      steps { script {
+        if (params.APK_URL == null) {
+          error("APK_URL parameter not set!")
+        }
+        if (params.APK_URL_UPGRADE == null) {
+          error("APK_URL_UPGRADE parameter not set!")
+        }
+      } }
+    }
+
     stage('Setup') {
       steps { script {
         dir('test/appium') {
@@ -36,6 +47,7 @@ pipeline {
         }
       } }
     }
+
     stage('Test') {
       steps { script {
        /* for managing optional arguments */
@@ -77,8 +89,8 @@ pipeline {
                 --numprocesses 4 \
                 --rerun_count=2 \
                 --testrail_report=True \
-                --apk=${params.APK_NAME} \
-                --apk_upgrade=${params.APK_NAME_UPGRADE} \
+                --apk=${params.APK_URL} \
+                --apk_upgrade=${params.APK_URL_UPGRADE} \
                  ${extraPytestOpts}
             """
           }


### PR DESCRIPTION
Using `copyArtifacts()` is more reliable and faster then fetching APKs based on URLs acquired by parsing GitHub comments from Jenkins builds.