### PR TITLE
Fix UX issue while spamming the copy button on share shell tab.

### DIFF
--- a/src/status_im2/common/home/view.cljs
+++ b/src/status_im2/common/home/view.cljs
@@ -6,7 +6,8 @@
     [status-im2.common.home.style :as style]
     [status-im2.common.plus-button.view :as plus-button]
     [status-im2.constants :as constants]
-    [utils.re-frame :as rf]))
+    [utils.re-frame :as rf]
+    [utils.debounce :refer [dispatch-and-chill]]))
 
 (defn title-column
   [{:keys [label handler accessibility-label customization-color]}]
@@ -101,7 +102,7 @@
      [quo/button
       (merge button-common-props
              {:accessibility-label :show-qr-button
-              :on-press            #(rf/dispatch [:open-modal :share-shell])})
+              :on-press            #(dispatch-and-chill [:open-modal :share-shell] 1000)})
       :i/qr-code]
      [rn/view
       [unread-indicator]

--- a/src/status_im2/contexts/share/events.cljs
+++ b/src/status_im2/contexts/share/events.cljs
@@ -5,11 +5,12 @@
 
 (rf/defn copy-text-and-show-toast
   {:events [:share/copy-text-and-show-toast]}
-  [cofx text-to-copy post-copy-message]
+  [{:keys [db] :as cofx} {:keys [text-to-copy post-copy-message]}]
   (rf/merge cofx
             {:copy-to-clipboard text-to-copy}
             (toasts/upsert
              {:icon           :correct
+              :id             :successful-copy-toast-message
               :icon-color     colors/success-50
               :override-theme :dark
               :text           post-copy-message})))

--- a/src/status_im2/contexts/share/view.cljs
+++ b/src/status_im2/contexts/share/view.cljs
@@ -74,10 +74,12 @@
          {:active-opacity   1
           :underlay-color   colors/neutral-80-opa-1-blur
           :background-color :transparent
-          :on-press         #(rf/dispatch [:share/copy-text-and-show-toast profile-url
-                                           (i18n/label :t/link-to-profile-copied)])
-          :on-long-press    #(rf/dispatch [:share/copy-text-and-show-toast profile-url
-                                           (i18n/label :t/link-to-profile-copied)])}
+          :on-press         #(rf/dispatch [:share/copy-text-and-show-toast
+                                           {:text-to-copy      profile-url
+                                            :post-copy-message (i18n/label :t/link-to-profile-copied)}])
+          :on-long-press    #(rf/dispatch [:share/copy-text-and-show-toast
+                                           {:text-to-copy      profile-url
+                                            :post-copy-message (i18n/label :t/link-to-profile-copied)}])}
          [quo/text
           {:style           style/profile-address-content
            :size            :paragraph-1
@@ -107,10 +109,12 @@
          {:active-opacity   1
           :underlay-color   colors/neutral-80-opa-1-blur
           :background-color :transparent
-          :on-press         #(rf/dispatch [:share/copy-text-and-show-toast emoji-hash
-                                           (i18n/label :t/emoji-hash-copied)])
-          :on-long-press    #(rf/dispatch [:share/copy-text-and-show-toast emoji-hash
-                                           (i18n/label :t/emoji-hash-copied)])}
+          :on-press         #(rf/dispatch [:share/copy-text-and-show-toast
+                                           {:text-to-copy      emoji-hash
+                                            :post-copy-message (i18n/label :t/emoji-hash-copied)}])
+          :on-long-press    #(rf/dispatch [:share/copy-text-and-show-toast
+                                           {:text-to-copy      emoji-hash
+                                            :post-copy-message (i18n/label :t/emoji-hash-copied)}])}
          [rn/text {:style style/emoji-hash-content} emoji-hash]]]]
       [rn/view {:style style/emoji-share-button-container}
        [quo/button
@@ -120,10 +124,12 @@
          :accessibility-label :link-to-profile
          :override-theme      :dark
          :style               {:margin-right 12}
-         :on-press            #(rf/dispatch [:share/copy-text-and-show-toast emoji-hash
-                                             (i18n/label :t/emoji-hash-copied)])
-         :on-long-press       #(rf/dispatch [:share/copy-text-and-show-toast emoji-hash
-                                             (i18n/label :t/emoji-hash-copied)])}
+         :on-press            #(rf/dispatch [:share/copy-text-and-show-toast
+                                             {:text-to-copy      emoji-hash
+                                              :post-copy-message (i18n/label :t/emoji-hash-copied)}])
+         :on-long-press       #(rf/dispatch [:share/copy-text-and-show-toast
+                                             {:text-to-copy      emoji-hash
+                                              :post-copy-message (i18n/label :t/emoji-hash-copied)}])}
         :i/copy]]]]))
 
 (defn wallet-tab


### PR DESCRIPTION
fixes #15926

### Summary
Few UX improvements were made to share shell screen:

1. Modified `copy-text-and-show-toast` to first dismiss existing toasts before dispatching a new toast notification.
3. Dispatch and chill when the share tab is opened from home screen.

#### Platforms
- Android
- iOS

status: ready
