### PR TITLE
use debounce-and-dispatch to improve mention performance

### DIFF
--- a/src/status_im2/contexts/chat/composer/effects.cljs
+++ b/src/status_im2/contexts/chat/composer/effects.cljs
@@ -159,7 +159,7 @@
        (when @input-ref
          (.setNativeProps ^js @input-ref (clj->js {:text input-text})))
        (reset! text-value input-text)
-       (debounce/debounce-and-dispatch [:mention/on-change-text input-text] 400)))
+       (debounce/debounce-and-dispatch [:mention/on-change-text input-text] 300)))
    [input-text]))
 
 (defn did-mount

--- a/src/status_im2/contexts/chat/composer/effects.cljs
+++ b/src/status_im2/contexts/chat/composer/effects.cljs
@@ -159,7 +159,7 @@
        (when @input-ref
          (.setNativeProps ^js @input-ref (clj->js {:text input-text})))
        (reset! text-value input-text)
-       (debounce/debounce-and-dispatch [:mention/on-change-text input-text] 200)))
+       (debounce/debounce-and-dispatch [:mention/on-change-text input-text] 400)))
    [input-text]))
 
 (defn did-mount

--- a/src/status_im2/contexts/chat/composer/effects.cljs
+++ b/src/status_im2/contexts/chat/composer/effects.cljs
@@ -8,7 +8,7 @@
     [status-im2.contexts.chat.composer.keyboard :as kb]
     [utils.number :as utils.number]
     [oops.core :as oops]
-    [utils.re-frame :as rf]))
+    [utils.debounce :as debounce]))
 
 (defn reenter-screen-effect
   [{:keys [text-value saved-cursor-position maximized?]}
@@ -159,7 +159,7 @@
        (when @input-ref
          (.setNativeProps ^js @input-ref (clj->js {:text input-text})))
        (reset! text-value input-text)
-       (rf/dispatch [:mention/on-change-text input-text])))
+       (debounce/debounce-and-dispatch [:mention/on-change-text input-text] 200)))
    [input-text]))
 
 (defn did-mount

--- a/src/status_im2/contexts/chat/composer/handlers.cljs
+++ b/src/status_im2/contexts/chat/composer/handlers.cljs
@@ -119,7 +119,7 @@
     (@record-reset-fn)
     (reset! recording? false))
   (rf/dispatch [:chat.ui/set-chat-input-text text])
-  (debounce/debounce-and-dispatch [:mention/on-change-text text] 200))
+  (debounce/debounce-and-dispatch [:mention/on-change-text text] 400))
 
 (defn selection-change
   [event

--- a/src/status_im2/contexts/chat/composer/handlers.cljs
+++ b/src/status_im2/contexts/chat/composer/handlers.cljs
@@ -119,7 +119,7 @@
     (@record-reset-fn)
     (reset! recording? false))
   (rf/dispatch [:chat.ui/set-chat-input-text text])
-  (debounce/debounce-and-dispatch [:mention/on-change-text text] 400))
+  (debounce/debounce-and-dispatch [:mention/on-change-text text] 300))
 
 (defn selection-change
   [event

--- a/src/status_im2/contexts/chat/composer/handlers.cljs
+++ b/src/status_im2/contexts/chat/composer/handlers.cljs
@@ -8,7 +8,8 @@
     [status-im2.contexts.chat.composer.keyboard :as kb]
     [status-im2.contexts.chat.composer.utils :as utils]
     [status-im2.contexts.chat.composer.selection :as selection]
-    [utils.re-frame :as rf]))
+    [utils.re-frame :as rf]
+    [utils.debounce :as debounce]))
 
 (defn focus
   [{:keys [input-ref] :as props}
@@ -118,7 +119,7 @@
     (@record-reset-fn)
     (reset! recording? false))
   (rf/dispatch [:chat.ui/set-chat-input-text text])
-  (rf/dispatch [:mention/on-change-text text]))
+  (debounce/debounce-and-dispatch [:mention/on-change-text text] 200))
 
 (defn selection-change
   [event

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.150.2",
-    "commit-sha1": "31144ed5a38589fd129945b634f54e800b39645a",
-    "src-sha256": "0jh6bidhf0gs15samqh5whw4iigr7ql11cx0v6ma7achr6j4r1d2"
+    "version": "improvement/mention",
+    "commit-sha1": "29af0f242a38bc79e70be89c0edeca34c1bb4230",
+    "src-sha256": "1qz7m7amlqv8rcq4xaglimsibnj3gv39r70v8yk6y22196njmzfa"
 }

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "improvement/mention",
-    "commit-sha1": "29af0f242a38bc79e70be89c0edeca34c1bb4230",
-    "src-sha256": "1qz7m7amlqv8rcq4xaglimsibnj3gv39r70v8yk6y22196njmzfa"
+    "version": "v0.151.4",
+    "commit-sha1": "570d998939dd4286ee5adc2303d675938a171210",
+    "src-sha256": "13vkh7mjywv2cc3c52cdpbyrhwh8n05zhnqmjhv4piw4w52nc24w"
 }

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -4,6 +4,6 @@
     "owner": "status-im",
     "repo": "status-go",
     "version": "v0.151.4",
-    "commit-sha1": "570d998939dd4286ee5adc2303d675938a171210",
-    "src-sha256": "13vkh7mjywv2cc3c52cdpbyrhwh8n05zhnqmjhv4piw4w52nc24w"
+    "commit-sha1": "39f486a47ad04a224416ff23f06363bc4991d7e1",
+    "src-sha256": "04djwki409xcjsqgv59k5vh1nwfw7hxq64kh3kh6m4cz14symqk3"
 }


### PR DESCRIPTION
### Summary
- used `debounce-and-dispatch` to reduce times of calling `wakuext_chatMentionOnChangeText`
- removed unused code relate to mention
- combined `wakuext_chatMentionRecheckAtIdxs` and `wakuext_chatMentionNewInputTextWithMention`

relate [PR](https://github.com/status-im/status-go/pull/3479) for status-go

thanks to @ilmotta to let me know we have `debounce-and-dispatch`

### Testing notes
it should improve the performance of mention and mention should work as before

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

status: ready <!-- Can be ready or wip -->
