### PR TITLE
[WIP][16457] Messages containing Giphy and Tenor are not delivered to User B

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.162.14",
-    "commit-sha1": "60143556ff942e24f4641dc741049e8ad4fef619",
-    "src-sha256": "0b8rk8v9fmsf36611c3frzdgq6y09pzy83h4zbz50fccphzrcxcf"
+    "version": "status-mobile-16457",
+    "commit-sha1": "244742ecf3baf112efe2c4411081e2f0afcbac89",
+    "src-sha256": "0l7b3c34snxnlv7ddgvsln4m5z2m48dcdp84hnj5ynmqgvcmjnpc"
 }


### PR DESCRIPTION
fixes #16457 

### Summary

Messages containing giphy or tenor URLs didn't get successfully delivered, It was caused by not matched property naming between JSON and the the defined ones.

And unfortunately, Tenor unfurling won't work at the moment as it returns an iFrame and not an image URI but message will be sent

##### Functional

- 1-1 chats
- public chats
- group chats

status: ready
