### PR TITLE
Various fixes for Contact Request flows (2nd attempt)

### DIFF
--- a/src/status_im/add_new/core.cljs
+++ b/src/status_im/add_new/core.cljs
@@ -82,7 +82,7 @@
     (if-not validation-result
       (if new-contact?
         (rf/merge cofx
-                  (contact/add-contact chat-key nickname ens-name)
+                  (contact/send-contact-request chat-key)
                   (navigation/navigate-to :contacts-list {}))
         (chat/start-chat cofx chat-key ens-name))
       {:utils/show-popup {:title      (i18n/label :t/unable-to-read-this-code)

--- a/src/status_im/contact/chat.cljs
+++ b/src/status_im/contact/chat.cljs
@@ -1,8 +1,8 @@
 (ns status-im.contact.chat
   (:require [re-frame.core :as re-frame]
             [status-im2.contexts.contacts.events :as contact]
-            [utils.re-frame :as rf]
-            [status-im2.navigation.events :as navigation]))
+            [status-im2.navigation.events :as navigation]
+            [utils.re-frame :as rf]))
 
 (rf/defn contact-code-submitted
   {:events       [:contact.ui/contact-code-submitted]
@@ -11,7 +11,7 @@
   (let [{:keys [public-key ens-name]} new-identity]
     (rf/merge cofx
               #(if new-contact?
-                 (contact/add-contact % public-key nickname ens-name)
+                 (contact/send-contact-request % public-key)
                  {:dispatch [:chat.ui/start-chat public-key ens-name]})
               #(when new-contact?
                  (navigation/navigate-back %)))))

--- a/src/status_im/ui/screens/profile/contact/views.cljs
+++ b/src/status_im/ui/screens/profile/contact/views.cljs
@@ -36,8 +36,9 @@
               :disabled            blocked?
               :accessibility-label :add-to-contacts-button
               :action              (when-not blocked?
-                                     #(re-frame/dispatch [:contact.ui/add-contact-pressed public-key
-                                                          nil ens-name]))}])
+                                     (fn []
+                                       (re-frame/dispatch [:contact.ui/send-contact-request
+                                                           public-key])))}])
           [{:label               (i18n/label (if (or muted? blocked?) :t/unmute :t/mute))
             :icon                :main-icons/notification
             :accessibility-label :mute-chat

--- a/src/status_im2/contexts/contacts/events.cljs
+++ b/src/status_im2/contexts/contacts/events.cljs
@@ -1,10 +1,11 @@
 (ns status-im2.contexts.contacts.events
   (:require
-    [utils.re-frame :as rf]
-    [taoensso.timbre :as log]
-    [status-im.utils.types :as types]
     [oops.core :as oops]
-    [status-im2.constants :as constants]))
+    [status-im.utils.types :as types]
+    [status-im2.constants :as constants]
+    [taoensso.timbre :as log]
+    [utils.i18n :as i18n]
+    [utils.re-frame :as rf]))
 
 (defn <-rpc-js
   [^js js-contact]
@@ -82,7 +83,7 @@
     {:json-rpc/call
      [{:method      "wakuext_sendContactRequest"
        :js-response true
-       :params      [{:id id :message "Please add me to your contacts"}]
+       :params      [{:id id :message (i18n/label :t/add-me-to-your-contacts)}]
        :on-error    (fn [error]
                       (log/error "Failed to send contact request"
                                  {:error error

--- a/translations/en.json
+++ b/translations/en.json
@@ -45,6 +45,7 @@
     "advanced": "Advanced",
     "advanced-settings": "Advanced settings",
     "agree-by-continuing": "By continuing you agree\n to our ",
+    "add-me-to-your-contacts": "Please add me to your contacts",
     "all": "All",
     "allow": "Allow",
     "allowing-authorizes-this-dapp": "Allowing authorizes this DApp to retrieve your wallet address and enable Web3",


### PR DESCRIPTION
Fixes https://github.com/status-im/status-mobile/issues/15679

### Summary

A quick and dirty PR that serves two purposes:

- [x] Make sure status-mobile works well with the upcoming status-go changes in PR https://github.com/status-im/status-go/pull/3379.
- [x] Replace calls to `wakuext_addContact` with `wakuext_sendContactRequest`. This is what's been aligned with the desktop team, as we will go on to remove `wakuext_addContact` in the near future.

Note: **Once this PR has been approved and tested by QAs, the status-go PR will be merged first**, business as usual, and I'll update the `status-go-version.json` file to point to an actual status-go tag.

### Out of scope

Refactoring; improvements in the existing code; UX.

#### Platforms

- Android
- iOS

### Steps to test (for QAs)

Contact request flows may be impacted. The status-go PR https://github.com/status-im/status-go/pull/3379 describes the changes being introduced, but perhaps for good measure all important CR flows should be double-checked in mobile.

status: ready
