### PR TITLE
Community: Request to join - Show addresses shared

### DIFF
--- a/src/status_im2/contexts/communities/actions/accounts_selection/view.cljs
+++ b/src/status_im2/contexts/communities/actions/accounts_selection/view.cljs
@@ -62,7 +62,8 @@
        [quo/category
         {:list-type :settings
          :data      [{:title             (i18n/label :t/join-as-a-member)
-                      :on-press          not-implemented/alert
+                      :on-press          #(rf/dispatch [:open-modal :addresses-for-permissions
+                                                        {:community-id id}])
                       :description       :text
                       :action            :arrow
                       :label             :preview

--- a/src/status_im2/contexts/communities/actions/addresses_for_permissions/style.cljs
+++ b/src/status_im2/contexts/communities/actions/addresses_for_permissions/style.cljs
@@ -1,0 +1,22 @@
+(ns status-im2.contexts.communities.actions.addresses-for-permissions.style
+  (:require [quo.foundations.colors :as colors]))
+
+(def container {:flex 1})
+
+(def account-item-container
+  {:font-size          30
+   :border-radius      16
+   :flex-direction     :row
+   :border-width       1
+   :height             56
+   :padding-horizontal 12
+   :align-items        :center
+   :margin-bottom      8
+   :gap                8
+   :border-color       colors/neutral-90})
+
+(def buttons
+  {:flex-direction     :row
+   :gap                12
+   :padding-horizontal 20
+   :padding-vertical   12})

--- a/src/status_im2/contexts/communities/actions/addresses_for_permissions/view.cljs
+++ b/src/status_im2/contexts/communities/actions/addresses_for_permissions/view.cljs
@@ -1,0 +1,58 @@
+(ns status-im2.contexts.communities.actions.addresses-for-permissions.view
+  (:require [quo.core :as quo]
+            [react-native.core :as rn]
+            [status-im2.common.not-implemented :as not-implemented]
+            [status-im2.contexts.communities.actions.addresses-for-permissions.style :as style]
+            [utils.i18n :as i18n]
+            [utils.re-frame :as rf]))
+
+(defn- account-item
+  [item]
+  [rn/view
+   {:style style/account-item-container}
+   [quo/account-avatar (assoc item :size 32)]
+   [rn/view
+    [quo/text
+     {:size   :paragraph-1
+      :weight :semi-bold}
+     (:name item)]
+    [quo/address-text
+     {:address (:address item)
+      :format  :short}]]])
+
+(defn view
+  []
+  (let [{id :community-id}          (rf/sub [:get-screen-params])
+        {:keys [name color images]} (rf/sub [:communities/community id])
+        accounts                    (->> (rf/sub [:wallet])
+                                         :accounts
+                                         vals
+                                         (map #(assoc % :customization-color (:color %))))]
+    [rn/safe-area-view {:style style/container}
+
+     [quo/drawer-top
+      {:type                :context-tag
+       :title               (i18n/label :t/addresses-for-permissions)
+       :community-name      name
+       :button-icon         :i/info
+       :on-button-press     not-implemented/alert
+       :community-logo      (get-in images [:thumbnail :uri])
+       :customization-color color}]
+
+     [rn/flat-list
+      {:render-fn               account-item
+       :content-container-style {:padding 20}
+       :key-fn                  :key-uid
+       :data                    accounts}]
+
+     [rn/view {:style style/buttons}
+      [quo/button
+       {:type            :grey
+        :container-style {:flex 1}
+        :on-press        #(rf/dispatch [:navigate-back])}
+       (i18n/label :t/cancel)]
+      [quo/button
+       {:container-style     {:flex 1}
+        :customization-color color
+        :on-press            #(rf/dispatch [:navigate-back])}
+       (i18n/label :t/confirm-changes)]]]))

--- a/src/status_im2/navigation/screens.cljs
+++ b/src/status_im2/navigation/screens.cljs
@@ -11,6 +11,8 @@
     [status-im2.contexts.chat.new-chat.view :as new-chat]
     [status-im2.contexts.chat.photo-selector.view :as photo-selector]
     [status-im2.contexts.communities.actions.accounts-selection.view :as communities.accounts-selection]
+    [status-im2.contexts.communities.actions.addresses-for-permissions.view :as
+     addresses-for-permissions]
     [status-im2.contexts.communities.actions.request-to-join.view :as join-menu]
     [status-im2.contexts.communities.discover.view :as communities.discover]
     [status-im2.contexts.communities.overview.view :as communities.overview]
@@ -97,6 +99,10 @@
     {:name      :community-account-selection
      :options   {:sheet? true}
      :component communities.accounts-selection/view}
+
+    {:name      :addresses-for-permissions
+     :options   {:sheet? true}
+     :component addresses-for-permissions/view}
 
     {:name      :lightbox
      :options   options/lightbox
@@ -352,4 +358,3 @@
 
    (when config/quo-preview-enabled?
      status-im-preview/main-screens)))
-

--- a/translations/en.json
+++ b/translations/en.json
@@ -178,6 +178,8 @@
     },
     "community-rules": "Community rules",
     "address-to-share": "Addresses to share",
+    "addresses-for-permissions": "Addresses for permissions",
+    "confirm-changes": "Confirm changes",
     "join-as-a-member": "Join as a Member",
     "all-addresses": "All addresses",
     "for-airdrops": "For airdrops",


### PR DESCRIPTION
fixes #17977 

### Description
Implements an "Addresses for Permissions" sheet to display the addresses shared with a community when initiating the joining process. This enhancement aims to provide users with visibility into the addresses shared with the community.

### Screenshot
<img src="https://github.com/status-im/status-mobile/assets/19279756/07599f17-2cad-46ad-a46e-4297d8ab0326" width=350/>

### Review Note
This PR is not intended to achieve pixel-perfect design. Rather, it focuses on implementing the functionality.

### Test Note
To test this, change the `community-accounts-selection-enabled?` flag in `src/status_im2/config.cljs` to `true`.

This feature is currently under a flag that is not enabled in the develop branch, so these changes do not require manual QA.