### PR TITLE
[Fix] Accessibility for single image in chat

### DIFF
--- a/src/status_im2/contexts/chat/messages/content/image/view.cljs
+++ b/src/status_im2/contexts/chat/messages/content/image/view.cljs
@@ -31,6 +31,7 @@
                                        :index    0
                                        :insets   insets}])}
       [fast-image/fast-image
-       {:source    {:uri (:image content)}
-        :style     (merge dimensions {:border-radius 12})
-        :native-ID (when (= shared-element-id message-id) :shared-element)}]]]))
+       {:source              {:uri (:image content)}
+        :style               (merge dimensions {:border-radius 12})
+        :native-ID           (when (= shared-element-id message-id) :shared-element)
+        :accessibility-label :image-message}]]]))


### PR DESCRIPTION
fixes #15901

@churik The accessibility label is `image-message` for a single image in a message.

status: ready 
