### PR TITLE
Remove 3 words alias

### DIFF
--- a/src/status_im/integration_test.cljs
+++ b/src/status_im/integration_test.cljs
@@ -231,7 +231,7 @@
     [compressed-key "zQ3shWj4WaBdf2zYKCkXe6PHxDxNTzZyid1i75879Ue9cX9gA"
      public-key
      "0x048a6773339d11ccf5fd81677b7e54daeec544a1287bd92b725047ad6faa9a9b9f8ea86ed5a226d2a994f5f46d0b43321fd8de7b7997a166e67905c8c73cd37cea"
-     three-words-name "Rich Total Pondskater"]
+     primary-name "zQ3...9cX9gA"]
     (rf-test/run-test-async
      (initialize-app!)
      (rf-test/wait-for
@@ -254,6 +254,6 @@
              (rf-test/wait-for
                [:contacts/contact-built]
                (let [contact @(rf/subscribe [:contacts/current-contact])]
-                 (is (= three-words-name (:primary-name contact))))
+                 (is (= primary-name (:primary-name contact))))
                (logout!)
                (rf-test/wait-for [::logout/logout-method])))))))))

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.166.3",
-    "commit-sha1": "347d875acb290929e93969bee2b2c178d4c50ac2",
-    "src-sha256": "036vgywbd10pwddam2q9f7sxfan2rbaj8l9khph7wxn2l37476q1"
+    "version": "v0.166.4",
+    "commit-sha1": "bf748de216a2061bf14afb2a410599485ee1ee7c",
+    "src-sha256": "0acpdc8sw6i6zpxyfzahrfbr270ldcf3jv8g4bp4kh59q2mf6bxz"
 }


### PR DESCRIPTION
This commit replaces the 3 random words alias with `zQ....something`, as per designs.
It will only work for accounts that are not in your contact yet, previous accounts will still show the 3 random words name (thought that could be fixed, but I could do in a separate PR).