### PR TITLE
[#16278] fix tips in white border

### DIFF
--- a/src/status_im2/contexts/syncing/scan_sync_code/style.cljs
+++ b/src/status_im2/contexts/syncing/scan_sync_code/style.cljs
@@ -89,7 +89,7 @@
 (def white-border
   (let [base-tip {:background-color colors/white
                   :position         :absolute
-                  :height           1.9
+                  :height           1.9 ; 1.9 instead of 2 to fix the tips protruding
                   :width            1.9
                   :border-radius    1}]
     {:top-left

--- a/src/status_im2/contexts/syncing/scan_sync_code/style.cljs
+++ b/src/status_im2/contexts/syncing/scan_sync_code/style.cljs
@@ -77,29 +77,37 @@
    :top      (- (+ (:y viewfinder) (:height viewfinder)) flash-button-size flash-button-spacing)
    :right    (+ screen-padding flash-button-spacing)})
 
-(defn border
-  [border1 border2 corner]
-  (assoc {:border-color colors/white
-          :width        78
-          :height       78}
-         border1
-         2
-         border2
-         2
-         corner
-         16))
+(defn- get-border
+  [border-vertical border-horizontal corner-radius]
+  {:border-color     colors/white
+   :width            78
+   :height           78
+   border-vertical   2
+   border-horizontal 2
+   corner-radius     16})
 
-(defn border-tip
-  [top bottom right left]
-  {:background-color colors/white
-   :position         :absolute
-   :top              top
-   :bottom           bottom
-   :right            right
-   :left             left
-   :height           2
-   :width            2
-   :border-radius    2})
+(def white-border
+  (let [base-tip {:background-color colors/white
+                  :position         :absolute
+                  :height           1.9
+                  :width            1.9
+                  :border-radius    1}]
+    {:top-left
+     {:border (get-border :border-top-width :border-left-width :border-top-left-radius)
+      :tip-1  (assoc base-tip :right -1 :top 0)
+      :tip-2  (assoc base-tip :left 0 :bottom -1)}
+     :top-right
+     {:border (get-border :border-top-width :border-right-width :border-top-right-radius)
+      :tip-1  (assoc base-tip :right 0 :bottom -1)
+      :tip-2  (assoc base-tip :left -1 :top 0)}
+     :bottom-left
+     {:border (get-border :border-bottom-width :border-left-width :border-bottom-left-radius)
+      :tip-1  (assoc base-tip :right -1 :bottom 0)
+      :tip-2  (assoc base-tip :left 0 :top -1)}
+     :bottom-right
+     {:border (get-border :border-bottom-width :border-right-width :border-bottom-right-radius)
+      :tip-1  (assoc base-tip :right 0 :top -1)
+      :tip-2  (assoc base-tip :left -1 :bottom 0)}}))
 
 (def viewfinder-text
   {:color       colors/white-opa-70

--- a/src/status_im2/contexts/syncing/scan_sync_code/style.cljs
+++ b/src/status_im2/contexts/syncing/scan_sync_code/style.cljs
@@ -78,13 +78,13 @@
    :right    (+ screen-padding flash-button-spacing)})
 
 (defn- get-border
-  [border-vertical border-horizontal corner-radius]
-  {:border-color     colors/white
-   :width            78
-   :height           78
-   border-vertical   2
-   border-horizontal 2
-   corner-radius     16})
+  [border-vertical-width border-horizontal-width corner-radius]
+  {:border-color           colors/white
+   :width                  78
+   :height                 78
+   border-vertical-width   2
+   border-horizontal-width 2
+   corner-radius           16})
 
 (def white-border
   (let [base-tip {:background-color colors/white

--- a/src/status_im2/contexts/syncing/scan_sync_code/view.cljs
+++ b/src/status_im2/contexts/syncing/scan_sync_code/view.cljs
@@ -36,7 +36,7 @@
   []
   (rf/dispatch [:syncing/preflight-outbound-check #(reset! preflight-check-passed? %)]))
 
-(defn- f-header
+(defn- header
   [{:keys [active-tab read-qr-once? title title-opacity subtitle-opacity reset-animations-fn animated?]}]
   (let [subtitle-translate-x (reanimated/interpolate subtitle-opacity [0 1] [-13 0])
         subtitle-translate-y (reanimated/interpolate subtitle-opacity [0 1] [-85 0])
@@ -109,10 +109,6 @@
         :on-change      (fn [id]
                           (reset! active-tab id)
                           (reset! read-qr-once? false))}]]]))
-
-(defn- header
-  [props]
-  [:f> f-header props])
 
 (defn get-labels-and-on-press-method
   []
@@ -388,7 +384,7 @@
          (when (or (not animated?) @render-camera?)
            [render-camera show-camera? torch-mode @qr-view-finder camera-ref on-read-code])
          [rn/view {:style (style/root-container (:top insets))}
-          [header
+          [:f> header
            {:active-tab          active-tab
             :read-qr-once?       read-qr-once?
             :title               title


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

Partial solution to #16278

### Summary

This PR fixes the tips in the white border
![image](https://github.com/status-im/status-mobile/assets/90291778/cb35f57b-a0f0-4f51-a173-53f6ea8bbd00)


### Review notes
Sometimes in React Native is hard to perfectly center an UI element due to the unit managed in different devices, the tip in these borders had that problem. I solved it by reducing the width from 1 to 0.9 and it worked in the devices I tested (emulators and physical devices).


#### Platforms

- Android
- iOS

### Steps to test

- Open Status in a fresh install and click on Sign in, or add a new existing Status profile
- Activate the camera
- The border tips are not outside the view

status: ready
