### PR TITLE
proper use of "ens-username-owned-continue" translation key

### DIFF
--- a/src/status_im/ui/screens/ens/views.cljs
+++ b/src/status_im/ui/screens/ens/views.cljs
@@ -147,7 +147,7 @@
     :owned
     [help-message-text-element
      :t/ens-username-owned
-     :t/ens-username-continue]
+     :t/ens-username-owned-continue]
     :connected
     [help-message-text-element
      :t/ens-username-connected


### PR DESCRIPTION
### Summary

`src/status_im/ui/screens/ens/views.cljs` [uses](https://github.com/status-im/status-mobile/blob/609eb04cff6e5edead4fc2f31c104f7d5d193840/src/status_im/ui/screens/ens/views.cljs#L148-L150) the translation key `"ens-username-continue"` which does not exist in `translations/en.json` (or any other translation file).
Most likely, this was supposed to be the key `"ens-username-owned-continue"` (with the English tranlsation of "Continuing will connect this username with your chat key.") which is present in many translation files.

This was discovered during work on #17735.