### PR TITLE
Fix new message indicator for chats bottom tab

### DIFF
--- a/src/status_im2/subs/shell.cljs
+++ b/src/status_im2/subs/shell.cljs
@@ -215,8 +215,8 @@
        :counter-label          (:unviewed-mentions-count community-stack)}
       :chats-stack
       {:new-notifications?     (pos? (:unviewed-messages-count chats-stack))
-       :notification-indicator (if (pos? (:unviewed-mentions-count chats-stack)) :counter :unread-dot)
-       :counter-label          (:unviewed-mentions-count chats-stack)}})))
+       :notification-indicator :counter
+       :counter-label          (:unviewed-messages-count chats-stack)}})))
 
 ;; Floating screens
 (re-frame/reg-sub

--- a/src/status_im2/subs/shell_test.cljs
+++ b/src/status_im2/subs/shell_test.cljs
@@ -29,8 +29,8 @@
                        :notification-indicator :unread-dot
                        :counter-label          0}
    :chats-stack       {:new-notifications?     true
-                       :notification-indicator :unread-dot
-                       :counter-label          0}})
+                       :notification-indicator :counter
+                       :counter-label          7}})
 
 (def one-to-one-group-community-chats2
   (merge
@@ -51,7 +51,7 @@
                        :counter-label          7}
    :chats-stack       {:new-notifications?     true
                        :notification-indicator :counter
-                       :counter-label          9}})
+                       :counter-label          19}})
 
 (h/deftest-sub :shell/bottom-tabs-notifications-data
   [sub-name]


### PR DESCRIPTION
fixes #16412

### Summary

Now bottom tab for chats doesn't show unread indicators, only counter for unread messages.


### Steps to test

Alice sends Bob 1 mention and 1 ordinary messages in 1-1 chat.

**Expected result:**

The Messages bottom tab should display “2” as the number displayed here should always be the sum of all the individual counters in that section of the app


status: ready
