### PR TITLE
Remove support for cancelling outgoing contact requests

### DIFF
--- a/src/status_im2/contexts/activity_center/notification/contact_requests/events.cljs
+++ b/src/status_im2/contexts/activity_center/notification/contact_requests/events.cljs
@@ -1,6 +1,5 @@
 (ns status-im2.contexts.activity-center.notification.contact-requests.events
-  (:require [status-im2.contexts.activity-center.events :as ac-events]
-            [taoensso.timbre :as log]
+  (:require [taoensso.timbre :as log]
             [utils.re-frame :as rf]))
 
 (rf/defn accept-contact-request

--- a/src/status_im2/contexts/activity_center/notification/contact_requests/events.cljs
+++ b/src/status_im2/contexts/activity_center/notification/contact_requests/events.cljs
@@ -19,8 +19,7 @@
   (log/error "Failed to accept contact-request"
              {:error      error
               :event      :activity-center.contact-requests/accept
-              :contact-id contact-id})
-  nil)
+              :contact-id contact-id}))
 
 (rf/defn decline-contact-request
   {:events [:activity-center.contact-requests/decline]}
@@ -38,32 +37,4 @@
   (log/error "Failed to decline contact-request"
              {:error      error
               :event      :activity-center.contact-requests/decline
-              :contact-id contact-id})
-  nil)
-
-(rf/defn cancel-outgoing-contact-request
-  {:events [:activity-center.contact-requests/cancel-outgoing]}
-  [{:keys [db]} {:keys [contact-id notification-id]}]
-  (when-let [notification (ac-events/get-notification db notification-id)]
-    {:json-rpc/call
-     [{:method     "wakuext_cancelOutgoingContactRequest"
-       :params     [{:id contact-id}]
-       :on-success #(rf/dispatch [:activity-center.contact-requests/cancel-outgoing-success
-                                  notification])
-       :on-error   #(rf/dispatch [:activity-center.contact-requests/cancel-outgoing-error contact-id
-                                  %])}]}))
-
-(rf/defn cancel-outgoing-contact-request-success
-  {:events [:activity-center.contact-requests/cancel-outgoing-success]}
-  [_ notification]
-  {:dispatch [:activity-center.notifications/reconcile
-              [(assoc notification :deleted true)]]})
-
-(rf/defn cancel-outgoing-contact-request-error
-  {:events [:activity-center.contact-requests/cancel-outgoing-error]}
-  [_ contact-id error]
-  (log/error "Failed to cancel outgoing contact-request"
-             {:error      error
-              :event      :activity-center.contact-requests/cancel-outgoing
-              :contact-id contact-id})
-  nil)
+              :contact-id contact-id}))

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "94cd1ec",
-    "commit-sha1": "94cd1ec",
-    "src-sha256": "1inm5x6wwfm2v45aq0jyaq52lw6hpgkyy82h3v1bh2bs7bl1yd26"
+    "version": "feat/remove-cancel-contact-request",
+    "commit-sha1": "a0168425a0b11e06bcf3acb5afe4b0ae15c06923",
+    "src-sha256": "07r7ra4r0b4kbkr4j95x8jlp48axan9cpnm4kvkjcp5r75wbv4yf"
 }

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "feat/remove-cancel-contact-request",
-    "commit-sha1": "a0168425a0b11e06bcf3acb5afe4b0ae15c06923",
-    "src-sha256": "07r7ra4r0b4kbkr4j95x8jlp48axan9cpnm4kvkjcp5r75wbv4yf"
+    "version": "v0.139.0",
+    "commit-sha1": "9c1c01c66f652ad6ce6fd4bbfbc613cc7a292878",
+    "src-sha256": "15cbbzir3bddgdbrrc9pnwdrsahn7a2ihaab7mfz93r0dg3q110i"
 }


### PR DESCRIPTION
Fixes https://github.com/status-im/status-mobile/issues/15357

### Summary

This PR removes the feature that allows users to cancel outgoing contact requests (possible spam vector). From now on, the user who sent the contact request will only be able to see the notification in the pending state, like the screenshot below. It seems this feature will be revisited in the future, but for now the agreement is to do the simplest thing and remove it.

The problem is further explained in the PR's issue. This PR is coordinated with the Desktop team, so that the [status-go PR](https://github.com/status-im/status-go/pull/3293) can be merged in lockstep.

<img src="https://user-images.githubusercontent.com/46027/226400639-1c0e7ffa-1707-4fc1-8d3f-0041b97e202b.png" width="300" />

<img src="https://user-images.githubusercontent.com/46027/226403704-e8fb33ae-51ed-4ccf-816d-dd89e9a47e92.png" width="300" />

#### Platforms

- Android
- iOS

### Steps to test

- Send CR from `A` to `B`.
- `A` should see a new notification in the pending state.
- `B` should receive a notification. If `B` accepts the CR, then `A`'s pending CR disappears. If `B` declines the CR, then `A`'s notification stays pending forever.

Note: As expected, `A` can swipe left->right to mark the outgoing pending notification as read or swipe right->left to delete it.

status: ready
