### PR TITLE
scripts: disable pipefail when greping for SHA

### DIFF
--- a/scripts/update-status-go.sh
+++ b/scripts/update-status-go.sh
@@ -1,12 +1,8 @@
 #!/usr/bin/env bash
 
 GIT_ROOT=$(cd "${BASH_SOURCE%/*}" && git rev-parse --show-toplevel)
+source "${GIT_ROOT}/scripts/colors.sh"
 source "${GIT_ROOT}/nix/scripts/source.sh"
-
-if [[ ! -x "$(command -v nix-prefetch-url)" ]]; then
-    echo "No 'nix-prefetch-url' utility found!" >&2
-    exit 1
-fi
 
 set -ef
 
@@ -25,13 +21,29 @@ urlencode() {
     LC_COLLATE=$old_lc_collate
 }
 
-VERSION_FILE="${GIT_ROOT}/status-go-version.json"
-SCRIPT_FILE="$(basename "$0")"
+identify_git_sha() {
+    # Do not fail on grep for refs
+    set +o pipefail
 
-STATUS_GO_REPO="${STATUS_GO_REPO:=status-go}"
-STATUS_GO_OWNER="${STATUS_GO_OWNER:=status-im}"
-REPO_URL="https://github.com/${STATUS_GO_OWNER}/${STATUS_GO_REPO}"
-STATUS_GO_VERSION=$1
+    # ls-remote finds only tags, branches, and pull requests, but can't find commits
+    STATUS_GO_MATCHING_REFS=$(git ls-remote ${REPO_URL} ${1})
+
+    # It's possible that there's both a branch and a tag matching the given version
+    STATUS_GO_TAG_SHA1=$(echo "${STATUS_GO_MATCHING_REFS}" | grep 'refs/tags' | cut -f1)
+    STATUS_GO_BRANCH_SHA1=$(echo "${STATUS_GO_MATCHING_REFS}" | grep 'refs/heads' | cut -f1)
+
+    # Prefer tag over branch if both are found
+    if [[ -n "${STATUS_GO_TAG_SHA1}" ]]; then
+        echo -n "${STATUS_GO_TAG_SHA1}"
+    elif [[ -n "${STATUS_GO_BRANCH_SHA1}" ]]; then
+        echo -n "${STATUS_GO_BRANCH_SHA1}"
+    elif [[ "${#STATUS_GO_VERSION}" -gt 4 ]]; then
+        echo -n "${1}"
+    else
+        echo -e "${RED}${BLD}ERROR:${RST} Input not a tag or branch, but too short to be a SHA1!" >&2
+        exit 1
+    fi
+}
 
 HELP_MESSAGE=$(cat <<-END
 This is a tool for upgrading status-go to a given version in:
@@ -58,6 +70,11 @@ Examples:
 END
 )
 
+if [[ ! -x "$(command -v nix-prefetch-url)" ]]; then
+    echo "No 'nix-prefetch-url' utility found!" >&2
+    exit 1
+fi
+
 if [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
     echo "${HELP_MESSAGE}"
     exit 1
@@ -70,31 +87,23 @@ if [ $# -eq 0 ]; then
     exit 1
 fi
 
+VERSION_FILE="${GIT_ROOT}/status-go-version.json"
+SCRIPT_FILE="$(basename "$0")"
+
+STATUS_GO_REPO="${STATUS_GO_REPO:=status-go}"
+STATUS_GO_OWNER="${STATUS_GO_OWNER:=status-im}"
+REPO_URL="https://github.com/${STATUS_GO_OWNER}/${STATUS_GO_REPO}"
+STATUS_GO_VERSION=$1
+
 # If prefixed with # we assume argument is a PR number
 if [[ "${STATUS_GO_VERSION}" = PR-* ]]; then
     STATUS_GO_VERSION="refs/pull/${STATUS_GO_VERSION#"PR-"}/head"
 fi
 
-# ls-remote finds only tags, branches, and pull requests, but can't find commits
-STATUS_GO_MATCHING_REFS=$(git ls-remote ${REPO_URL} ${STATUS_GO_VERSION})
-
-# It's possible that there's both a branch and a tag matching the given version
-STATUS_GO_TAG_SHA1=$(echo "${STATUS_GO_MATCHING_REFS}" | grep 'refs/tags' | cut -f1)
-STATUS_GO_BRANCH_SHA1=$(echo "${STATUS_GO_MATCHING_REFS}" | grep 'refs/heads' | cut -f1)
-
-# Prefer tag over branch if both are found
-if [[ -n "${STATUS_GO_TAG_SHA1}" ]]; then
-    STATUS_GO_COMMIT_SHA1="${STATUS_GO_TAG_SHA1}"
-elif [[ -n "${STATUS_GO_BRANCH_SHA1}" ]]; then
-    STATUS_GO_COMMIT_SHA1="${STATUS_GO_BRANCH_SHA1}"
-elif [[ "${#STATUS_GO_VERSION}" -gt 4 ]]; then
-    STATUS_GO_COMMIT_SHA1="${STATUS_GO_VERSION}"
-else
-    echo "ERROR: Input not a tag or branch, but too short to be a SHA1!" >&2
-    exit 1
-fi
-
-STATUS_GO_SHA256=$(nix-prefetch-url --unpack ${REPO_URL}/archive/$(urlencode ${STATUS_GO_VERSION}).zip --name status-go-archive.zip)
+STATUS_GO_COMMIT_SHA1="$(identify_git_sha "${STATUS_GO_VERSION}")"
+STATUS_GO_COMMIT_URL="https://github.com/${STATUS_GO_OWNER}/${STATUS_GO_REPO}/commit/${STATUS_GO_COMMIT_SHA1}"
+STATUS_GO_ZIP_URL="${REPO_URL}/archive/$(urlencode ${STATUS_GO_VERSION}).zip"
+STATUS_GO_SHA256=$(nix-prefetch-url --unpack ${STATUS_GO_ZIP_URL} --name status-go-archive.zip)
 
 cat << EOF > ${VERSION_FILE}
 {
@@ -108,6 +117,6 @@ cat << EOF > ${VERSION_FILE}
 }
 EOF
 
-echo "SHA-1 for ${STATUS_GO_VERSION} is ${STATUS_GO_COMMIT_SHA1}.
-SHA-256 for source archive is ${STATUS_GO_SHA256}
-Owner is ${STATUS_GO_OWNER}"
+echo -e "${GRN}URL${RST}:     ${BLD}${STATUS_GO_COMMIT_URL}${RST}"
+echo -e "${GRN}SHA-1${RST}:   ${BLD}${STATUS_GO_COMMIT_SHA1}${RST}"
+echo -e "${GRN}SHA-256${RST}: ${BLD}${STATUS_GO_SHA256}${RST}"


### PR DESCRIPTION
Otherwise it fails early and doesn't work for branches.

I also refactored it a bit so the `pipefail` disabling is local.