### PR TITLE
Show "Kicked from community" notification in Activity Center

### DIFF
--- a/src/status_im2/contexts/activity_center/notification/community_kicked/view.cljs
+++ b/src/status_im2/contexts/activity_center/notification/community_kicked/view.cljs
@@ -1,0 +1,37 @@
+(ns status-im2.contexts.activity-center.notification.community-kicked.view
+  (:require [quo2.core :as quo]
+            [status-im2.contexts.activity-center.notification.common.style :as common-style]
+            [status-im2.contexts.activity-center.notification.common.view :as common]
+            [utils.datetime :as datetime]
+            [utils.i18n :as i18n]
+            [utils.re-frame :as rf]))
+
+(defn- swipeable
+  [{:keys [active-swipeable extra-fn]} child]
+  [common/swipeable
+   {:left-button      common/swipe-button-read-or-unread
+    :left-on-press    common/swipe-on-press-toggle-read
+    :right-button     common/swipe-button-delete
+    :right-on-press   common/swipe-on-press-delete
+    :active-swipeable active-swipeable
+    :extra-fn         extra-fn}
+   child])
+
+(defn view
+  [{:keys [notification set-swipeable-height] :as props}]
+  (let [{:keys [community-id read
+                timestamp]} notification
+        community           (rf/sub [:communities/community community-id])
+        community-name      (:name community)
+        community-image     (get-in community [:images :thumbnail :uri])]
+    [swipeable props
+     [quo/activity-log
+      {:title     (i18n/label :t/community-kicked-heading)
+       :icon      :i/placeholder
+       :on-layout set-swipeable-height
+       :timestamp (datetime/timestamp->relative timestamp)
+       :unread?   (not read)
+       :context   [[quo/text {:style common-style/user-avatar-tag-text}
+                    (i18n/label :t/community-kicked-body)]
+                   [quo/context-tag common/tag-params {:uri community-image}
+                    community-name]]}]]))

--- a/src/status_im2/contexts/activity_center/notification_types.cljs
+++ b/src/status_im2/contexts/activity_center/notification_types.cljs
@@ -8,6 +8,7 @@
 (def ^:const contact-request 5)
 (def ^:const community-request 7)
 (def ^:const admin 8)
+(def ^:const community-kicked 9)
 (def ^:const contact-verification 10)
 
 (def ^:const all-supported
@@ -18,6 +19,7 @@
     contact-request
     community-request
     admin
+    community-kicked
     contact-verification})
 
 ;; TODO: Replace with correct enum values once status-go implements them.
@@ -29,4 +31,5 @@
   it doesn't have a corresponding type in the backend. Think of the collection
   as a composite key of actual types."
   #{private-group-chat
-    community-request})
+    community-request
+    community-kicked})

--- a/src/status_im2/contexts/activity_center/view.cljs
+++ b/src/status_im2/contexts/activity_center/view.cljs
@@ -14,6 +14,8 @@
             [status-im2.contexts.activity-center.notification.reply.view :as reply]
             [status-im2.contexts.activity-center.notification.community-request.view :as
              community-request]
+            [status-im2.contexts.activity-center.notification.community-kicked.view :as
+             community-kicked]
             [status-im2.contexts.activity-center.style :as style]
             [utils.i18n :as i18n]
             [utils.re-frame :as rf]
@@ -202,6 +204,8 @@
              types/private-group-chat [membership/view props]
 
              types/community-request  [community-request/view props]
+
+             types/community-kicked   [community-kicked/view props]
 
              nil)
 

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.147.1",
-    "commit-sha1": "213dc463bcc1ae449bc78b6cf7c598c4f68830c5",
-    "src-sha256": "1q00agdsqc4p16l8d5cv88gwfnpnl7bb61mayc3520c82hw93q3r"
+    "version": "fix/community-kicked-notification",
+    "commit-sha1": "20898097c7d9f49c0279e4f9765e806c3a4caec9",
+    "src-sha256": "109k8ww5spd2prv5mz24ls5b2z0nzpj3p0ir1h15xawp9p4r6w29"
 }

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "fix/community-kicked-notification",
-    "commit-sha1": "d68980d48d50d82ed85e1bcfc4994e47fc17b11d",
-    "src-sha256": "05sa27f6wfq5p7kka8bj4j85l0qwsy8b5ihmjjnd73rg02gpc68h"
+    "version": "v0.148.1",
+    "commit-sha1": "78d7d5e2d4826e0240bd1ba70105de5155704eac",
+    "src-sha256": "1bkk8blmhz0rzld5i0ilm5l37h5sbdhxmhw8g11wlwmm640labb2"
 }

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -4,6 +4,6 @@
     "owner": "status-im",
     "repo": "status-go",
     "version": "fix/community-kicked-notification",
-    "commit-sha1": "20898097c7d9f49c0279e4f9765e806c3a4caec9",
-    "src-sha256": "109k8ww5spd2prv5mz24ls5b2z0nzpj3p0ir1h15xawp9p4r6w29"
+    "commit-sha1": "d68980d48d50d82ed85e1bcfc4994e47fc17b11d",
+    "src-sha256": "05sa27f6wfq5p7kka8bj4j85l0qwsy8b5ihmjjnd73rg02gpc68h"
 }

--- a/translations/en.json
+++ b/translations/en.json
@@ -2079,5 +2079,7 @@
     "community-request-not-accepted-body-text-prefix": "Your request to join",
     "community-request-not-accepted-body-text-suffix": "hasn't been accepted",
     "community-request-pending": "Request pending",
-    "community-request-pending-body-text": "You requested to join"
+    "community-request-pending-body-text": "You requested to join",
+    "community-kicked-heading": "Kicked from community",
+    "community-kicked-body": "You were kicked from"
 }


### PR DESCRIPTION
fixes #15733

### Summary

This PR implements the `Kicked from community` notification in Activity Center

#### Platforms

- Android
- iOS

### Steps to test

#### Prerequisites:  User `A` and User `B` are mutual contacts. User `A`  is an admin of a closed community and user `B` is a member.

- User `A` kicks out user `B` from the Community
- User `B` receives a notification in Activity Center that he/she has been kicked out.

status: ready 
