### PR TITLE
nix: use Darwin stat command explicitly

### DIFF
--- a/nix/scripts/lib.sh
+++ b/nix/scripts/lib.sh
@@ -8,7 +8,8 @@ file_group() {
     if [[ "${UNAME}" == "Linux" ]]; then
         stat -Lc "%G" "${1}" 2>/dev/null
     elif [[ "${UNAME}" == "Darwin" ]]; then
-        stat -Lf "%Sg" "${1}" 2>/dev/null
+        # Avoid using Nix GNU stat when in Nix shell.
+        /usr/bin/stat -Lf "%Sg" "${1}" 2>/dev/null
     fi
 }
 


### PR DESCRIPTION
Otherwise if in Nix context we can accidentally use GNU stat which results in a different output due to different command line flags:
```
[nix-shell:~/status-mobile]$ stat -Lf "%Sg" "/nix/store"
stat: cannot read file system information for '%Sg': No such file or directory
  File: "/nix/store"
    ID: 10000110000001a Namelen: ?       Type: apfs
Block size: 4096       Fundamental block size: 4096
Blocks: Total: 242837545  Free: 199242283  Available: 199242283
Inodes: Total: 7971454780 Free: 7969691320
```
And it should be just owner group name or ID. Which in turn results in:
```
Unknown Nix installtion type!
```