### PR TITLE
disable chat swipe back navigation in ios

### DIFF
--- a/src/status_im2/navigation/screens.cljs
+++ b/src/status_im2/navigation/screens.cljs
@@ -53,7 +53,8 @@
      :component shell/shell-stack}
 
     {:name      :chat
-     :options   {:insets {:top? true}}
+     :options   {:insets     {:top? true}
+                 :popGesture false}
      :component chat/chat}
 
     {:name      :start-a-new-chat


### PR DESCRIPTION
fixes: https://github.com/status-im/status-mobile/issues/16034

### Summary

While navigating back using swipe in ios, `navigate-back-handler` don't get called and chat never gets closed.

### Testing
So now we are remove chat from db, when chat screen is not visible, like going back to home screen.
Is there any other screen we can open without closing chat screen, like having chat screen in background?
In that case this solution might create problem. Please let me know if there are any such cases.

status: ready