### PR TITLE
fix composer max-lines

### DIFF
--- a/src/status_im2/contexts/chat/composer/utils.cljs
+++ b/src/status_im2/contexts/chat/composer/utils.cljs
@@ -35,7 +35,7 @@
   [y lines max-lines gradient-opacity focused?]
   (and
    (> y constants/line-height)
-   (>= lines max-lines)
+   (>= lines (dec max-lines))
    (= (reanimated/get-shared-value gradient-opacity) 0)
    @focused?))
 

--- a/src/status_im2/contexts/chat/composer/utils.cljs
+++ b/src/status_im2/contexts/chat/composer/utils.cljs
@@ -35,7 +35,7 @@
   [y lines max-lines gradient-opacity focused?]
   (and
    (> y constants/line-height)
-   (>= lines (dec max-lines))
+   (>= lines max-lines)
    (= (reanimated/get-shared-value gradient-opacity) 0)
    @focused?))
 
@@ -61,9 +61,12 @@
       (> (reanimated/get-shared-value layout-height) (oops/oget event "nativeEvent.layout.height"))))
 
 (defn calc-lines
-  [height]
-  (let [lines (Math/round (/ height constants/line-height))]
-    (if platform/ios? lines (dec lines))))
+  ([height]
+   (calc-lines height false))
+  ([height floor?]
+   (let [lines (/ height constants/line-height)
+         lines (if floor? (Math/floor lines) (Math/round lines))]
+     (if platform/ios? lines (dec lines)))))
 
 (defn calc-extra-content-height
   [images? link-previews? reply? edit?]

--- a/src/status_im2/contexts/chat/composer/view.cljs
+++ b/src/status_im2/contexts/chat/composer/view.cljs
@@ -36,7 +36,7 @@
                                                         insets)
         lines                    (utils/calc-lines (- @content-height
                                                       constants/extra-content-offset))
-        max-lines                (utils/calc-lines max-height)
+        max-lines                (utils/calc-lines max-height true)
         animations               (utils/init-animations
                                   subs
                                   lines


### PR DESCRIPTION
This PR fixes max-lines calculation by using `floor` instead of `round`.