### PR TITLE
fix: disable edit image message until it's implemented

### DIFF
--- a/src/status_im2/contexts/chat/messages/drawers/view.cljs
+++ b/src/status_im2/contexts/chat/messages/drawers/view.cljs
@@ -27,6 +27,10 @@
   (concat
    (when (and outgoing
               (not (or deleted? deleted-for-me?))
+              ;; temporarily disable edit image message until
+              ;; https://github.com/status-im/status-mobile/issues/15298
+              ;; is implemented
+              (not= content-type constants/content-type-image)
               (not= content-type constants/content-type-audio))
      [{:type     :main
        :on-press #(rf/dispatch [:chat.ui/edit-message message-data])


### PR DESCRIPTION
-------

background https://github.com/status-im/status-mobile/issues/15444
related https://github.com/status-im/status-mobile/issues/15298

status: ready <!-- Can be ready or wip -->