### PR TITLE
[#17446] fix: Display name is not shown in chats after sync

### DIFF
--- a/src/status_im/multiaccounts/core.cljs
+++ b/src/status_im/multiaccounts/core.cljs
@@ -41,13 +41,16 @@
 
 (defn contact-two-names-by-identity
   [contact profile contact-identity]
-  (let [me? (= (:public-key profile) contact-identity)]
+  (let [{:keys [public-key preferred-name display-name]} profile
+        {:keys [primary-name secondary-name]}            contact
+        me?                                              (= public-key contact-identity)]
     (if me?
-      [(or (:preferred-name profile)
-           (:display-name profile)
-           (:primary-name contact)
-           (gfycat/generate-gfy contact-identity))]
-      [(:primary-name contact) (:secondary-name contact)])))
+      [(cond
+         (not (string/blank? preferred-name)) preferred-name
+         (not (string/blank? display-name))   display-name
+         (not (string/blank? primary-name))   primary-name
+         :else                                (gfycat/generate-gfy contact-identity))]
+      [primary-name secondary-name])))
 
 (defn displayed-photo
   [{:keys [images]}]


### PR DESCRIPTION
fixes #17446

Display name is not shown in chats after sync

### Steps to test

- Device 1 generates sync QR
- Device 2 scans QR > finish sync
- Device 2: send message to any community

### Result 

https://github.com/status-im/status-mobile/assets/71308738/9cbde03f-8e53-4eb5-b466-ae74267bf132


status: ready
