### PR TITLE
ci: set e2e/status-app-prs timeout to 90 minutes

### DIFF
--- a/ci/tests/Jenkinsfile.e2e-prs
+++ b/ci/tests/Jenkinsfile.e2e-prs
@@ -45,6 +45,7 @@ pipeline {
 
   options {
     disableConcurrentBuilds()
+    timeout(time: 90, unit: 'MINUTES')
   }
 
   stages {


### PR DESCRIPTION
### Summary

Sometimes (2/week) E2E tests are freezing, clogging the queue. [Example](https://ci.status.im/job/status-mobile/job/e2e/job/status-app-prs/3622/)
Manual abortion is then needed.
Most successful builds take 50 minutes. [Build History](https://ci.status.im/job/status-mobile/job/e2e/job/status-app-prs/buildTimeTrend)
Confirmed with Mobile QA, that 90 minutes should be Ok.

### Review notes

Could this timeout be reused somewhere else, so impacting not only e2e/status-app-prs, but other pipeline?

### Testing notes
No QA

#### Areas that maybe impacted
CI

status: ready
