### PR TITLE
move image-server out of status-im namespace

### DIFF
--- a/src/status_im2/subs/chat/chats.cljs
+++ b/src/status_im2/subs/chat/chats.cljs
@@ -7,11 +7,12 @@
             [status-im.group-chats.core :as group-chat]
             [status-im.group-chats.db :as group-chats.db]
             [status-im.multiaccounts.core :as multiaccounts]
-            [status-im.utils.image-server :as image-server]
+            [utils.image-server :as image-server]
             [status-im2.config :as config]
             [status-im2.constants :as constants]
             [status-im2.contexts.chat.events :as chat.events]
-            [utils.i18n :as i18n]))
+            [utils.i18n :as i18n]
+            [quo2.theme :as theme]))
 
 (re-frame/reg-sub
  :chats/chat
@@ -289,7 +290,7 @@
                        multiaccount)
                      (get contacts id))]
      (if (nil? contact)
-       (image-server/get-identicons-uri port id)
+       (image-server/get-identicons-uri port id (theme/get-theme))
        (multiaccounts/displayed-photo contact)))))
 
 (re-frame/reg-sub

--- a/src/status_im2/subs/contact.cljs
+++ b/src/status_im2/subs/contact.cljs
@@ -7,9 +7,10 @@
             [status-im.multiaccounts.core :as multiaccounts]
             [status-im.ui.screens.profile.visibility-status.utils :as visibility-status-utils]
             [status-im.utils.gfycat.core :as gfycat]
-            [status-im.utils.image-server :as image-server]
+            [utils.image-server :as image-server]
             [utils.collection]
-            [status-im2.constants :as constants]))
+            [status-im2.constants :as constants]
+            [quo2.theme :as theme]))
 
 (re-frame/reg-sub
  ::query-current-chat-contacts
@@ -32,7 +33,8 @@
 
 (defn- replace-contact-image-uri
   [contact port identity]
-  (let [identicon      (image-server/get-identicons-uri port identity)
+  (let [theme          (theme/get-theme)
+        identicon      (image-server/get-identicons-uri port identity theme)
         contact-images (:images contact)
         contact-images (reduce (fn [acc image]
                                  (let [image-name (:type image)
@@ -42,7 +44,8 @@
                                        uri        (image-server/get-contact-image-uri port
                                                                                       identity
                                                                                       image-name
-                                                                                      clock)]
+                                                                                      clock
+                                                                                      theme)]
                                    (assoc-in acc [(keyword image-name) :uri] uri)))
                                contact-images
                                (vals contact-images))]

--- a/src/status_im2/subs/multiaccount.cljs
+++ b/src/status_im2/subs/multiaccount.cljs
@@ -5,8 +5,9 @@
             [status-im.ethereum.core :as ethereum]
             [status-im.fleet.core :as fleet]
             [status-im.multiaccounts.db :as multiaccounts.db]
-            [status-im.utils.image-server :as image-server]
-            [utils.security.core :as security]))
+            [utils.image-server :as image-server]
+            [utils.security.core :as security]
+            [quo2.theme :as theme]))
 
 (re-frame/reg-sub
  :multiaccount/public-key
@@ -208,7 +209,8 @@
 (defn- replace-multiaccount-image-uri
   [multiaccount port]
   (let [public-key   (:public-key multiaccount)
-        identicon    (image-server/get-identicons-uri port public-key)
+        theme        (theme/get-theme)
+        identicon    (image-server/get-identicons-uri port public-key theme)
         multiaccount (assoc multiaccount :identicon identicon)
         images       (:images multiaccount)
         images       (reduce (fn [acc current]
@@ -217,7 +219,8 @@
                                      uri        (image-server/get-account-image-uri port
                                                                                     public-key
                                                                                     image-name
-                                                                                    key-uid)]
+                                                                                    key-uid
+                                                                                    theme)]
                                  (conj acc (assoc current :uri uri))))
                              []
                              images)]

--- a/src/utils/image_server.cljs
+++ b/src/utils/image_server.cljs
@@ -1,36 +1,34 @@
-(ns status-im.utils.image-server
-  (:require [quo.design-system.colors :as colors]))
+(ns utils.image-server
+  (:require [utils.datetime :as datetime]))
 
 (def ^:const image-server-uri-prefix "https://localhost:")
 (def ^:const identicons-action "/messages/identicons")
 (def ^:const account-images-action "/accountImages")
 (def ^:const contact-images-action "/contactImages")
 
-(defn current-theme
-  []
-  (case @colors/theme-type
+(defn timestamp [] (datetime/timestamp))
+
+(defn current-theme-index
+  [theme]
+  (case theme
     :light 1
     :dark  2))
 
-(defn- timestamp
-  []
-  (.getTime (js/Date.)))
-
 (defn get-identicons-uri
-  [port public-key]
+  [port public-key theme]
   (str image-server-uri-prefix
        port
        identicons-action
        "?publicKey="
        public-key
        "&theme="
-       (current-theme)
+       (current-theme-index theme)
        "&clock="
        (timestamp)
        "&addRing=1"))
 
 (defn get-account-image-uri
-  [port public-key image-name key-uid]
+  [port public-key image-name key-uid theme]
   (str image-server-uri-prefix
        port
        account-images-action
@@ -41,13 +39,13 @@
        "&imageName="
        image-name
        "&theme="
-       (current-theme)
+       (current-theme-index theme)
        "&clock="
        (timestamp)
        "&addRing=1"))
 
 (defn get-contact-image-uri
-  [port public-key image-name clock]
+  [port public-key image-name clock theme]
   (str image-server-uri-prefix
        port
        contact-images-action
@@ -56,7 +54,7 @@
        "&imageName="
        image-name
        "&theme="
-       (current-theme)
+       (current-theme-index theme)
        "&clock="
        clock
        "&addRing=1"))


### PR DESCRIPTION
This PR moves `image_server.cljs` file out of status-im namespace into utils namespace.
All the references have also been updated.

status: ready 
