### PR TITLE
fix: close keyboard when start scrolling on chat

### DIFF
--- a/src/status_im2/contexts/chat/messages/list/view.cljs
+++ b/src/status_im2/contexts/chat/messages/list/view.cljs
@@ -291,7 +291,8 @@
        :content-container-style      {:padding-bottom style/messages-list-bottom-offset}
        :scroll-indicator-insets      {:top (- composer.constants/composer-default-height 16)}
        :keyboard-dismiss-mode        :interactive
-       :keyboard-should-persist-taps :handled
+       :keyboard-should-persist-taps :always
+       :on-scroll-begin-drag         rn/dismiss-keyboard!
        :on-momentum-scroll-begin     state/start-scrolling
        :on-momentum-scroll-end       state/stop-scrolling
        :scroll-event-throttle        16


### PR DESCRIPTION
fixes #16328 

### Summary

Close keyboard when user start scrolling

#### Results

https://github.com/status-im/status-mobile/assets/18485527/b0696a02-3985-4f65-8171-d6767e6b0239

#### Platforms

- Android
- iOS

##### Functional

- 1-1 chats
- public chats
- group chats

### Steps to test

- Open Status
- Open a chat
- Tap on text input on composer to make keyboard show up
- Scroll on chat
- Verify keyboard dismisses correctly

status: ready