### PR TITLE
[#15045] - Refactor user-avatar and add tests

### DIFF
--- a/src/quo2/components/avatars/user_avatar/component_spec.cljs
+++ b/src/quo2/components/avatars/user_avatar/component_spec.cljs
@@ -4,33 +4,25 @@
 
 (defonce mock-picture (js/require "../resources/images/mock2/user_picture_male4.png"))
 
-(defn- is-truthy
-  [element]
-  (.toBeTruthy (js/expect element)))
-
-(defn- is-null
-  [element]
-  (.toBeNull (js/expect element)))
-
 (h/describe "user avatar"
   (h/test "Default render"
     (h/render [user-avatar/user-avatar])
-    (is-truthy (h/get-by-label-text :user-avatar))
-    (is-truthy (h/get-by-text "EN")))
+    (h/is-truthy (h/get-by-label-text :user-avatar))
+    (h/is-truthy (h/get-by-text "EN")))
 
   (h/describe "Profile picture"
     (h/test "Renders"
       (h/render
        [user-avatar/user-avatar {:profile-picture mock-picture}])
-      (is-truthy (h/get-by-label-text :profile-picture)))
+      (h/is-truthy (h/get-by-label-text :profile-picture)))
 
     (h/test "Renders even if `:full-name` is passed"
       (h/render
        [user-avatar/user-avatar
         {:profile-picture mock-picture
          :full-name       "New User1"}])
-      (is-truthy (h/get-by-label-text :profile-picture))
-      (is-null (h/query-by-label-text :initials-avatar)))
+      (h/is-truthy (h/get-by-label-text :profile-picture))
+      (h/is-null (h/query-by-label-text :initials-avatar)))
 
     (h/describe "Status indicator"
       (h/test "Render"
@@ -38,16 +30,16 @@
          [user-avatar/user-avatar
           {:profile-picture   mock-picture
            :status-indicator? true}])
-        (is-truthy (h/get-by-label-text :profile-picture))
-        (is-truthy (h/get-by-label-text :status-indicator)))
+        (h/is-truthy (h/get-by-label-text :profile-picture))
+        (h/is-truthy (h/get-by-label-text :status-indicator)))
 
       (h/test "Do not render"
         (h/render
          [user-avatar/user-avatar
           {:profile-picture   mock-picture
            :status-indicator? false}])
-        (is-truthy (h/get-by-label-text :profile-picture))
-        (is-null (h/query-by-label-text :status-indicator)))))
+        (h/is-truthy (h/get-by-label-text :profile-picture))
+        (h/is-null (h/query-by-label-text :status-indicator)))))
 
   (h/describe "Initials Avatar"
     (h/describe "Render initials"
@@ -58,28 +50,28 @@
         (h/describe "Two letters"
           (h/test "Size :big"
             (h/render (user-avatar-component :big))
-            (is-truthy (h/get-by-text "NU")))
+            (h/is-truthy (h/get-by-text "NU")))
 
           (h/test "Size :medium"
             (h/render (user-avatar-component :medium))
-            (is-truthy (h/get-by-text "NU")))
+            (h/is-truthy (h/get-by-text "NU")))
 
           (h/test "Size :small"
             (h/render (user-avatar-component :small))
-            (is-truthy (h/get-by-text "NU"))))
+            (h/is-truthy (h/get-by-text "NU"))))
 
         (h/describe "One letter"
           (h/test "Size :xs"
             (h/render (user-avatar-component :xs))
-            (is-truthy (h/get-by-text "N")))
+            (h/is-truthy (h/get-by-text "N")))
 
           (h/test "Size :xxs"
             (h/render (user-avatar-component :xxs))
-            (is-truthy (h/get-by-text "N")))
+            (h/is-truthy (h/get-by-text "N")))
 
           (h/test "Size :xxxs"
             (h/render (user-avatar-component :xxxs))
-            (is-truthy (h/get-by-text "N"))))))
+            (h/is-truthy (h/get-by-text "N"))))))
 
     (h/describe "Render ring"
       (letfn [(user-avatar-component [size]
@@ -90,34 +82,34 @@
         (h/describe "Passed and drawn"
           (h/test "Size :big"
             (h/render (user-avatar-component :big))
-            (is-truthy (h/get-by-label-text :initials-avatar))
-            (is-truthy (h/get-by-label-text :ring-background)))
+            (h/is-truthy (h/get-by-label-text :initials-avatar))
+            (h/is-truthy (h/get-by-label-text :ring-background)))
 
           (h/test "Size :medium"
             (h/render (user-avatar-component :medium))
-            (is-truthy (h/get-by-label-text :initials-avatar))
-            (is-truthy (h/get-by-label-text :ring-background)))
+            (h/is-truthy (h/get-by-label-text :initials-avatar))
+            (h/is-truthy (h/get-by-label-text :ring-background)))
 
           (h/test "Size :small"
             (h/render (user-avatar-component :small))
-            (is-truthy (h/get-by-label-text :initials-avatar))
-            (is-truthy (h/get-by-label-text :ring-background))))
+            (h/is-truthy (h/get-by-label-text :initials-avatar))
+            (h/is-truthy (h/get-by-label-text :ring-background))))
 
         (h/describe "Passed and not drawn (because of invalid size for ring)"
           (h/test "Size :xs"
             (h/render (user-avatar-component :xs))
-            (is-truthy (h/get-by-label-text :initials-avatar))
-            (is-null (h/query-by-label-text :ring-background)))
+            (h/is-truthy (h/get-by-label-text :initials-avatar))
+            (h/is-null (h/query-by-label-text :ring-background)))
 
           (h/test "Size :xxs"
             (h/render (user-avatar-component :xxs))
-            (is-truthy (h/get-by-label-text :initials-avatar))
-            (is-null (h/query-by-label-text :ring-background)))
+            (h/is-truthy (h/get-by-label-text :initials-avatar))
+            (h/is-null (h/query-by-label-text :ring-background)))
 
           (h/test "Size :xxxs"
             (h/render (user-avatar-component :xxxs))
-            (is-truthy (h/get-by-label-text :initials-avatar))
-            (is-null (h/query-by-label-text :ring-background))))))
+            (h/is-truthy (h/get-by-label-text :initials-avatar))
+            (h/is-null (h/query-by-label-text :ring-background))))))
 
     (h/describe "Status indicator"
       (h/test "Render"
@@ -125,13 +117,13 @@
          [user-avatar/user-avatar
           {:full-name         "Test User"
            :status-indicator? true}])
-        (is-truthy (h/get-by-label-text :initials-avatar))
-        (is-truthy (h/get-by-label-text :status-indicator)))
+        (h/is-truthy (h/get-by-label-text :initials-avatar))
+        (h/is-truthy (h/get-by-label-text :status-indicator)))
 
       (h/test "Do not render"
         (h/render
          [user-avatar/user-avatar
           {:full-name         "Test User"
            :status-indicator? false}])
-        (is-truthy (h/get-by-label-text :initials-avatar))
-        (is-null (h/query-by-label-text :status-indicator))))))
+        (h/is-truthy (h/get-by-label-text :initials-avatar))
+        (h/is-null (h/query-by-label-text :status-indicator))))))

--- a/src/quo2/components/avatars/user_avatar/component_spec.cljs
+++ b/src/quo2/components/avatars/user_avatar/component_spec.cljs
@@ -1,26 +1,127 @@
 (ns quo2.components.avatars.user-avatar.component-spec
-  (:require  [quo2.components.avatars.user-avatar.view :as user-avatar]
-             [test-helpers.component :as h]))
+  (:require [quo2.components.avatars.user-avatar.view :as user-avatar]
+            [status-im2.common.resources :as resources]
+            [test-helpers.component :as h]))
 
+(defn- test-truthy [element]
+  (.toBeTruthy (js/expect element)))
 
-
-(js/jest.mock "react-native-fast-image" (fn []
-                                          (fn [props] props.source.uri)))
-
+(defn- test-null [element]
+  (.toBeNull (js/expect element)))
 
 (h/describe "user avatar"
-            (h/test "it tests the default render"
-                    (h/render [user-avatar/user-avatar])
-                    (-> (js/expect (h/get-by-text "EN"))
-                        (.toBeTruthy)))
+  (h/test "Default render"
+    (h/render [user-avatar/user-avatar])
+    (test-truthy (h/get-by-label-text :user-avatar))
+    (test-truthy (h/get-by-text "EN")))
 
-            (h/test "it tests using a different name "
-                    (h/render [user-avatar/user-avatar {:full-name "Test User"}])
-                    (-> (js/expect (h/get-by-text "TU"))
-                        (.toBeTruthy)))
+  (h/describe "Profile picture"
+    (h/test "Renders"
+      (h/render
+       [user-avatar/user-avatar {:profile-picture (resources/get-mock-image :user-picture-male4)}])
+      (test-truthy (h/get-by-label-text :profile-picture)))
 
-            (h/test "it tests using a custom picture "
-                    (h/render [user-avatar/user-avatar {:full-name "Test User"
-                                                        :profile-picture "some mock uri"}])
-                    (-> (js/expect (h/find-by-text "some mock uri"))
-                        (.toBeTruthy))))
+    (h/test "Renders even if `:full-name` is passed"
+      (h/render
+       [user-avatar/user-avatar {:profile-picture (resources/get-mock-image :user-picture-male4)
+                                 :full-name       "New User1"}])
+      (test-truthy (h/get-by-label-text :profile-picture))
+      (test-null (h/query-by-label-text :initials-avatar)))
+
+    (h/describe "Status indicator"
+      (h/test "Render"
+        (h/render
+         [user-avatar/user-avatar {:profile-picture   (resources/get-mock-image :user-picture-male4)
+                                   :status-indicator? true}])
+        (test-truthy (h/get-by-label-text :profile-picture))
+        (test-truthy (h/get-by-label-text :status-indicator)))
+
+      (h/test "Do not render"
+        (h/render
+         [user-avatar/user-avatar {:profile-picture   (resources/get-mock-image :user-picture-male4)
+                                   :status-indicator? false}])
+        (test-truthy (h/get-by-label-text :profile-picture))
+        (test-null (h/query-by-label-text :status-indicator)))))
+
+  (h/describe "Initials Avatar"
+    (h/describe "Render initials"
+      (letfn [(user-avatar-component [size]
+                [user-avatar/user-avatar {:full-name "New User"
+                                          :size      size}])]
+        (h/describe "Two letters"
+          (h/test "Size :big"
+            (h/render (user-avatar-component :big))
+            (test-truthy (h/get-by-text "NU")))
+
+          (h/test "Size :medium"
+            (h/render (user-avatar-component :medium))
+            (test-truthy (h/get-by-text "NU")))
+
+          (h/test "Size :small"
+            (h/render (user-avatar-component :small))
+            (test-truthy (h/get-by-text "NU"))))
+
+        (h/describe "One letter"
+          (h/test "Size :xs"
+            (h/render (user-avatar-component :xs))
+            (test-truthy (h/get-by-text "N")))
+
+          (h/test "Size :xxs"
+            (h/render (user-avatar-component :xxs))
+            (test-truthy (h/get-by-text "N")))
+
+          (h/test "Size :xxxs"
+            (h/render (user-avatar-component :xxxs))
+            (test-truthy (h/get-by-text "N"))))))
+
+    (h/describe "Render ring"
+      (letfn [(user-avatar-component [size]
+                [user-avatar/user-avatar {:full-name       "New User"
+                                          :ring-background (resources/get-mock-image :ring)
+                                          :size            size}])]
+        (h/describe "Passed and drawn"
+          (h/test "Size :big"
+            (h/render (user-avatar-component :big))
+            (test-truthy (h/get-by-label-text :initials-avatar))
+            (test-truthy (h/get-by-label-text :ring-background)))
+
+          (h/test "Size :medium"
+            (h/render (user-avatar-component :medium))
+            (test-truthy (h/get-by-label-text :initials-avatar))
+            (test-truthy (h/get-by-label-text :ring-background)))
+
+          (h/test "Size :small"
+            (h/render (user-avatar-component :small))
+            (test-truthy (h/get-by-label-text :initials-avatar))
+            (test-truthy (h/get-by-label-text :ring-background))))
+
+        (h/describe "Passed and not drawn (because of invalid size for ring)"
+          (h/test "Size :xs"
+            (h/render (user-avatar-component :xs))
+            (test-truthy (h/get-by-label-text :initials-avatar))
+            (test-null (h/query-by-label-text :ring-background)))
+
+          (h/test "Size :xxs"
+            (h/render (user-avatar-component :xxs))
+            (test-truthy (h/get-by-label-text :initials-avatar))
+            (test-null (h/query-by-label-text :ring-background)))
+
+          (h/test "Size :xxxs"
+            (h/render (user-avatar-component :xxxs))
+            (test-truthy (h/get-by-label-text :initials-avatar))
+            (test-null (h/query-by-label-text :ring-background))))))
+
+    (h/describe "Status indicator"
+      (h/test "Render"
+        (h/render
+         [user-avatar/user-avatar {:full-name         "Test User"
+                                   :status-indicator? true}])
+        (test-truthy (h/get-by-label-text :initials-avatar))
+        (test-truthy (h/get-by-label-text :status-indicator)))
+
+      (h/test "Do not render"
+        (h/render
+         [user-avatar/user-avatar {:full-name         "Test User"
+                                   :status-indicator? false}])
+        (test-truthy (h/get-by-label-text :initials-avatar))
+        (test-null (h/query-by-label-text :status-indicator))))))

--- a/src/quo2/components/avatars/user_avatar/component_spec.cljs
+++ b/src/quo2/components/avatars/user_avatar/component_spec.cljs
@@ -4,10 +4,12 @@
 
 (defonce mock-picture (js/require "../resources/images/mock2/user_picture_male4.png"))
 
-(defn- test-truthy [element]
+(defn- test-truthy
+  [element]
   (.toBeTruthy (js/expect element)))
 
-(defn- test-null [element]
+(defn- test-null
+  [element]
   (.toBeNull (js/expect element)))
 
 (h/describe "user avatar"
@@ -24,31 +26,35 @@
 
     (h/test "Renders even if `:full-name` is passed"
       (h/render
-       [user-avatar/user-avatar {:profile-picture mock-picture
-                                 :full-name       "New User1"}])
+       [user-avatar/user-avatar
+        {:profile-picture mock-picture
+         :full-name       "New User1"}])
       (test-truthy (h/get-by-label-text :profile-picture))
       (test-null (h/query-by-label-text :initials-avatar)))
 
     (h/describe "Status indicator"
       (h/test "Render"
         (h/render
-         [user-avatar/user-avatar {:profile-picture   mock-picture
-                                   :status-indicator? true}])
+         [user-avatar/user-avatar
+          {:profile-picture   mock-picture
+           :status-indicator? true}])
         (test-truthy (h/get-by-label-text :profile-picture))
         (test-truthy (h/get-by-label-text :status-indicator)))
 
       (h/test "Do not render"
         (h/render
-         [user-avatar/user-avatar {:profile-picture   mock-picture
-                                   :status-indicator? false}])
+         [user-avatar/user-avatar
+          {:profile-picture   mock-picture
+           :status-indicator? false}])
         (test-truthy (h/get-by-label-text :profile-picture))
         (test-null (h/query-by-label-text :status-indicator)))))
 
   (h/describe "Initials Avatar"
     (h/describe "Render initials"
       (letfn [(user-avatar-component [size]
-                [user-avatar/user-avatar {:full-name "New User"
-                                          :size      size}])]
+                [user-avatar/user-avatar
+                 {:full-name "New User"
+                  :size      size}])]
         (h/describe "Two letters"
           (h/test "Size :big"
             (h/render (user-avatar-component :big))
@@ -77,9 +83,10 @@
 
     (h/describe "Render ring"
       (letfn [(user-avatar-component [size]
-                [user-avatar/user-avatar {:full-name       "New User"
-                                          :ring-background mock-picture
-                                          :size            size}])]
+                [user-avatar/user-avatar
+                 {:full-name       "New User"
+                  :ring-background mock-picture
+                  :size            size}])]
         (h/describe "Passed and drawn"
           (h/test "Size :big"
             (h/render (user-avatar-component :big))
@@ -115,14 +122,16 @@
     (h/describe "Status indicator"
       (h/test "Render"
         (h/render
-         [user-avatar/user-avatar {:full-name         "Test User"
-                                   :status-indicator? true}])
+         [user-avatar/user-avatar
+          {:full-name         "Test User"
+           :status-indicator? true}])
         (test-truthy (h/get-by-label-text :initials-avatar))
         (test-truthy (h/get-by-label-text :status-indicator)))
 
       (h/test "Do not render"
         (h/render
-         [user-avatar/user-avatar {:full-name         "Test User"
-                                   :status-indicator? false}])
+         [user-avatar/user-avatar
+          {:full-name         "Test User"
+           :status-indicator? false}])
         (test-truthy (h/get-by-label-text :initials-avatar))
         (test-null (h/query-by-label-text :status-indicator))))))

--- a/src/quo2/components/avatars/user_avatar/component_spec.cljs
+++ b/src/quo2/components/avatars/user_avatar/component_spec.cljs
@@ -1,0 +1,26 @@
+(ns quo2.components.avatars.user-avatar.component-spec
+  (:require  [quo2.components.avatars.user-avatar.view :as user-avatar]
+             [test-helpers.component :as h]))
+
+
+
+(js/jest.mock "react-native-fast-image" (fn []
+                                          (fn [props] props.source.uri)))
+
+
+(h/describe "user avatar"
+            (h/test "it tests the default render"
+                    (h/render [user-avatar/user-avatar])
+                    (-> (js/expect (h/get-by-text "EN"))
+                        (.toBeTruthy)))
+
+            (h/test "it tests using a different name "
+                    (h/render [user-avatar/user-avatar {:full-name "Test User"}])
+                    (-> (js/expect (h/get-by-text "TU"))
+                        (.toBeTruthy)))
+
+            (h/test "it tests using a custom picture "
+                    (h/render [user-avatar/user-avatar {:full-name "Test User"
+                                                        :profile-picture "some mock uri"}])
+                    (-> (js/expect (h/find-by-text "some mock uri"))
+                        (.toBeTruthy))))

--- a/src/quo2/components/avatars/user_avatar/component_spec.cljs
+++ b/src/quo2/components/avatars/user_avatar/component_spec.cljs
@@ -4,33 +4,33 @@
 
 (defonce mock-picture (js/require "../resources/images/mock2/user_picture_male4.png"))
 
-(defn- test-truthy
+(defn- is-truthy
   [element]
   (.toBeTruthy (js/expect element)))
 
-(defn- test-null
+(defn- is-null
   [element]
   (.toBeNull (js/expect element)))
 
 (h/describe "user avatar"
   (h/test "Default render"
     (h/render [user-avatar/user-avatar])
-    (test-truthy (h/get-by-label-text :user-avatar))
-    (test-truthy (h/get-by-text "EN")))
+    (is-truthy (h/get-by-label-text :user-avatar))
+    (is-truthy (h/get-by-text "EN")))
 
   (h/describe "Profile picture"
     (h/test "Renders"
       (h/render
        [user-avatar/user-avatar {:profile-picture mock-picture}])
-      (test-truthy (h/get-by-label-text :profile-picture)))
+      (is-truthy (h/get-by-label-text :profile-picture)))
 
     (h/test "Renders even if `:full-name` is passed"
       (h/render
        [user-avatar/user-avatar
         {:profile-picture mock-picture
          :full-name       "New User1"}])
-      (test-truthy (h/get-by-label-text :profile-picture))
-      (test-null (h/query-by-label-text :initials-avatar)))
+      (is-truthy (h/get-by-label-text :profile-picture))
+      (is-null (h/query-by-label-text :initials-avatar)))
 
     (h/describe "Status indicator"
       (h/test "Render"
@@ -38,16 +38,16 @@
          [user-avatar/user-avatar
           {:profile-picture   mock-picture
            :status-indicator? true}])
-        (test-truthy (h/get-by-label-text :profile-picture))
-        (test-truthy (h/get-by-label-text :status-indicator)))
+        (is-truthy (h/get-by-label-text :profile-picture))
+        (is-truthy (h/get-by-label-text :status-indicator)))
 
       (h/test "Do not render"
         (h/render
          [user-avatar/user-avatar
           {:profile-picture   mock-picture
            :status-indicator? false}])
-        (test-truthy (h/get-by-label-text :profile-picture))
-        (test-null (h/query-by-label-text :status-indicator)))))
+        (is-truthy (h/get-by-label-text :profile-picture))
+        (is-null (h/query-by-label-text :status-indicator)))))
 
   (h/describe "Initials Avatar"
     (h/describe "Render initials"
@@ -58,28 +58,28 @@
         (h/describe "Two letters"
           (h/test "Size :big"
             (h/render (user-avatar-component :big))
-            (test-truthy (h/get-by-text "NU")))
+            (is-truthy (h/get-by-text "NU")))
 
           (h/test "Size :medium"
             (h/render (user-avatar-component :medium))
-            (test-truthy (h/get-by-text "NU")))
+            (is-truthy (h/get-by-text "NU")))
 
           (h/test "Size :small"
             (h/render (user-avatar-component :small))
-            (test-truthy (h/get-by-text "NU"))))
+            (is-truthy (h/get-by-text "NU"))))
 
         (h/describe "One letter"
           (h/test "Size :xs"
             (h/render (user-avatar-component :xs))
-            (test-truthy (h/get-by-text "N")))
+            (is-truthy (h/get-by-text "N")))
 
           (h/test "Size :xxs"
             (h/render (user-avatar-component :xxs))
-            (test-truthy (h/get-by-text "N")))
+            (is-truthy (h/get-by-text "N")))
 
           (h/test "Size :xxxs"
             (h/render (user-avatar-component :xxxs))
-            (test-truthy (h/get-by-text "N"))))))
+            (is-truthy (h/get-by-text "N"))))))
 
     (h/describe "Render ring"
       (letfn [(user-avatar-component [size]
@@ -90,34 +90,34 @@
         (h/describe "Passed and drawn"
           (h/test "Size :big"
             (h/render (user-avatar-component :big))
-            (test-truthy (h/get-by-label-text :initials-avatar))
-            (test-truthy (h/get-by-label-text :ring-background)))
+            (is-truthy (h/get-by-label-text :initials-avatar))
+            (is-truthy (h/get-by-label-text :ring-background)))
 
           (h/test "Size :medium"
             (h/render (user-avatar-component :medium))
-            (test-truthy (h/get-by-label-text :initials-avatar))
-            (test-truthy (h/get-by-label-text :ring-background)))
+            (is-truthy (h/get-by-label-text :initials-avatar))
+            (is-truthy (h/get-by-label-text :ring-background)))
 
           (h/test "Size :small"
             (h/render (user-avatar-component :small))
-            (test-truthy (h/get-by-label-text :initials-avatar))
-            (test-truthy (h/get-by-label-text :ring-background))))
+            (is-truthy (h/get-by-label-text :initials-avatar))
+            (is-truthy (h/get-by-label-text :ring-background))))
 
         (h/describe "Passed and not drawn (because of invalid size for ring)"
           (h/test "Size :xs"
             (h/render (user-avatar-component :xs))
-            (test-truthy (h/get-by-label-text :initials-avatar))
-            (test-null (h/query-by-label-text :ring-background)))
+            (is-truthy (h/get-by-label-text :initials-avatar))
+            (is-null (h/query-by-label-text :ring-background)))
 
           (h/test "Size :xxs"
             (h/render (user-avatar-component :xxs))
-            (test-truthy (h/get-by-label-text :initials-avatar))
-            (test-null (h/query-by-label-text :ring-background)))
+            (is-truthy (h/get-by-label-text :initials-avatar))
+            (is-null (h/query-by-label-text :ring-background)))
 
           (h/test "Size :xxxs"
             (h/render (user-avatar-component :xxxs))
-            (test-truthy (h/get-by-label-text :initials-avatar))
-            (test-null (h/query-by-label-text :ring-background))))))
+            (is-truthy (h/get-by-label-text :initials-avatar))
+            (is-null (h/query-by-label-text :ring-background))))))
 
     (h/describe "Status indicator"
       (h/test "Render"
@@ -125,13 +125,13 @@
          [user-avatar/user-avatar
           {:full-name         "Test User"
            :status-indicator? true}])
-        (test-truthy (h/get-by-label-text :initials-avatar))
-        (test-truthy (h/get-by-label-text :status-indicator)))
+        (is-truthy (h/get-by-label-text :initials-avatar))
+        (is-truthy (h/get-by-label-text :status-indicator)))
 
       (h/test "Do not render"
         (h/render
          [user-avatar/user-avatar
           {:full-name         "Test User"
            :status-indicator? false}])
-        (test-truthy (h/get-by-label-text :initials-avatar))
-        (test-null (h/query-by-label-text :status-indicator))))))
+        (is-truthy (h/get-by-label-text :initials-avatar))
+        (is-null (h/query-by-label-text :status-indicator))))))

--- a/src/quo2/components/avatars/user_avatar/component_spec.cljs
+++ b/src/quo2/components/avatars/user_avatar/component_spec.cljs
@@ -1,7 +1,8 @@
 (ns quo2.components.avatars.user-avatar.component-spec
   (:require [quo2.components.avatars.user-avatar.view :as user-avatar]
-            [status-im2.common.resources :as resources]
             [test-helpers.component :as h]))
+
+(defonce mock-picture (js/require "../resources/images/mock2/user_picture_male4.png"))
 
 (defn- test-truthy [element]
   (.toBeTruthy (js/expect element)))
@@ -18,12 +19,12 @@
   (h/describe "Profile picture"
     (h/test "Renders"
       (h/render
-       [user-avatar/user-avatar {:profile-picture (resources/get-mock-image :user-picture-male4)}])
+       [user-avatar/user-avatar {:profile-picture mock-picture}])
       (test-truthy (h/get-by-label-text :profile-picture)))
 
     (h/test "Renders even if `:full-name` is passed"
       (h/render
-       [user-avatar/user-avatar {:profile-picture (resources/get-mock-image :user-picture-male4)
+       [user-avatar/user-avatar {:profile-picture mock-picture
                                  :full-name       "New User1"}])
       (test-truthy (h/get-by-label-text :profile-picture))
       (test-null (h/query-by-label-text :initials-avatar)))
@@ -31,14 +32,14 @@
     (h/describe "Status indicator"
       (h/test "Render"
         (h/render
-         [user-avatar/user-avatar {:profile-picture   (resources/get-mock-image :user-picture-male4)
+         [user-avatar/user-avatar {:profile-picture   mock-picture
                                    :status-indicator? true}])
         (test-truthy (h/get-by-label-text :profile-picture))
         (test-truthy (h/get-by-label-text :status-indicator)))
 
       (h/test "Do not render"
         (h/render
-         [user-avatar/user-avatar {:profile-picture   (resources/get-mock-image :user-picture-male4)
+         [user-avatar/user-avatar {:profile-picture   mock-picture
                                    :status-indicator? false}])
         (test-truthy (h/get-by-label-text :profile-picture))
         (test-null (h/query-by-label-text :status-indicator)))))
@@ -77,7 +78,7 @@
     (h/describe "Render ring"
       (letfn [(user-avatar-component [size]
                 [user-avatar/user-avatar {:full-name       "New User"
-                                          :ring-background (resources/get-mock-image :ring)
+                                          :ring-background mock-picture
                                           :size            size}])]
         (h/describe "Passed and drawn"
           (h/test "Size :big"

--- a/src/quo2/components/avatars/user_avatar/style.cljs
+++ b/src/quo2/components/avatars/user_avatar/style.cljs
@@ -1,0 +1,83 @@
+(ns quo2.components.avatars.user-avatar.style
+  (:require [quo2.foundations.colors :as colors]))
+
+(def sizes
+  {:big    {:outer                   80
+            :inner                   72
+            :status-indicator        20
+            :status-indicator-border 4
+            :font-size               :heading-1}
+   :medium {:outer                   48
+            :inner                   44
+            :status-indicator        12
+            :status-indicator-border 2
+            :font-size               :paragraph-1}
+   :small  {:outer                   32
+            :inner                   28
+            :status-indicator        12
+            :status-indicator-border 2
+            :font-size               :paragraph-2}
+   :xs     {:outer                   24
+            :inner                   24
+            :status-indicator        0
+            :status-indicator-border 0
+            :font-size               :paragraph-2}
+   :xxs    {:outer                   20
+            :inner                   20
+            :status-indicator        0
+            :status-indicator-border 0
+            :font-size               :label}
+   :xxxs   {:outer                   16
+            :inner                   16
+            :status-indicator        0
+            :status-indicator-border 0
+            :font-size               :label}})
+
+(defn outer
+  [size]
+  (let [dimensions (get-in sizes [size :outer])]
+    {:width         dimensions
+     :height        dimensions
+     :border-radius dimensions}))
+
+(defn initials-avatar
+  [size draw-ring?]
+  (let [outer-dimensions (get-in sizes [size :outer])
+        inner-dimensions (get-in sizes [size (if draw-ring? :inner :outer)])]
+    {:position         :absolute
+     :top              (/ (- outer-dimensions inner-dimensions) 2)
+     :left             (/ (- outer-dimensions inner-dimensions) 2)
+     :width            inner-dimensions
+     :height           inner-dimensions
+     :border-radius    inner-dimensions
+     :justify-content  :center
+     :align-items      :center
+     :background-color (colors/custom-color-by-theme :turquoise 50 60)}))
+
+(def initials-avatar-text
+  {:color colors/white-opa-70})
+
+(defn dot
+  [size online? ring?]
+  (let [background   (if online? colors/success-50 colors/neutral-40)
+        dimensions   (get-in sizes [size :status-indicator])
+        border-width (get-in sizes [size :status-indicator-border])
+        right        (case size
+                       :big    2
+                       :medium 0
+                       :small  -2
+                       0)
+        bottom       (case size
+                       :big    (if ring? -1 2)
+                       :medium (if ring? 0 -2)
+                       :small  -2
+                       0)]
+    {:position         :absolute
+     :bottom           bottom
+     :right            right
+     :width            dimensions
+     :height           dimensions
+     :border-width     border-width
+     :border-radius    dimensions
+     :border-color     (colors/theme-colors colors/white colors/neutral-100)
+     :background-color background}))

--- a/src/quo2/components/avatars/user_avatar/style.cljs
+++ b/src/quo2/components/avatars/user_avatar/style.cljs
@@ -41,7 +41,7 @@
      :border-radius dimensions}))
 
 (defn initials-avatar
-  [size draw-ring?]
+  [size draw-ring? customization-color]
   (let [outer-dimensions (get-in sizes [size :outer])
         inner-dimensions (get-in sizes [size (if draw-ring? :inner :outer)])]
     {:position         :absolute
@@ -52,7 +52,7 @@
      :border-radius    inner-dimensions
      :justify-content  :center
      :align-items      :center
-     :background-color (colors/custom-color-by-theme :turquoise 50 60)}))
+     :background-color (colors/custom-color-by-theme customization-color 50 60)}))
 
 (def initials-avatar-text
   {:color colors/white-opa-70})

--- a/src/quo2/components/avatars/user_avatar/view.cljs
+++ b/src/quo2/components/avatars/user_avatar/view.cljs
@@ -15,12 +15,12 @@
          (string/join))))
 
 (defn initials-avatar
-  [{:keys [full-name size draw-ring?]}]
+  [{:keys [full-name size draw-ring? customization-color]}]
   (let [font-size       (get-in style/sizes [size :font-size])
         amount-initials (if (#{:xs :xxs :xxxs} size) 1 2)]
     [rn/view
      {:accessibility-label :initials-avatar
-      :style               (style/initials-avatar size draw-ring?)}
+      :style               (style/initials-avatar size draw-ring? customization-color)}
      [text/text
       {:style  style/initials-avatar-text
        :size   font-size
@@ -33,10 +33,12 @@
   "If no `profile-picture` is given, draws the initials based on the `full-name` and
   uses `ring-background` to display the ring behind the initials when given. Otherwise,
   shows the `profile-picture` which already comes with the ring drawn."
-  [{:keys [full-name status-indicator? online? size profile-picture ring-background]
-    :or   {status-indicator? true
-           online?           true
-           size              :big}}]
+  [{:keys [full-name status-indicator? online? size profile-picture ring-background
+           customization-color]
+    :or   {status-indicator?   true
+           online?             true
+           size                :big
+           customization-color :turquoise}}]
   (let [full-name    (or full-name "empty name")
         draw-ring?   (and ring-background (valid-ring-sizes size))
         outer-styles (style/outer size)]
@@ -49,9 +51,10 @@
          :source              image}])
      (when-not profile-picture
        [initials-avatar
-        {:full-name  full-name
-         :size       size
-         :draw-ring? draw-ring?}])
+        {:full-name           full-name
+         :size                size
+         :draw-ring?          draw-ring?
+         :customization-color customization-color}])
      (when status-indicator?
        [rn/view
         {:accessibility-label :status-indicator

--- a/src/quo2/components/avatars/user_avatar/view.cljs
+++ b/src/quo2/components/avatars/user_avatar/view.cljs
@@ -1,138 +1,53 @@
 (ns quo2.components.avatars.user-avatar.view
   (:require [clojure.string :as string]
+            [quo2.components.avatars.user-avatar.style :as style]
             [quo2.components.markdown.text :as text]
-            [quo2.foundations.colors :as colors]
-            [quo2.theme :refer [dark?]]
             [react-native.core :as rn]
             [react-native.fast-image :as fast-image]))
 
-(def sizes
-  {:big    {:outer                   80
-            :inner                   72
-            :status-indicator        20
-            :status-indicator-border 4
-            :font-size               :heading-1}
-   :medium {:outer                   48
-            :inner                   44
-            :status-indicator        12
-            :status-indicator-border 2
-            :font-size               :paragraph-1}
-   :small  {:outer                   32
-            :inner                   28
-            :status-indicator        12
-            :status-indicator-border 2
-            :font-size               :paragraph-2}
-   :xs     {:outer                   24
-            :inner                   24
-            :status-indicator        0
-            :status-indicator-border 0
-            :font-size               :paragraph-2}
-   :xxs    {:outer                   20
-            :inner                   20
-            :status-indicator        0
-            :status-indicator-border 0
-            :font-size               :label}
-   :xxxs   {:outer                   16
-            :inner                   16
-            :status-indicator        0
-            :status-indicator-border 0
-            :font-size               :label}})
-
-(defn dot-indicator
-  [{:keys [size online? ring? dark?]}]
-  (let [dimensions   (get-in sizes [size :status-indicator])
-        border-width (get-in sizes [size :status-indicator-border])
-        right        (case size
-                       :big    2
-                       :medium 0
-                       :small  -2
-                       0)
-        bottom       (case size
-                       :big    (if ring? -1 2)
-                       :medium (if ring? 0 -2)
-                       :small  -2
-                       0)]
-    [rn/view
-     {:style {:background-color (if online?
-                                  colors/success-50
-                                  colors/neutral-40)
-              :width            dimensions
-              :height           dimensions
-              :border-width     border-width
-              :border-radius    dimensions
-              :border-color     (if dark?
-                                  colors/neutral-100
-                                  colors/white)
-              :position         :absolute
-              :bottom           bottom
-              :right            right}}]))
-
-(defn initials-style
-  [inner-dimensions outer-dimensions]
-  {:position         :absolute
-   :top              (/ (- outer-dimensions inner-dimensions) 2)
-   :left             (/ (- outer-dimensions inner-dimensions) 2)
-   :width            inner-dimensions
-   :height           inner-dimensions
-   :border-radius    inner-dimensions
-   :justify-content  :center
-   :align-items      :center
-   :background-color (colors/custom-color-by-theme :turquoise 50 60)})
-
-(defn outer-styles
-  [outer-dimensions]
-  {:width         outer-dimensions
-   :height        outer-dimensions
-   :border-radius outer-dimensions})
-
-(def one-initial-letter-sizes #{:xs :xxs :xxxs})
-(def valid-ring-sizes #{:big :medium :small})
+(defn- extract-initials
+  [full-name amount-initials]
+  (let [upper-case-first-letter (comp string/upper-case first)
+        names-list              (string/split full-name " ")]
+    (->> names-list
+         (map upper-case-first-letter)
+         (take amount-initials)
+         (string/join))))
 
 (defn initials-avatar
-  [{:keys [full-name size inner-dimensions outer-dimensions]}]
-  (let [amount-initials (if (one-initial-letter-sizes size) 1 2)
-        initials        (as-> full-name $
-                          (string/split $ " ")
-                          (map (comp string/upper-case first) $)
-                          (take amount-initials $)
-                          (string/join $))
-        font-size       (get-in sizes [size :font-size])]
-    [rn/view {:style (initials-style inner-dimensions outer-dimensions)}
+  [{:keys [full-name size draw-ring?]}]
+  (let [font-size       (get-in style/sizes [size :font-size])
+        amount-initials (if (#{:xs :xxs :xxxs} size) 1 2)]
+    [rn/view {:style (style/initials-avatar size draw-ring?)}
      [text/text
-      {:style  {:color colors/white-opa-70}
-       :weight :semi-bold
-       :size   font-size}
-      initials]]))
+      {:style  style/initials-avatar-text
+       :size   font-size
+       :weight :semi-bold}
+      (extract-initials full-name amount-initials)]]))
+
+(def valid-ring-sizes #{:big :medium :small})
 
 (defn user-avatar
   "If no `profile-picture` is given, draws the initials based on the `full-name` and
   uses `ring-background` to display the ring behind the initials when given. Otherwise,
-  shows the profile picture which already comes with the ring drawn over it."
+  shows the `profile-picture` which already comes with the ring drawn."
   [{:keys [full-name status-indicator? online? size profile-picture ring-background]
     :or   {status-indicator? true
            online?           true
            size              :big}}]
-  (let [full-name        (or full-name "empty name")
-        draw-ring?       (and ring-background (valid-ring-sizes size))
-        outer-dimensions (get-in sizes [size :outer])
-        inner-dimensions (get-in sizes [size (if draw-ring? :inner :outer)])]
-    [rn/view
-     {:style               (outer-styles outer-dimensions)
-      :accessibility-label :user-avatar}
+  (let [full-name    (or full-name "empty name")
+        draw-ring?   (and ring-background (valid-ring-sizes size))
+        outer-styles (style/outer size)]
+    [rn/view {:style outer-styles :accessibility-label :user-avatar}
      ;; The `profile-picture` already has the ring in it
      (when-let [image (or profile-picture ring-background)]
        [fast-image/fast-image
-        {:style  (outer-styles outer-dimensions)
+        {:style  outer-styles
          :source image}])
      (when-not profile-picture
        [initials-avatar
-        {:full-name        full-name
-         :size             size
-         :inner-dimensions inner-dimensions
-         :outer-dimensions outer-dimensions}])
+        {:full-name  full-name
+         :size       size
+         :draw-ring? draw-ring?}])
      (when status-indicator?
-       [dot-indicator
-        {:size    size
-         :online? online?
-         :ring?   draw-ring?
-         :dark?   (dark?)}])]))
+       [rn/view {:style (style/dot size online? draw-ring?)}])]))

--- a/src/quo2/components/avatars/user_avatar/view.cljs
+++ b/src/quo2/components/avatars/user_avatar/view.cljs
@@ -1,4 +1,4 @@
-(ns quo2.components.avatars.user-avatar
+(ns quo2.components.avatars.user-avatar.view
   (:require [clojure.string :as string]
             [quo2.components.markdown.text :as text]
             [quo2.foundations.colors :as colors]

--- a/src/quo2/components/avatars/user_avatar/view.cljs
+++ b/src/quo2/components/avatars/user_avatar/view.cljs
@@ -18,7 +18,8 @@
   [{:keys [full-name size draw-ring?]}]
   (let [font-size       (get-in style/sizes [size :font-size])
         amount-initials (if (#{:xs :xxs :xxxs} size) 1 2)]
-    [rn/view {:style (style/initials-avatar size draw-ring?)}
+    [rn/view {:accessibility-label :initials-avatar
+              :style               (style/initials-avatar size draw-ring?)}
      [text/text
       {:style  style/initials-avatar-text
        :size   font-size
@@ -42,12 +43,14 @@
      ;; The `profile-picture` already has the ring in it
      (when-let [image (or profile-picture ring-background)]
        [fast-image/fast-image
-        {:style  outer-styles
-         :source image}])
+        {:accessibility-label (if draw-ring? :ring-background :profile-picture)
+         :style               outer-styles
+         :source              image}])
      (when-not profile-picture
        [initials-avatar
         {:full-name  full-name
          :size       size
          :draw-ring? draw-ring?}])
      (when status-indicator?
-       [rn/view {:style (style/dot size online? draw-ring?)}])]))
+       [rn/view {:accessibility-label :status-indicator
+                 :style               (style/dot size online? draw-ring?)}])]))

--- a/src/quo2/components/avatars/user_avatar/view.cljs
+++ b/src/quo2/components/avatars/user_avatar/view.cljs
@@ -18,8 +18,9 @@
   [{:keys [full-name size draw-ring?]}]
   (let [font-size       (get-in style/sizes [size :font-size])
         amount-initials (if (#{:xs :xxs :xxxs} size) 1 2)]
-    [rn/view {:accessibility-label :initials-avatar
-              :style               (style/initials-avatar size draw-ring?)}
+    [rn/view
+     {:accessibility-label :initials-avatar
+      :style               (style/initials-avatar size draw-ring?)}
      [text/text
       {:style  style/initials-avatar-text
        :size   font-size
@@ -52,5 +53,6 @@
          :size       size
          :draw-ring? draw-ring?}])
      (when status-indicator?
-       [rn/view {:accessibility-label :status-indicator
-                 :style               (style/dot size online? draw-ring?)}])]))
+       [rn/view
+        {:accessibility-label :status-indicator
+         :style               (style/dot size online? draw-ring?)}])]))

--- a/src/quo2/components/list_items/preview_list.cljs
+++ b/src/quo2/components/list_items/preview_list.cljs
@@ -1,5 +1,5 @@
 (ns quo2.components.list-items.preview-list
-  (:require [quo2.components.avatars.user-avatar :as user-avatar]
+  (:require [quo2.components.avatars.user-avatar.view :as user-avatar]
             [quo2.components.icon :as quo2.icons]
             [quo2.components.markdown.text :as quo2.text]
             [quo2.foundations.colors :as colors]

--- a/src/quo2/components/list_items/user_list.cljs
+++ b/src/quo2/components/list_items/user_list.cljs
@@ -1,6 +1,6 @@
 (ns quo2.components.list-items.user-list
   (:require [react-native.core :as rn]
-            [quo2.components.avatars.user-avatar :as user-avatar]
+            [quo2.components.avatars.user-avatar.view :as user-avatar]
             [quo2.components.markdown.text :as text]
             [quo2.components.icon :as icons]
             [quo2.foundations.colors :as colors]

--- a/src/quo2/components/messages/system_message.cljs
+++ b/src/quo2/components/messages/system_message.cljs
@@ -1,6 +1,6 @@
 (ns quo2.components.messages.system-message
   (:require [quo2.components.avatars.icon-avatar :as icon-avatar]
-            [quo2.components.avatars.user-avatar :as user-avatar]
+            [quo2.components.avatars.user-avatar.view :as user-avatar]
             [quo2.components.markdown.text :as text]
             [quo2.foundations.colors :as colors]
             [quo2.theme :as theme]

--- a/src/quo2/components/navigation/page_nav.cljs
+++ b/src/quo2/components/navigation/page_nav.cljs
@@ -1,6 +1,6 @@
 (ns quo2.components.navigation.page-nav
   (:require [clojure.string :as string]
-            [quo2.components.avatars.user-avatar :as user-avatar]
+            [quo2.components.avatars.user-avatar.view :as user-avatar]
             [quo2.components.buttons.button :as button]
             [quo2.components.icon :as icons]
             [quo2.components.markdown.text :as text]

--- a/src/quo2/components/profile/profile_card/view.cljs
+++ b/src/quo2/components/profile/profile_card/view.cljs
@@ -6,7 +6,7 @@
             [quo2.foundations.colors :as colors]
             [quo2.components.markdown.text :as text]
             [quo2.components.buttons.button :as button]
-            [quo2.components.avatars.user-avatar :as user-avatar]
+            [quo2.components.avatars.user-avatar.view :as user-avatar]
             [quo2.components.profile.profile-card.style :as style]))
 
 (defn profile-card

--- a/src/quo2/components/profile/select_profile/view.cljs
+++ b/src/quo2/components/profile/select_profile/view.cljs
@@ -3,7 +3,7 @@
     [quo2.components.profile.select-profile.style :as style]
     [react-native.core :as rn]
     [quo2.components.markdown.text :as text]
-    [quo2.components.avatars.user-avatar :as user-avatar]
+    [quo2.components.avatars.user-avatar.view :as user-avatar]
     [reagent.core :as reagent]))
 
 (defn- on-change-handler

--- a/src/quo2/core.cljs
+++ b/src/quo2/core.cljs
@@ -5,7 +5,7 @@
     quo2.components.avatars.channel-avatar
     quo2.components.avatars.group-avatar
     quo2.components.avatars.icon-avatar
-    quo2.components.avatars.user-avatar
+    quo2.components.avatars.user-avatar.view
     quo2.components.avatars.wallet-user-avatar
     quo2.components.banners.banner.view
     quo2.components.buttons.button
@@ -102,7 +102,7 @@
 (def channel-avatar quo2.components.avatars.channel-avatar/channel-avatar)
 (def group-avatar quo2.components.avatars.group-avatar/group-avatar)
 (def icon-avatar quo2.components.avatars.icon-avatar/icon-avatar)
-(def user-avatar quo2.components.avatars.user-avatar/user-avatar)
+(def user-avatar quo2.components.avatars.user-avatar.view/user-avatar)
 (def wallet-user-avatar quo2.components.avatars.wallet-user-avatar/wallet-user-avatar)
 
 ;;;; BANNER

--- a/src/quo2/core_spec.cljs
+++ b/src/quo2/core_spec.cljs
@@ -1,5 +1,6 @@
 (ns quo2.core-spec
-  (:require [quo2.components.banners.banner.component-spec]
+  (:require [quo2.components.avatars.user-avatar.component-spec]
+            [quo2.components.banners.banner.component-spec]
             [quo2.components.buttons.--tests--.buttons-component-spec]
             [quo2.components.counter.--tests--.counter-component-spec]
             [quo2.components.dividers.--tests--.divider-label-component-spec]

--- a/src/status_im2/contexts/quo_preview/avatars/user_avatar.cljs
+++ b/src/status_im2/contexts/quo_preview/avatars/user_avatar.cljs
@@ -22,6 +22,13 @@
                :value "xx Small"}
               {:key   :xxxs
                :value "xxx Small"}]}
+   {:label   "Customization color:"
+    :key     :customization-color
+    :type    :select
+    :options (map (fn [[color-kw _]]
+                    {:key   color-kw
+                     :value (name color-kw)})
+                  colors/customization)}
    {:label "Online status"
     :key   :online?
     :type  :boolean}
@@ -46,10 +53,11 @@
 
 (defn cool-preview
   []
-  (let [state (reagent/atom {:full-name         "A Y"
-                             :status-indicator? true
-                             :online?           true
-                             :size              :medium})]
+  (let [state (reagent/atom {:full-name           "A Y"
+                             :status-indicator?   true
+                             :online?             true
+                             :size                :medium
+                             :customization-color :blue})]
     (fn []
       [rn/touchable-without-feedback {:on-press rn/dismiss-keyboard!}
        [rn/view {:padding-bottom 150}

--- a/src/status_im2/contexts/quo_preview/avatars/user_avatar.cljs
+++ b/src/status_im2/contexts/quo_preview/avatars/user_avatar.cljs
@@ -1,5 +1,5 @@
 (ns status-im2.contexts.quo-preview.avatars.user-avatar
-  (:require [quo2.components.avatars.user-avatar :as quo2]
+  (:require [quo2.components.avatars.user-avatar.view :as quo2]
             [quo2.foundations.colors :as colors]
             [react-native.core :as rn]
             [reagent.core :as reagent]

--- a/src/test_helpers/component.cljs
+++ b/src/test_helpers/component.cljs
@@ -38,6 +38,10 @@
   [label]
   (rtl/screen.getByLabelText (name label)))
 
+(defn query-by-label-text
+  [label]
+  (rtl/screen.queryByLabelText (name label)))
+
 (defn get-by-translation-text
   [keyword]
   (get-by-text (str "tx:" (name keyword))))

--- a/src/test_helpers/component.cljs
+++ b/src/test_helpers/component.cljs
@@ -63,3 +63,11 @@
   (js/jest.advanceTimersByTime time-ms))
 
 (def mock-fn js/jest.fn)
+
+(defn is-truthy
+  [element]
+  (.toBeTruthy (js/expect element)))
+
+(defn is-null
+  [element]
+  (.toBeNull (js/expect element)))

--- a/src/test_helpers/component.cljs
+++ b/src/test_helpers/component.cljs
@@ -30,6 +30,10 @@
   [text]
   (rtl/screen.getByText text))
 
+(defn find-by-text
+  [text]
+  (rtl/screen.findByText text))
+
 (defn get-by-label-text
   [label]
   (rtl/screen.getByLabelText (name label)))


### PR DESCRIPTION
Refactors the user-avatar component and add tests. This PR is the continuation of #14861.

Thanks to @J-Son89 because he started this work in a separate branch in order to help me :) I cherry-picked his commit 8d43a6d5bef0310ab60386837c055551d0d5960d