### PR TITLE
[Fixes: #15093] Add support for mention @everyone

### DIFF
--- a/src/status_im/ui/screens/chat/components/contact_request.cljs
+++ b/src/status_im/ui/screens/chat/components/contact_request.cljs
@@ -42,7 +42,7 @@
              (get-quoted-text-with-mentions children)
 
              (= type "mention")
-             @(re-frame/subscribe [:contacts/contact-name-by-identity literal])
+             @(re-frame/subscribe [:messages/resolve-mention literal])
 
              (seq children)
              (get-quoted-text-with-mentions children)

--- a/src/status_im/ui/screens/chat/components/reply.cljs
+++ b/src/status_im/ui/screens/chat/components/reply.cljs
@@ -43,7 +43,7 @@
              (get-quoted-text-with-mentions children)
 
              (= type "mention")
-             @(re-frame/subscribe [:contacts/contact-name-by-identity literal])
+             @(re-frame/subscribe [:messages/resolve-mention literal])
 
              (seq children)
              (get-quoted-text-with-mentions children)

--- a/src/status_im/ui/screens/home/views/inner_item.cljs
+++ b/src/status_im/ui/screens/home/views/inner_item.cljs
@@ -49,7 +49,7 @@
 
                  "mention"
                  {:components [react/text-class
-                               @(re-frame/subscribe [:contacts/contact-name-by-identity literal])]
+                               @(re-frame/subscribe [:messages/resolve-mention literal])]
                   :length     4} ;; we can't predict name length so take the smallest possible
 
                  "status-tag"

--- a/src/status_im/ui2/screens/chat/components/reply/view.cljs
+++ b/src/status_im/ui2/screens/chat/components/reply/view.cljs
@@ -22,7 +22,7 @@
              (get-quoted-text-with-mentions children)
 
              (= type "mention")
-             (rf/sub [:contacts/contact-name-by-identity literal])
+             (rf/sub [:messages/resolve-mention literal])
 
              (seq children)
              (get-quoted-text-with-mentions children)

--- a/src/status_im/ui2/screens/chat/messages/message.cljs
+++ b/src/status_im/ui2/screens/chat/messages/message.cljs
@@ -35,7 +35,7 @@
 
 (defn mention-element
   [from]
-  (rf/sub [:contacts/contact-name-by-identity from]))
+  (rf/sub [:messages/resolve-mention from]))
 
 (defn render-inline
   [_message-text content-type acc {:keys [type literal destination]}]

--- a/src/status_im2/constants.cljs
+++ b/src/status_im2/constants.cljs
@@ -281,3 +281,5 @@
 (def ^:const local-pair-action-connect 1)
 (def ^:const local-pair-action-pairing-account 2)
 (def ^:const local-pair-action-sync-device 3)
+
+(def ^:const everyone-mention-id "0x00001")

--- a/src/status_im2/contexts/activity_center/notification/mentions/view.cljs
+++ b/src/status_im2/contexts/activity_center/notification/mentions/view.cljs
@@ -31,7 +31,7 @@
                            "mention" [quo/text
                                       {:style style/mention-text
                                        :size  :paragraph-1}
-                                      (str "@" (rf/sub [:contacts/contact-name-by-identity literal]))]
+                                      (str "@" (rf/sub [:messages/resolve-mention literal]))]
                            literal))
                        parsed-text-children))))
 

--- a/src/status_im2/contexts/chat/home/chat_list_item/view.cljs
+++ b/src/status_im2/contexts/chat/home/chat_list_item/view.cljs
@@ -38,7 +38,7 @@
                   children)
 
                  "mention"
-                 {:components [quo/text (rf/sub [:contacts/contact-name-by-identity literal])]
+                 {:components [quo/text (rf/sub [:messages/resolve-mention literal])]
                   :length     4} ;; we can't predict name length so take the
                                  ;; smallest possible
 

--- a/src/status_im2/contexts/chat/messages/content/text/view.cljs
+++ b/src/status_im2/contexts/chat/messages/content/text/view.cljs
@@ -46,7 +46,7 @@
       [quo/text
        {:weight :medium
         :style  {:color (colors/theme-colors colors/primary-50 colors/primary-60)}}
-       (rf/sub [:contacts/contact-name-by-identity literal])]])
+       (rf/sub [:messages/resolve-mention literal])]])
 
     (conj units literal)))
 

--- a/src/status_im2/subs/chat/messages.cljs
+++ b/src/status_im2/subs/chat/messages.cljs
@@ -3,6 +3,7 @@
             [status-im.chat.models.reactions :as models.reactions]
             [status-im2.constants :as constants]
             [status-im2.contexts.chat.messages.list.events :as models.message-list]
+            [utils.i18n :as i18n]
             [utils.datetime :as datetime]))
 
 (defn intersperse-datemark
@@ -271,3 +272,13 @@
                           joined
                           loading-messages?)
            (albumize-messages))))))
+
+(re-frame/reg-sub
+ :messages/resolve-mention
+ (fn [[_ mention] _]
+   [(re-frame/subscribe [:contacts/contact-name-by-identity mention])])
+ (fn [[contact-name] [_ mention]]
+   (if (= mention constants/everyone-mention-id)
+     (i18n/label :t/everyone-mention)
+     contact-name)))
+

--- a/translations/en.json
+++ b/translations/en.json
@@ -1629,6 +1629,7 @@
     "transfer-ma-unknown-error-desc-1": "It looks like your multiaccount was not deleted. Database may have been reset",
     "transfer-ma-unknown-error-desc-2": "Please check your account list and try again. If the account is not listed go to Access existing keys to recover with seed phrase",
     "everyone": "Everyone",
+    "everyone-mention": "everyone",
     "show-profile-pictures": "See profile pictures from",
     "show-profile-pictures-to": "Show your profile picture to",
     "non-archival-node": "RPC endpoint doesn't support archival requests. Your local transfers history might be incomplete.",


### PR DESCRIPTION
This commit adds support for displaying @everyone mention.

### Testing

1) Create a community and invite user B on Desktop
2) On Desktop, post `@everyone` in a community channel
3) Open the community on mobile (this PR)

`@everyone` should be displayed as a mention, clicking on it should have no effect.

@ulisesmac @flexsurfer this is ready to be reviewed now, thank you!