### PR TITLE
Allow/Add mobile link previews for YouTube and Twitter

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -4,6 +4,6 @@
     "owner": "status-im",
     "repo": "status-go",
     "version": "v0.142.3",
-    "commit-sha1": "b38b381778088bf44c8cafecc1e61958226123d0",
-    "src-sha256": "003c4d0jiv2wqx9dnjzqycads4grq3yics30mbl84lsy1r56jn75"
+    "commit-sha1": "142b170ec99498bbeb41d7f4ce5b7140db597e56",
+    "src-sha256": "038p3axqj4m2wczs3fg44535rn6y235hr23w9fjriaglp80p2z07"
 }

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -4,6 +4,6 @@
     "owner": "status-im",
     "repo": "status-go",
     "version": "v0.142.3",
-    "commit-sha1": "142b170ec99498bbeb41d7f4ce5b7140db597e56",
-    "src-sha256": "038p3axqj4m2wczs3fg44535rn6y235hr23w9fjriaglp80p2z07"
+    "commit-sha1": "b38b381778088bf44c8cafecc1e61958226123d0",
+    "src-sha256": "003c4d0jiv2wqx9dnjzqycads4grq3yics30mbl84lsy1r56jn75"
 }

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.142.3",
-    "commit-sha1": "b38b381778088bf44c8cafecc1e61958226123d0",
-    "src-sha256": "003c4d0jiv2wqx9dnjzqycads4grq3yics30mbl84lsy1r56jn75"
+    "version": "v0.142.4",
+    "commit-sha1": "142b170ec99498bbeb41d7f4ce5b7140db597e56",
+    "src-sha256": "038p3axqj4m2wczs3fg44535rn6y235hr23w9fjriaglp80p2z07"
 }


### PR DESCRIPTION
fixes #15402 

### Summary

Mobile URL versions of YouTube and Twitter links were not supported by our current implementation for link previews, I just added them to the list of link previews on status-go and they too (Just worked :D)

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS
- macOS
- Linux
- Windows

#### Areas that maybe impacted
Link reviews

##### Functional

- 1-1 chats
- public chats
- group chats

### Steps to test

1. Send a URL that has the mobile subdomain (m.youtube - mobile.twitter)
2. See if the link preview works

status: ready
