### PR TITLE
[Fix] [iOS] Crash on onboarding for second profile without biometrics

### DIFF
--- a/src/status_im2/contexts/onboarding/events.cljs
+++ b/src/status_im2/contexts/onboarding/events.cljs
@@ -105,7 +105,10 @@
                          :previewPrivacy           config/blank-preview?}]
     {effect    request
      :dispatch [:navigate-to :generating-keys]
-     :db       (assoc db :onboarding-2/new-account? true)}))
+     :db       (-> db
+                   (dissoc :multiaccounts/login)
+                   (dissoc :auth-method)
+                   (assoc :onboarding-2/new-account? true))}))
 
 (rf/defn on-delete-profile-success
   {:events [:onboarding-2/on-delete-profile-success]}


### PR DESCRIPTION
fixes #15632 

### Summary

This PR fixes the crash on iOS when the user tries to create a second profile without enabling biometrics.

### Review notes

The crash happened from Keychain due to setting a `nil` value into the keychain on login signal handling. This is resolved by removing any profile login data (`:multiaccounts/login` and `:auth-method` keys) from `app-db` on the `onboarding-2/create-account-and-login` event handler.

### Platforms

- iOS

status: ready 
