### PR TITLE
fix: reply with album

### DIFF
--- a/src/status_im/chat/models/input.cljs
+++ b/src/status_im/chat/models/input.cljs
@@ -147,8 +147,9 @@
 
 (defn build-image-messages
   [{db :db} chat-id input-text]
-  (let [images   (get-in db [:chat/inputs chat-id :metadata :sending-image])
-        album-id (str (random-uuid))]
+  (let [images               (get-in db [:chat/inputs chat-id :metadata :sending-image])
+        {:keys [message-id]} (get-in db [:chat/inputs chat-id :metadata :responding-to-message])
+        album-id             (str (random-uuid))]
     (mapv (fn [[_ {:keys [resized-uri width height]}]]
             {:chat-id      chat-id
              :album-id     album-id
@@ -159,7 +160,8 @@
              ;; TODO: message not received if text field is
              ;; nil or empty, issue:
              ;; https://github.com/status-im/status-mobile/issues/14754
-             :text         (or input-text "placeholder")})
+             :text         (or input-text "placeholder")
+             :response-to  message-id})
           images)))
 
 (rf/defn clean-input

--- a/src/status_im2/subs/chat/messages.cljs
+++ b/src/status_im2/subs/chat/messages.cljs
@@ -112,27 +112,34 @@
 (defn albumize-messages
   [messages]
   (get
-   (reduce (fn [{:keys [messages albums]} message]
-             (let [album-id (:album-id message)
-                   albums   (cond-> albums album-id (update album-id conj message))
-                   messages (if album-id
-                              (conj (filterv #(not= album-id (:album-id %)) messages)
-                                    {:album           (get albums album-id)
-                                     :album-id        album-id
-                                     :albumize?       (:albumize? message)
-                                     :message-id      (:message-id message)
-                                     :deleted?        (:deleted? message)
-                                     :deleted-for-me? (:deleted-for-me? message)
-                                     :deleted-by      (:deleted-by message)
-                                     :from            (:from message)
-                                     :timestamp-str   (:timestamp-str message)
-                                     :content-type    constants/content-type-album})
-                              (conj messages message))]
-               {:messages messages
-                :albums   albums}))
-           {:messages []
-            :albums   {}}
-           messages)
+   (reduce
+    (fn [{:keys [messages albums]} message]
+      (let [{:keys [album-id content quoted-message]} message
+            {:keys [response-to]}                     content
+            albums                                    (cond-> albums
+                                                        album-id (update album-id conj message))
+            messages                                  (if album-id
+                                                        (conj
+                                                         (filterv #(not= album-id (:album-id %))
+                                                                  messages)
+                                                         {:album           (get albums album-id)
+                                                          :album-id        album-id
+                                                          :albumize?       (:albumize? message)
+                                                          :message-id      (:message-id message)
+                                                          :deleted?        (:deleted? message)
+                                                          :deleted-for-me? (:deleted-for-me? message)
+                                                          :deleted-by      (:deleted-by message)
+                                                          :from            (:from message)
+                                                          :timestamp-str   (:timestamp-str message)
+                                                          :content         {:response-to response-to}
+                                                          :quoted-message  quoted-message
+                                                          :content-type    constants/content-type-album})
+                                                        (conj messages message))]
+        {:messages messages
+         :albums   albums}))
+    {:messages []
+     :albums   {}}
+    messages)
    :messages))
 
 (re-frame/reg-sub

--- a/src/status_im2/subs/chat/messages_test.cljs
+++ b/src/status_im2/subs/chat/messages_test.cljs
@@ -17,6 +17,8 @@
             {:message-id "0x333" :album-id "abc" :albumize? true :from :xyz :timestamp-str "14:00"}
             {:message-id "0x222" :album-id "abc" :albumize? true :from :xyz :timestamp-str "14:00"}
             {:message-id "0x111" :album-id "abc" :albumize? true :from :xyz :timestamp-str "14:00"}]
+    :content {:response-to nil}
+    :quoted-message nil
     :album-id "abc"
     :albumize? true
     :message-id "0x444"


### PR DESCRIPTION
resolve #15318


reason

1. no `:response-to` in image message when mobile->go (do we support reply with image before album added?)
2. no `:response-to` (in `:content`) in `albumize-messages` when build `:message-list` from `:messages` 

status: ready <!-- Can be ready or wip -->