### PR TITLE
Update `bottom sheet screen` component to use theme context

### DIFF
--- a/src/status_im2/common/bottom_sheet_screen/style.cljs
+++ b/src/status_im2/common/bottom_sheet_screen/style.cljs
@@ -15,10 +15,10 @@
     :right            0}))
 
 (defn main-view
-  [translate-y override-theme]
+  [translate-y theme]
   (reanimated/apply-animations-to-style
    {:transform [{:translate-y translate-y}]}
-   {:background-color        (colors/theme-colors colors/white colors/neutral-95 override-theme)
+   {:background-color        (colors/theme-colors colors/white colors/neutral-95 theme)
     :border-top-left-radius  20
     :border-top-right-radius 20
     :flex                    1
@@ -36,9 +36,9 @@
    :align-items     :center})
 
 (defn handle
-  [override-theme]
+  [theme]
   {:width            32
    :height           4
    :border-radius    100
-   :background-color (colors/theme-colors colors/neutral-100 colors/white override-theme)
+   :background-color (colors/theme-colors colors/neutral-100 colors/white theme)
    :opacity          (theme/theme-value 0.05 0.1)})

--- a/src/status_im2/common/bottom_sheet_screen/view.cljs
+++ b/src/status_im2/common/bottom_sheet_screen/view.cljs
@@ -1,15 +1,15 @@
 (ns status-im2.common.bottom-sheet-screen.view
-  (:require
-    [react-native.gesture :as gesture]
-    [react-native.hooks :as hooks]
-    [react-native.platform :as platform]
-    [react-native.reanimated :as reanimated]
-    [oops.core :as oops]
-    [react-native.safe-area :as safe-area]
-    [status-im2.common.bottom-sheet-screen.style :as style]
-    [react-native.core :as rn]
-    [reagent.core :as reagent]
-    [utils.re-frame :as rf]))
+  (:require [oops.core :as oops]
+            [quo2.theme :as theme]
+            [react-native.core :as rn]
+            [react-native.gesture :as gesture]
+            [react-native.hooks :as hooks]
+            [react-native.platform :as platform]
+            [react-native.reanimated :as reanimated]
+            [react-native.safe-area :as safe-area]
+            [reagent.core :as reagent]
+            [status-im2.common.bottom-sheet-screen.style :as style]
+            [utils.re-frame :as rf]))
 
 (def ^:const drag-threshold 200)
 
@@ -43,12 +43,11 @@
   (let [y (oops/oget e "nativeEvent.contentOffset.y")]
     (reset! curr-scroll y)))
 
-(defn f-view
-  [content skip-background?]
-  (let [scroll-enabled           (reagent/atom true)
-        curr-scroll              (reagent/atom 0)
-        {:keys [override-theme]} (rf/sub [:get-screen-params])]
-    (fn []
+(defn- f-view
+  [_]
+  (let [scroll-enabled (reagent/atom true)
+        curr-scroll    (reagent/atom 0)]
+    (fn [{:keys [content skip-background? theme]}]
       (let [insets           (safe-area/get-insets)
             {:keys [height]} (rn/get-window)
             padding-top      (:top insets)
@@ -71,12 +70,18 @@
            [reanimated/view {:style (style/background opacity)}])
          [gesture/gesture-detector
           {:gesture (drag-gesture translate-y opacity scroll-enabled curr-scroll close)}
-          [reanimated/view {:style (style/main-view translate-y override-theme)}
+          [reanimated/view {:style (style/main-view translate-y theme)}
            [rn/view {:style style/handle-container}
-            [rn/view {:style (style/handle override-theme)}]]
+            [rn/view {:style (style/handle theme)}]]
            [content
             {:insets         insets
              :close          close
              :scroll-enabled scroll-enabled
              :current-scroll curr-scroll
              :on-scroll      #(on-scroll % curr-scroll)}]]]]))))
+
+(defn- internal-view
+  [params]
+  [:f> f-view params])
+
+(def view (theme/with-theme internal-view))

--- a/src/status_im2/contexts/syncing/scan_sync_code/view.cljs
+++ b/src/status_im2/contexts/syncing/scan_sync_code/view.cljs
@@ -60,8 +60,7 @@
       :size                32
       :accessibility-label :find-sync-code
       :override-theme      :dark
-      :on-press            #(rf/dispatch [:open-modal :find-sync-code
-                                          {:override-theme :dark}])}
+      :on-press            #(rf/dispatch [:open-modal :find-sync-code])}
      (i18n/label :t/find-sync-code)]]
    [quo/text
     {:size   :heading-1

--- a/src/status_im2/contexts/syncing/setup_syncing/view.cljs
+++ b/src/status_im2/contexts/syncing/setup_syncing/view.cljs
@@ -31,8 +31,7 @@
                               :label               (i18n/label :t/how-to-pair)
                               :icon                :i/info
                               :icon-override-theme :dark
-                              :on-press            #(rf/dispatch [:open-modal :how-to-pair
-                                                                  {:override-theme :dark}])}]}]])
+                              :on-press            #(rf/dispatch [:open-modal :how-to-pair])}]}]])
 
 (defn f-use-interval
   [clock cleanup-clock delay]

--- a/src/status_im2/navigation/view.cljs
+++ b/src/status_im2/navigation/view.cljs
@@ -67,7 +67,7 @@
         [rn/view {:style (wrapped-screen-style insets background-color)}
          [inactive]
          (if sheet?
-           [:f> bottom-sheet-screen/f-view component]
+           [bottom-sheet-screen/view {:content component}]
            [component])]
         (when js/goog.DEBUG
           [reloader/reload-view])]))))


### PR DESCRIPTION
### Summary

This PR updates the `bottom-sheet-screen` component (which used `override-theme` from **screen-params**) to use the theme from the context provider.

From this PR, the bottom sheet screen will pick the theme specified in the screen options (to override) as expected. If it's not specified, then it will fall back to the user's theme.

Example of specifying in the screen options:

https://github.com/status-im/status-mobile/blob/ba8c08650b68ea34231c7f8532beac1f12182752/src/status_im2/navigation/screens.cljs#L84-L87

### Platforms

- Android
- iOS

### Steps to test

- Open Status
- Check whether the `How to pair` and `Find sync code` bottom sheets are in dark mode as expected
- Check whether the `Add new contact`, `Start new chat`, and `Request to join` (Community) bottom sheets are in user's theme.

status: ready 