### PR TITLE
Fix crash on x86_64 emulators 

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -42,7 +42,7 @@ KEYSTORE_KEY_PASSWORD=password
 # By default we build a mostly universal APK
 ANDROID_ABI_SPLIT=false
 # Some platforms are excluded though
-ANDROID_ABI_INCLUDE=armeabi-v7a;arm64-v8a;x86
+ANDROID_ABI_INCLUDE=armeabi-v7a;arm64-v8a;x86;x86_64
 
 org.gradle.jvmargs=-Xmx8704M
 

--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.7.15'
+library 'status-jenkins-lib@switch_e2e_to_x86_64'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@switch_e2e_to_x86_64'
+library 'status-jenkins-lib@v1.8.4'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.7.15'
+library 'status-jenkins-lib@v1.8.4'
 
 pipeline {
   agent { label 'linux' }

--- a/ci/Jenkinsfile.e2e-nightly
+++ b/ci/Jenkinsfile.e2e-nightly
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.7.15'
+library 'status-jenkins-lib@v1.8.4'
 
 pipeline {
   agent { label 'linux' }

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.7.15'
+library 'status-jenkins-lib@v1.8.4'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.tests
+++ b/ci/Jenkinsfile.tests
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.7.15'
+library 'status-jenkins-lib@v1.8.4'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()


### PR DESCRIPTION
This PR
- points to status-go branch where crash is fixed for x86_64 emulators
- attempts to explicitly build also for x86_64 ABI 

fixes #17265

#### Platforms
- Android

##### Functional
- 1-1 chats
- public chats
- group chats
- wallet / transactions
- dapps / app browsing
- account recovery
- new account
- user profile updates
- networks
- mailservers
- fleet
- bootnodes

##### Non-functional
- battery performance
- CPU performance / speed of the app
- network consumption

##### Todos

- [x] https://github.com/status-im/status-mobile/issues/18086
- [x] https://github.com/status-im/status-mobile/issues/17678

status: ready
