### PR TITLE
Change view-id as per the selected bottom tab and refactor subscriptions

### DIFF
--- a/src/status_im/search/core.cljs
+++ b/src/status_im/search/core.cljs
@@ -1,11 +1,6 @@
 (ns status-im.search.core
   (:require [utils.re-frame :as rf]))
 
-(rf/defn home-filter-changed
-  {:events [:search/home-filter-changed]}
-  [cofx search-filter]
-  {:db (assoc-in (:db cofx) [:ui/search :home-filter] search-filter)})
-
 (rf/defn currency-filter-changed
   {:events [:search/currency-filter-changed]}
   [cofx search-filter]

--- a/src/status_im2/contexts/chat/home/chat_list_item/view.cljs
+++ b/src/status_im2/contexts/chat/home/chat_list_item/view.cljs
@@ -14,8 +14,7 @@
   [chat-id]
   (fn []
     (rf/dispatch [:dismiss-keyboard])
-    (rf/dispatch [:chat/navigate-to-chat chat-id])
-    (rf/dispatch [:search/home-filter-changed nil])))
+    (rf/dispatch [:chat/navigate-to-chat chat-id])))
 
 (defn truncate-literal
   [literal]

--- a/src/status_im2/contexts/chat/home/view.cljs
+++ b/src/status_im2/contexts/chat/home/view.cljs
@@ -37,10 +37,9 @@
 
 (defn chats
   [selected-tab top]
-  (let [{:keys [items search-filter]} (rf/sub [:home-items])
-        items                         (filter-items-by-tab selected-tab items)]
-    (if (and (empty? items)
-             (empty? search-filter))
+  (let [unfiltered-items (rf/sub [:chats-stack-items])
+        items            (filter-items-by-tab selected-tab unfiltered-items)]
+    (if (empty? items)
       [welcome-blank-chats]
       [rn/flat-list
        {:key-fn                            #(or (:chat-id %) (:public-key %) (:id %))

--- a/src/status_im2/contexts/communities/overview/view.cljs
+++ b/src/status_im2/contexts/communities/overview/view.cljs
@@ -186,8 +186,7 @@
      (when (and (not locked?) id)
        {:on-press (fn []
                     (rf/dispatch [:dismiss-keyboard])
-                    (rf/dispatch [:chat/navigate-to-chat (str community-id id)])
-                    (rf/dispatch [:search/home-filter-changed nil]))}))))
+                    (rf/dispatch [:chat/navigate-to-chat (str community-id id)]))}))))
 
 (defn add-on-press-handler-to-chats
   [community-id chats]

--- a/src/status_im2/contexts/shell/animation.cljs
+++ b/src/status_im2/contexts/shell/animation.cljs
@@ -51,6 +51,7 @@
                                    (calculate-home-stack-state-value stack-id))]
     (reset! selected-stack-id stack-id)
     (reset! home-stack-state home-stack-state-value)
+    (rf/dispatch [:set-view-id (or stack-id :shell)])
     (when store?
       (async-storage/set-item! :selected-stack-id stack-id))))
 

--- a/src/status_im2/navigation/core.cljs
+++ b/src/status_im2/navigation/core.cljs
@@ -4,6 +4,7 @@
             [react-native.gesture :as gesture]
             [react-native.navigation :as navigation]
             [status-im.multiaccounts.login.core :as login-core]
+            [status-im2.contexts.shell.animation :as shell.animation]
             [status-im2.navigation.roots :as roots]
             [status-im2.navigation.state :as state]
             [status-im2.navigation.view :as views]
@@ -35,8 +36,11 @@
 (defn set-view-id
   [view-id]
   (when-let [{:keys [on-focus]} (get views/screens view-id)]
-    (re-frame/dispatch [:set-view-id view-id])
     (re-frame/dispatch [:screens/on-will-focus view-id])
+    (re-frame/dispatch [:set-view-id
+                        (if (= view-id :shell-stack)
+                          (or @shell.animation/selected-stack-id :shell)
+                          view-id)])
     (when on-focus
       (re-frame/dispatch on-focus))))
 

--- a/src/status_im2/subs/general.cljs
+++ b/src/status_im2/subs/general.cljs
@@ -146,12 +146,6 @@
    (get-in animations [type item-id :delete-swiped])))
 
 (re-frame/reg-sub
- :search/home-filter
- :<- [:ui/search]
- (fn [search]
-   (get search :home-filter)))
-
-(re-frame/reg-sub
  :search/recipient-filter
  :<- [:ui/search]
  (fn [search]

--- a/src/status_im2/subs/home.cljs
+++ b/src/status_im2/subs/home.cljs
@@ -1,38 +1,20 @@
 (ns status-im2.subs.home
   (:require [re-frame.core :as re-frame]))
 
-(def memo-home-items (atom nil))
+(def memo-chats-stack-items (atom nil))
 
 (re-frame/reg-sub
- :home-items
- :<- [:search/home-filter]
- :<- [:search/filtered-chats]
- :<- [:communities/communities]
+ :chats-stack-items
+ :<- [:chats/home-list-chats]
  :<- [:view-id]
  :<- [:home-items-show-number]
- (fn [[search-filter filtered-chats communities view-id home-items-show-number]]
-   (if (= view-id :shell-stack)
-     (let [communities-count          (count communities)
-           chats-count                (count filtered-chats)
-           ;; If we have both communities & chats we want to display
-           ;; a separator between them
-
-           communities-with-separator (if (and (pos? communities-count)
-                                               (pos? chats-count))
-                                        (update communities
-                                                (dec communities-count)
-                                                assoc
-                                                :last?
-                                                true)
-                                        communities)
-           res                        {:search-filter search-filter
-                                       :items         (concat communities-with-separator
-                                                              (take home-items-show-number
-                                                                    filtered-chats))}]
-       (reset! memo-home-items res)
+ (fn [[chats view-id home-items-show-number]]
+   (if (= view-id :chats-stack)
+     (let [res (take home-items-show-number chats)]
+       (reset! memo-chats-stack-items res)
        res)
      ;;we want to keep data unchanged so react doesn't change component when we leave screen
-     @memo-home-items)))
+     @memo-chats-stack-items)))
 
 (re-frame/reg-sub
  :hide-home-tooltip?

--- a/src/status_im2/subs/search.cljs
+++ b/src/status_im2/subs/search.cljs
@@ -1,7 +1,6 @@
 (ns status-im2.subs.search
   (:require [clojure.string :as string])
   (:require [clojure.string :as string]
-            [status-im.utils.gfycat.core :as gfycat]
             [re-frame.core :as re-frame]
             [status-im.utils.currency :as currency]))
 
@@ -35,41 +34,6 @@
     (if sort?
       (sort-by-timestamp results)
       results)))
-
-(defn filter-chat
-  [contacts search-filter {:keys [group-chat alias name chat-id]}]
-  (let [alias    (if-not group-chat
-                   (string/lower-case (or alias
-                                          (get-in contacts [chat-id :alias])
-                                          (gfycat/generate-gfy chat-id)))
-                   "")
-        nickname (get-in contacts [chat-id :nickname])]
-    (or
-     (string/includes? (string/lower-case (str name)) search-filter)
-     (string/includes? (string/lower-case alias) search-filter)
-     (when nickname
-       (string/includes? (string/lower-case nickname) search-filter))
-     (and
-      (get-in contacts [chat-id :ens-verified])
-      (string/includes? (string/lower-case
-                         (str (get-in contacts [chat-id :name])))
-                        search-filter)))))
-
-(re-frame/reg-sub
- :search/filtered-chats
- :<- [:chats/home-list-chats]
- :<- [:contacts/contacts]
- :<- [:search/home-filter]
- (fn [[chats contacts search-filter]]
-   ;; Short-circuit if search-filter is empty
-   (let [filtered-chats (if (seq search-filter)
-                          (filter
-                           (partial filter-chat
-                                    contacts
-                                    (string/lower-case search-filter))
-                           chats)
-                          chats)]
-     (sort-by :timestamp > filtered-chats))))
 
 (defn extract-currency-attributes
   [currency]

--- a/src/status_im2/subs/shell.cljs
+++ b/src/status_im2/subs/shell.cljs
@@ -103,11 +103,18 @@
                  #(re-frame/dispatch [:chat/navigate-to-chat channel-id])
                  100))}))
 
+(def memo-shell-cards (atom nil))
+
 (re-frame/reg-sub
  :shell/sorted-switcher-cards
  :<- [:shell/switcher-cards]
- (fn [stacks]
-   (sort-by :clock > (map val stacks))))
+ :<- [:view-id]
+ (fn [[stacks view-id]]
+   (if (= view-id :shell)
+     (let [sorted-shell-cards (sort-by :clock > (map val stacks))]
+       (reset! memo-shell-cards sorted-shell-cards)
+       sorted-shell-cards)
+     @memo-shell-cards)))
 
 (re-frame/reg-sub
  :shell/shell-pass-through?


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/15609

### Summary
- view-id will be changed as per selected bottom tabs
 (used to make sure react doesn't change the chats list component when other tabs are selected)
- Removes some unnecessary subscription wrappers, which are not used anymore

### Testing
Please check communities & chats home list items for any regressions.
Note: When the user will be on another tab then the chats-tab, and receive any new message, it will only be updated once he/she navigates back to the chats-tab.