### PR TITLE
Get community-id from notification data for mentions and replies

### DIFF
--- a/src/status_im2/contexts/activity_center/notification/mentions/view.cljs
+++ b/src/status_im2/contexts/activity_center/notification/mentions/view.cljs
@@ -36,10 +36,8 @@
                        parsed-text-children))))
 
 (defn view
-  [{:keys [author chat-name chat-id message read timestamp]}]
-  (let [chat                    (rf/sub [:chats/chat chat-id])
-        community-id            (:community-id chat)
-        is-chat-from-community? (not (nil? community-id))
+  [{:keys [author chat-name community-id chat-id message read timestamp]}]
+  (let [is-chat-from-community? (not (string/blank? community-id))
         community               (rf/sub [:communities/community community-id])
         community-name          (:name community)
         community-image         (get-in community [:images :thumbnail :uri])]

--- a/src/status_im2/contexts/activity_center/notification/mentions/view.cljs
+++ b/src/status_im2/contexts/activity_center/notification/mentions/view.cljs
@@ -37,10 +37,10 @@
 
 (defn view
   [{:keys [author chat-name community-id chat-id message read timestamp]}]
-  (let [is-chat-from-community? (not (string/blank? community-id))
-        community               (rf/sub [:communities/community community-id])
-        community-name          (:name community)
-        community-image         (get-in community [:images :thumbnail :uri])]
+  (let [community-chat? (not (string/blank? community-id))
+        community       (rf/sub [:communities/community community-id])
+        community-name  (:name community)
+        community-image (get-in community [:images :thumbnail :uri])]
     [rn/touchable-opacity
      {:on-press (fn []
                   (rf/dispatch [:hide-popover])
@@ -52,7 +52,7 @@
        :unread?   (not read)
        :context   [[common/user-avatar-tag author]
                    [quo/text {:style style/tag-text} (string/lower-case (i18n/label :t/on))]
-                   (if is-chat-from-community?
+                   (if community-chat?
                      [quo/context-tag tag-params {:uri community-image} community-name chat-name]
                      [quo/group-avatar-tag chat-name tag-params])]
        :message   {:body (message-body message)}}]]))

--- a/src/status_im2/contexts/activity_center/notification/reply/view.cljs
+++ b/src/status_im2/contexts/activity_center/notification/reply/view.cljs
@@ -1,5 +1,6 @@
 (ns status-im2.contexts.activity-center.notification.reply.view
-  (:require [quo2.core :as quo]
+  (:require [clojure.string :as string]
+            [quo2.core :as quo]
             [quo2.foundations.colors :as colors]
             [react-native.core :as rn]
             [status-im.ui2.screens.chat.messages.message :as old-message]
@@ -37,10 +38,8 @@
     nil))
 
 (defn view
-  [{:keys [author chat-name chat-id message read timestamp]}]
-  (let [chat                    (rf/sub [:chats/chat chat-id])
-        community-id            (:community-id chat)
-        is-chat-from-community? (not (nil? community-id))
+  [{:keys [author chat-name community-id chat-id message read timestamp]}]
+  (let [is-chat-from-community? (not (string/blank? community-id))
         community               (rf/sub [:communities/community community-id])
         community-name          (:name community)
         community-image         (get-in community [:images :thumbnail :uri])]

--- a/src/status_im2/contexts/activity_center/notification/reply/view.cljs
+++ b/src/status_im2/contexts/activity_center/notification/reply/view.cljs
@@ -39,10 +39,10 @@
 
 (defn view
   [{:keys [author chat-name community-id chat-id message read timestamp]}]
-  (let [is-chat-from-community? (not (string/blank? community-id))
-        community               (rf/sub [:communities/community community-id])
-        community-name          (:name community)
-        community-image         (get-in community [:images :thumbnail :uri])]
+  (let [community-chat? (not (string/blank? community-id))
+        community       (rf/sub [:communities/community community-id])
+        community-name  (:name community)
+        community-image (get-in community [:images :thumbnail :uri])]
     [rn/touchable-opacity
      {:on-press (fn []
                   (rf/dispatch [:hide-popover])
@@ -54,7 +54,7 @@
        :unread?   (not read)
        :context   [[common/user-avatar-tag author]
                    [quo/text {:style style/lowercase-text} (i18n/label :t/on)]
-                   (if is-chat-from-community?
+                   (if community-chat?
                      [quo/context-tag tag-params {:uri community-image} community-name chat-name]
                      [quo/group-avatar-tag chat-name tag-params])]
        :message   {:body-number-of-lines 1


### PR DESCRIPTION
### Summary

This PR updates the `mentions` and `replies` components to get the `community-id` from notification data rather than getting it from chat (`chat-id`). 


status: ready
