### PR TITLE
[#17218] fix: android channel name ellipsis completely

### DIFF
--- a/src/status_im2/contexts/chat/messages/content/text/view.cljs
+++ b/src/status_im2/contexts/chat/messages/content/text/view.cljs
@@ -2,11 +2,11 @@
   (:require
     [quo2.core :as quo]
     [quo2.foundations.colors :as colors]
+    [react-native.platform :as platform]
     [react-native.core :as rn]
     [status-im2.contexts.chat.messages.content.link-preview.view :as link-preview]
     [status-im2.contexts.chat.messages.content.text.style :as style]
     [utils.i18n :as i18n]
-    [react-native.platform :as platform]
     [utils.re-frame :as rf]))
 
 (defn render-inline

--- a/src/status_im2/contexts/chat/messages/list/style.cljs
+++ b/src/status_im2/contexts/chat/messages/list/style.cljs
@@ -56,9 +56,5 @@
     :margin-bottom side-margin-animation}
    {:align-items :flex-start}))
 
-(def name-container
-  {:flex-direction :row
-   :align-items    :center})
-
 (def bio
   {:margin-top 8})

--- a/src/status_im2/contexts/chat/messages/list/view.cljs
+++ b/src/status_im2/contexts/chat/messages/list/view.cljs
@@ -223,14 +223,13 @@
              :display-name    display-name
              :online?         online?
              :profile-picture photo-path}])]
-        [rn/view {:style style/name-container}
-         [quo/text
-          {:weight          :semi-bold
-           :size            :heading-1
-           :style           {:margin-top (if group-chat 54 12)}
-           :number-of-lines 1}
-          display-name
-          [contact-icon contact]]]
+        [quo/text
+         {:weight          :semi-bold
+          :size            :heading-1
+          :style           {:margin-top (if group-chat 54 12)}
+          :number-of-lines 1}
+         display-name
+         [contact-icon contact]]
         (when bio
           [quo/text {:style style/bio}
            bio])


### PR DESCRIPTION
fixes #17218

In Android, when we use :number-of-lines 1 for long text that doesn't have any space between words, it will ellipsis the entire text.

**Actual behavior**
Three dots are shown instead of the channel name in the opened channel

**Expected behavior**
The channel name is shown into the opened channel

Before:
<img src="https://github.com/status-im/status-mobile/assets/71308738/eb5b1444-5850-422c-a40c-2feed42cc202" width="375px"/>

After:
<img src="https://github.com/status-im/status-mobile/assets/71308738/f637ff6f-69ab-4ddb-b598-dafb8b7ec294" width="375px"/>

#### Platforms
- Android

status: ready
