### PR TITLE
Add requirement for component tests

### DIFF
--- a/doc/new-guidelines.md
+++ b/doc/new-guidelines.md
@@ -716,7 +716,7 @@ src
 
 - `src/js`: Raw Javascript files, e.g. React Native Reanimated worklets.
 - `src/mocks`: Plumbing configuration to be able to run tests.
-- `src/quo/`: The component library for Status Mobile.
+- `src/quo/`: The component library for Status Mobile. [Read more...](../src/quo/README.md)
 - `src/react_native/`: Contains only low-level constructs to help React Native
   work in tandem with Clojure(Script).
 - `src/status_im2/`: Directory where we try to be as strict as possible about

--- a/doc/new-guidelines.md
+++ b/doc/new-guidelines.md
@@ -687,17 +687,6 @@ actually subscribing to them, so reframe's signal graph gets validated too.
     (is (= expected (rf/sub [sub-name])))))
 ```
 
-#### Component tests
-
-When writing tests for the component that has props, please add one test that covers situation when props aren't passed. Because even if component not showing anything meaningful without props, it shouldn't crash.
-
-```clojure
-(h/describe "Transaction Progress"
-  (h/test "component renders without props"
-    (h/render [quo/transaction-progress {}])
-    (h/is-truthy (h/get-by-label-text :transaction-progress)))
-```
-
 ## Project Structure
 
 First, the bird's-eye view with some example ClojureScript files:

--- a/doc/new-guidelines.md
+++ b/doc/new-guidelines.md
@@ -687,6 +687,17 @@ actually subscribing to them, so reframe's signal graph gets validated too.
     (is (= expected (rf/sub [sub-name])))))
 ```
 
+#### Component tests
+
+When writing tests for the component that has props, please add one test that covers situation when props aren't passed. Because even if component not showing anything meaningful without props, it shouldn't crash.
+
+```clojure
+(h/describe "Transaction Progress"
+  (h/test "component renders without props"
+    (h/render [quo/transaction-progress {}])
+    (h/is-truthy (h/get-by-label-text :transaction-progress)))
+```
+
 ## Project Structure
 
 First, the bird's-eye view with some example ClojureScript files:

--- a/src/quo/README.md
+++ b/src/quo/README.md
@@ -116,6 +116,17 @@ rendered. We use [React Native Testing Library](https://callstack.github.io/reac
 There are dozens of examples in the repository, so use them as a reference. A
 good and complete example is [quo.components.avatars.user-avatar.component-spec](/src/quo/components/avatars/user_avatar/component_spec.cljs)
 
+### No-props test
+
+When writing tests for the component that has props, please add one test that covers situation when props aren't passed. Because even if component not showing anything meaningful without props, it shouldn't crash.
+
+```clojure
+(h/describe "Transaction Progress"
+  (h/test "component renders without props"
+    (h/render [quo/transaction-progress {}])
+    (h/is-truthy (h/get-by-label-text :transaction-progress)))
+```
+
 ## Do not couple the library with re-frame
 
 Don't use re-frame inside this library (e.g. dispatch & subscribe). If a


### PR DESCRIPTION
### Summary

Added requirement to have a component test without props. To ensure components don't crash in such case

status: ready
