### PR TITLE
Add jump-to button to community-overview screen

### DIFF
--- a/src/status_im2/contexts/activity_center/notification/membership/view.cljs
+++ b/src/status_im2/contexts/activity_center/notification/membership/view.cljs
@@ -12,7 +12,7 @@
     (into [rn/touchable-opacity
            {:on-press (fn []
                         (rf/dispatch [:hide-popover])
-                        (rf/dispatch [:chat.ui/navigate-to-chat-nav2 chat-id]))}]
+                        (rf/dispatch [:chat/navigate-to-chat chat-id]))}]
           children)
     (into [:<>] children)))
 

--- a/src/status_im2/contexts/chat/events.cljs
+++ b/src/status_im2/contexts/chat/events.cljs
@@ -172,7 +172,7 @@
                  ;; used here.
                  (when (and community-id (not navigate-to-shell?))
                    {:dispatch-n [[:shell/add-switcher-card
-                                  :community {:community-id community-id}]]})))
+                                  :community-overview community-id]]})))
               (delete-for-me/sync-all)
               (delete-message/send-all)
               (offload-messages chat-id))))

--- a/src/status_im2/contexts/communities/home/view.cljs
+++ b/src/status_im2/contexts/communities/home/view.cljs
@@ -30,7 +30,7 @@
       (let [community (rf/sub [:communities/home-item id])]
         ^{:key index}
         [quo/communities-membership-list-item
-         {:on-press      #(rf/dispatch [:navigate-to :community-overview id])
+         {:on-press      #(rf/dispatch [:navigate-to-nav2 :community-overview id])
           :on-long-press #(rf/dispatch
                            [:bottom-sheet/show-sheet
                             {:content       (fn []

--- a/src/status_im2/contexts/communities/overview/view.cljs
+++ b/src/status_im2/contexts/communities/overview/view.cljs
@@ -11,6 +11,7 @@
             [status-im2.contexts.communities.overview.style :as style]
             [status-im2.contexts.communities.menus.community-options.view :as options]
             [status-im2.contexts.communities.menus.request-to-join.view :as join-menu]
+            [quo2.components.navigation.floating-shell-button :as floating-shell-button]
             [status-im2.contexts.communities.overview.utils :as utils]
             [utils.re-frame :as rf]))
 
@@ -318,4 +319,9 @@
         community (rf/sub [:communities/community id])]
     [rn/view
      {:style style/community-overview-container}
-     [community-card-page-view community]]))
+     [community-card-page-view community]
+     [floating-shell-button/floating-shell-button
+      {:jump-to {:on-press #(rf/dispatch [:shell/navigate-to-jump-to])
+                 :label    (i18n/label :t/jump-to)}}
+      {:position :absolute
+       :bottom   41}]]))

--- a/src/status_im2/contexts/shell/events.cljs
+++ b/src/status_im2/contexts/shell/events.cljs
@@ -72,13 +72,13 @@
 
         nil))
 
-    :community
+    :community-overview
     {:navigate-from :communities-stack
-     :card-id       (:community-id id)
+     :card-id       id
      :switcher-card {:type      shell.constants/community-card
-                     :card-id   (:community-id id)
+                     :card-id   id
                      :clock     now
-                     :screen-id (:community-id id)}}
+                     :screen-id id}}
     nil))
 
 (rf/defn add-switcher-card

--- a/src/status_im2/subs/shell.cljs
+++ b/src/status_im2/subs/shell.cljs
@@ -90,8 +90,7 @@
                             {:name (:name community)})
      :customization-color (or (:customization-color community) :primary)
      :on-close            #(re-frame/dispatch [:shell/close-switcher-card id])
-     :on-press            #(re-frame/dispatch [:navigate-to-nav2 :community
-                                               {:community-id id} true])
+     :on-press            #(re-frame/dispatch [:navigate-to-nav2 :community-overview id true])
      :content             {:community-info {:type :permission}}}))
 
 (defn community-channel-card
@@ -101,7 +100,7 @@
    {:content  {:community-channel {:emoji        (:emoji channel)
                                    :channel-name (str "# " (:name channel))}}
     :on-press (fn []
-                (re-frame/dispatch [:navigate-to-nav2 :community {:community-id community-id}])
+                (re-frame/dispatch [:navigate-to-nav2 :community-overview community-id true])
                 (js/setTimeout
                  #(re-frame/dispatch [:chat/navigate-to-chat channel-id true])
                  100))}))


### PR DESCRIPTION
## Summary
We replaced the default community screen to community-overview(new design) in https://github.com/status-im/status-mobile/pull/14799, PR migrates shell navigation as per that screen and also adds jump-to button.

status: ready