### PR TITLE
feat: add ident ring for login profile picture

### DIFF
--- a/src/status_im2/contexts/onboarding/profiles/view.cljs
+++ b/src/status_im2/contexts/onboarding/profiles/view.cljs
@@ -73,11 +73,10 @@
                  :shell?  true}]))
 
 (defn profile-card
-  [{:keys [name key-uid customization-color keycard-pairing last-index set-hide-profiles]
-    :as   multiaccount}
+  [{:keys [name key-uid customization-color keycard-pairing last-index set-hide-profiles]}
    index]
   (let [last-item?      (= last-index index)
-        profile-picture (:uri (first (:images multiaccount)))]
+        profile-picture (rf/sub [:multiaccounts/login-profiles-picture key-uid])]
     [quo/profile-card
      {:name                 name
       :login-card?          true
@@ -176,10 +175,10 @@
 
 (defn login-section
   [{:keys [set-show-profiles]}]
-  (let [{:keys [name customization-color error processing password]
-         :as   multiaccount} (rf/sub [:multiaccounts/login])
-        sign-in-enabled?     (rf/sub [:sign-in-enabled?])
-        profile-picture      (:uri (first (:images multiaccount)))]
+  (let [{:keys [key-uid name customization-color error
+                processing password]} (rf/sub [:multiaccounts/login])
+        sign-in-enabled?              (rf/sub [:sign-in-enabled?])
+        profile-picture               (rf/sub [:multiaccounts/login-profiles-picture key-uid])]
     [rn/keyboard-avoiding-view
      {:style                  style/login-container
       :keyboardVerticalOffset (- (safe-area/get-bottom))}

--- a/src/status_im2/subs/multiaccount.cljs
+++ b/src/status_im2/subs/multiaccount.cljs
@@ -1,13 +1,13 @@
 (ns status-im2.subs.multiaccount
   (:require [cljs.spec.alpha :as spec]
             [clojure.string :as string]
+            [quo2.theme :as theme]
             [re-frame.core :as re-frame]
             [status-im.ethereum.core :as ethereum]
             [status-im.fleet.core :as fleet]
             [status-im.multiaccounts.db :as multiaccounts.db]
             [utils.image-server :as image-server]
-            [utils.security.core :as security]
-            [quo2.theme :as theme]))
+            [utils.security.core :as security]))
 
 (re-frame/reg-sub
  :multiaccount/public-key
@@ -214,11 +214,12 @@
         images     (reduce (fn [acc current]
                              (let [key-uid    (:keyUid current)
                                    image-name (:type current)
-                                   uri        (image-server/get-account-image-uri port
-                                                                                  public-key
-                                                                                  image-name
-                                                                                  key-uid
-                                                                                  theme)]
+                                   uri        (image-server/get-account-image-uri {:port       port
+                                                                                   :public-key public-key
+                                                                                   :image-name image-name
+                                                                                   :key-uid    key-uid
+                                                                                   :theme      theme
+                                                                                   :ring?      true})]
                                (conj acc (assoc current :uri uri))))
                            []
                            images)]

--- a/src/status_im2/subs/onboarding.cljs
+++ b/src/status_im2/subs/onboarding.cljs
@@ -1,7 +1,9 @@
 (ns status-im2.subs.onboarding
-  (:require [re-frame.core :as re-frame]
+  (:require [quo2.theme :as theme]
+            [re-frame.core :as re-frame]
             [status-im.multiaccounts.recover.core :as recover]
-            [status-im2.constants :as constants]))
+            [status-im2.constants :as constants]
+            [utils.image-server :as image-server]))
 
 (re-frame/reg-sub
  :intro-wizard
@@ -47,6 +49,22 @@
  :<- [:multiaccounts/multiaccounts]
  (fn [[intro-wizard multiaccounts]]
    (recover/existing-account? (:root-key intro-wizard) multiaccounts)))
+
+(re-frame/reg-sub
+ :multiaccounts/login-profiles-picture
+ :<- [:multiaccounts/multiaccounts]
+ :<- [:mediaserver/port]
+ (fn [[multiaccounts port] [_ target-key-uid]]
+   (let [image-name (-> multiaccounts
+                        (get-in [target-key-uid :images])
+                        first
+                        :type)]
+     (when image-name
+       (image-server/get-account-image-uri {:port       port
+                                            :image-name image-name
+                                            :key-uid    target-key-uid
+                                            :theme      (theme/get-theme)
+                                            :ring?      true})))))
 
 (defn login-ma-keycard-pairing
   "Compute the keycard-pairing value of the multiaccount selected for login"

--- a/src/status_im2/subs/onboarding_test.cljs
+++ b/src/status_im2/subs/onboarding_test.cljs
@@ -1,0 +1,38 @@
+(ns status-im2.subs.onboarding-test
+  (:require [cljs.test :as t]
+            [quo2.theme :as theme]
+            [re-frame.db :as rf-db]
+            status-im2.subs.onboarding
+            [test-helpers.unit :as h]
+            [utils.image-server :as image-server]
+            [utils.re-frame :as rf]))
+
+(def key-uid "0x1")
+(def port "mediaserver-port")
+(def cur-theme :current-theme)
+
+(h/deftest-sub :multiaccounts/login-profiles-picture
+  [sub-name]
+  (with-redefs [image-server/get-account-image-uri identity
+                theme/get-theme                    (constantly cur-theme)]
+    (t/testing "nil when no images"
+      (swap! rf-db/app-db assoc :multiaccounts/multiaccounts {key-uid {}})
+      (t/is (nil? (rf/sub [sub-name key-uid]))))
+
+    (t/testing "nil when no key-uid"
+      (swap! rf-db/app-db assoc :multiaccounts/multiaccounts {key-uid {}})
+      (t/is (nil? (rf/sub [sub-name "0x2"]))))
+
+    (t/testing "result from image-server/get-account-image-uri"
+      (swap!
+        rf-db/app-db
+        assoc
+        :multiaccounts/multiaccounts {key-uid {:images [{:type "large"}
+                                                        {:type "thumbnail"}]}}
+        :mediaserver/port            port)
+      (t/is (= (rf/sub [sub-name key-uid])
+               {:port       port
+                :image-name "large"
+                :key-uid    key-uid
+                :theme      cur-theme
+                :ring?      true})))))

--- a/src/utils/image_server.cljs
+++ b/src/utils/image_server.cljs
@@ -26,7 +26,7 @@
     4))
 
 (defn get-account-image-uri
-  [port public-key image-name key-uid theme]
+  [{:keys [port public-key image-name key-uid theme ring?]}]
   (str image-server-uri-prefix
        port
        account-images-action
@@ -40,7 +40,8 @@
        (current-theme-index theme)
        "&clock="
        (timestamp)
-       "&addRing=1"))
+       "&addRing="
+       (if ring? 1 0)))
 
 (defn get-contact-image-uri
   [port public-key image-name clock theme]

--- a/src/utils/image_server_test.cljs
+++ b/src/utils/image_server_test.cljs
@@ -1,0 +1,17 @@
+(ns utils.image-server-test
+  (:require [cljs.test :as t]
+            [utils.image-server :as sut]))
+
+(t/deftest get-account-image-uri
+  (with-redefs
+    [sut/current-theme-index identity
+     sut/timestamp           (constantly "timestamp")]
+    (t/is
+     (=
+      (sut/get-account-image-uri {:port       "port"
+                                  :public-key "public-key"
+                                  :image-name "image-name"
+                                  :key-uid    "key-uid"
+                                  :theme      "theme"
+                                  :ring?      true})
+      "https://localhost:port/accountImages?publicKey=public-key&keyUid=key-uid&imageName=image-name&theme=theme&clock=timestamp&addRing=1"))))


### PR DESCRIPTION
partial fix for subissue 1 in #15788

Adds ident ring for user set profile picture in views before login
ident ring around initials is not supported yet. Will work on that next.


![CleanShot 2023-05-18 at 16 37 12](https://github.com/status-im/status-mobile/assets/15090582/ccf0ac5e-013d-4821-8238-24e3273aadbf)
![CleanShot 2023-05-18 at 16 37 07](https://github.com/status-im/status-mobile/assets/15090582/346334d5-eec1-4c23-9aed-3986f622b6a2)


related status-go PR https://github.com/status-im/status-go/pull/3500 https://github.com/status-im/status-go/pull/3505
with these status-go changes
1. media server gets started before login
1. colorhash and colorid are always available in multiaccount db (db avaliable before login)

status: ready <!-- Can be ready or wip -->