### PR TITLE
small ns changes

### DIFF
--- a/src/status_im2/common/data_store/wallet.cljs
+++ b/src/status_im2/common/data_store/wallet.cljs
@@ -1,4 +1,4 @@
-(ns status-im2.data-store.wallet
+(ns status-im2.common.data-store.wallet
   (:require
     clojure.set))
 

--- a/src/status_im2/contexts/quo_preview/component_preview/events.cljs
+++ b/src/status_im2/contexts/quo_preview/component_preview/events.cljs
@@ -1,4 +1,4 @@
-(ns dev.component-preview.events
+(ns status-im2.contexts.quo-preview.component-preview.events
   (:require
     [quo.core :as quo]
     [re-frame.core :as re-frame]))

--- a/src/status_im2/contexts/quo_preview/component_preview/view.cljs
+++ b/src/status_im2/contexts/quo_preview/component_preview/view.cljs
@@ -1,4 +1,4 @@
-(ns dev.component-preview.view
+(ns status-im2.contexts.quo-preview.component-preview.view
   (:require
     [react-native.core :as rn]
     [utils.re-frame :as rf]))

--- a/src/status_im2/contexts/wallet/events.cljs
+++ b/src/status_im2/contexts/wallet/events.cljs
@@ -1,7 +1,7 @@
 (ns status-im2.contexts.wallet.events
   (:require
     [native-module.core :as native-module]
-    [status-im2.data-store.wallet :as data-store]
+    [status-im2.common.data-store.wallet :as data-store]
     [taoensso.timbre :as log]
     [utils.re-frame :as rf]
     [utils.security.core :as security]))

--- a/src/status_im2/navigation/screens.cljs
+++ b/src/status_im2/navigation/screens.cljs
@@ -1,6 +1,5 @@
 (ns status-im2.navigation.screens
   (:require
-    [status-im2.contexts.quo-preview.component-preview.view :as component-preview]
     [status-im.ui.screens.screens :as old-screens]
     [status-im2.config :as config]
     [status-im2.contexts.add-new-contact.views :as add-new-contact]
@@ -28,6 +27,7 @@
     [status-im2.contexts.onboarding.syncing.results.view :as syncing-results]
     [status-im2.contexts.onboarding.welcome.view :as welcome]
     [status-im2.contexts.profile.profiles.view :as profiles]
+    [status-im2.contexts.quo-preview.component-preview.view :as component-preview]
     [status-im2.contexts.quo-preview.main :as quo.preview]
     [status-im2.contexts.shell.activity-center.view :as activity-center]
     [status-im2.contexts.shell.jump-to.view :as shell]

--- a/src/status_im2/navigation/screens.cljs
+++ b/src/status_im2/navigation/screens.cljs
@@ -1,6 +1,6 @@
 (ns status-im2.navigation.screens
   (:require
-    [dev.component-preview.view :as component-preview]
+    [status-im2.contexts.quo-preview.component-preview.view :as component-preview]
     [status-im.ui.screens.screens :as old-screens]
     [status-im2.config :as config]
     [status-im2.contexts.add-new-contact.views :as add-new-contact]


### PR DESCRIPTION
moved `status-im2.data-store` under `common`
moved `dev.component-preview.events` under `status-im2.contexts.quo-preview.` because it can't be used outside status-im and mostly needed for quo components