### PR TITLE
Fix chat lightbox shadow appearing when scrolling

### DIFF
--- a/src/js/worklets/lightbox.js
+++ b/src/js/worklets/lightbox.js
@@ -6,10 +6,3 @@ export function infoLayout(input, isTop) {
     return isTop ? input.value : -input.value;
   });
 }
-
-export function textSheet(input, isHeight) {
-  return useDerivedValue(function () {
-    'worklet';
-    return isHeight ? input.value : -input.value;
-  });
-}

--- a/src/status_im2/contexts/chat/lightbox/bottom_view.cljs
+++ b/src/status_im2/contexts/chat/lightbox/bottom_view.cljs
@@ -49,15 +49,15 @@
   [item index _ render-data]
   [:f> f-small-image item index _ render-data])
 
-
 (defn bottom-view
-  [messages index scroll-index insets animations derived item-width props state]
+  [messages index scroll-index insets animations derived item-width props state transparent?]
   (let [padding-horizontal (- (/ item-width 2) (/ c/focused-image-size 2))]
     [reanimated/linear-gradient
-     {:colors [colors/neutral-100-opa-100 colors/neutral-100-opa-50]
-      :start  {:x 0 :y 1}
-      :end    {:x 0 :y 0}
-      :style  (style/gradient-container insets animations derived)}
+     {:colors   [colors/neutral-100-opa-100 colors/neutral-100-opa-80 colors/neutral-100-opa-0]
+      :location [0.2 0.9]
+      :start    {:x 0 :y 1}
+      :end      {:x 0 :y 0}
+      :style    (style/gradient-container insets animations derived transparent?)}
      [text-sheet/view messages animations state props]
      [rn/flat-list
       {:ref                               #(reset! (:small-list-ref props) %)

--- a/src/status_im2/contexts/chat/lightbox/style.cljs
+++ b/src/status_im2/contexts/chat/lightbox/style.cljs
@@ -62,14 +62,16 @@
 
 ;;;; BOTTOM-VIEW
 (defn gradient-container
-  [insets {:keys [opacity]} {:keys [bottom-layout]}]
+  [insets {:keys [opacity]} {:keys [bottom-layout]} transparent?]
   (reanimated/apply-animations-to-style
    {:transform [{:translateY bottom-layout}]
     :opacity   opacity}
    {:position       :absolute
     :overflow       :visible
+    :display        (if @transparent? :none :flex)
     :bottom         0
     :padding-bottom (:bottom insets)
+    :padding-top    c/text-min-height
     :z-index        3}))
 
 (defn content-container
@@ -80,17 +82,27 @@
    :justify-content    :center})
 
 
-(defn background
+(defn background-bottom-gradient
   [{:keys [overlay-opacity]} z-index]
   (reanimated/apply-animations-to-style
-   {:opacity overlay-opacity}
-   {:background-color colors/neutral-100-opa-70
-    :position         :absolute
-    :top              0
-    :bottom           0
-    :z-index          z-index
-    :left             0
-    :right            0}))
+   {:opacity (reanimated/interpolate overlay-opacity [0 0.1 0.4 1] [0 0.1 1 1])}
+   {:position :absolute
+    :top      0
+    :bottom   0
+    :z-index  z-index
+    :left     0
+    :right    0}))
+
+(defn background-top-gradient
+  [{:keys [overlay-opacity]} z-index]
+  (reanimated/apply-animations-to-style
+   {:opacity (reanimated/interpolate overlay-opacity [0.3 1] [0 1])}
+   {:position :absolute
+    :top      0
+    :bottom   0
+    :z-index  z-index
+    :left     0
+    :right    0}))
 
 (defn bottom-inset-cover-up
   [insets]

--- a/src/status_im2/contexts/chat/lightbox/text_sheet/style.cljs
+++ b/src/status_im2/contexts/chat/lightbox/text_sheet/style.cljs
@@ -13,10 +13,11 @@
     :left     0
     :right    0}))
 
-(def text-style
+(defn text-style
+  [expanding-message?]
   {:color             colors/white
    :margin-horizontal 20
-   :margin-bottom     constants/text-margin
+   :align-items       (when-not expanding-message? :center)
    :flex-grow         1})
 
 (def bar-container
@@ -31,30 +32,37 @@
   {:width            32
    :height           4
    :border-radius    100
-   :background-color colors/white-opa-40
-   :border-width     0.5
-   :border-color     colors/neutral-100})
+   :background-color colors/white-opa-10})
 
 (defn top-gradient
-  [{:keys [gradient-opacity]} insets]
-  (reanimated/apply-animations-to-style
-   {:opacity gradient-opacity}
-   {:position :absolute
-    :left     0
-    :right    0
-    :top      (- (+ (:top insets)
-                    constants/top-view-height))
-    :height   (+ (:top insets)
-                 constants/top-view-height
-                 constants/bar-container-height
-                 constants/text-margin
-                 (* constants/line-height 2))
-    :z-index  1}))
+  [{:keys [derived-value]} {:keys [top]} insets max-height]
+  (let [initial-top (- (+ (:top insets)
+                          constants/top-view-height))
+        height      (+ (:top insets)
+                       constants/top-view-height
+                       (* constants/line-height 2))]
+    (reanimated/apply-animations-to-style
+     {:opacity (reanimated/interpolate derived-value
+                                       [max-height (+ max-height constants/line-height)]
+                                       [0 1])
+      :top     (reanimated/interpolate top
+                                       [0 (- max-height)]
+                                       [initial-top (- initial-top max-height)]
+                                       {:extrapolateLeft  "clamp"
+                                        :extrapolateRight "clamp"})}
+     {:position :absolute
+      :left     0
+      :height   height
+      :right    0
+      :z-index  1})))
 
-(def bottom-gradient
-  {:position :absolute
-   :left     0
-   :right    0
-   :height   28
-   :bottom   0
-   :z-index  1})
+(defn bottom-gradient
+  [bottom-inset]
+  (let [gradient-distance (+ constants/small-list-height bottom-inset)]
+    {:position :absolute
+     :left     0
+     :right    0
+     :height   (+ gradient-distance (* 2 constants/line-height))
+     :bottom   (- gradient-distance)
+     :opacity  0.8
+     :z-index  1}))

--- a/src/status_im2/contexts/chat/lightbox/text_sheet/utils.cljs
+++ b/src/status_im2/contexts/chat/lightbox/text_sheet/utils.cljs
@@ -3,41 +3,69 @@
     [oops.core :as oops]
     [react-native.gesture :as gesture]
     [react-native.reanimated :as reanimated]
-    [status-im2.contexts.chat.lightbox.constants :as constants]
-    [utils.worklets.lightbox :as worklet]))
+    [reagent.core :as r]
+    [status-im2.contexts.chat.lightbox.constants :as constants]))
+
+(defn- collapse-sheet
+  [{:keys [derived-value overlay-opacity saved-top expanded? overlay-z-index]}]
+  (reanimated/animate derived-value constants/text-min-height)
+  (reanimated/animate overlay-opacity 0)
+  (reanimated/set-shared-value saved-top (- constants/text-min-height))
+  (reset! expanded? false)
+  (js/setTimeout #(reset! overlay-z-index 0) 300))
 
 (defn sheet-gesture
   [{:keys [derived-value saved-top overlay-opacity gradient-opacity]}
-   expanded-height max-height overlay-z-index expanded? dragging?]
-  (-> (gesture/gesture-pan)
-      (gesture/on-start (fn []
-                          (reset! overlay-z-index 1)
-                          (reset! dragging? true)
-                          (reanimated/animate gradient-opacity 0)))
-      (gesture/on-update
-       (fn [e]
-         (let [new-value     (+ (reanimated/get-shared-value saved-top) (oops/oget e "translationY"))
-               bounded-value (max (min (- new-value) expanded-height) constants/text-min-height)
-               progress      (/ (- new-value) max-height)]
-           (reanimated/set-shared-value overlay-opacity progress)
-           (reanimated/set-shared-value derived-value bounded-value))))
-      (gesture/on-end
-       (fn []
-         (if (or (> (- (reanimated/get-shared-value derived-value))
-                    (reanimated/get-shared-value saved-top))
-                 (= (reanimated/get-shared-value derived-value)
-                    constants/text-min-height))
-           (do ; minimize
-             (reanimated/animate derived-value constants/text-min-height)
-             (reanimated/animate overlay-opacity 0)
-             (reanimated/set-shared-value saved-top (- constants/text-min-height))
-             (reset! expanded? false)
-             (js/setTimeout #(reset! overlay-z-index 0) 300))
-           (reanimated/set-shared-value saved-top
-                                        (- (reanimated/get-shared-value derived-value))))
-         (when (= (reanimated/get-shared-value derived-value) expanded-height)
-           (reset! expanded? true))
-         (reset! dragging? false)))))
+   expanded-height max-height full-height overlay-z-index expanded? dragging? expanding-message?]
+  (let [disable-gesture-update (r/atom false)]
+    (-> (gesture/gesture-pan)
+        (gesture/enabled expanding-message?)
+        (gesture/on-start (fn []
+                            (reset! overlay-z-index 1)
+                            (reset! dragging? true)
+                            (reset! disable-gesture-update false)
+                            (when (not expanded?)
+                              (reanimated/animate gradient-opacity 0))))
+        (gesture/on-update
+         (fn [e]
+           (when-not @disable-gesture-update
+             (let [event-value       (oops/oget e :translationY)
+                   old-value         (reanimated/get-shared-value saved-top)
+                   new-value         (+ old-value event-value)
+                   progress          (/ (- new-value) max-height)
+                   reached-expanded? (< new-value (- max-height))
+                   upper-boundary?   (< new-value (- full-height))
+                   lower-boundary?   (and (> new-value (- constants/text-min-height))
+                                          (pos? event-value))]
+               (when (and (not upper-boundary?) (not lower-boundary?))
+                 (reset! expanded? false)
+                 (reanimated/set-shared-value overlay-opacity progress)
+                 (reanimated/set-shared-value derived-value (- new-value)))
+               (when reached-expanded? (reset! expanded? true))
+               (when lower-boundary?
+                 (reset! disable-gesture-update true)
+                 (collapse-sheet {:derived-value   derived-value
+                                  :overlay-opacity overlay-opacity
+                                  :saved-top       saved-top
+                                  :expanded?       expanded?
+                                  :overlay-z-index overlay-z-index}))))))
+        (gesture/on-end
+         (fn []
+           (let [shared-derived-value (reanimated/get-shared-value derived-value)
+                 below-max-height?    (< shared-derived-value max-height)
+                 below-saved-top?     (> (- shared-derived-value)
+                                         (reanimated/get-shared-value saved-top))]
+             (if (and below-max-height? below-saved-top?)
+               (collapse-sheet {:derived-value   derived-value
+                                :overlay-opacity overlay-opacity
+                                :saved-top       saved-top
+                                :expanded?       expanded?
+                                :overlay-z-index overlay-z-index})
+               (reanimated/set-shared-value saved-top
+                                            (- shared-derived-value)))
+             (when (= shared-derived-value expanded-height)
+               (reset! expanded? true))
+             (reset! dragging? false)))))))
 
 (defn expand-sheet
   [{:keys [derived-value overlay-opacity saved-top]}
@@ -48,12 +76,6 @@
     (reanimated/set-shared-value saved-top (- expanded-height))
     (reset! overlay-z-index 1)
     (reset! expanded? true)))
-
-(defn on-scroll
-  [e expanded? dragging? {:keys [gradient-opacity]}]
-  (if (and (> (oops/oget e "nativeEvent.contentOffset.y") 0) expanded? (not dragging?))
-    (reanimated/animate gradient-opacity 1)
-    (reanimated/animate gradient-opacity 0)))
 
 (defn on-layout
   [e text-height]
@@ -68,5 +90,5 @@
 
 (defn init-derived-animations
   [{:keys [derived-value]}]
-  {:height (worklet/text-sheet derived-value true)
-   :top    (worklet/text-sheet derived-value false)})
+  {:height derived-value
+   :top    (reanimated/interpolate derived-value [0 1] [0 -1])})

--- a/src/status_im2/contexts/chat/lightbox/text_sheet/view.cljs
+++ b/src/status_im2/contexts/chat/lightbox/text_sheet/view.cljs
@@ -13,13 +13,7 @@
     [status-im2.contexts.chat.lightbox.text-sheet.utils :as utils]
     [status-im2.contexts.chat.messages.content.text.view :as message-view]))
 
-(defn bar
-  [text-height]
-  (when (> text-height (* constants/line-height 2))
-    [rn/view {:style style/bar-container}
-     [rn/view {:style style/bar}]]))
-
-(defn text-sheet
+(defn- text-sheet
   [messages overlay-opacity overlay-z-index text-sheet-lock?]
   (let [text-height (reagent/atom 0)
         expanded?   (reagent/atom false)
@@ -33,50 +27,63 @@
                                          constants/top-view-height
                                          (:bottom insets)
                                          (when platform/ios? (:top insets)))
-            expanded-height           (min max-height
-                                           (+ constants/bar-container-height
-                                              @text-height
-                                              constants/text-margin))
+            full-height               (+ constants/bar-container-height
+                                         constants/text-margin
+                                         constants/line-height
+                                         @text-height)
+            expanded-height           (min max-height full-height)
             animations                (utils/init-animations overlay-opacity)
-            derived                   (utils/init-derived-animations animations)]
-        [gesture/gesture-detector
-         {:gesture (utils/sheet-gesture animations
-                                        expanded-height
-                                        max-height
-                                        overlay-z-index
-                                        expanded?
-                                        dragging?)}
-         [reanimated/touchable-opacity
-          {:active-opacity 1
-           :on-press
-           #(utils/expand-sheet animations
-                                expanded-height
-                                max-height
-                                overlay-z-index
-                                expanded?
-                                text-sheet-lock?)
-           :style (style/sheet-container derived)}
-          [bar @text-height]
-          [reanimated/linear-gradient
-           {:colors [colors/neutral-100-opa-0 colors/neutral-100]
-            :start  {:x 0 :y 1}
-            :end    {:x 0 :y 0}
-            :style  (style/top-gradient animations insets)}]
-          [linear-gradient/linear-gradient
-           {:colors [colors/neutral-100-opa-50 colors/neutral-100-opa-0]
-            :start  {:x 0 :y 1}
-            :end    {:x 0 :y 0}
-            :style  style/bottom-gradient}]
-          [gesture/scroll-view
-           {:scroll-enabled        @expanded?
-            :scroll-event-throttle 16
-            :on-scroll             #(utils/on-scroll % @expanded? @dragging? animations)
-            :style                 {:height (- max-height constants/bar-container-height)}}
-           [message-view/render-parsed-text
-            {:content        content
-             :chat-id        chat-id
-             :style-override style/text-style
-             :on-layout      #(utils/on-layout % text-height)}]]]]))))
+            derived                   (utils/init-derived-animations animations)
+            expanding-message?        (> @text-height (* constants/line-height 2))]
+        [rn/view
+         [reanimated/linear-gradient
+          {:colors         [colors/neutral-100-opa-0 colors/neutral-100]
+           :pointer-events :none
+           :locations      [0 0.3]
+           :start          {:x 0 :y 1}
+           :end            {:x 0 :y 0}
+           :style          (style/top-gradient animations derived insets max-height)}]
+         [gesture/gesture-detector
+          {:gesture (utils/sheet-gesture animations
+                                         expanded-height
+                                         max-height
+                                         full-height
+                                         overlay-z-index
+                                         expanded?
+                                         dragging?
+                                         expanding-message?)}
+          [gesture/gesture-detector
+           {:gesture (-> (gesture/gesture-tap)
+                         (gesture/enabled (and expanding-message? (not @expanded?)))
+                         (gesture/on-start (fn []
+                                             (utils/expand-sheet animations
+                                                                 expanded-height
+                                                                 max-height
+                                                                 overlay-z-index
+                                                                 expanded?
+                                                                 text-sheet-lock?))))}
+           [reanimated/view {:style (style/sheet-container derived)}
+            (when expanding-message?
+              [rn/view {:style style/bar-container}
+               [rn/view {:style style/bar}]])
+            [linear-gradient/linear-gradient
+             {:colors    [colors/neutral-100-opa-100 colors/neutral-100-opa-70 colors/neutral-100-opa-0]
+              :start     {:x 0 :y 1}
+              :end       {:x 0 :y 0}
+              :locations [0.7 0.8 1]
+              :style     (style/bottom-gradient (:bottom insets))}]
+            [gesture/scroll-view
+             {:scroll-enabled          false
+              :scroll-event-throttle   16
+              :bounces                 false
+              :style                   {:height (- max-height constants/bar-container-height)}
+              :content-container-style {:padding-top (when (not expanding-message?)
+                                                       constants/bar-container-height)}}
+             [message-view/render-parsed-text
+              {:content        content
+               :chat-id        chat-id
+               :style-override (style/text-style expanding-message?)
+               :on-layout      #(utils/on-layout % text-height)}]]]]]]))))
 
 (defn view
   [messages {:keys [overlay-opacity]} {:keys [overlay-z-index]} {:keys [text-sheet-lock?]}]

--- a/src/status_im2/contexts/chat/lightbox/view.cljs
+++ b/src/status_im2/contexts/chat/lightbox/view.cljs
@@ -75,7 +75,16 @@
                 {:transform [{:translateY (:pan-y animations)}
                              {:translateX (:pan-x animations)}]}
                 {})}
-       [reanimated/view {:style (style/background animations @(:overlay-z-index state))}]
+       [reanimated/linear-gradient
+        {:colors         [colors/neutral-100-opa-0 colors/neutral-100-opa-0 colors/neutral-100-opa-100
+                          colors/neutral-100]
+         :locations      [0.3 0.4 0.6 1]
+         :pointer-events :none
+         :style          (style/background-bottom-gradient animations @(:overlay-z-index state))}]
+       [reanimated/linear-gradient
+        {:colors         [colors/neutral-100-opa-50 colors/neutral-100]
+         :pointer-events :none
+         :style          (style/background-top-gradient animations @(:overlay-z-index state))}]
        [gesture/flat-list
         {:ref                               #(reset! (:flat-list-ref props) %)
          :key-fn                            :message-id
@@ -85,6 +94,7 @@
          :data                              @data
          :render-fn                         image
          :render-data                       {:opacity-value     (:opacity animations)
+                                             :overlay-opacity   (:overlay-opacity animations)
                                              :border-value      (:border animations)
                                              :full-screen-scale (:full-screen-scale animations)
                                              :images-opacity    (:images-opacity animations)
@@ -105,9 +115,12 @@
          :shows-vertical-scroll-indicator   false
          :shows-horizontal-scroll-indicator false
          :on-viewable-items-changed         handle-items-changed}]]]
-     (when (and (not @transparent?) (not landscape?))
+     ;; NOTE: not un-mounting bottom-view based on `transparent?` (like we do with the top-view
+     ;;       above), since we need to save the state of the text-sheet position. Instead, we use
+     ;;       the `:display` style property to hide the bottom-sheet.
+     (when (not landscape?)
        [:f> bottom-view/bottom-view messages index scroll-index insets animations derived
-        item-width props state])]))
+        item-width props state transparent?])]))
 
 (defn- f-lightbox
   []

--- a/src/status_im2/contexts/chat/lightbox/zoomable_image/view.cljs
+++ b/src/status_im2/contexts/chat/lightbox/zoomable_image/view.cljs
@@ -6,6 +6,7 @@
     [react-native.orientation :as orientation]
     [react-native.platform :as platform]
     [react-native.reanimated :as reanimated]
+    [reagent.core :as r]
     [status-im2.contexts.chat.lightbox.animations :as anim]
     [status-im2.contexts.chat.lightbox.zoomable-image.constants :as c]
     [status-im2.contexts.chat.lightbox.zoomable-image.style :as style]
@@ -209,7 +210,8 @@
    image-dimensions-nil?]
   (let [{:keys [transparent? set-full-height?]} render-data
         portrait? (= curr-orientation orientation/portrait)
-        on-tap #(utils/toggle-opacity index render-data portrait?)
+        last-overlay-opacity (r/atom 0)
+        on-tap #(utils/toggle-opacity index render-data portrait? last-overlay-opacity)
         tap (tap-gesture on-tap)
         double-tap (double-tap-gesture dimensions animations rescale transparent? on-tap)
         pinch (pinch-gesture dimensions animations state rescale transparent? on-tap)
@@ -242,8 +244,8 @@
             zoom-out-signal                             (rf/sub [:lightbox/zoom-out-signal])
             {:keys [set-full-height? curr-orientation]} render-data
             focused?                                    (= shared-element-id message-id)
-            ;; TODO - remove `image-dimensions` check,
-            ;; once https://github.com/status-im/status-desktop/issues/10944 is fixed
+            ;; TODO - remove `image-dimensions` check, once
+            ;; https://github.com/status-im/status-desktop/issues/10944 is fixed
             image-dimensions-nil?                       (not (and image-width image-height))
             dimensions                                  (utils/get-dimensions
                                                          (or image-width (:screen-width render-data))

--- a/src/utils/worklets/lightbox.cljs
+++ b/src/utils/worklets/lightbox.cljs
@@ -5,7 +5,3 @@
 (defn info-layout
   [input top?]
   (.infoLayout ^js layout-worklets input top?))
-
-(defn text-sheet
-  [input height?]
-  (.textSheet ^js layout-worklets input height?))


### PR DESCRIPTION
fixes #17555

### Summary

Removed the "rogue" shadow effect, which happens when the message inside the lightbox component is fully expanded and the user scrolls the content further (bounce effect).

Additionally, I noticed a few differences with the [designs](https://www.figma.com/file/wA8Epdki2OWa8Vr067PCNQ/Composer-for-Mobile?type=design&node-id=6376-372864&mode=design&t=OEAQFb3NKTeqDUlR-4) so added a few changes to the gestures/styles, namely:
1. Gestures felt a bit weird because of using scrollview together with the pan handler e.g. can't drag down overflowing text since the scrollview takes over the touches from the pan handler (which is needed to allow scrolling the text up)
2. Background opacity was "re-starting" on text (that doesn't get to the top of the screen) if dragging it repeatedly when already fully expanded
3. When scrolling off-screen, the "draggable" bar should be hiding behind the header together with the text
4. Text can't be dragged lower that the initial position anymore (was causing issues with opacity, etc)
5. Changed the top/bottom gradients according to designs
6. Pressing text that covers the whole screen will move it below the header, meaning also that pressing it when it is already scrolled behind the header will move it to the top as well. This is helpful for _really_ long text, so the user can get to the beginning by pressing on it while being consistent with the expanding behaviour.
7. Fixed styles and removed gestures for one-lined text, according to designs

@OmarBasem since you worked on it originally, please have a look to make sure I didn't miss/break anything.


### Testing notes
<!-- (Optional) -->

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS


#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- 1-1 chats
- public chats
- group chats

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open any chat
- Send a message containing image and about 9 lines if text
- Open the sent image
- Start scrolling the image description
- Continue scrolling after the whole description is expanded
- Pay attention at shadow effect which appears during scrolling
<!-- (PRs will only be accepted if squashed into single commit.) -->

### Before and after screenshots comparison

https://github.com/status-im/-mobile/assets/21865759/f44b07f2-7637-4e78-89e0-cd1ab98e6a73

| Figma (if available) | iOS (if available)    | Android (if available)
| --- | --- | --- |
| Please embed Image/Video here of the before and after.  | <img src=https://github.com/status-im/status-mobile/assets/21865759/359123d2-3417-463d-847a-8c70ed49159a width=200 /> <img src=https://github.com/status-im/status-mobile/assets/21865759/13da911c-5313-4215-be7b-0d8c6882aa6f width=200 /> <img src=https://github.com/status-im/status-mobile/assets/21865759/b4ef09f4-8c7d-44fa-9eed-a172a8761702 width=200 />  | Please embed Image/Video here of the before and after. |

status: ready