### PR TITLE
Raise clj-kondo linter levels

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -9,22 +9,23 @@
                 status-im.utils.styles/defn    clojure.core/defn
                 test-helpers.unit/deftest-sub  clojure.core/defn
                 taoensso.tufte/defnp           clojure.core/defn}
- :linters      {:consistent-alias  {:level   :error
-                                    :aliases {clojure.string  string
-                                              clojure.set     set
-                                              clojure.walk    walk
-                                              taoensso.timbre log}}
-                :shadowed-var      {:level   :error
-                                    ;; We temporarily use :include to define an
-                                    ;; allowlist of core Clojure vars. In the
-                                    ;; future, as we progressively fix shadowed
-                                    ;; vars, we should be able to delete this
-                                    ;; option and lint all vars.
-                                    :exclude [type name]}
-                :invalid-arity     {:skip-args [status-im.utils.fx/defn utils.re-frame/defn]}
+ :linters      {:unresolved-namespace {:level :error}
+                :consistent-alias     {:level   :error
+                                       :aliases {clojure.string  string
+                                                 clojure.set     set
+                                                 clojure.walk    walk
+                                                 taoensso.timbre log}}
+                :shadowed-var         {:level   :error
+                                       ;; We temporarily use :include to define an
+                                       ;; allowlist of core Clojure vars. In the
+                                       ;; future, as we progressively fix shadowed
+                                       ;; vars, we should be able to delete this
+                                       ;; option and lint all vars.
+                                       :exclude [type name]}
+                :invalid-arity        {:skip-args [status-im.utils.fx/defn utils.re-frame/defn]}
                 ;; TODO remove number when this is fixed
                 ;; https://github.com/borkdude/clj-kondo/issues/867
-                :unresolved-symbol {:exclude [PersistentPriorityMap.EMPTY
-                                              number
-                                              status-im.test-helpers/restore-app-db]}}
+                :unresolved-symbol    {:exclude [PersistentPriorityMap.EMPTY
+                                                 number
+                                                 status-im.test-helpers/restore-app-db]}}
  :config-in-ns {mocks.js-dependencies {:linters {:clojure-lsp/unused-public-var {:level :off}}}}}

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -9,23 +9,49 @@
                 status-im.utils.styles/defn    clojure.core/defn
                 test-helpers.unit/deftest-sub  clojure.core/defn
                 taoensso.tufte/defnp           clojure.core/defn}
- :linters      {:unresolved-namespace {:level :error}
-                :consistent-alias     {:level   :error
-                                       :aliases {clojure.string  string
-                                                 clojure.set     set
-                                                 clojure.walk    walk
-                                                 taoensso.timbre log}}
-                :shadowed-var         {:level   :error
-                                       ;; We temporarily use :include to define an
-                                       ;; allowlist of core Clojure vars. In the
-                                       ;; future, as we progressively fix shadowed
-                                       ;; vars, we should be able to delete this
-                                       ;; option and lint all vars.
-                                       :exclude [type name]}
-                :invalid-arity        {:skip-args [status-im.utils.fx/defn utils.re-frame/defn]}
+ :linters      {:clj-kondo-config              {:level :error}
+                :cond-else                     {:level :error}
+                :consistent-alias              {:level   :error
+                                                :aliases {clojure.string  string
+                                                          clojure.set     set
+                                                          clojure.walk    walk
+                                                          taoensso.timbre log}}
+                :docstring-blank               {:level :error}
+                :inline-def                    {:level :error}
+                :invalid-arity                 {:skip-args [status-im.utils.fx/defn utils.re-frame/defn]}
+                :loop-without-recur            {:level :error}
+                :misplaced-docstring           {:level :error}
+                :missing-body-in-when          {:level :error}
+                :missing-clause-in-try         {:level :error}
+                :missing-else-branch           {:level :error}
+                :not-empty?                    {:level :error}
+                :quoted-case-test-constant     {:level :error}
+                :redundant-do                  {:level :error}
+                :redundant-let                 {:level :error}
+                :refer-all                     {:level :error}
+                :shadowed-var                  {:level   :error
+                                                ;; We temporarily use :include to define an
+                                                ;; allowlist of core Clojure vars. In the
+                                                ;; future, as we progressively fix shadowed
+                                                ;; vars, we should be able to delete this
+                                                ;; option and lint all vars.
+                                                :exclude [type name]}
+                :single-operand-comparison     {:level :error}
+                :syntax                        {:level :error}
+                :unbound-destructuring-default {:level :error}
+                :unknown-require-option        {:level :error}
+                :unreachable-code              {:level :error}
+                :unresolved-namespace          {:level :error}
                 ;; TODO remove number when this is fixed
                 ;; https://github.com/borkdude/clj-kondo/issues/867
-                :unresolved-symbol    {:exclude [PersistentPriorityMap.EMPTY
-                                                 number
-                                                 status-im.test-helpers/restore-app-db]}}
+                :unresolved-symbol             {:exclude [PersistentPriorityMap.EMPTY
+                                                          number
+                                                          status-im.test-helpers/restore-app-db]}
+                :unresolved-var                {:level :error}
+                :unused-binding                {:level :error}
+                :unused-import                 {:level :error}
+                :unused-namespace              {:level :error}
+                :unused-private-var            {:level :error}
+                :unused-referred-var           {:level :error}
+                :use                           {:level :error}}
  :config-in-ns {mocks.js-dependencies {:linters {:clojure-lsp/unused-public-var {:level :off}}}}}

--- a/src/status_im/signals/core.cljs
+++ b/src/status_im/signals/core.cljs
@@ -96,52 +96,52 @@
         ^js event-js (.-event data)
         type         (.-type data)]
     (case type
-      "node.login"                 (profile.login/login-node-signal cofx (transforms/js->clj event-js))
-      "backup.performed"           {:db (assoc-in db
-                                         [:profile/profile :last-backup]
-                                         (.-lastBackup event-js))}
-      "envelope.sent"              (transport.message/update-envelopes-status cofx
-                                                                              (:ids
-                                                                               (js->clj event-js
-                                                                                        :keywordize-keys
-                                                                                        true))
-                                                                              :sent)
-      "envelope.expired"           (transport.message/update-envelopes-status cofx
-                                                                              (:ids
-                                                                               (js->clj event-js
-                                                                                        :keywordize-keys
-                                                                                        true))
-                                                                              :not-sent)
-      "message.delivered"          (let [{:keys [chatID messageID]} (js->clj event-js
-                                                                             :keywordize-keys
-                                                                             true)]
-                                     (models.message/update-db-message-status cofx
-                                                                              chatID
-                                                                              messageID
-                                                                              :delivered))
-      "mailserver.changed"         (mailserver/handle-mailserver-changed cofx (.-id event-js))
-      "mailserver.available"       (mailserver/handle-mailserver-available cofx (.-id event-js))
-      "mailserver.not.working"     (mailserver/handle-mailserver-not-working cofx)
-      "discovery.summary"          (summary cofx (js->clj event-js :keywordize-keys true))
-      "mediaserver.started"        {:db (assoc db :mediaserver/port (.-port event-js))}
-      "wakuv2.peerstats"           (wakuv2-peer-stats cofx (js->clj event-js :keywordize-keys true))
-      "messages.new"               (transport.message/sanitize-messages-and-process-response cofx
-                                                                                             event-js
-                                                                                             true)
-      "wallet"                     (ethereum.subscriptions/new-wallet-event cofx
+      "node.login"              (profile.login/login-node-signal cofx (transforms/js->clj event-js))
+      "backup.performed"        {:db (assoc-in db
+                                      [:profile/profile :last-backup]
+                                      (.-lastBackup event-js))}
+      "envelope.sent"           (transport.message/update-envelopes-status cofx
+                                                                           (:ids
                                                                             (js->clj event-js
                                                                                      :keywordize-keys
                                                                                      true))
-      "local-notifications"        (local-notifications/process cofx
-                                                                (js->clj event-js :keywordize-keys true))
-      "community.found"            (link-preview/cache-community-preview-data (js->clj event-js
-                                                                                       :keywordize-keys
-                                                                                       true))
-      "status.updates.timedout"    (visibility-status-updates/handle-visibility-status-updates
-                                    cofx
-                                    (js->clj event-js :keywordize-keys true))
-      "localPairing"               (handle-local-pairing-signals
-                                    cofx
-                                    (js->clj event-js :keywordize-keys true))
+                                                                           :sent)
+      "envelope.expired"        (transport.message/update-envelopes-status cofx
+                                                                           (:ids
+                                                                            (js->clj event-js
+                                                                                     :keywordize-keys
+                                                                                     true))
+                                                                           :not-sent)
+      "message.delivered"       (let [{:keys [chatID messageID]} (js->clj event-js
+                                                                          :keywordize-keys
+                                                                          true)]
+                                  (models.message/update-db-message-status cofx
+                                                                           chatID
+                                                                           messageID
+                                                                           :delivered))
+      "mailserver.changed"      (mailserver/handle-mailserver-changed cofx (.-id event-js))
+      "mailserver.available"    (mailserver/handle-mailserver-available cofx (.-id event-js))
+      "mailserver.not.working"  (mailserver/handle-mailserver-not-working cofx)
+      "discovery.summary"       (summary cofx (js->clj event-js :keywordize-keys true))
+      "mediaserver.started"     {:db (assoc db :mediaserver/port (.-port event-js))}
+      "wakuv2.peerstats"        (wakuv2-peer-stats cofx (js->clj event-js :keywordize-keys true))
+      "messages.new"            (transport.message/sanitize-messages-and-process-response cofx
+                                                                                          event-js
+                                                                                          true)
+      "wallet"                  (ethereum.subscriptions/new-wallet-event cofx
+                                                                         (js->clj event-js
+                                                                                  :keywordize-keys
+                                                                                  true))
+      "local-notifications"     (local-notifications/process cofx
+                                                             (js->clj event-js :keywordize-keys true))
+      "community.found"         (link-preview/cache-community-preview-data (js->clj event-js
+                                                                                    :keywordize-keys
+                                                                                    true))
+      "status.updates.timedout" (visibility-status-updates/handle-visibility-status-updates
+                                 cofx
+                                 (js->clj event-js :keywordize-keys true))
+      "localPairing"            (handle-local-pairing-signals
+                                 cofx
+                                 (js->clj event-js :keywordize-keys true))
 
       (log/debug "Event " type " not handled"))))

--- a/src/status_im2/contexts/chat/messages/content/text/view.cljs
+++ b/src/status_im2/contexts/chat/messages/content/text/view.cljs
@@ -6,6 +6,7 @@
     [status-im2.contexts.chat.messages.content.link-preview.view :as link-preview]
     [status-im2.contexts.chat.messages.content.text.style :as style]
     [utils.i18n :as i18n]
+    [react-native.platform :as platform]
     [utils.re-frame :as rf]))
 
 (defn render-inline
@@ -104,8 +105,8 @@
                 (render-inline acc e chat-id style-override mention-first))
               [quo/text
                {:style {:size          :paragraph-1
-                        :margin-bottom (if mention-first (if quo.platform/ios? 4 0) 2)
-                        :margin-top    (if mention-first (if quo.platform/ios? -4 0) 2)
+                        :margin-bottom (if mention-first (if platform/ios? 4 0) 2)
+                        :margin-top    (if mention-first (if platform/ios? -4 0) 2)
                         :color         (when (seq style-override) colors/white)}}]
               children)])
 


### PR DESCRIPTION
### Summary

Recently, we changed clj-kondo default `fail-level` from `warning` to `error`, but we missed the fact that we needed to raise the default level for all linters set to `warning`.

This PR fixes this problem at once.

#### Areas that may be impacted

None.

status: ready
