### PR TITLE
Add "Goerli network" English translation

### DIFF
--- a/translations/en.json
+++ b/translations/en.json
@@ -646,6 +646,7 @@
     "get-stickers": "Get Stickers",
     "gif": "GIF",
     "go-to-settings": "Go to Settings...",
+    "goerli-network": "Goerli network",
     "got-it": "Got it",
     "group-chat": "Group chat",
     "group-chat-admin": "Admin",


### PR DESCRIPTION
### Summary

There is usage of the `:t/goerli-network` translation keyword in the codebase [here](https://github.com/status-im/status-mobile/blob/609eb04cff6e5edead4fc2f31c104f7d5d193840/src/status_im/ui/screens/network/edit_network/views.cljs#L16-L18), but there is no such key in `translations/en.json`.

Since `src/status_im/ui/screens/network/edit_network/views.cljs` is (still) part of the codebase, there should be translation keys for all used translation keywords.

This was discovered during the work on #17735
