### PR TITLE
[#17230] fix: fetch group member info

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.171.1",
-    "commit-sha1": "3326362b90ba3b853118ac0aa3be8502fc1aed4f",
-    "src-sha256": "1npjwhvckmldjy1p7mc6rml8i21mb23409mgl13dzysmlqkppqb1"
+    "version": "v0.171.6",
+    "commit-sha1": "27b770c41bd2896ebc30b01985eeea1fbe642fba",
+    "src-sha256": "1zbw5m3n9piwnkk63kw938m5pajsmm3z14sj9ia0dasa3kigc91d"
 }


### PR DESCRIPTION
fixes #17230

### Steps to test

1. User A creates group chat and invites User B and User C
2. User B goes offline
3. User C opens group chat
4. Open mentions list by User C
5. See which User's B data is fetched for User C

### Result

https://github.com/status-im/status-mobile/assets/71308738/fc4171a6-9731-4e18-a021-c3426ccba24c


status: ready
