### PR TITLE
Fix Profile URLs not opening universal link on new accounts

### DIFF
--- a/src/status_im/utils/universal_links/core.cljs
+++ b/src/status_im/utils/universal_links/core.cljs
@@ -13,8 +13,7 @@
             [status-im.wallet.choose-recipient.core :as choose-recipient]
             [status-im2.navigation.events :as navigation]
             [taoensso.timbre :as log]
-            [native-module.core :as native-module]
-            [react-native.platform :as platform]))
+            [native-module.core :as native-module]))
 
 ;; TODO(yenda) investigate why `handle-universal-link` event is
 ;; dispatched 7 times for the same link
@@ -175,15 +174,10 @@
 
 (rf/defn handle-url
   "Store url in the database if the user is not logged in, to be processed
-  on login, otherwise just handle it. On Android platform the app-state value
-  in db is `background` immediately after account creation, hence we avoid the
-  app-state check for android platforms to fix this e2e blocker :
-  https://github.com/status-im/status-mobile/issues/15859
-  "
+  on login, otherwise just handle it."
   {:events [:universal-links/handle-url]}
   [{:keys [db] :as cofx} url]
-  (if (and (multiaccounts.model/logged-in? db)
-           (or platform/android? (= (:app-state db) "active")))
+  (if (multiaccounts.model/logged-in? db)
     (route-url cofx url)
     (store-url-for-later cofx url)))
 


### PR DESCRIPTION
Fixes : #15991

### Summary 

So far my investigation has concluded that `:app-state` key in `re-frame` db is set to `background` and should be `active` when the user logs out from one profile and creates a new account.

This issue was only reproducible on `iOS` because on `android` we skipped this check.

This PR gets rid of the app-state check which is buggy on both platforms `android` and `iOS`.
The app-state becomes `active` after the universal link code has executed always resulting in the redirect not happening.

status: ready


