### PR TITLE
Fix: resolve our Clojure source dependencies first in the classpath

### DIFF
--- a/nix/mobile/jsbundle/default.nix
+++ b/nix/mobile/jsbundle/default.nix
@@ -68,8 +68,8 @@ stdenv.mkDerivation {
   buildPhase = ''
     # Assemble CLASSPATH from available clojure dependencies.
     # We append 'src' so it can find the local sources.
-    export CLASS_PATH="$(find ${deps.clojure} \
-      -iname '*.jar' | tr '\n' ':')src"
+    export CLASS_PATH="src:$(find ${deps.clojure} \
+      -iname '*.jar' | tr '\n' ':')"
 
     # target must be one of the builds defined in shadow-cljs.edn
     java -cp "$CLASS_PATH" clojure.main \

--- a/nix/mobile/jsbundle/default.nix
+++ b/nix/mobile/jsbundle/default.nix
@@ -67,7 +67,10 @@ stdenv.mkDerivation {
   '';
   buildPhase = ''
     # Assemble CLASSPATH from available clojure dependencies.
-    # We append 'src' so it can find the local sources.
+    # We prepend 'src' so it can find the local sources and prioritize
+    # our own namespaces over dependencies, given that indirect dependencies
+    # can also cause naming conflicts (e.g. prismatic/schema already uses
+    # namespace schema.core).
     export CLASS_PATH="src:$(find ${deps.clojure} \
       -iname '*.jar' | tr '\n' ':')"
 


### PR DESCRIPTION
### Summary

In the (currently open) malli PR https://github.com/status-im/status-mobile/pull/17867#issuecomment-1810839739, @pavloburykh reported the PR build wasn't working and all e2e failed.

The root of the problem is that in our malli PR we have a namespace named `schema.core`, but this namespace is taken by library `prismatic/schema` already (see [source](https://github.com/plumatic/schema/tree/master/src/cljc/schema)), a library used by our direct dependency on`bidi 2.1.6`. This leads to a broken build where the ClojureScript compiler reports undeclared vars (https://clojurescript.org/reference/compiler-options#warnings).

This PR changes the order Java resolves dependencies via the classpath mechanism. We now first resolve our own Clojure sources, and then project dependencies.

#### Note

I tested this solution is correct in this WIP commit https://github.com/status-im/status-mobile/pull/17867/commits/bd5b69b1855df34a5b7ba2169c27e1eba3d8729c, which I extracted for this new PR. Once this PR is merged, I'll remove the WIP commit from the malli PR and rebase from `develop`.

#### Platforms

- Android
- iOS

status: ready
