### PR TITLE
Add missing clj-kondo linter for library nubank/matcher-combinators

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -62,15 +62,7 @@
                 ;; https://github.com/borkdude/clj-kondo/issues/867
                 :unresolved-symbol             {:exclude [PersistentPriorityMap.EMPTY
                                                           number
-                                                          status-im.test-helpers/restore-app-db
-
-                                                          ;; When the namespace
-                                                          ;; matcher-combinators.test is loaded, it
-                                                          ;; extends cljs.test/is macro with
-                                                          ;; directives `match?` and
-                                                          ;; `thrown-match?`.
-                                                          match?
-                                                          thrown-match?]}
+                                                          status-im.test-helpers/restore-app-db]}
                 :unresolved-var                {:level :error}
                 :unsorted-required-namespaces  {:level :error}
                 :unused-alias                  {:level :warning}

--- a/.clj-kondo/nubank/matcher-combinators/config.edn
+++ b/.clj-kondo/nubank/matcher-combinators/config.edn
@@ -1,0 +1,4 @@
+{:linters
+ {:unresolved-symbol
+  {:exclude [(cljs.test/is [match? thrown-match?])
+             (clojure.test/is [match? thrown-match?])]}}}


### PR DESCRIPTION
### Summary

I forgot to add clj-kondo rules after adding the library `nubank/matcher-combinators`. Unfortunately, it's easy to miss this because only a few commands trigger the generation of external clj-kondo rules. In my case, they weren't generated by the time I coded and merged PR https://github.com/status-im/status-mobile/pull/18049.

#### Areas that may be impacted

None, just added an auto-generated clj-kondo linter.

status: ready
