### PR TITLE
fix: keyboard is not closing when opening album selector

### DIFF
--- a/src/status_im2/contexts/chat/messages/composer/controls/view.cljs
+++ b/src/status_im2/contexts/chat/messages/composer/controls/view.cljs
@@ -43,6 +43,7 @@
   [insets]
   [quo/button
    {:on-press (fn []
+                (rf/dispatch [:dismiss-keyboard])
                 (permissions/request-permissions
                  {:permissions [:read-external-storage :write-external-storage]
                   :on-allowed  #(rf/dispatch [:open-modal :photo-selector {:insets insets}])


### PR DESCRIPTION
Fixes #15511

### How to test
1. Open chat
2. Click on the message input box to open the keyboard
3. Click on the 'album' icon to launch the album selector - the keyboard should close automatically.

status: ready