### PR TITLE
Improve `make show-ios-devices`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -286,7 +286,6 @@ else
 	npx react-native run-ios
 endif
 
-show-ios-devices: export TARGET := ios
 show-ios-devices: ##@other shows connected ios device and its name
 	xcrun xctrace list devices
 


### PR DESCRIPTION
After discussing with @yakimant I realised that `make show-ios-devices` command does an un-necessary  status-go build because it uses the IOS Target.

This PR removes the dependency of the IOS Target for `show-ios-devices` command. We no longer need the IOS target because the default shell contains the `ios-deploy` library, which is used by this command already.


status: ready
