### PR TITLE
move messages legacy view

### DIFF
--- a/src/status_im/ui/screens/chat/message/legacy_view.cljs
+++ b/src/status_im/ui/screens/chat/message/legacy_view.cljs
@@ -1,4 +1,4 @@
-(ns status-im2.contexts.chat.messages.content.legacy-view
+(ns status-im.ui.screens.chat.message.legacy-view
   (:require
     [quo.design-system.colors :as quo.colors]
     [quo.react-native :as rn]

--- a/src/status_im2/contexts/chat/messages/content/system/text/view.cljs
+++ b/src/status_im2/contexts/chat/messages/content/system/text/view.cljs
@@ -1,6 +1,6 @@
 (ns status-im2.contexts.chat.messages.content.system.text.view
   (:require [react-native.core :as rn]
-            [status-im2.contexts.chat.messages.content.legacy-view :as old-message]))
+            [status-im.ui.screens.chat.message.legacy-view :as old-message]))
 
 (defn text-content
   [message-data]

--- a/src/status_im2/contexts/chat/messages/content/view.cljs
+++ b/src/status_im2/contexts/chat/messages/content/view.cljs
@@ -19,7 +19,7 @@
     [status-im2.contexts.chat.messages.content.audio.view :as audio]
     [quo2.core :as quo]
     [utils.re-frame :as rf]
-    [status-im2.contexts.chat.messages.content.legacy-view :as old-message]
+    [status-im.ui.screens.chat.message.legacy-view :as old-message]
     [status-im2.contexts.chat.composer.reply.view :as reply]
     [status-im2.common.not-implemented :as not-implemented]
     [utils.datetime :as datetime]

--- a/src/status_im2/contexts/shell/activity_center/notification/reply/view.cljs
+++ b/src/status_im2/contexts/shell/activity_center/notification/reply/view.cljs
@@ -2,7 +2,7 @@
   (:require [clojure.string :as string]
             [quo2.core :as quo]
             [react-native.gesture :as gesture]
-            [status-im2.contexts.chat.messages.content.legacy-view :as old-message]
+            [status-im.ui.screens.chat.message.legacy-view :as old-message]
             [status-im2.common.not-implemented :as not-implemented]
             [status-im2.constants :as constants]
             [status-im2.contexts.shell.activity-center.notification.common.view :as common]


### PR DESCRIPTION
legacy-view requires lots of legacy deps, so it's better to move it outside status-im2 so we can continue cleaning