### PR TITLE
Add image url to chat previews and chats

### DIFF
--- a/src/status_im/data_store/chats.cljs
+++ b/src/status_im/data_store/chats.cljs
@@ -92,6 +92,7 @@
        :unviewed-messages-count (.-unviewedMessagesCount chat)
        :unviewed-mentions-count (.-unviewedMentionsCount chat)
        :last-message            {:content            {:text        (.-text chat)
+                                                      :image       (.-imageLocalUrl chat)
                                                       :parsed-text (types/js->clj (.-parsedText chat))
                                                       :response-to (.-responseTo chat)}
                                  :content-type       (.-contentType chat)

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.163.9",
-    "commit-sha1": "f2f599fe867a0eba90aaa717a29bb6e99cb5749e",
-    "src-sha256": "0p282pv2lz5f2b0vhpcx0nj74dp5mf7hb41l12js2hxsp21sprmj"
+    "version": "bug/add-image-local-url-to-chat-preview-and-chats",
+    "commit-sha1": "813c2e0c831ede4c55c899b6bd20ed34f55b663f",
+    "src-sha256": "0q2ysaxaaz1wjl123p45qbr3853j4c60xal0bj0knskf4x7brjd7"
 }


### PR DESCRIPTION
Fixes: #14625

Status-go PR: https://github.com/status-im/status-go/pull/3900

It had to be fixed in 2 places, ChatPreview & Chat. I am not sure we should keep using ChatPreview, since any time we receive a message it will be overriden by Chat, so both needs to be kept in sync.
Maybe worth considering re-thinking and addressing the performance issue differently? (my understanding is that we use ChatPreview for performance reason)

I have kept the mock as I am not 100% sure I have covered all the cases, just to make sure it doesn't throw an error for now, but could be removed as well.


https://github.com/status-im/status-go/compare/f2f599fe...813c2e0c

