### PR TITLE
chore: add sub to get network info

### DIFF
--- a/src/quo/foundations/resources.cljs
+++ b/src/quo/foundations/resources.cljs
@@ -37,7 +37,7 @@
   [k]
   (get tokens k))
 
-(def networks
+(def ^:private networks
   {:arbitrum (js/require "../resources/images/networks/Arbitrum.png")
    :ethereum (js/require "../resources/images/networks/Ethereum.png")
    :gnosis   (js/require "../resources/images/networks/Gnosis.png")

--- a/src/status_im2/constants.cljs
+++ b/src/status_im2/constants.cljs
@@ -358,3 +358,17 @@
 
 (def ^:const ens-action-type-register 1)
 (def ^:const ens-action-type-set-pub-key 2)
+
+;; wallet
+(def ^:const mainnet-chain-id 1)
+(def ^:const optimism-chain-id 10)
+(def ^:const arbitrum-chain-id 42161)
+(def ^:const goerli-chain-id 5)
+
+(def ^:const mainnet-short-name "eth")
+(def ^:const optimism-short-name "opt")
+(def ^:const arbitrum-short-name "arb1")
+
+(def ^:const mainnet-network-name :ethereum)
+(def ^:const optimism-network-name :optimism)
+(def ^:const arbitrum-network-name :arbitrum)

--- a/src/status_im2/contexts/profile/login/events.cljs
+++ b/src/status_im2/contexts/profile/login/events.cljs
@@ -22,6 +22,7 @@
     [status-im2.contexts.profile.rpc :as profile.rpc]
     [status-im2.contexts.push-notifications.events :as notifications]
     [status-im2.contexts.shell.activity-center.events :as activity-center]
+    [status-im2.contexts.wallet.events :as wallet]
     [status-im2.navigation.events :as navigation]
     [taoensso.timbre :as log]
     [utils.re-frame :as rf]
@@ -91,6 +92,7 @@
               (activity-center/notifications-fetch-pending-contact-requests)
               (activity-center/update-seen-state)
               (activity-center/notifications-fetch-unread-count)
+              (wallet/get-ethereum-chains)
               (redirect-to-root))))
 
 ;; login phase 2, we want to load and show chats faster so we split login into 2 phases

--- a/src/status_im2/contexts/wallet/account/tabs/about/view.cljs
+++ b/src/status_im2/contexts/wallet/account/tabs/about/view.cljs
@@ -2,6 +2,7 @@
   (:require
     [quo.core :as quo]
     [quo.foundations.colors :as colors]
+    [quo.theme :as quo.theme]
     [react-native.core :as rn]
     [status-im2.contexts.wallet.account.tabs.about.style :as style]
     [status-im2.contexts.wallet.common.temp :as temp]
@@ -9,20 +10,21 @@
     [utils.re-frame :as rf]))
 
 (defn description
-  [{:keys [address]}]
-  [quo/text {:size :paragraph-2}
-   (map (fn [network]
-          ^{:key (str network)}
-          [quo/text
-           {:size   :paragraph-2
-            :weight :medium
-            :style  {:color (colors/custom-color network)}}
-           (str (subs (name network) 0 3) (when (= network :arbitrum) "1") ":")])
-        temp/network-names)
-   [quo/text
-    {:size   :paragraph-2
-     :weight :monospace}
-    address]])
+  [{:keys [address theme]}]
+  (let [networks-list (rf/sub [:wallet/network-details])]
+    [quo/text {:size :paragraph-2}
+     (map (fn [{:keys [chain-id short-name network-name]}]
+            ^{:key (str chain-id short-name)}
+            [quo/text
+             {:size   :paragraph-2
+              :weight :medium
+              :style  {:color (colors/resolve-color network-name theme)}}
+             (str short-name ":")])
+          networks-list)
+     [quo/text
+      {:size   :paragraph-2
+       :weight :monospace}
+      address]]))
 
 (defn about-options
   []
@@ -49,12 +51,16 @@
       :accessibility-label :share-address
       :label               (i18n/label :t/share-address)}]]])
 
-(defn view
-  []
+(defn- view-internal
+  [{:keys [theme]}]
   [rn/view {:style style/about-tab}
    [quo/data-item
     (merge temp/data-item-state
-           {:custom-subtitle (fn [] [description {:address temp/address}])
+           {:custom-subtitle (fn [] [description
+                                     {:theme   theme
+                                      :address temp/address}])
             :container-style {:margin-bottom 12}
             :on-press        #(rf/dispatch [:show-bottom-sheet {:content about-options}])})]
    [quo/account-origin temp/account-origin-state]])
+
+(def view (quo.theme/with-theme view-internal))

--- a/src/status_im2/contexts/wallet/account/view.cljs
+++ b/src/status_im2/contexts/wallet/account/view.cljs
@@ -1,7 +1,6 @@
 (ns status-im2.contexts.wallet.account.view
   (:require
     [quo.core :as quo]
-    [quo.foundations.resources :as quo.resources]
     [react-native.core :as rn]
     [react-native.safe-area :as safe-area]
     [reagent.core :as reagent]
@@ -49,11 +48,6 @@
                  :padding-bottom     8}
      :render-fn quo/settings-item}]])
 
-(def ^:private networks-list
-  [{:source (quo.resources/get-network :ethereum)}
-   {:source (quo.resources/get-network :optimism)}
-   {:source (quo.resources/get-network :arbitrum)}])
-
 (def tabs-data
   [{:id :assets :label (i18n/label :t/assets) :accessibility-label :assets-tab}
    {:id :collectibles :label (i18n/label :t/collectibles) :accessibility-label :collectibles-tab}
@@ -67,34 +61,35 @@
   (let [top          (safe-area/get-top)
         selected-tab (reagent/atom (:id (first tabs-data)))]
     (fn []
-      [rn/view
-       {:style {:flex       1
-                :margin-top top}}
-       [quo/page-nav
-        {:type              :wallet-networks
-         :background        :blur
-         :icon-name         :i/close
-         :on-press          #(rf/dispatch [:navigate-back])
-         :networks          networks-list
-         :networks-on-press #(js/alert "Pressed Networks")
-         :right-side        :account-switcher
-         :account-switcher  {:customization-color :purple
-                             :on-press            #(rf/dispatch [:show-bottom-sheet
-                                                                 {:content             account-options
-                                                                  :gradient-cover?     true
-                                                                  :customization-color :purple}])
-                             :emoji               "🍑"}}]
-       [quo/account-overview temp/account-overview-state]
-       [quo/wallet-graph {:time-frame :empty}]
-       [quo/wallet-ctas
-        {:send-action #(rf/dispatch [:open-modal :wallet-select-address])
-         :buy-action  #(rf/dispatch [:show-bottom-sheet
-                                     {:content buy-drawer}])}]
-       [quo/tabs
-        {:style          style/tabs
-         :size           32
-         :default-active @selected-tab
-         :data           tabs-data
-         :on-change      #(reset! selected-tab %)
-         :scrollable?    true}]
-       [tabs/view {:selected-tab @selected-tab}]])))
+      (let [networks (rf/sub [:wallet/network-details])]
+        [rn/view
+         {:style {:flex       1
+                  :margin-top top}}
+         [quo/page-nav
+          {:type              :wallet-networks
+           :background        :blur
+           :icon-name         :i/close
+           :on-press          #(rf/dispatch [:navigate-back])
+           :networks          networks
+           :networks-on-press #(js/alert "Pressed Networks")
+           :right-side        :account-switcher
+           :account-switcher  {:customization-color :purple
+                               :on-press            #(rf/dispatch [:show-bottom-sheet
+                                                                   {:content             account-options
+                                                                    :gradient-cover?     true
+                                                                    :customization-color :purple}])
+                               :emoji               "🍑"}}]
+         [quo/account-overview temp/account-overview-state]
+         [quo/wallet-graph {:time-frame :empty}]
+         [quo/wallet-ctas
+          {:send-action #(rf/dispatch [:open-modal :wallet-select-address])
+           :buy-action  #(rf/dispatch [:show-bottom-sheet
+                                       {:content buy-drawer}])}]
+         [quo/tabs
+          {:style          style/tabs
+           :size           32
+           :default-active @selected-tab
+           :data           tabs-data
+           :on-change      #(reset! selected-tab %)
+           :scrollable?    true}]
+         [tabs/view {:selected-tab @selected-tab}]]))))

--- a/src/status_im2/contexts/wallet/common/temp.cljs
+++ b/src/status_im2/contexts/wallet/common/temp.cljs
@@ -9,10 +9,6 @@
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]))
 
-(def networks
-  [{:source (quo.resources/get-network :ethereum)}
-   {:source (quo.resources/get-network :optimism)}
-   {:source (quo.resources/get-network :arbitrum)}])
 
 (defn wallet-temporary-navigation
   []
@@ -28,7 +24,8 @@
    [quo/button {:on-press #(rf/dispatch [:navigate-to :wallet-saved-addresses])}
     "Saved Addresses"]])
 
-(def wallet-overview-state
+(defn wallet-overview-state
+  [networks]
   {:state             :default
    :time-frame        :none
    :metrics           :none
@@ -110,8 +107,6 @@
    :account-name        "Account 1"
    :account             :default
    :customization-color :blue})
-
-(def network-names [:ethereum :optimism :arbitrum])
 
 (def address "0x39cf6E0Ba4C4530735616e1Ee7ff5FbCB726fBd4")
 

--- a/src/status_im2/contexts/wallet/home/view.cljs
+++ b/src/status_im2/contexts/wallet/home/view.cljs
@@ -51,33 +51,35 @@
   (let [top          (safe-area/get-top)
         selected-tab (reagent/atom (:id (first tabs-data)))]
     (fn []
-      [rn/view
-       {:style {:margin-top top
-                :flex       1}}
-       [common.top-nav/view]
-       [rn/view {:style style/overview-container}
-        [quo/wallet-overview temp/wallet-overview-state]]
-       [rn/pressable
-        {:on-long-press #(rf/dispatch [:show-bottom-sheet {:content temp/wallet-temporary-navigation}])}
-        [quo/wallet-graph {:time-frame :empty}]]
-       [rn/view {:style style/accounts-container}
-        [rn/flat-list
-         {:style      style/accounts-list
-          :data       account-cards
-          :horizontal true
-          :separator  [rn/view {:style {:width 12}}]
-          :render-fn  quo/account-card}]]
-       [quo/tabs
-        {:style          style/tabs
-         :size           32
-         :default-active @selected-tab
-         :data           tabs-data
-         :on-change      #(reset! selected-tab %)}]
-       (case @selected-tab
-         :assets       [rn/flat-list
-                        {:render-fn               token-value/view
-                         :data                    temp/tokens
-                         :key                     :assets-list
-                         :content-container-style {:padding-horizontal 8}}]
-         :collectibles [collectibles/view]
-         [activity/view])])))
+      (let [networks (rf/sub [:wallet/network-details])]
+        [rn/view
+         {:style {:margin-top top
+                  :flex       1}}
+         [common.top-nav/view]
+         [rn/view {:style style/overview-container}
+          [quo/wallet-overview (temp/wallet-overview-state networks)]]
+         [rn/pressable
+          {:on-long-press #(rf/dispatch [:show-bottom-sheet
+                                         {:content temp/wallet-temporary-navigation}])}
+          [quo/wallet-graph {:time-frame :empty}]]
+         [rn/view {:style style/accounts-container}
+          [rn/flat-list
+           {:style      style/accounts-list
+            :data       account-cards
+            :horizontal true
+            :separator  [rn/view {:style {:width 12}}]
+            :render-fn  quo/account-card}]]
+         [quo/tabs
+          {:style          style/tabs
+           :size           32
+           :default-active @selected-tab
+           :data           tabs-data
+           :on-change      #(reset! selected-tab %)}]
+         (case @selected-tab
+           :assets       [rn/flat-list
+                          {:render-fn               token-value/view
+                           :data                    temp/tokens
+                           :key                     :assets-list
+                           :content-container-style {:padding-horizontal 8}}]
+           :collectibles [collectibles/view]
+           [activity/view])]))))

--- a/src/status_im2/data_store/wallet.cljs
+++ b/src/status_im2/data_store/wallet.cljs
@@ -1,0 +1,25 @@
+(ns status-im2.data-store.wallet
+  (:require
+    clojure.set))
+
+(defn <-rpc
+  [network]
+  (-> network
+      (clojure.set/rename-keys
+       {:Prod                   :prod
+        :Test                   :test
+        :isTest                 :test?
+        :tokenOverrides         :token-overrides
+        :rpcUrl                 :rpc-url
+        :chainColor             :chain-color
+        :chainName              :chain-name
+        :nativeCurrencyDecimals :native-currency-decimals
+        :relatedChainId         :related-chain-id
+        :shortName              :short-name
+        :chainId                :chain-id
+        :originalFallbackURL    :original-fallback-url
+        :originalRpcUrl         :original-rpc-url
+        :fallbackURL            :fallback-url
+        :blockExplorerUrl       :block-explorer-url
+        :nativeCurrencySymbol   :native-currency-symbol
+        :nativeCurrencyName     :native-currency-symbol})))

--- a/src/status_im2/subs/root.cljs
+++ b/src/status_im2/subs/root.cljs
@@ -10,7 +10,8 @@
     status-im2.subs.onboarding
     status-im2.subs.pairing
     status-im2.subs.profile
-    status-im2.subs.shell))
+    status-im2.subs.shell
+    status-im2.subs.wallet.networks))
 
 (defn reg-root-key-sub
   [sub-name db-key]
@@ -147,6 +148,7 @@
 ;;wallet
 (reg-root-key-sub :wallet/scanned-address :wallet/scanned-address)
 (reg-root-key-sub :wallet/create-account :wallet/create-account)
+(reg-root-key-sub :wallet/networks :wallet/networks)
 
 ;;debug
 (when js/goog.DEBUG

--- a/src/status_im2/subs/wallet/networks.cljs
+++ b/src/status_im2/subs/wallet/networks.cljs
@@ -1,0 +1,43 @@
+(ns status-im2.subs.wallet.networks
+  (:require [quo.foundations.resources :as resources]
+            [re-frame.core :as re-frame]
+            [status-im2.constants :as constants]))
+
+(re-frame/reg-sub
+ :wallet/filtered-networks-by-mode
+ :<- [:wallet/networks]
+ (fn [networks [_ test?]]
+   (get networks (if test? :test :prod))))
+
+(def mainnet-network-details
+  {:source       (resources/get-network constants/mainnet-network-name)
+   :short-name   constants/mainnet-short-name
+   :network-name constants/mainnet-network-name})
+
+(def arbitrum-network-details
+  {:source       (resources/get-network constants/arbitrum-network-name)
+   :short-name   constants/arbitrum-short-name
+   :network-name constants/arbitrum-network-name})
+
+(def optimism-network-details
+  {:source       (resources/get-network constants/optimism-network-name)
+   :short-name   constants/optimism-short-name
+   :network-name constants/optimism-network-name})
+
+(def network-list
+  {constants/mainnet-chain-id  mainnet-network-details
+   constants/goerli-chain-id   mainnet-network-details
+   constants/arbitrum-chain-id arbitrum-network-details
+   constants/optimism-chain-id optimism-network-details})
+
+(re-frame/reg-sub
+ :wallet/network-details
+ :<- [:wallet/filtered-networks-by-mode false]
+ (fn [networks]
+   (keep
+    (fn [{:keys [chain-id related-chain-id test?]}]
+      (let [network-details (get network-list (if test? related-chain-id chain-id))]
+        (assoc network-details
+               :chain-id         chain-id
+               :related-chain-id related-chain-id)))
+    networks)))

--- a/src/status_im2/subs/wallet/networks_test.cljs
+++ b/src/status_im2/subs/wallet/networks_test.cljs
@@ -1,0 +1,44 @@
+(ns status-im2.subs.wallet.networks-test
+  (:require
+    [cljs.test :refer [is testing]]
+    [re-frame.db :as rf-db]
+    status-im2.subs.root
+    status-im2.subs.wallet.networks
+    [test-helpers.unit :as h]
+    [utils.re-frame :as rf]))
+
+(def network-data
+  {:test [{:test?            true
+           :short-name       "eth"
+           :network-name     :ethereum
+           :related-chain-id 1}
+          {:test?            true
+           :short-name       "arb1"
+           :related-chain-id 42161}
+          {:test?            true
+           :short-name       "opt"
+           :related-chain-id 10}]
+   :prod [{:test?      false
+           :short-name "eth"
+           :chain-id   1}
+          {:test?      false
+           :short-name "arb1"
+           :chain-id   42161}
+          {:test?      false
+           :short-name "opt"
+           :chain-id   10}]})
+
+(h/deftest-sub :wallet/network-details
+  [sub-name]
+  (testing "returns data with prod"
+    (swap! rf-db/app-db assoc :wallet/networks network-data)
+    (is (= [{:network-name :ethereum
+             :short-name   "eth"
+             :chain-id     1}
+            {:network-name :arbitrum
+             :short-name   "arb1"
+             :chain-id     42161}
+            {:network-name :optimism
+             :short-name   "opt"
+             :chain-id     10}]
+           (map #(dissoc % :source :related-chain-id) (rf/sub [sub-name]))))))


### PR DESCRIPTION
fixes: https://github.com/status-im/status-mobile/issues/17649

This pr removes some hardcoded data and gets most of the info from the backend endpoints of status go. Some of the data provided is not consistent with how they are displayed in the new designs and I will reach out to Desktop to see if we can move this info in Status-Go.

In any case it centralises this information to a reframe subscription and I updated the current uses of this data.

**Note 1:** I wanted to add a unit/integration test, however I have a separate pr to clean up the integration test file and i will update that pr and add the test there once I get that working

**Note 2:** Looking at the wallet settings page this info will also be needed there for setting the test net etc so it's good to have this in a sub for the moment, especially when we add the on/off toggle for test-net mode 👍 


To test:
This pr adds no new functionality. It essentially takes some data we had in the app and centralizes the location we read it from. 

It gets some of this data from status go and adds it to the db on login. So there should e no differences for the user to see. 
Mostly it is to check everything is working as before and there is nothing broken in the new wallet ui.

No design review needed