### PR TITLE
Navigate to Error Screen if pairing failed

### DIFF
--- a/src/status_im/signals/core.cljs
+++ b/src/status_im/signals/core.cljs
@@ -93,13 +93,17 @@
 
                   completed-pairing?
                   (assoc-in [:syncing :pairing-status] :completed))}
-           (when (and navigate-to-syncing-devices? (not user-in-syncing-devices-screen?))
-             {:dispatch [:navigate-to :syncing-progress]})
-           (when (and completed-pairing? sender?)
-             {:dispatch [:syncing/clear-states]})
-           (when (and completed-pairing? receiver?)
-             {:dispatch [:multiaccounts.login/local-paired-user]})
-           (when error-on-pairing?
+           (cond
+             (and navigate-to-syncing-devices? (not user-in-syncing-devices-screen?))
+             {:dispatch [:navigate-to :syncing-progress]}
+
+             (and completed-pairing? sender?)
+             {:dispatch [:syncing/clear-states]}
+
+             (and completed-pairing? receiver?)
+             {:dispatch [:multiaccounts.login/local-paired-user]}
+
+             error-on-pairing?
              {:dispatch [:toasts/upsert
                          {:icon       :i/alert
                           :icon-color colors/danger-50

--- a/src/status_im/signals/core.cljs
+++ b/src/status_im/signals/core.cljs
@@ -78,7 +78,7 @@
                                              (and (some? account) (some? password)))
         multiaccount-data               (when received-account?
                                           (merge account {:password password}))
-        navigate-to-syncing-devices?    (and connection-success? receiver?)
+        navigate-to-syncing-devices?    (and (or connection-success? error-on-pairing?) receiver?)
         user-in-syncing-devices-screen? (= (:view-id db) :syncing-progress)]
     (merge {:db (cond-> db
                   connection-success?

--- a/src/status_im/signals/core.cljs
+++ b/src/status_im/signals/core.cljs
@@ -10,7 +10,8 @@
             [utils.re-frame :as rf]
             [status-im2.contexts.chat.messages.link-preview.events :as link-preview]
             [taoensso.timbre :as log]
-            [status-im2.constants :as constants]))
+            [status-im2.constants :as constants]
+            [quo2.foundations.colors :as colors]))
 
 (rf/defn status-node-started
   [{db :db :as cofx} {:keys [error]}]
@@ -55,7 +56,7 @@
                 :peers-count (count (:peers peer-stats)))}))
 
 (rf/defn handle-local-pairing-signals
-  [{:keys [db] :as cofx} {:keys [type action data] :as event}]
+  [{:keys [db] :as cofx} {:keys [type action data error] :as event}]
   (log/info "local pairing signal received"
             {:event event})
   (let [{:keys [account password]}      data
@@ -97,7 +98,12 @@
            (when (and completed-pairing? sender?)
              {:dispatch [:syncing/clear-states]})
            (when (and completed-pairing? receiver?)
-             {:dispatch [:multiaccounts.login/local-paired-user]}))))
+             {:dispatch [:multiaccounts.login/local-paired-user]})
+           (when error-on-pairing?
+             {:dispatch [:toasts/upsert
+                         {:icon       :i/alert
+                          :icon-color colors/danger-50
+                          :text       error}]}))))
 
 (rf/defn process
   {:events [:signals/signal-received]}


### PR DESCRIPTION
### Summary

This PR adds an additional error check to local pairing signals. If the receiver couldn't able to connect to the sender device, we should take the user to the error screen.


#### Platforms

- Android
- iOS



status: ready
