### PR TITLE
Fix crash when selecting photos from cameraroll [iOS]

### DIFF
--- a/src/status_im2/contexts/chat/photo_selector/events.cljs
+++ b/src/status_im2/contexts/chat/photo_selector/events.cljs
@@ -43,7 +43,7 @@
         (merge {:first      num
                 :assetType  "Photos"
                 :groupTypes (if (= album (i18n/label :t/recent)) "All" "Albums")
-                :groupName  (when (not= album (i18n/label :t/recent)) album)
+                :groupName  (if (not= album (i18n/label :t/recent)) album "")
                 :include    ["imageSize"]}
                (when end-cursor
                  {:after end-cursor}))


### PR DESCRIPTION
fixes #17203

### Summary

Fix the crash when selecting a photo from the camera roll e.g. when selecting photos from the chat composer.

### Testing notes
<!-- (Optional) -->

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- iOS

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- 1-1 chats
- public chats
- group chats

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- Open Status
- Open chat
- Press the image selector from the composer
- (Optionally accept permissions)
- Select images to share
- When pressing `Confirm selection`, the app would crash

status: ready <!-- Can be ready or wip -->
