### PR TITLE
Disable fn-deprecated warning during development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -308,7 +308,7 @@ endef
 lint: export TARGET := clojure
 lint: ##@test Run code style checks
 	@sh scripts/lint-re-frame-in-quo-components.sh && \
-	clj-kondo --config .clj-kondo/config.edn --cache false --lint src && \
+	clj-kondo --config .clj-kondo/config.edn --cache false --fail-level error --lint src && \
 	ALL_CLOJURE_FILES=$(call find_all_clojure_files) && \
 	zprint '{:search-config? true}' -sfc $$ALL_CLOJURE_FILES && \
 	sh scripts/lint-trailing-newline.sh && \

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -66,10 +66,14 @@
           status-im2.config/ALCHEMY_OPTIMISM_MAINNET_TOKEN #shadow/env "ALCHEMY_OPTIMISM_MAINNET_TOKEN"
           status-im2.config/ALCHEMY_ARBITRUM_MAINNET_TOKEN #shadow/env "ALCHEMY_ARBITRUM_MAINNET_TOKEN"}
          :compiler-options {:output-feature-set :es5
-                            :closure-defines
-                            {re-frame.trace/trace-enabled? true}
-                            :source-map false
-                            :infer-externs true}
+                            ;; We disable `:fn-deprecated` warnings because we
+                            ;; are managing deprecation via clj-kondo and we
+                            ;; don't want the terminal output to be littered
+                            ;; with warnings on every code reload.
+                            :warnings           {:fn-deprecated false}
+                            :closure-defines    {re-frame.trace/trace-enabled? true}
+                            :source-map         false
+                            :infer-externs      true}
          ;; if you want to use a real device, set your local ip
          ;; in the SHADOW_HOST env variable to make sure that
          ;; it will use the right interface


### PR DESCRIPTION
### Summary

Disable `:fn-deprecated` warnings from the Closure compiler for the `mobile` shadow-cljs target **during development**. The compiler warnings are no longer necessary, because we're managing deprecation via clj-kondo.

Without the compiler setting's change, every code reload will generate warnings for each and every deprecated call in the repo, which can quickly grow to the hundreds or more, thus making the terminal output horrendous to understand.

#### Notes

Also set clj-kondo's `fail-level` to `error` (the default is `warning`).

status: ready
