### PR TITLE
Revert "communities home header flickering when user scrolls"

### DIFF
--- a/src/status_im2/common/scroll_page/view.cljs
+++ b/src/status_im2/common/scroll_page/view.cljs
@@ -74,7 +74,7 @@
            :style  {:line-height 21}}
           name]])
       (if top-nav
-        top-nav
+        [top-nav]
         [quo/page-nav
          (merge {:horizontal-description? true
                  :one-icon-align-left?    true
@@ -89,7 +89,7 @@
                                   :icon-background-color (icon-color)
                                   :on-press              #(rf/dispatch [:navigate-back])}}))])
       (when title-colum
-        title-colum)
+        [title-colum])
       sticky-header]]))
 
 

--- a/src/status_im2/contexts/communities/home/view.cljs
+++ b/src/status_im2/contexts/communities/home/view.cljs
@@ -77,30 +77,18 @@
 
 (defn home-page-comunity-lists
   [{:keys [selected-tab padding-top]}]
-  [rn/view {:style {:flex 1}}
-   [communities-header selected-tab padding-top]
-   [render-communities-segments selected-tab]])
+  (fn []
+    [rn/view {:style {:flex 1}}
+     [communities-header selected-tab padding-top]
+     [render-communities-segments selected-tab]]))
 
 (defn home-sticky-header
   [{:keys [selected-tab scroll-height padding-top]}]
-  (when (> @scroll-height 80)
-    [rn/view
-     {:style style/blur-tabs-header}
-     [community-segments selected-tab padding-top]]))
-
-(defn home-nav
-  []
-  [common.home/top-nav
-   {:type        :default
-    :hide-search true
-    :style       {:background-color :transparent}}])
-
-(defn title-column
-  []
-  [common.home/title-column
-   {:label               (i18n/label :t/communities)
-    :handler             #(rf/dispatch [:bottom-sheet/show-sheet :add-new {}])
-    :accessibility-label :new-chat-button}])
+  (fn []
+    (when (> @scroll-height 80)
+      [rn/view
+       {:style style/blur-tabs-header}
+       [community-segments selected-tab padding-top]])))
 
 (defn communities-screen-content
   []
@@ -110,8 +98,16 @@
       [scroll-page/scroll-page
        {:name             (i18n/label :t/communities)
         :on-scroll        #(reset! scroll-height %)
-        :top-nav          [home-nav]
-        :title-colum      [title-column]
+        :top-nav          (fn []
+                            [common.home/top-nav
+                             {:type        :default
+                              :hide-search true
+                              :style       {:background-color :transparent}}])
+        :title-colum      (fn []
+                            [common.home/title-column
+                             {:label               (i18n/label :t/communities)
+                              :handler             #(rf/dispatch [:bottom-sheet/show-sheet :add-new {}])
+                              :accessibility-label :new-chat-button}])
         :background-color (colors/theme-colors
                            colors/white
                            colors/neutral-95)


### PR DESCRIPTION
Reverts status-im/status-mobile#15060

I reverted this pr because I realized after having merged it, there was a request-manual-qa label. 