### PR TITLE
[#17507] fix: image placeholder issue in create-profile

### DIFF
--- a/src/status_im2/contexts/onboarding/create_profile/view.cljs
+++ b/src/status_im2/contexts/onboarding/create_profile/view.cljs
@@ -18,7 +18,7 @@
 
 ;; NOTE - validation should match with Desktop
 ;; https://github.com/status-im/status-desktop/blob/2ba96803168461088346bf5030df750cb226df4c/ui/imports/utils/Constants.qml#L468
-;; 
+;;
 (def emoji-regex
   (new
    js/RegExp
@@ -172,11 +172,7 @@
                                        {:content (fn []
                                                    [method-menu/view on-change-profile-pic])
                                         :shell?  true}]))
-              :image-picker-props  {:profile-picture     (or
-                                                          @profile-pic
-                                                          (rf/sub
-                                                           [:profile/onboarding-placeholder-avatar
-                                                            @profile-pic]))
+              :image-picker-props  {:profile-picture     @profile-pic
                                     :full-name           (if (seq @full-name)
                                                            @full-name
                                                            (i18n/label :t/your-name))


### PR DESCRIPTION
fixes #17507

Reproduction

1. Install Status on your iOS device
2. On the intro screen lock the device screen/send the app to background
3. Wait ~ 2 munites
4. Open the app
5. Press I'm new to Status > Generate keys


it was hard to reproduce but now it should be fine, i noticed sometime the port has been missed for mediaserver ,so i try to avoid calling mediaserver when user doesn't have any avatar there


status: ready
