### PR TITLE
[#14703] Fix highlighted text mention in chat input

### DIFF
--- a/src/status_im/chat/models/input.cljs
+++ b/src/status_im/chat/models/input.cljs
@@ -48,10 +48,11 @@
         cursor      (+ at-sign-idx (count primary-name) 2)]
     (rf/merge
      cofx
-     {:db                   (-> db
-                                (assoc-in [:chats/cursor chat-id] cursor)
-                                (assoc-in [:chats/mention-suggestions chat-id] nil))
-      :set-text-input-value [chat-id new-text text-input-ref]}
+     {:db (-> db
+              (assoc-in [:chats/cursor chat-id] cursor)
+              (assoc-in [:chats/mention-suggestions chat-id] nil))
+      ;:set-text-input-value [chat-id new-text text-input-ref]
+     }
      (set-chat-input-text new-text chat-id)
      ;; NOTE(rasom): Some keyboards do not react on selection property passed to
      ;; text input (specifically Samsung keyboard with predictive text set on).

--- a/src/status_im/ui2/screens/chat/composer/input.cljs
+++ b/src/status_im/ui2/screens/chat/composer/input.cljs
@@ -192,49 +192,59 @@
 
 (defn text-input
   [{:keys [refs chat-id sending-image on-content-size-change]}]
-  (let [cooldown-enabled? (rf/sub [:chats/current-chat-cooldown-enabled?])
-        mentionable-users (rf/sub [:chats/mentionable-users])
-        timeout-id (reagent/atom nil)
-        last-text-change (reagent/atom nil)
-        mentions-enabled? (get @mentions-enabled? chat-id)
-        props
-        {:style (text-input-style chat-id)
-         :ref (:text-input-ref refs)
-         :max-font-size-multiplier 1
-         :accessibility-label :chat-message-input
-         :text-align-vertical :center
-         :multiline true
-         :editable (not cooldown-enabled?)
-         :blur-on-submit false
-         :auto-focus false
-         :max-length chat.constants/max-text-size
-         :placeholder-text-color (colors/theme-colors colors/neutral-40 colors/white-opa-30)
-         :placeholder (if cooldown-enabled?
-                        (i18n/label :cooldown/text-input-disabled)
-                        (i18n/label :t/type-a-message))
-         :default-value (get @input-texts chat-id)
-         :underline-color-android :transparent
-         :auto-capitalize :sentences
-         :auto-correct false
-         :spell-check false
-         :on-content-size-change on-content-size-change
-         :on-selection-change (partial on-selection-change
-                                       timeout-id
-                                       last-text-change
-                                       mentionable-users)
-         :on-change
-         (partial on-change last-text-change timeout-id mentionable-users refs chat-id sending-image)
-         :on-text-input (partial on-text-input mentionable-users chat-id)}
+  (let [cooldown-enabled?   (rf/sub [:chats/current-chat-cooldown-enabled?])
+        mentionable-users   (rf/sub [:chats/mentionable-users])
+        timeout-id          (reagent/atom nil)
+        last-text-change    (reagent/atom nil)
+        mentions-enabled?   (get @mentions-enabled? chat-id)
+        props               {:style (text-input-style chat-id)
+                             :ref (:text-input-ref refs)
+                             :max-font-size-multiplier 1
+                             :accessibility-label :chat-message-input
+                             :text-align-vertical :center
+                             :multiline true
+                             :editable (not cooldown-enabled?)
+                             :blur-on-submit false
+                             :auto-focus false
+                             :max-length chat.constants/max-text-size
+                             :placeholder-text-color (colors/theme-colors colors/neutral-40
+                                                                          colors/white-opa-30)
+                             :placeholder (if cooldown-enabled?
+                                            (i18n/label :cooldown/text-input-disabled)
+                                            (i18n/label :t/type-a-message))
+                             :default-value (get @input-texts chat-id)
+                             :underline-color-android :transparent
+                             :auto-capitalize :sentences
+                             :auto-correct false
+                             :spell-check false
+                             :on-content-size-change on-content-size-change
+                             :on-selection-change (partial on-selection-change
+                                                           timeout-id
+                                                           last-text-change
+                                                           mentionable-users)
+                             :on-change
+                             (partial on-change
+                                      last-text-change
+                                      timeout-id
+                                      mentionable-users
+                                      refs
+                                      chat-id
+                                      sending-image)
+                             :on-text-input (partial on-text-input
+                                                     mentionable-users
+                                                     chat-id)}
         input-with-mentions (rf/sub [:chat/input-with-mentions])
-        children (fn []
-                   (if mentions-enabled?
-                     (map-indexed
-                      (fn [index [_ text]]
-                        ^{:key (str index "_" type "_" text)}
-                        [rn/text (when (= type :mention) {:style {:color colors/primary-50}})
-                         text])
-                      input-with-mentions)
-                     (get @input-texts chat-id)))]
+        children            (if mentions-enabled?
+                              (map-indexed (fn [index [text-type text]]
+                                             ;; This type is the clojure fn?
+                                             ;; Should it be in the destructuring vector?
+                                             ^{:key (str index "_" text-type "_" text)}
+                                             [rn/text
+                                              (when (= text-type :mention)
+                                                {:style {:color colors/primary-50}})
+                                              text])
+                                           input-with-mentions)
+                              (get @input-texts chat-id))]
     (reset! text-input-ref (:text-input-ref refs))
     ;when ios implementation for selectable-text-input is ready, we need remove this condition and use
     ;selectable-text-input directly.
@@ -361,9 +371,9 @@
 
       :reagent-render
       (fn [chat-id {:keys [style ref on-selection-change] :as props} children]
-        (let [ref #(do (reset! text-input-ref %)
-                       (when ref
-                         (quo.react/set-ref-val! ref %)))
+        (let [ref                 #(do (reset! text-input-ref %)
+                                       (when ref
+                                         (quo.react/set-ref-val! ref %)))
               on-selection-change (fn [args]
                                     (let [selection    (.-selection ^js (.-nativeEvent ^js args))
                                           start        (.-start selection)
@@ -378,29 +388,30 @@
                                       (let [{:keys [start end text-input-handle]} @selection-event]
                                         (update-selection text-input-handle start end)
                                         (reset! selection-event nil))))
-              on-selection
-              (fn [^js event]
-                (let [native-event           (.-nativeEvent event)
-                      native-event           (transforms/js->clj native-event)
-                      {:keys [eventType content selectionStart
-                              selectionEnd]} native-event
-                      full-text              (:input-text (rf/sub [:chats/current-chat-input]))]
-                  (on-menu-item-touched {:first-level       first-level
-                                         :event-type        eventType
-                                         :content           content
-                                         :selection-start   selectionStart
-                                         :selection-end     selectionEnd
-                                         :text-input        @text-input-ref
-                                         :text-input-handle (rn/find-node-handle @text-input-ref)
-                                         :full-text         full-text
-                                         :menu-items        menu-items
-                                         :chat-id           chat-id
-                                         :selection-event   selection-event})))
-              props (merge props
-                           {:ref                 ref
-                            :style               (dissoc style :margin-horizontal)
-                            :on-selection-change on-selection-change
-                            :on-selection        on-selection})]
+              on-selection        (fn [^js event]
+                                    (let [native-event           (.-nativeEvent event)
+                                          native-event           (transforms/js->clj native-event)
+                                          {:keys [eventType content selectionStart
+                                                  selectionEnd]} native-event
+                                          full-text              (:input-text
+                                                                  (rf/sub [:chats/current-chat-input]))]
+                                      (on-menu-item-touched {:first-level       first-level
+                                                             :event-type        eventType
+                                                             :content           content
+                                                             :selection-start   selectionStart
+                                                             :selection-end     selectionEnd
+                                                             :text-input        @text-input-ref
+                                                             :text-input-handle (rn/find-node-handle
+                                                                                 @text-input-ref)
+                                                             :full-text         full-text
+                                                             :menu-items        menu-items
+                                                             :chat-id           chat-id
+                                                             :selection-event   selection-event})))
+              props               (assoc props
+                                         :ref                 ref
+                                         :style               (dissoc style :margin-horizontal)
+                                         :on-selection-change on-selection-change
+                                         :on-selection        on-selection)]
           [rn/selectable-text-input {:menuItems @menu-items :style style}
-           [rn/text-input props
+           [rn/text-input (dissoc props :default-value)
             children]]))})))


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes #14703

### Summary

[comment]: # (Summarise the problem and how the pull request solves it)

This PR fix the warning showing that functions aren't allowed as React children, but few other issues arose because the component that created the warning was not being used, so I managed to use it.

![image](https://user-images.githubusercontent.com/90291778/229266293-24386b5f-deaf-46f3-bc4f-e1c87c068599.png)


I'll explain with more detail in this PR's comments

#### Platforms
 **IMPORTANT: Only addressed on Android**

#### Areas that maybe impacted
1-1 chats

##### Functional

- 1-1 chats

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open Status
- Open a chat with someone
- Write a message and include @ to create a mention
- Once the mention is created, it'll be showed in blue


status: WIP
