### PR TITLE
Collectibles list on accounts page connected to backend

### DIFF
--- a/src/status_im/ethereum/subscriptions.cljs
+++ b/src/status_im/ethereum/subscriptions.cljs
@@ -74,9 +74,12 @@
             "blockNumber" blockNumber
             "accounts"    accounts)
   (case type
-    "new-transfers"              (new-transfers cofx blockNumber accounts)
-    "recent-history-fetching"    (recent-history-fetching-started cofx accounts)
-    "recent-history-ready"       (recent-history-fetching-ended cofx event)
-    "fetching-history-error"     (fetching-error cofx event)
-    "non-archival-node-detected" (non-archival-node-detected cofx event)
+    "new-transfers"                            (new-transfers cofx blockNumber accounts)
+    "recent-history-fetching"                  (recent-history-fetching-started cofx accounts)
+    "recent-history-ready"                     (recent-history-fetching-ended cofx event)
+    "fetching-history-error"                   (fetching-error cofx event)
+    "non-archival-node-detected"               (non-archival-node-detected cofx event)
+    "wallet-owned-collectibles-filtering-done" {:fx [[:dispatch
+                                                      [:wallet/owned-collectibles-filtering-done
+                                                       event]]]}
     (log/warn ::unknown-wallet-event :type type :event event)))

--- a/src/status_im2/common/log.cljs
+++ b/src/status_im2/common/log.cljs
@@ -1,5 +1,6 @@
 (ns status-im2.common.log
   (:require
+    [clojure.pprint :as p]
     [clojure.string :as string]
     [native-module.core :as native-module]
     [re-frame.core :as re-frame]
@@ -37,10 +38,16 @@
                                 string/lower-case
                                 keyword))
         (log/merge-config!
-         {:output-fn (fn [& data]
-                       (let [res (apply log/default-output-fn data)]
-                         (add-log-entry res)
-                         res))})
+         {:output-fn  (fn [& data]
+                        (let [res (apply log/default-output-fn data)]
+                          (add-log-entry res)
+                          res))
+          :middleware [(fn [data]
+                         (update data
+                                 :vargs
+                                 (partial mapv #(if (string? %) % (with-out-str (p/pprint %))))))]
+
+         })
         (native-module/init-status-go-logging logging-params)))))
 
 (re-frame/reg-fx

--- a/src/status_im2/common/log.cljs
+++ b/src/status_im2/common/log.cljs
@@ -45,9 +45,7 @@
           :middleware [(fn [data]
                          (update data
                                  :vargs
-                                 (partial mapv #(if (string? %) % (with-out-str (p/pprint %))))))]
-
-         })
+                                 (partial mapv #(if (string? %) % (with-out-str (p/pprint %))))))]})
         (native-module/init-status-go-logging logging-params)))))
 
 (re-frame/reg-fx

--- a/src/status_im2/contexts/wallet/common/collectibles_tab/view.cljs
+++ b/src/status_im2/contexts/wallet/common/collectibles_tab/view.cljs
@@ -4,14 +4,15 @@
     [react-native.core :as rn]
     [status-im2.contexts.wallet.common.empty-tab.view :as empty-tab]
     [utils.i18n :as i18n]
+    [clojure.string :as string]
     [utils.re-frame :as rf]))
 
 (defn- collectible-image-url
-  [{:keys [image_url animation_url animation_media_type]}]
-  (if (and (not= "" animation_url)
-           (not= animation_media_type "image/svg+xml"))
-    animation_url
-    image_url))
+  [{:keys [image-url animation-url animation-media-type]}]
+  (if (and (not (string/blank? animation-url))
+           (not= animation-media-type "image/svg+xml"))
+    animation-url
+    image-url))
 
 (defn view
   []

--- a/src/status_im2/contexts/wallet/common/collectibles_tab/view.cljs
+++ b/src/status_im2/contexts/wallet/common/collectibles_tab/view.cljs
@@ -3,14 +3,19 @@
     [quo.core :as quo]
     [react-native.core :as rn]
     [status-im2.contexts.wallet.common.empty-tab.view :as empty-tab]
-    [status-im2.contexts.wallet.common.temp :as temp]
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]))
 
+(defn- collectible-image-url
+  [{:keys [image_url animation_url animation_media_type]}]
+  (if (and (not= "" animation_url)
+           (not= animation_media_type "image/svg+xml"))
+    animation_url
+    image_url))
 
 (defn view
   []
-  (let [collectible-list temp/collectible-list]
+  (let [collectible-list (rf/sub [:wallet/collectibles])]
     (if (empty? collectible-list)
       [empty-tab/view
        {:title        (i18n/label :t/no-collectibles)
@@ -21,7 +26,9 @@
         :style                   {:flex 1}
         :content-container-style {:align-items :center}
         :num-columns             2
-        :render-fn               (fn [item] [quo/collectible
-                                             {:images   (repeat 1 item)
-                                              :on-press #(rf/dispatch [:navigate-to
-                                                                       :wallet-collectible])}])}])))
+        :render-fn               (fn [collectible]
+                                   [quo/collectible
+                                    {:images   [(collectible-image-url collectible)]
+                                     :on-press #(rf/dispatch
+                                                 [:navigate-to
+                                                  :wallet-collectible])}])}])))

--- a/src/status_im2/contexts/wallet/common/collectibles_tab/view.cljs
+++ b/src/status_im2/contexts/wallet/common/collectibles_tab/view.cljs
@@ -1,10 +1,10 @@
 (ns status-im2.contexts.wallet.common.collectibles-tab.view
   (:require
+    [clojure.string :as string]
     [quo.core :as quo]
     [react-native.core :as rn]
     [status-im2.contexts.wallet.common.empty-tab.view :as empty-tab]
     [utils.i18n :as i18n]
-    [clojure.string :as string]
     [utils.re-frame :as rf]))
 
 (defn- collectible-image-url

--- a/src/status_im2/contexts/wallet/common/collectibles_tab/view.cljs
+++ b/src/status_im2/contexts/wallet/common/collectibles_tab/view.cljs
@@ -1,18 +1,10 @@
 (ns status-im2.contexts.wallet.common.collectibles-tab.view
   (:require
-    [clojure.string :as string]
     [quo.core :as quo]
     [react-native.core :as rn]
     [status-im2.contexts.wallet.common.empty-tab.view :as empty-tab]
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]))
-
-(defn- collectible-image-url
-  [{:keys [image-url animation-url animation-media-type]}]
-  (if (and (not (string/blank? animation-url))
-           (not= animation-media-type "image/svg+xml"))
-    animation-url
-    image-url))
 
 (defn view
   []
@@ -27,9 +19,9 @@
         :style                   {:flex 1}
         :content-container-style {:align-items :center}
         :num-columns             2
-        :render-fn               (fn [collectible]
+        :render-fn               (fn [{:keys [preview-url]}]
                                    [quo/collectible
-                                    {:images   [(collectible-image-url collectible)]
+                                    {:images   [preview-url]
                                      :on-press #(rf/dispatch
                                                  [:navigate-to
                                                   :wallet-collectible])}])}])))

--- a/src/status_im2/contexts/wallet/events.cljs
+++ b/src/status_im2/contexts/wallet/events.cljs
@@ -125,11 +125,11 @@
 (rf/reg-event-fx :wallet/clear-stored-collectibles clear-stored-collectibles)
 
 (rf/reg-event-fx :wallet/request-collectibles
- (fn [{:keys [db]} [{:keys [offset new-request?]}]]
+ (fn [{:keys [db]} [{:keys [start-at-index new-request?]}]]
    (let [request-params [0
                          [(chain/chain-id db)]
                          (map :address (:profile/wallet-accounts db))
-                         offset
+                         start-at-index
                          collectibles-request-batch-size]]
      {:json-rpc/call [{:method     "wallet_filterOwnedCollectiblesAsync"
                        :params     request-params
@@ -148,11 +148,10 @@
    (let [response                               (cske/transform-keys csk/->kebab-case-keyword
                                                                      (types/json->clj message))
          {:keys [collectibles has-more offset]} response
-         next-offset                            (+ offset (count collectibles))]
+         start-at-index                         (+ offset (count collectibles))]
      {:fx
       [[:dispatch [:wallet/store-collectibles collectibles]]
        (when has-more
          [:dispatch
           [:wallet/request-collectibles
-           {:offset next-offset}]])]})))
-
+           {:start-at-index start-at-index}]])]})))

--- a/src/status_im2/contexts/wallet/events_test.cljs
+++ b/src/status_im2/contexts/wallet/events_test.cljs
@@ -20,3 +20,52 @@
             effects     (events/clean-scanned-address {:db db})
             result-db   (:db effects)]
         (is (= result-db expected-db))))))
+
+(deftest store-collectibles
+  (let []
+    (testing "(displayable-collectible?) helper function"
+      (let [expected-results [[true {:image-url "https://..." :animation-url "https://..."}]
+                              [true {:image-url "" :animation-url "https://..."}]
+                              [true {:image-url nil :animation-url "https://..."}]
+                              [true {:image-url "https://..." :animation-url ""}]
+                              [true {:image-url "https://..." :animation-url nil}]
+                              [false {:image-url "" :animation-url nil}]
+                              [false {:image-url nil :animation-url nil}]
+                              [false {:image-url nil :animation-url ""}]
+                              [false {:image-url "" :animation-url ""}]]]
+        (doseq [[result collection] expected-results]
+          (is (= result (events/displayable-collectible? collection))))))
+    (testing "save-collectibles-request-details"
+      (let [db           {:wallet {}}
+            collectibles [{:image-url "https://..." :animation-url "https://..."}
+                          {:image-url "" :animation-url "https://..."}
+                          {:image-url "" :animation-url nil}]
+            expected-db  {:wallet {:collectibles [{:image-url "https://..." :animation-url "https://..."}
+                                                  {:image-url "" :animation-url "https://..."}]}}
+            effects      (events/store-collectibles {:db db} [collectibles])
+            result-db    (:db effects)]
+        (is (= result-db expected-db))))))
+
+(deftest clear-stored-collectibles
+  (let [db {:wallet {:collectibles [{:id 1} {:id 2}]}}]
+    (testing "clear-stored-collectibles"
+      (let [expected-db {:wallet {}}
+            effects     (events/clear-stored-collectibles {:db db})
+            result-db   (:db effects)]
+        (is (= result-db expected-db))))))
+
+(deftest save-collectibles-request-details
+  (let [db {:wallet {}}]
+    (testing "save-collectibles-request-details"
+      (let [expected-db {:wallet {:ongoing-collectibles-request {:addresses ["1" "2" "3"]}}}
+            effects     (events/save-collectibles-request-details {:db db} [{:addresses ["1" "2" "3"]}])
+            result-db   (:db effects)]
+        (is (= result-db expected-db))))))
+
+(deftest clear-collectibles-request-details
+  (let [db {:wallet {:ongoing-collectibles-request {:addresses ["1" "2" "3"]}}}]
+    (testing "clear-stored-collectibles"
+      (let [expected-db {:wallet {}}
+            effects     (events/clear-collectibles-request-details {:db db})
+            result-db   (:db effects)]
+        (is (= result-db expected-db))))))

--- a/src/status_im2/contexts/wallet/events_test.cljs
+++ b/src/status_im2/contexts/wallet/events_test.cljs
@@ -53,19 +53,3 @@
             effects     (events/clear-stored-collectibles {:db db})
             result-db   (:db effects)]
         (is (= result-db expected-db))))))
-
-(deftest save-collectibles-request-details
-  (let [db {:wallet {}}]
-    (testing "save-collectibles-request-details"
-      (let [expected-db {:wallet {:ongoing-collectibles-request {:addresses ["1" "2" "3"]}}}
-            effects     (events/save-collectibles-request-details {:db db} [{:addresses ["1" "2" "3"]}])
-            result-db   (:db effects)]
-        (is (= result-db expected-db))))))
-
-(deftest clear-collectibles-request-details
-  (let [db {:wallet {:ongoing-collectibles-request {:addresses ["1" "2" "3"]}}}]
-    (testing "clear-stored-collectibles"
-      (let [expected-db {:wallet {}}
-            effects     (events/clear-collectibles-request-details {:db db})
-            result-db   (:db effects)]
-        (is (= result-db expected-db))))))

--- a/src/status_im2/contexts/wallet/events_test.cljs
+++ b/src/status_im2/contexts/wallet/events_test.cljs
@@ -22,29 +22,28 @@
         (is (= result-db expected-db))))))
 
 (deftest store-collectibles
-  (let []
-    (testing "(displayable-collectible?) helper function"
-      (let [expected-results [[true {:image-url "https://..." :animation-url "https://..."}]
-                              [true {:image-url "" :animation-url "https://..."}]
-                              [true {:image-url nil :animation-url "https://..."}]
-                              [true {:image-url "https://..." :animation-url ""}]
-                              [true {:image-url "https://..." :animation-url nil}]
-                              [false {:image-url "" :animation-url nil}]
-                              [false {:image-url nil :animation-url nil}]
-                              [false {:image-url nil :animation-url ""}]
-                              [false {:image-url "" :animation-url ""}]]]
-        (doseq [[result collection] expected-results]
-          (is (= result (events/displayable-collectible? collection))))))
-    (testing "save-collectibles-request-details"
-      (let [db           {:wallet {}}
-            collectibles [{:image-url "https://..." :animation-url "https://..."}
-                          {:image-url "" :animation-url "https://..."}
-                          {:image-url "" :animation-url nil}]
-            expected-db  {:wallet {:collectibles [{:image-url "https://..." :animation-url "https://..."}
-                                                  {:image-url "" :animation-url "https://..."}]}}
-            effects      (events/store-collectibles {:db db} [collectibles])
-            result-db    (:db effects)]
-        (is (= result-db expected-db))))))
+  (testing "(displayable-collectible?) helper function"
+    (let [expected-results [[true {:image-url "https://..." :animation-url "https://..."}]
+                            [true {:image-url "" :animation-url "https://..."}]
+                            [true {:image-url nil :animation-url "https://..."}]
+                            [true {:image-url "https://..." :animation-url ""}]
+                            [true {:image-url "https://..." :animation-url nil}]
+                            [false {:image-url "" :animation-url nil}]
+                            [false {:image-url nil :animation-url nil}]
+                            [false {:image-url nil :animation-url ""}]
+                            [false {:image-url "" :animation-url ""}]]]
+      (doseq [[result collection] expected-results]
+        (is (= result (events/displayable-collectible? collection))))))
+  (testing "save-collectibles-request-details"
+    (let [db           {:wallet {}}
+          collectibles [{:image-url "https://..." :animation-url "https://..."}
+                        {:image-url "" :animation-url "https://..."}
+                        {:image-url "" :animation-url nil}]
+          expected-db  {:wallet {:collectibles [{:image-url "https://..." :animation-url "https://..."}
+                                                {:image-url "" :animation-url "https://..."}]}}
+          effects      (events/store-collectibles {:db db} [collectibles])
+          result-db    (:db effects)]
+      (is (= result-db expected-db)))))
 
 (deftest clear-stored-collectibles
   (let [db {:wallet {:collectibles [{:id 1} {:id 2}]}}]

--- a/src/status_im2/contexts/wallet/home/view.cljs
+++ b/src/status_im2/contexts/wallet/home/view.cljs
@@ -62,14 +62,12 @@
                  :new-request? true}])
   (let [selected-tab (reagent/atom (:id (first tabs-data)))]
     (fn []
-
       (let [accounts (rf/sub [:profile/wallet-accounts])
             top      (safe-area/get-top)
             loading? (rf/sub [:wallet/tokens-loading?])
             balances (rf/sub [:wallet/balances])
             profile  (rf/sub [:profile/profile])
             networks (rf/sub [:wallet/network-details])]
-
         [rn/view
          {:style {:margin-top top
                   :flex       1}}

--- a/src/status_im2/contexts/wallet/home/view.cljs
+++ b/src/status_im2/contexts/wallet/home/view.cljs
@@ -54,23 +54,22 @@
          accounts)]
     (conj accounts-with-balances (add-account-placeholder (:customization-color profile)))))
 
-(defn f-view
+(defn view
   []
   (rf/dispatch [:wallet/get-wallet-token])
+  (rf/dispatch [:wallet/request-collectibles
+                {:offset       0
+                 :new-request? true}])
   (let [selected-tab (reagent/atom (:id (first tabs-data)))]
     (fn []
-      (let [accounts         (rf/sub [:profile/wallet-accounts])
-            top              (safe-area/get-top)
-            loading?         (rf/sub [:wallet/tokens-loading?])
-            balances         (rf/sub [:wallet/balances])
-            profile          (rf/sub [:profile/profile])
-            networks         (rf/sub [:wallet/network-details])
-            wallet-addresses (rf/sub [:wallet/all-addresses])]
-        (rn/use-effect (fn []
-                         (rf/dispatch [:wallet/request-collectibles
-                                       {:addresses    wallet-addresses
-                                        :offset       0
-                                        :new-request? true}])))
+
+      (let [accounts (rf/sub [:profile/wallet-accounts])
+            top      (safe-area/get-top)
+            loading? (rf/sub [:wallet/tokens-loading?])
+            balances (rf/sub [:wallet/balances])
+            profile  (rf/sub [:profile/profile])
+            networks (rf/sub [:wallet/network-details])]
+
         [rn/view
          {:style {:margin-top top
                   :flex       1}}
@@ -104,7 +103,3 @@
                            :content-container-style {:padding-horizontal 8}}]
            :collectibles [collectibles/view]
            [activity/view])]))))
-
-(defn view
-  []
-  [:f> f-view])

--- a/src/status_im2/contexts/wallet/home/view.cljs
+++ b/src/status_im2/contexts/wallet/home/view.cljs
@@ -58,8 +58,8 @@
   []
   (rf/dispatch [:wallet/get-wallet-token])
   (rf/dispatch [:wallet/request-collectibles
-                {:offset       0
-                 :new-request? true}])
+                {:start-at-index 0
+                 :new-request?   true}])
   (let [selected-tab (reagent/atom (:id (first tabs-data)))]
     (fn []
       (let [accounts (rf/sub [:profile/wallet-accounts])

--- a/src/status_im2/contexts/wallet/home/view.cljs
+++ b/src/status_im2/contexts/wallet/home/view.cljs
@@ -54,17 +54,23 @@
          accounts)]
     (conj accounts-with-balances (add-account-placeholder (:customization-color profile)))))
 
-(defn view
+(defn f-view
   []
   (rf/dispatch [:wallet/get-wallet-token])
   (let [selected-tab (reagent/atom (:id (first tabs-data)))]
     (fn []
-      (let [accounts (rf/sub [:profile/wallet-accounts])
-            top      (safe-area/get-top)
-            loading? (rf/sub [:wallet/tokens-loading?])
-            balances (rf/sub [:wallet/balances])
-            profile  (rf/sub [:profile/profile])
-            networks (rf/sub [:wallet/network-details])]
+      (let [accounts         (rf/sub [:profile/wallet-accounts])
+            top              (safe-area/get-top)
+            loading?         (rf/sub [:wallet/tokens-loading?])
+            balances         (rf/sub [:wallet/balances])
+            profile          (rf/sub [:profile/profile])
+            networks         (rf/sub [:wallet/network-details])
+            wallet-addresses (rf/sub [:wallet/all-addresses])]
+        (rn/use-effect (fn []
+                         (rf/dispatch [:wallet/request-collectibles
+                                       {:addresses    wallet-addresses
+                                        :offset       0
+                                        :new-request? true}])))
         [rn/view
          {:style {:margin-top top
                   :flex       1}}
@@ -98,3 +104,7 @@
                            :content-container-style {:padding-horizontal 8}}]
            :collectibles [collectibles/view]
            [activity/view])]))))
+
+(defn view
+  []
+  [:f> f-view])

--- a/src/status_im2/subs/root.cljs
+++ b/src/status_im2/subs/root.cljs
@@ -11,6 +11,7 @@
     status-im2.subs.pairing
     status-im2.subs.profile
     status-im2.subs.shell
+    status-im2.subs.wallet.collectibles
     status-im2.subs.wallet.networks
     status-im2.subs.wallet.wallet))
 
@@ -151,6 +152,7 @@
 (reg-root-key-sub :activity-center :activity-center)
 
 ;;wallet
+(reg-root-key-sub :wallet :wallet)
 (reg-root-key-sub :wallet/scanned-address :wallet/scanned-address)
 (reg-root-key-sub :wallet/create-account :wallet/create-account)
 (reg-root-key-sub :wallet/networks :wallet/networks)

--- a/src/status_im2/subs/wallet/collectibles.cljs
+++ b/src/status_im2/subs/wallet/collectibles.cljs
@@ -1,9 +1,20 @@
 (ns status-im2.subs.wallet.collectibles
   (:require
+    [clojure.string :as string]
     [re-frame.core :as re-frame]))
+
+(defn- preview-url
+  [{:keys [image-url animation-url animation-media-type]}]
+  (if (and (not (string/blank? animation-url))
+           (not= animation-media-type "image/svg+xml"))
+    animation-url
+    image-url))
 
 (re-frame/reg-sub
  :wallet/collectibles
  :<- [:wallet]
  (fn [wallet]
-   (:collectibles wallet)))
+   (map (fn [collectible]
+          (assoc collectible :preview-url (preview-url collectible)))
+        (:collectibles wallet))))
+

--- a/src/status_im2/subs/wallet/collectibles.cljs
+++ b/src/status_im2/subs/wallet/collectibles.cljs
@@ -1,0 +1,9 @@
+(ns status-im2.subs.wallet.collectibles
+  (:require
+    [re-frame.core :as re-frame]))
+
+(re-frame/reg-sub
+ :wallet/collectibles
+ :<- [:wallet]
+ (fn [wallet]
+   (:collectibles wallet)))

--- a/src/status_im2/subs/wallet/wallet.cljs
+++ b/src/status_im2/subs/wallet/wallet.cljs
@@ -50,8 +50,3 @@
     :balance
     (utils/get-balance-by-address balances account-address))))
 
-(re-frame/reg-sub
- :wallet/all-addresses
- :<- [:profile/wallet-accounts]
- (fn [accounts]
-   (map :address accounts)))

--- a/src/status_im2/subs/wallet/wallet.cljs
+++ b/src/status_im2/subs/wallet/wallet.cljs
@@ -49,3 +49,9 @@
     (utils/get-account-by-address accounts account-address)
     :balance
     (utils/get-balance-by-address balances account-address))))
+
+(re-frame/reg-sub
+ :wallet/all-addresses
+ :<- [:profile/wallet-accounts]
+ (fn [accounts]
+   (map :address accounts)))

--- a/src/status_im2/subs/wallet/wallet.cljs
+++ b/src/status_im2/subs/wallet/wallet.cljs
@@ -49,4 +49,3 @@
     (utils/get-account-by-address accounts account-address)
     :balance
     (utils/get-balance-by-address balances account-address))))
-


### PR DESCRIPTION
fixes #17299

### Summary

Collectibles loaded from the backend

https://github.com/status-im/status-mobile/assets/5786310/6c3cc2af-7fed-4cf3-beef-5bf8d1cdc9c4


### Review notes
In this PR I use an approach with one root key `:wallet` in app db and all other wallet data stored under it. (cc) @J-Son89, @ulisesmac 

**Implementation:**
When wallet view mounted, request `"wallet_filterOwnedCollectiblesAsync"` sent to backend with attempt to fetch 1000 collectibles (arbitrary size, I've found that it works better for cases when there are many collectibles).
When 1000 collectibles fetched, those of fetched that contain `image_url` of `animation_url` stored in `app-db` (because we don't need to display collectibles that can't be displayed). If there are more collectibles to fetch, another request to backend sent.

Address `sonnyF.eth` contains around 6k collectibles, of which only around 900 are displayable (have image\animation URLs). I don't know why. @stefandunca, maybe you can give a hint?


**Things I'd like to leave for next prs:**
- performance issues when too many collectibles loaded at the same time
- loading previews


### Steps to test
- Synchronize account between desktop and mobile
- Add watch-only accounts with collectibles to mobile, for example:
  - 0x12E838Ae1f769147b12956485dc56e57138f3AC8
  - 0x35F0686c63F50707Ea3b5baCe186938E4E19f03a
- Open new wallet in Status and switch to `collectibles` tab


status: ready
