### PR TITLE
[Fix] Nav bar overlap in "Syncing" screen

### DIFF
--- a/src/status_im2/contexts/syncing/setup_syncing/style.cljs
+++ b/src/status_im2/contexts/syncing/setup_syncing/style.cljs
@@ -1,11 +1,9 @@
 (ns status-im2.contexts.syncing.setup-syncing.style
   (:require [quo2.foundations.colors :as colors]))
 
-(defn container-main
-  [top]
+(def container-main
   {:background-color colors/neutral-95
-   :flex             1
-   :padding-top      top})
+   :flex             1})
 
 (def page-container
   {:margin-horizontal 20})

--- a/src/status_im2/contexts/syncing/setup_syncing/view.cljs
+++ b/src/status_im2/contexts/syncing/setup_syncing/view.cljs
@@ -12,7 +12,6 @@
             [reagent.core :as reagent]
             [status-im2.common.resources :as resources]
             [react-native.hooks :as hooks]
-            [react-native.safe-area :as safe-area]
             [status-im2.contexts.syncing.utils :as sync-utils]))
 
 (def code-valid-for-ms 120000)
@@ -66,7 +65,7 @@
                         (reset! valid-for-ms code-valid-for-ms))]
 
     (fn []
-      [rn/view {:style (style/container-main (safe-area/get-top))}
+      [rn/view {:style style/container-main}
        [:f> f-use-interval clock cleanup-clock @delay]
        [rn/scroll-view {}
         [navigation-bar]

--- a/src/status_im2/navigation/options.cljs
+++ b/src/status_im2/navigation/options.cljs
@@ -90,6 +90,12 @@
    :animations             {:showModal    {:alpha {:from 1 :to 1 :duration 300}}
                             :dismissModal {:alpha {:from 1 :to 1 :duration 300}}}})
 
+(def dark-screen
+  (merge (statusbar true)
+         {:layout {:componentBackgroundColor colors/neutral-95
+                   :orientation              ["portrait"]
+                   :backgroundColor          colors/neutral-95}}))
+
 (def lightbox
   {:topBar        {:visible false}
    :statusBar     {:backgroundColor :transparent

--- a/src/status_im2/navigation/screens.cljs
+++ b/src/status_im2/navigation/screens.cljs
@@ -95,12 +95,11 @@
      :component communities.overview/overview}
 
     {:name      :settings-syncing
-     :options   (options/statusbar true)
+     :options   (merge options/dark-screen {:insets {:top? true}})
      :component settings-syncing/view}
 
     {:name      :settings-setup-syncing
-     :options   (options/statusbar true)
-
+     :options   (merge options/dark-screen {:insets {:top? true}})
      :component settings-setup-syncing/view}
 
     ;; Onboarding


### PR DESCRIPTION
fixes #16011

### Summary

This PR fixes the overlap of the Navigation bar with the status bar in the "Syncing" screen.

### Steps to test

- Open Status
- Navigate to Profile > Syncing
- Check if the Navigation bar overlaps with the status bar

status: ready 
