### PR TITLE
[#17333] fix: reopen multiline message in collapsed composer

### DIFF
--- a/src/status_im2/contexts/chat/composer/effects.cljs
+++ b/src/status_im2/contexts/chat/composer/effects.cljs
@@ -87,12 +87,12 @@
 
 (defn initialize
   [props state animations {:keys [max-height] :as dimensions}
-   {:keys [audio] :as subscriptions}]
+   {:keys [chat-input audio] :as subscriptions}]
   (rn/use-effect
    (fn []
      (layout-effect state)
      (kb-default-height-effect state)
-     (background-effect state animations dimensions subscriptions)
+     (background-effect state animations dimensions chat-input)
      (link-preview-effect state)
      (audio-effect state animations audio)
      (empty-effect state animations subscriptions)

--- a/src/status_im2/contexts/chat/composer/effects.cljs
+++ b/src/status_im2/contexts/chat/composer/effects.cljs
@@ -28,6 +28,8 @@
    {:keys [height saved-height last-height]}
    {:keys [max-height]}
    {:keys [input-content-height]}]
+  (reanimated/set-shared-value saved-height input-content-height)
+  (reanimated/set-shared-value last-height input-content-height)
   (when (or @maximized? (>= input-content-height max-height))
     (reanimated/animate height max-height)
     (reanimated/set-shared-value saved-height max-height)
@@ -85,13 +87,12 @@
 
 (defn initialize
   [props state animations {:keys [max-height] :as dimensions}
-   {:keys [chat-input audio] :as subscriptions}]
+   {:keys [audio] :as subscriptions}]
   (rn/use-effect
    (fn []
-     (maximized-effect state animations dimensions chat-input)
      (layout-effect state)
      (kb-default-height-effect state)
-     (background-effect state animations dimensions chat-input)
+     (background-effect state animations dimensions subscriptions)
      (link-preview-effect state)
      (audio-effect state animations audio)
      (empty-effect state animations subscriptions)
@@ -100,6 +101,7 @@
    [max-height])
   (rn/use-effect
    (fn []
+     (maximized-effect state animations dimensions subscriptions)
      (reenter-screen-effect state dimensions subscriptions))
    [max-height subscriptions]))
 


### PR DESCRIPTION
fixes #17361

can't see the entire multiline message in collapsed composer after reopening the chat

### Steps to test
- Open chat
- Type a multiline message
- Close the chat and open it again
- Try to set the cursor to the end of the message

[Screen_recording_20230926_103511.webm](https://github.com/status-im/status-mobile/assets/71308738/d8a95d61-7fcf-4cfe-a4c9-6c9b19d8d006)

status: ready
