### PR TITLE
Don't restrict Diawi upload for `iOS` release builds

### DIFF
--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -77,7 +77,6 @@ pipeline {
           }
         }
         stage('Upload') {
-          when { expression { !utils.isReleaseBuild() } }
           steps { script {
             env.DIAWI_URL = ios.uploadToDiawi()
             env.PKG_URL = env.DIAWI_URL


### PR DESCRIPTION
This PR removes the restriction of uploading iOS release builds to Diawi

### Summary
Its helpful to have app uploaded to Diawi to test release builds on our iPhones.
The installer is very straightforward and makes life easier.

I don't know why we restricted this before.

status: ready 
