### PR TITLE
fix switcher cards position in ios

### DIFF
--- a/src/status_im2/contexts/shell/components/shell_screen/view.cljs
+++ b/src/status_im2/contexts/shell/components/shell_screen/view.cljs
@@ -70,17 +70,18 @@
   (let [data (if (seq switcher-cards) switcher-cards empty-cards)]
     [:<>
      [rn/flat-list
-      {:data                    data
-       :render-fn               render-card
-       :key-fn                  :id
-       :header                  (jump-to-text)
-       :ref                     #(reset! state/jump-to-list-ref %)
-       :num-columns             2
-       :column-wrapper-style    {:margin-horizontal shell-margin
-                                 :justify-content   :space-between
-                                 :margin-bottom     16}
-       :style                   style/jump-to-list
-       :content-container-style {:padding-bottom (utils/bottom-tabs-container-height)}}]
+      {:data                              data
+       :render-fn                         render-card
+       :key-fn                            :id
+       :header                            (jump-to-text)
+       :ref                               #(reset! state/jump-to-list-ref %)
+       :num-columns                       2
+       :column-wrapper-style              {:margin-horizontal shell-margin
+                                           :justify-content   :space-between
+                                           :margin-bottom     16}
+       :style                             style/jump-to-list
+       :content-inset-adjustment-behavior :never
+       :content-container-style           {:padding-bottom (utils/bottom-tabs-container-height)}}]
      (when-not (seq switcher-cards)
        [placeholder])]))
 


### PR DESCRIPTION
fixes: https://github.com/status-im/status-mobile/issues/16050

### Summary

When the flat list is used in ios with full-screen size and without a safe area, ios pushes it down.
Tried initializing the flat list with a negative margin as status-bar height to neutralize this push.
It fixes the initial issue, but as soon as we scroll the flat list to the top, it ignores the initial pushed effect and scrolls only to the negative margin.


status: ready