### PR TITLE
[Fix] Tapable area of user avatar in chat

### DIFF
--- a/src/status_im2/contexts/chat/messages/avatar/view.cljs
+++ b/src/status_im2/contexts/chat/messages/avatar/view.cljs
@@ -9,8 +9,10 @@
         contact      (rf/sub [:contacts/contact-by-address public-key])
         photo-path   (when (seq (:images contact)) (rf/sub [:chats/photo-path public-key]))
         online?      (rf/sub [:visibility-status-updates/online? public-key])]
-    [rn/touchable-without-feedback {:on-press #(rf/dispatch [:chat.ui/show-profile public-key])}
-     [rn/view {:padding-top 2}
+    [rn/view {:style {:padding-top 2}}
+     [rn/touchable-opacity
+      {:active-opacity 1
+       :on-press       #(rf/dispatch [:chat.ui/show-profile public-key])}
       [quo/user-avatar
        {:full-name         display-name
         :profile-picture   photo-path


### PR DESCRIPTION
fixes #15838

### Review notes

`touchable-without-feedback` doesn't work (on-press, styles, ...etc) for some reason if `quo/user-avatar` is the only child. So, I had to change `touchable-without-feedback` to `touchable-opacity`.

### Platforms

- Android
- iOS

### Steps to test

##### Prerequisites: User `A` and `B` are mutual contacts

- Open Status
- User `A` sends a long message in any chat
- User `B` taps on the area below User `A` avatar. 

status: ready
