### PR TITLE
Added docs on building mobile with custom status-go version

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -10,9 +10,9 @@
 
 [Coding guidelines](new-guidelines.md)
 
-[Release Checklist](release-checklist.md)
+[Debugging](debugging.md)
 
-[Release Guide](release-guide.md)
+[Using custom `status-go` version](custom-status-go.md)
 
 [Merging PR process](merging-pr-process.md)
 
@@ -20,7 +20,10 @@
 
 [Working on PR together with QA team](pipeline_process.md)
 
-[Debugging](debugging.md)
+[Release Checklist](release-checklist.md)
+
+[Release Guide](release-guide.md)
+
 
 [Patching](patching.md)
 

--- a/doc/custom-status-go.md
+++ b/doc/custom-status-go.md
@@ -1,0 +1,27 @@
+# Using custom `status-go` version
+
+## Building mobile with custom `status-go` branch
+If you need to use a branch of a `status-go` as a dependency of `status-mobile`, you specify it using an update script in `status-mobile` repo:
+```bash
+scripts/update-status-go.sh <rev>
+```
+
+Where `rev` is a branch name, tag, or commit SHA1 you want to build. The script will save the indicated commit hash along with other information in the `status-go-version.json` file.
+
+If you are using a GitHub fork of `status-go` repo, export the `STATUS_GO_OWNER` environment variable when running the script.
+
+## Building mobile with `status-go` from local repository
+If instead you need to use a locally checked-out `status-go` repository as a dependency of `status-mobile`, you can achieve that by defining the `STATUS_GO_SRC_OVERRIDE`
+environment variable:
+
+```bash
+export STATUS_GO_SRC_OVERRIDE=$GOPATH/src/github.com/status-im/status-go
+# Any command that you run from now on will use the specified status-go location.
+make run-ios
+```
+
+or for a one-off build:
+
+```bash
+make run-ios STATUS_GO_SRC_OVERRIDE=$GOPATH/src/github.com/status-im/status-go
+```


### PR DESCRIPTION
### Summary

Added info about building mobile with custom `status-go` from [old doc](https://status.im/de/technical/build_status/) to our documentation.