### PR TITLE
nix: fix Gradle nodeps JAR symlink filename

### DIFF
--- a/nix/deps/gradle/default.nix
+++ b/nix/deps/gradle/default.nix
@@ -60,7 +60,7 @@ let
         echo "${jar.sha1}" > "${dep.path}.${dep.type}.sha1"
         ''}
         ${optionalString (nodeps-download != "") ''
-        ln -s "${nodeps-download}" "${dep.path}.${dep.type}"
+        ln -s "${nodeps-download}" "${dep.path}-nodeps.jar"
         ''}
         ${optionalString (nodeps.sha1 != "") ''
         echo "${nodeps.sha1}" > "${dep.path}.${dep.type}.sha1"


### PR DESCRIPTION
Introduced in:

* https://github.com/status-im/status-mobile/pull/15212

Not breaking anything YET, but will when RN upgrade will be merged.

This whole derivation needs refactoring, but that's not the highest priority right now.