### PR TITLE
Add collapsing of categories

### DIFF
--- a/src/quo2/components/dividers/divider_label.cljs
+++ b/src/quo2/components/dividers/divider_label.cljs
@@ -11,10 +11,21 @@
 (defn divider-label
   "label -> string
    chevron-position -> :left, :right
+   chevron-icon -> keyword
+   on-press -> function
+   padding-bottom -> number
    counter-value -> number
    increase-padding-top? -> boolean
    blur? -> boolean"
-  [{:keys [label chevron-position counter-value increase-padding-top? blur? container-style]}]
+  [{:keys [label
+           chevron-position
+           chevron-icon
+           counter-value
+           increase-padding-top?
+           padding-bottom
+           blur?
+           container-style
+           on-press]}]
   (let [dark?                       (colors/dark?)
         border-and-counter-bg-color (if dark?
                                       (if blur? colors/white-opa-5 colors/neutral-70)
@@ -22,50 +33,53 @@
         padding-top                 (if increase-padding-top? 16 8)
         text-and-icon-color         (if dark? colors/neutral-40 colors/neutral-50)
         counter-text-color          (if dark? colors/white colors/neutral-100)]
-    [rn/view
-     {:accessible          true
-      :accessibility-label :divider-label
-      :style               (merge {:border-top-width   1
-                                   :border-top-color   border-and-counter-bg-color
-                                   :padding-top        padding-top
-                                   :padding-horizontal 16
-                                   :align-items        :center
-                                   :flex-direction     :row}
-                                  container-style)}
-     (when (= chevron-position :left)
-       [rn/view
-        {:test-ID :divider-label-icon-left
-         :style   {:margin-right 4}}
-        [icons/icon
-         :main-icons/chevron-down
-         {:color  text-and-icon-color
-          :width  chevron-icon-container-width
-          :height chevron-icon-container-height}]])
-     [markdown.text/text
-      {:size   :paragraph-2
-       :weight :medium
-       :style  {:color text-and-icon-color
-                :flex  1}}
-      label]
-     (when (= chevron-position :right)
-       [rn/view {:test-ID :divider-label-icon-right}
-        [icons/icon
-         :main-icons/chevron-down
-         {:color text-and-icon-color
-          :size  chevron-icon-container-width}]])
-     (when (pos? counter-value)
-       [rn/view
-        {:style {:border-radius    6
-                 :height           16
-                 :width            (case (count counter-value)
-                                     1 16
-                                     2 20
-                                     28)
-                 :background-color border-and-counter-bg-color
-                 :align-items      :center
-                 :justify-content  :center}}
-        [markdown.text/text
-         {:size   :label
-          :weight :medium
-          :style  {:color counter-text-color}}
-         counter-value]])]))
+    [rn/touchable-without-feedback
+     {:on-press on-press}
+     [rn/view
+      {:accessible          true
+       :accessibility-label :divider-label
+       :style               (merge {:border-top-width   1
+                                    :border-top-color   border-and-counter-bg-color
+                                    :padding-top        padding-top
+                                    :padding-bottom     padding-bottom
+                                    :padding-horizontal 16
+                                    :align-items        :center
+                                    :flex-direction     :row}
+                                   container-style)}
+      (when (= chevron-position :left)
+        [rn/view
+         {:test-ID :divider-label-icon-left
+          :style   {:margin-right 4}}
+         [icons/icon
+          (or chevron-icon :i/chevron-down)
+          {:color  text-and-icon-color
+           :width  chevron-icon-container-width
+           :height chevron-icon-container-height}]])
+      [markdown.text/text
+       {:size   :paragraph-2
+        :weight :medium
+        :style  {:color text-and-icon-color
+                 :flex  1}}
+       label]
+      (when (= chevron-position :right)
+        [rn/view {:test-ID :divider-label-icon-right}
+         [icons/icon
+          (or chevron-icon :i/chevron-down)
+          {:color text-and-icon-color
+           :size  chevron-icon-container-width}]])
+      (when (pos? counter-value)
+        [rn/view
+         {:style {:border-radius    6
+                  :height           16
+                  :width            (case (count counter-value)
+                                      1 16
+                                      2 20
+                                      28)
+                  :background-color border-and-counter-bg-color
+                  :align-items      :center
+                  :justify-content  :center}}
+         [markdown.text/text
+          {:size   :label
+           :weight :medium
+           :style  {:color counter-text-color}}
+          counter-value]])]]))

--- a/src/status_im/multiaccounts/login/core.cljs
+++ b/src/status_im/multiaccounts/login/core.cljs
@@ -47,16 +47,6 @@
     [utils.security.core :as security]))
 
 (re-frame/reg-fx
- ::initialize-communities-enabled
- (fn []
-   (let [callback #(re-frame/dispatch [:multiaccounts.ui/switch-communities-enabled %])]
-     (if config/communities-enabled?
-       (callback true)
-       (async-storage/get-item
-        :communities-enabled?
-        callback)))))
-
-(re-frame/reg-fx
  ::initialize-transactions-management-enabled
  (fn []
    (let [callback #(re-frame/dispatch [:multiaccounts.ui/switch-transactions-management-enabled %])]
@@ -358,10 +348,6 @@
    [{:method     "wakuext_getGroupChatInvitations"
      :on-success #(re-frame/dispatch [::initialize-invitations %])}]})
 
-(rf/defn initialize-communities-enabled
-  [cofx]
-  {::initialize-communities-enabled nil})
-
 (rf/defn initialize-transactions-management-enabled
   [cofx]
   {::initialize-transactions-management-enabled nil})
@@ -408,10 +394,10 @@
                      (rf/dispatch [:communities/get-user-requests-to-join])
                      (re-frame/dispatch [::get-chats-callback]))})
               (initialize-appearance)
-              (initialize-communities-enabled)
               (initialize-wallet-connect)
               (get-node-config)
               (communities/fetch)
+              (communities/fetch-collapsed-community-categories)
               (logging/set-log-level (:log-level multiaccount))
               (activity-center/notifications-fetch-pending-contact-requests)
               (activity-center/update-seen-state)
@@ -539,7 +525,6 @@
               (communities/fetch)
               (data-store.chats/fetch-chats-rpc
                {:on-success #(re-frame/dispatch [:chats-list/load-success %])})
-              (initialize-communities-enabled)
               (multiaccounts/switch-preview-privacy-mode-flag)
               (link-preview/request-link-preview-whitelist)
               (logging/set-log-level (:log-level multiaccount))

--- a/src/status_im/ui/screens/advanced_settings/views.cljs
+++ b/src/status_im/ui/screens/advanced_settings/views.cljs
@@ -2,15 +2,13 @@
   (:require [quo.core :as quo]
             [re-frame.core :as re-frame]
             [utils.i18n :as i18n]
-            [status-im.ui.components.list.views :as list]
-            [status-im2.config :as config])
+            [status-im.ui.components.list.views :as list])
   (:require-macros [status-im.utils.views :as views]))
 
 (defn- normal-mode-settings-data
   [{:keys [network-name
            current-log-level
            waku-bloom-filter-mode
-           communities-enabled?
            transactions-management-enabled?
            wakuv2-flag
            current-fleet
@@ -76,17 +74,6 @@
      :on-press
      #(re-frame/dispatch [:navigate-to :peers-stats])
      :chevron true}
-    ;; If it's enabled in the config, we don't show the option
-    (when (not config/communities-enabled?)
-      {:size :small
-       :title (i18n/label :t/communities-enabled)
-       :accessibility-label :communities-enabled
-       :container-margin-bottom 8
-       :on-press
-       #(re-frame/dispatch
-         [:multiaccounts.ui/switch-communities-enabled (not communities-enabled?)])
-       :accessory :switch
-       :active communities-enabled?})
     {:size :small
      :title (i18n/label :t/transactions-management-enabled)
      :accessibility-label :transactions-management-enabled
@@ -132,7 +119,6 @@
                   network-name                     [:network-name]
                   waku-bloom-filter-mode           [:waku/bloom-filter-mode]
                   wakuv2-flag                      [:waku/v2-flag]
-                  communities-enabled?             [:communities/enabled?]
                   transactions-management-enabled? [:wallet/transactions-management-enabled?]
                   current-log-level                [:log-level/current-log-level]
                   current-fleet                    [:fleets/current-fleet]]
@@ -140,7 +126,6 @@
      {:data      (flat-list-data
                   {:network-name                     network-name
                    :current-log-level                current-log-level
-                   :communities-enabled?             communities-enabled?
                    :transactions-management-enabled? transactions-management-enabled?
                    :current-fleet                    current-fleet
                    :dev-mode?                        false

--- a/src/status_im/ui/screens/communities/views.cljs
+++ b/src/status_im/ui/screens/communities/views.cljs
@@ -142,28 +142,25 @@
 
 (defn communities
   []
-  (let [communities          (rf/sub [:communities/section-list])
-        communities-enabled? (rf/sub [:communities/enabled?])]
+  (let [communities (rf/sub [:communities/section-list])]
     [:<>
      [topbar/topbar
-      (cond-> {:title (i18n/label :t/communities)}
-        communities-enabled?
-        (assoc :right-accessories
-               [{:icon :main-icons/more
-                 :accessibility-label :chat-menu-button
-                 :on-press
-                 #(rf/dispatch [:bottom-sheet/show-sheet
-                                {:content (fn []
-                                            [communities-actions])
-                                 :height  256}])}]))]
+      {:title (i18n/label :t/communities)
+       :right-accessories
+       [{:icon :main-icons/more
+         :accessibility-label :chat-menu-button
+         :on-press
+         #(rf/dispatch [:bottom-sheet/show-sheet
+                        {:content (fn []
+                                    [communities-actions])
+                         :height  256}])}]}]
      [communities-list communities]
-     (when communities-enabled?
-       [toolbar/toolbar
-        {:show-border? true
-         :center       [quo/button
-                        {:on-press #(rf/dispatch [::communities/open-create-community])
-                         :type     :secondary}
-                        (i18n/label :t/create-community)]}])]))
+     [toolbar/toolbar
+      {:show-border? true
+       :center       [quo/button
+                      {:on-press #(rf/dispatch [::communities/open-create-community])
+                       :type     :secondary}
+                      (i18n/label :t/create-community)]}]]))
 
 (defn export-community
   []

--- a/src/status_im/ui/screens/home/sheet/views.cljs
+++ b/src/status_im/ui/screens/home/sheet/views.cljs
@@ -51,13 +51,12 @@
      :accessibility-label :join-public-chat-button
      :icon                :main-icons/public-chat
      :on-press            #(hide-sheet-and-dispatch [:open-modal :new-public-chat])}]
-   (when (rf/sub [:communities/enabled?])
-     [quo/list-item
-      {:theme               :accent
-       :title               (i18n/label :t/communities-alpha)
-       :accessibility-label :communities-button
-       :icon                :main-icons/communities
-       :on-press            #(hide-sheet-and-dispatch [:navigate-to :communities])}])
+   [quo/list-item
+    {:theme               :accent
+     :title               (i18n/label :t/communities-alpha)
+     :accessibility-label :communities-button
+     :icon                :main-icons/communities
+     :on-press            #(hide-sheet-and-dispatch [:navigate-to :communities])}]
    [invite/list-item
     {:accessibility-label :chats-menu-invite-friends-button}]])
 

--- a/src/status_im/ui2/screens/chat/messages/message.cljs
+++ b/src/status_im/ui2/screens/chat/messages/message.cljs
@@ -354,9 +354,8 @@
 
 (defview community-content
   [{:keys [community-id] :as message}]
-  (letsubs [{:keys [name description verified] :as community} [:communities/community community-id]
-            communities-enabled?                              [:communities/enabled?]]
-    (when (and communities-enabled? community)
+  (letsubs [{:keys [name description verified] :as community} [:communities/community community-id]]
+    (when community
       [rn/view
        {:style (assoc (style/message-wrapper message)
                       :margin-vertical 10

--- a/src/status_im2/config.cljs
+++ b/src/status_im2/config.cljs
@@ -31,7 +31,6 @@
 (def keycard-test-menu-enabled? (enabled? (get-config :KEYCARD_TEST_MENU "1")))
 (def qr-test-menu-enabled? (enabled? (get-config :QR_READ_TEST_MENU "0")))
 (def quo-preview-enabled? (enabled? (get-config :ENABLE_QUO_PREVIEW "0")))
-(def communities-enabled? (enabled? (get-config :COMMUNITIES_ENABLED "0")))
 (def database-management-enabled? (enabled? (get-config :DATABASE_MANAGEMENT_ENABLED "0")))
 (def debug-webview? (enabled? (get-config :DEBUG_WEBVIEW "0")))
 (def collectibles-enabled? (enabled? (get-config :COLLECTIBLES_ENABLED "1")))

--- a/src/status_im2/constants.cljs
+++ b/src/status_im2/constants.cljs
@@ -290,3 +290,5 @@
 (def ^:const local-pair-action-sync-device 3)
 
 (def ^:const everyone-mention-id "0x00001")
+
+(def ^:const empty-category-id :communities/not-categorized)

--- a/src/status_im2/subs/communities.cljs
+++ b/src/status_im2/subs/communities.cljs
@@ -7,15 +7,6 @@
             [utils.i18n :as i18n]))
 
 (re-frame/reg-sub
- :communities
- :<- [:raw-communities]
- :<- [:communities/enabled?]
- (fn [[raw-communities communities-enabled?]]
-   (if communities-enabled?
-     raw-communities
-     [])))
-
-(re-frame/reg-sub
  :communities/fetching-community
  :<- [:communities/resolve-community-info]
  (fn [info [_ id]]
@@ -81,16 +72,13 @@
 
 (re-frame/reg-sub
  :communities/featured-communities
- :<- [:communities/enabled?]
  :<- [:search/home-filter]
  :<- [:communities]
- (fn [[communities-enabled? search-filter communities]]
+ (fn [[search-filter communities]]
    (filterv
-    (fn [{:keys [name id]}]
-      (and (or communities-enabled?
-               (= id constants/status-community-id))
-           (or (empty? search-filter)
-               (string/includes? (string/lower-case (str name)) search-filter))))
+    (fn [{:keys [name]}]
+      (or (empty? search-filter)
+          (string/includes? (string/lower-case (str name)) search-filter)))
     (vals communities))))
 
 (re-frame/reg-sub
@@ -101,17 +89,13 @@
 
 (re-frame/reg-sub
  :communities/communities
- :<- [:communities/enabled?]
  :<- [:search/home-filter]
  :<- [:communities]
- (fn [[communities-enabled? search-filter communities]]
+ (fn [[search-filter communities]]
    (filterv
-    (fn [{:keys [name id]}]
-      (and
-       (or communities-enabled?
-           (= id constants/status-community-id))
-       (or (empty? search-filter)
-           (string/includes? (string/lower-case (str name)) search-filter))))
+    (fn [{:keys [name]}]
+      (or (empty? search-filter)
+          (string/includes? (string/lower-case (str name)) search-filter)))
     (vals communities))))
 
 (re-frame/reg-sub
@@ -151,7 +135,7 @@
 (re-frame/reg-sub
  :communities/home-item
  (fn [[_ community-id]]
-   [(re-frame/subscribe [:raw-communities])
+   [(re-frame/subscribe [:communities])
     (re-frame/subscribe [:communities/unviewed-counts community-id])])
  (fn [[communities counts] [_ identity]]
    (community->home-item
@@ -230,31 +214,62 @@
         (sort-by :position)
         (into []))))
 
+(defn reduce-over-categories
+  [community-id
+   joined
+   categories
+   collapsed-categories
+   full-chats-data]
+  (fn [acc
+       [_ {:keys [name categoryID position id emoji can-post?]}]]
+    (let [category-id                       (if (seq categoryID) categoryID constants/empty-category-id)
+          {:keys [unviewed-messages-count
+                  unviewed-mentions-count]} (get full-chats-data
+                                                 (str community-id id))
+          acc-with-category                 (if (get acc category-id)
+                                              acc
+                                              (assoc acc
+                                                     category-id
+                                                     (assoc
+                                                      (or (get categories category-id)
+                                                          {:name (i18n/label :t/none)})
+                                                      :collapsed? (get collapsed-categories
+                                                                       category-id)
+                                                      :chats      [])))
+          chat                              {:name             name
+                                             :emoji            emoji
+                                             :unread-messages? (pos? unviewed-messages-count)
+                                             :position         position
+                                             :mentions-count   (or unviewed-mentions-count 0)
+                                             :locked?          (or (not joined)
+                                                                   (not can-post?))
+                                             :id               id}]
+      (update-in acc-with-category [category-id :chats] conj chat))))
+
 (re-frame/reg-sub
  :communities/categorized-channels
  (fn [[_ community-id]]
    [(re-frame/subscribe [:communities/community community-id])
-    (re-frame/subscribe [:chats/chats])])
- (fn [[{:keys [joined categories chats]} full-chats-data] [_ community-id]]
-   (reduce
-    (fn [acc [_ {:keys [name categoryID id emoji can-post?]}]]
-      (let [category                                                  (keyword
-                                                                       (get-in categories
-                                                                               [categoryID :name]
-                                                                               (i18n/label :t/none)))
-            {:keys [unviewed-messages-count unviewed-mentions-count]} (get full-chats-data
-                                                                           (str community-id id))]
-        (update acc
-                category
-                #(vec (conj %1 %2))
-                {:name             name
-                 :emoji            emoji
-                 :unread-messages? (pos? unviewed-messages-count)
-                 :mentions-count   (or unviewed-mentions-count 0)
-                 :locked?          (or (not joined) (not can-post?))
-                 :id               id})))
-    {}
-    chats)))
+    (re-frame/subscribe [:chats/chats])
+    (re-frame/subscribe [:communities/collapsed-categories-for-community community-id])])
+ (fn [[{:keys [joined categories chats]} full-chats-data collapsed-categories] [_ community-id]]
+   (let [reduce-fn (reduce-over-categories
+                    community-id
+                    joined
+                    categories
+                    collapsed-categories
+                    full-chats-data)
+         categories-and-chats
+         (->>
+           chats
+           (reduce
+            reduce-fn
+            {})
+           (sort-by (comp :position second))
+           (map (fn [[k v]]
+                  [k (update v :chats #(sort-by :position %))])))]
+
+     categories-and-chats)))
 
 (re-frame/reg-sub
  :communities/users
@@ -264,3 +279,9 @@
     {:full-name "Marcus C"}
     {:full-name "MNO PQR"}
     {:full-name "STU VWX"}]))
+
+(re-frame/reg-sub
+ :communities/collapsed-categories-for-community
+ :<- [:communities/collapsed-categories]
+ (fn [collapsed-categories [_ community-id]]
+   (get collapsed-categories community-id)))

--- a/src/status_im2/subs/communities_test.cljs
+++ b/src/status_im2/subs/communities_test.cljs
@@ -3,25 +3,22 @@
             [re-frame.db :as rf-db]
             [test-helpers.unit :as h]
             status-im2.subs.communities
+            [status-im2.constants :as constants]
             [utils.re-frame :as rf]
             [utils.i18n :as i18n]))
 
 (use-fixtures :each
-              {:before #(reset! rf-db/app-db {:communities/enabled? true})})
+              {:before #(reset! rf-db/app-db {})})
 
 (def community-id "0x1")
 
 (h/deftest-sub :communities
   [sub-name]
-  (testing "returns empty vector if flag is disabled"
-    (swap! rf-db/app-db assoc :communities/enabled? false)
-    (is (= [] (rf/sub [sub-name]))))
-
-  (testing "returns raw communities if flag is enabled"
+  (testing "returns raw communities"
     (let [raw-communities {"0x1" {:id "0x1"}}]
       (swap! rf-db/app-db assoc
-        :communities/enabled? true
-        :communities          raw-communities)
+        :communities
+        raw-communities)
       (is (= raw-communities (rf/sub [sub-name]))))))
 
 (h/deftest-sub :communities/section-list
@@ -85,13 +82,12 @@
   [sub-name]
   (testing "Empty communities list"
     (swap! rf-db/app-db assoc
-      :communities/enabled? true
-      :communities          {})
+      :communities
+      {})
     (is (= []
            (rf/sub [sub-name]))))
   (testing "communities sorted by name"
     (swap! rf-db/app-db assoc
-      :communities/enabled? true
       :communities
       {"0x1" {:id "0x1" :name "Civilized monkeys"}
        "0x2" {:id "0x2" :name "Civilized rats"}
@@ -105,56 +101,127 @@
   [sub-name]
   (testing "Channels with categories"
     (swap! rf-db/app-db assoc
-      :communities/enabled? true
       :communities
       {"0x1" {:id         "0x1"
-              :chats      {"0x1" {:id "0x1" :name "chat1" :categoryID 1 :can-post? true}
-                           "0x2" {:id "0x2" :name "chat2" :categoryID 1 :can-post? false}
-                           "0x3" {:id "0x3" :name "chat3" :categoryID 2 :can-post? true}}
-              :categories {1 {:id 1 :name "category1"}
-                           2 {:id 2 :name "category2"}}
+              :chats      {"0x1" {:id "0x1" :position 1 :name "chat1" :categoryID "1" :can-post? true}
+                           "0x2" {:id "0x2" :position 2 :name "chat2" :categoryID "1" :can-post? false}
+                           "0x3" {:id "0x3" :position 3 :name "chat3" :categoryID "2" :can-post? true}}
+              :categories {"1" {:id       "1"
+                                :position 2
+                                :name     "category1"}
+                           "2" {:id       "2"
+                                :position 1
+                                :name     "category2"}}
               :joined     true}})
     (is
-     (= {:category1
-         [{:name "chat1" :emoji nil :locked? false :id "0x1" :unread-messages? false :mentions-count 0}
-          {:name "chat2" :emoji nil :locked? true :id "0x2" :unread-messages? false :mentions-count 0}]
-         :category2
-         [{:name "chat3" :emoji nil :locked? false :id "0x3" :unread-messages? false :mentions-count 0}]}
+     (= [["2"
+          {:id         "2"
+           :name       "category2"
+           :collapsed? nil
+           :position   1
+           :chats      [{:name             "chat3"
+                         :position         3
+                         :emoji            nil
+                         :locked?          false
+                         :id               "0x3"
+                         :unread-messages? false
+                         :mentions-count   0}]}]
+         ["1"
+          {:id         "1"
+           :name       "category1"
+           :collapsed? nil
+           :position   2
+           :chats      [{:name             "chat1"
+                         :emoji            nil
+                         :position         1
+                         :locked?          false
+                         :id               "0x1"
+                         :unread-messages? false
+                         :mentions-count   0}
+                        {:name             "chat2"
+                         :emoji            nil
+                         :position         2
+                         :locked?          true
+                         :id               "0x2"
+                         :unread-messages? false
+                         :mentions-count   0}]}]]
         (rf/sub [sub-name "0x1"]))))
   (testing "Channels without categories"
     (swap! rf-db/app-db assoc
-      :communities/enabled? true
       :communities
       {"0x1" {:id         "0x1"
-              :chats      {"0x1" {:id "0x1" :name "chat1" :categoryID 1 :can-post? true}
-                           "0x2" {:id "0x2" :name "chat2" :categoryID 1 :can-post? false}
-                           "0x3" {:id "0x3" :name "chat3" :can-post? true}}
-              :categories {1 {:id 1 :name "category1"}
-                           2 {:id 2 :name "category2"}}
+              :chats      {"0x1" {:id "0x1" :position 1 :name "chat1" :categoryID "1" :can-post? true}
+                           "0x2" {:id "0x2" :position 2 :name "chat2" :categoryID "1" :can-post? false}
+                           "0x3" {:id "0x3" :position 3 :name "chat3" :can-post? true}}
+              :categories {"1" {:id       "1"
+                                :position 1
+                                :name     "category1"}
+                           "2" {:id       "2"
+                                :position 2
+                                :name     "category2"}}
               :joined     true}})
     (is
-     (= {:category1
-         [{:name "chat1" :emoji nil :locked? false :id "0x1" :unread-messages? false :mentions-count 0}
-          {:name "chat2" :emoji nil :locked? true :id "0x2" :unread-messages? false :mentions-count 0}]
-         (keyword (i18n/label :t/none))
-         [{:name "chat3" :emoji nil :locked? false :id "0x3" :unread-messages? false :mentions-count 0}]}
-        (rf/sub [sub-name "0x1"]))))
+     (=
+      [[constants/empty-category-id
+        {:name       (i18n/label :t/none)
+         :collapsed? nil
+         :chats      [{:name             "chat3"
+                       :emoji            nil
+                       :position         3
+                       :locked?          false
+                       :id               "0x3"
+                       :unread-messages? false
+                       :mentions-count   0}]}]
+       ["1"
+        {:name       "category1"
+         :id         "1"
+         :position   1
+         :collapsed? nil
+         :chats      [{:name             "chat1"
+                       :emoji            nil
+                       :position         1
+                       :locked?          false
+                       :id               "0x1"
+                       :unread-messages? false
+                       :mentions-count   0}
+                      {:name             "chat2"
+                       :emoji            nil
+                       :position         2
+                       :locked?          true
+                       :id               "0x2"
+                       :unread-messages? false
+                       :mentions-count   0}]}]]
+      (rf/sub [sub-name "0x1"]))))
   (testing "Unread messages"
     (swap! rf-db/app-db assoc
-      :communities/enabled? true
       :communities
       {"0x1" {:id         "0x1"
-              :chats      {"0x1" {:id "0x1" :name "chat1" :categoryID 1 :can-post? true}
-                           "0x2" {:id "0x2" :name "chat2" :categoryID 1 :can-post? false}}
-              :categories {1 {:id 1 :name "category1"}}
+              :chats      {"0x1" {:id "0x1" :position 1 :name "chat1" :categoryID "1" :can-post? true}
+                           "0x2" {:id "0x2" :position 2 :name "chat2" :categoryID "1" :can-post? false}}
+              :categories {"1" {:id "1" :name "category1"}}
               :joined     true}}
       :chats
       {"0x10x1" {:unviewed-messages-count 1 :unviewed-mentions-count 2}
        "0x10x2" {:unviewed-messages-count 0 :unviewed-mentions-count 0}})
     (is
-     (= {:category1
-         [{:name "chat1" :emoji nil :locked? false :id "0x1" :unread-messages? true :mentions-count 2}
-          {:name "chat2" :emoji nil :locked? true :id "0x2" :unread-messages? false :mentions-count 0}]}
+     (= [["1"
+          {:name       "category1"
+           :id         "1"
+           :collapsed? nil
+           :chats      [{:name             "chat1"
+                         :emoji            nil
+                         :position         1
+                         :locked?          false
+                         :id               "0x1"
+                         :unread-messages? true
+                         :mentions-count   2}
+                        {:name             "chat2"
+                         :emoji            nil
+                         :position         2
+                         :locked?          true
+                         :id               "0x2"
+                         :unread-messages? false
+                         :mentions-count   0}]}]]
         (rf/sub [sub-name "0x1"])))))
 
 (h/deftest-sub :communities/my-pending-requests-to-join

--- a/src/status_im2/subs/root.cljs
+++ b/src/status_im2/subs/root.cljs
@@ -238,14 +238,14 @@
 
 ;; communities
 
-(reg-root-key-sub :raw-communities :communities)
+(reg-root-key-sub :communities :communities)
 (reg-root-key-sub :communities/create :communities/create)
 (reg-root-key-sub :communities/create-channel :communities/create-channel)
 (reg-root-key-sub :communities/requests-to-join :communities/requests-to-join)
 (reg-root-key-sub :communities/community-id-input :communities/community-id-input)
-(reg-root-key-sub :communities/enabled? :communities/enabled?)
 (reg-root-key-sub :communities/resolve-community-info :communities/resolve-community-info)
 (reg-root-key-sub :communities/my-pending-requests-to-join :communities/my-pending-requests-to-join)
+(reg-root-key-sub :communities/collapsed-categories :communities/collapsed-categories)
 
 (reg-root-key-sub :activity-center :activity-center)
 
@@ -253,6 +253,7 @@
 (reg-root-key-sub :bug-report/details :bug-report/details)
 
 (reg-root-key-sub :backup/performing-backup :backup/performing-backup)
+
 
 ;; wallet connect
 (reg-root-key-sub :wallet-connect/proposal-metadata :wallet-connect/proposal-metadata)

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.138.3",
-    "commit-sha1": "290579f74f10a374ffb8c37abc47dbe2c1e90f5d",
-    "src-sha256": "0vgs3m1fbyri9r1wqxfanzxlx24yzx9zaabflk26qc9d4pclmi7i"
+    "version": "v0.138.4",
+    "commit-sha1": "44a0f5b74d31fe31bd77b565ae679f839ea40e94",
+    "src-sha256": "05j9y1fg23xgqj4348cjpn7xm6jmhzj9xz2zwhvhagnq1c28800c"
 }


### PR DESCRIPTION
https://github.com/status-im/status-go/compare/4d705ce1...0143c12a

Fixes: #15290

This commit adds collapsing of categories.
It also adds ordering of chats/categories as it was previously ignored.

It also removes the communities/enabled? flag as it's not used anymore, and communities should always be enabled.

