### PR TITLE
Fix composer height overflow with extra content

### DIFF
--- a/src/status_im2/contexts/chat/composer/effects.cljs
+++ b/src/status_im2/contexts/chat/composer/effects.cljs
@@ -105,9 +105,23 @@
   (.remove ^js @keyboard-hide-listener)
   (.remove ^js @keyboard-frame-listener))
 
+(defn max-height-effect
+  [{:keys [focused?]}
+   {:keys [max-height]}
+   {:keys [height saved-height last-height]}]
+  (rn/use-effect
+   (fn []
+     (when @focused?
+       (let [new-last-height (min max-height (reanimated/get-shared-value last-height))]
+         (reanimated/set-shared-value last-height new-last-height)
+         (reanimated/animate height new-last-height)
+         (reanimated/set-shared-value saved-height new-last-height))))
+   [max-height @focused?]))
+
 (defn initialize
   [props state animations {:keys [max-height] :as dimensions}
    {:keys [chat-input images link-previews? reply audio]}]
+  (max-height-effect state dimensions animations)
   (rn/use-effect
    (fn []
      (maximized-effect state animations dimensions chat-input)

--- a/src/status_im2/contexts/chat/composer/effects.cljs
+++ b/src/status_im2/contexts/chat/composer/effects.cljs
@@ -111,11 +111,14 @@
    {:keys [height saved-height last-height]}]
   (rn/use-effect
    (fn []
+     ;; Some subscriptions can arrive after the composer if focused (esp. link
+     ;; previews), so we need to react to changes in `max-height` outside of the
+     ;; `on-focus` handler.
      (when @focused?
-       (let [new-last-height (min max-height (reanimated/get-shared-value last-height))]
-         (reanimated/set-shared-value last-height new-last-height)
-         (reanimated/animate height new-last-height)
-         (reanimated/set-shared-value saved-height new-last-height))))
+       (let [new-height (min max-height (reanimated/get-shared-value last-height))]
+         (reanimated/set-shared-value last-height new-height)
+         (reanimated/animate height new-height)
+         (reanimated/set-shared-value saved-height new-height))))
    [max-height @focused?]))
 
 (defn initialize

--- a/src/status_im2/contexts/chat/composer/handlers.cljs
+++ b/src/status_im2/contexts/chat/composer/handlers.cljs
@@ -14,13 +14,10 @@
 (defn focus
   [{:keys [input-ref] :as props}
    {:keys [text-value focused? lock-selection? saved-cursor-position gradient-z-index]}
-   {:keys [height saved-height last-height opacity background-y gradient-opacity container-opacity]
-    :as   animations}
+   {:keys [last-height opacity background-y gradient-opacity container-opacity] :as animations}
    {:keys [max-height] :as dimensions}]
   (reset! focused? true)
   (rf/dispatch [:chat.ui/set-input-focused true])
-  (reanimated/animate height (reanimated/get-shared-value last-height))
-  (reanimated/set-shared-value saved-height (reanimated/get-shared-value last-height))
   (reanimated/animate container-opacity 1)
   (when (> (reanimated/get-shared-value last-height) (* constants/background-threshold max-height))
     (reanimated/animate opacity 1)


### PR DESCRIPTION
Fixes https://github.com/status-im/status-mobile/issues/15949

### Summary

This PR fixes the maximum height overflow of the composer when there are images and/or link previews (any *extra content* as we call it in the code).

### Cause

The bug happened because the `on-focus` event of the composer happens before subscriptions arrive, and thus it uses the incorrect `max-height`.

Bug demo:

[bug-composer-with-image-and-long-text.webm](https://github.com/status-im/status-mobile/assets/46027/31940e18-6a8c-4d87-94af-a8b6c44ed51d)

### Fix

The fix makes the animation values of `height`, `last-height`, and `saved-height` be truncated based on the newest calculated `max-height`, and they happen in a separate `use-effect`, outside of the `on-focus` event.

This solution also works when link previews are loaded after `on-focus` is triggered automatically when the chat opens, whereas from inside `on-focus` the *seen* `max-height`  is outdated (which leads to the bug).

[fixed.webm](https://github.com/status-im/status-mobile/assets/46027/7bf366ad-c2b5-4d68-ba60-9976aaee8713)

#### Platforms

- Android
- iOS

### Steps to test

Paste a handful of lines to stretch out the composer closer to the max height and add images and/or link previews. You should *not* see the composer height overflowing.

status: ready
