### PR TITLE
Add account page: fixed button style, fixed input reappearing

### DIFF
--- a/src/quo2/components/buttons/button.cljs
+++ b/src/quo2/components/buttons/button.cljs
@@ -254,7 +254,7 @@
                    (shape-style-container type icon size)
                    {:background-color
                     (if (= state :pressed)
-                      (colors/theme-colors colors/neutral-100 colors/white)
+                      (colors/theme-colors colors/white colors/neutral-100)
                       :transparent)
                     :width width}
                    style)}

--- a/src/status_im2/contexts/add_new_contact/events.cljs
+++ b/src/status_im2/contexts/add_new_contact/events.cljs
@@ -90,21 +90,25 @@
 (rf/defn set-new-identity-success
   {:events [:contacts/set-new-identity-success]}
   [{:keys [db]} input ens-name pubkey]
-  {:db (assoc db
-              :contacts/new-identity
-              {:input      input
-               :public-key pubkey
-               :ens-name   ens-name
-               :state      :valid})})
+  (let [current-input (get-in db [:contacts/new-identity :input])]
+    (when (= current-input input)
+      {:db (assoc db
+                  :contacts/new-identity
+                  {:input      input
+                   :public-key pubkey
+                   :ens-name   ens-name
+                   :state      :valid})})))
 
 (rf/defn set-new-identity-error
   {:events [:contacts/set-new-identity-error]}
   [{:keys [db]} error input]
-  {:db (assoc db
-              :contacts/new-identity
-              {:input input
-               :state :error
-               :error :invalid})})
+  (let [current-input (get-in db [:contacts/new-identity :input])]
+    (when (= current-input input)
+      {:db (assoc db
+                  :contacts/new-identity
+                  {:input input
+                   :state :error
+                   :error :invalid})})))
 
 (rf/defn clear-new-identity
   {:events [:contacts/clear-new-identity :contacts/new-chat-focus]}


### PR DESCRIPTION
fixes #15146

### Summary

- Fixed button style
- Fixed input reappearing after deletion

### Review notes
The issue with reappearing deleted text was tied to the late arrival of events, signaling that address can or can't be successfully understood as identity. 
For example user typed "a" and then removed it, leaving the text field blank. In a bad scenario last two events will be:
- `:contacts/set-new-identity`, that make new identity field empty
- `:contacts/set-new-identity-error`, that delivers late processing of "a" as an incorrect identity and returns identity field to "a" state.
To avoid this, `set-new-identity-error` and `set-new-identity-success` event handlers were updated to ensure they related to latest value of identity field.


status: ready
