### PR TITLE
Respect status-go API changes for collectibles request 

### DIFF
--- a/src/status_im2/contexts/wallet/events.cljs
+++ b/src/status_im2/contexts/wallet/events.cljs
@@ -201,12 +201,13 @@
 
 (rf/reg-event-fx :wallet/request-collectibles
  (fn [{:keys [db]} [{:keys [start-at-index new-request?]}]]
-   (let [request-params [0
-                         [(chain/chain-id db)]
-                         (map :address (:profile/wallet-accounts db))
-                         nil
-                         start-at-index
-                         collectibles-request-batch-size]]
+   (let [collectibles-filter nil
+         request-params      [0
+                              [(chain/chain-id db)]
+                              (map :address (:profile/wallet-accounts db))
+                              collectibles-filter
+                              start-at-index
+                              collectibles-request-batch-size]]
      {:json-rpc/call [{:method     "wallet_filterOwnedCollectiblesAsync"
                        :params     request-params
                        :on-success #()

--- a/src/status_im2/contexts/wallet/events.cljs
+++ b/src/status_im2/contexts/wallet/events.cljs
@@ -204,6 +204,7 @@
    (let [request-params [0
                          [(chain/chain-id db)]
                          (map :address (:profile/wallet-accounts db))
+                         nil
                          start-at-index
                          collectibles-request-batch-size]]
      {:json-rpc/call [{:method     "wallet_filterOwnedCollectiblesAsync"

--- a/src/status_im2/contexts/wallet/events.cljs
+++ b/src/status_im2/contexts/wallet/events.cljs
@@ -201,8 +201,9 @@
 
 (rf/reg-event-fx :wallet/request-collectibles
  (fn [{:keys [db]} [{:keys [start-at-index new-request?]}]]
-   (let [collectibles-filter nil
-         request-params      [0
+   (let [request-id          0
+         collectibles-filter nil
+         request-params      [request-id
                               [(chain/chain-id db)]
                               (map :address (:profile/wallet-accounts db))
                               collectibles-filter


### PR DESCRIPTION
### Summary

status-go changed API for retrieving collectibles. One more parameter added - filter. Currently, it is not needed in mobile, so I've added `nil` as a quickfix.