### PR TITLE
[16079] Fix dark mode for communities and messages home

### DIFF
--- a/src/status_im2/contexts/chat/home/view.cljs
+++ b/src/status_im2/contexts/chat/home/view.cljs
@@ -131,8 +131,8 @@
      [rn/view {:style (style/blur-container top)}
       [blur/view
        {:blur-amount   (if platform/ios? 20 10)
-        :blur-type     (if (colors/dark?) :dark (if platform/ios? :light :xlight))
-        :overlay-color (if (colors/dark?) colors/neutral-95-opa-70 colors/white-opa-70)
+        :blur-type     (theme/theme-value (if platform/ios? :light :xlight) :dark)
+        :overlay-color (theme/theme-value colors/white-opa-70 colors/neutral-95-opa-70)
         :style         style/blur}]
       [common.home/top-nav
        {:type   :grey

--- a/src/status_im2/contexts/chat/home/view.cljs
+++ b/src/status_im2/contexts/chat/home/view.cljs
@@ -131,8 +131,8 @@
      [rn/view {:style (style/blur-container top)}
       [blur/view
        {:blur-amount   (if platform/ios? 20 10)
-        :blur-type     (theme/theme-value (if platform/ios? :light :xlight) :dark)
-        :overlay-color (theme/theme-value colors/white-opa-70 colors/neutral-95-opa-70)
+        :blur-type     :transparent
+        :overlay-color :transparent
         :style         style/blur}]
       [common.home/top-nav
        {:type   :grey

--- a/src/status_im2/contexts/chat/home/view.cljs
+++ b/src/status_im2/contexts/chat/home/view.cljs
@@ -73,7 +73,7 @@
         :get-item-layout                   get-item-layout
         :on-end-reached                    #(re-frame/dispatch [:chat/show-more-chats])
         :keyboard-should-persist-taps      :always
-        :data                              items
+        :data                              (concat items items items items items items items items)
         :render-fn                         chat-list-item/chat-list-item}])))
 
 (defn contact-item-render
@@ -129,10 +129,15 @@
        [contacts pending-contact-requests top]
        [chats selected-tab top])
      [rn/view {:style (style/blur-container top)}
-      [blur/view
-       {:blur-amount (if platform/ios? 20 10)
-        :blur-type   (if (colors/dark?) :dark (if platform/ios? :light :xlight))
-        :style       style/blur}]
+      (let [{:keys [sheets]} (rf/sub [:bottom-sheet])]
+        [blur/view
+         {:blur-amount   (if platform/ios? 20 10)
+          :blur-type     (if (colors/dark?) :dark (if platform/ios? :light :xlight))
+          :style         style/blur
+          :overlay-color (if (seq sheets)
+                           (theme/theme-value colors/white colors/neutral-95-opa-70)
+                           (when (colors/dark?)
+                             colors/neutral-95-opa-70))}])
       [common.home/top-nav
        {:type   :grey
         :avatar {:customization-color customization-color

--- a/src/status_im2/contexts/chat/home/view.cljs
+++ b/src/status_im2/contexts/chat/home/view.cljs
@@ -130,9 +130,10 @@
        [chats selected-tab top])
      [rn/view {:style (style/blur-container top)}
       [blur/view
-       {:blur-amount (if platform/ios? 20 10)
-        :blur-type   (if (colors/dark?) :dark (if platform/ios? :light :xlight))
-        :style       style/blur}]
+       {:blur-amount   (if platform/ios? 20 10)
+        :blur-type     (if (colors/dark?) :dark (if platform/ios? :light :xlight))
+        :overlay-color (if (colors/dark?) colors/neutral-95-opa-70 colors/white-opa-70)
+        :style         style/blur}]
       [common.home/top-nav
        {:type   :grey
         :avatar {:customization-color customization-color

--- a/src/status_im2/contexts/communities/home/view.cljs
+++ b/src/status_im2/contexts/communities/home/view.cljs
@@ -96,8 +96,8 @@
      [rn/view {:style (style/blur-container top)}
       [blur/view
        {:blur-amount   (if platform/ios? 20 10)
-        :blur-type     (theme/theme-value (if platform/ios? :light :xlight) :dark)
-        :overlay-color (theme/theme-value colors/white-opa-70 colors/neutral-95-opa-70)
+        :blur-type     :transparent
+        :overlay-color :transparent
         :style         style/blur}]
       [common.home/top-nav
        {:type   :grey

--- a/src/status_im2/contexts/communities/home/view.cljs
+++ b/src/status_im2/contexts/communities/home/view.cljs
@@ -95,9 +95,10 @@
 
      [rn/view {:style (style/blur-container top)}
       [blur/view
-       {:blur-amount (if platform/ios? 20 10)
-        :blur-type   (if (colors/dark?) :dark (if platform/ios? :light :xlight))
-        :style       style/blur}]
+       {:blur-amount   (if platform/ios? 20 10)
+        :blur-type     (if (colors/dark?) :dark (if platform/ios? :light :xlight))
+        :overlay-color (if (colors/dark?) colors/neutral-95-opa-70 colors/white-opa-70)
+        :style         style/blur}]
       [common.home/top-nav
        {:type   :grey
         :avatar {:customization-color customization-color

--- a/src/status_im2/contexts/communities/home/view.cljs
+++ b/src/status_im2/contexts/communities/home/view.cljs
@@ -96,8 +96,8 @@
      [rn/view {:style (style/blur-container top)}
       [blur/view
        {:blur-amount   (if platform/ios? 20 10)
-        :blur-type     (if (colors/dark?) :dark (if platform/ios? :light :xlight))
-        :overlay-color (if (colors/dark?) colors/neutral-95-opa-70 colors/white-opa-70)
+        :blur-type     (theme/theme-value (if platform/ios? :light :xlight) :dark)
+        :overlay-color (theme/theme-value colors/white-opa-70 colors/neutral-95-opa-70)
         :style         style/blur}]
       [common.home/top-nav
        {:type   :grey

--- a/src/status_im2/contexts/communities/home/view.cljs
+++ b/src/status_im2/contexts/communities/home/view.cljs
@@ -94,10 +94,15 @@
          :data                              selected-items}])
 
      [rn/view {:style (style/blur-container top)}
-      [blur/view
-       {:blur-amount (if platform/ios? 20 10)
-        :blur-type   (if (colors/dark?) :dark (if platform/ios? :light :xlight))
-        :style       style/blur}]
+      (let [{:keys [sheets]} (rf/sub [:bottom-sheet])]
+        [blur/view
+         {:blur-amount   (if platform/ios? 20 10)
+          :blur-type     (if (colors/dark?) :dark (if platform/ios? :light :xlight))
+          :style         style/blur
+          :overlay-color (if (seq sheets)
+                           (theme/theme-value colors/white colors/neutral-95-opa-70)
+                           (when (colors/dark?)
+                             colors/neutral-95-opa-70))}])
       [common.home/top-nav
        {:type   :grey
         :avatar {:customization-color customization-color


### PR DESCRIPTION
fixes #16079 

### Summary
Removes the dark background on communities home by adding an `overlay-color` on it's blur view.

After:
![image](https://github.com/status-im/status-mobile/assets/33176106/06f16302-b51b-4782-8be2-c7ca6c96a436)


status: ready
