### PR TITLE
local pair: check netIPs if empty before find server cert

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -4,6 +4,6 @@
     "owner": "status-im",
     "repo": "status-go",
     "version": "release/0.171.x",
-    "commit-sha1": "53fdb0bb3d3aa8d14b37f8b4ba312b33c95e591c",
-    "src-sha256": "046chjjii0d2w9racdsl2darkjfhfwzqmn90zzzb04x0k3rbx6sm"
+    "commit-sha1": "d700763232415c2d0f57e8c525c813523e3e0c66",
+    "src-sha256": "1agvd4iklw1kgsd80vlkp4bg9inm6x3xjsj9j0czm2whyh2zvhg3"
 }


### PR DESCRIPTION
fix relate [issue](https://github.com/status-im/status-mobile/issues/17634#issuecomment-1806768628)
with this PR we should see the error as screenshot shows when doing local pair and client/server are in different network.
<img width="437" alt="image" src="https://github.com/status-im/status-mobile/assets/12406719/6b9e1da2-4b10-44c5-8dbb-cfc783930ee2">

status: ready <!-- Can be ready or wip -->
