### PR TITLE
fix: still need this fix to run-ios on m1 mac

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -35,6 +35,16 @@ abstract_target 'Status' do
   target 'StatusImPR' do
   end
 
+  post_install do |installer|
+    # some of libs wouldn't be build for x86_64 otherwise and that is
+    # necessary for ios simulators
+    installer.pods_project.targets.each do |target|
+      target.build_configurations.each do |config|
+        config.build_settings['ONLY_ACTIVE_ARCH'] = 'NO'
+      end
+    end
+  end
+
   use_native_modules!
 end
 


### PR DESCRIPTION
Failed to build without this fix on m1 mac, fix was removed at #15317

got below errors without this fix, basically missing bunch of `.modulemap` file while compiling `Bridge.swift`

```
SwiftCompile normal x86_64 Compiling\ Bridge.swift /Users/yqrashawn/workspace/office/status-mobile/ios/Bridge.swift (in target 'StatusIm' from project 'StatusIm')
    cd /Users/yqrashawn/workspace/office/status-mobile/ios
    builtin-swiftTaskExecution -- /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swift-frontend @/Users/yqrashawn/Library/Developer/Xcode/DerivedData/StatusIm-gnapbwbxjxgwhtacxvputzmiutpv/Build/Intermediates.noindex/StatusIm.build/Debug-iphonesimulator/StatusIm.build/Objects-normal/x86_64/arguments-2287786857555690686.resp
CompileSwift normal x86_64 /Users/yqrashawn/workspace/office/status-mobile/ios/Bridge.swift (in target 'StatusIm' from project 'StatusIm')
    cd /Users/yqrashawn/workspace/office/status-mobile/ios
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swift-frontend -c -primary-file /Users/yqrashawn/workspace/office/status-mobile/ios/Bridge.swift
...
...
...

{
  "kind": "finished",
  "name": "compile",
  "pid": 81028,
  "output": "<unknown>:0: error: module map file '\/Users\/yqrashawn\/Library\/Developer\/Xcode\/DerivedData\/StatusIm-gnapbwbxjxgwhtacxvputzmiutpv\/Build\/Products\/Debug-iphonesimulator\/CryptoSwift\/CryptoSwift.modulemap' not found\n<unknown>:0: error: module map file '\/Users\/yqrashawn\/Library\/Developer\/Xcode\/DerivedData\/StatusIm-gnapbwbxjxgwhtacxvputzmiutpv\/Build\/Products\/Debug-iphonesimulator\/Keycard\/Keycard.modulemap' not found\n<unknown>:0: error: module map file '\/Users\/yqrashawn\/Library\/Developer\/Xcode\/DerivedData\/StatusIm-gnapbwbxjxgwhtacxvputzmiutpv\/Build\/Products\/Debug-iphonesimulator\/react-native-status-keycard\/react_native_status_keycard.modulemap' not found\n<unknown>:0: error: module map file '\/Users\/yqrashawn\/Library\/Developer\/Xcode\/DerivedData\/StatusIm-gnapbwbxjxgwhtacxvputzmiutpv\/Build\/Products\/Debug-iphonesimulator\/secp256k1\/secp256k1.modulemap' not found\n",
  "process": {
    "real_pid": 81028
  },
  "exit-status": 1
}


SwiftCompile normal x86_64 Compiling\ Bridge.swift /Users/yqrashawn/workspace/office/status-mobile/ios/Bridge.swift (in target 'StatusIm' from project 'StatusIm')
    cd /Users/yqrashawn/workspace/office/status-mobile/ios
    builtin-swiftTaskExecution -- /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swift-frontend @/Users/yqrashawn/Library/Developer/Xcode/DerivedData/StatusIm-g
napbwbxjxgwhtacxvputzmiutpv/Build/Intermediates.noindex/StatusIm.build/Debug-iphonesimulator/StatusIm.build/Objects-normal/x86_64/arguments-6260525661634880335.resp
CompileSwift normal x86_64 /Users/yqrashawn/workspace/office/status-mobile/ios/Bridge.swift (in target 'StatusIm' from project 'StatusIm')
    cd /Users/yqrashawn/workspace/office/status-mobile/ios
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swift-frontend -c -primary-file /Users/yqrashawn/workspace/office/status-mobile/ios/Bridge.swift
...
...
...

** BUILD FAILED **


The following build commands failed:
        SwiftEmitModule normal x86_64 Emitting\ module\ for\ StatusIm (in target 'StatusIm' from project 'StatusIm')
(1 failure)
```

<img width="691" alt="image" src="https://user-images.githubusercontent.com/15090582/226864994-3912ab76-2234-4e49-820e-945d447b8863.png">


status: ready <!-- Can be ready or wip -->