### PR TITLE
refactor: chat message list context related

### DIFF
--- a/src/status_im2/contexts/chat/messages/drawers/view.cljs
+++ b/src/status_im2/contexts/chat/messages/drawers/view.cljs
@@ -22,11 +22,10 @@
 (defn get-actions
   [{:keys [outgoing content pinned outgoing-status deleted? deleted-for-me? content-type]
     :as   message-data}
-   {:keys [edit-enabled show-input? community? can-delete-message-for-everyone?
+   {:keys [able-to-send-message? community? can-delete-message-for-everyone?
            message-pin-enabled group-chat group-admin?]}]
   (concat
    (when (and outgoing
-              edit-enabled
               (not (or deleted? deleted-for-me?))
               (not= content-type constants/content-type-audio))
      [{:type     :main
@@ -34,7 +33,7 @@
        :label    (i18n/label :t/edit-message)
        :icon     :i/edit
        :id       :edit}])
-   (when (and show-input? (not= outgoing-status :sending) (not (or deleted? deleted-for-me?)))
+   (when (and able-to-send-message? (not= outgoing-status :sending) (not (or deleted? deleted-for-me?)))
      [{:type     :main
        :on-press #(rf/dispatch [:chat.ui/reply-to-message message-data])
        :label    (i18n/label :t/message-reply)

--- a/src/status_im2/contexts/chat/messages/pin/list/view.cljs
+++ b/src/status_im2/contexts/chat/messages/pin/list/view.cljs
@@ -19,15 +19,11 @@
 
 (defn pinned-messages-list
   [chat-id]
-  (let [pinned-messages (rf/sub [:chats/pinned-sorted-list
-                                 chat-id])
-        current-chat (rf/sub [:chat-by-id chat-id])
-
-        {:keys [group-chat chat-id public? community-id admins]}
-        current-chat
-
-        community (rf/sub [:communities/community
-                           community-id])]
+  (let [pinned-messages        (rf/sub [:chats/pinned-sorted-list chat-id])
+        render-data            (rf/sub [:chats/current-chat-message-list-view-context :in-pinned-view])
+        current-chat           (rf/sub [:chat-by-id chat-id])
+        {:keys [community-id]} current-chat
+        community              (rf/sub [:communities/community community-id])]
     [rn/view {:accessibility-label :pinned-messages-list}
      ;; TODO (flexsurfer) this should be a component in quo2
      ;; https://github.com/status-im/status-mobile/issues/14529
@@ -56,17 +52,10 @@
           {:style {:margin-left  4
                    :margin-right 8}}
           (str "# " (:chat-name current-chat))]])]
-     (if (> (count pinned-messages) 0)
+     (if (pos? (count pinned-messages))
        [rn/flat-list
         {:data        pinned-messages
-         :render-data (list.view/get-render-data {:group-chat      group-chat
-                                                  :chat-id         chat-id
-                                                  :public?         public?
-                                                  :community-id    community-id
-                                                  :show-input?     false
-                                                  :admins          admins
-                                                  :edit-enabled    true
-                                                  :in-pinned-view? true})
+         :render-data render-data
          :render-fn   message-render-fn
          :key-fn      list-key-fn
          :separator   quo/separator}]

--- a/src/status_im2/contexts/chat/messages/pin/list/view.cljs
+++ b/src/status_im2/contexts/chat/messages/pin/list/view.cljs
@@ -4,7 +4,6 @@
             [react-native.core :as rn]
             [status-im2.contexts.chat.messages.content.deleted.view :as content.deleted]
             [status-im2.contexts.chat.messages.content.view :as message]
-            [status-im2.contexts.chat.messages.list.view :as list.view]
             [utils.i18n :as i18n]
             [utils.re-frame :as rf]))
 

--- a/src/status_im2/contexts/chat/messages/view.cljs
+++ b/src/status_im2/contexts/chat/messages/view.cljs
@@ -4,11 +4,11 @@
             [react-native.core :as rn]
             [react-native.safe-area :as safe-area]
             [reagent.core :as reagent]
-            [status-im2.contexts.chat.messages.composer.view :as composer]
             [status-im2.constants :as constants]
-            [status-im2.contexts.chat.messages.list.view :as messages.list]
+            [status-im2.contexts.chat.messages.composer.view :as composer]
             [status-im2.contexts.chat.messages.contact-requests.bottom-drawer :as
              contact-requests.bottom-drawer]
+            [status-im2.contexts.chat.messages.list.view :as messages.list]
             [status-im2.contexts.chat.messages.pin.banner.view :as pin.banner]
             [status-im2.navigation.state :as navigation.state]
             [utils.debounce :as debounce]
@@ -67,7 +67,7 @@
 (defn chat-render
   []
   (let [;;NOTE: we want to react only on these fields, do not use full chat map here
-        {:keys [chat-id contact-request-state group-chat show-input?] :as chat}
+        {:keys [chat-id contact-request-state group-chat able-to-send-message?] :as chat}
         (rf/sub [:chats/current-chat-chat-view])]
     [safe-area/consumer
      (fn [insets]
@@ -76,8 +76,8 @@
          :keyboardVerticalOffset (- (:bottom insets))}
         [page-nav]
         [pin.banner/banner chat-id]
-        [messages.list/messages-list {:chat chat :show-input? show-input?}]
-        (if-not show-input?
+        [messages.list/messages-list chat]
+        (if-not able-to-send-message?
           [contact-requests.bottom-drawer/view chat-id contact-request-state group-chat]
           [composer/composer chat-id insets])])]))
 

--- a/src/status_im2/subs/chat/chats_test.cljs
+++ b/src/status_im2/subs/chat/chats_test.cljs
@@ -1,8 +1,8 @@
 (ns status-im2.subs.chat.chats-test
   (:require [cljs.test :refer [is testing]]
             [re-frame.db :as rf-db]
-            [test-helpers.unit :as h]
             [status-im2.constants :as constants]
+            [test-helpers.unit :as h]
             [utils.re-frame :as rf]))
 
 (def public-key "0xpk")
@@ -31,14 +31,14 @@
         :multiaccount    multiaccount
         :current-chat-id chat-id
         :chats           chats)
-      (is (true? (:show-input? (rf/sub [sub-name]))))))
+      (is (true? (:able-to-send-message? (rf/sub [sub-name]))))))
   (testing "private group chat, user is not member"
     (let [chats {chat-id (dissoc private-group-chat :members)}]
       (swap! rf-db/app-db assoc
         :multiaccount    multiaccount
         :current-chat-id chat-id
         :chats           chats)
-      (is (not (:show-input? (rf/sub [sub-name]))))))
+      (is (not (:able-to-send-message? (rf/sub [sub-name]))))))
   (testing "one to one chat, mutual contacts"
     (let [chats {chat-id one-to-one-chat}]
       (swap! rf-db/app-db assoc
@@ -46,7 +46,7 @@
         :multiaccount      multiaccount
         :current-chat-id   chat-id
         :chats             chats)
-      (is (:show-input? (rf/sub [sub-name])))))
+      (is (:able-to-send-message? (rf/sub [sub-name])))))
   (testing "one to one chat, not a contact"
     (let [chats {chat-id one-to-one-chat}]
       (swap! rf-db/app-db assoc
@@ -54,4 +54,4 @@
         :multiaccount      multiaccount
         :current-chat-id   chat-id
         :chats             chats)
-      (is (not (:show-input? (rf/sub [sub-name])))))))
+      (is (not (:able-to-send-message? (rf/sub [sub-name])))))))

--- a/src/status_im2/subs/chat/chats_test.cljs
+++ b/src/status_im2/subs/chat/chats_test.cljs
@@ -9,6 +9,8 @@
 (def multiaccount {:public-key public-key})
 (def chat-id "1")
 (def chat {:chat-id chat-id})
+(def community-id "community-1")
+(def community {:community-id community-id})
 
 (def private-group-chat
   (assoc
@@ -16,6 +18,13 @@
    :members    #{{:id public-key}}
    :group-chat true
    :chat-type  constants/private-group-chat-type))
+
+(def community-chat
+  (assoc
+   chat
+   :group-chat   true
+   :community-id community-id
+   :chat-type    constants/community-chat-type))
 
 (def one-to-one-chat
   (assoc
@@ -55,3 +64,99 @@
         :current-chat-id   chat-id
         :chats             chats)
       (is (not (:able-to-send-message? (rf/sub [sub-name])))))))
+
+(h/deftest-sub :chats/current-chat-message-list-view-context
+  [sub-name]
+  (testing "reflect :in-pinned-view? in the result"
+    (reset! rf-db/app-db {})
+    (is (true? (:in-pinned-view? (rf/sub [sub-name :in-pinned-view]))))
+    (is (false? (:in-pinned-view? (rf/sub [sub-name])))))
+  (testing "reflect current community in community?"
+    (let [chats       {chat-id community-chat}
+          communities {community-id community}]
+      (is (false? (:community? (rf/sub [sub-name]))))
+      (swap! rf-db/app-db assoc
+        :communities/enabled? true
+        :current-chat-id      chat-id
+        :chats                chats
+        :communities          communities)
+      (is (true? (:community? (rf/sub [sub-name]))))))
+  (testing "community admin"
+    (let [chats       {chat-id community-chat}
+          communities {community-id (assoc community
+                                           :admin true
+                                           :can-delete-message-for-everyone? true
+                                           :admin-settings {:pin-message-all-members-enabled? false})}]
+      (is (false? (:community? (rf/sub [sub-name]))))
+      (swap! rf-db/app-db assoc
+        :communities/enabled? true
+        :multiaccount         multiaccount
+        :current-chat-id      chat-id
+        :chats                chats
+        :communities          communities)
+      (is (= chat-id (:chat-id (rf/sub [sub-name]))))
+      (is (= public-key (:current-public-key (rf/sub [sub-name]))))
+      (is (true? (:community? (rf/sub [sub-name]))))
+      (is (true? (:group-chat (rf/sub [sub-name]))))
+      (is (true? (:community-admin? (rf/sub [sub-name]))))
+      (is (true? (:can-delete-message-for-everyone? (rf/sub [sub-name]))))
+      (is (not (:group-admin? (rf/sub [sub-name]))))
+      (is (true? (:message-pin-enabled (rf/sub [sub-name]))))))
+  (testing "community member"
+    (let [chats       {chat-id community-chat}
+          communities {community-id (assoc community
+                                           :admin false
+                                           :can-delete-message-for-everyone? false
+                                           :admin-settings {:pin-message-all-members-enabled?
+                                                            false})}]
+      (is (false? (:community? (rf/sub [sub-name]))))
+      (swap! rf-db/app-db assoc
+        :communities/enabled? true
+        :multiaccount         multiaccount
+        :current-chat-id      chat-id
+        :chats                chats
+        :communities          communities)
+      (is (= chat-id (:chat-id (rf/sub [sub-name]))))
+      (is (= public-key (:current-public-key (rf/sub [sub-name]))))
+      (is (true? (:community? (rf/sub [sub-name]))))
+      (is (true? (:group-chat (rf/sub [sub-name]))))
+      (is (not (:community-admin? (rf/sub [sub-name]))))
+      (is (not (:can-delete-message-for-everyone? (rf/sub [sub-name]))))
+      (is (not (:group-admin? (rf/sub [sub-name]))))
+      (is (not (:message-pin-enabled (rf/sub [sub-name]))))))
+  (testing "group admin"
+    (let [chats {chat-id (assoc private-group-chat
+                                :admins
+                                #{public-key})}]
+      (swap! rf-db/app-db assoc
+        :communities/enabled? true
+        :multiaccount         multiaccount
+        :current-chat-id      chat-id
+        :chats                chats)
+      (is (= chat-id (:chat-id (rf/sub [sub-name]))))
+      (is (= public-key (:current-public-key (rf/sub [sub-name]))))
+      (is (not (:public? (rf/sub [sub-name]))))
+      (is (not (:community? (rf/sub [sub-name]))))
+      (is (true? (:group-chat (rf/sub [sub-name]))))
+      (is (not (:community-admin? (rf/sub [sub-name]))))
+      (is (not (:can-delete-message-for-everyone? (rf/sub [sub-name]))))
+      (is (true? (:group-admin? (rf/sub [sub-name]))))
+      (is (true? (:message-pin-enabled (rf/sub [sub-name]))))))
+  (testing "group member"
+    (let [chats {chat-id (assoc private-group-chat
+                                :admins
+                                #{})}]
+      (swap! rf-db/app-db assoc
+        :communities/enabled? true
+        :multiaccount         multiaccount
+        :current-chat-id      chat-id
+        :chats                chats)
+      (is (= chat-id (:chat-id (rf/sub [sub-name]))))
+      (is (= public-key (:current-public-key (rf/sub [sub-name]))))
+      (is (not (:public? (rf/sub [sub-name]))))
+      (is (not (:community? (rf/sub [sub-name]))))
+      (is (true? (:group-chat (rf/sub [sub-name]))))
+      (is (not (:community-admin? (rf/sub [sub-name]))))
+      (is (not (:can-delete-message-for-everyone? (rf/sub [sub-name]))))
+      (is (not (:group-admin? (rf/sub [sub-name]))))
+      (is (not (:message-pin-enabled (rf/sub [sub-name])))))))


### PR DESCRIPTION
### Summary

refactor the `get-render-data` fn which used to compute the (pinned) message list render context, which is the `context` in `:render-fn` of the falt list.

1. remove `edit-enabled`, `true` every where
2. rename `show-input?` to `able-to-send-message?`
3. move message-list `get-render-data` to chat subs `:chats/current-chat-message-list-view-context`

related comment https://github.com/status-im/status-mobile/pull/15197#discussion_r1119029129


### Testing notes
mainly related to message list and pinned message list in chat

status: ready <!-- Can be ready or wip -->