### PR TITLE
Fixes for the Community Channel avatar component

### DIFF
--- a/src/quo2/components/avatars/channel_avatar/component_spec.cljs
+++ b/src/quo2/components/avatars/channel_avatar/component_spec.cljs
@@ -24,12 +24,12 @@
     (h/render [component/view {:locked? false}])
     (h/is-truthy (h/query-by-label-text :lock)))
 
-  (h/test "no emoji, 1 initial"
+  (h/test "no emoji, smaller size"
     (h/render [component/view {:full-name "Status Mobile"}])
     (h/is-truthy (h/query-by-text "S")))
 
-  (h/test "no emoji, 2 initials"
+  (h/test "no emoji, big size"
     (h/render [component/view
-               {:full-name       "Status Mobile"
-                :amount-initials 2}])
+               {:full-name "Status Mobile"
+                :big?      true}])
     (h/is-truthy (h/query-by-text "SM"))))

--- a/src/quo2/components/avatars/channel_avatar/component_spec.cljs
+++ b/src/quo2/components/avatars/channel_avatar/component_spec.cljs
@@ -1,0 +1,35 @@
+(ns quo2.components.avatars.channel-avatar.component-spec
+  (:require [quo2.components.avatars.channel-avatar.view :as component]
+            [test-helpers.component :as h]))
+
+(h/describe "Channel Avatar"
+  (h/test "default render"
+    (h/render [component/view])
+    (h/is-truthy (h/query-by-label-text :initials))
+    (h/is-null (h/query-by-label-text :emoji))
+    (h/is-null (h/query-by-label-text :lock)))
+
+  (h/test "with emoji, no lock set, big size"
+    (let [emoji "🍓"]
+      (h/render [component/view {:emoji emoji :big? true}])
+      (h/is-null (h/query-by-label-text :initials))
+      (h/is-truthy (h/query-by-text emoji))
+      (h/is-null (h/query-by-label-text :lock))))
+
+  (h/test "locked"
+    (h/render [component/view {:locked? true}])
+    (h/is-truthy (h/query-by-label-text :lock)))
+
+  (h/test "unlocked"
+    (h/render [component/view {:locked? false}])
+    (h/is-truthy (h/query-by-label-text :lock)))
+
+  (h/test "no emoji, 1 initial"
+    (h/render [component/view {:full-name "Status Mobile"}])
+    (h/is-truthy (h/query-by-text "S")))
+
+  (h/test "no emoji, 2 initials"
+    (h/render [component/view
+               {:full-name       "Status Mobile"
+                :amount-initials 2}])
+    (h/is-truthy (h/query-by-text "SM"))))

--- a/src/quo2/components/avatars/channel_avatar/component_spec.cljs
+++ b/src/quo2/components/avatars/channel_avatar/component_spec.cljs
@@ -9,9 +9,9 @@
     (h/is-null (h/query-by-label-text :emoji))
     (h/is-null (h/query-by-label-text :lock)))
 
-  (h/test "with emoji, no lock set, big size"
+  (h/test "with emoji, no lock set, large size"
     (let [emoji "🍓"]
-      (h/render [component/view {:emoji emoji :big? true}])
+      (h/render [component/view {:emoji emoji :size :size/l}])
       (h/is-null (h/query-by-label-text :initials))
       (h/is-truthy (h/query-by-text emoji))
       (h/is-null (h/query-by-label-text :lock))))
@@ -28,8 +28,8 @@
     (h/render [component/view {:full-name "Status Mobile"}])
     (h/is-truthy (h/query-by-text "S")))
 
-  (h/test "no emoji, big size"
+  (h/test "no emoji, large size"
     (h/render [component/view
                {:full-name "Status Mobile"
-                :big?      true}])
+                :size      :size/l}])
     (h/is-truthy (h/query-by-text "SM"))))

--- a/src/quo2/components/avatars/channel_avatar/style.cljs
+++ b/src/quo2/components/avatars/channel_avatar/style.cljs
@@ -14,7 +14,7 @@
      :background-color (colors/theme-alpha color 0.1 0.1)}))
 
 (defn lock-container
-  [{:keys [big?]}]
+  [big?]
   (let [distance (if big? 20 12)]
     {:position         :absolute
      :left             distance

--- a/src/quo2/components/avatars/channel_avatar/style.cljs
+++ b/src/quo2/components/avatars/channel_avatar/style.cljs
@@ -12,15 +12,11 @@
    :align-items      :center
    :background-color background-color})
 
-(def inner-container
-  {:justify-content :center
-   :align-items     :center})
-
 (defn lock-container
   [{:keys [big?]}]
   {:position         :absolute
-   :left             (if big? 14 8)
-   :top              (if big? 15 8)
+   :left             (if big? 20 12)
+   :top              (if big? 20 12)
    :background-color (colors/theme-colors colors/white colors/neutral-90)
    :border-radius    (* 2 lock-icon-size)
    :padding          2})

--- a/src/quo2/components/avatars/channel_avatar/style.cljs
+++ b/src/quo2/components/avatars/channel_avatar/style.cljs
@@ -1,0 +1,30 @@
+(ns quo2.components.avatars.channel-avatar.style
+  (:require [quo2.foundations.colors :as colors]))
+
+(def lock-icon-size 12)
+
+(defn outer-container
+  [{:keys [big? background-color]}]
+  {:width            (if big? 32 24)
+   :height           (if big? 32 24)
+   :border-radius    (if big? 32 24)
+   :justify-content  :center
+   :align-items      :center
+   :background-color background-color})
+
+(def inner-container
+  {:justify-content :center
+   :align-items     :center})
+
+(defn lock-container
+  [{:keys [big?]}]
+  {:position         :absolute
+   :left             (if big? 14 8)
+   :top              (if big? 15 8)
+   :background-color (colors/theme-colors colors/white colors/neutral-90)
+   :border-radius    (* 2 lock-icon-size)
+   :padding          2})
+
+(def lock-icon
+  {:width  lock-icon-size
+   :height lock-icon-size})

--- a/src/quo2/components/avatars/channel_avatar/style.cljs
+++ b/src/quo2/components/avatars/channel_avatar/style.cljs
@@ -4,13 +4,13 @@
 (def lock-icon-size 12)
 
 (defn outer-container
-  [{:keys [big? background-color]}]
+  [{:keys [big? color]}]
   {:width            (if big? 32 24)
    :height           (if big? 32 24)
    :border-radius    (if big? 32 24)
    :justify-content  :center
    :align-items      :center
-   :background-color background-color})
+   :background-color (colors/theme-alpha color 0.1 0.1)})
 
 (defn lock-container
   [{:keys [big?]}]

--- a/src/quo2/components/avatars/channel_avatar/style.cljs
+++ b/src/quo2/components/avatars/channel_avatar/style.cljs
@@ -19,7 +19,7 @@
     {:position         :absolute
      :left             distance
      :top              distance
-     :background-color (colors/theme-colors colors/white colors/neutral-90)
+     :background-color (colors/theme-colors colors/white colors/neutral-95)
      :border-radius    (* 2 lock-icon-size)
      :padding          2}))
 

--- a/src/quo2/components/avatars/channel_avatar/style.cljs
+++ b/src/quo2/components/avatars/channel_avatar/style.cljs
@@ -4,8 +4,8 @@
 (def lock-icon-size 12)
 
 (defn outer-container
-  [{:keys [big? color]}]
-  (let [size (if big? 32 24)]
+  [{:keys [size color]}]
+  (let [size (if (= size :size/l) 32 24)]
     {:width            size
      :height           size
      :border-radius    size
@@ -14,8 +14,8 @@
      :background-color (colors/theme-alpha color 0.1 0.1)}))
 
 (defn lock-container
-  [big?]
-  (let [distance (if big? 20 12)]
+  [size]
+  (let [distance (if (= size :size/l) 20 12)]
     {:position         :absolute
      :left             distance
      :top              distance

--- a/src/quo2/components/avatars/channel_avatar/style.cljs
+++ b/src/quo2/components/avatars/channel_avatar/style.cljs
@@ -5,21 +5,23 @@
 
 (defn outer-container
   [{:keys [big? color]}]
-  {:width            (if big? 32 24)
-   :height           (if big? 32 24)
-   :border-radius    (if big? 32 24)
-   :justify-content  :center
-   :align-items      :center
-   :background-color (colors/theme-alpha color 0.1 0.1)})
+  (let [size (if big? 32 24)]
+    {:width            size
+     :height           size
+     :border-radius    size
+     :justify-content  :center
+     :align-items      :center
+     :background-color (colors/theme-alpha color 0.1 0.1)}))
 
 (defn lock-container
   [{:keys [big?]}]
-  {:position         :absolute
-   :left             (if big? 20 12)
-   :top              (if big? 20 12)
-   :background-color (colors/theme-colors colors/white colors/neutral-90)
-   :border-radius    (* 2 lock-icon-size)
-   :padding          2})
+  (let [distance (if big? 20 12)]
+    {:position         :absolute
+     :left             distance
+     :top              distance
+     :background-color (colors/theme-colors colors/white colors/neutral-90)
+     :border-radius    (* 2 lock-icon-size)
+     :padding          2}))
 
 (def lock-icon
   {:width  lock-icon-size

--- a/src/quo2/components/avatars/channel_avatar/view.cljs
+++ b/src/quo2/components/avatars/channel_avatar/view.cljs
@@ -8,15 +8,14 @@
             utils.string))
 
 (defn- initials
-  [full-name amount-initials color]
-  [text/text
-   {:accessibility-label :initials
-    :size                :paragraph-2
-    :number-of-lines     1
-    :ellipsize-mode      :clip
-    :weight              :semi-bold
-    :style               {:color color}}
-   (utils.string/get-initials full-name amount-initials)])
+  [full-name big? color]
+  (let [amount-initials (if big? 2 1)]
+    [text/text
+     {:accessibility-label :initials
+      :size                :paragraph-2
+      :weight              :semi-bold
+      :style               {:color color}}
+     (utils.string/get-initials full-name amount-initials)]))
 
 (defn- lock
   [locked? big?]
@@ -45,19 +44,15 @@
 
   :full-name - string (default nil) - When :emoji is blank, this value will be
   used to extract the initials.
-
-  :amount-initials - int (default 1) - Number of initials to be extracted
-  from :full-name when :emoji is blank.
   "
-  [{:keys [big? emoji color locked? full-name amount-initials]}]
-  (let [amount-initials (or amount-initials 1)]
-    [rn/view
-     {:accessibility-label :channel-avatar
-      :style               (style/outer-container {:big? big? :color color})}
-     (if (string/blank? emoji)
-       [initials full-name amount-initials color]
-       [text/text
-        {:accessibility-label :emoji
-         :size                (if big? :paragraph-1 :label)}
-        emoji])
-     [lock locked? big?]]))
+  [{:keys [big? emoji color locked? full-name]}]
+  [rn/view
+   {:accessibility-label :channel-avatar
+    :style               (style/outer-container {:big? big? :color color})}
+   (if (string/blank? emoji)
+     [initials full-name big? color]
+     [text/text
+      {:accessibility-label :emoji
+       :size                (if big? :paragraph-1 :label)}
+      emoji])
+   [lock locked? big?]])

--- a/src/quo2/components/avatars/channel_avatar/view.cljs
+++ b/src/quo2/components/avatars/channel_avatar/view.cljs
@@ -1,9 +1,27 @@
 (ns quo2.components.avatars.channel-avatar.view
-  (:require [quo2.components.avatars.channel-avatar.style :as style]
+  (:require [clojure.string :as string]
+            [quo2.components.avatars.channel-avatar.style :as style]
             [quo2.components.icon :as icons]
-            [quo2.foundations.colors :as colors]
             [quo2.components.markdown.text :as text]
+            [quo2.foundations.colors :as colors]
             [react-native.core :as rn]))
+
+(defn- extract-initials
+  [s amount-initials]
+  (let [words (-> s string/trim (string/split #"\s+"))]
+    (->> words
+         (take amount-initials)
+         (map (comp string/upper-case str first))
+         (string/join))))
+
+(defn- initials
+  [full-name amount-initials]
+  [text/text
+   {:size            :paragraph-2
+    :number-of-lines 1
+    :ellipsize-mode  :clip
+    :weight          :semi-bold}
+   (extract-initials full-name amount-initials)])
 
 (defn- lock
   [{:keys [locked? big?]}]
@@ -17,9 +35,29 @@
        :size            12}]]))
 
 (defn view
-  [{:keys [big? locked? emoji-background-color emoji]}]
+  "Options:
+
+  :big? - bool (default nil) - Container size
+
+  :emoji - string (default nil)
+
+  :emoji-background-color - color (default nil)
+
+  :locked? - nil/bool (default nil) - When true/false display a locked/unlocked
+  icon respectively. When nil does not show icon.
+
+  :full-name - string (default nil) - When :emoji is blank, this value will be
+  used to extract the initials.
+
+  :amount-initials - int (default 1) - Number of initials to be extracted
+  from :full-name when :emoji is blank.
+  "
+  [{:keys [big? locked? emoji-background-color emoji full-name amount-initials]
+    :or   {amount-initials 1}}]
   [rn/view {:style (style/outer-container {:big? big? :background-color emoji-background-color})}
    [rn/view {:style style/inner-container}
-    [text/text {:size (if big? :paragraph-1 :label)}
-     emoji]
+    (if (string/blank? emoji)
+      [initials full-name amount-initials]
+      [text/text {:size (if big? :paragraph-1 :label)}
+       emoji])
     [lock {:locked? locked? :big? big?}]]])

--- a/src/quo2/components/avatars/channel_avatar/view.cljs
+++ b/src/quo2/components/avatars/channel_avatar/view.cljs
@@ -56,5 +56,5 @@
      [text/text
       {:accessibility-label :emoji
        :size                (if (= size :size/l) :paragraph-1 :label)}
-      emoji])
+      (string/trim emoji)])
    [lock locked? size]])

--- a/src/quo2/components/avatars/channel_avatar/view.cljs
+++ b/src/quo2/components/avatars/channel_avatar/view.cljs
@@ -4,29 +4,25 @@
             [quo2.components.icon :as icons]
             [quo2.components.markdown.text :as text]
             [quo2.foundations.colors :as colors]
-            [react-native.core :as rn]))
-
-(defn- extract-initials
-  [s amount-initials]
-  (let [words (-> s string/trim (string/split #"\s+"))]
-    (->> words
-         (take amount-initials)
-         (map (comp string/upper-case str first))
-         (string/join))))
+            [react-native.core :as rn]
+            utils.string))
 
 (defn- initials
   [full-name amount-initials]
   [text/text
-   {:size            :paragraph-2
-    :number-of-lines 1
-    :ellipsize-mode  :clip
-    :weight          :semi-bold}
-   (extract-initials full-name amount-initials)])
+   {:accessibility-label :initials
+    :size                :paragraph-2
+    :number-of-lines     1
+    :ellipsize-mode      :clip
+    :weight              :semi-bold}
+   (utils.string/get-initials full-name amount-initials)])
 
 (defn- lock
-  [{:keys [locked? big?]}]
+  [locked? big?]
   (when (boolean? locked?)
-    [rn/view {:style (style/lock-container {:big? big?})}
+    [rn/view
+     {:accessibility-label :lock
+      :style               (style/lock-container {:big? big?})}
      [icons/icon
       (cond (true? locked?)  :i/locked
             (false? locked?) :i/unlocked)
@@ -52,12 +48,16 @@
   :amount-initials - int (default 1) - Number of initials to be extracted
   from :full-name when :emoji is blank.
   "
-  [{:keys [big? locked? emoji-background-color emoji full-name amount-initials]
+  [{:keys [big? emoji emoji-background-color locked? full-name amount-initials]
     :or   {amount-initials 1}}]
-  [rn/view {:style (style/outer-container {:big? big? :background-color emoji-background-color})}
+  [rn/view
+   {:accessibility-label :channel-avatar
+    :style               (style/outer-container {:big? big? :background-color emoji-background-color})}
    [rn/view {:style style/inner-container}
     (if (string/blank? emoji)
       [initials full-name amount-initials]
-      [text/text {:size (if big? :paragraph-1 :label)}
+      [text/text
+       {:accessibility-label :emoji
+        :size                (if big? :paragraph-1 :label)}
        emoji])
-    [lock {:locked? locked? :big? big?}]]])
+    [lock locked? big?]]])

--- a/src/quo2/components/avatars/channel_avatar/view.cljs
+++ b/src/quo2/components/avatars/channel_avatar/view.cljs
@@ -20,13 +20,12 @@
 
 (defn- lock
   [locked? big?]
+  ;; When `locked?` is nil, we must not display the unlocked icon.
   (when (boolean? locked?)
     [rn/view
      {:accessibility-label :lock
       :style               (style/lock-container {:big? big?})}
-     [icons/icon
-      (cond (true? locked?)  :i/locked
-            (false? locked?) :i/unlocked)
+     [icons/icon (if locked? :i/locked :i/unlocked)
       {:color           (colors/theme-colors colors/neutral-50 colors/neutral-40)
        :container-style style/lock-icon
        :size            12}]]))
@@ -51,8 +50,7 @@
   from :full-name when :emoji is blank.
   "
   [{:keys [big? emoji color locked? full-name amount-initials]}]
-  (let [amount-initials (or amount-initials 1)
-        color           (or color (colors/custom-color-by-theme :blue 50 50))]
+  (let [amount-initials (or amount-initials 1)]
     [rn/view
      {:accessibility-label :channel-avatar
       :style               (style/outer-container {:big? big? :color color})}

--- a/src/quo2/components/avatars/channel_avatar/view.cljs
+++ b/src/quo2/components/avatars/channel_avatar/view.cljs
@@ -1,11 +1,11 @@
-(ns quo2.components.avatars.channel-avatar
+(ns quo2.components.avatars.channel-avatar.view
   (:require [quo2.components.icon :as icons]
             [quo2.components.markdown.text :as text]
             [quo2.foundations.colors :as colors]
             [quo2.theme :as theme]
             [react-native.core :as rn]))
 
-(defn channel-avatar
+(defn view
   [{:keys [big? locked? emoji-background-color emoji]}]
   (let [lock-exists? locked?
         dark?        (theme/dark?)]

--- a/src/quo2/components/avatars/channel_avatar/view.cljs
+++ b/src/quo2/components/avatars/channel_avatar/view.cljs
@@ -36,8 +36,9 @@
 
   :emoji - string (default nil)
 
-  :color - color (default nil) If the component is used for a community channel,
-  then the default color should be the community custom color.
+  :customization-color - color (default nil) If the component is used for a
+  community channel, then the default color should be the community custom
+  color.
 
   :locked? - nil/bool (default nil) - When true/false display a locked/unlocked
   icon respectively. When nil does not show icon.
@@ -45,12 +46,12 @@
   :full-name - string (default nil) - When :emoji is blank, this value will be
   used to extract the initials.
   "
-  [{:keys [big? emoji color locked? full-name]}]
+  [{:keys [big? emoji customization-color locked? full-name]}]
   [rn/view
    {:accessibility-label :channel-avatar
-    :style               (style/outer-container {:big? big? :color color})}
+    :style               (style/outer-container {:big? big? :color customization-color})}
    (if (string/blank? emoji)
-     [initials full-name big? color]
+     [initials full-name big? customization-color]
      [text/text
       {:accessibility-label :emoji
        :size                (if big? :paragraph-1 :label)}

--- a/src/quo2/components/avatars/channel_avatar/view.cljs
+++ b/src/quo2/components/avatars/channel_avatar/view.cljs
@@ -1,50 +1,25 @@
 (ns quo2.components.avatars.channel-avatar.view
-  (:require [quo2.components.icon :as icons]
-            [quo2.components.markdown.text :as text]
+  (:require [quo2.components.avatars.channel-avatar.style :as style]
+            [quo2.components.icon :as icons]
             [quo2.foundations.colors :as colors]
-            [quo2.theme :as theme]
+            [quo2.components.markdown.text :as text]
             [react-native.core :as rn]))
+
+(defn- lock
+  [{:keys [locked? big?]}]
+  (when (boolean? locked?)
+    [rn/view {:style (style/lock-container {:big? big?})}
+     [icons/icon
+      (cond (true? locked?)  :i/locked
+            (false? locked?) :i/unlocked)
+      {:color           (colors/theme-colors colors/neutral-50 colors/neutral-40)
+       :container-style style/lock-icon
+       :size            12}]]))
 
 (defn view
   [{:keys [big? locked? emoji-background-color emoji]}]
-  (let [lock-exists? locked?
-        dark?        (theme/dark?)]
-    [rn/view
-     {:style {:width            (if big? 32 24)
-              :height           (if big? 32 24)
-              :border-radius    (if big? 32 24)
-              :justify-content  :center
-              :align-items      :center
-              :background-color emoji-background-color}}
-     [rn/view
-      {:style {:display         :flex
-               :justify-content :center
-               :align-items     :center}}
-      [text/text
-       {:size (if big?
-                :paragraph-1
-                :label)} emoji]
-      (when lock-exists?
-        [rn/view
-         {:style {:position         :absolute
-                  :left             (if big?
-                                      14
-                                      8)
-                  :top              (if big?
-                                      15
-                                      8)
-                  :background-color (if dark?
-                                      colors/neutral-90
-                                      colors/white)
-                  :border-radius    15
-                  :padding          2}}
-         [icons/icon
-          (if locked?
-            :main-icons/locked
-            :main-icons/unlocked)
-          {:color           (if dark?
-                              colors/neutral-40
-                              colors/neutral-50)
-           :container-style {:width  12
-                             :height 12}
-           :size            12}]])]]))
+  [rn/view {:style (style/outer-container {:big? big? :background-color emoji-background-color})}
+   [rn/view {:style style/inner-container}
+    [text/text {:size (if big? :paragraph-1 :label)}
+     emoji]
+    [lock {:locked? locked? :big? big?}]]])

--- a/src/quo2/components/avatars/channel_avatar/view.cljs
+++ b/src/quo2/components/avatars/channel_avatar/view.cljs
@@ -8,8 +8,8 @@
             utils.string))
 
 (defn- initials
-  [full-name big? color]
-  (let [amount-initials (if big? 2 1)]
+  [full-name size color]
+  (let [amount-initials (if (= size :size/l) 2 1)]
     [text/text
      {:accessibility-label :initials
       :size                :paragraph-2
@@ -18,12 +18,12 @@
      (utils.string/get-initials full-name amount-initials)]))
 
 (defn- lock
-  [locked? big?]
+  [locked? size]
   ;; When `locked?` is nil, we must not display the unlocked icon.
   (when (boolean? locked?)
     [rn/view
      {:accessibility-label :lock
-      :style               (style/lock-container big?)}
+      :style               (style/lock-container size)}
      [icons/icon (if locked? :i/locked :i/unlocked)
       {:color           (colors/theme-colors colors/neutral-50 colors/neutral-40)
        :container-style style/lock-icon
@@ -32,7 +32,8 @@
 (defn view
   "Options:
 
-  :big? - bool (default nil) - Container size
+  :size - keyword (default nil) - Container size, for the moment,
+  only :size/l (meaning large) is supported.
 
   :emoji - string (default nil)
 
@@ -46,14 +47,14 @@
   :full-name - string (default nil) - When :emoji is blank, this value will be
   used to extract the initials.
   "
-  [{:keys [big? emoji customization-color locked? full-name]}]
+  [{:keys [size emoji customization-color locked? full-name]}]
   [rn/view
    {:accessibility-label :channel-avatar
-    :style               (style/outer-container {:big? big? :color customization-color})}
+    :style               (style/outer-container {:size size :color customization-color})}
    (if (string/blank? emoji)
-     [initials full-name big? customization-color]
+     [initials full-name size customization-color]
      [text/text
       {:accessibility-label :emoji
-       :size                (if big? :paragraph-1 :label)}
+       :size                (if (= size :size/l) :paragraph-1 :label)}
       emoji])
-   [lock locked? big?]])
+   [lock locked? size]])

--- a/src/quo2/components/avatars/channel_avatar/view.cljs
+++ b/src/quo2/components/avatars/channel_avatar/view.cljs
@@ -23,7 +23,7 @@
   (when (boolean? locked?)
     [rn/view
      {:accessibility-label :lock
-      :style               (style/lock-container {:big? big?})}
+      :style               (style/lock-container big?)}
      [icons/icon (if locked? :i/locked :i/unlocked)
       {:color           (colors/theme-colors colors/neutral-50 colors/neutral-40)
        :container-style style/lock-icon

--- a/src/quo2/components/avatars/channel_avatar/view.cljs
+++ b/src/quo2/components/avatars/channel_avatar/view.cljs
@@ -53,11 +53,10 @@
   [rn/view
    {:accessibility-label :channel-avatar
     :style               (style/outer-container {:big? big? :background-color emoji-background-color})}
-   [rn/view {:style style/inner-container}
-    (if (string/blank? emoji)
-      [initials full-name amount-initials]
-      [text/text
-       {:accessibility-label :emoji
-        :size                (if big? :paragraph-1 :label)}
-       emoji])
-    [lock locked? big?]]])
+   (if (string/blank? emoji)
+     [initials full-name amount-initials]
+     [text/text
+      {:accessibility-label :emoji
+       :size                (if big? :paragraph-1 :label)}
+      emoji])
+   [lock locked? big?]])

--- a/src/quo2/components/avatars/channel_avatar/view.cljs
+++ b/src/quo2/components/avatars/channel_avatar/view.cljs
@@ -8,13 +8,14 @@
             utils.string))
 
 (defn- initials
-  [full-name amount-initials]
+  [full-name amount-initials color]
   [text/text
    {:accessibility-label :initials
     :size                :paragraph-2
     :number-of-lines     1
     :ellipsize-mode      :clip
-    :weight              :semi-bold}
+    :weight              :semi-bold
+    :style               {:color color}}
    (utils.string/get-initials full-name amount-initials)])
 
 (defn- lock
@@ -37,7 +38,8 @@
 
   :emoji - string (default nil)
 
-  :emoji-background-color - color (default nil)
+  :color - color (default nil) If the component is used for a community channel,
+  then the default color should be the community custom color.
 
   :locked? - nil/bool (default nil) - When true/false display a locked/unlocked
   icon respectively. When nil does not show icon.
@@ -48,15 +50,16 @@
   :amount-initials - int (default 1) - Number of initials to be extracted
   from :full-name when :emoji is blank.
   "
-  [{:keys [big? emoji emoji-background-color locked? full-name amount-initials]
-    :or   {amount-initials 1}}]
-  [rn/view
-   {:accessibility-label :channel-avatar
-    :style               (style/outer-container {:big? big? :background-color emoji-background-color})}
-   (if (string/blank? emoji)
-     [initials full-name amount-initials]
-     [text/text
-      {:accessibility-label :emoji
-       :size                (if big? :paragraph-1 :label)}
-      emoji])
-   [lock locked? big?]])
+  [{:keys [big? emoji color locked? full-name amount-initials]}]
+  (let [amount-initials (or amount-initials 1)
+        color           (or color (colors/custom-color-by-theme :blue 50 50))]
+    [rn/view
+     {:accessibility-label :channel-avatar
+      :style               (style/outer-container {:big? big? :color color})}
+     (if (string/blank? emoji)
+       [initials full-name amount-initials color]
+       [text/text
+        {:accessibility-label :emoji
+         :size                (if big? :paragraph-1 :label)}
+        emoji])
+     [lock locked? big?]]))

--- a/src/quo2/components/avatars/user_avatar/view.cljs
+++ b/src/quo2/components/avatars/user_avatar/view.cljs
@@ -1,22 +1,9 @@
 (ns quo2.components.avatars.user-avatar.view
-  (:require [clojure.string :as string]
-            [quo2.components.avatars.user-avatar.style :as style]
+  (:require [quo2.components.avatars.user-avatar.style :as style]
             [quo2.components.markdown.text :as text]
             [react-native.core :as rn]
-            [react-native.fast-image :as fast-image]))
-
-(defn trim-whitespace [s] (string/join " " (string/split (string/trim s) #"\s+")))
-
-(defn- extract-initials
-  [full-name amount-initials]
-  (let [upper-case-first-letter (comp string/upper-case first)
-        names-list              (string/split (trim-whitespace full-name) " ")]
-    (if (= (first names-list) "")
-      ""
-      (->> names-list
-           (map upper-case-first-letter)
-           (take amount-initials)
-           (string/join)))))
+            [react-native.fast-image :as fast-image]
+            utils.string))
 
 (defn initials-avatar
   [{:keys [full-name size draw-ring? customization-color]}]
@@ -29,7 +16,7 @@
       {:style  style/initials-avatar-text
        :size   font-size
        :weight :semi-bold}
-      (extract-initials full-name amount-initials)]]))
+      (utils.string/get-initials full-name amount-initials)]]))
 
 (def valid-ring-sizes #{:big :medium :small})
 

--- a/src/quo2/components/list_items/channel.cljs
+++ b/src/quo2/components/list_items/channel.cljs
@@ -39,6 +39,7 @@
        [channel-avatar/view
         {:big?                   true
          :locked?                locked?
+         :full-name              (:name props)
          :emoji-background-color (colors/theme-alpha channel-color 0.1 0.1)
          :emoji                  emoji}]
        [quo2.text/text

--- a/src/quo2/components/list_items/channel.cljs
+++ b/src/quo2/components/list_items/channel.cljs
@@ -13,10 +13,11 @@
 
 (defn list-item
   [{:keys [locked? mentions-count unread-messages?
-           muted? is-active-channel? emoji channel-color]
-    :or   {channel-color colors/primary-50}
+           muted? is-active-channel? emoji channel-color
+           default-color]
     :as   props}]
-  (let [standard-props (apply dissoc props custom-props)
+  (let [channel-color  (or channel-color default-color)
+        standard-props (apply dissoc props custom-props)
         name-text      (:name props)]
     [rn/touchable-opacity standard-props
      [rn/view

--- a/src/quo2/components/list_items/channel.cljs
+++ b/src/quo2/components/list_items/channel.cljs
@@ -38,7 +38,7 @@
         :accessible          true
         :accessibility-label :chat-name-text}
        [channel-avatar/view
-        {:big?                true
+        {:size                :size/l
          :locked?             locked?
          :full-name           (:name props)
          :customization-color channel-color

--- a/src/quo2/components/list_items/channel.cljs
+++ b/src/quo2/components/list_items/channel.cljs
@@ -1,6 +1,6 @@
 (ns quo2.components.list-items.channel
-  (:require [quo2.components.avatars.channel-avatar :as channel-avatar]
-            [quo2.components.common.unread-grey-dot.view :refer [unread-grey-dot]]
+  (:require [quo2.components.avatars.channel-avatar.view :as channel-avatar]
+            [quo2.components.common.unread-grey-dot.view :as unread-grey-dot]
             [quo2.components.counter.counter :as quo2.counter]
             [quo2.components.icon :as quo2.icons]
             [quo2.components.markdown.text :as quo2.text]
@@ -36,7 +36,7 @@
                               :align-items     :center}
         :accessible          true
         :accessibility-label :chat-name-text}
-       [channel-avatar/channel-avatar
+       [channel-avatar/view
         {:big?                   true
          :locked?                locked?
          :emoji-background-color (colors/theme-alpha channel-color 0.1 0.1)
@@ -63,4 +63,4 @@
              mentions-count]]
 
            unread-messages?
-           [unread-grey-dot :unviewed-messages-public])])]]))
+           [unread-grey-dot/unread-grey-dot :unviewed-messages-public])])]]))

--- a/src/quo2/components/list_items/channel.cljs
+++ b/src/quo2/components/list_items/channel.cljs
@@ -37,11 +37,11 @@
         :accessible          true
         :accessibility-label :chat-name-text}
        [channel-avatar/view
-        {:big?                   true
-         :locked?                locked?
-         :full-name              (:name props)
-         :emoji-background-color (colors/theme-alpha channel-color 0.1 0.1)
-         :emoji                  emoji}]
+        {:big?      true
+         :locked?   locked?
+         :full-name (:name props)
+         :color     channel-color
+         :emoji     emoji}]
        [quo2.text/text
         {:style  (cond-> {:margin-left 12}
                    (and (not locked?) muted?)

--- a/src/quo2/components/list_items/channel.cljs
+++ b/src/quo2/components/list_items/channel.cljs
@@ -38,11 +38,11 @@
         :accessible          true
         :accessibility-label :chat-name-text}
        [channel-avatar/view
-        {:big?      true
-         :locked?   locked?
-         :full-name (:name props)
-         :color     channel-color
-         :emoji     emoji}]
+        {:big?                true
+         :locked?             locked?
+         :full-name           (:name props)
+         :customization-color channel-color
+         :emoji               emoji}]
        [quo2.text/text
         {:style  (cond-> {:margin-left 12}
                    (and (not locked?) muted?)

--- a/src/quo2/core.cljs
+++ b/src/quo2/core.cljs
@@ -2,7 +2,7 @@
   (:refer-clojure :exclude [filter])
   (:require
     quo2.components.avatars.account-avatar
-    quo2.components.avatars.channel-avatar
+    quo2.components.avatars.channel-avatar.view
     quo2.components.avatars.group-avatar
     quo2.components.avatars.icon-avatar
     quo2.components.avatars.user-avatar.view
@@ -121,7 +121,7 @@
 
 ;;;; AVATAR
 (def account-avatar quo2.components.avatars.account-avatar/account-avatar)
-(def channel-avatar quo2.components.avatars.channel-avatar/channel-avatar)
+(def channel-avatar quo2.components.avatars.channel-avatar.view/view)
 (def group-avatar quo2.components.avatars.group-avatar/group-avatar)
 (def icon-avatar quo2.components.avatars.icon-avatar/icon-avatar)
 (def user-avatar quo2.components.avatars.user-avatar.view/user-avatar)

--- a/src/status_im2/contexts/communities/overview/view.cljs
+++ b/src/status_im2/contexts/communities/overview/view.cljs
@@ -49,7 +49,7 @@
   (oops/oget event "nativeEvent.layout.y"))
 
 (defn- channel-chat-item
-  [community-id {chat-id :id muted? :muted? :as chat}]
+  [community-id community-color {chat-id :id muted? :muted? :as chat}]
   (let [sheet-content      [actions/chat-actions
                             (assoc chat :chat-type constants/community-chat-type)
                             false]
@@ -58,12 +58,13 @@
     [rn/view {:key chat-id :style {:margin-top 4}}
      [quo/channel-list-item
       (assoc chat
+             :default-color community-color
              :on-long-press #(rf/dispatch [:show-bottom-sheet channel-sheet-data])
              :muted?        (or muted?
                                 (rf/sub [:chat/check-channel-muted? community-id chat-id])))]]))
 
 (defn channel-list-component
-  [{:keys [on-category-layout community-id on-first-channel-height-changed]}
+  [{:keys [on-category-layout community-id community-color on-first-channel-height-changed]}
    channels-list]
   [rn/view
    {:on-layout #(on-first-channel-height-changed
@@ -91,7 +92,7 @@
            :chevron-position :left}])
        (when-not collapsed?
          (into [rn/view {:style {:padding-horizontal 8 :padding-bottom 8}}]
-               (map #(channel-chat-item community-id %))
+               (map #(channel-chat-item community-id community-color %))
                chats))]))])
 
 (defn request-to-join-text
@@ -262,7 +263,7 @@
    description])
 
 (defn community-content
-  [{:keys [name description joined tags id]
+  [{:keys [name description joined tags color id]
     :as   community}
    pending?
    {:keys [on-category-layout on-first-channel-height-changed]}]
@@ -280,6 +281,7 @@
      [channel-list-component
       {:on-category-layout              on-category-layout
        :community-id                    id
+       :community-color                 color
        :on-first-channel-height-changed on-first-channel-height-changed}
       (add-handlers-to-categorized-chats id chats-by-category)]]))
 

--- a/src/status_im2/contexts/quo_preview/avatars/channel_avatar.cljs
+++ b/src/status_im2/contexts/quo_preview/avatars/channel_avatar.cljs
@@ -16,11 +16,11 @@
     :key   :full-name
     :type  :text}
    (preview/customization-color-option)
-   {:label   "Is Locked?"
-    :key     :locked?
+   {:label   "Locked state"
+    :key     :locked-state
     :type    :select
     :options [{:key   :not-set
-               :value "None"}
+               :value "Not set"}
               {:key   :unlocked
                :value "Unlocked"}
               {:key   :locked
@@ -28,14 +28,14 @@
 
 (defn cool-preview
   []
-  (let [state (reagent/atom {:big?      true
-                             :locked?   :not-set
-                             :emoji     "🍑"
-                             :full-name "Some channel"
-                             :color     :blue})]
+  (let [state (reagent/atom {:big?         true
+                             :locked-state :not-set
+                             :emoji        "🍑"
+                             :full-name    "Some channel"
+                             :color        :blue})]
     (fn []
       (let [color   (colors/custom-color-by-theme (:color @state) 50 60)
-            locked? (case (:locked? @state)
+            locked? (case (:locked-state @state)
                       :not-set  nil
                       :unlocked false
                       :locked   true

--- a/src/status_im2/contexts/quo_preview/avatars/channel_avatar.cljs
+++ b/src/status_im2/contexts/quo_preview/avatars/channel_avatar.cljs
@@ -42,13 +42,13 @@
       (let [amount-initials (utils.number/parse-int (:amount-initials @state) 1)
             color           (colors/custom-color-by-theme (:color @state) 50 60)]
         [rn/touchable-without-feedback {:on-press rn/dismiss-keyboard!}
-         [rn/view {:padding-bottom 150}
-          [rn/view {:flex 1}
+         [rn/view {:style {:padding-bottom 150}}
+          [rn/view {:style {:flex 1}}
            [preview/customizer state descriptor]]
           [rn/view
-           {:padding-vertical 60
-            :flex-direction   :row
-            :justify-content  :center}
+           {:style {:padding-vertical 60
+                    :flex-direction   :row
+                    :justify-content  :center}}
            [quo/channel-avatar
             (assoc @state
                    :amount-initials amount-initials
@@ -57,8 +57,8 @@
 (defn preview-channel-avatar
   []
   [rn/view
-   {:background-color (colors/theme-colors colors/white colors/neutral-90)
-    :flex             1}
+   {:style {:background-color (colors/theme-colors colors/white colors/neutral-90)
+            :flex             1}}
    [rn/flat-list
     {:flex                         1
      :keyboard-should-persist-taps :always

--- a/src/status_im2/contexts/quo_preview/avatars/channel_avatar.cljs
+++ b/src/status_im2/contexts/quo_preview/avatars/channel_avatar.cljs
@@ -28,18 +28,18 @@
 
 (defn cool-preview
   []
-  (let [state (reagent/atom {:big?         true
-                             :locked-state :not-set
-                             :emoji        "🍑"
-                             :full-name    "Some channel"
-                             :color        :blue})]
+  (let [state (reagent/atom {:big?                true
+                             :locked-state        :not-set
+                             :emoji               "🍑"
+                             :full-name           "Some channel"
+                             :customization-color :blue})]
     (fn []
-      (let [color   (colors/custom-color-by-theme (:color @state) 50 60)
-            locked? (case (:locked-state @state)
-                      :not-set  nil
-                      :unlocked false
-                      :locked   true
-                      nil)]
+      (let [customization-color (colors/custom-color-by-theme (:customization-color @state) 50 60)
+            locked?             (case (:locked-state @state)
+                                  :not-set  nil
+                                  :unlocked false
+                                  :locked   true
+                                  nil)]
         [rn/touchable-without-feedback {:on-press rn/dismiss-keyboard!}
          [rn/view {:style {:padding-bottom 150}}
           [rn/view {:style {:flex 1}}
@@ -50,8 +50,8 @@
                     :justify-content  :center}}
            [quo/channel-avatar
             (assoc @state
-                   :locked? locked?
-                   :color   color)]]]]))))
+                   :locked?             locked?
+                   :customization-color customization-color)]]]]))))
 
 (defn preview-channel-avatar
   []

--- a/src/status_im2/contexts/quo_preview/avatars/channel_avatar.cljs
+++ b/src/status_im2/contexts/quo_preview/avatars/channel_avatar.cljs
@@ -3,8 +3,7 @@
             [quo2.foundations.colors :as colors]
             [react-native.core :as rn]
             [reagent.core :as reagent]
-            [status-im2.contexts.quo-preview.preview :as preview]
-            utils.number))
+            [status-im2.contexts.quo-preview.preview :as preview]))
 
 (def descriptor
   [{:label "Big?"
@@ -15,9 +14,6 @@
     :type  :text}
    {:label "Full name"
     :key   :full-name
-    :type  :text}
-   {:label "Number of initials"
-    :key   :amount-initials
     :type  :text}
    (preview/customization-color-option)
    {:label   "Is Locked?"
@@ -32,20 +28,18 @@
 
 (defn cool-preview
   []
-  (let [state (reagent/atom {:big?            true
-                             :locked?         :not-set
-                             :emoji           "🍑"
-                             :full-name       "Some channel"
-                             :amount-initials "1"
-                             :color           :blue})]
+  (let [state (reagent/atom {:big?      true
+                             :locked?   :not-set
+                             :emoji     "🍑"
+                             :full-name "Some channel"
+                             :color     :blue})]
     (fn []
-      (let [amount-initials (utils.number/parse-int (:amount-initials @state) 1)
-            color           (colors/custom-color-by-theme (:color @state) 50 60)
-            locked?         (case (:locked? @state)
-                              :not-set  nil
-                              :unlocked false
-                              :locked   true
-                              nil)]
+      (let [color   (colors/custom-color-by-theme (:color @state) 50 60)
+            locked? (case (:locked? @state)
+                      :not-set  nil
+                      :unlocked false
+                      :locked   true
+                      nil)]
         [rn/touchable-without-feedback {:on-press rn/dismiss-keyboard!}
          [rn/view {:style {:padding-bottom 150}}
           [rn/view {:style {:flex 1}}
@@ -56,9 +50,8 @@
                     :justify-content  :center}}
            [quo/channel-avatar
             (assoc @state
-                   :locked?         locked?
-                   :amount-initials amount-initials
-                   :color           color)]]]]))))
+                   :locked? locked?
+                   :color   color)]]]]))))
 
 (defn preview-channel-avatar
   []

--- a/src/status_im2/contexts/quo_preview/avatars/channel_avatar.cljs
+++ b/src/status_im2/contexts/quo_preview/avatars/channel_avatar.cljs
@@ -3,7 +3,8 @@
             [quo2.foundations.colors :as colors]
             [react-native.core :as rn]
             [reagent.core :as reagent]
-            [status-im2.contexts.quo-preview.preview :as preview]))
+            [status-im2.contexts.quo-preview.preview :as preview]
+            utils.number))
 
 (def descriptor
   [{:label "Big?"
@@ -12,8 +13,14 @@
    {:label "Avatar color"
     :key   :emoji-background-color
     :type  :text}
-   {:label "Avatar color"
+   {:label "Emoji"
     :key   :emoji
+    :type  :text}
+   {:label "Full name"
+    :key   :full-name
+    :type  :text}
+   {:label "Number of initials"
+    :key   :amount-initials
     :type  :text}
    {:label   "Is Locked?"
     :key     :locked?
@@ -30,17 +37,20 @@
   (let [state (reagent/atom {:big?                   true
                              :locked?                nil
                              :emoji                  "🍑"
+                             :full-name              "Some channel"
+                             :amount-initials        "1"
                              :emoji-background-color :gray})]
     (fn []
-      [rn/touchable-without-feedback {:on-press rn/dismiss-keyboard!}
-       [rn/view {:padding-bottom 150}
-        [rn/view {:flex 1}
-         [preview/customizer state descriptor]]
-        [rn/view
-         {:padding-vertical 60
-          :flex-direction   :row
-          :justify-content  :center}
-         [quo/channel-avatar @state]]]])))
+      (let [amount-initials (utils.number/parse-int (:amount-initials @state) 1)]
+        [rn/touchable-without-feedback {:on-press rn/dismiss-keyboard!}
+         [rn/view {:padding-bottom 150}
+          [rn/view {:flex 1}
+           [preview/customizer state descriptor]]
+          [rn/view
+           {:padding-vertical 60
+            :flex-direction   :row
+            :justify-content  :center}
+           [quo/channel-avatar (assoc @state :amount-initials amount-initials)]]]]))))
 
 (defn preview-channel-avatar
   []

--- a/src/status_im2/contexts/quo_preview/avatars/channel_avatar.cljs
+++ b/src/status_im2/contexts/quo_preview/avatars/channel_avatar.cljs
@@ -11,14 +11,6 @@
   [{:label "Big?"
     :key   :big?
     :type  :boolean}
-   {:label   "Custom color"
-    :key     :color
-    :type    :select
-    :options (->> colors/customization
-                  keys
-                  sort
-                  (map (fn [k]
-                         {:key k :value (string/capitalize (name k))})))}
    {:label "Emoji"
     :key   :emoji
     :type  :text}
@@ -28,6 +20,7 @@
    {:label "Number of initials"
     :key   :amount-initials
     :type  :text}
+   (preview/customization-color-option)
    {:label   "Is Locked?"
     :key     :locked?
     :type    :select

--- a/src/status_im2/contexts/quo_preview/avatars/channel_avatar.cljs
+++ b/src/status_im2/contexts/quo_preview/avatars/channel_avatar.cljs
@@ -6,17 +6,19 @@
             [status-im2.contexts.quo-preview.preview :as preview]))
 
 (def descriptor
-  [{:label "Big?"
-    :key   :big?
-    :type  :boolean}
-   {:label "Emoji"
+  [{:label   "Size:"
+    :key     :size
+    :type    :select
+    :options [{:key :size/l :value "Large"}
+              {:key :default :value "Default"}]}
+   {:label "Emoji:"
     :key   :emoji
     :type  :text}
-   {:label "Full name"
+   {:label "Full name:"
     :key   :full-name
     :type  :text}
    (preview/customization-color-option)
-   {:label   "Locked state"
+   {:label   "Locked state:"
     :key     :locked-state
     :type    :select
     :options [{:key   :not-set
@@ -28,7 +30,7 @@
 
 (defn cool-preview
   []
-  (let [state (reagent/atom {:big?                true
+  (let [state (reagent/atom {:size                :size/l
                              :locked-state        :not-set
                              :emoji               "🍑"
                              :full-name           "Some channel"
@@ -56,7 +58,7 @@
 (defn preview-channel-avatar
   []
   [rn/view
-   {:style {:background-color (colors/theme-colors colors/white colors/neutral-90)
+   {:style {:background-color (colors/theme-colors colors/white colors/neutral-95)
             :flex             1}}
    [rn/flat-list
     {:flex                         1

--- a/src/status_im2/contexts/quo_preview/avatars/channel_avatar.cljs
+++ b/src/status_im2/contexts/quo_preview/avatars/channel_avatar.cljs
@@ -15,7 +15,7 @@
    {:label "Avatar color"
     :key   :emoji
     :type  :text}
-   {:label   "is Locked?"
+   {:label   "Is Locked?"
     :key     :locked?
     :type    :select
     :options [{:key   nil

--- a/src/status_im2/contexts/quo_preview/avatars/channel_avatar.cljs
+++ b/src/status_im2/contexts/quo_preview/avatars/channel_avatar.cljs
@@ -23,24 +23,29 @@
    {:label   "Is Locked?"
     :key     :locked?
     :type    :select
-    :options [{:key   nil
+    :options [{:key   :not-set
                :value "None"}
-              {:key   false
+              {:key   :unlocked
                :value "Unlocked"}
-              {:key   true
+              {:key   :locked
                :value "Locked"}]}])
 
 (defn cool-preview
   []
   (let [state (reagent/atom {:big?            true
-                             :locked?         nil
+                             :locked?         :not-set
                              :emoji           "🍑"
                              :full-name       "Some channel"
                              :amount-initials "1"
                              :color           :blue})]
     (fn []
       (let [amount-initials (utils.number/parse-int (:amount-initials @state) 1)
-            color           (colors/custom-color-by-theme (:color @state) 50 60)]
+            color           (colors/custom-color-by-theme (:color @state) 50 60)
+            locked?         (case (:locked? @state)
+                              :not-set  nil
+                              :unlocked false
+                              :locked   true
+                              nil)]
         [rn/touchable-without-feedback {:on-press rn/dismiss-keyboard!}
          [rn/view {:style {:padding-bottom 150}}
           [rn/view {:style {:flex 1}}
@@ -51,6 +56,7 @@
                     :justify-content  :center}}
            [quo/channel-avatar
             (assoc @state
+                   :locked?         locked?
                    :amount-initials amount-initials
                    :color           color)]]]]))))
 

--- a/src/status_im2/contexts/quo_preview/avatars/channel_avatar.cljs
+++ b/src/status_im2/contexts/quo_preview/avatars/channel_avatar.cljs
@@ -1,5 +1,5 @@
 (ns status-im2.contexts.quo-preview.avatars.channel-avatar
-  (:require [quo2.components.avatars.channel-avatar :as quo2]
+  (:require [quo2.core :as quo]
             [quo2.foundations.colors :as colors]
             [react-native.core :as rn]
             [reagent.core :as reagent]
@@ -40,13 +40,12 @@
          {:padding-vertical 60
           :flex-direction   :row
           :justify-content  :center}
-         [quo2/channel-avatar @state]]]])))
+         [quo/channel-avatar @state]]]])))
 
 (defn preview-channel-avatar
   []
   [rn/view
-   {:background-color (colors/theme-colors colors/white
-                                           colors/neutral-90)
+   {:background-color (colors/theme-colors colors/white colors/neutral-90)
     :flex             1}
    [rn/flat-list
     {:flex                         1

--- a/src/status_im2/contexts/quo_preview/avatars/channel_avatar.cljs
+++ b/src/status_im2/contexts/quo_preview/avatars/channel_avatar.cljs
@@ -1,6 +1,5 @@
 (ns status-im2.contexts.quo-preview.avatars.channel-avatar
-  (:require [clojure.string :as string]
-            [quo2.core :as quo]
+  (:require [quo2.core :as quo]
             [quo2.foundations.colors :as colors]
             [react-native.core :as rn]
             [reagent.core :as reagent]

--- a/src/status_im2/contexts/quo_preview/avatars/channel_avatar.cljs
+++ b/src/status_im2/contexts/quo_preview/avatars/channel_avatar.cljs
@@ -1,5 +1,6 @@
 (ns status-im2.contexts.quo-preview.avatars.channel-avatar
-  (:require [quo2.core :as quo]
+  (:require [clojure.string :as string]
+            [quo2.core :as quo]
             [quo2.foundations.colors :as colors]
             [react-native.core :as rn]
             [reagent.core :as reagent]
@@ -10,9 +11,14 @@
   [{:label "Big?"
     :key   :big?
     :type  :boolean}
-   {:label "Avatar color"
-    :key   :emoji-background-color
-    :type  :text}
+   {:label   "Custom color"
+    :key     :color
+    :type    :select
+    :options (->> colors/customization
+                  keys
+                  sort
+                  (map (fn [k]
+                         {:key k :value (string/capitalize (name k))})))}
    {:label "Emoji"
     :key   :emoji
     :type  :text}
@@ -34,14 +40,15 @@
 
 (defn cool-preview
   []
-  (let [state (reagent/atom {:big?                   true
-                             :locked?                nil
-                             :emoji                  "🍑"
-                             :full-name              "Some channel"
-                             :amount-initials        "1"
-                             :emoji-background-color :gray})]
+  (let [state (reagent/atom {:big?            true
+                             :locked?         nil
+                             :emoji           "🍑"
+                             :full-name       "Some channel"
+                             :amount-initials "1"
+                             :color           :blue})]
     (fn []
-      (let [amount-initials (utils.number/parse-int (:amount-initials @state) 1)]
+      (let [amount-initials (utils.number/parse-int (:amount-initials @state) 1)
+            color           (colors/custom-color-by-theme (:color @state) 50 60)]
         [rn/touchable-without-feedback {:on-press rn/dismiss-keyboard!}
          [rn/view {:padding-bottom 150}
           [rn/view {:flex 1}
@@ -50,7 +57,10 @@
            {:padding-vertical 60
             :flex-direction   :row
             :justify-content  :center}
-           [quo/channel-avatar (assoc @state :amount-initials amount-initials)]]]]))))
+           [quo/channel-avatar
+            (assoc @state
+                   :amount-initials amount-initials
+                   :color           color)]]]]))))
 
 (defn preview-channel-avatar
   []

--- a/src/status_im2/contexts/quo_preview/preview.cljs
+++ b/src/status_im2/contexts/quo_preview/preview.cljs
@@ -202,6 +202,20 @@
          :select  [customizer-select descriptor]
          nil)]))])
 
+(defn customization-color-option
+  ([]
+   (customization-color-option {}))
+  ([opts]
+   (merge {:label   "Custom color"
+           :key     :color
+           :type    :select
+           :options (->> colors/customization
+                         keys
+                         sort
+                         (map (fn [k]
+                                {:key k :value (string/capitalize (name k))})))}
+          opts)))
+
 (comment
   [{:label "Show error:"
     :key   :error

--- a/src/status_im2/contexts/quo_preview/preview.cljs
+++ b/src/status_im2/contexts/quo_preview/preview.cljs
@@ -206,8 +206,8 @@
   ([]
    (customization-color-option {}))
   ([opts]
-   (merge {:label   "Custom color"
-           :key     :color
+   (merge {:label   "Custom color:"
+           :key     :customization-color
            :type    :select
            :options (->> colors/customization
                          keys

--- a/src/status_im2/contexts/shell/jump_to/components/switcher_cards/view.cljs
+++ b/src/status_im2/contexts/shell/jump_to/components/switcher_cards/view.cljs
@@ -41,8 +41,8 @@
       {:style {:flex-direction :row
                :align-items    :center}}
       [quo/channel-avatar
-       {:emoji                  (:emoji community-channel)
-        :emoji-background-color (colors/alpha color-50 0.1)}]
+       {:emoji (:emoji community-channel)
+        :color color-50}]
       [quo/text
        {:size            :paragraph-2
         :weight          :medium

--- a/src/status_im2/contexts/shell/jump_to/components/switcher_cards/view.cljs
+++ b/src/status_im2/contexts/shell/jump_to/components/switcher_cards/view.cljs
@@ -41,8 +41,8 @@
       {:style {:flex-direction :row
                :align-items    :center}}
       [quo/channel-avatar
-       {:emoji (:emoji community-channel)
-        :color color-50}]
+       {:emoji               (:emoji community-channel)
+        :customization-color color-50}]
       [quo/text
        {:size            :paragraph-2
         :weight          :medium

--- a/src/utils/string.cljs
+++ b/src/utils/string.cljs
@@ -49,3 +49,12 @@
   [s m r]
   (when (string? s)
     (string/replace s m r)))
+
+(defn get-initials
+  "Returns `n` number of initial letters from `s`, all uppercased."
+  [s n]
+  (let [words (-> s str string/trim (string/split #"\s+"))]
+    (->> words
+         (take n)
+         (map (comp string/upper-case str first))
+         string/join)))

--- a/src/utils/string_test.cljs
+++ b/src/utils/string_test.cljs
@@ -13,6 +13,7 @@
    "A"   "ab"          1
    "A"   " ab  "       1
    "A"   "a b"         1
+   "A"   "ab"          2
    "AB"  "a b"         2
    "ABC" "a b c d"     3
    "ABC" " a  b  c  d" 3))

--- a/src/utils/string_test.cljs
+++ b/src/utils/string_test.cljs
@@ -1,0 +1,18 @@
+(ns utils.string-test
+  (:require [cljs.test :refer [are deftest]]
+            utils.string))
+
+(deftest get-initials-test
+  (are [expected input amount-initials]
+   (= expected (utils.string/get-initials input amount-initials))
+   ""    nil           0
+   ""    nil           1
+   ""    ""            0
+   ""    "ab"          0
+   ""    ""            1
+   "A"   "ab"          1
+   "A"   " ab  "       1
+   "A"   "a b"         1
+   "AB"  "a b"         2
+   "ABC" "a b c d"     3
+   "ABC" " a  b  c  d" 3))


### PR DESCRIPTION
- Fixes https://github.com/status-im/status-mobile/issues/16332
- Fixes https://github.com/status-im/status-mobile/issues/16327

### Summary

Another step on the journey to fix the Community overview screen. This time around, I'm fixing:

- [x] Community channels may not have an emoji, and in such cases, it should fall back to a single letter. The component was recently updated in [Figma](https://www.figma.com/file/WQZcp6S0EnzxdTL4taoKDv/Design-System-for-Mobile?type=design&node-id=399-20709&mode=design&t=UZYVQAGns9IVRxew-0) after this concern was brought up to designers.
- [x] The default (fallback) color to be used in the list of community channels should be the **community color,** not a default `primary-50` as was before. It's a subtle change because the colors are rendered at 10% transparency.
- [x] Rewrote the `channel-avatar` component to follow guidelines. 

### Examples

<table>
  <thead>
    <tr>
        <th>Before</th>
        <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img src="https://github.com/status-im/status-mobile/assets/46027/2926f245-f184-42eb-88dc-9eb3c81aa3ac" width="350" /></td>
      <td><img src="https://github.com/status-im/status-mobile/assets/46027/80893036-99d5-40b9-95b2-5fd6f06fc718" width="350" /></td>
    </tr>
    <tr>
      <td><img src="https://github.com/status-im/status-mobile/assets/46027/47d740df-b299-462c-b305-3808c788b1ff" width="350" /></td>
      <td><img src="https://github.com/status-im/status-mobile/assets/46027/93a8ddd4-aa47-45e1-848d-acab47fb7c6d" width="350" /></td>
    </tr>
  </tbody>
</table>

### Quo component

<img src="https://github.com/status-im/status-mobile/assets/46027/ba90e1fc-abc9-4882-854c-303952ebd646" width="400" />

<img src="https://github.com/status-im/status-mobile/assets/46027/4fe9b912-8ecf-419f-ae7d-dd41c7ceeb61" width="400" />

### How to test

- Open a community with lots of channels, ideally with a mix of custom colors.
- Check the quo2 preview `avatar` > `channel-avatar`.

### Resources

- [Design System > Avatars > Channel Avatar](https://www.figma.com/file/WQZcp6S0EnzxdTL4taoKDv/Design-System-for-Mobile?type=design&node-id=399-20709&mode=design&t=vt6rTZgV5rgSqgfO-0)
- [Communities for Mobile > Channels](https://www.figma.com/file/h9wo4GipgZURbqqr1vShFN/Communities-for-Mobile?type=design&node-id=12697-455084&mode=design&t=urMJx8grNxPPA59i-0)

status: ready
