### PR TITLE
chore: small refactor to remove some uses of status-im in status-im2

### DIFF
--- a/src/status_im/chat/models/input.cljs
+++ b/src/status_im/chat/models/input.cljs
@@ -11,17 +11,18 @@
             [status-im2.contexts.chat.composer.link-preview.events :as link-preview]
             [taoensso.timbre :as log]
             [utils.i18n :as i18n]
-            [utils.re-frame :as rf]))
+            [utils.re-frame :as rf]
+            [utils.string :as utils.string]))
 
 (defn text->emoji
   "Replaces emojis in a specified `text`"
   [text]
-  (utils/safe-replace text
-                      #":([a-z_\-+0-9]*):"
-                      (fn [[original emoji-id]]
-                        (if-let [emoji-map (object/get (.-lib emojis) emoji-id)]
-                          (.-char ^js emoji-map)
-                          original))))
+  (utils.string/safe-replace text
+                             #":([a-z_\-+0-9]*):"
+                             (fn [[original emoji-id]]
+                               (if-let [emoji-map (object/get (.-lib emojis) emoji-id)]
+                                 (.-char ^js emoji-map)
+                                 original))))
 
 ;; effects
 (re-frame/reg-fx
@@ -169,7 +170,7 @@
             {:chat-id      chat-id
              :album-id     album-id
              :content-type constants/content-type-image
-             :image-path   (utils/safe-replace resized-uri #"file://" "")
+             :image-path   (utils.string/safe-replace resized-uri #"file://" "")
              :image-width  width
              :image-height height
              :text         input-text

--- a/src/status_im/ui/screens/wallet/recipient/views.cljs
+++ b/src/status_im/ui/screens/wallet/recipient/views.cljs
@@ -16,7 +16,8 @@
             [status-im.ui.components.topbar :as topbar]
             [status-im.ui.screens.wallet.components.views :as components]
             [status-im.utils.utils :as utils]
-            [utils.debounce :as debounce])
+            [utils.debounce :as debounce]
+            [utils.string :as utils.string])
   (:require-macros [status-im.utils.views :as views]))
 
 (defn- recipient-topbar
@@ -304,7 +305,7 @@
                                      (re-frame/dispatch [:set-in [:wallet/recipient :searching]
                                                          :searching])
                                      (debounce/debounce-and-dispatch [:wallet.recipient/address-changed
-                                                                      (utils/safe-trim %)]
+                                                                      (utils.string/safe-trim %)]
                                                                      600))
              :accessibility-label :recipient-address-input}]]
           [react/view {:align-items :center :height 30 :padding-bottom 8}

--- a/src/status_im/utils/utils.cljs
+++ b/src/status_im/utils/utils.cljs
@@ -116,16 +116,6 @@
       (gstring/format (str "%." places "f") amount)
       (or (str amount) 0))))
 
-(defn safe-trim
-  [s]
-  (when (string? s)
-    (string/trim s)))
-
-(defn safe-replace
-  [s m r]
-  (when (string? s)
-    (string/replace s m r)))
-
 (defn safe-nth
   [coll index]
   (when (number? index)

--- a/src/status_im/wallet/recipient/core.cljs
+++ b/src/status_im/wallet/recipient/core.cljs
@@ -11,7 +11,8 @@
             [status-im.utils.random :as random]
             [status-im.utils.utils :as utils]
             [status-im2.common.json-rpc.events :as json-rpc]
-            [status-im2.navigation.events :as navigation]))
+            [status-im2.navigation.events :as navigation]
+            [utils.string :as utils.string]))
 
 ;;NOTE we want to handle only last resolve
 (def resolve-last-id (atom nil))
@@ -37,7 +38,7 @@
   [{:keys [db] :as cofx} raw-recipient id]
   (when (or (not id) (= id @resolve-last-id))
     (reset! resolve-last-id nil)
-    (let [recipient (utils/safe-trim raw-recipient)]
+    (let [recipient (utils.string/safe-trim raw-recipient)]
       (cond
         (ethereum/address? recipient)
         (let [checksum (eip55/address->checksum recipient)]

--- a/src/status_im2/contexts/add_new_contact/events.cljs
+++ b/src/status_im2/contexts/add_new_contact/events.cljs
@@ -10,8 +10,8 @@
             [status-im2.navigation.events :as navigation]
             [utils.validators :as validators]
             [status-im2.contexts.contacts.events :as data-store.contacts]
-            [status-im.utils.utils :as utils]
-            [status-im2.constants :as constants]))
+            [status-im2.constants :as constants]
+            [utils.string :as utils.string]))
 
 (defn init-contact
   "Create a new contact (persisted to app-db as [:contacts/new-identity]).
@@ -37,7 +37,7 @@
 
 (defn ->id
   [{:keys [input] :as contact}]
-  (let [trimmed-input (utils/safe-trim input)]
+  (let [trimmed-input (utils.string/safe-trim input)]
     (->> {:id (if (empty? trimmed-input)
                 nil
                 (if-some [[_ id] (re-matches url-regex trimmed-input)]

--- a/src/utils/string.cljs
+++ b/src/utils/string.cljs
@@ -1,4 +1,5 @@
-(ns utils.string)
+(ns utils.string
+  (:require [clojure.string :as string]))
 
 (defn truncate-str-memo
   "Given string and max threshold, trims the string to threshold length with `...`
@@ -38,3 +39,13 @@
 (defn at-least-n-chars?
   [s n]
   (>= (count s) n))
+
+(defn safe-trim
+  [s]
+  (when (string? s)
+    (string/trim s)))
+
+(defn safe-replace
+  [s m r]
+  (when (string? s)
+    (string/replace s m r)))


### PR DESCRIPTION
This pr includes a few small changes to remove the use of status_im requires within status-im2 namespace.

There are three small changes:
moved safe-trim and safe replace from `src/status_im/utils/utils.cljs`  to utils at `src/utils/string.cljs`

updated use of background-timer in toasts to use same feature from `react-native.background-timer` 
- also a small minor refactor that just names the functions/variables.

moved `replace-port` function in `src/status_im/utils/http.cljs` to `src/status_im2/contexts/chat/utils/core.cljs` as this function is only used in the context of chat

To test:
This adds no new functionality as it's just moving code around. But some good places to check are in chat / sending images.
Toasts and also wallet with views related to reciepients 👍 