### PR TITLE
Composer size when re-entering with unfinished multiline message

### DIFF
--- a/src/status_im/contexts/chat/messenger/composer/effects.cljs
+++ b/src/status_im/contexts/chat/messenger/composer/effects.cljs
@@ -16,13 +16,19 @@
 (defn reenter-screen-effect
   [{:keys [text-value saved-cursor-position maximized?]}
    {:keys [content-height]}
-   {:keys [input-content-height input-text input-maximized?]}]
-  (when (and (empty? @text-value) (not= input-text nil))
-    (reset! text-value input-text)
-    (reset! content-height input-content-height)
-    (reset! saved-cursor-position (count input-text)))
-  (when input-maximized?
-    (reset! maximized? true)))
+   {:keys [input-content-height input-text input-maximized?]}
+   {:keys [height]}]
+  (let [lines            (utils/calc-lines input-content-height)
+        minimized-height (if (or (= lines 1) (empty? input-text))
+                           constants/input-height
+                           constants/multiline-minimized-height)]
+    (when (and (empty? @text-value) (not= input-text nil))
+      (reset! text-value input-text)
+      (reset! content-height input-content-height)
+      (reset! saved-cursor-position (count input-text))
+      (reanimated/set-shared-value height minimized-height))
+    (when input-maximized?
+      (reset! maximized? true))))
 
 (defn maximized-effect
   [{:keys [maximized?]}
@@ -101,7 +107,7 @@
    [max-height])
   (rn/use-effect
    (fn []
-     (reenter-screen-effect state dimensions subscriptions))
+     (reenter-screen-effect state dimensions subscriptions animations))
    [max-height subscriptions]))
 
 (defn use-edit

--- a/src/status_im/contexts/chat/messenger/composer/gradients/style.cljs
+++ b/src/status_im/contexts/chat/messenger/composer/gradients/style.cljs
@@ -31,8 +31,7 @@
    :position :absolute
    :bottom   0
    :left     0
-   :right    0
-   :z-index  2})
+   :right    0})
 
 (defn bottom-gradient
   []

--- a/src/status_im/contexts/chat/messenger/composer/gradients/view.cljs
+++ b/src/status_im/contexts/chat/messenger/composer/gradients/view.cljs
@@ -19,6 +19,7 @@
      (when show-bottom-gradient?
        [rn/pressable
         {:on-press            #(when @input-ref (.focus ^js @input-ref))
+         :style               {:z-index 1}
          :accessibility-label :bottom-gradient}
         [linear-gradient/linear-gradient (style/bottom-gradient)]])]))
 

--- a/src/status_im/contexts/chat/messenger/composer/handlers.cljs
+++ b/src/status_im/contexts/chat/messenger/composer/handlers.cljs
@@ -16,18 +16,20 @@
 (defn focus
   "Animate to the `saved-height`, display background-overlay if needed, and set cursor position"
   [{:keys [input-ref] :as props}
-   {:keys [text-value focused? lock-selection? saved-cursor-position composer-focused?]}
+   {:keys [text-value focused? lock-selection? saved-cursor-position composer-focused? maximized?]}
    {:keys [height saved-height last-height opacity background-y container-opacity]
     :as   animations}
    {:keys [max-height] :as dimensions}]
   (reanimated/set-shared-value composer-focused? true)
   (reset! focused? true)
   (rf/dispatch [:chat.ui/set-input-focused true])
-  (let [last-height-value (reanimated/get-shared-value last-height)]
-    (reanimated/animate height last-height-value)
-    (reanimated/set-shared-value saved-height last-height-value)
+  (let [last-height-value (reanimated/get-shared-value last-height)
+        new-height        (min max-height last-height-value)]
+    (reanimated/animate height new-height)
+    (reanimated/set-shared-value saved-height new-height)
     (reanimated/animate container-opacity 1)
     (when (> last-height-value (* constants/background-threshold max-height))
+      (reset! maximized? true)
       (reanimated/animate opacity 1)
       (reanimated/set-shared-value background-y 0)))
 


### PR DESCRIPTION
fixes #17361 

### Summary

[comment]: # (Summarise the problem and how the pull request solves it)

When re-entering the composer while there's an unfinished multiline message, the composer wouldn't show it properly. Even when focused, it only showed one line. Now, in the same scenario, it will show the first two lines of the message when not focused and the entire message when focused, as usual.

NOTE: additionally, added a fix to the composer bottom shadow, which should be shown when the composer is collapsed and has a multiline message.

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- 1-1 chats
- public chats
- group chats

status: ready <!-- Can be ready or wip -->
