### PR TITLE
[#17893] Integrate new stickers/ens endpoints

### DIFF
--- a/src/status_im/signing/core.cljs
+++ b/src/status_im/signing/core.cljs
@@ -151,35 +151,10 @@
                                                             custom-domain? %])
                                     nil))}])]
         (when-not in-progress?
-          (cond-> {:db (update db :signing/sign assoc :error nil :in-progress? true)}
-            (nil? action)                                 (assoc :signing/send-transaction-fx
-                                                                 {:tx-obj          tx-obj-to-send
-                                                                  :hashed-password hashed-password
-                                                                  :cb              cb})
-            (= action constants/ens-action-type-register) (assoc :json-rpc/call
-                                                                 [{:method "ens_register"
-                                                                   :params [chain-id tx-obj-to-send
-                                                                            hashed-password username
-                                                                            public-key]
-                                                                   :on-success
-                                                                   #(do
-                                                                      (cb (types/clj->json
-                                                                           {:result %}))
-                                                                      (watch-ens-tx-fn %))
-                                                                   :on-error #(cb (types/clj->json
-                                                                                   {:error %}))}])
-            (= action
-               constants/ens-action-type-set-pub-key)     (assoc :json-rpc/call
-                                                                 [{:method     "ens_setPubKey"
-                                                                   :params     [chain-id tx-obj-to-send
-                                                                                hashed-password username
-                                                                                public-key]
-                                                                   :on-success #(do (cb (types/clj->json
-                                                                                         {:result %}))
-                                                                                    (watch-ens-tx-fn %))
-                                                                   :on-error   #(cb (types/clj->json
-                                                                                     {:error
-                                                                                      %}))}])))))))
+          {:db                          (update db :signing/sign assoc :error nil :in-progress? true)
+           :signing/send-transaction-fx {:tx-obj          tx-obj-to-send
+                                         :hashed-password hashed-password
+                                         :cb              cb}})))))
 
 (rf/defn prepare-unconfirmed-transaction
   [{:keys [db now]} new-tx-hash

--- a/src/status_im/stickers/core.cljs
+++ b/src/status_im/stickers/core.cljs
@@ -42,7 +42,8 @@
 (rf/defn buy-pack
   {:events [:stickers/buy-pack]}
   [{db :db} pack-id]
-  {:json-rpc/call [{:method     "stickers_buyPrepareTx" ;; probably it should be changed https://github.com/status-im/status-go/pull/4286
+  {:json-rpc/call [{:method     "stickers_buyPrepareTx" ;; probably it should be changed
+                                                        ;; https://github.com/status-im/status-go/pull/4286
                     :params     [(chain/chain-id db) (wallet.utils/default-address db) (int pack-id)]
                     :on-success #(re-frame/dispatch [:signing.ui/sign
                                                      {:tx-obj    %

--- a/src/status_im/stickers/core.cljs
+++ b/src/status_im/stickers/core.cljs
@@ -42,7 +42,7 @@
 (rf/defn buy-pack
   {:events [:stickers/buy-pack]}
   [{db :db} pack-id]
-  {:json-rpc/call [{:method     "stickers_buyPrepareTx"
+  {:json-rpc/call [{:method     "stickers_buyPrepareTx" ;; probably it should be changed https://github.com/status-im/status-go/pull/4286
                     :params     [(chain/chain-id db) (wallet.utils/default-address db) (int pack-id)]
                     :on-success #(re-frame/dispatch [:signing.ui/sign
                                                      {:tx-obj    %

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.171.11",
-    "commit-sha1": "8a4c2d8d2f17117aa0a00338e83b0f753ebf1328",
-    "src-sha256": "160qnl9dsl1ypvqg9w6z8wps4fvgq3qxi16piymhrlzgssdwkz8h"
+    "version": "feat/keycard-signing-for-ens-and-stickers",
+    "commit-sha1": "f45484f70cd83fc76506e60bb6ea3bb08a8a9b1a",
+    "src-sha256": "00wi8gxl8l8rldx2dmgvr1p5k83gchn5l695adhwpg0xmq6vn75a"
 }


### PR DESCRIPTION
fixes #17893

there are no changes in this PR, just updated status-go version and removed some outdated code, new API from status-go should be updated later when the relevant parts of the application are developed on mobile

for QA: we don't have stickers in the UI so only ens should be tested, register ens, and assign public key to existing ens 