### PR TITLE
[#16446] Communities banner animation

### DIFF
--- a/src/quo2/components/community/banner/style.cljs
+++ b/src/quo2/components/community/banner/style.cljs
@@ -2,7 +2,7 @@
   (:require [quo2.foundations.colors :as colors]))
 
 (defn community-card
-  []
+  [theme]
   {:shadow-offset     {:width 0 :height 2}
    :shadow-radius     16
    :shadow-opacity    1
@@ -10,7 +10,7 @@
    :elevation         1
    :border-radius     16
    :justify-content   :space-between
-   :background-color  (colors/theme-colors colors/white colors/neutral-90)
+   :background-color  (colors/theme-colors colors/white colors/neutral-90 theme)
    :flex-direction    :row
    :margin-horizontal 20
    :margin-top        8

--- a/src/quo2/components/community/banner/style.cljs
+++ b/src/quo2/components/community/banner/style.cljs
@@ -2,18 +2,21 @@
   (:require [quo2.foundations.colors :as colors]))
 
 (defn community-card
-  [radius]
-  {:shadow-offset    {:width  0
-                      :height 2}
-   :shadow-radius    radius
-   :shadow-opacity   1
-   :shadow-color     colors/shadow
-   :elevation        1
-   :border-radius    radius
-   :justify-content  :space-between
-   :background-color (colors/theme-colors
-                      colors/white
-                      colors/neutral-90)})
+  []
+  {:shadow-offset     {:width 0 :height 2}
+   :shadow-radius     16
+   :shadow-opacity    1
+   :shadow-color      colors/shadow
+   :elevation         1
+   :border-radius     16
+   :justify-content   :space-between
+   :background-color  (colors/theme-colors colors/white colors/neutral-90)
+   :flex-direction    :row
+   :margin-horizontal 20
+   :margin-top        8
+   :margin-bottom     8
+   :height            56
+   :padding-right     12})
 
 (def banner-content
   {:flex           1
@@ -24,13 +27,6 @@
 (def banner-title
   {:flex               1
    :padding-horizontal 12})
-
-(def banner-card
-  {:flex-direction    :row
-   :margin-horizontal 20
-   :margin-vertical   8
-   :height            56
-   :padding-right     12})
 
 (def discover-illustration
   {:position :absolute

--- a/src/quo2/components/community/banner/view.cljs
+++ b/src/quo2/components/community/banner/view.cljs
@@ -29,16 +29,11 @@
      description]]])
 
 (defn view
-  [{:keys [title description on-press accessibility-label banner]}]
+  [{:keys [title description on-press accessibility-label banner style]}]
   [rn/touchable-without-feedback
    {:on-press            on-press
     :accessibility-label accessibility-label}
-   [rn/view
-    (merge (style/community-card 16)
-           {:background-color (colors/theme-colors
-                               colors/white
-                               colors/neutral-90)}
-           style/banner-card)
+   [rn/view {:style (merge (style/community-card) style)}
     [card-title-and-description title description]
     [rn/image
      {:style               style/discover-illustration

--- a/src/quo2/components/community/banner/view.cljs
+++ b/src/quo2/components/community/banner/view.cljs
@@ -2,14 +2,13 @@
   (:require [quo2.components.community.banner.style :as style]
             [quo2.components.markdown.text :as text]
             [quo2.foundations.colors :as colors]
+            [quo2.theme :as theme]
             [react-native.core :as rn]))
 
 (defn- card-title-and-description
-  [title description]
-  [rn/view
-   {:style style/banner-content}
-   [rn/view
-    {:style style/banner-title}
+  [title description theme]
+  [rn/view {:style style/banner-content}
+   [rn/view {:style style/banner-title}
     [text/text
      {:accessibility-label :community-name-text
       :ellipsize-mode      :tail
@@ -21,21 +20,21 @@
      {:accessibility-label :community-name-text
       :ellipsize-mode      :tail
       :number-of-lines     1
-      :color               (colors/theme-colors
-                            colors/neutral-50
-                            colors/neutral-40)
+      :color               (colors/theme-colors colors/neutral-50 colors/neutral-40 theme)
       :weight              :regular
       :size                :paragraph-2}
      description]]])
 
-(defn view
-  [{:keys [title description on-press accessibility-label banner style]}]
+(defn view-internal
+  [{:keys [title description on-press accessibility-label banner style theme]}]
   [rn/touchable-without-feedback
    {:on-press            on-press
     :accessibility-label accessibility-label}
-   [rn/view {:style (merge (style/community-card) style)}
-    [card-title-and-description title description]
+   [rn/view {:style (merge (style/community-card theme) style)}
+    [card-title-and-description title description theme]
     [rn/image
      {:style               style/discover-illustration
       :source              banner
       :accessibility-label :discover-communities-illustration}]]])
+
+(def view (theme/with-theme view-internal))

--- a/src/quo2/components/tabs/tabs.cljs
+++ b/src/quo2/components/tabs/tabs.cljs
@@ -6,7 +6,7 @@
             [react-native.masked-view :as masked-view]
             [reagent.core :as reagent]
             [utils.collection :as utils.collection]
-            [utils.number :as utils.number]
+            [utils.number]
             [react-native.gesture :as gesture]))
 
 (def default-tab-size 32)

--- a/src/status_im2/contexts/chat/composer/effects.cljs
+++ b/src/status_im2/contexts/chat/composer/effects.cljs
@@ -9,7 +9,7 @@
     [status-im2.contexts.chat.composer.constants :as constants]
     [status-im2.contexts.chat.composer.keyboard :as kb]
     [status-im2.contexts.chat.composer.utils :as utils]
-    [utils.number :as utils.number]
+    [utils.number]
     [utils.re-frame :as rf]))
 
 (defn reenter-screen-effect

--- a/src/status_im2/contexts/chat/composer/gesture.cljs
+++ b/src/status_im2/contexts/chat/composer/gesture.cljs
@@ -1,10 +1,11 @@
 (ns status-im2.contexts.chat.composer.gesture
   (:require
+    [oops.core :as oops]
     [react-native.gesture :as gesture]
     [react-native.reanimated :as reanimated]
-    [oops.core :as oops]
     [status-im2.contexts.chat.composer.constants :as constants]
     [status-im2.contexts.chat.composer.utils :as utils]
+    [utils.number]
     [utils.re-frame :as rf]))
 
 (defn set-opacity
@@ -83,7 +84,7 @@
            (let [translation    (oops/oget event "translationY")
                  min-height     (utils/get-min-height lines images link-previews?)
                  new-height     (- (reanimated/get-shared-value saved-height) translation)
-                 bounded-height (utils/bounded-val new-height min-height max-height)]
+                 bounded-height (utils.number/value-in-range new-height min-height max-height)]
              (when keyboard-shown
                (if (>= new-height min-height)
                  (do ; expand sheet

--- a/src/status_im2/contexts/chat/composer/handlers.cljs
+++ b/src/status_im2/contexts/chat/composer/handlers.cljs
@@ -10,6 +10,7 @@
     [status-im2.contexts.chat.composer.selection :as selection]
     [status-im2.contexts.chat.composer.utils :as utils]
     [utils.debounce :as debounce]
+    [utils.number]
     [utils.re-frame :as rf]))
 
 (defn focus
@@ -82,7 +83,9 @@
           content-size          (if (or (= lines 1) (empty? @text-value))
                                   constants/input-height
                                   (if (= lines 2) constants/multiline-minimized-height content-size))
-          new-height            (utils/bounded-val content-size constants/input-height max-height)
+          new-height            (utils.number/value-in-range content-size
+                                                             constants/input-height
+                                                             max-height)
           bottom-content-height (utils/calc-bottom-content-height images link-previews?)
           new-height            (min (+ new-height bottom-content-height) max-height)]
       (reset! content-height content-size)

--- a/src/status_im2/contexts/chat/composer/utils.cljs
+++ b/src/status_im2/contexts/chat/composer/utils.cljs
@@ -8,6 +8,7 @@
     [reagent.core :as reagent]
     [status-im2.contexts.chat.composer.constants :as constants]
     [status-im2.contexts.chat.composer.selection :as selection]
+    [utils.number]
     [utils.re-frame :as rf]))
 
 (defn bounded-val
@@ -142,7 +143,7 @@
         base             (+ base (- curr-height constants/input-height))
         base             (+ base (calc-top-content-height reply edit))
         view-height      (- window-height keyboard-height (:top insets))
-        container-height (bounded-val
+        container-height (utils.number/value-in-range
                           (* (/ constants/mentions-max-height 4) size)
                           (/ constants/mentions-max-height 4)
                           constants/mentions-max-height)]
@@ -228,7 +229,7 @@
      :saved-height      (reanimated/use-shared-value
                          initial-height)
      :last-height       (reanimated/use-shared-value
-                         (bounded-val
+                         (utils.number/value-in-range
                           (+ @content-height bottom-content-height)
                           constants/input-height
                           max-height))

--- a/src/status_im2/contexts/communities/home/style.cljs
+++ b/src/status_im2/contexts/communities/home/style.cljs
@@ -1,8 +1,7 @@
 (ns status-im2.contexts.communities.home.style
   (:require [quo2.foundations.colors :as colors]
             [react-native.platform :as platform]
-            [react-native.reanimated :as reanimated]
-            [utils.number :as number]))
+            [react-native.reanimated :as reanimated]))
 
 (def header-height 245)
 
@@ -44,21 +43,7 @@
    :left        0
    :padding-top top})
 
-;;;; CARD ANIMATION
 (def card-bottom-override {:margin-bottom 16}) ; Original 8 + 8 from tabs top padding
-(def card-height (+ 56 16)) ; Card height + its vertical margins
-(def card-total-height (+ card-height 8)) ; added 8 from tabs top padding
-(def card-opacity-factor (/ 100 card-height 100))
-
-(defn set-animated-card-values
-  [{:keys [scroll-offset height translation-y opacity]}]
-  (let [new-height        (- card-total-height scroll-offset)
-        new-opacity       (* (- card-height scroll-offset) card-opacity-factor)
-        new-translation-y (- scroll-offset)]
-    (reanimated/set-shared-value height (number/value-in-range new-height 0 card-total-height))
-    (reanimated/set-shared-value opacity (number/value-in-range new-opacity 0 1))
-    (reanimated/set-shared-value translation-y
-                                 (number/value-in-range new-translation-y (- card-total-height) 0))))
 
 (defn animated-card-container
   [height opacity]

--- a/src/status_im2/contexts/communities/home/style.cljs
+++ b/src/status_im2/contexts/communities/home/style.cljs
@@ -1,12 +1,13 @@
 (ns status-im2.contexts.communities.home.style
   (:require [quo2.foundations.colors :as colors]
-            [react-native.platform :as platform]))
+            [react-native.platform :as platform]
+            [react-native.reanimated :as reanimated]))
 
 (def header-height 245)
 
 (def tabs
   {:padding-horizontal 20
-   :padding-top        16
+   :padding-top        8
    :padding-bottom     12})
 
 (def blur
@@ -42,3 +43,34 @@
    :left        0
    :padding-top top})
 
+;;;; CARD ANIMATION
+(def card-bottom-override {:margin-bottom 16}) ; Original 8 + 8 from tabs top padding
+(def card-height (+ 56 16)) ; Card height + its vertical margins
+(def card-total-height (+ card-height 8)) ; added 8 from tabs top padding
+(def card-opacity-factor (/ 100 card-height 100))
+
+(defn- value-in-range
+  "Returns `num` if is in the range [`lower-bound` `upper-bound`]
+  if `num` exceeds a given bound, then returns the bound exceeded."
+  [num [lower-bound upper-bound]]
+  (max lower-bound (min num upper-bound)))
+
+(defn set-animated-card-values
+  [{:keys [scroll-offset height translation-y opacity]}]
+  (let [new-height        (- card-total-height scroll-offset)
+        new-opacity       (* (- card-height scroll-offset) card-opacity-factor)
+        new-translation-y (- scroll-offset)]
+    (reanimated/set-shared-value height (value-in-range new-height [0 card-total-height]))
+    (reanimated/set-shared-value opacity (value-in-range new-opacity [0 1]))
+    (reanimated/set-shared-value translation-y
+                                 (value-in-range new-translation-y [(- card-total-height) 0]))))
+
+(defn animated-card-container
+  [height opacity]
+  (reanimated/apply-animations-to-style {:height height :opacity opacity}
+                                        {:overflow :hidden}))
+
+(defn animated-card-translation
+  [translate-y]
+  (reanimated/apply-animations-to-style {:transform [{:translate-y translate-y}]}
+                                        {}))

--- a/src/status_im2/contexts/communities/home/style.cljs
+++ b/src/status_im2/contexts/communities/home/style.cljs
@@ -1,6 +1,7 @@
 (ns status-im2.contexts.communities.home.style
   (:require [quo2.foundations.colors :as colors]
             [react-native.platform :as platform]
+            [react-native.safe-area :as safe-area]
             [react-native.reanimated :as reanimated]))
 
 (def header-height 245)
@@ -18,8 +19,8 @@
    :bottom   0})
 
 (defn empty-state-container
-  [top]
-  {:margin-top      (+ header-height top)
+  []
+  {:margin-top      (+ header-height (safe-area/get-top))
    :margin-bottom   44
    :flex            1
    :justify-content :center})
@@ -30,27 +31,46 @@
    :background-color colors/danger-50})
 
 (defn header-spacing
-  [top]
-  {:height (+ header-height top)})
+  []
+  {:height (+ header-height (safe-area/get-top))})
 
-(defn blur-container
-  [top]
-  {:overflow    (if platform/ios? :visible :hidden)
+(defn blur-banner-layer
+  [animated-translation-y]
+  (let [fixed-height (+ (safe-area/get-top) 244)]
+    (reanimated/apply-animations-to-style
+     {:transform [{:translate-y animated-translation-y}]}
+     {:overflow (if platform/ios? :visible :hidden)
+      :z-index  1
+      :position :absolute
+      :top      0
+      :right    0
+      :left     0
+      :height   fixed-height})))
+
+(defn hiding-banner-layer
+  []
+  {:z-index     2
    :position    :absolute
-   :z-index     1
    :top         0
    :right       0
    :left        0
-   :padding-top top})
+   :padding-top (safe-area/get-top)})
 
-(def card-bottom-override {:margin-bottom 16}) ; Original 8 + 8 from tabs top padding
+(defn tabs-banner-layer
+  [animated-translation-y]
+  (let [top-offset (+ (safe-area/get-top) 192)]
+    (reanimated/apply-animations-to-style
+     {:transform [{:translate-y animated-translation-y}]}
+     {:z-index  3
+      :position :absolute
+      :top      top-offset
+      :right    0
+      :left     0})))
 
-(defn animated-card-container
-  [height opacity]
-  (reanimated/apply-animations-to-style {:height height :opacity opacity}
-                                        {:overflow :hidden}))
+(def animated-card-container {:overflow :hidden})
 
-(defn animated-card-translation
-  [translate-y]
-  (reanimated/apply-animations-to-style {:transform [{:translate-y translate-y}]}
+(defn animated-card
+  [opacity translate-y]
+  (reanimated/apply-animations-to-style {:opacity   opacity
+                                         :transform [{:translate-y translate-y}]}
                                         {}))

--- a/src/status_im2/contexts/communities/home/style.cljs
+++ b/src/status_im2/contexts/communities/home/style.cljs
@@ -1,7 +1,8 @@
 (ns status-im2.contexts.communities.home.style
   (:require [quo2.foundations.colors :as colors]
             [react-native.platform :as platform]
-            [react-native.reanimated :as reanimated]))
+            [react-native.reanimated :as reanimated]
+            [utils.number :as number]))
 
 (def header-height 245)
 
@@ -49,21 +50,15 @@
 (def card-total-height (+ card-height 8)) ; added 8 from tabs top padding
 (def card-opacity-factor (/ 100 card-height 100))
 
-(defn- value-in-range
-  "Returns `num` if is in the range [`lower-bound` `upper-bound`]
-  if `num` exceeds a given bound, then returns the bound exceeded."
-  [num [lower-bound upper-bound]]
-  (max lower-bound (min num upper-bound)))
-
 (defn set-animated-card-values
   [{:keys [scroll-offset height translation-y opacity]}]
   (let [new-height        (- card-total-height scroll-offset)
         new-opacity       (* (- card-height scroll-offset) card-opacity-factor)
         new-translation-y (- scroll-offset)]
-    (reanimated/set-shared-value height (value-in-range new-height [0 card-total-height]))
-    (reanimated/set-shared-value opacity (value-in-range new-opacity [0 1]))
+    (reanimated/set-shared-value height (number/value-in-range new-height 0 card-total-height))
+    (reanimated/set-shared-value opacity (number/value-in-range new-opacity 0 1))
     (reanimated/set-shared-value translation-y
-                                 (value-in-range new-translation-y [(- card-total-height) 0]))))
+                                 (number/value-in-range new-translation-y (- card-total-height) 0))))
 
 (defn animated-card-container
   [height opacity]

--- a/src/status_im2/contexts/communities/home/view.cljs
+++ b/src/status_im2/contexts/communities/home/view.cljs
@@ -99,6 +99,7 @@
   (let [selected-tab                    (or (rf/sub [:communities/selected-tab]) :joined)
         {:keys [joined pending opened]} (rf/sub [:communities/grouped-by-status])
         customization-color             (rf/sub [:profile/customization-color])
+        open-sheet?                     (-> (rf/sub [:bottom-sheet]) :sheets seq)
         selected-items                  (case selected-tab
                                           :joined  joined
                                           :pending pending
@@ -126,14 +127,13 @@
                                                :opacity       animated-card-opacity})}])
 
      [rn/view {:style (style/blur-container top)}
-      (let [{:keys [sheets]} (rf/sub [:bottom-sheet])]
-        [blur/view
-         {:blur-amount   (if platform/ios? 20 10)
-          :blur-type     (theme/theme-value (if platform/ios? :light :xlight) :dark)
-          :style         style/blur
-          :overlay-color (if (seq sheets)
-                           (colors/theme-colors colors/white colors/neutral-95-opa-70)
-                           (theme/theme-value nil colors/neutral-95-opa-70))}])
+      [blur/view
+       {:blur-amount   (if platform/ios? 20 10)
+        :blur-type     (theme/theme-value (if platform/ios? :light :xlight) :dark)
+        :style         style/blur
+        :overlay-color (if open-sheet?
+                         (colors/theme-colors colors/white colors/neutral-95-opa-70)
+                         (theme/theme-value nil colors/neutral-95-opa-70))}]
       [common.home/top-nav {:type :grey}]
       [common.home/title-column
        {:label               (i18n/label :t/communities)

--- a/src/status_im2/contexts/communities/home/view.cljs
+++ b/src/status_im2/contexts/communities/home/view.cljs
@@ -105,12 +105,15 @@
          :banner              (resources/get-image :discover)
          :accessibility-label :communities-home-discover-card}]]]]))
 
-(defn- reset-banner-animation [animated-opacity animated-translation-y]
+(defn- reset-banner-animation
+  [animated-opacity animated-translation-y]
   (reanimated/animate-shared-value-with-timing animated-opacity 1 200 :easing3)
   (reanimated/animate-shared-value-with-timing animated-translation-y 0 200 :easing3))
 
-(defn- reset-scroll [flat-list-ref]
-  (some-> flat-list-ref (.scrollToOffset #js {:offset 0 :animated? true})))
+(defn- reset-scroll
+  [flat-list-ref]
+  (some-> flat-list-ref
+          (.scrollToOffset #js {:offset 0 :animated? true})))
 
 (defn- tabs-banner-layer
   [animated-translation-y animated-opacity selected-tab flat-list-ref]
@@ -158,9 +161,6 @@
                                               :joined  joined
                                               :pending pending
                                               :opened  opened)
-            selected-items                  (if (= selected-tab :opened)
-                                              (repeat 20 (last selected-items))
-                                              selected-items)
             animated-opacity                (reanimated/use-shared-value 1)
             animated-translation-y          (reanimated/use-shared-value 0)]
         [:<>

--- a/src/status_im2/contexts/communities/home/view.cljs
+++ b/src/status_im2/contexts/communities/home/view.cljs
@@ -3,7 +3,6 @@
             [quo2.core :as quo]
             [quo2.foundations.colors :as colors]
             [quo2.theme :as theme]
-            [utils.debounce :as debounce]
             [react-native.blur :as blur]
             [react-native.core :as rn]
             [react-native.platform :as platform]
@@ -14,6 +13,7 @@
             [status-im2.contexts.communities.actions.community-options.view :as options]
             [status-im2.contexts.communities.actions.home-plus.view :as actions.home-plus]
             [status-im2.contexts.communities.home.style :as style]
+            [utils.debounce :as debounce]
             [utils.i18n :as i18n]
             [utils.re-frame :as rf]))
 

--- a/src/status_im2/contexts/communities/home/view.cljs
+++ b/src/status_im2/contexts/communities/home/view.cljs
@@ -148,8 +148,8 @@
                               (utils.number/value-in-range 0 1))
         new-translation-y (-> (- scroll-offset)
                               (utils.number/value-in-range max-scroll 0))]
-    (reanimated/set-shared-value opacity new-opacity)
-    (reanimated/set-shared-value translation-y new-translation-y)))
+    (reanimated/animate-shared-value-with-timing opacity new-opacity 80 :easing4)
+    (reanimated/animate-shared-value-with-timing translation-y new-translation-y 80 :easing4)))
 
 (defn home
   []

--- a/src/status_im2/contexts/communities/home/view.cljs
+++ b/src/status_im2/contexts/communities/home/view.cljs
@@ -105,18 +105,19 @@
          :banner              (resources/get-image :discover)
          :accessibility-label :communities-home-discover-card}]]]]))
 
+(defn- reset-banner-animation [animated-opacity animated-translation-y]
+  (reanimated/animate-shared-value-with-timing animated-opacity 1 200 :easing3)
+  (reanimated/animate-shared-value-with-timing animated-translation-y 0 200 :easing3))
+
+(defn- reset-scroll [flat-list-ref]
+  (some-> flat-list-ref (.scrollToOffset #js {:offset 0 :animated? true})))
+
 (defn- tabs-banner-layer
   [animated-translation-y animated-opacity selected-tab flat-list-ref]
   (let [on-tab-change (fn [tab]
                         (if (empty? (get (rf/sub [:communities/grouped-by-status]) tab))
-                          (do
-                            (reanimated/animate-shared-value-with-timing animated-opacity 1 200 :easing3)
-                            (reanimated/animate-shared-value-with-timing animated-translation-y
-                                                                         0
-                                                                         200
-                                                                         :easing3))
-                          (some-> @flat-list-ref
-                                  (.scrollToOffset #js {:offset 0 :animated? true})))
+                          (reset-banner-animation animated-opacity animated-translation-y)
+                          (reset-scroll @flat-list-ref))
                         (rf/dispatch [:communities/select-tab tab]))]
     [reanimated/view {:style (style/tabs-banner-layer animated-translation-y)}
      ^{:key (str "tabs-" selected-tab)}
@@ -157,6 +158,9 @@
                                               :joined  joined
                                               :pending pending
                                               :opened  opened)
+            selected-items                  (if (= selected-tab :opened)
+                                              (repeat 20 (last selected-items))
+                                              selected-items)
             animated-opacity                (reanimated/use-shared-value 1)
             animated-translation-y          (reanimated/use-shared-value 0)]
         [:<>

--- a/src/status_im2/contexts/shell/jump_to/components/home_stack/view.cljs
+++ b/src/status_im2/contexts/shell/jump_to/components/home_stack/view.cljs
@@ -27,7 +27,7 @@
              :z-index (get shared-values
                            (get shell.constants/stacks-z-index-keywords stack-id))})}
    (case stack-id
-     :communities-stack [communities/home]
+     :communities-stack [:f> communities/home]
      :chats-stack       [chat/home]
      :wallet-stack      [wallet.accounts/accounts-overview-old]
      :browser-stack     [browser.stack/browser-stack]

--- a/src/utils/number.cljs
+++ b/src/utils/number.cljs
@@ -23,3 +23,9 @@
      (if (integer? maybe-int)
        maybe-int
        default))))
+
+(defn value-in-range
+  "Returns `num` if is in the range [`lower-bound` `upper-bound`]
+  if `num` exceeds a given bound, then returns the bound exceeded."
+  [number lower-bound upper-bound]
+  (max lower-bound (min number upper-bound)))


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)


fixes #16446

### Summary

This PR adds the animation for the top card banner for the communities page:

[Comunity banner animation.webm](https://github.com/status-im/status-mobile/assets/90291778/47c9e74a-910d-4e17-b14b-be1e975149af)


### Review notes

The screen has the following structure:
```
[Communities-text]
[Discovery-card]
[Tabs]
[list of communities]
```
I had a problem, in figma, when the discovery card is hidden, it also affects the margin top of the `[Tabs]` component.
From 16:
![image](https://github.com/status-im/status-mobile/assets/90291778/4a7b88bc-78ce-4add-9568-dc485ec2267d)
to 8: 
![image](https://github.com/status-im/status-mobile/assets/90291778/1f6dca38-cd90-4a43-8d4e-494606bb7799)

So the solution is not as clean as I would have liked: to avoid the animation on two components and more complex code, I just added the 8 units from the top tabs margin to the margin bottom of the discovery card. 

More details in the code, don't worry, the styles are looking as in figma :+1: 
If you want to check the designs:
https://www.figma.com/file/h9wo4GipgZURbqqr1vShFN/Communities-for-Mobile?type=design&node-id=4996-221671&mode=design&t=NkOqJ1RAu0gpxHJ8-4

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that are impacted

- Communities tab

### Steps to test

- Open Status
- Navigate to communities tab
- Create enough communities that doesn't fit on the list, so the scroll will be enabled
- Scroll and the discovery banner will be animated and hidden.

Link to the animation:
https://vimeo.com/794327616

status: ready
