### PR TITLE
Show number of unread messages

### DIFF
--- a/src/status_im2/contexts/chat/home/chat_list_item/view.cljs
+++ b/src/status_im2/contexts/chat/home/chat_list_item/view.cljs
@@ -206,7 +206,7 @@
       :size  :medium}]))
 
 (defn chat-list-item
-  [{:keys [chat-id group-chat color name unviewed-messages-count unviewed-mentions-count
+  [{:keys [chat-id group-chat color name unviewed-messages-count
            timestamp last-message muted]
     :as   item}]
   (let [display-name (if group-chat
@@ -228,8 +228,6 @@
       [name-view display-name contact timestamp]
       [last-message-preview group-chat last-message]]
      (when-not muted
-       (if (> unviewed-mentions-count 0)
+       (when (> unviewed-messages-count 0)
          [quo/info-count {:style {:top 16}}
-          unviewed-mentions-count]
-         (when (> unviewed-messages-count 0)
-           [rn/view {:style (style/count-container)}])))]))
+          unviewed-messages-count]))]))


### PR DESCRIPTION
fixes #15943

### Summary

Numbers instead of dot indicator used for all unread messages in 1-1 chat

![Screenshot 2023-05-22 at 19 57 00](https://github.com/status-im/status-mobile/assets/5786310/4b784455-d5c6-437a-9941-94c1be30423f)


### Steps to test
- UserA sends a message to UserB
- UserB checks the chat on the chat screen

status: ready
