### PR TITLE
Allow running debug iOS builds on physical device via CLI and Enable Automatic code signing for Debug builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -282,6 +282,17 @@ else
 	npx react-native run-ios
 endif
 
+show-ios-devices: export TARGET := ios
+show-ios-devices: ##@other shows connected ios device and its name
+	xcrun xctrace list devices
+
+run-ios-device: export TARGET := ios
+run-ios-device: ##@run iOS app and start it on a connected device by its name
+ifndef DEVICE_NAME
+	$(error Usage: make run-ios-device DEVICE_NAME=your-device-name)
+endif
+	react-native run-ios --device "$(DEVICE_NAME)"
+
 #--------------
 # Tests
 #--------------

--- a/ios/StatusIm.xcodeproj/project.pbxproj
+++ b/ios/StatusIm.xcodeproj/project.pbxproj
@@ -417,9 +417,7 @@
 						TestTargetID = 13B07F861A680F5B00A75B9A;
 					};
 					13B07F861A680F5B00A75B9A = {
-						DevelopmentTeam = 8B5X2M6H2Y;
 						LastSwiftMigration = 1140;
-						ProvisioningStyle = Manual;
 						SystemCapabilities = {
 							com.apple.BackgroundModes = {
 								enabled = 1;
@@ -843,9 +841,8 @@
 				BUNDLE_ID_SUFFIX = .debug;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = StatusIm/StatusIm.entitlements;
-				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				CUSTOM_PRODUCT_NAME = "Status Debug";
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = 8B5X2M6H2Y;
@@ -899,8 +896,7 @@
 				PRESERVE_DEAD_CODE_INITS_AND_TERMS = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = im.status.ethereum;
 				PRODUCT_NAME = StatusIm;
-				PROVISIONING_PROFILE = "9da75626-9594-43d9-a827-0f6d43c28f54";
-				PROVISIONING_PROFILE_SPECIFIER = "match Development im.status.ethereum";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "StatusIm-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;


### PR DESCRIPTION
This PR does the following :
- Adds a command in makefile to show connected ios devices via `make show-ios-devices`
- Developers can then copy their connected iPhone's Device Name and use it to deploy debug builds
on the device by `run-ios-device DEVICE_NAME="their-device-name"`
- Enables automatic code signing ( only for Debug scheme this time :) )

status : ready