### PR TITLE
ci: update ITSEncryptionExportComplianceCode

### DIFF
--- a/ios/StatusIm/Info.plist
+++ b/ios/StatusIm/Info.plist
@@ -52,7 +52,7 @@
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<true/>
 	<key>ITSEncryptionExportComplianceCode</key>
-	<string>1aa92c4d-6194-4d7d-b70a-16b48256b87e</string>
+	<string>37d5ac79-0eb2-4e66-9117-8a8515185a7f</string>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>whatsapp</string>

--- a/ios/StatusImPR/Info.plist
+++ b/ios/StatusImPR/Info.plist
@@ -48,7 +48,7 @@
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<true/>
 	<key>ITSEncryptionExportComplianceCode</key>
-	<string>1aa92c4d-6194-4d7d-b70a-16b48256b87e</string>
+	<string>37d5ac79-0eb2-4e66-9117-8a8515185a7f</string>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>whatsapp</string>


### PR DESCRIPTION
We were using old ID for the encryption compliance from old Org. Because of this the iOS release builds failed at TestFlight upload:
```
Error: Asset validation failed Invalid Export Compliance Code.
The export compliance key value [1aa92c4d-6194-4d7d-b70a-16b48256b87e]
in the app's Info.plist doesn’t match the key value of the app’s export
compliance documentation.
To find the correct value, go to My Apps on App Store Connect. (90592)
```
Had to find it in https://appstoreconnect.apple.com/ under `Status App > Services > Encryption`.

Related:
- https://stackoverflow.com/questions/53326492/
- https://help.apple.com/app-store-connect/#/dev38f592ac9