### PR TITLE
feat: address (mocked) suggestions

### DIFF
--- a/src/quo/components/inputs/address_input/view.cljs
+++ b/src/quo/components/inputs/address_input/view.cljs
@@ -65,22 +65,23 @@
                  ens-regex address-regex
                  valid-ens-or-address?]}]
       (let [on-change              (fn [text]
-                                     (let [ens?     (when ens-regex
-                                                      (boolean (re-matches ens-regex text)))
-                                           address? (when address-regex
-                                                      (boolean (re-matches address-regex text)))]
-                                       (if (> (count text) 0)
-                                         (reset! status :typing)
-                                         (reset! status :active))
-                                       (reset! value text)
-                                       (when on-change-text
-                                         (on-change-text text))
-                                       (when (and ens? on-detect-ens)
-                                         (reset! status :loading)
-                                         (on-detect-ens text))
-                                       (when (and address? on-detect-address)
-                                         (reset! status :loading)
-                                         (on-detect-address text))))
+                                     (when (not= @value text)
+                                       (let [ens?     (when ens-regex
+                                                        (boolean (re-matches ens-regex text)))
+                                             address? (when address-regex
+                                                        (boolean (re-matches address-regex text)))]
+                                         (if (> (count text) 0)
+                                           (reset! status :typing)
+                                           (reset! status :active))
+                                         (reset! value text)
+                                         (when on-change-text
+                                           (on-change-text text))
+                                         (when (and ens? on-detect-ens)
+                                           (reset! status :loading)
+                                           (on-detect-ens text))
+                                         (when (and address? on-detect-address)
+                                           (reset! status :loading)
+                                           (on-detect-address text)))))
             on-paste               (fn []
                                      (clipboard/get-string
                                       (fn [clipboard]
@@ -90,6 +91,8 @@
             on-clear               (fn []
                                      (reset! value "")
                                      (reset! status (if @focused? :active :default))
+                                     (when on-change-text
+                                       (on-change-text ""))
                                      (when on-clear
                                        (on-clear)))
             on-scan                #(when on-scan
@@ -119,6 +122,7 @@
            :auto-complete          (when platform/ios? :none)
            :auto-capitalize        :none
            :auto-correct           false
+           :spell-check            false
            :keyboard-appearance    (quo.theme/theme-value :light :dark theme)
            :on-focus               on-focus
            :on-blur                on-blur

--- a/src/quo/components/list_items/address/style.cljs
+++ b/src/quo/components/list_items/address/style.cljs
@@ -31,4 +31,5 @@
    :align-items    :center})
 
 (def account-container
-  {:margin-left 8})
+  {:margin-left   8
+   :padding-right 56})

--- a/src/quo/components/list_items/address/view.cljs
+++ b/src/quo/components/list_items/address/view.cljs
@@ -1,13 +1,13 @@
 (ns quo.components.list-items.address.view
   (:require
-    [clojure.string :as string]
     [quo.components.avatars.wallet-user-avatar.view :as wallet-user-avatar]
     [quo.components.list-items.address.style :as style]
     [quo.components.markdown.text :as text]
     [quo.foundations.colors :as colors]
     [quo.theme :as quo.theme]
     [react-native.core :as rn]
-    [reagent.core :as reagent]))
+    [reagent.core :as reagent]
+    [utils.address :as address]))
 
 (defn- left-container
   [{:keys [theme address networks blur?]}]
@@ -25,7 +25,8 @@
             [text/text
              {:size   :paragraph-1
               :weight :semi-bold
-              :style  {:color (colors/resolve-color network)}} (str (subs (name network) 0 3) ":")])
+              :style  {:color (colors/resolve-color network theme)}}
+             (str (subs (name network) 0 3) ":")])
           networks)
      [text/text
       {:size   :paragraph-1
@@ -33,7 +34,7 @@
        :style  {:color (if blur?
                          colors/white
                          (colors/theme-colors colors/neutral-100 colors/white theme))}}
-      (string/replace address "x" "×")]]]])
+      (address/get-shortened-key address)]]]])
 
 (defn- internal-view
   []
@@ -60,6 +61,7 @@
          [left-container
           {:theme    theme
            :networks networks
-           :address  address}]]))))
+           :address  address
+           :blur?    blur?}]]))))
 
 (def view (quo.theme/with-theme internal-view))

--- a/src/quo/components/list_items/saved_address/component_spec.cljs
+++ b/src/quo/components/list_items/saved_address/component_spec.cljs
@@ -13,7 +13,7 @@
     (h/render [saved-address/view])
     (h/fire-event :on-press-in (h/get-by-label-text :container))
     (h/wait-for #(h/has-style (h/query-by-label-text :container)
-                              {:backgroundColor (colors/custom-color :blue 50 5)})))
+                              {:backgroundColor (colors/resolve-color :blue :light 5)})))
 
   (h/test "on-press-in changes state to :pressed with blur? enabled"
     (h/render [saved-address/view {:blur? true}])
@@ -22,24 +22,25 @@
                               {:backgroundColor colors/white-opa-5})))
 
   (h/test "on-press-out changes state to :active"
-    (h/render [saved-address/view])
+    (h/render [saved-address/view {:active-state? true}])
     (h/fire-event :on-press-in (h/get-by-label-text :container))
     (h/fire-event :on-press-out (h/get-by-label-text :container))
     (h/wait-for #(h/has-style (h/query-by-label-text :container)
-                              {:backgroundColor (colors/custom-color :blue 50 10)})))
+                              {:backgroundColor (colors/resolve-color :blue :light 10)})))
 
   (h/test "on-press-out changes state to :active with blur? enabled"
-    (h/render [saved-address/view {:blur? true}])
+    (h/render [saved-address/view
+               {:blur?         true
+                :active-state? true}])
     (h/fire-event :on-press-in (h/get-by-label-text :container))
     (h/fire-event :on-press-out (h/get-by-label-text :container))
     (h/wait-for #(h/has-style (h/query-by-label-text :container)
                               {:backgroundColor colors/white-opa-10})))
 
-  (h/test "on-press-out calls on-press"
+  (h/test "on-press container calls on-press"
     (let [on-press (h/mock-fn)]
       (h/render [saved-address/view {:on-press on-press}])
-      (h/fire-event :on-press-in (h/get-by-label-text :container))
-      (h/fire-event :on-press-out (h/get-by-label-text :container))
+      (h/fire-event :on-press (h/get-by-label-text :container))
       (h/was-called on-press)))
 
   (h/test "renders options button if type :action"

--- a/src/quo/components/list_items/saved_address/view.cljs
+++ b/src/quo/components/list_items/saved_address/view.cljs
@@ -8,19 +8,20 @@
     [quo.foundations.colors :as colors]
     [quo.theme :as quo.theme]
     [react-native.core :as rn]
-    [reagent.core :as reagent]))
+    [reagent.core :as reagent]
+    [utils.address :as address]))
 
 (defn- left-container
-  [{:keys [blur? theme name address customization-color]}]
+  [{:keys [blur? theme name ens address customization-color]}]
   (let [names      (remove string/blank? (string/split name " "))
         first-name (if (> (count names) 0) (first names) "")
         last-name  (if (> (count names) 1) (last names) "")]
     [rn/view {:style style/left-container}
      [wallet-user-avatar/wallet-user-avatar
-      {:size   :medium
-       :f-name first-name
-       :l-name last-name
-       :color  customization-color}]
+      {:size                :medium
+       :f-name              first-name
+       :l-name              last-name
+       :customization-color customization-color}]
      [rn/view {:style style/account-container}
       [text/text
        {:weight :semi-bold
@@ -32,7 +33,7 @@
         {:size   :paragraph-2
          :weight :monospace
          :style  (style/account-address blur? theme)}
-        address]]]]))
+        (or ens (address/get-shortened-key address))]]]]))
 
 (defn- internal-view
   []
@@ -42,39 +43,39 @@
         on-press-in (fn []
                       (when-not (= @state :selected)
                         (reset! timer (js/setTimeout #(reset! state :pressed) 100))))]
-    (fn [{:keys [blur? user-props customization-color
+    (fn [{:keys [blur? user-props active-state? customization-color
                  on-press
                  on-options-press
                  theme]
           :or   {customization-color :blue
                  blur?               false}}]
       (let [on-press-out (fn []
-                           (let [new-state (if @active? :default :active)]
+                           (let [new-state (if (or (not active-state?) @active?) :default :active)]
                              (when @timer (js/clearTimeout @timer))
                              (reset! timer nil)
                              (reset! active? (= new-state :active))
-                             (reset! state new-state)
-                             (when on-press
-                               (on-press))))]
+                             (reset! state new-state)))]
         [rn/pressable
          {:style               (style/container
                                 {:state @state :blur? blur? :customization-color customization-color})
           :on-press-in         on-press-in
           :on-press-out        on-press-out
+          :on-press            on-press
           :accessibility-label :container}
          [left-container
           {:blur?               blur?
            :theme               theme
            :name                (:name user-props)
+           :ens                 (:ens user-props)
            :address             (:address user-props)
-           :customization-color (:customization-color user-props)}]
-         [rn/pressable
-          {:accessibility-label :options-button
-           :on-press            #(when on-options-press
-                                   (on-options-press))}
-          [icon/icon :i/options
-           {:color (if blur?
-                     colors/white-opa-70
-                     (colors/theme-colors colors/neutral-50 colors/neutral-40 theme))}]]]))))
+           :customization-color (or (:customization-color user-props) :blue)}]
+         (when on-options-press
+           [rn/pressable
+            {:accessibility-label :options-button
+             :on-press            on-options-press}
+            [icon/icon :i/options
+             {:color (if blur?
+                       colors/white-opa-70
+                       (colors/theme-colors colors/neutral-50 colors/neutral-40 theme))}]])]))))
 
 (def view (quo.theme/with-theme internal-view))

--- a/src/quo/components/list_items/saved_contact_address/view.cljs
+++ b/src/quo/components/list_items/saved_contact_address/view.cljs
@@ -9,6 +9,7 @@
     [quo.theme :as quo.theme]
     [react-native.core :as rn]
     [reagent.core :as reagent]
+    [utils.address :as address]
     [utils.i18n :as i18n]))
 
 (defn- account
@@ -30,7 +31,7 @@
     {:size   :paragraph-2
      :weight :monospace
      :style  (style/account-address theme)}
-    address]])
+    (address/get-shortened-key address)]])
 
 (defn- internal-view
   []

--- a/src/status_im2/constants.cljs
+++ b/src/status_im2/constants.cljs
@@ -185,6 +185,7 @@
 (def regx-address #"^0x[a-fA-F0-9]{40}$")
 (def regx-address-contains #"(?i)0x[a-fA-F0-9]{40}")
 (def regx-starts-with-uuid #"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}")
+(def regx-address-fragment #"^0x[a-fA-F0-9]{1,40}$")
 
 (def ^:const dapp-permission-contact-code "contact-code")
 (def ^:const dapp-permission-web3 "web3")

--- a/src/status_im2/contexts/wallet/item_types.cljs
+++ b/src/status_im2/contexts/wallet/item_types.cljs
@@ -1,0 +1,13 @@
+(ns status-im2.contexts.wallet.item-types)
+
+(def ^:const no-type 0)
+(def ^:const account 1)
+(def ^:const saved-address 2)
+(def ^:const address 3)
+(def ^:const saved-contact-address 4)
+
+(def ^:const all-supported
+  #{account
+    saved-address
+    address
+    saved-contact-address})

--- a/src/status_im2/contexts/wallet/send/select_address/style.cljs
+++ b/src/status_im2/contexts/wallet/send/select_address/style.cljs
@@ -21,3 +21,8 @@
   {:justify-content :center
    :flex            1
    :margin-bottom   44})
+
+(def button
+  {:justify-self      :flex-end
+   :margin-bottom     46
+   :margin-horizontal 20})

--- a/src/status_im2/contexts/wallet/send/select_address/view.cljs
+++ b/src/status_im2/contexts/wallet/send/select_address/view.cljs
@@ -1,12 +1,15 @@
 (ns status-im2.contexts.wallet.send.select-address.view
   (:require
     [quo.core :as quo]
+    [quo.foundations.colors :as colors]
     [quo.theme :as quo.theme]
     [react-native.core :as rn]
     [react-native.safe-area :as safe-area]
     [reagent.core :as reagent]
     [status-im2.constants :as constants]
+    [status-im2.contexts.wallet.item-types :as types]
     [status-im2.contexts.wallet.send.select-address.style :as style]
+    [utils.debounce :as debounce]
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]))
 
@@ -41,70 +44,150 @@
                        :container-style style/empty-container-style}]))
 
 (defn- address-input
-  []
-  (let [timer                    (atom nil)
-        valid-ens-or-address?    (reagent/atom false)
-        input-value              (atom "")
-        on-detect-address-or-ens (fn [_]
-                                   (reset! valid-ens-or-address? false)
-                                   (when @timer (js/clearTimeout @timer))
-                                   (reset! timer (js/setTimeout #(reset! valid-ens-or-address? true)
-                                                                2000)))]
-    (fn []
-      (let [scanned-address (rf/sub [:wallet/scanned-address])]
-        [quo/address-input
-         {:on-scan               #(rf/dispatch [:open-modal :scan-address])
-          :ens-regex             constants/regx-ens
-          :address-regex         constants/regx-address
-          :scanned-value         scanned-address
-          :on-detect-ens         on-detect-address-or-ens
-          :on-detect-address     on-detect-address-or-ens
-          :on-change-text        (fn [text]
+  [input-value input-focused?]
+  (fn []
+    (let [scanned-address       (rf/sub [:wallet/scanned-address])
+          send-address          (rf/sub [:wallet/send-address])
+          valid-ens-or-address? (boolean (rf/sub [:wallet/valid-ens-or-address?]))]
+      [quo/address-input
+       {:on-focus              #(reset! input-focused? true)
+        :on-blur               #(reset! input-focused? false)
+        :on-scan               (fn []
+                                 (rn/dismiss-keyboard!)
+                                 (rf/dispatch [:open-modal :scan-address]))
+        :ens-regex             constants/regx-ens
+        :address-regex         constants/regx-address
+        :scanned-value         (or send-address scanned-address)
+        :on-detect-ens         #(debounce/debounce-and-dispatch
+                                 [:wallet/validate-ens %]
+                                 300)
+        :on-detect-address     #(debounce/debounce-and-dispatch
+                                 [:wallet/validate-address %]
+                                 300)
+        :on-change-text        (fn [text]
+                                 (let [starts-like-eth-address (re-matches
+                                                                constants/regx-address-fragment
+                                                                text)]
                                    (when-not (= scanned-address text)
                                      (rf/dispatch [:wallet/clean-scanned-address]))
-                                   (reset! input-value text))
-          :on-clear              #(rf/dispatch [:wallet/clean-scanned-address])
-          :valid-ens-or-address? @valid-ens-or-address?}]))))
+                                   (if starts-like-eth-address
+                                     (rf/dispatch [:wallet/fetch-address-suggestions text])
+                                     (rf/dispatch [:wallet/clean-local-suggestions]))
+                                   (reset! input-value text)))
+        :valid-ens-or-address? valid-ens-or-address?}])))
+
+(defn- ens-linked-address
+  [{:keys [address networks theme]}]
+  [quo/text
+   {:size  :paragraph-2
+    :style {:padding-horizontal 12
+            :padding-top        4}}
+   (map (fn [network]
+          ^{:key (str network)}
+          [quo/text
+           {:size  :paragraph-2
+            :style {:color (colors/resolve-color network theme)}}
+           (str (subs (name network) 0 3) ":")])
+        networks)
+   [quo/text
+    {:size   :paragraph-2
+     :weight :monospace
+     :style  {:color (colors/theme-colors colors/neutral-100 colors/white theme)}}
+    address]])
+
+(defn- suggestion-component
+  []
+  (fn [{:keys [type ens address accounts] :as local-suggestion} _ _ _]
+    (let [props {:on-press      (fn []
+                                  (let [address (if accounts (:address (first accounts)) address)]
+                                    (when-not ens (rf/dispatch [:wallet/select-send-address address]))))
+                 :active-state? false}]
+      (cond
+        (= type types/saved-address)
+        [quo/saved-address (merge props {:user-props local-suggestion})]
+        (= type types/saved-contact-address)
+        [quo/saved-contact-address (merge props local-suggestion)]
+        (and (not ens) (= type types/address))
+        [quo/address (merge props local-suggestion)]
+        (and ens (= type types/address))
+        [ens-linked-address local-suggestion]
+        :else nil))))
+
+(defn- local-suggestions-list
+  []
+  (fn []
+    (let [local-suggestion (rf/sub [:wallet/local-suggestions])]
+      [rn/view {:style {:flex 1}}
+       [rn/flat-list
+        {:data                         local-suggestion
+         :content-container-style      {:flex-grow 1}
+         :key-fn                       :id
+         :on-scroll-to-index-failed    identity
+         :keyboard-should-persist-taps :handled
+         :render-fn                    suggestion-component}]])))
 
 (defn- f-view-internal
   []
-  (let [margin-top    (safe-area/get-top)
-        selected-tab  (reagent/atom (:id (first tabs-data)))
-        on-close      #(rf/dispatch [:dismiss-modal :wallet-select-address])
-        on-change-tab #(reset! selected-tab %)]
+  (let [margin-top     (safe-area/get-top)
+        selected-tab   (reagent/atom (:id (first tabs-data)))
+        on-close       #(rf/dispatch [:navigate-back])
+        on-change-tab  #(reset! selected-tab %)
+        input-value    (reagent/atom "")
+        input-focused? (reagent/atom false)]
     (fn []
-      (rn/use-effect (fn [] #(rf/dispatch [:wallet/clean-scanned-address])))
-      [rn/scroll-view
-       {:content-container-style      (style/container margin-top)
-        :keyboard-should-persist-taps :never
-        :scroll-enabled               false}
-       [quo/page-nav
-        {:icon-name           :i/close
-         :on-press            on-close
-         :accessibility-label :top-bar
-         :right-side          :account-switcher
-         :account-switcher    {:customization-color :purple
-                               :on-press            #(js/alert "Not implemented yet")
-                               :state               :default
-                               :emoji               "🍑"}}]
-       [quo/text-combinations
-        {:title                     (i18n/label :t/send-to)
-         :container-style           style/title-container
-         :title-accessibility-label :title-label}]
-       [address-input]
-       [quo/divider-line]
-       [quo/tabs
-        {:style            style/tabs
-         :container-style  style/tabs-content
-         :size             32
-         :default-active   @selected-tab
-         :data             tabs-data
-         :scrollable?      true
-         :scroll-on-press? true
-         :on-change        on-change-tab}]
-       [tab-view @selected-tab]])))
+      (let [valid-ens-or-address? (boolean (rf/sub [:wallet/valid-ens-or-address?]))]
+        (rn/use-effect (fn []
+                         (fn []
+                           (rf/dispatch [:wallet/clean-scanned-address])
+                           (rf/dispatch [:wallet/clean-local-suggestions]))))
+        [rn/scroll-view
+         {:content-container-style      (style/container margin-top)
+          :keyboard-should-persist-taps :handled
+          :scroll-enabled               false}
+         [quo/page-nav
+          {:icon-name           :i/close
+           :on-press            on-close
+           :accessibility-label :top-bar
+           :right-side          :account-switcher
+           :account-switcher    {:customization-color :purple
+                                 :on-press            #(js/alert "Not implemented yet")
+                                 :state               :default
+                                 :emoji               "🍑"}}]
+         [quo/text-combinations
+          {:title                     (i18n/label :t/send-to)
+           :container-style           style/title-container
+           :title-accessibility-label :title-label}]
+         [address-input input-value input-focused?]
+         [quo/divider-line]
+         (if (or @input-focused? (> (count @input-value) 0))
+           [rn/keyboard-avoiding-view
+            {:style                    {:flex 1}
+             :keyboard-vertical-offset 26}
+            [rn/view
+             {:style {:flex    1
+                      :padding 8}}
+             [local-suggestions-list]]
+            (when (> (count @input-value) 0)
+              [quo/button
+               {:accessibility-label :continue-button
+                :type                :primary
+                :disabled?           (not valid-ens-or-address?)
+                :container-style     style/button
+                :on-press            #(js/alert "Not implemented yet")}
+               (i18n/label :t/continue)])]
+           [:<>
+            [quo/tabs
+             {:style            style/tabs
+              :container-style  style/tabs-content
+              :size             32
+              :default-active   @selected-tab
+              :data             tabs-data
+              :scrollable?      true
+              :scroll-on-press? true
+              :on-change        on-change-tab}]
+            [tab-view @selected-tab]])]))))
 
-(defn view-internal
+(defn- view-internal
   []
   [:f> f-view-internal])
 

--- a/src/status_im2/contexts/wallet/temp.cljs
+++ b/src/status_im2/contexts/wallet/temp.cljs
@@ -1,0 +1,46 @@
+(ns status-im2.contexts.wallet.temp
+  (:require [clojure.string :as string]
+            [status-im2.common.resources :as resources]
+            [status-im2.contexts.wallet.item-types :as types]))
+
+(def ens-local-suggestion-saved-address-mock
+  {:type     types/saved-address
+   :name     "Pedro"
+   :ens      "pedro.eth"
+   :address  "0x4732894732894738294783294723894723984"
+   :networks [:ethereum :optimism]})
+
+(def ens-local-suggestion-mock
+  {:type     types/address
+   :ens      "pedro.eth"
+   :address  "0x4732894732894738294783294723894723984"
+   :networks [:ethereum :optimism]})
+
+(def address-local-suggestion-saved-contact-address-mock
+  {:type                types/saved-contact-address
+   :customization-color :blue
+   :accounts            [{:name                "New House"
+                          :address             "0x62cf6E0Ba4C4530735616e1Ee7ff5FbCB726fBd2"
+                          :emoji               "🍔"
+                          :customization-color :blue}]
+   :contact-props       {:full-name           "Mark Libot"
+                         :profile-picture     (resources/get-mock-image :user-picture-male4)
+                         :customization-color :purple}})
+
+(def address-local-suggestion-saved-address-mock
+  {:type                types/saved-address
+   :name                "Peter Lamborginski"
+   :address             "0x12FaBc34De56Ef78A9B0Cd12Ef3456AbC7D8E9F0"
+   :customization-color :magenta
+   :networks            [:ethereum :optimism]})
+
+(def address-local-suggestion-mock
+  {:type     types/address
+   :address  "0x1233cD34De56Ef78A9B0Cd12Ef3456AbC7123dee"
+   :networks [:ethereum :optimism]})
+
+(defn find-matching-addresses
+  [substring]
+  (let [all-addresses [address-local-suggestion-saved-address-mock
+                       address-local-suggestion-mock]]
+    (vec (filter #(string/starts-with? (:address %) substring) all-addresses))))

--- a/src/status_im2/subs/root.cljs
+++ b/src/status_im2/subs/root.cljs
@@ -156,6 +156,10 @@
 (reg-root-key-sub :wallet/scanned-address :wallet/scanned-address)
 (reg-root-key-sub :wallet/create-account :wallet/create-account)
 (reg-root-key-sub :wallet/networks :wallet/networks)
+(reg-root-key-sub :wallet/scanned-address :wallet/scanned-address)
+(reg-root-key-sub :wallet/local-suggestions :wallet/local-suggestions)
+(reg-root-key-sub :wallet/valid-ens-or-address? :wallet/valid-ens-or-address?)
+(reg-root-key-sub :wallet/send-address :wallet/send-address)
 
 ;;debug
 (when js/goog.DEBUG


### PR DESCRIPTION
fixes #16912 

### Summary

Implement address suggestions with mocked data (backend integration pending)

#### Results

https://github.com/status-im/status-mobile/assets/18485527/7de4d8bb-e8f5-4384-803c-bd6954fb3d9c

https://github.com/status-im/status-mobile/assets/18485527/53b2f807-bca8-451c-a522-1ad77384b9d2

https://github.com/status-im/status-mobile/assets/18485527/4eb80b85-f2b4-442a-ab34-86b2593b70eb

#### Platforms

- Android
- iOS

### Steps to test

- Open Status
- Login
- go to new wallet
- Enter an account
- Tap on Send
- Start typing in the address input, scanning QR or pasting and verify correct behavior of the suggestions, taking in mind it works with mocked data and is not integrated with status-go yet

#### Some testing material

###### Saved contact address QR (Mark Libot)
![](https://github.com/status-im/status-mobile/assets/18485527/c7c4d302-828f-44b4-a653-71f68a261f67)

###### Saved address QR (Peter Lamborginski)
![](https://github.com/status-im/status-mobile/assets/18485527/0f4ae870-cc13-43e8-a6fd-2915fc45c3a4)

###### Address QR (0x1233...dee)
![](https://github.com/status-im/status-mobile/assets/18485527/886596bc-e220-4446-ac99-ab186468f1b3)

###### Addresses that start similar to test suggestions while typing
- 0x12FaBc34De56Ef78A9B0Cd12Ef3456AbC7D8E9F0
- 0x1233cD34De56Ef78A9B0Cd12Ef3456AbC7123dee

###### ENS with saved address
- pedro.eth

###### ENS with no saved address
- peter.eth
- Or any other ENS that is not `pedro.eth`

Take in mind this PR does not have backend integration so results are mocked and results will be always the same

status: ready