### PR TITLE
Show Community Request Notifications in Activity Center

### DIFF
--- a/src/status_im/ui/screens/communities/community.cljs
+++ b/src/status_im/ui/screens/communities/community.cljs
@@ -25,7 +25,7 @@
     [utils.datetime :as datetime]
     [utils.re-frame :as rf]))
 
-(def request-cooldown-ms (* 24 60 60 1000))
+(def request-cooldown-ms (* 7 24 60 60 1000))
 
 (defn can-request-access-again?
   [requested-at]

--- a/src/status_im2/contexts/activity_center/notification/admin/view.cljs
+++ b/src/status_im2/contexts/activity_center/notification/admin/view.cljs
@@ -1,8 +1,6 @@
 (ns status-im2.contexts.activity-center.notification.admin.view
   (:require [quo2.core :as quo]
-            [quo2.foundations.colors :as colors]
             [status-im2.constants :as constants]
-            [status-im2.contexts.activity-center.notification.common.style :as style]
             [status-im2.contexts.activity-center.notification.common.view :as common]
             [utils.datetime :as datetime]
             [utils.i18n :as i18n]
@@ -38,11 +36,7 @@
       :context   [[common/user-avatar-tag author]
                   (i18n/label :t/wants-to-join)
                   [quo/context-tag
-                   {:size           :small
-                    :override-theme :dark
-                    :color          colors/primary-50
-                    :style          style/user-avatar-tag
-                    :text-style     style/user-avatar-tag-text}
+                   common/tag-params
                    {:uri community-image} community-name]]
       :items     (case membership-status
                    constants/activity-center-membership-status-accepted

--- a/src/status_im2/contexts/activity_center/notification/common/style.cljs
+++ b/src/status_im2/contexts/activity_center/notification/common/style.cljs
@@ -4,10 +4,10 @@
 (def swipe-action-width 72)
 (def swipe-button-border-radius 16)
 
-(def user-avatar-tag
+(def tag
   {:background-color colors/white-opa-10})
 
-(def user-avatar-tag-text
+(def tag-text
   {:color colors/white})
 
 (def left-swipe-opacity-interpolation-js

--- a/src/status_im2/contexts/activity_center/notification/common/view.cljs
+++ b/src/status_im2/contexts/activity_center/notification/common/view.cljs
@@ -8,15 +8,17 @@
             [utils.i18n :as i18n]
             [utils.re-frame :as rf]))
 
+(def tag-params
+  {:size           :small
+   :override-theme :dark
+   :color          colors/primary-50
+   :style          style/tag
+   :text-style     style/tag-text})
+
 (defn user-avatar-tag
   [user-id]
   (let [contact (rf/sub [:contacts/contact-by-identity user-id])]
-    [quo/user-avatar-tag
-     {:color          :purple
-      :override-theme :dark
-      :size           :small
-      :style          style/user-avatar-tag
-      :text-style     style/user-avatar-tag-text}
+    [quo/user-avatar-tag tag-params
      (:primary-name contact)
      (multiaccounts/displayed-photo contact)]))
 

--- a/src/status_im2/contexts/activity_center/notification/community_request/view.cljs
+++ b/src/status_im2/contexts/activity_center/notification/community_request/view.cljs
@@ -6,7 +6,7 @@
             [utils.i18n :as i18n]
             [utils.re-frame :as rf]))
 
-(defn- generate-header-and-body-text
+(defn- get-header-and-body-text
   [membership-status]
   (case membership-status
     1 {:header-text (i18n/label :t/community-request-pending)
@@ -22,7 +22,7 @@
 
 (defn view
   [{:keys [community-id membership-status read timestamp]}]
-  (let [{:keys [header-text body-text]} (generate-header-and-body-text membership-status)
+  (let [{:keys [header-text body-text]} (get-header-and-body-text membership-status)
         community                       (rf/sub [:communities/community community-id])
         community-name                  (:name community)
         community-image                 (get-in community [:images :thumbnail :uri])]

--- a/src/status_im2/contexts/activity_center/notification/community_request/view.cljs
+++ b/src/status_im2/contexts/activity_center/notification/community_request/view.cljs
@@ -1,0 +1,35 @@
+(ns status-im2.contexts.activity-center.notification.community-request.view
+  (:require [quo2.core :as quo]
+            [status-im2.contexts.activity-center.notification.common.style :as common-style]
+            [status-im2.contexts.activity-center.notification.common.view :as common]
+            [utils.datetime :as datetime]
+            [utils.i18n :as i18n]
+            [utils.re-frame :as rf]))
+
+(defn- generate-header-and-body-text
+  [membership-status]
+  (case membership-status
+    1 {:header-text (i18n/label :t/community-request-pending)
+       :body-text   (i18n/label :t/community-request-pending-body-text)}
+
+    2 {:header-text (i18n/label :t/community-request-accepted)
+       :body-text   (i18n/label :t/community-request-accepted-body-text)}
+
+    3 {:header-text (i18n/label :t/community-request-declined)
+       :body-text   (i18n/label :t/community-request-declined=body-text)}
+
+    nil))
+
+(defn view
+  [{:keys [community-id membership-status read timestamp]}]
+  (let [{:keys [header-text body-text]} (generate-header-and-body-text membership-status)
+        community                       (rf/sub [:communities/community community-id])
+        community-name                  (:name community)
+        community-image                 (get-in community [:images :thumbnail :uri])]
+    [quo/activity-log
+     {:title     header-text
+      :icon      :i/communities
+      :timestamp (datetime/timestamp->relative timestamp)
+      :unread?   (not read)
+      :context   [[quo/text {:style common-style/tag-text} body-text]
+                  [quo/context-tag common/tag-params {:uri community-image} community-name]]}]))

--- a/src/status_im2/contexts/activity_center/notification/community_request/view.cljs
+++ b/src/status_im2/contexts/activity_center/notification/community_request/view.cljs
@@ -1,5 +1,6 @@
 (ns status-im2.contexts.activity-center.notification.community-request.view
   (:require [quo2.core :as quo]
+            [status-im2.constants :as constants]
             [status-im2.contexts.activity-center.notification.common.style :as common-style]
             [status-im2.contexts.activity-center.notification.common.view :as common]
             [utils.datetime :as datetime]
@@ -9,14 +10,17 @@
 (defn- get-header-and-body-text
   [membership-status]
   (case membership-status
-    1 {:header-text (i18n/label :t/community-request-pending)
-       :body-text   (i18n/label :t/community-request-pending-body-text)}
+    constants/activity-center-membership-status-pending
+    {:header-text (i18n/label :t/community-request-pending)
+     :body-text   (i18n/label :t/community-request-pending-body-text)}
 
-    2 {:header-text (i18n/label :t/community-request-accepted)
-       :body-text   (i18n/label :t/community-request-accepted-body-text)}
+    constants/activity-center-membership-status-accepted
+    {:header-text (i18n/label :t/community-request-accepted)
+     :body-text   (i18n/label :t/community-request-accepted-body-text)}
 
-    3 {:header-text (i18n/label :t/community-request-declined)
-       :body-text   (i18n/label :t/community-request-declined=body-text)}
+    constants/activity-center-membership-status-declined
+    {:header-text (i18n/label :t/community-request-declined)
+     :body-text   (i18n/label :t/community-request-declined=body-text)}
 
     nil))
 

--- a/src/status_im2/contexts/activity_center/notification/mentions/style.cljs
+++ b/src/status_im2/contexts/activity_center/notification/mentions/style.cljs
@@ -1,12 +1,6 @@
 (ns status-im2.contexts.activity-center.notification.mentions.style
   (:require [quo2.foundations.colors :as colors]))
 
-(def tag
-  {:background-color colors/white-opa-10})
-
-(def tag-text
-  {:color colors/white})
-
 (def mention-text
   {:color              colors/white
    :border-radius      6

--- a/src/status_im2/contexts/activity_center/notification/mentions/view.cljs
+++ b/src/status_im2/contexts/activity_center/notification/mentions/view.cljs
@@ -1,20 +1,13 @@
 (ns status-im2.contexts.activity-center.notification.mentions.view
   (:require [clojure.string :as string]
             [quo2.core :as quo]
-            [quo2.foundations.colors :as colors]
             [react-native.gesture :as gesture]
             [status-im2.contexts.activity-center.notification.common.view :as common]
+            [status-im2.contexts.activity-center.notification.common.style :as common-style]
             [status-im2.contexts.activity-center.notification.mentions.style :as style]
             [utils.datetime :as datetime]
             [utils.i18n :as i18n]
             [utils.re-frame :as rf]))
-
-(def tag-params
-  {:size           :small
-   :override-theme :dark
-   :color          colors/primary-50
-   :style          style/tag
-   :text-style     style/tag-text})
 
 (defn message-body
   [message]
@@ -22,7 +15,7 @@
         parsed-text-children (:children (first parsed-text))]
     (into [quo/text
            {:number-of-lines     1
-            :style               style/tag-text
+            :style               common-style/tag-text
             :accessibility-label :activity-message-body
             :size                :paragraph-1}]
           (map-indexed (fn [index {:keys [type literal]}]
@@ -64,8 +57,8 @@
        :timestamp (datetime/timestamp->relative timestamp)
        :unread?   (not read)
        :context   [[common/user-avatar-tag author]
-                   [quo/text {:style style/tag-text} (string/lower-case (i18n/label :t/on))]
+                   [quo/text {:style common-style/tag-text} (string/lower-case (i18n/label :t/on))]
                    (if community-chat?
-                     [quo/context-tag tag-params {:uri community-image} community-name chat-name]
-                     [quo/group-avatar-tag chat-name tag-params])]
+                     [quo/context-tag common/tag-params {:uri community-image} community-name chat-name]
+                     [quo/group-avatar-tag chat-name common/tag-params])]
        :message   {:body (message-body message)}}]]))

--- a/src/status_im2/contexts/activity_center/notification/reply/style.cljs
+++ b/src/status_im2/contexts/activity_center/notification/reply/style.cljs
@@ -1,12 +1,6 @@
 (ns status-im2.contexts.activity-center.notification.reply.style
   (:require [quo2.foundations.colors :as colors]))
 
-(def tag
-  {:background-color colors/white-opa-10})
-
-(def tag-text
-  {:color colors/white})
-
 (def lowercase-text
   {:color          colors/white
    :text-transform :lowercase})

--- a/src/status_im2/contexts/activity_center/notification/reply/view.cljs
+++ b/src/status_im2/contexts/activity_center/notification/reply/view.cljs
@@ -1,23 +1,16 @@
 (ns status-im2.contexts.activity-center.notification.reply.view
   (:require [clojure.string :as string]
             [quo2.core :as quo]
-            [quo2.foundations.colors :as colors]
             [react-native.gesture :as gesture]
             [status-im.ui2.screens.chat.messages.message :as old-message]
             [status-im2.common.not-implemented :as not-implemented]
             [status-im2.constants :as constants]
             [status-im2.contexts.activity-center.notification.common.view :as common]
+            [status-im2.contexts.activity-center.notification.common.style :as common-style]
             [status-im2.contexts.activity-center.notification.reply.style :as style]
             [utils.datetime :as datetime]
             [utils.i18n :as i18n]
             [utils.re-frame :as rf]))
-
-(def tag-params
-  {:size           :small
-   :override-theme :dark
-   :color          colors/primary-50
-   :style          style/tag
-   :text-style     style/tag-text})
 
 ;; NOTE: Replies support text, image and stickers only.
 (defn get-message-content
@@ -32,7 +25,7 @@
     ;; NOTE: The following type (system-text) doesn't have a design yet.
     ;; https://github.com/status-im/status-mobile/issues/14915
     constants/content-type-system-text [not-implemented/not-implemented
-                                        [quo/text {:style style/tag-text}
+                                        [quo/text {:style common-style/tag-text}
                                          (get-in message [:content :text])]]
 
     nil))
@@ -68,7 +61,7 @@
        :context   [[common/user-avatar-tag author]
                    [quo/text {:style style/lowercase-text} (i18n/label :t/on)]
                    (if community-chat?
-                     [quo/context-tag tag-params {:uri community-image} community-name chat-name]
-                     [quo/group-avatar-tag chat-name tag-params])]
+                     [quo/context-tag common/tag-params {:uri community-image} community-name chat-name]
+                     [quo/group-avatar-tag chat-name common/tag-params])]
        :message   {:body-number-of-lines 1
                    :body                 (get-message-content message)}}]]))

--- a/src/status_im2/contexts/activity_center/notification_types.cljs
+++ b/src/status_im2/contexts/activity_center/notification_types.cljs
@@ -6,6 +6,7 @@
 (def ^:const mention 3)
 (def ^:const reply 4)
 (def ^:const contact-request 5)
+(def ^:const community-request 7)
 (def ^:const admin 8)
 (def ^:const contact-verification 10)
 
@@ -15,6 +16,7 @@
     mention
     reply
     contact-request
+    community-request
     admin
     contact-verification})
 
@@ -26,4 +28,5 @@
   "Membership is like a logical group of notifications with different types, i.e.
   it doesn't have a corresponding type in the backend. Think of the collection
   as a composite key of actual types."
-  #{private-group-chat})
+  #{private-group-chat
+    community-request})

--- a/src/status_im2/contexts/activity_center/view.cljs
+++ b/src/status_im2/contexts/activity_center/view.cljs
@@ -12,6 +12,8 @@
             [status-im2.contexts.activity-center.notification.membership.view :as membership]
             [status-im2.contexts.activity-center.notification.mentions.view :as mentions]
             [status-im2.contexts.activity-center.notification.reply.view :as reply]
+            [status-im2.contexts.activity-center.notification.community-request.view :as
+             community-request]
             [status-im2.contexts.activity-center.style :as style]
             [utils.i18n :as i18n]
             [utils.re-frame :as rf]))
@@ -196,7 +198,12 @@
             [admin/view notification set-swipeable-height]]
 
            (some types/membership [type])
-           [membership/view notification]
+           (case type
+             types/private-group-chat [membership/view notification]
+
+             types/community-request  [community-request/view notification]
+
+             nil)
 
            :else
            nil)]))))

--- a/src/utils/requests.cljs
+++ b/src/utils/requests.cljs
@@ -1,7 +1,7 @@
 (ns utils.requests
   (:require [utils.datetime :as datetime]))
 
-(def request-cooldown-ms (* 24 60 60 1000))
+(def request-cooldown-ms (* 7 24 60 60 1000))
 
 (defn can-request-access-again?
   [requested-at]

--- a/translations/en.json
+++ b/translations/en.json
@@ -1979,7 +1979,8 @@
     "community-request-accepted": "Request accepted",
     "community-request-accepted-body-text": "Now you are a member of",
     "community-request-not-accepted": "Request hasn't been accepted",
-    "community-request-not-accepted-body-text": "Your request to join {{community-name}} hasn't been accepted",
+    "community-request-not-accepted-body-text-prefix": "Your request to join",
+    "community-request-not-accepted-body-text-suffix": "hasn't been accepted",
     "community-request-pending": "Request pending",
     "community-request-pending-body-text": "You requested to join"
 }

--- a/translations/en.json
+++ b/translations/en.json
@@ -1975,5 +1975,11 @@
     "strength-divider-weak-label": "Weak",
     "strength-divider-okay-label": "Okay",
     "strength-divider-strong-label": "Strong",
-    "strength-divider-very-strong-label": "Very strong"
+    "strength-divider-very-strong-label": "Very strong",
+    "community-request-accepted": "Request accepted",
+    "community-request-accepted-body-text": "Now you are a member of",
+    "community-request-not-accepted": "Request hasn't been accepted",
+    "community-request-not-accepted-body-text": "Your request to join {{community-name}} hasn't been accepted",
+    "community-request-pending": "Request pending",
+    "community-request-pending-body-text": "You requested to join"
 }


### PR DESCRIPTION
fixes #15082

### Summary

Show Community Request Notifications in Activity Center

![1 line](https://user-images.githubusercontent.com/19339952/218719686-4eef94c8-5c40-43df-9ba5-5b11332d6419.png)

![1 line](https://user-images.githubusercontent.com/19339952/218719770-177afe75-8282-4692-8eec-907a3db2f618.png)

### Notes

This PR additionally cleans/moves the common styles and parameters used in Activity Center.

### Platforms

- Android
- iOS


### Steps to test

- Open Status
- User `A` requests to join a community (with required approval)
- User `A` opens the Activity Center and sees the status of the request

status: ready
