### PR TITLE
[#15210] Show user avatar in contact request toast

### DIFF
--- a/src/quo2/components/notifications/toast/view.cljs
+++ b/src/quo2/components/notifications/toast/view.cljs
@@ -1,5 +1,6 @@
 (ns quo2.components.notifications.toast.view
-  (:require [quo2.components.icon :as icon]
+  (:require [quo2.components.avatars.user-avatar.view :as user-avatar]
+            [quo2.components.icon :as icon]
             [quo2.components.markdown.text :as text]
             [quo2.components.notifications.count-down-circle :as count-down-circle]
             [quo2.components.notifications.toast.style :as style]
@@ -60,13 +61,16 @@
 
 (defn toast
   [{:keys [icon icon-color title text action undo-duration undo-on-press container-style
-           override-theme]}]
+           override-theme user]}]
   [toast-container
-   {:left            (when icon
-                       [icon/icon icon
-                        (cond-> (style/icon override-theme)
-                          icon-color
-                          (assoc :color icon-color))])
+   {:left            (cond icon
+                           [icon/icon icon
+                            (cond-> (style/icon override-theme)
+                              icon-color
+                              (assoc :color icon-color))]
+
+                           user
+                           [user-avatar/user-avatar user])
     :title           title
     :text            text
     :right           (if undo-duration


### PR DESCRIPTION
fix for #15210 
<img width="296" alt="Screenshot 2023-02-28 at 14 09 10" src="https://user-images.githubusercontent.com/2364994/222119792-350ad5de-c184-42bf-b34c-9066178b07f8.png">


It looks a bit ugly because (probably) `user-avatar` component is not fully implemented.

status: ready