### PR TITLE
Composer polishing

### DIFF
--- a/src/status_im2/contexts/chat/composer/actions/view.cljs
+++ b/src/status_im2/contexts/chat/composer/actions/view.cljs
@@ -58,9 +58,9 @@
     :i/arrow-up]])
 
 (defn send-button
-  [state animations window-height images?]
+  [{:keys [text-value] :as state} animations window-height images?]
   (let [btn-opacity (reanimated/use-shared-value 0)
-        z-index     (reagent/atom 0)]
+        z-index     (reagent/atom (if (and (empty? @text-value) (not images?)) 0 1))]
     [:f> f-send-button state animations window-height images? btn-opacity z-index]))
 
 (defn audio-button
@@ -176,7 +176,7 @@
    :i/format])
 
 (defn view
-  [props state animations window-height insets edit? images?]
+  [props state animations window-height insets {:keys [edit images]}]
   [rn/view {:style style/actions-container}
    [rn/view
     {:style {:flex-direction :row
@@ -185,6 +185,6 @@
     [image-button props animations insets]
     [reaction-button]
     [format-button]]
-   [:f> send-button state animations window-height images?]
-   (when (and (not edit?) (not images?))
+   [:f> send-button state animations window-height images]
+   (when (and (not edit) (not images))
      [audio-button props state animations])])

--- a/src/status_im2/contexts/chat/composer/effects.cljs
+++ b/src/status_im2/contexts/chat/composer/effects.cljs
@@ -91,8 +91,7 @@
   (.remove ^js @keyboard-frame-listener))
 
 (defn initialize
-  [props state animations {:keys [max-height] :as dimensions} chat-input images? reply?
-   audio]
+  [props state animations {:keys [max-height] :as dimensions} {:keys [chat-input images reply audio]}]
   (rn/use-effect
    (fn []
      (maximized-effect state animations dimensions chat-input)
@@ -100,9 +99,9 @@
      (layout-effect state)
      (kb-default-height-effect state)
      (background-effect state animations dimensions chat-input)
-     (images-effect props animations images?)
+     (images-effect props animations images)
      (audio-effect state animations audio)
-     (empty-effect state animations images? reply? audio)
+     (empty-effect state animations images reply audio)
      (kb/add-kb-listeners props state animations dimensions)
      #(component-will-unmount props))
    [max-height]))
@@ -110,7 +109,7 @@
 (defn edit
   [{:keys [input-ref]}
    {:keys [text-value saved-cursor-position]}
-   edit]
+   {:keys [edit]}]
   (rn/use-effect
    (fn []
      (let [edit-text (get-in edit [:content :text])]
@@ -124,7 +123,7 @@
 (defn reply
   [{:keys [input-ref]}
    {:keys [container-opacity]}
-   reply]
+   {:keys [reply]}]
   (rn/use-effect
    (fn []
      (when reply
@@ -134,7 +133,7 @@
    [(:message-id reply)]))
 
 (defn edit-mentions
-  [{:keys [input-ref]} {:keys [text-value cursor-position]} input-with-mentions]
+  [{:keys [input-ref]} {:keys [text-value cursor-position]} {:keys [input-with-mentions]}]
   (rn/use-effect (fn []
                    (let [input-text (reduce (fn [acc item]
                                               (str acc (second item)))
@@ -153,7 +152,7 @@
 (defn update-input-mention
   [{:keys [input-ref]}
    {:keys [text-value]}
-   input-text]
+   {:keys [input-text]}]
   (rn/use-effect
    (fn []
      (when (and input-text (not= @text-value input-text))

--- a/src/status_im2/contexts/chat/composer/handlers.cljs
+++ b/src/status_im2/contexts/chat/composer/handlers.cljs
@@ -38,8 +38,7 @@
            maximized?]}
    {:keys [height saved-height last-height gradient-opacity container-opacity opacity background-y]}
    {:keys [content-height max-height window-height]}
-   images
-   reply]
+   {:keys [images reply]}]
   (let [lines         (utils/calc-lines (- @content-height constants/extra-content-offset))
         min-height    (utils/get-min-height lines)
         reopen-height (utils/calc-reopen-height text-value min-height content-height saved-height)]

--- a/src/status_im2/contexts/chat/composer/images/view.cljs
+++ b/src/status_im2/contexts/chat/composer/images/view.cljs
@@ -31,7 +31,6 @@
                      (reanimated/animate height
                                          (if (seq images) constants/images-container-height 0)))
                    [images])
-    (println "qqq" images)
     [reanimated/view
      {:style (reanimated/apply-animations-to-style {:height height} {:margin-horizontal -20})}
      [gesture/flat-list

--- a/src/status_im2/contexts/chat/composer/images/view.cljs
+++ b/src/status_im2/contexts/chat/composer/images/view.cljs
@@ -31,6 +31,7 @@
                      (reanimated/animate height
                                          (if (seq images) constants/images-container-height 0)))
                    [images])
+    (println "qqq" images)
     [reanimated/view
      {:style (reanimated/apply-animations-to-style {:height height} {:margin-horizontal -20})}
      [gesture/flat-list

--- a/src/status_im2/contexts/chat/composer/mentions/view.cljs
+++ b/src/status_im2/contexts/chat/composer/mentions/view.cljs
@@ -30,16 +30,17 @@
    user])
 
 (defn- f-view
-  [suggestions-atom props state animations max-height cursor-pos]
+  [suggestions-atom props state animations {:keys [reply edit images]} max-height cursor-pos]
   (let [suggestions  (rf/sub [:chat/mention-suggestions])
         opacity      (reanimated/use-shared-value (if (seq suggestions) 1 0))
         size         (count suggestions)
         data         {:keyboard-height @(:kb-height state)
                       :insets          (safe-area/get-insets)
                       :curr-height     (reanimated/get-shared-value (:height animations))
-                      :window-height   (rf/sub [:dimensions/window-height])
-                      :reply           (rf/sub [:chats/reply-message])
-                      :edit            (rf/sub [:chats/edit-message])}
+                      :window-height   (:height (rn/get-window))
+                      :reply           reply
+                      :edit            edit
+                      :images          images}
         mentions-pos (utils/calc-suggestions-position cursor-pos max-height size state data)]
     (rn/use-effect
      (fn []
@@ -60,6 +61,6 @@
        :accessibility-label          :mentions-list}]]))
 
 (defn view
-  [props state animations max-height cursor-pos]
+  [props state animations subs max-height cursor-pos]
   (let [suggestions-atom (reagent/atom {})]
-    [:f> f-view suggestions-atom props state animations max-height cursor-pos]))
+    [:f> f-view suggestions-atom props state animations subs max-height cursor-pos]))

--- a/src/status_im2/contexts/chat/composer/sub_view.cljs
+++ b/src/status_im2/contexts/chat/composer/sub_view.cljs
@@ -4,6 +4,7 @@
     [react-native.blur :as blur]
     [react-native.core :as rn]
     [react-native.reanimated :as reanimated]
+    [react-native.safe-area :as safe-area]
     [status-im2.contexts.chat.composer.style :as style]
     [status-im2.contexts.chat.composer.utils :as utils]
     [status-im2.contexts.chat.messages.list.view :as messages.list]
@@ -25,10 +26,16 @@
   [:f> f-blur-view layout-height focused?])
 
 (defn- f-shell-button
-  [insets height maximized?]
-  (let [translate-y (reanimated/use-shared-value (utils/calc-shell-neg-y insets maximized?))]
-    (rn/use-effect #(reanimated/animate translate-y (utils/calc-shell-neg-y insets maximized?))
-                   [@maximized?])
+  [{:keys [maximized?]} {:keys [height]} {:keys [images reply edit]}]
+  (let [insets       (safe-area/get-insets)
+        extra-height (utils/calc-extra-content-height images reply edit)
+        translate-y  (reanimated/use-shared-value
+                      (utils/calc-shell-neg-y insets maximized? extra-height))]
+    (rn/use-effect (fn []
+                     (let [extra-height (utils/calc-extra-content-height images reply edit)]
+                       (reanimated/animate translate-y
+                                           (utils/calc-shell-neg-y insets maximized? extra-height))))
+                   [@maximized? images reply edit])
     [reanimated/view
      {:style (reanimated/apply-animations-to-style
               {:bottom    height ; we use height of the input directly as bottom position
@@ -48,5 +55,5 @@
       {}]]))
 
 (defn shell-button
-  [insets {:keys [height]} {:keys [maximized?]}]
-  [:f> f-shell-button insets height maximized?])
+  [state animations subs]
+  [:f> f-shell-button state animations subs])

--- a/src/status_im2/contexts/chat/messages/content/album/view.cljs
+++ b/src/status_im2/contexts/chat/messages/content/album/view.cljs
@@ -72,5 +72,6 @@
       [:<>
        (map-indexed
         (fn [index item]
-          [image/image-message index item context #(on-long-press message context)])
+          [:<> {:key (:message-id item)}
+           [image/image-message index item context #(on-long-press message context)]])
         (:album message))])))

--- a/src/status_im2/contexts/chat/messages/content/image/view.cljs
+++ b/src/status_im2/contexts/chat/messages/content/image/view.cljs
@@ -15,23 +15,21 @@
 
 (defn image-message
   [index {:keys [content image-width image-height message-id] :as message} context on-long-press]
-  (let [insets     (safe-area/get-insets)
-        dimensions (calculate-dimensions (or image-width 1000) (or image-height 1000))]
-    (fn []
-      (let [shared-element-id (rf/sub [:shared-element-id])]
-        [rn/touchable-opacity
-         {:active-opacity 1
-          :key            message-id
-          :style          {:margin-top (when (pos? index) 10)}
-          :on-long-press  on-long-press
-          :on-press       #(rf/dispatch [:chat.ui/navigate-to-lightbox
-                                         message-id
-                                         {:messages [message]
-                                          :index    0
-                                          :insets   insets}])}
-         (when (= index 0)
-           [rn/view {:style {:margin-bottom 10}} [text/text-content message context]])
-         [fast-image/fast-image
-          {:source    {:uri (:image content)}
-           :style     (merge dimensions {:border-radius 12})
-           :native-ID (when (= shared-element-id message-id) :shared-element)}]]))))
+  (let [insets            (safe-area/get-insets)
+        dimensions        (calculate-dimensions (or image-width 1000) (or image-height 1000))
+        shared-element-id (rf/sub [:shared-element-id])]
+    [rn/touchable-opacity
+     {:active-opacity 1
+      :style          {:margin-top (when (pos? index) 10)}
+      :on-long-press  on-long-press
+      :on-press       #(rf/dispatch [:chat.ui/navigate-to-lightbox
+                                     message-id
+                                     {:messages [message]
+                                      :index    0
+                                      :insets   insets}])}
+     (when (= index 0)
+       [rn/view {:style {:margin-bottom 10}} [text/text-content message context]])
+     [fast-image/fast-image
+      {:source    {:uri (:image content)}
+       :style     (merge dimensions {:border-radius 12})
+       :native-ID (when (= shared-element-id message-id) :shared-element)}]]))


### PR DESCRIPTION
This PR does some refactoring to the composer. 

It adds an `init-subs` function to group the subscriptions together, similar to `init-state` and `init-props`. 

It also adds a `calc-extra-content-height` to calculate the height of (edit, reply, images) and be reused in calculating composer max-height, mentions position, and shell button position.