### PR TITLE
Bottom Sheet Fixes

### DIFF
--- a/src/quo2/components/gradient/gradient_cover/style.cljs
+++ b/src/quo2/components/gradient/gradient_cover/style.cljs
@@ -1,4 +1,6 @@
 (ns quo2.components.gradient.gradient-cover.style)
 
-(def root-container
-  {:height 252})
+(defn root-container
+  [opacity]
+  {:height  252
+   :opacity opacity})

--- a/src/quo2/components/gradient/gradient_cover/view.cljs
+++ b/src/quo2/components/gradient/gradient_cover/view.cljs
@@ -5,7 +5,7 @@
             [react-native.linear-gradient :as linear-gradient]))
 
 (defn- view-internal
-  [{:keys [customization-color container-style] :or {customization-color :blue}}]
+  [{:keys [customization-color opacity container-style] :or {customization-color :blue}}]
   (let [color-top    (colors/custom-color customization-color 50 20)
         color-bottom (colors/custom-color customization-color 50 0)]
     [linear-gradient/linear-gradient
@@ -13,6 +13,6 @@
       :colors              [color-top color-bottom]
       :start               {:x 0 :y 0}
       :end                 {:x 0 :y 1}
-      :style               (merge style/root-container container-style)}]))
+      :style               (merge (style/root-container opacity) container-style)}]))
 
 (def view (quo.theme/with-theme view-internal))

--- a/src/status_im2/common/bottom_sheet/style.cljs
+++ b/src/status_im2/common/bottom_sheet/style.cljs
@@ -1,5 +1,6 @@
 (ns status-im2.common.bottom-sheet.style
   (:require [quo2.foundations.colors :as colors]
+            [quo2.foundations.shadows :as shadows]
             [quo2.theme :as theme]
             [react-native.platform :as platform]))
 
@@ -14,7 +15,7 @@
    :margin-vertical  8})
 
 (defn sheet
-  [{:keys [top bottom]} window-height theme padding-bottom-override selected-item shell?]
+  [{:keys [top]} window-height selected-item]
   {:position                :absolute
    :max-height              (- window-height top)
    :z-index                 1
@@ -24,11 +25,7 @@
    :border-top-left-radius  20
    :border-top-right-radius 20
    :overflow                (when-not selected-item :hidden)
-   :flex                    1
-   :padding-bottom          (or padding-bottom-override (+ bottom))
-   :background-color        (if shell?
-                              :transparent
-                              (colors/theme-colors colors/white colors/neutral-95 theme))})
+   :flex                    1})
 
 (def gradient-bg
   {:position :absolute
@@ -45,11 +42,15 @@
    :bottom           0})
 
 (defn sheet-content
-  [theme padding-bottom-override insets bottom-margin]
-  {:background-color        (colors/theme-colors colors/white colors/neutral-95 theme)
-   :border-top-left-radius  20
-   :border-top-right-radius 20
-   :padding-bottom          (or padding-bottom-override (+ (:bottom insets) bottom-margin))})
+  [theme padding-bottom-override {:keys [bottom]} shell? bottom-margin]
+  (merge
+   (shadows/get 4 theme :inverted)
+   {:border-top-left-radius  20
+    :border-top-right-radius 20
+    :padding-bottom          (or padding-bottom-override (+ bottom bottom-margin))
+    :background-color        (if shell?
+                               :transparent
+                               (colors/theme-colors colors/white colors/neutral-95 theme))}))
 
 (defn selected-item
   [theme top bottom sheet-bottom-margin border-radius]

--- a/src/status_im2/common/bottom_sheet/style.cljs
+++ b/src/status_im2/common/bottom_sheet/style.cljs
@@ -53,9 +53,9 @@
                                (colors/theme-colors colors/white colors/neutral-95 theme))}))
 
 (defn selected-item
-  [theme top bottom sheet-bottom-margin border-radius]
+  [theme top bottom selected-item-smaller-than-sheet? border-radius]
   {:position          :absolute
-   :top               (when-not sheet-bottom-margin (- 0 top))
+   :top               (when-not selected-item-smaller-than-sheet? (- 0 top))
    :bottom            bottom
    :overflow          :hidden
    :left              0

--- a/src/status_im2/common/bottom_sheet/style.cljs
+++ b/src/status_im2/common/bottom_sheet/style.cljs
@@ -1,6 +1,5 @@
 (ns status-im2.common.bottom-sheet.style
   (:require [quo2.foundations.colors :as colors]
-            [quo2.foundations.shadows :as shadows]
             [quo2.theme :as theme]
             [react-native.platform :as platform]))
 
@@ -43,14 +42,12 @@
 
 (defn sheet-content
   [theme padding-bottom-override {:keys [bottom]} shell? bottom-margin]
-  (merge
-   (shadows/get 4 theme :inverted)
-   {:border-top-left-radius  20
-    :border-top-right-radius 20
-    :padding-bottom          (or padding-bottom-override (+ bottom bottom-margin))
-    :background-color        (if shell?
-                               :transparent
-                               (colors/theme-colors colors/white colors/neutral-95 theme))}))
+  {:border-top-left-radius  20
+   :border-top-right-radius 20
+   :padding-bottom          (or padding-bottom-override (+ bottom bottom-margin))
+   :background-color        (if shell?
+                              :transparent
+                              (colors/theme-colors colors/white colors/neutral-95 theme))})
 
 (defn selected-item
   [theme top bottom selected-item-smaller-than-sheet? border-radius]

--- a/src/status_im2/common/bottom_sheet/view.cljs
+++ b/src/status_im2/common/bottom_sheet/view.cljs
@@ -64,16 +64,23 @@
          {:keys [content selected-item padding-bottom-override border-radius on-close shell?
                  gradient-cover? customization-color]
           :or   {border-radius 12}}]
-      (let [{window-height :height} (rn/get-window)
-            bg-opacity              (reanimated/use-shared-value 0)
-            translate-y             (reanimated/use-shared-value window-height)
-            sheet-gesture           (get-sheet-gesture translate-y bg-opacity window-height on-close)
-            sheet-bottom-margin     (< @item-height
-                                       (- window-height @sheet-height (:top insets) bottom-margin))
-            top                     (- window-height (:top insets) (:bottom insets) @sheet-height)
-            bottom                  (if sheet-bottom-margin
-                                      (+ @sheet-height bottom-margin (:bottom insets))
-                                      (:bottom insets))]
+      (let [{window-height :height}           (rn/get-window)
+            bg-opacity                        (reanimated/use-shared-value 0)
+            translate-y                       (reanimated/use-shared-value window-height)
+            sheet-gesture                     (get-sheet-gesture translate-y
+                                                                 bg-opacity
+                                                                 window-height
+                                                                 on-close)
+            selected-item-smaller-than-sheet? (< @item-height
+                                                 (- window-height
+                                                    @sheet-height
+                                                    (:top insets)
+                                                    (:bottom insets)
+                                                    bottom-margin))
+            top                               (- window-height (:top insets) @sheet-height)
+            bottom                            (if selected-item-smaller-than-sheet?
+                                                (+ @sheet-height bottom-margin)
+                                                (:bottom insets))]
         (rn/use-effect
          #(if hide?
             (hide translate-y bg-opacity window-height on-close)
@@ -103,7 +110,7 @@
              [rn/view
               {:on-layout #(reset! item-height (.-nativeEvent.layout.height ^js %))
                :style
-               (style/selected-item theme top bottom sheet-bottom-margin border-radius)}
+               (style/selected-item theme top bottom selected-item-smaller-than-sheet? border-radius)}
               [selected-item]])
 
            [rn/view

--- a/src/status_im2/common/bottom_sheet/view.cljs
+++ b/src/status_im2/common/bottom_sheet/view.cljs
@@ -96,12 +96,7 @@
           [reanimated/view
            {:style (reanimated/apply-animations-to-style
                     {:transform [{:translateY translate-y}]}
-                    (style/sheet insets
-                                 window-height
-                                 theme
-                                 padding-bottom-override
-                                 selected-item
-                                 shell?))}
+                    (style/sheet insets window-height selected-item))}
            (when gradient-cover?
              [rn/view {:style style/gradient-bg}
               [quo/gradient-cover {:customization-color customization-color}]])
@@ -115,7 +110,7 @@
               [selected-item]])
 
            [rn/view
-            {:style     (style/sheet-content theme padding-bottom-override insets bottom-margin)
+            {:style     (style/sheet-content theme padding-bottom-override insets shell? bottom-margin)
              :on-layout #(reset! sheet-height (.-nativeEvent.layout.height ^js %))}
             [rn/view {:style (style/handle theme)}]
             [content]]]]]))))

--- a/src/status_im2/common/bottom_sheet/view.cljs
+++ b/src/status_im2/common/bottom_sheet/view.cljs
@@ -97,9 +97,6 @@
            {:style (reanimated/apply-animations-to-style
                     {:transform [{:translateY translate-y}]}
                     (style/sheet insets window-height selected-item))}
-           (when gradient-cover?
-             [rn/view {:style style/gradient-bg}
-              [quo/gradient-cover {:customization-color customization-color}]])
            (when shell?
              [blur/ios-view {:style style/shell-bg}])
            (when selected-item
@@ -112,6 +109,11 @@
            [rn/view
             {:style     (style/sheet-content theme padding-bottom-override insets shell? bottom-margin)
              :on-layout #(reset! sheet-height (.-nativeEvent.layout.height ^js %))}
+            (when gradient-cover?
+              [rn/view {:style style/gradient-bg}
+               [quo/gradient-cover
+                {:customization-color customization-color
+                 :opacity             0.4}]])
             [rn/view {:style (style/handle theme)}]
             [content]]]]]))))
 

--- a/src/status_im2/contexts/onboarding/create_profile/view.cljs
+++ b/src/status_im2/contexts/onboarding/create_profile/view.cljs
@@ -168,9 +168,9 @@
                                      (rf/dispatch [:dismiss-keyboard])
                                      (rf/dispatch
                                       [:show-bottom-sheet
-                                       {:content
-                                        (fn []
-                                          [method-menu/view on-change-profile-pic])}]))
+                                       {:content (fn []
+                                                   [method-menu/view on-change-profile-pic])
+                                        :shell?  true}]))
               :image-picker-props  {:profile-picture     (or
                                                           @profile-pic
                                                           (rf/sub

--- a/src/status_im2/contexts/quo_preview/gradient/gradient_cover.cljs
+++ b/src/status_im2/contexts/quo_preview/gradient/gradient_cover.cljs
@@ -9,18 +9,16 @@
             [utils.re-frame :as rf]))
 
 (defn render-action-sheet
-  []
+  [customization-color]
   [:<>
-   [rn/view {:style {:align-items :center}}
-    [quo/summary-info
-     {:type          :status-account
-      :networks?     false
-      :account-props {:customization-color :purple
-                      :size                32
-                      :emoji               "🍑"
-                      :type                :default
-                      :name                "Collectibles vault"
-                      :address             "0x0ah...78b"}}]]
+   [quo/drawer-top
+    {:type                 :account
+     :blur?                false
+     :title                "Collectibles vault"
+     :networks             [:ethereum :optimism]
+     :description          "0x0ah...78b"
+     :account-avatar-emoji "🍿"
+     :customization-color  (or customization-color :blue)}]
    [quo/action-drawer
     [[{:icon     :i/edit
        :label    "Edit account"
@@ -31,10 +29,11 @@
       {:icon     :i/share
        :label    "Share account"
        :on-press #(js/alert "Share account")}
-      {:icon     :i/delete
-       :label    "Remove account"
-       :danger?  true
-       :on-press #(js/alert "Remove account")}]]]])
+      {:icon         :i/delete
+       :label        "Remove account"
+       :danger?      true
+       :on-press     #(js/alert "Remove account")
+       :add-divider? true}]]]])
 
 (def descriptor
   [(preview/customization-color-option)
@@ -76,7 +75,9 @@
         [quo/button
          {:container-style {:margin-horizontal 40}
           :on-press        #(rf/dispatch [:show-bottom-sheet
-                                          {:content             (fn [] [render-action-sheet])
+                                          {:content             (fn []
+                                                                  [render-action-sheet
+                                                                   @customization-color])
                                            :gradient-cover?     true
                                            :customization-color @customization-color}])}
          "See in bottom sheet"]])]))

--- a/src/status_im2/contexts/shell/activity_center/header/view.cljs
+++ b/src/status_im2/contexts/shell/activity_center/header/view.cljs
@@ -40,7 +40,8 @@
       :accessibility-label :activity-center-open-more
       :on-press            #(rf/dispatch [:show-bottom-sheet
                                           {:content drawer/options
-                                           :theme   :dark}])}
+                                           :theme   :dark
+                                           :shell?  true}])}
      :i/options]]
    [quo/text
     {:size   :heading-1


### PR DESCRIPTION
fixes #17588

### Summary

This PR fixes the following issues in the bottom sheet:

1. the sheet is cut off at the bottom in the `shell` (dark blur) theme (the drawers in the onboarding/login flow)

| Bug  | Fix
| --- | --- |
| <img width=250 src="https://github.com/status-im/status-mobile/assets/19339952/3a42fe46-4b1c-45b4-9c3e-0c963d896edb" /> | <img width=250 src="https://github.com/status-im/status-mobile/assets/19339952/9d8454c3-0807-48ae-87b5-dcdc06219edb" /> |

2. the incorrect background in the `shell` (dark blur) theme (the drawers in the onboarding/login flow)

| Bug  | Fix
| --- | --- |
| <img width=250 src="https://github.com/status-im/status-mobile/assets/19339952/8d0c2f7e-cdb7-4ad7-b237-b0cbbca72c07" /> | <img width=250 src="https://github.com/status-im/status-mobile/assets/19339952/46e4addc-6af5-4907-a160-512fe887f42c" /> |


3. the spacing at the bottom is doubled

| Bug  | Fix
| --- | --- |
| <img width=250 src="https://github.com/status-im/status-mobile/assets/19339952/d269fbc3-0b46-47d8-881d-7c64538b58b2" /> | <img width=250 src="https://github.com/status-im/status-mobile/assets/19339952/8469a1f7-3465-4ffb-97a8-43365dc4979c" /> |

4. the gradient cover is not shown in the bottom sheet

| Bug  | Fix
| --- | --- |
| <img width=250 src="https://github.com/status-im/status-mobile/assets/19339952/987c8fef-f402-465e-9c0a-21791a748f8e" /> | <img width=250 src="https://github.com/status-im/status-mobile/assets/19339952/45b767d0-5279-46a4-a7df-028b908de14f" /> |

### Review notes

The recent bottom sheet changes (d5a71e2ce08579919ee3cf8d5f9b535a5d17b91b) have broken the background of the `shell` dark blur variant and gradient cover usage. This PR fixes those bugs.

### Testing notes

The whole application needs to be tested as it updates the bottom sheet core file. A design review is not required as these are bug fixes.

### Platforms

- Android
- iOS

### Steps to test

It is advisable to test the whole application due to core file changes.

#### Gradient Cover component (not used in any screen)

- Open Status
- Navigate to `Quo2 preview > gradient > gradient cover`
- Tap on the `See in bottom sheet` button

status: ready 
