### PR TITLE
[15383] Add the album count attribute to message body

### DIFF
--- a/src/status_im/data_store/messages.cljs
+++ b/src/status_im/data_store/messages.cljs
@@ -41,7 +41,8 @@
         :albumId                  :album-id
         :imageWidth               :image-width
         :imageHeight              :image-height
-        :new                      :new?})
+        :new                      :new?
+        :albumCount               :album-count})
 
       (update :quoted-message
               set/rename-keys

--- a/src/status_im/data_store/messages.cljs
+++ b/src/status_im/data_store/messages.cljs
@@ -42,7 +42,7 @@
         :imageWidth               :image-width
         :imageHeight              :image-height
         :new                      :new?
-        :albumCount               :album-count})
+        :albumImagesCount         :album-images-count})
 
       (update :quoted-message
               set/rename-keys

--- a/src/status_im/ui2/screens/chat/components/reply/view.cljs
+++ b/src/status_im/ui2/screens/chat/components/reply/view.cljs
@@ -115,7 +115,7 @@
                                    {:color (colors/theme-colors colors/neutral-50 colors/neutral-40)}))}
           (case (or content-type contentType)
             constants/content-type-image   (if album-count
-                                             (str album-count \space (i18n/label :t/images))
+                                             (i18n/label :t/images-albums-count {:album-count album-count})
                                              (i18n/label :t/image))
             constants/content-type-sticker (i18n/label :t/sticker)
             constants/content-type-audio   (i18n/label :t/audio)

--- a/src/status_im/ui2/screens/chat/components/reply/view.cljs
+++ b/src/status_im/ui2/screens/chat/components/reply/view.cljs
@@ -76,7 +76,8 @@
     (format-reply-author from contact-name current-public-key)]])
 
 (defn reply-message
-  [{:keys [from identicon content-type contentType parsed-text content deleted? deleted-for-me?]}
+  [{:keys [from identicon content-type contentType parsed-text content deleted? deleted-for-me?
+           album-count]}
    in-chat-input? pin? recording-audio?]
   (let [contact-name       (rf/sub [:contacts/contact-name-by-identity from])
         current-public-key (rf/sub [:multiaccount/public-key])
@@ -113,7 +114,9 @@
                                            (= constants/content-type-audio content-type))
                                    {:color (colors/theme-colors colors/neutral-50 colors/neutral-40)}))}
           (case (or content-type contentType)
-            constants/content-type-image   "Image"
+            constants/content-type-image   (if album-count
+                                             (str album-count " " "Images")
+                                             "Image")
             constants/content-type-sticker "Sticker"
             constants/content-type-audio   "Audio"
             (get-quoted-text-with-mentions (or parsed-text (:parsed-text content))))]])]

--- a/src/status_im/ui2/screens/chat/components/reply/view.cljs
+++ b/src/status_im/ui2/screens/chat/components/reply/view.cljs
@@ -115,10 +115,10 @@
                                    {:color (colors/theme-colors colors/neutral-50 colors/neutral-40)}))}
           (case (or content-type contentType)
             constants/content-type-image   (if album-count
-                                             (str album-count \space "Images")
-                                             "Image")
-            constants/content-type-sticker "Sticker"
-            constants/content-type-audio   "Audio"
+                                             (str album-count \space (i18n/label :t/images))
+                                             (i18n/label :t/image))
+            constants/content-type-sticker (i18n/label :t/sticker)
+            constants/content-type-audio   (i18n/label :t/audio)
             (get-quoted-text-with-mentions (or parsed-text (:parsed-text content))))]])]
      (when (and in-chat-input? (not recording-audio?))
        [quo2.button/button

--- a/src/status_im/ui2/screens/chat/components/reply/view.cljs
+++ b/src/status_im/ui2/screens/chat/components/reply/view.cljs
@@ -77,7 +77,7 @@
 
 (defn reply-message
   [{:keys [from identicon content-type contentType parsed-text content deleted? deleted-for-me?
-           album-count]}
+           album-images-count]}
    in-chat-input? pin? recording-audio?]
   (let [contact-name       (rf/sub [:contacts/contact-name-by-identity from])
         current-public-key (rf/sub [:multiaccount/public-key])
@@ -114,8 +114,8 @@
                                            (= constants/content-type-audio content-type))
                                    {:color (colors/theme-colors colors/neutral-50 colors/neutral-40)}))}
           (case (or content-type contentType)
-            constants/content-type-image   (if album-count
-                                             (i18n/label :t/images-albums-count {:album-count album-count})
+            constants/content-type-image   (if album-images-count
+                                             (i18n/label :t/images-albums-count {:album-images-count album-images-count})
                                              (i18n/label :t/image))
             constants/content-type-sticker (i18n/label :t/sticker)
             constants/content-type-audio   (i18n/label :t/audio)

--- a/src/status_im/ui2/screens/chat/components/reply/view.cljs
+++ b/src/status_im/ui2/screens/chat/components/reply/view.cljs
@@ -115,7 +115,7 @@
                                    {:color (colors/theme-colors colors/neutral-50 colors/neutral-40)}))}
           (case (or content-type contentType)
             constants/content-type-image   (if album-count
-                                             (str album-count " " "Images")
+                                             (str album-count \space "Images")
                                              "Image")
             constants/content-type-sticker "Sticker"
             constants/content-type-audio   "Audio"

--- a/src/status_im/ui2/screens/chat/components/reply/view.cljs
+++ b/src/status_im/ui2/screens/chat/components/reply/view.cljs
@@ -115,7 +115,8 @@
                                    {:color (colors/theme-colors colors/neutral-50 colors/neutral-40)}))}
           (case (or content-type contentType)
             constants/content-type-image   (if album-images-count
-                                             (i18n/label :t/images-albums-count {:album-images-count album-images-count})
+                                             (i18n/label :t/images-albums-count
+                                                         {:album-images-count album-images-count})
                                              (i18n/label :t/image))
             constants/content-type-sticker (i18n/label :t/sticker)
             constants/content-type-audio   (i18n/label :t/audio)

--- a/translations/en.json
+++ b/translations/en.json
@@ -2018,7 +2018,7 @@
     "you-have-no-contacts": "You have no contacts",
     "my-albums": "My albums",
     "images": "images",
-    "images-albums-count": "{{album-count}} images",
+    "images-albums-count": "{{album-images-count}} images",
     "only-6-images": "You can only add 6 images to your message",
     "delivered": "Delivered",
     "mark-all-notifications-as-read": "Mark all notifications as read",

--- a/translations/en.json
+++ b/translations/en.json
@@ -2018,6 +2018,7 @@
     "you-have-no-contacts": "You have no contacts",
     "my-albums": "My albums",
     "images": "images",
+    "images-albums-count": "{{album-count}} images",
     "only-6-images": "You can only add 6 images to your message",
     "delivered": "Delivered",
     "mark-all-notifications-as-read": "Mark all notifications as read",


### PR DESCRIPTION
This PR adds the album count attribute to the message body .. So that we can know how many images are in an album

fixes #15383 

### Summary

This PR adds a key to indicate how many photos were sent in a message .. This is helpful in identifying how many images are in a message .. And then I just added logic to render the number of images on reply

- Android
- iOS

##### Functional

- 1-1 chats
- public chats
- group chats

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open Status
- Step 1, Send a message with multiple images
- Step 2, Reply to it and check when writing the reply if the number of images will show or not
- Step 3, Send the reply and check if the count is shown with the new reply or not

Expected behaviour:
Images count to show when sending the reply and after sending it
![image](https://user-images.githubusercontent.com/33176106/227768339-815d7472-271b-42b3-bb16-beabd3d170d9.png)

Example:


status: ready
