### PR TITLE
Information about patching 3rd parties

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -20,6 +20,8 @@
 
 [Debugging](debugging.md)
 
+[Patching 3rd parties](patching-3rdparties.md)
+
 
 ## Testing
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -20,7 +20,7 @@
 
 [Debugging](debugging.md)
 
-[Patching 3rd parties](patching-3rdparties.md)
+[Patching](patching.md)
 
 
 ## Testing

--- a/doc/patching-3rdparties.md
+++ b/doc/patching-3rdparties.md
@@ -1,0 +1,6 @@
+# Patching 3rd party dependencies
+
+If 3rd party dependency has an issue and fix is not yet released (or we can't switch to a new release), local patch can be applied. 
+Status doesn't used nodejs-way of applying patches. Instead we use Nix.
+
+Patches should be added to [this file](https://github.com/status-im/status-mobile/blob/develop/nix/deps/nodejs-patched/default.nix).

--- a/doc/patching-3rdparties.md
+++ b/doc/patching-3rdparties.md
@@ -1,6 +1,13 @@
 # Patching 3rd party dependencies
 
-If 3rd party dependency has an issue and fix is not yet released (or we can't switch to a new release), local patch can be applied. 
-Status doesn't used nodejs-way of applying patches. Instead we use Nix.
+## Libraries
+If 3rd party library has an issue and fix is not yet released (or we can't switch to a new release), we use forks. Fix should be commited to the fork and tagged.
+
+Example: [`react-native-hole-view`](https://github.com/status-im/react-native-hole-view#refs/tags/v2.1.1-status)
+
+## React Native
+When patch need to be applied to React Native itself Status does patching with Nix instead of doing it nodejs-way.
 
 Patches should be added to [this file](https://github.com/status-im/status-mobile/blob/develop/nix/deps/nodejs-patched/default.nix).
+
+Example: [patching `react-native/Yoga` to build app with XCode 14.3](https://github.com/status-im/status-mobile/pull/15589)

--- a/doc/patching.md
+++ b/doc/patching.md
@@ -1,7 +1,7 @@
-# Patching 3rd party dependencies
+# Patching
 
 ## Libraries
-If 3rd party library has an issue and fix is not yet released (or we can't switch to a new release), we use forks. Fix should be commited to the fork and tagged.
+If 3rd party library has an issue and fix is not yet released (or we can't switch to a new release), we use forks. Fix should be commited to the fork, tagged and referenced from package.json.
 
 Example: [`react-native-hole-view`](https://github.com/status-im/react-native-hole-view#refs/tags/v2.1.1-status)
 


### PR DESCRIPTION

### Summary

Docs updated with information on how we use Nix for patching 3rd parties instead of doing it nodejs-way

status: ready
