### PR TITLE
fix: mark :albumize? true when rebuild message

### DIFF
--- a/src/status_im/chat/models/loading.cljs
+++ b/src/status_im/chat/models/loading.cljs
@@ -1,9 +1,9 @@
 (ns status-im.chat.models.loading
   (:require [re-frame.core :as re-frame]
-            [status-im2.contexts.chat.messages.list.events :as message-list]
-            [status-im2.constants :as constants]
             [status-im.data-store.chats :as data-store.chats]
             [status-im.data-store.messages :as data-store.messages]
+            [status-im2.constants :as constants]
+            [status-im2.contexts.chat.messages.list.events :as message-list]
             [taoensso.timbre :as log]
             [utils.re-frame :as rf]))
 
@@ -100,17 +100,6 @@
                                     :on-success #(re-frame/dispatch
                                                   [::mark-all-read-in-community-successful %])}]}))
 
-;; For example, when a user receives a list of 4 image messages while inside the chat screen we
-;; shouldn't group the images into albums. When the user exists the chat screen then enters the
-;; chat screen again, we now need to group the images into albums (like WhatsApp). The albumize?
-;; boolean is used to know whether we need to group these images into albums now or not. The
-;; album-id can't be used for this because it will always be there.
-(defn mark-album
-  [message]
-  (if (:album-id message)
-    (assoc message :albumize? true)
-    message))
-
 (rf/defn messages-loaded
   "Loads more messages for current chat"
   {:events [::messages-loaded]}
@@ -124,15 +113,25 @@
           (reduce (fn [{:keys [all-messages] :as acc}
                        {:keys [message-id from]
                         :as   message}]
-                    (cond-> acc
-                      (not (get-in db [:chats chat-id :users from]))
-                      (update :senders assoc from message)
+                    (let [message
+                          ;; For example, when a user receives a list of 4 image messages while inside
+                          ;; the chat screen we shouldn't group the images into albums. When the user
+                          ;; exists the chat screen then enters the chat screen again, we now need to
+                          ;; group the images into albums (like WhatsApp). The albumize? boolean is used
+                          ;; to know whether we need to group these images into albums now or not. The
+                          ;; album-id can't be used for this because it will always be there.
+                          (if (and (:album-id message) (nil? (get all-messages message-id)))
+                            (assoc message :albumize? true)
+                            message)]
+                      (cond-> acc
+                        (not (get-in db [:chats chat-id :users from]))
+                        (update :senders assoc from message)
 
-                      (nil? (get all-messages message-id))
-                      (update :new-messages conj message)
+                        (nil? (get all-messages message-id))
+                        (update :new-messages conj message)
 
-                      :always
-                      (update :all-messages assoc message-id message)))
+                        :always
+                        (update :all-messages assoc message-id message))))
                   {:all-messages already-loaded-messages
                    :senders      {}
                    :contacts     {}
@@ -141,8 +140,7 @@
           current-clock-value (get-in db
                                       [:pagination-info chat-id
                                        :cursor-clock-value])
-          clock-value (when cursor (cursor->clock-value cursor))
-          new-messages (map mark-album new-messages)]
+          clock-value (when cursor (cursor->clock-value cursor))]
       {:db (-> db
                (update-in [:pagination-info chat-id :cursor-clock-value]
                           #(if (and (seq cursor) (or (not %) (< clock-value %)))

--- a/src/status_im2/contexts/chat/messages/list/events.cljs
+++ b/src/status_im2/contexts/chat/messages/list/events.cljs
@@ -1,8 +1,8 @@
 (ns status-im2.contexts.chat.messages.list.events
-  (:require [utils.red-black-tree :as red-black-tree]
+  (:require [status-im2.constants :as constants]
             [utils.datetime :as datetime]
             [utils.re-frame :as rf]
-            [status-im2.constants :as constants]))
+            [utils.red-black-tree :as red-black-tree]))
 
 (defn- add-datemark
   [{:keys [whisper-timestamp] :as msg}]


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/15217

`:albumize?` of loaded messages (instead of newly sent messages) is marked true in order to display album only for loaded messages

this PR mark it `true` when `rebuild-message-list`

delete or undo delete will cause newly sent message be albumized as well, check the below video


https://user-images.githubusercontent.com/15090582/223677801-088b0fe0-0914-43c0-bfeb-60efeb0b21b0.mp4



status: ready <!-- Can be ready or wip -->