### PR TITLE
[Feature] Activity check on entered watch address

### DIFF
--- a/src/quo/components/info/info_message.cljs
+++ b/src/quo/components/info/info_message.cljs
@@ -11,6 +11,7 @@
   (case k
     :success (colors/resolve-color :success theme)
     :error   (colors/resolve-color :danger theme)
+    :warning (colors/resolve-color :orange theme)
     (colors/theme-colors colors/neutral-50 colors/neutral-40 theme)))
 
 (defn view-internal

--- a/src/quo/components/info/info_message.cljs
+++ b/src/quo/components/info/info_message.cljs
@@ -11,7 +11,7 @@
   (case k
     :success (colors/resolve-color :success theme)
     :error   (colors/resolve-color :danger theme)
-    :warning (colors/resolve-color :orange theme)
+    :warning (colors/resolve-color :warning theme)
     (colors/theme-colors colors/neutral-50 colors/neutral-40 theme)))
 
 (defn view-internal

--- a/src/quo/foundations/colors.cljs
+++ b/src/quo/foundations/colors.cljs
@@ -203,6 +203,16 @@
 (def danger-50-opa-30 (alpha danger-50 0.3))
 (def danger-50-opa-40 (alpha danger-50 0.4))
 
+;;;;Warning
+(def warning-50 "#FF7D46")
+(def warning-60 "#CC6438")
+
+;;50 with transparency
+(def warning-50-opa-5 (alpha warning-50 0.05))
+(def warning-50-opa-10 (alpha warning-50 0.1))
+(def warning-50-opa-20 (alpha warning-50 0.2))
+(def warning-50-opa-30 (alpha warning-50 0.3))
+(def warning-50-opa-40 (alpha warning-50 0.4))
 
 ;; Colors for customizing users account
 (def customization
@@ -256,7 +266,9 @@
           :danger  {50 danger-50
                     60 danger-60}
           :success {50 success-50
-                    60 success-60}}
+                    60 success-60}
+          :warning {50 warning-50
+                    60 warning-60}}
          customization
          networks))
 

--- a/src/status_im2/contexts/wallet/add_address_to_watch/component_spec.cljs
+++ b/src/status_im2/contexts/wallet/add_address_to_watch/component_spec.cljs
@@ -14,9 +14,8 @@
 (h/describe "select address for watch only account"
   (h/test "validation messages show for already used addressed"
     (setup-subs {:wallet/scanned-address              nil
-                 :wallet/addresses                    (set
-                                                       ["0x12E838Ae1f769147b12956485dc56e57138f3AC8"
-                                                        "0x22E838Ae1f769147b12956485dc56e57138f3AC8"])
+                 :wallet/addresses                    #{"0x12E838Ae1f769147b12956485dc56e57138f3AC8"
+                                                        "0x22E838Ae1f769147b12956485dc56e57138f3AC8"}
                  :wallet/watch-address-activity-state nil
                  :profile/customization-color         :blue})
     (h/render [add-address-to-watch/view])
@@ -28,9 +27,8 @@
 
 (h/test "validation messages show for invalid address"
   (setup-subs {:wallet/scanned-address              nil
-               :wallet/addresses                    (set
-                                                     ["0x12E838Ae1f769147b12956485dc56e57138f3AC8"
-                                                      "0x22E838Ae1f769147b12956485dc56e57138f3AC8"])
+               :wallet/addresses                    #{"0x12E838Ae1f769147b12956485dc56e57138f3AC8"
+                                                      "0x22E838Ae1f769147b12956485dc56e57138f3AC8"}
                :wallet/watch-address-activity-state nil
                :profile/customization-color         :blue})
   (h/render [add-address-to-watch/view])

--- a/src/status_im2/contexts/wallet/add_address_to_watch/component_spec.cljs
+++ b/src/status_im2/contexts/wallet/add_address_to_watch/component_spec.cljs
@@ -13,11 +13,12 @@
 
 (h/describe "select address for watch only account"
   (h/test "validation messages show for already used addressed"
-    (setup-subs {:wallet/scanned-address      nil
-                 :wallet/addresses            (set
-                                               ["0x12E838Ae1f769147b12956485dc56e57138f3AC8"
-                                                "0x22E838Ae1f769147b12956485dc56e57138f3AC8"])
-                 :profile/customization-color :blue})
+    (setup-subs {:wallet/scanned-address              nil
+                 :wallet/addresses                    (set
+                                                       ["0x12E838Ae1f769147b12956485dc56e57138f3AC8"
+                                                        "0x22E838Ae1f769147b12956485dc56e57138f3AC8"])
+                 :wallet/watch-address-activity-state nil
+                 :profile/customization-color         :blue})
     (h/render [add-address-to-watch/view])
     (h/is-falsy (h/query-by-label-text :error-message))
     (h/fire-event :change-text
@@ -26,11 +27,12 @@
     (h/is-truthy (h/get-by-translation-text :address-already-in-use))))
 
 (h/test "validation messages show for invalid address"
-  (setup-subs {:wallet/scanned-address      nil
-               :wallet/addresses            (set
-                                             ["0x12E838Ae1f769147b12956485dc56e57138f3AC8"
-                                              "0x22E838Ae1f769147b12956485dc56e57138f3AC8"])
-               :profile/customization-color :blue})
+  (setup-subs {:wallet/scanned-address              nil
+               :wallet/addresses                    (set
+                                                     ["0x12E838Ae1f769147b12956485dc56e57138f3AC8"
+                                                      "0x22E838Ae1f769147b12956485dc56e57138f3AC8"])
+               :wallet/watch-address-activity-state nil
+               :profile/customization-color         :blue})
   (h/render [add-address-to-watch/view])
   (h/is-falsy (h/query-by-label-text :error-message))
   (h/fire-event :change-text (h/get-by-label-text :add-address-to-watch) "0x12E838Ae1f769147b")

--- a/src/status_im2/contexts/wallet/add_address_to_watch/view.cljs
+++ b/src/status_im2/contexts/wallet/add_address_to_watch/view.cljs
@@ -72,24 +72,21 @@
 
 (defn activity-indicator
   []
-  (let [activity-state                                  (rf/sub [:wallet/watch-address-activity-state])
-        {:keys [accessibility-label icon type message]} (case activity-state
-                                                          :has-activity {:accessibility-label
-                                                                         :account-has-activity
-                                                                         :icon :i/done
-                                                                         :type :success
-                                                                         :message
-                                                                         :t/this-address-has-activity}
-                                                          :no-activity  {:accessibility-label
-                                                                         :account-has-no-activity
-                                                                         :icon :i/info
-                                                                         :type :warning
-                                                                         :message
-                                                                         :t/this-address-has-no-activity}
-                                                          {:accessibility-label :searching-for-activity
-                                                           :icon :i/pending-state
-                                                           :type :default
-                                                           :message :t/searching-for-activity})]
+  (let [activity-state (rf/sub [:wallet/watch-address-activity-state])
+        {:keys [accessibility-label icon type message]}
+        (case activity-state
+          :has-activity {:accessibility-label :account-has-activity
+                         :icon                :i/done
+                         :type                :success
+                         :message             :t/this-address-has-activity}
+          :no-activity  {:accessibility-label :account-has-no-activity
+                         :icon                :i/info
+                         :type                :warning
+                         :message             :t/this-address-has-no-activity}
+          {:accessibility-label :searching-for-activity
+           :icon                :i/pending-state
+           :type                :default
+           :message             :t/searching-for-activity})]
     (when activity-state
       [quo/info-message
        {:accessibility-label accessibility-label

--- a/src/status_im2/contexts/wallet/add_address_to_watch/view.cljs
+++ b/src/status_im2/contexts/wallet/add_address_to_watch/view.cljs
@@ -27,11 +27,14 @@
   (let [scanned-address (rf/sub [:wallet/scanned-address])
         empty-input?    (and (string/blank? @input-value)
                              (string/blank? scanned-address))
-
         on-change-text  (fn [new-text]
                           (reset! validation-msg (validate new-text))
                           (reset! input-value new-text)
+                          (if (and (not-empty new-text) (nil? (validate new-text)))
+                            (rf/dispatch [:wallet/get-address-details new-text])
+                            (rf/dispatch [:wallet/clear-address-activity-check]))
                           (when (and scanned-address (not= scanned-address new-text))
+                            (rf/dispatch [:wallet/clear-address-activity-check])
                             (rf/dispatch [:wallet/clean-scanned-address])))
         paste-on-input  #(clipboard/get-string
                           (fn [clipboard-text]
@@ -67,6 +70,35 @@
        :icon-only?      true}
       :i/scan]]))
 
+(defn activity-indicator
+  []
+  (let [activity-state                                  (rf/sub [:wallet/watch-address-activity-state])
+        {:keys [accessibility-label icon type message]} (case activity-state
+                                                          :has-activity {:accessibility-label
+                                                                         :account-has-activity
+                                                                         :icon :i/done
+                                                                         :type :success
+                                                                         :message
+                                                                         :t/this-address-has-activity}
+                                                          :no-activity  {:accessibility-label
+                                                                         :account-has-no-activity
+                                                                         :icon :i/info
+                                                                         :type :warning
+                                                                         :message
+                                                                         :t/this-address-has-no-activity}
+                                                          {:accessibility-label :searching-for-activity
+                                                           :icon :i/pending-state
+                                                           :type :default
+                                                           :message :t/searching-for-activity})]
+    (when activity-state
+      [quo/info-message
+       {:accessibility-label accessibility-label
+        :size                :default
+        :icon                icon
+        :type                type
+        :style               style/info-message}
+       (i18n/label message)])))
+
 (defn view
   []
   (let [addresses           (rf/sub [:wallet/addresses])
@@ -77,9 +109,11 @@
         clear-input         (fn []
                               (reset! input-value nil)
                               (reset! validation-msg nil)
+                              (rf/dispatch [:wallet/clear-address-activity-check])
                               (rf/dispatch [:wallet/clean-scanned-address]))
         customization-color (rf/sub [:profile/customization-color])]
     (rf/dispatch [:wallet/clean-scanned-address])
+    (rf/dispatch [:wallet/clear-address-activity-check])
     (fn []
       [rn/view
        {:style {:flex 1}}
@@ -89,11 +123,12 @@
                    :icon-name :i/close
                    :on-press  (fn []
                                 (rf/dispatch [:wallet/clean-scanned-address])
+                                (rf/dispatch [:wallet/clear-address-activity-check])
                                 (rf/dispatch [:navigate-back]))}]
          :footer
          [quo/button
           {:customization-color customization-color
-           :disabled?           (string/blank? @input-value)
+           :disabled?           (or (string/blank? @input-value) (some? (validate @input-value)))
            :on-press            #(rf/dispatch [:navigate-to
                                                :confirm-address-to-watch
                                                {:address @input-value}])
@@ -115,4 +150,5 @@
             :icon                :i/info
             :type                :error
             :style               style/info-message}
-           @validation-msg])]])))
+           @validation-msg])
+        [activity-indicator]]])))

--- a/src/status_im2/contexts/wallet/events.cljs
+++ b/src/status_im2/contexts/wallet/events.cljs
@@ -355,3 +355,24 @@
 (rf/reg-event-fx :wallet/select-send-address
  (fn [{:keys [db]} [address]]
    {:db (assoc db :wallet/send-address address)}))
+
+(rf/reg-event-fx :wallet/get-address-details-success
+ (fn [{:keys [db]} [{:keys [hasActivity]}]]
+   {:db (assoc-in db
+         [:wallet :ui :watch-address-activity-state]
+         (if hasActivity :has-activity :no-activity))}))
+
+(rf/reg-event-fx :wallet/clear-address-activity-check
+ (fn [{:keys [db]}]
+   {:db (update-in db [:wallet :ui] dissoc :watch-address-activity-state)}))
+
+(rf/reg-event-fx :wallet/get-address-details
+ (fn [{:keys [db]} [address]]
+   {:db (assoc-in db [:wallet :ui :watch-address-activity-state] :scanning)
+    :fx [[:json-rpc/call
+          [{:method     "wallet_getAddressDetails"
+            :params     [(chain/chain-id db) address]
+            :on-success [:wallet/get-address-details-success]
+            :on-error   #(log/info "failed to get address details"
+                                   {:error %
+                                    :event :wallet/get-address-details})}]]]}))

--- a/src/status_im2/navigation/screens.cljs
+++ b/src/status_im2/navigation/screens.cljs
@@ -270,8 +270,7 @@
      :component wallet-edit-account/view}
 
     {:name      :add-address-to-watch
-     :options   {:insets {:top?    true
-                          :bottom? true}}
+     :options   {:insets {:top? true}}
      :component add-address-to-watch/view}
 
     {:name      :confirm-address-to-watch

--- a/src/status_im2/subs/wallet/wallet.cljs
+++ b/src/status_im2/subs/wallet/wallet.cljs
@@ -15,6 +15,11 @@
  :-> :tokens-loading?)
 
 (rf/reg-sub
+ :wallet/watch-address-activity-state
+ :<- [:wallet/ui]
+ :-> :watch-address-activity-state)
+
+(rf/reg-sub
  :wallet/accounts
  :<- [:wallet]
  :-> #(->> %

--- a/src/status_im2/subs/wallet/wallet_test.cljs
+++ b/src/status_im2/subs/wallet/wallet_test.cljs
@@ -181,3 +181,15 @@
      (= (set ["0x1" "0x2"])
         (rf/sub [sub-name])))))
 
+(h/deftest-sub :wallet/watch-address-activity-state
+  [sub-name]
+  (testing "watch address activity state with nil value"
+    (is (= nil (rf/sub [sub-name]))))
+
+  (testing "watch address activity state with no-activity value"
+    (swap! rf-db/app-db #(assoc-in % [:wallet :ui :watch-address-activity-state] :no-activity))
+    (is (= :no-activity (rf/sub [sub-name]))))
+
+  (testing "watch address activity state with has-activity value"
+    (swap! rf-db/app-db #(assoc-in % [:wallet :ui :watch-address-activity-state] :has-activity))
+    (is (= :has-activity (rf/sub [sub-name])))))

--- a/translations/en.json
+++ b/translations/en.json
@@ -2395,6 +2395,8 @@
     "address-copied": "Address copied",
     "no-dapps-description": "We want dApps!",
     "select-asset": "Select asset",
-    "send-limit": "Max: {{limit}}"
+    "send-limit": "Max: {{limit}}",
+    "searching-for-activity": "Searching for activity...",
+    "this-address-has-no-activity": "This address has no activity",
+    "this-address-has-activity": "This address has activity"   
 }
-


### PR DESCRIPTION
fixes #17877

### Summary

This PR implements the activity check for the entered watch address.


https://github.com/status-im/status-mobile/assets/19339952/228a37b9-4fe1-4ea3-b449-353fdb050add


### Design

[Figma Link](https://www.figma.com/file/HKncH4wnDwZDAhc4AryK8Y/Wallet-for-Mobile?type=design&node-id=2052%3A522375&mode=design&t=nWpEyk6URzby5erP-1)

### Testing notes

This activity check is just checking if there is any balance in the entered address.

### Platforms

- Android
- iOS

### Steps to test

- Open Status
- Navigate to the (new) wallet tab
- Tap on `+` card in the end
- Tap on `Add address to watch`
- Enter an address with some assets (balance) in it to simulate the success message
- Enter an address with no assets (balance) in it to simulate the warning message

status: ready
