### PR TITLE
WIP: refactor button 1

### DIFF
--- a/src/quo2/components/buttons/button/type_values.cljs
+++ b/src/quo2/components/buttons/button/type_values.cljs
@@ -2,23 +2,58 @@
   (:require [quo2.foundations.colors :as colors]
             [quo2.theme :as quo2.theme]))
 
+(defn custom-color-type
+  [customization-color]
+  {:icon-color           colors/white
+   :icon-secondary-color colors/white-opa-70
+   :label-color          colors/white
+   :background-color     (colors/custom-color
+                          customization-color
+                          50)})
+
 (defn get-value-from-type
   [{:keys [customization-color theme type background pressed?]}]
   (cond
-    (= type :primary)                           {:icon-color           colors/white
-                                                 :icon-secondary-color colors/white-opa-70
-                                                 :label-color          colors/white
-                                                 :background-color     (colors/custom-color
-                                                                        customization-color
-                                                                        50)}
-
-    (= type :positive)                           {:icon-color           colors/white
-                                                  :icon-secondary-color colors/white-opa-70
-                                                  :label-color          colors/white
-                                                  :background-color     colors/success-50}
-
+    (= type :primary) (custom-color-type customization-color)
+    (= type :positive) (custom-color-type customization-color)
+    (= type :danger) (custom-color-type customization-color)
     ;; TODO Remove type blurred
-    (or  (= type :blurred) (and (= :photo background) (= type :grey)))
+    (or (= type :blurred) (and (= :photo background) (= type :grey)))
+    {:icon-color            (colors/theme-colors
+                             colors/neutral-100
+                             colors/white
+                             theme)
+     :icon-secondary-color  (colors/theme-colors
+                             colors/neutral-80-opa-40
+                             colors/white-opa-70
+                             theme)
+     :label-color           (colors/theme-colors
+                             colors/neutral-100
+                             colors/white
+                             theme)
+     :background-color      (if-not pressed?
+                              (colors/theme-colors
+                               colors/neutral-80-opa-5
+                               colors/white-opa-5
+                               theme)
+                              (colors/theme-colors
+                               colors/neutral-80-opa-10
+                               colors/white-opa-10
+                               theme))
+     :icon-background-color (quo2.theme/theme-value
+                             {:default colors/neutral-20
+                              :blurred colors/neutral-80-opa-10}
+                             {:default colors/neutral-80
+                              :blurred colors/white-opa-10})
+
+     :blur-overlay-color    (colors/theme-colors
+                             colors/neutral-10-opa-40-blur
+                             colors/neutral-80-opa-40
+                             theme)
+     :blur-type             (if (= theme :light) :light :dark)}
+
+    ;; TODO Remove type blur-bg
+    (or (= type :blur-bg) (and (= :blur background) (= type :grey)))
     {:icon-color           (colors/theme-colors
                             colors/neutral-100
                             colors/white
@@ -27,7 +62,6 @@
                             colors/neutral-80-opa-40
                             colors/white-opa-70
                             theme)
-
      :label-color          (colors/theme-colors
                             colors/neutral-100
                             colors/white
@@ -40,42 +74,7 @@
                              (colors/theme-colors
                               colors/neutral-80-opa-10
                               colors/white-opa-10
-                              theme))
-
-     :icon-background-color (quo2.theme/theme-value
-                             {:default colors/neutral-20
-                              :blurred colors/neutral-80-opa-10}
-                             {:default colors/neutral-80
-                              :blurred colors/white-opa-10})
-
-     :blur-overlay-color   (colors/theme-colors
-                            colors/neutral-10-opa-40-blur
-                            colors/neutral-80-opa-40
-                            theme)
-     :blur-type             (if (= theme :light) :light :dark)}
-
-    ;; TODO Remove type blur-bg
-    (or  (= type :blur-bg) (and (= :blur background) (= type :grey)))  {:icon-color           (colors/theme-colors
-                                                                                               colors/neutral-100
-                                                                                               colors/white
-                                                                                               theme)
-                                                                        :icon-secondary-color (colors/theme-colors
-                                                                                               colors/neutral-80-opa-40
-                                                                                               colors/white-opa-70
-                                                                                               theme)
-                                                                        :label-color          (colors/theme-colors
-                                                                                               colors/neutral-100
-                                                                                               colors/white
-                                                                                               theme)
-                                                                        :background-color     (if-not pressed?
-                                                                                                (colors/theme-colors
-                                                                                                 colors/neutral-80-opa-5
-                                                                                                 colors/white-opa-5
-                                                                                                 theme)
-                                                                                                (colors/theme-colors
-                                                                                                 colors/neutral-80-opa-10
-                                                                                                 colors/white-opa-10
-                                                                                                 theme))}
+                              theme))}
     (and (= :blur background) (= type :outline)) {:icon-color           (colors/theme-colors
                                                                          colors/neutral-100
                                                                          colors/white
@@ -96,99 +95,92 @@
                                                                           (colors/theme-colors
                                                                            colors/neutral-80-opa-20
                                                                            colors/white-opa-20))}
-    (= type :grey)                               {:icon-color           (colors/theme-colors
-                                                                         colors/neutral-100
-                                                                         colors/white
-                                                                         theme)
-                                                  :icon-secondary-color (colors/theme-colors
-                                                                         colors/neutral-50
-                                                                         colors/neutral-40
-                                                                         theme)
-                                                  :label-color          (colors/theme-colors
-                                                                         colors/neutral-100
-                                                                         colors/white
-                                                                         theme)
-                                                  :background-color     (if-not pressed?
-                                                                          (colors/theme-colors
-                                                                           colors/neutral-10
-                                                                           colors/neutral-90
-                                                                           theme)
-                                                                          (colors/theme-colors
-                                                                           colors/neutral-20
-                                                                           colors/neutral-60
-                                                                           theme))}
+    (= type :grey) {:icon-color           (colors/theme-colors
+                                           colors/neutral-100
+                                           colors/white
+                                           theme)
+                    :icon-secondary-color (colors/theme-colors
+                                           colors/neutral-50
+                                           colors/neutral-40
+                                           theme)
+                    :label-color          (colors/theme-colors
+                                           colors/neutral-100
+                                           colors/white
+                                           theme)
+                    :background-color     (if-not pressed?
+                                            (colors/theme-colors
+                                             colors/neutral-10
+                                             colors/neutral-90
+                                             theme)
+                                            (colors/theme-colors
+                                             colors/neutral-20
+                                             colors/neutral-60
+                                             theme))}
 
-    (= type :dark-grey)                          {:icon-color           (colors/theme-colors
-                                                                         colors/neutral-100
-                                                                         colors/white
-                                                                         theme)
-                                                  :icon-secondary-color (colors/theme-colors
-                                                                         colors/neutral-50
-                                                                         colors/neutral-40
-                                                                         theme)
-                                                  :label-color          (colors/theme-colors
-                                                                         colors/neutral-100
-                                                                         colors/white
-                                                                         theme)
-                                                  :background-color     (if-not pressed?
-                                                                          (colors/theme-colors
-                                                                           colors/neutral-20
-                                                                           colors/neutral-70
-                                                                           theme)
-                                                                          (colors/theme-colors
-                                                                           colors/neutral-30
-                                                                           colors/neutral-60
-                                                                           theme))}
+    (= type :dark-grey) {:icon-color           (colors/theme-colors
+                                                colors/neutral-100
+                                                colors/white
+                                                theme)
+                         :icon-secondary-color (colors/theme-colors
+                                                colors/neutral-50
+                                                colors/neutral-40
+                                                theme)
+                         :label-color          (colors/theme-colors
+                                                colors/neutral-100
+                                                colors/white
+                                                theme)
+                         :background-color     (if-not pressed?
+                                                 (colors/theme-colors
+                                                  colors/neutral-20
+                                                  colors/neutral-70
+                                                  theme)
+                                                 (colors/theme-colors
+                                                  colors/neutral-30
+                                                  colors/neutral-60
+                                                  theme))}
 
-    (= type :outline)                            {:icon-color           (colors/theme-colors
-                                                                         colors/neutral-50
-                                                                         colors/neutral-40
-                                                                         theme)
-                                                  :icon-secondary-color (colors/theme-colors
-                                                                         colors/neutral-50
-                                                                         colors/neutral-40
-                                                                         theme)
-                                                  :label-color          (colors/theme-colors
-                                                                         colors/neutral-100
-                                                                         colors/white
-                                                                         theme)
-                                                  :border-color         (if-not pressed?
-                                                                          (colors/theme-colors
-                                                                           colors/neutral-30
-                                                                           colors/neutral-70
-                                                                           theme)
-                                                                          (colors/theme-colors
-                                                                           colors/neutral-40
-                                                                           colors/neutral-60
-                                                                           theme))}
+    (= type :outline) {:icon-color           (colors/theme-colors
+                                              colors/neutral-50
+                                              colors/neutral-40
+                                              theme)
+                       :icon-secondary-color (colors/theme-colors
+                                              colors/neutral-50
+                                              colors/neutral-40
+                                              theme)
+                       :label-color          (colors/theme-colors
+                                              colors/neutral-100
+                                              colors/white
+                                              theme)
+                       :border-color         (if-not pressed?
+                                               (colors/theme-colors
+                                                colors/neutral-30
+                                                colors/neutral-70
+                                                theme)
+                                               (colors/theme-colors
+                                                colors/neutral-40
+                                                colors/neutral-60
+                                                theme))}
 
-    (= type :ghost)                              {:icon-color           (colors/theme-colors
-                                                                         colors/neutral-50
-                                                                         colors/neutral-40
-                                                                         theme)
-                                                  :icon-secondary-color (colors/theme-colors
-                                                                         colors/neutral-50
-                                                                         colors/neutral-40
-                                                                         theme)
-                                                  :label-color          (colors/theme-colors
-                                                                         colors/neutral-100
-                                                                         colors/white
-                                                                         theme)
-                                                  :background-color     (when pressed?
-                                                                          (colors/theme-colors
-                                                                           colors/neutral-10
-                                                                           colors/neutral-80
-                                                                           theme))}
-
-    (= type :danger)                             {:icon-color           colors/white
-                                                  :icon-secondary-color colors/white-opa-70
-                                                  :label-color          colors/white
-                                                  :background-color     colors/danger-50}
-
-
-    ;; TODO: remove type shell 
-    (or (= type :shell) (= type :black))                           {:icon-color       colors/white
-                                                                     :label-color      colors/white
-                                                                     :background-color (if-not pressed?
-                                                                                         colors/neutral-95
-                                                                                         colors/neutral-80)}))
+    (= type :ghost) {:icon-color           (colors/theme-colors
+                                            colors/neutral-50
+                                            colors/neutral-40
+                                            theme)
+                     :icon-secondary-color (colors/theme-colors
+                                            colors/neutral-50
+                                            colors/neutral-40
+                                            theme)
+                     :label-color          (colors/theme-colors
+                                            colors/neutral-100
+                                            colors/white
+                                            theme)
+                     :background-color     (when pressed?
+                                             (colors/theme-colors
+                                              colors/neutral-10
+                                              colors/neutral-80
+                                              theme))}
+    ;; TODO: remove type shell
+    (or (= type :shell) (= type :black)) {:icon-color       colors/white
+                                          :label-color      colors/white
+                                          :background-color (if-not pressed?
+                                                              colors/neutral-95
+                                                              colors/neutral-80)}))

--- a/src/quo2/components/buttons/button/type_values.cljs
+++ b/src/quo2/components/buttons/button/type_values.cljs
@@ -1,0 +1,194 @@
+(ns quo2.components.buttons.button.type-values
+  (:require [quo2.foundations.colors :as colors]
+            [quo2.theme :as quo2.theme]))
+
+(defn get-value-from-type
+  [{:keys [customization-color theme type background pressed?]}]
+  (cond
+    (= type :primary)                           {:icon-color           colors/white
+                                                 :icon-secondary-color colors/white-opa-70
+                                                 :label-color          colors/white
+                                                 :background-color     (colors/custom-color
+                                                                        customization-color
+                                                                        50)}
+
+    (= type :positive)                           {:icon-color           colors/white
+                                                  :icon-secondary-color colors/white-opa-70
+                                                  :label-color          colors/white
+                                                  :background-color     colors/success-50}
+
+    ;; TODO Remove type blurred
+    (or  (= type :blurred) (and (= :photo background) (= type :grey)))
+    {:icon-color           (colors/theme-colors
+                            colors/neutral-100
+                            colors/white
+                            theme)
+     :icon-secondary-color (colors/theme-colors
+                            colors/neutral-80-opa-40
+                            colors/white-opa-70
+                            theme)
+
+     :label-color          (colors/theme-colors
+                            colors/neutral-100
+                            colors/white
+                            theme)
+     :background-color     (if-not pressed?
+                             (colors/theme-colors
+                              colors/neutral-80-opa-5
+                              colors/white-opa-5
+                              theme)
+                             (colors/theme-colors
+                              colors/neutral-80-opa-10
+                              colors/white-opa-10
+                              theme))
+
+     :icon-background-color (quo2.theme/theme-value
+                             {:default colors/neutral-20
+                              :blurred colors/neutral-80-opa-10}
+                             {:default colors/neutral-80
+                              :blurred colors/white-opa-10})
+
+     :blur-overlay-color   (colors/theme-colors
+                            colors/neutral-10-opa-40-blur
+                            colors/neutral-80-opa-40
+                            theme)
+     :blur-type             (if (= theme :light) :light :dark)}
+
+    ;; TODO Remove type blur-bg
+    (or  (= type :blur-bg) (and (= :blur background) (= type :grey)))  {:icon-color           (colors/theme-colors
+                                                                                               colors/neutral-100
+                                                                                               colors/white
+                                                                                               theme)
+                                                                        :icon-secondary-color (colors/theme-colors
+                                                                                               colors/neutral-80-opa-40
+                                                                                               colors/white-opa-70
+                                                                                               theme)
+                                                                        :label-color          (colors/theme-colors
+                                                                                               colors/neutral-100
+                                                                                               colors/white
+                                                                                               theme)
+                                                                        :background-color     (if-not pressed?
+                                                                                                (colors/theme-colors
+                                                                                                 colors/neutral-80-opa-5
+                                                                                                 colors/white-opa-5
+                                                                                                 theme)
+                                                                                                (colors/theme-colors
+                                                                                                 colors/neutral-80-opa-10
+                                                                                                 colors/white-opa-10
+                                                                                                 theme))}
+    (and (= :blur background) (= type :outline)) {:icon-color           (colors/theme-colors
+                                                                         colors/neutral-100
+                                                                         colors/white
+                                                                         theme)
+                                                  :icon-secondary-color (colors/theme-colors
+                                                                         colors/neutral-80-opa-40
+                                                                         colors/white-opa-40
+                                                                         theme)
+
+                                                  :label-color          (colors/theme-colors
+                                                                         colors/neutral-100
+                                                                         colors/white
+                                                                         theme)
+                                                  :border-color         (if-not pressed?
+                                                                          (colors/theme-colors
+                                                                           colors/neutral-80-opa-10
+                                                                           colors/white-opa-10)
+                                                                          (colors/theme-colors
+                                                                           colors/neutral-80-opa-20
+                                                                           colors/white-opa-20))}
+    (= type :grey)                               {:icon-color           (colors/theme-colors
+                                                                         colors/neutral-100
+                                                                         colors/white
+                                                                         theme)
+                                                  :icon-secondary-color (colors/theme-colors
+                                                                         colors/neutral-50
+                                                                         colors/neutral-40
+                                                                         theme)
+                                                  :label-color          (colors/theme-colors
+                                                                         colors/neutral-100
+                                                                         colors/white
+                                                                         theme)
+                                                  :background-color     (if-not pressed?
+                                                                          (colors/theme-colors
+                                                                           colors/neutral-10
+                                                                           colors/neutral-90
+                                                                           theme)
+                                                                          (colors/theme-colors
+                                                                           colors/neutral-20
+                                                                           colors/neutral-60
+                                                                           theme))}
+
+    (= type :dark-grey)                          {:icon-color           (colors/theme-colors
+                                                                         colors/neutral-100
+                                                                         colors/white
+                                                                         theme)
+                                                  :icon-secondary-color (colors/theme-colors
+                                                                         colors/neutral-50
+                                                                         colors/neutral-40
+                                                                         theme)
+                                                  :label-color          (colors/theme-colors
+                                                                         colors/neutral-100
+                                                                         colors/white
+                                                                         theme)
+                                                  :background-color     (if-not pressed?
+                                                                          (colors/theme-colors
+                                                                           colors/neutral-20
+                                                                           colors/neutral-70
+                                                                           theme)
+                                                                          (colors/theme-colors
+                                                                           colors/neutral-30
+                                                                           colors/neutral-60
+                                                                           theme))}
+
+    (= type :outline)                            {:icon-color           (colors/theme-colors
+                                                                         colors/neutral-50
+                                                                         colors/neutral-40
+                                                                         theme)
+                                                  :icon-secondary-color (colors/theme-colors
+                                                                         colors/neutral-50
+                                                                         colors/neutral-40
+                                                                         theme)
+                                                  :label-color          (colors/theme-colors
+                                                                         colors/neutral-100
+                                                                         colors/white
+                                                                         theme)
+                                                  :border-color         (if-not pressed?
+                                                                          (colors/theme-colors
+                                                                           colors/neutral-30
+                                                                           colors/neutral-70
+                                                                           theme)
+                                                                          (colors/theme-colors
+                                                                           colors/neutral-40
+                                                                           colors/neutral-60
+                                                                           theme))}
+
+    (= type :ghost)                              {:icon-color           (colors/theme-colors
+                                                                         colors/neutral-50
+                                                                         colors/neutral-40
+                                                                         theme)
+                                                  :icon-secondary-color (colors/theme-colors
+                                                                         colors/neutral-50
+                                                                         colors/neutral-40
+                                                                         theme)
+                                                  :label-color          (colors/theme-colors
+                                                                         colors/neutral-100
+                                                                         colors/white
+                                                                         theme)
+                                                  :background-color     (when pressed?
+                                                                          (colors/theme-colors
+                                                                           colors/neutral-10
+                                                                           colors/neutral-80
+                                                                           theme))}
+
+    (= type :danger)                             {:icon-color           colors/white
+                                                  :icon-secondary-color colors/white-opa-70
+                                                  :label-color          colors/white
+                                                  :background-color     colors/danger-50}
+
+
+    ;; TODO: remove type shell 
+    (or (= type :shell) (= type :black))                           {:icon-color       colors/white
+                                                                     :label-color      colors/white
+                                                                     :background-color (if-not pressed?
+                                                                                         colors/neutral-95
+                                                                                         colors/neutral-80)}))

--- a/src/quo2/components/buttons/button/view.cljs
+++ b/src/quo2/components/buttons/button/view.cljs
@@ -40,12 +40,10 @@
             {:keys [icon-color icon-secondary-color background-color label-color border-color blur-type
                     blur-overlay-color icon-background-color]}
             (type-values/get-value-from-type {:customization-color customization-color
-                                              :background background
-                                              :type type
-                                              :theme theme
-                                              :pressed? pressed})
-
-
+                                              :background          background
+                                              :type                type
+                                              :theme               theme
+                                              :pressed?            pressed?})
             state (cond disabled                 :disabled
                         (or @pressed-in pressed) :pressed
                         :else                    :default)
@@ -82,7 +80,6 @@
                                             :before before
                                             :after after
                                             :blur-active? blur-active?})
-                   
                     inner-style)}
            (when customization-color
              [customization-colors/overlay
@@ -104,9 +101,9 @@
            (when before
              [rn/view
               {:style (style/before-icon-style
-                       {:size                    size
-                        :icon-background-color   (get icon-background-color blur-state)
-                        :icon-size               icon-size})}
+                       {:size                  size
+                        :icon-background-color (get icon-background-color blur-state)
+                        :icon-size             icon-size})}
               [quo2.icons/icon before
                {:color icon-secondary-color
                 :size  icon-size}]])
@@ -131,9 +128,9 @@
            (when after
              [rn/view
               {:style (style/after-icon-style
-                       {:size                    size
-                        :icon-background-color   (get icon-background-color blur-state)
-                        :icon-size               icon-size})}
+                       {:size                  size
+                        :icon-background-color (get icon-background-color blur-state)
+                        :icon-size             icon-size})}
               [quo2.icons/icon after
                {:no-color icon-secondary-no-color
                 :color    icon-secondary-color
@@ -143,7 +140,7 @@
   [{:keys [type customization-color] :or {type :primary} :as props} label]
   (let [color (case type
                 :primary  (or customization-color :primary)
-                :positive :positive
+                :positive :success
                 :danger   :danger
                 nil)]
     [button-internal (assoc props :customization-color color :type type) label]))

--- a/src/quo2/components/dropdowns/dropdown.cljs
+++ b/src/quo2/components/dropdowns/dropdown.cljs
@@ -1,10 +1,11 @@
 (ns quo2.components.dropdowns.dropdown
-  (:require [quo2.components.buttons.button.view :as button]))
+  (:require [quo2.components.dropdowns.old-button-view :as old-button]))
 
 (defn dropdown
   [_ _]
   (fn [{:keys [on-change selected] :as opts} children]
-    [button/button
+    ;TODO: Dropdown needs to be implemented/refactored to be its own component - https://github.com/status-im/status-mobile/issues/16456
+    [old-button/button
      (merge
       opts
       {:after                   (if selected :i/chevron-top :i/chevron-down)

--- a/src/quo2/components/dropdowns/dropdown.cljs
+++ b/src/quo2/components/dropdowns/dropdown.cljs
@@ -4,7 +4,8 @@
 (defn dropdown
   [_ _]
   (fn [{:keys [on-change selected] :as opts} children]
-    ;TODO: Dropdown needs to be implemented/refactored to be its own component - https://github.com/status-im/status-mobile/issues/16456
+    ;TODO: Dropdown needs to be implemented/refactored to be its own component -
+    ;https://github.com/status-im/status-mobile/issues/16456
     [old-button/button
      (merge
       opts

--- a/src/quo2/components/dropdowns/old_button_style.cljs
+++ b/src/quo2/components/dropdowns/old_button_style.cljs
@@ -1,0 +1,265 @@
+(ns quo2.components.dropdowns.old-button-style
+  (:require [quo2.foundations.colors :as colors]))
+;TODO: Dropdown needs to be implemented as its own component - https://github.com/status-im/status-mobile/issues/16456
+
+(def blur-view
+  {:position :absolute
+   :top      0
+   :left     0
+   :right    0
+   :bottom   0})
+
+(defn before-icon-style
+  [{:keys [override-margins size icon-container-size icon-background-color icon-container-rounded?
+           icon-size]}]
+  (merge
+   {:margin-left     (or (get override-margins :left)
+                         (if (= size 40) 12 8))
+    :margin-right    (or (get override-margins :right) 4)
+    :align-items     :center
+    :justify-content :center}
+   (when icon-container-size
+     {:width  icon-container-size
+      :height icon-container-size})
+   (when icon-background-color
+     {:background-color icon-background-color})
+   (when icon-container-rounded?
+     {:border-radius (/ (or icon-container-size icon-size) 2)})))
+
+(defn after-icon-style
+  [{:keys [override-margins size icon-container-size icon-background-color icon-container-rounded?
+           icon-size]}]
+  (merge
+   {:margin-left     (or (get override-margins :left) 4)
+    :margin-right    (or (get override-margins :right)
+                         (if (= size 40) 12 8))
+    :align-items     :center
+    :justify-content :center}
+   (when icon-container-size
+     {:width  icon-container-size
+      :height icon-container-size})
+   (when icon-background-color
+     {:background-color icon-background-color})
+   (when icon-container-rounded?
+     {:border-radius (/ (or icon-container-size icon-size) 2)})))
+
+(defn themes
+  [customization-color]
+  {:light
+   {:primary         {:icon-color           colors/white
+                      :icon-secondary-color colors/white-opa-70
+                      :label-color          colors/white
+                      :background-color     {:default  (colors/custom-color customization-color 50)
+                                             :pressed  (colors/custom-color customization-color 60)
+                                             :disabled (colors/custom-color customization-color 50)}}
+    :secondary       {:icon-color       colors/primary-50
+                      :label-color      colors/primary-50
+                      :background-color {:default  colors/primary-50-opa-20
+                                         :pressed  colors/primary-50-opa-40
+                                         :disabled colors/primary-50-opa-20}}
+    :grey            {:icon-color           colors/neutral-100
+                      :icon-secondary-color colors/neutral-50
+                      :label-color          colors/neutral-100
+                      :background-color     {:default  colors/neutral-10
+                                             :pressed  colors/neutral-20
+                                             :disabled colors/neutral-10}}
+    :dark-grey       {:icon-color           colors/neutral-100
+                      :icon-secondary-color colors/neutral-50
+                      :label-color          colors/neutral-100
+                      :background-color     {:default  colors/neutral-20
+                                             :pressed  colors/neutral-30
+                                             :disabled colors/neutral-20}}
+    :outline         {:icon-color           colors/neutral-50
+                      :icon-secondary-color colors/neutral-50
+                      :label-color          colors/neutral-100
+                      :border-color         {:default  colors/neutral-30
+                                             :pressed  colors/neutral-40
+                                             :disabled colors/neutral-30}}
+    :ghost           {:icon-color           colors/neutral-50
+                      :icon-secondary-color colors/neutral-50
+                      :label-color          colors/neutral-100
+                      :background-color     {:pressed colors/neutral-10}}
+    :danger          {:icon-color           colors/white
+                      :icon-secondary-color colors/white-opa-70
+                      :label-color          colors/white
+                      :background-color     {:default  colors/danger-50
+                                             :pressed  colors/danger-60
+                                             :disabled colors/danger-50}}
+    :positive        {:icon-color           colors/white
+                      :icon-secondary-color colors/white-opa-70
+                      :label-color          colors/white
+                      :background-color     {:default  colors/success-50
+                                             :pressed  colors/success-60
+                                             :disabled colors/success-50-opa-30}}
+    :photo-bg        {:icon-color           colors/neutral-100
+                      :icon-secondary-color colors/neutral-80-opa-40
+                      :label-color          colors/neutral-100
+                      :background-color     {:default  colors/white-opa-40
+                                             :pressed  colors/white-opa-50
+                                             :disabled colors/white-opa-40}}
+    :blur-bg         {:icon-color           colors/neutral-100
+                      :icon-secondary-color colors/neutral-80-opa-40
+                      :label-color          colors/neutral-100
+                      :background-color     {:default  colors/neutral-80-opa-5
+                                             :pressed  colors/neutral-80-opa-10
+                                             :disabled colors/neutral-80-opa-5}}
+    :blurred         {:icon-color            colors/neutral-100
+                      :icon-secondary-color  colors/neutral-100
+                      :icon-background-color {:default colors/neutral-20
+                                              :blurred colors/neutral-80-opa-10}
+                      :label-color           colors/neutral-100
+                      :background-color      {:default  colors/neutral-10
+                                              :pressed  colors/neutral-10
+                                              :disabled colors/neutral-10-opa-10-blur}
+                      :blur-overlay-color    colors/neutral-10-opa-40-blur
+                      :blur-type             :light}
+    :blur-bg-outline {:icon-color           colors/neutral-100
+                      :icon-secondary-color colors/neutral-80-opa-40
+                      :label-color          colors/neutral-100
+                      :border-color         {:default  colors/neutral-80-opa-10
+                                             :pressed  colors/neutral-80-opa-20
+                                             :disabled colors/neutral-80-opa-10}}
+    :shell           {:icon-color       colors/white
+                      :label-color      colors/white
+                      :background-color {:default  colors/neutral-95
+                                         :pressed  colors/neutral-95
+                                         :disabled colors/neutral-95}}}
+   :dark
+   {:primary         {:icon-color           colors/white
+                      :icon-secondary-color colors/white-opa-70
+                      :label-color          colors/white
+                      :background-color     {:default  (colors/custom-color customization-color 60)
+                                             :pressed  (colors/custom-color customization-color 50)
+                                             :disabled (colors/custom-color customization-color 60)}}
+    :secondary       {:icon-color       colors/primary-50
+                      :label-color      colors/primary-50
+                      :background-color {:default  colors/primary-50-opa-20
+                                         :pressed  colors/primary-50-opa-30
+                                         :disabled colors/primary-50-opa-20}}
+    :grey            {:icon-color           colors/white
+                      :icon-secondary-color colors/neutral-40
+                      :label-color          colors/white
+                      :background-color     {:default  colors/neutral-90
+                                             :pressed  colors/neutral-60
+                                             :disabled colors/neutral-90}}
+    :dark-grey       {:icon-color           colors/white
+                      :icon-secondary-color colors/neutral-40
+                      :label-color          colors/white
+                      :background-color     {:default  colors/neutral-70
+                                             :pressed  colors/neutral-60
+                                             :disabled colors/neutral-70}}
+    :outline         {:icon-color           colors/neutral-40
+                      :icon-secondary-color colors/neutral-40
+                      :label-color          colors/white
+                      :border-color         {:default  colors/neutral-70
+                                             :pressed  colors/neutral-60
+                                             :disabled colors/neutral-70}}
+    :ghost           {:icon-color           colors/neutral-40
+                      :icon-secondary-color colors/neutral-40
+                      :label-color          colors/white
+                      :background-color     {:pressed colors/neutral-80}}
+    :danger          {:icon-color           colors/white
+                      :icon-secondary-color colors/white-opa-70
+                      :label-color          colors/white
+                      :background-color     {:default  colors/danger-60
+                                             :pressed  colors/danger-50
+                                             :disabled colors/danger-60}}
+    :positive        {:icon-color           colors/white
+                      :icon-secondary-color colors/white-opa-70
+                      :label-color          colors/white
+                      :background-color     {:default  colors/success-60
+                                             :pressed  colors/success-50
+                                             :disabled colors/success-60-opa-30}}
+    :photo-bg        {:icon-color           colors/white
+                      :icon-secondary-color colors/neutral-30
+                      :label-color          colors/white
+                      :background-color     {:default  colors/neutral-80-opa-40
+                                             :pressed  colors/neutral-80-opa-50
+                                             :disabled colors/neutral-80-opa-40}}
+    :blur-bg         {:icon-color           colors/white
+                      :icon-secondary-color colors/white-opa-70
+                      :label-color          colors/white
+                      :background-color     {:default  colors/white-opa-5
+                                             :pressed  colors/white-opa-10
+                                             :disabled colors/white-opa-5}}
+    :blurred         {:icon-color            colors/white
+                      :icon-secondary-color  colors/white
+                      :icon-background-color {:default colors/neutral-80
+                                              :blurred colors/white-opa-10}
+                      :label-color           colors/white
+                      :background-color      {:default  colors/neutral-90
+                                              :pressed  colors/neutral-90
+                                              :disabled colors/neutral-90-opa-10-blur}
+                      :blur-overlay-color    colors/neutral-80-opa-40
+                      :blur-type             :dark}
+    :blur-bg-outline {:icon-color           colors/white
+                      :icon-secondary-color colors/white-opa-40
+                      :label-color          colors/white
+                      :border-color         {:default  colors/white-opa-10
+                                             :pressed  colors/white-opa-20
+                                             :disabled colors/white-opa-5}}
+    :shell           {:icon-color       colors/white
+                      :label-color      colors/white
+                      :background-color {:default colors/neutral-95}}}})
+
+(defn shape-style-container
+  [type icon size]
+  {:height        size
+   :border-radius (if (and icon (#{:primary :secondary :danger} type))
+                    24
+                    (case size
+                      56 12
+                      40 12
+                      32 10
+                      24 8))})
+
+(defn style-container
+  [{:keys [type size disabled background-color border-color icon above width before after blur-active?]}]
+  (merge {:height             size
+          :align-items        :center
+          :justify-content    :center
+          :flex-direction     (if above :column :row)
+          :padding-horizontal (when-not (or icon before after)
+                                (case size
+                                  56 16
+                                  40 16
+                                  32 12
+                                  24 8))
+          :padding-left       (when-not (or icon before)
+                                (case size
+                                  56 16
+                                  40 16
+                                  32 12
+                                  24 8))
+          :padding-right      (when-not (or icon after)
+                                (case size
+                                  56 16
+                                  40 16
+                                  32 12
+                                  24 8))
+          :padding-top        (when-not (or icon before after)
+                                (case size
+                                  56 0
+                                  40 9
+                                  32 5
+                                  24 3))
+          :padding-bottom     (when-not (or icon before after)
+                                (case size
+                                  56 0
+                                  40 9
+                                  32 5
+                                  24 4))
+          :overflow           :hidden}
+         (when (or (and (= type :blurred) (not blur-active?))
+                   (not= type :blurred))
+           {:background-color background-color})
+         (shape-style-container type icon size)
+         (when width
+           {:width width})
+         (when icon
+           {:width size})
+         (when border-color
+           {:border-color border-color
+            :border-width 1})
+         (when disabled
+           {:opacity 0.3})))

--- a/src/quo2/components/dropdowns/old_button_style.cljs
+++ b/src/quo2/components/dropdowns/old_button_style.cljs
@@ -1,6 +1,7 @@
 (ns quo2.components.dropdowns.old-button-style
   (:require [quo2.foundations.colors :as colors]))
-;TODO: Dropdown needs to be implemented as its own component - https://github.com/status-im/status-mobile/issues/16456
+;TODO: Dropdown needs to be implemented as its own component -
+;https://github.com/status-im/status-mobile/issues/16456
 
 (def blur-view
   {:position :absolute

--- a/src/quo2/components/dropdowns/old_button_view.cljs
+++ b/src/quo2/components/dropdowns/old_button_view.cljs
@@ -6,7 +6,8 @@
             [react-native.blur :as blur]
             [reagent.core :as reagent]
             [quo2.components.dropdowns.old-button-style :as style]))
-;TODO: Dropdown needs to be implemented as its own component - https://github.com/status-im/status-mobile/issues/16456
+;TODO: Dropdown needs to be implemented as its own component -
+;https://github.com/status-im/status-mobile/issues/16456
 
 (defn- button-internal
   "with label

--- a/src/quo2/foundations/colors.cljs
+++ b/src/quo2/foundations/colors.cljs
@@ -244,10 +244,13 @@
      ([color suffix]
       (custom-color color suffix nil))
      ([color suffix opacity]
-      (let [color-keyword (keyword color)
+      (let [hex?          (not (keyword? color))
+            color-keyword (keyword color)
             base-color    (get-in colors-map
                                   [color-keyword suffix])]
-        (if opacity (alpha base-color (/ opacity 100)) base-color))))))
+        (if hex?
+          color
+          (if opacity (alpha base-color (/ opacity 100)) base-color)))))))
 
 (defn custom-color-by-theme
   "(custom-color-by-theme color suffix-light suffix-dark opacity-light opacity-dark)

--- a/src/quo2/foundations/customization_colors.cljs
+++ b/src/quo2/foundations/customization_colors.cljs
@@ -1,0 +1,19 @@
+(ns quo2.foundations.customization-colors
+  (:require [quo2.foundations.colors :as colors]
+            [react-native.core :as rn]))
+
+(defn get-overlay-color
+  [theme pressed?]
+  (if (= theme :light)
+    (colors/alpha colors/black (if-not pressed? 0 0.2))
+    (colors/alpha colors/black (if-not pressed? 0.2 0))))
+
+(defn overlay
+  [{:keys [theme pressed?]}]
+  [rn/view
+   {:position         :absolute
+    :top              0
+    :left             0
+    :right            0
+    :bottom           0
+    :background-color (get-overlay-color theme pressed?)}])

--- a/src/status_im2/contexts/communities/overview/view.cljs
+++ b/src/status_im2/contexts/communities/overview/view.cljs
@@ -162,7 +162,7 @@
        [quo/button
         {:on-press                  #(join-gated-community id)
          :accessibility-label       :join-community-button
-         :override-background-color community-color
+         :customization-color community-color
          :style                     {:margin-horizontal 12 :margin-top 12 :margin-bottom 12}
          :disabled                  (not can-request-access?)
          :before                    (if can-request-access? :i/unlocked :i/locked)}

--- a/src/status_im2/contexts/communities/overview/view.cljs
+++ b/src/status_im2/contexts/communities/overview/view.cljs
@@ -136,7 +136,7 @@
 (defn token-gates
   [{:keys [id]}]
   (rf/dispatch [:communities/check-permissions-to-join-community id])
-  (fn [{:keys [id community-color]}]
+  (fn [{:keys [id color]}]
     (let [{:keys [can-request-access?
                   number-of-hold-tokens tokens]} (rf/sub [:community/token-gated-overview id])]
       [rn/view {:style (style/token-gated-container)}
@@ -160,16 +160,16 @@
         {:tokens   tokens
          :padding? true}]
        [quo/button
-        {:on-press                  #(join-gated-community id)
-         :accessibility-label       :join-community-button
-         :customization-color community-color
-         :style                     {:margin-horizontal 12 :margin-top 12 :margin-bottom 12}
-         :disabled                  (not can-request-access?)
-         :before                    (if can-request-access? :i/unlocked :i/locked)}
+        {:on-press            #(join-gated-community id)
+         :accessibility-label :join-community-button
+         :customization-color color
+         :style               {:margin-horizontal 12 :margin-top 12 :margin-bottom 12}
+         :disabled            (not can-request-access?)
+         :before              (if can-request-access? :i/unlocked :i/locked)}
         (i18n/label :t/join-open-community)]])))
 
 (defn join-community
-  [{:keys [joined can-join? community-color permissions token-permissions] :as community}
+  [{:keys [joined can-join? color permissions token-permissions] :as community}
    pending?]
   (let [access-type     (get-access-type (:access permissions))
         unknown-access? (= access-type :unknown-access)
@@ -181,10 +181,10 @@
        (if token-permissions
          [token-gates community]
          [quo/button
-          {:on-press                  #(rf/dispatch [:open-modal :community-requests-to-join community])
-           :accessibility-label       :show-request-to-join-screen-button
-           :override-background-color community-color
-           :before                    :i/communities}
+          {:on-press            #(rf/dispatch [:open-modal :community-requests-to-join community])
+           :accessibility-label :show-request-to-join-screen-button
+           :customization-color color
+           :before              :i/communities}
           (request-to-join-text is-open?)]))
 
      (when (and (not (or joined pending? token-permissions)) (not (or is-open? node-offline?)))

--- a/src/status_im2/contexts/onboarding/enable_biometrics/view.cljs
+++ b/src/status_im2/contexts/onboarding/enable_biometrics/view.cljs
@@ -28,17 +28,17 @@
         profile-color            (:color (rf/sub [:onboarding-2/profile]))]
     [rn/view {:style (style/buttons insets)}
      [quo/button
-      {:accessibility-label       :enable-biometrics-button
-       :on-press                  #(rf/dispatch [:onboarding-2/enable-biometrics])
-       :before                    :i/face-id
+      {:accessibility-label :enable-biometrics-button
+       :on-press            #(rf/dispatch [:onboarding-2/enable-biometrics])
+       :before              :i/face-id
        :customization-color profile-color}
       (i18n/label :t/biometric-enable-button {:bio-type-label bio-type-label})]
      [quo/button
-      {:accessibility-label       :maybe-later-button
-       :background :blur
-       :type :grey
-       :on-press                  #(rf/dispatch [:onboarding-2/create-account-and-login])
-       :style                     {:margin-top 12}}
+      {:accessibility-label :maybe-later-button
+       :background          :blur
+       :type                :grey
+       :on-press            #(rf/dispatch [:onboarding-2/create-account-and-login])
+       :style               {:margin-top 12}}
       (i18n/label :t/maybe-later)]]))
 
 (defn enable-biometrics-parallax

--- a/src/status_im2/contexts/onboarding/enable_biometrics/view.cljs
+++ b/src/status_im2/contexts/onboarding/enable_biometrics/view.cljs
@@ -1,6 +1,5 @@
 (ns status-im2.contexts.onboarding.enable-biometrics.view
   (:require [quo2.core :as quo]
-            [quo2.foundations.colors :as colors]
             [react-native.core :as rn]
             [react-native.safe-area :as safe-area]
             [status-im2.contexts.onboarding.enable-biometrics.style :as style]
@@ -32,12 +31,13 @@
       {:accessibility-label       :enable-biometrics-button
        :on-press                  #(rf/dispatch [:onboarding-2/enable-biometrics])
        :before                    :i/face-id
-       :override-background-color (colors/custom-color profile-color 50)}
+       :customization-color profile-color}
       (i18n/label :t/biometric-enable-button {:bio-type-label bio-type-label})]
      [quo/button
       {:accessibility-label       :maybe-later-button
+       :background :blur
+       :type :grey
        :on-press                  #(rf/dispatch [:onboarding-2/create-account-and-login])
-       :override-background-color colors/white-opa-5
        :style                     {:margin-top 12}}
       (i18n/label :t/maybe-later)]]))
 

--- a/src/status_im2/contexts/onboarding/enable_notifications/view.cljs
+++ b/src/status_im2/contexts/onboarding/enable_notifications/view.cljs
@@ -37,12 +37,13 @@
        :override-background-color (colors/custom-color profile-color 60)}
       (i18n/label :t/intro-wizard-title6)]
      [quo/button
-      {:on-press                  (fn []
-                                    (shell.utils/change-selected-stack-id :communities-stack true nil)
-                                    (rf/dispatch [:init-root :welcome]))
-       :accessibility-label       :enable-notifications-later-button
-       :override-background-color colors/white-opa-5
-       :style                     {:margin-top 12}}
+      {:on-press            (fn []
+                              (shell.utils/change-selected-stack-id :communities-stack true nil)
+                              (rf/dispatch [:init-root :welcome]))
+       :accessibility-label :enable-notifications-later-button
+       :type                :grey
+       :background          :blur
+       :style               {:margin-top 12}}
       (i18n/label :t/maybe-later)]]))
 
 (defn enable-notifications

--- a/src/status_im2/contexts/onboarding/identifiers/view.cljs
+++ b/src/status_im2/contexts/onboarding/identifiers/view.cljs
@@ -57,10 +57,11 @@
          :customization-color color
          :progress            progress}]
        [quo/button
-        {:accessibility-label       :skip-identifiers
-         :on-press                  #(rf/dispatch [:navigate-to :enable-notifications])
-         :override-background-color colors/white-opa-5
-         :style                     style/button}
+        {:accessibility-label :skip-identifiers
+         :type                :grey
+         :background          :blur
+         :on-press            #(rf/dispatch [:navigate-to :enable-notifications])
+         :style               style/button}
         (i18n/label :t/skip)]]]]))
 
 (defn view [props] [:f> f-view props])

--- a/src/status_im2/contexts/onboarding/welcome/view.cljs
+++ b/src/status_im2/contexts/onboarding/welcome/view.cljs
@@ -32,8 +32,10 @@
     :align-mid?              false
     :page-nav-color          :transparent
     :left-section            {:icon                  :i/arrow-left
+                              ;TODO this is wrong - page nav needs updating
+                              ; should be type:grey, and page nav can use background instead.
                               :icon-background-color colors/white-opa-5
-                              :type                  :shell
+                              :type                  :grey
                               :on-press              #(rf/dispatch [:init-root root])}}])
 
 (defn dispatch-visibility-status-update

--- a/src/status_im2/contexts/profile/profiles/view.cljs
+++ b/src/status_im2/contexts/profile/profiles/view.cljs
@@ -250,7 +250,6 @@
        :type                :primary
        :customization-color (or customization-color :primary)
        :accessibility-label :login-button
-       :override-theme      :dark
        :before              :i/unlocked
        :disabled            (or (not sign-in-enabled?) processing)
        :on-press            login-multiaccount

--- a/src/status_im2/contexts/quo_preview/buttons/button.cljs
+++ b/src/status_im2/contexts/quo_preview/buttons/button.cljs
@@ -11,8 +11,8 @@
     :type    :select
     :options [{:key   :primary
                :value "Primary"}
-              {:key   :secondary
-               :value "Secondary"}
+              {:key   :positive
+               :value "Positive"}
               {:key   :grey
                :value "Grey"}
               {:key   :dark-grey
@@ -23,8 +23,8 @@
                :value "Ghost"}
               {:key   :danger
                :value "Danger"}
-              {:key   :positive
-               :value "Positive"}]}
+              {:key   :black
+               :value "Black"}]}
    {:label   "Size:"
     :key     :size
     :type    :select
@@ -36,6 +36,13 @@
                :value "32"}
               {:key   24
                :value "24"}]}
+   {:label   "Background:"
+    :key     :background
+    :type    :select
+    :options [{:key   :blur
+               :value "Blur"}
+              {:key   :photo
+               :value "Photo"}]}
    {:label "Icon:"
     :key   :icon
     :type  :boolean}
@@ -78,7 +85,8 @@
                   :theme
                   :before
                   :after)
-                 {:on-press #(println "Hello world!")}
+                 {:background (:background @state)
+                  :on-press   #(println "Hello world!")}
                  (when @above
                    {:above :i/placeholder})
                  (when @before


### PR DESCRIPTION
Partially fixes: https://github.com/status-im/status-mobile/issues/16396

This pr makes a number of changes to the button component:

1. aligns button component closer to Figma API - retains old types so that we can update these uses across the codebase in a follow up pr.

2. creates and uses customization color mask in button component so that community colors can now be used correctly for buttons. Similarly this approach can be used in other customisation/community color components.

3. Moves Drop down component to it's own component but still this needs to be refactored properly in a follow up issue.

4. removed a number of props that are not needed and unused - icon-no-color, test-ID, icon-secondary-no-color, dropdown component related props

5. Updated a few uses of the correct types and backgrounds, particularly in onboarding flow



Note: I will be doing a further follow ups to clean up the button even more. 
This includes removing the prop `override-background-color` and all it's uses.
Updating prop `icon` to `icon-only?` and removing some redundant config that goes with that.
Properly using `background` `:blur` and `:photo`  across the codebase.
remove use of `width` prop in button
remove use of `inner-style`
change `style` prop to `container-style`

See issue: https://github.com/status-im/status-mobile/issues/16535

To Test:
It's worth doing a review of uses of buttons on different pages and in different themes.
Additionally the dropdown component moved place, technically nothing changed there but perhaps a quick review of it's uses for styling is worth doing.

Additionally test community colors for the button component. This can be done by creating a community on desktop. Setting a community color, then test the color is showing correctly for the button on the community page.