### PR TITLE
[Fix] Keyboard Close on "Forgot Password" tap

### DIFF
--- a/src/status_im2/contexts/onboarding/profiles/view.cljs
+++ b/src/status_im2/contexts/onboarding/profiles/view.cljs
@@ -227,8 +227,10 @@
            :style          {:margin-left -4}
            :disabled       processing
            :active-opacity 1
-           :on-press       #(rf/dispatch [:show-bottom-sheet
-                                          {:content forget-password-doc :shell? true}])}
+           :on-press       (fn []
+                             (rn/dismiss-keyboard!)
+                             (rf/dispatch [:show-bottom-sheet
+                                           {:content forget-password-doc :shell? true}]))}
           [rn/text
            {:style                 {:text-decoration-line :underline
                                     :color                colors/danger-60}


### PR DESCRIPTION
fixes #15965

#### Summary

This PR fixes the Keyboard being open on tapping `Forgot Password?`

status: ready 
