### PR TITLE
fix: images 1.22

### DIFF
--- a/src/status_im2/contexts/chat/lightbox/zoomable_image/constants.cljs
+++ b/src/status_im2/contexts/chat/lightbox/zoomable_image/constants.cljs
@@ -14,4 +14,4 @@
 
 (def ^:const default-duration 300)
 
-(def ^:const default-dimension 1000)
+(def ^:const default-dimension 300)

--- a/src/status_im2/contexts/chat/messages/composer/controls/view.cljs
+++ b/src/status_im2/contexts/chat/messages/composer/controls/view.cljs
@@ -41,12 +41,12 @@
      :size 32} :i/reaction]])
 
 (defn image-button
-  [bottom-inset]
+  [insets]
   [quo/button
    {:on-press (fn []
                 (permissions/request-permissions
                  {:permissions [:read-external-storage :write-external-storage]
-                  :on-allowed  #(rf/dispatch [:open-modal :photo-selector {:bottom-inset bottom-inset}])
+                  :on-allowed  #(rf/dispatch [:open-modal :photo-selector {:insets insets}])
                   :on-denied   (fn []
                                  (background-timer/set-timeout
                                   #(utils-old/show-popup (i18n/label :t/error)

--- a/src/status_im2/contexts/chat/photo_selector/view.cljs
+++ b/src/status_im2/contexts/chat/photo_selector/view.cljs
@@ -13,6 +13,7 @@
     [status-im2.contexts.chat.photo-selector.style :as style]
     [status-im.utils.core :as utils]
     [quo.react]
+    [status-im2.common.bottom-sheet-screen.view :as bottom-sheet-screen]
     [utils.re-frame :as rf]))
 
 (defn on-press-confirm-selection
@@ -24,13 +25,13 @@
   (rf/dispatch [:navigate-back]))
 
 (defn bottom-gradient
-  [selected-images bottom-inset selected]
+  [selected-images insets selected]
   (when (or (seq @selected) (seq selected-images))
     [linear-gradient/linear-gradient
      {:colors [:black :transparent]
       :start  {:x 0 :y 1}
       :end    {:x 0 :y 0}
-      :style  (style/gradient-container bottom-inset)}
+      :style  (style/gradient-container (:bottom insets))}
      [quo/button
       {:style               {:align-self        :stretch
                              :margin-horizontal 20
@@ -108,15 +109,15 @@
 
 
 (defn photo-selector
-  [{:keys [scroll-enabled on-scroll]}]
+  []
   [:f>
-   (let [{:keys [bottom-inset]} (rf/sub [:screen-params]) ; TODO:
-                                                          ; https://github.com/status-im/status-mobile/issues/15535
-         temporary-selected     (reagent/atom [])] ; used when switching albums
+   (let [{:keys [insets]}   (rf/sub [:get-screen-params])
+         temporary-selected (reagent/atom [])] ; used when switching albums
      (fn []
-       (let [selected        (reagent/atom [])     ; currently selected
+       (let [selected        (reagent/atom []) ; currently selected
              selected-images (rf/sub [:chats/sending-image]) ; already selected and dispatched
              selected-album  (or (rf/sub [:camera-roll/selected-album]) (i18n/label :t/recent))]
+         (println "insets" insets)
          (rn/use-effect
           (fn []
             (rf/dispatch [:chat.ui/camera-roll-get-photos 20 nil selected-album])
@@ -124,8 +125,8 @@
               (reset! selected (vec (vals selected-images)))
               (reset! selected @temporary-selected)))
           [selected-album])
-         [:f>
-          (fn []
+         [bottom-sheet-screen/view
+          (fn [{:keys [scroll-enabled on-scroll]}]
             (let [window-width       (:width (rn/get-window))
                   camera-roll-photos (rf/sub [:camera-roll/photos])
                   end-cursor         (rf/sub [:camera-roll/end-cursor])
@@ -134,7 +135,7 @@
               [:<>
                [rn/view
                 {:style style/buttons-container}
-                [album-title true selected-album selected temporary-selected]
+                [album-title true selected-album selected temporary-selected insets]
                 [clear-button selected]]
                [gesture/flat-list
                 {:key-fn                  identity
@@ -143,11 +144,11 @@
                  :data                    camera-roll-photos
                  :num-columns             3
                  :content-container-style {:width          "100%"
-                                           :padding-bottom (+ (:bottom bottom-inset) 100)
+                                           :padding-bottom (+ (:bottom insets) 100)
                                            :padding-top    64}
                  :on-scroll               on-scroll
                  :scroll-enabled          scroll-enabled
                  :on-end-reached          #(rf/dispatch [:camera-roll/on-end-reached end-cursor
                                                          selected-album loading?
                                                          has-next-page?])}]
-               [bottom-gradient selected-images bottom-inset selected]]))])))])
+               [bottom-gradient selected-images insets selected]]))])))])

--- a/src/status_im2/contexts/chat/photo_selector/view.cljs
+++ b/src/status_im2/contexts/chat/photo_selector/view.cljs
@@ -117,7 +117,6 @@
        (let [selected        (reagent/atom []) ; currently selected
              selected-images (rf/sub [:chats/sending-image]) ; already selected and dispatched
              selected-album  (or (rf/sub [:camera-roll/selected-album]) (i18n/label :t/recent))]
-         (println "insets" insets)
          (rn/use-effect
           (fn []
             (rf/dispatch [:chat.ui/camera-roll-get-photos 20 nil selected-album])


### PR DESCRIPTION
fixes: https://github.com/status-im/status-mobile/issues/15573 for branch `release/1.22.x`

#### Note for QA:
Regarding issue 2: the images should now be squared in the view mode. Depending on the image, that may still be incorrect dimensions for the image. The desktop app should be sending the image dimensions to render them accurately.