### PR TITLE
[#17909] fix: unhandled error when app launched in offline mode

### DIFF
--- a/src/status_im2/contexts/profile/events.cljs
+++ b/src/status_im2/contexts/profile/events.cljs
@@ -43,10 +43,10 @@
           {:keys [key-uid]} (first (sort-by :timestamp > (vals profiles)))]
       (rf/merge cofx
                 (navigation/init-root :profiles)
-                (init-profiles-overview profiles key-uid)
+                (when key-uid (init-profiles-overview profiles key-uid))
                 ;;we check if biometric is available, and try to login with it,
                 ;;if succeed "node.login" signal will be triggered
-                (profile.login/login-with-biometric-if-available key-uid)))
+                (when key-uid (profile.login/login-with-biometric-if-available key-uid))))
     (navigation/init-root cofx :intro)))
 
 (rf/defn update-setting-from-backup

--- a/src/status_im2/contexts/profile/rpc.cljs
+++ b/src/status_im2/contexts/profile/rpc.cljs
@@ -5,8 +5,10 @@
 
 (defn rpc->profiles-overview
   [{:keys [customizationColor keycard-pairing] :as profile}]
-  (-> profile
-      (dissoc :customizationColor)
-      (assoc :customization-color (keyword customizationColor))
-      (assoc :ens-name? (utils.ens/is-valid-eth-name? (:name profile)))
-      (assoc :keycard-pairing (when-not (string/blank? keycard-pairing) keycard-pairing))))
+  (if (map? profile)
+    (-> profile
+        (dissoc :customizationColor)
+        (assoc :customization-color (keyword customizationColor))
+        (assoc :ens-name? (utils.ens/is-valid-eth-name? (:name profile)))
+        (assoc :keycard-pairing (when-not (string/blank? keycard-pairing) keycard-pairing)))
+    profile))


### PR DESCRIPTION
fixes #17909

### Summary
- Read certificate PEM in offline mode throws null pointer error in android
- timesource had issue when device is offline in status-go, already fixed here [status-go/pull/4304](https://github.com/status-im/status-go/pull/4304). i just pointed the app to latest changes

### Steps to test

1. Close the app
2. Turn on the flight mode
3. Open the app again

### Result

iOS

https://github.com/status-im/status-mobile/assets/71308738/63a5d99f-4306-4d6a-99f6-4594670d397d



status: ready
