### PR TITLE
[Fix] Seen state of notifications in Activity Center

### DIFF
--- a/src/status_im2/contexts/activity_center/events.cljs
+++ b/src/status_im2/contexts/activity_center/events.cljs
@@ -80,7 +80,9 @@
                             new-notifications
                             (get-in db [:activity-center :filter]))
      :dispatch-n [[:activity-center.notifications/fetch-unread-count]
-                  [:activity-center.notifications/fetch-pending-contact-requests]]}))
+                  [:activity-center.notifications/fetch-pending-contact-requests]
+                  (when (= (:view-id db) :activity-center)
+                    [:activity-center/mark-as-seen])]}))
 
 (rf/defn notifications-reconcile-from-response
   {:events [:activity-center/reconcile-notifications-from-response]}


### PR DESCRIPTION
fixes #16306

### Summary

This PR fixes the seen state of notifications if the user is in the Activity Center screen while receiving a new notification.

### Platforms

- Android
- iOS

### Areas impacted

- Activity Center

### Steps to test

- Open Status
- Navigate to the Activity Center
- Keep the Activity Center open
- Receive any Activity Center notification (Contact Request, Mentions, Replies,...etc)
- Close the Activity Center
- Check the colour of the unread counter on the Notification Bell Icon

status: ready