### PR TITLE
init status-go logging once app start up

### DIFF
--- a/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusModule.java
+++ b/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusModule.java
@@ -154,8 +154,8 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
         // Environment.getExternalStoragePublicDirectory doesn't work as expected on Android Q
         // https://developer.android.com/reference/android/os/Environment#getExternalStoragePublicDirectory(java.lang.String)
         return context.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS);
-
     }
+
     private File getLogsFile() {
         final File pubDirectory = this.getPublicStorageDirectory();
         final File logFile = new File(pubDirectory, gethLogFileName);
@@ -1372,6 +1372,17 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
                 Statusgo.initKeystore(keyStoreDir);
                 return Statusgo.convertToKeycardAccount(accountData, options, keycardUID, password, newPassword);
             }, callback);
+    }
+
+    @ReactMethod
+    public void initLogging(final boolean enabled, final boolean mobileSystem, final String logLevel, final Callback callback) throws JSONException {
+        final JSONObject jsonConfig = new JSONObject();
+        jsonConfig.put("Enabled", enabled);
+        jsonConfig.put("MobileSystem", mobileSystem);
+        jsonConfig.put("Level", logLevel);
+        jsonConfig.put("File", getLogsFile().getAbsolutePath());
+        final String config = jsonConfig.toString();
+        executeRunnableStatusGoMethod(() -> Statusgo.initLogging(config), callback);
     }
 
 }

--- a/modules/react-native-status/ios/RCTStatus/RCTStatus.m
+++ b/modules/react-native-status/ios/RCTStatus/RCTStatus.m
@@ -906,6 +906,37 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(logFileDirectory) {
     return rootUrl.path;
 }
 
+RCT_EXPORT_METHOD(initLogging:(BOOL)enabled
+                  mobileSystem:(BOOL)mobileSystem
+                  logLevel:(NSString *)logLevel
+                  callback:(RCTResponseSenderBlock)callback)
+{
+    NSString *logDirectory = [self logFileDirectory];
+    NSString *logFilePath = [logDirectory stringByAppendingPathComponent:@"geth.log"];
+
+    NSMutableDictionary *jsonConfig = [NSMutableDictionary dictionary];
+    jsonConfig[@"Enabled"] = @(enabled);
+    jsonConfig[@"MobileSystem"] = @(mobileSystem);
+    jsonConfig[@"Level"] = logLevel;
+    jsonConfig[@"File"] = logFilePath;
+
+    NSError *error = nil;
+    NSData *jsonData = [NSJSONSerialization dataWithJSONObject:jsonConfig options:0 error:&error];
+
+    if (error) {
+        // Handle JSON serialization error
+        callback(@[error.localizedDescription]);
+        return;
+    }
+
+    NSString *config = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
+
+    // Call your native logging initialization method here
+    NSString *initResult = StatusgoInitLogging(config);
+
+    callback(@[initResult]);
+}
+
 RCT_EXPORT_METHOD(generateAliasAsync:(NSString *)publicKey
                   callback:(RCTResponseSenderBlock)callback) {
 #if DEBUG

--- a/modules/react-native-status/nodejs/status.cpp
+++ b/modules/react-native-status/nodejs/status.cpp
@@ -1873,6 +1873,35 @@ void _ConnectionChange(const FunctionCallbackInfo<Value>& args) {
 	ConnectionChange(arg0, arg1);
 }
 
+void _InitLogging(const FunctionCallbackInfo<Value>& args) {
+	Isolate* isolate = args.GetIsolate();
+    Local<Context> context = isolate->GetCurrentContext();
+
+	if (args.Length() != 1) {
+		// Throw an Error that is passed back to JavaScript
+		isolate->ThrowException(Exception::TypeError(
+			String::NewFromUtf8Literal(isolate, "Wrong number of arguments for InitLogging")));
+		return;
+	}
+
+	// Check the argument types
+	if (!args[0]->IsString()) {
+		isolate->ThrowException(Exception::TypeError(
+			String::NewFromUtf8Literal(isolate, "Wrong argument type for 'logSettingsJSON'")));
+		return;
+	}
+
+	String::Utf8Value arg0Obj(isolate, args[0]->ToString(context).ToLocalChecked());
+	char *arg0 = *arg0Obj;
+
+	// Call exported Go function, which returns a C string
+	char *c = InitLogging(arg0);
+
+	Local<String> ret = String::NewFromUtf8(isolate, c).ToLocalChecked();
+    args.GetReturnValue().Set(ret);
+    delete c;
+}
+
 
 void init(Local<Object> exports) {
 	NODE_SET_METHOD(exports, "multiAccountGenerateAndDeriveAddresses", _MultiAccountGenerateAndDeriveAddresses);
@@ -1922,13 +1951,14 @@ void init(Local<Object> exports) {
 	NODE_SET_METHOD(exports, "signTypedData", _SignTypedData);
 	NODE_SET_METHOD(exports, "sendTransaction", _SendTransaction);
 	NODE_SET_METHOD(exports, "appStateChange", _AppStateChange);
-        NODE_SET_METHOD(exports, "setSignalEventCallback", _SetSignalEventCallback);
+    NODE_SET_METHOD(exports, "setSignalEventCallback", _SetSignalEventCallback);
 	NODE_SET_METHOD(exports, "validateNodeConfig", _ValidateNodeConfig);
 	NODE_SET_METHOD(exports, "hashTypedData", _HashTypedData);
 	NODE_SET_METHOD(exports, "recover", _Recover);
 	NODE_SET_METHOD(exports, "hashTransaction", _HashTransaction);
 	NODE_SET_METHOD(exports, "connectionChange", _ConnectionChange);
 	NODE_SET_METHOD(exports, "pollSignal", _PollSignal);
+	NODE_SET_METHOD(exports, "initLogging", _InitLogging);
 }
 
 NODE_MODULE(NODE_GYP_MODULE_NAME, init)

--- a/src/native_module/core.cljs
+++ b/src/native_module/core.cljs
@@ -545,3 +545,7 @@
 (defn log-file-directory
   []
   (.logFileDirectory ^js (status)))
+
+(defn init-status-go-logging
+  [{:keys [enable? mobile-system? log-level callback]}]
+  (.initLogging ^js (status) enable? mobile-system? log-level callback))

--- a/src/status_im/utils/test.cljs
+++ b/src/status_im/utils/test.cljs
@@ -1,5 +1,6 @@
 (ns status-im.utils.test
-  (:require [re-frame.core :as re-frame]))
+  (:require [re-frame.core :as re-frame]
+            [status-im.utils.types :as types]))
 
 (def native-status (js/require "../../modules/react-native-status/nodejs/bindings"))
 
@@ -125,4 +126,12 @@
     :validateMnemonic
     (fn [json callback] (callback (.validateMnemonic native-status json)))
 
-    :startLocalNotifications identity}))
+    :startLocalNotifications identity
+
+    :initLogging
+    (fn [enabled mobile-system log-level callback]
+      (callback (.initLogging native-status
+                              (types/clj->json {:Enabled      enabled
+                                                :MobileSystem mobile-system
+                                                :Level        log-level
+                                                :File         (str test-dir "/geth.log")}))))}))

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.159.2",
-    "commit-sha1": "fee033fadbaf7654ffde52c224e21603afbd122e",
-    "src-sha256": "0m9r3wknmc96r90pgv918im09fnia21hsdcxcd2gcn18jrjsy13b"
+    "version": "v0.159.4",
+    "commit-sha1": "7da1ed38d4da3c6f9f5bd6fb32657b4183e8fa74",
+    "src-sha256": "10j8p8ng0i6jkv8bplfwwq847yfvyvnz1r2xf5csiy0b86gdwn8n"
 }


### PR DESCRIPTION
It would be helpful if we could check the geth.log file to investigate any issues that might occur even if the user hasn't logged in yet. For example, local pairing may occur on the receiver side before login. If any problems arise during this process, we currently lack a log for status-go since logging for status-go is only configured after login.

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open Status , don't login
- Check geth.log, there should be a line contains: `lvl=info msg="logging initialised"`

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->
