### PR TITLE
[#15443] Show community name/description in message on Android

### DIFF
--- a/src/status_im/ui2/screens/chat/messages/message.cljs
+++ b/src/status_im/ui2/screens/chat/messages/message.cljs
@@ -377,9 +377,9 @@
                       :height 40}}]
            [communities.icon/community-icon community])]
         [rn/view {:padding-right 14 :flex 1}
-         [rn/text {:style {:font-weight "700" :font-size 17}}
+         [rn/text {:style {:font-weight "700" :font-size 17 :color quo.colors/black}}
           name]
-         [rn/text description]]]
+         [rn/text {:style {:color quo.colors/black}} description]]]
        [rn/view (style/community-view-button)
         [rn/touchable-opacity
          {:on-press #(re-frame/dispatch


### PR DESCRIPTION
That's an old code which probably will be rewritten soon. Here I just fixed white font color which caused the problem on android.

fix #15443

status: ready