### PR TITLE
[WIP] Add `Xcode` env to explicitly use the `node` version specified by `nix` 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,3 +183,6 @@ test/appium/tests/users.py
 
 ## component-tests
 *.log
+
+## local xcode env introduced in react-native 0.69
+.xcode.env.local

--- a/ios/.xcode.env
+++ b/ios/.xcode.env
@@ -1,0 +1,12 @@
+# This `.xcode.env` file is versioned and is used to source the environment
+# used when running script phases inside Xcode.
+# To customize your local environment, you can create an `.xcode.env.local`
+# file that is not versioned.
+
+# NODE_BINARY variable contains the PATH to the node executable.
+#
+# Customize the NODE_BINARY variable here.
+# For example, to use nvm with brew, add the following line
+# . "$(brew --prefix nvm)/nvm.sh" --no-use
+export NODE_BINARY="${NODE_BINARY:-node}"
+export NODE_ARGS="${NODE_ARGS:- --max-old-space-size=16384 }"

--- a/nix/scripts/node_modules.sh
+++ b/nix/scripts/node_modules.sh
@@ -76,7 +76,7 @@ nodeModulesUnchanged() {
 
   # Sentinel file holds location of the node_modules source in Nix store
   currentNixSrc="$(cat "${sentinelFile}")"
-  
+
   if [ "${currentNixSrc}" != "${src}" ]; then
     echo -e "${YLW}Yarn modules changed, copying new version over${RST}" >&2
     return 1
@@ -104,13 +104,29 @@ replaceNodeModules() {
 
   if nodeModulesUnchanged "${src}" "${dst}"; then
       return
-  fi 
+  fi
 
   # Replace node_modules if necessary
   echo "Copying node_modules from Nix store:" >&2
   echo " - ${src}" >&2
   copyNodeModules "${src}" "${dst}"
   echo -n "${src}" > "${sentinelFile}"
+}
+
+addLocalXcodeEnv() {
+  # Get the path of NODE_BINARY using `which node`
+  NODE_BINARY_PATH=$(which node)
+
+  # Check if the file ios/.xcode.env.local exists
+  if [ ! -f ios/.xcode.env.local ]; then
+      # If it doesn't exist, create it with the following contents
+      echo "export NODE_BINARY=${NODE_BINARY_PATH}" > ios/.xcode.env.local
+      echo 'export NODE_ARGS="${NODE_ARGS:- --max-old-space-size=16384 }"' >> ios/.xcode.env.local
+      echo "ios/.xcode.env.local created successfully."
+  else
+      echo "ios/.xcode.env.local already exists and nothing to worry."
+  fi
+
 }
 
 # Destination folder, Nix sets STATUS_MOBILE_HOME
@@ -124,7 +140,7 @@ if [[ ! -d ${src} ]]; then
 fi
 
 # Make those available in shell spawned by flock
-export -f replaceNodeModules nodeModulesUnchanged copyNodeModules findFilesNewerThan removeDir
+export -f replaceNodeModules nodeModulesUnchanged copyNodeModules findFilesNewerThan removeDir addLocalXcodeEnv
 
 mkdir -p "${dst}"
 # Leverage file lock to create an exclusive lock.


### PR DESCRIPTION
This PR adds 2 files :
- `ios/.xcode.env` 
- `ios/.xcode.env.local`

`ios/.xcode.env.local` is added to `.gitignore` and is to be considered as a local configuration.
We have to add path of `node` binary from our local nix store over here to instruct `Xcode` to find this explicit `node` version and use it for building.

- [x] generate `ios/.xcode.env.local` with existing nix store path of node at build time


status : wip