### PR TITLE
ci: fix Jenkins lib function for reading version

### DIFF
--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.6.5'
+library 'status-jenkins-lib@v1.6.6'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.6.3'
+library 'status-jenkins-lib@v1.6.6'
 
 pipeline {
   agent { label 'linux' }

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.6.5'
+library 'status-jenkins-lib@v1.6.6'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.nix-cache
+++ b/ci/Jenkinsfile.nix-cache
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.6.3'
+library 'status-jenkins-lib@v1.6.6'
 
 pipeline {
   agent { label params.AGENT_LABEL }

--- a/ci/Jenkinsfile.tests
+++ b/ci/Jenkinsfile.tests
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.6.3'
+library 'status-jenkins-lib@v1.6.6'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/tests/Jenkinsfile.e2e-nightly
+++ b/ci/tests/Jenkinsfile.e2e-nightly
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.6.5'
+library 'status-jenkins-lib@v1.6.6'
 
 pipeline {
 

--- a/ci/tests/Jenkinsfile.e2e-prs
+++ b/ci/tests/Jenkinsfile.e2e-prs
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.6.5'
+library 'status-jenkins-lib@v1.6.6'
 
 pipeline {
 

--- a/ci/tests/Jenkinsfile.e2e-upgrade
+++ b/ci/tests/Jenkinsfile.e2e-upgrade
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.6.5'
+library 'status-jenkins-lib@v1.6.6'
 
 pipeline {
 

--- a/ci/tools/Jenkinsfile.fastlane-clean
+++ b/ci/tools/Jenkinsfile.fastlane-clean
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.6.3'
+library 'status-jenkins-lib@v1.6.6'
 
 pipeline {
   agent { label 'macos' }

--- a/ci/tools/Jenkinsfile.playstore-meta
+++ b/ci/tools/Jenkinsfile.playstore-meta
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.6.3'
+library 'status-jenkins-lib@v1.6.6'
 
 pipeline {
   agent { label 'linux' }


### PR DESCRIPTION
Otherwise we just get `UNKNOWN` in release filenames.

Depends on:
* https://github.com/status-im/status-jenkins-lib/pull/56

Manually tested in:
https://ci.infra.status.im/job/status-mobile/job/platforms/job/android/941/