### PR TITLE
feat: support ens profile name in lock screen

### DIFF
--- a/src/status_im/ens/core.cljs
+++ b/src/status_im/ens/core.cljs
@@ -2,17 +2,16 @@
   (:refer-clojure :exclude [name])
   (:require [clojure.string :as string]
             [re-frame.core :as re-frame]
+            [status-im.bottom-sheet.events :as bottom-sheet]
             [status-im.ethereum.core :as ethereum]
             [status-im.ethereum.eip55 :as eip55]
             [status-im.ethereum.ens :as ens]
             [status-im.ethereum.stateofus :as stateofus]
             [status-im.multiaccounts.update.core :as multiaccounts.update]
-            [status-im.utils.random :as random]
-            [status-im2.common.bottom-sheet.events :as bottom-sheet]
-            [status-im2.navigation.events :as navigation]
-            [taoensso.timbre :as log]
+            [utils.re-frame :as rf]
             [utils.datetime :as datetime]
-            [utils.re-frame :as rf]))
+            [status-im.utils.random :as random]
+            [status-im2.navigation.events :as navigation]))
 
 (defn fullname
   [custom-domain? username]
@@ -123,27 +122,6 @@
     (case state
       (:available :owned)
       (navigation/navigate-to cofx :ens-checkout {})
-      :connected-with-different-key
-      (re-frame/dispatch [::set-pub-key])
-      :connected
-      (save-username cofx custom-domain? username true)
-      ;; for other states, we do nothing
-      nil)))
-
-(comment
-  (log/spy :info :kkk)
-  (rf/dispatch [::remove-username "rashawn.eth"])
-  (rf/dispatch [::input-submitted-2]))
-
-(rf/defn on-input-submitted-2
-  {:events [::input-submitted-2]}
-  [{:keys [db] :as cofx}]
-  (let [state          :connected
-        username       "rashawn.eth"
-        custom-domain? true]
-    (case state
-      (:available :owned)
-      (navigation/navigate-to-cofx cofx :ens-checkout {})
       :connected-with-different-key
       (re-frame/dispatch [::set-pub-key])
       :connected

--- a/src/status_im/ens/core.cljs
+++ b/src/status_im/ens/core.cljs
@@ -2,16 +2,17 @@
   (:refer-clojure :exclude [name])
   (:require [clojure.string :as string]
             [re-frame.core :as re-frame]
-            [status-im.bottom-sheet.events :as bottom-sheet]
             [status-im.ethereum.core :as ethereum]
             [status-im.ethereum.eip55 :as eip55]
             [status-im.ethereum.ens :as ens]
             [status-im.ethereum.stateofus :as stateofus]
             [status-im.multiaccounts.update.core :as multiaccounts.update]
-            [utils.re-frame :as rf]
-            [utils.datetime :as datetime]
             [status-im.utils.random :as random]
-            [status-im2.navigation.events :as navigation]))
+            [status-im2.common.bottom-sheet.events :as bottom-sheet]
+            [status-im2.navigation.events :as navigation]
+            [taoensso.timbre :as log]
+            [utils.datetime :as datetime]
+            [utils.re-frame :as rf]))
 
 (defn fullname
   [custom-domain? username]
@@ -122,6 +123,27 @@
     (case state
       (:available :owned)
       (navigation/navigate-to cofx :ens-checkout {})
+      :connected-with-different-key
+      (re-frame/dispatch [::set-pub-key])
+      :connected
+      (save-username cofx custom-domain? username true)
+      ;; for other states, we do nothing
+      nil)))
+
+(comment
+  (log/spy :info :kkk)
+  (rf/dispatch [::remove-username "rashawn.eth"])
+  (rf/dispatch [::input-submitted-2]))
+
+(rf/defn on-input-submitted-2
+  {:events [::input-submitted-2]}
+  [{:keys [db] :as cofx}]
+  (let [state          :connected
+        username       "rashawn.eth"
+        custom-domain? true]
+    (case state
+      (:available :owned)
+      (navigation/navigate-to-cofx cofx :ens-checkout {})
       :connected-with-different-key
       (re-frame/dispatch [::set-pub-key])
       :connected

--- a/src/status_im/multiaccounts/update/core.cljs
+++ b/src/status_im/multiaccounts/update/core.cljs
@@ -5,9 +5,8 @@
             [utils.re-frame :as rf]))
 
 (rf/defn send-contact-update
-  [{:keys [db] :as cofx}]
-  (let [multiaccount                                       (:multiaccount db)
-        {:keys [name preferred-name display-name address]} multiaccount]
+  [{:keys [db]}]
+  (let [{:keys [name preferred-name display-name address]} (:multiaccount db)]
     {:json-rpc/call [{:method     "wakuext_sendContactUpdates"
                       :params     [(or preferred-name display-name name) ""]
                       :on-success #(log/debug "sent contact update")}]}))
@@ -16,9 +15,9 @@
   "This updates the profile name in the profile list before login"
   {:events [:multiaccounts.ui/update-name]}
   [{:keys [db] :as cofx} raw-multiaccounts-from-status-go]
-  (let [{:keys [key-uid name preferred-name display-name]
-         :as   multiaccount} (:multiaccount db)
-        account              (some #(and (= (:key-uid %) key-uid) %) raw-multiaccounts-from-status-go)]
+  (let [{:keys [key-uid name preferred-name
+                display-name]} (:multiaccount db)
+        account                (some #(and (= (:key-uid %) key-uid) %) raw-multiaccounts-from-status-go)]
     (when-let [new-name (and account (or preferred-name display-name name))]
       (rf/merge cofx
                 {:json-rpc/call [{:method     "multiaccounts_updateAccount"

--- a/src/status_im/multiaccounts/update/core_test.cljs
+++ b/src/status_im/multiaccounts/update/core_test.cljs
@@ -1,5 +1,5 @@
 (ns status-im.multiaccounts.update.core-test
-  (:require [clojure.test :refer-macros [deftest is]]
+  (:require [clojure.test :refer-macros [deftest is testing]]
             [status-im.multiaccounts.update.core :as multiaccounts.update]))
 
 (deftest test-multiaccount-update
@@ -21,3 +21,36 @@
         json-rpc (into #{} (map :method (:json-rpc/call efx)))]
     (is (json-rpc "settings_saveSetting"))
     (is (nil? (get-in efx [:db :multiaccount :mnemonic])))))
+
+(deftest test-update-multiaccount-account-name
+  (let [cofx                             {:db {:multiaccount {:key-uid        1
+                                                              :name           "name"
+                                                              :preferred-name "preferred-name"
+                                                              :display-name   "display-name"}}}
+        raw-multiaccounts-from-status-go [{:key-uid 1 :name "old-name"}]]
+    (testing "wrong account"
+      (is (nil? (multiaccounts.update/update-multiaccount-account-name cofx []))))
+    (testing "name priority preferred-name > display-name > name"
+      (let [new-account-name= (fn [efx new-name]
+                                (-> efx
+                                    :json-rpc/call
+                                    first
+                                    :params
+                                    first
+                                    :name
+                                    (= new-name)))]
+        (is (new-account-name=
+             (multiaccounts.update/update-multiaccount-account-name
+              cofx
+              raw-multiaccounts-from-status-go)
+             "preferred-name"))
+        (is (new-account-name=
+             (multiaccounts.update/update-multiaccount-account-name
+              (update-in cofx [:db :multiaccount] dissoc :preferred-name)
+              raw-multiaccounts-from-status-go)
+             "display-name"))
+        (is (new-account-name=
+             (multiaccounts.update/update-multiaccount-account-name
+              (update-in cofx [:db :multiaccount] dissoc :preferred-name :display-name)
+              raw-multiaccounts-from-status-go)
+             "name"))))))

--- a/src/status_im/pairing/core.cljs
+++ b/src/status_im/pairing/core.cljs
@@ -247,11 +247,11 @@
   [cofx installation-id]
   (rf/merge cofx
             (enable installation-id)
-            (multiaccounts.update/send-multiaccount-update)))
+            (multiaccounts.update/send-contact-update)))
 
 (rf/defn disable-installation-success
   {:events [:pairing.callback/disable-installation-success]}
   [cofx installation-id]
   (rf/merge cofx
             (disable installation-id)
-            (multiaccounts.update/send-multiaccount-update)))
+            (multiaccounts.update/send-contact-update)))


### PR DESCRIPTION
resolve https://github.com/status-im/status-mobile/issues/15435

### Summary

account name in lock screen is persisted in another db
this PR sync name changes to that db when user logged in

syncing is triggered by `multiaccount-update` which calling `settings_saveSetting`, and is filtered by `(#{:name :preferred-name} setting-key)`

Also not sure if we should do this in mobile or go



https://user-images.githubusercontent.com/15090582/229445653-240561d3-c03f-44ef-8fb7-9e206a485399.mp4


https://user-images.githubusercontent.com/15090582/229445674-14f842f2-78a2-4dfe-85a7-bf5aa93b550d.mp4


### Testing notes
might miss other places that changes ens name

status: ready <!-- Can be ready or wip -->