### PR TITLE
Add gradient background support in bottom sheet

### DIFF
--- a/src/status_im2/common/bottom_sheet/style.cljs
+++ b/src/status_im2/common/bottom_sheet/style.cljs
@@ -23,12 +23,18 @@
    :right                   0
    :border-top-left-radius  20
    :border-top-right-radius 20
-   :overflow                (when shell? :hidden)
+   :overflow                :hidden
    :flex                    1
    :padding-bottom          (or padding-bottom-override (+ bottom 8))
    :background-color        (if shell?
                               :transparent
                               (colors/theme-colors colors/white colors/neutral-95 theme))})
+
+(def gradient-bg
+  {:position :absolute
+   :top      0
+   :left     0
+   :right    0})
 
 (def shell-bg
   {:position         :absolute

--- a/src/status_im2/common/bottom_sheet/style.cljs
+++ b/src/status_im2/common/bottom_sheet/style.cljs
@@ -14,7 +14,7 @@
    :margin-vertical  8})
 
 (defn sheet
-  [{:keys [top bottom]} window-height theme padding-bottom-override shell?]
+  [{:keys [top bottom]} window-height theme padding-bottom-override selected-item shell?]
   {:position                :absolute
    :max-height              (- window-height top)
    :z-index                 1
@@ -23,7 +23,7 @@
    :right                   0
    :border-top-left-radius  20
    :border-top-right-radius 20
-   :overflow                :hidden
+   :overflow                (when-not selected-item :hidden)
    :flex                    1
    :padding-bottom          (or padding-bottom-override (+ bottom 8))
    :background-color        (if shell?

--- a/src/status_im2/common/bottom_sheet/view.cljs
+++ b/src/status_im2/common/bottom_sheet/view.cljs
@@ -1,5 +1,6 @@
 (ns status-im2.common.bottom-sheet.view
   (:require [oops.core :as oops]
+            [quo2.core :as quo]
             [quo2.foundations.colors :as colors]
             [quo2.theme :as theme]
             [react-native.blur :as blur]
@@ -57,7 +58,8 @@
   [_ _]
   (let [sheet-height (reagent/atom 0)]
     (fn [{:keys [hide? insets theme]}
-         {:keys [content selected-item padding-bottom-override on-close shell?]}]
+         {:keys [content selected-item padding-bottom-override on-close shell?
+                 gradient-customization-color]}]
       (let [{window-height :height} (rn/get-window)
             bg-opacity              (reanimated/use-shared-value 0)
             translate-y             (reanimated/use-shared-value window-height)
@@ -90,6 +92,9 @@
                                      padding-bottom-override
                                      shell?))
             :on-layout #(reset! sheet-height (oops/oget % "nativeEvent" "layout" "height"))}
+           (when gradient-customization-color
+             [rn/view {:style style/gradient-bg}
+              [quo/gradient-cover {:customization-color gradient-customization-color}]])
            (when shell?
              [blur/ios-view {:style style/shell-bg}])
            (when selected-item

--- a/src/status_im2/common/bottom_sheet/view.cljs
+++ b/src/status_im2/common/bottom_sheet/view.cljs
@@ -2,7 +2,7 @@
   (:require [oops.core :as oops]
             [quo2.core :as quo]
             [quo2.foundations.colors :as colors]
-            [quo2.theme :as theme]
+            [quo2.theme :as quo.theme]
             [react-native.blur :as blur]
             [react-native.core :as rn]
             [react-native.gesture :as gesture]
@@ -59,7 +59,7 @@
   (let [sheet-height (reagent/atom 0)]
     (fn [{:keys [hide? insets theme]}
          {:keys [content selected-item padding-bottom-override on-close shell?
-                 gradient-customization-color]}]
+                 gradient-cover? customization-color]}]
       (let [{window-height :height} (rn/get-window)
             bg-opacity              (reanimated/use-shared-value 0)
             translate-y             (reanimated/use-shared-value window-height)
@@ -92,9 +92,9 @@
                                      padding-bottom-override
                                      shell?))
             :on-layout #(reset! sheet-height (oops/oget % "nativeEvent" "layout" "height"))}
-           (when gradient-customization-color
+           (when gradient-cover?
              [rn/view {:style style/gradient-bg}
-              [quo/gradient-cover {:customization-color gradient-customization-color}]])
+              [quo/gradient-cover {:customization-color customization-color}]])
            (when shell?
              [blur/ios-view {:style style/shell-bg}])
            (when selected-item
@@ -111,4 +111,4 @@
   [args sheet]
   [:f> f-view args sheet])
 
-(def view (theme/with-theme internal-view))
+(def view (quo.theme/with-theme internal-view))

--- a/src/status_im2/common/bottom_sheet/view.cljs
+++ b/src/status_im2/common/bottom_sheet/view.cljs
@@ -90,6 +90,7 @@
                                      window-height
                                      theme
                                      padding-bottom-override
+                                     selected-item
                                      shell?))
             :on-layout #(reset! sheet-height (oops/oget % "nativeEvent" "layout" "height"))}
            (when gradient-cover?

--- a/src/status_im2/contexts/quo_preview/gradient/gradient_cover.cljs
+++ b/src/status_im2/contexts/quo_preview/gradient/gradient_cover.cljs
@@ -1,21 +1,44 @@
 (ns status-im2.contexts.quo-preview.gradient.gradient-cover
-  (:require [quo2.components.colors.color-picker.view :as color-picker]
-            [quo2.components.gradient.gradient-cover.view :as gradient-cover]
+  (:require [quo2.core :as quo]
             [quo2.foundations.colors :as colors]
             [quo2.theme :as quo.theme]
             [react-native.blur :as blur]
             [react-native.core :as rn]
             [reagent.core :as reagent]
             [status-im2.common.resources :as resources]
-            [status-im2.contexts.quo-preview.preview :as preview]))
+            [status-im2.contexts.quo-preview.preview :as preview]
+            [utils.re-frame :as rf]))
+
+(defn render-action-sheet
+  []
+  [:<>
+   [rn/view {:style {:align-items :center}}
+    [quo/summary-info
+     {:type          :status-account
+      :networks?     false
+      :account-props {:customization-color :purple
+                      :size                32
+                      :emoji               "🍑"
+                      :type                :default
+                      :name                "Collectibles vault"
+                      :address             "0x0ah...78b"}}]]
+   [quo/action-drawer
+    [[{:icon     :i/edit
+       :label    "Edit account"
+       :on-press #(js/alert "Edit account")}
+      {:icon     :i/copy
+       :label    "Copy address"
+       :on-press #(js/alert "Copy address")}
+      {:icon     :i/share
+       :label    "Share account"
+       :on-press #(js/alert "Share account")}
+      {:icon     :i/delete
+       :label    "Remove account"
+       :danger?  true
+       :on-press #(js/alert "Remove account")}]]]])
 
 (def descriptor
-  [{:label   "Customization color:"
-    :key     :customization-color
-    :type    :select
-    :options (mapv (fn [color]
-                     {:key color :value color})
-                   color-picker/color-list)}
+  [(preview/customization-color-option)
    {:label "Blur (dark only)?"
     :key   :blur?
     :type  :boolean}])
@@ -51,14 +74,20 @@
                        :bottom           0
                        :padding-vertical 40}
            :blur-type :dark}
-          [gradient-cover/view @state]]]
+          [quo/gradient-cover @state]]]
         [rn/view
          {:style {:padding-vertical   20
                   :padding-horizontal 16}}
-         [color-picker/view
+         [quo/color-picker
           {:blur?     @blur?
            :selected  @customization-color
-           :on-change #(reset! customization-color %)}]]])]))
+           :on-change #(reset! customization-color %)}]]
+        [quo/button
+         {:container-style {:margin-horizontal 40}
+          :on-press        #(rf/dispatch [:show-bottom-sheet
+                                          {:content                      (fn [] [render-action-sheet])
+                                           :gradient-customization-color @customization-color}])}
+         "See in bottom sheet"]])]))
 
 (defn preview-gradient-cover
   []

--- a/src/status_im2/contexts/quo_preview/gradient/gradient_cover.cljs
+++ b/src/status_im2/contexts/quo_preview/gradient/gradient_cover.cljs
@@ -85,8 +85,9 @@
         [quo/button
          {:container-style {:margin-horizontal 40}
           :on-press        #(rf/dispatch [:show-bottom-sheet
-                                          {:content                      (fn [] [render-action-sheet])
-                                           :gradient-customization-color @customization-color}])}
+                                          {:content             (fn [] [render-action-sheet])
+                                           :gradient-cover?     true
+                                           :customization-color @customization-color}])}
          "See in bottom sheet"]])]))
 
 (defn preview-gradient-cover


### PR DESCRIPTION
fixes #16950

### Summary

This PR add Gradient Background in the bottom sheet which will be used in Account Actions, and Switcher bottom sheet.

<img src="https://github.com/status-im/status-mobile/assets/19339952/e2459c59-2538-4367-bccd-5201ab7e1007" width="250" />

### Review notes

⚠️ The UI in the design will look different from the implementation due to the color.
Ref: https://github.com/status-im/status-mobile/issues/16950#issuecomment-1674444453

This PR is the first step to add an Account Switcher list in the bottom sheet and to ensure UI updates in the bottom sheet design don't break other places.

### Testing notes

Check whether the bottom sheets across the app work as expected.

### Platforms

- Android
- iOS

### Steps to test

- Open Status
- Navigate to `Quo2 preview > gradient > gradient-cover`
- Tap on the `See in bottom sheet` button

status: ready 
