### PR TITLE
[#17533] fix: 'Sign in' page overlaps 'Main' page

### DIFF
--- a/src/status_im2/contexts/syncing/scan_sync_code/view.cljs
+++ b/src/status_im2/contexts/syncing/scan_sync_code/view.cljs
@@ -311,7 +311,8 @@
                                       :show-camera?     show-camera?
                                       :content-opacity  content-opacity
                                       :subtitle-opacity subtitle-opacity
-                                      :title-opacity    title-opacity})]
+                                      :title-opacity    title-opacity})
+            view-id                 (rf/sub [:view-id])]
 
         (rn/use-effect
          #(set-listener-torch-off-on-app-inactive torch?))
@@ -319,9 +320,10 @@
         (when animated?
           (rn/use-effect
            (fn []
-             (rn/hw-back-add-listener reset-animations-fn)
-             #(rn/hw-back-remove-listener reset-animations-fn))
-           [])
+             (when (= view-id :sign-in-intro)
+               (rn/hw-back-add-listener reset-animations-fn)
+               #(rn/hw-back-remove-listener reset-animations-fn)))
+           [view-id])
           (animation/animate-subtitle subtitle-opacity)
           (animation/animate-title title-opacity)
           (animation/animate-bottom bottom-view-translate-y))


### PR DESCRIPTION
fixes #17533

'Sign in' page overlaps 'Main' page after closing Find sync code bottom sheet via system back button (Android)

#### Platforms
- Android

### Steps to test

1. Tap 'Sign in' tab;
2. Tap 'Find sync code' tab;
3. Tap 'Back' system button

### Result 
[Screen_recording_20231010_184911.webm](https://github.com/status-im/status-mobile/assets/71308738/889394c6-77a8-45ff-9325-b2a0e2d3595c)


status: ready
