### PR TITLE
fix: crash on wallet view

### DIFF
--- a/src/status_im2/subs/wallet/wallet.cljs
+++ b/src/status_im2/subs/wallet/wallet.cljs
@@ -3,10 +3,10 @@
             [re-frame.core :as re-frame]
             [status-im.ethereum.core :as ethereum]
             [status-im.ethereum.tokens :as tokens]
-            [utils.i18n :as i18n]
-            [status-im2.config :as config]
             [status-im.utils.currency :as currency]
-            [status-im.utils.money :as money]))
+            [status-im.utils.money :as money]
+            [status-im2.config :as config]
+            [utils.i18n :as i18n]))
 
 (re-frame/reg-sub
  :balance
@@ -253,7 +253,7 @@
  :wallet/currency
  :<- [:wallet.settings/currency]
  (fn [currency-id]
-   (get currency/currencies currency-id)))
+   (get currency/currencies currency-id (get currency/currencies :usd))))
 
 (defn filter-recipient-favs
   [search-filter {:keys [name]}]


### PR DESCRIPTION
resolve https://github.com/status-im/status-mobile/issues/15425


issue caused by:

the `:currency` of this account is somehow set to `:USD` instead of `:usd`. @pavloburykh any idea?

--- 
**related code**

sub that  get `:currency` from `:multiaccount` https://github.com/status-im/status-mobile/blob/a326158f33bce9804d8b2905646e902d18578cba/src/status_im2/subs/wallet/wallet.cljs#L60

leads to the price [here](https://github.com/status-im/status-mobile/blob/a326158f33bce9804d8b2905646e902d18578cba/src/status_im2/subs/wallet/wallet.cljs#L65) being `{}` instead of `nil`


status: ready <!-- Can be ready or wip -->