### PR TITLE
nix: downgrade watchman to 4.9.0

### DIFF
--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -49,6 +49,12 @@ in {
     doCheck = false;
   });
 
+  # Downgrade watchman in attempt to fix "too many files open issue"
+  watchman = callPackage ./pkgs/watchman {
+    inherit (super.darwin.apple_sdk.frameworks) CoreServices;
+    autoconf = super.buildPackages.autoconf269;
+  };
+
   # Package version adjustments
   gradle = super.gradle_7;
   nodejs = super.nodejs-18_x;

--- a/nix/pkgs/watchman/README.md
+++ b/nix/pkgs/watchman/README.md
@@ -1,0 +1,23 @@
+# Issue
+
+`watchman` was upgraded significantly during the last nixpkgs upgrade (`4.9.0` (Aug 16, 2017) to `2023.01.30.00` - 6 years between):
+- https://github.com/status-im/status-mobile/pull/14944
+- https://github.com/status-im/nixpkgs/commit/4e9c02bcc709fe1737a746add0e8e0109133d808
+
+Probably causing developers to have "too many files open" issue:
+https://github.com/status-im/status-mobile/issues/16341
+
+```
+Error: A non-recoverable condition has triggered.  Watchman needs your help!
+The triggering condition was at timestamp=1687286390: opendir(/Users/javid/Projects/status-mobile/node_modules/metro-core/node_modules/jest-regex-util/build) -> Too many open files
+All requests will continue to fail with this message until you resolve
+the underlying problem.  You will find more information on fixing this at
+https://facebook.github.io/watchman/docs/troubleshooting.html#poison-opendir
+```
+
+# Fix
+This is an attempt to fix the issue by downgrading the watchman
+
+# Upgrade
+When upgrading in the future, please read the comments:
+https://github.com/status-im/status-mobile/issues/16341

--- a/nix/pkgs/watchman/default.nix
+++ b/nix/pkgs/watchman/default.nix
@@ -1,0 +1,48 @@
+{ stdenv, lib, config, fetchFromGitHub, autoconf, automake, pcre
+, libtool, pkg-config, openssl
+, confFile ? config.watchman.confFile or null
+, withApple ? stdenv.isDarwin, CoreServices
+}:
+
+stdenv.mkDerivation rec {
+  pname = "watchman";
+  version = "4.9.0";
+
+  src = fetchFromGitHub {
+    owner = "facebook";
+    repo = "watchman";
+    rev = "v${version}";
+    sha256 = "0fdaj5pmicm6j17d5q7px800m5rmam1a400x3hv1iiifnmhgnkal";
+  };
+
+  nativeBuildInputs = [ autoconf automake pkg-config libtool ];
+  buildInputs = [ pcre openssl ]
+    #++ lib.optionals withApple [ CoreServices ];
+    ++ lib.optionals stdenv.isDarwin [ CoreServices ];
+
+  configureFlags = [
+    "--enable-lenient"
+    "--enable-conffile=${if confFile == null then "no" else confFile}"
+    "--with-pcre=yes"
+
+    # For security considerations re: --disable-statedir, see:
+    # https://github.com/facebook/watchman/issues/178
+    "--disable-statedir"
+  ];
+
+  prePatch = ''
+    patchShebangs .
+  '';
+
+  preConfigure = ''
+    ./autogen.sh
+  '';
+
+  meta = with lib; {
+    description = "Watches files and takes action when they change";
+    homepage    = "https://facebook.github.io/watchman";
+    maintainers = with maintainers; [ cstrahan ];
+    platforms   = with platforms; linux ++ darwin;
+    license     = licenses.asl20;
+  };
+}


### PR DESCRIPTION
fixes #16341

### Summary
`watchman` was upgraded significantly during the last #14944 (`4.9.0` (Aug 16, 2017) to `2023.01.30.00` - 6 years between):
https://github.com/status-im/nixpkgs/commit/4e9c02bcc709fe1737a746add0e8e0109133d808

Probably causing developers to have "too many files open" issue #16341

This PR is an attempt to fix the issue by downgrading the `watchman`

### Testing notes
"too many files open" issue of `watchman` might be difficult to catch.
So let's test, that the downgrade doesn't break the flow rather.

### Steps to test
- `run-clojure/run-metro/run-...` flow shouls continue to work and update the app as before

status: wip
