### PR TITLE
Wallet activity design followup fixes

### DIFF
--- a/src/quo2/components/wallet/wallet_activity/style.cljs
+++ b/src/quo2/components/wallet/wallet_activity/style.cljs
@@ -33,11 +33,14 @@
   [theme blur?]
   {:border-width       1
    :border-radius      6
-   :margin-right       8
+   :margin-right       4
    :padding-horizontal 2
    :border-color       (if-not blur?
                          (colors/theme-colors colors/neutral-20 colors/neutral-80 theme)
                          colors/white-opa-10)})
+
+(def timestamp-container
+  {:margin-left 4})
 
 (defn timestamp
   [theme blur?]

--- a/src/quo2/components/wallet/wallet_activity/view.cljs
+++ b/src/quo2/components/wallet/wallet_activity/view.cljs
@@ -56,7 +56,7 @@
         :size   :label
         :style  (style/transaction-counter theme)}
        (i18n/label :t/x-counter {:counter counter})]])
-   [rn/view
+   [rn/view {:style style/timestamp-container}
     [text/text
      {:weight :regular
       :size   :label

--- a/src/status_im2/contexts/quo_preview/wallet/wallet_activity.cljs
+++ b/src/status_im2/contexts/quo_preview/wallet/wallet_activity.cljs
@@ -45,6 +45,12 @@
    :full-name       "Aretha Gosling"
    :profile-picture (resources/mock-images :user-picture-female2)})
 
+(def jessica-stewart
+  {:size            24
+   :type            :default
+   :full-name       "Jessica Stewart"
+   :profile-picture (resources/mock-images :user-picture-female2)})
+
 (def james-bond
   {:size            24
    :type            :default
@@ -101,6 +107,8 @@
     :value "Account: Piggy bank"}
    {:key   aretha-gosling
     :value "Person: Aretha Gosling"}
+   {:key   jessica-stewart
+    :value "Person: Jessica Stewart"}
    {:key   james-bond
     :value "Person: James Bond"}
    {:key   mainnet


### PR DESCRIPTION
fixes #17264

### Summary

Wallet activity component slightly fixed to match designs, [per design followup](https://www.figma.com/file/Tf5nfkYvpbnNCo4rKLK7lS/Feedback-for-Mobile?type=design&node-id=3446%3A227419&mode=design&t=fpP8PGxy1uzPvXIk-1).

### Design notes

Overlapping comparison after fixes. There is a difference in comma between "1500 SNT" vs "1,500 SNT", but it is a potential issue of a `context-tag` component.

![Screenshot 2023-10-09 at 15 21 16](https://github.com/status-im/status-mobile/assets/5786310/9b20f5b3-fe1d-4da6-bc7d-5ee1a8bda056)

![Screenshot 2023-10-09 at 15 22 23](https://github.com/status-im/status-mobile/assets/5786310/82f6d330-fcab-4aca-acdd-e338210cd32b)




status: ready
