### PR TITLE
[Fix] QR scanner scanning QR when user moved to next screen

### DIFF
--- a/src/status_im2/contexts/onboarding/syncing/progress/view.cljs
+++ b/src/status_im2/contexts/onboarding/syncing/progress/view.cljs
@@ -31,7 +31,9 @@
 (defn try-again-button
   [profile-color]
   [quo/button
-   {:on-press                  #(rf/dispatch [:navigate-back])
+   {:on-press                  (fn []
+                                 (rf/dispatch [:syncing/clear-states])
+                                 (rf/dispatch [:navigate-back]))
     :accessibility-label       :try-again-later-button
     :override-background-color (colors/custom-color profile-color 60)
     :style                     style/try-again-button}

--- a/src/status_im2/contexts/syncing/events.cljs
+++ b/src/status_im2/contexts/syncing/events.cljs
@@ -24,6 +24,11 @@
   [{:keys [db]} role]
   {:db (assoc-in db [:syncing :role] role)})
 
+(rf/defn local-pairing-clear-states
+  {:events [:syncing/clear-states]}
+  [{:keys [db]} role]
+  {:db (dissoc db :syncing)})
+
 (defn- get-default-node-config
   [installation-id]
   (let [db {:networks/current-network config/default-network

--- a/src/status_im2/contexts/syncing/scan_sync_code/view.cljs
+++ b/src/status_im2/contexts/syncing/scan_sync_code/view.cljs
@@ -201,10 +201,11 @@
                                                         :text (i18n/label
                                                                :t/camera-permission-denied)}])}]))]
     (fn []
-      (let [view-id                          (rf/sub [:view-id])
-            camera-ref                       (atom nil)
+      (let [camera-ref                       (atom nil)
             read-qr-once?                    (atom false)
-            user-in-syncing-progress-screen? (= view-id :syncing-progress)
+            ;; The below check is to prevent scanning of any QR code
+            ;; when the user is in syncing progress screen
+            user-in-syncing-progress-screen? (= (rf/sub [:view-id]) :syncing-progress)
             on-read-code                     (fn [data]
                                                (when (and (not @read-qr-once?)
                                                           (not user-in-syncing-progress-screen?))

--- a/src/status_im2/contexts/syncing/scan_sync_code/view.cljs
+++ b/src/status_im2/contexts/syncing/scan_sync_code/view.cljs
@@ -185,8 +185,7 @@
 
 (defn f-view
   [{:keys [title show-bottom-view? background]}]
-  (let [view-id                   (rf/sub [:view-id])
-        insets                    (safe-area/get-insets)
+  (let [insets                    (safe-area/get-insets)
         active-tab                (reagent/atom 1)
         qr-view-finder            (reagent/atom {})
         request-camera-permission (fn []
@@ -202,7 +201,8 @@
                                                         :text (i18n/label
                                                                :t/camera-permission-denied)}])}]))]
     (fn []
-      (let [camera-ref                       (atom nil)
+      (let [view-id                          (rf/sub [:view-id])
+            camera-ref                       (atom nil)
             read-qr-once?                    (atom false)
             user-in-syncing-progress-screen? (= view-id :syncing-progress)
             on-read-code                     (fn [data]

--- a/src/status_im2/contexts/syncing/scan_sync_code/view.cljs
+++ b/src/status_im2/contexts/syncing/scan_sync_code/view.cljs
@@ -185,7 +185,8 @@
 
 (defn f-view
   [{:keys [title show-bottom-view? background]}]
-  (let [insets                    (safe-area/get-insets)
+  (let [view-id                   (rf/sub [:view-id])
+        insets                    (safe-area/get-insets)
         active-tab                (reagent/atom 1)
         qr-view-finder            (reagent/atom {})
         request-camera-permission (fn []
@@ -201,19 +202,21 @@
                                                         :text (i18n/label
                                                                :t/camera-permission-denied)}])}]))]
     (fn []
-      (let [camera-ref        (atom nil)
-            read-qr-once?     (atom false)
-            on-read-code      (fn [data]
-                                (when-not @read-qr-once?
-                                  (reset! read-qr-once? true)
-                                  (js/setTimeout (fn []
-                                                   (reset! read-qr-once? false))
-                                                 3000)
-                                  (check-qr-code-data data)))
-            scan-qr-code-tab? (= @active-tab 1)
-            show-camera?      (and scan-qr-code-tab? @camera-permission-granted?)
-            show-holes?       (and show-camera?
-                                   (boolean (not-empty @qr-view-finder)))]
+      (let [camera-ref                       (atom nil)
+            read-qr-once?                    (atom false)
+            user-in-syncing-progress-screen? (= view-id :syncing-progress)
+            on-read-code                     (fn [data]
+                                               (when (and (not @read-qr-once?)
+                                                          (not user-in-syncing-progress-screen?))
+                                                 (reset! read-qr-once? true)
+                                                 (js/setTimeout (fn []
+                                                                  (reset! read-qr-once? false))
+                                                                3000)
+                                                 (check-qr-code-data data)))
+            scan-qr-code-tab?                (= @active-tab 1)
+            show-camera?                     (and scan-qr-code-tab? @camera-permission-granted?)
+            show-holes?                      (and show-camera?
+                                                  (boolean (not-empty @qr-view-finder)))]
         (rn/use-effect
          (fn []
            (when-not @camera-permission-granted?


### PR DESCRIPTION
fixes #15970

### Summary

This PR fixes the QR scanner that scans the QR code when the user is moved to the next screen (`:syncing-progress`). 

The bug was caused when due to the navigational stack. The "QR scanner" screen will be behind the "Syncing devices" screen, and the QR scanner reset after 3 seconds to scan/process any QR code. The fix was to ensure the scanner scan/process the data only when the user is on the "QR scanner" screen.

### Platforms

- Android
- iOS

### Steps to test

- Open Status
- Navigate to `Sign in`
- Enable access to the camera
- Point the camera at an invalid QR code. (for instance, a QR code that has been used before)
- Check if the user gets redirected again to the `Something went wrong` screen more than once.

status: ready 
