### PR TITLE
Handle long names in system messages

### DIFF
--- a/src/status_im2/contexts/chat/messages/content/deleted/view.cljs
+++ b/src/status_im2/contexts/chat/messages/content/deleted/view.cljs
@@ -6,7 +6,10 @@
 
 (defn user-xxx-deleted-this-message
   [{:keys [display-name profile-picture]}]
-  [:<>
+  [rn/view
+   {:style {:flex-direction :row
+            :align-items    :center
+            :flex-shrink    1}}
    [rn/view
     {:style {:margin-right 4
              :align-self   :center}}
@@ -15,11 +18,15 @@
       :profile-picture   profile-picture
       :status-indicator? false
       :size              :xxxs}]]
-   [quo/author
-    {:primary-name display-name
-     :style        {:margin-right 4}}]
+   [quo/text
+    {:weight          :semi-bold
+     :number-of-lines 1
+     :style           {:flex-shrink 1 :margin-right 4}
+     :size            :paragraph-2}
+    display-name]
    [quo/text
     {:size            :paragraph-2
+     :flex-shrink     0
      :number-of-lines 1}
     (i18n/label :t/deleted-this-message)]])
 


### PR DESCRIPTION
fixes #16345 

### Summary
Truncate user name in system messages when a user's name is lengthy and cannot be fully displayed along with the system message in a single line.

<img src="https://github.com/status-im/status-mobile/assets/19279756/b83335c1-3b98-4986-adb9-c1bdda5fb1e5" width=350/>


### Review notes
> I will cleanup the code in a separate PR along with the component refactor.

### Testing notes
- System Messages Component: Quo2 Preview -> Messages -> System Messages
- Following System message types in the chat
  - pinned
  - contact-request
  - added (user added)
  - removed (user removed)

#### Platforms
- Android
- iOS

#### Areas that maybe impacted
- Chat

status: ready <!-- Can be ready or wip -->
