### PR TITLE
fix: carousel text overflow

### DIFF
--- a/src/status_im2/contexts/onboarding/common/carousel/style.cljs
+++ b/src/status_im2/contexts/onboarding/common/carousel/style.cljs
@@ -16,9 +16,9 @@
 
 (defn header-text-view
   [window-width]
-  {:flex-direction :column
-   :width          window-width
-   :padding-left   20})
+  {:flex-direction     :column
+   :width              window-width
+   :padding-horizontal 20})
 
 (def carousel-text
   {:color colors/white})


### PR DESCRIPTION

Follow up to this comment https://github.com/status-im/status-mobile/pull/17269#issuecomment-1717428473, fixes https://github.com/status-im/status-mobile/issues/17276

The text and sub text can overflow and don't seem to have a right padding

#### Platforms
- Android
- iOS


status: ready 
