### PR TITLE
fix: change system time backward break image server

### DIFF
--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.171.25",
-    "commit-sha1": "8206ffc736cdf054f0699b98c3cb52ce6bd6ed96",
-    "src-sha256": "12lfn5xlg9n1fgk9zbi92kmzsqz7wv9zm84xsiisl495w4y8dvsl"
+    "version": "v0.171.26",
+    "commit-sha1": "d92284edcee9f2af5d7f34644796fa5492892720",
+    "src-sha256": "0gjnw0jcwj37a5hmvhc56dm29dcyargmjb0bz9bdbdhdrsjfw9yp"
 }


### PR DESCRIPTION
https://github.com/status-im/status-go/compare/8a4c2d8d...4d4f94cf

fixes #17789

### Summary
status-go pr https://github.com/status-im/status-go/pull/4377
media server TSL cert validity from
now -> 1 year later
to
100 years before -> 100 years later

**user will still encounter the same issue if change their datetime back to more than 100 years ago or after 100 years later**

warning: 
I changed my mac's system time to 1989 and the trackpad stopped working (can track but can't tap)
you can run `sudo date 112416072023` to change your system time to `11/24/2023 16:07` and the trackpad should work again

status: ready <!-- Can be ready or wip -->