### PR TITLE
[15524] Support mentioning non Latin nicknames

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "feat/support-mention-non-latin-nickname",
-    "commit-sha1": "22ae4e7f2a29e4b45295e6e5df5361b354b32f74",
-    "src-sha256": "12s7dkn2ycqiwjf8q9l1ddgy8xg6psmind38dphl51wi23rwjhjs"
+    "version": "v0.159.2",
+    "commit-sha1": "fee033fadbaf7654ffde52c224e21603afbd122e",
+    "src-sha256": "0m9r3wknmc96r90pgv918im09fnia21hsdcxcd2gcn18jrjsy13b"
 }

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.157.2",
-    "commit-sha1": "47711c4f15d0ebb4665cc121f17184b183f4d2df",
-    "src-sha256": "1w0marsyq8gk2dv4qi4xxplgm67iw6sif7n551jdypbl01i1s17w"
+    "version": "feat/support-mention-non-latin-nickname",
+    "commit-sha1": "4ab0fae231f5bcebf4544729ec9aa73126a771a9",
+    "src-sha256": "15r3wijzvgrd3v80xph763hymd0wqbja734gfy5abadqa7p84v81"
 }

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -4,6 +4,6 @@
     "owner": "status-im",
     "repo": "status-go",
     "version": "feat/support-mention-non-latin-nickname",
-    "commit-sha1": "4ab0fae231f5bcebf4544729ec9aa73126a771a9",
-    "src-sha256": "15r3wijzvgrd3v80xph763hymd0wqbja734gfy5abadqa7p84v81"
+    "commit-sha1": "5292334888719fd57f41d8ab40b9836938d4bded",
+    "src-sha256": "0s6vfk4cy50x074rv0fbm8w883n8mh8n6fg5kfmkp45fyynmy65x"
 }

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -4,6 +4,6 @@
     "owner": "status-im",
     "repo": "status-go",
     "version": "feat/support-mention-non-latin-nickname",
-    "commit-sha1": "5292334888719fd57f41d8ab40b9836938d4bded",
-    "src-sha256": "0s6vfk4cy50x074rv0fbm8w883n8mh8n6fg5kfmkp45fyynmy65x"
+    "commit-sha1": "22ae4e7f2a29e4b45295e6e5df5361b354b32f74",
+    "src-sha256": "12s7dkn2ycqiwjf8q9l1ddgy8xg6psmind38dphl51wi23rwjhjs"
 }


### PR DESCRIPTION
the issue #15524 is very old and mention implementation changed a lot, when I trying to reproduce , I found the non-latin nickname even won't appear in the mention suggestion list when trying mention,  this [PR](https://github.com/status-im/status-go/pull/3641) should make it appear in the mention suggestion list when trying @, after it, I can't reproduce it. (spaces at end/beginnig of the nickname doesn't count in ATM as I [commented](https://github.com/status-im/status-mobile/issues/15524#issuecomment-1598007238)) , we need QA to confirm if bug still exist.

fixes #15524

status: ready <!-- Can be ready or wip -->
