### PR TITLE
update guidlines

### DIFF
--- a/doc/new-guidelines.md
+++ b/doc/new-guidelines.md
@@ -164,11 +164,11 @@ Properties must be set on view level
 ```
 
 
-### Never apply animated styles in the style file
+### Apply animated styles in the style file
 
 
 ```clojure
-;; good
+;; bad
 (defn circle
   []
   (let [opacity (reanimated/use-shared-value 1)]
@@ -176,7 +176,7 @@ Properties must be set on view level
                               {:opacity opacity}
                               style/circle-container)}]))
 
-;; bad
+;; good
 (defn circle
   []
   (let [opacity (reanimated/use-shared-value 1)]


### PR DESCRIPTION
fixes #15552

1) added part for inline functions usage in hiccup
2) relaxed styles rule
3) ~changed ### Always apply animated styles in the style file to Never
because there is no real reason to mix animated styles and hide animated function inside styles namespace , better to just simplify reanimated function~
4) don't mix props and styles in styles ns