### PR TITLE
Share wallet address [17865]

### DIFF
--- a/doc/debugging.md
+++ b/doc/debugging.md
@@ -7,13 +7,13 @@
 
 To start `re-frisk`, execute the following command:
 ```bash
-$ yarn shadow-cljs run re-frisk-remote.core/start
+yarn shadow-cljs run re-frisk-remote.core/start
 ```
 
 or you can also use make:
 
 ```bash
-$ make run-re-frisk
+make run-re-frisk
 ```
 
 A server will be started at http://localhost:4567. It might show "not connected" at first. Don't worry and just start using the app. The events and state will populate.

--- a/src/quo/components/share/share_qr_code/component_spec.cljs
+++ b/src/quo/components/share/share_qr_code/component_spec.cljs
@@ -73,10 +73,6 @@
            :accessibility-label :link-to-profile
            :event-name          :press
            :callback-prop-key   :on-share-press}
-          {:test-name           "Info icon pressed"
-           :accessibility-label :share-qr-code-info-icon
-           :event-name          :press
-           :callback-prop-key   :on-info-press}
           {:test-name           "Legacy tab pressed"
            :accessibility-label :share-qr-code-legacy-tab
            :event-name          :press
@@ -101,10 +97,6 @@
            :accessibility-label :link-to-profile
            :event-name          :press
            :callback-prop-key   :on-share-press}
-          {:test-name           "Info icon pressed"
-           :accessibility-label :share-qr-code-info-icon
-           :event-name          :press
-           :callback-prop-key   :on-info-press}
           {:test-name           "Legacy tab pressed"
            :accessibility-label :share-qr-code-legacy-tab
            :event-name          :press

--- a/src/quo/components/share/share_qr_code/style.cljs
+++ b/src/quo/components/share/share_qr_code/style.cljs
@@ -18,18 +18,25 @@
 
 ;;; Header
 (def header-container
+  {:margin-bottom 12})
+
+(def header-title-container
+  {:margin-bottom   20
+   :flex-direction  :row
+   :justify-content :space-between
+   :overflow        :hidden})
+
+(def header-and-avatar-container
   {:flex-direction :row
-   :margin-bottom  12})
+   :align-items    :center
+   :word-wrap      :no-wrap})
+
+(def flex-direction-row
+  {:flex-direction :row})
 
 (def header-tab-active {:background-color colors/white-opa-20})
 (def header-tab-inactive {:background-color colors/white-opa-5})
 (def space-between-tabs {:width 8})
-
-(def info-icon
-  {:margin-left :auto
-   :align-self  :center})
-
-(def info-icon-color colors/white-opa-40)
 
 ;;; QR code
 (defn qr-code-size
@@ -43,6 +50,12 @@
    :justify-content :space-between})
 
 (def title {:color colors/white-opa-40})
+
+(defn header-title
+  [component-width]
+  {:color       colors/white
+   :margin-left 8
+   :max-width   (* component-width 0.7)})
 
 (def share-button-size 32)
 (def ^:private share-button-gap 16)
@@ -60,49 +73,12 @@
 (def wallet-data-and-share-container
   {:margin-top      2
    :flex-direction  :row
+   :align-items     :center
    :justify-content :space-between})
 
 (def wallet-legacy-container {:flex 1})
 
-(def wallet-multichain-container {:flex 1 :margin-top 4})
-
-(def wallet-multichain-networks
-  {:flex-direction  :row
-   :justify-content :space-between
-   :margin-bottom   8})
-
-(def wallet-multichain-data-container {:margin-top 4})
-
-;;; Dashed line
-(def divider-container
-  {:height            8
-   :margin-horizontal 4
-   :justify-content   :center
-   :overflow          :hidden})
-
-(def ^:private padding-for-divider (+ padding-horizontal 4))
-(def ^:private dashed-line-width 2)
-(def ^:private dashed-line-space 4)
-
-(def dashed-line
-  {:flex-direction :row
-   :margin-left    -1})
-
-(def line
-  {:background-color colors/white-opa-20
-   :width            dashed-line-width
-   :height           1})
-
-(def line-space
-  {:width  dashed-line-space
-   :height 1})
-
-(defn number-lines-and-spaces-to-fill
-  [component-width]
-  (let [line-and-space-width (+ dashed-line-width dashed-line-space)
-        width-to-fill        (- component-width (* 2 padding-for-divider))
-        number-of-lines      (* (/ width-to-fill line-and-space-width) 2)]
-    (inc (int number-of-lines))))
+(def wallet-multichain-container {:flex 1})
 
 (def ^:private get-network-full-name
   {"eth"  :ethereum

--- a/src/status_im2/contexts/quo_preview/share/share_qr_code.cljs
+++ b/src/status_im2/contexts/quo_preview/share/share_qr_code.cljs
@@ -92,7 +92,6 @@
                              :full-name           "My User"
                              :customization-color :purple
                              :emoji               "🐈"
-                             :on-info-press       #(js/alert "Info pressed")
                              :on-legacy-press     #(js/alert (str "Tab " % " pressed"))
                              :on-multichain-press #(js/alert (str "Tab " % " pressed"))
                              :networks            (take 2 possible-networks)


### PR DESCRIPTION
fixes #17865 

## Share wallet address design update (UI only)
While I'm working on adding share-qr-code to the wallet share screen and re-using swipeable status component, I've decided to share the UI part asap

### Steps to test
<!-- (Specify exact steps to test if there are such) -->

- go to quo library
- scroll all the way down to `share-qr-code`

### Before and after screenshots comparison

#### Before:
<img src="https://github.com/status-im/status-mobile/assets/15213331/36ca8275-7e95-4ec1-ab30-3990943a1123" width="400">
<img src="https://github.com/status-im/status-mobile/assets/15213331/77707b2e-3014-442a-8fb4-8b0369359622" width="400">

#### After:
<img src="https://github.com/status-im/status-mobile/assets/15213331/dfabf8c9-fcb6-4f24-9b8c-c6add2e046a1" width="400">
<img src="https://github.com/status-im/status-mobile/assets/15213331/4c984d7d-da38-44fb-b159-85de30e135c5" width="400">

| [Figma (if available) ](https://www.figma.com/file/eDfxTa9IoaCMUy5cLTp0ys/Shell-for-Mobile?type=design&node-id=451-18993&mode=design&t=7fJFburgVjMSvySD-0)

status: ready
