### PR TITLE
Debug mode fix: photo selector

### DIFF
--- a/src/status_im2/navigation/options.cljs
+++ b/src/status_im2/navigation/options.cljs
@@ -87,7 +87,8 @@
                             :orientation              ["portrait"]
                             :backgroundColor          :transparent}
    :modalPresentationStyle :overCurrentContext
-   ;; disabled on iOS in debug mode: https://github.com/status-im/status-mobile/pull/16053#issuecomment-1568349702
+   ;; disabled on iOS in debug mode:
+   ;; https://github.com/status-im/status-mobile/pull/16053#issuecomment-1568349702
    :animations             (if (or platform/android? (not js/goog.DEBUG))
                              {:showModal    {:alpha {:from 1 :to 1 :duration 300}}
                               :dismissModal {:alpha {:from 1 :to 1 :duration 300}}}

--- a/src/status_im2/navigation/options.cljs
+++ b/src/status_im2/navigation/options.cljs
@@ -87,6 +87,7 @@
                             :orientation              ["portrait"]
                             :backgroundColor          :transparent}
    :modalPresentationStyle :overCurrentContext
+   ;; disabled on iOS in debug mode: https://github.com/status-im/status-mobile/pull/16053#issuecomment-1568349702
    :animations             (if (or platform/android? (not js/goog.DEBUG))
                              {:showModal    {:alpha {:from 1 :to 1 :duration 300}}
                               :dismissModal {:alpha {:from 1 :to 1 :duration 300}}}

--- a/src/status_im2/navigation/options.cljs
+++ b/src/status_im2/navigation/options.cljs
@@ -87,8 +87,10 @@
                             :orientation              ["portrait"]
                             :backgroundColor          :transparent}
    :modalPresentationStyle :overCurrentContext
-   :animations             {:showModal    {:alpha {:from 1 :to 1 :duration 300}}
-                            :dismissModal {:alpha {:from 1 :to 1 :duration 300}}}})
+   :animations             (if (or platform/android? (not js/goog.DEBUG))
+                             {:showModal    {:alpha {:from 1 :to 1 :duration 300}}
+                              :dismissModal {:alpha {:from 1 :to 1 :duration 300}}}
+                             {})})
 
 (def dark-screen
   (merge (statusbar true)


### PR DESCRIPTION
The red screen error shown in [that video](https://github.com/status-im/status-mobile/pull/16053#issuecomment-1568349702) seems to be caused by the `showModal` and `dismissModal` animation. This PR disables this animation in debug mode on iOS.

This animation seems to be deprecated as [shown here](https://wix.github.io/react-native-navigation/docs/style-animations#modal-animations). @flexsurfer So probably it won't work when upgrading RNN ? 