### PR TITLE
nix: add  `cmake` to shell

### DIFF
--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -23,7 +23,7 @@ in mkShell {
       # build specific utilities
       clojure maven watchman
       # other nice to have stuff
-      yarn nodejs python310
+      yarn nodejs python310 cmake
     ] # and some special cases
       ++ lib.optionals   stdenv.isDarwin ([ cocoapods clang tcl ] ++ appleSDKFrameworks)
       ++ lib.optionals (!stdenv.isDarwin) [ gcc8 ]


### PR DESCRIPTION
If we don't specify `cmake` in shell then while building react-native local environment `cmake` is referred which can cause problems.

This PR adds `cmake` to shell to ensure we refer to that while building the app.

fixes #18207

status: ready
