### PR TITLE
Improve dissmiss all overlays

### DIFF
--- a/src/react_native/navigation.cljs
+++ b/src/react_native/navigation.cljs
@@ -41,10 +41,6 @@
   [comp]
   (.catch (.dismissOverlay Navigation comp) #()))
 
-(defn dissmiss-all-overlays
-  []
-  (.catch (.dismissAllOverlays Navigation) #()))
-
 (defn reg-app-launched-listener
   [handler]
   (.registerAppLaunchedListener ^js (.events ^js Navigation) handler))

--- a/src/status_im2/common/toasts/events.cljs
+++ b/src/status_im2/common/toasts/events.cljs
@@ -45,3 +45,11 @@
             (update-in [:db :toasts] assoc :hide-toasts-timer-set true)
             (assoc :dispatch-later [{:ms 500 :dispatch [:toasts/hide-with-check]}]))
         effect))))
+
+(rf/defn close-all-toasts
+  {:events [:toasts/close-all-toasts]}
+  [{:keys [db]}]
+  {:dispatch-n (reduce (fn [acc toast]
+                         (conj acc [:toasts/close (key toast)]))
+                       []
+                       (get-in db [:toasts :toasts]))})

--- a/src/status_im2/navigation/core.cljs
+++ b/src/status_im2/navigation/core.cljs
@@ -160,8 +160,6 @@
 ;; OVERLAY
 (def dissmiss-overlay navigation/dissmiss-overlay)
 
-(def dissmiss-all-overlays navigation/dissmiss-all-overlays)
-
 (defn show-overlay
   ([comp] (show-overlay comp {}))
   ([comp opts]
@@ -174,8 +172,6 @@
                                             :orientation              :portrait}
                                   :overlay {:interceptTouchOutside true}}
                                  opts)}})))
-
-(re-frame/reg-fx :dissmiss-all-overlays-fx dissmiss-all-overlays)
 
 ;; toast
 (navigation/register-component "toasts" (fn [] views/toasts) js/undefined)

--- a/src/status_im2/navigation/events.cljs
+++ b/src/status_im2/navigation/events.cljs
@@ -143,8 +143,14 @@
 (rf/defn dismiss-all-overlays
   {:events [:dissmiss-all-overlays]}
   [{:keys [db]}]
-  {:dissmiss-all-overlays-fx nil
-   :db                       (-> db
-                                 (dissoc :popover/popover)
-                                 (dissoc :visibility-status-popover/popover)
-                                 (assoc-in [:bottom-sheet :hide?] true))})
+  {:dispatch-n [[:hide-popover]
+                [:hide-visibility-status-popover]
+                [:hide-bottom-sheet]
+                [:bottom-sheet-hidden]
+                [:hide-wallet-connect-sheet]
+                [:hide-wallet-connect-success-sheet]
+                [:hide-wallet-connect-app-management-sheet]
+                [:hide-signing-sheet]
+                [:hide-select-acc-sheet]
+                [:bottom-sheet/hide-old-navigation-overlay]
+                [:toasts/close-all-toasts]]})


### PR DESCRIPTION
fixes: https://github.com/status-im/status-mobile/issues/15771

### Summary
There are too many overlay views, and all have their own effects for closing.
So function like `dismissAllOverlays` is not enough.

### Testing
Please test theme changes with all overlay types
- bottom sheet (messaging & communities, they use different overlays)
- popover like chat qr code
- visibility status popover
- toasts (Quo preview can be used for creating toast)