### PR TITLE
Improve guidelines

### DIFF
--- a/doc/new-guidelines.md
+++ b/doc/new-guidelines.md
@@ -305,8 +305,8 @@ core interop macros.
 
 ### Accessibility labels
 
-Use keywords instead of strings. As a bonus, remember keywords are cached in
-memory.
+Accessibility labels are currently used only for end-to-end tests. Use keywords
+instead of strings (remember keywords are cached).
 
 ```clojure
 ;; bad
@@ -316,6 +316,18 @@ memory.
 ;; good
 [text/text {:accessibility-label :profile-nickname}
  "Markov"]
+```
+
+Avoid dynamic labels, for example to specify an element's index because
+[Appium](https://appium.io/) already supports element selection based on
+indices.
+
+```clojure
+;; bad
+[button {:accessibility-label (str "do-something" index)}]
+
+;; good
+[button {:accessibility-label :do-something}]
 ```
 
 ### Icons

--- a/doc/new-guidelines.md
+++ b/doc/new-guidelines.md
@@ -181,11 +181,11 @@ Use the simple `defn` to declare components. Don't use `utils.views/defview` and
 ```clojure
 ;; bad
 [rn/view
- (render-parsed-text message)]
+ (message-card message)]
 
 ;; good
 [rn/view
- [render-parsed-text message]]
+ [message-card message]]
 ```
 
 ### Using re-frame subscriptions and dispatching events

--- a/doc/new-guidelines.md
+++ b/doc/new-guidelines.md
@@ -63,7 +63,7 @@ the source file. For a real example, see
 
 ### Don't use percents to define width/height
 
-In ReactNative all layouts use the [flexbox
+In ReactNative, all layouts use the [flexbox
 model](https://reactnative.dev/docs/flexbox), so percentages are unnecessary the
 vast majority of the time, don't use them.
 

--- a/doc/new-guidelines.md
+++ b/doc/new-guidelines.md
@@ -63,12 +63,17 @@ the source file. For a real example, see
 
 ### Don't use percents to define width/height
 
-We shouldn't use percentage:
+In ReactNative all layouts use the [flexbox
+model](https://reactnative.dev/docs/flexbox), so percentages are unnecessary the
+vast majority of the time, don't use them.
 
-- because 100% doesn't make sense in flexbox
-- because we always have fixed margins or paddings in the design. For example, Instead of using `80%` we should use `padding-horizontal 20`. This is because `%` will be different on different devices in pixels, but we should always have same the paddings in pixels on all devices.
+```clojure
+;; bad
+[rn/view {:style {:width "80%"}}]
 
-
+;; good
+[rn/view {:style {:padding-horizontal 20}}]
+```
 
 #### Styles def vs defn
 

--- a/doc/new-guidelines.md
+++ b/doc/new-guidelines.md
@@ -168,6 +168,26 @@ Use the simple `defn` to declare components. Don't use `utils.views/defview` and
     (do-something window-width)))
 ```
 
+#### Use `[]` instead of `()` in Reagent components
+
+- The `()` version [does NOT work with Form-2 and
+  Form-3](https://github.com/reagent-project/reagent/blob/master/doc/UsingSquareBracketsInsteadOfParens.md#a-further-significant-why)
+  components.
+- Components defined with `[]` will be [more efficient at re-render
+  time](https://github.com/reagent-project/reagent/blob/master/doc/UsingSquareBracketsInsteadOfParens.md#which-and-why)
+  because they're interpreted by Reagent and transformed into distinct React
+  components, with their own lifecycle.
+
+```clojure
+;; bad
+[rn/view
+ (render-parsed-text message)]
+
+;; good
+[rn/view
+ [render-parsed-text message]]
+```
+
 ### Using re-frame subscriptions and dispatching events
 
 Use the `utils.re-frame` namespace instead of `re-frame.core` to subscribe and

--- a/doc/new-guidelines.md
+++ b/doc/new-guidelines.md
@@ -65,7 +65,9 @@ the source file. For a real example, see
 
 In ReactNative, all layouts use the [flexbox
 model](https://reactnative.dev/docs/flexbox), so percentages are unnecessary the
-vast majority of the time, don't use them.
+vast majority of the time, don't use them. Check out this great [interactive
+flexbox guide](https://www.joshwcomeau.com/css/interactive-guide-to-flexbox/) by
+Joshua Comeau.
 
 ```clojure
 ;; bad


### PR DESCRIPTION
### Summary

Quick updates to the guidelines:

- **Use `[]` instead of `()` in Reagent components** New section after this comment https://github.com/status-im/status-mobile/pull/15005#discussion_r1098220176
- **Don't use percents to define width/height**: reworded to follow the style of the rest of the document.
- **Accessibility labels**: added example about avoiding dynamic labels

status: ready