### PR TITLE
Feat: pass node config and kdf when local pairing

### DIFF
--- a/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusModule.java
+++ b/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusModule.java
@@ -797,7 +797,7 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
          final JSONObject jsonConfig = new JSONObject(configJSON);
          final String keyStorePath = pathCombine(this.getNoBackupDirectory(), "/keystore");
          jsonConfig.put("keystorePath", keyStorePath);
-
+         jsonConfig.put("rootDataDir", this.getNoBackupDirectory());
         executeRunnableStatusGoMethod(() -> Statusgo.inputConnectionStringForBootstrapping(connectionString, jsonConfig.toString()), callback);
     }
 

--- a/modules/react-native-status/ios/RCTStatus/RCTStatus.m
+++ b/modules/react-native-status/ios/RCTStatus/RCTStatus.m
@@ -329,12 +329,13 @@ RCT_EXPORT_METHOD(inputConnectionStringForBootstrapping:(NSString *)cs
     NSDictionary *configDict = [NSJSONSerialization JSONObjectWithData:configData options:NSJSONReadingMutableContainers error:nil];
     NSFileManager *fileManager = [NSFileManager defaultManager];
     NSURL *rootUrl =[[fileManager URLsForDirectory:NSLibraryDirectory inDomains:NSUserDomainMask] lastObject];
+    NSURL *rootDataDir = rootUrl.path;
     NSURL *multiaccountKeystoreDir = [rootUrl URLByAppendingPathComponent:@"keystore"];
     NSString *keystoreDir = multiaccountKeystoreDir.path;
 
     [configDict setValue:keystoreDir forKey:@"keystorePath"];
+    [configDict setValue:rootDataDir forKey:@"rootDataDir"];
     NSString *modifiedConfigJSON = [configDict bv_jsonStringWithPrettyPrint:NO];
-
     NSString *result = StatusgoInputConnectionStringForBootstrapping(cs,modifiedConfigJSON);
     callback(@[result]);
 }

--- a/src/status_im/node/core.cljs
+++ b/src/status_im/node/core.cljs
@@ -115,7 +115,7 @@
   (let [ks (keys fleet)]
     (some #(string/includes? (str %) "waku") ks)))
 
-(defn- get-multiaccount-node-config
+(defn get-multiaccount-node-config
   [{:keys [multiaccount :networks/networks :networks/current-network]
     :as   db}]
   (let [wakuv2-config (get multiaccount :wakuv2-config {})

--- a/src/status_im2/config.cljs
+++ b/src/status_im2/config.cljs
@@ -151,3 +151,5 @@
    ["enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@prod.waku.nodes.status.im"]
    :wakuv2.test
    ["enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@test.waku.nodes.status.im"]})
+
+(def default-kdf-iterations 3200)

--- a/src/status_im2/contexts/syncing/events.cljs
+++ b/src/status_im2/contexts/syncing/events.cljs
@@ -3,17 +3,43 @@
             [status-im2.contexts.syncing.sheets.enter-password.view :as sheet]
             [taoensso.timbre :as log]
             [utils.re-frame :as rf]
-            [utils.security.core :as security]))
+            [utils.security.core :as security]
+            [status-im2.config :as config]
+            [status-im.node.core :as node]
+            [re-frame.core :as re-frame]
+            [status-im.data-store.settings :as data-store.settings]))
+
+(defn- get-default-node-config
+  [installation-id]
+  (let [db {:networks/current-network config/default-network
+            :networks/networks        (data-store.settings/rpc->networks config/default-networks)
+            :multiaccount             {:installation-id           installation-id
+                                       :log-level                 config/log-level
+                                       :waku-bloom-filter-mode    false
+                                       :custom-bootnodes          nil
+                                       :custom-bootnodes-enabled? false}}]
+    (node/get-multiaccount-node-config db)))
 
 (rf/defn initiate-local-pairing-with-connection-string
-  {:events [:syncing/input-connection-string-for-bootstrapping]}
-  [{:keys [db]} {:keys [data]}]
-  (let [config-map        (.stringify js/JSON (clj->js {:keyUID "" :keystorePath "" :password ""}))
-        connection-string data]
-    (status/input-connection-string-for-bootstrapping
-     connection-string
-     config-map
-     #(log/info "this is response from initiate-local-pairing-with-connection-string " %))))
+  {:events       [:syncing/input-connection-string-for-bootstrapping]
+   :interceptors [(re-frame/inject-cofx :random-guid-generator)]}
+  [{:keys [random-guid-generator db]} {connection-string :data}]
+  (let [installation-id (random-guid-generator)
+        default-node-config (get-default-node-config installation-id)
+        default-node-config-string (.stringify js/JSON (clj->js default-node-config))
+        callback
+        (fn [final-node-config]
+          (let [config-map (.stringify js/JSON
+                                       (clj->js {:kdfIterations         config/default-kdf-iterations
+                                                 :nodeConfig            final-node-config
+                                                 :settingCurrentNetwork config/default-network}))]
+            (status/input-connection-string-for-bootstrapping
+             connection-string
+             config-map
+             #(log/info "Initiated local pairing"
+                        {:response %
+                         :event    :syncing/input-connection-string-for-bootstrapping}))))]
+    (status/prepare-dir-and-update-config "" default-node-config-string callback)))
 
 (rf/defn preparations-for-connection-string
   {:events [:syncing/get-connection-string-for-bootstrapping-another-device]}

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -1,9 +1,9 @@
 {
-    "_comment": "THIS SHOULD NOT BE EDITED BY HAND.",
-    "_comment": "Instead use: scripts/update-status-go.sh <rev>",
-    "owner": "status-im",
-    "repo": "status-go",
-    "version": "v0.131.7",
-    "commit-sha1": "97579ee36393955705e51f364fce3ab40d1d6921",
-    "src-sha256": "0b15kv6f1f1935lljl4bmvmndsr5smb9kxazx0fxz6xfsyjd1x5i"
+  "_comment": "THIS SHOULD NOT BE EDITED BY HAND.",
+  "_comment": "Instead use: scripts/update-status-go.sh <rev>",
+  "owner": "status-im",
+  "repo": "status-go",
+  "version": "v0.131.10",
+  "commit-sha1": "8ff91ba0024f5ecf05d29904288537b236329f51",
+  "src-sha256": "1m3an4fhzhh0vq8bb24xfjwdysfdd9qrz08a3gfz3ddahkh41jad"
 }


### PR DESCRIPTION
before this PR, node config were synced from sender when local pairing, and saved default kdf 3200 to db.
in this PR, default node config and kdf are passed to backend when the role of device is receiver.
relate [PR](https://github.com/status-im/status-go/pull/3179)

### Testing notes
local pairing should work as before

#### Platforms
- Android
- iOS

### Steps to test
we can reference [here](https://github.com/status-im/status-mobile/pull/14763)

status: ready
