### PR TITLE
fix: no ident ring in pinned msg

### DIFF
--- a/src/status_im2/contexts/chat/composer/reply/view.cljs
+++ b/src/status_im2/contexts/chat/composer/reply/view.cljs
@@ -69,7 +69,8 @@
       {:full-name         display-name
        :profile-picture   photo-path
        :status-indicator? false
-       :size              :xxxs}]
+       :size              :xxxs
+       :ring?             false}]
      [quo/text
       {:weight          :semi-bold
        :size            :paragraph-2


### PR DESCRIPTION
-------

fixes sub issue 1 in #16876

### Summary

![CleanShot 2023-08-15 at 10 43 15](https://github.com/status-im/status-mobile/assets/15090582/d4b3b9a2-aee6-4745-ab84-81afe885c4c5)

after:

![CleanShot 2023-08-15 at 10 43 53](https://github.com/status-im/status-mobile/assets/15090582/d1273e2e-dd57-4449-be34-c1b86d417981)


status: ready <!-- Can be ready or wip -->