### PR TITLE
fix: timbre log to react-native start console

### DIFF
--- a/src/status_im2/common/log.cljs
+++ b/src/status_im2/common/log.cljs
@@ -1,11 +1,11 @@
 (ns status-im2.common.log
   (:require [clojure.string :as string]
+            [native-module.core :as native-module]
             [re-frame.core :as re-frame]
+            [status-im.utils.types :as types]
             [status-im2.config :as config]
             [taoensso.timbre :as log]
-            [utils.re-frame :as rf]
-            [native-module.core :as native-module]
-            [status-im.utils.types :as types]))
+            [utils.re-frame :as rf]))
 
 (def logs-queue (atom #queue []))
 (def max-log-entries 1000)
@@ -28,6 +28,7 @@
                         :mobile-system? false
                         :log-level      level
                         :callback       handle-error}]
+    (log/merge-config! {:ns-whitelist ["*"]})
     (if (string/blank? level)
       (native-module/init-status-go-logging (merge logging-params {:log-level "WARN"}))
       (do


### PR DESCRIPTION
-------

### Summary

macros like `log/info`, `log/spy` stop working recently, maybe after shadow-cljs upgrade?

add `"*"` to `taoensso.timbre/*config*` `:ns-whitelist`

timbre uses `taoensso.encore/compile-ns-filter` (through `taoensso.timbre/may-log?`) to generate a ns filter and use it against ns strings
I don't know exactly why this stopped working, but altering the whitelist makes it work again

![CleanShot 2023-08-17 at 11 20 46](https://github.com/status-im/status-mobile/assets/15090582/d206b562-070a-486b-8b90-ab813af2c9cb)


### Testing notes
dev exp issue


status: ready <!-- Can be ready or wip -->