### PR TITLE
[#17823] Refactor tokens data app-db

### DIFF
--- a/src/status_im2/contexts/profile/login/events.cljs
+++ b/src/status_im2/contexts/profile/login/events.cljs
@@ -73,12 +73,12 @@
         (data-store.settings/rpc->settings settings)
         profile-overview (profile.rpc/rpc->profiles-overview account)]
     (rf/merge cofx
-              {:db (assoc db
-                          :chats/loading?           true
-                          :networks/current-network current-network
-                          :wallet/tokens-loading?   true
-                          :networks/networks        (merge networks config/default-networks-by-id)
-                          :profile/profile          (merge profile-overview settings))}
+              {:db (-> db
+                       (assoc :chats/loading?           true
+                              :networks/current-network current-network
+                              :networks/networks        (merge networks config/default-networks-by-id)
+                              :profile/profile          (merge profile-overview settings))
+                       (assoc-in [:wallet :ui :tokens-loading?] true))}
               (notifications/load-preferences)
               (data-store.chats/fetch-chats-preview
                {:on-success

--- a/src/status_im2/contexts/wallet/common/utils.cljs
+++ b/src/status_im2/contexts/wallet/common/utils.cljs
@@ -1,21 +1,11 @@
 (ns status-im2.contexts.wallet.common.utils
   (:require [clojure.string :as string]
-            [status-im2.constants :as constants]))
+            [status-im2.constants :as constants]
+            [utils.number]))
 
 (defn get-first-name
   [full-name]
   (first (string/split full-name #" ")))
-
-(defn get-balance-by-address
-  [balances address]
-  (->> balances
-       (filter #(= (:address %) address))
-       first
-       :balance))
-
-(defn get-account-by-address
-  [accounts address]
-  (some #(when (= (:address %) address) %) accounts))
 
 (defn prettify-balance
   [balance]
@@ -32,3 +22,24 @@
   [number-of-accounts]
   (let [path (get-derivation-path number-of-accounts)]
     (format-derivation-path path)))
+
+(defn- calculate-raw-balance
+  [raw-balance decimals]
+  (if-let [n (utils.number/parse-int raw-balance nil)]
+    (/ n (Math/pow 10 (utils.number/parse-int decimals)))
+    0))
+
+(defn- total-token-value-in-all-chains
+  [{:keys [balances-per-chain decimals]}]
+  (->> balances-per-chain
+       (vals)
+       (map #(calculate-raw-balance (:raw-balance %) decimals))
+       (reduce +)))
+
+(defn calculate-balance
+  [tokens-in-account]
+  (->> tokens-in-account
+       (map (fn [token]
+              (* (total-token-value-in-all-chains token)
+                 (-> token :market-values-per-currency :usd :price))))
+       (reduce +)))

--- a/src/status_im2/contexts/wallet/edit_account/view.cljs
+++ b/src/status_im2/contexts/wallet/edit_account/view.cljs
@@ -4,29 +4,33 @@
             [quo.theme :as quo.theme]
             [react-native.core :as rn]
             [reagent.core :as reagent]
-            [status-im2.contexts.wallet.common.screen-base.create-or-edit-account.view :as
-             create-or-edit-account]
-            [status-im2.contexts.wallet.common.sheets.network-preferences.view :as network-preferences]
+            [status-im2.contexts.wallet.common.screen-base.create-or-edit-account.view
+             :as create-or-edit-account]
+            [status-im2.contexts.wallet.common.sheets.network-preferences.view
+             :as network-preferences]
             [status-im2.contexts.wallet.edit-account.style :as style]
             [utils.i18n :as i18n]
             [utils.re-frame :as rf]))
 
+(defn- show-save-account-toast
+  [updated-key theme]
+  (let [message (case updated-key
+                  :name  :t/edit-wallet-account-name-updated-message
+                  :color :t/edit-wallet-account-colour-updated-message
+                  :emoji :t/edit-wallet-account-emoji-updated-message
+                  nil)]
+    (rf/dispatch [:toasts/upsert
+                  {:id         :edit-account
+                   :icon       :i/correct
+                   :icon-color (colors/resolve-color :success theme)
+                   :text       (i18n/label message)}])))
+
 (defn- save-account
-  [{:keys [theme type value account]}]
-  (let [edited-account-data (assoc account type value)
-        message             (case type
-                              :name  :t/edit-wallet-account-name-updated-message
-                              :color :t/edit-wallet-account-colour-updated-message
-                              :emoji :t/edit-wallet-account-emoji-updated-message
-                              nil)
-        callback            #(rf/dispatch [:toasts/upsert
-                                           {:id         :edit-account
-                                            :icon       :i/correct
-                                            :icon-color (colors/resolve-color :success theme)
-                                            :text       (i18n/label message)}])]
+  [{:keys [account updated-key new-value theme]}]
+  (let [edited-account-data (assoc account updated-key new-value)]
     (rf/dispatch [:wallet/save-account
-                  {:account  edited-account-data
-                   :callback callback}])))
+                  {:account    edited-account-data
+                   :on-success #(show-save-account-toast updated-key theme)}])))
 
 (defn- view-internal
   [{:keys [theme]}]
@@ -34,22 +38,22 @@
         show-confirm-button? (reagent/atom false)
         on-change-color      (fn [edited-color {:keys [color] :as account}]
                                (when (not= edited-color color)
-                                 (save-account {:account account
-                                                :type    :color
-                                                :value   edited-color
-                                                :theme   theme})))
+                                 (save-account {:account     account
+                                                :updated-key :color
+                                                :new-value   edited-color
+                                                :theme       theme})))
         on-change-emoji      (fn [edited-emoji {:keys [emoji] :as account}]
                                (when (not= edited-emoji emoji)
-                                 (save-account {:account account
-                                                :type    :emoji
-                                                :value   edited-emoji
-                                                :theme   theme})))
+                                 (save-account {:account     account
+                                                :updated-key :emoji
+                                                :new-value   edited-emoji
+                                                :theme       theme})))
         on-confirm-name      (fn [account]
                                (rn/dismiss-keyboard!)
-                               (save-account {:account account
-                                              :type    :name
-                                              :value   @edited-account-name
-                                              :theme   theme}))]
+                               (save-account {:account     account
+                                              :updated-key :name
+                                              :new-value   @edited-account-name
+                                              :theme       theme}))]
     (fn []
       (let [{:keys [name emoji address color]
              :as   account}  (rf/sub [:wallet/current-viewing-account])
@@ -82,17 +86,18 @@
            :right-icon      :i/advanced
            :card?           true
            :title           (i18n/label :t/address)
-           :custom-subtitle (fn [] [quo/address-text
-                                    {:networks [{:network-name :ethereum :short-name "eth"}
-                                                {:network-name :optimism :short-name "opt"}
-                                                {:network-name :arbitrum :short-name "arb1"}]
-                                     :address  address
-                                     :format   :long}])
+           :custom-subtitle (fn []
+                              [quo/address-text
+                               {:networks [{:network-name :ethereum :short-name "eth"}
+                                           {:network-name :optimism :short-name "opt"}
+                                           {:network-name :arbitrum :short-name "arb1"}]
+                                :address  address
+                                :format   :long}])
            :on-press        (fn []
                               (rf/dispatch [:show-bottom-sheet
-                                            {:content (fn [] [network-preferences/view
-                                                              {:on-save #(js/alert
-                                                                          "calling on save")}])}]))
+                                            {:content (fn []
+                                                        [network-preferences/view
+                                                         {:on-save #(js/alert "calling on save")}])}]))
            :container-style style/data-item}]]))))
 
 (def view (quo.theme/with-theme view-internal))

--- a/src/status_im2/contexts/wallet/events.cljs
+++ b/src/status_im2/contexts/wallet/events.cljs
@@ -72,14 +72,14 @@
 
 (rf/reg-event-fx
  :wallet/save-account
- (fn [_ [{:keys [account callback]}]]
+ (fn [_ [{:keys [account on-success]}]]
    {:fx [[:json-rpc/call
           [{:method     "accounts_saveAccount"
             :params     [(data-store/<-account account)]
             :on-success (fn []
                           (rf/dispatch [:wallet/get-accounts])
-                          (when (fn? callback)
-                            (callback)))
+                          (when (fn? on-success)
+                            (on-success)))
             :on-error   #(log/info "failed to save account "
                                    {:error %
                                     :event :wallet/save-account})}]]]}))

--- a/src/status_im2/subs/root.cljs
+++ b/src/status_im2/subs/root.cljs
@@ -145,10 +145,6 @@
 (reg-root-key-sub :communities/selected-tab :communities/selected-tab)
 (reg-root-key-sub :contract-communities :contract-communities)
 
-;;wallet
-(reg-root-key-sub :wallet/tokens :wallet/tokens)
-(reg-root-key-sub :wallet/tokens-loading? :wallet/tokens-loading?)
-
 ;;activity center
 (reg-root-key-sub :activity-center :activity-center)
 

--- a/src/status_im2/subs/wallet/wallet.cljs
+++ b/src/status_im2/subs/wallet/wallet.cljs
@@ -1,22 +1,17 @@
 (ns status-im2.subs.wallet.wallet
-  (:require [re-frame.core :as re-frame]
+  (:require [re-frame.core :as rf]
             [status-im2.contexts.wallet.common.utils :as utils]
             [utils.number]))
 
-(defn- calculate-raw-balance
-  [raw-balance decimals]
-  (if-let [n (utils.number/parse-int raw-balance nil)]
-    (/ n (Math/pow 10 (utils.number/parse-int decimals)))
-    0))
+(rf/reg-sub
+ :wallet/ui
+ :<- [:wallet]
+ :-> :ui)
 
-(defn- total-per-token
-  [item]
-  (reduce (fn [ac balances]
-            (+ (calculate-raw-balance (:rawBalance balances)
-                                      (:decimals item))
-               ac))
-          0
-          (vals (:balancesPerChain item))))
+(rf/reg-sub
+ :wallet/tokens-loading?
+ :<- [:wallet/ui]
+ :-> :tokens-loading?)
 
 (defn- calculate-balance
   [address tokens]

--- a/src/status_im2/subs/wallet/wallet.cljs
+++ b/src/status_im2/subs/wallet/wallet.cljs
@@ -28,7 +28,21 @@
    (zipmap (map :address accounts)
            (map #(-> % :tokens utils/calculate-balance) accounts))))
 
-(re-frame/reg-sub
+(rf/reg-sub
+ :wallet/account-cards-data
+ :<- [:wallet/accounts]
+ :<- [:wallet/balances]
+ :<- [:wallet/tokens-loading?]
+ (fn [[accounts balances tokens-loading?]]
+   (mapv (fn [{:keys [color address] :as account}]
+           (assoc account
+                  :customization-color color
+                  :type                :empty
+                  :on-press            #(rf/dispatch [:wallet/navigate-to-account address])
+                  :loading?            tokens-loading?
+                  :balance             (utils/prettify-balance (get balances address))))
+         accounts)))
+
 (rf/reg-sub
  :wallet/current-viewing-account
  :<- [:wallet]

--- a/src/status_im2/subs/wallet/wallet.cljs
+++ b/src/status_im2/subs/wallet/wallet.cljs
@@ -13,19 +13,7 @@
  :<- [:wallet/ui]
  :-> :tokens-loading?)
 
-(defn- calculate-balance
-  [address tokens]
-  (let [token  (get tokens (keyword address))
-        result (reduce
-                (fn [acc item]
-                  (let [total-values (* (total-per-token item)
-                                        (get-in item [:marketValuesPerCurrency :USD :price]))]
-                    (+ acc total-values)))
-                0
-                token)]
-    result))
-
-(re-frame/reg-sub
+(rf/reg-sub
  :wallet/accounts
  :<- [:wallet]
  :-> #(->> %
@@ -33,20 +21,19 @@
            vals
            (sort-by :position)))
 
-(re-frame/reg-sub
+(rf/reg-sub
  :wallet/balances
  :<- [:wallet/accounts]
- :<- [:wallet/tokens]
- (fn [[accounts tokens]]
-   (for [{:keys [address]} accounts]
-     {:address address
-      :balance (calculate-balance address tokens)})))
+ (fn [accounts]
+   (zipmap (map :address accounts)
+           (map #(-> % :tokens utils/calculate-balance) accounts))))
 
 (re-frame/reg-sub
+(rf/reg-sub
  :wallet/current-viewing-account
  :<- [:wallet]
  :<- [:wallet/balances]
  (fn [[{:keys [current-viewing-account-address] :as wallet} balances]]
    (-> wallet
        (get-in [:accounts current-viewing-account-address])
-       (assoc :balance (utils/get-balance-by-address balances current-viewing-account-address)))))
+       (assoc :balance (get balances current-viewing-account-address)))))

--- a/src/status_im2/subs/wallet/wallet_test.cljs
+++ b/src/status_im2/subs/wallet/wallet_test.cljs
@@ -8,43 +8,35 @@
 (use-fixtures :each
               {:before #(reset! rf-db/app-db {})})
 
-(def tokens
-  {:0x1 [{:decimals                1
-          :symbol                  "ETH"
-          :name                    "Ether"
-          :balancesPerChain        {:1 {:rawBalance "20"
-                                        :hasError   false}
-                                    :2 {:rawBalance "10"
-                                        :hasError   false}}
-          :marketValuesPerCurrency {:USD {:price 1000}}} ;; total should be 3000
-         {:decimals                2
-          :symbol                  "DAI"
-          :name                    "Dai Stablecoin"
-          :balancesPerChain        {:1 {:rawBalance "100"
-                                        :hasError   false}
-                                    :2 {:rawBalance "150"
-                                        :hasError   false}}
-          :marketValuesPerCurrency {:USD {:price 100}}}] ;; total should be 250
-   :0x2 [{:decimals                3
-          :symbol                  "ETH"
-          :name                    "Ether"
-          :balancesPerChain        {:1 {:rawBalance "2500"
-                                        :hasError   false}
-                                    :2 {:rawBalance "3000"
-                                        :hasError   false}
-                                    :3 {:rawBalance "<nil>"
-                                        :hasError   false}}
-          :marketValuesPerCurrency {:USD {:price 200}}} ;; total should be 1100
-         {:decimals                10
-          :symbol                  "DAI"
-          :name                    "Dai Stablecoin"
-          :balancesPerChain        {:1 {:rawBalance "10000000000"
-                                        :hasError   false}
-                                    :2 {:rawBalance "0"
-                                        :hasError   false}
-                                    :3 {:rawBalance "<nil>"
-                                        :hasError   false}}
-          :marketValuesPerCurrency {:USD {:price 1000}}}]}) ;; total should be 1000
+(def tokens-0x1
+  [{:decimals                   1
+    :symbol                     "ETH"
+    :name                       "Ether"
+    :balances-per-chain         {1 {:raw-balance "20" :has-error false}
+                                 2 {:raw-balance "10" :has-error false}}
+    :market-values-per-currency {:usd {:price 1000}}}
+   {:decimals                   2
+    :symbol                     "DAI"
+    :name                       "Dai Stablecoin"
+    :balances-per-chain         {1 {:raw-balance "100" :has-error false}
+                                 2 {:raw-balance "150" :has-error false}}
+    :market-values-per-currency {:usd {:price 100}}}])
+
+(def tokens-0x2
+  [{:decimals                   3
+    :symbol                     "ETH"
+    :name                       "Ether"
+    :balances-per-chain         {1 {:raw-balance "2500" :has-error false}
+                                 2 {:raw-balance "3000" :has-error false}
+                                 3 {:raw-balance "<nil>" :has-error false}}
+    :market-values-per-currency {:usd {:price 200}}}
+   {:decimals                   10
+    :symbol                     "DAI"
+    :name                       "Dai Stablecoin"
+    :balances-per-chain         {1 {:raw-balance "10000000000" :has-error false}
+                                 2 {:raw-balance "0" :has-error false}
+                                 3 {:raw-balance "<nil>" :has-error false}}
+    :market-values-per-currency {:usd {:price 1000}}}])
 
 (def accounts
   {"0x1" {:path                     "m/44'/60'/0'/0/0"
@@ -65,7 +57,8 @@
           :operable                 "fully"
           :mixedcase-address        "0x7bcDfc75c431"
           :public-key               "0x04371e2d9d66b82f056bc128064"
-          :removed                  false}
+          :removed                  false
+          :tokens                   tokens-0x1}
    "0x2" {:path                     "m/44'/60'/0'/0/1"
           :emoji                    "💎"
           :key-uid                  "0x2f5ea39"
@@ -84,7 +77,8 @@
           :operable                 "fully"
           :mixedcase-address        "0x7bcDfc75c431"
           :public-key               "0x04371e2d9d66b82f056bc128064"
-          :removed                  false}})
+          :removed                  false
+          :tokens                   tokens-0x2}})
 
 (h/deftest-sub :wallet/balances
   [sub-name]
@@ -101,49 +95,49 @@
 (h/deftest-sub :wallet/accounts
   [sub-name]
   (testing "returns all accounts without balance"
-    (swap! rf-db/app-db
-      #(-> %
-           (assoc-in [:wallet :accounts] accounts)
-           (assoc :wallet/tokens tokens)))
+    (swap! rf-db/app-db #(assoc-in % [:wallet :accounts] accounts))
+
     (is
-     (= `({:path                     "m/44'/60'/0'/0/0"
-           :emoji                    "😃"
-           :key-uid                  "0x2f5ea39"
-           :address                  "0x1"
-           :wallet                   false
-           :name                     "Account One"
-           :type                     :generated
-           :chat                     false
-           :test-preferred-chain-ids #{5 420 421613}
-           :color                    :blue
-           :hidden                   false
-           :prod-preferred-chain-ids #{1 10 42161}
-           :position                 0
-           :clock                    1698945829328
-           :created-at               1698928839000
-           :operable                 "fully"
-           :mixedcase-address        "0x7bcDfc75c431"
-           :public-key               "0x04371e2d9d66b82f056bc128064"
-           :removed                  false}
-          {:path                     "m/44'/60'/0'/0/1"
-           :emoji                    "💎"
-           :key-uid                  "0x2f5ea39"
-           :address                  "0x2"
-           :wallet                   false
-           :name                     "Account Two"
-           :type                     :generated
-           :chat                     false
-           :test-preferred-chain-ids #{5 420 421613}
-           :color                    :purple
-           :hidden                   false
-           :prod-preferred-chain-ids #{1 10 42161}
-           :position                 1
-           :clock                    1698945829328
-           :created-at               1698928839000
-           :operable                 "fully"
-           :mixedcase-address        "0x7bcDfc75c431"
-           :public-key               "0x04371e2d9d66b82f056bc128064"
-           :removed                  false})
+     (= (list {:path                     "m/44'/60'/0'/0/0"
+               :emoji                    "😃"
+               :key-uid                  "0x2f5ea39"
+               :address                  "0x1"
+               :wallet                   false
+               :name                     "Account One"
+               :type                     :generated
+               :chat                     false
+               :test-preferred-chain-ids #{5 420 421613}
+               :color                    :blue
+               :hidden                   false
+               :prod-preferred-chain-ids #{1 10 42161}
+               :position                 0
+               :clock                    1698945829328
+               :created-at               1698928839000
+               :operable                 "fully"
+               :mixedcase-address        "0x7bcDfc75c431"
+               :public-key               "0x04371e2d9d66b82f056bc128064"
+               :removed                  false
+               :tokens                   tokens-0x1}
+              {:path                     "m/44'/60'/0'/0/1"
+               :emoji                    "💎"
+               :key-uid                  "0x2f5ea39"
+               :address                  "0x2"
+               :wallet                   false
+               :name                     "Account Two"
+               :type                     :generated
+               :chat                     false
+               :test-preferred-chain-ids #{5 420 421613}
+               :color                    :purple
+               :hidden                   false
+               :prod-preferred-chain-ids #{1 10 42161}
+               :position                 1
+               :clock                    1698945829328
+               :created-at               1698928839000
+               :operable                 "fully"
+               :mixedcase-address        "0x7bcDfc75c431"
+               :public-key               "0x04371e2d9d66b82f056bc128064"
+               :removed                  false
+               :tokens                   tokens-0x2})
         (rf/sub [sub-name])))))
 
 (h/deftest-sub :wallet/current-viewing-account
@@ -152,8 +146,8 @@
     (swap! rf-db/app-db
       #(-> %
            (assoc-in [:wallet :accounts] accounts)
-           (assoc-in [:wallet :current-viewing-account-address] "0x1")
-           (assoc :wallet/tokens tokens)))
+           (assoc-in [:wallet :current-viewing-account-address] "0x1")))
+
     (is
      (= {:path                     "m/44'/60'/0'/0/0"
          :emoji                    "😃"
@@ -174,5 +168,6 @@
          :mixedcase-address        "0x7bcDfc75c431"
          :public-key               "0x04371e2d9d66b82f056bc128064"
          :removed                  false
-         :balance                  3250}
+         :balance                  3250
+         :tokens                   tokens-0x1}
         (rf/sub [sub-name])))))

--- a/src/status_im2/subs/wallet/wallet_test.cljs
+++ b/src/status_im2/subs/wallet/wallet_test.cljs
@@ -82,14 +82,10 @@
 
 (h/deftest-sub :wallet/balances
   [sub-name]
-  (testing "returns seq of maps containing :address and :balance"
-    (swap! rf-db/app-db #(-> %
-                             (assoc-in [:wallet :accounts] accounts)
-                             (assoc :wallet/tokens tokens)))
-    (is (= `({:address "0x1"
-              :balance 3250}
-             {:address "0x2"
-              :balance 2100})
+  (testing "a map: address->balance"
+    (swap! rf-db/app-db #(assoc-in % [:wallet :accounts] accounts))
+
+    (is (= {"0x1" 3250 "0x2" 2100}
            (rf/sub [sub-name])))))
 
 (h/deftest-sub :wallet/accounts


### PR DESCRIPTION
[comment]: # (Please replace ... with your information. Remove < and >)
[comment]: # (To auto-close issue on merge, please insert the related issue number after # i.e fixes #566)

fixes #17823

### Summary

This PR refactors app-db for the wallet data related to tokens and accounts. Full list of changes:

#### Refactor edit-account view and events:

- Fix `(fn [])` code style.
- Avoid overriding `clojure.core/type` by destructuring the `:type` key.
- Split the toast callback to a different function.
- `:wallet/save-account` receives `:on-success` instead of `:callback` to improve readability.

#### Refactor app-db for `:wallet/tokens` & `:wallet/tokens-loading?`

- Remove the root sub `:wallet/tokens-loading?`, now it's in app-db in `[:wallet :ui :tokens-loading?]`.
- Remove the root subs `:wallet/tokens`, now the value is returned along with the account data by the sub
  `:wallet/accounts`, it's stored in app-db in `[:wallet :address "0x..." :tokens]`.
- Fix the format of the token data returned by the endpoint `"wallet_getWalletToken"` and the fn `js->clj`,
  - Addresses are no longer keywords (since keywords mustn't start with a number).
  - Keys are now kebab-case.
  - Chain-ids are no longer keywords, now they are integers.
- Update tests

#### Move logic to calculate `:wallet/balances` and change value returned

- Move logic to `status-im2.contexts.wallet.common.utils`
- The `:wallet/balances` value returned by the sub had the following structure:
```clojure
   [{:address "0x1...", :balance 12345}
    {:address "0x2...", :balance 67890} 
    ,,,]
```
  This required a helper function to get the balance for an address (`get-balance-by-address`)
  It has been changed to a map:
```clojure
   {"0x1..." 12345
    "0x2..." 67890,
    ,,,}
```
  
  So now we don't need a helper function (just the hashmap itself or `clojure.core/get`).
- Because of the previous change, now the `get-balance-by-address` has been removed.
- The function `get-account-by-address` has zero uses, so it has been removed.
- The test for the sub has been updated.

#### Create sub `:wallet/account-cards-data`

 - This sub returns a vector of maps to render the account cards in the wallet page.
 - This logic was previously in the `view` namespace, but it was completely calculated from the subs `:wallet/accounts`, `:wallet/balances` and `:wallet/tokens-loading?`, so it was  clear that's a derived value.


### Review notes
All points listed in the issue had been solved:

- [x]  The tokens data are currently stored in the (root) key :wallet/tokens and it needs to be moved under the :wallet key (along with the accounts and other data). The :token key (under wallet) will be a map which will contain the data and loading? keys.
- [x] The keys inside the token data need to be renamed (kebab-case) and the helper methods should be placed in status-im2.common.data-store.wallet ns.
- [x] The subscriptions need to be updated to attach the token data for each account along with the account data.
- [x] The helper methods for the calculation of balances should be moved to status-im2.contexts.wallet.common.utils ns.
- [x] The usage should be updated across the wallet.

#### Platforms

- Android
- iOS

#### Areas that maybe impacted
- Wallet account cards in the home screen
- Wallet Edit account

status: ready
