### PR TITLE
Upgrade clang and patch Glog for fixing iOS builds on MacOS Sonoma, Xcode 15

### DIFF
--- a/nix/deps/nodejs-patched/default.nix
+++ b/nix/deps/nodejs-patched/default.nix
@@ -14,6 +14,7 @@ stdenv.mkDerivation {
     "patchJavaPhase"
     "patchReactNativePhase"
     "patchPodPhase"
+    "patchGlogPhase"
     "installPhase"
   ];
 
@@ -96,6 +97,14 @@ stdenv.mkDerivation {
     substituteInPlace ./node_modules/react-native/React/CoreModules/RCTActionSheetManager.mm --replace \
           '[RCTConvert UIColor:options.cancelButtonTintColor() ? @(*options.cancelButtonTintColor()) : nil];' \
           '[RCTConvert UIColor:options.tintColor() ? @(*options.tintColor()) : nil];'
+  '';
+
+  # Fix pod issue after upgrading to MacOS Sonoma and Xcode 15
+  # https://github.com/status-im/status-mobile/issues/17682
+  patchGlogPhase = ''
+    substituteInPlace ./node_modules/react-native/scripts/ios-configure-glog.sh \
+    --replace 'export CC="' '#export CC="' \
+    --replace 'export CXX="' '#export CXX="'
   '';
 
   # The ELF types are incompatible with the host platform, so let's not even try

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -73,6 +73,7 @@ in {
     allowHigher = true;
   };
   go = super.go_1_19;
+  clang = super.clang_15;
   buildGoPackage = super.buildGo119Package;
   buildGoModule = super.buildGo119Module;
   gomobile = (super.gomobile.overrideAttrs (old: {


### PR DESCRIPTION
fixes #17682 

After upgrading `MacOS` to `Sonoma` and `Xcode` to 15, pod install stage would fail with `clang` errors.
Turns out that `react-native`'s configure `glog` script sets 2 additional flags, `CC` and `CXX` which conflicts with flags already set in `nix` iOS shell.

In this PR we : 
- bump `clang` from `10.0.0` to `15.0.7`
- patch `glog` configure script to avoid setting those flags

This fixes the `iOS` builds.

status: ready
