### PR TITLE
fix sticky header category line position on scroll 

### DIFF
--- a/src/status_im/common/scroll_page/view.cljs
+++ b/src/status_im/common/scroll_page/view.cljs
@@ -3,6 +3,7 @@
     [oops.core :as oops]
     [quo.core :as quo]
     [react-native.core :as rn]
+    [react-native.platform :as platform]
     [react-native.reanimated :as reanimated]
     [reagent.core :as reagent]
     [status-im.common.scroll-page.style :as style]
@@ -59,7 +60,7 @@
         [rn/view {:style {:margin-top 0}}
          top-nav]
         [quo/page-nav
-         (cond-> {:margin-top     44
+         (cond-> {:margin-top     (if platform/ios? 44 40)
                   :type           :no-title
                   :background     (if (= 1 (reanimated/get-shared-value opacity-animation))
                                     :blur

--- a/src/status_im/contexts/communities/overview/style.cljs
+++ b/src/status_im/contexts/communities/overview/style.cljs
@@ -1,6 +1,7 @@
 (ns status-im.contexts.communities.overview.style
   (:require
     [quo.foundations.colors :as colors]
+    [react-native.platform :as platform]
     [status-im.contexts.shell.jump-to.constants :as jump-to.constants]))
 
 (def screen-horizontal-padding 20)
@@ -23,7 +24,7 @@
 
 (def blur-channel-header
   {:position :absolute
-   :top      100
+   :top      (if platform/ios? 100 96)
    :height   34
    :right    0
    :left     0


### PR DESCRIPTION


fixes #18147

This pr fixes the height of the category line when the user scroll on android. This issue works well on ios so this fix is only for android. 

For more comments on this https://github.com/status-im/status-mobile/issues/16860#issuecomment-1856806866

<img width="519" alt="Screenshot 2023-12-19 at 11 16 28" src="https://github.com/status-im/status-mobile/assets/28704507/6054e314-5465-42db-a66f-20f72ae4e57c">


