### PR TITLE
fix: quo2 title-input component selection color fix for android

### DIFF
--- a/src/quo2/components/inputs/title_input/style.cljs
+++ b/src/quo2/components/inputs/title_input/style.cljs
@@ -1,5 +1,6 @@
 (ns quo2.components.inputs.title-input.style
-  (:require [quo2.foundations.colors :as colors]))
+  (:require [quo2.foundations.colors :as colors]
+            [react-native.platform :as platform]))
 
 (defn get-focused-placeholder-color
   [blur? override-theme]
@@ -28,9 +29,11 @@
 
 (defn get-selection-color
   [customization-color blur? override-theme]
-  (if blur?
-    (colors/theme-colors colors/neutral-100 colors/white override-theme)
-    (colors/custom-color customization-color (if (or (= :dark override-theme) (colors/dark?)) 60 50))))
+  (colors/alpha (if blur?
+                  (colors/theme-colors colors/neutral-100 colors/white override-theme)
+                  (colors/custom-color customization-color
+                                       (if (or (= :dark override-theme) colors/dark?) 60 50)))
+                (if platform/ios? 1 0.2)))
 
 (def text-input-container {:flex 1})
 


### PR DESCRIPTION
fixes #15624 

### How to test
1. Go to 'Im new to Status' flow
2. Open the 'Display name' page set up
3. Type any text into 'Display name' -> highlight it

### Fix Screenshots
android | ios
-|-
![android-selection](https://user-images.githubusercontent.com/19279756/233834020-41eb36d8-452d-4a57-a4f6-b9bf4889e23a.png) | ![ios-selection](https://user-images.githubusercontent.com/19279756/233834024-e42aa3db-34f3-452e-a070-d446dd6450ce.png)

### Cause for the original issue
The `selection-color` property behaves differently on iOS and Android. When providing a solid color for this property, iOS will use a translucent version of the color for the background of text selection, while Android will use the original solid color. 

android | ios
-|-
![android-selection-color](https://user-images.githubusercontent.com/19279756/233834234-142e94fd-6144-4d40-8f6b-470743a8f4d2.png) | ![ios-selection-color](https://user-images.githubusercontent.com/19279756/233834235-6a6ab5bd-d1bf-46af-a8ba-f4e80b623c18.png)

### Issue introduced in this PR
TextInput component caret color is dependent on the `selection-color` property. As a result, on Android, the caret will appear lighter in color compared to iOS.
android | ios
-|-
![android-cursor](https://user-images.githubusercontent.com/19279756/233834643-9f5d7a0f-af41-4f3b-92ef-1f2336630398.png) | ![ios-cursor](https://user-images.githubusercontent.com/19279756/233834647-3583d7dd-82b0-4f54-9b51-0c7a191d7059.png)

status: ready