### PR TITLE
Communities - Channel list should not be shown for token-gated communities

### DIFF
--- a/src/status_im2/contexts/communities/overview/view.cljs
+++ b/src/status_im2/contexts/communities/overview/view.cljs
@@ -255,7 +255,7 @@
 (defn community-content
   [community]
   (rf/dispatch [:communities/check-all-community-channels-permissions (:id community)])
-  (fn [{:keys [name description joined images tags color id] :as community}
+  (fn [{:keys [name description joined images tags color id token-permissions] :as community}
        pending?
        {:keys [on-category-layout
                collapsed?
@@ -273,12 +273,14 @@
             :last-item-style style/last-community-tag
             :container-style style/community-tag-container}])
         [join-community community pending?]]
-       [channel-list-component
-        {:on-category-layout              on-category-layout
-         :community-id                    id
-         :community-color                 color
-         :on-first-channel-height-changed on-first-channel-height-changed}
-        (add-handlers-to-categorized-chats id chats-by-category joined)]])))
+       (when (or (and (seq token-permissions) joined)
+                 (empty? token-permissions))
+         [channel-list-component
+          {:on-category-layout              on-category-layout
+           :community-id                    id
+           :community-color                 color
+           :on-first-channel-height-changed on-first-channel-height-changed}
+          (add-handlers-to-categorized-chats id chats-by-category joined)])])))
 
 (defn sticky-category-header
   [_]


### PR DESCRIPTION
fix: #17836

Figma design: 

https://www.figma.com/file/h9wo4GipgZURbqqr1vShFN/Communities-for-Mobile?type=design&node-id=14009-569565&mode=design&t=CYSZhcyPISfU2ds1-0

### Demo

https://github.com/status-im/status-mobile/assets/5999878/f33452bc-e85e-4279-97b1-3d9e82837a20

### Summary
#### This approach only displays the channels if the conditions are satisfied.  

#### Platforms

- Android
- iOS


status: ready