### PR TITLE
Sync display names

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.130.0",
-    "commit-sha1": "dea21f440a9f630c4b8324fcde0b016d6c3fc02b",
-    "src-sha256": "1w9iyigj0rkqfnyb8m9w802r1lx1cydg41p8qb7hnsry2bgrfk97"
+    "version": "debug/sync-contacts",
+    "commit-sha1": "60ec3ab644ea05eca6547d15eb4eec723117b836",
+    "src-sha256": "0zykx04vhm9s23gr7zwyjwxh6s81j4sbcamjv3yy390k9xr7k7fn"
 }


### PR DESCRIPTION
Display names were never synced.
This commit adds this feature.

It only works this PR -> this PR as discussed with @churik 

### Testing


1) Create account A1
2) Create account B1 on desktop, setting display name
3) A1 :heart:  B1 = mutual contacts
4) Ideally wait a long time
5) A1 pairs with A2, sync installations

B1 contact name should be propagated to A2.

Fixes (ish): #15066

https://github.com/status-im/status-go/pull/3194