### PR TITLE
support local pairing after logged in as receiver

### DIFF
--- a/src/status_im2/contexts/syncing/events.cljs
+++ b/src/status_im2/contexts/syncing/events.cljs
@@ -7,7 +7,8 @@
             [status-im2.config :as config]
             [status-im.node.core :as node]
             [re-frame.core :as re-frame]
-            [status-im.data-store.settings :as data-store.settings]))
+            [status-im.data-store.settings :as data-store.settings]
+            [status-im.utils.platform :as utils.platform]))
 
 (defn- get-default-node-config
   [installation-id]
@@ -32,7 +33,8 @@
           (let [config-map (.stringify js/JSON
                                        (clj->js {:kdfIterations         config/default-kdf-iterations
                                                  :nodeConfig            final-node-config
-                                                 :settingCurrentNetwork config/default-network}))]
+                                                 :settingCurrentNetwork config/default-network
+                                                 :deviceType            utils.platform/os}))]
             (status/input-connection-string-for-bootstrapping
              connection-string
              config-map
@@ -46,7 +48,11 @@
   [{:keys [db]} entered-password]
   (let [sha3-pwd   (status/sha3 (str (security/safe-unmask-data entered-password)))
         key-uid    (get-in db [:multiaccount :key-uid])
-        config-map (.stringify js/JSON (clj->js {:keyUID key-uid :keystorePath "" :password sha3-pwd}))]
+        config-map (.stringify js/JSON
+                               (clj->js {:keyUID       key-uid
+                                         :keystorePath ""
+                                         :password     sha3-pwd
+                                         :deviceType   utils.platform/os}))]
     (status/get-connection-string-for-bootstrapping-another-device
      config-map
      (fn [connection-string]

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.133.2",
-    "commit-sha1": "f77bff6d25d53e264a6fca3c2d0bb0e8d07e474e",
-    "src-sha256": "0hm63fsjrnigb5a2l44ybf3pmqmgad4hwnxwqs96rxdx5p98vbv1"
+    "version": "v0.134.0",
+    "commit-sha1": "a9bfed21a7ef2729846f6e45b6b2c052b4efd438",
+    "src-sha256": "00gdnxr80qc0aj9mrwl5pp48524igmzc895jg7llhap8p36d8p7g"
 }


### PR DESCRIPTION
Before this PR, local pairing will only sync data between sender and receiver, but they are not paired since they didn't exchange installation data. When we say they are paired, we should see the other device get checked in the paired devices list and viceversa. This PR mainly solved above issue. Also it support local pairing after logged in as receiver now.

<img width="824" alt="image" src="https://user-images.githubusercontent.com/12406719/221791060-a8708644-310d-4bb6-8aaa-a4ec17367b46.png">

relate [PR for backend](https://github.com/status-im/status-go/pull/3202).

### Testing notes
- need to check local pairing flow and see that nothing has been broken that used to work before.
- because receiver do the local pairing after logged in, nothing will happen for the UI side after scan sync qr code, but it should received the data from sender, ui should be improved in the future PR.

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

### Steps to test
1. create an account(let's say accountA) on device A
2. restore accountA using seed phrase on device B
3. create sync qr code on device A
4. scan qr code using device B, after a while, they should be paired(we can check the paired devices list on each device). 
5. do some updates(e.g. update profile image) on device B/A, we should the latest update on the other device.


status: ready <!-- Can be ready or wip -->
