### PR TITLE
nix: set ios status-go targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -224,6 +224,7 @@ release-android: keystore build-android ##@build Build signed Android APK
 	@scripts/sign-android.sh result/app-release-unsigned.apk
 
 release-ios: export TARGET := ios
+release-ios: export IOS_STATUS_GO_TARGETS := ios/arm64
 release-ios: export BUILD_ENV ?= prod
 release-ios: watchman-clean ios-clean jsbundle ##@build Build release for iOS release
 	xcodebuild \
@@ -279,6 +280,7 @@ run-android: ##@run Build Android APK and start it on the device
 
 SIMULATOR=iPhone 11 Pro
 run-ios: export TARGET := ios
+run-ios: export IOS_STATUS_GO_TARGETS := iossimulator/amd64
 run-ios: ##@run Build iOS app and start it in a simulator/device
 ifneq ("$(SIMULATOR)", "")
 	npx react-native run-ios --simulator="$(SIMULATOR)"
@@ -290,6 +292,7 @@ show-ios-devices: ##@other shows connected ios device and its name
 	xcrun xctrace list devices
 
 run-ios-device: export TARGET := ios
+run-ios-device: export IOS_STATUS_GO_TARGETS := ios/arm64
 run-ios-device: ##@run iOS app and start it on a connected device by its name
 ifndef DEVICE_NAME
 	$(error Usage: make run-ios-device DEVICE_NAME=your-device-name)

--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.7.12'
+library 'status-jenkins-lib@v1.7.14'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.7.12'
+library 'status-jenkins-lib@v1.7.14'
 
 pipeline {
   agent { label 'linux' }

--- a/ci/Jenkinsfile.e2e-nightly
+++ b/ci/Jenkinsfile.e2e-nightly
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.7.12'
+library 'status-jenkins-lib@v1.7.14'
 
 pipeline {
   agent { label 'linux' }

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.7.12'
+library 'status-jenkins-lib@set_ios_status_go_targets'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.tests
+++ b/ci/Jenkinsfile.tests
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.7.12'
+library 'status-jenkins-lib@v1.7.14'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/tests/Jenkinsfile.e2e-nightly
+++ b/ci/tests/Jenkinsfile.e2e-nightly
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.7.12'
+library 'status-jenkins-lib@v1.7.14'
 
 pipeline {
 

--- a/ci/tests/Jenkinsfile.e2e-prs
+++ b/ci/tests/Jenkinsfile.e2e-prs
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.7.12'
+library 'status-jenkins-lib@v1.7.14'
 
 pipeline {
 

--- a/ci/tests/Jenkinsfile.e2e-upgrade
+++ b/ci/tests/Jenkinsfile.e2e-upgrade
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.7.12'
+library 'status-jenkins-lib@v1.7.14'
 
 pipeline {
 

--- a/ci/tools/Jenkinsfile.fastlane-clean
+++ b/ci/tools/Jenkinsfile.fastlane-clean
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.7.12'
+library 'status-jenkins-lib@v1.7.14'
 
 pipeline {
   agent { label 'macos' }

--- a/ci/tools/Jenkinsfile.nix-cache
+++ b/ci/tools/Jenkinsfile.nix-cache
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.7.12'
+library 'status-jenkins-lib@v1.7.14'
 
 pipeline {
   agent { label params.AGENT_LABEL }

--- a/ci/tools/Jenkinsfile.playstore-meta
+++ b/ci/tools/Jenkinsfile.playstore-meta
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.7.12'
+library 'status-jenkins-lib@v1.7.14'
 
 pipeline {
   agent { label 'linux' }

--- a/ci/tools/Jenkinsfile.xcode-clean
+++ b/ci/tools/Jenkinsfile.xcode-clean
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.7.12'
+library 'status-jenkins-lib@v1.7.14'
 
 pipeline {
   agent {

--- a/nix/mobile/ios/shells/status-go.nix
+++ b/nix/mobile/ios/shells/status-go.nix
@@ -3,28 +3,33 @@
 # It copies the status-go build result to 'modules/react-native-status/ios/RCTStatus'.
 #
 
-{ mkShell, status-go }:
+{ lib, mkShell, status-go }:
 
-mkShell {
-  shellHook = ''
-    export STATUS_GO_IOS_LIBDIR=${status-go}/Statusgo.xcframework
-
-    RCTSTATUS_DIR="$STATUS_MOBILE_HOME/modules/react-native-status/ios/RCTStatus"
-    targetBasename='Statusgo.xcframework'
-
-    # Compare target folder with source to see if copying is required
-    if [ -d "$RCTSTATUS_DIR/$targetBasename" ] && [ -d $STATUS_MOBILE_HOME/ios/Pods/ ] && \
-      diff -qr --no-dereference $RCTSTATUS_DIR/$targetBasename/ $STATUS_GO_IOS_LIBDIR/ > /dev/null; then
-      echo "$RCTSTATUS_DIR/$targetBasename already in place"
-    else
-      sourceBasename="$(basename $STATUS_GO_IOS_LIBDIR)"
-      echo "Copying $sourceBasename from Nix store to $RCTSTATUS_DIR"
-      rm -rf "$RCTSTATUS_DIR/$targetBasename/"
-      cp -a $STATUS_GO_IOS_LIBDIR $RCTSTATUS_DIR
-      chmod -R 755 "$RCTSTATUS_DIR/$targetBasename"
-      if [ "$sourceBasename" != "$targetBasename" ]; then
-        mv "$RCTSTATUS_DIR/$sourceBasename" "$RCTSTATUS_DIR/$targetBasename"
+let
+    targets = let
+      targetsString = lib.getEnvWithDefault "IOS_STATUS_GO_TARGETS" "ios/arm64;iossimulator/amd64";
+    in lib.splitString ";" targetsString;
+in
+  mkShell {
+    shellHook = ''
+      export STATUS_GO_IOS_LIBDIR=${status-go { inherit targets; } }/Statusgo.xcframework
+ 
+      RCTSTATUS_DIR="$STATUS_MOBILE_HOME/modules/react-native-status/ios/RCTStatus"
+      targetBasename='Statusgo.xcframework'
+ 
+      # Compare target folder with source to see if copying is required
+      if [ -d "$RCTSTATUS_DIR/$targetBasename" ] && [ -d $STATUS_MOBILE_HOME/ios/Pods/ ] && \
+        diff -qr --no-dereference $RCTSTATUS_DIR/$targetBasename/ $STATUS_GO_IOS_LIBDIR/ > /dev/null; then
+        echo "$RCTSTATUS_DIR/$targetBasename already in place"
+      else
+        sourceBasename="$(basename $STATUS_GO_IOS_LIBDIR)"
+        echo "Copying $sourceBasename from Nix store to $RCTSTATUS_DIR"
+        rm -rf "$RCTSTATUS_DIR/$targetBasename/"
+        cp -a $STATUS_GO_IOS_LIBDIR $RCTSTATUS_DIR
+        chmod -R 755 "$RCTSTATUS_DIR/$targetBasename"
+        if [ "$sourceBasename" != "$targetBasename" ]; then
+          mv "$RCTSTATUS_DIR/$sourceBasename" "$RCTSTATUS_DIR/$targetBasename"
+        fi
       fi
-    fi
-  '';
+    '';
 }

--- a/nix/status-go/mobile/default.nix
+++ b/nix/status-go/mobile/default.nix
@@ -17,11 +17,10 @@
     inherit meta source goBuildLdFlags;
   };
 
-  ios = callPackage ./build.nix {
+  ios = {targets ? [ "ios/arm64" "iossimulator/amd64"]}: callPackage ./build.nix {
     platform = "ios";
     platformVersion = "8.0";
-    targets = [ "ios" "iossimulator" ];
     outputFileName = "Statusgo.xcframework";
-    inherit meta source goBuildLdFlags;
+    inherit meta source goBuildLdFlags targets;
   };
 }


### PR DESCRIPTION
### Summary

In order to build less for iOS we need to set status-go targets depending on iOS platform (or device type):
- if we build for simulator, targets should be `iossimulator` (both x86 and arm)
- if we build for real device, targets should be `ios`

As for app architecture, after some research:
- For device - it's always `arm64`. Which is good, we only have `arm64` iphones currently
- For simulator - there could be an option to build only x86 or arm. Needs more investigation.