### PR TITLE
Use nil instead of empty string for display-name

### DIFF
--- a/src/status_im/multiaccounts/core.cljs
+++ b/src/status_im/multiaccounts/core.cljs
@@ -68,10 +68,9 @@
 (defn displayed-name
   "Use preferred name, display-name, name or alias in that order"
   [{:keys [name display-name preferred-name alias public-key ens-verified]}]
-  (let [display-name (if (string/blank? display-name) nil display-name)
-        ens-name     (or preferred-name
-                         display-name
-                         name)]
+  (let [ens-name (or preferred-name
+                     display-name
+                     name)]
     ;; Preferred name is our own otherwise we make sure it's verified
     (if (or preferred-name (and ens-verified name))
       (let [username (stateofus/username ens-name)]

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -1,9 +1,9 @@
 {
-  "_comment": "THIS SHOULD NOT BE EDITED BY HAND.",
-  "_comment": "Instead use: scripts/update-status-go.sh <rev>",
-  "owner": "status-im",
-  "repo": "status-go",
-  "version": "v0.131.10",
-  "commit-sha1": "8ff91ba0024f5ecf05d29904288537b236329f51",
-  "src-sha256": "1m3an4fhzhh0vq8bb24xfjwdysfdd9qrz08a3gfz3ddahkh41jad"
+    "_comment": "THIS SHOULD NOT BE EDITED BY HAND.",
+    "_comment": "Instead use: scripts/update-status-go.sh <rev>",
+    "owner": "status-im",
+    "repo": "status-go",
+    "version": "fix/omitempty-for-display-name",
+    "commit-sha1": "7ebfe063f79f00a30f84e332c40db62f6836a691",
+    "src-sha256": "1lzf8fgmq2y8qq2pk3rgxjpdcq9lvjh1ndip1w6b31n75q6nw901"
 }


### PR DESCRIPTION
Settings json now uses omitempty for displayName field. This helps to obsolete https://github.com/status-im/status-mobile/pull/15122. Steps outlined in https://github.com/status-im/status-mobile/issues/15120 should work.

Depends on https://github.com/status-im/status-go/pull/3215