### PR TITLE
[WIP] feat: new variant for private key input

### DIFF
--- a/src/quo2/components/inputs/private_key_input/style.cljs
+++ b/src/quo2/components/inputs/private_key_input/style.cljs
@@ -1,0 +1,62 @@
+(ns quo2.components.inputs.private-key-input.style
+  (:require [quo2.foundations.colors :as colors]
+            [quo2.foundations.typography :as typography]))
+
+(def container-text-input
+  {:flex-direction     :row
+   :justify-content    :space-between
+   :padding-horizontal 20})
+
+(defn text-input-container
+  [invalid?]
+  {:padding-left   12
+   :padding-right  7
+   :min-height     40
+   :flex           1
+   :flex-direction :row
+   :border-width   1
+   :border-radius  12
+   :border-color   (if invalid?
+                     colors/danger-50-opa-40
+                     colors/neutral-60)})
+
+(defn text-input
+  []
+  (merge typography/monospace
+         typography/paragraph-1
+         {:flex                1
+          :padding-bottom      8
+          :color               colors/white
+          :text-align-vertical :center}))
+
+(def label-texts-container
+  {:flex-direction :row
+   :height         18
+   :margin-bottom  8})
+
+(def button-paste
+  {:margin-top 8})
+
+(def clear-icon
+  {:size  20
+   :color colors/neutral-80-opa-30})
+
+(def right-icon-touchable-area
+  {:margin-left   8
+   :padding-right 4
+   :padding-top   6
+   :margin-bottom 4})
+
+(def label-pairing
+  {:color colors/white-opa-40})
+
+(def label-container
+  {:flex-direction :row
+   :margin-left    20
+   :line-height    18
+   :margin-top     20
+   :margin-bottom  8})
+
+(def continue-button-container
+  {:margin-top         12
+   :padding-horizontal 22})

--- a/src/quo2/components/inputs/private_key_input/style.cljs
+++ b/src/quo2/components/inputs/private_key_input/style.cljs
@@ -2,10 +2,13 @@
   (:require [quo2.foundations.colors :as colors]
             [quo2.foundations.typography :as typography]))
 
+(def container-inner
+  {:style {:flex-direction :column
+           :align-items    :flex-start}})
+
 (def container-text-input
-  {:flex-direction     :row
-   :justify-content    :space-between
-   :padding-horizontal 20})
+  {:flex-direction  :row
+   :justify-content :space-between})
 
 (defn text-input-container
   [invalid?]
@@ -52,7 +55,7 @@
 
 (def label-container
   {:flex-direction :row
-   :margin-left    20
+   ;   :margin-left    20
    :line-height    18
    :margin-top     20
    :margin-bottom  8})

--- a/src/quo2/components/inputs/private_key_input/view.cljs
+++ b/src/quo2/components/inputs/private_key_input/view.cljs
@@ -1,0 +1,58 @@
+(ns quo2.components.inputs.private-key-input.view
+  (:require
+    [quo2.components.inputs.private-key-input.style :as style]
+    [quo2.components.markdown.text :as quo-text]
+    [react-native.core :as rn]
+    [quo2.components.icon :as quo-icon]
+    [quo2.components.buttons.button.view :as quo-button]
+    [quo2.foundations.colors :as colors]
+    [reagent.core :as reagent]
+    [utils.i18n :as i18n]
+    [clojure.string :as string]
+    [react-native.clipboard :as clipboard]))
+
+(defn private-key-input
+  [{:keys [input-placeholder
+           title-text]}]
+  (let [text-input-value (reagent/atom "")]
+    (fn []
+      (let [invalid?           false
+            show-paste-button? (string/blank? @text-input-value)]
+        [:<>
+         [rn/view
+          {:style style/label-container}
+          [quo-text/text
+           {:style  style/label-pairing
+            :weight :medium
+            :size   :paragraph-2}
+           title-text]]
+         [rn/view {:style style/container-text-input}
+          [rn/view {:style (style/text-input-container invalid?)}
+           [rn/text-input
+            {:style                  (style/text-input)
+             :value                  @text-input-value
+             :placeholder            input-placeholder
+             :on-change-text         (fn [updated-text]
+                                       (reset! text-input-value updated-text)
+                                       (reagent/flush))
+             :blur-on-submit         true
+             :return-key-type        :done
+             :accessibility-label    :enter-sync-code-input
+             :auto-capitalize        :none
+             :placeholder-text-color colors/white-opa-40
+             :multiline              true}]
+           (if show-paste-button?
+             [quo-button/button
+              {:on-press        (fn [_]
+                                  (clipboard/get-string #(reset! text-input-value %)))
+               :type            :outline
+               :container-style style/button-paste
+               :size            24}
+              (i18n/label :t/paste)]
+
+             [rn/pressable
+              {:accessibility-label :input-right-icon
+               :style               style/right-icon-touchable-area
+               :on-press            (fn [_]
+                                      (reset! text-input-value nil))}
+              [quo-icon/icon :i/clear style/clear-icon]])]]]))))

--- a/src/quo2/components/inputs/private_key_input/view.cljs
+++ b/src/quo2/components/inputs/private_key_input/view.cljs
@@ -25,7 +25,6 @@
     (fn []
 
       (let [show-paste-button? (string/blank? @text-input-value)]
-        (if show-paste-button? (reset! invalid? false))
         [:<>
          [rn/view style/container-inner
           [rn/view

--- a/src/quo2/components/inputs/private_key_input/view.cljs
+++ b/src/quo2/components/inputs/private_key_input/view.cljs
@@ -13,46 +13,66 @@
 
 (defn private-key-input
   [{:keys [input-placeholder
-           title-text]}]
+           title-text
+           scan-variant?
+           on-scan-press
+           after-paste-press
+           on-change-text
+           invalid?
+           blur-on-submit
+           return-key-type]}]
   (let [text-input-value (reagent/atom "")]
     (fn []
-      (let [invalid?           false
-            show-paste-button? (string/blank? @text-input-value)]
-        [:<>
-         [rn/view
-          {:style style/label-container}
-          [quo-text/text
-           {:style  style/label-pairing
-            :weight :medium
-            :size   :paragraph-2}
-           title-text]]
-         [rn/view {:style style/container-text-input}
-          [rn/view {:style (style/text-input-container invalid?)}
-           [rn/text-input
-            {:style                  (style/text-input)
-             :value                  @text-input-value
-             :placeholder            input-placeholder
-             :on-change-text         (fn [updated-text]
-                                       (reset! text-input-value updated-text)
-                                       (reagent/flush))
-             :blur-on-submit         true
-             :return-key-type        :done
-             :accessibility-label    :enter-sync-code-input
-             :auto-capitalize        :none
-             :placeholder-text-color colors/white-opa-40
-             :multiline              true}]
-           (if show-paste-button?
-             [quo-button/button
-              {:on-press        (fn [_]
-                                  (clipboard/get-string #(reset! text-input-value %)))
-               :type            :outline
-               :container-style style/button-paste
-               :size            24}
-              (i18n/label :t/paste)]
 
-             [rn/pressable
-              {:accessibility-label :input-right-icon
-               :style               style/right-icon-touchable-area
-               :on-press            (fn [_]
-                                      (reset! text-input-value nil))}
-              [quo-icon/icon :i/clear style/clear-icon]])]]]))))
+      (let [show-paste-button? (string/blank? @text-input-value)]
+        (if show-paste-button? (reset! invalid? false))
+        [:<>
+         [rn/view style/container-inner
+          [rn/view
+           {:style style/label-container}
+           [quo-text/text
+            {:style  style/label-pairing
+             :weight :medium
+             :size   :paragraph-2}
+            title-text]]
+          [rn/view {:style style/container-text-input}
+           [rn/view {:style (style/text-input-container @invalid?)}
+            [rn/text-input
+             {:style                  (style/text-input)
+              :value                  @text-input-value
+              :placeholder            input-placeholder
+              :on-change-text         (fn [updated-text]
+                                        (reset! text-input-value updated-text)
+                                        (when on-change-text
+                                          (on-change-text text-input-value))
+                                        (reagent/flush))
+              :accessibility-label    :enter-sync-code-input
+              :auto-capitalize        :none
+              :placeholder-text-color colors/white-opa-40
+              :multiline              true
+              :blur-on-submit         blur-on-submit
+              :return-key-type        return-key-type}]
+            (if show-paste-button?
+              [quo-button/button
+               {:on-press        (fn [_]
+                                   (clipboard/get-string #(reset! text-input-value %))
+                                   (when after-paste-press (after-paste-press)))
+                :type            :outline
+                :container-style style/button-paste
+                :size            24}
+               (i18n/label :t/paste)]
+
+              [rn/pressable
+               {:accessibility-label :input-right-icon
+                :style               style/right-icon-touchable-area
+                :on-press            (fn [_]
+                                       (reset! text-input-value nil))}
+               [quo-icon/icon :i/clear style/clear-icon]])]
+           (if scan-variant?
+             [quo-button/button
+              {:type            :outline
+               :icon-only?      true
+               :size            40
+               :on-press        on-scan-press
+               :container-style {:margin-left 8}}
+              :i/scan])]]]))))

--- a/src/quo2/core.cljs
+++ b/src/quo2/core.cljs
@@ -58,6 +58,7 @@
     quo2.components.inputs.recovery-phrase.view
     quo2.components.inputs.search-input.view
     quo2.components.inputs.title-input.view
+    quo2.components.inputs.private-key-input.view
     quo2.components.keycard.view
     quo2.components.links.link-preview.view
     quo2.components.links.url-preview-list.view
@@ -238,7 +239,7 @@
 (def recovery-phrase-input quo2.components.inputs.recovery-phrase.view/recovery-phrase-input)
 (def search-input quo2.components.inputs.search-input.view/search-input)
 (def title-input quo2.components.inputs.title-input.view/view)
-
+(def private-key-input quo2.components.inputs.private-key-input.view/private-key-input)
 ;;;; Numbered Keyboard
 (def keyboard-key quo2.components.numbered-keyboard.keyboard-key.view/view)
 (def numbered-keyboard quo2.components.numbered-keyboard.numbered-keyboard.view/view)

--- a/src/status_im2/contexts/add_new_contact/views.cljs
+++ b/src/status_im2/contexts/add_new_contact/views.cljs
@@ -45,10 +45,9 @@
         invalid-state (reagent/atom nil)]
     (fn []
       (clipboard/get-string #(reset! clipboard %))
-      (let [{:keys [input scanned public-key ens state msg]}
-            (rf/sub [:contacts/new-identity])
+      (let [{:keys [input scanned public-key ens state msg]} (rf/sub [:contacts/new-identity])
             customization-color (rf/sub [:profile/customization-color])
-            invalid? (reset! invalid-state (= state :invalid))
+            _ (reset! invalid-state (= state :invalid))
             show-paste-button? (and (not (string/blank? @clipboard))
                                     (string/blank? @default-value)
                                     (string/blank? input))]

--- a/src/status_im2/contexts/quo_preview/inputs/private_key_input.cljs
+++ b/src/status_im2/contexts/quo_preview/inputs/private_key_input.cljs
@@ -1,0 +1,22 @@
+(ns status-im2.contexts.quo-preview.inputs.private-key-input
+  (:require [quo2.core :as quo]
+            [reagent.core :as reagent]
+            [status-im2.contexts.quo-preview.preview :as preview]))
+
+(def descriptor
+  [{:key  :input-placeholder
+    :type :text}
+   {:key  :title-text
+    :type :text}])
+
+(defn view
+  []
+  (let [state (reagent/atom {:color             nil
+                             :input-placeholder "cs2:4FH..."
+                             :disabled?         false
+                             :title-text        "Type or paste sync code"})]
+    (fn []
+      [preview/preview-container
+       {:state      state
+        :descriptor descriptor}
+       [quo/private-key-input @state]])))

--- a/src/status_im2/contexts/quo_preview/inputs/private_key_input.cljs
+++ b/src/status_im2/contexts/quo_preview/inputs/private_key_input.cljs
@@ -7,16 +7,20 @@
   [{:key  :input-placeholder
     :type :text}
    {:key  :title-text
-    :type :text}])
+    :type :text}
+   {:key  :invalid?
+    :type :boolean}
+  ])
 
 (defn view
   []
-  (let [state (reagent/atom {:color             nil
-                             :input-placeholder "cs2:4FH..."
-                             :disabled?         false
-                             :title-text        "Type or paste sync code"})]
+  (let [state    (reagent/atom {:input-placeholder "cs2:4FH..."
+                                :disabled?         false
+                                :title-text        "Type or paste sync code"
+                                :scan-variant?     false})
+        invalid? (reagent/atom nil)]
     (fn []
       [preview/preview-container
        {:state      state
         :descriptor descriptor}
-       [quo/private-key-input @state]])))
+       [quo/private-key-input @state {:invalid invalid?}]])))

--- a/src/status_im2/contexts/quo_preview/main.cljs
+++ b/src/status_im2/contexts/quo_preview/main.cljs
@@ -59,6 +59,7 @@
     [status-im2.contexts.quo-preview.inputs.profile-input :as profile-input]
     [status-im2.contexts.quo-preview.inputs.search-input :as search-input]
     [status-im2.contexts.quo-preview.inputs.title-input :as title-input]
+    [status-im2.contexts.quo-preview.inputs.private-key-input :as private-key-input]
     [status-im2.contexts.quo-preview.numbered-keyboard.keyboard-key :as keyboard-key]
     [status-im2.contexts.quo-preview.numbered-keyboard.numbered-keyboard :as numbered-keyboard]
     [status-im2.contexts.quo-preview.links.url-preview :as url-preview]
@@ -247,7 +248,9 @@
                        {:name      :search-input
                         :component search-input/view}
                        {:name      :title-input
-                        :component title-input/view}]
+                        :component title-input/view}
+                       {:name      :private-key-input
+                        :component private-key-input/view}]
    :numbered-keyboard [{:name      :keyboard-key
                         :options   {:insets {:top? true}}
                         :component keyboard-key/preview-keyboard-key}


### PR DESCRIPTION
fixes #16858 

### Summary
Quo2 input variant to handle pasting of chat keys.

I first tried to fix multi-line in base input variant and in doing so it would work in a few cases but would break when I would use it in conjunction of other options like placing buttons inside the text-input.

So instead of modifying this god component I decided to make a variant ( following how there were other variants of input component in quo2).

### Testing notes
This is a Quo2 component and In this PR I will replace existing implementation of add contact screen with this component.

#### Platforms
- Android
- iOS

status: wip
