### PR TITLE
[Fix] Error on opening "How to scan" bottom sheet

### DIFF
--- a/src/quo2/components/tags/context_tag/view.cljs
+++ b/src/quo2/components/tags/context_tag/view.cljs
@@ -44,7 +44,7 @@
   (let [text-params       {:weight :medium
                            :size   :paragraph-2
                            :style  (assoc text-style :justify-content :center)}
-        empty-photo?      (empty? photo)
+        empty-photo?      (nil? photo)
         avatar-size       :xxs
         avatar-outer-size (get-in user-avatar-style/sizes [avatar-size :outer])]
     [rn/view {:flex-direction :row}

--- a/src/status_im2/common/bottom_sheet_screen/style.cljs
+++ b/src/status_im2/common/bottom_sheet_screen/style.cljs
@@ -15,10 +15,10 @@
     :right            0}))
 
 (defn main-view
-  [translate-y]
+  [translate-y override-theme]
   (reanimated/apply-animations-to-style
    {:transform [{:translate-y translate-y}]}
-   {:background-color        (colors/theme-colors colors/white colors/neutral-95)
+   {:background-color        (colors/theme-colors colors/white colors/neutral-95 override-theme)
     :border-top-left-radius  20
     :border-top-right-radius 20
     :flex                    1
@@ -36,8 +36,8 @@
    :align-items     :center})
 
 (defn handle
-  []
+  [override-theme]
   {:width            32
    :height           4
    :border-radius    100
-   :background-color (colors/theme-colors colors/neutral-100-opa-30 colors/white-opa-30)})
+   :background-color (colors/theme-colors colors/neutral-100-opa-30 colors/white-opa-30 override-theme)})

--- a/src/status_im2/common/bottom_sheet_screen/view.cljs
+++ b/src/status_im2/common/bottom_sheet_screen/view.cljs
@@ -45,8 +45,9 @@
 
 (defn f-view
   [content skip-background?]
-  (let [scroll-enabled (reagent/atom true)
-        curr-scroll    (atom 0)]
+  (let [scroll-enabled           (reagent/atom true)
+        curr-scroll              (atom 0)
+        {:keys [override-theme]} (rf/sub [:get-screen-params])]
     (fn []
       (let [insets           (safe-area/get-insets)
             {:keys [height]} (rn/get-window)
@@ -70,9 +71,9 @@
            [reanimated/view {:style (style/background opacity)}])
          [gesture/gesture-detector
           {:gesture (drag-gesture translate-y opacity scroll-enabled curr-scroll close)}
-          [reanimated/view {:style (style/main-view translate-y)}
+          [reanimated/view {:style (style/main-view translate-y override-theme)}
            [rn/view {:style style/handle-container}
-            [rn/view {:style (style/handle)}]]
+            [rn/view {:style (style/handle override-theme)}]]
            [content
             {:insets         insets
              :close          close

--- a/src/status_im2/contexts/syncing/how_to_pair/view.cljs
+++ b/src/status_im2/contexts/syncing/how_to_pair/view.cljs
@@ -49,7 +49,8 @@
      (i18n/label (:label value))]))
 
 (defn render-item
-  [i item]
+  [i list-item]
+  ^{:key i}
   [rn/view
    {:margin-vertical 6
     :style           style/numbered-list-item}
@@ -60,7 +61,11 @@
      {:size   :label
       :weight :medium
       :style  style/list-icon-text} i]]
-   (map #(render-element %) item)])
+   (map-indexed (fn [idx item]
+                  ^{:key idx}
+                  [:<>
+                   (render-element item)])
+                list-item)])
 
 (defn render-list
   [{:keys [title image list]}]

--- a/src/status_im2/contexts/syncing/how_to_pair/view.cljs
+++ b/src/status_im2/contexts/syncing/how_to_pair/view.cljs
@@ -63,8 +63,7 @@
       :style  style/list-icon-text} i]]
    (map-indexed (fn [idx item]
                   ^{:key idx}
-                  [:<>
-                   (render-element item)])
+                  [render-element item])
                 list-item)])
 
 (defn render-list

--- a/src/status_im2/contexts/syncing/setup_syncing/view.cljs
+++ b/src/status_im2/contexts/syncing/setup_syncing/view.cljs
@@ -31,7 +31,8 @@
                               :label               (i18n/label :t/how-to-scan)
                               :icon                :i/info
                               :icon-override-theme :dark
-                              :on-press            #(rf/dispatch [:open-modal :how-to-pair])}]}]])
+                              :on-press            #(rf/dispatch [:open-modal :how-to-pair
+                                                                  {:override-theme :dark}])}]}]])
 
 (defn f-use-interval
   [clock cleanup-clock delay]


### PR DESCRIPTION
fixes #16032

### Summary

This PR fixes the `723 is not ISeqable` error popup that is thrown when trying to open the `How to scan` bottom sheet.

The issue is caused due to the `empty?` check on the photo in `context-tag`. The picture data is either a string (web URL, base64) or a number (local asset). It is never a sequence. So, replaced the `empty?` check with `nil?` as it's more appropriate. I have checked the context usage across the application, everything works fine.

#### Platforms

- Android
- iOS

### Steps to test

1) Open Status
2) Log in to your existing account
3) Navigate to `Profile > Syncing`.
4) Navigate to the `Setup Syncing` screen by tapping the `+` button on the top right.
5) Tap on the `How to scan` button

status: ready 
