### PR TITLE
remove SQLCipher dependency for ios

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -33,7 +33,6 @@ abstract_target 'Status' do
   pod 'react-native-image-resizer', :path => '../node_modules/react-native-image-resizer'
   pod 'react-native-config', :path => '../node_modules/react-native-config'
 
-  pod 'SQLCipher', '~>3.0'
   pod 'SSZipArchive', '2.4.3'
 
   permissions_path = '../node_modules/react-native-permissions/ios'

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -434,11 +434,6 @@ PODS:
     - libwebp (~> 1.0)
     - SDWebImage/Core (~> 5.10)
   - secp256k1 (0.1.6)
-  - SQLCipher (3.4.2):
-    - SQLCipher/standard (= 3.4.2)
-  - SQLCipher/common (3.4.2)
-  - SQLCipher/standard (3.4.2):
-    - SQLCipher/common
   - SSZipArchive (2.4.3)
   - TOCropViewController (2.6.1)
   - TouchID (4.4.1):
@@ -520,7 +515,6 @@ DEPENDENCIES:
   - RNStaticSafeAreaInsets (from `../node_modules/react-native-static-safe-area-insets`)
   - RNSVG (from `../node_modules/react-native-svg`)
   - secp256k1 (from `https://github.com/status-im/secp256k1.swift.git`)
-  - SQLCipher (~> 3.0)
   - SSZipArchive (= 2.4.3)
   - TouchID (from `../node_modules/react-native-touch-id`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
@@ -533,7 +527,6 @@ SPEC REPOS:
     - libwebp
     - SDWebImage
     - SDWebImageWebPCoder
-    - SQLCipher
     - SSZipArchive
     - TOCropViewController
 
@@ -772,19 +765,18 @@ SPEC CHECKSUMS:
   RNLanguages: 962e562af0d34ab1958d89bcfdb64fafc37c513e
   RNPermissions: ad71dd4f767ec254f2cd57592fbee02afee75467
   RNReactNativeHapticFeedback: 2566b468cc8d0e7bb2f84b23adc0f4614594d071
-  RNReanimated: 43adb0307a62c1ce9694f36f124ca3b51a15272a
+  RNReanimated: cf1259a8cf8dfb1d7fa586ce02565fd0610da1d7
   RNShare: d82e10f6b7677f4b0048c23709bd04098d5aee6c
   RNStaticSafeAreaInsets: 055ddbf5e476321720457cdaeec0ff2ba40ec1b8
   RNSVG: 80584470ff1ffc7994923ea135a3e5ad825546b9
   SDWebImage: a7f831e1a65eb5e285e3fb046a23fcfbf08e696d
   SDWebImageWebPCoder: 908b83b6adda48effe7667cd2b7f78c897e5111d
   secp256k1: f61d67e6fdcb85fd727acf1bf35ace6036db540c
-  SQLCipher: f9fcf29b2e59ced7defc2a2bdd0ebe79b40d4990
   SSZipArchive: fe6a26b2a54d5a0890f2567b5cc6de5caa600aef
   TOCropViewController: edfd4f25713d56905ad1e0b9f5be3fbe0f59c863
   TouchID: ba4c656d849cceabc2e4eef722dea5e55959ecf4
   Yoga: d24d6184b6b85f742536bd93bd07d69d7b9bb4c1
 
-PODFILE CHECKSUM: ac30a0172ff0126b6f307c20f34c47ce0ebf278f
+PODFILE CHECKSUM: 4d710b4207b0fb0f6ecef4aa92bb79b716a7d13c
 
 COCOAPODS: 1.12.0


### PR DESCRIPTION
after removing this dependency, following error disappeared:
```
lvl=eror msg="failed to create account" error="failed to migrate up: near \"DROP\": syntax error in line 0: ALTER TABLE settings DROP COLUMN include_watch_only_account;\n, current version: 1697123140"
```
the error stops us creating new account on ios.

note: 3.0 does not support dropping columns and we have dependency `github.com/mutecomm/go-sqlcipher/v4` in `status-go` side already.

relate old [PR](https://github.com/status-im/status-mobile/pull/7294)
relate [comment](https://github.com/status-im/status-mobile/pull/7294#issuecomment-455554636) on history

encrypting feature works after removing the dependency, relate test [code](https://gist.github.com/qfrank/501e3bb8e92c7d27054ed7d4f804a275) 

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- iOS

status: ready <!-- Can be ready or wip -->
