### PR TITLE
[#15779] Disable input after login

### DIFF
--- a/src/status_im2/contexts/onboarding/events.cljs
+++ b/src/status_im2/contexts/onboarding/events.cljs
@@ -1,17 +1,16 @@
 (ns status-im2.contexts.onboarding.events
   (:require
-    [utils.re-frame :as rf]
-    [taoensso.timbre :as log]
+    [clojure.string :as string]
+    [native-module.core :as native-module]
     [re-frame.core :as re-frame]
+    [status-im.ethereum.core :as ethereum]
     [status-im.utils.types :as types]
     [status-im2.config :as config]
-    [clojure.string :as string]
-    [utils.i18n :as i18n]
-    [utils.security.core :as security]
-    [native-module.core :as native-module]
-    [status-im.ethereum.core :as ethereum]
     [status-im2.constants :as constants]
-    [status-im2.contexts.onboarding.profiles.view :as profiles.view]))
+    [taoensso.timbre :as log]
+    [utils.i18n :as i18n]
+    [utils.re-frame :as rf]
+    [utils.security.core :as security]))
 
 (re-frame/reg-fx
  :multiaccount/create-account-and-login

--- a/src/status_im2/contexts/onboarding/events.cljs
+++ b/src/status_im2/contexts/onboarding/events.cljs
@@ -140,12 +140,10 @@
      {:title               (i18n/label :t/multiaccount-exists-title)
       :content             (i18n/label :t/multiaccount-exists-content)
       :confirm-button-text (i18n/label :t/unlock)
-      :on-accept           #(do
-                              (re-frame/dispatch [:pop-to-root :profiles])
-                              ;; FIXME(rasom): obviously not cool
-                              (reset! profiles.view/show-profiles? false)
-                              (re-frame/dispatch
-                               [:multiaccounts.login.ui/multiaccount-selected key-uid]))
+      :on-accept           (fn []
+                             (re-frame/dispatch [:pop-to-root :profiles])
+                             (re-frame/dispatch
+                              [:multiaccounts.login.ui/multiaccount-selected key-uid]))
       :on-cancel           #(re-frame/dispatch [:pop-to-root :multiaccounts])}}
     {:db       (assoc-in db [:onboarding-2/profile :seed-phrase] seed-phrase)
      :dispatch [:navigate-to :create-profile]}))

--- a/src/status_im2/contexts/onboarding/profiles/view.cljs
+++ b/src/status_im2/contexts/onboarding/profiles/view.cljs
@@ -184,6 +184,7 @@
        :type                :blur-bg
        :icon                true
        :on-press            set-show-profiles
+       :disabled            processing
        :override-theme      :dark
        :width               32
        :accessibility-label :show-profiles
@@ -222,6 +223,7 @@
       {:size                40
        :type                :ghost
        :before              :i/info
+       :disabled            processing
        :accessibility-label :forget-password-button
        :override-theme      :dark
        :style               style/forget-password-button

--- a/src/status_im2/contexts/onboarding/profiles/view.cljs
+++ b/src/status_im2/contexts/onboarding/profiles/view.cljs
@@ -12,8 +12,6 @@
             [utils.security.core :as security]
             [utils.transforms :as types]))
 
-(def show-profiles? (reagent/atom false))
-
 (defn login-multiaccount
   []
   (rf/dispatch [:multiaccounts.login.ui/password-input-submitted]))
@@ -43,14 +41,14 @@
     :context             context
     :button-text         (i18n/label :t/remove)
     :close-button-text   (i18n/label :t/cancel)
-    :on-press            #(do
-                            (rf/dispatch [:hide-bottom-sheet])
-                            (native-module/delete-multiaccount
-                             key-uid
-                             (fn [result]
-                               (let [{:keys [error]} (types/json->clj result)]
-                                 (rf/dispatch [:onboarding-2/on-delete-profile-success key-uid])
-                                 (log/info "profile deleted: error" error)))))}])
+    :on-press            (fn []
+                           (rf/dispatch [:hide-bottom-sheet])
+                           (native-module/delete-multiaccount
+                            key-uid
+                            (fn [result]
+                              (let [{:keys [error]} (types/json->clj result)]
+                                (rf/dispatch [:onboarding-2/on-delete-profile-success key-uid])
+                                (log/info "profile deleted: error" error)))))}])
 
 (defn show-confirmation
   [key-uid context]
@@ -72,7 +70,9 @@
                 {:content (fn [] [profile-options key-uid context])}]))
 
 (defn profile-card
-  [{:keys [name key-uid customization-color keycard-pairing last-index] :as multiaccount} index]
+  [{:keys [name key-uid customization-color keycard-pairing last-index set-hide-profiles]
+    :as   multiaccount}
+   index]
   (let [last-item?      (= last-index index)
         profile-picture (:uri (first (:images multiaccount)))]
     [quo/profile-card
@@ -89,15 +89,18 @@
                               {:name            name
                                :color           customization-color
                                :profile-picture profile-picture})
-      :on-card-press        #(do
-                               (rf/dispatch
-                                [:multiaccounts.login.ui/multiaccount-selected key-uid])
-                               (when-not keycard-pairing (reset! show-profiles? false)))}]))
+      :on-card-press        (fn []
+                              (rf/dispatch
+                               [:multiaccounts.login.ui/multiaccount-selected key-uid])
+                              (when-not keycard-pairing (set-hide-profiles)))}]))
 
 (defn profiles-section
-  []
+  [{:keys [set-hide-profiles]}]
   (let [multiaccounts (vals (rf/sub [:multiaccounts/multiaccounts]))
-        multiaccounts (map #(assoc % :last-index (- (count multiaccounts) 1)) multiaccounts)]
+        profiles-data (map #(assoc %
+                                   :last-index        (- (count multiaccounts) 1)
+                                   :set-hide-profiles set-hide-profiles)
+                           multiaccounts)]
     [rn/view
      {:style style/profiles-container}
      [rn/view
@@ -116,7 +119,7 @@
         :override-theme      :dark}
        :main-icons/add]]
      [rn/flat-list
-      {:data                    (sort-by :timestamp > multiaccounts)
+      {:data                    (sort-by :timestamp > profiles-data)
        :key-fn                  :key-uid
        :content-container-style {:padding-bottom 20}
        :render-fn               profile-card}]]))
@@ -169,18 +172,18 @@
        (i18n/label :t/forgot-your-password-info-create-new-password-description)]]]]])
 
 (defn login-section
-  []
+  [{:keys [set-show-profiles]}]
   (let [{:keys [name customization-color error processing password]
          :as   multiaccount} (rf/sub [:multiaccounts/login])
-        sign-in-enabled? (rf/sub [:sign-in-enabled?])
-        profile-picture  (:uri (first (:images multiaccount)))]
+        sign-in-enabled?     (rf/sub [:sign-in-enabled?])
+        profile-picture      (:uri (first (:images multiaccount)))]
     [rn/keyboard-avoiding-view
      {:style style/login-container}
      [quo/button
       {:size                32
        :type                :blur-bg
        :icon                true
-       :on-press            #(reset! show-profiles? true)
+       :on-press            set-show-profiles
        :override-theme      :dark
        :width               32
        :accessibility-label :show-profiles
@@ -239,10 +242,12 @@
 
 (defn views
   []
-  (reset! show-profiles? false)
-  (fn []
-    [:<>
-     [background/view true]
-     (if @show-profiles?
-       [profiles-section]
-       [login-section])]))
+  (let [show-profiles?    (reagent/atom false)
+        set-show-profiles #(reset! show-profiles? true)
+        set-hide-profiles #(reset! show-profiles? false)]
+    (fn []
+      [:<>
+       [background/view true]
+       (if @show-profiles?
+         [profiles-section {:set-hide-profiles set-hide-profiles}]
+         [login-section {:set-show-profiles set-show-profiles}])])))

--- a/src/status_im2/contexts/onboarding/profiles/view.cljs
+++ b/src/status_im2/contexts/onboarding/profiles/view.cljs
@@ -197,13 +197,11 @@
       [quo/input
        {:type              :password
         :blur?             true
-        :override-theme    :dark
         :disabled?         processing
         :placeholder       (i18n/label :t/type-your-password)
         :auto-focus        true
         :error?            (when (not-empty error) error)
         :label             (i18n/label :t/profile-password)
-        :secure-text-entry true
         :on-change-text    (fn [password]
                              (rf/dispatch-sync [:set-in [:multiaccounts/login :password]
                                                 (security/mask-data password)])

--- a/src/status_im2/contexts/onboarding/profiles/view.cljs
+++ b/src/status_im2/contexts/onboarding/profiles/view.cljs
@@ -200,7 +200,7 @@
         :disabled?         processing
         :placeholder       (i18n/label :t/type-your-password)
         :auto-focus        true
-        :error?            (when (not-empty error) error)
+        :error?            (seq error)
         :label             (i18n/label :t/profile-password)
         :on-change-text    (fn [password]
                              (rf/dispatch-sync [:set-in [:multiaccounts/login :password]
@@ -208,7 +208,7 @@
                              (rf/dispatch [:set-in [:multiaccounts/login :error] ""]))
         :value             (security/safe-unmask-data password)
         :on-submit-editing (when sign-in-enabled? login-multiaccount)}]
-      (when (not-empty error)
+      (when (seq error)
         [quo/info-message
          {:type  :error
           :size  :default

--- a/src/status_im2/contexts/onboarding/profiles/view.cljs
+++ b/src/status_im2/contexts/onboarding/profiles/view.cljs
@@ -206,10 +206,10 @@
         :error?            (seq error)
         :label             (i18n/label :t/profile-password)
         :on-change-text    (fn [password]
-                             (rf/dispatch-sync [:set-in [:multiaccounts/login :password]
-                                                (security/mask-data password)])
+                             (rf/dispatch [:set-in [:multiaccounts/login :password]
+                                           (security/mask-data password)])
                              (rf/dispatch [:set-in [:multiaccounts/login :error] ""]))
-        :value             (security/safe-unmask-data password)
+        :default-value     (security/safe-unmask-data password)
         :on-submit-editing (when sign-in-enabled? login-multiaccount)}]
       (when (seq error)
         [quo/info-message

--- a/src/status_im2/contexts/onboarding/profiles/view.cljs
+++ b/src/status_im2/contexts/onboarding/profiles/view.cljs
@@ -170,10 +170,10 @@
 
 (defn login-section
   []
-  (let [{:keys [name customization-color error processing]
+  (let [{:keys [name customization-color error processing password]
          :as   multiaccount} (rf/sub [:multiaccounts/login])
-        sign-in-enabled?     (rf/sub [:sign-in-enabled?])
-        profile-picture      (:uri (first (:images multiaccount)))]
+        sign-in-enabled? (rf/sub [:sign-in-enabled?])
+        profile-picture  (:uri (first (:images multiaccount)))]
     [rn/keyboard-avoiding-view
      {:style style/login-container}
      [quo/button
@@ -198,15 +198,17 @@
        {:type              :password
         :blur?             true
         :override-theme    :dark
+        :disabled?         processing
         :placeholder       (i18n/label :t/type-your-password)
         :auto-focus        true
         :error?            (when (not-empty error) error)
         :label             (i18n/label :t/profile-password)
         :secure-text-entry true
         :on-change-text    (fn [password]
-                             (rf/dispatch [:set-in [:multiaccounts/login :password]
-                                           (security/mask-data password)])
+                             (rf/dispatch-sync [:set-in [:multiaccounts/login :password]
+                                                (security/mask-data password)])
                              (rf/dispatch [:set-in [:multiaccounts/login :error] ""]))
+        :value             (security/safe-unmask-data password)
         :on-submit-editing (when sign-in-enabled? login-multiaccount)}]
       (when (not-empty error)
         [quo/info-message

--- a/src/utils/re_frame.cljs
+++ b/src/utils/re_frame.cljs
@@ -84,4 +84,3 @@
 (def sub (comp deref re-frame/subscribe))
 
 (def dispatch re-frame/dispatch)
-(def dispatch-sync re-frame/dispatch-sync)

--- a/src/utils/re_frame.cljs
+++ b/src/utils/re_frame.cljs
@@ -84,3 +84,4 @@
 (def sub (comp deref re-frame/subscribe))
 
 (def dispatch re-frame/dispatch)
+(def dispatch-sync re-frame/dispatch-sync)


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes #15779

### Summary

[comment]: # (Summarise the problem and how the pull request solves it)

This PR disables the input component in the unlock app screen while logging in.

### Review notes
I refactored the code a little, better explanation in this PR comments


#### Platforms

- Android
- iOS

#### Areas that maybe impacted

Onboarding

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open Status
- Keep in the unlock the app screen:
![image](https://github.com/status-im/status-mobile/assets/90291778/b73b2718-4031-4975-bce8-3646afffdbda)
- Log-in and while the info is being sent, the password input will be disabled.

status: ready
