### PR TITLE
keep chat screen loaded

### DIFF
--- a/src/status_im/contexts/chat/messages/view.cljs
+++ b/src/status_im/contexts/chat/messages/view.cljs
@@ -13,8 +13,7 @@
 
 ;; NOTE(parvesh) - I am working on refactoring/optimization of the chat screen for performance
 ;; improvement. Please avoid refactoring these files. Also if you are not already working on bug
-;; fixes related to the chat navigation bar, please skip them.
-;; And ping me, so I can address them while refactoring
+;; fixes related to the composer, please skip them. And ping me, so I can address them while refactoring
 (defn- f-chat-screen
   [calculations-complete?]
   (let [insets                            (safe-area/get-insets)
@@ -47,6 +46,8 @@
 (defn lazy-chat-screen
   [calculations-complete?]
   (let [screen-loaded? (rf/sub [:shell/chat-screen-loaded?])]
+    (when-not screen-loaded?
+      (reanimated/set-shared-value calculations-complete? false))
     (when screen-loaded?
       [:f> f-chat-screen calculations-complete?])))
 

--- a/src/status_im/contexts/shell/jump_to/animation.cljs
+++ b/src/status_im/contexts/shell/jump_to/animation.cljs
@@ -1,6 +1,5 @@
 (ns status-im.contexts.shell.jump-to.animation
   (:require
-    [react-native.platform :as platform]
     [react-native.reanimated :as reanimated]
     [status-im.contexts.shell.jump-to.constants :as shell.constants]
     [status-im.contexts.shell.jump-to.state :as state]
@@ -47,11 +46,6 @@
 
 ;;;; Floating Screen
 
-;; Dispatch Delay - Animation time for the opening of a screen is 200 ms,
-;; But starting and completion of animation sometimes takes a little extra time,
-;; according to the performance of the device. And if before the animation is
-;; complete we start other tasks like rendering messages or opening of the home screen
-;; in the background then the animation breaks. So we are adding a small delay for that dispatch.
 (defn animate-floating-screen
   [screen-id {:keys [id animation community-id hidden-screen?]}]
   (when (not= animation (get @state/floating-screens-state screen-id))
@@ -66,13 +60,7 @@
                                        shell.constants/close-screen-without-animation}
                                      animation)
                                   0
-                                  shell.constants/shell-animation-time)
-          dispatch-delay        (cond
-                                  (not floating-screen-open?) 0
-                                  js/goog.DEBUG               100
-                                  platform/android?           75
-                                  :else                       50)
-          dispatch-time         (+ animation-time dispatch-delay)]
+                                  shell.constants/shell-animation-time)]
       (js/setTimeout
        (fn [floating-screen-open?]
          (if floating-screen-open?
@@ -81,7 +69,7 @@
                          id community-id hidden-screen?])
            ;; Events realted to closing of a screen
            (rf/dispatch [:shell/floating-screen-closed screen-id])))
-       dispatch-time
+       animation-time
        floating-screen-open?))))
 
 (defn set-floating-screen-position

--- a/src/status_im/contexts/shell/jump_to/components/floating_screens/view.cljs
+++ b/src/status_im/contexts/shell/jump_to/components/floating_screens/view.cljs
@@ -33,12 +33,9 @@
      [rn/view
       {:style               (style/screen-container (utils/dimensions))
        :accessibility-label (str screen-id "-floating-screen")
-       :accessible          true
-       :key                 id}
+       :accessible          true}
       [(get screens-map screen-id) id]]]))
 
-;; Currently chat screen and events both depends on current-chat-id, once we remove
-;; use of current-chat-id from view then we can keep last chat loaded, for fast navigation
 (defn lazy-screen
   [screen-id]
   (let [screen-param (rf/sub [:shell/floating-screen screen-id])]

--- a/src/status_im/contexts/shell/jump_to/events.cljs
+++ b/src/status_im/contexts/shell/jump_to/events.cljs
@@ -201,9 +201,9 @@
 (rf/defn floating-screen-closed
   {:events [:shell/floating-screen-closed]}
   [{:keys [db]} screen-id]
-  (merge
-   {:db         (-> (update db :shell/floating-screens dissoc screen-id)
-                    (update :shell/loaded-screens dissoc screen-id))
-    :dispatch-n (cond-> [[:set-view-id :shell-stack]]
-                  (= screen-id shell.constants/chat-screen)
-                  (conj [:chat/close]))}))
+  {:db         (cond-> (update db :shell/loaded-screens dissoc screen-id)
+                 (= screen-id shell.constants/discover-communities-screen)
+                 (update :shell/floating-screen dissoc screen-id))
+   :dispatch-n (cond-> [[:set-view-id :shell-stack]]
+                 (= screen-id shell.constants/chat-screen)
+                 (conj [:chat/close]))})


### PR DESCRIPTION
related to https://github.com/status-im/status-mobile/issues/16714

### Summary
In this PR we are making sure we open the chat screen the first time on-demand and then keep it ready for reopen.

We probably will not see much performance difference right now, as I removed the composer and top bar in https://github.com/status-im/status-mobile/pull/18055 from the loading screen. But once we re-add the new implementation of placeholders this change will make sure the chat still opens quickly even when those components are added.

### Testing
Please smoke test navigation to chat and community screen (From shell, home etc)

status: ready