### PR TITLE
fix: back button on 1:1 chat

### DIFF
--- a/src/status_im2/contexts/chat/messages/navigation/style.cljs
+++ b/src/status_im2/contexts/chat/messages/navigation/style.cljs
@@ -5,6 +5,17 @@
 (defonce ^:const navigation-bar-height 100)
 (defonce ^:const header-offset 56)
 
+(defn button-container
+  [position]
+  (merge
+   {:width            32
+    :height           32
+    :border-radius    10
+    :justify-content  :center
+    :align-items      :center
+    :background-color (colors/theme-colors colors/neutral-80-opa-5 colors/white-opa-5)}
+   position))
+
 (defn background-view
   [theme]
   {:position         :absolute

--- a/src/status_im2/contexts/chat/messages/navigation/style.cljs
+++ b/src/status_im2/contexts/chat/messages/navigation/style.cljs
@@ -5,16 +5,6 @@
 (defonce ^:const navigation-bar-height 100)
 (defonce ^:const header-offset 56)
 
-(defn button-container
-  [theme]
-  {:width            32
-   :height           32
-   :border-radius    10
-   :justify-content  :center
-   :align-items      :center
-   :background-color (colors/theme-colors colors/neutral-80-opa-5 colors/white-opa-5 theme)})
-
-
 (defn background-view
   [theme]
   {:position         :absolute

--- a/src/status_im2/contexts/chat/messages/navigation/style.cljs
+++ b/src/status_im2/contexts/chat/messages/navigation/style.cljs
@@ -6,15 +6,14 @@
 (defonce ^:const header-offset 56)
 
 (defn button-container
-  [position]
-  (merge
-   {:width            32
-    :height           32
-    :border-radius    10
-    :justify-content  :center
-    :align-items      :center
-    :background-color (colors/theme-colors colors/neutral-80-opa-5 colors/white-opa-5)}
-   position))
+  [theme]
+  {:width            32
+   :height           32
+   :border-radius    10
+   :justify-content  :center
+   :align-items      :center
+   :background-color (colors/theme-colors colors/neutral-80-opa-5 colors/white-opa-5 theme)})
+
 
 (defn background-view
   [theme]

--- a/src/status_im2/contexts/chat/messages/navigation/view.cljs
+++ b/src/status_im2/contexts/chat/messages/navigation/view.cljs
@@ -15,8 +15,8 @@
             [utils.re-frame :as rf]))
 
 (defn f-view
-  [{:keys [theme scroll-y chat chat-screen-loaded? all-loaded? display-name online? photo-path back-icon]
-    :or   {back-icon :i/arrow-left}}]
+  [{:keys [theme scroll-y chat chat-screen-loaded? all-loaded? display-name online? photo-path
+           back-icon]}]
   (let [{:keys [group-chat chat-id]} chat
         opacity-animation            (reanimated/interpolate scroll-y
                                                              [style/navigation-bar-height
@@ -54,16 +54,17 @@
         :style         {:flex 1}}]]
 
      [rn/view {:style style/header-container}
-      [rn/touchable-opacity
-       {:active-opacity      1
+      [quo/button
+       {:icon-only?          true
+        :type                :grey
+        :background          :blur
+        :size                32
+        :accessibility-label :back-button
         :on-press            #(do
                                 (when config/shell-navigation-disabled?
                                   (rf/dispatch [:chat/close]))
-                                (rf/dispatch [:navigate-back]))
-        :accessibility-label :back-button
-        :style               (style/button-container theme)}
-       [quo/icon back-icon
-        {:size 20 :color (colors/theme-colors colors/black colors/white)}]]
+                                (rf/dispatch [:navigate-back]))}
+       back-icon]
       [reanimated/view
        {:style (style/animated-header all-loaded? translate-animation title-opacity-animation)}
        [rn/view {:style style/header-content-container}

--- a/src/status_im2/contexts/chat/messages/navigation/view.cljs
+++ b/src/status_im2/contexts/chat/messages/navigation/view.cljs
@@ -59,10 +59,11 @@
         :background          :blur
         :size                32
         :accessibility-label :back-button
+        :style               (style/button-container {:margin-left 20})}
         :on-press            #(do
                                 (when config/shell-navigation-disabled?
                                   (rf/dispatch [:chat/close]))
-                                (rf/dispatch [:navigate-back]))}
+                                (rf/dispatch [:navigate-back]))
        :i/arrow-left]
       [reanimated/view
        {:style (style/animated-header all-loaded? translate-animation title-opacity-animation)}

--- a/src/status_im2/contexts/chat/messages/navigation/view.cljs
+++ b/src/status_im2/contexts/chat/messages/navigation/view.cljs
@@ -15,7 +15,8 @@
             [utils.re-frame :as rf]))
 
 (defn f-view
-  [{:keys [theme scroll-y chat chat-screen-loaded? all-loaded? display-name online? photo-path]}]
+  [{:keys [theme scroll-y chat chat-screen-loaded? all-loaded? display-name online? photo-path back-icon]
+    :or   {back-icon :i/arrow-left}}]
   (let [{:keys [group-chat chat-id]} chat
         opacity-animation            (reanimated/interpolate scroll-y
                                                              [style/navigation-bar-height
@@ -53,18 +54,16 @@
         :style         {:flex 1}}]]
 
      [rn/view {:style style/header-container}
-      [quo/button
-       {:icon-only?          true
-        :type                :grey
-        :background          :blur
-        :size                32
-        :accessibility-label :back-button
-        :style               (style/button-container {:margin-left 20})}
+      [rn/touchable-opacity
+       {:active-opacity      1
         :on-press            #(do
                                 (when config/shell-navigation-disabled?
                                   (rf/dispatch [:chat/close]))
                                 (rf/dispatch [:navigate-back]))
-       :i/arrow-left]
+        :accessibility-label :back-button
+        :style               (style/button-container theme)}
+       [quo/icon back-icon
+        {:size 20 :color (colors/theme-colors colors/black colors/white)}]]
       [reanimated/view
        {:style (style/animated-header all-loaded? translate-animation title-opacity-animation)}
        [rn/view {:style style/header-content-container}

--- a/src/status_im2/contexts/chat/messages/view.cljs
+++ b/src/status_im2/contexts/chat/messages/view.cljs
@@ -39,7 +39,10 @@
                                                    (str (when emoji (str emoji " ")) "# " chat-name)
                                                    :else (str emoji chat-name))
         online?                                  (rf/sub [:visibility-status-updates/online? chat-id])
-        photo-path                               (rf/sub [:chats/photo-path chat-id])]
+        photo-path                               (rf/sub [:chats/photo-path chat-id])
+        back-icon                                (when (or (= chat-type constants/one-to-one-chat-type)
+                                                           (= chat-type constants/community-chat-type))
+                                                   :i/close)]
     (rn/use-effect
      (fn []
        ;; If keyboard is shown then adjust `scroll-y`
@@ -71,6 +74,7 @@
 
      [messages.navigation/navigation-view
       {:scroll-y            scroll-y
+       :back-icon           back-icon
        :chat                chat
        :chat-screen-loaded? chat-screen-loaded?
        :all-loaded?         all-loaded?

--- a/src/status_im2/contexts/chat/messages/view.cljs
+++ b/src/status_im2/contexts/chat/messages/view.cljs
@@ -40,9 +40,9 @@
                                                    :else (str emoji chat-name))
         online?                                  (rf/sub [:visibility-status-updates/online? chat-id])
         photo-path                               (rf/sub [:chats/photo-path chat-id])
-        back-icon                                (when (or (= chat-type constants/one-to-one-chat-type)
-                                                           (= chat-type constants/community-chat-type))
-                                                   :i/close)]
+        back-icon                                (if (= chat-type constants/one-to-one-chat-type)
+                                                   :i/close
+                                                   :i/arrow-left)]
     (rn/use-effect
      (fn []
        ;; If keyboard is shown then adjust `scroll-y`


### PR DESCRIPTION
Fixes https://github.com/status-im/status-mobile/issues/17537

### Summary
The icon used for the back button is the wrong one.  The colors for light and dark theme were also interchanged with the wrong opacity.

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

##### Functional

- 1-1 chats
- 
status: ready 
