### PR TITLE
Prevent Logged In Account Local Pairing / Syncing With Another Account

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.166.11",
-    "commit-sha1": "6bcf5f1289f9160168574290cbd6f90dede3f8f6",
-    "src-sha256": "0g56pawjpxgjp93slvpbkajz73ajrjfi0n0js3hvqh8x4ciwa43p"
+    "version": "v0.167.2",
+    "commit-sha1": "b3213172a7fd2ed59c791613fbbe89a22275c5c2",
+    "src-sha256": "0fzq2s02h7q31imqqdrv79z3qr0mcam9m8qjcqaqa5lrg5dd3n9a"
 }


### PR DESCRIPTION
This PR added check that prevent 2 different logged in accounts doing local pairing / syncing.

fixes #17270

### Testing notes
After 2 different logged in accounts doing local pairing/syncing, **horrible db coruption** shouldn't happen again. 

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->
