### PR TITLE
fix Home-stack overlaps bottom tabs in Xiaomi devices on first run

### DIFF
--- a/src/status_im2/contexts/shell/view.cljs
+++ b/src/status_im2/contexts/shell/view.cljs
@@ -1,14 +1,12 @@
 (ns status-im2.contexts.shell.view
   (:require [utils.i18n :as i18n]
             [quo2.core :as quo]
-            [oops.core :refer [oget]]
             [quo2.foundations.colors :as colors]
             [react-native.core :as rn]
             [react-native.blur :as blur]
             [react-native.linear-gradient :as linear-gradient]
             [react-native.safe-area :as safe-area]
             [status-im2.common.home.view :as common.home]
-            [status-im.async-storage.core :as async-storage]
             [status-im2.contexts.shell.animation :as animation]
             [status-im2.contexts.shell.bottom-tabs :as bottom-tabs]
             [status-im2.contexts.shell.cards.view :as switcher-cards]
@@ -112,32 +110,11 @@
        :style {:margin-top top
                :z-index    2}}]]))
 
-(defn on-layout
-  [evt]
-  (let [dimensions (rf/sub [:dimensions/window])
-        height     (or (oget evt "nativeEvent" "layout" "height") 0)
-        width      (or (oget evt "nativeEvent" "layout" "width") 0)]
-    ;; Layout height calculation
-    ;; 1. Make sure height is more than width, and on-layout is not fired while the
-    ;; screen is horizontal
-    ;; 2. Initialize values with 0 in case of nil
-    ;; 3. In the case of notch devices, the dimensions height will be smaller than
-    ;; on-layout,
-    ;; (without status bar height included)
-    ;; https://github.com/status-im/status-mobile/issues/14633
-    ;; 4. In the case of devices without a notch, both heights should be the same,
-    ;; but actual values differ in some pixels, so arbitrary 5 pixels is allowed
-    (when (and (> height width)
-               (>= (+ height 5) (or (:height dimensions) 0)))
-      (reset! animation/screen-height height)
-      (async-storage/set-item! :screen-height height))))
-
 (defn f-shell-stack
   []
   (let [shared-values (animation/calculate-shared-values)]
     [rn/view
-     {:style     {:flex 1}
-      :on-layout on-layout}
+     {:style {:flex 1}}
      [shell]
      [bottom-tabs/bottom-tabs]
      [:f> home-stack/f-home-stack]


### PR DESCRIPTION
fixes: https://github.com/status-im/status-mobile/issues/15164

### Review Notes:
Leftover from https://github.com/status-im/status-mobile/pull/14639#issuecomment-1366995541
Moving screen height to on-boarding, so home-stack height will be correct even for first run.

### Testing
@churik @pavloburykh can you please check if this fixes the home-stack height in xiaomi device and emulator

status: ready