### PR TITLE
Add Accessiblity for Image Container in Chat

### DIFF
--- a/src/status_im2/contexts/chat/messages/content/album/view.cljs
+++ b/src/status_im2/contexts/chat/messages/content/album/view.cljs
@@ -34,7 +34,9 @@
       [:<>
        [rn/view {:style {:margin-bottom 10}} [text/text-content first-image context]]
        [rn/view
-        {:style (style/album-container portrait?)}
+        {:style               (style/album-container portrait?)
+         :accessible          true
+         :accessibility-label :image-container}
         (map-indexed
          (fn [index item]
            (let [images-size-key (if (< images-count constants/max-album-photos)


### PR DESCRIPTION
fixes #15901

### Summary

This PR adds an accessibility label for the album container in the chat for E2E testing.

### Platforms

- Android
- iOS

status: ready
