### PR TITLE
Don't parse unused identicon in android pn

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -348,6 +348,11 @@ test: ##@test Run tests once in NodeJS
 	yarn shadow-cljs compile test && \
 	node --require ./test-resources/override.js target/test/test.js
 
+android-test: jsbundle
+android-test: export TARGET := android
+android-test:
+	cd android && ./gradlew test
+
 component-test-watch: export TARGET := clojure
 component-test-watch: export COMPONENT_TEST := true
 component-test-watch: export BABEL_ENV := test

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   presets: ['module:metro-react-native-babel-preset'],
-  plugins: ['react-native-reanimated/plugin'],
+  plugins: ['react-native-reanimated/plugin', '@babel/plugin-transform-named-capturing-groups-regex'],
   env: {
     test: {
       presets: [

--- a/modules/react-native-status/android/build.gradle
+++ b/modules/react-native-status/android/build.gradle
@@ -37,4 +37,7 @@ dependencies {
     implementation 'com.github.status-im:function:0.0.1'
     implementation 'androidx.appcompat:appcompat:1.0.0'
     implementation(group: 'status-im', name: 'status-go', version: getStatusGoSHA1(), ext: 'aar')
+
+    testImplementation 'junit:junit:4.13.2'
+    testImplementation "org.mockito:mockito-core:3.+"
 }

--- a/modules/react-native-status/android/src/main/java/im/status/ethereum/pushnotifications/PushNotification.java
+++ b/modules/react-native-status/android/src/main/java/im/status/ethereum/pushnotifications/PushNotification.java
@@ -45,7 +45,8 @@ public class PushNotification extends ReactContextBaseJavaModule implements Acti
         reactContext.addActivityEventListener(this);
         Application applicationContext = (Application) reactContext.getApplicationContext();
 
-        pushNotificationHelper = new PushNotificationHelper(applicationContext);
+        IntentFilter intentFilter = new IntentFilter();
+        pushNotificationHelper = new PushNotificationHelper(applicationContext, intentFilter);
 
         delivery = new PushNotificationJsDelivery(reactContext);
     }

--- a/modules/react-native-status/android/src/main/java/im/status/ethereum/pushnotifications/PushNotificationActions.java
+++ b/modules/react-native-status/android/src/main/java/im/status/ethereum/pushnotifications/PushNotificationActions.java
@@ -6,6 +6,7 @@ import android.app.NotificationManager;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.content.IntentFilter;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
@@ -51,7 +52,9 @@ public class PushNotificationActions extends BroadcastReceiver {
 
       // Notify the action.
       if(invokeApp) {
-          PushNotificationHelper helper = new PushNotificationHelper((Application) context.getApplicationContext());
+
+          IntentFilter intentFilter = new IntentFilter();
+          PushNotificationHelper helper = new PushNotificationHelper((Application) context.getApplicationContext(), intentFilter);
 
           helper.invokeApp(bundle);
       } else {

--- a/modules/react-native-status/android/src/main/java/im/status/ethereum/pushnotifications/PushNotificationHelper.java
+++ b/modules/react-native-status/android/src/main/java/im/status/ethereum/pushnotifications/PushNotificationHelper.java
@@ -76,8 +76,11 @@ public class PushNotificationHelper {
     private HashMap<String, Person> persons;
     private HashMap<String, StatusMessageGroup> messageGroups;
 
-    public PushNotificationHelper(Application context) {
+    private IntentFilter intentFilter;
+
+    public PushNotificationHelper(Application context, IntentFilter intentFilter) {
         this.context = context;
+        this.intentFilter = intentFilter;
         this.persons = new HashMap<String, Person>();
         this.messageGroups = new HashMap<String, StatusMessageGroup>();
         this.notificationManager = context.getSystemService(NotificationManager.class);
@@ -133,11 +136,10 @@ public class PushNotificationHelper {
             }
         };
 
-    private void registerBroadcastReceiver() {
-        IntentFilter filter = new IntentFilter();
-        filter.addAction(ACTION_DELETE_NOTIFICATION);
-        filter.addAction(ACTION_TAP_STOP);
-        context.registerReceiver(notificationActionReceiver, filter);
+    public void registerBroadcastReceiver() {
+        this.intentFilter.addAction(ACTION_DELETE_NOTIFICATION);
+        this.intentFilter.addAction(ACTION_TAP_STOP);
+        context.registerReceiver(notificationActionReceiver, this.intentFilter);
         Log.e(LOG_TAG, "Broadcast Receiver registered");
     }
 
@@ -684,13 +686,9 @@ public class PushNotificationHelper {
     }
     
     private Person getPerson(Bundle bundle) {
-      String base64Image = bundle.getString("icon").split(",")[1];
-      byte[] decodedString = Base64.decode(base64Image, Base64.DEFAULT);
-      Bitmap decodedByte = BitmapFactory.decodeByteArray(decodedString, 0, decodedString.length);
+     String name = bundle.getString("name");
 
-      String name = bundle.getString("name");
-
-      return new Person.Builder().setIcon(IconCompat.createWithBitmap(getCircleBitmap(decodedByte))).setName(name).build();
+      return new Person.Builder().setName(name).build();
     }
 
     private StatusMessage createMessage(Bundle data) {
@@ -737,6 +735,10 @@ public class PushNotificationHelper {
       group.removeMessage(id);
 
       this.showMessages(bundle);
+    }
+
+    public StatusMessageGroup getMessageGroup(String conversationId) {
+      return this.messageGroups.get(conversationId);
     }
 
     public void addStatusMessage(Bundle bundle) {

--- a/modules/react-native-status/android/src/test/java/android/util/Log.java
+++ b/modules/react-native-status/android/src/test/java/android/util/Log.java
@@ -1,0 +1,23 @@
+package android.util;
+
+public class Log {
+    public static int d(String tag, String msg) {
+        System.out.println("DEBUG: " + tag + ": " + msg);
+        return 0;
+    }
+
+    public static int i(String tag, String msg) {
+        System.out.println("INFO: " + tag + ": " + msg);
+        return 0;
+    }
+
+    public static int w(String tag, String msg) {
+        System.out.println("WARN: " + tag + ": " + msg);
+        return 0;
+    }
+
+    public static int e(String tag, String msg) {
+        System.out.println("ERROR: " + tag + ": " + msg);
+        return 0;
+    }
+}

--- a/modules/react-native-status/android/src/test/java/im/status/ethereum/pushnotifications/PushNotificationHelperTest.java
+++ b/modules/react-native-status/android/src/test/java/im/status/ethereum/pushnotifications/PushNotificationHelperTest.java
@@ -1,0 +1,54 @@
+package im.status.ethereum.pushnotifications;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+import android.app.Application;
+import android.app.NotificationManager;
+import android.os.Bundle;
+
+import android.content.Intent;
+import android.app.PendingIntent;
+import android.content.IntentFilter;
+import static org.mockito.Mockito.*;
+import org.mockito.Spy;
+
+public class PushNotificationHelperTest {
+
+    PushNotificationHelper helper;
+
+
+   @Test
+    public void testAddStatusMessage() {
+        final Application context = mock(Application.class);
+        final NotificationManager manager = mock(NotificationManager.class);
+        final IntentFilter filter = mock(IntentFilter.class);
+
+        when(context.getSystemService(NotificationManager.class)).thenReturn(manager);
+
+        // Create a spy for PushNotificationHelper
+        PushNotificationHelper realHelper = new PushNotificationHelper(context, filter);
+        helper = spy(realHelper);
+
+        Bundle bundle = mock(Bundle.class);
+        Bundle personBundle = mock(Bundle.class);
+
+        String conversationId = "conversation-id";
+        String deepLink = "deep-link";
+
+        when(bundle.getString("conversationId")).thenReturn(conversationId);
+        when(bundle.getString("id")).thenReturn("id");
+        when(bundle.getString("message")).thenReturn("message");
+        when(bundle.getDouble("timestamp")).thenReturn(100000.0);
+        when(bundle.getString("deepLink")).thenReturn(deepLink);
+
+        when(personBundle.getString("name")).thenReturn("name");
+        when(bundle.getBundle("notificationAuthor")).thenReturn(personBundle);
+
+
+        doNothing().when(helper).showMessages(bundle);
+
+        helper.addStatusMessage(bundle);
+        assertNotNull(helper.getMessageGroup(conversationId));
+    }
+}
+

--- a/nix/deps/gradle/deps.json
+++ b/nix/deps/gradle/deps.json
@@ -12875,6 +12875,21 @@
   },
 
   {
+    "path": "net/bytebuddy/byte-buddy-agent/1.11.13",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "byte-buddy-agent-1.11.13.pom": {
+        "sha1": "462542bd3a41955bedcb1b86512cf10d1280575d",
+        "sha256": "sha256-sDhEB2p1yahs4azSrqxPu3kEJ0AzlrbGi7/KlTZLbrQ="
+      },
+      "byte-buddy-agent-1.11.13.jar": {
+        "sha1": "8c7aaa0ef9863fa89a711bfc5d8e2e0affa0d67f",
+        "sha256": "sha256-SbQ7DRD4ux2ADVYTe98PRGKEEuvh+9gE5F82PUlYYPo="
+      }
+    }
+  },
+
+  {
     "path": "net/bytebuddy/byte-buddy-agent/1.14.6",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
@@ -12890,12 +12905,38 @@
   },
 
   {
+    "path": "net/bytebuddy/byte-buddy-parent/1.11.13",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "byte-buddy-parent-1.11.13.pom": {
+        "sha1": "e3334dfff8e86e2caf5c632bc98e6fca2f1a4222",
+        "sha256": "sha256-BZo8mkiOF2lhULG5budtAJyWs6pTVp5jxyS6s6SIAQo="
+      }
+    }
+  },
+
+  {
     "path": "net/bytebuddy/byte-buddy-parent/1.14.6",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
       "byte-buddy-parent-1.14.6.pom": {
         "sha1": "05abbecf7fee254bb50c1f1bfd6ecaf68b4e8fd3",
         "sha256": "sha256-+Ik5S55Xah56POE+/Ue1yy5i67wz4tVczw6SNlzKYvY="
+      }
+    }
+  },
+
+  {
+    "path": "net/bytebuddy/byte-buddy/1.11.13",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "byte-buddy-1.11.13.pom": {
+        "sha1": "3d4916e320cae88ae58704cedc347c1eebca0ca8",
+        "sha256": "sha256-Krna5rnDCPcpvGMb1osG0i+X0ky2Ao85/lRMqpDWrJc="
+      },
+      "byte-buddy-1.11.13.jar": {
+        "sha1": "0a85d4d74de5ce7a4dd5cbbd337ced6af2740acd",
+        "sha256": "sha256-4p+nW5A0Mqxk0FwYwZ0OO5Am50q9pSu9b5Bl5V9KKfU="
       }
     }
   },
@@ -13278,27 +13319,27 @@
   },
 
   {
-    "path": "org/antlr/antlr4-master/4.13.0",
+    "path": "org/antlr/antlr4-master/4.13.1",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "antlr4-master-4.13.0.pom": {
-        "sha1": "d8cb4559e841b8fb7fb73da13b6fb28aad20e8c6",
-        "sha256": "sha256-IiBv17pJUVLlJvUO/sn8j03QX8tD38+PJk6Dffa2Qk8="
+      "antlr4-master-4.13.1.pom": {
+        "sha1": "bbbe6ef89c12fbfb3fde78ac5c190adebbfed6ea",
+        "sha256": "sha256-28/JebgFKPwMtFP8to28nSsGA6e+LNzpmrL8aHFGnRg="
       }
     }
   },
 
   {
-    "path": "org/antlr/antlr4-runtime/4.13.0",
+    "path": "org/antlr/antlr4-runtime/4.13.1",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
-      "antlr4-runtime-4.13.0.pom": {
-        "sha1": "bd7a583a403c741d7b33674d693a7d3787a41519",
-        "sha256": "sha256-GY40+1rHWXsaPDGTAwHgjOlB5cpQQRbdVKOnU3iRSn8="
+      "antlr4-runtime-4.13.1.pom": {
+        "sha1": "4ca08d3d1a1f5cb989858cde922f40acf129e9ac",
+        "sha256": "sha256-GSJrF7+jj5nqImsi6XQg4qjt4JqXQg+xrPGG2a2kZXE="
       },
-      "antlr4-runtime-4.13.0.jar": {
-        "sha1": "5a02e48521624faaf5ff4d99afc88b01686af655",
-        "sha256": "sha256-vX97XQe8CwR/EJFbMspLsd6eV9gEkJiILkRTyIwHal0="
+      "antlr4-runtime-4.13.1.jar": {
+        "sha1": "17125bae1d965624e265ef49552f6465a2bfa307",
+        "sha256": "sha256-VGZdKDjMZkWDQ0aO/FOeRU/JW0aooEsTxqxD/JvmNQU="
       }
     }
   },
@@ -17515,6 +17556,21 @@
   },
 
   {
+    "path": "org/mockito/mockito-core/3.12.4",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "mockito-core-3.12.4.pom": {
+        "sha1": "e159a2a2e92b2410cd76a4cde41a0d63abe82883",
+        "sha256": "sha256-8AK44cJMjXozH5kVpTumW1lFT8Lqqf15b9m/z8HLCv4="
+      },
+      "mockito-core-3.12.4.jar": {
+        "sha1": "f9cdc14ea4a3573c0c0366d47d5ca960be24ddb6",
+        "sha256": "sha256-ddSxS6eu+DbpK6ey1Tyn1rIV3X21Ylr7w5JS8TWINf4="
+      }
+    }
+  },
+
+  {
     "path": "org/mockito/mockito-core/5.5.0",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
@@ -17530,12 +17586,38 @@
   },
 
   {
+    "path": "org/objenesis/objenesis-parent/3.2",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "objenesis-parent-3.2.pom": {
+        "sha1": "833ced74e7fd53408a3915080c5e50f2dc90dc35",
+        "sha256": "sha256-CFm6DVz+77E5ZOWGLANvqkigvM/0kyY4+xP+NEXfM/c="
+      }
+    }
+  },
+
+  {
     "path": "org/objenesis/objenesis-parent/3.3",
     "repo": "https://repo.maven.apache.org/maven2",
     "files": {
       "objenesis-parent-3.3.pom": {
         "sha1": "60b46fea1dc4cb9c3123f8c366f8b33d0c774fa3",
         "sha256": "sha256-MFw4SqLx4cf+U6ltpBw+w1JDuX1CjSSo93mBjMEL5P8="
+      }
+    }
+  },
+
+  {
+    "path": "org/objenesis/objenesis/3.2",
+    "repo": "https://repo.maven.apache.org/maven2",
+    "files": {
+      "objenesis-3.2.pom": {
+        "sha1": "d6bda29a6a26aa5207ab880a4f09870aff20e3c6",
+        "sha256": "sha256-ThCt8Ud7jHEbRbihXrlg9rRIcfXh3vOPFmgTSKoWaww="
+      },
+      "objenesis-3.2.jar": {
+        "sha1": "7fadf57620c8b8abdf7519533e5527367cb51f09",
+        "sha256": "sha256-A9lgvVrvA8ZT6wAEE62hXrd83SuOREiIbt9WkoBeNfM="
       }
     }
   },

--- a/nix/deps/gradle/deps.list
+++ b/nix/deps/gradle/deps.list
@@ -631,7 +631,10 @@ javax.inject:javax.inject:1
 javax.xml.bind:jaxb-api:2.2.12-b140109.1041
 javax.xml.bind:jaxb-api:2.3.1
 junit:junit:4.12
+junit:junit:4.13.2
 me.zhanghai.android.materialprogressbar:library:1.4.2
+net.bytebuddy:byte-buddy-agent:1.11.13
+net.bytebuddy:byte-buddy:1.11.13
 net.java.dev.jna:jna-platform:5.6.0
 net.java.dev.jna:jna:5.6.0
 net.sf.jopt-simple:jopt-simple:4.9
@@ -788,6 +791,8 @@ org.jsoup:jsoup:1.13.1
 org.jvnet.staxex:stax-ex:1.7.7
 org.jvnet.staxex:stax-ex:1.8
 org.jvnet.staxex:stax-ex:1.8.1
+org.mockito:mockito-core:3.12.4
+org.objenesis:objenesis:3.2
 org.ow2.asm:asm-analysis:5.0.3
 org.ow2.asm:asm-analysis:5.1
 org.ow2.asm:asm-analysis:6.0

--- a/nix/deps/gradle/deps.urls
+++ b/nix/deps/gradle/deps.urls
@@ -871,8 +871,11 @@ https://repo.maven.apache.org/maven2/javax/xml/stream/stax-api/1.0-2/stax-api-1.
 https://repo.maven.apache.org/maven2/junit/junit/4.12/junit-4.12.pom
 https://repo.maven.apache.org/maven2/junit/junit/4.13.2/junit-4.13.2.pom
 https://repo.maven.apache.org/maven2/me/zhanghai/android/materialprogressbar/library/1.4.2/library-1.4.2.pom
+https://repo.maven.apache.org/maven2/net/bytebuddy/byte-buddy-agent/1.11.13/byte-buddy-agent-1.11.13.pom
 https://repo.maven.apache.org/maven2/net/bytebuddy/byte-buddy-agent/1.14.6/byte-buddy-agent-1.14.6.pom
+https://repo.maven.apache.org/maven2/net/bytebuddy/byte-buddy-parent/1.11.13/byte-buddy-parent-1.11.13.pom
 https://repo.maven.apache.org/maven2/net/bytebuddy/byte-buddy-parent/1.14.6/byte-buddy-parent-1.14.6.pom
+https://repo.maven.apache.org/maven2/net/bytebuddy/byte-buddy/1.11.13/byte-buddy-1.11.13.pom
 https://repo.maven.apache.org/maven2/net/bytebuddy/byte-buddy/1.14.6/byte-buddy-1.14.6.pom
 https://repo.maven.apache.org/maven2/net/java/dev/jna/jna-platform/5.6.0/jna-platform-5.6.0.pom
 https://repo.maven.apache.org/maven2/net/java/dev/jna/jna/5.6.0/jna-5.6.0.pom
@@ -900,8 +903,8 @@ https://repo.maven.apache.org/maven2/org/abego/treelayout/org.abego.treelayout.c
 https://repo.maven.apache.org/maven2/org/antlr/ST4/4.0.8/ST4-4.0.8.pom
 https://repo.maven.apache.org/maven2/org/antlr/ST4/4.3.4/ST4-4.3.4.pom
 https://repo.maven.apache.org/maven2/org/antlr/antlr4-master/4.5.3/antlr4-master-4.5.3.pom
-https://repo.maven.apache.org/maven2/org/antlr/antlr4-master/4.13.0/antlr4-master-4.13.0.pom
-https://repo.maven.apache.org/maven2/org/antlr/antlr4-runtime/4.13.0/antlr4-runtime-4.13.0.pom
+https://repo.maven.apache.org/maven2/org/antlr/antlr4-master/4.13.1/antlr4-master-4.13.1.pom
+https://repo.maven.apache.org/maven2/org/antlr/antlr4-runtime/4.13.1/antlr4-runtime-4.13.1.pom
 https://repo.maven.apache.org/maven2/org/antlr/antlr4/4.5.3/antlr4-4.5.3.pom
 https://repo.maven.apache.org/maven2/org/antlr/antlr-master/3.3/antlr-master-3.3.pom
 https://repo.maven.apache.org/maven2/org/antlr/antlr-master/3.5.2/antlr-master-3.5.2.pom
@@ -1199,8 +1202,11 @@ https://repo.maven.apache.org/maven2/org/jvnet/staxex/stax-ex/1.7.7/stax-ex-1.7.
 https://repo.maven.apache.org/maven2/org/jvnet/staxex/stax-ex/1.8.1/stax-ex-1.8.1.pom
 https://repo.maven.apache.org/maven2/org/jvnet/staxex/stax-ex/1.8/stax-ex-1.8.pom
 https://repo.maven.apache.org/maven2/org/jvnet/staxex/stax-ex/2.1.0/stax-ex-2.1.0.pom
+https://repo.maven.apache.org/maven2/org/mockito/mockito-core/3.12.4/mockito-core-3.12.4.pom
 https://repo.maven.apache.org/maven2/org/mockito/mockito-core/5.5.0/mockito-core-5.5.0.pom
+https://repo.maven.apache.org/maven2/org/objenesis/objenesis-parent/3.2/objenesis-parent-3.2.pom
 https://repo.maven.apache.org/maven2/org/objenesis/objenesis-parent/3.3/objenesis-parent-3.3.pom
+https://repo.maven.apache.org/maven2/org/objenesis/objenesis/3.2/objenesis-3.2.pom
 https://repo.maven.apache.org/maven2/org/objenesis/objenesis/3.3/objenesis-3.3.pom
 https://repo.maven.apache.org/maven2/org/ow2/asm/asm-analysis/5.0.3/asm-analysis-5.0.3.pom
 https://repo.maven.apache.org/maven2/org/ow2/asm/asm-analysis/5.1/asm-analysis-5.1.pom

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "@babel/generator": "7.0.0",
     "@babel/helper-builder-react-jsx": "7.0.0",
     "@babel/plugin-transform-block-scoping": "7.0.0",
+    "@babel/plugin-transform-named-capturing-groups-regex": "^7.22.5",
     "@babel/preset-env": "7.1.0",
     "@babel/preset-react": "^7.18.6",
     "@babel/register": "7.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -186,6 +186,13 @@
   dependencies:
     "@babel/types" "^7.18.6"
 
+"@babel/helper-annotate-as-pure@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.22.5.tgz#e7f06737b197d580a01edf75d97e2c8be99d3882"
+  integrity sha512-LvBTxu8bQSQkcyKOU+a1btnNFQ1dMAd0R6PyW3arXes06F6QLWLIrd681bxRPIXlrMGR3XYnW9JyML7dP3qgxg==
+  dependencies:
+    "@babel/types" "^7.22.5"
+
 "@babel/helper-annotate-as-pure@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.8.3.tgz#60bc0bc657f63a0924ff9a4b4a0b24a13cf4deee"
@@ -273,6 +280,15 @@
   dependencies:
     "@babel/helper-annotate-as-pure" "^7.18.6"
     regexpu-core "^5.3.1"
+
+"@babel/helper-create-regexp-features-plugin@^7.22.5":
+  version "7.22.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.22.9.tgz#9d8e61a8d9366fe66198f57c40565663de0825f6"
+  integrity sha512-+svjVa/tFwsNSG4NEy1h85+HQ5imbT92Q5/bgtS7P0GTQlP8WuFdqsiABmQouhiFGyV66oGxZFpeYHza1rNsKw==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.22.5"
+    regexpu-core "^5.3.1"
+    semver "^6.3.1"
 
 "@babel/helper-create-regexp-features-plugin@^7.8.3", "@babel/helper-create-regexp-features-plugin@^7.8.8":
   version "7.8.8"
@@ -521,6 +537,11 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.21.5.tgz#345f2377d05a720a4e5ecfa39cbf4474a4daed56"
   integrity sha512-0WDaIlXKOX/3KfBK/dwP1oQGiPh6rjMkT7HIRv7i5RR2VUMwrx5ZL0dwBkKx7+SW1zwNdgjHd34IMk5ZjTeHVg==
 
+"@babel/helper-plugin-utils@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz#dd7ee3735e8a313b9f7b05a773d892e88e6d7295"
+  integrity sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==
+
 "@babel/helper-regex@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-regex/-/helper-regex-7.8.3.tgz#139772607d51b93f23effe72105b319d2a4c6965"
@@ -642,6 +663,11 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.21.5.tgz#2b3eea65443c6bdc31c22d037c65f6d323b6b2bd"
   integrity sha512-5pTUx3hAJaZIdW99sJ6ZUUgWq/Y+Hja7TowEnLNMm1VivRgZQL3vpBY3qUACVsvw+yQU6+YgfBVmcbLaZtrA1w==
 
+"@babel/helper-string-parser@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz#533f36457a25814cf1df6488523ad547d784a99f"
+  integrity sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==
+
 "@babel/helper-validator-identifier@^7.16.7":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz#e8c602438c4a8195751243da9031d1607d247cad"
@@ -651,6 +677,11 @@
   version "7.19.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz#7eea834cf32901ffdc1a7ee555e2f9c27e249ca2"
   integrity sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==
+
+"@babel/helper-validator-identifier@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz#9544ef6a33999343c8740fa51350f30eeaaaf193"
+  integrity sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==
 
 "@babel/helper-validator-identifier@^7.9.0", "@babel/helper-validator-identifier@^7.9.5":
   version "7.9.5"
@@ -1223,6 +1254,14 @@
     "@babel/helper-create-regexp-features-plugin" "^7.20.5"
     "@babel/helper-plugin-utils" "^7.20.2"
 
+"@babel/plugin-transform-named-capturing-groups-regex@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.22.5.tgz#67fe18ee8ce02d57c855185e27e3dc959b2e991f"
+  integrity sha512-YgLLKmS3aUBhHaxp5hi1WJTgOUb/NCuDHzGT9z9WTt3YG+CPRhJs6nprbStx6DnWM4dh6gt7SU3sZodbZ08adQ==
+  dependencies:
+    "@babel/helper-create-regexp-features-plugin" "^7.22.5"
+    "@babel/helper-plugin-utils" "^7.22.5"
+
 "@babel/plugin-transform-new-target@^7.0.0":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.8.3.tgz#60cc2ae66d85c95ab540eb34babb6434d4c70c43"
@@ -1731,6 +1770,15 @@
   dependencies:
     "@babel/helper-string-parser" "^7.21.5"
     "@babel/helper-validator-identifier" "^7.19.1"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.22.5":
+  version "7.22.11"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.22.11.tgz#0e65a6a1d4d9cbaa892b2213f6159485fe632ea2"
+  integrity sha512-siazHiGuZRz9aB9NpHy9GOs9xiQPKnMzgdr493iI1M67vRXpnEq8ZOOKzezC5q7zwuQ6sDhdSp4SD9ixKSqKZg==
+  dependencies:
+    "@babel/helper-string-parser" "^7.22.5"
+    "@babel/helper-validator-identifier" "^7.22.5"
     to-fast-properties "^2.0.0"
 
 "@bcoe/v8-coverage@^0.2.3":
@@ -9571,6 +9619,11 @@ semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
+semver@^6.3.1:
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
+  integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
 semver@^7.3.2:
   version "7.3.8"


### PR DESCRIPTION
Removes parsing of identicon from notification, which won't be showing it anymore (it's a bit more complicated to add the actual image, so removing for now).

I am trying to set up unit tests for this part, but getting into some issues, as this is a blocker, I will send the PR for review now

Fixes: #17160