### PR TITLE
Disable warning about non-reactive context during subscription tests

### DIFF
--- a/src/test_helpers/unit.clj
+++ b/src/test_helpers/unit.clj
@@ -51,10 +51,12 @@
        (let [~args [sub-name#]]
          (restore-app-db
           (fn []
-            ~@(clojure.walk/postwalk-replace
-               {'cljs.test/testing `testing-subscription
-                'testing           `testing-subscription}
-               body)))))))
+            ;; Do not warn about subscriptions being used in non-reactive contexts.
+            (with-redefs [re-frame.interop/debug-enabled? false]
+              ~@(clojure.walk/postwalk-replace
+                 {'cljs.test/testing `testing-subscription
+                  'testing           `testing-subscription}
+                 body))))))))
 
 (defmacro use-log-fixture
   "Register log fixture which allows inspecting all calls to `taoensso.timbre/log`.


### PR DESCRIPTION
### Summary

Quick one, here we force re-frame to stop warning about subscriptions in non-reactive contexts while executing subscription tests (i.e. unit tests using the macro `test-helpers.unit/deftest-sub`).

The net result? No more hundreds of useless warnings in the output of `make test`.

```
re-frame: Subscribe was called outside of a reactive context.
 See: https://day8.github.io/re-frame/FAQs/UseASubscriptionInAJsEvent/
```

The warning is actually useful in production code, but in a subscription test we already know we're never inside a reactive context.

#### Areas that maybe impacted

None.

status: ready
