### PR TITLE
fix: audio issues when sending app to background on Android

### DIFF
--- a/src/quo2/components/record_audio/record_audio/view.cljs
+++ b/src/quo2/components/record_audio/record_audio/view.cljs
@@ -173,6 +173,7 @@
            reached-max-duration? (atom false)
            touch-timestamp (atom nil)
            disabled? (atom false)
+           app-state-listener (atom nil)
            rec-options
            (merge
             audio/default-recorder-options
@@ -512,7 +513,13 @@
                          (on-init reset-recorder))
                        (when audio-file
                          (let [filename (last (string/split audio-file "/"))]
-                           (reload-player filename)))))
+                           (reload-player filename)))
+                       (reset! app-state-listener
+                         (.addEventListener rn/app-state
+                                            "change"
+                                            #(when (= % "background")
+                                               (reset! playing-audio? false))))
+                       #(.remove @app-state-listener)))
          [rn/view
           {:style          style/bar-container
            :pointer-events :box-none}

--- a/src/react_native/audio_toolkit.cljs
+++ b/src/react_native/audio_toolkit.cljs
@@ -130,6 +130,11 @@
   (when (and player (.-canPlay ^js player))
     (.-currentTime ^js player)))
 
+(defn set-player-wake-lock
+  [player wake-lock?]
+  (when player
+    (set! (.-wakeLock player) wake-lock?)))
+
 (defn toggle-playpause-player
   [player on-play on-pause on-error]
   (when (and player (.-canPlay ^js player))

--- a/src/status_im2/contexts/chat/messages/content/audio/component_spec.cljs
+++ b/src/status_im2/contexts/chat/messages/content/audio/component_spec.cljs
@@ -20,7 +20,8 @@
 
 (h/describe "audio message"
   (h/before-each
-   #(setup-subs {:mediaserver/port 1000}))
+   #(setup-subs {:mediaserver/port 1000
+                 :app-state        "active"}))
 
   (h/test "renders correctly"
     (h/render [audio-message/audio-message message context])


### PR DESCRIPTION
fixes #15819 

### Summary

This PR mainly fixes a weird issue on Android that sometimes the audio player comes to an idle state when sending app to background.
But also, fixes two more issues:
- When audio is playing and user sends app to background without pausing the audio, now it automatically pauses and shows the play button after returning to the app
- As the second video in the issue shows, when resuming audio after returning from background, instead of resuming audio from when the audio was previously paused, it started from the beginning of it. Now it should resume audio from the pausing point.

#### Platforms

- Android
- iOS

##### Functional

- 1-1 chats
- public chats
- group chats

### Steps to test

#### Test case 1
- Open Status
- Reproduce an audio
- Pause it
- Send app to background
- Return to app
- Play audio again and check it resumes playing without problems

#### Test case 2
- Open Status
- Reproduce an audio
- Send app to background without pausing
- Return to app
- Check correct state of play button and check it resumes playing without problems

status: ready
