### PR TITLE
Fix UI freezing when image is opened from activity center

### DIFF
--- a/src/quo2/components/notifications/activity_log/style.cljs
+++ b/src/quo2/components/notifications/activity_log/style.cljs
@@ -25,11 +25,12 @@
 (def message-body
   {:color colors/white})
 
-(def message-container
+(defn message-container
+  [attachment]
   {:border-radius      12
    :margin-top         12
    :padding-horizontal 12
-   :padding-vertical   8
+   :padding-vertical   (if (#{:photo :gif} attachment) 12 8)
    :background-color   colors/white-opa-5})
 
 (def footer-container

--- a/src/quo2/components/notifications/activity_log/view.cljs
+++ b/src/quo2/components/notifications/activity_log/view.cljs
@@ -74,8 +74,8 @@
            context))))
 
 (defn- activity-message
-  [{:keys [title body title-number-of-lines body-number-of-lines]}]
-  [rn/view {:style style/message-container}
+  [{:keys [title body title-number-of-lines body-number-of-lines attachment]}]
+  [rn/view {:style (style/message-container attachment)}
    (when title
      [text/text
       {:size                :paragraph-2


### PR DESCRIPTION
fixes: https://github.com/status-im/status-mobile/issues/16706

### Summary
We are directly [using](https://github.com/status-im/status-mobile/blob/e99f6de4340411da0982e94a09ea8ac1da557f0c/src/status_im2/contexts/shell/activity_center/notification/reply/view.cljs#L13C1-L13C1) components created for messaging inside the activity center. And apart from the visible view, those components also have stuff like `on-press` and `on-long-press` events, etc.
Not sure if we want to process those events, But If yes we need to properly implement that, we can't navigate to the lightbox and open the image, without opening the chat screen.


status: ready