### PR TITLE
Test Steps to reduce PR Android APK size

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -32,7 +32,10 @@
             android:theme="@style/Theme.AppSplash"
             android:name=".MainApplication"
             android:largeHeap="true"
-            android:usesCleartextTraffic="true">
+            android:usesCleartextTraffic="true"
+            android:extractNativeLibs="true">
+<!--        After upgrading Android Gradle Plugin to 4.2.0 and above we must get rid of `extractNativeLibs="true"`
+            and use`useLegacyPackaging` flag in our app's `build.gradle`-->
         <meta-data android:name="commitHash" android:value="${commitHash}"/>
         <activity
                 android:name=".MainActivity"


### PR DESCRIPTION
This PR adds steps to reduce the APK size which has almost doubled after the recent react-native upgrade https://github.com/status-im/status-mobile/pull/15486.
Android APK sizes before the react-native upgrade were below 100mb and now they are 211MB.

by adding `extractNativeLibs="true"` in `AndroidManifest.xml` we are instructing the app to compress native libs and extract them after installing the APK on device.

With this change the Android APK size dropped to 103MB.

A side effect of this may be that the app may now take more space on the device.

ref : https://developer.android.com/guide/topics/manifest/application-element#extractNativeLibs

After upgrading Android Gradle Plugin to 4.2.0 and above we must use `useLegacyPackaging` in our app's `build.gradle`
and get rid of `extractNativeLibs="true"` from `AndroidManifest.xml`

status : ready
