### PR TITLE
Hide feature communities section if none is fetched.

### DIFF
--- a/src/status_im2/contexts/communities/discover/view.cljs
+++ b/src/status_im2/contexts/communities/discover/view.cljs
@@ -119,9 +119,11 @@
            selected-tab]}]
   [react/animated-view
    [screen-title]
-   [featured-communities-header featured-communities-count]
-   [featured-list featured-communities view-type]
-   [quo/separator {:style {:margin-horizontal 20}}]
+   (when (pos? featured-communities-count)
+     [:<>
+      [featured-communities-header featured-communities-count]
+      [featured-list featured-communities view-type]
+      [quo/separator {:style {:margin-horizontal 20}}]])
    [discover-communities-segments selected-tab false]])
 
 (defn other-communities-list


### PR DESCRIPTION
Hides feature communities section if none is fetched.

The reason I believe is that it can't be retrieved by mailserver, as the admin wasn't online to publish an updated community description. I have asked Iuri to take a look since we are not admin of these communities.