### PR TITLE
Fix necessity to tap twice in mentions suggestion list component

### DIFF
--- a/src/status_im2/contexts/chat/messages/composer/view.cljs
+++ b/src/status_im2/contexts/chat/messages/composer/view.cljs
@@ -231,7 +231,7 @@
                  :sending-image          (seq images)
                  :refs                   refs}]]]]
             (if suggestions?
-              [mentions/mentions params insets]
+              [mentions/mentions (select-keys params [:refs :suggestions :max-y]) insets]
               [controls/view send-ref record-ref params insets chat-id images
                edit #(clean-and-minimize params)])
             ;;;;black background


### PR DESCRIPTION

fixes #15235

### Summary

The mentions list component was getting more props than it needs and they caused re-mounting when the user clicks the first time. After truncating props to required-only problem disappeared.


#### Platforms

 - iOS

### Steps to test

- Open any chat
- Start typing @ in order to open mention list
- Tap once on any name in the list
- See if it has been selected i.e.mention has appeared in message input field

status: ready
