### PR TITLE
fix: no avatar for the first message in 1-1 chat

### DIFF
--- a/src/status_im2/contexts/chat/messages/content/reactions/view.cljs
+++ b/src/status_im2/contexts/chat/messages/content/reactions/view.cljs
@@ -2,7 +2,6 @@
   (:require
     [quo.core :as quo]
     [quo.theme :as quo.theme]
-    [react-native.core :as rn]
     [status-im2.constants :as constants]
     [status-im2.contexts.chat.messages.drawers.view :as drawers]
     [utils.re-frame :as rf]))

--- a/src/status_im2/contexts/chat/messages/list/events.cljs
+++ b/src/status_im2/contexts/chat/messages/list/events.cljs
@@ -5,6 +5,17 @@
     [utils.re-frame :as rf]
     [utils.red-black-tree :as red-black-tree]))
 
+(defn- is-system-message?
+  [content-type]
+  (#{constants/content-type-system-text
+     constants/content-type-community
+     constants/content-type-system-message-mutual-event-accepted
+     constants/content-type-system-message-mutual-event-removed
+     constants/content-type-system-message-mutual-event-sent
+     constants/content-type-system-pinned-message}
+   content-type)
+)
+
 (defn- add-datemark
   [{:keys [whisper-timestamp] :as msg}]
   ;;NOTE(performance) this is slow
@@ -31,13 +42,7 @@
        :one-to-one?       (= constants/message-type-one-to-one message-type)
        :system-message?   (boolean
                            (or
-                            (#{constants/content-type-system-text
-                               constants/content-type-community
-                               constants/content-type-system-message-mutual-event-accepted
-                               constants/content-type-system-message-mutual-event-removed
-                               constants/content-type-system-message-mutual-event-sent
-                               constants/content-type-system-pinned-message}
-                             content-type)
+                            (is-system-message? content-type)
                             (= constants/message-type-private-group-system-message
                                message-type)
                             deleted?

--- a/src/status_im2/contexts/chat/messages/list/events.cljs
+++ b/src/status_im2/contexts/chat/messages/list/events.cljs
@@ -5,13 +5,20 @@
     [utils.re-frame :as rf]
     [utils.red-black-tree :as red-black-tree]))
 
-(def is-system-message?
+(def is-system-message-content-type?
   #{constants/content-type-system-text
     constants/content-type-community
     constants/content-type-system-message-mutual-event-accepted
     constants/content-type-system-message-mutual-event-removed
     constants/content-type-system-message-mutual-event-sent
     constants/content-type-system-pinned-message})
+
+(defn is-system-message?
+  [content-type message-type]
+  (or
+   (is-system-message-content-type? content-type)
+   (= constants/message-type-private-group-system-message
+      message-type)))
 
 (defn- add-datemark
   [{:keys [whisper-timestamp] :as msg}]
@@ -37,13 +44,10 @@
   (-> {:whisper-timestamp whisper-timestamp
        :from              from
        :one-to-one?       (= constants/message-type-one-to-one message-type)
-       :system-message?   (boolean
-                           (or
-                            (is-system-message? content-type)
-                            (= constants/message-type-private-group-system-message
-                               message-type)
-                            deleted?
-                            deleted-for-me?))
+       :system-message?   (or
+                           (is-system-message? content-type message-type)
+                           deleted?
+                           deleted-for-me?)
        :clock-value       clock-value
        :type              :message
        :message-id        message-id

--- a/src/status_im2/contexts/chat/messages/list/events.cljs
+++ b/src/status_im2/contexts/chat/messages/list/events.cljs
@@ -11,8 +11,7 @@
     constants/content-type-system-message-mutual-event-accepted
     constants/content-type-system-message-mutual-event-removed
     constants/content-type-system-message-mutual-event-sent
-    constants/content-type-system-pinned-message}
-)
+    constants/content-type-system-pinned-message})
 
 (defn- add-datemark
   [{:keys [whisper-timestamp] :as msg}]

--- a/src/status_im2/contexts/chat/messages/list/events.cljs
+++ b/src/status_im2/contexts/chat/messages/list/events.cljs
@@ -5,15 +5,13 @@
     [utils.re-frame :as rf]
     [utils.red-black-tree :as red-black-tree]))
 
-(defn- is-system-message?
-  [content-type]
-  (#{constants/content-type-system-text
-     constants/content-type-community
-     constants/content-type-system-message-mutual-event-accepted
-     constants/content-type-system-message-mutual-event-removed
-     constants/content-type-system-message-mutual-event-sent
-     constants/content-type-system-pinned-message}
-   content-type)
+(def is-system-message?
+  #{constants/content-type-system-text
+    constants/content-type-community
+    constants/content-type-system-message-mutual-event-accepted
+    constants/content-type-system-message-mutual-event-removed
+    constants/content-type-system-message-mutual-event-sent
+    constants/content-type-system-pinned-message}
 )
 
 (defn- add-datemark

--- a/src/status_im2/contexts/chat/messages/list/events.cljs
+++ b/src/status_im2/contexts/chat/messages/list/events.cljs
@@ -19,6 +19,7 @@
            clock-value
            album-id
            message-type
+           content-type
            from
            outgoing
            whisper-timestamp
@@ -30,6 +31,13 @@
        :one-to-one?       (= constants/message-type-one-to-one message-type)
        :system-message?   (boolean
                            (or
+                            (#{constants/content-type-system-text
+                               constants/content-type-community
+                               constants/content-type-system-message-mutual-event-accepted
+                               constants/content-type-system-message-mutual-event-removed
+                               constants/content-type-system-message-mutual-event-sent
+                               constants/content-type-system-pinned-message}
+                             content-type)
                             (= constants/message-type-private-group-system-message
                                message-type)
                             deleted?


### PR DESCRIPTION
fixes #17345 

### Summary

Fix the first messages sent after accepting contact request do not contain avatar

#### Platforms
<!-- (Optional. Specify which platforms should be tested) -->

- Android
- iOS

#### Areas that maybe impacted
<!-- (Optional. Specify if some specific areas has to be tested, for example 1-1 chats) -->

##### Functional

- 1-1 chats

### Steps to test
1. User1: send contact request
2. User2: accept contact request
3. User2: send message

status: ready <!-- Can be ready or wip -->
