### PR TITLE
fix: intro screen carousel

### DIFF
--- a/src/status_im2/contexts/onboarding/common/background/view.cljs
+++ b/src/status_im2/contexts/onboarding/common/background/view.cljs
@@ -26,9 +26,10 @@
 (defn background-image
   [content-width]
   [rn/image
-   {:style  {:resize-mode :stretch
-             :margin-top  32
-             :width       content-width}
+   {:style  {:resize-mode   :stretch
+             :resize-method :scale
+             :margin-top    32
+             :width         content-width}
     :source (resources/get-image :onboarding-illustration)}])
 
 (defonce progress (atom nil))

--- a/src/status_im2/contexts/onboarding/common/carousel/style.cljs
+++ b/src/status_im2/contexts/onboarding/common/carousel/style.cljs
@@ -64,7 +64,6 @@
 (defn carousel-container
   [left animate?]
   (cond->> {:position       :absolute
-            :right          0
             :top            0
             :flex-direction :row
             :left           left}


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/17186

The last slide appears for a split second due to initial styling, before the animated styling takes precedence.

On Android, it takes a while to load the image because of the stretched dimension and size of image, used `scale` `resizeMethod` to load this faster since it uses hardware acceleration.

#### Platforms
- Android
- iOS

status: ready
