### PR TITLE
[#15663] Recovery phrase input 

### DIFF
--- a/src/quo2/components/inputs/recovery_phrase/style.cljs
+++ b/src/quo2/components/inputs/recovery_phrase/style.cljs
@@ -1,0 +1,45 @@
+(ns quo2.components.inputs.recovery-phrase.style
+  (:require [quo2.components.markdown.text :as markdown.text]
+            [quo2.foundations.colors :as colors]))
+
+(def container
+  {:min-height         40
+   :flex               1
+   :padding-vertical   4
+   :padding-horizontal 20})
+
+(defn input
+  []
+  (assoc (markdown.text/text-style {})
+         :height              32
+         :flex-grow           1
+         :padding-vertical    5
+         :text-align-vertical :top))
+
+(defn placeholder-color
+  [input-state override-theme blur?]
+  (cond
+    (and (= input-state :focused) blur?)
+    (colors/theme-colors colors/neutral-80-opa-20 colors/white-opa-20 override-theme)
+
+    (= input-state :focused) ; Not blur
+    (colors/theme-colors colors/neutral-30 colors/neutral-60 override-theme)
+
+    blur? ; :default & blur
+    (colors/theme-colors colors/neutral-80-opa-40 colors/white-opa-30 override-theme)
+
+    :else ; :default & not blur
+    (colors/theme-colors colors/neutral-40 colors/neutral-50 override-theme)))
+
+(defn cursor-color
+  [customization-color override-theme]
+  (colors/theme-colors (colors/custom-color customization-color 50)
+                       (colors/custom-color customization-color 60)
+                       override-theme))
+
+(defn error-word
+  []
+  {:height             22
+   :padding-horizontal 20
+   :background-color   colors/danger-50-opa-10
+   :color              (colors/theme-colors colors/danger-50 colors/danger-60)})

--- a/src/quo2/components/inputs/recovery_phrase/view.cljs
+++ b/src/quo2/components/inputs/recovery_phrase/view.cljs
@@ -1,0 +1,53 @@
+(ns quo2.components.inputs.recovery-phrase.view
+  (:require [clojure.string :as string]
+            [quo2.components.inputs.recovery-phrase.style :as style]
+            [react-native.core :as rn]
+            [reagent.core :as reagent]))
+
+(def ^:private custom-props
+  [:customization-color :override-theme :blur? :cursor-color :multiline :on-focus :on-blur
+   :placeholder-text-color :mark-errors? :error-pred :word-limit])
+
+(defn- error-word
+  [text]
+  [rn/text {:style (style/error-word)}
+   text])
+
+(defn- mark-error-words
+  [pred text word-limit]
+  (let [word-limit (or word-limit ##Inf)]
+    (into [:<>]
+          (comp (map-indexed (fn [idx word]
+                               (if (or (pred word) (>= (inc idx) word-limit))
+                                 [error-word word]
+                                 word)))
+                (interpose " "))
+          (string/split text #" "))))
+
+(defn recovery-phrase-input
+  [_ _]
+  (let [state       (reagent/atom :default)
+        set-focused #(reset! state :focused)
+        set-default #(reset! state :default)]
+    (fn [{:keys [customization-color override-theme blur? on-focus on-blur mark-errors?
+                 error-pred word-limit]
+          :or   {customization-color :blue}
+          :as   props}
+         text]
+      (let [extra-props (apply dissoc props custom-props)]
+        [rn/view {:style style/container}
+         [rn/text-input
+          (merge {:style                  (style/input)
+                  :placeholder-text-color (style/placeholder-color @state override-theme blur?)
+                  :cursor-color           (style/cursor-color customization-color override-theme)
+                  :multiline              true
+                  :on-focus               (fn []
+                                            (set-focused)
+                                            (when on-focus (on-focus)))
+                  :on-blur                (fn []
+                                            (set-default)
+                                            (when on-blur (on-blur)))}
+                 extra-props)
+          (if mark-errors?
+            (mark-error-words error-pred text (inc word-limit))
+            text)]]))))

--- a/src/quo2/core.cljs
+++ b/src/quo2/core.cljs
@@ -32,6 +32,7 @@
     quo2.components.info.information-box
     quo2.components.inputs.input.view
     quo2.components.inputs.profile-input.view
+    quo2.components.inputs.recovery-phrase.view
     quo2.components.inputs.search-input.view
     quo2.components.inputs.title-input.view
     quo2.components.links.url-preview-list.view
@@ -150,8 +151,9 @@
 
 ;;;; INPUTS
 (def input quo2.components.inputs.input.view/input)
-(def search-input quo2.components.inputs.search-input.view/search-input)
 (def profile-input quo2.components.inputs.profile-input.view/profile-input)
+(def recovery-phrase-input quo2.components.inputs.recovery-phrase.view/recovery-phrase-input)
+(def search-input quo2.components.inputs.search-input.view/search-input)
 (def title-input quo2.components.inputs.title-input.view/title-input)
 
 ;;;; LIST ITEMS

--- a/src/status_im2/contexts/onboarding/create_password/view.cljs
+++ b/src/status_im2/contexts/onboarding/create_password/view.cljs
@@ -165,7 +165,8 @@
          [rn/view {:style style/bottom-part}
           [rn/view {:style style/disclaimer-container}
            [quo/disclaimer
-            {:on-change #(reset! accepts-disclaimer? %)
+            {:blur?     true
+             :on-change #(reset! accepts-disclaimer? %)
              :checked?  @accepts-disclaimer?}
             (i18n/label :t/password-creation-disclaimer)]]
 

--- a/src/status_im2/contexts/onboarding/enter_seed_phrase/view.cljs
+++ b/src/status_im2/contexts/onboarding/enter_seed_phrase/view.cljs
@@ -1,18 +1,17 @@
 (ns status-im2.contexts.onboarding.enter-seed-phrase.view
-  (:require [quo2.core :as quo]
-            [quo.core :as quo1]
-            [clojure.string :as string]
-            [status-im.ethereum.mnemonic :as mnemonic]
-            [status-im2.constants :as constants]
-            [utils.security.core :as security]
-            [utils.re-frame :as rf]
-            [reagent.core :as reagent]
+  (:require [clojure.string :as string]
+            [quo2.core :as quo]
             [react-native.core :as rn]
             [react-native.safe-area :as safe-area]
-            [status-im2.contexts.onboarding.enter-seed-phrase.style :as style]
+            [reagent.core :as reagent]
+            [status-im.ethereum.mnemonic :as mnemonic]
+            [status-im2.constants :as constants]
             [status-im2.contexts.onboarding.common.background.view :as background]
             [status-im2.contexts.onboarding.common.navigation-bar.view :as navigation-bar]
-            [utils.i18n :as i18n]))
+            [status-im2.contexts.onboarding.enter-seed-phrase.style :as style]
+            [utils.i18n :as i18n]
+            [utils.re-frame :as rf]
+            [utils.security.core :as security]))
 
 (def button-disabled?
   (comp not constants/seed-phrase-valid-length mnemonic/words-count))
@@ -40,20 +39,22 @@
          (i18n/label :t/use-recovery-phrase)]
         [quo/text
          (i18n/label-pluralize (mnemonic/words-count @seed-phrase) :t/words-n)]
-        [:<>
-         [quo1/text-input
+        [rn/view
+         {:style {:height            120
+                  :margin-horizontal -20}}
+         [quo/recovery-phrase-input
           {:on-change-text      (fn [t]
                                   (reset! seed-phrase (clean-seed-phrase t))
                                   (reset! error-message ""))
+           :mark-errors?        true
+           ; TODO(@ulisesmac): error-pred must return true if a word is marked as wrong
+           :error-pred          (constantly false)
+           :word-limit          24
            :auto-focus          true
            :accessibility-label :passphrase-input
            :placeholder         (i18n/label :t/seed-phrase-placeholder)
-           :show-cancel         false
-           :bottom-value        40
-           :multiline           true
-           :auto-correct        false
-           :keyboard-type       :visible-password
-           :monospace           true}]]
+           :auto-correct        false}
+          @seed-phrase]]
         [quo/button
          {:disabled (button-disabled? @seed-phrase)
           :on-press #(rf/dispatch [:onboarding-2/seed-phrase-entered

--- a/src/status_im2/contexts/quo_preview/inputs/recovery_phrase_input.cljs
+++ b/src/status_im2/contexts/quo_preview/inputs/recovery_phrase_input.cljs
@@ -1,0 +1,77 @@
+(ns status-im2.contexts.quo-preview.inputs.recovery-phrase-input
+  (:require [quo2.core :as quo]
+            [quo2.foundations.colors :as colors]
+            [react-native.core :as rn]
+            [reagent.core :as reagent]
+            [status-im2.contexts.quo-preview.preview :as preview]))
+
+(def descriptor
+  [{:label "Text"
+    :key   :text
+    :type  :text}
+   {:label "Placeholder"
+    :key   :placeholder
+    :type  :text}
+   {:label "Blur"
+    :key   :blur?
+    :type  :boolean}
+   {:label "Mark errors"
+    :key   :mark-errors?
+    :type  :boolean}
+   {:label   "Customization color"
+    :key     :customization-color
+    :type    :select
+    :options (map (fn [[color _]]
+                    {:key color :value (name color)})
+                  colors/customization)}
+   {:label   "Word limit"
+    :key     :word-limit
+    :type    :select
+    :options [{:key nil :value "No limit"}
+              {:key 5 :value "5 words"}
+              {:key 10 :value "10 words"}
+              {:key 20 :value "20 words"}]}])
+
+(defn cool-preview
+  []
+  (let [state (reagent/atom {:text                ""
+                             :placeholder         "Type or paste your recovery phrase"
+                             :customization-color :blue
+                             :word-limit          20
+                             :mark-errors?        true})]
+    (fn []
+      [rn/touchable-without-feedback {:on-press rn/dismiss-keyboard!}
+       [rn/view {:style {:padding-bottom 150}}
+        [rn/view {:style {:flex 1}}
+         [preview/customizer state descriptor]
+         [quo/text {:size :paragraph-2}
+          "(Any word with at least 6 chars is marked as error)"]]
+        [preview/blur-view
+         {:style                 {:align-items     :center
+                                  :margin-vertical 20
+                                  :width           "100%"}
+          :height                200
+          :show-blur-background? (:blur? @state)}
+         [rn/view
+          {:style {:height 150
+                   :width  "100%"}}
+          [quo/recovery-phrase-input
+           {:mark-errors?        (:mark-errors? @state)
+            :error-pred          #(> (count %) 5)
+            :on-change-text      #(swap! state assoc :text %)
+            :placeholder         (:placeholder @state)
+            :customization-color (:customization-color @state)
+            :word-limit          (:word-limit @state)}
+           (:text @state)]]]]])))
+
+(defn preview-recovery-phrase-input
+  []
+  [rn/view
+   {:style {:background-color (colors/theme-colors colors/white colors/neutral-95)
+            :flex             1}}
+   [rn/flat-list
+    {:style                     {:flex 1}
+     :keyboardShouldPersistTaps :always
+     :header                    [cool-preview]
+     :key-fn                    str}]])
+

--- a/src/status_im2/contexts/quo_preview/main.cljs
+++ b/src/status_im2/contexts/quo_preview/main.cljs
@@ -38,6 +38,7 @@
     [status-im2.contexts.quo-preview.info.info-message :as info-message]
     [status-im2.contexts.quo-preview.info.information-box :as information-box]
     [status-im2.contexts.quo-preview.inputs.input :as input]
+    [status-im2.contexts.quo-preview.inputs.recovery-phrase-input :as recovery-phrase-input]
     [status-im2.contexts.quo-preview.inputs.profile-input :as profile-input]
     [status-im2.contexts.quo-preview.inputs.title-input :as title-input]
     [status-im2.contexts.quo-preview.links.url-preview :as url-preview]
@@ -181,6 +182,9 @@
                            {:name      :profile-input
                             :insets    {:top false}
                             :component profile-input/preview-profile-input}
+                           {:name      :recovery-phrase-input
+                            :insets    {:top false}
+                            :component recovery-phrase-input/preview-recovery-phrase-input}
                            {:name      :search-input
                             :insets    {:top false}
                             :component search-input/preview-search-input}


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes #15663

### Summary

[comment]: # (Summarise the problem and how the pull request solves it)

This PR creates the cecovery phrase input and adds it to the recovery phrase onboarding screen.

![image](https://user-images.githubusercontent.com/90291778/233232988-2eed4c8e-c60c-4251-a2a3-9bfbfbbc3869.png)


### Review notes
Nesting views into text-inputs is not supported, so I wasn't able to add the padding & border-radius present in designs when a word has an error:
![image](https://user-images.githubusercontent.com/90291778/233233197-13cfc140-97d2-4f1c-bb25-6a9317951460.png)

This PR only creates the input and adds it to the screen, the seed phrase screen still needs to be enhanced.

#### Platforms

- Android
- iOS

#### Areas that maybe impacted
Onboarding seed phrase screen

### Steps to test

#### Onboarding: 

- Open Status in a fresh install
- Navigate to I'm new to Status -> use recovery phrase
-  Test the new input

#### Preview screen
- Open Status
- Navigate to Quo2.0 components -> inputs -> recovery phrase
-  Test the new input

status: ready
