### PR TITLE
feat: spectate community before join

### DIFF
--- a/src/status_im/common/universal_links.cljs
+++ b/src/status_im/common/universal_links.cljs
@@ -86,7 +86,7 @@
   (native-module/deserialize-and-compress-key
    community-id
    (fn [deserialized-key]
-     (rf/dispatch [:chat.ui/resolve-community-info (str deserialized-key)])
+     (rf/dispatch [:chat.ui/fetch-community (str deserialized-key)])
      (rf/dispatch [:handle-navigation-to-desktop-community-from-mobile (str deserialized-key)]))))
 
 (rf/defn handle-community-chat

--- a/src/status_im/contexts/chat/messages/link_preview/events.cljs
+++ b/src/status_im/contexts/chat/messages/link_preview/events.cljs
@@ -43,14 +43,12 @@
    {}))
 
 (defn community-resolved
-  [{:keys [db]} [community-id {token-permissions :tokenPermissions :keys [joined] :as community}]]
+  [{:keys [db]} [community-id community]]
   (when community
-    (cond-> {:db (update db :communities/resolve-community-info dissoc community-id)
-             :fx [[:dispatch [:communities/handle-community community]]
-                  [:dispatch
-                   [:chat.ui/cache-link-preview-data (community-link community-id) community]]]}
-      (and (not joined) (not (seq token-permissions)))
-      (update :fx conj [:dispatch [:chat.ui/spectate-community community-id]]))))
+    {:db (update db :communities/resolve-community-info dissoc community-id)
+     :fx [[:dispatch [:communities/handle-community community]]
+          [:dispatch
+           [:chat.ui/cache-link-preview-data (community-link community-id) community]]]}))
 
 (rf/reg-event-fx :chat.ui/community-resolved community-resolved)
 

--- a/src/status_im/contexts/chat/messages/link_preview/events.cljs
+++ b/src/status_im/contexts/chat/messages/link_preview/events.cljs
@@ -2,6 +2,7 @@
   (:require
     [camel-snake-kebab.core :as csk]
     [legacy.status-im.mailserver.core :as mailserver]
+    [schema.core :as schema]
     [status-im.contexts.profile.settings.events :as profile.settings.events]
     [taoensso.timbre :as log]
     [utils.collection]
@@ -41,69 +42,95 @@
    (boolean enabled?)
    {}))
 
-(rf/reg-event-fx
- :chat.ui/community-resolved
- (fn [{:keys [db]} [community-id {token-permissions :tokenPermissions :keys [joined] :as community}]]
-   (when community
-     (cond-> {:db (update db :communities/resolve-community-info dissoc community-id)
-              :fx [[:dispatch [:communities/handle-community community]]
-                   [:dispatch
-                    [:chat.ui/cache-link-preview-data (community-link community-id) community]]]}
-       (and (not joined) (not (seq token-permissions)))
-       (update :fx conj [:dispatch [:chat.ui/spectate-community community-id]])))))
+(defn community-resolved
+  [{:keys [db]} [community-id {token-permissions :tokenPermissions :keys [joined] :as community}]]
+  (when community
+    (cond-> {:db (update db :communities/resolve-community-info dissoc community-id)
+             :fx [[:dispatch [:communities/handle-community community]]
+                  [:dispatch
+                   [:chat.ui/cache-link-preview-data (community-link community-id) community]]]}
+      (and (not joined) (not (seq token-permissions)))
+      (update :fx conj [:dispatch [:chat.ui/spectate-community community-id]]))))
 
-(rf/reg-event-fx
- :chat.ui/community-failed-to-resolve
- (fn [{:keys [db]} [community-id]]
-   {:db (update db :communities/resolve-community-info dissoc community-id)}))
+(rf/reg-event-fx :chat.ui/community-resolved community-resolved)
 
-(rf/reg-event-fx
- :chat.ui/fetch-community
- (fn [{:keys [db]} [community-id]]
-   {:db            (assoc-in db [:communities/resolve-community-info community-id] true)
-    :json-rpc/call [{:method     "wakuext_fetchCommunity"
-                     :params     [{:CommunityKey    community-id
-                                   :TryDatabase     true
-                                   :WaitForResponse true}]
-                     :on-success (fn [community]
-                                   (rf/dispatch [:chat.ui/community-resolved community-id community]))
-                     :on-error   (fn [err]
-                                   (rf/dispatch [:chat.ui/community-failed-to-resolve community-id])
-                                   (log/error {:message
-                                               "Failed to request community info from mailserver"
-                                               :error err}))}]}))
+(defn community-failed-to-resolve
+  [{:keys [db]} [community-id]]
+  {:db (update db :communities/resolve-community-info dissoc community-id)})
 
-(rf/reg-event-fx
- :chat.ui/spectate-community-successed
- (fn [{:keys [db]} [{:keys [communities]}]]
-   (when-let [community (first communities)]
-     {:db (-> db
-              (assoc-in [:communities (:id community) :spectated] true)
-              (assoc-in [:communities (:id community) :spectating] false))
-      :fx [[:dispatch [:communities/handle-community community]]
-           [:dispatch [::mailserver/request-messages]]]})))
+(rf/reg-event-fx :chat.ui/community-failed-to-resolve community-failed-to-resolve)
 
-(rf/reg-event-fx
- :chat.ui/spectate-community-failed
- (fn [{:keys [db]} [community-id]]
-   {:db (assoc-in db [:communities community-id :spectating] false)}))
+(defn fetch-community
+  [{:keys [db]} [community-id]]
+  (when community-id
+    {:db            (assoc-in db [:communities/resolve-community-info community-id] true)
+     :json-rpc/call [{:method     "wakuext_fetchCommunity"
+                      :params     [{:CommunityKey    community-id
+                                    :TryDatabase     true
+                                    :WaitForResponse true}]
+                      :on-success (fn [community]
+                                    (rf/dispatch [:chat.ui/community-resolved community-id community]))
+                      :on-error   (fn [err]
+                                    (rf/dispatch [:chat.ui/community-failed-to-resolve community-id])
+                                    (log/error {:message
+                                                "Failed to request community info from mailserver"
+                                                :error err}))}]}))
 
-(rf/reg-event-fx
- :chat.ui/spectate-community
- (fn [{:keys [db]} [community-id]]
-   (let [{:keys [spectated spectating joined]} (get-in db [:communities community-id])]
-     (when (and (not joined) (not spectated) (not spectating))
-       {:db            (assoc-in db [:communities community-id :spectating] true)
-        :json-rpc/call [{:method     "wakuext_spectateCommunity"
-                         :params     [community-id]
-                         :on-success (fn [res]
-                                       (rf/dispatch [:chat.ui/spectate-community-successed res]))
-                         :on-error   (fn [err]
-                                       (log/error {:message
-                                                   "Failed to spectate community"
-                                                   :error err})
-                                       (rf/dispatch [:chat.ui/spectate-community-failed
-                                                     community-id]))}]}))))
+(schema/=> fetch-community
+  [:=>
+   [:catn
+    [:cofx :schema.re-frame/cofx]
+    [:args
+     [:schema [:catn [:community-id [:? :string]]]]]]
+   [:map
+    [:db map?]
+    [:json-rpc/call :schema.common/rpc-call]]])
+
+(rf/reg-event-fx :chat.ui/fetch-community fetch-community)
+
+(defn spectate-community-success
+  [{:keys [db]} [{:keys [communities]}]]
+  (when-let [community (first communities)]
+    {:db (-> db
+             (assoc-in [:communities (:id community) :spectated] true)
+             (assoc-in [:communities (:id community) :spectating] false))
+     :fx [[:dispatch [:communities/handle-community community]]
+          [:dispatch [::mailserver/request-messages]]]}))
+
+(rf/reg-event-fx :chat.ui/spectate-community-success spectate-community-success)
+
+(defn spectate-community-failed
+  [{:keys [db]} [community-id]]
+  {:db (assoc-in db [:communities community-id :spectating] false)})
+
+(rf/reg-event-fx :chat.ui/spectate-community-failed spectate-community-failed)
+
+(defn spectate-community
+  [{:keys [db]} [community-id]]
+  (let [{:keys [spectated spectating joined]} (get-in db [:communities community-id])]
+    (when (and (not joined) (not spectated) (not spectating))
+      {:db            (assoc-in db [:communities community-id :spectating] true)
+       :json-rpc/call [{:method     "wakuext_spectateCommunity"
+                        :params     [community-id]
+                        :on-success [:chat.ui/spectate-community-success]
+                        :on-error   (fn [err]
+                                      (log/error {:message
+                                                  "Failed to spectate community"
+                                                  :error err})
+                                      (rf/dispatch [:chat.ui/spectate-community-failed
+                                                    community-id]))}]})))
+
+(schema/=> spectate-community
+  [:=>
+   [:catn
+    [:cofx :schema.re-frame/cofx]
+    [:args
+     [:schema [:catn [:community-id [:? :string]]]]]]
+   [:map
+    [:db map?]
+    [:json-rpc/call :schema.common/rpc-call]]])
+
+(rf/reg-event-fx :chat.ui/spectate-community spectate-community)
 
 (rf/defn save-link-preview-whitelist
   {:events [:chat.ui/link-preview-whitelist-received]}

--- a/src/status_im/contexts/chat/messages/link_preview/events_test.cljs
+++ b/src/status_im/contexts/chat/messages/link_preview/events_test.cljs
@@ -1,0 +1,140 @@
+(ns status-im.contexts.chat.messages.link-preview.events-test
+  (:require [cljs.test :as t]
+            [legacy.status-im.mailserver.core :as mailserver]
+            matcher-combinators.test
+            [status-im.contexts.chat.messages.link-preview.events :as sut]))
+
+(t/deftest fetch-community
+  (t/testing "with community id"
+    (t/testing "update resolving indicator in db"
+      (t/is (match?
+             {:db {:communities/resolve-community-info {"community-id" true}}}
+             (sut/fetch-community {} ["community-id"]))))
+    (t/testing "call the fetch community rpc method with correct community id"
+      (t/is (match?
+             {:json-rpc/call [{:method "wakuext_fetchCommunity"
+                               :params [{:CommunityKey    "community-id"
+                                         :TryDatabase     true
+                                         :WaitForResponse true}]}]}
+             (sut/fetch-community {} ["community-id"])))))
+  (t/testing "with nil community id"
+    (t/testing "do nothing"
+      (t/is (match?
+             nil
+             (sut/fetch-community {} nil))))))
+
+(t/deftest community-failed-to-resolve
+  (t/testing "given a community id"
+    (t/testing "remove community id from resolving indicator in db"
+      (t/is (match?
+             nil
+             (get-in (sut/community-failed-to-resolve {:db {:communities/resolve-community-info
+                                                            {"community-id" true}}}
+                                                      ["community-id"])
+                     [:db :communities/resolve-community-info "community-id"]))))))
+
+(t/deftest community-resolved
+  (with-redefs [sut/community-link (fn [id] (str "community-link+" id))]
+    (t/testing "given a community"
+      (let [cofx {:db {:communities/resolve-community-info {"community-id" true}}}
+            arg  ["community-id" {:id "community-id"}]]
+        (t/testing "remove community id from resolving indicator in db"
+          (t/is (match?
+                 nil
+                 (get-in (sut/community-resolved cofx arg)
+                         [:db :communities/resolve-community-info "community-id"]))))
+        (t/testing "dispatch fxs"
+          (t/is (match?
+                 {:fx [[:dispatch [:communities/handle-community {:id "community-id"}]]
+                       [:dispatch
+                        [:chat.ui/cache-link-preview-data "community-link+community-id"
+                         {:id "community-id"}]]
+                       [:dispatch [:chat.ui/spectate-community "community-id"]]]}
+                 (sut/community-resolved cofx arg))))))
+    (t/testing "given a joined community"
+      (let [cofx {:db {:communities/resolve-community-info {"community-id" true}}}
+            arg  ["community-id" {:id "community-id" :joined true}]]
+        (t/testing "dispatch fxs, do not spectate community"
+          (t/is (match?
+                 {:fx [[:dispatch [:communities/handle-community {:id "community-id"}]]
+                       [:dispatch
+                        [:chat.ui/cache-link-preview-data "community-link+community-id"
+                         {:id "community-id"}]]]}
+                 (sut/community-resolved cofx arg))))))
+    (t/testing "given a token-gated community"
+      (let [cofx {:db {:communities/resolve-community-info {"community-id" true}}}
+            arg  ["community-id" {:id "community-id" :tokenPermissions [1]}]]
+        (t/testing "dispatch fxs, do not spectate community"
+          (t/is (match?
+                 {:fx [[:dispatch [:communities/handle-community {:id "community-id"}]]
+                       [:dispatch
+                        [:chat.ui/cache-link-preview-data "community-link+community-id"
+                         {:id "community-id"}]]]}
+                 (sut/community-resolved cofx arg))))))
+    (t/testing "given nil community"
+      (t/testing "do nothing"
+        (t/is (match?
+               nil
+               (sut/community-resolved {} ["community-id" nil])))))))
+
+(t/deftest spectate-community
+  (t/testing "given a joined community"
+    (t/testing "do nothing"
+      (t/is (match?
+             nil
+             (sut/spectate-community {:db {:communities {"community-id" {:joined true}}}}
+                                     ["community-id"])))))
+  (t/testing "given a spectated community"
+    (t/testing "do nothing"
+      (t/is (match?
+             nil
+             (sut/spectate-community {:db {:communities {"community-id" {:spectated true}}}}
+                                     ["community-id"])))))
+  (t/testing "given a spectating community"
+    (t/testing "do nothing"
+      (t/is (match?
+             nil
+             (sut/spectate-community {:db {:communities {"community-id" {:spectating true}}}}
+                                     ["community-id"])))))
+  (t/testing "given a community"
+    (t/testing "mark community spectating"
+      (t/is (match?
+             {:db {:communities {"community-id" {:spectating true}}}}
+             (sut/spectate-community {:db {:communities {"community-id" {}}}} ["community-id"]))))
+    (t/testing "call spectate community rpc with correct community id"
+      (t/is (match?
+             {:json-rpc/call [{:method "wakuext_spectateCommunity"
+                               :params ["community-id"]}]}
+             (sut/spectate-community {:db {:communities {"community-id" {}}}} ["community-id"]))))))
+
+(t/deftest spectate-community-failed
+  (t/testing "mark community spectating false"
+    (t/is (match?
+           {:db {:communities {"community-id" {:spectating false}}}}
+           (sut/spectate-community-failed {} ["community-id"])))))
+
+(t/deftest spectate-community-success
+  (t/testing "given communities"
+    (t/testing "mark first community spectating false"
+      (t/is (match?
+             {:db {:communities {"community-id" {:spectating false}}}}
+             (sut/spectate-community-success {} [{:communities [{:id "community-id"}]}]))))
+    (t/testing "mark first community spectated true"
+      (t/is (match?
+             {:db {:communities {"community-id" {:spectated true}}}}
+             (sut/spectate-community-success {} [{:communities [{:id "community-id"}]}]))))
+    (t/testing "dispatch fxs for first community"
+      (t/is (match?
+             {:fx [[:dispatch [:communities/handle-community {:id "community-id"}]]
+                   [:dispatch [::mailserver/request-messages]]]}
+             (sut/spectate-community-success {} [{:communities [{:id "community-id"}]}])))))
+  (t/testing "given empty community"
+    (t/testing "do nothing"
+      (t/is (match?
+             nil
+             (sut/spectate-community-success {} [{:communities []}])))))
+  (t/testing "given nil community"
+    (t/testing "do nothing"
+      (t/is (match?
+             nil
+             (sut/spectate-community-success {} []))))))

--- a/src/status_im/contexts/chat/messages/link_preview/events_test.cljs
+++ b/src/status_im/contexts/chat/messages/link_preview/events_test.cljs
@@ -48,8 +48,7 @@
                  {:fx [[:dispatch [:communities/handle-community {:id "community-id"}]]
                        [:dispatch
                         [:chat.ui/cache-link-preview-data "community-link+community-id"
-                         {:id "community-id"}]]
-                       [:dispatch [:chat.ui/spectate-community "community-id"]]]}
+                         {:id "community-id"}]]]}
                  (sut/community-resolved cofx arg))))))
     (t/testing "given a joined community"
       (let [cofx {:db {:communities/resolve-community-info {"community-id" true}}}

--- a/src/status_im/contexts/chat/messages/link_preview/view.cljs
+++ b/src/status_im/contexts/chat/messages/link_preview/view.cljs
@@ -81,7 +81,7 @@
       (fn []
         (when-not cached-preview-data
           (let [community-id (community-id-from-link community-link)]
-            (rf/dispatch [:chat.ui/resolve-community-info community-id]))))
+            (rf/dispatch [:chat.ui/fetch-community community-id]))))
       :reagent-render
       (fn []
         (when cached-preview-data

--- a/src/status_im/contexts/communities/events.cljs
+++ b/src/status_im/contexts/communities/events.cljs
@@ -63,10 +63,11 @@
                      {}
                      (:communityTokensMetadata c)))))
 
-(rf/defn handle-community
-  [{:keys [db]} {:keys [id] :as community}]
-  (when id
-    {:db (assoc-in db [:communities id] (<-rpc community))}))
+(rf/reg-event-fx
+ :communities/handle-community
+ (fn [{:keys [db]} [{:keys [id] :as community}]]
+   (when id
+     {:db (assoc-in db [:communities id] (<-rpc community))})))
 
 (rf/defn handle-removed-chats
   [{:keys [db]} chat-ids]

--- a/src/status_im/contexts/communities/events.cljs
+++ b/src/status_im/contexts/communities/events.cljs
@@ -63,11 +63,21 @@
                      {}
                      (:communityTokensMetadata c)))))
 
-(rf/reg-event-fx
- :communities/handle-community
- (fn [{:keys [db]} [{:keys [id] :as community}]]
-   (when id
-     {:db (assoc-in db [:communities id] (<-rpc community))})))
+(rf/reg-event-fx :communities/handle-community
+ (fn [{:keys [db]}
+      [community-js]]
+   (when community-js
+     (let [{:keys [token-permissions
+                   token-permissions-check joined id]
+            :as   community}      (<-rpc community-js)
+           has-token-permissions? (not (seq token-permissions))]
+       {:db (assoc-in db [:communities id] community)
+        :fx [(when (and has-token-permissions? (not joined))
+               [:dispatch [:chat.ui/spectate-community id]])
+             (when (and has-token-permissions? (nil? token-permissions-check))
+               [:dispatch [:communities/check-permissions-to-join-community id]])
+             (when (and has-token-permissions? (not (get-in db [:community-channels-permissions id])))
+               [:dispatch [:communities/check-all-community-channels-permissions id]])]}))))
 
 (rf/defn handle-removed-chats
   [{:keys [db]} chat-ids]
@@ -110,10 +120,9 @@
 (rf/defn handle-communities
   {:events [:community/fetch-success]}
   [{:keys [db]} communities]
-  {:db (reduce (fn [db {:keys [id] :as community}]
-                 (assoc-in db [:communities id] (<-rpc community)))
-               db
-               communities)})
+  {:fx
+   (->> communities
+        (map #(vector :dispatch [:communities/handle-community %])))})
 
 (rf/reg-event-fx :communities/request-to-join-result
  (fn [{:keys [db]} [community-id request-id response-js]]
@@ -138,7 +147,6 @@
       :js-response true
       :on-success  #(rf/dispatch [:communities/request-to-join-result community-id request-id %])
       :on-error    #(log/error "failed to accept requests-to-join" community-id request-id %)}]}))
-
 
 (rf/reg-event-fx :communities/get-user-requests-to-join-success
  (fn [{:keys [db]} [requests]]

--- a/src/status_im/contexts/communities/overview/view.cljs
+++ b/src/status_im/contexts/communities/overview/view.cljs
@@ -212,18 +212,16 @@
 
 (defn add-handlers
   [community-id
-   joined
    {:keys [id locked?]
     :or   {locked? false}
     :as   chat}]
   (merge
    chat
    (when (and (not locked?) id)
-     {:on-press      (when joined
-                       (fn []
-                         (rf/dispatch [:dismiss-keyboard])
-                         (debounce/dispatch-and-chill [:chat/navigate-to-chat (str community-id id)]
-                                                      1000)))
+     {:on-press      (fn []
+                       (rf/dispatch [:dismiss-keyboard])
+                       (debounce/dispatch-and-chill [:chat/navigate-to-chat (str community-id id)]
+                                                    1000))
       :on-long-press #(rf/dispatch
                        [:show-bottom-sheet
                         {:content (fn []
@@ -231,12 +229,12 @@
       :community-id  community-id})))
 
 (defn add-handlers-to-chats
-  [community-id joined chats]
-  (mapv (partial add-handlers community-id joined) chats))
+  [community-id chats]
+  (mapv (partial add-handlers community-id) chats))
 
 (defn add-handlers-to-categorized-chats
-  [community-id categorized-chats joined]
-  (let [add-on-press (partial add-handlers-to-chats community-id joined)]
+  [community-id categorized-chats]
+  (let [add-on-press (partial add-handlers-to-chats community-id)]
     (map (fn [[category v]]
            [category (update v :chats add-on-press)])
          categorized-chats)))
@@ -286,7 +284,7 @@
            :community-id                    id
            :community-color                 color
            :on-first-channel-height-changed on-first-channel-height-changed}
-          (add-handlers-to-categorized-chats id chats-by-category joined)])])))
+          (add-handlers-to-categorized-chats id chats-by-category)])])))
 
 (defn sticky-category-header
   [_]


### PR DESCRIPTION
fixes #17971

### Summary

spectate non-token-gated community before join

1. `wakuext_requestCommunityInfoFromMailserver` is deprecated, replace it with `wakuext_fetchCommunity`
1. call `wakuext_spectateCommunity` once successfully running `wakuext_fetchCommunity` if it's not joined and it's a non-token-gated community
1. `::mailserver/request-messages` once successfully spectate community
1. channel list is not clickable if the community is not `joined` and not `spectated` (channel list is clickable once after the community is spectated but before the channel message is actually fetched)
1. community link in the video https://status.app/c/G2IAAGR023_wJpaujeShMUp3hQ04cA8w9JW2b-_isMesTfz17_fQ4zzosVAUtaPtue__MX92vAp14DNf9ANarRBxTZRVXuRZhFwL#zQ3shdAchHncDqEPjW4Vt6LjqAHGjsZmQiaBJ81dukJX1otMp


https://github.com/status-im/status-mobile/assets/15090582/539e1e37-1371-4bae-9237-973fa3fbd34c


#### Areas that maybe impacted
anything related to `Community A`
- where `Community A` is not joined and it's non-token-gated
- after mobile app fetched `Community A`
- before join `Community A`

about "fetched"
`:chat.ui/fetch-community` is only called in community link preview(not implemented yet) and when opening community universal link


### Steps to test
check the video

status: ready <!-- Can be ready or wip -->