### PR TITLE
nix: add ios-deploy package to ios shell

### DIFF
--- a/nix/mobile/ios/default.nix
+++ b/nix/mobile/ios/default.nix
@@ -1,5 +1,8 @@
-{ callPackage, lib, mkShell, pkgs
+{ callPackage, lib, mkShell, pkgs, stdenv
 , status-go, fastlane }:
+
+assert lib.assertMsg stdenv.isDarwin
+  "iOS development shell supported only on OSX.";
 
 let
   inherit (lib) catAttrs unique;
@@ -17,6 +20,7 @@ in {
     buildInputs = with pkgs; [
       xcodeWrapper watchman procps
       flock # used in nix/scripts/node_modules.sh
+      ios-deploy # used in 'make run-ios-device'
     ];
 
     # WARNING: Executes shellHook in reverse order.

--- a/nix/mobile/ios/shells/nodejs.nix
+++ b/nix/mobile/ios/shells/nodejs.nix
@@ -1,17 +1,15 @@
 { mkShell, nodejs, deps }:
 
 mkShell {
-  # Check if node modules changed and if so install them.
   shellHook = ''
     # Fix for ERR_OSSL_EVP_UNSUPPORTED error.
     export NODE_OPTIONS="--openssl-legacy-provider";
     # Same fix but for Xcode React Native script.
     export NODE_ARGS="--openssl-legacy-provider --max-old-space-size=16384";
-
     # Fix Xcode using system Node.js version.
     export NODE_BINARY="${nodejs}/bin/node";
 
-    export STATUS_MOBILE_HOME=$(git rev-parse --show-toplevel)
+    # Check if node modules changed and if so install them.
     "$STATUS_MOBILE_HOME/nix/scripts/node_modules.sh" ${deps.nodejs-patched}
   '';
 }

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -44,6 +44,18 @@ in {
     });
   };
 
+  # Fix for missing libarclite_macosx.a in Xcode 14.3.
+  # https://github.com/ios-control/ios-deploy/issues/580
+  ios-deploy = super.darwin.ios-deploy.overrideAttrs (old: rec {
+    version = "1.12.2";
+    src = super.fetchFromGitHub {
+      owner = "ios-control";
+      repo = "ios-deploy";
+      rev = version;
+      sha256 = "sha256-TVGC+f+1ow3b93CK3PhIL70le5SZxxb2ug5OkIg8XCA";
+    };
+  });
+
   # Package version adjustments
   gradle = super.gradle_6;
   nodejs = super.nodejs-18_x;

--- a/nix/shells.nix
+++ b/nix/shells.nix
@@ -12,22 +12,19 @@ let
   # the default shell with most commonly used tools
   default = callPackage ./shell.nix { };
 
-  # Combines with many other shells
-  nodejs-sh = targets.mobile.ios.nodejs-sh;
-
   # An attrset for easier merging with default shell
   shells = {
     inherit default;
 
-    nodejs = nodejs-sh;
-
     # for calling clojure targets in CI or Makefile
     clojure = mkShell {
       buildInputs = with pkgs; [ clojure flock maven openjdk ];
-      inputsFrom = [ nodejs-sh ];
       # CLASSPATH from clojure deps with 'src' appended to find local sources.
       shellHook = with pkgs; ''
         export CLASS_PATH="$(find ${deps.clojure} -iname '*.jar' | tr '\n' ':')src"
+
+        # Check if node modules changed and if so install them.
+        "$STATUS_MOBILE_HOME/nix/scripts/node_modules.sh" ${pkgs.deps.nodejs-patched}
       '';
     };
 


### PR DESCRIPTION
Also adds an assertion that gives a better error when trying to use an `ios` Nix shell on an unsupported operating system.

Resolves:
* https://github.com/status-im/status-mobile/issues/15695