### PR TITLE
Unshadow remaining core & non-core vars

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -22,6 +22,7 @@
                                     ;; option and lint all vars.
                                     :include [comparator
                                               count
+                                              delay
                                               identity
                                               iter
                                               key

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -30,6 +30,7 @@
                                               iter
                                               key
                                               keys
+                                              list
                                               new
                                               ns
                                               resolve

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -20,7 +20,8 @@
                                     ;; future, as we progressively fix shadowed
                                     ;; vars, we should be able to delete this
                                     ;; option and lint all vars.
-                                    :include [comp
+                                    :include [binding
+                                              comp
                                               comparator
                                               count
                                               delay

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -27,6 +27,7 @@
                                               identity
                                               iter
                                               key
+                                              resolve
                                               str
                                               subs
                                               symbol

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -28,6 +28,7 @@
                                               iter
                                               key
                                               keys
+                                              new
                                               resolve
                                               str
                                               subs

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -27,6 +27,7 @@
                                               identity
                                               iter
                                               key
+                                              keys
                                               resolve
                                               str
                                               subs

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -25,6 +25,7 @@
                                               count
                                               delay
                                               empty?
+                                              hash
                                               identity
                                               iter
                                               key

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -33,6 +33,7 @@
                                               new
                                               ns
                                               resolve
+                                              seq
                                               str
                                               subs
                                               symbol

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -31,6 +31,7 @@
                                               key
                                               keys
                                               list
+                                              meta
                                               new
                                               ns
                                               resolve

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -38,7 +38,8 @@
                                               subs
                                               symbol
                                               time
-                                              val]}
+                                              val
+                                              var]}
                 :invalid-arity     {:skip-args [status-im.utils.fx/defn utils.re-frame/defn]}
                 ;; TODO remove number when this is fixed
                 ;; https://github.com/borkdude/clj-kondo/issues/867

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -34,6 +34,7 @@
                                               meta
                                               new
                                               ns
+                                              range
                                               resolve
                                               seq
                                               str

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -20,7 +20,8 @@
                                     ;; future, as we progressively fix shadowed
                                     ;; vars, we should be able to delete this
                                     ;; option and lint all vars.
-                                    :include [comparator
+                                    :include [comp
+                                              comparator
                                               count
                                               delay
                                               identity

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -25,6 +25,7 @@
                                               count
                                               delay
                                               empty?
+                                              exists?
                                               hash
                                               identity
                                               iter

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -30,6 +30,7 @@
                                               key
                                               keys
                                               new
+                                              ns
                                               resolve
                                               str
                                               subs

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -20,35 +20,16 @@
                                     ;; future, as we progressively fix shadowed
                                     ;; vars, we should be able to delete this
                                     ;; option and lint all vars.
-                                    :include [binding
-                                              comp
-                                              comparator
-                                              count
-                                              delay
-                                              empty?
-                                              exists?
-                                              hash
-                                              identity
-                                              iter
-                                              key
-                                              keys
-                                              list
-                                              max
-                                              meta
-                                              methods
-                                              min
-                                              new
-                                              ns
-                                              range
-                                              replace
-                                              resolve
-                                              seq
-                                              str
-                                              subs
-                                              symbol
-                                              time
-                                              val
-                                              var]}
+                                    :include [binding comp comparator
+                                              count delay empty?
+                                              exists? hash identity
+                                              iter key keys
+                                              list max meta
+                                              methods min new
+                                              ns range replace
+                                              resolve seq str
+                                              subs symbol time
+                                              val var]}
                 :invalid-arity     {:skip-args [status-im.utils.fx/defn utils.re-frame/defn]}
                 ;; TODO remove number when this is fixed
                 ;; https://github.com/borkdude/clj-kondo/issues/867

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -24,6 +24,7 @@
                                               comparator
                                               count
                                               delay
+                                              empty?
                                               identity
                                               iter
                                               key

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -32,10 +32,14 @@
                                               key
                                               keys
                                               list
+                                              max
                                               meta
+                                              methods
+                                              min
                                               new
                                               ns
                                               range
+                                              replace
                                               resolve
                                               seq
                                               str

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -28,6 +28,7 @@
                                               iter
                                               key
                                               str
+                                              subs
                                               symbol
                                               time
                                               val]}

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -20,16 +20,7 @@
                                     ;; future, as we progressively fix shadowed
                                     ;; vars, we should be able to delete this
                                     ;; option and lint all vars.
-                                    :include [binding comp comparator
-                                              count delay empty?
-                                              exists? hash identity
-                                              iter key keys
-                                              list max meta
-                                              methods min new
-                                              ns range replace
-                                              resolve seq str
-                                              subs symbol time
-                                              val var]}
+                                    :exclude [type name]}
                 :invalid-arity     {:skip-args [status-im.utils.fx/defn utils.re-frame/defn]}
                 ;; TODO remove number when this is fixed
                 ;; https://github.com/borkdude/clj-kondo/issues/867

--- a/src/native_module/core.cljs
+++ b/src/native_module/core.cljs
@@ -389,11 +389,11 @@
   []
   (log/debug "[native-module] get-device-model-info")
   ;;NOTE: we have to check for status module because of tests
-  (when-let [^js status (status)]
-    {:model     (.-model status)
-     :brand     (.-brand status)
-     :build-id  (.-buildId status)
-     :device-id (.-deviceId status)}))
+  (when-let [^js status-module (status)]
+    {:model     (.-model status-module)
+     :brand     (.-brand status-module)
+     :build-id  (.-buildId status-module)
+     :device-id (.-deviceId status-module)}))
 
 (defn get-installation-name
   []

--- a/src/quo/components/header.cljs
+++ b/src/quo/components/header.cljs
@@ -35,7 +35,7 @@
    :align-items     :center
    :justify-content :center})
 
-(def left
+(def left-style
   {:position        :absolute
    :left            0
    :top             0
@@ -43,7 +43,7 @@
    :justify-content :center
    :align-items     :flex-start})
 
-(def right
+(def right-style
   {:position        :absolute
    :right           0
    :top             0
@@ -179,7 +179,7 @@
             {:style          content
              :pointer-events :box-none}
             [rn/view
-             {:style          left
+             {:style          left-style
               :on-layout      (handle-layout :left get-layout)
               :pointer-events :box-none}
              [header-actions
@@ -197,7 +197,7 @@
                :component   title-component}]]
 
             [rn/view
-             {:style          right
+             {:style          right-style
               :on-layout      (handle-layout :right get-layout)
               :pointer-events :box-none}
              [header-actions

--- a/src/quo/previews/preview.clj
+++ b/src/quo/previews/preview.clj
@@ -1,10 +1,10 @@
 (ns quo.previews.preview)
 
 (defmacro list-comp
-  [[binding seq-expr & bindings] body-expr]
-  (cond (not binding)
+  [[the-binding seq-expr & bindings] body-expr]
+  (cond (not the-binding)
         `(list ~body-expr)
 
         :else
-        `(mapcat (fn [~binding] (list-comp ~bindings ~body-expr))
+        `(mapcat (fn [~the-binding] (list-comp ~bindings ~body-expr))
           ~seq-expr)))

--- a/src/quo2/components/buttons/slide_button/component_spec.cljs
+++ b/src/quo2/components/buttons/slide_button/component_spec.cljs
@@ -19,15 +19,15 @@
   Reagent and React render."
   [f]
   (js/Promise.
-   (fn [resolve reject]
+   (fn [resolve-fn reject]
      (try
        (.then (rtl/act
-               #(let [p (js/Promise. (fn [resolve _reject]
+               #(let [p (js/Promise. (fn [resolve-fn2 _reject]
                                        (r/after-render (fn reagent-act-after-reagent-flush []
-                                                         (resolve)))))]
+                                                         (resolve-fn2)))))]
                   (f)
                   p))
-              resolve
+              resolve-fn
               reject)
        (catch :default e
          (reject e))))))
@@ -117,4 +117,3 @@
                                                                 gesture-events)))]
         (h/advance-timers-by-time 250)
         (-> promise (.then #(h/was-not-called (:on-complete props))))))))
-

--- a/src/quo2/components/graph/utils.cljs
+++ b/src/quo2/components/graph/utils.cljs
@@ -36,10 +36,10 @@
         (str formatted-scaled-number "0" suffix)))))
 
 (defn calculate-x-axis-labels
-  [array num-elements]
-  (let [array-length (count array)
+  [coll num-elements]
+  (let [array-length (count coll)
         partitions   (partition-all (js/Math.floor (/ array-length (min array-length num-elements)))
-                                    array)]
+                                    coll)]
     (->> partitions
          (map first)
          (map :date))))

--- a/src/quo2/components/graph/wallet_graph/view.cljs
+++ b/src/quo2/components/graph/wallet_graph/view.cljs
@@ -8,7 +8,7 @@
             [quo2.components.markdown.text :as text]
             [quo2.components.graph.utils :as utils]))
 
-(defn- max-data-points
+(defn- time-frame->max-data-points
   [time-frame]
   (case time-frame
     :empty    0
@@ -20,7 +20,7 @@
 
 (defn- view-internal
   [{:keys [data state time-frame theme]}]
-  (let [max-data-points (max-data-points time-frame)
+  (let [max-data-points (time-frame->max-data-points time-frame)
         data            (if (and (not= time-frame :empty) (> (count data) max-data-points))
                           (utils/downsample-data data max-data-points)
                           data)

--- a/src/quo2/components/header.cljs
+++ b/src/quo2/components/header.cljs
@@ -37,7 +37,7 @@
    :align-items     :center
    :justify-content :center})
 
-(def left
+(def left-style
   {:position        :absolute
    :left            0
    :top             0
@@ -45,7 +45,7 @@
    :justify-content :center
    :align-items     :flex-start})
 
-(def right
+(def right-style
   {:position        :absolute
    :right           0
    :top             0
@@ -176,7 +176,7 @@
             {:style          content
              :pointer-events :box-none}
             [rn/view
-             {:style          left
+             {:style          left-style
               :on-layout      (handle-layout :left get-layout)
               :pointer-events :box-none}
              [header-actions
@@ -194,7 +194,7 @@
                :component   title-component}]]
 
             [rn/view
-             {:style          right
+             {:style          right-style
               :on-layout      (handle-layout :right get-layout)
               :pointer-events :box-none}
              [header-actions

--- a/src/quo2/components/profile/profile_card/view.cljs
+++ b/src/quo2/components/profile/profile_card/view.cljs
@@ -11,7 +11,7 @@
             [quo2.components.avatars.user-avatar.view :as user-avatar]))
 
 (defn- f-profile-card-component
-  [{:keys [keycard-account? profile-picture name hash
+  [{:keys [keycard-account? profile-picture name
            customization-color emoji-hash on-options-press
            show-emoji-hash? show-options-button? show-user-hash?
            show-logged-in? on-card-press login-card? last-item? card-style]
@@ -24,7 +24,8 @@
            login-card?          false
            last-item?           false
            card-style           {:padding-horizontal 20
-                                 :flex               1}}}]
+                                 :flex               1}}
+    :as   args}]
   (let [{:keys [width]}      (rn/get-window)
         padding-bottom       (cond
                                login-card?      38
@@ -94,7 +95,8 @@
        (when show-user-hash?
          [text/text
           {:weight :monospace
-           :style  style/user-hash} hash])
+           :style  style/user-hash}
+          (:hash args)])
        (when (and show-emoji-hash? emoji-hash)
          [text/text
           {:weight          :monospace

--- a/src/quo2/components/record_audio/record_audio/helpers.cljs
+++ b/src/quo2/components/record_audio/record_audio/helpers.cljs
@@ -10,22 +10,22 @@
    :linear))
 
 (defn animate-linear-with-delay
-  [shared-value value duration delay]
+  [shared-value value duration delay-ms]
   (reanimated/animate-shared-value-with-delay
    shared-value
    value
    duration
    :linear
-   delay))
+   delay-ms))
 
 (defn animate-linear-with-delay-loop
-  [shared-value value duration delay]
+  [shared-value value duration delay-ms]
   (reanimated/animate-shared-value-with-delay-repeat
    shared-value
    value
    duration
    :linear
-   delay
+   delay-ms
    -1))
 
 (defn animate-easing
@@ -37,13 +37,13 @@
    :easing1))
 
 (defn animate-easing-with-delay
-  [shared-value value duration delay]
+  [shared-value value duration delay-ms]
   (reanimated/animate-shared-value-with-delay
    shared-value
    value
    duration
    :easing1
-   delay))
+   delay-ms))
 
 (defn set-value
   [shared-value value]

--- a/src/quo2/components/tabs/account_selector.cljs
+++ b/src/quo2/components/tabs/account_selector.cljs
@@ -28,10 +28,6 @@
    :background-color background-color
    :border-radius    12})
 
-(def account-emoji
-  {:height 16
-   :width  16})
-
 (def account-avatar-container
   {:margin-left  4
    :margin-right 8})

--- a/src/quo2/components/wallet/account_card/component_spec.cljs
+++ b/src/quo2/components/wallet/account_card/component_spec.cljs
@@ -6,8 +6,8 @@
 (def empty-username "Account 1")
 
 (defn get-test-data
-  [type watch-only? empty? loading? metrics?]
-  {:name                (if empty? empty-username username)
+  [type watch-only? empty-type? loading? metrics?]
+  {:name                (if empty-type? empty-username username)
    :balance             "€1,000.00"
    :percentage-value    "50%"
    :amount              "€500.00"

--- a/src/quo2/components/wallet/account_card/view.cljs
+++ b/src/quo2/components/wallet/account_card/view.cljs
@@ -11,7 +11,7 @@
 (defn- loading-view
   [{:keys [customization-color type theme metrics?]}]
   (let [watch-only? (= :watch-only type)
-        empty?      (= :empty type)]
+        empty-type? (= :empty type)]
     [rn/view
      {:accessibility-label :loading
       :style               (style/card customization-color watch-only? metrics? theme)}
@@ -28,7 +28,7 @@
        (when watch-only? [icon/icon :reveal {:color colors/neutral-50 :size 12}])]]
      [rn/view
       {:style (assoc (style/loader-view
-                      (if empty? 56 80)
+                      (if empty-type? 56 80)
                       16
                       watch-only?
                       theme)
@@ -38,7 +38,7 @@
        [rn/view
         {:accessibility-label :metrics
          :style               (assoc (style/loader-view
-                                      (if empty? 37 96)
+                                      (if empty-type? 37 96)
                                       8
                                       watch-only?
                                       theme)
@@ -49,7 +49,7 @@
   [{:keys [state name balance percentage-value loading? amount customization-color type emoji metrics?
            theme on-press]}]
   (let [watch-only?        (= :watch-only type)
-        empty?             (= :empty type)
+        empty-type?        (= :empty type)
         account-amount     (if (= :empty state) "€0.00" amount)
         account-name       (if (= :empty state) (i18n/label :t/Account 1) name)
         account-percentage (if (= :empty state) "€0.00" percentage-value)]
@@ -85,7 +85,7 @@
             :accessibility-label :metrics
             :style               (style/metrics watch-only? theme)}
            account-percentage]
-          (when (not empty?)
+          (when (not empty-type?)
             [:<>
              [rn/view (style/separator watch-only? theme)]
              [text/text

--- a/src/react_native/hooks.cljs
+++ b/src/react_native/hooks.cljs
@@ -14,7 +14,7 @@
   (.useBackHandler hooks handler))
 
 (defn use-interval
-  [cb cleanup-cb delay]
+  [cb cleanup-cb delay-ms]
   (let [saved-callback (rn/use-ref)]
     (rn/use-effect
      (fn []
@@ -24,9 +24,9 @@
     (rn/use-effect
      (fn []
        (let [tick (oops/oget saved-callback "current")]
-         (when delay
-           (let [id (js/setInterval tick delay)]
+         (when delay-ms
+           (let [id (js/setInterval tick delay-ms)]
              (fn []
                (cleanup-cb)
                (js/clearInterval id))))))
-     [delay])))
+     [delay-ms])))

--- a/src/react_native/navigation.cljs
+++ b/src/react_native/navigation.cljs
@@ -14,36 +14,40 @@
   (.setRoot ^js Navigation (clj->js root)))
 
 (defn set-stack-root
-  [stack comp]
-  (.setStackRoot ^js Navigation stack (clj->js comp)))
+  [stack component]
+  (.setStackRoot ^js Navigation stack (clj->js component)))
 
 (defn push
   [arg1 arg2]
   (.push ^js Navigation arg1 (clj->js arg2)))
 
-(defn pop [comp] (.pop ^js Navigation comp))
+(defn pop
+  [component]
+  (.pop ^js Navigation component))
 
 (defn show-modal
-  [arg]
-  (.showModal ^js Navigation (clj->js arg)))
+  [component]
+  (.showModal ^js Navigation (clj->js component)))
 
-(defn dismiss-modal [comp] (.dismissModal ^js Navigation comp))
+(defn dismiss-modal
+  [component]
+  (.dismissModal ^js Navigation component))
 
 (defn show-overlay
-  [comp]
-  (.showOverlay Navigation (clj->js comp)))
+  [component]
+  (.showOverlay Navigation (clj->js component)))
 
 (defn pop-to
-  [comp]
-  (.popTo Navigation (clj->js comp)))
+  [component]
+  (.popTo Navigation (clj->js component)))
 
 (defn pop-to-root
   [tab]
   (.popToRoot Navigation (clj->js tab)))
 
 (defn dissmiss-overlay
-  [comp]
-  (.catch (.dismissOverlay Navigation comp) #()))
+  [component]
+  (.catch (.dismissOverlay Navigation component) #()))
 
 (defn reg-app-launched-listener
   [handler]

--- a/src/react_native/reanimated.cljs
+++ b/src/react_native/reanimated.cljs
@@ -122,19 +122,19 @@
                                          "easing"   (get easings easing)))))
 
 (defn animate-shared-value-with-delay
-  [anim v duration easing delay]
+  [anim v duration easing delay-ms]
   (set-shared-value anim
-                    (with-delay delay
+                    (with-delay delay-ms
                                 (with-timing v
                                              (js-obj "duration" duration
                                                      "easing"   (get easings easing))))))
 
 (defn animate-delay
-  ([animation v delay]
-   (animate-delay animation v delay default-duration))
-  ([animation v delay duration]
+  ([animation v delay-ms]
+   (animate-delay animation v delay-ms default-duration))
+  ([animation v delay-ms duration]
    (set-shared-value animation
-                     (with-delay delay
+                     (with-delay delay-ms
                                  (with-timing v
                                               (clj->js {:duration duration
                                                         :easing   (default-easing)}))))))
@@ -149,11 +149,11 @@
                                  reverse?)))
 
 (defn animate-shared-value-with-delay-repeat
-  ([anim v duration easing delay number-of-repetitions]
-   (animate-shared-value-with-delay-repeat anim v duration easing delay number-of-repetitions false))
-  ([anim v duration easing delay number-of-repetitions reverse?]
+  ([anim v duration easing delay-ms number-of-repetitions]
+   (animate-shared-value-with-delay-repeat anim v duration easing delay-ms number-of-repetitions false))
+  ([anim v duration easing delay-ms number-of-repetitions reverse?]
    (set-shared-value anim
-                     (with-delay delay
+                     (with-delay delay-ms
                                  (with-repeat
                                   (with-timing v
                                                #js

--- a/src/status_im/async_storage/core.cljs
+++ b/src/status_im/async_storage/core.cljs
@@ -30,13 +30,13 @@
       (debounced))))
 
 (defn get-items
-  [keys cb]
+  [ks cb]
   (-> ^js async-storage
-      (.multiGet (to-array (map key->string keys)))
+      (.multiGet (to-array (map key->string ks)))
       (.then (fn [^js data]
                (cb (->> (js->clj data)
                         (map (comp transit->clj second))
-                        (zipmap keys)))))
+                        (zipmap ks)))))
       (.catch (fn [error]
                 (cb nil)
                 (log/error "[async-storage]" error)))))
@@ -58,5 +58,5 @@
 
 (re-frame/reg-fx
  ::get
- (fn [{:keys [keys cb]}]
-   (get-items keys cb)))
+ (fn [{ks :keys cb :cb}]
+   (get-items ks cb)))

--- a/src/status_im/bottom_sheet/view.cljs
+++ b/src/status_im/bottom_sheet/view.cljs
@@ -66,7 +66,7 @@
                (and @expanded? (< end-pan-y collapse-threshold))
                (reset! expanded? false))))))))
 
-(defn handle-comp
+(defn handle-view
   [window-width override-theme]
   [rn/view
    {:style {:width            window-width
@@ -151,7 +151,7 @@
                                    close-bottom-sheet
                                    gesture-running?)
              handle-comp [gesture/gesture-detector {:gesture bottom-sheet-gesture}
-                          [handle-comp window-width override-theme]]]
+                          [handle-view window-width override-theme]]]
 
          (react/effect! #(do
                            (cond

--- a/src/status_im/chat/models/message.cljs
+++ b/src/status_im/chat/models/message.cljs
@@ -47,7 +47,7 @@
 
 (defn add-message
   [{:keys [db] :as acc} message-js chat-id message-id cursor-clock-value]
-  (let [{:keys [replace from clock-value] :as message}
+  (let [{:keys [from clock-value] :as message}
         (data-store.messages/<-rpc (types/js->clj message-js))
         acc-with-pinned-message (add-pinned-message acc chat-id message-id message)]
     (if (message-loaded? db chat-id message-id)
@@ -72,9 +72,9 @@
         (not (get-in db [:chats chat-id :users from]))
         (update :senders assoc from message)
 
-        (not (string/blank? replace))
+        (not (string/blank? (:replace message)))
         ;;TODO this is expensive
-        (hide-message chat-id replace)))))
+        (hide-message chat-id (:replace message))))))
 
 (defn reduce-js-messages
   [{:keys [db] :as acc} ^js message-js]
@@ -93,11 +93,11 @@
         (add-message acc message-js chat-id message-id cursor-clock-value)
         ;; Not in the current view, set all-loaded to false
         ;; and offload to db and update cursor if necessary
-        ;;TODO if we'll offload messages , it will conflict with end reached, so probably if we reached
-        ;;the end of visible area,
-        ;; we need to drop other messages with (< clock-value cursor-clock-value) from response-js so we
-        ;; don't update
-        ;; :cursor-clock-value because it will be changed when we loadMore message
+        ;;TODO if we'll offload messages , it will conflict with end reached, so probably if we
+        ;;reached the end of visible area,
+        ;; we need to drop other messages with (< clock-value cursor-clock-value) from response-js
+        ;; so we don't update :cursor-clock-value because it will be changed when we loadMore
+        ;; message
         {:db (cond-> (assoc-in db [:pagination-info chat-id :all-loaded?] false)
                (> clock-value cursor-clock-value)
                ;;TODO cut older messages from messages-list
@@ -114,8 +114,8 @@
         (reduce reduce-js-messages
                 {:db db :chats #{} :senders {} :transactions #{}}
                 messages-js)]
-    ;;we want to render new messages as soon as possible
-    ;;so we dispatch later all other events which can be handled async
+    ;;we want to render new messages as soon as possible so we dispatch later all other events which
+    ;;can be handled async
     {:db db
      :utils/dispatch-later
      (concat [{:ms 20 :dispatch [:process-response response-js]}]

--- a/src/status_im/ethereum/core.cljs
+++ b/src/status_im/ethereum/core.cljs
@@ -163,8 +163,8 @@
       name))
 
 (defn get-current-network
-  [{:networks/keys [current-network networks]}]
-  (get networks current-network))
+  [m]
+  (get (:networks/networks m) (:networks/current-network m)))
 
 (defn chain-keyword
   [db]

--- a/src/status_im/ethereum/ens.cljs
+++ b/src/status_im/ethereum/ens.cljs
@@ -69,13 +69,13 @@
                   #(cb (* (js/Number (native-module/hex-to-number %)) 1000))}))
 
 (defn register-prepare-tx
-  [chain-id from ens-name pubkey cb]
+  [chain-id from ens-name public-key cb]
   (json-rpc/call {:method     "ens_registerPrepareTx"
-                  :params     [chain-id {:from from} ens-name pubkey]
+                  :params     [chain-id {:from from} ens-name public-key]
                   :on-success cb}))
 
 (defn set-pub-key-prepare-tx
-  [chain-id from ens-name pubkey cb]
+  [chain-id from ens-name public-key cb]
   (json-rpc/call {:method     "ens_setPubKeyPrepareTx"
-                  :params     [chain-id {:from from} ens-name pubkey]
+                  :params     [chain-id {:from from} ens-name public-key]
                   :on-success cb}))

--- a/src/status_im/ethereum/stateofus.cljs
+++ b/src/status_im/ethereum/stateofus.cljs
@@ -57,10 +57,9 @@
     (= s (string/lower-case s))))
 
 (defn valid-username?
-  [username]
-  (boolean
-   (and (lower-case? username)
-        (re-find #"^[a-z0-9]+$" username))))
+  [s]
+  (boolean (and (lower-case? s)
+                (re-find #"^[a-z0-9]+$" s))))
 
 (defn ens-name-parse
   [contact-identity]

--- a/src/status_im/ethereum/transactions/core.cljs
+++ b/src/status_im/ethereum/transactions/core.cljs
@@ -24,20 +24,20 @@
 (def network->subdomain {5 "goerli"})
 
 (defn get-transaction-details-url
-  [chain-id hash]
-  {:pre  [(number? chain-id) (string? hash)]
+  [chain-id tx-hash]
+  {:pre  [(number? chain-id) (string? tx-hash)]
    :post [(or (nil? %) (string? %))]}
   (cond
     (etherscan-supported? chain-id)
     (let [network-subdomain (when-let [subdomain (network->subdomain chain-id)]
                               (str subdomain "."))]
-      (str "https://" network-subdomain "etherscan.io/tx/" hash))
+      (str "https://" network-subdomain "etherscan.io/tx/" tx-hash))
 
     (= chain-id binance-mainnet-chain-id)
-    (str "https://bscscan.com/tx/" hash)
+    (str "https://bscscan.com/tx/" tx-hash)
 
     (= chain-id binance-testnet-chain-id)
-    (str "https://testnet.bscscan.com/tx/" hash)))
+    (str "https://testnet.bscscan.com/tx/" tx-hash)))
 
 (def default-erc20-token
   {:symbol   :ERC20

--- a/src/status_im/keycard/card.cljs
+++ b/src/status_im/keycard/card.cljs
@@ -504,11 +504,11 @@
         (error-object->map response)]))}))
 
 (defn sign-typed-data
-  [{:keys [hash]}]
+  [{card-hash :hash}]
   (log/debug "[keycard] sign-typed-data")
   (keycard/sign-typed-data
    card
-   {:hash hash
+   {:hash card-hash
     :on-success
     (fn [response]
       (log/debug "[keycard response succ] sign-typed-data")

--- a/src/status_im/keycard/real_keycard.cljs
+++ b/src/status_im/keycard/real_keycard.cljs
@@ -273,24 +273,24 @@
         (catch on-failure))))
 
 (defn sign
-  [{:keys [pin path hash on-success on-failure]}]
+  [{pin :pin path :path card-hash :hash on-success :on-success on-failure :on-failure}]
   (log/debug "keycard sign" "path" path)
-  (when (and pin hash)
+  (when (and pin card-hash)
     (if path
       (.. status-keycard
-          (signWithPath pin path hash)
+          (signWithPath pin path card-hash)
           (then on-success)
           (catch on-failure))
       (.. status-keycard
-          (sign pin hash)
+          (sign pin card-hash)
           (then on-success)
           (catch on-failure)))))
 
 (defn sign-typed-data
-  [{:keys [hash on-success on-failure]}]
-  (when hash
+  [{card-hash :hash on-success :on-success on-failure :on-failure}]
+  (when card-hash
     (.. status-keycard
-        (signPinless hash)
+        (signPinless card-hash)
         (then on-success)
         (catch on-failure))))
 

--- a/src/status_im/keycard/simulated_keycard.cljs
+++ b/src/status_im/keycard/simulated_keycard.cljs
@@ -450,7 +450,7 @@
 (def import-keys get-keys)
 
 (defn sign
-  [{:keys [pin hash data path typed? on-success on-failure]}]
+  [{:keys [pin data path typed? on-success on-failure] :as card}]
   (with-pin pin
             on-failure
             #(let [address
@@ -469,7 +469,7 @@
                  (let [params (types/clj->json
                                {:account  address
                                 :password password
-                                :data     (or data (str "0x" hash))})]
+                                :data     (or data (str "0x" (:hash card)))})]
                    (native-module/sign-message
                     params
                     (fn [res]

--- a/src/status_im/keycard/simulated_keycard.cljs
+++ b/src/status_im/keycard/simulated_keycard.cljs
@@ -429,19 +429,19 @@
   (with-pin pin
             on-failure
             (if @derived-acc
-              (let [[id keys] (multiaccount->keys @derived-acc)]
+              (let [[id account-keys] (multiaccount->keys @derived-acc)]
                 (swap! state assoc-in
                   [:application-info :key-uid]
-                  (:key-uid keys))
+                  (:key-uid account-keys))
                 (native-module/multiaccount-store-derived
                  id
-                 (:key-uid keys)
+                 (:key-uid account-keys)
                  [constants/path-wallet-root
                   constants/path-eip1581
                   constants/path-whisper
                   constants/path-default-wallet]
                  account-password
-                 #(on-success keys)))
+                 #(on-success account-keys)))
               #(on-success
                 {:key-uid               (get-in @state [:application-info :key-uid])
                  :instance-uid          (get-in @state [:application-info :instance-uid])

--- a/src/status_im/node/core.cljs
+++ b/src/status_im/node/core.cljs
@@ -119,10 +119,10 @@
   [{:keys [profile/profile :networks/networks :networks/current-network]
     :as   db}]
   (let [wakuv2-config (get profile :wakuv2-config {})
-        current-fleet-key (current-fleet-key db)
+        fleet-key (current-fleet-key db)
         current-fleet (get-current-fleet db)
         wakuv2-enabled (wakuv2-enabled? current-fleet)
-        waku-nodes (get config/waku-nodes-config current-fleet-key)
+        waku-nodes (get config/waku-nodes-config fleet-key)
         rendezvous-nodes (pick-nodes 3 (vals (:rendezvous current-fleet)))
         {:keys [installation-id log-level
                 waku-bloom-filter-mode
@@ -140,7 +140,7 @@
       (assoc :NoDiscovery   wakuv2-enabled
              :Rendezvous    (if wakuv2-enabled false (boolean (seq rendezvous-nodes)))
              :ClusterConfig {:Enabled true
-                             :Fleet (name current-fleet-key)
+                             :Fleet (name fleet-key)
                              :DiscV5BootstrapNodes
                              (if wakuv2-enabled
                                waku-nodes

--- a/src/status_im/notifications/core.cljs
+++ b/src/status_im/notifications/core.cljs
@@ -288,8 +288,10 @@
        (= (:identifier x) (:identifier y))))
 
 (defn- update-preference
-  [all new]
-  (conj (filter (comp not (partial preference= new)) all) new))
+  [all new-preference]
+  (conj (filter (comp not (partial preference= new-preference))
+                all)
+        new-preference))
 
 (rf/defn switch-transaction-notifications
   {:events [::switch-transaction-notifications]}

--- a/src/status_im/signing/core.cljs
+++ b/src/status_im/signing/core.cljs
@@ -200,10 +200,10 @@
              :symbol   (:symbol token)}))))))
 
 (defn parse-tx-obj
-  [db {:keys [from to value data cancel? hash]}]
+  [db {:keys [from to value data cancel?] :as tx}]
   (merge {:from    {:address from}
           :cancel? cancel?
-          :hash    hash}
+          :hash    (:hash tx)}
          (if (nil? to)
            {:contact {:name (i18n/label :t/new-contract)}}
            (let [eth-value  (when value (money/bignumber value))
@@ -562,10 +562,10 @@
 
 (re-frame/reg-fx
  :signing/get-transaction-by-hash-fx
- (fn [[hash handler]]
+ (fn [[tx-hash handler]]
    (json-rpc/call
     {:method     "eth_getTransactionByHash"
-     :params     [hash]
+     :params     [tx-hash]
      :on-success handler})))
 
 (rf/defn cancel-transaction-pressed

--- a/src/status_im/test_runner.cljs
+++ b/src/status_im/test_runner.cljs
@@ -64,16 +64,16 @@
 
     (->> (env/get-test-vars)
          (filter (fn [the-var]
-                   (let [{:keys [name ns]} (meta the-var)]
-                     (or (contains? test-namespaces ns)
-                         (contains? test-var-syms (symbol ns name)))))))))
+                   (let [{name :name the-ns :ns} (meta the-var)]
+                     (or (contains? test-namespaces the-ns)
+                         (contains? test-var-syms (symbol the-ns name)))))))))
 
 (defn execute-cli
   [{:keys [test-syms help list repl] :as _opts}]
   (let [test-env
         (-> (ct/empty-env)
-            ;; can't think of a proper way to let CLI specify custom reporter?
-            ;; :report-fn is mostly for UI purposes, CLI should be fine with default report
+            ;; can't think of a proper way to let CLI specify custom reporter? :report-fn is mostly
+            ;; for UI purposes, CLI should be fine with default report
             #_(assoc :report-fn
                      (fn [m]
                        (tap> [:test m (ct/get-current-env)])
@@ -89,10 +89,10 @@
         (println "  --repl (start node without automatically running tests)"))
 
       list
-      (doseq [[ns ns-info]
+      (doseq [[the-ns ns-info]
               (->> (env/get-tests)
                    (sort-by first))]
-        (println "Namespace:" ns)
+        (println "Namespace:" the-ns)
         (doseq [var  (:vars ns-info)
                 :let [m (meta var)]]
           (println (str "  " (:ns m) "/" (:name m))))

--- a/src/status_im/test_runner.cljs
+++ b/src/status_im/test_runner.cljs
@@ -69,7 +69,7 @@
                          (contains? test-var-syms (symbol the-ns name)))))))))
 
 (defn execute-cli
-  [{:keys [test-syms help list repl] :as _opts}]
+  [{:keys [test-syms help repl] :as opts}]
   (let [test-env
         (-> (ct/empty-env)
             ;; can't think of a proper way to let CLI specify custom reporter? :report-fn is mostly
@@ -88,7 +88,7 @@
          "  --test=<ns-to-test>,<fqn-symbol-to-test> (run test for namespace or single var, separated by comma)")
         (println "  --repl (start node without automatically running tests)"))
 
-      list
+      (:list opts)
       (doseq [[the-ns ns-info]
               (->> (env/get-tests)
                    (sort-by first))]

--- a/src/status_im/test_runner.cljs
+++ b/src/status_im/test_runner.cljs
@@ -93,8 +93,8 @@
               (->> (env/get-tests)
                    (sort-by first))]
         (println "Namespace:" the-ns)
-        (doseq [var  (:vars ns-info)
-                :let [m (meta var)]]
+        (doseq [the-var (:vars ns-info)
+                :let    [m (meta the-var)]]
           (println (str "  " (:ns m) "/" (:name m))))
         (println "---------------------------------"))
 

--- a/src/status_im/transport/message/core.cljs
+++ b/src/status_im/transport/message/core.cljs
@@ -202,10 +202,10 @@
         message-type            (.-messageType message-js)
         from                    (.-from message-js)
         mentioned               (.-mentioned message-js)
-        new                     (.-new message-js)
+        new-message             (.-new message-js)
         current                 (= current-chat-id chat-id)
         should-update-unviewed? (and (not current)
-                                     new
+                                     new-message
                                      (not (= message-type
                                              constants/message-type-private-group-system-message))
                                      (not (= from (get-in db [:profile/profile :public-key]))))
@@ -300,8 +300,7 @@
            (get-in db [:transport/message-envelopes message-id])]
     (when-let [{:keys [from]} (get-in db [:messages chat-id message-id])]
       (check-confirmations cofx status chat-id message-id))
-    ;; We don't have a message-envelope for this, might be that the confirmation
-    ;; came too early
+    ;; We don't have a message-envelope for this, might be that the confirmation came too early
     {:db (update-in db [:transport/message-confirmations message-id] conj status)}))
 
 (rf/defn update-envelopes-status

--- a/src/status_im/ui/components/react.cljs
+++ b/src/status_im/ui/components/react.cljs
@@ -153,14 +153,14 @@
 
 (defn text-input
   [options _]
-  (let [render-fn (fn [options text]
+  (let [render-fn (fn [options value]
                     [text-input-class
                      (merge
                       {:underline-color-android  :transparent
                        :max-font-size-multiplier max-font-size-multiplier
                        :placeholder-text-color   colors/text-gray
                        :placeholder              (i18n/label :t/type-a-message)
-                       :value                    text}
+                       :value                    value}
                       (-> options
                           (dissoc :preserve-input?)
                           (update :style typography/get-style)
@@ -172,7 +172,7 @@
          {:component-will-unmount #(when @input-ref
                                      (swap! text-input-refs dissoc @input-ref))
           :reagent-render
-          (fn [options text]
+          (fn [options value]
             (render-fn (assoc options
                               :ref
                               (fn [r]
@@ -183,7 +183,7 @@
                                 (reset! input-ref r)
                                 (when (:ref options)
                                   ((:ref options) r))))
-                       text))})))))
+                       value))})))))
 
 (defn i18n-text
   [{style :style k :key}]
@@ -248,8 +248,8 @@
   (.-Share react-native))
 
 (defn copy-to-clipboard
-  [text]
-  (.setString ^js Clipboard text))
+  [s]
+  (.setString ^js Clipboard s))
 
 (defn get-from-clipboard
   [clbk]

--- a/src/status_im/ui/components/react.cljs
+++ b/src/status_im/ui/components/react.cljs
@@ -288,7 +288,7 @@
   (vec (conj children props scroll-view-class)))
 
 (views/defview with-activity-indicator
-  [{:keys [timeout style enabled? preview]} comp]
+  [{:keys [timeout style enabled? preview]} component]
   (views/letsubs
     [loading (reagent/atom true)]
     {:component-did-mount (fn []
@@ -304,7 +304,7 @@
                        {:justify-content :center
                         :align-items     :center})}
            [activity-indicator {:animating true}]])
-      comp)))
+      component)))
 
 (defn hw-back-add-listener
   [callback]

--- a/src/status_im/ui/screens/appearance/views.cljs
+++ b/src/status_im/ui/screens/appearance/views.cljs
@@ -19,7 +19,7 @@
     [react/text {:style {:margin-top 8}}
      (i18n/label label)]]])
 
-(views/defview appearance
+(views/defview appearance-view
   []
   (views/letsubs [{:keys [appearance]} [:profile/profile]]
     [:<>

--- a/src/status_im/ui/screens/browser/bookmarks/views.cljs
+++ b/src/status_im/ui/screens/browser/bookmarks/views.cljs
@@ -11,10 +11,10 @@
             [status-im.ui.components.topbar :as topbar]))
 
 (defn screen
-  [{:keys [url name new]}]
+  [{url :url name :name new-arg :new}]
   (let [input-name (reagent/atom name)]
     (fn []
-      (let [edit? (not new)]
+      (let [edit? (not new-arg)]
         [kb-presentation/keyboard-avoiding-view
          {:style         {:flex 1}
           :ignore-offset true}

--- a/src/status_im/ui/screens/browser/empty_tab/views.cljs
+++ b/src/status_im/ui/screens/browser/empty_tab/views.cljs
@@ -82,14 +82,14 @@
 (defn dapp-image [] [components.common/image-contain nil dapp-image-data])
 
 (defn list-header
-  [empty?]
+  [empty-bookmarks?]
   [react/view
    [react/touchable-highlight {:on-press #(re-frame/dispatch [:browser.ui/open-url "https://dap.ps"])}
     [react/view (styles/dapp-store-container)
      [dapp-image nil dapp-image-data]
      [react/text {:style styles/open-dapp-store} (i18n/label :t/open-dapp-store)]
      [react/text {:style {:color colors/blue :font-size 13 :line-height 22}} "https://dap.ps ->"]]]
-   (when-not empty?
+   (when-not empty-bookmarks?
      [react/view {:margin-top 14 :margin-left 16 :margin-bottom 4}
       [react/text {:style {:line-height 22 :font-size 15 :color colors/gray}}
        (i18n/label :t/favourites)]])])

--- a/src/status_im/ui/screens/browser/views.cljs
+++ b/src/status_im/ui/screens/browser/views.cljs
@@ -220,8 +220,7 @@
                                                         url
                                                         @webview-ref/webview-ref)
                                                        (block-resources-access-and-notify-user url))
-        ;; Extract event data here due to
-        ;; https://reactjs.org/docs/events.html#event-pooling
+        ;; Extract event data here due to https://reactjs.org/docs/events.html#event-pooling
         :on-message                                 #(re-frame/dispatch [:browser/bridge-message-received
                                                                          (.. ^js % -nativeEvent -data)])
         :on-load                                    #(re-frame/dispatch [:browser/loading-started])
@@ -245,16 +244,16 @@
 (views/defview browser
   []
   (views/letsubs [window-width [:dimensions/window-width]
-                  {:keys [browser-id dapp? dapp name unsafe? ignore-unsafe secure?] :as browser}
+                  {:keys [browser-id dapp? dapp name unsafe? ignore-unsafe secure?] :as current-browser}
                   [:get-current-browser]
                   {:keys [url error? loading? url-editing? show-tooltip show-permission resolving?]}
                   [:browser/options]
                   dapps-account [:dapps-account]
                   network-id [:chain-id]
                   {:keys [webview-allow-permission-requests?]} [:profile/profile]]
-    (let [can-go-back?    (browser/can-go-back? browser)
-          can-go-forward? (browser/can-go-forward? browser)
-          url-original    (browser/get-current-url browser)]
+    (let [can-go-back?    (browser/can-go-back? current-browser)
+          can-go-forward? (browser/can-go-forward? current-browser)
+          url-original    (browser/get-current-url current-browser)]
       [react/view {:style styles/browser}
        [toolbar-content url url-original secure? url-editing? unsafe?]
        [components/separator-dark]

--- a/src/status_im/ui/screens/communities/membership.cljs
+++ b/src/status_im/ui/screens/communities/membership.cljs
@@ -28,7 +28,7 @@
     (i18n/label description)]
    [quo/separator {:style {:margin-vertical 8}}]])
 
-(defn membership
+(defn membership-view
   []
   (let [{:keys [membership]} (rf/sub [:communities/create])]
     [:<>

--- a/src/status_im/ui/screens/ens/views.cljs
+++ b/src/status_im/ui/screens/ens/views.cljs
@@ -182,8 +182,7 @@
   (let [input-ref (atom nil)]
     (fn [_ state placeholder]
       [react/view {:flex-direction :row :justify-content :center}
-       ;;NOTE required so that the keyboards shows up when navigating
-       ;;back from checkout screen
+       ;;NOTE required so that the keyboards shows up when navigating back from checkout screen
        ;; TODO: navigation-events were deprecated
        ;; [:> navigation/navigation-events
        ;;  {:on-did-focus
@@ -220,8 +219,7 @@
     [react/keyboard-avoiding-view {:flex 1}
      [react/scroll-view
       {:style                        {:flex 1}
-       ;;NOTE required so that switching custom-domain
-       ;;works on first tap and persists keyboard
+       ;;NOTE required so that switching custom-domain works on first tap and persists keyboard
        ;;instead of dismissing keyboard and requiring two taps
        :keyboard-should-persist-taps :always}
       [react/view {:style {:flex 1}}
@@ -556,9 +554,8 @@
            {:title   (i18n/label :t/key)
             :content public-key}]])
        [react/view {:style {:margin-top 16 :margin-bottom 32}}
-        ;;TODO this is temporary fix for accounts with failed txs
-        ;;we still need this for regular ens names (not pending) but we need to detach public key in the
-        ;;contract
+        ;;TODO this is temporary fix for accounts with failed txs we still need this for regular ens
+        ;;names (not pending) but we need to detach public key in the contract
         (when pending?
           [quo/list-item
            {:title    (i18n/label :t/ens-remove-username)
@@ -699,13 +696,13 @@
 (views/defview in-progress-registrations
   [registrations]
   [react/view {:style {:margin-top 8}}
-   (for [[hash {:keys [state username]}] registrations
-         :when                           (or (= state :submitted) (= state :failure))]
-     ^{:key hash}
+   (for [[tx-hash {:keys [state username]}] registrations
+         :when                              (or (= state :submitted) (= state :failure))]
+     ^{:key tx-hash}
      [name-item
       {:name     username
        :action   (when-not (= state :submitted)
-                   #(re-frame/dispatch [:clear-ens-registration hash]))
+                   #(re-frame/dispatch [:clear-ens-registration tx-hash]))
        :subtitle (case state
                    :submitted (i18n/label :t/ens-registration-in-progress)
                    :failure   (i18n/label :t/ens-registration-failure)

--- a/src/status_im/ui/screens/group/views.cljs
+++ b/src/status_im/ui/screens/group/views.cljs
@@ -25,7 +25,7 @@
       :subtitle secondary-name
       :icon     [chat-icon/contact-icon-contacts-tab row]}]))
 
-(defn- on-toggle
+(defn- on-toggle-default
   [allow-new-users? checked? public-key]
   (cond
 
@@ -64,7 +64,7 @@
 
 (defn- group-toggle-contact
   [contact _ _ allow-new-users?]
-  [toggle-item allow-new-users? :is-contact-selected? contact on-toggle])
+  [toggle-item allow-new-users? :is-contact-selected? contact on-toggle-default])
 
 (defn- group-toggle-participant
   [contact _ _ allow-new-users?]
@@ -79,7 +79,7 @@
     :render-fn                    render-fn
     :keyboard-should-persist-taps :always}])
 
-(defn no-contacts
+(defn no-contacts-view
   [{:keys [no-contacts]}]
   [react/view {:style styles/no-contacts}
    [react/text
@@ -175,7 +175,7 @@
            {:contacts    (filter-contacts @search-value contacts)
             :render-data allow-new-users?
             :render-fn   toggle-fn}]
-          [no-contacts {:no-contacts no-contacts-label}])]])))
+          [no-contacts-view {:no-contacts no-contacts-label}])]])))
 
 ;; Start group chat
 (views/defview contact-toggle-list

--- a/src/status_im/ui/screens/keycard/components/keycard_animation.cljs
+++ b/src/status_im/ui/screens/keycard/components/keycard_animation.cljs
@@ -48,7 +48,7 @@
                                          :outputRange [0 1]})}]}}
    children])
 
-(defn indicator
+(defn indicator-view
   [{:keys [state animation-value]}]
   [indicator-container animation-value
    (case @state
@@ -99,7 +99,7 @@
      :chip-color colors/white}
     nil))
 
-(defn card
+(defn card-view
   [{:keys [card-scale state indicator-value animation-value]}]
   (let [{:keys [card-color
                 chip-color
@@ -136,11 +136,11 @@
        {:color  key-color
         :width  25
         :height 42}]]
-     [indicator
+     [indicator-view
       {:state           state
        :animation-value indicator-value}]]))
 
-(defn phone
+(defn phone-view
   [{:keys [animation-value]}]
   [react/animated-view
    {:style {:position  :absolute
@@ -312,7 +312,7 @@
                                  :small      animation-small
                                  :medium     animation-medium
                                  :big        animation-big}))
-        on-error            #(do
+        on-error-fn         #(do
                                (on-card-disconnected)
                                (on-error
                                 {:state   state
@@ -325,7 +325,7 @@
           (keycard-nfc/remove-event-listener listener))
 
         (reset! listeners [(keycard-nfc/on-card-connected on-card-connected)
-                           (keycard-nfc/on-card-disconnected on-error)])
+                           (keycard-nfc/on-card-disconnected on-error-fn)])
 
         (on-start-animation)
 
@@ -359,10 +359,10 @@
            :size            80
            :color           "#D2D9F0"}]
 
-         [card
+         [card-view
           {:animation-value animation-card
            :state           state
            :indicator-value animation-indicator
            :card-scale      card-scale}]
 
-         [phone {:animation-value animation-phone}]])})))
+         [phone-view {:animation-value animation-phone}]])})))

--- a/src/status_im/ui/screens/keycard/components/keycard_animation.cljs
+++ b/src/status_im/ui/screens/keycard/components/keycard_animation.cljs
@@ -163,10 +163,10 @@
 (def card-easing (animation/bezier 0.77 0 0.175 1))
 
 (defn- circle-animation
-  [animation-value to delay]
+  [animation-value to delay-ms]
   (animation/timing animation-value
                     {:toValue  to
-                     :delay    delay
+                     :delay    delay-ms
                      :duration 1000
                      :easing   circle-easing}))
 

--- a/src/status_im/ui/screens/keycard/onboarding/views.cljs
+++ b/src/status_im/ui/screens/keycard/onboarding/views.cljs
@@ -93,9 +93,9 @@
 
 (defview puk-code
   []
-  (letsubs [secrets  [:keycard-secrets]
-            steps    [:keycard-flow-steps]
-            puk-code [:keycard-puk-code]]
+  (letsubs [secrets [:keycard-secrets]
+            steps   [:keycard-flow-steps]
+            puk     [:keycard-puk-code]]
     [react/view styles/container
      [topbar/topbar
       {:navigation {:on-press #(re-frame/dispatch [::keycard.onboarding/cancel-pressed])
@@ -151,7 +151,7 @@
               :size                :large
               :monospace           true
               :accessibility-label :puk-code}
-             puk-code]]]]
+             puk]]]]
          [react/view {:margin-top 16}
           [react/text {:style {:color colors/gray}}
            (i18n/label :t/puk-code-explanation)]]
@@ -199,7 +199,7 @@
 
 (defview pin
   []
-  (letsubs [pin           [:keycard/pin]
+  (letsubs [card-pin      [:keycard/pin]
             enter-step    [:keycard/pin-enter-step]
             status        [:keycard/pin-status]
             error-label   [:keycard/pin-error-label]
@@ -236,7 +236,7 @@
           [react/text {:style {:color colors/gray}}
            (i18n/label :t/intro-wizard-text4)])]]
       [pin.views/pin-view
-       {:pin           pin
+       {:pin           card-pin
         :status        status
         :small-screen? small-screen?
         :error-label   error-label

--- a/src/status_im/ui/screens/keycard/recovery/views.cljs
+++ b/src/status_im/ui/screens/keycard/recovery/views.cljs
@@ -80,7 +80,7 @@
 
 (defview pin
   []
-  (letsubs [pin           [:keycard/pin]
+  (letsubs [card-pin      [:keycard/pin]
             status        [:keycard/pin-status]
             error-label   [:keycard/pin-error-label]
             small-screen? [:dimensions/small-screen?]
@@ -114,7 +114,7 @@
                     :text-align :center}}
            (i18n/label :t/enter-your-code)]]]
         [pin.views/pin-view
-         {:pin           pin
+         {:pin           card-pin
           :retry-counter retry-counter
           :small-screen? small-screen?
           :status        status

--- a/src/status_im/ui/screens/network_info/views.cljs
+++ b/src/status_im/ui/screens/network_info/views.cljs
@@ -15,10 +15,6 @@
     :on-success callback
     :on-error   #(js/alert (str "can't fetch latest block" %))}))
 
-(defn last-loaded-block-number
-  []
-  @(re-frame/subscribe [:ethereum/current-block]))
-
 (defn to-date
   [timestamp]
   (datetime/timestamp->long-date
@@ -37,7 +33,7 @@
              (get-block
               (str "0x"
                    (native-module/number-to-hex
-                    (last-loaded-block-number)))
+                    @(re-frame/subscribe [:ethereum/current-block])))
               (fn [res]
                 (reset! last-loaded-block res))))))]
     (fn []

--- a/src/status_im/ui/screens/pairing/views.cljs
+++ b/src/status_im/ui/screens/pairing/views.cljs
@@ -20,8 +20,7 @@
 (defn synchronize-installations!
   []
   (reset! syncing true)
-  ;; Currently we don't know how long it takes, so we just disable for 10s, to avoid
-  ;; spamming
+  ;; Currently we don't know how long it takes, so we just disable for 10s, to avoid spamming
   (js/setTimeout #(reset! syncing false) 10000)
   (re-frame/dispatch [:pairing.ui/synchronize-installation-pressed]))
 
@@ -44,7 +43,7 @@
     (enable-installation! installation-id)))
 
 (defn footer
-  [syncing]
+  []
   [react/touchable-highlight
    {:on-press (when-not @syncing
                 synchronize-installations!)
@@ -152,13 +151,13 @@
 
 (views/defview installations
   []
-  (views/letsubs [installations [:pairing/installations]]
+  (views/letsubs [installs [:pairing/installations]]
     [:<>
      [react/scroll-view
-      (if (string/blank? (-> installations first :name))
+      (if (string/blank? (-> installs first :name))
         [edit-installation-name]
         [react/view
          [pair-this-device]
          [info-section]
-         [installations-list installations]])]
-     (when (seq installations) [footer syncing])]))
+         [installations-list installs]])]
+     (when (seq installs) [footer])]))

--- a/src/status_im/ui/screens/popover/views.cljs
+++ b/src/status_im/ui/screens/popover/views.cljs
@@ -161,6 +161,6 @@
 
 (views/defview popover
   []
-  (views/letsubs [popover                 [:popover/popover]
+  (views/letsubs [current-popover         [:popover/popover]
                   {window-height :height} [:dimensions/window]]
-    [popover-view popover window-height]))
+    [popover-view current-popover window-height]))

--- a/src/status_im/ui/screens/privacy_and_security_settings/messages_from_contacts_only.cljs
+++ b/src/status_im/ui/screens/privacy_and_security_settings/messages_from_contacts_only.cljs
@@ -15,7 +15,7 @@
                                             value
                                             {}))
 
-(views/defview messages-from-contacts-only
+(views/defview messages-from-contacts-only-view
   []
   (views/letsubs [{:keys [messages-from-contacts-only]} [:profile/profile]]
     [react/view {:margin-top 8}

--- a/src/status_im/ui/screens/profile/visibility_status/utils.cljs
+++ b/src/status_im/ui/screens/profile/visibility_status/utils.cljs
@@ -1,6 +1,5 @@
 (ns status-im.ui.screens.profile.visibility-status.utils
-  (:require [clojure.string :as string]
-            [quo.design-system.colors :as colors]
+  (:require [quo.design-system.colors :as colors]
             [quo2.foundations.colors :as quo2.colors]
             [status-im2.constants :as constants]
             [utils.i18n :as i18n]
@@ -77,14 +76,6 @@
   [{:keys [status-type] :or {status-type constants/visibility-status-inactive}}]
   (:color (get visibility-status-type-data status-type)))
 
-(defn visibility-status-update
-  [public-key]
-  (let [my-icon? (or (string/blank? public-key)
-                     (= public-key (rf/sub [:multiaccount/public-key])))]
-    (if my-icon?
-      (rf/sub [:multiaccount/current-user-visibility-status])
-      (rf/sub [:visibility-status-updates/visibility-status-update public-key]))))
-
 (defn icon-dot-accessibility-label
   [dot-color]
   (if (= dot-color quo2.colors/success-50)
@@ -97,7 +88,7 @@
 
 (defn icon-visibility-status-dot
   [public-key container-size]
-  (let [status    (visibility-status-update public-key)
+  (let [status    (rf/sub [:visibility-status-updates/visibility-status-update public-key])
         size      (icon-dot-size container-size)
         margin    -2
         dot-color (icon-dot-color status)
@@ -112,6 +103,6 @@
 
 (defn visibility-status-order
   [public-key]
-  (let [status    (visibility-status-update public-key)
+  (let [status    (rf/sub [:visibility-status-updates/visibility-status-update public-key])
         dot-color (icon-dot-color status)]
     (if (= dot-color colors/color-online) 0 1)))

--- a/src/status_im/ui/screens/profile/visibility_status/utils.cljs
+++ b/src/status_im/ui/screens/profile/visibility_status/utils.cljs
@@ -83,8 +83,8 @@
       (= public-key (rf/sub [:multiaccount/public-key]))))
 
 (defn visibility-status-update
-  [public-key my-icon?]
-  (if my-icon?
+  [public-key icon?]
+  (if icon?
     (rf/sub [:multiaccount/current-user-visibility-status])
     (rf/sub [:visibility-status-updates/visibility-status-update public-key])))
 
@@ -100,12 +100,12 @@
 
 (defn icon-visibility-status-dot
   [public-key container-size]
-  (let [my-icon?                 (my-icon? public-key)
-        visibility-status-update (visibility-status-update public-key my-icon?)
-        size                     (icon-dot-size container-size)
-        margin                   -2
-        dot-color                (icon-dot-color visibility-status-update)
-        new-ui?                  true]
+  (let [icon?     (my-icon? public-key)
+        status    (visibility-status-update public-key icon?)
+        size      (icon-dot-size container-size)
+        margin    -2
+        dot-color (icon-dot-color status)
+        new-ui?   true]
     (merge (styles/visibility-status-dot {:color   dot-color
                                           :size    size
                                           :new-ui? new-ui?})
@@ -116,7 +116,7 @@
 
 (defn visibility-status-order
   [public-key]
-  (let [my-icon?                 (my-icon? public-key)
-        visibility-status-update (visibility-status-update public-key my-icon?)
-        dot-color                (icon-dot-color visibility-status-update)]
+  (let [icon?     (my-icon? public-key)
+        status    (visibility-status-update public-key icon?)
+        dot-color (icon-dot-color status)]
     (if (= dot-color colors/color-online) 0 1)))

--- a/src/status_im/ui/screens/profile/visibility_status/utils.cljs
+++ b/src/status_im/ui/screens/profile/visibility_status/utils.cljs
@@ -77,7 +77,7 @@
   [{:keys [status-type] :or {status-type constants/visibility-status-inactive}}]
   (:color (get visibility-status-type-data status-type)))
 
-(defn my-icon?
+(defn my-public-key?
   [public-key]
   (or (string/blank? public-key)
       (= public-key (rf/sub [:multiaccount/public-key]))))
@@ -100,8 +100,7 @@
 
 (defn icon-visibility-status-dot
   [public-key container-size]
-  (let [icon?     (my-icon? public-key)
-        status    (visibility-status-update public-key icon?)
+  (let [status    (visibility-status-update public-key (my-public-key? public-key))
         size      (icon-dot-size container-size)
         margin    -2
         dot-color (icon-dot-color status)
@@ -116,7 +115,6 @@
 
 (defn visibility-status-order
   [public-key]
-  (let [icon?     (my-icon? public-key)
-        status    (visibility-status-update public-key icon?)
+  (let [status    (visibility-status-update public-key (my-public-key? public-key))
         dot-color (icon-dot-color status)]
     (if (= dot-color colors/color-online) 0 1)))

--- a/src/status_im/ui/screens/profile/visibility_status/utils.cljs
+++ b/src/status_im/ui/screens/profile/visibility_status/utils.cljs
@@ -77,16 +77,13 @@
   [{:keys [status-type] :or {status-type constants/visibility-status-inactive}}]
   (:color (get visibility-status-type-data status-type)))
 
-(defn my-public-key?
-  [public-key]
-  (or (string/blank? public-key)
-      (= public-key (rf/sub [:multiaccount/public-key]))))
-
 (defn visibility-status-update
-  [public-key icon?]
-  (if icon?
-    (rf/sub [:multiaccount/current-user-visibility-status])
-    (rf/sub [:visibility-status-updates/visibility-status-update public-key])))
+  [public-key]
+  (let [my-icon? (or (string/blank? public-key)
+                     (= public-key (rf/sub [:multiaccount/public-key])))]
+    (if my-icon?
+      (rf/sub [:multiaccount/current-user-visibility-status])
+      (rf/sub [:visibility-status-updates/visibility-status-update public-key]))))
 
 (defn icon-dot-accessibility-label
   [dot-color]
@@ -100,7 +97,7 @@
 
 (defn icon-visibility-status-dot
   [public-key container-size]
-  (let [status    (visibility-status-update public-key (my-public-key? public-key))
+  (let [status    (visibility-status-update public-key)
         size      (icon-dot-size container-size)
         margin    -2
         dot-color (icon-dot-color status)
@@ -115,6 +112,6 @@
 
 (defn visibility-status-order
   [public-key]
-  (let [status    (visibility-status-update public-key (my-public-key? public-key))
+  (let [status    (visibility-status-update public-key)
         dot-color (icon-dot-color status)]
     (if (= dot-color colors/color-online) 0 1)))

--- a/src/status_im/ui/screens/qr_scanner/views.cljs
+++ b/src/status_im/ui/screens/qr_scanner/views.cljs
@@ -59,9 +59,15 @@
        "Ok"]]]))
 
 (defn corner
-  [border1 border2 corner]
+  [border1 border2 corner-radius]
   [react/view
-   (assoc {:border-color colors/white-persist :width 60 :height 60} border1 5 border2 5 corner 32)])
+   {:style (assoc {:border-color colors/white-persist :width 60 :height 60}
+                  border1
+                  5
+                  border2
+                  5
+                  corner-radius
+                  32)}])
 
 (defn- viewfinder
   [size]

--- a/src/status_im/ui/screens/rpc_usage_info.cljs
+++ b/src/status_im/ui/screens/rpc_usage_info.cljs
@@ -19,9 +19,9 @@
  :rpc-usage/data
  :<- [:rpc-usage/raw-data]
  :<- [:rpc-usage/filter]
- (fn [[{:keys [total methods]} method-filter]]
+ (fn [[{total :total rpc-methods :methods} method-filter]]
    (let [data
-         (->> methods
+         (->> rpc-methods
               (map (fn [[k v]]
                      [(name k) v]))
               (filter (fn [[k]]

--- a/src/status_im/ui/screens/screens.cljs
+++ b/src/status_im/ui/screens/screens.cljs
@@ -137,7 +137,7 @@
     :options   {:topBar {:title {:text (i18n/label :t/membership-title)}}
                 :insets {:top?    true
                          :bottom? true}}
-    :component membership/membership}
+    :component membership/membership-view}
 
    ;;WALLET
 
@@ -153,7 +153,7 @@
    {:name      :add-new-account
     ;;TODO dynamic title
     :options   {:insets {:top? true}}
-    :component add-account/add-account}
+    :component add-account/add-account-view}
    {:name      :add-new-account-pin
     ;;TODO dynamic title
     :options   {:insets {:top? true}}
@@ -295,11 +295,11 @@
    {:name      :messages-from-contacts-only
     :options   {:topBar {:title {:text (i18n/label :t/accept-new-chats-from)}}
                 :insets {:top? true}}
-    :component messages-from-contacts-only/messages-from-contacts-only}
+    :component messages-from-contacts-only/messages-from-contacts-only-view}
    {:name      :appearance
     :options   {:topBar {:title {:text (i18n/label :t/appearance)}}
                 :insets {:top? true}}
-    :component appearance/appearance}
+    :component appearance/appearance-view}
    {:name      :privacy-and-security-profile-pic-show-to
     :options   {:topbar {:title {:text (i18n/label :t/show-profile-pictures-to)}}
                 :insets {:top? true}}

--- a/src/status_im/ui/screens/signing/views.cljs
+++ b/src/status_im/ui/screens/signing/views.cljs
@@ -76,7 +76,7 @@
 
 (defn header
   [{:keys [in-progress?] :as sign}
-   {:keys [contact amount approve? cancel? hash]}
+   {:keys [contact amount approve? cancel?] :as tx}
    display-symbol fee fee-display-symbol]
   [react/view styles/header
    (when sign
@@ -94,7 +94,7 @@
                   :else
                   (i18n/label :t/sending))
             (if cancel?
-              (str " " (utils/get-shortened-address hash))
+              (str " " (utils/get-shortened-address (:hash tx)))
               (str " " amount " " display-symbol)))]
       [react/text {:style {:typography :title-bold}} (i18n/label :t/contract-interaction)])
     (if sign

--- a/src/status_im/ui/screens/stickers/views.cljs
+++ b/src/status_im/ui/screens/stickers/views.cljs
@@ -69,13 +69,13 @@
 
 (defview packs
   []
-  (letsubs [packs [:stickers/all-packs]]
+  (letsubs [all-packs [:stickers/all-packs]]
     [react/view styles/screen
      [react/keyboard-avoiding-view {:flex 1}
-      (if (seq packs)
+      (if (seq all-packs)
         [react/scroll-view {:keyboard-should-persist-taps :handled :style {:padding 16}}
          [react/view
-          (for [pack packs]
+          (for [pack all-packs]
             ^{:key pack}
             [pack-badge pack])]]
         [react/view {:flex 1 :align-items :center :justify-content :center}

--- a/src/status_im/ui/screens/wallet/account/views.cljs
+++ b/src/status_im/ui/screens/wallet/account/views.cljs
@@ -305,8 +305,8 @@
 
 (views/defview account
   []
-  (views/letsubs [{:keys [name address] :as account} [:multiaccount/current-account]
-                  fetching-error                     [:wallet/fetching-error]]
+  (views/letsubs [{:keys [name address] :as current-account} [:multiaccount/current-account]
+                  fetching-error                             [:wallet/fetching-error]]
     (let [anim-y   (animation/create-value button-group-height)
           scroll-y (animation/create-value 0)]
       (anim-listener anim-y scroll-y)
@@ -356,9 +356,9 @@
         [react/view {:padding-left 16}
          [react/scroll-view {:horizontal true}
           [react/view {:flex-direction :row :padding-top 8 :padding-bottom 12}
-           [account-card account]]]]
+           [account-card current-account]]]]
         (if config/swap-enabled?
           [top-actions]
           [buy-crypto/banner])
         [assets-and-collections address]]
-       [bottom-send-recv-buttons account anim-y]])))
+       [bottom-send-recv-buttons current-account anim-y]])))

--- a/src/status_im/ui/screens/wallet/accounts/views.cljs
+++ b/src/status_im/ui/screens/wallet/accounts/views.cljs
@@ -268,11 +268,11 @@
 
 (views/defview accounts
   [selected-account-atom]
-  (views/letsubs [accounts [:multiaccount/visible-accounts]]
+  (views/letsubs [visible-accounts [:multiaccount/visible-accounts]]
     ;keycard? [:keycard-multiaccount?]]
     (do
-      (reset! selected-account-atom (:address (first accounts)))
-      (let [accounts-data (for [account accounts]
+      (reset! selected-account-atom (:address (first visible-accounts)))
+      (let [accounts-data (for [account visible-accounts]
                             {:label (:name account)
                              :id    (:address account)})]
         [react/scroll-view
@@ -283,7 +283,7 @@
           :margin-bottom                     20}
          [react/view {:flex-direction :row}
           [quo2/tabs
-           {:default-active (:address (first accounts))
+           {:default-active (:address (first visible-accounts))
             :on-change      #(reset! selected-account-atom %)
             :data           accounts-data}]
           [quo2/button

--- a/src/status_im/ui/screens/wallet/add_new/views.cljs
+++ b/src/status_im/ui/screens/wallet/add_new/views.cljs
@@ -127,7 +127,7 @@
 
 (defview pin
   []
-  (letsubs [pin           [:keycard/pin]
+  (letsubs [card-pin      [:keycard/pin]
             status        [:keycard/pin-status]
             error-label   [:keycard/pin-error-label]
             retry-counter [:keycard/retry-counter]]
@@ -140,7 +140,7 @@
        [{:label    (i18n/label :t/cancel)
          :on-press #(re-frame/dispatch [:keycard/new-account-pin-sheet-hide])}]}]
      [pin.views/pin-view
-      {:pin               pin
+      {:pin               card-pin
        :status            status
        :retry-counter     retry-counter
        :title-label       :t/current-pin
@@ -148,7 +148,7 @@
        :error-label       error-label
        :step              :export-key}]]))
 
-(defview add-account
+(defview add-account-view
   []
   (letsubs [{:keys [type account] :as add-account} [:add-account]
             add-account-disabled?                  [:add-account-disabled?]

--- a/src/status_im/utils/async.cljs
+++ b/src/status_im/utils/async.cljs
@@ -47,11 +47,11 @@
   channel constructor.
   Returns task-queue where tasks represented by 0 arg task functions can be put for processing."
   [& args]
-  (let [task-queue (apply async/chan args)]
-    (async/go-loop [task-fn (async/<! task-queue)]
+  (let [queue (apply async/chan args)]
+    (async/go-loop [task-fn (async/<! queue)]
       (run-task task-fn)
-      (recur (async/<! task-queue)))
-    task-queue))
+      (recur (async/<! queue)))
+    queue))
 
 ;; ---------------------------------------------------------------------------
 ;; Periodic background job

--- a/src/status_im/utils/priority_map.cljs
+++ b/src/status_im/utils/priority_map.cljs
@@ -7,6 +7,7 @@
 ;; https://github.com/tailrecursion/cljs-priority-map/blob/master/src/cljs/tailrecursion/priority_map.cljs
 ;; fixing `vals` and `keys` function
 
+#_{:clj-kondo/ignore [:shadowed-var]}
 (deftype PersistentPriorityMap [priority->set-of-items item->priority meta keyfn ^:mutable __hash]
   IPrintWithWriter
     (-pr-writer [coll writer opts]

--- a/src/status_im/utils/views.clj
+++ b/src/status_im/utils/views.clj
@@ -15,14 +15,14 @@
     (or (form->sym sub) sub)))
 
 (defn prepare-subs
-  [subs]
+  [subscriptions]
   (let [pairs     (map (fn [[form sub]]
                          {:form form
                           :sub  sub
                           :sym  (if (atom? sub)
                                   (gensym (str (if (map? form) "keys" form)))
                                   form)})
-                       (partition 2 subs))
+                       (partition 2 subscriptions))
         form->sym (->> pairs
                        (map (fn [{:keys [form sym]}]
                               [form sym]))
@@ -45,19 +45,19 @@
 
 (defmacro defview
   [n params & rest-body]
-  (let [first-symbol                  (ffirst rest-body)
-        rest-body'                    (if (and (symbol? first-symbol)
-                                               (= (name first-symbol) "letsubs"))
-                                        (rest (first rest-body))
-                                        rest-body)
-        [subs component-map body]     (case (count rest-body')
-                                        1 [nil {} (first rest-body')]
-                                        2 (let [first-element (first rest-body')]
-                                            (if (map? first-element)
-                                              [nil first-element (second rest-body')]
-                                              [(first rest-body') {} (second rest-body')]))
-                                        3 rest-body')
-        [subs-bindings vars-bindings] (prepare-subs subs)]
+  (let [first-symbol                       (ffirst rest-body)
+        rest-body'                         (if (and (symbol? first-symbol)
+                                                    (= (name first-symbol) "letsubs"))
+                                             (rest (first rest-body))
+                                             rest-body)
+        [subscriptions component-map body] (case (count rest-body')
+                                             1 [nil {} (first rest-body')]
+                                             2 (let [first-element (first rest-body')]
+                                                 (if (map? first-element)
+                                                   [nil first-element (second rest-body')]
+                                                   [(first rest-body') {} (second rest-body')]))
+                                             3 rest-body')
+        [subs-bindings vars-bindings]      (prepare-subs subscriptions)]
     `(defn ~n
        ~params
        (let [~@subs-bindings]

--- a/src/status_im/wallet/choose_recipient/core.cljs
+++ b/src/status_im/wallet/choose_recipient/core.cljs
@@ -44,8 +44,8 @@
    (-> (js/Promise.all
         (clj->js (mapv (fn [ens-name]
                          (js/Promise.
-                          (fn [resolve _]
-                            (ens/address chain-id ens-name resolve))))
+                          (fn [resolve-fn _]
+                            (ens/address chain-id ens-name resolve-fn))))
                        ens-names)))
        (.then callback)
        (.catch (fn [error]

--- a/src/status_im/wallet/core.cljs
+++ b/src/status_im/wallet/core.cljs
@@ -763,23 +763,23 @@
 
 (re-frame/reg-fx
  :load-transaction-by-hash
- (fn [[address hash]]
-   (log/info "calling wallet_loadTransferByHash" address hash)
+ (fn [[address tx-hash]]
+   (log/info "calling wallet_loadTransferByHash" address tx-hash)
    (json-rpc/call
     {:method     "wallet_loadTransferByHash"
-     :params     [address hash]
+     :params     [address tx-hash]
      :on-success #(re-frame/dispatch [:transaction/get-fetched-transfers])
      :on-error   #(log/warn "Transfer loading failed" %)})))
 
 (rf/defn load-transaction-by-hash
-  [_ address hash]
-  {:load-transaction-by-hash [address hash]})
+  [_ address tx-hash]
+  {:load-transaction-by-hash [address tx-hash]})
 
 (rf/defn transaction-included
   {:events [::transaction-included]}
-  [{:keys [db] :as cofx} address hash]
+  [{:keys [db] :as cofx} address tx-hash]
   (if (ethereum/binance-chain? db)
-    (load-transaction-by-hash cofx address hash)
+    (load-transaction-by-hash cofx address tx-hash)
     (restart cofx true)))
 
 (def pull-to-refresh-cooldown-period (* 1 60 1000))
@@ -803,12 +803,12 @@
  ::start-watching
  (fn [hashes]
    (log/info "[wallet] watch transactions" hashes)
-   (doseq [[address hash] hashes]
+   (doseq [[address tx-hash] hashes]
      (json-rpc/call
       {:method     "wallet_watchTransaction"
-       :params     [hash]
-       :on-success #(re-frame.core/dispatch [::transaction-included address hash])
-       :on-error   #(log/info "[wallet] watch transaction error" % "hash" hash)}))))
+       :params     [tx-hash]
+       :on-success #(re-frame.core/dispatch [::transaction-included address tx-hash])
+       :on-error   #(log/info "[wallet] watch transaction error" % "hash" tx-hash)}))))
 
 (rf/defn watch-tx
   {:events [:watch-tx]}
@@ -1006,8 +1006,8 @@
   [{:keys [db]} raw-transactions]
   (log/info "[wallet] pending transactions")
   {:db
-   (reduce (fn [db {:keys [from hash] :as transaction}]
-             (let [path [:wallet :accounts from :transactions hash]]
+   (reduce (fn [db {:keys [from] :as transaction}]
+             (let [path [:wallet :accounts from :transactions (:hash transaction)]]
                (if-not (get-in db path)
                  (assoc-in db path transaction)
                  db)))
@@ -1019,11 +1019,11 @@
  :wallet/delete-pending-transactions
  (fn [hashes]
    (log/info "[wallet] delete pending transactions")
-   (doseq [hash hashes]
+   (doseq [tx-hash hashes]
      (json-rpc/call
       {:method     "wallet_deletePendingTransaction"
-       :params     [hash]
-       :on-success #(log/info "[wallet] pending transaction deleted" hash)}))))
+       :params     [tx-hash]
+       :on-success #(log/info "[wallet] pending transaction deleted" tx-hash)}))))
 
 (rf/defn switch-transactions-management-enabled
   {:events [:multiaccounts.ui/switch-transactions-management-enabled]}

--- a/src/status_im/wallet/core.cljs
+++ b/src/status_im/wallet/core.cljs
@@ -1084,12 +1084,12 @@
    (-> (js/Promise.all
         (clj->js
          [(js/Promise.
-           (fn [resolve reject]
+           (fn [resolve-fn reject]
              (json-rpc/call {:method     "accounts_getAccounts"
-                             :on-success resolve
+                             :on-success resolve-fn
                              :on-error   reject})))
           (js/Promise.
-           (fn [resolve _]
+           (fn [resolve-fn _]
              (json-rpc/call
               {:method "wallet_addEthereumChain"
                :params
@@ -1104,24 +1104,24 @@
                  :chainId                (int network-id)
                  :enabled                false
                  :fallbackURL            (get-in network [:config :UpstreamConfig :URL])}]
-               :on-success resolve
-               :on-error (fn [_] (resolve nil))})))
+               :on-success resolve-fn
+               :on-error (fn [_] (resolve-fn nil))})))
           (js/Promise.
-           (fn [resolve _]
+           (fn [resolve-fn _]
              (json-rpc/call {:method     "wallet_getTokens"
                              :params     [(int network-id)]
-                             :on-success resolve
+                             :on-success resolve-fn
                              :on-error   (fn [_]
-                                           (resolve nil))})))
+                                           (resolve-fn nil))})))
           (js/Promise.
-           (fn [resolve reject]
+           (fn [resolve-fn reject]
              (json-rpc/call {:method     "wallet_getCustomTokens"
-                             :on-success resolve
+                             :on-success resolve-fn
                              :on-error   reject})))
           (js/Promise.
-           (fn [resolve reject]
+           (fn [resolve-fn reject]
              (json-rpc/call {:method     "wallet_getSavedAddresses"
-                             :on-success resolve
+                             :on-success resolve-fn
                              :on-error   reject})))]))
        (.then (fn [[accounts _ tokens custom-tokens favourites]]
                 (callback accounts

--- a/src/status_im/wallet/core.cljs
+++ b/src/status_im/wallet/core.cljs
@@ -91,8 +91,8 @@
   (navigation/navigate-to cofx :wallet-transaction-details {:hash hash :address address}))
 
 (defn dups
-  [seq]
-  (for [[id freq] (frequencies seq)
+  [coll]
+  (for [[id freq] (frequencies coll)
         :when     (> freq 1)]
     id))
 

--- a/src/status_im2/common/json_rpc/events.cljs
+++ b/src/status_im2/common/json_rpc/events.cljs
@@ -8,15 +8,20 @@
             [utils.transforms :as transforms]))
 
 (defn- on-error-retry
-  [call-method {:keys [method number-of-retries delay on-error] :as arg}]
+  [call-method
+   {method            :method
+    number-of-retries :number-of-retries
+    delay-ms          :delay
+    on-error          :on-error
+    :as               arg}]
   (if (pos? number-of-retries)
     (fn [error]
-      (let [updated-delay (if delay
-                            (min 2000 (* 2 delay))
+      (let [updated-delay (if delay-ms
+                            (min 2000 (* 2 delay-ms))
                             50)]
         (log/debug "[on-error-retry]"  method
                    "number-of-retries" number-of-retries
-                   "delay"             delay
+                   "delay"             delay-ms
                    "error"             error)
         (background-timer/set-timeout #(call-method (-> arg
                                                         (update :number-of-retries dec)

--- a/src/status_im2/contexts/chat/camera/view.cljs
+++ b/src/status_im2/contexts/chat/camera/view.cljs
@@ -18,7 +18,8 @@
   [flash uri]
   (let [current-flash @flash]
     (when platform/android?
-      (reset! flash false) ; On Android, setting flash needs to be delayed until camera has initialized
+      ;; On Android, setting flash needs to be delayed until camera has initialized
+      (reset! flash false)
       (js/setTimeout #(reset! flash current-flash) 300))
     (reset! uri nil)))
 
@@ -116,7 +117,7 @@
         top-landscape          (/ (- height (* width 0.75) (:bottom insets)) 2)
         portrait?              (= @current-orientation orientation/portrait)
         rotate                 (reanimated/use-shared-value "0deg")
-        retake                 #(retake flash uri)
+        on-press               #(retake flash uri)
         use-photo              (fn []
                                  (rf/dispatch [:photo-selector/camera-roll-pick {:uri @uri}])
                                  (rf/dispatch [:navigate-back]))]
@@ -144,7 +145,7 @@
        [zoom-buttons top insets rotate])
      [rn/view {:style (style/confirmation-container insets @uri)}
       [quo/text
-       {:on-press retake
+       {:on-press on-press
         :style    {:font-size 17
                    :color     colors/white}}
        (i18n/label :t/retake)]

--- a/src/status_im2/contexts/chat/composer/effects.cljs
+++ b/src/status_im2/contexts/chat/composer/effects.cljs
@@ -100,7 +100,7 @@
      #(component-will-unmount props))
    [max-height]))
 
-(defn edit
+(defn use-edit
   [{:keys [input-ref]}
    {:keys [text-value saved-cursor-position]}
    {:keys [edit]}]
@@ -114,7 +114,7 @@
          (reset! saved-cursor-position (count edit-text)))))
    [(:message-id edit)]))
 
-(defn reply
+(defn use-reply
   [{:keys [input-ref]}
    {:keys [container-opacity]}
    {:keys [reply]}]
@@ -179,7 +179,7 @@
      (reset! sending-links? link-previews?))
    [link-previews?]))
 
-(defn images
+(defn use-images
   [{:keys [sending-images? input-ref]}
    {:keys [text-value maximized?]}
    {:keys [container-opacity height saved-height last-height]}

--- a/src/status_im2/contexts/chat/composer/effects.cljs
+++ b/src/status_im2/contexts/chat/composer/effects.cljs
@@ -85,7 +85,7 @@
 
 (defn initialize
   [props state animations {:keys [max-height] :as dimensions}
-   {:keys [chat-input audio] :as subs}]
+   {:keys [chat-input audio] :as subscriptions}]
   (rn/use-effect
    (fn []
      (maximized-effect state animations dimensions chat-input)
@@ -95,7 +95,7 @@
      (background-effect state animations dimensions chat-input)
      (link-preview-effect state)
      (audio-effect state animations audio)
-     (empty-effect state animations subs)
+     (empty-effect state animations subscriptions)
      (kb/add-kb-listeners props state animations dimensions)
      #(component-will-unmount props))
    [max-height]))

--- a/src/status_im2/contexts/chat/composer/keyboard.cljs
+++ b/src/status_im2/contexts/chat/composer/keyboard.cljs
@@ -24,12 +24,12 @@
    {:keys [text-value]}
    {:keys [height saved-height]}
    {:keys [max-height]}]
-  (let [start-h   (oops/oget event "startCoordinates.height")
-        end-h     (oops/oget event "endCoordinates.height")
-        diff      (- end-h start-h)
-        max       (- max-height diff)
-        curr-text @text-value]
-    (if (> (reanimated/get-shared-value height) max)
+  (let [start-h         (oops/oget event "startCoordinates.height")
+        end-h           (oops/oget event "endCoordinates.height")
+        diff            (- end-h start-h)
+        max-height-diff (- max-height diff)
+        curr-text       @text-value]
+    (if (> (reanimated/get-shared-value height) max-height-diff)
       (do
         (reanimated/set-shared-value height (- (reanimated/get-shared-value height) diff))
         (reanimated/set-shared-value saved-height (- (reanimated/get-shared-value saved-height) diff))

--- a/src/status_im2/contexts/chat/composer/sub_view.cljs
+++ b/src/status_im2/contexts/chat/composer/sub_view.cljs
@@ -54,5 +54,5 @@
         style/scroll-to-bottom-button])]))
 
 (defn shell-button
-  [state animations subs]
-  [:f> f-shell-button state animations subs])
+  [state animations subscriptions]
+  [:f> f-shell-button state animations subscriptions])

--- a/src/status_im2/contexts/chat/composer/view.cljs
+++ b/src/status_im2/contexts/chat/composer/view.cljs
@@ -61,12 +61,12 @@
                         animations
                         dimensions
                         subscriptions)
-    (effects/edit props state subscriptions)
-    (effects/reply props animations subscriptions)
+    (effects/use-edit props state subscriptions)
+    (effects/use-reply props animations subscriptions)
     (effects/update-input-mention props state subscriptions)
     (effects/edit-mentions props state subscriptions)
     (effects/link-previews props state animations subscriptions)
-    (effects/images props state animations subscriptions)
+    (effects/use-images props state animations subscriptions)
     [:<>
      (when chat-screen-loaded?
        [mentions/view props state animations max-height cursor-pos

--- a/src/status_im2/contexts/chat/lightbox/zoomable_image/utils.cljs
+++ b/src/status_im2/contexts/chat/lightbox/zoomable_image/utils.cljs
@@ -200,9 +200,9 @@
 
 (defn get-focal
   [focal size screen-size]
-  (let [min (/ (- screen-size size) 2)
-        max (+ min size)]
-    (if (or (> focal max) (< focal min))
+  (let [min-size (/ (- screen-size size) 2)
+        max-size (+ min-size size)]
+    (if (or (> focal max-size) (< focal min-size))
       (/ screen-size 2)
       focal)))
 

--- a/src/status_im2/contexts/chat/menus/pinned_messages/view.cljs
+++ b/src/status_im2/contexts/chat/menus/pinned_messages/view.cljs
@@ -28,7 +28,7 @@
 
 (defn pinned-messages
   [chat-id]
-  (let [pinned-messages        (rf/sub [:chats/pinned-sorted-list chat-id])
+  (let [pinned                 (rf/sub [:chats/pinned-sorted-list chat-id])
         render-data            (rf/sub [:chats/current-chat-message-list-view-context :in-pinned-view])
         current-chat           (rf/sub [:chat-by-id chat-id])
         {:keys [community-id]} current-chat
@@ -58,9 +58,9 @@
          [rn/text
           {:style (style/chat-name-text)}
           (str "# " (:chat-name current-chat))]])]
-     (if (pos? (count pinned-messages))
+     (if (pos? (count pinned))
        [rn/flat-list
-        {:data        pinned-messages
+        {:data        pinned
          :render-data render-data
          :render-fn   message-render-fn
          :footer      [rn/view {:style (style/list-footer bottom-inset)}]

--- a/src/status_im2/contexts/chat/messages/content/audio/component_spec.cljs
+++ b/src/status_im2/contexts/chat/messages/content/audio/component_spec.cljs
@@ -12,8 +12,8 @@
   {:in-pinned-view? false})
 
 (defn setup-subs
-  [subs]
-  (doseq [keyval subs]
+  [subscriptions]
+  (doseq [keyval subscriptions]
     (re-frame/reg-sub
      (key keyval)
      (fn [_] (val keyval)))))

--- a/src/status_im2/contexts/chat/messages/drawers/view.cljs
+++ b/src/status_im2/contexts/chat/messages/drawers/view.cljs
@@ -93,8 +93,7 @@
    (when (and outgoing
               (not (or deleted? deleted-for-me?))
               ;; temporarily disable edit image message until
-              ;; https://github.com/status-im/status-mobile/issues/15298
-              ;; is implemented
+              ;; https://github.com/status-im/status-mobile/issues/15298 is implemented
               (not= content-type constants/content-type-image)
               (not= content-type constants/content-type-audio))
      [{:type     :main
@@ -162,13 +161,13 @@
 
 (defn reactions
   [{:keys [chat-id message-id]}]
-  (let [reactions     (rf/sub [:chats/message-reactions message-id chat-id])
+  (let [msg-reactions (rf/sub [:chats/message-reactions message-id chat-id])
         own-reactions (reduce (fn [acc {:keys [emoji-id own emoji-reaction-id]}]
                                 (if own
                                   (assoc acc emoji-id emoji-reaction-id)
                                   acc))
                               {}
-                              reactions)]
+                              msg-reactions)]
     [rn/view
      {:style {:flex-direction     :row
               :justify-content    :space-between

--- a/src/status_im2/contexts/chat/messages/view.cljs
+++ b/src/status_im2/contexts/chat/messages/view.cljs
@@ -12,10 +12,10 @@
                 contact-request-state
                 group-chat
                 able-to-send-message?]
-         :as   chat} (rf/sub [:chats/current-chat-chat-view])]
+         :as   current-chat} (rf/sub [:chats/current-chat-chat-view])]
     [messages.list/messages-list
      {:cover-bg-color :turquoise
-      :chat           chat
+      :chat           current-chat
       :header-comp    (fn [{:keys [scroll-y]}]
                         [messages.navigation/navigation-view {:scroll-y scroll-y}])
       :footer-comp    (fn [{:keys [insets]}]

--- a/src/status_im2/contexts/communities/actions/community_options/component_spec.cljs
+++ b/src/status_im2/contexts/communities/actions/community_options/component_spec.cljs
@@ -4,8 +4,8 @@
             [status-im2.contexts.communities.actions.community-options.view :as options]))
 
 (defn setup-subs
-  [subs]
-  (doseq [keyval subs]
+  [subscriptions]
+  (doseq [keyval subscriptions]
     (re-frame/reg-sub
      (key keyval)
      (fn [_] (val keyval)))))

--- a/src/status_im2/contexts/communities/actions/community_rules_list/view.cljs
+++ b/src/status_im2/contexts/communities/actions/community_rules_list/view.cljs
@@ -3,7 +3,7 @@
             [react-native.core :as rn]
             [status-im2.contexts.communities.actions.community-rules-list.style :as style]))
 
-(def rules
+(def standard-rules
   [{:index 1
     :title "Be respectful"
     :content

--- a/src/status_im2/contexts/communities/actions/request_to_join/view.cljs
+++ b/src/status_im2/contexts/communities/actions/request_to_join/view.cljs
@@ -53,7 +53,7 @@
              :weight              :semi-bold
              :size                :paragraph-1}
             (i18n/label :t/community-rules)]
-           [community-rules/view community-rules/rules]
+           [community-rules/view community-rules/standard-rules]
            [quo/disclaimer
             {:accessibility-label :rules-disclaimer-checkbox
              :container-style     {:margin-top 20}

--- a/src/status_im2/contexts/communities/actions/see_rules/view.cljs
+++ b/src/status_im2/contexts/communities/actions/see_rules/view.cljs
@@ -9,4 +9,4 @@
    {:id    id
     :title (i18n/label :t/community-rules)}
 
-   [community-rules/view community-rules/rules]])
+   [community-rules/view community-rules/standard-rules]])

--- a/src/status_im2/contexts/onboarding/identifiers/profile_card/view.cljs
+++ b/src/status_im2/contexts/onboarding/identifiers/profile_card/view.cljs
@@ -9,9 +9,10 @@
             [utils.worklets.identifiers-highlighting :as worklets.identifiers-highlighting]))
 
 (defn- f-profile-card-component
-  [{:keys [profile-picture name hash emoji-hash
+  [{:keys [profile-picture name emoji-hash
            customization-color progress]
-    :or   {customization-color :turquoise}}]
+    :or   {customization-color :turquoise}
+    :as   props}]
   (let [container-background (worklets.identifiers-highlighting/background
                               (colors/custom-color customization-color 50)
                               @progress)
@@ -48,7 +49,7 @@
       [reanimated/text
        {:number-of-lines 3
         :style           (style/user-hash user-hash-color user-hash-opacity)}
-       hash]
+       (:hash props)]
       [reanimated/view
        {:style [emoji-hash-style]}
        [quo/text

--- a/src/status_im2/contexts/quo_preview/calendar/calendar.cljs
+++ b/src/status_im2/contexts/quo_preview/calendar/calendar.cljs
@@ -12,15 +12,15 @@
 
 (defn view
   []
-  (let [state (reagent/atom {:start-date nil :end-date nil})
-        range (reagent/atom {:start-date nil :end-date nil})]
+  (let [state  (reagent/atom {:start-date nil :end-date nil})
+        period (reagent/atom {:start-date nil :end-date nil})]
     (fn []
       [preview/preview-container {:state state :descriptor descriptor}
        [quo/calendar
-        {:start-date (:start-date @range)
-         :end-date   (:end-date @range)
+        {:start-date (:start-date @period)
+         :end-date   (:end-date @period)
          :on-change  (fn [new-range]
                        (reset! state
                          {:start-date (datetime/format-date (:start-date new-range))
                           :end-date   (datetime/format-date (:end-date new-range))})
-                       (reset! range new-range))}]])))
+                       (reset! period new-range))}]])))

--- a/src/status_im2/contexts/quo_preview/preview.clj
+++ b/src/status_im2/contexts/quo_preview/preview.clj
@@ -1,10 +1,10 @@
 (ns status-im2.contexts.quo-preview.preview)
 
 (defmacro list-comp
-  [[binding seq-expr & bindings] body-expr]
-  (cond (not binding)
+  [[the-binding seq-expr & bindings] body-expr]
+  (cond (not the-binding)
         `(list ~body-expr)
 
         :else
-        `(mapcat (fn [~binding] (list-comp ~bindings ~body-expr))
+        `(mapcat (fn [~the-binding] (list-comp ~bindings ~body-expr))
           ~seq-expr)))

--- a/src/status_im2/contexts/syncing/setup_syncing/view.cljs
+++ b/src/status_im2/contexts/syncing/setup_syncing/view.cljs
@@ -18,8 +18,8 @@
 (def one-min-ms 60000)
 
 (defn f-use-interval
-  [clock cleanup-clock delay]
-  (hooks/use-interval clock cleanup-clock delay)
+  [clock cleanup-clock delay-ms]
+  (hooks/use-interval clock cleanup-clock delay-ms)
   nil)
 
 (defn view
@@ -27,12 +27,12 @@
   (let [profile-color (rf/sub [:profile/customization-color])
         valid-for-ms  (reagent/atom code-valid-for-ms)
         code          (reagent/atom nil)
-        delay         (reagent/atom nil)
+        delay-ms      (reagent/atom nil)
         timestamp     (reagent/atom nil)
         set-code      (fn [connection-string]
                         (when (sync-utils/valid-connection-string? connection-string)
                           (reset! timestamp (* 1000 (js/Math.ceil (/ (datetime/timestamp) 1000))))
-                          (reset! delay 1000)
+                          (reset! delay-ms 1000)
                           (reset! code connection-string)))
         clock         (fn []
                         (if (pos? (- code-valid-for-ms
@@ -43,7 +43,7 @@
                                                    (- (* 1000
                                                          (js/Math.ceil (/ (datetime/timestamp) 1000)))
                                                       @timestamp))))
-                          (reset! delay nil)))
+                          (reset! delay-ms nil)))
         cleanup-clock (fn []
                         (reset! code nil)
                         (reset! timestamp nil)
@@ -51,7 +51,7 @@
 
     (fn []
       [rn/view {:style style/container-main}
-       [:f> f-use-interval clock cleanup-clock @delay]
+       [:f> f-use-interval clock cleanup-clock @delay-ms]
        [rn/scroll-view {}
         [quo/page-nav
          {:type       :no-title

--- a/src/status_im2/contexts/syncing/syncing_instructions/view.cljs
+++ b/src/status_im2/contexts/syncing/syncing_instructions/view.cljs
@@ -63,7 +63,7 @@
                 list-item)])
 
 (defn- render-instruction
-  [{:keys [title image list]}]
+  [{title :title image :image coll :list}]
   [rn/view
    (when title
      [quo/text
@@ -83,7 +83,7 @@
     (map-indexed (fn [i item]
                    ^{:key i}
                    [render-item (inc i) item])
-                 list)]])
+                 coll)]])
 
 (defn- map-instructions
   [idx instructions instructions-count]

--- a/src/status_im2/contexts/syncing/syncing_instructions/view.cljs
+++ b/src/status_im2/contexts/syncing/syncing_instructions/view.cljs
@@ -100,8 +100,8 @@
                        {:id    :desktop
                         :label (i18n/label :t/desktop)}]]
     (fn []
-      (let [instructions       (get props @platform)
-            instructions-count (count instructions)]
+      (let [sync-instructions  (get props @platform)
+            instructions-count (count sync-instructions)]
         [rn/view {:style style/container-outer}
          [quo/text
           {:size   :heading-1
@@ -119,4 +119,4 @@
            (map-indexed (fn [idx item]
                           ^{:key idx}
                           [map-instructions idx item instructions-count])
-                        instructions))]]))))
+                        sync-instructions))]]))))

--- a/src/status_im2/navigation/core.cljs
+++ b/src/status_im2/navigation/core.cljs
@@ -81,13 +81,13 @@
 
 ;; NAVIGATE-TO
 (defn navigate
-  [comp]
-  (let [{:keys [options]} (get views/screens comp)]
+  [component]
+  (let [{:keys [options]} (get views/screens component)]
     (dismiss-all-modals)
     (navigation/push
      (name @state/root-id)
-     {:component {:id      comp
-                  :name    comp
+     {:component {:id      component
+                  :name    component
                   :options (merge (options/default-root)
                                   (options/statusbar-and-navbar)
                                   options
@@ -97,12 +97,12 @@
 
 ;; NAVIGATE-TO-WITHIN-STACK
 (defn navigate-to-within-stack
-  [[comp comp-id]]
-  (let [{:keys [options]} (get views/screens comp)]
+  [[component comp-id]]
+  (let [{:keys [options]} (get views/screens component)]
     (navigation/push
      (name comp-id)
-     {:component {:id      comp
-                  :name    comp
+     {:component {:id      component
+                  :name    component
                   :options (merge (options/statusbar-and-navbar)
                                   options
                                   (if (:topBar options)
@@ -145,18 +145,18 @@
 
 ;; MODAL
 (defn open-modal
-  [comp]
-  (let [{:keys [options]} (get views/screens comp)
+  [component]
+  (let [{:keys [options]} (get views/screens component)
         sheet?            (:sheet? options)]
     (if @state/dissmissing
-      (reset! state/dissmissing comp)
+      (reset! state/dissmissing component)
       (do
         (reset! state/curr-modal true)
-        (swap! state/modals conj comp)
+        (swap! state/modals conj component)
         (navigation/show-modal
          {:stack {:children [{:component
-                              {:name    comp
-                               :id      comp
+                              {:name    component
+                               :id      component
                                :options (merge (options/default-root)
                                                (options/statusbar-and-navbar)
                                                options
@@ -193,21 +193,21 @@
        (reset! state/curr-modal false)
        (set-view-id @state/pushed-screen-id)))
 
-   (let [comp @state/dissmissing]
+   (let [component @state/dissmissing]
      (reset! state/dissmissing false)
-     (when (keyword? comp)
-       (open-modal comp)))))
+     (when (keyword? component)
+       (open-modal component)))))
 
 ;; OVERLAY
 (def dissmiss-overlay navigation/dissmiss-overlay)
 
 (defn show-overlay
-  ([comp] (show-overlay comp {}))
-  ([comp opts]
-   (dissmiss-overlay comp)
+  ([component] (show-overlay component {}))
+  ([component opts]
+   (dissmiss-overlay component)
    (navigation/show-overlay
-    {:component {:name    comp
-                 :id      comp
+    {:component {:name    component
+                 :id      component
                  :options (merge (options/statusbar)
                                  {:layout  {:componentBackgroundColor :transparent
                                             :orientation              ["portrait"]}
@@ -249,27 +249,27 @@
 
 ;; LEGACY (should be removed in status 2.0)
 (defn get-screen-component
-  [comp]
-  (let [{:keys [options]} (get views/screens comp)]
-    {:component {:id      comp
-                 :name    comp
+  [component]
+  (let [{:keys [options]} (get views/screens component)]
+    {:component {:id      component
+                 :name    component
                  :options (merge (options/statusbar-and-navbar)
                                  options
                                  (options/merge-top-bar (options/topbar-options) options))}}))
 
 (re-frame/reg-fx
  :set-stack-root-fx
- (fn [[stack comp]]
+ (fn [[stack component]]
    ;; We don't have bottom tabs as separate stacks anymore,. So the old way of pushing screens in
    ;; specific tabs will not work. Disabled set-stack-root for :shell-stack as it is not working
    ;; and currently only being used for browser and some rare keycard flows after login
    (when-not (= @state/root-id :shell-stack)
-     (log/debug :set-stack-root-fx stack comp)
+     (log/debug :set-stack-root-fx stack component)
      (navigation/set-stack-root
       (name stack)
-      (if (vector? comp)
-        (mapv get-screen-component comp)
-        (get-screen-component comp))))))
+      (if (vector? component)
+        (mapv get-screen-component component)
+        (get-screen-component component))))))
 
 (re-frame/reg-fx :show-popover (fn [] (show-overlay "popover")))
 (re-frame/reg-fx :hide-popover (fn [] (dissmiss-overlay "popover")))

--- a/src/status_im2/subs/general.cljs
+++ b/src/status_im2/subs/general.cljs
@@ -1,5 +1,6 @@
 (ns status-im2.subs.general
   (:require [re-frame.core :as re-frame]
+            [clojure.string :as string]
             [status-im.ethereum.core :as ethereum]
             [status-im.ethereum.tokens :as tokens]
             [status-im.multiaccounts.model :as multiaccounts.model]
@@ -13,7 +14,7 @@
  :<- [:multiaccount/current-user-visibility-status]
  :<- [:visibility-status-updates]
  (fn [[my-public-key my-status-update status-updates] [_ public-key]]
-   (if (= public-key my-public-key)
+   (if (or (string/blank? public-key) (= public-key my-public-key))
      my-status-update
      (get status-updates public-key))))
 
@@ -94,8 +95,7 @@
  :<- [:waku/v2-flag]
  :<- [:waku/v2-peer-stats]
  (fn [[peers-count wakuv2-flag peer-stats]]
-   ;; If wakuv2 is enabled,
-   ;; then fetch connectivity status from
+   ;; If wakuv2 is enabled, then fetch connectivity status from
    ;; peer-stats (populated from "wakuv2.peerstats" status-go signal)
    ;; Otherwise use peers-count fetched from "discovery.summary" signal
    (if wakuv2-flag (not (:isOnline peer-stats)) (zero? peers-count))))

--- a/src/test_helpers/unit.cljs
+++ b/src/test_helpers/unit.cljs
@@ -26,8 +26,8 @@
   []
   (rf/reg-event-db
    :test/assoc-in
-   (fn [db [_ path value]]
-     (assoc-in db path value))))
+   (fn [app-db [_ path value]]
+     (assoc-in app-db path value))))
 
 (defn spy-event-fx
   "Re-register event effect using id `id`, but conj to `state` the event

--- a/src/test_helpers/unit.cljs
+++ b/src/test_helpers/unit.cljs
@@ -26,8 +26,8 @@
   []
   (rf/reg-event-db
    :test/assoc-in
-   (fn [db [_ keys value]]
-     (assoc-in db keys value))))
+   (fn [db [_ path value]]
+     (assoc-in db path value))))
 
 (defn spy-event-fx
   "Re-register event effect using id `id`, but conj to `state` the event

--- a/src/utils/datetime.cljs
+++ b/src/utils/datetime.cljs
@@ -136,10 +136,10 @@
 
 (defn today?
   [datetime]
-  (let [now (t/now)]
-    (and (= (t/year now) (t/year datetime))
-         (= (t/month now) (t/month datetime))
-         (= (t/day now) (t/day datetime)))))
+  (let [time-now (t/now)]
+    (and (= (t/year time-now) (t/year datetime))
+         (= (t/month time-now) (t/month datetime))
+         (= (t/day time-now) (t/day datetime)))))
 
 (defn tomorrow?
   [datetime]
@@ -151,9 +151,9 @@
 (defn within-last-n-days?
   "Returns true if `datetime` is within last `n` days (inclusive on both ends)."
   [datetime n]
-  (let [now   (t/now)
-        start (t/at-midnight (t/minus now (t/days n)))
-        end   (t/plus now (t/millis 1))]
+  (let [time-now (t/now)
+        start    (t/at-midnight (t/minus time-now (t/days n)))
+        end      (t/plus time-now (t/millis 1))]
     (t/within? start end datetime)))
 
 ;;;; Timestamp formatters
@@ -247,9 +247,9 @@
                    :time-intervals name}))))
 (defn seconds-ago
   [date-time]
-  (let [now (t/now)]
-    (if (<= (.getTime ^js date-time) (.getTime ^js now))
-      (t/in-seconds (t/interval date-time now))
+  (let [time-now (t/now)]
+    (if (<= (.getTime ^js date-time) (.getTime ^js time-now))
+      (t/in-seconds (t/interval date-time time-now))
       0)))
 
 (defn time-ago
@@ -265,15 +265,15 @@
 
 (defn time-ago-long
   [date-time]
-  (let [seconds-ago (seconds-ago date-time)
-        unit        (first (drop-while #(and (>= seconds-ago (:limit %))
-                                             (:limit %))
-                                       units))
-        diff        (-> (/ seconds-ago (:in-second unit))
-                        Math/floor
-                        int)
+  (let [time-ago-seconds (seconds-ago date-time)
+        unit             (first (drop-while #(and (>= time-ago-seconds (:limit %))
+                                                  (:limit %))
+                                            units))
+        diff             (-> (/ time-ago-seconds (:in-second unit))
+                             Math/floor
+                             int)
 
-        name        (i18n/label-pluralize diff (:name unit))]
+        name             (i18n/label-pluralize diff (:name unit))]
     (i18n/label :t/datetime-ago-format
                 {:ago            (i18n/label :t/datetime-ago)
                  :number         diff

--- a/src/utils/image_server.cljs
+++ b/src/utils/image_server.cljs
@@ -30,8 +30,8 @@
           copy           #(utils.fs/copy-assets src dest)
           cb             #(callback dest)]
       (.then (utils.fs/file-exists? dest)
-             (fn [exists?]
-               (if exists?
+             (fn [file?]
+               (if file?
                  (cb)
                  (.then (copy) cb)))))
     (callback (str (utils.fs/main-bundle-path)

--- a/src/utils/red_black_tree.cljs
+++ b/src/utils/red_black_tree.cljs
@@ -5,12 +5,12 @@
 (def tree ^js red-black-tree)
 
 (defn find
-  [^js tree item]
-  (.find tree item))
+  [^js t item]
+  (.find t item))
 
 (defn insert
-  [^js tree item]
-  (.insert tree item))
+  [^js t item]
+  (.insert t item))
 
 (defn update
   [^js iterator item]
@@ -21,8 +21,8 @@
   (.remove iterator))
 
 (defn get-values
-  [^js tree]
-  (.-values ^js tree))
+  [^js t]
+  (.-values ^js t))
 
 (defn get-prev-element
   "Get previous item in the iterator, and wind it back to the initial state"


### PR DESCRIPTION
### Summary

This PR unshadows all remaining vars in status-mobile, including non `cljs.core/clojure.core` ones. The only exceptions are `cljs.core/type` and `cljs.core/name` (which happen quite often, so I'm not sure if it's worth unshadowing them).

**To avoid rebase hell, please help review this PR in a timely manner** 🙏🏼 🙏🏼 .

### Out of scope

I refrained from improving code and focused exclusively on satisfying clj-kondo's [shadowed-var linter](https://github.com/clj-kondo/clj-kondo/blob/master/doc/linters.md#shadowed-var).

#### Areas that may be impacted

In theory nothing, but I'll make sure to run e2e tests and check the results carefully.

status: ready
