### PR TITLE
fix: image preview padding

### DIFF
--- a/src/status_im2/contexts/chat/composer/images/style.cljs
+++ b/src/status_im2/contexts/chat/composer/images/style.cljs
@@ -7,18 +7,20 @@
    :padding-right  12})
 
 (def remove-photo-container
-  {:width            14
-   :height           14
-   :border-radius    7
+  {:width            15
+   :height           15
+   :border-radius    8
    :background-color colors/neutral-50
+   :border-width     1
+   :border-color     colors/white
    :position         :absolute
    :top              5
-   :right            5
+   :right            9
    :justify-content  :center
    :align-items      :center})
 
 (def small-image
   {:width         56
    :height        56
-   :border-radius 8})
+   :border-radius 12})
 

--- a/src/status_im2/contexts/chat/composer/images/style.cljs
+++ b/src/status_im2/contexts/chat/composer/images/style.cljs
@@ -6,16 +6,24 @@
    :padding-bottom 8
    :padding-right  12})
 
-(def remove-photo-container
-  {:width            15
-   :height           15
+(defn remove-photo-container
+  [theme]
+  {:width            16
+   :height           16
    :border-radius    8
-   :background-color colors/neutral-50
-   :border-width     1
-   :border-color     colors/white
+   :background-color (colors/theme-colors colors/white colors/neutral-95 theme)
    :position         :absolute
    :top              5
    :right            9
+   :justify-content  :center
+   :align-items      :center
+  })
+
+(def remove-photo-inner-container
+  {:width            14
+   :height           14
+   :border-radius    7
+   :background-color colors/neutral-50
    :justify-content  :center
    :align-items      :center})
 

--- a/src/status_im2/contexts/chat/composer/images/view.cljs
+++ b/src/status_im2/contexts/chat/composer/images/view.cljs
@@ -23,7 +23,7 @@
                 :top    10
                 :bottom 10}}
     [rn/view {:style style/remove-photo-inner-container}
-     [quo/icon :i/clear {:size 20 :color-2 colors/white}]]]])
+     [quo/icon :i/clear {:size 20 :color colors/neutral-50 :color-2 colors/white}]]]])
 
 (defn f-images-list
   []

--- a/src/status_im2/contexts/chat/composer/images/view.cljs
+++ b/src/status_im2/contexts/chat/composer/images/view.cljs
@@ -1,6 +1,7 @@
 (ns status-im2.contexts.chat.composer.images.view
   (:require [quo2.core :as quo]
             [quo2.foundations.colors :as colors]
+            [quo2.theme :as quo.theme]
             [react-native.core :as rn]
             [react-native.gesture :as gesture]
             [react-native.reanimated :as reanimated]
@@ -9,23 +10,25 @@
             [status-im2.contexts.chat.composer.constants :as constants]))
 
 (defn image
-  [item]
+  [item theme]
   [rn/view style/image-container
    [rn/image
     {:source {:uri (:resized-uri (val item))}
      :style  style/small-image}]
    [rn/touchable-opacity
     {:on-press #(rf/dispatch [:chat.ui/image-unselected (val item)])
-     :style    style/remove-photo-container
+     :style    (style/remove-photo-container theme)
      :hit-slop {:right  5
                 :left   5
                 :top    10
                 :bottom 10}}
-    [quo/icon :i/close {:color colors/white :size 12}]]])
+    [rn/view {:style style/remove-photo-inner-container}
+     [quo/icon :i/clear {:size 20 :color-2 colors/white}]]]])
 
 (defn f-images-list
   []
-  (let [images (rf/sub [:chats/sending-image])
+  (let [theme  (quo.theme/use-theme-value)
+        images (rf/sub [:chats/sending-image])
         height (reanimated/use-shared-value (if (seq images) constants/images-container-height 0))]
     (rn/use-effect (fn []
                      (reanimated/animate height
@@ -37,7 +40,8 @@
                                                     :z-index           1})}
      [gesture/flat-list
       {:key-fn                            first
-       :render-fn                         image
+       :render-fn                         (fn [item]
+                                            (image item theme))
        :data                              images
        :content-container-style           {:padding-horizontal 20}
        :horizontal                        true

--- a/src/status_im2/contexts/chat/composer/style.cljs
+++ b/src/status_im2/contexts/chat/composer/style.cljs
@@ -54,12 +54,12 @@
   [height max-height]
   (reanimated/apply-animations-to-style
    {:height height}
-   {:max-height max-height
-    :overflow   :hidden}))
+   {:max-height max-height}))
 
 (defn input-view
   [{:keys [recording?]}]
-  {:z-index    1
+  {:overflow   :hidden
+   :z-index    1
    :flex       1
    :display    (if @recording? :none :flex)
    :min-height constants/input-height})


### PR DESCRIPTION
Fixes https://github.com/status-im/status-mobile/issues/17542

### Summary
Image previews cut off due to padding horizontal, so it doesn't scroll to the edge of the screen on both ends.

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

**Before:**

![simulator_screenshot_4991FB4C-494A-4B21-A5B6-98E2F47C2FDE](https://github.com/status-im/status-mobile/assets/45393944/fb0d0722-6751-494d-8efa-f7df4bf79c77)

**After:**

![simulator_screenshot_94AD01A0-8AB1-4E5A-96BA-4CAAC8DADA30](https://github.com/status-im/status-mobile/assets/45393944/061d5c83-34bf-4d8e-ae2f-af3acd3e9e0a)


##### Functional

- 1-1 chats

status: ready
