### PR TITLE
fix: chat over scroll

### DIFF
--- a/src/status_im2/contexts/chat/messages/list/view.cljs
+++ b/src/status_im2/contexts/chat/messages/list/view.cljs
@@ -292,6 +292,7 @@
      [rn/flat-list
       {:key-fn                            list-key-fn
        :ref                               list-ref
+       :bounces                           false
        :header                            [:<>
                                            [list-header insets (:able-to-send-message? context) theme]
                                            (when (= (:chat-type chat) constants/private-group-chat-type)


### PR DESCRIPTION
Fixes https://github.com/status-im/status-mobile/issues/17538

The chat screen bounces and shows the underlying parent view's background when a user over scrolls.

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

##### Functional

- 1-1 chats

status: ready 
