### PR TITLE
fix: Display name is not shown on Profile page after sync

### DIFF
--- a/src/status_im/multiaccounts/core.cljs
+++ b/src/status_im/multiaccounts/core.cljs
@@ -24,10 +24,11 @@
 (defn displayed-name
   "Use preferred name, display-name, name or alias in that order"
   [{:keys [name display-name preferred-name alias public-key ens-verified primary-name]}]
-  (let [display-name (if (string/blank? display-name) nil display-name)
-        ens-name     (or preferred-name
-                         display-name
-                         name)]
+  (let [display-name   (if (string/blank? display-name) nil display-name)
+        preferred-name (if (string/blank? preferred-name) nil preferred-name)
+        ens-name       (or preferred-name
+                           display-name
+                           name)]
     ;; Preferred name is our own otherwise we make sure it's verified
     (if (or preferred-name (and ens-verified name))
       ens-name


### PR DESCRIPTION
`preferred-name` could be "" which makes operation [`or`](https://github.com/status-im/status-react/blob/7bd862c424c47009f53fb902fe7917779a30ca46/src/status_im/multiaccounts/core.cljs#L29) not work.

fixes #17308

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

status: ready <!-- Can be ready or wip -->
