### PR TITLE
Add on-press prop to the collectable component

### DIFF
--- a/src/quo2/components/profile/collectible/view.cljs
+++ b/src/quo2/components/profile/collectible/view.cljs
@@ -91,7 +91,9 @@
              [remaining-tiles (- (count remaining-images) 3)]])]]))))
 
 (defn collectible
-  [{:keys [images]}]
+  [{:keys [images on-press]}]
   [rn/view {:style style/tile-outer-container}
-   [rn/view {:style style/tile-inner-container}
+   [rn/pressable
+    {:on-press on-press
+     :style    style/tile-inner-container}
     [tile-container {:images images}]]])

--- a/src/status_im2/contexts/quo_preview/profile/collectible.cljs
+++ b/src/status_im2/contexts/quo_preview/profile/collectible.cljs
@@ -36,7 +36,9 @@
          [rn/view
           {:padding-vertical 100
            :align-items      :center}
-          [quo/collectible {:images images-to-show}]]]))))
+          [quo/collectible
+           {:images   images-to-show
+            :on-press #(js/alert "Pressed")}]]]))))
 
 (defn preview-collectible
   []


### PR DESCRIPTION
fixes #16743

### Summary

This PR adds the `on-press` prop required for navigating to other screens, such as the details screen, when we will start building screens.

### Testing notes

This is a very minor functional update to the component. 
Ref: https://github.com/status-im/status-mobile/issues/16743#issuecomment-1661988435

### Platforms

- Android
- iOS

### Steps to test

- Open Status
- Navigate to `Quo2 Preview > profile > collectible`
- Tap on the collectable and check whether the alert is shown

status: ready 
