### PR TITLE
[WIP] fix muted colors of composer elements after reopening the chat

### DIFF
--- a/src/status_im2/contexts/chat/composer/effects.cljs
+++ b/src/status_im2/contexts/chat/composer/effects.cljs
@@ -74,8 +74,13 @@
   [{:keys [focused?]}
    {:keys [container-opacity]}
    {:keys [input-text images link-previews? reply audio]}]
-  (when (and (not @focused?) (utils/empty-input? input-text images link-previews? reply audio))
-    (reanimated/animate-delay container-opacity constants/empty-opacity 200)))
+  (reanimated/animate-delay
+   container-opacity
+   (if (and (not @focused?)
+            (utils/empty-input? input-text images link-previews? reply audio))
+     constants/empty-opacity
+     1)
+   200))
 
 (defn component-will-unmount
   [{:keys [keyboard-show-listener keyboard-hide-listener keyboard-frame-listener]}]
@@ -101,7 +106,11 @@
   (rn/use-effect
    (fn []
      (reenter-screen-effect state dimensions subscriptions))
-   [max-height subscriptions]))
+   [max-height subscriptions])
+  (rn/use-effect
+   (fn []
+     (empty-effect state animations subscriptions))
+   [subscriptions]))
 
 (defn use-edit
   [{:keys [input-ref]}

--- a/src/status_im2/contexts/chat/composer/utils.cljs
+++ b/src/status_im2/contexts/chat/composer/utils.cljs
@@ -209,21 +209,13 @@
 
 (defn init-animations
   [{:keys [input-text images link-previews? reply audio]}
-   lines content-height max-height opacity background-y]
+   lines content-height max-height opacity container-opacity background-y]
   (let [initial-height        (if (> lines 1)
                                 constants/multiline-minimized-height
                                 constants/input-height)
         bottom-content-height 0]
     {:gradient-opacity  (reanimated/use-shared-value 0)
-     :container-opacity (reanimated/use-shared-value
-                         (if (empty-input?
-                              input-text
-                              images
-                              link-previews?
-                              reply
-                              audio)
-                           0.7
-                           1))
+     :container-opacity container-opacity
      :height            (reanimated/use-shared-value
                          initial-height)
      :saved-height      (reanimated/use-shared-value

--- a/src/status_im2/contexts/chat/composer/view.cljs
+++ b/src/status_im2/contexts/chat/composer/view.cljs
@@ -32,6 +32,7 @@
            window-height
            blur-height
            opacity
+           container-opacity
            background-y
            theme]} props state]
   (let [{:keys [chat-screen-loaded?]
@@ -52,6 +53,7 @@
                                   content-height
                                   max-height
                                   opacity
+                                  container-opacity
                                   background-y)
         dimensions               {:content-height content-height
                                   :max-height     max-height
@@ -144,22 +146,24 @@
 
 (defn composer
   [{:keys [insets scroll-to-bottom-fn show-floating-scroll-down-button?]}]
-  (let [window-height (:height (rn/get-window))
-        theme         (quo.theme/use-theme-value)
-        opacity       (reanimated/use-shared-value 0)
-        background-y  (reanimated/use-shared-value (- window-height))
-        blur-height   (reanimated/use-shared-value (+ constants/composer-default-height
-                                                      (:bottom insets)))
-        extra-params  {:insets                            insets
-                       :window-height                     window-height
-                       :scroll-to-bottom-fn               scroll-to-bottom-fn
-                       :show-floating-scroll-down-button? show-floating-scroll-down-button?
-                       :blur-height                       blur-height
-                       :opacity                           opacity
-                       :background-y                      background-y
-                       :theme                             theme}
-        props         (utils/init-props)
-        state         (utils/init-state)]
+  (let [window-height     (:height (rn/get-window))
+        theme             (quo.theme/use-theme-value)
+        opacity           (reanimated/use-shared-value 0)
+        container-opacity (reanimated/use-shared-value 1)
+        background-y      (reanimated/use-shared-value (- window-height))
+        blur-height       (reanimated/use-shared-value (+ constants/composer-default-height
+                                                          (:bottom insets)))
+        extra-params      {:insets                            insets
+                           :window-height                     window-height
+                           :scroll-to-bottom-fn               scroll-to-bottom-fn
+                           :show-floating-scroll-down-button? show-floating-scroll-down-button?
+                           :blur-height                       blur-height
+                           :opacity                           opacity
+                           :background-y                      background-y
+                           :theme                             theme
+                           :container-opacity                 container-opacity}
+        props             (utils/init-props)
+        state             (utils/init-state)]
     [rn/view (when platform/ios? {:style {:z-index 1}})
      [reanimated/view {:style (style/background opacity background-y window-height)}]
      [sub-view/blur-view


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/17615

### Summary

`:container-opacity (reanimated/use-shared-value (if (empty-input? input-text images link-previews? reply audio) 0.7 1))`

Value of `empty-input?` function is returning `true/false` correctly according to `input-text` value, but for some reason `use-shared-value` caches old value when called again quickly. Probably a library bug.

status: wip (its fixing the bug, but opacity change of container is not smooth, fixing that)