### PR TITLE
Add display name/ens to activity center

### DIFF
--- a/src/status_im2/contexts/activity_center/utils.cljs
+++ b/src/status_im2/contexts/activity_center/utils.cljs
@@ -2,5 +2,10 @@
 
 (defn contact-name
   [contact]
-  (or (get-in contact [:names :nickname])
-      (get-in contact [:names :three-words-name])))
+  (->> [(get-in contact [:names :nickname])
+        (get-in contact [:names :ens-name])
+        (get-in contact [:names :display-name])
+        (get-in contact [:names :three-words-name])]
+
+       (filter seq)
+       first))


### PR DESCRIPTION
We were only checking nickname/three-random words, added support for ens-name/display-name in the correct order, probably this should be pulled by a subscription and we should rationalize the logic and keep it in a single place (maybe `contacts` namespace? )
But this is an include for RC, so best to do in a separate PR

status: ready