### PR TITLE
[Fix] Sorting of Chat list items

### DIFF
--- a/src/status_im2/contexts/chat/home/view.cljs
+++ b/src/status_im2/contexts/chat/home/view.cljs
@@ -22,11 +22,12 @@
   [_ index]
   #js {:length 56 :offset (* 56 index) :index index})
 
-(defn filter-items-by-tab
+(defn filter-and-sort-items-by-tab
   [tab items]
-  (if (= tab :tab/groups)
-    (filter :group-chat items)
-    (filter :chat-id items)))
+  (let [key (if (= tab :tab/groups) :group-chat :chat-id)]
+    (->> items
+         (filter key)
+         (sort-by :timestamp >))))
 
 (defn welcome-blank-chats
   []
@@ -38,7 +39,7 @@
 (defn chats
   [selected-tab top]
   (let [unfiltered-items (rf/sub [:chats-stack-items])
-        items            (filter-items-by-tab selected-tab unfiltered-items)]
+        items            (filter-and-sort-items-by-tab selected-tab unfiltered-items)]
     (if (empty? items)
       [welcome-blank-chats]
       [rn/flat-list


### PR DESCRIPTION
fixes #15960

### Summary

This PR fixes/adds the sorting of chat list items to display the recent chat on the top.
Refer to #15960 for a detailed description of the bug.

#### Platforms

- Android
- iOS

#### Steps to test

- Have more than 3 chats (1-1 Chats, and Group Chats) on the chat list
- Receive messages from other users/groups
- Check if the recent chat moves to the top of the list

status: ready 
