### PR TITLE
Dynamically calculate composer height to adjust the spacing on the bottom of the list

### DIFF
--- a/src/status_im2/contexts/chat/messages/list/view.cljs
+++ b/src/status_im2/contexts/chat/messages/list/view.cljs
@@ -126,13 +126,13 @@
           loading-indicator-page-loading-height)]])))
 
 (defn list-header
-  [insets composer-height]
+  [insets]
   [rn/view
    {:background-color (colors/theme-colors colors/white colors/neutral-95)
     :margin-bottom    (- 0
                          (:top insets)
                          (when platform/ios? style/overscroll-cover-height))
-    :height           (+ composer-height
+    :height           (+ composer.constants/composer-default-height
                          (:bottom insets)
                          spacing-between-composer-and-content
                          (when platform/ios? style/overscroll-cover-height))}])
@@ -251,11 +251,11 @@
 
 (defn render-fn
   [{:keys [type value content-type] :as message-data} _ _
-   {:keys [context keyboard-shown? insets composer-height]}]
+   {:keys [context keyboard-shown? insets]}]
   ;;TODO temporary hide mutual-state-updates https://github.com/status-im/status-mobile/issues/16254
   (when (not= content-type constants/content-type-system-mutual-state-update)
     (if (= type :header)
-      [list-header insets composer-height]
+      [list-header insets]
       [rn/view
        (add-inverted-y-android {:background-color (colors/theme-colors colors/white colors/neutral-95)})
        (if (= type :datemark)
@@ -281,9 +281,7 @@
         recording?                (when shell-animation-complete?
                                     (rf/sub [:chats/recording?]))
         all-loaded?               (when shell-animation-complete?
-                                    (rf/sub [:chats/all-loaded? (:chat-id chat)]))
-        composer-height           (when shell-animation-complete?
-                                    (rf/sub [:chats/composer-height]))]
+                                    (rf/sub [:chats/all-loaded? (:chat-id chat)]))]
     ;; NOTE(rasom): Top bar needs to react on `all-loaded?` only after messages
     ;; rendering, otherwise animation flickers
     (rn/use-effect (fn []
@@ -305,13 +303,12 @@
        :data                         (into [{:type :header}] messages)
        :render-data                  {:context         context
                                       :keyboard-shown? keyboard-shown?
-                                      :insets          insets
-                                      :composer-height composer-height}
+                                      :insets          insets}
        :render-fn                    render-fn
        :on-viewable-items-changed    on-viewable-items-changed
        :on-end-reached               #(list-on-end-reached scroll-y)
        :on-scroll-to-index-failed    identity
-       :scroll-indicator-insets      {:top (- composer-height 12)}
+       :scroll-indicator-insets      {:top (- composer.constants/composer-default-height 16)}
        :keyboard-dismiss-mode        :interactive
        :keyboard-should-persist-taps :always
        :on-scroll-begin-drag         rn/dismiss-keyboard!

--- a/src/status_im2/contexts/chat/messages/list/view.cljs
+++ b/src/status_im2/contexts/chat/messages/list/view.cljs
@@ -126,13 +126,13 @@
           loading-indicator-page-loading-height)]])))
 
 (defn list-header
-  [insets]
+  [insets composer-height]
   [rn/view
    {:background-color (colors/theme-colors colors/white colors/neutral-95)
     :margin-bottom    (- 0
                          (:top insets)
                          (when platform/ios? style/overscroll-cover-height))
-    :height           (+ composer.constants/composer-default-height
+    :height           (+ composer-height
                          (:bottom insets)
                          spacing-between-composer-and-content
                          (when platform/ios? style/overscroll-cover-height))}])
@@ -251,16 +251,18 @@
 
 (defn render-fn
   [{:keys [type value content-type] :as message-data} _ _
-   {:keys [context keyboard-shown?]}]
+   {:keys [context keyboard-shown? insets composer-height]}]
   ;;TODO temporary hide mutual-state-updates https://github.com/status-im/status-mobile/issues/16254
   (when (not= content-type constants/content-type-system-mutual-state-update)
-    [rn/view
-     (add-inverted-y-android {:background-color (colors/theme-colors colors/white colors/neutral-95)})
-     (if (= type :datemark)
-       [quo/divider-date value]
-       (if (= content-type constants/content-type-gap)
-         [message.gap/gap message-data]
-         [message/message message-data context keyboard-shown?]))]))
+    (if (= type :footer)
+      [list-header insets composer-height]
+      [rn/view
+       (add-inverted-y-android {:background-color (colors/theme-colors colors/white colors/neutral-95)})
+       (if (= type :datemark)
+         [quo/divider-date value]
+         (if (= content-type constants/content-type-gap)
+           [message.gap/gap message-data]
+           [message/message message-data context keyboard-shown?]))])))
 
 (defn scroll-handler
   [event scroll-y]
@@ -279,7 +281,9 @@
         recording?                (when shell-animation-complete?
                                     (rf/sub [:chats/recording?]))
         all-loaded?               (when shell-animation-complete?
-                                    (rf/sub [:chats/all-loaded? (:chat-id chat)]))]
+                                    (rf/sub [:chats/all-loaded? (:chat-id chat)]))
+        composer-height           (when shell-animation-complete?
+                                    (rf/sub [:chats/composer-height]))]
     ;; NOTE(rasom): Top bar needs to react on `all-loaded?` only after messages
     ;; rendering, otherwise animation flickers
     (rn/use-effect (fn []
@@ -291,23 +295,23 @@
        :ref                          list-ref
        :header                       [:<>
                                       (when (= (:chat-type chat) constants/private-group-chat-type)
-                                        [list-group-chat-header chat])
-                                      [list-header insets]]
+                                        [list-group-chat-header chat])]
        :footer                       [list-footer
                                       {:chat                      chat
                                        :scroll-y                  scroll-y
                                        :cover-bg-color            cover-bg-color
                                        :on-layout                 footer-on-layout
                                        :shell-animation-complete? shell-animation-complete?}]
-       :data                         messages
+       :data                         (into [{:type :footer}] messages)
        :render-data                  {:context         context
-                                      :keyboard-shown? keyboard-shown?}
+                                      :keyboard-shown? keyboard-shown?
+                                      :insets          insets
+                                      :composer-height composer-height}
        :render-fn                    render-fn
        :on-viewable-items-changed    on-viewable-items-changed
        :on-end-reached               #(list-on-end-reached scroll-y)
        :on-scroll-to-index-failed    identity
-       :content-container-style      {:padding-bottom style/messages-list-bottom-offset}
-       :scroll-indicator-insets      {:top (- composer.constants/composer-default-height 16)}
+       :scroll-indicator-insets      {:top (- composer-height 12)}
        :keyboard-dismiss-mode        :interactive
        :keyboard-should-persist-taps :always
        :on-scroll-begin-drag         rn/dismiss-keyboard!
@@ -329,9 +333,6 @@
        ;;TODO(rasom) https://github.com/facebook/react-native/issues/30034
        :inverted                     (when platform/ios? true)
        :on-layout                    (fn [e]
-                                       ;; FIXME: this is due to Android not triggering the initial
-                                       ;; scrollTo event
-                                       (scroll-to-offset 1)
                                        (let [layout-height (oops/oget e "nativeEvent.layout.height")]
                                          (reset! messages-view-height layout-height)))
        :scroll-enabled               (not recording?)}]]))

--- a/src/status_im2/contexts/chat/messages/list/view.cljs
+++ b/src/status_im2/contexts/chat/messages/list/view.cljs
@@ -254,7 +254,7 @@
    {:keys [context keyboard-shown? insets composer-height]}]
   ;;TODO temporary hide mutual-state-updates https://github.com/status-im/status-mobile/issues/16254
   (when (not= content-type constants/content-type-system-mutual-state-update)
-    (if (= type :footer)
+    (if (= type :header)
       [list-header insets composer-height]
       [rn/view
        (add-inverted-y-android {:background-color (colors/theme-colors colors/white colors/neutral-95)})
@@ -302,7 +302,7 @@
                                        :cover-bg-color            cover-bg-color
                                        :on-layout                 footer-on-layout
                                        :shell-animation-complete? shell-animation-complete?}]
-       :data                         (into [{:type :footer}] messages)
+       :data                         (into [{:type :header}] messages)
        :render-data                  {:context         context
                                       :keyboard-shown? keyboard-shown?
                                       :insets          insets

--- a/src/status_im2/subs/chat/chats.cljs
+++ b/src/status_im2/subs/chat/chats.cljs
@@ -6,6 +6,7 @@
             [status-im.group-chats.db :as group-chats.db]
             [status-im.multiaccounts.core :as multiaccounts]
             [status-im2.constants :as constants]
+            [status-im2.contexts.chat.composer.constants :as composer.constants]
             [status-im2.contexts.chat.events :as chat.events]))
 
 (re-frame/reg-sub
@@ -139,6 +140,24 @@
  :<- [:chat/inputs]
  (fn [[chat-id inputs]]
    (get inputs chat-id)))
+
+(re-frame/reg-sub
+ :chats/composer-height
+ :<- [:chats/current-chat-input]
+ :<- [:chats/link-previews-unfurled]
+ (fn [[{:keys [input-content-height metadata]} link-previews]]
+   (let [{:keys [responding-to-message editing-message sending-image]} metadata]
+     (+ (max composer.constants/input-height input-content-height)
+        (when responding-to-message
+          composer.constants/reply-container-height)
+        (when editing-message
+          composer.constants/edit-container-height)
+        (when (seq sending-image)
+          composer.constants/images-container-height)
+        (when (seq link-previews)
+          composer.constants/links-container-height)
+        composer.constants/bar-container-height
+        composer.constants/actions-container-height))))
 
 (re-frame/reg-sub
  :chats/sending-image


### PR DESCRIPTION
Currently the spacing on the bottom is fixed (it uses `composer.constants/composer-default-height`) which is a problem because composer doesn't actually have a fixed height.

This PR makes it use the dynamucally calculated height in order to make sure composer never overlaps the content and always leaves the right amount of space.

Tagging @OmarBasem here to double check if the calculation is done right.

Also fixes https://github.com/status-im/status-mobile/issues/16153

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

##### Functional

- 1-1 chats
- public chats
- group chats

status: wip <!-- Can be ready or wip -->
