### PR TITLE
feat: store avatar with ring into account db for lock screen [WIP]

### DIFF
--- a/src/status_im2/subs/multiaccount.cljs
+++ b/src/status_im2/subs/multiaccount.cljs
@@ -4,10 +4,9 @@
             [re-frame.core :as re-frame]
             [status-im.ethereum.core :as ethereum]
             [status-im.fleet.core :as fleet]
+            [status-im.multiaccounts.core :as multiaccount.core]
             [status-im.multiaccounts.db :as multiaccounts.db]
-            [utils.image-server :as image-server]
-            [utils.security.core :as security]
-            [quo2.theme :as theme]))
+            [utils.security.core :as security]))
 
 (re-frame/reg-sub
  :multiaccount/public-key
@@ -206,30 +205,12 @@
  (fn [multiaccount]
    (pos? (count (get multiaccount :images)))))
 
-(defn- replace-multiaccount-image-uri
-  [multiaccount port]
-  (let [public-key (:public-key multiaccount)
-        theme      (theme/get-theme)
-        images     (:images multiaccount)
-        images     (reduce (fn [acc current]
-                             (let [key-uid    (:keyUid current)
-                                   image-name (:type current)
-                                   uri        (image-server/get-account-image-uri port
-                                                                                  public-key
-                                                                                  image-name
-                                                                                  key-uid
-                                                                                  theme)]
-                               (conj acc (assoc current :uri uri))))
-                           []
-                           images)]
-    (assoc multiaccount :images images)))
-
 (re-frame/reg-sub
  :profile/multiaccount
  :<- [:multiaccount]
  :<- [:mediaserver/port]
  (fn [[multiaccount port]]
-   (replace-multiaccount-image-uri multiaccount port)))
+   (multiaccount.core/replace-multiaccount-image-uri multiaccount port)))
 
 ;; LINK PREVIEW
 ;; ========================================================================================================


### PR DESCRIPTION
-------

fixes sub issue 1 in https://github.com/status-im/status-mobile/issues/15788

### Summary

- the problem:
we want identity ring before login
but there's no media server before login and identity ring are dynamically generated through media server

- the solution:
1. store the identicon with identity ring once pubkey generated into account db
2. store the user uploaded avatar with identity ring on custom avatar set

- wip
1. there's dark/light version of identicon but lock screen is always dark
2. need changes in status-go https://github.com/status-im/status-go/pull/3473 so that it can accept media server image url, which is served using a self signed cert

status: wip <!-- Can be ready or wip -->