### PR TITLE
[#16481] Fix unread badge group chats

### DIFF
--- a/src/quo2/components/notifications/info_count.cljs
+++ b/src/quo2/components/notifications/info_count.cljs
@@ -22,7 +22,7 @@
      :or   {customization-color :blue}
      :as   props}
     amount]
-   (when (pos? 0)
+   (when (pos? amount)
      [rn/view (assoc props :style (counter-style customization-color style))
       [rn/text
        {:style (merge typography/font-medium

--- a/src/quo2/components/notifications/info_count.cljs
+++ b/src/quo2/components/notifications/info_count.cljs
@@ -23,7 +23,7 @@
      :as   props}
     amount]
    (when (> amount 0)
-     [rn/view (merge props {:style (counter-style customization-color style)})
+     [rn/view (assoc props :style (counter-style customization-color style))
       [rn/text
        {:style (merge typography/font-medium
                       typography/label

--- a/src/quo2/components/notifications/info_count.cljs
+++ b/src/quo2/components/notifications/info_count.cljs
@@ -22,7 +22,7 @@
      :or   {customization-color :blue}
      :as   props}
     amount]
-   (when (> amount 0)
+   (when (pos? 0)
      [rn/view (assoc props :style (counter-style customization-color style))
       [rn/text
        {:style (merge typography/font-medium

--- a/src/quo2/components/notifications/info_count.cljs
+++ b/src/quo2/components/notifications/info_count.cljs
@@ -3,22 +3,27 @@
             [quo2.foundations.typography :as typography]
             [react-native.core :as rn]))
 
+(defn- counter-style
+  [customization-color overwritten-styles]
+  (merge {:width            16
+          :height           16
+          :position         :absolute
+          :right            22
+          :border-radius    6
+          :justify-content  :center
+          :align-items      :center
+          :background-color (colors/custom-color-by-theme customization-color 50 60)}
+         overwritten-styles))
+
 (defn info-count
   ([amount]
    (info-count {} amount))
-  ([props amount]
+  ([{:keys [customization-color style]
+     :or   {customization-color :blue}
+     :as   props}
+    amount]
    (when (> amount 0)
-     [rn/view
-      (merge props
-             {:style (merge {:width            16
-                             :height           16
-                             :position         :absolute
-                             :right            22
-                             :border-radius    6
-                             :justify-content  :center
-                             :align-items      :center
-                             :background-color (colors/theme-colors colors/primary-50 colors/primary-60)}
-                            (:style props))})
+     [rn/view (merge props {:style (counter-style customization-color style)})
       [rn/text
        {:style (merge typography/font-medium
                       typography/label

--- a/src/status_im2/contexts/chat/home/chat_list_item/style.cljs
+++ b/src/status_im2/contexts/chat/home/chat_list_item/style.cljs
@@ -21,15 +21,31 @@
    :top              16
    :background-color (colors/theme-colors colors/neutral-40 colors/neutral-60)})
 
-(def muted-icon
-  {:position :absolute
-   :right    19
-   :top      16})
-
 (defn timestamp
   [muted?]
-  {:color       (or (when muted?
-                      colors/neutral-50)
-                    (colors/theme-colors colors/neutral-50 colors/neutral-40))
+  {:color       (if muted?
+                  colors/neutral-50
+                  (colors/theme-colors colors/neutral-50 colors/neutral-40))
    :margin-top  3
    :margin-left 8})
+
+(def chat-data-container
+  {:flex         1
+   :margin-left  8
+   :margin-right 16})
+
+(def notification-container
+  {:margin-left     :auto
+   :height          20
+   :width           20
+   :justify-content :center
+   :align-items     :center})
+
+;; TODO: duplicate of `quo2.components.common.unread-grey-dot.style`
+;; Replace it when this component is defined as part of `quo2.components`
+(defn grey-dot
+  []
+  {:width            8
+   :height           8
+   :border-radius    4
+   :background-color (colors/theme-colors colors/neutral-40 colors/neutral-60)})

--- a/src/status_im2/contexts/chat/home/chat_list_item/view.cljs
+++ b/src/status_im2/contexts/chat/home/chat_list_item/view.cljs
@@ -211,8 +211,8 @@
 (defn notification
   [{:keys [muted group-chat unviewed-messages-count unviewed-mentions-count]}]
   (let [customization-color (rf/sub [:profile/customization-color])
-        unread-messages?    (> unviewed-messages-count 0)
-        unread-mentions?    (> unviewed-mentions-count 0)]
+        unread-messages?    (pos? unviewed-messages-count)
+        unread-mentions?    (pos? unviewed-mentions-count)]
     [rn/view {:style style/notification-container}
      (cond
        muted


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)


fixes #16481

### Summary

This PR fix the badge showed for group chats, instead of showing a counter when a non-mention message arrives, now shows the gray dot as in [designs](https://www.figma.com/file/WQZcp6S0EnzxdTL4taoKDv/Design-System-for-Mobile?type=design&node-id=10732-130432&mode=design&t=Z6hZDu3Ilwu46l04-4).

now:
![image](https://github.com/status-im/status-mobile/assets/90291778/4372b1ac-31fd-4634-8897-52722b053b53)

before:
![image](https://github.com/status-im/status-mobile/assets/90291778/b35f5ca9-f09a-4da1-8786-26b3afd895a9)

Also this PR fixes:

- The badge component was not using customization color
- The badge component was not correctly aligned vertically and horizontally
- Since the badge component was misaligned, the text was not using the expected ellipsis, not it is using it.

An image showing the differences in the previous screens:
![image](https://github.com/status-im/status-mobile/assets/90291778/eb82b542-f415-433e-96cb-729930aa0653)


### Review notes

I added two `TODO`s in the code, I wanted to use the `grey-dot` component but it's not exposed as part of the quo2 library, so I noticed, actually, this component to show 1:1 chats should be part of our library, instead, it is being created in `status-im2.contexts`.

I created an issue to solve it:
#16611

To solve this issue, I copied the gray button styles and added a note to be deleted when the component is moved to  the quo2 library.

#### Platforms

- Android
- iOS

#### Areas that maybe impacted
##### Functional

- 1-1 chats
- group chats

### Steps to test

- Open Status
- Create a chat group.
 - Send a message (without mention) in the chat group. the notification badge in the group listing for other uses should be a gray dot.
- Mention a user within the chat group, look at the notification should be a badge with the number of unread mentions
- Send a normal message to a user, the notification should be a badge with the number of unread messages.

status: ready <!-- Can be ready or wip -->
