### PR TITLE
autocomplete password

### DIFF
--- a/src/quo2/components/inputs/input/view.cljs
+++ b/src/quo2/components/inputs/input/view.cljs
@@ -142,7 +142,7 @@
        (assoc props
               :accessibility-label :password-input
               :auto-capitalize     :none
-              :auto-complete       :password-new
+              :auto-complete       :password
               :secure-text-entry   (not @password-shown?)
               :right-icon          {:style-fn  style/password-icon
                                     :icon-name (if @password-shown? :i/hide :i/reveal)


### PR DESCRIPTION
Warning: Failed prop type: Invalid prop autoComplete of value password-new

im not sure why we use a value which is not supported