### PR TITLE
[#15663] Recovery phrase onboarding

### DIFF
--- a/src/quo2/components/inputs/recovery_phrase/component_spec.cljs
+++ b/src/quo2/components/inputs/recovery_phrase/component_spec.cljs
@@ -27,12 +27,13 @@
 
   (h/describe "Error text"
     (h/test "Marked when words doesn't satisfy a predicate"
-      (h/render [recovery-phrase/recovery-phrase-input {:mark-errors? true
-                                                        :error-pred   #(>= (count %) 5)}
+      (h/render [recovery-phrase/recovery-phrase-input
+                 {:mark-errors? true
+                  :error-pred   #(>= (count %) 5)}
                  "Text with some error words that don't satisfy the predicate"])
-      (let [children-text-nodes (-> (h/get-by-label-text :recovery-phrase-input)
-                                    (oops/oget "props" "children" "props" "children")
-                                    (js->clj :keywordize-keys true))
+      (let [children-text-nodes            (-> (h/get-by-label-text :recovery-phrase-input)
+                                               (oops/oget "props" "children" "props" "children")
+                                               (js->clj :keywordize-keys true))
             {:keys [ok-words error-words]} (group-by #(if (string? %) :ok-words :error-words)
                                                      children-text-nodes)]
         (h/is-equal (apply str ok-words) "Text with some   that   the ")
@@ -40,12 +41,13 @@
                         ["error" "words" "don't" "satisfy" "predicate"]))))
 
     (h/test "Marked when words exceed the limit given"
-      (h/render [recovery-phrase/recovery-phrase-input {:mark-errors? true
-                                                        :word-limit   4}
+      (h/render [recovery-phrase/recovery-phrase-input
+                 {:mark-errors? true
+                  :word-limit   4}
                  "these are ok words, these words exceed the limit"])
-      (let [children-text-nodes (-> (h/get-by-label-text :recovery-phrase-input)
-                                    (oops/oget "props" "children" "props" "children")
-                                    (js->clj :keywordize-keys true))
+      (let [children-text-nodes            (-> (h/get-by-label-text :recovery-phrase-input)
+                                               (oops/oget "props" "children" "props" "children")
+                                               (js->clj :keywordize-keys true))
             {:keys [ok-words error-words]} (group-by #(if (string? %) :ok-words :error-words)
                                                      children-text-nodes)]
         (h/is-equal (string/trim (apply str ok-words))

--- a/src/quo2/components/inputs/recovery_phrase/component_spec.cljs
+++ b/src/quo2/components/inputs/recovery_phrase/component_spec.cljs
@@ -1,8 +1,69 @@
 (ns quo2.components.inputs.recovery-phrase.component-spec
   (:require [quo2.components.inputs.recovery-phrase.view :as recovery-phrase]
-            [test-helpers.component :as h]))
+            [test-helpers.component :as h]
+            [oops.core :as oops]))
 
 (h/describe "Recovery phrase input"
   (h/test "Default render"
     (h/render [recovery-phrase/recovery-phrase-input {}])
-    (h/is-truthy (h/get-by-label-text :recovery-phrase-input))))
+    (h/is-truthy (h/get-by-label-text :recovery-phrase-input)))
+
+  (h/test "Renders specified text"
+    (let [text-expected "My custom text"]
+      (h/render [recovery-phrase/recovery-phrase-input {} text-expected])
+      (h/is-equal (oops/oget (h/get-by-label-text :recovery-phrase-input) "props" "children")
+                  text-expected)))
+
+  (h/test "Text changes and dispatches on-change-text"
+    (let [new-text       "New text"
+          on-change-mock (h/mock-fn)
+          get-new-text   #(-> % (oops/oget "props" "onChangeText" "mock" "calls") (aget 0 0))]
+      (h/render [recovery-phrase/recovery-phrase-input {:on-change-text on-change-mock}
+                 "Old text"])
+      (h/fire-event :change-text (h/get-by-label-text :recovery-phrase-input) new-text)
+      (h/is-equal (get-new-text (h/get-by-label-text :recovery-phrase-input)) new-text)
+      (h/was-called on-change-mock))))
+
+#_(h/test "Renders specified text"
+    (let [text-expected "Custom text"]
+      (h/render [recovery-phrase/recovery-phrase-input {} text-expected])
+      ;; TODO: investigate how to get the children
+      (prn (js-keys (h/get-by-label-text :recovery-phrase-input)))))
+
+;(h/test "Text changes and dispatches on-change"
+;  (let [new-text       "New text"
+;        on-change-mock (h/mock-fn)]
+;    (h/render [recovery-phrase/recovery-phrase-input {:on-change-text on-change-mock}
+;               ""])
+;    (h/fire-event :change-text (h/get-by-label-text :recovery-phrase-input) new-text)
+;    #_(h/debug (h/get-by-label-text :recovery-phrase-input))
+;    #_(h/was-called on-change-mock)
+;
+;    #_(h/is-truthy (h/get-by-text new-text))))
+
+;(h/describe "Error text"
+;  (h/test "Marked when a word doesn't satisfy a predicate"
+;    (h/render [recovery-phrase/recovery-phrase-input {:mark-errors? true
+;                                                      :error-pred   #(>= (count %) 5)}
+;               "Text with some words satisfying the predicate"])
+;    ;; TODO: filter result to only return the wrong-marked workds
+;    (prn (.children (.props (h/get-by-label-text :recovery-phrase-input)
+;                            (fn [node]
+;                              (string? (.-type node)))))))
+;
+;  #_(h/test "Not marked when `mark-errors?` false"
+;      (h/render [recovery-phrase/recovery-phrase-input {:mark-errors? false
+;                                                        :error-pred   #(>= 4 count)}
+;                 "Text with some words satisfying the predicate"])
+;      ;; TODO: filter result and see that all ar regular words
+;      (h/get-by-label-text :recovery-phrase-input))
+;
+;  #_(h/test "Marked when words exceed the limit given"
+;      (let [ok-words    "Words within the limit"
+;            error-words "Words out of the limit"
+;            words       (str ok-words error-words)]
+;        (h/render [recovery-phrase/recovery-phrase-input {:mark-errors? true
+;                                                          :word-limit   4}
+;                   words]))
+;      ;; TODO: filter result to only return the wrong-marked workds
+;      (h/get-by-label-text :recovery-phrase-input))

--- a/src/quo2/components/inputs/recovery_phrase/view.cljs
+++ b/src/quo2/components/inputs/recovery_phrase/view.cljs
@@ -31,7 +31,8 @@
         set-default #(reset! state :default)]
     (fn [{:keys [customization-color override-theme blur? on-focus on-blur mark-errors?
                  error-pred word-limit]
-          :or   {customization-color :blue}
+          :or   {customization-color :blue
+                 error-pred          (constantly false)}
           :as   props}
          text]
       (let [extra-props (apply dissoc props custom-props)]

--- a/src/status_im2/contexts/onboarding/enter_seed_phrase/style.cljs
+++ b/src/status_im2/contexts/onboarding/enter_seed_phrase/style.cljs
@@ -8,3 +8,7 @@
    :left             0
    :right            0
    :background-color colors/neutral-80-opa-80-blur})
+
+(def input-container
+  {:height            120
+   :margin-horizontal -20})

--- a/src/status_im2/contexts/onboarding/enter_seed_phrase/view.cljs
+++ b/src/status_im2/contexts/onboarding/enter_seed_phrase/view.cljs
@@ -39,9 +39,7 @@
          (i18n/label :t/use-recovery-phrase)]
         [quo/text
          (i18n/label-pluralize (mnemonic/words-count @seed-phrase) :t/words-n)]
-        [rn/view
-         {:style {:height            120
-                  :margin-horizontal -20}}
+        [rn/view {:style style/input-container}
          [quo/recovery-phrase-input
           {:on-change-text      (fn [t]
                                   (reset! seed-phrase (clean-seed-phrase t))

--- a/src/status_im2/contexts/onboarding/enter_seed_phrase/view.cljs
+++ b/src/status_im2/contexts/onboarding/enter_seed_phrase/view.cljs
@@ -1,18 +1,17 @@
 (ns status-im2.contexts.onboarding.enter-seed-phrase.view
-  (:require [quo2.core :as quo]
-            [quo.core :as quo1]
-            [clojure.string :as string]
-            [status-im.ethereum.mnemonic :as mnemonic]
-            [status-im2.constants :as constants]
-            [utils.security.core :as security]
-            [utils.re-frame :as rf]
-            [reagent.core :as reagent]
+  (:require [clojure.string :as string]
+            [quo2.core :as quo]
             [react-native.core :as rn]
             [react-native.safe-area :as safe-area]
-            [status-im2.contexts.onboarding.enter-seed-phrase.style :as style]
+            [reagent.core :as reagent]
+            [status-im.ethereum.mnemonic :as mnemonic]
+            [status-im2.constants :as constants]
             [status-im2.contexts.onboarding.common.background.view :as background]
             [status-im2.contexts.onboarding.common.navigation-bar.view :as navigation-bar]
-            [utils.i18n :as i18n]))
+            [status-im2.contexts.onboarding.enter-seed-phrase.style :as style]
+            [utils.i18n :as i18n]
+            [utils.re-frame :as rf]
+            [utils.security.core :as security]))
 
 (def button-disabled?
   (comp not constants/seed-phrase-valid-length mnemonic/words-count))
@@ -40,20 +39,21 @@
          (i18n/label :t/use-recovery-phrase)]
         [quo/text
          (i18n/label-pluralize (mnemonic/words-count @seed-phrase) :t/words-n)]
-        [:<>
-         [quo1/text-input
+        [rn/view
+         {:style {:height            120
+                  :margin-horizontal -20}}
+         [quo/recovery-phrase-input
           {:on-change-text      (fn [t]
                                   (reset! seed-phrase (clean-seed-phrase t))
                                   (reset! error-message ""))
+           :mark-errors?        true
+           :error-pred          (constantly false)
+           :word-limit          24
            :auto-focus          true
            :accessibility-label :passphrase-input
            :placeholder         (i18n/label :t/seed-phrase-placeholder)
-           :show-cancel         false
-           :bottom-value        40
-           :multiline           true
-           :auto-correct        false
-           :keyboard-type       :visible-password
-           :monospace           true}]]
+           :auto-correct        false}
+          @seed-phrase]]
         [quo/button
          {:disabled (button-disabled? @seed-phrase)
           :on-press #(rf/dispatch [:onboarding-2/seed-phrase-entered

--- a/src/test_helpers/component.cljs
+++ b/src/test_helpers/component.cljs
@@ -192,6 +192,10 @@
   [element]
   (.toBeNull (js/expect element)))
 
+(defn is-equal
+  [element-1 element-2]
+  (.toBe (js/expect element-1) element-2))
+
 (defn was-called
   [mock]
   (.toHaveBeenCalled (js/expect mock)))


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes #15663

### Summary

[comment]: # (Summarise the problem and how the pull request solves it)

This PR adds the recovery phrase input to the onboarding screen:

![image](https://user-images.githubusercontent.com/90291778/236801572-db1df7ac-dd63-470a-8d9c-e2bd611590f3.png)


Also adds pending tests for the Recovery phrase input 

### Review notes
This screen is not looking as defined in designs, that will be addressed in a separate issue (#15476) as well as the behaviour of this input. This input is able to mark errors but that capability is not being used atm in this screen.


#### Platforms
- Android
- iOS

#### Areas that maybe impacted

- Onboarding

### Steps to test

- Open Status in a fresh install 
- I'm new to Status
- Use recovery phrase
- The new input is being used

status: ready 