### PR TITLE
Fix timesource in waku-2

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.141.1",
-    "commit-sha1": "458f28178ca15732df8e6c806ef5326fad44427c",
-    "src-sha256": "1hhfswn17dja62rxkb572afd6fsx86wfxs4j666lhscdz7zzs4gx"
+    "version": "bug/fix-timesource",
+    "commit-sha1": "4ddb878289dccc8b6d77f882e0ccdd0b9fd970cf",
+    "src-sha256": "1kf9fb40v5kwxk9n9rqs2nqghq2xdrcx5kvmwwld03igfwvgs4f9"
 }


### PR DESCRIPTION
This fixes a bug in waku-2 implementation, where it wasn't using a ntp synced timesource.


To test:

1) Take develop (without this commit), set your phone clock to two days ago
2) Send messages, it should not be received by anyone else

If you use this PR, it should be received

There's still a fundamental issue, since this worked with waku1, because it wanted nodes to be synchronized +/-20 seconds, waku-2 does not require that, so the check is really not meaningful, so I believe there's room for a potential attack by racing clock values, this will need to be addressed.