### PR TITLE
Match the changes in collectibles api in status-go

### DIFF
--- a/src/status_im2/contexts/wallet/collectible/view.cljs
+++ b/src/status_im2/contexts/wallet/collectible/view.cljs
@@ -112,11 +112,11 @@
 
 (defn view
   []
-  (let [collectible                                               (rf/sub
-                                                                   [:wallet/last-collectible-details])
-        {:keys [id collectible-data preview-url collection-data]} collectible
-        {:keys [traits description]}                              collectible-data
-        chain-id                                                  (get-in id [:contract-id :chain-id])]
+  (let [collectible                  (rf/sub [:wallet/last-collectible-details])
+        {:keys [collectible-data preview-url
+                collection-data]}    collectible
+        {:keys [traits description]} collectible-data
+        chain-id                     (rf/sub [:wallet/last-collectible-chain-id])]
     [scroll-page/scroll-page
      {:navigate-back? true
       :height         148

--- a/src/status_im2/contexts/wallet/collectible/view.cljs
+++ b/src/status_im2/contexts/wallet/collectible/view.cljs
@@ -10,7 +10,7 @@
     [utils.re-frame :as rf]))
 
 (defn header
-  [{:keys [name description collection-image-url]}]
+  [{:keys [name description] :as _collectible-details} collection-image-url]
   [rn/view {:style style/header}
    [quo/text
     {:weight :semi-bold
@@ -112,9 +112,11 @@
 
 (defn view
   []
-  (let [collectible-details                              (rf/sub [:wallet/last-collectible-details])
-        {:keys [name description preview-url traits id]} collectible-details
-        chain-id                                         (get-in id [:contract-id :chain-id])]
+  (let [collectible                                               (rf/sub
+                                                                   [:wallet/last-collectible-details])
+        {:keys [id collectible-data preview-url collection-data]} collectible
+        {:keys [traits description]}                              collectible-data
+        chain-id                                                  (get-in id [:contract-id :chain-id])]
     [scroll-page/scroll-page
      {:navigate-back? true
       :height         148
@@ -129,7 +131,7 @@
        [rn/image
         {:source preview-url
          :style  style/preview}]]
-      [header collectible-details]
+      [header collectible-data (:image-url collection-data)]
       [cta-buttons]
       [tabs]
       [info chain-id]

--- a/src/status_im2/contexts/wallet/events.cljs
+++ b/src/status_im2/contexts/wallet/events.cljs
@@ -215,9 +215,10 @@
 (def collectibles-request-batch-size 1000)
 
 (defn displayable-collectible?
-  [{:keys [image-url animation-url]}]
-  (or (not (string/blank? animation-url))
-      (not (string/blank? image-url))))
+  [collectible]
+  (let [{:keys [image-url animation-url]} (:collectible-data collectible)]
+    (or (not (string/blank? animation-url))
+        (not (string/blank? image-url)))))
 
 (defn store-collectibles
   [{:keys [db]} [collectibles]]
@@ -243,18 +244,37 @@
 
 (rf/reg-event-fx :wallet/store-last-collectible-details store-last-collectible-details)
 
+(def collectible-data-types
+  {:unique-id        0
+   :header           1
+   :details          2
+   :community-header 3})
+
+(def fetch-type
+  {:never-fetch         0
+   :always-fetch        1
+   :fetch-if-not-cached 2
+   :fetch-if-cache-old  3})
+
+(def max-cache-age-seconds 3600)
+
 (rf/reg-event-fx
  :wallet/request-collectibles
  (fn [{:keys [db]} [{:keys [start-at-index new-request?]}]]
    (let [request-id          0
          collectibles-filter nil
+         data-type           (collectible-data-types :header)
+         fetch-criteria      {:fetch-type            (fetch-type :fetch-if-not-cached)
+                              :max-cache-age-seconds max-cache-age-seconds}
          request-params      [request-id
                               [(chain/chain-id db)]
                               (map :address (:profile/wallet-accounts db))
                               collectibles-filter
                               start-at-index
-                              collectibles-request-batch-size]]
-     {:json-rpc/call [{:method     "wallet_filterOwnedCollectiblesAsync"
+                              collectibles-request-batch-size
+                              data-type
+                              fetch-criteria]]
+     {:json-rpc/call [{:method     "wallet_getOwnedCollectiblesAsync"
                        :params     request-params
                        :on-success #()
                        :on-error   (fn [error]
@@ -283,8 +303,9 @@
  (fn [_ [collectible-id]]
    (let [request-id               0
          collectible-id-converted (cske/transform-keys csk/->PascalCaseKeyword collectible-id)
-         request-params           [request-id [collectible-id-converted]]]
-     {:json-rpc/call [{:method   "wallet_getCollectiblesDetailsAsync"
+         data-type                (collectible-data-types :details)
+         request-params           [request-id [collectible-id-converted] data-type]]
+     {:json-rpc/call [{:method   "wallet_getCollectiblesByUniqueIDAsync"
                        :params   request-params
                        :on-error (fn [error]
                                    (log/error "failed to request collectible"

--- a/src/status_im2/contexts/wallet/events.cljs
+++ b/src/status_im2/contexts/wallet/events.cljs
@@ -274,17 +274,17 @@
                               collectibles-request-batch-size
                               data-type
                               fetch-criteria]]
-     {:json-rpc/call [{:method     "wallet_getOwnedCollectiblesAsync"
-                       :params     request-params
-                       :on-success #()
-                       :on-error   (fn [error]
-                                     (log/error "failed to request collectibles"
-                                                {:event  :wallet/request-collectibles
-                                                 :error  error
-                                                 :params request-params}))}]
-      :fx            (if new-request?
-                       [[:dispatch [:wallet/clear-stored-collectibles]]]
-                       [])})))
+     {:fx [[:json-rpc/call
+            [{:method     "wallet_getOwnedCollectiblesAsync"
+              :params     request-params
+              :on-success #()
+              :on-error   (fn [error]
+                            (log/error "failed to request collectibles"
+                                       {:event  :wallet/request-collectibles
+                                        :error  error
+                                        :params request-params}))}]]
+           (when new-request?
+             [:dispatch [:wallet/clear-stored-collectibles]])]})))
 
 (rf/reg-event-fx :wallet/owned-collectibles-filtering-done
  (fn [_ [{:keys [message]}]]
@@ -305,13 +305,14 @@
          collectible-id-converted (cske/transform-keys csk/->PascalCaseKeyword collectible-id)
          data-type                (collectible-data-types :details)
          request-params           [request-id [collectible-id-converted] data-type]]
-     {:json-rpc/call [{:method   "wallet_getCollectiblesByUniqueIDAsync"
-                       :params   request-params
-                       :on-error (fn [error]
-                                   (log/error "failed to request collectible"
-                                              {:event  :wallet/get-collectible-details
-                                               :error  error
-                                               :params request-params}))}]})))
+     {:fx [[:json-rpc/call
+            [{:method   "wallet_getCollectiblesByUniqueIDAsync"
+              :params   request-params
+              :on-error (fn [error]
+                          (log/error "failed to request collectible"
+                                     {:event  :wallet/get-collectible-details
+                                      :error  error
+                                      :params request-params}))}]]]})))
 
 (rf/reg-event-fx :wallet/get-collectible-details-done
  (fn [_ [{:keys [message]}]]

--- a/src/status_im2/contexts/wallet/events_test.cljs
+++ b/src/status_im2/contexts/wallet/events_test.cljs
@@ -23,15 +23,16 @@
 
 (deftest store-collectibles
   (testing "(displayable-collectible?) helper function"
-    (let [expected-results [[true {:image-url "https://..." :animation-url "https://..."}]
-                            [true {:image-url "" :animation-url "https://..."}]
-                            [true {:image-url nil :animation-url "https://..."}]
-                            [true {:image-url "https://..." :animation-url ""}]
-                            [true {:image-url "https://..." :animation-url nil}]
-                            [false {:image-url "" :animation-url nil}]
-                            [false {:image-url nil :animation-url nil}]
-                            [false {:image-url nil :animation-url ""}]
-                            [false {:image-url "" :animation-url ""}]]]
+    (let [expected-results [[true
+                             {:collectible-data {:image-url "https://..." :animation-url "https://..."}}]
+                            [true {:collectible-data {:image-url "" :animation-url "https://..."}}]
+                            [true {:collectible-data {:image-url nil :animation-url "https://..."}}]
+                            [true {:collectible-data {:image-url "https://..." :animation-url ""}}]
+                            [true {:collectible-data {:image-url "https://..." :animation-url nil}}]
+                            [false {:collectible-data {:image-url "" :animation-url nil}}]
+                            [false {:collectible-data {:image-url nil :animation-url nil}}]
+                            [false {:collectible-data {:image-url nil :animation-url ""}}]
+                            [false {:collectible-data {:image-url "" :animation-url ""}}]]]
       (doseq [[result collection] expected-results]
         (is (= result (events/displayable-collectible? collection))))))
   (testing "save-collectibles-request-details"

--- a/src/status_im2/contexts/wallet/events_test.cljs
+++ b/src/status_im2/contexts/wallet/events_test.cljs
@@ -37,11 +37,13 @@
         (is (= result (events/displayable-collectible? collection))))))
   (testing "save-collectibles-request-details"
     (let [db           {:wallet {}}
-          collectibles [{:image-url "https://..." :animation-url "https://..."}
-                        {:image-url "" :animation-url "https://..."}
-                        {:image-url "" :animation-url nil}]
-          expected-db  {:wallet {:collectibles [{:image-url "https://..." :animation-url "https://..."}
-                                                {:image-url "" :animation-url "https://..."}]}}
+          collectibles [{:collectible-data {:image-url "https://..." :animation-url "https://..."}}
+                        {:collectible-data {:image-url "" :animation-url "https://..."}}
+                        {:collectible-data {:image-url "" :animation-url nil}}]
+          expected-db  {:wallet {:collectibles [{:collectible-data
+                                                 {:image-url "https://..." :animation-url "https://..."}}
+                                                {:collectible-data
+                                                 {:image-url "" :animation-url "https://..."}}]}}
           effects      (events/store-collectibles {:db db} [collectibles])
           result-db    (:db effects)]
       (is (= result-db expected-db)))))

--- a/src/status_im2/subs/wallet/collectibles.cljs
+++ b/src/status_im2/subs/wallet/collectibles.cljs
@@ -24,3 +24,9 @@
  (fn [wallet]
    (let [last-collectible (:last-collectible-details wallet)]
      (assoc last-collectible :preview-url (preview-url (:collectible-data last-collectible))))))
+
+(re-frame/reg-sub
+ :wallet/last-collectible-chain-id
+ :<- [:wallet/last-collectible-details]
+ (fn [collectible]
+   (get-in collectible [:id :contract-id :chain-id])))

--- a/src/status_im2/subs/wallet/collectibles.cljs
+++ b/src/status_im2/subs/wallet/collectibles.cljs
@@ -15,7 +15,7 @@
  :<- [:wallet]
  (fn [wallet]
    (map (fn [collectible]
-          (assoc collectible :preview-url (preview-url collectible)))
+          (assoc collectible :preview-url (preview-url (:collectible-data collectible))))
         (:collectibles wallet))))
 
 (re-frame/reg-sub
@@ -23,4 +23,4 @@
  :<- [:wallet]
  (fn [wallet]
    (let [last-collectible (:last-collectible-details wallet)]
-     (assoc last-collectible :preview-url (preview-url last-collectible)))))
+     (assoc last-collectible :preview-url (preview-url (:collectible-data last-collectible))))))


### PR DESCRIPTION

fixes #17936

### Summary

Collectible api was changed by [this status-go PR](https://github.com/status-im/status-go/pull/4290/files).
This PR updates the mobile code to match the changes.


### Review notes
Latest `status-go` commit used, not sure if it is better to use the commit from PR with API changes.


status: ready
