### PR TITLE
updated selected item view

### DIFF
--- a/src/status_im2/common/bottom_sheet/style.cljs
+++ b/src/status_im2/common/bottom_sheet/style.cljs
@@ -45,13 +45,15 @@
    :bottom           0})
 
 (defn selected-item
-  [theme window-height sheet-height {:keys [top]}]
+  [theme window-height sheet-height item-height {:keys [top]}]
+  (js/console.log (str "item-height " item-height))
   {:position          :absolute
-   :bottom            10
-   :max-height        (- window-height sheet-height top)
+   :bottom            8
+   ;; we minus 8 on the max-height since the bottom has a margin of 8
+   :max-height        (- window-height sheet-height top 8)
    :overflow          :hidden
    :left              0
    :right             0
    :border-radius     12
    :margin-horizontal 8
-   :background-color  (colors/theme-colors colors/white colors/neutral-95 theme)})
+   :background-color  (colors/theme-colors colors/white colors/neutral-90 theme)})

--- a/src/status_im2/common/bottom_sheet/style.cljs
+++ b/src/status_im2/common/bottom_sheet/style.cljs
@@ -3,6 +3,8 @@
             [quo2.theme :as theme]
             [react-native.platform :as platform]))
 
+(def bottom-margin 8)
+
 (defn handle
   [theme]
   {:width            32
@@ -45,12 +47,12 @@
    :bottom           0})
 
 (defn selected-item
-  [theme window-height sheet-height item-height {:keys [top]}]
-  (js/console.log (str "item-height " item-height))
+  [theme max-height sheet-height show-bottom-margin]
   {:position          :absolute
-   :bottom            8
-   ;; we minus 8 on the max-height since the bottom has a margin of 8
-   :max-height        (- window-height sheet-height top 8)
+   :top               (when (not show-bottom-margin) (- 0 max-height))
+   ;; Bottom margin of 8 is added when the selected item height is less than 
+   ;; or equals the max-height of the selected item
+   :bottom            (when show-bottom-margin (+ sheet-height bottom-margin))
    :overflow          :hidden
    :left              0
    :right             0

--- a/src/status_im2/common/bottom_sheet/style.cljs
+++ b/src/status_im2/common/bottom_sheet/style.cljs
@@ -27,7 +27,7 @@
    :border-top-right-radius 20
    :overflow                (when-not selected-item :hidden)
    :flex                    1
-   :padding-bottom          (or padding-bottom-override (+ bottom 8))
+   :padding-bottom          (or padding-bottom-override (+ bottom))
    :background-color        (if shell?
                               :transparent
                               (colors/theme-colors colors/white colors/neutral-95 theme))})
@@ -46,16 +46,27 @@
    :top              0
    :bottom           0})
 
+(defn sheet-content
+  [theme padding-bottom-override insets]
+  {:position                :absolute
+   :background-color        (colors/theme-colors colors/white colors/neutral-95 theme)
+   :bottom                  0
+   :left                    0
+   :right                   0
+   :border-top-left-radius  20
+   :border-top-right-radius 20
+   :padding-bottom          (or padding-bottom-override (+ (:bottom insets) bottom-margin))})
+
 (defn selected-item
-  [theme max-height sheet-height show-bottom-margin]
+  [theme top sheet-height show-bottom-margin border-radius]
   {:position          :absolute
-   :top               (when (not show-bottom-margin) (- 0 max-height))
-   ;; Bottom margin of 8 is added when the selected item height is less than 
-   ;; or equals the max-height of the selected item
-   :bottom            (when show-bottom-margin (+ sheet-height bottom-margin))
+   :top               (when (not show-bottom-margin) (- 0 top))
+   ;; Bottom margin of 8 is added when the selected item height is less than
+   ;; the max-height of the selected item view
+   :bottom            (when show-bottom-margin (+ sheet-height 8))
    :overflow          :hidden
    :left              0
    :right             0
-   :border-radius     12
+   :border-radius     border-radius
    :margin-horizontal 8
    :background-color  (colors/theme-colors colors/white colors/neutral-90 theme)})

--- a/src/status_im2/common/bottom_sheet/style.cljs
+++ b/src/status_im2/common/bottom_sheet/style.cljs
@@ -3,8 +3,6 @@
             [quo2.theme :as theme]
             [react-native.platform :as platform]))
 
-(def bottom-margin 8)
-
 (defn handle
   [theme]
   {:width            32
@@ -47,7 +45,7 @@
    :bottom           0})
 
 (defn sheet-content
-  [theme padding-bottom-override insets]
+  [theme padding-bottom-override insets sheet-bottom-margin]
   {:position                :absolute
    :background-color        (colors/theme-colors colors/white colors/neutral-95 theme)
    :bottom                  0
@@ -55,15 +53,13 @@
    :right                   0
    :border-top-left-radius  20
    :border-top-right-radius 20
-   :padding-bottom          (or padding-bottom-override (+ (:bottom insets) bottom-margin))})
+   :padding-bottom          (or padding-bottom-override (+ (:bottom insets) sheet-bottom-margin))})
 
 (defn selected-item
-  [theme top sheet-height show-bottom-margin border-radius]
+  [theme top sheet-height sheet-bottom-margin border-radius]
   {:position          :absolute
-   :top               (when (not show-bottom-margin) (- 0 top))
-   ;; Bottom margin of 8 is added when the selected item height is less than
-   ;; the max-height of the selected item view
-   :bottom            (when show-bottom-margin (+ sheet-height 8))
+   :top               (when-not sheet-bottom-margin (- 0 top))
+   :bottom            (when sheet-bottom-margin (+ sheet-height sheet-bottom-margin))
    :overflow          :hidden
    :left              0
    :right             0

--- a/src/status_im2/common/bottom_sheet/style.cljs
+++ b/src/status_im2/common/bottom_sheet/style.cljs
@@ -45,21 +45,17 @@
    :bottom           0})
 
 (defn sheet-content
-  [theme padding-bottom-override insets sheet-bottom-margin]
-  {:position                :absolute
-   :background-color        (colors/theme-colors colors/white colors/neutral-95 theme)
-   :bottom                  0
-   :left                    0
-   :right                   0
+  [theme padding-bottom-override insets bottom-margin]
+  {:background-color        (colors/theme-colors colors/white colors/neutral-95 theme)
    :border-top-left-radius  20
    :border-top-right-radius 20
-   :padding-bottom          (or padding-bottom-override (+ (:bottom insets) sheet-bottom-margin))})
+   :padding-bottom          (or padding-bottom-override (+ (:bottom insets) bottom-margin))})
 
 (defn selected-item
-  [theme top sheet-height sheet-bottom-margin border-radius]
+  [theme top bottom sheet-bottom-margin border-radius]
   {:position          :absolute
    :top               (when-not sheet-bottom-margin (- 0 top))
-   :bottom            (when sheet-bottom-margin (+ sheet-height sheet-bottom-margin))
+   :bottom            bottom
    :overflow          :hidden
    :left              0
    :right             0

--- a/src/status_im2/common/bottom_sheet/view.cljs
+++ b/src/status_im2/common/bottom_sheet/view.cljs
@@ -57,7 +57,8 @@
 
 (defn- f-view
   [_ _]
-  (let [sheet-height (reagent/atom 0)]
+  (let [sheet-height (reagent/atom 0)
+        item-height  (reagent/atom 0)]
     (fn [{:keys [hide? insets theme]}
          {:keys [content selected-item padding-bottom-override on-close shell?
                  gradient-cover? customization-color]}]
@@ -101,7 +102,9 @@
              [blur/ios-view {:style style/shell-bg}])
            (when selected-item
              [rn/view
-              [rn/view {:style (style/selected-item theme window-height @sheet-height insets)}
+              [rn/view {:on-layout (fn [event]
+                                     (reset! item-height (oops/oget event "nativeEvent" "layout" "height")))
+                        :style     (style/selected-item theme window-height @sheet-height @item-height insets)}
                [selected-item]]])
 
            ;; handle

--- a/src/status_im2/common/bottom_sheet/view.cljs
+++ b/src/status_im2/common/bottom_sheet/view.cljs
@@ -65,17 +65,18 @@
                  gradient-cover? customization-color]
           :or   {border-radius 12}}]
       (let [{window-height :height} (rn/get-window)
-            bg-opacity (reanimated/use-shared-value 0)
-            translate-y (reanimated/use-shared-value window-height)
-            sheet-gesture (get-sheet-gesture translate-y bg-opacity window-height on-close)
-            sheet-bottom-margin
-            (when (< @item-height
-                     (- window-height
-                        @sheet-height
-                        (:top insets)
-                        bottom-margin))
-              bottom-margin)
-            top (- window-height (:top insets) (:bottom insets) sheet-bottom-margin)]
+            bg-opacity              (reanimated/use-shared-value 0)
+            translate-y             (reanimated/use-shared-value window-height)
+            sheet-gesture           (get-sheet-gesture translate-y bg-opacity window-height on-close)
+            sheet-bottom-margin     (< @item-height
+                                       (- window-height @sheet-height (:top insets) bottom-margin))
+            top                     (- window-height (:top insets) (:bottom insets) @sheet-height)
+            bottom                  (if sheet-bottom-margin
+                                      (+ @sheet-height bottom-margin (:bottom insets))
+                                      (:bottom insets))]
+        (js/console.log (str "item height " @item-height))
+        (js/console.log (str "sheet height " @sheet-height))
+        (js/console.log (str "sheet-bottom-margin  " bottom))
         (rn/use-effect
          #(if hide?
             (hide translate-y bg-opacity window-height on-close)
@@ -108,18 +109,17 @@
              [rn/view {:style style/gradient-bg}
               [quo/gradient-cover {:customization-color customization-color}]])
            (when shell?
-             [blur/ios-view {:style style/shell-bg}]) 
+             [blur/ios-view {:style style/shell-bg}])
            (when selected-item
              [rn/view
               {:on-layout #(reset! item-height (.-nativeEvent.layout.height ^js %))
-               :style (style/selected-item theme top @sheet-height sheet-bottom-margin border-radius)}
+               :style
+               (style/selected-item theme top bottom sheet-bottom-margin border-radius)}
               [selected-item]])
 
            [rn/view
-            {:style     (when selected-item
-                          (style/sheet-content theme padding-bottom-override insets sheet-bottom-margin))
-             :on-layout #(reset! sheet-height
-                                 (.-nativeEvent.layout.height ^js %))}
+            {:style     (style/sheet-content theme padding-bottom-override insets bottom-margin)
+             :on-layout #(reset! sheet-height (.-nativeEvent.layout.height ^js %))}
             [rn/view {:style (style/handle theme)}]
             [content]]]]]))))
 

--- a/src/status_im2/contexts/chat/messages/content/album/view.cljs
+++ b/src/status_im2/contexts/chat/messages/content/album/view.cljs
@@ -12,6 +12,7 @@
 
 (def rectangular-style-count 3)
 
+
 (defn find-size
   [size-arr album-style]
   (if (= album-style :landscape)
@@ -19,13 +20,14 @@
     {:width (second size-arr) :height (first size-arr) :album-style album-style}))
 
 (defn album-message
-  [{:keys [albumize?] :as message} context on-long-press]
+  [{:keys [albumize?] :as message} context on-long-press message-container-data]
   (let [shared-element-id (rf/sub [:shared-element-id])
         first-image       (first (:album message))
         album-style       (if (> (:image-width first-image) (:image-height first-image))
                             :landscape
                             :portrait)
         images-count      (count (:album message))
+      
         ;; album images are always square, except when we have 3 images, then they must be rectangular
         ;; (portrait or landscape)
         portrait?         (and (= images-count rectangular-style-count) (= album-style :portrait))]
@@ -74,5 +76,5 @@
        (map-indexed
         (fn [index item]
           [:<> {:key (:message-id item)}
-           [image/image-message index item {:on-long-press #(on-long-press message context)}]])
+           [image/image-message index item {:on-long-press #(on-long-press message context)} message-container-data]])
         (:album message))])))

--- a/src/status_im2/contexts/chat/messages/content/album/view.cljs
+++ b/src/status_im2/contexts/chat/messages/content/album/view.cljs
@@ -27,7 +27,6 @@
                             :landscape
                             :portrait)
         images-count      (count (:album message))
-      
         ;; album images are always square, except when we have 3 images, then they must be rectangular
         ;; (portrait or landscape)
         portrait?         (and (= images-count rectangular-style-count) (= album-style :portrait))]
@@ -76,5 +75,6 @@
        (map-indexed
         (fn [index item]
           [:<> {:key (:message-id item)}
-           [image/image-message index item {:on-long-press #(on-long-press message context)} message-container-data]])
+           [image/image-message index item {:on-long-press #(on-long-press message context)}
+            message-container-data]])
         (:album message))])))

--- a/src/status_im2/contexts/chat/messages/content/album/view.cljs
+++ b/src/status_im2/contexts/chat/messages/content/album/view.cljs
@@ -12,7 +12,6 @@
 
 (def rectangular-style-count 3)
 
-
 (defn find-size
   [size-arr album-style]
   (if (= album-style :landscape)

--- a/src/status_im2/contexts/chat/messages/content/image/view.cljs
+++ b/src/status_im2/contexts/chat/messages/content/image/view.cljs
@@ -15,16 +15,21 @@
     {:width (min width max-width) :height (min height max-height)}))
 
 (defn image-message
-  [index {:keys [content image-width image-height message-id] :as message} {:keys [on-long-press]} message-container-data]
-  (let [insets            (safe-area/get-insets)
-        max-width         (- (:window-width            message-container-data)
-                             (:padding-horizontal      message-container-data)
-                             (:avatar-container-width  message-container-data)
-                             (:message-margin-left     message-container-data))
-        max-height        (* (/ image-height image-width) max-width)
-        dimensions        (calculate-dimensions image-width image-height max-width max-height)
-        shared-element-id (rf/sub [:shared-element-id])
-        image-local-url   (url/replace-port (:image content) (rf/sub [:mediaserver/port]))]
+  [index {:keys [content image-width image-height message-id] :as message} {:keys [on-long-press]}
+   message-container-data]
+  (let [insets               (safe-area/get-insets)
+        max-container-width  (- (:window-width message-container-data)
+                                (:padding-left message-container-data)
+                                (:padding-right message-container-data)
+                                (:avatar-container-width message-container-data)
+                                (:message-margin-left message-container-data))
+        max-container-height (* (/ image-height image-width) max-container-width)
+        dimensions           (calculate-dimensions image-width
+                                                   image-height
+                                                   max-container-width
+                                                   max-container-height)
+        shared-element-id    (rf/sub [:shared-element-id])
+        image-local-url      (url/replace-port (:image content) (rf/sub [:mediaserver/port]))]
     [:<>
      (when (= index 0)
        [text/text-content message])

--- a/src/status_im2/contexts/chat/messages/content/image/view.cljs
+++ b/src/status_im2/contexts/chat/messages/content/image/view.cljs
@@ -9,15 +9,20 @@
     [utils.url :as url]))
 
 (defn calculate-dimensions
-  [width height]
-  (let [max-width  (if (> width height) (* 2 constants/image-size) (* 1.5 constants/image-size))
-        max-height (if (> width height) (* 1.5 constants/image-size) (* 2 constants/image-size))]
+  [width height max-container-width max-container-height]
+  (let [max-width  (if (> width height) max-container-width (* 1.5 constants/image-size))
+        max-height (if (> width height) max-container-height (* 2 constants/image-size))]
     {:width (min width max-width) :height (min height max-height)}))
 
 (defn image-message
-  [index {:keys [content image-width image-height message-id] :as message} {:keys [on-long-press]}]
+  [index {:keys [content image-width image-height message-id] :as message} {:keys [on-long-press]} message-container-data]
   (let [insets            (safe-area/get-insets)
-        dimensions        (calculate-dimensions (or image-width 1000) (or image-height 1000))
+        max-width         (- (:window-width            message-container-data)
+                             (:padding-horizontal      message-container-data)
+                             (:avatar-container-width  message-container-data)
+                             (:message-margin-left     message-container-data))
+        max-height        (* (/ image-height image-width) max-width)
+        dimensions        (calculate-dimensions image-width image-height max-width max-height)
         shared-element-id (rf/sub [:shared-element-id])
         image-local-url   (url/replace-port (:image content) (rf/sub [:mediaserver/port]))]
     [:<>

--- a/src/status_im2/contexts/chat/messages/content/image/view.cljs
+++ b/src/status_im2/contexts/chat/messages/content/image/view.cljs
@@ -17,19 +17,21 @@
 (defn image-message
   [index {:keys [content image-width image-height message-id] :as message} {:keys [on-long-press]}
    message-container-data]
-  (let [insets               (safe-area/get-insets)
-        max-container-width  (- (:window-width message-container-data)
-                                (:padding-left message-container-data)
-                                (:padding-right message-container-data)
-                                (:avatar-container-width message-container-data)
-                                (:message-margin-left message-container-data))
-        max-container-height (* (/ image-height image-width) max-container-width)
-        dimensions           (calculate-dimensions image-width
-                                                   image-height
-                                                   max-container-width
-                                                   max-container-height)
-        shared-element-id    (rf/sub [:shared-element-id])
-        image-local-url      (url/replace-port (:image content) (rf/sub [:mediaserver/port]))]
+  (let [insets                        (safe-area/get-insets)
+        {:keys [window-width padding-left padding-right avatar-container-width
+                message-margin-left]} message-container-data
+        max-container-width           (- window-width
+                                         padding-left
+                                         padding-right
+                                         avatar-container-width
+                                         message-margin-left)
+        max-container-height          (* (/ image-height image-width) max-container-width)
+        dimensions                    (calculate-dimensions image-width
+                                                            image-height
+                                                            max-container-width
+                                                            max-container-height)
+        shared-element-id             (rf/sub [:shared-element-id])
+        image-local-url               (url/replace-port (:image content) (rf/sub [:mediaserver/port]))]
     [:<>
      (when (= index 0)
        [text/text-content message])

--- a/src/status_im2/contexts/chat/messages/content/text/view.cljs
+++ b/src/status_im2/contexts/chat/messages/content/text/view.cljs
@@ -1,13 +1,13 @@
 (ns status-im2.contexts.chat.messages.content.text.view
   (:require
-    [quo2.core :as quo]
-    [quo2.foundations.colors :as colors]
-    [react-native.platform :as platform]
-    [react-native.core :as rn]
-    [status-im2.contexts.chat.messages.content.link-preview.view :as link-preview]
-    [status-im2.contexts.chat.messages.content.text.style :as style]
-    [utils.i18n :as i18n]
-    [utils.re-frame :as rf]))
+   [quo2.core :as quo]
+   [quo2.foundations.colors :as colors]
+   [react-native.platform :as platform]
+   [react-native.core :as rn]
+   [status-im2.contexts.chat.messages.content.link-preview.view :as link-preview]
+   [status-im2.contexts.chat.messages.content.text.style :as style]
+   [utils.i18n :as i18n]
+   [utils.re-frame :as rf]))
 
 (defn render-inline
   [units {:keys [type literal destination]} chat-id style-override first-child-mention]
@@ -104,8 +104,8 @@
               (fn [acc e]
                 (render-inline acc e chat-id style-override mention-first))
               [quo/text
-               {:style {:size          :paragraph-1
-                        :margin-bottom (if mention-first (if platform/ios? 4 0) 2)
+               {:size  :paragraph-1
+                :style {:margin-bottom (if mention-first (if platform/ios? 4 0) 2)
                         :margin-top    (if mention-first (if platform/ios? -4 0) 2)
                         :color         (when (seq style-override) colors/white)}}]
               children)])

--- a/src/status_im2/contexts/chat/messages/content/text/view.cljs
+++ b/src/status_im2/contexts/chat/messages/content/text/view.cljs
@@ -1,13 +1,13 @@
 (ns status-im2.contexts.chat.messages.content.text.view
   (:require
-   [quo2.core :as quo]
-   [quo2.foundations.colors :as colors]
-   [react-native.platform :as platform]
-   [react-native.core :as rn]
-   [status-im2.contexts.chat.messages.content.link-preview.view :as link-preview]
-   [status-im2.contexts.chat.messages.content.text.style :as style]
-   [utils.i18n :as i18n]
-   [utils.re-frame :as rf]))
+    [quo2.core :as quo]
+    [quo2.foundations.colors :as colors]
+    [react-native.platform :as platform]
+    [react-native.core :as rn]
+    [status-im2.contexts.chat.messages.content.link-preview.view :as link-preview]
+    [status-im2.contexts.chat.messages.content.text.style :as style]
+    [utils.i18n :as i18n]
+    [utils.re-frame :as rf]))
 
 (defn render-inline
   [units {:keys [type literal destination]} chat-id style-override first-child-mention]

--- a/src/status_im2/contexts/chat/messages/content/view.cljs
+++ b/src/status_im2/contexts/chat/messages/content/view.cljs
@@ -29,6 +29,8 @@
     [quo2.theme :as quo.theme]))
 
 (def delivery-state-showing-time-ms 3000)
+;; (def message-container-width (reagent/atom 0))
+
 
 (defn avatar-container
   [{:keys [content last-in-group? pinned-by quoted-message from]} show-reactions? show-user-info?]
@@ -129,7 +131,12 @@
                                                                                 context
                                                                                 keyboard-shown?))
             response-to                                  (:response-to content)
-            height                                       (rf/sub [:dimensions/window-height])]
+            height                                       (rf/sub [:dimensions/window-height])
+            {window-width :width}                        (rn/get-window)
+            message-container-data                       {:window-width            window-width
+                                                          :padding-horizontal      40
+                                                          :avatar-container-width  32
+                                                          :message-margin-left     8}]
         [rn/touchable-highlight
          {:accessibility-label (if (and outgoing (= outgoing-status :sending))
                                  :message-sending
@@ -149,14 +156,14 @@
                                      (js/setTimeout #(reset! show-delivery-state? false)
                                                     delivery-state-showing-time-ms))))
           :on-long-press       #(on-long-press message-data context keyboard-shown?)}
-         [:<>
+         [rn/view
           (when pinned-by
             [pin/pinned-by-view pinned-by])
           (when (and (seq response-to) quoted-message)
             [reply/quoted-message quoted-message])
           [rn/view
            {:style {:padding-horizontal 4
-                    :flex-direction     :row}}
+                    :flex-direction      :row}}
            [avatar-container message-data show-reactions? show-user-info?]
            (into
             (if show-reactions?
@@ -182,10 +189,10 @@
                [audio/audio-message message-data context]
 
                constants/content-type-image
-               [image/image-message 0 message-data context]
-
+               [image/image-message 0 message-data context 0 message-container-data]
+               
                constants/content-type-album
-               [album/album-message message-data context on-long-press]
+               [album/album-message message-data context on-long-press message-container-data]
 
                [not-implemented/not-implemented
                 [content.unknown/unknown-content message-data]])

--- a/src/status_im2/contexts/chat/messages/content/view.cljs
+++ b/src/status_im2/contexts/chat/messages/content/view.cljs
@@ -29,8 +29,6 @@
     [quo2.theme :as quo.theme]))
 
 (def delivery-state-showing-time-ms 3000)
-;; (def message-container-width (reagent/atom 0))
-
 
 (defn avatar-container
   [{:keys [content last-in-group? pinned-by quoted-message from]} show-reactions? show-user-info?]
@@ -133,10 +131,11 @@
             response-to                                  (:response-to content)
             height                                       (rf/sub [:dimensions/window-height])
             {window-width :width}                        (rn/get-window)
-            message-container-data                       {:window-width            window-width
-                                                          :padding-horizontal      40
-                                                          :avatar-container-width  32
-                                                          :message-margin-left     8}]
+            message-container-data                       {:window-width           window-width
+                                                          :padding-right          20
+                                                          :padding-left           20
+                                                          :avatar-container-width 32
+                                                          :message-margin-left    8}]
         [rn/touchable-highlight
          {:accessibility-label (if (and outgoing (= outgoing-status :sending))
                                  :message-sending
@@ -156,14 +155,14 @@
                                      (js/setTimeout #(reset! show-delivery-state? false)
                                                     delivery-state-showing-time-ms))))
           :on-long-press       #(on-long-press message-data context keyboard-shown?)}
-         [rn/view
+         [:<>
           (when pinned-by
             [pin/pinned-by-view pinned-by])
           (when (and (seq response-to) quoted-message)
             [reply/quoted-message quoted-message])
           [rn/view
            {:style {:padding-horizontal 4
-                    :flex-direction      :row}}
+                    :flex-direction     :row}}
            [avatar-container message-data show-reactions? show-user-info?]
            (into
             (if show-reactions?
@@ -190,7 +189,7 @@
 
                constants/content-type-image
                [image/image-message 0 message-data context 0 message-container-data]
-               
+
                constants/content-type-album
                [album/album-message message-data context on-long-press message-container-data]
 
@@ -216,6 +215,7 @@
   (rf/dispatch [:dismiss-keyboard])
   (rf/dispatch [:show-bottom-sheet
                 {:content       (drawers/reactions-and-actions message-data context)
+                 :border-radius 16
                  :selected-item (fn []
                                   [rn/view {:pointer-events :none}
                                    [user-message-content

--- a/src/status_im2/contexts/chat/messages/drawers/view.cljs
+++ b/src/status_im2/contexts/chat/messages/drawers/view.cljs
@@ -230,6 +230,7 @@
               :on-press            (fn []
                                      (rf/dispatch [:hide-bottom-sheet])
                                      (when on-press (on-press)))}]))
+
         (when-not (empty? danger-actions)
           [quo/separator])
 
@@ -245,6 +246,7 @@
               :on-press            (fn []
                                      (rf/dispatch [:hide-bottom-sheet])
                                      (when on-press (on-press)))}]))
+
         (when-not (empty? admin-actions)
           [quo/separator])
 

--- a/src/status_im2/contexts/chat/messages/drawers/view.cljs
+++ b/src/status_im2/contexts/chat/messages/drawers/view.cljs
@@ -230,7 +230,6 @@
               :on-press            (fn []
                                      (rf/dispatch [:hide-bottom-sheet])
                                      (when on-press (on-press)))}]))
-
         (when-not (empty? danger-actions)
           [quo/separator])
 
@@ -246,7 +245,6 @@
               :on-press            (fn []
                                      (rf/dispatch [:hide-bottom-sheet])
                                      (when on-press (on-press)))}]))
-
         (when-not (empty? admin-actions)
           [quo/separator])
 


### PR DESCRIPTION
fixes #17254

### Summary
This pr fix some issue with the selected-item-view shown on the bottom sheet when a message in chat or community item is selected

<img src="https://github.com/status-im/status-mobile/assets/28704507/27e38ef1-33ce-491f-a6ed-e1a20aa5f9b4" width="325">

<img src="https://github.com/status-im/status-mobile/assets/28704507/2e71ee2b-2b41-4536-928a-6a3d103e3579" width="325">

<img src="https://github.com/status-im/status-mobile/assets/28704507/727171da-cd53-401e-a6c1-0e5059397fbd" width="325">

<img src="https://github.com/status-im/status-mobile/assets/28704507/189d8de0-f80a-468b-8dcc-9d81d606d75f" width="325">
