### PR TITLE
ci: fix missing API secrets variables for APIs

### DIFF
--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.7.5'
+library 'status-jenkins-lib@ios/fix-alchemy-vars'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.7.5'
+library 'status-jenkins-lib@ios/fix-alchemy-vars'
 
 pipeline {
   agent { label 'linux' }

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.7.5'
+library 'status-jenkins-lib@ios/fix-alchemy-vars'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.nix-cache
+++ b/ci/Jenkinsfile.nix-cache
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.7.5'
+library 'status-jenkins-lib@ios/fix-alchemy-vars'
 
 pipeline {
   agent { label params.AGENT_LABEL }

--- a/ci/Jenkinsfile.tests
+++ b/ci/Jenkinsfile.tests
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.7.5'
+library 'status-jenkins-lib@ios/fix-alchemy-vars'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/tests/Jenkinsfile.e2e-nightly
+++ b/ci/tests/Jenkinsfile.e2e-nightly
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.7.5'
+library 'status-jenkins-lib@ios/fix-alchemy-vars'
 
 pipeline {
 

--- a/ci/tests/Jenkinsfile.e2e-prs
+++ b/ci/tests/Jenkinsfile.e2e-prs
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.7.5'
+library 'status-jenkins-lib@ios/fix-alchemy-vars'
 
 pipeline {
 

--- a/ci/tests/Jenkinsfile.e2e-upgrade
+++ b/ci/tests/Jenkinsfile.e2e-upgrade
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.7.5'
+library 'status-jenkins-lib@ios/fix-alchemy-vars'
 
 pipeline {
 

--- a/ci/tools/Jenkinsfile.fastlane-clean
+++ b/ci/tools/Jenkinsfile.fastlane-clean
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.7.5'
+library 'status-jenkins-lib@ios/fix-alchemy-vars'
 
 pipeline {
   agent { label 'macos' }

--- a/ci/tools/Jenkinsfile.playstore-meta
+++ b/ci/tools/Jenkinsfile.playstore-meta
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.7.5'
+library 'status-jenkins-lib@ios/fix-alchemy-vars'
 
 pipeline {
   agent { label 'linux' }

--- a/ci/tools/Jenkinsfile.xcode-clean
+++ b/ci/tools/Jenkinsfile.xcode-clean
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.7.5'
+library 'status-jenkins-lib@ios/fix-alchemy-vars'
 
 pipeline {
   agent {


### PR DESCRIPTION
It appears the variables need to be passed at JSBundle build time:
https://shadow-cljs.github.io/docs/UsersGuide.html#closure-defines

Depends on:
* https://github.com/status-im/status-jenkins-lib/pull/66