### PR TITLE
[#16156] Top bar flashing

### DIFF
--- a/src/status_im2/contexts/chat/messages/navigation/view.cljs
+++ b/src/status_im2/contexts/chat/messages/navigation/view.cljs
@@ -14,11 +14,11 @@
             [status-im2.common.home.actions.view :as actions]))
 
 (defn f-navigation-view
-  [{:keys [scroll-y]}]
+  [{:keys [scroll-y shared-all-loaded?]}]
   (let [{:keys [group-chat chat-id chat-name emoji
                 chat-type]
          :as   chat}             (rf/sub [:chats/current-chat-chat-view])
-        all-loaded?              (rf/sub [:chats/all-loaded? chat-id])
+        all-loaded?              @shared-all-loaded?
         display-name             (if (= chat-type constants/one-to-one-chat-type)
                                    (first (rf/sub [:contacts/contact-two-names-by-identity chat-id]))
                                    (str emoji " " chat-name))

--- a/src/status_im2/contexts/chat/messages/view.cljs
+++ b/src/status_im2/contexts/chat/messages/view.cljs
@@ -25,8 +25,10 @@
     [messages.list/messages-list
      {:cover-bg-color (colors/custom-color :turquoise 50 20)
       :chat           chat
-      :header-comp    (fn [{:keys [scroll-y]}]
-                        [messages.navigation/navigation-view {:scroll-y scroll-y}])
+      :header-comp    (fn [{:keys [scroll-y shared-all-loaded?]}]
+                        [messages.navigation/navigation-view
+                         {:scroll-y           scroll-y
+                          :shared-all-loaded? shared-all-loaded?}])
       :footer-comp    (fn [{:keys [insets]}]
                         (if-not able-to-send-message?
                           [contact-requests.bottom-drawer/view chat-id contact-request-state


### PR DESCRIPTION
fix #16156

status: ready

The issue is caused by `chats/all-loaded?` sub being updated faster then the list of messages, thus Top Bar behaves like all messages are loaded (technically they are, but in app-db, not in the view) and animation is started. In order to prevent this we need to avoid reaction on `all-loaded?` change. 