### PR TITLE
[#15944] Set installation name on account creation and pairing

### DIFF
--- a/modules/react-native-status/ios/RCTStatus/RCTStatus.m
+++ b/modules/react-native-status/ios/RCTStatus/RCTStatus.m
@@ -1156,23 +1156,7 @@ RCT_EXPORT_METHOD(deactivateKeepAwake)
 
 - (NSString*) deviceName
 {
-
-    NSString* deviceName = nil;
-
-    if ([self.deviceId rangeOfString:@"iPod"].location != NSNotFound) {
-        deviceName = @"iPod Touch";
-    }
-    else if([self.deviceId rangeOfString:@"iPad"].location != NSNotFound) {
-        deviceName = @"iPad";
-    }
-    else if([self.deviceId rangeOfString:@"iPhone"].location != NSNotFound){
-        deviceName = @"iPhone";
-    }
-    else if([self.deviceId rangeOfString:@"AppleTV"].location != NSNotFound){
-        deviceName = @"Apple TV";
-    }
-
-    return deviceName;
+    return [[UIDevice currentDevice] name];;
 }
 
 - (NSDictionary *)constantsToExport

--- a/src/native_module/core.cljs
+++ b/src/native_module/core.cljs
@@ -4,7 +4,8 @@
             [taoensso.timbre :as log]
             [react-native.platform :as platform]
             [react-native.core :as rn]
-            [utils.transforms :as types]))
+            [utils.transforms :as types]
+            [clojure.string :as string]))
 
 (defn status
   []
@@ -386,6 +387,14 @@
      :brand     (.-brand status)
      :build-id  (.-buildId status)
      :device-id (.-deviceId status)}))
+
+(defn get-installation-name
+  []
+  ;; NOTE(rasom): Only needed for android devices currently
+  (when platform/android?
+    (string/join " "
+                 ((juxt :model :device-id)
+                  (get-device-model-info)))))
 
 (defn get-node-config
   [callback]

--- a/src/status_im2/contexts/onboarding/events.cljs
+++ b/src/status_im2/contexts/onboarding/events.cljs
@@ -80,6 +80,7 @@
                           :multiaccount/restore-account-and-login
                           :multiaccount/create-account-and-login)
         request         {:displayName                 display-name
+                         :deviceName                  (native-module/get-installation-name)
                          :password                    (ethereum/sha3 (security/safe-unmask-data
                                                                       password))
                          :mnemonic                    (when seed-phrase

--- a/src/status_im2/contexts/syncing/events.cljs
+++ b/src/status_im2/contexts/syncing/events.cljs
@@ -26,6 +26,7 @@
   (let [db {:networks/current-network config/default-network
             :networks/networks        (data-store.settings/rpc->networks config/default-networks)
             :profile/profile          {:installation-id           installation-id
+                                       :device-name               (native-module/get-installation-name)
                                        :log-level                 config/log-level
                                        :waku-bloom-filter-mode    false
                                        :custom-bootnodes          nil
@@ -59,7 +60,9 @@
                                         {:receiverConfig {:kdfIterations config/default-kdf-iterations
                                                           :nodeConfig final-node-config
                                                           :settingCurrentNetwork config/default-network
-                                                          :deviceType utils.platform/os}}))]
+                                                          :deviceType utils.platform/os
+                                                          :deviceName
+                                                          (native-module/get-installation-name)}}))]
             (rf/dispatch [:syncing/update-role constants/local-pairing-role-receiver])
             (native-module/input-connection-string-for-bootstrapping
              connection-string


### PR DESCRIPTION
fix #15944

This line returns "localhost" https://github.com/status-im/status-go/blob/develop/server/device.go#L29, so instead we set installation name during account creation or pairing.

status: ready