### PR TITLE
Add checked? property & dark blur variant to disclaimer component

### DIFF
--- a/doc/new-guidelines.md
+++ b/doc/new-guidelines.md
@@ -61,6 +61,35 @@ the source file. For a real example, see
    [rn/view (do-something)]])
 ```
 
+### Always add styles inside the `:style` key
+
+Although when compiling ReactNative for mobile some components are able work with 
+their styles in the top-level of the properties map, prefer to add them inside the
+`:style` key in order to separate styles from properties:
+
+```clojure
+;; bad
+[rn/button {:flex               1
+            :padding-vertical   10
+            :padding-horizontal 20
+            :on-press           #(js/alert "Hi!")
+            :title              "Button"}]
+
+;; good
+[rn/button {:style    {:flex               1
+                       :padding-vertical   10
+                       :padding-horizontal 20}
+            :on-press #(js/alert "Hi!")
+            :title    "Button"}]
+
+;; better 
+;; (define them in a style ns & place them inside `:style` key)
+[rn/button {:style    (style/button)
+            :on-press #(js/alert "Hi!")
+            :title    "Button"}
+ ]
+```
+
 ### Don't use percents to define width/height
 
 In ReactNative, all layouts use the [flexbox

--- a/src/quo2/components/selectors/disclaimer/component_spec.cljs
+++ b/src/quo2/components/selectors/disclaimer/component_spec.cljs
@@ -1,0 +1,15 @@
+(ns quo2.components.selectors.disclaimer.component-spec
+  (:require [quo2.components.selectors.disclaimer.view :as disclaimer]
+            [test-helpers.component :as h]))
+
+(h/describe "disclaimer tests"
+            (h/test "default render of toggle component"
+                    (h/render [disclaimer/view {:on-change (h/mock-fn)} "test"])
+                    (h/is-truthy (h/get-by-label-text :checkbox-off)))
+
+            (h/test "on change event gets fire after press"
+                    (let [mock-fn (h/mock-fn)]
+                      (h/debug (h/render [disclaimer/view {:on-change mock-fn} "test"]))
+                      (h/fire-event :press (h/get-by-label-text :checkbox-off))
+                      (h/was-called mock-fn))))
+

--- a/src/quo2/components/selectors/disclaimer/component_spec.cljs
+++ b/src/quo2/components/selectors/disclaimer/component_spec.cljs
@@ -2,14 +2,28 @@
   (:require [quo2.components.selectors.disclaimer.view :as disclaimer]
             [test-helpers.component :as h]))
 
-(h/describe "disclaimer tests"
-            (h/test "default render of toggle component"
-                    (h/render [disclaimer/view {:on-change (h/mock-fn)} "test"])
-                    (h/is-truthy (h/get-by-label-text :checkbox-off)))
+(h/describe "Disclaimer tests"
+  (h/test "Default render of toggle component"
+    (h/render [disclaimer/view {:on-change (h/mock-fn)} "test"])
+    (h/is-truthy (h/get-by-label-text :checkbox-off)))
 
-            (h/test "on change event gets fire after press"
-                    (let [mock-fn (h/mock-fn)]
-                      (h/debug (h/render [disclaimer/view {:on-change mock-fn} "test"]))
-                      (h/fire-event :press (h/get-by-label-text :checkbox-off))
-                      (h/was-called mock-fn))))
+  (h/test "Renders its text"
+    (let [text "I accept this disclaimer"]
+      (h/render [disclaimer/view {} text])
+      (h/is-truthy (h/get-by-text text))))
 
+  (h/test "On change event gets fire after press"
+    (let [mock-fn (h/mock-fn)]
+      (h/render [disclaimer/view {:on-change mock-fn} "test"])
+      (h/fire-event :press (h/get-by-label-text :checkbox-off))
+      (h/was-called mock-fn)))
+
+  (h/describe "It's rendered according to its `checked?` property"
+    (h/test "checked? true"
+      (h/render [disclaimer/view {:checked? true} "test"])
+      (h/is-null (h/query-by-label-text :checkbox-off))
+      (h/is-truthy (h/query-by-label-text :checkbox-on)))
+    (h/test "checked? false"
+      (h/render [disclaimer/view {:checked? false} "test"])
+      (h/is-null (h/query-by-label-text :checkbox-on))
+      (h/is-truthy (h/query-by-label-text :checkbox-off)))))

--- a/src/quo2/components/selectors/disclaimer/style.cljs
+++ b/src/quo2/components/selectors/disclaimer/style.cljs
@@ -2,14 +2,16 @@
   (:require [quo2.foundations.colors :as colors]))
 
 (defn container
-  []
-  {:flex-direction   :row
-   :background-color (colors/theme-colors colors/neutral-5 colors/neutral-80-opa-40)
-   :padding          11
-   :align-self       :stretch
-   :border-radius    12
-   :border-width     1
-   :border-color     (colors/theme-colors colors/neutral-20 colors/neutral-70)})
+  [blur?]
+  (let [dark-background (if blur? colors/white-opa-5 colors/neutral-80-opa-40)
+        dark-border     (if blur? colors/white-opa-10 colors/neutral-70)]
+    {:flex-direction   :row
+     :background-color (colors/theme-colors colors/neutral-5 dark-background)
+     :padding          11
+     :align-self       :stretch
+     :border-radius    12
+     :border-width     1
+     :border-color     (colors/theme-colors colors/neutral-20 dark-border)}))
 
 (def text
   {:margin-left 8})

--- a/src/quo2/components/selectors/disclaimer/view.cljs
+++ b/src/quo2/components/selectors/disclaimer/view.cljs
@@ -5,9 +5,9 @@
             [react-native.core :as rn]))
 
 (defn view
-  [{:keys [checked? on-change accessibility-label container-style]} label]
+  [{:keys [checked? blur? on-change accessibility-label container-style]} label]
   [rn/view
-   {:style (merge container-style (style/container))}
+   {:style (merge container-style (style/container blur?))}
    [selectors/checkbox
     {:accessibility-label accessibility-label
      :on-change           on-change

--- a/src/quo2/core_spec.cljs
+++ b/src/quo2/core_spec.cljs
@@ -19,5 +19,6 @@
             [quo2.components.record-audio.record-audio.--tests--.record-audio-component-spec]
             [quo2.components.record-audio.soundtrack.--tests--.soundtrack-component-spec]
             [quo2.components.selectors.--tests--.selectors-component-spec]
+            [quo2.components.selectors.disclaimer.component-spec]
             [quo2.components.selectors.filter.component-spec]
             [quo2.components.tags.--tests--.status-tags-component-spec]))

--- a/src/status_im2/contexts/quo_preview/selectors/disclaimer.cljs
+++ b/src/status_im2/contexts/quo_preview/selectors/disclaimer.cljs
@@ -1,27 +1,48 @@
 (ns status-im2.contexts.quo-preview.selectors.disclaimer
   (:require [quo2.components.buttons.button :as button]
-            [quo2.components.selectors.disclaimer.view :as quo]
+            [quo2.components.selectors.disclaimer.view :as disclaimer]
             [quo2.foundations.colors :as colors]
             [react-native.core :as rn]
-            [reagent.core :as reagent]))
+            [reagent.core :as reagent]
+            [status-im2.contexts.quo-preview.preview :as preview]))
+
+(def descriptor
+  [{:label "Checked:"
+    :key   :checked?
+    :type  :boolean}
+   {:label "Blur (only for dark theme):"
+    :key   :blur?
+    :type  :boolean}])
 
 (defn cool-preview
   []
-  (let [checked? (reagent/atom false)]
+  (let [state (reagent/atom {:checked? false
+                             :blur?    true})]
     (fn []
-      [rn/view
-       {:margin-bottom      50
-        :padding-vertical   16
-        :padding-horizontal 20}
-       [rn/view
-        {:padding-vertical 60
-         :align-items      :center}
-        [quo/view
-         {:container-style {:margin-bottom 40}
-          :on-change       #(swap! checked? not)}
-         "I agree with the community rules"]
-        [button/button
-         {:disabled (not @checked?)}
+      [rn/view {:style {:flex 1}}
+       [rn/view {:style {:flex 1}}
+        [preview/customizer state descriptor]]
+       [rn/view {:style {:padding-horizontal 15}}
+        (when (and (:blur? @state) (quo2.theme/dark?))
+          [rn/view
+           {:style {:position :absolute
+                    :top      0
+                    :bottom   0
+                    :left     0
+                    :right    0}}
+           [preview/blur-view
+            {:style                 {:flex        1
+                                     :align-items :center}
+             :show-blur-background? true}]])
+        [rn/view
+         {:style {:margin-vertical 50
+                  :width           "100%"}}
+         [disclaimer/view
+          {:blur?     (:blur? @state)
+           :checked?  (:checked? @state)
+           :on-change #(swap! state update :checked? not)}
+          "I agree with the community rules"]]
+        [button/button {:disabled (not (:checked? @state))}
          "submit"]]])))
 
 (defn preview-disclaimer

--- a/src/status_im2/contexts/quo_preview/selectors/disclaimer.cljs
+++ b/src/status_im2/contexts/quo_preview/selectors/disclaimer.cljs
@@ -2,6 +2,7 @@
   (:require [quo2.components.buttons.button :as button]
             [quo2.components.selectors.disclaimer.view :as disclaimer]
             [quo2.foundations.colors :as colors]
+            [quo2.theme :as theme]
             [react-native.core :as rn]
             [reagent.core :as reagent]
             [status-im2.contexts.quo-preview.preview :as preview]))
@@ -23,7 +24,7 @@
        [rn/view {:style {:flex 1}}
         [preview/customizer state descriptor]]
        [rn/view {:style {:padding-horizontal 15}}
-        (when (and (:blur? @state) (quo2.theme/dark?))
+        (when (and (:blur? @state) (theme/dark?))
           [rn/view
            {:style {:position :absolute
                     :top      0

--- a/src/status_im2/contexts/quo_preview/selectors/disclaimer.cljs
+++ b/src/status_im2/contexts/quo_preview/selectors/disclaimer.cljs
@@ -13,38 +13,44 @@
     :type  :boolean}
    {:label "Blur (only for dark theme):"
     :key   :blur?
-    :type  :boolean}])
+    :type  :boolean}
+   {:label "Text"
+    :key   :text
+    :type  :text}])
+
+(defn blur-background
+  [blur?]
+  (when (and blur? (theme/dark?))
+    [rn/view
+     {:style {:position :absolute
+              :top      0
+              :bottom   0
+              :left     0
+              :right    0}}
+     [preview/blur-view
+      {:style                 {:flex 1}
+       :show-blur-background? true}]]))
 
 (defn cool-preview
   []
   (let [state (reagent/atom {:checked? false
-                             :blur?    true})]
+                             :blur?    true
+                             :text     "I agree with the community rules"})]
     (fn []
-      [rn/view {:style {:flex 1}}
-       [rn/view {:style {:flex 1}}
-        [preview/customizer state descriptor]]
-       [rn/view {:style {:padding-horizontal 15}}
-        (when (and (:blur? @state) (theme/dark?))
-          [rn/view
-           {:style {:position :absolute
-                    :top      0
-                    :bottom   0
-                    :left     0
-                    :right    0}}
-           [preview/blur-view
-            {:style                 {:flex        1
-                                     :align-items :center}
-             :show-blur-background? true}]])
-        [rn/view
-         {:style {:margin-vertical 50
-                  :width           "100%"}}
-         [disclaimer/view
-          {:blur?     (:blur? @state)
-           :checked?  (:checked? @state)
-           :on-change #(swap! state update :checked? not)}
-          "I agree with the community rules"]]
-        [button/button {:disabled (not (:checked? @state))}
-         "submit"]]])))
+      (let [{:keys [blur? checked? text]} @state]
+        [rn/view {:style {:flex 1}}
+         [rn/view {:style {:flex 1}}
+          [preview/customizer state descriptor]]
+         [rn/view {:style {:padding-horizontal 15}}
+          [blur-background blur?]
+          [rn/view {:style {:margin-vertical 50}}
+           [disclaimer/view
+            {:blur?     blur?
+             :checked?  checked?
+             :on-change #(swap! state update :checked? not)}
+            text]]
+          [button/button {:disabled (not checked?)}
+           "submit"]]]))))
 
 (defn preview-disclaimer
   []


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes #15456 

### Summary
This PR adds the missing dark blur variant for the disclaimer component:

https://www.figma.com/file/WQZcp6S0EnzxdTL4taoKDv/Design-System-for-Mobile?node-id=2638-40983&t=8j6VbS0teDXkNWWW-4

And updates the preview screen to be able to set the `:blur?` property:

![image](https://user-images.githubusercontent.com/90291778/227362277-f2c8ad91-408f-4137-9ceb-402d6eedc8d0.png)
![image](https://user-images.githubusercontent.com/90291778/227362291-a6dd7fbc-0461-4b8c-aab7-c50a601bae2e.png)


### Review notes

While solving this issue, I noticed the checkbox component lacks of its blur (both light & dark) variants. Tried to solve it in this issue, but it looks as a lot of work, so to keep this issue focused, I'll open a follow up issue to create all the missing blur variants for the selectors.

Designs:

![image](https://user-images.githubusercontent.com/90291778/227363177-68f72c01-f475-42d1-a4bb-5938e08a8eec.png)

Current:
![image](https://user-images.githubusercontent.com/90291778/227363215-f56a828a-ffea-49d1-9684-55143241f100.png)


#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open Status
- Go to preview components -> Selectors -> Disclaimer
- Test it can be checked and the blur variant is shown only for the dark theme.

status: ready
