### PR TITLE
Prevent overflowing of chat name and message preview in the Chat List

### DIFF
--- a/src/status_im2/contexts/chat/home/chat_list_item/view.cljs
+++ b/src/status_im2/contexts/chat/home/chat_list_item/view.cljs
@@ -177,31 +177,22 @@
          :color    (colors/theme-colors colors/primary-50 colors/primary-60)}]])))
 
 (defn name-view
-  [display-name {:keys [ens-verified added?] :as contact} timestamp show-unread-badge?]
-  (let [show-verified-or-contact-icon? (or ens-verified added?)
-        name-text-max-width            (cond-> (if show-unread-badge? 70 71.5)
-
-                                         ;; Adding the below percent for group and
-                                         ;; not-mutual contact chats to take the
-                                         ;; space of the icon
-                                         (nil? show-verified-or-contact-icon?)
-                                         (+ (if show-unread-badge? 4.5 5.3)))]
-    [rn/view
-     {:style {:flex           1
-              :flex-direction :row}}
-     [quo/text
-      {:weight              :semi-bold
-       :accessibility-label :chat-name-text
-       :style               {:max-width (str name-text-max-width "%")}
-       :number-of-lines     1
-       :ellipsize-mode      :tail}
-      display-name]
-     (when show-verified-or-contact-icon?
-       [verified-or-contact-icon contact])
-     [quo/text
-      {:size  :label
-       :style (style/timestamp)}
-      (datetime/to-short-str timestamp)]]))
+  [display-name contact timestamp]
+  [rn/view
+   {:style {:flex           1
+            :flex-direction :row}}
+   [quo/text
+    {:weight              :semi-bold
+     :accessibility-label :chat-name-text
+     :style               {:flex-shrink 1}
+     :number-of-lines     1
+     :ellipsize-mode      :tail}
+    display-name]
+   [verified-or-contact-icon contact]
+   [quo/text
+    {:size  :label
+     :style (style/timestamp)}
+    (datetime/to-short-str timestamp)]])
 
 (defn avatar-view
   [{:keys [contact chat-id full-name color]}]
@@ -242,7 +233,7 @@
       {:style {:flex         1
                :margin-left  8
                :margin-right (if show-unread-badge? 36 0)}}
-      [name-view display-name contact timestamp show-unread-badge?]
+      [name-view display-name contact timestamp]
       [last-message-preview group-chat last-message]]
      (when show-unread-badge?
        [quo/info-count

--- a/src/status_im2/contexts/chat/home/chat_list_item/view.cljs
+++ b/src/status_im2/contexts/chat/home/chat_list_item/view.cljs
@@ -177,14 +177,15 @@
          :color    (colors/theme-colors colors/primary-50 colors/primary-60)}]])))
 
 (defn name-view
-  [display-name {:keys [ens-verified added?] :as contact} timestamp has-unread-badge?]
+  [display-name {:keys [ens-verified added?] :as contact} timestamp show-unread-badge?]
   (let [show-verified-or-contact-icon? (or ens-verified added?)
-        name-text-max-width            (cond-> (if has-unread-badge? 70 71.5)
+        name-text-max-width            (cond-> (if show-unread-badge? 70 71.5)
 
                                          ;; Adding the below percent for group and
-                                         ;; not-mutual contact chats
+                                         ;; not-mutual contact chats to take the
+                                         ;; space of the icon
                                          (nil? show-verified-or-contact-icon?)
-                                         (+ (if has-unread-badge? 4.5 5.3)))]
+                                         (+ (if show-unread-badge? 4.5 5.3)))]
     [rn/view
      {:style {:flex           1
               :flex-direction :row}}
@@ -221,12 +222,12 @@
   [{:keys [chat-id group-chat color name unviewed-messages-count
            timestamp last-message muted]
     :as   item}]
-  (let [display-name      (if group-chat
-                            name
-                            (first (rf/sub [:contacts/contact-two-names-by-identity chat-id])))
-        contact           (when-not group-chat
-                            (rf/sub [:contacts/contact-by-address chat-id]))
-        has-unread-badge? (and (not muted) (> unviewed-messages-count 0))]
+  (let [display-name       (if group-chat
+                             name
+                             (first (rf/sub [:contacts/contact-two-names-by-identity chat-id])))
+        contact            (when-not group-chat
+                             (rf/sub [:contacts/contact-by-address chat-id]))
+        show-unread-badge? (and (not muted) (> unviewed-messages-count 0))]
     [rn/touchable-opacity
      {:style         (style/container)
       :on-press      (open-chat chat-id)
@@ -240,12 +241,11 @@
      [rn/view
       {:style {:flex         1
                :margin-left  8
-               :margin-right (if has-unread-badge? 36 0)}}
-      [name-view display-name contact timestamp has-unread-badge?]
+               :margin-right (if show-unread-badge? 36 0)}}
+      [name-view display-name contact timestamp show-unread-badge?]
       [last-message-preview group-chat last-message]]
-     (when-not muted
-       (when (> unviewed-messages-count 0)
-         [quo/info-count
-          {:style {:top   16
-                   :right 16}}
-          unviewed-messages-count]))]))
+     (when show-unread-badge?
+       [quo/info-count
+        {:style {:top   16
+                 :right 16}}
+        unviewed-messages-count])]))


### PR DESCRIPTION
fixes #16161

### Summary

This PR attempts to prevent the overflowing of chat name and message preview in the chat list by adding `flex-shrink` to the text component which displays the chat name.

### Platforms

- Android
- iOS

### Areas impacted

- Chat list

### Steps to test

#### Prerequisites: Have at least one contact

- Open Status
- Update the nickname of a contact to a lengthy one
- Receive a long message from other contact(s) 
- check if the contact name and message text are overflowing

status: ready 
