### PR TITLE
nix: build derivation from sources if cache fails

### DIFF
--- a/nix/nix.conf
+++ b/nix/nix.conf
@@ -6,6 +6,8 @@ trusted-public-keys = nix-cache.status.im-1:x/93lOfLU+duPplwMSBR+OlY4+mo+dCN7n0m
 stalled-download-timeout = 3600
 connect-timeout = 10
 max-jobs = auto
+# Build packages if fetching from cache fails.
+fallback = true
 # Helps avoid removing currently used dependencies via garbage collection
 keep-derivations = true
 keep-outputs = true


### PR DESCRIPTION
This is a workaround for a well known issue of Nix failing to download bigger packages from Nix cache due to errors like this:
```
HTTP error 200 (curl error: Transferred a partial file)
```
or
```
HTTP error 200 (curl error: Stream error in the HTTP/2 framing layer)
```
From docs: https://nixos.org/manual/nix/stable/command-ref/conf-file.html#conf-fallback

>If set to true, Nix will fall back to building from source if a binary substitute fails. This is equivalent to the `--fallback` flag.

Related to:
* https://github.com/status-im/infra-ci/issues/17