### PR TITLE
Profile color in Jump-to and View Profile buttons

### DIFF
--- a/src/status_im2/contexts/add_new_contact/style.cljs
+++ b/src/status_im2/contexts/add_new_contact/style.cljs
@@ -167,8 +167,9 @@
            colors/neutral-40)})
 
 (defn button-view-profile
-  [state]
+  [state customization-color]
   {:type                :primary
+   :customization-color customization-color
    :size                40
    :width               335
    :style               {:margin-top    24

--- a/src/status_im2/contexts/add_new_contact/views.cljs
+++ b/src/status_im2/contexts/add_new_contact/views.cljs
@@ -47,6 +47,7 @@
       (clipboard/get-string #(reset! clipboard %))
       (let [{:keys [input scanned public-key ens state msg]}
             (rf/sub [:contacts/new-identity])
+            customization-color (rf/sub [:profile/customization-color])
             invalid? (= state :invalid)
             show-paste-button? (and (not (string/blank? @clipboard))
                                     (string/blank? @default-value)
@@ -107,7 +108,7 @@
             (when (= state :valid)
               [found-contact public-key])]
            [quo/button
-            (merge (style/button-view-profile state)
+            (merge (style/button-view-profile state customization-color)
                    {:on-press
                     (fn []
                       (reset! clipboard nil)

--- a/src/status_im2/contexts/chat/composer/sub_view.cljs
+++ b/src/status_im2/contexts/chat/composer/sub_view.cljs
@@ -27,13 +27,14 @@
 
 (defn- f-shell-button
   [{:keys [maximized? focused?]} {:keys [height]} {:keys [reply edit]}]
-  (let [insets       (safe-area/get-insets)
-        extra-height (utils/calc-top-content-height reply edit)
-        neg-y        (utils/calc-shell-neg-y insets maximized? extra-height)
-        y-container  (reanimated/use-shared-value neg-y)
-        hide-shell?  (or @focused? @messages.list/show-floating-scroll-down-button)
-        y-shell      (reanimated/use-shared-value (if hide-shell? 35 0))
-        opacity      (reanimated/use-shared-value (if hide-shell? 0 1))]
+  (let [customization-color (rf/sub [:profile/customization-color])
+        insets              (safe-area/get-insets)
+        extra-height        (utils/calc-top-content-height reply edit)
+        neg-y               (utils/calc-shell-neg-y insets maximized? extra-height)
+        y-container         (reanimated/use-shared-value neg-y)
+        hide-shell?         (or @focused? @messages.list/show-floating-scroll-down-button)
+        y-shell             (reanimated/use-shared-value (if hide-shell? 35 0))
+        opacity             (reanimated/use-shared-value (if hide-shell? 0 1))]
     (rn/use-effect
      (fn []
        (reanimated/animate opacity (if hide-shell? 0 1))
@@ -46,11 +47,12 @@
       {:style (style/shell-button y-shell opacity)}
       [quo/floating-shell-button
        {:jump-to
-        {:on-press (fn []
-                     (rf/dispatch [:chat/close true])
-                     (rf/dispatch [:shell/navigate-to-jump-to]))
-         :label    (i18n/label :t/jump-to)
-         :style    {:align-self :center}}} {}]]
+        {:on-press            (fn []
+                                (rf/dispatch [:chat/close true])
+                                (rf/dispatch [:shell/navigate-to-jump-to]))
+         :customization-color customization-color
+         :label               (i18n/label :t/jump-to)
+         :style               {:align-self :center}}} {}]]
      [quo/floating-shell-button
       (when @messages.list/show-floating-scroll-down-button
         {:scroll-to-bottom {:on-press messages.list/scroll-to-bottom}})

--- a/src/status_im2/contexts/communities/overview/view.cljs
+++ b/src/status_im2/contexts/communities/overview/view.cljs
@@ -356,11 +356,13 @@
 
 (defn overview
   [id]
-  (let [id (or id (rf/sub [:get-screen-params :community-overview]))]
+  (let [id                  (or id (rf/sub [:get-screen-params :community-overview]))
+        customization-color (rf/sub [:profile/customization-color])]
     [rn/view {:style style/community-overview-container}
      [community-card-page-view id]
      [floating-shell-button/floating-shell-button
-      {:jump-to {:on-press #(rf/dispatch [:shell/navigate-to-jump-to])
-                 :label    (i18n/label :t/jump-to)}}
+      {:jump-to {:on-press            #(rf/dispatch [:shell/navigate-to-jump-to])
+                 :customization-color customization-color
+                 :label               (i18n/label :t/jump-to)}}
       {:position :absolute
        :bottom   41}]]))


### PR DESCRIPTION
fixes #16477

### Summary

This PR fixes the profile colour in the following screens: 
- `View Profile` button on the `Add a contact` page
- `Jump to` button inside the chat
- `Jump to` button in the Community Overview screen


### Platforms

- Android
- iOS


status: ready 
