### PR TITLE
fix: send user to settings if audio permission is rejected

### DIFF
--- a/src/react_native/permissions.cljs
+++ b/src/react_native/permissions.cljs
@@ -1,5 +1,5 @@
 (ns react-native.permissions
-  (:require ["react-native-permissions" :refer (check requestMultiple PERMISSIONS RESULTS)]
+  (:require ["react-native-permissions" :refer (check openSettings requestMultiple PERMISSIONS RESULTS)]
             [react-native.platform :as platform]))
 
 (def permissions-map
@@ -38,3 +38,5 @@
   (-> (check (get permissions-map permission))
       (.then #(on-result (not (#{(.-BLOCKED RESULTS) (.-DENIED RESULTS)} %))))
       (.catch #(on-error %))))
+
+(def open-settings openSettings)

--- a/src/status_im2/common/alert/events.cljs
+++ b/src/status_im2/common/alert/events.cljs
@@ -5,17 +5,25 @@
 
 (defn show-popup
   ([title content]
-   (show-popup title content nil))
+   (show-popup title content nil nil))
   ([title content on-dismiss]
-   (rn/alert
-    title
-    content
-    (vector (merge {:text                "OK"
-                    :style               "cancel"
-                    :accessibility-label :cancel-button}
-                   (when on-dismiss {:onPress on-dismiss})))
-    (when on-dismiss
-      {:cancelable false}))))
+   (show-popup title content on-dismiss nil))
+  ([title content on-dismiss action-button]
+   (let [dismiss-button
+         (merge {:text                "OK"
+                 :style               "cancel"
+                 :accessibility-label :cancel-button}
+                (when on-dismiss {:onPress on-dismiss}))]
+     (rn/alert
+      title
+      content
+      (if action-button
+        (vector
+         action-button
+         dismiss-button)
+        dismiss-button)
+      (when on-dismiss
+        {:cancelable false})))))
 
 (re-frame/reg-fx
  :utils/show-popup

--- a/src/status_im2/contexts/chat/composer/actions/view.cljs
+++ b/src/status_im2/contexts/chat/composer/actions/view.cljs
@@ -138,7 +138,11 @@
                                                     (alert/show-popup
                                                      (i18n/label :t/audio-recorder-error)
                                                      (i18n/label
-                                                      :t/audio-recorder-permissions-error)))
+                                                      :t/audio-recorder-permissions-error)
+                                                     nil
+                                                     {:text (i18n/label :t/settings)
+                                                      :accessibility-label :settings-button
+                                                      :onPress (fn [] (permissions/open-settings))}))
                                                   50)}]))}]]))
 
 


### PR DESCRIPTION
If user has previously declined audio permission, it gives the user the option to go to device settings to re-enable audio permissions

<img width="300" src="https://github.com/status-im/status-mobile/assets/18485527/6367e1fb-08fc-4960-9272-dbe0a0d9dc84">

status: ready

cc @qoqobolo 