### PR TITLE
fix: nav conflicts when return from bg from link

### DIFF
--- a/src/react_native/async_storage.cljs
+++ b/src/react_native/async_storage.cljs
@@ -18,12 +18,14 @@
          (log/error e))))
 
 (defn set-item!
-  [k value]
-  (-> ^js async-storage
-      (.setItem (str k)
-                (clj->transit value))
-      (.catch (fn [error]
-                (log/error "[async-storage]" error)))))
+  ([k value] (set-item! k value identity))
+  ([k value cb]
+   (-> ^js async-storage
+       (.setItem (str k)
+                 (clj->transit value))
+       (.then (fn [_] (cb)))
+       (.catch (fn [error]
+                 (log/error "[async-storage]" error))))))
 
 (defn set-item-factory
   []

--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -158,7 +158,9 @@
 
 (rf/defn on-going-in-background
   [{:keys [db now]}]
-  {:db (assoc db :app-in-background-since now)})
+  {:db (-> db
+           (assoc :app-in-background-since now)
+           (dissoc :universal-links/handling))})
    ;; event not implemented
    ;; :dispatch-n [[:audio-recorder/on-background] [:audio-message/on-background]]
 

--- a/src/status_im2/contexts/profile/login/events.cljs
+++ b/src/status_im2/contexts/profile/login/events.cljs
@@ -113,8 +113,9 @@
                         (fn [accounts tokens custom-tokens favourites]
                           (re-frame/dispatch [:wallet-legacy/initialize-wallet
                                               accounts tokens custom-tokens favourites]))]
-                       :check-eip1559-activation {:network-id network-id}
-                       :chat/open-last-chat (get-in db [:profile/profile :key-uid])}
+                       :check-eip1559-activation {:network-id network-id}}
+                (not (:universal-links/handling db))
+                (assoc :chat/open-last-chat (get-in db [:profile/profile :key-uid]))
                 notifications-enabled?
                 (assoc :effects/push-notifications-enable nil))
               (transport/start-messenger)

--- a/src/status_im2/contexts/push_notifications/events.cljs
+++ b/src/status_im2/contexts/push_notifications/events.cljs
@@ -20,8 +20,9 @@
 (defn handle-notification-press
   [{{deep-link :deepLink} :userInfo
     interaction           :userInteraction}]
-  (async-storage/set-item! (str :chat-id) nil)
+  (async-storage/set-item! (str :chat-id) nil #(rf/dispatch [:universal-links/remove-handling]))
   (when (and deep-link (or platform/ios? (and platform/android? interaction)))
+    (rf/dispatch [:universal-links/handling])
     (rf/dispatch [:universal-links/handle-url deep-link])))
 
 (defn listen-notifications


### PR DESCRIPTION
fixes #17790

### Summary

the issue is caused by conflicts between `:chat/open-last-chat` and chat triggered by universal/deep link (notification)
PR add `:universal-links/handling` mark to db when app is triggered by universal/deep link
and skip `:chat/open-last-chat` when the mark exists

### Testing notes
affects trigger app open with deep/universal link while there's already existing chat view



### Steps to test
<!-- (Specify exact steps to test if there are such) -->

same steps in #17790

<!-- (PRs will only be accepted if squashed into single commit.) -->


status: ready