### PR TITLE
Fix: missing community logo in Activity Center

### DIFF
--- a/src/react_native/core.cljs
+++ b/src/react_native/core.cljs
@@ -16,7 +16,17 @@
 
 (def view (reagent/adapt-react-class (.-View ^js react-native)))
 (def scroll-view (reagent/adapt-react-class (.-ScrollView ^js react-native)))
-(def image (reagent/adapt-react-class (.-Image ^js react-native)))
+
+(def ^:private image-native
+  (reagent/adapt-react-class (.-Image ^js react-native)))
+
+(defn image
+  [{:keys [source] :as props}]
+  [image-native
+   (if (string? source)
+     (assoc props :source {:uri source})
+     props)])
+
 (defn image-get-size [uri callback] (.getSize ^js (.-Image ^js react-native) uri callback))
 (def text (reagent/adapt-react-class (.-Text ^js react-native)))
 (def text-input (reagent/adapt-react-class (.-TextInput ^js react-native)))


### PR DESCRIPTION
Fixes https://github.com/status-im/status-mobile/issues/17157

### Summary

The bug was caused, again, by the fact that the component `react-native/image` source was a string and it was not wrapped inside the map `{:uri "..."}`. The bug was introduced recently by commit 255a3b917265d381fed57e26422277b4cc8772e4

I decided to change `react-native.image` for good, similarly to what we do in `react-native/fast-image` so we can prevent this type of bug in the future.

https://github.com/status-im/status-mobile/blob/ebd38295c6e5715a0ee04217b248ac69f9ddceab/src/react_native/fast_image.cljs#L21

### Screenshot after fix

<img src="https://github.com/status-im/status-mobile/assets/46027/4ffcb399-9979-4e6f-b5b2-c4f637ef5541" height="700" />

#### Platforms

- Android
- iOS

### Steps to test

_(described in the original issue)_

status: ready
