### PR TITLE
[161108] Optimize message styling when there's multiple mentions on top of each other

### DIFF
--- a/src/status_im2/contexts/chat/messages/content/text/style.cljs
+++ b/src/status_im2/contexts/chat/messages/content/text/style.cljs
@@ -30,7 +30,7 @@
                                                colors/primary-60)
    :selection-color       :transparent
    :suppress-highlighting true
-   :line-height           22})
+   :line-height           21})
 
 (defn code
   []

--- a/src/status_im2/contexts/chat/messages/content/text/style.cljs
+++ b/src/status_im2/contexts/chat/messages/content/text/style.cljs
@@ -21,7 +21,8 @@
   {:background-color   colors/primary-50-opa-10
    :padding-horizontal 3
    :border-radius      6
-   :margin-bottom      -3})
+   :margin-bottom      -3
+   :height             22})
 
 (def mention-tag-text
   {:color                 (colors/theme-colors colors/primary-50

--- a/src/status_im2/contexts/chat/messages/content/text/style.cljs
+++ b/src/status_im2/contexts/chat/messages/content/text/style.cljs
@@ -15,7 +15,8 @@
 (defn mention-tag-wrapper
   []
   {:flex-direction :row
-   :align-items    :center})
+   :align-items    :center
+   :height         22})
 
 (def mention-tag
   {:background-color   colors/primary-50-opa-10
@@ -28,7 +29,8 @@
   {:color                 (colors/theme-colors colors/primary-50
                                                colors/primary-60)
    :selection-color       :transparent
-   :suppress-highlighting true})
+   :suppress-highlighting true
+   :line-height           22})
 
 (defn code
   []

--- a/src/status_im2/contexts/chat/messages/content/text/view.cljs
+++ b/src/status_im2/contexts/chat/messages/content/text/view.cljs
@@ -63,7 +63,8 @@
           :style          style/mention-tag}
          [quo/text
           {:weight :medium
-           :style  style/mention-tag-text}
+           :style  style/mention-tag-text
+           :size   :paragraph-1}
           (rf/sub [:messages/resolve-mention literal])]]])
 
       :edited


### PR DESCRIPTION
fixes #16108 

### Summary
Side to side comparison
<img>
![image](https://github.com/status-im/status-mobile/assets/33176106/84e8db13-e320-484b-836e-8b8725689a4e)
</img>
<img>
![image](https://github.com/status-im/status-mobile/assets/33176106/e940077b-d746-4b79-bdc9-0819298cd897)
</img>

QA notes:
Need testing on multiple devices

status: ready
