### PR TITLE
[Fix] network-routing component test

### DIFF
--- a/src/quo/components/wallet/network_routing/component_spec.cljs
+++ b/src/quo/components/wallet/network_routing/component_spec.cljs
@@ -1,6 +1,6 @@
-(ns quo2.components.wallet.network-routing.component-spec
+(ns quo.components.wallet.network-routing.component-spec
   (:require [oops.core :as oops]
-            [quo2.components.wallet.network-routing.view :as network-routing]
+            [quo.components.wallet.network-routing.view :as network-routing]
             [reagent.core :as reagent]
             [test-helpers.component :as h]))
 

--- a/src/quo/core_spec.cljs
+++ b/src/quo/core_spec.cljs
@@ -79,6 +79,7 @@
     [quo.components.wallet.keypair.component-spec]
     [quo.components.wallet.network-amount.component-spec]
     [quo.components.wallet.network-bridge.component-spec]
+    [quo.components.wallet.network-routing.component-spec]
     [quo.components.wallet.progress-bar.component-spec]
     [quo.components.wallet.summary-info.component-spec]
     [quo.components.wallet.token-input.component-spec]


### PR DESCRIPTION
### Summary

This PR moves the `network-routing` component test to the `quo` ns from `quo2` ns.

With this, the `quo2` directory is completely removed.

### Testing notes

This PR doesn't require any manual testing as it moves the component test for a component to its rightful place/namespace.

status: ready 
