### PR TITLE
Set initial block range for a newly created account

### DIFF
--- a/src/status_im2/contexts/profile/login/events.cljs
+++ b/src/status_im2/contexts/profile/login/events.cljs
@@ -132,19 +132,19 @@
               (switcher-cards-store/fetch-switcher-cards-rpc))))
 
 (rf/defn login-node-signal
-  [{{:keys [recovered-account?] :as db} :db :as cofx} {:keys [settings account error]}]
+  [{{:onboarding-2/keys [recovered-account? new-account?] :as db} :db :as cofx}
+   {:keys [settings account error]}]
   (log/debug "[signals] node.login" "error" error)
   (if error
     {:db (update db :profile/login #(-> % (dissoc :processing) (assoc :error error)))}
-    (let [{:keys [creating?]} (:profile/login db)]
-      (rf/merge cofx
-                {:db         (dissoc db :profile/login)
-                 :dispatch-n [[:logging/initialize-web3-client-version]
-                              (when (and creating? (not recovered-account?))
-                                [:wallet/set-initial-blocks-range])]}
-                (if (or creating? recovered-account?)
-                  (profile.create/login-new-profile recovered-account?)
-                  (login-existing-profile settings account))))))
+    (rf/merge cofx
+              {:db         (dissoc db :profile/login)
+               :dispatch-n [[:logging/initialize-web3-client-version]
+                            (when (and new-account? (not recovered-account?))
+                              [:wallet/set-initial-blocks-range])]}
+              (if (or new-account? recovered-account?)
+                (profile.create/login-new-profile recovered-account?)
+                (login-existing-profile settings account)))))
 
 (rf/defn login-with-biometric-if-available
   {:events [:profile.login/login-with-biometric-if-available]}

--- a/src/status_im2/contexts/profile/recover/events.cljs
+++ b/src/status_im2/contexts/profile/recover/events.cljs
@@ -14,8 +14,11 @@
 
 (rf/defn recover-profile-and-login
   {:events [:profile.recover/recover-and-login]}
-  [_ {:keys [display-name password image-path color seed-phrase]}]
-  {::restore-profile-and-login
+  [{:keys [db]} {:keys [display-name password image-path color seed-phrase]}]
+  {:db
+   (assoc db :onboarding-2/recovered-account? true)
+
+   ::restore-profile-and-login
    (merge (profile.config/create)
           {:displayName        display-name
            :mnemonic           (security/safe-unmask-data seed-phrase)


### PR DESCRIPTION
Currently we try to fetch transfer history for a newly created account which costs us some unnecessary rpc requests

<img src="https://cdn.discordapp.com/attachments/1135875424208044103/1135884847928315935/image.png" width=320 />


This can be fixed by setting initial blocks range as scanned, and worked like this with an old version of onboarding.

status: ready