### PR TITLE
Communities: Share airdrop address in non token-gated community

### DIFF
--- a/src/status_im/contexts/communities/actions/accounts_selection/view.cljs
+++ b/src/status_im/contexts/communities/actions/accounts_selection/view.cljs
@@ -3,7 +3,6 @@
     [quo.core :as quo]
     [react-native.core :as rn]
     [react-native.gesture :as gesture]
-    [status-im.common.not-implemented :as not-implemented]
     [status-im.common.password-authentication.view :as password-authentication]
     [status-im.contexts.communities.actions.accounts-selection.style :as style]
     [status-im.contexts.communities.actions.community-rules.view :as community-rules]
@@ -58,7 +57,6 @@
          :weight              :semi-bold
          :size                :paragraph-1}
         (i18n/label :t/address-to-share)]
-
        [quo/category
         {:list-type :settings
          :data      [{:title             (i18n/label :t/join-as-a-member)
@@ -71,14 +69,14 @@
                                           :data accounts}
                       :description-props {:text (i18n/label :t/all-addresses)}}
                      {:title             (i18n/label :t/for-airdrops)
-                      :on-press          not-implemented/alert
+                      :on-press          #(rf/dispatch [:open-modal :airdrop-addresses
+                                                        {:community-id id}])
                       :description       :text
                       :action            :arrow
                       :label             :preview
                       :label-props       {:type :accounts
-                                          :data (take 1 accounts)}
+                                          :data [(first accounts)]}
                       :description-props {:text (-> accounts first :name)}}]}]
-
        [quo/text
         {:style               style/section-title
          :accessibility-label :community-rules-title

--- a/src/status_im/contexts/communities/actions/airdrop_addresses/style.cljs
+++ b/src/status_im/contexts/communities/actions/airdrop_addresses/style.cljs
@@ -1,0 +1,6 @@
+(ns status-im.contexts.communities.actions.airdrop-addresses.style)
+
+(def account-list-container
+  {:flex           1
+   :padding-top    12
+   :padding-bottom 8})

--- a/src/status_im/contexts/communities/actions/airdrop_addresses/view.cljs
+++ b/src/status_im/contexts/communities/actions/airdrop_addresses/view.cljs
@@ -1,0 +1,46 @@
+(ns status-im.contexts.communities.actions.airdrop-addresses.view
+  (:require
+    [quo.core :as quo]
+    [react-native.core :as rn]
+    [status-im.common.not-implemented :as not-implemented]
+    [status-im.contexts.communities.actions.airdrop-addresses.style :as style]
+    [utils.i18n :as i18n]
+    [utils.re-frame :as rf]))
+
+(defn- render-item
+  [item]
+  [quo/account-item
+   {:account-props item
+    :emoji         (:emoji item)}])
+
+(defn- accounts-list
+  [{:keys [accounts]}]
+  [rn/view {:style style/account-list-container}
+   (when (seq accounts)
+     [rn/flat-list
+      {:data      accounts
+       :render-fn render-item
+       :key-fn    :address}])])
+
+(defn view
+  []
+  (let [{id :community-id}          (rf/sub [:get-screen-params])
+        {:keys [name images color]} (rf/sub [:communities/community id])
+        logo-uri                    (get-in images [:thumbnail :uri])
+        accounts                    (->> (rf/sub [:wallet])
+                                         :accounts
+                                         vals
+                                         (map #(assoc % :customization-color (:color %))))]
+    [:<>
+     [quo/drawer-top
+      {:type                :context-tag
+       :title               (i18n/label :t/airdrop-addresses)
+       :community-name      name
+       :button-icon         :i/info
+       :on-button-press     not-implemented/alert
+       :community-logo      (get-in images [:thumbnail :uri])
+       :customization-color color}]
+     [accounts-list
+      {:accounts       accounts
+       :logo-uri       logo-uri
+       :community-name name}]]))

--- a/src/status_im/navigation/screens.cljs
+++ b/src/status_im/navigation/screens.cljs
@@ -13,6 +13,7 @@
     [status-im.contexts.communities.actions.accounts-selection.view :as communities.accounts-selection]
     [status-im.contexts.communities.actions.addresses-for-permissions.view :as
      addresses-for-permissions]
+    [status-im.contexts.communities.actions.airdrop-addresses.view :as airdrop-addresses]
     [status-im.contexts.communities.actions.request-to-join.view :as join-menu]
     [status-im.contexts.communities.discover.view :as communities.discover]
     [status-im.contexts.communities.overview.view :as communities.overview]
@@ -103,6 +104,10 @@
     {:name      :addresses-for-permissions
      :options   {:sheet? true}
      :component addresses-for-permissions/view}
+
+    {:name      :airdrop-addresses
+     :options   {:sheet? true}
+     :component airdrop-addresses/view}
 
     {:name      :lightbox
      :options   options/lightbox

--- a/translations/en.json
+++ b/translations/en.json
@@ -180,6 +180,7 @@
     "address-to-share": "Addresses to share",
     "addresses-for-permissions": "Addresses for permissions",
     "confirm-changes": "Confirm changes",
+    "airdrop-addresses": "Address for airdrops",
     "join-as-a-member": "Join as a Member",
     "all-addresses": "All addresses",
     "for-airdrops": "For airdrops",


### PR DESCRIPTION
fixes #18081 

### Summary

This pull request addresses the first two subtasks of #18081, encompassing:

- Displaying a summary of the selected airdrop addresses.
- Presenting the list of potential airdrop addresses.


[Figma](https://www.figma.com/file/h9wo4GipgZURbqqr1vShFN/Communities-for-Mobile?type=design&node-id=15331-286958&mode=design&t=esUiSc1hu4Tc066w-0)

Please check changes here:

Before refactor, using bottom-sheet:

https://github.com/status-im/status-mobile/assets/5999878/b47e4cf8-1304-4d82-8996-ab3fcba8f46d

After the refactor, using a new screen:



https://github.com/status-im/status-mobile/assets/5999878/d4d487e1-8386-4071-8ee7-9355e4e93c71




### Review notes
For now, we are not been pixel perfect. To actually select the address is the next scope.

This feature is currently under a flag that is not enabled in the develop branch, so these changes do not require manual QA.

##### Platforms
- Android
- iOS

##### Functional

- public chats
- group chats
- wallet / transactions
- networks

### Steps to test
- Navigate to `src/status_im2/config.cljs` and set `community-accounts-selection-enabled?` to `true`.
- Ensure you have some wallets. If not, you can create them in the wallet tab.
- Create a community on desktop and invite another user.
- When the invited user attempts to join this community, the option to select airdrop addresses should appear.

status: ready 
