### PR TITLE
chore: add common page-nav component for wallet

### DIFF
--- a/src/status_im2/contexts/wallet/account/bridge/view.cljs
+++ b/src/status_im2/contexts/wallet/account/bridge/view.cljs
@@ -4,7 +4,7 @@
     [quo.foundations.resources :as quo.resources]
     [react-native.core :as rn]
     [status-im2.contexts.wallet.account.bridge.style :as style]
-    [status-im2.contexts.wallet.common.sheets.account-options.view :as account-options]
+    [status-im2.contexts.wallet.common.account-switcher.view :as account-switcher]
     [status-im2.contexts.wallet.common.temp :as temp]
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]))
@@ -18,17 +18,9 @@
   (let [networks       (rf/sub [:wallet/network-details])
         networks-logos (map network-logo networks)]
     [rn/view {:style {:flex 1}}
-     [quo/page-nav
-      {:icon-name           :i/close
-       :on-press            #(rf/dispatch [:navigate-back])
-       :accessibility-label :top-bar
-       :right-side          :account-switcher
-       :account-switcher    {:customization-color :purple
-                             :on-press            #(rf/dispatch [:show-bottom-sheet
-                                                                 {:content account-options/view
-                                                                  :gradient-cover? true
-                                                                  :customization-color :purple}])
-                             :emoji               "🍑"}}]
+     [account-switcher/view
+      {:on-press            #(rf/dispatch [:navigate-back])
+       :accessibility-label :top-bar}]
      [quo/text-combinations
       {:container-style style/header-container
        :title           (i18n/label :t/bridge)}]

--- a/src/status_im2/contexts/wallet/account/view.cljs
+++ b/src/status_im2/contexts/wallet/account/view.cljs
@@ -5,7 +5,7 @@
     [reagent.core :as reagent]
     [status-im2.contexts.wallet.account.style :as style]
     [status-im2.contexts.wallet.account.tabs.view :as tabs]
-    [status-im2.contexts.wallet.common.sheets.account-options.view :as account-options]
+    [status-im2.contexts.wallet.common.account-switcher.view :as account-switcher]
     [status-im2.contexts.wallet.common.temp :as temp]
     [status-im2.contexts.wallet.common.utils :as utils]
     [utils.i18n :as i18n]
@@ -32,23 +32,10 @@
   []
   (let [selected-tab (reagent/atom (:id (first tabs-data)))]
     (fn []
-      (let [{:keys [name color emoji balance]} (rf/sub [:wallet/current-viewing-account])
-            networks                           (rf/sub [:wallet/network-details])]
+      (let [{:keys [name color balance]} (rf/sub [:wallet/current-viewing-account])
+           ]
         [rn/view {:style {:flex 1}}
-         [quo/page-nav
-          {:type              :wallet-networks
-           :background        :blur
-           :icon-name         :i/close
-           :on-press          #(rf/dispatch [:wallet/close-account-page])
-           :networks          networks
-           :networks-on-press #(js/alert "Pressed Networks")
-           :right-side        :account-switcher
-           :account-switcher  {:customization-color color
-                               :on-press            #(rf/dispatch [:show-bottom-sheet
-                                                                   {:content account-options/view
-                                                                    :gradient-cover? true
-                                                                    :customization-color color}])
-                               :emoji               emoji}}]
+         [account-switcher/view {:on-press #(rf/dispatch [:wallet/close-account-page])}]
          [quo/account-overview
           {:current-value       (utils/prettify-balance balance)
            :account-name        name

--- a/src/status_im2/contexts/wallet/common/account_switcher/view.cljs
+++ b/src/status_im2/contexts/wallet/common/account_switcher/view.cljs
@@ -1,0 +1,22 @@
+(ns status-im2.contexts.wallet.common.account-switcher.view
+  (:require [quo.core :as quo]
+            [status-im2.contexts.wallet.common.sheets.account-options.view :as account-options]
+            [utils.re-frame :as rf]))
+
+(defn view
+  [{:keys [on-press accessibility-label] :or {accessibility-label :top-bar}}]
+  (let [{:keys [color emoji]} (rf/sub [:wallet/current-viewing-account])
+        networks              (rf/sub [:wallet/network-details])]
+    [quo/page-nav
+     {:icon-name           :i/close
+      :on-press            on-press
+      :accessibility-label accessibility-label
+      :networks            networks
+      :networks-on-press   #(js/alert "Pressed Networks")
+      :right-side          :account-switcher
+      :account-switcher    {:customization-color color
+                            :on-press            #(rf/dispatch [:show-bottom-sheet
+                                                                {:content account-options/view
+                                                                 :gradient-cover? true
+                                                                 :customization-color color}])
+                            :emoji               emoji}}]))

--- a/src/status_im2/contexts/wallet/send/select_address/view.cljs
+++ b/src/status_im2/contexts/wallet/send/select_address/view.cljs
@@ -7,6 +7,7 @@
     [react-native.safe-area :as safe-area]
     [reagent.core :as reagent]
     [status-im2.constants :as constants]
+    [status-im2.contexts.wallet.common.account-switcher.view :as account-switcher]
     [status-im2.contexts.wallet.item-types :as types]
     [status-im2.contexts.wallet.send.select-address.style :as style]
     [utils.debounce :as debounce]
@@ -146,15 +147,7 @@
          {:content-container-style      (style/container margin-top)
           :keyboard-should-persist-taps :handled
           :scroll-enabled               false}
-         [quo/page-nav
-          {:icon-name           :i/close
-           :on-press            on-close
-           :accessibility-label :top-bar
-           :right-side          :account-switcher
-           :account-switcher    {:customization-color :purple
-                                 :on-press            #(js/alert "Not implemented yet")
-                                 :state               :default
-                                 :emoji               "🍑"}}]
+         [account-switcher/view {:on-press on-close}]
          [quo/text-combinations
           {:title                     (i18n/label :t/send-to)
            :container-style           style/title-container


### PR DESCRIPTION
fixes: https://github.com/status-im/status-mobile/issues/17872

This pr creates a single component for handling the account switcher in the wallet and updates the uses in the pr.  Some of the data in this component is still mocked but handling this properly depends on pr: https://github.com/status-im/status-mobile/pull/17862  for this reason that will be done as a follow up, however it is using the correct emoji and colour etc of the current account being viewed.  

Screens to check: 
New Wallet account page 

Select Address (Send To) page B

Bridge Page (click bridge button on account page)  


**Bridge Page**
<img width="280px" src="https://github.com/status-im/status-mobile/assets/22799766/fca15ab5-5da7-42cd-ac39-ffd39f973f0c" />

**Send To**
<img width="280px" src="https://github.com/status-im/status-mobile/assets/22799766/2a749c39-9e01-4ff5-a84e-88169ab8618c" />

**App switcher menu**
<img width="280px" src="https://github.com/status-im/status-mobile/assets/22799766/661670a9-0df9-49e2-8f69-26b4bfb2022d" />
**Account Page**
<img width="280px" alt="Screenshot 2023-11-18 at 18 41 48" src="https://github.com/status-im/status-mobile/assets/22799766/3b1c1b11-c9ee-483b-b0ee-f35353a5dcfa">
