### PR TITLE
Fix freeze to open AC

### DIFF
--- a/src/status_im2/contexts/activity_center/events.cljs
+++ b/src/status_im2/contexts/activity_center/events.cljs
@@ -33,7 +33,6 @@
    :dispatch [:show-popover
               {:view                       :activity-center
                :style                      {:margin 0}
-               :delay-ms                   50
                :disable-touchable-overlay? true
                :blur-view?                 true
                :blur-view-props            {:blur-amount 20


### PR DESCRIPTION
Fixes #15230

For reference, see also PR https://github.com/status-im/status-mobile/pull/15225, which introduced the supposed "improvement", but actually caused a regression. There's a discussion around rewriting the popover so we don't need a hardcoded delay of 250ms.