### PR TITLE
Activity Center Empty Community Image

### DIFF
--- a/src/quo2/components/tags/context_tag/view.cljs
+++ b/src/quo2/components/tags/context_tag/view.cljs
@@ -4,6 +4,7 @@
             [quo2.components.icon :as icons]
             [quo2.components.markdown.text :as text]
             [quo2.components.tags.context-tag.style :as style]
+            [quo2.components.avatars.user-avatar.style :as user-avatar-style]
             [react-native.core :as rn]))
 
 (defn trim-public-key
@@ -39,16 +40,21 @@
     (trim-public-key public-key)]])
 
 (defn context-tag
-  [{:keys [text-style blur?] :as params} photo name channel-name]
-  (let [text-params {:weight :medium
-                     :size   :paragraph-2
-                     :style  (assoc text-style :justify-content :center)}]
+  [{:keys [text-style blur? no-avatar-placeholder?] :as params} photo name channel-name]
+  (let [text-params       {:weight :medium
+                           :size   :paragraph-2
+                           :style  (assoc text-style :justify-content :center)}
+        empty-photo?      (empty? photo)
+        avatar-size       :xxs
+        avatar-outer-size (get-in user-avatar-style/sizes [avatar-size :outer])]
     [base-tag (assoc-in params [:style :padding-left] 3)
-     [user-avatar/user-avatar
-      {:full-name         name
-       :profile-picture   photo
-       :size              :xxs
-       :status-indicator? false}]
+     (if (and empty-photo? no-avatar-placeholder?)
+       [rn/view {:style {:width avatar-outer-size}}]
+       [user-avatar/user-avatar
+        {:full-name         name
+         :profile-picture   photo
+         :size              avatar-size
+         :status-indicator? false}])
      [rn/view {:style style/context-tag-text-container}
       [text/text text-params (str " " name)]
       (when channel-name

--- a/src/status_im/ui/screens/communities/icon.cljs
+++ b/src/status_im/ui/screens/communities/icon.cljs
@@ -17,7 +17,7 @@
         :style  {:width  40
                  :height 40}}]
       (seq thumbnail-image)
-      [photos/photo thumbnail-image {:size 40}]
+      [photos/photo {:uri thumbnail-image} {:size 40}]
 
       :else
       [chat-icon.screen/chat-icon-view-chat-list

--- a/src/status_im2/contexts/activity_center/notification/admin/view.cljs
+++ b/src/status_im2/contexts/activity_center/notification/admin/view.cljs
@@ -1,6 +1,5 @@
 (ns status-im2.contexts.activity-center.notification.admin.view
   (:require [quo2.core :as quo]
-            [quo2.foundations.colors :as colors]
             [status-im2.constants :as constants]
             [status-im2.contexts.activity-center.notification.common.style :as common-style]
             [status-im2.contexts.activity-center.notification.common.view :as common]
@@ -69,12 +68,8 @@
        :context   [[common/user-avatar-tag author]
                    (i18n/label :t/wants-to-join)
                    [quo/context-tag
-                    {:size           :small
-                     :override-theme :dark
-                     :color          colors/primary-50
-                     :style          common-style/user-avatar-tag
-                     :text-style     common-style/user-avatar-tag-text}
-                    {:uri community-image} community-name]]
+                    common/tag-params
+                    community-image community-name]]
        :items     (case membership-status
                     constants/activity-center-membership-status-accepted
                     [{:type    :status

--- a/src/status_im2/contexts/activity_center/notification/common/view.cljs
+++ b/src/status_im2/contexts/activity_center/notification/common/view.cljs
@@ -9,11 +9,12 @@
             [utils.re-frame :as rf]))
 
 (def tag-params
-  {:size           :small
-   :override-theme :dark
-   :color          colors/primary-50
-   :style          style/user-avatar-tag
-   :text-style     style/user-avatar-tag-text})
+  {:size                   :small
+   :override-theme         :dark
+   :color                  colors/primary-50
+   :style                  style/user-avatar-tag
+   :text-style             style/user-avatar-tag-text
+   :no-avatar-placeholder? true})
 
 (defn user-avatar-tag
   [user-id]

--- a/src/status_im2/contexts/activity_center/notification/community_kicked/view.cljs
+++ b/src/status_im2/contexts/activity_center/notification/community_kicked/view.cljs
@@ -33,5 +33,5 @@
        :unread?   (not read)
        :context   [[quo/text {:style common-style/user-avatar-tag-text}
                     (i18n/label :t/community-kicked-body)]
-                   [quo/context-tag common/tag-params {:uri community-image}
+                   [quo/context-tag common/tag-params community-image
                     community-name]]}]]))

--- a/src/status_im2/contexts/activity_center/notification/community_request/view.cljs
+++ b/src/status_im2/contexts/activity_center/notification/community_request/view.cljs
@@ -22,7 +22,7 @@
   [community membership-status]
   (let [community-name        (:name community)
         community-image       (get-in community [:images :thumbnail :uri])
-        community-context-tag [quo/context-tag common/tag-params {:uri community-image}
+        community-context-tag [quo/context-tag common/tag-params community-image
                                community-name]]
     (cond
       (= membership-status constants/activity-center-membership-status-idle)

--- a/src/status_im2/contexts/activity_center/notification/mentions/view.cljs
+++ b/src/status_im2/contexts/activity_center/notification/mentions/view.cljs
@@ -1,20 +1,12 @@
 (ns status-im2.contexts.activity-center.notification.mentions.view
   (:require [clojure.string :as string]
             [quo2.core :as quo]
-            [quo2.foundations.colors :as colors]
             [react-native.gesture :as gesture]
             [status-im2.contexts.activity-center.notification.common.view :as common]
             [status-im2.contexts.activity-center.notification.mentions.style :as style]
             [utils.datetime :as datetime]
             [utils.i18n :as i18n]
             [utils.re-frame :as rf]))
-
-(def ^:private tag-params
-  {:size           :small
-   :override-theme :dark
-   :color          colors/primary-50
-   :style          style/tag
-   :text-style     style/tag-text})
 
 (defn- message-body
   [message]
@@ -68,6 +60,6 @@
         :context   [[common/user-avatar-tag author]
                     [quo/text {:style style/tag-text} (string/lower-case (i18n/label :t/on))]
                     (if community-chat?
-                      [quo/context-tag tag-params {:uri community-image} community-name chat-name]
-                      [quo/group-avatar-tag chat-name tag-params])]
+                      [quo/context-tag common/tag-params community-image community-name chat-name]
+                      [quo/group-avatar-tag chat-name common/tag-params])]
         :message   {:body (message-body message)}}]]]))

--- a/src/status_im2/contexts/activity_center/notification/reply/view.cljs
+++ b/src/status_im2/contexts/activity_center/notification/reply/view.cljs
@@ -1,7 +1,6 @@
 (ns status-im2.contexts.activity-center.notification.reply.view
   (:require [clojure.string :as string]
             [quo2.core :as quo]
-            [quo2.foundations.colors :as colors]
             [react-native.gesture :as gesture]
             [status-im.ui2.screens.chat.messages.message :as old-message]
             [status-im2.common.not-implemented :as not-implemented]
@@ -11,13 +10,6 @@
             [utils.datetime :as datetime]
             [utils.i18n :as i18n]
             [utils.re-frame :as rf]))
-
-(def ^:private tag-params
-  {:size           :small
-   :override-theme :dark
-   :color          colors/primary-50
-   :style          style/tag
-   :text-style     style/tag-text})
 
 ;; NOTE: Replies support text, image and stickers only.
 (defn- get-message-content
@@ -76,7 +68,7 @@
         :context   [[common/user-avatar-tag author]
                     [quo/text {:style style/lowercase-text} (i18n/label :t/on)]
                     (if community-chat?
-                      [quo/context-tag tag-params {:uri community-image} community-name chat-name]
-                      [quo/group-avatar-tag chat-name tag-params])]
+                      [quo/context-tag common/tag-params community-image community-name chat-name]
+                      [quo/group-avatar-tag chat-name common/tag-params])]
         :message   {:body-number-of-lines 1
                     :body                 (get-message-content message)}}]]]))

--- a/src/status_im2/contexts/quo_preview/tags/context_tags.cljs
+++ b/src/status_im2/contexts/quo_preview/tags/context_tags.cljs
@@ -43,19 +43,27 @@
     :type  :boolean}])
 
 (def context-tag-descriptor
-  [{:label "Label"
+  [{:label "Show avatar"
+    :key   :show-avatar?
+    :type  :boolean}
+   {:label "Label"
     :key   :label
     :type  :text}
-   {:label "Channel Name"
+   {:label "Channel name"
     :key   :channel-name
-    :type  :text}])
+    :type  :text}
+   {:label "Avatar placeholder"
+    :key   :no-avatar-placeholder?
+    :type  :boolean}])
 
 (defn cool-preview
   []
-  (let [state (reagent/atom {:label        "Name"
-                             :channel-name "Channel"
-                             :type         :group-avatar
-                             :duration     "00:32"})]
+  (let [state (reagent/atom {:label                  "Name"
+                             :channel-name           "Channel"
+                             :type                   :group-avatar
+                             :duration               "00:32"
+                             :show-avatar?           true
+                             :no-avatar-placeholder? false})]
     (fn []
       (let [contacts             {example-pk  {:public-key   example-pk
                                                :primary-name "Automatic incompatible Coati"
@@ -122,10 +130,12 @@
              :show-blur-background? (:blur? @state)}
             (case (:type @state)
               :context-tag  [quo2/context-tag
-                             {:blur? (:blur? @state)
-                              :size  :small
-                              :color :purple}
-                             {:uri example-photo2}
+                             {:blur?                  (:blur? @state)
+                              :size                   :small
+                              :color                  :purple
+                              :no-avatar-placeholder? (:no-avatar-placeholder? @state)}
+                             (when (:show-avatar? @state)
+                               example-photo2)
                              (:label @state)
                              (:channel-name @state)]
 


### PR DESCRIPTION
fixes #15888

### Summary

This PR fixes the loading (`activity-indicator`) and the `x` mark shown for the communities which have no (avatar) image.

### Review notes

Introduced the `no-avatar-placeholder?` key to the `context-tag` component to prevent breaking the changes from https://github.com/status-im/status-mobile/pull/15815.

#### Platforms

- Android
- iOS

### Steps to test

- Generate Admin, Mention, Replies, and Community Request (Membership) notifications from communities with no (avatar) image
- Check whether loading or `x` mark is shown.

status: ready 
