### PR TITLE
nix: pin Ruby at 3.1, fastlane shell for nix-update-gems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ nix-update-clojure: export TARGET := clojure
 nix-update-clojure: ##@nix Update maven Nix expressions based on current clojure setup
 	nix/deps/clojure/generate.sh
 
-nix-update-gems: export TARGET := default
+nix-update-gems: export TARGET := fastlane
 nix-update-gems: ##@nix Update Ruby gems in fastlane/Gemfile.lock and fastlane/gemset.nix
 	fastlane/update.sh
 

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -65,6 +65,7 @@ in {
   # Package version adjustments
   gradle = super.gradle_7;
   nodejs = super.nodejs-18_x;
+  ruby = super.ruby_3_1;
   yarn = super.yarn.override { nodejs = super.nodejs-18_x; };
   openjdk = super.openjdk11_headless;
   xcodeWrapper = super.xcodeenv.composeXcodeWrapper {


### PR DESCRIPTION
Since the `default` shell doesn't have Ruby, the `nix-update-gems` target would incorrectly use the system Ruby instead of the one from Nix.
https://github.com/status-im/status-mobile/blob/1e5651d044f974754b5bee93b27541ece7ca02c9/nix/mobile/fastlane/default.nix#L17-L18