### PR TITLE
Set fleet to shards.test

### DIFF
--- a/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusModule.java
+++ b/modules/react-native-status/android/src/main/java/im/status/ethereum/module/StatusModule.java
@@ -1184,6 +1184,11 @@ class StatusModule extends ReactContextBaseJavaModule implements LifecycleEventL
     }
 
     @ReactMethod(isBlockingSynchronousMethod = true)
+    public String fleets() {
+        return Statusgo.fleets();
+    }
+
+    @ReactMethod(isBlockingSynchronousMethod = true)
     public String backupDisabledDataDir() {
         return this.getNoBackupDirectory();
     }

--- a/modules/react-native-status/ios/RCTStatus/RCTStatus.m
+++ b/modules/react-native-status/ios/RCTStatus/RCTStatus.m
@@ -981,6 +981,10 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(isAddress:(NSString *)address) {
   return StatusgoIsAddress(address);
 }
 
+RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(fleets) {
+  return StatusgoFleets();
+}
+
 RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(toChecksumAddress:(NSString *)address) {
   return StatusgoToChecksumAddress(address);
 }

--- a/modules/react-native-status/nodejs/status.cpp
+++ b/modules/react-native-status/nodejs/status.cpp
@@ -298,6 +298,7 @@ void _MultiAccountStoreAccount(const FunctionCallbackInfo<Value>& args) {
 	delete c;
 }
 
+
 void _InitKeystore(const FunctionCallbackInfo<Value>& args) {
 	Isolate* isolate = args.GetIsolate();
         Local<Context> context = isolate->GetCurrentContext();
@@ -561,6 +562,17 @@ void _CheckAddressChecksum(const FunctionCallbackInfo<Value>& args) {
 	delete c;
 
 }
+
+void _Fleets(const FunctionCallbackInfo<Value>& args) {
+	Isolate* isolate = args.GetIsolate();
+	// Call exported Go function, which returns a C string
+	char *c = Fleets();
+
+	Local<String> ret = String::NewFromUtf8(isolate, c).ToLocalChecked();
+	args.GetReturnValue().Set(ret);
+	delete c;
+}
+
 
 void _IsAddress(const FunctionCallbackInfo<Value>& args) {
 	Isolate* isolate = args.GetIsolate();
@@ -1888,6 +1900,7 @@ void init(Local<Object> exports) {
 	NODE_SET_METHOD(exports, "multiAccountStoreDerivedAccounts", _MultiAccountStoreDerivedAccounts);
 	NODE_SET_METHOD(exports, "multiAccountStoreAccount", _MultiAccountStoreAccount);
 	NODE_SET_METHOD(exports, "initKeystore", _InitKeystore);
+	NODE_SET_METHOD(exports, "fleets", _Fleets);
 	NODE_SET_METHOD(exports, "stopCPUProfiling", _StopCPUProfiling);
 	NODE_SET_METHOD(exports, "encodeTransfer", _EncodeTransfer);
 	NODE_SET_METHOD(exports, "encodeFunctionCall", _EncodeFunctionCall);

--- a/src/legacy/status_im/keycard/card.cljs
+++ b/src/legacy/status_im/keycard/card.cljs
@@ -527,23 +527,7 @@
         (error-object->map response)]))}))
 
 (defn save-multiaccount-and-login
-  [{:keys [key-uid multiaccount-data password settings node-config accounts-data chat-key]}]
-  (if config/keycard-test-menu-enabled?
-    (native-module/save-account-and-login
-     key-uid
-     (types/clj->json multiaccount-data)
-     password
-     (types/clj->json settings)
-     node-config
-     (types/clj->json accounts-data))
-    (native-module/save-multiaccount-and-login-with-keycard
-     key-uid
-     (types/clj->json multiaccount-data)
-     password
-     (types/clj->json settings)
-     node-config
-     (types/clj->json accounts-data)
-     chat-key)))
+  [_])
 
 (defn login
   [{:keys [key-uid multiaccount-data password] :as args}]

--- a/src/legacy/status_im/keycard/recovery.cljs
+++ b/src/legacy/status_im/keycard/recovery.cljs
@@ -16,7 +16,6 @@
     [taoensso.timbre :as log]
     [utils.address :as address]
     [utils.datetime :as datetime]
-    [utils.ethereum.eip.eip55 :as eip55]
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]
     [utils.security.core :as security]))
@@ -151,6 +150,7 @@
              :keycard/check-nfc-enabled nil}
             (intro-wizard)))
 
+;; NOTE: currently non functional, keycard needs to be reimplemented
 (rf/defn create-keycard-multiaccount
   {:events       [::create-keycard-multiaccount]
    :interceptors [(re-frame/inject-cofx :random-guid-generator)
@@ -181,27 +181,7 @@
     (rf/merge cofx
               {:db (-> db
                        (assoc-in [:keycard :setup-step] nil)
-                       (dissoc :intro-wizard))}
-              (multiaccounts.create/on-multiaccount-created
-               {:recovered            (or recovered (get-in db [:intro-wizard :recovering?]))
-                :derived              {constants/path-wallet-root-keyword
-                                       {:public-key wallet-root-public-key
-                                        :address    (eip55/address->checksum wallet-root-address)}
-                                       constants/path-whisper-keyword
-                                       {:public-key whisper-public-key
-                                        :address    (eip55/address->checksum whisper-address)}
-                                       constants/path-default-wallet-keyword
-                                       {:public-key wallet-public-key
-                                        :address    (eip55/address->checksum wallet-address)}}
-                :address              address
-                :public-key           public-key
-                :keycard-instance-uid instance-uid
-                :key-uid              (address/normalized-hex key-uid)
-                :keycard-pairing      pairing
-                :keycard-paired-on    paired-on
-                :chat-key             whisper-private-key}
-               encryption-public-key
-               {}))))
+                       (dissoc :intro-wizard))})))
 
 (rf/defn return-to-keycard-login
   [{:keys [db] :as cofx}]

--- a/src/legacy/status_im/log_level/core.cljs
+++ b/src/legacy/status_im/log_level/core.cljs
@@ -1,7 +1,6 @@
 (ns legacy.status-im.log-level.core
   (:require
     [legacy.status-im.multiaccounts.update.core :as multiaccounts.update]
-    [legacy.status-im.node.core :as node]
     [re-frame.core :as re-frame]
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]))
@@ -11,13 +10,11 @@
   [{:keys [db now] :as cofx} log-level]
   (let [old-log-level (get-in db [:profile/profile :log-level])]
     (when (not= old-log-level log-level)
-      (rf/merge cofx
-                (multiaccounts.update/multiaccount-update
-                 :log-level
-                 log-level
-                 {})
-                (node/prepare-new-config
-                 {:on-success #(re-frame/dispatch [:logout])})))))
+      (multiaccounts.update/multiaccount-update
+       cofx
+       :log-level
+       log-level
+       {:on-success #(re-frame/dispatch [:logout])}))))
 
 (rf/defn show-change-log-level-confirmation
   {:events [:log-level.ui/log-level-selected]}

--- a/src/legacy/status_im/multiaccounts/create/core.cljs
+++ b/src/legacy/status_im/multiaccounts/create/core.cljs
@@ -1,18 +1,11 @@
 (ns legacy.status-im.multiaccounts.create.core
   (:require
-    [legacy.status-im.data-store.settings :as data-store.settings]
-    [legacy.status-im.node.core :as node]
-    [legacy.status-im.ui.components.colors :as colors]
     [legacy.status-im.utils.deprecated-types :as types]
     [legacy.status-im.utils.signing-phrase.core :as signing-phrase]
     [native-module.core :as native-module]
     [re-frame.core :as re-frame]
-    [status-im.config :as config]
     [status-im.constants :as constants]
-    [utils.ethereum.eip.eip55 :as eip55]
-    [utils.i18n :as i18n]
-    [utils.re-frame :as rf]
-    [utils.security.core :as security]))
+    [utils.re-frame :as rf]))
 
 (defn normalize-derived-data-keys
   [derived-data]
@@ -82,134 +75,3 @@
 (rf/defn save-multiaccount-and-login-with-keycard
   [_ args]
   {:keycard/save-multiaccount-and-login args})
-
-(re-frame/reg-fx
- ::save-account-and-login
- (fn [[key-uid multiaccount-data hashed-password settings config accounts-data]]
-   (native-module/save-account-and-login
-    key-uid
-    multiaccount-data
-    hashed-password
-    settings
-    config
-    accounts-data)))
-
-(rf/defn save-account-and-login
-  [{:keys [db]} key-uid multiaccount-data password settings node-config accounts-data]
-  {:db                      (assoc-in db [:syncing :login-sha3-password] password)
-   ::save-account-and-login [key-uid
-                             (types/clj->json multiaccount-data)
-                             password
-                             (types/clj->json settings)
-                             node-config
-                             (types/clj->json accounts-data)]})
-
-(defn prepare-accounts-data
-  [multiaccount]
-  [(let [{:keys [public-key address]}
-         (get-in multiaccount [:derived constants/path-default-wallet-keyword])]
-     {:public-key public-key
-      :address    (eip55/address->checksum address)
-      :color      colors/blue-persist
-      :wallet     true
-      :path       constants/path-default-wallet
-      :name       (i18n/label :t/main-account)})
-   (let [{:keys [compressed-key public-key address name]}
-         (get-in multiaccount [:derived constants/path-whisper-keyword])]
-     {:public-key     public-key
-      :compressed-key compressed-key
-      :address        (eip55/address->checksum address)
-      :name           name
-      :path           constants/path-whisper
-      :chat           true})])
-
-(rf/defn on-multiaccount-created
-  [{:keys [signing-phrase random-guid-generator db] :as cofx}
-   {:keys [address chat-key keycard-instance-uid key-uid
-           keycard-pairing keycard-paired-on mnemonic recovered]
-    :as   multiaccount}
-   password
-   {:keys [save-mnemonic? login?] :or {login? true save-mnemonic? false}}]
-  (let [[wallet-account
-         {:keys [public-key
-                 compressed-key
-                 name]} :as accounts-data]
-        (prepare-accounts-data
-         multiaccount)
-        multiaccount-data {:name            name
-                           :address         address
-                           :key-uid         key-uid
-                           :keycard-pairing keycard-pairing}
-        keycard-multiaccount? (boolean keycard-pairing)
-        eip1581-address (get-in multiaccount
-                                [:derived
-                                 constants/path-eip1581-keyword
-                                 :address])
-        new-multiaccount
-        (cond->
-          (merge
-           {;; address of the master key
-            :address address
-            ;; sha256 of master public key
-            :key-uid key-uid
-            ;; The address from which we derive any wallet
-            :wallet-root-address
-            (get-in multiaccount
-                    [:derived
-                     constants/path-wallet-root-keyword
-                     :address])
-            :name name
-            ;; public key of the chat account
-            :public-key public-key
-            ;; compressed key of the chat account
-            :compressed-key compressed-key
-            ;; default address for Dapps
-            :dapps-address (:address wallet-account)
-            :latest-derived-path 0
-            :signing-phrase signing-phrase
-            :backup-enabled? true
-            :installation-id (random-guid-generator)
-            ;; default mailserver (history node) setting
-            :use-mailservers? true
-            :recovered recovered}
-           config/default-multiaccount)
-          ;; The address from which we derive any chat account/encryption keys
-          eip1581-address
-          (assoc :eip1581-address eip1581-address)
-          save-mnemonic?
-          (assoc :mnemonic mnemonic)
-          keycard-multiaccount?
-          (assoc :keycard-instance-uid keycard-instance-uid
-                 :keycard-pairing      keycard-pairing
-                 :keycard-paired-on    keycard-paired-on))
-        db (assoc db
-                  :profile/login            {:key-uid    key-uid
-                                             :name       name
-                                             :password   password
-                                             :creating?  true
-                                             :processing true}
-                  :profile/profile          new-multiaccount
-                  :profile/wallet-accounts  [wallet-account]
-                  :networks/current-network config/default-network
-                  :networks/networks        (data-store.settings/rpc->networks config/default-networks))
-        settings (assoc new-multiaccount
-                        :networks/current-network config/default-network
-                        :networks/networks        config/default-networks)]
-    (rf/merge cofx
-              {:db db}
-              (if keycard-multiaccount?
-                (save-multiaccount-and-login-with-keycard
-                 {:key-uid           key-uid
-                  :multiaccount-data multiaccount-data
-                  :password          password
-                  :settings          settings
-                  :node-config       (node/get-new-config db)
-                  :accounts-data     accounts-data
-                  :chat-key          chat-key})
-                (save-account-and-login
-                 key-uid
-                 multiaccount-data
-                 (native-module/sha3 (security/safe-unmask-data password))
-                 settings
-                 (node/get-new-config db)
-                 accounts-data)))))

--- a/src/legacy/status_im/network/core.cljs
+++ b/src/legacy/status_im/network/core.cljs
@@ -1,7 +1,6 @@
 (ns legacy.status-im.network.core
   (:require
     [clojure.string :as string]
-    [legacy.status-im.node.core :as node]
     [re-frame.core :as re-frame]
     [status-im.navigation.events :as navigation]
     [utils.ethereum.chain :as chain]
@@ -117,12 +116,10 @@
 (rf/defn save-network-settings
   {:events [::save-network-settings-pressed]}
   [{:keys [db] :as cofx} network]
-  (rf/merge cofx
-            {:db            (assoc db :networks/current-network network)
-             :json-rpc/call [{:method     "settings_saveSetting"
-                              :params     [:networks/current-network network]
-                              :on-success #()}]}
-            (node/prepare-new-config {:on-success #(re-frame/dispatch [:logout])})))
+  {:db            (assoc db :networks/current-network network)
+   :json-rpc/call [{:method     "settings_saveSetting"
+                    :params     [:networks/current-network network]
+                    :on-success #(re-frame/dispatch [:logout])}]})
 
 (rf/defn remove-network
   {:events [::remove-network-confirmed]}

--- a/src/legacy/status_im/ui/screens/advanced_settings/views.cljs
+++ b/src/legacy/status_im/ui/screens/advanced_settings/views.cljs
@@ -15,9 +15,8 @@
 (defn- normal-mode-settings-data
   [{:keys [network-name
            current-log-level
-           waku-bloom-filter-mode
+           light-client-enabled?
            transactions-management-enabled?
-           wakuv2-flag
            current-fleet
            webview-debug
            test-networks-enabled?]}]
@@ -55,19 +54,12 @@
      :accessory :text
      :accessory-text current-fleet
      :chevron true}
-    (if wakuv2-flag
-      {:size :small
-       :title (i18n/label :t/wakuv2-settings)
-       :accessibility-label :wakuv2-settings-button
-       :on-press
-       #(re-frame/dispatch [:wakuv2.ui/enter-settings-pressed])
-       :chevron true}
-      {:size :small
-       :title (i18n/label :t/bootnodes)
-       :accessibility-label :bootnodes-settings-button
-       :on-press
-       #(re-frame/dispatch [:navigate-to :bootnodes-settings])
-       :chevron true})
+    {:size :small
+     :title (i18n/label :t/wakuv2-settings)
+     :accessibility-label :wakuv2-settings-button
+     :on-press
+     #(re-frame/dispatch [:wakuv2.ui/enter-settings-pressed])
+     :chevron true}
     {:size :small
      :title (i18n/label :t/rpc-usage-info)
      :accessibility-label :rpc-usage-info
@@ -82,6 +74,15 @@
      :on-press
      #(re-frame/dispatch [:navigate-to :peers-stats])
      :chevron true}
+    {:size :small
+     :title (i18n/label :t/light-client-enabled)
+     :accessibility-label :light-client-enabled
+     :container-margin-bottom 8
+     :on-press
+     #(re-frame/dispatch
+       [:wakuv2.ui/toggle-light-client (not light-client-enabled?)])
+     :accessory :switch
+     :active light-client-enabled?}
     {:size :small
      :title (i18n/label :t/transactions-management-enabled)
      :accessibility-label :transactions-management-enabled
@@ -109,15 +110,6 @@
      #(re-frame/dispatch [:profile.settings/toggle-test-networks])
      :accessory :switch
      :active test-networks-enabled?}
-    {:size :small
-     :title (i18n/label :t/waku-bloom-filter-mode)
-     :accessibility-label :waku-bloom-filter-mode-settings-switch
-     :container-margin-bottom 8
-     :on-press
-     #(re-frame/dispatch
-       [:multiaccounts.ui/waku-bloom-filter-mode-switched (not waku-bloom-filter-mode)])
-     :accessory :switch
-     :active waku-bloom-filter-mode}
     {:size                :small
      :title               (i18n/label :t/set-currency)
      :accessibility-label :wallet-change-currency
@@ -137,11 +129,10 @@
 
 (views/defview advanced-settings
   []
-  (views/letsubs [{:keys [webview-debug
-                          test-networks-enabled?]} [:profile/profile]
+  (views/letsubs [test-networks-enabled?           [:profile/test-networks-enabled?]
+                  light-client-enabled?            [:profile/light-client-enabled?]
+                  webview-debug                    [:profile/webview-debug]
                   network-name                     [:network-name]
-                  waku-bloom-filter-mode           [:waku/bloom-filter-mode]
-                  wakuv2-flag                      [:waku/v2-flag]
                   transactions-management-enabled? [:wallet-legacy/transactions-management-enabled?]
                   current-log-level                [:log-level/current-log-level]
                   current-fleet                    [:fleets/current-fleet]]
@@ -150,10 +141,9 @@
                   {:network-name                     network-name
                    :current-log-level                current-log-level
                    :transactions-management-enabled? transactions-management-enabled?
+                   :light-client-enabled?            light-client-enabled?
                    :current-fleet                    current-fleet
                    :dev-mode?                        false
-                   :wakuv2-flag                      wakuv2-flag
-                   :waku-bloom-filter-mode           waku-bloom-filter-mode
                    :webview-debug                    webview-debug
                    :test-networks-enabled?           test-networks-enabled?})
       :key-fn    (fn [_ i] (str i))

--- a/src/legacy/status_im/ui/screens/fleet_settings/views.cljs
+++ b/src/legacy/status_im/ui/screens/fleet_settings/views.cljs
@@ -1,6 +1,6 @@
 (ns legacy.status-im.ui.screens.fleet-settings.views
   (:require
-    [legacy.status-im.node.core :as node]
+    [legacy.status-im.fleet.core :as fleets]
     [legacy.status-im.ui.components.icons.icons :as icons]
     [legacy.status-im.ui.components.list.views :as list]
     [legacy.status-im.ui.components.react :as react]
@@ -30,16 +30,11 @@
        [react/text {:style styles/fleet-item-name-text}
         fleet]]]]))
 
-(defn fleets
-  [custom-fleets]
-  (map name (keys (node/fleets {:custom-fleets custom-fleets}))))
-
 (views/defview fleet-settings
   []
-  (views/letsubs [custom-fleets [:fleets/custom-fleets]
-                  current-fleet [:fleets/current-fleet]]
+  (views/letsubs [current-fleet [:fleets/current-fleet]]
     [list/flat-list
-     {:data               (fleets custom-fleets)
+     {:data               fleets/fleets
       :default-separator? false
       :key-fn             identity
       :render-data        (name current-fleet)

--- a/src/legacy/status_im/utils/test.cljs
+++ b/src/legacy/status_im/utils/test.cljs
@@ -121,6 +121,9 @@
     :isAddress
     (fn [address] (.isAddress native-status address))
 
+    :fleets
+    (fn [] (.fleets native-status))
+
     :validateMnemonic
     (fn [json callback] (callback (.validateMnemonic native-status json)))
 

--- a/src/legacy/status_im/waku/core.cljs
+++ b/src/legacy/status_im/waku/core.cljs
@@ -1,23 +1,12 @@
 (ns legacy.status-im.waku.core
   (:require
     [clojure.string :as string]
-    [legacy.status-im.multiaccounts.update.core :as multiaccounts.update]
-    [legacy.status-im.node.core :as node]
     [re-frame.core :as re-frame]
     [status-im.navigation.events :as navigation]
+    [taoensso.timbre :as log]
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]))
 
-(rf/defn switch-waku-bloom-filter-mode
-  {:events [:multiaccounts.ui/waku-bloom-filter-mode-switched]}
-  [cofx enabled?]
-  (rf/merge cofx
-            (multiaccounts.update/multiaccount-update
-             :waku-bloom-filter-mode
-             enabled?
-             {})
-            (node/prepare-new-config
-             {:on-success #(re-frame/dispatch [:logout])})))
 
 (def address-regex #"/ip4/\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/tcp/\d{1,5}/p2p/[a-zA-Z0-9]+")
 
@@ -108,13 +97,16 @@
                        vals
                        (map #(vector (:name %1) (:address %1)))
                        (into {}))]
-    (rf/merge cofx
-              {:db       (-> db
-                             (assoc-in [:profile/profile :wakuv2-config :CustomNodes] new-nodes)
-                             (dissoc :wakuv2-nodes/manage :wakuv2-nodes/list))
-               :dispatch [:navigate-back]}
-              (node/prepare-new-config
-               {:on-success #(re-frame/dispatch [:logout])}))))
+    {:db            (-> db
+                        (assoc-in [:profile/profile :wakuv2-config :CustomNodes] new-nodes)
+                        (dissoc :wakuv2-nodes/manage :wakuv2-nodes/list))
+     :json-rpc/call [{:method     "wakuext_setCustomNodes"
+                      :params     [{:customNodes new-nodes}]
+                      :on-success #(log/info "updated custom nodes")
+                      :on-error   #(log/error "failed to set custom nodes"
+                                              {:error        %
+                                               :custom-nodes new-nodes})}]
+     :dispatch      [:navigate-back]}))
 
 (rf/defn show-delete-node-confirmation
   {:events [:wakuv2.ui/delete-pressed]}
@@ -131,3 +123,17 @@
   (rf/merge cofx
             (delete id)
             (navigation/navigate-back)))
+
+(rf/defn toggle-light-client
+  {:events [:wakuv2.ui/toggle-light-client]}
+  [{:keys [db]} enabled?]
+  {:db            (assoc-in db [:profile/profile :wakuv2-config :LightClient] enabled?)
+
+   :json-rpc/call [{:method     "wakuext_setLightClient"
+                    :params     [{:enabled enabled?}]
+                    :on-success (fn []
+                                  (log/info "light client set successfully" enabled?)
+                                  (re-frame/dispatch [:logout]))
+                    :on-error   #(log/error "failed to set light client"
+                                            {:error    %
+                                             :enabled? enabled?})}]})

--- a/src/native_module/core.cljs
+++ b/src/native_module/core.cljs
@@ -40,23 +40,6 @@
                               config
                               #(callback (types/json->clj %))))
 
-(defn save-account-and-login
-  "NOTE: beware, the password has to be sha3 hashed"
-  [key-uid multiaccount-data hashed-password settings config accounts-data]
-  (log/debug "[native-module] save-account-and-login"
-             "multiaccount-data"
-             multiaccount-data)
-  (clear-web-data)
-  (init-keystore
-   key-uid
-   #(.saveAccountAndLogin
-     ^js (status)
-     multiaccount-data
-     hashed-password
-     settings
-     config
-     accounts-data)))
-
 (defn save-multiaccount-and-login-with-keycard
   "NOTE: chat-key is a whisper private key sent from keycard"
   [key-uid multiaccount-data password settings config accounts-data chat-key]
@@ -535,6 +518,10 @@
 (defn backup-disabled-data-dir
   []
   (.backupDisabledDataDir ^js (status)))
+
+(defn fleets
+  []
+  (.fleets ^js (status)))
 
 (defn keystore-dir
   []

--- a/src/status_im/common/home/actions/view.cljs
+++ b/src/status_im/common/home/actions/view.cljs
@@ -6,8 +6,10 @@
     [status-im.common.confirmation-drawer.view :as confirmation-drawer]
     [status-im.common.mute-drawer.view :as mute-drawer]
     [status-im.common.muting.helpers :refer [format-mute-till]]
+    [status-im.config :as config]
     [status-im.constants :as constants]
-    [status-im.contexts.communities.actions.chat.view :as chat-actions]
+    [status-im.contexts.chat.actions.view :as chat-actions]
+    [status-im.contexts.communities.actions.chat.view :as communities-chat-actions]
     [status-im.contexts.contacts.drawers.nickname-drawer.view :as nickname-drawer]
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]))
@@ -255,16 +257,6 @@
           :chevron?            true
           :add-divider?        add-divider?}))
 
-;; TODO(OmarBasem): Requires design input.
-(defn fetch-messages-entry
-  []
-  (entry {:icon                :i/save
-          :label               (i18n/label :t/fetch-messages)
-          :on-press            #(js/alert "TODO: to be implemented, requires design input")
-          :danger?             false
-          :accessibility-label :fetch-messages
-          :sub-label           nil
-          :chevron?            true}))
 
 (defn remove-from-contacts-entry
   [contact]
@@ -422,8 +414,8 @@
   [(mark-as-read-entry chat-id needs-divider?)
    (mute-chat-entry chat-id chat-type muted-till)
    (notifications-entry false)
-   (when inside-chat?
-     (fetch-messages-entry))
+   (when (and config/fetch-messages-enabled? inside-chat?)
+     (chat-actions/fetch-messages chat-id))
    (when public?
      (show-qr-entry))
    (when public?
@@ -481,7 +473,7 @@
     constants/private-group-chat-type
     [private-group-chat-actions chat inside-chat?]
     constants/community-chat-type
-    [chat-actions/actions chat inside-chat?]
+    [communities-chat-actions/actions chat inside-chat?]
     nil))
 
 (defn group-details-actions

--- a/src/status_im/config.cljs
+++ b/src/status_im/config.cljs
@@ -158,3 +158,4 @@
 (def default-kdf-iterations 3200)
 
 (def community-accounts-selection-enabled? false)
+(def fetch-messages-enabled? (enabled? (get-config :FETCH_MESSAGES_ENABLED "1")))

--- a/src/status_im/contexts/chat/actions/view.cljs
+++ b/src/status_im/contexts/chat/actions/view.cljs
@@ -4,6 +4,16 @@
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]))
 
+(defn fetch-messages
+  [chat-id]
+  {:icon                :i/download
+   :right-icon          :i/chevron-right
+   :accessibility-label :chat-fetch-messages
+   :on-press            (fn []
+                          (rf/dispatch [:hide-bottom-sheet])
+                          (rf/dispatch [:chat/fetch-messages chat-id]))
+   :label               (i18n/label :t/fetch-messages)})
+
 (defn new-chat
   []
   [quo/action-drawer

--- a/src/status_im/contexts/chat/events.cljs
+++ b/src/status_im/contexts/chat/events.cljs
@@ -442,3 +442,11 @@
     (when (and id
                (not= (:current-chat-id db) (str community-id id)))
       (navigate-to-chat cofx (str community-id id) nil))))
+
+(rf/defn fetch-messages
+  {:events [:chat/fetch-messages]}
+  [_ chat-id]
+  {:json-rpc/call [{:method     "wakuext_fetchMessages"
+                    :params     [{:id chat-id}]
+                    :on-success #()
+                    :on-error   #(log/error "failed to fetch messages for chat" chat-id %)}]})

--- a/src/status_im/contexts/communities/actions/chat/view.cljs
+++ b/src/status_im/contexts/communities/actions/chat/view.cljs
@@ -4,6 +4,8 @@
     [status-im.common.mute-drawer.view :as mute-drawer]
     [status-im.common.muting.helpers :refer [format-mute-till]]
     [status-im.common.not-implemented :as not-implemented]
+    [status-im.config :as config]
+    [status-im.contexts.chat.actions.view :as chat-actions]
     [utils.i18n :as i18n]
     [utils.re-frame :as rf]))
 
@@ -83,13 +85,6 @@
    :on-press            not-implemented/alert
    :label               (i18n/label :t/pinned-messages)})
 
-(defn- action-fetch-messages
-  []
-  {:icon                :i/download
-   :right-icon          :i/chevron-right
-   :accessibility-label :chat-fetch-messages
-   :on-press            not-implemented/alert
-   :label               (i18n/label :t/fetch-messages)})
 
 (defn- action-invite-people
   []
@@ -141,7 +136,8 @@
          (action-mark-as-read)
          (action-toggle-muted chat-id muted muted-till chat-type)
          (action-notification-settings)
-         (action-fetch-messages)
+         (when config/fetch-messages-enabled?
+           (chat-actions/fetch-messages chat-id))
          (action-invite-people)
          (action-qr-code)
          (action-share)]]]

--- a/src/status_im/contexts/profile/rpc.cljs
+++ b/src/status_im/contexts/profile/rpc.cljs
@@ -1,12 +1,18 @@
 (ns status-im.contexts.profile.rpc
   (:require
+    clojure.set
     [clojure.string :as string]
     [utils.ens.core :as utils.ens]))
+
+(defn rpc->wakuv2-config
+  [wakuv2-config]
+  (clojure.set/rename-keys wakuv2-config {:LightClient :light-client}))
 
 (defn rpc->profiles-overview
   [{:keys [customizationColor keycard-pairing] :as profile}]
   (if (map? profile)
     (-> profile
+        (update :wakuv2-config rpc->wakuv2-config)
         (dissoc :customizationColor)
         (assoc :customization-color (keyword customizationColor))
         (assoc :ens-name? (utils.ens/is-valid-eth-name? (:name profile)))

--- a/src/status_im/subs/profile.cljs
+++ b/src/status_im/subs/profile.cljs
@@ -78,6 +78,25 @@
    public-key))
 
 (re-frame/reg-sub
+ :profile/webview-debug
+ :<- [:profile/profile]
+ (fn [{:keys [webview-debug]}]
+   webview-debug))
+
+(re-frame/reg-sub
+ :profile/light-client-enabled?
+ :<- [:profile/profile]
+ (fn [profile]
+   (get-in profile [:wakuv2-config :LightClient])))
+
+(re-frame/reg-sub
+ :profile/test-networks-enabled?
+ :<- [:profile/profile]
+ (fn [profile]
+   (:test-networks-enabled? profile)))
+
+
+(re-frame/reg-sub
  :multiaccount/contact
  :<- [:profile/profile]
  (fn [current-account]
@@ -125,12 +144,6 @@
  :<- [:profile/profile]
  (fn [multiaccount]
    (get multiaccount :log-level)))
-
-(re-frame/reg-sub
- :waku/bloom-filter-mode
- :<- [:profile/profile]
- (fn [multiaccount]
-   (boolean (get multiaccount :waku-bloom-filter-mode))))
 
 (re-frame/reg-sub
  :waku/v2-flag

--- a/status-go-version.json
+++ b/status-go-version.json
@@ -3,7 +3,7 @@
     "_comment": "Instead use: scripts/update-status-go.sh <rev>",
     "owner": "status-im",
     "repo": "status-go",
-    "version": "v0.171.34",
-    "commit-sha1": "90c31afe7ca16f36b4c4ffa4604bf0c7e70c35e1",
-    "src-sha256": "1f7bdqqzwksj9yn7r28jh8kgab220hvkl5pdv27didgyd6fw0z0j"
+    "version": "v0.171.37",
+    "commit-sha1": "1adcf02f867effe39199e383d80681f47db9cef8",
+    "src-sha256": "1mhz0rgd3r6jvgy78ljwq2vjha5rnp5dqhh3ggbp8hpww7nqv4v3"
 }

--- a/translations/en.json
+++ b/translations/en.json
@@ -2383,6 +2383,7 @@
     "edit-derivation-path": "Edit derivation path",
     "path-format": "Path format",
     "reset": "Reset",
+    "light-client-enabled": "Light client",
     "reveal-address": "Reveal address",
     "derive-addresses": "Derive addresses",
     "sign transactions": "sign transactions",


### PR DESCRIPTION
Set fleet to shards.test and remove dependency on status-mobile for fleet definition (there's still some work to be done on syncing to completely remove all the node config/fleet from status-mobile and have everything driven by status-go)

### Behavior

New accounts should have `shards.test` fleet set by default
Migrated accounts should have `shards.test` fleet set by default **if they never set one before**


includes https://github.com/status-im/status-mobile/pull/18007 as related changes
