### PR TITLE
Adapt to status-go API Changes for Request to Join Community Flow

### DIFF
--- a/src/status_im/communities/core.cljs
+++ b/src/status_im/communities/core.cljs
@@ -220,32 +220,6 @@
                                     (log/error "failed to import community" %)
                                     (re-frame/dispatch [::failed-to-import %]))}]})
 
-(rf/defn request-to-join
-  {:events [:communities/request-to-join]}
-  [_ community-id]
-  {:json-rpc/call [{:method      "wakuext_requestToJoinCommunity"
-                    :params      [{:communityId community-id}]
-                    :js-response true
-                    :on-success  #(re-frame/dispatch [:communities/requested-to-join %])
-                    :on-error    #(log/error "failed to request to join community" community-id)}]})
-
-(rf/defn requested-to-join-with-password-error
-  {:events [:communities/requested-to-join-with-password-error]}
-  [{:keys [db]} error]
-  {:db (assoc-in db [:password-authentication :error] error)})
-
-(rf/defn request-to-join-with-password
-  {:events [:communities/request-to-join-with-password]}
-  [_ community-id password]
-  {:json-rpc/call [{:method      "wakuext_requestToJoinCommunity"
-                    :params      [{:communityId community-id :password password}]
-                    :js-response true
-                    :on-success  #(re-frame/dispatch [:communities/requested-to-join %])
-                    :on-error    (fn [error]
-                                   (log/error "failed to request to join community" community-id error)
-                                   (re-frame/dispatch [:communities/requested-to-join-with-password-error
-                                                       error]))}]})
-
 (rf/defn get-user-requests-to-join
   {:events [:communities/get-user-requests-to-join]}
   [_]

--- a/src/status_im2/contexts/communities/actions/request_to_join/view.cljs
+++ b/src/status_im2/contexts/communities/actions/request_to_join/view.cljs
@@ -14,7 +14,8 @@
   (rf/dispatch [:password-authentication/show
                 {:content (fn [] [password-authentication/view])}
                 {:label    (i18n/label :t/join-open-community)
-                 :on-press #(rf/dispatch [:communities/request-to-join-with-password id %])}])
+                 :on-press #(rf/dispatch [:communities/request-to-join
+                                          {:community-id id :password %}])}])
   (rf/dispatch [:navigate-back]))
 
 (defn request-to-join

--- a/src/status_im2/contexts/communities/overview/events.cljs
+++ b/src/status_im2/contexts/communities/overview/events.cljs
@@ -21,3 +21,41 @@
                     :on-success #(rf/dispatch [:communities/check-permissions-to-join-community-success
                                                community-id %])
                     :on-error   #(log/error "failed to request to join community" community-id %)}]})
+
+;; Event to be called to request to join a community.
+;; This event will generate the data to be signed and then call the sign-data event.
+;; This is the only event that should be called from the UI.
+(rf/reg-event-fx :communities/request-to-join
+ (fn [{:keys [db]} [{:keys [community-id password]}]]
+   (let [pub-key             (get-in db [:profile/profile :public-key])
+         addresses-to-reveal []]
+     {:fx [[:json-rpc/call
+            [{:method     "wakuext_generateJoiningCommunityRequestsForSigning"
+              :params     [pub-key community-id addresses-to-reveal]
+              :on-success [:communities/sign-data community-id password]
+              :on-error   [:communities/requested-to-join-error community-id]}]]]})))
+
+(rf/reg-event-fx :communities/sign-data
+ (fn [_ [community-id password sign-params]]
+   {:fx [[:json-rpc/call
+          [{:method     "wakuext_signData"
+            :params     [(map #(assoc % :password password) sign-params)]
+            :on-success [:communities/request-to-join-with-signatures community-id]
+            :on-error   [:communities/requested-to-join-error community-id]}]]]}))
+
+(rf/reg-event-fx :communities/requested-to-join-error
+ (fn [{:keys [db]} [community-id error]]
+   (log/error "failed to request to join community"
+              {:community-id community-id
+               :error        error
+               :event        :communities/requested-to-join-error})
+   {:db (assoc-in db [:password-authentication :error] error)}))
+
+(rf/reg-event-fx :communities/request-to-join-with-signatures
+ (fn [_ [community-id signatures]]
+   {:fx [[:json-rpc/call
+          [{:method      "wakuext_requestToJoinCommunity"
+            :params      [{:communityId community-id :signatures signatures}]
+            :js-response true
+            :on-success  [:communities/requested-to-join]
+            :on-error    [:communities/requested-to-join-error community-id]}]]]}))

--- a/src/status_im2/contexts/communities/overview/view.cljs
+++ b/src/status_im2/contexts/communities/overview/view.cljs
@@ -113,7 +113,8 @@
   (rf/dispatch [:password-authentication/show
                 {:content (fn [] [password-authentication/view])}
                 {:label    (i18n/label :t/join-open-community)
-                 :on-press #(rf/dispatch [:communities/request-to-join-with-password id %])}]))
+                 :on-press #(rf/dispatch [:communities/request-to-join
+                                          {:community-id id :password %}])}]))
 
 (defn info-button
   []

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.171.8",
-    "commit-sha1": "678fc03b376e02df7142e89f2c626e3ba1c03807",
-    "src-sha256": "0bapjbyyyrvg2k3jimpfshcwc77lylamhlm9si3mbnrbm1dl89xc"
+    "version": "v0.171.9",
+    "commit-sha1": "af0c8c33b2d00930ef19448ed146c542b1346cce",
+    "src-sha256": "0gc4gymby0ghg59wzv6537qg9a9hgz1kkfmdrpif3lrq32d98lmk"
 }


### PR DESCRIPTION
In this pull request, we have updated the status-mobile code to seamlessly accommodate the newly introduced request to join the community flow. This modification is in response to the changes proposed in [PR #4178](https://github.com/status-im/status-go/pull/4178) in the status-go repository.

This PR primarily focuses on behind-the-scenes adjustments, and as such, it does not bring about any visible UI or functional alterations. The request to join the community flow will continue to function as expected, preserving the existing user experience.

cc: @ilmotta, @saledjenic

status: ready <!-- Can be ready or wip -->
