### PR TITLE
[17825] prevent composer from focusing on opening chat with edit/reply

### DIFF
--- a/src/status_im/chat/models/input.cljs
+++ b/src/status_im/chat/models/input.cljs
@@ -107,15 +107,14 @@
   [{:keys [db] :as cofx} message]
   (let [current-chat-id (:current-chat-id db)
         text            (get-in message [:content :text])]
-    {:db         (-> db
-                     (assoc-in [:chat/inputs current-chat-id :metadata :editing-message]
-                               message)
-                     (assoc-in [:chat/inputs current-chat-id :metadata :responding-to-message] nil)
-                     (update-in [:chat/inputs current-chat-id :metadata]
-                                dissoc
-                                :sending-image))
-     :dispatch-n [[:chat.ui/set-chat-input-text nil current-chat-id]
-                  [:mention/to-input-field text current-chat-id]]}))
+    {:db       (-> db
+                   (assoc-in [:chat/inputs current-chat-id :metadata :editing-message]
+                             message)
+                   (assoc-in [:chat/inputs current-chat-id :metadata :responding-to-message] nil)
+                   (update-in [:chat/inputs current-chat-id :metadata]
+                              dissoc
+                              :sending-image))
+     :dispatch [:mention/to-input-field text current-chat-id]}))
 
 (rf/defn show-contact-request-input
   "Sets reference to previous chat message and focuses on input"

--- a/src/status_im/chat/models/input.cljs
+++ b/src/status_im/chat/models/input.cljs
@@ -107,14 +107,15 @@
   [{:keys [db] :as cofx} message]
   (let [current-chat-id (:current-chat-id db)
         text            (get-in message [:content :text])]
-    {:db       (-> db
-                   (assoc-in [:chat/inputs current-chat-id :metadata :editing-message]
-                             message)
-                   (assoc-in [:chat/inputs current-chat-id :metadata :responding-to-message] nil)
-                   (update-in [:chat/inputs current-chat-id :metadata]
-                              dissoc
-                              :sending-image))
-     :dispatch [:mention/to-input-field text current-chat-id]}))
+    {:db         (-> db
+                     (assoc-in [:chat/inputs current-chat-id :metadata :editing-message]
+                               message)
+                     (assoc-in [:chat/inputs current-chat-id :metadata :responding-to-message] nil)
+                     (update-in [:chat/inputs current-chat-id :metadata]
+                                dissoc
+                                :sending-image))
+     :dispatch-n [[:chat.ui/set-chat-input-text nil current-chat-id]
+                  [:mention/to-input-field text current-chat-id]]}))
 
 (rf/defn show-contact-request-input
   "Sets reference to previous chat message and focuses on input"

--- a/src/status_im2/contexts/chat/composer/effects.cljs
+++ b/src/status_im2/contexts/chat/composer/effects.cljs
@@ -106,12 +106,17 @@
 (defn use-edit
   [{:keys [input-ref]}
    {:keys [text-value saved-cursor-position]}
-   {:keys [edit]}]
+   {:keys [edit]}
+   message-list-rendered?]
   (rn/use-effect
    (fn []
      (let [edit-text        (get-in edit [:content :text])
            text-value-count (count @text-value)]
-       (when (and edit @input-ref)
+       (when (and edit @input-ref @message-list-rendered?)
+         ;; A small setTimeout is necessary to ensure the statement is enqueued and will get executed
+         ;; ASAP.
+         ;; https://github.com/software-mansion/react-native-screens/issues/472
+         (js/setTimeout #(.focus ^js @input-ref) 250)
          (.setNativeProps ^js @input-ref (clj->js {:text edit-text}))
          (reset! text-value edit-text)
          (reset! saved-cursor-position (if (zero? text-value-count)
@@ -122,7 +127,8 @@
 (defn use-reply
   [_
    {:keys [container-opacity]}
-   {:keys [reply]}]
+   {:keys [reply]}
+   message-list-rendered?]
   (rn/use-effect
    (fn []
      (when reply

--- a/src/status_im2/contexts/chat/composer/effects.cljs
+++ b/src/status_im2/contexts/chat/composer/effects.cljs
@@ -116,13 +116,13 @@
          ;; A small setTimeout is necessary to ensure the statement is enqueued and will get
          ;; executed
          ;; ASAP. Https://github.com/software-mansion/react-native-screens/issues/472
+         (reset! saved-cursor-position (if edit-text
+                                         (count edit-text)
+                                         text-value-count))
          (js/setTimeout #(.focus ^js @input-ref) 250))
        (when (and edit @input-ref)
          (.setNativeProps ^js @input-ref (clj->js {:text edit-text}))
-         (reset! text-value edit-text)
-         (reset! saved-cursor-position (if (zero? text-value-count)
-                                         (count edit-text)
-                                         text-value-count)))))
+         (reset! text-value edit-text))))
    [(:message-id edit)]))
 
 (defn use-reply

--- a/src/status_im2/contexts/chat/composer/effects.cljs
+++ b/src/status_im2/contexts/chat/composer/effects.cljs
@@ -111,25 +111,19 @@
    (fn []
      (let [edit-text (get-in edit [:content :text])]
        (when (and edit @input-ref)
-         ;; A small setTimeout is necessary to ensure the statement is enqueued and will get executed
-         ;; ASAP.
-         ;; https://github.com/software-mansion/react-native-screens/issues/472
-         (js/setTimeout #(.focus ^js @input-ref) 250)
          (.setNativeProps ^js @input-ref (clj->js {:text edit-text}))
          (reset! text-value edit-text)
          (reset! saved-cursor-position (count edit-text)))))
    [(:message-id edit)]))
 
 (defn use-reply
-  [{:keys [input-ref]}
+  [_
    {:keys [container-opacity]}
    {:keys [reply]}]
   (rn/use-effect
    (fn []
      (when reply
-       (reanimated/animate container-opacity 1))
-     (when (and reply @input-ref)
-       (js/setTimeout #(.focus ^js @input-ref) 250)))
+       (reanimated/animate container-opacity 1)))
    [(:message-id reply)]))
 
 (defn edit-mentions

--- a/src/status_im2/contexts/chat/composer/effects.cljs
+++ b/src/status_im2/contexts/chat/composer/effects.cljs
@@ -135,7 +135,7 @@
        (reanimated/animate container-opacity 1))
      (when (and reply @input-ref @message-list-rendered?)
        (js/setTimeout #(.focus ^js @input-ref) 250))))
-   [(:message-id reply)])
+  [(:message-id reply)])
 
 (defn edit-mentions
   [{:keys [input-ref]} {:keys [text-value cursor-position]} {:keys [input-with-mentions]}]

--- a/src/status_im2/contexts/chat/composer/effects.cljs
+++ b/src/status_im2/contexts/chat/composer/effects.cljs
@@ -109,11 +109,14 @@
    {:keys [edit]}]
   (rn/use-effect
    (fn []
-     (let [edit-text (get-in edit [:content :text])]
+     (let [edit-text        (get-in edit [:content :text])
+           text-value-count (count @text-value)]
        (when (and edit @input-ref)
          (.setNativeProps ^js @input-ref (clj->js {:text edit-text}))
          (reset! text-value edit-text)
-         (reset! saved-cursor-position (count edit-text)))))
+         (reset! saved-cursor-position (if (zero? text-value-count)
+                                         (count edit-text)
+                                         text-value-count)))))
    [(:message-id edit)]))
 
 (defn use-reply

--- a/src/status_im2/contexts/chat/composer/effects.cljs
+++ b/src/status_im2/contexts/chat/composer/effects.cljs
@@ -109,8 +109,7 @@
    {:keys [edit]}]
   (rn/use-effect
    (fn []
-     (let [edit-text        (get-in edit [:content :text])
-           text-value-count (count @text-value)]
+     (let [edit-text (get-in edit [:content :text])]
        (when (and edit @input-ref)
          ;; A small setTimeout is necessary to ensure the statement is enqueued and will get executed
          ;; ASAP.
@@ -118,9 +117,7 @@
          (js/setTimeout #(.focus ^js @input-ref) 250)
          (.setNativeProps ^js @input-ref (clj->js {:text edit-text}))
          (reset! text-value edit-text)
-         (reset! saved-cursor-position (if (zero? text-value-count)
-                                         (count edit-text)
-                                         text-value-count)))))
+         (reset! saved-cursor-position (count edit-text)))))
    [(:message-id edit)]))
 
 (defn use-reply

--- a/src/status_im2/contexts/chat/composer/effects.cljs
+++ b/src/status_im2/contexts/chat/composer/effects.cljs
@@ -112,11 +112,12 @@
    (fn []
      (let [edit-text        (get-in edit [:content :text])
            text-value-count (count @text-value)]
-       (when (and edit @input-ref @messages-list-on-layout-finished?)
-         ;; A small setTimeout is necessary to ensure the statement is enqueued and will get executed
-         ;; ASAP.
-         ;; https://github.com/software-mansion/react-native-screens/issues/472
-         (js/setTimeout #(.focus ^js @input-ref) 250)
+       (when @messages-list-on-layout-finished?
+         ;; A small setTimeout is necessary to ensure the statement is enqueued and will get
+         ;; executed
+         ;; ASAP. Https://github.com/software-mansion/react-native-screens/issues/472
+         (js/setTimeout #(.focus ^js @input-ref) 250))
+       (when (and edit @input-ref)
          (.setNativeProps ^js @input-ref (clj->js {:text edit-text}))
          (reset! text-value edit-text)
          (reset! saved-cursor-position (if (zero? text-value-count)

--- a/src/status_im2/contexts/chat/composer/effects.cljs
+++ b/src/status_im2/contexts/chat/composer/effects.cljs
@@ -125,15 +125,17 @@
    [(:message-id edit)]))
 
 (defn use-reply
-  [_
+  [{:keys [input-ref]}
    {:keys [container-opacity]}
    {:keys [reply]}
    message-list-rendered?]
   (rn/use-effect
    (fn []
      (when reply
-       (reanimated/animate container-opacity 1)))
-   [(:message-id reply)]))
+       (reanimated/animate container-opacity 1))
+     (when (and reply @input-ref @message-list-rendered?)
+       (js/setTimeout #(.focus ^js @input-ref) 250))))
+   [(:message-id reply)])
 
 (defn edit-mentions
   [{:keys [input-ref]} {:keys [text-value cursor-position]} {:keys [input-with-mentions]}]

--- a/src/status_im2/contexts/chat/composer/effects.cljs
+++ b/src/status_im2/contexts/chat/composer/effects.cljs
@@ -107,12 +107,12 @@
   [{:keys [input-ref]}
    {:keys [text-value saved-cursor-position]}
    {:keys [edit]}
-   message-list-rendered?]
+   messages-list-on-layout-finished?]
   (rn/use-effect
    (fn []
      (let [edit-text        (get-in edit [:content :text])
            text-value-count (count @text-value)]
-       (when (and edit @input-ref @message-list-rendered?)
+       (when (and edit @input-ref @messages-list-on-layout-finished?)
          ;; A small setTimeout is necessary to ensure the statement is enqueued and will get executed
          ;; ASAP.
          ;; https://github.com/software-mansion/react-native-screens/issues/472
@@ -128,12 +128,12 @@
   [{:keys [input-ref]}
    {:keys [container-opacity]}
    {:keys [reply]}
-   message-list-rendered?]
+   messages-list-on-layout-finished?]
   (rn/use-effect
    (fn []
      (when reply
        (reanimated/animate container-opacity 1))
-     (when (and reply @input-ref @message-list-rendered?)
+     (when (and reply @input-ref @messages-list-on-layout-finished?)
        (js/setTimeout #(.focus ^js @input-ref) 250))))
   [(:message-id reply)])
 

--- a/src/status_im2/contexts/chat/composer/view.cljs
+++ b/src/status_im2/contexts/chat/composer/view.cljs
@@ -33,7 +33,8 @@
            blur-height
            opacity
            background-y
-           theme]} props state]
+           theme
+           message-list-rendered?]} props state]
   (let [{:keys [chat-screen-loaded?]
          :as   subscriptions}    (utils/init-subs)
         content-height           (reagent/atom (or (:input-content-height ; Actual text height
@@ -73,8 +74,8 @@
                         animations
                         dimensions
                         subscriptions)
-    (effects/use-edit props state subscriptions)
-    (effects/use-reply props animations subscriptions)
+    (effects/use-edit props state subscriptions message-list-rendered?)
+    (effects/use-reply props animations subscriptions message-list-rendered?)
     (effects/update-input-mention props state subscriptions)
     (effects/edit-mentions props state subscriptions)
     (effects/link-previews props state animations subscriptions)
@@ -147,7 +148,7 @@
          subscriptions]]]]]))
 
 (defn composer
-  [{:keys [insets scroll-to-bottom-fn show-floating-scroll-down-button?]}]
+  [{:keys [insets scroll-to-bottom-fn show-floating-scroll-down-button? message-list-rendered?]}]
   (let [window-height (:height (rn/get-window))
         theme         (quo.theme/use-theme-value)
         opacity       (reanimated/use-shared-value 0)
@@ -161,7 +162,8 @@
                        :blur-height                       blur-height
                        :opacity                           opacity
                        :background-y                      background-y
-                       :theme                             theme}
+                       :theme                             theme
+                       :message-list-rendered?            message-list-rendered?}
         props         (utils/init-non-reactive-state)
         state         (utils/init-reactive-state)]
     [rn/view (when platform/ios? {:style {:z-index 1}})

--- a/src/status_im2/contexts/chat/composer/view.cljs
+++ b/src/status_im2/contexts/chat/composer/view.cljs
@@ -34,7 +34,7 @@
            opacity
            background-y
            theme
-           message-list-rendered?]} props state]
+           messages-list-on-layout-finished?]} props state]
   (let [{:keys [chat-screen-loaded?]
          :as   subscriptions}    (utils/init-subs)
         content-height           (reagent/atom (or (:input-content-height ; Actual text height
@@ -74,8 +74,8 @@
                         animations
                         dimensions
                         subscriptions)
-    (effects/use-edit props state subscriptions message-list-rendered?)
-    (effects/use-reply props animations subscriptions message-list-rendered?)
+    (effects/use-edit props state subscriptions messages-list-on-layout-finished?)
+    (effects/use-reply props animations subscriptions messages-list-on-layout-finished?)
     (effects/update-input-mention props state subscriptions)
     (effects/edit-mentions props state subscriptions)
     (effects/link-previews props state animations subscriptions)
@@ -148,7 +148,8 @@
          subscriptions]]]]]))
 
 (defn composer
-  [{:keys [insets scroll-to-bottom-fn show-floating-scroll-down-button? message-list-rendered?]}]
+  [{:keys [insets scroll-to-bottom-fn show-floating-scroll-down-button?
+           messages-list-on-layout-finished?]}]
   (let [window-height (:height (rn/get-window))
         theme         (quo.theme/use-theme-value)
         opacity       (reanimated/use-shared-value 0)
@@ -163,7 +164,7 @@
                        :opacity                           opacity
                        :background-y                      background-y
                        :theme                             theme
-                       :message-list-rendered?            message-list-rendered?}
+                       :messages-list-on-layout-finished? messages-list-on-layout-finished?}
         props         (utils/init-non-reactive-state)
         state         (utils/init-reactive-state)]
     [rn/view (when platform/ios? {:style {:z-index 1}})

--- a/src/status_im2/contexts/chat/messages/list/view.cljs
+++ b/src/status_im2/contexts/chat/messages/list/view.cljs
@@ -298,7 +298,7 @@
 
 (defn f-messages-list-content
   [{:keys [chat insets scroll-y content-height cover-bg-color keyboard-shown? inner-state-atoms
-           big-name-visible? animate-topbar-opacity? composer-active?
+           big-name-visible? animate-topbar-opacity? composer-active? message-list-rendered?
            on-end-reached? animate-topbar-name?]}]
   (rn/use-effect (fn []
                    (if (and (not @on-end-reached?)
@@ -412,6 +412,7 @@
        ;;TODO(rasom) https://github.com/facebook/react-native/issues/30034
        :inverted                          (when platform/ios? true)
        :on-layout                         (fn [e]
+                                            (reset! message-list-rendered? true)
                                             (let [layout-height (oops/oget e
                                                                            "nativeEvent.layout.height")]
                                               (reset! messages-view-height layout-height)))

--- a/src/status_im2/contexts/chat/messages/list/view.cljs
+++ b/src/status_im2/contexts/chat/messages/list/view.cljs
@@ -298,7 +298,7 @@
 
 (defn f-messages-list-content
   [{:keys [chat insets scroll-y content-height cover-bg-color keyboard-shown? inner-state-atoms
-           big-name-visible? animate-topbar-opacity? composer-active? message-list-rendered?
+           big-name-visible? animate-topbar-opacity? composer-active? messages-list-on-layout-finished?
            on-end-reached? animate-topbar-name?]}]
   (rn/use-effect (fn []
                    (if (and (not @on-end-reached?)
@@ -412,7 +412,7 @@
        ;;TODO(rasom) https://github.com/facebook/react-native/issues/30034
        :inverted                          (when platform/ios? true)
        :on-layout                         (fn [e]
-                                            (reset! message-list-rendered? true)
+                                            (reset! messages-list-on-layout-finished? true)
                                             (let [layout-height (oops/oget e
                                                                            "nativeEvent.layout.height")]
                                               (reset! messages-view-height layout-height)))

--- a/src/status_im2/contexts/chat/messages/view.cljs
+++ b/src/status_im2/contexts/chat/messages/view.cljs
@@ -15,7 +15,7 @@
 
 (defn f-chat
   [{:keys [show-floating-scroll-down-button? animate-topbar-name?
-           big-name-visible? animate-topbar-opacity? on-end-reached?]
+           big-name-visible? animate-topbar-opacity? on-end-reached? message-list-rendered?]
     :as   inner-state-atoms}]
   (let [insets                   (safe-area/get-insets)
         scroll-y                 (reanimated/use-shared-value 0)
@@ -64,7 +64,8 @@
        :big-name-visible?       big-name-visible?
        :animate-topbar-opacity? animate-topbar-opacity?
        :composer-active?        focused?
-       :on-end-reached?         on-end-reached?}]
+       :on-end-reached?         on-end-reached?
+       :message-list-rendered?  message-list-rendered?}]
 
      [messages.navigation/navigation-view
       {:scroll-y                scroll-y
@@ -86,7 +87,8 @@
          [:f> composer.view/composer
           {:insets                            insets
            :scroll-to-bottom-fn               list.view/scroll-to-bottom
-           :show-floating-scroll-down-button? show-floating-scroll-down-button?}]
+           :show-floating-scroll-down-button? show-floating-scroll-down-button?
+           :message-list-rendered?            message-list-rendered?}]
          [contact-requests.bottom-drawer/view chat-id contact-request-state group-chat]))]))
 
 (defn chat
@@ -99,5 +101,6 @@
          :animate-topbar-name?              (reagent/atom false)
          :big-name-visible?                 (reagent/atom :initial-render)
          :animate-topbar-opacity?           (reagent/atom false)
-         :on-end-reached?                   (reagent/atom false)}]
+         :on-end-reached?                   (reagent/atom false)
+         :message-list-rendered?            (reagent/atom false)}]
     [:f> f-chat inner-state-atoms]))

--- a/src/status_im2/contexts/chat/messages/view.cljs
+++ b/src/status_im2/contexts/chat/messages/view.cljs
@@ -15,7 +15,7 @@
 
 (defn f-chat
   [{:keys [show-floating-scroll-down-button? animate-topbar-name?
-           big-name-visible? animate-topbar-opacity? on-end-reached? message-list-rendered?]
+           big-name-visible? animate-topbar-opacity? on-end-reached? messages-list-on-layout-finished?]
     :as   inner-state-atoms}]
   (let [insets                   (safe-area/get-insets)
         scroll-y                 (reanimated/use-shared-value 0)
@@ -53,19 +53,19 @@
       :keyboard-vertical-offset (- (:bottom insets))}
 
      [list.view/message-list-content-view
-      {:chat                    chat
-       :insets                  insets
-       :scroll-y                scroll-y
-       :content-height          content-height
-       :cover-bg-color          :turquoise
-       :keyboard-shown?         keyboard-shown
-       :inner-state-atoms       inner-state-atoms
-       :animate-topbar-name?    animate-topbar-name?
-       :big-name-visible?       big-name-visible?
-       :animate-topbar-opacity? animate-topbar-opacity?
-       :composer-active?        focused?
-       :on-end-reached?         on-end-reached?
-       :message-list-rendered?  message-list-rendered?}]
+      {:chat                              chat
+       :insets                            insets
+       :scroll-y                          scroll-y
+       :content-height                    content-height
+       :cover-bg-color                    :turquoise
+       :keyboard-shown?                   keyboard-shown
+       :inner-state-atoms                 inner-state-atoms
+       :animate-topbar-name?              animate-topbar-name?
+       :big-name-visible?                 big-name-visible?
+       :animate-topbar-opacity?           animate-topbar-opacity?
+       :composer-active?                  focused?
+       :on-end-reached?                   on-end-reached?
+       :messages-list-on-layout-finished? messages-list-on-layout-finished?}]
 
      [messages.navigation/navigation-view
       {:scroll-y                scroll-y
@@ -88,7 +88,7 @@
           {:insets                            insets
            :scroll-to-bottom-fn               list.view/scroll-to-bottom
            :show-floating-scroll-down-button? show-floating-scroll-down-button?
-           :message-list-rendered?            message-list-rendered?}]
+           :messages-list-on-layout-finished? messages-list-on-layout-finished?}]
          [contact-requests.bottom-drawer/view chat-id contact-request-state group-chat]))]))
 
 (defn chat
@@ -102,5 +102,5 @@
          :big-name-visible?                 (reagent/atom :initial-render)
          :animate-topbar-opacity?           (reagent/atom false)
          :on-end-reached?                   (reagent/atom false)
-         :message-list-rendered?            (reagent/atom false)}]
+         :messages-list-on-layout-finished? (reagent/atom false)}]
     [:f> f-chat inner-state-atoms]))


### PR DESCRIPTION
fixes #17825 

### Summary

Prevents composer from auto-focusing when opening a chat with edit/reply

status: ready