### PR TITLE
fix: theming toast component

### DIFF
--- a/src/quo/components/notifications/toast/style.cljs
+++ b/src/quo/components/notifications/toast/style.cljs
@@ -38,8 +38,14 @@
   {:color (colors/theme-colors colors/white colors/neutral-100 theme)})
 
 (defn icon
-  [theme]
-  {:color           (colors/theme-colors colors/white colors/neutral-100 theme)
+  [type theme]
+  {:color           (condp = type
+                      :negative (colors/resolve-color :danger theme)
+                      :positive (colors/resolve-color :success theme)
+                      (colors/theme-colors colors/white-opa-40
+                                           colors/neutral-80-opa-40
+                                           theme)
+                    )
    :container-style {:width 20 :height 20}})
 
 (def left-side-container {:padding 2})

--- a/src/quo/components/notifications/toast/style.cljs
+++ b/src/quo/components/notifications/toast/style.cljs
@@ -38,14 +38,13 @@
   {:color (colors/theme-colors colors/white colors/neutral-100 theme)})
 
 (defn icon
-  [type theme]
-  {:color           (condp = type
+  [toast-type theme]
+  {:color           (case toast-type
                       :negative (colors/resolve-color :danger theme)
                       :positive (colors/resolve-color :success theme)
-                      (colors/theme-colors colors/white-opa-40
-                                           colors/neutral-80-opa-40
-                                           theme)
-                    )
+                      :neutral  (colors/theme-colors colors/white-opa-40
+                                                     colors/neutral-80-opa-40
+                                                     theme))
    :container-style {:width 20 :height 20}})
 
 (def left-side-container {:padding 2})

--- a/src/quo/components/notifications/toast/view.cljs
+++ b/src/quo/components/notifications/toast/view.cljs
@@ -77,15 +77,16 @@
     :or   {type :neutral}}]
   (let [context-theme (or theme (quo.theme/get-theme))
         icon-name     (case type
-                        :positive :i/incorrect
-                        :negative :i/correct
+                        :positive :i/correct
+                        :negative :i/incorrect
                         :neutral  :i/placeholder)]
     [quo.theme/provider {:theme context-theme}
      [toast-container
-      {:left            (cond icon-name
+      {:left            (cond user
+                              [user-avatar/user-avatar user]
+                              icon-name
                               [icon/icon icon-name (style/icon type context-theme)]
-                              user
-                              [user-avatar/user-avatar user])
+                        )
        :title           title
        :text            text
        :right           (if undo-duration

--- a/src/quo/components/notifications/toast/view.cljs
+++ b/src/quo/components/notifications/toast/view.cljs
@@ -77,9 +77,9 @@
     :or   {type :neutral}}]
   (let [context-theme (or theme (quo.theme/get-theme))
         icon-name     (case type
-                        :positive "incorrect"
-                        :negative "correct"
-                        :neutral  "placeholder")]
+                        :positive :i/incorrect
+                        :negative :i/correct
+                        :neutral  :i/placeholder)]
     [quo.theme/provider {:theme context-theme}
      [toast-container
       {:left            (cond icon-name

--- a/src/quo/components/notifications/toast/view.cljs
+++ b/src/quo/components/notifications/toast/view.cljs
@@ -73,13 +73,17 @@
    
    :type => :neutral/:negative/:positive
    "
-  [{:keys [icon type title text action undo-duration undo-on-press container-style theme user]
+  [{:keys [type title text action undo-duration undo-on-press container-style theme user]
     :or   {type :neutral}}]
-  (let [context-theme (or theme (quo.theme/get-theme))]
+  (let [context-theme (or theme (quo.theme/get-theme))
+        icon-name     (case type
+                        :positive "incorrect"
+                        :negative "correct"
+                        :neutral  "placeholder")]
     [quo.theme/provider {:theme context-theme}
      [toast-container
-      {:left            (cond icon
-                              [icon/icon icon (style/icon type context-theme)]
+      {:left            (cond icon-name
+                              [icon/icon icon-name (style/icon type context-theme)]
                               user
                               [user-avatar/user-avatar user])
        :title           title

--- a/src/quo/components/notifications/toast/view.cljs
+++ b/src/quo/components/notifications/toast/view.cljs
@@ -73,13 +73,13 @@
    
    :type => :neutral/:negative/:positive
    "
-  [{:keys [type title text action undo-duration undo-on-press container-style theme user]
-    :or   {type :neutral}}]
+  [{:keys [type icon title text action undo-duration undo-on-press container-style theme user]
+    :or   {type :neutral icon :i/placeholder}}]
   (let [context-theme (or theme (quo.theme/get-theme))
         icon-name     (case type
                         :positive :i/correct
                         :negative :i/incorrect
-                        :neutral  :i/placeholder)]
+                        :neutral  icon)]
     [quo.theme/provider {:theme context-theme}
      [toast-container
       {:left            (cond user

--- a/src/quo/components/notifications/toast/view.cljs
+++ b/src/quo/components/notifications/toast/view.cljs
@@ -69,15 +69,17 @@
 (def ^:private toast-container (quo.theme/with-theme toast-container-internal))
 
 (defn toast
-  [{:keys [icon icon-color title text action undo-duration undo-on-press container-style theme user]}]
+  "Options:
+   
+   :type => :neutral/:negative/:positive
+   "
+  [{:keys [icon type title text action undo-duration undo-on-press container-style theme user]
+    :or   {type :neutral}}]
   (let [context-theme (or theme (quo.theme/get-theme))]
     [quo.theme/provider {:theme context-theme}
      [toast-container
       {:left            (cond icon
-                              [icon/icon icon
-                               (cond-> (style/icon context-theme)
-                                 icon-color
-                                 (assoc :color icon-color))]
+                              [icon/icon icon (style/icon type context-theme)]
                               user
                               [user-avatar/user-avatar user])
        :title           title

--- a/src/quo/core_spec.cljs
+++ b/src/quo/core_spec.cljs
@@ -1,5 +1,10 @@
 (ns quo.core-spec
-  (:require
+  (:require ;; [quo.components.list-items.account.component-spec]
+    ;; [quo.components.list-items.address.component-spec]
+    ;; [quo.components.list-items.saved-address.component-spec]
+    ;; [quo.components.list-items.saved-contact-address.component-spec]
+    ;; [quo.components.list-items.saved-contact-address.component-spec]
+    ;; [quo.components.list-items.token-network.component-spec]
     [quo.components.avatars.account-avatar.component-spec]
     [quo.components.avatars.user-avatar.component-spec]
     [quo.components.banners.banner.component-spec]

--- a/src/status_im/common/device_permissions.cljs
+++ b/src/status_im/common/device_permissions.cljs
@@ -1,6 +1,5 @@
 (ns status-im.common.device-permissions
   (:require
-    [quo.foundations.colors :as colors]
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]))
 
@@ -12,7 +11,7 @@
      :on-allowed  on-allowed
      :on-denied   #(rf/dispatch
                     [:toasts/upsert
-                     {:icon       :i/info
-                      :icon-color colors/danger-50
-                      :theme      :dark
-                      :text       (i18n/label :t/camera-permission-denied)}])}]))
+                     {:icon  :i/info
+                      :type  :negative
+                      :theme :dark
+                      :text  (i18n/label :t/camera-permission-denied)}])}]))

--- a/src/status_im/common/device_permissions.cljs
+++ b/src/status_im/common/device_permissions.cljs
@@ -11,7 +11,6 @@
      :on-allowed  on-allowed
      :on-denied   #(rf/dispatch
                     [:toasts/upsert
-                     {:icon  :i/info
-                      :type  :negative
+                     {:type  :negative
                       :theme :dark
                       :text  (i18n/label :t/camera-permission-denied)}])}]))

--- a/src/status_im/common/home/actions/view.cljs
+++ b/src/status_im/common/home/actions/view.cljs
@@ -2,7 +2,6 @@
   (:require
     [clojure.string :as string]
     [quo.core :as quo]
-    [quo.foundations.colors :as colors]
     [status-im.common.confirmation-drawer.view :as confirmation-drawer]
     [status-im.common.mute-drawer.view :as mute-drawer]
     [status-im.common.muting.helpers :refer [format-mute-till]]
@@ -221,13 +220,11 @@
                                (do
                                  (rf/dispatch [:hide-bottom-sheet])
                                  (rf/dispatch [:toasts/upsert
-                                               {:id         :remove-nickname
-                                                :icon       :i/correct
-                                                :icon-color (colors/theme-colors colors/success-60
-                                                                                 colors/success-50)
-                                                :text       (i18n/label
-                                                             :t/remove-nickname-toast
-                                                             {:secondary-name secondary-name})}])
+                                               {:id   :remove-nickname
+                                                :type :positive
+                                                :text (i18n/label
+                                                       :t/remove-nickname-toast
+                                                       {:secondary-name secondary-name})}])
                                  (rf/dispatch [:contacts/update-nickname public-key ""]))))
       :danger?             false
       :accessibility-label :add-nickname

--- a/src/status_im/common/pairing/events.cljs
+++ b/src/status_im/common/pairing/events.cljs
@@ -1,6 +1,5 @@
 (ns status-im.common.pairing.events
   (:require
-    [quo.foundations.colors :as colors]
     [status-im.constants :as constants]
     [status-im.contexts.communities.discover.events]
     [taoensso.timbre :as log]
@@ -63,6 +62,5 @@
 
              (and error-on-pairing? (some? error))
              {:dispatch [:toasts/upsert
-                         {:icon       :i/alert
-                          :icon-color colors/danger-50
-                          :text       error}]}))))
+                         {:type :negative
+                          :text error}]}))))

--- a/src/status_im/common/scan_qr_code/view.cljs
+++ b/src/status_im/common/scan_qr_code/view.cljs
@@ -141,8 +141,7 @@
         (on-failed-scan)
         (debounce/debounce-and-dispatch
          [:toasts/upsert
-          {:icon  :i/info
-           :type  :negative
+          {:type  :negative
            :theme :dark
            :text  error-message}]
          300)))))

--- a/src/status_im/common/scan_qr_code/view.cljs
+++ b/src/status_im/common/scan_qr_code/view.cljs
@@ -141,10 +141,10 @@
         (on-failed-scan)
         (debounce/debounce-and-dispatch
          [:toasts/upsert
-          {:icon       :i/info
-           :icon-color colors/danger-50
-           :theme      :dark
-           :text       error-message}]
+          {:icon  :i/info
+           :type  :negative
+           :theme :dark
+           :text  error-message}]
          300)))))
 
 (defn- render-camera

--- a/src/status_im/contexts/chat/composer/actions/view.cljs
+++ b/src/status_im/contexts/chat/composer/actions/view.cljs
@@ -160,7 +160,6 @@
   []
   (rf/dispatch [:toasts/upsert
                 {:id              :random-id
-                 :icon            :info
                  :type            :negative
                  :container-style {:top (when platform/ios? 20)}
                  :text            (i18n/label :t/only-6-images)}]))

--- a/src/status_im/contexts/chat/composer/actions/view.cljs
+++ b/src/status_im/contexts/chat/composer/actions/view.cljs
@@ -1,7 +1,6 @@
 (ns status-im.contexts.chat.composer.actions.view
   (:require
     [quo.core :as quo]
-    [quo.foundations.colors :as colors]
     [react-native.core :as rn]
     [react-native.permissions :as permissions]
     [react-native.platform :as platform]
@@ -162,7 +161,7 @@
   (rf/dispatch [:toasts/upsert
                 {:id              :random-id
                  :icon            :info
-                 :icon-color      colors/danger-50-opa-40
+                 :type            :negative
                  :container-style {:top (when platform/ios? 20)}
                  :text            (i18n/label :t/only-6-images)}]))
 

--- a/src/status_im/contexts/chat/events.cljs
+++ b/src/status_im/contexts/chat/events.cljs
@@ -3,7 +3,6 @@
     [clojure.set :as set]
     [legacy.status-im.chat.models.loading :as loading]
     [legacy.status-im.data-store.chats :as chats-store]
-    [quo.foundations.colors :as colors]
     [re-frame.core :as re-frame]
     [reagent.core :as reagent]
     [status-im.common.muting.helpers :refer [format-mute-till]]
@@ -350,11 +349,9 @@
                           :t/channel-unmuted-successfully))))]
     {:db       (assoc-in db [:chats chat-id :muted-till] muted-till)
      :dispatch [:toasts/upsert
-                {:icon       :i/correct
-                 :icon-color (colors/theme-colors colors/success-60
-                                                  colors/success-50)
-                 :text       (mute-duration-text (when (some? muted-till)
-                                                   (str (format-mute-till muted-till))))}]}))
+                {:type :positive
+                 :text (mute-duration-text (when (some? muted-till)
+                                             (str (format-mute-till muted-till))))}]}))
 
 (rf/defn mute-chat
   {:events [:chat.ui/mute]}

--- a/src/status_im/contexts/chat/lightbox/top_view.cljs
+++ b/src/status_im/contexts/chat/lightbox/top_view.cljs
@@ -56,8 +56,7 @@
                                  uri
                                  #(rf/dispatch [:toasts/upsert
                                                 {:id              :random-id
-                                                 :icon            :i/correct
-                                                 :icon-color      colors/success-50
+                                                 :type            :positive
                                                  :container-style {:bottom (when platform/android? 20)}
                                                  :text            (i18n/label :t/photo-saved)}])]))}]]]))
 

--- a/src/status_im/contexts/chat/messages/delete_message/events.cljs
+++ b/src/status_im/contexts/chat/messages/delete_message/events.cljs
@@ -73,9 +73,8 @@
   {:events [:chat.ui/delete-message]}
   [{:keys [db]} {:keys [chat-id message-id]} undo-time-limit-ms]
   (when-let [message (get-in db [:messages chat-id message-id])]
-    ;; all delete message toast are the same toast with id :delete-message-for-everyone
-    ;; new delete operation will reset prev pending deletes' undo timelimit
-    ;; undo will undo all pending deletes
+    ;; all delete message toast are the same toast with id :delete-message-for-everyone new delete
+    ;; operation will reset prev pending deletes' undo timelimit undo will undo all pending deletes
     ;; all pending deletes are stored in toast
     (let [unpin? (should-and-able-to-unpin-to-be-deleted-message
                   db
@@ -164,9 +163,8 @@
   (when-let [message (get-in db [:messages chat-id message-id])]
     (when (or force? (check-before-delete-and-send db chat-id message-id))
       (let [unpin-locally?
-            ;; this only check against local client data
-            ;; generally msg is already unpinned at delete locally phase when user
-            ;; has unpin permission
+            ;; this only check against local client data generally msg is already unpinned at delete
+            ;; locally phase when user has unpin permission
             ;;
             ;; will be true only if
             ;; 1. admin delete an unpinned msg

--- a/src/status_im/contexts/chat/messages/delete_message/events.cljs
+++ b/src/status_im/contexts/chat/messages/delete_message/events.cljs
@@ -1,6 +1,5 @@
 (ns status-im.contexts.chat.messages.delete-message.events
   (:require
-    [quo.foundations.colors :as colors]
     [status-im.contexts.chat.messages.list.events :as message-list]
     [taoensso.timbre :as log]
     [utils.datetime :as datetime]
@@ -106,8 +105,7 @@
        [[:toasts/close :delete-message-for-everyone]
         [:toasts/upsert
          {:id                                 :delete-message-for-everyone
-          :icon                               :i/info
-          :icon-color                         colors/danger-50-opa-40
+          :type                               :negative
           :message-deleted-for-everyone-count toast-count
           :message-deleted-for-everyone-undos existing-undos
           :text                               (i18n/label-pluralize

--- a/src/status_im/contexts/chat/messages/delete_message_for_me/events.cljs
+++ b/src/status_im/contexts/chat/messages/delete_message_for_me/events.cljs
@@ -1,6 +1,5 @@
 (ns status-im.contexts.chat.messages.delete-message-for-me.events
   (:require
-    [quo.foundations.colors :as colors]
     [status-im.contexts.chat.messages.list.events :as message-list]
     [taoensso.timbre :as log]
     [utils.datetime :as datetime]
@@ -62,8 +61,7 @@
        :dispatch-n           [[:toasts/close :delete-message-for-me]
                               [:toasts/upsert
                                {:id :delete-message-for-me
-                                :icon :i/info
-                                :icon-color colors/danger-50-opa-40
+                                :type :negative
                                 :message-deleted-for-me-count toast-count
                                 :message-deleted-for-me-undos existing-undos
                                 :text (i18n/label-pluralize toast-count

--- a/src/status_im/contexts/chat/messages/pin/events.cljs
+++ b/src/status_im/contexts/chat/messages/pin/events.cljs
@@ -2,7 +2,6 @@
   (:require
     [legacy.status-im.data-store.messages :as data-store.messages]
     [legacy.status-im.data-store.pin-messages :as data-store.pin-messages]
-    [quo.foundations.colors :as colors]
     [re-frame.core :as re-frame]
     [status-im.common.toasts.events :as toasts]
     [status-im.constants :as constants]
@@ -123,9 +122,8 @@
   {:events [:pin-message/show-pin-limit-modal]}
   [cofx]
   (toasts/upsert cofx
-                 {:icon       :alert
-                  :icon-color colors/danger-50
-                  :text       (i18n/label :t/pin-limit-reached)}))
+                 {:type :negative
+                  :text (i18n/label :t/pin-limit-reached)}))
 
 (rf/defn show-pins-bottom-sheet
   {:events [:pin-message/show-pins-bottom-sheet]}

--- a/src/status_im/contexts/chat/photo_selector/view.cljs
+++ b/src/status_im/contexts/chat/photo_selector/view.cljs
@@ -1,7 +1,6 @@
 (ns status-im.contexts.chat.photo-selector.view
   (:require
     [quo.core :as quo]
-    [quo.foundations.colors :as colors]
     [react-native.core :as rn]
     [react-native.gesture :as gesture]
     [react-native.linear-gradient :as linear-gradient]
@@ -23,7 +22,7 @@
   (rf/dispatch [:toasts/upsert
                 {:id              :random-id
                  :icon            :i/info
-                 :icon-color      colors/danger-50-opa-40
+                 :type            :negative
                  :container-style {:top (when platform/ios? 20)}
                  :text            (i18n/label :t/only-6-images)}]))
 

--- a/src/status_im/contexts/chat/photo_selector/view.cljs
+++ b/src/status_im/contexts/chat/photo_selector/view.cljs
@@ -21,7 +21,6 @@
   []
   (rf/dispatch [:toasts/upsert
                 {:id              :random-id
-                 :icon            :i/info
                  :type            :negative
                  :container-style {:top (when platform/ios? 20)}
                  :text            (i18n/label :t/only-6-images)}]))

--- a/src/status_im/contexts/communities/actions/community_options/events.cljs
+++ b/src/status_im/contexts/communities/actions/community_options/events.cljs
@@ -1,6 +1,5 @@
 (ns status-im.contexts.communities.actions.community-options.events
-  (:require [quo.foundations.colors :as quo.colors]
-            [status-im.common.muting.helpers :as muting.helpers]
+  (:require [status-im.common.muting.helpers :as muting.helpers]
             [taoensso.timbre :as log]
             [utils.i18n :as i18n]
             [utils.re-frame :as rf]))
@@ -26,13 +25,12 @@
      {:db         (assoc-in db [:communities community-id :muted-till] muted-till)
       :dispatch-n [[:community/update-community-chats-mute-status community-id muted? muted-till]
                    [:toasts/upsert
-                    {:icon       :correct
-                     :icon-color (quo.colors/theme-colors quo.colors/success-60 quo.colors/success-50)
-                     :text       (if muted?
-                                   (when (some? muted-till)
-                                     (time-string :t/muted-until
-                                                  (muting.helpers/format-mute-till muted-till)))
-                                   (i18n/label :t/community-unmuted))}]]})))
+                    {:type :positive
+                     :text (if muted?
+                             (when (some? muted-till)
+                               (time-string :t/muted-until
+                                            (muting.helpers/format-mute-till muted-till)))
+                             (i18n/label :t/community-unmuted))}]]})))
 
 (rf/reg-event-fx :community/set-muted
  (fn [{:keys [db]} [community-id muted? muted-type]]

--- a/src/status_im/contexts/communities/actions/leave/events.cljs
+++ b/src/status_im/contexts/communities/actions/leave/events.cljs
@@ -1,6 +1,5 @@
 (ns status-im.contexts.communities.actions.leave.events
-  (:require [legacy.status-im.ui.components.colors :as colors]
-            [taoensso.timbre :as log]
+  (:require [taoensso.timbre :as log]
             [utils.i18n :as i18n]
             [utils.re-frame :as rf]))
 
@@ -9,9 +8,8 @@
    {:fx [[:dispatch [:sanitize-messages-and-process-response response-js]]
          [:dispatch
           [:toasts/upsert
-           {:icon       :correct
-            :icon-color (:positive-01 @colors/theme)
-            :text       (i18n/label :t/you-canceled-the-request)}]]]}))
+           {:type :positive
+            :text (i18n/label :t/you-canceled-the-request)}]]]}))
 
 (rf/reg-event-fx :communities/cancel-request-to-join
  (fn [_ [request-to-join-id]]
@@ -28,9 +26,8 @@
      {:fx [[:dispatch [:sanitize-messages-and-process-response response-js]]
            [:dispatch
             [:toasts/upsert
-             {:icon       :correct
-              :icon-color (:positive-01 @colors/theme)
-              :text       (i18n/label :t/left-community {:community community-name})}]]
+             {:type :positive
+              :text (i18n/label :t/left-community {:community community-name})}]]
            [:dispatch [:activity-center.notifications/fetch-unread-count]]
            [:dispatch [:navigate-back]]]})))
 

--- a/src/status_im/contexts/communities/events.cljs
+++ b/src/status_im/contexts/communities/events.cljs
@@ -1,7 +1,6 @@
 (ns status-im.contexts.communities.events
   (:require [clojure.set :as set]
             [clojure.walk :as walk]
-            [legacy.status-im.ui.components.colors :as colors]
             [status-im.constants :as constants]
             status-im.contexts.communities.actions.community-options.events
             status-im.contexts.communities.actions.leave.events
@@ -93,10 +92,9 @@
           (assoc-in db [:communities/my-pending-requests-to-join community-id] request)
           (and (= constants/community-request-to-join-state-accepted state) (not deleted))
           (do (rf/dispatch [:toasts/upsert
-                            {:icon       :i/correct
-                             :id         :joined-community
-                             :icon-color (:positive-01 @colors/theme)
-                             :text       (i18n/label :t/joined-community {:community name})}])
+                            {:id   :joined-community
+                             :type :positive
+                             :text (i18n/label :t/joined-community {:community name})}])
               (update-in db [:communities/my-pending-requests-to-join] dissoc community-id))
           :else (update-in db [:communities/my-pending-requests-to-join] dissoc community-id))))
 

--- a/src/status_im/contexts/communities/overview/events.cljs
+++ b/src/status_im/contexts/communities/overview/events.cljs
@@ -1,7 +1,6 @@
 (ns status-im.contexts.communities.overview.events
   (:require
     [legacy.status-im.data-store.communities :as data-store]
-    [legacy.status-im.ui.components.colors :as colors]
     [taoensso.timbre :as log]
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]))
@@ -104,11 +103,10 @@
            [:dispatch [:hide-bottom-sheet]]
            [:dispatch
             [:toasts/upsert
-             {:icon       :correct
-              :icon-color (:positive-01 @colors/theme)
-              :text       (i18n/label
-                           :t/requested-to-join-community
-                           {:community community-name})}]]]})))
+             {:type :positive
+              :text (i18n/label
+                     :t/requested-to-join-community
+                     {:community community-name})}]]]})))
 
 (defn request-to-join-with-signatures
   [_ [community-id addresses-to-reveal signatures]]

--- a/src/status_im/contexts/contacts/drawers/nickname_drawer/view.cljs
+++ b/src/status_im/contexts/contacts/drawers/nickname_drawer/view.cljs
@@ -17,7 +17,6 @@
     (rf/dispatch [:hide-bottom-sheet])
     (rf/dispatch [:toasts/upsert
                   {:id   :add-nickname
-                   :icon :i/correct
                    :type :positive
                    :text (i18n/label
                           :t/set-nickname-toast

--- a/src/status_im/contexts/contacts/drawers/nickname_drawer/view.cljs
+++ b/src/status_im/contexts/contacts/drawers/nickname_drawer/view.cljs
@@ -16,13 +16,13 @@
   (when-not (string/blank? entered-nickname)
     (rf/dispatch [:hide-bottom-sheet])
     (rf/dispatch [:toasts/upsert
-                  {:id         :add-nickname
-                   :icon       :i/correct
-                   :icon-color (colors/theme-colors colors/success-60 colors/success-50)
-                   :text       (i18n/label
-                                :t/set-nickname-toast
-                                {:primary-name primary-name
-                                 :nickname     (string/trim entered-nickname)})}])
+                  {:id   :add-nickname
+                   :icon :i/correct
+                   :type :positive
+                   :text (i18n/label
+                          :t/set-nickname-toast
+                          {:primary-name primary-name
+                           :nickname     (string/trim entered-nickname)})}])
     (rf/dispatch [:contacts/update-nickname public-key (string/trim entered-nickname)])))
 
 (defn nickname-drawer

--- a/src/status_im/contexts/quo_preview/notifications/toast.cljs
+++ b/src/status_im/contexts/quo_preview/notifications/toast.cljs
@@ -24,21 +24,19 @@
   []
   [toast-button
    "Toast: basic"
-   {:icon :placeholder :text "This is an example toast"}])
+   {:text "This is an example toast"}])
 
 (defn toast-button-with-undo-action
   []
   [toast-button
    "Toast: with undo action"
-   {:icon          :info
-    :type          :negative
+   {:type          :negative
     :text          "This is an example toast"
     :duration      4000
     :undo-duration 4
     :undo-on-press #(do
                       (rf/dispatch [:toasts/upsert
-                                    {:icon :i/correct
-                                     :type :success
+                                    {:type :success
                                      :text "Undo pressed"}])
                       (rf/dispatch [:toasts/close
                                     "Toast: with undo action"]))}])
@@ -47,8 +45,7 @@
   []
   [toast-button
    "Toast: multiline"
-   {:icon :correct
-    :type :positive
+   {:type :positive
     :text
     "This is an example multiline toast This is an example multiline toast This is an example multiline toast"
     :undo-duration 4
@@ -56,15 +53,14 @@
     #(do
        (rf/dispatch
         [:toasts/upsert
-         {:icon :i/correct :type :positive :text "Undo pressed"}])
+         {:type :positive :text "Undo pressed"}])
        (rf/dispatch [:toasts/close "Toast: with undo action"]))}])
 
 (defn toast-button-30s-duration
   []
   [toast-button
    "Toast: 30s duration"
-   {:icon     :correct
-    :type     :positive
+   {:type     :positive
     :text     "This is an example toast"
     :duration 30000}])
 
@@ -89,7 +85,6 @@
              #(rf/dispatch
                [:toasts/upsert
                 {:id       "Toast: 30s duration"
-                 :icon     :i/info
                  :type     :negative
                  :text     (str "This is an updated example toast" " - " (swap! suffix inc))
                  :duration 3000}])}

--- a/src/status_im/contexts/quo_preview/notifications/toast.cljs
+++ b/src/status_im/contexts/quo_preview/notifications/toast.cljs
@@ -1,7 +1,6 @@
 (ns status-im.contexts.quo-preview.notifications.toast
   (:require
     [quo.core :as quo]
-    [quo.foundations.colors :as colors]
     [react-native.core :as rn]
     [reagent.core :as reagent]
     [status-im.common.resources :as resources]
@@ -25,22 +24,22 @@
   []
   [toast-button
    "Toast: basic"
-   {:icon :placeholder :icon-color "white" :text "This is an example toast"}])
+   {:icon :placeholder :text "This is an example toast"}])
 
 (defn toast-button-with-undo-action
   []
   [toast-button
    "Toast: with undo action"
    {:icon          :info
-    :icon-color    colors/danger-50-opa-40
+    :type          :negative
     :text          "This is an example toast"
     :duration      4000
     :undo-duration 4
     :undo-on-press #(do
                       (rf/dispatch [:toasts/upsert
-                                    {:icon       :i/correct
-                                     :icon-color colors/success-50-opa-40
-                                     :text       "Undo pressed"}])
+                                    {:icon :i/correct
+                                     :type :success
+                                     :text "Undo pressed"}])
                       (rf/dispatch [:toasts/close
                                     "Toast: with undo action"]))}])
 
@@ -49,7 +48,7 @@
   [toast-button
    "Toast: multiline"
    {:icon :correct
-    :icon-color colors/success-50-opa-40
+    :type :positive
     :text
     "This is an example multiline toast This is an example multiline toast This is an example multiline toast"
     :undo-duration 4
@@ -57,17 +56,17 @@
     #(do
        (rf/dispatch
         [:toasts/upsert
-         {:icon :i/correct :icon-color colors/success-50-opa-40 :text "Undo pressed"}])
+         {:icon :i/correct :type :positive :text "Undo pressed"}])
        (rf/dispatch [:toasts/close "Toast: with undo action"]))}])
 
 (defn toast-button-30s-duration
   []
   [toast-button
    "Toast: 30s duration"
-   {:icon       :correct
-    :icon-color colors/success-50-opa-40
-    :text       "This is an example toast"
-    :duration   30000}])
+   {:icon     :correct
+    :type     :positive
+    :text     "This is an example toast"
+    :duration 30000}])
 
 (defn toast-button-with-user-avatar
   []
@@ -89,11 +88,11 @@
              :on-press
              #(rf/dispatch
                [:toasts/upsert
-                {:id         "Toast: 30s duration"
-                 :icon       :i/info
-                 :icon-color colors/danger-50-opa-40
-                 :text       (str "This is an updated example toast" " - " (swap! suffix inc))
-                 :duration   3000}])}
+                {:id       "Toast: 30s duration"
+                 :icon     :i/info
+                 :type     :negative
+                 :text     (str "This is an updated example toast" " - " (swap! suffix inc))
+                 :duration 3000}])}
             "update above toast"]])))))
 
 (defn view

--- a/src/status_im/contexts/quo_preview/notifications/toast.cljs
+++ b/src/status_im/contexts/quo_preview/notifications/toast.cljs
@@ -36,7 +36,7 @@
     :undo-duration 4
     :undo-on-press #(do
                       (rf/dispatch [:toasts/upsert
-                                    {:type :success
+                                    {:type :positive
                                      :text "Undo pressed"}])
                       (rf/dispatch [:toasts/close
                                     "Toast: with undo action"]))}])

--- a/src/status_im/contexts/shell/share/events.cljs
+++ b/src/status_im/contexts/shell/share/events.cljs
@@ -1,6 +1,5 @@
 (ns status-im.contexts.shell.share.events
   (:require
-    [quo.foundations.colors :as colors]
     [status-im.common.toasts.events :as toasts]
     [utils.re-frame :as rf]))
 
@@ -10,8 +9,7 @@
   (rf/merge cofx
             {:copy-to-clipboard text-to-copy}
             (toasts/upsert
-             {:icon           :correct
-              :id             :successful-copy-toast-message
-              :icon-color     colors/success-50
+             {:id             :successful-copy-toast-message
+              :type           :positive
               :override-theme :dark
               :text           post-copy-message})))

--- a/src/status_im/contexts/syncing/enter_sync_code/view.cljs
+++ b/src/status_im/contexts/syncing/enter_sync_code/view.cljs
@@ -69,9 +69,9 @@
                                       @sync-code-value]
                                      300)
                                     (rf/dispatch [:toasts/upsert
-                                                  {:icon :i/info
-                                                   :icon-color colors/danger-50
+                                                  {:icon  :i/info
+                                                   :type  :negative
                                                    :theme :dark
-                                                   :text (i18n/label
-                                                          :t/error-this-is-not-a-sync-qr-code)}])))}
+                                                   :text  (i18n/label
+                                                           :t/error-this-is-not-a-sync-qr-code)}])))}
           (i18n/label :t/confirm)]]))))

--- a/src/status_im/contexts/syncing/enter_sync_code/view.cljs
+++ b/src/status_im/contexts/syncing/enter_sync_code/view.cljs
@@ -69,8 +69,7 @@
                                       @sync-code-value]
                                      300)
                                     (rf/dispatch [:toasts/upsert
-                                                  {:icon  :i/info
-                                                   :type  :negative
+                                                  {:type  :negative
                                                    :theme :dark
                                                    :text  (i18n/label
                                                            :t/error-this-is-not-a-sync-qr-code)}])))}

--- a/src/status_im/contexts/syncing/events.cljs
+++ b/src/status_im/contexts/syncing/events.cljs
@@ -4,7 +4,6 @@
     [legacy.status-im.data-store.settings :as data-store.settings]
     [legacy.status-im.node.core :as node]
     [native-module.core :as native-module]
-    [quo.foundations.colors :as colors]
     [re-frame.core :as re-frame]
     [react-native.platform :as platform]
     [status-im.config :as config]
@@ -52,9 +51,9 @@
                 (str "generic-error: " res))]
     (when (some? error)
       (rf/dispatch [:toasts/upsert
-                    {:icon       :i/alert
-                     :icon-color colors/danger-50
-                     :text       error}]))))
+                    {:icon :i/alert
+                     :type :negative
+                     :text error}]))))
 
 (rf/defn preflight-outbound-check-for-local-pairing
   {:events [:syncing/preflight-outbound-check]}

--- a/src/status_im/contexts/syncing/events.cljs
+++ b/src/status_im/contexts/syncing/events.cljs
@@ -51,8 +51,7 @@
                 (str "generic-error: " res))]
     (when (some? error)
       (rf/dispatch [:toasts/upsert
-                    {:icon :i/alert
-                     :type :negative
+                    {:type :negative
                      :text error}]))))
 
 (rf/defn preflight-outbound-check-for-local-pairing

--- a/src/status_im/contexts/syncing/scan_sync_code/view.cljs
+++ b/src/status_im/contexts/syncing/scan_sync_code/view.cljs
@@ -232,8 +232,7 @@
         (on-failed-scan)
         (debounce/debounce-and-dispatch
          [:toasts/upsert
-          {:icon  :i/info
-           :type  :negative
+          {:type  :negative
            :theme :dark
            :text  (i18n/label :t/error-this-is-not-a-sync-qr-code)}]
          300)))))

--- a/src/status_im/contexts/syncing/scan_sync_code/view.cljs
+++ b/src/status_im/contexts/syncing/scan_sync_code/view.cljs
@@ -232,10 +232,10 @@
         (on-failed-scan)
         (debounce/debounce-and-dispatch
          [:toasts/upsert
-          {:icon       :i/info
-           :icon-color colors/danger-50
-           :theme      :dark
-           :text       (i18n/label :t/error-this-is-not-a-sync-qr-code)}]
+          {:icon  :i/info
+           :type  :negative
+           :theme :dark
+           :text  (i18n/label :t/error-this-is-not-a-sync-qr-code)}]
          300)))))
 
 (defn- render-camera

--- a/src/status_im/contexts/syncing/setup_syncing/view.cljs
+++ b/src/status_im/contexts/syncing/setup_syncing/view.cljs
@@ -109,10 +109,10 @@
               {:on-press        (fn []
                                   (clipboard/set-string @code)
                                   (rf/dispatch [:toasts/upsert
-                                                {:icon       :correct
-                                                 :icon-color colors/success-50
-                                                 :text       (i18n/label
-                                                              :t/sharing-copied-to-clipboard)}]))
+                                                {:icon :correct
+                                                 :type :positive
+                                                 :text (i18n/label
+                                                        :t/sharing-copied-to-clipboard)}]))
                :type            :grey
                :container-style {:margin-top 12}
                :icon-left       :i/copy}

--- a/src/status_im/contexts/syncing/setup_syncing/view.cljs
+++ b/src/status_im/contexts/syncing/setup_syncing/view.cljs
@@ -109,8 +109,7 @@
               {:on-press        (fn []
                                   (clipboard/set-string @code)
                                   (rf/dispatch [:toasts/upsert
-                                                {:icon :correct
-                                                 :type :positive
+                                                {:type :positive
                                                  :text (i18n/label
                                                         :t/sharing-copied-to-clipboard)}]))
                :type            :grey

--- a/src/status_im/contexts/wallet/common/sheets/account_options/view.cljs
+++ b/src/status_im/contexts/wallet/common/sheets/account_options/view.cljs
@@ -70,9 +70,8 @@
          :label               (i18n/label :t/copy-address)
          :on-press            (fn []
                                 (rf/dispatch [:toasts/upsert
-                                              {:icon       :i/correct
-                                               :icon-color (colors/resolve-color :success theme)
-                                               :text       (i18n/label :t/address-copied)}])
+                                              {:type :positive
+                                               :text (i18n/label :t/address-copied)}])
                                 (clipboard/set-string address))}
         {:icon                :i/share
          :accessibility-label :share-account

--- a/src/status_im/contexts/wallet/edit_account/view.cljs
+++ b/src/status_im/contexts/wallet/edit_account/view.cljs
@@ -26,34 +26,31 @@
                    :text (i18n/label message)}])))
 
 (defn- save-account
-  [{:keys [account updated-key new-value theme]}]
+  [{:keys [account updated-key new-value]}]
   (let [edited-account-data (assoc account updated-key new-value)]
     (rf/dispatch [:wallet/save-account
                   {:account    edited-account-data
-                   :on-success #(show-save-account-toast updated-key theme)}])))
+                   :on-success #(show-save-account-toast updated-key)}])))
 
 (defn- view-internal
-  [{:keys [theme]}]
+  []
   (let [edited-account-name  (reagent/atom nil)
         show-confirm-button? (reagent/atom false)
         on-change-color      (fn [edited-color {:keys [color] :as account}]
                                (when (not= edited-color color)
                                  (save-account {:account     account
                                                 :updated-key :color
-                                                :new-value   edited-color
-                                                :theme       theme})))
+                                                :new-value   edited-color})))
         on-change-emoji      (fn [edited-emoji {:keys [emoji] :as account}]
                                (when (not= edited-emoji emoji)
                                  (save-account {:account     account
                                                 :updated-key :emoji
-                                                :new-value   edited-emoji
-                                                :theme       theme})))
+                                                :new-value   edited-emoji})))
         on-confirm-name      (fn [account]
                                (rn/dismiss-keyboard!)
                                (save-account {:account     account
                                               :updated-key :name
-                                              :new-value   @edited-account-name
-                                              :theme       theme}))]
+                                              :new-value   @edited-account-name}))]
     (fn []
       (let [{:keys [name emoji address color] :as account} (rf/sub [:wallet/current-viewing-account])
             network-details                                (rf/sub [:wallet/network-preference-details])

--- a/src/status_im/contexts/wallet/edit_account/view.cljs
+++ b/src/status_im/contexts/wallet/edit_account/view.cljs
@@ -21,7 +21,6 @@
                   nil)]
     (rf/dispatch [:toasts/upsert
                   {:id   :edit-account
-                   :icon :i/correct
                    :type :positive
                    :text (i18n/label message)}])))
 

--- a/src/status_im/contexts/wallet/edit_account/view.cljs
+++ b/src/status_im/contexts/wallet/edit_account/view.cljs
@@ -1,6 +1,5 @@
 (ns status-im.contexts.wallet.edit-account.view
   (:require [quo.core :as quo]
-            [quo.foundations.colors :as colors]
             [quo.theme :as quo.theme]
             [react-native.core :as rn]
             [reagent.core :as reagent]
@@ -13,7 +12,7 @@
             [utils.re-frame :as rf]))
 
 (defn- show-save-account-toast
-  [updated-key theme]
+  [updated-key]
   (let [message (case updated-key
                   :name                     :t/edit-wallet-account-name-updated-message
                   :color                    :t/edit-wallet-account-colour-updated-message
@@ -21,10 +20,10 @@
                   :prod-preferred-chain-ids :t/edit-wallet-network-preferences-updated-message
                   nil)]
     (rf/dispatch [:toasts/upsert
-                  {:id         :edit-account
-                   :icon       :i/correct
-                   :icon-color (colors/resolve-color :success theme)
-                   :text       (i18n/label message)}])))
+                  {:id   :edit-account
+                   :icon :i/correct
+                   :type :positive
+                   :text (i18n/label message)}])))
 
 (defn- save-account
   [{:keys [account updated-key new-value theme]}]

--- a/src/status_im/contexts/wallet/edit_account/view.cljs
+++ b/src/status_im/contexts/wallet/edit_account/view.cljs
@@ -1,6 +1,5 @@
 (ns status-im.contexts.wallet.edit-account.view
   (:require [quo.core :as quo]
-            [quo.theme :as quo.theme]
             [react-native.core :as rn]
             [reagent.core :as reagent]
             [status-im.contexts.wallet.common.screen-base.create-or-edit-account.view
@@ -31,8 +30,7 @@
                   {:account    edited-account-data
                    :on-success #(show-save-account-toast updated-key)}])))
 
-(defn- view-internal
-  []
+(def view
   (let [edited-account-name  (reagent/atom nil)
         show-confirm-button? (reagent/atom false)
         on-change-color      (fn [edited-color {:keys [color] :as account}]
@@ -97,8 +95,5 @@
                                                             (save-account
                                                              {:account     account
                                                               :updated-key :prod-preferred-chain-ids
-                                                              :new-value   chain-ids
-                                                              :theme       theme}))}])}]))
+                                                              :new-value   chain-ids}))}])}]))
            :container-style style/data-item}]]))))
-
-(def view (quo.theme/with-theme view-internal))

--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -24,7 +24,7 @@
             [:toasts/upsert
              {:id   :new-wallet-account-created
               :type :positive
-              :text (i18n/label :t/account-created {:name name})}]]]})))
+              :text (i18n/label :t/account-created {:name (:name account)})}]]]})))
 
 (rf/reg-event-fx :wallet/navigate-to-account
  (fn [{:keys [db]} [address]]

--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -3,7 +3,6 @@
     [camel-snake-kebab.core :as csk]
     [camel-snake-kebab.extras :as cske]
     [clojure.string :as string]
-    [quo.foundations.colors :as colors]
     [react-native.background-timer :as background-timer]
     [status-im.common.data-store.wallet :as data-store]
     [status-im.contexts.wallet.item-types :as item-types]
@@ -23,10 +22,10 @@
      {:db (update db :wallet dissoc :navigate-to-account :new-account?)
       :fx [[:dispatch
             [:toasts/upsert
-             {:id         :new-wallet-account-created
-              :icon       :i/correct
-              :icon-color colors/success-50
-              :text       (i18n/label :t/account-created {:name (:name account)})}]]]})))
+             {:id   :new-wallet-account-created
+              :icon :i/correct
+              :type :positive
+              :text (i18n/label :t/account-created {:name name})}]]]})))
 
 (rf/reg-event-fx :wallet/navigate-to-account
  (fn [{:keys [db]} [address]]

--- a/src/status_im/contexts/wallet/events.cljs
+++ b/src/status_im/contexts/wallet/events.cljs
@@ -23,7 +23,6 @@
       :fx [[:dispatch
             [:toasts/upsert
              {:id   :new-wallet-account-created
-              :icon :i/correct
               :type :positive
               :text (i18n/label :t/account-created {:name name})}]]]})))
 


### PR DESCRIPTION
fixes #17878 

### Summary

Refactor quo/toast component
- remove `:icon-color` and add `:type` property
- fix everywhere using toast component
<!-- (Optional, remove if no changes to documentation) -->

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS
- macOS
- Linux
- Windows

##### Functional

- 1-1 chats
- public chats
- group chats
- wallet / transactions
- dapps / app browsing
- account recovery
- new account
- user profile updates
- networks
- mailservers
- fleet
- bootnodes

status: ready <!-- Can be ready or wip -->
