### PR TITLE
Fix empty chat in opened on pressing hashtag in a community channel

### DIFF
--- a/src/status_im/browser/core.cljs
+++ b/src/status_im/browser/core.cljs
@@ -17,6 +17,7 @@
     [status-im.utils.deprecated-types :as types]
     [status-im.utils.random :as random]
     [status-im2.constants :as constants]
+    [status-im2.contexts.chat.events :as chat.events]
     [status-im2.navigation.events :as navigation]
     [taoensso.timbre :as log]
     [utils.address :as address]
@@ -310,6 +311,7 @@
                             {:browser-id (:browser-id browser)}
                             :browser/screen-id :browser)}
                 (navigation/pop-to-root :shell-stack)
+                (chat.events/close-chat)
                 (navigation/change-tab :browser-stack)
                 (update-browser browser)
                 (resolve-url nil)))))

--- a/src/status_im/group_chats/core.cljs
+++ b/src/status_im/group_chats/core.cljs
@@ -17,7 +17,7 @@
   {:events [:navigate-chat-updated]}
   [cofx chat-id]
   (when (get-in cofx [:db :chats chat-id])
-    (chat.events/navigate-to-chat cofx chat-id nil)))
+    (chat.events/pop-to-root-and-navigate-to-chat cofx chat-id nil)))
 
 (rf/defn handle-chat-removed
   {:events [:chat-removed]}
@@ -80,7 +80,7 @@
   {:events [:group-chats/create-from-link]}
   [cofx {:keys [chat-id invitation-admin chat-name]}]
   (if (get-in cofx [:db :chats chat-id])
-    {:dispatch [:chat/navigate-to-chat chat-id]}
+    {:dispatch [:chat/pop-to-root-and-navigate-to-chat chat-id]}
     {:json-rpc/call [{:method      "wakuext_createGroupChatFromInvitation"
                       :params      [chat-name chat-id invitation-admin]
                       :js-response true

--- a/src/status_im2/common/universal_links.cljs
+++ b/src/status_im2/common/universal_links.cljs
@@ -69,7 +69,7 @@
 (rf/defn handle-community-chat
   [cofx {:keys [chat-id]}]
   (log/info "universal-links: handling community chat" chat-id)
-  {:dispatch [:chat/navigate-to-chat chat-id]})
+  {:dispatch [:chat/pop-to-root-and-navigate-to-chat chat-id]})
 
 (rf/defn handle-view-profile
   [{:keys [db] :as cofx} {:keys [public-key ens-name]}]

--- a/src/status_im2/contexts/chat/effects.cljs
+++ b/src/status_im2/contexts/chat/effects.cljs
@@ -14,5 +14,5 @@
          :key-uid
          (fn [stored-key-uid]
            (when (= stored-key-uid key-uid)
-             (rf/dispatch [:chat/navigate-to-chat chat-id
+             (rf/dispatch [:chat/pop-to-root-and-navigate-to-chat chat-id
                            shell.constants/open-screen-without-animation])))))))))

--- a/src/status_im2/contexts/chat/events.cljs
+++ b/src/status_im2/contexts/chat/events.cljs
@@ -208,8 +208,6 @@
   [{db :db :as cofx} chat-id animation]
   (rf/merge cofx
             {:dispatch [(if animation :shell/navigate-to :navigate-to) :chat chat-id animation]}
-            (when-not (#{:community :community-overview :shell} (:view-id db))
-              (navigation/pop-to-root :shell-stack))
             (close-chat)
             (force-close-chat chat-id)
             (fn [{:keys [db]}]
@@ -217,6 +215,14 @@
             (preload-chat-data chat-id)
             #(when (group-chat? cofx chat-id)
                (loading/load-chat % chat-id))))
+
+(rf/defn pop-to-root-and-navigate-to-chat
+  {:events [:chat/pop-to-root-and-navigate-to-chat]}
+  [cofx chat-id animation]
+  (rf/merge
+   cofx
+   (navigation/pop-to-root :shell-stack)
+   (navigate-to-chat chat-id animation)))
 
 (rf/defn handle-clear-history-response
   {:events [:chat/history-cleared]}
@@ -237,7 +243,7 @@
                  (assoc-in [:chats chat-id] chat)
                  :always
                  (update :chats-home-list conj chat-id))
-     :dispatch [:chat/navigate-to-chat chat-id]}))
+     :dispatch [:chat/pop-to-root-and-navigate-to-chat chat-id]}))
 
 (rf/defn decrease-unviewed-count
   {:events [:chat/decrease-unviewed-count]}

--- a/src/status_im2/contexts/shell/activity_center/notification/membership/view.cljs
+++ b/src/status_im2/contexts/shell/activity_center/notification/membership/view.cljs
@@ -14,7 +14,7 @@
     [gesture/touchable-without-feedback
      {:on-press (fn []
                   (rf/dispatch [:hide-popover])
-                  (rf/dispatch [:chat/navigate-to-chat chat-id]))}
+                  (rf/dispatch [:chat/pop-to-root-and-navigate-to-chat chat-id]))}
      child]
     child))
 

--- a/src/status_im2/contexts/shell/activity_center/notification/mentions/view.cljs
+++ b/src/status_im2/contexts/shell/activity_center/notification/mentions/view.cljs
@@ -52,7 +52,7 @@
      [gesture/touchable-without-feedback
       {:on-press (fn []
                    (rf/dispatch [:hide-popover])
-                   (rf/dispatch [:chat/navigate-to-chat chat-id]))}
+                   (rf/dispatch [:chat/pop-to-root-and-navigate-to-chat chat-id]))}
       [quo/activity-log
        {:title               (i18n/label :t/mention)
         :customization-color customization-color

--- a/src/status_im2/contexts/shell/activity_center/notification/reply/view.cljs
+++ b/src/status_im2/contexts/shell/activity_center/notification/reply/view.cljs
@@ -74,7 +74,7 @@
      [gesture/touchable-without-feedback
       {:on-press (fn []
                    (rf/dispatch [:hide-popover])
-                   (rf/dispatch [:chat/navigate-to-chat chat-id]))}
+                   (rf/dispatch [:chat/pop-to-root-and-navigate-to-chat chat-id]))}
       [quo/activity-log
        {:title               (i18n/label :t/message-reply)
         :customization-color customization-color

--- a/src/status_im2/navigation/events.cljs
+++ b/src/status_im2/navigation/events.cljs
@@ -60,15 +60,12 @@
 (rf/defn pop-to-root
   {:events [:pop-to-root]}
   [{:keys [db]} tab]
-  (merge
-   {:pop-to-root-fx            tab
-    :db                        (-> db
-                                   (dissoc :shell/floating-screens)
-                                   (dissoc :shell/loaded-screens)
-                                   (assoc :view-id (or @shell.state/selected-stack-id :shell)))
-    :effects.shell/pop-to-root nil}
-   (when (:current-chat-id db)
-     {:dispatch-n [[:chat/close]]})))
+  {:pop-to-root-fx            tab
+   :db                        (-> db
+                                  (dissoc :shell/floating-screens)
+                                  (dissoc :shell/loaded-screens)
+                                  (assoc :view-id (or @shell.state/selected-stack-id :shell)))
+   :effects.shell/pop-to-root nil})
 
 (rf/defn init-root
   {:events [:init-root]}


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/18095

### Summary
- Explicitly pop to root when needed
- Explicitly close chat when needed

### Testing
- Please make sure the background community screen is not getting closed while navigating to a different channel
- Please also test https://github.com/status-im/status-mobile/issues/18065
- PR affects how we navigate to chats from different places (the navigation center, profile page, etc.). Changes are simple and tested, but let me know if anything breaks there.
