### PR TITLE
#16691 fix navigation to community from discover communities screen

### DIFF
--- a/src/status_im2/contexts/communities/discover/view.cljs
+++ b/src/status_im2/contexts/communities/discover/view.cljs
@@ -28,12 +28,12 @@
         cover {:uri (get-in (:images item) [:banner :uri])}]
     (if (= view-type :card-view)
       [quo/community-card-view-item (assoc item :width width :cover cover)
-       #(rf/dispatch [:navigate-to :community-overview (:id item)])]
+       #(rf/dispatch [:communities/navigate-to-community (:id item)])]
       [quo/community-list-item
        {:on-press      (fn []
                          (rf/dispatch [:communities/load-category-states (:id item)])
                          (rf/dispatch [:dismiss-keyboard])
-                         (rf/dispatch [:navigate-to :community-overview (:id item)]))
+                         (rf/dispatch [:communities/navigate-to-community (:id item)]))
         :on-long-press #(rf/dispatch
                          [:show-bottom-sheet
                           {:content (fn []
@@ -141,12 +141,12 @@
             (merge community
                    (get mock-community-item-data :data)
                    {:cover cover})
-            #(rf/dispatch [:navigate-to :community-overview (:id community)])]
+            #(rf/dispatch [:communities/navigate-to-community (:id community)])]
            [quo/community-list-item
             {:on-press      (fn []
                               (rf/dispatch [:communities/load-category-states (:id community)])
                               (rf/dispatch [:dismiss-keyboard])
-                              (rf/dispatch [:navigate-to :community-overview (:id community)]))
+                              (rf/dispatch [:communities/navigate-to-community (:id community)]))
              :on-long-press #(js/alert "TODO: to be implemented")}
             (merge community
                    (get mock-community-item-data :data))])]))


### PR DESCRIPTION
fixes: https://github.com/status-im/status-mobile/issues/16691

### Summary
Community is opening from the discover communities screen but it's hidden behind. The quickest solution is to close the discover communities screen while opening the community (handled by `:communities/navigate-to-community`). Later we can either embed a floating screen inside the discover communities screen or better make the discover community screen itself use shell navigation, so jump-to animation works nicely.
will be implemented in: https://github.com/status-im/status-mobile/issues/16701

status: ready