### PR TITLE
multiaccounts refactoring part1

### DIFF
--- a/src/status_im/bootnodes/core.cljs
+++ b/src/status_im/bootnodes/core.cljs
@@ -22,7 +22,7 @@
 (rf/defn fetch
   [cofx id]
   (let [network (get-in cofx [:db :networks/current-network])]
-    (get-in cofx [:db :multiaccount :custom-bootnodes network id])))
+    (get-in cofx [:db :profile/profile :custom-bootnodes network id])))
 
 (rf/defn set-input
   {:events [:bootnodes.ui/input-changed]}
@@ -54,26 +54,26 @@
 (defn custom-bootnodes-in-use?
   [{:keys [db]}]
   (let [network (:networks/current-network db)]
-    (get-in db [:multiaccount :custom-bootnodes-enabled? network])))
+    (get-in db [:profile/profile :custom-bootnodes-enabled? network])))
 
 (rf/defn delete
-  [{{:keys [multiaccount] :as db} :db :as cofx} id]
-  (let [network          (:networks/current-network db)
-        new-multiaccount (update-in multiaccount [:custom-bootnodes network] dissoc id)]
+  [{{:profile/keys [profile] :as db} :db :as cofx} id]
+  (let [network     (:networks/current-network db)
+        new-profile (update-in profile [:custom-bootnodes network] dissoc id)]
     (rf/merge cofx
-              {:db (assoc db :multiaccount new-multiaccount)}
+              {:db (assoc db :profile/profile new-profile)}
               (multiaccounts.update/multiaccount-update
                :custom-bootnodes
-               (:custom-bootnodes new-multiaccount)
+               (:custom-bootnodes new-profile)
                {:success-event (when (custom-bootnodes-in-use? cofx)
                                  [:multiaccounts.update.callback/save-settings-success])}))))
 
 (rf/defn upsert
   {:events       [:bootnodes.ui/save-pressed]
    :interceptors [(re-frame/inject-cofx :random-id-generator)]}
-  [{{:bootnodes/keys [manage] :keys [multiaccount] :as db} :db
-    random-id-generator                                    :random-id-generator
-    :as                                                    cofx}]
+  [{{:bootnodes/keys [manage] :profile/keys [profile] :as db} :db
+    random-id-generator                                       :random-id-generator
+    :as                                                       cofx}]
   (let [{:keys [name id url]} manage
         network               (:networks/current-network db)
         bootnode              (build
@@ -82,7 +82,7 @@
                                (:value url)
                                network)
         new-bootnodes         (assoc-in
-                               (:custom-bootnodes multiaccount)
+                               (:custom-bootnodes profile)
                                [network (:id bootnode)]
                                bootnode)]
 
@@ -99,7 +99,7 @@
   {:events [:bootnodes.ui/custom-bootnodes-switch-toggled]}
   [{:keys [db] :as cofx} value]
   (let [current-network    (:networks/current-network db)
-        bootnodes-settings (get-in db [:multiaccount :custom-bootnodes-enabled?])]
+        bootnodes-settings (get-in db [:profile/profile :custom-bootnodes-enabled?])]
     (multiaccounts.update/multiaccount-update
      cofx
      :custom-bootnodes-enabled?

--- a/src/status_im/bootnodes/core_test.cljs
+++ b/src/status_im/bootnodes/core_test.cljs
@@ -20,9 +20,9 @@
                         {:random-id-generator (constantly "some-id")
                          :db                  {:bootnodes/manage new-bootnode
                                                :networks/current-network "mainnet_rpc"
-                                               :multiaccount {:not-empty
-                                                              "would throw an error if was empty"}}})]
-      (is (= expected (get-in actual [:db :multiaccount :custom-bootnodes])))))
+                                               :profile/profile {:not-empty
+                                                                 "would throw an error if was empty"}}})]
+      (is (= expected (get-in actual [:db :profile/profile :custom-bootnodes])))))
   (testing "adding an existing bootnode"
     (let [new-bootnode {:id   {:value "a"}
                         :name {:value "new-name"}
@@ -35,13 +35,13 @@
                         {:random-id-generator (constantly "some-id")
                          :db                  {:bootnodes/manage         new-bootnode
                                                :networks/current-network "mainnet_rpc"
-                                               :multiaccount             {:custom-bootnodes
+                                               :profile/profile          {:custom-bootnodes
                                                                           {"mainnet_rpc"
                                                                            {"a" {:name    "name"
                                                                                  :address "url"
                                                                                  :chain   "mainnet_rpc"
                                                                                  :id      "a"}}}}}})]
-      (is (= expected (get-in actual [:db :multiaccount :custom-bootnodes]))))))
+      (is (= expected (get-in actual [:db :profile/profile :custom-bootnodes]))))))
 
 (deftest set-input-bootnode
   (testing "it validates names"
@@ -72,7 +72,7 @@
 
 (deftest edit-bootnode
   (let [db   {:networks/current-network "mainnet_rpc"
-              :multiaccount
+              :profile/profile
               {:custom-bootnodes
                {"mainnet_rpc"
                 {"a" {:id      "a"
@@ -123,7 +123,7 @@
 (deftest fetch-bootnode
   (testing "it fetches the bootnode from the db"
     (let [cofx {:db {:networks/current-network "mainnet_rpc"
-                     :multiaccount             {:custom-bootnodes
+                     :profile/profile          {:custom-bootnodes
                                                 {"mainnet_rpc"
                                                  {"a" {:id "a"
                                                        :name "name"
@@ -138,7 +138,7 @@
     (testing "it returns true when enabled"
       (is (model/custom-bootnodes-in-use?
            {:db {:networks/current-network "mainnet_rpc"
-                 :multiaccount             {:custom-bootnodes-enabled?
+                 :profile/profile          {:custom-bootnodes-enabled?
                                             {"mainnet_rpc" true}}}}))))
   (testing "is on a different network"
     (testing "it returns false when not enabled"
@@ -146,13 +146,13 @@
     (testing "it returns true when enabled"
       (is (not (model/custom-bootnodes-in-use?
                 {:db {:networks/current-network "goerli_rpc"
-                      :multiaccount             {:custom-bootnodes-enabled?
+                      :profile/profile          {:custom-bootnodes-enabled?
                                                  {"mainnnet_rpc" true}}}}))))))
 
 (deftest delete-bootnode
   (testing "non existing bootnode"
     (let [cofx   {:db {:networks/current-network "mainnet_rpc"
-                       :multiaccount             {:custom-bootnodes
+                       :profile/profile          {:custom-bootnodes
                                                   {"mainnet_rpc"
                                                    {"a" {:id "a"
                                                          :name "name"
@@ -165,7 +165,7 @@
         (is (model/fetch actual "a")))))
   (testing "existing bootnode"
     (let [cofx   {:db {:networks/current-network "mainnet_rpc"
-                       :multiaccount             {:custom-bootnodes
+                       :profile/profile          {:custom-bootnodes
                                                   {"mainnet_rpc"
                                                    {"a" {:id "a"
                                                          :name "name"

--- a/src/status_im/browser/core.cljs
+++ b/src/status_im/browser/core.cljs
@@ -385,7 +385,7 @@
 (rf/defn web3-send-async
   [cofx dapp-name {:keys [method params id] :as payload} message-id]
   (let [message?      (web3-sign-message? method)
-        dapps-address (get-in cofx [:db :multiaccount :dapps-address])
+        dapps-address (get-in cofx [:db :profile/profile :dapps-address])
         typed?        (and (not= constants/web3-personal-sign method)
                            (not= constants/web3-eth-sign method))]
     (if (or message? (= constants/web3-send-transaction method))

--- a/src/status_im/browser/permissions.cljs
+++ b/src/status_im/browser/permissions.cljs
@@ -42,7 +42,7 @@
 
 (defn get-permission-data
   [cofx allowed-permission]
-  (let [multiaccount (get-in cofx [:db :multiaccount])]
+  (let [multiaccount (get-in cofx [:db :profile/profile])]
     (get {constants/dapp-permission-contact-code (:public-key multiaccount)
           constants/dapp-permission-web3         [(:dapps-address multiaccount)]}
          allowed-permission)))

--- a/src/status_im/browser/permissions_test.cljs
+++ b/src/status_im/browser/permissions_test.cljs
@@ -9,7 +9,7 @@
   (let [dapp-name  "test.com"
         dapp-name2 "test2.org"
         cofx       {:db (assoc-in (:db (browser/open-url {:db {}} dapp-name))
-                         [:multiaccount :public-key]
+                         [:profile/profile :public-key]
                          "public-key")}
         dapp-id    (core.tests/get-dapp-id cofx dapp-name)]
     (testing "dapps permissions are initialized"

--- a/src/status_im/chat/models/input.cljs
+++ b/src/status_im/chat/models/input.cljs
@@ -148,7 +148,7 @@
   (when-not (string/blank? input-text)
     (let [{:keys [message-id]}
           (get-in db [:chat/inputs current-chat-id :metadata :responding-to-message])
-          preferred-name (get-in db [:multiaccount :preferred-name])
+          preferred-name (get-in db [:profile/profile :preferred-name])
           emoji? (message-content/emoji-only-content? {:text        input-text
                                                        :response-to message-id})]
       {:chat-id       current-chat-id

--- a/src/status_im/chat/models/loading.cljs
+++ b/src/status_im/chat/models/loading.cljs
@@ -83,7 +83,7 @@
   [{db :db} chat-id]
   {:db                          (mark-chat-all-read db chat-id)
    :clear-message-notifications [[chat-id]
-                                 (get-in db [:multiaccount :remote-push-notifications-enabled?])]
+                                 (get-in db [:profile/profile :remote-push-notifications-enabled?])]
    :json-rpc/call               [{:method     "wakuext_markAllRead"
                                   :params     [chat-id]
                                   :on-success #(re-frame/dispatch [::mark-all-read-successful])}]})
@@ -94,7 +94,7 @@
   (let [community-chat-ids (map #(str community-id %)
                                 (keys (get-in db [:communities community-id :chats])))]
     {:clear-message-notifications [community-chat-ids
-                                   (get-in db [:multiaccount :remote-push-notifications-enabled?])]
+                                   (get-in db [:profile/profile :remote-push-notifications-enabled?])]
      :json-rpc/call               [{:method     "wakuext_markAllReadInCommunity"
                                     :params     [community-id]
                                     :on-success #(re-frame/dispatch

--- a/src/status_im/commands/core.cljs
+++ b/src/status_im/commands/core.cljs
@@ -9,7 +9,7 @@
   {:db                    (assoc db
                                  :commands/select-account
                                  {:message message
-                                  :from    (ethereum/get-default-account (:multiaccount/accounts db))})
+                                  :from    (ethereum/get-default-account (:profile/wallet-accounts db))})
    :show-select-acc-sheet nil})
 
 (rf/defn set-selected-account

--- a/src/status_im/communities/core.cljs
+++ b/src/status_im/communities/core.cljs
@@ -102,7 +102,7 @@
 
 (rf/defn handle-requests-to-join
   [{:keys [db]} requests]
-  (let [my-public-key (get-in db [:multiaccount :public-key])]
+  (let [my-public-key (get-in db [:profile/profile :public-key])]
     {:db (reduce (fn [db {:keys [public-key] :as request}]
                    (let [my-request? (= my-public-key public-key)]
                      (if my-request?
@@ -278,7 +278,7 @@
   (let [community-chat-ids (map #(str community-id %)
                                 (keys (get-in db [:communities community-id :chats])))]
     {:clear-message-notifications [community-chat-ids
-                                   (get-in db [:multiaccount :remote-push-notifications-enabled?])]
+                                   (get-in db [:profile/profile :remote-push-notifications-enabled?])]
      :dispatch                    [:shell/close-switcher-card community-id]
      :json-rpc/call               [{:method      "wakuext_leaveCommunity"
                                     :params      [community-id]
@@ -795,14 +795,14 @@
 (rf/defn store-category-state
   {:events [::store-category-state]}
   [{:keys [db]} community-id category-id state-open?]
-  (let [public-key (get-in db [:multiaccount :public-key])
+  (let [public-key (get-in db [:profile/profile :public-key])
         hash       (category-hash public-key community-id category-id)]
     {::async-storage/set! {hash state-open?}}))
 
 (rf/defn update-category-states-in-db
   {:events [::category-states-loaded]}
   [{:keys [db]} community-id hashes states]
-  (let [public-key     (get-in db [:multiaccount :public-key])
+  (let [public-key     (get-in db [:profile/profile :public-key])
         categories-old (get-in db [:communities community-id :categories])
         categories     (reduce (fn [acc [category-id category]]
                                  (let [hash             (get hashes category-id)
@@ -816,7 +816,7 @@
 (rf/defn load-category-states
   {:events [:communities/load-category-states]}
   [{:keys [db]} community-id]
-  (let [public-key            (get-in db [:multiaccount :public-key])
+  (let [public-key            (get-in db [:profile/profile :public-key])
         categories            (get-in db [:communities community-id :categories])
         {:keys [keys hashes]} (reduce (fn [acc category]
                                         (let [category-id (get category 0)

--- a/src/status_im/contact/block.cljs
+++ b/src/status_im/contact/block.cljs
@@ -49,7 +49,7 @@
                     (assoc-in [:contacts/contacts public-key :added?] false))
             :dispatch [:shell/close-switcher-card public-key]
             :clear-message-notifications
-            [[public-key] (get-in db [:multiaccount :remote-push-notifications-enabled?])]}
+            [[public-key] (get-in db [:profile/profile :remote-push-notifications-enabled?])]}
            (activity-center/notifications-fetch-unread-count)
            fxs)))
 

--- a/src/status_im/currency/core.cljs
+++ b/src/status_im/currency/core.cljs
@@ -5,7 +5,7 @@
 
 (defn get-currency
   [db]
-  (get-in db [:multiaccount :currency] :usd))
+  (get-in db [:profile/profile :currency] :usd))
 
 (rf/defn set-currency
   {:events [:wallet.settings.ui/currency-selected]}

--- a/src/status_im/currency/core_test.cljs
+++ b/src/status_im/currency/core_test.cljs
@@ -3,16 +3,18 @@
             [status-im.currency.core :as models]))
 
 (deftest get-currency
-  (is (= :usd (models/get-currency {:multiaccount {:currency :usd}})))
-  (is (= :usd (models/get-currency {:multiaccount {:not-empty "would throw an error if was empty"}})))
-  (is (= :aud (models/get-currency {:multiaccount {:currency :aud}}))))
+  (is (= :usd (models/get-currency {:profile/profile {:currency :usd}})))
+  (is (= :usd (models/get-currency {:profile/profile {:not-empty "would throw an error if was empty"}})))
+  (is (= :aud (models/get-currency {:profile/profile {:currency :aud}}))))
 
 (deftest set-currency
-  (let [cofx (models/set-currency {:db {:multiaccount {:not-empty "would throw an error if was empty"}}}
+  (let [cofx (models/set-currency {:db {:profile/profile {:not-empty
+                                                          "would throw an error if was empty"}}}
                                   :usd)]
-    (is (= :usd (get-in cofx [:db :multiaccount :currency]))))
+    (is (= :usd (get-in cofx [:db :profile/profile :currency]))))
   (is
    (= :jpy
-      (get-in (models/set-currency {:db {:multiaccount {:not-empty "would throw an error if was empty"}}}
+      (get-in (models/set-currency {:db {:profile/profile {:not-empty
+                                                           "would throw an error if was empty"}}}
                                    :jpy)
-              [:db :multiaccount :currency]))))
+              [:db :profile/profile :currency]))))

--- a/src/status_im/ethereum/core.cljs
+++ b/src/status_im/ethereum/core.cljs
@@ -82,7 +82,7 @@
 
 (defn current-address
   [db]
-  (-> (get-in db [:multiaccount :address])
+  (-> (get-in db [:profile/profile :address])
       normalized-hex))
 
 (defn get-default-account
@@ -91,7 +91,7 @@
 
 (defn default-address
   [db]
-  (-> (get db :multiaccount/accounts)
+  (-> (get db :profile/wallet-accounts)
       get-default-account
       :address))
 
@@ -99,7 +99,7 @@
   [db]
   (into #{}
         (remove #(= (:type %) :watch)
-                (map #(eip55/address->checksum (:address %)) (get db :multiaccount/accounts)))))
+                (map #(eip55/address->checksum (:address %)) (get db :profile/wallet-accounts)))))
 
 (defn naked-address
   [s]

--- a/src/status_im/ethereum/transactions/core.cljs
+++ b/src/status_im/ethereum/transactions/core.cljs
@@ -401,5 +401,5 @@
   [{:keys [db]}]
   {:transactions/get-transfers
    {:chain-tokens (:wallet/all-tokens db)
-    :addresses    (map :address (get db :multiaccount/accounts))
+    :addresses    (map :address (get db :profile/wallet-accounts))
     :fetch-more?  false}})

--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -117,11 +117,11 @@
 (rf/defn system-theme-mode-changed
   {:events [:system-theme-mode-changed]}
   [{:keys [db] :as cofx} _]
-  (let [current-theme-type (get-in cofx [:db :multiaccount :appearance])]
+  (let [current-theme-type (get-in cofx [:db :profile/profile :appearance])]
     (when (and (multiaccounts.model/logged-in? db)
                (= current-theme-type status-im2.constants/theme-type-system))
       {:multiaccounts.ui/switch-theme-fx
-       [(get-in db [:multiaccount :appearance])
+       [(get-in db [:profile/profile :appearance])
         (:view-id db) true]})))
 
 (def authentication-options
@@ -146,7 +146,7 @@
   [{:keys [db now] :as cofx}]
   (let [new-account?            (get db :onboarding-2/new-account?)
         app-in-background-since (get db :app-in-background-since)
-        signed-up?              (get-in db [:multiaccount :signed-up?])
+        signed-up?              (get-in db [:profile/profile :signed-up?])
         biometric-auth?         (= (:auth-method db) "biometric")
         requires-bio-auth       (and
                                  signed-up?
@@ -202,7 +202,7 @@
             (cond
               (= :chat view-id)
               {::async-storage/set! {:chat-id (get-in cofx [:db :current-chat-id])
-                                     :key-uid (get-in cofx [:db :multiaccount :key-uid])}
+                                     :key-uid (get-in cofx [:db :profile/profile :key-uid])}
                :db                  (assoc db :screens/was-focused-once? true)}
 
               (= :login view-id)
@@ -291,7 +291,7 @@
 (rf/defn close-information-box
   {:events [:close-information-box]}
   [{:keys [db]} id global?]
-  (let [public-key (get-in db [:multiaccount :public-key])
+  (let [public-key (get-in db [:profile/profile :public-key])
         hash       (information-box-id-hash id public-key global?)]
     {::async-storage/set! {hash true}
      :db                  (assoc-in db [:information-box-states id] true)}))
@@ -310,7 +310,7 @@
 (rf/defn load-information-box-states
   {:events [:load-information-box-states]}
   [{:keys [db]}]
-  (let [public-key            (get-in db [:multiaccount :public-key])
+  (let [public-key            (get-in db [:profile/profile :public-key])
         {:keys [keys hashes]} (reduce (fn [acc {:keys [id global?]}]
                                         (let [hash (information-box-id-hash
                                                     id

--- a/src/status_im/fleet/core.cljs
+++ b/src/status_im/fleet/core.cljs
@@ -75,7 +75,7 @@
 (rf/defn save
   {:events [:fleet.ui/save-fleet-confirmed]}
   [{:keys [db now] :as cofx} fleet]
-  (let [old-fleet (get-in db [:multiaccount :fleet])]
+  (let [old-fleet (get-in db [:profile/profile :fleet])]
     (when (not= fleet old-fleet)
       (rf/merge
        cofx

--- a/src/status_im/integration_test.cljs
+++ b/src/status_im/integration_test.cljs
@@ -73,7 +73,7 @@
    (rf-test/wait-for
      ;; use initialize-view because it has the longest avg. time and
      ;; is dispatched by initialize-multiaccounts (last non-view event)
-     [:get-profiles-overview-success]
+     [:profile/get-profiles-overview-success]
      (assert-app-initialized))))
 
 (deftest create-account-test
@@ -81,7 +81,7 @@
   (rf-test/run-test-async
    (initialize-app!) ; initialize app
    (rf-test/wait-for
-     [:get-profiles-overview-success]
+     [:profile/get-profiles-overview-success]
      (generate-and-derive-addresses!) ; generate 5 new keys
      (rf-test/wait-for
        [:multiaccount-generate-and-derive-addresses-success] ; wait for the keys
@@ -97,7 +97,7 @@
   (rf-test/run-test-async
    (initialize-app!) ; initialize app
    (rf-test/wait-for
-     [:get-profiles-overview-success]
+     [:profile/get-profiles-overview-success]
      (generate-and-derive-addresses!) ; generate 5 new keys
      (rf-test/wait-for
        [:multiaccount-generate-and-derive-addresses-success]
@@ -120,7 +120,7 @@
   (rf-test/run-test-async
    (initialize-app!)
    (rf-test/wait-for
-     [:get-profiles-overview-success]
+     [:profile/get-profiles-overview-success]
      (generate-and-derive-addresses!) ; generate 5 new keys
      (rf-test/wait-for
        [:multiaccount-generate-and-derive-addresses-success]
@@ -140,7 +140,7 @@
   (rf-test/run-test-async
    (initialize-app!)
    (rf-test/wait-for
-     [:get-profiles-overview-success]
+     [:profile/get-profiles-overview-success]
      (generate-and-derive-addresses!)
      (rf-test/wait-for
        [:multiaccount-generate-and-derive-addresses-success]
@@ -179,7 +179,7 @@
   (rf-test/run-test-async
    (initialize-app!)
    (rf-test/wait-for
-     [:get-profiles-overview-success]
+     [:profile/get-profiles-overview-success]
      (generate-and-derive-addresses!)
      (rf-test/wait-for
        [:multiaccount-generate-and-derive-addresses-success] ; wait for the keys
@@ -200,7 +200,7 @@
   (rf-test/run-test-async
    (initialize-app!)
    (rf-test/wait-for
-     [:get-profiles-overview-success]
+     [:profile/get-profiles-overview-success]
      (generate-and-derive-addresses!)
      (rf-test/wait-for
        [:multiaccount-generate-and-derive-addresses-success] ; wait for the keys
@@ -224,7 +224,7 @@
   (rf-test/run-test-async
    (initialize-app!)
    (rf-test/wait-for
-     [:get-profiles-overview-success]
+     [:profile/get-profiles-overview-success]
      (generate-and-derive-addresses!)
      (rf-test/wait-for
        [:multiaccount-generate-and-derive-addresses-success] ; wait for the keys
@@ -259,7 +259,7 @@
     (rf-test/run-test-async
      (initialize-app!)
      (rf-test/wait-for
-       [:get-profiles-overview-success]
+       [:profile/get-profiles-overview-success]
        (generate-and-derive-addresses!)
        (rf-test/wait-for
          [:multiaccount-generate-and-derive-addresses-success]

--- a/src/status_im/integration_test.cljs
+++ b/src/status_im/integration_test.cljs
@@ -150,11 +150,11 @@
          (assert-messenger-started)
          (rf/dispatch-sync [:set-in [:my-profile/seed :step] :12-words]) ; display seed phrase to user
          (rf/dispatch-sync [:my-profile/enter-two-random-words]) ; begin prompting user for seed words
-         (let [ma    @(rf/subscribe [:profile/profile])
-               seed  @(rf/subscribe [:my-profile/seed])
-               word1 (second (:first-word seed))
-               word2 (second (:second-word seed))]
-           (is (= 12 (count (string/split (:mnemonic ma) #" ")))) ; assert 12-word seed phrase
+         (let [{:keys [mnemonic]} @(rf/subscribe [:profile/profile])
+               seed               @(rf/subscribe [:my-profile/seed])
+               word1              (second (:first-word seed))
+               word2              (second (:second-word seed))]
+           (is (= 12 (count (string/split mnemonic #" ")))) ; assert 12-word seed phrase
            (rf/dispatch-sync [:set-in [:my-profile/seed :word] word1])
            (rf/dispatch-sync [:my-profile/set-step :second-word])
            (rf/dispatch-sync [:set-in [:my-profile/seed :word] word2])

--- a/src/status_im/keycard/backup_key.cljs
+++ b/src/status_im/keycard/backup_key.cljs
@@ -17,7 +17,7 @@
   (rf/merge cofx
             {:db (-> db
                      (assoc-in [:keycard :creating-backup?] backup-type))}
-            (when (:multiaccount db)
+            (when (:profile/profile db)
               (navigation/navigate-to :my-profile nil))
             (navigation/navigate-to :seed-phrase nil)))
 

--- a/src/status_im/keycard/change_pin.cljs
+++ b/src/status_im/keycard/change_pin.cljs
@@ -152,7 +152,7 @@
               (if puk-restore?
                 (navigation/navigate-to :multiaccounts nil)
                 (navigation/set-stack-root :profile-stack [:my-profile :keycard-settings]))
-              (when (:multiaccounts/login db)
+              (when (:profile/login db)
                 (common/get-keys-from-keycard)))))
 
 (rf/defn on-change-puk-success

--- a/src/status_im/keycard/core.cljs
+++ b/src/status_im/keycard/core.cljs
@@ -543,7 +543,7 @@
           :not-paired       :pair
           :no-pairing-slots :no-slots
           :init             :card-ready
-          :multiaccount     :import-multiaccount
+          :profile/profile  :import-multiaccount
           :begin))})
 
 (rf/defn show-no-keycard-applet-alert
@@ -586,7 +586,7 @@
                      (common/clear-on-card-read)
                      (load-pin-screen)))))
 
-              (when (and (= card-state :multiaccount)
+              (when (and (= card-state :profile/profile)
                          (= flow :import))
                 (if (common/find-multiaccount-by-key-uid db key-uid)
                   (multiaccounts.recover/show-existing-multiaccount-alert key-uid)
@@ -599,7 +599,7 @@
                   (navigation/navigate-to :keycard-recovery-no-key nil)
                   (show-no-keycard-applet-alert)))
 
-              (when (and (= card-state :multiaccount)
+              (when (and (= card-state :profile/profile)
                          (#{:create :recovery} flow))
                 (show-keycard-has-multiaccount-alert)))))
 

--- a/src/status_im/keycard/core_test.cljs
+++ b/src/status_im/keycard/core_test.cljs
@@ -62,7 +62,7 @@
            "04f2a432677a1b7c4f1bb22078135821d1d10fce23422297b5c808a545f2b61cdba38ee7394762172fc6ff5e9e28db7535e555efe2812905ffd4e0c25e82a98ae8"
            "whisper-address" "87df2285f90b71221fab6267b7cb37532fedbb1f"
            "wallet-address" "7e92236392a850980d00d0cd2a4b92886bd7fe7b"})
-        [:db :keycard :multiaccount])
+        [:db :keycard :profile/profile])
        [:whisper-private-key
         :whisper-public-key
         :encryption-public-key

--- a/src/status_im/keycard/delete_key.cljs
+++ b/src/status_im/keycard/delete_key.cljs
@@ -11,7 +11,7 @@
 (rf/defn delete-card
   [{:keys [db] :as cofx}]
   (let [key-uid              (get-in db [:keycard :application-info :key-uid])
-        multiaccount-key-uid (get-in db [:multiaccount :key-uid])]
+        multiaccount-key-uid (get-in db [:profile/profile :key-uid])]
     (if (and key-uid
              (= key-uid multiaccount-key-uid))
       {:keycard/delete nil}

--- a/src/status_im/keycard/login.cljs
+++ b/src/status_im/keycard/login.cljs
@@ -69,9 +69,9 @@
                                    :error      nil
                                    :status     nil))
       :hide-popover nil})
-   (when (:multiaccount db)
+   (when (:profile/profile db)
      (navigation/navigate-to :my-profile nil))
-   (when-not (:multiaccounts/login db)
+   (when-not (:profile/login db)
      (if (:popover/popover db)
        (navigation/navigate-replace :keycard-pin nil)
        (navigation/navigate-to :keycard-pin nil)))))
@@ -94,7 +94,7 @@
         key-uid (get-in db [:keycard :application-info :key-uid])
         paired? (get-in db [:keycard :application-info :paired?])
         multiaccount (get-in db
-                             [:multiaccounts/multiaccounts (get-in db [:multiaccounts/login :key-uid])])
+                             [:profile/profiles-overview (get-in db [:profile/login :key-uid])])
         multiaccount-key-uid (get multiaccount :key-uid)
         multiaccount-mismatch? (or (nil? multiaccount)
                                    (not= multiaccount-key-uid key-uid))]
@@ -151,7 +151,7 @@
                                :multiaccounts-stack
                                [:multiaccounts
                                 :keycard-login-pin])
-    (let [{:keys [name]}    (get-in db [:multiaccounts/multiaccounts key-uid])
+    (let [{:keys [name]}    (get-in db [:profile/profiles-overview key-uid])
           multiaccount-data (types/clj->json {:name    name
                                               :key-uid key-uid})
           account-data      {:key-uid               key-uid
@@ -161,14 +161,14 @@
        (-> db
            (assoc-in [:keycard :pin :status] nil)
            (assoc-in [:keycard :pin :login] [])
-           (assoc-in [:keycard :multiaccount]
+           (assoc-in [:keycard :profile/profile]
                      (update account-data :whisper-public-key ethereum/normalized-hex))
            (assoc-in [:keycard :flow] nil)
-           (update :multiaccounts/login assoc
-                   :password            encryption-public-key
-                   :key-uid             key-uid
-                   :name                name
-                   :save-password?      true))
+           (update :profile/login  assoc
+                   :password       encryption-public-key
+                   :key-uid        key-uid
+                   :name           name
+                   :save-password? true))
        :keycard/login-with-keycard
        {:multiaccount-data multiaccount-data
         :key-uid           key-uid

--- a/src/status_im/keycard/recovery.cljs
+++ b/src/status_im/keycard/recovery.cljs
@@ -134,7 +134,7 @@
 (rf/defn intro-wizard
   {:events [:multiaccounts.create.ui/intro-wizard]}
   [{:keys [db] :as cofx}]
-  (let [accs (get db :multiaccounts/multiaccounts)]
+  (let [accs (get db :profile/profiles-overview)]
     (rf/merge cofx
               {:db (-> db
                        (update :keycard dissoc :flow)
@@ -157,7 +157,7 @@
    :interceptors [(re-frame/inject-cofx :random-guid-generator)
                   (re-frame/inject-cofx ::multiaccounts.create/get-signing-phrase)]}
   [{:keys [db] :as cofx}]
-  (let [{{:keys [multiaccount secrets flow]} :keycard} db
+  (let [{{:keys [secrets flow] :profile/keys [profile]} :keycard} db
         {:keys [address
                 name
                 public-key
@@ -172,7 +172,7 @@
                 instance-uid
                 key-uid
                 recovered]}
-        multiaccount
+        profile
         {:keys [pairing paired-on]} secrets
         {:keys [name]}
         (if (nil? name)
@@ -238,7 +238,7 @@
               (multiaccounts.model/logged-in? db)
               (navigation/set-stack-root :profile-stack [:my-profile :keycard-settings])
 
-              (:multiaccounts/login db)
+              (:profile/login db)
               (return-to-keycard-login)
 
               :else
@@ -263,9 +263,9 @@
   [{:keys [db] :as cofx}]
   (let [pairing         (get-in db [:keycard :secrets :pairing])
         paired-on       (get-in db [:keycard :secrets :paired-on])
-        instance-uid    (get-in db [:keycard :multiaccount :instance-uid])
+        instance-uid    (get-in db [:keycard :profile/profile :instance-uid])
         account         (-> db
-                            :multiaccounts/login
+                            :profile/login
                             (assoc :keycard-pairing pairing)
                             (assoc :save-password? false))
         key-uid         (-> account :key-uid)
@@ -275,14 +275,15 @@
         password        (ethereum/sha3 (security/safe-unmask-data (get-in db
                                                                           [:keycard
                                                                            :migration-password])))
-        encryption-pass (get-in db [:keycard :multiaccount :encryption-public-key])
+        encryption-pass (get-in db [:keycard :profile/profile :encryption-public-key])
         login-params    {:key-uid           key-uid
                          :multiaccount-data (types/clj->json account)
                          :password          encryption-pass
-                         :chat-key          (get-in db [:keycard :multiaccount :whisper-private-key])}]
+                         :chat-key          (get-in db
+                                                    [:keycard :profile/profile :whisper-private-key])}]
     {:db                (-> db
-                            (assoc-in [:multiaccounts/multiaccounts key-uid :keycard-pairing] pairing)
-                            (assoc :multiaccounts/login account)
+                            (assoc-in [:profile/profiles-overview key-uid :keycard-pairing] pairing)
+                            (assoc :profile/login account)
                             (assoc :auth-method keychain/auth-method-none)
                             (update :keycard dissoc :flow :migration-password)
                             (dissoc :recovered-account?))
@@ -290,7 +291,7 @@
 
 (rf/defn delete-multiaccount
   [{:keys [db]}]
-  (let [key-uid (get-in db [:multiaccounts/login :key-uid])]
+  (let [key-uid (get-in db [:profile/login :key-uid])]
     {:keycard/delete-multiaccount-before-migration
      {:key-uid    key-uid
       :on-error   #(re-frame/dispatch [::delete-multiaccount-error %])
@@ -313,7 +314,7 @@
      cofx
      {:db (-> db
               (assoc-in
-               [:keycard :multiaccount]
+               [:keycard :profile/profile]
                (-> account-data
                    (update :address ethereum/normalized-hex)
                    (update :whisper-address ethereum/normalized-hex)
@@ -323,7 +324,7 @@
                    (update :whisper-public-key ethereum/normalized-hex)
                    (update :wallet-public-key ethereum/normalized-hex)
                    (update :wallet-root-public-key ethereum/normalized-hex)
-                   (update :instance-uid #(get-in db [:keycard :multiaccount :instance-uid] %))))
+                   (update :instance-uid #(get-in db [:keycard :profile/profile :instance-uid] %))))
               (assoc-in [:keycard :multiaccount-wallet-address] (:wallet-address account-data))
               (assoc-in [:keycard :multiaccount-whisper-public-key] (:whisper-public-key account-data))
               (assoc-in [:keycard :pin :status] nil)
@@ -362,7 +363,7 @@
         pin               (common/vector->string (get-in db [:keycard :pin :import-multiaccount]))]
     (rf/merge cofx
               {:db (-> db
-                       (assoc-in [:keycard :multiaccount :instance-uid] instance-uid)
+                       (assoc-in [:keycard :profile/profile :instance-uid] instance-uid)
                        (assoc-in [:keycard :pin :status] :verifying)
                        (assoc-in [:keycard :secrets]
                                  {:pairing   pairing'
@@ -387,7 +388,7 @@
   (rf/merge
    cofx
    {:db (update-in db
-                   [:keycard :multiaccount]
+                   [:keycard :profile/profile]
                    (fn [multiacc]
                      (assoc multiacc
                             :recovered (get db :recovered-account?)

--- a/src/status_im/keycard/sign.cljs
+++ b/src/status_im/keycard/sign.cljs
@@ -12,7 +12,7 @@
   {:events [:keycard/sign]}
   [{:keys [db] :as cofx} hash on-success]
   (let [card-connected?     (get-in db [:keycard :card-connected?])
-        key-uid             (get-in db [:multiaccount :key-uid])
+        key-uid             (get-in db [:profile/profile :key-uid])
         keycard-key-uid     (get-in db [:keycard :application-info :key-uid])
         keycard-pin-retries (get-in db [:keycard :application-info :pin-retry-counter])
         keycard-match?      (= key-uid keycard-key-uid)
@@ -28,7 +28,7 @@
                                (when (ethereum/address= from address)
                                  (reduced path)))
                              nil
-                             (:multiaccount/accounts db))]
+                             (:profile/wallet-accounts db))]
     (cond
       (not keycard-match?)
       (common/show-wrong-keycard-alert cofx)

--- a/src/status_im/keycard/simulated_keycard.cljs
+++ b/src/status_im/keycard/simulated_keycard.cljs
@@ -44,7 +44,7 @@
      :initialized? true
      :pin-retry-counter 3
      :puk-retry-counter 5
-     :key-uid (get-in @re-frame.db/app-db [:multiaccounts/login :key-uid])})
+     :key-uid (get-in @re-frame.db/app-db [:profile/login :key-uid])})
   (swap! state assoc :pin default-pin :puk default-puk :password kk1-password)
   (connect-card))
 
@@ -389,11 +389,11 @@
    pin
    on-failure
    #(let [{:keys [key-uid wallet-root-address]}
-          (get @re-frame.db/app-db :multiaccount)
-          accounts (get @re-frame.db/app-db :multiaccount/accounts)
+          (get @re-frame.db/app-db :profile/profile)
+          accounts (get @re-frame.db/app-db :profile/wallet-accounts)
           hashed-password account-password
           path-num (inc (get-in @re-frame.db/app-db
-                                [:multiaccount :latest-derived-path]))
+                                [:profile/profile :latest-derived-path]))
           path (str "m/" path-num)]
       (native-module/multiaccount-load-account
        wallet-root-address
@@ -460,8 +460,8 @@
                         (when (= path (:path acc))
                           (reduced address)))
                       nil
-                      (:multiaccount/accounts @re-frame.db/app-db))
-                     (-> (:multiaccount/accounts @re-frame.db/app-db)
+                      (:profile/wallet-accounts @re-frame.db/app-db))
+                     (-> (:profile/wallet-accounts @re-frame.db/app-db)
                          first
                          :address))
                    password account-password]

--- a/src/status_im/keycard/unpair.cljs
+++ b/src/status_im/keycard/unpair.cljs
@@ -119,13 +119,13 @@
 
 (defn handle-account-removal
   [{:keys [db] :as cofx} keys-removed-from-card?]
-  (let [key-uid      (get-in db [:multiaccount :key-uid])
+  (let [key-uid      (get-in db [:profile/profile :key-uid])
         instance-uid (get-in db [:keycard :application-info :instance-uid])
         pairings     (get-in db [:keycard :pairings])]
     (rf/merge
      cofx
      {:db                               (-> db
-                                            (update :multiaccounts/multiaccounts dissoc key-uid)
+                                            (update :profile/profiles-overview dissoc key-uid)
                                             (assoc-in [:keycard :secrets] nil)
                                             (update-in [:keycard :pairings]
                                                        dissoc

--- a/src/status_im/keycard/wallet.cljs
+++ b/src/status_im/keycard/wallet.cljs
@@ -34,7 +34,7 @@
 (rf/defn generate-new-keycard-account
   {:events [:wallet.accounts/generate-new-keycard-account]}
   [{:keys [db]}]
-  (let [path-num (inc (get-in db [:multiaccount :latest-derived-path]))
+  (let [path-num (inc (get-in db [:profile/profile :latest-derived-path]))
         path     (str constants/path-wallet-root "/" path-num)
         pin      (common/vector->string (get-in db [:keycard :pin :export-key]))]
     {:db

--- a/src/status_im/log_level/core.cljs
+++ b/src/status_im/log_level/core.cljs
@@ -8,7 +8,7 @@
 (rf/defn save-log-level
   {:events [:log-level.ui/change-log-level-confirmed]}
   [{:keys [db now] :as cofx} log-level]
-  (let [old-log-level (get-in db [:multiaccount :log-level])]
+  (let [old-log-level (get-in db [:profile/profile :log-level])]
     (when (not= old-log-level log-level)
       (rf/merge cofx
                 (multiaccounts.update/multiaccount-update

--- a/src/status_im/mailserver/core.cljs
+++ b/src/status_im/mailserver/core.cljs
@@ -36,7 +36,7 @@
 
 (defn preferred-mailserver-id
   [db]
-  (get-in db [:multiaccount :pinned-mailservers (node/current-fleet-key db)]))
+  (get-in db [:profile/profile :pinned-mailservers (node/current-fleet-key db)]))
 
 (defn connection-error-dismissed
   [db]
@@ -61,7 +61,7 @@
 
 (defn fetch-use-mailservers?
   [{:keys [db]}]
-  (get-in db [:multiaccount :use-mailservers?]))
+  (get-in db [:profile/profile :use-mailservers?]))
 
 (defonce showing-connection-error-popup? (atom false))
 
@@ -105,7 +105,7 @@
   [{:keys [db] :as cofx}]
   (let [current-fleet     (node/current-fleet-key db)
         error-dismissed?  (connection-error-dismissed db)
-        pinned-mailserver (get-in db [:multiaccount :pinned-mailservers current-fleet])]
+        pinned-mailserver (get-in db [:profile/profile :pinned-mailservers current-fleet])]
     (when (and pinned-mailserver
                (not error-dismissed?)
                (not @showing-connection-error-popup?))
@@ -266,9 +266,9 @@
 (rf/defn upsert
   {:events       [:mailserver.ui/save-pressed]
    :interceptors [(re-frame/inject-cofx :random-id-generator)]}
-  [{{:mailserver.edit/keys [mailserver] :keys [multiaccount] :as db} :db
-    random-id-generator                                              :random-id-generator
-    :as                                                              cofx}]
+  [{{:mailserver.edit/keys [mailserver] :profile/keys [profile] :as db} :db
+    random-id-generator                                                 :random-id-generator
+    :as                                                                 cofx}]
 
   (let [{:keys [name url id]} mailserver
         current-fleet         (node/current-fleet-key db)]
@@ -364,7 +364,7 @@
   {:events [:mailserver.ui/connect-confirmed]}
   [{:keys [db] :as cofx} current-fleet mailserver-id]
   (let [pinned-mailservers (-> db
-                               (get-in [:multiaccount :pinned-mailservers])
+                               (get-in [:profile/profile :pinned-mailservers])
                                (assoc current-fleet mailserver-id))]
     (rf/merge cofx
               {:db            (assoc db :mailserver/current-id mailserver-id)
@@ -379,7 +379,7 @@
   [{:keys [db] :as cofx}]
   (let [current-fleet      (node/current-fleet-key db)
         pinned-mailservers (-> db
-                               (get-in [:multiaccount :pinned-mailservers])
+                               (get-in [:profile/profile :pinned-mailservers])
                                (dissoc current-fleet))]
     (rf/merge cofx
               {:json-rpc/call [{:method     "wakuext_setPinnedMailservers"
@@ -396,7 +396,7 @@
   [{:keys [db] :as cofx}]
   (let [current-fleet      (node/current-fleet-key db)
         mailserver-id      (:mailserver/current-id db)
-        pinned-mailservers (get-in db [:multiaccount :pinned-mailservers])]
+        pinned-mailservers (get-in db [:profile/profile :pinned-mailservers])]
     (rf/merge cofx
               (multiaccounts.update/multiaccount-update
                :pinned-mailservers

--- a/src/status_im/mobile_sync_settings/core.cljs
+++ b/src/status_im/mobile_sync_settings/core.cljs
@@ -12,7 +12,7 @@
 
 (rf/defn sheet-defaults
   [{:keys [db]}]
-  (let [remember-choice? (get-in db [:multiaccount :remember-syncing-choice?])]
+  (let [remember-choice? (get-in db [:profile/profile :remember-syncing-choice?])]
     {:db (assoc db
                 :mobile-network/remember-choice?
                 (or (nil? remember-choice?)
@@ -22,7 +22,7 @@
   [{:keys [db] :as cofx}]
   (let [initialized?                       (get db :network-status/initialized?)
         logged-in?                         (multiaccounts.model/logged-in? db)
-        {:keys [remember-syncing-choice?]} (:multiaccount db)]
+        {:keys [remember-syncing-choice?]} (:profile/profile db)]
     (apply
      rf/merge
      cofx
@@ -91,13 +91,13 @@
 (rf/defn mobile-network-set-syncing
   {:events [:mobile-network/set-syncing]}
   [{:keys [db] :as cofx} syncing?]
-  (let [{:keys [remember-syncing-choice?]} (:multiaccount db)]
+  (let [{:keys [remember-syncing-choice?]} (:profile/profile db)]
     ((apply-settings syncing? remember-syncing-choice?) cofx)))
 
 (rf/defn mobile-network-ask-on-mobile-network?
   {:events [:mobile-network/ask-on-mobile-network?]}
   [{:keys [db] :as cofx} ask?]
-  (let [{:keys [syncing-on-mobile-network?]} (:multiaccount db)]
+  (let [{:keys [syncing-on-mobile-network?]} (:profile/profile db)]
     ((apply-settings syncing-on-mobile-network? (not ask?)) cofx)))
 
 (rf/defn mobile-network-restore-defaults

--- a/src/status_im/multiaccounts/biometric/core.cljs
+++ b/src/status_im/multiaccounts/biometric/core.cljs
@@ -101,7 +101,7 @@
        (.catch #(cb (generate-error-result %))))))
 
 (re-frame/reg-fx
- :get-supported-biometric-auth
+ :biometric/get-supported-biometric-auth
  (fn []
    (let [callback #(re-frame/dispatch [:init.callback/get-supported-biometric-auth-success %])]
      ;;NOTE: if we can't save user password, we can't support biometrics

--- a/src/status_im/multiaccounts/biometric/core.cljs
+++ b/src/status_im/multiaccounts/biometric/core.cljs
@@ -149,8 +149,8 @@
 
 (rf/defn update-biometric
   [{db :db :as cofx} biometric-auth?]
-  (let [key-uid (or (get-in db [:multiaccount :key-uid])
-                    (get-in db [:multiaccounts/login :key-uid]))]
+  (let [key-uid (or (get-in db [:profile/profile :key-uid])
+                    (get-in db [:profile/login :key-uid]))]
     (rf/merge cofx
               (keychain/save-auth-method
                key-uid
@@ -214,7 +214,7 @@
    cofx
    {:db (-> db
             (assoc :auth-method keychain/auth-method-none)
-            (assoc-in [:multiaccounts/login :save-password?] false))}
+            (assoc-in [:profile/login :save-password?] false))}
    (popover/hide-popover)))
 
 (rf/defn setup-done

--- a/src/status_im/multiaccounts/core.cljs
+++ b/src/status_im/multiaccounts/core.cljs
@@ -120,7 +120,7 @@
 
 (rf/defn switch-preview-privacy-mode-flag
   [{:keys [db]}]
-  (let [private? (get-in db [:multiaccount :preview-privacy?])]
+  (let [private? (get-in db [:profile/profile :preview-privacy?])]
     {::blank-preview-flag-changed private?}))
 
 (re-frame/reg-fx
@@ -153,7 +153,7 @@
   {:events [:multiaccounts.ui/switch-theme]}
   [cofx theme view-id]
   (let [theme (or theme
-                  (get-in cofx [:db :multiaccount :appearance])
+                  (get-in cofx [:db :profile/profile :appearance])
                   constants/theme-type-dark)]
     {:multiaccounts.ui/switch-theme-fx [theme view-id false]}))
 
@@ -180,7 +180,7 @@
 (rf/defn save-profile-picture
   {:events [::save-profile-picture]}
   [cofx path ax ay bx by]
-  (let [key-uid (get-in cofx [:db :multiaccount :key-uid])]
+  (let [key-uid (get-in cofx [:db :profile/profile :key-uid])]
     (rf/merge cofx
               {:json-rpc/call [{:method     "multiaccounts_storeIdentityImage"
                                 :params     [key-uid (clean-path path) ax ay bx by]
@@ -191,7 +191,7 @@
 (rf/defn save-profile-picture-from-url
   {:events [::save-profile-picture-from-url]}
   [cofx url]
-  (let [key-uid (get-in cofx [:db :multiaccount :key-uid])]
+  (let [key-uid (get-in cofx [:db :profile/profile :key-uid])]
     (rf/merge cofx
               {:json-rpc/call [{:method     "multiaccounts_storeIdentityImageFromURL"
                                 :params     [key-uid url]
@@ -207,7 +207,7 @@
 (rf/defn delete-profile-picture
   {:events [::delete-profile-picture]}
   [cofx name]
-  (let [key-uid (get-in cofx [:db :multiaccount :key-uid])]
+  (let [key-uid (get-in cofx [:db :profile/profile :key-uid])]
     (rf/merge cofx
               {:json-rpc/call [{:method     "multiaccounts_deleteIdentityImage"
                                 :params     [key-uid]
@@ -219,7 +219,7 @@
 
 (rf/defn get-profile-picture
   [cofx]
-  (let [key-uid (get-in cofx [:db :multiaccount :key-uid])]
+  (let [key-uid (get-in cofx [:db :profile/profile :key-uid])]
     {:json-rpc/call [{:method     "multiaccounts_getIdentityImages"
                       :params     [key-uid]
                       :on-success #(re-frame/dispatch [::update-local-picture %])}]}))

--- a/src/status_im/multiaccounts/create/core.cljs
+++ b/src/status_im/multiaccounts/create/core.cljs
@@ -225,13 +225,13 @@
                  :keycard-pairing      keycard-pairing
                  :keycard-paired-on    keycard-paired-on))
         db (assoc db
-                  :multiaccounts/login      {:key-uid    key-uid
+                  :profile/login            {:key-uid    key-uid
                                              :name       name
                                              :password   password
                                              :creating?  true
                                              :processing true}
-                  :multiaccount             new-multiaccount
-                  :multiaccount/accounts    [wallet-account]
+                  :profile/profile          new-multiaccount
+                  :profile/wallet-accounts  [wallet-account]
                   :networks/current-network config/default-network
                   :networks/networks        (data-store.settings/rpc->networks config/default-networks))
         settings (assoc new-multiaccount

--- a/src/status_im/multiaccounts/key_storage/core_test.cljs
+++ b/src/status_im/multiaccounts/key_storage/core_test.cljs
@@ -1,30 +1,7 @@
 (ns status-im.multiaccounts.key-storage.core-test
   (:require [cljs.test :refer-macros [deftest is testing]]
-            [clojure.string :as string]
             [status-im.multiaccounts.key-storage.core :as models]
             [utils.security.core :as security]))
-
-(deftest move-keystore-checked
-  (testing "Checks checkbox on-press"
-    (let [res (models/move-keystore-checked {:db {}} true)]
-      (is (= true (get-in res [:db :multiaccounts/key-storage :move-keystore-checked?]))))))
-
-(deftest seed-phrase-input-changed
-  (testing "nil seed phrase shape is invalid"
-    (let [res (models/seed-phrase-input-changed {:db {}} (security/mask-data nil))]
-      (is (get-in res [:db :multiaccounts/key-storage :seed-shape-invalid?]))))
-
-  (let [sample-phrase "h h h h h h h h h h h H" ;; 12 characters
-        res           (models/seed-phrase-input-changed {:db {}} (security/mask-data sample-phrase))]
-    (testing "Seed shape for 12 letter seed phrase is valid"
-      (is (false? (get-in res [:db :multiaccounts/key-storage :seed-shape-invalid?]))))
-
-    (testing "Seed words counted correctly"
-      (is (= 12 (get-in res [:db :multiaccounts/key-storage :seed-word-count]))))
-
-    (testing "Seed phrase is lowercased"
-      (is (= (get-in res [:db :multiaccounts/key-storage :seed-phrase])
-             (string/lower-case sample-phrase))))))
 
 (def seed-key-uid-pair
   {:seed-phrase "rocket mixed rebel affair umbrella legal resemble scene virus park deposit cargo"

--- a/src/status_im/multiaccounts/login/core_test.cljs
+++ b/src/status_im/multiaccounts/login/core_test.cljs
@@ -11,16 +11,16 @@
                              :supported-biometric-auth false}}
           {:keys [db]} (login/save-password initial-cofx true)]
       (test/is (= false (contains? db :popover/popover)))
-      (test/is (= true (get-in db [:multiaccounts/login :save-password?])))
+      (test/is (= true (get-in db [:profile/login :save-password?])))
       (test/testing "uncheck save password"
         (let [{:keys [db]} (login/save-password {:db db} false)]
           (test/is (= false (contains? db :popover/popover)))
-          (test/is (= false (get-in db [:multiaccounts/login :save-password?])))))))
+          (test/is (= false (get-in db [:profile/login :save-password?])))))))
   (test/testing "check save password, biometric available"
     (let [initial-cofx {:db {:auth-method              keychain/auth-method-none
                              :supported-biometric-auth true}}
           {:keys [db]} (login/save-password initial-cofx true)]
-      (test/is (= true (get-in db [:multiaccounts/login :save-password?])))
+      (test/is (= true (get-in db [:profile/login :save-password?])))
       (test/testing "enable biometric auth"
         (let [{:keys [db] :as res} (biometric/enable {:db db})]
           (test/is (contains? res :biometric-auth/authenticate))
@@ -53,10 +53,10 @@
                                                :bioauth-message nil
                                                :bioauth-code    nil}))
                                             false)]
-      (test/is (= true (get-in db [:multiaccounts/login :save-password?])))
+      (test/is (= true (get-in db [:profile/login :save-password?])))
       ;; case 2 from https://github.com/status-im/status-mobile/issues/9573
       (test/is (= keychain/auth-method-biometric-prepare (:auth-method db)))
       (test/testing "disable biometric"
         (let [{:keys [db]} (biometric/disable {:db db})]
-          (test/is (= false (get-in db [:multiaccounts/login :save-password?])))
+          (test/is (= false (get-in db [:profile/login :save-password?])))
           (test/is (= keychain/auth-method-none (:auth-method db))))))))

--- a/src/status_im/multiaccounts/login/flow_test.cljs
+++ b/src/status_im/multiaccounts/login/flow_test.cljs
@@ -10,28 +10,28 @@
 (deftest on-password-input-submitted
   (testing
     "handling :multiaccounts.login.ui/password-input-submitted event"
-    (let [cofx {:db {:multiaccounts/login {:key-uid  "key-uid"
-                                           :password "password"
-                                           :name     "user"}}}
+    (let [cofx {:db {:profile/login {:key-uid  "key-uid"
+                                     :password "password"
+                                     :name     "user"}}}
           efx  (login.core/login cofx)]
       (testing "Change multiaccount."
         (is (= (::login.core/login efx)
                ["key-uid" "{\"name\":\"user\",\"key-uid\":\"key-uid\"}"
                 (ethereum/sha3 "password")])))
       (testing "start activity indicator"
-        (is (= (get-in efx [:db :multiaccounts/login :processing]) true))))))
+        (is (= (get-in efx [:db :profile/login :processing]) true))))))
 
 (deftest login-success
   (testing ":accounts.login.callback/login-success event received."
-    (let [db       {:multiaccounts/login {:address  "address"
-                                          :password "password"}
-                    :multiaccount        data/multiaccount}
+    (let [db       {:profile/login   {:address  "address"
+                                      :password "password"}
+                    :profile/profile data/multiaccount}
           cofx     {:db db}
           efx      (login.core/multiaccount-login-success cofx)
           json-rpc (into #{} (map :method (:json-rpc/call efx)))]
       ;; TODO: Account is now cleared only after all sign in fx are executed.
       ;; (testing ":accounts/login cleared."
-      ;;   (is (not (contains? new-db :multiaccounts/login))))
+      ;;   (is (not (contains? new-db :profile/login))))
       (testing "Check the rest of effects."
         (is (json-rpc "web3_clientVersion"))))))
 
@@ -44,7 +44,7 @@
          "04f43da85ff1c333f3e7277b9ac4df92c9120fbb251f1dede7d41286e8c055acfeb845f6d2654821afca25da119daff9043530b296ee0e28e202ba92ec5842d617"
          db
          {:keycard
-          {:multiaccount
+          {:profile/profile
            {:encryption-public-key epk
             :whisper-private-key wpk
             :wallet-address "83278851e290d2488b6add2a257259f5741a3b7d"

--- a/src/status_im/multiaccounts/logout/core.cljs
+++ b/src/status_im/multiaccounts/logout/core.cljs
@@ -21,8 +21,9 @@
                ::logout                              nil
                ::multiaccounts/webview-debug-changed false
                :keychain/clear-user-password         key-uid
-               :get-profiles-overview                #(re-frame/dispatch [:get-profiles-overview-success
-                                                                          %])}
+               :profile/get-profiles-overview        #(re-frame/dispatch
+                                                       [:profile/get-profiles-overview-success
+                                                        %])}
               (keychain/save-auth-method key-uid auth-method)
               (wallet/clear-timeouts)
               (init/initialize-app-db))))

--- a/src/status_im/multiaccounts/logout/core.cljs
+++ b/src/status_im/multiaccounts/logout/core.cljs
@@ -12,7 +12,7 @@
 (rf/defn logout-method
   {:events [::logout-method]}
   [{:keys [db] :as cofx} {:keys [auth-method logout?]}]
-  (let [key-uid (get-in db [:multiaccount :key-uid])]
+  (let [key-uid (get-in db [:profile/profile :key-uid])]
     (rf/merge cofx
               {:set-root                             :progress
                :chat.ui/clear-inputs                 nil
@@ -21,8 +21,8 @@
                ::logout                              nil
                ::multiaccounts/webview-debug-changed false
                :keychain/clear-user-password         key-uid
-               :setup/open-multiaccounts             #(re-frame/dispatch [:setup/initialize-multiaccounts
-                                                                          % {:logout? logout?}])}
+               :get-profiles-overview                #(re-frame/dispatch [:get-profiles-overview-success
+                                                                          %])}
               (keychain/save-auth-method key-uid auth-method)
               (wallet/clear-timeouts)
               (init/initialize-app-db))))
@@ -56,7 +56,7 @@
             (logout-method {:auth-method keychain/auth-method-biometric-prepare
                             :logout?     false})
             (fn [{:keys [db]}]
-              {:db (assoc-in db [:multiaccounts/login :save-password?] true)})))
+              {:db (assoc-in db [:profile/login :save-password?] true)})))
 
 (re-frame/reg-fx
  ::logout

--- a/src/status_im/multiaccounts/model.cljs
+++ b/src/status_im/multiaccounts/model.cljs
@@ -1,13 +1,5 @@
 (ns status-im.multiaccounts.model)
 
 (defn logged-in?
-  [{:keys [multiaccount]}]
-  (boolean multiaccount))
-
-(defn credentials
-  [cofx]
-  (select-keys (get-in cofx [:db :multiaccounts/login]) [:key-uid :password :save-password?]))
-
-(defn current-public-key
-  [cofx]
-  (get-in cofx [:db :multiaccount :public-key]))
+  [{:keys [profile/profile]}]
+  (boolean profile))

--- a/src/status_im/multiaccounts/model_test.cljs
+++ b/src/status_im/multiaccounts/model_test.cljs
@@ -4,6 +4,6 @@
 
 (deftest logged-in-test
   (testing "multiaccount is defined"
-    (is (multiaccounts.model/logged-in? {:multiaccount {}})))
+    (is (multiaccounts.model/logged-in? {:profile/profile {}})))
   (testing "multiaccount is not there"
     (is (not (multiaccounts.model/logged-in? {})))))

--- a/src/status_im/multiaccounts/recover/core.cljs
+++ b/src/status_im/multiaccounts/recover/core.cljs
@@ -29,7 +29,6 @@
   {:events [:multiaccounts.recover/passphrase-input-changed]}
   [{:keys [db]} masked-recovery-phrase]
   (let [recovery-phrase (security/safe-unmask-data masked-recovery-phrase)]
-    (println "recovery-phrase" recovery-phrase)
     {:db (update db
                  :intro-wizard          assoc
                  :passphrase            (string/lower-case recovery-phrase)

--- a/src/status_im/multiaccounts/recover/core_test.cljs
+++ b/src/status_im/multiaccounts/recover/core_test.cljs
@@ -73,13 +73,13 @@
 (deftest on-import-multiaccount-success
   (testing "importing a new multiaccount"
     (let [res (models/on-import-multiaccount-success
-               {:db {:multiaccounts/multiaccounts {:acc1 {}}}}
+               {:db {:profile/profiles-overview {:acc1 {}}}}
                {:key-uid :acc2}
                nil)]
       (is (nil? (:utils/show-confirmation res)))))
   (testing "importing an existing multiaccount"
     (let [res (models/on-import-multiaccount-success
-               {:db {:multiaccounts/multiaccounts {:acc1 {}}}}
+               {:db {:profile/profiles-overview {:acc1 {}}}}
                {:key-uid :acc1}
                nil)]
       (is (contains? res :utils/show-confirmation)))))

--- a/src/status_im/multiaccounts/reset_password/core.cljs
+++ b/src/status_im/multiaccounts/reset_password/core.cljs
@@ -35,7 +35,7 @@
 (rf/defn password-reset-success
   {:events [::password-reset-success]}
   [{:keys [db] :as cofx}]
-  (let [{:keys [key-uid]} (:multiaccount db)
+  (let [{:keys [key-uid]} (:profile/profile db)
         auth-method       (get db :auth-method keychain/auth-method-none)
         new-password      (get-in db [:multiaccount/reset-password-form-vals :new-password])]
     (rf/merge cofx
@@ -68,7 +68,7 @@
 (rf/defn handle-verification-success
   {:events [::handle-verification-success]}
   [{:keys [db] :as cofx} form-vals]
-  (let [{:keys [key-uid name]} (:multiaccount db)]
+  (let [{:keys [key-uid name]} (:profile/profile db)]
     (rf/merge cofx
               {::change-db-password [key-uid form-vals]
                :db                  (assoc db
@@ -98,4 +98,4 @@
   {::validate-current-password-and-reset
    (assoc form-vals
           :address
-          (get-in db [:multiaccount :wallet-root-address]))})
+          (get-in db [:profile/profile :wallet-root-address]))})

--- a/src/status_im/multiaccounts/update/core.cljs
+++ b/src/status_im/multiaccounts/update/core.cljs
@@ -48,7 +48,7 @@
           :on-success on-success}]}
 
        (when (#{:name :preferred-name} setting)
-         (constantly {:get-profiles-overview #(rf/dispatch [:multiaccounts.ui/update-name %])}))
+         (constantly {:profile/get-profiles-overview #(rf/dispatch [:multiaccounts.ui/update-name %])}))
 
        (when (and (not dont-sync?) (#{:name :preferred-name} setting))
          (send-contact-update))))))

--- a/src/status_im/multiaccounts/update/core.cljs
+++ b/src/status_im/multiaccounts/update/core.cljs
@@ -6,7 +6,7 @@
 
 (rf/defn send-contact-update
   [{:keys [db]}]
-  (let [{:keys [name preferred-name display-name address]} (:multiaccount db)]
+  (let [{:keys [name preferred-name display-name address]} (:profile/profile db)]
     {:json-rpc/call [{:method     "wakuext_sendContactUpdates"
                       :params     [(or preferred-name display-name name) ""]
                       :on-success #(log/debug "sent contact update")}]}))
@@ -16,7 +16,7 @@
   {:events [:multiaccounts.ui/update-name]}
   [{:keys [db] :as cofx} raw-multiaccounts-from-status-go]
   (let [{:keys [key-uid name preferred-name
-                display-name]} (:multiaccount db)
+                display-name]} (:profile/profile db)
         account                (some #(and (= (:key-uid %) key-uid) %) raw-multiaccounts-from-status-go)]
     (when-let [new-name (and account (or preferred-name display-name name))]
       (rf/merge cofx
@@ -30,7 +30,7 @@
   [{:keys [db] :as cofx}
    setting setting-value
    {:keys [dont-sync? on-success] :or {on-success #()}}]
-  (let [current-multiaccount (:multiaccount db)]
+  (let [current-multiaccount (:profile/profile db)]
     (if (empty? current-multiaccount)
       ;; NOTE: this should never happen, but if it does this is a critical error
       ;; and it is better to crash than risk having an unstable state
@@ -40,15 +40,15 @@
       (rf/merge
        cofx
        {:db (if setting-value
-              (assoc-in db [:multiaccount setting] setting-value)
-              (update db :multiaccount dissoc setting))
+              (assoc-in db [:profile/profile setting] setting-value)
+              (update db :profile/profile dissoc setting))
         :json-rpc/call
         [{:method     "settings_saveSetting"
           :params     [setting setting-value]
           :on-success on-success}]}
 
        (when (#{:name :preferred-name} setting)
-         (constantly {:setup/open-multiaccounts #(rf/dispatch [:multiaccounts.ui/update-name %])}))
+         (constantly {:get-profiles-overview #(rf/dispatch [:multiaccounts.ui/update-name %])}))
 
        (when (and (not dont-sync?) (#{:name :preferred-name} setting))
          (send-contact-update))))))
@@ -73,7 +73,7 @@
 
 (rf/defn optimistic
   [{:keys [db] :as cofx} setting setting-value]
-  (let [current-multiaccount (:multiaccount db)
+  (let [current-multiaccount (:profile/profile db)
         setting-value        (if (= :currency setting)
                                (keyword setting-value)
                                setting-value)
@@ -97,8 +97,8 @@
                                  (assoc db :stickers/recent-stickers recent-stickers-from-remote))
                                db)]
     {:db (if setting-value
-           (assoc-in db [:multiaccount setting] setting-value)
-           (update db :multiaccount dissoc setting))}))
+           (assoc-in db [:profile/profile setting] setting-value)
+           (update db :profile/profile dissoc setting))}))
 
 (rf/defn set-many-js
   [cofx settings-js]
@@ -119,7 +119,7 @@
   {:events [::toggle-opensea-nfts-visiblity]}
   [cofx visible?]
   (rf/merge cofx
-            {:db       (assoc-in (:db cofx) [:multiaccount :opensea-enabled?] visible?)
+            {:db       (assoc-in (:db cofx) [:profile/profile :opensea-enabled?] visible?)
              ;; need to add fully qualified namespace to counter circular deps
              :dispatch [:status-im.wallet.core/fetch-collectibles-collection]}
             (multiaccount-update :opensea-enabled? visible? {})))

--- a/src/status_im/multiaccounts/update/core_test.cljs
+++ b/src/status_im/multiaccounts/update/core_test.cljs
@@ -6,27 +6,27 @@
   ;;TODO this test case actually shows that we are doing a needless rpc call when
   ;;there is no changes, but it is an edge case that shouldn't really happen
   (let [efx      (multiaccounts.update/multiaccount-update
-                  {:db {:multiaccount {:not-empty "would throw an error if was empty"}}}
+                  {:db {:profile/profile {:not-empty "would throw an error if was empty"}}}
                   nil
                   nil
                   {})
         json-rpc (into #{} (map :method (:json-rpc/call efx)))]
     (is (json-rpc "settings_saveSetting"))
-    (is (= (get-in efx [:db :multiaccount]) {:not-empty "would throw an error if was empty"}))))
+    (is (= (get-in efx [:db :profile/profile]) {:not-empty "would throw an error if was empty"}))))
 
 (deftest test-clean-seed-phrase
   (let [efx      (multiaccounts.update/clean-seed-phrase
-                  {:db {:multiaccount {:mnemonic "lalalala"}}}
+                  {:db {:profile/profile {:mnemonic "lalalala"}}}
                   {})
         json-rpc (into #{} (map :method (:json-rpc/call efx)))]
     (is (json-rpc "settings_saveSetting"))
-    (is (nil? (get-in efx [:db :multiaccount :mnemonic])))))
+    (is (nil? (get-in efx [:db :profile/profile :mnemonic])))))
 
 (deftest test-update-multiaccount-account-name
-  (let [cofx                             {:db {:multiaccount {:key-uid        1
-                                                              :name           "name"
-                                                              :preferred-name "preferred-name"
-                                                              :display-name   "display-name"}}}
+  (let [cofx                             {:db {:profile/profile {:key-uid        1
+                                                                 :name           "name"
+                                                                 :preferred-name "preferred-name"
+                                                                 :display-name   "display-name"}}}
         raw-multiaccounts-from-status-go [{:key-uid 1 :name "old-name"}]]
     (testing "wrong account"
       (is (nil? (multiaccounts.update/update-multiaccount-account-name cofx []))))
@@ -46,11 +46,11 @@
              "preferred-name"))
         (is (new-account-name=
              (multiaccounts.update/update-multiaccount-account-name
-              (update-in cofx [:db :multiaccount] dissoc :preferred-name)
+              (update-in cofx [:db :profile/profile] dissoc :preferred-name)
               raw-multiaccounts-from-status-go)
              "display-name"))
         (is (new-account-name=
              (multiaccounts.update/update-multiaccount-account-name
-              (update-in cofx [:db :multiaccount] dissoc :preferred-name :display-name)
+              (update-in cofx [:db :profile/profile] dissoc :preferred-name :display-name)
               raw-multiaccounts-from-status-go)
              "name"))))))

--- a/src/status_im/network/core_test.cljs
+++ b/src/status_im/network/core_test.cljs
@@ -123,7 +123,7 @@
                                          :db                  {:networks/manage {:url   {:value "wrong"}
                                                                                  :chain {:value "1"}
                                                                                  :name  {:value "empty"}}
-                                                               :multiaccount    {}}})))))
+                                                               :profile/profile {}}})))))
 
 (deftest save-valid-network
   (testing "save a valid network"
@@ -133,7 +133,7 @@
                                                          :chain  {:value :mainnet}
                                                          :symbol {:value "symbol"}
                                                          :name   {:value "valid"}}
-                                     :multiaccount      {}
+                                     :profile/profile   {}
                                      :networks/networks {"random2"
                                                          {:id     "random2"
                                                           :name   "network-name"
@@ -156,7 +156,7 @@
                                                              :chain      {:value :custom}
                                                              :name       {:value "valid"}
                                                              :network-id {:value 1}}
-                                         :multiaccount      {}
+                                         :profile/profile   {}
                                          :networks/networks {"random"
                                                              {:id     "random"
                                                               :name   "network-name"
@@ -176,7 +176,7 @@
                                                          :name       {:value "valid"}
                                                          :symbol     {:value "symbol"}
                                                          :network-id {:value 5}}
-                                     :multiaccount      {}
+                                     :profile/profile   {}
                                      :networks/networks {"randomid"
                                                          {:id     "randomid"
                                                           :name   "network-name"

--- a/src/status_im/network/net_info.cljs
+++ b/src/status_im/network/net_info.cljs
@@ -13,7 +13,7 @@
             {:db (assoc db :network-status (if is-connected? :online :offline))}
             (when (and is-connected?
                        (or (not= (count (get-in db [:wallet :accounts]))
-                                 (count (get db :multiaccount/accounts)))
+                                 (count (get db :profile/wallet-accounts)))
                            (wallet/has-empty-balances? db)))
               (wallet/update-balances nil nil))))
 

--- a/src/status_im/node/core.cljs
+++ b/src/status_im/node/core.cljs
@@ -102,7 +102,7 @@
 (defn current-fleet-key
   [db]
   (keyword (get-in db
-                   [:multiaccount :fleet]
+                   [:profile/profile :fleet]
                    config/fleet)))
 
 (defn get-current-fleet
@@ -116,9 +116,9 @@
     (some #(string/includes? (str %) "waku") ks)))
 
 (defn get-multiaccount-node-config
-  [{:keys [multiaccount :networks/networks :networks/current-network]
+  [{:keys [profile/profile :networks/networks :networks/current-network]
     :as   db}]
-  (let [wakuv2-config (get multiaccount :wakuv2-config {})
+  (let [wakuv2-config (get profile :wakuv2-config {})
         current-fleet-key (current-fleet-key db)
         current-fleet (get-current-fleet db)
         wakuv2-enabled (wakuv2-enabled? current-fleet)
@@ -127,7 +127,7 @@
         {:keys [installation-id log-level
                 waku-bloom-filter-mode
                 custom-bootnodes custom-bootnodes-enabled?]}
-        multiaccount
+        profile
         use-custom-bootnodes (get custom-bootnodes-enabled? current-network)]
     (cond-> (get-in networks [current-network :config])
       :always
@@ -212,7 +212,7 @@ app-db"
 (rf/defn prepare-new-config
   "Use this function to apply settings to the current account node config"
   [{:keys [db]} {:keys [on-success]}]
-  (let [key-uid (get-in db [:multiaccount :key-uid])]
+  (let [key-uid (get-in db [:profile/profile :key-uid])]
     {::prepare-new-config [key-uid
                            (get-new-config db)
                            #(re-frame/dispatch

--- a/src/status_im/notifications/local.cljs
+++ b/src/status_im/notifications/local.cljs
@@ -110,12 +110,12 @@
        (= view-id :chat)))
 
 (defn show-message-pn?
-  [{{:keys [app-state multiaccount]} :db :as cofx}
+  [{{:keys [app-state profile/profile]} :db :as cofx}
    notification]
   (let [chat-id             (get-in notification [:body :chat :id])
         notification-author (get-in notification [:notificationAuthor :id])]
     (and
-     (not= notification-author (:public-key multiaccount))
+     (not= notification-author (:public-key profile))
      (or (= app-state "background")
          (not (foreground-chat? cofx chat-id))))))
 

--- a/src/status_im/pairing/core.cljs
+++ b/src/status_im/pairing/core.cljs
@@ -91,7 +91,7 @@
   "Set the name of the device"
   {:events [:pairing.ui/set-name-pressed]}
   [{:keys [db]} installation-name]
-  (let [our-installation-id (get-in db [:multiaccount :installation-id])]
+  (let [our-installation-id (get-in db [:profile/profile :installation-id])]
     {:pairing/set-installation-metadata [our-installation-id
                                          {:name       installation-name
                                           :deviceType utils.platform/os}]}))
@@ -195,7 +195,7 @@
 (rf/defn send-installation-messages
   {:events [:pairing.ui/synchronize-installation-pressed]}
   [{:keys [db]}]
-  (let [multiaccount                  (:multiaccount db)
+  (let [multiaccount                  (:profile/profile db)
         {:keys [name preferred-name]} multiaccount]
     {:json-rpc/call [{:method     "wakuext_syncDevices"
                       :params     [(or preferred-name name)]

--- a/src/status_im/profile/core.cljs
+++ b/src/status_im/profile/core.cljs
@@ -57,7 +57,7 @@
 (rf/defn enter-two-random-words
   {:events [:my-profile/enter-two-random-words]}
   [{:keys [db]}]
-  (let [{:keys [mnemonic]} (:multiaccount db)
+  (let [{:keys [mnemonic]} (:profile/profile db)
         shuffled-mnemonic  (shuffle (map-indexed vector (string/split mnemonic #" ")))]
     {:db (assoc db
                 :my-profile/seed
@@ -88,7 +88,7 @@
 (rf/defn show-profile
   {:events [:chat.ui/show-profile]}
   [{:keys [db]} identity ens-name]
-  (let [my-public-key (get-in db [:multiaccount :public-key])]
+  (let [my-public-key (get-in db [:profile/profile :public-key])]
     (if (not= my-public-key identity)
       {:db       (-> db
                      (assoc :contacts/identity identity)

--- a/src/status_im/qr_scanner/core.cljs
+++ b/src/status_im/qr_scanner/core.cljs
@@ -42,8 +42,8 @@
             (navigation/navigate-back)))
 
 (defn own-public-key?
-  [{:keys [multiaccount]} public-key]
-  (= (:public-key multiaccount) public-key))
+  [{:keys [profile/profile]} public-key]
+  (= (:public-key profile) public-key))
 
 (rf/defn handle-private-chat
   [{:keys [db] :as cofx} {:keys [chat-id]}]

--- a/src/status_im/signals/core.cljs
+++ b/src/status_im/signals/core.cljs
@@ -21,8 +21,8 @@
   (if error
     (cond->
       {:db (-> db
-               (update :multiaccounts/login dissoc :processing)
-               (assoc-in [:multiaccounts/login :error]
+               (update :profile/login dissoc :processing)
+               (assoc-in [:profile/login :error]
                          ;; NOTE: the only currently known error is
                          ;; "file is not a database" which occurs
                          ;; when the user inputs the wrong password
@@ -86,7 +86,7 @@
                   (assoc-in [:syncing :pairing-status] :connected)
 
                   received-account?
-                  (assoc-in [:syncing :multiaccount] multiaccount-data)
+                  (assoc-in [:syncing :profile/profile] multiaccount-data)
 
                   error-on-pairing?
                   (assoc-in [:syncing :pairing-status] :error)
@@ -120,7 +120,9 @@
         type         (.-type data)]
     (case type
       "node.login"              (status-node-started cofx (js->clj event-js :keywordize-keys true))
-      "backup.performed"        {:db (assoc-in db [:multiaccount :last-backup] (.-lastBackup event-js))}
+      "backup.performed"        {:db (assoc-in db
+                                      [:profile/profile :last-backup]
+                                      (.-lastBackup event-js))}
       "envelope.sent"           (transport.message/update-envelopes-status cofx
                                                                            (:ids
                                                                             (js->clj event-js

--- a/src/status_im/signing/core.cljs
+++ b/src/status_im/signing/core.cljs
@@ -245,8 +245,8 @@
          {:keys [data typed? pinless?] :as message}     :message
          :as                                            tx}
         (last queue)
-        keycard-multiaccount? (boolean (get-in db [:multiaccount :keycard-pairing]))
-        wallet-set-up-passed? (get-in db [:multiaccount :wallet-set-up-passed?])]
+        keycard-multiaccount? (boolean (get-in db [:profile/profile :keycard-pairing]))
+        wallet-set-up-passed? (get-in db [:profile/profile :wallet-set-up-passed?])]
     (if message
       (rf/merge
        cofx
@@ -349,7 +349,7 @@
   [{:keys [db] :as cofx} transaction-hash hashed-password
    {:keys [message-id chat-id from] :as tx-obj}]
   (let [{:keys [on-result symbol amount contract value]} (get db :signing/tx)
-        data                                             (str (get-in db [:multiaccount :public-key])
+        data                                             (str (get-in db [:profile/profile :public-key])
                                                               (subs transaction-hash 2))]
     (rf/merge
      cofx

--- a/src/status_im/transport/message/core.cljs
+++ b/src/status_im/transport/message/core.cljs
@@ -14,7 +14,6 @@
     [status-im.data-store.reactions :as data-store.reactions]
     [status-im.group-chats.core :as models.group]
     [status-im.multiaccounts.login.core :as multiaccounts.login]
-    [status-im.multiaccounts.model :as multiaccounts.model]
     [status-im.multiaccounts.update.core :as update.core]
     [status-im.pairing.core :as models.pairing]
     [utils.re-frame :as rf]
@@ -209,7 +208,7 @@
                                      new
                                      (not (= message-type
                                              constants/message-type-private-group-system-message))
-                                     (not (= from (multiaccounts.model/current-public-key {:db db}))))
+                                     (not (= from (get-in db [:profile/profile :public-key]))))
         tx-hash                 (and (.-commandParameters message-js)
                                      (.-commandParameters.transactionHash message-js))]
     (cond-> acc

--- a/src/status_im/ui/components/connectivity/view.cljs
+++ b/src/status_im/ui/components/connectivity/view.cljs
@@ -88,7 +88,7 @@
   (letsubs [{:keys [peers node mobile sync]}     [:connectivity/state]
             current-mailserver-name              [:mailserver/current-name]
             peers-count                          [:peers-count]
-            {:keys [syncing-on-mobile-network?]} [:multiaccount]]
+            {:keys [syncing-on-mobile-network?]} [:profile/profile]]
     [:<>
      [quo/header {:title (i18n/label :t/connection-status) :border-bottom false}]
      [quo/list-header (i18n/label :t/peer-to-peer)]

--- a/src/status_im/ui/components/invite/events.cljs
+++ b/src/status_im/ui/components/invite/events.cljs
@@ -13,7 +13,7 @@
 (rf/defn share-link
   {:events [:invite.events/share-link]}
   [{:keys [db]}]
-  (let [{:keys [public-key preferred-name]} (get db :multiaccount)
+  (let [{:keys [public-key preferred-name]} (get db :profile/profile)
         profile-link                        (universal-links/generate-link :user
                                                                            :external
                                                                            (or preferred-name

--- a/src/status_im/ui/screens/advanced_settings/views.cljs
+++ b/src/status_im/ui/screens/advanced_settings/views.cljs
@@ -115,7 +115,7 @@
 
 (views/defview advanced-settings
   []
-  (views/letsubs [{:keys [webview-debug]}          [:multiaccount]
+  (views/letsubs [{:keys [webview-debug]}          [:profile/profile]
                   network-name                     [:network-name]
                   waku-bloom-filter-mode           [:waku/bloom-filter-mode]
                   wakuv2-flag                      [:waku/v2-flag]

--- a/src/status_im/ui/screens/appearance/views.cljs
+++ b/src/status_im/ui/screens/appearance/views.cljs
@@ -21,7 +21,7 @@
 
 (views/defview appearance
   []
-  (views/letsubs [{:keys [appearance]} [:multiaccount]]
+  (views/letsubs [{:keys [appearance]} [:profile/profile]]
     [:<>
      [quo/list-header (i18n/label :t/preference)]
      [react/view

--- a/src/status_im/ui/screens/backup_settings/view.cljs
+++ b/src/status_im/ui/screens/backup_settings/view.cljs
@@ -32,7 +32,7 @@
   []
   (views/letsubs
     [{:keys [last-backup backup-enabled?]}
-     [:multiaccount]
+     [:profile/profile]
      performing-backup? [:backup/performing-backup]]
     [:<>
      [react/scroll-view

--- a/src/status_im/ui/screens/browser/views.cljs
+++ b/src/status_im/ui/screens/browser/views.cljs
@@ -251,7 +251,7 @@
                   [:browser/options]
                   dapps-account [:dapps-account]
                   network-id [:chain-id]
-                  {:keys [webview-allow-permission-requests?]} [:multiaccount]]
+                  {:keys [webview-allow-permission-requests?]} [:profile/profile]]
     (let [can-go-back?    (browser/can-go-back? browser)
           can-go-forward? (browser/can-go-forward? browser)
           url-original    (browser/get-current-url browser)]

--- a/src/status_im/ui/screens/default_sync_period_settings/view.cljs
+++ b/src/status_im/ui/screens/default_sync_period_settings/view.cljs
@@ -26,7 +26,7 @@
   []
   (views/letsubs [{:keys [default-sync-period]
                    :or   {default-sync-period constants/one-day}}
-                  [:multiaccount]]
+                  [:profile/profile]]
     [react/view {:margin-top 8}
      (when config/two-minutes-syncing?
        [radio-item constants/two-mins default-sync-period])

--- a/src/status_im/ui/screens/ens/views.cljs
+++ b/src/status_im/ui/screens/ens/views.cljs
@@ -611,7 +611,7 @@
 
 (defn- welcome
   []
-  (let [name (:name @(re-frame/subscribe [:multiaccount]))]
+  (let [name (:name @(re-frame/subscribe [:profile/profile]))]
     [react/view {:style {:flex 1}}
      [react/scroll-view {:content-container-style {:align-items :center}}
       [react/image
@@ -761,8 +761,8 @@
 
 (views/defview main
   []
-  (views/letsubs [{:keys [names multiaccount show? registrations]} [:ens.main/screen]]
+  (views/letsubs [{:keys [names profile/profile show? registrations]} [:ens.main/screen]]
     [react/keyboard-avoiding-view {:style {:flex 1}}
      (if (or (seq names) registrations)
-       [registered names multiaccount show? registrations]
+       [registered names profile show? registrations]
        [welcome])]))

--- a/src/status_im/ui/screens/keycard/pin/views.cljs
+++ b/src/status_im/ui/screens/keycard/pin/views.cljs
@@ -88,7 +88,7 @@
 
 (defn save-password
   []
-  (let [{:keys [save-password?]} @(re-frame/subscribe [:multiaccounts/login])
+  (let [{:keys [save-password?]} @(re-frame/subscribe [:profile/login])
         auth-method              @(re-frame/subscribe [:auth-method])]
     (when-not (and platform/android? (not auth-method))
       [react/view

--- a/src/status_im/ui/screens/keycard/views.cljs
+++ b/src/status_im/ui/screens/keycard/views.cljs
@@ -316,8 +316,8 @@
             enter-step         [:keycard/pin-enter-step]
             status             [:keycard/pin-status]
             error-label        [:keycard/pin-error-label]
-            login-multiaccount [:multiaccounts/login]
-            multiaccount       [:multiaccount]
+            login-multiaccount [:profile/login]
+            multiaccount       [:profile/profile]
             small-screen?      [:dimensions/small-screen?]
             retry-counter      [:keycard/retry-counter]]
     (let [{:keys [name] :as account} (or login-multiaccount multiaccount)

--- a/src/status_im/ui/screens/mobile_network_settings/view.cljs
+++ b/src/status_im/ui/screens/mobile_network_settings/view.cljs
@@ -24,7 +24,7 @@
   (views/letsubs
     [{:keys [syncing-on-mobile-network?
              remember-syncing-choice?]}
-     [:multiaccount]]
+     [:profile/profile]]
     [:<>
      [react/view
       {:style               styles/switch-container

--- a/src/status_im/ui/screens/notifications_settings/views.cljs
+++ b/src/status_im/ui/screens/notifications_settings/views.cljs
@@ -33,7 +33,7 @@
   (let [{:keys [remote-push-notifications-enabled?
                 push-notifications-block-mentions?
                 push-notifications-from-contacts-only?]}
-        @(re-frame/subscribe [:multiaccount])]
+        @(re-frame/subscribe [:profile/profile])]
     [:<>
      [quo/list-item
       {:size                :small
@@ -71,7 +71,7 @@
 
 (defn notifications-settings-android
   []
-  (let [{:keys [notifications-enabled?]} @(re-frame/subscribe [:multiaccount])]
+  (let [{:keys [notifications-enabled?]} @(re-frame/subscribe [:profile/profile])]
     [:<>
      [quo/list-item
       {:title               (i18n/label :t/local-notifications)
@@ -97,7 +97,7 @@
   (let [{:keys [remote-push-notifications-enabled?
                 send-push-notifications?
                 push-notifications-server-enabled?]}
-        @(re-frame/subscribe [:multiaccount])]
+        @(re-frame/subscribe [:profile/profile])]
     [react/scroll-view
      {:style                   {:flex 1}
       :content-container-style {:padding-vertical 8}}

--- a/src/status_im/ui/screens/offline_messaging_settings/views.cljs
+++ b/src/status_im/ui/screens/offline_messaging_settings/views.cljs
@@ -53,7 +53,7 @@
   (views/letsubs [current-mailserver-id      [:mailserver/current-id]
                   preferred-mailserver-id    [:mailserver/preferred-id]
                   mailservers                [:mailserver/fleet-mailservers]
-                  {:keys [use-mailservers?]} [:multiaccount]]
+                  {:keys [use-mailservers?]} [:profile/profile]]
     [react/view {:style styles/wrapper}
      [topbar/topbar
       {:title (i18n/label :t/history-nodes)

--- a/src/status_im/ui/screens/privacy_and_security_settings/delete_profile.cljs
+++ b/src/status_im/ui/screens/privacy_and_security_settings/delete_profile.cljs
@@ -32,7 +32,7 @@
         text-input-ref (atom nil)]
     (fn []
       (let [keycard?              @(re-frame/subscribe [:keycard-multiaccount?])
-            multiaccount          @(re-frame/subscribe [:multiaccount])
+            multiaccount          @(re-frame/subscribe [:profile/profile])
             error                 @(re-frame/subscribe [:delete-profile/error])
             keep-keys-on-keycard? @(re-frame/subscribe [:delete-profile/keep-keys-on-keycard?])]
         (when (and @text-input-ref error (not @password))

--- a/src/status_im/ui/screens/privacy_and_security_settings/events.cljs
+++ b/src/status_im/ui/screens/privacy_and_security_settings/events.cljs
@@ -39,7 +39,7 @@
   {:events [::delete-profile]}
   [{:keys [db] :as cofx} masked-password]
   (log/info "[delete-profile] delete")
-  (let [{:keys [key-uid wallet-root-address]} (:multiaccount db)]
+  (let [{:keys [key-uid wallet-root-address]} (:profile/profile db)]
     {:db (dissoc db :delete-profile/error)
      ::delete-profile
      {:masked-password masked-password

--- a/src/status_im/ui/screens/privacy_and_security_settings/messages_from_contacts_only.cljs
+++ b/src/status_im/ui/screens/privacy_and_security_settings/messages_from_contacts_only.cljs
@@ -17,7 +17,7 @@
 
 (views/defview messages-from-contacts-only
   []
-  (views/letsubs [{:keys [messages-from-contacts-only]} [:multiaccount]]
+  (views/letsubs [{:keys [messages-from-contacts-only]} [:profile/profile]]
     [react/view {:margin-top 8}
      [quo/list-item
       {:active    (not messages-from-contacts-only)

--- a/src/status_im/ui/screens/privacy_and_security_settings/views.cljs
+++ b/src/status_im/ui/screens/privacy_and_security_settings/views.cljs
@@ -33,7 +33,7 @@
                           webview-allow-permission-requests?
                           opensea-enabled?
                           profile-pictures-visibility]}
-                  [:multiaccount]
+                  [:profile/profile]
                   has-picture [:profile/has-picture]
                   supported-biometric-auth [:supported-biometric-auth]
                   keycard? [:keycard-multiaccount?]
@@ -174,7 +174,7 @@
 
 (views/defview profile-pic-show-to
   []
-  (views/letsubs [{:keys [profile-pictures-show-to]} [:multiaccount]]
+  (views/letsubs [{:keys [profile-pictures-show-to]} [:profile/profile]]
     [react/view {:margin-top 8}
      [ppst-radio-item constants/profile-pictures-show-to-everyone profile-pictures-show-to]
      [ppst-radio-item constants/profile-pictures-show-to-contacts-only profile-pictures-show-to]
@@ -194,7 +194,7 @@
 
 (views/defview profile-pic
   []
-  (views/letsubs [{:keys [profile-pictures-visibility]} [:multiaccount]]
+  (views/letsubs [{:keys [profile-pictures-visibility]} [:profile/profile]]
     [react/view {:margin-top 8}
      [ppvf-radio-item constants/profile-pictures-visibility-everyone profile-pictures-visibility]
      [ppvf-radio-item constants/profile-pictures-visibility-contacts-only profile-pictures-visibility]

--- a/src/status_im/ui/screens/profile/seed/views.cljs
+++ b/src/status_im/ui/screens/profile/seed/views.cljs
@@ -153,7 +153,7 @@
 
 (defview backup-seed
   []
-  (letsubs [current-multiaccount                             [:multiaccount]
+  (letsubs [current-multiaccount                             [:profile/profile]
             {:keys [step first-word second-word error word]} [:my-profile/recovery]]
     [react/keyboard-avoiding-view
      {:style         {:flex 1}

--- a/src/status_im/ui/screens/profile/user/views.cljs
+++ b/src/status_im/ui/screens/profile/user/views.cljs
@@ -71,7 +71,7 @@
   (let [{:keys [preferred-name
                 mnemonic
                 keycard-pairing]}
-        @(re-frame/subscribe [:multiaccount])
+        @(re-frame/subscribe [:profile/profile])
         active-contacts-count @(re-frame/subscribe [:contacts/active-count])
         chain @(re-frame/subscribe [:chain-keyword])
         registrar (stateofus/get-cached-registrar chain)

--- a/src/status_im/ui/screens/sync_settings/views.cljs
+++ b/src/status_im/ui/screens/sync_settings/views.cljs
@@ -13,7 +13,7 @@
                           backup-enabled?
                           default-sync-period
                           use-mailservers?]}
-                  [:multiaccount]
+                  [:profile/profile]
                   current-mailserver-name [:mailserver/current-name]]
     [react/scroll-view
      [quo/list-header (i18n/label :t/data-syncing)]

--- a/src/status_im/ui/screens/wallet/accounts/views.cljs
+++ b/src/status_im/ui/screens/wallet/accounts/views.cljs
@@ -146,7 +146,7 @@
                   portfolio-value    [:portfolio-value]
                   empty-balances?    [:empty-balances?]
                   frozen-card?       [:keycard/frozen-card?]
-                  {:keys [mnemonic]} [:multiaccount]]
+                  {:keys [mnemonic]} [:profile/profile]]
     [reanimated/view {:style (styles/container {:minimized minimized})}
      (when (or
             (and frozen-card? minimized)

--- a/src/status_im/ui/screens/wallet/accounts_manage/views.cljs
+++ b/src/status_im/ui/screens/wallet/accounts_manage/views.cljs
@@ -30,7 +30,7 @@
 
 (defn manage
   []
-  (let [accounts (rf/sub [:multiaccount/accounts])]
+  (let [accounts (rf/sub [:profile/wallet-accounts])]
     [list/flat-list
      {:key-fn    :address
       :data      accounts

--- a/src/status_im/ui/screens/wallet/signing_phrase/views.cljs
+++ b/src/status_im/ui/screens/wallet/signing_phrase/views.cljs
@@ -10,7 +10,7 @@
 (views/defview signing-phrase
   []
   (views/letsubs [phrase                          [:signing/phrase]
-                  {:keys [wallet-set-up-passed?]} [:multiaccount]]
+                  {:keys [wallet-set-up-passed?]} [:profile/profile]]
     [react/view
      [react/view {:margin-top 24 :margin-horizontal 24 :align-items :center}
       [react/view

--- a/src/status_im/utils/keychain/core.cljs
+++ b/src/status_im/utils/keychain/core.cljs
@@ -221,11 +221,6 @@
    (-> (.resetInternetCredentials react-native-keychain (string/lower-case key-uid))
        (.then #(when-not % (log/error (str "Error while clearing saved password.")))))))
 
-(rf/defn get-auth-method
-  [_ key-uid]
-  {:keychain/get-auth-method
-   [key-uid #(re-frame/dispatch [:multiaccounts.login/get-auth-method-success % key-uid])]})
-
 (rf/defn get-user-password
   [_ key-uid]
   {:keychain/get-user-password

--- a/src/status_im/utils/logging/core.cljs
+++ b/src/status_im/utils/logging/core.cljs
@@ -97,9 +97,9 @@
         (re-frame/dispatch [:show-client-error]))))))
 
 (defn logs-enabled?
-  [{:keys [multiaccount]}]
-  (let [log-level (if multiaccount ;; already login
-                    (get multiaccount :log-level)
+  [{:profile/keys [profile]}]
+  (let [log-level (if profile ;; already login
+                    (get profile :log-level)
                     config/log-level)]
     (not (string/blank? log-level))))
 

--- a/src/status_im/utils/mobile_sync.cljs
+++ b/src/status_im/utils/mobile_sync.cljs
@@ -7,7 +7,7 @@
 (defn syncing-allowed?
   [{:keys [db]}]
   (let [network                              (:network/type db)
-        {:keys [syncing-on-mobile-network?]} (:multiaccount db)]
+        {:keys [syncing-on-mobile-network?]} (:profile/profile db)]
     (or (= network "wifi")
         (and syncing-on-mobile-network?
              (= network "cellular")))))

--- a/src/status_im/utils/pairing.cljs
+++ b/src/status_im/utils/pairing.cljs
@@ -2,7 +2,7 @@
 
 (defn has-paired-installations?
   [cofx]
-  (let [our-installation-id (get-in cofx [:db :multiaccount :installation-id])]
+  (let [our-installation-id (get-in cofx [:db :profile/profile :installation-id])]
     (->>
       (get-in cofx [:db :pairing/installations])
       vals

--- a/src/status_im/utils/universal_links/core.cljs
+++ b/src/status_im/utils/universal_links/core.cljs
@@ -59,8 +59,8 @@
   (group-chats/create-from-link cofx params))
 
 (defn own-public-key?
-  [{:keys [multiaccount]} public-key]
-  (= (:public-key multiaccount) public-key))
+  [{:keys [profile/profile]} public-key]
+  (= (:public-key profile) public-key))
 
 (rf/defn handle-private-chat
   [{:keys [db] :as cofx} {:keys [chat-id]}]
@@ -123,7 +123,7 @@
     (some #(when (= (string/lower-case (:address %))
                     (string/lower-case address))
              %)
-          (:multiaccount/accounts db))))
+          (:profile/wallet-accounts db))))
 
 (rf/defn handle-wallet-account
   [cofx {address :account}]

--- a/src/status_im/utils/universal_links/core_test.cljs
+++ b/src/status_im/utils/universal_links/core_test.cljs
@@ -12,7 +12,7 @@
         (is (= {:db {:universal-links/url "some-url"}}
                (links/handle-url {:db {}} "some-url")))))
     (testing "the user is logged in"
-      (let [db {:multiaccount        {:public-key "pk"}
+      (let [db {:profile/profile     {:public-key "pk"}
                 :app-state           "active"
                 :universal-links/url "some-url"}]
         (testing "it clears the url"

--- a/src/status_im/waku/core.cljs
+++ b/src/status_im/waku/core.cljs
@@ -41,7 +41,7 @@
   (let [custom-nodes (into {}
                            (map #(vector (random-guid-generator)
                                          {:name (name (first %1)) :address (second %1)})
-                                (get-in db [:multiaccount :wakuv2-config :CustomNodes])))]
+                                (get-in db [:profile/profile :wakuv2-config :CustomNodes])))]
     (rf/merge cofx
               {:db       (assoc db :wakuv2-nodes/list custom-nodes)
                :dispatch [:navigate-to :wakuv2-settings]})))
@@ -109,7 +109,7 @@
                        (into {}))]
     (rf/merge cofx
               {:db       (-> db
-                             (assoc-in [:multiaccount :wakuv2-config :CustomNodes] new-nodes)
+                             (assoc-in [:profile/profile :wakuv2-config :CustomNodes] new-nodes)
                              (dissoc :wakuv2-nodes/manage :wakuv2-nodes/list))
                :dispatch [:navigate-back]}
               (node/prepare-new-config

--- a/src/status_im/wallet/accounts/core.cljs
+++ b/src/status_im/wallet/accounts/core.cljs
@@ -29,7 +29,7 @@
 (rf/defn start-adding-new-account
   {:events [:wallet.accounts/start-adding-new-account]}
   [{:keys [db] :as cofx} {:keys [type] :as add-account}]
-  (let [{:keys [latest-derived-path]} (:multiaccount db)
+  (let [{:keys [latest-derived-path]} (:profile/profile db)
         path-num                      (inc latest-derived-path)
         account                       (merge
                                        {:color (rand-nth colors/account-colors)}
@@ -152,9 +152,9 @@
 (rf/defn generate-new-account
   [{:keys [db]} hashed-password]
   (let [{:keys [key-uid wallet-root-address]}
-        (get db :multiaccount)
-        path-num (inc (get-in db [:multiaccount :latest-derived-path]))
-        accounts (:multiaccount/accounts db)]
+        (get db :profile/profile)
+        path-num (inc (get-in db [:profile/profile :latest-derived-path]))
+        accounts (:profile/wallet-accounts db)]
     {:db                (assoc-in db [:add-account :step] :generating)
      ::generate-account {:derivation-info {:path    (str "m/" path-num)
                                            :address wallet-root-address}
@@ -173,10 +173,10 @@
   {:events [:wallet.accounts/seed-validated]}
   [{:keys [db] :as cofx} phrase-warnings passphrase hashed-password]
   (let [error             (:error (types/json->clj phrase-warnings))
-        {:keys [key-uid]} (:multiaccount db)]
+        {:keys [key-uid]} (:profile/profile db)]
     (if-not (string/blank? error)
       (new-account-error cofx :account-error error)
-      (let [accounts (:multiaccount/accounts db)]
+      (let [accounts (:profile/wallet-accounts db)]
         {::import-account-seed {:passphrase      passphrase
                                 :hashed-password hashed-password
                                 :accounts        accounts
@@ -184,7 +184,7 @@
 
 (rf/defn import-new-account-private-key
   [{:keys [db]} private-key hashed-password]
-  (let [{:keys [key-uid]} (:multiaccount db)]
+  (let [{:keys [key-uid]} (:profile/profile db)]
     {:db                          (assoc-in db [:add-account :step] :generating)
      ::import-account-private-key {:private-key     private-key
                                    :hashed-password hashed-password
@@ -192,11 +192,11 @@
 
 (rf/defn save-new-account
   [{:keys [db] :as cofx}]
-  (let [{:keys [latest-derived-path]} (:multiaccount db)
+  (let [{:keys [latest-derived-path]} (:profile/profile db)
         {:keys [account type]} (:add-account db)
         {:keys [address name key-uid]} account
-        main-key-uid (or key-uid (get-in db [:multiaccount :key-uid]))
-        accounts (:multiaccount/accounts db)
+        main-key-uid (or key-uid (get-in db [:profile/profile :key-uid]))
+        accounts (:profile/wallet-accounts db)
         new-accounts (conj accounts account)
         ;; Note(rasom): in case if a new account is created using a mnemonic or
         ;; a private key we add a new keypair to the database, otherwise we just
@@ -222,7 +222,7 @@
                                   :params     params
                                   :on-success #(re-frame/dispatch [::wallet/restart])}]
                  :db            (-> db
-                                    (assoc :multiaccount/accounts new-accounts)
+                                    (assoc :profile/wallet-accounts new-accounts)
                                     (dissoc :add-account))}
                 (when (= type :generate)
                   (multiaccounts.update/multiaccount-update
@@ -233,7 +233,7 @@
 (rf/defn account-generated
   {:events [:wallet.accounts/account-stored]}
   [{:keys [db] :as cofx} {:keys [address] :as account}]
-  (let [accounts (:multiaccount/accounts db)]
+  (let [accounts (:profile/wallet-accounts db)]
     (if (some #(when (= (:address %) address) %) accounts)
       (new-account-error cofx :account-error (i18n/label :t/account-exists-title))
       (rf/merge cofx
@@ -270,7 +270,7 @@
 (rf/defn add-new-account-verify-password
   [{:keys [db]} hashed-password]
   {:db               (assoc-in db [:add-account :step] :generating)
-   ::verify-password {:address         (get-in db [:multiaccount :wallet-root-address])
+   ::verify-password {:address         (get-in db [:profile/profile :wallet-root-address])
                       :hashed-password hashed-password}})
 
 (rf/defn set-account-to-watch
@@ -308,7 +308,7 @@
 (rf/defn save-account
   {:events [:wallet.accounts/save-account]}
   [{:keys [db]} account {:keys [name color hidden]}]
-  (let [accounts     (:multiaccount/accounts db)
+  (let [accounts     (:profile/wallet-accounts db)
         new-account  (cond-> account
                        name                (assoc :name name)
                        color               (assoc :color color)
@@ -317,12 +317,12 @@
     {:json-rpc/call [{:method     "accounts_saveAccount"
                       :params     [new-account]
                       :on-success #()}]
-     :db            (assoc db :multiaccount/accounts new-accounts)}))
+     :db            (assoc db :profile/wallet-accounts new-accounts)}))
 
 (rf/defn delete-account
   {:events [:wallet.accounts/delete-account]}
   [{:keys [db] :as cofx} account]
-  (let [accounts        (:multiaccount/accounts db)
+  (let [accounts        (:profile/wallet-accounts db)
         new-accounts    (vec (remove #(= account %) accounts))
         deleted-address (:address account)]
     (rf/merge cofx
@@ -330,7 +330,7 @@
                                 :params     [(:address account)]
                                 :on-success #()}]
                :db            (-> db
-                                  (assoc :multiaccount/accounts new-accounts)
+                                  (assoc :profile/wallet-accounts new-accounts)
                                   (update-in [:wallet :accounts] dissoc deleted-address))}
               (navigation/pop-to-root :shell-stack))))
 
@@ -338,12 +338,12 @@
   {:events [:wallet.accounts/delete-key]}
   [{:keys [db] :as cofx} account password on-error]
   (let [deleted-address (:address account)
-        dapps-address   (get-in cofx [:db :multiaccount :dapps-address])]
+        dapps-address   (get-in cofx [:db :profile/profile :dapps-address])]
     (if (= (string/lower-case dapps-address) (string/lower-case deleted-address))
       {:utils/show-popup {:title   (i18n/label :t/warning)
                           :content (i18n/label :t/account-is-used)}}
       {::key-storage/delete-imported-key
-       {:key-uid    (get-in db [:multiaccount :key-uid])
+       {:key-uid    (get-in db [:profile/profile :key-uid])
         :address    (:address account)
         :password   password
         :on-success #(do

--- a/src/status_im/wallet/choose_recipient/core.cljs
+++ b/src/status_im/wallet/choose_recipient/core.cljs
@@ -61,7 +61,7 @@
          (cond-> {:to      address
                   :to-name (or name (find-address-name db address))
                   :from    (ethereum/get-default-account
-                            (get db :multiaccount/accounts))}
+                            (get db :profile/wallet-accounts))}
            gas      (assoc :gas (money/bignumber gas))
            gasLimit (assoc :gas (money/bignumber gasLimit))
            gasPrice (assoc :gasPrice (money/bignumber gasPrice))

--- a/src/status_im/wallet/core.cljs
+++ b/src/status_im/wallet/core.cljs
@@ -66,7 +66,7 @@
 (rf/defn get-cached-balances
   [{:keys [db]} scan-all-tokens?]
   (let [addresses (map (comp string/lower-case :address)
-                       (get db :multiaccount/accounts))]
+                       (get db :profile/wallet-accounts))]
     {:wallet/get-cached-balances
      {:addresses  addresses
       :on-success #(re-frame/dispatch [::set-cached-balances addresses % scan-all-tokens?])
@@ -155,11 +155,11 @@
   {:events [::fetch-collectibles-collection]}
   [{:keys [db]}]
   (let [addresses (map (comp string/lower-case :address)
-                       (get db :multiaccount/accounts))
+                       (get db :profile/wallet-accounts))
         chain-id  (-> db
                       ethereum/current-network
                       ethereum/network->chain-id)]
-    (when (get-in db [:multiaccount :opensea-enabled?])
+    (when (get-in db [:profile/profile :opensea-enabled?])
       {:json-rpc/call (map
                        (fn [address]
                          {:method     "wallet_getOpenseaCollectionsByOwner"
@@ -230,16 +230,17 @@
 
 (rf/defn update-balances
   {:events [:wallet/update-balances]}
-  [{{:keys [network-status :wallet/all-tokens
-            multiaccount :multiaccount/accounts]
+  [{{:keys [network-status]
+     :wallet/keys [all-tokens]
+     :profile/keys [profile wallet-accounts]
      :as   db}
     :db
     :as cofx} addresses scan-all-tokens?]
   (log/debug "update-balances"
              "accounts"         addresses
              "scan-all-tokens?" scan-all-tokens?)
-  (let [addresses                        (or addresses (map (comp string/lower-case :address) accounts))
-        {:keys [:wallet/visible-tokens]} multiaccount
+  (let [addresses                        (or addresses (map (comp string/lower-case :address) wallet-accounts))
+        {:keys [:wallet/visible-tokens]} profile
         chain                            (ethereum/chain-keyword db)
         assets                           (get visible-tokens chain)
         tokens                           (->> (vals all-tokens)
@@ -306,9 +307,9 @@
         (get-in db [:wallet :accounts])))
 
 (rf/defn update-toggle-in-settings
-  [{{:keys [multiaccount] :as db} :db :as cofx} symbol checked?]
+  [{{:profile/keys [profile] :as db} :db :as cofx} symbol checked?]
   (let [chain          (ethereum/chain-keyword db)
-        visible-tokens (get multiaccount :wallet/visible-tokens)]
+        visible-tokens (get profile :wallet/visible-tokens)]
     (rf/merge cofx
               (multiaccounts.update/multiaccount-update
                :wallet/visible-tokens
@@ -353,7 +354,7 @@
   {:events [::tokens-found]}
   [{:keys [db] :as cofx} balances]
   (let [chain                (ethereum/chain-keyword db)
-        visible-tokens       (get-in db [:multiaccount :wallet/visible-tokens])
+        visible-tokens       (get-in db [:profile/profile :wallet/visible-tokens])
         chain-visible-tokens (into (or (config/default-visible-tokens chain)
                                        #{})
                                    (flatten (map keys (vals balances))))]
@@ -460,7 +461,7 @@
         amount-text (str (money/internal->formatted value symbol decimals))]
     {:db       (assoc db
                       :wallet/prepare-transaction
-                      {:from               (ethereum/get-default-account (:multiaccount/accounts db))
+                      {:from               (ethereum/get-default-account (:profile/wallet-accounts db))
                        :to                 (or (get-in db [:contacts/contacts identity])
                                                (-> identity
                                                    contact.db/public-key->new-contact
@@ -515,7 +516,7 @@
     (cond-> {:db       (assoc db
                               :wallet/prepare-transaction
                               {:from       (ethereum/get-default-account
-                                            (:multiaccount/accounts db))
+                                            (:profile/wallet-accounts db))
                                :to         contact
                                :symbol     :ETH
                                :from-chat? true})
@@ -535,7 +536,7 @@
   (let [identity (:current-chat-id db)]
     {:db       (assoc db
                       :wallet/prepare-transaction
-                      {:from             (ethereum/get-default-account (:multiaccount/accounts db))
+                      {:from             (ethereum/get-default-account (:profile/wallet-accounts db))
                        :to               (or (get-in db [:contacts/contacts identity])
                                              (-> identity
                                                  contact.db/public-key->new-contact
@@ -709,7 +710,7 @@
 (rf/defn check-recent-history
   [{:keys [db] :as cofx}
    {:keys [on-recent-history-fetching force-restart?]}]
-  (let [addresses   (map :address (get db :multiaccount/accounts))
+  (let [addresses   (map :address (get db :profile/wallet-accounts))
         old-timeout (get db :wallet-service/restart-timeout)
         timeout     (if force-restart?
                       old-timeout
@@ -729,7 +730,7 @@
   [{:keys [db] :as cofx}
    {:keys [force-restart? on-recent-history-fetching]
     :as   params}]
-  (when (:multiaccount db)
+  (when (:profile/profile db)
     (let [syncing-allowed? (mobile-network-utils/syncing-allowed? cofx)
           binance-chain?   (ethereum/binance-chain? db)]
       (log/info "restart-wallet-service"
@@ -832,7 +833,7 @@
 (rf/defn wallet-will-focus
   {:events [::wallet-stack]}
   [{:keys [db]}]
-  (let [wallet-set-up-passed? (get-in db [:multiaccount :wallet-set-up-passed?])
+  (let [wallet-set-up-passed? (get-in db [:profile/profile :wallet-set-up-passed?])
         sign-phrase-showed?   (get db :wallet/sign-phrase-showed?)]
     {:dispatch-n [[:wallet.ui/pull-to-refresh]] ;TODO temporary simple fix for v1
      ;;[:show-popover {:view [signing-phrase/signing-phrase]}]]

--- a/src/status_im/wallet/core.cljs
+++ b/src/status_im/wallet/core.cljs
@@ -230,16 +230,17 @@
 
 (rf/defn update-balances
   {:events [:wallet/update-balances]}
-  [{{:keys [network-status]
-     :wallet/keys [all-tokens]
+  [{{:keys         [network-status]
+     :wallet/keys  [all-tokens]
      :profile/keys [profile wallet-accounts]
-     :as   db}
+     :as           db}
     :db
     :as cofx} addresses scan-all-tokens?]
   (log/debug "update-balances"
              "accounts"         addresses
              "scan-all-tokens?" scan-all-tokens?)
-  (let [addresses                        (or addresses (map (comp string/lower-case :address) wallet-accounts))
+  (let [addresses                        (or addresses
+                                             (map (comp string/lower-case :address) wallet-accounts))
         {:keys [:wallet/visible-tokens]} profile
         chain                            (ethereum/chain-keyword db)
         assets                           (get visible-tokens chain)

--- a/src/status_im/wallet/prices.cljs
+++ b/src/status_im/wallet/prices.cljs
@@ -51,7 +51,7 @@
   [{{:keys [network-status :wallet/all-tokens]
      {:keys [currency :wallet/visible-tokens]
       :or   {currency :usd}}
-     :multiaccount
+     :profile/profile
      :as db}
     :db}]
   (let [chain    (ethereum/chain-keyword db)

--- a/src/status_im/wallet_connect/core.cljs
+++ b/src/status_im/wallet_connect/core.cljs
@@ -238,7 +238,7 @@
 (rf/defn wallet-connect-send-async
   [cofx {:keys [method params id] :as payload} message-id topic]
   (let [message?      (browser/web3-sign-message? method)
-        dapps-address (get-in cofx [:db :multiaccount :dapps-address])
+        dapps-address (get-in cofx [:db :profile/profile :dapps-address])
         accounts      (get-in cofx [:db :multiaccount/visible-accounts])
         typed?        (and (not= constants/web3-personal-sign method)
                            (not= constants/web3-eth-sign method))]

--- a/src/status_im2/common/home/view.cljs
+++ b/src/status_im2/common/home/view.cljs
@@ -51,7 +51,7 @@
 
 (defn- left-section
   [{:keys [avatar]}]
-  (let [{:keys [public-key]} (rf/sub [:multiaccount])
+  (let [{:keys [public-key]} (rf/sub [:profile/profile])
         online?              (rf/sub [:visibility-status-updates/online? public-key])]
     [rn/touchable-without-feedback {:on-press #(rf/dispatch [:navigate-to :my-profile])}
      [rn/view

--- a/src/status_im2/common/log.cljs
+++ b/src/status_im2/common/log.cljs
@@ -49,5 +49,5 @@
 (rf/defn set-log-level
   [{:keys [db]} log-level]
   (let [log-level (or log-level config/log-level)]
-    {:db             (assoc-in db [:multiaccount :log-level] log-level)
+    {:db             (assoc-in db [:profile/profile :log-level] log-level)
      :logs/set-level log-level}))

--- a/src/status_im2/common/theme/events.cljs
+++ b/src/status_im2/common/theme/events.cljs
@@ -1,0 +1,8 @@
+(ns status-im2.common.theme.events
+  (:require [re-frame.core :as re-frame]
+            [status-im2.common.theme.core :as theme]))
+
+(re-frame/reg-fx
+ :init-theme
+ (fn []
+   (theme/add-device-theme-change-listener)))

--- a/src/status_im2/common/theme/events.cljs
+++ b/src/status_im2/common/theme/events.cljs
@@ -3,6 +3,6 @@
             [status-im2.common.theme.core :as theme]))
 
 (re-frame/reg-fx
- :init-theme
+ :theme/init-theme
  (fn []
    (theme/add-device-theme-change-listener)))

--- a/src/status_im2/contexts/add_new_contact/events.cljs
+++ b/src/status_im2/contexts/add_new_contact/events.cljs
@@ -95,7 +95,7 @@
 (rf/defn set-new-identity
   {:events [:contacts/set-new-identity]}
   [{:keys [db]} input scanned]
-  (let [user-public-key (get-in db [:multiaccount :public-key])
+  (let [user-public-key (get-in db [:profile/profile :public-key])
         {:keys [input id ens state]
          :as   contact} (-> {:user-public-key user-public-key
                              :input           input

--- a/src/status_im2/contexts/add_new_contact/events_test.cljs
+++ b/src/status_im2/contexts/add_new_contact/events_test.cljs
@@ -75,7 +75,7 @@
 ;;; event handler tests (no callbacks)
 
 (def db
-  {:multiaccount             {:public-key user-ukey}
+  {:profile/profile          {:public-key user-ukey}
    :networks/current-network "mainnet_rpc"
    :networks/networks        {"mainnet_rpc"
                               {:id     "mainnet_rpc"

--- a/src/status_im2/contexts/chat/events.cljs
+++ b/src/status_im2/contexts/chat/events.cljs
@@ -13,7 +13,6 @@
             [status-im.chat.models.loading :as loading]
             [status-im.data-store.chats :as chats-store]
             [status-im2.contexts.contacts.events :as contacts-store]
-            [status-im.multiaccounts.model :as multiaccounts.model]
             [status-im.utils.clocks :as utils.clocks]
             [status-im.utils.types :as types]
             [reagent.core :as reagent]
@@ -112,7 +111,7 @@
             (when (not-empty removed-chats)
               {:clear-message-notifications
                [removed-chats
-                (get-in db [:multiaccount :remote-push-notifications-enabled?])]}))
+                (get-in db [:profile/profile :remote-push-notifications-enabled?])]}))
      leave-removed-chat)))
 
 (rf/defn clear-history
@@ -259,7 +258,7 @@
   "Start a chat, making sure it exists"
   {:events [:chat.ui/start-chat]}
   [cofx chat-id ens-name]
-  (when (not= (multiaccounts.model/current-public-key cofx) chat-id)
+  (when (not= (get-in cofx [:db :profile/profile :public-key]) chat-id)
     {:json-rpc/call [{:method      "wakuext_createOneToOneChat"
                       :params      [{:id chat-id :ensName ens-name}]
                       :js-response true
@@ -284,7 +283,7 @@
   [{:keys [db now] :as cofx} chat-id]
   (rf/merge cofx
             {:clear-message-notifications
-             [[chat-id] (get-in db [:multiaccount :remote-push-notifications-enabled?])]
+             [[chat-id] (get-in db [:profile/profile :remote-push-notifications-enabled?])]
              :dispatch [:shell/close-switcher-card chat-id]}
             (deactivate-chat chat-id)
             (offload-messages chat-id)))

--- a/src/status_im2/contexts/chat/events_test.cljs
+++ b/src/status_im2/contexts/chat/events_test.cljs
@@ -75,13 +75,13 @@
         (is (not (chat/group-chat? cofx chat-id)))))))
 
 (def test-db
-  {:multiaccount {:public-key "me"}
+  {:profile/profile {:public-key "me"}
 
-   :messages     {"status" {"4" {} "5" {} "6" {}}}
-   :chats        {"status" {:public?    true
-                            :group-chat true}
-                  "opened" {}
-                  "1-1"    {}}})
+   :messages        {"status" {"4" {} "5" {} "6" {}}}
+   :chats           {"status" {:public?    true
+                               :group-chat true}
+                     "opened" {}
+                     "1-1"    {}}})
 
 (deftest navigate-to-chat
   (let [chat-id "test_chat"

--- a/src/status_im2/contexts/chat/home/view.cljs
+++ b/src/status_im2/contexts/chat/home/view.cljs
@@ -121,10 +121,8 @@
   []
   (let [pending-contact-requests (rf/sub [:activity-center/pending-contact-requests])
         selected-tab             (or (rf/sub [:messages-home/selected-tab]) :tab/recent)
-        {:keys [key-uid]}        (rf/sub [:multiaccount])
         account                  (rf/sub [:profile/multiaccount])
-        customization-color      (or (:color (rf/sub [:onboarding-2/profile]))
-                                     (rf/sub [:profile/customization-color key-uid]))
+        customization-color      (rf/sub [:profile/customization-color])
         top                      (safe-area/get-top)]
     [:<>
      (if (= selected-tab :tab/contacts)

--- a/src/status_im2/contexts/chat/messages/delete_message/events.cljs
+++ b/src/status_im2/contexts/chat/messages/delete_message/events.cljs
@@ -52,19 +52,20 @@
   1. if the to-be deleted message is pinned
   2. if user has the permission to unpin message in current chat"
   [db {:keys [chat-id message-id]}]
-  (let [{:keys [group-chat chat-id public? community-id admins]} (get-in db [:chats chat-id])
-        community                                                (get-in db [:communities community-id])
-        community-admin?                                         (get community :admin false)
-        pub-key                                                  (get-in db [:multiaccount :public-key])
-        group-admin?                                             (get admins pub-key)
-        message-pin-enabled                                      (and (not public?)
-                                                                      (or (not group-chat)
-                                                                          (and group-chat
-                                                                               (or group-admin?
-                                                                                   community-admin?))))
-        pinned                                                   (get-in db
-                                                                         [:pin-messages chat-id
-                                                                          message-id])]
+  (let [{:keys [group-chat chat-id public? community-id
+                admins]}    (get-in db [:chats chat-id])
+        community           (get-in db [:communities community-id])
+        community-admin?    (get community :admin false)
+        pub-key             (get-in db [:profile/profile :public-key])
+        group-admin?        (get admins pub-key)
+        message-pin-enabled (and (not public?)
+                                 (or (not group-chat)
+                                     (and group-chat
+                                          (or group-admin?
+                                              community-admin?))))
+        pinned              (get-in db
+                                    [:pin-messages chat-id
+                                     message-id])]
     (and pinned message-pin-enabled)))
 
 (rf/defn delete
@@ -80,7 +81,7 @@
                   db
                   {:chat-id chat-id :message-id message-id})
 
-          pub-key (get-in db [:multiaccount :public-key])
+          pub-key (get-in db [:profile/profile :public-key])
 
           ;; compute deleted by
           message-from (get message :from)

--- a/src/status_im2/contexts/chat/messages/link_preview/events.cljs
+++ b/src/status_im2/contexts/chat/messages/link_preview/events.cljs
@@ -13,8 +13,8 @@
 
 (rf/defn cache-link-preview-data
   {:events [:chat.ui/cache-link-preview-data]}
-  [{{:keys [multiaccount]} :db :as cofx} site data]
-  (let [link-previews-cache (get multiaccount :link-previews-cache {})]
+  [{{:profile/keys [profile]} :db :as cofx} site data]
+  (let [link-previews-cache (get profile :link-previews-cache {})]
     (multiaccounts.update/optimistic
      cofx
      :link-previews-cache
@@ -22,8 +22,8 @@
 
 (rf/defn load-link-preview-data
   {:events [:chat.ui/load-link-preview-data]}
-  [{{:keys [multiaccount] :as db} :db} link]
-  (let [{:keys [error] :as cache-data} (get-in multiaccount [:link-previews-cache link])]
+  [{{:profile/keys [profile] :as db} :db} link]
+  (let [{:keys [error] :as cache-data} (get-in profile [:link-previews-cache link])]
     (if (or (not cache-data) error)
       {:json-rpc/call [{:method     "wakuext_getLinkPreviewData"
                         :params     [link]
@@ -86,18 +86,18 @@
 
 (rf/defn enable
   {:events [:chat.ui/enable-link-previews]}
-  [{{:keys [multiaccount]} :db :as cofx} site enabled?]
+  [{{:profile/keys [profile]} :db :as cofx} site enabled?]
   (multiaccounts.update/multiaccount-update
    cofx
    :link-previews-enabled-sites
    (if enabled?
-     (conj (get multiaccount :link-previews-enabled-sites #{}) site)
-     (disj (get multiaccount :link-previews-enabled-sites #{}) site))
+     (conj (get profile :link-previews-enabled-sites #{}) site)
+     (disj (get profile :link-previews-enabled-sites #{}) site))
    {}))
 
 (rf/defn enable-all
   {:events [:chat.ui/enable-all-link-previews]}
-  [{{:keys [multiaccount]} :db :as cofx} link-previews-whitelist enabled?]
+  [{{:profile/keys [profile]} :db :as cofx} link-previews-whitelist enabled?]
   (multiaccounts.update/multiaccount-update
    cofx
    :link-previews-enabled-sites

--- a/src/status_im2/contexts/chat/messages/pin/events.cljs
+++ b/src/status_im2/contexts/chat/messages/pin/events.cljs
@@ -80,7 +80,7 @@
   "Pin message, rebuild pinned messages list locally"
   {:events [:pin-message/send-pin-message-locally]}
   [{:keys [db] :as cofx} {:keys [chat-id message-id pinned] :as pin-message}]
-  (let [current-public-key       (get-in db [:multiaccount :public-key])
+  (let [current-public-key       (get-in db [:profile/profile :public-key])
         message                  (merge pin-message {:pinned-by current-public-key})
         pin-message-lists-exist? (some? (get-in db [:pin-message-lists chat-id]))]
     (rf/merge cofx

--- a/src/status_im2/contexts/communities/home/view.cljs
+++ b/src/status_im2/contexts/communities/home/view.cljs
@@ -73,10 +73,8 @@
   []
   (let [selected-tab                    (or (rf/sub [:communities/selected-tab]) :joined)
         {:keys [joined pending opened]} (rf/sub [:communities/grouped-by-status])
-        {:keys [key-uid]}               (rf/sub [:multiaccount])
         account                         (rf/sub [:profile/multiaccount])
-        customization-color             (or (:color (rf/sub [:onboarding-2/profile]))
-                                            (rf/sub [:profile/customization-color key-uid]))
+        customization-color             (rf/sub [:profile/customization-color])
         selected-items                  (case selected-tab
                                           :joined  joined
                                           :pending pending

--- a/src/status_im2/contexts/contacts/events.cljs
+++ b/src/status_im2/contexts/contacts/events.cljs
@@ -78,7 +78,7 @@
 (rf/defn send-contact-request
   {:events [:contact.ui/send-contact-request]}
   [{:keys [db]} id]
-  (when (not= id (get-in db [:multiaccount :public-key]))
+  (when (not= id (get-in db [:profile/profile :public-key]))
     {:json-rpc/call
      [{:method      "wakuext_sendContactRequest"
        :js-response true

--- a/src/status_im2/contexts/onboarding/events.cljs
+++ b/src/status_im2/contexts/onboarding/events.cljs
@@ -114,16 +114,16 @@
     {effect    request
      :dispatch [:navigate-to :generating-keys]
      :db       (-> db
-                   (dissoc :multiaccounts/login)
+                   (dissoc :profile/login)
                    (dissoc :auth-method)
                    (assoc :onboarding-2/new-account? true))}))
 
 (rf/defn on-delete-profile-success
   {:events [:onboarding-2/on-delete-profile-success]}
   [{:keys [db]} key-uid]
-  (let [multiaccounts (dissoc (:multiaccounts/multiaccounts db) key-uid)]
+  (let [multiaccounts (dissoc (:profile/profiles-overview db) key-uid)]
     (merge
-     {:db (assoc db :multiaccounts/multiaccounts multiaccounts)}
+     {:db (assoc db :profile/profiles-overview multiaccounts)}
      (when-not (seq multiaccounts)
        {:set-root :intro}))))
 
@@ -147,7 +147,7 @@
 (rf/defn seed-phrase-validated
   {:events [:onboarding-2/seed-phrase-validated]}
   [{:keys [db]} seed-phrase key-uid]
-  (if (contains? (:multiaccounts/multiaccounts db) key-uid)
+  (if (contains? (:profile/profiles-overview db) key-uid)
     {:utils/show-confirmation
      {:title               (i18n/label :t/multiaccount-exists-title)
       :content             (i18n/label :t/multiaccount-exists-content)
@@ -155,7 +155,7 @@
       :on-accept           (fn []
                              (re-frame/dispatch [:pop-to-root :profiles])
                              (re-frame/dispatch
-                              [:multiaccounts.login.ui/multiaccount-selected key-uid]))
+                              [:profile/profile-selected key-uid]))
       :on-cancel           #(re-frame/dispatch [:pop-to-root :multiaccounts])}}
     {:db       (assoc-in db [:onboarding-2/profile :seed-phrase] seed-phrase)
      :dispatch [:navigate-to :create-profile]}))
@@ -171,7 +171,7 @@
   {:events [:onboarding-2/finalize-setup]}
   [{:keys [db]}]
   (let [masked-password    (get-in db [:onboarding-2/profile :password])
-        key-uid            (get-in db [:multiaccount :key-uid])
+        key-uid            (get-in db [:profile/profile :key-uid])
         biometric-enabled? (=
                             constants/auth-method-biometric
                             (get-in db [:onboarding-2/profile :auth-method]))]

--- a/src/status_im2/contexts/onboarding/identifiers/view.cljs
+++ b/src/status_im2/contexts/onboarding/identifiers/view.cljs
@@ -28,7 +28,7 @@
         is-dragging?         (atom nil)
         drag-amount          (atom nil)
         {:keys [emoji-hash display-name compressed-key
-                public-key]} (rf/sub [:multiaccount])
+                public-key]} (rf/sub [:profile/profile])
         {:keys [color]}      (rf/sub [:onboarding-2/profile])
         photo-path           (rf/sub [:chats/photo-path public-key])
         emoji-string         (string/join emoji-hash)]

--- a/src/status_im2/contexts/profile/events.cljs
+++ b/src/status_im2/contexts/profile/events.cljs
@@ -1,0 +1,35 @@
+(ns status-im2.contexts.profile.events
+  (:require [utils.re-frame :as rf]
+            [clojure.string :as string]))
+
+(rf/defn profile-selected
+  {:events [:profile/profile-selected]}
+  [{:keys [db]} key-uid]
+  {:db (update db
+               :profile/login
+               #(-> %
+                    (assoc :key-uid key-uid)
+                    (dissoc :error :password)))})
+
+(defn rpc->profiles-overview
+  [{:keys [customizationColor keycard-pairing] :as profile}]
+  (-> profile
+      (dissoc :customizationColor)
+      (assoc :customization-color (keyword customizationColor))
+      (assoc :keycard-pairing (when-not (string/blank? keycard-pairing) keycard-pairing))))
+
+(rf/defn init-profiles-overview
+  [{:keys [db] :as cofx} profiles]
+  (let [profiles          (reduce
+                           (fn [acc {:keys [key-uid] :as profile}]
+                             (assoc acc key-uid (rpc->profiles-overview profile)))
+                           {}
+                           profiles)
+        {:keys [key-uid]} (first (sort-by :timestamp > (vals profiles)))]
+    (rf/merge cofx
+              {:db (assoc db :profile/profiles-overview profiles)
+               :keychain/get-auth-method
+               [key-uid #(rf/dispatch [:multiaccounts.login/get-auth-method-success % key-uid])]
+               :dispatch-n [[:get-opted-in-to-new-terms-of-service]
+                            [:load-information-box-states]]}
+              (profile-selected key-uid))))

--- a/src/status_im2/contexts/profile/login/events.cljs
+++ b/src/status_im2/contexts/profile/login/events.cljs
@@ -1,0 +1,3 @@
+(ns status-im2.contexts.profile.login.events)
+
+

--- a/src/status_im2/contexts/shell/activity_center/events.cljs
+++ b/src/status_im2/contexts/shell/activity_center/events.cljs
@@ -498,7 +498,7 @@
 (rf/defn show-toasts
   {:events [:activity-center.notifications/show-toasts]}
   [{:keys [db]} new-notifications]
-  (let [my-public-key (get-in db [:multiaccount :public-key])]
+  (let [my-public-key (get-in db [:profile/profile :public-key])]
     (reduce (fn [cofx {:keys [author type accepted dismissed message name] :as x}]
               (let [user-avatar {:full-name         name
                                  :status-indicator? true

--- a/src/status_im2/contexts/shell/jump_to/components/bottom_tabs/view.cljs
+++ b/src/status_im2/contexts/shell/jump_to/components/bottom_tabs/view.cljs
@@ -21,9 +21,7 @@
 
 (defn bottom-tab
   [icon stack-id shared-values notifications-data]
-  (let [{:keys [key-uid]}   (rf/sub [:multiaccount])
-        customization-color (or (:color (rf/sub [:onboarding-2/profile]))
-                                (rf/sub [:profile/customization-color key-uid]))
+  (let [customization-color (rf/sub [:profile/customization-color])
         icon-color          (->> stack-id
                                  (get shell.constants/tabs-icon-color-keywords)
                                  (get shared-values))]

--- a/src/status_im2/contexts/shell/share/view.cljs
+++ b/src/status_im2/contexts/shell/share/view.cljs
@@ -6,11 +6,11 @@
             [utils.re-frame :as rf]
             [reagent.core :as reagent]
             [quo2.foundations.colors :as colors]
-            [clojure.string :as string]
             [react-native.blur :as blur]
             [status-im.ui.components.list-selection :as list-selection]
             [utils.image-server :as image-server]
-            [react-native.navigation :as navigation]))
+            [react-native.navigation :as navigation]
+            [clojure.string :as string]))
 
 (defn header
   []
@@ -45,18 +45,21 @@
 
 (defn profile-tab
   [window-width]
-  (let [multiaccount    (rf/sub [:multiaccount])
-        emoji-hash      (string/join (get multiaccount :emoji-hash))
-        qr-size         (int (- window-width 64))
-        public-pk       (get multiaccount :compressed-key)
-        abbreviated-url (abbreviated-url image-server/status-profile-base-url-without-https public-pk)
-        profile-url     (str image-server/status-profile-base-url public-pk)
-        port            (rf/sub [:mediaserver/port])
-        key-uid         (get multiaccount :key-uid)
-        source-uri      (image-server/get-account-qr-image-uri {:key-uid    key-uid
-                                                                :public-key public-pk
-                                                                :port       port
-                                                                :qr-size    qr-size})]
+  (let [{:keys [emoji-hash
+                compressed-key
+                key-uid]} (rf/sub [:profile/profile])
+        port              (rf/sub [:mediaserver/port])
+        emoji-hash-string (string/join emoji-hash)
+        qr-size           (int (- window-width 64))
+        abbreviated-url   (abbreviated-url
+                           image-server/status-profile-base-url-without-https
+                           compressed-key)
+        profile-url       (str image-server/status-profile-base-url compressed-key)
+        source-uri        (image-server/get-account-qr-image-uri
+                           {:key-uid    key-uid
+                            :public-key compressed-key
+                            :port       port
+                            :qr-size    qr-size})]
     [:<>
      [rn/view {:style style/qr-code-container}
       [quo/qr-code
@@ -110,12 +113,12 @@
           :underlay-color   colors/neutral-80-opa-1-blur
           :background-color :transparent
           :on-press         #(rf/dispatch [:share/copy-text-and-show-toast
-                                           {:text-to-copy      emoji-hash
+                                           {:text-to-copy      emoji-hash-string
                                             :post-copy-message (i18n/label :t/emoji-hash-copied)}])
           :on-long-press    #(rf/dispatch [:share/copy-text-and-show-toast
-                                           {:text-to-copy      emoji-hash
+                                           {:text-to-copy      emoji-hash-string
                                             :post-copy-message (i18n/label :t/emoji-hash-copied)}])}
-         [rn/text {:style style/emoji-hash-content} emoji-hash]]]]
+         [rn/text {:style style/emoji-hash-content} emoji-hash-string]]]]
       [rn/view {:style style/emoji-share-button-container}
        [quo/button
         {:icon                true
@@ -125,10 +128,10 @@
          :override-theme      :dark
          :style               {:margin-right 12}
          :on-press            #(rf/dispatch [:share/copy-text-and-show-toast
-                                             {:text-to-copy      emoji-hash
+                                             {:text-to-copy      emoji-hash-string
                                               :post-copy-message (i18n/label :t/emoji-hash-copied)}])
          :on-long-press       #(rf/dispatch [:share/copy-text-and-show-toast
-                                             {:text-to-copy      emoji-hash
+                                             {:text-to-copy      emoji-hash-string
                                               :post-copy-message (i18n/label :t/emoji-hash-copied)}])}
         :i/copy]]]]))
 

--- a/src/status_im2/contexts/syncing/events.cljs
+++ b/src/status_im2/contexts/syncing/events.cljs
@@ -25,7 +25,7 @@
   [installation-id]
   (let [db {:networks/current-network config/default-network
             :networks/networks        (data-store.settings/rpc->networks config/default-networks)
-            :multiaccount             {:installation-id           installation-id
+            :profile/profile          {:installation-id           installation-id
                                        :log-level                 config/log-level
                                        :waku-bloom-filter-mode    false
                                        :custom-bootnodes          nil
@@ -79,7 +79,7 @@
                           (rf/dispatch [:bottom-sheet/hide]))]
     (if valid-password?
       (let [sha3-pwd   (native-module/sha3 (str (security/safe-unmask-data entered-password)))
-            key-uid    (get-in db [:multiaccount :key-uid])
+            key-uid    (get-in db [:profile/profile :key-uid])
             config-map (.stringify js/JSON
                                    (clj->js {:senderConfig {:keyUID       key-uid
                                                             :keystorePath ""

--- a/src/status_im2/core.cljs
+++ b/src/status_im2/core.cljs
@@ -51,4 +51,4 @@
 
   (dev/setup)
 
-  (re-frame/dispatch-sync [:setup/app-started]))
+  (re-frame/dispatch-sync [:app-started]))

--- a/src/status_im2/events.cljs
+++ b/src/status_im2/events.cljs
@@ -35,12 +35,12 @@
               :goto-key-storage?        goto-key-storage?)})
 
 (re-frame/reg-fx
- :get-profiles-overview
+ :profile/get-profiles-overview
  (fn [callback]
    (native-module/open-accounts callback)))
 
 (rf/defn get-profiles-overview-success
-  {:events [:get-profiles-overview-success]}
+  {:events [:profile/get-profiles-overview-success]}
   [cofx profiles-overview]
   (if (seq profiles-overview)
     (profile.events/init-profiles-overview cofx profiles-overview)
@@ -50,12 +50,13 @@
   {:events [:app-started]}
   [cofx]
   (rf/merge cofx
-            {:init-theme                     nil
-             :get-profiles-overview          #(re-frame/dispatch [:get-profiles-overview-success %])
-             :get-supported-biometric-auth   nil
-             :network/listen-to-network-info nil
-             :keycard/register-card-events   nil
-             :keycard/check-nfc-support      nil
-             :keycard/check-nfc-enabled      nil
-             :keycard/retrieve-pairings      nil}
+            {:theme/init-theme                       nil
+             :biometric/get-supported-biometric-auth nil
+             :network/listen-to-network-info         nil
+             :keycard/register-card-events           nil
+             :keycard/check-nfc-support              nil
+             :keycard/check-nfc-enabled              nil
+             :keycard/retrieve-pairings              nil
+             :profile/get-profiles-overview          #(re-frame/dispatch
+                                                       [:profile/get-profiles-overview-success %])}
             (initialize-app-db)))

--- a/src/status_im2/events.cljs
+++ b/src/status_im2/events.cljs
@@ -1,16 +1,10 @@
 (ns status-im2.events
-  (:require [clojure.string :as string]
-            [re-frame.core :as re-frame]
-            [status-im.multiaccounts.login.core :as multiaccounts.login]
-            [native-module.core :as native-module]
-            [status-im.utils.keychain.core :as keychain]
+  (:require [re-frame.core :as re-frame]
             [status-im2.common.json-rpc.events]
-            [status-im2.common.theme.core :as theme]
             [status-im2.common.toasts.events]
             [status-im2.contexts.add-new-contact.events]
             status-im2.contexts.onboarding.events
             [status-im.bottom-sheet.events]
-            [status-im2.navigation.events :as navigation]
             [status-im2.db :as db]
             [utils.re-frame :as rf]
             [utils.datetime :as datetime]
@@ -19,66 +13,13 @@
             status-im2.contexts.chat.events
             status-im2.common.password-authentication.events
             status-im2.contexts.communities.overview.events
-            status-im2.contexts.chat.photo-selector.events))
+            status-im2.contexts.chat.photo-selector.events
+            [status-im2.contexts.profile.events :as profile.events]
+            status-im2.common.theme.events
+            [status-im2.navigation.events :as navigation]
+            [native-module.core :as native-module]))
 
-(re-frame/reg-cofx
- :now
- (fn [coeffects _]
-   (assoc coeffects :now (datetime/timestamp))))
-
-(re-frame/reg-fx
- :setup/open-multiaccounts
- (fn [callback]
-   (native-module/open-accounts callback)))
-
-(re-frame/reg-fx
- :setup/init-theme
- (fn []
-   (theme/add-device-theme-change-listener)))
-
-(rf/defn initialize-views
-  {:events [:setup/initialize-view]}
-  [cofx]
-  (let [{{:multiaccounts/keys [multiaccounts]} :db} cofx]
-    (if (and (seq multiaccounts))
-      ;; We specifically pass a bunch of fields instead of the whole multiaccount
-      ;; as we want store some fields in multiaccount that are not here
-      (let [multiaccount (first (sort-by :timestamp > (vals multiaccounts)))]
-        (rf/merge cofx
-                  (multiaccounts.login/open-login (select-keys
-                                                   multiaccount
-                                                   [:key-uid :name :public-key :images
-                                                    :customization-color]))
-                  (keychain/get-auth-method (:key-uid multiaccount))))
-      (navigation/init-root cofx :intro))))
-
-(defn rpc->multiaccount
-  [{:keys [customizationColor keycard-pairing] :as multiaccount}]
-  (-> multiaccount
-      (dissoc :customizationColor)
-      (assoc :customization-color (keyword customizationColor))
-      (assoc :keycard-pairing
-             (when-not
-               (string/blank? keycard-pairing)
-               keycard-pairing))))
-
-(rf/defn initialize-multiaccounts
-  {:events [:setup/initialize-multiaccounts]}
-  [{:keys [db] :as cofx} all-multiaccounts {:keys [logout?]}]
-  (let [multiaccounts (reduce (fn [acc
-                                   {:keys [key-uid keycard-pairing]
-                                    :as   multiaccount}]
-                                (assoc acc key-uid (rpc->multiaccount multiaccount)))
-                              {}
-                              all-multiaccounts)]
-    (rf/merge cofx
-              {:db         (-> db
-                               (assoc :multiaccounts/multiaccounts multiaccounts)
-                               (assoc :multiaccounts/logout? logout?)
-                               (assoc :multiaccounts/loading false))
-               :dispatch-n [[:setup/initialize-view]
-                            [:get-opted-in-to-new-terms-of-service]
-                            [:load-information-box-states]]})))
+(re-frame/reg-cofx :now (fn [coeffects _] (assoc coeffects :now (datetime/timestamp))))
 
 (rf/defn initialize-app-db
   "Initialize db to initial state"
@@ -91,22 +32,30 @@
               :keycard/banner-hidden    banner-hidden
               :keycard                  (dissoc keycard :secrets :pin :application-info)
               :supported-biometric-auth supported-biometric-auth
-              :goto-key-storage?        goto-key-storage?
-              :multiaccounts/loading    true)})
+              :goto-key-storage?        goto-key-storage?)})
+
+(re-frame/reg-fx
+ :get-profiles-overview
+ (fn [callback]
+   (native-module/open-accounts callback)))
+
+(rf/defn get-profiles-overview-success
+  {:events [:get-profiles-overview-success]}
+  [cofx profiles-overview]
+  (if (seq profiles-overview)
+    (profile.events/init-profiles-overview cofx profiles-overview)
+    (navigation/init-root cofx :intro)))
 
 (rf/defn start-app
-  {:events [:setup/app-started]}
+  {:events [:app-started]}
   [cofx]
   (rf/merge cofx
-            {:setup/init-theme               nil
+            {:init-theme                     nil
+             :get-profiles-overview          #(re-frame/dispatch [:get-profiles-overview-success %])
              :get-supported-biometric-auth   nil
              :network/listen-to-network-info nil
              :keycard/register-card-events   nil
              :keycard/check-nfc-support      nil
              :keycard/check-nfc-enabled      nil
-             :keycard/retrieve-pairings      nil
-             :setup/open-multiaccounts       #(do
-                                                (re-frame/dispatch [:setup/initialize-multiaccounts %
-                                                                    {:logout? false}])
-                                                (re-frame/dispatch [:get-keycard-banner-preference]))}
+             :keycard/retrieve-pairings      nil}
             (initialize-app-db)))

--- a/src/status_im2/navigation/events.cljs
+++ b/src/status_im2/navigation/events.cljs
@@ -133,9 +133,9 @@
 (rf/defn set-multiaccount-root
   {:events [:set-multiaccount-root]}
   [{:keys [db]}]
-  (let [key-uid          (get-in db [:multiaccounts/login :key-uid])
+  (let [key-uid          (get-in db [:profile/login :key-uid])
         keycard-account? (boolean (get-in db
-                                          [:multiaccounts/multiaccounts
+                                          [:profile/profiles-overview
                                            key-uid
                                            :keycard-pairing]))]
     {:set-root (if keycard-account? :multiaccounts-keycard :multiaccounts)}))

--- a/src/status_im2/navigation/roots.cljs
+++ b/src/status_im2/navigation/roots.cljs
@@ -80,7 +80,7 @@
 ;; Theme Order for navigation roots
 ;; 1. Themes hardcoded in below map
 ;; 2. If nil or no entry in map, then theme stored in
-;;    [:db :multiaccount :appearance] will be used (for mulitaccounts)
+;;    [:db :profile/profile :appearance] will be used (for mulitaccounts)
 ;; 3). Fallback theme - Dark
 (def themes
   {:intro       constants/theme-type-dark

--- a/src/status_im2/subs/bootnodes.cljs
+++ b/src/status_im2/subs/bootnodes.cljs
@@ -3,14 +3,14 @@
 
 (re-frame/reg-sub
  :custom-bootnodes/enabled?
- :<- [:multiaccount]
+ :<- [:profile/profile]
  :<- [:networks/current-network]
  (fn [[{:keys [custom-bootnodes-enabled?]} current-network]]
    (get custom-bootnodes-enabled? current-network)))
 
 (re-frame/reg-sub
  :custom-bootnodes/network-bootnodes
- :<- [:multiaccount]
+ :<- [:profile/profile]
  :<- [:networks/current-network]
  (fn [[multiaccount current-network]]
    (get-in multiaccount [:custom-bootnodes current-network])))

--- a/src/status_im2/subs/chat/chats.cljs
+++ b/src/status_im2/subs/chat/chats.cljs
@@ -285,12 +285,6 @@
                                       (get contacts id)))))
 
 (re-frame/reg-sub
- :profile/customization-color
- :<- [:multiaccounts/multiaccounts]
- (fn [multiaccounts [_ id]]
-   (or (:customization-color (get multiaccounts id)) constants/profile-default-color)))
-
-(re-frame/reg-sub
  :chats/unread-messages-number
  :<- [:chats/home-list-chats]
  (fn [chats _]

--- a/src/status_im2/subs/chat/chats_test.cljs
+++ b/src/status_im2/subs/chat/chats_test.cljs
@@ -37,14 +37,14 @@
   (testing "private group chat, user is a member"
     (let [chats {chat-id private-group-chat}]
       (swap! rf-db/app-db assoc
-        :multiaccount    multiaccount
+        :profile/profile multiaccount
         :current-chat-id chat-id
         :chats           chats)
       (is (true? (:able-to-send-message? (rf/sub [sub-name]))))))
   (testing "private group chat, user is not member"
     (let [chats {chat-id (dissoc private-group-chat :members)}]
       (swap! rf-db/app-db assoc
-        :multiaccount    multiaccount
+        :profile/profile multiaccount
         :current-chat-id chat-id
         :chats           chats)
       (is (not (:able-to-send-message? (rf/sub [sub-name]))))))
@@ -52,7 +52,7 @@
     (let [chats {chat-id one-to-one-chat}]
       (swap! rf-db/app-db assoc
         :contacts/contacts {chat-id {:contact-request-state constants/contact-request-state-mutual}}
-        :multiaccount      multiaccount
+        :profile/profile   multiaccount
         :current-chat-id   chat-id
         :chats             chats)
       (is (:able-to-send-message? (rf/sub [sub-name])))))
@@ -60,7 +60,7 @@
     (let [chats {chat-id one-to-one-chat}]
       (swap! rf-db/app-db assoc
         :contacts/contacts {chat-id {:contact-request-state constants/contact-request-state-sent}}
-        :multiaccount      multiaccount
+        :profile/profile   multiaccount
         :current-chat-id   chat-id
         :chats             chats)
       (is (not (:able-to-send-message? (rf/sub [sub-name])))))))
@@ -90,7 +90,7 @@
       (is (false? (:community? (rf/sub [sub-name]))))
       (swap! rf-db/app-db assoc
         :communities/enabled? true
-        :multiaccount         multiaccount
+        :profile/profile      multiaccount
         :current-chat-id      chat-id
         :chats                chats
         :communities          communities)
@@ -112,7 +112,7 @@
       (is (false? (:community? (rf/sub [sub-name]))))
       (swap! rf-db/app-db assoc
         :communities/enabled? true
-        :multiaccount         multiaccount
+        :profile/profile      multiaccount
         :current-chat-id      chat-id
         :chats                chats
         :communities          communities)
@@ -130,7 +130,7 @@
                                 #{public-key})}]
       (swap! rf-db/app-db assoc
         :communities/enabled? true
-        :multiaccount         multiaccount
+        :profile/profile      multiaccount
         :current-chat-id      chat-id
         :chats                chats)
       (is (= chat-id (:chat-id (rf/sub [sub-name]))))
@@ -148,7 +148,7 @@
                                 #{})}]
       (swap! rf-db/app-db assoc
         :communities/enabled? true
-        :multiaccount         multiaccount
+        :profile/profile      multiaccount
         :current-chat-id      chat-id
         :chats                chats)
       (is (= chat-id (:chat-id (rf/sub [sub-name]))))

--- a/src/status_im2/subs/communities.cljs
+++ b/src/status_im2/subs/communities.cljs
@@ -52,7 +52,7 @@
  :communities/sorted-community-members
  (fn [[_ community-id]]
    (let [contacts     (re-frame/subscribe [:contacts/contacts])
-         multiaccount (re-frame/subscribe [:multiaccount])
+         multiaccount (re-frame/subscribe [:profile/profile])
          members      (re-frame/subscribe [:communities/community-members community-id])]
      [contacts multiaccount members]))
  (fn [[contacts multiaccount members] _]

--- a/src/status_im2/subs/contact.cljs
+++ b/src/status_im2/subs/contact.cljs
@@ -21,13 +21,13 @@
 
 (re-frame/reg-sub
  :multiaccount/profile-pictures-show-to
- :<- [:multiaccount]
+ :<- [:profile/profile]
  (fn [multiaccount]
    (get multiaccount :profile-pictures-show-to)))
 
 (re-frame/reg-sub
  ::profile-pictures-visibility
- :<- [:multiaccount]
+ :<- [:profile/profile]
  (fn [multiaccount]
    (get multiaccount :profile-pictures-visibility)))
 
@@ -216,7 +216,7 @@
  :contacts/contact-two-names-by-identity
  (fn [[_ identity] _]
    [(re-frame/subscribe [:contacts/contact-by-identity identity])
-    (re-frame/subscribe [:multiaccount])])
+    (re-frame/subscribe [:profile/profile])])
  (fn [[contact current-multiaccount] [_ identity]]
    (multiaccounts/contact-two-names-by-identity contact
                                                 current-multiaccount
@@ -233,7 +233,7 @@
  :messages/quote-info
  :<- [:chats/messages]
  :<- [:contacts/contacts]
- :<- [:multiaccount]
+ :<- [:profile/profile]
  (fn [[messages contacts current-multiaccount] [_ message-id]]
    (when-let [message (get messages message-id)]
      (let [identity (:from message)
@@ -262,7 +262,7 @@
  :contacts/current-chat-contacts
  :<- [:chats/current-chat]
  :<- [:contacts/contacts]
- :<- [:multiaccount]
+ :<- [:profile/profile]
  (fn [[{:keys [contacts admins]} all-contacts current-multiaccount]]
    (contact.db/get-all-contacts-in-group-chat contacts admins all-contacts current-multiaccount)))
 

--- a/src/status_im2/subs/ens.cljs
+++ b/src/status_im2/subs/ens.cljs
@@ -7,13 +7,13 @@
 
 (re-frame/reg-sub
  :multiaccount/usernames
- :<- [:multiaccount]
+ :<- [:profile/profile]
  (fn [multiaccount]
    (:usernames multiaccount)))
 
 (re-frame/reg-sub
  :ens/preferred-name
- :<- [:multiaccount]
+ :<- [:profile/profile]
  (fn [multiaccount]
    (:preferred-name multiaccount)))
 
@@ -84,11 +84,11 @@
 (re-frame/reg-sub
  :ens.main/screen
  :<- [:multiaccount/usernames]
- :<- [:multiaccount]
+ :<- [:profile/profile]
  :<- [:ens/preferred-name]
  :<- [:ens/registrations]
  (fn [[names multiaccount preferred-name registrations]]
-   {:names          names
-    :multiaccount   multiaccount
-    :preferred-name preferred-name
-    :registrations  registrations}))
+   {:names           names
+    :profile/profile multiaccount
+    :preferred-name  preferred-name
+    :registrations   registrations}))

--- a/src/status_im2/subs/general.cljs
+++ b/src/status_im2/subs/general.cljs
@@ -34,7 +34,7 @@
 (re-frame/reg-sub
  :hide-screen?
  :<- [:app-state]
- :<- [:multiaccount]
+ :<- [:profile/profile]
  (fn [[state multiaccount]]
    (and (= state "inactive") (:preview-privacy? multiaccount))))
 
@@ -242,7 +242,7 @@
  :<- [:mailserver/connection-error?]
  :<- [:mailserver/request-error?]
  :<- [:network/type]
- :<- [:multiaccount]
+ :<- [:profile/profile]
  (fn [[network-status disconnected? mailserver-connecting? mailserver-connection-error?
        mailserver-request-error? network-type {:keys [syncing-on-mobile-network? use-mailservers?]}]]
    (merge {:mobile (mobile-network-utils/cellular? network-type)
@@ -272,20 +272,20 @@
 
 (re-frame/reg-sub
  :mnemonic
- :<- [:multiaccount]
+ :<- [:profile/profile]
  (fn [{:keys [mnemonic]}]
    mnemonic))
 
 (re-frame/reg-sub
  :get-profile-unread-messages-number
- :<- [:multiaccount]
+ :<- [:profile/profile]
  (fn [{:keys [mnemonic]}]
    (if mnemonic 1 0)))
 
 (re-frame/reg-sub
  :mobile-network/syncing-allowed?
  :<- [:network/type]
- :<- [:multiaccount]
+ :<- [:profile/profile]
  (fn [[network-type {:keys [syncing-on-mobile-network?]}]]
    (or (= network-type "wifi")
        (and

--- a/src/status_im2/subs/home.cljs
+++ b/src/status_im2/subs/home.cljs
@@ -18,6 +18,6 @@
 
 (re-frame/reg-sub
  :hide-home-tooltip?
- :<- [:multiaccount]
+ :<- [:profile/profile]
  (fn [multiaccount]
    (:hide-home-tooltip? multiaccount)))

--- a/src/status_im2/subs/keycard.cljs
+++ b/src/status_im2/subs/keycard.cljs
@@ -106,7 +106,7 @@
 (re-frame/reg-sub
  :keycard-multiaccount
  (fn [db]
-   (get-in db [:keycard :multiaccount])))
+   (get-in db [:keycard :profile/profile])))
 
 (re-frame/reg-sub
  :keycard-multiaccount-wallet-address
@@ -121,13 +121,13 @@
 (re-frame/reg-sub
  :keycard-paired-on
  (fn [db]
-   (some-> (get-in db [:multiaccount :keycard-paired-on])
+   (some-> (get-in db [:profile/profile :keycard-paired-on])
            (datetime/timestamp->year-month-day-date))))
 
 (re-frame/reg-sub
  :keycard-multiaccount-pairing
  (fn [db]
-   (get-in db [:multiaccount :keycard-pairing])))
+   (get-in db [:profile/profile :keycard-pairing])))
 
 (re-frame/reg-sub
  :keycard/pin-retry-counter

--- a/src/status_im2/subs/mailservers.cljs
+++ b/src/status_im2/subs/mailservers.cljs
@@ -82,7 +82,7 @@
 
 (re-frame/reg-sub
  :mailserver/preferred-id
- :<- [:multiaccount]
+ :<- [:profile/profile]
  (fn [multiaccount]
    (get-in multiaccount
            [:pinned-mailservers (fleet/current-fleet-sub multiaccount)])))

--- a/src/status_im2/subs/onboarding.cljs
+++ b/src/status_im2/subs/onboarding.cljs
@@ -66,7 +66,7 @@
                                             :theme      (theme/get-theme)
                                             :ring?      true})))))
 
-(defn login-ma-keycard-pairing
+(defn login-profile-keycard-pairing
   "Compute the keycard-pairing value of the multiaccount selected for login"
   [db _]
   (when-let [acc-to-login (-> db :profile/login)]
@@ -77,4 +77,4 @@
 
 (re-frame/reg-sub
  :intro-wizard/acc-to-login-keycard-pairing
- login-ma-keycard-pairing)
+ login-profile-keycard-pairing)

--- a/src/status_im2/subs/onboarding.cljs
+++ b/src/status_im2/subs/onboarding.cljs
@@ -46,13 +46,13 @@
 (re-frame/reg-sub
  :intro-wizard/recover-existing-account?
  :<- [:intro-wizard]
- :<- [:multiaccounts/multiaccounts]
+ :<- [:profile/profiles-overview]
  (fn [[intro-wizard multiaccounts]]
    (recover/existing-account? (:root-key intro-wizard) multiaccounts)))
 
 (re-frame/reg-sub
- :multiaccounts/login-profiles-picture
- :<- [:multiaccounts/multiaccounts]
+ :profile/login-profiles-picture
+ :<- [:profile/profiles-overview]
  :<- [:mediaserver/port]
  (fn [[multiaccounts port] [_ target-key-uid]]
    (let [image-name (-> multiaccounts
@@ -69,9 +69,9 @@
 (defn login-ma-keycard-pairing
   "Compute the keycard-pairing value of the multiaccount selected for login"
   [db _]
-  (when-let [acc-to-login (-> db :multiaccounts/login)]
+  (when-let [acc-to-login (-> db :profile/login)]
     (-> db
-        :multiaccounts/multiaccounts
+        :profile/profiles-overview
         (get (:key-uid acc-to-login))
         :keycard-pairing)))
 

--- a/src/status_im2/subs/onboarding_test.cljs
+++ b/src/status_im2/subs/onboarding_test.cljs
@@ -11,25 +11,25 @@
 (def port "mediaserver-port")
 (def cur-theme :current-theme)
 
-(h/deftest-sub :multiaccounts/login-profiles-picture
+(h/deftest-sub :profile/login-profiles-picture
   [sub-name]
   (with-redefs [image-server/get-account-image-uri identity
                 theme/get-theme                    (constantly cur-theme)]
     (t/testing "nil when no images"
-      (swap! rf-db/app-db assoc :multiaccounts/multiaccounts {key-uid {}})
+      (swap! rf-db/app-db assoc :profile/profiles-overview {key-uid {}})
       (t/is (nil? (rf/sub [sub-name key-uid]))))
 
     (t/testing "nil when no key-uid"
-      (swap! rf-db/app-db assoc :multiaccounts/multiaccounts {key-uid {}})
+      (swap! rf-db/app-db assoc :profile/profiles-overview {key-uid {}})
       (t/is (nil? (rf/sub [sub-name "0x2"]))))
 
     (t/testing "result from image-server/get-account-image-uri"
       (swap!
         rf-db/app-db
         assoc
-        :multiaccounts/multiaccounts {key-uid {:images [{:type "large"}
-                                                        {:type "thumbnail"}]}}
-        :mediaserver/port            port)
+        :profile/profiles-overview {key-uid {:images [{:type "large"}
+                                                      {:type "thumbnail"}]}}
+        :mediaserver/port          port)
       (t/is (= (rf/sub [sub-name key-uid])
                {:port       port
                 :image-name "large"

--- a/src/status_im2/subs/pairing.cljs
+++ b/src/status_im2/subs/pairing.cljs
@@ -19,12 +19,12 @@
 
 (re-frame/reg-sub
  :pairing/installation-id
- :<- [:multiaccount]
+ :<- [:profile/profile]
  (fn [multiaccount] (:installation-id multiaccount)))
 
 (re-frame/reg-sub
  :pairing/installation-name
- :<- [:multiaccount]
+ :<- [:profile/profile]
  (fn [multiaccount] (:installation-name multiaccount)))
 
 (re-frame/reg-sub

--- a/src/status_im2/subs/root.cljs
+++ b/src/status_im2/subs/root.cljs
@@ -89,6 +89,7 @@
 (reg-root-key-sub :profile/profiles-overview :profile/profiles-overview)
 (reg-root-key-sub :profile/login :profile/login)
 ;; we have some fields only in overview, would be cool to merge them in status-go
+;; https://github.com/status-im/status-mobile/issues/16422
 (reg-root-key-sub :profile/profile-settings :profile/profile)
 (reg-root-key-sub :profile/wallet-accounts :profile/wallet-accounts)
 

--- a/src/status_im2/subs/root.cljs
+++ b/src/status_im2/subs/root.cljs
@@ -13,7 +13,7 @@
     status-im2.subs.home
     status-im2.subs.keycard
     status-im2.subs.mailservers
-    status-im2.subs.multiaccount
+    status-im2.subs.profile
     status-im2.subs.networks
     status-im2.subs.onboarding
     status-im2.subs.pairing
@@ -82,17 +82,16 @@
 ;; it is about cellular network/ wifi network
 (reg-root-key-sub :network/type :network/type)
 
-;;profile
+;;my profile
 (reg-root-key-sub :my-profile/seed :my-profile/seed)
-(reg-root-key-sub :my-profile/advanced? :my-profile/advanced?)
-(reg-root-key-sub :my-profile/profile :my-profile/profile)
 
-;;multiaccount
-(reg-root-key-sub :multiaccounts/multiaccounts :multiaccounts/multiaccounts)
-(reg-root-key-sub :multiaccounts/login :multiaccounts/login)
-(reg-root-key-sub :multiaccount :multiaccount)
-(reg-root-key-sub :multiaccount/accounts :multiaccount/accounts)
-(reg-root-key-sub :get-recover-multiaccount :multiaccounts/recover)
+;;profiles
+(reg-root-key-sub :profile/profiles-overview :profile/profiles-overview)
+(reg-root-key-sub :profile/login :profile/login)
+;; we have some fields only in overview, would be cool to merge them in status-go
+(reg-root-key-sub :profile/profile-settings :profile/profile)
+(reg-root-key-sub :profile/wallet-accounts :profile/wallet-accounts)
+
 (reg-root-key-sub :multiaccounts/key-storage :multiaccounts/key-storage)
 (reg-root-key-sub :multiaccount/reset-password-form-vals :multiaccount/reset-password-form-vals)
 (reg-root-key-sub :multiaccount/reset-password-errors :multiaccount/reset-password-errors)
@@ -231,8 +230,6 @@
 (reg-root-key-sub :keycard :keycard)
 
 (reg-root-key-sub :auth-method :auth-method)
-
-(reg-root-key-sub :multiaccounts/loading :multiaccounts/loading)
 
 (reg-root-key-sub :tos-accept-next-root :tos-accept-next-root)
 

--- a/src/status_im2/subs/subs_test.cljs
+++ b/src/status_im2/subs/subs_test.cljs
@@ -25,18 +25,18 @@
            grouped-transactions))))
 
 (deftest login-ma-keycard-pairing
-  (testing "returns nil when no :multiaccounts/login"
+  (testing "returns nil when no :profile/login"
     (let [res (onboarding/login-ma-keycard-pairing
-               {:multiaccounts/login nil
-                :multiaccounts/multiaccounts
+               {:profile/login nil
+                :profile/profiles-overview
                 {"0x1" {:keycard-pairing "keycard-pairing-code"}}}
                {})]
       (is (nil? res))))
 
-  (testing "returns :keycard-pairing when :multiaccounts/login is present"
+  (testing "returns :keycard-pairing when :profile/login is present"
     (let [res (onboarding/login-ma-keycard-pairing
-               {:multiaccounts/login {:key-uid "0x1"}
-                :multiaccounts/multiaccounts
+               {:profile/login {:key-uid "0x1"}
+                :profile/profiles-overview
                 {"0x1" {:keycard-pairing "keycard-pairing-code"}}}
                {})]
       (is (= res "keycard-pairing-code")))))

--- a/src/status_im2/subs/subs_test.cljs
+++ b/src/status_im2/subs/subs_test.cljs
@@ -24,9 +24,9 @@
     (is (= (wallet.transactions/group-transactions-by-date transactions)
            grouped-transactions))))
 
-(deftest login-ma-keycard-pairing
+(deftest login-profile-keycard-pairing
   (testing "returns nil when no :profile/login"
-    (let [res (onboarding/login-ma-keycard-pairing
+    (let [res (onboarding/login-profile-keycard-pairing
                {:profile/login nil
                 :profile/profiles-overview
                 {"0x1" {:keycard-pairing "keycard-pairing-code"}}}
@@ -34,7 +34,7 @@
       (is (nil? res))))
 
   (testing "returns :keycard-pairing when :profile/login is present"
-    (let [res (onboarding/login-ma-keycard-pairing
+    (let [res (onboarding/login-profile-keycard-pairing
                {:profile/login {:key-uid "0x1"}
                 :profile/profiles-overview
                 {"0x1" {:keycard-pairing "keycard-pairing-code"}}}

--- a/src/status_im2/subs/wallet/signing.cljs
+++ b/src/status_im2/subs/wallet/signing.cljs
@@ -84,14 +84,14 @@
 
 (re-frame/reg-sub
  :signing/phrase
- :<- [:multiaccount]
+ :<- [:profile/profile]
  (fn [{:keys [signing-phrase]}]
    signing-phrase))
 
 (re-frame/reg-sub
  :signing/sign-message
  :<- [:signing/sign]
- :<- [:multiaccount/accounts]
+ :<- [:profile/wallet-accounts]
  :<- [:prices]
  (fn [[sign wallet-accounts prices]]
    (if (= :pinless (:type sign))

--- a/src/status_im2/subs/wallet/wallet.cljs
+++ b/src/status_im2/subs/wallet/wallet.cljs
@@ -17,7 +17,7 @@
 (re-frame/reg-sub
  :balance-default
  :<- [:wallet]
- :<- [:multiaccount/accounts]
+ :<- [:profile/wallet-accounts]
  (fn [[wallet accounts]]
    (get-in wallet [:accounts (:address (ethereum/get-default-account accounts)) :balance])))
 
@@ -55,7 +55,7 @@
 
 (re-frame/reg-sub
  :wallet.settings/currency
- :<- [:multiaccount]
+ :<- [:profile/profile]
  (fn [settings]
    (or (get settings :currency) :usd)))
 
@@ -170,7 +170,7 @@
 (re-frame/reg-sub
  :wallet/visible-tokens-symbols
  :<- [:ethereum/chain-keyword]
- :<- [:multiaccount]
+ :<- [:profile/profile]
  (fn [[chain current-multiaccount]]
    (get-in current-multiaccount [:wallet/visible-tokens chain])))
 

--- a/src/status_im2/subs/wallet/wallet_test.cljs
+++ b/src/status_im2/subs/wallet/wallet_test.cljs
@@ -52,8 +52,8 @@
 (h/deftest-sub :balances
   [sub-name]
   (swap! rf-db/app-db assoc
-    :multiaccount/accounts accounts
-    :wallet                wallet)
+    :profile/wallet-accounts accounts
+    :wallet                  wallet)
   (is (= [{:ETH money-eth
            :SNT money-snt}
           {:ETH money-eth
@@ -90,18 +90,18 @@
                                    {:balance {:ETH money-zero
                                               :SNT money-zero}}}}]
       (swap! rf-db/app-db assoc
-        :multiaccount/accounts accounts
-        :prices                prices
-        :wallet                empty-wallet
-        :wallet/all-tokens     tokens)
+        :profile/wallet-accounts accounts
+        :prices                  prices
+        :wallet                  empty-wallet
+        :wallet/all-tokens       tokens)
       (is (= "0" (rf/sub [sub-name])))))
 
   (testing "returns formatted value in the default USD currency"
     (swap! rf-db/app-db assoc
-      :multiaccount/accounts accounts
-      :prices                prices
-      :wallet                wallet
-      :wallet/all-tokens     tokens)
+      :profile/wallet-accounts accounts
+      :prices                  prices
+      :wallet                  wallet
+      :wallet/all-tokens       tokens)
     (is (= "20,550.76" (rf/sub [sub-name])))))
 
 (h/deftest-sub :account-portfolio-value
@@ -114,16 +114,16 @@
                                    {:balance {:ETH money-zero
                                               :SNT money-zero}}}}]
       (swap! rf-db/app-db assoc
-        :multiaccount/accounts accounts
-        :prices                prices
-        :wallet                empty-wallet
-        :wallet/all-tokens     tokens)
+        :profile/wallet-accounts accounts
+        :prices                  prices
+        :wallet                  empty-wallet
+        :wallet/all-tokens       tokens)
       (is (= "0" (rf/sub [sub-name main-account-id])))))
 
   (testing "returns formatted value in the default USD currency"
     (swap! rf-db/app-db assoc
-      :multiaccount/accounts accounts
-      :prices                prices
-      :wallet                wallet
-      :wallet/all-tokens     tokens)
+      :profile/wallet-accounts accounts
+      :prices                  prices
+      :wallet                  wallet
+      :wallet/all-tokens       tokens)
     (is (= "10,275.38" (rf/sub [sub-name main-account-id])))))


### PR DESCRIPTION
i know it looks scary, but someone should do it :) 

the first step of moving from multiaccounts to profiles

`:multiaccounts/multiaccounts` renamed to `:profile/profiles-overview` , it's unencrypted part of profiles used on login page

`:multiaccounts/login` renamed to `:profile/login`

`:multiaccount` renamed to `:profile/profile` which is actually a `:profile/profile-settings` which is merged with `:profile/profiles-overview` in `:profile/profile` subscription, latter it would be great to `merge` it on status-go side  https://github.com/status-im/status-mobile/issues/16422

`:multiaccount/accounts` renamed to `:profile/wallet-accounts`

also fixes: https://github.com/status-im/status-mobile/issues/16175
