### PR TITLE
fix `make test` on macOS

### DIFF
--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -10,21 +10,26 @@ let
 in mkShell {
   name = "status-mobile-shell"; # for identifying all shells
 
-  buildInputs = with pkgs; lib.unique ([
-    # core utilities that should always be present in a shell
-    bash curl wget file unzip flock procps
-    git gnumake jq ncurses gnugrep parallel
-    lsof # used in start-react-native.sh
-    # build specific utilities
-    clojure maven watchman
-    # lint specific utilities
-    clj-kondo zprint
-    # other nice to have stuff
-    yarn nodejs python310
-  ] # and some special cases
-    ++ lib.optionals stdenv.isDarwin [ cocoapods clang tcl ]
-    ++ lib.optionals (!stdenv.isDarwin) [ gcc8 ]
-  );
+  buildInputs = let
+    appleSDKFrameworks = (with pkgs.darwin.apple_sdk.frameworks; [
+      IOKit CoreServices
+    ]);
+  in
+    with pkgs; lib.unique ([
+      # core utilities that should always be present in a shell
+      bash curl wget file unzip flock procps
+      git gnumake jq ncurses gnugrep parallel
+      lsof # used in start-react-native.sh
+      # build specific utilities
+      clojure maven watchman
+      # lint specific utilities
+      clj-kondo zprint
+      # other nice to have stuff
+      yarn nodejs python310
+    ] # and some special cases
+      ++ lib.optionals   stdenv.isDarwin ([ cocoapods clang tcl ] ++ appleSDKFrameworks)
+      ++ lib.optionals (!stdenv.isDarwin) [ gcc8 ]
+    );
 
   # avoid terminal issues
   TERM="xterm";


### PR DESCRIPTION
Fixes following error:
```
ld: framework not found IOKit
clang-11: error: linker command failed with exit code 1 (use -v to see invocation)
make[1]: *** [status_nodejs_addon.target.mk:175: Release/status_nodejs_addon.node] Error 1
```
The `make test` target started to fail on macOS after #14944.

This PR adds 2 Apple SDK frameworks to default shell: `IOKit` and `CoreServices`

The other 2 mentioned in:
https://github.com/status-im/status-mobile/blob/d300e880627c1333c1258c6ab27c1d259143f727/binding.gyp#L18-L25
are not added, but build is ok.

Resolves: https://github.com/status-im/status-mobile/issues/16356