### PR TITLE
Allow underscores as a valid character for status-tags

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.140.1",
-    "commit-sha1": "e2082bf5bdd2c43bf1f140ddc4d3eece6de88bc0",
-    "src-sha256": "1gfykjs51862kbfjqr2sslsdhmn4j19hj67zr34gm3xdcy9ci0xx"
+    "version": "v0.138.2",
+    "commit-sha1": "cd96f557f9f8e35cb17cf55f48e396e7b84a4eb6",
+    "src-sha256": "0pcf3kz8rvqmw2kvlx2zypw09ixvnbyh7hqn38nvfyyvc4lqx6gp"
 }


### PR DESCRIPTION
fixes #15335 
[Status-go PR](https://github.com/status-im/status-go/pull/3286)
Adds underscores as a valid character for status-tags
status: ready 
