### PR TITLE
Enable layout animations by default

### DIFF
--- a/src/react_native/reanimated.cljs
+++ b/src/react_native/reanimated.cljs
@@ -17,11 +17,14 @@
                              SlideInUp
                              SlideOutUp
                              LinearTransition
+                             enableLayoutAnimations
                              runOnJS)]
             [reagent.core :as reagent]
             ["react-native-redash" :refer (withPause)]
             [react-native.flat-list :as rn-flat-list]
             [utils.worklets.core :as worklets.core]))
+
+(def enable-layout-animations enableLayoutAnimations)
 
 (def ^:const default-duration 300)
 

--- a/src/status_im2/core.cljs
+++ b/src/status_im2/core.cljs
@@ -7,6 +7,7 @@
     [react-native.core :as rn]
     [react-native.platform :as platform]
     [react-native.shake :as react-native-shake]
+    [react-native.reanimated :as reanimated]
     [reagent.impl.batching :as batching]
     [status-im2.contexts.shell.jump-to.utils :as shell.utils]
     [status-im2.contexts.shell.jump-to.state :as shell.state]
@@ -46,6 +47,8 @@
   ;; Shell
   (async-storage/get-item :selected-stack-id #(shell.utils/change-selected-stack-id % nil nil))
   (async-storage/get-item :screen-height #(reset! shell.state/screen-height %))
+
+  (reanimated/enable-layout-animations true)
 
   (dev/setup)
 

--- a/src/status_im2/core.cljs
+++ b/src/status_im2/core.cljs
@@ -48,6 +48,12 @@
   (async-storage/get-item :selected-stack-id #(shell.utils/change-selected-stack-id % nil nil))
   (async-storage/get-item :screen-height #(reset! shell.state/screen-height %))
 
+  ;; Note - We have to enable layout animations manually at app startup,
+  ;; otherwise, they will be enabled at runtime when they are used and will cause few bugs.
+  ;; https://github.com/status-im/status-mobile/issues/16693
+  ;; We can remove this call, once reanimated library is upgraded to v3.
+  ;; Also, we can't move this call to reanimated.cljs file,
+  ;; because that causes component tests to fail. (as function is not mocked in library jestUtils)
   (reanimated/enable-layout-animations true)
 
   (dev/setup)


### PR DESCRIPTION
fixes: https://github.com/status-im/status-mobile/issues/16693

### Summary

The issue is happening due to [layout animations](https://github.com/status-im/status-mobile/pull/16433) (used by toasts). This is a [known issue](https://github.com/software-mansion/react-native-reanimated/issues/2758) and happens because layout animations are [disabled by default](https://github.com/software-mansion/react-native-reanimated/pull/2651) and when toasts tried to use them, it enabled layout animations at runtime and caused this weird behavior.

Once we upgrade to [reanimated v3](https://github.com/status-im/status-mobile/issues/15764), this change will be redundant as layout animations will be [enabled](https://github.com/software-mansion/react-native-reanimated/pull/2802) by default in newer versions

### Testing:
Please also test https://github.com/status-im/status-mobile/issues/14752 

(Thank you @qoqobolo for your help in tracking issue [cause](https://github.com/status-im/status-mobile/pull/16729#issuecomment-1660486401))

status: ready