### PR TITLE
Messages don't get "sent" status when sent while internet is off

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.138.4",
-    "commit-sha1": "44a0f5b74d31fe31bd77b565ae679f839ea40e94",
-    "src-sha256": "05j9y1fg23xgqj4348cjpn7xm6jmhzj9xz2zwhvhagnq1c28800c"
+    "version": "94cd1ec",
+    "commit-sha1": "94cd1ec",
+    "src-sha256": "1inm5x6wwfm2v45aq0jyaq52lw6hpgkyy82h3v1bh2bs7bl1yd26"
 }


### PR DESCRIPTION
fixes #15087

### Summary
There was an issue with messages marked as "sent" even when they are sent while the internet connection is off.
Turned out that in status-go `ConnectionChanged()` wasn't invoked correctly

[related status-go PR](https://github.com/status-im/status-go/pull/3310)



### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Go to 1-1 chat
- Send at least 1 message
- Turn off the internet connection
- Send an additional message

Expected result:
The message sent with interrupted internet is shown with the 'sending' status

status: ready
