### PR TITLE
Quick win: move effects to separate namespaces

### DIFF
--- a/.zprintrc
+++ b/.zprintrc
@@ -32,6 +32,7 @@
   "letsubs"         :binding
   "with-let"        "let"
   "reg-event-fx"    :arg1-pair
+  "reg-fx"          :arg1-pair
   "testing"         :arg1-body
   "deftest-sub"     :arg1-body
   "wait-for"        :arg1-body

--- a/src/status_im/events.cljs
+++ b/src/status_im/events.cljs
@@ -194,9 +194,9 @@
   (rf/merge cofx
             (cond
               (= :chat view-id)
-              {:async-storage-set {:chat-id (get-in cofx [:db :current-chat-id])
-                                   :key-uid (get-in cofx [:db :profile/profile :key-uid])}
-               :db                (assoc db :screens/was-focused-once? true)}
+              {:effects.async-storage/set {:chat-id (get-in cofx [:db :current-chat-id])
+                                           :key-uid (get-in cofx [:db :profile/profile :key-uid])}
+               :db                        (assoc db :screens/was-focused-once? true)}
 
               (not (get db :screens/was-focused-once?))
               {:db (assoc db :screens/was-focused-once? true)})

--- a/src/status_im/keycard/change_pin.cljs
+++ b/src/status_im/keycard/change_pin.cljs
@@ -141,14 +141,14 @@
   (let [pin          (get-in db [:keycard :pin :original])
         puk-restore? (get-in db [:keycard :pin :puk-restore?])]
     (rf/merge cofx
-              {:db               (assoc-in db
-                                  [:keycard :pin]
-                                  {:status       nil
-                                   :login        pin
-                                   :confirmation []
-                                   :error-label  nil})
-               :utils/show-popup {:title   ""
-                                  :content (i18n/label :t/pin-changed)}}
+              {:db                       (assoc-in db
+                                          [:keycard :pin]
+                                          {:status       nil
+                                           :login        pin
+                                           :confirmation []
+                                           :error-label  nil})
+               :effects.utils/show-popup {:title   ""
+                                          :content (i18n/label :t/pin-changed)}}
               (common/hide-connection-sheet)
               (if puk-restore?
                 (navigation/navigate-to :multiaccounts nil)
@@ -160,14 +160,14 @@
   {:events [:keycard.callback/on-change-puk-success]}
   [{:keys [db] :as cofx}]
   (rf/merge cofx
-            {:db               (assoc-in db
-                                [:keycard :pin]
-                                {:status           nil
-                                 :puk-original     []
-                                 :puk-confirmation []
-                                 :error-label      nil})
-             :utils/show-popup {:title   ""
-                                :content (i18n/label :t/puk-changed)}}
+            {:db                       (assoc-in db
+                                        [:keycard :pin]
+                                        {:status           nil
+                                         :puk-original     []
+                                         :puk-confirmation []
+                                         :error-label      nil})
+             :effects.utils/show-popup {:title   ""
+                                        :content (i18n/label :t/puk-changed)}}
             (common/hide-connection-sheet)
             (navigation/set-stack-root :profile-stack [:my-profile :keycard-settings])))
 
@@ -175,13 +175,13 @@
   {:events [:keycard.callback/on-change-pairing-success]}
   [{:keys [db] :as cofx}]
   (rf/merge cofx
-            {:db               (assoc-in db
-                                [:keycard :pin]
-                                {:status       nil
-                                 :pairing-code nil
-                                 :error-label  nil})
-             :utils/show-popup {:title   ""
-                                :content (i18n/label :t/pairing-changed)}}
+            {:db                       (assoc-in db
+                                        [:keycard :pin]
+                                        {:status       nil
+                                         :pairing-code nil
+                                         :error-label  nil})
+             :effects.utils/show-popup {:title   ""
+                                        :content (i18n/label :t/pairing-changed)}}
             (common/hide-connection-sheet)
             (navigation/set-stack-root :profile-stack [:my-profile :keycard-settings])))
 

--- a/src/status_im/keycard/common.cljs
+++ b/src/status_im/keycard/common.cljs
@@ -293,14 +293,14 @@
 (rf/defn show-wrong-keycard-alert
   [_]
   (log/debug "show-wrong-keycard-alert")
-  {:utils/show-popup {:title   (i18n/label :t/wrong-card)
-                      :content (i18n/label :t/wrong-card-text)}})
+  {:effects.utils/show-popup {:title   (i18n/label :t/wrong-card)
+                              :content (i18n/label :t/wrong-card-text)}})
 
 (rf/defn unauthorized-operation
   [cofx]
   (rf/merge cofx
-            {:utils/show-popup {:title   ""
-                                :content (i18n/label :t/keycard-unauthorized-operation)}}
+            {:effects.utils/show-popup {:title   ""
+                                        :content (i18n/label :t/keycard-unauthorized-operation)}}
             (clear-on-card-connected)
             (navigation/set-stack-root :profile-stack [:my-profile :keycard-settings])))
 

--- a/src/status_im/keycard/core.cljs
+++ b/src/status_im/keycard/core.cljs
@@ -24,12 +24,12 @@
 (rf/defn show-keycard-has-multiaccount-alert
   [{:keys [db] :as cofx}]
   (rf/merge cofx
-            {:db                      (assoc-in db [:keycard :setup-step] nil)
-             :utils/show-confirmation {:title               nil
-                                       :content             (i18n/label
-                                                             :t/keycard-has-multiaccount-on-it)
-                                       :cancel-button-text  ""
-                                       :confirm-button-text :t/okay}}))
+            {:db                              (assoc-in db [:keycard :setup-step] nil)
+             :effects.utils/show-confirmation {:title               nil
+                                               :content             (i18n/label
+                                                                     :t/keycard-has-multiaccount-on-it)
+                                               :cancel-button-text  ""
+                                               :confirm-button-text :t/okay}}))
 
 (rf/defn load-pin-screen
   [{:keys [db] :as cofx}]
@@ -548,10 +548,11 @@
 
 (rf/defn show-no-keycard-applet-alert
   [_]
-  {:utils/show-confirmation {:title               (i18n/label :t/no-keycard-applet-on-card)
-                             :content             (i18n/label :t/keycard-applet-install-instructions)
-                             :cancel-button-text  ""
-                             :confirm-button-text :t/okay}})
+  {:effects.utils/show-confirmation {:title               (i18n/label :t/no-keycard-applet-on-card)
+                                     :content             (i18n/label
+                                                           :t/keycard-applet-install-instructions)
+                                     :cancel-button-text  ""
+                                     :confirm-button-text :t/okay}})
 
 ;; NOTE: Maybe replaced by multiple events based on on flow to make it easier to maintain.
 ;; Because there are many execution paths it is harder to follow all possible states.

--- a/src/status_im/keycard/onboarding.cljs
+++ b/src/status_im/keycard/onboarding.cljs
@@ -35,8 +35,8 @@
       (do
         (log/debug (str "Cannot start keycard installation from state: " card-state))
         (rf/merge cofx
-                  {:utils/show-popup {:title   (i18n/label :t/error)
-                                      :content (i18n/label :t/something-went-wrong)}}
+                  {:effects.utils/show-popup {:title   (i18n/label :t/error)
+                                              :content (i18n/label :t/something-went-wrong)}}
                   (navigation/navigate-to :keycard-authentication-method nil))))))
 
 (rf/defn load-preparing-screen

--- a/src/status_im/keycard/recovery.cljs
+++ b/src/status_im/keycard/recovery.cljs
@@ -221,12 +221,12 @@
 (rf/defn on-backup-success
   [{:keys [db] :as cofx} backup-type]
   (rf/merge cofx
-            {:utils/show-popup {:title   (i18n/label (if (= backup-type :recovery-card)
-                                                       :t/keycard-access-reset
-                                                       :t/keycard-backup-success-title))
-                                :content (i18n/label (if (= backup-type :recovery-card)
-                                                       :t/keycard-can-use-with-new-passcode
-                                                       :t/keycard-backup-success-body))}}
+            {:effects.utils/show-popup {:title   (i18n/label (if (= backup-type :recovery-card)
+                                                               :t/keycard-access-reset
+                                                               :t/keycard-backup-success-title))
+                                        :content (i18n/label (if (= backup-type :recovery-card)
+                                                               :t/keycard-can-use-with-new-passcode
+                                                               :t/keycard-backup-success-body))}}
             (cond
               (multiaccounts.model/logged-in? db)
               (navigation/set-stack-root :profile-stack [:my-profile :keycard-settings])
@@ -373,4 +373,3 @@
    cofx
    {:on-card-connected :keycard/load-recovering-key-screen
     :handler           (common/dispatch-event :keycard/import-multiaccount)}))
-

--- a/src/status_im/keycard/unpair.cljs
+++ b/src/status_im/keycard/unpair.cljs
@@ -83,7 +83,7 @@
                                                :error-label nil
                                                :on-verified nil}))
       :keycard/persist-pairings (dissoc pairings (keyword instance-uid))
-      :utils/show-popup         {:title   ""
+      :effects.utils/show-popup {:title   ""
                                  :content (i18n/label :t/card-unpaired)}}
      (common/clear-on-card-connected)
      (remove-pairing-from-multiaccount nil)
@@ -100,7 +100,7 @@
                                              :error-label nil
                                              :on-verified nil})
              :keycard/get-application-info nil
-             :utils/show-popup             {:title   ""
+             :effects.utils/show-popup     {:title   ""
                                             :content (i18n/label :t/something-went-wrong)}}
             (common/clear-on-card-connected)
             (navigation/navigate-to :keycard-settings nil)))
@@ -139,15 +139,14 @@
                                                :error-label nil
                                                :on-verified nil}))
       :keycard/persist-pairings (dissoc pairings (keyword instance-uid))
-      :utils/show-popup         {:title      (i18n/label (if keys-removed-from-card?
+      :effects.utils/show-popup {:title      (i18n/label (if keys-removed-from-card?
                                                            :t/profile-deleted-title
                                                            :t/database-reset-title))
                                  :content    (i18n/label (if keys-removed-from-card?
                                                            :t/profile-deleted-keycard
                                                            :t/database-reset-content))
                                  :on-dismiss #(re-frame/dispatch [:logout])}}
-     ;;should be reimplemented
-     ;;:key-storage/delete-profile {:key-uid    key-uid
+     ;;should be reimplemented :key-storage/delete-profile {:key-uid    key-uid
      ;;:on-success #(log/debug "[keycard] remove account ok")
      ;;                                  :on-error   #(log/warn "[keycard] remove account: " %)}
      (common/clear-on-card-connected)

--- a/src/status_im/mailserver/core.cljs
+++ b/src/status_im/mailserver/core.cljs
@@ -194,7 +194,7 @@
   {:events [:mailserver.ui/request-error-pressed]}
   [{:keys [db]}]
   (let [mailserver-error (:mailserver/request-error db)]
-    {:utils/show-confirmation
+    {:effects.utils/show-confirmation
      {:title               (i18n/label :t/mailserver-request-error-title)
       :content             (i18n/label :t/mailserver-request-error-content
                                        {:error mailserver-error})
@@ -290,8 +290,7 @@
          [{:method     "mailservers_addMailserver"
            :params     [(mailserver->rpc mailserver current-fleet)]
            :on-success (fn []
-                         ;; we naively logout if the user is connected to
-                         ;; the edited mailserver
+                         ;; we naively logout if the user is connected to the edited mailserver
                          (when current
                            (re-frame/dispatch
                             [:multiaccounts.logout.ui/logout-confirmed]))

--- a/src/status_im/multiaccounts/logout/core.cljs
+++ b/src/status_im/multiaccounts/logout/core.cljs
@@ -31,7 +31,7 @@
     (rf/merge cofx
               {:set-root                               :progress
                :chat.ui/clear-inputs                   nil
-               :shell/reset-state                      nil
+               :effects.shell/reset-state              nil
                :hide-popover                           nil
                ::logout                                nil
                :profile.settings/webview-debug-changed false

--- a/src/status_im/network/core.cljs
+++ b/src/status_im/network/core.cljs
@@ -89,7 +89,7 @@
 (rf/defn connect-failure
   {:events [::connect-failure]}
   [_ reason]
-  {:utils/show-popup
+  {:effects.utils/show-popup
    {:title   (i18n/label :t/error)
     :content (str reason)}})
 

--- a/src/status_im/pairing/core.cljs
+++ b/src/status_im/pairing/core.cljs
@@ -165,9 +165,9 @@
   (if (< (count (filter :enabled? (vals (get-in cofx [:db :pairing/installations]))))
          (inc config/max-installations))
     {:pairing/enable-installation [installation-id]}
-    {:utils/show-popup {:title   (i18n/label :t/pairing-maximum-number-reached-title)
+    {:effects.utils/show-popup {:title   (i18n/label :t/pairing-maximum-number-reached-title)
 
-                        :content (i18n/label :t/pairing-maximum-number-reached-content)}}))
+                                :content (i18n/label :t/pairing-maximum-number-reached-content)}}))
 
 (rf/defn disable-fx
   {:events [:pairing.ui/disable-installation-pressed]}

--- a/src/status_im/qr_scanner/core.cljs
+++ b/src/status_im/qr_scanner/core.cljs
@@ -49,8 +49,8 @@
   [{:keys [db] :as cofx} {:keys [chat-id]}]
   (if-not (own-public-key? db chat-id)
     {:dispatch [:chat.ui/start-chat chat-id]}
-    {:utils/show-popup {:title   (i18n/label :t/unable-to-read-this-code)
-                        :content (i18n/label :t/can-not-add-yourself)}}))
+    {:effects.utils/show-popup {:title   (i18n/label :t/unable-to-read-this-code)
+                                :content (i18n/label :t/can-not-add-yourself)}}))
 
 (rf/defn handle-group-chat
   [cofx params]
@@ -71,9 +71,9 @@
                 (navigation/navigate-back))
 
       :else
-      {:utils/show-popup {:title      (i18n/label :t/unable-to-read-this-code)
-                          :content    (i18n/label :t/ens-name-not-found)
-                          :on-dismiss #(re-frame/dispatch [:pop-to-root :shell-stack])}})))
+      {:effects.utils/show-popup {:title      (i18n/label :t/unable-to-read-this-code)
+                                  :content    (i18n/label :t/ens-name-not-found)
+                                  :on-dismiss #(re-frame/dispatch [:pop-to-root :shell-stack])}})))
 
 (rf/defn handle-eip681
   [cofx data]
@@ -103,9 +103,9 @@
       (log/info "Unable to find matcher for scanned value"
                 {:type  type
                  :event ::match-scanned-value})
-      {:dispatch         [:navigate-back]
-       :utils/show-popup {:title      (i18n/label :t/unable-to-read-this-code)
-                          :on-dismiss #(re-frame/dispatch [:pop-to-root :shell-stack])}})))
+      {:dispatch                 [:navigate-back]
+       :effects.utils/show-popup {:title      (i18n/label :t/unable-to-read-this-code)
+                                  :on-dismiss #(re-frame/dispatch [:pop-to-root :shell-stack])}})))
 
 (rf/defn on-scan
   {:events [::on-scan-success]}

--- a/src/status_im/signing/keycard.cljs
+++ b/src/status_im/signing/keycard.cljs
@@ -78,9 +78,9 @@
   [{:keys [db]} data typed? result]
   (let [{:keys [result error]} (types/json->clj result)]
     (if error
-      {:dispatch         [:signing.ui/cancel-is-pressed]
-       :utils/show-popup {:title   (i18n/label :t/sign-request-failed)
-                          :content (:message error)}}
+      {:dispatch                 [:signing.ui/cancel-is-pressed]
+       :effects.utils/show-popup {:title   (i18n/label :t/sign-request-failed)
+                                  :content (:message error)}}
       {:db (update db
                    :keycard assoc
                    :hash    result

--- a/src/status_im/ui/screens/privacy_and_security_settings/events.cljs
+++ b/src/status_im/ui/screens/privacy_and_security_settings/events.cljs
@@ -56,7 +56,7 @@
   {:events [::on-delete-profile-success]}
   [cofx]
   (log/info "[delete-profile] on-success")
-  {:utils/show-popup
+  {:effects.utils/show-popup
    {:title      (i18n/label :t/profile-deleted-title)
     :content    (i18n/label :t/profile-deleted-content)
     :on-dismiss #(re-frame/dispatch [:logout])}})

--- a/src/status_im/utils/logging/core.cljs
+++ b/src/status_im/utils/logging/core.cljs
@@ -151,15 +151,15 @@
 (rf/defn show-client-error
   {:events [:show-client-error]}
   [_]
-  {:utils/show-popup {:title   (i18n/label :t/cant-report-bug)
-                      :content (i18n/label :t/mail-should-be-configured)}})
+  {:effects.utils/show-popup {:title   (i18n/label :t/cant-report-bug)
+                              :content (i18n/label :t/mail-should-be-configured)}})
 
 (rf/defn show-logs-dialog
   {:events [:shake-event]}
   [{:keys [db]}]
   (when-not (:logging/dialog-shown? db)
     {:db (assoc db :logging/dialog-shown? true)
-     :utils/show-confirmation
+     :effects.utils/show-confirmation
      (cond-> {:title               (i18n/label :t/send-logs)
               :content             (i18n/label :t/send-logs-to
                                                {:email report-email})

--- a/src/status_im/wallet/accounts/core.cljs
+++ b/src/status_im/wallet/accounts/core.cljs
@@ -359,8 +359,8 @@
   (let [deleted-address (:address account)
         dapps-address   (get-in cofx [:db :profile/profile :dapps-address])]
     (if (= (string/lower-case dapps-address) (string/lower-case deleted-address))
-      {:utils/show-popup {:title   (i18n/label :t/warning)
-                          :content (i18n/label :t/account-is-used)}}
+      {:effects.utils/show-popup {:title   (i18n/label :t/warning)
+                                  :content (i18n/label :t/account-is-used)}}
       {:key-storage/delete-imported-key
        {:key-uid    (get-in db [:profile/profile :key-uid])
         :address    (:address account)
@@ -379,8 +379,8 @@
                               (assoc-in [:add-account :scanned-address] address)
                               (assoc-in [:add-account :address] address))}
                      (when-not address
-                       {:utils/show-popup {:title   (i18n/label :t/error)
-                                           :content (i18n/label :t/invalid-address-qr-code)}}))
+                       {:effects.utils/show-popup {:title   (i18n/label :t/error)
+                                                   :content (i18n/label :t/invalid-address-qr-code)}}))
               (navigation/navigate-back))))
 
 (re-frame/reg-fx
@@ -392,4 +392,3 @@
   {:events [:wallet-legacy.accounts/share]}
   [_ address]
   {:list.selection/open-share {:message (eip55/address->checksum address)}})
-

--- a/src/status_im/wallet/core.cljs
+++ b/src/status_im/wallet/core.cljs
@@ -246,8 +246,8 @@
         assets                                  (get visible-tokens chain)
         tokens                                  (->> (vals all-tokens)
                                                      (remove #(or (:hidden? %)
-                                                                  ;;if not scan-all-tokens? remove not
-                                                                  ;;visible tokens
+                                                                  ;;if not scan-all-tokens? remove
+                                                                  ;;not visible tokens
                                                                   (and (not scan-all-tokens?)
                                                                        (not (get assets (:symbol %))))))
                                                      (reduce (fn [acc {:keys [address symbol]}]
@@ -822,8 +822,8 @@
 (rf/defn get-buy-crypto-preference
   {:events [::get-buy-crypto]}
   [_]
-  {:async-storage-get {:keys [:buy-crypto-hidden]
-                       :cb   #(re-frame/dispatch [::store-buy-crypto-preference %])}})
+  {:effects.async-storage/get {:keys [:buy-crypto-hidden]
+                               :cb   #(re-frame/dispatch [::store-buy-crypto-preference %])}})
 
 (rf/defn wallet-will-focus
   {:events [::wallet-stack]}
@@ -844,8 +844,8 @@
 (rf/defn hide-buy-crypto
   {:events [::hide-buy-crypto]}
   [{:keys [db]}]
-  {:db                (assoc db :wallet-legacy/buy-crypto-hidden true)
-   :async-storage-set {:buy-crypto-hidden true}})
+  {:db                        (assoc db :wallet-legacy/buy-crypto-hidden true)
+   :effects.async-storage/set {:buy-crypto-hidden true}})
 
 (rf/defn store-buy-crypto
   {:events [::store-buy-crypto-preference]}
@@ -1023,8 +1023,8 @@
 (rf/defn switch-transactions-management-enabled
   {:events [:multiaccounts.ui/switch-transactions-management-enabled]}
   [{:keys [db]} enabled?]
-  {:async-storage-set {:transactions-management-enabled? enabled?}
-   :db                (assoc db :wallet-legacy/transactions-management-enabled? enabled?)})
+  {:effects.async-storage/set {:transactions-management-enabled? enabled?}
+   :db                        (assoc db :wallet-legacy/transactions-management-enabled? enabled?)})
 
 (re-frame/reg-fx
  :wallet-legacy/initialize-transactions-management-enabled
@@ -1072,9 +1072,8 @@
                                                        true])}))
     2000)))
 
-(re-frame/reg-fx
- ;;TODO: this could be replaced by a single API call on status-go side
- :wallet-legacy/initialize-wallet
+;;TODO: this could be replaced by a single API call on status-go side
+(re-frame/reg-fx :wallet-legacy/initialize-wallet
  (fn [[network-id network callback]]
    (-> (js/Promise.all
         (clj->js

--- a/src/status_im/wallet/custom_tokens/core.cljs
+++ b/src/status_im/wallet/custom_tokens/core.cljs
@@ -65,8 +65,8 @@
 (rf/defn not-supported
   {:events [:wallet-legacy.custom-token/not-supported]}
   [{:keys [db]}]
-  {:db               (assoc-in db [:wallet-legacy/custom-token-screen :in-progress?] nil)
-   :utils/show-popup {:content (i18n/label :t/contract-isnt-supported)}})
+  {:db                       (assoc-in db [:wallet-legacy/custom-token-screen :in-progress?] nil)
+   :effects.utils/show-popup {:content (i18n/label :t/contract-isnt-supported)}})
 
 (rf/defn add-custom-token
   {:events [:wallet-legacy.custom-token.ui/add-pressed]}

--- a/src/status_im2/common/alert/effects.cljs
+++ b/src/status_im2/common/alert/effects.cljs
@@ -1,8 +1,8 @@
-(ns status-im2.common.alert.events
+(ns status-im2.common.alert.effects
   (:require
-    [re-frame.core :as re-frame]
     [react-native.core :as rn]
-    [utils.i18n :as i18n]))
+    [utils.i18n :as i18n]
+    [utils.re-frame :as rf]))
 
 (defn show-popup
   ([title content]
@@ -26,8 +26,7 @@
       (when on-dismiss
         {:cancelable false})))))
 
-(re-frame/reg-fx
- :utils/show-popup
+(rf/reg-fx :effects.utils/show-popup
  (fn [{:keys [title content on-dismiss]}]
    (show-popup title content on-dismiss)))
 
@@ -50,8 +49,7 @@
     (or extra-options nil))
    {:cancelable false}))
 
-(re-frame/reg-fx
- :utils/show-confirmation
+(rf/reg-fx :effects.utils/show-confirmation
  (fn [{:keys [title content confirm-button-text on-accept on-cancel cancel-button-text extra-options]}]
    (show-confirmation {:title               title
                        :content             content
@@ -60,18 +58,3 @@
                        :on-accept           on-accept
                        :on-cancel           on-cancel
                        :extra-options       extra-options})))
-
-(defn show-question
-  ([title content on-accept]
-   (show-question title content on-accept nil))
-  ([title content on-accept on-cancel]
-   (rn/alert
-    title
-    content
-    (vector (merge {:text                (i18n/label :t/no)
-                    :accessibility-label :no-button}
-                   (when on-cancel {:onPress on-cancel}))
-            {:text                (i18n/label :t/yes)
-             :onPress             on-accept
-             :accessibility-label :yes-button})
-    nil)))

--- a/src/status_im2/common/async_storage.cljs
+++ b/src/status_im2/common/async_storage.cljs
@@ -1,8 +1,0 @@
-(ns status-im2.common.async-storage
-  (:require
-    [re-frame.core :as re-frame]
-    react-native.async-storage))
-
-(re-frame/reg-fx :async-storage-set (react-native.async-storage/set-item-factory))
-(re-frame/reg-fx :async-storage-get
-                 (fn [{ks :keys cb :cb}] (react-native.async-storage/get-items ks cb)))

--- a/src/status_im2/common/async_storage/effects.cljs
+++ b/src/status_im2/common/async_storage/effects.cljs
@@ -1,0 +1,11 @@
+(ns status-im2.common.async-storage.effects
+  (:require
+    [react-native.async-storage :as async-storage]
+    [utils.re-frame :as rf]))
+
+(rf/reg-fx :effects.async-storage/set
+ (async-storage/set-item-factory))
+
+(rf/reg-fx :effects.async-storage/get
+ (fn [{ks :keys cb :cb}]
+   (async-storage/get-items ks cb)))

--- a/src/status_im2/common/biometric/events.cljs
+++ b/src/status_im2/common/biometric/events.cljs
@@ -51,7 +51,7 @@
                         (i18n/label :t/grant-face-id-permissions)
                         (i18n/label :t/biometric-auth-error {:code code}))]
     (when handle-error?
-      {:utils/show-popup
+      {:effects.utils/show-popup
        {:title   (i18n/label :t/biometric-auth-login-error-title)
         :content content}})))
 

--- a/src/status_im2/common/font/effects.cljs
+++ b/src/status_im2/common/font/effects.cljs
@@ -1,0 +1,8 @@
+(ns status-im2.common.font.effects
+  (:require
+    utils.image-server
+    [utils.re-frame :as rf]))
+
+(rf/reg-fx :effects.font/get-font-file-for-initials-avatar
+ (fn [callback]
+   (utils.image-server/get-font-file-ready callback)))

--- a/src/status_im2/common/font/events.cljs
+++ b/src/status_im2/common/font/events.cljs
@@ -1,14 +1,8 @@
-(ns status-im2.common.font
+(ns status-im2.common.font.events
   (:require
     [clojure.string :as string]
-    [re-frame.core :as re-frame]
-    utils.image-server
+    status-im2.common.font.effects
     [utils.re-frame :as rf]))
-
-(re-frame/reg-fx
- :font/get-font-file-for-initials-avatar
- (fn [callback]
-   (utils.image-server/get-font-file-ready callback)))
 
 (rf/defn init-abs-root-path
   {:events [:font/init-font-file-for-initials-avatar]}

--- a/src/status_im2/common/universal_links.cljs
+++ b/src/status_im2/common/universal_links.cljs
@@ -44,8 +44,8 @@
   (when chat-id
     (if-not (own-public-key? db chat-id)
       {:dispatch [:chat.ui/start-chat chat-id]}
-      {:utils/show-popup {:title   (i18n/label :t/unable-to-read-this-code)
-                          :content (i18n/label :t/can-not-add-yourself)}})))
+      {:effects.utils/show-popup {:title   (i18n/label :t/unable-to-read-this-code)
+                                  :content (i18n/label :t/can-not-add-yourself)}})))
 
 (rf/defn handle-community-requests
   [cofx {:keys [community-id]}]

--- a/src/status_im2/contexts/add_new_contact/effects.cljs
+++ b/src/status_im2/contexts/add_new_contact/effects.cljs
@@ -1,0 +1,22 @@
+(ns status-im2.contexts.add-new-contact.effects
+  (:require
+    [native-module.core :as native-module]
+    [status-im.ethereum.ens :as ens]
+    [status-im2.constants :as constants]
+    [utils.re-frame :as rf]
+    [utils.transforms :as transforms]))
+
+(rf/reg-fx :effects.contacts/decompress-public-key
+ (fn [{:keys [compressed-key on-success on-error]}]
+   (native-module/compressed-key->public-key
+    compressed-key
+    constants/deserialization-key
+    (fn [resp]
+      (let [{:keys [error]} (transforms/json->clj resp)]
+        (if error
+          (on-error error)
+          (on-success (str "0x" (subs resp 5)))))))))
+
+(rf/reg-fx :effects.contacts/resolve-public-key-from-ens
+ (fn [{:keys [chain-id ens on-success on-error]}]
+   (ens/pubkey chain-id ens on-success on-error)))

--- a/src/status_im2/contexts/add_new_contact/events_test.cljs
+++ b/src/status_im2/contexts/add_new_contact/events_test.cljs
@@ -115,7 +115,7 @@
                              :ens             ens-stateofus-eth
                              :public-key      nil ; not yet...
                              :state           :resolve-ens}))
-                :contacts/resolve-public-key-from-ens
+                :effects.contacts/resolve-public-key-from-ens
                 {:chain-id   1
                  :ens        ens-stateofus-eth
                  :on-success [:contacts/set-new-identity-success ens]
@@ -131,7 +131,7 @@
                              :type            :compressed-key
                              :public-key      nil ; not yet...
                              :state           :decompress-key}))
-                :contacts/decompress-public-key
+                :effects.contacts/decompress-public-key
                 {:compressed-key user-ckey
                  :on-success     [:contacts/set-new-identity-success user-ckey]
                  :on-error       [:contacts/set-new-identity-error user-ckey]}})))

--- a/src/status_im2/contexts/chat/composer/actions/view.cljs
+++ b/src/status_im2/contexts/chat/composer/actions/view.cljs
@@ -7,7 +7,7 @@
     [react-native.platform :as platform]
     [react-native.reanimated :as reanimated]
     [reagent.core :as reagent]
-    [status-im2.common.alert.events :as alert]
+    [status-im2.common.alert.effects :as alert.effects]
     [status-im2.common.device-permissions :as device-permissions]
     [status-im2.constants :as constants]
     [status-im2.contexts.chat.composer.actions.style :as style]
@@ -146,7 +146,7 @@
                                                 :on-denied
                                                 #(js/setTimeout
                                                   (fn []
-                                                    (alert/show-popup
+                                                    (alert.effects/show-popup
                                                      (i18n/label :t/audio-recorder-error)
                                                      (i18n/label
                                                       :t/audio-recorder-permissions-error)
@@ -198,9 +198,9 @@
                                  (reanimated/get-shared-value height)])
                    (rf/dispatch [:open-modal :photo-selector {:insets insets}]))
     :on-denied   (fn []
-                   (alert/show-popup (i18n/label :t/error)
-                                     (i18n/label
-                                      :t/external-storage-denied)))}))
+                   (alert.effects/show-popup (i18n/label :t/error)
+                                             (i18n/label
+                                              :t/external-storage-denied)))}))
 
 (defn image-button
   [props animations insets edit]
@@ -246,6 +246,6 @@
      [:f> send-button props state animations window-height images edit send-btn-opacity
       scroll-to-bottom-fn]
      (when (and (not edit) (not images))
-       ;; TODO(alwx): needs to be replaced with an `audio-button` later.
-       ;; See https://github.com/status-im/status-mobile/issues/16084 for more details.
+       ;; TODO(alwx): needs to be replaced with an `audio-button` later. See
+       ;; https://github.com/status-im/status-mobile/issues/16084 for more details.
        [:f> disabled-audio-button audio-btn-opacity])]))

--- a/src/status_im2/contexts/chat/effects.cljs
+++ b/src/status_im2/contexts/chat/effects.cljs
@@ -1,0 +1,18 @@
+(ns status-im2.contexts.chat.effects
+  (:require
+    [react-native.async-storage :as async-storage]
+    [status-im2.contexts.shell.jump-to.constants :as shell.constants]
+    [utils.re-frame :as rf]))
+
+(rf/reg-fx :effects.chat/open-last-chat
+ (fn [key-uid]
+   (async-storage/get-item
+    :chat-id
+    (fn [chat-id]
+      (when chat-id
+        (async-storage/get-item
+         :key-uid
+         (fn [stored-key-uid]
+           (when (= stored-key-uid key-uid)
+             (rf/dispatch [:chat/navigate-to-chat chat-id
+                           shell.constants/open-screen-without-animation])))))))))

--- a/src/status_im2/contexts/chat/photo_selector/effects.cljs
+++ b/src/status_im2/contexts/chat/photo_selector/effects.cljs
@@ -1,0 +1,94 @@
+(ns status-im2.contexts.chat.photo-selector.effects
+  (:require
+    [clojure.string :as string]
+    [react-native.cameraroll :as cameraroll]
+    [react-native.core :as rn]
+    [react-native.image-resizer :as image-resizer]
+    [react-native.permissions :as permissions]
+    [react-native.platform :as platform]
+    [taoensso.timbre :as log]
+    [utils.i18n :as i18n]
+    [utils.re-frame :as rf]))
+
+(def ^:private maximum-image-size-px 2000)
+
+(rf/reg-fx :effects.camera-roll/request-permissions-and-get-photos
+ (fn [[num end-cursor album]]
+   (permissions/request-permissions
+    {:permissions [:read-external-storage]
+     :on-allowed
+     (fn []
+       (cameraroll/get-photos
+        (merge {:first      num
+                :assetType  "Photos"
+                :groupTypes (if (= album (i18n/label :t/recent)) "All" "Albums")
+                :groupName  (if (not= album (i18n/label :t/recent)) album "")
+                :include    ["imageSize"]}
+               (when end-cursor
+                 {:after end-cursor}))
+        #(rf/dispatch [:on-camera-roll-get-photos (:edges %) (:page_info %) end-cursor])))})))
+
+(defn- resize-photo
+  [uri callback]
+  (rn/image-get-size
+   uri
+   (fn [width height]
+     (let [resize? (> (max width height) maximum-image-size-px)]
+       (image-resizer/resize
+        uri
+        (if resize? maximum-image-size-px width)
+        (if resize? maximum-image-size-px height)
+        60
+        (fn [^js resized-image]
+          (let [path (.-path resized-image)
+                path (if (string/starts-with? path "file") path (str "file://" path))]
+            (callback {:resized-uri path
+                       :width       width
+                       :height      height})))
+        #(log/error "could not resize image" %))))))
+
+(rf/reg-fx :effects.camera-roll/image-selected
+ (fn [[image chat-id]]
+   (resize-photo (:uri image) #(rf/dispatch [:photo-selector/image-selected chat-id image %]))))
+
+(defn- get-albums
+  [callback]
+  (let [albums (atom {:smart-album []
+                      :my-albums   []})]
+    ;; Get the "recent" album first
+    (cameraroll/get-photos
+     {:first 1 :groupTypes "All" :assetType "Photos"}
+     (fn [res-recent]
+       (swap! albums assoc
+         :smart-album
+         {:title (i18n/label :t/recent)
+          :uri   (get-in (first (:edges res-recent)) [:node :image :uri])})
+       ;; Get albums, then loop over albums and get each one's cover (first photo)
+       (cameraroll/get-albums
+        {:assetType "Photos"}
+        (fn [res-albums]
+          (let [response-count (count res-albums)]
+            (if (pos? response-count)
+              (doseq [album res-albums]
+                (cameraroll/get-photos
+                 {:first 1 :groupTypes "Albums" :groupName (:title album) :assetType "Photos"}
+                 (fn [res]
+                   (let [uri (get-in (first (:edges res)) [:node :image :uri])]
+                     (swap! albums update :my-albums conj (merge album {:uri uri}))
+                     (when (= (count (:my-albums @albums)) response-count)
+                       (swap! albums update :my-albums #(sort-by :title %))
+                       (callback @albums))))))
+              (callback @albums)))))))))
+
+(rf/reg-fx :effects.camera-roll/get-albums
+ (fn []
+   (get-albums #(rf/dispatch [:on-camera-roll-get-albums %]))))
+
+(defn get-photos-count-ios-fx
+  [cb]
+  (cameraroll/get-photos-count-ios cb))
+
+(rf/reg-fx :effects.camera-roll/get-photos-count-ios
+ (fn []
+   (when platform/ios?
+     (get-photos-count-ios-fx #(rf/dispatch [:on-camera-roll-get-images-count-ios %])))))

--- a/src/status_im2/contexts/chat/photo_selector/events.cljs
+++ b/src/status_im2/contexts/chat/photo_selector/events.cljs
@@ -1,103 +1,9 @@
 (ns status-im2.contexts.chat.photo-selector.events
   (:require
-    [clojure.string :as string]
-    [re-frame.core :as re-frame]
-    [react-native.cameraroll :as cameraroll]
-    [react-native.core :as rn]
-    [react-native.image-resizer :as image-resizer]
-    [react-native.permissions :as permissions]
-    [react-native.platform :as platform]
     [status-im2.constants :as constants]
-    [taoensso.timbre :as log]
+    status-im2.contexts.chat.photo-selector.effects
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]))
-
-(def maximum-image-size-px 2000)
-
-(defn- resize-photo
-  [uri callback]
-  (rn/image-get-size
-   uri
-   (fn [width height]
-     (let [resize? (> (max width height) maximum-image-size-px)]
-       (image-resizer/resize
-        uri
-        (if resize? maximum-image-size-px width)
-        (if resize? maximum-image-size-px height)
-        60
-        (fn [^js resized-image]
-          (let [path (.-path resized-image)
-                path (if (string/starts-with? path "file") path (str "file://" path))]
-            (callback {:resized-uri path
-                       :width       width
-                       :height      height})))
-        #(log/error "could not resize image" %))))))
-
-(re-frame/reg-fx
- :camera-roll-request-permissions-and-get-photos
- (fn [[num end-cursor album]]
-   (permissions/request-permissions
-    {:permissions [:read-external-storage]
-     :on-allowed
-     (fn []
-       (cameraroll/get-photos
-        (merge {:first      num
-                :assetType  "Photos"
-                :groupTypes (if (= album (i18n/label :t/recent)) "All" "Albums")
-                :groupName  (if (not= album (i18n/label :t/recent)) album "")
-                :include    ["imageSize"]}
-               (when end-cursor
-                 {:after end-cursor}))
-        #(re-frame/dispatch [:on-camera-roll-get-photos (:edges %) (:page_info %) end-cursor])))})))
-
-(re-frame/reg-fx
- :camera-roll-image-selected
- (fn [[image chat-id]]
-   (resize-photo (:uri image) #(re-frame/dispatch [:photo-selector/image-selected chat-id image %]))))
-
-(defn get-albums
-  [callback]
-  (let [albums (atom {:smart-album []
-                      :my-albums   []})]
-    ;; Get the "recent" album first
-    (cameraroll/get-photos
-     {:first 1 :groupTypes "All" :assetType "Photos"}
-     (fn [res-recent]
-       (swap! albums assoc
-         :smart-album
-         {:title (i18n/label :t/recent)
-          :uri   (get-in (first (:edges res-recent)) [:node :image :uri])})
-       ;; Get albums, then loop over albums and get each one's cover (first photo)
-       (cameraroll/get-albums
-        {:assetType "Photos"}
-        (fn [res-albums]
-          (let [response-count (count res-albums)]
-            (if (pos? response-count)
-              (doseq [album res-albums]
-                (cameraroll/get-photos
-                 {:first 1 :groupTypes "Albums" :groupName (:title album) :assetType "Photos"}
-                 (fn [res]
-                   (let [uri (get-in (first (:edges res)) [:node :image :uri])]
-                     (swap! albums update :my-albums conj (merge album {:uri uri}))
-                     (when (= (count (:my-albums @albums)) response-count)
-                       (swap! albums update :my-albums #(sort-by :title %))
-                       (callback @albums))))))
-              (callback @albums)))))))))
-
-(defn get-photos-count-ios-fx
-  [cb]
-  (cameraroll/get-photos-count-ios cb))
-
-(re-frame/reg-fx
- :camera-roll-get-albums
- (fn []
-   (get-albums #(re-frame/dispatch [:on-camera-roll-get-albums %]))))
-
-(re-frame/reg-fx
- :camera-roll-get-photos-count-ios
- (fn []
-   (when platform/ios?
-     (get-photos-count-ios-fx #(re-frame/dispatch [:on-camera-roll-get-images-count-ios %])))))
 
 (rf/defn on-camera-roll-get-albums
   {:events [:on-camera-roll-get-albums]}
@@ -113,12 +19,12 @@
 (rf/defn camera-roll-get-albums
   {:events [:photo-selector/camera-roll-get-albums]}
   [_]
-  {:camera-roll-get-albums nil})
+  {:effects.camera-roll/get-albums nil})
 
 (rf/defn camera-roll-get-ios-photo-count
   {:events [:photo-selector/camera-roll-get-ios-photo-count]}
   [_]
-  {:camera-roll-get-photos-count-ios nil})
+  {:effects.camera-roll/get-photos-count-ios nil})
 
 (rf/defn camera-roll-select-album
   {:events [:chat.ui/camera-roll-select-album]}
@@ -150,9 +56,10 @@
 (rf/defn get-photos-for-selected-album
   {:events [:photo-selector/get-photos-for-selected-album]}
   [{:keys [db]} end-cursor]
-  {:camera-roll-request-permissions-and-get-photos [21 end-cursor
-                                                    (or (:camera-roll/selected-album db)
-                                                        (i18n/label :t/recent))]})
+  {:effects.camera-roll/request-permissions-and-get-photos
+   [21 end-cursor
+    (or (:camera-roll/selected-album db)
+        (i18n/label :t/recent))]})
 
 (rf/defn camera-roll-loading-more
   {:events [:photo-selector/camera-roll-loading-more]}
@@ -166,4 +73,4 @@
         images          (get-in db [:chat/inputs current-chat-id :metadata :sending-image])]
     (when (and (< (count images) constants/max-album-photos)
                (not (some #(= (:uri image) (:uri %)) images)))
-      {:camera-roll-image-selected [image current-chat-id]})))
+      {:effects.camera-roll/image-selected [image current-chat-id]})))

--- a/src/status_im2/contexts/onboarding/events.cljs
+++ b/src/status_im2/contexts/onboarding/events.cljs
@@ -114,7 +114,7 @@
   {:events [:onboarding/seed-phrase-validated]}
   [{:keys [db]} seed-phrase key-uid]
   (if (contains? (:profile/profiles-overview db) key-uid)
-    {:utils/show-confirmation
+    {:effects.utils/show-confirmation
      {:title               (i18n/label :t/multiaccount-exists-title)
       :content             (i18n/label :t/multiaccount-exists-content)
       :confirm-button-text (i18n/label :t/unlock)

--- a/src/status_im2/contexts/profile/create/effects.cljs
+++ b/src/status_im2/contexts/profile/create/effects.cljs
@@ -1,0 +1,9 @@
+(ns status-im2.contexts.profile.create.effects
+  (:require
+    [native-module.core :as native-module]
+    [utils.re-frame :as rf]))
+
+(rf/reg-fx :effects.profile/create-and-login
+ (fn [request]
+   ;;"node.login" signal will be triggered as a callback
+   (native-module/create-account-and-login request)))

--- a/src/status_im2/contexts/profile/create/events.cljs
+++ b/src/status_im2/contexts/profile/create/events.cljs
@@ -1,21 +1,15 @@
 (ns status-im2.contexts.profile.create.events
   (:require
     [native-module.core :as native-module]
-    [re-frame.core :as re-frame]
     [status-im2.contexts.profile.config :as profile.config]
+    status-im2.contexts.profile.create.effects
     [utils.re-frame :as rf]
     [utils.security.core :as security]))
-
-(re-frame/reg-fx
- ::create-profile-and-login
- (fn [request]
-   ;;"node.login" signal will be triggered as a callback
-   (native-module/create-account-and-login request)))
 
 (rf/defn create-profile-and-login
   {:events [:profile.create/create-and-login]}
   [_ {:keys [display-name password image-path color]}]
-  {::create-profile-and-login
+  {:effects.profile/create-and-login
    (assoc (profile.config/create)
           :displayName        display-name
           :password           (native-module/sha3 (security/safe-unmask-data password))

--- a/src/status_im2/contexts/profile/login/effects.cljs
+++ b/src/status_im2/contexts/profile/login/effects.cljs
@@ -1,0 +1,11 @@
+(ns status-im2.contexts.profile.login.effects
+  (:require
+    [native-module.core :as native-module]
+    [status-im2.contexts.profile.config :as profile.config]
+    [utils.re-frame :as rf]))
+
+(rf/reg-fx :effects.profile/login
+ (fn [[key-uid hashed-password]]
+   ;;"node.login" signal will be triggered as a callback
+   (native-module/login-account
+    (assoc (profile.config/login) :keyUid key-uid :password hashed-password))))

--- a/src/status_im2/contexts/profile/recover/effects.cljs
+++ b/src/status_im2/contexts/profile/recover/effects.cljs
@@ -1,0 +1,9 @@
+(ns status-im2.contexts.profile.recover.effects
+  (:require
+    [native-module.core :as native-module]
+    [utils.re-frame :as rf]))
+
+(rf/reg-fx :effects.profile/restore-and-login
+ (fn [request]
+   ;;"node.login" signal will be triggered as a callback
+   (native-module/restore-account-and-login request)))

--- a/src/status_im2/contexts/profile/recover/events.cljs
+++ b/src/status_im2/contexts/profile/recover/events.cljs
@@ -1,16 +1,10 @@
 (ns status-im2.contexts.profile.recover.events
   (:require
     [native-module.core :as native-module]
-    [re-frame.core :as re-frame]
     [status-im2.contexts.profile.config :as profile.config]
+    status-im2.contexts.profile.recover.effects
     [utils.re-frame :as rf]
     [utils.security.core :as security]))
-
-(re-frame/reg-fx
- ::restore-profile-and-login
- (fn [request]
-   ;;"node.login" signal will be triggered as a callback
-   (native-module/restore-account-and-login request)))
 
 (rf/defn recover-profile-and-login
   {:events [:profile.recover/recover-and-login]}
@@ -18,7 +12,7 @@
   {:db
    (assoc db :onboarding/recovered-account? true)
 
-   ::restore-profile-and-login
+   :effects.profile/restore-and-login
    (merge (profile.config/create)
           {:displayName        display-name
            :mnemonic           (security/safe-unmask-data seed-phrase)

--- a/src/status_im2/contexts/push_notifications/local/effects.cljs
+++ b/src/status_im2/contexts/push_notifications/local/effects.cljs
@@ -6,14 +6,14 @@
     [utils.re-frame :as rf]))
 
 (rf/reg-fx :effects/push-notifications-local-present-ios
-           (fn [{:keys [title message user-info body-type]}]
-             (when (not= body-type "message")
-               (pn-ios/present-local-notification title
-                                                  message
-                                                  (bean/->js (merge user-info
-                                                                    {:notificationType
-                                                                     "local-notification"}))))))
+ (fn [{:keys [title message user-info body-type]}]
+   (when (not= body-type "message")
+     (pn-ios/present-local-notification title
+                                        message
+                                        (bean/->js (merge user-info
+                                                          {:notificationType
+                                                           "local-notification"}))))))
 
 (rf/reg-fx :effects/push-notifications-local-present-android
-           (fn [notification]
-             (native-module.pn/present-local-notification notification)))
+ (fn [notification]
+   (native-module.pn/present-local-notification notification)))

--- a/src/status_im2/contexts/quo_preview/record_audio/record_audio.cljs
+++ b/src/status_im2/contexts/quo_preview/record_audio/record_audio.cljs
@@ -4,7 +4,7 @@
     [react-native.core :as rn]
     [react-native.permissions :as permissions]
     [reagent.core :as reagent]
-    [status-im2.common.alert.events :as alert]
+    [status-im2.common.alert.effects :as alert.effects]
     [status-im2.constants :as constants]
     [status-im2.contexts.quo-preview.preview :as preview]
     [utils.i18n :as i18n]
@@ -35,7 +35,7 @@
                                                 :on-denied
                                                 #(js/setTimeout
                                                   (fn []
-                                                    (alert/show-popup
+                                                    (alert.effects/show-popup
                                                      (i18n/label :t/audio-recorder-error)
                                                      (i18n/label
                                                       :t/audio-recorder-permissions-error)))

--- a/src/status_im2/contexts/shell/jump_to/effects.cljs
+++ b/src/status_im2/contexts/shell/jump_to/effects.cljs
@@ -1,0 +1,32 @@
+(ns status-im2.contexts.shell.jump-to.effects
+  (:require
+    [status-im2.config :as config]
+    [status-im2.contexts.shell.jump-to.animation :as animation]
+    [status-im2.contexts.shell.jump-to.constants :as shell.constants]
+    [status-im2.contexts.shell.jump-to.state :as state]
+    [status-im2.contexts.shell.jump-to.utils :as shell.utils]
+    [utils.re-frame :as rf]))
+
+(rf/reg-fx :effects.shell/change-tab
+ (fn [stack-id]
+   (when (some #(= stack-id %) shell.constants/stacks-ids)
+     (animation/bottom-tab-on-press stack-id false))))
+
+(rf/reg-fx :effects.shell/navigate-to-jump-to
+ (fn []
+   (animation/close-home-stack false)
+   (when-not config/shell-navigation-disabled?
+     (some-> ^js @state/jump-to-list-ref
+             (.scrollToOffset #js {:y 0 :animated false})))))
+
+;; Note - pop-to-root resets currently opened screens to `close-screen-without-animation`.
+;; This might take some time. So don't directly merge the effect of `pop-to-root` and
+;; `navigate-to` for the floating screen. Because it might close even the currently opened screen.
+;; https://github.com/status-im/status-mobile/pull/16438#issuecomment-1623954774
+(rf/reg-fx :effects.shell/pop-to-root
+ (fn []
+   (shell.utils/reset-floating-screens)))
+
+(rf/reg-fx :effects.shell/reset-state
+ (fn []
+   (reset! state/floating-screens-state {})))

--- a/src/status_im2/events.cljs
+++ b/src/status_im2/events.cljs
@@ -2,8 +2,9 @@
   (:require
     [status-im.bottom-sheet.events]
     [status-im.keycard.core :as keycard]
-    status-im2.common.async-storage
-    status-im2.common.font
+    status-im2.common.alert.effects
+    status-im2.common.async-storage.effects
+    status-im2.common.font.events
     [status-im2.common.json-rpc.events]
     status-im2.common.password-authentication.events
     status-im2.common.theme.events
@@ -26,14 +27,14 @@
 (rf/defn start-app
   {:events [:app-started]}
   [cofx]
-  (rf/merge cofx
-            {:db                                     db/app-db
-             :theme/init-theme                       nil
-             :network/listen-to-network-info         nil
-             :biometric/get-supported-biometric-type nil
-             ;;app starting flow continues in get-profiles-overview
-             :profile/get-profiles-overview          #(rf/dispatch
-                                                       [:profile/get-profiles-overview-success %])
-             :font/get-font-file-for-initials-avatar #(rf/dispatch
-                                                       [:font/init-font-file-for-initials-avatar %])}
-            (keycard/init)))
+  (rf/merge
+   cofx
+   {:db db/app-db
+    :theme/init-theme nil
+    :network/listen-to-network-info nil
+    :biometric/get-supported-biometric-type nil
+    ;;app starting flow continues in get-profiles-overview
+    :profile/get-profiles-overview #(rf/dispatch [:profile/get-profiles-overview-success %])
+    :effects.font/get-font-file-for-initials-avatar
+    #(rf/dispatch [:font/init-font-file-for-initials-avatar %])}
+   (keycard/init)))

--- a/src/status_im2/navigation/core.cljs
+++ b/src/status_im2/navigation/core.cljs
@@ -5,11 +5,11 @@
     [react-native.gesture :as gesture]
     [react-native.navigation :as navigation]
     [status-im2.common.theme.core :as theme]
+    [status-im2.navigation.effects :as effects]
     [status-im2.navigation.options :as options]
-    [status-im2.navigation.roots :as roots]
     [status-im2.navigation.state :as state]
     [status-im2.navigation.view :as views]
-    [taoensso.timbre :as log]))
+    [utils.re-frame :as rf]))
 
 (navigation/set-lazy-component-registrator
  (fn [screen-key]
@@ -33,150 +33,26 @@
        (re-frame/dispatch [:chat/check-last-chat])))
    (rn/hide-splash-screen)))
 
-(defn set-view-id
-  [view-id]
-  (when (get views/screens view-id)
-    (re-frame/dispatch [:set-view-id view-id])))
-
-(re-frame/reg-fx
- :set-view-id-fx
- (fn [view-id]
-   (re-frame/dispatch [:screens/on-will-focus view-id])
-   (when-let [{:keys [on-focus]} (get views/screens view-id)]
-     (when on-focus
-       (re-frame/dispatch on-focus)))))
-
 (navigation/reg-component-did-appear-listener
  (fn [view-id]
    (when (get views/screens view-id)
-     ;;NOTE when back from the background on Android, this event happens for all screens, but we need
-     ;;only for active one
+     ;;NOTE when back from the background on Android, this event happens for all screens, but we
+     ;;need only for active one
      (when (and @state/curr-modal (= @state/curr-modal view-id))
-       (set-view-id view-id))
+       (effects/set-view-id view-id))
      (when-not @state/curr-modal
-       (set-view-id view-id)
+       (effects/set-view-id view-id)
        (reset! state/pushed-screen-id view-id)))))
 
-(defn dissmissModal
-  ([] (dissmissModal nil))
-  ([comp-id]
-   (reset! state/dissmissing true)
-   (navigation/dismiss-modal (name (or comp-id (last @state/modals))))))
-
-(defn dismiss-all-modals
-  []
-  (when @state/curr-modal
-    (reset! state/curr-modal false)
-    (reset! state/dissmissing true)
-    (doseq [modal @state/modals]
-      (navigation/dismiss-modal (name modal)))
-    (reset! state/modals [])))
-
-;; ROOT
-(re-frame/reg-fx
- :set-root
- (fn [root-id]
-   (let [root (get (roots/roots) root-id)]
-     (dismiss-all-modals)
-     (re-frame/dispatch [:profile.settings/switch-theme
-                         (get roots/themes root-id)
-                         root-id])
-     (reset! state/root-id (or (get-in root [:root :stack :id]) root-id))
-     (navigation/set-root root))))
-
-;; NAVIGATE-TO
-(defn navigate
-  [component]
-  (let [{:keys [options]} (get views/screens component)]
-    (dismiss-all-modals)
-    (navigation/push
-     (name @state/root-id)
-     {:component {:id      component
-                  :name    component
-                  :options (merge (options/default-root)
-                                  (options/statusbar-and-navbar)
-                                  options
-                                  (if (:topBar options)
-                                    (options/merge-top-bar (options/topbar-options) options)
-                                    {:topBar {:visible false}}))}})))
-
-;; NAVIGATE-TO-WITHIN-STACK
-(defn navigate-to-within-stack
-  [[component comp-id]]
-  (let [{:keys [options]} (get views/screens component)]
-    (navigation/push
-     (name comp-id)
-     {:component {:id      component
-                  :name    component
-                  :options (merge (options/statusbar-and-navbar)
-                                  options
-                                  (if (:topBar options)
-                                    (options/merge-top-bar (options/topbar-options) options)
-                                    {:topBar {:visible false}}))}})))
-
-(re-frame/reg-fx :navigate-to navigate)
-
-(re-frame/reg-fx :navigate-to-within-stack navigate-to-within-stack)
-
-(re-frame/reg-fx :navigate-replace-fx
-                 (fn [view-id]
-                   (navigation/pop (name @state/root-id))
-                   (navigate view-id)))
-
-(re-frame/reg-fx :navigate-back
-                 (fn []
-                   (if @state/curr-modal
-                     (dissmissModal)
-                     (navigation/pop (name @state/root-id)))))
-
-(re-frame/reg-fx :navigate-back-within-stack
-                 (fn [comp-id]
-                   (navigation/pop (name comp-id))))
-
-(re-frame/reg-fx :navigate-back-to
-                 (fn [comp-id]
-                   (navigation/pop-to (name comp-id))))
-
-(re-frame/reg-fx :dismiss-modal
-                 (fn [comp-id]
-                   (dissmissModal (name comp-id))))
-
-(defn pop-to-root
-  [root-id]
-  (navigation/pop-to-root root-id)
-  (dismiss-all-modals))
-
-(re-frame/reg-fx :pop-to-root-fx pop-to-root)
-
-;; MODAL
-(defn open-modal
-  [component]
-  (let [{:keys [options]} (get views/screens component)
-        sheet?            (:sheet? options)]
-    (if @state/dissmissing
-      (reset! state/dissmissing component)
-      (do
-        (reset! state/curr-modal true)
-        (swap! state/modals conj component)
-        (navigation/show-modal
-         {:stack {:children [{:component
-                              {:name    component
-                               :id      component
-                               :options (merge (options/default-root)
-                                               (options/statusbar-and-navbar)
-                                               options
-                                               (when sheet?
-                                                 options/sheet-options))}}]}})))))
-
-(re-frame/reg-fx :open-modal-fx open-modal)
+;;;; Modal
 
 (navigation/reg-button-pressed-listener
  (fn [id]
    (if (= "dismiss-modal" id)
      (do
        (when-let [event (get-in views/screens [(last @state/modals) :on-dissmiss])]
-         (re-frame/dispatch event))
-       (dissmissModal))
+         (rf/dispatch event))
+       (effects/dismiss-modal))
      (when-let [handler (get-in views/screens [(keyword id) :right-handler])]
        (handler)))))
 
@@ -185,112 +61,38 @@
    (if (> (count @state/modals) 1)
      (let [new-modals (butlast @state/modals)]
        (reset! state/modals (vec new-modals))
-       (set-view-id (last new-modals)))
+       (effects/set-view-id (last new-modals)))
      (do
        (reset! state/modals [])
        (reset! state/curr-modal false)
-       (set-view-id @state/pushed-screen-id)))
+       (effects/set-view-id @state/pushed-screen-id)))
 
    (let [component @state/dissmissing]
      (reset! state/dissmissing false)
      (when (keyword? component)
-       (open-modal component)))))
+       (effects/open-modal component)))))
 
-;; OVERLAY
-(def dissmiss-overlay navigation/dissmiss-overlay)
+;;;; Toast
 
-(defn show-overlay
-  ([component] (show-overlay component {}))
-  ([component opts]
-   (dissmiss-overlay component)
-   (navigation/show-overlay
-    {:component {:name    component
-                 :id      component
-                 :options (merge (options/statusbar)
-                                 {:layout  {:componentBackgroundColor :transparent
-                                            :orientation              ["portrait"]}
-                                  :overlay {:interceptTouchOutside true}}
-                                 opts)}})))
+(navigation/register-component
+ "toasts"
+ ; `:flex 0` is the same as `flex: 0 0 auto` in CSS.
+ ; We need this to override the HOC default layout which is
+ ; flex 1. If we don't override this property, this HOC
+ ; will catch all touches/gestures while the toast is shown,
+ ; preventing the user doing any action in the app
+ #(gesture/gesture-handler-root-hoc views/toasts
+                                    #js {:flex 0})
+ (fn [] views/toasts))
 
-;; toast
-(navigation/register-component "toasts"
-                               ; `:flex 0` is the same as `flex: 0 0 auto` in CSS.
-                               ; We need this to override the HOC default layout which is
-                               ; flex 1. If we don't override this property, this HOC
-                               ; will catch all touches/gestures while the toast is shown,
-                               ; preventing the user doing any action in the app
-                               #(gesture/gesture-handler-root-hoc views/toasts
-                                                                  #js {:flex 0})
-                               (fn [] views/toasts))
+;;;; Bottom sheet
 
-(re-frame/reg-fx :show-toasts
-                 (fn []
-                   (show-overlay "toasts"
-                                 {:overlay {:interceptTouchOutside false}
-                                  :layout  {:componentBackgroundColor :transparent
-                                            :orientation              ["portrait"]}})))
-(re-frame/reg-fx :hide-toasts (fn [] (dissmiss-overlay "toasts")))
-
-;; bottom sheet
-(navigation/register-component "bottom-sheet"
-                               (fn [] (gesture/gesture-handler-root-hoc views/bottom-sheet))
-                               (fn [] views/bottom-sheet))
-
-(re-frame/reg-fx :show-bottom-sheet (fn [] (show-overlay "bottom-sheet")))
-(re-frame/reg-fx :hide-bottom-sheet (fn [] (dissmiss-overlay "bottom-sheet")))
-
-;; MERGE OPTIONS
-(re-frame/reg-fx
- :merge-options
- (fn [{:keys [id options]}]
-   (navigation/merge-options id options)))
+(navigation/register-component
+ "bottom-sheet"
+ (fn [] (gesture/gesture-handler-root-hoc views/bottom-sheet))
+ (fn [] views/bottom-sheet))
 
 ;; LEGACY (should be removed in status 2.0)
-(defn get-screen-component
-  [component]
-  (let [{:keys [options]} (get views/screens component)]
-    {:component {:id      component
-                 :name    component
-                 :options (merge (options/statusbar-and-navbar)
-                                 options
-                                 (options/merge-top-bar (options/topbar-options) options))}}))
-
-(re-frame/reg-fx
- :set-stack-root-fx
- (fn [[stack component]]
-   ;; We don't have bottom tabs as separate stacks anymore,. So the old way of pushing screens in
-   ;; specific tabs will not work. Disabled set-stack-root for :shell-stack as it is not working
-   ;; and currently only being used for browser and some rare keycard flows after login
-   (when-not (= @state/root-id :shell-stack)
-     (log/debug :set-stack-root-fx stack component)
-     (navigation/set-stack-root
-      (name stack)
-      (if (vector? component)
-        (mapv get-screen-component component)
-        (get-screen-component component))))))
-
-(re-frame/reg-fx :show-popover (fn [] (show-overlay "popover")))
-(re-frame/reg-fx :hide-popover (fn [] (dissmiss-overlay "popover")))
-(re-frame/reg-fx :show-visibility-status-popover
-                 (fn [] (show-overlay "visibility-status-popover")))
-(re-frame/reg-fx :hide-visibility-status-popover
-                 (fn [] (dissmiss-overlay "visibility-status-popover")))
-(re-frame/reg-fx :show-bottom-sheet-overlay-old (fn [] (show-overlay "bottom-sheet-old")))
-(re-frame/reg-fx :dismiss-bottom-sheet-overlay-old (fn [] (dissmiss-overlay "bottom-sheet-old")))
-(re-frame/reg-fx :show-wallet-connect-sheet (fn [] (show-overlay "wallet-connect-sheet")))
-(re-frame/reg-fx :hide-wallet-connect-sheet (fn [] (dissmiss-overlay "wallet-connect-sheet")))
-(re-frame/reg-fx :show-wallet-connect-success-sheet
-                 (fn [] (show-overlay "wallet-connect-success-sheet")))
-(re-frame/reg-fx :hide-wallet-connect-success-sheet
-                 (fn [] (dissmiss-overlay "wallet-connect-success-sheet")))
-(re-frame/reg-fx :show-wallet-connect-app-management-sheet
-                 (fn [] (show-overlay "wallet-connect-app-management-sheet")))
-(re-frame/reg-fx :hide-wallet-connect-app-management-sheet
-                 (fn [] (dissmiss-overlay "wallet-connect-app-management-sheet")))
-(re-frame/reg-fx :show-signing-sheet (fn [] (show-overlay "signing-sheet")))
-(re-frame/reg-fx :hide-signing-sheet (fn [] (dissmiss-overlay "signing-sheet")))
-(re-frame/reg-fx :show-select-acc-sheet (fn [] (show-overlay "select-acc-sheet")))
-(re-frame/reg-fx :hide-select-acc-sheet (fn [] (dissmiss-overlay "select-acc-sheet")))
 
 (defonce
   _

--- a/src/status_im2/navigation/effects.cljs
+++ b/src/status_im2/navigation/effects.cljs
@@ -1,0 +1,248 @@
+(ns status-im2.navigation.effects
+  (:require
+    [react-native.navigation :as navigation]
+    [status-im2.navigation.options :as options]
+    [status-im2.navigation.roots :as roots]
+    [status-im2.navigation.state :as state]
+    [status-im2.navigation.view :as views]
+    [taoensso.timbre :as log]
+    [utils.re-frame :as rf]))
+
+(rf/reg-fx :set-view-id-fx
+ (fn [view-id]
+   (rf/dispatch [:screens/on-will-focus view-id])
+   (when-let [{:keys [on-focus]} (get views/screens view-id)]
+     (when on-focus
+       (rf/dispatch on-focus)))))
+
+(defn set-view-id
+  [view-id]
+  (when (get views/screens view-id)
+    (rf/dispatch [:set-view-id view-id])))
+
+(defn- dismiss-all-modals
+  []
+  (when @state/curr-modal
+    (reset! state/curr-modal false)
+    (reset! state/dissmissing true)
+    (doseq [modal @state/modals]
+      (navigation/dismiss-modal (name modal)))
+    (reset! state/modals [])))
+
+;;;; Root
+
+(rf/reg-fx :set-root
+ (fn [root-id]
+   (let [root (get (roots/roots) root-id)]
+     (dismiss-all-modals)
+     (rf/dispatch [:profile.settings/switch-theme
+                   (get roots/themes root-id)
+                   root-id])
+     (reset! state/root-id (or (get-in root [:root :stack :id]) root-id))
+     (navigation/set-root root))))
+
+;;;; Navigate to
+
+(defn- navigate
+  [component]
+  (let [{:keys [options]} (get views/screens component)]
+    (dismiss-all-modals)
+    (navigation/push
+     (name @state/root-id)
+     {:component {:id      component
+                  :name    component
+                  :options (merge (options/default-root)
+                                  (options/statusbar-and-navbar)
+                                  options
+                                  (if (:topBar options)
+                                    (options/merge-top-bar (options/topbar-options) options)
+                                    {:topBar {:visible false}}))}})))
+
+(rf/reg-fx :navigate-to navigate)
+
+;;;; Navigate to within stack
+
+(defn- navigate-to-within-stack
+  [[component comp-id]]
+  (let [{:keys [options]} (get views/screens component)]
+    (navigation/push
+     (name comp-id)
+     {:component {:id      component
+                  :name    component
+                  :options (merge (options/statusbar-and-navbar)
+                                  options
+                                  (if (:topBar options)
+                                    (options/merge-top-bar (options/topbar-options) options)
+                                    {:topBar {:visible false}}))}})))
+
+(rf/reg-fx :navigate-to-within-stack navigate-to-within-stack)
+
+(rf/reg-fx :navigate-replace-fx
+ (fn [view-id]
+   (navigation/pop (name @state/root-id))
+   (navigate view-id)))
+
+(defn dismiss-modal
+  ([] (dismiss-modal nil))
+  ([comp-id]
+   (reset! state/dissmissing true)
+   (navigation/dismiss-modal (name (or comp-id (last @state/modals))))))
+
+(rf/reg-fx :navigate-back
+ (fn []
+   (if @state/curr-modal
+     (dismiss-modal)
+     (navigation/pop (name @state/root-id)))))
+
+(rf/reg-fx :navigate-back-within-stack
+ (fn [comp-id]
+   (navigation/pop (name comp-id))))
+
+(rf/reg-fx :navigate-back-to
+ (fn [comp-id]
+   (navigation/pop-to (name comp-id))))
+
+(rf/reg-fx :dismiss-modal
+ (fn [comp-id]
+   (dismiss-modal (name comp-id))))
+
+(defn- pop-to-root
+  [root-id]
+  (navigation/pop-to-root root-id)
+  (dismiss-all-modals))
+
+(rf/reg-fx :pop-to-root-fx pop-to-root)
+
+;;;; Modal
+
+(defn open-modal
+  [component]
+  (let [{:keys [options]} (get views/screens component)
+        sheet?            (:sheet? options)]
+    (if @state/dissmissing
+      (reset! state/dissmissing component)
+      (do
+        (reset! state/curr-modal true)
+        (swap! state/modals conj component)
+        (navigation/show-modal
+         {:stack {:children [{:component
+                              {:name    component
+                               :id      component
+                               :options (merge (options/default-root)
+                                               (options/statusbar-and-navbar)
+                                               options
+                                               (when sheet?
+                                                 options/sheet-options))}}]}})))))
+
+(rf/reg-fx :open-modal-fx open-modal)
+
+;;;; Overlay
+
+(defn show-overlay
+  ([component] (show-overlay component {}))
+  ([component opts]
+   (navigation/dissmiss-overlay component)
+   (navigation/show-overlay
+    {:component {:name    component
+                 :id      component
+                 :options (merge (options/statusbar)
+                                 {:layout  {:componentBackgroundColor :transparent
+                                            :orientation              ["portrait"]}
+                                  :overlay {:interceptTouchOutside true}}
+                                 opts)}})))
+
+(rf/reg-fx :show-toasts
+ (fn []
+   (show-overlay "toasts"
+                 {:overlay {:interceptTouchOutside false}
+                  :layout  {:componentBackgroundColor :transparent
+                            :orientation              ["portrait"]}})))
+
+(rf/reg-fx :hide-toasts
+ (fn [] (navigation/dissmiss-overlay "toasts")))
+
+;;;; Bottom sheet
+
+(rf/reg-fx :show-bottom-sheet
+ (fn [] (show-overlay "bottom-sheet")))
+
+(rf/reg-fx :hide-bottom-sheet
+ (fn [] (navigation/dissmiss-overlay "bottom-sheet")))
+
+;;;; Merge options
+
+(rf/reg-fx :merge-options
+ (fn [{:keys [id options]}]
+   (navigation/merge-options id options)))
+
+;;;; Legacy (should be removed in status 2.0)
+
+(defn- get-screen-component
+  [component]
+  (let [{:keys [options]} (get views/screens component)]
+    {:component {:id      component
+                 :name    component
+                 :options (merge (options/statusbar-and-navbar)
+                                 options
+                                 (options/merge-top-bar (options/topbar-options) options))}}))
+
+(rf/reg-fx :set-stack-root-fx
+ (fn [[stack component]]
+   ;; We don't have bottom tabs as separate stacks anymore,. So the old way of pushing screens in
+   ;; specific tabs will not work. Disabled set-stack-root for :shell-stack as it is not working
+   ;; and currently only being used for browser and some rare keycard flows after login
+   (when-not (= @state/root-id :shell-stack)
+     (log/debug :set-stack-root-fx stack component)
+     (navigation/set-stack-root
+      (name stack)
+      (if (vector? component)
+        (mapv get-screen-component component)
+        (get-screen-component component))))))
+
+(rf/reg-fx :show-popover
+ (fn [] (show-overlay "popover")))
+
+(rf/reg-fx :hide-popover
+ (fn [] (navigation/dissmiss-overlay "popover")))
+
+(rf/reg-fx :show-visibility-status-popover
+ (fn [] (show-overlay "visibility-status-popover")))
+
+(rf/reg-fx :hide-visibility-status-popover
+ (fn [] (navigation/dissmiss-overlay "visibility-status-popover")))
+
+(rf/reg-fx :show-bottom-sheet-overlay-old
+ (fn [] (show-overlay "bottom-sheet-old")))
+
+(rf/reg-fx :dismiss-bottom-sheet-overlay-old
+ (fn [] (navigation/dissmiss-overlay "bottom-sheet-old")))
+
+(rf/reg-fx :show-wallet-connect-sheet
+ (fn [] (show-overlay "wallet-connect-sheet")))
+
+(rf/reg-fx :hide-wallet-connect-sheet
+ (fn [] (navigation/dissmiss-overlay "wallet-connect-sheet")))
+
+(rf/reg-fx :show-wallet-connect-success-sheet
+ (fn [] (show-overlay "wallet-connect-success-sheet")))
+
+(rf/reg-fx :hide-wallet-connect-success-sheet
+ (fn [] (navigation/dissmiss-overlay "wallet-connect-success-sheet")))
+
+(rf/reg-fx :show-wallet-connect-app-management-sheet
+ (fn [] (show-overlay "wallet-connect-app-management-sheet")))
+
+(rf/reg-fx :hide-wallet-connect-app-management-sheet
+ (fn [] (navigation/dissmiss-overlay "wallet-connect-app-management-sheet")))
+
+(rf/reg-fx :show-signing-sheet
+ (fn [] (show-overlay "signing-sheet")))
+
+(rf/reg-fx :hide-signing-sheet
+ (fn [] (navigation/dissmiss-overlay "signing-sheet")))
+
+(rf/reg-fx :show-select-acc-sheet
+ (fn [] (show-overlay "select-acc-sheet")))
+
+(rf/reg-fx :hide-select-acc-sheet
+ (fn [] (navigation/dissmiss-overlay "select-acc-sheet")))

--- a/src/status_im2/navigation/events.cljs
+++ b/src/status_im2/navigation/events.cljs
@@ -60,12 +60,12 @@
 (rf/defn pop-to-root
   {:events [:pop-to-root]}
   [{:keys [db]} tab]
-  {:pop-to-root-fx       tab
-   :db                   (-> db
-                             (dissoc :shell/floating-screens)
-                             (dissoc :shell/loaded-screens)
-                             (assoc :view-id (or @shell.state/selected-stack-id :shell)))
-   :shell/pop-to-root-fx nil})
+  {:pop-to-root-fx            tab
+   :db                        (-> db
+                                  (dissoc :shell/floating-screens)
+                                  (dissoc :shell/loaded-screens)
+                                  (assoc :view-id (or @shell.state/selected-stack-id :shell)))
+   :effects.shell/pop-to-root nil})
 
 (rf/defn init-root
   {:events [:init-root]}
@@ -80,8 +80,8 @@
 (rf/defn change-tab
   {:events [:navigate-change-tab]}
   [{:keys [db]} stack-id]
-  {:db                  (assoc db :view-id stack-id)
-   :shell/change-tab-fx stack-id})
+  {:db                       (assoc db :view-id stack-id)
+   :effects.shell/change-tab stack-id})
 
 (rf/defn navigate-replace
   {:events [:navigate-replace]}

--- a/src/status_im2/setup/global_error.cljs
+++ b/src/status_im2/setup/global_error.cljs
@@ -2,7 +2,7 @@
   (:require
     [clojure.string :as string]
     [re-frame.core :as re-frame]
-    [status-im2.common.alert.events :as alert]
+    [status-im2.common.alert.effects :as alert.effects]
     [utils.i18n :as i18n]))
 
 ;; Error handling code based on https://gist.github.com/pesterhazy/e6846be1b6712a9038537022d131ce46
@@ -62,7 +62,7 @@
          (if js/goog.DEBUG
            (some-> orig-handler
                    (.call nil e isFatal))
-           (alert/show-confirmation
+           (alert.effects/show-confirmation
             {:title               "Error"
              :content             (.-message e)
              :confirm-button-text (i18n/label :t/send-logs)


### PR DESCRIPTION
### Summary

This PR moves re-frame effects to separate `effects.cljs` files in an attempt to improve code consistency. I focused on `status-im2` only and I skipped `common.keychain.events` because it was being changed while I was working on this PR.

### Review notes

Besides moving things around, any other change is out of scope to reduce the chance of regressions.

- ~I have not changed a single effect name. Also, if it's namespaced it stays namespaced in this PR.~
- Not a single semantic change in the PR.

#### Areas that may be impacted

None

### Steps to test

E2E tests should be plenty. I ran basic smoke tests, like establishing friendship, sending messages with photos, AC interactions, onboarding, etc.

status: ready
