### PR TITLE
fix status-bar font color

### DIFF
--- a/src/status_im/multiaccounts/login/core.cljs
+++ b/src/status_im/multiaccounts/login/core.cljs
@@ -365,9 +365,25 @@
   [_]
   (status/get-node-config #(re-frame/dispatch [::get-node-config-callback %])))
 
+(rf/defn redirect-to-root
+  "Decides which root should be initialised depending on user and app state"
+  [{:keys [db] :as cofx}]
+  (cond
+    (get db :onboarding-2/new-account?)
+    {:dispatch [:onboarding-2/finalize-setup]}
+
+    (get db :tos/accepted?)
+    (rf/merge
+     cofx
+     (multiaccounts/switch-theme nil :shell-stack)
+     (navigation/init-root :shell-stack))
+
+    :else
+    {:dispatch [:init-root :tos]}))
+
 (rf/defn get-settings-callback
   {:events [::get-settings-callback]}
-  [{:keys [db] :as cofx} settings]
+  [{:keys [db] :as cofx} settings pairing-in-progress?]
   (let [{:networks/keys [current-network networks]
          :as            settings}
         (data-store.settings/rpc->settings settings)
@@ -397,7 +413,9 @@
               (logging/set-log-level (:log-level multiaccount))
               (activity-center/notifications-fetch-pending-contact-requests)
               (activity-center/update-seen-state)
-              (activity-center/notifications-fetch-unread-count))))
+              (activity-center/notifications-fetch-unread-count)
+              (when-not pairing-in-progress?
+                (redirect-to-root)))))
 
 (re-frame/reg-fx
  ::open-last-chat
@@ -472,19 +490,6 @@
         keychain/auth-method-biometric
         keychain/auth-method-password))))
 
-(defn redirect-to-root
-  "Decides which root should be initialised depending on user and app state"
-  [db]
-  (cond
-    (get db :onboarding-2/new-account?)
-    (re-frame/dispatch [:onboarding-2/finalize-setup])
-
-    (get db :tos/accepted?)
-    (re-frame/dispatch [:init-root :shell-stack])
-
-    :else
-    (re-frame/dispatch [:init-root :tos])))
-
 (rf/defn login-only-events
   [{:keys [db] :as cofx} key-uid password save-password?]
   (let [auth-method          (:auth-method db)
@@ -497,9 +502,7 @@
               {:db (assoc db :chats/loading? true)
                :json-rpc/call
                [{:method     "settings_getSettings"
-                 :on-success #(do (re-frame/dispatch [::get-settings-callback %])
-                                  (when-not pairing-in-progress?
-                                    (redirect-to-root db)))}]}
+                 :on-success #(re-frame/dispatch [::get-settings-callback % pairing-in-progress?])}]}
               (notifications/load-notification-preferences)
               (when save-password?
                 (keychain/save-user-password key-uid password))

--- a/src/status_im2/navigation/options.cljs
+++ b/src/status_im2/navigation/options.cljs
@@ -7,19 +7,23 @@
   {:layout {:orientation :portrait}
    :topBar {:visible false}})
 
+;; Note: Currently, the status bar style provided while setting the root has a high preference,
+;; and even if we change the status bar style later dynamically, the style gets restored to this
+;; set root style while navigating
+;; https://github.com/status-im/status-mobile/pull/15596
 (defn statusbar-and-navbar-root
-  []
+  [& [status-bar-theme]]
   (if platform/android?
     {:navigationBar {:backgroundColor colors/neutral-100}
      :statusBar     {:translucent     true
                      :backgroundColor :transparent
-                     :style           :light
+                     :style           (or status-bar-theme :light)
                      :drawBehind      true}}
-    {:statusBar {:style :light}}))
+    {:statusBar {:style (or status-bar-theme :light)}}))
 
 (defn default-root
-  []
-  (merge (statusbar-and-navbar-root)
+  [& [status-bar-theme]]
+  (merge (statusbar-and-navbar-root status-bar-theme)
          {:topBar {:visible false}
           :layout {:componentBackgroundColor (colors/theme-colors colors/white colors/neutral-100)
                    :orientation              :portrait

--- a/src/status_im2/navigation/roots.cljs
+++ b/src/status_im2/navigation/roots.cljs
@@ -1,5 +1,6 @@
 (ns status-im2.navigation.roots
   (:require [status-im2.navigation.view :as views]
+            [quo2.foundations.colors :as colors]
             [status-im2.navigation.options :as options]
             [status-im2.constants :as constants]))
 
@@ -101,7 +102,8 @@
            {:stack {:id       :shell-stack
                     :children [{:component {:name    :shell-stack
                                             :id      :shell-stack
-                                            :options (options/default-root)}}]}}}
+                                            :options (options/default-root
+                                                      (if (colors/dark?) :light :dark))}}]}}}
           :profiles
           {:root
            {:stack {:id       :profiles


### PR DESCRIPTION
fixes: https://github.com/status-im/status-mobile/issues/15590

### Summary
- We are initializing root before processing settings data (which has the account theme)
- RNN Bug - We are also changing the status-bar-theme at runtime, but for some reason theme used at the time of root initialization has high priority and gets restored on navigation (going back from chat, etc.)
- Also we need to change app theme, before root

### Testing
- The issue should be fixed for both light and dark app themes, but as mentioned above, the theme needs to be provided at the time of root initialization. So if the theme changes after login, then the behavior will be the same, until the account relogin.
- PR also makes alters small modification made in https://github.com/status-im/status-mobile/pull/15574. So please check pairing is working as expected

status: ready