### PR TITLE
[#17396] fix: Mention is displayed as public key in PNs

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.167.2",
-    "commit-sha1": "b3213172a7fd2ed59c791613fbbe89a22275c5c2",
-    "src-sha256": "0fzq2s02h7q31imqqdrv79z3qr0mcam9m8qjcqaqa5lrg5dd3n9a"
+    "version": "v0.167.5",
+    "commit-sha1": "c88b6e53af42c1c7a3b7d252093a687dafaf4aac",
+    "src-sha256": "13qrz8wgbqldl1vd3qwyrayfiay5j3i79f7a7g0lcwchc7k3k50a"
 }


### PR DESCRIPTION
fixes #17396

display name/ens/nickname should be displayed in PN.

when somebody mention you in one-to-one chat or community, in your device it shows your public key in PN instead of your name/ens/nickname 

Result:

https://github.com/status-im/status-mobile/assets/71308738/5129b1b3-93ea-4c49-8022-d9fb2458d817



status: ready
