### PR TITLE
nix: fix cache usage by modifying global config

### DIFF
--- a/nix/scripts/lib.sh
+++ b/nix/scripts/lib.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+set -eo pipefail
+GIT_ROOT=$(cd "${BASH_SOURCE%/*}" && git rev-parse --show-toplevel)
 
 # Checking group ownership to identify installation type.
 file_group() {
@@ -51,4 +53,38 @@ nix_root() {
 
 nix_current_version() {
     nix-env --version | awk '{print $3}'
+}
+
+nix_get_local_setting() {
+    local NIX_LOCAL_CONFIG="${GIT_ROOT}/nix/nix.conf"
+    local KEY="${1}"
+    awk -F' = ' "/^${KEY} *=/{print \$2}" nix/nix.conf
+}
+
+nix_set_global_setting() {
+    local NIX_GLOBAL_CONFIG="/etc/nix/nix.conf"
+    local KEY="${1}"
+    local VAL="${2}"
+    if grep "${KEY}" "${NIX_GLOBAL_CONFIG}" 2>/dev/null; then
+        sed -i "s/${KEY} = \(.*\)$/${KEY} = ${VAL}/" "${NIX_GLOBAL_CONFIG}"
+    else
+        echo "${KEY} = ${VAL}" | sudo tee -a "${NIX_GLOBAL_CONFIG}" >/dev/null
+    fi
+}
+
+nix_daemon_restart() {
+    # Restarting Nix Daemon makes sense only on a multi-user install.
+    [[ $(nix_install_type) != "multi" ]] && return
+    if [[ "$(uname -s)" == "Darwin" ]]; then
+        echo "Restarting Nix daemon Launchd service..." >&2
+        sudo launchctl unload /Library/LaunchDaemons/org.nixos.nix-daemon.plist
+        sudo launchctl load   /Library/LaunchDaemons/org.nixos.nix-daemon.plist
+    elif [[ "$(uname -s)" == "Linux" ]] && [[ "$(nix_install_type)" == "multi" ]]; then
+        echo "Restarting Nix daemon Systemd service..." >&2
+        sudo systemctl daemon-reload
+        sudo systemctl restart nix-daemon
+    else
+        echo "Unknown platform! Unable to restart daemon!" >&2
+        exit 1
+    fi
 }

--- a/nix/scripts/upgrade.sh
+++ b/nix/scripts/upgrade.sh
@@ -5,6 +5,7 @@ set -eo pipefail
 
 GIT_ROOT=$(cd "${BASH_SOURCE%/*}" && git rev-parse --show-toplevel)
 source "${GIT_ROOT}/scripts/colors.sh"
+source "${GIT_ROOT}/nix/scripts/lib.sh"
 source "${GIT_ROOT}/nix/scripts/source.sh"
 source "${GIT_ROOT}/nix/scripts/version.sh"
 
@@ -12,15 +13,7 @@ nix_upgrade() {
     echo -e "Upgrading Nix interpreter to: ${GRN}${NIX_VERSION}${RST}" >&2
     nix-channel --update
     nix-env --install --attr "nixpkgs.${NIX_PACKAGE}" "nixpkgs.cacert"
-    if [[ "$(uname -s)" == "Darwin" ]]; then
-        echo "Restarting Nix daemon Launchd service" >&2
-        launchctl unload /Library/LaunchDaemons/org.nixos.nix-daemon.plist
-        launchctl load   /Library/LaunchDaemons/org.nixos.nix-daemon.plist
-    elif [[ "$(uname -s)" == "Linux" ]] && [[ "$(nix_install_type)" == "multi" ]]; then
-        echo "Restarting Nix daemon Systemd service" >&2
-        systemctl daemon-reload
-        systemctl restart nix-daemon
-    fi
+    nix_daemon_restart
 }
 
 # Allow for sourcing the script


### PR DESCRIPTION
Otherwise Nix produces warnings like this:
```
warning: ignoring untrusted substituter 'https://nix-cache.status.im/', you are not a trusted user.
```
Since adding users to `trusted-users` essentially gives them `root`:

>Adding a user to trusted-users is essentially equivalent to giving that user root access to the system.
> — https://nixos.org/manual/nix/stable/command-ref/conf-file.html#conf-trusted-users

A more kosher approach might be to just add the cache config itself globally.

Result:
```
jakubgs@ubuntuvm:~/status-mobile % cat /etc/nix/nix.conf 
build-users-group = nixbld
substituters = https://nix-cache.status.im/ https://cache.nixos.org/
trusted-substituters = https://nix-cache.status.im/ https://cache.nixos.org/
trusted-public-keys = nix-cache.status.im-1:x/93lOfLU+duPplwMSBR+OlY4+mo+dCN7n0mr4oPwgY= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
```