### PR TITLE
nix: fix cache usage due to untrusted user

### DIFF
--- a/nix/scripts/lib.sh
+++ b/nix/scripts/lib.sh
@@ -52,3 +52,18 @@ nix_root() {
 nix_current_version() {
     nix-env --version | awk '{print $3}'
 }
+
+nix_daemon_restart() {
+    if [[ "$(uname -s)" == "Darwin" ]]; then
+        echo "Restarting Nix daemon Launchd service" >&2
+        sudo launchctl unload /Library/LaunchDaemons/org.nixos.nix-daemon.plist
+        sudo launchctl load   /Library/LaunchDaemons/org.nixos.nix-daemon.plist
+    elif [[ "$(uname -s)" == "Linux" ]] && [[ "$(nix_install_type)" == "multi" ]]; then
+        echo "Restarting Nix daemon Systemd service" >&2
+        sudo systemctl daemon-reload
+        sudo systemctl restart nix-daemon
+    else
+        echo "Unknown platform! Unable to restart daemon!" >&2
+        exit 1
+    fi
+}

--- a/nix/scripts/setup.sh
+++ b/nix/scripts/setup.sh
@@ -38,6 +38,22 @@ nix_install() {
         echo "Please see: https://nixos.org/nix/manual/#chap-installation" >&2
         exit 1
     fi
+
+    # Additional fixes
+    nix_make_user_trusted
+    nix_daemon_restart
+}
+
+# Fix for warnings about ignoring binary cache.
+nix_make_user_trusted() {
+    # Single-user installations do not have this issue.
+    [[ ! -f /etc/nix/nix.conf ]] && return
+    echo -e "Adding ${USER} to trusted-users..." >&2
+    if grep trusted-users /etc/nix/nix.conf 2>/dev/null; then
+        sed -i "s/trusted-users = \(.*\)$/trusted-users = \1 $USER/" /etc/nix/nix.conf
+    else
+        echo "trusted-users = $USER" | sudo tee -a /etc/nix/nix.conf >/dev/null
+    fi
 }
 
 if [[ ! -x "$(command -v sha256sum)" ]]; then

--- a/nix/scripts/upgrade.sh
+++ b/nix/scripts/upgrade.sh
@@ -5,6 +5,7 @@ set -eo pipefail
 
 GIT_ROOT=$(cd "${BASH_SOURCE%/*}" && git rev-parse --show-toplevel)
 source "${GIT_ROOT}/scripts/colors.sh"
+source "${GIT_ROOT}/nix/scripts/lib.sh"
 source "${GIT_ROOT}/nix/scripts/source.sh"
 source "${GIT_ROOT}/nix/scripts/version.sh"
 
@@ -12,15 +13,7 @@ nix_upgrade() {
     echo -e "Upgrading Nix interpreter to: ${GRN}${NIX_VERSION}${RST}" >&2
     nix-channel --update
     nix-env --install --attr "nixpkgs.${NIX_PACKAGE}" "nixpkgs.cacert"
-    if [[ "$(uname -s)" == "Darwin" ]]; then
-        echo "Restarting Nix daemon Launchd service" >&2
-        launchctl unload /Library/LaunchDaemons/org.nixos.nix-daemon.plist
-        launchctl load   /Library/LaunchDaemons/org.nixos.nix-daemon.plist
-    elif [[ "$(uname -s)" == "Linux" ]] && [[ "$(nix_install_type)" == "multi" ]]; then
-        echo "Restarting Nix daemon Systemd service" >&2
-        systemctl daemon-reload
-        systemctl restart nix-daemon
-    fi
+    nix_daemon_restart
 }
 
 # Allow for sourcing the script


### PR DESCRIPTION
Otherwise Nix produces warnings like this:
```
warning: ignoring untrusted substituter 'https://nix-cache.status.im/', you are not a trusted user.
```
As pointed out by @ilmotta this does indeed grant user extra permissions similar to `root`:

>Adding a user to trusted-users is essentially equivalent to giving that user root access to the system.
> — https://nixos.org/manual/nix/stable/command-ref/conf-file.html#conf-trusted-users

But considering the developer already has `root` access via `sudo` this is hardly that much of a difference.

Currently this will only affect MacOS as this is the only platform that uses the multi-user Nix installation by default.

__NODE:__ This PR includes changes from #16347 and waits for that to be rebased.