### PR TITLE
Bottom sheet background on Android changed to overcome issues with blur

### DIFF
--- a/src/status_im2/common/bottom_sheet/styles.cljs
+++ b/src/status_im2/common/bottom_sheet/styles.cljs
@@ -1,5 +1,6 @@
 (ns status-im2.common.bottom-sheet.styles
-  (:require [quo2.foundations.colors :as colors]))
+  (:require [quo2.foundations.colors :as colors]
+            [status-im.utils.platform :as platform]))
 
 (defn handle
   [override-theme]
@@ -30,7 +31,7 @@
 
 (def shell-bg
   {:position         :absolute
-   :background-color colors/white-opa-5
+   :background-color (if platform/ios? colors/white-opa-5 colors/neutral-100-opa-90)
    :left             0
    :right            0
    :top              0


### PR DESCRIPTION
fixes #16007

### Summary
Background on bottom_shett with `shell?` option made non-transparent for Android. Hope this is a temporary solution until Android blur fixed (fingers crossed for @briansztamfater with #15953 🤞)

<img width="336" alt="Screenshot 2023-05-24 at 14 54 31" src="https://github.com/status-im/status-mobile/assets/5786310/fb21b5db-432c-40f0-b02b-3ed484ff9b52">



status: ready