### PR TITLE
fix: remove hole view code with error

### DIFF
--- a/src/quo2/components/navigation/top_nav/view.cljs
+++ b/src/quo2/components/navigation/top_nav/view.cljs
@@ -5,32 +5,7 @@
             [quo2.components.counter.counter.view :as counter]
             [quo2.components.navigation.top-nav.style :as style]
             [quo2.theme :as quo.theme]
-            [react-native.hole-view :as hole-view]
             [quo2.components.common.notification-dot.view :as notification-dot]))
-
-(def notification-dot-hole
-  [{:x            37
-    :y            -2
-    :width        9
-    :height       9
-    :borderRadius 4}])
-
-(defn unread-counter-hole
-  [notification-count]
-  (let [x     (case (count (str notification-count))
-                (1 2) 33
-                29)
-        width (case (count (str notification-count))
-                1 16
-                2 20
-                28)]
-    (if (pos? (js/Number notification-count))
-      [{:x            x
-        :y            -5
-        :width        width
-        :height       16
-        :borderRadius 6}]
-      nil)))
 
 (defn- get-button-common-props
   [{:keys [jump-to? theme blur?]}]
@@ -90,8 +65,6 @@
   [{:keys [theme
            jump-to?
            blur?
-           notification
-           notification-count
            activity-center-on-press
            scan-on-press
            qr-code-on-press
@@ -122,17 +95,12 @@
               :on-press            qr-code-on-press})
       :i/qr-code]
      [rn/view
-      [hole-view/hole-view
-       {:holes (case notification
-                 (:seen :notification)    notification-dot-hole
-                 (:mention :mention-seen) (unread-counter-hole notification-count)
-                 nil)}
-       [button/button
-        (merge button-common-props
-               {:accessibility-label :open-activity-center-button
-                :on-press            activity-center-on-press})
-        :i/activity-center]]
-      [notification-highlight props]]]))
+      [button/button
+       (merge button-common-props
+              {:accessibility-label :open-activity-center-button
+               :on-press            activity-center-on-press})
+       :i/activity-center]]
+     [notification-highlight props]]))
 
 (defn view-internal
   [{:keys [avatar-on-press avatar-props customization-color container-style] :as props}]


### PR DESCRIPTION
<img width="340" alt="400" src="https://github.com/status-im/status-mobile/assets/22799766/9ce76ee0-d85d-4b95-ba4d-b10e424150a5">


Removes the hole view code which is incorrectly using `nil` in the quo2 top nav component.
 Will add this code back in a separate pr once it is stable 👍 