### PR TITLE
Add 'Test Networks Enabled' option in settings

### DIFF
--- a/src/status_im/ui/screens/advanced_settings/views.cljs
+++ b/src/status_im/ui/screens/advanced_settings/views.cljs
@@ -19,7 +19,8 @@
            transactions-management-enabled?
            wakuv2-flag
            current-fleet
-           webview-debug]}]
+           webview-debug
+           test-networks-enabled?]}]
   (keep
    identity
    [{:size :small
@@ -101,6 +102,14 @@
      :accessory :switch
      :active webview-debug}
     {:size :small
+     :title "Testnet mode"
+     :accessibility-label :test-networks-enabled
+     :container-margin-bottom 8
+     :on-press
+     #(re-frame/dispatch [:profile.settings/toggle-test-networks])
+     :accessory :switch
+     :active test-networks-enabled?}
+    {:size :small
      :title (i18n/label :t/waku-bloom-filter-mode)
      :accessibility-label :waku-bloom-filter-mode-settings-switch
      :container-margin-bottom 8
@@ -128,7 +137,8 @@
 
 (views/defview advanced-settings
   []
-  (views/letsubs [{:keys [webview-debug]}          [:profile/profile]
+  (views/letsubs [{:keys [webview-debug
+                          test-networks-enabled?]} [:profile/profile]
                   network-name                     [:network-name]
                   waku-bloom-filter-mode           [:waku/bloom-filter-mode]
                   wakuv2-flag                      [:waku/v2-flag]
@@ -144,6 +154,7 @@
                    :dev-mode?                        false
                    :wakuv2-flag                      wakuv2-flag
                    :waku-bloom-filter-mode           waku-bloom-filter-mode
-                   :webview-debug                    webview-debug})
+                   :webview-debug                    webview-debug
+                   :test-networks-enabled?           test-networks-enabled?})
       :key-fn    (fn [_ i] (str i))
       :render-fn render-item}]))

--- a/src/status_im2/contexts/communities/discover/view.cljs
+++ b/src/status_im2/contexts/communities/discover/view.cljs
@@ -242,6 +242,7 @@
 
 (defn- internal-discover-view
   [params]
+  (rf/dispatch [:fetch-contract-communities])
   [:f> f-view-internal params])
 
 (def view (quo.theme/with-theme internal-discover-view))

--- a/src/status_im2/contexts/profile/settings/events.cljs
+++ b/src/status_im2/contexts/profile/settings/events.cljs
@@ -4,6 +4,7 @@
             [status-im2.constants :as constants]
             status-im2.contexts.profile.settings.effects
             [taoensso.timbre :as log]
+            [utils.i18n :as i18n]
             [utils.re-frame :as rf]))
 
 (rf/defn send-contact-update
@@ -14,6 +15,7 @@
                       :on-success #(log/debug "sent contact update")}]}))
 
 (rf/defn profile-update
+  {:events [:profile.settings/profile-update]}
   [{:keys [db] :as cofx}
    setting setting-value
    {:keys [dont-sync? on-success] :or {on-success #()}}]
@@ -55,6 +57,18 @@
   (rf/merge cofx
             {:profile.settings/webview-debug-changed value}
             (profile-update :webview-debug (boolean value) {})))
+
+(rf/reg-event-fx :profile.settings/toggle-test-networks
+ (fn [{:keys [db]}]
+   (let [value      (get-in db [:profile/profile :test-networks-enabled?])
+         on-success #(rf/dispatch [:logout])]
+     {:fx [[:ui/show-confirmation
+            {:title     (i18n/label :t/testnet-mode-prompt-title)
+             :content   (i18n/label :t/testnet-mode-prompt-content)
+             :on-accept #(rf/dispatch [:profile.settings/profile-update :test-networks-enabled?
+                                       (not value)
+                                       {:on-success on-success}])
+             :on-cancel nil}]]})))
 
 (rf/defn change-preview-privacy-flag
   {:events [:profile.settings/change-preview-privacy]}

--- a/translations/en.json
+++ b/translations/en.json
@@ -1407,6 +1407,8 @@
     "try-keeping-the-card-still": "Try keeping the card still",
     "turn-nfc-on": "Turn NFC on to continue",
     "turn-nfc-description": "NFC is disabled on yor device. You can enable it in settings",
+    "testnet-mode-prompt-title": "Warning!",
+    "testnet-mode-prompt-content": "You are about to switch the network mode. This will log you out and you will have to login again.",
     "keycard-init-title": "Looking for cards...",
     "keycard-init-description": "Put the card to the back of your phone to continue",
     "keycard-awaiting-title": "Still looking...",


### PR DESCRIPTION
fixes: https://github.com/status-im/status-mobile/issues/17826

Add **Test Networks Enabled** toggle in Advanced Settings

### Test Notes

1. Go to Advanced settings
2. Toggle **Test Networks Enabled** option
3. The user will be logged out from the account automatically
4. Log back in & see if the **Test Networks Enabled** option persists in the previous state.

Note: This option is required to test curated communities in `status.test` fleet. This PR doesn't fix the issue logged here: https://github.com/status-im/status-mobile/issues/17852, additional changes are required to fully fix that.

