### PR TITLE
Use new login endpoint

### DIFF
--- a/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusModule.java
+++ b/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusModule.java
@@ -415,6 +415,17 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
     }
 
     @ReactMethod
+    public void loginAccount(final String request) {
+        Log.d(TAG, "loginAccount");
+        String result = Statusgo.loginAccount(request);
+        if (result.startsWith("{\"error\":\"\"")) {
+            Log.d(TAG, "loginAccount result: " + result);
+        } else {
+            Log.e(TAG, "loginAccount failed: " + result);
+        }
+    }
+
+    @ReactMethod
     public void exportUnencryptedDatabase(final String accountData, final String password, final Callback callback) {
         Log.d(TAG, "login");
 

--- a/modules/react-native-status/ios/RCTStatus/RCTStatus.m
+++ b/modules/react-native-status/ios/RCTStatus/RCTStatus.m
@@ -623,6 +623,14 @@ RCT_EXPORT_METHOD(loginWithConfig:(NSString *)accountData
     NSLog(@"%@", result);
 }
 
+RCT_EXPORT_METHOD(loginAccount:(NSString *)request) {
+#if DEBUG
+    NSLog(@"LoginAccount() method called");
+#endif
+    NSString *result = StatusgoLoginAccount(request);
+    NSLog(@"%@", result);
+}
+
 RCT_EXPORT_METHOD(loginWithKeycard:(NSString *)accountData
                   password:(NSString *)password
                   chatKey:(NSString *)chatKey) {

--- a/src/native_module/core.cljs
+++ b/src/native_module/core.cljs
@@ -82,6 +82,15 @@
      key-uid
      #(.loginWithConfig ^js (status) account-data hashed-password config))))
 
+(defn login-account
+  "NOTE: beware, the password has to be sha3 hashed"
+  [{:keys [keyUid] :as request}]
+  (log/debug "[native-module] loginWithConfig")
+  (clear-web-data)
+  (init-keystore
+   keyUid
+   #(.loginAccount ^js (status) (types/clj->json request))))
+
 (defn create-account-and-login
   [request]
   (.createAccountAndLogin ^js (status) (types/clj->json request)))

--- a/src/status_im/multiaccounts/login/core.cljs
+++ b/src/status_im/multiaccounts/login/core.cljs
@@ -21,7 +21,6 @@
     [status-im.multiaccounts.biometric.core :as biometric]
     [status-im.multiaccounts.core :as multiaccounts]
     [native-module.core :as native-module]
-    [status-im.node.core :as node]
     [status-im.notifications.core :as notifications]
     [status-im.popover.core :as popover]
     [status-im.signing.eip1559 :as eip1559]
@@ -58,8 +57,18 @@
 
 (re-frame/reg-fx
  ::login
- (fn [[key-uid account-data hashed-password]]
-   (native-module/login-with-config key-uid account-data hashed-password node/login-node-config)))
+ (fn [[key-uid _ hashed-password]]
+   (native-module/login-account {:keyUid                      key-uid
+                                 :password                    hashed-password
+                                 :openseaAPIKey               config/opensea-api-key
+
+                                 :poktToken                   config/POKT_TOKEN
+                                 :infuraToken                 config/INFURA_TOKEN
+
+                                 :alchemyOptimismMainnetToken config/ALCHEMY_OPTIMISM_MAINNET_TOKEN
+                                 :alchemyOptimismGoerliToken  config/ALCHEMY_OPTIMISM_GOERLI_TOKEN
+                                 :alchemyArbitrumMainnetToken config/ALCHEMY_ARBITRUM_MAINNET_TOKEN
+                                 :alchemyArbitrumGoerliToken  config/ALCHEMY_ARBITRUM_GOERLI_TOKEN})))
 
 (re-frame/reg-fx
  ::export-db


### PR DESCRIPTION
Use new login endpoint
https://github.com/status-im/status-go/compare/75864528...3559636a

This commit changes the login endpoint so that it uses LoginAccount.
The main difference is that is consistent with the two others we use for
creation/importing, and this will override the networks and use the
secrets provided.

This should allow us in theory to remove a fair amount of code (anything to do with node config, but that would be a separate PR)