### PR TITLE
chore: add floating button page component

### DIFF
--- a/src/status_im/ui/screens/profile/user/views.cljs
+++ b/src/status_im/ui/screens/profile/user/views.cljs
@@ -131,6 +131,13 @@
          :accessibility-label :appearance-settings-button
          :chevron             true
          :on-press            #(re-frame/dispatch [:navigate-to :quo-preview])}])
+     (when config/quo-preview-enabled?
+       [list.item/list-item
+        {:icon                :main-icons/appearance
+         :title               "Status IM Components"
+         :accessibility-label :status-im-common-components
+         :chevron             true
+         :on-press            #(re-frame/dispatch [:navigate-to :status-im-preview])}])
      [list.item/list-item
       {:icon                :main-icons/appearance
        :title               (i18n/label :t/appearance)

--- a/src/status_im2/common/floating_button_page/component_spec.cljs
+++ b/src/status_im2/common/floating_button_page/component_spec.cljs
@@ -1,0 +1,32 @@
+(ns status-im2.common.floating-button-page.component-spec
+  (:require [quo.core :as quo]
+            [status-im2.common.floating-button-page.view :as floating-button-page]
+            [test-helpers.component :as h]))
+
+(h/describe "floating button page"
+  (h/test "renders with a header and standard button"
+    (h/render [floating-button-page/view
+               {:header [quo/page-nav
+                         {:type        :title-description
+                          :title       "floating button page"
+                          :description "press right icon to swap button type"
+                          :text-align  :left
+                          :background  :blur
+                          :icon-name   :i/close}]
+                :footer [quo/button {} "continue"]}])
+    (h/is-truthy (h/get-by-text "continue"))
+    (h/is-truthy (h/get-by-text "floating button page")))
+
+  (h/test "renders with a header and a slide button"
+    (h/render [floating-button-page/view
+               {:header [quo/page-nav
+                         {:type        :title-description
+                          :title       "floating button page"
+                          :description "press right icon to swap button type"
+                          :text-align  :left
+                          :background  :blur
+                          :icon-name   :i/close}]
+                :footer [quo/slide-button
+                         {:track-text "We gotta slide"
+                          :track-icon :face-id}]}])
+    (h/is-truthy (h/get-by-text "We gotta slide"))))

--- a/src/status_im2/common/floating_button_page/floating_container/style.cljs
+++ b/src/status_im2/common/floating_button_page/floating_container/style.cljs
@@ -1,0 +1,18 @@
+(ns status-im2.common.floating-button-page.floating-container.style
+  (:require [react-native.platform :as platform]))
+
+(def container
+  {:width      "100%"
+   :margin-top :auto
+   :align-self :flex-end})
+
+(def view-container
+  (assoc container
+         :padding-left   20
+         :padding-right  20
+         :padding-top    12
+         :padding-bottom 12))
+
+(def blur-container
+  (merge container
+         (when platform/android? {:margin-left 20})))

--- a/src/status_im2/common/floating_button_page/floating_container/style.cljs
+++ b/src/status_im2/common/floating_button_page/floating_container/style.cljs
@@ -1,18 +1,17 @@
 (ns status-im2.common.floating-button-page.floating-container.style
-  (:require [react-native.platform :as platform]))
+  (:require [react-native.safe-area :as safe-area]))
 
-(def container
-  {:width      "100%"
-   :margin-top :auto
-   :align-self :flex-end})
+(defn content-container
+  [blur? keyboard-shown?]
+  (let [margin-bottom (if keyboard-shown? 0 (safe-area/get-bottom))]
+    (cond-> {:margin-top         :auto
+             :overflow           :hidden
+             :margin-bottom      margin-bottom
+             :padding-vertical   12
+             :padding-horizontal 20}
+      blur? (dissoc :padding-vertical :padding-horizontal))))
 
-(def view-container
-  (assoc container
-         :padding-left   20
-         :padding-right  20
-         :padding-top    12
-         :padding-bottom 12))
-
-(def blur-container
-  (merge container
-         (when platform/android? {:margin-left 20})))
+(def blur-inner-container
+  {:background-color   :transparent ; required, otherwise blur-view will shrink
+   :padding-vertical   12
+   :padding-horizontal 20})

--- a/src/status_im2/common/floating_button_page/floating_container/view.cljs
+++ b/src/status_im2/common/floating_button_page/floating_container/view.cljs
@@ -1,0 +1,75 @@
+(ns status-im2.common.floating-button-page.floating-container.view
+  (:require [quo.foundations.colors :as colors]
+            [quo.theme :as quo.theme]
+            [react-native.blur :as blur]
+            [react-native.core :as rn]
+            [react-native.platform :as platform]
+            [react-native.reanimated :as reanimated]
+            [react-native.safe-area :as safe-area]
+            [status-im2.common.floating-button-page.floating-container.style :as style]))
+
+(def duration 100)
+
+(defn blur-container-props
+  [theme]
+  {:blur-amount      12
+   :blur-radius      25
+   :blur-type        (quo.theme/theme-value :light :dark theme)
+   :style            (when platform/ios?
+                       {:width              "100%"
+                        :padding-horizontal 20
+                        :padding-vertical   12})
+   :background-color (colors/theme-colors colors/white-70-blur colors/neutral-80-opa-1-blur theme)})
+
+(defn- blur-container
+  [props & children]
+  [rn/view
+   (merge props
+          {:width    "100%"
+           :overflow :hidden}
+          (when platform/android?
+            {:padding-horizontal 20
+             :padding-vertical   12}))
+   (into [blur/view (blur-container-props (:theme props))] children)])
+
+"
+-        on-layout : will trigger to dynamically get the height of the container to screen using it.
+- show-background? : blurred container that is activated when this component is on top of the page content.
+-  keyboard-shown? : keyboard  is visible on the current page.
+"
+(defn get-margin-bottom
+  [show-background? keyboard-will-show?]
+  (if platform/android?
+    0
+    (cond keyboard-will-show?                        (safe-area/get-top)
+          (and show-background? keyboard-will-show?) (safe-area/get-bottom)
+          :else                                      (safe-area/get-bottom))))
+
+(defn f-view
+  [{:keys [on-layout show-background? keyboard-will-show?]}
+   children]
+  (let [theme                  (quo.theme/use-theme-value)
+        container-view         (if show-background? blur-container rn/view)
+        inline-container-style (if show-background? style/blur-container style/view-container)
+        margin-bottom          (reanimated/use-shared-value (get-margin-bottom show-background?
+                                                                               keyboard-will-show?))]
+    (rn/use-effect #(reanimated/animate-shared-value-with-timing
+                     margin-bottom
+                     (get-margin-bottom show-background? keyboard-will-show?)
+                     duration
+                     :easing4)
+                   [keyboard-will-show?])
+    [reanimated/view
+     {:style (reanimated/apply-animations-to-style
+              {:margin-bottom margin-bottom}
+              {:margin-top :auto})}
+     [container-view
+      {:on-layout on-layout
+       :theme theme
+       :style
+       (merge inline-container-style)}
+      children]]))
+
+(defn view
+  [props children]
+  [:f> f-view props children])

--- a/src/status_im2/common/floating_button_page/floating_container/view.cljs
+++ b/src/status_im2/common/floating_button_page/floating_container/view.cljs
@@ -1,75 +1,25 @@
 (ns status-im2.common.floating-button-page.floating-container.view
-  (:require [quo.foundations.colors :as colors]
-            [quo.theme :as quo.theme]
+  (:require [quo.theme :as quo.theme]
             [react-native.blur :as blur]
             [react-native.core :as rn]
-            [react-native.platform :as platform]
-            [react-native.reanimated :as reanimated]
-            [react-native.safe-area :as safe-area]
             [status-im2.common.floating-button-page.floating-container.style :as style]))
 
-(def duration 100)
-
-(defn blur-container-props
-  [theme]
-  {:blur-amount      12
-   :blur-radius      25
-   :blur-type        (quo.theme/theme-value :light :dark theme)
-   :style            (when platform/ios?
-                       {:width              "100%"
-                        :padding-horizontal 20
-                        :padding-vertical   12})
-   :background-color (colors/theme-colors colors/white-70-blur colors/neutral-80-opa-1-blur theme)})
-
 (defn- blur-container
-  [props & children]
+  [child theme]
+  [blur/view
+   {:blur-amount 12
+    :blur-radius 12
+    :blur-type   (quo.theme/theme-value :light :dark theme)}
+   [rn/view {:style style/blur-inner-container}
+    child]])
+
+(defn view-internal
+  [{:keys [theme on-layout keyboard-shown? blur?]} child]
   [rn/view
-   (merge props
-          {:width    "100%"
-           :overflow :hidden}
-          (when platform/android?
-            {:padding-horizontal 20
-             :padding-vertical   12}))
-   (into [blur/view (blur-container-props (:theme props))] children)])
+   {:style     (style/content-container blur? keyboard-shown?)
+    :on-layout on-layout}
+   (if blur?
+     [blur-container child theme]
+     child)])
 
-"
--        on-layout : will trigger to dynamically get the height of the container to screen using it.
-- show-background? : blurred container that is activated when this component is on top of the page content.
--  keyboard-shown? : keyboard  is visible on the current page.
-"
-(defn get-margin-bottom
-  [show-background? keyboard-will-show?]
-  (if platform/android?
-    0
-    (cond keyboard-will-show?                        (safe-area/get-top)
-          (and show-background? keyboard-will-show?) (safe-area/get-bottom)
-          :else                                      (safe-area/get-bottom))))
-
-(defn f-view
-  [{:keys [on-layout show-background? keyboard-will-show?]}
-   children]
-  (let [theme                  (quo.theme/use-theme-value)
-        container-view         (if show-background? blur-container rn/view)
-        inline-container-style (if show-background? style/blur-container style/view-container)
-        margin-bottom          (reanimated/use-shared-value (get-margin-bottom show-background?
-                                                                               keyboard-will-show?))]
-    (rn/use-effect #(reanimated/animate-shared-value-with-timing
-                     margin-bottom
-                     (get-margin-bottom show-background? keyboard-will-show?)
-                     duration
-                     :easing4)
-                   [keyboard-will-show?])
-    [reanimated/view
-     {:style (reanimated/apply-animations-to-style
-              {:margin-bottom margin-bottom}
-              {:margin-top :auto})}
-     [container-view
-      {:on-layout on-layout
-       :theme theme
-       :style
-       (merge inline-container-style)}
-      children]]))
-
-(defn view
-  [props children]
-  [:f> f-view props children])
+(def view (quo.theme/with-theme view-internal))

--- a/src/status_im2/common/floating_button_page/style.cljs
+++ b/src/status_im2/common/floating_button_page/style.cljs
@@ -1,0 +1,15 @@
+(ns status-im2.common.floating-button-page.style)
+
+(def page-container
+  {:position :absolute
+   :top      0
+   :bottom   0
+   :left     0
+   :right    0})
+
+(def keyboard-avoiding-view
+  {:position :absolute
+   :top      0
+   :bottom   0
+   :left     0
+   :right    0})

--- a/src/status_im2/common/floating_button_page/view.cljs
+++ b/src/status_im2/common/floating_button_page/view.cljs
@@ -8,111 +8,86 @@
     [status-im2.common.floating-button-page.floating-container.view :as floating-container]
     [status-im2.common.floating-button-page.style :as style]))
 
-(defn- show-background-android
-  [{:keys [window-height keyboard-height floating-container-height
-           content-scroll-y content-container-height header-height]} keyboard-did-show?]
-  (let [available-space (- window-height
-                           keyboard-height
-                           floating-container-height
-                           header-height)
-        content-height  (+ content-container-height
-                           content-scroll-y)]
-    (and keyboard-did-show? (< available-space content-height))))
+(defn- show-background
+  [{:keys [window-height keyboard-height footer-container-height content-scroll-y
+           content-container-height header-height keyboard-shown?]}]
+  (let [available-space    (- window-height
+                              (safe-area/get-top)
+                              header-height
+                              keyboard-height ; Already contains the bottom safe area value
+                              footer-container-height)
+        scroll-view-height (- content-container-height content-scroll-y)
+        overlap?           (< available-space scroll-view-height)]
+    (and keyboard-shown? overlap?)))
 
-(defn- show-background-ios
-  [{:keys [window-height keyboard-height floating-container-height
-           content-scroll-y content-container-height header-height]} keyboard-did-show?]
-  (let [available-space (- window-height
-                           keyboard-height
-                           floating-container-height
-                           (safe-area/get-top))
-        content-height  (+ (safe-area/get-bottom)
-                           header-height
-                           content-scroll-y
-                           content-container-height)]
-    (and keyboard-did-show? (< content-height available-space))))
-
-(defn set-height-on-layout
+(defn- set-height-on-layout
   [ratom]
   (fn [event]
     (let [height (oops/oget event "nativeEvent.layout.height")]
       (reset! ratom height))))
 
-(defn show-background
-  [props keyboard-did-show?]
-  (if platform/android?
-    (show-background-android props keyboard-did-show?)
-    (show-background-ios props keyboard-did-show?)))
-
 (defn view
-  [{:keys [header footer]}
-   page-content]
-  (reagent/with-let [window-height                       (:height (rn/get-window))
-                     floating-container-height           (reagent/atom 0)
-                     header-height                       (reagent/atom 0)
-                     content-container-height            (reagent/atom 0)
-                     content-scroll-y                    (reagent/atom 0)
-                     keyboard-height                     (reagent/atom 0)
-                     keyboard-will-show?                 (reagent/atom false)
-                     keyboard-did-show?                  (reagent/atom false)
-                     will-show-listener                  (oops/ocall rn/keyboard
-                                                                     "addListener"
-                                                                     "keyboardWillShow"
-                                                                     #(reset! keyboard-will-show? true))
-                     did-show-listener                   (oops/ocall
-                                                          rn/keyboard
-                                                          "addListener"
-                                                          "keyboardDidShow"
-                                                          (fn [value]
-                                                            (reset! keyboard-height
-                                                              (oops/oget value "endCoordinates.height"))
-                                                            (reset! keyboard-did-show? true)))
-
-                     will-hide-listener                  (oops/ocall rn/keyboard
-                                                                     "addListener"
-                                                                     "keyboardWillHide"
-                                                                     #(reset! keyboard-will-show? false))
-                     did-hide-listener                   (oops/ocall rn/keyboard
-                                                                     "addListener"
-                                                                     "keyboardDidHide"
-                                                                     #(reset! keyboard-did-show? false))
-                     heider-height-on-layout             (set-height-on-layout header-height)
-                     content-container-height-on-layout  (set-height-on-layout content-container-height)
-                     floating-container-height-on-layout (set-height-on-layout floating-container-height)
-                     content-y-on-scroll                 (fn [event]
-                                                           (let [y (oops/oget
-                                                                    event
-                                                                    "nativeEvent.contentOffset.y")]
-                                                             (reset! content-scroll-y y)))]
-    (let [show-background? (show-background {:window-height window-height
-                                             :floating-container-height
-                                             @floating-container-height
-                                             :keyboard-height @keyboard-height
-                                             :content-scroll-y @content-scroll-y
+  [{:keys [header footer]} & children]
+  (reagent/with-let [window-height                (:height (rn/get-window))
+                     footer-container-height      (reagent/atom 0)
+                     header-height                (reagent/atom 0)
+                     content-container-height     (reagent/atom 0)
+                     content-scroll-y             (reagent/atom 0)
+                     keyboard-height              (reagent/atom 0)
+                     keyboard-will-show?          (reagent/atom false)
+                     keyboard-did-show?           (reagent/atom false)
+                     will-show-listener           (oops/ocall rn/keyboard
+                                                              "addListener"
+                                                              "keyboardWillShow"
+                                                              #(reset! keyboard-will-show? true))
+                     did-show-listener            (oops/ocall rn/keyboard
+                                                              "addListener"
+                                                              "keyboardDidShow"
+                                                              (fn [e]
+                                                                (reset! keyboard-height
+                                                                  (oops/oget e "endCoordinates.height"))
+                                                                (reset! keyboard-did-show? true)))
+                     will-hide-listener           (oops/ocall rn/keyboard
+                                                              "addListener"
+                                                              "keyboardWillHide"
+                                                              #(reset! keyboard-will-show? false))
+                     did-hide-listener            (oops/ocall rn/keyboard
+                                                              "addListener"
+                                                              "keyboardDidHide"
+                                                              #(reset! keyboard-did-show? false))
+                     set-header-height            (set-height-on-layout header-height)
+                     set-content-container-height (set-height-on-layout content-container-height)
+                     set-footer-container-height  (set-height-on-layout footer-container-height)
+                     set-content-y-scroll         (fn [event]
+                                                    (reset! content-scroll-y
+                                                      (oops/oget event "nativeEvent.contentOffset.y")))]
+    (let [keyboard-shown?  (if platform/ios? @keyboard-will-show? @keyboard-did-show?)
+          show-background? (show-background {:window-height            window-height
+                                             :footer-container-height  @footer-container-height
+                                             :keyboard-height          @keyboard-height
+                                             :content-scroll-y         @content-scroll-y
                                              :content-container-height @content-container-height
-                                             :header-height @header-height}
-                                            @keyboard-did-show?)]
+                                             :header-height            @header-height
+                                             :keyboard-shown?          keyboard-shown?})]
+
       [rn/view {:style style/page-container}
-       [rn/view
-        {:on-layout heider-height-on-layout}
+       [rn/view {:on-layout set-header-height}
         header]
        [rn/scroll-view
-        {:on-scroll               content-y-on-scroll
+        {:on-scroll               set-content-y-scroll
          :scroll-event-throttle   64
-         :content-container-style {:flexGrow 1}}
-        [rn/view
-         {:on-layout content-container-height-on-layout}
-         page-content]]
+         :content-container-style {:flex-grow 1}}
+        (into [rn/view {:on-layout set-content-container-height}]
+              children)]
        [rn/keyboard-avoiding-view
-        {:style          style/keyboard-avoiding-view
-         :pointer-events :box-none}
+        {:style                    style/keyboard-avoiding-view
+         :keyboard-vertical-offset (if platform/ios? (safe-area/get-top) 0)
+         :pointer-events           :box-none}
         [floating-container/view
-         {:keyboard-will-show? @keyboard-will-show?
-          :show-background?    show-background?
-          :on-layout           floating-container-height-on-layout}
+         {:on-layout       set-footer-container-height
+          :keyboard-shown? keyboard-shown?
+          :blur?           show-background?}
          footer]]])
     (finally
-     (oops/ocall will-show-listener "remove")
-     (oops/ocall will-hide-listener "remove")
-     (oops/ocall did-show-listener "remove")
-     (oops/ocall did-hide-listener "remove"))))
+     (doseq [listener [will-show-listener will-hide-listener did-show-listener did-hide-listener]]
+       (oops/ocall listener "remove")))))

--- a/src/status_im2/common/floating_button_page/view.cljs
+++ b/src/status_im2/common/floating_button_page/view.cljs
@@ -1,0 +1,118 @@
+(ns status-im2.common.floating-button-page.view
+  (:require
+    [oops.core :as oops]
+    [react-native.core :as rn]
+    [react-native.platform :as platform]
+    [react-native.safe-area :as safe-area]
+    [reagent.core :as reagent]
+    [status-im2.common.floating-button-page.floating-container.view :as floating-container]
+    [status-im2.common.floating-button-page.style :as style]))
+
+(defn- show-background-android
+  [{:keys [window-height keyboard-height floating-container-height
+           content-scroll-y content-container-height header-height]} keyboard-did-show?]
+  (let [available-space (- window-height
+                           keyboard-height
+                           floating-container-height
+                           header-height)
+        content-height  (+ content-container-height
+                           content-scroll-y)]
+    (and keyboard-did-show? (< available-space content-height))))
+
+(defn- show-background-ios
+  [{:keys [window-height keyboard-height floating-container-height
+           content-scroll-y content-container-height header-height]} keyboard-did-show?]
+  (let [available-space (- window-height
+                           keyboard-height
+                           floating-container-height
+                           (safe-area/get-top))
+        content-height  (+ (safe-area/get-bottom)
+                           header-height
+                           content-scroll-y
+                           content-container-height)]
+    (and keyboard-did-show? (< content-height available-space))))
+
+(defn set-height-on-layout
+  [ratom]
+  (fn [event]
+    (let [height (oops/oget event "nativeEvent.layout.height")]
+      (reset! ratom height))))
+
+(defn show-background
+  [props keyboard-did-show?]
+  (if platform/android?
+    (show-background-android props keyboard-did-show?)
+    (show-background-ios props keyboard-did-show?)))
+
+(defn view
+  [{:keys [header footer]}
+   page-content]
+  (reagent/with-let [window-height                       (:height (rn/get-window))
+                     floating-container-height           (reagent/atom 0)
+                     header-height                       (reagent/atom 0)
+                     content-container-height            (reagent/atom 0)
+                     content-scroll-y                    (reagent/atom 0)
+                     keyboard-height                     (reagent/atom 0)
+                     keyboard-will-show?                 (reagent/atom false)
+                     keyboard-did-show?                  (reagent/atom false)
+                     will-show-listener                  (oops/ocall rn/keyboard
+                                                                     "addListener"
+                                                                     "keyboardWillShow"
+                                                                     #(reset! keyboard-will-show? true))
+                     did-show-listener                   (oops/ocall
+                                                          rn/keyboard
+                                                          "addListener"
+                                                          "keyboardDidShow"
+                                                          (fn [value]
+                                                            (reset! keyboard-height
+                                                              (oops/oget value "endCoordinates.height"))
+                                                            (reset! keyboard-did-show? true)))
+
+                     will-hide-listener                  (oops/ocall rn/keyboard
+                                                                     "addListener"
+                                                                     "keyboardWillHide"
+                                                                     #(reset! keyboard-will-show? false))
+                     did-hide-listener                   (oops/ocall rn/keyboard
+                                                                     "addListener"
+                                                                     "keyboardDidHide"
+                                                                     #(reset! keyboard-did-show? false))
+                     heider-height-on-layout             (set-height-on-layout header-height)
+                     content-container-height-on-layout  (set-height-on-layout content-container-height)
+                     floating-container-height-on-layout (set-height-on-layout floating-container-height)
+                     content-y-on-scroll                 (fn [event]
+                                                           (let [y (oops/oget
+                                                                    event
+                                                                    "nativeEvent.contentOffset.y")]
+                                                             (reset! content-scroll-y y)))]
+    (let [show-background? (show-background {:window-height window-height
+                                             :floating-container-height
+                                             @floating-container-height
+                                             :keyboard-height @keyboard-height
+                                             :content-scroll-y @content-scroll-y
+                                             :content-container-height @content-container-height
+                                             :header-height @header-height}
+                                            @keyboard-did-show?)]
+      [rn/view {:style style/page-container}
+       [rn/view
+        {:on-layout heider-height-on-layout}
+        header]
+       [rn/scroll-view
+        {:on-scroll               content-y-on-scroll
+         :scroll-event-throttle   64
+         :content-container-style {:flexGrow 1}}
+        [rn/view
+         {:on-layout content-container-height-on-layout}
+         page-content]]
+       [rn/keyboard-avoiding-view
+        {:style          style/keyboard-avoiding-view
+         :pointer-events :box-none}
+        [floating-container/view
+         {:keyboard-will-show? @keyboard-will-show?
+          :show-background?    show-background?
+          :on-layout           floating-container-height-on-layout}
+         footer]]])
+    (finally
+     (oops/ocall will-show-listener "remove")
+     (oops/ocall will-hide-listener "remove")
+     (oops/ocall did-show-listener "remove")
+     (oops/ocall did-hide-listener "remove"))))

--- a/src/status_im2/contexts/quo_preview/common.cljs
+++ b/src/status_im2/contexts/quo_preview/common.cljs
@@ -6,14 +6,14 @@
 
 
 (defn- view-internal
-  [{:keys [theme]}]
+  [{:keys [theme title]}]
   (let [logged-in?    (rf/sub [:multiaccount/logged-in?])
         has-profiles? (boolean (rf/sub [:profile/profiles-overview]))
         root          (if has-profiles? :profiles :intro)
         light?        (= theme :light)]
     [quo/page-nav
      {:type       :title
-      :title      "quo components preview"
+      :title      title
       :text-align :left
       :icon-name  :i/close
       :right-side [{:icon-name (if light? :i/dark :i/light)

--- a/src/status_im2/contexts/quo_preview/main.cljs
+++ b/src/status_im2/contexts/quo_preview/main.cljs
@@ -487,7 +487,7 @@
 (defn- main-screen
   []
   [:<>
-   [common/navigation-bar]
+   [common/navigation-bar {:title "Quo components preview"}]
    [rn/scroll-view {:style (style/main)}
     (for [category (sort screens-categories)]
       ^{:key (first category)}

--- a/src/status_im2/contexts/quo_preview/preview.cljs
+++ b/src/status_im2/contexts/quo_preview/preview.cljs
@@ -317,10 +317,10 @@
          children)])
 
 (defn- f-preview-container
-  [{:keys [state descriptor blur? blur-dark-only?
+  [{:keys [title state descriptor blur? blur-dark-only?
            component-container-style
            blur-container-style blur-view-props blur-height show-blur-background?]
-    :or   {blur-height 200}}
+    :or   {blur-height 200 title "quo component"}}
    & children]
   (let [theme (quo.theme/use-theme-value)]
     (rn/use-effect (fn []
@@ -332,7 +332,7 @@
     [rn/view
      {:style {:top  (safe-area/get-top)
               :flex 1}}
-     [common/navigation-bar]
+     [common/navigation-bar {:title title}]
      [rn/scroll-view
       {:style                           (style/panel-basic)
        :shows-vertical-scroll-indicator false}

--- a/src/status_im2/contexts/status_im_preview/common/floating_button_page/style.cljs
+++ b/src/status_im2/contexts/status_im_preview/common/floating_button_page/style.cljs
@@ -1,0 +1,16 @@
+(ns status-im2.contexts.status-im-preview.common.floating-button-page.style
+  (:require [quo.foundations.colors :as colors]
+            [react-native.safe-area :as safe-area]))
+
+(def background-image
+  {:position :absolute
+   :top      (- (safe-area/get-top))
+   :left     0
+   :right    0
+   :bottom   200})
+(defn page-content
+  [height]
+  {:flex             1
+   :height           height
+   :overflow         :hidden
+   :background-color (colors/resolve-color :army 30)})

--- a/src/status_im2/contexts/status_im_preview/common/floating_button_page/style.cljs
+++ b/src/status_im2/contexts/status_im_preview/common/floating_button_page/style.cljs
@@ -2,12 +2,17 @@
   (:require [quo.foundations.colors :as colors]
             [react-native.safe-area :as safe-area]))
 
+(defn container []
+  {:flex       1
+   :margin-top (safe-area/get-top)})
+
 (def background-image
   {:position :absolute
    :top      (- (safe-area/get-top))
    :left     0
    :right    0
    :bottom   200})
+
 (defn page-content
   [height]
   {:flex             1

--- a/src/status_im2/contexts/status_im_preview/common/floating_button_page/style.cljs
+++ b/src/status_im2/contexts/status_im_preview/common/floating_button_page/style.cljs
@@ -2,7 +2,8 @@
   (:require [quo.foundations.colors :as colors]
             [react-native.safe-area :as safe-area]))
 
-(defn container []
+(defn container
+  []
   {:flex       1
    :margin-top (safe-area/get-top)})
 

--- a/src/status_im2/contexts/status_im_preview/common/floating_button_page/view.cljs
+++ b/src/status_im2/contexts/status_im_preview/common/floating_button_page/view.cljs
@@ -1,0 +1,59 @@
+(ns status-im2.contexts.status-im-preview.common.floating-button-page.view
+  (:require [quo.core :as quo]
+            [re-frame.core :as rf]
+            [react-native.core :as rn]
+            [react-native.safe-area :as safe-area]
+            [reagent.core :as reagent]
+            [status-im2.common.floating-button-page.view :as floating-button-page]
+            [status-im2.common.resources :as resources]
+            [status-im2.contexts.status-im-preview.common.floating-button-page.style :as style]))
+
+(defn view
+  []
+  (let [content-height (reagent/atom 300)
+        slide?         (reagent/atom false)]
+    (fn []
+      [rn/view
+       {:flex       1
+        :margin-top (safe-area/get-top)}
+       (when-not @slide?
+         [rn/image
+          {:style  style/background-image
+           :source (resources/get-mock-image :dark-blur-bg)}])
+       [floating-button-page/view
+        {:header [quo/page-nav
+                  {:type        :title-description
+                   :title       "floating button page"
+                   :description "press right icon to swap button type"
+                   :text-align  :left
+                   :right-side  [{:icon-name :i/swap
+                                  :on-press  #(swap! slide? not)}]
+                   :background  :blur
+                   :icon-name   :i/close
+                   :on-press    #(rf/dispatch [:navigate-back])}]
+         :footer (if @slide?
+                   [quo/slide-button
+                    {:track-text          "We gotta slide"
+                     :track-icon          :face-id
+                     :container-style     {:z-index 2}
+                     :customization-color :blue
+                     :on-complete         #(js/alert "button slid")}
+                    "Save address"]
+                   [quo/button
+                    {:container-style {:z-index 2}
+                     :on-press        #(js/alert "button pressed")}
+                    "Save address"])}
+        [rn/view
+         {:style (style/page-content @content-height)}
+         [quo/text {:size :heading-1} "Page Content"]
+         [quo/input
+          {:auto-focus true
+           :value      ""}]
+         [quo/button
+          {:type     :outline
+           :on-press #(swap! content-height (fn [v] (+ v 10)))}
+          "increase height"]
+         [quo/button
+          {:type     :outline
+           :on-press #(swap! content-height (fn [v] (- v 10)))}
+          "decrease height"]]]])))

--- a/src/status_im2/contexts/status_im_preview/common/floating_button_page/view.cljs
+++ b/src/status_im2/contexts/status_im_preview/common/floating_button_page/view.cljs
@@ -10,7 +10,7 @@
 
 (defn view
   []
-  (let [content-height (reagent/atom 300)
+  (let [content-height (reagent/atom 450)
         slide?         (reagent/atom false)]
     (fn []
       [rn/view

--- a/src/status_im2/contexts/status_im_preview/common/floating_button_page/view.cljs
+++ b/src/status_im2/contexts/status_im_preview/common/floating_button_page/view.cljs
@@ -2,7 +2,6 @@
   (:require [quo.core :as quo]
             [re-frame.core :as rf]
             [react-native.core :as rn]
-            [react-native.safe-area :as safe-area]
             [reagent.core :as reagent]
             [status-im2.common.floating-button-page.view :as floating-button-page]
             [status-im2.common.resources :as resources]
@@ -13,9 +12,7 @@
   (let [content-height (reagent/atom 450)
         slide?         (reagent/atom false)]
     (fn []
-      [rn/view
-       {:flex       1
-        :margin-top (safe-area/get-top)}
+      [rn/view {:style (style/container)}
        (when-not @slide?
          [rn/image
           {:style  style/background-image
@@ -43,8 +40,7 @@
                     {:container-style {:z-index 2}
                      :on-press        #(js/alert "button pressed")}
                     "Save address"])}
-        [rn/view
-         {:style (style/page-content @content-height)}
+        [rn/view {:style (style/page-content @content-height)}
          [quo/text {:size :heading-1} "Page Content"]
          [quo/input
           {:auto-focus true

--- a/src/status_im2/contexts/status_im_preview/main.cljs
+++ b/src/status_im2/contexts/status_im_preview/main.cljs
@@ -1,0 +1,59 @@
+(ns status-im2.contexts.status-im-preview.main
+  (:refer-clojure :exclude [filter])
+  (:require
+    [quo.core :as quo]
+    [react-native.core :as rn]
+    [reagent.core :as reagent]
+    [status-im2.contexts.quo-preview.common :as common]
+    [status-im2.contexts.status-im-preview.common.floating-button-page.view :as floating-button-page]
+    [status-im2.contexts.status-im-preview.style :as style]
+    [utils.re-frame :as rf]))
+
+(def screens-categories
+  {:common [{:name      :floating-button-page
+             :component floating-button-page/view}]})
+
+(defn- category-view
+  []
+  (let [open?    (reagent/atom false)
+        on-press #(swap! open? not)]
+    (fn [category]
+      [rn/view {:style {:margin-vertical 8}}
+       [quo/dropdown
+        {:type     :grey
+         :state    (if @open? :active :default)
+         :on-press on-press}
+        (name (key category))]
+       (when @open?
+         (for [{category-name :name} (val category)]
+           ^{:key category-name}
+           [quo/button
+            {:type            :outline
+             :container-style {:margin-vertical 8}
+             :on-press        #(rf/dispatch [:navigate-to category-name])}
+            (name category-name)]))])))
+
+(defn- main-screen
+  []
+  [:<>
+   [common/navigation-bar {:title "Status IM components"}]
+   [rn/scroll-view {:style (style/main)}
+    (for [category (sort screens-categories)]
+      ^{:key (first category)}
+      [category-view category])]])
+
+(def screens
+  (->> screens-categories
+       (map val)
+       flatten
+       (map (fn [subcategory]
+              (update-in subcategory
+                         [:options :topBar]
+                         merge
+                         {:visible false})))))
+
+(def main-screens
+  [{:name      :status-im-preview
+    :options   {:topBar {:visible false}
+                :insets {:top? true}}
+    :component main-screen}])

--- a/src/status_im2/contexts/status_im_preview/style.cljs
+++ b/src/status_im2/contexts/status_im_preview/style.cljs
@@ -1,0 +1,10 @@
+(ns status-im2.contexts.status-im-preview.style
+  (:require
+    [quo.foundations.colors :as colors]))
+
+(defn main
+  []
+  {:flex               1
+   :padding-bottom     8
+   :padding-horizontal 16
+   :background-color   (colors/theme-colors colors/white colors/neutral-90)})

--- a/src/status_im2/contexts/syncing/setup_syncing/view.cljs
+++ b/src/status_im2/contexts/syncing/setup_syncing/view.cljs
@@ -66,7 +66,7 @@
           :background :blur
           :on-press   #(rf/dispatch [:navigate-back])
           :right-side [{:icon-left :i/info
-                        :label     (i18n/label :t/how-to-pair)
+                        :label     "swap button"
                         :on-press  #(rf/dispatch [:open-modal :how-to-pair])}]}]
         [rn/view {:style style/page-container}
          [rn/view {:style style/title-container}

--- a/src/status_im2/contexts/syncing/setup_syncing/view.cljs
+++ b/src/status_im2/contexts/syncing/setup_syncing/view.cljs
@@ -66,7 +66,7 @@
           :background :blur
           :on-press   #(rf/dispatch [:navigate-back])
           :right-side [{:icon-left :i/info
-                        :label     "swap button"
+                        :label     (i18n/label :t/how-to-pair)
                         :on-press  #(rf/dispatch [:open-modal :how-to-pair])}]}]
         [rn/view {:style style/page-container}
          [rn/view {:style style/title-container}

--- a/src/status_im2/core_spec.cljs
+++ b/src/status_im2/core_spec.cljs
@@ -1,5 +1,6 @@
 (ns status-im2.core-spec
   (:require
+    [status-im2.common.floating-button-page.component-spec]
     [status-im2.contexts.chat.messages.content.audio.component-spec]
     [status-im2.contexts.communities.actions.community-options.component-spec]
     [status-im2.contexts.wallet.create-account.edit-derivation-path.component-spec]))

--- a/src/status_im2/navigation/screens.cljs
+++ b/src/status_im2/navigation/screens.cljs
@@ -32,6 +32,7 @@
     [status-im2.contexts.shell.activity-center.view :as activity-center]
     [status-im2.contexts.shell.jump-to.view :as shell]
     [status-im2.contexts.shell.share.view :as share]
+    [status-im2.contexts.status-im-preview.main :as status-im-preview]
     [status-im2.contexts.syncing.find-sync-code.view :as find-sync-code]
     [status-im2.contexts.syncing.how-to-pair.view :as how-to-pair]
     [status-im2.contexts.syncing.scan-sync-code-page.view :as scan-sync-code-page]
@@ -46,7 +47,7 @@
     [status-im2.contexts.wallet.create-account.select-keypair.view :as wallet-select-keypair]
     [status-im2.contexts.wallet.create-account.view :as wallet-create-account]
     [status-im2.contexts.wallet.edit-account.view :as wallet-edit-account]
-    [status-im2.contexts.wallet.saved-address.view :as wallet-saved-address]
+    [status-im2.contexts.wallet.saved-addresses.view :as wallet-saved-addresses]
     [status-im2.contexts.wallet.scan-account.view :as scan-address]
     [status-im2.contexts.wallet.send.select-address.view :as wallet-select-address]
     [status-im2.navigation.options :as options]
@@ -283,8 +284,8 @@
      :options   {:insets {:top? true}}
      :component wallet-create-account/view}
 
-    {:name      :wallet-saved-address
-     :component wallet-saved-address/view}
+    {:name      :wallet-saved-addresses
+     :component wallet-saved-addresses/view}
 
     {:name      :wallet-select-address
      :options   {:modalPresentationStyle :overCurrentContext}
@@ -305,4 +306,11 @@
      quo.preview/screens)
 
    (when config/quo-preview-enabled?
-     quo.preview/main-screens)))
+     quo.preview/main-screens)
+
+   (when config/quo-preview-enabled?
+     status-im-preview/screens)
+
+   (when config/quo-preview-enabled?
+     status-im-preview/main-screens)))
+

--- a/test/jest/jestSetup.js
+++ b/test/jest/jestSetup.js
@@ -9,7 +9,7 @@ jest.mock('@react-native-async-storage/async-storage', () => mockAsyncStorage);
 
 jest.mock('react-native-navigation', () => ({
   getNavigationConstants: () => ({ constants: [] }),
-  Navigation: { constants: async () => {} },
+  Navigation: { constants: async () => { } },
 }));
 
 jest.mock('react-native-background-timer', () => ({}));
@@ -24,6 +24,12 @@ jest.mock('react-native-languages', () => ({
     locale: 'en',
   },
 }));
+
+jest.mock('react-native-static-safe-area-insets', () => ({
+  default: {
+    safeAreaInsetsTop: 0,
+    safeAreaInsetsBottom: 0,
+  }}));
 
 jest.mock('react-native-permissions', () => require('react-native-permissions/mock'));
 
@@ -62,6 +68,11 @@ jest.mock('@react-native-community/audio-toolkit', () => ({
     SoloAmbient: 3,
   },
 }));
+
+jest.mock("react-native", () => ({
+  ...jest.requireActual("react-native"),
+  "Keyboard"
+}))
 
 jest.mock('i18n-js', () => ({
   ...jest.requireActual('i18n-js'),

--- a/test/jest/jestSetup.js
+++ b/test/jest/jestSetup.js
@@ -9,7 +9,7 @@ jest.mock('@react-native-async-storage/async-storage', () => mockAsyncStorage);
 
 jest.mock('react-native-navigation', () => ({
   getNavigationConstants: () => ({ constants: [] }),
-  Navigation: { constants: async () => { } },
+  Navigation: { constants: async () => {} },
 }));
 
 jest.mock('react-native-background-timer', () => ({}));
@@ -29,7 +29,8 @@ jest.mock('react-native-static-safe-area-insets', () => ({
   default: {
     safeAreaInsetsTop: 0,
     safeAreaInsetsBottom: 0,
-  }}));
+  },
+}));
 
 jest.mock('react-native-permissions', () => require('react-native-permissions/mock'));
 
@@ -68,11 +69,6 @@ jest.mock('@react-native-community/audio-toolkit', () => ({
     SoloAmbient: 3,
   },
 }));
-
-jest.mock("react-native", () => ({
-  ...jest.requireActual("react-native"),
-  "Keyboard"
-}))
 
 jest.mock('i18n-js', () => ({
   ...jest.requireActual('i18n-js'),


### PR DESCRIPTION
fixes: https://github.com/status-im/status-mobile/issues/17747

This pr adds a common page component that is consistently used in the designs. It is for pages that have scrolling content and a button at the bottom to call some action.  when the keyboard is visible on these pages the button should sit on top of the keyboard and if the button is over the content of the page then a blur background will sit behind the button. The button can be a slide button or a regular button.

Additionally this pr starts adding a preview space for Status IM common components to be displayed. More work around this will be created, for now I added the minimum required to get this started.

A video of it working on ios

https://github.com/status-im/status-mobile/assets/22799766/33b26c07-f81f-4b0a-b9f6-e878e904a00d


Checked with Figma and everything is aligning nicely 👍 

No test needed as this is only a new component not touching production code

Design review will be nice to verify the behaviour is working as expected, however it will be easier to check on a nicer page then the preview screen I created :)