### PR TITLE
[Fix] "View Profile" button behaviour on keyboard open in "Add a contact" modal

### DIFF
--- a/src/status_im2/contexts/add_new_contact/style.cljs
+++ b/src/status_im2/contexts/add_new_contact/style.cljs
@@ -1,11 +1,12 @@
 (ns status-im2.contexts.add-new-contact.style
   (:require [quo2.foundations.colors :as colors]
+            [quo2.foundations.typography :as typography]
             [react-native.platform :as platform]
-            [quo2.foundations.typography :as typography]))
+            [react-native.safe-area :as safe-area]))
 
 (defn container-outer
   []
-  {:style {:flex             (if platform/ios? 4.5 5)
+  {:style {:flex             1
            :background-color (colors/theme-colors colors/white colors/neutral-95)
            :justify-content  :space-between
            :align-items      :center
@@ -171,7 +172,7 @@
    :size                40
    :width               335
    :style               {:margin-top    24
-                         :margin-bottom 24}
+                         :margin-bottom (+ (safe-area/get-bottom) 12)}
    :accessibility-label :new-contact-button
    :before              :i/profile
    :disabled            (not= state :valid)})

--- a/src/status_im2/contexts/add_new_contact/views.cljs
+++ b/src/status_im2/contexts/add_new_contact/views.cljs
@@ -73,13 +73,13 @@
             [rn/view (style/text-input-container invalid?)
              [rn/text-input
               (merge (style/text-input)
-                     {:default-value  (or scanned @default-value input)
-                      :placeholder    (i18n/label :t/type-some-chat-key)
-                      :on-change-text (fn [v]
-                                        (reset! default-value v)
-                                        (debounce/debounce-and-dispatch
-                                         [:contacts/set-new-identity v nil]
-                                         600))
+                     {:default-value   (or scanned @default-value input)
+                      :placeholder     (i18n/label :t/type-some-chat-key)
+                      :on-change-text  (fn [v]
+                                         (reset! default-value v)
+                                         (debounce/debounce-and-dispatch
+                                          [:contacts/set-new-identity v nil]
+                                          600))
                       :blur-on-submit  true
                       :return-key-type :done})]
              (when show-paste-button?

--- a/src/status_im2/contexts/add_new_contact/views.cljs
+++ b/src/status_im2/contexts/add_new_contact/views.cljs
@@ -51,8 +51,8 @@
             show-paste-button? (and (not (string/blank? @clipboard))
                                     (string/blank? @default-value)
                                     (string/blank? input))]
-        [rn/touchable-without-feedback
-         {:on-press rn/dismiss-keyboard!}
+        [rn/keyboard-avoiding-view
+         {:style {:flex 1}}
          [rn/view (style/container-outer)
           [rn/view style/container-inner
            [quo/button
@@ -102,14 +102,13 @@
                (i18n/label (or msg :t/invalid-ens-or-key))]])
            (when (= state :valid)
              [found-contact public-key])]
-          [rn/view
-           [quo/button
-            (merge (style/button-view-profile state)
-                   {:on-press
-                    (fn []
-                      (reset! clipboard nil)
-                      (reset! default-value nil)
-                      (rf/dispatch [:contacts/clear-new-identity])
-                      (rf/dispatch [:navigate-back])
-                      (rf/dispatch [:chat.ui/show-profile public-key ens]))})
-            (i18n/label :t/view-profile)]]]]))))
+          [quo/button
+           (merge (style/button-view-profile state)
+                  {:on-press
+                   (fn []
+                     (reset! clipboard nil)
+                     (reset! default-value nil)
+                     (rf/dispatch [:contacts/clear-new-identity])
+                     (rf/dispatch [:navigate-back])
+                     (rf/dispatch [:chat.ui/show-profile public-key ens]))})
+           (i18n/label :t/view-profile)]]]))))

--- a/src/status_im2/contexts/add_new_contact/views.cljs
+++ b/src/status_im2/contexts/add_new_contact/views.cljs
@@ -79,7 +79,9 @@
                                         (reset! default-value v)
                                         (debounce/debounce-and-dispatch
                                          [:contacts/set-new-identity v nil]
-                                         600))})]
+                                         600))
+                      :blur-on-submit  true
+                      :return-key-type :done})]
              (when show-paste-button?
                [quo/button
                 (merge style/button-paste

--- a/src/status_im2/contexts/add_new_contact/views.cljs
+++ b/src/status_im2/contexts/add_new_contact/views.cljs
@@ -51,64 +51,65 @@
             show-paste-button? (and (not (string/blank? @clipboard))
                                     (string/blank? @default-value)
                                     (string/blank? input))]
-
-        [rn/view (style/container-outer)
-         [rn/view style/container-inner
-          [quo/button
-           (merge (style/button-close)
-                  {:on-press
-                   (fn []
-                     (reset! clipboard nil)
-                     (reset! default-value nil)
-                     (rf/dispatch [:contacts/clear-new-identity])
-                     (rf/dispatch [:navigate-back]))}) :i/close]
-          [quo/text (style/text-title)
-           (i18n/label :t/add-a-contact)]
-          [quo/text (style/text-subtitle)
-           (i18n/label :t/find-your-friends)]
-          [quo/text (style/text-description)
-           (i18n/label :t/ens-or-chat-key)]
-          [rn/view style/container-text-input
-           [rn/view (style/text-input-container invalid?)
-            [rn/text-input
-             (merge (style/text-input)
-                    {:default-value  (or scanned @default-value input)
-                     :placeholder    (i18n/label :t/type-some-chat-key)
-                     :on-change-text (fn [v]
-                                       (reset! default-value v)
-                                       (debounce/debounce-and-dispatch
-                                        [:contacts/set-new-identity v nil]
-                                        600))})]
-            (when show-paste-button?
-              [quo/button
-               (merge style/button-paste
-                      {:on-press
-                       (fn []
-                         (reset! default-value @clipboard)
-                         (rf/dispatch
-                          [:contacts/set-new-identity @clipboard nil]))})
-               (i18n/label :t/paste)])]
+        [rn/touchable-without-feedback
+         {:on-press rn/dismiss-keyboard!}
+         [rn/view (style/container-outer)
+          [rn/view style/container-inner
            [quo/button
-            (merge style/button-qr
-                   {:on-press #(rf/dispatch
-                                [::qr-scanner/scan-code
-                                 {:handler :contacts/qr-code-scanned}])})
-            :i/scan]]
-          (when invalid?
-            [rn/view style/container-invalid
-             [quo/icon :i/alert style/icon-invalid]
-             [quo/text style/text-invalid
-              (i18n/label (or msg :t/invalid-ens-or-key))]])
-          (when (= state :valid)
-            [found-contact public-key])]
-         [rn/view
-          [quo/button
-           (merge (style/button-view-profile state)
-                  {:on-press
-                   (fn []
-                     (reset! clipboard nil)
-                     (reset! default-value nil)
-                     (rf/dispatch [:contacts/clear-new-identity])
-                     (rf/dispatch [:navigate-back])
-                     (rf/dispatch [:chat.ui/show-profile public-key ens]))})
-           (i18n/label :t/view-profile)]]]))))
+            (merge (style/button-close)
+                   {:on-press
+                    (fn []
+                      (reset! clipboard nil)
+                      (reset! default-value nil)
+                      (rf/dispatch [:contacts/clear-new-identity])
+                      (rf/dispatch [:navigate-back]))}) :i/close]
+           [quo/text (style/text-title)
+            (i18n/label :t/add-a-contact)]
+           [quo/text (style/text-subtitle)
+            (i18n/label :t/find-your-friends)]
+           [quo/text (style/text-description)
+            (i18n/label :t/ens-or-chat-key)]
+           [rn/view style/container-text-input
+            [rn/view (style/text-input-container invalid?)
+             [rn/text-input
+              (merge (style/text-input)
+                     {:default-value  (or scanned @default-value input)
+                      :placeholder    (i18n/label :t/type-some-chat-key)
+                      :on-change-text (fn [v]
+                                        (reset! default-value v)
+                                        (debounce/debounce-and-dispatch
+                                         [:contacts/set-new-identity v nil]
+                                         600))})]
+             (when show-paste-button?
+               [quo/button
+                (merge style/button-paste
+                       {:on-press
+                        (fn []
+                          (reset! default-value @clipboard)
+                          (rf/dispatch
+                           [:contacts/set-new-identity @clipboard nil]))})
+                (i18n/label :t/paste)])]
+            [quo/button
+             (merge style/button-qr
+                    {:on-press #(rf/dispatch
+                                 [::qr-scanner/scan-code
+                                  {:handler :contacts/qr-code-scanned}])})
+             :i/scan]]
+           (when invalid?
+             [rn/view style/container-invalid
+              [quo/icon :i/alert style/icon-invalid]
+              [quo/text style/text-invalid
+               (i18n/label (or msg :t/invalid-ens-or-key))]])
+           (when (= state :valid)
+             [found-contact public-key])]
+          [rn/view
+           [quo/button
+            (merge (style/button-view-profile state)
+                   {:on-press
+                    (fn []
+                      (reset! clipboard nil)
+                      (reset! default-value nil)
+                      (rf/dispatch [:contacts/clear-new-identity])
+                      (rf/dispatch [:navigate-back])
+                      (rf/dispatch [:chat.ui/show-profile public-key ens]))})
+            (i18n/label :t/view-profile)]]]]))))

--- a/src/status_im2/contexts/add_new_contact/views.cljs
+++ b/src/status_im2/contexts/add_new_contact/views.cljs
@@ -53,64 +53,66 @@
                                     (string/blank? input))]
         [rn/keyboard-avoiding-view
          {:style {:flex 1}}
-         [rn/view (style/container-outer)
-          [rn/view style/container-inner
+         [rn/touchable-without-feedback
+          {:on-press rn/dismiss-keyboard!}
+          [rn/view (style/container-outer)
+           [rn/view style/container-inner
+            [quo/button
+             (merge (style/button-close)
+                    {:on-press
+                     (fn []
+                       (reset! clipboard nil)
+                       (reset! default-value nil)
+                       (rf/dispatch [:contacts/clear-new-identity])
+                       (rf/dispatch [:navigate-back]))}) :i/close]
+            [quo/text (style/text-title)
+             (i18n/label :t/add-a-contact)]
+            [quo/text (style/text-subtitle)
+             (i18n/label :t/find-your-friends)]
+            [quo/text (style/text-description)
+             (i18n/label :t/ens-or-chat-key)]
+            [rn/view style/container-text-input
+             [rn/view (style/text-input-container invalid?)
+              [rn/text-input
+               (merge (style/text-input)
+                      {:default-value   (or scanned @default-value input)
+                       :placeholder     (i18n/label :t/type-some-chat-key)
+                       :on-change-text  (fn [v]
+                                          (reset! default-value v)
+                                          (debounce/debounce-and-dispatch
+                                           [:contacts/set-new-identity v nil]
+                                           600))
+                       :blur-on-submit  true
+                       :return-key-type :done})]
+              (when show-paste-button?
+                [quo/button
+                 (merge style/button-paste
+                        {:on-press
+                         (fn []
+                           (reset! default-value @clipboard)
+                           (rf/dispatch
+                            [:contacts/set-new-identity @clipboard nil]))})
+                 (i18n/label :t/paste)])]
+             [quo/button
+              (merge style/button-qr
+                     {:on-press #(rf/dispatch
+                                  [::qr-scanner/scan-code
+                                   {:handler :contacts/qr-code-scanned}])})
+              :i/scan]]
+            (when invalid?
+              [rn/view style/container-invalid
+               [quo/icon :i/alert style/icon-invalid]
+               [quo/text style/text-invalid
+                (i18n/label (or msg :t/invalid-ens-or-key))]])
+            (when (= state :valid)
+              [found-contact public-key])]
            [quo/button
-            (merge (style/button-close)
+            (merge (style/button-view-profile state)
                    {:on-press
                     (fn []
                       (reset! clipboard nil)
                       (reset! default-value nil)
                       (rf/dispatch [:contacts/clear-new-identity])
-                      (rf/dispatch [:navigate-back]))}) :i/close]
-           [quo/text (style/text-title)
-            (i18n/label :t/add-a-contact)]
-           [quo/text (style/text-subtitle)
-            (i18n/label :t/find-your-friends)]
-           [quo/text (style/text-description)
-            (i18n/label :t/ens-or-chat-key)]
-           [rn/view style/container-text-input
-            [rn/view (style/text-input-container invalid?)
-             [rn/text-input
-              (merge (style/text-input)
-                     {:default-value   (or scanned @default-value input)
-                      :placeholder     (i18n/label :t/type-some-chat-key)
-                      :on-change-text  (fn [v]
-                                         (reset! default-value v)
-                                         (debounce/debounce-and-dispatch
-                                          [:contacts/set-new-identity v nil]
-                                          600))
-                      :blur-on-submit  true
-                      :return-key-type :done})]
-             (when show-paste-button?
-               [quo/button
-                (merge style/button-paste
-                       {:on-press
-                        (fn []
-                          (reset! default-value @clipboard)
-                          (rf/dispatch
-                           [:contacts/set-new-identity @clipboard nil]))})
-                (i18n/label :t/paste)])]
-            [quo/button
-             (merge style/button-qr
-                    {:on-press #(rf/dispatch
-                                 [::qr-scanner/scan-code
-                                  {:handler :contacts/qr-code-scanned}])})
-             :i/scan]]
-           (when invalid?
-             [rn/view style/container-invalid
-              [quo/icon :i/alert style/icon-invalid]
-              [quo/text style/text-invalid
-               (i18n/label (or msg :t/invalid-ens-or-key))]])
-           (when (= state :valid)
-             [found-contact public-key])]
-          [quo/button
-           (merge (style/button-view-profile state)
-                  {:on-press
-                   (fn []
-                     (reset! clipboard nil)
-                     (reset! default-value nil)
-                     (rf/dispatch [:contacts/clear-new-identity])
-                     (rf/dispatch [:navigate-back])
-                     (rf/dispatch [:chat.ui/show-profile public-key ens]))})
-           (i18n/label :t/view-profile)]]]))))
+                      (rf/dispatch [:navigate-back])
+                      (rf/dispatch [:chat.ui/show-profile public-key ens]))})
+            (i18n/label :t/view-profile)]]]]))))


### PR DESCRIPTION
fixes #15976

### Summary

This PR fixes the behaviour of the `View Profile` button in the "Add a contact" modal when the keyboard is open.

#### Platforms

- Android
- iOS

### Steps to test

1) Open Status
2) Navigate to the `Messages` tab
3) Tap on `+` button on top right corner
4) Press `Add a contact` 
5) Bring up the keyboard by tapping/focusing on  `ENS or Chat Key`
6) See whether the `View Profile` button sticks to the top of the keyboard

status: ready 
