### PR TITLE
display-name -> preferred-name

### DIFF
--- a/src/status_im/multiaccounts/core.cljs
+++ b/src/status_im/multiaccounts/core.cljs
@@ -66,15 +66,16 @@
     (assoc contact' :two-names (contact-two-names contact' true))))
 
 (defn displayed-name
-  "Use preferred name, name or alias in that order"
-  [{:keys [name preferred-name alias public-key ens-verified]}]
+  "Use preferred name, display-name, name or alias in that order"
+  [{:keys [name display-name preferred-name alias public-key ens-verified]}]
   (let [ens-name (or preferred-name
+                     display-name
                      name)]
     ;; Preferred name is our own otherwise we make sure it's verified
     (if (or preferred-name (and ens-verified name))
       (let [username (stateofus/username ens-name)]
         (or username ens-name))
-      (or alias (gfycat/generate-gfy public-key)))))
+      (or display-name alias (gfycat/generate-gfy public-key)))))
 
 (defn contact-by-identity
   [contacts identity]

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.131.4",
-    "commit-sha1": "0b2f0ef28923d2bc3c9051d038e7c512bfdc741f",
-    "src-sha256": "1pql2dkzwny5yv8ggi2dikfc6dbp64cyxjnm8k0nyl2wfs8ax2cg"
+    "version": "v0.131.7",
+    "commit-sha1": "97579ee36393955705e51f364fce3ab40d1d6921",
+    "src-sha256": "0b15kv6f1f1935lljl4bmvmndsr5smb9kxazx0fxz6xfsyjd1x5i"
 }


### PR DESCRIPTION
Use `display-name` in profile view. Depends on https://github.com/status-im/status-go/pull/3193, which fixes account list name display.

Fixes #15067