### PR TITLE
fix wrong counter color in jump-to screen

### DIFF
--- a/src/status_im2/contexts/shell/jump_to/components/bottom_tabs/view.cljs
+++ b/src/status_im2/contexts/shell/jump_to/components/bottom_tabs/view.cljs
@@ -1,10 +1,11 @@
 (ns status-im2.contexts.shell.jump-to.components.bottom-tabs.view
-  (:require [utils.re-frame :as rf]
+  (:require [quo2.core :as quo]
+            [quo2.theme :as theme]
+            [utils.re-frame :as rf]
             [react-native.core :as rn]
             [react-native.gesture :as gesture]
             [react-native.platform :as platform]
             [react-native.reanimated :as reanimated]
-            [quo2.core :as quo]
             [status-im2.contexts.shell.jump-to.utils :as utils]
             [status-im2.contexts.shell.jump-to.state :as state]
             [status-im2.contexts.shell.jump-to.animation :as animation]
@@ -58,14 +59,15 @@
                                                                         shared-values))]
     (utils/load-stack @state/selected-stack-id)
     (reanimated/set-shared-value (:pass-through? shared-values) pass-through?)
-    [reanimated/view
-     {:style (style/bottom-tabs-container pass-through? (:bottom-tabs-height shared-values))}
-     (when pass-through?
-       [reanimated/blur-view (blur-overlay-params bottom-tabs-blur-overlay-style)])
-     [rn/view {:style (style/bottom-tabs)}
-      [gesture/gesture-detector {:gesture communities-double-tab-gesture}
-       [bottom-tab :i/communities :communities-stack shared-values notifications-data]]
-      [gesture/gesture-detector {:gesture messages-double-tap-gesture}
-       [bottom-tab :i/messages :chats-stack shared-values notifications-data]]
-      [bottom-tab :i/wallet :wallet-stack shared-values notifications-data]
-      [bottom-tab :i/browser :browser-stack shared-values notifications-data]]]))
+    [theme/provider {:theme :dark}
+     [reanimated/view
+      {:style (style/bottom-tabs-container pass-through? (:bottom-tabs-height shared-values))}
+      (when pass-through?
+        [reanimated/blur-view (blur-overlay-params bottom-tabs-blur-overlay-style)])
+      [rn/view {:style (style/bottom-tabs)}
+       [gesture/gesture-detector {:gesture communities-double-tab-gesture}
+        [bottom-tab :i/communities :communities-stack shared-values notifications-data]]
+       [gesture/gesture-detector {:gesture messages-double-tap-gesture}
+        [bottom-tab :i/messages :chats-stack shared-values notifications-data]]
+       [bottom-tab :i/wallet :wallet-stack shared-values notifications-data]
+       [bottom-tab :i/browser :browser-stack shared-values notifications-data]]]]))

--- a/src/status_im2/contexts/shell/jump_to/components/bottom_tabs/view.cljs
+++ b/src/status_im2/contexts/shell/jump_to/components/bottom_tabs/view.cljs
@@ -1,7 +1,7 @@
 (ns status-im2.contexts.shell.jump-to.components.bottom-tabs.view
   (:require [quo2.core :as quo]
-            [quo2.theme :as theme]
             [utils.re-frame :as rf]
+            [quo2.theme :as quo.theme]
             [react-native.core :as rn]
             [react-native.gesture :as gesture]
             [react-native.platform :as platform]
@@ -59,7 +59,7 @@
                                                                         shared-values))]
     (utils/load-stack @state/selected-stack-id)
     (reanimated/set-shared-value (:pass-through? shared-values) pass-through?)
-    [theme/provider {:theme :dark}
+    [quo.theme/provider {:theme :dark}
      [reanimated/view
       {:style (style/bottom-tabs-container pass-through? (:bottom-tabs-height shared-values))}
       (when pass-through?


### PR DESCRIPTION
fixes: https://github.com/status-im/status-mobile/issues/17553

### Testing (Design)
In the design review, both the bottom nav and top bar counter color are reported as wrong, but I tried printing color and using a color picker and it looks like the top bar in the jump-to screen is using the right color. Maybe it is fixed in develop after release. Please let me know if this is not the case

status: ready