### PR TITLE
#15025 - New input component

### DIFF
--- a/src/quo2/components/input/style.cljs
+++ b/src/quo2/components/input/style.cljs
@@ -3,73 +3,99 @@
 
 ;; TODO: remove duplicates
 (def status-colors
-  {:light      {:default {:border-color      colors/neutral-20
-                          :placeholder-color colors/neutral-40
-                          :cursor-color      (get-in colors/customization [:blue 50])
-                          :text-color        colors/neutral-100}
-                :focus   {:border-color      colors/neutral-40
-                          :placeholder-color colors/neutral-30
-                          :cursor-color      (get-in colors/customization [:blue 50])
-                          :text-color        colors/neutral-100}
-                :error   {:border-color      colors/danger-opa-40
-                          :placeholder-color colors/neutral-40
-                          :cursor-color      (get-in colors/customization [:blue 50])
-                          :text-color        colors/neutral-100}}
+  {:light      {:default {:border-color        colors/neutral-20
+                          :placeholder-color   colors/neutral-40
+                          :cursor-color        (get-in colors/customization [:blue 50])
+                          :text-color          colors/neutral-100
+                          :icon-color          colors/neutral-50
+                          :password-icon-color colors/neutral-100}
+                :focus   {:border-color        colors/neutral-40
+                          :placeholder-color   colors/neutral-30
+                          :cursor-color        (get-in colors/customization [:blue 50])
+                          :text-color          colors/neutral-100
+                          :icon-color          colors/neutral-50
+                          :password-icon-color colors/neutral-100
+                          }
+                :error   {:border-color        colors/danger-opa-40
+                          :placeholder-color   colors/neutral-40
+                          :cursor-color        (get-in colors/customization [:blue 50])
+                          :text-color          colors/neutral-100
+                          :icon-color          colors/neutral-50
+                          :password-icon-color colors/neutral-100}}
    ;;
-   :light-blur {:default {:border-color      colors/neutral-80-opa-10
-                          :placeholder-color colors/neutral-80-opa-40
-                          :cursor-color      (get-in colors/customization [:blue 50])
-                          :text-color        colors/neutral-100}
-                :focus   {:border-color      colors/neutral-80-opa-20
-                          :placeholder-color colors/neutral-80-opa-20
-                          :cursor-color      (get-in colors/customization [:blue 50])
-                          :text-color        colors/neutral-100}
-                :error   {:border-color      colors/danger-opa-40
-                          :placeholder-color colors/neutral-80-opa-40
-                          :cursor-color      (get-in colors/customization [:blue 50])
-                          :text-color        colors/neutral-100}}
+   :light-blur {:default {:border-color        colors/neutral-80-opa-10
+                          :placeholder-color   colors/neutral-80-opa-40
+                          :cursor-color        (get-in colors/customization [:blue 50])
+                          :text-color          colors/neutral-100
+                          :icon-color          colors/neutral-80-opa-70
+                          :password-icon-color colors/neutral-100}
+                :focus   {:border-color        colors/neutral-80-opa-20
+                          :placeholder-color   colors/neutral-80-opa-20
+                          :cursor-color        (get-in colors/customization [:blue 50])
+                          :text-color          colors/neutral-100
+                          :icon-color          colors/neutral-80-opa-70
+                          :password-icon-color colors/neutral-100}
+                :error   {:border-color        colors/danger-opa-40
+                          :placeholder-color   colors/neutral-80-opa-40
+                          :cursor-color        (get-in colors/customization [:blue 50])
+                          :text-color          colors/neutral-100
+                          :icon-color          colors/neutral-80-opa-70
+                          :password-icon-color colors/neutral-100}}
    ;;
-   :dark       {:default {:border-color      colors/neutral-80
-                          :placeholder-color colors/neutral-50
-                          :cursor-color      (get-in colors/customization [:blue 60])
-                          :text-color        colors/white}
-                :focus   {:border-color      colors/neutral-60
-                          :placeholder-color colors/neutral-60
-                          :cursor-color      (get-in colors/customization [:blue 60])
-                          :text-color        colors/white}
-                :error   {:border-color      colors/danger-opa-40
-                          :placeholder-color colors/white-opa-40
-                          :cursor-color      (get-in colors/customization [:blue 60])
-                          :text-color        colors/white}}
+   :dark       {:default {:border-color        colors/neutral-80
+                          :placeholder-color   colors/neutral-50
+                          :cursor-color        (get-in colors/customization [:blue 60])
+                          :text-color          colors/white
+                          :icon-color          colors/neutral-40
+                          :password-icon-color colors/white
+                          }
+                :focus   {:border-color        colors/neutral-60
+                          :placeholder-color   colors/neutral-60
+                          :cursor-color        (get-in colors/customization [:blue 60])
+                          :text-color          colors/white
+                          :icon-color          colors/neutral-40
+                          :password-icon-color colors/white}
+                :error   {:border-color        colors/danger-opa-40
+                          :placeholder-color   colors/white-opa-40
+                          :cursor-color        (get-in colors/customization [:blue 60])
+                          :text-color          colors/white
+                          :icon-color          colors/neutral-40
+                          :password-icon-color colors/white}}
    ;;
-   :dark-blur  {:default {:border-color      colors/white-opa-10
-                          :placeholder-color colors/white-opa-40
-                          :cursor-color      colors/white
-                          :text-color        colors/white}
-                :focus   {:border-color      colors/white-opa-40
-                          :placeholder-color colors/white-opa-20
-                          :cursor-color      colors/white
-                          :text-color        colors/white}
-                :error   {:border-color      colors/danger-opa-40
-                          :placeholder-color colors/white-opa-40
-                          :cursor-color      colors/white
-                          :text-color        colors/white}}})
+   :dark-blur  {:default {:border-color        colors/white-opa-10
+                          :placeholder-color   colors/white-opa-40
+                          :cursor-color        colors/white
+                          :text-color          colors/white
+                          :icon-color          colors/white-opa-70
+                          :password-icon-color colors/white}
+                :focus   {:border-color        colors/white-opa-40
+                          :placeholder-color   colors/white-opa-20
+                          :cursor-color        colors/white
+                          :text-color          colors/white
+                          :icon-color          colors/white-opa-70
+                          :password-icon-color colors/white}
+                :error   {:border-color        colors/danger-opa-40
+                          :placeholder-color   colors/white-opa-40
+                          :cursor-color        colors/white
+                          :text-color          colors/white
+                          :icon-color          colors/white-opa-70
+                          :password-icon-color colors/white}}})
 
 (defn input
-  [colors-by-status]
+  [colors-by-status left-icon?]
   {:height           40
    :border-width     1
    :border-color     (:border-color colors-by-status)
    :padding-vertical 9
-   :padding-left     16
+   :padding-left     (if left-icon? 40 16)
    :padding-right    40
    :border-radius    14
    :color            (:text-color colors-by-status)})
 
 (def right-icon-touchable-area
   {:position         :absolute
-   :right            0
    :top              0
+   :right            0
    :bottom           0
    :width            32
    :padding-vertical 9
@@ -77,8 +103,10 @@
    :justify-content  :center
    :align-items      :center})
 
-(defn icon [variant]
+(defn password-icon [colors-by-status]
   {:size  20
-   :color (if (#{:dark :dark-blur} variant)
-            colors/white
-            colors/neutral-100)})
+   :color (:password-icon-color colors-by-status)})
+
+(defn icon [colors-by-status]
+  {:size  20
+   :color (:icon-color colors-by-status)})

--- a/src/quo2/components/input/style.cljs
+++ b/src/quo2/components/input/style.cljs
@@ -1,16 +1,59 @@
 (ns quo2.components.input.style
   (:require [quo2.foundations.colors :as colors]))
 
+;; TODO: remove duplicates
 (def status-colors
-  {:dark-blur {:default {:border-color      colors/white-opa-10
-                         :placeholder-color colors/white-opa-40
-                         :cursor-color      colors/white}
-               :focus   {:border-color      colors/white-opa-40
-                         :placeholder-color colors/white-opa-20
-                         :cursor-color      colors/white}
-               :error   {:border-color      colors/danger-opa-40
-                         :placeholder-color colors/white-opa-40
-                         :cursor-color      colors/white}}})
+  {:light      {:default {:border-color      colors/neutral-20
+                          :placeholder-color colors/neutral-40
+                          :cursor-color      (get-in colors/customization [:blue 50])
+                          :text-color        colors/neutral-100}
+                :focus   {:border-color      colors/neutral-40
+                          :placeholder-color colors/neutral-30
+                          :cursor-color      (get-in colors/customization [:blue 50])
+                          :text-color        colors/neutral-100}
+                :error   {:border-color      colors/danger-opa-40
+                          :placeholder-color colors/neutral-40
+                          :cursor-color      (get-in colors/customization [:blue 50])
+                          :text-color        colors/neutral-100}}
+   ;;
+   :light-blur {:default {:border-color      colors/neutral-80-opa-10
+                          :placeholder-color colors/neutral-80-opa-40
+                          :cursor-color      (get-in colors/customization [:blue 50])
+                          :text-color        colors/neutral-100}
+                :focus   {:border-color      colors/neutral-80-opa-20
+                          :placeholder-color colors/neutral-80-opa-20
+                          :cursor-color      (get-in colors/customization [:blue 50])
+                          :text-color        colors/neutral-100}
+                :error   {:border-color      colors/danger-opa-40
+                          :placeholder-color colors/neutral-80-opa-40
+                          :cursor-color      (get-in colors/customization [:blue 50])
+                          :text-color        colors/neutral-100}}
+   ;;
+   :dark       {:default {:border-color      colors/neutral-80
+                          :placeholder-color colors/neutral-50
+                          :cursor-color      (get-in colors/customization [:blue 60])
+                          :text-color        colors/white}
+                :focus   {:border-color      colors/neutral-60
+                          :placeholder-color colors/neutral-60
+                          :cursor-color      (get-in colors/customization [:blue 60])
+                          :text-color        colors/white}
+                :error   {:border-color      colors/danger-opa-40
+                          :placeholder-color colors/white-opa-40
+                          :cursor-color      (get-in colors/customization [:blue 60])
+                          :text-color        colors/white}}
+   ;;
+   :dark-blur  {:default {:border-color      colors/white-opa-10
+                          :placeholder-color colors/white-opa-40
+                          :cursor-color      colors/white
+                          :text-color        colors/white}
+                :focus   {:border-color      colors/white-opa-40
+                          :placeholder-color colors/white-opa-20
+                          :cursor-color      colors/white
+                          :text-color        colors/white}
+                :error   {:border-color      colors/danger-opa-40
+                          :placeholder-color colors/white-opa-40
+                          :cursor-color      colors/white
+                          :text-color        colors/white}}})
 
 (defn input
   [colors-by-status]
@@ -21,7 +64,7 @@
    :padding-left     16
    :padding-right    40
    :border-radius    14
-   :color            colors/white})
+   :color            (:text-color colors-by-status)})
 
 (def right-icon-touchable-area
   {:position         :absolute
@@ -34,6 +77,8 @@
    :justify-content  :center
    :align-items      :center})
 
-(def icon
-  {:color colors/white
-   :size  20})
+(defn icon [variant]
+  {:size  20
+   :color (if (#{:dark :dark-blur} variant)
+            colors/white
+            colors/neutral-100)})

--- a/src/quo2/components/input/style.cljs
+++ b/src/quo2/components/input/style.cljs
@@ -3,83 +3,114 @@
 
 ;; TODO: remove duplicates
 (def status-colors
-  {:light      {:default {:border-color        colors/neutral-20
-                          :placeholder-color   colors/neutral-40
-                          :cursor-color        (get-in colors/customization [:blue 50])
-                          :text-color          colors/neutral-100
-                          :icon-color          colors/neutral-50
-                          :password-icon-color colors/neutral-100}
-                :focus   {:border-color        colors/neutral-40
-                          :placeholder-color   colors/neutral-30
-                          :cursor-color        (get-in colors/customization [:blue 50])
-                          :text-color          colors/neutral-100
-                          :icon-color          colors/neutral-50
-                          :password-icon-color colors/neutral-100
-                          }
-                :error   {:border-color        colors/danger-opa-40
-                          :placeholder-color   colors/neutral-40
-                          :cursor-color        (get-in colors/customization [:blue 50])
-                          :text-color          colors/neutral-100
-                          :icon-color          colors/neutral-50
-                          :password-icon-color colors/neutral-100}}
+  {:light      {:default  {:border-color        colors/neutral-20
+                           :placeholder-color   colors/neutral-40
+                           :cursor-color        (get-in colors/customization [:blue 50])
+                           :text-color          colors/neutral-100
+                           :icon-color          colors/neutral-50
+                           :password-icon-color colors/neutral-100}
+                :focus    {:border-color        colors/neutral-40
+                           :placeholder-color   colors/neutral-30
+                           :cursor-color        (get-in colors/customization [:blue 50])
+                           :text-color          colors/neutral-100
+                           :icon-color          colors/neutral-50
+                           :password-icon-color colors/neutral-100
+                           }
+                :error    {:border-color        colors/danger-opa-40
+                           :placeholder-color   colors/neutral-40
+                           :cursor-color        (get-in colors/customization [:blue 50])
+                           :text-color          colors/neutral-100
+                           :icon-color          colors/neutral-50
+                           :password-icon-color colors/neutral-100}
+
+                :disabled {:border-color        colors/neutral-20
+                           :placeholder-color   colors/neutral-40
+                           :cursor-color        (get-in colors/customization [:blue 50]) ;; Not used
+                           :text-color          colors/neutral-40
+                           :icon-color          colors/neutral-50
+                           :password-icon-color colors/neutral-50}
+                }
    ;;
-   :light-blur {:default {:border-color        colors/neutral-80-opa-10
-                          :placeholder-color   colors/neutral-80-opa-40
-                          :cursor-color        (get-in colors/customization [:blue 50])
-                          :text-color          colors/neutral-100
-                          :icon-color          colors/neutral-80-opa-70
-                          :password-icon-color colors/neutral-100}
-                :focus   {:border-color        colors/neutral-80-opa-20
-                          :placeholder-color   colors/neutral-80-opa-20
-                          :cursor-color        (get-in colors/customization [:blue 50])
-                          :text-color          colors/neutral-100
-                          :icon-color          colors/neutral-80-opa-70
-                          :password-icon-color colors/neutral-100}
-                :error   {:border-color        colors/danger-opa-40
-                          :placeholder-color   colors/neutral-80-opa-40
-                          :cursor-color        (get-in colors/customization [:blue 50])
-                          :text-color          colors/neutral-100
-                          :icon-color          colors/neutral-80-opa-70
-                          :password-icon-color colors/neutral-100}}
+   :light-blur {:default  {:border-color        colors/neutral-80-opa-10
+                           :placeholder-color   colors/neutral-80-opa-40
+                           :cursor-color        (get-in colors/customization [:blue 50])
+                           :text-color          colors/neutral-100
+                           :icon-color          colors/neutral-80-opa-70
+                           :password-icon-color colors/neutral-100}
+                :focus    {:border-color        colors/neutral-80-opa-20
+                           :placeholder-color   colors/neutral-80-opa-20
+                           :cursor-color        (get-in colors/customization [:blue 50])
+                           :text-color          colors/neutral-100
+                           :icon-color          colors/neutral-80-opa-70
+                           :password-icon-color colors/neutral-100}
+                :error    {:border-color        colors/danger-opa-40
+                           :placeholder-color   colors/neutral-80-opa-40
+                           :cursor-color        (get-in colors/customization [:blue 50])
+                           :text-color          colors/neutral-100
+                           :icon-color          colors/neutral-80-opa-70
+                           :password-icon-color colors/neutral-100}
+
+                :disabled {:border-color        colors/neutral-80-opa-10
+                           :placeholder-color   colors/neutral-80-opa-30
+                           :cursor-color        (get-in colors/customization [:blue 50]) ;; Not used
+                           :text-color          colors/neutral-80-opa-30
+                           :icon-color          colors/neutral-80-opa-70
+                           :password-icon-color colors/neutral-80-opa-70}
+                }
    ;;
-   :dark       {:default {:border-color        colors/neutral-80
-                          :placeholder-color   colors/neutral-50
-                          :cursor-color        (get-in colors/customization [:blue 60])
-                          :text-color          colors/white
-                          :icon-color          colors/neutral-40
-                          :password-icon-color colors/white
-                          }
-                :focus   {:border-color        colors/neutral-60
-                          :placeholder-color   colors/neutral-60
-                          :cursor-color        (get-in colors/customization [:blue 60])
-                          :text-color          colors/white
-                          :icon-color          colors/neutral-40
-                          :password-icon-color colors/white}
-                :error   {:border-color        colors/danger-opa-40
-                          :placeholder-color   colors/white-opa-40
-                          :cursor-color        (get-in colors/customization [:blue 60])
-                          :text-color          colors/white
-                          :icon-color          colors/neutral-40
-                          :password-icon-color colors/white}}
+   :dark       {:default  {:border-color        colors/neutral-80
+                           :placeholder-color   colors/neutral-50
+                           :cursor-color        (get-in colors/customization [:blue 60])
+                           :text-color          colors/white
+                           :icon-color          colors/neutral-40
+                           :password-icon-color colors/white
+                           }
+                :focus    {:border-color        colors/neutral-60
+                           :placeholder-color   colors/neutral-60
+                           :cursor-color        (get-in colors/customization [:blue 60])
+                           :text-color          colors/white
+                           :icon-color          colors/neutral-40
+                           :password-icon-color colors/white}
+                :error    {:border-color        colors/danger-opa-40
+                           :placeholder-color   colors/white-opa-40
+                           :cursor-color        (get-in colors/customization [:blue 60])
+                           :text-color          colors/white
+                           :icon-color          colors/neutral-40
+                           :password-icon-color colors/white}
+
+                :disabled {:border-color        colors/neutral-80
+                           :placeholder-color   colors/neutral-40
+                           :cursor-color        (get-in colors/customization [:blue 50]) ;; Not used
+                           :text-color          colors/neutral-40
+                           :icon-color          colors/neutral-40
+                           :password-icon-color colors/neutral-40}}
    ;;
-   :dark-blur  {:default {:border-color        colors/white-opa-10
-                          :placeholder-color   colors/white-opa-40
-                          :cursor-color        colors/white
-                          :text-color          colors/white
-                          :icon-color          colors/white-opa-70
-                          :password-icon-color colors/white}
-                :focus   {:border-color        colors/white-opa-40
-                          :placeholder-color   colors/white-opa-20
-                          :cursor-color        colors/white
-                          :text-color          colors/white
-                          :icon-color          colors/white-opa-70
-                          :password-icon-color colors/white}
-                :error   {:border-color        colors/danger-opa-40
-                          :placeholder-color   colors/white-opa-40
-                          :cursor-color        colors/white
-                          :text-color          colors/white
-                          :icon-color          colors/white-opa-70
-                          :password-icon-color colors/white}}})
+   :dark-blur  {:default  {:border-color        colors/white-opa-10
+                           :placeholder-color   colors/white-opa-40
+                           :cursor-color        colors/white
+                           :text-color          colors/white
+                           :icon-color          colors/white-opa-70
+                           :password-icon-color colors/white}
+                :focus    {:border-color        colors/white-opa-40
+                           :placeholder-color   colors/white-opa-20
+                           :cursor-color        colors/white
+                           :text-color          colors/white
+                           :icon-color          colors/white-opa-70
+                           :password-icon-color colors/white}
+                :error    {:border-color        colors/danger-opa-40
+                           :placeholder-color   colors/white-opa-40
+                           :cursor-color        colors/white
+                           :text-color          colors/white
+                           :icon-color          colors/white-opa-70
+                           :password-icon-color colors/white}
+
+                :disabled {:border-color        colors/white-opa-10
+                           :placeholder-color   colors/white-opa-20
+                           :cursor-color        (get-in colors/customization [:blue 50]) ;; Not used
+                           :text-color          colors/white-opa-20
+                           :icon-color          colors/white-opa-70
+                           :password-icon-color colors/white-opa-70}
+                }})
 
 (defn input
   [colors-by-status left-icon?]

--- a/src/quo2/components/input/style.cljs
+++ b/src/quo2/components/input/style.cljs
@@ -1,0 +1,39 @@
+(ns quo2.components.input.style
+  (:require [quo2.foundations.colors :as colors]))
+
+(def status-colors
+  {:dark-blur {:default {:border-color      colors/white-opa-10
+                         :placeholder-color colors/white-opa-40
+                         :cursor-color      colors/white}
+               :focus   {:border-color      colors/white-opa-40
+                         :placeholder-color colors/white-opa-20
+                         :cursor-color      colors/white}
+               :error   {:border-color      colors/danger-opa-40
+                         :placeholder-color colors/white-opa-40
+                         :cursor-color      colors/white}}})
+
+(defn input
+  [colors-by-status]
+  {:height           40
+   :border-width     1
+   :border-color     (:border-color colors-by-status)
+   :padding-vertical 9
+   :padding-left     16
+   :padding-right    40
+   :border-radius    14
+   :color            colors/white})
+
+(def right-icon-touchable-area
+  {:position         :absolute
+   :right            0
+   :top              0
+   :bottom           0
+   :width            32
+   :padding-vertical 9
+   :padding-right    12
+   :justify-content  :center
+   :align-items      :center})
+
+(def icon
+  {:color colors/white
+   :size  20})

--- a/src/quo2/components/input/view.cljs
+++ b/src/quo2/components/input/view.cljs
@@ -1,68 +1,73 @@
-(ns quo2.components.input.view
-  (:require [quo2.components.icon :as icon]
-            [quo2.components.input.style :as style]
-            [react-native.core :as rn]
-            [reagent.core :as reagent]))
+  (ns quo2.components.input.view
+    (:require [quo2.components.icon :as icon]
+              [quo2.components.input.style :as style]
+              [react-native.core :as rn]
+              [reagent.core :as reagent]))
 
-(def ^:private custom-props [:type :variant :error :right-icon])
+  (def ^:private custom-props [:type :variant :error :right-icon])
 
-(defn- base-input
-  [_]
-  (let [status (reagent/atom :default)]
-    (fn [{:keys [variant error right-icon left-icon]
-          :or   {variant :dark-blur}
-          :as   props}]
-      (let [colors-by-status (get-in style/status-colors [variant (if error :error @status)])
-            clean-props      (apply dissoc props custom-props)]
-        [rn/view
-         (when-let [{:keys [icon-name]} left-icon]
-           [rn/view {:style {:position        :absolute
-                             :top             10
-                             :bottom          10
-                             :left            12
-                             :justify-content :center
-                             :align-items     :center}}
-            [icon/icon icon-name (style/icon colors-by-status)]])
+  (defn- base-input
+    [_]
+    (let [status (reagent/atom :default)]
+      (fn [{:keys [variant error right-icon left-icon disabled]
+            :or   {variant :dark-blur}
+            :as   props}]
+        (let [color-path       [variant (cond
+                                          disabled :disabled
+                                          error :error
+                                          :else @status)]
+              colors-by-status (get-in style/status-colors color-path)
+              clean-props      (apply dissoc props custom-props)]
+          [rn/view (when disabled {:style {:opacity 0.3}})
+           (when-let [{:keys [icon-name]} left-icon]
+             [rn/view {:style {:position        :absolute
+                               :top             10
+                               :bottom          10
+                               :left            12
+                               :justify-content :center
+                               :align-items     :center}}
+              [icon/icon icon-name (style/icon colors-by-status)]])
 
-         [rn/text-input
-          (merge {:style                  (style/input colors-by-status left-icon)
-                  :placeholder-text-color (:placeholder-color colors-by-status)
-                  :cursor-color           (:cursor-color colors-by-status)
-                  :on-focus               #(reset! status :focus)
-                  :on-blur                #(reset! status :default)}
-                 clean-props)]
+           [rn/text-input
+            (merge {:style                  (style/input colors-by-status left-icon)
+                    :placeholder-text-color (:placeholder-color colors-by-status)
+                    :cursor-color           (:cursor-color colors-by-status)
+                    :editable               (not disabled)
+                    :on-focus               #(reset! status :focus)
+                    :on-blur                #(reset! status :default)}
+                   clean-props)]
 
-         (when-let [{:keys [on-press icon-name]} right-icon]
-           [rn/touchable-opacity
-            {:style    style/right-icon-touchable-area
-             :on-press on-press}
-            [icon/icon icon-name (style/password-icon colors-by-status)]])]))))
+           (when-let [{:keys [on-press icon-name]} right-icon]
+             [rn/touchable-opacity
+              {:style    style/right-icon-touchable-area
+               :on-press on-press}
+              [icon/icon icon-name (style/password-icon colors-by-status)]])]))))
 
-(defn- password-input
-  [_]
-  (let [password-shown? (reagent/atom false)]
-    (fn [props]
-      [base-input
-       (assoc props
-              :auto-capitalize   :none
-              :auto-complete     :new-password
-              :secure-text-entry (not @password-shown?)
-              :right-icon        {:on-press  #(swap! password-shown? not)
-                                  :icon-name (if @password-shown? :i/hide :i/reveal)})])))
+  (defn- password-input
+    [_]
+    (let [password-shown? (reagent/atom false)]
+      (fn [props]
+        [base-input
+         (assoc props
+                :auto-capitalize   :none
+                :auto-complete     :new-password
+                :secure-text-entry (not @password-shown?)
+                :right-icon        {:on-press  #(swap! password-shown? not)
+                                    :icon-name (if @password-shown? :i/hide :i/reveal)})])))
 
-(defn input
-  "{:type      :password
-    :variant   :dark-blur
-    ...
-    & any other TextInput available prop, such as: value, :default-value & :on-change
-    }"
-  [{:keys [type]
-    ; TODO(@ulisesmac): Temp default type, should be removed as the component grows
-    :or   {type :password}
-    :as   props}]
-  (let [props (if (:icon-name props)
-                (assoc-in props [:left-icon :icon-name] (:icon-name props))
-                props)]
-    (if (= type :password)
-      [password-input props]
-      [rn/text "Not implemented"])))
+  (defn input
+    "{:type      :password
+      :variant   :dark-blur
+      ...
+      & any other TextInput available prop, such as: value, :default-value & :on-change
+      }"
+    [{:keys [type]
+      ; TODO(@ulisesmac): Temp default type, should be removed as the component grows
+      :or   {type :password}
+      :as   props}]
+    (let [props (if (:icon-name props)
+                  (assoc-in props [:left-icon :icon-name] (:icon-name props))
+                  props)]
+      (if (= type :password)
+        [password-input props]
+        [rn/text "Not implemented"])))

--- a/src/quo2/components/input/view.cljs
+++ b/src/quo2/components/input/view.cljs
@@ -1,0 +1,55 @@
+(ns quo2.components.input.view
+  (:require [quo2.components.icon :as icon]
+            [quo2.components.input.style :as style]
+            [react-native.core :as rn]
+            [reagent.core :as reagent]))
+
+(def ^:private custom-props [:type :variant :error :right-icon])
+
+(defn- base-input
+  [_]
+  (let [status (reagent/atom :default)]
+    (fn [{:keys [variant error right-icon]
+          :or   {variant :dark-blur}
+          :as   props}]
+      (let [colors-by-status (get-in style/status-colors [variant (if error :error @status)])
+            clean-props      (apply dissoc props custom-props)]
+        [rn/view
+         [rn/text-input
+          (merge {:style                  (style/input colors-by-status)
+                  :placeholder-text-color (:placeholder-color colors-by-status)
+                  :cursor-color           (:cursor-color colors-by-status)
+                  :on-focus               #(reset! status :focus)
+                  :on-blur                #(reset! status :default)}
+                 clean-props)]
+         (when-let [{:keys [on-press icon-name]} right-icon]
+           [rn/touchable-opacity
+            {:style    style/right-icon-touchable-area
+             :on-press on-press}
+            [icon/icon icon-name style/icon]])]))))
+
+(defn- password-input
+  [_]
+  (let [password-shown? (reagent/atom false)]
+    (fn [props]
+      [base-input
+       (assoc props
+              :auto-capitalize   :none
+              :auto-complete     :new-password
+              :secure-text-entry (not @password-shown?)
+              :right-icon        {:on-press  #(swap! password-shown? not)
+                                  :icon-name (if @password-shown? :i/hide :i/reveal)})])))
+
+(defn input
+  "{:type      :password
+    :variant   :dark-blur
+    ...
+    & any other TextInput available prop, such as: value, :default-value & :on-change
+    }"
+  [{:keys [type]
+    ; TODO(@ulisesmac): Temp default type, should be removed as the component grows
+    :or   {type :password}
+    :as   props}]
+  (if (= type :password)
+    [password-input props]
+    [rn/text "Not implemented"]))

--- a/src/quo2/components/input/view.cljs
+++ b/src/quo2/components/input/view.cljs
@@ -26,7 +26,7 @@
            [rn/touchable-opacity
             {:style    style/right-icon-touchable-area
              :on-press on-press}
-            [icon/icon icon-name style/icon]])]))))
+            [icon/icon icon-name (style/icon variant)]])]))))
 
 (defn- password-input
   [_]

--- a/src/quo2/components/input/view.cljs
+++ b/src/quo2/components/input/view.cljs
@@ -9,24 +9,34 @@
 (defn- base-input
   [_]
   (let [status (reagent/atom :default)]
-    (fn [{:keys [variant error right-icon]
+    (fn [{:keys [variant error right-icon left-icon]
           :or   {variant :dark-blur}
           :as   props}]
       (let [colors-by-status (get-in style/status-colors [variant (if error :error @status)])
             clean-props      (apply dissoc props custom-props)]
         [rn/view
+         (when-let [{:keys [icon-name]} left-icon]
+           [rn/view {:style {:position        :absolute
+                             :top             10
+                             :bottom          10
+                             :left            12
+                             :justify-content :center
+                             :align-items     :center}}
+            [icon/icon icon-name (style/icon colors-by-status)]])
+
          [rn/text-input
-          (merge {:style                  (style/input colors-by-status)
+          (merge {:style                  (style/input colors-by-status left-icon)
                   :placeholder-text-color (:placeholder-color colors-by-status)
                   :cursor-color           (:cursor-color colors-by-status)
                   :on-focus               #(reset! status :focus)
                   :on-blur                #(reset! status :default)}
                  clean-props)]
+
          (when-let [{:keys [on-press icon-name]} right-icon]
            [rn/touchable-opacity
             {:style    style/right-icon-touchable-area
              :on-press on-press}
-            [icon/icon icon-name (style/icon variant)]])]))))
+            [icon/icon icon-name (style/password-icon colors-by-status)]])]))))
 
 (defn- password-input
   [_]
@@ -50,6 +60,9 @@
     ; TODO(@ulisesmac): Temp default type, should be removed as the component grows
     :or   {type :password}
     :as   props}]
-  (if (= type :password)
-    [password-input props]
-    [rn/text "Not implemented"]))
+  (let [props (if (:icon-name props)
+                (assoc-in props [:left-icon :icon-name] (:icon-name props))
+                props)]
+    (if (= type :password)
+      [password-input props]
+      [rn/text "Not implemented"])))

--- a/src/quo2/core.cljs
+++ b/src/quo2/core.cljs
@@ -29,6 +29,7 @@
     quo2.components.icon
     quo2.components.info.info-message
     quo2.components.info.information-box
+    quo2.components.input.view
     quo2.components.list-items.channel
     quo2.components.list-items.menu-item
     quo2.components.list-items.preview-list
@@ -136,6 +137,9 @@
 (def action-drawer quo2.components.drawers.action-drawers.view/action-drawer)
 (def drawer-buttons quo2.components.drawers.drawer-buttons.view/view)
 (def permission-context quo2.components.drawers.permission-context.view/view)
+
+;;;; INPUTS
+(def input quo2.components.input.view/input)
 
 ;;;; LIST ITEMS
 (def channel-list-item quo2.components.list-items.channel/list-item)

--- a/src/quo2/foundations/colors.cljs
+++ b/src/quo2/foundations/colors.cljs
@@ -60,6 +60,7 @@
 
 ;;Blur
 (def neutral-5-opa-70 (alpha neutral-5 0.7))
+(def neutral-80-blur-opa-80 "rgba(25,36,56,0.8)")
 (def neutral-90-opa-70 (alpha neutral-90 0.7))
 
 ;;80 with transparency
@@ -152,6 +153,10 @@
 (def success-60-opa-40 (alpha success-60 0.4))
 
 ;;;;Danger
+(def danger "#E95460")
+
+;; Danger with transparency
+(def danger-opa-40 (alpha danger 0.4))
 
 ;;Solid
 (def danger-50 "#E65F5C")

--- a/src/status_im2/contexts/quo_preview/inputs/input.cljs
+++ b/src/status_im2/contexts/quo_preview/inputs/input.cljs
@@ -35,6 +35,10 @@
                :value "Placeholder icon"}
               {:key   :i/email
                :value "Email icon"}]}
+
+   {:label "Disabled:"
+    :key   :disabled
+    :type  :boolean}
    ]
   )
 
@@ -55,9 +59,9 @@
                   :align-items      :center
                   :padding-vertical 60
                   :background-color (case (:variant @state)
-                                      :dark-blur colors/neutral-80-blur-opa-80
+                                      :dark-blur "rgba(39, 61, 81, 1)"
                                       :dark colors/neutral-95
-                                      :light-blur "#deef"
+                                      :light-blur "#EBF8F8FF"
                                       :white)}}
          [rn/view {:style {:width 288}}
           [quo2/input @state]]]]])))

--- a/src/status_im2/contexts/quo_preview/inputs/input.cljs
+++ b/src/status_im2/contexts/quo_preview/inputs/input.cljs
@@ -27,15 +27,24 @@
     :key   :error
     :type  :boolean}
    ;;
+
+   {:label   "Icon:"
+    :key     :icon-name
+    :type    :select
+    :options [{:key   :i/placeholder
+               :value "Placeholder icon"}
+              {:key   :i/email
+               :value "Email icon"}]}
    ]
   )
 
 (defn cool-preview
   []
   (let [state (reagent/atom {:type        :password
-                             :variant     :light-blur
+                             :variant     :dark
                              :placeholder "Type something"
-                             :error       false})]
+                             :error       false
+                             :icon-name   :i/placeholder})]
     (fn []
       [rn/touchable-without-feedback {:on-press rn/dismiss-keyboard!}
        [rn/view {:style {:padding-bottom 150}}
@@ -48,7 +57,8 @@
                   :background-color (case (:variant @state)
                                       :dark-blur colors/neutral-80-blur-opa-80
                                       :dark colors/neutral-95
-                                      :transparent)}}
+                                      :light-blur "#deef"
+                                      :white)}}
          [rn/view {:style {:width 288}}
           [quo2/input @state]]]]])))
 

--- a/src/status_im2/contexts/quo_preview/inputs/input.cljs
+++ b/src/status_im2/contexts/quo_preview/inputs/input.cljs
@@ -1,0 +1,51 @@
+(ns status-im2.contexts.quo-preview.inputs.input
+  (:require [quo2.components.input.view :as quo2]
+            [quo2.foundations.colors :as colors]
+            [react-native.core :as rn]
+            [reagent.core :as reagent]
+            [status-im2.contexts.quo-preview.preview :as preview]))
+
+(def descriptor
+  [{:label   "Type:"
+    :key     :type
+    :type    :select
+    :options [{:key   :password
+               :value "Password"}]}
+   {:label   "Variant:"
+    :key     :variant
+    :type    :select
+    :options [{:key   :dark-blur
+               :value "Dark blur"}]}
+   {:label "Error:"
+    :key   :error
+    :type  :boolean}])
+
+(defn cool-preview
+  []
+  (let [state (reagent/atom {:type        :password
+                             :variant     :dark-blur
+                             :placeholder "Type something"
+                             :error       false})]
+    (fn []
+      [rn/touchable-without-feedback {:on-press rn/dismiss-keyboard!}
+       [rn/view {:style {:padding-bottom 150}}
+        [rn/view {:style {:flex 1}}
+         [preview/customizer state descriptor]]
+        [rn/view
+         {:style {:flex             1
+                  :align-items      :center
+                  :padding-vertical 60
+                  :background-color colors/neutral-80-blur-opa-80}}
+         [rn/view {:style {:width 288}}
+          [quo2/input @state]]]]])))
+
+(defn preview-input
+  []
+  [rn/view
+   {:style {:background-color (colors/theme-colors colors/white colors/neutral-90)
+            :flex             1}}
+   [rn/flat-list
+    {:style                     {:flex 1}
+     :keyboardShouldPersistTaps :always
+     :header                    [cool-preview]
+     :key-fn                    str}]])

--- a/src/status_im2/contexts/quo_preview/inputs/input.cljs
+++ b/src/status_im2/contexts/quo_preview/inputs/input.cljs
@@ -14,16 +14,26 @@
    {:label   "Variant:"
     :key     :variant
     :type    :select
-    :options [{:key   :dark-blur
+    :options [{:key   :light
+               :value "Light"}
+              {:key   :dark
+               :value "Dark"}
+              {:key   :light-blur
+               :value "Light blur"}
+              {:key   :dark-blur
                :value "Dark blur"}]}
+   ;;
    {:label "Error:"
     :key   :error
-    :type  :boolean}])
+    :type  :boolean}
+   ;;
+   ]
+  )
 
 (defn cool-preview
   []
   (let [state (reagent/atom {:type        :password
-                             :variant     :dark-blur
+                             :variant     :light-blur
                              :placeholder "Type something"
                              :error       false})]
     (fn []
@@ -35,7 +45,10 @@
          {:style {:flex             1
                   :align-items      :center
                   :padding-vertical 60
-                  :background-color colors/neutral-80-blur-opa-80}}
+                  :background-color (case (:variant @state)
+                                      :dark-blur colors/neutral-80-blur-opa-80
+                                      :dark colors/neutral-95
+                                      :transparent)}}
          [rn/view {:style {:width 288}}
           [quo2/input @state]]]]])))
 

--- a/src/status_im2/contexts/quo_preview/main.cljs
+++ b/src/status_im2/contexts/quo_preview/main.cljs
@@ -71,6 +71,7 @@
     [status-im2.contexts.quo-preview.tags.status-tags :as status-tags]
     [status-im2.contexts.quo-preview.tags.tags :as tags]
     [status-im2.contexts.quo-preview.tags.token-tag :as token-tag]
+    [status-im2.contexts.quo-preview.inputs.input :as input]
     [status-im2.contexts.quo-preview.wallet.lowest-price :as lowest-price]
     [status-im2.contexts.quo-preview.wallet.network-amount :as network-amount]
     [status-im2.contexts.quo-preview.wallet.network-breakdown :as network-breakdown]
@@ -161,6 +162,9 @@
                            {:name      :information-box
                             :insets    {:top false}
                             :component information-box/preview-information-box}]
+   :inputs                [{:name      :input
+                            :insets    {:top false}
+                            :component input/preview-input}]
    :list-items            [{:name      :channel
                             :insets    {:top false}
                             :component channel/preview-channel}


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes #15025 

### Summary

[comment]: # (Summarise the problem and how the pull request solves it)
Implements [the new input component](https://www.figma.com/file/WQZcp6S0EnzxdTL4taoKDv/Design-System-for-Mobile?node-id=3560%3A72848&t=FnvCIFbD8J7nYZZk-4) in all of its variants, including the [multiline one](https://www.figma.com/file/eDfxTa9IoaCMUy5cLTp0ys/Shell-for-Mobile?node-id=3804%3A822914&t=LIa1oLVcfu0WCsYL-4).

![image](https://user-images.githubusercontent.com/90291778/222537493-8c49836c-6864-4ba1-b18d-ee8df726eb5d.png)
![image](https://user-images.githubusercontent.com/90291778/222537398-24cfe060-3819-4397-8f37-ca01b5b96fe3.png)
![image](https://user-images.githubusercontent.com/90291778/222537694-9bfc659a-ac06-47c1-a7a5-d13986cb2eb4.png)
![image](https://user-images.githubusercontent.com/90291778/222538593-8d830bd0-1bb5-45cc-a55e-2d638f8d18e2.png)

### Review notes

### Found issues

#### Cursor color on iOS:
The React Native TextInput component only allows to set the cursor color for Android: https://reactnative.dev/docs/textinput#cursorcolor-android - I'm using this feature for this PR.

To set the cursor color on iOS we could use the `selectionColor` property: https://reactnative.dev/docs/textinput#selectioncolor

The problem with that feature is the designs specify a **white font** and a **white cursor**, if we set a **white selection** then we will be unable to see the text selected (it looks just as a white block).

#### Clear() function
To implement the `clearable` behavior first I tried using the [`clear()` method](https://reactnative.dev/docs/0.69/textinput#clear) but the problem is when that method is called, it doesn't trigger the `on-change-text` callback :( , instead, I decided to receive an `:on-clear` function for the user to specify what  should happen when the button is pressed.

#### Clear icon
The clear Icon we have is the following:
![image](https://user-images.githubusercontent.com/90291778/222539986-7249567b-5253-4237-a3f8-e386c2f3160a.png)

But when used in the views and a color is assigned, it looks as follows:
![image](https://user-images.githubusercontent.com/90291778/222540076-b1ea142a-b817-49d2-a142-37e5679414ee.png) ![image](https://user-images.githubusercontent.com/90291778/222540108-2064d539-8147-43d1-b730-b4dbe0e6bbf2.png) ![image](https://user-images.githubusercontent.com/90291778/222540155-395ea783-95a5-4113-84ab-f3bbc615100c.png) ![image](https://user-images.githubusercontent.com/90291778/222540182-e3ed6cbe-9587-46e9-a7d6-d2570687af2a.png)

Why is the `X` not showing? What should I do to show it?

#### Multiline variant
The problem with this variant is it "auto-controls" its height, so:
- If I set the height, the input won't grow as new lines are added
- If I don't set the height, the input when there's just one line, will have a greater height as expected by designs

The solution I found is to set the height **only** when the input has one line, if there's more than one line, let the input to automatically manage its height, to achieve this I'm using the [onContentSizeChange callback](https://reactnative.dev/docs/0.69/textinput#oncontentsizechange), but there's still a small problem, when I pass from controlled height to uncontrolled height, the text's input is moved.

Please [watch this video](https://user-images.githubusercontent.com/90291778/222542631-81c45824-44ce-470c-98d0-190006d4cbd6.webm)



### Testing notes

#### Platforms
- Android
- iOS

### Steps to test

- Open Status
- Go to Quo2.0 Preview -> Inputs -> input
- Test the component by writing on it, you also be able to show or hide the password by tapping the icon

status: ready
