### PR TITLE
[#17207] fix: incorrect mentions alignment in messages

### DIFF
--- a/src/status_im2/contexts/chat/messages/content/text/style.cljs
+++ b/src/status_im2/contexts/chat/messages/content/text/style.cljs
@@ -1,7 +1,6 @@
 (ns status-im2.contexts.chat.messages.content.text.style
-  (:require [quo2.foundations.colors :as colors]))
-
-(def spacing-between-blocks 0)
+  (:require [quo2.foundations.colors :as colors]
+            [quo.platform :as platform]))
 
 (def block
   {:border-radius      6
@@ -12,18 +11,14 @@
    :padding-left      10
    :border-left-color colors/neutral-40})
 
-(defn mention-tag-wrapper
-  []
-  {:flex-direction :row
-   :align-items    :center
-   :height         22})
-
-(def mention-tag
-  {:background-color   colors/primary-50-opa-10
+(def mention-tag-wrapper
+  {:flex-direction     :row
+   :align-items        :center
+   :height             22
+   :background-color   colors/primary-50-opa-10
    :padding-horizontal 3
    :border-radius      6
-   :margin-bottom      -3
-   :height             22})
+   :transform          [{:translateY (if platform/ios? 4 6)}]})
 
 (def mention-tag-text
   {:color                 (colors/theme-colors colors/primary-50

--- a/src/status_im2/contexts/chat/messages/content/text/style.cljs
+++ b/src/status_im2/contexts/chat/messages/content/text/style.cljs
@@ -11,14 +11,15 @@
    :padding-left      10
    :border-left-color colors/neutral-40})
 
-(def mention-tag-wrapper
+(defn mention-tag-wrapper
+  [first-child-mention]
   {:flex-direction     :row
    :align-items        :center
-   :height             22
+   :height             (if platform/ios? 22 21)
    :background-color   colors/primary-50-opa-10
    :padding-horizontal 3
    :border-radius      6
-   :transform          [{:translateY (if platform/ios? 4 6)}]})
+   :transform          [{:translateY (if platform/ios? (if first-child-mention 4.5 3) 4.5)}]})
 
 (def mention-tag-text
   {:color                 (colors/theme-colors colors/primary-50

--- a/src/status_im2/contexts/chat/messages/content/text/view.cljs
+++ b/src/status_im2/contexts/chat/messages/content/text/view.cljs
@@ -55,21 +55,17 @@
       :mention
       (conj
        units
-       [rn/view
-        {:style style/mention-tag-wrapper}
-        [rn/touchable-opacity
-         {:active-opacity 1
-          :on-press       #(rf/dispatch [:chat.ui/show-profile literal])
-          :style          style/mention-tag}
-         [quo/text
-          {:weight :medium
-           :style  style/mention-tag-text
-           :size   :paragraph-1}
-          (rf/sub [:messages/resolve-mention literal])]]])
+       [rn/pressable
+        {:on-press #(rf/dispatch [:chat.ui/show-profile literal])
+         :style    style/mention-tag-wrapper}
+        [quo/text
+         {:weight :medium
+          :style  style/mention-tag-text
+          :size   :paragraph-1}
+         (rf/sub [:messages/resolve-mention literal])]])
 
       :edited
       (conj units
-
             [quo/text
              {:weight :medium
               :style  {:font-size 11 ; Font-size must be used instead of props or the
@@ -90,6 +86,11 @@
 
       (conj units literal))))
 
+(defn first-child-mention
+  [children]
+  (and (> (count children) 0)
+       (= (keyword (:type (second children))) :mention)
+       (empty? (get-in children [0 :literal]))))
 
 (defn render-block
   [blocks {:keys [type literal children]} chat-id style-override]
@@ -101,8 +102,9 @@
             (fn [acc e]
               (render-inline acc e chat-id style-override))
             [quo/text
-             {:style {:size  :paragraph-1
-                      :color (when (seq style-override) colors/white)}}]
+             {:style {:size          :paragraph-1
+                      :margin-bottom (if (first-child-mention children) 4 0)
+                      :color         (when (seq style-override) colors/white)}}]
             children)])
 
     :edited-block


### PR DESCRIPTION
fixes #17207

I've noticed some issues related to the mention tag, and I'd like to provide a technical explanation that we can refer to in case we encounter similar problems in the future.

Issues:

- #15745
- #15702
- #15693
- #16108

The mention tag faces certain limitations because we're rendering a view inside a text component. Essentially, it's affected by an open issue in React Native regarding vertical alignment ([Nested View and Text vertical alignment issue](https://github.com/facebook/react-native/issues/#31955)). 

The workaround we currently employ involves trial and error to adjust the position of the mention tag so that it aligns with the text. Please note that this alignment may not be consistent across all OS versions and platforms.

Additionally, I explored an alternative solution that involves using just a text component instead of a view. However, this approach also has its limitations, particularly related to styles. For instance, nested text components don't accept properties like border radius or padding, although alignment works correctly.

So what I've done here is applied some additional improvements until the React Native team addresses the issue, or until we discover an alternative workaround or a different design approach that's implementable.

cc @pavloburykh @cammellos 

**Android** Before -> After

<img alt="Android Before" src="https://github.com/status-im/status-mobile/assets/71308738/8938c5e3-a097-453f-8451-070c3ee99962" width="375px"/>

<img alt="Android After" src="https://github.com/status-im/status-mobile/assets/71308738/544415c6-808d-44a7-bddb-f30d7424eede" width="375px"/>

**iOS** Before -> After

<img alt="iOS Before" src="https://github.com/status-im/status-mobile/assets/71308738/caedb22b-7d1a-44ae-8c37-f8e2718bc8a9" width="375px"/>

<img alt="iOS After" src="https://github.com/status-im/status-mobile/assets/71308738/aa88086d-a850-49fb-84a6-8fc210a0d9be" width="375px"/>

status: ready
