### PR TITLE
fix: onboarding carousel overflows causing navigation glitches

### DIFF
--- a/src/status_im2/contexts/onboarding/common/background/style.cljs
+++ b/src/status_im2/contexts/onboarding/common/background/style.cljs
@@ -5,6 +5,7 @@
   {:background-color colors/neutral-95
    :flex-direction   :row
    :position         :absolute
+   :overflow         :hidden
    :top              0
    :bottom           0
    :left             0


### PR DESCRIPTION
fixes #16512

### Summary

Hides overflow of background carousel, as it leads to navigation glitches within onboarding

#### Platforms

- iOS

##### Functional

- onboarding

### Steps to test

- Open Status
- Start account creation flow from onboarding
- Navigate back to the previous onboarding steps
- Verify correct behavior

status: ready