### PR TITLE
Feature/display Community Rules on Request to Join

### DIFF
--- a/src/status_im/communities/core.cljs
+++ b/src/status_im/communities/core.cljs
@@ -74,6 +74,7 @@
                         :adminSettings               :admin-settings
                         :tokenPermissions            :token-permissions
                         :communityTokensMetadata     :tokens-metadata
+                        :introMessage                :intro-message
                         :muteTill                    :muted-till})
       (update :admin-settings
               set/rename-keys

--- a/src/status_im2/contexts/communities/actions/accounts_selection/view.cljs
+++ b/src/status_im2/contexts/communities/actions/accounts_selection/view.cljs
@@ -4,6 +4,7 @@
     [react-native.core :as rn]
     [react-native.gesture :as gesture]
     [status-im2.common.password-authentication.view :as password-authentication]
+    [status-im2.contexts.communities.actions.community-rules.view :as community-rules]
     [status-im2.contexts.communities.actions.request-to-join.style :as style]
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]))
@@ -26,6 +27,13 @@
       [rn/view {:flex 1}
        [gesture/scroll-view {:style {:flex 1}}
         [rn/view style/page-container
+         [quo/text
+          {:style               {:margin-top 24}
+           :accessibility-label :community-rules-title
+           :weight              :semi-bold
+           :size                :paragraph-1}
+          (i18n/label :t/community-rules)]
+         [community-rules/view id]
          [rn/view {:style (style/bottom-container)}
           [quo/button
            {:accessibility-label :cancel

--- a/src/status_im2/contexts/communities/actions/community_rules/style.cljs
+++ b/src/status_im2/contexts/communities/actions/community_rules/style.cljs
@@ -1,0 +1,10 @@
+(ns status-im2.contexts.communities.actions.community-rules.style)
+
+(def community-rule
+  {:flex        1
+   :align-items :flex-start
+   :margin-top  16})
+
+(def community-rule-text
+  {:margin-left 6
+   :flex        1})

--- a/src/status_im2/contexts/communities/actions/community_rules/view.cljs
+++ b/src/status_im2/contexts/communities/actions/community_rules/view.cljs
@@ -1,0 +1,16 @@
+(ns status-im2.contexts.communities.actions.community-rules.view
+  (:require
+    [quo.core :as quo]
+    [react-native.core :as rn]
+    [status-im2.contexts.communities.actions.community-rules.style :as style]
+    [utils.re-frame :as rf]))
+
+(defn view
+  [id]
+  (let [rules (rf/sub [:communities/rules id])]
+    [rn/view {:style style/community-rule}
+     [quo/text
+      {:style  style/community-rule-text
+       :weight :regular
+       :size   :paragraph-2}
+      rules]]))

--- a/src/status_im2/subs/communities.cljs
+++ b/src/status_im2/subs/communities.cljs
@@ -329,3 +329,9 @@
  :<- [:communities]
  (fn [communities [_ id]]
    (get-in communities [id :images])))
+
+(re-frame/reg-sub
+ :communities/rules
+ :<- [:communities]
+ (fn [communities [_ community-id]]
+   (get-in communities [community-id :intro-message])))


### PR DESCRIPTION
fixes #17969 

### Summary

This update introduces a feature that displays community rules to users as they join. The goal is to ensure immediate awareness and understanding of the community guidelines, reducing the likelihood of violations and potential removals from the community.

The feature is behind a feature toggle , disabled in `develop`.


#### Platforms

- Android
- iOS

#### Areas that maybe impacted

- Request to Join Community process
- Public chats
- Group chats

##### Functional

- public chats
- group chats

### Steps to test

- Enable` toggle status-im2.config/community-accounts-selection-enabled?`
- Set up a community rule using the Status Desktop application.
- Invite a new user to this community.
- Observe that the community rules are displayed to the new user when they request to join.

### Before and after screenshots comparison

#### Before

Previously, users saw a generic static message, not the specific one set up on Status Desktop.

<img width="672" alt="image" src="https://github.com/status-im/status-mobile/assets/5999878/082a3a08-54b9-4f34-b888-2d50687e3322">


#### After

Now, the community rules set up on Status Desktop are displayed to users when they join.

https://github.com/status-im/status-mobile/assets/5999878/7f39d8a4-ca41-4478-809e-350f96e9b5f0



status: ready 