### PR TITLE
nix: fix Android SDK on Darwin with nixpkgs system override

### DIFF
--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -17,9 +17,20 @@ let
 
   # Override some packages and utilities
   pkgsOverlay = import ./overlay.nix;
+
+  # Fix for lack of Android SDK for M1 Macs.
+  systemOverride = let
+    inherit (builtins) currentSystem getEnv;
+    envSystemOverride = getEnv "NIXPKGS_SYSTEM_OVERRIDE";
+  in
+    if envSystemOverride != "" then
+      envSystemOverride
+    else
+      currentSystem;
 in
   # import nixpkgs with a config override
   (import nixpkgsSrc) {
     config = defaultConfig // config;
+    system = systemOverride;
     overlays = [ pkgsOverlay ];
   }

--- a/nix/pkgs/android-sdk/compose.nix
+++ b/nix/pkgs/android-sdk/compose.nix
@@ -3,7 +3,10 @@
 # for the Android development environment.
 #
 
-{ androidenv }:
+{ androidenv, lib, stdenv }:
+
+assert lib.assertMsg (stdenv.system != "aarch64-darwin")
+  "aarch64-darwin not supported for Android SDK. Use: NIXPKGS_SYSTEM_OVERRIDE=x86_64-darwin";
 
 # The "android-sdk-license" license is accepted
 # by setting android_sdk.accept_license = true.

--- a/nix/scripts/build.sh
+++ b/nix/scripts/build.sh
@@ -25,7 +25,7 @@ cleanup() {
 
 # If you want to clean after every build set _NIX_CLEAN=true
 if [[ -n "${_NIX_CLEAN}" ]]; then
-    trap cleanup EXIT ERR INT QUIT
+  trap cleanup EXIT ERR INT QUIT
 fi
 
 # build output will end up under /nix, we have to extract it
@@ -42,6 +42,12 @@ shift
 if [[ -z "${TARGET}" ]]; then
   echo -e "${RED}First argument is mandatory and has to specify the Nix attribute!${RST}"
   exit 1
+fi
+
+# Hack fix for missing Android SDK for aarch64 on Darwin. See systemOverride in `nix/pkgs.nix`.
+if [[ "${TARGET}" =~ ^(targets.status-go.mobile.android|targets.mobile.android.release)$ ]]; then
+  os=$(uname -s | tr '[:upper:]' '[:lower:]')
+  export NIXPKGS_SYSTEM_OVERRIDE="x86_64-${os}"
 fi
 
 # Some defaults flags, --pure could be optional in the future.

--- a/nix/scripts/shell.sh
+++ b/nix/scripts/shell.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-#
 # This script is used by the Makefile to have an implicit nix-shell.
 # The following environment variables modify the script behavior:
 # - TARGET: This attribute is passed via --attr to Nix, defining the scope.
@@ -62,6 +61,12 @@ fi
 if [[ -n "${_NIX_PURE}" ]]; then
     nixArgs+=("--pure")
     pureDesc='pure '
+fi
+
+# Hack fix for missing Android SDK for aarch64 on Darwin. See systemOverride in `nix/pkgs.nix`.
+if [[ "${TARGET}" =~ ^(android-sdk|android|gradle|keytool|status-go)$ ]]; then
+    os=$(uname -s | tr '[:upper:]' '[:lower:]')
+    export NIXPKGS_SYSTEM_OVERRIDE="x86_64-${os}"
 fi
 
 echo -e "${GRN}Configuring ${pureDesc}Nix shell for target '${TARGET}'...${RST}" 1>&2


### PR DESCRIPTION
### Summary
Android SDK in `nixpkg` doesn't support `aarch64-darwin`, for details see https://github.com/status-im/status-mobile/issues/12794.
The workaround was to run terminal application with Rosetta or make with `aarch` tool.

This PR overrides system architecture to always be `x86_64` for Android shell and build targets ran by make.

CI is not affected as it runs `nix` directly.

### Review notes
Are there any conmmands, which developers run?

### Testing notes
Shell and Build on Apple Silicon should work without Rosetta or `arch`.
iOS build/run performance should not be affected on Apple Silicon.
Linux x86 should not be affected.

### Steps to test
- Disable Rosetta or `arch` workarounds
- Run Android related commands (`make build-android`, `make status-go-android`, `make shell TARGET=android-sdk`)

status: ready