### PR TITLE
nix: bump nixpkgs to include fix for apksigner

### DIFF
--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -11,10 +11,11 @@ let
   # We follow the master branch of official nixpkgs.
   nixpkgsSrc = fetchFromGitHub {
     name = "nixpkgs-source";
-    owner = "status-im"; # FIXME: Fork used to get Cocoapods 1.12.0.
+    # FIXME: Fork used to get Cocoapods 1.12.0 and apksigner macOS build.
+    owner = "status-im";
     repo = "nixpkgs";
-    rev = "b9b2ed705edc00003d47625950602136be3e1ed5";
-    sha256 = "sha256-F0qOawdKx7kgiGqwVikYIawL2taJ1XfcgHy0Wn0mho8=";
+    rev = "d0c06fa3d3982a91aa01bd63ed84020cbde3d3ab";
+    sha256 = "sha256-8blvuUHnuf0hFr/PpBxVohJp5CaGXIXhgJlFN/cv7us=";
     # To get the compressed Nix sha256, use:
     # nix-prefetch-url --unpack https://github.com/${ORG}/nixpkgs/archive/${REV}.tar.gz
   };


### PR DESCRIPTION
Without this [fix](https://github.com/NixOS/nixpkgs/commit/472f3dfaa246e0c08e23afae1bc83b0c95ef96d7):

- https://github.com/NixOS/nixpkgs/commit/d0c06fa3 - apksigner: enable on unix platforms

The `apksigner` utility is unavailable on macOS:
```
error: Package ‘apksigner-33.0.1’ in .../pkgs/development/tools/apksigner/default.nix:86
is not supported on ‘x86_64-darwin’, refusing to evaluate.
```