### PR TITLE
fix: use custom color for send button

### DIFF
--- a/src/status_im2/contexts/chat/composer/actions/view.cljs
+++ b/src/status_im2/contexts/chat/composer/actions/view.cljs
@@ -45,24 +45,27 @@
   [props {:keys [text-value] :as state}
    animations window-height images?
    btn-opacity z-index edit]
-  (rn/use-effect (fn []
-                   (if (or (seq @text-value) images?)
-                     (when (or (not= @z-index 1) (not= (reanimated/get-shared-value btn-opacity) 1))
-                       (reset! z-index 1)
-                       (js/setTimeout #(reanimated/animate btn-opacity 1) 50))
-                     (when (or (not= @z-index 0) (not= (reanimated/get-shared-value btn-opacity) 0))
-                       (reanimated/animate btn-opacity 0)
-                       (js/setTimeout #(when (and (empty? @text-value) (not images?)) (reset! z-index 0))
-                                      300))))
-                 [(and (empty? @text-value) (not images?))])
-  [reanimated/view
-   {:style (style/send-button btn-opacity @z-index)}
-   [quo/button
-    {:icon-only?          true
-     :size                32
-     :accessibility-label :send-message-button
-     :on-press            #(send-message props state animations window-height edit)}
-    :i/arrow-up]])
+  (let [customization-color (rf/sub [:profile/customization-color])]
+    (rn/use-effect (fn []
+                     (if (or (seq @text-value) images?)
+                       (when (or (not= @z-index 1) (not= (reanimated/get-shared-value btn-opacity) 1))
+                         (reset! z-index 1)
+                         (js/setTimeout #(reanimated/animate btn-opacity 1) 50))
+                       (when (or (not= @z-index 0) (not= (reanimated/get-shared-value btn-opacity) 0))
+                         (reanimated/animate btn-opacity 0)
+                         (js/setTimeout #(when (and (empty? @text-value) (not images?))
+                                           (reset! z-index 0))
+                                        300))))
+                   [(and (empty? @text-value) (not images?))])
+    [reanimated/view
+     {:style (style/send-button btn-opacity @z-index)}
+     [quo/button
+      {:icon-only?          true
+       :size                32
+       :customization-color customization-color
+       :accessibility-label :send-message-button
+       :on-press            #(send-message props state animations window-height edit)}
+      :i/arrow-up]]))
 
 (defn send-button
   [props {:keys [text-value] :as state} animations window-height images? edit btn-opacity]


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/17136

The `Send` button in chat view should inherit a custom color. 

status: ready 
