### PR TITLE
Local Pairing Updates

### DIFF
--- a/src/status_im/multiaccounts/login/core.cljs
+++ b/src/status_im/multiaccounts/login/core.cljs
@@ -168,7 +168,7 @@
 (rf/defn login
   {:events [:multiaccounts.login.ui/password-input-submitted]}
   [{:keys [db]}]
-  (let [{:keys [key-uid password name hashed-password?]} (:multiaccounts/login db)]
+  (let [{:keys [key-uid password name]} (:multiaccounts/login db)]
     {:db     (-> db
                  (assoc-in [:multiaccounts/login :processing] true)
                  (dissoc :intro-wizard :recovered-account?)
@@ -176,9 +176,7 @@
      ::login [key-uid
               (types/clj->json {:name    name
                                 :key-uid key-uid})
-              (if hashed-password?
-                password
-                (ethereum/sha3 (security/safe-unmask-data password)))]}))
+              (ethereum/sha3 (security/safe-unmask-data password))]}))
 
 (rf/defn export-db-submitted
   {:events [:multiaccounts.login.ui/export-db-submitted]}

--- a/src/status_im/multiaccounts/login/core.cljs
+++ b/src/status_im/multiaccounts/login/core.cljs
@@ -165,6 +165,15 @@
      (wallet/request-current-block-update))
    (prices/update-prices)))
 
+(rf/defn login-local-paired-user
+  {:events [:multiaccounts.login/local-paired-user]}
+  [{:keys [db]}]
+  (let [{:keys [key-uid name password]} (get-in db [:syncing :multiaccount])]
+    {::login [key-uid
+              (types/clj->json {:name    name
+                                :key-uid key-uid})
+              password]}))
+
 (rf/defn login
   {:events [:multiaccounts.login.ui/password-input-submitted]}
   [{:keys [db]}]

--- a/src/status_im/signals/core.cljs
+++ b/src/status_im/signals/core.cljs
@@ -75,7 +75,8 @@
                                              (= action
                                                 constants/local-pairing-action-pairing-account)
                                              (and (contains? data :account) (contains? data :password)))
-        multiaccount-data               (when received-account? (merge (:account data) (:password data)))
+        multiaccount-data               (when received-account?
+                                          (merge (:account data) {:password (:password data)}))
         navigate-to-syncing-devices?    (and connection-success? receiver?)
         user-in-syncing-devices-screen? (= (:view-id db) :syncing-progress)]
     (merge {:db (cond-> db

--- a/src/status_im/signals/core.cljs
+++ b/src/status_im/signals/core.cljs
@@ -58,7 +58,8 @@
   [{:keys [db] :as cofx} {:keys [type action data] :as event}]
   (log/info "local pairing signal received"
             {:event event})
-  (let [role                            (get-in db [:syncing :role])
+  (let [{:keys [account password]}      data
+        role                            (get-in db [:syncing :role])
         receiver?                       (= role constants/local-pairing-role-receiver)
         sender?                         (= role constants/local-pairing-role-sender)
         connection-success?             (and (= type
@@ -74,9 +75,9 @@
                                                 constants/local-pairing-event-received-account)
                                              (= action
                                                 constants/local-pairing-action-pairing-account)
-                                             (and (contains? data :account) (contains? data :password)))
+                                             (and (some? account) (some? password)))
         multiaccount-data               (when received-account?
-                                          (merge (:account data) {:password (:password data)}))
+                                          (merge account {:password password}))
         navigate-to-syncing-devices?    (and connection-success? receiver?)
         user-in-syncing-devices-screen? (= (:view-id db) :syncing-progress)]
     (merge {:db (cond-> db

--- a/src/status_im/signals/core.cljs
+++ b/src/status_im/signals/core.cljs
@@ -96,7 +96,7 @@
            (when (and completed-pairing? sender?)
              {:dispatch [:syncing/clear-states]})
            (when (and completed-pairing? receiver?)
-             {:dispatch [:syncing/receiver-pairing-completed]}))))
+             {:dispatch [:multiaccounts.login/local-paired-user]}))))
 
 (rf/defn process
   {:events [:signals/signal-received]}

--- a/src/status_im/signals/core.cljs
+++ b/src/status_im/signals/core.cljs
@@ -10,8 +10,7 @@
             [utils.re-frame :as rf]
             [status-im2.contexts.chat.messages.link-preview.events :as link-preview]
             [taoensso.timbre :as log]
-            [status-im2.constants :as constants]
-            [status-im.multiaccounts.model :as multiaccounts.model]))
+            [status-im2.constants :as constants]))
 
 (rf/defn status-node-started
   [{db :db :as cofx} {:keys [error]}]
@@ -56,26 +55,38 @@
                 :peers-count (count (:peers peer-stats)))}))
 
 (rf/defn handle-local-pairing-signals
-  [{:keys [db] :as cofx} event]
+  [{:keys [db] :as cofx} {:keys [type action data] :as event}]
   (log/info "local pairing signal received"
             {:event event})
-  (let [connection-success?             (and (= (:type event)
+  (let [role                            (get-in db [:syncing :role])
+        receiver?                       (= role constants/local-pairing-role-receiver)
+        sender?                         (= role constants/local-pairing-role-sender)
+        connection-success?             (and (= type
                                                 constants/local-pairing-event-connection-success)
-                                             (= (:action event)
+                                             (= action
                                                 constants/local-pairing-action-connect))
-        error-on-pairing?               (contains? constants/local-pairing-event-errors (:type event))
-        completed-pairing?              (and (= (:type event)
+        error-on-pairing?               (contains? constants/local-pairing-event-errors type)
+        completed-pairing?              (and (= type
                                                 constants/local-pairing-event-transfer-success)
-                                             (= (:action event)
+                                             (= action
                                                 constants/local-pairing-action-pairing-installation))
-        logged-in?                      (multiaccounts.model/logged-in? db)
-        ;; since `connection-success` event is received on both sender and receiver devices
-        ;; we check the `logged-in?` status to identify the receiver and take the user to next screen
-        navigate-to-syncing-devices?    (and connection-success? (not logged-in?))
+        received-account?               (and (= type
+                                                constants/local-pairing-event-received-account)
+                                             (= action
+                                                constants/local-pairing-action-pairing-account)
+                                             (boolean (:account data)))
+        updated-account-data            (when received-account?
+                                          (-> (:account data)
+                                              (assoc :password (:password data))
+                                              (assoc :hashed-password? true)))
+        navigate-to-syncing-devices?    (and connection-success? receiver?)
         user-in-syncing-devices-screen? (= (:view-id db) :syncing-progress)]
     (merge {:db (cond-> db
                   connection-success?
                   (assoc-in [:syncing :pairing-in-progress?] :connected)
+
+                  received-account?
+                  (assoc :multiaccounts/login updated-account-data)
 
                   error-on-pairing?
                   (assoc-in [:syncing :pairing-in-progress?] :error)
@@ -84,8 +95,10 @@
                   (assoc-in [:syncing :pairing-in-progress?] :completed))}
            (when (and navigate-to-syncing-devices? (not user-in-syncing-devices-screen?))
              {:dispatch [:navigate-to :syncing-progress]})
-           (when completed-pairing?
-             {:dispatch [:syncing/pairing-completed]}))))
+           (when (and completed-pairing? sender?)
+             {:dispatch [:syncing/clear-states]})
+           (when (and completed-pairing? receiver?)
+             {:dispatch [:multiaccounts.login.ui/password-input-submitted]}))))
 
 (rf/defn process
   {:events [:signals/signal-received]}

--- a/src/status_im2/constants.cljs
+++ b/src/status_im2/constants.cljs
@@ -277,9 +277,10 @@
 (def ^:const local-pairing-event-transfer-error "transfer-error")
 
 ;; receiver events
-(def ^:const local-pairing-event-received-amount "received-account")
+(def ^:const local-pairing-event-received-account "received-account")
 (def ^:const local-pairing-event-process-success "process-success")
 (def ^:const local-pairing-event-process-error "process-error")
+(def ^:const local-pairing-event-received-installation "received-installation")
 
 (def ^:const local-pairing-event-errors
   #{local-pairing-event-connection-error

--- a/src/status_im2/contexts/onboarding/syncing/progress/view.cljs
+++ b/src/status_im2/contexts/onboarding/syncing/progress/view.cljs
@@ -41,7 +41,7 @@
 
 (defn view
   []
-  (let [pairing-status (rf/sub [:pairing/pairing-in-progress])
+  (let [pairing-status (rf/sub [:pairing/pairing-status])
         profile-color  (:color (rf/sub [:onboarding-2/profile]))]
     [rn/view {:style style/page-container}
      [background/view true]

--- a/src/status_im2/contexts/syncing/events.cljs
+++ b/src/status_im2/contexts/syncing/events.cljs
@@ -8,7 +8,17 @@
             [re-frame.core :as re-frame]
             [status-im.data-store.settings :as data-store.settings]
             [status-im.utils.platform :as utils.platform]
+            [status-im.utils.types :as types]
             [status-im2.constants :as constants]))
+
+(rf/defn local-pairing-completed-for-receiver
+  {:events [:syncing/receiver-pairing-completed]}
+  [{:keys [db]}]
+  (let [{:keys [key-uid name password]} (get-in db [:syncing :multiaccount])]
+    {::login [key-uid
+              (types/clj->json {:name    name
+                                :key-uid key-uid})
+              password]}))
 
 (rf/defn local-pairing-completed
   {:events [:syncing/pairing-completed]}

--- a/src/status_im2/contexts/syncing/events.cljs
+++ b/src/status_im2/contexts/syncing/events.cljs
@@ -8,26 +8,7 @@
             [re-frame.core :as re-frame]
             [status-im.data-store.settings :as data-store.settings]
             [status-im.utils.platform :as utils.platform]
-            [status-im.utils.types :as types]
             [status-im2.constants :as constants]))
-
-(rf/defn local-pairing-completed-for-receiver
-  {:events [:syncing/receiver-pairing-completed]}
-  [{:keys [db]}]
-  (let [{:keys [key-uid name password]} (get-in db [:syncing :multiaccount])]
-    {::login [key-uid
-              (types/clj->json {:name    name
-                                :key-uid key-uid})
-              password]}))
-
-(rf/defn local-pairing-completed
-  {:events [:syncing/pairing-completed]}
-  [{:keys [db]}]
-  (let [receiver? (= (get-in db [:syncing :role]) constants/local-pairing-role-receiver)]
-    (merge
-     {:db (dissoc db :syncing)}
-     (when receiver?
-       {:dispatch [:init-root :syncing-results]}))))
 
 (rf/defn local-pairing-update-role
   {:events [:syncing/update-role]}

--- a/src/status_im2/navigation/screens.cljs
+++ b/src/status_im2/navigation/screens.cljs
@@ -160,7 +160,8 @@
      :component sign-in/view}
 
     {:name      :syncing-progress
-     :options   {:layout options/onboarding-layout}
+     :options   {:layout     options/onboarding-layout
+                 :popGesture false}
      :component syncing-devices/view}
 
     {:name      :syncing-results

--- a/src/status_im2/subs/pairing.cljs
+++ b/src/status_im2/subs/pairing.cljs
@@ -28,7 +28,7 @@
  (fn [multiaccount] (:installation-name multiaccount)))
 
 (re-frame/reg-sub
- :pairing/pairing-in-progress
+ :pairing/pairing-status
  :<- [:syncing]
  (fn [syncing]
-   (:pairing-in-progress? syncing)))
+   (:pairing-status syncing)))

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "feature/lp-release-messenger-update",
-    "commit-sha1": "fbfb95e98257330eb65d4698eb74667eb9992d9d",
-    "src-sha256": "0hjc690cxnxs10wbmdkkcl0sy2r8kxn40b0kd52y07wp479hcjnh"
+    "version": "v0.154.0",
+    "commit-sha1": "a7df4ed388e4d78653326ed7a35e72221e23a5d9",
+    "src-sha256": "1mh7kb0s49c16z0h72v8nz9c6z6vd78db6wc1wdlzizc75xb0pw2"
 }

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.152.3",
-    "commit-sha1": "aded83fc6e9a2834c061f1a268fff071bcdc5621",
-    "src-sha256": "02hrlv2484x5d2ycvk3p58bkng7q40z7nyl2k2f6xhxzx9ppnbjs"
+    "version": "feature/lp-release-messenger-update",
+    "commit-sha1": "fbfb95e98257330eb65d4698eb74667eb9992d9d",
+    "src-sha256": "0hjc690cxnxs10wbmdkkcl0sy2r8kxn40b0kd52y07wp479hcjnh"
 }


### PR DESCRIPTION
fixes #16071

### Summary

This PR updates the Status mobile to cater to the `status-go` local pairing changes. After local pairing is completed, the receiver is logged out. The user needs to be logged in (automatically) to the application in order to land in the subsequent screens, and dashboard/shell (as per the onboarding flow) without the need to enter the password.

The problem is further explained in the PR's issue. This PR is coordinated with the Desktop team so that the https://github.com/status-im/status-go/pull/3536 can be merged in lockstep.

### Changes done

- [x] Store received multiaccount data during pairing
- [x] Remove the existing `pairing-in-progress?` check in login, which is used to skip navigation
- [x] Once pairing is completed, log in the user automatically using the multiaccount data received during pairing
- [x] Navigate the user/receiver to the `syncing-results` screen upon successful login.

### Testing notes

- Ensure you are using this PR build for both sender and receiver

### Platforms

- Android
- iOS

### Areas impacted

- Local pairing

### Steps to test

- Open Status
- Sign in by syncing
- The pairing works as before

status: ready
