### PR TITLE
ignore /.clj-kondo/rewrite-clj/rewrite-clj/config.edn which is generated by lint-fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -194,3 +194,4 @@ lefthook.yml
 ## clj-kondo
 /.clj-kondo/taoensso/*
 /.clj-kondo/babashka/*
+/.clj-kondo/rewrite-clj/rewrite-clj/config.edn


### PR DESCRIPTION
status: ready <!-- Can be ready or wip -->
