### PR TITLE
Display component name in quo preview header

### DIFF
--- a/src/status_im2/contexts/quo_preview/preview.cljs
+++ b/src/status_im2/contexts/quo_preview/preview.cljs
@@ -5,6 +5,7 @@
     [quo.core :as quo]
     [quo.foundations.colors :as colors]
     [quo.theme :as quo.theme]
+    [re-frame.core :as rf]
     [react-native.blur :as blur]
     [react-native.core :as rn]
     [react-native.safe-area :as safe-area]
@@ -320,9 +321,10 @@
   [{:keys [title state descriptor blur? blur-dark-only?
            component-container-style
            blur-container-style blur-view-props blur-height show-blur-background?]
-    :or   {blur-height 200 title "quo component"}}
+    :or   {blur-height 200}}
    & children]
-  (let [theme (quo.theme/use-theme-value)]
+  (let [theme (quo.theme/use-theme-value)
+        title (or title @(rf/subscribe [:view-id]))]
     (rn/use-effect (fn []
                      (when blur-dark-only?
                        (if blur?


### PR DESCRIPTION
Display the name of the currently previewing component in the header.

<img src="https://github.com/status-im/status-mobile/assets/19279756/558fb6ea-5879-4b70-982e-01a6907af835" width=350/>


status: ready <!-- Can be ready or wip -->
