### PR TITLE
[Update] Checks for Syncing completed signal

### DIFF
--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -115,7 +115,7 @@
   {:events [:system-theme-mode-changed]}
   [{:keys [db] :as cofx} _]
   (let [current-theme-type (get-in cofx [:db :multiaccount :appearance])]
-    (when (and (multiaccounts.model/logged-in? cofx)
+    (when (and (multiaccounts.model/logged-in? db)
                (= current-theme-type status-im2.constants/theme-type-system))
       {:multiaccounts.ui/switch-theme-fx
        [(get-in db [:multiaccount :appearance])

--- a/src/status_im/keycard/recovery.cljs
+++ b/src/status_im/keycard/recovery.cljs
@@ -238,7 +238,7 @@
                                                        :t/keycard-can-use-with-new-passcode
                                                        :t/keycard-backup-success-body))}}
             (cond
-              (multiaccounts.model/logged-in? cofx)
+              (multiaccounts.model/logged-in? db)
               (navigation/set-stack-root :profile-stack [:my-profile :keycard-settings])
 
               (:multiaccounts/login db)

--- a/src/status_im/mobile_sync_settings/core.cljs
+++ b/src/status_im/mobile_sync_settings/core.cljs
@@ -21,7 +21,7 @@
 (rf/defn on-network-status-change
   [{:keys [db] :as cofx}]
   (let [initialized?                       (get db :network-status/initialized?)
-        logged-in?                         (multiaccounts.model/logged-in? cofx)
+        logged-in?                         (multiaccounts.model/logged-in? db)
         {:keys [remember-syncing-choice?]} (:multiaccount db)]
     (apply
      rf/merge

--- a/src/status_im/multiaccounts/key_storage/core.cljs
+++ b/src/status_im/multiaccounts/key_storage/core.cljs
@@ -21,10 +21,10 @@
 (rf/defn key-and-storage-management-pressed
   "This event can be dispatched before login and from profile and needs to redirect accordingly"
   {:events [::key-and-storage-management-pressed]}
-  [cofx]
+  [{:keys [db] :as cofx}]
   (navigation/navigate-to
    cofx
-   (if (multiaccounts.model/logged-in? cofx)
+   (if (multiaccounts.model/logged-in? db)
      :actions-logged-in
      :actions-not-logged-in)
    nil))

--- a/src/status_im/multiaccounts/model.cljs
+++ b/src/status_im/multiaccounts/model.cljs
@@ -1,9 +1,8 @@
 (ns status-im.multiaccounts.model)
 
 (defn logged-in?
-  [cofx]
-  (boolean
-   (get-in cofx [:db :multiaccount])))
+  [{:keys [multiaccount]}]
+  (boolean multiaccount))
 
 (defn credentials
   [cofx]

--- a/src/status_im/multiaccounts/model_test.cljs
+++ b/src/status_im/multiaccounts/model_test.cljs
@@ -4,6 +4,6 @@
 
 (deftest logged-in-test
   (testing "multiaccount is defined"
-    (is (multiaccounts.model/logged-in? {:db {:multiaccount {}}})))
+    (is (multiaccounts.model/logged-in? {:multiaccount {}})))
   (testing "multiaccount is not there"
-    (is (not (multiaccounts.model/logged-in? {:db {}})))))
+    (is (not (multiaccounts.model/logged-in? {})))))

--- a/src/status_im/utils/universal_links/core.cljs
+++ b/src/status_im/utils/universal_links/core.cljs
@@ -184,7 +184,7 @@
   on login, otherwise just handle it"
   {:events [:universal-links/handle-url]}
   [{:keys [db] :as cofx} url]
-  (if (and (multiaccounts.model/logged-in? cofx) (= (:app-state db) "active"))
+  (if (and (multiaccounts.model/logged-in? db) (= (:app-state db) "active"))
     (route-url cofx url)
     (store-url-for-later cofx url)))
 

--- a/src/status_im2/constants.cljs
+++ b/src/status_im2/constants.cljs
@@ -263,6 +263,9 @@
   An example of a connection string is -> cs2:5vd6J6:Jfc:27xMmHKEYwzRGXcvTtuiLZFfXscMx4Mz8d9wEHUxDj4p7:EG7Z13QScfWBJNJ5cprszzDQ5fBVsYMirXo8MaQFJvpF:3 "
   "cs")
 
+(def ^:const local-pairing-role-sender "sender")
+(def ^:const local-pairing-role-receiver "receiver")
+
 ;; sender and receiver events
 (def ^:const local-pairing-event-connection-success "connection-success")
 (def ^:const local-pairing-event-connection-error "connection-error")

--- a/src/status_im2/subs/general.cljs
+++ b/src/status_im2/subs/general.cljs
@@ -29,7 +29,7 @@
 (re-frame/reg-sub
  :multiaccount/logged-in?
  (fn [db]
-   (multiaccounts.model/logged-in? {:db db})))
+   (multiaccounts.model/logged-in? db)))
 
 (re-frame/reg-sub
  :hide-screen?


### PR DESCRIPTION
### Summary

This PR updates the checks for the completion of syncing/local pairing and navigation (to `enable notification` screen) upon syncing completion in the signal handling.

#### Why changed?

During the syncing process, Both Sender and Receiver devices receive a series of signals from `status-go`.  After the `{:event {:type "transfer-success", :action 3}}` signal, the user who scanned the QR (receiver device) needs to be logged in (with a `node.login` signal received) to complete the syncing with pairing installation data. In end, the `{:event {:type "transfer-success", :action 4}}` signal is received as a mark of syncing completed on both sender and receiver devices.

Upon receiving the login signal, the login events are dispatched to set up the receiver except the receiver should not be navigated to the next screen until syncing is completed (as per design).

Before this PR, The receiver device listened to the `{:event {:type "transfer-success", :action 3}` signal as a check for pairing completed and handled the navigation in the login signal. So, that's why this PR updates the checks and navigation.

These changes are needed for the issue https://github.com/status-im/status-mobile/issues/15356.

#### Review notes

- This PR also refactors the `logged-in?` method to receive just the **app-db** as it doesn't require **cofx**.  https://github.com/status-im/status-mobile/pull/15416#discussion_r1143782461

- This PR introduces the `role` key in **app-db** but haven't used it yet because it will be needed (and used) for this issue https://github.com/status-im/status-mobile/issues/15356 to take the sender and receiver to the appropriate screens upon completion.

#### Testing notes

The Pairing should be working as expected as tested in https://github.com/status-im/status-mobile/pull/15416

#### Platforms

- Android
- iOS

status: ready
