### PR TITLE
Community request to join changes

### DIFF
--- a/src/status_im/multiaccounts/login/core.cljs
+++ b/src/status_im/multiaccounts/login/core.cljs
@@ -410,6 +410,7 @@
               (get-node-config)
               (communities/fetch)
               (communities/fetch-collapsed-community-categories)
+              (communities/check-and-delete-pending-request-to-join)
               (logging/set-log-level (:log-level multiaccount))
               (activity-center/notifications-fetch-pending-contact-requests)
               (activity-center/update-seen-state)

--- a/src/status_im/transport/message/core.cljs
+++ b/src/status_im/transport/message/core.cljs
@@ -124,10 +124,13 @@
                   (models.communities/handle-removed-chats removed-chats-clj)))
 
       (seq requests-to-join-community)
-      (let [request-js (types/js->clj (.pop requests-to-join-community))]
+      (let [requests (->> requests-to-join-community
+                          types/js->clj
+                          (map models.communities/<-request-to-join-community-rpc))]
+        (js-delete response-js "requestsToJoinCommunity")
         (rf/merge cofx
                   (process-next response-js sync-handler)
-                  (models.communities/handle-request-to-join request-js)))
+                  (models.communities/handle-requests-to-join requests)))
 
       (seq emoji-reactions)
       (let [reactions (types/js->clj emoji-reactions)]

--- a/src/status_im2/contexts/activity_center/notification/common/view.cljs
+++ b/src/status_im2/contexts/activity_center/notification/common/view.cljs
@@ -8,6 +8,13 @@
             [utils.i18n :as i18n]
             [utils.re-frame :as rf]))
 
+(def tag-params
+  {:size           :small
+   :override-theme :dark
+   :color          colors/primary-50
+   :style          style/user-avatar-tag
+   :text-style     style/user-avatar-tag-text})
+
 (defn user-avatar-tag
   [user-id]
   (let [contact (rf/sub [:contacts/contact-by-identity user-id])]

--- a/src/status_im2/contexts/activity_center/notification/community_request/view.cljs
+++ b/src/status_im2/contexts/activity_center/notification/community_request/view.cljs
@@ -1,0 +1,64 @@
+(ns status-im2.contexts.activity-center.notification.community-request.view
+  (:require [quo2.core :as quo]
+            [status-im2.constants :as constants]
+            [status-im2.contexts.activity-center.notification.common.style :as common-style]
+            [status-im2.contexts.activity-center.notification.common.view :as common]
+            [utils.datetime :as datetime]
+            [utils.i18n :as i18n]
+            [utils.re-frame :as rf]))
+
+(defn- swipeable
+  [{:keys [active-swipeable extra-fn]} child]
+  [common/swipeable
+   {:left-button      common/swipe-button-read-or-unread
+    :left-on-press    common/swipe-on-press-toggle-read
+    :right-button     common/swipe-button-delete
+    :right-on-press   common/swipe-on-press-delete
+    :active-swipeable active-swipeable
+    :extra-fn         extra-fn}
+   child])
+
+(defn- get-header-text-and-context
+  [community membership-status]
+  (let [community-name        (:name community)
+        community-image       (get-in community [:images :thumbnail :uri])
+        community-context-tag [quo/context-tag common/tag-params {:uri community-image}
+                               community-name]]
+    (cond
+      (= membership-status constants/activity-center-membership-status-idle)
+      {:header-text (i18n/label :t/community-request-not-accepted)
+       :context     [[quo/text {:style common-style/user-avatar-tag-text}
+                      (i18n/label :t/community-request-not-accepted-body-text-prefix)]
+                     community-context-tag
+                     [quo/text {:style common-style/user-avatar-tag-text}
+                      (i18n/label :t/community-request-not-accepted-body-text-suffix)]]}
+
+      (= membership-status constants/activity-center-membership-status-pending)
+      {:header-text (i18n/label :t/community-request-pending)
+       :context     [[quo/text {:style common-style/user-avatar-tag-text}
+                      (i18n/label :t/community-request-pending-body-text)]
+                     community-context-tag]}
+
+      (= membership-status constants/activity-center-membership-status-accepted)
+      {:header-text (i18n/label :t/community-request-accepted)
+       :context     [[quo/text {:style common-style/user-avatar-tag-text}
+                      (i18n/label :t/community-request-accepted-body-text)]
+                     community-context-tag]}
+
+      :else nil)))
+
+(defn view
+  [{:keys [notification set-swipeable-height] :as props}]
+  (let [{:keys [community-id membership-status read
+                timestamp]}           notification
+        community                     (rf/sub [:communities/community community-id])
+        {:keys [header-text context]} (get-header-text-and-context community
+                                                                   membership-status)]
+    [swipeable props
+     [quo/activity-log
+      {:title     header-text
+       :icon      :i/communities
+       :on-layout set-swipeable-height
+       :timestamp (datetime/timestamp->relative timestamp)
+       :unread?   (not read)
+       :context   context}]]))

--- a/src/status_im2/contexts/activity_center/notification_types.cljs
+++ b/src/status_im2/contexts/activity_center/notification_types.cljs
@@ -16,6 +16,7 @@
     mention
     reply
     contact-request
+    community-request
     admin
     contact-verification})
 

--- a/src/status_im2/contexts/activity_center/notification_types.cljs
+++ b/src/status_im2/contexts/activity_center/notification_types.cljs
@@ -6,6 +6,7 @@
 (def ^:const mention 3)
 (def ^:const reply 4)
 (def ^:const contact-request 5)
+(def ^:const community-request 7)
 (def ^:const admin 8)
 (def ^:const contact-verification 10)
 
@@ -26,4 +27,5 @@
   "Membership is like a logical group of notifications with different types, i.e.
   it doesn't have a corresponding type in the backend. Think of the collection
   as a composite key of actual types."
-  #{private-group-chat})
+  #{private-group-chat
+    community-request})

--- a/src/status_im2/contexts/activity_center/view.cljs
+++ b/src/status_im2/contexts/activity_center/view.cljs
@@ -12,6 +12,8 @@
             [status-im2.contexts.activity-center.notification.membership.view :as membership]
             [status-im2.contexts.activity-center.notification.mentions.view :as mentions]
             [status-im2.contexts.activity-center.notification.reply.view :as reply]
+            [status-im2.contexts.activity-center.notification.community-request.view :as
+             community-request]
             [status-im2.contexts.activity-center.style :as style]
             [utils.i18n :as i18n]
             [utils.re-frame :as rf]
@@ -196,7 +198,12 @@
            [admin/view props]
 
            (some types/membership [type])
-           [membership/view props]
+           (case type
+             types/private-group-chat [membership/view props]
+
+             types/community-request  [community-request/view props]
+
+             nil)
 
            :else
            nil)]))))

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.146.3",
-    "commit-sha1": "9dea0aaee3ce0ebb29c6898c771a383dfbd6bb52",
-    "src-sha256": "08hcl3bmy0f90b3drd2ny1gn0hs6rmbzdkv7drikvgpsnfanm8gw"
+    "version": "feature/community-request-to-join-changes",
+    "commit-sha1": "cdddfcb0f1d6d27b3d92d0d7200f2d35b8f2b0c9",
+    "src-sha256": "1262hgz9dvpn44pjq0xn5wvcr1ynl108ixjzkgmh81l1v8v71jv2"
 }

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -4,6 +4,6 @@
     "owner": "status-im",
     "repo": "status-go",
     "version": "feature/community-request-to-join-changes",
-    "commit-sha1": "abd782889620eeb6329343d310e9929881473b68",
-    "src-sha256": "1j8bh1gl46qxibzlwpvgdjx43yvh32m4cv99px0mmcljsrmad7pj"
+    "commit-sha1": "24a78adc84d6f910cd8bb27b3fdc46b4d4924f85",
+    "src-sha256": "12yb67v7z0q057bpkmm0ccaijqgi7rg7ywrlkk0yvq2kyfjg4hyq"
 }

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "feature/community-request-to-join-changes",
-    "commit-sha1": "eac23ec8f70fe5bcd9cb45b2416146b7a8d83e3c",
-    "src-sha256": "06481l12qi2352rg5x214kzrxw3s85g4g9bhiaaihsl76h7k22g3"
+    "version": "v0.146.4",
+    "commit-sha1": "e8ceed11125dfd470c0e0caac0755313fb85cba6",
+    "src-sha256": "1flwq5sfy1cfdl40fiip0q555rdcq5f5l2lpb4az8j5bwmwmi31x"
 }

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -4,6 +4,6 @@
     "owner": "status-im",
     "repo": "status-go",
     "version": "feature/community-request-to-join-changes",
-    "commit-sha1": "24a78adc84d6f910cd8bb27b3fdc46b4d4924f85",
-    "src-sha256": "12yb67v7z0q057bpkmm0ccaijqgi7rg7ywrlkk0yvq2kyfjg4hyq"
+    "commit-sha1": "eac23ec8f70fe5bcd9cb45b2416146b7a8d83e3c",
+    "src-sha256": "06481l12qi2352rg5x214kzrxw3s85g4g9bhiaaihsl76h7k22g3"
 }

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -4,6 +4,6 @@
     "owner": "status-im",
     "repo": "status-go",
     "version": "feature/community-request-to-join-changes",
-    "commit-sha1": "cdddfcb0f1d6d27b3d92d0d7200f2d35b8f2b0c9",
-    "src-sha256": "1262hgz9dvpn44pjq0xn5wvcr1ynl108ixjzkgmh81l1v8v71jv2"
+    "commit-sha1": "abd782889620eeb6329343d310e9929881473b68",
+    "src-sha256": "1j8bh1gl46qxibzlwpvgdjx43yvh32m4cv99px0mmcljsrmad7pj"
 }

--- a/translations/en.json
+++ b/translations/en.json
@@ -2071,5 +2071,12 @@
     "mute-for-8-hours": "For 8 hours",
     "mute-for-1-week": "For 7 days",
     "mute-till-unmute": "Until you turn it back on",
-    "mute-channel": "Mute channel"
+    "mute-channel": "Mute channel",
+    "community-request-accepted": "Request accepted",
+    "community-request-accepted-body-text": "Now you are a member of",
+    "community-request-not-accepted": "Request hasn't been accepted",
+    "community-request-not-accepted-body-text-prefix": "Your request to join",
+    "community-request-not-accepted-body-text-suffix": "hasn't been accepted",
+    "community-request-pending": "Request pending",
+    "community-request-pending-body-text": "You requested to join"
 }


### PR DESCRIPTION
fixes #15322 #15082 #15694

### Summary

This PR updates the behaviour of the request to join a community.

- If the request to join a community is ignored or unhandled by the Admin/Community Manager for more than seven (7) days, the request is removed for both Admin and Requester
- The community "Join request" notification from Admin/Community Manager's Activity Center is deleted after seven (7) days if the request is unhandled
- If the request is declined by the Admin/Community Manager, The Sender/Requester would be able to request again after seven (7) days from the original request time

Status-go PR: https://github.com/status-im/status-go/pull/3387

### Testing notes

⚠️ For testing, the expiry/timeout period is set to **5 minutes** instead of **7 days**.

### Platforms

- Android
- iOS

### Steps to test

#### Preconditions: User `A` and User `B` are mutual contacts. User `A`  is an admin of a closed community. 

#### Scenario 1: Unhandled request for 7 days

- User `A` shares community with user `B`
- User `B` sends a "Request to join the community" 
- User `B` AC gets updated with a notification that he/she requested to join the community 
- User `A` receives a "Join Request" notification in AC and leaves the request unattended for 7 days 
- User `A` checks the "Join Request" notification in AC and it's removed (after 7 days)
- User `B` opens the AC and sees that the "request hasn't been accepted"

#### Scenario 2: Request declined

- User `A` shares community with user `B`
- User `B` sends a "Request to join the community"
- User `B` AC gets updated with a notification that he/she requested to join the community 
- User `A` receives a "Join Request" notification in AC
- User `A` declines the request
- User `B` opens the AC (after 7 days from request time) and sees that the "request hasn't been accepted"

#### Scenario 3: Admin opens the app after request timeout (7 days)

- User `A` shares community with user `B`
- User `B` sends a "Request to join the community" 
- User `B` AC gets updated with a notification that he/she requested to join the community 
- User `A` opens the app after the request timeout (7 days)*
- User `A` should not receive the "Join Request" notification in AC 
- User `B` opens the AC and sees that the "request hasn't been accepted"

*User `A` (admin) is not available/hasn't opened the app during the request validity period.

#### Scenario 4: Request again 7 days

##### Follow the steps of Scenario 1 or Scenario 2 or Scenario 3

- User `B` can send a "Request to join the community" after 7 days from the last request time
- User `B` AC gets an updated notification that he/she requested to join the community**
- User `A` receives a "Join Request" notification in AC**

**Replacing the old notification with an updated timestamp

### Known Issue

If the notification is unread, the unread dot overlaps with the timestamp.

![Issue copy](https://user-images.githubusercontent.com/19339952/232018421-73327e0b-b8f9-4289-8bf7-7692aedddc00.png)

In [Figma](https://www.figma.com/file/eDfxTa9IoaCMUy5cLTp0ys/Shell-for-Mobile?node-id=4537%3A515620&t=KbCqCLW3kNt9LXy0-1), The timestamp is missing in this notification, and this needs to be discussed with the design team (@xAlisher) as the title can be a short one just as like other notifications.


status: ready
