### PR TITLE
chore: ignore auto generated lint-fix files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -190,3 +190,7 @@ test/appium/tests/users.py
 
 ## git hooks
 lefthook.yml
+
+## clj-kondo
+/.clj-kondo/taoensso/*
+/.clj-kondo/babashka/*


### PR DESCRIPTION
We get these 2 files auto generated locally as part of `make lint-fix`

- `.clj-kondo/taoensso/encore/config.edn`
-  `.clj-kondo/taoensso/encore/taoensso/encore.clj`

These ideally don't belong inside the repository.

This PR gitIgnores them for good.

### Testing notes
Doesn't require testing, this PR adds dot files related to linting

status: ready
