### PR TITLE
16709 chat home banner animation

### DIFF
--- a/src/react_native/section_list.cljs
+++ b/src/react_native/section_list.cljs
@@ -32,7 +32,7 @@
 
 (defn section-list
   "A wrapper for SectionList.
-   To render something on empty sections, use renderSectionFooter and conditionaly
+   To render something on empty sections, use renderSectionFooter and conditionally
    render on empty data
    See https://facebook.github.io/react-native/docs/sectionlist.html"
   [{:keys [sections render-section-header-fn render-section-footer-fn style] :as props}]

--- a/src/status_im2/common/home/banner/style.cljs
+++ b/src/status_im2/common/home/banner/style.cljs
@@ -1,0 +1,63 @@
+(ns status-im2.common.home.banner.style
+  (:require [react-native.platform :as platform]
+            [react-native.reanimated :as reanimated]
+            [react-native.safe-area :as safe-area]))
+
+(def ^:private card-height (+ 56 16))
+(def ^:private max-scroll (+ card-height 8))
+
+(def fill-space
+  {:position :absolute
+   :top      0
+   :right    0
+   :left     0
+   :bottom   0})
+
+(defn- animated-card-translation-y
+  [scroll-shared-value]
+  (reanimated/interpolate scroll-shared-value [0 max-scroll] [0 (- max-scroll)] :clamp))
+
+(defn banner-card-blur-layer
+  [scroll-shared-value]
+  (reanimated/apply-animations-to-style
+   {:transform [{:translate-y (animated-card-translation-y scroll-shared-value)}]}
+   {:overflow (if platform/ios? :visible :hidden)
+    :z-index  1
+    :position :absolute
+    :top      0
+    :right    0
+    :left     0
+    :height   (+ (safe-area/get-top) 244)}))
+
+(defn banner-card-hiding-layer
+  []
+  {:z-index     2
+   :position    :absolute
+   :top         0
+   :right       0
+   :left        0
+   :padding-top (safe-area/get-top)})
+
+(def animated-banner-card-container {:overflow :hidden})
+
+(defn animated-banner-card
+  [scroll-shared-value]
+  (reanimated/apply-animations-to-style
+   {:opacity   (reanimated/interpolate scroll-shared-value [0 card-height] [1 0] :clamp)
+    :transform [{:translate-y (animated-card-translation-y scroll-shared-value)}]}
+   {}))
+
+(defn banner-card-tabs-layer
+  [scroll-shared-value]
+  (reanimated/apply-animations-to-style
+   {:transform [{:translate-y (animated-card-translation-y scroll-shared-value)}]}
+   {:z-index  3
+    :position :absolute
+    :top      (+ (safe-area/get-top) 192)
+    :right    0
+    :left     0}))
+
+(def banner-card-tabs
+  {:padding-horizontal 20
+   :padding-top        8
+   :padding-bottom     12})

--- a/src/status_im2/common/home/banner/view.cljs
+++ b/src/status_im2/common/home/banner/view.cljs
@@ -9,33 +9,7 @@
             [react-native.reanimated :as reanimated]
             [status-im2.common.home.banner.style :as style]
             [status-im2.common.home.view :as common.home]
-            [status-im2.common.resources :as resources]
-            [status-im2.contexts.chat.actions.view :as home.sheet]
-            [status-im2.contexts.communities.actions.home-plus.view :as actions.home-plus]
-            [utils.i18n :as i18n]
             [utils.re-frame :as rf]))
-
-(def ^:private banner-content
-  {:communities
-   {:title-props
-    {:label               (i18n/label :t/communities)
-     :handler             #(rf/dispatch [:show-bottom-sheet {:content actions.home-plus/view}])
-     :accessibility-label :new-communities-button}
-    :card-props
-    {:on-press            #(rf/dispatch [:navigate-to :discover-communities])
-     :title               (i18n/label :t/discover)
-     :description         (i18n/label :t/favorite-communities)
-     :banner              (resources/get-image :discover)
-     :accessibility-label :communities-home-discover-card}}
-   :chats
-   {:title-props
-    {:label               (i18n/label :t/messages)
-     :handler             #(rf/dispatch [:show-bottom-sheet {:content home.sheet/new-chat}])
-     :accessibility-label :new-chat-button}
-    :card-props
-    {:banner      (resources/get-image :invite-friends)
-     :title       (i18n/label :t/invite-friends-to-status)
-     :description (i18n/label :t/share-invite-link)}}})
 
 (defn- reset-banner-animation
   [scroll-shared-value]
@@ -45,11 +19,9 @@
   [scroll-ref]
   (cond
     (.-scrollToLocation scroll-ref)
-    (oops/ocall! scroll-ref "scrollToLocation" #js{:itemIndex    0
-                                                   :sectionIndex 0
-                                                   :viewOffset   0})
+    (oops/ocall! scroll-ref "scrollToLocation" #js {:itemIndex 0 :sectionIndex 0 :viewOffset 0})
     (.-scrollToOffset scroll-ref)
-    (oops/ocall! scroll-ref "scrollToOffset" #js{:offset 0})))
+    (oops/ocall! scroll-ref "scrollToOffset" #js {:offset 0})))
 
 (defn- banner-card-blur-layer
   [scroll-shared-value]
@@ -84,15 +56,16 @@
      :data           tabs
      :on-change      (fn [tab]
                        (reset-banner-animation scroll-shared-value)
-                       (some-> scroll-ref deref reset-scroll)
+                       (some-> scroll-ref
+                               deref
+                               reset-scroll)
                        (on-tab-change tab))}]])
 
 (defn animated-banner
   [{:keys [scroll-ref tabs selected-tab on-tab-change scroll-shared-value content]}]
   [:<>
    [:f> banner-card-blur-layer scroll-shared-value]
-   [:f> banner-card-hiding-layer
-    (assoc (banner-content content) :scroll-shared-value scroll-shared-value)]
+   [:f> banner-card-hiding-layer (assoc content :scroll-shared-value scroll-shared-value)]
    [:f> banner-card-tabs-layer
     {:scroll-shared-value scroll-shared-value
      :selected-tab        selected-tab

--- a/src/status_im2/common/home/banner/view.cljs
+++ b/src/status_im2/common/home/banner/view.cljs
@@ -1,0 +1,100 @@
+(ns status-im2.common.home.banner.view
+  (:require [quo2.core :as quo]
+            [quo2.foundations.colors :as colors]
+            [quo2.theme :as theme]
+            [react-native.blur :as blur]
+            [react-native.core :as rn]
+            [react-native.platform :as platform]
+            [react-native.reanimated :as reanimated]
+            [status-im2.common.home.banner.style :as style]
+            [status-im2.common.home.view :as common.home]
+            [status-im2.common.resources :as resources]
+            [status-im2.contexts.chat.actions.view :as home.sheet]
+            [status-im2.contexts.communities.actions.home-plus.view :as actions.home-plus]
+            [utils.i18n :as i18n]
+            [utils.re-frame :as rf]))
+
+(def ^:private banner-content
+  {:communities
+   {:title-props
+    {:label               (i18n/label :t/communities)
+     :handler             #(rf/dispatch [:show-bottom-sheet {:content actions.home-plus/view}])
+     :accessibility-label :new-communities-button}
+    :card-props
+    {:on-press            #(rf/dispatch [:navigate-to :discover-communities])
+     :title               (i18n/label :t/discover)
+     :description         (i18n/label :t/favorite-communities)
+     :banner              (resources/get-image :discover)
+     :accessibility-label :communities-home-discover-card}}
+   :chats
+   {:title-props
+    {:label               (i18n/label :t/messages)
+     :handler             #(rf/dispatch [:show-bottom-sheet {:content home.sheet/new-chat}])
+     :accessibility-label :new-chat-button}
+    :card-props
+    {:banner      (resources/get-image :invite-friends)
+     :title       (i18n/label :t/invite-friends-to-status)
+     :description (i18n/label :t/share-invite-link)}}})
+
+(defn- reset-banner-animation
+  [scroll-shared-value]
+  (reanimated/animate-shared-value-with-timing scroll-shared-value 0 200 :easing3))
+
+(defn- reset-scroll
+  [flat-list-ref]
+  (some-> flat-list-ref
+          (.scrollToOffset #js {:offset 0 :animated? true})))
+
+(defn- banner-card-blur-layer
+  [scroll-shared-value]
+  (let [open-sheet? (-> (rf/sub [:bottom-sheet]) :sheets seq)]
+    [reanimated/view {:style (style/banner-card-blur-layer scroll-shared-value)}
+     [blur/view
+      {:style         style/fill-space
+       :blur-amount   (if platform/ios? 20 10)
+       :blur-type     (theme/theme-value (if platform/ios? :light :xlight) :dark)
+       :overlay-color (if open-sheet?
+                        (colors/theme-colors colors/white colors/neutral-95-opa-70)
+                        (theme/theme-value nil colors/neutral-95-opa-70))}]]))
+
+(defn- banner-card-hiding-layer
+  [{:keys [title-props card-props scroll-shared-value]}]
+  (let [customization-color (rf/sub [:profile/customization-color])]
+    [rn/view {:style (style/banner-card-hiding-layer)}
+     [common.home/top-nav {:type :grey}]
+     [common.home/title-column (assoc title-props :customization-color customization-color)]
+     [rn/view {:style style/animated-banner-card-container}
+      [reanimated/view {:style (style/animated-banner-card scroll-shared-value)}
+       [quo/discover-card card-props]]]]))
+
+(defn- banner-card-tabs-layer
+  [{:keys [selected-tab tabs on-tab-change-event flat-list-ref scroll-shared-value]}]
+  [reanimated/view {:style (style/banner-card-tabs-layer scroll-shared-value)}
+   ^{:key (str "tabs-" selected-tab)}
+   [quo/tabs
+    {:style          style/banner-card-tabs
+     :size           32
+     :default-active selected-tab
+     :data           tabs
+     :on-change      (fn [tab]
+                       (if (empty? (get (rf/sub [:communities/grouped-by-status]) tab))
+                         (reset-banner-animation scroll-shared-value)
+                         (reset-scroll @flat-list-ref))
+                       (on-tab-change-event tab))}]])
+
+(defn animated-banner
+  [{:keys [flat-list-ref tabs selected-tab on-tab-change-event scroll-shared-value content]}]
+  [:<>
+   [:f> banner-card-blur-layer scroll-shared-value]
+   [:f> banner-card-hiding-layer
+    (assoc (banner-content content) :scroll-shared-value scroll-shared-value)]
+   [:f> banner-card-tabs-layer
+    {:scroll-shared-value scroll-shared-value
+     :selected-tab        selected-tab
+     :tabs                tabs
+     :on-tab-change-event on-tab-change-event
+     :flat-list-ref       flat-list-ref}]])
+
+(defn set-scroll-shared-value
+  [{:keys [shared-value scroll-input]}]
+  (reanimated/animate-shared-value-with-timing shared-value scroll-input 80 :easing4))

--- a/src/status_im2/common/home/banner/view.cljs
+++ b/src/status_im2/common/home/banner/view.cljs
@@ -97,4 +97,4 @@
 
 (defn set-scroll-shared-value
   [{:keys [shared-value scroll-input]}]
-  (reanimated/animate-shared-value-with-timing shared-value scroll-input 80 :easing4))
+  (reanimated/set-shared-value shared-value scroll-input))

--- a/src/status_im2/common/home/style.cljs
+++ b/src/status_im2/common/home/style.cljs
@@ -1,4 +1,5 @@
-(ns status-im2.common.home.style)
+(ns status-im2.common.home.style
+  (:require [react-native.safe-area :as safe-area]))
 
 (def title-column
   {:flex-direction     :row
@@ -44,3 +45,16 @@
 
 (def top-nav-container
   {:height 56})
+
+(def header-height 245)
+
+(defn header-spacing
+  []
+  {:height (+ header-height (safe-area/get-top))})
+
+(defn empty-state-container
+  []
+  {:flex            1
+   :margin-top      (+ header-height (safe-area/get-top))
+   :margin-bottom   44
+   :justify-content :center})

--- a/src/status_im2/common/home/view.cljs
+++ b/src/status_im2/common/home/view.cljs
@@ -3,12 +3,12 @@
     [quo2.core :as quo]
     [quo2.foundations.colors :as colors]
     [react-native.core :as rn]
-    [status-im2.common.home.style :as style]
     [status-im.multiaccounts.core :as multiaccounts]
+    [status-im2.common.home.style :as style]
     [status-im2.common.plus-button.view :as plus-button]
     [status-im2.constants :as constants]
-    [utils.re-frame :as rf]
-    [utils.debounce :refer [dispatch-and-chill]]))
+    [utils.debounce :refer [dispatch-and-chill]]
+    [utils.re-frame :as rf]))
 
 (defn title-column
   [{:keys [label handler accessibility-label customization-color]}]
@@ -130,3 +130,18 @@
     [rn/view {:style (merge style/top-nav-container style)}
      [left-section {:avatar avatar}]
      [right-section {:button-type type :button-background background :search? search?}]]))
+
+(defn header-spacing
+  []
+  [rn/view {:style (style/header-spacing)}])
+
+(defn empty-state-image
+  [{:keys [selected-tab tab->content]}]
+  (let [{:keys [image title description]} (tab->content selected-tab)
+        customization-color               (rf/sub [:profile/customization-color])]
+    [rn/view {:style (style/empty-state-container)}
+     [quo/empty-state
+      {:customization-color customization-color
+       :image               image
+       :title               title
+       :description         description}]]))

--- a/src/status_im2/contexts/chat/home/style.cljs
+++ b/src/status_im2/contexts/chat/home/style.cljs
@@ -1,5 +1,6 @@
 (ns status-im2.contexts.chat.home.style
-  (:require [react-native.platform :as platform]))
+  (:require [react-native.platform :as platform]
+            [react-native.safe-area :as safe-area]))
 
 (def tabs
   {:padding-horizontal 20
@@ -14,24 +15,11 @@
    :bottom   0})
 
 (defn blur-container
-  [top]
+  []
   {:overflow    (if platform/ios? :visible :hidden)
    :position    :absolute
    :z-index     1
    :top         0
    :right       0
    :left        0
-   :padding-top top})
-
-(def header-height 245)
-
-(defn header-space
-  [top]
-  {:height (+ header-height top)})
-
-(defn empty-content-container
-  [top]
-  {:flex            1
-   :margin-top      (+ header-height top)
-   :margin-bottom   44
-   :justify-content :center})
+   :padding-top (safe-area/get-top)})

--- a/src/status_im2/contexts/chat/home/view.cljs
+++ b/src/status_im2/contexts/chat/home/view.cljs
@@ -46,13 +46,13 @@
 (defn chats
   [{:keys [selected-tab flat-list-ref scroll-shared-value]}]
   (let [unfiltered-items (rf/sub [:chats-stack-items])
-        items            (filter-and-sort-items-by-tab selected-tab unfiltered-items)]
+        items            (take 15 (cycle (filter-and-sort-items-by-tab selected-tab unfiltered-items)))]
     (if (empty? items)
       [common.home/empty-state-image
        {:selected-tab selected-tab
         :tab->content empty-state-content}]
-      [rn/flat-list
-       {:flat-list-ref                     #(reset! flat-list-ref %)
+      [reanimated/flat-list
+       {:ref                               #(reset! flat-list-ref %)
         :key-fn                            #(or (:chat-id %) (:public-key %) (:id %))
         :content-inset-adjustment-behavior :never
         :header                            [common.home/header-spacing]
@@ -61,6 +61,7 @@
         :keyboard-should-persist-taps      :always
         :data                              items
         :render-fn                         chat-list-item/chat-list-item
+        :scroll-event-throttle             8
         :on-scroll                         #(common.home.banner/set-scroll-shared-value
                                              {:scroll-input (oops/oget % "nativeEvent.contentOffset.y")
                                               :shared-value scroll-shared-value})}])))
@@ -80,13 +81,13 @@
 
 (defn contacts
   [{:keys [pending-contact-requests flat-list-ref scroll-shared-value]}]
-  (let [items (rf/sub [:contacts/active-sections])]
+  (let [items (take 15 (cycle (rf/sub [:contacts/active-sections])))]
     (if (and (empty? items) (empty? pending-contact-requests))
       [common.home/empty-state-image
        {:selected-tab :tab/contacts
         :tab->content empty-state-content}]
       [rn/section-list
-       {:flat-list-ref                     #(reset! flat-list-ref %)
+       {:ref                               #(reset! flat-list-ref %)
         :key-fn                            :public-key
         :get-item-layout                   get-item-layout
         :content-inset-adjustment-behavior :never
@@ -99,6 +100,7 @@
         :sticky-section-headers-enabled    false
         :render-section-header-fn          contact-list/contacts-section-header
         :render-fn                         contact-item-render
+        :scroll-event-throttle             8
         :on-scroll                         #(common.home.banner/set-scroll-shared-value
                                              {:scroll-input (oops/oget % "nativeEvent.contentOffset.y")
                                               :shared-value scroll-shared-value})}])))

--- a/src/status_im2/contexts/chat/home/view.cljs
+++ b/src/status_im2/contexts/chat/home/view.cljs
@@ -30,34 +30,22 @@
          (filter k)
          (sort-by :timestamp >))))
 
-(defn empty-state-content
-  [selected-tab]
-  (case selected-tab
-    :tab/contacts
-    {:title       (i18n/label :t/no-contacts)
-     :description (i18n/label :t/no-contacts-description)
-     :image       (resources/get-image
-                   (theme/theme-value :no-contacts-light :no-contacts-dark))}
-    :tab/groups
-    {:title       (i18n/label :t/no-group-chats)
-     :description (i18n/label :t/no-group-chats-description)
-     :image       (resources/get-image
-                   (theme/theme-value :no-group-chats-light :no-group-chats-dark))}
-    :tab/recent
-    {:title       (i18n/label :t/no-messages)
-     :description (i18n/label :t/no-messages-description)
-     :image       (resources/get-image
-                   (theme/theme-value :no-messages-light :no-messages-dark))}
-    nil))
-
-(defn empty-state
-  [{:keys [selected-tab top]}]
-  (let [{:keys [image title description]} (empty-state-content selected-tab)]
-    [rn/view {:style (style/empty-content-container top)}
-     [quo/empty-state
-      {:image       image
-       :title       title
-       :description description}]]))
+(def empty-state-content
+  #:tab{:contacts
+        {:title       (i18n/label :t/no-contacts)
+         :description (i18n/label :t/no-contacts-description)
+         :image       (resources/get-image
+                       (theme/theme-value :no-contacts-light :no-contacts-dark))}
+        :groups
+        {:title       (i18n/label :t/no-group-chats)
+         :description (i18n/label :t/no-group-chats-description)
+         :image       (resources/get-image
+                       (theme/theme-value :no-group-chats-light :no-group-chats-dark))}
+        :recent
+        {:title       (i18n/label :t/no-messages)
+         :description (i18n/label :t/no-messages-description)
+         :image       (resources/get-image
+                       (theme/theme-value :no-messages-light :no-messages-dark))}})
 
 (defn chats
   [selected-tab top]
@@ -92,13 +80,15 @@
   [pending-contact-requests top]
   (let [items (rf/sub [:contacts/active-sections])]
     (if (and (empty? items) (empty? pending-contact-requests))
-      [empty-state {:top top :selected-tab :tab/contacts}]
+      [common.home/empty-state-image
+       {:selected-tab :tab/contacts
+        :tab->content empty-state-content}]
       [rn/section-list
        {:key-fn                            :public-key
         :get-item-layout                   get-item-layout
         :content-inset-adjustment-behavior :never
         :header                            [:<>
-                                            [rn/view {:style (style/header-space top)}]
+                                            [common.home/header-spacing]
                                             (when (seq pending-contact-requests)
                                               [contact-request/contact-requests
                                                pending-contact-requests])]

--- a/src/status_im2/contexts/chat/home/view.cljs
+++ b/src/status_im2/contexts/chat/home/view.cljs
@@ -10,6 +10,7 @@
             [status-im2.common.home.banner.view :as common.home.banner]
             [status-im2.common.home.view :as common.home]
             [status-im2.common.resources :as resources]
+            [status-im2.contexts.chat.actions.view :as chat.actions.view]
             [status-im2.contexts.chat.home.chat-list-item.view :as chat-list-item]
             [status-im2.contexts.chat.home.contact-request.view :as contact-request]
             [utils.i18n :as i18n]
@@ -46,7 +47,7 @@
 (defn chats
   [{:keys [selected-tab set-scroll-ref scroll-shared-value]}]
   (let [unfiltered-items (rf/sub [:chats-stack-items])
-        items            (take 15 (cycle (filter-and-sort-items-by-tab selected-tab unfiltered-items)))]
+        items            (filter-and-sort-items-by-tab selected-tab unfiltered-items)]
     (if (empty? items)
       [common.home/empty-state-image
        {:selected-tab selected-tab
@@ -81,7 +82,7 @@
 
 (defn contacts
   [{:keys [pending-contact-requests set-scroll-ref scroll-shared-value]}]
-  (let [items (take 15 (cycle (rf/sub [:contacts/active-sections])))]
+  (let [items (rf/sub [:contacts/active-sections])]
     (if (and (empty? items) (empty? pending-contact-requests))
       [common.home/empty-state-image
        {:selected-tab :tab/contacts
@@ -114,6 +115,17 @@
     :accessibility-label :tab-contacts
     :notification-dot?   dot?}])
 
+(def ^:private banner-data
+  {:title-props
+   {:label               (i18n/label :t/messages)
+    :handler             #(rf/dispatch
+                           [:show-bottom-sheet {:content chat.actions.view/new-chat}])
+    :accessibility-label :new-chat-button}
+   :card-props
+   {:banner      (resources/get-image :invite-friends)
+    :title       (i18n/label :t/invite-friends-to-status)
+    :description (i18n/label :t/share-invite-link)}})
+
 (defn home
   []
   (let [scroll-ref     (atom nil)
@@ -133,7 +145,7 @@
              :set-scroll-ref      set-scroll-ref
              :scroll-shared-value scroll-shared-value}])
          [:f> common.home.banner/animated-banner
-          {:content             :chats
+          {:content             banner-data
            :scroll-ref          scroll-ref
            :tabs                (get-tabs-data (pos? (count pending-contact-requests)))
            :selected-tab        selected-tab

--- a/src/status_im2/contexts/communities/home/style.cljs
+++ b/src/status_im2/contexts/communities/home/style.cljs
@@ -1,10 +1,8 @@
 (ns status-im2.contexts.communities.home.style
   (:require [quo2.foundations.colors :as colors]
             [react-native.platform :as platform]
-            [react-native.safe-area :as safe-area]
-            [react-native.reanimated :as reanimated]))
-
-(def header-height 245)
+            [react-native.reanimated :as reanimated]
+            [react-native.safe-area :as safe-area]))
 
 (def tabs
   {:padding-horizontal 20
@@ -18,21 +16,10 @@
    :left     0
    :bottom   0})
 
-(defn empty-state-container
-  []
-  {:margin-top      (+ header-height (safe-area/get-top))
-   :margin-bottom   44
-   :flex            1
-   :justify-content :center})
-
 (def empty-state-placeholder
   {:height           120
    :width            120
    :background-color colors/danger-50})
-
-(defn header-spacing
-  []
-  {:height (+ header-height (safe-area/get-top))})
 
 (defn blur-banner-layer
   [animated-translation-y]

--- a/src/status_im2/contexts/communities/home/view.cljs
+++ b/src/status_im2/contexts/communities/home/view.cljs
@@ -8,6 +8,7 @@
             [status-im2.common.home.view :as common.home]
             [status-im2.common.resources :as resources]
             [status-im2.contexts.communities.actions.community-options.view :as options]
+            [status-im2.contexts.communities.actions.home-plus.view :as actions.home-plus]
             [utils.debounce :as debounce]
             [utils.i18n :as i18n]
             [utils.number]
@@ -57,6 +58,18 @@
     :image       (resources/get-image (theme/theme-value :no-opened-communities-light
                                                          :no-opened-communities-dark))}})
 
+(def ^:private banner-data
+  {:title-props
+   {:label               (i18n/label :t/communities)
+    :handler             #(rf/dispatch [:show-bottom-sheet {:content actions.home-plus/view}])
+    :accessibility-label :new-communities-button}
+   :card-props
+   {:on-press            #(rf/dispatch [:navigate-to :discover-communities])
+    :title               (i18n/label :t/discover)
+    :description         (i18n/label :t/favorite-communities)
+    :banner              (resources/get-image :discover)
+    :accessibility-label :communities-home-discover-card}})
+
 (defn home
   []
   (let [flat-list-ref     (atom nil)
@@ -64,10 +77,10 @@
     (fn []
       (let [selected-tab                    (or (rf/sub [:communities/selected-tab]) :joined)
             {:keys [joined pending opened]} (rf/sub [:communities/grouped-by-status])
-            selected-items                  (take 15 (cycle (case selected-tab
-                                                              :joined joined
-                                                              :pending pending
-                                                              :opened opened)))
+            selected-items                  (case selected-tab
+                                              :joined  joined
+                                              :pending pending
+                                              :opened  opened)
             scroll-shared-value             (reanimated/use-shared-value 0)]
         [:<>
          (if (empty? selected-items)
@@ -88,7 +101,7 @@
                                                                   "nativeEvent.contentOffset.y")
                                                    :shared-value scroll-shared-value})}])
          [:f> common.home.banner/animated-banner
-          {:content             :communities
+          {:content             banner-data
            :scroll-ref          flat-list-ref
            :tabs                tabs-data
            :selected-tab        selected-tab

--- a/src/status_im2/contexts/communities/home/view.cljs
+++ b/src/status_im2/contexts/communities/home/view.cljs
@@ -59,7 +59,8 @@
 
 (defn home
   []
-  (let [flat-list-ref (atom nil)]
+  (let [flat-list-ref     (atom nil)
+        set-flat-list-ref #(reset! flat-list-ref %)]
     (fn []
       (let [selected-tab                    (or (rf/sub [:communities/selected-tab]) :joined)
             {:keys [joined pending opened]} (rf/sub [:communities/grouped-by-status])
@@ -74,7 +75,7 @@
             {:selected-tab selected-tab
              :tab->content empty-state-content}]
            [reanimated/flat-list
-            {:ref                               #(reset! flat-list-ref %)
+            {:ref                               set-flat-list-ref
              :key-fn                            :id
              :content-inset-adjustment-behavior :never
              :header                            [common.home/header-spacing]
@@ -88,8 +89,8 @@
                                                    :shared-value scroll-shared-value})}])
          [:f> common.home.banner/animated-banner
           {:content             :communities
-           :flat-list-ref       flat-list-ref
+           :scroll-ref          flat-list-ref
            :tabs                tabs-data
            :selected-tab        selected-tab
-           :on-tab-change-event (fn [tab] (rf/dispatch [:communities/select-tab tab]))
+           :on-tab-change       (fn [tab] (rf/dispatch [:communities/select-tab tab]))
            :scroll-shared-value scroll-shared-value}]]))))

--- a/src/status_im2/contexts/communities/home/view.cljs
+++ b/src/status_im2/contexts/communities/home/view.cljs
@@ -63,23 +63,24 @@
     (fn []
       (let [selected-tab                    (or (rf/sub [:communities/selected-tab]) :joined)
             {:keys [joined pending opened]} (rf/sub [:communities/grouped-by-status])
-            selected-items                  (case selected-tab
-                                              :joined  joined
-                                              :pending pending
-                                              :opened  opened)
+            selected-items                  (take 15 (cycle (case selected-tab
+                                                              :joined joined
+                                                              :pending pending
+                                                              :opened opened)))
             scroll-shared-value             (reanimated/use-shared-value 0)]
         [:<>
          (if (empty? selected-items)
            [common.home/empty-state-image
             {:selected-tab selected-tab
              :tab->content empty-state-content}]
-           [rn/flat-list
+           [reanimated/flat-list
             {:ref                               #(reset! flat-list-ref %)
              :key-fn                            :id
              :content-inset-adjustment-behavior :never
              :header                            [common.home/header-spacing]
              :render-fn                         item-render
              :data                              selected-items
+             :scroll-event-throttle             8
              :on-scroll                         #(common.home.banner/set-scroll-shared-value
                                                   {:scroll-input (oops/oget
                                                                   %

--- a/src/status_im2/contexts/communities/home/view.cljs
+++ b/src/status_im2/contexts/communities/home/view.cljs
@@ -1,17 +1,13 @@
 (ns status-im2.contexts.communities.home.view
   (:require [oops.core :as oops]
             [quo2.core :as quo]
-            [quo2.foundations.colors :as colors]
             [quo2.theme :as theme]
-            [react-native.blur :as blur]
             [react-native.core :as rn]
-            [react-native.platform :as platform]
             [react-native.reanimated :as reanimated]
+            [status-im2.common.home.banner.view :as common.home.banner]
             [status-im2.common.home.view :as common.home]
             [status-im2.common.resources :as resources]
             [status-im2.contexts.communities.actions.community-options.view :as options]
-            [status-im2.contexts.communities.actions.home-plus.view :as actions.home-plus]
-            [status-im2.contexts.communities.home.style :as style]
             [utils.debounce :as debounce]
             [utils.i18n :as i18n]
             [utils.number]
@@ -71,8 +67,7 @@
                                               :joined  joined
                                               :pending pending
                                               :opened  opened)
-            animated-opacity                (reanimated/use-shared-value 1)
-            animated-translation-y          (reanimated/use-shared-value 0)]
+            scroll-shared-value             (reanimated/use-shared-value 0)]
         [:<>
          (if (empty? selected-items)
            [common.home/empty-state-image
@@ -85,14 +80,15 @@
              :header                            [common.home/header-spacing]
              :render-fn                         item-render
              :data                              selected-items
-             :on-scroll                         #(set-animated-banner-values
-                                                  {:scroll-offset (oops/oget
-                                                                   %
-                                                                   "nativeEvent.contentOffset.y")
-                                                   :translation-y animated-translation-y
-                                                   :opacity       animated-opacity})}])
-         [:f> animated-banner
-          {:selected-tab           selected-tab
-           :animated-translation-y animated-translation-y
-           :animated-opacity       animated-opacity
-           :flat-list-ref          flat-list-ref}]]))))
+             :on-scroll                         #(common.home.banner/set-scroll-shared-value
+                                                  {:scroll-input (oops/oget
+                                                                  %
+                                                                  "nativeEvent.contentOffset.y")
+                                                   :shared-value scroll-shared-value})}])
+         [:f> common.home.banner/animated-banner
+          {:content             :communities
+           :flat-list-ref       flat-list-ref
+           :tabs                tabs-data
+           :selected-tab        selected-tab
+           :on-tab-change-event (fn [tab] (rf/dispatch [:communities/select-tab tab]))
+           :scroll-shared-value scroll-shared-value}]]))))

--- a/src/status_im2/contexts/shell/jump_to/components/home_stack/view.cljs
+++ b/src/status_im2/contexts/shell/jump_to/components/home_stack/view.cljs
@@ -28,7 +28,7 @@
                            (get shell.constants/stacks-z-index-keywords stack-id))})}
    (case stack-id
      :communities-stack [:f> communities/home]
-     :chats-stack       [chat/home]
+     :chats-stack       [:f> chat/home]
      :wallet-stack      [wallet.accounts/accounts-overview-old]
      :browser-stack     [browser.stack/browser-stack]
      [:<>])])


### PR DESCRIPTION
fixes #16709

### Summary

[comment]: # (Summarise the problem and how the pull request solves it)

This PR:
- Creates a common animated banner component
- Uses that component to animate both: communities & chats banner.
- Moves the following components to the `status-im2.common.home.view` namespace, since they are used by both screens (communities and chats) in the same way:
- `empty-state` (the one responsible for the cat in a box image)
- a simple banner spacing

Video:
https://github.com/status-im/status-mobile/assets/90291778/1b27c6d8-b408-4713-929e-11f8acf55f61


### Review notes
The code for the animated banner has been simplified a little more.

#### Platforms
- Android
- iOS

##### Functional

- Communities tab
- Chats tab

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open Status
- Navigate to Chats tab
- iOS: Have at least one item  in each chat tab and scroll up
-  Android: Have enough elements in chats tabs so that the listing are bigger than the screen. (to activate the scroll behaviour), then scroll up
- The banner is hidden

status: ready
