### PR TITLE
[#17497] fix: Unexpected lines are shown in the chat

### DIFF
--- a/src/status_im2/contexts/chat/messages/list/view.cljs
+++ b/src/status_im2/contexts/chat/messages/list/view.cljs
@@ -171,7 +171,7 @@
   [style]
   (cond-> style
     platform/android?
-    (assoc :scale-y -1)))
+    (assoc :scale-y -1.02)))
 
 (defn actions
   [chat-id cover-bg-color]


### PR DESCRIPTION
fixes #17497

I discovered that the issue is connected to the `scale-y` property. We implemented it this way because of an open issue in [React Native](https://github.com/facebook/react-native/issues/30034). The only workaround I've found so far is to increase the scale by an additional 0.02 to eliminate those lines.

#### Platforms
- Android

### Steps to test

1. Open any chat
2. Sent at least 4-5 messages
3. Check the chat

### Before and after screenshots comparison

Before 
<div>
 <img src="https://github.com/status-im/status-mobile/assets/71308738/614d56d6-9ef5-429c-a065-0d619a5dc939" width="375px"/>
 <img src="https://github.com/status-im/status-mobile/assets/71308738/914a74e7-c8ce-4cd3-bf91-bfd90aa04f76" width="375px"/>
</div>

After 
<div>
 <img src="https://github.com/status-im/status-mobile/assets/71308738/d0c42089-4f47-40a0-838a-c5f5860e6d96" width="375px"/>
 <img src="https://github.com/status-im/status-mobile/assets/71308738/d8dff837-d36f-4d0f-add9-29365158bee5" width="375px"/>
</div>




status: ready
