### PR TITLE
fix: update use of setting-item component to match new api

### DIFF
--- a/src/quo2/components/settings/settings_item/style.cljs
+++ b/src/quo2/components/settings/settings_item/style.cljs
@@ -8,12 +8,14 @@
     (if tag 72 icon-height)))
 
 (defn container
-  [{:keys [in-card? tag]}]
-  {:padding-horizontal 12
-   :padding-vertical   (if in-card? 12 13)
-   :flex-direction     :row
-   :justify-content    :space-between
-   :height             (if tag 96 48)})
+  [{:keys [in-card? tag container-style]}]
+  (merge {:padding-horizontal 12
+          :padding-top        (if in-card? 12 13)
+          :padding-bottom     (if in-card? 12 13)
+          :flex-direction     :row
+          :justify-content    :space-between
+          :height             (if tag 96 48)}
+         container-style))
 
 (def sub-container
   {:flex-direction :row

--- a/src/quo2/components/settings/settings_item/view.cljs
+++ b/src/quo2/components/settings/settings_item/view.cljs
@@ -62,7 +62,8 @@
   (case tag
     :positive [status-tags/status-tag
                {:status          {:type :positive}
-                :label           (i18n/label :t/positive)
+                :label           (:label tag-props)
+                :no-icon?        true
                 :size            :small
                 :container-style {:margin-top 8}}]
     :context  [context-tag/view

--- a/src/status_im2/contexts/syncing/device/style.cljs
+++ b/src/status_im2/contexts/syncing/device/style.cljs
@@ -2,10 +2,7 @@
   (:require [quo2.foundations.colors :as colors]))
 
 (def device-container
-  {:padding-top        12
-   :padding-horizontal 12
-   :padding-bottom     16
-   :border-color       colors/white-opa-5
-   :border-radius      16
-   :border-width       1
-   :margin-top         12})
+  {:border-color  colors/white-opa-5
+   :border-radius 16
+   :border-width  1
+   :margin-top    12})

--- a/src/status_im2/contexts/syncing/device/view.cljs
+++ b/src/status_im2/contexts/syncing/device/view.cljs
@@ -16,21 +16,20 @@
      (cond->
        {:container-style style/device-container
         :title           name
-        :override-theme  :dark
-        :left-icon       (cond (#{:mobile :ios :android} (keyword device-type))
+        :image           :icon
+        :image-props     (cond (#{:mobile :ios :android} (keyword device-type))
                                :i/mobile
                                :else :i/desktop)}
-       (and show-button? unpaired?) (assoc :button-props
-                                           {:title    (i18n/label :t/pair)
-                                            :on-press #(js/alert "feature not added yet")})
-       (and show-button? paired?)   (assoc
-                                     :button-props
-                                     {:title    (i18n/label :t/unpair)
+       (and show-button? unpaired?) (assoc
+                                     :action :button
+                                     :action-props
+                                     {:title    (i18n/label :t/pair)
                                       :on-press #(js/alert "feature not added yet")})
+       (and show-button? paired?)   (assoc
+                                     :action :button
+                                     :action-props
+                                     {:button-text (i18n/label :t/unpair)
+                                      :on-press    #(js/alert "feature not added yet")})
        this-device?                 (assoc
-                                     :status-tag-props
-                                     {:size           :small
-                                      :status         {:type :positive}
-                                      :no-icon?       true
-                                      :label          (i18n/label :t/this-device)
-                                      :override-theme :dark}))]))
+                                     :tag       :positive
+                                     :tag-props {:label (i18n/label :t/this-device)}))]))


### PR DESCRIPTION
follow up to: https://github.com/status-im/status-mobile/pull/17179

The setting-item component had some recent refactors to its api but the use of this component was not adjusted on the syncing page.
This fixes that.


To test, check the settings-item component and its uses on the syncing page.

**Before:**
<img src="https://github.com/status-im/status-mobile/assets/22799766/478a3117-407a-45f6-ae2a-1aa9ddbd780d" width="300px" />

**After:** 
<img src="https://github.com/status-im/status-mobile/assets/22799766/270a5442-d2c0-4d6f-8c15-f4c71e9fa05d" width="300px" />

**Note!**
Unfortunately the designs for the syncing page include the text "Next backup in ...". Without this text the component will not sit right as in the designs. This text is not available and there are considerations of whether we actually want to retrieve this data (cc @cammellos)
So at the moment the component will not sit right unless we have that secondary text being used in the component.

e.g it would look like this:
<img src="https://github.com/status-im/status-mobile/assets/22799766/934cb657-e0a2-430a-8bf1-ee94c0207c00" width="300px" />

