### PR TITLE
Add support for discovering local pairing peers

### DIFF
--- a/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusModule.java
+++ b/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusModule.java
@@ -824,6 +824,11 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
     }
 
     @ReactMethod
+    public void startSearchForLocalPairingPeers(final Callback callback) throws JSONException {
+        executeRunnableStatusGoMethod(() -> Statusgo.startSearchForLocalPairingPeers(), callback);
+    }
+
+    @ReactMethod
     public void getConnectionStringForBootstrappingAnotherDevice(final String configJSON, final Callback callback) throws JSONException {
          final JSONObject jsonConfig = new JSONObject(configJSON);
          final JSONObject senderConfig = jsonConfig.getJSONObject("senderConfig");
@@ -1172,19 +1177,19 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
         executeRunnableStatusGoMethod(() -> Statusgo.deleteImportedKey(address, password, keyStoreDir), callback);
     }
 
-    @ReactMethod(isBlockingSynchronousMethod = true) 
+    @ReactMethod(isBlockingSynchronousMethod = true)
     public String keystoreDir() {
         final String absRootDirPath = this.getNoBackupDirectory();
         return pathCombine(absRootDirPath, "keystore");
     }
 
-    @ReactMethod(isBlockingSynchronousMethod = true) 
+    @ReactMethod(isBlockingSynchronousMethod = true)
     public String backupDisabledDataDir() {
         return this.getNoBackupDirectory();
     }
 
 
-    @ReactMethod(isBlockingSynchronousMethod = true) 
+    @ReactMethod(isBlockingSynchronousMethod = true)
     public String logFileDirectory() {
         return getPublicStorageDirectory().getAbsolutePath();
     }

--- a/modules/react-native-status/ios/RCTStatus/RCTStatus.m
+++ b/modules/react-native-status/ios/RCTStatus/RCTStatus.m
@@ -312,6 +312,11 @@ RCT_EXPORT_METHOD(localPairingPreflightOutboundCheck:(RCTResponseSenderBlock)cal
     callback(@[result]);
 }
 
+RCT_EXPORT_METHOD(startSearchForLocalPairingPeers:callback:(RCTResponseSenderBlock)callback) {
+    NSString *result = StatusgoStartSearchForLocalPairingPeers();
+    callback(@[result]);
+}
+
 RCT_EXPORT_METHOD(getConnectionStringForBootstrappingAnotherDevice:(NSString *)configJSON
                   callback:(RCTResponseSenderBlock)callback) {
 

--- a/src/native_module/core.cljs
+++ b/src/native_module/core.cljs
@@ -258,6 +258,13 @@
   (log/debug "[native-module] hash-message")
   (.hashMessage ^js (status) message callback))
 
+(defn start-searching-for-local-pairing-peers
+  "starts a UDP multicast beacon that both listens for and broadcasts to LAN peers"
+  [callback]
+  (log/info "[native-module] Start Searching for Local Pairing Peers"
+            {:fn :start-searching-for-local-pairing-peers})
+  (.startSearchForLocalPairingPeers ^js (status) callback))
+
 (defn local-pairing-preflight-outbound-check
   "Checks whether the device has allows connecting to the local server"
   [callback]

--- a/src/status_im/utils/universal_links/core.cljs
+++ b/src/status_im/utils/universal_links/core.cljs
@@ -210,7 +210,9 @@
   (js/setTimeout #(-> (.getInitialURL ^js react/linking)
                       (.then dispatch-url))
                  200)
-  (.addEventListener ^js react/linking "url" url-event-listener))
+  (.addEventListener ^js react/linking "url" url-event-listener)
+  (native-module/start-searching-for-local-pairing-peers
+   #(log/info "[local-pairing] errors from local-pairing-preflight-outbound-check ->" %)))
 
 (defn finalize
   "Remove event listener for url"


### PR DESCRIPTION
### Summary
This PR initialises the status-go method `startSearchForLocalPairingPeers` which in turn will produce logs that are important for peer discovery while local pairing and will produce logs important to detect local pairing crashes.

#### Platforms
- Android
- iOS

##### Functional
- Syncing

### Steps to test
This PR does not require any testing.

status: ready
