### PR TITLE
fix: get rid of `:redef-in-file` warning

### DIFF
--- a/src/quo/components/tags/tag.cljs
+++ b/src/quo/components/tags/tag.cljs
@@ -66,17 +66,17 @@
              text-color)
       label])])
 
-(defn tag
+(defn tag-internal
   "opts
    {:type         :icon/:emoji/:label
     :label        string
     :size         32/24
     :on-press     fn
-    :blurred?     true/false 
+    :blurred?     true/false
     :resource     icon/image
     :labelled?    true/false
     :disabled?    true/false}
-  
+
    opts
     - `blurred`  boolean: use to determine border color if the background is blurred
     - `type`     can be icon or emoji with or without a tag label
@@ -106,5 +106,5 @@
        :labelled?           (if (= type :label) true labelled?)}
       [tag-resources size type resource icon-color label text-color labelled?]]]))
 
-(def tag (quo.theme/with-theme tag))
+(def tag (quo.theme/with-theme tag-internal))
 


### PR DESCRIPTION
`make run-clojure` would throw the following warning:

```
------ WARNING #1 - :redef-in-file ---------------------------------------------
 File: /Users/siddarthkumar/code/status-im/PR/status-mobile/src/quo/components/tags/tag.cljs:109:1
--------------------------------------------------------------------------------
 106 |        :labelled?           (if (= type :label) true labelled?)}
 107 |       [tag-resources size type resource icon-color label text-color labelled?]]]))
 108 |
 109 | (def tag (quo.theme/with-theme tag))
-------^------------------------------------------------------------------------
 tag at line 69 is being replaced
--------------------------------------------------------------------------------
 110 |
 111 |
```

This PR fixes that warning.

status: ready
