### PR TITLE
feat: add customization color to wallet graph

### DIFF
--- a/src/quo2/components/graph/wallet_graph/view.cljs
+++ b/src/quo2/components/graph/wallet_graph/view.cljs
@@ -18,17 +18,26 @@
     :1-year   365
     500))
 
+(defn- get-line-color
+  [customization-color state theme]
+  (let [color-keyword (cond
+                        customization-color customization-color
+                        (= state :positive) :success
+                        :else               :danger)]
+    (colors/theme-colors
+     (colors/custom-color color-keyword 50)
+     (colors/custom-color color-keyword 60)
+     theme)))
+
 (defn- view-internal
-  [{:keys [data state time-frame theme]}]
+  [{:keys [data state time-frame customization-color theme]}]
   (let [max-data-points (time-frame->max-data-points time-frame)
         data            (if (and (not= time-frame :empty) (> (count data) max-data-points))
                           (utils/downsample-data data max-data-points)
                           data)
         max-value       (when-not (= time-frame :empty) (utils/find-highest-value data))
         width           (:width (rn/get-window))
-        line-color      (if (= state :positive)
-                          (colors/theme-colors colors/success-50 colors/success-60 theme)
-                          (colors/theme-colors colors/danger-50 colors/danger-60 theme))
+        line-color      (get-line-color customization-color state theme)
         gradient-colors [(colors/alpha line-color 0.1) (colors/alpha line-color 0)]
         fill-color      (colors/theme-colors colors/white colors/neutral-95)]
     (if (= time-frame :empty)

--- a/src/status_im2/contexts/quo_preview/graph/wallet_graph.cljs
+++ b/src/status_im2/contexts/quo_preview/graph/wallet_graph.cljs
@@ -30,7 +30,8 @@
               {:key :3-months}
               {:key :1-year}
               {:key   :all-time
-               :value "All time (500 years data)"}]}])
+               :value "All time (500 years data)"}]}
+   (preview/customization-color-option)])
 
 (defn generate-data
   [time-frame]
@@ -60,6 +61,7 @@
         :descriptor                descriptor
         :component-container-style {:padding-horizontal 0 :margin-top 200}}
        [quo/wallet-graph
-        {:data       (generate-data (:time-frame @state))
-         :state      (:state @state)
-         :time-frame (:time-frame @state)}]])))
+        {:data                (generate-data (:time-frame @state))
+         :state               (:state @state)
+         :time-frame          (:time-frame @state)
+         :customization-color (:customization-color @state)}]])))


### PR DESCRIPTION
fixes #17148 

### Summary

Add customization color to wallet graph component. If customization color is set, positive / negative state is ignored.

#### Results

<img width="340" src="https://github.com/status-im/status-mobile/assets/18485527/6555adb3-c9de-40e7-a782-cab0f1fb8611"> <img width="340" src="https://github.com/status-im/status-mobile/assets/18485527/3992308f-2ca6-416c-a061-cc1c7b8d2b04">

#### Platforms

- Android
- iOS

### Steps to test

- Open Status
- Open quo2 previews
- Select graph > Wallet graph
- Test new customization color field

status: ready