### PR TITLE
Fix: composer is separated from the footer

### DIFF
--- a/src/status_im2/contexts/chat/messages/list/view.cljs
+++ b/src/status_im2/contexts/chat/messages/list/view.cljs
@@ -363,5 +363,5 @@
         top-spacing         (when (not chat-screen-loaded?) navigation.style/navigation-bar-height)]
     (if chat-screen-loaded?
       [:f> f-messages-list-content props]
-      [rn/view {:style {:padding-top top-spacing}}
+      [rn/view {:style {:padding-top top-spacing :flex 1}}
        [quo/skeleton-list (skeleton-list-props :messages content-height false)]])))


### PR DESCRIPTION
fixes #17237

### Summary

### Review notes
Please test on your Android/iOS simulators

### Testing notes
All tests should pass

#### Platforms

- Android
- iOS

##### Functional

- 1-1 chats
- public chats
- group chats

### Steps to test

- Enter chat
- Pay attention at composer while chat is being loaded

status: wip

iOS after changes:

https://github.com/status-im/status-mobile/assets/5999878/c33181b7-bf59-408f-92a1-9e8660404b18


