### PR TITLE
[Fix] Remove AC request to join notification on community request cancellation

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "fix/remove-ac-notification-for-cancel-request-to-join",
-    "commit-sha1": "f2f01857f2fe207a6fcac6f39f952bac51d13418",
-    "src-sha256": "0g78d6wfiv4s10qpg5h7r6n4irdpyzrlpwb9gn7zpyiwh640mwv2"
+    "version": "v0.143.0",
+    "commit-sha1": "39be3c081ce80178f0daa1f38c00aebb87c1a574",
+    "src-sha256": "0hdz740p0n6dk384cdqgpc7pv3a8fz558q20k4iji98bk9m5qjs1"
 }

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.142.4",
-    "commit-sha1": "142b170ec99498bbeb41d7f4ce5b7140db597e56",
-    "src-sha256": "038p3axqj4m2wczs3fg44535rn6y235hr23w9fjriaglp80p2z07"
+    "version": "fix/remove-ac-notification-for-cancel-request-to-join",
+    "commit-sha1": "f2f01857f2fe207a6fcac6f39f952bac51d13418",
+    "src-sha256": "0g78d6wfiv4s10qpg5h7r6n4irdpyzrlpwb9gn7zpyiwh640mwv2"
 }


### PR DESCRIPTION
fixes #15328


### Platforms

- Android
- iOS


### Steps to test

#### Preconditions: User `A`  is an admin of a closed community. User `A` and User `B` are mutual contacts.

- User `A` shares community with user `B`
- User `B` sends a "Request to join to the community" (now notification is shown for user `A` in AC)
- User `B` cancels the request
- User `A` checks notification in AC


status: ready
