### PR TITLE
fix subs bug

### DIFF
--- a/src/status_im2/common/toasts/view.cljs
+++ b/src/status_im2/common/toasts/view.cljs
@@ -43,7 +43,7 @@
       [:f>
        (fn []
          (let [duration (or (rf/sub [:toasts/toast-cursor id :duration]) 3000)
-               on-dismissed #((or (rf/sub [:toasts/toast-cursor id :on-dismissed]) identity) id)
+               on-dismissed (or (rf/sub [:toasts/toast-cursor id :on-dismissed]) identity)
                create-timer (fn []
                               (reset! timer (utils.utils/set-timeout close! duration)))
                translate-y (reanimated/use-shared-value 0)
@@ -80,7 +80,7 @@
                                      (create-timer)))))]
            ;; create auto dismiss timer, clear timer when unmount or duration changed
            (rn/use-effect (fn [] (create-timer) clear-timer) [duration])
-           (rn/use-unmount on-dismissed)
+           (rn/use-unmount #(on-dismissed id))
            [gesture/gesture-detector {:gesture pan}
             [reanimated/view
              {;; TODO: this will enable layout animation at runtime and causing flicker on android

--- a/src/status_im2/common/toasts/view.cljs
+++ b/src/status_im2/common/toasts/view.cljs
@@ -100,4 +100,5 @@
     [into
      [rn/view
       {:style style/outmost-transparent-container}]
-     (map (fn [id] ^{:key id} [container id]) toasts-ordered)]))
+     (doall
+       (map (fn [id] ^{:key id} [container id]) toasts-ordered))]))

--- a/src/status_im2/common/toasts/view.cljs
+++ b/src/status_im2/common/toasts/view.cljs
@@ -101,4 +101,4 @@
      [rn/view
       {:style style/outmost-transparent-container}]
      (doall
-       (map (fn [id] ^{:key id} [container id]) toasts-ordered))]))
+      (map (fn [id] ^{:key id} [container id]) toasts-ordered))]))


### PR DESCRIPTION
fixes #15678

sometimes you can see in re-frisk subscriptions run in the loop, that means there is a mistake in usage, and we should find and fix that

<img width="680" alt="image" src="https://user-images.githubusercontent.com/11790366/232790391-64b15d61-4a45-4665-8864-054bce2d11d4.png">


PS: actually it didn't solve the problem, so the review is on hold

PS2: fixed , so subscription must be called only by reagent when its initializing the view, but in this case it was run in the dismiss function outside of reagent context , which leads to subscription leak 

ready for review
