### PR TITLE
fix composer calc lines

### DIFF
--- a/src/status_im2/contexts/chat/composer/utils.cljs
+++ b/src/status_im2/contexts/chat/composer/utils.cljs
@@ -62,8 +62,7 @@
 
 (defn calc-lines
   [height]
-  (let [lines (Math/round (/ height constants/line-height))]
-    (if platform/ios? lines (dec lines))))
+  (Math/floor (/ height constants/line-height)))
 
 (defn calc-extra-content-height
   [images? link-previews? reply? edit?]


### PR DESCRIPTION
This PR fixes `calc-lines` method in composer by using `floor` instead of `round`, and removing unnecessary if condition.