### PR TITLE
[Fix] Remove `quo` style usage in emoji picker

### DIFF
--- a/src/quo/components/profile/showcase_nav/style.cljs
+++ b/src/quo/components/profile/showcase_nav/style.cljs
@@ -2,11 +2,6 @@
   (:require
     [quo.foundations.colors :as colors]))
 
-(def height 56)
-
-(def root-container
-  {:height height})
-
 (defn container
   [state theme]
   {:padding-top      12

--- a/src/quo/components/profile/showcase_nav/view.cljs
+++ b/src/quo/components/profile/showcase_nav/view.cljs
@@ -25,7 +25,7 @@
 (defn- view-internal
   [{:keys [theme container-style default-active state data on-press active-id]}]
   [rn/view
-   {:style               (merge style/root-container container-style)
+   {:style               container-style
     :accessibility-label :showcase-nav}
    [rn/flat-list
     {:data                              data

--- a/src/status_im2/contexts/emoji_picker/constants.cljs
+++ b/src/status_im2/contexts/emoji_picker/constants.cljs
@@ -16,6 +16,8 @@
 
 (def ^:const emoji-row-separator-height 16)
 
+(def ^:const categories-selector-height 56)
+
 (def ^:const emoji-item-margin-right
   (/ (- (:width (rn/get-window))
         (* emoji-row-padding-horizontal 2)

--- a/src/status_im2/contexts/emoji_picker/style.cljs
+++ b/src/status_im2/contexts/emoji_picker/style.cljs
@@ -1,13 +1,12 @@
 (ns status-im2.contexts.emoji-picker.style
   (:require
-    [quo.components.profile.showcase-nav.style :as showcase-nav.style]
     [quo.foundations.colors :as colors]
     [react-native.safe-area :as safe-area]
     [status-im2.contexts.emoji-picker.constants :as constants]))
 
 (def flex-spacer {:flex 1})
 
-(def category-nav-height (+ (safe-area/get-bottom) showcase-nav.style/height))
+(def category-nav-height (+ (safe-area/get-bottom) constants/categories-selector-height))
 
 (def search-input-container
   {:padding-horizontal 20
@@ -35,7 +34,7 @@
     (dissoc :margin-right)))
 
 (def list-container
-  {:padding-bottom showcase-nav.style/height})
+  {:padding-bottom constants/categories-selector-height})
 
 (def empty-results
   {:margin-top 100})


### PR DESCRIPTION
fixes #17838

### Summary

This PR moves the emoji categories selector height from the `showcase-nav` component to the emoji picker as we should not use any `quo` ns (except `quo.core`) inside the `status-im2` ns.

### Review notes

The `showcase-nav` component doesn't have any fixed height. It was added during the emoji picker development to facilitate easy updates of height from the component. It is then removed and moved to the emoji picker in this PR.

### Platforms

- Android
- iOS

status: ready 
