### PR TITLE
Set display-name during settings creation

### DIFF
--- a/src/status_im/multiaccounts/create/core.cljs
+++ b/src/status_im/multiaccounts/create/core.cljs
@@ -202,6 +202,7 @@
                      constants/path-wallet-root-keyword
                      :address])
             :name name
+            :display-name name
             :identicon identicon
             ;; public key of the chat account
             :public-key public-key


### PR DESCRIPTION
This way we can avoid always invoking (although memoized) `generate-gfycat` function in `displayed-name` fn https://github.com/status-im/status-mobile/blob/900688dc159b2040f66bd58fed1f1828fbb47215/src/status_im/multiaccounts/core.cljs#L78 in cases when no custom `display-name` has been set by the user.

This makes https://github.com/status-im/status-mobile/pull/15122 unnecessary.


Related to https://github.com/status-im/status-go/issues/3205 and https://github.com/status-im/status-mobile/issues/15120