### PR TITLE
Identifiers screen design updates

### DIFF
--- a/src/quo2/components/profile/profile_card/style.cljs
+++ b/src/quo2/components/profile/profile_card/style.cljs
@@ -27,7 +27,8 @@
   {:color colors/white})
 
 (def emoji-hash
-  {:margin-top 12})
+  {:margin-top     12
+   :letter-spacing 1.5})
 
 (def user-hash
   {:margin-top 2

--- a/src/quo2/components/profile/profile_card/view.cljs
+++ b/src/quo2/components/profile/profile_card/view.cljs
@@ -94,9 +94,8 @@
            style/keycard-icon))]
        (when show-user-hash?
          [text/text
-          {:weight          :monospace
-           :number-of-lines 1
-           :style           style/user-hash} hash])
+          {:weight :monospace
+           :style  style/user-hash} hash])
        (when (and show-emoji-hash? emoji-hash)
          [text/text
           {:weight          :monospace

--- a/src/status_im2/contexts/onboarding/identifiers/style.cljs
+++ b/src/status_im2/contexts/onboarding/identifiers/style.cljs
@@ -5,7 +5,7 @@
 
 (def content-container
   {:position :absolute
-   :top      160
+   :top      170
    :bottom   0
    :left     0
    :right    0})


### PR DESCRIPTION
fixes #16075

### Summary

This PR updates the following UI elements in Onboarding - Identifiers screen:

- Lower the profile card
- Display compressed public key without any truncation
- Increase the spacing between the emojis in the emoji hash

<img src="https://github.com/status-im/status-mobile/assets/19339952/d4b72106-2f19-4a65-8bf6-a8c679bdbc96" width="300" />

#### Platforms

- Android
- iOS

status: ready 
