### PR TITLE
Double-tap for communities & fix for 'Recent' tab not being shown as selected if message icon is double tapped

### DIFF
--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -62,7 +62,8 @@
     [status-im2.common.theme.core :as theme]
     [react-native.core :as rn]
     [react-native.platform :as platform]
-    status-im2.contexts.chat.home.events))
+    status-im2.contexts.chat.home.events
+    status-im2.contexts.communities.home.events))
 
 (re-frame/reg-fx
  :dismiss-keyboard

--- a/src/status_im2/contexts/chat/home/view.cljs
+++ b/src/status_im2/contexts/chat/home/view.cljs
@@ -102,7 +102,8 @@
   []
   (fn []
     (let [pending-contact-requests (rf/sub [:activity-center/pending-contact-requests])
-          selected-tab             (or (rf/sub [:messages-home/selected-tab]) :tab/recent)
+          selected-tab             (or (rf/sub [:messages-home/selected-tab])
+                                       :tab/recent)
           top                      (safe-area/get-top)]
       [:<>
        (if (= selected-tab :tab/contacts)
@@ -122,6 +123,7 @@
         [quo/discover-card
          {:title       (i18n/label :t/invite-friends-to-status)
           :description (i18n/label :t/share-invite-link)}]
+        ^{:key (str "tabs-" selected-tab)}
         [quo/tabs
          {:style          style/tabs
           :size           32

--- a/src/status_im2/contexts/communities/home/events.cljs
+++ b/src/status_im2/contexts/communities/home/events.cljs
@@ -1,0 +1,8 @@
+(ns status-im2.contexts.communities.home.events
+  (:require
+    [utils.re-frame :as rf]))
+
+(rf/defn communities-select-tab-event
+  {:events [:communities/select-tab]}
+  [{:keys [db]} tab]
+  {:db (assoc db :communities/selected-tab tab)})

--- a/src/status_im2/contexts/communities/home/view.cljs
+++ b/src/status_im2/contexts/communities/home/view.cljs
@@ -1,7 +1,6 @@
 (ns status-im2.contexts.communities.home.view
   (:require [utils.i18n :as i18n]
             [quo2.core :as quo]
-            [reagent.core :as reagent]
             [react-native.core :as rn]
             [status-im2.common.home.view :as common.home]
             [status-im2.contexts.communities.actions.community-options.view :as options]

--- a/src/status_im2/contexts/communities/home/view.cljs
+++ b/src/status_im2/contexts/communities/home/view.cljs
@@ -35,40 +35,42 @@
 
 (defn home
   []
-  (let [selected-tab (reagent/atom :joined)]
-    (fn []
-      (let [{:keys [joined pending opened]} (rf/sub [:communities/grouped-by-status])
-            selected-items                  (case @selected-tab
-                                              :joined  joined
-                                              :pending pending
-                                              :opened  opened)
-            top                             (safe-area/get-top)]
-        [:<>
-         [rn/flat-list
-          {:key-fn                            :id
-           :content-inset-adjustment-behavior :never
-           :header                            [rn/view {:height (+ 245 top)}]
-           :render-fn                         item-render
-           :data                              selected-items}]
-         [rn/view
-          {:style (style/blur-container top)}
-          [blur/view
-           {:blur-amount (if platform/ios? 20 10)
-            :blur-type   (if (colors/dark?) :dark (if platform/ios? :light :xlight))
-            :style       style/blur}]
-          [common.home/top-nav]
-          [common.home/title-column
-           {:label               (i18n/label :t/communities)
-            :handler             #(rf/dispatch [:show-bottom-sheet {:content actions.home-plus/view}])
-            :accessibility-label :new-chat-button}]
-          [quo/discover-card
-           {:on-press            #(rf/dispatch [:navigate-to :discover-communities])
-            :title               (i18n/label :t/discover)
-            :description         (i18n/label :t/whats-trending)
-            :accessibility-label :communities-home-discover-card}]
-          [quo/tabs
-           {:size           32
-            :style          style/tabs
-            :on-change      #(reset! selected-tab %)
-            :default-active @selected-tab
-            :data           tabs-data}]]]))))
+  (fn []
+    (let [selected-tab                    (or (rf/sub [:communities/selected-tab]) :joined)
+          {:keys [joined pending opened]} (rf/sub [:communities/grouped-by-status])
+          selected-items                  (case selected-tab
+                                            :joined  joined
+                                            :pending pending
+                                            :opened  opened)
+          top                             (safe-area/get-top)]
+      [:<>
+       [rn/flat-list
+        {:key-fn                            :id
+         :content-inset-adjustment-behavior :never
+         :header                            [rn/view {:height (+ 245 top)}]
+         :render-fn                         item-render
+         :data                              selected-items}]
+       [rn/view
+        {:style (style/blur-container top)}
+        [blur/view
+         {:blur-amount (if platform/ios? 20 10)
+          :blur-type   (if (colors/dark?) :dark (if platform/ios? :light :xlight))
+          :style       style/blur}]
+        [common.home/top-nav]
+        [common.home/title-column
+         {:label               (i18n/label :t/communities)
+          :handler             #(rf/dispatch [:show-bottom-sheet {:content actions.home-plus/view}])
+          :accessibility-label :new-chat-button}]
+        [quo/discover-card
+         {:on-press            #(rf/dispatch [:navigate-to :discover-communities])
+          :title               (i18n/label :t/discover)
+          :description         (i18n/label :t/whats-trending)
+          :accessibility-label :communities-home-discover-card}]
+        ^{:key (str "tabs-" selected-tab)}
+        [quo/tabs
+         {:size           32
+          :style          style/tabs
+          :on-change      (fn [tab]
+                            (rf/dispatch [:communities/select-tab tab]))
+          :default-active selected-tab
+          :data           tabs-data}]]])))

--- a/src/status_im2/contexts/shell/bottom_tabs.cljs
+++ b/src/status_im2/contexts/shell/bottom_tabs.cljs
@@ -31,25 +31,31 @@
 
 (defn- f-bottom-tabs
   []
-  (let [notifications-data          (rf/sub [:shell/bottom-tabs-notifications-data])
-        pass-through?               (rf/sub [:shell/shell-pass-through?])
-        shared-values               @animation/shared-values-atom
-        original-style              (style/bottom-tabs-container pass-through?)
-        animated-style              (reanimated/apply-animations-to-style
-                                     {:height (:bottom-tabs-height shared-values)}
-                                     original-style)
-        messages-double-tap-gesture (-> (gesture/gesture-tap)
-                                        (gesture/number-of-taps 2)
-                                        (gesture/on-start
-                                         (fn [_event]
-                                           (rf/dispatch [:messages-home/select-tab :tab/recent]))))]
+  (let [notifications-data             (rf/sub [:shell/bottom-tabs-notifications-data])
+        pass-through?                  (rf/sub [:shell/shell-pass-through?])
+        shared-values                  @animation/shared-values-atom
+        original-style                 (style/bottom-tabs-container pass-through?)
+        animated-style                 (reanimated/apply-animations-to-style
+                                        {:height (:bottom-tabs-height shared-values)}
+                                        original-style)
+        communities-double-tab-gesture (-> (gesture/gesture-tap)
+                                           (gesture/number-of-taps 2)
+                                           (gesture/on-start
+                                            (fn [_event]
+                                              (rf/dispatch [:communities/select-tab :joined]))))
+        messages-double-tap-gesture    (-> (gesture/gesture-tap)
+                                           (gesture/number-of-taps 2)
+                                           (gesture/on-start
+                                            (fn [_event]
+                                              (rf/dispatch [:messages-home/select-tab :tab/recent]))))]
     (animation/load-stack @animation/selected-stack-id)
     (reanimated/set-shared-value (:pass-through? shared-values) pass-through?)
     [reanimated/view {:style animated-style}
      (when pass-through?
        [blur/view (blur-overlay-params style/bottom-tabs-blur-overlay)])
      [rn/view {:style (style/bottom-tabs)}
-      [bottom-tab :i/communities :communities-stack shared-values notifications-data]
+      [gesture/gesture-detector {:gesture communities-double-tab-gesture}
+       [bottom-tab :i/communities :communities-stack shared-values notifications-data]]
       [gesture/gesture-detector {:gesture messages-double-tap-gesture}
        [bottom-tab :i/messages :chats-stack shared-values notifications-data]]
       [bottom-tab :i/wallet :wallet-stack shared-values notifications-data]

--- a/src/status_im2/subs/root.cljs
+++ b/src/status_im2/subs/root.cljs
@@ -249,6 +249,7 @@
 (reg-root-key-sub :communities/resolve-community-info :communities/resolve-community-info)
 (reg-root-key-sub :communities/my-pending-requests-to-join :communities/my-pending-requests-to-join)
 (reg-root-key-sub :communities/collapsed-categories :communities/collapsed-categories)
+(reg-root-key-sub :communities/selected-tab :communities/selected-tab)
 
 (reg-root-key-sub :activity-center :activity-center)
 


### PR DESCRIPTION
fixes #15810 

Also implements https://github.com/status-im/status-mobile/issues/15569 but for communities.

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

status: ready <!-- Can be ready or wip -->
