### PR TITLE
ci: add cleanup step to all e2e Jenkins jobs

### DIFF
--- a/ci/tests/Jenkinsfile.e2e-nightly
+++ b/ci/tests/Jenkinsfile.e2e-nightly
@@ -97,5 +97,8 @@ pipeline {
         )
       }
     }
+    cleanup {
+      sh 'make purge'
+    }
   }
 }

--- a/ci/tests/Jenkinsfile.e2e-prs
+++ b/ci/tests/Jenkinsfile.e2e-prs
@@ -129,4 +129,9 @@ pipeline {
       } }
     }
   }
+  post {
+    cleanup {
+      sh 'make purge'
+    }
+  }
 }

--- a/ci/tests/Jenkinsfile.e2e-upgrade
+++ b/ci/tests/Jenkinsfile.e2e-upgrade
@@ -115,5 +115,8 @@ pipeline {
         )
       }
     }
+    cleanup {
+      sh 'make purge'
+    }
   }
 }


### PR DESCRIPTION
Otherwise we get multiple APKs in the `results` folder.
```
admin@linux-01.he-eu-hel1.ci.devel:/home/jenkins/workspace/status-mobile/e2e/status-app-prs % ls -l result
total 502236
-rw-r--r-- 1 jenkins jenkins 57334087 Feb  7 10:25 StatusIm-Mobile-230207-101618-991339-pr14988-x86.apk
-rw-r--r-- 1 jenkins jenkins 57080127 Feb  7 13:18 StatusIm-Mobile-230207-131114-098c05-pr14977-x86.apk
-rw-r--r-- 1 jenkins jenkins 57088322 Feb  7 14:19 StatusIm-Mobile-230207-141155-05cc4c-pr15002-x86.apk
...
```
And `utils.findFile()` just pick the first one alphabetically.