### PR TITLE
Make popover delay configurable

### DIFF
--- a/src/status_im/popover/core.cljs
+++ b/src/status_im/popover/core.cljs
@@ -4,10 +4,14 @@
 (rf/defn show-popover
   {:events [:show-popover]}
   [_ value]
-  {:show-popover     nil
-   ;;TODO refactor popover just start animation on mount
-   :dispatch-later   [{:ms 250 :dispatch [:show-popover-db value]}]
-   :dismiss-keyboard nil})
+  (let [delay-ms (or (:delay-ms value) 250)
+        value    (dissoc value :delay-ms)]
+    {:show-popover     nil
+     ;; We should probably refactor to start the animation on mount, so that the
+     ;; delay can be removed. See comment for more details:
+     ;; https://github.com/status-im/status-mobile/pull/15222#issuecomment-1450162137
+     :dispatch-later   [{:ms delay-ms :dispatch [:show-popover-db value]}]
+     :dismiss-keyboard nil}))
 
 (rf/defn show-popover-db
   {:events [:show-popover-db]}

--- a/src/status_im2/contexts/activity_center/events.cljs
+++ b/src/status_im2/contexts/activity_center/events.cljs
@@ -33,6 +33,7 @@
    :dispatch [:show-popover
               {:view                       :activity-center
                :style                      {:margin 0}
+               :delay-ms                   30
                :disable-touchable-overlay? true
                :blur-view?                 true
                :blur-view-props            {:blur-amount 20

--- a/src/status_im2/contexts/activity_center/events.cljs
+++ b/src/status_im2/contexts/activity_center/events.cljs
@@ -33,7 +33,7 @@
    :dispatch [:show-popover
               {:view                       :activity-center
                :style                      {:margin 0}
-               :delay-ms                   30
+               :delay-ms                   50
                :disable-touchable-overlay? true
                :blur-view?                 true
                :blur-view-props            {:blur-amount 20


### PR DESCRIPTION
### Summary

Make the popover delay in milliseconds configurable.

To open the Activity Center, 30ms delay seems to be more than enough. It's a quick fix because the current 250ms to open the AC gives the wrong impression to users (and confuses even us developers) who think the AC has a performance issue to open.

See issue https://github.com/status-im/status-mobile/pull/15222 for the full discussion.

Thanks @flexsurfer and @OmarBasem for commenting about this delay in other PRs.

### Any negative impact?

Nope, it should be quite safe to merge, but I'll request a quick review from QA so they can check in iOS.

### Testing notes

1. Open the AC with at least one notification, and check that the AC opens correctly at all times.

status: ready
