### PR TITLE
set `make run-metro` target to `clojure`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -263,7 +263,7 @@ run-clojure: export TARGET := clojure
 run-clojure: ##@run Watch for and build Clojure changes for mobile
 	yarn shadow-cljs watch mobile
 
-run-metro: export TARGET := android
+run-metro: export TARGET := clojure
 run-metro: ##@run Start Metro to build React Native changes
 	@scripts/start-react-native.sh
 


### PR DESCRIPTION
The metro terminal no longer needs to have `android` target anymore.
I had to do this in https://github.com/status-im/status-mobile/pull/17241 

This PR sets the target of metro terminal back to `clojure`.

I tested building `android` and `iOS` on my MacOS and on my linux machines and found no side effect.
Now metro terminal is fast again.

status: ready
