### PR TITLE
feat: allow navigation within different stacks

### DIFF
--- a/src/react_native/navigation.cljs
+++ b/src/react_native/navigation.cljs
@@ -33,6 +33,10 @@
   [comp]
   (.showOverlay Navigation (clj->js comp)))
 
+(defn pop-to
+  [comp]
+  (.popTo Navigation (clj->js comp)))
+
 (defn pop-to-root
   [tab]
   (.popToRoot Navigation (clj->js tab)))

--- a/src/status_im2/navigation/events.cljs
+++ b/src/status_im2/navigation/events.cljs
@@ -21,6 +21,11 @@
     :dispatch-n [[:hide-bottom-sheet]]}
    (shell.events/shell-navigate-to go-to-view-id screen-params nil nil)))
 
+(rf/defn navigate-to-within-stack
+  {:events [:navigate-to-within-stack]}
+  [_ comp-id]
+  {:navigate-to-within-stack comp-id})
+
 (rf/defn open-modal
   {:events [:open-modal]}
   [{:keys [db]} comp screen-params]
@@ -29,10 +34,25 @@
    :dispatch      [:hide-bottom-sheet]
    :open-modal-fx comp})
 
+(rf/defn dismiss-modal
+  {:events [:dismiss-modal]}
+  [_ comp-id]
+  {:dismiss-modal comp-id})
+
 (rf/defn navigate-back
   {:events [:navigate-back]}
   [cofx]
   (shell.events/shell-navigate-back cofx))
+
+(rf/defn navigate-back-within-stack
+  {:events [:navigate-back-within-stack]}
+  [_ comp-id]
+  {:navigate-back-within-stack comp-id})
+
+(rf/defn navigate-back-to
+  {:events [:navigate-back-to]}
+  [_ comp-id]
+  {:navigate-back-to comp-id})
 
 (rf/defn pop-to-root
   {:events [:pop-to-root]}


### PR DESCRIPTION
fixes #16418

### Summary

Currently, for navigation between screens we only have `:navigate-to` and `:navigate-back` events, which respectively pushes and pops screens from / to the root stack, and dismisses any modal that may be presented to the user. This PR adds the ability to navigate inside different navigation stacks, and also creates a new stack when we present a modal screen, so we could optionally push new screens on that modal sub-flow. There are several cases that need this solution, but most (or maybe all of them) are those where we present a modal, and we need to push a new screen within that modal stack. One example is [this issue](https://github.com/status-im/status-mobile/pull/16167#issuecomment-1609793057) found by @pavloburykh, where we now use a modal screen for the Sign In sub-flow inside the Onboarding flow, and current navigation events forces a modal to dismiss. I am sure we will need this in many other parts of the application as flows complexity starts to increase.

To summarize changes:
- On `open-modal` function, add the screen to a stack with that screen as the root of the stack. It does not affect current modals that doesn't make use of navigation. Reference: https://wix.github.io/react-native-navigation/api/modal#showmodal
- `dissmissModal` function (there's a typo in that function name, we can fix it in another PR) now receives an optional parameter `comp-id`, which is the `react-native-navigation` componentId, and uses `@state/modals` as fallback value, so we could now dismiss a specific modal. Reference: https://wix.github.io/react-native-navigation/api/modal#dismissmodal
- I am adding three new events to the navigation namespace:
    - `:navigate-to-within-stack` which receives the name of the screen to be pushed to the stack, and the componentId of the screen provided by react-native-navigation, which is needed to identify on which stack the screen needs to be pushed. Reference: https://wix.github.io/react-native-navigation/api/stack/#push
    - `:navigate-back-within-stack` which receives the componentId of the screen provided by react-native-navigation, which is needed to identify which stack needs to pop. Reference: https://wix.github.io/react-native-navigation/api/stack/#pop
    - `:navigate-back-to` which receives the componentId of the screen provided by react-native-navigation, which is needed to identify which screen needs to pop to, on its corresponding stack. Reference: https://wix.github.io/react-native-navigation/api/stack/#popto

### Testing notes

Some smoke testing would be useful

#### Platforms

- Android
- iOS

#### Areas that maybe impacted

##### Functional

- onboarding
- 1-1 chats
- communities
- group chats
- wallet / transactions
- account recovery

### Steps to test

- Open Status
- Use the app
- Some general smoke testing

status: ready
