### PR TITLE
chore: remove old wallet UI, move set currency to legacy settings, re…

### DIFF
--- a/src/status_im/ui/screens/advanced_settings/views.cljs
+++ b/src/status_im/ui/screens/advanced_settings/views.cljs
@@ -7,6 +7,11 @@
     [utils.i18n :as i18n])
   (:require-macros [status-im.utils.views :as views]))
 
+(defn hide-sheet-and-dispatch
+  [event]
+  (re-frame/dispatch [:bottom-sheet/hide-old])
+  (re-frame/dispatch event))
+
 (defn- normal-mode-settings-data
   [{:keys [network-name
            current-log-level
@@ -103,7 +108,13 @@
      #(re-frame/dispatch
        [:multiaccounts.ui/waku-bloom-filter-mode-switched (not waku-bloom-filter-mode)])
      :accessory :switch
-     :active waku-bloom-filter-mode}]))
+     :active waku-bloom-filter-mode}
+    {:size                :small
+     :title               (i18n/label :t/set-currency)
+     :accessibility-label :wallet-change-currency
+     :on-press            #(hide-sheet-and-dispatch
+                            [:navigate-to :currency-settings])
+     :chevron             true}]))
 
 (defn- flat-list-data
   [options]

--- a/src/status_im/wallet/core.cljs
+++ b/src/status_im/wallet/core.cljs
@@ -1074,7 +1074,7 @@
 
 ;;TODO: this could be replaced by a single API call on status-go side
 (re-frame/reg-fx :wallet-legacy/initialize-wallet
- (fn [[network-id network callback]]
+ (fn [[network-id _network callback]]
    (-> (js/Promise.all
         (clj->js
          [(js/Promise.
@@ -1082,24 +1082,6 @@
              (json-rpc/call {:method     "accounts_getAccounts"
                              :on-success resolve-fn
                              :on-error   reject})))
-          (js/Promise.
-           (fn [resolve-fn _]
-             (json-rpc/call
-              {:method "wallet_addEthereumChain"
-               :params
-               [{:isTest                 false
-                 :tokenOverrides         []
-                 :rpcUrl                 (get-in network [:config :UpstreamConfig :URL])
-                 :chainColor             "green"
-                 :chainName              (:name network)
-                 :nativeCurrencyDecimals 10
-                 :shortName              "erc20"
-                 :layer                  1
-                 :chainId                (int network-id)
-                 :enabled                false
-                 :fallbackURL            (get-in network [:config :UpstreamConfig :URL])}]
-               :on-success resolve-fn
-               :on-error (fn [_] (resolve-fn nil))})))
           (js/Promise.
            (fn [resolve-fn _]
              (json-rpc/call {:method     "wallet_getTokens"

--- a/src/status_im2/contexts/shell/jump_to/state.cljs
+++ b/src/status_im2/contexts/shell/jump_to/state.cljs
@@ -17,6 +17,5 @@
 (def load-chats-stack? (reagent/atom false))
 (def load-wallet-stack? (reagent/atom false))
 (def load-browser-stack? (reagent/atom false))
-
 ;NOTE temporary while we support old wallet
-(def load-new-wallet? (reagent/atom false))
+(def load-new-wallet? (reagent/atom true))


### PR DESCRIPTION
fixes: https://github.com/status-im/status-mobile/issues/17995
https://github.com/status-im/status-mobile/issues/18028

This pr does 3 things. 

1- removes the option to choose the old wallet in the UI. (the code still remains but removing from the UI for now)

2 - Move "set currency" to advanced menu in legacy options.

<img width="296" alt="Screenshot 2023-11-29 at 17 15 58" src="https://github.com/status-im/status-mobile/assets/22799766/76149e82-6ebd-4a3a-88c6-17b2c5a940a0">

3- remove override that was causing ETH balances to be incorrect.

To test:
- ensure old wallet can't be viewed
- check balances for accounts with ETH tokesn - should be correct now.
- check set currency can be reached from the settings page -> advanced settings
