### PR TITLE
[#16520] ENS setting is unavailable on PRs when test network is set

### DIFF
--- a/src/status_im/data_store/settings.cljs
+++ b/src/status_im/data_store/settings.cljs
@@ -48,6 +48,5 @@
       (update :custom-bootnodes-enabled? rpc->custom-bootnodes)
       (update :currency keyword)
       (visibility-status-updates/<-rpc-settings)
-      (dissoc :networks/current-network :networks/networks)
       (set/rename-keys {:compressedKey :compressed-key
                         :emojiHash     :emoji-hash})))


### PR DESCRIPTION

fixes #16520

