### PR TITLE
[#15518]Show disclaimer during password creation

### DIFF
--- a/src/status_im2/contexts/onboarding/create_password/view.cljs
+++ b/src/status_im2/contexts/onboarding/create_password/view.cljs
@@ -65,7 +65,7 @@
                         :shown  true}
        :placeholder    (i18n/label :t/password-creation-placeholder-1)
        :on-change-text on-change-password
-       :on-focus       #(on-input-focus :password)}]
+       :on-focus       on-input-focus}]
      [rn/view {:style style/space-between-inputs}]
      [password-with-hint
       {:hint           {:text   hint-2-text
@@ -75,7 +75,7 @@
        :error?         error?
        :placeholder    (i18n/label :t/password-creation-placeholder-2)
        :on-change-text on-change-repeat-password
-       :on-focus       #(on-input-focus :repeat-password)
+       :on-focus       on-input-focus
        :on-blur        on-blur-repeat-password}]]))
 
 (def strength-status
@@ -146,9 +146,9 @@
             :passwords-match?          same-passwords?
             :empty-password?           empty-password?
             :show-password-validation? @show-password-validation?
-            :on-input-focus            (fn [input-id]
+            :on-input-focus            (fn []
                                          (scroll-to-end-fn)
-                                         (reset! focused-input input-id))
+                                         (reset! focused-input :password))
             :on-change-password        (fn [new-value]
                                          (reset! password new-value)
                                          (when (same-password-length?)
@@ -162,18 +162,16 @@
                                           (reset! show-password-validation? true))}]]
 
          [rn/view {:style style/bottom-part}
+          [rn/view {:style style/disclaimer-container}
+           [quo/disclaimer
+            {:on-change #(reset! accepts-disclaimer? %)
+             :checked?  @accepts-disclaimer?}
+            (i18n/label :t/password-creation-disclaimer)]]
+
           (when (= @focused-input :password)
             [help
              {:validations       validations
               :password-strength password-strength}])
-
-          (when (= @focused-input :repeat-password)
-            [rn/view {:style style/disclaimer-container}
-             [quo/disclaimer
-              {:blur?     true
-               :checked?  @accepts-disclaimer?
-               :on-change #(reset! accepts-disclaimer? %)}
-              (i18n/label :t/password-creation-disclaimer)]])
 
           [rn/view {:style style/button-container}
            [quo/button


### PR DESCRIPTION
fixes #15518

### Summary

Modified the passwrod creation screen to show the  disclaimer on the screen always from the beginning / always when both password fields are filled.


https://user-images.githubusercontent.com/73246484/231986107-b9cf102d-4df3-4534-94a8-50c64a233d61.mp4



### Review notes
- In the code, you can notice that the I moved the disclaimer part above the password validation, I moved it because I wanted to display the disclaimer above the validation text when the password was focused.
- Also another bug to be noted (apart from the current issue), from the above video you can see that the topbar is being overlapped by the status bar by a little bit. I can include that fix in this PR if its okay.


#### Platforms
- Android
- iOS

#### Areas that maybe impacted
Onboarding

### Steps to test

- Open Status in a Fresh install
- Press I'm new to status -> Generate keys -> Continue
- When the page is open, we can see the disclaimer immediately in the bottom and it will remain there through out the process.


status: ready
