### PR TITLE
warn users when running component tests of clojure/metro terminals

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -362,6 +362,7 @@ component-test-watch: export TARGET := clojure
 component-test-watch: export COMPONENT_TEST := true
 component-test-watch: export BABEL_ENV := test
 component-test-watch: ##@ Watch tests and re-run no changes to cljs files
+	@@scripts/check-metro-shadow-process.sh
 	rm -rf ./component-spec
 	yarn install
 	nodemon --exec 'yarn shadow-cljs compile component-test && jest --config=test/jest/jest.config.js' -e cljs
@@ -370,6 +371,7 @@ component-test: export TARGET := clojure
 component-test: export COMPONENT_TEST := true
 component-test: export BABEL_ENV := test
 component-test: ##@test Run component tests once in NodeJS
+	@scripts/check-metro-shadow-process.sh
 	rm -rf ./component-spec
 	yarn install
 	yarn shadow-cljs compile component-test && \

--- a/scripts/check-metro-shadow-process.sh
+++ b/scripts/check-metro-shadow-process.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+if pgrep -f 'shadow-cljs watch mobile' > /dev/null; then
+    echo "Error: make run-clojure is already running in another terminal" >&2
+    echo "Please close that terminal before running this command." >&2
+    exit 1
+fi
+
+if pgrep -f 'react-native start' > /dev/null; then
+    echo "Error: make run-metro is already running in another terminal" >&2
+    echo "Please close that terminal before running this command." >&2
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION

As reported by @J-Son89 

Many times devs run 
`make component-test` or` make component-test-watch` when there is already a metro or clojure terminal running on their system.
This causes weird behaviour and it is advised to not run them together.

This PR prevents that and shows a warning.

status: ready
