### PR TITLE
ci: drop uploading e2e builds to SauceLabs

### DIFF
--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.6.3'
+library 'status-jenkins-lib@v1.6.5'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()
@@ -75,20 +75,12 @@ pipeline {
         stage('Upload') {
           steps { script {
             def urls = apks.collect { s3.uploadArtifact(it) }
-            /* return only the universal APK */
-            if (urls.size() > 1) {
+            if (urls.size() > 1) { /* Return only the universal APK. */
               env.PKG_URL = urls.find { it.contains('universal') }
-            } else { /* if no universal is available pick first */
+            } else { /* If no universal is available pick first. */
               env.PKG_URL = urls.first()
             }
             jenkins.setBuildDesc(APK: env.PKG_URL)
-            /* e2e builds get tested in SauceLabs */
-            if (utils.isE2EBuild()) {
-              env.SAUCE_URL = android.uploadToSauceLabs()
-            }
-            if (utils.isNightlyBuild()) {
-              env.DIAWI_URL = android.uploadToDiawi()
-            }
           } }
         }
       }

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.6.3'
+library 'status-jenkins-lib@v1.6.5'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()
@@ -72,15 +72,11 @@ pipeline {
           }
         }
         stage('Upload') {
+          when { expression { !utils.isReleaseBuild() } }
           steps { script {
-            env.PKG_URL = s3.uploadArtifact(api)
+            env.DIAWI_URL = ios.uploadToDiawi()
+            env.PKG_URL = env.DIAWI_URL
             jenkins.setBuildDesc(IPA: env.PKG_URL)
-            /* e2e builds get tested in SauceLabs */
-            if (utils.isE2EBuild()) {
-              env.SAUCE_URL = ios.uploadToSauceLabs()
-            } else if (!utils.isReleaseBuild()) {
-              env.DIAWI_URL = ios.uploadToDiawi()
-            }
           } }
         }
       }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -334,16 +334,4 @@ platform :android do
       version_code: '2020042307'
     )
   end
-
-  desc '`fastlane android upload_diawi` - upload .apk to diawi'
-  desc 'expects to have an .apk prepared: `result/app.apk`'
-  desc 'expects to have a diawi token as DIAWI_TOKEN env variable'
-  desc 'expects to have a github token as GITHUB_TOKEN env variable'
-  desc "will fails if file isn't there"
-  desc '---'
-  desc 'Output: writes `fastlane/diawi.out` file url of the uploded file'
-  lane :upload_diawi do
-    uniApk = APK_PATHS.detect { |a| a.include? 'universal' }
-    upload_to_diawi(uniApk)
-  end
 end


### PR DESCRIPTION
Since uploads to SauceLabs were dropped from `Fastfile` in:

* https://github.com/status-im/status-mobile/pull/14969

Also dropped:
- Useless Diawi upload of APK
- Useless DO Spaces upload of IPA