### PR TITLE
Unshadow more Clojure core vars

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -20,7 +20,7 @@
                                     ;; future, as we progressively fix shadowed
                                     ;; vars, we should be able to delete this
                                     ;; option and lint all vars.
-                                    :include [count iter key time val identity str]}
+                                    :include [count iter key time val identity str comparator]}
                 :invalid-arity     {:skip-args [status-im.utils.fx/defn utils.re-frame/defn]}
                 ;; TODO remove number when this is fixed
                 ;; https://github.com/borkdude/clj-kondo/issues/867

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -20,7 +20,7 @@
                                     ;; future, as we progressively fix shadowed
                                     ;; vars, we should be able to delete this
                                     ;; option and lint all vars.
-                                    :include [count iter key time val identity]}
+                                    :include [count iter key time val identity str]}
                 :invalid-arity     {:skip-args [status-im.utils.fx/defn utils.re-frame/defn]}
                 ;; TODO remove number when this is fixed
                 ;; https://github.com/borkdude/clj-kondo/issues/867

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -20,7 +20,7 @@
                                     ;; future, as we progressively fix shadowed
                                     ;; vars, we should be able to delete this
                                     ;; option and lint all vars.
-                                    :include [count iter key time]}
+                                    :include [count iter key time val]}
                 :invalid-arity     {:skip-args [status-im.utils.fx/defn utils.re-frame/defn]}
                 ;; TODO remove number when this is fixed
                 ;; https://github.com/borkdude/clj-kondo/issues/867

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -20,7 +20,7 @@
                                     ;; future, as we progressively fix shadowed
                                     ;; vars, we should be able to delete this
                                     ;; option and lint all vars.
-                                    :include [count iter key time val]}
+                                    :include [count iter key time val identity]}
                 :invalid-arity     {:skip-args [status-im.utils.fx/defn utils.re-frame/defn]}
                 ;; TODO remove number when this is fixed
                 ;; https://github.com/borkdude/clj-kondo/issues/867

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -20,7 +20,15 @@
                                     ;; future, as we progressively fix shadowed
                                     ;; vars, we should be able to delete this
                                     ;; option and lint all vars.
-                                    :include [count iter key time val identity str comparator]}
+                                    :include [comparator
+                                              count
+                                              identity
+                                              iter
+                                              key
+                                              str
+                                              symbol
+                                              time
+                                              val]}
                 :invalid-arity     {:skip-args [status-im.utils.fx/defn utils.re-frame/defn]}
                 ;; TODO remove number when this is fixed
                 ;; https://github.com/borkdude/clj-kondo/issues/867

--- a/src/native_module/core.cljs
+++ b/src/native_module/core.cljs
@@ -461,19 +461,19 @@
   (.numberToHex ^js (status) (str num)))
 
 (defn sha3
-  [str]
+  [s]
   (log/debug "[native-module] sha3")
-  (.sha3 ^js (status) str))
+  (.sha3 ^js (status) s))
 
 (defn utf8-to-hex
-  [str]
+  [s]
   (log/debug "[native-module] utf8-to-hex")
-  (.utf8ToHex ^js (status) str))
+  (.utf8ToHex ^js (status) s))
 
 (defn hex-to-utf8
-  [str]
+  [s]
   (log/debug "[native-module] hex-to-utf8")
-  (.hexToUtf8 ^js (status) str))
+  (.hexToUtf8 ^js (status) s))
 
 (defn check-address-checksum
   [address]

--- a/src/quo/animated.cljs
+++ b/src/quo/animated.cljs
@@ -82,8 +82,8 @@
           :restDisplacementThreshold 0.001}})
 
 (defn set-value
-  [anim val]
-  (ocall anim "setValue" val))
+  [anim v]
+  (ocall anim "setValue" v))
 
 (def Value (oget animated "Value"))
 
@@ -178,20 +178,20 @@
   (.withOffset ^js redash (clj->js config)))
 
 (defn with-spring-transition
-  [val config]
-  (.withSpringTransition ^js redash val (clj->js config)))
+  [v config]
+  (.withSpringTransition ^js redash v (clj->js config)))
 
 (defn with-timing-transition
-  [val config]
-  (.withTimingTransition ^js redash val (clj->js config)))
+  [v config]
+  (.withTimingTransition ^js redash v (clj->js config)))
 
 (defn use-spring-transition
-  [val config]
-  (.useSpringTransition ^js redash val (clj->js config)))
+  [v config]
+  (.useSpringTransition ^js redash v (clj->js config)))
 
 (defn use-timing-transition
-  [val config]
-  (.useTimingTransition ^js redash val (clj->js config)))
+  [v config]
+  (.useTimingTransition ^js redash v (clj->js config)))
 
 (defn re-timing
   [config]
@@ -232,11 +232,11 @@
      :onGestureEvent       (.-onGestureEvent ^js gesture)}))
 
 (defn snap-point
-  [value velocity snap-points]
-  (.snapPoint ^js redash value velocity (to-array snap-points)))
+  [v velocity snap-points]
+  (.snapPoint ^js redash v velocity (to-array snap-points)))
 
 (defn with-easing
-  [{val   :value
+  [{v     :value
     :keys [snap-points velocity offset state easing duration
            animation-over]
     :or   {duration       250
@@ -257,7 +257,7 @@
              (set position offset))
       (cond* (neq state (:end gh/states))
              [(set animation-over 0)
-              (set position (add offset val))])
+              (set position (add offset v))])
       (cond* (and* (eq state (:end gh/states))
                    (not* animation-over))
              [(set position

--- a/src/quo/react.cljs
+++ b/src/quo/react.cljs
@@ -12,9 +12,9 @@
 
 ;; Inspired from UIX, Rum and Rumext
 (defn set-ref-val!
-  [ref val]
-  (oset! ref "current" val)
-  val)
+  [ref v]
+  (oset! ref "current" v)
+  v)
 
 (defn set-native-props
   [^js ref ^js props]
@@ -54,8 +54,8 @@
                    #js [value set-value])))
 
 (defn use-ref
-  [val]
-  (let [ref (react/useRef val)]
+  [v]
+  (let [ref (react/useRef v)]
     (reify
      cljs.core/IHash
        (-hash [_] (goog/getUid ref))

--- a/src/quo2/components/community/token_gating.cljs
+++ b/src/quo2/components/community/token_gating.cljs
@@ -12,11 +12,11 @@
    {:style (style/token-row padding?)}
    (doall
     (map-indexed (fn [token-index token]
-                   (let [{:keys [img-src symbol amount sufficient? purchasable? loading?]} token]
+                   (let [{:keys [img-src amount sufficient? purchasable? loading?]} token]
                      ^{:key token-index}
                      [rn/view {:style style/token-tag-spacing}
                       [token-tag/token-tag
-                       {:symbol      symbol
+                       {:symbol      (:symbol token)
                         :value       amount
                         :size        24
                         :sufficient? sufficient?

--- a/src/quo2/components/messages/gap.cljs
+++ b/src/quo2/components/messages/gap.cljs
@@ -82,11 +82,12 @@
     :border-radius 50}])
 
 (defn timestamp
-  [str]
+  [s]
   [text/text
    {:size  :label
     :style {:text-transform :none
-            :color          (get-color :time)}} str])
+            :color          (get-color :time)}}
+   s])
 
 (defn info-button
   [on-press]

--- a/src/quo2/components/tags/token_tag.cljs
+++ b/src/quo2/components/tags/token_tag.cljs
@@ -105,10 +105,11 @@
     :loading? true/false
     }"
   [_ _]
-  (fn [{:keys [symbol value size img-src border-color purchasable? sufficient? loading?]
-        :or
-        {size :small}}]
-    (let [sufficient?  (when-not loading? sufficient?)
+  (fn [{:keys [value size img-src border-color purchasable? sufficient? loading?]
+        :or   {size :small}
+        :as   props}]
+    (let [sym          (:symbol props)
+          sufficient?  (when-not loading? sufficient?)
           border-color (if sufficient? colors/success-50 border-color)]
       [tag
        {:size size
@@ -119,4 +120,4 @@
           [loading-icon]
           (when (or purchasable? sufficient?)
             [icon size border-color sufficient?]))}
-       (str value " " symbol)])))
+       (str value " " sym)])))

--- a/src/react_native/reanimated.cljs
+++ b/src/react_native/reanimated.cljs
@@ -91,9 +91,9 @@
     (.-value anim)))
 
 (defn set-shared-value
-  [anim val]
-  (when (and anim (some? val))
-    (set! (.-value anim) val)))
+  [anim v]
+  (when (and anim (some? v))
+    (set! (.-value anim) v)))
 
 (defn interpolate
   ([shared-value input-range output-range]
@@ -112,47 +112,47 @@
 
 ;; Animators
 (defn animate-shared-value-with-timing
-  [anim val duration easing]
+  [anim v duration easing]
   (set-shared-value anim
-                    (with-timing val
+                    (with-timing v
                                  (js-obj "duration" duration
                                          "easing"   (get easings easing)))))
 
 (defn animate-shared-value-with-delay
-  [anim val duration easing delay]
+  [anim v duration easing delay]
   (set-shared-value anim
                     (with-delay delay
-                                (with-timing val
+                                (with-timing v
                                              (js-obj "duration" duration
                                                      "easing"   (get easings easing))))))
 
 (defn animate-delay
-  ([animation val delay]
-   (animate-delay animation val delay default-duration))
-  ([animation val delay duration]
+  ([animation v delay]
+   (animate-delay animation v delay default-duration))
+  ([animation v delay duration]
    (set-shared-value animation
                      (with-delay delay
-                                 (with-timing val
+                                 (with-timing v
                                               (clj->js {:duration duration
                                                         :easing   (default-easing)}))))))
 
 (defn animate-shared-value-with-repeat
-  [anim val duration easing number-of-repetitions reverse?]
+  [anim v duration easing number-of-repetitions reverse?]
   (set-shared-value anim
-                    (with-repeat (with-timing val
+                    (with-repeat (with-timing v
                                               (js-obj "duration" duration
                                                       "easing"   (get easings easing)))
                                  number-of-repetitions
                                  reverse?)))
 
 (defn animate-shared-value-with-delay-repeat
-  ([anim val duration easing delay number-of-repetitions]
-   (animate-shared-value-with-delay-repeat anim val duration easing delay number-of-repetitions false))
-  ([anim val duration easing delay number-of-repetitions reverse?]
+  ([anim v duration easing delay number-of-repetitions]
+   (animate-shared-value-with-delay-repeat anim v duration easing delay number-of-repetitions false))
+  ([anim v duration easing delay number-of-repetitions reverse?]
    (set-shared-value anim
                      (with-delay delay
                                  (with-repeat
-                                  (with-timing val
+                                  (with-timing v
                                                #js
                                                 {:duration duration
                                                  :easing   (get easings easing)})
@@ -160,9 +160,9 @@
                                   reverse?)))))
 
 (defn animate-shared-value-with-spring
-  [anim val {:keys [mass stiffness damping]}]
+  [anim v {:keys [mass stiffness damping]}]
   (set-shared-value anim
-                    (with-spring val
+                    (with-spring v
                                  (js-obj "mass"      mass
                                          "damping"   damping
                                          "stiffness" stiffness))))
@@ -183,7 +183,7 @@
                                             :easing   (default-easing)})))))
 
 (defn with-timing-duration
-  [val duration]
-  (with-timing val
+  [v duration]
+  (with-timing v
                (clj->js {:duration duration
                          :easing   (in-out (.-quad ^js Easing))})))

--- a/src/status_im/chat/models/mentions.cljs
+++ b/src/status_im/chat/models/mentions.cljs
@@ -40,10 +40,10 @@
 ; referenced function: contact-list-item
 (defn- rename-mentionable-users
   [mentionable-users]
-  (reduce (fn [acc [id val]]
+  (reduce (fn [acc [id v]]
             (assoc acc
                    id
-                   (set/rename-keys val
+                   (set/rename-keys v
                                     {:id            :public-key
                                      :primaryName   :primary-name
                                      :secondaryName :secondary-name
@@ -55,6 +55,7 @@
 
           {}
           mentionable-users))
+
 (defn- transfer-mention-result
   [result]
   (let [{:keys [input-segments mentionable-users state chat-id new-text]}

--- a/src/status_im/communities/core.cljs
+++ b/src/status_im/communities/core.cljs
@@ -83,7 +83,8 @@
       (update :chats <-chats-rpc)
       (update :categories <-categories-rpc)
       (assoc :token-images
-             (reduce (fn [acc {:keys [symbol image]}] (assoc acc symbol image))
+             (reduce (fn [acc {sym :symbol image :image}]
+                       (assoc acc sym image))
                      {}
                      (:communityTokensMetadata c)))))
 

--- a/src/status_im/ethereum/eip681.cljs
+++ b/src/status_im/ethereum/eip681.cljs
@@ -143,8 +143,8 @@
 
 (defn generate-erc20-uri
   "Generate a EIP 681 URI encapsulating ERC20 token transfer"
-  [address {:keys [symbol value] :as m} all-tokens]
-  (when-let [token (tokens/symbol->token all-tokens symbol)]
+  [address {sym :symbol value :value :as m} all-tokens]
+  (when-let [token (tokens/symbol->token all-tokens sym)]
     (generate-uri (:address token)
                   (merge (dissoc m :value :symbol)
                          {:function-name      "transfer"

--- a/src/status_im/ethereum/eip681_test.cljs
+++ b/src/status_im/ethereum/eip681_test.cljs
@@ -190,18 +190,23 @@
   (is (.equals (money/bignumber "111122223333441239") (eip681/parse-eth-value "111122223333441239"))))
 
 (deftest extract-request-details
-  (let [{:keys [value symbol address]} (eip681/extract-request-details
-                                        {:address "0x89205a3a3b2a69de6dbf7f01ed13b2108b2c43e7"
-                                         :value   "1ETH"}
-                                        {})]
+  (let [{value   :value
+         sym     :symbol
+         address :address}
+        (eip681/extract-request-details
+         {:address "0x89205a3a3b2a69de6dbf7f01ed13b2108b2c43e7"
+          :value   "1ETH"}
+         {})]
     (is (.equals (money/ether->wei (money/bignumber 1)) value))
-    (is (= :ETH symbol))
+    (is (= :ETH sym))
     (is (= "0x89205a3a3b2a69de6dbf7f01ed13b2108b2c43e7" address)))
   (is (= (eip681/extract-request-details
           {:address "0x744d70fdbe2ba4cf95131626614a1763df805b9e" :chain-id 1 :function-name "unknown"}
           {})
          {:address "0x744d70fdbe2ba4cf95131626614a1763df805b9e" :chain-id 1 :function-name "unknown"}))
-  (let [{:keys [value symbol address]}
+  (let [{value   :value
+         sym     :symbol
+         address :address}
         (eip681/extract-request-details
          {:address            "0x744d70fdbe2ba4cf95131626614a1763df805b9e"
           :chain-id           1
@@ -213,5 +218,5 @@
                                                         :symbol :SNT
                                                         :decimals 18}})]
     (is (.equals (money/bignumber 1000) value))
-    (is (= :SNT symbol))
+    (is (= :SNT sym))
     (is (= "0x89205a3a3b2a69de6dbf7f01ed13b2108b2c43e7" address))))

--- a/src/status_im/ethereum/tokens.cljs
+++ b/src/status_im/ethereum/tokens.cljs
@@ -5,10 +5,10 @@
 
 (def default-native-currency
   (memoize
-   (fn [symbol]
+   (fn [sym]
      {:name           "Native"
       :symbol         :ETH
-      :symbol-display symbol
+      :symbol-display sym
       :decimals       18
       :icon           {:source (js/require "../resources/images/tokens/default-token.png")}})))
 
@@ -41,13 +41,13 @@
   (set (map #(-> % val :symbol) all-native-currencies)))
 
 (defn native-currency
-  [{:keys [symbol] :as current-network}]
+  [{sym :symbol :as current-network}]
   (let [chain (ethereum/network->chain-keyword current-network)]
-    (get all-native-currencies chain (default-native-currency symbol))))
+    (get all-native-currencies chain (default-native-currency sym))))
 
 (defn ethereum?
-  [symbol]
-  (native-currency-symbols symbol))
+  [sym]
+  (native-currency-symbols sym))
 
 (def token-icons
   {:mainnet (resolve-icons :mainnet)
@@ -74,17 +74,17 @@
                        (string/lower-case (:name %2))))))
 
 (defn symbol->token
-  [all-tokens symbol]
-  (some #(when (= symbol (:symbol %)) %) (vals all-tokens)))
+  [all-tokens sym]
+  (some #(when (= sym (:symbol %)) %) (vals all-tokens)))
 
 (defn address->token
   [all-tokens address]
   (get all-tokens (string/lower-case address)))
 
 (defn asset-for
-  [all-tokens current-network symbol]
+  [all-tokens current-network sym]
   (let [native-coin (native-currency current-network)]
-    (if (or (= (:symbol-display native-coin) symbol)
-            (= (:symbol native-coin) symbol))
+    (if (or (= (:symbol-display native-coin) sym)
+            (= (:symbol native-coin) sym))
       native-coin
-      (symbol->token all-tokens symbol))))
+      (symbol->token all-tokens sym))))

--- a/src/status_im/ethereum/transactions/core.cljs
+++ b/src/status_im/ethereum/transactions/core.cljs
@@ -52,10 +52,8 @@
 
 (defn- parse-token-transfer
   [chain-tokens contract]
-  (let [{:keys [symbol] :as token} (get chain-tokens
-                                        contract
-                                        default-erc20-token)]
-    {:symbol   symbol
+  (let [token (get chain-tokens contract default-erc20-token)]
+    {:symbol   (:symbol token)
      :token    token
      ;; NOTE(goranjovic) - just a flag we need when we merge this entry
      ;; with the existing entry in the app, e.g. transaction info with
@@ -387,11 +385,10 @@
        :addresses         [address]
        :before-block      min-known-block
        :fetch-more?       (utils.mobile-sync/syncing-allowed? cofx)
-       ;; Transfers are requested before and including `min-known-block` because
-       ;; there is no guarantee that all transfers from that block are shown
-       ;; already. To make sure that we fetch the whole `default-transfers-limit`
-       ;; of transfers the number of transfers already received for
-       ;; `min-known-block` is added to the page size.
+       ;; Transfers are requested before and including `min-known-block` because there is no
+       ;; guarantee that all transfers from that block are shown already. To make sure that we fetch
+       ;; the whole `default-transfers-limit` of transfers the number of transfers already received
+       ;; for `min-known-block` is added to the page size.
        :limit-per-address {address (+ default-transfers-limit
                                       min-block-transfers-count)}}}
      (tx-fetching-in-progress [address]))))

--- a/src/status_im/multiaccounts/core.cljs
+++ b/src/status_im/multiaccounts/core.cljs
@@ -34,18 +34,18 @@
       (or display-name primary-name alias (gfycat/generate-gfy public-key)))))
 
 (defn contact-by-identity
-  [contacts identity]
-  (or (get contacts identity)
-      (contact.db/public-key->new-contact identity)))
+  [contacts contact-identity]
+  (or (get contacts contact-identity)
+      (contact.db/public-key->new-contact contact-identity)))
 
 (defn contact-two-names-by-identity
-  [contact profile identity]
-  (let [me? (= (:public-key profile) identity)]
+  [contact profile contact-identity]
+  (let [me? (= (:public-key profile) contact-identity)]
     (if me?
       [(or (:preferred-name profile)
            (:display-name profile)
            (:primary-name contact)
-           (gfycat/generate-gfy identity))]
+           (gfycat/generate-gfy contact-identity))]
       [(:primary-name contact) (:secondary-name contact)])))
 
 (defn displayed-photo
@@ -212,8 +212,8 @@
     (rf/merge cofx
               {:json-rpc/call [{:method     "multiaccounts_deleteIdentityImage"
                                 :params     [key-uid]
-                                ;; NOTE: In case of an error we could fallback to previous image in UI
-                                ;; with a toast error
+                                ;; NOTE: In case of an error we could fallback to previous image in
+                                ;; UI with a toast error
                                 :on-success #(log/info "[multiaccount] Delete profile image" %)}]}
               (multiaccounts.update/optimistic :images nil)
               (bottom-sheet/hide-bottom-sheet-old))))

--- a/src/status_im/network/core.cljs
+++ b/src/status_im/network/core.cljs
@@ -158,7 +158,7 @@
                       :on-success #(re-frame/dispatch [:navigate-back])}]}))
 
 (defn new-network
-  [random-id network-name symbol upstream-url chain-type chain-id]
+  [random-id network-name sym upstream-url chain-type chain-id]
   (let [data-dir (str "/ethereum/" (name chain-type) "_rpc")
         config   {:NetworkId      (or (when chain-id (int chain-id))
                                       (ethereum/chain-keyword->chain-id chain-type))
@@ -167,7 +167,7 @@
                                    :URL     upstream-url}}]
     {:id     random-id
      :name   network-name
-     :symbol symbol
+     :symbol sym
      :config config}))
 
 (rf/defn save

--- a/src/status_im/signing/core.cljs
+++ b/src/status_im/signing/core.cljs
@@ -181,7 +181,7 @@
 
 (defn get-transfer-token
   [db to data]
-  (let [{:keys [symbol decimals] :as token} (tokens/address->token (:wallet/all-tokens db) to)]
+  (let [{:keys [decimals] :as token} (tokens/address->token (:wallet/all-tokens db) to)]
     (when (and token data (string? data))
       (when-let [type (get-method-type data)]
         (let [[address value _] (native-module/decode-parameters
@@ -197,7 +197,7 @@
              :value    value
              :amount   (money/to-fixed (money/token->unit value decimals))
              :token    token
-             :symbol   symbol}))))))
+             :symbol   (:symbol token)}))))))
 
 (defn parse-tx-obj
   [db {:keys [from to value data cancel? hash]}]

--- a/src/status_im/ui/components/bottom_panel/views.cljs
+++ b/src/status_im/ui/components/bottom_panel/views.cljs
@@ -140,11 +140,11 @@
                                            nil)))})))
 
 (views/defview animated-bottom-panel
-  [val view on-close on-touch-outside show-overlay?]
+  [m view on-close on-touch-outside show-overlay?]
   (views/letsubs [{window-height :height} [:dimensions/window]]
     [bottom-panel
-     (when val
-       (select-keys val
+     (when m
+       (select-keys m
                     [:from :contact :amount :token :approve? :message :cancel? :hash :name :url :icons
                      :wc-version :params :connector :description :topic :relay :self :peer :permissions
                      :state])) view window-height on-close on-touch-outside

--- a/src/status_im/ui/screens/signing/sheets.cljs
+++ b/src/status_im/ui/screens/signing/sheets.cljs
@@ -298,8 +298,10 @@
        (i18n/label :t/save)]]]))
 
 (defn gwei
-  [val]
-  (str (money/to-fixed val 2) " " (i18n/label :t/gwei)))
+  [amount]
+  (str (money/to-fixed amount 2)
+       " "
+       (i18n/label :t/gwei)))
 
 (defn fees-warning
   []

--- a/src/status_im/ui/screens/wallet/custom_tokens/views.cljs
+++ b/src/status_im/ui/screens/wallet/custom_tokens/views.cljs
@@ -23,102 +23,104 @@
 
 (defview add-custom-token
   []
-  (letsubs [{:keys [contract name symbol decimals in-progress? error error-name error-symbol]}
+  (letsubs [{:keys [contract name decimals in-progress? error error-name error-symbol]
+             :as   m}
             [:wallet/custom-token-screen]]
-    [react/keyboard-avoiding-view {:flex 1 :background-color colors/white}
-     [react/scroll-view
-      {:keyboard-should-persist-taps :handled
-       :style                        {:flex               1
-                                      :padding-horizontal 16}}
-      [react/view {:padding-vertical 8}
-       [react/view
-        {:style {:flex-direction   :row
-                 :justify-content  :space-between
-                 :padding-vertical 10}}
-        [react/text (i18n/label :t/contract-address)]
-        (when in-progress?
-          [react/view {:flex-direction :row :justify-content :center}
-           [react/view {:height 20}
-            [react/activity-indicator {:width 24 :height 24 :animating true}]]
-           [react/text {:style {:color colors/gray :margin-left 5}}
-            (i18n/label :t/processing)]])]
-       (when-not in-progress?
-         ;;tooltip covers button
-         [react/view {:position :absolute :z-index 1000 :right 0 :top 10}
-          [react/touchable-highlight
-           {:on-press #(re-frame/dispatch [:wallet.custom-token.ui/contract-address-paste])}
-           [react/text {:style {:color colors/blue}}
-            (i18n/label :t/paste)]]])
-       [quo/text-input
-        {:on-change-text #(debounce-and-save :contract %)
-         :error          error
-         :default-value  contract
-         :monospace      true
-         :multiline      true
-         :height         78
-         :auto-focus     false
-         :placeholder    (i18n/label :t/specify-address)}]]
-      [react/view {:padding-vertical 8}
-       [quo/text-input
-        {:on-change-text #(debounce-and-save :name %)
-         :label          (i18n/label :t/name)
-         :default-value  name
-         :error          error-name
-         :auto-focus     false
-         :placeholder    (i18n/label :t/name-of-token)}]]
-      [react/view {:padding-vertical 8}
-       [react/view {:style {:flex-direction :row}}
-        [react/view
-         {:flex          1
-          :padding-right 8}
+    (let [sym (:symbol m)]
+      [react/keyboard-avoiding-view {:flex 1 :background-color colors/white}
+       [react/scroll-view
+        {:keyboard-should-persist-taps :handled
+         :style                        {:flex               1
+                                        :padding-horizontal 16}}
+        [react/view {:padding-vertical 8}
+         [react/view
+          {:style {:flex-direction   :row
+                   :justify-content  :space-between
+                   :padding-vertical 10}}
+          [react/text (i18n/label :t/contract-address)]
+          (when in-progress?
+            [react/view {:flex-direction :row :justify-content :center}
+             [react/view {:height 20}
+              [react/activity-indicator {:width 24 :height 24 :animating true}]]
+             [react/text {:style {:color colors/gray :margin-left 5}}
+              (i18n/label :t/processing)]])]
+         (when-not in-progress?
+           ;;tooltip covers button
+           [react/view {:position :absolute :z-index 1000 :right 0 :top 10}
+            [react/touchable-highlight
+             {:on-press #(re-frame/dispatch [:wallet.custom-token.ui/contract-address-paste])}
+             [react/text {:style {:color colors/blue}}
+              (i18n/label :t/paste)]]])
          [quo/text-input
-          {:on-change-text #(debounce-and-save :symbol %)
-           :label          (i18n/label :t/symbol)
-           :error          error-symbol
-           :default-value  symbol
+          {:on-change-text #(debounce-and-save :contract %)
+           :error          error
+           :default-value  contract
+           :monospace      true
+           :multiline      true
+           :height         78
            :auto-focus     false
-           :show-cancel    false
-           :placeholder    "ABC"}]]
-        [react/view
-         {:flex         1
-          :padding-left 8}
+           :placeholder    (i18n/label :t/specify-address)}]]
+        [react/view {:padding-vertical 8}
          [quo/text-input
-          {:label          (i18n/label :t/decimals)
-           :on-change-text #(debounce-and-save :decimals %)
-           :default-value  decimals
-           :keyboard-type  :number-pad
-           :max-length     2
+          {:on-change-text #(debounce-and-save :name %)
+           :label          (i18n/label :t/name)
+           :default-value  name
+           :error          error-name
            :auto-focus     false
-           :show-cancel    false
-           :placeholder    "18"}]]]]
-      #_[quo/text-input
-         {:label         (i18n/label :t/balance)
-          :default-value (when (and balance decimals)
-                           (wallet.utils/format-amount balance decimals))
-          :editable      false
-          :placeholder   (i18n/label :t/no-tokens-found)}]]
+           :placeholder    (i18n/label :t/name-of-token)}]]
+        [react/view {:padding-vertical 8}
+         [react/view {:style {:flex-direction :row}}
+          [react/view
+           {:flex          1
+            :padding-right 8}
+           [quo/text-input
+            {:on-change-text #(debounce-and-save :symbol %)
+             :label          (i18n/label :t/symbol)
+             :error          error-symbol
+             :default-value  sym
+             :auto-focus     false
+             :show-cancel    false
+             :placeholder    "ABC"}]]
+          [react/view
+           {:flex         1
+            :padding-left 8}
+           [quo/text-input
+            {:label          (i18n/label :t/decimals)
+             :on-change-text #(debounce-and-save :decimals %)
+             :default-value  decimals
+             :keyboard-type  :number-pad
+             :max-length     2
+             :auto-focus     false
+             :show-cancel    false
+             :placeholder    "18"}]]]]
+        #_[quo/text-input
+           {:label         (i18n/label :t/balance)
+            :default-value (when (and balance decimals)
+                             (wallet.utils/format-amount balance decimals))
+            :editable      false
+            :placeholder   (i18n/label :t/no-tokens-found)}]]
 
-     [toolbar/toolbar
-      {:show-border? true
-       :right
-       [quo/button
-        {:type     :secondary
-         :after    :main-icon/next
-         :disabled (boolean
-                    (or in-progress?
-                        error
-                        error-name
-                        error-symbol
-                        (string/blank? contract)
-                        (string/blank? name)
-                        (string/blank? symbol)
-                        (string/blank? decimals)))
-         :on-press #(re-frame/dispatch [:wallet.custom-token.ui/add-pressed])}
-        (i18n/label :t/add)]}]]))
+       [toolbar/toolbar
+        {:show-border? true
+         :right
+         [quo/button
+          {:type     :secondary
+           :after    :main-icon/next
+           :disabled (boolean
+                      (or in-progress?
+                          error
+                          error-name
+                          error-symbol
+                          (string/blank? contract)
+                          (string/blank? name)
+                          (string/blank? sym)
+                          (string/blank? decimals)))
+           :on-press #(re-frame/dispatch [:wallet.custom-token.ui/add-pressed])}
+          (i18n/label :t/add)]}]])))
 
 (defview custom-token-details
   []
-  (letsubs [{:keys [address name symbol decimals custom?] :as token}
+  (letsubs [{:keys [address name decimals custom?] :as token}
             [:get-screen-params]]
     [react/keyboard-avoiding-view
      {:style         {:flex 1}
@@ -149,7 +151,7 @@
            {:label         (i18n/label :t/symbol)
             :editable      false
             :show-cancel   false
-            :default-value symbol}]]
+            :default-value (:symbol token)}]]
          [react/view {:flex 1 :padding-left 8}
           [quo/text-input
            {:label         (i18n/label :t/decimals)

--- a/src/status_im/ui/screens/wallet/send/views.cljs
+++ b/src/status_im/ui/screens/wallet/send/views.cljs
@@ -112,8 +112,8 @@
     [react/text {:style {:color colors/blue}} (i18n/label :t/set-max)]]])
 
 (defn fiat-value
-  [amount {:keys [symbol]} prices wallet-currency]
-  (when-let [price (get-in prices [(keyword symbol) (keyword (:code wallet-currency)) :price])]
+  [amount {sym :symbol} prices wallet-currency]
+  (when-let [price (get-in prices [(keyword sym) (keyword (:code wallet-currency)) :price])]
     (let [norm-amount (js/parseFloat (money/normalize amount))
           amount      (if (js/isNaN norm-amount) 0 norm-amount)]
       [react/text

--- a/src/status_im/ui/screens/wallet/settings/views.cljs
+++ b/src/status_im/ui/screens/wallet/settings/views.cljs
@@ -51,7 +51,12 @@
     (fn [_ [_ old-token] [_ new-token]]
       (not= (:checked? old-token) (:checked? new-token)))
     :reagent-render
-    (fn [{:keys [symbol name icon color checked?] :as token}]
+    (fn [{sym      :symbol
+          title    :name
+          icon     :icon
+          color    :color
+          checked? :checked?
+          :as      token}]
       [quo/list-item
        {:active              checked?
         :accessory           :checkbox
@@ -59,14 +64,13 @@
         :animated            false
         :icon                (if icon
                                [wallet.components/token-icon icon]
-                               [chat-icon/custom-icon-view-list name color])
-        :title               name
-        :subtitle            (clojure.core/name symbol)
-        :on-press            #(re-frame/dispatch
-                               [:wallet.settings/toggle-visible-token (keyword symbol) (not checked?)])
-        :on-long-press       #(re-frame/dispatch
-                               [:bottom-sheet/show-sheet-old
-                                {:content (custom-token-actions-view token)}])}])}))
+                               [chat-icon/custom-icon-view-list title color])
+        :title               title
+        :subtitle            (name sym)
+        :on-press            #(re-frame/dispatch [:wallet.settings/toggle-visible-token (keyword sym)
+                                                  (not checked?)])
+        :on-long-press       #(re-frame/dispatch [:bottom-sheet/show-sheet-old
+                                                  {:content (custom-token-actions-view token)}])}])}))
 
 (defn- render-token-wrapper
   [token]

--- a/src/status_im/utils/http.cljs
+++ b/src/status_im/utils/http.cljs
@@ -132,9 +132,9 @@
     (catch :default _ nil)))
 
 (defn url?
-  [str]
+  [s]
   (try
-    (when-let [host (.getDomain ^js (goog.Uri. str))]
+    (when-let [host (.getDomain ^js (goog.Uri. s))]
       (not (string/blank? host)))
     (catch :default _ nil)))
 

--- a/src/status_im/utils/priority_map.cljs
+++ b/src/status_im/utils/priority_map.cljs
@@ -191,12 +191,14 @@
   (PersistentPriorityMap. (sorted-map) {} {} identity nil))
 
 (defn- pm-empty-by
-  [comparator]
-  (PersistentPriorityMap. (sorted-map-by comparator) {} {} identity nil))
+  [f-comparator]
+  (PersistentPriorityMap. (sorted-map-by f-comparator) {} {} identity nil))
 
 (defn- pm-empty-keyfn
-  ([keyfn] (PersistentPriorityMap. (sorted-map) {} {} keyfn nil))
-  ([keyfn comparator] (PersistentPriorityMap. (sorted-map-by comparator) {} {} keyfn nil)))
+  ([keyfn]
+   (PersistentPriorityMap. (sorted-map) {} {} keyfn nil))
+  ([keyfn f-comparator]
+   (PersistentPriorityMap. (sorted-map-by f-comparator) {} {} keyfn nil)))
 
 (defn- read-priority-map
   [elems]
@@ -221,9 +223,9 @@
   "keyval => key val
   Returns a new priority map with supplied
   mappings, using the supplied comparator."
-  ([comparator & keyvals]
+  ([f-comparator & keyvals]
    (loop [in  (seq keyvals)
-          out (pm-empty-by comparator)]
+          out (pm-empty-by f-comparator)]
      (if in
        (recur (nnext in) (assoc out (first in) (second in)))
        out))))
@@ -243,9 +245,9 @@
   "keyval => key val
   Returns a new priority map with supplied
   mappings, using the supplied keyfn and comparator."
-  ([keyfn comparator & keyvals]
+  ([keyfn f-comparator & keyvals]
    (loop [in  (seq keyvals)
-          out (pm-empty-keyfn keyfn comparator)]
+          out (pm-empty-keyfn keyfn f-comparator)]
      (if in
        (recur (nnext in) (assoc out (first in) (second in)))
        out))))

--- a/src/status_im/utils/test.cljs
+++ b/src/status_im/utils/test.cljs
@@ -120,7 +120,7 @@
     (fn [address] (.checkAddressChecksum native-status address))
 
     :sha3
-    (fn [str] (.sha3 native-status str))
+    (fn [s] (.sha3 native-status s))
 
     :toChecksumAddress
     (fn [address] (.toChecksumAddress native-status address))

--- a/src/status_im/wallet/choose_recipient/core.cljs
+++ b/src/status_im/wallet/choose_recipient/core.cljs
@@ -53,8 +53,14 @@
 
 (defn- fill-prepare-transaction-details
   [db
-   {:keys [address name value symbol gas gasPrice gasLimit]
-    :or   {symbol :ETH}}
+   {address   :address
+    name      :name
+    value     :value
+    sym       :symbol
+    gas       :gas
+    gas-price :gasPrice
+    gas-limit :gasLimit
+    :or       {sym :ETH}}
    all-tokens]
   (assoc db
          :wallet/prepare-transaction
@@ -62,14 +68,14 @@
                   :to-name (or name (find-address-name db address))
                   :from    (ethereum/get-default-account
                             (get db :profile/wallet-accounts))}
-           gas      (assoc :gas (money/bignumber gas))
-           gasLimit (assoc :gas (money/bignumber gasLimit))
-           gasPrice (assoc :gasPrice (money/bignumber gasPrice))
-           value    (assoc :amount-text
-                           (if (= :ETH symbol)
-                             (str (money/internal->formatted value symbol (get all-tokens symbol)))
-                             (str value)))
-           symbol   (assoc :symbol symbol))))
+           gas       (assoc :gas (money/bignumber gas))
+           gas-limit (assoc :gas (money/bignumber gas-limit))
+           gas-price (assoc :gasPrice (money/bignumber gas-price))
+           value     (assoc :amount-text
+                            (if (= :ETH sym)
+                              (str (money/internal->formatted value sym (get all-tokens sym)))
+                              (str value)))
+           sym       (assoc :symbol sym))))
 
 (rf/defn request-uri-parsed
   {:events [:wallet/request-uri-parsed]}

--- a/src/status_im/wallet/core.cljs
+++ b/src/status_im/wallet/core.cljs
@@ -987,15 +987,15 @@
   {::get-pending-transactions nil})
 
 (defn normalize-transaction
-  [db {:keys [symbol gasPrice gasLimit value from to] :as transaction}]
-  (let [symbol (keyword symbol)
-        token  (tokens/symbol->token (:wallet/all-tokens db) symbol)]
+  [db {:keys [gasPrice gasLimit value from to] :as transaction}]
+  (let [sym   (-> transaction :symbol keyword)
+        token (tokens/symbol->token (:wallet/all-tokens db) sym)]
     (-> transaction
         (select-keys [:timestamp :hash :data])
         (assoc :from      (eip55/address->checksum from)
                :to        (eip55/address->checksum to)
                :type      :pending
-               :symbol    symbol
+               :symbol    sym
                :token     token
                :value     (money/bignumber value)
                :gas-price (money/bignumber gasPrice)

--- a/src/status_im/wallet/utils.cljs
+++ b/src/status_im/wallet/utils.cljs
@@ -12,13 +12,15 @@
 ;; some sidechains have different names for this native currency, which we handle with `symbol-display`
 ;; override.
 (defn display-symbol
-  [{:keys [symbol-display symbol]}]
-  (when-let [name (or symbol-display symbol)]
-    (clojure.core/name name)))
+  [m]
+  (when-let [some-symbol (or (:symbol-display m) (:symbol m))]
+    (name some-symbol)))
 
 ;;NOTE(goranjovic) - in addition to custom symbol display, some sidechain native currencies are listed
 ;;under a different
 ;; ticker on exchange networks. We handle that with `symbol-exchange` override.
 (defn exchange-symbol
-  [{:keys [symbol-exchange symbol-display symbol]}]
-  (clojure.core/name (or symbol-exchange symbol-display symbol)))
+  [m]
+  (name (or (:symbol-exchange m)
+            (:symbol-display m)
+            (:symbol m))))

--- a/src/status_im2/contexts/chat/composer/utils.cljs
+++ b/src/status_im2/contexts/chat/composer/utils.cljs
@@ -11,8 +11,8 @@
     [utils.re-frame :as rf]))
 
 (defn bounded-val
-  [val min-val max-val]
-  (max min-val (min val max-val)))
+  [v min-v max-v]
+  (max min-v (min v max-v)))
 
 (defn update-height?
   [content-size height max-height maximized?]

--- a/src/status_im2/subs/communities.cljs
+++ b/src/status_im2/subs/communities.cljs
@@ -288,12 +288,12 @@
                                   (let [check-criteria (get-in token-permissions-check
                                                                [:permissions perm-key :criteria])]
                                     (map
-                                     (fn [{:keys [symbol amount]} sufficient?]
-                                       {:symbol      symbol
+                                     (fn [{sym :symbol amount :amount} sufficient?]
+                                       {:symbol      sym
                                         :sufficient? (when (seq check-criteria) sufficient?)
                                         :loading?    checking-permissions?
                                         :amount      amount
-                                        :img-src     (get token-images symbol)})
+                                        :img-src     (get token-images sym)})
                                      token_criteria
                                      (or check-criteria token_criteria))))
                                 token-permissions)}))

--- a/src/status_im2/subs/communities.cljs
+++ b/src/status_im2/subs/communities.cljs
@@ -56,14 +56,15 @@
          members      (re-frame/subscribe [:communities/community-members community-id])]
      [contacts multiaccount members]))
  (fn [[contacts multiaccount members] _]
-   (let [names (reduce (fn [acc identity]
-                         (let [me?     (= (:public-key multiaccount) identity)
+   (let [names (reduce (fn [acc contact-identity]
+                         (let [me?     (= (:public-key multiaccount) contact-identity)
                                contact (when-not me?
-                                         (multiaccounts/contact-by-identity contacts identity))
-                               name    (first (multiaccounts/contact-two-names-by-identity contact
-                                                                                           multiaccount
-                                                                                           identity))]
-                           (assoc acc identity name)))
+                                         (multiaccounts/contact-by-identity contacts contact-identity))
+                               name    (first (multiaccounts/contact-two-names-by-identity
+                                               contact
+                                               multiaccount
+                                               contact-identity))]
+                           (assoc acc contact-identity name)))
                        {}
                        (keys members))]
      (->> members
@@ -95,10 +96,9 @@
  :<- [:view-id]
  :<- [:communities]
  :<- [:communities/my-pending-requests-to-join]
- ;; Return communities splitted by level of user participation. Some communities user
- ;; already joined, to some of them join request sent and others were opened one day
- ;; and their data remained in app-db.
- ;; Result map has form: {:joined [id1, id2] :pending [id3, id5] :opened [id4]}"
+ ;; Return communities splitted by level of user participation. Some communities user already
+ ;; joined, to some of them join request sent and others were opened one day and their data remained
+ ;; in app-db. Result map has form: {:joined [id1, id2] :pending [id3, id5] :opened [id4]}"
  (fn [[view-id communities requests]]
    (if (or (empty? @memo-communities-stack-items) (= view-id :communities-stack))
      (let [grouped-communities (reduce (fn [acc community]
@@ -128,9 +128,9 @@
  (fn [[_ community-id]]
    [(re-frame/subscribe [:communities])
     (re-frame/subscribe [:communities/unviewed-counts community-id])])
- (fn [[communities counts] [_ identity]]
+ (fn [[communities counts] [_ community-identity]]
    (community->home-item
-    (get communities identity)
+    (get communities community-identity)
     counts)))
 
 (re-frame/reg-sub

--- a/src/status_im2/subs/search.cljs
+++ b/src/status_im2/subs/search.cljs
@@ -52,8 +52,7 @@
 
 (defn extract-token-attributes
   [token]
-  (let [{:keys [symbol name]} token]
-    [symbol name]))
+  [(:symbol token) (:name token)])
 
 (re-frame/reg-sub
  :wallet/filtered-grouped-chain-tokens

--- a/src/status_im2/subs/wallet/transactions.cljs
+++ b/src/status_im2/subs/wallet/transactions.cljs
@@ -44,14 +44,14 @@
           [to :to-contact :from-wallet])
         wallet (i18n/label :main-wallet)
         contact (get contacts contact-address)
-        {:keys [symbol-display symbol decimals] :as asset}
+        {:keys [symbol-display decimals] :as asset}
         (or token native-currency)
         amount-text (if value
                       (wallet.utils/format-amount value decimals)
                       "...")
         currency-text (when asset
                         (clojure.core/name (or symbol-display
-                                               symbol)))]
+                                               (:symbol asset))))]
     (cond-> transaction
       contact (assoc key-contact (:name contact))
       :always (assoc key-wallet

--- a/src/status_im2/subs/wallet/wallet.cljs
+++ b/src/status_im2/subs/wallet/wallet.cljs
@@ -61,10 +61,10 @@
 
 (defn get-balance-total-value
   [balance prices currency token->decimals]
-  (reduce-kv (fn [acc symbol value]
-               (if-let [price (get-in prices [symbol currency])]
+  (reduce-kv (fn [acc sym value]
+               (if-let [price (get-in prices [sym currency])]
                  (+ acc
-                    (or (some-> (money/internal->formatted value symbol (token->decimals symbol))
+                    (or (some-> (money/internal->formatted value sym (token->decimals sym))
                                 ^js (money/crypto->fiat price)
                                 .toNumber)
                         0))
@@ -193,13 +193,14 @@
 
 (defn update-value
   [prices currency]
-  (fn [{:keys [symbol decimals amount] :as token}]
-    (let [currency-kw (-> currency :code keyword)
-          price       (get-in prices [symbol currency-kw])]
+  (fn [{:keys [decimals amount] :as token}]
+    (let [sym         (:symbol token)
+          currency-kw (-> currency :code keyword)
+          price       (get-in prices [sym currency-kw])]
       (assoc token
              :price price
              :value (when (and amount price)
-                      (-> (money/internal->formatted amount symbol decimals)
+                      (-> (money/internal->formatted amount sym decimals)
                           (money/crypto->fiat price)
                           (money/with-precision 2)
                           str

--- a/src/utils/money.cljs
+++ b/src/utils/money.cljs
@@ -155,14 +155,14 @@
 ;; to get the amount scale right.
 
 (defn formatted->internal
-  [n symbol decimals]
-  (if (= :ETH symbol)
+  [n sym decimals]
+  (if (= :ETH sym)
     (ether->wei n)
     (unit->token n decimals)))
 
 (defn internal->formatted
-  [n symbol decimals]
-  (if (= :ETH symbol)
+  [n sym decimals]
+  (if (= :ETH sym)
     (wei->ether n)
     (token->unit n decimals)))
 

--- a/src/utils/re_frame.cljs
+++ b/src/utils/re_frame.cljs
@@ -39,8 +39,8 @@
 (def ^:private mergeable-keys (atom nil))
 
 (defn set-mergeable-keys
-  [val]
-  (reset! mergeable-keys val))
+  [v]
+  (reset! mergeable-keys v))
 
 (defn- safe-merge
   [fx new-fx]


### PR DESCRIPTION
# Summary

This PR is a continuation of PR https://github.com/status-im/status-mobile/pull/16500 (`Lint & fix some shadowed core Clojure(Script) vars`).

## Notes

As a reminder, the goal is to eventually disallow shadowing core Clojure vars entirely, but to get there and avoid rebase hell and regressions, we need to do in smaller steps, especially because we can't safely automate the process of unshadowing vars.

In this PR we are already down from ~500 shadowed core vars to 350 in total.

Whenever I'm on the mood I'll try to work on this mini epic ;) But of course, if you are also on the mood, join me in this quest!

## Why is this PR is using names such as `s`, `v` or `sym`?

Names such as `s` or `v` are the so called **idiomatic names**, and are listed in the Clojure Style Guide https://guide.clojure.style/#idiomatic-names. I used them whenever I felt appropriate. For the var `cljs.core/symbol` I opted to use `sym`, even though the *symbol* in question is not necessarily a Clojure symbol, I think the alias conveys the meaning well enough (https://www.clojure.org/guides/learn/syntax#_symbols_and_idents). 

## Which new vars are now linted?

These are the new vars added to the clj-kondo config file:

- `comparator`
- `identity`
- `str`
- `symbol`
- `val`

Outstanding shadowed vars include `type`, `name`, `hash`, `comp`.

status: ready
