### PR TITLE
Remove 100ms delay when opening image

### DIFF
--- a/src/status_im2/contexts/chat/events.cljs
+++ b/src/status_im2/contexts/chat/events.cljs
@@ -340,11 +340,11 @@
   {:db (assoc db :shared-element-id shared-element-id)})
 
 (rf/defn navigate-to-lightbox
-         {:events [:chat.ui/navigate-to-lightbox]}
-         [{:keys [db]} shared-element-id screen-params]
-         (let [updated-db (assoc db :shared-element-id shared-element-id)]
-           (reagent/next-tick #(rf/dispatch [:navigate-to :lightbox screen-params]))
-           {:db updated-db}))
+  {:events [:chat.ui/navigate-to-lightbox]}
+  [{:keys [db]} shared-element-id screen-params]
+  (let [updated-db (assoc db :shared-element-id shared-element-id)]
+    (reagent/next-tick #(rf/dispatch [:navigate-to :lightbox screen-params]))
+    {:db updated-db}))
 
 (rf/defn exit-lightbox-signal
   {:events [:chat.ui/exit-lightbox-signal]}

--- a/src/status_im2/contexts/chat/events.cljs
+++ b/src/status_im2/contexts/chat/events.cljs
@@ -342,9 +342,8 @@
 (rf/defn navigate-to-lightbox
   {:events [:chat.ui/navigate-to-lightbox]}
   [{:keys [db]} shared-element-id screen-params]
-  (let [updated-db (assoc db :shared-element-id shared-element-id)]
-    (reagent/next-tick #(rf/dispatch [:navigate-to :lightbox screen-params]))
-    {:db updated-db}))
+  (reagent/next-tick #(rf/dispatch [:navigate-to :lightbox screen-params]))
+  {:db (assoc db :shared-element-id shared-element-id)})
 
 (rf/defn exit-lightbox-signal
   {:events [:chat.ui/exit-lightbox-signal]}

--- a/src/status_im2/contexts/chat/events.cljs
+++ b/src/status_im2/contexts/chat/events.cljs
@@ -13,7 +13,8 @@
             [status-im2.contexts.contacts.events :as contacts-store]
             [status-im.multiaccounts.model :as multiaccounts.model]
             [status-im.utils.clocks :as utils.clocks]
-            [status-im.utils.types :as types]))
+            [status-im.utils.types :as types]
+            [reagent.core :as reagent]))
 
 (defn- get-chat
   [cofx chat-id]
@@ -338,6 +339,13 @@
   [{:keys [db]} shared-element-id]
   {:db (assoc db :shared-element-id shared-element-id)})
 
+(rf/defn navigate-to-lightbox
+         {:events [:chat.ui/navigate-to-lightbox]}
+         [{:keys [db]} shared-element-id screen-params]
+         (let [updated-db (assoc db :shared-element-id shared-element-id)]
+           (reagent/next-tick #(rf/dispatch [:navigate-to :lightbox screen-params]))
+           {:db updated-db}))
+
 (rf/defn exit-lightbox-signal
   {:events [:chat.ui/exit-lightbox-signal]}
   [{:keys [db]} value]
@@ -357,4 +365,3 @@
   {:events [:chat.ui/lightbox-scale]}
   [{:keys [db]} value]
   {:db (assoc db :lightbox/scale value)})
-

--- a/src/status_im2/contexts/chat/messages/content/album/view.cljs
+++ b/src/status_im2/contexts/chat/messages/content/album/view.cljs
@@ -52,13 +52,11 @@
                  {:key            (:message-id item)
                   :active-opacity 1
                   :on-long-press  #(on-long-press message context)
-                  :on-press       (fn []
-                                    (rf/dispatch [:chat.ui/update-shared-element-id (:message-id item)])
-                                    (js/setTimeout #(rf/dispatch [:navigate-to :lightbox
-                                                                  {:messages (:album message)
-                                                                   :index    index
-                                                                   :insets   insets}])
-                                                   100))}
+                  :on-press       #(rf/dispatch [:chat.ui/navigate-to-lightbox
+                                                 (:message-id item)
+                                                 {:messages (:album message)
+                                                  :index    index
+                                                  :insets   insets}])}
                  [fast-image/fast-image
                   {:style     (style/image dimensions index portrait? images-count)
                    :source    {:uri (:image (:content item))}

--- a/src/status_im2/contexts/chat/messages/content/image/view.cljs
+++ b/src/status_im2/contexts/chat/messages/content/image/view.cljs
@@ -27,13 +27,11 @@
              :key            message-id
              :style          {:margin-top (when (pos? index) 10)}
              :on-long-press  on-long-press
-             :on-press       (fn []
-                               (rf/dispatch [:chat.ui/update-shared-element-id message-id])
-                               (js/setTimeout #(rf/dispatch [:navigate-to :lightbox
-                                                             {:messages [message]
-                                                              :index    0
-                                                              :insets   insets}])
-                                              100))}
+             :on-press       #(rf/dispatch [:chat.ui/navigate-to-lightbox
+                                            message-id
+                                            {:messages [message]
+                                             :index    0
+                                             :insets   insets}])}
             (when (and (not= text "placeholder") (= index 0))
               [rn/view {:style {:margin-bottom 10}} [text/text-content message context]])
             [fast-image/fast-image


### PR DESCRIPTION
fixes: https://github.com/status-im/status-mobile/issues/15358

#### QA notes:
What needs to be tested is that when pressing on an image, the opening animation executes. Currently, this works only on iOS. For Android there is an open issue: https://github.com/status-im/status-mobile/issues/15421
Also note that there is some open issues for images (https://github.com/status-im/status-mobile/issues/15395, https://github.com/status-im/status-mobile/issues/15391)