### PR TITLE
Quo2: Settings item blur

### DIFF
--- a/src/status_im2/contexts/quo_preview/preview.cljs
+++ b/src/status_im2/contexts/quo_preview/preview.cljs
@@ -243,7 +243,7 @@
                         (if blur?
                           (quo.theme/set-theme :dark)
                           (quo.theme/set-theme :light))))
-                    [blur?])
+                    [blur? blur-dark-only?])
      [rn/view
       {:style {:top  (safe-area/get-top)
                :flex 1}}

--- a/src/status_im2/contexts/quo_preview/preview.cljs
+++ b/src/status_im2/contexts/quo_preview/preview.cljs
@@ -231,35 +231,43 @@
 
 
 (defn preview-container
-  [{:keys [state descriptor blur?
+  [{:keys [state descriptor blur? blur-dark-only?
            component-container-style
            blur-container-style blur-view-props blur-height show-blur-background?]
     :or   {blur-height 200}}
    & children]
-  [rn/view
-   {:style {:top  (safe-area/get-top)
-            :flex 1}}
-   [common/navigation-bar]
-   [rn/scroll-view
-    {:style                           (style/panel-basic)
-     :shows-vertical-scroll-indicator false}
-    [rn/pressable {:on-press rn/dismiss-keyboard!}
-     (when descriptor
-       [rn/view {:style style/customizer-container}
-        [customizer state descriptor]])
-     (if blur?
-       [rn/view {:style (merge style/component-container component-container-style)}
-        (into [blur-view
-               {:show-blur-background? show-blur-background?
-                :height                blur-height
-                :style                 (merge {:width     "100%"
-                                               :flex-grow 1}
-                                              (when-not show-blur-background?
-                                                {:padding-horizontal 0
-                                                 :top                0})
-                                              blur-container-style)
-                :blur-view-props       (merge {:blur-type (quo.theme/get-theme)}
-                                              blur-view-props)}]
-              children)]
-       (into [rn/view {:style (merge style/component-container component-container-style)}]
-             children))]]])
+  [:f>
+   (fn []
+     (rn/use-effect (fn []
+                      (when blur-dark-only?
+                        (if blur?
+                          (quo.theme/set-theme :dark)
+                          (quo.theme/set-theme :light))))
+                    [blur?])
+     [rn/view
+      {:style {:top  (safe-area/get-top)
+               :flex 1}}
+      [common/navigation-bar]
+      [rn/scroll-view
+       {:style                           (style/panel-basic)
+        :shows-vertical-scroll-indicator false}
+       [rn/pressable {:on-press rn/dismiss-keyboard!}
+        (when descriptor
+          [rn/view {:style style/customizer-container}
+           [customizer state descriptor]])
+        (if blur?
+          [rn/view {:style (merge style/component-container component-container-style)}
+           (into [blur-view
+                  {:show-blur-background? show-blur-background?
+                   :height                blur-height
+                   :style                 (merge {:width     "100%"
+                                                  :flex-grow 1}
+                                                 (when-not show-blur-background?
+                                                   {:padding-horizontal 0
+                                                    :top                0})
+                                                 blur-container-style)
+                   :blur-view-props       (merge {:blur-type (quo.theme/get-theme)}
+                                                 blur-view-props)}]
+                 children)]
+          (into [rn/view {:style (merge style/component-container component-container-style)}]
+                children))]]])])

--- a/src/status_im2/contexts/quo_preview/settings/settings_item.cljs
+++ b/src/status_im2/contexts/quo_preview/settings/settings_item.cljs
@@ -56,7 +56,9 @@
               {:key   :positive
                :value :positive}
               {:key   :context
-               :value :context}]}])
+               :value :context}]}
+   {:key  :blur?
+    :type :boolean}])
 
 (def communities-list
   [{:source (resources/get-mock-image :coinbase)}
@@ -111,6 +113,7 @@
        {:state                 state
         :descriptor            descriptor
         :blur?                 (:blur? @state)
-        :show-blur-background? true}
+        :show-blur-background? true
+        :blur-dark-only?       true}
        [rn/view {:style {:flex 1}}
         [quo/settings-item (get-props @state)]]])))


### PR DESCRIPTION
This PR adds blur option for settings item component in preview screen.

It also adds a small improvement to the preview container. Many of the blur components have blur in dark mode only. An effect would need to be used to change to dark mode when changing blur in preview screen. This PR adds a `blur-dark-only?` option that can be passed to the preview container to change to dark theme automatically when setting blur.