### PR TITLE
[#17333] fix: disable ring for small avatar

### DIFF
--- a/src/status_im2/common/confirmation_drawer/view.cljs
+++ b/src/status_im2/common/confirmation_drawer/view.cljs
@@ -16,6 +16,7 @@
      {:full-name         display-name
       :profile-picture   photo-path
       :size              :xxs
+      :ring?             false
       :status-indicator? false}]))
 
 (defn extra-action-view

--- a/src/status_im2/contexts/chat/messages/content/deleted/view.cljs
+++ b/src/status_im2/contexts/chat/messages/content/deleted/view.cljs
@@ -17,6 +17,7 @@
      {:full-name         display-name
       :profile-picture   profile-picture
       :status-indicator? false
+      :ring?             false
       :size              :xxxs}]]
    [quo/text
     {:weight          :semi-bold

--- a/src/status_im2/subs/profile.cljs
+++ b/src/status_im2/subs/profile.cljs
@@ -40,7 +40,7 @@
  (fn [[multiaccounts port font-file] [_ target-key-uid]]
    (let [{:keys [images ens-name?] :as multiaccount} (get multiaccounts target-key-uid)
          image-name                                  (-> images first :type)
-         override-ring?                              (not ens-name?)]
+         override-ring?                              (when ens-name? false)]
      (when multiaccount
        {:fn
         (if image-name


### PR DESCRIPTION
fixes #17333

The identifier rings should not be displayed on small avatars like deleted message, delete chat and delete profile

Result: 
<img src="https://github.com/status-im/status-mobile/assets/71308738/8f4454c3-0541-4cf3-8f29-ffe5afa44591" width="375px"/>

<img src="https://github.com/status-im/status-mobile/assets/71308738/12c7eabc-559e-44a7-83bf-6fd70aa93d1e" width="375px"/>

<img src="https://github.com/status-im/status-mobile/assets/71308738/3380a0f9-bf4b-4c8e-8109-5e918265374c" width="375px"/>

status: ready
