### PR TITLE
Add default customization color

### DIFF
--- a/src/status_im2/subs/chat/chats.cljs
+++ b/src/status_im2/subs/chat/chats.cljs
@@ -282,7 +282,7 @@
  :profile/customization-color
  :<- [:multiaccounts/multiaccounts]
  (fn [multiaccounts [_ id]]
-   (:customization-color (get multiaccounts id))))
+   (or (:customization-color (get multiaccounts id)) constants/profile-default-color)))
 
 (re-frame/reg-sub
  :chats/unread-messages-number


### PR DESCRIPTION
temporary fix for #15969

### Summary

This PR adds the default customization color to the sub `:profile/customization-color`.


status: ready
