### PR TITLE
nix: map android arch to status-go builds

### DIFF
--- a/nix/mobile/android/default.nix
+++ b/nix/mobile/android/default.nix
@@ -15,19 +15,11 @@ rec {
     ];
 
     inputsFrom = [
-      release
+      (release {})
       androidShell
     ];
 
     shellHook = ''
-      export ANDROID_SDK_ROOT="${androidPkgs.sdk}"
-      export ANDROID_NDK_ROOT="${androidPkgs.ndk}"
-
-      export STATUS_NIX_MAVEN_REPO="${deps.gradle}"
-
-      # required by some makefile targets
-      export STATUS_GO_ANDROID_LIBDIR=${status-go}
-
       # check if node modules changed and if so install them
       $STATUS_MOBILE_HOME/nix/scripts/node_modules.sh ${deps.nodejs-patched}
     '';

--- a/nix/shells.nix
+++ b/nix/shells.nix
@@ -66,7 +66,7 @@ let
     # helpers for use with target argument
     ios = targets.mobile.ios.shell;
     android = targets.mobile.android.shell;
-    status-go = targets.status-go.mobile.android;
+    status-go = targets.status-go.mobile.android {};
   };
 
   # for merging the default shell with others

--- a/nix/status-go/mobile/default.nix
+++ b/nix/status-go/mobile/default.nix
@@ -1,10 +1,18 @@
 { callPackage, meta, source, goBuildLdFlags }:
 
 {
-  android = callPackage ./build.nix {
+  android = {abis ? [ "armeabi-v7a" "arm64-v8a" "x86" ]}: callPackage ./build.nix {
     platform = "android";
     platformVersion = "23";
-    targets = [ "android/arm" "android/arm64" "android/386" ];
+    # Hide different arch naming in gomobile from Android builds.
+    targets = let
+      abiMap = {
+        "armeabi-v7a" = "android/arm";
+        "arm64-v8a"   = "android/arm64";
+        "x86"         = "android/386";
+        "x86_64"      = "android/amd64";
+        };
+      in map (arch: abiMap."${arch}") abis;
     outputFileName = "status-go-${source.shortRev}.aar";
     inherit meta source goBuildLdFlags;
   };


### PR DESCRIPTION
fixes #15595

### Summary

We have the following redundant builds now:
`status-go` is always built for all acrhs, see https://github.com/status-im/status-mobile/issues/15595

In this PR we map Android ABI to status-go targets in order to reduce the ammount of builds `status-go`.

How does it work:
- If `ANDROID_ABI_INCLUDE` env var is set (eg `armeabi-v7a;arm64-v8a`) - it will not only build the apk for arm, but also `status-go`. So `status-go` is not build for intel arch.
- If it's not set - the defaults are used:
  - `ANDROID_ABI_INCLUDE = armeabi-v7a;arm64-v8a;x86`
  - `targets = [ "android/arm" "android/arm64" "android/386" ]` (status-go)

### Testing notes

- [ ] jenkins
  - [x] build jobs are succesfull
  - [ ] jenkins e2e is succesfull
  - [x] build job have `status-go` set accordingly
- [x] make
  - [x] `shell TARGET=status-go` succeed
  - [x] `status-go-ios` succeed
  - [x] `status-go-android` succeed
  - [x] `shell TARGET=android` succeed ~~and set `status-go` arch accordingly~~
  - [x] `build-android` succeed and set `status-go` arch accordingly
  - [x] `run-android` succeed ~~and set `status-go` arch accordingly~~
