### PR TITLE
chore: restore label on im new to status page

### DIFF
--- a/src/status_im2/contexts/onboarding/new_to_status/style.cljs
+++ b/src/status_im2/contexts/onboarding/new_to_status/style.cljs
@@ -19,13 +19,12 @@
    :margin-bottom 20})
 
 (def subtitle-container
-  {:height         42
-   :padding-top    16
-   :padding-bottom 8})
+  {:height        20
+   :margin-top    16
+   :margin-bottom 4})
 
 (def subtitle
-  {:color         colors/white-opa-70
-   :margin-bottom 20})
+  {:color colors/white-opa-70})
 
 (def suboptions
   {:padding-top    4


### PR DESCRIPTION
address the task - Experienced in Web3?" missing label 
in https://github.com/status-im/status-mobile/issues/15780

<img width="300px" src="https://github.com/status-im/status-mobile/assets/22799766/16940982-a14a-4c1b-9f25-02f18b6702f4" />
