### PR TITLE
chore: add old edit option to communities options

### DIFF
--- a/src/status_im/communities/core.cljs
+++ b/src/status_im/communities/core.cljs
@@ -427,7 +427,7 @@
             (navigation/navigate-to :community-create nil)))
 
 (rf/defn open-edit-community
-  {:events [::open-edit-community]}
+  {:events [::open-edit-community :communities/open-edit-community]}
   [{:keys [db] :as cofx} id]
   (let [{:keys [name description images permissions color]} (get-in db [:communities id])
         {:keys [access]}                                    permissions]

--- a/src/status_im2/contexts/communities/menus/community_options/view.cljs
+++ b/src/status_im2/contexts/communities/menus/community_options/view.cljs
@@ -101,7 +101,8 @@
   {:icon                :i/edit
    :label               (i18n/label :t/edit-community)
    :accessibility-label :edit-community
-   :on-press            #(js/alert (str "implement action" id))})
+   :on-press            #(rf/dispatch [:communities/open-edit-community id]
+                                      (rf/dispatch [:bottom-sheet/hide]))})
 
 (defn not-joined-options
   [id token-gated?]
@@ -149,18 +150,14 @@
 
 (defn get-context-drawers
   [{:keys [id]}]
-  (let [community     (rf/sub [:communities/community id])
-        token-gated?  (:token-gated? community)
-        joined?       (:joined community)
-        admin?        (:admin community)
-        request-sent? (pos? (:requested-to-join-at community))
-        muted?        (:muted community)
-        banned?       (:banList community)]
+  (let [{:keys [token-gated? admin joined requested-to-join-at
+                muted banList]} (rf/sub [:communities/community id])
+        request-sent?           (pos? requested-to-join-at)]
     (cond
-      joined?       (joined-options id token-gated? muted?)
-      admin?        (owner-options id token-gated? muted?)
+      admin         (owner-options id token-gated? muted)
+      joined        (joined-options id token-gated? muted)
       request-sent? (join-request-sent-options id token-gated?)
-      banned?       (banned-options id token-gated?)
+      banList       (banned-options id token-gated?)
       :else         (not-joined-options id token-gated?))))
 
 (defn community-options-bottom-sheet


### PR DESCRIPTION
partially fixes: https://github.com/status-im/status-mobile/issues/14818

There was an old edit community action which was not hooked up to the current communities pages. It's better to have this functionality there than an empty button. 

A follow up issue will be created once the community edit page is redesigned and the priority is there to implement the screens.

To test:

create a community
go to that community page
open options menu, edit community should be selectable.
hit it and it should bring you to the old flow for edit community