### PR TITLE
[#16378] Channel unread counter space

### DIFF
--- a/src/quo2/components/dividers/divider_label.cljs
+++ b/src/quo2/components/dividers/divider_label.cljs
@@ -1,8 +1,8 @@
 (ns quo2.components.dividers.divider-label
-  (:require [quo2.theme :as theme]
-            [quo2.components.icon :as icons]
+  (:require [quo2.components.icon :as icons]
             [quo2.components.markdown.text :as markdown.text]
             [quo2.foundations.colors :as colors]
+            [quo2.theme :as theme]
             [react-native.core :as rn]))
 
 (def chevron-icon-container-width 20)
@@ -36,18 +36,18 @@
         padding-top                 (if increase-padding-top? 16 8)
         text-and-icon-color         (if dark? colors/neutral-40 colors/neutral-50)
         counter-text-color          (if dark? colors/white colors/neutral-100)]
-    [rn/touchable-without-feedback
-     {:on-press on-press}
+    [rn/touchable-without-feedback {:on-press on-press}
      [rn/view
       {:accessible          true
        :accessibility-label :divider-label
-       :style               (merge {:border-top-width   1
-                                    :border-top-color   border-and-counter-bg-color
-                                    :padding-top        padding-top
-                                    :padding-bottom     padding-bottom
-                                    :padding-horizontal 16
-                                    :align-items        :center
-                                    :flex-direction     :row}
+       :style               (merge {:border-top-width 1
+                                    :border-top-color border-and-counter-bg-color
+                                    :padding-top      padding-top
+                                    :padding-bottom   padding-bottom
+                                    :padding-left     16
+                                    :padding-right    16
+                                    :align-items      :center
+                                    :flex-direction   :row}
                                    container-style)}
       (when (= chevron-position :left)
         [rn/view

--- a/src/quo2/components/list_items/channel.cljs
+++ b/src/quo2/components/list_items/channel.cljs
@@ -1,12 +1,11 @@
 (ns quo2.components.list-items.channel
   (:require [quo2.components.avatars.channel-avatar :as channel-avatar]
+            [quo2.components.common.unread-grey-dot.view :refer [unread-grey-dot]]
             [quo2.components.counter.counter :as quo2.counter]
             [quo2.components.icon :as quo2.icons]
             [quo2.components.markdown.text :as quo2.text]
             [quo2.foundations.colors :as colors]
-            [quo2.theme :as theme]
-            [react-native.core :as rn]
-            [quo2.components.common.unread-grey-dot.view :refer [unread-grey-dot]]))
+            [react-native.core :as rn]))
 
 (def ^:private custom-props
   [:name :locked? :mentions-count :unread-messages?
@@ -21,22 +20,20 @@
         name-text      (:name props)]
     [rn/touchable-opacity standard-props
      [rn/view
-      {:style (merge {:height          48
-                      :display         :flex
-                      :border-radius   12
-                      :flex-direction  :row
-                      :justify-content :space-between
-                      :align-items     :center
-                      :width           "100%"
-                      :padding-left    12
-                      :padding-right   12}
-                     (when is-active-channel?
-                       {:background-color (colors/theme-alpha channel-color 0.05 0.05)}))}
+      {:style (cond-> {:height          48
+                       :border-radius   12
+                       :flex-direction  :row
+                       :justify-content :space-between
+                       :align-items     :center
+                       :width           "100%"
+                       :padding-left    12
+                       :padding-right   12}
+                is-active-channel? (assoc :background-color
+                                          (colors/theme-alpha channel-color 0.05 0.05)))}
       [rn/view
-       {:display             :flex
-        :flex-direction      :row
-        :justify-content     :flex-start
-        :align-items         :center
+       {:style               {:flex-direction  :row
+                              :justify-content :flex-start
+                              :align-items     :center}
         :accessible          true
         :accessibility-label :chat-name-text}
        [channel-avatar/channel-avatar
@@ -45,30 +42,25 @@
          :emoji-background-color (colors/theme-alpha channel-color 0.1 0.1)
          :emoji                  emoji}]
        [quo2.text/text
-        {:style  (merge {:margin-left 12}
-                        (when (and (not locked?) muted?)
-                          {:color (if (theme/dark?) colors/neutral-60 colors/neutral-40)}))
+        {:style  (cond-> {:margin-left 12}
+                   (and (not locked?) muted?)
+                   (assoc :color (colors/theme-colors colors/neutral-40 colors/neutral-60)))
          :weight :medium
-         :size   :paragraph-1} (str "# " name-text)]]
-      [rn/view
-       {:style {:height          20
-                :justify-content :center}}
-       (when (and (not locked?)
-                  muted?)
-         [quo2.icons/icon :i/muted
-          {:size            20
-           :color           colors/neutral-40
-           :container-style {:margin-right 1
-                             :margin-top   2}}])
-       (when (and (not locked?)
-                  (not muted?)
-                  (pos? (int mentions-count)))
-         [rn/view
-          {:style {:margin-right 2
-                   :margin-top   2}}
-          [quo2.counter/counter {:override-bg-color channel-color} mentions-count]])
-       (when (and (not locked?)
-                  (not muted?)
-                  (not (pos? (int mentions-count)))
-                  unread-messages?)
-         [unread-grey-dot :unviewed-messages-public])]]]))
+         :size   :paragraph-1}
+        (str "# " name-text)]]
+      (when-not locked?
+        [rn/view {:style {:height 20 :justify-content :center}}
+         (cond
+           muted?
+           [quo2.icons/icon :i/muted
+            {:size            20
+             :color           colors/neutral-40
+             :container-style {:margin-right 1 :margin-top 2}}]
+
+           (pos? (int mentions-count))
+           [rn/view {:style {:margin-right 2 :margin-top 2}}
+            [quo2.counter/counter {:override-bg-color channel-color}
+             mentions-count]]
+
+           unread-messages?
+           [unread-grey-dot :unviewed-messages-public])])]]))

--- a/src/status_im2/contexts/communities/overview/view.cljs
+++ b/src/status_im2/contexts/communities/overview/view.cljs
@@ -87,7 +87,7 @@
                               :padding-bottom 7}
            :label            name
            :on-press         #(collapse-category community-id category-id collapsed?)
-           :chevron-icon     (if collapsed? :main-icons/chevron-right :main-icons/chevron-down)
+           :chevron-icon     (if collapsed? :i/chevron-right :i/chevron-down)
            :chevron-position :left}])
        (when-not collapsed?
          (into [rn/view {:style {:padding-horizontal 8 :padding-bottom 8}}]


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes #16378

### Summary

This PR solves the problem with the alignment of the unread counter in channels.

Android:

before | after

![Android-before](https://github.com/status-im/status-mobile/assets/90291778/73d234bf-57c5-4dfb-9796-3b3a7d470930) ![Android-after](https://github.com/status-im/status-mobile/assets/90291778/f2406f87-b134-415b-8e90-f99da9775b20)

iOS:

before | after
![iOS-before](https://github.com/status-im/status-mobile/assets/90291778/69272fbf-4696-4661-a506-9d4c50ac8f60) ![iOS-now](https://github.com/status-im/status-mobile/assets/90291778/0d141cd6-22c0-4477-a6ea-56551f1b7fa5)


To check how it looks compared to [expected designs](https://www.figma.com/file/h9wo4GipgZURbqqr1vShFN/Communities-for-Mobile?type=design&node-id=6605-604639&mode=design&t=ODMV6CCoyLEHTuVr-4), here is an overlay using iOS iPhone 11 Pro:

before:

![PR-image-prev](https://github.com/status-im/status-mobile/assets/90291778/c6f03296-c21f-4c0e-89fe-974ab3f1d603)

now:

![PR-image](https://github.com/status-im/status-mobile/assets/90291778/1d2867b6-46e3-4aec-a61e-ad48657a3771)

the counter is still not perfect, but it seems it's due to not being allowed to correctly center some items, check next section (review notes)

### Review notes

Additional checks for the `divider-label` and `channel` components are required.
Currently, the `divider-label` component is not using correct styles, so I'm overwriting them (the component allows to do it) to properly match the UI.
I opened:  
- #16461
- #16462 


#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted

 - Communities overview

### Steps to test
(there might be different ways to test, this is just a suggested one, we will need two status accounts and a community 

- (Account 1) - Create a new community or join into an existing one
- (Account 2) - Join to the same community as before 
- (Account 1) - Mention Account 2 or tag everyone in a channel in the community
- (Account 2) - Check the community overview and you will see the unread counter


status: ready
