### PR TITLE
[Fix] Crash on onboarding due to nil value

### DIFF
--- a/src/status_im2/contexts/onboarding/new_to_status/view.cljs
+++ b/src/status_im2/contexts/onboarding/new_to_status/view.cljs
@@ -110,19 +110,20 @@
                              :icon-background :blur
                              :icon            :i/arrow-left
                              :on-press        navigate-back}
-     :right-section-buttons [(when config/quo-preview-enabled?
-                               {:type            :grey
-                                :icon            :i/reveal-whitelist
-                                :icon-background :blur
-                                :on-press        #(rf/dispatch [:navigate-to
-                                                                :quo2-preview])})
-                             {:type            :grey
-                              :icon            :i/info
-                              :icon-background :blur
-                              :on-press        #(rf/dispatch
-                                                 [:show-bottom-sheet
-                                                  {:content getting-started-doc
-                                                   :shell?  true}])}]}]])
+     :right-section-buttons (cond-> [{:type            :grey
+                                      :icon            :i/info
+                                      :icon-background :blur
+                                      :on-press        #(rf/dispatch
+                                                         [:show-bottom-sheet
+                                                          {:content getting-started-doc
+                                                           :shell?  true}])}]
+
+                              config/quo-preview-enabled?
+                              (conj {:type            :grey
+                                     :icon            :i/reveal-whitelist
+                                     :icon-background :blur
+                                     :on-press        #(rf/dispatch [:navigate-to
+                                                                     :quo2-preview])}))}]])
 
 (defn new-to-status
   []


### PR DESCRIPTION
fixes #16883

### Summary

This PR fixes the crash on the `New to status` screen to due usage of `when` inside the vector which produces `nil` value.

### Platforms

- Android
- iOS

### Steps to test

- Open Status
- Navigate to the `New to status` screen
- Check whether the app crashes or not

status: ready 
