### PR TITLE
[Fix] SVG Icon color

### DIFF
--- a/src/quo2/components/icon.cljs
+++ b/src/quo2/components/icon.cljs
@@ -21,11 +21,15 @@
     ^{:key icon-name}
     (if-let [svg-icon (icons.svg/get-icon icon-name size)]
       [svg-icon
-       {:size                size
-        :color               (when (valid-color? color) color)
-        :color-2             (when (valid-color? color-2) color-2)
-        :accessibility-label accessibility-label
-        :style               container-style}]
+       (cond-> {:size                size
+                :accessibility-label accessibility-label
+                :style               container-style}
+
+         (and color (valid-color? color))
+         (assoc :color color)
+
+         (and color-2 (valid-color? color-2))
+         (assoc :color-2 color-2))]
       [rn/image
        {:style
         (merge {:width  size


### PR DESCRIPTION
fixes #17558

### Summary

This PR fixes the `X` mark in the `clear` icon displayed in inputs and URL preview components by updating the props for  `svg-icon` to add the `color` and `color-2` keys only if it's present and valid.

### Review notes

```clojure
:color   (when (valid-color? color) color)
:color-2 (when (valid-color? color-2) color-2)
```

The above code produces `nil`. values,  if `color` or `color-2` is not passed which in turn fails to use the fallback colors in the SVG (using `:or`).


### Testing notes

Testing the whole app is suggested as this updates the core icon component.

### Platforms

- Android
- iOS

### Steps to test

#### URL Preview Component

1. Open Status
2. Navigate to "quo2 preview > links > url-preview"

#### Input Component

1. Open Status
2. Navigate to "quo2 preview > inputs > input"
3. Enable `clearable?`


status: ready
