### PR TITLE
Reduce Clojure linter warning noise

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -308,11 +308,21 @@ define find_all_clojure_files
 $$(comm -23 <(sort <(git ls-files --cached --others --exclude-standard)) <(sort <(git ls-files --deleted)) | grep -e \.clj$$ -e \.cljs$$ -e \.cljc$$ -e \.edn)
 endef
 
+# Lint Clojure files with clj-kondo.
+#
+# Args:
+#   $1: When equal to true, print warnings.
+define lint_clojure_files
+	$(if $(filter true,$1), \
+			clj-kondo --config .clj-kondo/config.edn --cache false --fail-level error --lint src, \
+			clj-kondo --config .clj-kondo/config.edn --cache false --fail-level error --lint src | grep -v ': warning: ')
+endef
+
 lint: export TARGET := clojure
 lint: ##@test Run code style checks
 	@sh scripts/lint-re-frame-in-quo-components.sh && \
 	sh scripts/lint-old-quo-usage.sh && \
-	clj-kondo --config .clj-kondo/config.edn --cache false --fail-level error --lint src && \
+	$(call lint_clojure_files, $(CLJ_LINTER_PRINT_WARNINGS)) && \
 	ALL_CLOJURE_FILES=$(call find_all_clojure_files) && \
 	zprint '{:search-config? true}' -sfc $$ALL_CLOJURE_FILES && \
 	sh scripts/lint-trailing-newline.sh && \

--- a/Makefile
+++ b/Makefile
@@ -308,21 +308,12 @@ define find_all_clojure_files
 $$(comm -23 <(sort <(git ls-files --cached --others --exclude-standard)) <(sort <(git ls-files --deleted)) | grep -e \.clj$$ -e \.cljs$$ -e \.cljc$$ -e \.edn)
 endef
 
-# Lint Clojure files with clj-kondo.
-#
-# Args:
-#   $1: When equal to true, print warnings.
-define lint_clojure_files
-	$(if $(filter true,$1), \
-			clj-kondo --config .clj-kondo/config.edn --cache false --fail-level error --lint src, \
-			clj-kondo --config .clj-kondo/config.edn --cache false --fail-level error --lint src | grep -v ': warning: ')
-endef
-
 lint: export TARGET := clojure
+lint: export CLJ_LINTER_PRINT_WARNINGS ?= false
 lint: ##@test Run code style checks
 	@sh scripts/lint-re-frame-in-quo-components.sh && \
 	sh scripts/lint-old-quo-usage.sh && \
-	$(call lint_clojure_files, $(CLJ_LINTER_PRINT_WARNINGS)) && \
+	clj-kondo --config .clj-kondo/config.edn --cache false --fail-level error --lint src $(if $(filter $(CLJ_LINTER_PRINT_WARNINGS),true),,| grep -v ': warning: ') && \
 	ALL_CLOJURE_FILES=$(call find_all_clojure_files) && \
 	zprint '{:search-config? true}' -sfc $$ALL_CLOJURE_FILES && \
 	sh scripts/lint-trailing-newline.sh && \

--- a/Makefile
+++ b/Makefile
@@ -311,7 +311,7 @@ endef
 lint: export TARGET := clojure
 lint: ##@test Run code style checks
 	@sh scripts/lint-re-frame-in-quo-components.sh && \
-	sh scripts/lint-old-quo-usage.sh \
+	sh scripts/lint-old-quo-usage.sh && \
 	clj-kondo --config .clj-kondo/config.edn --cache false --fail-level error --lint src && \
 	ALL_CLOJURE_FILES=$(call find_all_clojure_files) && \
 	zprint '{:search-config? true}' -sfc $$ALL_CLOJURE_FILES && \

--- a/ci/Jenkinsfile.tests
+++ b/ci/Jenkinsfile.tests
@@ -48,7 +48,7 @@ pipeline {
           steps {
             sh """#!/bin/bash
               set -eo pipefail
-              make lint 2>&1 | tee ${LOG_FILE}
+              make lint CLJ_LINTER_PRINT_WARNINGS=true 2>&1 | tee ${LOG_FILE}
             """
           }
         }

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -129,6 +129,7 @@
     ;; needed because we use deref in tests
     :static-fns    false
     :optimizations :simple
+    :warnings      {:fn-deprecated false}
     :infer-externs true}}
 
   ;; mock.js-dependencies is mocking the react-native libraries


### PR DESCRIPTION
### Summary

This PR changes the make `lint` target default behavior to NOT show clj-kondo warnings.

In the CI I kept the same behavior, i.e. show all warnings and errors simultaneously.

### Motivation

When devs run `make lint`, most of the time, they don't want to see a long list of warnings. Their focus is on the errors. Additionally, the majority of devs in the mobile team see clj-kondo warnings in their editors of choice already.

We (some of us) believe the editor feedback/warnings are sufficiently noisy.

### But I don't like this new default!

Okay, add the following somewhere in your config files:

```sh
export CLJ_LINTER_PRINT_WARNINGS=true
```

### Do you think we should invert the logic?

I can also change this PR to invert the logic, i.e. we keep the current behavior (a bit noisy) and then devs can export a `CLJ_LINTER_HIDE_WARNINGS=true` in their own environments if they want less noise.

#### Areas that may be impacted

None

### Steps to test

- `make lint`
- `make lint CLJ_LINTER_PRINT_WARNINGS=true`

status: ready
