### PR TITLE
Community Request to Join - Show Addresses to share Cards

### DIFF
--- a/src/status_im2/contexts/communities/actions/accounts_selection/style.cljs
+++ b/src/status_im2/contexts/communities/actions/accounts_selection/style.cljs
@@ -11,8 +11,9 @@
   {:padding-vertical   12
    :padding-horizontal screen-horizontal-padding})
 
-(def content
-  {:margin-bottom      20
+(def section-title
+  {:padding-top        12
+   :padding-bottom     4
    :padding-horizontal screen-horizontal-padding})
 
 (defn bottom-actions

--- a/src/status_im2/contexts/communities/actions/accounts_selection/view.cljs
+++ b/src/status_im2/contexts/communities/actions/accounts_selection/view.cljs
@@ -3,6 +3,7 @@
     [quo.core :as quo]
     [react-native.core :as rn]
     [react-native.gesture :as gesture]
+    [status-im2.common.not-implemented :as not-implemented]
     [status-im2.common.password-authentication.view :as password-authentication]
     [status-im2.contexts.communities.actions.accounts-selection.style :as style]
     [status-im2.contexts.communities.actions.community-rules.view :as community-rules]
@@ -35,7 +36,11 @@
 (defn view
   []
   (let [{id :community-id}          (rf/sub [:get-screen-params])
-        {:keys [name color images]} (rf/sub [:communities/community id])]
+        {:keys [name color images]} (rf/sub [:communities/community id])
+        accounts                    (->> (rf/sub [:wallet])
+                                         :accounts
+                                         vals
+                                         (map #(assoc % :customization-color (:color %))))]
     [rn/view {:style style/container}
      [quo/page-nav
       {:text-align          :left
@@ -46,9 +51,35 @@
       {:community-name name
        :logo-uri       (get-in images [:thumbnail :uri])}]
      [gesture/scroll-view
-      [rn/view {:style style/content}
+      [:<>
        [quo/text
-        {:style               {:margin-top 24}
+        {:style               style/section-title
+         :accessibility-label :community-rules-title
+         :weight              :semi-bold
+         :size                :paragraph-1}
+        (i18n/label :t/address-to-share)]
+
+       [quo/category
+        {:list-type :settings
+         :data      [{:title             (i18n/label :t/join-as-a-member)
+                      :on-press          not-implemented/alert
+                      :description       :text
+                      :action            :arrow
+                      :label             :preview
+                      :label-props       {:type :accounts
+                                          :data accounts}
+                      :description-props {:text (i18n/label :t/all-addresses)}}
+                     {:title             (i18n/label :t/for-airdrops)
+                      :on-press          not-implemented/alert
+                      :description       :text
+                      :action            :arrow
+                      :label             :preview
+                      :label-props       {:type :accounts
+                                          :data (take 1 accounts)}
+                      :description-props {:text (-> accounts first :name)}}]}]
+
+       [quo/text
+        {:style               style/section-title
          :accessibility-label :community-rules-title
          :weight              :semi-bold
          :size                :paragraph-1}

--- a/src/status_im2/contexts/communities/actions/community_rules/style.cljs
+++ b/src/status_im2/contexts/communities/actions/community_rules/style.cljs
@@ -1,10 +1,7 @@
 (ns status-im2.contexts.communities.actions.community-rules.style)
 
 (def community-rule
-  {:flex        1
-   :align-items :flex-start
-   :margin-top  16})
-
-(def community-rule-text
-  {:margin-left 6
-   :flex        1})
+  {:flex               1
+   :align-items        :flex-start
+   :padding-vertical   8
+   :padding-horizontal 20})

--- a/src/status_im2/contexts/communities/actions/community_rules/view.cljs
+++ b/src/status_im2/contexts/communities/actions/community_rules/view.cljs
@@ -10,7 +10,6 @@
   (let [rules (rf/sub [:communities/rules id])]
     [rn/view {:style style/community-rule}
      [quo/text
-      {:style  style/community-rule-text
-       :weight :regular
+      {:weight :regular
        :size   :paragraph-2}
       rules]]))

--- a/translations/en.json
+++ b/translations/en.json
@@ -177,6 +177,10 @@
         "other": "{{count}} members"
     },
     "community-rules": "Community rules",
+    "address-to-share": "Addresses to share",
+    "join-as-a-member": "Join as a Member",
+    "all-addresses": "All addresses",
+    "for-airdrops": "For airdrops",
     "members-label": "Members",
     "open-membership": "Open membership",
     "member-kick": "Kick member",


### PR DESCRIPTION
Part of #17977 & #18081

<img src="https://github.com/status-im/status-mobile/assets/19279756/5b10fcfd-0f04-46d4-8a14-67ad3f4ad5ae" width=350/>

Also added some style fixes along with changes.

### Known issue
The account icon is currently 24x24, which does not align with the 32x32 size on Figma. This issue stems from the `settings_item` component, where the size is hardcoded. Modifying that component will necessitate manual QA, so I will address it in a separate PR.

### Test Note
To test this, change the `community-accounts-selection-enabled?` flag in `src/status_im2/config.cljs` to `true`.

This feature is currently under a flag that is not enabled in the develop branch, so these changes do not require manual QA.

> This PR will enable @FFFra and me to work concurrently on the above-mentioned issues, minimizing the likelihood of future conflicts.