### PR TITLE
Create search-input component

### DIFF
--- a/src/quo2/components/inputs/search_input/style.cljs
+++ b/src/quo2/components/inputs/search_input/style.cljs
@@ -8,13 +8,13 @@
     (and blur? (= state :active))
     (colors/theme-colors colors/neutral-80-opa-20 colors/white-opa-20 override-theme)
 
-    blur? ;; state is default
+    blur? ; state is default
     (colors/theme-colors colors/neutral-80-opa-40 colors/white-opa-30 override-theme)
 
     (= state :active)
     (colors/theme-colors colors/neutral-30 colors/neutral-60 override-theme)
 
-    :else ;; Not blur and state is default
+    :else ; Not blur and state is default
     (colors/theme-colors colors/neutral-40 colors/neutral-50 override-theme)))
 
 (def clear-icon-container

--- a/src/quo2/components/inputs/search_input/style.cljs
+++ b/src/quo2/components/inputs/search_input/style.cljs
@@ -1,0 +1,68 @@
+(ns quo2.components.inputs.search-input.style
+  (:require [quo2.components.markdown.text :as text]
+            [quo2.foundations.colors :as colors]))
+
+(defn placeholder-color
+  [state blur? override-theme]
+  (cond
+    (and blur? (= state :active))
+    (colors/theme-colors colors/neutral-80-opa-20 colors/white-opa-20 override-theme)
+
+    blur? ;; state is default
+    (colors/theme-colors colors/neutral-80-opa-40 colors/white-opa-30 override-theme)
+
+    (= state :active)
+    (colors/theme-colors colors/neutral-30 colors/neutral-60 override-theme)
+
+    :else ;; Not blur and state is default
+    (colors/theme-colors colors/neutral-40 colors/neutral-50 override-theme)))
+
+(def clear-icon-container
+  {:justify-content :center
+   :align-items     :center
+   :margin-left     8
+   :height          20
+   :width           20})
+
+(defn clear-icon
+  [blur? override-theme]
+  (if blur?
+    (colors/theme-colors colors/neutral-80-opa-30 colors/white-opa-10 override-theme)
+    (colors/theme-colors colors/neutral-40 colors/neutral-50 override-theme)))
+
+(defn cursor
+  [customization-color override-theme]
+  (colors/theme-colors (colors/custom-color customization-color 50)
+                       (colors/custom-color customization-color 60)
+                       override-theme))
+
+(def tag-separator {:width 8})
+
+(def tag-container
+  {:flex-direction :row
+   :margin-right   8})
+
+(def container
+  {:flex           1
+   :flex-direction :row
+   :align-items    :center})
+
+(def scroll-container
+  {:flex-direction :row
+   :flex           1
+   :height         32})
+
+(def scroll-content
+  {:flex-grow       1
+   :align-items     :center
+   :justify-content :flex-start})
+
+(defn input-text
+  [disabled?]
+  (assoc (text/text-style {:size   :paragraph-1
+                           :weight :regular})
+         :flex             1
+         :padding-vertical 5
+         :min-width        120
+         :opacity          (if disabled? 0.3 1)
+         :min-height       32))

--- a/src/quo2/components/inputs/search_input/view.cljs
+++ b/src/quo2/components/inputs/search_input/view.cljs
@@ -23,7 +23,7 @@
      :size  20}]])
 
 (defn handle-backspace
-  [^js/Object event scroll-view-ref]
+  [event ^js/Object scroll-view-ref]
   (when (= (oops/oget event "nativeEvent.key") "Backspace")
     (.scrollToEnd scroll-view-ref #js {:animated false})))
 

--- a/src/quo2/components/inputs/search_input/view.cljs
+++ b/src/quo2/components/inputs/search_input/view.cljs
@@ -22,9 +22,10 @@
     {:color (style/clear-icon blur? override-theme)
      :size  20}]])
 
-(defn handle-backspace
+(defn- handle-backspace
   [event ^js/Object scroll-view-ref]
-  (when (= (oops/oget event "nativeEvent.key") "Backspace")
+  (when (and (= (oops/oget event "nativeEvent.key") "Backspace")
+             scroll-view-ref)
     (.scrollToEnd scroll-view-ref #js {:animated false})))
 
 (def ^:private props-to-remove

--- a/src/quo2/components/inputs/search_input/view.cljs
+++ b/src/quo2/components/inputs/search_input/view.cljs
@@ -1,0 +1,88 @@
+(ns quo2.components.inputs.search-input.view
+  (:require [oops.core :as oops]
+            [quo2.components.icon :as icon]
+            [quo2.components.inputs.search-input.style :as style]
+            [react-native.core :as rn]
+            [reagent.core :as reagent]))
+
+(def ^:private tag-separator [rn/view {:style style/tag-separator}])
+
+(defn- inner-tags
+  [tags-coll]
+  (into [rn/view {:style style/tag-container}]
+        (interpose tag-separator)
+        tags-coll))
+
+(defn- clear-button
+  [{:keys [on-press blur? override-theme]}]
+  [rn/touchable-opacity
+   {:style    style/clear-icon-container
+    :on-press on-press}
+   [icon/icon :i/clear
+    {:color (style/clear-icon blur? override-theme)
+     :size  20}]])
+
+(defn handle-backspace
+  [^js/Object event scroll-view-ref]
+  (when (= (oops/oget event "nativeEvent.key") "Backspace")
+    (.scrollToEnd scroll-view-ref #js {:animated false})))
+
+(def ^:private props-to-remove
+  [:cursor-color :placeholder-text-color :editable :on-change-text :on-focus
+   :on-blur :on-clear :value :tags :disabled? :blur? :customization-color :override-theme])
+
+(defn- add-children
+  [text-input children]
+  (if (seq children)
+    (into text-input children)
+    text-input))
+
+(defn search-input
+  [{:keys [value]}]
+  (let [state           (reagent/atom :default)
+        set-active      #(reset! state :active)
+        set-default     #(reset! state :default)
+        scroll-view-ref (atom nil)
+        use-value?      (boolean value)]
+    (fn [{:keys [value tags disabled? blur? on-change-text customization-color
+                 on-clear on-focus on-blur override-theme]
+          :or   {customization-color :blue}
+          :as   props}
+         & children]
+      (let [clean-props (apply dissoc props props-to-remove)]
+        [rn/view {:style style/container}
+         [rn/scroll-view
+          {:ref                               #(reset! scroll-view-ref %)
+           :style                             style/scroll-container
+           :content-container-style           style/scroll-content
+           :horizontal                        true
+           :shows-horizontal-scroll-indicator false}
+          (when (seq tags)
+            [inner-tags tags])
+
+          (add-children
+           [rn/text-input
+            (cond-> {:style                  (style/input-text disabled?)
+                     :cursor-color           (style/cursor customization-color override-theme)
+                     :placeholder-text-color (style/placeholder-color @state blur? override-theme)
+                     :editable               (not disabled?)
+                     :on-key-press           #(handle-backspace % @scroll-view-ref)
+                     :on-change-text         (fn [new-text]
+                                               (when on-change-text
+                                                 (on-change-text new-text))
+                                               (reagent/flush))
+                     :on-focus               (fn []
+                                               (set-active)
+                                               (when on-focus (on-focus)))
+                     :on-blur                (fn []
+                                               (set-default)
+                                               (when on-blur (on-blur)))}
+              use-value?        (assoc :value value)
+              (seq clean-props) (merge clean-props))]
+           (when-not use-value? children))]
+
+         (when (or (seq value) (seq children))
+           [clear-button
+            {:on-press       on-clear
+             :blur?          blur?
+             :override-theme override-theme}])]))))

--- a/src/quo2/core.cljs
+++ b/src/quo2/core.cljs
@@ -32,6 +32,7 @@
     quo2.components.info.information-box
     quo2.components.inputs.input.view
     quo2.components.inputs.profile-input.view
+    quo2.components.inputs.search-input.view
     quo2.components.inputs.title-input.view
     quo2.components.links.url-preview-list.view
     quo2.components.links.url-preview.view
@@ -149,6 +150,7 @@
 
 ;;;; INPUTS
 (def input quo2.components.inputs.input.view/input)
+(def search-input quo2.components.inputs.search-input.view/search-input)
 (def profile-input quo2.components.inputs.profile-input.view/profile-input)
 (def title-input quo2.components.inputs.title-input.view/title-input)
 

--- a/src/status_im2/contexts/quo_preview/inputs/search_input.cljs
+++ b/src/status_im2/contexts/quo_preview/inputs/search_input.cljs
@@ -1,0 +1,74 @@
+(ns status-im2.contexts.quo-preview.inputs.search-input
+  (:require [quo2.core :as quo]
+            [quo2.foundations.colors :as colors]
+            [react-native.core :as rn]
+            [reagent.core :as reagent]
+            [status-im2.common.resources :as resources]
+            [status-im2.contexts.quo-preview.preview :as preview]))
+
+(def descriptor
+  [{:label "Value"
+    :key   :value
+    :type  :text}
+   {:label "Blur"
+    :key   :blur?
+    :type  :boolean}
+   {:label "Disabled"
+    :key   :disabled?
+    :type  :boolean}
+   {:label   "Number of Tags"
+    :key     :number-tags
+    :type    :select
+    :options (map (fn [n]
+                    {:key n :value (str n)})
+                  (range 0 5))}])
+
+(defn example-tags
+  [blur?]
+  [[quo/context-tag {:blur? [blur?]}
+    (resources/get-mock-image :user-picture-male5)
+    "alisher.eth"]
+   [quo/context-tag {:blur? [blur?]}
+    (resources/get-mock-image :user-picture-male4)
+    "Pedro"]
+   [quo/context-tag {:blur? [blur?]}
+    (resources/get-mock-image :user-picture-female2)
+    "Freya Odinson"]])
+
+(defn cool-preview
+  []
+  (let [state          (reagent/atom {:blur?       false
+                                      :disabled?   false
+                                      :number-tags 0
+                                      :placeholder "Search..."
+                                      :value       ""
+                                      :on-clear    #(js/alert "Clear pressed")})
+        on-change-text (fn [new-text]
+                         (swap! state assoc :value new-text))]
+    (fn []
+      (let [tags (take (:number-tags @state) (example-tags (:blur? @state)))]
+        [rn/touchable-without-feedback {:on-press rn/dismiss-keyboard!}
+         [rn/view {:style {:padding-bottom 150}}
+          [rn/view {:style {:flex 1}}
+           [preview/customizer state descriptor]]
+          [preview/blur-view
+           {:style                 {:align-items     :center
+                                    :margin-vertical 20
+                                    :width           "100%"}
+            :show-blur-background? (:blur? @state)}
+           [rn/view {:style {:width "100%"}}
+            [quo/search-input
+             (assoc @state
+                    :tags           tags
+                    :on-change-text on-change-text)]]]]]))))
+
+(defn preview-search-input
+  []
+  [rn/view
+   {:style {:background-color (colors/theme-colors colors/white colors/neutral-95)
+            :flex             1}}
+   [rn/flat-list
+    {:style                     {:flex 1}
+     :keyboardShouldPersistTaps :always
+     :header                    [cool-preview]
+     :key-fn                    str}]])

--- a/src/status_im2/contexts/quo_preview/main.cljs
+++ b/src/status_im2/contexts/quo_preview/main.cljs
@@ -81,6 +81,8 @@
     [status-im2.contexts.quo-preview.tags.tags :as tags]
     [status-im2.contexts.quo-preview.tags.token-tag :as token-tag]
     [status-im2.contexts.quo-preview.title.title :as title]
+    [status-im2.contexts.quo-preview.inputs.input :as input]
+    [status-im2.contexts.quo-preview.inputs.search-input :as search-input]
     [status-im2.contexts.quo-preview.wallet.lowest-price :as lowest-price]
     [status-im2.contexts.quo-preview.wallet.network-amount :as network-amount]
     [status-im2.contexts.quo-preview.wallet.network-breakdown :as network-breakdown]
@@ -180,6 +182,9 @@
                            {:name      :profile-input
                             :insets    {:top false}
                             :component profile-input/preview-profile-input}
+                           {:name      :search-input
+                            :insets    {:top false}
+                            :component search-input/preview-search-input}
                            {:name      :title-input
                             :insets    {:top false}
                             :component title-input/preview-title-input}]

--- a/src/status_im2/contexts/quo_preview/main.cljs
+++ b/src/status_im2/contexts/quo_preview/main.cljs
@@ -81,7 +81,6 @@
     [status-im2.contexts.quo-preview.tags.tags :as tags]
     [status-im2.contexts.quo-preview.tags.token-tag :as token-tag]
     [status-im2.contexts.quo-preview.title.title :as title]
-    [status-im2.contexts.quo-preview.inputs.input :as input]
     [status-im2.contexts.quo-preview.inputs.search-input :as search-input]
     [status-im2.contexts.quo-preview.wallet.lowest-price :as lowest-price]
     [status-im2.contexts.quo-preview.wallet.network-amount :as network-amount]


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes #15480

### Summary

[comment]: # (Summarise the problem and how the pull request solves it)

This PR implements the new [search input component](https://www.figma.com/file/WQZcp6S0EnzxdTL4taoKDv/Design-System-for-Mobile?node-id=12375-140491&t=Oc5zEPMoABpApwJ2-4)

This component was intended to be used in the recovery seed phrase onboarding screen, but designs have changed and now the component is different (the related issue is https://github.com/status-im/status-mobile/issues/15663), so this PR only adds the component and uses it in its preview screen.

![image](https://user-images.githubusercontent.com/90291778/232146658-d60f4e5e-d8a7-4cdb-bcfa-4f0ae5588a95.png)
![image](https://user-images.githubusercontent.com/90291778/232146707-fdb1371d-d8f7-4350-a6f1-da9d55c95d74.png)
![image](https://user-images.githubusercontent.com/90291778/232151089-25d01662-78e8-4c69-904e-d31147423e08.png)
![image](https://user-images.githubusercontent.com/90291778/232151163-8f2d5f02-b197-42ad-9c09-3c9a5c116297.png)




### Review notes
The clear icon is not displayed correctly yet.

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open Status
-Navigate to Quo2 preview -> inputs -> seach input
- Test it

status: ready
