### PR TITLE
fix: image typo

### DIFF
--- a/src/status_im2/contexts/chat/messages/content/image/view.cljs
+++ b/src/status_im2/contexts/chat/messages/content/image/view.cljs
@@ -30,8 +30,8 @@
              :on-press       (fn []
                                (rf/dispatch [:chat.ui/update-shared-element-id message-id])
                                (js/setTimeout #(rf/dispatch [:navigate-to :lightbox
-                                                             {:messages (:album message)
-                                                              :index    index
+                                                             {:messages [message]
+                                                              :index    0
                                                               :insets   insets}])
                                               100))}
             (when (and (not= text "placeholder") (= index 0))


### PR DESCRIPTION
fixes: https://github.com/status-im/status-mobile/issues/15389

fixes a small typo when opening image