### PR TITLE
Community fetching performance

### DIFF
--- a/src/status_im/signals/core.cljs
+++ b/src/status_im/signals/core.cljs
@@ -96,52 +96,54 @@
         ^js event-js (.-event data)
         type         (.-type data)]
     (case type
-      "node.login"              (profile.login/login-node-signal cofx (transforms/js->clj event-js))
-      "backup.performed"        {:db (assoc-in db
-                                      [:profile/profile :last-backup]
-                                      (.-lastBackup event-js))}
-      "envelope.sent"           (transport.message/update-envelopes-status cofx
-                                                                           (:ids
+      "node.login"                 (profile.login/login-node-signal cofx (transforms/js->clj event-js))
+      "backup.performed"           {:db (assoc-in db
+                                         [:profile/profile :last-backup]
+                                         (.-lastBackup event-js))}
+      "envelope.sent"              (transport.message/update-envelopes-status cofx
+                                                                              (:ids
+                                                                               (js->clj event-js
+                                                                                        :keywordize-keys
+                                                                                        true))
+                                                                              :sent)
+      "envelope.expired"           (transport.message/update-envelopes-status cofx
+                                                                              (:ids
+                                                                               (js->clj event-js
+                                                                                        :keywordize-keys
+                                                                                        true))
+                                                                              :not-sent)
+      "message.delivered"          (let [{:keys [chatID messageID]} (js->clj event-js
+                                                                             :keywordize-keys
+                                                                             true)]
+                                     (models.message/update-db-message-status cofx
+                                                                              chatID
+                                                                              messageID
+                                                                              :delivered))
+      "mailserver.changed"         (mailserver/handle-mailserver-changed cofx (.-id event-js))
+      "mailserver.available"       (mailserver/handle-mailserver-available cofx (.-id event-js))
+      "mailserver.not.working"     (mailserver/handle-mailserver-not-working cofx)
+      "discovery.summary"          (summary cofx (js->clj event-js :keywordize-keys true))
+      "mediaserver.started"        {:db (assoc db :mediaserver/port (.-port event-js))}
+      "wakuv2.peerstats"           (wakuv2-peer-stats cofx (js->clj event-js :keywordize-keys true))
+      "messages.new"               (transport.message/sanitize-messages-and-process-response cofx
+                                                                                             event-js
+                                                                                             true)
+      "wallet"                     (ethereum.subscriptions/new-wallet-event cofx
                                                                             (js->clj event-js
                                                                                      :keywordize-keys
                                                                                      true))
-                                                                           :sent)
-      "envelope.expired"        (transport.message/update-envelopes-status cofx
-                                                                           (:ids
-                                                                            (js->clj event-js
-                                                                                     :keywordize-keys
-                                                                                     true))
-                                                                           :not-sent)
-      "message.delivered"       (let [{:keys [chatID messageID]} (js->clj event-js
-                                                                          :keywordize-keys
-                                                                          true)]
-                                  (models.message/update-db-message-status cofx
-                                                                           chatID
-                                                                           messageID
-                                                                           :delivered))
-      "mailserver.changed"      (mailserver/handle-mailserver-changed cofx (.-id event-js))
-      "mailserver.available"    (mailserver/handle-mailserver-available cofx (.-id event-js))
-      "mailserver.not.working"  (mailserver/handle-mailserver-not-working cofx)
-      "discovery.summary"       (summary cofx (js->clj event-js :keywordize-keys true))
-      "mediaserver.started"     {:db (assoc db :mediaserver/port (.-port event-js))}
-      "wakuv2.peerstats"        (wakuv2-peer-stats cofx (js->clj event-js :keywordize-keys true))
-      "messages.new"            (transport.message/sanitize-messages-and-process-response cofx
-                                                                                          event-js
-                                                                                          true)
-      "wallet"                  (ethereum.subscriptions/new-wallet-event cofx
-                                                                         (js->clj event-js
-                                                                                  :keywordize-keys
-                                                                                  true))
-      "local-notifications"     (local-notifications/process cofx
-                                                             (js->clj event-js :keywordize-keys true))
-      "community.found"         (link-preview/cache-community-preview-data (js->clj event-js
-                                                                                    :keywordize-keys
-                                                                                    true))
-      "status.updates.timedout" (visibility-status-updates/handle-visibility-status-updates
-                                 cofx
-                                 (js->clj event-js :keywordize-keys true))
-      "localPairing"            (handle-local-pairing-signals
-                                 cofx
-                                 (js->clj event-js :keywordize-keys true))
+      "local-notifications"        (local-notifications/process cofx
+                                                                (js->clj event-js :keywordize-keys true))
+      "community.found"            (link-preview/cache-community-preview-data (js->clj event-js
+                                                                                       :keywordize-keys
+                                                                                       true))
+      "status.updates.timedout"    (visibility-status-updates/handle-visibility-status-updates
+                                    cofx
+                                    (js->clj event-js :keywordize-keys true))
+      "localPairing"               (handle-local-pairing-signals
+                                    cofx
+                                    (js->clj event-js :keywordize-keys true))
+      "curated.communities.update" (rf/dispatch [:fetched-contract-communities
+                                                 (js->clj event-js :keywordize-keys true)])
 
       (log/debug "Event " type " not handled"))))

--- a/src/status_im2/contexts/communities/discover/events.cljs
+++ b/src/status_im2/contexts/communities/discover/events.cljs
@@ -1,19 +1,42 @@
 (ns status-im2.contexts.communities.discover.events
-  (:require [camel-snake-kebab.core :as csk]
-            [clojure.string :as string]
-            [taoensso.timbre :as log]
+  (:require [taoensso.timbre :as log]
             [utils.re-frame :as rf]))
+
+(def commmunity-keys-renamed
+  {:requestedAccessAt           :requested-access-at
+   :fileSize                    :file-size
+   :communityTokensMetadata     :community-tokens-metadata
+   :activeMembersCount          :active-members-count
+   :unknownCommunities          :unknown-communities
+   :canRequestAccess            :can-request-access?
+   :adminSettings               :admin-settings
+   :canManageUsers              :can-manage-users?
+   :categoryID                  :category-id
+   :canPost                     :can-post?
+   :isControlNode               :is-control-node?
+   :pinMessageAllMembersEnabled :pin-message-all-members-enabled
+   :isMember                    :is-member?
+   :canDeleteMessageForEveryone :can-delete-message-for-everyone?
+   :tokenPermissions            :token-permissions
+   :muteTill                    :mute-till
+   :contractCommunities         :contract-communities
+   :banList                     :ban-list
+   :keyUid                      :key-uid
+   :memberRole                  :member-role
+   :introMessage                :intro-message
+   :contractFeaturedCommunities :contract-featured-communities
+   :canJoin                     :can-join?
+   :outroMessage                :outro-message
+   :resizeTarget                :resize-target})
 
 (defn rename-contract-community-key
   [k]
   (let [s                  (name k)
-        lower-cased        (csk/->kebab-case-string s)
         starts-with-digit? (re-matches #"^\d.*" s)
-        predicate?         (some #(string/starts-with? lower-cased %)
-                                 ["can-" "is-"])]
+        existing-rename    (k commmunity-keys-renamed)]
     (cond starts-with-digit? s
-          predicate?         (keyword (str lower-cased "?"))
-          :else              (keyword lower-cased))))
+          existing-rename    existing-rename
+          :else              (keyword s))))
 
 (defn rename-contract-community-keys
   [m]
@@ -43,4 +66,3 @@
                     :params     []
                     :on-success #(rf/dispatch [:fetched-contract-communities %])
                     :on-error   #(log/error "failed to fetch contract communities" %)}]})
-

--- a/src/status_im2/contexts/communities/discover/events_test.cljs
+++ b/src/status_im2/contexts/communities/discover/events_test.cljs
@@ -4,16 +4,12 @@
 
 (deftest rename-contract-community-key-test
   (are [i e] (= (events/rename-contract-community-key i) e)
-   :foo           :foo
-   :fooBar        :foo-bar
-   :fooBarBaz     :foo-bar-baz
-   :isFoo         :is-foo?
-   :isFooBar      :is-foo-bar?
-   :canFoo        :can-foo?
-   :canFooBar     :can-foo-bar?
-   :0x025d27e58   "0x025d27e58"
-   :093b4684-92f0 "093b4684-92f0"
-   :3f9e77b8-97c7 "3f9e77b8-97c7"))
+   :requestedAccessAt           :requested-access-at
+   :canDeleteMessageForEveryone :can-delete-message-for-everyone?
+   :name                        :name
+   :0x025d27e58                 "0x025d27e58"
+   :093b4684-92f0               "093b4684-92f0"
+   :3f9e77b8-97c7               "3f9e77b8-97c7"))
 
 (deftest rename-contract-community-keys-test
   (are [i e] (= (events/rename-contract-community-keys i) e)


### PR DESCRIPTION
fixes #17282

### Summary

Keyword renaming changed to be more performant when app fetches communities.
On my simulator before this PR event `:fetched-contract-communities` did take 80ms, after - 2ms.

status: ready