### PR TITLE
Connected android devices abis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -272,6 +272,8 @@ run-re-frisk: ##@run Start re-frisk server
 
 # TODO: Migrate this to a Nix recipe, much the same way as nix/mobile/android/targets/release-android.nix
 run-android: export TARGET := android
+# INFO: If it's empty (no devices attached, parsing issues, script error) - for Nix it's the same as not set.
+run-android: export ANDROID_ABI_INCLUDE ?= $(shell ./scripts/adb_devices_arch.sh)
 run-android: ##@run Build Android APK and start it on the device
 	npx react-native run-android --appIdSuffix debug
 

--- a/scripts/adb_devices_abis.sh
+++ b/scripts/adb_devices_abis.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+set -e
+typeset -a abis
+SCRIPT_NAME=$(basename $0)
+
+function log() {
+  echo "${SCRIPT_NAME} ${1}: ${2}" >&2
+}
+
+# make sure server is running, otherwise sdb will show devices offline
+adb start-server
+
+while IFS= read line; do
+  read -a arr <<< "${line}"
+
+  device_name="${arr[0]}"
+  device_status=${arr[1]}
+
+  log "DEBUG" "device_name=${device_name}"
+  log "DEBUG" "device_status=${device_status}"
+
+  if [[ "${device_status}" != "device" ]]; then
+    continue
+  fi
+
+  device_product_abi=$(adb -s ${device_name} shell -n getprop ro.product.cpu.abi)
+  log "DEBUG" "device_product_abi=${device_product_abi}"
+
+  if [[ ! ${abis[*]} =~ ${device_product_abi} ]]; then
+    abis+=("${device_product_abi}")
+  fi
+done <<< "$(adb devices | tail -n+2)"
+
+if [[ ! "${abis[*]}" ]]; then
+  log "ERROR" "no devices found. Check 'adb devices -l' output and share with Infra team if needed."
+  exit 3
+fi
+
+log "DEBUG" "resulting abis:"
+IFS=\;; echo "${abis[*]}"


### PR DESCRIPTION
### Summary

#17040 allowed to build less targets of `status-go` on CI and using `ANDROID_ABI_INCLUDE` env var.
This PR will automate setting of required `ANDROID_ABI_INCLUDE` by the results of `adb devices -l`.

Some details:
- Need to run `adb server` so devices are shown properly if it's not running already
- If we are not sure if device is emulator or real - we don't override ABI and print a message to STDERR
- If no devices attached - we don't override ABI and print a message to STDERR
- If device is real - we assume `arm64-v8a` ABI
- Requirements for real device: usb field, name doesn't start with `emulator`, product doesn't start with `sdk_`