### PR TITLE
On password creation screen make the password disclaimer tappable

### DIFF
--- a/src/quo2/components/selectors/disclaimer/view.cljs
+++ b/src/quo2/components/selectors/disclaimer/view.cljs
@@ -5,15 +5,17 @@
             [react-native.core :as rn]))
 
 (defn view
-  [{:keys [checked? blur? on-change accessibility-label container-style]} label]
-  [rn/view
-   {:style (merge container-style (style/container blur?))}
-   [selectors/checkbox
-    {:accessibility-label accessibility-label
-     :blur?               blur?
-     :checked?            checked?
-     :on-change           on-change}]
-   [text/text
-    {:size  :paragraph-2
-     :style style/text}
-    label]])
+  [{:keys [checked? blur? accessibility-label container-style on-change]} label]
+  [rn/touchable-opacity
+   {:on-press            on-change
+    :accessibility-label "disclaimer-touchable-opacity"}
+   [rn/view {:style (merge container-style (style/container blur?))}
+    [selectors/checkbox
+     {:accessibility-label accessibility-label
+      :blur?               blur?
+      :checked?            checked?
+      :on-change           on-change}]
+    [text/text
+     {:size  :paragraph-2
+      :style style/text}
+     label]]])

--- a/src/status_im2/contexts/onboarding/create_password/view.cljs
+++ b/src/status_im2/contexts/onboarding/create_password/view.cljs
@@ -166,7 +166,7 @@
           [rn/view {:style style/disclaimer-container}
            [quo/disclaimer
             {:blur?     true
-             :on-change #(reset! accepts-disclaimer? %)
+             :on-change #(swap! accepts-disclaimer? not)
              :checked?  @accepts-disclaimer?}
             (i18n/label :t/password-creation-disclaimer)]]
 


### PR DESCRIPTION
This PR solves a tiny UX issue on password creation screens.
Currently the password disclaimer is a tiny checkbox which has a very small tappable area : 

![Screenshot_20230426-163632](https://user-images.githubusercontent.com/64726664/234567378-bdd3acf7-250a-4c92-9fdb-24933f9397c3.jpeg)

This PR makes the entire row tappable so that its easier for the users to just tap the disclaimer and move forward.

https://user-images.githubusercontent.com/64726664/234567647-fb381494-4d45-47c2-ba33-079ca8f8b6fe.mov

#### Platforms
- Android
- iOS

#### Areas that maybe impacted
Onboarding

fixes : https://github.com/status-im/status-mobile/issues/15662

status: ready
