### PR TITLE
Prevent changing deps outside nix shell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -316,7 +316,7 @@ lint: ##@test Run code style checks
 	ALL_CLOJURE_FILES=$(call find_all_clojure_files) && \
 	zprint '{:search-config? true}' -sfc $$ALL_CLOJURE_FILES && \
 	sh scripts/lint-trailing-newline.sh && \
-	yarn prettier
+	node_modules/.bin/prettier --write .
 
 # NOTE: We run the linter twice because of https://github.com/kkinnear/zprint/issues/271
 lint-fix: export TARGET := clojure
@@ -326,7 +326,7 @@ lint-fix: ##@test Run code style checks and fix issues
 	zprint '{:search-config? true}' -sw $$ALL_CLOJURE_FILES && \
 	clojure-lsp --ns-exclude-regex ".*/src/status_im2/core\.cljs$$" clean-ns && \
 	sh scripts/lint-trailing-newline.sh --fix && \
-	yarn prettier
+	node_modules/.bin/prettier --write .
 
 shadow-server: export TARGET := clojure
 shadow-server:##@ Start shadow-cljs in server mode for watching

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -12,6 +12,15 @@ production = ENV["PRODUCTION"] == "1"
 # TODO: remove this flag once you upgrade react-native above version 0.70
 ENV['USE_CODEGEN_DISCOVERY'] = "1"
 
+# If inside a Nix shell, allow pod install
+inside_nix_shell = ENV['IN_NIX_SHELL']
+allow_pod_install = !inside_nix_shell.nil?
+
+unless allow_pod_install
+    puts "ERROR: 'pod install' must be run inside a Nix shell. Please ensure you're inside a nix shell and try again."
+    exit 1
+end
+
 abstract_target 'Status' do
   # Pods for StatusQuo
   config = use_native_modules!

--- a/package.json
+++ b/package.json
@@ -4,14 +4,8 @@
   "main": "modules/react-native-status/nodejs/bindings.js",
   "private": true,
   "scripts": {
-    "start": "react-native start",
-    "ios": "react-native run-ios",
-    "preinstall": "make status-go-library",
-    "app:compile:android": "shadow-cljs compile android",
-    "app:watch": "shadow-cljs watch android",
-    "app:packager": "react-native start --host 0.0.0.0 --port 8081",
-    "app:android": "react-native run-android",
-    "prettier": "node_modules/.bin/prettier --write ."
+    "_comment": "This also prevents 'yarn install' from running outside of nix.",
+    "preinstall": "scripts/check-nix-shell.sh && make status-go-library"
   },
   "dependencies": {
     "@babel/preset-typescript": "^7.17.12",

--- a/scripts/check-nix-shell.sh
+++ b/scripts/check-nix-shell.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Check if inside Nix shell
+if [[ -z "${IN_NIX_SHELL}" ]]; then
+    echo "ERROR: This command must be run inside a Nix shell. Please ensure you're inside a nix shell and try again."
+    exit 1
+fi


### PR DESCRIPTION
We've often seen cases of devs attempting to change dependencies outside a nix-shell and run into weird side effects
I've been guilt of doing this in the past myself.

This PR stops them from : 
- updating pods outside a nix shell
- updating node deps outside a nix shell

This PR also cleanup unused scripts in `package.json`

status: ready
