### PR TITLE
[15902] BUGFIX - Resolve public keys into the user's name in the confirmation drawer

### DIFF
--- a/src/status_im2/common/confirmation_drawer/view.cljs
+++ b/src/status_im2/common/confirmation_drawer/view.cljs
@@ -34,9 +34,9 @@
                     profile-picture name]} context
             id                             (or chat-id public-key)
             display-name                   (or
-                                            name
                                             (when-not group-chat
-                                              (rf/sub [:contacts/contact-name-by-identity id])))
+                                              (rf/sub [:contacts/contact-name-by-identity id]))
+                                            name)
             contact                        (when-not group-chat
                                              (rf/sub [:contacts/contact-by-address
                                                       id]))

--- a/src/status_im2/contexts/chat/lightbox/bottom_view.cljs
+++ b/src/status_im2/contexts/chat/lightbox/bottom_view.cljs
@@ -7,7 +7,7 @@
     [utils.re-frame :as rf]
     [status-im2.contexts.chat.lightbox.animations :as anim]
     [status-im2.contexts.chat.lightbox.constants :as c]
-    [status-im2.constants :as constants]))
+    [status-im2.contexts.chat.messages.content.text.view :as message-view]))
 
 (defn get-small-item-layout
   [_ index]
@@ -50,15 +50,17 @@
 
 (defn bottom-view
   [messages index scroll-index insets animations derived item-width props]
-  (let [text               (get-in (first messages) [:content :text])
-        padding-horizontal (- (/ item-width 2) (/ c/focused-image-size 2))]
+  (let [{:keys [chat-id content]} (first messages)
+        padding-horizontal        (- (/ item-width 2) (/ c/focused-image-size 2))]
     [reanimated/linear-gradient
      {:colors [:black :transparent]
       :start  {:x 0 :y 1}
       :end    {:x 0 :y 0}
       :style  (style/gradient-container insets animations derived)}
-     (when constants/image-description-in-lightbox?
-       [rn/text {:style style/text-style} text])
+     [message-view/render-parsed-text
+      {:content        content
+       :chat-id        chat-id
+       :style-override style/text-style}]
      [rn/flat-list
       {:ref                               #(reset! (:small-list-ref props) %)
        :key-fn                            :message-id

--- a/src/status_im2/contexts/chat/messages/content/text/view.cljs
+++ b/src/status_im2/contexts/chat/messages/content/text/view.cljs
@@ -75,15 +75,19 @@
 
 
 (defn render-block
-  [blocks {:keys [type literal children]} chat-id]
+  [blocks {:keys [type literal children]} chat-id style-override]
   (case (keyword type)
     :paragraph
     (conj blocks
-          (reduce
-           (fn [acc e]
-             (render-inline acc e chat-id))
-           [quo/text {:size :paragraph-1}]
-           children))
+          [rn/view {:style style/paragraph}
+           (reduce
+            (fn [acc e]
+              (render-inline acc e chat-id))
+            [quo/text
+             {:style {:size  :paragraph-1
+                      :color (when (seq style-override)
+                               colors/white)}}]
+            children)])
 
     :edited-block
     (conj blocks
@@ -120,11 +124,15 @@
       (conj parsed-text {:type :edited-block :children [edited-tag]}))))
 
 (defn render-parsed-text
-  [{:keys [content chat-id edited-at]}]
+  [{:keys [content chat-id edited-at style-override]}]
   ^{:key (:parsed-text content)}
+<<<<<<< HEAD
   [rn/view
+=======
+  [rn/view {:style (or style-override style/parsed-text-block)}
+>>>>>>> d0d579374 (Fix mention in chat)
    (reduce (fn [acc e]
-             (render-block acc e chat-id))
+             (render-block acc e chat-id style-override))
            [:<>]
            (cond-> (:parsed-text content)
              edited-at

--- a/src/status_im2/contexts/chat/messages/content/text/view.cljs
+++ b/src/status_im2/contexts/chat/messages/content/text/view.cljs
@@ -79,7 +79,7 @@
   (case (keyword type)
     :paragraph
     (conj blocks
-          [rn/view {:style style/paragraph}
+          [rn/view
            (reduce
             (fn [acc e]
               (render-inline acc e chat-id))
@@ -126,11 +126,7 @@
 (defn render-parsed-text
   [{:keys [content chat-id edited-at style-override]}]
   ^{:key (:parsed-text content)}
-<<<<<<< HEAD
-  [rn/view
-=======
-  [rn/view {:style (or style-override style/parsed-text-block)}
->>>>>>> d0d579374 (Fix mention in chat)
+  [rn/view {:style style-override}
    (reduce (fn [acc e]
              (render-block acc e chat-id style-override))
            [:<>]

--- a/src/status_im2/contexts/chat/messages/content/text/view.cljs
+++ b/src/status_im2/contexts/chat/messages/content/text/view.cljs
@@ -9,69 +9,85 @@
     [utils.re-frame :as rf]))
 
 (defn render-inline
-  [units {:keys [type literal destination]} chat-id]
-  (case (keyword type)
-    :code
-    (conj units [quo/text {:style (merge style/block (style/code)) :weight :code} literal])
-
-    :emph
-    (conj units [quo/text {:style {:font-style :italic}} literal])
-
-    :strong
-    (conj units [quo/text {:weight :bold} literal])
-
-    :strong-emph
-    (conj units
-          [quo/text
-           {:weight :bold
-            :style  {:font-style :italic}} literal])
-
-    :del
-    (conj units [quo/text {:style {:text-decoration-line :line-through}} literal])
-
-    :link
-    (conj units
-          [quo/text
-           {:style    {:color (colors/theme-colors colors/primary-50 colors/primary-60)}
-            :on-press #(rf/dispatch [:browser.ui/message-link-pressed destination])}
-           destination])
-
-    :mention
-    (conj
-     units
-     [rn/view
-      {:style style/mention-tag-wrapper}
-      [rn/touchable-opacity
-       {:active-opacity 1
-        :on-press       #(rf/dispatch [:chat.ui/show-profile literal])
-        :style          style/mention-tag}
-       [quo/text
-        {:weight :medium
-         :style  style/mention-tag-text}
-        (rf/sub [:messages/resolve-mention literal])]]])
-
-    :edited
-    (conj units
-
-          [quo/text
-           {:weight :medium
-            :style  {:font-size 11 ; Font-size must be used instead of props or the
-                                   ; styles will clash with original message text
-                     :color     (colors/theme-colors colors/neutral-40
-                                                     colors/neutral-50)}}
-           literal])
-    :status-tag
-    (let [community-id (rf/sub [:community-id-by-chat-id chat-id])]
+  [units {:keys [type literal destination]} chat-id style-override]
+  (let [show-as-plain-text? (seq style-override)]
+    (case (keyword type)
+      :code
       (conj units
-            [rn/text
-             (when community-id
-               {:style    {:color                :blue
-                           :text-decoration-line :underline}
-                :on-press #(rf/dispatch [:communities/status-tag-pressed community-id literal])})
-             "#"
-             literal]))
+            [quo/text
+             {:style  (if show-as-plain-text?
+                        {:color colors/white}
+                        (merge style/block (style/code)))
+              :weight :code} literal])
 
-    (conj units literal)))
+      :emph
+      (conj units
+            [quo/text
+             {:style {:font-style :italic
+                      :color      (when show-as-plain-text? colors/white)}} literal])
+
+      :strong
+      (conj units
+            [quo/text
+             (cond-> {:weight :bold}
+               show-as-plain-text? (assoc :style {:color colors/white})) literal])
+
+      :strong-emph
+      (conj units
+            [quo/text
+             {:weight :bold
+              :style  {:font-style :italic
+                       :color      (when show-as-plain-text? colors/white)}} literal])
+
+      :del
+      (conj units
+            [quo/text
+             {:style {:text-decoration-line :line-through
+                      :color                (when show-as-plain-text? colors/white)}} literal])
+
+      :link
+      (conj units
+            [quo/text
+             {:style    {:color (colors/theme-colors colors/primary-50 colors/primary-60)}
+              :on-press #(rf/dispatch [:browser.ui/message-link-pressed destination])}
+             destination])
+
+      :mention
+      (conj
+       units
+       [rn/view
+        {:style style/mention-tag-wrapper}
+        [rn/touchable-opacity
+         {:active-opacity 1
+          :on-press       #(rf/dispatch [:chat.ui/show-profile literal])
+          :style          style/mention-tag}
+         [quo/text
+          {:weight :medium
+           :style  style/mention-tag-text}
+          (rf/sub [:messages/resolve-mention literal])]]])
+
+      :edited
+      (conj units
+
+            [quo/text
+             {:weight :medium
+              :style  {:font-size 11 ; Font-size must be used instead of props or the
+                       ; styles will clash with original message text
+                       :color     (colors/theme-colors colors/neutral-40
+                                                       colors/neutral-50)}}
+             literal])
+      :status-tag
+      (let [community-id (rf/sub [:community-id-by-chat-id chat-id])]
+        (conj units
+              [rn/text
+               (when community-id
+                 {:style    {:color                :blue
+                             :text-decoration-line :underline}
+                  :on-press #(rf/dispatch [:communities/status-tag-pressed community-id literal])})
+               "#"
+               literal]))
+
+      (conj units literal))))
 
 
 (defn render-block
@@ -82,18 +98,17 @@
           [rn/view
            (reduce
             (fn [acc e]
-              (render-inline acc e chat-id))
+              (render-inline acc e chat-id style-override))
             [quo/text
              {:style {:size  :paragraph-1
-                      :color (when (seq style-override)
-                               colors/white)}}]
+                      :color (when (seq style-override) colors/white)}}]
             children)])
 
     :edited-block
     (conj blocks
           (reduce
            (fn [acc e]
-             (render-inline acc e chat-id))
+             (render-inline acc e chat-id style-override))
            [quo/text {:size :paragraph-1}]
            children))
 


### PR DESCRIPTION
fixes #15902 

### Summary

Fixes wrong OR operator on confirmation drawer of destructive actions on chat items on the home screen.

status: ready
