### PR TITLE
ci: bump timeout for tests to 15 minutes

### DIFF
--- a/ci/Jenkinsfile.tests
+++ b/ci/Jenkinsfile.tests
@@ -9,7 +9,7 @@ pipeline {
   options {
     timestamps()
     /* Prevent Jenkins jobs from running forever */
-    timeout(time: 10, unit: 'MINUTES')
+    timeout(time: 15, unit: 'MINUTES')
     /* Limit builds retained */
     buildDiscarder(logRotator(
       numToKeepStr: '10',


### PR DESCRIPTION
We've been seing longer runs on release CI for nightlies, possibly due to more than 2 parallel builds running on one host.

![image](https://github.com/status-im/status-mobile/assets/2212681/36f08853-9143-49c1-b57f-e34669768ee5)

https://ci.infra.status.im/job/status-mobile/job/platforms/job/tests/