### PR TITLE
Implement `gradient cover` component

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
   - boost (1.76.0)
-  - BVLinearGradient (2.5.6):
-    - React
+  - BVLinearGradient (2.8.0):
+    - React-Core
   - CryptoSwift (1.5.1)
   - DoubleConversion (1.1.6)
   - FBLazyVector (0.69.10)
@@ -701,13 +701,13 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   boost: a7c83b31436843459a1961bfd74b96033dc77234
-  BVLinearGradient: e3aad03778a456d77928f594a649e96995f1c872
+  BVLinearGradient: 612a04ff38e8480291f3379ee5b5a2c571f03fe0
   CryptoSwift: c4f2debceb38bf44c80659afe009f71e23e4a082
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   FBLazyVector: a8af91c2b5a0029d12ff6b32e428863d63c48991
   FBReactNativeSpec: 1b2309b096448a1dc9d0c43999216f8fda809ae8
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: d93527a855523adb8c113837db4be68fb00e230d
+  glog: 166d178815c300e8126de9a7900101814eb16253
   HMSegmentedControl: 34c1f54d822d8308e7b24f5d901ec674dfa31352
   Keycard: ac6df4d91525c3c82635ac24d4ddd9a80aca5fc8
   libwebp: f62cb61d0a484ba548448a4bd52aabf150ff6eef
@@ -772,7 +772,7 @@ SPEC CHECKSUMS:
   RNLanguages: 962e562af0d34ab1958d89bcfdb64fafc37c513e
   RNPermissions: ad71dd4f767ec254f2cd57592fbee02afee75467
   RNReactNativeHapticFeedback: 2566b468cc8d0e7bb2f84b23adc0f4614594d071
-  RNReanimated: 43adb0307a62c1ce9694f36f124ca3b51a15272a
+  RNReanimated: 3e375fc41870cc66c5152a38514c450f7adbc3e1
   RNShare: d82e10f6b7677f4b0048c23709bd04098d5aee6c
   RNStaticSafeAreaInsets: 055ddbf5e476321720457cdaeec0ff2ba40ec1b8
   RNSVG: 8ba35cbeb385a52fd960fd28db9d7d18b4c2974f
@@ -785,6 +785,6 @@ SPEC CHECKSUMS:
   TouchID: ba4c656d849cceabc2e4eef722dea5e55959ecf4
   Yoga: d24d6184b6b85f742536bd93bd07d69d7b9bb4c1
 
-PODFILE CHECKSUM: a7c3cb360cf217ab90667d67deeab588677d540a
+PODFILE CHECKSUM: 1b60eee24bff3a6287f8b33e57657289b2966342
 
-COCOAPODS: 1.12.1
+COCOAPODS: 1.12.0

--- a/nix/deps/gradle/deps.json
+++ b/nix/deps/gradle/deps.json
@@ -9492,16 +9492,16 @@
   },
 
   {
-    "path": "com/google/auto/value/auto-value-annotations/1.10.1",
+    "path": "com/google/auto/value/auto-value-annotations/1.10.2",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "auto-value-annotations-1.10.1.pom": {
-        "sha1": "72aa2e866fd52dc58222aacc490b6f469ff8a50f",
-        "sha256": "sha256-n7rMhpTRkE37TVrx5KVGD9ZMHKnQBJ0YFFQs0q0osEc="
+      "auto-value-annotations-1.10.2.pom": {
+        "sha1": "bdae7d62039b58f8e6099403bd8d663064e00805",
+        "sha256": "sha256-ck+V7NRFowDEx39LIHU+xe2rcLmth1Hez3CcgWUKdyE="
       },
-      "auto-value-annotations-1.10.1.jar": {
-        "sha1": "9e5162c15f6033c524134cba05a5e93dc1d37c4b",
-        "sha256": "sha256-pP4KIRkl6TioUQ10F2PuEXGhG/kx9Yke9NTuhPynK+I="
+      "auto-value-annotations-1.10.2.jar": {
+        "sha1": "337954851fc17058d9b4b692b6e67e57b20e14f0",
+        "sha256": "sha256-Pzt+369/u9iGQve9WwlIe43PK55fOhnx63s+U/IPFLo="
       }
     }
   },
@@ -9529,12 +9529,12 @@
   },
 
   {
-    "path": "com/google/auto/value/auto-value-parent/1.10.1",
+    "path": "com/google/auto/value/auto-value-parent/1.10.2",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "auto-value-parent-1.10.1.pom": {
-        "sha1": "cfd31b18489357b9f2b0acee57d6674394575c37",
-        "sha256": "sha256-9y2jrhi84YuHRM1yM6qDSjLTvR4LRTsV9tujP3lzz+k="
+      "auto-value-parent-1.10.2.pom": {
+        "sha1": "8828fce3eb0708d36059af557545ab9b0c5a82de",
+        "sha256": "sha256-kdaz5RX4jKobwFyqsbvciU/27dY1Se8PCaVYTJeT7mk="
       }
     }
   },
@@ -10186,27 +10186,27 @@
   },
 
   {
-    "path": "com/google/guava/guava-parent/32.0.1-jre",
+    "path": "com/google/guava/guava-parent/32.1.1-jre",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "guava-parent-32.0.1-jre.pom": {
-        "sha1": "88c9e60e238868208ca8e375a475a23142e52ac6",
-        "sha256": "sha256-Q+0ONrNT9B5et1zXVmZ8ni35fO8G6xYGaWcVih0DTSo="
+      "guava-parent-32.1.1-jre.pom": {
+        "sha1": "01c4a3f0686592f40c1052b273c9b533f6a71e6d",
+        "sha256": "sha256-BqpdGsBo8vgJUw8/9T+1yMlAFSolNiPQtTxPU/WhOj0="
       }
     }
   },
 
   {
-    "path": "com/google/guava/guava-testlib/32.0.1-jre",
+    "path": "com/google/guava/guava-testlib/32.1.1-jre",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "guava-testlib-32.0.1-jre.pom": {
-        "sha1": "a15680d2a8dd88549afda6094b5dc79ec008a5bb",
-        "sha256": "sha256-kPF5mSKi2TRJl+1qpiD6HnzEJuOleB9/ufksEPWFAhs="
+      "guava-testlib-32.1.1-jre.pom": {
+        "sha1": "db7f2a81be1c208ea156572f3e344b6e47b4402f",
+        "sha256": "sha256-8vbywCb/80CvDqzmn1SHRUG62UPLj8nvh7rm0z5yT1w="
       },
-      "guava-testlib-32.0.1-jre.jar": {
-        "sha1": "53ebb9303be258ba8fda12881f04be811e0f496e",
-        "sha256": "sha256-yXURhJpeCFKA8QbfKwWVZv69KAsRjTPWqeBo0jgQC2M="
+      "guava-testlib-32.1.1-jre.jar": {
+        "sha1": "7cf13628fd8fedd5c612b928858912d9d6573d28",
+        "sha256": "sha256-d+b5cAvGPxiz2iTScB9BucnhzEpXNG8hztZssAZtojU="
       }
     }
   },
@@ -10377,16 +10377,16 @@
   },
 
   {
-    "path": "com/google/guava/guava/32.0.1-jre",
+    "path": "com/google/guava/guava/32.1.1-jre",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "guava-32.0.1-jre.pom": {
-        "sha1": "4b29ff9dfc268252e73839b0f7324ef705e07108",
-        "sha256": "sha256-QsJX9/c203ezGv7u6XirJtcwzXCvYN3nZi4YI1LiSCo="
+      "guava-32.1.1-jre.pom": {
+        "sha1": "0e5cbc6d9046ce986b121a842f8d30ee6d81a900",
+        "sha256": "sha256-LJBx19FSKwx2IFfDToub+uOZJ6DrdVw2qnZRlyGHDXs="
       },
-      "guava-32.0.1-jre.jar": {
-        "sha1": "6e5d51a72d142f2d40a57dfb897188b36a95b489",
-        "sha256": "sha256-vX+iJ1kfuFCWd9DREiz5UVjzuKn0VlP1goHYefbcSMU="
+      "guava-32.1.1-jre.jar": {
+        "sha1": "ad575652d84153075dd41ec6177ccb15251262b2",
+        "sha256": "sha256-kfu6N/HIslHPnqnn06Np63nrHmpd8dS79IPdA4B0AoE="
       }
     }
   },
@@ -11044,16 +11044,16 @@
   },
 
   {
-    "path": "com/squareup/okio/okio-jvm/3.3.0",
+    "path": "com/squareup/okio/okio-jvm/3.4.0",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "okio-jvm-3.3.0.pom": {
-        "sha1": "441db5e3f85f26d8891b7ae05cffb9a1a67ee54f",
-        "sha256": "sha256-RgAOC5D+UbfbTA6YseP5IxVWJqh7vD9N3ItWwNM3GM4="
+      "okio-jvm-3.4.0.pom": {
+        "sha1": "5863f748d245d922f99b22c24e3d0c00455f6687",
+        "sha256": "sha256-ZqiFeYHqbD7IuGE6QJvxLxR5Ze+UmMt6jzcXKMTi2k0="
       },
-      "okio-jvm-3.3.0.jar": {
-        "sha1": "2d175add2d06a67bda111ae5455e49b42d0bb287",
-        "sha256": "sha256-3/qEF+wg19Rrx0xq16QiazjaJYipdU9imGJPBN8jciI="
+      "okio-jvm-3.4.0.jar": {
+        "sha1": "4e8bd78a52ab935ce383d0092646922154295e54",
+        "sha256": "sha256-ATnselBtu9VMrWIpGwGcuFBTS+CXyMZsEADV++jt7z4="
       }
     }
   },
@@ -11115,16 +11115,16 @@
   },
 
   {
-    "path": "com/squareup/okio/okio/3.3.0",
+    "path": "com/squareup/okio/okio/3.4.0",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "okio-3.3.0.pom": {
-        "sha1": "8b5abd4bc3965b81e4c8c718bfabdac9afbebe7b",
-        "sha256": "sha256-1aiEoZkyN9rnxa9t5C+vkxzzO9pwLm2qmdOrCKi8xZ8="
+      "okio-3.4.0.pom": {
+        "sha1": "10df463795f884e8f616849ef57229603f116f80",
+        "sha256": "sha256-QOr9s+epasxcFR3pzL7BKFDy37XL53Ph90zrU2JVggM="
       },
-      "okio-3.3.0.jar": {
-        "sha1": "c3ad4568143c88518e82eb63de30e2d3de011439",
-        "sha256": "sha256-DyFSCU7lcwFZ4Yu6aZBdAk6cep9Ij2AhGh3Sg3N/q8U="
+      "okio-3.4.0.jar": {
+        "sha1": "cdbfd045ea8fb402b78e3b3a1177ce6f19d8b2f3",
+        "sha256": "sha256-GHgMXSKb0AiVzyi5E8Wh5YXb8Kq49BD8SDkuF4OrtEI="
       }
     }
   },
@@ -14254,16 +14254,16 @@
   },
 
   {
-    "path": "org/checkerframework/checker-qual/3.35.0",
+    "path": "org/checkerframework/checker-qual/3.36.0",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "checker-qual-3.35.0.pom": {
-        "sha1": "5211a7196b70c37b573e3405d14661cd82e1eddb",
-        "sha256": "sha256-CzlY7JehFV7QAHwXbMICwUrdZm1PV1gPuhzpy2mb+KM="
+      "checker-qual-3.36.0.pom": {
+        "sha1": "6718527e5d8619731637618c68b4d49aa1649c0d",
+        "sha256": "sha256-kLwP0YLqKfP2kkuLYmzMaqTmSm1Apw7klU1j4gb/zvQ="
       },
-      "checker-qual-3.35.0.jar": {
-        "sha1": "3baabaf8eecea6e9e22b8e39cd25953ff4813e0e",
-        "sha256": "sha256-IQYPqght/eyDCkD5RgZ3p1673P/nzcASrRBp6cwwqVk="
+      "checker-qual-3.36.0.jar": {
+        "sha1": "62ea2b911acf3a3eecd25a1a2986864b7403f6d2",
+        "sha256": "sha256-uj7BaeB28uXYLfpRQubunxbnayvvMMrc5FV+1fq3gu0="
       }
     }
   },
@@ -15875,16 +15875,16 @@
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-reflect/1.9.0-RC",
+    "path": "org/jetbrains/kotlin/kotlin-reflect/1.9.0",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "kotlin-reflect-1.9.0-RC.pom": {
-        "sha1": "3a1dca889c37677ab1031646e99190406b48b60d",
-        "sha256": "sha256-AaWDwwugU0BM/4qe7iGCL2kBfXUCbOXqzFCXjKcBuiA="
+      "kotlin-reflect-1.9.0.pom": {
+        "sha1": "eb198069ed7e9e8458d900c47325475ec581507a",
+        "sha256": "sha256-hXFWVnbRiXIEcTBs7ppV2RbAgDgvNabaaBk6x7EvTNs="
       },
-      "kotlin-reflect-1.9.0-RC.jar": {
-        "sha1": "2a7a69e82364a9e6f26b8d7053c0e4f1095693e5",
-        "sha256": "sha256-RCoElBkwb/CgCVHMmCTorhyB1HWKo/v5ineCxM68O/c="
+      "kotlin-reflect-1.9.0.jar": {
+        "sha1": "2891f552979d4bf4d4ec516acb9df769fb62dbe9",
+        "sha256": "sha256-IHAVm+UU6o6jziyLHueZPm/2CpNWWimfIAYpqn339YE="
       }
     }
   },
@@ -16325,16 +16325,16 @@
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-stdlib-common/1.9.0-RC",
+    "path": "org/jetbrains/kotlin/kotlin-stdlib-common/1.9.0",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "kotlin-stdlib-common-1.9.0-RC.pom": {
-        "sha1": "1eee188e6e339347cb905505ba0884504b7d271c",
-        "sha256": "sha256-jybwbbD1aQ6epaWjeA9hyEAVaRnYpXqOGvnt8cvQjD0="
+      "kotlin-stdlib-common-1.9.0.pom": {
+        "sha1": "0a865a0c5a64618fd1dcca13d05dea4cba44c832",
+        "sha256": "sha256-NmDTanD+s6vknxG5BjPkHTYnNXbwcbDhCdqbOg3wgqU="
       },
-      "kotlin-stdlib-common-1.9.0-RC.jar": {
-        "sha1": "0d9bdb03665199f3548ff91464625d943f816594",
-        "sha256": "sha256-2nsa2F4a/WQ9riwPDVFaUTZiW839GD7YbFeVrhfgWpk="
+      "kotlin-stdlib-common-1.9.0.jar": {
+        "sha1": "cd65c21cfd1eec4d44ef09f9f52b6d9f8a720636",
+        "sha256": "sha256-KDJ0IEvXwCB4nsRvj45yr0JE1/VQszkqV+XKAGrXqiw="
       }
     }
   },
@@ -17030,16 +17030,16 @@
   },
 
   {
-    "path": "org/jetbrains/kotlin/kotlin-stdlib/1.9.0-RC",
+    "path": "org/jetbrains/kotlin/kotlin-stdlib/1.9.0",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "kotlin-stdlib-1.9.0-RC.pom": {
-        "sha1": "9b8fee0f61426896867f6bbeff6cd80c5e364789",
-        "sha256": "sha256-Ljsx4IQ1ngB2u5q9jpoBUDQ8wdLA81Zx4gKhy1Rqp6A="
+      "kotlin-stdlib-1.9.0.pom": {
+        "sha1": "4aea0493dfd3ee18df73bcd97db791c2ea5bb383",
+        "sha256": "sha256-N3UiY/Ysw+MlCFbiiO5Kc9QQLXJqd2JwNPlIBsjBCso="
       },
-      "kotlin-stdlib-1.9.0-RC.jar": {
-        "sha1": "f42325be451f7f28ec68e1e60227035beae7ca9b",
-        "sha256": "sha256-x+O9exwYsJnuUeNXIOxgSndh2fpFEmlkQgQOPb9X0Oo="
+      "kotlin-stdlib-1.9.0.jar": {
+        "sha1": "8ee15ef0c67dc83d874f412d84378d7f0eb50b63",
+        "sha256": "sha256-Na7/vi21qkRgcs7lD87ki3+p4vxRyjfAzH19C8OdlS4="
       }
     }
   },
@@ -17232,12 +17232,12 @@
   },
 
   {
-    "path": "org/junit/junit-bom/5.10.0-M1",
+    "path": "org/junit/junit-bom/5.10.0",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "junit-bom-5.10.0-M1.pom": {
-        "sha1": "32146a4e02dff4367f085571d9157924622888a2",
-        "sha256": "sha256-2ltnOOp1EcGyT/z0h2UMPcB1aihjLktKfA2qbiTt7O0="
+      "junit-bom-5.10.0.pom": {
+        "sha1": "1136f35a5438634393bf628f69b8ca43c8518f7c",
+        "sha256": "sha256-4AbdiJT5/Ht1/DK7Ev5e2L5lZn1bRU+Z4uC4xbuNMLM="
       }
     }
   },

--- a/nix/deps/gradle/deps.urls
+++ b/nix/deps/gradle/deps.urls
@@ -634,10 +634,10 @@ https://repo.maven.apache.org/maven2/com/google/auto/auto-parent/6/auto-parent-6
 https://repo.maven.apache.org/maven2/com/google/auto/auto-parent/7/auto-parent-7.pom
 https://repo.maven.apache.org/maven2/com/google/auto/value/auto-value-annotations/1.6.2/auto-value-annotations-1.6.2.pom
 https://repo.maven.apache.org/maven2/com/google/auto/value/auto-value-annotations/1.6.3/auto-value-annotations-1.6.3.pom
-https://repo.maven.apache.org/maven2/com/google/auto/value/auto-value-annotations/1.10.1/auto-value-annotations-1.10.1.pom
+https://repo.maven.apache.org/maven2/com/google/auto/value/auto-value-annotations/1.10.2/auto-value-annotations-1.10.2.pom
 https://repo.maven.apache.org/maven2/com/google/auto/value/auto-value-parent/1.6.2/auto-value-parent-1.6.2.pom
 https://repo.maven.apache.org/maven2/com/google/auto/value/auto-value-parent/1.6.3/auto-value-parent-1.6.3.pom
-https://repo.maven.apache.org/maven2/com/google/auto/value/auto-value-parent/1.10.1/auto-value-parent-1.10.1.pom
+https://repo.maven.apache.org/maven2/com/google/auto/value/auto-value-parent/1.10.2/auto-value-parent-1.10.2.pom
 https://repo.maven.apache.org/maven2/com/google/auto/value/auto-value/1.5.2/auto-value-1.5.2.pom
 https://repo.maven.apache.org/maven2/com/google/code/findbugs/jsr305/1.3.9/jsr305-1.3.9.pom
 https://repo.maven.apache.org/maven2/com/google/code/findbugs/jsr305/3.0.1/jsr305-3.0.1.pom
@@ -688,8 +688,8 @@ https://repo.maven.apache.org/maven2/com/google/guava/guava-parent/29.0-jre/guav
 https://repo.maven.apache.org/maven2/com/google/guava/guava-parent/30.1-android/guava-parent-30.1-android.pom
 https://repo.maven.apache.org/maven2/com/google/guava/guava-parent/30.1-jre/guava-parent-30.1-jre.pom
 https://repo.maven.apache.org/maven2/com/google/guava/guava-parent/31.0.1-jre/guava-parent-31.0.1-jre.pom
-https://repo.maven.apache.org/maven2/com/google/guava/guava-parent/32.0.1-jre/guava-parent-32.0.1-jre.pom
-https://repo.maven.apache.org/maven2/com/google/guava/guava-testlib/32.0.1-jre/guava-testlib-32.0.1-jre.pom
+https://repo.maven.apache.org/maven2/com/google/guava/guava-parent/32.1.1-jre/guava-parent-32.1.1-jre.pom
+https://repo.maven.apache.org/maven2/com/google/guava/guava-testlib/32.1.1-jre/guava-testlib-32.1.1-jre.pom
 https://repo.maven.apache.org/maven2/com/google/guava/guava/17.0/guava-17.0.pom
 https://repo.maven.apache.org/maven2/com/google/guava/guava/22.0/guava-22.0.pom
 https://repo.maven.apache.org/maven2/com/google/guava/guava/23.0/guava-23.0.pom
@@ -701,7 +701,7 @@ https://repo.maven.apache.org/maven2/com/google/guava/guava/29.0-jre/guava-29.0-
 https://repo.maven.apache.org/maven2/com/google/guava/guava/30.1-android/guava-30.1-android.pom
 https://repo.maven.apache.org/maven2/com/google/guava/guava/30.1-jre/guava-30.1-jre.pom
 https://repo.maven.apache.org/maven2/com/google/guava/guava/31.0.1-jre/guava-31.0.1-jre.pom
-https://repo.maven.apache.org/maven2/com/google/guava/guava/32.0.1-jre/guava-32.0.1-jre.pom
+https://repo.maven.apache.org/maven2/com/google/guava/guava/32.1.1-jre/guava-32.1.1-jre.pom
 https://repo.maven.apache.org/maven2/com/google/guava/listenablefuture/1.0/listenablefuture-1.0.pom
 https://repo.maven.apache.org/maven2/com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.pom
 https://repo.maven.apache.org/maven2/com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1.pom
@@ -750,12 +750,12 @@ https://repo.maven.apache.org/maven2/com/squareup/okhttp3/okhttp/3.12.1/okhttp-3
 https://repo.maven.apache.org/maven2/com/squareup/okhttp3/okhttp/4.9.2/okhttp-4.9.2.pom
 https://repo.maven.apache.org/maven2/com/squareup/okhttp3/parent/3.9.1/parent-3.9.1.pom
 https://repo.maven.apache.org/maven2/com/squareup/okhttp3/parent/3.12.1/parent-3.12.1.pom
-https://repo.maven.apache.org/maven2/com/squareup/okio/okio-jvm/3.3.0/okio-jvm-3.3.0.pom
+https://repo.maven.apache.org/maven2/com/squareup/okio/okio-jvm/3.4.0/okio-jvm-3.4.0.pom
 https://repo.maven.apache.org/maven2/com/squareup/okio/okio-parent/1.17.4/okio-parent-1.17.4.pom
 https://repo.maven.apache.org/maven2/com/squareup/okio/okio/1.17.4/okio-1.17.4.pom
 https://repo.maven.apache.org/maven2/com/squareup/okio/okio/2.8.0/okio-2.8.0.pom
 https://repo.maven.apache.org/maven2/com/squareup/okio/okio/2.9.0/okio-2.9.0.pom
-https://repo.maven.apache.org/maven2/com/squareup/okio/okio/3.3.0/okio-3.3.0.pom
+https://repo.maven.apache.org/maven2/com/squareup/okio/okio/3.4.0/okio-3.4.0.pom
 https://repo.maven.apache.org/maven2/com/sun/activation/all/1.2.0/all-1.2.0.pom
 https://repo.maven.apache.org/maven2/com/sun/activation/all/1.2.1/all-1.2.1.pom
 https://repo.maven.apache.org/maven2/com/sun/activation/all/1.2.2/all-1.2.2.pom
@@ -988,7 +988,7 @@ https://repo.maven.apache.org/maven2/org/checkerframework/checker-qual/2.8.1/che
 https://repo.maven.apache.org/maven2/org/checkerframework/checker-qual/2.11.1/checker-qual-2.11.1.pom
 https://repo.maven.apache.org/maven2/org/checkerframework/checker-qual/3.5.0/checker-qual-3.5.0.pom
 https://repo.maven.apache.org/maven2/org/checkerframework/checker-qual/3.12.0/checker-qual-3.12.0.pom
-https://repo.maven.apache.org/maven2/org/checkerframework/checker-qual/3.35.0/checker-qual-3.35.0.pom
+https://repo.maven.apache.org/maven2/org/checkerframework/checker-qual/3.36.0/checker-qual-3.36.0.pom
 https://repo.maven.apache.org/maven2/org/codehaus/codehaus-parent/4/codehaus-parent-4.pom
 https://repo.maven.apache.org/maven2/org/codehaus/groovy/groovy-xml/3.0.10/groovy-xml-3.0.10.pom
 https://repo.maven.apache.org/maven2/org/codehaus/groovy/groovy/3.0.9/groovy-3.0.9.pom
@@ -1103,7 +1103,7 @@ https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-reflect/1.4.32/
 https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-reflect/1.5.31/kotlin-reflect-1.5.31.pom
 https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-reflect/1.6.10/kotlin-reflect-1.6.10.pom
 https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-reflect/1.6.20/kotlin-reflect-1.6.20.pom
-https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-reflect/1.9.0-RC/kotlin-reflect-1.9.0-RC.pom
+https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-reflect/1.9.0/kotlin-reflect-1.9.0.pom
 https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-scripting-common/1.6.10/kotlin-scripting-common-1.6.10.pom
 https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-scripting-common/1.6.20/kotlin-scripting-common-1.6.20.pom
 https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-scripting-compiler-embeddable/1.6.10/kotlin-scripting-compiler-embeddable-1.6.10.pom
@@ -1133,7 +1133,7 @@ https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib-common/1
 https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib-common/1.6.20/kotlin-stdlib-common-1.6.20.pom
 https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib-common/1.6.21/kotlin-stdlib-common-1.6.21.pom
 https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib-common/1.8.0/kotlin-stdlib-common-1.8.0.pom
-https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib-common/1.9.0-RC/kotlin-stdlib-common-1.9.0-RC.pom
+https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib-common/1.9.0/kotlin-stdlib-common-1.9.0.pom
 https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib-jdk7/1.2.71/kotlin-stdlib-jdk7-1.2.71.pom
 https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib-jdk7/1.3.20/kotlin-stdlib-jdk7-1.3.20.pom
 https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib-jdk7/1.3.50/kotlin-stdlib-jdk7-1.3.50.pom
@@ -1180,7 +1180,7 @@ https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/1.6.10/k
 https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/1.6.20/kotlin-stdlib-1.6.20.pom
 https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/1.6.21/kotlin-stdlib-1.6.21.pom
 https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/1.8.0/kotlin-stdlib-1.8.0.pom
-https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/1.9.0-RC/kotlin-stdlib-1.9.0-RC.pom
+https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/1.9.0/kotlin-stdlib-1.9.0.pom
 https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-tooling-metadata/1.6.10/kotlin-tooling-metadata-1.6.10.pom
 https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-tooling-metadata/1.6.20/kotlin-tooling-metadata-1.6.20.pom
 https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-util-io/1.6.10/kotlin-util-io-1.6.10.pom
@@ -1194,7 +1194,7 @@ https://repo.maven.apache.org/maven2/org/json/json/20180813/json-20180813.pom
 https://repo.maven.apache.org/maven2/org/json/json/20230618/json-20230618.pom
 https://repo.maven.apache.org/maven2/org/jsoup/jsoup/1.13.1/jsoup-1.13.1.pom
 https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.9.2/junit-bom-5.9.2.pom
-https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.10.0-M1/junit-bom-5.10.0-M1.pom
+https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.10.0/junit-bom-5.10.0.pom
 https://repo.maven.apache.org/maven2/org/jvnet/staxex/stax-ex/1.7.7/stax-ex-1.7.7.pom
 https://repo.maven.apache.org/maven2/org/jvnet/staxex/stax-ex/1.8.1/stax-ex-1.8.1.pom
 https://repo.maven.apache.org/maven2/org/jvnet/staxex/stax-ex/1.8/stax-ex-1.8.pom

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "react-native-image-viewing": "git+https://github.com/status-im/react-native-image-viewing.git#refs/tags/v0.2.1.status",
     "react-native-keychain": "git+https://github.com/status-im/react-native-keychain.git#refs/tags/v.3.0.0-5-status",
     "react-native-languages": "^3.0.2",
-    "react-native-linear-gradient": "^2.5.6",
+    "react-native-linear-gradient": "^2.8.0",
     "react-native-lottie-splash-screen": "^1.0.1",
     "react-native-mail": "git+https://github.com/status-im/react-native-mail.git#refs/tags/v6.1.2-status",
     "react-native-navigation": "^7.27.1",

--- a/src/quo2/components/gradient/gradient_cover/component_spec.cljs
+++ b/src/quo2/components/gradient/gradient_cover/component_spec.cljs
@@ -1,0 +1,8 @@
+(ns quo2.components.gradient.gradient-cover.component-spec
+  (:require [quo2.components.gradient.gradient-cover.view :as gradient-cover]
+            [test-helpers.component :as h]))
+
+(h/describe "gradient cover"
+  (h/test "default render"
+    (h/render [gradient-cover/view])
+    (h/is-truthy (h/get-by-label-text :gradient-cover))))

--- a/src/quo2/components/gradient/gradient_cover/style.cljs
+++ b/src/quo2/components/gradient/gradient_cover/style.cljs
@@ -1,5 +1,4 @@
 (ns quo2.components.gradient.gradient-cover.style)
 
 (def root-container
-  {:flex   1
-   :height 252})
+  {:height 252})

--- a/src/quo2/components/gradient/gradient_cover/style.cljs
+++ b/src/quo2/components/gradient/gradient_cover/style.cljs
@@ -1,0 +1,5 @@
+(ns quo2.components.gradient.gradient-cover.style)
+
+(def root-container
+  {:flex   1
+   :height 252})

--- a/src/quo2/components/gradient/gradient_cover/view.cljs
+++ b/src/quo2/components/gradient/gradient_cover/view.cljs
@@ -1,0 +1,17 @@
+(ns quo2.components.gradient.gradient-cover.view
+  (:require [quo2.components.gradient.gradient-cover.style :as style]
+            [quo2.foundations.colors :as colors]
+            [quo2.theme :as quo.theme]
+            [react-native.linear-gradient :as linear-gradient]))
+
+(defn- view-internal
+  [{:keys [color] :or {color :blue}}]
+  (let [color-top    (colors/custom-color-by-theme color 50 50 20 20)
+        color-bottom (colors/custom-color-by-theme color 50 50 0 0)]
+    [linear-gradient/linear-gradient
+     {:colors [color-top color-bottom]
+      :start  {:x 0 :y 0}
+      :end    {:x 0 :y 1}
+      :style  style/root-container}]))
+
+(def view (quo.theme/with-theme view-internal))

--- a/src/quo2/components/gradient/gradient_cover/view.cljs
+++ b/src/quo2/components/gradient/gradient_cover/view.cljs
@@ -9,9 +9,10 @@
   (let [color-top    (colors/custom-color-by-theme color 50 50 20 20)
         color-bottom (colors/custom-color-by-theme color 50 50 0 0)]
     [linear-gradient/linear-gradient
-     {:colors [color-top color-bottom]
-      :start  {:x 0 :y 0}
-      :end    {:x 0 :y 1}
-      :style  style/root-container}]))
+     {:accessibility-label :gradient-cover
+      :colors              [color-top color-bottom]
+      :start               {:x 0 :y 0}
+      :end                 {:x 0 :y 1}
+      :style               style/root-container}]))
 
 (def view (quo.theme/with-theme view-internal))

--- a/src/quo2/components/gradient/gradient_cover/view.cljs
+++ b/src/quo2/components/gradient/gradient_cover/view.cljs
@@ -5,9 +5,9 @@
             [react-native.linear-gradient :as linear-gradient]))
 
 (defn- view-internal
-  [{:keys [color] :or {color :blue}}]
-  (let [color-top    (colors/custom-color-by-theme color 50 50 20 20)
-        color-bottom (colors/custom-color-by-theme color 50 50 0 0)]
+  [{:keys [customization-color] :or {customization-color :blue}}]
+  (let [color-top    (colors/custom-color customization-color 50 20)
+        color-bottom (colors/custom-color customization-color 50 0)]
     [linear-gradient/linear-gradient
      {:accessibility-label :gradient-cover
       :colors              [color-top color-bottom]

--- a/src/quo2/core.cljs
+++ b/src/quo2/core.cljs
@@ -38,6 +38,7 @@
     quo2.components.drawers.permission-context.view
     quo2.components.dropdowns.dropdown
     quo2.components.empty-state.empty-state.view
+    quo2.components.gradient.gradient-cover.view
     quo2.components.header
     quo2.components.icon
     quo2.components.info.info-message
@@ -281,3 +282,6 @@
 (def url-preview quo2.components.links.url-preview.view/view)
 (def url-preview-list quo2.components.links.url-preview-list.view/view)
 (def link-preview quo2.components.links.link-preview.view/view)
+
+;;;; GRADIENT
+(def gradient-cover quo2.components.gradient.gradient-cover.view/view)

--- a/src/quo2/core_spec.cljs
+++ b/src/quo2/core_spec.cljs
@@ -44,4 +44,5 @@
     [quo2.components.settings.settings-list.component-spec]
     [quo2.components.settings.category.component-spec]
     [quo2.components.share.share-qr-code.component-spec]
-    [quo2.components.tags.status-tags-component-spec]))
+    [quo2.components.tags.status-tags-component-spec]
+    [quo2.components.gradient.gradient-cover.component-spec]))

--- a/src/quo2/core_spec.cljs
+++ b/src/quo2/core_spec.cljs
@@ -19,6 +19,7 @@
     [quo2.components.drawers.documentation-drawers.component-spec]
     [quo2.components.drawers.drawer-buttons.component-spec]
     [quo2.components.drawers.permission-context.component-spec]
+    [quo2.components.gradient.gradient-cover.component-spec]
     [quo2.components.inputs.input.component-spec]
     [quo2.components.inputs.profile-input.component-spec]
     [quo2.components.inputs.recovery-phrase.component-spec]
@@ -44,5 +45,4 @@
     [quo2.components.settings.settings-list.component-spec]
     [quo2.components.settings.category.component-spec]
     [quo2.components.share.share-qr-code.component-spec]
-    [quo2.components.tags.status-tags-component-spec]
-    [quo2.components.gradient.gradient-cover.component-spec]))
+    [quo2.components.tags.status-tags-component-spec]))

--- a/src/status_im2/contexts/quo_preview/gradient/gradient_cover.cljs
+++ b/src/status_im2/contexts/quo_preview/gradient/gradient_cover.cljs
@@ -1,0 +1,76 @@
+(ns status-im2.contexts.quo-preview.gradient.gradient-cover
+  (:require [quo2.components.gradient.gradient-cover.view :as gradient-cover]
+            [quo2.core :as quo]
+            [quo2.foundations.colors :as colors]
+            [quo2.theme :as quo.theme]
+            [react-native.core :as rn]
+            [react-native.blur :as blur]
+            [reagent.core :as reagent]
+            [status-im2.contexts.quo-preview.preview :as preview]))
+
+(def descriptor
+  [{:label   "Color:"
+    :key     :color
+    :type    :select
+    :options (map (fn [color]
+                    (let [k (get color :name)]
+                      {:key k :value k}))
+                  (quo/picker-colors))}
+   {:label "Blur (dark only)?"
+    :key   :blur?
+    :type  :boolean}])
+
+(defn cool-preview
+  []
+  (let [state (reagent/atom {:color :blue :blur? false})
+        blur? (reagent/cursor state [:blur?])
+        color (reagent/cursor state [:color])]
+    [:f>
+     (fn []
+       (rn/use-effect (fn []
+                        (when @blur?
+                          (quo.theme/set-theme :dark)))
+                      [@blur?])
+       [:<>
+        [preview/customizer state descriptor]
+        [rn/view
+         {:style {:height        332
+                  :margin-top    24
+                  :overflow      :hidden
+                  :border-radius 12}}
+         (when @blur?
+           [rn/image
+            {:style {:height 332}
+             :source
+             {:uri
+              "https://4kwallpapers.com/images/wallpapers/giau-pass-mountain-pass-italy-dolomites-landscape-mountain-750x1334-4282.jpg"}}])
+         [(if @blur? blur/view rn/view)
+          {:style     {:height           332
+                       :position         :absolute
+                       :top              0
+                       :left             0
+                       :right            0
+                       :bottom           0
+                       :padding-vertical 40}
+           :blur-type :dark}
+          [gradient-cover/view @state]]]
+        [rn/view
+         {:style {:padding-vertical   20
+                  :padding-horizontal 16}}
+         [quo/color-picker
+          {:blur?     @blur?
+           :selected  @color
+           :on-change #(reset! color %)}]]])]))
+
+(defn preview-gradient-cover
+  []
+  [rn/view
+   {:background-color (colors/theme-colors
+                       colors/white
+                       colors/neutral-90)
+    :flex             1}
+   [rn/flat-list
+    {:flex                         1
+     :keyboard-should-persist-taps :always
+     :header                       [cool-preview]
+     :key-fn                       str}]])

--- a/src/status_im2/contexts/quo_preview/gradient/gradient_cover.cljs
+++ b/src/status_im2/contexts/quo_preview/gradient/gradient_cover.cljs
@@ -1,6 +1,6 @@
 (ns status-im2.contexts.quo-preview.gradient.gradient-cover
-  (:require [quo2.components.gradient.gradient-cover.view :as gradient-cover]
-            [quo2.core :as quo]
+  (:require [quo2.components.colors.color-picker.view :as color-picker]
+            [quo2.components.gradient.gradient-cover.view :as gradient-cover]
             [quo2.foundations.colors :as colors]
             [quo2.theme :as quo.theme]
             [react-native.core :as rn]
@@ -12,10 +12,9 @@
   [{:label   "Color:"
     :key     :color
     :type    :select
-    :options (map (fn [color]
-                    (let [k (get color :name)]
-                      {:key k :value k}))
-                  (quo/picker-colors))}
+    :options (mapv (fn [color]
+                     {:key color :value color})
+                   color-picker/color-list)}
    {:label "Blur (dark only)?"
     :key   :blur?
     :type  :boolean}])
@@ -57,7 +56,7 @@
         [rn/view
          {:style {:padding-vertical   20
                   :padding-horizontal 16}}
-         [quo/color-picker
+         [color-picker/view
           {:blur?     @blur?
            :selected  @color
            :on-change #(reset! color %)}]]])]))

--- a/src/status_im2/contexts/quo_preview/gradient/gradient_cover.cljs
+++ b/src/status_im2/contexts/quo_preview/gradient/gradient_cover.cljs
@@ -3,14 +3,14 @@
             [quo2.components.gradient.gradient-cover.view :as gradient-cover]
             [quo2.foundations.colors :as colors]
             [quo2.theme :as quo.theme]
-            [react-native.core :as rn]
             [react-native.blur :as blur]
+            [react-native.core :as rn]
             [reagent.core :as reagent]
             [status-im2.contexts.quo-preview.preview :as preview]))
 
 (def descriptor
-  [{:label   "Color:"
-    :key     :color
+  [{:label   "Customization color:"
+    :key     :customization-color
     :type    :select
     :options (mapv (fn [color]
                      {:key color :value color})
@@ -21,9 +21,9 @@
 
 (defn cool-preview
   []
-  (let [state (reagent/atom {:color :blue :blur? false})
-        blur? (reagent/cursor state [:blur?])
-        color (reagent/cursor state [:color])]
+  (let [state               (reagent/atom {:customization-color :blue :blur? false})
+        blur?               (reagent/cursor state [:blur?])
+        customization-color (reagent/cursor state [:customization-color])]
     [:f>
      (fn []
        (rn/use-effect (fn []
@@ -58,8 +58,8 @@
                   :padding-horizontal 16}}
          [color-picker/view
           {:blur?     @blur?
-           :selected  @color
-           :on-change #(reset! color %)}]]])]))
+           :selected  @customization-color
+           :on-change #(reset! customization-color %)}]]])]))
 
 (defn preview-gradient-cover
   []

--- a/src/status_im2/contexts/quo_preview/gradient/gradient_cover.cljs
+++ b/src/status_im2/contexts/quo_preview/gradient/gradient_cover.cljs
@@ -6,8 +6,8 @@
             [react-native.blur :as blur]
             [react-native.core :as rn]
             [reagent.core :as reagent]
-            [status-im2.contexts.quo-preview.preview :as preview]
-            [status-im2.common.resources :as resources]))
+            [status-im2.common.resources :as resources]
+            [status-im2.contexts.quo-preview.preview :as preview]))
 
 (def descriptor
   [{:label   "Customization color:"
@@ -41,7 +41,7 @@
          (when @blur?
            [rn/image
             {:style  {:height 332}
-             :source {:uri (resources/get-mock-image :dark-blur-bg)}}])
+             :source (resources/get-mock-image :dark-blur-bg)}])
          [(if @blur? blur/view rn/view)
           {:style     {:height           332
                        :position         :absolute

--- a/src/status_im2/contexts/quo_preview/gradient/gradient_cover.cljs
+++ b/src/status_im2/contexts/quo_preview/gradient/gradient_cover.cljs
@@ -6,7 +6,8 @@
             [react-native.blur :as blur]
             [react-native.core :as rn]
             [reagent.core :as reagent]
-            [status-im2.contexts.quo-preview.preview :as preview]))
+            [status-im2.contexts.quo-preview.preview :as preview]
+            [status-im2.common.resources :as resources]))
 
 (def descriptor
   [{:label   "Customization color:"
@@ -39,10 +40,8 @@
                   :border-radius 12}}
          (when @blur?
            [rn/image
-            {:style {:height 332}
-             :source
-             {:uri
-              "https://4kwallpapers.com/images/wallpapers/giau-pass-mountain-pass-italy-dolomites-landscape-mountain-750x1334-4282.jpg"}}])
+            {:style  {:height 332}
+             :source {:uri (resources/get-mock-image :dark-blur-bg)}}])
          [(if @blur? blur/view rn/view)
           {:style     {:height           332
                        :position         :absolute

--- a/src/status_im2/contexts/quo_preview/main.cljs
+++ b/src/status_im2/contexts/quo_preview/main.cljs
@@ -103,7 +103,8 @@
     [status-im2.contexts.quo-preview.wallet.token-overview :as token-overview]
     [status-im2.contexts.quo-preview.keycard.keycard :as keycard]
     [status-im2.contexts.quo-preview.loaders.skeleton :as skeleton]
-    [status-im2.contexts.quo-preview.community.channel-actions :as channel-actions]))
+    [status-im2.contexts.quo-preview.community.channel-actions :as channel-actions]
+    [status-im2.contexts.quo-preview.gradient.gradient-cover :as gradient-cover]))
 
 (def screens-categories
   {:foundations       [{:name      :shadows
@@ -216,6 +217,9 @@
    :empty-state       [{:name      :empty-state
                         :options   {:topBar {:visible true}}
                         :component empty-state/preview-empty-state}]
+   :gradient          [{:name      :gradient-cover
+                        :options   {:topBar {:visible true}}
+                        :component gradient-cover/preview-gradient-cover}]
    :info              [{:name      :info-message
                         :options   {:topBar {:visible true}}
                         :component info-message/preview-info-message}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8885,10 +8885,10 @@ react-native-languages@^3.0.2:
   resolved "https://registry.yarnpkg.com/react-native-languages/-/react-native-languages-3.0.2.tgz#c2c4c5050974fe4b50f7372051ca1f9824c1c778"
   integrity sha512-LGsTfixFM6hXDhcFJI6mrtrNBsGPSvXT9RtZQ0tlqmGFKmMyZW6eQgJ7kLw8lISD2FIGl4jJwY06EAJpbMsNxg==
 
-react-native-linear-gradient@^2.5.6:
-  version "2.5.6"
-  resolved "https://registry.yarnpkg.com/react-native-linear-gradient/-/react-native-linear-gradient-2.5.6.tgz#96215cbc5ec7a01247a20890888aa75b834d44a0"
-  integrity sha512-HDwEaXcQIuXXCV70O+bK1rizFong3wj+5Q/jSyifKFLg0VWF95xh8XQgfzXwtq0NggL9vNjPKXa016KuFu+VFg==
+react-native-linear-gradient@^2.8.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/react-native-linear-gradient/-/react-native-linear-gradient-2.8.0.tgz#767eda0a5c5dbed852f99e4c07fb7d54a8ee3030"
+  integrity sha512-ZuvNXEB98CMEOAphV/8N9eWrIQTbzUIZD5Tb8IqFoDE8ESERISPT2hTZMvoHTSfjvaB1zge6YpWVg3rpwiTZow==
 
 react-native-lottie-splash-screen@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
fixes #16607

### Summary

This PR implements the `gradient cover` component which is needed for wallet screen development.

### Design

[Link to Figma](https://www.figma.com/file/WQZcp6S0EnzxdTL4taoKDv/Design-System-for-Mobile?type=design&node-id=19749-198078&mode=design&t=clczHMbxGIjtUkcH-0)

### Platforms

- Android
- iOS

### Steps to test

- Open Status
- Navigate to `Quo2 Preview > gradient > gradient cover`

status: ready
