### PR TITLE
[#17518] fix: try again when sync has error outside the onboarding flow

### DIFF
--- a/src/status_im2/common/pairing/events.cljs
+++ b/src/status_im2/common/pairing/events.cljs
@@ -18,6 +18,8 @@
                                                 constants/local-pairing-event-connection-success)
                                              (= action
                                                 constants/local-pairing-action-connect))
+        connection-error?               (and (= type
+                                                constants/local-pairing-event-connection-error))
         error-on-pairing?               (contains? constants/local-pairing-event-errors type)
         completed-pairing?              (and (= type
                                                 constants/local-pairing-event-transfer-success)
@@ -30,8 +32,9 @@
                                              (and (some? account) (some? password)))
         multiaccount-data               (when received-account?
                                           (merge account {:password password}))
-        navigate-to-syncing-devices?    (and (or connection-success? error-on-pairing?) receiver?)
+        navigate-to-syncing-devices?    (and (or connection-success? connection-error?) receiver?)
         user-in-syncing-devices-screen? (or (= (:view-id db) :syncing-progress)
+                                            (= (:view-id db) :profiles)
                                             (= (:view-id db) :syncing-progress-intro))
         user-in-sign-in-intro-screen?   (= (:view-id db) :sign-in-intro)]
     (merge {:db (cond-> db


### PR DESCRIPTION
fixes #17518

### Summary

try again button logic is wrong when user is not in onboarding flow and also we shouldn't show the toast message when the 'Oops something went wrong' page is displayed

### Steps to test

1. User A: Generates a QR sync code (mobile or desktop user, no matter)
2. User B: Goes to Syncing -> tap [+] -> Scan or enter sync code (now the "Oops, something went wrong" screen is shown with 'logged in keyID not the same as keyUID in payload' error)
3. Tap 'try again' button


### Result

https://github.com/status-im/status-mobile/assets/71308738/3359e1f5-cf52-4e75-885b-a69697dff94d

status: ready
