### PR TITLE
Integrate support for SVG icons and fix clear icon

### DIFF
--- a/src/mocks/js_dependencies.cljs
+++ b/src/mocks/js_dependencies.cljs
@@ -141,6 +141,7 @@ globalThis.__STATUS_MOBILE_JS_IDENTITY_PROXY__ = new Proxy({}, {get() { return (
    {:ClipPath #js {:render identity}
     :Circle   #js {:render identity}
     :Defs     #js {:render identity}
+    :G        #js {:render identity}
     :Path     #js {:render identity}
     :Rect     #js {:render identity}
     :SvgUri   #js {:render identity}

--- a/src/quo2/components/icon.cljs
+++ b/src/quo2/components/icon.cljs
@@ -9,6 +9,12 @@
   [color]
   (and (string? color) (not (string/blank? color))))
 
+(defn- append-to-keyword
+  [k & xs]
+  (keyword (apply str
+                  (subs (str k) 1)
+                  xs)))
+
 (defn memo-icon-fn
   ([icon-name] (memo-icon-fn icon-name nil))
   ([icon-name
@@ -18,7 +24,7 @@
      :or   {accessibility-label :icon}}]
    (let [size (or size 20)]
      ^{:key icon-name}
-     (if-let [svg-icon (get icons.svg/icons icon-name)]
+     (if-let [svg-icon (get icons.svg/icons (append-to-keyword icon-name "-" size))]
        (let [foreground-color (cond
                                 (valid-color? foreground-color)
                                 foreground-color

--- a/src/quo2/components/icon.cljs
+++ b/src/quo2/components/icon.cljs
@@ -1,29 +1,51 @@
 (ns quo2.components.icon
   (:require [clojure.string :as string]
             [quo2.components.icons.icons :as icons]
+            [quo2.components.icons.svg :as icons.svg]
             [quo2.foundations.colors :as colors]
             [react-native.core :as rn]))
+
+(defn- valid-color?
+  [color]
+  (and (string? color) (not (string/blank? color))))
 
 (defn memo-icon-fn
   ([icon-name] (memo-icon-fn icon-name nil))
   ([icon-name
-    {:keys [color container-style size
-            accessibility-label no-color]
+    {:keys [color no-color
+            background-color foreground-color
+            container-style size accessibility-label]
      :or   {accessibility-label :icon}}]
    (let [size (or size 20)]
      ^{:key icon-name}
-     [rn/image
-      {:style
-       (merge {:width  size
-               :height size}
+     (if-let [svg-icon (get icons.svg/icons icon-name)]
+       (let [foreground-color (cond
+                                (valid-color? foreground-color)
+                                foreground-color
 
-              (when (not no-color)
-                {:tint-color (if (and (string? color) (not (string/blank? color)))
-                               color
-                               (colors/theme-colors colors/neutral-100 colors/white))})
+                                (valid-color? color)
+                                color
 
-              container-style)
-       :accessibility-label accessibility-label
-       :source (icons/icon-source (str (name icon-name) size))}])))
+                                :else
+                                (colors/theme-colors colors/neutral-100 colors/white))]
+         [svg-icon
+          {:size                size
+           :background-color    background-color
+           :foreground-color    foreground-color
+           :accessibility-label accessibility-label
+           :style               container-style}])
+       [rn/image
+        {:style
+         (merge {:width  size
+                 :height size}
+
+                (when (not no-color)
+                  {:tint-color (if (and (string? color) (not (string/blank? color)))
+                                 color
+                                 (colors/theme-colors colors/neutral-100 colors/white))})
+
+                container-style)
+         :accessibility-label accessibility-label
+         :source (icons/icon-source (str (name icon-name) size))}]))))
 
 (def icon (memoize memo-icon-fn))

--- a/src/quo2/components/icon.cljs
+++ b/src/quo2/components/icon.cljs
@@ -7,7 +7,9 @@
 
 (defn- valid-color?
   [color]
-  (and (string? color) (not (string/blank? color))))
+  (or (keyword? color)
+      (and (string? color)
+           (not (string/blank? color)))))
 
 (defn- append-to-keyword
   [k & xs]
@@ -18,28 +20,18 @@
 (defn memo-icon-fn
   ([icon-name] (memo-icon-fn icon-name nil))
   ([icon-name
-    {:keys [color no-color
-            background-color foreground-color
+    {:keys [color color-2 no-color
             container-style size accessibility-label]
      :or   {accessibility-label :icon}}]
    (let [size (or size 20)]
      ^{:key icon-name}
      (if-let [svg-icon (get icons.svg/icons (append-to-keyword icon-name "-" size))]
-       (let [foreground-color (cond
-                                (valid-color? foreground-color)
-                                foreground-color
-
-                                (valid-color? color)
-                                color
-
-                                :else
-                                (colors/theme-colors colors/neutral-100 colors/white))]
-         [svg-icon
-          {:size                size
-           :background-color    background-color
-           :foreground-color    foreground-color
-           :accessibility-label accessibility-label
-           :style               container-style}])
+       [svg-icon
+        {:size                size
+         :color               (when (valid-color? color) color)
+         :color-2             (when (valid-color? color-2) color-2)
+         :accessibility-label accessibility-label
+         :style               container-style}]
        [rn/image
         {:style
          (merge {:width  size

--- a/src/quo2/components/icon.cljs
+++ b/src/quo2/components/icon.cljs
@@ -11,12 +11,6 @@
       (and (string? color)
            (not (string/blank? color)))))
 
-(defn- append-to-keyword
-  [k & xs]
-  (keyword (apply str
-                  (subs (str k) 1)
-                  xs)))
-
 (defn memo-icon-fn
   ([icon-name] (memo-icon-fn icon-name nil))
   ([icon-name
@@ -25,7 +19,7 @@
      :or   {accessibility-label :icon}}]
    (let [size (or size 20)]
      ^{:key icon-name}
-     (if-let [svg-icon (get icons.svg/icons (append-to-keyword icon-name "-" size))]
+     (if-let [svg-icon (icons.svg/get-icon icon-name size)]
        [svg-icon
         {:size                size
          :color               (when (valid-color? color) color)

--- a/src/quo2/components/icons/icons.clj
+++ b/src/quo2/components/icons/icons.clj
@@ -2,9 +2,9 @@
   (:require [clojure.java.io :as io]
             [clojure.string :as string]))
 
-(def icon-path "./resources/images/icons2/")
+(def ^:private icon-path "./resources/images/icons2/")
 
-(defn require-icon
+(defn- require-icon
   [size path]
   (fn [el]
     (let [s (str "." path el ".png")
@@ -15,7 +15,7 @@
                 (str size))]
       [k `(js/require ~s)])))
 
-(defn get-files
+(defn- get-files
   [path]
   (->> (io/file path)
        file-seq
@@ -23,7 +23,7 @@
        (map #(first (string/split (.getName %) #"@")))
        distinct))
 
-(defn get-icons
+(defn- get-icons
   [size]
   (let [path (str icon-path size "x" size "/")]
     (into {} (map (require-icon size path) (get-files path)))))

--- a/src/quo2/components/icons/icons.cljs
+++ b/src/quo2/components/icons/icons.cljs
@@ -2,7 +2,7 @@
   (:require-macros [quo2.components.icons.icons :as icons])
   (:require [taoensso.timbre :as log]))
 
-(def icons (icons/resolve-icons))
+(def ^:private icons (icons/resolve-icons))
 
 (defn icon-source
   [icon]

--- a/src/quo2/components/icons/svg.cljs
+++ b/src/quo2/components/icons/svg.cljs
@@ -3,8 +3,9 @@
   ReactNative `:tint-color` prop affects all non-transparent pixels of PNGs. If
   the icon has only one color, prefer a PNG.
 
-  Keep all SVG components private and expose them by name via the `icons` var."
-  (:require [react-native.svg :as svg]))
+  Keep all SVG components private and expose them by name in the `icons` var."
+  (:require [react-native.svg :as svg]
+            [quo2.foundations.colors :as colors]))
 
 (defn- container
   [{:keys [size accessibility-label style]
@@ -19,17 +20,19 @@
           :fill                :none}]
         children))
 
-(defn- clear
+(defn- clear-20
   [{:keys [foreground-color background-color] :as props}]
-  [container props
-   [svg/path
-    {:d
-     "M3 10C3 6.13401 6.13401 3 10 3C13.866 3 17 6.13401 17 10C17 13.866 13.866 17 10 17C6.13401 17 3 13.866 3 10Z"
-     :fill background-color}]
-   [svg/path
-    {:d
-     "M9.15142 9.99998L7.07566 12.0757L7.9242 12.9243L9.99994 10.8485L12.0757 12.9242L12.9242 12.0757L10.8485 9.99998L12.9242 7.92421L12.0757 7.07568L9.99994 9.15145L7.92421 7.07572L7.07568 7.92425L9.15142 9.99998Z"
-     :fill foreground-color}]])
+  (let [background-color (or background-color colors/neutral-100)
+        foreground-color (or foreground-color colors/white)]
+    [container props
+     [svg/path
+      {:d
+       "M3 10C3 6.13401 6.13401 3 10 3C13.866 3 17 6.13401 17 10C17 13.866 13.866 17 10 17C6.13401 17 3 13.866 3 10Z"
+       :fill background-color}]
+     [svg/path
+      {:d
+       "M9.15142 9.99998L7.07566 12.0757L7.9242 12.9243L9.99994 10.8485L12.0757 12.9242L12.9242 12.0757L10.8485 9.99998L12.9242 7.92421L12.0757 7.07568L9.99994 9.15145L7.92421 7.07572L7.07568 7.92425L9.15142 9.99998Z"
+       :fill foreground-color}]]))
 
 (def icons
-  {:i/clear clear})
+  {:i/clear-20 clear-20})

--- a/src/quo2/components/icons/svg.cljs
+++ b/src/quo2/components/icons/svg.cljs
@@ -1,0 +1,35 @@
+(ns quo2.components.icons.svg
+  "Declare icons in this namespace when they have two possible colors, because the
+  ReactNative `:tint-color` prop affects all non-transparent pixels of PNGs. If
+  the icon has only one color, prefer a PNG.
+
+  Keep all SVG components private and expose them by name via the `icons` var."
+  (:require [react-native.svg :as svg]))
+
+(defn- container
+  [{:keys [size accessibility-label style]
+    :or   {size 20}}
+   & children]
+  (into [svg/svg
+         {:accessibility-label accessibility-label
+          :style               style
+          :width               size
+          :height              size
+          :view-box            (str "0 0 " size " " size)
+          :fill                :none}]
+        children))
+
+(defn- clear
+  [{:keys [foreground-color background-color] :as props}]
+  [container props
+   [svg/path
+    {:d
+     "M3 10C3 6.13401 6.13401 3 10 3C13.866 3 17 6.13401 17 10C17 13.866 13.866 17 10 17C6.13401 17 3 13.866 3 10Z"
+     :fill background-color}]
+   [svg/path
+    {:d
+     "M9.15142 9.99998L7.07566 12.0757L7.9242 12.9243L9.99994 10.8485L12.0757 12.9242L12.9242 12.0757L10.8485 9.99998L12.9242 7.92421L12.0757 7.07568L9.99994 9.15145L7.92421 7.07572L7.07568 7.92425L9.15142 9.99998Z"
+     :fill foreground-color}]])
+
+(def icons
+  {:i/clear clear})

--- a/src/quo2/components/icons/svg.cljs
+++ b/src/quo2/components/icons/svg.cljs
@@ -34,5 +34,15 @@
        "M9.15142 9.99998L7.07566 12.0757L7.9242 12.9243L9.99994 10.8485L12.0757 12.9242L12.9242 12.0757L10.8485 9.99998L12.9242 7.92421L12.0757 7.07568L9.99994 9.15145L7.92421 7.07572L7.07568 7.92425L9.15142 9.99998Z"
        :fill color-2}]]))
 
-(def icons
+(def ^:private icons
   {:i/clear-20 clear-20})
+
+(defn- append-to-keyword
+  [k & xs]
+  (keyword (apply str
+                  (subs (str k) 1)
+                  xs)))
+
+(defn get-icon
+  [icon-name size]
+  (get icons (append-to-keyword icon-name "-" size)))

--- a/src/quo2/components/icons/svg.cljs
+++ b/src/quo2/components/icons/svg.cljs
@@ -21,18 +21,18 @@
         children))
 
 (defn- clear-20
-  [{:keys [foreground-color background-color] :as props}]
-  (let [background-color (or background-color colors/neutral-100)
-        foreground-color (or foreground-color colors/white)]
+  [{:keys [color color-2] :as props}]
+  (let [color   (or color colors/neutral-100)
+        color-2 (or color-2 colors/white)]
     [container props
      [svg/path
       {:d
        "M3 10C3 6.13401 6.13401 3 10 3C13.866 3 17 6.13401 17 10C17 13.866 13.866 17 10 17C6.13401 17 3 13.866 3 10Z"
-       :fill background-color}]
+       :fill color}]
      [svg/path
       {:d
        "M9.15142 9.99998L7.07566 12.0757L7.9242 12.9243L9.99994 10.8485L12.0757 12.9242L12.9242 12.0757L10.8485 9.99998L12.9242 7.92421L12.0757 7.07568L9.99994 9.15145L7.92421 7.07572L7.07568 7.92425L9.15142 9.99998Z"
-       :fill foreground-color}]]))
+       :fill color-2}]]))
 
 (def icons
   {:i/clear-20 clear-20})

--- a/src/quo2/components/inputs/search_input/style.cljs
+++ b/src/quo2/components/inputs/search_input/style.cljs
@@ -24,7 +24,7 @@
    :height          20
    :width           20})
 
-(defn clear-icon-bg-color
+(defn clear-icon
   [blur? override-theme]
   (if blur?
     (colors/theme-colors colors/neutral-80-opa-30 colors/white-opa-10 override-theme)

--- a/src/quo2/components/inputs/search_input/style.cljs
+++ b/src/quo2/components/inputs/search_input/style.cljs
@@ -24,11 +24,11 @@
    :height          20
    :width           20})
 
-(defn clear-icon
+(defn clear-icon-bg-color
   [blur? override-theme]
   (if blur?
     (colors/theme-colors colors/neutral-80-opa-30 colors/white-opa-10 override-theme)
-    (colors/theme-colors colors/neutral-40 colors/neutral-50 override-theme)))
+    (colors/theme-colors colors/neutral-40 colors/neutral-60 override-theme)))
 
 (defn cursor
   [customization-color override-theme]

--- a/src/quo2/components/inputs/search_input/view.cljs
+++ b/src/quo2/components/inputs/search_input/view.cljs
@@ -19,7 +19,7 @@
    {:style    style/clear-icon-container
     :on-press on-press}
    [icon/icon :i/clear
-    {:color (style/clear-icon-bg-color blur? override-theme)
+    {:color (style/clear-icon blur? override-theme)
      :size  20}]])
 
 (defn- handle-backspace

--- a/src/quo2/components/inputs/search_input/view.cljs
+++ b/src/quo2/components/inputs/search_input/view.cljs
@@ -19,9 +19,8 @@
    {:style    style/clear-icon-container
     :on-press on-press}
    [icon/icon :i/clear
-    {:foreground-color style/clear-icon-fg-color
-     :background-color (style/clear-icon-bg-color blur? override-theme)
-     :size             20}]])
+    {:color (style/clear-icon-bg-color blur? override-theme)
+     :size  20}]])
 
 (defn- handle-backspace
   [event ^js/Object scroll-view-ref]

--- a/src/quo2/components/inputs/search_input/view.cljs
+++ b/src/quo2/components/inputs/search_input/view.cljs
@@ -19,8 +19,9 @@
    {:style    style/clear-icon-container
     :on-press on-press}
    [icon/icon :i/clear
-    {:color (style/clear-icon blur? override-theme)
-     :size  20}]])
+    {:foreground-color style/clear-icon-fg-color
+     :background-color (style/clear-icon-bg-color blur? override-theme)
+     :size             20}]])
 
 (defn- handle-backspace
   [event ^js/Object scroll-view-ref]

--- a/src/quo2/components/links/url_preview/style.cljs
+++ b/src/quo2/components/links/url_preview/style.cljs
@@ -48,10 +48,6 @@
   {:text-transform :lowercase
    :color          (colors/theme-colors colors/neutral-50 colors/neutral-40)})
 
-(def clear-button
-  {:border-color colors/danger-50
-   :border-width 1})
-
 (def clear-button-container
   {:width       20
    :height      20

--- a/src/quo2/components/links/url_preview/view.cljs
+++ b/src/quo2/components/links/url_preview/view.cljs
@@ -39,9 +39,8 @@
     :hit-slop            {:top 3 :right 3 :bottom 3 :left 3}
     :accessibility-label :button-clear-preview}
    [icon/icon :i/clear
-    {:size             20
-     :background-color (colors/theme-colors colors/neutral-50 colors/neutral-60)
-     :foreground-color colors/white}]])
+    {:size  20
+     :color (colors/theme-colors colors/neutral-50 colors/neutral-60)}]])
 
 (defn view
   [{:keys [title body logo on-clear loading? loading-message container-style]}]

--- a/src/quo2/components/links/url_preview/view.cljs
+++ b/src/quo2/components/links/url_preview/view.cljs
@@ -39,9 +39,9 @@
     :hit-slop            {:top 3 :right 3 :bottom 3 :left 3}
     :accessibility-label :button-clear-preview}
    [icon/icon :i/clear
-    {:size            20
-     :container-style style/clear-button
-     :color           (colors/theme-colors colors/neutral-50 colors/neutral-60)}]])
+    {:size             20
+     :background-color (colors/theme-colors colors/neutral-50 colors/neutral-60)
+     :foreground-color colors/white}]])
 
 (defn view
   [{:keys [title body logo on-clear loading? loading-message container-style]}]

--- a/src/react_native/svg.cljs
+++ b/src/react_native/svg.cljs
@@ -9,3 +9,4 @@
 (def defs (reagent/adapt-react-class Svg/Defs))
 (def circle (reagent/adapt-react-class Svg/Circle))
 (def svgxml (reagent/adapt-react-class Svg/SvgXml))
+(def g (reagent/adapt-react-class Svg/G))

--- a/src/status_im/ui2/screens/chat/composer/images/style.cljs
+++ b/src/status_im/ui2/screens/chat/composer/images/style.cljs
@@ -1,16 +1,9 @@
-(ns status-im.ui2.screens.chat.composer.images.style
-  (:require [quo2.foundations.colors :as colors]))
+(ns status-im.ui2.screens.chat.composer.images.style)
 
 (def remove-photo-container
-  {:width            14
-   :height           14
-   :border-radius    7
-   :background-color colors/neutral-50
-   :position         :absolute
-   :top              5
-   :right            5
-   :justify-content  :center
-   :align-items      :center})
+  {:position :absolute
+   :top      5
+   :right    5})
 
 (def small-image
   {:width         56

--- a/src/status_im/ui2/screens/chat/composer/images/view.cljs
+++ b/src/status_im/ui2/screens/chat/composer/images/view.cljs
@@ -21,9 +21,8 @@
                 :top    10
                 :bottom 10}}
     [quo/icon :i/clear
-     {:size             20
-      :background-color (colors/theme-colors colors/neutral-50 colors/neutral-60)
-      :foreground-color colors/white}]]])
+     {:size  20
+      :color (colors/theme-colors colors/neutral-50 colors/neutral-60)}]]])
 
 (defn images-list
   [images]

--- a/src/status_im/ui2/screens/chat/composer/images/view.cljs
+++ b/src/status_im/ui2/screens/chat/composer/images/view.cljs
@@ -20,7 +20,10 @@
                 :left   5
                 :top    10
                 :bottom 10}}
-    [quo/icon :i/close {:color colors/white :size 12}]]])
+    [quo/icon :i/clear
+     {:size             20
+      :background-color (colors/theme-colors colors/neutral-50 colors/neutral-60)
+      :foreground-color colors/white}]]])
 
 (defn images-list
   [images]


### PR DESCRIPTION
Fixes https://github.com/status-im/status-mobile/issues/15606

### Summary

This PR solves the problem described in detail in the issue #15606, but in essence, it fixes the clear icon by integrating support for SVG icons.

- Hopefully, if SVG icons prove to be a solid solution, we can easily and progressively migrate PNG icons to SVGs, but for the moment, it was aligned with @flexsurfer https://github.com/status-im/status-mobile/issues/15606#issuecomment-1514631270 that we'll only use SVG icons on demand.
- Note that it's possible to import SVGs directly via `js/require` by installing the library `react-native-svg-transformer`, but this approach is only good when we don't want/need color customization, which is rarely the case with icons where we want to change the foreground and/or background colors. I opted for rendering the SVG icon as hiccup to support color customization.
- Since icons are fully memoized, I believe the app's performance is on the same ballpark as PNGs rendered with RN `Image`.
- It's possible to trim down SVGs by using a tool such as https://github.com/svg/svgo, but this is obviously outside the scope of this PR.

### 1. Fix incorrect clear icon in the input chat image list

**Before**
<img src="https://user-images.githubusercontent.com/46027/233206199-e5495203-45ba-4cc8-9774-9064b9db26a7.png" width="600" />

**After**
<img src="https://user-images.githubusercontent.com/46027/233206162-1ee40fe7-2bbd-4b8c-a4af-9de713d08807.png" width="600" />
<img src="https://user-images.githubusercontent.com/46027/233206175-1ef162f3-183f-4fe6-9f89-02217e9bffe3.png" width="600" />

### 2. Fix incorrect clear icon in the input component

<img src="https://user-images.githubusercontent.com/46027/233206187-cc9cabb3-7e4e-440a-9377-4a37a4c83ba2.png" width="600" />

### 3. Fix incorrect clear icon in the input search component

<img src="https://user-images.githubusercontent.com/46027/233206193-8c5ee777-3502-48f0-ac83-4137105481b9.png" width="600" />

### 4. Fix incorrect clear icon in the URL preview component

**Before**
<img src="https://user-images.githubusercontent.com/46027/230887851-465404d2-23a6-4ae8-826e-8c3338575c2e.png" width="600" />

**After**
<img src="https://user-images.githubusercontent.com/46027/233207225-f084b327-69af-4fd6-a53e-902d92569fe8.png" width="600" />

#### Platforms

- Android
- iOS

status: ready
