### PR TITLE
add members to open community

### DIFF
--- a/src/status_im/communities/core.cljs
+++ b/src/status_im/communities/core.cljs
@@ -220,15 +220,6 @@
                                     (log/error "failed to import community" %)
                                     (re-frame/dispatch [::failed-to-import %]))}]})
 
-(rf/defn join
-  {:events [:communities/join]}
-  [_ community-id]
-  {:json-rpc/call [{:method      "wakuext_joinCommunity"
-                    :params      [community-id]
-                    :js-response true
-                    :on-success  #(re-frame/dispatch [::joined %])
-                    :on-error    #(log/error "failed to join community" community-id %)}]})
-
 (rf/defn request-to-join
   {:events [:communities/request-to-join]}
   [_ community-id]

--- a/src/status_im2/contexts/communities/actions/request_to_join/view.cljs
+++ b/src/status_im2/contexts/communities/actions/request_to_join/view.cljs
@@ -67,7 +67,7 @@
               :on-press            (fn []
                                      (if can-join?
                                        (do
-                                         (rf/dispatch [:communities/join id])
+                                         (rf/dispatch [:communities/request-to-join id])
                                          (rf/dispatch [:navigate-back]))
                                        (do (and can-request-access?
                                                 (not pending?)

--- a/src/status_im2/contexts/shell/activity_center/notification/community_request/view.cljs
+++ b/src/status_im2/contexts/shell/activity_center/notification/community_request/view.cljs
@@ -21,9 +21,11 @@
 (defn- get-header-text-and-context
   [community membership-status]
   (let [community-name        (:name community)
+        permissions           (:permissions community)
         community-image       (get-in community [:images :thumbnail :uri])
         community-context-tag [quo/context-tag common/tag-params community-image
-                               community-name]]
+                               community-name]
+        open?                 (not= 3 (:access permissions))]
     (cond
       (= membership-status constants/activity-center-membership-status-idle)
       {:header-text (i18n/label :t/community-request-not-accepted)
@@ -40,9 +42,14 @@
                      community-context-tag]}
 
       (= membership-status constants/activity-center-membership-status-accepted)
-      {:header-text (i18n/label :t/community-request-accepted)
+      {:header-text (i18n/label (if open?
+                                  :t/join-open-community
+                                  :t/community-request-accepted))
        :context     [[quo/text {:style common-style/user-avatar-tag-text}
-                      (i18n/label :t/community-request-accepted-body-text)]
+                      (i18n/label (if open?
+                                    :t/joined-community
+                                    :t/community-request-accepted-body-text)
+                                  (when open? {:community community-name}))]
                      community-context-tag]}
 
       :else nil)))

--- a/translations/en.json
+++ b/translations/en.json
@@ -196,6 +196,7 @@
     "communities-verified": "✓ Verified Status Community",
     "communities-enabled": "Communities enabled",
     "request-access": "Request access",
+    "requesting": "Requesting",
     "membership-request-pending": "Membership request pending",
     "create-community": "Create a community",
     "create-category": "Create category",


### PR DESCRIPTION
fixes #14956

### Summary
There has been some updates on joining communities. Before users would basically add themselves to the member list and didn't have to wait for the control node to confirm the request (in fact it wouldn't actually send a request in the first place, it'd just join right away).

With the updates we have moved on from the part where `JoinCommunity()` would add the user to the member list because what actually needs to happen is that there has to be a `RequestToJoinResponse()`. This is regardless of whether the community is open to join or not

Mobile still uses `JoinCommunity()` which mean the control node  never receives a the request to join for approval and therefore no RequestToJoinResponse which leads to the user not being added to the member list

Current what happens is:

- Mobile calls `JoinCommunity()`
- Mobile UI now assumes joining was successful, while in fact nothing has happened

In this case the user does not get listed in the member list

What needs to happen is:

- Mobile calls RequestToJoinCommunity() regardless of the community's configuration
- Waits for a RequestToJoinResponse
- In the mean time, puts UI in "pending" state
- Once RequestToJoinResponse comes in, check if it's accepted = true
- if `true` the user becomes part of the community
  
The mobile client most likely receives a new CommunityDescription with your user as a member, shortly before receiving the request to join response

This PR removes the updates the client to call `RequestToJoinCommunity()` instead of `JoinCommunity()` which resolves the issue
