### PR TITLE
Dont check `app-state` for `Android` when evaluating universal links routing

### DIFF
--- a/test/appium/tests/critical/chats/test_1_1_public_chats.py
+++ b/test/appium/tests/critical/chats/test_1_1_public_chats.py
@@ -1065,7 +1065,6 @@ class TestOneToOneChatMultipleSharedDevicesNewUi(MultipleSharedDeviceTestCase):
         self.errors.verify_no_errors()
 
     @marks.testrail_id(702813)
-    @marks.xfail(reason="blocked by 15859")
     def test_1_1_chat_push_emoji(self):
         message_no_pn, message = 'No PN', 'Text push notification'
 

--- a/test/appium/tests/critical/chats/test_group_chat.py
+++ b/test/appium/tests/critical/chats/test_group_chat.py
@@ -203,7 +203,6 @@ class TestGroupChatMultipleDeviceMergedNewUI(MultipleSharedDeviceTestCase):
         self.chats[0].send_message(self.message_before_adding)
 
     @marks.testrail_id(702807)
-    @marks.xfail(reason="blocked by 15859")
     def test_group_chat_join_send_text_messages_push(self):
         message_to_admin = self.message_to_admin
         [self.homes[i].click_system_back_button_until_element_is_shown() for i in range(3)]

--- a/test/appium/tests/critical/test_public_chat_browsing.py
+++ b/test/appium/tests/critical/test_public_chat_browsing.py
@@ -743,7 +743,6 @@ class TestCommunityMultipleDeviceMerged(MultipleSharedDeviceTestCase):
         self.errors.verify_no_errors()
 
     @marks.testrail_id(702786)
-    @marks.xfail(reason="blocked by 15859")
     def test_community_mentions_push_notification(self):
         self.home_1.click_system_back_button_until_element_is_shown()
         if not self.channel_2.chat_message_input.is_element_displayed():


### PR DESCRIPTION
fixes #15859

### Summary
On `Android` devices, right after account creation and before a log out, the `:app-state` value in `reframe` db is set to `background`. The value becomes `active` after a log out and then log in which causes tapping on push notifications to do nothing.

This behaviour breaks E2E and hence in this PR, I remove the checking of this case only for `Android` platforms.
More work should be done to figure out why the app state event handler is behaving this way on `Android` but for now I would like to unblock E2E.

#### Platforms
- Android

status: ready 
