### PR TITLE
[#16550] fix: device type indicators in syncing screen

### DIFF
--- a/src/quo2/components/settings/settings_list/style.cljs
+++ b/src/quo2/components/settings/settings_list/style.cljs
@@ -52,4 +52,5 @@
    :margin-right    12})
 
 (def tag-container
-  {:margin-top 8})
+  {:margin-top  8
+   :margin-left -1})

--- a/src/quo2/components/tags/status_tags.cljs
+++ b/src/quo2/components/tags/status_tags.cljs
@@ -11,7 +11,7 @@
 
 (def small-container-style
   (merge default-container-style
-         {:min-height         24
+         {:min-height         26
           :padding-horizontal 8
           :padding-vertical   3}))
 
@@ -44,6 +44,7 @@
                                     :background-color background-color)}
        [rn/view
         {:flex-direction :row
+         :align-items    :center
          :flex           1}
         [rn/view
          {:style {:justify-content :center
@@ -56,7 +57,7 @@
         [text/text
          {:size   paragraph-size
           :weight :medium
-          :style  {:padding-left 5
+          :style  {:padding-left (if icon 5 0)
                    :color        text-color}} label]]])))
 
 (defn- positive

--- a/src/status_im2/contexts/syncing/device/view.cljs
+++ b/src/status_im2/contexts/syncing/device/view.cljs
@@ -17,7 +17,9 @@
        {:container-style style/device-container
         :title           name
         :override-theme  :dark
-        :left-icon       (if (= device-type :mobile) :i/mobile :i/desktop)}
+        :left-icon       (cond (#{:mobile :ios :android} (keyword device-type))
+                               :i/mobile
+                               :else :i/desktop)}
        (and show-button? unpaired?) (assoc :button-props
                                            {:title    (i18n/label :t/pair)
                                             :on-press #(js/alert "feature not added yet")})


### PR DESCRIPTION
fixes #16550

Actual result:
- Mobile indicator is not shown. Only the laptop indicator icon is shown for all types of devices Online status is not shown

Expected result:
- The mobile indicator should be shown for mobile devices.


ios
<img src="https://github.com/status-im/status-mobile/assets/71308738/ef8d6e6f-28fe-4062-b4c7-55fc63cf1d35" width="375px" />

status: ready


