### PR TITLE
feat: bottom sheet screen

### DIFF
--- a/src/quo2/foundations/colors.cljs
+++ b/src/quo2/foundations/colors.cljs
@@ -85,6 +85,7 @@
 ;;100 with transparency
 (def neutral-100-opa-0 (alpha neutral-100 0))
 (def neutral-100-opa-10 (alpha neutral-100 0.1))
+(def neutral-100-opa-30 (alpha neutral-100 0.3))
 (def neutral-100-opa-60 (alpha neutral-100 0.6))
 (def neutral-100-opa-70 (alpha neutral-100 0.7))
 (def neutral-100-opa-80 (alpha neutral-100 0.8))

--- a/src/react_native/hooks.cljs
+++ b/src/react_native/hooks.cljs
@@ -6,3 +6,7 @@
   (let [kb (.useKeyboard hooks)]
     {:keyboard-shown  (.-keyboardShown ^js kb)
      :keyboard-height (.-keyboardHeight ^js kb)}))
+
+(defn use-back-handler
+  [handler]
+  (.useBackHandler hooks handler))

--- a/src/react_native/reanimated.cljs
+++ b/src/react_native/reanimated.cljs
@@ -21,6 +21,8 @@
             [utils.collection]
             [utils.worklets.core :as worklets.core]))
 
+(def ^:const default-duration 300)
+
 ;; Animations
 (def slide-in-up-animation SlideInUp)
 (def slide-out-up-animation SlideOutUp)
@@ -65,7 +67,8 @@
 (def in-out
   (.-inOut ^js Easing))
 
-(defn default-easing [] (in-out (.-quad ^js Easing)))
+;; trying to put default-easing inside easings map causes test to fail
+(def default-easing (in-out (.-quad ^js Easing)))
 
 (def easings
   {:linear  (bezier 0 0 1 1)
@@ -115,13 +118,15 @@
                                              (js-obj "duration" duration
                                                      "easing"   (get easings easing))))))
 
-(defn animate-shared-value-with-delay-default-easing
-  [anim val duration delay]
-  (set-shared-value anim
-                    (with-delay delay
-                                (with-timing val
-                                             (js-obj "duration" duration
-                                                     "easing"   (in-out (.-quad ^js Easing)))))))
+(defn animate-delay
+  ([animation val delay]
+   (animate-delay animation val delay default-duration))
+  ([animation val delay duration]
+   (set-shared-value animation
+                     (with-delay delay
+                                 (with-timing val
+                                              (clj->js {:duration duration
+                                                        :easing   default-easing}))))))
 
 (defn animate-shared-value-with-repeat
   [anim val duration easing number-of-repetitions reverse?]

--- a/src/react_native/reanimated.cljs
+++ b/src/react_native/reanimated.cljs
@@ -68,7 +68,7 @@
   (.-inOut ^js Easing))
 
 ;; trying to put default-easing inside easings map causes test to fail
-(def default-easing (in-out (.-quad ^js Easing)))
+(defn default-easing [] (in-out (.-quad ^js Easing)))
 
 (def easings
   {:linear  (bezier 0 0 1 1)
@@ -126,7 +126,7 @@
                      (with-delay delay
                                  (with-timing val
                                               (clj->js {:duration duration
-                                                        :easing   default-easing}))))))
+                                                        :easing   (default-easing)}))))))
 
 (defn animate-shared-value-with-repeat
   [anim val duration easing number-of-repetitions reverse?]

--- a/src/status_im2/common/bottom_sheet_screen/style.cljs
+++ b/src/status_im2/common/bottom_sheet_screen/style.cljs
@@ -18,7 +18,7 @@
   [translate-y]
   (reanimated/apply-animations-to-style
    {:transform [{:translate-y translate-y}]}
-   {:background-color        (colors/theme-colors colors/white colors/neutral-100)
+   {:background-color        (colors/theme-colors colors/white colors/neutral-95)
     :border-top-left-radius  20
     :border-top-right-radius 20
     :flex                    1
@@ -34,8 +34,9 @@
    :justify-content :center
    :align-items     :center})
 
-(def handle
+(defn handle
+  []
   {:width            32
    :height           4
    :border-radius    100
-   :background-color (colors/theme-colors colors/neutral-100-opa-10 colors/white-opa-10)})
+   :background-color (colors/theme-colors colors/neutral-100-opa-30 colors/white-opa-30)})

--- a/src/status_im2/common/bottom_sheet_screen/style.cljs
+++ b/src/status_im2/common/bottom_sheet_screen/style.cljs
@@ -1,0 +1,42 @@
+(ns status-im2.common.bottom-sheet-screen.style
+  (:require
+    [quo2.foundations.colors :as colors]
+    [react-native.reanimated :as reanimated]))
+
+(defn background
+  [opacity]
+  (reanimated/apply-animations-to-style
+   {:opacity opacity}
+   {:background-color colors/neutral-100-opa-70
+    :position         :absolute
+    :top              0
+    :bottom           0
+    :left             0
+    :right            0}))
+
+(defn main-view
+  [translate-y]
+  (reanimated/apply-animations-to-style
+   {:transform [{:translateY translate-y}]}
+   {:margin-top              0
+    :background-color        (colors/theme-colors colors/white colors/neutral-100)
+    :border-top-left-radius  20
+    :border-top-right-radius 20
+    :flex                    1
+    :overflow                :hidden}))
+
+(def handle-container
+  {:left            0
+   :right           0
+   :top             0
+   :height          20
+   :z-index         1
+   :position        :absolute
+   :justify-content :center
+   :align-items     :center})
+
+(def handle
+  {:width            32
+   :height           4
+   :border-radius    100
+   :background-color (colors/theme-colors colors/neutral-100-opa-10 colors/white-opa-10)})

--- a/src/status_im2/common/bottom_sheet_screen/style.cljs
+++ b/src/status_im2/common/bottom_sheet_screen/style.cljs
@@ -17,9 +17,8 @@
 (defn main-view
   [translate-y]
   (reanimated/apply-animations-to-style
-   {:transform [{:translateY translate-y}]}
-   {:margin-top              0
-    :background-color        (colors/theme-colors colors/white colors/neutral-100)
+   {:transform [{:translate-y translate-y}]}
+   {:background-color        (colors/theme-colors colors/white colors/neutral-100)
     :border-top-left-radius  20
     :border-top-right-radius 20
     :flex                    1

--- a/src/status_im2/common/bottom_sheet_screen/view.cljs
+++ b/src/status_im2/common/bottom_sheet_screen/view.cljs
@@ -1,6 +1,7 @@
 (ns status-im2.common.bottom-sheet-screen.view
   (:require
     [react-native.gesture :as gesture]
+    [react-native.hooks :as hooks]
     [react-native.navigation :as navigation]
     [react-native.platform :as platform]
     [react-native.reanimated :as reanimated]
@@ -59,8 +60,8 @@
                            (rf/dispatch [:navigate-back]))]
          (rn/use-effect
           (fn []
-            (reanimated/animate-delay opacity 1 (if platform/ios? 300 100))
-            (rn/hw-back-add-listener close)))
+            (reanimated/animate-delay opacity 1 (if platform/ios? 300 100))))
+         (hooks/use-back-handler close)
          [rn/view
           {:style {:flex        1
                    :padding-top padding-top}}

--- a/src/status_im2/common/bottom_sheet_screen/view.cljs
+++ b/src/status_im2/common/bottom_sheet_screen/view.cljs
@@ -6,6 +6,7 @@
     [react-native.platform :as platform]
     [react-native.reanimated :as reanimated]
     [oops.core :as oops]
+    [react-native.safe-area :as safe-area]
     [status-im2.common.bottom-sheet-screen.style :as style]
     [react-native.core :as rn]
     [reagent.core :as reagent]
@@ -49,11 +50,13 @@
   [content skip-background?]
   [:f>
    (let [scroll-enabled (reagent/atom true)
-         curr-scroll    (atom 0)
-         padding-top    (navigation/status-bar-height)
-         padding-top    (if platform/ios? padding-top (+ padding-top 10))]
+         curr-scroll    (atom 0)]
      (fn []
-       (let [opacity     (reanimated/use-shared-value 0)
+       (let [sb-height   (navigation/status-bar-height)
+             insets      (safe-area/use-safe-area)
+             padding-top (Math/max sb-height (:top insets))
+             padding-top (if platform/ios? padding-top (+ padding-top 10))
+             opacity     (reanimated/use-shared-value 0)
              translate-y (reanimated/use-shared-value 0)
              close       (fn []
                            (reanimated/set-shared-value opacity (reanimated/with-timing-duration 0 100))
@@ -71,7 +74,7 @@
            {:gesture (drag-gesture translate-y opacity scroll-enabled curr-scroll)}
            [reanimated/view {:style (style/main-view translate-y)}
             [rn/view {:style style/handle-container}
-             [rn/view {:style style/handle}]]
+             [rn/view {:style (style/handle)}]]
             [content
              {:close          close
               :scroll-enabled @scroll-enabled

--- a/src/status_im2/common/bottom_sheet_screen/view.cljs
+++ b/src/status_im2/common/bottom_sheet_screen/view.cljs
@@ -50,7 +50,7 @@
    (let [scroll-enabled (reagent/atom true)
          curr-scroll    (atom 0)
          padding-top    (navigation/status-bar-height)
-         padding-top    (if platform/ios? padding-top (+ padding-top 20))]
+         padding-top    (if platform/ios? padding-top (+ padding-top 10))]
      (fn []
        (let [opacity     (reanimated/use-shared-value 0)
              translate-y (reanimated/use-shared-value 0)

--- a/src/status_im2/contexts/chat/lightbox/top_view.cljs
+++ b/src/status_im2/contexts/chat/lightbox/top_view.cljs
@@ -77,7 +77,8 @@
           [quo/text
            {:weight :medium
             :size   :paragraph-2
-            ;; TODO: layout animation in release mode causes crash: https://github.com/status-im/status-mobile/issues/15395
+            ;; TODO: layout animation in release mode causes crash:
+            ;; https://github.com/status-im/status-mobile/issues/15395
             :style  {:color colors/neutral-40}} "9:41 AM"]]]
         [rn/view {:style style/top-right-buttons}
          [rn/touchable-opacity

--- a/src/status_im2/contexts/chat/lightbox/top_view.cljs
+++ b/src/status_im2/contexts/chat/lightbox/top_view.cljs
@@ -77,7 +77,7 @@
           [quo/text
            {:weight :medium
             :size   :paragraph-2
-            :style  {:color colors/neutral-40}} (datetime/to-short-str timestamp)]]]
+            :style  {:color colors/neutral-40}} "9:41 AM"]]]
         [rn/view {:style style/top-right-buttons}
          [rn/touchable-opacity
           {:active-opacity 1

--- a/src/status_im2/contexts/chat/lightbox/top_view.cljs
+++ b/src/status_im2/contexts/chat/lightbox/top_view.cljs
@@ -8,7 +8,6 @@
     [react-native.reanimated :as reanimated]
     [status-im2.contexts.chat.lightbox.animations :as anim]
     [status-im2.contexts.chat.lightbox.style :as style]
-    [utils.datetime :as datetime]
     [utils.re-frame :as rf]
     [status-im2.contexts.chat.lightbox.constants :as c]))
 

--- a/src/status_im2/contexts/chat/lightbox/top_view.cljs
+++ b/src/status_im2/contexts/chat/lightbox/top_view.cljs
@@ -40,7 +40,7 @@
         (anim/animate top-view-bg colors/neutral-100-opa-0)))))
 
 (defn top-view
-  [{:keys [from timestamp]} insets index animations derived landscape? screen-width]
+  [{:keys [from]} insets index animations derived landscape? screen-width]
   [:f>
    (fn []
      (let [display-name                       (first (rf/sub [:contacts/contact-two-names-by-identity
@@ -77,7 +77,9 @@
           [quo/text
            {:weight :medium
             :size   :paragraph-2
-            :style  {:color colors/neutral-40}} (datetime/to-short-str timestamp)]]]
+            ;; TODO: layout animation in release mode causes crash:
+            ;; https://github.com/status-im/status-mobile/issues/15395
+            :style  {:color colors/neutral-40}} "9:41 AM"]]]
         [rn/view {:style style/top-right-buttons}
          [rn/touchable-opacity
           {:active-opacity 1

--- a/src/status_im2/contexts/chat/lightbox/top_view.cljs
+++ b/src/status_im2/contexts/chat/lightbox/top_view.cljs
@@ -40,7 +40,7 @@
         (anim/animate top-view-bg colors/neutral-100-opa-0)))))
 
 (defn top-view
-  [{:keys [from]} insets index animations derived landscape? screen-width]
+  [{:keys [from timestamp]} insets index animations derived landscape? screen-width]
   [:f>
    (fn []
      (let [display-name                       (first (rf/sub [:contacts/contact-two-names-by-identity
@@ -77,9 +77,7 @@
           [quo/text
            {:weight :medium
             :size   :paragraph-2
-            ;; TODO: layout animation in release mode causes crash:
-            ;; https://github.com/status-im/status-mobile/issues/15395
-            :style  {:color colors/neutral-40}} "9:41 AM"]]]
+            :style  {:color colors/neutral-40}} timestamp]]]
         [rn/view {:style style/top-right-buttons}
          [rn/touchable-opacity
           {:active-opacity 1

--- a/src/status_im2/contexts/chat/lightbox/top_view.cljs
+++ b/src/status_im2/contexts/chat/lightbox/top_view.cljs
@@ -40,7 +40,7 @@
         (anim/animate top-view-bg colors/neutral-100-opa-0)))))
 
 (defn top-view
-  [{:keys [from timestamp]} insets index animations derived landscape? screen-width]
+  [{:keys [from]} insets index animations derived landscape? screen-width]
   [:f>
    (fn []
      (let [display-name                       (first (rf/sub [:contacts/contact-two-names-by-identity
@@ -77,6 +77,7 @@
           [quo/text
            {:weight :medium
             :size   :paragraph-2
+            ;; TODO: layout animation in release mode causes crash: https://github.com/status-im/status-mobile/issues/15395
             :style  {:color colors/neutral-40}} "9:41 AM"]]]
         [rn/view {:style style/top-right-buttons}
          [rn/touchable-opacity

--- a/src/status_im2/contexts/chat/lightbox/top_view.cljs
+++ b/src/status_im2/contexts/chat/lightbox/top_view.cljs
@@ -8,6 +8,7 @@
     [react-native.reanimated :as reanimated]
     [status-im2.contexts.chat.lightbox.animations :as anim]
     [status-im2.contexts.chat.lightbox.style :as style]
+    [utils.datetime :as datetime]
     [utils.re-frame :as rf]
     [status-im2.contexts.chat.lightbox.constants :as c]))
 
@@ -39,7 +40,7 @@
         (anim/animate top-view-bg colors/neutral-100-opa-0)))))
 
 (defn top-view
-  [{:keys [from]} insets index animations derived landscape? screen-width]
+  [{:keys [from timestamp]} insets index animations derived landscape? screen-width]
   [:f>
    (fn []
      (let [display-name                       (first (rf/sub [:contacts/contact-two-names-by-identity
@@ -76,9 +77,7 @@
           [quo/text
            {:weight :medium
             :size   :paragraph-2
-            ;; TODO: layout animation in release mode causes crash:
-            ;; https://github.com/status-im/status-mobile/issues/15395
-            :style  {:color colors/neutral-40}} "9:41 AM"]]]
+            :style  {:color colors/neutral-40}} (datetime/to-short-str timestamp)]]]
         [rn/view {:style style/top-right-buttons}
          [rn/touchable-opacity
           {:active-opacity 1

--- a/src/status_im2/contexts/chat/lightbox/top_view.cljs
+++ b/src/status_im2/contexts/chat/lightbox/top_view.cljs
@@ -8,6 +8,7 @@
     [react-native.reanimated :as reanimated]
     [status-im2.contexts.chat.lightbox.animations :as anim]
     [status-im2.contexts.chat.lightbox.style :as style]
+    [utils.datetime :as datetime]
     [utils.re-frame :as rf]
     [status-im2.contexts.chat.lightbox.constants :as c]))
 
@@ -76,7 +77,7 @@
           [quo/text
            {:weight :medium
             :size   :paragraph-2
-            :style  {:color colors/neutral-40}} timestamp]]]
+            :style  {:color colors/neutral-40}} (datetime/to-short-str timestamp)]]]
         [rn/view {:style style/top-right-buttons}
          [rn/touchable-opacity
           {:active-opacity 1

--- a/src/status_im2/contexts/chat/messages/composer/controls/view.cljs
+++ b/src/status_im2/contexts/chat/messages/composer/controls/view.cljs
@@ -41,13 +41,13 @@
      :size 32} :i/reaction]])
 
 (defn image-button
-  [chat-id]
+  [insets]
   [quo/button
    {:on-press (fn []
                 (permissions/request-permissions
                  {:permissions [:read-external-storage :write-external-storage]
                   :on-allowed  #(rf/dispatch
-                                 [:open-modal :photo-selector {:chat-id chat-id}])
+                                 [:open-modal :photo-selector {:insets insets}])
                   :on-denied   (fn []
                                  (background-timer/set-timeout
                                   #(utils-old/show-popup (i18n/label :t/error)
@@ -122,7 +122,7 @@
     (when (and (not @input/recording-audio?)
                (nil? (get @input/reviewing-audio-filepath chat-id)))
       [:<>
-       [image-button chat-id]
+       [image-button insets]
        [rn/view {:width 12}]
        [reactions-button]
        [rn/view {:flex 1}]

--- a/src/status_im2/contexts/chat/photo_selector/style.cljs
+++ b/src/status_im2/contexts/chat/photo_selector/style.cljs
@@ -15,8 +15,7 @@
    :flex-direction  :row
    :left            0
    :right           0
-   :margin-top      20
-   :margin-bottom   12
+   :top             20
    :justify-content :center
    :z-index         1})
 
@@ -66,8 +65,8 @@
    :height                  (/ window-width 3)
    :margin-left             (when (not= (mod index 3) 0) 1)
    :margin-bottom           1
-   :border-top-left-radius  (when (= index 0) 10)
-   :border-top-right-radius (when (= index 2) 10)})
+   :border-top-left-radius  (when (= index 0) 20)
+   :border-top-right-radius (when (= index 2) 20)})
 
 (defn overlay
   [window-width]

--- a/src/status_im2/contexts/chat/photo_selector/view.cljs
+++ b/src/status_im2/contexts/chat/photo_selector/view.cljs
@@ -124,8 +124,8 @@
               (reset! selected (vec (vals selected-images)))
               (reset! selected @temporary-selected)))
           [selected-album])
-         [bottom-sheet-screen/consumer
-          (fn [close scroll-enabled on-scroll]
+         [bottom-sheet-screen/view
+          (fn [{:keys [close scroll-enabled on-scroll]}]
             (let [window-width       (:width (rn/get-window))
                   camera-roll-photos (rf/sub [:camera-roll/photos])
                   end-cursor         (rf/sub [:camera-roll/end-cursor])

--- a/src/status_im2/contexts/chat/photo_selector/view.cljs
+++ b/src/status_im2/contexts/chat/photo_selector/view.cljs
@@ -134,12 +134,6 @@
               [:<>
                [rn/view
                 {:style style/buttons-container}
-                [rn/touchable-opacity
-                 {:active-opacity 1
-                  :on-press       close
-                  :style          (style/close-button-container)}
-                 [quo/icon :i/close
-                  {:size 20 :color (colors/theme-colors colors/black colors/white)}]]
                 [album-title true selected-album selected temporary-selected insets]
                 [clear-button selected]]
                [gesture/flat-list

--- a/src/status_im2/contexts/chat/photo_selector/view.cljs
+++ b/src/status_im2/contexts/chat/photo_selector/view.cljs
@@ -1,9 +1,9 @@
 (ns status-im2.contexts.chat.photo-selector.view
   (:require
+    [react-native.gesture :as gesture]
     [react-native.platform :as platform]
     [status-im2.constants :as constants]
     [utils.i18n :as i18n]
-    [react-native.safe-area :as safe-area]
     [quo2.components.notifications.info-count :as info-count]
     [quo2.core :as quo]
     [quo2.foundations.colors :as colors]
@@ -13,6 +13,7 @@
     [status-im2.contexts.chat.photo-selector.style :as style]
     [status-im.utils.core :as utils]
     [quo.react]
+    [status-im2.common.bottom-sheet-screen.view :as bottom-sheet-screen]
     [utils.re-frame :as rf]))
 
 (defn on-press-confirm-selection
@@ -80,31 +81,38 @@
       (inc (utils/first-index #(= (:uri item) (:uri %)) @selected))])])
 
 (defn album-title
-  [photos? selected-album selected temporary-selected]
-  [rn/touchable-opacity
-   {:style               (style/title-container)
-    :active-opacity      1
-    :accessibility-label :album-title
-    :on-press            (fn []
-                           (if photos?
-                             (do
-                               (reset! temporary-selected @selected)
-                               (rf/dispatch [:open-modal :album-selector]))
-                             (rf/dispatch [:navigate-back])))}
-   [quo/text
-    {:weight          :medium
-     :ellipsize-mode  :tail
-     :number-of-lines 1
-     :style           {:max-width 150}}
-    selected-album]
-   [rn/view {:style (style/chevron-container)}
-    [quo/icon (if photos? :i/chevron-down :i/chevron-up)
-     {:color (colors/theme-colors colors/neutral-100 colors/white)}]]])
+  [photos? selected-album]
+  (fn []
+    [rn/touchable-opacity
+     {:style               (style/title-container)
+      :active-opacity      1
+      :accessibility-label :album-title
+      :on-press            (fn []
+                             ;; TODO: album-selector issue:
+                             ;; https://github.com/status-im/status-mobile/issues/15398
+                             (js/alert "currently disabled")
+                             ;(if photos?
+                             ;  (do
+                             ;    (reset! temporary-selected @selected)
+                             ;    (rf/dispatch [:open-modal :album-selector {:insets insets}]))
+                             ;  (rf/dispatch [:navigate-back]))
+                           )}
+     [quo/text
+      {:weight          :medium
+       :ellipsize-mode  :tail
+       :number-of-lines 1
+       :style           {:max-width 150}}
+      selected-album]
+     [rn/view {:style (style/chevron-container)}
+      [quo/icon (if photos? :i/chevron-down :i/chevron-up)
+       {:color (colors/theme-colors colors/neutral-100 colors/white)}]]]))
+
 
 (defn photo-selector
   []
   [:f>
-   (let [temporary-selected (reagent/atom [])] ; used when switching albums
+   (let [{:keys [insets]}   (rf/sub [:get-screen-params])
+         temporary-selected (reagent/atom [])] ; used when switching albums
      (fn []
        (let [selected        (reagent/atom []) ; currently selected
              selected-images (rf/sub [:chats/sending-image]) ; already selected and dispatched
@@ -116,26 +124,25 @@
               (reset! selected (vec (vals selected-images)))
               (reset! selected @temporary-selected)))
           [selected-album])
-         [safe-area/consumer
-          (fn [insets]
+         [bottom-sheet-screen/consumer
+          (fn [close scroll-enabled on-scroll]
             (let [window-width       (:width (rn/get-window))
                   camera-roll-photos (rf/sub [:camera-roll/photos])
                   end-cursor         (rf/sub [:camera-roll/end-cursor])
                   loading?           (rf/sub [:camera-roll/loading-more])
                   has-next-page?     (rf/sub [:camera-roll/has-next-page])]
-              [rn/view {:style {:flex 1}}
+              [:<>
                [rn/view
                 {:style style/buttons-container}
-                (when platform/android?
-                  [rn/touchable-opacity
-                   {:active-opacity 1
-                    :on-press       #(rf/dispatch [:navigate-back])
-                    :style          (style/close-button-container)}
-                   [quo/icon :i/close
-                    {:size 20 :color (colors/theme-colors colors/black colors/white)}]])
-                [album-title true selected-album selected temporary-selected]
+                [rn/touchable-opacity
+                 {:active-opacity 1
+                  :on-press       close
+                  :style          (style/close-button-container)}
+                 [quo/icon :i/close
+                  {:size 20 :color (colors/theme-colors colors/black colors/white)}]]
+                [album-title true selected-album selected temporary-selected insets]
                 [clear-button selected]]
-               [rn/flat-list
+               [gesture/flat-list
                 {:key-fn                  identity
                  :render-fn               image
                  :render-data             {:window-width window-width :selected selected}
@@ -143,7 +150,9 @@
                  :num-columns             3
                  :content-container-style {:width          "100%"
                                            :padding-bottom (+ (:bottom insets) 100)
-                                           :padding-top    80}
+                                           :padding-top    64}
+                 :on-scroll               on-scroll
+                 :scroll-enabled          scroll-enabled
                  :on-end-reached          #(rf/dispatch [:camera-roll/on-end-reached end-cursor
                                                          selected-album loading?
                                                          has-next-page?])}]

--- a/src/status_im2/contexts/chat/photo_selector/view.cljs
+++ b/src/status_im2/contexts/chat/photo_selector/view.cljs
@@ -125,7 +125,7 @@
               (reset! selected @temporary-selected)))
           [selected-album])
          [bottom-sheet-screen/view
-          (fn [{:keys [close scroll-enabled on-scroll]}]
+          (fn [{:keys [scroll-enabled on-scroll]}]
             (let [window-width       (:width (rn/get-window))
                   camera-roll-photos (rf/sub [:camera-roll/photos])
                   end-cursor         (rf/sub [:camera-roll/end-cursor])

--- a/src/status_im2/navigation/screens.cljs
+++ b/src/status_im2/navigation/screens.cljs
@@ -43,6 +43,15 @@
                       :drawBehind      true}}
      {:statusBar {:style :light}})))
 
+(def bottom-sheet-options
+  {:topBar                 {:visible false}
+   :layout                 {:componentBackgroundColor :transparent
+                            :backgroundColor          :transparent}
+   :modalPresentationStyle :overCurrentContext})
+
+(def bottom-sheet-insets
+  {:top false})
+
 (defn screens
   []
   (concat
@@ -87,7 +96,8 @@
                                                                                     :factor 1.5}}]}}}
      :component lightbox/lightbox}
     {:name      :photo-selector
-     :options   {:topBar {:visible false}}
+     :insets    bottom-sheet-insets
+     :options   bottom-sheet-options
      :component photo-selector/photo-selector}
 
     {:name      :album-selector


### PR DESCRIPTION
fixes: https://github.com/status-im/status-mobile/issues/15332

### Summary

This PR implements a bottom sheet screen using RNN Modal Screen (+ RNGH and Reanimated).

### Features:

✅ Implemented using an RNN screen for smooth animations
✅  Bottom-sheet UI as in [the designs](https://www.figma.com/file/wA8Epdki2OWa8Vr067PCNQ/Composer-for-Mobile?node-id=6376-372334&t=nZFsF8QZgseRAUUF-0), with the margin at the top, background opacity, border radius, handle, etc
✅ Draggable by gestures, on both iOS and Android
✅  Whole screen can read gestures, even when using a flat list
✅  Background opacity animates as it moves up and down

Also, does not have that bug on Android: https://github.com/status-im/status-mobile/issues/15238

### Demoes

Android (opening, closing, gestures):

https://user-images.githubusercontent.com/29354102/225831516-b0e04781-0c8f-413e-aefa-44cbf569d695.mp4

iOS (opening, closing):

https://user-images.githubusercontent.com/29354102/225831603-e5239b5d-0018-4e0f-ab09-47f39bee5fb8.mov

iOS (gestures):

https://user-images.githubusercontent.com/29354102/225831633-c971647a-1182-4e16-91f5-736f202c571f.MOV

### Usage

1. Use bottom-sheet options and insets defined in `status-im2.navigation.screens`
2. Wrap the component with the bottom-sheet-screen consumer:

```
 [bottom-sheet-screen/view
          (fn [close scroll-enabled on-scroll]
   [children])]
```

The function receives 3 args: a close function to be used for a close button if necessary, and 2 props to be added to flatlist (if used). If a flatlist is used, `rn/flatlist` needs to be swapped with `gesture/flatlist`.

### QA review notes: 
https://github.com/status-im/status-mobile/pull/15399#issuecomment-1476449511

status: ready