### PR TITLE
ci: build generic status-go and all shells

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ export NODE_OPTIONS += --openssl-legacy-provider
 export KEYSTORE_PATH ?= $(HOME)/.gradle/status-im.keystore
 
 # Our custom config is located in nix/nix.conf
-export NIX_CONF_DIR = $(PWD)/nix
+export NIX_USER_CONF_FILES = $(PWD)/nix/nix.conf
 # Location of symlinks to derivations that should not be garbage collected
 export _NIX_GCROOTS = /nix/var/nix/gcroots/per-user/$(USER)/status-mobile
 # Defines which variables will be kept for Nix pure shell, use semicolon as divider

--- a/ci/tools/Jenkinsfile.nix-cache
+++ b/ci/tools/Jenkinsfile.nix-cache
@@ -28,7 +28,7 @@ pipeline {
     timestamps()
     disableConcurrentBuilds()
     /* Prevent Jenkins jobs from running forever */
-    timeout(time: 300, unit: 'MINUTES')
+    timeout(time: 120, unit: 'MINUTES')
     /* Limit builds retained */
     buildDiscarder(logRotator(
       numToKeepStr: '20',
@@ -41,18 +41,19 @@ pipeline {
       steps { script {
         nix.shell('nix-env -i openssh', sandbox: false, pure: false)
         /* some build targets don't build on MacOS */
-        uname = sh(script: 'uname', returnStdout: true)
+        os = sh(script: 'uname', returnStdout: true)
+        arch = sh(script: 'arch', returnStdout: true)
       } }
     }
     stage('Build status-go') {
       steps { script {
-        def platforms = ['mobile.android', 'mobile.ios']
-        if (uname != "Darwin") {
-          platforms.removeAll { it == "ios" }
-        }
+        def platforms = ['mobile.android', 'mobile.ios', 'library']
+        if (os != 'Darwin')  { platforms.removeAll { it == 'mobile.ios' } }
+        /* FIXME: Remove this when #16237 is merged. */
+        if (arch == 'arm64') { platforms.removeAll { it == 'mobile.android' } }
         platforms.each { os ->
           nix.build(
-            attr: "targets.status-go.${os}.buildInputs",
+            attr: "targets.status-go.${os}",
             sandbox: false,
             link: false
           )
@@ -83,12 +84,16 @@ pipeline {
     }
     stage('Build nix shell deps') {
       steps { script {
+        def shells = ['android', 'ios', 'fastlane', 'keytool', 'clojure', 'gradle']
+        if (os != "Darwin") { shells.removeAll { it == 'ios' } }
         /* Build/fetch deps required to start default Nix shell. */
-        nix.build(
-          attr: 'shells.default.buildInputs',
-          sandbox: false,
-          link: false
-        )
+        shells.each { shell ->
+          nix.build(
+            attr: "shells.${shell}.buildInputs",
+            sandbox: false,
+            link: false
+          )
+        }
       } }
     }
     stage('Upload') {

--- a/nix/KNOWN_ISSUES.md
+++ b/nix/KNOWN_ISSUES.md
@@ -1,5 +1,18 @@
 # Known Issues
 
+## Ignoring Untrusted Substituter on NixOS
+
+When using our setup on NixOS users can see this warning:
+```
+warning: ignoring untrusted substituter 'https://nix-cache.status.im/', you are not a trusted user.
+```
+Which is due to incorrect `trusted-users` setting:
+```
+> grep trusted-users /etc/nix/nix.conf
+trusted-users = root
+```
+Which can be extended using the [`nix.settings.trusted-users`](https://search.nixos.org/options?channel=23.05&show=nix.settings.trusted-users) option.
+
 ## Too many open files
 
 ### Single-User Installation

--- a/nix/nix.conf
+++ b/nix/nix.conf
@@ -1,6 +1,6 @@
-# NOTE: If you are in Asia you might want to add https://nix-cache-cn.status.im/ to extra-substituters
-extra-substituters = https://nix-cache.status.im/
-substituters = https://cache.nixos.org/
+# NOTE: If you are in Asia you might want to add https://nix-cache-cn.status.im/ to substituters.
+substituters = https://nix-cache.status.im/ https://cache.nixos.org/
+trusted-substituters = https://nix-cache.status.im/ https://cache.nixos.org/
 trusted-public-keys = nix-cache.status.im-1:x/93lOfLU+duPplwMSBR+OlY4+mo+dCN7n0mr4oPwgY= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
 # Some downloads are multiple GB, default is 5 minutes
 stalled-download-timeout = 3600


### PR DESCRIPTION
When discussing caching of `status-go` with Sid I noticed that the build we cache daily created from our nightly job is different from the build we create locally due to a single input.

In a release CI host we can see the IPFS URL is that of Infura:
```
 > find /nix/store -maxdepth 1 -name '*-status-go-*android' | tail -n1
/nix/store/2cc8ilhx5g3k2awbn4sla61n4cml2405-status-go-0.130.1-d2cce5e-android

 > RESULT=$(find /nix/store -maxdepth 1 -name '*-status-go-*android' | tail -n1)

 > nix show-derivation $RESULT | tr ' ' '\n' | grep IpfsGateway
github.com/status-im/status-go/params.IpfsGatewayURL=https://status-im.infura-ipfs.io/ipfs/
```
But for a local build the URL is the default, which is our own gateway:
```
 > nix-build --no-out-link -A targets.status-go.mobile.android
/nix/store/1p53m7a6y1kg3vcyd8d06scf3bsyn5rk-status-go-0.157.2-47711c4-android

 > RESULT=$(nix-build --no-out-link -A targets.status-go.mobile.android)

 > nix show-derivation $RESULT | tr ' ' '\n' | grep IpfsGateway
github.com/status-im/status-go/params.IpfsGatewayURL=https://ipfs.status.im/
```
This difference causes builds of `status-go` that get uploaded to our Nix cache to not match what developers locally would build, which results in a cache miss.

This changes the Nix cache CI jobs to instead of building only dependencies(`buildInuts`) to simply build the generic versions of `status-go` without nightly specific inputs.

This also fixes configuration of our own Nix cache:

According to this line from the docs:

>The system-wide configuration file sysconfdir/nix/nix.conf (i.e. /etc/nix/nix.conf),
>or $NIX_CONF_DIR/nix.conf if NIX_CONF_DIR is set. Values loaded in this file are not
>forwarded to the Nix daemon. The client assumes that the daemon has already loaded them.

https://nixos.org/manual/nix/stable/command-ref/conf-file.html#description

Our usage of `NIX_CONF_DIR` has been wrong for a while now.
The correct way of applying this config is using `NIX_USER_CONF_FILES`.

In addition the `extra-substituters` no longer exists in the docs.
Use of `trusted-substituters` is necessary according to:

>At least one of the following conditions must be met for Nix to use a substituter:
>
>- the substituter is in the trusted-substituters list
>- the user calling Nix is in the trusted-users list

https://nixos.org/manual/nix/stable/command-ref/conf-file.html#conf-substituters