### PR TITLE
Fix for sender's name, profile icon, chat key, timestamp being lost for messages that contain images

### DIFF
--- a/src/status_im2/subs/chat/messages.cljs
+++ b/src/status_im2/subs/chat/messages.cljs
@@ -115,8 +115,8 @@
   (->> messages
        (reduce
         (fn [{:keys [messages albums]} message]
-          (let [album-id (:album-id message
-                )
+          (let [{:keys [album-id content quoted-message]} message
+                {:keys [response-to]}                     content
                 albums                                    (cond-> albums
                                                             album-id
                                                             (update album-id conj message))
@@ -126,7 +126,9 @@
                                                                   (merge message
                                                                          {:album (get albums album-id)
                                                                           :album-id album-id
-
+                                                                          :content {:response-to
+                                                                                    response-to}
+                                                                          :quoted-message quoted-message
                                                                           :content-type
                                                                           constants/content-type-album}))
                                                             (conj messages message))]

--- a/src/status_im2/subs/chat/messages_test.cljs
+++ b/src/status_im2/subs/chat/messages_test.cljs
@@ -22,9 +22,6 @@
     :album-id "abc"
     :albumize? true
     :message-id "0x444"
-    :deleted? nil
-    :deleted-for-me? nil
-    :deleted-by nil
     :from :xyz
     :timestamp-str "14:00"
     :content-type constants/content-type-album}])


### PR DESCRIPTION
Fixes #15392

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- 1-1 chats
- public chats
- group chats

status: ready <!-- Can be ready or wip -->
