### PR TITLE
Community display picture & cover image style fixes

### DIFF
--- a/src/status_im2/common/scroll_page/style.cljs
+++ b/src/status_im2/common/scroll_page/style.cljs
@@ -58,7 +58,7 @@
   [animation]
   (reanimated/apply-animations-to-style
    {:transform [{:scale animation}]}
-   {:border-radius    40
+   {:border-radius    50
     :border-width     1
     :border-color     colors/white
     :position         :absolute

--- a/src/status_im2/common/scroll_page/view.cljs
+++ b/src/status_im2/common/scroll_page/view.cljs
@@ -146,8 +146,11 @@
           [rn/view {:style {:height 151}}
            [rn/image
             {:source cover-image
-             :style  {:overflow :visible
-                      :flex     1}}]])
+             ;; Using negative margin-bottom as a workaround because on Android,
+             ;; ScrollView clips its children despite setting overflow: 'visible'.
+             ;; Related issue: https://github.com/facebook/react-native/issues/31218
+             :style  {:margin-bottom -16
+                      :flex          1}}]])
         (when children
           [rn/view
            {:flex             1


### PR DESCRIPTION
Fixes #14974 

### Summary
- Community display image rendered as oval instead of circle shape - fixed by increasing the border-radius.
- Community background top round issue on Android - Android doesn't support `overflow: visible` on scroll view children's. Fixed by using `margin-bottom` instead of the `overflow` property.

### Screenshots

#### Before(issue)
<img width="468" alt="Before" src="https://user-images.githubusercontent.com/19279756/217794244-44de3462-26ec-494c-b0b9-1820bd388917.png">


#### After(fix)
<img width="468" alt="After" src="https://user-images.githubusercontent.com/19279756/217794265-f3192f3b-ff61-47bb-ad82-1f7aef3b690a.png">


#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted
- Community overview pages

### Steps to test
- Open a community overview page and check the display picture and cover image.

status: ready <!-- Can be ready or wip -->
