### PR TITLE
Set up skeleton for communities request to join

### DIFF
--- a/src/status_im2/config.cljs
+++ b/src/status_im2/config.cljs
@@ -170,3 +170,5 @@
 (def default-kdf-iterations 3200)
 
 (def shell-navigation-disabled? false)
+
+(def community-accounts-selection-enabled? false)

--- a/src/status_im2/contexts/communities/actions/accounts_selection/view.cljs
+++ b/src/status_im2/contexts/communities/actions/accounts_selection/view.cljs
@@ -1,0 +1,40 @@
+(ns status-im2.contexts.communities.actions.accounts-selection.view
+  (:require
+    [quo.core :as quo]
+    [react-native.core :as rn]
+    [react-native.gesture :as gesture]
+    [status-im2.common.password-authentication.view :as password-authentication]
+    [status-im2.contexts.communities.actions.request-to-join.style :as style]
+    [utils.i18n :as i18n]
+    [utils.re-frame :as rf]))
+
+(defn join-community-and-navigate-back
+  [id]
+  (rf/dispatch [:password-authentication/show
+                {:content (fn [] [password-authentication/view])}
+                {:label    (i18n/label :t/join-open-community)
+                 :on-press #(rf/dispatch [:communities/request-to-join
+                                          {:community-id id :password %}])}])
+  (rf/dispatch [:navigate-back]))
+
+(defn view
+  []
+  (fn []
+    (let [{:keys [_name
+                  id
+                  _images]} (rf/sub [:get-screen-params])]
+      [rn/view {:flex 1}
+       [gesture/scroll-view {:style {:flex 1}}
+        [rn/view style/page-container
+         [rn/view {:style (style/bottom-container)}
+          [quo/button
+           {:accessibility-label :cancel
+            :on-press            #(rf/dispatch [:navigate-back])
+            :type                :grey
+            :container-style     style/cancel-button}
+           (i18n/label :t/cancel)]
+          [quo/button
+           {:accessibility-label :join-community-button
+            :on-press            #(join-community-and-navigate-back id)
+            :container-style     {:flex 1}}
+           (i18n/label :t/request-to-join)]]]]])))

--- a/src/status_im2/contexts/communities/overview/view.cljs
+++ b/src/status_im2/contexts/communities/overview/view.cljs
@@ -10,6 +10,7 @@
     [status-im2.common.password-authentication.view :as password-authentication]
     [status-im2.common.scroll-page.style :as scroll-page.style]
     [status-im2.common.scroll-page.view :as scroll-page]
+    [status-im2.config :as config]
     [status-im2.constants :as constants]
     [status-im2.contexts.communities.actions.chat.view :as chat-actions]
     [status-im2.contexts.communities.actions.community-options.view :as options]
@@ -182,10 +183,14 @@
        (if (seq token-permissions)
          [token-gates community]
          [quo/button
-          {:on-press            #(rf/dispatch [:open-modal :community-requests-to-join community])
+          {:on-press
+           (if config/community-accounts-selection-enabled?
+             #(rf/dispatch [:open-modal :community-account-selection community])
+             #(rf/dispatch [:open-modal :community-requests-to-join community]))
+
            :accessibility-label :show-request-to-join-screen-button
            :customization-color color
-           :icon-left           :i/communities}
+           :icon-left :i/communities}
           (i18n/label :t/request-to-join-community)]))
 
      (when (not (or joined pending? token-permissions))

--- a/src/status_im2/navigation/screens.cljs
+++ b/src/status_im2/navigation/screens.cljs
@@ -9,6 +9,7 @@
     [status-im2.contexts.chat.messages.view :as chat]
     [status-im2.contexts.chat.new-chat.view :as new-chat]
     [status-im2.contexts.chat.photo-selector.view :as photo-selector]
+    [status-im2.contexts.communities.actions.accounts-selection.view :as communities.accounts-selection]
     [status-im2.contexts.communities.actions.request-to-join.view :as join-menu]
     [status-im2.contexts.communities.discover.view :as communities.discover]
     [status-im2.contexts.communities.overview.view :as communities.overview]
@@ -88,6 +89,10 @@
     {:name      :community-requests-to-join
      :options   {:sheet? true}
      :component join-menu/request-to-join}
+
+    {:name      :community-account-selection
+     :options   {:sheet? true}
+     :component communities.accounts-selection/view}
 
     {:name      :lightbox
      :options   options/lightbox


### PR DESCRIPTION
This commit sets up a feature toggled (disabled) skeleton for the work on account selection for the community.

I have tested both paths and it shows the right modal if the toggle is on or off.

I wasn't able to actually join a community (the request was staying at pending in both cases :face_with_thermometer: ), but I don't believe there's anything wrong with this code, I will take a look, but that's a separate issue.

This will skip manual QA, since it's a minor change and doesn't impact production (cc @churik, if you are ok with it), but could either @ilmotta @FFFra @ajayesivan @yqrashawn validate the behavior? 

I kept it to a minimum and removed everything but the cancel/request to join button, in order to have a full flow.