### PR TITLE
Implement edit account endpoint and refactor wallet events and subs

### DIFF
--- a/src/quo/components/inputs/title_input/view.cljs
+++ b/src/quo/components/inputs/title_input/view.cljs
@@ -23,6 +23,8 @@
            return-key-type
            size
            theme
+           on-focus
+           on-blur
            container-style]
     :or   {max-length    0
            auto-focus    false
@@ -48,8 +50,14 @@
           :accessibility-label :profile-title-input
           :keyboard-appearance (quo.theme/theme-value :light :dark theme)
           :return-key-type return-key-type
-          :on-focus #(swap! focused? (constantly true))
-          :on-blur #(swap! focused? (constantly false))
+          :on-focus (fn []
+                      (when (fn? on-focus)
+                        (on-focus))
+                      (swap! focused? (constantly true)))
+          :on-blur (fn []
+                     (when (fn? on-blur)
+                       (on-blur))
+                     (swap! focused? (constantly false)))
           :auto-focus auto-focus
           :input-mode :text
           :on-change-text on-change

--- a/src/quo/components/inputs/title_input/view.cljs
+++ b/src/quo/components/inputs/title_input/view.cljs
@@ -53,11 +53,11 @@
           :on-focus (fn []
                       (when (fn? on-focus)
                         (on-focus))
-                      (swap! focused? (constantly true)))
+                      (reset! focused? true))
           :on-blur (fn []
                      (when (fn? on-blur)
                        (on-blur))
-                     (swap! focused? (constantly false)))
+                     (reset! focused? false))
           :auto-focus auto-focus
           :input-mode :text
           :on-change-text on-change

--- a/src/status_im/wallet/core.cljs
+++ b/src/status_im/wallet/core.cljs
@@ -1190,7 +1190,8 @@
     ::enable-local-notifications nil
     :dispatch-n                  [(when (or (not (utils.mobile-sync/syncing-allowed? cofx))
                                             (chain/binance-chain? db))
-                                    [:transaction/get-fetched-transfers])]}
+                                    [:transaction/get-fetched-transfers])]
+    :dispatch                    [:wallet/get-accounts-success accounts]}
    (check-invalid-ens)
    (initialize-tokens tokens custom-tokens)
    (initialize-favourites favourites)

--- a/src/status_im2/common/data_store/wallet.cljs
+++ b/src/status_im2/common/data_store/wallet.cljs
@@ -15,17 +15,16 @@
   (string/join constants/chain-id-separator ids))
 
 (defn rpc->account
-  [{:keys [colorId] :as account}]
+  [account]
   (-> account
       (set/rename-keys {:prodPreferredChainIds :prod-preferred-chain-ids
                         :testPreferredChainIds :test-preferred-chain-ids
-                        :createdAt             :created-at})
+                        :createdAt             :created-at
+                        :colorId               :color})
       (update :prod-preferred-chain-ids chain-ids-string->set)
       (update :test-preferred-chain-ids chain-ids-string->set)
       (update :type keyword)
-      (assoc :customization-color
-             (if (seq colorId) (keyword colorId) constants/account-default-customization-color))
-      (dissoc :colorId)))
+      (update :color #(if (seq %) (keyword %) constants/account-default-customization-color))))
 
 (defn rpc->accounts
   [accounts]
@@ -34,14 +33,13 @@
        (map rpc->account)))
 
 (defn <-account
-  [{:keys [customization-color] :as account}]
+  [account]
   (-> account
       (set/rename-keys {:prod-preferred-chain-ids :prodPreferredChainIds
-                        :test-preferred-chain-ids :testPreferredChainIds})
+                        :test-preferred-chain-ids :testPreferredChainIds
+                        :color                    :colorId})
       (update :prodPreferredChainIds chain-ids-set->string)
-      (update :testPreferredChainIds chain-ids-set->string)
-      (assoc :colorId customization-color)
-      (dissoc :customization-color)))
+      (update :testPreferredChainIds chain-ids-set->string)))
 
 (defn <-rpc
   [network]

--- a/src/status_im2/common/data_store/wallet.cljs
+++ b/src/status_im2/common/data_store/wallet.cljs
@@ -2,13 +2,14 @@
   (:require
     [clojure.set :as set]
     [clojure.string :as string]
-    [status-im2.constants :as constants]))
+    [status-im2.constants :as constants]
+    [utils.number :as utils.number]))
 
 (defn chain-ids-string->set
   [ids-string]
-  (->> (string/split ids-string constants/chain-id-separator)
-       (map js/parseInt)
-       (into #{})))
+  (into #{}
+        (map utils.number/parse-int)
+        (string/split ids-string constants/chain-id-separator)))
 
 (defn chain-ids-set->string
   [ids]

--- a/src/status_im2/common/standard_authentication/enter_password/view.cljs
+++ b/src/status_im2/common/standard_authentication/enter_password/view.cljs
@@ -9,10 +9,10 @@
     [utils.re-frame :as rf]))
 
 (defn view
-  [{:keys [on-enter-password button-label button-icon-left profile-color customization-color]}]
-  (let [{:keys [key-uid] :as profile}       (rf/sub [:profile/profile-with-image])
-        {:keys [error processing password]} (rf/sub [:profile/login])
-        sign-in-enabled?                    (rf/sub [:sign-in-enabled?])]
+  [{:keys [on-enter-password button-label button-icon-left]}]
+  (let [{:keys [key-uid customization-color] :as profile} (rf/sub [:profile/profile-with-image])
+        {:keys [error processing password]}               (rf/sub [:profile/login])
+        sign-in-enabled?                                  (rf/sub [:sign-in-enabled?])]
     [:<>
      [rn/view {:style style/enter-password-container}
       [rn/view
@@ -29,7 +29,7 @@
           :blur?               true
           :profile-picture     (profile.utils/photo profile)
           :full-name           (profile.utils/displayed-name profile)
-          :customization-color profile-color
+          :customization-color customization-color
           :size                24}]]
        [password-input/view
         {:processing       processing

--- a/src/status_im2/common/standard_authentication/enter_password/view.cljs
+++ b/src/status_im2/common/standard_authentication/enter_password/view.cljs
@@ -9,7 +9,7 @@
     [utils.re-frame :as rf]))
 
 (defn view
-  [{:keys [on-enter-password button-label button-icon-left customization-color]}]
+  [{:keys [on-enter-password button-label button-icon-left profile-color customization-color]}]
   (let [{:keys [key-uid] :as profile}       (rf/sub [:profile/profile-with-image])
         {:keys [error processing password]} (rf/sub [:profile/login])
         sign-in-enabled?                    (rf/sub [:sign-in-enabled?])]
@@ -29,7 +29,7 @@
           :blur?               true
           :profile-picture     (profile.utils/photo profile)
           :full-name           (profile.utils/displayed-name profile)
-          :customization-color customization-color
+          :customization-color profile-color
           :size                24}]]
        [password-input/view
         {:processing       processing

--- a/src/status_im2/common/standard_authentication/standard_auth/view.cljs
+++ b/src/status_im2/common/standard_authentication/standard_auth/view.cljs
@@ -17,7 +17,7 @@
 
 (defn authorize
   [{:keys [on-enter-password biometric-auth? on-auth-success on-auth-fail on-close
-           auth-button-label theme blur? customization-color auth-button-icon-left]}]
+           auth-button-label theme blur? profile-color customization-color auth-button-icon-left]}]
   (biometric/get-supported-type
    (fn [biometric-type]
      (if (and biometric-auth? biometric-type)
@@ -43,14 +43,16 @@
                         :shell?   blur?
                         :content  (fn []
                                     [enter-password/view
-                                     {:customization-color customization-color
+                                     {:profile-color       profile-color
+                                      :customization-color customization-color
                                       :on-enter-password   on-enter-password
                                       :button-icon-left    auth-button-icon-left
                                       :button-label        auth-button-label}])}]))))))
 
 (defn- view-internal
   [_]
-  (let [reset-slider? (reagent/atom false)
+  (let [profile-color (rf/sub [:profile/customization-color])
+        reset-slider? (reagent/atom false)
         on-close      #(reset! reset-slider? true)]
     (fn [{:keys [biometric-auth?
                  track-text
@@ -74,6 +76,7 @@
                                            :auth-button-icon-left auth-button-icon-left
                                            :theme                 theme
                                            :blur?                 blur?
+                                           :profile-color         profile-color
                                            :customization-color   customization-color
                                            :on-enter-password     on-enter-password
                                            :biometric-auth?       biometric-auth?

--- a/src/status_im2/common/standard_authentication/standard_auth/view.cljs
+++ b/src/status_im2/common/standard_authentication/standard_auth/view.cljs
@@ -17,7 +17,7 @@
 
 (defn authorize
   [{:keys [on-enter-password biometric-auth? on-auth-success on-auth-fail on-close
-           auth-button-label theme blur? profile-color customization-color auth-button-icon-left]}]
+           auth-button-label theme blur? auth-button-icon-left]}]
   (biometric/get-supported-type
    (fn [biometric-type]
      (if (and biometric-auth? biometric-type)
@@ -43,16 +43,13 @@
                         :shell?   blur?
                         :content  (fn []
                                     [enter-password/view
-                                     {:profile-color       profile-color
-                                      :customization-color customization-color
-                                      :on-enter-password   on-enter-password
-                                      :button-icon-left    auth-button-icon-left
-                                      :button-label        auth-button-label}])}]))))))
+                                     {:on-enter-password on-enter-password
+                                      :button-icon-left  auth-button-icon-left
+                                      :button-label      auth-button-label}])}]))))))
 
 (defn- view-internal
   [_]
-  (let [profile-color (rf/sub [:profile/customization-color])
-        reset-slider? (reagent/atom false)
+  (let [reset-slider? (reagent/atom false)
         on-close      #(reset! reset-slider? true)]
     (fn [{:keys [biometric-auth?
                  track-text
@@ -76,8 +73,6 @@
                                            :auth-button-icon-left auth-button-icon-left
                                            :theme                 theme
                                            :blur?                 blur?
-                                           :profile-color         profile-color
-                                           :customization-color   customization-color
                                            :on-enter-password     on-enter-password
                                            :biometric-auth?       biometric-auth?
                                            :on-auth-success       on-auth-success

--- a/src/status_im2/constants.cljs
+++ b/src/status_im2/constants.cljs
@@ -378,3 +378,5 @@
 (def ^:const chain-id-separator ":")
 
 (def ^:const account-default-customization-color :blue)
+
+(def ^:const wallet-account-name-max-length 20)

--- a/src/status_im2/constants.cljs
+++ b/src/status_im2/constants.cljs
@@ -374,3 +374,7 @@
 (def ^:const mainnet-network-name :ethereum)
 (def ^:const optimism-network-name :optimism)
 (def ^:const arbitrum-network-name :arbitrum)
+
+(def ^:const chain-id-separator ":")
+
+(def ^:const account-default-customization-color :blue)

--- a/src/status_im2/contexts/wallet/account/view.cljs
+++ b/src/status_im2/contexts/wallet/account/view.cljs
@@ -30,32 +30,31 @@
    {:id :about :label (i18n/label :t/about) :accessibility-label :about}])
 
 (defn view
-  [account-address]
+  []
   (let [selected-tab (reagent/atom (:id (first tabs-data)))]
     (fn []
-      (let [account-address (or account-address (rf/sub [:get-screen-params :wallet-accounts]))
-            account         (rf/sub [:wallet/account account-address])
-            networks        (rf/sub [:wallet/network-details])]
+      (let [{:keys [name customization-color emoji balance]} (rf/sub [:wallet/current-viewing-account])
+            networks                                         (rf/sub [:wallet/network-details])]
         [rn/view {:style {:flex 1}}
          [quo/page-nav
           {:type              :wallet-networks
            :background        :blur
            :icon-name         :i/close
-           :on-press          #(rf/dispatch [:navigate-back])
+           :on-press          #(rf/dispatch [:wallet/close-account-page])
            :networks          networks
            :networks-on-press #(js/alert "Pressed Networks")
            :right-side        :account-switcher
-           :account-switcher  {:customization-color :purple
+           :account-switcher  {:customization-color customization-color
                                :on-press            #(rf/dispatch [:show-bottom-sheet
                                                                    {:content account-options/view
                                                                     :gradient-cover? true
-                                                                    :customization-color :purple}])
-                               :emoji               "🍑"}}]
+                                                                    :customization-color customization-color}])
+                               :emoji              emoji}}]
          [quo/account-overview
-          {:current-value       (utils/prettify-balance (:balance account))
-           :account-name        (:name account)
+          {:current-value       (utils/prettify-balance balance)
+           :account-name        name
            :account             :default
-           :customization-color :blue}]
+           :customization-color customization-color}]
          [quo/wallet-graph {:time-frame :empty}]
          [quo/wallet-ctas
           {:send-action   #(rf/dispatch [:open-modal :wallet-select-address])

--- a/src/status_im2/contexts/wallet/account/view.cljs
+++ b/src/status_im2/contexts/wallet/account/view.cljs
@@ -46,8 +46,8 @@
            :right-side        :account-switcher
            :account-switcher  {:customization-color color
                                :on-press            #(rf/dispatch [:show-bottom-sheet
-                                                                   {:content             account-options/view
-                                                                    :gradient-cover?     true
+                                                                   {:content account-options/view
+                                                                    :gradient-cover? true
                                                                     :customization-color color}])
                                :emoji               emoji}}]
          [quo/account-overview

--- a/src/status_im2/contexts/wallet/account/view.cljs
+++ b/src/status_im2/contexts/wallet/account/view.cljs
@@ -33,8 +33,8 @@
   []
   (let [selected-tab (reagent/atom (:id (first tabs-data)))]
     (fn []
-      (let [{:keys [name customization-color emoji balance]} (rf/sub [:wallet/current-viewing-account])
-            networks                                         (rf/sub [:wallet/network-details])]
+      (let [{:keys [name color emoji balance]} (rf/sub [:wallet/current-viewing-account])
+            networks                           (rf/sub [:wallet/network-details])]
         [rn/view {:style {:flex 1}}
          [quo/page-nav
           {:type              :wallet-networks
@@ -44,17 +44,17 @@
            :networks          networks
            :networks-on-press #(js/alert "Pressed Networks")
            :right-side        :account-switcher
-           :account-switcher  {:customization-color customization-color
+           :account-switcher  {:customization-color color
                                :on-press            #(rf/dispatch [:show-bottom-sheet
-                                                                   {:content account-options/view
-                                                                    :gradient-cover? true
-                                                                    :customization-color customization-color}])
-                               :emoji              emoji}}]
+                                                                   {:content             account-options/view
+                                                                    :gradient-cover?     true
+                                                                    :customization-color color}])
+                               :emoji               emoji}}]
          [quo/account-overview
           {:current-value       (utils/prettify-balance balance)
            :account-name        name
            :account             :default
-           :customization-color customization-color}]
+           :customization-color color}]
          [quo/wallet-graph {:time-frame :empty}]
          [quo/wallet-ctas
           {:send-action   #(rf/dispatch [:open-modal :wallet-select-address])

--- a/src/status_im2/contexts/wallet/common/screen_base/create_or_edit_account/style.cljs
+++ b/src/status_im2/contexts/wallet/common/screen_base/create_or_edit_account/style.cljs
@@ -22,13 +22,10 @@
    :bottom   0
    :left     76})
 
-(defn title-input-container
-  [error-message]
-  (cond-> {:padding-horizontal 20
-           :padding-top        12
-           :padding-bottom     16}
-    error-message
-    (assoc :padding-bottom 8)))
+(def title-input-container
+  {:padding-horizontal 20
+   :padding-top        12
+   :padding-bottom     16})
 
 (def error-container
   {:margin-horizontal 20

--- a/src/status_im2/contexts/wallet/common/screen_base/create_or_edit_account/style.cljs
+++ b/src/status_im2/contexts/wallet/common/screen_base/create_or_edit_account/style.cljs
@@ -22,10 +22,17 @@
    :bottom   0
    :left     76})
 
-(def title-input-container
-  {:padding-horizontal 20
-   :padding-top        12
-   :padding-bottom     16})
+(defn title-input-container
+  [error-message]
+  (cond-> {:padding-horizontal 20
+           :padding-top        12
+           :padding-bottom     16}
+    error-message
+    (assoc :padding-bottom 8)))
+
+(def error-container
+  {:margin-horizontal 20
+   :margin-bottom     16})
 
 (def divider-1
   {:margin-bottom 12})

--- a/src/status_im2/contexts/wallet/common/screen_base/create_or_edit_account/view.cljs
+++ b/src/status_im2/contexts/wallet/common/screen_base/create_or_edit_account/view.cljs
@@ -3,6 +3,7 @@
             [quo.theme :as quo.theme]
             [react-native.core :as rn]
             [react-native.safe-area :as safe-area]
+            [status-im2.constants :as constants]
             [status-im2.contexts.wallet.common.screen-base.create-or-edit-account.style :as style]
             [utils.i18n :as i18n]
             [utils.re-frame :as rf]))
@@ -46,7 +47,7 @@
          :i/reaction]]
        [quo/title-input
         {:placeholder     (i18n/label :t/account-name-input-placeholder)
-         :max-length      20
+         :max-length      constants/wallet-account-name-max-length
          :blur?           true
          :default-value   account-name
          :on-change-text  on-change-name

--- a/src/status_im2/contexts/wallet/common/screen_base/create_or_edit_account/view.cljs
+++ b/src/status_im2/contexts/wallet/common/screen_base/create_or_edit_account/view.cljs
@@ -11,7 +11,7 @@
 (defn- view-internal
   [{:keys [margin-top? page-nav-right-side account-name account-color account-emoji on-change-name
            on-change-color
-           on-change-emoji on-focus on-blur error-message section-label bottom-action?
+           on-change-emoji on-focus on-blur section-label bottom-action?
            bottom-action-label bottom-action-props
            custom-bottom-action]} & children]
   (let [{:keys [top bottom]}  (safe-area/get-insets)
@@ -51,17 +51,10 @@
          :blur?           true
          :default-value   account-name
          :on-change-text  on-change-name
-         :container-style (style/title-input-container error-message)
+         :container-style style/title-input-container
          :return-key-type :done
          :on-focus        on-focus
          :on-blur         on-blur}]
-       (when error-message
-         [quo/info-message
-          {:type  :error
-           :size  :default
-           :icon  :i/info
-           :style style/error-container}
-          (i18n/label error-message)])
        [quo/divider-line {:container-style style/divider-1}]
        [quo/section-label
         {:section         (i18n/label :t/colour)

--- a/src/status_im2/contexts/wallet/common/screen_base/create_or_edit_account/view.cljs
+++ b/src/status_im2/contexts/wallet/common/screen_base/create_or_edit_account/view.cljs
@@ -10,7 +10,8 @@
 (defn- view-internal
   [{:keys [margin-top? page-nav-right-side account-name account-color account-emoji on-change-name
            on-change-color
-           on-change-emoji section-label bottom-action? bottom-action-label bottom-action-props
+           on-change-emoji on-focus on-blur error-message section-label bottom-action?
+           bottom-action-label bottom-action-props
            custom-bottom-action]} & children]
   (let [{:keys [top bottom]}  (safe-area/get-insets)
         margin-top            (if (false? margin-top?) 0 top)
@@ -45,12 +46,21 @@
          :i/reaction]]
        [quo/title-input
         {:placeholder     (i18n/label :t/account-name-input-placeholder)
-         :max-length      24
+         :max-length      20
          :blur?           true
          :default-value   account-name
          :on-change-text  on-change-name
-         :container-style style/title-input-container
-         :return-key-type :done}]
+         :container-style (style/title-input-container error-message)
+         :return-key-type :done
+         :on-focus        on-focus
+         :on-blur         on-blur}]
+       (when error-message
+         [quo/info-message
+          {:type  :error
+           :size  :default
+           :icon  :i/info
+           :style style/error-container}
+          (i18n/label error-message)])
        [quo/divider-line {:container-style style/divider-1}]
        [quo/section-label
         {:section         (i18n/label :t/colour)

--- a/src/status_im2/contexts/wallet/common/screen_base/create_or_edit_account/view.cljs
+++ b/src/status_im2/contexts/wallet/common/screen_base/create_or_edit_account/view.cljs
@@ -52,7 +52,6 @@
          :default-value   account-name
          :on-change-text  on-change-name
          :container-style style/title-input-container
-         :return-key-type :done
          :on-focus        on-focus
          :on-blur         on-blur}]
        [quo/divider-line {:container-style style/divider-1}]

--- a/src/status_im2/contexts/wallet/common/sheets/account_options/view.cljs
+++ b/src/status_im2/contexts/wallet/common/sheets/account_options/view.cljs
@@ -8,7 +8,7 @@
 
 (defn view
   []
-  (let [{:keys [name customization-color emoji address]} (rf/sub [:wallet/current-viewing-account])]
+  (let [{:keys [name color emoji address]} (rf/sub [:wallet/current-viewing-account])]
     [:<>
      [quo/drawer-top
       {:title                name
@@ -18,7 +18,7 @@
                               {:network-name :arbitrum :short-name "arb1"}]
        :description          address
        :account-avatar-emoji emoji
-       :customization-color  customization-color}]
+       :customization-color  color}]
      [quo/action-drawer
       [[{:icon                :i/edit
          :accessibility-label :edit

--- a/src/status_im2/contexts/wallet/common/sheets/account_options/view.cljs
+++ b/src/status_im2/contexts/wallet/common/sheets/account_options/view.cljs
@@ -8,28 +8,37 @@
 
 (defn view
   []
-  [:<>
-   [quo/drawer-top temp/account-data]
-   [quo/action-drawer
-    [[{:icon                :i/edit
-       :accessibility-label :edit
-       :label               (i18n/label :t/edit-account)
-       :on-press            #(rf/dispatch [:navigate-to :wallet-edit-account])}
-      {:icon                :i/copy
-       :accessibility-label :copy-address
-       :label               (i18n/label :t/copy-address)}
-      {:icon                :i/share
-       :accessibility-label :share-account
-       :label               (i18n/label :t/share-account)}
-      {:icon                :i/delete
-       :accessibility-label :remove-account
-       :label               (i18n/label :t/remove-account)
-       :danger?             true}]]]
-   [quo/divider-line {:container-style {:margin-top 8}}]
-   [quo/section-label
-    {:section         (i18n/label :t/select-another-account)
-     :container-style style/drawer-section-label}]
-   [rn/flat-list
-    {:data      temp/other-accounts
-     :render-fn (fn [account] [quo/account-item {:account-props account}])
-     :style     {:margin-horizontal 8}}]])
+  (let [{:keys [name customization-color emoji address]} (rf/sub [:wallet/current-viewing-account])]
+    [:<>
+     [quo/drawer-top
+      {:title                name
+       :type                 :account
+       :networks             [{:network-name :ethereum :short-name "eth"}
+                              {:network-name :optimism :short-name "opt"}
+                              {:network-name :arbitrum :short-name "arb1"}]
+       :description          address
+       :account-avatar-emoji emoji
+       :customization-color  customization-color}]
+     [quo/action-drawer
+      [[{:icon                :i/edit
+         :accessibility-label :edit
+         :label               (i18n/label :t/edit-account)
+         :on-press            #(rf/dispatch [:navigate-to :wallet-edit-account])}
+        {:icon                :i/copy
+         :accessibility-label :copy-address
+         :label               (i18n/label :t/copy-address)}
+        {:icon                :i/share
+         :accessibility-label :share-account
+         :label               (i18n/label :t/share-account)}
+        {:icon                :i/delete
+         :accessibility-label :remove-account
+         :label               (i18n/label :t/remove-account)
+         :danger?             true}]]]
+     [quo/divider-line {:container-style {:margin-top 8}}]
+     [quo/section-label
+      {:section         (i18n/label :t/select-another-account)
+       :container-style style/drawer-section-label}]
+     [rn/flat-list
+      {:data      temp/other-accounts
+       :render-fn (fn [account] [quo/account-item {:account-props account}])
+       :style     {:margin-horizontal 8}}]]))

--- a/src/status_im2/contexts/wallet/common/sheets/network_preferences/view.cljs
+++ b/src/status_im2/contexts/wallet/common/sheets/network_preferences/view.cljs
@@ -7,7 +7,7 @@
             [utils.i18n :as i18n]
             [utils.re-frame :as rf]))
 
-(defn mainnet
+(defn- mainnet
   [customization-color]
   [{:title        "Mainnet"
     :image        :icon-avatar
@@ -17,7 +17,7 @@
     :action-props {:type                :checkbox
                    :customization-color customization-color}}])
 
-(defn networks-list
+(defn- networks-list
   [customization-color]
   [{:title        "Optimism"
     :image        :icon-avatar

--- a/src/status_im2/contexts/wallet/common/sheets/network_preferences/view.cljs
+++ b/src/status_im2/contexts/wallet/common/sheets/network_preferences/view.cljs
@@ -8,35 +8,35 @@
             [utils.re-frame :as rf]))
 
 (defn- mainnet
-  [customization-color]
+  [account-color]
   [{:title        "Mainnet"
     :image        :icon-avatar
     :image-props  {:icon (resources/get-network :ethereum)
                    :size :size-20}
     :action       :selector
     :action-props {:type                :checkbox
-                   :customization-color customization-color}}])
+                   :customization-color account-color}}])
 
 (defn- networks-list
-  [customization-color]
+  [account-color]
   [{:title        "Optimism"
     :image        :icon-avatar
     :image-props  {:icon (resources/get-network :optimism)
                    :size :size-20}
     :action       :selector
     :action-props {:type                :checkbox
-                   :customization-color customization-color}}
+                   :customization-color account-color}}
    {:title        "Arbitrum"
     :image        :icon-avatar
     :image-props  {:icon (resources/get-network :arbitrum)
                    :size :size-20}
     :action       :selector
     :action-props {:type                :checkbox
-                   :customization-color customization-color}}])
+                   :customization-color account-color}}])
 
 (defn- view-internal
   [{:keys [on-save theme]}]
-  (let [{:keys [customization-color address]} (rf/sub [:wallet/current-viewing-account])]
+  (let [{:keys [color address]} (rf/sub [:wallet/current-viewing-account])]
     [:<>
      [quo/drawer-top
       {:title       (i18n/label :t/network-preferences)
@@ -56,15 +56,15 @@
                                                                        theme)})}]
      [quo/category
       {:list-type :settings
-       :data      (mainnet customization-color)}]
+       :data      (mainnet color)}]
      [quo/category
       {:list-type :settings
        :label     (i18n/label :t/layer-2)
-       :data      (networks-list customization-color)}]
+       :data      (networks-list color)}]
      [quo/bottom-actions
       {:button-one-label (i18n/label :t/update)
        :button-one-props {:disabled?           true
                           :on-press            on-save
-                          :customization-color customization-color}}]]))
+                          :customization-color color}}]]))
 
 (def view (quo.theme/with-theme view-internal))

--- a/src/status_im2/contexts/wallet/common/sheets/network_preferences/view.cljs
+++ b/src/status_im2/contexts/wallet/common/sheets/network_preferences/view.cljs
@@ -4,59 +4,67 @@
             [quo.foundations.resources :as resources]
             [quo.theme :as quo.theme]
             [status-im2.contexts.wallet.common.sheets.network-preferences.style :as style]
-            [utils.i18n :as i18n]))
+            [utils.i18n :as i18n]
+            [utils.re-frame :as rf]))
 
-(def mainnet
+(defn mainnet
+  [customization-color]
   [{:title        "Mainnet"
     :image        :icon-avatar
     :image-props  {:icon (resources/get-network :ethereum)
                    :size :size-20}
     :action       :selector
-    :action-props {:type :checkbox}}])
+    :action-props {:type                :checkbox
+                   :customization-color customization-color}}])
 
-(def networks-list
+(defn networks-list
+  [customization-color]
   [{:title        "Optimism"
     :image        :icon-avatar
     :image-props  {:icon (resources/get-network :optimism)
                    :size :size-20}
     :action       :selector
-    :action-props {:type :checkbox}}
+    :action-props {:type                :checkbox
+                   :customization-color customization-color}}
    {:title        "Arbitrum"
     :image        :icon-avatar
     :image-props  {:icon (resources/get-network :arbitrum)
                    :size :size-20}
     :action       :selector
-    :action-props {:type :checkbox}}])
+    :action-props {:type                :checkbox
+                   :customization-color customization-color}}])
 
 (defn- view-internal
-  [{:keys [address on-save theme]}]
-  [:<>
-   [quo/drawer-top
-    {:title       (i18n/label :t/network-preferences)
-     :description (i18n/label :t/network-preferences-desc)}]
-   [quo/data-item
-    {:status          :default
-     :size            :default
-     :description     :default
-     :label           :none
-     :blur?           false
-     :card?           true
-     :title           (i18n/label :t/address)
-     :subtitle        address
-     :container-style (merge style/data-item
-                             {:background-color (colors/theme-colors colors/neutral-2_5
-                                                                     colors/neutral-90
-                                                                     theme)})}]
-   [quo/category
-    {:list-type :settings
-     :data      mainnet}]
-   [quo/category
-    {:list-type :settings
-     :label     (i18n/label :t/layer-2)
-     :data      networks-list}]
-   [quo/bottom-actions
-    {:button-one-label (i18n/label :t/update)
-     :button-one-props {:disabled? true
-                        :on-press  on-save}}]])
+  [{:keys [on-save theme]}]
+  (let [{:keys [customization-color address]} (rf/sub [:wallet/current-viewing-account])]
+    [:<>
+     [quo/drawer-top
+      {:title       (i18n/label :t/network-preferences)
+       :description (i18n/label :t/network-preferences-desc)}]
+     [quo/data-item
+      {:status          :default
+       :size            :default
+       :description     :default
+       :label           :none
+       :blur?           false
+       :card?           true
+       :title           (i18n/label :t/address)
+       :subtitle        address
+       :container-style (merge style/data-item
+                               {:background-color (colors/theme-colors colors/neutral-2_5
+                                                                       colors/neutral-90
+                                                                       theme)})}]
+     [quo/category
+      {:list-type :settings
+       :data      (mainnet customization-color)}]
+     [quo/category
+      {:list-type :settings
+       :label     (i18n/label :t/layer-2)
+       :data      (networks-list customization-color)}]
+     [quo/bottom-actions
+      {:button-one-label (i18n/label :t/update)
+       :button-one-props {:disabled?           true
+                          :on-press            on-save
+                          :customization-color customization-color}}]]))
 
 (def view (quo.theme/with-theme view-internal))

--- a/src/status_im2/contexts/wallet/common/temp.cljs
+++ b/src/status_im2/contexts/wallet/common/temp.cljs
@@ -149,16 +149,6 @@
     :action        :icon
     :on-press-icon on-press-icon}])
 
-(def account-data
-  {:title                "Trip to Vegas"
-   :type                 :account
-   :networks             [{:network-name :ethereum :short-name "eth"}
-                          {:network-name :optimism :short-name "opt"}
-                          {:network-name :arbitrum :short-name "arb1"}]
-   :description          "0x39cf6E0Ba4C4530735616e1Ee7ff5FbCB726fBd4"
-   :account-avatar-emoji "🍑"
-   :customization-color  :purple})
-
 (def other-accounts
   [{:customization-color :flamingo
     :emoji               "🍿"

--- a/src/status_im2/contexts/wallet/create_account/view.cljs
+++ b/src/status_im2/contexts/wallet/create_account/view.cljs
@@ -6,6 +6,7 @@
     [react-native.safe-area :as safe-area]
     [reagent.core :as reagent]
     [status-im2.common.standard-authentication.standard-auth.view :as standard-auth]
+    [status-im2.constants :as constants]
     [status-im2.contexts.emoji-picker.utils :as emoji-picker.utils]
     [status-im2.contexts.wallet.common.utils :as utils]
     [status-im2.contexts.wallet.create-account.style :as style]
@@ -83,7 +84,7 @@
         {:customization-color @account-color
          :placeholder         "Type something here"
          :on-change-text      on-change-text
-         :max-length          20
+         :max-length          constants/wallet-account-name-max-length
          :blur?               true
          :disabled?           false
          :default-value       @account-name

--- a/src/status_im2/contexts/wallet/create_account/view.cljs
+++ b/src/status_im2/contexts/wallet/create_account/view.cljs
@@ -6,13 +6,12 @@
     [react-native.safe-area :as safe-area]
     [reagent.core :as reagent]
     [status-im2.common.standard-authentication.standard-auth.view :as standard-auth]
+    [status-im2.contexts.emoji-picker.utils :as emoji-picker.utils]
     [status-im2.contexts.wallet.common.utils :as utils]
     [status-im2.contexts.wallet.create-account.style :as style]
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]
     [utils.responsiveness :refer [iphone-11-Pro-20-pixel-from-width]]))
-
-(def diamond-emoji "\uD83D\uDC8E")
 
 (defn keypair-string
   [full-name]
@@ -44,8 +43,8 @@
   (let [top                   (safe-area/get-top)
         bottom                (safe-area/get-bottom)
         account-color         (reagent/atom :blue)
-        emoji                 (reagent/atom diamond-emoji)
-        number-of-accounts    (count (rf/sub [:profile/wallet-accounts]))
+        emoji                 (reagent/atom (emoji-picker.utils/random-emoji))
+        number-of-accounts    (count (rf/sub [:wallet/accounts]))
         account-name          (reagent/atom (i18n/label :t/default-account-name
                                                         {:number (inc number-of-accounts)}))
         derivation-path       (reagent/atom (utils/get-derivation-path number-of-accounts))
@@ -84,7 +83,7 @@
         {:customization-color @account-color
          :placeholder         "Type something here"
          :on-change-text      on-change-text
-         :max-length          24
+         :max-length          20
          :blur?               true
          :disabled?           false
          :default-value       @account-name

--- a/src/status_im2/contexts/wallet/edit_account/view.cljs
+++ b/src/status_im2/contexts/wallet/edit_account/view.cljs
@@ -13,15 +13,16 @@
 
 (defn show-toast
   [{:keys [type theme]}]
-  (let [messsage (condp = type
-                   :name  :t/edit-wallet-account-name-updated-message
-                   :color :t/edit-wallet-account-colour-updated-message
-                   :emoji :t/edit-wallet-account-emoji-updated-message)]
+  (let [message (case type
+                  :name  :t/edit-wallet-account-name-updated-message
+                  :color :t/edit-wallet-account-colour-updated-message
+                  :emoji :t/edit-wallet-account-emoji-updated-message
+                  nil)]
     (rf/dispatch [:toasts/upsert
                   {:id         :edit-account
                    :icon       :i/correct
                    :icon-color (colors/resolve-color :success theme)
-                   :text       (i18n/label messsage)}])))
+                   :text       (i18n/label message)}])))
 
 (defn- view-internal
   [{:keys [theme]}]
@@ -34,7 +35,6 @@
         account-color        (reagent/cursor edited-data [:customization-color])
         account-emoji        (reagent/cursor edited-data [:emoji])
         on-change-name       (fn [edited-name]
-                               ;;validation needs to be performed on the name (#17372)
                                (swap! edited-data assoc :name edited-name))
         show-confirm-button? (reagent/atom false)
         on-change-color      (fn [edited-color]

--- a/src/status_im2/contexts/wallet/edit_account/view.cljs
+++ b/src/status_im2/contexts/wallet/edit_account/view.cljs
@@ -26,38 +26,37 @@
 
 (defn- view-internal
   [{:keys [theme]}]
-  (let [{:keys [name customization-color emoji address]
-         :as   account}      (rf/sub [:wallet/current-viewing-account])
-        edited-data          (reagent/atom {:name                name
-                                            :customization-color customization-color
-                                            :emoji               emoji})
-        account-name         (reagent/cursor edited-data [:name])
-        account-color        (reagent/cursor edited-data [:customization-color])
-        account-emoji        (reagent/cursor edited-data [:emoji])
-        on-change-name       (fn [edited-name]
-                               (swap! edited-data assoc :name edited-name))
-        show-confirm-button? (reagent/atom false)
-        on-change-color      (fn [edited-color]
-                               (swap! edited-data assoc :customization-color edited-color)
-                               (rf/dispatch [:wallet/save-account
-                                             {:address     address
-                                              :edited-data @edited-data}
-                                             #(show-toast {:type  :color
-                                                           :theme theme})]))
-        on-change-emoji      (fn [edited-emoji]
-                               (swap! edited-data assoc :emoji edited-emoji)
-                               (rf/dispatch [:wallet/save-account
-                                             {:address     address
-                                              :edited-data @edited-data}
-                                             #(show-toast {:type  :emoji
-                                                           :theme theme})]))
-        on-confirm           (fn []
-                               (rn/dismiss-keyboard!)
-                               (rf/dispatch [:wallet/save-account
-                                             {:address     address
-                                              :edited-data @edited-data}
-                                             #(show-toast {:type  :name
-                                                           :theme theme})]))]
+  (let [{:keys [name emoji address color]} (rf/sub [:wallet/current-viewing-account])
+        edited-data                        (reagent/atom {:name  name
+                                                          :color color
+                                                          :emoji emoji})
+        account-name                       (reagent/cursor edited-data [:name])
+        account-color                      (reagent/cursor edited-data [:color])
+        account-emoji                      (reagent/cursor edited-data [:emoji])
+        on-change-name                     (fn [edited-name]
+                                             (swap! edited-data assoc :name edited-name))
+        show-confirm-button?               (reagent/atom false)
+        on-change-color                    (fn [edited-color]
+                                             (swap! edited-data assoc :color edited-color)
+                                             (rf/dispatch [:wallet/save-account
+                                                           {:address     address
+                                                            :edited-data @edited-data}
+                                                           #(show-toast {:type  :color
+                                                                         :theme theme})]))
+        on-change-emoji                    (fn [edited-emoji]
+                                             (swap! edited-data assoc :emoji edited-emoji)
+                                             (rf/dispatch [:wallet/save-account
+                                                           {:address     address
+                                                            :edited-data @edited-data}
+                                                           #(show-toast {:type  :emoji
+                                                                         :theme theme})]))
+        on-confirm                         (fn []
+                                             (rn/dismiss-keyboard!)
+                                             (rf/dispatch [:wallet/save-account
+                                                           {:address     address
+                                                            :edited-data @edited-data}
+                                                           #(show-toast {:type  :name
+                                                                         :theme theme})]))]
     (fn []
       [create-or-edit-account/view
        {:page-nav-right-side [{:icon-name :i/delete
@@ -95,8 +94,7 @@
          :on-press        (fn []
                             (rf/dispatch [:show-bottom-sheet
                                           {:content (fn [] [network-preferences/view
-                                                            {:account account
-                                                             :on-save #(js/alert
+                                                            {:on-save #(js/alert
                                                                         "calling on save")}])}]))
          :container-style style/data-item}]])))
 

--- a/src/status_im2/contexts/wallet/events.cljs
+++ b/src/status_im2/contexts/wallet/events.cljs
@@ -70,21 +70,19 @@
                                    {:error %
                                     :event :wallet/get-accounts})}]]]}))
 
-(rf/reg-event-fx :wallet/save-account
- (fn [{:keys [db]} [{:keys [address edited-data]} callback]]
-   (let [account        (get-in db [:wallet :accounts address])
-         edited-account (-> (merge account edited-data)
-                            data-store/<-account)]
-     {:fx [[:json-rpc/call
-            [{:method     "accounts_saveAccount"
-              :params     [edited-account]
-              :on-success (fn []
-                            (rf/dispatch [:wallet/get-accounts])
-                            (when (fn? callback)
-                              (callback)))
-              :on-error   #(log/info "failed to save account "
-                                     {:error %
-                                      :event :wallet/save-account})}]]]})))
+(rf/reg-event-fx
+ :wallet/save-account
+ (fn [_ [{:keys [account callback]}]]
+   {:fx [[:json-rpc/call
+          [{:method     "accounts_saveAccount"
+            :params     [(data-store/<-account account)]
+            :on-success (fn []
+                          (rf/dispatch [:wallet/get-accounts])
+                          (when (fn? callback)
+                            (callback)))
+            :on-error   #(log/info "failed to save account "
+                                   {:error %
+                                    :event :wallet/save-account})}]]]}))
 
 (rf/reg-event-fx :wallet/get-wallet-token
  (fn [{:keys [db]}]

--- a/src/status_im2/contexts/wallet/home/style.cljs
+++ b/src/status_im2/contexts/wallet/home/style.cljs
@@ -12,10 +12,12 @@
   {:height 86})
 
 (def accounts-list
-  {:padding-horizontal 20
-   :padding-top        32
-   :padding-bottom     12
-   :max-height         112})
+  {:padding-top    32
+   :padding-bottom 12
+   :max-height     112})
+
+(def accounts-list-container
+  {:padding-horizontal 20})
 
 (def empty-container-style
   {:justify-content :center

--- a/src/status_im2/contexts/wallet/home/view.cljs
+++ b/src/status_im2/contexts/wallet/home/view.cljs
@@ -43,13 +43,14 @@
   [{:keys [accounts loading? balances profile-color]}]
   (let [accounts-with-balances
         (mapv
-         (fn [{:keys [address] :as account}]
+         (fn [{:keys [color address] :as account}]
            (assoc account
-                  :type     :empty
-                  :on-press #(rf/dispatch [:wallet/navigate-to-account address])
-                  :loading? loading?
-                  :balance  (utils/prettify-balance
-                             (utils/get-balance-by-address balances address))))
+                  :customization-color color
+                  :type                :empty
+                  :on-press            #(rf/dispatch [:wallet/navigate-to-account address])
+                  :loading?            loading?
+                  :balance             (utils/prettify-balance
+                                        (utils/get-balance-by-address balances address))))
          accounts)]
     (conj accounts-with-balances (add-account-placeholder profile-color))))
 

--- a/src/status_im2/contexts/wallet/home/view.cljs
+++ b/src/status_im2/contexts/wallet/home/view.cljs
@@ -58,45 +58,46 @@
   (rf/dispatch [:wallet/request-collectibles
                 {:start-at-index 0
                  :new-request?   true}])
-  (fn []
-    (let [accounts      (rf/sub [:wallet/accounts])
-          loading?      (rf/sub [:wallet/tokens-loading?])
-          balances      (rf/sub [:wallet/balances])
-          profile-color (rf/sub [:profile/customization-color])
-          networks      (rf/sub [:wallet/network-details])
-          top           (safe-area/get-top)
-          selected-tab  (reagent/atom (:id (first tabs-data)))]
-      [rn/view
-       {:style {:margin-top top
-                :flex       1}}
-       [common.top-nav/view]
-       [rn/view {:style style/overview-container}
-        [quo/wallet-overview (temp/wallet-overview-state networks)]]
-       [rn/pressable
-        {:on-long-press #(rf/dispatch [:show-bottom-sheet {:content temp/wallet-temporary-navigation}])}
-        [quo/wallet-graph {:time-frame :empty}]]
-       [rn/flat-list
-        {:style                             style/accounts-list
-         :content-container-style           style/accounts-list-container
-         :data                              (account-cards {:accounts      accounts
-                                                            :loading?      loading?
-                                                            :balances      balances
-                                                            :profile-color profile-color})
-         :horizontal                        true
-         :separator                         [rn/view {:style {:width 12}}]
-         :render-fn                         quo/account-card
-         :shows-horizontal-scroll-indicator false}]
-       [quo/tabs
-        {:style          style/tabs
-         :size           32
-         :default-active @selected-tab
-         :data           tabs-data
-         :on-change      #(reset! selected-tab %)}]
-       (case @selected-tab
-         :assets       [rn/flat-list
-                        {:render-fn               quo/token-value
-                         :data                    temp/tokens
-                         :key                     :assets-list
-                         :content-container-style {:padding-horizontal 8}}]
-         :collectibles [collectibles/view]
-         [activity/view])])))
+  (let [top          (safe-area/get-top)
+        selected-tab (reagent/atom (:id (first tabs-data)))]
+    (fn []
+      (let [accounts      (rf/sub [:wallet/accounts])
+            loading?      (rf/sub [:wallet/tokens-loading?])
+            balances      (rf/sub [:wallet/balances])
+            profile-color (rf/sub [:profile/customization-color])
+            networks      (rf/sub [:wallet/network-details])]
+        [rn/view
+         {:style {:margin-top top
+                  :flex       1}}
+         [common.top-nav/view]
+         [rn/view {:style style/overview-container}
+          [quo/wallet-overview (temp/wallet-overview-state networks)]]
+         [rn/pressable
+          {:on-long-press #(rf/dispatch [:show-bottom-sheet
+                                         {:content temp/wallet-temporary-navigation}])}
+          [quo/wallet-graph {:time-frame :empty}]]
+         [rn/flat-list
+          {:style                             style/accounts-list
+           :content-container-style           style/accounts-list-container
+           :data                              (account-cards {:accounts      accounts
+                                                              :loading?      loading?
+                                                              :balances      balances
+                                                              :profile-color profile-color})
+           :horizontal                        true
+           :separator                         [rn/view {:style {:width 12}}]
+           :render-fn                         quo/account-card
+           :shows-horizontal-scroll-indicator false}]
+         [quo/tabs
+          {:style          style/tabs
+           :size           32
+           :default-active @selected-tab
+           :data           tabs-data
+           :on-change      #(reset! selected-tab %)}]
+         (case @selected-tab
+           :assets       [rn/flat-list
+                          {:render-fn               quo/token-value
+                           :data                    temp/tokens
+                           :key                     :assets-list
+                           :content-container-style {:padding-horizontal 8}}]
+           :collectibles [collectibles/view]
+           [activity/view])]))))

--- a/src/status_im2/contexts/wallet/home/view.cljs
+++ b/src/status_im2/contexts/wallet/home/view.cljs
@@ -40,64 +40,63 @@
    {:id :activity :label (i18n/label :t/activity) :accessibility-label :activity-tab}])
 
 (defn account-cards
-  [{:keys [accounts loading? balances profile]}]
+  [{:keys [accounts loading? balances profile-color]}]
   (let [accounts-with-balances
         (mapv
-         (fn [account]
+         (fn [{:keys [address] :as account}]
            (assoc account
-                  :type                :empty
-                  :customization-color (:customization-color profile)
-                  :on-press            #(rf/dispatch [:navigate-to :wallet-accounts (:address account)])
-                  :loading?            loading?
-                  :balance             (utils/prettify-balance
-                                        (utils/get-balance-by-address balances (:address account)))))
+                  :type     :empty
+                  :on-press #(rf/dispatch [:wallet/navigate-to-account address])
+                  :loading? loading?
+                  :balance  (utils/prettify-balance
+                             (utils/get-balance-by-address balances address))))
          accounts)]
-    (conj accounts-with-balances (add-account-placeholder (:customization-color profile)))))
+    (conj accounts-with-balances (add-account-placeholder profile-color))))
 
 (defn view
   []
-  (rf/dispatch [:wallet/get-wallet-token])
   (rf/dispatch [:wallet/request-collectibles
                 {:start-at-index 0
                  :new-request?   true}])
-  (let [selected-tab (reagent/atom (:id (first tabs-data)))]
-    (fn []
-      (let [accounts (rf/sub [:profile/wallet-accounts])
-            top      (safe-area/get-top)
-            loading? (rf/sub [:wallet/tokens-loading?])
-            balances (rf/sub [:wallet/balances])
-            profile  (rf/sub [:profile/profile])
-            networks (rf/sub [:wallet/network-details])]
-        [rn/view
-         {:style {:margin-top top
-                  :flex       1}}
-         [common.top-nav/view]
-         [rn/view {:style style/overview-container}
-          [quo/wallet-overview (temp/wallet-overview-state networks)]]
-         [rn/pressable
-          {:on-long-press #(rf/dispatch [:show-bottom-sheet
-                                         {:content temp/wallet-temporary-navigation}])}
-          [quo/wallet-graph {:time-frame :empty}]]
-         [rn/flat-list
-          {:style      style/accounts-list
-           :data       (account-cards {:accounts accounts
-                                       :loading? loading?
-                                       :balances balances
-                                       :profile  profile})
-           :horizontal true
-           :separator  [rn/view {:style {:width 12}}]
-           :render-fn  quo/account-card}]
-         [quo/tabs
-          {:style          style/tabs
-           :size           32
-           :default-active @selected-tab
-           :data           tabs-data
-           :on-change      #(reset! selected-tab %)}]
-         (case @selected-tab
-           :assets       [rn/flat-list
-                          {:render-fn               quo/token-value
-                           :data                    temp/tokens
-                           :key                     :assets-list
-                           :content-container-style {:padding-horizontal 8}}]
-           :collectibles [collectibles/view]
-           [activity/view])]))))
+  (fn []
+    (let [accounts      (rf/sub [:wallet/accounts])
+          loading?      (rf/sub [:wallet/tokens-loading?])
+          balances      (rf/sub [:wallet/balances])
+          profile-color (rf/sub [:profile/customization-color])
+          networks      (rf/sub [:wallet/network-details])
+          top           (safe-area/get-top)
+          selected-tab  (reagent/atom (:id (first tabs-data)))]
+      [rn/view
+       {:style {:margin-top top
+                :flex       1}}
+       [common.top-nav/view]
+       [rn/view {:style style/overview-container}
+        [quo/wallet-overview (temp/wallet-overview-state networks)]]
+       [rn/pressable
+        {:on-long-press #(rf/dispatch [:show-bottom-sheet {:content temp/wallet-temporary-navigation}])}
+        [quo/wallet-graph {:time-frame :empty}]]
+       [rn/flat-list
+        {:style                             style/accounts-list
+         :content-container-style           style/accounts-list-container
+         :data                              (account-cards {:accounts      accounts
+                                                            :loading?      loading?
+                                                            :balances      balances
+                                                            :profile-color profile-color})
+         :horizontal                        true
+         :separator                         [rn/view {:style {:width 12}}]
+         :render-fn                         quo/account-card
+         :shows-horizontal-scroll-indicator false}]
+       [quo/tabs
+        {:style          style/tabs
+         :size           32
+         :default-active @selected-tab
+         :data           tabs-data
+         :on-change      #(reset! selected-tab %)}]
+       (case @selected-tab
+         :assets       [rn/flat-list
+                        {:render-fn               quo/token-value
+                         :data                    temp/tokens
+                         :key                     :assets-list
+                         :content-container-style {:padding-horizontal 8}}]
+         :collectibles [collectibles/view]
+         [activity/view])])))

--- a/src/status_im2/subs/wallet/wallet.cljs
+++ b/src/status_im2/subs/wallet/wallet.cljs
@@ -33,9 +33,10 @@
 (re-frame/reg-sub
  :wallet/accounts
  :<- [:wallet]
- (fn [{:keys [accounts]}]
-   (->> (vals accounts)
-        (sort-by :position))))
+ :-> #(->> %
+           :accounts
+           vals
+           (sort-by :position)))
 
 (re-frame/reg-sub
  :wallet/balances
@@ -51,5 +52,6 @@
  :<- [:wallet]
  :<- [:wallet/balances]
  (fn [[{:keys [current-viewing-account-address] :as wallet} balances]]
-   (-> (get-in wallet [:accounts current-viewing-account-address])
+   (-> wallet
+       (get-in [:accounts current-viewing-account-address])
        (assoc :balance (utils/get-balance-by-address balances current-viewing-account-address)))))

--- a/src/status_im2/subs/wallet/wallet_test.cljs
+++ b/src/status_im2/subs/wallet/wallet_test.cljs
@@ -56,7 +56,7 @@
           :type                     :generated
           :chat                     false
           :test-preferred-chain-ids #{5 420 421613}
-          :customization-color      :blue
+          :color                    :blue
           :hidden                   false
           :prod-preferred-chain-ids #{1 10 42161}
           :position                 0
@@ -75,7 +75,7 @@
           :type                     :generated
           :chat                     false
           :test-preferred-chain-ids #{5 420 421613}
-          :customization-color      :purple
+          :color                    :purple
           :hidden                   false
           :prod-preferred-chain-ids #{1 10 42161}
           :position                 1
@@ -115,7 +115,7 @@
            :type                     :generated
            :chat                     false
            :test-preferred-chain-ids #{5 420 421613}
-           :customization-color      :blue
+           :color                    :blue
            :hidden                   false
            :prod-preferred-chain-ids #{1 10 42161}
            :position                 0
@@ -134,7 +134,7 @@
            :type                     :generated
            :chat                     false
            :test-preferred-chain-ids #{5 420 421613}
-           :customization-color      :purple
+           :color                    :purple
            :hidden                   false
            :prod-preferred-chain-ids #{1 10 42161}
            :position                 1
@@ -164,7 +164,7 @@
          :type                     :generated
          :chat                     false
          :test-preferred-chain-ids #{5 420 421613}
-         :customization-color      :blue
+         :color                    :blue
          :hidden                   false
          :prod-preferred-chain-ids #{1 10 42161}
          :position                 0

--- a/src/status_im2/subs/wallet/wallet_test.cljs
+++ b/src/status_im2/subs/wallet/wallet_test.cljs
@@ -1,9 +1,12 @@
 (ns status-im2.subs.wallet.wallet-test
-  (:require [cljs.test :refer [is testing]]
+  (:require [cljs.test :refer [is testing use-fixtures]]
             [re-frame.db :as rf-db]
             status-im2.subs.root
             [test-helpers.unit :as h]
             [utils.re-frame :as rf]))
+
+(use-fixtures :each
+              {:before #(reset! rf-db/app-db {})})
 
 (def tokens
   {:0x1 [{:decimals                1
@@ -44,40 +47,132 @@
           :marketValuesPerCurrency {:USD {:price 1000}}}]}) ;; total should be 1000
 
 (def accounts
-  [{:address "0x1"
-    :name    "Main account"
-    :hidden  false
-    :removed false}
-   {:address "0x2"
-    :name    "Secondary account"
-    :hidden  false
-    :removed false}])
+  {"0x1" {:path                     "m/44'/60'/0'/0/0"
+          :emoji                    "😃"
+          :key-uid                  "0x2f5ea39"
+          :address                  "0x1"
+          :wallet                   false
+          :name                     "Account One"
+          :type                     :generated
+          :chat                     false
+          :test-preferred-chain-ids #{5 420 421613}
+          :customization-color      :blue
+          :hidden                   false
+          :prod-preferred-chain-ids #{1 10 42161}
+          :position                 0
+          :clock                    1698945829328
+          :created-at               1698928839000
+          :operable                 "fully"
+          :mixedcase-address        "0x7bcDfc75c431"
+          :public-key               "0x04371e2d9d66b82f056bc128064"
+          :removed                  false}
+   "0x2" {:path                     "m/44'/60'/0'/0/1"
+          :emoji                    "💎"
+          :key-uid                  "0x2f5ea39"
+          :address                  "0x2"
+          :wallet                   false
+          :name                     "Account Two"
+          :type                     :generated
+          :chat                     false
+          :test-preferred-chain-ids #{5 420 421613}
+          :customization-color      :purple
+          :hidden                   false
+          :prod-preferred-chain-ids #{1 10 42161}
+          :position                 1
+          :clock                    1698945829328
+          :created-at               1698928839000
+          :operable                 "fully"
+          :mixedcase-address        "0x7bcDfc75c431"
+          :public-key               "0x04371e2d9d66b82f056bc128064"
+          :removed                  false}})
 
 (h/deftest-sub :wallet/balances
   [sub-name]
-  (testing "returns vector of maps containing :address and :balance"
-    (swap! rf-db/app-db assoc
-      :profile/wallet-accounts accounts
-      :wallet/tokens           tokens)
-    (is (= [{:address "0x1"
-             :balance 3250}
-            {:address "0x2"
-             :balance 2100}]
+  (testing "returns seq of maps containing :address and :balance"
+    (swap! rf-db/app-db #(-> %
+                             (assoc-in [:wallet :accounts] accounts)
+                             (assoc :wallet/tokens tokens)))
+    (is (= `({:address "0x1"
+              :balance 3250}
+             {:address "0x2"
+              :balance 2100})
            (rf/sub [sub-name])))))
 
-(h/deftest-sub :wallet/account
+(h/deftest-sub :wallet/accounts
   [sub-name]
-  (testing "returns current account with balance base on the account-address"
-    (swap! rf-db/app-db assoc
-      :profile/wallet-accounts accounts
-      :wallet/tokens           tokens
-      :wallet/balances         [{:address "0x1"
-                                 :balance 3250}
-                                {:address "0x2"
-                                 :balance 2100}])
-    (is (= {:address "0x1"
-            :name    "Main account"
-            :hidden  false
-            :removed false
-            :balance 3250}
-           (rf/sub [sub-name "0x1"])))))
+  (testing "returns all accounts without balance"
+    (swap! rf-db/app-db
+      #(-> %
+           (assoc-in [:wallet :accounts] accounts)
+           (assoc :wallet/tokens tokens)))
+    (is
+     (= `({:path                     "m/44'/60'/0'/0/0"
+           :emoji                    "😃"
+           :key-uid                  "0x2f5ea39"
+           :address                  "0x1"
+           :wallet                   false
+           :name                     "Account One"
+           :type                     :generated
+           :chat                     false
+           :test-preferred-chain-ids #{5 420 421613}
+           :customization-color      :blue
+           :hidden                   false
+           :prod-preferred-chain-ids #{1 10 42161}
+           :position                 0
+           :clock                    1698945829328
+           :created-at               1698928839000
+           :operable                 "fully"
+           :mixedcase-address        "0x7bcDfc75c431"
+           :public-key               "0x04371e2d9d66b82f056bc128064"
+           :removed                  false}
+          {:path                     "m/44'/60'/0'/0/1"
+           :emoji                    "💎"
+           :key-uid                  "0x2f5ea39"
+           :address                  "0x2"
+           :wallet                   false
+           :name                     "Account Two"
+           :type                     :generated
+           :chat                     false
+           :test-preferred-chain-ids #{5 420 421613}
+           :customization-color      :purple
+           :hidden                   false
+           :prod-preferred-chain-ids #{1 10 42161}
+           :position                 1
+           :clock                    1698945829328
+           :created-at               1698928839000
+           :operable                 "fully"
+           :mixedcase-address        "0x7bcDfc75c431"
+           :public-key               "0x04371e2d9d66b82f056bc128064"
+           :removed                  false})
+        (rf/sub [sub-name])))))
+
+(h/deftest-sub :wallet/current-viewing-account
+  [sub-name]
+  (testing "returns current account with balance base"
+    (swap! rf-db/app-db
+      #(-> %
+           (assoc-in [:wallet :accounts] accounts)
+           (assoc-in [:wallet :current-viewing-account-address] "0x1")
+           (assoc :wallet/tokens tokens)))
+    (is
+     (= {:path                     "m/44'/60'/0'/0/0"
+         :emoji                    "😃"
+         :key-uid                  "0x2f5ea39"
+         :address                  "0x1"
+         :wallet                   false
+         :name                     "Account One"
+         :type                     :generated
+         :chat                     false
+         :test-preferred-chain-ids #{5 420 421613}
+         :customization-color      :blue
+         :hidden                   false
+         :prod-preferred-chain-ids #{1 10 42161}
+         :position                 0
+         :clock                    1698945829328
+         :created-at               1698928839000
+         :operable                 "fully"
+         :mixedcase-address        "0x7bcDfc75c431"
+         :public-key               "0x04371e2d9d66b82f056bc128064"
+         :removed                  false
+         :balance                  3250}
+        (rf/sub [sub-name])))))

--- a/translations/en.json
+++ b/translations/en.json
@@ -2376,5 +2376,10 @@
     "derive-addresses": "Derive addresses",
     "address-activity": "This address has activity",
     "sign transactions": "sign transactions",
-    "search-assets": "Search assets"
+    "search-assets": "Search assets",
+    "account-created": "{{name}} created",
+    "update-account-name": "Update account name",
+    "edit-wallet-account-emoji-updated-message": "Account emoji has been updated",
+    "edit-wallet-account-name-updated-message": "Account name has been updated",
+    "edit-wallet-account-colour-updated-message": "Account colour has been updated"
 }


### PR DESCRIPTION
fixes #17791 & #17371 

### Summary

This PR updates the following:

- Allow users to create new wallet accounts without having to re-login (latest account data is fetched immediately)
- Updates the max length of wallet account name to 20
- Updates the account cards in the wallet home screen to render the actual account colour
- Updates the (individual) account screen to show the correct color, emoji, name and address
- Allows users to edit account name, colour and emoji
- The rest of the wallet screens would see the updated account information immediately
- Fixes the color (uses profile color) of the context tag and button color in the authentication (`enter password`) bottom sheet
- Fixes the overflowing of the `+` card in the wallet home when there are two or more accounts.

#### Video Walkthrough

https://github.com/status-im/status-mobile/assets/19339952/366286ef-1311-4fbe-ab9d-6244acd516d8

### Review notes (Dev)

This PR 
 - removes the existing sub `:wallet/account`
 - introduces a new sub `:wallet/current-viewing-account`, which will return the account map the user viewing. This would be helpful in all the flows which depend on the current user viewing account.
 - updates the token RPC event handlers to use the `reg-event-fx`
 - follows the new nested approach in storing data in app-db 
 - updates the `getWalletToken` RPC event to be called on the success of fetching accounts data (will reduce load time and also helps on newly created accounts)
 
##### The existing tokens and balance data will be refactored once this PR is merged.

### Testing notes

- This PR needs to be tested on edit account flows (name, emoji and color) where it should reflected on the rest of the wallet screens.
- The validation for the account name will be implemented in a separate PR.
- A design review is not required for this PR.

#### Known Issues:

- Slider to create a account is hidden behind the soft keyboard in iOS (this is an existing issue which will be fixed later)

### Platforms

- Android
- iOS

### Steps to test

##### Creating a new account

- Open Status
- Navigate to the new wallet home (by long-press on the wallet tab)
- Tap on the "+" button on the last tile in the wallet home
- Select "Add account" 
- Fill up the account name, color and emoji
- Create an account by sliding the bottom action
- Check you are redirected to the account screen where the account name is displayed with the account avatar/switcher (on top right) should display the selected emoji and colour

##### Editing an account

- Open Status
- Navigate to the new wallet home (by long-press on the wallet tab)
- Check the cards in the wallet home
- Tap on any account to navigate to the account screen
- Tap on the top right corner (account avatar) to open account options/switcher
- Tap on "Edit account" to navigate to the edit account screen
- Change name, colour and emoji
- Check whether it's reflecting in the previous screens and persists on re-logins


status: ready
