### PR TITLE
[#16073] Password info box

### DIFF
--- a/src/quo2/components/drawers/documentation_drawers/style.cljs
+++ b/src/quo2/components/drawers/documentation_drawers/style.cljs
@@ -1,5 +1,6 @@
 (ns quo2.components.drawers.documentation-drawers.style
-  (:require [react-native.safe-area :as safe-area]))
+  (:require [quo2.foundations.colors :as colors]
+            [react-native.safe-area :as safe-area]))
 
 (def outer-container
   ;; Margin negative to fill the bottom-sheet container where this component is used
@@ -12,3 +13,9 @@
 (def content
   {:margin-top    8
    :margin-bottom (+ (safe-area/get-bottom) 8)})
+
+(defn title
+  [shell?]
+  {:color (colors/theme-colors colors/neutral-100
+                               colors/white
+                               (when shell? :dark))})

--- a/src/quo2/components/drawers/documentation_drawers/style.cljs
+++ b/src/quo2/components/drawers/documentation_drawers/style.cljs
@@ -1,4 +1,9 @@
-(ns quo2.components.drawers.documentation-drawers.style)
+(ns quo2.components.drawers.documentation-drawers.style
+  (:require [react-native.safe-area :as safe-area]))
+
+(def outer-container
+  ;; Margin negative to fill the bottom-sheet container where this component is used
+  {:margin-bottom (- (+ (safe-area/get-bottom) 8))})
 
 (def container
   {:align-items        :flex-start
@@ -6,4 +11,4 @@
 
 (def content
   {:margin-top    8
-   :margin-bottom 16})
+   :margin-bottom (+ (safe-area/get-bottom) 8)})

--- a/src/quo2/components/drawers/documentation_drawers/view.cljs
+++ b/src/quo2/components/drawers/documentation_drawers/view.cljs
@@ -1,10 +1,10 @@
 (ns quo2.components.drawers.documentation-drawers.view
-  (:require [quo2.components.markdown.text :as text]
+  (:require [quo2.components.buttons.button :as button]
             [quo2.components.drawers.documentation-drawers.style :as style]
+            [quo2.components.markdown.text :as text]
+            [quo2.foundations.colors :as colors]
             [react-native.core :as rn]
-            [react-native.gesture :as gesture]
-            [quo2.components.buttons.button :as button]
-            [quo2.foundations.colors :as colors]))
+            [react-native.gesture :as gesture]))
 
 (defn view
   "Options
@@ -14,11 +14,13 @@
    - `button-icon` button icon
    - `on-press-button` On press handler for the button
    - `shell?` use shell theme
-
    `content` Content of the drawer
    "
   [{:keys [title show-button? on-press-button button-label button-icon shell?]} content]
   [gesture/scroll-view
+   {:style                             style/outer-container
+    :always-bounce-vertical            false
+    :content-inset-adjustment-behavior :never}
    [rn/view {:style style/container}
     [text/text
      {:size                :heading-2

--- a/src/quo2/components/drawers/documentation_drawers/view.cljs
+++ b/src/quo2/components/drawers/documentation_drawers/view.cljs
@@ -2,7 +2,6 @@
   (:require [quo2.components.buttons.button :as button]
             [quo2.components.drawers.documentation-drawers.style :as style]
             [quo2.components.markdown.text :as text]
-            [quo2.foundations.colors :as colors]
             [react-native.core :as rn]
             [react-native.gesture :as gesture]))
 
@@ -25,9 +24,7 @@
     [text/text
      {:size                :heading-2
       :accessibility-label :documentation-drawer-title
-      :style               {:color (colors/theme-colors colors/neutral-100
-                                                        colors/white
-                                                        (when shell? :dark))}
+      :style               (style/title shell?)
       :weight              :semi-bold}
      title]
     [rn/view {:style style/content :accessibility-label :documentation-drawer-content}

--- a/src/react_native/safe_area.cljs
+++ b/src/react_native/safe_area.cljs
@@ -10,7 +10,8 @@
 
 (defn- get-static-bottom
   []
-  (oops/oget StaticSafeAreaInsets "safeAreaInsetsBottom"))
+  (some-> StaticSafeAreaInsets
+          (oops/oget "safeAreaInsetsBottom")))
 
 (defn get-top
   []
@@ -20,8 +21,8 @@
 
 (defn get-bottom
   []
-  (if platform/ios?
-    (get-static-bottom)
+  (if-let [bottom (and platform/ios? (get-static-bottom))]
+    bottom
     0))
 
 (defn get-insets

--- a/src/status_im2/common/bottom_sheet/style.cljs
+++ b/src/status_im2/common/bottom_sheet/style.cljs
@@ -16,8 +16,7 @@
 (defn sheet
   [{:keys [top bottom]} window-height override-theme padding-bottom-override shell?]
   {:position                :absolute
-   :max-height              (cond-> window-height
-                              platform/ios? (- top))
+   :max-height              (- window-height top)
    :z-index                 1
    :bottom                  0
    :left                    0


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes #16073

### Summary

[comment]: # (Summarise the problem and how the pull request solves it)

This PR fixes the style and behaviour of the documenation drawer, which is used in the password info box.

- When the documentation drawer is opened and the content is bigger than the drawer, it is drawn over the iOS swipe bar, as in designs:

https://www.figma.com/file/o4qG1bnFyuyFOvHQVGgeFY/Onboarding-for-Mobile?type=design&node-id=4338-513310&mode=design&t=ecMw9WCY71kQ5ISi-4


![Simulator Screenshot - iPhone 11 Pro - 2023-06-27 at 14 14 13](https://github.com/status-im/status-mobile/assets/90291778/97e8fe68-a65b-4ca3-b099-9dfcc4c176d3)


- When scrolling to the bottom of the content, the space below is the expected as in designs:

![Simulator Screenshot - iPhone 11 Pro - 2023-06-27 at 14 14 21](https://github.com/status-im/status-mobile/assets/90291778/211a9ee7-9b3a-4a1c-bec7-0ac5ccdc961f)


- When the content fits in the drawer, the content is no longer scrollable:

![Simulator Screenshot - iPhone 11 Pro - 2023-06-27 at 14 14 46](https://github.com/status-im/status-mobile/assets/90291778/9b34af49-ae5e-48e4-a50f-e4064839f9b8)


### Review notes

This change affects all documentation drawers

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open Status
- Create a new profile, test the documentation drawer shown in the "I'm new to status screen" (click info button). 
- Create a new username
- Test the documentation drawer in the password screen

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->
