### PR TITLE
[17827] Fix text content when editing and reentering chat

### DIFF
--- a/src/status_im/chat/models/input.cljs
+++ b/src/status_im/chat/models/input.cljs
@@ -107,14 +107,15 @@
   [{:keys [db] :as cofx} message]
   (let [current-chat-id (:current-chat-id db)
         text            (get-in message [:content :text])]
-    {:db       (-> db
-                   (assoc-in [:chat/inputs current-chat-id :metadata :editing-message]
-                             message)
-                   (assoc-in [:chat/inputs current-chat-id :metadata :responding-to-message] nil)
-                   (update-in [:chat/inputs current-chat-id :metadata]
-                              dissoc
-                              :sending-image))
-     :dispatch [:mention/to-input-field text current-chat-id]}))
+    {:db         (-> db
+                     (assoc-in [:chat/inputs current-chat-id :metadata :editing-message]
+                               message)
+                     (assoc-in [:chat/inputs current-chat-id :metadata :responding-to-message] nil)
+                     (update-in [:chat/inputs current-chat-id :metadata]
+                                dissoc
+                                :sending-image))
+     :dispatch-n [[:chat.ui/set-chat-input-text nil current-chat-id]
+                  [:mention/to-input-field text current-chat-id]]}))
 
 (rf/defn show-contact-request-input
   "Sets reference to previous chat message and focuses on input"

--- a/src/status_im2/contexts/chat/composer/effects.cljs
+++ b/src/status_im2/contexts/chat/composer/effects.cljs
@@ -109,8 +109,7 @@
    {:keys [edit]}]
   (rn/use-effect
    (fn []
-     (let [edit-text        (get-in edit [:content :text])
-           text-value-count (count @text-value)]
+     (let [edit-text (get-in edit [:content :text])]
        (when (and edit @input-ref)
          ;; A small setTimeout is necessary to ensure the statement is enqueued and will get executed
          ;; ASAP.
@@ -118,9 +117,7 @@
          (js/setTimeout #(.focus ^js @input-ref) 250)
          (.setNativeProps ^js @input-ref (clj->js {:text edit-text}))
          (reset! text-value edit-text)
-         (reset! saved-cursor-position (if (zero? text-value-count)
-                                         (count edit-text)
-                                         text-value-count)))))
+         (reset! saved-cursor-position (count edit-text)))))
    [(:message-id edit)]))
 
 (defn use-reply


### PR DESCRIPTION
fixes #17827

### Summary

Fixes an issue when users types some text in composer, starts editing a message and reopens chat

status: ready
