### PR TITLE
Various fixes on messaging

### DIFF
--- a/src/quo2/components/messages/author/style.cljs
+++ b/src/quo2/components/messages/author/style.cljs
@@ -4,7 +4,7 @@
 (def container
   {:flex-wrap      :wrap
    :flex-direction :row
-   :align-items    :baseline})
+   :align-items    :center})
 
 (def middle-dot-nickname
   {:color             colors/neutral-50

--- a/src/quo2/components/reactions/reaction.cljs
+++ b/src/quo2/components/reactions/reaction.cljs
@@ -7,18 +7,15 @@
             [quo2.theme :as theme]
             [react-native.core :as rn]))
 
-(defn add-reaction
-  [{:keys [on-press]}]
-  (let [dark? (theme/dark?)]
-    [rn/touchable-opacity
-     {:on-press            on-press
-      :accessibility-label :emoji-reaction-add
-      :style               (style/add-reaction)}
-     [icons/icon :i/add-reaction
-      {:size  20
-       :color (if dark?
-                colors/white
-                colors/neutral-100)}]]))
+(defn- add-reaction-internal
+  [{:keys [on-press theme]}]
+  [rn/touchable-opacity
+   {:on-press            on-press
+    :accessibility-label :emoji-reaction-add
+    :style               (style/add-reaction)}
+   [icons/icon :i/add-reaction
+    {:size  20
+     :color (colors/theme-colors colors/neutral-50 colors/white theme)}]])
 
 (defn reaction
   "Add your emoji as a param here"
@@ -41,3 +38,5 @@
        :justify-content :center}
       (when (pos? numeric-value)
         (str " " numeric-value))]]))
+
+(def add-reaction (theme/with-theme add-reaction-internal))

--- a/src/status_im2/contexts/chat/composer/reply/view.cljs
+++ b/src/status_im2/contexts/chat/composer/reply/view.cljs
@@ -73,7 +73,7 @@
        :size              :xxxs}]
      [quo/text
       {:weight          :semi-bold
-       :size            :label
+       :size            :paragraph-2
        :number-of-lines 1
        :style           style/message-author-text}
       (format-reply-author from contact-name current-public-key)]]))

--- a/src/status_im2/contexts/chat/composer/view.cljs
+++ b/src/status_im2/contexts/chat/composer/view.cljs
@@ -112,7 +112,7 @@
            :max-font-size-multiplier 1
            :multiline                true
            :placeholder              (i18n/label :t/type-something)
-           :placeholder-text-color   (colors/theme-colors colors/neutral-40 colors/neutral-50)
+           :placeholder-text-color   (colors/theme-colors colors/neutral-30 colors/neutral-50)
            :style                    (style/input-text props state subs max-height)
            :max-length               constants/max-text-size
            :accessibility-label      :chat-message-input}]]


### PR DESCRIPTION
Fixes: #16894 

Alignment of contact icon in the author component was aligned to baseline instead of being center-aligned.
Check a message of a contact and see the message author row, the contact icon should now be center aligned with the author name (and public key was similarly misaligned to the baseline).

Fixes: #16904

Color of add emojii was off
When there's a post with an emojii, the button to add an emojii was of the wrong color.

Fixes: #16908
Fixes: #16927

Reply author name size was wrong in both composer and message

Fixes: #16928

Color of input placeholder in chat was not as per designs 
