### PR TITLE
Communities - Token gated community fixes

### DIFF
--- a/src/status_im/data_store/communities.cljs
+++ b/src/status_im/data_store/communities.cljs
@@ -1,0 +1,9 @@
+(ns status-im.data-store.communities
+  (:require [clojure.set :as set]))
+
+(defn rpc->channel-permissions
+  [rpc-channels-permissions]
+  (update-vals rpc-channels-permissions
+               (fn [{:keys [viewAndPostPermissions viewOnlyPermissions]}]
+                 {:view-only     (set/rename-keys viewOnlyPermissions {:satisfied :satisfied?})
+                  :view-and-post (set/rename-keys viewAndPostPermissions {:satisfied :satisfied?})})))

--- a/src/status_im/data_store/communities_test.cljs
+++ b/src/status_im/data_store/communities_test.cljs
@@ -1,0 +1,23 @@
+(ns status-im.data-store.communities-test
+  (:require
+    [cljs.test :refer [deftest is]]
+    [status-im.data-store.communities :as sut]))
+
+(def permissions
+  {"community-id-chat-1"
+   {:viewOnlyPermissions    {:satisfied   false
+                             :permissions {:token-permission-id-01 {:criteria [false]}}}
+    :viewAndPostPermissions {:satisfied true :permissions {}}}
+   "community-id-chat-2"
+   {:viewOnlyPermissions    {:satisfied true :permissions {}}
+    :viewAndPostPermissions {:satisfied true :permissions {}}}})
+
+(deftest rpc->channel-permissions-test
+  (is (= {"community-id-chat-1"
+          {:view-only     {:satisfied?  false
+                           :permissions {:token-permission-id-01 {:criteria [false]}}}
+           :view-and-post {:satisfied? true :permissions {}}}
+          "community-id-chat-2"
+          {:view-only     {:satisfied? true :permissions {}}
+           :view-and-post {:satisfied? true :permissions {}}}}
+         (sut/rpc->channel-permissions permissions))))

--- a/src/status_im2/constants.cljs
+++ b/src/status_im2/constants.cljs
@@ -143,6 +143,19 @@
 (def ^:const community-invitation-only-access 2)
 (def ^:const community-on-request-access 3)
 
+(def ^:const community-token-permission-unknown 0)
+(def ^:const community-token-permission-become-admin 1)
+(def ^:const community-token-permission-become-member 2)
+(def ^:const community-token-permission-can-view-channel 3)
+(def ^:const community-token-permission-can-view-and-post-channel 4)
+(def ^:const community-token-permission-become-token-master 5)
+(def ^:const community-token-permission-become-token-owner 6)
+(def ^:const community-token-permission-non-channel-permissions
+  #{community-token-permission-become-admin
+    community-token-permission-become-member
+    community-token-permission-become-token-master
+    community-token-permission-become-token-owner})
+
 ;; Community rules for joining
 (def ^:const community-rule-ens-only "ens-only")
 

--- a/src/status_im2/constants.cljs
+++ b/src/status_im2/constants.cljs
@@ -150,11 +150,6 @@
 (def ^:const community-token-permission-can-view-and-post-channel 4)
 (def ^:const community-token-permission-become-token-master 5)
 (def ^:const community-token-permission-become-token-owner 6)
-(def ^:const community-token-permission-non-channel-permissions
-  #{community-token-permission-become-admin
-    community-token-permission-become-member
-    community-token-permission-become-token-master
-    community-token-permission-become-token-owner})
 
 ;; Community rules for joining
 (def ^:const community-rule-ens-only "ens-only")

--- a/src/status_im2/contexts/communities/discover/view.cljs
+++ b/src/status_im2/contexts/communities/discover/view.cljs
@@ -206,15 +206,16 @@
         featured-communities-count (count featured-communities)]
     (fn []
       [scroll-page/scroll-page
-       {:theme          theme
-        :on-scroll      #(reset! scroll-height %)
-        :navigate-back? :true
-        :height         (if (> @scroll-height 360)
-                          208
-                          148)
-        :sticky-header  [render-sticky-header
-                         {:selected-tab  selected-tab
-                          :scroll-height scroll-height}]}
+       {:theme            theme
+        :on-scroll        #(reset! scroll-height %)
+        :navigate-back?   :true
+        :height           (if (> @scroll-height 360)
+                            208
+                            148)
+        :background-color (colors/theme-colors colors/white colors/neutral-95)
+        :sticky-header    [render-sticky-header
+                           {:selected-tab  selected-tab
+                            :scroll-height scroll-height}]}
 
        [render-communities
         selected-tab

--- a/src/status_im2/contexts/communities/overview/events.cljs
+++ b/src/status_im2/contexts/communities/overview/events.cljs
@@ -1,7 +1,27 @@
 (ns status-im2.contexts.communities.overview.events
   (:require
+    [status-im.data-store.communities :as data-store]
     [taoensso.timbre :as log]
     [utils.re-frame :as rf]))
+
+(rf/reg-event-fx :communities/check-all-community-channels-permissions-success
+ (fn [{:keys [db]} [community-id response]]
+   {:db (assoc-in db
+         [:community-channels-permissions community-id]
+         (data-store/rpc->channel-permissions (:channels response)))}))
+
+(rf/reg-event-fx :communities/check-all-community-channels-permissions
+ (fn [_ [community-id]]
+   {:fx [[:json-rpc/call
+          [{:method     "wakuext_checkAllCommunityChannelsPermissions"
+            :params     [{:CommunityID community-id}]
+            :on-success [:communities/check-all-community-channels-permissions-success community-id]
+            :on-error   (fn [error]
+                          (log/error "failed to check channels permissions"
+                                     {:error error
+                                      :community-id community-id
+                                      :event
+                                      :communities/check-all-community-channels-permissions}))}]]]}))
 
 (rf/defn check-permissions-to-join-community-success
   {:events [:communities/check-permissions-to-join-community-success]}

--- a/src/status_im2/contexts/communities/overview/view.cljs
+++ b/src/status_im2/contexts/communities/overview/view.cljs
@@ -82,23 +82,23 @@
                  (+ 38 (int (Math/ceil (layout-y %))))
                  (into #{} (map (comp :name second) channels-list)))
     :style     {:margin-top 8 :flex 1}}
-   (doall
-    (for [[category-id {:keys [chats name collapsed?]}] channels-list]
-      [rn/view
-       {:key       category-id
-        ;; on-layout fires only when the component re-renders, so
-        ;; in case the category hasn't changed, it will not be fired
-        :on-layout #(on-category-layout name (int (layout-y %)))}
-       (when-not (= constants/empty-category-id category-id)
-         [quo/divider-label
-          {:on-press     #(collapse-category community-id category-id collapsed?)
-           :chevron-icon (if collapsed? :i/chevron-right :i/chevron-down)
-           :chevron      :left}
-          name])
-       (when-not collapsed?
-         (into [rn/view {:style {:padding-horizontal 8 :padding-bottom 8}}]
-               (map #(channel-chat-item community-id community-color %))
-               chats))]))])
+   (for [[category-id {:keys [chats name collapsed?]}] channels-list]
+     [rn/view
+      {:key       category-id
+       ;; on-layout fires only when the component re-renders, so
+       ;; in case the category hasn't changed, it will not be fired
+       :on-layout #(on-category-layout name (int (layout-y %)))}
+      (when-not (= constants/empty-category-id category-id)
+        [quo/divider-label
+         {:on-press     #(collapse-category community-id category-id collapsed?)
+          :chevron-icon (if collapsed? :i/chevron-right :i/chevron-down)
+          :chevron      :left}
+         name])
+      (when-not collapsed?
+        [rn/view {:style {:padding-horizontal 8 :padding-bottom 8}}
+         (for [chat chats]
+           ^{:key (:id chat)}
+           [channel-chat-item community-id community-color chat])])])])
 
 (defn get-access-type
   [access]

--- a/src/status_im2/contexts/communities/overview/view.cljs
+++ b/src/status_im2/contexts/communities/overview/view.cljs
@@ -262,7 +262,7 @@
         [status-tag pending? joined])
       [community-header name (when collapsed? (get-in images [:thumbnail :uri]))
        (when-not collapsed? description)]
-      (when-not collapsed?
+      (when (and (seq tags) (not collapsed?))
         [quo/community-tags
          {:tags            tags
           :last-item-style style/last-community-tag

--- a/src/status_im2/contexts/communities/overview/view.cljs
+++ b/src/status_im2/contexts/communities/overview/view.cljs
@@ -205,15 +205,18 @@
 
 (defn add-handlers
   [community-id
+   joined
    {:keys [id locked?]
     :or   {locked? false}
     :as   chat}]
   (merge
    chat
    (when (and (not locked?) id)
-     {:on-press      (fn []
-                       (rf/dispatch [:dismiss-keyboard])
-                       (debounce/dispatch-and-chill [:chat/navigate-to-chat (str community-id id)] 1000))
+     {:on-press      (when joined
+                       (fn []
+                         (rf/dispatch [:dismiss-keyboard])
+                         (debounce/dispatch-and-chill [:chat/navigate-to-chat (str community-id id)]
+                                                      1000)))
       :on-long-press #(rf/dispatch
                        [:show-bottom-sheet
                         {:content (fn []
@@ -221,12 +224,12 @@
       :community-id  community-id})))
 
 (defn add-handlers-to-chats
-  [community-id chats]
-  (mapv (partial add-handlers community-id) chats))
+  [community-id joined chats]
+  (mapv (partial add-handlers community-id joined) chats))
 
 (defn add-handlers-to-categorized-chats
-  [community-id categorized-chats]
-  (let [add-on-press (partial add-handlers-to-chats community-id)]
+  [community-id categorized-chats joined]
+  (let [add-on-press (partial add-handlers-to-chats community-id joined)]
     (map (fn [[category v]]
            [category (update v :chats add-on-press)])
          categorized-chats)))
@@ -273,7 +276,7 @@
        :community-id                    id
        :community-color                 color
        :on-first-channel-height-changed on-first-channel-height-changed}
-      (add-handlers-to-categorized-chats id chats-by-category)]]))
+      (add-handlers-to-categorized-chats id chats-by-category joined)]]))
 
 (defn sticky-category-header
   [_]

--- a/src/status_im2/contexts/communities/overview/view.cljs
+++ b/src/status_im2/contexts/communities/overview/view.cljs
@@ -151,11 +151,12 @@
            (i18n/label :t/you-eligible-to-join)
            (i18n/label :t/you-not-eligible-to-join))]
         [info-button]]
-       [quo/text {:style {:padding-horizontal 12 :padding-bottom 18} :size :paragraph-2}
-        (if can-request-access?
-          (i18n/label :t/you-hold-number-of-hold-tokens-of-these
-                      {:number-of-hold-tokens number-of-hold-tokens})
-          (i18n/label :t/you-must-hold))]
+       (when (pos? number-of-hold-tokens)
+         [quo/text {:style {:padding-horizontal 12 :padding-bottom 18} :size :paragraph-2}
+          (if can-request-access?
+            (i18n/label :t/you-hold-number-of-hold-tokens-of-these
+                        {:number-of-hold-tokens number-of-hold-tokens})
+            (i18n/label :t/you-must-hold))])
        [quo/token-requirement-list
         {:tokens   tokens
          :padding? true}]

--- a/src/status_im2/contexts/communities/overview/view.cljs
+++ b/src/status_im2/contexts/communities/overview/view.cljs
@@ -2,6 +2,7 @@
   (:require
     [oops.core :as oops]
     [quo.core :as quo]
+    [quo.foundations.colors :as colors]
     [react-native.blur :as blur]
     [react-native.core :as rn]
     [reagent.core :as reagent]
@@ -323,24 +324,25 @@
             collapsed?     (and initial-joined? (:joined community))
             overlay-shown? (boolean (:sheets (rf/sub [:bottom-sheet])))]
         [scroll-page/scroll-page
-         {:cover-image    cover
-          :collapsed?     collapsed?
-          :logo           logo
-          :name           name
-          :on-scroll      #(reset! scroll-height %)
-          :navigate-back? true
-          :height         148
-          :overlay-shown? overlay-shown?
-          :page-nav-props {:type           :community
-                           :right-side     (page-nav-right-section-buttons id)
-                           :community-name name
-                           :community-logo logo}
-          :sticky-header  [sticky-category-header
-                           {:enabled (> @scroll-height @first-channel-height)
-                            :label   (pick-first-category-by-height
-                                      @scroll-height
-                                      @first-channel-height
-                                      @categories-heights)}]}
+         {:cover-image      cover
+          :collapsed?       collapsed?
+          :logo             logo
+          :name             name
+          :on-scroll        #(reset! scroll-height %)
+          :navigate-back?   true
+          :height           148
+          :overlay-shown?   overlay-shown?
+          :background-color (colors/theme-colors colors/white colors/neutral-95)
+          :page-nav-props   {:type           :community
+                             :right-side     (page-nav-right-section-buttons id)
+                             :community-name name
+                             :community-logo logo}
+          :sticky-header    [sticky-category-header
+                             {:enabled (> @scroll-height @first-channel-height)
+                              :label   (pick-first-category-by-height
+                                        @scroll-height
+                                        @first-channel-height
+                                        @categories-heights)}]}
          [community-content
           community
           pending?

--- a/src/status_im2/contexts/communities/overview/view.cljs
+++ b/src/status_im2/contexts/communities/overview/view.cljs
@@ -253,31 +253,32 @@
     :description-accessibility-label :community-description}])
 
 (defn community-content
-  [{:keys [name description joined images tags color id]
-    :as   community}
-   pending?
-   {:keys [on-category-layout
-           collapsed?
-           on-first-channel-height-changed]}]
-  (let [chats-by-category (rf/sub [:communities/categorized-channels id])]
-    [:<>
-     [rn/view {:style style/community-content-container}
-      (when-not collapsed?
-        [status-tag pending? joined])
-      [community-header name (when collapsed? (get-in images [:thumbnail :uri]))
-       (when-not collapsed? description)]
-      (when (and (seq tags) (not collapsed?))
-        [quo/community-tags
-         {:tags            tags
-          :last-item-style style/last-community-tag
-          :container-style style/community-tag-container}])
-      [join-community community pending?]]
-     [channel-list-component
-      {:on-category-layout              on-category-layout
-       :community-id                    id
-       :community-color                 color
-       :on-first-channel-height-changed on-first-channel-height-changed}
-      (add-handlers-to-categorized-chats id chats-by-category joined)]]))
+  [community]
+  (rf/dispatch [:communities/check-all-community-channels-permissions (:id community)])
+  (fn [{:keys [name description joined images tags color id] :as community}
+       pending?
+       {:keys [on-category-layout
+               collapsed?
+               on-first-channel-height-changed]}]
+    (let [chats-by-category (rf/sub [:communities/categorized-channels id])]
+      [:<>
+       [rn/view {:style style/community-content-container}
+        (when-not collapsed?
+          [status-tag pending? joined])
+        [community-header name (when collapsed? (get-in images [:thumbnail :uri]))
+         (when-not collapsed? description)]
+        (when (and (seq tags) (not collapsed?))
+          [quo/community-tags
+           {:tags            tags
+            :last-item-style style/last-community-tag
+            :container-style style/community-tag-container}])
+        [join-community community pending?]]
+       [channel-list-component
+        {:on-category-layout              on-category-layout
+         :community-id                    id
+         :community-color                 color
+         :on-first-channel-height-changed on-first-channel-height-changed}
+        (add-handlers-to-categorized-chats id chats-by-category joined)]])))
 
 (defn sticky-category-header
   [_]

--- a/src/status_im2/subs/communities.cljs
+++ b/src/status_im2/subs/communities.cljs
@@ -210,19 +210,17 @@
   - Nil: no lock
   - True: locked
   - False: unlocked"
-  [{community-id :id token-permissions :token-permissions joined? :joined}
+  [{community-id :id token-permissions :token-permissions}
    {chat-id :id can-post? :can-post?}]
-  (if (not joined?)
-    true
-    (let [chat-permissions (->> token-permissions
-                                (map second)
-                                (filter (fn [{:keys [chat_ids]}]
-                                          (some (fn [permission-chat-id]
-                                                  (= permission-chat-id (str community-id chat-id)))
-                                                chat_ids))))]
-      (cond
-        (empty? chat-permissions) nil
-        :else                     (not can-post?)))))
+  (let [chat-permissions (->> token-permissions
+                              (map second)
+                              (filter (fn [{:keys [chat_ids]}]
+                                        (some (fn [permission-chat-id]
+                                                (= permission-chat-id (str community-id chat-id)))
+                                              chat_ids))))]
+    (cond
+      (empty? chat-permissions) nil
+      :else                     (not can-post?))))
 
 (defn reduce-over-categories
   [community

--- a/src/status_im2/subs/communities.cljs
+++ b/src/status_im2/subs/communities.cljs
@@ -280,19 +280,23 @@
                               (reduce #(+ %1 (if %2 1 0)) acc criteria))
                             0
                             (:permissions token-permissions-check))
-    :tokens                (map (fn [[perm-key {:keys [token_criteria]}]]
-                                  (let [check-criteria (get-in token-permissions-check
-                                                               [:permissions perm-key :criteria])]
-                                    (map
-                                     (fn [{sym :symbol amount :amount} sufficient?]
-                                       {:symbol      sym
-                                        :sufficient? (when (seq check-criteria) sufficient?)
-                                        :loading?    checking-permissions?
-                                        :amount      amount
-                                        :img-src     (get token-images sym)})
-                                     token_criteria
-                                     (or check-criteria token_criteria))))
-                                token-permissions)}))
+    :tokens                (->> token-permissions
+                                (filter (fn [[_ {:keys [type]}]]
+                                          (contains?
+                                           constants/community-token-permission-non-channel-permissions
+                                           type)))
+                                (map (fn [[perm-key {:keys [token_criteria]}]]
+                                       (let [check-criteria (get-in token-permissions-check
+                                                                    [:permissions perm-key :criteria])]
+                                         (map
+                                          (fn [{sym :symbol amount :amount} sufficient?]
+                                            {:symbol      sym
+                                             :sufficient? (when (seq check-criteria) sufficient?)
+                                             :loading?    checking-permissions?
+                                             :amount      amount
+                                             :img-src     (get token-images sym)})
+                                          token_criteria
+                                          (or check-criteria token_criteria))))))}))
 
 (re-frame/reg-sub
  :community/images

--- a/src/status_im2/subs/communities.cljs
+++ b/src/status_im2/subs/communities.cljs
@@ -222,9 +222,9 @@
   - False: unlocked (there are permissions and can-post? is true)"
   [community {chat-id :id can-post? :can-post?}]
   (let [chat-permissions (get-chat-token-permissions community chat-id)]
-    (cond
-      (empty? chat-permissions) nil
-      :else                     (not can-post?))))
+    (if (empty? chat-permissions)
+      nil
+      (not can-post?))))
 
 (defn- reduce-over-categories
   [community

--- a/src/status_im2/subs/communities.cljs
+++ b/src/status_im2/subs/communities.cljs
@@ -299,9 +299,7 @@
                             (:permissions token-permissions-check))
     :tokens                (->> token-permissions
                                 (filter (fn [[_ {:keys [type]}]]
-                                          (contains?
-                                           constants/community-token-permission-non-channel-permissions
-                                           type)))
+                                          (= type constants/community-token-permission-become-member)))
                                 (map (fn [[perm-key {:keys [token_criteria]}]]
                                        (let [check-criteria (get-in token-permissions-check
                                                                     [:permissions perm-key :criteria])]

--- a/src/status_im2/subs/communities.cljs
+++ b/src/status_im2/subs/communities.cljs
@@ -217,9 +217,9 @@
 (defn- get-chat-lock-state
   "Returns the chat lock state.
 
-  - Nil: no lock
-  - True: locked
-  - False: unlocked"
+  - Nil:   no lock  (there are no permissions for the chat)
+  - True:  locked   (there are permissions and can-post? is false)
+  - False: unlocked (there are permissions and can-post? is true)"
   [community {chat-id :id can-post? :can-post?}]
   (let [chat-permissions (get-chat-token-permissions community chat-id)]
     (cond

--- a/src/status_im2/subs/communities_test.cljs
+++ b/src/status_im2/subs/communities_test.cljs
@@ -146,6 +146,97 @@
                          :unread-messages? false
                          :mentions-count   0}]}]]
         (rf/sub [sub-name "0x1"]))))
+  (testing "Channels with categories and token permissions"
+    (swap! rf-db/app-db assoc
+      :communities
+      {community-id {:id                community-id
+                     :token-permissions [[:token-permission-id-01
+                                          {:id "token-permission-id-01"
+                                           :type constants/community-token-permission-can-view-channel
+                                           :token_criteria [{:contract_addresses {:5 "0x0"}
+                                                             :type               1
+                                                             :symbol             "SNT"
+                                                             :amount             "0.0020000000000000"
+                                                             :decimals           18}]
+                                           :chat_ids [(str community-id "0x100")]}]
+                                         [:token-permission-id-02
+                                          {:id "token-permission-id-02"
+                                           :type constants/community-token-permission-become-member
+                                           :token_criteria [{:contract_addresses {:5 "0x0"}
+                                                             :type               1
+                                                             :symbol             "ETH"
+                                                             :amount             "0.0010000000000000"
+                                                             :decimals           18}]}]
+                                         [:token-permission-id-03
+                                          {:id "token-permission-id-03"
+                                           :type constants/community-token-permission-can-view-channel
+                                           :token_criteria [{:contract_addresses {:5 "0x0"}
+                                                             :type               1
+                                                             :symbol             "ETH"
+                                                             :amount             "0.1"
+                                                             :decimals           18}]
+                                           :chat_ids [(str community-id "0x300")]}]]
+                     :chats             {"0x100" {:id         "0x100"
+                                                  :position   1
+                                                  :name       "chat1"
+                                                  :muted?     nil
+                                                  :categoryID "1"
+                                                  :can-post?  false}
+                                         "0x200" {:id         "0x200"
+                                                  :position   2
+                                                  :name       "chat2"
+                                                  :muted?     nil
+                                                  :categoryID "1"
+                                                  :can-post?  false}
+                                         "0x300" {:id         "0x300"
+                                                  :position   3
+                                                  :name       "chat3"
+                                                  :muted?     nil
+                                                  :categoryID "2"
+                                                  :can-post?  true}}
+                     :categories        {"1" {:id       "1"
+                                              :position 2
+                                              :name     "category1"}
+                                         "2" {:id       "2"
+                                              :position 1
+                                              :name     "category2"}}
+                     :joined            true}})
+    (is
+     (= [["2"
+          {:id         "2"
+           :name       "category2"
+           :collapsed? nil
+           :position   1
+           :chats      [{:name             "chat3"
+                         :position         3
+                         :emoji            nil
+                         :muted?           nil
+                         :locked?          false
+                         :id               "0x300"
+                         :unread-messages? false
+                         :mentions-count   0}]}]
+         ["1"
+          {:id         "1"
+           :name       "category1"
+           :collapsed? nil
+           :position   2
+           :chats      [{:name             "chat1"
+                         :emoji            nil
+                         :position         1
+                         :muted?           nil
+                         :locked?          true
+                         :id               "0x100"
+                         :unread-messages? false
+                         :mentions-count   0}
+                        {:name             "chat2"
+                         :emoji            nil
+                         :position         2
+                         :muted?           nil
+                         :locked?          nil
+                         :id               "0x200"
+                         :unread-messages? false
+                         :mentions-count   0}]}]]
+        (rf/sub [sub-name "0x1"]))))
   (testing "Channels without categories"
     (swap! rf-db/app-db assoc
       :communities

--- a/src/status_im2/subs/communities_test.cljs
+++ b/src/status_im2/subs/communities_test.cljs
@@ -374,23 +374,33 @@
                 :checking-permissions?   checking-permissions?
                 :permissions             {:access 3}
                 :token-images            {"ETH" token-image-eth}
-                :token-permissions       [[:abcde
-                                           {:id "abcde"
+                :token-permissions       [[:permission-id-01
+                                           {:id "permission-id-01"
                                             :type constants/community-token-permission-can-view-channel
                                             :token_criteria [{:contract_addresses {:5 "0x0"}
                                                               :type               1
                                                               :symbol             "SNT"
-                                                              :amount             "0.0020000000000000"
+                                                              :amount             "0.002"
                                                               :decimals           18}]
                                             :chat_ids [(str community-id
                                                             "89f98a1e-6776-4e5f-8626-8ab9f855253f")]}]
-                                          [:xyz
-                                           {:id "xyz"
+                                          [:permission-id-02
+                                           {:id "permission-id-02"
+                                            :type constants/community-token-permission-become-admin
+                                            :token_criteria [{:contract_addresses {:5 "0x0"}
+                                                              :type               1
+                                                              :symbol             "DAI"
+                                                              :amount             "5.0"
+                                                              :decimals           18}]
+                                            :chat_ids [(str community-id
+                                                            "89f98a1e-6776-4e5f-8626-8ab9f855253f")]}]
+                                          [:permission-id-03
+                                           {:id "permission-id-03"
                                             :type constants/community-token-permission-become-member
                                             :token_criteria [{:contract_addresses {:5 "0x0"}
                                                               :type               1
                                                               :symbol             "ETH"
-                                                              :amount             "0.0010000000000000"
+                                                              :amount             "0.001"
                                                               :decimals           18}]}]]
                 :name                    "Community super name"
                 :chats                   {"89f98a1e-6776-4e5f-8626-8ab9f855253f"
@@ -432,7 +442,7 @@
     (is (= {:can-request-access?   true
             :number-of-hold-tokens 2
             :tokens                [[{:symbol      "ETH"
-                                      :amount      "0.0010000000000000"
+                                      :amount      "0.001"
                                       :sufficient? nil
                                       :loading?    checking-permissions?
                                       :img-src     token-image-eth}]]}

--- a/src/status_im2/subs/communities_test.cljs
+++ b/src/status_im2/subs/communities_test.cljs
@@ -146,61 +146,61 @@
                          :unread-messages? false
                          :mentions-count   0}]}]]
         (rf/sub [sub-name "0x1"]))))
+
   (testing "Channels with categories and token permissions"
     (swap! rf-db/app-db assoc
+      :community-channels-permissions
+      {community-id
+       {(keyword (str community-id "0x100"))
+        {:view-only     {:satisfied?  false
+                         :permissions {:token-permission-id-01 {:criteria [false]}}}
+         :view-and-post {:satisfied? true :permissions {}}}
+        (keyword (str community-id "0x200"))
+        {:view-only     {:satisfied? true :permissions {}}
+         :view-and-post {:satisfied? true :permissions {}}}
+        (keyword (str community-id "0x300"))
+        {:view-only     {:satisfied? false :permissions {}}
+         :view-and-post {:satisfied?  true
+                         :permissions {:token-permission-id-03 {:criteria [true]}}}}
+        (keyword (str community-id "0x400"))
+        {:view-only     {:satisfied?  true
+                         :permissions {}}
+         :view-and-post {:satisfied?  false
+                         :permissions {:token-permission-id-04 {:criteria [false]}}}}}}
+
       :communities
-      {community-id {:id                community-id
-                     :token-permissions [[:token-permission-id-01
-                                          {:id "token-permission-id-01"
-                                           :type constants/community-token-permission-can-view-channel
-                                           :token_criteria [{:contract_addresses {:5 "0x0"}
-                                                             :type               1
-                                                             :symbol             "SNT"
-                                                             :amount             "0.0020000000000000"
-                                                             :decimals           18}]
-                                           :chat_ids [(str community-id "0x100")]}]
-                                         [:token-permission-id-02
-                                          {:id "token-permission-id-02"
-                                           :type constants/community-token-permission-become-member
-                                           :token_criteria [{:contract_addresses {:5 "0x0"}
-                                                             :type               1
-                                                             :symbol             "ETH"
-                                                             :amount             "0.0010000000000000"
-                                                             :decimals           18}]}]
-                                         [:token-permission-id-03
-                                          {:id "token-permission-id-03"
-                                           :type constants/community-token-permission-can-view-channel
-                                           :token_criteria [{:contract_addresses {:5 "0x0"}
-                                                             :type               1
-                                                             :symbol             "ETH"
-                                                             :amount             "0.1"
-                                                             :decimals           18}]
-                                           :chat_ids [(str community-id "0x300")]}]]
-                     :chats             {"0x100" {:id         "0x100"
-                                                  :position   1
-                                                  :name       "chat1"
-                                                  :muted?     nil
-                                                  :categoryID "1"
-                                                  :can-post?  false}
-                                         "0x200" {:id         "0x200"
-                                                  :position   2
-                                                  :name       "chat2"
-                                                  :muted?     nil
-                                                  :categoryID "1"
-                                                  :can-post?  false}
-                                         "0x300" {:id         "0x300"
-                                                  :position   3
-                                                  :name       "chat3"
-                                                  :muted?     nil
-                                                  :categoryID "2"
-                                                  :can-post?  true}}
-                     :categories        {"1" {:id       "1"
-                                              :position 2
-                                              :name     "category1"}
-                                         "2" {:id       "2"
-                                              :position 1
-                                              :name     "category2"}}
-                     :joined            true}})
+      {community-id {:id         community-id
+                     :chats      {"0x100" {:id         "0x100"
+                                           :position   1
+                                           :name       "chat1"
+                                           :muted?     nil
+                                           :categoryID "1"
+                                           :can-post?  false}
+                                  "0x200" {:id         "0x200"
+                                           :position   2
+                                           :name       "chat2"
+                                           :muted?     nil
+                                           :categoryID "1"
+                                           :can-post?  false}
+                                  "0x300" {:id         "0x300"
+                                           :position   3
+                                           :name       "chat3"
+                                           :muted?     nil
+                                           :categoryID "2"
+                                           :can-post?  true}
+                                  "0x400" {:id         "0x400"
+                                           :position   4
+                                           :name       "chat4"
+                                           :muted?     nil
+                                           :categoryID "2"
+                                           :can-post?  true}}
+                     :categories {"1" {:id       "1"
+                                       :position 2
+                                       :name     "category1"}
+                                  "2" {:id       "2"
+                                       :position 1
+                                       :name     "category2"}}
+                     :joined     true}})
     (is
      (= [["2"
           {:id         "2"
@@ -213,6 +213,14 @@
                          :muted?           nil
                          :locked?          false
                          :id               "0x300"
+                         :unread-messages? false
+                         :mentions-count   0}
+                        {:name             "chat4"
+                         :position         4
+                         :emoji            nil
+                         :muted?           nil
+                         :locked?          true
+                         :id               "0x400"
                          :unread-messages? false
                          :mentions-count   0}]}]
          ["1"
@@ -237,6 +245,7 @@
                          :unread-messages? false
                          :mentions-count   0}]}]]
         (rf/sub [sub-name "0x1"]))))
+
   (testing "Channels without categories"
     (swap! rf-db/app-db assoc
       :communities
@@ -298,12 +307,15 @@
                        :unread-messages? false
                        :mentions-count   0}]}]]
       (rf/sub [sub-name "0x1"]))))
+
   (testing "Unread messages"
     (swap! rf-db/app-db assoc
       :communities
       {"0x1" {:id         "0x1"
-              :chats      {"0x1" {:id "0x1" :position 1 :name "chat1" :categoryID "1" :can-post? true}
-                           "0x2" {:id "0x2" :position 2 :name "chat2" :categoryID "1" :can-post? false}}
+              :chats      {"0x1"
+                           {:id "0x1" :position 1 :name "chat1" :categoryID "1" :can-post? true}
+                           "0x2"
+                           {:id "0x2" :position 2 :name "chat2" :categoryID "1" :can-post? false}}
               :categories {"1" {:id "1" :name "category1"}}
               :joined     true}}
       :chats

--- a/src/status_im2/subs/root.cljs
+++ b/src/status_im2/subs/root.cljs
@@ -136,6 +136,7 @@
 (reg-root-key-sub :communities :communities)
 (reg-root-key-sub :communities/create :communities/create)
 (reg-root-key-sub :communities/create-channel :communities/create-channel)
+(reg-root-key-sub :communities/channels-permissions :community-channels-permissions)
 (reg-root-key-sub :communities/requests-to-join :communities/requests-to-join)
 (reg-root-key-sub :communities/community-id-input :communities/community-id-input)
 (reg-root-key-sub :communities/resolve-community-info :communities/resolve-community-info)


### PR DESCRIPTION
Fixes https://github.com/status-im/status-mobile/issues/17267

### Summary

- [x] Fix: when there are only channel token permissions, don't show the text "You hold 0 of these:" because there are no requirements to show.
- [x] Fix: do not show channel token permissions when the user wants to join a community. In other words: only "become admin", "become member", "become token master", and "become token owner" are taken in consideration.
- [x] Fix: render correct channel lock icon in 3 states (no permission, with permissions and locked and with permissions and unlocked).
- [x] Fix: Previously, before having joined a community, all channels had a lock icon closed, now the lock icon is only closed when there's a permission set, otherwise no icon is shown (the lock is never open before the user joins the community).
- [x] Fix: small UI spacing fix, only display community tags component when there's at least one tag.
- [x] Bonus fix: community Overview and Discover screens top bar had a regression, see the screenshots.

To keep things manageable given the sheer amount of bugs related to token gating, this PR only focuses on the bare minimum usage of the permissions' system. Minted owner tokens were completely ignored for this PR.

<table>
  <thead>
    <tr>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img src="https://github.com/status-im/status-mobile/assets/46027/f0455c9e-d73b-4ed1-8af3-a1f26bbbf985" width="390"/></td>
      <td><img src="https://github.com/status-im/status-mobile/assets/46027/1d0f2c69-b068-4eaf-89df-764aee04e834" width="390"/></td>
    </tr>
  </tbody>
</table>

<table>
  <thead>
    <tr>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img src="https://github.com/status-im/status-mobile/assets/46027/542f8dbf-276b-4567-b67e-5570adaa6b16" width="390"/></td>
      <td><img src="https://github.com/status-im/status-mobile/assets/46027/ae3c9c93-9345-4629-b157-c086ab3c0236" width="390"/></td>
    </tr>
  </tbody>
</table>

### What about the trailing zeros problem?

We know we want to better format the number `0.00100000`, but the problem is that this value arrives from status-go already as a string. I would like to fix this issue in a separate PR, with more care, given that the formatted output varies depending on the locale. Additionally, there are good practices to format large numbers to users and I couldn't figure out from Figma alone the full requirements.

### Other known bugs

While working on the fixes, many bugs popped up, some of which could be caused on the mobile side.

- It's currently unclear how the "View only" permission works because it doesn't force a read-only mode on its affected channels.
- Sometimes it is necessary to close and reopen the mobile app for the request to join screen to show the correct token requirements. Sometimes it works.
- Sometimes it is necessary to re-add a member to a token gated community, otherwise the old permissions are still used after using the community invite.
- There are visible mobile UI bugs in the token gated component because it's not implemented as in Figma. For example, the join community button should be part of the design system, not the screen, and by doing that, other fixes would follow naturally.
- Sometimes after having left a community, I would be added to it automatically again.

Auto-join token-gated community bug:

[auto-join-bug.webm](https://github.com/status-im/status-mobile/assets/46027/36e80684-a0ff-498e-82cd-8dfb1d119e6c)

At one point or another, I reach a state where I can see the community in my list of communities I joined even though I'm not listed in the desktop app as a member, and when I try to open any channel it says "You are not a member of this group". The only way to restore to the correct behavior is to leave the community on mobile and request to join again. I think this bug can be achieved while restoring from a seed phrase, but I don't have the exact reproduction steps yet.

<img src="https://github.com/status-im/status-mobile/assets/46027/98109abc-50e2-4bc7-b857-7c2119356b2b" width="350" />

#### Platforms

- Android
- iOS

#### Areas that may be impacted

- Community overview, before and after joining a community.

### Steps to test

This PR was developed and tested using the Goerli network and with the `testnet` flag enabled in the Desktop client.

Please, ignore for the scope of this PR minted owner tokens and master tokens. The focus was only on the most basic permissions for communities and channels.

I intend to define proper test cases in the near future, but for the time being, these are the cases I mostly tested:

- Non token-gated communities.
- Token-gated only with "Become member" permission.
- Token-gated only with channel permissions.
- Token-gated with a mix of "Become member", "Become admin", "View only" and "View and post".

For each case I checked:

- Are the channel lock icons correct?
- Can the user open locked channels? Can the user open unlocked ones?
- Can the user leave and join a community using the previous invite? What about a new one?
- Can admins and members exchange messages in the community channels with/without permissions?

status: ready
