### PR TITLE
[#17572] fix: 'Join Community' notification is not getting dismissed

### DIFF
--- a/src/status_im2/contexts/communities/overview/view.cljs
+++ b/src/status_im2/contexts/communities/overview/view.cljs
@@ -366,9 +366,11 @@
 
 (defn community-card-page-view
   [id]
-  (let [{:keys [id]
+  (let [{:keys [id joined]
          :as   community} (rf/sub [:communities/community id])
         pending?          (rf/sub [:communities/my-pending-request-to-join id])]
+    (when joined
+      (rf/dispatch [:activity-center.notifications/dismiss-community-overview id]))
     [community-scroll-page community pending?]))
 
 (defn overview

--- a/src/status_im2/contexts/shell/activity_center/events.cljs
+++ b/src/status_im2/contexts/shell/activity_center/events.cljs
@@ -202,6 +202,12 @@
      :utils/dispatch-later [{:dispatch [:activity-center.notifications/mark-all-as-read]
                              :ms       undo-time-limit-ms}]}))
 
+(re-frame/reg-event-fx :activity-center.notifications/dismiss-community-overview
+ (fn [_ [community-id]]
+   {:json-rpc/call [{:method     "wakuext_dismissActivityCenterNotificationsByCommunity"
+                     :params     [{:communityId community-id}]
+                     :on-success [:activity-center.notifications/fetch-unread-count]}]}))
+
 (rf/defn accept-notification
   {:events [:activity-center.notifications/accept]}
   [{:keys [db]} notification-id]

--- a/src/status_im2/contexts/shell/activity_center/notification/community_kicked/view.cljs
+++ b/src/status_im2/contexts/shell/activity_center/notification/community_kicked/view.cljs
@@ -1,6 +1,7 @@
 (ns status-im2.contexts.shell.activity-center.notification.community-kicked.view
   (:require
     [quo.core :as quo]
+    [react-native.gesture :as gesture]
     [status-im2.contexts.shell.activity-center.notification.common.style :as common-style]
     [status-im2.contexts.shell.activity-center.notification.common.view :as common]
     [utils.datetime :as datetime]
@@ -26,18 +27,22 @@
         community-name      (:name community)
         community-image     (get-in community [:images :thumbnail :uri])]
     [swipeable props
-     [quo/activity-log
-      {:title               (i18n/label :t/community-kicked-heading)
-       :customization-color customization-color
-       :icon                :i/placeholder
-       :on-layout           set-swipeable-height
-       :timestamp           (datetime/timestamp->relative timestamp)
-       :unread?             (not read)
-       :context             [[quo/text {:style common-style/user-avatar-tag-text}
-                              (i18n/label :t/community-kicked-body)]
-                             [quo/context-tag
-                              {:type           :community
-                               :size           24
-                               :blur?          true
-                               :community-logo community-image
-                               :community-name community-name}]]}]]))
+     [gesture/touchable-without-feedback
+      {:on-press (fn []
+                   (rf/dispatch [:navigate-back])
+                   (rf/dispatch [:activity-center.notifications/mark-as-read (:id notification)]))}
+      [quo/activity-log
+       {:title               (i18n/label :t/community-kicked-heading)
+        :customization-color customization-color
+        :icon                :i/placeholder
+        :on-layout           set-swipeable-height
+        :timestamp           (datetime/timestamp->relative timestamp)
+        :unread?             (not read)
+        :context             [[quo/text {:style common-style/user-avatar-tag-text}
+                               (i18n/label :t/community-kicked-body)]
+                              [quo/context-tag
+                               {:type           :community
+                                :size           24
+                                :blur?          true
+                                :community-logo community-image
+                                :community-name community-name}]]}]]]))

--- a/src/status_im2/contexts/shell/activity_center/notification/community_request/view.cljs
+++ b/src/status_im2/contexts/shell/activity_center/notification/community_request/view.cljs
@@ -1,6 +1,7 @@
 (ns status-im2.contexts.shell.activity-center.notification.community-request.view
   (:require
     [quo.core :as quo]
+    [react-native.gesture :as gesture]
     [status-im2.constants :as constants]
     [status-im2.contexts.shell.activity-center.notification.common.style :as common-style]
     [status-im2.contexts.shell.activity-center.notification.common.view :as common]
@@ -67,11 +68,15 @@
         {:keys [header-text context]} (get-header-text-and-context community
                                                                    membership-status)]
     [swipeable props
-     [quo/activity-log
-      {:title               header-text
-       :customization-color customization-color
-       :icon                :i/communities
-       :on-layout           set-swipeable-height
-       :timestamp           (datetime/timestamp->relative timestamp)
-       :unread?             (not read)
-       :context             context}]]))
+     [gesture/touchable-without-feedback
+      {:on-press (fn []
+                   (rf/dispatch [:navigate-back])
+                   (rf/dispatch [:navigate-to :community-overview community-id]))}
+      [quo/activity-log
+       {:title               header-text
+        :customization-color customization-color
+        :icon                :i/communities
+        :on-layout           set-swipeable-height
+        :timestamp           (datetime/timestamp->relative timestamp)
+        :unread?             (not read)
+        :context             context}]]]))

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.171.26",
-    "commit-sha1": "d92284edcee9f2af5d7f34644796fa5492892720",
-    "src-sha256": "0gjnw0jcwj37a5hmvhc56dm29dcyargmjb0bz9bdbdhdrsjfw9yp"
+    "version": "v0.171.27",
+    "commit-sha1": "76b6745666b945f8d6336e2a5fc6e5705985273d",
+    "src-sha256": "1amak99bpsx6j8grzm2kzwd3si34gg4r8kbxqmnkfsrkm2nzvbx1"
 }


### PR DESCRIPTION
fixes #17572

### Summary

After joining a community, the 'Join Community' notification remains persistent in the notification center, even after accessing the community. Additionally, tapping on the notification has no effect.


### Steps to test

1. Join a new community.
2. Open the notification center.
3. Tap on the 'Join Community' notification.
4. Open the community.

### Before and after screenshots comparison

- When  user navigate to community

https://github.com/status-im/status-mobile/assets/71308738/2e3f2639-e9ee-43cf-ac58-8eef9510f66b


- When  user click on joined community notification

https://github.com/status-im/status-mobile/assets/71308738/76d71073-431e-441a-b5e5-074ea80726fd

- When  user click on kicked from community notification
https://github.com/status-im/status-mobile/assets/71308738/cd2932fa-521c-457a-9af9-e811db362741



status: ready
