### PR TITLE
fix: add min 5 characters validation for display names

### DIFF
--- a/src/status_im2/contexts/onboarding/create_profile/view.cljs
+++ b/src/status_im2/contexts/onboarding/create_profile/view.cljs
@@ -35,6 +35,10 @@
 (defn has-common-names [s] (pos? (count (filter #(string/includes? s %) common-names))))
 (def special-characters-regex (new js/RegExp #"[^a-zA-Z\d\s-._]" "i"))
 (defn has-special-characters [s] (re-find special-characters-regex s))
+(def min-length 5)
+(defn length-not-valid [s] (< (count (string/trim s)) min-length))
+(def valid-regex (new js/RegExp #"^[\w-\s]{5,24}$" "i"))
+(defn valid-name [s] (re-find valid-regex s))
 
 (defn validation-message
   [s]
@@ -47,6 +51,9 @@
     (string/ends-with? s ".eth") (i18n/label :t/ending-not-allowed {:ending ".eth"})
     (has-common-names s)         (i18n/label :t/are-not-allowed {:check (i18n/label :t/common-names)})
     (has-emojis s)               (i18n/label :t/are-not-allowed {:check (i18n/label :t/emojis)})
+    (length-not-valid s)         (i18n/label :t/name-must-have-at-least-characters
+                                             {:min-chars min-length})
+    (not (valid-name s))         (i18n/label :t/name-is-not-valid)
     :else                        nil))
 
 (defn button-container
@@ -67,7 +74,7 @@
            validation-msg        (reagent/atom (validation-message @full-name))
            on-change-text        (fn [s]
                                    (reset! validation-msg (validation-message s))
-                                   (reset! full-name s))
+                                   (reset! full-name (string/trim s)))
            custom-color          (reagent/atom (or color c/profile-default-color))
            profile-pic           (reagent/atom image-path)
            on-change-profile-pic #(reset! profile-pic %)

--- a/translations/en.json
+++ b/translations/en.json
@@ -2054,5 +2054,7 @@
     "error-syncing-connection-failed": "Oops! Connection failed. Try again",
     "camera-permission-denied": "Permission denied",
     "enable-biometrics": "Enable biometrics",
-    "use-biometrics": "Use biometrics to fill in your password"
+    "use-biometrics": "Use biometrics to fill in your password",
+    "name-must-have-at-least-characters": "Name must have at least {{min-chars}} characters",
+    "name-is-not-valid": "Name is not valid"
 }


### PR DESCRIPTION
fixes #15540 

### Summary

Add minimum character validation on profile name. Error message was not validated with design team but I suppose we can change it later if necessary.

<img src="https://user-images.githubusercontent.com/18485527/228994054-f9d2ae2d-2139-438f-b738-24016b0682d3.png" width="350"> <img src="https://user-images.githubusercontent.com/18485527/228994047-614ce398-8187-4fc4-b300-02951768a9b0.png" width="350">

#### Platforms

- Android
- iOS

#### Areas that maybe impacted

##### Functional

- onboarding
- message reliability impact

### Steps to test

- Open Status
- Create new account
- Type profile name
- Verify user can't continue profile creation if enters a name of less than 5 characters

status: ready
