### PR TITLE
fix(identifier): emoji hash line height

### DIFF
--- a/src/status_im2/contexts/onboarding/identifiers/profile_card/style.cljs
+++ b/src/status_im2/contexts/onboarding/identifiers/profile_card/style.cljs
@@ -66,4 +66,5 @@
           {:margin-top 2})))
 
 (def emoji-hash
-  {:margin-top 12})
+  {:margin-top  12
+   :line-height 20.5})


### PR DESCRIPTION
Fixes https://github.com/status-im/status-mobile/issues/17330, follow up to https://github.com/status-im/status-mobile/pull/17293

### Summary
The identifier card height in the onboarding flow should match the design

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

status: ready <!-- Can be ready or wip -->
