### PR TITLE
Tiny tag component feature #17341

### DIFF
--- a/src/quo2/components/tags/tiny_tag/component_spec.cljs
+++ b/src/quo2/components/tags/tiny_tag/component_spec.cljs
@@ -1,0 +1,15 @@
+(ns quo2.components.tags.tiny-tag.component-spec
+  (:require [quo2.components.tags.tiny-tag.view :as tiny-tag]
+            [test-helpers.component :as h]))
+
+(h/describe "Tiny tag component test"
+  (h/test "1,000 SNT render"
+    (h/render [tiny-tag/view
+               {:label "1,000 SNT"
+                :blur? false}])
+    (h/is-truthy (h/get-by-text "1,000 SNT")))
+  (h/test "2,000 SNT render with blur"
+    (h/render [tiny-tag/view
+               {:label "2,000 SNT"
+                :blur? true}])
+    (h/is-truthy (h/get-by-text "2,000 SNT"))))

--- a/src/quo2/components/tags/tiny_tag/style.cljs
+++ b/src/quo2/components/tags/tiny_tag/style.cljs
@@ -1,0 +1,33 @@
+(ns quo2.components.tags.tiny-tag.style
+  (:require [quo2.foundations.colors :as colors]))
+
+(defn get-border-color
+  [blur? theme]
+  (if blur?
+    (colors/theme-colors colors/neutral-80-opa-5 colors/white-opa-10 theme)
+    (colors/theme-colors colors/neutral-20 colors/neutral-80 theme)))
+
+(defn get-label-color
+  [blur? theme]
+  (if blur?
+    (colors/theme-colors colors/neutral-80-opa-70 colors/white-opa-70 theme)
+    (colors/theme-colors colors/neutral-50 colors/neutral-40 theme)))
+
+(def main
+  {:justify-content :center
+   :align-items     :center
+   :height          16})
+
+(defn inner
+  [{:keys [blur? theme]}]
+  {:border-width    1
+   :border-radius   6
+   :border-color    (get-border-color blur? theme)
+   :justify-content :center
+   :align-items     :center
+   :padding-left    2
+   :padding-right   3})
+
+(defn label
+  [{:keys [blur? theme]}]
+  {:color (get-label-color blur? theme)})

--- a/src/quo2/components/tags/tiny_tag/view.cljs
+++ b/src/quo2/components/tags/tiny_tag/view.cljs
@@ -1,0 +1,17 @@
+(ns quo2.components.tags.tiny-tag.view
+  (:require [quo2.components.markdown.text :as text]
+            [quo2.theme :as quo.theme]
+            [quo2.components.tags.tiny-tag.style :as style]
+            [react-native.core :as rn]))
+
+(defn- view-internal
+  [{:keys [label] :as props}]
+  [rn/view {:style style/main}
+   [rn/view {:style (style/inner props)}
+    [text/text
+     {:style  (style/label props)
+      :weight :medium
+      :size   :label
+      :align  :center} label]]])
+
+(def view (quo.theme/with-theme view-internal))

--- a/src/quo2/core.cljs
+++ b/src/quo2/core.cljs
@@ -127,6 +127,7 @@
     quo2.components.tags.status-tags
     quo2.components.tags.tag
     quo2.components.tags.tags
+    quo2.components.tags.tiny-tag.view
     quo2.components.tags.token-tag
     quo2.components.text-combinations.view
     quo2.components.wallet.account-card.view
@@ -353,6 +354,7 @@
 (def status-tag quo2.components.tags.status-tags/status-tag)
 (def tag quo2.components.tags.tag/tag)
 (def tags quo2.components.tags.tags/tags)
+(def tiny-tag quo2.components.tags.tiny-tag.view/view)
 (def token-tag quo2.components.tags.token-tag/tag)
 
 ;;;; Text combinations

--- a/src/status_im2/contexts/quo_preview/main.cljs
+++ b/src/status_im2/contexts/quo_preview/main.cljs
@@ -146,6 +146,7 @@
     [status-im2.contexts.quo-preview.tags.permission-tag :as permission-tag]
     [status-im2.contexts.quo-preview.tags.status-tags :as status-tags]
     [status-im2.contexts.quo-preview.tags.tags :as tags]
+    [status-im2.contexts.quo-preview.tags.tiny-tag :as tiny-tag]
     [status-im2.contexts.quo-preview.tags.token-tag :as token-tag]
     [status-im2.contexts.quo-preview.text-combinations.preview :as
      text-combinations]
@@ -420,6 +421,8 @@
                         :component status-tags/preview-status-tags}
                        {:name      :tags
                         :component tags/preview-tags}
+                       {:name      :tiny-tag
+                        :component tiny-tag/preview-tiny-tag}
                        {:name      :token-tag
                         :component token-tag/preview-token-tag}]
    :text-combinations [{:name      :text-combinations

--- a/src/status_im2/contexts/quo_preview/tags/tiny_tag.cljs
+++ b/src/status_im2/contexts/quo_preview/tags/tiny_tag.cljs
@@ -1,0 +1,26 @@
+(ns status-im2.contexts.quo-preview.tags.tiny-tag
+  (:require [quo2.core :as quo]
+            [react-native.core :as rn]
+            [reagent.core :as reagent]
+            [status-im2.contexts.quo-preview.preview :as preview]))
+
+(def descriptor
+  [{:label "Blur?"
+    :key   :blur?
+    :type  :boolean}
+   {:label "Label"
+    :key   :label
+    :type  :text}])
+
+(defn preview-tiny-tag
+  []
+  (let [state (reagent/atom {:blur? false
+                             :label "1,000 SNT"})]
+    (fn []
+      [preview/preview-container
+       {:state                 state
+        :descriptor            descriptor
+        :blur?                 (:blur? @state)
+        :show-blur-background? true}
+       [rn/view {:style {:align-items :center}}
+        [quo/tiny-tag @state]]])))


### PR DESCRIPTION
Fixes #17341

### Summary


### Review notes
Skips this part - https://github.com/status-im/status-mobile/issues/17341#issuecomment-1734738140

### Testing notes
Tested only in iOS simulator

#### Platforms
- Android
- iOS

### Before and after screenshots comparison
[Link to figma](https://www.figma.com/file/WQZcp6S0EnzxdTL4taoKDv/Design-System-for-Mobile?type=design&node-id=22562-203907&mode=design&t=FLdnfT1abM1btBM2-4)

| Figma | 
| --- |
|![](https://user-images.githubusercontent.com/18485527/269052376-4acd12b3-e058-4fa7-9b5b-fcce18ef0364.png)
| iOS |
|<img width="141" alt="Screenshot 2023-10-10 at 15 41 50" src="https://github.com/status-im/status-mobile/assets/10757633/2660bb5d-fe43-4ea1-9f39-bce2064425d8"><img width="85" alt="Screenshot 2023-10-10 at 15 41 59" src="https://github.com/status-im/status-mobile/assets/10757633/28a74f80-f3bd-4d43-8fa0-43416cd384a9"><img width="79" alt="Screenshot 2023-10-10 at 15 42 06" src="https://github.com/status-im/status-mobile/assets/10757633/0d37b903-d889-4e27-a118-cbe41ae5b6f3"><img width="84" alt="Screenshot 2023-10-10 at 15 42 15" src="https://github.com/status-im/status-mobile/assets/10757633/00847691-f7a3-4b32-b6bd-d184b46d207d">|
| Pixel compare |
|<img width="287" alt="Screenshot 2023-10-10 at 15 38 08" src="https://github.com/status-im/status-mobile/assets/10757633/d45d115c-b3fe-4bfb-a7ca-13ad95820c87">  -->> <img width="273" alt="Screenshot 2023-10-11 at 17 02 52" src="https://github.com/status-im/status-mobile/assets/10757633/85d8b23f-12ac-4c31-8731-59c0f90d71a0">|


status: ready
