### PR TITLE
[#15950] Updated build-image-messages

### DIFF
--- a/src/status_im/chat/models/input.cljs
+++ b/src/status_im/chat/models/input.cljs
@@ -167,14 +167,16 @@
         {:keys [message-id]} (get-in db [:chat/inputs chat-id :metadata :responding-to-message])
         album-id             (str (random-uuid))]
     (mapv (fn [[_ {:keys [resized-uri width height]}]]
-            {:chat-id      chat-id
-             :album-id     album-id
-             :content-type constants/content-type-image
-             :image-path   (utils.string/safe-replace resized-uri #"file://" "")
-             :image-width  width
-             :image-height height
-             :text         input-text
-             :response-to  message-id})
+            {:chat-id       chat-id
+             :album-id      album-id
+             :content-type  constants/content-type-image
+             :image-path    (utils.string/safe-replace resized-uri #"file://" "")
+             :image-width   width
+             :image-height  height
+             :text          input-text
+             :link-previews (map #(select-keys % [:url :title :description :thumbnail])
+                                 (get-in db [:chat/link-previews :unfurled]))
+             :response-to   message-id})
           images)))
 
 (rf/defn clean-input


### PR DESCRIPTION
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #5950)

fixes #15950

### Summary

Resolved bug: Link previews are not persisted if the message sent has images.

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->
