### PR TITLE
[#17309] fix: wrong cursor position in a pre-filled composer

### DIFF
--- a/src/status_im2/contexts/chat/composer/effects.cljs
+++ b/src/status_im2/contexts/chat/composer/effects.cljs
@@ -89,7 +89,6 @@
   (rn/use-effect
    (fn []
      (maximized-effect state animations dimensions chat-input)
-     (reenter-screen-effect state dimensions chat-input)
      (layout-effect state)
      (kb-default-height-effect state)
      (background-effect state animations dimensions chat-input)
@@ -98,7 +97,11 @@
      (empty-effect state animations subscriptions)
      (kb/add-kb-listeners props state animations dimensions)
      #(component-will-unmount props))
-   [max-height]))
+   [max-height])
+  (rn/use-effect
+   (fn []
+     (reenter-screen-effect state dimensions subscriptions))
+   [max-height subscriptions]))
 
 (defn use-edit
   [{:keys [input-ref]}

--- a/src/status_im2/contexts/chat/composer/effects.cljs
+++ b/src/status_im2/contexts/chat/composer/effects.cljs
@@ -109,12 +109,15 @@
    {:keys [edit]}]
   (rn/use-effect
    (fn []
-     (let [edit-text (get-in edit [:content :text])]
+     (let [edit-text        (get-in edit [:content :text])
+           text-value-count (count @text-value)]
        (when (and edit @input-ref)
          (.focus ^js @input-ref)
          (.setNativeProps ^js @input-ref (clj->js {:text edit-text}))
          (reset! text-value edit-text)
-         (reset! saved-cursor-position (count edit-text)))))
+         (reset! saved-cursor-position (if (zero? text-value-count)
+                                         (count edit-text)
+                                         text-value-count)))))
    [(:message-id edit)]))
 
 (defn use-reply


### PR DESCRIPTION
fixes #17309

The cursor should be displayed at the end of the pre-filled message in the composer when the chat is reopened.


### Result

https://github.com/status-im/status-mobile/assets/71308738/aba95ba3-3019-459c-85e3-0bc713c52dae



### Steps to test

1. Open a chat.
2. Type a message in the composer but do not send it.
3. Close the chat.
4. Reopen the same chat.

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready
