### PR TITLE
Don't sync AC notifications, only decisions/state

### DIFF
--- a/src/status_im2/contexts/shell/activity_center/notification/contact_requests/view.cljs
+++ b/src/status_im2/contexts/shell/activity_center/notification/contact_requests/view.cljs
@@ -59,9 +59,9 @@
 
 (defn- outgoing-contact-request-view
   [{:keys [notification set-swipeable-height customization-color]}]
-  (let [{:keys [chat-id message last-message]}      notification
-        {:keys [contact-request-state] :as message} (or message last-message)]
-    (if (= contact-request-state constants/contact-request-message-state-accepted)
+  (let [{:keys [chat-id message last-message accepted]} notification
+        {:keys [contact-request-state] :as message}     (or message last-message)]
+    (if accepted
       [quo/activity-log
        {:title               (i18n/label :t/contact-request-was-accepted)
         :customization-color customization-color

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.171.6",
-    "commit-sha1": "27b770c41bd2896ebc30b01985eeea1fbe642fba",
-    "src-sha256": "1zbw5m3n9piwnkk63kw938m5pajsmm3z14sj9ia0dasa3kigc91d"
+    "version": "v0.171.7",
+    "commit-sha1": "74396b461df0c18593262a67c9fd79d706287f7a",
+    "src-sha256": "1d46lav3g6m1f6ifpypjlsp2qm82c6yk4478awb8f68azpdkvcg5"
 }


### PR DESCRIPTION
fixes [issue](https://github.com/status-im/status-go/issues/3949)
relate [PR](https://github.com/status-im/status-go/pull/3979) for status-go

`state` means if there exist unread notifications
`decision` means accept/dismiss/markAsXXX(read/unread/deleted) 

### Testing notes
pls check if syncing AC notification works as expected

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

status: ready <!-- Can be ready or wip -->
