### PR TITLE
[#16322] - Carousel tap gesture

### DIFF
--- a/src/status_im2/contexts/onboarding/common/background/view.cljs
+++ b/src/status_im2/contexts/onboarding/common/background/view.cljs
@@ -79,7 +79,7 @@
        :paused?           paused?
        :header-text       header-text
        :header-background true
-       :swipeable?        true
+       :gesture           :swipeable
        :background        [background-image (* 4 window-width)]}]
      (when dark-overlay?
        [blur/view

--- a/src/status_im2/contexts/onboarding/common/carousel/animation.cljs
+++ b/src/status_im2/contexts/onboarding/common/carousel/animation.cljs
@@ -95,18 +95,21 @@
 
 (defn drag-gesture
   [progress paused]
-  (->
-    (gesture/gesture-pan)
-    (gesture/enabled true)
-    (gesture/max-pointers 1)
-    (gesture/on-finalize
-     (fn [event]
-       (let [next?     (< (oops/oget event "translationX") (- drag-limit))
-             previous? (> (oops/oget event "translationX") drag-limit)]
-         (when next?
-           (update-progress progress paused (get-next-progress progress)))
-         (when previous?
-           (update-progress progress paused (get-previous-progress progress))))))))
+  (-> (gesture/gesture-pan)
+      (gesture/max-pointers 1)
+      (gesture/on-finalize
+       (fn [event]
+         (let [next?     (< (oops/oget event "translationX") (- drag-limit))
+               previous? (> (oops/oget event "translationX") drag-limit)]
+           (when next?
+             (update-progress progress paused (get-next-progress progress)))
+           (when previous?
+             (update-progress progress paused (get-previous-progress progress))))))))
+
+(defn tap-gesture
+  [progress paused]
+  (-> (gesture/gesture-tap)
+      (gesture/on-end #(update-progress progress paused (get-next-progress progress)))))
 
 (defn carousel-left-position
   [window-width animate? progress]

--- a/src/status_im2/contexts/onboarding/common/carousel/style.cljs
+++ b/src/status_im2/contexts/onboarding/common/carousel/style.cljs
@@ -63,14 +63,9 @@
 
 (defn carousel-container
   [left animate?]
-  (let [normal-style {:position       :absolute
-                      :right          0
-                      :top            0
-                      :bottom         0
-                      :flex-direction :row
-                      :left           left}]
-    (if animate?
-      (reanimated/apply-animations-to-style
-       {:left left}
-       normal-style)
-      normal-style)))
+  (cond->> {:position       :absolute
+            :right          0
+            :top            0
+            :flex-direction :row
+            :left           left}
+    animate? (reanimated/apply-animations-to-style {:left left})))

--- a/src/status_im2/contexts/onboarding/common/carousel/view.cljs
+++ b/src/status_im2/contexts/onboarding/common/carousel/view.cljs
@@ -50,15 +50,18 @@
        :progress-bar-width progress-bar-width}]]))
 
 (defn f-view
-  [{:keys [animate? progress paused? header-text background header-background swipeable?]}]
+  [{:keys [animate? progress paused? header-text background header-background gesture]}]
   (let [window-width       (rf/sub [:dimensions/window-width])
         status-bar-height  (:status-bar-height @navigation/constants)
         progress-bar-width (- window-width 40)
         carousel-left      (animation/carousel-left-position window-width animate? progress)
-        container-view     (if animate? reanimated/view rn/view)]
+        container-view     (if animate? reanimated/view rn/view)
+        identified-gesture (case gesture
+                             :swipeable (animation/drag-gesture progress paused?)
+                             :tappable  (animation/tap-gesture progress paused?)
+                             nil)]
     [:<>
-     [gesture/gesture-detector
-      {:gesture (when swipeable? (animation/drag-gesture progress paused?))}
+     [gesture/gesture-detector {:gesture identified-gesture}
       [container-view {:style (style/carousel-container carousel-left animate?)}
        (for [index (range 2)]
          ^{:key index}
@@ -68,7 +71,7 @@
            :index             index
            :header-text       header-text
            :header-background header-background}
-          (when background background)])]]
+          background])]]
      [rn/view
       {:style (style/progress-bar-container
                progress-bar-width

--- a/src/status_im2/contexts/onboarding/identifiers/view.cljs
+++ b/src/status_im2/contexts/onboarding/identifiers/view.cljs
@@ -41,7 +41,7 @@
        {:animate?    true
         :progress    progress
         :paused?     paused?
-        :swipeable?  false
+        :gesture     :tappable
         :header-text header-text}]
       [rn/view {:style style/content-container}
        [quo/profile-card


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes #16322

### Summary

[comment]: # (Summarise the problem and how the pull request solves it)

Adds a tap gesture for the carousel and uses it in the identifiers onboarding screen:
 https://www.figma.com/file/o4qG1bnFyuyFOvHQVGgeFY/Onboarding-for-Mobile?type=design&node-id=2926-331925&t=fnJhl0L7L7X8JCNe-4


### Review notes

Refactored the code a little

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open Status
- Create a new profile
- Navigate to identifiers screen
- Tap on the text to show the following slide

status: ready <!-- Can be ready or wip -->
