### PR TITLE
fix root id of :init-root-fx

### DIFF
--- a/src/status_im2/navigation/core.cljs
+++ b/src/status_im2/navigation/core.cljs
@@ -189,10 +189,11 @@
 (re-frame/reg-fx
  :init-root-fx
  (fn [new-root-id]
-   (log/debug :init-root-fx new-root-id)
-   (dismiss-all-modals)
-   (reset! state/root-id new-root-id)
-   (navigation/set-root (get (roots/roots) new-root-id))))
+   (let [root (get (roots/roots) new-root-id)]
+     (log/debug :init-root-fx new-root-id)
+     (dismiss-all-modals)
+     (reset! state/root-id (or (get-in root [:root :stack :id]) new-root-id))
+     (navigation/set-root root))))
 
 (rf/defn set-multiaccount-root
   {:events [::set-multiaccount-root]}


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/15227

### Summary
root-id provided to `init-root-fx` is not root id of stack, it just map key where root is stored.
In some cases like for keycard account we have different root-id then the map key

![image](https://user-images.githubusercontent.com/17097240/222344773-9de97182-5d62-4d40-b1ab-aedc45adc48a.png)

Before https://github.com/status-im/status-mobile/pull/15196 we had another event `init-root-with-component` where we just passed this root-id separately.


status: ready