### PR TITLE
nix: skip git-lfs checks failing on darwin

### DIFF
--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -44,6 +44,11 @@ in {
     };
   });
 
+  # Checks fail on darwin.
+  git-lfs = super.git-lfs.overrideAttrs (old: {
+    doCheck = false;
+  });
+
   # Package version adjustments
   gradle = super.gradle_7;
   nodejs = super.nodejs-18_x;


### PR DESCRIPTION
On macOS `git-lfs` checks fail sometimes and they also take a lot of time to execute.

```log
FAIL    github.com/git-lfs/git-lfs/v3/lfshttp   0.820s
FAIL
error: builder for '/nix/store/abd6spw876qvcmlpcwsljsnbpbnvx1fg-git-lfs-3.3.0.drv' failed with exit code 1;
       last 10 log lines:
       >          Error Trace:    certs_test.go:210
       >              Error:          Expected value not to be nil.
       >          Test:           TestCertFromSSLCAPathEnv
       >     certs_test.go:210:
       >               Error Trace:    certs_test.go:210
       >              Error:          Expected value not to be nil.
       >          Test:           TestCertFromSSLCAPathEnv
       > FAIL
       > FAIL    github.com/git-lfs/git-lfs/v3/lfshttp   0.820s
       > FAIL
       For full logs, run 'nix-store -l /nix/store/abd6spw876qvcmlpcwsljsnbpbnvx1fg-git-lfs-3.3.0.drv'.
```
Failures initially observed by me and @smohamedjavid and then today again reported by @yqrashawn 

This PR adds a `nix` overlay that skips those checks

status: ready
