### PR TITLE
patch react-native script to not look for `nvm`

### DIFF
--- a/nix/deps/nodejs-patched/default.nix
+++ b/nix/deps/nodejs-patched/default.nix
@@ -15,6 +15,7 @@ stdenv.mkDerivation {
     "patchYogaNodePackagePhase"
     "patchReactNativePhase"
     "patchPodPhase"
+    "patchReactNativeXcodeScriptPhase"
     "installPhase"
   ];
 
@@ -105,6 +106,18 @@ stdenv.mkDerivation {
           '[RCTConvert UIColor:options.cancelButtonTintColor() ? @(*options.cancelButtonTintColor()) : nil];' \
           '[RCTConvert UIColor:options.tintColor() ? @(*options.tintColor()) : nil];'
   '';
+
+# Patch React Native Xcode Script that searches for nvm
+# FIXME: Remove this once we upgrade react-native to 0.69.x
+    patchReactNativeXcodeScriptPhase = ''
+      substituteInPlace ./node_modules/react-native/scripts/find-node.sh --replace \
+              '# Define NVM_DIR and source the nvm.sh setup script' \
+              '<<MULTI_LINE_COMMENT${"\n"}# Define NVM_DIR and source the nvm.sh setup script'
+
+      substituteInPlace ./node_modules/react-native/scripts/find-node.sh --replace \
+              '# Set up the nodenv node version manager if present' \
+              'MULTI_LINE_COMMENT${"\n"}# Set up the nodenv node version manager if present'
+    '';
 
 
   # The ELF types are incompatible with the host platform, so let's not even try


### PR DESCRIPTION
We had an issue on systems that had `nvm` installed.
react-native build scripts specifically look for `nvm` and grab the node version from over there in version 0.67.x

https://github.com/facebook/react-native/blob/0.67-stable/scripts/find-node.sh#L19-L32

we don't want this behaviour because we want to use the node version we pin at nix.

This PR adds a patch phase to get rid of those scripts.

status: ready
