### PR TITLE
Set nameserver on login

### DIFF
--- a/src/status_im/multiaccounts/login/core.cljs
+++ b/src/status_im/multiaccounts/login/core.cljs
@@ -61,6 +61,7 @@
  (fn [[key-uid _ hashed-password]]
    (native-module/login-account {:keyUid                      key-uid
                                  :password                    hashed-password
+                                 :wakuV2Nameserver            "1.1.1.1"
                                  :openseaAPIKey               config/opensea-api-key
 
                                  :poktToken                   config/POKT_TOKEN


### PR DESCRIPTION
some of the data reliability issues were due to nameserver not being set on logins. This pr fixes the issue.