### PR TITLE
feat: browser input

### DIFF
--- a/src/quo2/components/inputs/browser_input/component_spec.cljs
+++ b/src/quo2/components/inputs/browser_input/component_spec.cljs
@@ -1,0 +1,57 @@
+(ns quo2.components.inputs.browser-input.component-spec
+  (:require [quo2.components.inputs.browser-input.view :as browser-input]
+            [test-helpers.component :as h]))
+
+(h/describe "Browser input"
+  (h/test "Renders empty in default state"
+    (h/render [browser-input/browser-input
+               {:on-change-text (h/mock-fn)
+                :value          ""}])
+    (h/is-truthy (h/get-by-label-text :browser-input)))
+
+  (h/test "Value updates on change"
+    (let [on-change-text (h/mock-fn)]
+      (h/render [browser-input/browser-input
+                 {:on-change-text on-change-text
+                  :value          "mock text"}])
+      (h/fire-event :change-text (h/get-by-label-text :browser-input) "mock-text-new")
+      (h/was-called on-change-text)))
+
+  (h/describe "Input Label"
+    (h/test "Doesn't render when not specified"
+      (h/render [browser-input/browser-input])
+      (h/is-null (h/query-by-label-text :browser-input-label)))
+
+    (h/test "Renders label text when specified"
+      (h/render [browser-input/browser-input
+                 {:label "mock-label"}])
+      (h/is-truthy (h/query-by-label-text :browser-input-label)))
+
+    (h/test "Renders label favicon when specified alongside label text"
+      (h/render [browser-input/browser-input
+                 {:label "mock-label" :favicon :i/verified}])
+      (h/is-truthy (h/query-by-label-text :browser-input-favicon)))
+
+    (h/test "Renders lock icon when using ssl alongside label text"
+      (h/render [browser-input/browser-input
+                 {:label "mock-label" :use-ssl? true}])
+      (h/is-truthy (h/query-by-label-text :browser-input-locked-icon))))
+
+  (h/describe "Clear button"
+    (h/test "Doesn't render in default state"
+      (h/render [browser-input/browser-input])
+      (h/is-null (h/query-by-label-text :browser-input-clear-button)))
+
+    (h/test "Renders when there is a value"
+      (h/render [browser-input/browser-input
+                 {:default-value "mock text"}])
+      (h/is-truthy (h/query-by-label-text :browser-input-clear-button)))
+
+    (h/test "Is pressable"
+      (let [on-clear (h/mock-fn)]
+        (h/render [browser-input/browser-input
+                   {:default-value "mock text"
+                    :on-clear      on-clear}])
+        (h/is-truthy (h/query-by-label-text :browser-input-clear-button))
+        (h/fire-event :press (h/query-by-label-text :browser-input-clear-button))
+        (h/was-called on-clear)))))

--- a/src/quo2/components/inputs/browser_input/style.cljs
+++ b/src/quo2/components/inputs/browser_input/style.cljs
@@ -1,0 +1,44 @@
+(ns quo2.components.inputs.browser-input.style
+  (:require [quo2.components.markdown.text :as text]
+            [quo2.foundations.colors :as colors]))
+
+(def clear-icon-container
+  {:align-items     :center
+   :height          20
+   :justify-content :center
+   :margin-left     8
+   :width           20})
+
+(def favicon-icon-container
+  {:margin-right 4})
+
+(defn input
+  [disabled?]
+  (assoc (text/text-style {:size   :paragraph-1
+                           :weight :regular})
+         :flex             1
+         :min-height       32
+         :min-width        120
+         :opacity          (if disabled? 0.3 1)
+         :padding-vertical 5))
+
+(def lock-icon-container
+  {:margin-left 2})
+
+(def input-container
+  {:align-items    :center
+   :flex           1
+   :flex-direction :row})
+
+(def label-container
+  {:align-items    :center
+   :flex-direction :row
+   :margin-bottom  24
+  })
+
+(defn text
+  []
+  (assoc (text/text-style {:size   :paragraph-1
+                           :weight :medium})
+         :color
+         (colors/theme-colors colors/neutral-100 colors/white)))

--- a/src/quo2/components/inputs/browser_input/view.cljs
+++ b/src/quo2/components/inputs/browser_input/view.cljs
@@ -1,0 +1,129 @@
+(ns quo2.components.inputs.browser-input.view
+  (:require [quo2.components.icon :as icon]
+            [quo2.components.inputs.browser-input.style :as style]
+            [react-native.core :as rn]
+            [reagent.core :as reagent]
+            [quo2.foundations.colors :as colors]
+            [react-native.platform :as platform]))
+
+(defn clear-icon-color
+  [blur? override-theme]
+  (if blur?
+    (colors/theme-colors colors/neutral-80-opa-30 colors/white-opa-10 override-theme)
+    (colors/theme-colors colors/neutral-40 colors/neutral-60 override-theme)))
+
+(defn lock-icon-color
+  [blur? override-theme]
+  (if blur?
+    (colors/theme-colors colors/neutral-80-opa-40 colors/white-opa-40 override-theme)
+    (colors/theme-colors colors/neutral-50 colors/neutral-40 override-theme)))
+
+(defn- clear-button
+  [{:keys [on-press blur? override-theme]}]
+  [rn/touchable-opacity
+   {:accessibility-label :browser-input-clear-button
+    :on-press            on-press
+    :style               style/clear-icon-container}
+   [icon/icon :i/clear
+    {:color (clear-icon-color blur? override-theme)
+     :size  20}]])
+
+(defn lock-icon
+  [{:keys [blur? override-theme]}]
+  [rn/view
+   [icon/icon :i/locked
+    {:accessibility-label :browser-input-locked-icon
+     :color               (lock-icon-color blur? override-theme)
+     :container-style     style/lock-icon-container
+     :size                16}]])
+
+(defn cursor-color
+  [customization-color override-theme]
+  (colors/theme-colors (colors/custom-color customization-color 50)
+                       (colors/custom-color customization-color 60)
+                       override-theme))
+
+(defn placeholder-color
+  [state blur? override-theme]
+  (cond
+    (and blur? (= state :active))
+    (colors/theme-colors colors/neutral-80-opa-20 colors/white-opa-20 override-theme)
+
+    blur?
+    (colors/theme-colors colors/neutral-80-opa-40 colors/white-opa-30 override-theme)
+
+    (= state :active)
+    (colors/theme-colors colors/neutral-30 colors/neutral-60 override-theme)
+
+    :else
+    (colors/theme-colors colors/neutral-40 colors/neutral-50 override-theme)))
+
+(def ^:private props-to-remove
+  [:cursor-color :placeholder-text-color :editable :on-change-text :on-focus
+   :on-blur :on-clear :value :disabled? :blur? :customization-color :override-theme])
+
+(defn browser-input
+  [{:keys [default-value]
+    :or   {default-value ""}}]
+  (let [state       (reagent/atom :default)
+        value       (reagent/atom default-value)
+        set-active  #(reset! state :active)
+        set-default #(reset! state :default)
+        set-value   #(reset! value %)
+        ref         (atom nil)
+        clear-input (fn []
+                      (.clear ^js @ref)
+                      (reset! value ""))]
+    (fn [{:keys [disabled? blur? on-change-text customization-color
+                 on-clear on-focus on-blur override-theme get-ref use-ssl?
+                 favicon favicon-color favicon-size label]
+          :or   {customization-color :blue}
+          :as   props}]
+      (let [clean-props (apply dissoc props props-to-remove)]
+        [rn/view
+         (when label
+           [rn/view {:style style/label-container}
+            (when favicon
+              [icon/icon favicon
+               {:accessibility-label :browser-input-favicon
+                :color               favicon-color
+                :container-style     style/favicon-icon-container
+                :size                favicon-size}])
+            [rn/text
+             {:accessibility-label :browser-input-label
+              :style               (style/text)} label]
+            (when use-ssl?
+              [lock-icon
+               {:blur?          blur?
+                :override-theme override-theme}])])
+         [rn/view {:style style/input-container}
+          [rn/text-input
+           (merge
+            clean-props
+            {:accessibility-label    :browser-input
+             :cursor-color           (cursor-color customization-color override-theme)
+             :editable               (not disabled?)
+             :keyboard-appearance    (colors/theme-colors :light :dark override-theme)
+             :on-blur                (fn []
+                                       (set-default)
+                                       (when on-blur (on-blur)))
+             :on-change-text         (fn [new-text]
+                                       (set-value new-text)
+                                       (when on-change-text (on-change-text new-text)))
+             :on-focus               (fn []
+                                       (set-active)
+                                       (when on-focus (on-focus)))
+             :placeholder-text-color (placeholder-color @state blur? override-theme)
+             :ref                    (fn [r]
+                                       (reset! ref r)
+                                       (when get-ref (get-ref r)))
+             :selection-color        (when platform/ios?
+                                       (cursor-color customization-color override-theme))
+             :style                  (style/input disabled?)})]
+          (when (seq @value)
+            [clear-button
+             {:blur?          blur?
+              :on-press       (fn []
+                                (clear-input)
+                                (when on-clear (on-clear)))
+              :override-theme override-theme}])]]))))

--- a/src/quo2/core.cljs
+++ b/src/quo2/core.cljs
@@ -39,6 +39,7 @@
     quo2.components.inputs.recovery-phrase.view
     quo2.components.inputs.search-input.view
     quo2.components.inputs.title-input.view
+    quo2.components.inputs.browser-input.view
     quo2.components.keycard.view
     quo2.components.links.url-preview-list.view
     quo2.components.links.url-preview.view
@@ -178,6 +179,8 @@
 (def recovery-phrase-input quo2.components.inputs.recovery-phrase.view/recovery-phrase-input)
 (def search-input quo2.components.inputs.search-input.view/search-input)
 (def title-input quo2.components.inputs.title-input.view/title-input)
+(def browser-input quo2.components.inputs.browser-input.view/browser-input)
+
 
 ;;;; LIST ITEMS
 (def channel-list-item quo2.components.list-items.channel/list-item)

--- a/src/quo2/core_spec.cljs
+++ b/src/quo2/core_spec.cljs
@@ -17,6 +17,7 @@
     [quo2.components.inputs.profile-input.component-spec]
     [quo2.components.inputs.recovery-phrase.component-spec]
     [quo2.components.inputs.title-input.component-spec]
+    [quo2.components.inputs.browser-input.component-spec]
     [quo2.components.keycard.component-spec]
     [quo2.components.links.link-preview.component-spec]
     [quo2.components.links.url-preview-list.component-spec]

--- a/src/status_im2/contexts/quo_preview/inputs/browser_input.cljs
+++ b/src/status_im2/contexts/quo_preview/inputs/browser_input.cljs
@@ -1,0 +1,63 @@
+(ns status-im2.contexts.quo-preview.inputs.browser-input
+  (:require [quo2.core :as quo]
+            [quo2.foundations.colors :as colors]
+            [react-native.core :as rn]
+            [reagent.core :as reagent]
+            [status-im2.contexts.quo-preview.preview :as preview]))
+
+(def descriptor
+  [{:label "Show Label"
+    :key   :input-label?
+    :type  :boolean}
+   {:label "Show Favicon"
+    :key   :favicon?
+    :type  :boolean}
+   {:label "Use SSL"
+    :key   :use-ssl?
+    :type  :boolean}
+   {:label "Blur"
+    :key   :blur?
+    :type  :boolean}
+   {:label "Disabled"
+    :key   :disabled?
+    :type  :boolean}])
+
+(defn cool-preview
+  []
+  (let [input-ref (atom nil)
+        state     (reagent/atom {:blur?        false
+                                 :disabled?    false
+                                 :favicon?     false
+                                 :input-label? false
+                                 :on-clear     #(some-> ^js @input-ref
+                                                        (.clear))
+                                 :placeholder  "Search or enter dapp domain"
+                                 :use-ssl?     false})]
+    (fn []
+      [rn/touchable-without-feedback {:on-press rn/dismiss-keyboard!}
+       [rn/view {:style {:padding-bottom 150}}
+        [rn/view {:style {:flex 1}}
+         [preview/customizer state descriptor]]
+        [preview/blur-view
+         {:style                 {:align-items     :center
+                                  :margin-vertical 20
+                                  :width           "100%"}
+          :show-blur-background? (:blur? @state)
+          :height                150}
+         [rn/view {:style {:width "100%"}}
+          [quo/browser-input
+           (assoc @state
+                  :favicon (when (:favicon? @state) :i/verified)
+                  :get-ref #(reset! input-ref %)
+                  :label   (when (:input-label? @state) "rarible.com"))]]]]])))
+
+(defn preview-browser-input
+  []
+  [rn/view
+   {:style {:background-color (colors/theme-colors colors/white colors/neutral-95)
+            :flex             1}}
+   [rn/flat-list
+    {:header                    [cool-preview]
+     :key-fn                    str
+     :keyboardShouldPersistTaps :always
+     :style                     {:flex 1}}]])

--- a/src/status_im2/contexts/quo_preview/main.cljs
+++ b/src/status_im2/contexts/quo_preview/main.cljs
@@ -46,6 +46,7 @@
     [status-im2.contexts.quo-preview.inputs.profile-input :as profile-input]
     [status-im2.contexts.quo-preview.inputs.search-input :as search-input]
     [status-im2.contexts.quo-preview.inputs.title-input :as title-input]
+    [status-im2.contexts.quo-preview.inputs.browser-input :as browser-input]
     [status-im2.contexts.quo-preview.links.url-preview :as url-preview]
     [status-im2.contexts.quo-preview.links.url-preview-list :as url-preview-list]
     [status-im2.contexts.quo-preview.links.link-preview :as link-preview]
@@ -211,7 +212,10 @@
                             :component search-input/preview-search-input}
                            {:name      :title-input
                             :options   {:topBar {:visible true}}
-                            :component title-input/preview-title-input}]
+                            :component title-input/preview-title-input}
+                           {:name      :browser-input
+                            :options   {:topBar {:visible true}}
+                            :component browser-input/preview-browser-input}]
    :links                 [{:name      :url-preview
                             :options   {:insets {:top? true}
                                         :topBar {:visible true}}


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

Fixes https://github.com/status-im/status-mobile/issues/15972

Implements the browser input component according to the [designs](https://www.figma.com/file/WQZcp6S0EnzxdTL4taoKDv/Design-System-for-Mobile?type=design&node-id=4840-135087&t=1EwxozYZyGszVVME-0 "figma file").

The component is added to the quo preview in the profile settings.

<!--  <img width="429" alt="Screenshot 2023-05-29 at 10 56 41" src="https://github.com/status-im/status-mobile/assets/45393944/d6f7a13d-ef75-4f41-a060-5ba83c92a7a8">
<img width="429" alt="Screenshot 2023-05-29 at 11 04 29" src="https://github.com/status-im/status-mobile/assets/45393944/4ed3ae16-2226-4288-9dd3-d06e8fc22af9"> -->


<img width="429" alt="Screenshot_20230602-003702" src="https://github.com/status-im/status-mobile/assets/45393944/d86c6963-2994-430c-b5fe-5474d4ea92d7">
<img width="429" alt="Screenshot_20230602-003850" src="https://github.com/status-im/status-mobile/assets/45393944/aa0e8726-be04-4ffd-8989-669d0d6a4bff">
<img width="429" alt="Screenshot_20230602-003908" src="https://github.com/status-im/status-mobile/assets/45393944/d4c62230-5c69-4350-b0dc-59b1f56674f6">



<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->
