### PR TITLE
Fix compressed key ellipsis

### DIFF
--- a/src/status_im2/common/contact_list_item/view.cljs
+++ b/src/status_im2/common/contact_list_item/view.cljs
@@ -9,7 +9,7 @@
   (let [photo-path (rf/sub [:chats/photo-path public-key])
         online?    (rf/sub [:visibility-status-updates/online? public-key])]
     [quo/user-list
-     {:short-chat-key (address/get-shortened-key (or compressed-key public-key))
+     {:short-chat-key (address/get-shortened-compressed-key (or compressed-key public-key))
       :primary-name   primary-name
       :secondary-name secondary-name
       :photo-path     photo-path

--- a/src/status_im2/contexts/add_new_contact/views.cljs
+++ b/src/status_im2/contexts/add_new_contact/views.cljs
@@ -7,9 +7,9 @@
     [reagent.core :as reagent]
     [status-im.multiaccounts.core :as multiaccounts]
     [status-im.qr-scanner.core :as qr-scanner]
-    [status-im.utils.utils :as utils]
     [status-im2.contexts.add-new-contact.style :as style]
     [utils.debounce :as debounce]
+    [utils.address :as address]
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]))
 
@@ -37,7 +37,7 @@
           {:weight :regular
            :size   :paragraph-2
            :style  (style/found-user-key)}
-          (utils/get-shortened-address compressed-key)]]]])))
+          (address/get-shortened-compressed-key compressed-key)]]]])))
 
 (defn new-contact
   []

--- a/src/status_im2/contexts/chat/messages/content/view.cljs
+++ b/src/status_im2/contexts/chat/messages/content/view.cljs
@@ -54,7 +54,7 @@
       [quo/author
        {:primary-name   primary-name
         :secondary-name secondary-name
-        :short-chat-key (address/get-shortened-key (or compressed-key from))
+        :short-chat-key (address/get-shortened-compressed-key (or compressed-key from))
         :time-str       (datetime/timestamp->time timestamp)
         :contact?       added?
         :verified?      ens-verified}])))

--- a/src/status_im2/contexts/quo_preview/list_items/user_list.cljs
+++ b/src/status_im2/contexts/quo_preview/list_items/user_list.cljs
@@ -42,7 +42,7 @@
 (defn cool-preview
   []
   (let [state (reagent/atom {:primary-name   "Alisher Yakupov"
-                             :short-chat-key (address/get-shortened-key
+                             :short-chat-key (address/get-shortened-compressed-key
                                               "zQ3ssgRy5TtB47MMiMKMKaGyaawkCgMqqbrnAUYrZJ1sgt5N")
                              :ens-verified   true
                              :contact?       false

--- a/src/status_im2/contexts/quo_preview/messages/author.cljs
+++ b/src/status_im2/contexts/quo_preview/messages/author.cljs
@@ -36,7 +36,7 @@
   []
   (let [state (reagent/atom {:primary-name    "Alisher Yakupov"
                              :seconadary-name ""
-                             :short-chat-key  (address/get-shortened-key
+                             :short-chat-key  (address/get-shortened-compressed-key
                                                "zQ3ssgRy5TtB47MMiMKMKaGyaawkCgMqqbrnAUYrZJ1sgt5N")
                              :time-str        "09:30"
                              :contact?        false

--- a/src/status_im2/contexts/shell/share/view.cljs
+++ b/src/status_im2/contexts/shell/share/view.cljs
@@ -10,7 +10,8 @@
             [status-im.ui.components.list-selection :as list-selection]
             [utils.image-server :as image-server]
             [react-native.navigation :as navigation]
-            [clojure.string :as string]))
+            [clojure.string :as string]
+            [utils.address :as address]))
 
 (defn header
   []
@@ -30,19 +31,6 @@
      :style  style/header-heading}
     (i18n/label :t/share)]])
 
-(defn abbreviated-url
-  "The goal here is to generate a string that begins with
-   join.status.im/u/ joined with the 1st 5 characters
-   of the compressed public key followed by an ellipsis followed by
-   the last 12 characters of the compressed public key"
-  [base-url public-pk]
-  (let [first-part-of-public-pk (subs public-pk 0 5)
-        ellipsis                "..."
-        public-pk-size          (count public-pk)
-        last-part-of-public-pk  (subs public-pk (- public-pk-size 12) (- public-pk-size 1))
-        abbreviated-url         (str base-url first-part-of-public-pk ellipsis last-part-of-public-pk)]
-    abbreviated-url))
-
 (defn profile-tab
   [window-width]
   (let [{:keys [emoji-hash
@@ -51,7 +39,7 @@
         port              (rf/sub [:mediaserver/port])
         emoji-hash-string (string/join emoji-hash)
         qr-size           (int (- window-width 64))
-        abbreviated-url   (abbreviated-url
+        abbreviated-url   (address/get-abbreviated-profile-url
                            image-server/status-profile-base-url-without-https
                            compressed-key)
         profile-url       (str image-server/status-profile-base-url compressed-key)

--- a/src/utils/address.cljs
+++ b/src/utils/address.cljs
@@ -14,3 +14,35 @@
   [address]
   (when address
     (get-shortened-key (eip55/address->checksum (ethereum/normalized-hex address)))))
+
+(defn get-abbreviated-profile-url
+  "The goal here is to generate a string that begins with
+   join.status.im/u/ joined with the 1st 5 characters
+   of the compressed public key followed by an ellipsis followed by
+   the last 12 characters of the compressed public key"
+  [base-url public-key]
+  (if (and public-key base-url (> (count public-key) 17) (= "join.status.im/u/" base-url))
+    (let [first-part-of-public-pk (subs public-key 0 5)
+          ellipsis                "..."
+          public-key-size         (count public-key)
+          last-part-of-public-key (subs public-key (- public-key-size 12) public-key-size)
+          abbreviated-url         (str base-url
+                                       first-part-of-public-pk
+                                       ellipsis
+                                       last-part-of-public-key)]
+      abbreviated-url)
+    nil))
+
+(defn get-shortened-compressed-key
+  "The goal here is to generate a string that begins with 1st 3
+  characters of the compressed public key followed by an ellipsis followed by
+  the last 6 characters of the compressed public key"
+  [public-key]
+  (if (and public-key (> (count public-key) 9))
+    (let [first-part-of-public-key (subs public-key 0 3)
+          ellipsis                 "..."
+          public-key-size          (count public-key)
+          last-part-of-public-key  (subs public-key (- public-key-size 6) public-key-size)
+          abbreviated-public-key   (str first-part-of-public-key ellipsis last-part-of-public-key)]
+      abbreviated-public-key)
+    nil))

--- a/src/utils/address_test.cljs
+++ b/src/utils/address_test.cljs
@@ -1,0 +1,42 @@
+(ns utils.address-test
+  (:require [cljs.test :refer [deftest is testing]]
+            [utils.address]))
+
+(deftest get-shortened-compressed-key
+  (testing "Ensure the function correctly abbreviates a valid public key"
+    (is (= "zQ3...1sgt5N"
+           (utils.address/get-shortened-compressed-key
+            "zQ3ssgRy5TtB47MMiMKMKaGyaawkCgMqqbrnAUYrZJ1sgt5N"))))
+
+  (testing "Ensure the function returns nil when given an empty string"
+    (is (nil? (utils.address/get-shortened-compressed-key ""))))
+
+  (testing "Ensure the function returns nil when given a nil input"
+    (is (nil? (utils.address/get-shortened-compressed-key nil))))
+
+  (testing "Ensure the function returns nil when given a public key shorter than 9 characters"
+    (is (nil? (utils.address/get-shortened-compressed-key "abc")))
+    (is (nil? (utils.address/get-shortened-compressed-key "1234")))))
+
+
+(deftest test-get-abbreviated-profile-url
+  (testing "Ensure the function correctly generates an abbreviated profile URL for a valid public key"
+    (is (= "join.status.im/u/zQ3sh...aimrdYpzeFUa"
+           (utils.address/get-abbreviated-profile-url
+            "join.status.im/u/"
+            "zQ3shPrnUhhR42JJn3QdhodGest8w8MjiH8hPaimrdYpzeFUa"))))
+
+  (testing "Ensure the function returns nil when given an empty public key"
+    (is (nil? (utils.address/get-abbreviated-profile-url "join.status.im/u/" ""))))
+
+  (testing "Ensure the function returns nil when given a nil public key"
+    (is (nil? (utils.address/get-abbreviated-profile-url "join.status.im/u/" nil))))
+
+  (testing "Ensure the function returns nil when given an incorrect base URL"
+    (is (nil? (utils.address/get-abbreviated-profile-url
+               "join.status.im/uwu/"
+               "zQ3shPrnUhhR42JJn3QdhodGest8w8MjiH8hPaimrdYpzeFUa"))))
+
+  (testing "Ensure the function returns nil when given a public key shorter than 17 characters"
+    (is (nil? (utils.address/get-abbreviated-profile-url "join.status.im/u/" "abc")))
+    (is (nil? (utils.address/get-abbreviated-profile-url "join.status.im/u/" "1234")))))

--- a/translations/en.json
+++ b/translations/en.json
@@ -1980,7 +1980,7 @@
     "identity-verification-request": "Identity verification",
     "identity-verification-request-sent": "asks",
     "type-something": "Type something",
-    "type-some-chat-key": "zQ3abc...123",
+    "type-some-chat-key": "zQ3...1sgt5N",
     "your-answer": "Your answer",
     "membership": "Membership",
     "jump-to": "Jump to",


### PR DESCRIPTION
fixes #16047

### Summary

This PR does the following:
- Moves `get-abbreviated-profile-url` from shell share view into `utils.address` and update its usage.
- Adds `get-shortened-compressed-key` to `utils.address` and update the code using `get-shortened-key` to now use `get-shortened-compressed-key` instead.

### Testing notes
This PR ensures that the ellipsis on public key is now as per designs. 

#### Platforms
- Android
- iOS

status: ready
