### PR TITLE
feat: activity centre animations

### DIFF
--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -28,4 +28,12 @@
         <item name="android:textColorPrimary">@color/alert_text</item>
         <item name="android:background">@color/alert_background</item>
     </style>
+
+    <style name="Theme.FullScreenDialog">
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:windowIsFloating">false</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+    </style>
 </resources>

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "react-native-linear-gradient": "^2.5.6",
     "react-native-lottie-splash-screen": "^1.0.1",
     "react-native-mail": "^6.1.1",
+    "react-native-modal": "^13.0.1",
     "react-native-navigation": "^7.27.1",
     "react-native-orientation-locker": "^1.5.0",
     "react-native-permissions": "^2.1.5",

--- a/src/mocks/js_dependencies.cljs
+++ b/src/mocks/js_dependencies.cljs
@@ -338,6 +338,9 @@ globalThis.__STATUS_MOBILE_JS_IDENTITY_PROXY__ = new Proxy({}, {get() { return (
   (clj->js {:default                    #js {}
             :useDeviceOrientationChange #js {}}))
 
+(def react-native-modal
+  (clj->js {:default #js {}}))
+
 (def wallet-connect-client
   #js
    {:default       #js {}
@@ -404,6 +407,7 @@ globalThis.__STATUS_MOBILE_JS_IDENTITY_PROXY__ = new Proxy({}, {get() { return (
     "@react-native-async-storage/async-storage"     async-storage
     "react-native-svg"                              react-native-svg
     "react-native-orientation-locker"               react-native-orientation-locker
+    "react-native-modal"                            react-native-modal
     "../src/js/worklet_factory.js"                  worklet-factory
     "../src/js/shell_worklets.js"                   shell-worklets
     "../src/js/bottom_sheet.js"                     bottom-sheet

--- a/src/react_native/core.cljs
+++ b/src/react_native/core.cljs
@@ -1,6 +1,7 @@
 (ns react-native.core
   (:require ["react" :as react]
             ["react-native" :as react-native]
+            ["react-native-modal" :default Modal]
             [cljs-bean.core :as bean]
             [oops.core :as oops]
             [react-native.flat-list :as flat-list]
@@ -31,7 +32,8 @@
 
 (def activity-indicator (reagent/adapt-react-class (.-ActivityIndicator ^js react-native)))
 
-(def modal (reagent/adapt-react-class (.-Modal ^js react-native)))
+;; "react-native-modal" is a superset to the Modal component from RN, no need to define it separately
+(def modal (reagent/adapt-react-class Modal))
 
 (def keyboard ^js (.-Keyboard ^js react-native))
 

--- a/src/status_im2/common/home/view.cljs
+++ b/src/status_im2/common/home/view.cljs
@@ -55,7 +55,7 @@
                            (navigation/merge-options (clj->js view-id)
                                                      (clj->js {:statusBar {:style status-bar-style}})))]
     [rn/modal
-     {:is-visible             @visible?
+     {:visible             @visible?
       :cover-screen           true
       :transparent            true
       :status-bar-translucent true

--- a/src/status_im2/contexts/activity_center/style.cljs
+++ b/src/status_im2/contexts/activity_center/style.cljs
@@ -1,5 +1,6 @@
 (ns status-im2.contexts.activity-center.style
-  (:require [quo2.foundations.colors :as colors]))
+  (:require [quo2.foundations.colors :as colors]
+            [react-native.platform :as platform]))
 
 (def screen-padding 20)
 
@@ -60,3 +61,24 @@
    :height           120
    :background-color colors/danger-50
    :margin-bottom    20})
+
+(def blur-background
+  {:position :absolute
+   :top      0
+   :bottom   0
+   :left     0
+   :right    0})
+
+(defn options-content-container
+  [bottom-inset]
+  {:background-color        colors/neutral-100
+   :padding-bottom          (if platform/ios? bottom-inset 20)
+   :padding-top             20
+   :border-top-left-radius  20
+   :border-top-right-radius 20})
+
+(def options-modal-container
+  {:justify-content :flex-end
+   :margin          0
+   :width           "100%"
+   :align-self      :center})

--- a/src/status_im2/contexts/activity_center/style.cljs
+++ b/src/status_im2/contexts/activity_center/style.cljs
@@ -64,6 +64,7 @@
 
 (def blur-background
   {:position :absolute
+   :background-color colors/neutral-80-opa-80
    :top      0
    :bottom   0
    :left     0

--- a/src/status_im2/contexts/activity_center/view.cljs
+++ b/src/status_im2/contexts/activity_center/view.cljs
@@ -231,7 +231,7 @@
                 window-width  (rf/sub [:dimensions/window-width])]
             [rn/view {:style (style/screen-container window-width top bottom)}
              [blur/view
-              {:blurAmount 32
+              {:blurAmount 5
                :style      style/blur-background}]
              [options-bottom-sheet visible? bottom]
              [header request-close #(reset! visible? true)]

--- a/src/status_im2/contexts/activity_center/view.cljs
+++ b/src/status_im2/contexts/activity_center/view.cljs
@@ -3,7 +3,6 @@
             [quo2.core :as quo]
             [quo2.foundations.colors :as colors]
             [react-native.core :as rn]
-            [react-native.platform :as platform]
             [react-native.safe-area :as safe-area]
             [reagent.core :as reagent]
             [status-im2.contexts.activity-center.notification-types :as types]

--- a/yarn.lock
+++ b/yarn.lock
@@ -9330,6 +9330,13 @@ react-lifecycles-compat@2.0.0:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-2.0.0.tgz#71d9c4cde47114c4102454f76da055c2bc48c948"
   integrity sha512-txfpPCQYiazVdcbMRhatqWKcAxJweUu2wDXvts5/7Wyp6+Y9cHojqXHsLPEckzutfHlxZhG8Oiundbmp8Fd6eQ==
 
+react-native-animatable@1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/react-native-animatable/-/react-native-animatable-1.3.3.tgz#a13a4af8258e3bb14d0a9d839917e9bb9274ec8a"
+  integrity sha512-2ckIxZQAsvWn25Ho+DK3d1mXIgj7tITkrS4pYDvx96WyOttSvzzFeQnM2od0+FUMzILbdHDsDEqZvnz1DYNQ1w==
+  dependencies:
+    prop-types "^15.7.2"
+
 react-native-background-timer@^2.1.1:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/react-native-background-timer/-/react-native-background-timer-2.2.0.tgz#ff82d30899209b924983cc00e6ce174b8de5054a"
@@ -9457,6 +9464,14 @@ react-native-mail@^6.1.1:
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/react-native-mail/-/react-native-mail-6.1.1.tgz#f1b1f8034c84d2510a93e4a2a795f0db5a13595e"
   integrity sha512-pTs180wwyh7hN/iyTC9SfOX579U4YhDlHOLxi47IGvhPJENqO/QFdBq+wWKxyhNqdQuVSy+LoeIxLreWnIeYmg==
+
+react-native-modal@^13.0.1:
+  version "13.0.1"
+  resolved "https://registry.yarnpkg.com/react-native-modal/-/react-native-modal-13.0.1.tgz#691f1e646abb96fa82c1788bf18a16d585da37cd"
+  integrity sha512-UB+mjmUtf+miaG/sDhOikRfBOv0gJdBU2ZE1HtFWp6UixW9jCk/bhGdHUgmZljbPpp0RaO/6YiMmQSSK3kkMaw==
+  dependencies:
+    prop-types "^15.6.2"
+    react-native-animatable "1.3.3"
 
 react-native-navigation@^7.27.1:
   version "7.27.1"


### PR DESCRIPTION
fixes: https://github.com/status-im/status-mobile/issues/15261

This PR migrates activity centre away from using the `popover` component to using `Modal` component from React Native, plus some minor changes.

This PR introduces the following improvements:

- Reduces AC opening delay from being about 100ms to instantly.
- Improves the animation smoothness
- Removes that weird background overlay that suddenly appears before the animation, and suddenly disappears after the animation
- Fixes Status bar coloring on Android. For iOS see issue: https://github.com/status-im/status-mobile/issues/15260
- Makes the Status bar on Android translucent, to reflect the designs more accurately

And here how it looks:

-> on iOS:



https://user-images.githubusercontent.com/29354102/223080811-e3150021-a2d0-4a91-bbf2-f4903cf3526c.mp4




-> and Android:

https://user-images.githubusercontent.com/29354102/223045742-fe77962c-4e9f-4df7-94c7-b20b70c51e1a.mp4

