### PR TITLE
[Fix] Seen state in Activity Center when it is open

### DIFF
--- a/src/status_im2/contexts/shell/activity_center/events.cljs
+++ b/src/status_im2/contexts/shell/activity_center/events.cljs
@@ -102,7 +102,10 @@
 (rf/defn reconcile-seen-state
   {:events [:activity-center/reconcile-seen-state]}
   [{:keys [db]} seen?]
-  {:db (assoc-in db [:activity-center :seen?] seen?)})
+  (cond-> {:db (assoc-in db [:activity-center :seen?] seen?)}
+
+    (= (:view-id db) :activity-center)
+    (assoc :dispatch [:activity-center/mark-as-seen])))
 
 ;;;; Status changes (read/dismissed/deleted)
 

--- a/src/status_im2/contexts/shell/activity_center/events_test.cljs
+++ b/src/status_im2/contexts/shell/activity_center/events_test.cljs
@@ -436,3 +436,19 @@
                                               :type   types/one-to-one-chat}
                                      :cursor ""}}}
              (events/notifications-fetch-error cofx :dummy-error))))))
+
+(deftest seen-state-test
+  (testing "update seen state"
+    (is (= {:db {:activity-center {:seen? true}}}
+           (events/reconcile-seen-state {:db {}} true))))
+
+  (testing "update seen state when the user is on other screen"
+    (is (= {:db {:view-id         :chats-stack
+                 :activity-center {:seen? false}}}
+           (events/reconcile-seen-state {:db {:view-id :chats-stack}} false))))
+
+  (testing "update seen state when the user is on activity center"
+    (is (= {:db       {:view-id         :activity-center
+                       :activity-center {:seen? false}}
+            :dispatch [:activity-center/mark-as-seen]}
+           (events/reconcile-seen-state {:db {:view-id :activity-center}} false)))))


### PR DESCRIPTION
fixes #16306

### Summary

This PR fixes the seen state of notifications if the user is in the Activity Center screen while receiving a new notification.

### Platforms

- Android
- iOS

### Areas impacted

- Activity Center

### Steps to test

- Open Status
- Navigate to the Activity Center
- Keep the Activity Center open
- Receive any Activity Center notification (Contact Request, Mentions, Replies,...etc)
- Close the Activity Center
- Check the colour of the unread counter on the Notification Bell Icon

status: ready