### PR TITLE
fix: android blur view hash mismatch in some locations

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -234,7 +234,7 @@ PODS:
     - React
   - react-native-blob-util (0.13.18):
     - React-Core
-  - react-native-blur (4.3.2):
+  - react-native-blur (4.3.3):
     - React-Core
   - react-native-camera-kit (8.0.4):
     - React
@@ -706,7 +706,7 @@ SPEC CHECKSUMS:
   React-logger: 85f4ef06b9723714b2dfa5b0e5502b673b271b58
   react-native-background-timer: 1f7d560647b40e6a60b01c452ba29c54bf581fc4
   react-native-blob-util: 600972b1782380a5a7d5db61a3817ea32349dae9
-  react-native-blur: 4db8c7556566df4e8714c1af5762a4ebc99175d5
+  react-native-blur: c6d0a1dc2b4b519f7afe3b14d8151998632b6d18
   react-native-camera-kit: 498a6d111a904834e0824e9073cfadef7303235f
   react-native-cameraroll: 88f4e62d9ecd0e1f253abe4f685474f2ea14bfa2
   react-native-config: 5330c8258265c1e5fdb8c009d2cabd6badd96727

--- a/nix/deps/gradle/deps.json
+++ b/nix/deps/gradle/deps.json
@@ -4680,16 +4680,16 @@
   },
 
   {
-    "path": "com/github/Dimezis/BlurView/version-2.0.2",
+    "path": "com/github/Dimezis/BlurView/version-2.0.3",
     "repo": "https://jitpack.io",
     "files": {
-      "BlurView-version-2.0.2.pom": {
-        "sha1": "7b29beaf53b0e649c9598b61a2ba6432e0d9f63b",
-        "sha256": "002clz76ds41wn2dz5qy57r9xl437dl75zy2nxzrhv4cp45jiypc"
+      "BlurView-version-2.0.3.pom": {
+        "sha1": "678c8558151c1f1f37ab3e5e8baf00f1306ab6f5",
+        "sha256": "1llsi24w3zsmdvs8vgxc8hxm6lqz44a06fjhap33z4lllbyhy1ls"
       },
-      "BlurView-version-2.0.2.aar": {
-        "sha1": "519c2433da424f955c805bbc54466d3b10289466",
-        "sha256": "01rrg39davjar4hld6j0i3rjcajii66z50dpjy668431wchwxs4j"
+      "BlurView-version-2.0.3.aar": {
+        "sha1": "1a6b90b3dbd0714e0f9fd3a09196072c7da300a0",
+        "sha256": "18gbs09yj9z26ccjwzmlc4s12cp9pd4m763msc1y4hyyybizpqq6"
       }
     }
   },
@@ -7131,16 +7131,16 @@
   },
 
   {
-    "path": "com/google/errorprone/error_prone_annotations/2.18.0",
+    "path": "com/google/errorprone/error_prone_annotations/2.19.0",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "error_prone_annotations-2.18.0.pom": {
-        "sha1": "6d7bbfd3d7567e4c18e981a675ecda707e8a2db1",
-        "sha256": "1p5xswxnd9cjz1b2zldws560ld4dlm17c0awb9xr39fcgmwka0cj"
+      "error_prone_annotations-2.19.0.pom": {
+        "sha1": "a97fea6db80189ea6bca7722d4eea86996088f6c",
+        "sha256": "19dcjlah6rlccqq59532811jjs51b5f7rwpq6wys2mhv61g2amgq"
       },
-      "error_prone_annotations-2.18.0.jar": {
-        "sha1": "89b684257096f548fa39a7df9fdaa409d4d4df91",
-        "sha256": "1bjlxady2jg83lmicb2jil2vf6zjm29sj1qvznj8hsc1f75i8s4y"
+      "error_prone_annotations-2.19.0.jar": {
+        "sha1": "a715b4d2e99dc18b8cec61ae98ac79ebecabeb53",
+        "sha256": "1sx8w1b8b3v42027vxqmlrqyirn45w0lvmwrbf46cr641sx54p6b"
       }
     }
   },
@@ -7190,12 +7190,12 @@
   },
 
   {
-    "path": "com/google/errorprone/error_prone_parent/2.18.0",
+    "path": "com/google/errorprone/error_prone_parent/2.19.0",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "error_prone_parent-2.18.0.pom": {
-        "sha1": "b1779a677965027cd2a3de91e61a80102086bb30",
-        "sha256": "1bazw49mb0246s2nbkxvynk3npayk1vq6vzivs8n6imzqycjxwj7"
+      "error_prone_parent-2.19.0.pom": {
+        "sha1": "7c45180241eec291ab6b2088e588097364db7261",
+        "sha256": "0s5asyyrm05h7l85hgm5saxpx5s205ppgky155nc6h9ipq0fgf3j"
       }
     }
   },

--- a/nix/deps/gradle/deps.list
+++ b/nix/deps/gradle/deps.list
@@ -367,7 +367,7 @@ com.facebook.soloader:annotation:0.10.1
 com.facebook.soloader:nativeloader:0.10.1
 com.facebook.soloader:soloader:0.10.1
 com.facebook.yoga:proguard-annotations:1.19.0
-com.github.Dimezis:BlurView:version-2.0.2
+com.github.Dimezis:BlurView:version-2.0.3
 com.github.bumptech.glide:annotations:4.12.0
 com.github.bumptech.glide:compiler:4.12.0
 com.github.bumptech.glide:disklrucache:4.12.0

--- a/nix/deps/gradle/deps.urls
+++ b/nix/deps/gradle/deps.urls
@@ -310,7 +310,7 @@ https://dl.google.com/dl/android/maven2/com/android/zipflinger/4.1.0/zipflinger-
 https://dl.google.com/dl/android/maven2/com/google/android/material/material/1.0.0/material-1.0.0.pom
 https://dl.google.com/dl/android/maven2/com/google/android/material/material/1.2.0-alpha03/material-1.2.0-alpha03.pom
 https://dl.google.com/dl/android/maven2/com/google/test/platform/core-proto/0.0.2-dev/core-proto-0.0.2-dev.pom
-https://jitpack.io/com/github/Dimezis/BlurView/version-2.0.2/BlurView-version-2.0.2.pom
+https://jitpack.io/com/github/Dimezis/BlurView/version-2.0.3/BlurView-version-2.0.3.pom
 https://jitpack.io/com/github/status-im/function/0.0.1/function-0.0.1.pom
 https://jitpack.io/com/github/status-im/status-keycard-java/android/3.1.1/android-3.1.1.pom
 https://jitpack.io/com/github/status-im/status-keycard-java/lib/3.1.1/lib-3.1.1.pom
@@ -475,12 +475,12 @@ https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_annotatio
 https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_annotations/2.2.0/error_prone_annotations-2.2.0.pom
 https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_annotations/2.3.1/error_prone_annotations-2.3.1.pom
 https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_annotations/2.3.2/error_prone_annotations-2.3.2.pom
-https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_annotations/2.18.0/error_prone_annotations-2.18.0.pom
+https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_annotations/2.19.0/error_prone_annotations-2.19.0.pom
 https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_parent/2.0.18/error_prone_parent-2.0.18.pom
 https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_parent/2.2.0/error_prone_parent-2.2.0.pom
 https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_parent/2.3.1/error_prone_parent-2.3.1.pom
 https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_parent/2.3.2/error_prone_parent-2.3.2.pom
-https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_parent/2.18.0/error_prone_parent-2.18.0.pom
+https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_parent/2.19.0/error_prone_parent-2.19.0.pom
 https://repo.maven.apache.org/maven2/com/google/flatbuffers/flatbuffers-java/1.12.0/flatbuffers-java-1.12.0.pom
 https://repo.maven.apache.org/maven2/com/google/google/1/google-1.pom
 https://repo.maven.apache.org/maven2/com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1.pom

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@babel/preset-typescript": "^7.17.12",
     "@react-native-async-storage/async-storage": "^1.17.9",
     "@react-native-community/audio-toolkit": "git+https://github.com/tbenr/react-native-audio-toolkit.git#refs/tags/v2.0.3-status-v6",
-    "@react-native-community/blur": "git+https://github.com/status-im/react-native-blur#refs/tags/v4.3.2-status",
+    "@react-native-community/blur": "git+https://github.com/status-im/react-native-blur#refs/tags/v4.3.3-status",
     "@react-native-community/cameraroll": "git+https://github.com/status-im/react-native-cameraroll.git#refs/tags/v4.0.4-status.0",
     "@react-native-community/clipboard": "^1.2.2",
     "@react-native-community/hooks": "^2.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1921,9 +1921,9 @@
     eventemitter3 "^1.2.0"
     lodash "^4.17.15"
 
-"@react-native-community/blur@git+https://github.com/status-im/react-native-blur#refs/tags/v4.3.2-status":
-  version "4.3.2"
-  resolved "git+https://github.com/status-im/react-native-blur#722940e19c7ac8f90d3fccc5e9d34e0fd2342d51"
+"@react-native-community/blur@git+https://github.com/status-im/react-native-blur#refs/tags/v4.3.3-status":
+  version "4.3.3"
+  resolved "git+https://github.com/status-im/react-native-blur#c140cc8e7d54e3318af0a7c149b5d64b54de3419"
 
 "@react-native-community/cameraroll@git+https://github.com/status-im/react-native-cameraroll.git#refs/tags/v4.0.4-status.0":
   version "4.0.4"


### PR DESCRIPTION
### hash mismatch error
```
error: hash mismatch in fixed-output derivation '/nix/store/7ibyjmr1ldhk6yasab86hyr5r4s6z4sn-BlurView-version-2.0.2.pom.drv':
         specified: sha256-7PooC7mMbJh/t8L/cmg7g9Ce8ikel9+E5YHoZs6nTAA=
            got:    sha256-b4udT2p4zDDqRFpv1UN5TAyaFrluGZ0oyqWoB+jilZo=
error: 1 dependencies of derivation '/nix/store/azg436xwzlnidggv53sbzqwn3r5bvdym-create-local-maven-repo.drv' failed to build
building '/nix/store/digxrrd56wvin0hrn911h13iyr69i3fs-status-go-0.148.3-8608aec-android.drv'...
error: 1 dependencies of derivation '/nix/store/20qfb01rz459ppb5hl0bi7yvj67x20jd-status-mobile-maven-deps.drv' failed to build
error: build of '/nix/store/20qfb01rz459ppb5hl0bi7yvj67x20jd-status-mobile-maven-deps.drv', '/nix/store/36xb3h3w8lbkhhgjvamybc4c8kmx8ji3-gradle-6.9.2.drv', '/nix/store/digxrrd56wvin0hrn911h13iyr69i3fs-status-go-0.148.3-8608aec-android.drv' failed
make: *** [run-android] Error 1
```
### Root cause
A new build was created for [BlurView 2.0.2 version](https://jitpack.io/#Dimezis/BlurView) which updated `https://jitpack.io/com/github/Dimezis/BlurView/version-2.0.2/BlurView-version-2.0.2.pom`. But the old file was cached in some regions resulting in different hash for different region, eg:

region 1:
```bash
❯ curl -s https://jitpack.io/com/github/Dimezis/BlurView/version-2.0.2/BlurView-version-2.0.2.pom | md5sum
61a2197ec93fc31982685ec767066269  - # hash-1
```
region 2:
```bash
 > curl -s https://jitpack.io/com/github/Dimezis/BlurView/version-2.0.2/BlurView-version-2.0.2.pom | md5sum       
8a5f21977372ce4e82279c68b29c1329  - # hash-2
```
`hash-1` and `hash-2` are different, thats how we realised we were getting an outdated version in some regions.

region 2 with a url hack _(added `\?xyz` at the end to bypass the cache)_:
```bash
 > curl -s https://jitpack.io/com/github/Dimezis/BlurView/version-2.0.2/BlurView-version-2.0.2.pom\?xyz | md5sum
61a2197ec93fc31982685ec767066269  - # hash-3 == hash1
```

### Solution
Since this is a caching issue updating the sha won't work because some people may still get the cached version. But we found that the newer `BlurView:version-2.0.3` was not having this issue. So we upgraded BlurView to the newer version.

BlurView 2.0.3 region 1:
```bash
 > curl -s https://jitpack.io/com/github/Dimezis/BlurView/version-2.0.3/BlurView-version-2.0.3.pom | md5sum
2d9a46f9aa2bd8bddcd591eb5af920c0  -
```
BlurView 2.0.3 region 2:
```bash
curl -s https://jitpack.io/com/github/Dimezis/BlurView/version-2.0.3/BlurView-version-2.0.3.pom | md5sum
2d9a46f9aa2bd8bddcd591eb5af920c0  -
```
-----

Related PR: https://github.com/status-im/react-native-blur/pull/3

status: ready