### PR TITLE
Update broken `Status development` link in ide-setup.md

### DIFF
--- a/doc/ide-setup.md
+++ b/doc/ide-setup.md
@@ -169,7 +169,7 @@ For VS Code users.
 ### Start and connect the REPL
 
 1. Open the `status-mobile` folder.
-1. Start [Status development](STARTING_GUIDE.md#development) (Starting the `run-clojure` and `run-metro` jobs in split view in the VS Code integrated terminal works great.)
+1. Start [Status development](starting-guide.md#development) (Starting the `run-clojure` and `run-metro` jobs in split view in the VS Code integrated terminal works great.)
 1. Run the VS Code command: **Calva: Connect to a running REPL Server in the project**
    1. Select the project type `shadow-cljs`
    1. Accept the suggested connection `host:port`


### PR DESCRIPTION
### Summary

This PR updates the broken link of `Status development` in the `Start and connect the REPL` section.

Originally identified by external collaborator in issue https://github.com/status-im/status-mobile/issues/16243 

status: ready 
