### PR TITLE
fix: audio recording bugs while scroll in chat

### DIFF
--- a/src/quo2/components/record_audio/record_audio/__tests__/record_audio_component_spec.cljs
+++ b/src/quo2/components/record_audio/record_audio/__tests__/record_audio_component_spec.cljs
@@ -26,9 +26,10 @@
       (h/fire-event
        :on-start-should-set-responder
        (h/get-by-test-id "record-audio")
-       {:nativeEvent {:locationX 70
-                      :locationY 70
-                      :timestamp 0}})
+       {:nativeEvent {:locationX  70
+                      :locationY  70
+                      :timestamp  0
+                      :identifier 0}})
       (-> (h/expect event)
           (.toHaveBeenCalledTimes 1))))
 
@@ -43,16 +44,18 @@
         (h/fire-event
          :on-start-should-set-responder
          (h/get-by-test-id "record-audio")
-         {:nativeEvent {:locationX 70
-                        :locationY 70
-                        :timestamp 0}})
+         {:nativeEvent {:locationX  70
+                        :locationY  70
+                        :timestamp  0
+                        :identifier 0}})
         (h/advance-timers-by-time 500)
         (h/fire-event
          :on-responder-release
          (h/get-by-test-id "record-audio")
-         {:nativeEvent {:locationX 70
-                        :locationY 70
-                        :timestamp 200}})
+         {:nativeEvent {:locationX  70
+                        :locationY  70
+                        :timestamp  200
+                        :identifier 0}})
         (h/advance-timers-by-time 250)
         (-> (h/expect event)
             (.toHaveBeenCalledTimes 1)))))
@@ -69,29 +72,33 @@
         (h/fire-event
          :on-start-should-set-responder
          (h/get-by-test-id "record-audio")
-         {:nativeEvent {:locationX 70
-                        :locationY 70
-                        :timestamp 0}})
+         {:nativeEvent {:locationX  70
+                        :locationY  70
+                        :timestamp  0
+                        :identifier 0}})
         (h/advance-timers-by-time 500)
         (h/fire-event
          :on-responder-release
          (h/get-by-test-id "record-audio")
-         {:nativeEvent {:locationX 70
-                        :locationY 70
-                        :timestamp 200}})
+         {:nativeEvent {:locationX  70
+                        :locationY  70
+                        :timestamp  200
+                        :identifier 0}})
         (h/fire-event
          :on-start-should-set-responder
          (h/get-by-test-id "record-audio")
-         {:nativeEvent {:locationX 70
-                        :locationY 70
-                        :timestamp 0}})
+         {:nativeEvent {:locationX  70
+                        :locationY  70
+                        :timestamp  0
+                        :identifier 0}})
         (h/advance-timers-by-time 500)
         (h/fire-event
          :on-responder-release
          (h/get-by-test-id "record-audio")
-         {:nativeEvent {:locationX 80
-                        :locationY 80
-                        :timestamp 200}})
+         {:nativeEvent {:locationX  80
+                        :locationY  80
+                        :timestamp  200
+                        :identifier 0}})
         (h/advance-timers-by-time 250)
         (-> (js/expect event)
             (.toHaveBeenCalledTimes 1))
@@ -112,23 +119,26 @@
         (h/fire-event
          :on-start-should-set-responder
          (h/get-by-test-id "record-audio")
-         {:nativeEvent {:locationX 70
-                        :locationY 70
-                        :timestamp 0}})
+         {:nativeEvent {:locationX  70
+                        :locationY  70
+                        :timestamp  0
+                        :identifier 0}})
         (h/advance-timers-by-time 500)
         (h/fire-event
          :on-responder-move
          (h/get-by-test-id "record-audio")
-         {:nativeEvent {:locationX 80
-                        :locationY -30
-                        :pageX     80
-                        :pageY     -30}})
+         {:nativeEvent {:locationX  80
+                        :locationY  -30
+                        :pageX      80
+                        :pageY      -30
+                        :identifier 0}})
         (h/fire-event
          :on-responder-release
          (h/get-by-test-id "record-audio")
-         {:nativeEvent {:locationX 40
-                        :locationY 80
-                        :timestamp 200}})
+         {:nativeEvent {:locationX  40
+                        :locationY  80
+                        :timestamp  200
+                        :identifier 0}})
         (h/advance-timers-by-time 250)
         (-> (js/expect event)
             (.toHaveBeenCalledTimes 1))
@@ -146,22 +156,25 @@
         (h/fire-event
          :on-start-should-set-responder
          (h/get-by-test-id "record-audio")
-         {:nativeEvent {:locationX 70
-                        :locationY 70
-                        :timestamp 0}})
+         {:nativeEvent {:locationX  70
+                        :locationY  70
+                        :timestamp  0
+                        :identifier 0}})
         (h/advance-timers-by-time 500)
         (h/fire-event
          :on-responder-release
          (h/get-by-test-id "record-audio")
-         {:nativeEvent {:locationX 70
-                        :locationY 70
-                        :timestamp 200}})
+         {:nativeEvent {:locationX  70
+                        :locationY  70
+                        :timestamp  200
+                        :identifier 0}})
         (h/fire-event
          :on-responder-release
          (h/get-by-test-id "record-audio")
-         {:nativeEvent {:locationX 40
-                        :locationY 80
-                        :timestamp 200}})
+         {:nativeEvent {:locationX  40
+                        :locationY  80
+                        :timestamp  200
+                        :identifier 0}})
         (h/advance-timers-by-time 250)
         (-> (js/expect event)
             (.toHaveBeenCalledTimes 1)))))
@@ -178,23 +191,26 @@
         (h/fire-event
          :on-start-should-set-responder
          (h/get-by-test-id "record-audio")
-         {:nativeEvent {:locationX 70
-                        :locationY 70
-                        :timestamp 0}})
+         {:nativeEvent {:locationX  70
+                        :locationY  70
+                        :timestamp  0
+                        :identifier 0}})
         (h/advance-timers-by-time 500)
         (h/fire-event
          :on-responder-move
          (h/get-by-test-id "record-audio")
-         {:nativeEvent {:locationX -30
-                        :locationY 80
-                        :pageX     -30
-                        :pageY     80}})
+         {:nativeEvent {:locationX  -30
+                        :locationY  80
+                        :pageX      -30
+                        :pageY      80
+                        :identifier 0}})
         (h/fire-event
          :on-responder-release
          (h/get-by-test-id "record-audio")
-         {:nativeEvent {:locationX -10
-                        :locationY 70
-                        :timestamp 200}})
+         {:nativeEvent {:locationX  -10
+                        :locationY  70
+                        :timestamp  200
+                        :identifier 0}})
         (h/advance-timers-by-time 250)
         (-> (js/expect event)
             (.toHaveBeenCalledTimes 1))))))

--- a/src/status_im/chat/models/input.cljs
+++ b/src/status_im/chat/models/input.cljs
@@ -66,6 +66,11 @@
   (let [current-chat-id (or chat-id (:current-chat-id db))]
     {:db (assoc-in db [:chat/inputs current-chat-id :audio] audio)}))
 
+(rf/defn set-recording
+  {:events [:chat.ui/set-recording]}
+  [{db :db} recording?]
+  {:db (assoc db :chats/recording? recording?)})
+
 (rf/defn select-mention
   {:events [:chat.ui/select-mention]}
   [{:keys [db] :as cofx} text-input-ref {:keys [primary-name searched-text match public-key] :as user}]

--- a/src/status_im2/contexts/chat/composer/actions/view.cljs
+++ b/src/status_im2/contexts/chat/composer/actions/view.cljs
@@ -76,13 +76,18 @@
        :on-init                            (fn [reset-fn]
                                              (reset! record-reset-fn reset-fn))
        :on-start-recording                 (fn []
+                                             (rf/dispatch [:chat.ui/set-recording true])
                                              (reset! recording? true)
                                              (reset! gesture-enabled? false)
                                              (reanimated/animate container-opacity 1))
        :audio-file                         audio
+       :on-lock                            (fn []
+                                             (rf/dispatch [:chat.ui/set-recording false]))
        :on-reviewing-audio                 (fn [file]
+                                             (rf/dispatch [:chat.ui/set-recording false])
                                              (rf/dispatch [:chat.ui/set-input-audio file]))
        :on-send                            (fn [{:keys [file-path duration]}]
+                                             (rf/dispatch [:chat.ui/set-recording false])
                                              (reset! recording? false)
                                              (reset! gesture-enabled? true)
                                              (rf/dispatch [:chat/send-audio file-path duration])
@@ -94,6 +99,7 @@
                                              (rf/dispatch [:chat.ui/set-input-audio nil]))
        :on-cancel                          (fn []
                                              (when @recording?
+                                               (rf/dispatch [:chat.ui/set-recording false])
                                                (reset! recording? false)
                                                (reset! gesture-enabled? true)
                                                (if-not @focused?

--- a/src/status_im2/contexts/chat/messages/list/view.cljs
+++ b/src/status_im2/contexts/chat/messages/list/view.cljs
@@ -105,8 +105,9 @@
 (defn messages-list-content
   [{:keys [chat-id] :as chat} insets keyboard-shown]
   (fn []
-    (let [context  (rf/sub [:chats/current-chat-message-list-view-context])
-          messages (rf/sub [:chats/raw-chat-messages-stream chat-id])]
+    (let [context    (rf/sub [:chats/current-chat-message-list-view-context])
+          messages   (rf/sub [:chats/raw-chat-messages-stream chat-id])
+          recording? (rf/sub [:chats/recording?])]
       [rn/view
        {:style {:flex 1}}
        ;; NOTE: DO NOT use anonymous functions for handlers
@@ -137,7 +138,8 @@
          ;; TODO https://github.com/facebook/react-native/issues/30034
          :inverted                     (when platform/ios? true)
          :style                        (when platform/android? {:scaleY -1})
-         :on-layout                    on-messages-view-layout}]])))
+         :on-layout                    on-messages-view-layout
+         :scroll-enabled               (not recording?)}]])))
 
 ;; This should be replaced with keyboard hook. It has to do with flat-list probably. The keyboard-shown
 ;; value updates in the parent component, but does not get passed to the children.

--- a/src/status_im2/subs/root.cljs
+++ b/src/status_im2/subs/root.cljs
@@ -119,6 +119,7 @@
 (reg-root-key-sub :chats/mention-suggestions :chats/mention-suggestions)
 (reg-root-key-sub :chat/inputs-with-mentions :chat/inputs-with-mentions)
 (reg-root-key-sub :chats-home-list :chats-home-list)
+(reg-root-key-sub :chats/recording? :chats/recording?)
 
 ;;lightbox
 (reg-root-key-sub :lightbox/exit-signal :lightbox/exit-signal)


### PR DESCRIPTION
fixes #15889 

### Summary

There are some issues when holding touch to record audio and scrolling at the same time with another finger, but there's no sense on allowing the user that behaviour, so limited scrolling capability of the chat while the user is recording an audio unless recording is locked.

#### Platforms

- Android
- iOS

### Steps to test

1. Send multiple long text messages to enable scrolling in the chat.
2. Begin recording audio by holding down the 'record' button.
3. Check user can't scroll the chat while recording
4. Release the 'record' button to stop recording.
5. Send the recorded audio by tapping the  'record' button.
6. Check audio sends correctly

status: ready