### PR TITLE
Chat mention alignment fix

### DIFF
--- a/src/status_im2/contexts/chat/messages/content/text/view.cljs
+++ b/src/status_im2/contexts/chat/messages/content/text/view.cljs
@@ -8,6 +8,9 @@
     [utils.re-frame :as rf]
     [utils.i18n :as i18n]))
 
+(defn- pad-text
+  [text]
+  (str " " text " ")) ; Text inside Text doesn't support padding, so we need to add a space on each side to mimic that effect
 
 (defn render-inline
   [units {:keys [type literal destination]} chat-id]
@@ -40,13 +43,16 @@
     :mention
     (conj
      units
-     [rn/touchable-opacity
-      {:active-opacity 1
-       :on-press       #(rf/dispatch [:chat.ui/show-profile literal])
-       :style          (merge style/block {:background-color colors/primary-50-opa-10})}
-      [quo/text
-       {:weight :medium
-        :style  {:color (colors/theme-colors colors/primary-50 colors/primary-60)}}
+     [quo/text
+      {:weight                :medium
+       :on-press              #(rf/dispatch [:chat.ui/show-profile literal])
+       :selection-color       :transparent
+       :suppress-highlighting true
+       :style                 (merge style/block
+                                     {:color            (colors/theme-colors colors/primary-50
+                                                                             colors/primary-60)
+                                      :background-color colors/primary-50-opa-10})}
+      [pad-text
        (rf/sub [:messages/resolve-mention literal])]])
 
     :edited


### PR DESCRIPTION
fixes #15693 

### Screenshots
Android | iOS
-|-
![Android](https://user-images.githubusercontent.com/19279756/233330892-7c138e94-80f2-45f4-ab3e-ffe3498d0897.png) | ![iOS](https://user-images.githubusercontent.com/19279756/233330921-71758d6f-eb3a-4ccb-be45-f85e242e12f6.png)

### Affected areas
- 1:1 chat
- Community chat

### Known issue
- Border radius not working

status: ready <!-- Can be ready or wip -->