### PR TITLE
fix: calibrate duration calculation of recorded audio

### DIFF
--- a/src/quo2/components/record_audio/record_audio/__tests__/record_audio_component_spec.cljs
+++ b/src/quo2/components/record_audio/record_audio/__tests__/record_audio_component_spec.cljs
@@ -1,7 +1,9 @@
 (ns quo2.components.record-audio.record-audio.--tests--.record-audio-component-spec
   (:require [quo2.components.record-audio.record-audio.view :as record-audio]
             [react-native.audio-toolkit :as audio]
-            [test-helpers.component :as h]))
+            [test-helpers.component :as h]
+            [reagent.core :as reagent]
+            [utils.datetime :as datetime]))
 
 (h/describe "record audio component"
   (h/before-each
@@ -34,12 +36,16 @@
           (.toHaveBeenCalledTimes 1))))
 
   (h/test "record-audio on-reviewing-audio works"
-    (let [event (js/jest.fn)]
+    (let [event    (js/jest.fn)
+          on-meter (reagent/atom nil)]
       (h/render [record-audio/record-audio
                  {:on-reviewing-audio              event
                   :record-audio-permission-granted true}])
-      (with-redefs [audio/start-recording        (fn [_ on-start _]
-                                                   (on-start))
+      (with-redefs [audio/new-recorder           (fn [_ on-meter-fn _]
+                                                   (reset! on-meter on-meter-fn))
+                    audio/start-recording        (fn [_ on-start _]
+                                                   (on-start)
+                                                   (js/setInterval #(@on-meter) 100))
                     audio/get-recorder-file-path (fn [] "file-path")]
         (h/fire-event
          :on-start-should-set-responder
@@ -48,25 +54,30 @@
                         :locationY  70
                         :timestamp  0
                         :identifier 0}})
-        (h/advance-timers-by-time 500)
-        (h/fire-event
-         :on-responder-release
-         (h/get-by-test-id "record-audio")
-         {:nativeEvent {:locationX  70
-                        :locationY  70
-                        :timestamp  200
-                        :identifier 0}})
-        (h/advance-timers-by-time 250)
-        (-> (h/expect event)
-            (.toHaveBeenCalledTimes 1)))))
+        (with-redefs [datetime/timestamp (fn [] (+ (.now js/Date) 1000))]
+          (h/advance-timers-by-time 100)
+          (h/fire-event
+           :on-responder-release
+           (h/get-by-test-id "record-audio")
+           {:nativeEvent {:locationX  70
+                          :locationY  70
+                          :timestamp  200
+                          :identifier 0}})
+          (h/advance-timers-by-time 250)
+          (-> (h/expect event)
+              (.toHaveBeenCalledTimes 1))))))
 
   (h/test "record-audio on-send works after reviewing audio"
-    (let [event (js/jest.fn)]
+    (let [event    (js/jest.fn)
+          on-meter (reagent/atom nil)]
       (h/render [record-audio/record-audio
                  {:on-send                         event
                   :record-audio-permission-granted true}])
-      (with-redefs [audio/start-recording        (fn [_ on-start _]
-                                                   (on-start))
+      (with-redefs [audio/new-recorder           (fn [_ on-meter-fn _]
+                                                   (reset! on-meter on-meter-fn))
+                    audio/start-recording        (fn [_ on-start _]
+                                                   (on-start)
+                                                   (js/setInterval #(@on-meter) 100))
                     audio/get-recorder-file-path (fn [] "audio-file-path")
                     audio/get-player-duration    (fn [] 5000)]
         (h/fire-event
@@ -76,46 +87,57 @@
                         :locationY  70
                         :timestamp  0
                         :identifier 0}})
-        (h/advance-timers-by-time 500)
-        (h/fire-event
-         :on-responder-release
-         (h/get-by-test-id "record-audio")
-         {:nativeEvent {:locationX  70
-                        :locationY  70
-                        :timestamp  200
-                        :identifier 0}})
-        (h/fire-event
-         :on-start-should-set-responder
-         (h/get-by-test-id "record-audio")
-         {:nativeEvent {:locationX  70
-                        :locationY  70
-                        :timestamp  0
-                        :identifier 0}})
-        (h/advance-timers-by-time 500)
-        (h/fire-event
-         :on-responder-release
-         (h/get-by-test-id "record-audio")
-         {:nativeEvent {:locationX  80
-                        :locationY  80
-                        :timestamp  200
-                        :identifier 0}})
-        (h/advance-timers-by-time 250)
-        (-> (js/expect event)
-            (.toHaveBeenCalledTimes 1))
-        (-> (js/expect event)
-            (.toHaveBeenCalledWith {:file-path "audio-file-path"
-                                    :duration  5000})))))
+        (with-redefs [datetime/timestamp (fn [] (+ (.now js/Date) 1000))]
+          (h/advance-timers-by-time 100)
+          (h/fire-event
+           :on-responder-release
+           (h/get-by-test-id "record-audio")
+           {:nativeEvent {:locationX  70
+                          :locationY  70
+                          :timestamp  200
+                          :identifier 0}})
+          (h/fire-event
+           :on-start-should-set-responder
+           (h/get-by-test-id "record-audio")
+           {:nativeEvent {:locationX  70
+                          :locationY  70
+                          :timestamp  0
+                          :identifier 0}})
+          (h/advance-timers-by-time 500)
+          (h/fire-event
+           :on-responder-release
+           (h/get-by-test-id "record-audio")
+           {:nativeEvent {:locationX  80
+                          :locationY  80
+                          :timestamp  200
+                          :identifier 0}})
+          (h/advance-timers-by-time 250)
+          (-> (js/expect event)
+              (.toHaveBeenCalledTimes 1))
+          (-> (js/expect event)
+              (.toHaveBeenCalledWith {:file-path "audio-file-path"
+                                      :duration  5000}))))))
 
   (h/test "record-audio on-send works after sliding to the send button"
-    (let [event (js/jest.fn)]
+    (let [event       (js/jest.fn)
+          on-meter    (reagent/atom nil)
+          last-now-ms (atom nil)
+          duration-ms (atom nil)]
       (h/render [record-audio/record-audio
                  {:on-send                         event
                   :record-audio-permission-granted true}])
-      (with-redefs [audio/start-recording        (fn [_ on-start _]
-                                                   (on-start))
+      (with-redefs [audio/new-recorder           (fn [_ on-meter-fn _]
+                                                   (reset! on-meter on-meter-fn))
+                    audio/start-recording        (fn [_ on-start _]
+                                                   (on-start)
+                                                   (js/setInterval #(@on-meter) 100))
                     audio/stop-recording         (fn [_ on-stop _]
                                                    (on-stop))
-                    audio/get-recorder-file-path (fn [] "audio-file-path")]
+                    audio/get-recorder-file-path (fn [] "audio-file-path")
+                    datetime/timestamp           (fn []
+                                                   (let [now-ms (.now js/Date)]
+                                                     (reset! last-now-ms now-ms)
+                                                     now-ms))]
         (h/fire-event
          :on-start-should-set-responder
          (h/get-by-test-id "record-audio")
@@ -123,36 +145,46 @@
                         :locationY  70
                         :timestamp  0
                         :identifier 0}})
-        (h/advance-timers-by-time 500)
-        (h/fire-event
-         :on-responder-move
-         (h/get-by-test-id "record-audio")
-         {:nativeEvent {:locationX  80
-                        :locationY  -30
-                        :pageX      80
-                        :pageY      -30
-                        :identifier 0}})
-        (h/fire-event
-         :on-responder-release
-         (h/get-by-test-id "record-audio")
-         {:nativeEvent {:locationX  40
-                        :locationY  80
-                        :timestamp  200
-                        :identifier 0}})
-        (h/advance-timers-by-time 250)
-        (-> (js/expect event)
-            (.toHaveBeenCalledTimes 1))
-        (-> (js/expect event)
-            (.toHaveBeenCalledWith {:file-path "audio-file-path"
-                                    :duration  500})))))
+        (with-redefs [datetime/timestamp (fn []
+                                           (let [now-plus-ms  (+ (.now js/Date) 1000)
+                                                 time-diff-ms (- now-plus-ms @last-now-ms)]
+                                             (when-not @duration-ms
+                                               (reset! duration-ms time-diff-ms))
+                                             now-plus-ms))]
+          (h/advance-timers-by-time 100)
+          (h/fire-event
+           :on-responder-move
+           (h/get-by-test-id "record-audio")
+           {:nativeEvent {:locationX  80
+                          :locationY  -30
+                          :pageX      80
+                          :pageY      -30
+                          :identifier 0}})
+          (h/fire-event
+           :on-responder-release
+           (h/get-by-test-id "record-audio")
+           {:nativeEvent {:locationX  40
+                          :locationY  80
+                          :timestamp  200
+                          :identifier 0}})
+          (h/advance-timers-by-time 250)
+          (-> (js/expect event)
+              (.toHaveBeenCalledTimes 1))
+          (-> (js/expect event)
+              (.toHaveBeenCalledWith {:file-path "audio-file-path"
+                                      :duration  @duration-ms}))))))
 
   (h/test "record-audio on-cancel works after reviewing audio"
-    (let [event (js/jest.fn)]
+    (let [event    (js/jest.fn)
+          on-meter (reagent/atom nil)]
       (h/render [record-audio/record-audio
                  {:on-cancel                       event
                   :record-audio-permission-granted true}])
-      (with-redefs [audio/start-recording (fn [_ on-start _]
-                                            (on-start))]
+      (with-redefs [audio/new-recorder    (fn [_ on-meter-fn _]
+                                            (reset! on-meter on-meter-fn))
+                    audio/start-recording (fn [_ on-start _]
+                                            (on-start)
+                                            (js/setInterval #(@on-meter) 100))]
         (h/fire-event
          :on-start-should-set-responder
          (h/get-by-test-id "record-audio")
@@ -160,32 +192,37 @@
                         :locationY  70
                         :timestamp  0
                         :identifier 0}})
-        (h/advance-timers-by-time 500)
-        (h/fire-event
-         :on-responder-release
-         (h/get-by-test-id "record-audio")
-         {:nativeEvent {:locationX  70
-                        :locationY  70
-                        :timestamp  200
-                        :identifier 0}})
-        (h/fire-event
-         :on-responder-release
-         (h/get-by-test-id "record-audio")
-         {:nativeEvent {:locationX  40
-                        :locationY  80
-                        :timestamp  200
-                        :identifier 0}})
-        (h/advance-timers-by-time 250)
-        (-> (js/expect event)
-            (.toHaveBeenCalledTimes 1)))))
+        (with-redefs [datetime/timestamp (fn [] (+ (.now js/Date) 1000))]
+          (h/advance-timers-by-time 500)
+          (h/fire-event
+           :on-responder-release
+           (h/get-by-test-id "record-audio")
+           {:nativeEvent {:locationX  70
+                          :locationY  70
+                          :timestamp  200
+                          :identifier 0}})
+          (h/fire-event
+           :on-responder-release
+           (h/get-by-test-id "record-audio")
+           {:nativeEvent {:locationX  40
+                          :locationY  80
+                          :timestamp  200
+                          :identifier 0}})
+          (h/advance-timers-by-time 250)
+          (-> (js/expect event)
+              (.toHaveBeenCalledTimes 1))))))
 
-  (h/test "cord-audio on-cancel works after sliding to the cancel button"
-    (let [event (js/jest.fn)]
+  (h/test "record-audio on-cancel works after sliding to the cancel button"
+    (let [event    (js/jest.fn)
+          on-meter (reagent/atom nil)]
       (h/render [record-audio/record-audio
                  {:on-cancel                       event
                   :record-audio-permission-granted true}])
-      (with-redefs [audio/start-recording (fn [_ on-start _]
-                                            (on-start))
+      (with-redefs [audio/new-recorder    (fn [_ on-meter-fn _]
+                                            (reset! on-meter on-meter-fn))
+                    audio/start-recording (fn [_ on-start _]
+                                            (on-start)
+                                            (js/setInterval #(@on-meter) 100))
                     audio/stop-recording  (fn [_ on-stop _]
                                             (on-stop))]
         (h/fire-event
@@ -195,22 +232,25 @@
                         :locationY  70
                         :timestamp  0
                         :identifier 0}})
-        (h/advance-timers-by-time 500)
-        (h/fire-event
-         :on-responder-move
-         (h/get-by-test-id "record-audio")
-         {:nativeEvent {:locationX  -30
-                        :locationY  80
-                        :pageX      -30
-                        :pageY      80
-                        :identifier 0}})
-        (h/fire-event
-         :on-responder-release
-         (h/get-by-test-id "record-audio")
-         {:nativeEvent {:locationX  -10
-                        :locationY  70
-                        :timestamp  200
-                        :identifier 0}})
-        (h/advance-timers-by-time 250)
-        (-> (js/expect event)
-            (.toHaveBeenCalledTimes 1))))))
+        (with-redefs [datetime/timestamp (fn [] (+ (.now js/Date) 1000))]
+          (h/advance-timers-by-time 500)
+          (h/fire-event
+           :on-responder-move
+           (h/get-by-test-id "record-audio")
+           {:nativeEvent {:locationX  -30
+                          :locationY  80
+                          :pageX      -30
+                          :pageY      80
+                          :identifier 0}})
+          (h/fire-event
+           :on-responder-release
+           (h/get-by-test-id "record-audio")
+           {:nativeEvent {:locationX  -10
+                          :locationY  70
+                          :timestamp  200
+                          :identifier 0}})
+          (h/advance-timers-by-time 250)
+          (-> (js/expect event)
+              (.toHaveBeenCalledTimes 1)))))))
+
+

--- a/src/quo2/components/record_audio/record_audio/buttons/record_button_big.cljs
+++ b/src/quo2/components/record_audio/record_audio/buttons/record_button_big.cljs
@@ -29,7 +29,7 @@
 
 (defn f-record-button-big
   [recording? ready-to-send? ready-to-lock? ready-to-delete? record-button-is-animating?
-   record-button-at-initial-position? locked? reviewing-audio? recording-timer recording-length-ms
+   record-button-at-initial-position? locked? reviewing-audio? recording-length-ms
    clear-timeout touch-active? recorder-ref reload-recorder-fn idle? on-send on-cancel]
   (let [scale (reanimated/use-shared-value 1)
         opacity (reanimated/use-shared-value 0)
@@ -82,7 +82,6 @@
                (reset! ready-to-lock? false)
                (reset! idle? true)
                (js/setTimeout #(reset! idle? false) 1000)
-               (js/clearInterval @recording-timer)
                (reset! recording-length-ms 0)
                (log/debug "[record-audio] stop recording - success"))
              #(log/error "[record-audio] stop recording - error: " %))))

--- a/src/quo2/components/record_audio/soundtrack/view.cljs
+++ b/src/quo2/components/record_audio/soundtrack/view.cljs
@@ -10,8 +10,8 @@
 (def ^:private thumb-dark (js/require "../resources/images/icons2/12x12/thumb-dark.png"))
 
 (defn f-soundtrack
-  [{:keys [audio-current-time-ms player-ref style seeking-audio?]}]
-  (let [audio-duration-ms (audio/get-player-duration player-ref)]
+  [{:keys [audio-current-time-ms player-ref style seeking-audio? max-audio-duration-ms]}]
+  (let [audio-duration-ms (min max-audio-duration-ms (audio/get-player-duration player-ref))]
     [:<>
      [slider/slider
       {:test-ID                  "soundtrack"

--- a/src/status_im2/constants.cljs
+++ b/src/status_im2/constants.cljs
@@ -334,3 +334,5 @@
 (def ^:const auth-method-none "none")
 
 (def ^:const image-description-in-lightbox? false)
+
+(def ^:const audio-max-duration-ms 120000)

--- a/src/status_im2/contexts/chat/composer/actions/view.cljs
+++ b/src/status_im2/contexts/chat/composer/actions/view.cljs
@@ -7,29 +7,30 @@
     [react-native.reanimated :as reanimated]
     [reagent.core :as reagent]
     [status-im2.common.alert.events :as alert]
-    [status-im2.contexts.chat.composer.constants :as constants]
+    [status-im2.contexts.chat.composer.constants :as comp-constants]
     [status-im2.contexts.chat.messages.list.view :as messages.list]
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]
-    [status-im2.contexts.chat.composer.actions.style :as style]))
+    [status-im2.contexts.chat.composer.actions.style :as style]
+    [status-im2.constants :as constants]))
 
 (defn send-message
   [{:keys [sending-images? sending-links?]}
    {:keys [text-value focused? maximized?]}
    {:keys [height saved-height last-height opacity background-y container-opacity]}
    window-height]
-  (reanimated/animate height constants/input-height)
-  (reanimated/set-shared-value saved-height constants/input-height)
-  (reanimated/set-shared-value last-height constants/input-height)
+  (reanimated/animate height comp-constants/input-height)
+  (reanimated/set-shared-value saved-height comp-constants/input-height)
+  (reanimated/set-shared-value last-height comp-constants/input-height)
   (reanimated/animate opacity 0)
   (when-not @focused?
-    (js/setTimeout #(reanimated/animate container-opacity constants/empty-opacity) 300))
+    (js/setTimeout #(reanimated/animate container-opacity comp-constants/empty-opacity) 300))
   (js/setTimeout #(reanimated/set-shared-value background-y
                                                (- window-height))
                  300)
   (rf/dispatch [:chat.ui/send-current-message])
   (rf/dispatch [:chat.ui/set-input-maximized false])
-  (rf/dispatch [:chat.ui/set-input-content-height constants/input-height])
+  (rf/dispatch [:chat.ui/set-input-content-height comp-constants/input-height])
   (rf/dispatch [:chat.ui/set-chat-input-text nil])
   (reset! maximized? false)
   (reset! text-value "")
@@ -105,7 +106,7 @@
                                              (rf/dispatch [:chat/send-audio file-path duration])
                                              (if-not @focused?
                                                (reanimated/animate container-opacity
-                                                                   constants/empty-opacity)
+                                                                   comp-constants/empty-opacity)
                                                (js/setTimeout #(when @input-ref (.focus ^js @input-ref))
                                                               300))
                                              (rf/dispatch [:chat.ui/set-input-audio nil]))
@@ -116,7 +117,7 @@
                                                (reset! gesture-enabled? true)
                                                (if-not @focused?
                                                  (reanimated/animate container-opacity
-                                                                     constants/empty-opacity)
+                                                                     comp-constants/empty-opacity)
                                                  (js/setTimeout #(when @input-ref
                                                                    (.focus ^js @input-ref))
                                                                 300))
@@ -143,7 +144,8 @@
                                                      {:text (i18n/label :t/settings)
                                                       :accessibility-label :settings-button
                                                       :onPress (fn [] (permissions/open-settings))}))
-                                                  50)}]))}]]))
+                                                  50)}]))
+       :max-duration-ms                    constants/audio-max-duration-ms}]]))
 
 
 (defn camera-button

--- a/src/status_im2/contexts/quo_preview/record_audio/record_audio.cljs
+++ b/src/status_im2/contexts/quo_preview/record_audio/record_audio.cljs
@@ -6,7 +6,8 @@
             [utils.re-frame :as rf]
             [status-im2.common.alert.events :as alert]
             [utils.i18n :as i18n]
-            [react-native.permissions :as permissions]))
+            [react-native.permissions :as permissions]
+            [status-im2.constants :as constants]))
 
 (defonce record-audio-permission-granted (reagent/atom false))
 
@@ -52,7 +53,8 @@
           :on-reviewing-audio                 on-reviewing-audio
           :on-cancel                          on-cancel
           :on-check-audio-permissions         on-check-audio-permissions
-          :on-request-record-audio-permission on-request-record-audio-permission}]]
+          :on-request-record-audio-permission on-request-record-audio-permission
+          :max-duration-ms                    constants/audio-max-duration-ms}]]
        [quo/text {:style {:margin-horizontal 20}} @message]])))
 
 (defn preview-record-audio


### PR DESCRIPTION
fixes #15365

### Summary

Remove usage of JavaScript `setInterval` for calculating audio duration as it is not reliable due to single threaded nature of JavaScript and instead take advantage of metering callback from audio toolkit library + timestamp diff calculations.

#### Platforms

- Android
- iOS

#### Areas that maybe impacted

##### Functional

- 1-1 chats
- public chats
- group chats

### Steps to test

- Open Status
- Open a chat
- Record audio until max duration is reached
- Send it
- Check audio duration is 2:00 and not more

status: ready