### PR TITLE
Don't display "Add Unknown as contact to send a Message" if chat is not loaded

### DIFF
--- a/src/status_im/chat/models/loading.cljs
+++ b/src/status_im/chat/models/loading.cljs
@@ -59,12 +59,14 @@
 
 (defn mark-chat-all-read
   [db chat-id]
-  (update-in db
-             [:chats chat-id]
-             assoc
-             :unviewed-messages-count 0
-             :unviewed-mentions-count 0
-             :highlight               false))
+  (when (get-in db [:chats chat-id])
+    (update-in
+     db
+     [:chats chat-id]
+     assoc
+     :unviewed-messages-count 0
+     :unviewed-mentions-count 0
+     :highlight               false)))
 
 (rf/defn handle-mark-all-read-successful
   {:events [::mark-all-read-successful]}

--- a/src/status_im2/contexts/chat/messages/view.cljs
+++ b/src/status_im2/contexts/chat/messages/view.cljs
@@ -18,8 +18,9 @@
       :chat           current-chat
       :header-comp    (fn [{:keys [scroll-y]}]
                         [messages.navigation/navigation-view {:scroll-y scroll-y}])
-      :footer-comp    (fn [{:keys [insets]}]
-                        (if-not able-to-send-message?
-                          [contact-requests.bottom-drawer/view chat-id contact-request-state
-                           group-chat]
-                          [:f> composer/composer insets]))}]))
+      :footer-comp    (when (some? able-to-send-message?)
+                        (fn [{:keys [insets]}]
+                          (if-not able-to-send-message?
+                            [contact-requests.bottom-drawer/view chat-id contact-request-state
+                             group-chat]
+                            [:f> composer/composer insets])))}]))


### PR DESCRIPTION
fixes: https://github.com/status-im/status-mobile/issues/17153

### Summary:
If a user opens an open community, he/she also has access to the chats list, which we show on the community screen.
But if the user presses on Join community, we enable the opening of chats. But `:db/chats` still don't have that chat. It will take time to receive that chat from status-go, and until the chat is not received we don't know the chat type, so in meantime we should not show "Add Unknown as contact to send a Message"

status: ready