### PR TITLE
fix: several bugs in 1.25 design feedback

### DIFF
--- a/src/status_im2/contexts/chat/messages/avatar/view.cljs
+++ b/src/status_im2/contexts/chat/messages/avatar/view.cljs
@@ -4,7 +4,7 @@
             [utils.re-frame :as rf]))
 
 (defn avatar
-  [public-key size]
+  [{:keys [public-key size hide-ring?]}]
   (let [display-name (first (rf/sub [:contacts/contact-two-names-by-identity public-key]))
         photo-path   (rf/sub [:chats/photo-path public-key])
         online?      (rf/sub [:visibility-status-updates/online? public-key])]
@@ -14,6 +14,7 @@
        :on-press       #(rf/dispatch [:chat.ui/show-profile public-key])}
       [quo/user-avatar
        {:full-name       display-name
+        :ring?           (not hide-ring?)
         :profile-picture photo-path
         :online?         online?
         :size            size}]]]))

--- a/src/status_im2/contexts/chat/messages/content/view.cljs
+++ b/src/status_im2/contexts/chat/messages/content/view.cljs
@@ -32,14 +32,17 @@
 
 (defn avatar-container
   [{:keys [content last-in-group? pinned-by quoted-message from]} show-reactions?
-   show-user-info? in-pinned-view?]
+   in-reaction-and-action-menu? in-pinned-view?]
   (if (or (and (seq (:response-to content))
                quoted-message)
           last-in-group?
           pinned-by
           (not show-reactions?)
-          show-user-info?)
-    [avatar/avatar {:public-key from :size :small :hide-ring? (or in-pinned-view? show-user-info?)}]
+          in-reaction-and-action-menu?)
+    [avatar/avatar
+     {:public-key from
+      :size       :small
+      :hide-ring? (or in-pinned-view? in-reaction-and-action-menu?)}]
     [rn/view {:padding-top 4 :width 32}]))
 
 (defn author
@@ -51,12 +54,12 @@
            from
            timestamp]}
    show-reactions?
-   show-user-info?]
+   in-reaction-and-action-menu?]
   (when (or (and (seq response-to) quoted-message)
             last-in-group?
             pinned-by
             (not show-reactions?)
-            show-user-info?)
+            in-reaction-and-action-menu?)
     (let [[primary-name secondary-name] (rf/sub [:contacts/contact-two-names-by-identity from])
           {:keys [ens-verified added?]} (rf/sub [:contacts/contact-by-address from])]
       [quo/author
@@ -112,7 +115,8 @@
 (defn- user-message-content-internal
   []
   (let [show-delivery-state? (reagent/atom false)]
-    (fn [{:keys [message-data context keyboard-shown? show-reactions? show-user-info? theme]}]
+    (fn [{:keys [message-data context keyboard-shown? show-reactions? in-reaction-and-action-menu?
+                 theme]}]
       (let [{:keys [content-type quoted-message content
                     outgoing outgoing-status pinned-by]} message-data
             first-image                                  (first (:album message-data))
@@ -164,7 +168,8 @@
           [rn/view
            {:style {:padding-horizontal 4
                     :flex-direction     :row}}
-           [avatar-container message-data show-reactions? show-user-info? (:in-pinned-view? context)]
+           [avatar-container message-data show-reactions? in-reaction-and-action-menu?
+            (:in-pinned-view? context)]
            (into
             (if show-reactions?
               [rn/view]
@@ -173,7 +178,7 @@
                       :flex        1
                       :max-height  (when-not show-reactions?
                                      (* 0.4 height))}}
-             [author message-data show-reactions? show-user-info?]
+             [author message-data show-reactions? in-reaction-and-action-menu?]
              (condp = content-type
                constants/content-type-text
                [content.text/text-content message-data context]
@@ -219,11 +224,11 @@
                  :selected-item (fn []
                                   [rn/view {:pointer-events :none}
                                    [user-message-content
-                                    {:message-data    message-data
-                                     :context         context
-                                     :keyboard-shown? keyboard-shown?
-                                     :show-reactions? true
-                                     :show-user-info? true}]])}]))
+                                    {:message-data                 message-data
+                                     :context                      context
+                                     :keyboard-shown?              keyboard-shown?
+                                     :show-reactions?              true
+                                     :in-reaction-and-action-menu? true}]])}]))
 
 (defn system-message?
   [content-type]

--- a/src/status_im2/contexts/chat/messages/content/view.cljs
+++ b/src/status_im2/contexts/chat/messages/content/view.cljs
@@ -31,14 +31,15 @@
 (def delivery-state-showing-time-ms 3000)
 
 (defn avatar-container
-  [{:keys [content last-in-group? pinned-by quoted-message from]} show-reactions? show-user-info?]
+  [{:keys [content last-in-group? pinned-by quoted-message from]} show-reactions?
+   show-user-info?]
   (if (or (and (seq (:response-to content))
                quoted-message)
           last-in-group?
           pinned-by
           (not show-reactions?)
           show-user-info?)
-    [avatar/avatar from :small]
+    [avatar/avatar {:public-key from :size :small :hide-ring? show-user-info?}]
     [rn/view {:padding-top 4 :width 32}]))
 
 (defn author

--- a/src/status_im2/contexts/chat/messages/content/view.cljs
+++ b/src/status_im2/contexts/chat/messages/content/view.cljs
@@ -32,14 +32,14 @@
 
 (defn avatar-container
   [{:keys [content last-in-group? pinned-by quoted-message from]} show-reactions?
-   show-user-info?]
+   show-user-info? in-pinned-view?]
   (if (or (and (seq (:response-to content))
                quoted-message)
           last-in-group?
           pinned-by
           (not show-reactions?)
           show-user-info?)
-    [avatar/avatar {:public-key from :size :small :hide-ring? show-user-info?}]
+    [avatar/avatar {:public-key from :size :small :hide-ring? (or in-pinned-view? show-user-info?)}]
     [rn/view {:padding-top 4 :width 32}]))
 
 (defn author
@@ -164,7 +164,7 @@
           [rn/view
            {:style {:padding-horizontal 4
                     :flex-direction     :row}}
-           [avatar-container message-data show-reactions? show-user-info?]
+           [avatar-container message-data show-reactions? show-user-info? (:in-pinned-view? context)]
            (into
             (if show-reactions?
               [rn/view]

--- a/src/status_im2/contexts/onboarding/identifiers/profile_card/style.cljs
+++ b/src/status_im2/contexts/onboarding/identifiers/profile_card/style.cljs
@@ -36,7 +36,7 @@
     :background-color :transparent
     :height           48
     :border-color     :black
-    :border-width     3
+    :border-width     2
     :border-radius    44}))
 
 (def picture-avatar-mask


### PR DESCRIPTION
fixes #17541
fixes #17529
fixes #17525
fixes #17516
fixes #17510


#17541 and #17516 are both wrong color in action menu issue
I found the color in the implementation is the same as Figma design
danger-50 for light theme `#E95460`
danger-60 for dark theme `#BA434D`
screenshots at https://github.com/status-im/status-mobile/issues/17516#issuecomment-1747921130 and https://github.com/status-im/status-mobile/issues/17541#issuecomment-1747944699


### Summary
recommend to review [commit by commit](https://github.com/status-im/status-mobile/pull/17548/commits)

1. remove avatar ident ring in long-press selected message [screenshot](https://github.com/status-im/status-mobile/issues/17510#issuecomment-1747928984)
1. remove avatar ident ring in message in pinned message view [screenshot](https://github.com/status-im/status-mobile/issues/17525#issuecomment-1747928319)
1. fix wrong border width for ring mask in onboarding identicon tab [screenshot](https://github.com/status-im/status-mobile/issues/17529#issuecomment-1747938874)
1. refactor: `show-user-info?` -> `in-reaction-and-action-menu?` in msg content 

status: ready <!-- Can be ready or wip -->