### PR TITLE
[16467] Fix delete for me doesn't work on chat reopen

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.161.3",
-    "commit-sha1": "67050429df540792b7bda80a2f67dae4b28515bc",
-    "src-sha256": "1lv50lcg02ncv19lxhx0l0rkr10hck13pcgm6nyd0wsql174gh99"
+    "version": "status-mobile-16467",
+    "commit-sha1": "1fb8b2b887ee23b2fac0a4652eb856c85b2e2e92",
+    "src-sha256": "1w49rkisb2zyjkdmpghv4bnw2kf2r59hmgv6bvsdi8hj27bbw3ka"
 }

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "status-mobile-16467",
-    "commit-sha1": "af5a49a22903b7f1cdb172d391e5ab68eb08ec92",
-    "src-sha256": "1ryhmf2gwbvqi2p5hb5qjqvjfj0806aqjzaxr97kyy6rnnp9v72b"
+    "version": "v0.161.4",
+    "commit-sha1": "ca5075c14915103161bc5d26cd888feabf46efc7",
+    "src-sha256": "14m53jqj72i26w48y2q9hxpc6r7z9mfy4bw26j4dla6j2vibqr7f"
 }

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -4,6 +4,6 @@
     "owner": "status-im",
     "repo": "status-go",
     "version": "status-mobile-16467",
-    "commit-sha1": "1fb8b2b887ee23b2fac0a4652eb856c85b2e2e92",
-    "src-sha256": "1w49rkisb2zyjkdmpghv4bnw2kf2r59hmgv6bvsdi8hj27bbw3ka"
+    "commit-sha1": "af5a49a22903b7f1cdb172d391e5ab68eb08ec92",
+    "src-sha256": "1ryhmf2gwbvqi2p5hb5qjqvjfj0806aqjzaxr97kyy6rnnp9v72b"
 }


### PR DESCRIPTION
fixes #16467 

### Summary
On status-go we used localChatId key instead of chatId to delete-message-for-me, Reverting that change fixed it.

status: ready
