### PR TITLE
Fix show the hashtag in chat when replying/copying status-tag

### DIFF
--- a/src/status_im2/contexts/chat/composer/reply/view.cljs
+++ b/src/status_im2/contexts/chat/composer/reply/view.cljs
@@ -23,6 +23,9 @@
              (= type "mention")
              (rf/sub [:messages/resolve-mention literal])
 
+             (= type "status-tag")
+             (str "#" literal)
+
              (seq children)
              (get-quoted-text-with-mentions children)
 


### PR DESCRIPTION
fixes #11161

### Summary

Show the hashtag when the user copies and in the reply to a message containing a `status-tag` e.g. "#general". See screenshots below for the before and after versions respectively.

<div  style="flex-direction: row">
<img src="https://github.com/status-im/status-mobile/assets/21865759/6f9e3945-4625-47a0-a546-6990fe94459e" width="200">
<img src="https://github.com/status-im/status-mobile/assets/21865759/72c797cb-7b07-4ae2-8d30-4e3ab5b390a7" width="200">
</div>

### Testing notes
<!-- (Optional) -->

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- 1-1 chats
- public chats
- group chats

### Steps to test

- Open Status
- Go to a community channel (or a 1-1 chat)
- Send a message with a hashtag
- Reply to it _(the # should be visible in the reply)_
- Copy and paste it _(the inserted text should include the #)_

<!-- (PRs will only be accepted if squashed into single commit.) -->

status: ready <!-- Can be ready or wip -->
