### PR TITLE
Add fallback/default dimensions for Image sent from desktop

### DIFF
--- a/src/status_im2/contexts/chat/messages/content/image/view.cljs
+++ b/src/status_im2/contexts/chat/messages/content/image/view.cljs
@@ -8,6 +8,10 @@
     [utils.re-frame :as rf]
     [utils.url :as url]))
 
+;; these constants are used when there is no width or height defined for a specific image
+(def ^:const fallback-image-width 1000)
+(def ^:const fallback-image-height 1000)
+
 (defn calculate-dimensions
   [width height max-container-width max-container-height]
   (let [max-width  (if (> width height) max-container-width (* 1.5 constants/image-size))
@@ -15,7 +19,12 @@
     {:width (min width max-width) :height (min height max-height)}))
 
 (defn image-message
-  [index {:keys [content image-width image-height message-id] :as message} {:keys [on-long-press]}
+  [index
+   {:keys [content image-width image-height message-id]
+    :as   message
+    :or   {image-width  fallback-image-width
+           image-height fallback-image-height}}
+   {:keys [on-long-press]}
    message-container-data]
   (let [insets                        (safe-area/get-insets)
         {:keys [window-width padding-left padding-right avatar-container-width


### PR DESCRIPTION
Fixes #17956

Uses fallback values for dimensions because `image-width` and `image-height` are not always available which is the reason for images to be displayed incorrectly or not displayed at all.

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- 1-1 chats
- public chats
- group chats

status: ready <!-- Can be ready or wip -->
