### PR TITLE
fix: remove contact from mutual contact list after contact is blocked

### DIFF
--- a/src/status_im/contact/block.cljs
+++ b/src/status_im/contact/block.cljs
@@ -61,8 +61,7 @@
                                    public-key)
                                   (assoc :blocked? true
                                          :added?   false
-                                         :active?  false
-                                         :mutual?  false))
+                                         :active?  false))
         from-one-to-one-chat? (not (get-in db [:chats (:current-chat-id db) :group-chat]))]
     (rf/merge cofx
               {:db (assoc-in db [:contacts/contacts public-key] contact)}

--- a/src/status_im/contact/block.cljs
+++ b/src/status_im/contact/block.cljs
@@ -60,7 +60,9 @@
                                    (:contacts/contacts db)
                                    public-key)
                                   (assoc :blocked? true
-                                         :added?   false))
+                                         :added?   false
+                                         :active?  false
+                                         :mutual?  false))
         from-one-to-one-chat? (not (get-in db [:chats (:current-chat-id db) :group-chat]))]
     (rf/merge cofx
               {:db (assoc-in db [:contacts/contacts public-key] contact)}

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.145.2",
-    "commit-sha1": "719af90fcc077f301f50349c034938701883031e",
-    "src-sha256": "1p93x7ph03aq95961j4098fy2p7a4ssymf4hf3kbl5ldmvdk403p"
+    "version": "v0.146.3",
+    "commit-sha1": "9dea0aaee3ce0ebb29c6898c771a383dfbd6bb52",
+    "src-sha256": "08hcl3bmy0f90b3drd2ny1gn0hs6rmbzdkv7drikvgpsnfanm8gw"
 }


### PR DESCRIPTION
fixes #15279

### Summary
This pr removes user A (the blocked contact)  from the contact list of user B once blocked and removes user B from user A list of contacts
