### PR TITLE
[16543] Fix muting channel from inside and outside chat page

### DIFF
--- a/src/status_im2/contexts/communities/actions/chat/view.cljs
+++ b/src/status_im2/contexts/communities/actions/chat/view.cljs
@@ -106,8 +106,8 @@
    :label               (i18n/label :t/share-channel)})
 
 (defn actions
-  [{:keys [locked? id community-id]} inside-chat?]
-  (let [{:keys [muted muted-till chat-type]} (rf/sub [:chat-by-id (str community-id id)])]
+  [{:keys [locked? chat-id]} inside-chat?]
+  (let [{:keys [muted muted-till chat-type]} (rf/sub [:chat-by-id chat-id])]
     (cond
       locked?
       [quo/action-drawer
@@ -120,7 +120,7 @@
       [quo/action-drawer
        [[(action-view-members-and-details)
          (action-mark-as-read)
-         (action-toggle-muted (str community-id id) muted muted-till chat-type)
+         (action-toggle-muted chat-id muted muted-till chat-type)
          (action-notification-settings)
          (action-pinned-messages)
          (action-invite-people)
@@ -132,7 +132,7 @@
        [[(action-view-members-and-details)
          (action-token-requirements)
          (action-mark-as-read)
-         (action-toggle-muted (str community-id id) muted muted-till chat-type)
+         (action-toggle-muted chat-id muted muted-till chat-type)
          (action-notification-settings)
          (action-fetch-messages)
          (action-invite-people)

--- a/src/status_im2/contexts/communities/overview/view.cljs
+++ b/src/status_im2/contexts/communities/overview/view.cljs
@@ -51,7 +51,7 @@
 (defn- channel-chat-item
   [community-id community-color {chat-id :id muted? :muted? :as chat}]
   (let [sheet-content      [actions/chat-actions
-                            (assoc chat :chat-type constants/community-chat-type)
+                            (assoc chat :chat-type constants/community-chat-type :chat-id (str community-id chat-id))
                             false]
         channel-sheet-data {:selected-item (fn [] [quo/channel-list-item chat])
                             :content       (fn [] sheet-content)}]

--- a/src/status_im2/contexts/communities/overview/view.cljs
+++ b/src/status_im2/contexts/communities/overview/view.cljs
@@ -224,7 +224,7 @@
       :on-long-press #(rf/dispatch
                        [:show-bottom-sheet
                         {:content (fn []
-                                    [chat-actions/actions community-id id])}])
+                                    [chat-actions/actions chat false])}])
       :community-id  community-id})))
 
 (defn add-handlers-to-chats

--- a/src/status_im2/contexts/communities/overview/view.cljs
+++ b/src/status_im2/contexts/communities/overview/view.cljs
@@ -49,19 +49,19 @@
   (oops/oget event "nativeEvent.layout.y"))
 
 (defn- channel-chat-item
-  [community-id community-color {chat-id :id muted? :muted? :as chat}]
+  [community-id community-color {:keys [:muted? id] :as chat}]
   (let [sheet-content      [actions/chat-actions
-                            (assoc chat :chat-type constants/community-chat-type :chat-id (str community-id chat-id))
+                            (assoc chat :chat-type constants/community-chat-type :chat-id (str community-id id))
                             false]
         channel-sheet-data {:selected-item (fn [] [quo/channel-list-item chat])
                             :content       (fn [] sheet-content)}]
-    [rn/view {:key chat-id :style {:margin-top 4}}
+    [rn/view {:key id :style {:margin-top 4}}
      [quo/channel-list-item
       (assoc chat
              :default-color community-color
              :on-long-press #(rf/dispatch [:show-bottom-sheet channel-sheet-data])
              :muted?        (or muted?
-                                (rf/sub [:chat/check-channel-muted? community-id chat-id])))]]))
+                                (rf/sub [:chat/check-channel-muted? community-id id])))]]))
 
 (defn channel-list-component
   [{:keys [on-category-layout community-id community-color on-first-channel-height-changed]}

--- a/src/status_im2/contexts/communities/overview/view.cljs
+++ b/src/status_im2/contexts/communities/overview/view.cljs
@@ -51,7 +51,9 @@
 (defn- channel-chat-item
   [community-id community-color {:keys [:muted? id] :as chat}]
   (let [sheet-content      [actions/chat-actions
-                            (assoc chat :chat-type constants/community-chat-type :chat-id (str community-id id))
+                            (assoc chat
+                                   :chat-type constants/community-chat-type
+                                   :chat-id   (str community-id id))
                             false]
         channel-sheet-data {:selected-item (fn [] [quo/channel-list-item chat])
                             :content       (fn [] sheet-content)}]


### PR DESCRIPTION
fixes #16543 

### Summary
Fixes an inconsistency in how props are configured in the chat actions bottom sheet.
 
status: ready
