### PR TITLE
fix mentions delay

### DIFF
--- a/src/status_im2/contexts/chat/composer/effects.cljs
+++ b/src/status_im2/contexts/chat/composer/effects.cljs
@@ -183,7 +183,7 @@
        (when @input-ref
          (.setNativeProps ^js @input-ref (clj->js {:text input-text})))
        (reset! text-value input-text)
-       (debounce/debounce-and-dispatch [:mention/on-change-text input-text] 300)))
+       (rf/dispatch [:mention/on-change-text input-text])))
    [input-text]))
 
 (defn did-mount

--- a/src/status_im2/contexts/chat/composer/effects.cljs
+++ b/src/status_im2/contexts/chat/composer/effects.cljs
@@ -9,7 +9,6 @@
     [status-im2.contexts.chat.composer.constants :as constants]
     [status-im2.contexts.chat.composer.keyboard :as kb]
     [status-im2.contexts.chat.composer.utils :as utils]
-    [utils.debounce :as debounce]
     [utils.number :as utils.number]
     [utils.re-frame :as rf]))
 

--- a/src/status_im2/contexts/chat/composer/handlers.cljs
+++ b/src/status_im2/contexts/chat/composer/handlers.cljs
@@ -1,5 +1,6 @@
 (ns status-im2.contexts.chat.composer.handlers
   (:require
+    [clojure.string :as string]
     [oops.core :as oops]
     [react-native.core :as rn]
     [react-native.reanimated :as reanimated]
@@ -120,7 +121,7 @@
     (@record-reset-fn)
     (reset! recording? false))
   (rf/dispatch [:chat.ui/set-chat-input-text text])
-  (if (= "@" (utils/get-last-char text))
+  (if (string/ends-with? text "@")
     (rf/dispatch [:mention/on-change-text text])
     (debounce/debounce-and-dispatch [:mention/on-change-text text] 300)))
 

--- a/src/status_im2/contexts/chat/composer/handlers.cljs
+++ b/src/status_im2/contexts/chat/composer/handlers.cljs
@@ -60,7 +60,7 @@
 
 (defn content-size-change
   [event
-   {:keys [maximized? lock-layout?]}
+   {:keys [maximized? lock-layout? text-value]}
    {:keys [height saved-height opacity background-y]}
    {:keys [content-height window-height max-height]}
    keyboard-shown]
@@ -68,7 +68,7 @@
     (let [event-size   (oops/oget event "nativeEvent.contentSize.height")
           content-size (+ event-size constants/extra-content-offset)
           lines        (utils/calc-lines event-size)
-          content-size (if (= lines 1)
+          content-size (if (or (= lines 1) (empty? @text-value))
                          constants/input-height
                          (if (= lines 2) constants/multiline-minimized-height content-size))
           new-height   (utils/bounded-val content-size constants/input-height max-height)]
@@ -120,7 +120,9 @@
     (@record-reset-fn)
     (reset! recording? false))
   (rf/dispatch [:chat.ui/set-chat-input-text text])
-  (debounce/debounce-and-dispatch [:mention/on-change-text text] 300))
+  (if (= "@" (utils/get-last-char text))
+    (rf/dispatch [:mention/on-change-text text])
+    (debounce/debounce-and-dispatch [:mention/on-change-text text] 300)))
 
 (defn selection-change
   [event

--- a/src/status_im2/contexts/chat/composer/utils.cljs
+++ b/src/status_im2/contexts/chat/composer/utils.cljs
@@ -143,10 +143,6 @@
         base
         (+ constants/actions-container-height (:bottom insets) (- curr-height cursor-pos) 18)))))
 
-(defn get-last-char
-  [s]
-  (subs s (dec (count s))))
-
 (defn init-props
   []
   {:input-ref                   (atom nil)

--- a/src/status_im2/contexts/chat/composer/utils.cljs
+++ b/src/status_im2/contexts/chat/composer/utils.cljs
@@ -143,6 +143,9 @@
         base
         (+ constants/actions-container-height (:bottom insets) (- curr-height cursor-pos) 18)))))
 
+(defn get-last-char
+  [s]
+  (subs s (dec (count s))))
 
 (defn init-props
   []


### PR DESCRIPTION
Recently `debounce-and-dispatch` was used to find the mentions suggestions for performance reasons. But currently when typing the character "@" there is a noticeable delay before the suggestions list appears. This PR fixes that by dispatching immediately if the last typed char was "@", otherwise debounce.