### PR TITLE
fix Jump to button not responding in chat after app returns from background

### DIFF
--- a/src/status_im2/contexts/chat/composer/style.cljs
+++ b/src/status_im2/contexts/chat/composer/style.cljs
@@ -117,3 +117,8 @@
    {:transform [{:translate-y translate-y}]
     :opacity   opacity}
    {:z-index 1}))
+
+(def scroll-to-bottom-button
+  {:position :absolute
+   :right    0
+   :left     0})

--- a/src/status_im2/contexts/chat/composer/style.cljs
+++ b/src/status_im2/contexts/chat/composer/style.cljs
@@ -116,6 +116,4 @@
   (reanimated/apply-animations-to-style
    {:transform [{:translate-y translate-y}]
     :opacity   opacity}
-   {:position   :absolute
-    :top        0
-    :align-self :center}))
+   {:z-index 1}))

--- a/src/status_im2/contexts/chat/composer/sub_view.cljs
+++ b/src/status_im2/contexts/chat/composer/sub_view.cljs
@@ -48,10 +48,12 @@
          :label               (i18n/label :t/jump-to)
          :style               {:align-self :center}}}
        {}]]
-     [quo/floating-shell-button
-      (when @messages.list/show-floating-scroll-down-button
-        {:scroll-to-bottom {:on-press messages.list/scroll-to-bottom}})
-      {}]]))
+     (when @messages.list/show-floating-scroll-down-button
+       [quo/floating-shell-button
+        {:scroll-to-bottom {:on-press messages.list/scroll-to-bottom}}
+        {:position :absolute
+         :right    0
+         :left     0}])]))
 
 (defn shell-button
   [state animations subs]

--- a/src/status_im2/contexts/chat/composer/sub_view.cljs
+++ b/src/status_im2/contexts/chat/composer/sub_view.cljs
@@ -51,9 +51,7 @@
      (when @messages.list/show-floating-scroll-down-button
        [quo/floating-shell-button
         {:scroll-to-bottom {:on-press messages.list/scroll-to-bottom}}
-        {:position :absolute
-         :right    0
-         :left     0}])]))
+        style/scroll-to-bottom-button])]))
 
 (defn shell-button
   [state animations subs]


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/17079

### Summary
I think the problem was that we had two floating shell buttons (one for jump-to and one for scroll-to-bottom), and the scroll-to-bottom one always overlapped the jump-to one. And for some reason, it sometimes stopped propagating touch events.

status: ready