### PR TITLE
Fix: unable to join token-gated communities

### DIFF
--- a/src/status_im2/contexts/communities/overview/events.cljs
+++ b/src/status_im2/contexts/communities/overview/events.cljs
@@ -42,26 +42,31 @@
                                                community-id %])
                     :on-error   #(log/error "failed to request to join community" community-id %)}]})
 
+(defn request-to-join
+  [{:keys [db]} [{:keys [community-id password]}]]
+  (let [pub-key             (get-in db [:profile/profile :public-key])
+        addresses-to-reveal []]
+    {:fx [[:json-rpc/call
+           [{:method     "wakuext_generateJoiningCommunityRequestsForSigning"
+             :params     [pub-key community-id addresses-to-reveal]
+             :on-success [:communities/sign-data community-id password]
+             :on-error   [:communities/requested-to-join-error community-id]}]]]}))
+
 ;; Event to be called to request to join a community.
 ;; This event will generate the data to be signed and then call the sign-data event.
 ;; This is the only event that should be called from the UI.
-(rf/reg-event-fx :communities/request-to-join
- (fn [{:keys [db]} [{:keys [community-id password]}]]
-   (let [pub-key             (get-in db [:profile/profile :public-key])
-         addresses-to-reveal []]
-     {:fx [[:json-rpc/call
-            [{:method     "wakuext_generateJoiningCommunityRequestsForSigning"
-              :params     [pub-key community-id addresses-to-reveal]
-              :on-success [:communities/sign-data community-id password]
-              :on-error   [:communities/requested-to-join-error community-id]}]]]})))
+(rf/reg-event-fx :communities/request-to-join request-to-join)
 
-(rf/reg-event-fx :communities/sign-data
- (fn [_ [community-id password sign-params]]
-   {:fx [[:json-rpc/call
-          [{:method     "wakuext_signData"
-            :params     [(map #(assoc % :password password) sign-params)]
-            :on-success [:communities/request-to-join-with-signatures community-id]
-            :on-error   [:communities/requested-to-join-error community-id]}]]]}))
+(defn sign-data
+  [_ [community-id password sign-params]]
+  (let [addresses-to-reveal (map :account sign-params)]
+    {:fx [[:json-rpc/call
+           [{:method     "wakuext_signData"
+             :params     [(map #(assoc % :password password) sign-params)]
+             :on-success [:communities/request-to-join-with-signatures community-id addresses-to-reveal]
+             :on-error   [:communities/requested-to-join-error community-id]}]]]}))
+
+(rf/reg-event-fx :communities/sign-data sign-data)
 
 (rf/reg-event-fx :communities/requested-to-join-error
  (fn [{:keys [db]} [community-id error]]
@@ -71,11 +76,19 @@
                :event        :communities/requested-to-join-error})
    {:db (assoc-in db [:password-authentication :error] error)}))
 
-(rf/reg-event-fx :communities/request-to-join-with-signatures
- (fn [_ [community-id signatures]]
-   {:fx [[:json-rpc/call
-          [{:method      "wakuext_requestToJoinCommunity"
-            :params      [{:communityId community-id :signatures signatures}]
-            :js-response true
-            :on-success  [:communities/requested-to-join]
-            :on-error    [:communities/requested-to-join-error community-id]}]]]}))
+(defn request-to-join-with-signatures
+  [_ [community-id addresses-to-reveal signatures]]
+  {:fx [[:json-rpc/call
+         [{:method      "wakuext_requestToJoinCommunity"
+           :params      [{:communityId       community-id
+                          :signatures        signatures
+                          :addressesToReveal addresses-to-reveal
+                          ;; NOTE: At least one airdrop address is required.
+                          ;; This is a temporary solution while the address
+                          ;; selection feature is not implemented in mobile.
+                          :airdropAddress    (first addresses-to-reveal)}]
+           :js-response true
+           :on-success  [:communities/requested-to-join]
+           :on-error    [:communities/requested-to-join-error community-id]}]]]})
+
+(rf/reg-event-fx :communities/request-to-join-with-signatures request-to-join-with-signatures)

--- a/src/status_im2/contexts/communities/overview/events_test.cljs
+++ b/src/status_im2/contexts/communities/overview/events_test.cljs
@@ -1,0 +1,53 @@
+(ns status-im2.contexts.communities.overview.events-test
+  (:require [cljs.test :refer [deftest is]]
+            [native-module.core :as native-module]
+            [status-im2.contexts.communities.overview.events :as sut]))
+
+(def password (native-module/sha3 "password123"))
+(def community-id "0x99")
+(def account-pub-key "0x1")
+
+(deftest request-to-join-test
+  (let [cofx     {:db {:profile/profile {:public-key account-pub-key}}}
+        expected {:fx [[:json-rpc/call
+                        [{:method     "wakuext_generateJoiningCommunityRequestsForSigning"
+                          :params     [account-pub-key community-id []]
+                          :on-success [:communities/sign-data community-id password]
+                          :on-error   [:communities/requested-to-join-error community-id]}]]]}]
+    (is (= expected
+           (sut/request-to-join cofx
+                                [{:community-id community-id
+                                  :password     password}])))))
+
+(deftest sign-data-test
+  (let [cofx                {:db {}}
+        sign-params         [{:data "123" :account account-pub-key}
+                             {:data "456" :account "0x2"}]
+        addresses-to-reveal [account-pub-key "0x2"]
+        expected            {:fx
+                             [[:json-rpc/call
+                               [{:method     "wakuext_signData"
+                                 :params     [[{:data "123" :account account-pub-key :password password}
+                                               {:data "456" :account "0x2" :password password}]]
+                                 :on-success [:communities/request-to-join-with-signatures
+                                              community-id addresses-to-reveal]
+                                 :on-error   [:communities/requested-to-join-error community-id]}]]]}]
+    (is (= expected
+           (sut/sign-data cofx [community-id password sign-params])))))
+
+(deftest request-to-join-with-signatures-test
+  (let [cofx                {:db {}}
+        addresses-to-reveal [account-pub-key "0x2"]
+        signatures          ["11111" "222222"]
+        expected            {:fx [[:json-rpc/call
+                                   [{:method      "wakuext_requestToJoinCommunity"
+                                     :params      [{:communityId       community-id
+                                                    :signatures        signatures
+                                                    :addressesToReveal addresses-to-reveal
+                                                    :airdropAddress    "0x1"}]
+                                     :js-response true
+                                     :on-success  [:communities/requested-to-join]
+                                     :on-error    [:communities/requested-to-join-error
+                                                   community-id]}]]]}]
+    (is (= expected
+           (sut/request-to-join-with-signatures cofx [community-id addresses-to-reveal signatures])))))


### PR DESCRIPTION
Fixes https://github.com/status-im/status-mobile/issues/17861

### Summary

For unknown reasons, a few days after PR https://github.com/status-im/status-mobile/pull/17800 was properly QAed & merged, we started to not be able to join token-gated communities.

This PR fixes the bug by explicitly passing all the available addresses to be revealed to `wakuext_requestToJoinCommunity` and picking up the first available address as the airdrop address. This is a temporary solution while we work on the feature to allow users to choose which address to expose (see [Figma page](https://www.figma.com/file/h9wo4GipgZURbqqr1vShFN/Communities-for-Mobile?type=design&node-id=15331-288172&mode=design&t=FQjDSIIUAoDhCS2V-0)).

This solution was devised with @FFFra and @cammellos.

#### Fixed demo

[fixed.webm](https://github.com/status-im/status-mobile/assets/46027/9794a456-3ee5-4231-bece-ca402fee6d42)

#### Areas that may be impacted

Join community flows.

### Steps to test

Follow the reproduction steps in the issue.

**Verified cases**

```
Community "Request to join" option is enabled.
User holds more than X ETH.
Anyone who holds <X> ETH is allowed to Become member in <COMMUNITY>.

Expected: request to join is received by desktop client and accepted,
mobile user joins the community.
```

```
Community "Request to join" option is enabled.
User holds less than X ETH.
Anyone who holds <X> ETH is allowed to View and post in <CHANNEL>.

Expected: request to join is received by desktop client and accepted, mobile
user joins the community, but can't post in <CHANNEL>.
```

```
Community "Request to join" option is enabled.
No token permissions.

Expected: request to join is received by desktop client and accepted,
mobile user joins the community.
```

status: ready
