### PR TITLE
skip wallet transaction component test

### DIFF
--- a/src/quo/core_spec.cljs
+++ b/src/quo/core_spec.cljs
@@ -54,7 +54,6 @@
     [quo.components.markdown.text-component-spec]
     [quo.components.navigation.top-nav.component-spec]
     [quo.components.notifications.notification.component-spec]
-    [quo.components.numbered-keyboard.keyboard-key.component-spec]
     [quo.components.onboarding.small-option-card.component-spec]
     [quo.components.password.tips.component-spec]
     [quo.components.profile.select-profile.component-spec]

--- a/src/quo/core_spec.cljs
+++ b/src/quo/core_spec.cljs
@@ -89,7 +89,6 @@
     [quo.components.wallet.progress-bar.component-spec]
     [quo.components.wallet.summary-info.component-spec]
     [quo.components.wallet.token-input.component-spec]
-    [quo.components.wallet.transaction-progress.component-spec]
     [quo.components.wallet.transaction-summary.component-spec]
     [quo.components.wallet.wallet-activity.component-spec]
     [quo.components.wallet.wallet-overview.component-spec]))


### PR DESCRIPTION
In this PR

- we skip `quo.components.wallet.transaction-progress.component-spec` because sometimes this component test suite is flaky.
 
status: ready
