### PR TITLE
fix messages are marked as read automatically in 1-1/group chats after opening a link

### DIFF
--- a/src/status_im2/navigation/events.cljs
+++ b/src/status_im2/navigation/events.cljs
@@ -60,12 +60,15 @@
 (rf/defn pop-to-root
   {:events [:pop-to-root]}
   [{:keys [db]} tab]
-  {:pop-to-root-fx            tab
-   :db                        (-> db
-                                  (dissoc :shell/floating-screens)
-                                  (dissoc :shell/loaded-screens)
-                                  (assoc :view-id (or @shell.state/selected-stack-id :shell)))
-   :effects.shell/pop-to-root nil})
+  (merge
+   {:pop-to-root-fx            tab
+    :db                        (-> db
+                                   (dissoc :shell/floating-screens)
+                                   (dissoc :shell/loaded-screens)
+                                   (assoc :view-id (or @shell.state/selected-stack-id :shell)))
+    :effects.shell/pop-to-root nil}
+   (when (:current-chat-id db)
+     {:dispatch-n [[:chat/close]]})))
 
 (rf/defn init-root
   {:events [:init-root]}


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/18065

status: ready