### PR TITLE
fix: resolve activity centre design feedback

### DIFF
--- a/src/quo2/components/notifications/activity_log/style.cljs
+++ b/src/quo2/components/notifications/activity_log/style.cljs
@@ -44,6 +44,7 @@
 (def timestamp
   {:text-transform :none
    :margin-left    8
+   :margin-top     4
    :color          colors/neutral-40})
 
 (defn unread-dot
@@ -65,10 +66,8 @@
    :flex-wrap       :wrap})
 
 (def top-section-container
-  {:align-items    :center
-   :flex-direction :row})
+  {:flex-direction :row})
 
 (def title-container
   {:flex           1
-   :flex-direction :row
-   :align-items    :center})
+   :flex-direction :row})

--- a/src/quo2/components/notifications/activity_log/style.cljs
+++ b/src/quo2/components/notifications/activity_log/style.cljs
@@ -28,7 +28,7 @@
 (defn message-container
   [attachment]
   {:border-radius      12
-   :margin-top         12
+   :margin-top         10
    :padding-horizontal 12
    :padding-vertical   (if (#{:photo :gif} attachment) 12 8)
    :background-color   colors/white-opa-5})

--- a/src/quo2/components/notifications/activity_log/style.cljs
+++ b/src/quo2/components/notifications/activity_log/style.cljs
@@ -39,12 +39,14 @@
 
 (defn title
   []
-  {:color colors/white})
+  {:flex-shrink 1
+   :color       colors/white})
 
 (def timestamp
   {:text-transform :none
    :margin-left    8
    :margin-top     4
+   :flex-shrink    0
    :color          colors/neutral-40})
 
 (defn unread-dot

--- a/src/quo2/components/notifications/activity_log/view.cljs
+++ b/src/quo2/components/notifications/activity_log/view.cljs
@@ -52,7 +52,7 @@
 (defn- activity-context
   [context replying?]
   (let [first-line-offset (if replying? 4 0)
-        gap-between-lines 4]
+        gap-between-lines 5]
     (into [rn/view {:style (assoc style/context-container :margin-top first-line-offset)}]
           (mapcat
            (fn [detail]
@@ -176,9 +176,9 @@
     [rn/view
      [rn/view {:style style/top-section-container}
       [rn/view {:style style/title-container}
-       [activity-title title replying?]
-       (when-not replying?
-         [activity-timestamp timestamp])]
+       [activity-title title replying?]]
+      (when-not replying?
+        [activity-timestamp timestamp])
       (when (and unread? (not replying?))
         [activity-unread-dot customization-color])]
      (when context

--- a/src/quo2/components/notifications/activity_log/view.cljs
+++ b/src/quo2/components/notifications/activity_log/view.cljs
@@ -180,9 +180,9 @@
     [rn/view
      [rn/view {:style style/top-section-container}
       [rn/view {:style style/title-container}
-       [activity-title title replying?]]
-      (when-not replying?
-        [activity-timestamp timestamp])
+       [activity-title title replying?]
+       (when-not replying?
+         [activity-timestamp timestamp])]
       (when (and unread? (not replying?))
         [activity-unread-dot customization-color])]
      (when context

--- a/src/quo2/components/notifications/activity_log/view.cljs
+++ b/src/quo2/components/notifications/activity_log/view.cljs
@@ -130,6 +130,10 @@
          (assoc :size size)
          (assoc :type subtype)
          (assoc :disabled? (and replying? disable-when (disable-when @reply-input)))
+         (assoc :inner-style
+                {:justify-content :center
+                 :padding-bottom  0
+                 :padding-top     0})
          (update :container-style merge common-style {:margin-right 8}))
      label]))
 

--- a/src/quo2/components/selectors/filter/style.cljs
+++ b/src/quo2/components/selectors/filter/style.cljs
@@ -38,7 +38,7 @@
   [customization-color pressed? theme]
   (when pressed?
     (if customization-color
-      (colors/custom-color-by-theme customization-color 50 60)
+      (colors/custom-color (or customization-color :blue) 60)
       (colors/theme-colors colors/primary-50 colors/primary-60 theme))))
 
 (defn container-outer

--- a/src/quo2/components/tags/status_tags.cljs
+++ b/src/quo2/components/tags/status_tags.cljs
@@ -13,7 +13,7 @@
   (merge default-container-style
          {:min-height         24
           :padding-horizontal 8
-          :padding-vertical   1}))
+          :padding-vertical   3}))
 
 (def large-container-style
   (merge default-container-style


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/16841

- [x] 1. Dot is overlapping with the timestamp on "Request hasn't been accepted" notification - comment [here](https://www.figma.com/file/Tf5nfkYvpbnNCo4rKLK7lS?node-id=3674:328391&mode=design#510053049)  
- [x] 2. Spacing in AC notifications doesn't match the design - comment [here](https://www.figma.com/file/Tf5nfkYvpbnNCo4rKLK7lS?node-id=3674:328391&mode=design#510052712)
- [x] 3. on the `Accepted` label status tag padding is different from design - comment [here](https://www.figma.com/file/Tf5nfkYvpbnNCo4rKLK7lS?node-id=3674:328391&mode=design#511248488)
- [x] 4. wrong spacing in contact request AC notification between username and text - comment [here](https://www.figma.com/file/Tf5nfkYvpbnNCo4rKLK7lS?node-id=3674:328391&mode=design#511247483)
- [ ] 5. Deferred to @flexsurfer 
- [x] 6. Text isn't centred in the decline/accept buttons - comment [here](https://www.figma.com/file/Tf5nfkYvpbnNCo4rKLK7lS?node-id=4909:50437&mode=design#538594339)  
- [x] 7. Customization colors in shell theme are the dark theme ones (orange/60 in this case)- comment [here](https://www.figma.com/file/Tf5nfkYvpbnNCo4rKLK7lS?node-id=4909:50437&mode=design#538599185)


status: ready
