### PR TITLE
Composer - Link previews - Adjust for upcoming API breaking changes in status-go

### DIFF
--- a/src/status_im2/contexts/chat/composer/link_preview/events.cljs
+++ b/src/status_im2/contexts/chat/composer/link_preview/events.cljs
@@ -82,7 +82,7 @@
 
 (rf/defn unfurl-parsed-urls-success
   {:events [:link-preview/unfurl-parsed-urls-success]}
-  [{:keys [db]} request-id new-previews]
+  [{:keys [db]} request-id {new-previews :linkPreviews}]
   (when (= request-id (get-in db [:chat/link-previews :request-id]))
     (let [new-previews         (map data-store.messages/<-link-preview-rpc new-previews)
           curr-previews        (get-in db [:chat/link-previews :unfurled])

--- a/src/status_im2/contexts/chat/composer/link_preview/events_test.cljs
+++ b/src/status_im2/contexts/chat/composer/link_preview/events_test.cljs
@@ -139,7 +139,7 @@
                      {:request-id request-id
                       :unfurled   []
                       :cache      {}}}}]
-      (is (nil? (events/unfurl-parsed-urls-success cofx "banana" [preview-github])))))
+      (is (nil? (events/unfurl-parsed-urls-success cofx "banana" {:linkPreviews [preview-github]})))))
 
   (testing "reconciles new previews with existing ones"
     (let [cofx     {:db {:chat/link-previews
@@ -147,9 +147,10 @@
                           :unfurled   [preview-github
                                        {:url url-gitlab :loading? true}]
                           :cache      {url-github preview-github}}}}
-          {db :db} (events/unfurl-parsed-urls-success cofx
-                                                      request-id
-                                                      [preview-gitlab])]
+          {db :db} (events/unfurl-parsed-urls-success
+                    cofx
+                    request-id
+                    {:linkPreviews [preview-gitlab]})]
       (is (= {:chat/link-previews
               {:request-id request-id
                :unfurled   [preview-github preview-gitlab]
@@ -165,10 +166,11 @@
                                               preview-youtube
                                               {:url url-gitlab :loading? true}]
                                  :cache      {(:url preview-youtube) preview-youtube}}}}
-          {db :db}        (events/unfurl-parsed-urls-success cofx
-                                                             request-id
-                                                             [preview-github
-                                                              preview-youtube])]
+          {db :db}        (events/unfurl-parsed-urls-success
+                           cofx
+                           request-id
+                           {:linkPreviews [preview-github
+                                           preview-youtube]})]
       (is (= {:chat/link-previews
               {:request-id request-id
                :unfurled   [preview-github preview-youtube]

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.168.1",
-    "commit-sha1": "9034f0a984601d71e40d0aa846fbc5e4d01017cd",
-    "src-sha256": "1niics10a0p3dnlfr011sqf5prrjilv6kjplnc2c51q2pw6fv35h"
+    "version": "v0.170.0",
+    "commit-sha1": "aded258ccb68f88dc995e22f8b4e06157bb642db",
+    "src-sha256": "1wdc814yx6qam2ngrh119hm63bgjigqi4cpiawy2i0ywk47qwdbg"
 }


### PR DESCRIPTION
### Summary

This is a quick PR to adapt the JSON RPC response to the new shape returned by `wakuext_unfurlURLs`. There are no behavioral changes in the API as far as mobile is concerned at the moment.

The changes are being introduced by this status-go PR https://github.com/status-im/status-go/pull/4033. That PR is adding support for unfurling Status links, e.g. community links. On the mobile side, I'll be creating a couple issues next week to describe the work that needs to be done to support the new capabilities in status-go.

### Steps to test

Anything related to link previews is worth testing, but expect no changes whatsoever. Open any chat and type/paste URLs from websites such as Reddit, Wikipedia, etc. As noted above, Status links should be ignored because we haven't yet integrated with the new implementation in status-go.

status: ready
