### PR TITLE
nix: use builtins to not depend on channels

### DIFF
--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -3,20 +3,13 @@
 { config ? { } }:
 
 let
-  inherit (import <nixpkgs> { }) fetchFromGitHub;
-
   # For testing local version of nixpkgs
   #nixpkgsSrc = (import <nixpkgs> { }).lib.cleanSource "/home/jakubgs/work/nixpkgs";
 
   # We follow the master branch of official nixpkgs.
-  nixpkgsSrc = fetchFromGitHub {
-    name = "nixpkgs-source";
-    owner = "NixOS";
-    repo = "nixpkgs";
-    rev = "e7603eba51f2c7820c0a182c6bbb351181caa8e7";
-    sha256 = "sha256-XJZ/o17eOd2sEsGif+/MQBnfa2DKmndWgJyc7CWajFc=";
-    # To get the compressed Nix sha256, use:
-    # nix-prefetch-url --unpack https://github.com/${ORG}/nixpkgs/archive/${REV}.tar.gz
+  nixpkgsSrc = builtins.fetchTarball {
+    url = "https://github.com/NixOS/nixpkgs/archive/e7603eba51f2c7820c0a182c6bbb351181caa8e7.tar.gz";
+    sha256 = "sha256:0mwck8jyr74wh1b7g6nac1mxy6a0rkppz8n12andsffybsipz5jw";
   };
 
   # Status specific configuration defaults


### PR DESCRIPTION
We use `builtins.fetchTarball` to avoid having to import `nixpkgs` from existing channels, which breaks if there are no channels.

Otherwise new Nix 2.14 version can result in:
```
error: file 'nixpkgs' was not found in the Nix search path (add it using $NIX_PATH or -I)
```
Which happens due to no default `nixpkgs` channel existing:
```
 > nix-channel --list

```
The manual fix for this is just adding a channel:
```
nix-channel --add https://nixos.org/channels/nixpkgs-unstable nixpkgs
nix-channel --update
```
But this is a better fix.

Resolves: https://github.com/status-im/status-mobile/issues/16342