### PR TITLE
Do not show keyboard when audio recorded

### DIFF
--- a/src/status_im2/contexts/chat/composer/actions/view.cljs
+++ b/src/status_im2/contexts/chat/composer/actions/view.cljs
@@ -88,7 +88,8 @@
                                              (rf/dispatch [:chat.ui/set-recording false]))
        :on-reviewing-audio                 (fn [file]
                                              (rf/dispatch [:chat.ui/set-recording false])
-                                             (rf/dispatch [:chat.ui/set-input-audio file]))
+                                             (rf/dispatch [:chat.ui/set-input-audio file])
+                                             (rf/dispatch [:dismiss-keyboard]))
        :on-send                            (fn [{:keys [file-path duration]}]
                                              (rf/dispatch [:chat.ui/set-recording false])
                                              (reset! recording? false)

--- a/src/status_im2/contexts/chat/composer/view.cljs
+++ b/src/status_im2/contexts/chat/composer/view.cljs
@@ -81,7 +81,8 @@
        [edit/view state]
        [reanimated/touchable-opacity
         {:active-opacity      1
-         :on-press            (when @(:input-ref props) #(.focus ^js @(:input-ref props)))
+         :on-press            (when (and @(:input-ref props) (not (:audio subs)))
+                                #(.focus ^js @(:input-ref props)))
          :style               (style/input-container (:height animations) max-height)
          :accessibility-label :message-input-container}
         [rn/selectable-text-input


### PR DESCRIPTION
fixes #15930

### Summary

Changes:
- text input is not allowed to gain focus when audio is in place
- keyboard hidden after recording stopped even if it was opened

### Steps to test
Case 1:
- Open any chat
- Start recording the audio
- Stop recording
- Tap on the composer

Case 2:
- Tap on the composer (now the keyboard is opened)
- Start recording
- Stop recording

status: ready
