### PR TITLE
chore: group ens names with chain-id

### DIFF
--- a/src/status_im/subs/ens.cljs
+++ b/src/status_im/subs/ens.cljs
@@ -61,9 +61,16 @@
     :username username}))
 
 (re-frame/reg-sub
+ :ens/current-names
+ :<- [:ens/names]
+ :<- [:chain-id]
+ (fn [[all-names chain-id]]
+   (get all-names chain-id)))
+
+(re-frame/reg-sub
  :ens.name/screen
  :<- [:get-screen-params :ens-name-details]
- :<- [:ens/names]
+ :<- [:ens/current-names]
  (fn [[name ens]]
    (let [{:keys [address public-key expiration-date releasable?]} (get ens name)
          pending?                                                 (nil? address)]
@@ -79,7 +86,7 @@
 
 (re-frame/reg-sub
  :ens.main/screen
- :<- [:ens/names]
+ :<- [:ens/current-names]
  :<- [:profile/profile]
  :<- [:ens/preferred-name]
  :<- [:ens/registrations]

--- a/src/status_im2/subs/profile.cljs
+++ b/src/status_im2/subs/profile.cljs
@@ -276,7 +276,7 @@
 (re-frame/reg-sub
  :profile/profile-with-image
  :<- [:profile/profile]
- :<- [:ens/names]
+ :<- [:ens/current-names]
  :<- [:mediaserver/port]
  :<- [:initials-avatar-font-file]
  (fn [[profile ens-names port font-file] [_ avatar-opts]]


### PR DESCRIPTION
Adjust the db store structure to accommodate ENS names by adding a 'chain-id' to group them.

> 1) Verification of ENS should be on mainnet unless specifically set in the config. This is a build time config, and not something the user can change (i.e if you change from mainnet to goerli, verification is not impacted, it's set at build time). Testing builds can be set to goerli, but release build should be set to mainnet and cannot be changed.

Although we already have above rules implemented, user can still register ens name on different network via switch network.

Additional description:
status-go already implemented chain-id within table `ens_usernames`, but status-mobile didn't take care of field chain-id:

before my PR, the ens names store in re-frame db may like this:
userA.eth -> {username:userA.eth, chain-id: 1, clock: ...}
userB.eth -> {username:userB.eth, chain-id: 2, clock: ...}
but this could have potential issue like:
what if we got the same ens names, but on different chain-id?

after my PR, the ens names store in re-frame db like this:
1 -> userA.eth -> {username:userA.eth, chain-id: 1, clock: ...}
2 -> userB.eth -> {username:userB.eth, chain-id: 2, clock: ...}

ens names grouped by chain-id.

### Testing notes
- Ens name registraion should work as before.
- After sync ens name, user should only see the corresponding ens name in the ens name list depend on which network they're using.

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

status: ready <!-- Can be ready or wip -->
