### PR TITLE
Design note fixes (#15781)

### DIFF
--- a/src/quo2/components/info/info_message.cljs
+++ b/src/quo2/components/info/info_message.cljs
@@ -22,27 +22,26 @@
   opts
   {:type           :default/:success/:error
    :size           :default/:tiny
-   :icon           :i/info ;; info message icon
-   :text-color     colors/white     ;; text color override
-   :icon-color     colors/white    ;; icon color override
-   :no-icon-color? false       ;; disable tint color for icon"
+   :icon           :i/info       ;; info message icon
+   :text-color     colors/white  ;; text color override
+   :icon-color     colors/white  ;; icon color override
+   :no-icon-color? false         ;; disable tint color for icon"
   [{:keys [type size icon text-color icon-color no-icon-color? style]} message]
-  (let [weight          (if (= size :default) :regular :medium)
-        icon-size       (if (= size :default) 16 12)
-        icon-margin-top (if (= size :default) 2 3)
-        size            (if (= size :default) :paragraph-2 :label)
-        text-color      (or text-color (get-color type))
-        icon-color      (or icon-color text-color)]
+  (let [weight     (if (= size :default) :regular :medium)
+        icon-size  (if (= size :default) 16 12)
+        size       (if (= size :default) :paragraph-2 :label)
+        text-color (or text-color (get-color type))
+        icon-color (or icon-color text-color)]
     [rn/view
-     {:style (merge {:flex-direction :row}
+     {:style (merge {:flex-direction :row
+                     :align-items    :center}
                     style)}
      [quo2.icons/icon icon
-      {:color           icon-color
-       :no-color        no-icon-color?
-       :size            icon-size
-       :container-style {:margin-top icon-margin-top}}]
+      {:color    icon-color
+       :no-color no-icon-color?
+       :size     icon-size}]
      [text/text
       {:size   size
        :weight weight
        :style  {:color             text-color
-                :margin-horizontal 8}} message]]))
+                :margin-horizontal 4}} message]]))

--- a/src/quo2/components/inputs/profile_input/style.cljs
+++ b/src/quo2/components/inputs/profile_input/style.cljs
@@ -13,7 +13,7 @@
 
 (def button
   {:position      :absolute
-   :top           23
+   :top           24
    :bottom        0
    :left          33
    :right         0

--- a/src/quo2/components/inputs/profile_input/view.cljs
+++ b/src/quo2/components/inputs/profile_input/view.cljs
@@ -22,7 +22,7 @@
       (if platform/ios?
         [hole-view/hole-view
          {:holes [{:x            33
-                   :y            23
+                   :y            24
                    :width        24
                    :height       24
                    :borderRadius 12}]}

--- a/src/quo2/components/inputs/title_input/view.cljs
+++ b/src/quo2/components/inputs/title_input/view.cljs
@@ -15,13 +15,15 @@
 (defn title-input
   [{:keys [blur?
            on-change-text
+           auto-focus
            placeholder
            max-length
            default-value
            override-theme]
     :or   {max-length    0
+           auto-focus    false
            default-value ""}}]
-  (let [focused?  (reagent/atom false)
+  (let [focused?  (reagent/atom auto-focus)
         value     (reagent/atom default-value)
         on-change (fn [v]
                     (reset! value v)
@@ -42,6 +44,7 @@
           :keyboard-appearance (theme/theme-value :light :dark override-theme)
           :on-focus #(swap! focused? (fn [] true))
           :on-blur #(swap! focused? (fn [] false))
+          :auto-focus auto-focus
           :input-mode :text
           :on-change-text on-change
           :editable (not disabled?)

--- a/src/status_im2/contexts/onboarding/create_profile/style.cljs
+++ b/src/status_im2/contexts/onboarding/create_profile/style.cljs
@@ -28,7 +28,8 @@
    :top      0
    :bottom   0
    :left     0
-   :right    0})
+   :right    0
+   :z-index  100})
 
 (def info-message
   {:margin-top 8})

--- a/translations/en.json
+++ b/translations/en.json
@@ -1528,7 +1528,7 @@
     "your-data-belongs-to-you": "If you lose your seed phrase you lose your data and funds",
     "your-data-belongs-to-you-description": "If you lose access, for example by losing your phone, you can only access your keys with your seed phrase. No one, but you has your seed phrase. Write it down. Keep it safe",
     "your-identifiers": "Your identicon ring, chat key and emojihash will help others tell you from impersonators",
-    "your-name": "Your Name",
+    "your-name": "Your name",
     "your-recovery-phrase": "Your seed phrase",
     "your-recovery-phrase-description": "This is your seed phrase. You use it to prove that this is your wallet. You only get to see it once! Write it on paper and keep it in a secure place. You will need it if you lose or reinstall your wallet.",
     "custom-seed-phrase": "Invalid seed phrase",


### PR DESCRIPTION
fixes #15781

## Expected fixes

### Profile name
- [X] Change paddings (full comment [here](https://www.figma.com/file/Tf5nfkYvpbnNCo4rKLK7lS?node-id=1908:165988#428217503))
  - No changes: paddings/spacing looks accurate
- [X] Check avatar size (full comment [here](https://www.figma.com/file/Tf5nfkYvpbnNCo4rKLK7lS?node-id=1908:165988#428005167))
  - Confirmed: correct size = 48 (same as figma)
- [X] Check initial text size (full comment [here](https://www.figma.com/file/Tf5nfkYvpbnNCo4rKLK7lS?node-id=1908:165988#428005420))
  - Confirmed: :heading-2, font size: 19px
- [X] Align photo icon to the avatar (full comment [here](https://www.figma.com/file/Tf5nfkYvpbnNCo4rKLK7lS?node-id=1908:165988#428006053))
- [X] Make edit box focused by default with opened keyboard (full comment [here](https://www.figma.com/file/Tf5nfkYvpbnNCo4rKLK7lS?node-id=1908:165988#428007727)) 
  - Q: Is iOS, I cannot open the keyboard unless focus is already in the edit box
- [X] "Name" shouldn't start with a capital letter (full comment [here](https://www.figma.com/file/Tf5nfkYvpbnNCo4rKLK7lS?node-id=1908:165988#428008049))
  - Fixed in translations/en.json
- [X] Check font size of placeholder (full comment [here](https://www.figma.com/file/Tf5nfkYvpbnNCo4rKLK7lS?node-id=1908:165988#428217177))
  - Confirmed: :heading-2, font size: 19px
- [X] Medium font size for "Accent colour" (full comment [here](https://www.figma.com/file/Tf5nfkYvpbnNCo4rKLK7lS?node-id=1908:165988#428011481)) 
  - Fixed: Added ":weight :medium" (weight was not specified).
- [X] Change the background according to design (full comment [here](https://www.figma.com/file/Tf5nfkYvpbnNCo4rKLK7lS?node-id=1908:165988#428189441)) 
  - Figma Notes:
    This background is wrong:
    Only has to appear when button covers top content (colours)
    It's too dark, check design here: https://www.figma.com/file/o4qG1bnFyuyFOvHQVGgeFY/Onboarding-for-Mobile?node-id=6345%3A327366&t=azdmhomknDfXwYtl-1
  - Recommend this be added as a new issue: this appears to be a new UX feature (I don't see any place where this is already implemented).
  - pavloburykh: "Logged a separate issue to track that #16181"

### Avatar drawer
- [X] Check icon design/size (full comment [here](https://www.figma.com/file/Tf5nfkYvpbnNCo4rKLK7lS?node-id=1908:165988#428200533)) 
  - Confirmed: camera icon is correct image, and is 20x20 (gallery image is correct as well)
- [X] Check drawer background (full comment [here](https://www.figma.com/file/Tf5nfkYvpbnNCo4rKLK7lS?node-id=1908:165988#428203070)) 
  - Figma Note: Check drawer background, looks like dark theme, not blur theme
  - Recommend deferring this issue since blur implementation hasn't stabilized yet for iOS/Android.
  - J-Son89: "I imagine this is just a generic solution for bottom sheets so not necessary to fix in your issue/pr imo"

### Profile name - errors
- [X] "Special chars are not allowed" - Check size, design, distance to the text.... (full comment [here](https://www.figma.com/file/Tf5nfkYvpbnNCo4rKLK7lS?node-id=1908:165988#428266752)) 
  - Figma Notes: Icon is broken: Check size, design, distance to the text....
  - Icon size: correct (16)
  - Icon design: correct (info)
  - Distance to text: 'info-message' component modified as below:
    - removed extra icon container
    - changed text padding from 8 to 4
    - added align-items: center 
- [X] Flickering screen on focus (full comment [here](https://www.figma.com/file/Tf5nfkYvpbnNCo4rKLK7lS?node-id=1908:165988#428273559)) 
Video (slowed down 1/4X)
  - Figma Note: When you tap to focus on the name input, the title "Create profile" disappears for a second and the content jump

https://user-images.githubusercontent.com/4557972/235442939-54820d73-062d-459e-a9dd-5ef9b7b1036a.mp4

### Avatar selector
- [X] Flickering screen on selecting profile photos(full comment [here](https://www.figma.com/file/Tf5nfkYvpbnNCo4rKLK7lS?node-id=1908:165988#428294187), video is [here](https://drive.google.com/file/d/1JCZSsSNYy_2Q5UGoHOhQg6gJo_r_-K5K/view))
  - In the video, the photo is selected, which triggers the screen to be minimized while the photo fades out. Then the photo selection suddently appear for a split second (the flicker).
  - When I attempted to reproduce, the flicker did not occur.
  - J-Son89: "Afaik the flickering on image select is an issue with the package- https://github.com/ivpusic/react-native-image-crop-picker/issues/1658 I believe they have fixed it and once we upgrade the dependency then we will get that fix for free."


status: ready
