### PR TITLE
ci: create e2e nightly run on ci.status.im

### DIFF
--- a/ci/Jenkinsfile.e2e-nightly
+++ b/ci/Jenkinsfile.e2e-nightly
@@ -1,0 +1,51 @@
+#!/usr/bin/env groovy
+library 'status-jenkins-lib@v1.7.9'
+
+pipeline {
+  agent { label 'linux' }
+
+  triggers {
+    // Nightly at 4am
+    cron 'H 4 * * *'
+  }
+
+  parameters {
+    string(
+      name: 'BRANCH',
+      description: 'Name of the branch to checkout and build.',
+      defaultValue: 'develop',
+    )
+  }
+
+  options {
+    timestamps()
+    disableConcurrentBuilds()
+    buildDiscarder(logRotator(
+      numToKeepStr: '10',
+      daysToKeepStr: '30',
+    ))
+  }
+
+  stages {
+    stage('Build') {
+      steps {
+        script {
+          apk_build = jenkins.Build('status-mobile/platforms/android-e2e')
+          apk_build_number = apk_build.getNumber().toString()
+        }
+      }
+    }
+    stage('Run e2e') {
+      steps {
+        build(
+          job: 'status-mobile/e2e/status-app-nightly',
+          parameters: [
+            string(name: 'APK_BUILD_NUMBER', value: apk_build_number),
+            string(name: 'BRANCH', value: env.BRANCH),
+          ]
+        )
+      }
+    }
+  }
+}
+

--- a/ci/tests/Jenkinsfile.e2e-nightly-build-number
+++ b/ci/tests/Jenkinsfile.e2e-nightly-build-number
@@ -1,0 +1,120 @@
+#!/usr/bin/env groovy
+library 'status-jenkins-lib@v1.7.9'
+
+pipeline {
+
+  agent { label 'linux' }
+
+  parameters {
+    string(
+      name: 'APK_BUILD_NUMBER',
+      description: 'platform/e2e build number for apk artifact',
+    )
+    string(
+      name: 'KEYWORD_EXPRESSION',
+      description: 'This will run tests which contain names that match the given string expression  (Optional)',
+      defaultValue: '',
+    )
+    string(
+      name: 'BRANCH',
+      description: 'Name of the branch to checkout and build.',
+      defaultValue: 'develop',
+    )
+    string(
+      name: 'TR_CASE_IDS',
+      description: 'IDs of the TestRail case, separated by a comma (Optional)',
+      defaultValue: '',
+    )
+  }
+
+  options {
+    disableConcurrentBuilds()
+  }
+
+  stages {
+    stage('Fetch') {
+      steps { script {
+        copyArtifacts(
+          projectName: "status-mobile/platforms/android-e2e",
+          filter: 'result/*-x86.apk',
+          selector: specific(env.APK_BUILD_NUMBER),
+        )
+        apk_path = "${env.WORKSPACE}/${utils.findFile('result/*-x86.apk')}"
+
+      } }
+    }
+
+    stage('Setup') {
+      steps { script {
+        dir('test/appium') {
+          sh 'pip3 install --user -r requirements.txt'
+        }
+      } }
+    }
+
+    stage('Test') {
+      steps {
+        withCredentials([
+          usernamePassword(
+            credentialsId:  'test-rail-api',
+            usernameVariable: 'TESTRAIL_USER',
+            passwordVariable: 'TESTRAIL_PASS'
+          ),
+          usernamePassword(
+            credentialsId:  'sauce-labs-api',
+            usernameVariable: 'SAUCE_USERNAME',
+            passwordVariable: 'SAUCE_ACCESS_KEY'
+          ),
+          string(
+            credentialsId: 'etherscan-api-key',
+            variable: 'ETHERSCAN_API_KEY'
+          ),
+          string(
+            credentialsId: 'infura-e2e-token',
+            variable: 'WEB3_INFURA_PROJECT_ID'
+          ),
+          file(
+            credentialsId: "mobile-tests-eth-accounts",
+            variable: 'TEST_ETH_ACCOUNTS_FILE'
+          ),
+        ]) {
+          dir('test/appium/tests') {
+            /* Provide Eth test accounts secrets. */
+            sh 'cp -f $TEST_ETH_ACCOUNTS_FILE users.py'
+            sh """
+              python3 -m pytest \
+                --numprocesses 6 \
+                --rerun_count=2 \
+                --testrail_report=True \
+                -m testrail_id \
+                -m \"new_ui_critical or new_ui_medium\" \
+                -k \"${params.KEYWORD_EXPRESSION}\" \
+                --apk=${params.APK_URL ?: apk_path}
+            """
+          }
+        }
+      }
+    }
+  }
+
+  post {
+    always {
+      script {
+        sauce('sauce-labs-cred') {
+          saucePublisher()
+        }
+      }
+    }
+    success {
+      script {
+        junit(
+          testDataPublishers: [[$class: 'SauceOnDemandReportPublisher', jobVisibility: 'public']],
+          testResults: 'test/appium/tests/*.xml'
+        )
+      }
+    }
+    cleanup {
+      sh 'make purge'
+    }
+  }
+}


### PR DESCRIPTION
fixes #16440

### Summary
Before removing e2e relaled tasks from **ci.infra.status.im** - let's have a job on devel Jenkins instance.
