### PR TITLE
Fix incorrect channel option

### DIFF
--- a/src/status_im2/contexts/communities/actions/chat/view.cljs
+++ b/src/status_im2/contexts/communities/actions/chat/view.cljs
@@ -21,10 +21,9 @@
 (defn- action-mark-as-read
   []
   {:icon                :i/mark-as-read
-   :right-icon          :i/chevron-right
    :accessibility-label :chat-mark-as-read
    :on-press            not-implemented/alert
-   :label               (i18n/label :t/mute-channel)})
+   :label               (i18n/label :t/mark-as-read)})
 
 (defn- action-toggle-muted
   []


### PR DESCRIPTION
Linked to https://github.com/status-im/status-mobile/issues/16178

### Summary

A tiny PR fixing what was probably a typo.

This is how the *mark as read* options looks now:

<img src="https://github.com/status-im/status-mobile/assets/46027/41f2af76-e2ce-4307-9ec7-f1ddf8c83835" height="400" />

https://www.figma.com/file/h9wo4GipgZURbqqr1vShFN/Communities-for-Mobile?type=design&node-id=5487-240892&t=GkdOR7DFgkScU1wI-0

status: ready
