### PR TITLE
Enabling biometry without password during sync

### DIFF
--- a/src/react_native/keychain.cljs
+++ b/src/react_native/keychain.cljs
@@ -58,14 +58,16 @@
 
 (defn save-credentials
   "Stores the credentials for the address to the Keychain"
-  [server username password callback]
-  (-> (.setInternetCredentials ^js react-native-keychain
-                               (string/lower-case server)
-                               username
-                               password
-                               keychain-secure-hardware
-                               keychain-restricted-availability)
-      (.then callback)))
+  ([server username password]
+   (save-credentials server username password identity))
+  ([server username password callback]
+   (-> (.setInternetCredentials ^js react-native-keychain
+                                (string/lower-case server)
+                                username
+                                password
+                                keychain-secure-hardware
+                                keychain-restricted-availability)
+       (.then callback))))
 
 (defn get-credentials
   "Gets the credentials for a specified server from the Keychain"

--- a/src/status_im2/common/alert/events.cljs
+++ b/src/status_im2/common/alert/events.cljs
@@ -22,7 +22,7 @@
         (vector
          action-button
          dismiss-button)
-        dismiss-button)
+        (vector dismiss-button))
       (when on-dismiss
         {:cancelable false})))))
 

--- a/src/status_im2/common/biometric/events.cljs
+++ b/src/status_im2/common/biometric/events.cljs
@@ -42,11 +42,12 @@
 
 (rf/defn show-message
   [_ code]
-  (let [content (if (#{"NOT_AVAILABLE" "NOT_ENROLLED"} code)
-                  (i18n/label :t/grant-face-id-permissions)
-                  (when-not (or (= code "USER_CANCELED") (= code "USER_FALLBACK"))
-                    (i18n/label :t/biometric-auth-error {:code code})))]
-    (when content
+  (let [handle-error? (and code
+                           (not (contains? #{"USER_CANCELED" "USER_FALLBACK"} code)))
+        content       (if (#{"NOT_AVAILABLE" "NOT_ENROLLED"} code)
+                        (i18n/label :t/grant-face-id-permissions)
+                        (i18n/label :t/biometric-auth-error {:code code}))]
+    (when handle-error?
       {:utils/show-popup
        {:title   (i18n/label :t/biometric-auth-login-error-title)
         :content content}})))

--- a/src/status_im2/common/biometric/events.cljs
+++ b/src/status_im2/common/biometric/events.cljs
@@ -2,9 +2,11 @@
   (:require
     [native-module.core :as native-module]
     [re-frame.core :as re-frame]
+    [react-native.async-storage :as async-storage]
     [react-native.platform :as platform]
     [react-native.touch-id :as touch-id]
     [status-im2.common.keychain.events :as keychain]
+    [taoensso.timbre :as log]
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]))
 
@@ -41,6 +43,7 @@
   {:db (assoc db :biometric/supported-type supported-type)})
 
 (rf/defn show-message
+  {:events [:biometric/show-message]}
   [_ code]
   (let [handle-error? (and code
                            (not (contains? #{"USER_CANCELED" "USER_FALLBACK"} code)))
@@ -51,6 +54,48 @@
       {:utils/show-popup
        {:title   (i18n/label :t/biometric-auth-login-error-title)
         :content content}})))
+
+(defn- supress-biometry-error-key
+  [key-uid]
+  (keyword (str "biometric/supress-not-enrolled-error-" key-uid)))
+
+;; NOTE: if the account had biometrics registered, but it's not enrolled at the moment,
+;; we should show the error message only once and supress further "NOT_ENROLLED" errors
+;; until biometry is enrolled again. Note that we can only know that when :biometric/authenticate
+;; is dispatched and fails with "NOT_ENROLLED", since :biometric/get-supported-biometric-type
+;; only tells us what kind of biometric is available on the device, but it doesn't know of its
+;; enrollment status.
+(re-frame/reg-fx
+ :biometric/supress-not-enrolled-error
+ (fn [[key-uid dispatch-event]]
+   (let [storage-key (supress-biometry-error-key key-uid)]
+     (-> (async-storage/get-item storage-key identity)
+         (.then (fn [item]
+                  (when (not item)
+                    (rf/dispatch dispatch-event)
+                    (async-storage/set-item! storage-key true))))
+         (.catch (fn [err]
+                   (log/error "Couldn't supress biometry NOT_ENROLLED error"
+                              {:key-uid key-uid
+                               :event   :biometric/supress-not-enrolled-error
+                               :error   err})))))))
+
+;; NOTE: when biometrics is re-enrolled, we erase the flag in async-storage to assure
+;; the "NOT_ENROLLED" error message will be shown again if biometrics is un-enrolled
+;; in the future.
+(re-frame/reg-fx
+ :biometric/reset-not-enrolled-error
+ (fn [key-uid]
+   (let [storage-key (supress-biometry-error-key key-uid)]
+     (-> (async-storage/get-item storage-key identity)
+         (.then (fn [supress?]
+                  (when supress?
+                    (async-storage/set-item! storage-key nil))))
+         (.catch (fn [err]
+                   (log/error "Couldn't reset supressing biometry NOT_ENROLLED error"
+                              {:key-uid key-uid
+                               :event   :biometric/reset-not-enrolled-error
+                               :error   err})))))))
 
 (re-frame/reg-fx
  :biometric/authenticate

--- a/src/status_im2/common/keychain/events.cljs
+++ b/src/status_im2/common/keychain/events.cljs
@@ -123,7 +123,7 @@
   [key-uid callback]
   (keychain/get-credentials
    (password-migration-key-name key-uid)
-   #(comp callback boolean)))
+   (comp callback boolean)))
 
 (re-frame/reg-fx
  :keychain/clear-user-password

--- a/src/status_im2/common/keychain/events.cljs
+++ b/src/status_im2/common/keychain/events.cljs
@@ -49,15 +49,15 @@
 
 (defn save-auth-method!
   [key-uid method]
-  (keychain/save-credentials
-   (str key-uid "-auth")
-   key-uid
-   method)
-  (.catch (fn [err]
-            (log/error "Failed to save auth method in the keychain"
-                       {:error       err
-                        :key-uid     key-uid
-                        :auth-method method}))))
+  (-> (keychain/save-credentials
+       (str key-uid "-auth")
+       key-uid
+       method)
+      (.catch (fn [err]
+                (log/error "Failed to save auth method in the keychain"
+                           {:error       err
+                            :key-uid     key-uid
+                            :auth-method method})))))
 
 (re-frame/reg-fx
  :keychain/save-auth-method
@@ -110,16 +110,16 @@
 
 (defn save-password-migration!
   [key-uid]
-  (keychain/save-credentials
-   (password-migration-key-name key-uid)
-   key-uid
-   ;; NOTE: using the key-uid as the password, but we don't really care about the
-   ;; value, we only care that it's there
-   key-uid)
-  (.catch (fn [error]
-            (log/error "Failed to get the keychain password migration flag"
-                       {:error   error
-                        :key-uid key-uid}))))
+  (-> (keychain/save-credentials
+       (password-migration-key-name key-uid)
+       key-uid
+       ;; NOTE: using the key-uid as the password, but we don't really care about the
+       ;; value, we only care that it's there
+       key-uid)
+      (.catch (fn [error]
+                (log/error "Failed to get the keychain password migration flag"
+                           {:error   error
+                            :key-uid key-uid})))))
 
 (defn get-password-migration!
   [key-uid callback]

--- a/src/status_im2/common/keychain/events.cljs
+++ b/src/status_im2/common/keychain/events.cljs
@@ -81,6 +81,7 @@
          (str key-uid "-auth")
          #(callback (if % (oops/oget % "password") auth-method-none)))
         (callback nil))))))
+
 (defn save-user-password!
   [key-uid password]
   (keychain/save-credentials key-uid key-uid (security/safe-unmask-data password) #()))
@@ -88,9 +89,10 @@
 (defn get-user-password!
   [key-uid callback]
   (keychain/get-credentials key-uid
-                            #(if %
-                               (callback (security/mask-data (oops/oget % "password")))
-                               (callback nil))))
+                            #(callback (when %
+                                         (-> %
+                                             (oops/oget "password")
+                                             (security/mask-data))))))
 
 (re-frame/reg-fx
  :keychain/get-user-password
@@ -121,7 +123,7 @@
   [key-uid callback]
   (keychain/get-credentials
    (password-migration-key-name key-uid)
-   #(callback (boolean %))))
+   #(comp callback boolean)))
 
 (re-frame/reg-fx
  :keychain/clear-user-password

--- a/src/status_im2/common/keychain/events.cljs
+++ b/src/status_im2/common/keychain/events.cljs
@@ -113,7 +113,7 @@
   (keychain/save-credentials
    (password-migration-key-name key-uid)
    key-uid
-   ;; NOTE: using the key-id as the password, but we don't really care about the
+   ;; NOTE: using the key-uid as the password, but we don't really care about the
    ;; value, we only care that it's there
    key-uid)
   (.catch (fn [error]

--- a/src/status_im2/common/keychain/events.cljs
+++ b/src/status_im2/common/keychain/events.cljs
@@ -82,10 +82,12 @@
          #(callback (if % (oops/oget % "password") auth-method-none)))
         (callback nil))))))
 
+(def ^:const migration-server-suffix "-hashed")
+
 (defn save-migration-auth-hashed!
   [key-uid]
   (keychain/save-credentials
-   (str key-uid "-hashed")
+   (str key-uid migration-server-suffix)
    key-uid
    ;; NOTE: using the key-id as the password, but we don't really care about the
    ;; value, we only care that it's there
@@ -98,7 +100,7 @@
  :keychain/get-migration-auth-hashed
  (fn [[key-uid callback]]
    (keychain/get-credentials
-    (str key-uid "-hashed")
+    (str key-uid migration-server-suffix)
     #(callback (boolean %)))))
 
 (defn save-user-password!
@@ -119,6 +121,7 @@
 (re-frame/reg-fx
  :keychain/clear-user-password
  (fn [key-uid]
+   (keychain/reset-credentials (str key-uid migration-server-suffix))
    (keychain/reset-credentials key-uid)))
 
 (re-frame/reg-fx

--- a/src/status_im2/contexts/onboarding/enable_biometrics/view.cljs
+++ b/src/status_im2/contexts/onboarding/enable_biometrics/view.cljs
@@ -34,23 +34,13 @@
         syncing-results?         (= :syncing-results @state/root-id)]
     [rn/view {:style (style/buttons insets)}
      [standard-auth/button
-      (merge
-       {:size                40
-        :accessibility-label :enable-biometrics-button
-        :icon-left           :i/face-id
-        :customization-color profile-color
-        :button-label        (i18n/label :t/biometric-enable-button {:bio-type-label bio-type-label})}
-       (if syncing-results?
-         {:theme             theme
-          :blur?             true
-          :on-enter-password (fn [entered-password]
-                               (rf/dispatch
-                                [:onboarding-2/authenticate-enable-biometrics
-                                 (security/safe-unmask-data
-                                  entered-password)])
-                               (rf/dispatch [:hide-bottom-sheet]))
-          :auth-button-label (i18n/label :t/confirm)}
-         {:on-press #(rf/dispatch [:onboarding-2/enable-biometrics])}))]
+      {:size                40
+       :accessibility-label :enable-biometrics-button
+       :icon-left           :i/face-id
+       :customization-color profile-color
+       :theme               theme
+       :on-press            #(rf/dispatch [:onboarding-2/enable-biometrics])
+       :button-label        (i18n/label :t/biometric-enable-button {:bio-type-label bio-type-label})}]
      [quo/button
       {:accessibility-label :maybe-later-button
        :background          :blur

--- a/src/status_im2/contexts/onboarding/enable_biometrics/view.cljs
+++ b/src/status_im2/contexts/onboarding/enable_biometrics/view.cljs
@@ -1,7 +1,6 @@
 (ns status-im2.contexts.onboarding.enable-biometrics.view
   (:require
     [quo.core :as quo]
-    [quo.theme :as quo.theme]
     [react-native.core :as rn]
     [react-native.safe-area :as safe-area]
     [status-im2.common.biometric.events :as biometric]
@@ -25,7 +24,7 @@
     :description-accessibility-label :enable-biometrics-sub-title}])
 
 (defn enable-biometrics-buttons
-  [insets theme]
+  [insets]
   (let [supported-biometric-type (rf/sub [:biometric/supported-type])
         bio-type-label           (biometric/get-label-by-type supported-biometric-type)
         profile-color            (or (:color (rf/sub [:onboarding-2/profile]))
@@ -37,7 +36,6 @@
        :accessibility-label :enable-biometrics-button
        :icon-left           :i/face-id
        :customization-color profile-color
-       :theme               theme
        :on-press            #(rf/dispatch [:onboarding-2/enable-biometrics])
        :button-label        (i18n/label :t/biometric-enable-button {:bio-type-label bio-type-label})}]
      [quo/button
@@ -67,18 +65,16 @@
       :source      (resources/get-image :biometrics)}]))
 
 (defn f-enable-biometrics
-  [{:keys [theme]}]
+  []
   (let [insets (safe-area/get-insets)]
     [rn/view {:style (style/page-container insets)}
      [page-title]
      (if whitelist/whitelisted?
        [enable-biometrics-parallax]
        [enable-biometrics-simple])
-     [enable-biometrics-buttons insets theme]]))
+     [enable-biometrics-buttons insets]]))
 
+(defn view
+  []
+  [:f> f-enable-biometrics])
 
-(defn- internale-enable-biometrics
-  [params]
-  [:f> f-enable-biometrics params])
-
-(def view (quo.theme/with-theme internale-enable-biometrics))

--- a/src/status_im2/contexts/onboarding/enable_biometrics/view.cljs
+++ b/src/status_im2/contexts/onboarding/enable_biometrics/view.cljs
@@ -12,8 +12,7 @@
     [status-im2.contexts.onboarding.enable-biometrics.style :as style]
     [status-im2.navigation.state :as state]
     [utils.i18n :as i18n]
-    [utils.re-frame :as rf]
-    [utils.security.core :as security]))
+    [utils.re-frame :as rf]))
 
 
 (defn page-title

--- a/src/status_im2/contexts/onboarding/events.cljs
+++ b/src/status_im2/contexts/onboarding/events.cljs
@@ -154,7 +154,10 @@
       biometric-enabled?
       (assoc :keychain/save-password-and-auth-method
              {:key-uid         key-uid
-              :masked-password masked-password
+              :masked-password (-> masked-password
+                                   security/safe-unmask-data
+                                   native-module/sha3
+                                   security/mask-data)
               :on-success      (fn []
                                  (if syncing?
                                    (rf/dispatch [:onboarding-2/navigate-to-enable-notifications])

--- a/src/status_im2/contexts/profile/login/events.cljs
+++ b/src/status_im2/contexts/profile/login/events.cljs
@@ -195,7 +195,7 @@
                (fn []
                  (rf/dispatch [:biometric/authenticate
                                {:on-success #(rf/dispatch [:profile.login/biometric-success])
-                                :on-faile   #(rf/dispatch [:profile.login/biometric-auth-fail])}]))))))
+                                :on-fail    #(rf/dispatch [:profile.login/biometric-auth-fail])}]))))))
 
 (rf/defn biometric-auth-success
   {:events [:profile.login/biometric-success]}

--- a/src/status_im2/contexts/profile/login/events.cljs
+++ b/src/status_im2/contexts/profile/login/events.cljs
@@ -171,7 +171,7 @@
                          (rf/dispatch [:biometric/authenticate
                                        {:on-success #(rf/dispatch [:profile.login/biometric-success])
                                         :on-fail    #(rf/dispatch
-                                                      [:profile.login/biometric-auth-fail])}]))}})))
+                                                      [:profile.login/biometric-auth-fail %])}]))}})))
 
 (rf/defn biometric-auth-success
   {:events [:profile.login/biometric-success]}

--- a/src/status_im2/contexts/profile/login/events.cljs
+++ b/src/status_im2/contexts/profile/login/events.cljs
@@ -162,7 +162,7 @@
 
 (rf/defn get-auth-method-success
   {:events [:profile.login/get-auth-method-success]}
-  [{:keys [db] :as cofx} auth-method key-uid]
+  [{:keys [db]} auth-method key-uid]
   (merge {:db (assoc db :auth-method auth-method)}
          (when (= auth-method keychain/auth-method-biometric)
            {:keychain/password-hash-migration
@@ -212,7 +212,7 @@
 
 (rf/defn verify-database-password-success
   {:events [:profile.login/verified-database-password]}
-  [{:keys [db] :as cofx} valid? callback]
+  [{:keys [db]} valid? callback]
   (if valid?
     (do
       (when (fn? callback)

--- a/src/status_im2/contexts/profile/login/events.cljs
+++ b/src/status_im2/contexts/profile/login/events.cljs
@@ -42,8 +42,8 @@
     {:db     (assoc-in db [:profile/login :processing] true)
      ::login [key-uid (native-module/sha3 (security/safe-unmask-data password))]}))
 
-(rf/defn biometry-login
-  {:events [:profile.login/biometry-login]}
+(rf/defn biometrics-login
+  {:events [:profile.login/biometrics-login]}
   [{:keys [db]}]
   (let [{:keys [key-uid password]} (:profile/login db)]
     {:db     (assoc-in db [:profile/login :processing] true)
@@ -190,7 +190,7 @@
      cofx
      {:db (assoc-in db [:profile/login :password] password)}
      (navigation/init-root :progress)
-     (biometry-login))))
+     (biometrics-login))))
 
 (rf/defn biometric-auth-fail
   {:events [:profile.login/biometric-auth-fail]}

--- a/src/status_im2/contexts/profile/login/events.cljs
+++ b/src/status_im2/contexts/profile/login/events.cljs
@@ -11,7 +11,6 @@
     [status-im.group-chats.core :as group-chats]
     [status-im.mobile-sync-settings.core :as mobile-network]
     [status-im.transport.core :as transport]
-    [status-im2.common.biometric.events :as biometric]
     [status-im2.common.keychain.events :as keychain]
     [status-im2.common.log :as logging]
     [status-im2.config :as config]

--- a/src/utils/security/core.cljs
+++ b/src/utils/security/core.cljs
@@ -1,5 +1,6 @@
 (ns utils.security.core
   (:require
+    [native-module.core :as native-module]
     [utils.security.security-html :as h]))
 
 (defprotocol Unmaskable
@@ -58,3 +59,10 @@
   and does not contain an rtlo character, which might mean that the url is spoofed"
   [text]
   (not (re-matches rtlo-link-regex text)))
+
+(defn hash-masked-password
+  [masked-password]
+  (-> masked-password
+      safe-unmask-data
+      native-module/sha3
+      mask-data))

--- a/src/utils/security/core.cljs
+++ b/src/utils/security/core.cljs
@@ -72,10 +72,11 @@
   [value]
   (instance? MaskedData value))
 
+(def ?masked-password
+  [:fn {:error/message "should be an instance of utils.security.core/MaskedData"}
+   masked-data-instance?])
+
 (schema/=> hash-masked-password
   [:=>
-   [:cat
-    [:fn {:error/message "argument should be an instance of MaskedData"}
-     masked-data-instance?]]
-   [:fn {:error/message "return value should be an instance of MaskedData"}
-    masked-data-instance?]])
+   [:cat ?masked-password]
+   ?masked-password])

--- a/src/utils/security/core.cljs
+++ b/src/utils/security/core.cljs
@@ -60,9 +60,7 @@
   [text]
   (not (re-matches rtlo-link-regex text)))
 
-(defn hash-masked-password
-  [masked-password]
-  (-> masked-password
-      safe-unmask-data
-      native-module/sha3
-      mask-data))
+(def hash-masked-password
+  (comp safe-unmask-data
+        native-module/sha3
+        mask-data))

--- a/src/utils/security/core.cljs
+++ b/src/utils/security/core.cljs
@@ -61,6 +61,6 @@
   (not (re-matches rtlo-link-regex text)))
 
 (def hash-masked-password
-  (comp safe-unmask-data
+  (comp mask-data
         native-module/sha3
-        mask-data))
+        safe-unmask-data))

--- a/src/utils/security/security_test.cljs
+++ b/src/utils/security/security_test.cljs
@@ -51,6 +51,5 @@
   (testing "returns an instance of MaskedData with the hashed content"
     (is (= (-> "test" native-module/sha3 security/mask-data)
            (-> "test" security/mask-data security/hash-masked-password))))
-  (testing "returns the hashed content if the argument is not a MaskedData instance"
-    (is (= (native-module/sha3 "test")
-           (-> "test" security/hash-masked-password security/safe-unmask-data)))))
+  (testing "throws a schema exception if the argument is not an instance of MaskedData"
+    (is (thrown? js/Error (security/hash-masked-password "test")))))


### PR DESCRIPTION
fixes #17928 

### Summary
Currently, when the user syncs device A with device B (mobile), the user is prompted to input the device A password to enable biometry. This was needed because the device A password comes hashed during syncing, while for biometry authentication we need the password in plaintext for the keychain. 

As agreed with @cammellos and @Samyoul, we should be moving away from storing the plaintext password in the keychain in favor of storing it already hashed (we only need it hashed anyway). As such, this PR:
- adds a migration for the keychain password from plaintext to hashed form
- removes the password authentication step for enabling biometry from sync onboarding 

### Testing notes
<!-- (Optional) -->
To test the migration:
1. create an account with enabled biometry (don't use this branch yet)
2. install this PR build
3. try to log in using biometry

If it fails to log in during step 3, then there's something wrong with the migration.

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS


#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- onboarding
- biometry auth

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- start sync process on another device e.g. status-desktop
- open status-mobile
- start sync (by scanning the QR code or entering the sync code)
- when biometry is prompted, enable it and register it

When enabling biometry, the password auth should not appear and the user should be able to log it again with biometry after the app was closed.

status: ready <!-- Can be ready or wip -->
