### PR TITLE
fix: update write permissions for `react-native-reanimated` build files generated at run time

### DIFF
--- a/nix/scripts/node_modules.sh
+++ b/nix/scripts/node_modules.sh
@@ -46,7 +46,7 @@ copyNodeModules() {
   # WARNING: We can't de-reference .bin symlinks
   cp -Rf ${src}/node_modules/.bin/. "${tmp}/.bin/"
   # Cmake called by react-native-reanimated 3.3.0 during build creates read-only temporary files.
-  chmod -R u+w node_modules/react-native-reanimated/android/.cxx -f || true
+  chmod -R u+w node_modules/react-native-reanimated/android/ -f || true
   rm -r "${dst}"
   mv -f "${tmp}" "${dst}"
 }


### PR DESCRIPTION
`react-native-reanimated` generates write protected files during build time which are problematic because we copy over `node_modules` from `nix` store and when replacing them with new node modules we are manually asked to confirm this overwrite.

This used to happen before with `.cxx` files but now it also happens with `.so` files. 

This PR fixes those permissions.

partially fixes #18211 

status: ready
